### PR TITLE
[Indexer gRPC v2] Fix gap when querying historical data service with transaction filter

### DIFF
--- a/ecosystem/indexer-grpc/indexer-grpc-data-service-v2/src/historical_data_service.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-data-service-v2/src/historical_data_service.rs
@@ -221,6 +221,7 @@ impl HistoricalDataService {
                         .last_mut()
                         .unwrap()
                         .processed_range
+                        .as_mut()
                         .unwrap()
                         .last_version = last_processed_version;
                     responses


### PR DESCRIPTION
## Description
Fixes https://github.com/aptos-labs/aptos-indexer-processor-sdk/issues/159

## How Has This Been Tested?
No gaps after running `grpcurl -v -d '{"starting_version":"0", "transaction_filter":{"api_filter":{"transaction_root_filter":{"transaction_type":"TRANSACTION_TYPE_USER"}}}}' -max-msg-sz 30000000 -H "authorization:Bearer <key>" grpc.testnet.aptoslabs.com:443 aptos.indexer.v1.RawData/GetTransactions`

```
justinchang@Justins-MacBook-Pro ~ % grep -E '"processedRange"|"firstVersion"|"lastVersion"' /tmp/grpc_stream_output2.txt
  "processedRange": {
    "lastVersion": "51697"
  "processedRange": {
    "firstVersion": "51698",
    "lastVersion": "99999"
  "processedRange": {
    "firstVersion": "100000",
    "lastVersion": "155401"
  "processedRange": {
    "firstVersion": "155402",
    "lastVersion": "199999"
  "processedRange": {
    "firstVersion": "200000",
    "lastVersion": "247104"
  "processedRange": {
    "firstVersion": "247105",
    "lastVersion": "280633"
  "processedRange": {
    "firstVersion": "280634",
    "lastVersion": "299999"
  "processedRange": {
    "firstVersion": "300000",
    "lastVersion": "331600"
  "processedRange": {
    "firstVersion": "331601",
    "lastVersion": "363728"
  "processedRange": {
    "firstVersion": "363729",
    "lastVersion": "396050"
  "processedRange": {
    "firstVersion": "396051",
    "lastVersion": "399999"
  "processedRange": {
    "firstVersion": "400000",
    "lastVersion": "433866"
  "processedRange": {
    "firstVersion": "433867",
    "lastVersion": "468522"
  "processedRange": {
    "firstVersion": "468523",
    "lastVersion": "499999"
  "processedRange": {
    "firstVersion": "500000",
    "lastVersion": "532488"
```

## Key Areas to Review
All of it, changes are small

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [x] Other (Indexer gRPC v2)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensure the last response’s `processed_range.last_version` is updated by mutably accessing the optional `processed_range` via `as_mut()`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1809d64a3455f677619e2813f279e2f009e23794. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->