### PR TITLE
Switch small workflows to GH-hosted runners

### DIFF
--- a/.github/workflows/adhoc-forge.yaml
+++ b/.github/workflows/adhoc-forge.yaml
@@ -56,7 +56,7 @@ permissions:
 
 jobs:
   determine-forge-run-metadata:
-    runs-on: ubuntu-latest
+    runs-on: 2cpu-gh-ubuntu24-x64
     steps:
       - name: collect metadata
         run: |

--- a/.github/workflows/aptos-node-release.yaml
+++ b/.github/workflows/aptos-node-release.yaml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   release-aptos-node:
-    runs-on: ubuntu-latest
+    runs-on: 2cpu-gh-ubuntu24-x64
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/backport-to-release-branches.yaml
+++ b/.github/workflows/backport-to-release-branches.yaml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   permission-check:
     if: github.event.pull_request.merged == true && contains(join(github.event.pull_request.labels.*.name, ','), 'v1.')
-    runs-on: ubuntu-latest
+    runs-on: 2cpu-gh-ubuntu24-x64
     steps:
       - name: Check repository permission for user which triggered workflow
         uses: sushichop/action-repository-permission@13d208f5ae7a6a3fc0e5a7c2502c214983f0241c
@@ -22,7 +22,7 @@ jobs:
   backport:
     name: Backport PR
     needs: [permission-check]
-    runs-on: ubuntu-latest
+    runs-on: 2cpu-gh-ubuntu24-x64
     steps:
       - name: Backport Action
         uses: sorenlouv/backport-github-action@ad888e978060bc1b2798690dd9d03c4036560947

--- a/.github/workflows/bump-release-version.yaml
+++ b/.github/workflows/bump-release-version.yaml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   update-version:
-    runs-on: ubuntu-latest
+    runs-on: 2cpu-gh-ubuntu24-x64
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/check-minimum-revision.yaml
+++ b/.github/workflows/check-minimum-revision.yaml
@@ -18,7 +18,7 @@ env:
 
 jobs:
   check-minimum-revision:
-    runs-on: ubuntu-latest
+    runs-on: 2cpu-gh-ubuntu24-x64
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/cli-release.yaml
+++ b/.github/workflows/cli-release.yaml
@@ -158,7 +158,7 @@ jobs:
       - build-linux-arm-binary
       - build-macos-arm-binary
       - build-macos-x86_64-binary
-    runs-on: ubuntu-latest
+    runs-on: 2cpu-gh-ubuntu24-x64
     permissions:
       contents: "write"
       pull-requests: "read"
@@ -183,7 +183,7 @@ jobs:
     name: "Make PR to bump version in Homebrew"
     needs:
       - release-binaries
-    runs-on: ubuntu-latest
+    runs-on: 2cpu-gh-ubuntu24-x64
     steps:
       - uses: mislav/bump-homebrew-formula-action@v3
         with:

--- a/.github/workflows/close-stale-issues.yaml
+++ b/.github/workflows/close-stale-issues.yaml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   stale:
-    runs-on: ubuntu-latest
+    runs-on: 2cpu-gh-ubuntu24-x64
     steps:
       - uses: actions/stale@v6
         with:

--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on: 2cpu-gh-ubuntu24-x64
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -87,7 +87,7 @@ jobs:
       (github.event_name == 'workflow_dispatch' && github.ref_name == 'main')
       && !cancelled()
     needs: [ rust-unit-coverage, rust-smoke-coverage ]
-    runs-on: ubuntu-latest
+    runs-on: 2cpu-gh-ubuntu24-x64
     continue-on-error: true # Don't fail if the codecov upload fails
     env:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/cut-release-branch.yaml
+++ b/.github/workflows/cut-release-branch.yaml
@@ -29,7 +29,7 @@ permissions:
 
 jobs:
   cut-release-branch:
-    runs-on: ubuntu-latest
+    runs-on: 2cpu-gh-ubuntu24-x64
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/docker-build-test.yaml
+++ b/.github/workflows/docker-build-test.yaml
@@ -89,7 +89,7 @@ jobs:
       contains(join(github.event.pull_request.labels.*.name, ','), 'CICD:run-') ||
       github.event.pull_request.auto_merge != null ||
       contains(github.event.pull_request.body, '#e2e')
-    runs-on: ubuntu-latest
+    runs-on: 2cpu-gh-ubuntu24-x64
     steps:
       - name: Check repository permission for user which triggered workflow
         uses: sushichop/action-repository-permission@13d208f5ae7a6a3fc0e5a7c2502c214983f0241c
@@ -101,7 +101,7 @@ jobs:
   # for the subsequent docker builds. Reusable workflows do not currently have the "env" context: https://github.com/orgs/community/discussions/26671
   determine-docker-build-metadata:
     needs: [permission-check]
-    runs-on: ubuntu-latest
+    runs-on: 2cpu-gh-ubuntu24-x64
     steps:
       - name: collect metadata
         run: |
@@ -116,7 +116,7 @@ jobs:
   # This job determines which files were changed
   file_change_determinator:
     needs: [permission-check]
-    runs-on: ubuntu-latest
+    runs-on: 2cpu-gh-ubuntu24-x64
     outputs:
       only_docs_changed: ${{ steps.determine_file_changes.outputs.only_docs_changed }}
     steps:
@@ -128,7 +128,7 @@ jobs:
   # This job determines which tests to run
   test-target-determinator:
     needs: [permission-check]
-    runs-on: ubuntu-latest
+    runs-on: 2cpu-gh-ubuntu24-x64
     outputs:
       run_framework_upgrade_test: ${{ steps.determine_test_targets.outputs.run_framework_upgrade_test }}
     steps:
@@ -293,7 +293,7 @@ jobs:
         github.event.pull_request.auto_merge != null ||
         contains(github.event.pull_request.body, '#e2e')
       )
-    runs-on: ubuntu-latest
+    runs-on: 2cpu-gh-ubuntu24-x64
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/docker-update-images.yaml
+++ b/.github/workflows/docker-update-images.yaml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   update:
-    runs-on: ubuntu-latest
+    runs-on: 2cpu-gh-ubuntu24-x64
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/faucet-tests-prod.yaml
+++ b/.github/workflows/faucet-tests-prod.yaml
@@ -25,7 +25,7 @@ jobs:
   # triggered the workflow or on 'pull_request's which have set auto_merge=true
   # or have the label "CICD:run-e2e-tests".
   permission-check:
-    runs-on: ubuntu-latest
+    runs-on: 2cpu-gh-ubuntu24-x64
     steps:
       - name: Check repository permission for user which triggered workflow
         uses: sushichop/action-repository-permission@13d208f5ae7a6a3fc0e5a7c2502c214983f0241c

--- a/.github/workflows/forge-continuous-land-blocking-test.yaml
+++ b/.github/workflows/forge-continuous-land-blocking-test.yaml
@@ -33,7 +33,7 @@ env:
 
 jobs:
   permission-check:
-    runs-on: ubuntu-latest
+    runs-on: 2cpu-gh-ubuntu24-x64
     steps:
       - name: Check repository permission for user which triggered workflow
         uses: sushichop/action-repository-permission@13d208f5ae7a6a3fc0e5a7c2502c214983f0241c
@@ -45,7 +45,7 @@ jobs:
   # for the subsequent docker builds. Reusable workflows do not currently have the "env" context: https://github.com/orgs/community/discussions/26671
   determine-docker-build-metadata:
     needs: [permission-check]
-    runs-on: ubuntu-latest
+    runs-on: 2cpu-gh-ubuntu24-x64
     steps:
       - uses: actions/checkout@v4
       - uses: aptos-labs/aptos-core/.github/actions/docker-setup@main
@@ -100,7 +100,7 @@ jobs:
     #  runs only when need to run forge-compat-test or forge-framework-upgrade-test
     if: |
       !failure() && !cancelled() && needs.permission-check.result == 'success'
-    runs-on: ubuntu-latest
+    runs-on: 2cpu-gh-ubuntu24-x64
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/forge-stable.yaml
+++ b/.github/workflows/forge-stable.yaml
@@ -135,7 +135,7 @@ env:
 
 jobs:
   generate-matrix:
-    runs-on: ubuntu-latest
+    runs-on: 2cpu-gh-ubuntu24-x64
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
       imageVariants: ${{ steps.set-matrix.outputs.imageVariants }}
@@ -199,7 +199,7 @@ jobs:
   # This job determines the image tag and branch to test, and passes them to the other jobs
   # NOTE: this may be better as a separate workflow as the logic is quite complex but generalizable
   determine-test-metadata:
-    runs-on: ubuntu-latest
+    runs-on: 2cpu-gh-ubuntu24-x64
     needs: ["generate-matrix"]
     outputs:
       IMAGE_TAG: ${{ steps.get-docker-image-tag.outputs.IMAGE_TAG }}

--- a/.github/workflows/indexer-protos-sdk-update.yaml
+++ b/.github/workflows/indexer-protos-sdk-update.yaml
@@ -9,7 +9,7 @@ name: Checks the proto changes and release
 
 jobs:
   check-protos:
-    runs-on: ubuntu-latest
+    runs-on: 2cpu-gh-ubuntu24-x64
     steps:
       - uses: actions/checkout@v4
       # Install buf, which we use to generate code from the protos for Rust and TS.
@@ -49,7 +49,7 @@ jobs:
           fi
 
   update-sdk:
-    runs-on: ubuntu-latest
+    runs-on: 2cpu-gh-ubuntu24-x64
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -27,7 +27,7 @@ concurrency:
 jobs:
   # This job determines which files were changed
   file_change_determinator:
-    runs-on: ubuntu-latest
+    runs-on: 2cpu-gh-ubuntu24-x64
     outputs:
       only_docs_changed: ${{ steps.determine_file_changes.outputs.only_docs_changed }}
     steps:
@@ -39,7 +39,7 @@ jobs:
   # Run all general lints (i.e., non-rust and docs lints). This is a PR required job.
   general-lints:
     needs: file_change_determinator
-    runs-on: ubuntu-latest
+    runs-on: 2cpu-gh-ubuntu24-x64
     steps:
       - uses: actions/checkout@v4
         if: needs.file_change_determinator.outputs.only_docs_changed != 'true'
@@ -82,7 +82,7 @@ jobs:
   # Run cargo deny. This is a PR required job.
   rust-cargo-deny:
     needs: file_change_determinator
-    runs-on: ubuntu-latest
+    runs-on: 2cpu-gh-ubuntu24-x64
     steps:
       - uses: actions/checkout@v4
         if: needs.file_change_determinator.outputs.only_docs_changed != 'true'

--- a/.github/workflows/provision-replay-verify-archive-disks.yaml
+++ b/.github/workflows/provision-replay-verify-archive-disks.yaml
@@ -29,7 +29,7 @@ concurrency:
 
 jobs:
   determine-test-metadata:
-    runs-on: ubuntu-latest
+    runs-on: 2cpu-gh-ubuntu24-x64
     steps:
       - name: Debug
         run: |

--- a/.github/workflows/prune-old-workflow-runs.yaml
+++ b/.github/workflows/prune-old-workflow-runs.yaml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   prune:
     if: github.repository == 'aptos-labs/aptos-core'
-    runs-on: ubuntu-latest
+    runs-on: 2cpu-gh-ubuntu24-x64
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/rate-limit.yaml
+++ b/.github/workflows/rate-limit.yaml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   collect-and-upload:
-    runs-on: runs-on,runner=2cpu-ubuntu22-x64,run-id=${{ github.run_id }}
+    runs-on: 2cpu-gh-ubuntu24-x64
 
     steps:
       - name: Query GitHub API rate limits

--- a/.github/workflows/rust-client-tests.yaml
+++ b/.github/workflows/rust-client-tests.yaml
@@ -20,7 +20,7 @@ jobs:
   # triggered the workflow or on 'pull_request's which have set auto_merge=true
   # or have the label "CICD:run-e2e-tests".
   permission-check:
-    runs-on: ubuntu-latest
+    runs-on: 2cpu-gh-ubuntu24-x64
     steps:
       - name: Check repository permission for user which triggered workflow
         uses: sushichop/action-repository-permission@13d208f5ae7a6a3fc0e5a7c2502c214983f0241c

--- a/.github/workflows/semgrep.yaml
+++ b/.github/workflows/semgrep.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   semgrep:
     name: semgrep/ci
-    runs-on: ubuntu-latest
+    runs-on: 2cpu-gh-ubuntu24-x64
 
     container:
       image: returntocorp/semgrep

--- a/.github/workflows/terraform-freeze.yaml
+++ b/.github/workflows/terraform-freeze.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   check-terraform-modifications:
-    runs-on: ubuntu-latest
+    runs-on: 2cpu-gh-ubuntu24-x64
     steps:
       - run: |
           echo "Terraform modifications in this repository are not allowed."

--- a/.github/workflows/test-copy-images-to-dockerhub.yaml
+++ b/.github/workflows/test-copy-images-to-dockerhub.yaml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   test-copy-images:
-    runs-on: ubuntu-latest
+    runs-on: 2cpu-gh-ubuntu24-x64
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/trigger-release-branch-validation.yaml
+++ b/.github/workflows/trigger-release-branch-validation.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   check-branch-prefix:
-    runs-on: ubuntu-latest
+    runs-on: 2cpu-gh-ubuntu24-x64
     outputs:
       branch_matches: ${{ steps.check-prefix.outputs.branch_matches }}
     steps:
@@ -21,7 +21,7 @@ jobs:
   trigger-forge-stable:
     needs: check-branch-prefix
     if: needs.check-branch-prefix.outputs.branch_matches == 'true'
-    runs-on: ubuntu-latest
+    runs-on: 2cpu-gh-ubuntu24-x64
     steps:
       - name: Trigger Forge Stable Workflow'
         uses: actions/github-script@v7

--- a/.github/workflows/workflow-run-execution-performance.yaml
+++ b/.github/workflows/workflow-run-execution-performance.yaml
@@ -108,7 +108,7 @@ on:
 jobs:
   # This job determines which tests to run
   test-target-determinator:
-    runs-on: ubuntu-latest
+    runs-on: 2cpu-gh-ubuntu24-x64
     outputs:
       run_execution_performance_test: ${{ steps.determine_test_targets.outputs.run_execution_performance_test }}
     steps:

--- a/.github/workflows/workflow-run-replay-verify-archive-storage-provision.yaml
+++ b/.github/workflows/workflow-run-replay-verify-archive-storage-provision.yaml
@@ -16,7 +16,7 @@ on:
         required: true
 jobs:
   provision:
-    runs-on: ubuntu-latest
+    runs-on: 2cpu-gh-ubuntu24-x64
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/workflow-run-replay-verify-on-archive.yaml
+++ b/.github/workflows/workflow-run-replay-verify-on-archive.yaml
@@ -60,7 +60,7 @@ jobs:
       DRY_RUN: ${{ inputs.DRY_RUN }}
 
   run-replay-verify:
-    runs-on: ubuntu-latest-32-core # consider moving this to a smaller machien since the compute runs on GKE
+    runs-on: 4cpu-gh-ubuntu24-x64
     timeout-minutes: 420 # 7 hours
     needs: build-images
     steps:


### PR DESCRIPTION
## Description

Switch the small 2-core workflows.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches many workflows to `2cpu-gh-ubuntu24-x64` (and one to `4cpu-gh-ubuntu24-x64`) runners for small/auxiliary jobs.
> 
> - **CI Workflows (broadly across .github/workflows/)**:
>   - Standardize `runs-on` to `2cpu-gh-ubuntu24-x64` for small/auxiliary jobs (e.g., permission checks, metadata determinators, lint/docs ancillary steps, release/backport triggers, CodeQL, coverage upload, docker update, rate-limit, pruning, terraform freeze, SDK proto checks, semgrep, test-copy-images, branch validation, archive storage provision, forge utility jobs).
>   - Update replay-verify archive job runner to `4cpu-gh-ubuntu24-x64` in `workflow-run-replay-verify-on-archive.yaml`.
>   - Replace prior `ubuntu-latest`/custom runner labels with the new standardized labels without changing job logic.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f0c7b46fec9ed7c4a1fbc66f741a29a46afd25f4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->