### PR TITLE
[aptos cli] release cli 7.12.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,7 +304,7 @@ dependencies = [
 
 [[package]]
 name = "aptos"
-version = "7.11.1"
+version = "7.12.0"
 dependencies = [
  "anyhow",
  "aptos-api-types",

--- a/crates/aptos/CHANGELOG.md
+++ b/crates/aptos/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to the Aptos CLI will be captured in this file. This project
 
 # Unreleased
 
+## [7.12.0]
+- Add support for passing signed integer transaction arguments through the Aptos CLI.
+
 ## [7.11.1]
 - When Move unit tests detect that the legacy struct-based Option module is being loaded, replace it with the pre-compiled binary version.
 

--- a/crates/aptos/Cargo.toml
+++ b/crates/aptos/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aptos"
 description = "Aptos tool for management of nodes and interacting with the blockchain"
-version = "7.11.1"
+version = "7.12.0"
 
 # Workspace inherited keys
 authors = { workspace = true }


### PR DESCRIPTION
## Description
Release Aptos CLI 7.12.0, which adds support for passing signed integer transaction arguments through the CLI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Release Aptos CLI 7.12.0 adding support for signed integer transaction arguments.
> 
> - **Release/versioning**:
>   - Bump `aptos` crate version to `7.12.0` in `crates/aptos/Cargo.toml` and `Cargo.lock`.
> - **Changelog**:
>   - Add `7.12.0` entry noting support for passing signed integer transaction arguments.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 19ddbd6e6e64f49c344f1f7e4ce32a42e1bb976e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->