### PR TITLE
[Bug fix] Fix duplicate disk metrics

### DIFF
--- a/crates/node-resource-metrics/src/collectors/linux_collectors.rs
+++ b/crates/node-resource-metrics/src/collectors/linux_collectors.rs
@@ -11,7 +11,7 @@ use prometheus::{
     proto::MetricFamily,
     Opts,
 };
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 const LINUX_SYSTEM_CPU_USAGE: &str = "linux_system_cpu_usage";
 const LINUX_CPU_METRICS_COUNT: usize = 11;
@@ -284,8 +284,14 @@ impl Collector for LinuxDiskMetricsCollector {
                 },
             };
 
+        let mut seen_devices: HashSet<String> = HashSet::new();
+
         for mount in mounts {
             if let Some(disk_stat) = disk_stats.get(&mount.majmin) {
+                if !seen_devices.insert(disk_stat.name.clone()) {
+                    continue;
+                }
+
                 let labels = std::slice::from_ref(&disk_stat.name);
                 disk_stats_counter!(mfs, num_reads, disk_stat.reads, labels);
                 disk_stats_counter!(mfs, num_merged_reads, disk_stat.merged, labels);


### PR DESCRIPTION
## Summary

`DiskMetricsCollector` and `LinuxDiskMetricsCollector` emit duplicate metric series when the same physical device is mounted at multiple mount points.

## Problem

The `sysinfo::System::disks()` and `procfs::mountinfo()` APIs return entries per **mount point**, not per unique device. When a device like `/dev/nvme0n1p4` is mounted multiple times (common in containerized environments), the collectors emit identical metric series multiple times per scrape.

This causes Prometheus to log warnings and drop samples. 

## Affected metrics

- `node_disk_available_space`
- `node_disk_total_space`
- `node_linux_disk_*` (all Linux-specific disk I/O metrics)

## Fix

Both collectors now track seen device names using a `HashSet<String>`. Before emitting metrics for a device, we check if we've already processed it. This ensures each unique physical device is reported exactly once per scrape, regardless of how many times it's mounted.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensure disk metrics are emitted once per physical device by tracking seen devices in both sysinfo- and Linux-based collectors.
> 
> - **Node Resource Metrics**:
>   - **`DiskMetricsCollector`**:
>     - Track seen device names with `HashSet` and filter `system.disks()` to emit each device once.
>     - Prevent duplicate `node_disk_total_space` and `node_disk_available_space` series.
>   - **`LinuxDiskMetricsCollector`**:
>     - Track seen device names with `HashSet` while iterating `mountinfo`/`diskstats` and skip duplicates.
>     - Prevent duplicate `node_linux_disk_*` I/O metrics (counters and gauges).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 96bcf843c474aa3c2459a654fd38d70cc7743e6d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->