### PR TITLE
[move-vm] Native function modeling for runtime reference safety checker

### DIFF
--- a/aptos-move/aptos-vm/src/move_vm_ext/session/mod.rs
+++ b/aptos-move/aptos-vm/src/move_vm_ext/session/mod.rs
@@ -556,6 +556,10 @@ where
     let session_counter = session_id.session_counter();
     let txn_hash = session_id.txn_hash();
 
+    // Note: if any new native functions that return references are added,
+    // then runtime reference check models need to be added for them with
+    // `extensions.add_native_runtime_ref_checks_model`.
+    // See documentation for `NativeRuntimeRefChecksModel` for details.
     extensions.add(NativeTableContext::new(txn_hash, data_view));
     extensions.add(NativeRistrettoPointContext::new());
     extensions.add(AlgebraContext::new());

--- a/aptos-move/framework/src/natives/aggregator_natives/context.rs
+++ b/aptos-move/framework/src/natives/aggregator_natives/context.rs
@@ -13,7 +13,7 @@ use aptos_types::state_store::{state_key::StateKey, state_value::StateValueMetad
 use better_any::{Tid, TidAble};
 use move_binary_format::errors::PartialVMResult;
 use move_core_types::value::MoveTypeLayout;
-use move_vm_runtime::native_extensions::SessionListener;
+use move_vm_runtime::native_extensions::{NativeRuntimeRefCheckModelsCompleted, SessionListener};
 use move_vm_types::delayed_values::delayed_field_id::DelayedFieldID;
 use std::{
     cell::RefCell,
@@ -69,6 +69,10 @@ impl<'a> SessionListener for NativeAggregatorContext<'a> {
     fn abort(&mut self) {
         // TODO(sessions): implement
     }
+}
+
+impl<'a> NativeRuntimeRefCheckModelsCompleted for NativeAggregatorContext<'a> {
+    // No native functions in this context return references, so no models to add.
 }
 
 impl<'a> NativeAggregatorContext<'a> {

--- a/aptos-move/framework/src/natives/code.rs
+++ b/aptos-move/framework/src/natives/code.rs
@@ -14,7 +14,10 @@ use aptos_types::{
 use better_any::{Tid, TidAble};
 use move_binary_format::errors::{PartialVMError, PartialVMResult};
 use move_core_types::{account_address::AccountAddress, gas_algebra::NumBytes};
-use move_vm_runtime::{native_extensions::SessionListener, native_functions::NativeFunction};
+use move_vm_runtime::{
+    native_extensions::{NativeRuntimeRefCheckModelsCompleted, SessionListener},
+    native_functions::NativeFunction,
+};
 use move_vm_types::{
     loaded_data::runtime_types::Type,
     values::{Struct, Value},
@@ -186,6 +189,10 @@ impl SessionListener for NativeCodeContext {
     fn abort(&mut self) {
         // No state changes to abort. Context will be reset on new session's start.
     }
+}
+
+impl NativeRuntimeRefCheckModelsCompleted for NativeCodeContext {
+    // No native functions in this context return references, so no models to add.
 }
 
 impl NativeCodeContext {

--- a/aptos-move/framework/src/natives/cryptography/algebra/mod.rs
+++ b/aptos-move/framework/src/natives/cryptography/algebra/mod.rs
@@ -28,7 +28,10 @@ use ark_serialize::CanonicalDeserialize;
 use better_any::{Tid, TidAble};
 use move_binary_format::errors::PartialVMError;
 use move_core_types::{language_storage::TypeTag, vm_status::StatusCode};
-use move_vm_runtime::{native_extensions::SessionListener, native_functions::NativeFunction};
+use move_vm_runtime::{
+    native_extensions::{NativeRuntimeRefCheckModelsCompleted, SessionListener},
+    native_functions::NativeFunction,
+};
 use once_cell::sync::Lazy;
 use std::{any::Any, hash::Hash, rc::Rc};
 
@@ -203,6 +206,10 @@ impl SessionListener for AlgebraContext {
     fn abort(&mut self) {
         // No state changes to abort. Context will be reset on new session's start.
     }
+}
+
+impl NativeRuntimeRefCheckModelsCompleted for AlgebraContext {
+    // No native functions in this context return references, so no models to add.
 }
 
 impl AlgebraContext {

--- a/aptos-move/framework/src/natives/cryptography/ristretto255_point.rs
+++ b/aptos-move/framework/src/natives/cryptography/ristretto255_point.rs
@@ -21,7 +21,7 @@ use curve25519_dalek::{
     traits::{Identity, VartimeMultiscalarMul},
 };
 use move_core_types::gas_algebra::{NumArgs, NumBytes};
-use move_vm_runtime::native_extensions::SessionListener;
+use move_vm_runtime::native_extensions::{NativeRuntimeRefCheckModelsCompleted, SessionListener};
 use move_vm_types::{
     loaded_data::runtime_types::Type,
     values::{Reference, StructRef, Value, VectorRef},
@@ -93,6 +93,10 @@ impl SessionListener for NativeRistrettoPointContext {
     fn abort(&mut self) {
         // No state changes to abort. Context will be reset on new session's start.
     }
+}
+
+impl NativeRuntimeRefCheckModelsCompleted for NativeRistrettoPointContext {
+    // No native functions in this context return references, so no models to add.
 }
 
 impl NativeRistrettoPointContext {

--- a/aptos-move/framework/src/natives/event.rs
+++ b/aptos-move/framework/src/natives/event.rs
@@ -14,7 +14,10 @@ use aptos_types::event::EventKey;
 use better_any::{Tid, TidAble};
 use move_binary_format::errors::PartialVMError;
 use move_core_types::{language_storage::TypeTag, value::MoveTypeLayout, vm_status::StatusCode};
-use move_vm_runtime::{native_extensions::SessionListener, native_functions::NativeFunction};
+use move_vm_runtime::{
+    native_extensions::{NativeRuntimeRefCheckModelsCompleted, SessionListener},
+    native_functions::NativeFunction,
+};
 #[cfg(feature = "testing")]
 use move_vm_types::values::{Reference, Struct, StructRef};
 use move_vm_types::{
@@ -44,6 +47,10 @@ impl SessionListener for NativeEventContext {
     fn abort(&mut self) {
         // TODO(sessions): implement
     }
+}
+
+impl NativeRuntimeRefCheckModelsCompleted for NativeEventContext {
+    // No native functions in this context return references, so no models to add.
 }
 
 impl NativeEventContext {

--- a/aptos-move/framework/src/natives/object.rs
+++ b/aptos-move/framework/src/natives/object.rs
@@ -13,7 +13,10 @@ use move_core_types::{
     gas_algebra::{InternalGas, InternalGasPerByte},
     vm_status::StatusCode,
 };
-use move_vm_runtime::{native_extensions::SessionListener, native_functions::NativeFunction};
+use move_vm_runtime::{
+    native_extensions::{NativeRuntimeRefCheckModelsCompleted, SessionListener},
+    native_functions::NativeFunction,
+};
 use move_vm_types::{
     loaded_data::runtime_types::Type, natives::function::PartialVMError, values::Value,
 };
@@ -48,6 +51,10 @@ impl SessionListener for NativeObjectContext {
     fn abort(&mut self) {
         // No state changes to abort.
     }
+}
+
+impl NativeRuntimeRefCheckModelsCompleted for NativeObjectContext {
+    // No native functions in this context return references, so no models to add.
 }
 
 /***************************************************************************************************

--- a/aptos-move/framework/src/natives/randomness.rs
+++ b/aptos-move/framework/src/natives/randomness.rs
@@ -9,7 +9,10 @@ use aptos_native_interface::{
     RawSafeNative, SafeNativeBuilder, SafeNativeContext, SafeNativeError, SafeNativeResult,
 };
 use better_any::{Tid, TidAble};
-use move_vm_runtime::{native_extensions::SessionListener, native_functions::NativeFunction};
+use move_vm_runtime::{
+    native_extensions::{NativeRuntimeRefCheckModelsCompleted, SessionListener},
+    native_functions::NativeFunction,
+};
 use move_vm_types::{loaded_data::runtime_types::Type, values::Value};
 use smallvec::{smallvec, SmallVec};
 use std::collections::VecDeque;
@@ -39,6 +42,10 @@ impl SessionListener for RandomnessContext {
     fn abort(&mut self) {
         // No state changes to abort. Context will be reset on new session's start.
     }
+}
+
+impl NativeRuntimeRefCheckModelsCompleted for RandomnessContext {
+    // No native functions in this context return references, so no models to add.
 }
 
 impl RandomnessContext {

--- a/aptos-move/framework/src/natives/state_storage.rs
+++ b/aptos-move/framework/src/natives/state_storage.rs
@@ -9,7 +9,10 @@ use aptos_types::{state_store::state_key::StateKey, vm_status::StatusCode};
 use aptos_vm_types::resolver::StateStorageView;
 use better_any::{Tid, TidAble};
 use move_binary_format::errors::PartialVMError;
-use move_vm_runtime::{native_extensions::SessionListener, native_functions::NativeFunction};
+use move_vm_runtime::{
+    native_extensions::{NativeRuntimeRefCheckModelsCompleted, SessionListener},
+    native_functions::NativeFunction,
+};
 use move_vm_types::{
     loaded_data::runtime_types::Type,
     values::{Struct, Value},
@@ -31,6 +34,10 @@ impl<'a> SessionListener for NativeStateStorageContext<'a> {
     fn finish(&mut self) {}
 
     fn abort(&mut self) {}
+}
+
+impl<'a> NativeRuntimeRefCheckModelsCompleted for NativeStateStorageContext<'a> {
+    // No native functions in this context return references, so no models to add.
 }
 
 impl<'a> NativeStateStorageContext<'a> {

--- a/aptos-move/framework/src/natives/transaction_context.rs
+++ b/aptos-move/framework/src/natives/transaction_context.rs
@@ -16,7 +16,10 @@ use aptos_types::{
 use better_any::{Tid, TidAble};
 use move_binary_format::errors::PartialVMResult;
 use move_core_types::gas_algebra::{NumArgs, NumBytes};
-use move_vm_runtime::{native_extensions::SessionListener, native_functions::NativeFunction};
+use move_vm_runtime::{
+    native_extensions::{NativeRuntimeRefCheckModelsCompleted, SessionListener},
+    native_functions::NativeFunction,
+};
 use move_vm_types::{
     loaded_data::runtime_types::Type,
     values::{Struct, Value},
@@ -52,6 +55,10 @@ pub struct NativeTransactionContext {
     user_transaction_context_opt: Option<UserTransactionContext>,
     /// A number to represent the sessions inside the execution of a transaction. Used for computing the `monotonically_increasing_counter` method.
     session_counter: u8,
+}
+
+impl NativeRuntimeRefCheckModelsCompleted for NativeTransactionContext {
+    // No native functions in this context return references, so no models to add.
 }
 
 impl SessionListener for NativeTransactionContext {

--- a/aptos-move/framework/table-natives/src/lib.rs
+++ b/aptos-move/framework/table-natives/src/lib.rs
@@ -25,7 +25,7 @@ use move_core_types::{
 };
 pub use move_table_extension::{TableHandle, TableInfo, TableResolver};
 use move_vm_runtime::{
-    native_extensions::SessionListener,
+    native_extensions::{NativeRuntimeRefCheckModelsCompleted, SessionListener},
     native_functions::{LoaderContext, NativeFunctionTable},
 };
 use move_vm_types::{
@@ -123,6 +123,11 @@ impl<'a> SessionListener for NativeTableContext<'a> {
     fn abort(&mut self) {
         // TODO(sessions): implement
     }
+}
+
+impl<'a> NativeRuntimeRefCheckModelsCompleted for NativeTableContext<'a> {
+    // We have added runtime ref check models for native table functions that
+    // return references.
 }
 
 impl<'a> NativeTableContext<'a> {

--- a/third_party/move/extensions/move-table-extension/src/lib.rs
+++ b/third_party/move/extensions/move-table-extension/src/lib.rs
@@ -19,7 +19,7 @@ use move_core_types::{
     vm_status::StatusCode,
 };
 use move_vm_runtime::{
-    native_extensions::UnreachableSessionListener,
+    native_extensions::{NativeRuntimeRefCheckModelsCompleted, UnreachableSessionListener},
     native_functions,
     native_functions::{LoaderContext, NativeContext, NativeFunction, NativeFunctionTable},
 };
@@ -151,6 +151,11 @@ const HANDLE_FIELD_INDEX: usize = 0;
 // Implementation of Native Table Context
 
 impl<'a> UnreachableSessionListener for NativeTableContext<'a> {}
+
+impl<'a> NativeRuntimeRefCheckModelsCompleted for NativeTableContext<'a> {
+    // We have added runtime ref check models for native table functions that
+    // return references.
+}
 
 impl<'a> NativeTableContext<'a> {
     /// Create a new instance of a native table context. This must be passed in via an

--- a/third_party/move/move-vm/runtime/src/lib.rs
+++ b/third_party/move/move-vm/runtime/src/lib.rs
@@ -28,6 +28,7 @@ mod debug;
 mod access_control;
 mod frame;
 mod frame_type_cache;
+mod native_models_for_runtime_ref_checks;
 mod reentrancy_checker;
 mod runtime_ref_checks;
 mod runtime_type_checks;

--- a/third_party/move/move-vm/runtime/src/native_models_for_runtime_ref_checks.rs
+++ b/third_party/move/move-vm/runtime/src/native_models_for_runtime_ref_checks.rs
@@ -1,0 +1,104 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::{BTreeMap, HashSet};
+
+/// For each native function that returns references, we maintain a model of which
+/// of the returned references are derived from which of the input reference
+/// parameters.
+///
+/// The model is represented as a vector of input parameter indices (0-based).
+/// There is one entry in the vector for each returned reference.
+/// That entry says which input parameter index the returned reference is derived from.
+/// Entries should only refer to input parameters that are references.
+/// Note that there are no entries for returned values that are not references.
+///
+/// For example, consider a native function with signature:
+/// `native fun foo(x: u64, y1: &u64, y2: &mut u64, y3: &mut u64): (u64, &u64, &mut u64)`
+/// A model `[1, 3]` indicates that, for the 3 return values in order:
+/// - the first return value (u64) is not a reference, so there is no entry for it
+/// - the second return value (&u64) is derived from parameter `y1`
+/// - the third return value (&mut u64) is derived from the parameter `y3`
+///
+/// Notes for possible future extensions:
+/// - We currently only use the module and function names as keys to identify native
+///   functions, and not include addresses. If there is a need in the future to
+///   distinguish between different native-publishable addresses, we can extend the
+///   key to include addresses.
+/// - The model interface currently only supports one return value derivation per
+///   input reference, as this is sufficient for the existing native functions.
+///   If we need to support multiple (exclusive) derivations from the same input
+///   reference parameter, we can extend each model entry to be a tuple
+///   (input_param_index, derivation_label), where `derivation_label` is 0, 1, ..
+///   for each distinct derivation from the same input parameter.
+///   Currently, we just use the label `0` for all derivations, as there is only
+///   one derivation per input parameter.
+#[derive(Clone)]
+pub struct NativeRuntimeRefChecksModel {
+    /// Collection of models for native functions returning references.
+    /// The key is (module_name, function_name).
+    /// The value is the model vector as described above.
+    models: BTreeMap<(&'static str, &'static str), Vec<usize>>,
+}
+
+impl Default for NativeRuntimeRefChecksModel {
+    /// Create default models for native functions that return references.
+    fn default() -> Self {
+        // First return value is a reference derived from the first reference parameter.
+        // It is the only return value that is a reference.
+        let single_return_derived_from_first_ref_param = vec![0];
+        let models = BTreeMap::from([
+            (
+                ("signer", "borrow_address"),
+                single_return_derived_from_first_ref_param.clone(),
+            ),
+            (
+                ("table", "borrow_box"),
+                single_return_derived_from_first_ref_param.clone(),
+            ),
+            (
+                ("table", "borrow_box_mut"),
+                single_return_derived_from_first_ref_param,
+            ),
+        ]);
+        let me = Self { models };
+        debug_assert!(
+            me.models.values().all(|m| Self::no_duplicates(m)),
+            "duplicate derivations in a native model"
+        );
+        me
+    }
+}
+
+impl NativeRuntimeRefChecksModel {
+    /// Add a runtime ref checks `model` for a native function.
+    /// For the semantics of `model`, see the struct documentation.
+    /// The native function is identified by its module and function names.
+    pub fn add_model_for_native_function(
+        &mut self,
+        module_name: &'static str,
+        function_name: &'static str,
+        model: Vec<usize>,
+    ) {
+        debug_assert!(
+            Self::no_duplicates(&model),
+            "duplicate derivations in the native model"
+        );
+        self.models.insert((module_name, function_name), model);
+    }
+
+    /// Get the runtime ref checks model for a native function, if it exists.
+    pub fn get_model_for_native_function(
+        &self,
+        module_name: &str,
+        function_name: &str,
+    ) -> Option<Vec<usize>> {
+        self.models.get(&(module_name, function_name)).cloned()
+    }
+
+    #[allow(dead_code)]
+    fn no_duplicates(model: &[usize]) -> bool {
+        let hash_set = HashSet::<usize>::from_iter(model.iter().cloned());
+        hash_set.len() == model.len()
+    }
+}

--- a/third_party/move/move-vm/transactional-tests/tests/native_functions/signer_usage.exp
+++ b/third_party/move/move-vm/transactional-tests/tests/native_functions/signer_usage.exp
@@ -1,0 +1,3 @@
+processed 2 tasks
+task 0 lines 1-16:  publish [module 0xc0ffee::m {]
+task 1 lines 18-18:  run 0xc0ffee::m::borrow_then_move --signers 0xc0ffee

--- a/third_party/move/move-vm/transactional-tests/tests/native_functions/signer_usage.move
+++ b/third_party/move/move-vm/transactional-tests/tests/native_functions/signer_usage.move
@@ -1,0 +1,18 @@
+//# publish
+module 0xc0ffee::m {
+    use std::signer;
+
+    struct Marker has key, drop {
+        dummy: bool,
+    }
+
+    public entry fun borrow_then_move(account: signer) {
+        let addr_ref = signer::borrow_address(&account);
+        let addr = *addr_ref;
+
+        move_to(&account, Marker { dummy: true });
+        let _ = move_from<Marker>(addr);
+    }
+}
+
+//# run 0xc0ffee::m::borrow_then_move --signers 0xc0ffee

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/native_function_no_references_returned.baseline.exp
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/native_function_no_references_returned.baseline.exp
@@ -1,0 +1,4 @@
+processed 2 tasks
+task 0 lines 1-19:  publish [module 0xc0ffee::m {]
+task 1 lines 21-21:  run 0xc0ffee::m::test --verbose
+return values: 12

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/native_function_no_references_returned.move
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/native_function_no_references_returned.move
@@ -1,0 +1,21 @@
+//# publish
+module 0xc0ffee::m {
+    use std::bcs::to_bytes;
+    use std::vector;
+
+    fun data_maker(): vector<u8> {
+        let data = b"hello world";
+        let bytes = to_bytes(&data);
+        let len = vector::length(&bytes);
+        vector::push_back(&mut bytes, len as u8);
+        vector::pop_back(&mut bytes);
+        bytes
+    }
+
+    public fun test(): u64 {
+        let hash = data_maker();
+        vector::length(&hash)
+    }
+}
+
+//# run 0xc0ffee::m::test --verbose

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/native_function_no_references_returned.ref.exp
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/native_function_no_references_returned.ref.exp
@@ -1,0 +1,4 @@
+processed 2 tasks
+task 0 lines 1-19:  publish [module 0xc0ffee::m {]
+task 1 lines 21-21:  run 0xc0ffee::m::test --verbose
+return values: 12

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/native_function_refs_returned.baseline.exp
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/native_function_refs_returned.baseline.exp
@@ -1,0 +1,3 @@
+processed 2 tasks
+task 0 lines 1-9:  publish [module 0xc0ffee::m {]
+task 1 lines 11-11:  run 0xc0ffee::m::test --signers 0xc0ffee --verbose

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/native_function_refs_returned.move
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/native_function_refs_returned.move
@@ -1,0 +1,11 @@
+//# publish
+module 0xc0ffee::m {
+    use std::signer::{borrow_address, address_of};
+
+    public fun test(s: &signer) {
+        let addr = borrow_address(s);
+        assert!(address_of(s) == *addr, 1);
+    }
+}
+
+//# run 0xc0ffee::m::test --signers 0xc0ffee --verbose

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/native_function_refs_returned.ref.exp
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/native_function_refs_returned.ref.exp
@@ -1,0 +1,3 @@
+processed 2 tasks
+task 0 lines 1-9:  publish [module 0xc0ffee::m {]
+task 1 lines 11-11:  run 0xc0ffee::m::test --signers 0xc0ffee --verbose

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/vector_borrows.baseline.exp
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/vector_borrows.baseline.exp
@@ -1,0 +1,3 @@
+processed 2 tasks
+task 0 lines 1-20:  publish [module 0xc0ffee::m {]
+task 1 lines 22-22:  run 0xc0ffee::m::borrow_read_and_mutate

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/vector_borrows.move
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/vector_borrows.move
@@ -1,0 +1,22 @@
+//# publish
+module 0xc0ffee::m {
+    use std::vector;
+
+    public entry fun borrow_read_and_mutate() {
+        let values = vector::empty<u64>();
+        vector::push_back(&mut values, 1);
+        vector::push_back(&mut values, 2);
+
+        let first = *vector::borrow(&values, 0);
+
+        {
+            let second = vector::borrow_mut(&mut values, 1);
+            *second = first + 5;
+        };
+
+        let updated = *vector::borrow(&values, 1);
+        assert!(updated == 6, 0);
+    }
+}
+
+//# run 0xc0ffee::m::borrow_read_and_mutate

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/vector_borrows.ref.exp
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/vector_borrows.ref.exp
@@ -1,0 +1,3 @@
+processed 2 tasks
+task 0 lines 1-20:  publish [module 0xc0ffee::m {]
+task 1 lines 22-22:  run 0xc0ffee::m::borrow_read_and_mutate

--- a/third_party/move/tools/move-unit-test/src/extensions.rs
+++ b/third_party/move/tools/move-unit-test/src/extensions.rs
@@ -113,7 +113,9 @@ static DUMMY_RESOLVER: Lazy<BlankStorage> = Lazy::new(|| BlankStorage);
 mod tests {
     use crate::extensions::{new_extensions, set_extension_hook};
     use better_any::{Tid, TidAble};
-    use move_vm_runtime::native_extensions::{NativeContextExtensions, UnreachableSessionListener};
+    use move_vm_runtime::native_extensions::{
+        NativeContextExtensions, NativeRuntimeRefCheckModelsCompleted, UnreachableSessionListener,
+    };
 
     /// A test that extension hooks work as expected.
     #[test]
@@ -127,6 +129,7 @@ mod tests {
     struct TestExtension();
 
     impl UnreachableSessionListener for TestExtension {}
+    impl NativeRuntimeRefCheckModelsCompleted for TestExtension {}
 
     fn my_hook(ext: &mut NativeContextExtensions) {
         ext.add(TestExtension())


### PR DESCRIPTION
## Description

In this PR, we implement the native function modeling for the runtime reference safety checker. With this, the runtime reference safety checker is expected to be fully functional and can be used in fuzzers, etc.

Notes:
- the native function models can be provided from outside third-party, and is currently bundled with the `NativeContextExtensions`
- we do not yet enable it everywhere, but I did manually turn it on and run tests; future PRs will selectively turn this on

Assumptions made about native call implementation behavior and the modeling should all be documented in the code.

Performance improvements, potential async mode, potential trusted code mode, would all be followups.

## How Has This Been Tested?
- Existing tests, added some tests.
- Manually enabled this mode and ran all the tests in aptos core, including aptos framework tests which test the behavior of native functions.

## Type of Change
- [x] New feature

## Which Components or Systems Does This Change Impact?
- [x] Move/Aptos Virtual Machine

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables runtime reference safety for native functions by modeling how returned references derive from inputs and using these models during execution.
> 
> - Adds `native_models_for_runtime_ref_checks` and threads models through `NativeContextExtensions` (new marker trait `NativeRuntimeRefCheckModelsCompleted`, API to register models) and `RefCheckState::new(models)`
> - Updates interpreter to use models for reference transitions on native static/dynamic dispatch (`RTRCheck::native_*_transition`) and adjusts core call handling
> - Provides default models (e.g., for `signer::borrow_address`, `table::borrow_box[_mut]`) and enforces model presence by requiring the marker trait on all added native contexts
> - Implements the marker trait across native contexts and annotates where no refs are returned; adds guidance in session setup for registering new models
> - Adds transactional tests covering native refs/no-refs returns, signer usage, and vector borrow behavior
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 305b0babfc0e1de0b1ea242e4b260dc0a43e551f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->