### PR TITLE
[License] Change license attribute in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -291,8 +291,9 @@ default-members = [
 [workspace.package]
 authors = ["Aptos Labs <opensource@aptoslabs.com>"]
 edition = "2024"
-homepage = "https://aptoslabs.com"
-license = "Apache-2.0"
+homepage = "https://aptosnetwork.com/"
+license = "LicenseRef-Aptos"
+license-file = "LICENSE"
 publish = false
 repository = "https://github.com/aptos-labs/aptos-core"
 rust-version = "1.85"

--- a/deny.toml
+++ b/deny.toml
@@ -14,6 +14,7 @@ allow = [
     "CC0-1.0",
     "CDDL-1.0",
     "ISC",
+    "LicenseRef-Aptos",
     "MIT",
     "MIT-0",
     "MPL-2.0",

--- a/third_party/move/move-model/bytecode/abstract_domain_derive/Cargo.toml
+++ b/third_party/move/move-model/bytecode/abstract_domain_derive/Cargo.toml
@@ -2,7 +2,7 @@
 name = "abstract-domain-derive"
 version = "0.1.0"
 edition = { workspace = true }
-license = { workspace = true }
+license = "Apache-2.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/third_party/move/move-model/bytecode/ast-generator-tests/Cargo.toml
+++ b/third_party/move/move-model/bytecode/ast-generator-tests/Cargo.toml
@@ -2,7 +2,7 @@
 name = "move-ast-generator-tests"
 version = "0.1.0"
 edition = { workspace = true }
-license = { workspace = true }
+license = "Apache-2.0"
 
 [dev-dependencies]
 anyhow = { workspace = true }

--- a/third_party/move/move-vm/metrics/Cargo.toml
+++ b/third_party/move/move-vm/metrics/Cargo.toml
@@ -2,12 +2,12 @@
 name = "move-vm-metrics"
 description = "MoveVM metrics"
 version = "0.1.0"
+license = "Apache-2.0"
 
 # Workspace inherited keys
 authors = { workspace = true }
 edition = { workspace = true }
 homepage = { workspace = true }
-license = { workspace = true }
 publish = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }

--- a/third_party/move/move-vm/profiler/Cargo.toml
+++ b/third_party/move/move-vm/profiler/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "move-vm-profiler"
 version = "0.1.0"
+license = "Apache-2.0"
 
 # Workspace inherited keys
 authors = { workspace = true }
 edition = { workspace = true }
 homepage = { workspace = true }
-license = { workspace = true }
 publish = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }

--- a/third_party/move/tools/move-linter/Cargo.toml
+++ b/third_party/move/tools/move-linter/Cargo.toml
@@ -2,12 +2,12 @@
 name = "move-linter"
 description = "The Move Linter"
 version = "0.1.0"
+license = "Apache-2.0"
 
 # Workspace inherited keys
 authors = { workspace = true }
 edition = { workspace = true }
 homepage = { workspace = true }
-license = { workspace = true }
 publish = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }

--- a/third_party/move/tools/move-package-cache/Cargo.toml
+++ b/third_party/move/tools/move-package-cache/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "move-package-cache"
 version = "0.1.0"
+license = "Apache-2.0"
 
 # Workspace inherited keys
 authors = { workspace = true }
 edition = { workspace = true }
 homepage = { workspace = true }
-license = { workspace = true }
 publish = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }

--- a/third_party/move/tools/move-package-manifest/Cargo.toml
+++ b/third_party/move/tools/move-package-manifest/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "move-package-manifest"
 version = "0.1.0"
+license = "Apache-2.0"
 
 # Workspace inherited keys
 authors = { workspace = true }
 edition = { workspace = true }
 homepage = { workspace = true }
-license = { workspace = true }
 publish = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }

--- a/third_party/move/tools/move-package-resolver/Cargo.toml
+++ b/third_party/move/tools/move-package-resolver/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "move-package-resolver"
 version = "0.1.0"
+license = "Apache-2.0"
 
 # Workspace inherited keys
 authors = { workspace = true }
 edition = { workspace = true }
 homepage = { workspace = true }
-license = { workspace = true }
 publish = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }


### PR DESCRIPTION
## Description
This PR updates the license attribution in `Cargo.toml` to reference the new license file.

## Testing Plan
Manual verification.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches the workspace to a custom license with LICENSE file and updates cargo-deny, while explicitly setting several third-party Move crates to Apache-2.0 and updating the homepage URL.
> 
> - **Licensing**:
>   - **Workspace (`Cargo.toml`)**:
>     - Update `homepage` to `https://aptosnetwork.com/`.
>     - Change `license` to `LicenseRef-Aptos` and add `license-file` `LICENSE`.
>   - **cargo-deny (`deny.toml`)**:
>     - Add `LicenseRef-Aptos` to the allowed licenses.
>   - **Third-party Move crates (explicit Apache-2.0)**:
>     - `third_party/move/move-model/bytecode/abstract_domain_derive/Cargo.toml`
>     - `third_party/move/move-model/bytecode/ast-generator-tests/Cargo.toml`
>     - `third_party/move/move-vm/metrics/Cargo.toml`
>     - `third_party/move/move-vm/profiler/Cargo.toml`
>     - `third_party/move/tools/move-linter/Cargo.toml`
>     - `third_party/move/tools/move-package-cache/Cargo.toml`
>     - `third_party/move/tools/move-package-manifest/Cargo.toml`
>     - `third_party/move/tools/move-package-resolver/Cargo.toml`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b23bf7ec26f4e2c0bfc162299ce56ed1518a1ede. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->