### PR TITLE
[vm] Fix leak in function caches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8548,6 +8548,7 @@ dependencies = [
  "bcs 0.1.4",
  "claims",
  "hex",
+ "memory-stats",
  "move-binary-format",
  "move-core-types",
  "move-model",
@@ -12108,12 +12109,12 @@ dependencies = [
 
 [[package]]
 name = "memory-stats"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34f79cf9964c5c9545493acda1263f1912f8d2c56c8a2ffee2606cb960acaacc"
+checksum = "c73f5c649995a115e1a0220b35e4df0a1294500477f97a91d0660fb5abeb574a"
 dependencies = [
  "libc",
- "winapi 0.3.9",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/aptos-move/e2e-move-tests/Cargo.toml
+++ b/aptos-move/e2e-move-tests/Cargo.toml
@@ -47,6 +47,7 @@ test-case = { workspace = true }
 [dev-dependencies]
 aptos-vm-types = { workspace = true }
 claims = { workspace = true }
+memory-stats = { workspace = true }
 test-case = { workspace = true }
 tokio = { workspace = true }
 

--- a/aptos-move/e2e-move-tests/src/tests/function_caches.rs
+++ b/aptos-move/e2e-move-tests/src/tests/function_caches.rs
@@ -1,0 +1,83 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Tests that interpreter caches frees all allocated data structures for recursively called
+//! functions.
+
+use crate::{assert_success, tests::common, MoveHarness};
+use aptos_framework::BuildOptions;
+use aptos_package_builder::PackageBuilder;
+use aptos_transaction_simulation::Account;
+use aptos_types::transaction::TransactionStatus;
+use move_core_types::account_address::AccountAddress;
+
+#[test]
+fn test_function_caches_for_recursive_functions_do_not_leak_memory() {
+    let mut h = MoveHarness::new();
+    let acc = h.new_account_at(AccountAddress::from_hex_literal("0x99").unwrap());
+
+    let status = publish(
+        &mut h,
+        &acc,
+        r#"
+        module 0x99::m {
+            public entry fun factorial(n: u64) {
+                factorial_impl(n);
+            }
+
+            fun factorial_impl(n: u64): u64 {
+                if (n <= 1) {
+                    1
+                } else {
+                    n * factorial_impl(n - 1)
+                }
+            }
+        }
+        "#,
+    );
+    assert_success!(status);
+
+    // Warmup.
+    run_factorial(&mut h, &acc);
+
+    // Memory growth later in time should be smaller than at the beginning.
+    let a = run_factorial_measure_memory_growth(&mut h, &acc);
+    let b = run_factorial_measure_memory_growth(&mut h, &acc);
+    assert!(b <= a);
+}
+
+fn run_factorial(h: &mut MoveHarness, acc: &Account) {
+    for _ in 0..300 {
+        let status = h.run_entry_function(
+            acc,
+            str::parse("0x99::m::factorial").unwrap(),
+            vec![],
+            vec![bcs::to_bytes(&4_u64).unwrap()],
+        );
+        assert_success!(status);
+    }
+}
+
+fn run_factorial_measure_memory_growth(h: &mut MoveHarness, acc: &Account) -> usize {
+    let start = memory_stats::memory_stats().unwrap().virtual_mem;
+    run_factorial(h, acc);
+    memory_stats::memory_stats()
+        .unwrap()
+        .virtual_mem
+        .saturating_sub(start)
+}
+
+fn publish(h: &mut MoveHarness, account: &Account, source: &str) -> TransactionStatus {
+    let mut builder = PackageBuilder::new("Package");
+    builder.add_source("m.move", source);
+    builder.add_local_dep(
+        "MoveStdlib",
+        &common::framework_dir_path("move-stdlib").to_string_lossy(),
+    );
+    let path = builder.write_to_temp().unwrap();
+    h.publish_package_with_options(
+        account,
+        path.path(),
+        BuildOptions::move_2().set_latest_language(),
+    )
+}

--- a/aptos-move/e2e-move-tests/src/tests/mod.rs
+++ b/aptos-move/e2e-move-tests/src/tests/mod.rs
@@ -24,6 +24,7 @@ mod error_map;
 mod events;
 mod fee_payer;
 mod friends;
+mod function_caches;
 mod function_value_capture_option;
 mod function_value_depth;
 mod function_values;

--- a/third_party/move/move-vm/runtime/src/interpreter.rs
+++ b/third_party/move/move-vm/runtime/src/interpreter.rs
@@ -443,7 +443,13 @@ where
                         if let PerInstructionCache::Call(ref function, ref frame_cache) =
                             current_frame_cache.per_instruction_cache[current_frame.pc as usize]
                         {
-                            (Rc::clone(function), Rc::clone(frame_cache))
+                            let frame_cache = frame_cache.upgrade().ok_or_else(|| {
+                                PartialVMError::new_invariant_violation(
+                                    "Frame cache is dropped during interpreter execution",
+                                )
+                                .finish(Location::Undefined)
+                            })?;
+                            (Rc::clone(function), frame_cache)
                         } else {
                             let (function, frame_cache) =
                                 match current_frame_cache.function_cache.entry(fh_idx) {
@@ -458,15 +464,25 @@ where
                                             .map(Rc::new)?;
                                         let frame_cache = function_caches
                                             .get_or_create_frame_cache_non_generic(&function);
-                                        e.insert((function.clone(), frame_cache.clone()));
+                                        e.insert((function.clone(), Rc::downgrade(&frame_cache)));
                                         (function, frame_cache)
                                     },
-                                    Entry::Occupied(e) => e.into_mut().clone(),
+                                    Entry::Occupied(e) => {
+                                        let (function, frame_cache) = e.get();
+                                        let frame_cache =
+                                            frame_cache.upgrade().ok_or_else(|| {
+                                                PartialVMError::new_invariant_violation(
+                                            "Frame cache is dropped during interpreter execution",
+                                        )
+                                        .finish(Location::Undefined)
+                                            })?;
+                                        (function.clone(), frame_cache)
+                                    },
                                 };
                             current_frame_cache.per_instruction_cache[current_frame.pc as usize] =
                                 PerInstructionCache::Call(
                                     Rc::clone(&function),
-                                    Rc::clone(&frame_cache),
+                                    Rc::downgrade(&frame_cache),
                                 );
                             (function, frame_cache)
                         }
@@ -540,30 +556,46 @@ where
                         if let PerInstructionCache::CallGeneric(ref function, ref frame_cache) =
                             current_frame_cache.per_instruction_cache[current_frame.pc as usize]
                         {
-                            (Rc::clone(function), Rc::clone(frame_cache))
+                            let frame_cache = frame_cache.upgrade().ok_or_else(|| {
+                                PartialVMError::new_invariant_violation(
+                                    "Frame cache is dropped during interpreter execution",
+                                )
+                                .finish(Location::Undefined)
+                            })?;
+                            (Rc::clone(function), frame_cache)
                         } else {
-                            let (function, frame_cache) =
-                                match current_frame_cache.generic_function_cache.entry(idx) {
-                                    Entry::Vacant(e) => {
-                                        let function = Rc::new(
-                                            self.load_generic_function_no_visibility_checks(
-                                                gas_meter,
-                                                traversal_context,
-                                                &current_frame,
-                                                idx,
-                                            )?,
-                                        );
-                                        let frame_cache = function_caches
-                                            .get_or_create_frame_cache_generic(&function);
-                                        e.insert((function.clone(), frame_cache.clone()));
-                                        (function, frame_cache)
-                                    },
-                                    Entry::Occupied(e) => e.into_mut().clone(),
-                                };
+                            let (function, frame_cache) = match current_frame_cache
+                                .generic_function_cache
+                                .entry(idx)
+                            {
+                                Entry::Vacant(e) => {
+                                    let function =
+                                        Rc::new(self.load_generic_function_no_visibility_checks(
+                                            gas_meter,
+                                            traversal_context,
+                                            &current_frame,
+                                            idx,
+                                        )?);
+                                    let frame_cache = function_caches
+                                        .get_or_create_frame_cache_generic(&function);
+                                    e.insert((function.clone(), Rc::downgrade(&frame_cache)));
+                                    (function, frame_cache)
+                                },
+                                Entry::Occupied(e) => {
+                                    let (function, frame_cache) = e.get();
+                                    let frame_cache = frame_cache.upgrade().ok_or_else(|| {
+                                        PartialVMError::new_invariant_violation(
+                                            "Frame cache is dropped during interpreter execution",
+                                        )
+                                        .finish(Location::Undefined)
+                                    })?;
+                                    (function.clone(), frame_cache)
+                                },
+                            };
                             current_frame_cache.per_instruction_cache[current_frame.pc as usize] =
                                 PerInstructionCache::CallGeneric(
                                     Rc::clone(&function),
-                                    Rc::clone(&frame_cache),
+                                    Rc::downgrade(&frame_cache),
                                 );
                             (function, frame_cache)
                         }


### PR DESCRIPTION
## Description

Frame type caches store references to other caches of callers. In case the caller is recursive, e.g., function calling itself, this results in memory leak. Changing to weak references to avoid that.

## How Has This Been Tested?

Manual test that memory leaks, and does not leak with the fix. Added a not so flaky test to assert this.

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switch function/frame caches to Weak refs to break recursive reference cycles and add an e2e test that detects memory growth, plus minor deps update.
> 
> - **VM Runtime (Move VM)**:
>   - Change `PerInstructionCache::Call/CallGeneric` and frame caches to store `Weak<RefCell<FrameTypeCache>>` instead of `Rc`, breaking cycles in recursive calls.
>   - Update cache access to `upgrade()` weak refs and emit invariant-violation errors if dropped.
>   - Apply changes in `runtime/src/frame_type_cache.rs`, `runtime/src/interpreter.rs`, and `runtime/src/runtime_type_checks_async.rs` for both generic and non-generic calls.
> - **Tests**:
>   - Add `e2e-move-tests/src/tests/function_caches.rs`: runs recursive `factorial` repeatedly and asserts memory growth does not increase over time.
>   - Wire test in `e2e-move-tests/src/tests/mod.rs` and enable `memory-stats` in dev-deps.
> - **Dependencies**:
>   - Add `memory-stats` dev-dependency for tests; bump crate to `1.2.0` (lockfile updated).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit be6b8023d9e9d6590c4dc5b3e1ec1777d73dbf22. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->