### PR TITLE
Upgrade cc crate to 1.2.50 and stop setting LTO flags manually

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -28,8 +28,7 @@ rustflags = ["--cfg", "tokio_unstable", "-C", "force-frame-pointers=yes", "-C", 
 [target.x86_64-unknown-linux-gnu]
 # We also need to include `-C linker-plugin-lto` for performance builds to take
 # full advantage of LTO, but we cannot add it here because it would affect dev
-# and release builds as well, so we add it via `--config 'build.rustflags=...'`
-# when building docker images.
+# and release builds as well, so we add it only when building docker images.
 rustflags = [
   "--cfg",
   "tokio_unstable",
@@ -46,9 +45,9 @@ rustflags = [
 [env]
 CC_x86_64_unknown_linux_gnu = "clang"
 CXX_x86_64_unknown_linux_gnu = "clang++"
-CFLAGS_x86_64_unknown_linux_gnu = "-flto=thin -march=x86-64-v3"
+CFLAGS_x86_64_unknown_linux_gnu = "-march=x86-64-v3"
 # Need `-mpclmul` for RocksDB to build until its build script is fixed.
-CXXFLAGS_x86_64_unknown_linux_gnu = "-flto=thin -march=x86-64-v3 -mpclmul"
+CXXFLAGS_x86_64_unknown_linux_gnu = "-march=x86-64-v3 -mpclmul"
 
 # 64 bit MSVC
 [target.x86_64-pc-windows-msvc]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6793,10 +6793,11 @@ checksum = "a2698f953def977c68f935bb0dfa959375ad4638570e969e2f1e9f433cbf1af6"
 
 [[package]]
 name = "cc"
-version = "1.2.16"
+version = "1.2.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be714c154be609ec7f5dad223a33bf1482fff90472de28f7362806e6d4832b8c"
+checksum = "9f50d563227a1c37cc0a263f64eca3334388c01c5e4c4861a9def205c614383c"
 dependencies = [
+ "find-msvc-tools",
  "jobserver",
  "libc",
  "shlex",
@@ -9336,6 +9337,12 @@ dependencies = [
  "redox_syscall 0.4.1",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844"
 
 [[package]]
 name = "findshlibs"

--- a/docker/builder/build-indexer.sh
+++ b/docker/builder/build-indexer.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Copyright (c) Aptos
 # SPDX-License-Identifier: Apache-2.0
-set -e
+set -ex
 
 PROFILE=${PROFILE:-release}
 
@@ -10,12 +10,14 @@ echo "PROFILE: $PROFILE"
 
 echo "CARGO_TARGET_DIR: $CARGO_TARGET_DIR"
 
+BUILD_ENV=()
 if [[ "$PROFILE" == "performance" ]]; then
-  EXTRA_CONFIGS=(--config 'build.rustflags=["-C", "linker-plugin-lto"]')
+  source "$(dirname -- "${BASH_SOURCE[0]}")/performance_rustflags.sh"
+  BUILD_ENV=(RUSTFLAGS="${PERFORMANCE_RUSTFLAGS[*]}")
 fi
 
 # Build all the rust binaries
-cargo build "${EXTRA_CONFIGS[@]}" --locked --profile=$PROFILE \
+env "${BUILD_ENV[@]}" cargo build --locked --profile=$PROFILE \
     -p aptos-indexer-grpc-cache-worker \
     -p aptos-indexer-grpc-file-store \
     -p aptos-indexer-grpc-data-service \

--- a/docker/builder/build-tools.sh
+++ b/docker/builder/build-tools.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Copyright (c) Aptos
 # SPDX-License-Identifier: Apache-2.0
-set -e
+set -ex
 
 echo "Building tools and services docker images"
 echo "PROFILE: $PROFILE"
@@ -44,8 +44,10 @@ echo "Building the Aptos Move framework..."
 # We build everything above with `cli` profile, but building `aptos-debugger`
 # with `performance` profile, if specified, helps speed up replay-verify, so we
 # do it here separately.
+BUILD_ENV=()
 if [[ "$PROFILE" == "performance" ]]; then
-  EXTRA_CONFIGS=(--config 'build.rustflags=["-C", "linker-plugin-lto"]')
+  source "$(dirname -- "${BASH_SOURCE[0]}")/performance_rustflags.sh"
+  BUILD_ENV=(RUSTFLAGS="${PERFORMANCE_RUSTFLAGS[*]}")
 fi
-cargo build "${EXTRA_CONFIG[@]}" --locked --profile=$PROFILE -p aptos-debugger "$@"
+env "${BUILD_ENV[@]}" cargo build --locked --profile=$PROFILE -p aptos-debugger "$@"
 cp $CARGO_TARGET_DIR/$PROFILE/aptos-debugger dist/aptos-debugger

--- a/docker/builder/performance_rustflags.sh
+++ b/docker/builder/performance_rustflags.sh
@@ -1,0 +1,16 @@
+# Flags for performance builds. They must be kept in sync with the ones defined
+# in `.cargo/config.toml`, with `-C linker-plugin-lto` added at the end.
+PERFORMANCE_RUSTFLAGS=(
+  "--cfg"
+  "tokio_unstable"
+  "-C"
+  "link-arg=-fuse-ld=lld"
+  "-C"
+  "force-frame-pointers=yes"
+  "-C"
+  "force-unwind-tables=yes"
+  "-C"
+  "target-cpu=x86-64-v3"
+  "-C"
+  "linker-plugin-lto"
+)


### PR DESCRIPTION

The latest version of `cc` now automatically detects if `-C linker-plugin-lto` is set in Rust flags and applies `-flto=thin` accordingly: https://github.com/rust-lang/cc-rs/blob/0f78e0c502645402187a15103af78caac5659a7c/src/flags.rs#L324-L333

Previously, the old version (what we are currently using) did not have it, so we added `-flto=thin` manually.

This commit upgrades `cc` to the latest `1.2.50` version and remove `-flto=thin` from `.cargo/config.toml`. In some edge cases where gcc is used (despite that we set `CC=clang` in `.cargo/config.toml`), having `-flto=thin` would cause the build to fail.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps `cc` to 1.2.50 and removes manual `-flto=thin`, introducing `performance_rustflags.sh` and using env `RUSTFLAGS` for performance Docker builds.
> 
> - **Build configuration**:
>   - Remove manual `-flto=thin` from `.cargo/config.toml` (`CFLAGS_x86_64_unknown_linux_gnu`, `CXXFLAGS_x86_64_unknown_linux_gnu`); clarify LTO comment.
>   - Add `docker/builder/performance_rustflags.sh` with consolidated performance `RUSTFLAGS` (includes `-C linker-plugin-lto`).
> - **Docker build scripts**:
>   - Switch to `set -ex` and pass performance flags via `env RUSTFLAGS=...` instead of `--config build.rustflags=...` in `build-indexer.sh`, `build-node.sh`, and `build-tools.sh`.
> - **Dependencies**:
>   - Upgrade `cc` from `1.2.16` to `1.2.50` in `Cargo.lock` (adds `find-msvc-tools`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 806d7c9c5be273fa33c8942de977027d96847235. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->