### PR TITLE
[Hot State] Delete unused code

### DIFF
--- a/storage/storage-interface/src/state_store/state_delta.rs
+++ b/storage/storage-interface/src/state_store/state_delta.rs
@@ -4,10 +4,7 @@
 use crate::state_store::state::State;
 use aptos_experimental_layered_map::LayeredMap;
 use aptos_types::{
-    state_store::{
-        hot_state::HOT_STATE_MAX_ITEMS_PER_SHARD, state_key::StateKey, state_slot::StateSlot,
-        NUM_STATE_SHARDS,
-    },
+    state_store::{state_key::StateKey, state_slot::StateSlot, NUM_STATE_SHARDS},
     transaction::Version,
 };
 use std::sync::Arc;
@@ -53,20 +50,6 @@ impl StateDelta {
     /// `None` indicates the key is not updated in the delta.
     pub fn get_state_slot(&self, state_key: &StateKey) -> Option<StateSlot> {
         self.shards[state_key.get_shard_id()].get(state_key)
-    }
-
-    pub(crate) fn num_free_hot_slots(&self) -> [usize; NUM_STATE_SHARDS] {
-        std::array::from_fn(|shard_id| {
-            let num_items = self.current.num_hot_items(shard_id);
-            assert!(
-                num_items <= HOT_STATE_MAX_ITEMS_PER_SHARD,
-                "Number of hot state items {} exceeded max size {} in shard {}.",
-                num_items,
-                HOT_STATE_MAX_ITEMS_PER_SHARD,
-                shard_id,
-            );
-            HOT_STATE_MAX_ITEMS_PER_SHARD - num_items
-        })
     }
 
     pub fn latest_hot_key(&self, shard_id: usize) -> Option<StateKey> {

--- a/storage/storage-interface/src/state_store/state_view/cached_state_view.rs
+++ b/storage/storage-interface/src/state_store/state_view/cached_state_view.rs
@@ -18,9 +18,8 @@ use anyhow::Result;
 use aptos_metrics_core::{IntCounterVecHelper, TimerHelper};
 use aptos_types::{
     state_store::{
-        hot_state::THotStateSlot, state_key::StateKey, state_slot::StateSlot,
-        state_storage_usage::StateStorageUsage, StateViewId, StateViewResult, TStateView,
-        NUM_STATE_SHARDS,
+        state_key::StateKey, state_slot::StateSlot, state_storage_usage::StateStorageUsage,
+        StateViewId, StateViewResult, TStateView, NUM_STATE_SHARDS,
     },
     transaction::Version,
 };
@@ -303,51 +302,6 @@ impl TStateView for CachedStateView {
 
     fn next_version(&self) -> Version {
         self.speculative.next_version()
-    }
-
-    fn contains_hot_state_value(&self, state_key: &StateKey) -> bool {
-        if let Some(slot) = self.speculative.get_state_slot(state_key) {
-            // Most likely the slot we get from `self.speculative` is hot, because it is recently
-            // written to. However, this is not guaranteed because there could be rules, for
-            // example, one that prevents large state values from going into the hot state. So we
-            // need to check whether it's hot explicitly.
-            //
-            // Same for `get_next_old_key` below.
-            return slot.is_hot();
-        }
-
-        self.hot.get_state_slot(state_key).is_some()
-    }
-
-    fn num_free_hot_slots(&self) -> [usize; NUM_STATE_SHARDS] {
-        self.speculative.num_free_hot_slots()
-    }
-
-    fn get_shard_id(&self, state_key: &StateKey) -> usize {
-        state_key.get_shard_id()
-    }
-
-    fn get_next_old_key(
-        &self,
-        shard_id: usize,
-        state_key: Option<&StateKey>,
-    ) -> Option<Option<StateKey>> {
-        let key = match state_key {
-            Some(k) => {
-                assert_eq!(k.get_shard_id(), shard_id);
-                k
-            },
-            None => return Some(self.speculative.oldest_hot_key(shard_id)),
-        };
-
-        if let Some(slot) = self.speculative.get_state_slot(key) {
-            slot.is_hot().then(|| slot.next().cloned())
-        } else if let Some(slot) = self.hot.get_state_slot(key) {
-            assert!(slot.is_hot());
-            Some(slot.next().cloned())
-        } else {
-            None
-        }
     }
 }
 

--- a/types/src/state_store/mod.rs
+++ b/types/src/state_store/mod.rs
@@ -78,39 +78,6 @@ pub trait TStateView {
     fn contains_state_value(&self, state_key: &Self::Key) -> StateViewResult<bool> {
         self.get_state_value(state_key).map(|opt| opt.is_some())
     }
-
-    /// Checks if a state keyed by the given state key exists in the hot state.
-    // TODO(HotState): not used.
-    fn contains_hot_state_value(&self, _state_key: &Self::Key) -> bool {
-        false
-    }
-
-    /// Number of free slots in hot state.
-    // TODO(HotState): not used.
-    fn num_free_hot_slots(&self) -> [usize; NUM_STATE_SHARDS] {
-        [0; NUM_STATE_SHARDS]
-    }
-
-    // TODO(HotState): not used.
-    fn get_shard_id(&self, _state_key: &Self::Key) -> usize {
-        unimplemented!();
-    }
-
-    /// If the input key is `None`, returns the oldest key as `Some(Some(key))`, unless the LRU is
-    /// empty, in which case `Some(None)` is returned.
-    ///
-    /// Otherwise, returns the key that is just a bit newer, i.e. the next candidate for eviction,
-    /// or `Some(None)` if the input key is already the newest.
-    ///
-    /// Returns `None` if the input key does not exist in hot state at all.
-    // TODO(HotState): not used.
-    fn get_next_old_key(
-        &self,
-        _shard_id: usize,
-        _state_key: Option<&Self::Key>,
-    ) -> Option<Option<Self::Key>> {
-        unimplemented!();
-    }
 }
 
 pub trait StateView: TStateView<Key = StateKey> {}
@@ -161,26 +128,6 @@ where
 
     fn get_state_value(&self, state_key: &K) -> StateViewResult<Option<StateValue>> {
         self.deref().get_state_value(state_key)
-    }
-
-    fn contains_hot_state_value(&self, state_key: &Self::Key) -> bool {
-        self.deref().contains_hot_state_value(state_key)
-    }
-
-    fn num_free_hot_slots(&self) -> [usize; NUM_STATE_SHARDS] {
-        self.deref().num_free_hot_slots()
-    }
-
-    fn get_shard_id(&self, state_key: &Self::Key) -> usize {
-        self.deref().get_shard_id(state_key)
-    }
-
-    fn get_next_old_key(
-        &self,
-        shard_id: usize,
-        state_key: Option<&Self::Key>,
-    ) -> Option<Option<Self::Key>> {
-        self.deref().get_next_old_key(shard_id, state_key)
     }
 }
 


### PR DESCRIPTION

Old implementation. Not used anymore.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes unused Hot State-related APIs and references across state view and storage interface.
> 
> - Delete `contains_hot_state_value`, `num_free_hot_slots`, `get_shard_id`, and `get_next_old_key` from `TStateView` and its blanket impl
> - Remove corresponding methods from `CachedStateView`; simplify imports by dropping `THotStateSlot`
> - In `StateDelta`, remove `num_free_hot_slots` and associated `HOT_STATE_MAX_ITEMS_PER_SHARD` checks; clean up imports
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8945080f47601b8c66396075623db2c77d270a7f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->