### PR TITLE
[Hot State] Use config to replace hard-coded parameters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1700,6 +1700,7 @@ name = "aptos-executor-types"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "aptos-config",
  "aptos-crypto",
  "aptos-drop-helper",
  "aptos-infallible",
@@ -4242,6 +4243,7 @@ name = "aptos-storage-interface"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "aptos-config",
  "aptos-crypto",
  "aptos-experimental-layered-map",
  "aptos-logger",

--- a/config/src/config/storage_config.rs
+++ b/config/src/config/storage_config.rs
@@ -237,12 +237,29 @@ impl Default for RocksdbConfigs {
     }
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct HotStateConfig {
+    /// Max number of items in each shard.
+    pub max_items_per_shard: usize,
+}
+
+impl Default for HotStateConfig {
+    fn default() -> Self {
+        Self {
+            max_items_per_shard: 250_000,
+        }
+    }
+}
+
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct StorageConfig {
     pub backup_service_address: SocketAddr,
     /// Top level directory to store the RocksDB
     pub dir: PathBuf,
+    /// Hot state configuration
+    pub hot_state_config: HotStateConfig,
     /// Storage pruning configuration
     pub storage_pruner_config: PrunerConfig,
     /// Subdirectory for storage in tests only
@@ -406,6 +423,7 @@ impl Default for StorageConfig {
         StorageConfig {
             backup_service_address: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 6186),
             dir: PathBuf::from("db"),
+            hot_state_config: HotStateConfig::default(),
             // The prune window must at least out live a RPC request because its sub requests are
             // to return a consistent view of the DB at exactly same version. Considering a few
             // thousand TPS we are potentially going to achieve, and a few minutes a consistent view

--- a/execution/executor-types/Cargo.toml
+++ b/execution/executor-types/Cargo.toml
@@ -14,6 +14,7 @@ rust-version = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }
+aptos-config = { workspace = true }
 aptos-crypto = { workspace = true }
 aptos-drop-helper = { workspace = true }
 aptos-infallible = { workspace = true }

--- a/execution/executor-types/src/execution_output.rs
+++ b/execution/executor-types/src/execution_output.rs
@@ -7,6 +7,7 @@ use crate::{
     planned::Planned,
     transactions_with_output::{TransactionsToKeep, TransactionsWithOutput},
 };
+use aptos_config::config::HotStateConfig;
 use aptos_drop_helper::DropHelper;
 use aptos_storage_interface::state_store::{
     state::LedgerState, state_view::cached_state_view::ShardedStateCache,
@@ -14,7 +15,6 @@ use aptos_storage_interface::state_store::{
 use aptos_types::{
     contract_event::ContractEvent,
     epoch_state::EpochState,
-    state_store::hot_state::HotStateConfig,
     transaction::{
         block_epilogue::BlockEndInfo, ExecutionStatus, Transaction, TransactionStatus, Version,
     },

--- a/execution/executor/Cargo.toml
+++ b/execution/executor/Cargo.toml
@@ -15,6 +15,7 @@ rust-version = { workspace = true }
 [dependencies]
 anyhow = { workspace = true }
 aptos-block-executor = { workspace = true }
+aptos-config = { workspace = true }
 aptos-consensus-types = { workspace = true }
 aptos-crypto = { workspace = true }
 aptos-drop-helper = { workspace = true }

--- a/execution/executor/src/block_executor/block_tree/test.rs
+++ b/execution/executor/src/block_executor/block_tree/test.rs
@@ -5,13 +5,11 @@ use crate::{
     block_executor::block_tree::{epoch_genesis_block_id, BlockLookup, BlockTree},
     types::partial_state_compute_result::PartialStateComputeResult,
 };
+use aptos_config::config::HotStateConfig;
 use aptos_crypto::{hash::PRE_GENESIS_BLOCK_ID, HashValue};
 use aptos_infallible::Mutex;
 use aptos_storage_interface::LedgerSummary;
-use aptos_types::{
-    block_info::BlockInfo, epoch_state::EpochState, ledger_info::LedgerInfo,
-    state_store::hot_state::HotStateConfig,
-};
+use aptos_types::{block_info::BlockInfo, epoch_state::EpochState, ledger_info::LedgerInfo};
 use std::sync::Arc;
 
 impl BlockTree {

--- a/execution/executor/src/workflow/do_get_execution_output.rs
+++ b/execution/executor/src/workflow/do_get_execution_output.rs
@@ -564,12 +564,12 @@ impl TStateView for WriteSetStateView<'_> {
 #[cfg(test)]
 mod tests {
     use super::Parser;
+    use aptos_config::config::HotStateConfig;
     use aptos_storage_interface::state_store::{
         state::LedgerState, state_view::cached_state_view::CachedStateView,
     };
     use aptos_types::{
         contract_event::ContractEvent,
-        state_store::hot_state::HotStateConfig,
         transaction::{
             AuxiliaryInfo, ExecutionStatus, PersistedAuxiliaryInfo, Transaction,
             TransactionAuxiliaryData, TransactionOutput, TransactionStatus,

--- a/storage/aptosdb/src/state_store/hot_state.rs
+++ b/storage/aptosdb/src/state_store/hot_state.rs
@@ -3,6 +3,7 @@
 
 use crate::metrics::{COUNTER, GAUGE, OTHER_TIMERS_SECONDS};
 use anyhow::{ensure, Result};
+use aptos_config::config::HotStateConfig;
 use aptos_infallible::Mutex;
 use aptos_logger::prelude::*;
 use aptos_metrics_core::{IntCounterVecHelper, IntGaugeVecHelper, TimerHelper};
@@ -10,10 +11,7 @@ use aptos_storage_interface::state_store::{
     state::State, state_view::hot_state_view::HotStateView,
 };
 use aptos_types::state_store::{
-    hot_state::{HotStateConfig, THotStateSlot},
-    state_key::StateKey,
-    state_slot::StateSlot,
-    NUM_STATE_SHARDS,
+    hot_state::THotStateSlot, state_key::StateKey, state_slot::StateSlot, NUM_STATE_SHARDS,
 };
 #[cfg(test)]
 use aptos_types::transaction::Version;

--- a/storage/aptosdb/src/state_store/mod.rs
+++ b/storage/aptosdb/src/state_store/mod.rs
@@ -30,6 +30,7 @@ use crate::{
         ShardedStateKvSchemaBatch,
     },
 };
+use aptos_config::config::HotStateConfig;
 use aptos_crypto::{
     hash::{CryptoHash, CORRUPTION_SENTINEL, SPARSE_MERKLE_PLACEHOLDER_HASH},
     HashValue,
@@ -63,7 +64,6 @@ use aptos_storage_interface::{
 use aptos_types::{
     proof::{definition::LeafCount, SparseMerkleProofExt, SparseMerkleRangeProof},
     state_store::{
-        hot_state::HotStateConfig,
         state_key::{prefix::StateKeyPrefix, StateKey},
         state_slot::StateSlot,
         state_storage_usage::StateStorageUsage,

--- a/storage/aptosdb/src/state_store/persisted_state.rs
+++ b/storage/aptosdb/src/state_store/persisted_state.rs
@@ -2,6 +2,7 @@
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{metrics::OTHER_TIMERS_SECONDS, state_store::hot_state::HotState};
+use aptos_config::config::HotStateConfig;
 use aptos_infallible::Mutex;
 use aptos_metrics_core::TimerHelper;
 use aptos_scratchpad::SUBTREE_DROPPER;
@@ -9,7 +10,6 @@ use aptos_storage_interface::state_store::{
     state::State, state_summary::StateSummary, state_view::hot_state_view::HotStateView,
     state_with_summary::StateWithSummary,
 };
-use aptos_types::state_store::hot_state::HotStateConfig;
 use std::sync::Arc;
 
 #[derive(Clone)]

--- a/storage/aptosdb/src/state_store/tests/speculative_state_workflow.rs
+++ b/storage/aptosdb/src/state_store/tests/speculative_state_workflow.rs
@@ -3,6 +3,7 @@
 
 use crate::state_store::persisted_state::PersistedState;
 use aptos_block_executor::hot_state_op_accumulator::BlockHotStateOpAccumulator;
+use aptos_config::config::HotStateConfig;
 use aptos_crypto::{hash::CryptoHash, HashValue};
 use aptos_infallible::Mutex;
 use aptos_scratchpad::test_utils::naive_smt::NaiveSmt;
@@ -19,12 +20,9 @@ use aptos_storage_interface::{
 use aptos_types::{
     proof::SparseMerkleProofExt,
     state_store::{
-        hot_state::{HotStateConfig, LRUEntry},
-        state_key::StateKey,
-        state_slot::StateSlot,
-        state_storage_usage::StateStorageUsage,
-        state_value::StateValue,
-        StateViewId, StateViewResult, TStateView, NUM_STATE_SHARDS,
+        hot_state::LRUEntry, state_key::StateKey, state_slot::StateSlot,
+        state_storage_usage::StateStorageUsage, state_value::StateValue, StateViewId,
+        StateViewResult, TStateView, NUM_STATE_SHARDS,
     },
     transaction::Version,
     write_set::{BaseStateOp, HotStateOp, WriteOp},

--- a/storage/storage-interface/Cargo.toml
+++ b/storage/storage-interface/Cargo.toml
@@ -14,6 +14,7 @@ rust-version = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }
+aptos-config = { workspace = true }
 aptos-crypto = { workspace = true }
 aptos-experimental-layered-map = { workspace = true }
 aptos-logger = { workspace = true }

--- a/storage/storage-interface/src/ledger_summary.rs
+++ b/storage/storage-interface/src/ledger_summary.rs
@@ -2,9 +2,9 @@
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::state_store::{state::LedgerState, state_summary::LedgerStateSummary};
+use aptos_config::config::HotStateConfig;
 use aptos_types::{
     proof::accumulator::{InMemoryAccumulator, InMemoryTransactionAccumulator},
-    state_store::hot_state::HotStateConfig,
     transaction::Version,
 };
 use std::sync::Arc;

--- a/storage/storage-interface/src/state_store/state.rs
+++ b/storage/storage-interface/src/state_store/state.rs
@@ -18,12 +18,13 @@ use crate::{
     DbReader,
 };
 use anyhow::Result;
+use aptos_config::config::HotStateConfig;
 use aptos_experimental_layered_map::{LayeredMap, MapLayer};
 use aptos_metrics_core::TimerHelper;
 use aptos_types::{
     state_store::{
-        hot_state::HotStateConfig, state_key::StateKey, state_slot::StateSlot,
-        state_storage_usage::StateStorageUsage, StateViewId, NUM_STATE_SHARDS,
+        state_key::StateKey, state_slot::StateSlot, state_storage_usage::StateStorageUsage,
+        StateViewId, NUM_STATE_SHARDS,
     },
     transaction::Version,
 };

--- a/storage/storage-interface/src/state_store/state_with_summary.rs
+++ b/storage/storage-interface/src/state_store/state_with_summary.rs
@@ -5,12 +5,10 @@ use crate::state_store::{
     state::{LedgerState, State},
     state_summary::{LedgerStateSummary, StateSummary},
 };
+use aptos_config::config::HotStateConfig;
 use aptos_crypto::HashValue;
 use aptos_scratchpad::SparseMerkleTree;
-use aptos_types::{
-    state_store::{hot_state::HotStateConfig, state_storage_usage::StateStorageUsage},
-    transaction::Version,
-};
+use aptos_types::{state_store::state_storage_usage::StateStorageUsage, transaction::Version};
 use derive_more::{Deref, DerefMut};
 
 #[derive(Clone, Debug, Deref)]

--- a/types/src/state_store/hot_state.rs
+++ b/types/src/state_store/hot_state.rs
@@ -1,28 +1,6 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-// 256 MiB per shard
-pub const HOT_STATE_MAX_BYTES_PER_SHARD: usize = 256 * 1024 * 1024;
-// 250k items per shard
-pub const HOT_STATE_MAX_ITEMS_PER_SHARD: usize = 250_000;
-// 10KB, worst case the hot state still caches about 400K items (all shards)
-pub const HOT_STATE_MAX_SINGLE_VALUE_BYTES: usize = 10 * 1024;
-
-// TODO(HotState): later make this onchain config.
-#[derive(Clone, Copy, Debug)]
-pub struct HotStateConfig {
-    pub max_items_per_shard: usize,
-}
-
-// TODO(HotState): can be removed once we make it configurable.
-impl Default for HotStateConfig {
-    fn default() -> Self {
-        Self {
-            max_items_per_shard: HOT_STATE_MAX_ITEMS_PER_SHARD,
-        }
-    }
-}
-
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct LRUEntry<K> {
     /// The key that is slightly newer than the current entry. `None` for the newest entry.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Makes hot state sizing configurable via node config instead of hard-coded defaults.
> 
> - Adds `HotStateConfig` to `config/src/config/storage_config.rs` and wires it into `StorageConfig` (default `max_items_per_shard = 250_000`)
> - Removes `HotStateConfig` and related constants from `types/src/state_store/hot_state.rs`; keeps only `LRUEntry` and `THotStateSlot`
> - Updates executor, storage-interface, and aptosdb to import `HotStateConfig` from `aptos-config`; adjusts constructors and tests accordingly
> - Adds `aptos-config` dependency to affected crates
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f45019569482a62d954f963df65faa8292e4b4fb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->