### PR TITLE
[aptos cli] release cli 7.12.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,7 +304,7 @@ dependencies = [
 
 [[package]]
 name = "aptos"
-version = "7.12.0"
+version = "7.12.1"
 dependencies = [
  "anyhow",
  "aptos-api-types",

--- a/crates/aptos/CHANGELOG.md
+++ b/crates/aptos/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to the Aptos CLI will be captured in this file. This project
 
 # Unreleased
 
+## [7.12.1]
+- Fix link time optimization issues with Aptos CLI released via homebrew.
+
 ## [7.12.0]
 - Add support for passing signed integer transaction arguments through the Aptos CLI.
 

--- a/crates/aptos/Cargo.toml
+++ b/crates/aptos/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aptos"
 description = "Aptos tool for management of nodes and interacting with the blockchain"
-version = "7.12.0"
+version = "7.12.1"
 
 # Workspace inherited keys
 authors = { workspace = true }


### PR DESCRIPTION
## Description
This PR fixes link time optimization issues when release Aptos cli through homebrew.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps Aptos CLI to 7.12.1 and documents an LTO fix for Homebrew releases.
> 
> - **Release**:
>   - Bump `crates/aptos` version to `7.12.1` in `Cargo.toml` and `Cargo.lock`.
>   - Update `crates/aptos/CHANGELOG.md` with `7.12.1` entry noting fix for link-time optimization issues when released via Homebrew.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b37dbf8da0faadbc4f78d3714c1c65819af6515a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->