### PR TITLE
Fix reflection service to use the right file descriptor set based on …

### DIFF
--- a/ecosystem/indexer-grpc/indexer-grpc-fullnode/src/runtime.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-fullnode/src/runtime.rs
@@ -13,7 +13,10 @@ use aptos_protos::{
     indexer::v1::{
         raw_data_server::RawDataServer, FILE_DESCRIPTOR_SET as INDEXER_V1_FILE_DESCRIPTOR_SET,
     },
-    internal::fullnode::v1::fullnode_data_server::FullnodeDataServer,
+    internal::fullnode::v1::{
+        fullnode_data_server::FullnodeDataServer,
+        FILE_DESCRIPTOR_SET as FULLNODE_V1_FILE_DESCRIPTOR_SET,
+    },
     transaction::v1::FILE_DESCRIPTOR_SET as TRANSACTION_V1_TESTING_FILE_DESCRIPTOR_SET,
     util::timestamp::FILE_DESCRIPTOR_SET as UTIL_TIMESTAMP_FILE_DESCRIPTOR_SET,
 };
@@ -84,13 +87,19 @@ pub fn bootstrap(
         };
         let localnet_data_server = LocalnetDataService { service_context };
 
+        let data_server_descriptor_set = if use_data_service_interface {
+            INDEXER_V1_FILE_DESCRIPTOR_SET
+        } else {
+            FULLNODE_V1_FILE_DESCRIPTOR_SET
+        };
+
         let reflection_service = tonic_reflection::server::Builder::configure()
             // Note: It is critical that the file descriptor set is registered for every
             // file that the top level API proto depends on recursively. If you don't,
             // compilation will still succeed but reflection will fail at runtime.
             //
             // TODO: Add a test for this / something in build.rs, this is a big footgun.
-            .register_encoded_file_descriptor_set(INDEXER_V1_FILE_DESCRIPTOR_SET)
+            .register_encoded_file_descriptor_set(data_server_descriptor_set)
             .register_encoded_file_descriptor_set(TRANSACTION_V1_TESTING_FILE_DESCRIPTOR_SET)
             .register_encoded_file_descriptor_set(UTIL_TIMESTAMP_FILE_DESCRIPTOR_SET)
             .build_v1()


### PR DESCRIPTION
## Description
Register appropriate file descriptor set for reflection depending on `use_data_service_interface`.

## How Has This Been Tested?
Mannuly.
```
grpcurl -plaintext 127.0.0.1:50051 list
```
When `use_data_service_interface` set to `true`

```
aptos.indexer.v1.DataService
aptos.indexer.v1.GrpcManager
aptos.indexer.v1.RawData
grpc.reflection.v1.ServerReflection
```
When set to `false`
```
aptos.internal.fullnode.v1.FullnodeData
grpc.reflection.v1.ServerReflection
```

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [x] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [x] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Conditionally register `INDEXER_V1_FILE_DESCRIPTOR_SET` or `FULLNODE_V1_FILE_DESCRIPTOR_SET` for gRPC reflection in `runtime.rs` based on `use_data_service_interface`.
> 
> - **Indexer gRPC Fullnode Runtime (`runtime.rs`)**:
>   - **Reflection**: Use `use_data_service_interface` to choose descriptor set for reflection, registering `INDEXER_V1_FILE_DESCRIPTOR_SET` when true, otherwise `FULLNODE_V1_FILE_DESCRIPTOR_SET`.
>   - **Imports**: Add `FULLNODE_V1_FILE_DESCRIPTOR_SET` to support the conditional registration.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 885a184fcbdd2ded1251354078e3ef43f41e4370. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->