### PR TITLE
[cli] Update CLI to use latest formatter and mutation testing tool

### DIFF
--- a/crates/aptos/CHANGELOG.md
+++ b/crates/aptos/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to the Aptos CLI will be captured in this file. This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) and the format set out by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Unreleased
+- Updated default version of formatter to 1.4.5 and move mutation tests to 2.2.0.
 
 ## [7.13.0]
 - Set language version 2.3 as stable, which adds support for signed integer types.

--- a/crates/aptos/src/update/move_mutation_test.rs
+++ b/crates/aptos/src/update/move_mutation_test.rs
@@ -13,7 +13,7 @@ use self_update::update::ReleaseUpdate;
 use std::path::PathBuf;
 
 const MUTATION_TEST_BINARY_NAME: &str = "move-mutation-test";
-const TARGET_MUTATION_TEST_VERSION: &str = "2.0.0";
+const TARGET_MUTATION_TEST_VERSION: &str = "2.2.0";
 
 const MUTATION_TEST_EXE_ENV: &str = "MUTATION_TEST_EXE";
 #[cfg(target_os = "windows")]

--- a/crates/aptos/src/update/movefmt.rs
+++ b/crates/aptos/src/update/movefmt.rs
@@ -13,7 +13,7 @@ use self_update::update::ReleaseUpdate;
 use std::path::PathBuf;
 
 const FORMATTER_BINARY_NAME: &str = "movefmt";
-const TARGET_FORMATTER_VERSION: &str = "1.3.7";
+const TARGET_FORMATTER_VERSION: &str = "1.4.5";
 
 const FORMATTER_EXE_ENV: &str = "FORMATTER_EXE";
 #[cfg(target_os = "windows")]


### PR DESCRIPTION
## Description

Aptos cli to include latest version of formatter and mutation testing.

## Which Components or Systems Does This Change Impact?
- [x] Aptos CLI/SDK

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Update tool versions**
> 
> - Bump default `movefmt` version to `1.4.5` (`update/movefmt.rs`)
> - Bump default `move-mutation-test` version to `2.2.0` (`update/move_mutation_test.rs`)
> - Reflect these updates in `CHANGELOG.md`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 14eba17930d45c12a8b55359c7e238a1179389bf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->