### PR TITLE
[Hot State] Add a separate StateMerkleDb for hot state

### DIFF
--- a/api/test-context/src/test_context.rs
+++ b/api/test-context/src/test_context.rs
@@ -176,6 +176,7 @@ pub fn new_test_context_inner(
             BUFFERED_STATE_TARGET_ITEMS_FOR_TEST,
             DEFAULT_MAX_NUM_NODES_PER_LRU_CACHE_SHARD,
             None,
+            /* reset_hot_state = */ true,
         )
         .unwrap();
         if node_config

--- a/aptos-move/aptos-validator-interface/src/storage_interface.rs
+++ b/aptos-move/aptos-validator-interface/src/storage_interface.rs
@@ -25,13 +25,14 @@ impl DBDebuggerInterface {
         Ok(Self(Arc::new(
             AptosDB::open(
                 StorageDirPaths::from_path(db_root_path),
-                true,
+                /* readonly = */ true,
                 NO_OP_STORAGE_PRUNER_CONFIG,
                 RocksdbConfigs::default(),
-                false, /* indexer */
+                /* enable_indexer = */ false,
                 BUFFERED_STATE_TARGET_ITEMS,
                 DEFAULT_MAX_NUM_NODES_PER_LRU_CACHE_SHARD,
-                None,
+                /* internal_indexer_db = */ None,
+                /* reset_hot_state = */ false,
             )
             .map_err(anyhow::Error::from)?,
         )))

--- a/config/src/config/storage_config.rs
+++ b/config/src/config/storage_config.rs
@@ -34,6 +34,7 @@ struct DbPathConfig {
     state_kv_db_path: Option<ShardedDbPathConfig>,
     state_merkle_db_path: Option<ShardedDbPathConfig>,
     hot_state_kv_db_path: Option<ShardedDbPathConfig>,
+    hot_state_merkle_db_path: Option<ShardedDbPathConfig>,
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
@@ -242,12 +243,15 @@ impl Default for RocksdbConfigs {
 pub struct HotStateConfig {
     /// Max number of items in each shard.
     pub max_items_per_shard: usize,
+    /// Whether to delete persisted data on disk on restart. Used during development.
+    pub delete_on_restart: bool,
 }
 
 impl Default for HotStateConfig {
     fn default() -> Self {
         Self {
             max_items_per_shard: 250_000,
+            delete_on_restart: true,
         }
     }
 }
@@ -458,6 +462,7 @@ impl StorageConfig {
         let mut state_kv_db_paths = ShardedDbPaths::default();
         let mut state_merkle_db_paths = ShardedDbPaths::default();
         let mut hot_state_kv_db_paths = ShardedDbPaths::default();
+        let mut hot_state_merkle_db_paths = ShardedDbPaths::default();
 
         if let Some(db_path_overrides) = self.db_path_overrides.as_ref() {
             db_path_overrides
@@ -475,6 +480,12 @@ impl StorageConfig {
             if let Some(hot_state_kv_db_path) = db_path_overrides.hot_state_kv_db_path.as_ref() {
                 hot_state_kv_db_paths = ShardedDbPaths::new(hot_state_kv_db_path);
             }
+
+            if let Some(hot_state_merkle_db_path) =
+                db_path_overrides.hot_state_merkle_db_path.as_ref()
+            {
+                hot_state_merkle_db_paths = ShardedDbPaths::new(hot_state_merkle_db_path);
+            }
         }
 
         StorageDirPaths::new(
@@ -483,6 +494,7 @@ impl StorageConfig {
             state_kv_db_paths,
             state_merkle_db_paths,
             hot_state_kv_db_paths,
+            hot_state_merkle_db_paths,
         )
     }
 
@@ -503,6 +515,7 @@ pub struct StorageDirPaths {
     state_kv_db_paths: ShardedDbPaths,
     state_merkle_db_paths: ShardedDbPaths,
     hot_state_kv_db_paths: ShardedDbPaths,
+    hot_state_merkle_db_paths: ShardedDbPaths,
 }
 
 impl StorageDirPaths {
@@ -548,6 +561,18 @@ impl StorageDirPaths {
             .unwrap_or(&self.default_path)
     }
 
+    pub fn hot_state_merkle_db_metadata_root_path(&self) -> &PathBuf {
+        self.hot_state_merkle_db_paths
+            .metadata_path()
+            .unwrap_or(&self.default_path)
+    }
+
+    pub fn hot_state_merkle_db_shard_root_path(&self, shard_id: usize) -> &PathBuf {
+        self.hot_state_merkle_db_paths
+            .shard_path(shard_id)
+            .unwrap_or(&self.default_path)
+    }
+
     pub fn from_path<P: AsRef<Path>>(path: P) -> Self {
         Self {
             default_path: path.as_ref().to_path_buf(),
@@ -555,6 +580,7 @@ impl StorageDirPaths {
             state_kv_db_paths: Default::default(),
             state_merkle_db_paths: Default::default(),
             hot_state_kv_db_paths: Default::default(),
+            hot_state_merkle_db_paths: Default::default(),
         }
     }
 
@@ -564,6 +590,7 @@ impl StorageDirPaths {
         state_kv_db_paths: ShardedDbPaths,
         state_merkle_db_paths: ShardedDbPaths,
         hot_state_kv_db_paths: ShardedDbPaths,
+        hot_state_merkle_db_paths: ShardedDbPaths,
     ) -> Self {
         Self {
             default_path,
@@ -571,6 +598,7 @@ impl StorageDirPaths {
             state_kv_db_paths,
             state_merkle_db_paths,
             hot_state_kv_db_paths,
+            hot_state_merkle_db_paths,
         }
     }
 }
@@ -729,6 +757,23 @@ impl ConfigSanitizer for StorageConfig {
                 }
 
                 if let Err(e) = state_merkle_db_path.get_shard_paths() {
+                    return Err(Error::ConfigSanitizerFailed(sanitizer_name, e.to_string()));
+                }
+            }
+
+            if let Some(hot_state_merkle_db_path) =
+                db_path_overrides.hot_state_merkle_db_path.as_ref()
+            {
+                if let Some(metadata_path) = hot_state_merkle_db_path.metadata_path.as_ref() {
+                    if !metadata_path.is_absolute() {
+                        return Err(Error::ConfigSanitizerFailed(
+                            sanitizer_name,
+                            format!("Path {metadata_path:?} in db_path_overrides is not an absolute path."),
+                        ));
+                    }
+                }
+
+                if let Err(e) = hot_state_merkle_db_path.get_shard_paths() {
                     return Err(Error::ConfigSanitizerFailed(sanitizer_name, e.to_string()));
                 }
             }

--- a/crates/aptos-genesis/src/lib.rs
+++ b/crates/aptos-genesis/src/lib.rs
@@ -170,13 +170,14 @@ impl GenesisInfo {
         let path = TempPath::new();
         let aptosdb = AptosDB::open(
             StorageDirPaths::from_path(path),
-            false,
+            /* readonly = */ false,
             NO_OP_STORAGE_PRUNER_CONFIG,
             RocksdbConfigs::default(),
-            false, /* indexer */
+            /* enable_indexer = */ false,
             BUFFERED_STATE_TARGET_ITEMS,
             DEFAULT_MAX_NUM_NODES_PER_LRU_CACHE_SHARD,
-            None,
+            /* internal_indexer_db = */ None,
+            /* reset_hot_state = */ true,
         )?;
         let db_rw = DbReaderWriter::new(aptosdb);
         aptos_executor::db_bootstrapper::generate_waypoint::<AptosVMBlockExecutor>(&db_rw, genesis)

--- a/crates/aptos-genesis/src/mainnet.rs
+++ b/crates/aptos-genesis/src/mainnet.rs
@@ -154,13 +154,14 @@ impl MainnetGenesisInfo {
         let path = TempPath::new();
         let aptosdb = AptosDB::open(
             StorageDirPaths::from_path(path),
-            false,
+            /* readonly = */ false,
             NO_OP_STORAGE_PRUNER_CONFIG,
             RocksdbConfigs::default(),
-            false, /* indexer */
+            /* enable_indexer = */ false,
             BUFFERED_STATE_TARGET_ITEMS,
             DEFAULT_MAX_NUM_NODES_PER_LRU_CACHE_SHARD,
-            None,
+            /* internal_indexer_db = */ None,
+            /* reset_hot_state = */ true,
         )?;
         let db_rw = DbReaderWriter::new(aptosdb);
         aptos_executor::db_bootstrapper::generate_waypoint::<AptosVMBlockExecutor>(&db_rw, genesis)

--- a/execution/executor-benchmark/src/db_generator.rs
+++ b/execution/executor-benchmark/src/db_generator.rs
@@ -100,10 +100,11 @@ pub(crate) fn bootstrap_with_genesis(
             false, /* readonly */
             NO_OP_STORAGE_PRUNER_CONFIG,
             rocksdb_configs,
-            false, /* indexer */
+            false, /* enable_indexer */
             BUFFERED_STATE_TARGET_ITEMS,
             DEFAULT_MAX_NUM_NODES_PER_LRU_CACHE_SHARD,
-            None,
+            None, /* internal_indexer_db */
+            true, /* reset_hot_state */
         )
         .expect("DB should open."),
     );

--- a/execution/executor-benchmark/src/lib.rs
+++ b/execution/executor-benchmark/src/lib.rs
@@ -117,6 +117,7 @@ pub fn init_db(config: &NodeConfig) -> DbReaderWriter {
             config.storage.buffered_state_target_items,
             config.storage.max_num_nodes_per_lru_cache_shard,
             None,
+            /* reset_hot_state = */ true,
         )
         .expect("DB should open."),
     )

--- a/state-sync/state-sync-driver/src/tests/driver_factory.rs
+++ b/state-sync/state-sync-driver/src/tests/driver_factory.rs
@@ -41,6 +41,7 @@ fn test_new_initialized_configs() {
         BUFFERED_STATE_TARGET_ITEMS,
         DEFAULT_MAX_NUM_NODES_PER_LRU_CACHE_SHARD,
         None,
+        /* reset_hot_state = */ true,
     )
     .unwrap();
     let (_, db_rw) = DbReaderWriter::wrap(db);

--- a/storage/aptosdb/src/db/aptosdb_internal.rs
+++ b/storage/aptosdb/src/db/aptosdb_internal.rs
@@ -41,6 +41,7 @@ use std::{
 impl AptosDB {
     fn new_with_dbs(
         ledger_db: LedgerDb,
+        hot_state_merkle_db: Option<StateMerkleDb>,
         state_merkle_db: StateMerkleDb,
         state_kv_db: StateKvDb,
         pruner_config: PrunerConfig,
@@ -51,6 +52,7 @@ impl AptosDB {
         internal_indexer_db: Option<InternalIndexerDB>,
     ) -> Self {
         let ledger_db = Arc::new(ledger_db);
+        let hot_state_merkle_db = hot_state_merkle_db.map(Arc::new);
         let state_merkle_db = Arc::new(state_merkle_db);
         let state_kv_db = Arc::new(state_kv_db);
         let state_merkle_pruner = StateMerklePrunerManager::new(
@@ -65,6 +67,7 @@ impl AptosDB {
             StateKvPrunerManager::new(Arc::clone(&state_kv_db), pruner_config.ledger_pruner_config);
         let state_store = Arc::new(StateStore::new(
             Arc::clone(&ledger_db),
+            hot_state_merkle_db,
             Arc::clone(&state_merkle_db),
             Arc::clone(&state_kv_db),
             state_merkle_pruner,
@@ -113,6 +116,7 @@ impl AptosDB {
         max_num_nodes_per_lru_cache_shard: usize,
         empty_buffered_state_for_restore: bool,
         internal_indexer_db: Option<InternalIndexerDB>,
+        reset_hot_state: bool,
     ) -> Result<Self> {
         ensure!(
             pruner_config.eq(&NO_OP_STORAGE_PRUNER_CONFIG) || !readonly,
@@ -128,17 +132,19 @@ impl AptosDB {
             /* estimated_entry_charge = */ 0,
         );
 
-        let (ledger_db, state_merkle_db, state_kv_db) = Self::open_dbs(
+        let (ledger_db, hot_state_merkle_db, state_merkle_db, state_kv_db) = Self::open_dbs(
             db_paths,
             rocksdb_configs,
             Some(&env),
             Some(&block_cache),
             readonly,
             max_num_nodes_per_lru_cache_shard,
+            reset_hot_state,
         )?;
 
         let mut myself = Self::new_with_dbs(
             ledger_db,
+            hot_state_merkle_db,
             state_merkle_db,
             state_kv_db,
             pruner_config,
@@ -243,6 +249,7 @@ impl AptosDB {
             buffered_state_target_items,
             max_num_nodes_per_lru_cache_shard,
             None,
+            /* reset_hot_state = */ true,
         )
         .expect("Unable to open AptosDB")
     }

--- a/storage/aptosdb/src/db/aptosdb_reader.rs
+++ b/storage/aptosdb/src/db/aptosdb_reader.rs
@@ -660,12 +660,17 @@ impl DbReader for AptosDB {
         key_hash: &HashValue,
         version: Version,
         root_depth: usize,
+        use_hot_state: bool,
     ) -> Result<SparseMerkleProofExt> {
         gauged_api("get_state_proof_by_version_ext", || {
             self.error_if_state_merkle_pruned("State merkle", version)?;
 
-            self.state_store
-                .get_state_proof_by_version_ext(key_hash, version, root_depth)
+            self.state_store.get_state_proof_by_version_ext(
+                key_hash,
+                version,
+                root_depth,
+                use_hot_state,
+            )
         })
     }
 
@@ -674,12 +679,17 @@ impl DbReader for AptosDB {
         key_hash: &HashValue,
         version: Version,
         root_depth: usize,
+        use_hot_state: bool,
     ) -> Result<(Option<StateValue>, SparseMerkleProofExt)> {
         gauged_api("get_state_value_with_proof_by_version_ext", || {
             self.error_if_state_merkle_pruned("State merkle", version)?;
 
-            self.state_store
-                .get_state_value_with_proof_by_version_ext(key_hash, version, root_depth)
+            self.state_store.get_state_value_with_proof_by_version_ext(
+                key_hash,
+                version,
+                root_depth,
+                use_hot_state,
+            )
         })
     }
 

--- a/storage/aptosdb/src/db/aptosdb_test.rs
+++ b/storage/aptosdb/src/db/aptosdb_test.rs
@@ -256,6 +256,7 @@ pub fn test_state_merkle_pruning_impl(
         BUFFERED_STATE_TARGET_ITEMS_FOR_TEST,
         DEFAULT_MAX_NUM_NODES_PER_LRU_CACHE_SHARD,
         None,
+        /* reset_hot_state = */ true,
     )
     .unwrap();
 

--- a/storage/aptosdb/src/db/aptosdb_testonly.rs
+++ b/storage/aptosdb/src/db/aptosdb_testonly.rs
@@ -57,6 +57,7 @@ impl AptosDB {
             BUFFERED_STATE_TARGET_ITEMS_FOR_TEST,
             max_node_cache,
             None,
+            /* reset_hot_state = */ true,
         )
         .expect("Unable to open AptosDB")
     }

--- a/storage/aptosdb/src/db_debugger/common/mod.rs
+++ b/storage/aptosdb/src/db_debugger/common/mod.rs
@@ -36,8 +36,10 @@ impl DbDir {
             },
             env,
             block_cache,
-            false,
-            0,
+            /* read_only = */ false,
+            /* max_nodes_per_lru_cache_shard = */ 0,
+            /* is_hot = */ false,
+            /* delete_on_restart = */ false,
         )
     }
 

--- a/storage/aptosdb/src/db_debugger/examine/print_db_versions.rs
+++ b/storage/aptosdb/src/db_debugger/examine/print_db_versions.rs
@@ -43,13 +43,15 @@ impl Cmd {
         };
         let env = None;
         let block_cache = None;
-        let (ledger_db, state_merkle_db, state_kv_db) = AptosDB::open_dbs(
+        // TODO(HotState): handle hot state merkle db.
+        let (ledger_db, _hot_state_merkle_db, state_merkle_db, state_kv_db) = AptosDB::open_dbs(
             &StorageDirPaths::from_path(&self.db_dir),
             rocksdb_config,
             env,
             block_cache,
             /*readonly=*/ true,
             /*max_num_nodes_per_lru_cache_shard=*/ 0,
+            /*reset_hot_state=*/ false,
         )?;
 
         println!(

--- a/storage/aptosdb/src/db_debugger/examine/print_raw_data_by_version.rs
+++ b/storage/aptosdb/src/db_debugger/examine/print_raw_data_by_version.rs
@@ -29,13 +29,14 @@ impl Cmd {
         let env = None;
         let block_cache = None;
 
-        let (ledger_db, _, _) = AptosDB::open_dbs(
+        let (ledger_db, _, _, _) = AptosDB::open_dbs(
             &StorageDirPaths::from_path(&self.db_dir),
             rocksdb_config,
             env,
             block_cache,
             /*readonly=*/ true,
             /*max_num_nodes_per_lru_cache_shard=*/ 0,
+            /*reset_hot_state=*/ false,
         )?;
 
         println!(

--- a/storage/aptosdb/src/db_debugger/truncate/mod.rs
+++ b/storage/aptosdb/src/db_debugger/truncate/mod.rs
@@ -70,16 +70,19 @@ impl Cmd {
         };
         let env = None;
         let block_cache = None;
-        let (ledger_db, state_merkle_db, state_kv_db) = AptosDB::open_dbs(
+        // TODO(HotState): handle hot state merkle db.
+        let (ledger_db, hot_state_merkle_db, state_merkle_db, state_kv_db) = AptosDB::open_dbs(
             &StorageDirPaths::from_path(&self.db_dir),
             rocksdb_config,
             env,
             block_cache,
             /*readonly=*/ false,
             /*max_num_nodes_per_lru_cache_shard=*/ 0,
+            /*reset_hot_state=*/ true,
         )?;
 
         let ledger_db = Arc::new(ledger_db);
+        let hot_state_merkle_db = hot_state_merkle_db.map(Arc::new);
         let state_merkle_db = Arc::new(state_merkle_db);
         let state_kv_db = Arc::new(state_kv_db);
         let overall_version = ledger_db
@@ -148,6 +151,7 @@ impl Cmd {
                 );
                 let version = StateStore::catch_up_state_merkle_db(
                     Arc::clone(&ledger_db),
+                    hot_state_merkle_db,
                     Arc::clone(&state_merkle_db),
                     Arc::clone(&state_kv_db),
                 )?;
@@ -248,7 +252,8 @@ mod test {
 
             let env = None;
             let block_cache = None;
-            let (ledger_db, state_merkle_db, state_kv_db) = AptosDB::open_dbs(
+            // TODO(HotState): handle `_hot_state_merkle_db` here.
+            let (ledger_db, _hot_state_merkle_db, state_merkle_db, state_kv_db) = AptosDB::open_dbs(
                 &StorageDirPaths::from_path(tmp_dir.path()),
                 RocksdbConfigs {
                     enable_storage_sharding: input.1,
@@ -258,6 +263,7 @@ mod test {
                 block_cache,
                 /*readonly=*/ false,
                 /*max_num_nodes_per_lru_cache_shard=*/ 0,
+                /*reset_hot_state=*/ true,
             ).unwrap();
 
             let ledger_metadata_db = ledger_db.metadata_db_arc();

--- a/storage/aptosdb/src/db_debugger/watch/opened.rs
+++ b/storage/aptosdb/src/db_debugger/watch/opened.rs
@@ -33,6 +33,7 @@ impl Cmd {
             config.buffered_state_target_items,
             config.max_num_nodes_per_lru_cache_shard,
             None,
+            /* reset_hot_state = */ false,
         )
         .expect("Failed to open AptosDB");
 

--- a/storage/aptosdb/src/fast_sync_storage_wrapper.rs
+++ b/storage/aptosdb/src/fast_sync_storage_wrapper.rs
@@ -54,6 +54,7 @@ impl FastSyncStorageWrapper {
             config.storage.buffered_state_target_items,
             config.storage.max_num_nodes_per_lru_cache_shard,
             internal_indexer_db,
+            config.storage.hot_state_config.delete_on_restart,
         )
         .map_err(|err| anyhow!("fast sync DB failed to open {}", err))?;
         if let Some(sender) = update_sender {
@@ -84,6 +85,7 @@ impl FastSyncStorageWrapper {
                 config.storage.buffered_state_target_items,
                 config.storage.max_num_nodes_per_lru_cache_shard,
                 None,
+                config.storage.hot_state_config.delete_on_restart,
             )
             .map_err(|err| anyhow!("Secondary DB failed to open {}", err))?;
 

--- a/storage/aptosdb/src/state_store/tests/speculative_state_workflow.rs
+++ b/storage/aptosdb/src/state_store/tests/speculative_state_workflow.rs
@@ -55,6 +55,7 @@ const REFRESH_INTERVAL_VERSIONS: usize = 50;
 
 const TEST_CONFIG: HotStateConfig = HotStateConfig {
     max_items_per_shard: HOT_STATE_MAX_ITEMS_PER_SHARD,
+    delete_on_restart: false,
 };
 
 #[derive(Debug)]
@@ -480,6 +481,7 @@ impl DbReader for StateByVersion {
         key_hash: &HashValue,
         version: Version,
         _root_depth: usize,
+        _use_hot_state: bool,
     ) -> DbResult<SparseMerkleProofExt> {
         Ok(self.get_state(Some(version)).summary.get_proof(key_hash))
     }

--- a/storage/db-tool/src/bootstrap.rs
+++ b/storage/db-tool/src/bootstrap.rs
@@ -57,6 +57,7 @@ impl Command {
             BUFFERED_STATE_TARGET_ITEMS,
             DEFAULT_MAX_NUM_NODES_PER_LRU_CACHE_SHARD,
             None,
+            /* reset_hot_state = */ true,
         )
         .expect("Failed to open DB.");
         let db = DbReaderWriter::new(db);

--- a/storage/db-tool/src/replay_on_archive.rs
+++ b/storage/db-tool/src/replay_on_archive.rs
@@ -160,6 +160,7 @@ impl Verifier {
                     BUFFERED_STATE_TARGET_ITEMS,
                     DEFAULT_MAX_NUM_NODES_PER_LRU_CACHE_SHARD,
                     None,
+                    /* reset_hot_state = */ true,
                 )
             }) {
                 warn!("Unable to open AptosDB in write mode: {:?}", e);
@@ -175,6 +176,7 @@ impl Verifier {
             BUFFERED_STATE_TARGET_ITEMS,
             DEFAULT_MAX_NUM_NODES_PER_LRU_CACHE_SHARD,
             None,
+            /* reset_hot_state = */ false,
         )?;
 
         let backup_handler = aptos_db.get_backup_handler();

--- a/storage/db-tool/src/tests.rs
+++ b/storage/db-tool/src/tests.rs
@@ -468,6 +468,7 @@ mod dbtool_tests {
                 BUFFERED_STATE_TARGET_ITEMS_FOR_TEST,
                 1000,
                 Some(internal_indexer_db.clone()),
+                /* reset_hot_state = */ true,
             )
             .unwrap(),
         );

--- a/storage/storage-interface/src/errors.rs
+++ b/storage/storage-interface/src/errors.rs
@@ -32,6 +32,8 @@ pub enum AptosDbError {
     RecvError(String),
     #[error("AptosDB ParseInt Error: {0}")]
     ParseIntError(String),
+    #[error("Hot state not configured properly")]
+    HotStateError,
 }
 
 impl From<anyhow::Error> for AptosDbError {

--- a/storage/storage-interface/src/lib.rs
+++ b/storage/storage-interface/src/lib.rs
@@ -390,6 +390,7 @@ pub trait DbReader: Send + Sync {
             key_hash: &HashValue,
             version: Version,
             root_depth: usize,
+            use_hot_state: bool,
         ) -> Result<SparseMerkleProofExt>;
 
         /// Gets a state value by state key along with the proof, out of the ledger state indicated by the state
@@ -405,6 +406,7 @@ pub trait DbReader: Send + Sync {
             key_hash: &HashValue,
             version: Version,
             root_depth: usize,
+            use_hot_state: bool,
         ) -> Result<(Option<StateValue>, SparseMerkleProofExt)>;
 
         /// Gets the latest LedgerView no matter if db has been bootstrapped.
@@ -546,8 +548,14 @@ pub trait DbReader: Send + Sync {
         state_key: &StateKey,
         version: Version,
     ) -> Result<(Option<StateValue>, SparseMerkleProof)> {
-        self.get_state_value_with_proof_by_version_ext(state_key.crypto_hash_ref(), version, 0)
-            .map(|(value, proof_ext)| (value, proof_ext.into()))
+        // TODO(HotState): check all callers and possibly query hot state first
+        self.get_state_value_with_proof_by_version_ext(
+            state_key.crypto_hash_ref(),
+            version,
+            /* root_depth = */ 0,
+            /* use_hot_state = */ false,
+        )
+        .map(|(value, proof_ext)| (value, proof_ext.into()))
     }
 
     fn ensure_synced_version(&self) -> Result<Version> {

--- a/storage/storage-interface/src/mock.rs
+++ b/storage/storage-interface/src/mock.rs
@@ -28,6 +28,7 @@ impl DbReader for MockDbReaderWriter {
         _key_hash: &HashValue,
         _version: Version,
         _root_depth: usize,
+        _use_hot_state: bool,
     ) -> Result<SparseMerkleProofExt> {
         Ok(SparseMerkleProofExt::new(None, vec![]))
     }

--- a/storage/storage-interface/src/state_store/state_summary.rs
+++ b/storage/storage-interface/src/state_store/state_summary.rs
@@ -219,7 +219,9 @@ impl<'db> ProvableStateSummary<'db> {
             let (val_opt, proof) = self
                 .db
                 // check the full proof
-                .get_state_value_with_proof_by_version_ext(key, version, 0)?;
+                .get_state_value_with_proof_by_version_ext(
+                    key, version, /* root_depth = */ 0, /* use_hot_state = */ false,
+                )?;
             proof.verify(
                 self.state_summary.global_state_summary.root_hash(),
                 *key,
@@ -227,9 +229,9 @@ impl<'db> ProvableStateSummary<'db> {
             )?;
             Ok(proof)
         } else {
-            Ok(self
-                .db
-                .get_state_proof_by_version_ext(key, version, root_depth)?)
+            Ok(self.db.get_state_proof_by_version_ext(
+                key, version, root_depth, /* use_hot_state = */ false,
+            )?)
         }
     }
 }


### PR DESCRIPTION

In order to compute the hot state root hash for each block (including the
speculative ones), we have to be able to return Merkle proof for any given key
and version. The most straightforward way to do this is to add another instance
of `StateMerkleDb` in `StateStore`.

For now, we always delete and reset the DB on restart. This will give us more
flexibility to make changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a hot-state storage path to enable Merkle proofs for speculative blocks.
> 
> - Introduces optional `hot_state_merkle_db` in `AptosDB`/`StateStore`; proof APIs now take `use_hot_state` to read from hot or regular state
> - Extends `StateMerkleDb` to support hot vs. regular instances (separate folder/CF names), deletion-on-restart, and checkpointing for both
> - Configuration: new `HotStateConfig { max_items_per_shard, delete_on_restart }`, path overrides for `hot_state_merkle_db`, and `StorageDirPaths` getters
> - `AptosDB::open/open_internal/open_dbs` gain `reset_hot_state` and return the optional hot DB; all call sites updated (genesis, tests, benchmarks, tools)
> - Storage interface and mocks updated (add `use_hot_state` params); new `HotStateError` for missing/misconfigured hot state
> - DB debugger and truncate tools updated to handle new DB shape; default test/bench runners reset hot state on open
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 97680f2cb8cc28da7b2e71dc533a960114048624. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->