### PR TITLE
[move linter] revise a linter name

### DIFF
--- a/third_party/move/tools/move-linter/src/model_ast_lints.rs
+++ b/third_party/move/tools/move-linter/src/model_ast_lints.rs
@@ -11,7 +11,6 @@ mod collapsible_if;
 mod cyclomatic_complexity;
 mod empty_if;
 mod equal_operands_in_bin_op;
-mod find_unnecessary_casts;
 mod known_to_abort;
 mod needless_bool;
 mod needless_deref_ref;
@@ -23,6 +22,7 @@ mod self_assignment;
 mod simpler_bool_expression;
 mod simpler_numeric_expression;
 mod unnecessary_boolean_identity_comparison;
+mod unnecessary_cast;
 mod unnecessary_numerical_extreme_comparison;
 mod while_true;
 
@@ -40,7 +40,7 @@ pub fn get_default_linter_pipeline(config: &BTreeMap<String, String>) -> Vec<Box
         Box::<collapsible_if::CollapsibleIf>::default(),
         Box::<empty_if::EmptyIf>::default(),
         Box::<equal_operands_in_bin_op::EqualOperandsInBinOp>::default(),
-        Box::<find_unnecessary_casts::FindUnnecessaryCasts>::default(),
+        Box::<unnecessary_cast::FindUnnecessaryCast>::default(),
         Box::<known_to_abort::KnownToAbort>::default(),
         Box::<needless_bool::NeedlessBool>::default(),
         Box::<needless_deref_ref::NeedlessDerefRef>::default(),

--- a/third_party/move/tools/move-linter/src/model_ast_lints/unnecessary_cast.rs
+++ b/third_party/move/tools/move-linter/src/model_ast_lints/unnecessary_cast.rs
@@ -16,11 +16,11 @@ use move_model::{
 };
 
 #[derive(Default)]
-pub struct FindUnnecessaryCasts;
+pub struct FindUnnecessaryCast;
 
-impl ExpChecker for FindUnnecessaryCasts {
+impl ExpChecker for FindUnnecessaryCast {
     fn get_name(&self) -> String {
-        "find_unnecessary_casts".to_string()
+        "unnecessary_cast".to_string()
     }
 
     fn visit_expr_pre(&mut self, function: &FunctionEnv, expr: &ExpData) {

--- a/third_party/move/tools/move-linter/tests/model_ast_lints/find_unnecessary_casts_test.exp
+++ b/third_party/move/tools/move-linter/tests/model_ast_lints/find_unnecessary_casts_test.exp
@@ -1,13 +1,13 @@
-
-Diagnostics:
+Aborting with compilation errors:
+exiting with env checking errors
 warning: [lint] Unnecessary cast: the expression is already of the target type. Consider removing the cast for better readability.
    ┌─ tests/model_ast_lints/find_unnecessary_casts_test.move:13:17
    │
 13 │         let y = (x as u64);
    │                 ^^^^^^^^^^
    │
-   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(find_unnecessary_casts)]`.
-   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#find_unnecessary_casts.
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_cast)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#unnecessary_cast.
 
 warning: [lint] Unnecessary cast: the expression is already of the target type. Consider removing the cast for better readability.
    ┌─ tests/model_ast_lints/find_unnecessary_casts_test.move:18:33
@@ -15,8 +15,8 @@ warning: [lint] Unnecessary cast: the expression is already of the target type. 
 18 │         let result = helper_u64(x as u64);
    │                                 ^^^^^^^^
    │
-   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(find_unnecessary_casts)]`.
-   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#find_unnecessary_casts.
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_cast)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#unnecessary_cast.
 
 warning: [lint] Unnecessary cast: the expression is already of the target type. Consider removing the cast for better readability.
    ┌─ tests/model_ast_lints/find_unnecessary_casts_test.move:23:9
@@ -24,8 +24,8 @@ warning: [lint] Unnecessary cast: the expression is already of the target type. 
 23 │         (x as u64)
    │         ^^^^^^^^^^
    │
-   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(find_unnecessary_casts)]`.
-   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#find_unnecessary_casts.
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_cast)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#unnecessary_cast.
 
 warning: [lint] Unnecessary cast: the expression is already of the target type. Consider removing the cast for better readability.
    ┌─ tests/model_ast_lints/find_unnecessary_casts_test.move:29:22
@@ -33,8 +33,8 @@ warning: [lint] Unnecessary cast: the expression is already of the target type. 
 29 │         let result = ((a + b) as u32);
    │                      ^^^^^^^^^^^^^^^^
    │
-   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(find_unnecessary_casts)]`.
-   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#find_unnecessary_casts.
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_cast)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#unnecessary_cast.
 
 warning: [lint] Unnecessary cast: the expression is already of the target type. Consider removing the cast for better readability.
    ┌─ tests/model_ast_lints/find_unnecessary_casts_test.move:33:17
@@ -42,8 +42,8 @@ warning: [lint] Unnecessary cast: the expression is already of the target type. 
 33 │         let x = (U8_VALUE as u8);
    │                 ^^^^^^^^^^^^^^^^
    │
-   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(find_unnecessary_casts)]`.
-   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#find_unnecessary_casts.
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_cast)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#unnecessary_cast.
 
 warning: [lint] Unnecessary cast: the expression is already of the target type. Consider removing the cast for better readability.
    ┌─ tests/model_ast_lints/find_unnecessary_casts_test.move:38:13
@@ -51,8 +51,8 @@ warning: [lint] Unnecessary cast: the expression is already of the target type. 
 38 │         if ((x as u64) > 0) { };
    │             ^^^^^^^^^^
    │
-   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(find_unnecessary_casts)]`.
-   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#find_unnecessary_casts.
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_cast)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#unnecessary_cast.
 
 warning: [lint] Empty `if` branch. Consider simplifying by removing or rewriting.
    ┌─ tests/model_ast_lints/find_unnecessary_casts_test.move:38:9
@@ -69,8 +69,8 @@ warning: [lint] Unnecessary cast: the expression is already of the target type. 
 43 │         assert!((x as u16) > 0, 0);
    │                 ^^^^^^^^^^
    │
-   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(find_unnecessary_casts)]`.
-   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#find_unnecessary_casts.
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_cast)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#unnecessary_cast.
 
 warning: [lint] Unnecessary cast: the expression is already of the target type. Consider removing the cast for better readability.
    ┌─ tests/model_ast_lints/find_unnecessary_casts_test.move:49:19
@@ -78,8 +78,8 @@ warning: [lint] Unnecessary cast: the expression is already of the target type. 
 49 │         let sum = (a as u64) + (b as u64);
    │                   ^^^^^^^^^^
    │
-   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(find_unnecessary_casts)]`.
-   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#find_unnecessary_casts.
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_cast)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#unnecessary_cast.
 
 warning: [lint] Unnecessary cast: the expression is already of the target type. Consider removing the cast for better readability.
    ┌─ tests/model_ast_lints/find_unnecessary_casts_test.move:49:32
@@ -87,8 +87,8 @@ warning: [lint] Unnecessary cast: the expression is already of the target type. 
 49 │         let sum = (a as u64) + (b as u64);
    │                                ^^^^^^^^^^
    │
-   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(find_unnecessary_casts)]`.
-   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#find_unnecessary_casts.
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_cast)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#unnecessary_cast.
 
 warning: [lint] Unnecessary cast: the expression is already of the target type. Consider removing the cast for better readability.
    ┌─ tests/model_ast_lints/find_unnecessary_casts_test.move:54:18
@@ -96,8 +96,8 @@ warning: [lint] Unnecessary cast: the expression is already of the target type. 
 54 │         let y = ((x as u64) as u64);
    │                  ^^^^^^^^^^
    │
-   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(find_unnecessary_casts)]`.
-   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#find_unnecessary_casts.
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_cast)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#unnecessary_cast.
 
 warning: [lint] Unnecessary cast: the expression is already of the target type. Consider removing the cast for better readability.
    ┌─ tests/model_ast_lints/find_unnecessary_casts_test.move:54:17
@@ -105,101 +105,77 @@ warning: [lint] Unnecessary cast: the expression is already of the target type. 
 54 │         let y = ((x as u64) as u64);
    │                 ^^^^^^^^^^^^^^^^^^^
    │
-   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(find_unnecessary_casts)]`.
-   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#find_unnecessary_casts.
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_cast)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#unnecessary_cast.
 
-warning: This assignment/binding to the left-hand-side variable `y` is unused. Consider removing this assignment/binding, or prefixing the left-hand-side variable with an underscore (e.g., `_y`), or renaming to `_`
-   ┌─ tests/model_ast_lints/find_unnecessary_casts_test.move:13:17
+error: unknown lint check: `unnecessary_casts`
+   ┌─ tests/model_ast_lints/find_unnecessary_casts_test.move:90:18
    │
-13 │         let y = (x as u64);
-   │                 ^^^^^^^^^^
+90 │     #[lint::skip(unnecessary_casts)]
+   │                  ^^^^^^^^^^^^^^^^^
 
-warning: This assignment/binding to the left-hand-side variable `result` is unused. Consider removing this assignment/binding, or prefixing the left-hand-side variable with an underscore (e.g., `_result`), or renaming to `_`
-   ┌─ tests/model_ast_lints/find_unnecessary_casts_test.move:18:22
-   │
-18 │         let result = helper_u64(x as u64);
-   │                      ^^^^^^^^^^^^^^^^^^^^
-
-warning: This assignment/binding to the left-hand-side variable `result` is unused. Consider removing this assignment/binding, or prefixing the left-hand-side variable with an underscore (e.g., `_result`), or renaming to `_`
-   ┌─ tests/model_ast_lints/find_unnecessary_casts_test.move:29:22
-   │
-29 │         let result = ((a + b) as u32);
-   │                      ^^^^^^^^^^^^^^^^
-
-warning: This assignment/binding to the left-hand-side variable `x` is unused. Consider removing this assignment/binding, or prefixing the left-hand-side variable with an underscore (e.g., `_x`), or renaming to `_`
-   ┌─ tests/model_ast_lints/find_unnecessary_casts_test.move:33:17
-   │
-33 │         let x = (U8_VALUE as u8);
-   │                 ^^^^^^^^^^^^^^^^
-
-warning: This assignment/binding to the left-hand-side variable `sum` is unused. Consider removing this assignment/binding, or prefixing the left-hand-side variable with an underscore (e.g., `_sum`), or renaming to `_`
-   ┌─ tests/model_ast_lints/find_unnecessary_casts_test.move:49:19
-   │
-49 │         let sum = (a as u64) + (b as u64);
-   │                   ^^^^^^^^^^^^^^^^^^^^^^^
-
-warning: This assignment/binding to the left-hand-side variable `y` is unused. Consider removing this assignment/binding, or prefixing the left-hand-side variable with an underscore (e.g., `_y`), or renaming to `_`
-   ┌─ tests/model_ast_lints/find_unnecessary_casts_test.move:54:17
-   │
-54 │         let y = ((x as u64) as u64);
-   │                 ^^^^^^^^^^^^^^^^^^^
-
-warning: This assignment/binding to the left-hand-side variable `y` is unused. Consider removing this assignment/binding, or prefixing the left-hand-side variable with an underscore (e.g., `_y`), or renaming to `_`
-   ┌─ tests/model_ast_lints/find_unnecessary_casts_test.move:61:17
-   │
-61 │         let y = (x as u64);
-   │                 ^^^^^^^^^^
-
-warning: This assignment/binding to the left-hand-side variable `big` is unused. Consider removing this assignment/binding, or prefixing the left-hand-side variable with an underscore (e.g., `_big`), or renaming to `_`
-   ┌─ tests/model_ast_lints/find_unnecessary_casts_test.move:66:19
-   │
-66 │         let big = (small as u256);
-   │                   ^^^^^^^^^^^^^^^
-
-warning: This assignment/binding to the left-hand-side variable `x` is unused. Consider removing this assignment/binding, or prefixing the left-hand-side variable with an underscore (e.g., `_x`), or renaming to `_`
-   ┌─ tests/model_ast_lints/find_unnecessary_casts_test.move:70:17
-   │
-70 │         let x = (U8_VALUE as u256);
-   │                 ^^^^^^^^^^^^^^^^^^
-
-warning: This assignment/binding to the left-hand-side variable `y` is unused. Consider removing this assignment/binding, or prefixing the left-hand-side variable with an underscore (e.g., `_y`), or renaming to `_`
-   ┌─ tests/model_ast_lints/find_unnecessary_casts_test.move:75:17
-   │
-75 │         let y = x;
-   │                 ^
-
-warning: This assignment/binding to the left-hand-side variable `small` is unused. Consider removing this assignment/binding, or prefixing the left-hand-side variable with an underscore (e.g., `_small`), or renaming to `_`
-   ┌─ tests/model_ast_lints/find_unnecessary_casts_test.move:80:21
-   │
-80 │         let small = (big as u8);
-   │                     ^^^^^^^^^^^
-
-warning: This assignment/binding to the left-hand-side variable `bigger` is unused. Consider removing this assignment/binding, or prefixing the left-hand-side variable with an underscore (e.g., `_bigger`), or renaming to `_`
-   ┌─ tests/model_ast_lints/find_unnecessary_casts_test.move:85:22
-   │
-85 │         let bigger = (int_val as u128);
-   │                      ^^^^^^^^^^^^^^^^^
-
-warning: This assignment/binding to the left-hand-side variable `y` is unused. Consider removing this assignment/binding, or prefixing the left-hand-side variable with an underscore (e.g., `_y`), or renaming to `_`
+warning: [lint] Unnecessary cast: the expression is already of the target type. Consider removing the cast for better readability.
    ┌─ tests/model_ast_lints/find_unnecessary_casts_test.move:93:17
    │
 93 │         let y = (x as u64);
    │                 ^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_cast)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#unnecessary_cast.
 
-warning: This assignment/binding to the left-hand-side variable `sum` is unused. Consider removing this assignment/binding, or prefixing the left-hand-side variable with an underscore (e.g., `_sum`), or renaming to `_`
+error: unknown lint check: `unnecessary_casts`
+   ┌─ tests/model_ast_lints/find_unnecessary_casts_test.move:96:18
+   │
+96 │     #[lint::skip(unnecessary_casts)]
+   │                  ^^^^^^^^^^^^^^^^^
+
+warning: [lint] Unnecessary cast: the expression is already of the target type. Consider removing the cast for better readability.
     ┌─ tests/model_ast_lints/find_unnecessary_casts_test.move:100:19
     │
 100 │         let sum = (a as u32) + (b as u32);
-    │                   ^^^^^^^^^^^^^^^^^^^^^^^
+    │                   ^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_cast)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#unnecessary_cast.
 
-warning: This assignment/binding to the left-hand-side variable `y` is unused. Consider removing this assignment/binding, or prefixing the left-hand-side variable with an underscore (e.g., `_y`), or renaming to `_`
+warning: [lint] Unnecessary cast: the expression is already of the target type. Consider removing the cast for better readability.
+    ┌─ tests/model_ast_lints/find_unnecessary_casts_test.move:100:32
+    │
+100 │         let sum = (a as u32) + (b as u32);
+    │                                ^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_cast)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#unnecessary_cast.
+
+error: unknown lint check: `unnecessary_casts`
+    ┌─ tests/model_ast_lints/find_unnecessary_casts_test.move:105:14
+    │
+105 │ #[lint::skip(unnecessary_casts)]
+    │              ^^^^^^^^^^^^^^^^^
+
+warning: [lint] Unnecessary cast: the expression is already of the target type. Consider removing the cast for better readability.
     ┌─ tests/model_ast_lints/find_unnecessary_casts_test.move:110:17
     │
 110 │         let y = (x as u64);
     │                 ^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_cast)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#unnecessary_cast.
 
-warning: This assignment/binding to the left-hand-side variable `result` is unused. Consider removing this assignment/binding, or prefixing the left-hand-side variable with an underscore (e.g., `_result`), or renaming to `_`
+warning: [lint] Unnecessary cast: the expression is already of the target type. Consider removing the cast for better readability.
     ┌─ tests/model_ast_lints/find_unnecessary_casts_test.move:116:22
     │
 116 │         let result = (a as u8) + (b as u8);
-    │                      ^^^^^^^^^^^^^^^^^^^^^
+    │                      ^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_cast)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#unnecessary_cast.
+
+warning: [lint] Unnecessary cast: the expression is already of the target type. Consider removing the cast for better readability.
+    ┌─ tests/model_ast_lints/find_unnecessary_casts_test.move:116:34
+    │
+116 │         let result = (a as u8) + (b as u8);
+    │                                  ^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_cast)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#unnecessary_cast.

--- a/third_party/move/tools/move-linter/tests/model_ast_lints/find_unnecessary_casts_test.move
+++ b/third_party/move/tools/move-linter/tests/model_ast_lints/find_unnecessary_casts_test.move
@@ -87,13 +87,13 @@ module 0xc0ffee::unnecessary_casts_test {
 
     // ========== LINT SKIP TESTS ==========
 
-    #[lint::skip(find_unnecessary_casts)]
+    #[lint::skip(unnecessary_casts)]
     public fun test_skip_function_no_warn() {
         let x: u64 = 42;
         let y = (x as u64);
     }
 
-    #[lint::skip(find_unnecessary_casts)]
+    #[lint::skip(unnecessary_casts)]
     public fun test_skip_multiple_casts_no_warn() {
         let a: u32 = 1;
         let b: u32 = 2;
@@ -102,7 +102,7 @@ module 0xc0ffee::unnecessary_casts_test {
 }
 
 // Module-level lint skip test
-#[lint::skip(find_unnecessary_casts)]
+#[lint::skip(unnecessary_casts)]
 module 0xc0ffee::unnecessary_casts_skip_module {
 
     public fun test_module_skip_no_warn() {

--- a/third_party/move/tools/move-linter/tests/model_ast_lints/known_to_abort.exp
+++ b/third_party/move/tools/move-linter/tests/model_ast_lints/known_to_abort.exp
@@ -123,8 +123,8 @@ warning: [lint] Unnecessary cast: the expression is already of the target type. 
 56 │         (128u8 * 2) as u8
    │         ^^^^^^^^^^^^^^^^^
    │
-   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(find_unnecessary_casts)]`.
-   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#find_unnecessary_casts.
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_cast)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#unnecessary_cast.
 
 warning: [lint] Cast operation will abort because the value is outside the target type's range
    ┌─ tests/model_ast_lints/known_to_abort.move:60:9
@@ -141,8 +141,8 @@ warning: [lint] Unnecessary cast: the expression is already of the target type. 
 60 │         (32768u16 * 2) as u16
    │         ^^^^^^^^^^^^^^^^^^^^^
    │
-   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(find_unnecessary_casts)]`.
-   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#find_unnecessary_casts.
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_cast)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#unnecessary_cast.
 
 warning: [lint] Cast operation will abort because the value is outside the target type's range
    ┌─ tests/model_ast_lints/known_to_abort.move:64:9
@@ -159,8 +159,8 @@ warning: [lint] Unnecessary cast: the expression is already of the target type. 
 64 │         (128u8 + 128u8) as u8  // 256, overflows u8
    │         ^^^^^^^^^^^^^^^^^^^^^
    │
-   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(find_unnecessary_casts)]`.
-   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#find_unnecessary_casts.
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_cast)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#unnecessary_cast.
 
 warning: [lint] Cast operation will abort because the value is outside the target type's range
    ┌─ tests/model_ast_lints/known_to_abort.move:68:9
@@ -177,8 +177,8 @@ warning: [lint] Unnecessary cast: the expression is already of the target type. 
 68 │         (32768u16 * 2 + 1u16) as u16  // 65537, overflows u16
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    │
-   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(find_unnecessary_casts)]`.
-   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#find_unnecessary_casts.
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_cast)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#unnecessary_cast.
 
 warning: [lint] Cast operation will abort because the value is outside the target type's range
    ┌─ tests/model_ast_lints/known_to_abort.move:72:9
@@ -195,8 +195,8 @@ warning: [lint] Unnecessary cast: the expression is already of the target type. 
 72 │         (64u8 * 2 * 2) as u8  // 256, overflows u8
    │         ^^^^^^^^^^^^^^^^^^^^
    │
-   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(find_unnecessary_casts)]`.
-   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#find_unnecessary_casts.
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_cast)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#unnecessary_cast.
 
 warning: [lint] Cast operation will abort because the value is outside the target type's range
    ┌─ tests/model_ast_lints/known_to_abort.move:77:13
@@ -312,8 +312,8 @@ warning: [lint] Unnecessary cast: the expression is already of the target type. 
 152 │         ((x + 1) * 2) as u8
     │         ^^^^^^^^^^^^^^^^^^^
     │
-    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(find_unnecessary_casts)]`.
-    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#find_unnecessary_casts.
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_cast)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#unnecessary_cast.
 
 warning: [lint] Unnecessary cast: the expression is already of the target type. Consider removing the cast for better readability.
     ┌─ tests/model_ast_lints/known_to_abort.move:172:9
@@ -321,8 +321,8 @@ warning: [lint] Unnecessary cast: the expression is already of the target type. 
 172 │         (64u8 * 2 + 32) as u8  // 160, within u8 range
     │         ^^^^^^^^^^^^^^^^^^^^^
     │
-    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(find_unnecessary_casts)]`.
-    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#find_unnecessary_casts.
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_cast)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#unnecessary_cast.
 
 warning: [lint] Unnecessary cast: the expression is already of the target type. Consider removing the cast for better readability.
     ┌─ tests/model_ast_lints/known_to_abort.move:176:9
@@ -330,8 +330,8 @@ warning: [lint] Unnecessary cast: the expression is already of the target type. 
 176 │         (16u8 * 4 * 2) as u8  // 128, within u8 range
     │         ^^^^^^^^^^^^^^^^^^^^
     │
-    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(find_unnecessary_casts)]`.
-    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#find_unnecessary_casts.
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_cast)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#unnecessary_cast.
 
 warning: [lint] Unnecessary cast: the expression is already of the target type. Consider removing the cast for better readability.
     ┌─ tests/model_ast_lints/known_to_abort.move:180:9
@@ -339,8 +339,8 @@ warning: [lint] Unnecessary cast: the expression is already of the target type. 
 180 │         (32767u16 + 1 - 1) as u16  // 32767, within u16 range
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^
     │
-    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(find_unnecessary_casts)]`.
-    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#find_unnecessary_casts.
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_cast)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#unnecessary_cast.
 
 warning: [lint] Unnecessary cast: the expression is already of the target type. Consider removing the cast for better readability.
     ┌─ tests/model_ast_lints/known_to_abort.move:185:13
@@ -348,8 +348,8 @@ warning: [lint] Unnecessary cast: the expression is already of the target type. 
 185 │             (x * 2) as u8
     │             ^^^^^^^^^^^^^
     │
-    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(find_unnecessary_casts)]`.
-    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#find_unnecessary_casts.
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_cast)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#unnecessary_cast.
 
 warning: [lint] Unnecessary cast: the expression is already of the target type. Consider removing the cast for better readability.
     ┌─ tests/model_ast_lints/known_to_abort.move:187:13
@@ -357,8 +357,8 @@ warning: [lint] Unnecessary cast: the expression is already of the target type. 
 187 │             (y * 2) as u8
     │             ^^^^^^^^^^^^^
     │
-    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(find_unnecessary_casts)]`.
-    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#find_unnecessary_casts.
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_cast)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#unnecessary_cast.
 
 warning: [lint] Unnecessary cast: the expression is already of the target type. Consider removing the cast for better readability.
     ┌─ tests/model_ast_lints/known_to_abort.move:194:17
@@ -366,8 +366,8 @@ warning: [lint] Unnecessary cast: the expression is already of the target type. 
 194 │                 (x + y) as u8
     │                 ^^^^^^^^^^^^^
     │
-    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(find_unnecessary_casts)]`.
-    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#find_unnecessary_casts.
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_cast)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#unnecessary_cast.
 
 warning: [lint] Unnecessary cast: the expression is already of the target type. Consider removing the cast for better readability.
     ┌─ tests/model_ast_lints/known_to_abort.move:196:17
@@ -375,8 +375,8 @@ warning: [lint] Unnecessary cast: the expression is already of the target type. 
 196 │                 (x + z) as u8
     │                 ^^^^^^^^^^^^^
     │
-    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(find_unnecessary_casts)]`.
-    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#find_unnecessary_casts.
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_cast)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#unnecessary_cast.
 
 warning: [lint] Unnecessary cast: the expression is already of the target type. Consider removing the cast for better readability.
     ┌─ tests/model_ast_lints/known_to_abort.move:199:13
@@ -384,5 +384,5 @@ warning: [lint] Unnecessary cast: the expression is already of the target type. 
 199 │             (y + z) as u8
     │             ^^^^^^^^^^^^^
     │
-    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(find_unnecessary_casts)]`.
-    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#find_unnecessary_casts.
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_cast)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#unnecessary_cast.


### PR DESCRIPTION
## Description
This PR changes the linter name from `find_unnecessary_casts` to `unnecessary_casts` as linters are supposed to find. It also fixes other places affected by this name change.

## How Has This Been Tested?
- Existing linter tests

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [x] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [x] Other (Move linter)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors the unnecessary cast linter naming and wiring.
> 
> - Replaces `find_unnecessary_casts` with new module `unnecessary_cast` and checker `FindUnnecessaryCast` whose `get_name()` is `"unnecessary_cast"`
> - Updates default linter pipeline to use `unnecessary_cast`
> - Refreshes test expectations and docs/skip attribute references from `find_unnecessary_casts` to `unnecessary_cast`; fixtures also include errors for unknown `unnecessary_casts` where used
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6d2e44475bdbda6e6b0d035d1cde0c9ff9af99e3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->