### PR TITLE
[Hot State] Compute root hash for hot state

### DIFF
--- a/api/test-context/src/test_context.rs
+++ b/api/test-context/src/test_context.rs
@@ -10,8 +10,9 @@ use aptos_api_types::{
 use aptos_cached_packages::aptos_stdlib;
 use aptos_config::{
     config::{
-        NodeConfig, RocksdbConfigs, StorageDirPaths, BUFFERED_STATE_TARGET_ITEMS_FOR_TEST,
-        DEFAULT_MAX_NUM_NODES_PER_LRU_CACHE_SHARD, NO_OP_STORAGE_PRUNER_CONFIG,
+        HotStateConfig, NodeConfig, RocksdbConfigs, StorageDirPaths,
+        BUFFERED_STATE_TARGET_ITEMS_FOR_TEST, DEFAULT_MAX_NUM_NODES_PER_LRU_CACHE_SHARD,
+        NO_OP_STORAGE_PRUNER_CONFIG,
     },
     keys::ConfigKey,
 };
@@ -176,7 +177,7 @@ pub fn new_test_context_inner(
             BUFFERED_STATE_TARGET_ITEMS_FOR_TEST,
             DEFAULT_MAX_NUM_NODES_PER_LRU_CACHE_SHARD,
             None,
-            /* reset_hot_state = */ true,
+            HotStateConfig::default(),
         )
         .unwrap();
         if node_config

--- a/aptos-move/aptos-validator-interface/src/storage_interface.rs
+++ b/aptos-move/aptos-validator-interface/src/storage_interface.rs
@@ -4,7 +4,7 @@
 use crate::{AptosValidatorInterface, FilterCondition};
 use anyhow::{ensure, Result};
 use aptos_config::config::{
-    RocksdbConfigs, StorageDirPaths, BUFFERED_STATE_TARGET_ITEMS,
+    HotStateConfig, RocksdbConfigs, StorageDirPaths, BUFFERED_STATE_TARGET_ITEMS,
     DEFAULT_MAX_NUM_NODES_PER_LRU_CACHE_SHARD, NO_OP_STORAGE_PRUNER_CONFIG,
 };
 use aptos_db::AptosDB;
@@ -32,7 +32,10 @@ impl DBDebuggerInterface {
                 BUFFERED_STATE_TARGET_ITEMS,
                 DEFAULT_MAX_NUM_NODES_PER_LRU_CACHE_SHARD,
                 /* internal_indexer_db = */ None,
-                /* reset_hot_state = */ false,
+                HotStateConfig {
+                    delete_on_restart: false,
+                    ..Default::default()
+                },
             )
             .map_err(anyhow::Error::from)?,
         )))

--- a/config/src/config/storage_config.rs
+++ b/config/src/config/storage_config.rs
@@ -245,6 +245,9 @@ pub struct HotStateConfig {
     pub max_items_per_shard: usize,
     /// Whether to delete persisted data on disk on restart. Used during development.
     pub delete_on_restart: bool,
+    /// Whether we compute root hashes for hot state in executor and commit the resulting JMT to
+    /// db.
+    pub compute_root_hash: bool,
 }
 
 impl Default for HotStateConfig {
@@ -252,6 +255,7 @@ impl Default for HotStateConfig {
         Self {
             max_items_per_shard: 250_000,
             delete_on_restart: true,
+            compute_root_hash: true,
         }
     }
 }
@@ -657,6 +661,13 @@ impl ConfigOptimizer for StorageConfig {
                 && config_yaml["rocksdb_configs"]["enable_storage_sharding"].as_bool() != Some(true)
             {
                 panic!("Storage sharding (AIP-97) is not enabled in node config. Please follow the guide to migration your node, and set storage.rocksdb_configs.enable_storage_sharding to true explicitly in your node config. https://aptoslabs.notion.site/DB-Sharding-Migration-Public-Full-Nodes-1978b846eb7280b29f17ceee7d480730");
+            }
+            // TODO(HotState): Hot state root hash computation is off by default in Mainnet unless
+            // explicitly enabled.
+            if chain_id.is_mainnet()
+                && config_yaml["hot_state_config"]["compute_root_hash"].as_bool() != Some(true)
+            {
+                config.hot_state_config.compute_root_hash = false;
             }
         }
 

--- a/crates/aptos-genesis/src/lib.rs
+++ b/crates/aptos-genesis/src/lib.rs
@@ -13,7 +13,7 @@ pub mod test_utils;
 
 use crate::{builder::GenesisConfiguration, config::ValidatorConfiguration};
 use aptos_config::config::{
-    RocksdbConfigs, StorageDirPaths, BUFFERED_STATE_TARGET_ITEMS,
+    HotStateConfig, RocksdbConfigs, StorageDirPaths, BUFFERED_STATE_TARGET_ITEMS,
     DEFAULT_MAX_NUM_NODES_PER_LRU_CACHE_SHARD, NO_OP_STORAGE_PRUNER_CONFIG,
 };
 use aptos_crypto::ed25519::Ed25519PublicKey;
@@ -177,7 +177,7 @@ impl GenesisInfo {
             BUFFERED_STATE_TARGET_ITEMS,
             DEFAULT_MAX_NUM_NODES_PER_LRU_CACHE_SHARD,
             /* internal_indexer_db = */ None,
-            /* reset_hot_state = */ true,
+            HotStateConfig::default(),
         )?;
         let db_rw = DbReaderWriter::new(aptosdb);
         aptos_executor::db_bootstrapper::generate_waypoint::<AptosVMBlockExecutor>(&db_rw, genesis)

--- a/crates/aptos-genesis/src/mainnet.rs
+++ b/crates/aptos-genesis/src/mainnet.rs
@@ -3,7 +3,7 @@
 
 use crate::{builder::GenesisConfiguration, config::ValidatorConfiguration};
 use aptos_config::config::{
-    RocksdbConfigs, StorageDirPaths, BUFFERED_STATE_TARGET_ITEMS,
+    HotStateConfig, RocksdbConfigs, StorageDirPaths, BUFFERED_STATE_TARGET_ITEMS,
     DEFAULT_MAX_NUM_NODES_PER_LRU_CACHE_SHARD, NO_OP_STORAGE_PRUNER_CONFIG,
 };
 use aptos_db::AptosDB;
@@ -161,7 +161,7 @@ impl MainnetGenesisInfo {
             BUFFERED_STATE_TARGET_ITEMS,
             DEFAULT_MAX_NUM_NODES_PER_LRU_CACHE_SHARD,
             /* internal_indexer_db = */ None,
-            /* reset_hot_state = */ true,
+            HotStateConfig::default(),
         )?;
         let db_rw = DbReaderWriter::new(aptosdb);
         aptos_executor::db_bootstrapper::generate_waypoint::<AptosVMBlockExecutor>(&db_rw, genesis)

--- a/execution/executor-benchmark/src/db_generator.rs
+++ b/execution/executor-benchmark/src/db_generator.rs
@@ -4,7 +4,7 @@
 use crate::{add_accounts_impl, PipelineConfig, StorageTestConfig};
 use aptos_config::{
     config::{
-        RocksdbConfigs, StorageDirPaths, BUFFERED_STATE_TARGET_ITEMS,
+        HotStateConfig, RocksdbConfigs, StorageDirPaths, BUFFERED_STATE_TARGET_ITEMS,
         DEFAULT_MAX_NUM_NODES_PER_LRU_CACHE_SHARD, NO_OP_STORAGE_PRUNER_CONFIG,
     },
     utils::get_genesis_txn,
@@ -104,7 +104,7 @@ pub(crate) fn bootstrap_with_genesis(
             BUFFERED_STATE_TARGET_ITEMS,
             DEFAULT_MAX_NUM_NODES_PER_LRU_CACHE_SHARD,
             None, /* internal_indexer_db */
-            true, /* reset_hot_state */
+            HotStateConfig::default(),
         )
         .expect("DB should open."),
     );

--- a/execution/executor-benchmark/src/lib.rs
+++ b/execution/executor-benchmark/src/lib.rs
@@ -25,7 +25,8 @@ use crate::{
 };
 use aptos_api::context::Context;
 use aptos_config::config::{
-    get_default_processor_task_count, NodeConfig, PrunerConfig, NO_OP_STORAGE_PRUNER_CONFIG,
+    get_default_processor_task_count, HotStateConfig, NodeConfig, PrunerConfig,
+    NO_OP_STORAGE_PRUNER_CONFIG,
 };
 use aptos_db::AptosDB;
 use aptos_db_indexer::{db_ops::open_db, db_v2::IndexerAsyncV2, indexer_reader::IndexerReaders};
@@ -117,7 +118,7 @@ pub fn init_db(config: &NodeConfig) -> DbReaderWriter {
             config.storage.buffered_state_target_items,
             config.storage.max_num_nodes_per_lru_cache_shard,
             None,
-            /* reset_hot_state = */ true,
+            HotStateConfig::default(),
         )
         .expect("DB should open."),
     )

--- a/execution/executor-types/src/execution_output.rs
+++ b/execution/executor-types/src/execution_output.rs
@@ -10,7 +10,7 @@ use crate::{
 use aptos_config::config::HotStateConfig;
 use aptos_drop_helper::DropHelper;
 use aptos_storage_interface::state_store::{
-    state::LedgerState, state_view::cached_state_view::ShardedStateCache,
+    state::LedgerState, state_view::cached_state_view::ShardedStateCache, HotStateUpdates,
 };
 use aptos_types::{
     contract_event::ContractEvent,
@@ -38,6 +38,7 @@ impl ExecutionOutput {
         to_retry: TransactionsWithOutput,
         result_state: LedgerState,
         state_reads: ShardedStateCache,
+        hot_state_updates: HotStateUpdates,
         block_end_info: Option<BlockEndInfo>,
         next_epoch_state: Option<EpochState>,
         subscribable_events: Planned<Vec<ContractEvent>>,
@@ -62,6 +63,7 @@ impl ExecutionOutput {
             to_retry,
             result_state,
             state_reads,
+            hot_state_updates,
             block_end_info,
             next_epoch_state,
             subscribable_events,
@@ -78,6 +80,7 @@ impl ExecutionOutput {
             to_retry: TransactionsWithOutput::new_empty(),
             state_reads: ShardedStateCache::new_empty(state.version()),
             result_state: state,
+            hot_state_updates: HotStateUpdates::new_empty(),
             block_end_info: None,
             next_epoch_state: None,
             subscribable_events: Planned::ready(vec![]),
@@ -96,6 +99,7 @@ impl ExecutionOutput {
             to_retry: TransactionsWithOutput::new_empty(),
             result_state: LedgerState::new_empty(HotStateConfig::default()),
             state_reads: ShardedStateCache::new_empty(None),
+            hot_state_updates: HotStateUpdates::new_empty(),
             block_end_info: None,
             next_epoch_state: None,
             subscribable_events: Planned::ready(vec![]),
@@ -116,6 +120,7 @@ impl ExecutionOutput {
             to_retry: TransactionsWithOutput::new_empty(),
             result_state: self.result_state.clone(),
             state_reads: ShardedStateCache::new_empty(self.next_version().checked_sub(1)),
+            hot_state_updates: HotStateUpdates::new_empty(),
             block_end_info: None,
             next_epoch_state: self.next_epoch_state.clone(),
             subscribable_events: Planned::ready(vec![]),
@@ -158,6 +163,8 @@ pub struct Inner {
     /// State items read during execution, useful for calculating the state storge usage and
     /// indices used by the db pruner.
     pub state_reads: ShardedStateCache,
+    /// Updates to hot state, mainly used to compute hot state root hashes.
+    pub hot_state_updates: HotStateUpdates,
 
     /// Optional StateCheckpoint payload
     pub block_end_info: Option<BlockEndInfo>,

--- a/execution/executor-types/src/state_checkpoint_output.rs
+++ b/execution/executor-types/src/state_checkpoint_output.rs
@@ -3,6 +3,7 @@
 
 #![forbid(unsafe_code)]
 
+use aptos_config::config::HotStateConfig;
 use aptos_crypto::HashValue;
 use aptos_drop_helper::DropHelper;
 use aptos_storage_interface::state_store::state_summary::LedgerStateSummary;
@@ -34,7 +35,7 @@ impl StateCheckpointOutput {
     }
 
     pub fn new_dummy() -> Self {
-        Self::new_empty(LedgerStateSummary::new_empty())
+        Self::new_empty(LedgerStateSummary::new_empty(HotStateConfig::default()))
     }
 
     fn new_impl(inner: Inner) -> Self {

--- a/execution/executor/src/workflow/do_get_execution_output.rs
+++ b/execution/executor/src/workflow/do_get_execution_output.rs
@@ -417,7 +417,7 @@ impl Parser {
             },
         )?;
 
-        let result_state = parent_state.update_with_memorized_reads(
+        let (result_state, hot_state_updates) = parent_state.update_with_memorized_reads(
             base_state_view.persisted_hot_state(),
             base_state_view.persisted_state(),
             to_commit.state_update_refs(),
@@ -434,6 +434,7 @@ impl Parser {
             to_retry,
             result_state,
             state_reads,
+            hot_state_updates,
             block_end_info,
             next_epoch_state,
             Planned::place_holder(),

--- a/execution/executor/src/workflow/do_state_checkpoint.rs
+++ b/execution/executor/src/workflow/do_state_checkpoint.rs
@@ -25,6 +25,7 @@ impl DoStateCheckpoint {
 
         let state_summary = parent_state_summary.update(
             persisted_state_summary,
+            &execution_output.hot_state_updates,
             execution_output.to_commit.state_update_refs(),
         )?;
 

--- a/state-sync/state-sync-driver/src/tests/driver_factory.rs
+++ b/state-sync/state-sync-driver/src/tests/driver_factory.rs
@@ -4,7 +4,7 @@
 use crate::{driver_factory::DriverFactory, metadata_storage::PersistentMetadataStorage};
 use aptos_config::{
     config::{
-        RocksdbConfigs, StorageDirPaths, BUFFERED_STATE_TARGET_ITEMS,
+        HotStateConfig, RocksdbConfigs, StorageDirPaths, BUFFERED_STATE_TARGET_ITEMS,
         DEFAULT_MAX_NUM_NODES_PER_LRU_CACHE_SHARD, NO_OP_STORAGE_PRUNER_CONFIG,
     },
     utils::get_genesis_txn,
@@ -41,7 +41,7 @@ fn test_new_initialized_configs() {
         BUFFERED_STATE_TARGET_ITEMS,
         DEFAULT_MAX_NUM_NODES_PER_LRU_CACHE_SHARD,
         None,
-        /* reset_hot_state = */ true,
+        HotStateConfig::default(),
     )
     .unwrap();
     let (_, db_rw) = DbReaderWriter::wrap(db);

--- a/storage/aptosdb/src/backup/restore_utils.rs
+++ b/storage/aptosdb/src/backup/restore_utils.rs
@@ -267,7 +267,7 @@ pub(crate) fn save_transactions_impl(
     }
 
     if kv_replay && first_version > 0 && state_store.get_usage(Some(first_version - 1)).is_ok() {
-        let ledger_state = state_store.calculate_state_and_put_updates(
+        let (ledger_state, _hot_state_updates) = state_store.calculate_state_and_put_updates(
             &StateUpdateRefs::index_write_sets(first_version, write_sets, write_sets.len(), vec![]),
             &mut ledger_db_batch.ledger_metadata_db_batches, // used for storing the storage usage
             state_kv_batches,

--- a/storage/aptosdb/src/db/aptosdb_test.rs
+++ b/storage/aptosdb/src/db/aptosdb_test.rs
@@ -14,7 +14,7 @@ use crate::{
     schema::stale_node_index::StaleNodeIndexSchema,
 };
 use aptos_config::config::{
-    EpochSnapshotPrunerConfig, LedgerPrunerConfig, PrunerConfig, RocksdbConfigs,
+    EpochSnapshotPrunerConfig, HotStateConfig, LedgerPrunerConfig, PrunerConfig, RocksdbConfigs,
     StateMerklePrunerConfig, StorageDirPaths, BUFFERED_STATE_TARGET_ITEMS_FOR_TEST,
     DEFAULT_MAX_NUM_NODES_PER_LRU_CACHE_SHARD,
 };
@@ -256,7 +256,7 @@ pub fn test_state_merkle_pruning_impl(
         BUFFERED_STATE_TARGET_ITEMS_FOR_TEST,
         DEFAULT_MAX_NUM_NODES_PER_LRU_CACHE_SHARD,
         None,
-        /* reset_hot_state = */ true,
+        HotStateConfig::default(),
     )
     .unwrap();
 

--- a/storage/aptosdb/src/db/mod.rs
+++ b/storage/aptosdb/src/db/mod.rs
@@ -7,7 +7,7 @@ use crate::{
     state_kv_db::StateKvDb, state_merkle_db::StateMerkleDb, state_store::StateStore,
     transaction_store::TransactionStore,
 };
-use aptos_config::config::{PrunerConfig, RocksdbConfigs, StorageDirPaths};
+use aptos_config::config::{HotStateConfig, PrunerConfig, RocksdbConfigs, StorageDirPaths};
 use aptos_db_indexer::{db_indexer::InternalIndexerDB, Indexer};
 use aptos_logger::prelude::*;
 use aptos_schemadb::{batch::SchemaBatch, Cache, Env};
@@ -63,7 +63,7 @@ impl AptosDB {
         buffered_state_target_items: usize,
         max_num_nodes_per_lru_cache_shard: usize,
         internal_indexer_db: Option<InternalIndexerDB>,
-        reset_hot_state: bool,
+        hot_state_config: HotStateConfig,
     ) -> Result<Self> {
         Self::open_internal(
             &db_paths,
@@ -75,7 +75,7 @@ impl AptosDB {
             max_num_nodes_per_lru_cache_shard,
             false,
             internal_indexer_db,
-            reset_hot_state,
+            hot_state_config,
         )
     }
 
@@ -99,7 +99,7 @@ impl AptosDB {
             max_num_nodes_per_lru_cache_shard,
             true,
             internal_indexer_db,
-            /* reset_hot_state = */ true,
+            HotStateConfig::default(),
         )
     }
 

--- a/storage/aptosdb/src/db_debugger/watch/opened.rs
+++ b/storage/aptosdb/src/db_debugger/watch/opened.rs
@@ -23,6 +23,7 @@ impl Cmd {
         config.set_data_dir(self.db_dir);
         config.rocksdb_configs.enable_storage_sharding =
             self.sharding_config.enable_storage_sharding;
+        config.hot_state_config.delete_on_restart = false;
 
         let _db = AptosDB::open(
             config.get_dir_paths(),
@@ -33,7 +34,7 @@ impl Cmd {
             config.buffered_state_target_items,
             config.max_num_nodes_per_lru_cache_shard,
             None,
-            /* reset_hot_state = */ false,
+            config.hot_state_config,
         )
         .expect("Failed to open AptosDB");
 

--- a/storage/aptosdb/src/fast_sync_storage_wrapper.rs
+++ b/storage/aptosdb/src/fast_sync_storage_wrapper.rs
@@ -54,7 +54,7 @@ impl FastSyncStorageWrapper {
             config.storage.buffered_state_target_items,
             config.storage.max_num_nodes_per_lru_cache_shard,
             internal_indexer_db,
-            config.storage.hot_state_config.delete_on_restart,
+            config.storage.hot_state_config,
         )
         .map_err(|err| anyhow!("fast sync DB failed to open {}", err))?;
         if let Some(sender) = update_sender {
@@ -85,7 +85,7 @@ impl FastSyncStorageWrapper {
                 config.storage.buffered_state_target_items,
                 config.storage.max_num_nodes_per_lru_cache_shard,
                 None,
-                config.storage.hot_state_config.delete_on_restart,
+                config.storage.hot_state_config,
             )
             .map_err(|err| anyhow!("Secondary DB failed to open {}", err))?;
 

--- a/storage/aptosdb/src/state_merkle_db.rs
+++ b/storage/aptosdb/src/state_merkle_db.rs
@@ -347,7 +347,7 @@ impl StateMerkleDb {
         Ok(None)
     }
 
-    fn create_jmt_commit_batch_for_shard(
+    pub(crate) fn create_jmt_commit_batch_for_shard(
         &self,
         version: Version,
         shard_id: Option<usize>,

--- a/storage/aptosdb/src/state_store/mod.rs
+++ b/storage/aptosdb/src/state_store/mod.rs
@@ -41,7 +41,11 @@ use aptos_db_indexer_schemas::{
     schema::indexer_metadata::InternalIndexerMetadataSchema,
 };
 use aptos_infallible::Mutex;
-use aptos_jellyfish_merkle::iterator::JellyfishMerkleIterator;
+use aptos_jellyfish_merkle::{
+    iterator::JellyfishMerkleIterator,
+    node_type::{Node, NodeKey},
+    TreeUpdateBatch,
+};
 use aptos_logger::info;
 use aptos_metrics_core::TimerHelper;
 use aptos_schemadb::batch::{NativeBatch, SchemaBatch, WriteBatch};
@@ -58,6 +62,7 @@ use aptos_storage_interface::{
         },
         state_with_summary::{LedgerStateWithSummary, StateWithSummary},
         versioned_state_value::StateUpdateRef,
+        HotStateUpdates,
     },
     AptosDbError, DbReader, Result, StateSnapshotReceiver,
 };
@@ -125,6 +130,7 @@ pub(crate) struct StateStore {
     persisted_state: PersistedState,
     buffered_state_target_items: usize,
     internal_indexer_db: Option<InternalIndexerDB>,
+    hot_state_config: HotStateConfig,
 }
 
 impl Deref for StateStore {
@@ -184,9 +190,14 @@ impl DbReader for StateDb {
         use_hot_state: bool,
     ) -> Result<SparseMerkleProofExt> {
         let db = if use_hot_state {
-            self.hot_state_merkle_db
-                .as_ref()
-                .ok_or(AptosDbError::HotStateError)?
+            if self.state_merkle_db.sharding_enabled() {
+                self.hot_state_merkle_db
+                    .as_ref()
+                    .ok_or(AptosDbError::HotStateError)?
+            } else {
+                // Unsharded unit tests still rely on this.
+                &self.state_merkle_db
+            }
         } else {
             &self.state_merkle_db
         };
@@ -203,9 +214,14 @@ impl DbReader for StateDb {
         use_hot_state: bool,
     ) -> Result<(Option<StateValue>, SparseMerkleProofExt)> {
         let db = if use_hot_state {
-            self.hot_state_merkle_db
-                .as_ref()
-                .ok_or(AptosDbError::HotStateError)?
+            if self.state_merkle_db.sharding_enabled() {
+                self.hot_state_merkle_db
+                    .as_ref()
+                    .ok_or(AptosDbError::HotStateError)?
+            } else {
+                // Unsharded unit tests still rely on this.
+                &self.state_merkle_db
+            }
         } else {
             &self.state_merkle_db
         };
@@ -319,7 +335,7 @@ impl StateDb {
 }
 
 impl StateStore {
-    pub fn new(
+    pub(crate) fn new(
         ledger_db: Arc<LedgerDb>,
         hot_state_merkle_db: Option<Arc<StateMerkleDb>>,
         state_merkle_db: Arc<StateMerkleDb>,
@@ -332,6 +348,7 @@ impl StateStore {
         empty_buffered_state_for_restore: bool,
         skip_usage: bool,
         internal_indexer_db: Option<InternalIndexerDB>,
+        hot_state_config: HotStateConfig,
     ) -> Self {
         if !hack_for_tests && !empty_buffered_state_for_restore {
             Self::sync_commit_progress(
@@ -352,11 +369,10 @@ impl StateStore {
             skip_usage,
         });
         // TODO(HotState): probably fetch onchain config from storage.
-        let hot_state_config = HotStateConfig::default();
         let current_state = Arc::new(Mutex::new(LedgerStateWithSummary::new_empty(
             hot_state_config,
         )));
-        let persisted_state = PersistedState::new_empty();
+        let persisted_state = PersistedState::new_empty(hot_state_config);
         let buffered_state = if empty_buffered_state_for_restore {
             BufferedState::new_at_snapshot(
                 &state_db,
@@ -373,6 +389,7 @@ impl StateStore {
                 /*check_max_versions_after_snapshot=*/ true,
                 current_state.clone(),
                 persisted_state.clone(),
+                hot_state_config,
             )
             .expect("buffered state creation failed.")
         };
@@ -384,6 +401,7 @@ impl StateStore {
             current_state,
             persisted_state,
             internal_indexer_db,
+            hot_state_config,
         }
     }
 
@@ -517,7 +535,7 @@ impl StateStore {
         let current_state = Arc::new(Mutex::new(LedgerStateWithSummary::new_empty(
             HotStateConfig::default(),
         )));
-        let persisted_state = PersistedState::new_empty();
+        let persisted_state = PersistedState::new_empty(HotStateConfig::default());
         let _ = Self::create_buffered_state_from_latest_snapshot(
             &state_db,
             0,
@@ -525,6 +543,7 @@ impl StateStore {
             /*check_max_versions_after_snapshot=*/ false,
             current_state.clone(),
             persisted_state,
+            HotStateConfig::default(),
         )?;
         let base_version = current_state.lock().version();
         Ok(base_version)
@@ -537,6 +556,7 @@ impl StateStore {
         check_max_versions_after_snapshot: bool,
         out_current_state: Arc<Mutex<LedgerStateWithSummary>>,
         out_persisted_state: PersistedState,
+        hot_state_config: HotStateConfig,
     ) -> Result<BufferedState> {
         let num_transactions = state_db
             .ledger_db
@@ -554,6 +574,7 @@ impl StateStore {
             latest_snapshot_version = latest_snapshot_version,
             "Initializing BufferedState."
         );
+        // TODO(HotState): read hot root hash from DB.
         let latest_snapshot_root_hash = if let Some(version) = latest_snapshot_version {
             state_db
                 .state_merkle_db
@@ -568,7 +589,7 @@ impl StateStore {
             *SPARSE_MERKLE_PLACEHOLDER_HASH, // TODO(HotState): for now hot state always starts from empty upon restart.
             latest_snapshot_root_hash,
             usage,
-            HotStateConfig::default(),
+            hot_state_config,
         );
         let mut buffered_state = BufferedState::new_at_snapshot(
             state_db,
@@ -595,6 +616,26 @@ impl StateStore {
             );
         }
 
+        if snapshot_next_version > 0
+            && let Some(db) = &state_db.hot_state_merkle_db
+        {
+            // TODO(HotState): this is needed while starting with an empty hot state during
+            // development.
+            let prev_version = snapshot_next_version - 1;
+            let tree_update_batch = TreeUpdateBatch {
+                node_batch: vec![vec![(NodeKey::new_empty_path(prev_version), Node::Null)]],
+                stale_node_index_batch: vec![],
+            };
+            let raw_batch = db.create_jmt_commit_batch_for_shard(
+                prev_version,
+                /* shard_id = */ None,
+                &tree_update_batch,
+                /* previous_epoch_ending_version = */ None,
+            )?;
+            db.commit_top_levels(prev_version, raw_batch)?;
+            info!("Wrote null node for hot state at version {prev_version}");
+        }
+
         // Replaying the committed write sets after the latest snapshot.
         if snapshot_next_version < num_transactions {
             if check_max_versions_after_snapshot {
@@ -605,6 +646,8 @@ impl StateStore {
                     num_transactions,
                 );
             }
+            info!("Replaying writesets from {snapshot_next_version} to {num_transactions} to let state Merkle DB catch up.");
+
             let write_sets = state_db
                 .ledger_db
                 .write_set_db()
@@ -628,15 +671,13 @@ impl StateStore {
             );
             let current_state = out_current_state.lock().clone();
             let (hot_state, state) = out_persisted_state.get_state();
-            let (new_state, _state_reads) = current_state.ledger_state().update_with_db_reader(
-                &state,
-                hot_state,
-                &state_update_refs,
-                state_db.clone(),
-            )?;
+            let (new_state, _state_reads, hot_state_updates) = current_state
+                .ledger_state()
+                .update_with_db_reader(&state, hot_state, &state_update_refs, state_db.clone())?;
             let state_summary = out_persisted_state.get_state_summary();
             let new_state_summary = current_state.ledger_state_summary().update(
                 &ProvableStateSummary::new(state_summary, state_db.as_ref()),
+                &hot_state_updates,
                 &state_update_refs,
             )?;
             let updated =
@@ -652,8 +693,11 @@ impl StateStore {
         let current_state = out_current_state.lock().clone();
         info!(
             latest_in_memory_version = current_state.version(),
+            latest_in_memory_hot_root_hash = current_state.summary().hot_root_hash(),
             latest_in_memory_root_hash = current_state.summary().root_hash(),
             latest_snapshot_version = current_state.last_checkpoint().version(),
+            latest_snapshot_hot_root_hash =
+                current_state.last_checkpoint().summary().hot_root_hash(),
             latest_snapshot_root_hash = current_state.last_checkpoint().summary().root_hash(),
             "StateStore initialization finished.",
         );
@@ -669,6 +713,7 @@ impl StateStore {
             true,
             self.current_state.clone(),
             self.persisted_state.clone(),
+            self.hot_state_config,
         )
         .expect("buffered state creation failed.");
     }
@@ -717,10 +762,10 @@ impl StateStore {
         state_update_refs: &StateUpdateRefs,
         ledger_batch: &mut SchemaBatch,
         sharded_state_kv_batches: &mut ShardedStateKvSchemaBatch,
-    ) -> Result<LedgerState> {
+    ) -> Result<(LedgerState, HotStateUpdates)> {
         let current = self.current_state_locked().ledger_state();
         let (hot_state, persisted) = self.get_persisted_state()?;
-        let (new_state, reads) = current.update_with_db_reader(
+        let (new_state, reads, hot_state_updates) = current.update_with_db_reader(
             &persisted,
             hot_state,
             state_update_refs,
@@ -735,7 +780,7 @@ impl StateStore {
             sharded_state_kv_batches,
         )?;
 
-        Ok(new_state)
+        Ok((new_state, hot_state_updates))
     }
 
     pub fn put_state_updates(
@@ -1167,8 +1212,14 @@ impl StateStore {
             ledger_state.last_checkpoint().version(),
             hot_smt.clone(),
             smt.clone(),
+            HotStateConfig::default(),
         );
-        let summary = StateSummary::new_at_version(ledger_state.version(), hot_smt, smt);
+        let summary = StateSummary::new_at_version(
+            ledger_state.version(),
+            hot_smt,
+            smt,
+            HotStateConfig::default(),
+        );
 
         let last_checkpoint = StateWithSummary::new(
             ledger_state.last_checkpoint().clone(),
@@ -1384,7 +1435,7 @@ mod test_only {
             let mut ledger_batch = SchemaBatch::new();
             let mut sharded_state_kv_batches = self.state_kv_db.new_sharded_native_batches();
 
-            let new_ledger_state = self
+            let (new_ledger_state, hot_state_updates) = self
                 .calculate_state_and_put_updates(
                     &state_update_refs,
                     &mut ledger_batch,
@@ -1406,6 +1457,7 @@ mod test_only {
             let new_state_summary = current
                 .update(
                     &ProvableStateSummary::new(persisted, self.state_db.as_ref()),
+                    &hot_state_updates,
                     &state_update_refs,
                 )
                 .unwrap();

--- a/storage/aptosdb/src/state_store/persisted_state.rs
+++ b/storage/aptosdb/src/state_store/persisted_state.rs
@@ -21,14 +21,10 @@ pub struct PersistedState {
 impl PersistedState {
     const MAX_PENDING_DROPS: usize = 8;
 
-    pub fn new_empty() -> Self {
-        Self::new_empty_with_config(HotStateConfig::default())
-    }
-
-    pub fn new_empty_with_config(config: HotStateConfig) -> Self {
+    pub fn new_empty(config: HotStateConfig) -> Self {
         let state = State::new_empty(config);
         let hot_state = Arc::new(HotState::new(state, config));
-        let summary = Arc::new(Mutex::new(StateSummary::new_empty()));
+        let summary = Arc::new(Mutex::new(StateSummary::new_empty(config)));
         Self { hot_state, summary }
     }
 

--- a/storage/aptosdb/src/state_store/state_merkle_batch_committer.rs
+++ b/storage/aptosdb/src/state_store/state_merkle_batch_committer.rs
@@ -7,6 +7,7 @@ use crate::{
     metrics::{LATEST_SNAPSHOT_VERSION, OTHER_TIMERS_SECONDS},
     pruner::PrunerManager,
     schema::jellyfish_merkle_node::JellyfishMerkleNodeSchema,
+    state_merkle_db::StateMerkleDb,
     state_store::{buffered_state::CommitMessage, persisted_state::PersistedState, StateDb},
 };
 use anyhow::{anyhow, ensure, Result};
@@ -15,24 +16,30 @@ use aptos_logger::{info, trace};
 use aptos_metrics_core::TimerHelper;
 use aptos_schemadb::batch::RawBatch;
 use aptos_storage_interface::state_store::{state::State, state_with_summary::StateWithSummary};
+use aptos_types::transaction::Version;
 use std::sync::{mpsc::Receiver, Arc};
 
-pub struct StateMerkleBatch {
+pub(crate) struct StateMerkleCommit {
+    pub snapshot: StateWithSummary,
+    pub hot_batch: Option<StateMerkleBatch>,
+    pub cold_batch: StateMerkleBatch,
+}
+
+pub(crate) struct StateMerkleBatch {
     pub top_levels_batch: RawBatch,
     pub batches_for_shards: Vec<RawBatch>,
-    pub snapshot: StateWithSummary,
 }
 
 pub(crate) struct StateMerkleBatchCommitter {
     state_db: Arc<StateDb>,
-    state_merkle_batch_receiver: Receiver<CommitMessage<StateMerkleBatch>>,
+    state_merkle_batch_receiver: Receiver<CommitMessage<StateMerkleCommit>>,
     persisted_state: PersistedState,
 }
 
 impl StateMerkleBatchCommitter {
     pub fn new(
         state_db: Arc<StateDb>,
-        state_merkle_batch_receiver: Receiver<CommitMessage<StateMerkleBatch>>,
+        state_merkle_batch_receiver: Receiver<CommitMessage<StateMerkleCommit>>,
         persisted_state: PersistedState,
     ) -> Self {
         Self {
@@ -46,13 +53,11 @@ impl StateMerkleBatchCommitter {
         while let Ok(msg) = self.state_merkle_batch_receiver.recv() {
             let _timer = OTHER_TIMERS_SECONDS.timer_with(&["batch_committer_work"]);
             match msg {
-                CommitMessage::Data(state_merkle_batch) => {
-                    let StateMerkleBatch {
-                        top_levels_batch,
-                        batches_for_shards,
-                        snapshot,
-                    } = state_merkle_batch;
-
+                CommitMessage::Data(StateMerkleCommit {
+                    snapshot,
+                    hot_batch,
+                    cold_batch,
+                }) => {
                     let base_version = self.persisted_state.get_state_summary().version();
                     let current_version = snapshot
                         .version()
@@ -61,25 +66,30 @@ impl StateMerkleBatchCommitter {
                     // commit jellyfish merkle nodes
                     let _timer =
                         OTHER_TIMERS_SECONDS.timer_with(&["commit_jellyfish_merkle_nodes"]);
-                    self.state_db
-                        .state_merkle_db
-                        .commit(current_version, top_levels_batch, batches_for_shards)
-                        .expect("State merkle nodes commit failed.");
-                    if let Some(lru_cache) = self.state_db.state_merkle_db.lru_cache() {
-                        self.state_db
-                            .state_merkle_db
-                            .version_caches()
-                            .iter()
-                            .for_each(|(_, cache)| cache.maybe_evict_version(lru_cache));
+                    if let Some(hot_state_merkle_batch) = hot_batch {
+                        self.commit(
+                            self.state_db
+                                .hot_state_merkle_db
+                                .as_ref()
+                                .expect("Hot state merkle db must exist."),
+                            current_version,
+                            hot_state_merkle_batch,
+                        )
+                        .expect("Hot state merkle nodes commit failed.");
                     }
+                    self.commit(&self.state_db.state_merkle_db, current_version, cold_batch)
+                        .expect("State merkle nodes commit failed.");
 
                     info!(
                         version = current_version,
                         base_version = base_version,
                         root_hash = snapshot.summary().root_hash(),
+                        hot_root_hash = snapshot.summary().hot_root_hash(),
                         "State snapshot committed."
                     );
                     LATEST_SNAPSHOT_VERSION.set(current_version as i64);
+                    // TODO(HotState): no pruning for hot state right now, since we always reset it
+                    // upon restart.
                     self.state_db
                         .state_merkle_pruner
                         .maybe_set_pruner_target_db_version(current_version);
@@ -102,6 +112,25 @@ impl StateMerkleBatchCommitter {
             }
         }
         trace!("State merkle batch committing thread exit.")
+    }
+
+    fn commit(
+        &self,
+        db: &StateMerkleDb,
+        current_version: Version,
+        state_merkle_batch: StateMerkleBatch,
+    ) -> Result<()> {
+        let StateMerkleBatch {
+            top_levels_batch,
+            batches_for_shards,
+        } = state_merkle_batch;
+        db.commit(current_version, top_levels_batch, batches_for_shards)?;
+        if let Some(lru_cache) = db.lru_cache() {
+            db.version_caches()
+                .iter()
+                .for_each(|(_, cache)| cache.maybe_evict_version(lru_cache));
+        }
+        Ok(())
     }
 
     fn check_usage_consistency(&self, state: &State) -> Result<()> {

--- a/storage/aptosdb/src/state_store/state_snapshot_committer.rs
+++ b/storage/aptosdb/src/state_store/state_snapshot_committer.rs
@@ -5,27 +5,34 @@
 
 use crate::{
     metrics::OTHER_TIMERS_SECONDS,
+    state_merkle_db::StateMerkleDb,
     state_store::{
         buffered_state::CommitMessage,
         persisted_state::PersistedState,
-        state_merkle_batch_committer::{StateMerkleBatch, StateMerkleBatchCommitter},
+        state_merkle_batch_committer::{
+            StateMerkleBatch, StateMerkleBatchCommitter, StateMerkleCommit,
+        },
         StateDb,
     },
     versioned_node_cache::VersionedNodeCache,
 };
+use aptos_crypto::{hash::CryptoHash, HashValue};
 use aptos_experimental_runtimes::thread_manager::THREAD_MANAGER;
 use aptos_logger::info;
 use aptos_metrics_core::TimerHelper;
+use aptos_scratchpad::SparseMerkleTree;
 use aptos_storage_interface::{
     jmt_update_refs, state_store::state_with_summary::StateWithSummary, Result,
 };
-use itertools::Itertools;
+use aptos_types::{
+    state_store::{state_key::StateKey, NUM_STATE_SHARDS},
+    transaction::Version,
+};
 use rayon::prelude::*;
 use static_assertions::const_assert;
 use std::{
     sync::{
-        mpsc,
-        mpsc::{Receiver, SyncSender},
+        mpsc::{self, Receiver, SyncSender},
         Arc,
     },
     thread::JoinHandle,
@@ -36,7 +43,7 @@ pub(crate) struct StateSnapshotCommitter {
     /// Last snapshot merklized and sent for persistence, not guaranteed to have committed already.
     last_snapshot: StateWithSummary,
     state_snapshot_commit_receiver: Receiver<CommitMessage<StateWithSummary>>,
-    state_merkle_batch_commit_sender: SyncSender<CommitMessage<StateMerkleBatch>>,
+    state_merkle_batch_commit_sender: SyncSender<CommitMessage<StateMerkleCommit>>,
     join_handle: Option<JoinHandle<()>>,
 }
 
@@ -90,84 +97,69 @@ impl StateSnapshotCommitter {
                         .get_previous_epoch_ending(version)
                         .unwrap()
                         .map(|(v, _e)| v);
+                    let min_version = self.last_snapshot.next_version();
 
-                    let (shard_root_nodes, batches_for_shards) = {
-                        let _timer =
-                            OTHER_TIMERS_SECONDS.timer_with(&["calculate_batches_for_shards"]);
-
-                        let shard_persisted_versions = self
-                            .state_db
-                            .state_merkle_db
-                            .get_shard_persisted_versions(base_version)
-                            .unwrap();
-
-                        let min_version = self.last_snapshot.next_version();
-
-                        THREAD_MANAGER.get_non_exe_cpu_pool().install(|| {
-                            snapshot
-                                .make_delta(&self.last_snapshot)
-                                .shards
-                                .par_iter()
-                                .enumerate()
-                                .map(|(shard_id, updates)| {
-                                    let node_hashes = snapshot
-                                        .summary()
-                                        .global_state_summary
-                                        .new_node_hashes_since(
-                                            &self.last_snapshot.summary().global_state_summary,
-                                            shard_id as u8,
-                                        );
-                                    // TODO(aldenhu): iterator of refs
-                                    let updates = {
-                                        let _timer =
-                                            OTHER_TIMERS_SECONDS.timer_with(&["hash_jmt_updates"]);
-
-                                        updates
-                                            .iter()
-                                            .filter_map(|(key, slot)| {
-                                                slot.maybe_update_jmt(key, min_version)
-                                            })
-                                            .collect_vec()
-                                    };
-
-                                    self.state_db.state_merkle_db.merklize_value_set_for_shard(
-                                        shard_id,
-                                        jmt_update_refs(&updates),
-                                        Some(&node_hashes),
-                                        version,
-                                        base_version,
-                                        shard_persisted_versions[shard_id],
-                                        previous_epoch_ending_version,
-                                    )
-                                })
-                                .collect::<Result<Vec<_>>>()
-                                .expect("Error calculating StateMerkleBatch for shards.")
-                                .into_iter()
-                                .unzip()
+                    let (hot_updates, all_updates): (Vec<_>, Vec<_>) = snapshot
+                        .make_delta(&self.last_snapshot)
+                        .shards
+                        .iter()
+                        .map(|updates| {
+                            let _timer = OTHER_TIMERS_SECONDS.timer_with(&["hash_jmt_updates"]);
+                            let mut hot_updates = Vec::new();
+                            let mut all_updates = Vec::new();
+                            for (key, slot) in updates.iter() {
+                                if slot.is_hot() {
+                                    hot_updates.push((
+                                        CryptoHash::hash(&key),
+                                        slot.as_state_value_opt()
+                                            .map(|value| (CryptoHash::hash(value), key.clone())),
+                                    ));
+                                } else {
+                                    hot_updates.push((CryptoHash::hash(&key), None));
+                                }
+                                if let Some(value) = slot.maybe_update_jmt(key, min_version) {
+                                    all_updates.push(value);
+                                }
+                            }
+                            (hot_updates, all_updates)
                         })
-                    };
+                        .unzip();
 
-                    let (root_hash, leaf_count, top_levels_batch) = {
-                        let _timer =
-                            OTHER_TIMERS_SECONDS.timer_with(&["calculate_top_levels_batch"]);
-                        self.state_db
-                            .state_merkle_db
-                            .calculate_top_levels(
-                                shard_root_nodes,
-                                version,
+                    // TODO(HotState): for now we use `is_descendant_of` to determine if hot state
+                    // summary is computed at all. When it's not enabled everything is
+                    // `SparseMerkleTree::new_empty()`.
+                    let hot_state_merkle_batch_opt = if snapshot
+                        .summary()
+                        .hot_state_summary
+                        .is_descendant_of(&self.last_snapshot.summary().hot_state_summary)
+                    {
+                        self.state_db.hot_state_merkle_db.as_ref().map(|db| {
+                            Self::merklize(
+                                db,
                                 base_version,
+                                version,
+                                &self.last_snapshot.summary().hot_state_summary,
+                                &snapshot.summary().hot_state_summary,
+                                hot_updates.try_into().expect("Must be 16 shards."),
                                 previous_epoch_ending_version,
                             )
-                            .expect("Error calculating StateMerkleBatch for top levels.")
+                            .expect("Failed to compute JMT commit batch for hot state.")
+                            .0
+                        })
+                    } else {
+                        // TODO(HotState): this means that the relevant code path isn't enabled yet.
+                        None
                     };
-                    assert_eq!(
-                        root_hash,
-                        snapshot.summary().root_hash(),
-                        "root hash mismatch: jmt: {}, smt: {}",
-                        root_hash,
-                        snapshot.summary().root_hash(),
-                    );
-
+                    let (state_merkle_batch, leaf_count) = Self::merklize(
+                        &self.state_db.state_merkle_db,
+                        base_version,
+                        version,
+                        &self.last_snapshot.summary().global_state_summary,
+                        &snapshot.summary().global_state_summary,
+                        all_updates.try_into().expect("Must be 16 shards."),
+                        previous_epoch_ending_version,
+                    )
+                    .expect("Failed to compute JMT commit batch.");
                     let usage = snapshot.state().usage();
                     if !usage.is_untracked() {
                         assert_eq!(
@@ -182,10 +174,10 @@ impl StateSnapshotCommitter {
                     self.last_snapshot = snapshot.clone();
 
                     self.state_merkle_batch_commit_sender
-                        .send(CommitMessage::Data(StateMerkleBatch {
-                            top_levels_batch,
-                            batches_for_shards,
+                        .send(CommitMessage::Data(StateMerkleCommit {
                             snapshot,
+                            hot_batch: hot_state_merkle_batch_opt,
+                            cold_batch: state_merkle_batch,
                         }))
                         .unwrap();
                 },
@@ -203,6 +195,65 @@ impl StateSnapshotCommitter {
             }
         }
         info!("State snapshot committing thread exit.");
+    }
+
+    fn merklize(
+        db: &StateMerkleDb,
+        base_version: Option<Version>,
+        version: Version,
+        last_smt: &SparseMerkleTree,
+        smt: &SparseMerkleTree,
+        all_updates: [Vec<(HashValue, Option<(HashValue, StateKey)>)>; NUM_STATE_SHARDS],
+        previous_epoch_ending_version: Option<Version>,
+    ) -> Result<(StateMerkleBatch, usize)> {
+        let shard_persisted_versions = db.get_shard_persisted_versions(base_version)?;
+
+        let (shard_root_nodes, batches_for_shards) =
+            THREAD_MANAGER.get_non_exe_cpu_pool().install(|| {
+                let _timer = OTHER_TIMERS_SECONDS.timer_with(&["calculate_batches_for_shards"]);
+                all_updates
+                    .par_iter()
+                    .enumerate()
+                    .map(|(shard_id, updates)| {
+                        let node_hashes = smt.new_node_hashes_since(last_smt, shard_id as u8);
+                        db.merklize_value_set_for_shard(
+                            shard_id,
+                            jmt_update_refs(updates),
+                            Some(&node_hashes),
+                            version,
+                            base_version,
+                            shard_persisted_versions[shard_id],
+                            previous_epoch_ending_version,
+                        )
+                    })
+                    .collect::<Result<Vec<_>>>()
+                    .expect("Error calculating StateMerkleBatch for shards.")
+                    .into_iter()
+                    .unzip()
+            });
+
+        let _timer = OTHER_TIMERS_SECONDS.timer_with(&["calculate_top_levels_batch"]);
+        let (root_hash, leaf_count, top_levels_batch) = db.calculate_top_levels(
+            shard_root_nodes,
+            version,
+            base_version,
+            previous_epoch_ending_version,
+        )?;
+        assert_eq!(
+            root_hash,
+            smt.root_hash(),
+            "root hash mismatch: jmt: {}, smt: {}",
+            root_hash,
+            smt.root_hash()
+        );
+
+        Ok((
+            StateMerkleBatch {
+                top_levels_batch,
+                batches_for_shards,
+            },
+            leaf_count,
+        ))
     }
 }
 

--- a/storage/aptosdb/src/state_store/tests/speculative_state_workflow.rs
+++ b/storage/aptosdb/src/state_store/tests/speculative_state_workflow.rs
@@ -14,6 +14,7 @@ use aptos_storage_interface::{
         state_update_refs::StateUpdateRefs,
         state_view::cached_state_view::CachedStateView,
         state_with_summary::{LedgerStateWithSummary, StateWithSummary},
+        HotStateUpdates,
     },
     DbReader, Result as DbResult,
 };
@@ -56,6 +57,7 @@ const REFRESH_INTERVAL_VERSIONS: usize = 50;
 const TEST_CONFIG: HotStateConfig = HotStateConfig {
     max_items_per_shard: HOT_STATE_MAX_ITEMS_PER_SHARD,
     delete_on_restart: false,
+    compute_root_hash: true,
 };
 
 #[derive(Debug)]
@@ -168,6 +170,7 @@ struct VersionState {
     usage: StateStorageUsage,
     hot_state: [LruCache<StateKey, StateSlot>; NUM_STATE_SHARDS],
     state: HashMap<StateKey, (Version, StateValue)>,
+    hot_summary: NaiveSmt,
     summary: NaiveSmt,
     next_version: Version,
 }
@@ -178,6 +181,7 @@ impl VersionState {
             usage: StateStorageUsage::zero(),
             hot_state: [(); NUM_STATE_SHARDS].map(|_| LruCache::unbounded()),
             state: HashMap::new(),
+            hot_summary: NaiveSmt::default(),
             summary: NaiveSmt::default(),
             next_version: 0,
         }
@@ -194,6 +198,7 @@ impl VersionState {
 
         let mut hot_state = self.hot_state.clone();
         let mut state = self.state.clone();
+        let mut hot_smt_updates = vec![];
         let mut smt_updates = vec![];
 
         for (k, v_opt) in writes {
@@ -206,6 +211,7 @@ impl VersionState {
                     };
                     hot_state[shard_id].put(k.clone(), slot);
                     state.remove(k);
+                    hot_smt_updates.push((k.hash(), None));
                     smt_updates.push((k.hash(), None));
                 },
                 Some(v) => {
@@ -217,6 +223,7 @@ impl VersionState {
                     };
                     hot_state[shard_id].put(k.clone(), slot);
                     state.insert(k.clone(), (version, v.clone()));
+                    hot_smt_updates.push((k.hash(), Some(v.hash())));
                     smt_updates.push((k.hash(), Some(v.hash())));
                 },
             }
@@ -241,17 +248,20 @@ impl VersionState {
                     lru_info: LRUEntry::uninitialized(),
                 },
             };
+            hot_smt_updates.push((k.hash(), slot.as_state_value_opt().map(|v| v.hash())));
             hot_state[shard_id].put(k.clone(), slot);
         }
 
         if is_checkpoint {
             for shard in hot_state.iter_mut() {
                 while shard.len() > HOT_STATE_MAX_ITEMS_PER_SHARD {
-                    shard.pop_lru();
+                    let (k, _) = shard.pop_lru().unwrap();
+                    hot_smt_updates.push((k.hash(), None));
                 }
             }
         }
 
+        let hot_summary = self.hot_summary.clone().update(&hot_smt_updates);
         let summary = self.summary.clone().update(&smt_updates);
 
         let items = state.len();
@@ -262,6 +272,7 @@ impl VersionState {
             usage,
             hot_state,
             state,
+            hot_summary,
             summary,
             next_version: version + 1,
         }
@@ -373,6 +384,12 @@ impl StateByVersion {
     }
 
     fn assert_state_summary(&self, state_summary: &StateSummary) {
+        assert_eq!(
+            state_summary.hot_root_hash(),
+            self.get_state(state_summary.version())
+                .hot_summary
+                .get_root_hash()
+        );
         assert_eq!(
             state_summary.root_hash(),
             self.get_state(state_summary.version())
@@ -492,7 +509,7 @@ fn update_state(
     state_by_version: Arc<StateByVersion>,
     empty: LedgerStateWithSummary,
     persisted_state: PersistedState,
-    to_summary_update: Sender<(Chunk, LedgerState)>,
+    to_summary_update: Sender<(Chunk, LedgerState, HotStateUpdates)>,
 ) {
     let pool = rayon::ThreadPoolBuilder::new()
         .num_threads(4)
@@ -524,7 +541,7 @@ fn update_state(
         });
         let memorized_reads = state_view.into_memorized_reads();
 
-        let next_state = parent_state.update_with_memorized_reads(
+        let (next_state, hot_state_updates) = parent_state.update_with_memorized_reads(
             hot_state.clone(),
             &persisted_state,
             block.update_refs(),
@@ -536,7 +553,7 @@ fn update_state(
         parent_state = next_state.clone();
 
         to_summary_update
-            .send((block, next_state))
+            .send((block, next_state, hot_state_updates))
             .expect("send() failed.");
     }
 
@@ -548,17 +565,18 @@ fn update_state_summary(
     state_by_version: Arc<StateByVersion>,
     empty: LedgerStateWithSummary,
     persisted_state: PersistedState,
-    from_state_update: Receiver<(Chunk, LedgerState)>,
+    from_state_update: Receiver<(Chunk, LedgerState, HotStateUpdates)>,
     to_db_commit: Sender<LedgerStateWithSummary>,
 ) {
     let mut parent_summary = empty.ledger_state_summary();
 
-    while let Ok((block, ledger_state)) = from_state_update.recv() {
+    while let Ok((block, ledger_state, hot_state_updates)) = from_state_update.recv() {
         let persisted_summary = persisted_state.get_state_summary();
 
         let next_summary = parent_summary
             .update(
                 &ProvableStateSummary::new(persisted_summary, state_by_version.as_ref()),
+                &hot_state_updates,
                 block.update_refs(),
             )
             .unwrap();
@@ -667,7 +685,7 @@ fn naive_run_blocks(blocks: Vec<(Vec<UserTxn>, bool)>) -> (Vec<Txn>, StateByVers
                         Some(v) => (k, WriteOp::modification_to_value(v).into_base_op()),
                     })
                     .collect(),
-                is_checkpoint: false,
+                is_checkpoint,
             });
         }
         if append_epilogue {
@@ -695,7 +713,7 @@ fn replay_chunks_pipelined(chunks: Vec<Chunk>, state_by_version: Arc<StateByVers
     let empty = LedgerStateWithSummary::new_empty(TEST_CONFIG);
     let current_state = Arc::new(Mutex::new(empty.clone()));
 
-    let persisted_state = PersistedState::new_empty_with_config(TEST_CONFIG);
+    let persisted_state = PersistedState::new_empty(TEST_CONFIG);
     persisted_state.hack_reset(empty.deref().clone());
 
     let (to_summary_update, from_state_update) = channel();

--- a/storage/db-tool/src/bootstrap.rs
+++ b/storage/db-tool/src/bootstrap.rs
@@ -3,7 +3,7 @@
 
 use anyhow::{ensure, format_err, Context, Result};
 use aptos_config::config::{
-    RocksdbConfigs, StorageDirPaths, BUFFERED_STATE_TARGET_ITEMS,
+    HotStateConfig, RocksdbConfigs, StorageDirPaths, BUFFERED_STATE_TARGET_ITEMS,
     DEFAULT_MAX_NUM_NODES_PER_LRU_CACHE_SHARD, NO_OP_STORAGE_PRUNER_CONFIG,
 };
 use aptos_db::AptosDB;
@@ -57,7 +57,7 @@ impl Command {
             BUFFERED_STATE_TARGET_ITEMS,
             DEFAULT_MAX_NUM_NODES_PER_LRU_CACHE_SHARD,
             None,
-            /* reset_hot_state = */ true,
+            HotStateConfig::default(),
         )
         .expect("Failed to open DB.");
         let db = DbReaderWriter::new(db);

--- a/storage/db-tool/src/replay_on_archive.rs
+++ b/storage/db-tool/src/replay_on_archive.rs
@@ -5,8 +5,8 @@ use anyhow::{bail, Error, Ok, Result};
 use aptos_backup_cli::utils::{ReplayConcurrencyLevelOpt, RocksdbOpt};
 use aptos_block_executor::txn_provider::default::DefaultTxnProvider;
 use aptos_config::config::{
-    StorageDirPaths, BUFFERED_STATE_TARGET_ITEMS, DEFAULT_MAX_NUM_NODES_PER_LRU_CACHE_SHARD,
-    NO_OP_STORAGE_PRUNER_CONFIG,
+    HotStateConfig, StorageDirPaths, BUFFERED_STATE_TARGET_ITEMS,
+    DEFAULT_MAX_NUM_NODES_PER_LRU_CACHE_SHARD, NO_OP_STORAGE_PRUNER_CONFIG,
 };
 use aptos_db::{backup::backup_handler::BackupHandler, AptosDB};
 use aptos_logger::prelude::*;
@@ -160,7 +160,7 @@ impl Verifier {
                     BUFFERED_STATE_TARGET_ITEMS,
                     DEFAULT_MAX_NUM_NODES_PER_LRU_CACHE_SHARD,
                     None,
-                    /* reset_hot_state = */ true,
+                    HotStateConfig::default(),
                 )
             }) {
                 warn!("Unable to open AptosDB in write mode: {:?}", e);
@@ -176,7 +176,10 @@ impl Verifier {
             BUFFERED_STATE_TARGET_ITEMS,
             DEFAULT_MAX_NUM_NODES_PER_LRU_CACHE_SHARD,
             None,
-            /* reset_hot_state = */ false,
+            HotStateConfig {
+                delete_on_restart: false,
+                ..Default::default()
+            },
         )?;
 
         let backup_handler = aptos_db.get_backup_handler();

--- a/storage/db-tool/src/tests.rs
+++ b/storage/db-tool/src/tests.rs
@@ -80,6 +80,7 @@ mod dbtool_tests {
         storage::{local_fs::LocalFs, BackupStorage},
         utils::test_utils::start_local_backup_service,
     };
+    use aptos_config::config::HotStateConfig;
     use aptos_db::AptosDB;
     use aptos_executor_test_helpers::integration_test_impl::{
         test_execution_with_storage_impl, test_execution_with_storage_impl_inner,
@@ -468,7 +469,7 @@ mod dbtool_tests {
                 BUFFERED_STATE_TARGET_ITEMS_FOR_TEST,
                 1000,
                 Some(internal_indexer_db.clone()),
-                /* reset_hot_state = */ true,
+                HotStateConfig::default(),
             )
             .unwrap(),
         );

--- a/storage/jellyfish-merkle/src/lib.rs
+++ b/storage/jellyfish-merkle/src/lib.rs
@@ -475,6 +475,7 @@ where
                         }
                     }
                 },
+                Node::Null => (), // Possible in hot state since we start from a non-zero version.
                 _ => {
                     unreachable!("Assume the db doesn't have exactly 1 state.")
                 },

--- a/storage/storage-interface/src/ledger_summary.rs
+++ b/storage/storage-interface/src/ledger_summary.rs
@@ -41,7 +41,7 @@ impl LedgerSummary {
 
     pub fn new_empty(hot_state_config: HotStateConfig) -> Self {
         let state = LedgerState::new_empty(hot_state_config);
-        let state_summary = LedgerStateSummary::new_empty();
+        let state_summary = LedgerStateSummary::new_empty(hot_state_config);
         Self::new(
             state,
             state_summary,

--- a/storage/storage-interface/src/state_store/mod.rs
+++ b/storage/storage-interface/src/state_store/mod.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-// TODO(HotState): remove.
-#[allow(dead_code)]
 mod hot_state;
 pub mod state;
 pub mod state_delta;
@@ -11,3 +9,41 @@ pub mod state_update_refs;
 pub mod state_view;
 pub mod state_with_summary;
 pub mod versioned_state_value;
+
+use aptos_types::state_store::{state_key::StateKey, state_value::StateValue, NUM_STATE_SHARDS};
+use std::collections::HashMap;
+
+// TODO(HotState): this isn't the final form yet. For instance, `HotVacant` entries probably should
+// be included, but right now they are `None` in these and will be removed from the Merkle trees.
+#[derive(Debug)]
+pub(crate) struct HotStateShardUpdates {
+    insertions: HashMap<StateKey, Option<StateValue>>,
+    evictions: HashMap<StateKey, Option<StateValue>>,
+}
+
+impl HotStateShardUpdates {
+    pub fn new(
+        insertions: HashMap<StateKey, Option<StateValue>>,
+        evictions: HashMap<StateKey, Option<StateValue>>,
+    ) -> Self {
+        Self {
+            insertions,
+            evictions,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct HotStateUpdates {
+    for_last_checkpoint: Option<[HotStateShardUpdates; NUM_STATE_SHARDS]>,
+    for_latest: Option<[HotStateShardUpdates; NUM_STATE_SHARDS]>,
+}
+
+impl HotStateUpdates {
+    pub fn new_empty() -> Self {
+        Self {
+            for_last_checkpoint: None,
+            for_latest: None,
+        }
+    }
+}

--- a/storage/storage-interface/src/state_store/state.rs
+++ b/storage/storage-interface/src/state_store/state.rs
@@ -14,6 +14,7 @@ use crate::{
             hot_state_view::HotStateView,
         },
         versioned_state_value::StateUpdateRef,
+        HotStateShardUpdates, HotStateUpdates,
     },
     DbReader,
 };
@@ -24,7 +25,7 @@ use aptos_metrics_core::TimerHelper;
 use aptos_types::{
     state_store::{
         state_key::StateKey, state_slot::StateSlot, state_storage_usage::StateStorageUsage,
-        StateViewId, NUM_STATE_SHARDS,
+        state_value::StateValue, StateViewId, NUM_STATE_SHARDS,
     },
     transaction::Version,
 };
@@ -156,7 +157,7 @@ impl State {
         per_version_updates: &PerVersionStateUpdateRefs,
         all_checkpoint_versions: &[Version],
         state_cache: &ShardedStateCache,
-    ) -> Self {
+    ) -> (Self, [HotStateShardUpdates; NUM_STATE_SHARDS]) {
         let _timer = TIMER.timer_with(&["state__update"]);
 
         // 1. The update batch must begin at self.next_version().
@@ -176,7 +177,10 @@ impl State {
         assert!(self.next_version() >= state_cache.next_version());
 
         let overlay = self.make_delta(persisted);
-        let ((shards, new_metadata), usage_delta_per_shard): ((Vec<_>, Vec<_>), Vec<_>) = (
+        let (((shards, new_metadata), usage_delta_per_shard), hot_state_updates): (
+            ((Vec<_>, Vec<_>), Vec<_>),
+            Vec<_>,
+        ) = (
             state_cache.shards.as_slice(),
             overlay.shards.as_slice(),
             self.hot_state_metadata.as_slice(),
@@ -195,17 +199,31 @@ impl State {
                         hot_metadata.num_items,
                     );
                     let mut all_updates = per_version.iter();
+                    let mut insertions = HashMap::new();
+                    let mut evictions = HashMap::new();
                     for ckpt_version in all_checkpoint_versions {
                         for (key, update) in
                             all_updates.take_while_ref(|(_k, u)| u.version <= *ckpt_version)
                         {
-                            Self::apply_one_update(&mut lru, overlay, cache, key, update);
+                            evictions.remove(*key);
+                            insertions.insert(
+                                (*key).clone(),
+                                Self::apply_one_update(&mut lru, overlay, cache, key, update),
+                            );
                         }
                         // Only evict at the checkpoints.
-                        lru.maybe_evict();
+                        evictions.extend(lru.maybe_evict().into_iter().map(|(key, slot)| {
+                            insertions.remove(&key);
+                            assert!(slot.is_hot());
+                            (key, slot.into_state_value_opt())
+                        }));
                     }
                     for (key, update) in all_updates {
-                        Self::apply_one_update(&mut lru, overlay, cache, key, update);
+                        evictions.remove(*key);
+                        insertions.insert(
+                            (*key).clone(),
+                            Self::apply_one_update(&mut lru, overlay, cache, key, update),
+                        );
                     }
 
                     let (new_items, new_head, new_tail, new_num_items) = lru.into_updates();
@@ -219,21 +237,30 @@ impl State {
                         num_items: new_num_items,
                     };
                     let new_usage = Self::usage_delta_for_shard(cache, overlay, batched_updates);
-                    ((new_layer, new_metadata), new_usage)
+                    (
+                        ((new_layer, new_metadata), new_usage),
+                        HotStateShardUpdates::new(insertions, evictions),
+                    )
                 },
             )
             .unzip();
         let shards = Arc::new(shards.try_into().expect("Known to be 16 shards."));
         let new_metadata = new_metadata.try_into().expect("Known to be 16 shards.");
         let usage = self.update_usage(usage_delta_per_shard);
+        let hot_state_updates = hot_state_updates
+            .try_into()
+            .expect("Known to be 16 shards.");
 
         // TODO(HotState): extract and pass new hot state onchain config if needed.
-        State::new_with_updates(
-            batched_updates.last_version(),
-            shards,
-            new_metadata,
-            usage,
-            self.hot_state_config,
+        (
+            State::new_with_updates(
+                batched_updates.last_version(),
+                shards,
+                new_metadata,
+                usage,
+                self.hot_state_config,
+            ),
+            hot_state_updates,
         )
     }
 
@@ -243,26 +270,28 @@ impl State {
         read_cache: &StateCacheShard,
         key: &StateKey,
         update: &StateUpdateRef,
-    ) {
-        if update.state_op.is_value_write_op() {
+    ) -> Option<StateValue> {
+        if let Some(state_value_opt) = update.state_op.as_state_value_opt() {
             lru.insert((*key).clone(), update.to_result_slot().unwrap());
-            return;
+            return state_value_opt.cloned();
         }
 
         if let Some(mut slot) = lru.get_slot(key) {
-            lru.insert(
-                (*key).clone(),
-                if slot.is_hot() {
-                    slot.refresh(update.version);
-                    slot
-                } else {
-                    slot.to_hot(update.version)
-                },
-            );
+            let slot_to_insert = if slot.is_hot() {
+                slot.refresh(update.version);
+                slot
+            } else {
+                slot.to_hot(update.version)
+            };
+            let ret = slot_to_insert.as_state_value_opt().cloned();
+            lru.insert((*key).clone(), slot_to_insert);
+            ret
         } else {
             let slot = Self::expect_old_slot(overlay, read_cache, key);
             assert!(slot.is_cold());
+            let ret = slot.as_state_value_opt().cloned();
             lru.insert((*key).clone(), slot.to_hot(update.version));
+            ret
         }
     }
 
@@ -369,21 +398,24 @@ impl LedgerState {
         persisted_snapshot: &State,
         updates: &StateUpdateRefs,
         reads: &ShardedStateCache,
-    ) -> LedgerState {
+    ) -> (LedgerState, HotStateUpdates) {
         let _timer = TIMER.timer_with(&["ledger_state__update"]);
 
+        let mut all_hot_state_updates = HotStateUpdates::new_empty();
         let last_checkpoint = if let Some(batched) = updates.for_last_checkpoint_batched() {
             let per_version = updates
                 .for_last_checkpoint_per_version()
                 .expect("Both per-version and batched updates should exist.");
-            self.latest().update(
+            let (new_ckpt, hot_state_updates) = self.latest().update(
                 Arc::clone(&persisted_hot_view),
                 persisted_snapshot,
                 batched,
                 per_version,
                 updates.all_checkpoint_versions(),
                 reads,
-            )
+            );
+            all_hot_state_updates.for_last_checkpoint = Some(hot_state_updates);
+            new_ckpt
         } else {
             self.last_checkpoint.clone()
         };
@@ -397,19 +429,24 @@ impl LedgerState {
             let per_version = updates
                 .for_latest_per_version()
                 .expect("Both per-version and batched updates should exist.");
-            base_of_latest.update(
+            let (new_latest, hot_state_updates) = base_of_latest.update(
                 persisted_hot_view,
                 persisted_snapshot,
                 batched,
                 per_version,
                 &[],
                 reads,
-            )
+            );
+            all_hot_state_updates.for_latest = Some(hot_state_updates);
+            new_latest
         } else {
             base_of_latest.clone()
         };
 
-        LedgerState::new(latest, last_checkpoint)
+        (
+            LedgerState::new(latest, last_checkpoint),
+            all_hot_state_updates,
+        )
     }
 
     /// Old values of the updated keys are read from the DbReader at the version of the
@@ -420,7 +457,7 @@ impl LedgerState {
         hot_state: Arc<dyn HotStateView>,
         updates: &StateUpdateRefs,
         reader: Arc<dyn DbReader>,
-    ) -> Result<(LedgerState, ShardedStateCache)> {
+    ) -> Result<(LedgerState, ShardedStateCache, HotStateUpdates)> {
         let state_view = CachedStateView::new_impl(
             StateViewId::Miscellaneous,
             reader,
@@ -430,14 +467,14 @@ impl LedgerState {
         );
         state_view.prime_cache(updates, PrimingPolicy::All)?;
 
-        let updated = self.update_with_memorized_reads(
+        let (updated, hot_state_updates) = self.update_with_memorized_reads(
             hot_state,
             persisted_snapshot,
             updates,
             state_view.memorized_reads(),
         );
         let state_reads = state_view.into_memorized_reads();
-        Ok((updated, state_reads))
+        Ok((updated, state_reads, hot_state_updates))
     }
 
     pub fn is_the_same(&self, other: &Self) -> bool {

--- a/storage/storage-interface/src/state_store/state_with_summary.rs
+++ b/storage/storage-interface/src/state_store/state_with_summary.rs
@@ -27,7 +27,7 @@ impl StateWithSummary {
     pub fn new_empty(hot_state_config: HotStateConfig) -> Self {
         Self::new(
             State::new_empty(hot_state_config),
-            StateSummary::new_empty(),
+            StateSummary::new_empty(hot_state_config),
         )
     }
 
@@ -44,6 +44,7 @@ impl StateWithSummary {
                 version,
                 SparseMerkleTree::new(hot_state_root_hash),
                 SparseMerkleTree::new(global_state_root_hash),
+                hot_state_config,
             ),
         )
     }


### PR DESCRIPTION

This commit implements the logic to compute root hashes for hot state. It's an initial version with a number of TODO items, but it's a reasonable start. Most of the logic is gated behind a flag so we are not enabling this in mainnet yet, until we run things in testnet for some time and gain more confidence.

How this roughly works:
- `State::update` computes the changes to hot state. They are saved in `ExecutionOutput`.
- The above changes are passed to `StateSummary::update` and used to compute in-memory `SparseMerkleTree`.
- The resulting Merkle trees are committed to persisted database (`hot_state_merkle_db` introduced in #18385) so the proofs can be used in turn for future `StateSummary::update`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements hot state Merkle root computation and persistence, plus plumbs a new config across storage and execution.
> 
> - Introduces `HotStateConfig { max_items_per_shard, delete_on_restart, compute_root_hash }` and replaces `reset_hot_state` param in `AptosDB::open`; updates all call sites and tools/tests
> - Execution pipeline now emits `HotStateUpdates`; `State::update` produces hot-state changes; `StateSummary::update` computes both hot/global SMTs; state checkpointing commits hot and cold JMT batches (to `hot_state_merkle_db` and main JMT) and validates usage
> - Adds gating: `compute_root_hash` default true but auto-disabled on Mainnet unless explicitly enabled; readonly/debug paths set `delete_on_restart=false`
> - Storage init/restore and proofs updated (e.g., null node handling, hot/cold proof selection); API/types extended accordingly
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 389074b56ad2337eb573df66c448fb0c7002239f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->