### PR TITLE
[aptos cli] set language version 2.3 as stable and release cli 7.13.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,7 +304,7 @@ dependencies = [
 
 [[package]]
 name = "aptos"
-version = "7.12.1"
+version = "7.13.0"
 dependencies = [
  "anyhow",
  "aptos-api-types",

--- a/crates/aptos/CHANGELOG.md
+++ b/crates/aptos/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to the Aptos CLI will be captured in this file. This project
 
 # Unreleased
 
+## [7.13.0]
+- Set language version 2.3 as stable, which adds support for signed integer types.
+
 ## [7.12.1]
 - Fix link time optimization issues with Aptos CLI released via homebrew.
 

--- a/crates/aptos/Cargo.toml
+++ b/crates/aptos/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aptos"
 description = "Aptos tool for management of nodes and interacting with the blockchain"
-version = "7.12.1"
+version = "7.13.0"
 
 # Workspace inherited keys
 authors = { workspace = true }

--- a/third_party/move/move-model/src/builder/builtins.rs
+++ b/third_party/move/move-model/src/builder/builtins.rs
@@ -8,7 +8,9 @@ use crate::{
     ast::{Operation, TraceKind, Value},
     builder::model_builder::{ConstEntry, EntryVisibility, ModelBuilder, SpecOrBuiltinFunEntry},
     metadata::{
-        lang_feature_versions::{COMPILE_FOR_TESTING_VALUE, SINT_LANGUAGE_VERSION_VALUE},
+        lang_feature_versions::{
+            LANGUAGE_VERSION_FOR_COMPILE_FOR_TESTING, LANGUAGE_VERSION_FOR_SINT,
+        },
         LanguageVersion,
     },
     model::{Parameter, TypeParameter, TypeParameterKind},
@@ -68,7 +70,7 @@ pub(crate) fn declare_builtins(trans: &mut ModelBuilder) {
     {
         if options
             .language_version
-            .is_at_least(COMPILE_FOR_TESTING_VALUE)
+            .is_at_least(LANGUAGE_VERSION_FOR_COMPILE_FOR_TESTING)
         {
             use EntryVisibility::SpecAndImpl;
             // Compiler builtin constants.
@@ -590,7 +592,7 @@ pub(crate) fn declare_builtins(trans: &mut ModelBuilder) {
         );
         if options
             .language_version
-            .is_at_least(SINT_LANGUAGE_VERSION_VALUE)
+            .is_at_least(LANGUAGE_VERSION_FOR_SINT)
         {
             trans.define_spec_or_builtin_fun(
                 trans.unary_op_symbol(&PA::UnaryOp_::Negate),

--- a/third_party/move/move-model/src/builder/exp_builder.rs
+++ b/third_party/move/move-model/src/builder/exp_builder.rs
@@ -15,7 +15,7 @@ use crate::{
         module_builder::{ModuleBuilder, SpecBlockContext},
     },
     metadata::{
-        lang_feature_versions::{LANGUAGE_VERSION_FOR_RAC, SINT_LANGUAGE_VERSION_VALUE},
+        lang_feature_versions::{LANGUAGE_VERSION_FOR_RAC, LANGUAGE_VERSION_FOR_SINT},
         LanguageVersion,
     },
     model::{
@@ -947,11 +947,11 @@ impl ExpTranslator<'_, '_, '_> {
                         if !self
                             .env()
                             .language_version
-                            .is_at_least(SINT_LANGUAGE_VERSION_VALUE)
+                            .is_at_least(LANGUAGE_VERSION_FOR_SINT)
                         {
                             et.error(
                                 loc,
-                                &format!("signed integer types not supported prior to language version {}", SINT_LANGUAGE_VERSION_VALUE.to_str()),
+                                &format!("signed integer types not supported prior to language version {}", LANGUAGE_VERSION_FOR_SINT.to_str()),
                             );
                             Type::Error
                         } else {

--- a/third_party/move/move-model/src/metadata.rs
+++ b/third_party/move/move-model/src/metadata.rs
@@ -15,22 +15,28 @@ use std::{
 };
 
 const UNSTABLE_MARKER: &str = "-unstable";
-// 2.2, even though stable, produces several warnings in the frameworks which we first need to fix
-// before we can make it the default
+
+pub const LATEST_LANGUAGE_VERSION_VALUE: LanguageVersion = LanguageVersion::V2_5;
+
+/// Only stable versions are allowed on production networks
 pub const LATEST_STABLE_LANGUAGE_VERSION_VALUE: LanguageVersion = LanguageVersion::V2_2;
-pub const LATEST_STABLE_COMPILER_VERSION_VALUE: CompilerVersion = CompilerVersion::V2_0;
 pub const LATEST_STABLE_LANGUAGE_VERSION: &str = LATEST_STABLE_LANGUAGE_VERSION_VALUE.to_str();
+
+pub const LATEST_STABLE_COMPILER_VERSION_VALUE: CompilerVersion = CompilerVersion::V2_0;
 pub const LATEST_STABLE_COMPILER_VERSION: &str = LATEST_STABLE_COMPILER_VERSION_VALUE.to_str();
 
 pub static COMPILATION_METADATA_KEY: &[u8] = "compilation_metadata".as_bytes();
 
-// Language versions enabling specific features
+/// Language versions enabling specific features
 pub mod lang_feature_versions {
     use crate::LanguageVersion;
-    pub const COMPILE_FOR_TESTING_VALUE: LanguageVersion = LanguageVersion::V2_2;
-    pub const SINT_LANGUAGE_VERSION_VALUE: LanguageVersion = LanguageVersion::V2_3;
+    /// This version guards built-in constant `__COMPILE_FOR_TESTING__`,
+    /// which is set to `true` when the code is compiled for testing purposes.
+    pub const LANGUAGE_VERSION_FOR_COMPILE_FOR_TESTING: LanguageVersion = LanguageVersion::V2_2;
+    pub const LANGUAGE_VERSION_FOR_SINT: LanguageVersion = LanguageVersion::V2_3;
     pub const LANGUAGE_VERSION_FOR_PUBLIC_STRUCT: LanguageVersion = LanguageVersion::V2_4;
-    pub const LANGUAGE_VERSION_FOR_RAC: LanguageVersion = LanguageVersion::V2_5;
+    pub const LANGUAGE_VERSION_FOR_RAC: LanguageVersion =
+        crate::metadata::LATEST_LANGUAGE_VERSION_VALUE;
 }
 
 // ================================================================================'
@@ -205,7 +211,8 @@ pub enum LanguageVersion {
     V2_1,
     /// The 2.2 version of Move
     V2_2,
-    /// The currently unstable 2.3 version of Move
+    /// The 2.3 version of Move, which adds support for
+    /// - signed integer types
     V2_3,
     /// The currently unstable 2.4 version of Move
     V2_4,
@@ -280,17 +287,18 @@ impl From<LanguageVersion> for CompilerLanguageVersion {
 impl LanguageVersion {
     /// Whether the language version is unstable. An unstable version
     /// should not be allowed on production networks.
+    /// 2.3 is marked as stable to allow signed integers on production; remove this comment after making it the default.
     pub const fn unstable(self) -> bool {
         use LanguageVersion::*;
         match self {
-            V1 | V2_0 | V2_1 | V2_2 => false,
-            V2_3 | V2_4 | V2_5 => true,
+            V1 | V2_0 | V2_1 | V2_2 | V2_3 => false,
+            V2_4 | V2_5 => true,
         }
     }
 
     /// The latest language version.
     pub const fn latest() -> Self {
-        LanguageVersion::V2_5
+        LATEST_LANGUAGE_VERSION_VALUE
     }
 
     /// The latest stable language version.


### PR DESCRIPTION
## Description
This PR sets language version 2.3 as stable. It also upgrades aptos cli to version 7.13.0.

Extra nits: the PR adjusts the names of certain constants that represent specific language versions to stay consistent.

## How Has This Been Tested?
Manually tested locally to ensure 
* the `unstable` field in `compilation_metadata` of compiled modules, with language version 2.3, is set to `false`

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [x] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Highlights**
> 
> - Sets Move language `v2.3` as stable (signed integer types enabled) and updates CLI to `7.13.0` (`crates/aptos/Cargo.toml`, `Cargo.lock`, `crates/aptos/CHANGELOG.md`).
> 
> **Compiler/metadata updates**
> 
> - Adds `LATEST_LANGUAGE_VERSION_VALUE` (`V2_5`) and updates `unstable()` so `V2_3` is no longer unstable; keeps `LATEST_STABLE_LANGUAGE_VERSION_VALUE` at `V2_2`.
> - Renames feature-gate constants to `LANGUAGE_VERSION_FOR_COMPILE_FOR_TESTING` and `LANGUAGE_VERSION_FOR_SINT`; updates `LANGUAGE_VERSION_FOR_RAC` to use `LATEST_LANGUAGE_VERSION_VALUE` (`third_party/move/move-model/src/metadata.rs`).
> 
> **Code references updated**
> 
> - Switches checks from old constants to new ones in `builder/builtins.rs` and `builder/exp_builder.rs`; adjusts related error message for signed integers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 484504851281e0b7bcdbce01086928ba7676f6cc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->