### PR TITLE
[Storage] Fix error message formatting in config

### DIFF
--- a/config/src/config/storage_config.rs
+++ b/config/src/config/storage_config.rs
@@ -696,8 +696,9 @@ impl ConfigSanitizer for StorageConfig {
                 if !ledger_db_path.is_absolute() {
                     return Err(Error::ConfigSanitizerFailed(
                         sanitizer_name,
-                        "Path {ledger_db_path:?} in db_path_overrides is not an absolute path."
-                            .to_string(),
+                        format!(
+                            "Path {ledger_db_path:?} in db_path_overrides is not an absolute path."
+                        ),
                     ));
                 }
             }
@@ -707,8 +708,7 @@ impl ConfigSanitizer for StorageConfig {
                     if !metadata_path.is_absolute() {
                         return Err(Error::ConfigSanitizerFailed(
                             sanitizer_name,
-                            "Path {metadata_path:?} in db_path_overrides is not an absolute path."
-                                .to_string(),
+                            format!("Path {metadata_path:?} in db_path_overrides is not an absolute path."),
                         ));
                     }
                 }
@@ -723,8 +723,7 @@ impl ConfigSanitizer for StorageConfig {
                     if !metadata_path.is_absolute() {
                         return Err(Error::ConfigSanitizerFailed(
                             sanitizer_name,
-                            "Path {metadata_path:?} in db_path_overrides is not an absolute path."
-                                .to_string(),
+                            format!("Path {metadata_path:?} in db_path_overrides is not an absolute path."),
                         ));
                     }
                 }


### PR DESCRIPTION

These error messages use a plain string literal which won't print the variables in them.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures path variables are interpolated in storage config validation errors.
> 
> - Replaces plain string literals with `format!(...)` in `StorageConfig::sanitize` for `ledger_db_path` and `metadata_path` checks under `db_path_overrides` in `storage_config.rs`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fa9abf0549a757f4137d81d5911b370373b08f76. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->