### PR TITLE
[tests][vm] Additional tests to increase code coverage of runtime reference safety checker

### DIFF
--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/borrow_global_conflicts.baseline.exp
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/borrow_global_conflicts.baseline.exp
@@ -1,0 +1,19 @@
+processed 2 tasks
+task 0 lines 1-35:  publish [module 0xc0ffee::global_test]
+Error: Unable to publish module '0000000000000000000000000000000000000000000000000000000000c0ffee::global_test'. Got VMError: {
+    major_status: GLOBAL_REFERENCE_ERROR,
+    sub_status: None,
+    location: 0xc0ffee::global_test,
+    indices: [(FunctionDefinition, 0)],
+    offsets: [(FunctionDefinitionIndex(0), 10)],
+}
+task 1 lines 37-37:  run 0xc0ffee::global_test::test_mut_borrow_with_existing_immut --signers 0x1 --verbose
+Error: Function execution failed with VMError: {
+    message: Linker Error: Module 0000000000000000000000000000000000000000000000000000000000c0ffee::global_test doesn't exist,
+    major_status: LINKER_ERROR,
+    sub_status: None,
+    location: undefined,
+    indices: [],
+    offsets: [],
+    exec_state: None,
+}

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/borrow_global_conflicts.masm
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/borrow_global_conflicts.masm
@@ -1,0 +1,37 @@
+//# publish
+module 0xc0ffee::global_test
+
+struct Resource has key+drop
+    value: u64
+
+// Test: Cannot borrow_global_mut while immutable reference exists
+public fun test_mut_borrow_with_existing_immut(s: &signer) acquires Resource
+    local res: Resource
+    local immut_ref: &Resource
+    local mut_ref: &mut Resource
+
+    // Setup: publish a resource
+    ld_u64 42
+    pack Resource
+    st_loc res
+    copy_loc s
+    move_loc res
+    move_to Resource
+
+    // Create immutable global reference
+    ld_const<address> 0x1
+    borrow_global Resource
+    st_loc immut_ref
+
+    // Try to create mutable global reference (should fail)
+    ld_const<address> 0x1
+    mut_borrow_global Resource
+    st_loc mut_ref
+
+    move_loc immut_ref
+    pop
+    move_loc mut_ref
+    pop
+    ret
+
+//# run 0xc0ffee::global_test::test_mut_borrow_with_existing_immut --signers 0x1 --verbose

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/borrow_global_conflicts.ref.exp
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/borrow_global_conflicts.ref.exp
@@ -1,0 +1,12 @@
+processed 2 tasks
+task 0 lines 1-35:  publish [module 0xc0ffee::global_test]
+task 1 lines 37-37:  run 0xc0ffee::global_test::test_mut_borrow_with_existing_immut --signers 0x1 --verbose
+Error: Function execution failed with VMError: {
+    message: Cannot borrow_global_mut while there are existing references,
+    major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
+    sub_status: Some(3),
+    location: 0xc0ffee::global_test,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 10)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/call_with_mut_and_immut_refs.baseline.exp
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/call_with_mut_and_immut_refs.baseline.exp
@@ -1,0 +1,19 @@
+processed 2 tasks
+task 0 lines 1-37:  publish [module 0xc0ffee::lock_mix_test]
+Error: Unable to publish module '0000000000000000000000000000000000000000000000000000000000c0ffee::lock_mix_test'. Got VMError: {
+    major_status: BORROWLOC_EXISTS_BORROW_ERROR,
+    sub_status: None,
+    location: 0xc0ffee::lock_mix_test,
+    indices: [(FunctionDefinition, 1)],
+    offsets: [(FunctionDefinitionIndex(1), 6)],
+}
+task 1 lines 39-39:  run 0xc0ffee::lock_mix_test::test_call_mut_and_immut_refs --verbose
+Error: Function execution failed with VMError: {
+    message: Linker Error: Module 0000000000000000000000000000000000000000000000000000000000c0ffee::lock_mix_test doesn't exist,
+    major_status: LINKER_ERROR,
+    sub_status: None,
+    location: undefined,
+    indices: [],
+    offsets: [],
+    exec_state: None,
+}

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/call_with_mut_and_immut_refs.masm
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/call_with_mut_and_immut_refs.masm
@@ -1,0 +1,39 @@
+//# publish
+module 0xc0ffee::lock_mix_test
+
+struct Data has drop
+    value: u64
+
+public fun callee(x: &mut u64, y: &u64)
+    ret
+
+// Test: Cannot call function with mut ref and immut ref to overlapping locations
+public fun test_call_mut_and_immut_refs(): u64
+    local data: Data
+    local mut_ref: &mut u64
+    local immut_ref: &u64
+
+    // Create data
+    ld_u64 42
+    pack Data
+    st_loc data
+
+    // Get mutable reference to field
+    mut_borrow_loc data
+    mut_borrow_field Data, value
+    st_loc mut_ref
+
+    // Get immutable reference to same field
+    borrow_loc data
+    borrow_field Data, value
+    st_loc immut_ref
+
+    // Try to call with both references (should fail - exclusive lock conflict)
+    move_loc mut_ref
+    move_loc immut_ref
+    call callee
+
+    ld_u64 0
+    ret
+
+//# run 0xc0ffee::lock_mix_test::test_call_mut_and_immut_refs --verbose

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/call_with_mut_and_immut_refs.ref.exp
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/call_with_mut_and_immut_refs.ref.exp
@@ -1,0 +1,12 @@
+processed 2 tasks
+task 0 lines 1-37:  publish [module 0xc0ffee::lock_mix_test]
+task 1 lines 39-39:  run 0xc0ffee::lock_mix_test::test_call_mut_and_immut_refs --verbose
+Error: Function execution failed with VMError: {
+    message: Exclusive lock conflict,
+    major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
+    sub_status: Some(3),
+    location: undefined,
+    indices: [],
+    offsets: [],
+    exec_state: None,
+}

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/call_with_overlapping_mut_refs.baseline.exp
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/call_with_overlapping_mut_refs.baseline.exp
@@ -1,0 +1,19 @@
+processed 2 tasks
+task 0 lines 1-36:  publish [module 0xc0ffee::lock_conflict_test]
+Error: Unable to publish module '0000000000000000000000000000000000000000000000000000000000c0ffee::lock_conflict_test'. Got VMError: {
+    major_status: CALL_BORROWED_MUTABLE_REFERENCE_ERROR,
+    sub_status: None,
+    location: 0xc0ffee::lock_conflict_test,
+    indices: [(FunctionDefinition, 1)],
+    offsets: [(FunctionDefinitionIndex(1), 11)],
+}
+task 1 lines 38-38:  run 0xc0ffee::lock_conflict_test::test_call_overlapping_mut_refs --verbose
+Error: Function execution failed with VMError: {
+    message: Linker Error: Module 0000000000000000000000000000000000000000000000000000000000c0ffee::lock_conflict_test doesn't exist,
+    major_status: LINKER_ERROR,
+    sub_status: None,
+    location: undefined,
+    indices: [],
+    offsets: [],
+    exec_state: None,
+}

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/call_with_overlapping_mut_refs.masm
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/call_with_overlapping_mut_refs.masm
@@ -1,0 +1,38 @@
+//# publish
+module 0xc0ffee::lock_conflict_test
+
+struct Data has drop
+    value: u64
+
+public fun callee(x: &mut u64, y: &mut u64)
+    ret
+
+// Test: Cannot call function with two mutable references to same location (exclusive lock conflict)
+public fun test_call_overlapping_mut_refs(): u64
+    local data: Data
+    local ref1: &mut u64
+    local ref2: &mut u64
+
+    // Create data
+    ld_u64 42
+    pack Data
+    st_loc data
+
+    // Get two mutable references to the same field
+    mut_borrow_loc data
+    mut_borrow_field Data, value
+    st_loc ref1
+
+    mut_borrow_loc data
+    mut_borrow_field Data, value
+    st_loc ref2
+
+    // Try to call with both references (should fail - exclusive lock conflict)
+    move_loc ref1
+    move_loc ref2
+    call callee
+
+    ld_u64 0
+    ret
+
+//# run 0xc0ffee::lock_conflict_test::test_call_overlapping_mut_refs --verbose

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/call_with_overlapping_mut_refs.ref.exp
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/call_with_overlapping_mut_refs.ref.exp
@@ -1,0 +1,12 @@
+processed 2 tasks
+task 0 lines 1-36:  publish [module 0xc0ffee::lock_conflict_test]
+task 1 lines 38-38:  run 0xc0ffee::lock_conflict_test::test_call_overlapping_mut_refs --verbose
+Error: Function execution failed with VMError: {
+    message: Exclusive lock conflict,
+    major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
+    sub_status: Some(3),
+    location: undefined,
+    indices: [],
+    offsets: [],
+    exec_state: None,
+}

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/call_with_poisoned_ref.baseline.exp
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/call_with_poisoned_ref.baseline.exp
@@ -1,0 +1,19 @@
+processed 2 tasks
+task 0 lines 1-34:  publish [module 0xc0ffee::poisoned_arg_test]
+Error: Unable to publish module '0000000000000000000000000000000000000000000000000000000000c0ffee::poisoned_arg_test'. Got VMError: {
+    major_status: WRITEREF_EXISTS_BORROW_ERROR,
+    sub_status: None,
+    location: 0xc0ffee::poisoned_arg_test,
+    indices: [(FunctionDefinition, 1)],
+    offsets: [(FunctionDefinitionIndex(1), 8)],
+}
+task 1 lines 36-36:  run 0xc0ffee::poisoned_arg_test::test_call_with_poisoned_ref --verbose
+Error: Function execution failed with VMError: {
+    message: Linker Error: Module 0000000000000000000000000000000000000000000000000000000000c0ffee::poisoned_arg_test doesn't exist,
+    major_status: LINKER_ERROR,
+    sub_status: None,
+    location: undefined,
+    indices: [],
+    offsets: [],
+    exec_state: None,
+}

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/call_with_poisoned_ref.masm
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/call_with_poisoned_ref.masm
@@ -1,0 +1,36 @@
+//# publish
+module 0xc0ffee::poisoned_arg_test
+
+public fun callee(x: &u64)
+    ret
+
+// Test: Cannot call function with poisoned reference argument
+public fun test_call_with_poisoned_ref(): u64
+    local x: u64
+    local ref1: &u64
+    local ref2: &mut u64
+
+    ld_u64 42
+    st_loc x
+
+    // Create immutable reference
+    borrow_loc x
+    st_loc ref1
+
+    // Create mutable reference
+    mut_borrow_loc x
+    st_loc ref2
+
+    // Write via mutable ref (poisons ref1)
+    ld_u64 999
+    move_loc ref2
+    write_ref
+
+    // Try to call with poisoned ref1 (should fail at poison check)
+    move_loc ref1
+    call callee
+
+    ld_u64 0
+    ret
+
+//# run 0xc0ffee::poisoned_arg_test::test_call_with_poisoned_ref --verbose

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/call_with_poisoned_ref.ref.exp
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/call_with_poisoned_ref.ref.exp
@@ -1,0 +1,12 @@
+processed 2 tasks
+task 0 lines 1-34:  publish [module 0xc0ffee::poisoned_arg_test]
+task 1 lines 36-36:  run 0xc0ffee::poisoned_arg_test::test_call_with_poisoned_ref --verbose
+Error: Function execution failed with VMError: {
+    message: Poisoned reference accessed,
+    major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
+    sub_status: Some(3),
+    location: undefined,
+    indices: [],
+    offsets: [],
+    exec_state: None,
+}

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/closure_capture_values.baseline.exp
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/closure_capture_values.baseline.exp
@@ -1,0 +1,19 @@
+processed 2 tasks
+task 0 lines 1-59:  publish [module 0xc0ffee::closure_ref_safety_test]
+Error: Unable to publish module '0000000000000000000000000000000000000000000000000000000000c0ffee::closure_ref_safety_test'. Got VMError: {
+    major_status: WRITEREF_EXISTS_BORROW_ERROR,
+    sub_status: None,
+    location: 0xc0ffee::closure_ref_safety_test,
+    indices: [(FunctionDefinition, 2)],
+    offsets: [(FunctionDefinitionIndex(2), 13)],
+}
+task 1 lines 61-61:  run 0xc0ffee::closure_ref_safety_test::test_closure_creation_with_ref_poison --verbose
+Error: Function execution failed with VMError: {
+    message: Linker Error: Module 0000000000000000000000000000000000000000000000000000000000c0ffee::closure_ref_safety_test doesn't exist,
+    major_status: LINKER_ERROR,
+    sub_status: None,
+    location: undefined,
+    indices: [],
+    offsets: [],
+    exec_state: None,
+}

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/closure_capture_values.masm
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/closure_capture_values.masm
@@ -1,0 +1,61 @@
+//# publish
+module 0xc0ffee::closure_ref_safety_test
+
+// Test: Pack a closure that captures a value, while also having references
+// that get poisoned. This tests that reference checking works with closures.
+public fun make_closure_with_captured_value(x: u64): |u64|u64 has drop
+    // Pack closure that captures x
+    move_loc x
+    pack_closure action, 1
+    ret
+
+#[persistent] fun action(captured: u64, arg: u64): u64
+    move_loc captured
+    move_loc arg
+    add
+    ret
+
+// Test: Create a closure while holding references, then poison one reference
+public fun test_closure_creation_with_ref_poison(): u64
+    local x: u64
+    local y: u64
+    local immut_ref: &u64
+    local mut_ref: &mut u64
+    local closure: |u64|u64 has drop
+
+    ld_u64 10
+    st_loc x
+
+    ld_u64 20
+    st_loc y
+
+    // Create immutable reference to y
+    borrow_loc y
+    st_loc immut_ref
+
+    // Create mutable reference to y
+    mut_borrow_loc y
+    st_loc mut_ref
+
+    // Create a closure that captures x (independent value)
+    copy_loc x
+    call make_closure_with_captured_value
+    st_loc closure
+
+    // Write via mutable ref (poisons immut_ref)
+    ld_u64 999
+    move_loc mut_ref
+    write_ref
+
+    // Use the closure (argument first, then closure)
+    ld_u64 5
+    move_loc closure
+    call_closure<|u64|u64>
+    pop
+
+    // Try to read from poisoned immutable ref (should fail)
+    move_loc immut_ref
+    read_ref
+    ret
+
+//# run 0xc0ffee::closure_ref_safety_test::test_closure_creation_with_ref_poison --verbose

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/closure_capture_values.ref.exp
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/closure_capture_values.ref.exp
@@ -1,0 +1,12 @@
+processed 2 tasks
+task 0 lines 1-59:  publish [module 0xc0ffee::closure_ref_safety_test]
+task 1 lines 61-61:  run 0xc0ffee::closure_ref_safety_test::test_closure_creation_with_ref_poison --verbose
+Error: Function execution failed with VMError: {
+    message: Poisoned reference accessed,
+    major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
+    sub_status: Some(3),
+    location: 0xc0ffee::closure_ref_safety_test,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(2), 19)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/closure_with_overlapping_mut_refs.baseline.exp
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/closure_with_overlapping_mut_refs.baseline.exp
@@ -1,0 +1,19 @@
+processed 2 tasks
+task 0 lines 1-56:  publish [module 0xc0ffee::closure_overlap_test]
+Error: Unable to publish module '0000000000000000000000000000000000000000000000000000000000c0ffee::closure_overlap_test'. Got VMError: {
+    major_status: CALL_BORROWED_MUTABLE_REFERENCE_ERROR,
+    sub_status: None,
+    location: 0xc0ffee::closure_overlap_test,
+    indices: [(FunctionDefinition, 2)],
+    offsets: [(FunctionDefinitionIndex(2), 12)],
+}
+task 1 lines 58-58:  run 0xc0ffee::closure_overlap_test::test_closure_with_overlapping_mut_refs --verbose
+Error: Function execution failed with VMError: {
+    message: Linker Error: Module 0000000000000000000000000000000000000000000000000000000000c0ffee::closure_overlap_test doesn't exist,
+    major_status: LINKER_ERROR,
+    sub_status: None,
+    location: undefined,
+    indices: [],
+    offsets: [],
+    exec_state: None,
+}

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/closure_with_overlapping_mut_refs.masm
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/closure_with_overlapping_mut_refs.masm
@@ -1,0 +1,58 @@
+//# publish
+module 0xc0ffee::closure_overlap_test
+
+// Test: Closure that captures a value and takes TWO mutable reference parameters
+// This tests exclusive lock violation when calling closure with two refs to same location
+public fun make_closure_with_two_mut_refs(captured_val: u64): |&mut u64, &mut u64|u64 has drop
+    // Pack closure that captures the value (not a reference)
+    move_loc captured_val
+    pack_closure action_with_two_refs, 1
+    ret
+
+#[persistent] fun action_with_two_refs(captured: u64, ref1: &mut u64, ref2: &mut u64): u64
+    // Try to read from both mutable references
+    // If they point to same location, violates exclusivity
+    copy_loc ref1
+    read_ref
+    copy_loc ref2
+    read_ref
+    add
+    move_loc captured
+    add
+    ret
+
+// Test: Create closure with two &mut u64 parameters,
+// then call it with two mutable references to the SAME location
+// This should fail with exclusive lock conflict
+public fun test_closure_with_overlapping_mut_refs(): u64
+    local x: u64
+    local ref1: &mut u64
+    local ref2: &mut u64
+    local closure: |&mut u64, &mut u64|u64 has drop
+
+    // Create value
+    ld_u64 10
+    st_loc x
+
+    // Create first mutable reference to x
+    mut_borrow_loc x
+    st_loc ref1
+
+    // Create closure that takes two &mut u64 params and captures a value
+    ld_u64 5
+    call make_closure_with_two_mut_refs
+    st_loc closure
+
+    // Create second mutable reference to x (violates exclusivity with ref1)
+    mut_borrow_loc x
+    st_loc ref2
+
+    // Try to call closure with both refs to same location
+    // This should fail: can't have two mutable references to same location
+    move_loc ref1
+    move_loc ref2
+    move_loc closure
+    call_closure<|&mut u64, &mut u64|u64>
+    ret
+
+//# run 0xc0ffee::closure_overlap_test::test_closure_with_overlapping_mut_refs --verbose

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/closure_with_overlapping_mut_refs.ref.exp
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/closure_with_overlapping_mut_refs.ref.exp
@@ -1,0 +1,12 @@
+processed 2 tasks
+task 0 lines 1-56:  publish [module 0xc0ffee::closure_overlap_test]
+task 1 lines 58-58:  run 0xc0ffee::closure_overlap_test::test_closure_with_overlapping_mut_refs --verbose
+Error: Function execution failed with VMError: {
+    message: Exclusive lock conflict,
+    major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
+    sub_status: Some(3),
+    location: undefined,
+    indices: [],
+    offsets: [],
+    exec_state: None,
+}

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/copy_loc_immut_refs_valid.baseline.exp
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/copy_loc_immut_refs_valid.baseline.exp
@@ -1,0 +1,4 @@
+processed 2 tasks
+task 0 lines 1-23:  publish [module 0xc0ffee::copy_immut_test]
+task 1 lines 25-25:  run 0xc0ffee::copy_immut_test::test_copy_loc_immut_refs_ok --verbose
+return values: 42

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/copy_loc_immut_refs_valid.masm
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/copy_loc_immut_refs_valid.masm
@@ -1,0 +1,25 @@
+//# publish
+module 0xc0ffee::copy_immut_test
+
+// Test: CopyLoc does NOT poison immutable references (only mutable ones)
+public fun test_copy_loc_immut_refs_ok(): u64
+    local x: u64
+    local immut_ref: &u64
+
+    ld_u64 42
+    st_loc x
+
+    // Create immutable reference to x
+    borrow_loc x
+    st_loc immut_ref
+
+    // CopyLoc x (should NOT poison immut_ref, only mutable refs)
+    copy_loc x
+    pop
+
+    // Read from immut_ref should work
+    move_loc immut_ref
+    read_ref
+    ret
+
+//# run 0xc0ffee::copy_immut_test::test_copy_loc_immut_refs_ok --verbose

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/copy_loc_immut_refs_valid.ref.exp
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/copy_loc_immut_refs_valid.ref.exp
@@ -1,0 +1,4 @@
+processed 2 tasks
+task 0 lines 1-23:  publish [module 0xc0ffee::copy_immut_test]
+task 1 lines 25-25:  run 0xc0ffee::copy_immut_test::test_copy_loc_immut_refs_ok --verbose
+return values: 42

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/copy_loc_poisons_mut_refs.baseline.exp
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/copy_loc_poisons_mut_refs.baseline.exp
@@ -1,0 +1,19 @@
+processed 2 tasks
+task 0 lines 1-23:  publish [module 0xc0ffee::copy_loc_test]
+Error: Unable to publish module '0000000000000000000000000000000000000000000000000000000000c0ffee::copy_loc_test'. Got VMError: {
+    major_status: COPYLOC_EXISTS_BORROW_ERROR,
+    sub_status: None,
+    location: 0xc0ffee::copy_loc_test,
+    indices: [(FunctionDefinition, 0)],
+    offsets: [(FunctionDefinitionIndex(0), 4)],
+}
+task 1 lines 25-25:  run 0xc0ffee::copy_loc_test::test_copy_loc_poisons_mut_refs --verbose
+Error: Function execution failed with VMError: {
+    message: Linker Error: Module 0000000000000000000000000000000000000000000000000000000000c0ffee::copy_loc_test doesn't exist,
+    major_status: LINKER_ERROR,
+    sub_status: None,
+    location: undefined,
+    indices: [],
+    offsets: [],
+    exec_state: None,
+}

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/copy_loc_poisons_mut_refs.masm
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/copy_loc_poisons_mut_refs.masm
@@ -1,0 +1,25 @@
+//# publish
+module 0xc0ffee::copy_loc_test
+
+// Test: CopyLoc poisons mutable references (but not immutable ones)
+public fun test_copy_loc_poisons_mut_refs(): u64
+    local x: u64
+    local mut_ref: &mut u64
+
+    ld_u64 42
+    st_loc x
+
+    // Create mutable reference to x
+    mut_borrow_loc x
+    st_loc mut_ref
+
+    // CopyLoc x (should poison mut_ref)
+    copy_loc x
+    pop
+
+    // Try to read from poisoned mutable reference (should fail)
+    move_loc mut_ref
+    read_ref
+    ret
+
+//# run 0xc0ffee::copy_loc_test::test_copy_loc_poisons_mut_refs --verbose

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/copy_loc_poisons_mut_refs.ref.exp
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/copy_loc_poisons_mut_refs.ref.exp
@@ -1,0 +1,12 @@
+processed 2 tasks
+task 0 lines 1-23:  publish [module 0xc0ffee::copy_loc_test]
+task 1 lines 25-25:  run 0xc0ffee::copy_loc_test::test_copy_loc_poisons_mut_refs --verbose
+Error: Function execution failed with VMError: {
+    message: Poisoned reference accessed,
+    major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
+    sub_status: Some(3),
+    location: 0xc0ffee::copy_loc_test,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 7)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/deep_nested_refs.baseline.exp
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/deep_nested_refs.baseline.exp
@@ -1,0 +1,19 @@
+processed 2 tasks
+task 0 lines 1-90:  publish [module 0xc0ffee::deep_nesting]
+Error: Unable to publish module '0000000000000000000000000000000000000000000000000000000000c0ffee::deep_nesting'. Got VMError: {
+    major_status: WRITEREF_EXISTS_BORROW_ERROR,
+    sub_status: None,
+    location: 0xc0ffee::deep_nesting,
+    indices: [(FunctionDefinition, 0)],
+    offsets: [(FunctionDefinitionIndex(0), 33)],
+}
+task 1 lines 92-92:  run 0xc0ffee::deep_nesting::test_deep_nested_poisoning --verbose
+Error: Function execution failed with VMError: {
+    message: Linker Error: Module 0000000000000000000000000000000000000000000000000000000000c0ffee::deep_nesting doesn't exist,
+    major_status: LINKER_ERROR,
+    sub_status: None,
+    location: undefined,
+    indices: [],
+    offsets: [],
+    exec_state: None,
+}

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/deep_nested_refs.masm
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/deep_nested_refs.masm
@@ -1,0 +1,92 @@
+//# publish
+module 0xc0ffee::deep_nesting
+
+struct Level0 has drop
+    value: u64
+
+struct Level1 has drop
+    inner: Level0
+    data: u64
+
+struct Level2 has drop
+    inner: Level1
+    data: u64
+
+struct Level3 has drop
+    inner: Level2
+    data: u64
+
+// Test: Deep nesting with references at multiple levels
+public fun test_deep_nested_poisoning(): u64
+    local root: Level3
+    local ref_l0: &u64
+    local ref_l1: &u64
+    local ref_l2: &u64
+    local mut_ref_l1: &mut Level1
+
+    // Build deeply nested structure
+    // Level0
+    ld_u64 1
+    pack Level0
+    // Level1
+    ld_u64 2
+    pack Level1
+    // Level2
+    ld_u64 3
+    pack Level2
+    // Level3
+    ld_u64 4
+    pack Level3
+    st_loc root
+
+    // Get reference to deepest field (Level3.Level2.Level1.Level0.value)
+    borrow_loc root
+    borrow_field Level3, inner
+    borrow_field Level2, inner
+    borrow_field Level1, inner
+    borrow_field Level0, value
+    st_loc ref_l0
+
+    // Get reference to Level2.data
+    borrow_loc root
+    borrow_field Level3, inner
+    borrow_field Level2, data
+    st_loc ref_l2
+
+    // Get reference to Level1.data
+    borrow_loc root
+    borrow_field Level3, inner
+    borrow_field Level2, inner
+    borrow_field Level1, data
+    st_loc ref_l1
+
+    // Get mutable reference to Level1 and write (should poison ref_l0 and ref_l1)
+    mut_borrow_loc root
+    mut_borrow_field Level3, inner
+    mut_borrow_field Level2, inner
+    st_loc mut_ref_l1
+
+    // Write to Level1 (poisons descendants ref_l0 and ref_l1)
+    ld_u64 999
+    pack Level0
+    ld_u64 888
+    pack Level1
+    move_loc mut_ref_l1
+    write_ref
+
+    // ref_l2 should still be valid (different branch)
+    move_loc ref_l2
+    read_ref
+    pop
+
+    // Try to read from poisoned ref_l0 (should fail)
+    move_loc ref_l0
+    read_ref
+
+    // Cleanup
+    move_loc ref_l1
+    pop
+
+    ret
+
+//# run 0xc0ffee::deep_nesting::test_deep_nested_poisoning --verbose

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/deep_nested_refs.ref.exp
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/deep_nested_refs.ref.exp
@@ -1,0 +1,12 @@
+processed 2 tasks
+task 0 lines 1-90:  publish [module 0xc0ffee::deep_nesting]
+task 1 lines 92-92:  run 0xc0ffee::deep_nesting::test_deep_nested_poisoning --verbose
+Error: Function execution failed with VMError: {
+    message: Poisoned reference accessed,
+    major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
+    sub_status: Some(3),
+    location: 0xc0ffee::deep_nesting,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 38)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/field_ref_after_parent_move.baseline.exp
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/field_ref_after_parent_move.baseline.exp
@@ -1,0 +1,19 @@
+processed 2 tasks
+task 0 lines 1-31:  publish [module 0xc0ffee::field_poison_test]
+Error: Unable to publish module '0000000000000000000000000000000000000000000000000000000000c0ffee::field_poison_test'. Got VMError: {
+    major_status: MOVELOC_EXISTS_BORROW_ERROR,
+    sub_status: None,
+    location: 0xc0ffee::field_poison_test,
+    indices: [(FunctionDefinition, 0)],
+    offsets: [(FunctionDefinitionIndex(0), 7)],
+}
+task 1 lines 33-33:  run 0xc0ffee::field_poison_test::test_field_ref_after_parent_move --verbose
+Error: Function execution failed with VMError: {
+    message: Linker Error: Module 0000000000000000000000000000000000000000000000000000000000c0ffee::field_poison_test doesn't exist,
+    major_status: LINKER_ERROR,
+    sub_status: None,
+    location: undefined,
+    indices: [],
+    offsets: [],
+    exec_state: None,
+}

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/field_ref_after_parent_move.masm
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/field_ref_after_parent_move.masm
@@ -1,0 +1,33 @@
+//# publish
+module 0xc0ffee::field_poison_test
+
+struct Pair has drop
+    first: u64
+    second: u64
+
+// Test: Field reference should be poisoned after parent is moved
+public fun test_field_ref_after_parent_move(): u64
+    local pair: Pair
+    local field_ref: &u64
+
+    // Create a pair
+    ld_u64 10
+    ld_u64 20
+    pack Pair
+    st_loc pair
+
+    // Borrow reference to first field
+    borrow_loc pair
+    borrow_field Pair, first
+    st_loc field_ref
+
+    // Move the parent (should poison field_ref)
+    move_loc pair
+    pop
+
+    // Try to read from poisoned field reference (should fail)
+    move_loc field_ref
+    read_ref
+    ret
+
+//# run 0xc0ffee::field_poison_test::test_field_ref_after_parent_move --verbose

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/field_ref_after_parent_move.ref.exp
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/field_ref_after_parent_move.ref.exp
@@ -1,0 +1,12 @@
+processed 2 tasks
+task 0 lines 1-31:  publish [module 0xc0ffee::field_poison_test]
+task 1 lines 33-33:  run 0xc0ffee::field_poison_test::test_field_ref_after_parent_move --verbose
+Error: Function execution failed with VMError: {
+    message: Poisoned reference accessed,
+    major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
+    sub_status: Some(3),
+    location: 0xc0ffee::field_poison_test,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 10)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/freeze_ref_poisoned.baseline.exp
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/freeze_ref_poisoned.baseline.exp
@@ -1,0 +1,19 @@
+processed 2 tasks
+task 0 lines 1-43:  publish [module 0xc0ffee::freeze_poison_test]
+Error: Unable to publish module '0000000000000000000000000000000000000000000000000000000000c0ffee::freeze_poison_test'. Got VMError: {
+    major_status: WRITEREF_EXISTS_BORROW_ERROR,
+    sub_status: None,
+    location: 0xc0ffee::freeze_poison_test,
+    indices: [(FunctionDefinition, 0)],
+    offsets: [(FunctionDefinitionIndex(0), 11)],
+}
+task 1 lines 45-45:  run 0xc0ffee::freeze_poison_test::test_freeze_poisoned_ref --verbose
+Error: Function execution failed with VMError: {
+    message: Linker Error: Module 0000000000000000000000000000000000000000000000000000000000c0ffee::freeze_poison_test doesn't exist,
+    major_status: LINKER_ERROR,
+    sub_status: None,
+    location: undefined,
+    indices: [],
+    offsets: [],
+    exec_state: None,
+}

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/freeze_ref_poisoned.masm
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/freeze_ref_poisoned.masm
@@ -1,0 +1,45 @@
+//# publish
+module 0xc0ffee::freeze_poison_test
+
+struct Container has copy+drop
+    value: u64
+
+// Test: Cannot freeze a poisoned mutable reference
+// A child reference becomes poisoned when the parent is overwritten
+public fun test_freeze_poisoned_ref(): u64
+    local container: Container
+    local mut_field_ref: &mut u64
+    local parent_ref: &mut Container
+    local immut_ref: &u64
+
+    // Create container
+    ld_u64 42
+    pack Container
+    st_loc container
+
+    // Borrow field mutably (child reference)
+    mut_borrow_loc container
+    mut_borrow_field Container, value
+    st_loc mut_field_ref
+
+    // Get parent reference
+    mut_borrow_loc container
+    st_loc parent_ref
+
+    // Write to parent via dereferencing and overwriting
+    // This poisons the child reference (mut_field_ref)
+    ld_u64 100
+    pack Container
+    move_loc parent_ref
+    write_ref
+
+    // Try to freeze the now-poisoned mut_field_ref (should fail)
+    move_loc mut_field_ref
+    freeze_ref
+    st_loc immut_ref
+
+    move_loc immut_ref
+    read_ref
+    ret
+
+//# run 0xc0ffee::freeze_poison_test::test_freeze_poisoned_ref --verbose

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/freeze_ref_poisoned.ref.exp
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/freeze_ref_poisoned.ref.exp
@@ -1,0 +1,12 @@
+processed 2 tasks
+task 0 lines 1-43:  publish [module 0xc0ffee::freeze_poison_test]
+task 1 lines 45-45:  run 0xc0ffee::freeze_poison_test::test_freeze_poisoned_ref --verbose
+Error: Function execution failed with VMError: {
+    message: Poisoned reference accessed,
+    major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
+    sub_status: Some(3),
+    location: 0xc0ffee::freeze_poison_test,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 13)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/freeze_ref_valid.baseline.exp
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/freeze_ref_valid.baseline.exp
@@ -1,0 +1,4 @@
+processed 2 tasks
+task 0 lines 1-25:  publish [module 0xc0ffee::freeze_test]
+task 1 lines 27-27:  run 0xc0ffee::freeze_test::test_freeze_ref_valid --verbose
+return values: 42

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/freeze_ref_valid.masm
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/freeze_ref_valid.masm
@@ -1,0 +1,27 @@
+//# publish
+module 0xc0ffee::freeze_test
+
+// Test: FreezeRef should work correctly - converting mut ref to immut ref
+public fun test_freeze_ref_valid(): u64
+    local x: u64
+    local mut_ref: &mut u64
+    local immut_ref: &u64
+
+    ld_u64 42
+    st_loc x
+
+    // Create mutable reference
+    mut_borrow_loc x
+    st_loc mut_ref
+
+    // Freeze it to immutable
+    move_loc mut_ref
+    freeze_ref
+    st_loc immut_ref
+
+    // Read from frozen reference (should work)
+    move_loc immut_ref
+    read_ref
+    ret
+
+//# run 0xc0ffee::freeze_test::test_freeze_ref_valid --verbose

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/freeze_ref_valid.ref.exp
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/freeze_ref_valid.ref.exp
@@ -1,0 +1,4 @@
+processed 2 tasks
+task 0 lines 1-25:  publish [module 0xc0ffee::freeze_test]
+task 1 lines 27-27:  run 0xc0ffee::freeze_test::test_freeze_ref_valid --verbose
+return values: 42

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/global_borrow_sequence.baseline.exp
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/global_borrow_sequence.baseline.exp
@@ -1,0 +1,4 @@
+processed 2 tasks
+task 0 lines 1-45:  publish [module 0xc0ffee::global_seq_test]
+task 1 lines 47-47:  run 0xc0ffee::global_seq_test::test_global_borrow_sequence --signers 0x1 --verbose
+return values: 200

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/global_borrow_sequence.masm
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/global_borrow_sequence.masm
@@ -1,0 +1,47 @@
+//# publish
+module 0xc0ffee::global_seq_test
+
+struct Resource has key+drop
+    value: u64
+
+// Test: Sequential global borrows after releasing previous ones
+public fun test_global_borrow_sequence(s: &signer): u64 acquires Resource
+    local res: Resource
+    local mut_ref: &mut Resource
+    local immut_ref: &Resource
+    local result: u64
+
+    // Setup: publish resource
+    ld_u64 100
+    pack Resource
+    st_loc res
+    copy_loc s
+    move_loc res
+    move_to Resource
+
+    // First: borrow mutable, use it, then release (pop)
+    ld_const<address> 0x1
+    mut_borrow_global Resource
+    st_loc mut_ref
+
+    // Modify via mutable ref
+    ld_u64 200
+    pack Resource
+    move_loc mut_ref
+    write_ref
+
+    // Now borrow immutable (should work since mut ref was released)
+    ld_const<address> 0x1
+    borrow_global Resource
+    st_loc immut_ref
+
+    // Read value
+    move_loc immut_ref
+    borrow_field Resource, value
+    read_ref
+    st_loc result
+
+    move_loc result
+    ret
+
+//# run 0xc0ffee::global_seq_test::test_global_borrow_sequence --signers 0x1 --verbose

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/global_borrow_sequence.ref.exp
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/global_borrow_sequence.ref.exp
@@ -1,0 +1,4 @@
+processed 2 tasks
+task 0 lines 1-45:  publish [module 0xc0ffee::global_seq_test]
+task 1 lines 47-47:  run 0xc0ffee::global_seq_test::test_global_borrow_sequence --signers 0x1 --verbose
+return values: 200

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/global_multiple_immut_valid.baseline.exp
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/global_multiple_immut_valid.baseline.exp
@@ -1,0 +1,4 @@
+processed 2 tasks
+task 0 lines 1-55:  publish [module 0xc0ffee::global_multi_immut_test]
+task 1 lines 57-57:  run 0xc0ffee::global_multi_immut_test::test_multiple_immut_global_borrows --signers 0x1 --verbose
+return values: 30

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/global_multiple_immut_valid.masm
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/global_multiple_immut_valid.masm
@@ -1,0 +1,57 @@
+//# publish
+module 0xc0ffee::global_multi_immut_test
+
+struct Resource has key+drop
+    field1: u64
+    field2: u64
+
+// Test: Multiple immutable global borrows should work (shared locks)
+public fun test_multiple_immut_global_borrows(s: &signer): u64 acquires Resource
+    local res: Resource
+    local ref1: &Resource
+    local ref2: &Resource
+    local ref3: &Resource
+
+    // Setup
+    ld_u64 10
+    ld_u64 20
+    pack Resource
+    st_loc res
+    copy_loc s
+    move_loc res
+    move_to Resource
+
+    // Get multiple immutable references to same global (should work)
+    ld_const<address> 0x1
+    borrow_global Resource
+    st_loc ref1
+
+    ld_const<address> 0x1
+    borrow_global Resource
+    st_loc ref2
+
+    ld_const<address> 0x1
+    borrow_global Resource
+    st_loc ref3
+
+    // All should be readable
+    copy_loc ref1
+    borrow_field Resource, field1
+    read_ref
+
+    copy_loc ref2
+    borrow_field Resource, field2
+    read_ref
+    add
+
+    // Cleanup
+    move_loc ref1
+    pop
+    move_loc ref2
+    pop
+    move_loc ref3
+    pop
+
+    ret
+
+//# run 0xc0ffee::global_multi_immut_test::test_multiple_immut_global_borrows --signers 0x1 --verbose

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/global_multiple_immut_valid.ref.exp
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/global_multiple_immut_valid.ref.exp
@@ -1,0 +1,4 @@
+processed 2 tasks
+task 0 lines 1-55:  publish [module 0xc0ffee::global_multi_immut_test]
+task 1 lines 57-57:  run 0xc0ffee::global_multi_immut_test::test_multiple_immut_global_borrows --signers 0x1 --verbose
+return values: 30

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/interleaved_ref_ops.baseline.exp
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/interleaved_ref_ops.baseline.exp
@@ -1,0 +1,19 @@
+processed 2 tasks
+task 0 lines 1-70:  publish [module 0xc0ffee::interleaved_ops]
+Error: Unable to publish module '0000000000000000000000000000000000000000000000000000000000c0ffee::interleaved_ops'. Got VMError: {
+    major_status: WRITEREF_EXISTS_BORROW_ERROR,
+    sub_status: None,
+    location: 0xc0ffee::interleaved_ops,
+    indices: [(FunctionDefinition, 0)],
+    offsets: [(FunctionDefinitionIndex(0), 22)],
+}
+task 1 lines 72-72:  run 0xc0ffee::interleaved_ops::test_interleaved_operations --verbose
+Error: Function execution failed with VMError: {
+    message: Linker Error: Module 0000000000000000000000000000000000000000000000000000000000c0ffee::interleaved_ops doesn't exist,
+    major_status: LINKER_ERROR,
+    sub_status: None,
+    location: undefined,
+    indices: [],
+    offsets: [],
+    exec_state: None,
+}

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/interleaved_ref_ops.masm
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/interleaved_ref_ops.masm
@@ -1,0 +1,72 @@
+//# publish
+module 0xc0ffee::interleaved_ops
+
+struct Data has drop
+    field1: u64
+    field2: u64
+    field3: u64
+
+// Test: Complex interleaved reference operations
+public fun test_interleaved_operations(): u64
+    local data: Data
+    local ref1: &u64
+    local ref2: &u64
+    local ref3: &u64
+    local mut_ref: &mut u64
+
+    // Create data
+    ld_u64 10
+    ld_u64 20
+    ld_u64 30
+    pack Data
+    st_loc data
+
+    // Create multiple immutable refs to different fields
+    borrow_loc data
+    borrow_field Data, field1
+    st_loc ref1
+
+    borrow_loc data
+    borrow_field Data, field2
+    st_loc ref2
+
+    borrow_loc data
+    borrow_field Data, field3
+    st_loc ref3
+
+    // Read from ref1 (should work)
+    copy_loc ref1
+    read_ref
+    pop
+
+    // Get mutable ref to field2
+    mut_borrow_loc data
+    mut_borrow_field Data, field2
+    st_loc mut_ref
+
+    // Write via mut_ref (should poison ref2 but not ref1 or ref3)
+    ld_u64 999
+    move_loc mut_ref
+    write_ref
+
+    // Read from ref1 (should still work - different field)
+    copy_loc ref1
+    read_ref
+    pop
+
+    // Read from ref3 (should still work - different field)
+    move_loc ref3
+    read_ref
+    pop
+
+    // Try to read from poisoned ref2 (should fail)
+    move_loc ref2
+    read_ref
+
+    // Cleanup
+    move_loc ref1
+    pop
+
+    ret
+
+//# run 0xc0ffee::interleaved_ops::test_interleaved_operations --verbose

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/interleaved_ref_ops.ref.exp
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/interleaved_ref_ops.ref.exp
@@ -1,0 +1,12 @@
+processed 2 tasks
+task 0 lines 1-70:  publish [module 0xc0ffee::interleaved_ops]
+task 1 lines 72-72:  run 0xc0ffee::interleaved_ops::test_interleaved_operations --verbose
+Error: Function execution failed with VMError: {
+    message: Poisoned reference accessed,
+    major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
+    sub_status: Some(3),
+    location: 0xc0ffee::interleaved_ops,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 30)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/move_from_poisons_refs.baseline.exp
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/move_from_poisons_refs.baseline.exp
@@ -1,0 +1,19 @@
+processed 2 tasks
+task 0 lines 1-46:  publish [module 0xc0ffee::move_from_test]
+Error: Unable to publish module '0000000000000000000000000000000000000000000000000000000000c0ffee::move_from_test'. Got VMError: {
+    major_status: GLOBAL_REFERENCE_ERROR,
+    sub_status: None,
+    location: 0xc0ffee::move_from_test,
+    indices: [(FunctionDefinition, 0)],
+    offsets: [(FunctionDefinitionIndex(0), 14)],
+}
+task 1 lines 48-48:  run 0xc0ffee::move_from_test::test_move_from_poisons --signers 0x1 --verbose
+Error: Function execution failed with VMError: {
+    message: Linker Error: Module 0000000000000000000000000000000000000000000000000000000000c0ffee::move_from_test doesn't exist,
+    major_status: LINKER_ERROR,
+    sub_status: None,
+    location: undefined,
+    indices: [],
+    offsets: [],
+    exec_state: None,
+}

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/move_from_poisons_refs.masm
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/move_from_poisons_refs.masm
@@ -1,0 +1,48 @@
+//# publish
+module 0xc0ffee::move_from_test
+
+struct Resource has key+drop
+    value: u64
+
+// Test: MoveFrom poisons all references to the global resource
+public fun test_move_from_poisons(s: &signer): u64 acquires Resource
+    local res: Resource
+    local global_ref: &Resource
+    local field_ref: &u64
+
+    // Setup: publish a resource
+    ld_u64 42
+    pack Resource
+    st_loc res
+    copy_loc s
+    move_loc res
+    move_to Resource
+
+    // Create reference to global resource
+    ld_const<address> 0x1
+    borrow_global Resource
+    st_loc global_ref
+
+    // Create reference to field
+    ld_const<address> 0x1
+    borrow_global Resource
+    borrow_field Resource, value
+    st_loc field_ref
+
+    // MoveFrom the resource (should poison both refs)
+    ld_const<address> 0x1
+    move_from Resource
+    pop
+
+    // Try to read from poisoned reference (should fail)
+    move_loc global_ref
+    borrow_field Resource, value
+    read_ref
+
+    // Clean up
+    move_loc field_ref
+    pop
+
+    ret
+
+//# run 0xc0ffee::move_from_test::test_move_from_poisons --signers 0x1 --verbose

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/move_from_poisons_refs.ref.exp
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/move_from_poisons_refs.ref.exp
@@ -1,0 +1,12 @@
+processed 2 tasks
+task 0 lines 1-46:  publish [module 0xc0ffee::move_from_test]
+task 1 lines 48-48:  run 0xc0ffee::move_from_test::test_move_from_poisons --signers 0x1 --verbose
+Error: Function execution failed with VMError: {
+    message: Failed to move resource from 0000000000000000000000000000000000000000000000000000000000000001 @moving global resource with dangling reference,
+    major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
+    sub_status: Some(2),
+    location: 0xc0ffee::move_from_test,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 14)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/move_to_with_signer_ref.baseline.exp
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/move_to_with_signer_ref.baseline.exp
@@ -1,0 +1,3 @@
+processed 2 tasks
+task 0 lines 1-26:  publish [module 0xc0ffee::move_to_test]
+task 1 lines 28-28:  run 0xc0ffee::move_to_test::test_move_to --signers 0x1 --verbose

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/move_to_with_signer_ref.masm
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/move_to_with_signer_ref.masm
@@ -1,0 +1,28 @@
+//# publish
+module 0xc0ffee::move_to_test
+
+struct Resource has key+drop
+    value: u64
+
+// Test: MoveTo consumes signer reference correctly
+public fun test_move_to(s: &signer)
+    local signer_ref: &signer
+    local resource: Resource
+
+    // Get signer reference
+    move_loc s
+    st_loc signer_ref
+
+    // Create resource
+    ld_u64 42
+    pack Resource
+    st_loc resource
+
+    // MoveTo (should consume signer ref)
+    move_loc signer_ref
+    move_loc resource
+    move_to Resource
+
+    ret
+
+//# run 0xc0ffee::move_to_test::test_move_to --signers 0x1 --verbose

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/move_to_with_signer_ref.ref.exp
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/move_to_with_signer_ref.ref.exp
@@ -1,0 +1,3 @@
+processed 2 tasks
+task 0 lines 1-26:  publish [module 0xc0ffee::move_to_test]
+task 1 lines 28-28:  run 0xc0ffee::move_to_test::test_move_to --signers 0x1 --verbose

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/multiple_immut_refs_allowed.baseline.exp
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/multiple_immut_refs_allowed.baseline.exp
@@ -1,0 +1,4 @@
+processed 2 tasks
+task 0 lines 1-44:  publish [module 0xc0ffee::multi_immut_test]
+task 1 lines 46-46:  run 0xc0ffee::multi_immut_test::test_multiple_immut_refs_ok --verbose
+return values: 42

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/multiple_immut_refs_allowed.masm
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/multiple_immut_refs_allowed.masm
@@ -1,0 +1,46 @@
+//# publish
+module 0xc0ffee::multi_immut_test
+
+struct Data has drop
+    field1: u64
+    field2: u64
+
+public fun callee(x: &u64, y: &u64, z: &u64)
+    ret
+
+// Test: Multiple immutable references to same location should be allowed
+public fun test_multiple_immut_refs_ok(): u64
+    local data: Data
+    local ref1: &u64
+    local ref2: &u64
+    local ref3: &u64
+
+    // Create data
+    ld_u64 10
+    ld_u64 20
+    pack Data
+    st_loc data
+
+    // Create three immutable references to same field
+    borrow_loc data
+    borrow_field Data, field1
+    st_loc ref1
+
+    borrow_loc data
+    borrow_field Data, field1
+    st_loc ref2
+
+    borrow_loc data
+    borrow_field Data, field1
+    st_loc ref3
+
+    // Call function with all three refs (should succeed - shared locks OK)
+    move_loc ref1
+    move_loc ref2
+    move_loc ref3
+    call callee
+
+    ld_u64 42
+    ret
+
+//# run 0xc0ffee::multi_immut_test::test_multiple_immut_refs_ok --verbose

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/multiple_immut_refs_allowed.ref.exp
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/multiple_immut_refs_allowed.ref.exp
@@ -1,0 +1,4 @@
+processed 2 tasks
+task 0 lines 1-44:  publish [module 0xc0ffee::multi_immut_test]
+task 1 lines 46-46:  run 0xc0ffee::multi_immut_test::test_multiple_immut_refs_ok --verbose
+return values: 42

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/nested_field_poison.baseline.exp
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/nested_field_poison.baseline.exp
@@ -1,0 +1,19 @@
+processed 2 tasks
+task 0 lines 1-44:  publish [module 0xc0ffee::nested_field_test]
+Error: Unable to publish module '0000000000000000000000000000000000000000000000000000000000c0ffee::nested_field_test'. Got VMError: {
+    major_status: WRITEREF_EXISTS_BORROW_ERROR,
+    sub_status: None,
+    location: 0xc0ffee::nested_field_test,
+    indices: [(FunctionDefinition, 0)],
+    offsets: [(FunctionDefinitionIndex(0), 15)],
+}
+task 1 lines 46-46:  run 0xc0ffee::nested_field_test::test_nested_field_poison --verbose
+Error: Function execution failed with VMError: {
+    message: Linker Error: Module 0000000000000000000000000000000000000000000000000000000000c0ffee::nested_field_test doesn't exist,
+    major_status: LINKER_ERROR,
+    sub_status: None,
+    location: undefined,
+    indices: [],
+    offsets: [],
+    exec_state: None,
+}

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/nested_field_poison.masm
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/nested_field_poison.masm
@@ -1,0 +1,46 @@
+//# publish
+module 0xc0ffee::nested_field_test
+
+struct Inner has drop
+    value: u64
+
+struct Outer has drop
+    inner: Inner
+    other: u64
+
+// Test: Nested field reference poisoned when parent field is mutably written
+public fun test_nested_field_poison(): u64
+    local outer: Outer
+    local inner_value_ref: &u64
+    local inner_ref: &mut Inner
+
+    // Create nested structure
+    ld_u64 42
+    pack Inner
+    ld_u64 100
+    pack Outer
+    st_loc outer
+
+    // Get reference to nested field (outer.inner.value)
+    borrow_loc outer
+    borrow_field Outer, inner
+    borrow_field Inner, value
+    st_loc inner_value_ref
+
+    // Get mutable reference to inner field
+    mut_borrow_loc outer
+    mut_borrow_field Outer, inner
+    st_loc inner_ref
+
+    // Write to inner (should poison inner_value_ref)
+    ld_u64 999
+    pack Inner
+    move_loc inner_ref
+    write_ref
+
+    // Try to read from poisoned nested field reference (should fail)
+    move_loc inner_value_ref
+    read_ref
+    ret
+
+//# run 0xc0ffee::nested_field_test::test_nested_field_poison --verbose

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/nested_field_poison.ref.exp
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/nested_field_poison.ref.exp
@@ -1,0 +1,12 @@
+processed 2 tasks
+task 0 lines 1-44:  publish [module 0xc0ffee::nested_field_test]
+task 1 lines 46-46:  run 0xc0ffee::nested_field_test::test_nested_field_poison --verbose
+Error: Function execution failed with VMError: {
+    message: Poisoned reference accessed,
+    major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
+    sub_status: Some(3),
+    location: 0xc0ffee::nested_field_test,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 17)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/poisoned_ref_after_write.baseline.exp
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/poisoned_ref_after_write.baseline.exp
@@ -1,0 +1,19 @@
+processed 2 tasks
+task 0 lines 1-39:  publish [module 0xc0ffee::poison_test]
+Error: Unable to publish module '0000000000000000000000000000000000000000000000000000000000c0ffee::poison_test'. Got VMError: {
+    major_status: WRITEREF_EXISTS_BORROW_ERROR,
+    sub_status: None,
+    location: 0xc0ffee::poison_test,
+    indices: [(FunctionDefinition, 0)],
+    offsets: [(FunctionDefinitionIndex(0), 12)],
+}
+task 1 lines 41-41:  run 0xc0ffee::poison_test::test_poison_via_write --verbose
+Error: Function execution failed with VMError: {
+    message: Linker Error: Module 0000000000000000000000000000000000000000000000000000000000c0ffee::poison_test doesn't exist,
+    major_status: LINKER_ERROR,
+    sub_status: None,
+    location: undefined,
+    indices: [],
+    offsets: [],
+    exec_state: None,
+}

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/poisoned_ref_after_write.masm
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/poisoned_ref_after_write.masm
@@ -1,0 +1,41 @@
+//# publish
+module 0xc0ffee::poison_test
+
+struct Container has drop
+    field1: u64
+    field2: u64
+
+// Test: Create an immutable reference to a field, then write via mutable reference
+// The immutable reference should be poisoned and reading it should fail
+public fun test_poison_via_write(): u64
+    local container: Container
+    local mut_ref: &mut u64
+    local immut_ref: &u64
+
+    // Create a container
+    ld_u64 10
+    ld_u64 20
+    pack Container
+    st_loc container
+
+    // Create immutable reference to field1
+    borrow_loc container
+    borrow_field Container, field1
+    st_loc immut_ref
+
+    // Create mutable reference to field1
+    mut_borrow_loc container
+    mut_borrow_field Container, field1
+    st_loc mut_ref
+
+    // Write via mutable reference (this should poison immut_ref)
+    ld_u64 999
+    move_loc mut_ref
+    write_ref
+
+    // Try to read from poisoned immutable reference (should fail)
+    move_loc immut_ref
+    read_ref
+    ret
+
+//# run 0xc0ffee::poison_test::test_poison_via_write --verbose

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/poisoned_ref_after_write.ref.exp
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/poisoned_ref_after_write.ref.exp
@@ -1,0 +1,12 @@
+processed 2 tasks
+task 0 lines 1-39:  publish [module 0xc0ffee::poison_test]
+task 1 lines 41-41:  run 0xc0ffee::poison_test::test_poison_via_write --verbose
+Error: Function execution failed with VMError: {
+    message: Poisoned reference accessed,
+    major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
+    sub_status: Some(3),
+    location: 0xc0ffee::poison_test,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 14)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/reborrow_chains.baseline.exp
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/reborrow_chains.baseline.exp
@@ -1,0 +1,19 @@
+processed 2 tasks
+task 0 lines 1-64:  publish [module 0xc0ffee::reborrow_test]
+Error: Unable to publish module '0000000000000000000000000000000000000000000000000000000000c0ffee::reborrow_test'. Got VMError: {
+    major_status: BORROWFIELD_EXISTS_MUTABLE_BORROW_ERROR,
+    sub_status: None,
+    location: 0xc0ffee::reborrow_test,
+    indices: [(FunctionDefinition, 0)],
+    offsets: [(FunctionDefinitionIndex(0), 16)],
+}
+task 1 lines 66-66:  run 0xc0ffee::reborrow_test::test_reborrow_chain --verbose
+Error: Function execution failed with VMError: {
+    message: Linker Error: Module 0000000000000000000000000000000000000000000000000000000000c0ffee::reborrow_test doesn't exist,
+    major_status: LINKER_ERROR,
+    sub_status: None,
+    location: undefined,
+    indices: [],
+    offsets: [],
+    exec_state: None,
+}

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/reborrow_chains.masm
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/reborrow_chains.masm
@@ -1,0 +1,66 @@
+//# publish
+module 0xc0ffee::reborrow_test
+
+struct Inner has drop+copy
+    value: u64
+
+struct Outer has drop+copy
+    inner: Inner
+
+// Test: Chain of reborrows with poisoning
+public fun test_reborrow_chain(): u64
+    local outer: Outer
+    local ref_outer: &Outer
+    local ref_inner: &Inner
+    local ref_value: &u64
+    local mut_ref_inner: &mut Inner
+
+    // Create nested structure
+    ld_u64 42
+    pack Inner
+    pack Outer
+    st_loc outer
+
+    // Create chain of immutable borrows
+    borrow_loc outer
+    st_loc ref_outer
+
+    copy_loc ref_outer
+    borrow_field Outer, inner
+    st_loc ref_inner
+
+    copy_loc ref_inner
+    borrow_field Inner, value
+    st_loc ref_value
+
+    // Verify all refs work
+    copy_loc ref_value
+    read_ref
+    pop
+
+    // Now get mutable ref to inner and write (should poison all downstream refs)
+    mut_borrow_loc outer
+    mut_borrow_field Outer, inner
+    st_loc mut_ref_inner
+
+    ld_u64 999
+    pack Inner
+    move_loc mut_ref_inner
+    write_ref
+
+    // ref_outer should be poisoned (ancestor poisoning via immutable ref rules)
+    move_loc ref_outer
+    borrow_field Outer, inner
+    pop  // Just access the field (will fail if poisoned)
+
+    // Cleanup other refs
+    move_loc ref_inner
+    pop
+    move_loc ref_value
+    pop
+
+    // Return dummy value (test should fail before reaching here in ref mode)
+    ld_u64 0
+    ret
+
+//# run 0xc0ffee::reborrow_test::test_reborrow_chain --verbose

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/reborrow_chains.ref.exp
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/reborrow_chains.ref.exp
@@ -1,0 +1,12 @@
+processed 2 tasks
+task 0 lines 1-64:  publish [module 0xc0ffee::reborrow_test]
+task 1 lines 66-66:  run 0xc0ffee::reborrow_test::test_reborrow_chain --verbose
+Error: Function execution failed with VMError: {
+    message: Poisoned reference accessed,
+    major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
+    sub_status: Some(3),
+    location: 0xc0ffee::reborrow_test,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 23)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/return_derived_ref_valid.baseline.exp
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/return_derived_ref_valid.baseline.exp
@@ -1,0 +1,4 @@
+processed 2 tasks
+task 0 lines 1-29:  publish [module 0xc0ffee::valid_return_test]
+task 1 lines 31-31:  run 0xc0ffee::valid_return_test::test_call_get_first --verbose
+return values: 100

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/return_derived_ref_valid.masm
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/return_derived_ref_valid.masm
@@ -1,0 +1,31 @@
+//# publish
+module 0xc0ffee::valid_return_test
+
+struct Pair has drop
+    first: u64
+    second: u64
+
+// Test: Returning a reference derived from parameter should work
+public fun get_first(pair_ref: &Pair): &u64
+    move_loc pair_ref
+    borrow_field Pair, first
+    ret
+
+public fun test_call_get_first(): u64
+    local pair: Pair
+    local result_ref: &u64
+
+    ld_u64 100
+    ld_u64 200
+    pack Pair
+    st_loc pair
+
+    borrow_loc pair
+    call get_first
+    st_loc result_ref
+
+    move_loc result_ref
+    read_ref
+    ret
+
+//# run 0xc0ffee::valid_return_test::test_call_get_first --verbose

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/return_derived_ref_valid.ref.exp
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/return_derived_ref_valid.ref.exp
@@ -1,0 +1,4 @@
+processed 2 tasks
+task 0 lines 1-29:  publish [module 0xc0ffee::valid_return_test]
+task 1 lines 31-31:  run 0xc0ffee::valid_return_test::test_call_get_first --verbose
+return values: 100

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/return_global_ref.baseline.exp
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/return_global_ref.baseline.exp
@@ -1,0 +1,19 @@
+processed 2 tasks
+task 0 lines 1-27:  publish [module 0xc0ffee::return_global_test]
+Error: Unable to publish module '0000000000000000000000000000000000000000000000000000000000c0ffee::return_global_test'. Got VMError: {
+    major_status: UNSAFE_RET_LOCAL_OR_RESOURCE_STILL_BORROWED,
+    sub_status: None,
+    location: 0xc0ffee::return_global_test,
+    indices: [(FunctionDefinition, 0)],
+    offsets: [(FunctionDefinitionIndex(0), 10)],
+}
+task 1 lines 29-29:  run 0xc0ffee::return_global_test::test_return_global_ref --signers 0x1 --verbose
+Error: Function execution failed with VMError: {
+    message: Linker Error: Module 0000000000000000000000000000000000000000000000000000000000c0ffee::return_global_test doesn't exist,
+    major_status: LINKER_ERROR,
+    sub_status: None,
+    location: undefined,
+    indices: [],
+    offsets: [],
+    exec_state: None,
+}

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/return_global_ref.masm
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/return_global_ref.masm
@@ -1,0 +1,29 @@
+//# publish
+module 0xc0ffee::return_global_test
+
+struct Resource has key+drop
+    value: u64
+
+// Test: Cannot return a reference to global storage (not derived from parameter)
+public fun test_return_global_ref(s: &signer): &Resource acquires Resource
+    local res: Resource
+    local global_ref: &Resource
+
+    // Setup: publish a resource
+    ld_u64 42
+    pack Resource
+    st_loc res
+    copy_loc s
+    move_loc res
+    move_to Resource
+
+    // Borrow global resource
+    ld_const<address> 0x1
+    borrow_global Resource
+    st_loc global_ref
+
+    // Try to return global reference (should fail - not derived from parameter)
+    move_loc global_ref
+    ret
+
+//# run 0xc0ffee::return_global_test::test_return_global_ref --signers 0x1 --verbose

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/return_global_ref.ref.exp
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/return_global_ref.ref.exp
@@ -1,0 +1,12 @@
+processed 2 tasks
+task 0 lines 1-27:  publish [module 0xc0ffee::return_global_test]
+task 1 lines 29-29:  run 0xc0ffee::return_global_test::test_return_global_ref --signers 0x1 --verbose
+Error: Function execution failed with VMError: {
+    message: Returning a reference that is not derived from a reference parameter,
+    major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
+    sub_status: Some(3),
+    location: 0xc0ffee::return_global_test,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 10)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/return_local_ref.baseline.exp
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/return_local_ref.baseline.exp
@@ -1,0 +1,19 @@
+processed 2 tasks
+task 0 lines 1-18:  publish [module 0xc0ffee::return_test]
+Error: Unable to publish module '0000000000000000000000000000000000000000000000000000000000c0ffee::return_test'. Got VMError: {
+    major_status: UNSAFE_RET_LOCAL_OR_RESOURCE_STILL_BORROWED,
+    sub_status: None,
+    location: 0xc0ffee::return_test,
+    indices: [(FunctionDefinition, 0)],
+    offsets: [(FunctionDefinitionIndex(0), 5)],
+}
+task 1 lines 20-20:  run 0xc0ffee::return_test::test_return_local_ref --args 0 --verbose
+Error: Function execution failed with VMError: {
+    message: Linker Error: Module 0000000000000000000000000000000000000000000000000000000000c0ffee::return_test doesn't exist,
+    major_status: LINKER_ERROR,
+    sub_status: None,
+    location: undefined,
+    indices: [],
+    offsets: [],
+    exec_state: None,
+}

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/return_local_ref.masm
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/return_local_ref.masm
@@ -1,0 +1,20 @@
+//# publish
+module 0xc0ffee::return_test
+
+// Test: Cannot return a reference to a local (not derived from parameter)
+public fun test_return_local_ref(x_ref: &u64): &u64
+    local y: u64
+    local y_ref: &u64
+
+    ld_u64 100
+    st_loc y
+
+    // Borrow local y
+    borrow_loc y
+    st_loc y_ref
+
+    // Try to return reference to local y (should fail - not derived from parameter)
+    move_loc y_ref
+    ret
+
+//# run 0xc0ffee::return_test::test_return_local_ref --args 0 --verbose

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/return_local_ref.ref.exp
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/return_local_ref.ref.exp
@@ -1,0 +1,12 @@
+processed 2 tasks
+task 0 lines 1-18:  publish [module 0xc0ffee::return_test]
+task 1 lines 20-20:  run 0xc0ffee::return_test::test_return_local_ref --args 0 --verbose
+Error: Function execution failed with VMError: {
+    message: Returning a reference that is not derived from a reference parameter,
+    major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
+    sub_status: Some(3),
+    location: 0xc0ffee::return_test,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 5)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/return_multiple_from_param.baseline.exp
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/return_multiple_from_param.baseline.exp
@@ -1,0 +1,4 @@
+processed 2 tasks
+task 0 lines 1-50:  publish [module 0xc0ffee::multi_return_test]
+task 1 lines 52-52:  run 0xc0ffee::multi_return_test::caller --verbose
+return values: 300

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/return_multiple_from_param.masm
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/return_multiple_from_param.masm
@@ -1,0 +1,52 @@
+//# publish
+module 0xc0ffee::multi_return_test
+
+struct Pair has drop
+    first: u64
+    second: u64
+
+// Test: Return multiple references derived from same parameter (should work)
+public fun get_both_fields(pair_ref: &Pair): (&u64, &u64)
+    local ref1: &u64
+    local ref2: &u64
+
+    // Get reference to first field
+    copy_loc pair_ref
+    borrow_field Pair, first
+    st_loc ref1
+
+    // Get reference to second field
+    move_loc pair_ref
+    borrow_field Pair, second
+    st_loc ref2
+
+    // Return both (should work - both derived from same param, no overlap)
+    move_loc ref1
+    move_loc ref2
+    ret
+
+public fun caller(): u64
+    local pair: Pair
+    local ref1: &u64
+    local ref2: &u64
+
+    ld_u64 100
+    ld_u64 200
+    pack Pair
+    st_loc pair
+
+    borrow_loc pair
+    call get_both_fields
+    st_loc ref2
+    st_loc ref1
+
+    // Read both
+    move_loc ref1
+    read_ref
+    move_loc ref2
+    read_ref
+    add
+
+    ret
+
+//# run 0xc0ffee::multi_return_test::caller --verbose

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/return_multiple_from_param.ref.exp
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/return_multiple_from_param.ref.exp
@@ -1,0 +1,4 @@
+processed 2 tasks
+task 0 lines 1-50:  publish [module 0xc0ffee::multi_return_test]
+task 1 lines 52-52:  run 0xc0ffee::multi_return_test::caller --verbose
+return values: 300

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/return_nested_transformation.baseline.exp
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/return_nested_transformation.baseline.exp
@@ -1,0 +1,4 @@
+processed 2 tasks
+task 0 lines 1-49:  publish [module 0xc0ffee::return_transform_test]
+task 1 lines 51-51:  run 0xc0ffee::return_transform_test::caller_with_nesting --verbose
+return values: 42

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/return_nested_transformation.masm
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/return_nested_transformation.masm
@@ -1,0 +1,51 @@
+//# publish
+module 0xc0ffee::return_transform_test
+
+struct Inner has drop
+    value: u64
+
+struct Outer has drop
+    inner1: Inner
+    inner2: Inner
+
+// Test: Return deeply nested reference with caller transformation
+public fun get_inner_value(outer_ref: &Outer): &u64
+    local inner_ref: &Inner
+    local value_ref: &u64
+
+    // Navigate to inner1.value
+    move_loc outer_ref
+    borrow_field Outer, inner1
+    st_loc inner_ref
+
+    move_loc inner_ref
+    borrow_field Inner, value
+    st_loc value_ref
+
+    // Return the deeply nested reference
+    move_loc value_ref
+    ret
+
+public fun caller_with_nesting(): u64
+    local outer: Outer
+    local result_ref: &u64
+
+    // Create nested structure
+    ld_u64 42
+    pack Inner
+    ld_u64 84
+    pack Inner
+    pack Outer
+    st_loc outer
+
+    // Call function that returns nested reference
+    borrow_loc outer
+    call get_inner_value
+    st_loc result_ref
+
+    // Read the value
+    move_loc result_ref
+    read_ref
+    ret
+
+//# run 0xc0ffee::return_transform_test::caller_with_nesting --verbose

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/return_nested_transformation.ref.exp
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/return_nested_transformation.ref.exp
@@ -1,0 +1,4 @@
+processed 2 tasks
+task 0 lines 1-49:  publish [module 0xc0ffee::return_transform_test]
+task 1 lines 51-51:  run 0xc0ffee::return_transform_test::caller_with_nesting --verbose
+return values: 42

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/return_overlapping_mut_refs.baseline.exp
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/return_overlapping_mut_refs.baseline.exp
@@ -1,0 +1,19 @@
+processed 2 tasks
+task 0 lines 1-57:  publish [module 0xc0ffee::return_overlap_test]
+Error: Unable to publish module '0000000000000000000000000000000000000000000000000000000000c0ffee::return_overlap_test'. Got VMError: {
+    major_status: RET_BORROWED_MUTABLE_REFERENCE_ERROR,
+    sub_status: None,
+    location: 0xc0ffee::return_overlap_test,
+    indices: [(FunctionDefinition, 0)],
+    offsets: [(FunctionDefinitionIndex(0), 8)],
+}
+task 1 lines 59-59:  run 0xc0ffee::return_overlap_test::test_overlapping_mut_refs --verbose
+Error: Function execution failed with VMError: {
+    message: Linker Error: Module 0000000000000000000000000000000000000000000000000000000000c0ffee::return_overlap_test doesn't exist,
+    major_status: LINKER_ERROR,
+    sub_status: None,
+    location: undefined,
+    indices: [],
+    offsets: [],
+    exec_state: None,
+}

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/return_overlapping_mut_refs.masm
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/return_overlapping_mut_refs.masm
@@ -1,0 +1,59 @@
+//# publish
+module 0xc0ffee::return_overlap_test
+
+struct Pair has drop
+    first: u64
+    second: u64
+
+// Test: Cannot return overlapping mutable references (exclusivity violation)
+public fun get_both_mut(pair_ref: &mut Pair): (&mut u64, &mut u64)
+    local ref1: &mut u64
+    local ref2: &mut u64
+
+    // Get first mutable ref to first field
+    copy_loc pair_ref
+    mut_borrow_field Pair, first
+    st_loc ref1
+
+    // Get second mutable ref to SAME field (violates exclusivity)
+    move_loc pair_ref
+    mut_borrow_field Pair, first
+    st_loc ref2
+
+    // Try to return both
+    move_loc ref1
+    move_loc ref2
+    ret
+
+// Test wrapper function
+public fun test_overlapping_mut_refs()
+    local pair: Pair
+    local pair_ref: &mut Pair
+    local ref1: &mut u64
+    local ref2: &mut u64
+
+    // Create a pair
+    ld_u64 10
+    ld_u64 20
+    pack Pair
+    st_loc pair
+
+    // Get mutable reference to pair
+    mut_borrow_loc pair
+    st_loc pair_ref
+
+    // Call get_both_mut (should fail when returning overlapping refs)
+    move_loc pair_ref
+    call get_both_mut
+    st_loc ref2
+    st_loc ref1
+
+    // Cleanup
+    move_loc ref1
+    pop
+    move_loc ref2
+    pop
+
+    ret
+
+//# run 0xc0ffee::return_overlap_test::test_overlapping_mut_refs --verbose

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/return_overlapping_mut_refs.ref.exp
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/return_overlapping_mut_refs.ref.exp
@@ -1,0 +1,12 @@
+processed 2 tasks
+task 0 lines 1-57:  publish [module 0xc0ffee::return_overlap_test]
+task 1 lines 59-59:  run 0xc0ffee::return_overlap_test::test_overlapping_mut_refs --verbose
+Error: Function execution failed with VMError: {
+    message: Exclusive lock conflict,
+    major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
+    sub_status: Some(3),
+    location: 0xc0ffee::return_overlap_test,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 8)],
+    exec_state: Some(ExecutionState { stack_trace: [(Some(ModuleId { address: 0000000000000000000000000000000000000000000000000000000000c0ffee, name: Identifier("return_overlap_test") }), FunctionDefinitionIndex(1), 7)] }),
+}

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/st_loc_overwrite_poisons.baseline.exp
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/st_loc_overwrite_poisons.baseline.exp
@@ -1,0 +1,19 @@
+processed 2 tasks
+task 0 lines 1-33:  publish [module 0xc0ffee::st_loc_test]
+Error: Unable to publish module '0000000000000000000000000000000000000000000000000000000000c0ffee::st_loc_test'. Got VMError: {
+    major_status: STLOC_UNSAFE_TO_DESTROY_ERROR,
+    sub_status: None,
+    location: 0xc0ffee::st_loc_test,
+    indices: [(FunctionDefinition, 0)],
+    offsets: [(FunctionDefinitionIndex(0), 7)],
+}
+task 1 lines 35-35:  run 0xc0ffee::st_loc_test::test_st_loc_poisons_refs --verbose
+Error: Function execution failed with VMError: {
+    message: Linker Error: Module 0000000000000000000000000000000000000000000000000000000000c0ffee::st_loc_test doesn't exist,
+    major_status: LINKER_ERROR,
+    sub_status: None,
+    location: undefined,
+    indices: [],
+    offsets: [],
+    exec_state: None,
+}

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/st_loc_overwrite_poisons.masm
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/st_loc_overwrite_poisons.masm
@@ -1,0 +1,35 @@
+//# publish
+module 0xc0ffee::st_loc_test
+
+// Test: StLoc overwrites local, poisoning all references to it
+public fun test_st_loc_poisons_refs(): u64
+    local x: u64
+    local ref1: &u64
+    local ref2: &u64
+
+    // Initialize x
+    ld_u64 10
+    st_loc x
+
+    // Create references to x
+    borrow_loc x
+    st_loc ref1
+
+    borrow_loc x
+    st_loc ref2
+
+    // Overwrite x with StLoc (should poison both refs)
+    ld_u64 999
+    st_loc x
+
+    // Try to read from poisoned reference (should fail)
+    move_loc ref1
+    read_ref
+
+    // Clean up
+    move_loc ref2
+    pop
+
+    ret
+
+//# run 0xc0ffee::st_loc_test::test_st_loc_poisons_refs --verbose

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/st_loc_overwrite_poisons.ref.exp
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/st_loc_overwrite_poisons.ref.exp
@@ -1,0 +1,12 @@
+processed 2 tasks
+task 0 lines 1-33:  publish [module 0xc0ffee::st_loc_test]
+task 1 lines 35-35:  run 0xc0ffee::st_loc_test::test_st_loc_poisons_refs --verbose
+Error: Function execution failed with VMError: {
+    message: Poisoned reference accessed,
+    major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
+    sub_status: Some(3),
+    location: 0xc0ffee::st_loc_test,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 9)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/vector_multiple_elem_refs.baseline.exp
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/vector_multiple_elem_refs.baseline.exp
@@ -1,0 +1,19 @@
+processed 2 tasks
+task 0 lines 1-57:  publish [module 0xc0ffee::vec_multi_ref_test]
+Error: Unable to publish module '0000000000000000000000000000000000000000000000000000000000c0ffee::vec_multi_ref_test'. Got VMError: {
+    major_status: VEC_UPDATE_EXISTS_MUTABLE_BORROW_ERROR,
+    sub_status: None,
+    location: 0xc0ffee::vec_multi_ref_test,
+    indices: [(FunctionDefinition, 0)],
+    offsets: [(FunctionDefinitionIndex(0), 24)],
+}
+task 1 lines 59-59:  run 0xc0ffee::vec_multi_ref_test::test_vec_multiple_elem_refs --verbose
+Error: Function execution failed with VMError: {
+    message: Linker Error: Module 0000000000000000000000000000000000000000000000000000000000c0ffee::vec_multi_ref_test doesn't exist,
+    major_status: LINKER_ERROR,
+    sub_status: None,
+    location: undefined,
+    indices: [],
+    offsets: [],
+    exec_state: None,
+}

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/vector_multiple_elem_refs.masm
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/vector_multiple_elem_refs.masm
@@ -1,0 +1,59 @@
+//# publish
+module 0xc0ffee::vec_multi_ref_test
+
+// Test: Multiple references to vector elements with abstracted label (0)
+// All vector element refs use label 0, so they should conflict
+public fun test_vec_multiple_elem_refs(): u64
+    local vec: vector<u64>
+    local ref1: &u64
+    local ref2: &u64
+    local vec_ref: &mut vector<u64>
+
+    // Create vector with 3 elements
+    ld_u64 10
+    ld_u64 20
+    ld_u64 30
+    vec_pack<u64> 3
+    st_loc vec
+
+    // Get reference to element 0
+    mut_borrow_loc vec
+    ld_u64 0
+    vec_borrow<u64>
+    st_loc ref1
+
+    // Get reference to element 1 (uses same abstracted label 0)
+    mut_borrow_loc vec
+    ld_u64 1
+    vec_borrow<u64>
+    st_loc ref2
+
+    // Both refs should be valid now
+    copy_loc ref1
+    read_ref
+    pop
+
+    copy_loc ref2
+    read_ref
+    pop
+
+    // Get mutable vector ref and swap elements (poisons both refs)
+    mut_borrow_loc vec
+    st_loc vec_ref
+
+    move_loc vec_ref
+    ld_u64 0
+    ld_u64 1
+    vec_swap<u64>
+
+    // Try to read from ref1 (should fail - poisoned by swap)
+    move_loc ref1
+    read_ref
+
+    // Cleanup
+    move_loc ref2
+    pop
+
+    ret
+
+//# run 0xc0ffee::vec_multi_ref_test::test_vec_multiple_elem_refs --verbose

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/vector_multiple_elem_refs.ref.exp
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/vector_multiple_elem_refs.ref.exp
@@ -1,0 +1,12 @@
+processed 2 tasks
+task 0 lines 1-57:  publish [module 0xc0ffee::vec_multi_ref_test]
+task 1 lines 59-59:  run 0xc0ffee::vec_multi_ref_test::test_vec_multiple_elem_refs --verbose
+Error: Function execution failed with VMError: {
+    message: Poisoned reference accessed,
+    major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
+    sub_status: Some(3),
+    location: 0xc0ffee::vec_multi_ref_test,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 26)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/vector_pop_back_poison.baseline.exp
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/vector_pop_back_poison.baseline.exp
@@ -1,0 +1,19 @@
+processed 2 tasks
+task 0 lines 1-34:  publish [module 0xc0ffee::vec_test]
+Error: Unable to publish module '0000000000000000000000000000000000000000000000000000000000c0ffee::vec_test'. Got VMError: {
+    major_status: VEC_UPDATE_EXISTS_MUTABLE_BORROW_ERROR,
+    sub_status: None,
+    location: 0xc0ffee::vec_test,
+    indices: [(FunctionDefinition, 0)],
+    offsets: [(FunctionDefinitionIndex(0), 11)],
+}
+task 1 lines 36-36:  run 0xc0ffee::vec_test::test_vec_pop_back_poisons_elem_ref --verbose
+Error: Function execution failed with VMError: {
+    message: Linker Error: Module 0000000000000000000000000000000000000000000000000000000000c0ffee::vec_test doesn't exist,
+    major_status: LINKER_ERROR,
+    sub_status: None,
+    location: undefined,
+    indices: [],
+    offsets: [],
+    exec_state: None,
+}

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/vector_pop_back_poison.masm
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/vector_pop_back_poison.masm
@@ -1,0 +1,36 @@
+//# publish
+module 0xc0ffee::vec_test
+
+// Test: VecPopBack poisons existing references to vector elements
+public fun test_vec_pop_back_poisons_elem_ref(): u64
+    local vec: vector<u64>
+    local elem_ref: &u64
+    local vec_ref: &mut vector<u64>
+
+    // Create a vector with 2 elements
+    ld_u64 10
+    ld_u64 20
+    vec_pack<u64> 2
+    st_loc vec
+
+    // Borrow immutable reference to an element
+    mut_borrow_loc vec
+    ld_u64 0
+    vec_borrow<u64>
+    st_loc elem_ref
+
+    // Get mutable reference to vector
+    mut_borrow_loc vec
+    st_loc vec_ref
+
+    // Pop back from vector (should poison elem_ref)
+    move_loc vec_ref
+    vec_pop_back<u64>
+    pop
+
+    // Try to read from poisoned element reference (should fail)
+    move_loc elem_ref
+    read_ref
+    ret
+
+//# run 0xc0ffee::vec_test::test_vec_pop_back_poisons_elem_ref --verbose

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/vector_pop_back_poison.ref.exp
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/vector_pop_back_poison.ref.exp
@@ -1,0 +1,12 @@
+processed 2 tasks
+task 0 lines 1-34:  publish [module 0xc0ffee::vec_test]
+task 1 lines 36-36:  run 0xc0ffee::vec_test::test_vec_pop_back_poisons_elem_ref --verbose
+Error: Function execution failed with VMError: {
+    message: Poisoned reference accessed,
+    major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
+    sub_status: Some(3),
+    location: 0xc0ffee::vec_test,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 14)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/vector_push_back_valid.baseline.exp
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/vector_push_back_valid.baseline.exp
@@ -1,0 +1,19 @@
+processed 2 tasks
+task 0 lines 1-34:  publish [module 0xc0ffee::vec_push_test]
+Error: Unable to publish module '0000000000000000000000000000000000000000000000000000000000c0ffee::vec_push_test'. Got VMError: {
+    major_status: VEC_UPDATE_EXISTS_MUTABLE_BORROW_ERROR,
+    sub_status: None,
+    location: 0xc0ffee::vec_push_test,
+    indices: [(FunctionDefinition, 0)],
+    offsets: [(FunctionDefinitionIndex(0), 11)],
+}
+task 1 lines 36-36:  run 0xc0ffee::vec_push_test::test_vec_push_back_no_poison --verbose
+Error: Function execution failed with VMError: {
+    message: Linker Error: Module 0000000000000000000000000000000000000000000000000000000000c0ffee::vec_push_test doesn't exist,
+    major_status: LINKER_ERROR,
+    sub_status: None,
+    location: undefined,
+    indices: [],
+    offsets: [],
+    exec_state: None,
+}

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/vector_push_back_valid.masm
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/vector_push_back_valid.masm
@@ -1,0 +1,36 @@
+//# publish
+module 0xc0ffee::vec_push_test
+
+// Test: VecPushBack should work and NOT poison existing element references
+// (per line 1733-1735 in runtime_ref_checks.rs)
+public fun test_vec_push_back_no_poison(): u64
+    local vec: vector<u64>
+    local elem_ref: &u64
+    local vec_ref: &mut vector<u64>
+
+    // Create vector with 1 element
+    ld_u64 100
+    vec_pack<u64> 1
+    st_loc vec
+
+    // Get reference to the first element
+    mut_borrow_loc vec
+    ld_u64 0
+    vec_borrow<u64>
+    st_loc elem_ref
+
+    // Get mutable reference to vector
+    mut_borrow_loc vec
+    st_loc vec_ref
+
+    // Push back new element (should NOT poison elem_ref)
+    move_loc vec_ref
+    ld_u64 200
+    vec_push_back<u64>
+
+    // Read from elem_ref should still work
+    move_loc elem_ref
+    read_ref
+    ret
+
+//# run 0xc0ffee::vec_push_test::test_vec_push_back_no_poison --verbose

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/vector_push_back_valid.ref.exp
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/vector_push_back_valid.ref.exp
@@ -1,0 +1,4 @@
+processed 2 tasks
+task 0 lines 1-34:  publish [module 0xc0ffee::vec_push_test]
+task 1 lines 36-36:  run 0xc0ffee::vec_push_test::test_vec_push_back_no_poison --verbose
+return values: 100

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/vector_swap_poison.baseline.exp
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/vector_swap_poison.baseline.exp
@@ -1,0 +1,19 @@
+processed 2 tasks
+task 0 lines 1-47:  publish [module 0xc0ffee::vec_swap_test]
+Error: Unable to publish module '0000000000000000000000000000000000000000000000000000000000c0ffee::vec_swap_test'. Got VMError: {
+    major_status: VEC_UPDATE_EXISTS_MUTABLE_BORROW_ERROR,
+    sub_status: None,
+    location: 0xc0ffee::vec_swap_test,
+    indices: [(FunctionDefinition, 0)],
+    offsets: [(FunctionDefinitionIndex(0), 18)],
+}
+task 1 lines 49-49:  run 0xc0ffee::vec_swap_test::test_vec_swap_poisons_elem_refs --verbose
+Error: Function execution failed with VMError: {
+    message: Linker Error: Module 0000000000000000000000000000000000000000000000000000000000c0ffee::vec_swap_test doesn't exist,
+    major_status: LINKER_ERROR,
+    sub_status: None,
+    location: undefined,
+    indices: [],
+    offsets: [],
+    exec_state: None,
+}

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/vector_swap_poison.masm
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/vector_swap_poison.masm
@@ -1,0 +1,49 @@
+//# publish
+module 0xc0ffee::vec_swap_test
+
+// Test: VecSwap poisons existing references to vector elements
+public fun test_vec_swap_poisons_elem_refs(): u64
+    local vec: vector<u64>
+    local elem_ref1: &u64
+    local elem_ref2: &u64
+    local vec_ref: &mut vector<u64>
+
+    // Create a vector with 3 elements
+    ld_u64 100
+    ld_u64 200
+    ld_u64 300
+    vec_pack<u64> 3
+    st_loc vec
+
+    // Borrow immutable references to first two elements
+    mut_borrow_loc vec
+    ld_u64 0
+    vec_borrow<u64>
+    st_loc elem_ref1
+
+    mut_borrow_loc vec
+    ld_u64 1
+    vec_borrow<u64>
+    st_loc elem_ref2
+
+    // Get mutable reference to vector
+    mut_borrow_loc vec
+    st_loc vec_ref
+
+    // Swap elements (should poison both elem_ref1 and elem_ref2)
+    move_loc vec_ref
+    ld_u64 0
+    ld_u64 1
+    vec_swap<u64>
+
+    // Try to read from first poisoned element reference (should fail)
+    move_loc elem_ref1
+    read_ref
+
+    // Clean up second reference
+    move_loc elem_ref2
+    pop
+
+    ret
+
+//# run 0xc0ffee::vec_swap_test::test_vec_swap_poisons_elem_refs --verbose

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/vector_swap_poison.ref.exp
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/vector_swap_poison.ref.exp
@@ -1,0 +1,12 @@
+processed 2 tasks
+task 0 lines 1-47:  publish [module 0xc0ffee::vec_swap_test]
+task 1 lines 49-49:  run 0xc0ffee::vec_swap_test::test_vec_swap_poisons_elem_refs --verbose
+Error: Function execution failed with VMError: {
+    message: Poisoned reference accessed,
+    major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
+    sub_status: Some(3),
+    location: 0xc0ffee::vec_swap_test,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 20)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/write_field_poisons_parent.baseline.exp
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/write_field_poisons_parent.baseline.exp
@@ -1,0 +1,19 @@
+processed 2 tasks
+task 0 lines 1-38:  publish [module 0xc0ffee::ancestor_poison_test]
+Error: Unable to publish module '0000000000000000000000000000000000000000000000000000000000c0ffee::ancestor_poison_test'. Got VMError: {
+    major_status: BORROWFIELD_EXISTS_MUTABLE_BORROW_ERROR,
+    sub_status: None,
+    location: 0xc0ffee::ancestor_poison_test,
+    indices: [(FunctionDefinition, 0)],
+    offsets: [(FunctionDefinitionIndex(0), 7)],
+}
+task 1 lines 40-40:  run 0xc0ffee::ancestor_poison_test::test_write_field_poisons_parent --verbose
+Error: Function execution failed with VMError: {
+    message: Linker Error: Module 0000000000000000000000000000000000000000000000000000000000c0ffee::ancestor_poison_test doesn't exist,
+    major_status: LINKER_ERROR,
+    sub_status: None,
+    location: undefined,
+    indices: [],
+    offsets: [],
+    exec_state: None,
+}

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/write_field_poisons_parent.masm
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/write_field_poisons_parent.masm
@@ -1,0 +1,40 @@
+//# publish
+module 0xc0ffee::ancestor_poison_test
+
+struct Container has drop
+    field1: u64
+    field2: u64
+
+// Test: Writing to a field via mut ref poisons immutable references to parent
+public fun test_write_field_poisons_parent(): u64
+    local container: Container
+    local parent_ref: &Container
+    local field_ref: &mut u64
+
+    // Create container
+    ld_u64 10
+    ld_u64 20
+    pack Container
+    st_loc container
+
+    // Create immutable reference to parent
+    borrow_loc container
+    st_loc parent_ref
+
+    // Create mutable reference to field
+    mut_borrow_loc container
+    mut_borrow_field Container, field1
+    st_loc field_ref
+
+    // Write to field (should poison parent_ref)
+    ld_u64 999
+    move_loc field_ref
+    write_ref
+
+    // Try to read from poisoned parent reference (should fail)
+    move_loc parent_ref
+    borrow_field Container, field2
+    read_ref
+    ret
+
+//# run 0xc0ffee::ancestor_poison_test::test_write_field_poisons_parent --verbose

--- a/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/write_field_poisons_parent.ref.exp
+++ b/third_party/move/move-vm/transactional-tests/tests/runtime_ref_checks/write_field_poisons_parent.ref.exp
@@ -1,0 +1,12 @@
+processed 2 tasks
+task 0 lines 1-38:  publish [module 0xc0ffee::ancestor_poison_test]
+task 1 lines 40-40:  run 0xc0ffee::ancestor_poison_test::test_write_field_poisons_parent --verbose
+Error: Function execution failed with VMError: {
+    message: Poisoned reference accessed,
+    major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
+    sub_status: Some(3),
+    location: 0xc0ffee::ancestor_poison_test,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 13)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}


### PR DESCRIPTION
## Description

In this PR, we add new masm tests for the runtime reference safety checker, focusing on negative tests (leading to invariant violations when static bytecode verifier is disabled and VM is run with reference safety checker enabled). 

With these tests, the effective line coverage of the runtime ref safety checker is close to 90%, significant improvement from what it was before.

## How Has This Been Tested?

New tests added, all of which were manually reviewed.

## Type of Change
- [x] Tests


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a focused suite of transactional masm tests for the Move VM runtime reference safety checker, emphasizing negative cases (expected invariant violations) plus a few positive sanity checks to improve coverage.
> 
> - Introduces many new tests under `transactional-tests/tests/runtime_ref_checks` covering: local/global borrow conflicts, exclusive lock violations in calls and closures, reference poisoning via `write_ref`, `move_from`, `st_loc`, vector ops (`vec_swap`, `vec_pop_back`), and `copy_loc` behavior (immut OK, mut poisoned)
> - Validates nested/ancestor poisoning across deep structures, borrow sequencing, multiple immutable global borrows, proper `freeze_ref`, return rules (derived refs allowed; returning locals/globals rejected), and `move_to` consumption of signer refs
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2e233af91dfaef61d51ebca19c1c3356516f0502. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->