### PR TITLE
[compiler] fix issue 18335

### DIFF
--- a/third_party/move/move-compiler-v2/tests/ability-check/v1-signer/address_arg_is_not_signer.exp
+++ b/third_party/move/move-compiler-v2/tests/ability-check/v1-signer/address_arg_is_not_signer.exp
@@ -8,13 +8,13 @@ error: type `signer` is missing required ability `store`
   │
   = required by declaration of field `s`
 
-error: the function takes 2 arguments but 1 were provided
+error: the function takes 2 arguments but 1 was provided
    ┌─ tests/ability-check/v1-signer/address_arg_is_not_signer.move:14:9
    │
 14 │         0x2::M::store_signer(s)
    │         ^^^^^^^^^^^^^^^^^^^^^^^
 
-error: the function takes 2 arguments but 1 were provided
+error: the function takes 2 arguments but 1 was provided
    ┌─ tests/ability-check/v1-signer/address_arg_is_not_signer.move:21:9
    │
 21 │         0x2::M::store_signer(s2)

--- a/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/bug_18335.exp
+++ b/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/bug_18335.exp
@@ -1,0 +1,13 @@
+
+Diagnostics:
+error: expected function type has 0 arguments but 2 were provided
+   ┌─ tests/checking-lang-v2.2/bug_18335.move:13:20
+   │
+13 │         s.receiver(func); // type error happens here, as `func` (of type `|u64|(u64, u64)`) does not match function type `|u64|`
+   │                    ^^^^
+
+error: expected function type returns 0 values but 2 were provided
+   ┌─ tests/checking-lang-v2.2/bug_18335.move:29:20
+   │
+29 │         s.receiver(func); // type error happens here, as `func` (of type `|u64|(u64, u64)`) does not match function type `|u64|`
+   │                    ^^^^

--- a/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/bug_18335.move
+++ b/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/bug_18335.move
@@ -1,0 +1,31 @@
+module 0x99::bug_18335_args {
+    struct S has drop {
+        x: u64
+    }
+
+    fun receiver(self: &S, f: ||(u64, u64)): (u64, u64) {
+        f()
+    }
+
+    fun test(x: u64) {
+        let s = S { x: 42 };
+        let func = |x, y| { (x, y) };
+        s.receiver(func); // type error happens here, as `func` (of type `|u64|(u64, u64)`) does not match function type `|u64|`
+    }
+}
+
+module 0x99::bug_18335_returns {
+    struct S has drop {
+        x: u64
+    }
+
+    fun receiver(self: &S, f: |u64|) {
+        f(self.x);
+    }
+
+    fun test(x: u64) {
+        let s = S { x: 42 };
+        let func = |x| { (x, 1u64) };
+        s.receiver(func); // type error happens here, as `func` (of type `|u64|(u64, u64)`) does not match function type `|u64|`
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/checking/error_context/argument.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/error_context/argument.exp
@@ -30,7 +30,7 @@ error: cannot pass `&bool` to a function which expects argument of type `&mut bo
 30 │         g(&1, x)
    │               ^
 
-error: the function takes 2 arguments but 1 were provided
+error: the function takes 2 arguments but 1 was provided
    ┌─ tests/checking/error_context/argument.move:34:9
    │
 34 │         f(1);

--- a/third_party/move/move-compiler-v2/tests/checking/naming/generics_with_type_parameters.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/naming/generics_with_type_parameters.exp
@@ -1,18 +1,18 @@
 
 Diagnostics:
-error: expected 0 type arguments but 1 were provided
+error: expected 0 type arguments but 1 was provided
   ┌─ tests/checking/naming/generics_with_type_parameters.move:2:22
   │
 2 │     struct S<T> { f: T<u64> }
   │                      ^^^^^^
 
-error: expected 0 type arguments but 1 were provided
+error: expected 0 type arguments but 1 was provided
   ┌─ tests/checking/naming/generics_with_type_parameters.move:3:19
   │
 3 │     fun foo<T>(x: T<bool>): T<u64> {}
   │                   ^^^^^^^
 
-error: expected 0 type arguments but 1 were provided
+error: expected 0 type arguments but 1 was provided
   ┌─ tests/checking/naming/generics_with_type_parameters.move:3:29
   │
 3 │     fun foo<T>(x: T<bool>): T<u64> {}

--- a/third_party/move/move-compiler-v2/tests/checking/specs/expressions_err.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/specs/expressions_err.exp
@@ -42,7 +42,7 @@ error: expected function type returns value of type `num` but `bool` was provide
 37 │       wrongly_typed_fun_arg_callee(|x| false) // Wrongly typed function argument.
    │                                    ^^^^^^^^^
 
-error: expected 2 type arguments but 1 were provided
+error: expected 2 type arguments but 1 was provided
    ┌─ tests/checking/specs/expressions_err.move:42:7
    │
 42 │       wrong_instantiation<u64>(x) // Wrong instantiation

--- a/third_party/move/move-compiler-v2/tests/checking/typing/module_call.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/module_call.exp
@@ -1,84 +1,84 @@
 
 Diagnostics:
-error: the function takes 2 arguments but 1 were provided
+error: the function takes 2 arguments but 1 was provided
    ┌─ tests/checking/typing/module_call.move:43:26
    │
 43 │         let () = X::bing(X::baz(X::bar(X::foo()))); // invalid
    │                          ^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: the function takes 3 arguments but 1 were provided
+error: the function takes 3 arguments but 1 was provided
    ┌─ tests/checking/typing/module_call.move:43:18
    │
 43 │         let () = X::bing(X::baz(X::bar(X::foo()))); // invalid
    │                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: the function takes 2 arguments but 1 were provided
+error: the function takes 2 arguments but 1 was provided
    ┌─ tests/checking/typing/module_call.move:44:27
    │
 44 │         let () = X::bing (X::baz (X::bar (X::foo()))); // invalid
    │                           ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: the function takes 3 arguments but 1 were provided
+error: the function takes 3 arguments but 1 was provided
    ┌─ tests/checking/typing/module_call.move:44:18
    │
 44 │         let () = X::bing (X::baz (X::bar (X::foo()))); // invalid
    │                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: the function takes 2 arguments but 1 were provided
+error: the function takes 2 arguments but 1 was provided
    ┌─ tests/checking/typing/module_call.move:45:27
    │
 45 │         let () = X::bing (X::baz (X::bar(1))); // invalid
    │                           ^^^^^^^^^^^^^^^^^^
 
-error: the function takes 3 arguments but 1 were provided
+error: the function takes 3 arguments but 1 was provided
    ┌─ tests/checking/typing/module_call.move:45:18
    │
 45 │         let () = X::bing (X::baz (X::bar(1))); // invalid
    │                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: the function takes 3 arguments but 1 were provided
+error: the function takes 3 arguments but 1 was provided
    ┌─ tests/checking/typing/module_call.move:46:18
    │
 46 │         let () = X::bing (X::baz (@0x0, 1)); // invalid
    │                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: the function takes 2 arguments but 1 were provided
+error: the function takes 2 arguments but 1 was provided
    ┌─ tests/checking/typing/module_call.move:51:23
    │
 51 │         let () = bing(baz(bar(foo()))); // invalid
    │                       ^^^^^^^^^^^^^^^
 
-error: the function takes 3 arguments but 1 were provided
+error: the function takes 3 arguments but 1 was provided
    ┌─ tests/checking/typing/module_call.move:51:18
    │
 51 │         let () = bing(baz(bar(foo()))); // invalid
    │                  ^^^^^^^^^^^^^^^^^^^^^
 
-error: the function takes 2 arguments but 1 were provided
+error: the function takes 2 arguments but 1 was provided
    ┌─ tests/checking/typing/module_call.move:52:24
    │
 52 │         let () = bing (baz (bar (foo()))); // invalid
    │                        ^^^^^^^^^^^^^^^^^
 
-error: the function takes 3 arguments but 1 were provided
+error: the function takes 3 arguments but 1 was provided
    ┌─ tests/checking/typing/module_call.move:52:18
    │
 52 │         let () = bing (baz (bar (foo()))); // invalid
    │                  ^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: the function takes 2 arguments but 1 were provided
+error: the function takes 2 arguments but 1 was provided
    ┌─ tests/checking/typing/module_call.move:53:24
    │
 53 │         let () = bing (baz (bar(1))); // invalid
    │                        ^^^^^^^^^^^^
 
-error: the function takes 3 arguments but 1 were provided
+error: the function takes 3 arguments but 1 was provided
    ┌─ tests/checking/typing/module_call.move:53:18
    │
 53 │         let () = bing (baz (bar(1))); // invalid
    │                  ^^^^^^^^^^^^^^^^^^^
 
-error: the function takes 3 arguments but 1 were provided
+error: the function takes 3 arguments but 1 was provided
    ┌─ tests/checking/typing/module_call.move:54:18
    │
 54 │         let () = bing (baz (@0x0, 1)); // invalid

--- a/third_party/move/move-compiler-v2/tests/checking/typing/module_call_complicated_rhs.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/module_call_complicated_rhs.exp
@@ -1,72 +1,72 @@
 
 Diagnostics:
-error: the function takes 0 arguments but 1 were provided
+error: the function takes 0 arguments but 1 was provided
    ┌─ tests/checking/typing/module_call_complicated_rhs.move:11:9
    │
 11 │         foo (if (cond) () else ());
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: the function takes 2 arguments but 1 were provided
+error: the function takes 2 arguments but 1 was provided
    ┌─ tests/checking/typing/module_call_complicated_rhs.move:13:9
    │
 13 │         baz (if (cond) (false, @0x0) else (true, @0x1));
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: the function takes 0 arguments but 1 were provided
+error: the function takes 0 arguments but 1 was provided
    ┌─ tests/checking/typing/module_call_complicated_rhs.move:17:9
    │
 17 │         foo(if (cond) () else ());
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: the function takes 2 arguments but 1 were provided
+error: the function takes 2 arguments but 1 was provided
    ┌─ tests/checking/typing/module_call_complicated_rhs.move:19:9
    │
 19 │         baz(if (cond) (false, @0x0) else (true, @0x1));
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: the function takes 0 arguments but 1 were provided
+error: the function takes 0 arguments but 1 was provided
    ┌─ tests/checking/typing/module_call_complicated_rhs.move:23:9
    │
 23 │         foo({});
    │         ^^^^^^^
 
-error: the function takes 0 arguments but 1 were provided
+error: the function takes 0 arguments but 1 was provided
    ┌─ tests/checking/typing/module_call_complicated_rhs.move:24:9
    │
 24 │         foo({ let _x = 0; });
    │         ^^^^^^^^^^^^^^^^^^^^
 
-error: the function takes 2 arguments but 1 were provided
+error: the function takes 2 arguments but 1 was provided
    ┌─ tests/checking/typing/module_call_complicated_rhs.move:31:9
    │
 31 │         baz({ (a, x) });
    │         ^^^^^^^^^^^^^^^
 
-error: the function takes 2 arguments but 1 were provided
+error: the function takes 2 arguments but 1 was provided
    ┌─ tests/checking/typing/module_call_complicated_rhs.move:32:9
    │
 32 │         baz({ let a = false; (a, x) });
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: the function takes 0 arguments but 1 were provided
+error: the function takes 0 arguments but 1 was provided
    ┌─ tests/checking/typing/module_call_complicated_rhs.move:36:9
    │
 36 │         foo({});
    │         ^^^^^^^
 
-error: the function takes 0 arguments but 1 were provided
+error: the function takes 0 arguments but 1 was provided
    ┌─ tests/checking/typing/module_call_complicated_rhs.move:37:9
    │
 37 │         foo({ let _x = 0; });
    │         ^^^^^^^^^^^^^^^^^^^^
 
-error: the function takes 2 arguments but 1 were provided
+error: the function takes 2 arguments but 1 was provided
    ┌─ tests/checking/typing/module_call_complicated_rhs.move:44:9
    │
 44 │         baz({ (a, x) });
    │         ^^^^^^^^^^^^^^^
 
-error: the function takes 2 arguments but 1 were provided
+error: the function takes 2 arguments but 1 was provided
    ┌─ tests/checking/typing/module_call_complicated_rhs.move:45:9
    │
 45 │         baz({ let a = false; (a, x) });

--- a/third_party/move/move-compiler-v2/tests/checking/typing/module_call_wrong_arity.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/module_call_wrong_arity.exp
@@ -1,6 +1,6 @@
 
 Diagnostics:
-error: the function takes 0 arguments but 1 were provided
+error: the function takes 0 arguments but 1 was provided
    ┌─ tests/checking/typing/module_call_wrong_arity.move:27:9
    │
 27 │         X::foo(1);
@@ -30,7 +30,7 @@ error: the function takes 2 arguments but 0 were provided
 31 │         X::baz<u64, u64>();
    │         ^^^^^^^^^^^^^^^^^^
 
-error: the function takes 2 arguments but 1 were provided
+error: the function takes 2 arguments but 1 was provided
    ┌─ tests/checking/typing/module_call_wrong_arity.move:32:9
    │
 32 │         X::baz<u64, u64>(1);
@@ -42,7 +42,7 @@ error: the function takes 2 arguments but 3 were provided
 33 │         X::baz(1, 2, 3);
    │         ^^^^^^^^^^^^^^^
 
-error: the function takes 0 arguments but 1 were provided
+error: the function takes 0 arguments but 1 was provided
    ┌─ tests/checking/typing/module_call_wrong_arity.move:37:9
    │
 37 │         foo(1);
@@ -72,7 +72,7 @@ error: the function takes 2 arguments but 0 were provided
 41 │         baz<u64, u64>();
    │         ^^^^^^^^^^^^^^^
 
-error: the function takes 2 arguments but 1 were provided
+error: the function takes 2 arguments but 1 was provided
    ┌─ tests/checking/typing/module_call_wrong_arity.move:42:9
    │
 42 │         baz<u64, u64>(1);

--- a/third_party/move/move-compiler-v2/tests/checking/typing/v1-signer/move_to_missing_resource.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/v1-signer/move_to_missing_resource.exp
@@ -1,12 +1,12 @@
 
 Diagnostics:
-error: the function takes 2 arguments but 1 were provided
+error: the function takes 2 arguments but 1 was provided
   ┌─ tests/checking/typing/v1-signer/move_to_missing_resource.move:4:9
   │
 4 │         move_to<R>(s)
   │         ^^^^^^^^^^^^^
 
-error: the function takes 2 arguments but 1 were provided
+error: the function takes 2 arguments but 1 was provided
    ┌─ tests/checking/typing/v1-signer/move_to_missing_resource.move:14:14
    │
 14 │         () = move_to<R<bool>>(s);

--- a/third_party/move/move-compiler-v2/tests/checking/typing/v1-signer/move_to_missing_signer.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/v1-signer/move_to_missing_signer.exp
@@ -1,12 +1,12 @@
 
 Diagnostics:
-error: the function takes 2 arguments but 1 were provided
+error: the function takes 2 arguments but 1 was provided
   ┌─ tests/checking/typing/v1-signer/move_to_missing_signer.move:4:9
   │
 4 │         move_to<R>(R { f: false })
   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: the function takes 2 arguments but 1 were provided
+error: the function takes 2 arguments but 1 was provided
    ┌─ tests/checking/typing/v1-signer/move_to_missing_signer.move:14:14
    │
 14 │         () = move_to<R<bool>>(R<bool> { f: false });

--- a/third_party/move/move-compiler-v2/tests/checking/variants/variants_test_infer_err.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/variants/variants_test_infer_err.exp
@@ -24,7 +24,7 @@ error: expected variant of enum type but found type `0x815::m::S2`
 11 │         s is S2;
    │              ^^
 
-error: expected 0 type arguments but 1 were provided
+error: expected 0 type arguments but 1 was provided
    ┌─ tests/checking/variants/variants_test_infer_err.move:15:14
    │
 15 │         s is S2<u8>;

--- a/third_party/move/move-compiler-v2/tests/more-v1/parser/expr_unary_negation.exp
+++ b/third_party/move/move-compiler-v2/tests/more-v1/parser/expr_unary_negation.exp
@@ -1,6 +1,6 @@
 
 Diagnostics:
-error: the function takes 2 arguments but 1 were provided
+error: the function takes 2 arguments but 1 was provided
   ┌─ tests/more-v1/parser/expr_unary_negation.move:5:33
   │
 5 │     assert!(((1 - -2) == 3) && (-(1 - 2) == 1), 100);

--- a/third_party/move/move-model/src/builder/mod.rs
+++ b/third_party/move/move-model/src/builder/mod.rs
@@ -22,6 +22,14 @@ pub(crate) fn pluralize(s: &str, n: usize) -> String {
     }
 }
 
+pub(crate) fn pluralize_be(n: usize) -> String {
+    if n != 1 {
+        "were".to_string()
+    } else {
+        "was".to_string()
+    }
+}
+
 pub(crate) fn ith_str(n: usize) -> String {
     match n {
         0 => panic!("cannot be 0"),

--- a/third_party/move/move-model/src/ty.rs
+++ b/third_party/move/move-model/src/ty.rs
@@ -6,7 +6,7 @@
 
 use crate::{
     ast::{Address, ModuleName, QualifiedSymbol},
-    builder::{ith_str, pluralize},
+    builder::{ith_str, pluralize, pluralize_be},
     model::{
         FunId, GlobalEnv, Loc, ModuleId, QualifiedId, QualifiedInstId, StructEnv, StructId,
         TypeParameter, TypeParameterKind,
@@ -798,6 +798,10 @@ pub enum TypeUnificationError {
     FunResultTypeMismatch(Type, Type),
     /// The arity  of some construct mismatches: `ArityMismatch(for_type_args, actual, expected)`
     ArityMismatch(/*for_type_args*/ bool, usize, usize),
+    /// Arity mismatch in function argument types: `FunArgArityMismatch(actual, expected)`
+    FunArgArityMismatch(usize, usize),
+    /// Arity mismatch in function result types: `FunResultArityMismatch(actual, expected)`
+    FunResultArityMismatch(usize, usize),
     /// Two types have different mutability: `MutabilityMismatch(actual, expected)`.
     MutabilityMismatch(Type, Type),
     /// A generic representation of the error that a constraint wasn't satisfied, with
@@ -3045,61 +3049,68 @@ impl ErrorMessageContext {
                 actual,
             ),
             Argument => format!(
-                "the function takes {} {} but {} were provided",
+                "the function takes {} {} but {} {} provided",
                 expected,
                 if for_type_args {
                     pluralize("type argument", expected)
                 } else {
                     pluralize("argument", expected)
                 },
-                actual
+                actual,
+                pluralize_be(actual),
             ),
             PositionalUnpackArgument => format!(
-                "the struct/variant has {} {} but {} were provided",
+                "the struct/variant has {} {} but {} {} provided",
                 expected,
                 if for_type_args {
                     pluralize("type argument", expected)
                 } else {
                     pluralize("field", expected)
                 },
-                actual
+                actual,
+                pluralize_be(actual),
             ),
             ReceiverArgument => {
                 if for_type_args {
                     format!(
-                        "the receiver function takes {} type {} but {} were provided",
+                        "the receiver function takes {} type {} but {} {} provided",
                         expected,
                         pluralize("argument", expected),
-                        actual
+                        actual,
+                        pluralize_be(actual),
                     )
                 } else {
                     format!(
-                        "the receiver function takes {} {} but {} were provided",
+                        "the receiver function takes {} {} but {} {} provided",
                         expected - 1,
                         pluralize("argument", expected - 1),
-                        actual - 1
+                        actual - 1,
+                        pluralize_be(actual - 1),
                     )
                 }
             },
             OperatorArgument => format!(
-                "the operator takes {} {} but {} were provided",
+                "the operator takes {} {} but {} {} provided",
                 expected,
                 pluralize("argument", expected),
-                actual
+                actual,
+                pluralize_be(actual),
             ),
             TypeArgument => {
                 format!(
-                    "expected {} type {} but {} were provided",
+                    "expected {} type {} but {} {} provided",
                     expected,
                     pluralize("argument", expected),
-                    actual
+                    actual,
+                    pluralize_be(actual),
                 )
             },
             Return => format!(
-                "the function returns {} {} but {} were provided",
+                "the function returns {} {} but {} {} provided",
                 expected,
                 pluralize("argument", expected),
-                actual
+                actual,
+                pluralize_be(actual),
             ),
             SchemaInclusion(_) | General | TypeAnnotation => {
                 format!("expected {} items but found {}", expected, actual)
@@ -3194,7 +3205,13 @@ impl TypeUnificationError {
         match self {
             TypeUnificationError::TypeMismatch(t1, t2)
             | TypeUnificationError::MutabilityMismatch(t1, t2) => {
-                TypeUnificationError::FunArgTypeMismatch(t1, t2)
+                // Swap because function type arguments are unified with `order.swap()` (contra-variance), which causes
+                // `TypeMismatch`/`MutabilityMismatch` with swapped actual/expected values
+                TypeUnificationError::FunArgTypeMismatch(t2, t1)
+            },
+            TypeUnificationError::ArityMismatch(_for_type_args, actual, expected) => {
+                // Swap for the same reason as above
+                TypeUnificationError::FunArgArityMismatch(expected, actual)
             },
             _ => self,
         }
@@ -3205,6 +3222,9 @@ impl TypeUnificationError {
             TypeUnificationError::TypeMismatch(t1, t2)
             | TypeUnificationError::MutabilityMismatch(t1, t2) => {
                 TypeUnificationError::FunResultTypeMismatch(t1, t2)
+            },
+            TypeUnificationError::ArityMismatch(_for_type_args, actual, expected) => {
+                TypeUnificationError::FunResultArityMismatch(actual, expected)
             },
             _ => self,
         }
@@ -3254,8 +3274,7 @@ impl TypeUnificationError {
                 vec![],
                 vec![],
             ),
-            TypeUnificationError::FunArgTypeMismatch(expected, actual) => (
-                // Because of contra-variance, switches actual/expected order
+            TypeUnificationError::FunArgTypeMismatch(actual, expected) => (
                 format!(
                     "expected function type has argument of type `{}` but `{}` was provided",
                     expected.display(display_context),
@@ -3275,6 +3294,28 @@ impl TypeUnificationError {
             ),
             TypeUnificationError::ArityMismatch(for_type_args, actual, expected) => (
                 error_context.arity_mismatch(*for_type_args, *actual, *expected),
+                vec![],
+                vec![],
+            ),
+            TypeUnificationError::FunArgArityMismatch(actual, expected) => (
+                format!(
+                    "expected function type has {} {} but {} {} provided",
+                    expected,
+                    pluralize("argument", *expected),
+                    actual,
+                    pluralize_be(*actual)
+                ),
+                vec![],
+                vec![],
+            ),
+            TypeUnificationError::FunResultArityMismatch(actual, expected) => (
+                format!(
+                    "expected function type returns {} {} but {} {} provided",
+                    expected,
+                    pluralize("value", *expected),
+                    actual,
+                    pluralize_be(*actual)
+                ),
                 vec![],
                 vec![],
             ),

--- a/third_party/move/move-model/tests/sources/expressions_err.exp
+++ b/third_party/move/move-model/tests/sources/expressions_err.exp
@@ -40,7 +40,7 @@ error: expected function type returns value of type `num` but `bool` was provide
 41 │     fun wrongly_typed_fun_arg_caller(): num { wrongly_typed_fun_arg_callee(|x| false) }
    │                                                                            ^^^^^^^^^
 
-error: expected 2 type arguments but 1 were provided
+error: expected 2 type arguments but 1 was provided
    ┌─ tests/sources/expressions_err.move:46:7
    │
 46 │       wrong_instantiation<u64>(x)


### PR DESCRIPTION
## Description
This PR fixes issue #18335.

At the high level, the bug lies in error reporting during type resolution. When reporting an error, `message_with_hints_and_labels` (https://github.com/aptos-labs/aptos-core/blob/main/third_party/move/move-model/src/ty.rs#L3245) relies on both `ErrorMessageContext` and `TypeUnificationError` to report the error. However, the `ErrorMessageContext` may not match the actual context where `TypeUnificationError` happens, leading to confusing err msgs or even panics in rare cases.

Below is an example simplified from the case reported in the issue:
```Move
1. module 0x99::bug_18335 {
2.    struct S has drop {
3.        x: u64,
4.    }
5.
6.    fun receiver(self: &S, f: |u64|) {
7.        f(self.x);
8.    }
9.
10.    fun test(x: u64) {
11.        let s = S { x: 42 };
12.        let func = |x| {
13.            (x, 1u64)
14.        };
15.        s.receiver(func); // type error happens here, as `func` (of type `|u64|(u64, u64)`) does not match function type `|u64|`
16.    }
17.}
```

When translating line 15 `s.receiver(func)`, type resolution
* sets `ErrorMessageContext` to `ReceiverArgument` (https://github.com/aptos-labs/aptos-core/blob/main/third_party/move/move-model/src/builder/exp_builder.rs#L4966) 
* checks `func` against `type |u64|` , which recursively goes deeper to check `func`'s arg types and return types (https://github.com/aptos-labs/aptos-core/blob/main/third_party/move/move-model/src/ty.rs#L2297)
* when checking return types of `func`, the error message context is in principle no longer `ReceiverArgument` of `s.receiver(func)`, but the current code does not care.
* eventually, it will see that the return types of `func` , being `(u64, u64)` and not matching the expected `()`, throwing an `ArityMismatch` error.
* the error reporter will report this error under the context `ReceiverArgument` and error type `ArityMismatch` (https://github.com/aptos-labs/aptos-core/blob/main/third_party/move/move-model/src/ty.rs#L3038). 
* in usual cases, the message will say `the receiver function takes xx arguments but yy were provided`, which is confusing.
* in the case above, a panic due to int underflow will happen at https://github.com/aptos-labs/aptos-core/blob/main/third_party/move/move-model/src/ty.rs#L3078. Why: the `expected` , representing the number of return values by `f: |u64|`, is 0. Minus 1 from it will underflow.

To fundamentally fix the problem, we may need a redesign to ensure `ErrorMessageContext` always match the actual context where `TypeUnificationError` happens. This is non-trivial, requiring long-term plans.

This PR provides a temporary fix, which introduces two new error codes `FunArgArityMismatch` and `FunResultArityMismatch`, capturing arity mismatch on arguments and return values of function types. The PR also adapts the reporting function to report the two errors directly under the context of function types, ignoring the external `ErrorMessageContext`.

Close #18335

## How Has This Been Tested?
- Existing compiler tests
- New compiler tests: `third_party/move/move-compiler-v2/tests/checking-lang-v2.2/bug_18335.move`

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [x] Move Compiler
- [ ] Other (specify)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Resolves incorrect error context during function-type unification and eliminates an underflow panic.
> 
> - Introduces `FunArgArityMismatch` and `FunResultArityMismatch` and maps them in `map_to_fun_*` to report arg/return arity errors directly for function types
> - Adds `pluralize_be` and updates messages to use correct singular/plural: e.g., `the function takes N arguments but M was/were provided`
> - Adjusts `ErrorMessageContext::arity_mismatch` and related formatting to use `pluralize_be`
> - Adds regression test `tests/checking-lang-v2.2/bug_18335.move` and updates expected outputs across existing tests to the new wording
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0db7b53e68f9d7c77d36f0f9122267d2a21ff9e6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->