### PR TITLE
[move-prover] Adding behavioral predicates to the type checker

### DIFF
--- a/third_party/move/move-compiler-v2/src/bytecode_generator.rs
+++ b/third_party/move/move-compiler-v2/src/bytecode_generator.rs
@@ -1047,7 +1047,8 @@ impl Generator<'_> {
             | Operation::EmptyEventStore
             | Operation::ExtendEventStore
             | Operation::EventStoreIncludes
-            | Operation::EventStoreIncludedIn => self.internal_error(
+            | Operation::EventStoreIncludedIn
+            | Operation::Behavior(..) => self.internal_error(
                 id,
                 format!("unsupported specification construct: `{:?}`", op),
             ),

--- a/third_party/move/move-compiler-v2/tests/checking-lang-v2.4/specs/behavior_predicates_err.exp
+++ b/third_party/move/move-compiler-v2/tests/checking-lang-v2.4/specs/behavior_predicates_err.exp
@@ -1,49 +1,13 @@
 
 Diagnostics:
-error: behavior predicates for function values (requires_of, aborts_of, ensures_of, modifies_of) are not yet supported in the model
-   ┌─ tests/checking-lang-v2.4/specs/behavior_predicates_err.move:14:17
+error: global resource access expected
+   ┌─ tests/checking-lang-v2.4/specs/behavior_predicates_err.move:24:33
    │
-14 │         ensures requires_of<f>(x, y);
-   │                 ^^^^^^^^^^^^^^^^^^^^
-
-error: behavior predicates for function values (requires_of, aborts_of, ensures_of, modifies_of) are not yet supported in the model
-   ┌─ tests/checking-lang-v2.4/specs/behavior_predicates_err.move:17:17
-   │
-17 │         ensures ensures_of<f>(x, y, result);
-   │                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: behavior predicates for function values (requires_of, aborts_of, ensures_of, modifies_of) are not yet supported in the model
-   ┌─ tests/checking-lang-v2.4/specs/behavior_predicates_err.move:20:19
-   │
-20 │         aborts_if aborts_of<f>(x, y);
-   │                   ^^^^^^^^^^^^^^^^^^
-
-error: behavior predicates for function values (requires_of, aborts_of, ensures_of, modifies_of) are not yet supported in the model
-   ┌─ tests/checking-lang-v2.4/specs/behavior_predicates_err.move:23:18
-   │
-23 │         modifies modifies_of<f>(x);
-   │                  ^^^^^^^^^^^^^^^^^
+24 │         modifies modifies_of<f>(x);
+   │                                 ^
 
 error: global resource access expected
-   ┌─ tests/checking-lang-v2.4/specs/behavior_predicates_err.move:23:18
+   ┌─ tests/checking-lang-v2.4/specs/behavior_predicates_err.move:24:18
    │
-23 │         modifies modifies_of<f>(x);
+24 │         modifies modifies_of<f>(x);
    │                  ^^^^^^^^^^^^^^^^^
-
-error: behavior predicates for function values (requires_of, aborts_of, ensures_of, modifies_of) are not yet supported in the model
-   ┌─ tests/checking-lang-v2.4/specs/behavior_predicates_err.move:33:17
-   │
-33 │         ensures old@ensures_of<f>(x, result);
-   │                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: behavior predicates for function values (requires_of, aborts_of, ensures_of, modifies_of) are not yet supported in the model
-   ┌─ tests/checking-lang-v2.4/specs/behavior_predicates_err.move:36:17
-   │
-36 │         ensures ensures_of<f>(x, result)@post;
-   │                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: behavior predicates for function values (requires_of, aborts_of, ensures_of, modifies_of) are not yet supported in the model
-   ┌─ tests/checking-lang-v2.4/specs/behavior_predicates_err.move:39:17
-   │
-39 │         ensures pre@ensures_of<f>(x, result)@post;
-   │                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/checking-lang-v2.4/specs/behavior_predicates_err.move
+++ b/third_party/move/move-compiler-v2/tests/checking-lang-v2.4/specs/behavior_predicates_err.move
@@ -1,6 +1,7 @@
-// Tests for behavior predicate parsing and error messages.
+// Tests for behavior predicate type checking.
 // Behavior predicates (requires_of, aborts_of, ensures_of, modifies_of)
-// are parsed but not yet supported in the model builder.
+// are parsed and type-checked. This test verifies correct type checking
+// and expected error messages for invalid usage.
 
 module 0x42::M {
 

--- a/third_party/move/move-compiler-v2/tests/checking-lang-v2.4/specs/behavior_predicates_type_err.exp
+++ b/third_party/move/move-compiler-v2/tests/checking-lang-v2.4/specs/behavior_predicates_type_err.exp
@@ -1,0 +1,49 @@
+
+Diagnostics:
+error: expected 2 argument(s) for requires_of but 1 were provided
+   ┌─ tests/checking-lang-v2.4/specs/behavior_predicates_type_err.move:22:17
+   │
+22 │         ensures requires_of<binary>(a);
+   │                 ^^^^^^^^^^^^^^^^^^^^^^
+
+error: expected 2 argument(s) for ensures_of but 1 were provided
+   ┌─ tests/checking-lang-v2.4/specs/behavior_predicates_type_err.move:35:17
+   │
+35 │         ensures ensures_of<unary>(x);
+   │                 ^^^^^^^^^^^^^^^^^^^^
+
+error: unknown function `M::nonexistent_function` in behavior predicate
+   ┌─ tests/checking-lang-v2.4/specs/behavior_predicates_type_err.move:48:17
+   │
+48 │         ensures requires_of<nonexistent_function>(x);
+   │                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: type arguments cannot be provided for function parameter `f`
+   ┌─ tests/checking-lang-v2.4/specs/behavior_predicates_type_err.move:61:17
+   │
+61 │         ensures requires_of<f<u64>>(x);
+   │                 ^^^^^^^^^^^^^^^^^^^^^^
+
+error: behavior predicate target `x` must have function type, found `u64`
+   ┌─ tests/checking-lang-v2.4/specs/behavior_predicates_type_err.move:74:17
+   │
+74 │         ensures requires_of<x>(x);
+   │                 ^^^^^^^^^^^^^^^^^
+
+error: expected 1 type argument but 2 were provided
+   ┌─ tests/checking-lang-v2.4/specs/behavior_predicates_type_err.move:87:17
+   │
+87 │         ensures requires_of<generic_id<u64, u64>>(x);
+   │                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: expected `u64` but found a value of type `bool`
+    ┌─ tests/checking-lang-v2.4/specs/behavior_predicates_type_err.move:100:40
+    │
+100 │         ensures requires_of<binary>(a, b);
+    │                                        ^
+
+error: expected 2 argument(s) for requires_of but 3 were provided
+    ┌─ tests/checking-lang-v2.4/specs/behavior_predicates_type_err.move:113:17
+    │
+113 │         ensures requires_of<binary>(a, b, c);
+    │                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/checking-lang-v2.4/specs/behavior_predicates_type_err.move
+++ b/third_party/move/move-compiler-v2/tests/checking-lang-v2.4/specs/behavior_predicates_type_err.move
@@ -1,0 +1,115 @@
+// Tests for behavior predicate type checking errors.
+
+module 0x42::M {
+
+    // Helper functions
+    fun unary(x: u64): u64 { x }
+    fun binary(a: u64, b: u64): u64 { a + b }
+
+    // Generic helper function
+    fun generic_id<T>(x: T): T { x }
+
+    // ========================================
+    // Error: Wrong argument count for requires_of
+    // ========================================
+
+    fun test_requires_wrong_count(a: u64, b: u64): u64 {
+        binary(a, b)
+    }
+
+    spec test_requires_wrong_count {
+        // Error: binary takes 2 args, but only 1 provided
+        ensures requires_of<binary>(a);
+    }
+
+    // ========================================
+    // Error: Wrong argument count for ensures_of
+    // ========================================
+
+    fun test_ensures_wrong_count(x: u64): u64 {
+        unary(x)
+    }
+
+    spec test_ensures_wrong_count {
+        // Error: unary has 1 input + 1 result = 2 args needed, but only 1 provided
+        ensures ensures_of<unary>(x);
+    }
+
+    // ========================================
+    // Error: Unknown function target
+    // ========================================
+
+    fun test_unknown_function(x: u64): u64 {
+        x
+    }
+
+    spec test_unknown_function {
+        // Error: nonexistent_function doesn't exist
+        ensures requires_of<nonexistent_function>(x);
+    }
+
+    // ========================================
+    // Error: Type arguments provided for function parameter
+    // ========================================
+
+    fun apply_with_type_args(f: |u64| u64, x: u64): u64 {
+        f(x)
+    }
+
+    spec apply_with_type_args {
+        // Error: type arguments cannot be provided for function parameter
+        ensures requires_of<f<u64>>(x);
+    }
+
+    // ========================================
+    // Error: Non-function type used as target
+    // ========================================
+
+    fun test_non_function_target(x: u64): u64 {
+        x
+    }
+
+    spec test_non_function_target {
+        // Error: x is not a function type
+        ensures requires_of<x>(x);
+    }
+
+    // ========================================
+    // Error: Wrong type argument arity for generic function
+    // ========================================
+
+    fun test_wrong_type_arity(x: u64): u64 {
+        generic_id(x)
+    }
+
+    spec test_wrong_type_arity {
+        // Error: generic_id takes 1 type param, but 2 provided
+        ensures requires_of<generic_id<u64, u64>>(x);
+    }
+
+    // ========================================
+    // Error: Wrong argument type
+    // ========================================
+
+    fun test_wrong_arg_type(a: u64, b: bool): u64 {
+        a
+    }
+
+    spec test_wrong_arg_type {
+        // Error: binary expects (u64, u64), but (u64, bool) provided
+        ensures requires_of<binary>(a, b);
+    }
+
+    // ========================================
+    // Error: Too many arguments for requires_of
+    // ========================================
+
+    fun test_too_many_args(a: u64, b: u64, c: u64): u64 {
+        binary(a, b)
+    }
+
+    spec test_too_many_args {
+        // Error: binary takes 2 args, but 3 provided
+        ensures requires_of<binary>(a, b, c);
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/checking-lang-v2.4/specs/behavior_predicates_valid.exp
+++ b/third_party/move/move-compiler-v2/tests/checking-lang-v2.4/specs/behavior_predicates_valid.exp
@@ -1,0 +1,1906 @@
+// -- Model dump before first bytecode pipeline
+module 0x42::M {
+    struct Box<T> {
+        value: T,
+    }
+    struct Counter {
+        value: u64,
+    }
+    public fun swap<T>(a: T,b: T): (T, T) {
+        Tuple(b, a)
+    }
+    spec {
+      ensures Eq<#0>(result0(), $t1);
+      ensures Eq<#0>(result1(), $t0);
+    }
+
+    public fun add(a: u64,b: u64): u64 {
+        Add<u64>(a, b)
+    }
+    spec {
+      requires Le(Add($t0, $t1), 18446744073709551615);
+      ensures Eq<u64>(result0(), Add($t0, $t1));
+    }
+
+    private fun apply_aborts(f: |u64|u64,x: u64): u64 {
+        (f)(x)
+    }
+    spec {
+      aborts_if aborts_of<f>($t1);
+    }
+
+    private fun apply_binary(f: |u64, u64|u64,a: u64,b: u64): u64 {
+        (f)(a, b)
+    }
+    spec {
+      ensures requires_of<f>($t1, $t2);
+      ensures ensures_of<f>($t1, $t2, result0());
+      aborts_if aborts_of<f>($t1, $t2);
+    }
+
+    private fun apply_ensures(f: |u64|u64,x: u64): u64 {
+        (f)(x)
+    }
+    spec {
+      ensures ensures_of<f>($t1, result0());
+    }
+
+    private fun apply_modifies(f: |address|,addr: address) {
+        (f)(addr)
+    }
+    spec {
+      ensures modifies_of<f>(global<0x42::M::Counter>($t1));
+    }
+
+    private fun apply_requires(f: |u64|u64,x: u64): u64 {
+        (f)(x)
+    }
+    spec {
+      ensures requires_of<f>($t1);
+    }
+
+    private fun do_nothing(_x: u64) {
+        Tuple()
+    }
+    spec {
+      ensures true;
+    }
+
+    private fun generic_noop<T>(_x: T) {
+        Tuple()
+    }
+    public fun identity<T>(x: T): T {
+        x
+    }
+    spec {
+      ensures Eq<#0>(result0(), $t0);
+    }
+
+    public fun increment(x: u64): u64 {
+        Add<u64>(x, 1)
+    }
+    spec {
+      requires Lt($t0, 18446744073709551615);
+      ensures Eq<u64>(result0(), Add($t0, 1));
+    }
+
+    public fun increment_counter(addr: address)
+        acquires Counter(*)
+     {
+        {
+          let counter: &mut Counter = BorrowGlobal(Mutable)<Counter>(addr);
+          select M::Counter.value<&mut Counter>(counter) = Add<u64>(select M::Counter.value<&mut Counter>(counter), 1);
+          Tuple()
+        }
+    }
+    spec {
+      modifies global<0x42::M::Counter>($t0);
+      ensures Eq<u64>(select M::Counter.value<0x42::M::Counter>(global<0x42::M::Counter>($t0)), Add(select M::Counter.value<0x42::M::Counter>(Old<0x42::M::Counter>(global<0x42::M::Counter>($t0))), 1));
+    }
+
+    private fun mixed_params(x: u64,flag: bool): u64 {
+        if flag {
+          Add<u64>(x, 1)
+        } else {
+          x
+        }
+    }
+    public fun pair<T,U>(x: T,y: U): (T, U) {
+        Tuple(x, y)
+    }
+    spec {
+      ensures Eq<#0>(result0(), $t0);
+      ensures Eq<#1>(result1(), $t1);
+    }
+
+    private fun split(x: u64): (u64, u64) {
+        Tuple(Div<u64>(x, 2), Sub<u64>(x, Div<u64>(x, 2)))
+    }
+    spec {
+      ensures Eq<num>(Add(result0(), result1()), $t0);
+    }
+
+    public fun swap_counters(addr1: address,addr2: address)
+        acquires Counter(*)
+     {
+        {
+          let v1: u64 = select M::Counter.value<&Counter>(BorrowGlobal(Immutable)<Counter>(addr1));
+          {
+            let v2: u64 = select M::Counter.value<&Counter>(BorrowGlobal(Immutable)<Counter>(addr2));
+            select M::Counter.value<&mut Counter>(BorrowGlobal(Mutable)<Counter>(addr1)) = v2;
+            select M::Counter.value<&mut Counter>(BorrowGlobal(Mutable)<Counter>(addr2)) = v1;
+            Tuple()
+          }
+        }
+    }
+    spec {
+      modifies global<0x42::M::Counter>($t0);
+      modifies global<0x42::M::Counter>($t1);
+    }
+
+    private fun test_aborts(x: u64): u64 {
+        M::increment(x)
+    }
+    spec {
+      aborts_if aborts_of<M::increment>($t0);
+    }
+
+    private fun test_aborts_generic_explicit(x: u64): u64 {
+        M::identity<u64>(x)
+    }
+    spec {
+      aborts_if aborts_of<M::identity><u64>($t0);
+    }
+
+    private fun test_aborts_generic_inferred(x: u64): u64 {
+        M::identity<u64>(x)
+    }
+    spec {
+      aborts_if aborts_of<M::identity><u64>($t0);
+    }
+
+    private fun test_ensures_binary(a: u64,b: u64): u64 {
+        M::add(a, b)
+    }
+    spec {
+      ensures ensures_of<M::add>($t0, $t1, result0());
+    }
+
+    private fun test_ensures_generic_explicit(x: u64): u64 {
+        M::identity<u64>(x)
+    }
+    spec {
+      ensures ensures_of<M::identity><u64>($t0, result0());
+    }
+
+    private fun test_ensures_generic_inferred(x: u64): u64 {
+        M::identity<u64>(x)
+    }
+    spec {
+      ensures ensures_of<M::identity><u64>($t0, result0());
+    }
+
+    private fun test_ensures_generic_unit(x: u64) {
+        M::generic_noop<u64>(x)
+    }
+    spec {
+      ensures ensures_of<M::generic_noop><u64>($t0);
+    }
+
+    private fun test_ensures_multi(x: u64): (u64, u64) {
+        M::split(x)
+    }
+    spec {
+      ensures ensures_of<M::split>($t0, result0(), result1());
+    }
+
+    private fun test_ensures_unary(x: u64): u64 {
+        M::increment(x)
+    }
+    spec {
+      ensures ensures_of<M::increment>($t0, result0());
+    }
+
+    private fun test_ensures_unit(x: u64) {
+        M::do_nothing(x)
+    }
+    spec {
+      ensures ensures_of<M::do_nothing>($t0);
+    }
+
+    private fun test_mixed_params(x: u64,b: bool): u64 {
+        M::mixed_params(x, b)
+    }
+    spec {
+      ensures requires_of<M::mixed_params>($t0, $t1);
+      ensures ensures_of<M::mixed_params>($t0, $t1, result0());
+    }
+
+    private fun test_modifies_multi(addr1: address,addr2: address)
+        acquires Counter(*)
+     {
+        M::swap_counters(addr1, addr2)
+    }
+    spec {
+      ensures modifies_of<M::swap_counters>(global<0x42::M::Counter>($t0), global<0x42::M::Counter>($t1));
+    }
+
+    private fun test_modifies_single(addr: address)
+        acquires Counter(*)
+     {
+        M::increment_counter(addr)
+    }
+    spec {
+      ensures modifies_of<M::increment_counter>(global<0x42::M::Counter>($t0));
+    }
+
+    private fun test_pair_generic_explicit(x: u64,y: bool): (u64, bool) {
+        M::pair<u64, bool>(x, y)
+    }
+    spec {
+      ensures requires_of<M::pair><u64, bool>($t0, $t1);
+      ensures ensures_of<M::pair><u64, bool>($t0, $t1, result0(), result1());
+    }
+
+    private fun test_requires_binary(a: u64,b: u64): u64 {
+        M::add(a, b)
+    }
+    spec {
+      ensures requires_of<M::add>($t0, $t1);
+    }
+
+    private fun test_requires_generic_explicit(x: u64): u64 {
+        M::identity<u64>(x)
+    }
+    spec {
+      ensures requires_of<M::identity><u64>($t0);
+    }
+
+    private fun test_requires_generic_inferred(x: u64): u64 {
+        M::identity<u64>(x)
+    }
+    spec {
+      ensures requires_of<M::identity><u64>($t0);
+    }
+
+    private fun test_requires_unary(x: u64): u64 {
+        M::increment(x)
+    }
+    spec {
+      ensures requires_of<M::increment>($t0);
+    }
+
+    private fun test_swap_generic_explicit(a: u64,b: u64): (u64, u64) {
+        M::swap<u64>(a, b)
+    }
+    spec {
+      ensures requires_of<M::swap><u64>($t0, $t1);
+      ensures ensures_of<M::swap><u64>($t0, $t1, result0(), result1());
+    }
+
+    private fun test_swap_generic_inferred(a: u64,b: u64): (u64, u64) {
+        M::swap<u64>(a, b)
+    }
+    spec {
+      ensures requires_of<M::swap><u64>($t0, $t1);
+      ensures ensures_of<M::swap><u64>($t0, $t1, result0(), result1());
+    }
+
+    private fun test_unbox_inferred(b: Box<u64>): u64 {
+        M::unbox<u64>(b)
+    }
+    spec {
+      ensures requires_of<M::unbox><u64>($t0);
+      ensures ensures_of<M::unbox><u64>($t0, result0());
+    }
+
+    public fun unbox<T>(b: Box<T>): T {
+        select M::Box.value<Box<T>>(b)
+    }
+    spec {
+      ensures Eq<#0>(result0(), select M::Box.value<0x42::M::Box<#0>>($t0));
+    }
+
+} // end 0x42::M
+module 0x42::N {
+    use 0x42::M; // resolved as: 0x42::M
+    private fun call_add(a: u64,b: u64): u64 {
+        M::add(a, b)
+    }
+    spec {
+      ensures requires_of<M::add>($t0, $t1);
+      ensures ensures_of<M::add>($t0, $t1, result0());
+    }
+
+    private fun call_increment(x: u64): u64 {
+        M::increment(x)
+    }
+    spec {
+      ensures requires_of<M::increment>($t0);
+      ensures ensures_of<M::increment>($t0, result0());
+    }
+
+} // end 0x42::N
+
+// -- Sourcified model before first bytecode pipeline
+module 0x42::M {
+    struct Box<T> has copy, drop {
+        value: T,
+    }
+    struct Counter has key {
+        value: u64,
+    }
+    public fun swap<T>(a: T, b: T): (T, T) {
+        (b, a)
+    }
+    public fun add(a: u64, b: u64): u64 {
+        a + b
+    }
+    fun apply_aborts(f: |u64|u64, x: u64): u64 {
+        f(x)
+    }
+    fun apply_binary(f: |u64, u64|u64, a: u64, b: u64): u64 {
+        f(a, b)
+    }
+    fun apply_ensures(f: |u64|u64, x: u64): u64 {
+        f(x)
+    }
+    fun apply_modifies(f: |address|, addr: address) {
+        f(addr)
+    }
+    fun apply_requires(f: |u64|u64, x: u64): u64 {
+        f(x)
+    }
+    fun do_nothing(_x: u64) {
+    }
+    fun generic_noop<T: drop>(_x: T) {
+    }
+    public fun identity<T>(x: T): T {
+        x
+    }
+    public fun increment(x: u64): u64 {
+        x + 1
+    }
+    public fun increment_counter(addr: address)
+        acquires Counter
+    {
+        let counter = borrow_global_mut<Counter>(addr);
+        counter.value = counter.value + 1;
+    }
+    fun mixed_params(x: u64, flag: bool): u64 {
+        if (flag) x + 1 else x
+    }
+    public fun pair<T, U>(x: T, y: U): (T, U) {
+        (x, y)
+    }
+    fun split(x: u64): (u64, u64) {
+        (x / 2, x - x / 2)
+    }
+    public fun swap_counters(addr1: address, addr2: address)
+        acquires Counter
+    {
+        let v1 = borrow_global<Counter>(addr1).value;
+        let v2 = borrow_global<Counter>(addr2).value;
+        borrow_global_mut<Counter>(addr1).value = v2;
+        borrow_global_mut<Counter>(addr2).value = v1;
+    }
+    fun test_aborts(x: u64): u64 {
+        increment(x)
+    }
+    fun test_aborts_generic_explicit(x: u64): u64 {
+        identity<u64>(x)
+    }
+    fun test_aborts_generic_inferred(x: u64): u64 {
+        identity<u64>(x)
+    }
+    fun test_ensures_binary(a: u64, b: u64): u64 {
+        add(a, b)
+    }
+    fun test_ensures_generic_explicit(x: u64): u64 {
+        identity<u64>(x)
+    }
+    fun test_ensures_generic_inferred(x: u64): u64 {
+        identity<u64>(x)
+    }
+    fun test_ensures_generic_unit(x: u64) {
+        generic_noop<u64>(x)
+    }
+    fun test_ensures_multi(x: u64): (u64, u64) {
+        split(x)
+    }
+    fun test_ensures_unary(x: u64): u64 {
+        increment(x)
+    }
+    fun test_ensures_unit(x: u64) {
+        do_nothing(x)
+    }
+    fun test_mixed_params(x: u64, b: bool): u64 {
+        mixed_params(x, b)
+    }
+    fun test_modifies_multi(addr1: address, addr2: address)
+        acquires Counter
+    {
+        swap_counters(addr1, addr2)
+    }
+    fun test_modifies_single(addr: address)
+        acquires Counter
+    {
+        increment_counter(addr)
+    }
+    fun test_pair_generic_explicit(x: u64, y: bool): (u64, bool) {
+        pair<u64,bool>(x, y)
+    }
+    fun test_requires_binary(a: u64, b: u64): u64 {
+        add(a, b)
+    }
+    fun test_requires_generic_explicit(x: u64): u64 {
+        identity<u64>(x)
+    }
+    fun test_requires_generic_inferred(x: u64): u64 {
+        identity<u64>(x)
+    }
+    fun test_requires_unary(x: u64): u64 {
+        increment(x)
+    }
+    fun test_swap_generic_explicit(a: u64, b: u64): (u64, u64) {
+        swap<u64>(a, b)
+    }
+    fun test_swap_generic_inferred(a: u64, b: u64): (u64, u64) {
+        swap<u64>(a, b)
+    }
+    fun test_unbox_inferred(b: Box<u64>): u64 {
+        unbox<u64>(b)
+    }
+    public fun unbox<T: copy + drop>(b: Box<T>): T {
+        b.value
+    }
+}
+module 0x42::N {
+    use 0x42::M;
+    fun call_add(a: u64, b: u64): u64 {
+        M::add(a, b)
+    }
+    fun call_increment(x: u64): u64 {
+        M::increment(x)
+    }
+}
+
+============ bytecode before first stackless bytecode pipeline ================
+
+[variant baseline]
+public fun M::swap<#0>($t0: #0, $t1: #0): (#0, #0) {
+     var $t2: #0
+     var $t3: #0
+  0: $t2 := infer($t1)
+  1: $t3 := infer($t0)
+  2: return ($t2, $t3)
+}
+
+
+[variant baseline]
+public fun M::add($t0: u64, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+  0: $t3 := infer($t0)
+  1: $t2 := +($t3, $t1)
+  2: return $t2
+}
+
+
+[variant baseline]
+fun M::apply_aborts($t0: |u64|u64, $t1: u64): u64 {
+     var $t2: u64
+  0: $t2 := invoke($t1, $t0)
+  1: return $t2
+}
+
+
+[variant baseline]
+fun M::apply_binary($t0: |u64, u64|u64, $t1: u64, $t2: u64): u64 {
+     var $t3: u64
+     var $t4: u64
+  0: $t4 := infer($t1)
+  1: $t3 := invoke($t4, $t2, $t0)
+  2: return $t3
+}
+
+
+[variant baseline]
+fun M::apply_ensures($t0: |u64|u64, $t1: u64): u64 {
+     var $t2: u64
+  0: $t2 := invoke($t1, $t0)
+  1: return $t2
+}
+
+
+[variant baseline]
+fun M::apply_modifies($t0: |address|, $t1: address) {
+  0: invoke($t1, $t0)
+  1: return ()
+}
+
+
+[variant baseline]
+fun M::apply_requires($t0: |u64|u64, $t1: u64): u64 {
+     var $t2: u64
+  0: $t2 := invoke($t1, $t0)
+  1: return $t2
+}
+
+
+[variant baseline]
+fun M::do_nothing($t0: u64) {
+  0: return ()
+}
+
+
+[variant baseline]
+fun M::generic_noop<#0>($t0: #0) {
+  0: return ()
+}
+
+
+[variant baseline]
+public fun M::identity<#0>($t0: #0): #0 {
+     var $t1: #0
+  0: $t1 := infer($t0)
+  1: return $t1
+}
+
+
+[variant baseline]
+public fun M::increment($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+  0: $t2 := infer($t0)
+  1: $t3 := 1
+  2: $t1 := +($t2, $t3)
+  3: return $t1
+}
+
+
+[variant baseline]
+public fun M::increment_counter($t0: address) {
+     var $t1: &mut 0x42::M::Counter
+     var $t2: u64
+     var $t3: u64
+     var $t4: &u64
+     var $t5: u64
+     var $t6: &mut u64
+  0: $t1 := borrow_global<0x42::M::Counter>($t0)
+  1: $t4 := borrow_field<0x42::M::Counter>.value($t1)
+  2: $t3 := read_ref($t4)
+  3: $t5 := 1
+  4: $t2 := +($t3, $t5)
+  5: $t6 := borrow_field<0x42::M::Counter>.value($t1)
+  6: write_ref($t6, $t2)
+  7: return ()
+}
+
+
+[variant baseline]
+fun M::mixed_params($t0: u64, $t1: bool): u64 {
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+  0: if ($t1) goto 1 else goto 6
+  1: label L0
+  2: $t3 := infer($t0)
+  3: $t4 := 1
+  4: $t2 := +($t3, $t4)
+  5: goto 8
+  6: label L1
+  7: $t2 := infer($t0)
+  8: label L2
+  9: return $t2
+}
+
+
+[variant baseline]
+public fun M::pair<#0, #1>($t0: #0, $t1: #1): (#0, #1) {
+     var $t2: #0
+     var $t3: #1
+  0: $t2 := infer($t0)
+  1: $t3 := infer($t1)
+  2: return ($t2, $t3)
+}
+
+
+[variant baseline]
+fun M::split($t0: u64): (u64, u64) {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+     var $t8: u64
+  0: $t3 := infer($t0)
+  1: $t4 := 2
+  2: $t1 := /($t3, $t4)
+  3: $t5 := infer($t0)
+  4: $t7 := infer($t0)
+  5: $t8 := 2
+  6: $t6 := /($t7, $t8)
+  7: $t2 := -($t5, $t6)
+  8: return ($t1, $t2)
+}
+
+
+[variant baseline]
+public fun M::swap_counters($t0: address, $t1: address) {
+     var $t2: u64
+     var $t3: &0x42::M::Counter
+     var $t4: &u64
+     var $t5: u64
+     var $t6: &0x42::M::Counter
+     var $t7: &u64
+     var $t8: &mut u64
+     var $t9: &mut 0x42::M::Counter
+     var $t10: &mut u64
+     var $t11: &mut 0x42::M::Counter
+  0: $t3 := borrow_global<0x42::M::Counter>($t0)
+  1: $t4 := borrow_field<0x42::M::Counter>.value($t3)
+  2: $t2 := read_ref($t4)
+  3: $t6 := borrow_global<0x42::M::Counter>($t1)
+  4: $t7 := borrow_field<0x42::M::Counter>.value($t6)
+  5: $t5 := read_ref($t7)
+  6: $t9 := borrow_global<0x42::M::Counter>($t0)
+  7: $t8 := borrow_field<0x42::M::Counter>.value($t9)
+  8: write_ref($t8, $t5)
+  9: $t11 := borrow_global<0x42::M::Counter>($t1)
+ 10: $t10 := borrow_field<0x42::M::Counter>.value($t11)
+ 11: write_ref($t10, $t2)
+ 12: return ()
+}
+
+
+[variant baseline]
+fun M::test_aborts($t0: u64): u64 {
+     var $t1: u64
+  0: $t1 := M::increment($t0)
+  1: return $t1
+}
+
+
+[variant baseline]
+fun M::test_aborts_generic_explicit($t0: u64): u64 {
+     var $t1: u64
+  0: $t1 := M::identity<u64>($t0)
+  1: return $t1
+}
+
+
+[variant baseline]
+fun M::test_aborts_generic_inferred($t0: u64): u64 {
+     var $t1: u64
+  0: $t1 := M::identity<u64>($t0)
+  1: return $t1
+}
+
+
+[variant baseline]
+fun M::test_ensures_binary($t0: u64, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+  0: $t3 := infer($t0)
+  1: $t2 := M::add($t3, $t1)
+  2: return $t2
+}
+
+
+[variant baseline]
+fun M::test_ensures_generic_explicit($t0: u64): u64 {
+     var $t1: u64
+  0: $t1 := M::identity<u64>($t0)
+  1: return $t1
+}
+
+
+[variant baseline]
+fun M::test_ensures_generic_inferred($t0: u64): u64 {
+     var $t1: u64
+  0: $t1 := M::identity<u64>($t0)
+  1: return $t1
+}
+
+
+[variant baseline]
+fun M::test_ensures_generic_unit($t0: u64) {
+  0: M::generic_noop<u64>($t0)
+  1: return ()
+}
+
+
+[variant baseline]
+fun M::test_ensures_multi($t0: u64): (u64, u64) {
+     var $t1: u64
+     var $t2: u64
+  0: ($t1, $t2) := M::split($t0)
+  1: return ($t1, $t2)
+}
+
+
+[variant baseline]
+fun M::test_ensures_unary($t0: u64): u64 {
+     var $t1: u64
+  0: $t1 := M::increment($t0)
+  1: return $t1
+}
+
+
+[variant baseline]
+fun M::test_ensures_unit($t0: u64) {
+  0: M::do_nothing($t0)
+  1: return ()
+}
+
+
+[variant baseline]
+fun M::test_mixed_params($t0: u64, $t1: bool): u64 {
+     var $t2: u64
+     var $t3: u64
+  0: $t3 := infer($t0)
+  1: $t2 := M::mixed_params($t3, $t1)
+  2: return $t2
+}
+
+
+[variant baseline]
+fun M::test_modifies_multi($t0: address, $t1: address) {
+     var $t2: address
+  0: $t2 := infer($t0)
+  1: M::swap_counters($t2, $t1)
+  2: return ()
+}
+
+
+[variant baseline]
+fun M::test_modifies_single($t0: address) {
+  0: M::increment_counter($t0)
+  1: return ()
+}
+
+
+[variant baseline]
+fun M::test_pair_generic_explicit($t0: u64, $t1: bool): (u64, bool) {
+     var $t2: u64
+     var $t3: bool
+     var $t4: u64
+  0: $t4 := infer($t0)
+  1: ($t2, $t3) := M::pair<u64, bool>($t4, $t1)
+  2: return ($t2, $t3)
+}
+
+
+[variant baseline]
+fun M::test_requires_binary($t0: u64, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+  0: $t3 := infer($t0)
+  1: $t2 := M::add($t3, $t1)
+  2: return $t2
+}
+
+
+[variant baseline]
+fun M::test_requires_generic_explicit($t0: u64): u64 {
+     var $t1: u64
+  0: $t1 := M::identity<u64>($t0)
+  1: return $t1
+}
+
+
+[variant baseline]
+fun M::test_requires_generic_inferred($t0: u64): u64 {
+     var $t1: u64
+  0: $t1 := M::identity<u64>($t0)
+  1: return $t1
+}
+
+
+[variant baseline]
+fun M::test_requires_unary($t0: u64): u64 {
+     var $t1: u64
+  0: $t1 := M::increment($t0)
+  1: return $t1
+}
+
+
+[variant baseline]
+fun M::test_swap_generic_explicit($t0: u64, $t1: u64): (u64, u64) {
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+  0: $t4 := infer($t0)
+  1: ($t2, $t3) := M::swap<u64>($t4, $t1)
+  2: return ($t2, $t3)
+}
+
+
+[variant baseline]
+fun M::test_swap_generic_inferred($t0: u64, $t1: u64): (u64, u64) {
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+  0: $t4 := infer($t0)
+  1: ($t2, $t3) := M::swap<u64>($t4, $t1)
+  2: return ($t2, $t3)
+}
+
+
+[variant baseline]
+fun M::test_unbox_inferred($t0: 0x42::M::Box<u64>): u64 {
+     var $t1: u64
+  0: $t1 := M::unbox<u64>($t0)
+  1: return $t1
+}
+
+
+[variant baseline]
+public fun M::unbox<#0>($t0: 0x42::M::Box<#0>): #0 {
+     var $t1: #0
+     var $t2: &0x42::M::Box<#0>
+     var $t3: &#0
+  0: $t2 := borrow_local($t0)
+  1: $t3 := borrow_field<0x42::M::Box<#0>>.value($t2)
+  2: $t1 := read_ref($t3)
+  3: return $t1
+}
+
+
+[variant baseline]
+fun N::call_add($t0: u64, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+  0: $t3 := infer($t0)
+  1: $t2 := M::add($t3, $t1)
+  2: return $t2
+}
+
+
+[variant baseline]
+fun N::call_increment($t0: u64): u64 {
+     var $t1: u64
+  0: $t1 := M::increment($t0)
+  1: return $t1
+}
+
+// -- Model dump before second bytecode pipeline
+module 0x42::M {
+    struct Box<T> {
+        value: T,
+    }
+    struct Counter {
+        value: u64,
+    }
+    public fun swap<T>(a: T,b: T): (T, T) {
+        Tuple(b, a)
+    }
+    spec {
+      ensures Eq<#0>(result0(), $t1);
+      ensures Eq<#0>(result1(), $t0);
+    }
+
+    public fun add(a: u64,b: u64): u64 {
+        Add<u64>(a, b)
+    }
+    spec {
+      requires Le(Add($t0, $t1), 18446744073709551615);
+      ensures Eq<u64>(result0(), Add($t0, $t1));
+    }
+
+    private fun apply_aborts(f: |u64|u64,x: u64): u64 {
+        (f)(x)
+    }
+    spec {
+      aborts_if aborts_of<f>($t1);
+    }
+
+    private fun apply_binary(f: |u64, u64|u64,a: u64,b: u64): u64 {
+        (f)(a, b)
+    }
+    spec {
+      ensures requires_of<f>($t1, $t2);
+      ensures ensures_of<f>($t1, $t2, result0());
+      aborts_if aborts_of<f>($t1, $t2);
+    }
+
+    private fun apply_ensures(f: |u64|u64,x: u64): u64 {
+        (f)(x)
+    }
+    spec {
+      ensures ensures_of<f>($t1, result0());
+    }
+
+    private fun apply_modifies(f: |address|,addr: address) {
+        (f)(addr)
+    }
+    spec {
+      ensures modifies_of<f>(global<0x42::M::Counter>($t1));
+    }
+
+    private fun apply_requires(f: |u64|u64,x: u64): u64 {
+        (f)(x)
+    }
+    spec {
+      ensures requires_of<f>($t1);
+    }
+
+    private fun do_nothing(_x: u64) {
+        Tuple()
+    }
+    spec {
+      ensures true;
+    }
+
+    private fun generic_noop<T>(_x: T) {
+        Tuple()
+    }
+    public fun identity<T>(x: T): T {
+        x
+    }
+    spec {
+      ensures Eq<#0>(result0(), $t0);
+    }
+
+    public fun increment(x: u64): u64 {
+        Add<u64>(x, 1)
+    }
+    spec {
+      requires Lt($t0, 18446744073709551615);
+      ensures Eq<u64>(result0(), Add($t0, 1));
+    }
+
+    public fun increment_counter(addr: address)
+        acquires Counter(*)
+     {
+        {
+          let counter: &mut Counter = BorrowGlobal(Mutable)<Counter>(addr);
+          select M::Counter.value<&mut Counter>(counter) = Add<u64>(select M::Counter.value<&mut Counter>(counter), 1);
+          Tuple()
+        }
+    }
+    spec {
+      modifies global<0x42::M::Counter>($t0);
+      ensures Eq<u64>(select M::Counter.value<0x42::M::Counter>(global<0x42::M::Counter>($t0)), Add(select M::Counter.value<0x42::M::Counter>(Old<0x42::M::Counter>(global<0x42::M::Counter>($t0))), 1));
+    }
+
+    private fun mixed_params(x: u64,flag: bool): u64 {
+        if flag {
+          Add<u64>(x, 1)
+        } else {
+          x
+        }
+    }
+    public fun pair<T,U>(x: T,y: U): (T, U) {
+        Tuple(x, y)
+    }
+    spec {
+      ensures Eq<#0>(result0(), $t0);
+      ensures Eq<#1>(result1(), $t1);
+    }
+
+    private fun split(x: u64): (u64, u64) {
+        Tuple(Div<u64>(x, 2), Sub<u64>(x, Div<u64>(x, 2)))
+    }
+    spec {
+      ensures Eq<num>(Add(result0(), result1()), $t0);
+    }
+
+    public fun swap_counters(addr1: address,addr2: address)
+        acquires Counter(*)
+     {
+        {
+          let v1: u64 = select M::Counter.value<&Counter>(BorrowGlobal(Immutable)<Counter>(addr1));
+          {
+            let v2: u64 = select M::Counter.value<&Counter>(BorrowGlobal(Immutable)<Counter>(addr2));
+            select M::Counter.value<&mut Counter>(BorrowGlobal(Mutable)<Counter>(addr1)) = v2;
+            select M::Counter.value<&mut Counter>(BorrowGlobal(Mutable)<Counter>(addr2)) = v1;
+            Tuple()
+          }
+        }
+    }
+    spec {
+      modifies global<0x42::M::Counter>($t0);
+      modifies global<0x42::M::Counter>($t1);
+    }
+
+    private fun test_aborts(x: u64): u64 {
+        M::increment(x)
+    }
+    spec {
+      aborts_if aborts_of<M::increment>($t0);
+    }
+
+    private fun test_aborts_generic_explicit(x: u64): u64 {
+        M::identity<u64>(x)
+    }
+    spec {
+      aborts_if aborts_of<M::identity><u64>($t0);
+    }
+
+    private fun test_aborts_generic_inferred(x: u64): u64 {
+        M::identity<u64>(x)
+    }
+    spec {
+      aborts_if aborts_of<M::identity><u64>($t0);
+    }
+
+    private fun test_ensures_binary(a: u64,b: u64): u64 {
+        M::add(a, b)
+    }
+    spec {
+      ensures ensures_of<M::add>($t0, $t1, result0());
+    }
+
+    private fun test_ensures_generic_explicit(x: u64): u64 {
+        M::identity<u64>(x)
+    }
+    spec {
+      ensures ensures_of<M::identity><u64>($t0, result0());
+    }
+
+    private fun test_ensures_generic_inferred(x: u64): u64 {
+        M::identity<u64>(x)
+    }
+    spec {
+      ensures ensures_of<M::identity><u64>($t0, result0());
+    }
+
+    private fun test_ensures_generic_unit(x: u64) {
+        M::generic_noop<u64>(x)
+    }
+    spec {
+      ensures ensures_of<M::generic_noop><u64>($t0);
+    }
+
+    private fun test_ensures_multi(x: u64): (u64, u64) {
+        M::split(x)
+    }
+    spec {
+      ensures ensures_of<M::split>($t0, result0(), result1());
+    }
+
+    private fun test_ensures_unary(x: u64): u64 {
+        M::increment(x)
+    }
+    spec {
+      ensures ensures_of<M::increment>($t0, result0());
+    }
+
+    private fun test_ensures_unit(x: u64) {
+        M::do_nothing(x)
+    }
+    spec {
+      ensures ensures_of<M::do_nothing>($t0);
+    }
+
+    private fun test_mixed_params(x: u64,b: bool): u64 {
+        M::mixed_params(x, b)
+    }
+    spec {
+      ensures requires_of<M::mixed_params>($t0, $t1);
+      ensures ensures_of<M::mixed_params>($t0, $t1, result0());
+    }
+
+    private fun test_modifies_multi(addr1: address,addr2: address)
+        acquires Counter(*)
+     {
+        M::swap_counters(addr1, addr2)
+    }
+    spec {
+      ensures modifies_of<M::swap_counters>(global<0x42::M::Counter>($t0), global<0x42::M::Counter>($t1));
+    }
+
+    private fun test_modifies_single(addr: address)
+        acquires Counter(*)
+     {
+        M::increment_counter(addr)
+    }
+    spec {
+      ensures modifies_of<M::increment_counter>(global<0x42::M::Counter>($t0));
+    }
+
+    private fun test_pair_generic_explicit(x: u64,y: bool): (u64, bool) {
+        M::pair<u64, bool>(x, y)
+    }
+    spec {
+      ensures requires_of<M::pair><u64, bool>($t0, $t1);
+      ensures ensures_of<M::pair><u64, bool>($t0, $t1, result0(), result1());
+    }
+
+    private fun test_requires_binary(a: u64,b: u64): u64 {
+        M::add(a, b)
+    }
+    spec {
+      ensures requires_of<M::add>($t0, $t1);
+    }
+
+    private fun test_requires_generic_explicit(x: u64): u64 {
+        M::identity<u64>(x)
+    }
+    spec {
+      ensures requires_of<M::identity><u64>($t0);
+    }
+
+    private fun test_requires_generic_inferred(x: u64): u64 {
+        M::identity<u64>(x)
+    }
+    spec {
+      ensures requires_of<M::identity><u64>($t0);
+    }
+
+    private fun test_requires_unary(x: u64): u64 {
+        M::increment(x)
+    }
+    spec {
+      ensures requires_of<M::increment>($t0);
+    }
+
+    private fun test_swap_generic_explicit(a: u64,b: u64): (u64, u64) {
+        M::swap<u64>(a, b)
+    }
+    spec {
+      ensures requires_of<M::swap><u64>($t0, $t1);
+      ensures ensures_of<M::swap><u64>($t0, $t1, result0(), result1());
+    }
+
+    private fun test_swap_generic_inferred(a: u64,b: u64): (u64, u64) {
+        M::swap<u64>(a, b)
+    }
+    spec {
+      ensures requires_of<M::swap><u64>($t0, $t1);
+      ensures ensures_of<M::swap><u64>($t0, $t1, result0(), result1());
+    }
+
+    private fun test_unbox_inferred(b: Box<u64>): u64 {
+        M::unbox<u64>(b)
+    }
+    spec {
+      ensures requires_of<M::unbox><u64>($t0);
+      ensures ensures_of<M::unbox><u64>($t0, result0());
+    }
+
+    public fun unbox<T>(b: Box<T>): T {
+        select M::Box.value<Box<T>>(b)
+    }
+    spec {
+      ensures Eq<#0>(result0(), select M::Box.value<0x42::M::Box<#0>>($t0));
+    }
+
+} // end 0x42::M
+module 0x42::N {
+    use 0x42::M; // resolved as: 0x42::M
+    private fun call_add(a: u64,b: u64): u64 {
+        M::add(a, b)
+    }
+    spec {
+      ensures requires_of<M::add>($t0, $t1);
+      ensures ensures_of<M::add>($t0, $t1, result0());
+    }
+
+    private fun call_increment(x: u64): u64 {
+        M::increment(x)
+    }
+    spec {
+      ensures requires_of<M::increment>($t0);
+      ensures ensures_of<M::increment>($t0, result0());
+    }
+
+} // end 0x42::N
+
+============ bytecode before second stackless bytecode pipeline ================
+
+[variant baseline]
+public fun M::swap<#0>($t0: #0, $t1: #0): (#0, #0) {
+     var $t2: #0
+     var $t3: #0
+  0: $t2 := infer($t1)
+  1: $t3 := infer($t0)
+  2: return ($t2, $t3)
+}
+
+
+[variant baseline]
+public fun M::add($t0: u64, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+  0: $t3 := infer($t0)
+  1: $t2 := +($t3, $t1)
+  2: return $t2
+}
+
+
+[variant baseline]
+fun M::apply_aborts($t0: |u64|u64, $t1: u64): u64 {
+     var $t2: u64
+  0: $t2 := invoke($t1, $t0)
+  1: return $t2
+}
+
+
+[variant baseline]
+fun M::apply_binary($t0: |u64, u64|u64, $t1: u64, $t2: u64): u64 {
+     var $t3: u64
+     var $t4: u64
+  0: $t4 := infer($t1)
+  1: $t3 := invoke($t4, $t2, $t0)
+  2: return $t3
+}
+
+
+[variant baseline]
+fun M::apply_ensures($t0: |u64|u64, $t1: u64): u64 {
+     var $t2: u64
+  0: $t2 := invoke($t1, $t0)
+  1: return $t2
+}
+
+
+[variant baseline]
+fun M::apply_modifies($t0: |address|, $t1: address) {
+  0: invoke($t1, $t0)
+  1: return ()
+}
+
+
+[variant baseline]
+fun M::apply_requires($t0: |u64|u64, $t1: u64): u64 {
+     var $t2: u64
+  0: $t2 := invoke($t1, $t0)
+  1: return $t2
+}
+
+
+[variant baseline]
+fun M::do_nothing($t0: u64) {
+  0: return ()
+}
+
+
+[variant baseline]
+fun M::generic_noop<#0>($t0: #0) {
+  0: return ()
+}
+
+
+[variant baseline]
+public fun M::identity<#0>($t0: #0): #0 {
+     var $t1: #0
+  0: $t1 := infer($t0)
+  1: return $t1
+}
+
+
+[variant baseline]
+public fun M::increment($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+  0: $t2 := infer($t0)
+  1: $t3 := 1
+  2: $t1 := +($t2, $t3)
+  3: return $t1
+}
+
+
+[variant baseline]
+public fun M::increment_counter($t0: address) {
+     var $t1: &mut 0x42::M::Counter
+     var $t2: u64
+     var $t3: u64
+     var $t4: &u64
+     var $t5: u64
+     var $t6: &mut u64
+  0: $t1 := borrow_global<0x42::M::Counter>($t0)
+  1: $t4 := borrow_field<0x42::M::Counter>.value($t1)
+  2: $t3 := read_ref($t4)
+  3: $t5 := 1
+  4: $t2 := +($t3, $t5)
+  5: $t6 := borrow_field<0x42::M::Counter>.value($t1)
+  6: write_ref($t6, $t2)
+  7: return ()
+}
+
+
+[variant baseline]
+fun M::mixed_params($t0: u64, $t1: bool): u64 {
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+  0: if ($t1) goto 1 else goto 6
+  1: label L0
+  2: $t3 := infer($t0)
+  3: $t4 := 1
+  4: $t2 := +($t3, $t4)
+  5: goto 8
+  6: label L1
+  7: $t2 := infer($t0)
+  8: label L2
+  9: return $t2
+}
+
+
+[variant baseline]
+public fun M::pair<#0, #1>($t0: #0, $t1: #1): (#0, #1) {
+     var $t2: #0
+     var $t3: #1
+  0: $t2 := infer($t0)
+  1: $t3 := infer($t1)
+  2: return ($t2, $t3)
+}
+
+
+[variant baseline]
+fun M::split($t0: u64): (u64, u64) {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+     var $t8: u64
+  0: $t3 := infer($t0)
+  1: $t4 := 2
+  2: $t1 := /($t3, $t4)
+  3: $t5 := infer($t0)
+  4: $t7 := infer($t0)
+  5: $t8 := 2
+  6: $t6 := /($t7, $t8)
+  7: $t2 := -($t5, $t6)
+  8: return ($t1, $t2)
+}
+
+
+[variant baseline]
+public fun M::swap_counters($t0: address, $t1: address) {
+     var $t2: u64
+     var $t3: &0x42::M::Counter
+     var $t4: &u64
+     var $t5: u64
+     var $t6: &0x42::M::Counter
+     var $t7: &u64
+     var $t8: &mut u64
+     var $t9: &mut 0x42::M::Counter
+     var $t10: &mut u64
+     var $t11: &mut 0x42::M::Counter
+  0: $t3 := borrow_global<0x42::M::Counter>($t0)
+  1: $t4 := borrow_field<0x42::M::Counter>.value($t3)
+  2: $t2 := read_ref($t4)
+  3: $t6 := borrow_global<0x42::M::Counter>($t1)
+  4: $t7 := borrow_field<0x42::M::Counter>.value($t6)
+  5: $t5 := read_ref($t7)
+  6: $t9 := borrow_global<0x42::M::Counter>($t0)
+  7: $t8 := borrow_field<0x42::M::Counter>.value($t9)
+  8: write_ref($t8, $t5)
+  9: $t11 := borrow_global<0x42::M::Counter>($t1)
+ 10: $t10 := borrow_field<0x42::M::Counter>.value($t11)
+ 11: write_ref($t10, $t2)
+ 12: return ()
+}
+
+
+[variant baseline]
+fun M::test_aborts($t0: u64): u64 {
+     var $t1: u64
+  0: $t1 := M::increment($t0)
+  1: return $t1
+}
+
+
+[variant baseline]
+fun M::test_aborts_generic_explicit($t0: u64): u64 {
+     var $t1: u64
+  0: $t1 := M::identity<u64>($t0)
+  1: return $t1
+}
+
+
+[variant baseline]
+fun M::test_aborts_generic_inferred($t0: u64): u64 {
+     var $t1: u64
+  0: $t1 := M::identity<u64>($t0)
+  1: return $t1
+}
+
+
+[variant baseline]
+fun M::test_ensures_binary($t0: u64, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+  0: $t3 := infer($t0)
+  1: $t2 := M::add($t3, $t1)
+  2: return $t2
+}
+
+
+[variant baseline]
+fun M::test_ensures_generic_explicit($t0: u64): u64 {
+     var $t1: u64
+  0: $t1 := M::identity<u64>($t0)
+  1: return $t1
+}
+
+
+[variant baseline]
+fun M::test_ensures_generic_inferred($t0: u64): u64 {
+     var $t1: u64
+  0: $t1 := M::identity<u64>($t0)
+  1: return $t1
+}
+
+
+[variant baseline]
+fun M::test_ensures_generic_unit($t0: u64) {
+  0: M::generic_noop<u64>($t0)
+  1: return ()
+}
+
+
+[variant baseline]
+fun M::test_ensures_multi($t0: u64): (u64, u64) {
+     var $t1: u64
+     var $t2: u64
+  0: ($t1, $t2) := M::split($t0)
+  1: return ($t1, $t2)
+}
+
+
+[variant baseline]
+fun M::test_ensures_unary($t0: u64): u64 {
+     var $t1: u64
+  0: $t1 := M::increment($t0)
+  1: return $t1
+}
+
+
+[variant baseline]
+fun M::test_ensures_unit($t0: u64) {
+  0: M::do_nothing($t0)
+  1: return ()
+}
+
+
+[variant baseline]
+fun M::test_mixed_params($t0: u64, $t1: bool): u64 {
+     var $t2: u64
+     var $t3: u64
+  0: $t3 := infer($t0)
+  1: $t2 := M::mixed_params($t3, $t1)
+  2: return $t2
+}
+
+
+[variant baseline]
+fun M::test_modifies_multi($t0: address, $t1: address) {
+     var $t2: address
+  0: $t2 := infer($t0)
+  1: M::swap_counters($t2, $t1)
+  2: return ()
+}
+
+
+[variant baseline]
+fun M::test_modifies_single($t0: address) {
+  0: M::increment_counter($t0)
+  1: return ()
+}
+
+
+[variant baseline]
+fun M::test_pair_generic_explicit($t0: u64, $t1: bool): (u64, bool) {
+     var $t2: u64
+     var $t3: bool
+     var $t4: u64
+  0: $t4 := infer($t0)
+  1: ($t2, $t3) := M::pair<u64, bool>($t4, $t1)
+  2: return ($t2, $t3)
+}
+
+
+[variant baseline]
+fun M::test_requires_binary($t0: u64, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+  0: $t3 := infer($t0)
+  1: $t2 := M::add($t3, $t1)
+  2: return $t2
+}
+
+
+[variant baseline]
+fun M::test_requires_generic_explicit($t0: u64): u64 {
+     var $t1: u64
+  0: $t1 := M::identity<u64>($t0)
+  1: return $t1
+}
+
+
+[variant baseline]
+fun M::test_requires_generic_inferred($t0: u64): u64 {
+     var $t1: u64
+  0: $t1 := M::identity<u64>($t0)
+  1: return $t1
+}
+
+
+[variant baseline]
+fun M::test_requires_unary($t0: u64): u64 {
+     var $t1: u64
+  0: $t1 := M::increment($t0)
+  1: return $t1
+}
+
+
+[variant baseline]
+fun M::test_swap_generic_explicit($t0: u64, $t1: u64): (u64, u64) {
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+  0: $t4 := infer($t0)
+  1: ($t2, $t3) := M::swap<u64>($t4, $t1)
+  2: return ($t2, $t3)
+}
+
+
+[variant baseline]
+fun M::test_swap_generic_inferred($t0: u64, $t1: u64): (u64, u64) {
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+  0: $t4 := infer($t0)
+  1: ($t2, $t3) := M::swap<u64>($t4, $t1)
+  2: return ($t2, $t3)
+}
+
+
+[variant baseline]
+fun M::test_unbox_inferred($t0: 0x42::M::Box<u64>): u64 {
+     var $t1: u64
+  0: $t1 := M::unbox<u64>($t0)
+  1: return $t1
+}
+
+
+[variant baseline]
+public fun M::unbox<#0>($t0: 0x42::M::Box<#0>): #0 {
+     var $t1: #0
+     var $t2: &0x42::M::Box<#0>
+     var $t3: &#0
+  0: $t2 := borrow_local($t0)
+  1: $t3 := borrow_field<0x42::M::Box<#0>>.value($t2)
+  2: $t1 := read_ref($t3)
+  3: return $t1
+}
+
+
+[variant baseline]
+fun N::call_add($t0: u64, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+  0: $t3 := infer($t0)
+  1: $t2 := M::add($t3, $t1)
+  2: return $t2
+}
+
+
+[variant baseline]
+fun N::call_increment($t0: u64): u64 {
+     var $t1: u64
+  0: $t1 := M::increment($t0)
+  1: return $t1
+}
+
+
+============ disassembled file-format ==================
+// Bytecode version v10
+module 0x42::M
+struct Box<T0> has copy + drop
+  value: T0
+
+struct Counter has key
+  value: u64
+
+// Function definition at index 0
+#[persistent] public fun swap<T0>(l0: T0, l1: T0): (T0, T0)
+    move_loc l1
+    move_loc l0
+    ret
+
+// Function definition at index 1
+#[persistent] public fun add(l0: u64, l1: u64): u64
+    move_loc l0
+    move_loc l1
+    add
+    ret
+
+// Function definition at index 2
+fun apply_aborts(l0: |u64|u64, l1: u64): u64
+    move_loc l1
+    move_loc l0
+    call_closure <|u64|u64>
+    ret
+
+// Function definition at index 3
+fun apply_binary(l0: |u64, u64|u64, l1: u64, l2: u64): u64
+    move_loc l1
+    move_loc l2
+    move_loc l0
+    call_closure <|u64, u64|u64>
+    ret
+
+// Function definition at index 4
+fun apply_ensures(l0: |u64|u64, l1: u64): u64
+    move_loc l1
+    move_loc l0
+    call_closure <|u64|u64>
+    ret
+
+// Function definition at index 5
+fun apply_modifies(l0: |address|, l1: address)
+    move_loc l1
+    move_loc l0
+    call_closure <|address|>
+    ret
+
+// Function definition at index 6
+fun apply_requires(l0: |u64|u64, l1: u64): u64
+    move_loc l1
+    move_loc l0
+    call_closure <|u64|u64>
+    ret
+
+// Function definition at index 7
+fun do_nothing(l0: u64)
+    ret
+
+// Function definition at index 8
+fun generic_noop<T0: drop>(l0: T0)
+    ret
+
+// Function definition at index 9
+#[persistent] public fun identity<T0>(l0: T0): T0
+    move_loc l0
+    ret
+
+// Function definition at index 10
+#[persistent] public fun increment(l0: u64): u64
+    move_loc l0
+    ld_u64 1
+    add
+    ret
+
+// Function definition at index 11
+#[persistent] public fun increment_counter(l0: address) acquires Counter
+    local l1: &mut Counter
+    move_loc l0
+    mut_borrow_global Counter
+    st_loc l1
+    copy_loc l1
+    borrow_field Counter, value
+    // @5
+    read_ref
+    ld_u64 1
+    add
+    move_loc l1
+    mut_borrow_field Counter, value
+    // @10
+    write_ref
+    ret
+
+// Function definition at index 12
+fun mixed_params(l0: u64, l1: bool): u64
+    move_loc l1
+    br_false l0
+    move_loc l0
+    ld_u64 1
+    add
+    // @5
+    ret
+l0: move_loc l0
+    ret
+
+// Function definition at index 13
+#[persistent] public fun pair<T0, T1>(l0: T0, l1: T1): (T0, T1)
+    move_loc l0
+    move_loc l1
+    ret
+
+// Function definition at index 14
+fun split(l0: u64): (u64, u64)
+    copy_loc l0
+    ld_u64 2
+    div
+    copy_loc l0
+    move_loc l0
+    // @5
+    ld_u64 2
+    div
+    sub
+    ret
+
+// Function definition at index 15
+#[persistent] public fun swap_counters(l0: address, l1: address) acquires Counter
+    copy_loc l0
+    borrow_global Counter
+    borrow_field Counter, value
+    read_ref
+    copy_loc l1
+    // @5
+    borrow_global Counter
+    borrow_field Counter, value
+    read_ref
+    move_loc l0
+    mut_borrow_global Counter
+    // @10
+    mut_borrow_field Counter, value
+    write_ref
+    move_loc l1
+    mut_borrow_global Counter
+    mut_borrow_field Counter, value
+    // @15
+    write_ref
+    ret
+
+// Function definition at index 16
+fun test_aborts(l0: u64): u64
+    move_loc l0
+    call increment
+    ret
+
+// Function definition at index 17
+fun test_aborts_generic_explicit(l0: u64): u64
+    move_loc l0
+    call identity<u64>
+    ret
+
+// Function definition at index 18
+fun test_aborts_generic_inferred(l0: u64): u64
+    move_loc l0
+    call identity<u64>
+    ret
+
+// Function definition at index 19
+fun test_ensures_binary(l0: u64, l1: u64): u64
+    move_loc l0
+    move_loc l1
+    call add
+    ret
+
+// Function definition at index 20
+fun test_ensures_generic_explicit(l0: u64): u64
+    move_loc l0
+    call identity<u64>
+    ret
+
+// Function definition at index 21
+fun test_ensures_generic_inferred(l0: u64): u64
+    move_loc l0
+    call identity<u64>
+    ret
+
+// Function definition at index 22
+fun test_ensures_generic_unit(l0: u64)
+    move_loc l0
+    call generic_noop<u64>
+    ret
+
+// Function definition at index 23
+fun test_ensures_multi(l0: u64): (u64, u64)
+    move_loc l0
+    call split
+    ret
+
+// Function definition at index 24
+fun test_ensures_unary(l0: u64): u64
+    move_loc l0
+    call increment
+    ret
+
+// Function definition at index 25
+fun test_ensures_unit(l0: u64)
+    move_loc l0
+    call do_nothing
+    ret
+
+// Function definition at index 26
+fun test_mixed_params(l0: u64, l1: bool): u64
+    move_loc l0
+    move_loc l1
+    call mixed_params
+    ret
+
+// Function definition at index 27
+fun test_modifies_multi(l0: address, l1: address) acquires Counter
+    move_loc l0
+    move_loc l1
+    call swap_counters
+    ret
+
+// Function definition at index 28
+fun test_modifies_single(l0: address) acquires Counter
+    move_loc l0
+    call increment_counter
+    ret
+
+// Function definition at index 29
+fun test_pair_generic_explicit(l0: u64, l1: bool): (u64, bool)
+    move_loc l0
+    move_loc l1
+    call pair<u64, bool>
+    ret
+
+// Function definition at index 30
+fun test_requires_binary(l0: u64, l1: u64): u64
+    move_loc l0
+    move_loc l1
+    call add
+    ret
+
+// Function definition at index 31
+fun test_requires_generic_explicit(l0: u64): u64
+    move_loc l0
+    call identity<u64>
+    ret
+
+// Function definition at index 32
+fun test_requires_generic_inferred(l0: u64): u64
+    move_loc l0
+    call identity<u64>
+    ret
+
+// Function definition at index 33
+fun test_requires_unary(l0: u64): u64
+    move_loc l0
+    call increment
+    ret
+
+// Function definition at index 34
+fun test_swap_generic_explicit(l0: u64, l1: u64): (u64, u64)
+    move_loc l0
+    move_loc l1
+    call swap<u64>
+    ret
+
+// Function definition at index 35
+fun test_swap_generic_inferred(l0: u64, l1: u64): (u64, u64)
+    move_loc l0
+    move_loc l1
+    call swap<u64>
+    ret
+
+// Function definition at index 36
+fun test_unbox_inferred(l0: Box<u64>): u64
+    move_loc l0
+    call unbox<u64>
+    ret
+
+// Function definition at index 37
+#[persistent] public fun unbox<T0: copy + drop>(l0: Box<T0>): T0
+    borrow_loc l0
+    borrow_field Box<T0>, value
+    read_ref
+    ret
+
+// Bytecode version v10
+module 0x42::N
+use 0x42::M
+// Function definition at index 0
+fun call_add(l0: u64, l1: u64): u64
+    move_loc l0
+    move_loc l1
+    call M::add
+    ret
+
+// Function definition at index 1
+fun call_increment(l0: u64): u64
+    move_loc l0
+    call M::increment
+    ret
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/checking-lang-v2.4/specs/behavior_predicates_valid.move
+++ b/third_party/move/move-compiler-v2/tests/checking-lang-v2.4/specs/behavior_predicates_valid.move
@@ -1,0 +1,427 @@
+// Tests for valid behavior predicate type checking with qualified function targets.
+// Note: Function-typed parameters require inline functions, but inline functions
+// don't support spec blocks yet. So we test with qualified function targets only.
+
+module 0x42::M {
+
+    // ========================================
+    // Non-generic helper functions
+    // ========================================
+
+    // Simple unary function
+    public fun increment(x: u64): u64 {
+        x + 1
+    }
+
+    spec increment {
+        requires x < 18446744073709551615;
+        ensures result == x + 1;
+    }
+
+    // Binary function
+    public fun add(a: u64, b: u64): u64 {
+        a + b
+    }
+
+    spec add {
+        requires a + b <= 18446744073709551615;
+        ensures result == a + b;
+    }
+
+    // Function with no return value
+    fun do_nothing(_x: u64) {
+    }
+
+    spec do_nothing {
+        ensures true;
+    }
+
+    // Function with multiple return values
+    fun split(x: u64): (u64, u64) {
+        (x / 2, x - x / 2)
+    }
+
+    spec split {
+        ensures result_1 + result_2 == x;
+    }
+
+    // Function with different param types
+    fun mixed_params(x: u64, flag: bool): u64 {
+        if (flag) { x + 1 } else { x }
+    }
+
+    // ========================================
+    // Resource and functions with modifies
+    // ========================================
+
+    // Resource struct for testing modifies_of
+    struct Counter has key {
+        value: u64,
+    }
+
+    // Function that modifies a resource
+    public fun increment_counter(addr: address) acquires Counter {
+        let counter = borrow_global_mut<Counter>(addr);
+        counter.value = counter.value + 1;
+    }
+
+    spec increment_counter {
+        modifies global<Counter>(addr);
+        ensures global<Counter>(addr).value == old(global<Counter>(addr)).value + 1;
+    }
+
+    // Function that modifies multiple resources
+    public fun swap_counters(addr1: address, addr2: address) acquires Counter {
+        let v1 = borrow_global<Counter>(addr1).value;
+        let v2 = borrow_global<Counter>(addr2).value;
+        borrow_global_mut<Counter>(addr1).value = v2;
+        borrow_global_mut<Counter>(addr2).value = v1;
+    }
+
+    spec swap_counters {
+        modifies global<Counter>(addr1);
+        modifies global<Counter>(addr2);
+    }
+
+    // ========================================
+    // Generic helper functions
+    // ========================================
+
+    // Generic identity function (1 type param)
+    public fun identity<T>(x: T): T {
+        x
+    }
+
+    spec identity {
+        ensures result == x;
+    }
+
+    // Generic swap function (1 type param, 2 args)
+    public fun swap<T>(a: T, b: T): (T, T) {
+        (b, a)
+    }
+
+    spec swap {
+        ensures result_1 == b;
+        ensures result_2 == a;
+    }
+
+    // Generic function with 2 type params
+    public fun pair<T, U>(x: T, y: U): (T, U) {
+        (x, y)
+    }
+
+    spec pair {
+        ensures result_1 == x;
+        ensures result_2 == y;
+    }
+
+    // Generic function returning unit
+    fun generic_noop<T: drop>(_x: T) {
+    }
+
+    // ========================================
+    // Tests: Non-generic functions - all behavior kinds
+    // ========================================
+
+    // Test requires_of with non-generic unary function
+    fun test_requires_unary(x: u64): u64 {
+        increment(x)
+    }
+
+    spec test_requires_unary {
+        ensures requires_of<increment>(x);
+    }
+
+    // Test requires_of with non-generic binary function
+    fun test_requires_binary(a: u64, b: u64): u64 {
+        add(a, b)
+    }
+
+    spec test_requires_binary {
+        ensures requires_of<add>(a, b);
+    }
+
+    // Test aborts_of with non-generic function
+    fun test_aborts(x: u64): u64 {
+        increment(x)
+    }
+
+    spec test_aborts {
+        aborts_if aborts_of<increment>(x);
+    }
+
+    // Test ensures_of with non-generic unary function (input + result)
+    fun test_ensures_unary(x: u64): u64 {
+        increment(x)
+    }
+
+    spec test_ensures_unary {
+        ensures ensures_of<increment>(x, result);
+    }
+
+    // Test ensures_of with non-generic binary function (two inputs + result)
+    fun test_ensures_binary(a: u64, b: u64): u64 {
+        add(a, b)
+    }
+
+    spec test_ensures_binary {
+        ensures ensures_of<add>(a, b, result);
+    }
+
+    // Test ensures_of with function returning unit (only inputs)
+    fun test_ensures_unit(x: u64) {
+        do_nothing(x)
+    }
+
+    spec test_ensures_unit {
+        ensures ensures_of<do_nothing>(x);
+    }
+
+    // Test ensures_of with multiple return values
+    fun test_ensures_multi(x: u64): (u64, u64) {
+        split(x)
+    }
+
+    spec test_ensures_multi {
+        ensures ensures_of<split>(x, result_1, result_2);
+    }
+
+    // Test with mixed parameter types
+    fun test_mixed_params(x: u64, b: bool): u64 {
+        mixed_params(x, b)
+    }
+
+    spec test_mixed_params {
+        ensures requires_of<mixed_params>(x, b);
+        ensures ensures_of<mixed_params>(x, b, result);
+    }
+
+    // Test modifies_of with single resource
+    fun test_modifies_single(addr: address) acquires Counter {
+        increment_counter(addr)
+    }
+
+    spec test_modifies_single {
+        // modifies_of returns bool indicating if the modifies spec of the function holds
+        ensures modifies_of<increment_counter>(global<Counter>(addr));
+    }
+
+    // Test modifies_of with multiple resources
+    fun test_modifies_multi(addr1: address, addr2: address) acquires Counter {
+        swap_counters(addr1, addr2)
+    }
+
+    spec test_modifies_multi {
+        ensures modifies_of<swap_counters>(global<Counter>(addr1), global<Counter>(addr2));
+    }
+
+    // ========================================
+    // Tests: Generic functions WITH explicit type arguments - all behavior kinds
+    // ========================================
+
+    // Test requires_of with generic function (explicit type args)
+    fun test_requires_generic_explicit(x: u64): u64 {
+        identity<u64>(x)
+    }
+
+    spec test_requires_generic_explicit {
+        ensures requires_of<identity<u64>>(x);
+    }
+
+    // Test aborts_of with generic function (explicit type args)
+    fun test_aborts_generic_explicit(x: u64): u64 {
+        identity<u64>(x)
+    }
+
+    spec test_aborts_generic_explicit {
+        aborts_if aborts_of<identity<u64>>(x);
+    }
+
+    // Test ensures_of with generic function (explicit type args)
+    fun test_ensures_generic_explicit(x: u64): u64 {
+        identity<u64>(x)
+    }
+
+    spec test_ensures_generic_explicit {
+        ensures ensures_of<identity<u64>>(x, result);
+    }
+
+    // Test with generic swap function (explicit type args)
+    fun test_swap_generic_explicit(a: u64, b: u64): (u64, u64) {
+        swap<u64>(a, b)
+    }
+
+    spec test_swap_generic_explicit {
+        ensures requires_of<swap<u64>>(a, b);
+        ensures ensures_of<swap<u64>>(a, b, result_1, result_2);
+    }
+
+    // Test with 2 type parameters (explicit type args)
+    fun test_pair_generic_explicit(x: u64, y: bool): (u64, bool) {
+        pair<u64, bool>(x, y)
+    }
+
+    spec test_pair_generic_explicit {
+        ensures requires_of<pair<u64, bool>>(x, y);
+        ensures ensures_of<pair<u64, bool>>(x, y, result_1, result_2);
+    }
+
+    // Test ensures_of with generic function returning unit (explicit type args)
+    fun test_ensures_generic_unit(x: u64) {
+        generic_noop<u64>(x)
+    }
+
+    spec test_ensures_generic_unit {
+        ensures ensures_of<generic_noop<u64>>(x);
+    }
+
+    // ========================================
+    // Tests: Generic functions WITHOUT explicit type arguments (inferred)
+    // ========================================
+
+    // Test requires_of with generic function (inferred type args)
+    fun test_requires_generic_inferred(x: u64): u64 {
+        identity(x)
+    }
+
+    spec test_requires_generic_inferred {
+        // Type args inferred from argument type
+        ensures requires_of<identity>(x);
+    }
+
+    // Test aborts_of with generic function (inferred type args)
+    fun test_aborts_generic_inferred(x: u64): u64 {
+        identity(x)
+    }
+
+    spec test_aborts_generic_inferred {
+        aborts_if aborts_of<identity>(x);
+    }
+
+    // Test ensures_of with generic function (inferred type args)
+    fun test_ensures_generic_inferred(x: u64): u64 {
+        identity(x)
+    }
+
+    spec test_ensures_generic_inferred {
+        ensures ensures_of<identity>(x, result);
+    }
+
+    // Test swap with inferred type args
+    fun test_swap_generic_inferred(a: u64, b: u64): (u64, u64) {
+        swap(a, b)
+    }
+
+    spec test_swap_generic_inferred {
+        ensures requires_of<swap>(a, b);
+        ensures ensures_of<swap>(a, b, result_1, result_2);
+    }
+
+    // ========================================
+    // Tests: Generic functions with struct types (verifies type instantiation)
+    // ========================================
+
+    // Generic struct for testing type instantiation in behavior predicates
+    struct Box<T> has copy, drop {
+        value: T,
+    }
+
+    // Generic function operating on Box
+    public fun unbox<T: copy + drop>(b: Box<T>): T {
+        b.value
+    }
+
+    spec unbox {
+        ensures result == b.value;
+    }
+
+    // Test behavior predicate with inferred struct type arguments.
+    // This test verifies that type instantiation is properly registered on the node.
+    // Without set_node_instantiation, the type variable in Box<T> would remain unresolved
+    // as something like Box<?0> instead of Box<u64>.
+    fun test_unbox_inferred(b: Box<u64>): u64 {
+        unbox(b)
+    }
+
+    spec test_unbox_inferred {
+        // Type of b is Box<u64>, so unbox is instantiated with T=u64
+        ensures requires_of<unbox>(b);
+        ensures ensures_of<unbox>(b, result);
+    }
+
+    // ========================================
+    // Tests: Function parameters (no type args allowed)
+    // ========================================
+
+    // Test requires_of with function parameter
+    fun apply_requires(f: |u64| u64, x: u64): u64 {
+        f(x)
+    }
+
+    spec apply_requires {
+        ensures requires_of<f>(x);
+    }
+
+    // Test aborts_of with function parameter
+    fun apply_aborts(f: |u64| u64, x: u64): u64 {
+        f(x)
+    }
+
+    spec apply_aborts {
+        aborts_if aborts_of<f>(x);
+    }
+
+    // Test ensures_of with function parameter
+    fun apply_ensures(f: |u64| u64, x: u64): u64 {
+        f(x)
+    }
+
+    spec apply_ensures {
+        ensures ensures_of<f>(x, result);
+    }
+
+    // Test with binary function parameter
+    fun apply_binary(f: |u64, u64| u64, a: u64, b: u64): u64 {
+        f(a, b)
+    }
+
+    spec apply_binary {
+        ensures requires_of<f>(a, b);
+        ensures ensures_of<f>(a, b, result);
+        aborts_if aborts_of<f>(a, b);
+    }
+
+    // Test modifies_of with function parameter
+    fun apply_modifies(f: |address|, addr: address) {
+        f(addr)
+    }
+
+    spec apply_modifies {
+        ensures modifies_of<f>(global<Counter>(addr));
+    }
+}
+
+// Test cross-module function references
+module 0x42::N {
+    use 0x42::M;
+
+    fun call_increment(x: u64): u64 {
+        M::increment(x)
+    }
+
+    spec call_increment {
+        // Cross-module qualified function reference
+        ensures requires_of<M::increment>(x);
+        ensures ensures_of<M::increment>(x, result);
+    }
+
+    fun call_add(a: u64, b: u64): u64 {
+        M::add(a, b)
+    }
+
+    spec call_add {
+        ensures requires_of<M::add>(a, b);
+        ensures ensures_of<M::add>(a, b, result);
+    }
+}

--- a/third_party/move/move-model/bytecode/src/astifier.rs
+++ b/third_party/move/move-model/bytecode/src/astifier.rs
@@ -2391,6 +2391,7 @@ impl AssignTransformer<'_> {
                 | Operation::EventStoreIncludedIn
                 | Operation::EventStoreIncludes
                 | Operation::ExtendEventStore
+                | Operation::Behavior(..)
                 | Operation::NoOp => false,
             },
             ExpData::Value(..)

--- a/third_party/move/move-model/src/builder/exp_builder.rs
+++ b/third_party/move/move-model/src/builder/exp_builder.rs
@@ -4,9 +4,9 @@
 
 use crate::{
     ast::{
-        AbortKind, AccessSpecifier, AccessSpecifierKind, Address, AddressSpecifier, Exp, ExpData,
-        LambdaCaptureKind, MatchArm, ModuleName, Operation, Pattern, QualifiedSymbol, QuantKind,
-        ResourceSpecifier, RewriteResult, Spec, TempIndex, Value,
+        AbortKind, AccessSpecifier, AccessSpecifierKind, Address, AddressSpecifier, BehaviorKind,
+        BehaviorTarget, Exp, ExpData, LambdaCaptureKind, MatchArm, ModuleName, Operation, Pattern,
+        QualifiedSymbol, QuantKind, ResourceSpecifier, RewriteResult, Spec, TempIndex, Value,
     },
     builder::{
         model_builder::{
@@ -2039,12 +2039,16 @@ impl ExpTranslator<'_, '_, '_> {
                 }
                 ExpData::Call(id, Operation::NoOp, vec![])
             },
-            EA::Exp_::Behavior(..) => {
-                self.error(
+            EA::Exp_::Behavior(kind, _pre_label, fn_name, type_args, sp!(_, args), _post_label) => {
+                self.translate_behavior_predicate(
                     &loc,
-                    "behavior predicates for function values (requires_of, aborts_of, ensures_of, modifies_of) are not yet supported in the model"
-                );
-                self.new_error_exp()
+                    *kind,
+                    fn_name,
+                    type_args,
+                    args,
+                    expected_type,
+                    context,
+                )
             },
             EA::Exp_::UnresolvedError => {
                 // Error reported
@@ -5701,6 +5705,229 @@ impl ExpTranslator<'_, '_, '_> {
         self.check_type(loc, &quant_ty, expected_type, context);
         let id = self.new_node_id_with_type_loc(&quant_ty, loc);
         ExpData::Quant(id, rkind, rranges, rtriggers, rcondition, rbody.into_exp())
+    }
+
+    /// Translates a behavior predicate expression (requires_of, aborts_of, ensures_of, modifies_of).
+    fn translate_behavior_predicate(
+        &mut self,
+        loc: &Loc,
+        kind: PA::BehaviorKind,
+        fn_name: &EA::ModuleAccess,
+        type_args: &Option<Vec<EA::Type>>,
+        args: &[EA::Exp],
+        expected_type: &Type,
+        context: &ErrorMessageContext,
+    ) -> ExpData {
+        // Convert parser BehaviorKind to model BehaviorKind
+        let model_kind = match kind {
+            PA::BehaviorKind::RequiresOf => BehaviorKind::RequiresOf,
+            PA::BehaviorKind::AbortsOf => BehaviorKind::AbortsOf,
+            PA::BehaviorKind::EnsuresOf => BehaviorKind::EnsuresOf,
+            PA::BehaviorKind::ModifiesOf => BehaviorKind::ModifiesOf,
+        };
+
+        // Resolve the function name to a behavior target
+        let Some((target, expected_arg_types)) =
+            self.resolve_behavior_target(loc, fn_name, type_args, &model_kind)
+        else {
+            return self.new_error_exp();
+        };
+
+        // Translate arguments and check types
+        let translated_args =
+            self.translate_and_check_behavior_args(loc, args, &expected_arg_types, &model_kind);
+
+        // The result type of behavior predicates is bool
+        let result_ty = self.check_type(loc, &BOOL_TYPE, expected_type, context);
+        let id = self.new_node_id_with_type_loc(&result_ty, loc);
+
+        // Set the type instantiation on the node for proper type resolution during finalize_types
+        if let BehaviorTarget::Function(qid) = &target {
+            self.set_node_instantiation(id, qid.inst.clone());
+        }
+
+        // Labels are ignored for now (None, None)
+        ExpData::Call(
+            id,
+            Operation::Behavior(model_kind, None, target, None),
+            translated_args,
+        )
+    }
+
+    /// Resolves the target of a behavior predicate to either a parameter or a function.
+    /// Returns the BehaviorTarget and the expected argument types.
+    fn resolve_behavior_target(
+        &mut self,
+        loc: &Loc,
+        maccess: &EA::ModuleAccess,
+        type_args: &Option<Vec<EA::Type>>,
+        kind: &BehaviorKind,
+    ) -> Option<(BehaviorTarget, Vec<Type>)> {
+        match &maccess.value {
+            EA::ModuleAccess_::Name(name) => {
+                // First try to resolve as a local parameter
+                let sym = self.symbol_pool().make(name.value.as_str());
+                if let Some(entry) = self.lookup_local(sym, false) {
+                    // Check if it's a function type
+                    let entry_type = entry.type_.clone();
+                    let ty = self.subs.specialize(&entry_type);
+                    if let Type::Fun(arg_ty, result_ty, _abilities) = &ty {
+                        // Check that no type arguments are provided for function parameters
+                        if type_args.as_ref().is_some_and(|args| !args.is_empty()) {
+                            self.error(
+                                loc,
+                                &format!(
+                                    "type arguments cannot be provided for function parameter `{}`",
+                                    sym.display(self.symbol_pool())
+                                ),
+                            );
+                            return None;
+                        }
+                        let expected_types =
+                            self.compute_behavior_arg_types(arg_ty, result_ty, kind);
+                        return Some((BehaviorTarget::Parameter(sym), expected_types));
+                    } else {
+                        self.error(
+                            loc,
+                            &format!(
+                                "behavior predicate target `{}` must have function type, found `{}`",
+                                sym.display(self.symbol_pool()),
+                                ty.display(&self.type_display_context())
+                            ),
+                        );
+                        return None;
+                    }
+                }
+                // Fall through to try resolving as a function
+                let global_sym = self.parent.qualified_by_module(sym);
+                self.resolve_function_target(loc, &global_sym, type_args, kind)
+            },
+            EA::ModuleAccess_::ModuleAccess(..) => {
+                let global_sym = self.parent.module_access_to_qualified(maccess);
+                self.resolve_function_target(loc, &global_sym, type_args, kind)
+            },
+        }
+    }
+
+    /// Resolves a qualified function name for behavior predicates.
+    fn resolve_function_target(
+        &mut self,
+        loc: &Loc,
+        global_sym: &QualifiedSymbol,
+        type_args: &Option<Vec<EA::Type>>,
+        kind: &BehaviorKind,
+    ) -> Option<(BehaviorTarget, Vec<Type>)> {
+        if let Some(entry) = self.parent.parent.fun_table.get(global_sym) {
+            let module_id = entry.module_id;
+            let fun_id = entry.fun_id;
+            let type_params = entry.type_params.clone();
+            let params = entry.params.clone();
+            let result_type = entry.result_type.clone();
+
+            // Make instantiation
+            let instantiation = self.make_instantiation_or_report(
+                loc,
+                false,
+                global_sym.symbol,
+                &type_params,
+                type_args,
+            )?;
+
+            // Compute instantiated parameter types
+            let param_types: Vec<Type> = params
+                .iter()
+                .map(|p| p.get_type().instantiate(&instantiation))
+                .collect();
+            let instantiated_result_type = result_type.instantiate(&instantiation);
+
+            // Compute expected argument types based on behavior kind
+            let arg_ty = Type::tuple(param_types);
+            let expected_types =
+                self.compute_behavior_arg_types(&arg_ty, &instantiated_result_type, kind);
+
+            let qid = QualifiedInstId {
+                module_id,
+                id: fun_id,
+                inst: instantiation,
+            };
+            Some((BehaviorTarget::Function(qid), expected_types))
+        } else {
+            self.error(
+                loc,
+                &format!(
+                    "unknown function `{}` in behavior predicate",
+                    global_sym.display(self.env())
+                ),
+            );
+            None
+        }
+    }
+
+    /// Computes the expected argument types for a behavior predicate based on kind.
+    fn compute_behavior_arg_types(
+        &self,
+        arg_ty: &Type,
+        result_ty: &Type,
+        kind: &BehaviorKind,
+    ) -> Vec<Type> {
+        match kind {
+            BehaviorKind::RequiresOf | BehaviorKind::AbortsOf => {
+                // requires_of and aborts_of take input parameters
+                arg_ty.clone().flatten()
+            },
+            BehaviorKind::EnsuresOf => {
+                // ensures_of takes input parameters + result
+                let mut types = arg_ty.clone().flatten();
+                types.extend(result_ty.clone().flatten());
+                types
+            },
+            BehaviorKind::ModifiesOf => {
+                // modifies_of takes global resource references, not function parameters.
+                // We don't enforce argument count or types here.
+                vec![]
+            },
+        }
+    }
+
+    /// Translates and type-checks behavior predicate arguments.
+    fn translate_and_check_behavior_args(
+        &mut self,
+        loc: &Loc,
+        args: &[EA::Exp],
+        expected_types: &[Type],
+        kind: &BehaviorKind,
+    ) -> Vec<Exp> {
+        // For modifies_of, arguments must be global resource expressions
+        if matches!(kind, BehaviorKind::ModifiesOf) {
+            return args
+                .iter()
+                .map(|arg| self.translate_modify_target(arg).into_exp())
+                .collect();
+        }
+
+        // Check arity for other behavior kinds
+        if args.len() != expected_types.len() {
+            self.error(
+                loc,
+                &format!(
+                    "expected {} argument(s) for {} but {} were provided",
+                    expected_types.len(),
+                    kind,
+                    args.len()
+                ),
+            );
+            // Still translate arguments to provide better error messages
+            return args
+                .iter()
+                .map(|arg| self.translate_exp_free(arg).1.into_exp())
+                .collect();
+        }
+
+        // Translate each argument with expected type
+        args.iter()
+            .zip(expected_types.iter())
+            .map(|(arg, expected_ty)| self.translate_exp(arg, expected_ty).into_exp())
+            .collect()
     }
 
     /// Unify types with order `LeftToRight` and shallow variance

--- a/third_party/move/move-model/src/sourcifier.rs
+++ b/third_party/move/move-model/src/sourcifier.rs
@@ -1330,6 +1330,7 @@ impl<'a> ExpSourcifier<'a> {
             | Operation::Implies
             | Operation::Iff
             | Operation::Identical
+            | Operation::Behavior(..)
             | Operation::NoOp => {
                 emitln!(self.wr(), "/* unsupported spec operation {:?} */", oper)
             },

--- a/third_party/move/move-prover/boogie-backend/src/spec_translator.rs
+++ b/third_party/move/move-prover/boogie-backend/src/spec_translator.rs
@@ -1156,6 +1156,7 @@ impl SpecTranslator<'_> {
             | Operation::MoveTo
             | Operation::MoveFrom
             | Operation::Closure(..)
+            | Operation::Behavior(..)
             | Operation::Old => {
                 self.env.error(
                     &self.env.get_node_loc(node_id),


### PR DESCRIPTION
## Description

This extends the Move specification language with type checking for behavioral
predicates (requires_of, aborts_of, ensures_of, modifies_of) that allow
reasoning about function-typed parameters in specifications.

Changes:
- Added BehaviorKind and BehaviorTarget enums to Model AST (ast.rs)
- Added Operation::Behavior variant to represent behavior predicates
- Implemented type checker in exp_builder.rs:
  - Resolves target to either a function parameter or qualified function
  - Validates argument types based on behavior kind:
    - requires_of/aborts_of: args match function input parameters
    - ensures_of: args match input + output parameters
    - modifies_of: accepts any global resource expressions (no type checking)
  - Labels (@pre, @post) are parsed but ignored for now
- Added proper Display formatting for Behavior operations in model dump
- Updated Operation match statements in astifier.rs, sourcifier.rs,
  bytecode_generator.rs, and spec_translator.rs
- Added comprehensive tests for valid usage and type errors

Co-authored with Claude Opus 4.5.

## How Has This Been Tested?

- Added comprehensive test suite in `tests/checking-lang-v2.4/specs/`:
  - `behavior_predicates_valid.move` - Tests for all valid usage patterns including:
    - Non-generic functions with all behavior kinds (requires_of, aborts_of, ensures_of)
    - Generic functions with explicit type arguments
    - Generic functions with inferred type arguments  
    - Function parameters (all behavior kinds)
    - Cross-module function references
    - Functions with multiple return values
  - `behavior_predicates_type_err.move` - Tests for all error scenarios including:
    - Wrong argument count (too few/too many)
    - Unknown function target
    - Type arguments for function parameter (not allowed)
    - Non-function type used as target
    - Wrong type argument arity for generic functions
    - Wrong argument types
  - `behavior_predicates_err.move` - Tests for modifies_of specific errors
- All 2161 compiler tests pass

## Key Areas to Review

- `move-model/src/builder/exp_builder.rs`: The main type checking logic for behavior predicates in `translate_behavior_predicate` and `resolve_behavior_target` functions. These handle resolution of the target function and validation of argument types.
- `move-model/src/ast.rs`: The `BehaviorKind` and `BehaviorTarget` enums that define the model representation.

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [x] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [x] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces behavior predicate type checking in the Move spec language, enabling validation of function-typed targets and arguments.
> 
> - Add `BehaviorKind`, `BehaviorTarget`, and `Operation::Behavior(..)` to the model AST with display support
> - Implement `translate_behavior_predicate` and helpers in `exp_builder.rs` to resolve targets (parameter vs. qualified function), check arity and argument types, and set node instantiations; labels are parsed but currently ignored; `modifies_of` requires global resource expressions
> - Update operation handling to recognize `Operation::Behavior(..)` in `astifier.rs`, `sourcifier.rs`, `bytecode_generator.rs`, and `spec_translator.rs` (treated as unsupported for codegen/boogie translation but accepted in the model)
> - Replace prior "not supported" errors with precise diagnostics; update/expand tests: add `behavior_predicates_valid.move` (with `.exp` model dumps), `behavior_predicates_type_err` for arity/type/unknown target cases, and refine `behavior_predicates_err` to assert global resource access errors
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 935a9f14b2e8c9246537bf0029846c89ed370a40. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->