### PR TITLE
[move-unit-test] More information for unexpected aborts

### DIFF
--- a/third_party/move/tools/move-unit-test/tests/fail_fast/unittest-fast.exp
+++ b/third_party/move/tools/move-unit-test/tests/fail_fast/unittest-fast.exp
@@ -15,7 +15,7 @@ Failures in 0x1::UnitTest:
 │    │         ------- In this function in 0x1::UnitTest
 │ 18 │         let ret = bar(17);
 │ 19 │         assert!(ret == 19, ONE);
-│    │         ^^^^^^ Test was not expected to error, but it aborted with code 131073 originating in the module 0000000000000000000000000000000000000000000000000000000000000001::UnitTest rooted here
+│    │         ^^^^^^ Test was not expected to error, but it aborted with code 131073 (category: OUT_OF_RANGE, reason: 1) originating in the module 0000000000000000000000000000000000000000000000000000000000000001::UnitTest rooted here
 │ 
 │ 
 └──────────────────

--- a/third_party/move/tools/move-unit-test/tests/fail_fast/unittest.exp
+++ b/third_party/move/tools/move-unit-test/tests/fail_fast/unittest.exp
@@ -24,7 +24,7 @@ Failures in 0x1::UnitTest:
 │    │         ------- In this function in 0x1::UnitTest
 │ 18 │         let ret = bar(17);
 │ 19 │         assert!(ret == 19, ONE);
-│    │         ^^^^^^ Test was not expected to error, but it aborted with code 131073 originating in the module 0000000000000000000000000000000000000000000000000000000000000001::UnitTest rooted here
+│    │         ^^^^^^ Test was not expected to error, but it aborted with code 131073 (category: OUT_OF_RANGE, reason: 1) originating in the module 0000000000000000000000000000000000000000000000000000000000000001::UnitTest rooted here
 │ 
 │ 
 └──────────────────
@@ -38,7 +38,7 @@ Failures in 0x1::UnitTest:
 │    │         -------- In this function in 0x1::UnitTest
 │ 12 │         let ret = bar(17);
 │ 13 │         assert!(ret == 18, ONE);
-│    │         ^^^^^^ Test was not expected to error, but it aborted with code 131073 originating in the module 0000000000000000000000000000000000000000000000000000000000000001::UnitTest rooted here
+│    │         ^^^^^^ Test was not expected to error, but it aborted with code 131073 (category: OUT_OF_RANGE, reason: 1) originating in the module 0000000000000000000000000000000000000000000000000000000000000001::UnitTest rooted here
 │ 
 │ 
 └──────────────────

--- a/third_party/move/tools/move-unit-test/tests/test_sources/unexpected_abort.exp
+++ b/third_party/move/tools/move-unit-test/tests/test_sources/unexpected_abort.exp
@@ -3,6 +3,7 @@ Running Move unit tests
 [ PASS    ] 0x1::M::just_test_failure
 [ FAIL    ] 0x1::M::unexpected_abort
 [ FAIL    ] 0x1::M::unexpected_abort_in_other_function
+[ FAIL    ] 0x1::M::unexpected_abort_with_canonical_error_code
 [ FAIL    ] 0x1::M::wrong_abort_code
 0x1::M::correct_abort_code
 Output: Ok(Changes { accounts: {} })
@@ -11,6 +12,8 @@ Output: Ok(Changes { accounts: {} })
 0x1::M::unexpected_abort
 Output: Ok(Changes { accounts: {} })
 0x1::M::unexpected_abort_in_other_function
+Output: Ok(Changes { accounts: {} })
+0x1::M::unexpected_abort_with_canonical_error_code
 Output: Ok(Changes { accounts: {} })
 0x1::M::wrong_abort_code
 Output: Ok(Changes { accounts: {} })
@@ -48,6 +51,19 @@ Failures in 0x1::M:
 └──────────────────
 
 
+┌── unexpected_abort_with_canonical_error_code ──────
+│ error[E11001]: test failure
+│    ┌─ unexpected_abort.move:38:9
+│    │
+│ 37 │     public fun unexpected_abort_with_canonical_error_code() {
+│    │                ------------------------------------------ In this function in 0x1::M
+│ 38 │         abort std::error::invalid_state(42)
+│    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Test was not expected to error, but it aborted with code 196650 (category: INVALID_STATE, reason: 42) originating in the module 0000000000000000000000000000000000000000000000000000000000000001::M rooted here
+│ 
+│ 
+└──────────────────
+
+
 ┌── wrong_abort_code ──────
 │ error[E11001]: test failure
 │    ┌─ unexpected_abort.move:11:9
@@ -60,4 +76,4 @@ Failures in 0x1::M:
 │ 
 └──────────────────
 
-Test result: FAILED. Total tests: 5; passed: 2; failed: 3
+Test result: FAILED. Total tests: 6; passed: 2; failed: 4

--- a/third_party/move/tools/move-unit-test/tests/test_sources/unexpected_abort.move
+++ b/third_party/move/tools/move-unit-test/tests/test_sources/unexpected_abort.move
@@ -32,5 +32,10 @@ module M {
     fun unexpected_abort_in_other_function() {
         abort_in_other_function()
     }
+
+    #[test]
+    public fun unexpected_abort_with_canonical_error_code() {
+        abort std::error::invalid_state(42)
+    }
 }
 }


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

Fix #7800

Improve unit test error reporting by decoding abort codes. Unexpected test aborts now include the error category and reason if applicable, alongside the numeric code, making debugging easier. Example output:

**Before**
```
Test was not expected to error, but it aborted with code 131073 ...
```

**After**
```
Test was not expected to error, but it aborted with code 131073 (category: OUT_OF_RANGE, reason: 1) ...
```

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

Added new test that aborts with a canonical error code. 

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [x] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enhances unit test diagnostics for unexpected aborts by decoding abort codes into human-readable `category` and `reason`.
> 
> - Update `ExpectedMoveErrorDisplay` to append `(category: <NAME>, reason: <num>)` parsed via new `error_split` and `category_str` helpers; always include provided error messages
> - Update golden outputs in `unittest*.exp` and `unexpected_abort.exp` to reflect the enriched messages
> - Add `unexpected_abort_with_canonical_error_code` test and expected output; adjust test counts accordingly
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7254d4b116330875fd9c6aecff2d036bcac11d07. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->