### PR TITLE
[move-prover] Properly desugar receiver style functions in let statements

### DIFF
--- a/third_party/move/move-compiler-v2/tests/checking/specs/spec_receiver_let_ok.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/specs/spec_receiver_let_ok.exp
@@ -1,0 +1,53 @@
+// -- Model dump before first bytecode pipeline
+module 0x42::M {
+    struct S {
+        value: u64,
+    }
+    private fun borrow(self: &S): &S {
+        self
+    }
+    private fun get_value(self: &S): u64 {
+        select M::S.value<&S>(self)
+    }
+    private fun test_borrow(c: S): u64 {
+        select M::S.value<S>(c)
+    }
+    spec {
+      let s_ref = M::$borrow($t0);
+      ensures Eq<u64>(result0(), select M::S.value<0x42::M::S>(s_ref));
+    }
+
+    private fun test_borrow_get_value(data: &S): u64 {
+        select M::S.value<&S>(data)
+    }
+    spec {
+      let data_value = M::$get_value(M::$borrow($t0));
+      ensures Eq<u64>(result0(), data_value);
+    }
+
+    spec fun $borrow(self: S): S {
+        self
+    }
+    spec fun $get_value(self: S): u64 {
+        select M::S.value<0x42::M::S>(self)
+    }
+} // end 0x42::M
+
+// -- Sourcified model before first bytecode pipeline
+module 0x42::M {
+    struct S {
+        value: u64,
+    }
+    fun borrow(self: &S): &S {
+        self
+    }
+    fun get_value(self: &S): u64 {
+        self.value
+    }
+    fun test_borrow(c: S): u64 {
+        c.value
+    }
+    fun test_borrow_get_value(data: &S): u64 {
+        data.value
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/checking/specs/spec_receiver_let_ok.move
+++ b/third_party/move/move-compiler-v2/tests/checking/specs/spec_receiver_let_ok.move
@@ -1,0 +1,27 @@
+module 0x42::M {
+    struct S {
+        value: u64
+    }
+    fun borrow(self: &S): &S {
+        self
+    }
+    fun get_value(self: &S): u64 {
+        self.value
+    }
+
+    fun test_borrow(c: S): u64 {
+        c.value
+    }
+    spec test_borrow {
+        let s_ref = c.borrow();
+        ensures result == s_ref.value;
+    }
+
+    fun test_borrow_get_value(data: &S): u64 {
+        data.value
+    }
+    spec test_borrow_get_value {
+        let data_value = data.borrow().get_value();
+        ensures result == data_value;
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/aptos-labs/aptos-core/issues/16764

This bug blocks https://github.com/aptos-labs/aptos-core/pull/18423 as `let a = b.borrow()` translated into `let a = NOOP` otherwise. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves handling of receiver-style calls inside specification `let` bindings by inserting desugaring before final type inference.
> 
> - In `module_builder.rs`, `def_ana_let` now runs `finalize_types(false)`, `post_process_body(...)`, then `finalize_types(true)`, storing the desugared expression and node id for `let` tracking
> - Adds tests `spec_receiver_let_ok.move` and expected output `.exp` to verify `c.borrow()` and `data.borrow().get_value()` are resolved in spec `let`s
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a269104396a48fcf60b5f574b4db9679f99a2379. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->