### PR TITLE
[cli] bump version to 7.14

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,7 +304,7 @@ dependencies = [
 
 [[package]]
 name = "aptos"
-version = "7.13.0"
+version = "7.14.0"
 dependencies = [
  "anyhow",
  "aptos-api-types",

--- a/crates/aptos/CHANGELOG.md
+++ b/crates/aptos/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to the Aptos CLI will be captured in this file. This project
 
 # Unreleased
 
+## [7.14.0]
+- Add support for code object deployment and upgrade in Transaction Simulation Sessions
+
 ## [7.13.0]
 - Set language version 2.3 and bytecode version v9 as default, adding support for signed integer types.
 - Update default version of formatter to 1.4.5 and move mutation tests to 2.2.0.

--- a/crates/aptos/Cargo.toml
+++ b/crates/aptos/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aptos"
 description = "Aptos tool for management of nodes and interacting with the blockchain"
-version = "7.13.0"
+version = "7.14.0"
 
 # Workspace inherited keys
 authors = { workspace = true }


### PR DESCRIPTION
This bumps the CLI version to 7.14.0, in preparation for a release later today.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prepares a 7.14.0 CLI release.
> 
> - Bumps `aptos` crate version to `7.14.0` in `Cargo.toml` and `Cargo.lock`
> - Updates `CHANGELOG.md` with support for code object deployment and upgrade in Transaction Simulation Sessions
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 39c3c43613d4ada57a10f42b33cf27568910c920. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->