### PR TITLE
Add BlockMetadataExt V2 with Decryption Key Support

### DIFF
--- a/api/doc/spec.json
+++ b/api/doc/spec.json
@@ -16161,13 +16161,17 @@
           },
           {
             "$ref": "#/components/schemas/BlockMetadataExtension_BlockMetadataExtensionRandomness"
+          },
+          {
+            "$ref": "#/components/schemas/BlockMetadataExtension_BlockMetadataExtensionRandomnessAndDecKey"
           }
         ],
         "discriminator": {
           "propertyName": "type",
           "mapping": {
             "v0": "#/components/schemas/BlockMetadataExtension_BlockMetadataExtensionEmpty",
-            "v1": "#/components/schemas/BlockMetadataExtension_BlockMetadataExtensionRandomness"
+            "v1": "#/components/schemas/BlockMetadataExtension_BlockMetadataExtensionRandomness",
+            "v2": "#/components/schemas/BlockMetadataExtension_BlockMetadataExtensionRandomnessAndDecKey"
           }
         }
       },
@@ -16178,6 +16182,17 @@
         "type": "object",
         "properties": {
           "randomness": {
+            "$ref": "#/components/schemas/HexEncodedBytes"
+          }
+        }
+      },
+      "BlockMetadataExtensionRandomnessAndDecKey": {
+        "type": "object",
+        "properties": {
+          "randomness": {
+            "$ref": "#/components/schemas/HexEncodedBytes"
+          },
+          "decryption_key": {
             "$ref": "#/components/schemas/HexEncodedBytes"
           }
         }
@@ -16223,6 +16238,28 @@
           },
           {
             "$ref": "#/components/schemas/BlockMetadataExtensionRandomness"
+          }
+        ]
+      },
+      "BlockMetadataExtension_BlockMetadataExtensionRandomnessAndDecKey": {
+        "allOf": [
+          {
+            "type": "object",
+            "required": [
+              "type"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "v2"
+                ],
+                "example": "v2"
+              }
+            }
+          },
+          {
+            "$ref": "#/components/schemas/BlockMetadataExtensionRandomnessAndDecKey"
           }
         ]
       },

--- a/api/doc/spec.yaml
+++ b/api/doc/spec.yaml
@@ -12087,17 +12087,26 @@ components:
       oneOf:
       - $ref: '#/components/schemas/BlockMetadataExtension_BlockMetadataExtensionEmpty'
       - $ref: '#/components/schemas/BlockMetadataExtension_BlockMetadataExtensionRandomness'
+      - $ref: '#/components/schemas/BlockMetadataExtension_BlockMetadataExtensionRandomnessAndDecKey'
       discriminator:
         propertyName: type
         mapping:
           v0: '#/components/schemas/BlockMetadataExtension_BlockMetadataExtensionEmpty'
           v1: '#/components/schemas/BlockMetadataExtension_BlockMetadataExtensionRandomness'
+          v2: '#/components/schemas/BlockMetadataExtension_BlockMetadataExtensionRandomnessAndDecKey'
     BlockMetadataExtensionEmpty:
       type: object
     BlockMetadataExtensionRandomness:
       type: object
       properties:
         randomness:
+          $ref: '#/components/schemas/HexEncodedBytes'
+    BlockMetadataExtensionRandomnessAndDecKey:
+      type: object
+      properties:
+        randomness:
+          $ref: '#/components/schemas/HexEncodedBytes'
+        decryption_key:
           $ref: '#/components/schemas/HexEncodedBytes'
     BlockMetadataExtension_BlockMetadataExtensionEmpty:
       allOf:
@@ -12123,6 +12132,18 @@ components:
             - v1
             example: v1
       - $ref: '#/components/schemas/BlockMetadataExtensionRandomness'
+    BlockMetadataExtension_BlockMetadataExtensionRandomnessAndDecKey:
+      allOf:
+      - type: object
+        required:
+        - type
+        properties:
+          type:
+            type: string
+            enum:
+            - v2
+            example: v2
+      - $ref: '#/components/schemas/BlockMetadataExtensionRandomnessAndDecKey'
     BlockMetadataTransaction:
       type: object
       description: |-

--- a/api/types/src/transaction.rs
+++ b/api/types/src/transaction.rs
@@ -631,7 +631,7 @@ impl BlockMetadataExtension {
                 decryption_key: payload
                     .decryption_key
                     .as_ref()
-                    .map(|dk| HexEncodedBytes::from(bcs::to_bytes(dk).unwrap())),
+                    .map(|dk| HexEncodedBytes::from(dk.decryption_key_cloned())),
             }),
         }
     }

--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -62,9 +62,10 @@ use aptos_types::{
         transaction_slice_metadata::TransactionSliceMetadata,
     },
     block_metadata::BlockMetadata,
-    block_metadata_ext::{BlockMetadataExt, BlockMetadataWithRandomness},
+    block_metadata_ext::BlockMetadataExt,
     chain_id::ChainId,
     contract_event::ContractEvent,
+    decryption::BlockTxnDecryptionKey,
     fee_statement::FeeStatement,
     function_info::FunctionInfo,
     move_utils::as_move_value::AsMoveValue,
@@ -2487,46 +2488,56 @@ impl AptosVM {
             None,
         );
 
-        let block_metadata_with_randomness = match block_metadata_ext {
+        // Extract common fields and determine which function to call
+        let (function_name, args) = match block_metadata_ext {
             BlockMetadataExt::V0(_) => unreachable!(),
-            BlockMetadataExt::V1(v1) => v1,
+            BlockMetadataExt::V1(v1) => {
+                let args = vec![
+                    MoveValue::Signer(AccountAddress::ZERO), // Run as 0x0
+                    MoveValue::Address(AccountAddress::from_bytes(v1.id.to_vec()).unwrap()),
+                    MoveValue::U64(v1.epoch),
+                    MoveValue::U64(v1.round),
+                    MoveValue::Address(v1.proposer),
+                    v1.failed_proposer_indices
+                        .into_iter()
+                        .map(|i| i as u64)
+                        .collect::<Vec<_>>()
+                        .as_move_value(),
+                    v1.previous_block_votes_bitvec.as_move_value(),
+                    MoveValue::U64(v1.timestamp_usecs),
+                    v1.randomness
+                        .as_ref()
+                        .map(Randomness::randomness_cloned)
+                        .as_move_value(),
+                ];
+                (BLOCK_PROLOGUE_EXT, args)
+            },
             BlockMetadataExt::V2(v2) => {
-                return Err(VMStatus::error(
-                    StatusCode::FEATURE_UNDER_GATING,
-                    Some(String::from("BlockMetadataExt::V2 is not supported yet")),
-                ));
+                let args = vec![
+                    MoveValue::Signer(AccountAddress::ZERO), // Run as 0x0
+                    MoveValue::Address(AccountAddress::from_bytes(v2.id.to_vec()).unwrap()),
+                    MoveValue::U64(v2.epoch),
+                    MoveValue::U64(v2.round),
+                    MoveValue::Address(v2.proposer),
+                    v2.failed_proposer_indices
+                        .into_iter()
+                        .map(|i| i as u64)
+                        .collect::<Vec<_>>()
+                        .as_move_value(),
+                    v2.previous_block_votes_bitvec.as_move_value(),
+                    MoveValue::U64(v2.timestamp_usecs),
+                    v2.randomness
+                        .as_ref()
+                        .map(Randomness::randomness_cloned)
+                        .as_move_value(),
+                    v2.decryption_key
+                        .as_ref()
+                        .map(BlockTxnDecryptionKey::decryption_key_cloned)
+                        .as_move_value(),
+                ];
+                (BLOCK_PROLOGUE_EXT_V2, args)
             },
         };
-
-        let BlockMetadataWithRandomness {
-            id,
-            epoch,
-            round,
-            proposer,
-            previous_block_votes_bitvec,
-            failed_proposer_indices,
-            timestamp_usecs,
-            randomness,
-        } = block_metadata_with_randomness;
-
-        let args = vec![
-            MoveValue::Signer(AccountAddress::ZERO), // Run as 0x0
-            MoveValue::Address(AccountAddress::from_bytes(id.to_vec()).unwrap()),
-            MoveValue::U64(epoch),
-            MoveValue::U64(round),
-            MoveValue::Address(proposer),
-            failed_proposer_indices
-                .into_iter()
-                .map(|i| i as u64)
-                .collect::<Vec<_>>()
-                .as_move_value(),
-            previous_block_votes_bitvec.as_move_value(),
-            MoveValue::U64(timestamp_usecs),
-            randomness
-                .as_ref()
-                .map(Randomness::randomness_cloned)
-                .as_move_value(),
-        ];
 
         let traversal_storage = TraversalStorage::new();
         let mut traversal_context = TraversalContext::new(&traversal_storage);
@@ -2534,7 +2545,7 @@ impl AptosVM {
         session
             .execute_function_bypass_visibility(
                 &BLOCK_MODULE,
-                BLOCK_PROLOGUE_EXT,
+                function_name,
                 vec![],
                 serialize_values(&args),
                 &mut gas_meter,
@@ -2543,7 +2554,7 @@ impl AptosVM {
             )
             .map(|_return_vals| ())
             .or_else(|e| {
-                expect_only_successful_execution(e, BLOCK_PROLOGUE_EXT.as_str(), log_context)
+                expect_only_successful_execution(e, function_name.as_str(), log_context)
             })?;
         SYSTEM_TRANSACTIONS_EXECUTED.inc();
 

--- a/aptos-move/aptos-vm/src/system_module_names.rs
+++ b/aptos-move/aptos-vm/src/system_module_names.rs
@@ -37,6 +37,7 @@ pub static BLOCK_MODULE: Lazy<ModuleId> = Lazy::new(|| {
 
 pub const BLOCK_PROLOGUE: &IdentStr = ident_str!("block_prologue");
 pub const BLOCK_PROLOGUE_EXT: &IdentStr = ident_str!("block_prologue_ext");
+pub const BLOCK_PROLOGUE_EXT_V2: &IdentStr = ident_str!("block_prologue_ext_v2");
 pub const BLOCK_EPILOGUE: &IdentStr = ident_str!("block_epilogue");
 
 pub static RECONFIGURATION_WITH_DKG_MODULE: Lazy<ModuleId> = Lazy::new(|| {

--- a/aptos-move/framework/aptos-framework/doc/decryption.md
+++ b/aptos-move/framework/aptos-framework/doc/decryption.md
@@ -1,0 +1,132 @@
+
+<a id="0x1_decryption"></a>
+
+# Module `0x1::decryption`
+
+This module provides a decryption key unique to every block. This resource
+is updated in every block prologue. The decryption key is the key used to
+decrypt the encrypted transactions in the block.
+
+
+-  [Resource `PerBlockDecryptionKey`](#0x1_decryption_PerBlockDecryptionKey)
+-  [Function `initialize`](#0x1_decryption_initialize)
+-  [Function `on_new_block`](#0x1_decryption_on_new_block)
+
+
+<pre><code><b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option">0x1::option</a>;
+<b>use</b> <a href="system_addresses.md#0x1_system_addresses">0x1::system_addresses</a>;
+</code></pre>
+
+
+
+<a id="0x1_decryption_PerBlockDecryptionKey"></a>
+
+## Resource `PerBlockDecryptionKey`
+
+Decryption key unique to every block.
+This resource is updated in every block prologue.
+
+
+<pre><code><b>struct</b> <a href="decryption.md#0x1_decryption_PerBlockDecryptionKey">PerBlockDecryptionKey</a> <b>has</b> drop, key
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>epoch: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>round: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>decryption_key: <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;&gt;</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a id="0x1_decryption_initialize"></a>
+
+## Function `initialize`
+
+Called during genesis initialization.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="decryption.md#0x1_decryption_initialize">initialize</a>(framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="decryption.md#0x1_decryption_initialize">initialize</a>(framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>) {
+    <a href="system_addresses.md#0x1_system_addresses_assert_aptos_framework">system_addresses::assert_aptos_framework</a>(framework);
+    <b>if</b> (!<b>exists</b>&lt;<a href="decryption.md#0x1_decryption_PerBlockDecryptionKey">PerBlockDecryptionKey</a>&gt;(@aptos_framework)) {
+        <b>move_to</b>(
+            framework,
+            <a href="decryption.md#0x1_decryption_PerBlockDecryptionKey">PerBlockDecryptionKey</a> { epoch: 0, round: 0, decryption_key: <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_none">option::none</a>() }
+        );
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_decryption_on_new_block"></a>
+
+## Function `on_new_block`
+
+Invoked in block prologues to update the block decryption key.
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="decryption.md#0x1_decryption_on_new_block">on_new_block</a>(vm: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, epoch: u64, round: u64, decryption_key_for_new_block: <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="decryption.md#0x1_decryption_on_new_block">on_new_block</a>(
+    vm: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
+    epoch: u64,
+    round: u64,
+    decryption_key_for_new_block: Option&lt;<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;&gt;
+) <b>acquires</b> <a href="decryption.md#0x1_decryption_PerBlockDecryptionKey">PerBlockDecryptionKey</a> {
+    <a href="system_addresses.md#0x1_system_addresses_assert_vm">system_addresses::assert_vm</a>(vm);
+    <b>if</b> (<b>exists</b>&lt;<a href="decryption.md#0x1_decryption_PerBlockDecryptionKey">PerBlockDecryptionKey</a>&gt;(@aptos_framework)) {
+        <b>let</b> decryption_key =
+            <b>borrow_global_mut</b>&lt;<a href="decryption.md#0x1_decryption_PerBlockDecryptionKey">PerBlockDecryptionKey</a>&gt;(@aptos_framework);
+        decryption_key.epoch = epoch;
+        decryption_key.round = round;
+        decryption_key.decryption_key = decryption_key_for_new_block;
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/aptos-framework/doc/overview.md
+++ b/aptos-move/framework/aptos-framework/doc/overview.md
@@ -32,6 +32,7 @@ This is the reference documentation of the Aptos framework.
 -  [`0x1::config_buffer`](config_buffer.md#0x1_config_buffer)
 -  [`0x1::consensus_config`](consensus_config.md#0x1_consensus_config)
 -  [`0x1::create_signer`](create_signer.md#0x1_create_signer)
+-  [`0x1::decryption`](decryption.md#0x1_decryption)
 -  [`0x1::delegation_pool`](delegation_pool.md#0x1_delegation_pool)
 -  [`0x1::dispatchable_fungible_asset`](dispatchable_fungible_asset.md#0x1_dispatchable_fungible_asset)
 -  [`0x1::dkg`](dkg.md#0x1_dkg)

--- a/aptos-move/framework/aptos-framework/doc/randomness.md
+++ b/aptos-move/framework/aptos-framework/doc/randomness.md
@@ -219,11 +219,10 @@ Must be called in tests to initialize the <code><a href="randomness.md#0x1_rando
 <pre><code><b>public</b> <b>fun</b> <a href="randomness.md#0x1_randomness_initialize">initialize</a>(framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>) {
     <a href="system_addresses.md#0x1_system_addresses_assert_aptos_framework">system_addresses::assert_aptos_framework</a>(framework);
     <b>if</b> (!<b>exists</b>&lt;<a href="randomness.md#0x1_randomness_PerBlockRandomness">PerBlockRandomness</a>&gt;(@aptos_framework)) {
-        <b>move_to</b>(framework, <a href="randomness.md#0x1_randomness_PerBlockRandomness">PerBlockRandomness</a> {
-            epoch: 0,
-            round: 0,
-            seed: <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_none">option::none</a>(),
-        });
+        <b>move_to</b>(
+            framework,
+            <a href="randomness.md#0x1_randomness_PerBlockRandomness">PerBlockRandomness</a> { epoch: 0, round: 0, seed: <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_none">option::none</a>() }
+        );
     }
 }
 </code></pre>
@@ -248,7 +247,12 @@ Invoked in block prologues to update the block-level randomness seed.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="randomness.md#0x1_randomness_on_new_block">on_new_block</a>(vm: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, epoch: u64, round: u64, seed_for_new_block: Option&lt;<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;&gt;) <b>acquires</b> <a href="randomness.md#0x1_randomness_PerBlockRandomness">PerBlockRandomness</a> {
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="randomness.md#0x1_randomness_on_new_block">on_new_block</a>(
+    vm: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
+    epoch: u64,
+    round: u64,
+    seed_for_new_block: Option&lt;<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;&gt;
+) <b>acquires</b> <a href="randomness.md#0x1_randomness_PerBlockRandomness">PerBlockRandomness</a> {
     <a href="system_addresses.md#0x1_system_addresses_assert_vm">system_addresses::assert_vm</a>(vm);
     <b>if</b> (<b>exists</b>&lt;<a href="randomness.md#0x1_randomness_PerBlockRandomness">PerBlockRandomness</a>&gt;(@aptos_framework)) {
         <b>let</b> <a href="randomness.md#0x1_randomness">randomness</a> = <b>borrow_global_mut</b>&lt;<a href="randomness.md#0x1_randomness_PerBlockRandomness">PerBlockRandomness</a>&gt;(@aptos_framework);
@@ -830,7 +834,7 @@ If n is 0, returns the empty vector.
 
     <b>let</b> values = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[];
 
-    <b>if</b>(n == 0) {
+    <b>if</b> (n == 0) {
         <b>return</b> <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[]
     };
 
@@ -894,7 +898,15 @@ Compute <code>(a + b) % m</code>, assuming <code>m &gt;= 1, 0 &lt;= a &lt; m, 0&
     <b>let</b> a_clone = a;
     <b>let</b> neg_b = m - b;
     <b>let</b> a_less = a &lt; neg_b;
-    <a href="randomness.md#0x1_randomness_take_first">take_first</a>(<b>if</b> (a_less) { a + b } <b>else</b> { a_clone - neg_b }, <b>if</b> (!a_less) { a_clone - neg_b } <b>else</b> { a + b })
+    <a href="randomness.md#0x1_randomness_take_first">take_first</a>(
+        <b>if</b> (a_less) { a + b }
+        <b>else</b> {
+            a_clone - neg_b
+        },
+        <b>if</b> (!a_less) {
+            a_clone - neg_b
+        } <b>else</b> { a + b }
+    )
 }
 </code></pre>
 
@@ -917,7 +929,9 @@ Compute <code>(a + b) % m</code>, assuming <code>m &gt;= 1, 0 &lt;= a &lt; m, 0&
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="randomness.md#0x1_randomness_take_first">take_first</a>(x: u256, _y: u256 ): u256 { x }
+<pre><code><b>fun</b> <a href="randomness.md#0x1_randomness_take_first">take_first</a>(x: u256, _y: u256): u256 {
+    x
+}
 </code></pre>
 
 

--- a/aptos-move/framework/aptos-framework/sources/decryption.move
+++ b/aptos-move/framework/aptos-framework/sources/decryption.move
@@ -1,0 +1,47 @@
+/// This module provides a decryption key unique to every block. This resource
+/// is updated in every block prologue. The decryption key is the key used to
+/// decrypt the encrypted transactions in the block.
+module aptos_framework::decryption {
+    use std::option;
+    use std::option::Option;
+
+    use aptos_framework::system_addresses;
+
+    friend aptos_framework::block;
+
+    /// Decryption key unique to every block.
+    /// This resource is updated in every block prologue.
+    struct PerBlockDecryptionKey has drop, key {
+        epoch: u64,
+        round: u64,
+        decryption_key: Option<vector<u8>>
+    }
+
+    /// Called during genesis initialization.
+    public fun initialize(framework: &signer) {
+        system_addresses::assert_aptos_framework(framework);
+        if (!exists<PerBlockDecryptionKey>(@aptos_framework)) {
+            move_to(
+                framework,
+                PerBlockDecryptionKey { epoch: 0, round: 0, decryption_key: option::none() }
+            );
+        }
+    }
+
+    /// Invoked in block prologues to update the block decryption key.
+    public(friend) fun on_new_block(
+        vm: &signer,
+        epoch: u64,
+        round: u64,
+        decryption_key_for_new_block: Option<vector<u8>>
+    ) acquires PerBlockDecryptionKey {
+        system_addresses::assert_vm(vm);
+        if (exists<PerBlockDecryptionKey>(@aptos_framework)) {
+            let decryption_key =
+                borrow_global_mut<PerBlockDecryptionKey>(@aptos_framework);
+            decryption_key.epoch = epoch;
+            decryption_key.round = round;
+            decryption_key.decryption_key = decryption_key_for_new_block;
+        }
+    }
+}

--- a/aptos-move/framework/aptos-framework/sources/randomness.move
+++ b/aptos-move/framework/aptos-framework/sources/randomness.move
@@ -25,42 +25,46 @@ module aptos_framework::randomness {
     /// `#[randomness]` annotation. Otherwise, malicious users can bias randomness result.
     const E_API_USE_IS_BIASIBLE: u64 = 1;
 
-    const MAX_U256: u256 = 115792089237316195423570985008687907853269984665640564039457584007913129639935;
+    const MAX_U256: u256 =
+        115792089237316195423570985008687907853269984665640564039457584007913129639935;
 
     /// 32-byte randomness seed unique to every block.
     /// This resource is updated in every block prologue.
     struct PerBlockRandomness has drop, key {
         epoch: u64,
         round: u64,
-        seed: Option<vector<u8>>,
+        seed: Option<vector<u8>>
     }
 
     #[event]
     /// Event emitted every time a public randomness API in this module is called.
-    struct RandomnessGeneratedEvent has store, drop {
-    }
+    struct RandomnessGeneratedEvent has store, drop {}
 
     /// Called in genesis.move.
     /// Must be called in tests to initialize the `PerBlockRandomness` resource.
     public fun initialize(framework: &signer) {
         system_addresses::assert_aptos_framework(framework);
         if (!exists<PerBlockRandomness>(@aptos_framework)) {
-            move_to(framework, PerBlockRandomness {
-                epoch: 0,
-                round: 0,
-                seed: option::none(),
-            });
+            move_to(
+                framework,
+                PerBlockRandomness { epoch: 0, round: 0, seed: option::none() }
+            );
         }
     }
 
     #[test_only]
-    public fun initialize_for_testing(framework: &signer) acquires  PerBlockRandomness {
+    public fun initialize_for_testing(framework: &signer) acquires PerBlockRandomness {
         initialize(framework);
         set_seed(x"0000000000000000000000000000000000000000000000000000000000000000");
     }
 
     /// Invoked in block prologues to update the block-level randomness seed.
-    public(friend) fun on_new_block(vm: &signer, epoch: u64, round: u64, seed_for_new_block: Option<vector<u8>>) acquires PerBlockRandomness {
+    public(friend) fun on_new_block(
+        vm: &signer,
+        epoch: u64,
+        round: u64,
+        seed_for_new_block: Option<vector<u8>>
+    ) acquires PerBlockRandomness {
         system_addresses::assert_vm(vm);
         if (exists<PerBlockRandomness>(@aptos_framework)) {
             let randomness = borrow_global_mut<PerBlockRandomness>(@aptos_framework);
@@ -302,7 +306,7 @@ module aptos_framework::randomness {
 
         let values = vector[];
 
-        if(n == 0) {
+        if (n == 0) {
             return vector[]
         };
 
@@ -353,17 +357,26 @@ module aptos_framework::randomness {
         let a_clone = a;
         let neg_b = m - b;
         let a_less = a < neg_b;
-        take_first(if (a_less) { a + b } else { a_clone - neg_b }, if (!a_less) { a_clone - neg_b } else { a + b })
+        take_first(
+            if (a_less) { a + b }
+            else {
+                a_clone - neg_b
+            },
+            if (!a_less) {
+                a_clone - neg_b
+            } else { a + b }
+        )
     }
 
-    fun take_first(x: u256, _y: u256 ): u256 { x }
+    fun take_first(x: u256, _y: u256): u256 {
+        x
+    }
 
     #[verify_only]
     fun safe_add_mod_for_verification(a: u256, b: u256, m: u256): u256 {
         let neg_b = m - b;
-        if (a < neg_b) {
-            a + b
-        } else {
+        if (a < neg_b) { a + b }
+        else {
             a - neg_b
         }
     }
@@ -384,13 +397,69 @@ module aptos_framework::randomness {
         assert!(2 == safe_add_mod(4, 3, 5), 1);
         assert!(7 == safe_add_mod(3, 4, 9), 1);
         assert!(7 == safe_add_mod(4, 3, 9), 1);
-        assert!(0xfffffffffffffffffffffffffffffffffffffffffffffffe == safe_add_mod(0xfffffffffffffffffffffffffffffffffffffffffffffffd, 0x000000000000000000000000000000000000000000000001, 0xffffffffffffffffffffffffffffffffffffffffffffffff), 1);
-        assert!(0xfffffffffffffffffffffffffffffffffffffffffffffffe == safe_add_mod(0x000000000000000000000000000000000000000000000001, 0xfffffffffffffffffffffffffffffffffffffffffffffffd, 0xffffffffffffffffffffffffffffffffffffffffffffffff), 1);
-        assert!(0x000000000000000000000000000000000000000000000000 == safe_add_mod(0xfffffffffffffffffffffffffffffffffffffffffffffffd, 0x000000000000000000000000000000000000000000000002, 0xffffffffffffffffffffffffffffffffffffffffffffffff), 1);
-        assert!(0x000000000000000000000000000000000000000000000000 == safe_add_mod(0x000000000000000000000000000000000000000000000002, 0xfffffffffffffffffffffffffffffffffffffffffffffffd, 0xffffffffffffffffffffffffffffffffffffffffffffffff), 1);
-        assert!(0x000000000000000000000000000000000000000000000001 == safe_add_mod(0xfffffffffffffffffffffffffffffffffffffffffffffffd, 0x000000000000000000000000000000000000000000000003, 0xffffffffffffffffffffffffffffffffffffffffffffffff), 1);
-        assert!(0x000000000000000000000000000000000000000000000001 == safe_add_mod(0x000000000000000000000000000000000000000000000003, 0xfffffffffffffffffffffffffffffffffffffffffffffffd, 0xffffffffffffffffffffffffffffffffffffffffffffffff), 1);
-        assert!(0xfffffffffffffffffffffffffffffffffffffffffffffffd == safe_add_mod(0xfffffffffffffffffffffffffffffffffffffffffffffffe, 0xfffffffffffffffffffffffffffffffffffffffffffffffe, 0xffffffffffffffffffffffffffffffffffffffffffffffff), 1);
+        assert!(
+            0xfffffffffffffffffffffffffffffffffffffffffffffffe
+                == safe_add_mod(
+                    0xfffffffffffffffffffffffffffffffffffffffffffffffd,
+                    0x000000000000000000000000000000000000000000000001,
+                    0xffffffffffffffffffffffffffffffffffffffffffffffff
+                ),
+            1
+        );
+        assert!(
+            0xfffffffffffffffffffffffffffffffffffffffffffffffe
+                == safe_add_mod(
+                    0x000000000000000000000000000000000000000000000001,
+                    0xfffffffffffffffffffffffffffffffffffffffffffffffd,
+                    0xffffffffffffffffffffffffffffffffffffffffffffffff
+                ),
+            1
+        );
+        assert!(
+            0x000000000000000000000000000000000000000000000000
+                == safe_add_mod(
+                    0xfffffffffffffffffffffffffffffffffffffffffffffffd,
+                    0x000000000000000000000000000000000000000000000002,
+                    0xffffffffffffffffffffffffffffffffffffffffffffffff
+                ),
+            1
+        );
+        assert!(
+            0x000000000000000000000000000000000000000000000000
+                == safe_add_mod(
+                    0x000000000000000000000000000000000000000000000002,
+                    0xfffffffffffffffffffffffffffffffffffffffffffffffd,
+                    0xffffffffffffffffffffffffffffffffffffffffffffffff
+                ),
+            1
+        );
+        assert!(
+            0x000000000000000000000000000000000000000000000001
+                == safe_add_mod(
+                    0xfffffffffffffffffffffffffffffffffffffffffffffffd,
+                    0x000000000000000000000000000000000000000000000003,
+                    0xffffffffffffffffffffffffffffffffffffffffffffffff
+                ),
+            1
+        );
+        assert!(
+            0x000000000000000000000000000000000000000000000001
+                == safe_add_mod(
+                    0x000000000000000000000000000000000000000000000003,
+                    0xfffffffffffffffffffffffffffffffffffffffffffffffd,
+                    0xffffffffffffffffffffffffffffffffffffffffffffffff
+                ),
+            1
+        );
+        assert!(
+            0xfffffffffffffffffffffffffffffffffffffffffffffffd
+                == safe_add_mod(
+                    0xfffffffffffffffffffffffffffffffffffffffffffffffe,
+                    0xfffffffffffffffffffffffffffffffffffffffffffffffe,
+                    0xffffffffffffffffffffffffffffffffffffffffffffffff
+                ),
+            1
+        );
     }
 
     #[test(fx = @aptos_framework)]
@@ -523,7 +592,7 @@ module aptos_framework::randomness {
 
         for (i in 0..n) {
             let bit = present.borrow(i);
-            if(*bit == false) {
+            if (*bit == false) {
                 return false
             };
         };
@@ -558,12 +627,12 @@ module aptos_framework::randomness {
         let permutations = table_with_length::new<vector<u64>, bool>();
 
         // This loop will not exit until all permutations are created
-        while(permutations.length() < num_permutations) {
+        while (permutations.length() < num_permutations) {
             let v = permutation(size);
             assert!(v.length() == size, 0);
             assert!(is_permutation(&v), 0);
 
-            if(permutations.contains(v) == false) {
+            if (permutations.contains(v) == false) {
                 permutations.add(v, true);
             }
         };

--- a/consensus/consensus-types/src/block.rs
+++ b/consensus/consensus-types/src/block.rs
@@ -17,10 +17,10 @@ use aptos_types::{
     block_info::BlockInfo,
     block_metadata::BlockMetadata,
     block_metadata_ext::BlockMetadataExt,
+    decryption::BlockTxnDecryptionKey,
     epoch_state::EpochState,
     ledger_info::LedgerInfo,
     randomness::Randomness,
-    secret_sharing::DecryptionKey,
     transaction::{SignedTransaction, Transaction, Version},
     validator_signer::ValidatorSigner,
     validator_txn::ValidatorTransaction,
@@ -621,7 +621,7 @@ impl Block {
         &self,
         validators: &[AccountAddress],
         randomness: Option<Randomness>,
-        decryption_key: Option<DecryptionKey>,
+        decryption_key: Option<BlockTxnDecryptionKey>,
     ) -> BlockMetadataExt {
         BlockMetadataExt::new_v2(
             self.id(),

--- a/consensus/consensus-types/src/pipelined_block.rs
+++ b/consensus/consensus-types/src/pipelined_block.rs
@@ -20,9 +20,10 @@ use aptos_logger::{error, info, warn};
 use aptos_types::{
     block_info::BlockInfo,
     contract_event::ContractEvent,
+    decryption::BlockTxnDecryptionKey,
     ledger_info::LedgerInfoWithSignatures,
     randomness::Randomness,
-    secret_sharing::{DecryptionKey, SecretShare, SecretSharedKey},
+    secret_sharing::{SecretShare, SecretSharedKey},
     transaction::{
         signature_verified_transaction::SignatureVerifiedTransaction, SignedTransaction,
         TransactionStatus,
@@ -73,12 +74,12 @@ pub type DecryptionResult = (
     Vec<SignedTransaction>,
     Option<u64>,
     Option<u64>,
-    Option<DecryptionKey>,
+    Option<Option<BlockTxnDecryptionKey>>,
 );
 pub type PrepareResult = (
     Arc<Vec<SignatureVerifiedTransaction>>,
     Option<u64>,
-    Option<DecryptionKey>,
+    Option<Option<BlockTxnDecryptionKey>>,
 );
 // First Option is whether randomness is enabled
 // Second Option is whether randomness is skipped

--- a/consensus/src/rand/secret_sharing/block_queue.rs
+++ b/consensus/src/rand/secret_sharing/block_queue.rs
@@ -63,6 +63,7 @@ impl QueueItem {
 
     pub fn set_secret_shared_key(&mut self, round: Round, key: SecretSharedKey) {
         let offset = self.offset(round);
+        // TODO(ibalajiarun): revisit the importance of this hashset
         if self.pending_secret_key_rounds.contains(&round) {
             observe_block(
                 self.blocks()[offset].timestamp_usecs(),

--- a/execution/executor/tests/internal_indexer_test.rs
+++ b/execution/executor/tests/internal_indexer_test.rs
@@ -255,6 +255,7 @@ fn test_db_indexer_data() {
         ident_str!("bit_vector"),
         ident_str!("capability"),
         ident_str!("comparator"),
+        ident_str!("decryption"),
         ident_str!("math_fixed"),
         ident_str!("randomness"),
         ident_str!("simple_map"),

--- a/testsuite/generate-format/tests/staged/api.yaml
+++ b/testsuite/generate-format/tests/staged/api.yaml
@@ -213,6 +213,28 @@ BlockMetadataExt:
       V1:
         NEWTYPE:
           TYPENAME: BlockMetadataWithRandomness
+    2:
+      V2:
+        NEWTYPE:
+          TYPENAME: BlockMetadataWithRandAndDecKey
+BlockMetadataWithRandAndDecKey:
+  STRUCT:
+    - id:
+        TYPENAME: HashValue
+    - epoch: U64
+    - round: U64
+    - proposer:
+        TYPENAME: AccountAddress
+    - previous_block_votes_bitvec: BYTES
+    - failed_proposer_indices:
+        SEQ: U32
+    - timestamp_usecs: U64
+    - randomness:
+        OPTION:
+          TYPENAME: Randomness
+    - decryption_key:
+        OPTION:
+          TYPENAME: BlockTxnDecryptionKey
 BlockMetadataWithRandomness:
   STRUCT:
     - id:
@@ -228,6 +250,11 @@ BlockMetadataWithRandomness:
     - randomness:
         OPTION:
           TYPENAME: Randomness
+BlockTxnDecryptionKey:
+  STRUCT:
+    - metadata:
+        TYPENAME: DecKeyMetadata
+    - decryption_key: BYTES
 ChainId:
   NEWTYPESTRUCT: U8
 ChangeSet:
@@ -288,6 +315,10 @@ DKGTranscriptMetadata:
     - epoch: U64
     - author:
         TYPENAME: AccountAddress
+DecKeyMetadata:
+  STRUCT:
+    - epoch: U64
+    - round: U64
 DepositEvent:
   STRUCT:
     - amount: U64

--- a/testsuite/generate-format/tests/staged/aptos.yaml
+++ b/testsuite/generate-format/tests/staged/aptos.yaml
@@ -201,6 +201,28 @@ BlockMetadataExt:
       V1:
         NEWTYPE:
           TYPENAME: BlockMetadataWithRandomness
+    2:
+      V2:
+        NEWTYPE:
+          TYPENAME: BlockMetadataWithRandAndDecKey
+BlockMetadataWithRandAndDecKey:
+  STRUCT:
+    - id:
+        TYPENAME: HashValue
+    - epoch: U64
+    - round: U64
+    - proposer:
+        TYPENAME: AccountAddress
+    - previous_block_votes_bitvec: BYTES
+    - failed_proposer_indices:
+        SEQ: U32
+    - timestamp_usecs: U64
+    - randomness:
+        OPTION:
+          TYPENAME: Randomness
+    - decryption_key:
+        OPTION:
+          TYPENAME: BlockTxnDecryptionKey
 BlockMetadataWithRandomness:
   STRUCT:
     - id:
@@ -216,6 +238,11 @@ BlockMetadataWithRandomness:
     - randomness:
         OPTION:
           TYPENAME: Randomness
+BlockTxnDecryptionKey:
+  STRUCT:
+    - metadata:
+        TYPENAME: DecKeyMetadata
+    - decryption_key: BYTES
 ChainId:
   NEWTYPESTRUCT: U8
 ChangeSet:
@@ -268,6 +295,10 @@ DKGTranscriptMetadata:
     - epoch: U64
     - author:
         TYPENAME: AccountAddress
+DecKeyMetadata:
+  STRUCT:
+    - epoch: U64
+    - round: U64
 DeprecatedPayload:
   STRUCT:
     - dummy_value: U64

--- a/testsuite/generate-format/tests/staged/consensus.yaml
+++ b/testsuite/generate-format/tests/staged/consensus.yaml
@@ -311,6 +311,28 @@ BlockMetadataExt:
       V1:
         NEWTYPE:
           TYPENAME: BlockMetadataWithRandomness
+    2:
+      V2:
+        NEWTYPE:
+          TYPENAME: BlockMetadataWithRandAndDecKey
+BlockMetadataWithRandAndDecKey:
+  STRUCT:
+    - id:
+        TYPENAME: HashValue
+    - epoch: U64
+    - round: U64
+    - proposer:
+        TYPENAME: AccountAddress
+    - previous_block_votes_bitvec: BYTES
+    - failed_proposer_indices:
+        SEQ: U32
+    - timestamp_usecs: U64
+    - randomness:
+        OPTION:
+          TYPENAME: Randomness
+    - decryption_key:
+        OPTION:
+          TYPENAME: BlockTxnDecryptionKey
 BlockMetadataWithRandomness:
   STRUCT:
     - id:
@@ -367,6 +389,11 @@ BlockRetrievalStatus:
       NotEnoughBlocks: UNIT
     3:
       SucceededWithTarget: UNIT
+BlockTxnDecryptionKey:
+  STRUCT:
+    - metadata:
+        TYPENAME: DecKeyMetadata
+    - decryption_key: BYTES
 BlockType:
   ENUM:
     0:
@@ -588,6 +615,10 @@ DKGTranscriptMetadata:
     - epoch: U64
     - author:
         TYPENAME: AccountAddress
+DecKeyMetadata:
+  STRUCT:
+    - epoch: U64
+    - round: U64
 DeprecatedPayload:
   STRUCT:
     - dummy_value: U64

--- a/types/src/block_metadata_ext.rs
+++ b/types/src/block_metadata_ext.rs
@@ -1,7 +1,9 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-use crate::{block_metadata::BlockMetadata, randomness::Randomness, secret_sharing::DecryptionKey};
+use crate::{
+    block_metadata::BlockMetadata, decryption::BlockTxnDecryptionKey, randomness::Randomness,
+};
 use aptos_crypto::HashValue;
 use move_core_types::account_address::AccountAddress;
 use serde::{Deserialize, Serialize};
@@ -45,7 +47,7 @@ pub struct BlockMetadataWithRandAndDecKey {
     pub failed_proposer_indices: Vec<u32>,
     pub timestamp_usecs: u64,
     pub randomness: Option<Randomness>,
-    pub decryption_key: Option<DecryptionKey>,
+    pub decryption_key: Option<BlockTxnDecryptionKey>,
 }
 
 impl BlockMetadataExt {
@@ -80,7 +82,7 @@ impl BlockMetadataExt {
         failed_proposer_indices: Vec<u32>,
         timestamp_usecs: u64,
         randomness: Option<Randomness>,
-        decryption_key: Option<DecryptionKey>,
+        decryption_key: Option<BlockTxnDecryptionKey>,
     ) -> Self {
         Self::V2(BlockMetadataWithRandAndDecKey {
             id,

--- a/types/src/decryption.rs
+++ b/types/src/decryption.rs
@@ -1,0 +1,59 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+use crate::{block_info::Round, on_chain_config::OnChainConfig};
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Serialize, Deserialize, Debug, Default, PartialEq, Eq, Hash)]
+pub struct DecKeyMetadata {
+    pub epoch: u64,
+    pub round: Round,
+}
+
+#[derive(Clone, Serialize, Deserialize, Debug, Default, PartialEq, Eq)]
+pub struct BlockTxnDecryptionKey {
+    metadata: DecKeyMetadata,
+    #[serde(with = "serde_bytes")]
+    decryption_key: Vec<u8>,
+}
+
+impl BlockTxnDecryptionKey {
+    pub fn new(metadata: DecKeyMetadata, decryption_key: Vec<u8>) -> Self {
+        Self {
+            metadata,
+            decryption_key,
+        }
+    }
+
+    pub fn metadata(&self) -> &DecKeyMetadata {
+        &self.metadata
+    }
+
+    pub fn epoch(&self) -> u64 {
+        self.metadata.epoch
+    }
+
+    pub fn round(&self) -> Round {
+        self.metadata.round
+    }
+
+    pub fn decryption_key(&self) -> &[u8] {
+        &self.decryption_key
+    }
+
+    pub fn decryption_key_cloned(&self) -> Vec<u8> {
+        self.decryption_key.clone()
+    }
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+pub struct OnchainPerBlockDecryptionKey {
+    pub epoch: u64,
+    pub round: u64,
+    pub decryption_key: Option<Vec<u8>>,
+}
+
+impl OnChainConfig for OnchainPerBlockDecryptionKey {
+    const MODULE_IDENTIFIER: &'static str = "decryption";
+    const TYPE_IDENTIFIER: &'static str = "PerBlockDecryptionKey";
+}

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -11,6 +11,7 @@ pub mod block_metadata;
 pub mod block_metadata_ext;
 pub mod chain_id;
 pub mod contract_event;
+pub mod decryption;
 pub mod dkg;
 pub mod epoch_change;
 pub mod epoch_state;


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

Adds `BlockMetadataExt::V2` variant that includes a decryption key alongside randomness, enabling encrypted mempool transactions to be decrypted per-block.

When enabled and wired up completely, it should produce additional field is block metadata like below.

```
...
"block_metadata_extension": {
      "randomness": null,
      "decryption_key": "0x309592dd04ae787f48b63f263f18084a80c3ea43c9e75318ac5600f6c7a68b02fb2fec5ae469dd9444a6cc966ff7500c98",
      "type": "v2"
},
"type": "block_metadata_transaction"
```

## Changes

- Added `BlockMetadataExt::V2` with optional `DecryptionKey` field
- Updated VM to execute `block_prologue_ext_v2` with decryption key
- Added new `decryption.move` module for per-block decryption key storage
- Updated consensus pipeline to construct V2 block metadata
- Added API support for V2 in transaction responses