### PR TITLE
[batch-encryption] remove happy path in impls and traits

### DIFF
--- a/crates/aptos-batch-encryption/benches/fptx.rs
+++ b/crates/aptos-batch-encryption/benches/fptx.rs
@@ -14,8 +14,7 @@ pub fn digest(c: &mut Criterion) {
     for batch_size in [32, 128, 512, 2048] {
         let mut rng = thread_rng();
         let tc = ShamirThresholdConfig::new(1, 1);
-        let (ek, dk, _, _, _, _) =
-            FPTX::setup_for_testing(rng.r#gen(), batch_size, 1, &tc, &tc).unwrap();
+        let (ek, dk, _, _) = FPTX::setup_for_testing(rng.r#gen(), batch_size, 1, &tc).unwrap();
 
         let msg: String = String::from("hi");
         let associated_data: String = String::from("");
@@ -40,8 +39,7 @@ pub fn encrypt(c: &mut Criterion) {
     for batch_size in [32, 128, 512, 2048] {
         let mut rng = thread_rng();
         let tc = ShamirThresholdConfig::new(1, 1);
-        let (ek, _dk, _, _, _, _) =
-            FPTX::setup_for_testing(rng.r#gen(), batch_size, 1, &tc, &tc).unwrap();
+        let (ek, _dk, _, _) = FPTX::setup_for_testing(rng.r#gen(), batch_size, 1, &tc).unwrap();
 
         let msg: String = rng
             .sample_iter(&Alphanumeric)
@@ -66,8 +64,7 @@ pub fn verify_ct(c: &mut Criterion) {
     for batch_size in [32, 128, 512, 2048] {
         let mut rng = thread_rng();
         let tc = ShamirThresholdConfig::new(1, 1);
-        let (ek, _dk, _, _, _, _) =
-            FPTX::setup_for_testing(rng.r#gen(), batch_size, 1, &tc, &tc).unwrap();
+        let (ek, _dk, _, _) = FPTX::setup_for_testing(rng.r#gen(), batch_size, 1, &tc).unwrap();
 
         let msg: String = String::from("hi");
         let associated_data = String::from("");
@@ -87,8 +84,7 @@ pub fn eval_proofs_compute_all(c: &mut Criterion) {
     for batch_size in [32, 128, 256, 512, 2048] {
         let mut rng = thread_rng();
         let tc = ShamirThresholdConfig::new(1, 1);
-        let (ek, dk, _, _, _, _) =
-            FPTX::setup_for_testing(rng.r#gen(), batch_size, 1, &tc, &tc).unwrap();
+        let (ek, dk, _, _) = FPTX::setup_for_testing(rng.r#gen(), batch_size, 1, &tc).unwrap();
 
         let msg: String = String::from("hi");
         let associated_data = String::from("");
@@ -116,8 +112,7 @@ pub fn eval_proofs_compute_all_2(c: &mut Criterion) {
     for batch_size in [32, 128, 256, 512, 2048] {
         let mut rng = thread_rng();
         let tc = ShamirThresholdConfig::new(1, 1);
-        let (ek, dk, _, _, _, _) =
-            FPTX::setup_for_testing(rng.r#gen(), batch_size, 1, &tc, &tc).unwrap();
+        let (ek, dk, _, _) = FPTX::setup_for_testing(rng.r#gen(), batch_size, 1, &tc).unwrap();
 
         let msg: String = String::from("hi");
         let associated_data = String::from("");
@@ -146,8 +141,8 @@ pub fn derive_decryption_key_share(c: &mut Criterion) {
         let t = n * 2 / 3 + 1;
         let mut rng = thread_rng();
         let tc = ShamirThresholdConfig::new(t, n);
-        let (ek, dk, _, msk_shares, _, _) =
-            FPTX::setup_for_testing(rng.r#gen(), batch_size, 1, &tc, &tc).unwrap();
+        let (ek, dk, _, msk_shares) =
+            FPTX::setup_for_testing(rng.r#gen(), batch_size, 1, &tc).unwrap();
 
         let msg: String = String::from("hi");
         let associated_data = String::from("");
@@ -176,8 +171,8 @@ pub fn verify_decryption_key_share(c: &mut Criterion) {
     for batch_size in [32, 128, 512, 2048] {
         let mut rng = thread_rng();
         let tc = ShamirThresholdConfig::new(1, 1);
-        let (ek, dk, vks, msk_shares, _, _) =
-            FPTX::setup_for_testing(rng.r#gen(), batch_size, 1, &tc, &tc).unwrap();
+        let (ek, dk, vks, msk_shares) =
+            FPTX::setup_for_testing(rng.r#gen(), batch_size, 1, &tc).unwrap();
 
         let msg: String = String::from("hi");
         let associated_data = String::from("");
@@ -209,8 +204,8 @@ pub fn reconstruct_decryption_key(c: &mut Criterion) {
         let t = n * 2 / 3 + 1;
         let mut rng = thread_rng();
         let tc = ShamirThresholdConfig::new(t, n);
-        let (ek, dk, _, msk_shares, _, _) =
-            FPTX::setup_for_testing(rng.r#gen(), batch_size, 1, &tc, &tc).unwrap();
+        let (ek, dk, _, msk_shares) =
+            FPTX::setup_for_testing(rng.r#gen(), batch_size, 1, &tc).unwrap();
 
         let msg: String = String::from("hi");
         let associated_data = String::from("");
@@ -243,8 +238,8 @@ pub fn decrypt(c: &mut Criterion) {
     for batch_size in [32, 128, 512, 2048] {
         let mut rng = thread_rng();
         let tc = ShamirThresholdConfig::new(1, 1);
-        let (ek, dk, _, msk_shares, _, _) =
-            FPTX::setup_for_testing(rng.r#gen(), batch_size, 1, &tc, &tc).unwrap();
+        let (ek, dk, _, msk_shares) =
+            FPTX::setup_for_testing(rng.r#gen(), batch_size, 1, &tc).unwrap();
 
         let msg: String = String::from("hi");
         let associated_data = String::from("");

--- a/crates/aptos-batch-encryption/benches/fptx_succinct.rs
+++ b/crates/aptos-batch-encryption/benches/fptx_succinct.rs
@@ -14,8 +14,8 @@ pub fn digest(c: &mut Criterion) {
     for batch_size in [32, 128, 512, 2048] {
         let mut rng = thread_rng();
         let tc = ShamirThresholdConfig::new(1, 1);
-        let (ek, dk, _, _, _, _) =
-            FPTXSuccinct::setup_for_testing(rng.r#gen(), batch_size, 1, &tc, &tc).unwrap();
+        let (ek, dk, _, _) =
+            FPTXSuccinct::setup_for_testing(rng.r#gen(), batch_size, 1, &tc).unwrap();
 
         let msg: String = String::from("hi");
         let associated_data: String = String::from("");
@@ -40,8 +40,8 @@ pub fn encrypt(c: &mut Criterion) {
     for batch_size in [32, 128, 512, 2048] {
         let mut rng = thread_rng();
         let tc = ShamirThresholdConfig::new(1, 1);
-        let (ek, _dk, _, _, _, _) =
-            FPTXSuccinct::setup_for_testing(rng.r#gen(), batch_size, 1, &tc, &tc).unwrap();
+        let (ek, _dk, _, _) =
+            FPTXSuccinct::setup_for_testing(rng.r#gen(), batch_size, 1, &tc).unwrap();
 
         let msg: String = rng
             .sample_iter(&Alphanumeric)
@@ -66,8 +66,8 @@ pub fn verify_ct(c: &mut Criterion) {
     for batch_size in [32, 128, 512, 2048] {
         let mut rng = thread_rng();
         let tc = ShamirThresholdConfig::new(1, 1);
-        let (ek, _dk, _, _, _, _) =
-            FPTXSuccinct::setup_for_testing(rng.r#gen(), batch_size, 1, &tc, &tc).unwrap();
+        let (ek, _dk, _, _) =
+            FPTXSuccinct::setup_for_testing(rng.r#gen(), batch_size, 1, &tc).unwrap();
 
         let msg: String = String::from("hi");
         let associated_data = String::from("");
@@ -87,8 +87,8 @@ pub fn eval_proofs_compute_all(c: &mut Criterion) {
     for batch_size in [32, 128, 256, 512, 2048] {
         let mut rng = thread_rng();
         let tc = ShamirThresholdConfig::new(1, 1);
-        let (ek, dk, _, _, _, _) =
-            FPTXSuccinct::setup_for_testing(rng.r#gen(), batch_size, 1, &tc, &tc).unwrap();
+        let (ek, dk, _, _) =
+            FPTXSuccinct::setup_for_testing(rng.r#gen(), batch_size, 1, &tc).unwrap();
 
         let msg: String = String::from("hi");
         let associated_data = String::from("");
@@ -116,8 +116,8 @@ pub fn eval_proofs_compute_all_2(c: &mut Criterion) {
     for batch_size in [32, 128, 256, 512, 2048] {
         let mut rng = thread_rng();
         let tc = ShamirThresholdConfig::new(1, 1);
-        let (ek, dk, _, _, _, _) =
-            FPTXSuccinct::setup_for_testing(rng.r#gen(), batch_size, 1, &tc, &tc).unwrap();
+        let (ek, dk, _, _) =
+            FPTXSuccinct::setup_for_testing(rng.r#gen(), batch_size, 1, &tc).unwrap();
 
         let msg: String = String::from("hi");
         let associated_data = String::from("");
@@ -148,8 +148,8 @@ pub fn derive_decryption_key_share(c: &mut Criterion) {
         let t = n * 2 / 3 + 1;
         let mut rng = thread_rng();
         let tc = ShamirThresholdConfig::new(t, n);
-        let (ek, dk, _, msk_shares, _, _) =
-            FPTXSuccinct::setup_for_testing(rng.r#gen(), batch_size, 1, &tc, &tc).unwrap();
+        let (ek, dk, _, msk_shares) =
+            FPTXSuccinct::setup_for_testing(rng.r#gen(), batch_size, 1, &tc).unwrap();
 
         let msg: String = String::from("hi");
         let associated_data = String::from("");
@@ -178,8 +178,8 @@ pub fn verify_decryption_key_share(c: &mut Criterion) {
     for batch_size in [32, 128, 512, 2048] {
         let mut rng = thread_rng();
         let tc = ShamirThresholdConfig::new(1, 1);
-        let (ek, dk, vks, msk_shares, _, _) =
-            FPTXSuccinct::setup_for_testing(rng.r#gen(), batch_size, 1, &tc, &tc).unwrap();
+        let (ek, dk, vks, msk_shares) =
+            FPTXSuccinct::setup_for_testing(rng.r#gen(), batch_size, 1, &tc).unwrap();
 
         let msg: String = String::from("hi");
         let associated_data = String::from("");
@@ -211,8 +211,8 @@ pub fn reconstruct_decryption_key(c: &mut Criterion) {
         let t = n * 2 / 3 + 1;
         let mut rng = thread_rng();
         let tc = ShamirThresholdConfig::new(t, n);
-        let (ek, dk, _, msk_shares, _, _) =
-            FPTXSuccinct::setup_for_testing(rng.r#gen(), batch_size, 1, &tc, &tc).unwrap();
+        let (ek, dk, _, msk_shares) =
+            FPTXSuccinct::setup_for_testing(rng.r#gen(), batch_size, 1, &tc).unwrap();
 
         let msg: String = String::from("hi");
         let associated_data = String::from("");
@@ -245,8 +245,8 @@ pub fn decrypt(c: &mut Criterion) {
     for batch_size in [32, 128, 512, 2048] {
         let mut rng = thread_rng();
         let tc = ShamirThresholdConfig::new(1, 1);
-        let (ek, dk, _, msk_shares, _, _) =
-            FPTXSuccinct::setup_for_testing(rng.r#gen(), batch_size, 1, &tc, &tc).unwrap();
+        let (ek, dk, _, msk_shares) =
+            FPTXSuccinct::setup_for_testing(rng.r#gen(), batch_size, 1, &tc).unwrap();
 
         let msg: String = String::from("hi");
         let associated_data = String::from("");

--- a/crates/aptos-batch-encryption/src/schemes/fptx_weighted.rs
+++ b/crates/aptos-batch-encryption/src/schemes/fptx_weighted.rs
@@ -226,62 +226,39 @@ impl BatchThresholdEncryption for FPTXWeighted {
     fn setup(
         digest_key: &Self::DigestKey,
         pvss_public_params: &<Self::SubTranscript as Subtranscript>::PublicParameters,
-        subtranscript_happypath: &Self::SubTranscript,
-        subtranscript_slowpath: &Self::SubTranscript,
-        tc_happypath: &Self::ThresholdConfig,
-        tc_slowpath: &Self::ThresholdConfig,
+        subtranscript: &Self::SubTranscript,
+        threshold_config: &Self::ThresholdConfig,
         current_player: Player,
         msk_share_decryption_key: &<Self::SubTranscript as Subtranscript>::DecryptPrivKey,
     ) -> Result<(
         Self::EncryptionKey,
         Vec<Self::VerificationKey>,
         Self::MasterSecretKeyShare,
-        Vec<Self::VerificationKey>,
-        Self::MasterSecretKeyShare,
     )> {
-        (subtranscript_happypath.get_dealt_public_key()
-            == subtranscript_slowpath.get_dealt_public_key())
-        .then_some(())
-        .ok_or(BatchEncryptionError::HappySlowPathMismatchError)?;
-
-        let mpk_g2: G2Affine = subtranscript_happypath.get_dealt_public_key().as_g2();
+        let mpk_g2: G2Affine = subtranscript.get_dealt_public_key().as_g2();
 
         let ek = EncryptionKey::new(mpk_g2, digest_key.tau_g2);
 
-        let vks_happypath: Vec<Self::VerificationKey> = tc_happypath
+        let vks: Vec<Self::VerificationKey> = threshold_config
             .get_players()
             .into_iter()
             .map(|p| Self::VerificationKey {
                 weighted_player: p,
                 mpk_g2,
-                vks_g2: subtranscript_happypath
-                    .get_public_key_share(tc_happypath, &p)
+                vks_g2: subtranscript
+                    .get_public_key_share(threshold_config, &p)
                     .into_iter()
                     .map(|s| s.as_g2())
                     .collect(),
             })
             .collect();
 
-        let vks_slowpath: Vec<Self::VerificationKey> = tc_slowpath
-            .get_players()
-            .into_iter()
-            .map(|p| Self::VerificationKey {
-                weighted_player: p,
-                mpk_g2,
-                vks_g2: subtranscript_slowpath
-                    .get_public_key_share(tc_slowpath, &p)
-                    .into_iter()
-                    .map(|s| s.as_g2())
-                    .collect(),
-            })
-            .collect();
-
-        let msk_share_happypath = Self::MasterSecretKeyShare {
+        let msk_share = Self::MasterSecretKeyShare {
             mpk_g2,
             weighted_player: current_player,
-            shamir_share_evals: subtranscript_happypath
+            shamir_share_evals: subtranscript
                 .decrypt_own_share(
-                    tc_happypath,
+                    threshold_config,
                     &current_player,
                     msk_share_decryption_key,
                     pvss_public_params,
@@ -292,57 +269,27 @@ impl BatchThresholdEncryption for FPTXWeighted {
                 .collect(),
         };
 
-        let msk_share_slowpath = Self::MasterSecretKeyShare {
-            mpk_g2,
-            weighted_player: current_player,
-            shamir_share_evals: subtranscript_slowpath
-                .decrypt_own_share(
-                    tc_slowpath,
-                    &current_player,
-                    msk_share_decryption_key,
-                    pvss_public_params,
-                )
-                .0
-                .into_iter()
-                .map(|s| s.into_fr())
-                .collect(),
-        };
+        vks[msk_share.weighted_player.get_id()]
+            .vks_g2
+            .iter()
+            .zip(msk_share.shamir_share_evals.clone())
+            .try_for_each(|(vk_raw, msk_share_raw)| {
+                (G2Projective::from(*vk_raw) == G2Affine::generator() * msk_share_raw)
+                    .then_some(())
+                    .ok_or(BatchEncryptionError::VKMSKMismatchError)
+            })?;
 
-        for (vks, msk_share) in [
-            (&vks_happypath, &msk_share_happypath),
-            (&vks_slowpath, &msk_share_slowpath),
-        ] {
-            vks[msk_share.weighted_player.get_id()]
-                .vks_g2
-                .iter()
-                .zip(msk_share.shamir_share_evals.clone())
-                .try_for_each(|(vk_raw, msk_share_raw)| {
-                    (G2Projective::from(*vk_raw) == G2Affine::generator() * msk_share_raw)
-                        .then_some(())
-                        .ok_or(BatchEncryptionError::VKMSKMismatchError)
-                })?;
-        }
-
-        Ok((
-            ek,
-            vks_happypath,
-            msk_share_happypath,
-            vks_slowpath,
-            msk_share_slowpath,
-        ))
+        Ok((ek, vks, msk_share))
     }
 
     fn setup_for_testing(
         seed: u64,
         max_batch_size: usize,
         number_of_rounds: usize,
-        tc_happypath: &Self::ThresholdConfig,
-        tc_slowpath: &Self::ThresholdConfig,
+        threshold_config: &Self::ThresholdConfig,
     ) -> Result<(
         Self::EncryptionKey,
         Self::DigestKey,
-        Vec<Self::VerificationKey>,
-        Vec<Self::MasterSecretKeyShare>,
         Vec<Self::VerificationKey>,
         Vec<Self::MasterSecretKeyShare>,
     )> {
@@ -351,22 +298,11 @@ impl BatchThresholdEncryption for FPTXWeighted {
         let digest_key = DigestKey::new(&mut rng, max_batch_size, number_of_rounds)
             .ok_or(anyhow!("Failed to create digest key"))?;
         let msk = Fr::rand(&mut rng);
-        let (mpk, vks_happypath, msk_shares_happypath) =
-            gen_weighted_msk_shares(msk, &mut rng, tc_happypath);
-
-        let (_, vks_slowpath, msk_shares_slowpath) =
-            gen_weighted_msk_shares(msk, &mut rng, tc_slowpath);
+        let (mpk, vks, msk_shares) = gen_weighted_msk_shares(msk, &mut rng, threshold_config);
 
         let ek = EncryptionKey::new(mpk.0, digest_key.tau_g2);
 
-        Ok((
-            ek,
-            digest_key,
-            vks_happypath,
-            msk_shares_happypath,
-            vks_slowpath,
-            msk_shares_slowpath,
-        ))
+        Ok((ek, digest_key, vks, msk_shares))
     }
 
     fn encrypt<R: CryptoRng + RngCore>(

--- a/crates/aptos-batch-encryption/src/shared/ciphertext/bibe.rs
+++ b/crates/aptos-batch-encryption/src/shared/ciphertext/bibe.rs
@@ -190,8 +190,7 @@ pub mod tests {
     fn test_bibe_ct_encrypt_decrypt() {
         let mut rng = thread_rng();
         let tc = ShamirThresholdConfig::new(1, 1);
-        let (ek, dk, _, msk_shares, _, _) =
-            FPTX::setup_for_testing(rng.r#gen(), 8, 1, &tc, &tc).unwrap();
+        let (ek, dk, _, msk_shares) = FPTX::setup_for_testing(rng.r#gen(), 8, 1, &tc).unwrap();
 
         let mut ids = IdSet::with_capacity(dk.capacity()).unwrap();
         let mut counter = Fr::zero();

--- a/crates/aptos-batch-encryption/src/shared/ciphertext/mod.rs
+++ b/crates/aptos-batch-encryption/src/shared/ciphertext/mod.rs
@@ -187,8 +187,7 @@ pub mod tests {
     fn test_ct_encrypt_decrypt() {
         let mut rng = thread_rng();
         let tc = ShamirThresholdConfig::new(1, 1);
-        let (ek, dk, _, msk_shares, _, _) =
-            FPTX::setup_for_testing(rng.r#gen(), 8, 1, &tc, &tc).unwrap();
+        let (ek, dk, _, msk_shares) = FPTX::setup_for_testing(rng.r#gen(), 8, 1, &tc).unwrap();
 
         let plaintext = String::from("hi");
         let associated_data = String::from("");
@@ -247,7 +246,7 @@ pub mod tests {
     fn test_ct_verify() {
         let mut rng = thread_rng();
         let tc = ShamirThresholdConfig::new(1, 1);
-        let (ek, _, _, _, _, _) = FPTX::setup_for_testing(rng.r#gen(), 8, 1, &tc, &tc).unwrap();
+        let (ek, _, _, _) = FPTX::setup_for_testing(rng.r#gen(), 8, 1, &tc).unwrap();
 
         let plaintext = String::from("hi");
         let associated_data = String::from("associated data");

--- a/crates/aptos-batch-encryption/src/tests/fptx_smoke.rs
+++ b/crates/aptos-batch-encryption/src/tests/fptx_smoke.rs
@@ -3,10 +3,7 @@
 use crate::{
     group::G2Affine,
     schemes::fptx::FPTX,
-    shared::{
-        digest::DigestKey,
-        key_derivation::{BIBEDecryptionKey, BIBEDecryptionKeyShare},
-    },
+    shared::{digest::DigestKey, key_derivation::BIBEDecryptionKeyShare},
     traits::BatchThresholdEncryption,
 };
 use anyhow::Result;
@@ -16,14 +13,11 @@ use ark_std::rand::{seq::SliceRandom, thread_rng, CryptoRng, Rng as _, RngCore};
 
 fn smoke_with_setup<R: RngCore + CryptoRng>(
     rng: &mut R,
-    tc_happy: <FPTX as BatchThresholdEncryption>::ThresholdConfig,
-    tc_slow: <FPTX as BatchThresholdEncryption>::ThresholdConfig,
+    tc: <FPTX as BatchThresholdEncryption>::ThresholdConfig,
     ek: <FPTX as BatchThresholdEncryption>::EncryptionKey,
     dk: <FPTX as BatchThresholdEncryption>::DigestKey,
-    vks_happy: Vec<<FPTX as BatchThresholdEncryption>::VerificationKey>,
-    msk_shares_happy: Vec<<FPTX as BatchThresholdEncryption>::MasterSecretKeyShare>,
-    vks_slow: Vec<<FPTX as BatchThresholdEncryption>::VerificationKey>,
-    msk_shares_slow: Vec<<FPTX as BatchThresholdEncryption>::MasterSecretKeyShare>,
+    vks: Vec<<FPTX as BatchThresholdEncryption>::VerificationKey>,
+    msk_shares: Vec<<FPTX as BatchThresholdEncryption>::MasterSecretKeyShare>,
 ) {
     let plaintext: String = String::from("hi");
     let associated_data: String = String::from("hi");
@@ -34,83 +28,49 @@ fn smoke_with_setup<R: RngCore + CryptoRng>(
     let (d, pfs_promise) = FPTX::digest(&dk, &vec![ct.clone()], 0).unwrap();
     let pfs = FPTX::eval_proofs_compute_all(&pfs_promise, &dk);
 
-    let [dk_happy, dk_slow] = [
-        (tc_happy, vks_happy, msk_shares_happy),
-        (tc_slow, vks_slow, msk_shares_slow),
-    ]
-    .into_iter()
-    .map(|(tc, vks, msk_shares)| {
-        let dk_shares: Vec<<FPTX as BatchThresholdEncryption>::DecryptionKeyShare> = msk_shares
-            .into_iter()
-            .map(|msk_share| msk_share.derive_decryption_key_share(&d).unwrap())
-            .collect();
+    let dk_shares: Vec<<FPTX as BatchThresholdEncryption>::DecryptionKeyShare> = msk_shares
+        .into_iter()
+        .map(|msk_share| msk_share.derive_decryption_key_share(&d).unwrap())
+        .collect();
 
-        dk_shares
-            .iter()
-            .zip(vks)
-            .map(|(dk_share, vk)| FPTX::verify_decryption_key_share(&vk, &d, dk_share))
-            .collect::<Result<Vec<()>>>()
-            .unwrap();
-
-        let dk = FPTX::reconstruct_decryption_key(
-            &dk_shares
-                .choose_multiple(rng, tc.t)
-                .cloned()
-                .collect::<Vec<BIBEDecryptionKeyShare>>(),
-            &tc,
-        )
+    dk_shares
+        .iter()
+        .zip(&vks)
+        .map(|(dk_share, vk)| FPTX::verify_decryption_key_share(vk, &d, dk_share))
+        .collect::<Result<Vec<()>>>()
         .unwrap();
 
-        ek.verify_decryption_key(&d, &dk).unwrap();
-
-        dk
-    })
-    .collect::<Vec<BIBEDecryptionKey>>()
-    .try_into()
+    let dk = FPTX::reconstruct_decryption_key(
+        &dk_shares
+            .choose_multiple(rng, tc.t)
+            .cloned()
+            .collect::<Vec<BIBEDecryptionKeyShare>>(),
+        &tc,
+    )
     .unwrap();
 
-    let decrypted_plaintexts: Vec<String> =
-        FPTX::decrypt(&dk_happy, &vec![ct.prepare(&d, &pfs).unwrap()]).unwrap();
-
-    assert_eq!(decrypted_plaintexts[0], plaintext);
+    ek.verify_decryption_key(&d, &dk).unwrap();
 
     let decrypted_plaintexts: Vec<String> =
-        FPTX::decrypt(&dk_slow, &vec![ct.prepare(&d, &pfs).unwrap()]).unwrap();
+        FPTX::decrypt(&dk, &vec![ct.prepare(&d, &pfs).unwrap()]).unwrap();
 
     assert_eq!(decrypted_plaintexts[0], plaintext);
 
     // Test individual decryption
     let eval_proof = FPTX::eval_proof_for_ct(&pfs, &ct).unwrap();
     let individual_decrypted_plaintext: String =
-        FPTX::decrypt_individual(&dk_happy, &ct, &d, &eval_proof).unwrap();
-    assert_eq!(individual_decrypted_plaintext, plaintext);
-
-    let eval_proof = FPTX::eval_proof_for_ct(&pfs, &ct).unwrap();
-    let individual_decrypted_plaintext: String =
-        FPTX::decrypt_individual(&dk_slow, &ct, &d, &eval_proof).unwrap();
+        FPTX::decrypt_individual(&dk, &ct, &d, &eval_proof).unwrap();
     assert_eq!(individual_decrypted_plaintext, plaintext);
 }
 
 #[test]
 fn smoke_with_setup_for_testing() {
     let mut rng = thread_rng();
-    let tc_happy = ShamirThresholdConfig::new(5, 8);
-    let tc_slow = ShamirThresholdConfig::new(3, 8);
+    let tc = ShamirThresholdConfig::new(3, 8);
 
-    let (ek, dk, vks_happy, msk_shares_happy, vks_slow, msk_shares_slow) =
-        FPTX::setup_for_testing(rng.r#gen(), 8, 1, &tc_happy, &tc_slow).unwrap();
+    let (ek, dk, vks, msk_shares) = FPTX::setup_for_testing(rng.r#gen(), 8, 1, &tc).unwrap();
 
-    smoke_with_setup(
-        &mut rng,
-        tc_happy,
-        tc_slow,
-        ek,
-        dk,
-        vks_happy,
-        msk_shares_happy,
-        vks_slow,
-        msk_shares_slow,
-    );
+    smoke_with_setup(&mut rng, tc, ek, dk, vks, msk_shares);
 }
 
 type T = aptos_dkg::pvss::chunky::UnsignedUnweightedTranscript<crate::group::Pairing>;
@@ -127,17 +87,16 @@ fn smoke_with_pvss() {
     let mut rng = thread_rng();
     let mut rng_aptos = rand::thread_rng();
 
-    let tc_happy = ShamirThresholdConfig::new(5, 8);
-    let tc_slow = ShamirThresholdConfig::new(3, 8);
+    let tc = ShamirThresholdConfig::new(3, 8);
     let pp = <T as Transcript>::PublicParameters::new_with_commitment_base(
-        tc_happy.get_total_num_players(),
+        tc.get_total_num_players(),
         aptos_dkg::pvss::chunky::DEFAULT_ELL_FOR_TESTING,
         1,
         G2Affine::generator(),
         &mut rng_aptos,
     );
 
-    let ssks = (0..tc_happy.get_total_num_players())
+    let ssks = (0..tc.get_total_num_players())
         .map(|_| <T as Transcript>::SigningSecretKey::generate(&mut rng_aptos))
         .collect::<Vec<<T as Transcript>::SigningSecretKey>>();
     let spks = ssks
@@ -145,7 +104,7 @@ fn smoke_with_pvss() {
         .map(|ssk| ssk.verifying_key())
         .collect::<Vec<<T as Transcript>::SigningPubKey>>();
 
-    let dks: Vec<<T as Transcript>::DecryptPrivKey> = (0..tc_happy.get_total_num_players())
+    let dks: Vec<<T as Transcript>::DecryptPrivKey> = (0..tc.get_total_num_players())
         .map(|_| <T as Transcript>::DecryptPrivKey::generate(&mut rng_aptos))
         .collect();
     let eks: Vec<<T as Transcript>::EncryptPubKey> = dks
@@ -156,95 +115,48 @@ fn smoke_with_pvss() {
     let s = <T as Transcript>::InputSecret::generate(&mut rng_aptos);
 
     // Test dealing
-    let subtrx_happypath = T::deal(
-        &tc_happy,
+    let subtranscript = T::deal(
+        &tc,
         &pp,
         &ssks[0],
         &spks[0],
         &eks,
         &s,
         &NoAux,
-        &tc_happy.get_player(0),
-        &mut rng_aptos,
-    )
-    .get_subtranscript();
-
-    let subtrx_slowpath = T::deal(
-        &tc_slow,
-        &pp,
-        &ssks[0],
-        &spks[0],
-        &eks,
-        &s,
-        &NoAux,
-        &tc_slow.get_player(0),
+        &tc.get_player(0),
         &mut rng_aptos,
     )
     .get_subtranscript();
 
     let dk = DigestKey::new(&mut rng, 8, 1).unwrap();
 
-    let (ek, vks_happy, _, vks_slow, _) = FPTX::setup(
-        &dk,
-        &pp,
-        &subtrx_happypath,
-        &subtrx_slowpath,
-        &tc_happy,
-        &tc_slow,
-        tc_happy.get_player(0),
-        &dks[0],
-    )
-    .unwrap();
+    let (ek, vks, _) =
+        FPTX::setup(&dk, &pp, &subtranscript, &tc, tc.get_player(0), &dks[0]).unwrap();
 
-    let (msk_shares_happy, msk_shares_slow): (
-        Vec<<FPTX as BatchThresholdEncryption>::MasterSecretKeyShare>,
-        Vec<<FPTX as BatchThresholdEncryption>::MasterSecretKeyShare>,
-    ) = tc_happy
+    let msk_shares: Vec<<FPTX as BatchThresholdEncryption>::MasterSecretKeyShare> = tc
         .get_players()
         .into_iter()
         .map(|p| {
-            let (_, _, msk_share_happypath, _, msk_share_slowpath) = FPTX::setup(
-                &dk,
-                &pp,
-                &subtrx_happypath,
-                &subtrx_slowpath,
-                &tc_happy,
-                &tc_slow,
-                p,
-                &dks[p.get_id()],
-            )
-            .unwrap();
-            (msk_share_happypath, msk_share_slowpath)
+            let (_, _, msk_share) =
+                FPTX::setup(&dk, &pp, &subtranscript, &tc, p, &dks[p.get_id()]).unwrap();
+            msk_share
         })
         .collect();
 
-    smoke_with_setup(
-        &mut rng,
-        tc_happy,
-        tc_slow,
-        ek,
-        dk,
-        vks_happy,
-        msk_shares_happy,
-        vks_slow,
-        msk_shares_slow,
-    );
+    smoke_with_setup(&mut rng, tc, ek, dk, vks, msk_shares);
 }
 
 #[test]
 fn fptx_serialize_deserialize_setup() {
     let mut rng = thread_rng();
-    let tc_happy = ShamirThresholdConfig::new(5, 8);
-    let tc_slow = ShamirThresholdConfig::new(3, 8);
+    let tc = ShamirThresholdConfig::new(3, 8);
 
-    let setup = FPTX::setup_for_testing(rng.r#gen(), 8, 2, &tc_happy, &tc_slow).unwrap();
+    let setup = FPTX::setup_for_testing(rng.r#gen(), 8, 2, &tc).unwrap();
 
     let bytes = bcs::to_bytes(&setup).unwrap();
     let setup2: (
         <FPTX as BatchThresholdEncryption>::EncryptionKey,
         <FPTX as BatchThresholdEncryption>::DigestKey,
-        Vec<<FPTX as BatchThresholdEncryption>::VerificationKey>,
-        Vec<<FPTX as BatchThresholdEncryption>::MasterSecretKeyShare>,
         Vec<<FPTX as BatchThresholdEncryption>::VerificationKey>,
         Vec<<FPTX as BatchThresholdEncryption>::MasterSecretKeyShare>,
     ) = bcs::from_bytes(&bytes).unwrap();
@@ -255,8 +167,6 @@ fn fptx_serialize_deserialize_setup() {
     let setup2: (
         <FPTX as BatchThresholdEncryption>::EncryptionKey,
         <FPTX as BatchThresholdEncryption>::DigestKey,
-        Vec<<FPTX as BatchThresholdEncryption>::VerificationKey>,
-        Vec<<FPTX as BatchThresholdEncryption>::MasterSecretKeyShare>,
         Vec<<FPTX as BatchThresholdEncryption>::VerificationKey>,
         Vec<<FPTX as BatchThresholdEncryption>::MasterSecretKeyShare>,
     ) = serde_json::from_str(&json).unwrap();

--- a/crates/aptos-batch-encryption/src/tests/fptx_succinct_smoke.rs
+++ b/crates/aptos-batch-encryption/src/tests/fptx_succinct_smoke.rs
@@ -1,8 +1,7 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 use crate::{
-    schemes::fptx_succinct::FPTXSuccinct,
-    shared::key_derivation::{BIBEDecryptionKey, BIBEDecryptionKeyShare},
+    schemes::fptx_succinct::FPTXSuccinct, shared::key_derivation::BIBEDecryptionKeyShare,
     traits::BatchThresholdEncryption,
 };
 use anyhow::Result;
@@ -11,14 +10,11 @@ use ark_std::rand::{seq::SliceRandom, thread_rng, CryptoRng, Rng as _, RngCore};
 
 fn smoke_with_setup<R: RngCore + CryptoRng>(
     rng: &mut R,
-    tc_happy: <FPTXSuccinct as BatchThresholdEncryption>::ThresholdConfig,
-    tc_slow: <FPTXSuccinct as BatchThresholdEncryption>::ThresholdConfig,
+    tc: <FPTXSuccinct as BatchThresholdEncryption>::ThresholdConfig,
     ek: <FPTXSuccinct as BatchThresholdEncryption>::EncryptionKey,
     dk: <FPTXSuccinct as BatchThresholdEncryption>::DigestKey,
-    vks_happy: Vec<<FPTXSuccinct as BatchThresholdEncryption>::VerificationKey>,
-    msk_shares_happy: Vec<<FPTXSuccinct as BatchThresholdEncryption>::MasterSecretKeyShare>,
-    vks_slow: Vec<<FPTXSuccinct as BatchThresholdEncryption>::VerificationKey>,
-    msk_shares_slow: Vec<<FPTXSuccinct as BatchThresholdEncryption>::MasterSecretKeyShare>,
+    vks: Vec<<FPTXSuccinct as BatchThresholdEncryption>::VerificationKey>,
+    msk_shares: Vec<<FPTXSuccinct as BatchThresholdEncryption>::MasterSecretKeyShare>,
 ) {
     let plaintext: String = String::from("hi");
     let associated_data: String = String::from("hi");
@@ -29,82 +25,48 @@ fn smoke_with_setup<R: RngCore + CryptoRng>(
     let (d, pfs_promise) = FPTXSuccinct::digest(&dk, &vec![ct.clone()], 0).unwrap();
     let pfs = FPTXSuccinct::eval_proofs_compute_all(&pfs_promise, &dk);
 
-    let [dk_happy, dk_slow] = [
-        (tc_happy, vks_happy, msk_shares_happy),
-        (tc_slow, vks_slow, msk_shares_slow),
-    ]
-    .into_iter()
-    .map(|(tc, vks, msk_shares)| {
-        let dk_shares: Vec<<FPTXSuccinct as BatchThresholdEncryption>::DecryptionKeyShare> =
-            msk_shares
-                .into_iter()
-                .map(|msk_share| msk_share.derive_decryption_key_share(&d).unwrap())
-                .collect();
+    let dk_shares: Vec<<FPTXSuccinct as BatchThresholdEncryption>::DecryptionKeyShare> = msk_shares
+        .into_iter()
+        .map(|msk_share| msk_share.derive_decryption_key_share(&d).unwrap())
+        .collect();
 
-        dk_shares
-            .iter()
-            .zip(vks)
-            .map(|(dk_share, vk)| FPTXSuccinct::verify_decryption_key_share(&vk, &d, dk_share))
-            .collect::<Result<Vec<()>>>()
-            .unwrap();
-
-        let dk = FPTXSuccinct::reconstruct_decryption_key(
-            &dk_shares
-                .choose_multiple(rng, tc.t)
-                .cloned()
-                .collect::<Vec<BIBEDecryptionKeyShare>>(),
-            &tc,
-        )
+    dk_shares
+        .iter()
+        .zip(&vks)
+        .map(|(dk_share, vk)| FPTXSuccinct::verify_decryption_key_share(vk, &d, dk_share))
+        .collect::<Result<Vec<()>>>()
         .unwrap();
 
-        ek.verify_decryption_key(&d, &dk).unwrap();
-
-        dk
-    })
-    .collect::<Vec<BIBEDecryptionKey>>()
-    .try_into()
+    let dk = FPTXSuccinct::reconstruct_decryption_key(
+        &dk_shares
+            .choose_multiple(rng, tc.t)
+            .cloned()
+            .collect::<Vec<BIBEDecryptionKeyShare>>(),
+        &tc,
+    )
     .unwrap();
 
-    let decrypted_plaintexts: Vec<String> =
-        FPTXSuccinct::decrypt(&dk_happy, &vec![ct.prepare(&d, &pfs).unwrap()]).unwrap();
-
-    assert_eq!(decrypted_plaintexts[0], plaintext);
+    ek.verify_decryption_key(&d, &dk).unwrap();
 
     let decrypted_plaintexts: Vec<String> =
-        FPTXSuccinct::decrypt(&dk_slow, &vec![ct.prepare(&d, &pfs).unwrap()]).unwrap();
+        FPTXSuccinct::decrypt(&dk, &vec![ct.prepare(&d, &pfs).unwrap()]).unwrap();
 
     assert_eq!(decrypted_plaintexts[0], plaintext);
 
     // Test individual decryption
     let eval_proof = FPTXSuccinct::eval_proof_for_ct(&pfs, &ct).unwrap();
     let individual_decrypted_plaintext: String =
-        FPTXSuccinct::decrypt_individual(&dk_happy, &ct, &d, &eval_proof).unwrap();
-    assert_eq!(individual_decrypted_plaintext, plaintext);
-
-    let eval_proof = FPTXSuccinct::eval_proof_for_ct(&pfs, &ct).unwrap();
-    let individual_decrypted_plaintext: String =
-        FPTXSuccinct::decrypt_individual(&dk_slow, &ct, &d, &eval_proof).unwrap();
+        FPTXSuccinct::decrypt_individual(&dk, &ct, &d, &eval_proof).unwrap();
     assert_eq!(individual_decrypted_plaintext, plaintext);
 }
 
 #[test]
 fn smoke_with_setup_for_testing() {
     let mut rng = thread_rng();
-    let tc_happy = ShamirThresholdConfig::new(5, 8);
-    let tc_slow = ShamirThresholdConfig::new(3, 8);
+    let tc = ShamirThresholdConfig::new(5, 8);
 
-    let (ek, dk, vks_happy, msk_shares_happy, vks_slow, msk_shares_slow) =
-        FPTXSuccinct::setup_for_testing(rng.r#gen(), 8, 1, &tc_happy, &tc_slow).unwrap();
+    let (ek, dk, vks, msk_shares) =
+        FPTXSuccinct::setup_for_testing(rng.r#gen(), 8, 1, &tc).unwrap();
 
-    smoke_with_setup(
-        &mut rng,
-        tc_happy,
-        tc_slow,
-        ek,
-        dk,
-        vks_happy,
-        msk_shares_happy,
-        vks_slow,
-        msk_shares_slow,
-    );
+    smoke_with_setup(&mut rng, tc, ek, dk, vks, msk_shares);
 }

--- a/crates/aptos-batch-encryption/src/tests/fptx_weighted_smoke.rs
+++ b/crates/aptos-batch-encryption/src/tests/fptx_weighted_smoke.rs
@@ -2,7 +2,7 @@
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 use crate::{
     schemes::fptx_weighted::{FPTXWeighted, WeightedBIBEDecryptionKeyShare},
-    shared::{digest::DigestKey, key_derivation::BIBEDecryptionKey},
+    shared::digest::DigestKey,
     traits::BatchThresholdEncryption,
 };
 use anyhow::Result;
@@ -12,14 +12,11 @@ use ark_std::rand::{seq::SliceRandom, thread_rng, CryptoRng, Rng as _, RngCore};
 
 fn weighted_smoke_with_setup<R: RngCore + CryptoRng>(
     rng: &mut R,
-    tc_happy: <FPTXWeighted as BatchThresholdEncryption>::ThresholdConfig,
-    tc_slow: <FPTXWeighted as BatchThresholdEncryption>::ThresholdConfig,
+    tc: <FPTXWeighted as BatchThresholdEncryption>::ThresholdConfig,
     ek: <FPTXWeighted as BatchThresholdEncryption>::EncryptionKey,
     dk: <FPTXWeighted as BatchThresholdEncryption>::DigestKey,
-    vks_happy: Vec<<FPTXWeighted as BatchThresholdEncryption>::VerificationKey>,
-    msk_shares_happy: Vec<<FPTXWeighted as BatchThresholdEncryption>::MasterSecretKeyShare>,
-    vks_slow: Vec<<FPTXWeighted as BatchThresholdEncryption>::VerificationKey>,
-    msk_shares_slow: Vec<<FPTXWeighted as BatchThresholdEncryption>::MasterSecretKeyShare>,
+    vks: Vec<<FPTXWeighted as BatchThresholdEncryption>::VerificationKey>,
+    msk_shares: Vec<<FPTXWeighted as BatchThresholdEncryption>::MasterSecretKeyShare>,
 ) {
     let plaintext: String = String::from("hi");
     let associated_data: String = String::from("hi");
@@ -30,84 +27,50 @@ fn weighted_smoke_with_setup<R: RngCore + CryptoRng>(
     let (d, pfs_promise) = FPTXWeighted::digest(&dk, &vec![ct.clone()], 0).unwrap();
     let pfs = FPTXWeighted::eval_proofs_compute_all(&pfs_promise, &dk);
 
-    let [dk_happy, dk_slow] = [
-        (tc_happy, vks_happy, msk_shares_happy),
-        (tc_slow, vks_slow, msk_shares_slow),
-    ]
-    .into_iter()
-    .map(|(tc, vks, msk_shares)| {
-        let dk_shares: Vec<<FPTXWeighted as BatchThresholdEncryption>::DecryptionKeyShare> =
-            msk_shares
-                .into_iter()
-                .map(|msk_share| msk_share.derive_decryption_key_share(&d).unwrap())
-                .collect();
+    let dk_shares: Vec<<FPTXWeighted as BatchThresholdEncryption>::DecryptionKeyShare> = msk_shares
+        .into_iter()
+        .map(|msk_share| msk_share.derive_decryption_key_share(&d).unwrap())
+        .collect();
 
-        dk_shares
-            .iter()
-            .zip(vks)
-            .map(|(dk_share, vk)| FPTXWeighted::verify_decryption_key_share(&vk, &d, dk_share))
-            .collect::<Result<Vec<()>>>()
-            .unwrap();
-
-        let dk = FPTXWeighted::reconstruct_decryption_key(
-            &dk_shares
-                .choose_multiple(rng, tc.get_total_num_players()) // will be truncated
-                .cloned()
-                .collect::<Vec<WeightedBIBEDecryptionKeyShare>>(),
-            &tc,
-        )
+    dk_shares
+        .iter()
+        .zip(&vks)
+        .map(|(dk_share, vk)| FPTXWeighted::verify_decryption_key_share(vk, &d, dk_share))
+        .collect::<Result<Vec<()>>>()
         .unwrap();
 
-        ek.verify_decryption_key(&d, &dk).unwrap();
-
-        dk
-    })
-    .collect::<Vec<BIBEDecryptionKey>>()
-    .try_into()
+    let dk = FPTXWeighted::reconstruct_decryption_key(
+        &dk_shares
+            .choose_multiple(rng, tc.get_total_num_players()) // will be truncated
+            .cloned()
+            .collect::<Vec<WeightedBIBEDecryptionKeyShare>>(),
+        &tc,
+    )
     .unwrap();
 
-    let decrypted_plaintexts: Vec<String> =
-        FPTXWeighted::decrypt(&dk_happy, &vec![ct.prepare(&d, &pfs).unwrap()]).unwrap();
-
-    assert_eq!(decrypted_plaintexts[0], plaintext);
+    ek.verify_decryption_key(&d, &dk).unwrap();
 
     let decrypted_plaintexts: Vec<String> =
-        FPTXWeighted::decrypt(&dk_slow, &vec![ct.prepare(&d, &pfs).unwrap()]).unwrap();
+        FPTXWeighted::decrypt(&dk, &vec![ct.prepare(&d, &pfs).unwrap()]).unwrap();
 
     assert_eq!(decrypted_plaintexts[0], plaintext);
 
     // Test individual decryption
     let eval_proof = FPTXWeighted::eval_proof_for_ct(&pfs, &ct).unwrap();
     let individual_decrypted_plaintext: String =
-        FPTXWeighted::decrypt_individual(&dk_happy, &ct, &d, &eval_proof).unwrap();
-    assert_eq!(individual_decrypted_plaintext, plaintext);
-
-    let eval_proof = FPTXWeighted::eval_proof_for_ct(&pfs, &ct).unwrap();
-    let individual_decrypted_plaintext: String =
-        FPTXWeighted::decrypt_individual(&dk_slow, &ct, &d, &eval_proof).unwrap();
+        FPTXWeighted::decrypt_individual(&dk, &ct, &d, &eval_proof).unwrap();
     assert_eq!(individual_decrypted_plaintext, plaintext);
 }
 
 #[test]
 fn weighted_smoke_with_setup_for_testing() {
     let mut rng = thread_rng();
-    let tc_happy = WeightedConfigArkworks::new(5, vec![1, 2, 5]).unwrap();
-    let tc_slow = WeightedConfigArkworks::new(3, vec![1, 2, 5]).unwrap();
+    let tc = WeightedConfigArkworks::new(3, vec![1, 2, 5]).unwrap();
 
-    let (ek, dk, vks_happy, msk_shares_happy, vks_slow, msk_shares_slow) =
-        FPTXWeighted::setup_for_testing(rng.r#gen(), 8, 1, &tc_happy, &tc_slow).unwrap();
+    let (ek, dk, vks, msk_shares) =
+        FPTXWeighted::setup_for_testing(rng.r#gen(), 8, 1, &tc).unwrap();
 
-    weighted_smoke_with_setup(
-        &mut rng,
-        tc_happy,
-        tc_slow,
-        ek,
-        dk,
-        vks_happy,
-        msk_shares_happy,
-        vks_slow,
-        msk_shares_slow,
-    );
+    weighted_smoke_with_setup(&mut rng, tc, ek, dk, vks, msk_shares);
 }
 
 type T = aptos_dkg::pvss::chunky::SignedWeightedTranscript<crate::group::Pairing>;
@@ -127,17 +90,16 @@ fn weighted_smoke_with_pvss() {
     let mut rng = thread_rng();
     let mut rng_aptos = rand::thread_rng();
 
-    let tc_happy = WeightedConfigArkworks::new(5, vec![1, 2, 5]).unwrap();
-    let tc_slow = WeightedConfigArkworks::new(3, vec![1, 2, 5]).unwrap();
+    let tc = WeightedConfigArkworks::new(3, vec![1, 2, 5]).unwrap();
     let pp = <T as Transcript>::PublicParameters::new_with_commitment_base(
-        tc_happy.get_total_weight(),
+        tc.get_total_weight(),
         aptos_dkg::pvss::chunky::DEFAULT_ELL_FOR_TESTING,
-        tc_happy.get_total_num_players(),
+        tc.get_total_num_players(),
         G2Affine::generator(),
         &mut rng_aptos,
     );
 
-    let ssks = (0..tc_happy.get_total_num_players())
+    let ssks = (0..tc.get_total_num_players())
         .map(|_| <T as Transcript>::SigningSecretKey::generate(&mut rng_aptos))
         .collect::<Vec<<T as Transcript>::SigningSecretKey>>();
     let spks = ssks
@@ -145,7 +107,7 @@ fn weighted_smoke_with_pvss() {
         .map(|ssk| ssk.verifying_key())
         .collect::<Vec<<T as Transcript>::SigningPubKey>>();
 
-    let dks: Vec<<T as Transcript>::DecryptPrivKey> = (0..tc_happy.get_total_num_players())
+    let dks: Vec<<T as Transcript>::DecryptPrivKey> = (0..tc.get_total_num_players())
         .map(|_| <T as Transcript>::DecryptPrivKey::generate(&mut rng_aptos))
         .collect();
     let eks: Vec<<T as Transcript>::EncryptPubKey> = dks
@@ -153,104 +115,49 @@ fn weighted_smoke_with_pvss() {
         .map(|dk| dk.to(pp.get_encryption_public_params()))
         .collect();
 
-    let secrets: Vec<<T as Transcript>::InputSecret> = (0..tc_happy.get_total_num_players())
+    let secrets: Vec<<T as Transcript>::InputSecret> = (0..tc.get_total_num_players())
         .map(|_| <T as Transcript>::InputSecret::generate(&mut rng_aptos))
         .collect();
 
     // Test dealing
-    let subtrx_happypaths: Vec<<T as HasAggregatableSubtranscript>::Subtranscript> = secrets
+    let subtrx_paths: Vec<<T as HasAggregatableSubtranscript>::Subtranscript> = secrets
         .iter()
         .enumerate()
         .map(|(i, s)| {
             T::deal(
-                &tc_happy,
+                &tc,
                 &pp,
                 &ssks[i],
                 &spks[i],
                 &eks,
                 s,
                 &NoAux,
-                &tc_happy.get_player(i),
+                &tc.get_player(i),
                 &mut rng_aptos,
             )
             .get_subtranscript()
         })
         .collect();
 
-    let subtrx_slowpaths: Vec<<T as HasAggregatableSubtranscript>::Subtranscript> = secrets
-        .iter()
-        .enumerate()
-        .map(|(i, s)| {
-            T::deal(
-                &tc_slow,
-                &pp,
-                &ssks[i],
-                &spks[i],
-                &eks,
-                s,
-                &NoAux,
-                &tc_slow.get_player(i),
-                &mut rng_aptos,
-            )
-            .get_subtranscript()
-        })
-        .collect();
-
-    let mut subtrx_happypath = subtrx_happypaths[0].clone();
-    for acc in &subtrx_happypaths[1..] {
-        subtrx_happypath.aggregate_with(&tc_happy, acc).unwrap();
-    }
-
-    let mut subtrx_slowpath = subtrx_slowpaths[0].clone();
-    for acc in &subtrx_slowpaths[1..] {
-        subtrx_slowpath.aggregate_with(&tc_slow, acc).unwrap();
+    let mut subtranscript = subtrx_paths[0].clone();
+    for acc in &subtrx_paths[1..] {
+        subtranscript.aggregate_with(&tc, acc).unwrap();
     }
 
     let dk = DigestKey::new(&mut rng, 8, 1).unwrap();
 
-    let (ek, vks_happy, _, vks_slow, _) = FPTXWeighted::setup(
-        &dk,
-        &pp,
-        &subtrx_happypath,
-        &subtrx_slowpath,
-        &tc_happy,
-        &tc_slow,
-        tc_happy.get_player(0),
-        &dks[0],
-    )
-    .unwrap();
+    let (ek, vks, _) =
+        FPTXWeighted::setup(&dk, &pp, &subtranscript, &tc, tc.get_player(0), &dks[0]).unwrap();
 
-    let (msk_shares_happy, msk_shares_slow): (
-        Vec<<FPTXWeighted as BatchThresholdEncryption>::MasterSecretKeyShare>,
-        Vec<<FPTXWeighted as BatchThresholdEncryption>::MasterSecretKeyShare>,
-    ) = tc_happy
+    let msk_shares: Vec<<FPTXWeighted as BatchThresholdEncryption>::MasterSecretKeyShare> = tc
         .get_players()
         .into_iter()
         .map(|p| {
-            let (_, _, msk_share_happypath, _, msk_share_slowpath) = FPTXWeighted::setup(
-                &dk,
-                &pp,
-                &subtrx_happypath,
-                &subtrx_slowpath,
-                &tc_happy,
-                &tc_slow,
-                p,
-                &dks[p.get_id()],
-            )
-            .unwrap();
-            (msk_share_happypath, msk_share_slowpath)
+            let (_, _, msk_share) =
+                FPTXWeighted::setup(&dk, &pp, &subtranscript, &tc, p, &dks[p.get_id()]).unwrap();
+            msk_share
         })
         .collect();
 
-    weighted_smoke_with_setup(
-        &mut rng,
-        tc_happy,
-        tc_slow,
-        ek,
-        dk,
-        vks_happy,
-        msk_shares_happy,
-        vks_slow,
-        msk_shares_slow,
-    );
+    weighted_smoke_with_setup(&mut rng, tc, ek, dk, vks, msk_shares);
 }

--- a/crates/aptos-batch-encryption/src/traits.rs
+++ b/crates/aptos-batch-encryption/src/traits.rs
@@ -59,16 +59,12 @@ pub trait BatchThresholdEncryption {
     fn setup(
         digest_key: &Self::DigestKey,
         pvss_public_params: &<Self::SubTranscript as Subtranscript>::PublicParameters,
-        subtranscript_happypath: &Self::SubTranscript,
-        subtranscript_slowpath: &Self::SubTranscript,
-        tc_happypath: &Self::ThresholdConfig,
-        tc_slowpath: &Self::ThresholdConfig,
+        subtranscript: &Self::SubTranscript,
+        threshold_config: &Self::ThresholdConfig,
         current_player: Player,
         sk_share_decryption_key: &<Self::SubTranscript as Subtranscript>::DecryptPrivKey,
     ) -> Result<(
         Self::EncryptionKey,
-        Vec<Self::VerificationKey>,
-        Self::MasterSecretKeyShare,
         Vec<Self::VerificationKey>,
         Self::MasterSecretKeyShare,
     )>;
@@ -82,13 +78,10 @@ pub trait BatchThresholdEncryption {
         seed: u64,
         max_batch_size: usize,
         number_of_rounds: usize,
-        tc_happypath: &Self::ThresholdConfig,
-        tc_slowpath: &Self::ThresholdConfig,
+        threshold_config: &Self::ThresholdConfig,
     ) -> Result<(
         Self::EncryptionKey,
         Self::DigestKey,
-        Vec<Self::VerificationKey>,
-        Vec<Self::MasterSecretKeyShare>,
         Vec<Self::VerificationKey>,
         Vec<Self::MasterSecretKeyShare>,
     )>;


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

We are not going to implement the fast path, so this PR removes fast path from the implementation and traits. We can revisit this later if we need to introduce fast path again.