### PR TITLE
[simple][transaction simulation] fix bug in fund_apt_fungible_store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,7 +304,7 @@ dependencies = [
 
 [[package]]
 name = "aptos"
-version = "7.14.0"
+version = "7.14.1"
 dependencies = [
  "anyhow",
  "aptos-api-types",

--- a/aptos-move/aptos-transaction-simulation/src/state_store.rs
+++ b/aptos-move/aptos-transaction-simulation/src/state_store.rs
@@ -5,9 +5,11 @@ use crate::{genesis::GENESIS_CHANGE_SET_HEAD, Account, AccountData};
 use anyhow::{anyhow, bail, Result};
 use aptos_types::{
     account_config::{
-        primary_apt_store, CoinStoreResource, FungibleStoreResource, ObjectGroupResource,
+        primary_apt_store, CoinStoreResource, FungibleStoreResource, ObjectCoreResource,
+        ObjectGroupResource,
     },
     chain_id::ChainId,
+    event::EventHandle,
     on_chain_config::{FeatureFlag, Features, OnChainConfig},
     state_store::{
         state_key::StateKey, state_slot::StateSlot, state_storage_usage::StateStorageUsage,
@@ -293,6 +295,17 @@ pub trait SimulationStateStore: TStateView<Key = StateKey> {
         let mut resource_group = self
             .get_resource_group::<ObjectGroupResource>(primary_store_object_address)?
             .unwrap_or_else(BTreeMap::new);
+
+        resource_group
+            .entry(ObjectCoreResource::struct_tag())
+            .or_insert(bcs::to_bytes(&ObjectCoreResource::new(
+                address,
+                false,
+                EventHandle::new(
+                    aptos_types::event::EventKey::new(0, primary_store_object_address),
+                    0,
+                ),
+            ))?);
 
         let mut fungible_store = match resource_group.get(&FungibleStoreResource::struct_tag()) {
             Some(blob) => bcs::from_bytes(blob)?,

--- a/crates/aptos/CHANGELOG.md
+++ b/crates/aptos/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to the Aptos CLI will be captured in this file. This project
 
 # Unreleased
 
+## [7.14.1]
+- Transaction simulation: fix bug in `fund_apt_fungible_store`
+
 ## [7.14.0]
 - Add support for code object deployment and upgrade in Transaction Simulation Sessions
 

--- a/crates/aptos/Cargo.toml
+++ b/crates/aptos/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aptos"
 description = "Aptos tool for management of nodes and interacting with the blockchain"
-version = "7.14.0"
+version = "7.14.1"
 
 # Workspace inherited keys
 authors = { workspace = true }


### PR DESCRIPTION
This fixes a bug in the `fn fund_apt_fungible_store` which resulted in improper creation of the fungible store object, causing certain transactions to fail during simulation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes transaction simulation funding logic and bumps CLI version.
> 
> - In `state_store.rs`, `fund_apt_fungible_store` now ensures `ObjectCoreResource` (with an `EventHandle`) exists in the primary APT store resource group before updating `FungibleStoreResource` balance
> - Adds necessary imports for `ObjectCoreResource` and `EventHandle`
> - Updates `aptos` crate version to `7.14.1` and adds CHANGELOG entry
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cc11c1b8725e6240b74402722fd6b0f7909a9e3f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->