### PR TITLE
[move-prover] Implement behavioral predicates reduction

### DIFF
--- a/third_party/move/move-compiler-v2/src/env_pipeline/spec_rewriter.rs
+++ b/third_party/move/move-compiler-v2/src/env_pipeline/spec_rewriter.rs
@@ -23,23 +23,30 @@
 use crate::env_pipeline::rewrite_target::{
     RewriteState, RewriteTarget, RewriteTargets, RewritingScope,
 };
+use codespan_reporting::diagnostic::Severity;
 use itertools::Itertools;
 use log::debug;
 use move_model::{
-    ast::{ConditionKind, Exp, ExpData, GlobalInvariant, Operation, SpecBlockTarget, SpecFunDecl},
+    ast::{
+        BehaviorKind, BehaviorTarget, ConditionKind, Exp, ExpData, GlobalInvariant, Operation,
+        RewriteResult, SpecBlockTarget, SpecFunDecl, TempIndex,
+    },
+    exp_builder::ExpBuilder,
+    exp_generator::ExpGenerator,
     exp_rewriter::ExpRewriterFunctions,
     metadata::LanguageVersion,
     model::{
-        FunId, FunctionData, GlobalEnv, ModuleId, NodeId, Parameter, QualifiedId, SpecFunId,
-        StructEnv,
+        FunId, FunctionData, FunctionEnv, GlobalEnv, Loc, ModuleId, NodeId, Parameter, QualifiedId,
+        QualifiedInstId, SpecFunId, StructEnv,
     },
+    spec_translator::SpecTranslator,
     symbol::Symbol,
-    ty::ReferenceKind,
+    ty::{PrimitiveType, ReferenceKind, Type},
 };
 use petgraph::prelude::DiGraphMap;
 use std::{
     cell::RefCell,
-    collections::{BTreeMap, BTreeSet},
+    collections::{BTreeMap, BTreeSet, HashMap},
 };
 
 pub fn run_spec_rewriter(env: &mut GlobalEnv) {
@@ -137,16 +144,23 @@ pub fn run_spec_rewriter(env: &mut GlobalEnv) {
                 }
             },
             (SpecBlock(sb_target), Spec(spec)) => {
-                let mut converter = if let SpecBlockTarget::SpecFunction(mid, spec_fun_id) =
-                    sb_target
-                {
-                    // When the spec block is associated with a spec function, need to replace temps with parameter names
-                    let paras =
-                        get_param_names(&env.get_spec_fun(mid.qualified(*spec_fun_id)).params);
-                    SpecConverter::new(env, &function_mapping, true).symbolized_parameters(paras)
-                } else {
-                    SpecConverter::new(env, &function_mapping, true)
+                let mut converter = match sb_target {
+                    SpecBlockTarget::SpecFunction(mid, spec_fun_id) => {
+                        // When the spec block is associated with a spec function, need to replace temps with parameter names
+                        let paras =
+                            get_param_names(&env.get_spec_fun(mid.qualified(*spec_fun_id)).params);
+                        SpecConverter::new(env, &function_mapping, true)
+                            .symbolized_parameters(paras)
+                    },
+                    SpecBlockTarget::Function(mid, fid)
+                    | SpecBlockTarget::FunctionCode(mid, fid, _) => {
+                        // Set enclosing function context for behavioral predicate parameter handling
+                        SpecConverter::new(env, &function_mapping, true)
+                            .with_enclosing_fun(mid.qualified(*fid))
+                    },
+                    _ => SpecConverter::new(env, &function_mapping, true),
                 };
+
                 let (changed, new_spec) = converter.rewrite_spec_descent(sb_target, &spec);
                 if changed {
                     *targets.state_mut(&target) = Spec(new_spec)
@@ -338,6 +352,60 @@ fn derive_spec_fun(
 }
 
 // -------------------------------------------------------------------------------------------
+// Behavioral Predicate Reduction
+
+/// Minimal ExpGenerator implementation for behavioral predicate reduction.
+/// Provides enough context for SpecTranslator without full bytecode infrastructure.
+///
+/// Notice that `TempIndex` locals only exist artificially during translation as
+/// placeholders for actual expressions in the context of spec expressions. For historical
+/// reasons spec expressions use TempIndex for parameters exclusively, and Symbol for locals.
+struct BehaviorExpGenerator<'env> {
+    fun_env: FunctionEnv<'env>,
+    loc: Loc,
+    next_temp: TempIndex,
+    temp_types: BTreeMap<TempIndex, Type>,
+}
+
+impl<'env> BehaviorExpGenerator<'env> {
+    fn new(fun_env: FunctionEnv<'env>, loc: Loc, param_count: usize) -> Self {
+        // Start allocating temps after the function's parameters.
+        // In spec expressions, only function parameters can be TempIndex (0..param_count-1).
+        Self {
+            fun_env,
+            loc,
+            next_temp: param_count,
+            temp_types: BTreeMap::new(),
+        }
+    }
+}
+
+impl<'env> ExpGenerator<'env> for BehaviorExpGenerator<'env> {
+    fn function_env(&self) -> &FunctionEnv<'env> {
+        &self.fun_env
+    }
+
+    fn get_current_loc(&self) -> Loc {
+        self.loc.clone()
+    }
+
+    fn set_loc(&mut self, loc: Loc) {
+        self.loc = loc;
+    }
+
+    fn add_local(&mut self, ty: Type) -> TempIndex {
+        let idx = self.next_temp;
+        self.temp_types.insert(idx, ty);
+        self.next_temp += 1;
+        idx
+    }
+
+    fn get_local_type(&self, temp: TempIndex) -> Type {
+        self.temp_types.get(&temp).cloned().unwrap_or(Type::Error)
+    }
+}
+
+// -------------------------------------------------------------------------------------------
 // Expressions Conversion
 
 /// The expression converter takes a Move expression and converts it to a
@@ -359,6 +427,11 @@ struct SpecConverter<'a> {
     contains_imperative_expression: bool,
     /// Set to true when rewriting spec during inlining phase
     for_inline: bool,
+    /// The enclosing function for spec blocks (needed for parameter target handling)
+    enclosing_fun: Option<QualifiedId<FunId>>,
+    /// Cache for generated behavioral predicate spec functions:
+    /// (enclosing_fun, kind, param_sym) -> generated spec function id
+    behavior_spec_funs: HashMap<(QualifiedId<FunId>, BehaviorKind, Symbol), QualifiedId<SpecFunId>>,
 }
 
 impl<'a> SpecConverter<'a> {
@@ -375,6 +448,8 @@ impl<'a> SpecConverter<'a> {
             reference_strip_exempted: Default::default(),
             contains_imperative_expression: false,
             for_inline: false,
+            enclosing_fun: None,
+            behavior_spec_funs: HashMap::new(),
         }
     }
 
@@ -391,6 +466,8 @@ impl<'a> SpecConverter<'a> {
             reference_strip_exempted: Default::default(),
             contains_imperative_expression: false,
             for_inline: true,
+            enclosing_fun: None,
+            behavior_spec_funs: HashMap::new(),
         }
     }
 
@@ -399,6 +476,275 @@ impl<'a> SpecConverter<'a> {
             symbolized_parameters,
             ..self
         }
+    }
+
+    fn with_enclosing_fun(self, fun_id: QualifiedId<FunId>) -> Self {
+        Self {
+            enclosing_fun: Some(fun_id),
+            ..self
+        }
+    }
+
+    /// Generates an uninterpreted spec function for a behavioral predicate with a
+    /// function-typed parameter target. Returns a cached spec function if one was
+    /// already generated for this (enclosing_fun, kind, param) combination.
+    fn generate_behavior_spec_fun(
+        &mut self,
+        enclosing_fun: QualifiedId<FunId>,
+        kind: BehaviorKind,
+        param_sym: Symbol,
+        param_type: &Type,
+        loc: &Loc,
+    ) -> QualifiedId<SpecFunId> {
+        // Check cache first
+        let cache_key = (enclosing_fun, kind, param_sym);
+        if let Some(spec_fun_id) = self.behavior_spec_funs.get(&cache_key) {
+            return *spec_fun_id;
+        }
+
+        let fun_env = self.env.get_function(enclosing_fun);
+
+        // Build spec function name: $<kind>$<enclosing_fun_name>$<param_name>
+        let name = self.env.symbol_pool().make(&format!(
+            "${}${}${}",
+            kind,
+            fun_env.get_name().display(self.env.symbol_pool()),
+            param_sym.display(self.env.symbol_pool())
+        ));
+
+        // Extract argument types and result types from the function type
+        let (fn_arg_types, fn_result_types) = match param_type {
+            Type::Fun(arg, result, _) => (
+                arg.as_ref().clone().flatten(),
+                result.as_ref().clone().flatten(),
+            ),
+            _ => {
+                self.env.diag(
+                    Severity::Bug,
+                    loc,
+                    &format!(
+                        "behavioral predicate parameter `{}` has non-function type",
+                        param_sym.display(self.env.symbol_pool())
+                    ),
+                );
+                (vec![], vec![])
+            },
+        };
+
+        // Build parameters for the spec function (function's input arguments only)
+        let mut params: Vec<Parameter> = fn_arg_types
+            .iter()
+            .enumerate()
+            .map(|(i, ty)| {
+                let arg_name = self.env.symbol_pool().make(&format!("arg{}", i));
+                Parameter(arg_name, ty.clone(), loc.clone())
+            })
+            .collect();
+
+        // For EnsuresOf, add parameters for result values
+        if kind == BehaviorKind::EnsuresOf {
+            for (i, ty) in fn_result_types.iter().enumerate() {
+                let result_name = self.env.symbol_pool().make(&format!("result{}", i));
+                params.push(Parameter(result_name, ty.clone(), loc.clone()));
+            }
+        }
+
+        // Create the uninterpreted spec function declaration
+        let decl = SpecFunDecl {
+            loc: loc.clone(),
+            name,
+            type_params: fun_env.get_type_parameters(),
+            params,
+            context_params: None,
+            result_type: Type::Primitive(PrimitiveType::Bool),
+            used_memory: BTreeSet::new(),
+            uninterpreted: true,
+            is_move_fun: false,
+            is_native: false,
+            body: None,
+            callees: BTreeSet::new(),
+            is_recursive: RefCell::new(None),
+            insts_using_generic_type_reflection: Default::default(),
+            spec: RefCell::new(Default::default()),
+        };
+
+        // Add to environment
+        let spec_fun_id = self
+            .env
+            .add_spec_function_def(enclosing_fun.module_id, decl);
+
+        // Cache and return
+        self.behavior_spec_funs.insert(cache_key, spec_fun_id);
+        spec_fun_id
+    }
+
+    /// Reduces a behavioral predicate (requires_of, aborts_of, ensures_of, modifies_of)
+    /// for a known function target into plain predicates by using SpecTranslator
+    /// to properly extract and substitute the function's specification conditions.
+    fn reduce_behavior_predicate(
+        &mut self,
+        id: NodeId,
+        kind: BehaviorKind,
+        target_fun: &QualifiedInstId<FunId>,
+        args: &[Exp],
+    ) -> Exp {
+        let loc = self.env.get_node_loc(id);
+
+        // Scope the immutable borrow for SpecTranslator
+        let (translated, param_temps, ret_temps) = {
+            let env = &self.env;
+            let target_fun_env = env.get_function(target_fun.to_qualified_id());
+            let param_count = target_fun_env.get_parameter_count();
+            let type_args = &target_fun.inst;
+
+            // Create minimal ExpGenerator, starting temps after the function's parameters
+            let mut generator =
+                BehaviorExpGenerator::new(target_fun_env.clone(), loc.clone(), param_count);
+
+            // Allocate temps for parameters (used by param_substitution)
+            let param_temps: Vec<TempIndex> = (0..param_count)
+                .map(|i| {
+                    let ty = if i < args.len() {
+                        env.get_node_type(args[i].node_id())
+                    } else {
+                        Type::Error
+                    };
+                    generator.add_local(ty)
+                })
+                .collect();
+
+            // Allocate temps for results (used by ret_locals).
+            // We must allocate based on the function's return type, not the args provided,
+            // because SpecTranslator translates ALL conditions including ensures which may
+            // reference `result` even when we only need requires.
+            let ret_temps: Vec<TempIndex> = target_fun_env
+                .get_result_type()
+                .flatten()
+                .iter()
+                .map(|ty| generator.add_local(ty.clone()))
+                .collect();
+
+            // Translate the spec using SpecTranslator
+            let translated = SpecTranslator::translate_fun_spec(
+                false, // auto_trace
+                true,  // for_call
+                &mut generator,
+                &target_fun_env,
+                type_args,
+                Some(&param_temps),
+                &ret_temps,
+            );
+
+            (translated, param_temps, ret_temps)
+        };
+
+        // Build a mapping from saved param temps back to original param temps.
+        // SpecTranslator creates saved_params when translating post conditions to
+        // preserve pre-state values: saved_params maps param_temp -> saved_temp.
+        // We need the reverse: saved_temp -> param_temp, so we can trace back to args.
+        let saved_to_param: BTreeMap<TempIndex, TempIndex> = translated
+            .saved_params
+            .iter()
+            .map(|(param, saved)| (*saved, *param))
+            .collect();
+
+        // Extract and combine conditions based on behavior kind
+        let builder = ExpBuilder::new(self.env);
+        match kind {
+            BehaviorKind::RequiresOf => {
+                let conditions: Vec<Exp> = translated
+                    .pre
+                    .into_iter()
+                    .map(|(_, e)| {
+                        Self::substitute_temps_with_args(
+                            &e,
+                            &param_temps,
+                            &ret_temps,
+                            &saved_to_param,
+                            args,
+                        )
+                    })
+                    .collect();
+                builder.and_n(&loc, conditions)
+            },
+            BehaviorKind::AbortsOf => {
+                // Combine all abort conditions from TranslatedSpec
+                let abort_conds: Vec<Exp> = translated
+                    .aborts
+                    .into_iter()
+                    .map(|(_, e, _)| {
+                        Self::substitute_temps_with_args(
+                            &e,
+                            &param_temps,
+                            &ret_temps,
+                            &saved_to_param,
+                            args,
+                        )
+                    })
+                    .collect();
+                builder.or_n(&loc, abort_conds)
+            },
+            BehaviorKind::EnsuresOf => {
+                let conditions: Vec<Exp> = translated
+                    .post
+                    .into_iter()
+                    .map(|(_, e)| {
+                        Self::substitute_temps_with_args(
+                            &e,
+                            &param_temps,
+                            &ret_temps,
+                            &saved_to_param,
+                            args,
+                        )
+                    })
+                    .collect();
+                builder.and_n(&loc, conditions)
+            },
+            BehaviorKind::ModifiesOf => {
+                // Return true for now; proper semantics TBD
+                builder.bool_const(&loc, true)
+            },
+        }
+    }
+
+    /// Substitutes temporary references back to the original argument expressions.
+    /// SpecTranslator rewrites params to Temporary(param_temps[i]) and results to Temporary(ret_temps[j]).
+    /// For post conditions, params may be saved via saved_params (param_temp -> saved_temp).
+    /// We need to substitute these back to the original arg expressions.
+    fn substitute_temps_with_args(
+        exp: &Exp,
+        param_temps: &[TempIndex],
+        ret_temps: &[TempIndex],
+        saved_to_param: &BTreeMap<TempIndex, TempIndex>,
+        args: &[Exp],
+    ) -> Exp {
+        ExpData::rewrite(exp.clone(), &mut |e| {
+            if let ExpData::Temporary(_, idx) = e.as_ref() {
+                // Check if it's a param temp
+                if let Some(pos) = param_temps.iter().position(|t| *t == *idx) {
+                    if pos < args.len() {
+                        return RewriteResult::Rewritten(args[pos].clone());
+                    }
+                }
+                // Check if it's a result temp
+                if let Some(pos) = ret_temps.iter().position(|t| *t == *idx) {
+                    let arg_idx = param_temps.len() + pos;
+                    if arg_idx < args.len() {
+                        return RewriteResult::Rewritten(args[arg_idx].clone());
+                    }
+                }
+                // Check if it's a saved param temp (from post condition translation)
+                if let Some(original_param_temp) = saved_to_param.get(idx) {
+                    // Find the position of the original param temp
+                    if let Some(pos) = param_temps.iter().position(|t| *t == *original_param_temp) {
+                        if pos < args.len() {
+                            return RewriteResult::Rewritten(args[pos].clone());
+                        }
+                    }
+                }
+            }
+            RewriteResult::Unchanged(e)
+        })
     }
 }
 
@@ -620,6 +966,77 @@ impl ExpRewriterFunctions for SpecConverter<'_> {
                 self.env.set_node_instantiation(new_id, new_inst);
             }
             Some(new_id)
+        } else {
+            None
+        }
+    }
+
+    fn rewrite_call(&mut self, id: NodeId, oper: &Operation, args: &[Exp]) -> Option<Exp> {
+        if let Operation::Behavior(kind, _pre_label, target, _post_label) = oper {
+            match target {
+                BehaviorTarget::Function(qid) => {
+                    Some(self.reduce_behavior_predicate(id, *kind, qid, args))
+                },
+                BehaviorTarget::Parameter(sym) => {
+                    let loc = self.env.get_node_loc(id);
+
+                    // modifies_of is not supported for parameter targets
+                    if *kind == BehaviorKind::ModifiesOf {
+                        self.env.error(
+                            &loc,
+                            "`modifies_of` is not supported for function-typed parameters",
+                        );
+                        return None;
+                    }
+
+                    // Get enclosing function context
+                    let enclosing_fun = self.enclosing_fun.or_else(|| {
+                        self.env.diag(
+                            Severity::Bug,
+                            &loc,
+                            "behavioral predicate with parameter target requires \
+                             enclosing function context",
+                        );
+                        None
+                    })?;
+                    let fun_env = self.env.get_function(enclosing_fun);
+                    let param_type = fun_env
+                        .get_parameters()
+                        .iter()
+                        .find(|p| p.0 == *sym)
+                        .map(|p| p.1.clone())
+                        .expect("parameter not found");
+
+                    // Generate or retrieve the uninterpreted spec function
+                    let spec_fun_id = self.generate_behavior_spec_fun(
+                        enclosing_fun,
+                        *kind,
+                        *sym,
+                        &param_type,
+                        &loc,
+                    );
+
+                    // Build call: $kind$fun$param(arg1, arg2, ...)
+                    // The function parameter is encoded in the spec function name, not passed as arg
+                    let call_args: Vec<Exp> = args.to_vec();
+
+                    // Create node for the spec function call
+                    let result_type = Type::Primitive(PrimitiveType::Bool);
+                    let call_node_id = self.env.new_node(loc, result_type);
+                    // Copy type instantiation from original node for generic functions
+                    self.env
+                        .set_node_instantiation(call_node_id, self.env.get_node_instantiation(id));
+
+                    Some(
+                        ExpData::Call(
+                            call_node_id,
+                            Operation::SpecFunction(spec_fun_id.module_id, spec_fun_id.id, None),
+                            call_args,
+                        )
+                        .into_exp(),
+                    )
+                },
+            }
         } else {
             None
         }

--- a/third_party/move/move-compiler-v2/tests/checking-lang-v2.4/specs/behavior_predicates_param_err.exp
+++ b/third_party/move/move-compiler-v2/tests/checking-lang-v2.4/specs/behavior_predicates_param_err.exp
@@ -1,0 +1,7 @@
+
+Diagnostics:
+error: `modifies_of` is not supported for function-typed parameters
+   ┌─ tests/checking-lang-v2.4/specs/behavior_predicates_param_err.move:15:17
+   │
+15 │         ensures modifies_of<f>(global<Counter>(addr));
+   │                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/checking-lang-v2.4/specs/behavior_predicates_param_err.move
+++ b/third_party/move/move-compiler-v2/tests/checking-lang-v2.4/specs/behavior_predicates_param_err.move
@@ -1,0 +1,17 @@
+// Tests for behavior predicates with function parameter targets that produce errors.
+
+module 0x42::M {
+
+    struct Counter has key {
+        value: u64,
+    }
+
+    // Test modifies_of with function parameter - not supported
+    fun apply_modifies(f: |address|, addr: address) {
+        f(addr)
+    }
+
+    spec apply_modifies {
+        ensures modifies_of<f>(global<Counter>(addr));
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/checking-lang-v2.4/specs/behavior_predicates_param_valid.exp
+++ b/third_party/move/move-compiler-v2/tests/checking-lang-v2.4/specs/behavior_predicates_param_valid.exp
@@ -1,0 +1,247 @@
+// -- Model dump before first bytecode pipeline
+module 0x42::M {
+    private fun apply_aborts(f: |u64|u64,x: u64): u64 {
+        (f)(x)
+    }
+    spec {
+      aborts_if M::$aborts_of$apply_aborts$f($t1);
+    }
+
+    private fun apply_binary(f: |u64, u64|u64,a: u64,b: u64): u64 {
+        (f)(a, b)
+    }
+    spec {
+      ensures M::$requires_of$apply_binary$f($t1, $t2);
+      ensures M::$ensures_of$apply_binary$f($t1, $t2, result0());
+      aborts_if M::$aborts_of$apply_binary$f($t1, $t2);
+    }
+
+    private fun apply_ensures(f: |u64|u64,x: u64): u64 {
+        (f)(x)
+    }
+    spec {
+      ensures M::$ensures_of$apply_ensures$f($t1, result0());
+    }
+
+    private fun apply_generic<T>(f: |T|T,x: T): T {
+        (f)(x)
+    }
+    spec {
+      ensures M::$requires_of$apply_generic$f($t1);
+      ensures M::$ensures_of$apply_generic$f($t1, result0());
+    }
+
+    private fun apply_requires(f: |u64|u64,x: u64): u64 {
+        (f)(x)
+    }
+    spec {
+      ensures M::$requires_of$apply_requires$f($t1);
+    }
+
+    spec fun $aborts_of$apply_aborts$f(arg0: u64): bool;
+    spec fun $requires_of$apply_binary$f(arg0: u64,arg1: u64): bool;
+    spec fun $ensures_of$apply_binary$f(arg0: u64,arg1: u64,result0: u64): bool;
+    spec fun $aborts_of$apply_binary$f(arg0: u64,arg1: u64): bool;
+    spec fun $ensures_of$apply_ensures$f(arg0: u64,result0: u64): bool;
+    spec fun $requires_of$apply_generic$f<T>(arg0: #0): bool;
+    spec fun $ensures_of$apply_generic$f<T>(arg0: #0,result0: #0): bool;
+    spec fun $requires_of$apply_requires$f(arg0: u64): bool;
+} // end 0x42::M
+
+// -- Sourcified model before first bytecode pipeline
+module 0x42::M {
+    fun apply_aborts(f: |u64|u64, x: u64): u64 {
+        f(x)
+    }
+    fun apply_binary(f: |u64, u64|u64, a: u64, b: u64): u64 {
+        f(a, b)
+    }
+    fun apply_ensures(f: |u64|u64, x: u64): u64 {
+        f(x)
+    }
+    fun apply_generic<T>(f: |T|T, x: T): T {
+        f(x)
+    }
+    fun apply_requires(f: |u64|u64, x: u64): u64 {
+        f(x)
+    }
+}
+
+============ bytecode before first stackless bytecode pipeline ================
+
+[variant baseline]
+fun M::apply_aborts($t0: |u64|u64, $t1: u64): u64 {
+     var $t2: u64
+  0: $t2 := invoke($t1, $t0)
+  1: return $t2
+}
+
+
+[variant baseline]
+fun M::apply_binary($t0: |u64, u64|u64, $t1: u64, $t2: u64): u64 {
+     var $t3: u64
+     var $t4: u64
+  0: $t4 := infer($t1)
+  1: $t3 := invoke($t4, $t2, $t0)
+  2: return $t3
+}
+
+
+[variant baseline]
+fun M::apply_ensures($t0: |u64|u64, $t1: u64): u64 {
+     var $t2: u64
+  0: $t2 := invoke($t1, $t0)
+  1: return $t2
+}
+
+
+[variant baseline]
+fun M::apply_generic<#0>($t0: |#0|#0, $t1: #0): #0 {
+     var $t2: #0
+  0: $t2 := invoke($t1, $t0)
+  1: return $t2
+}
+
+
+[variant baseline]
+fun M::apply_requires($t0: |u64|u64, $t1: u64): u64 {
+     var $t2: u64
+  0: $t2 := invoke($t1, $t0)
+  1: return $t2
+}
+
+// -- Model dump before second bytecode pipeline
+module 0x42::M {
+    private fun apply_aborts(f: |u64|u64,x: u64): u64 {
+        (f)(x)
+    }
+    spec {
+      aborts_if M::$aborts_of$apply_aborts$f($t1);
+    }
+
+    private fun apply_binary(f: |u64, u64|u64,a: u64,b: u64): u64 {
+        (f)(a, b)
+    }
+    spec {
+      ensures M::$requires_of$apply_binary$f($t1, $t2);
+      ensures M::$ensures_of$apply_binary$f($t1, $t2, result0());
+      aborts_if M::$aborts_of$apply_binary$f($t1, $t2);
+    }
+
+    private fun apply_ensures(f: |u64|u64,x: u64): u64 {
+        (f)(x)
+    }
+    spec {
+      ensures M::$ensures_of$apply_ensures$f($t1, result0());
+    }
+
+    private fun apply_generic<T>(f: |T|T,x: T): T {
+        (f)(x)
+    }
+    spec {
+      ensures M::$requires_of$apply_generic$f($t1);
+      ensures M::$ensures_of$apply_generic$f($t1, result0());
+    }
+
+    private fun apply_requires(f: |u64|u64,x: u64): u64 {
+        (f)(x)
+    }
+    spec {
+      ensures M::$requires_of$apply_requires$f($t1);
+    }
+
+    spec fun $aborts_of$apply_aborts$f(arg0: u64): bool;
+    spec fun $requires_of$apply_binary$f(arg0: u64,arg1: u64): bool;
+    spec fun $ensures_of$apply_binary$f(arg0: u64,arg1: u64,result0: u64): bool;
+    spec fun $aborts_of$apply_binary$f(arg0: u64,arg1: u64): bool;
+    spec fun $ensures_of$apply_ensures$f(arg0: u64,result0: u64): bool;
+    spec fun $requires_of$apply_generic$f<T>(arg0: #0): bool;
+    spec fun $ensures_of$apply_generic$f<T>(arg0: #0,result0: #0): bool;
+    spec fun $requires_of$apply_requires$f(arg0: u64): bool;
+} // end 0x42::M
+
+============ bytecode before second stackless bytecode pipeline ================
+
+[variant baseline]
+fun M::apply_aborts($t0: |u64|u64, $t1: u64): u64 {
+     var $t2: u64
+  0: $t2 := invoke($t1, $t0)
+  1: return $t2
+}
+
+
+[variant baseline]
+fun M::apply_binary($t0: |u64, u64|u64, $t1: u64, $t2: u64): u64 {
+     var $t3: u64
+     var $t4: u64
+  0: $t4 := infer($t1)
+  1: $t3 := invoke($t4, $t2, $t0)
+  2: return $t3
+}
+
+
+[variant baseline]
+fun M::apply_ensures($t0: |u64|u64, $t1: u64): u64 {
+     var $t2: u64
+  0: $t2 := invoke($t1, $t0)
+  1: return $t2
+}
+
+
+[variant baseline]
+fun M::apply_generic<#0>($t0: |#0|#0, $t1: #0): #0 {
+     var $t2: #0
+  0: $t2 := invoke($t1, $t0)
+  1: return $t2
+}
+
+
+[variant baseline]
+fun M::apply_requires($t0: |u64|u64, $t1: u64): u64 {
+     var $t2: u64
+  0: $t2 := invoke($t1, $t0)
+  1: return $t2
+}
+
+
+============ disassembled file-format ==================
+// Bytecode version v10
+module 0x42::M
+// Function definition at index 0
+fun apply_aborts(l0: |u64|u64, l1: u64): u64
+    move_loc l1
+    move_loc l0
+    call_closure <|u64|u64>
+    ret
+
+// Function definition at index 1
+fun apply_binary(l0: |u64, u64|u64, l1: u64, l2: u64): u64
+    move_loc l1
+    move_loc l2
+    move_loc l0
+    call_closure <|u64, u64|u64>
+    ret
+
+// Function definition at index 2
+fun apply_ensures(l0: |u64|u64, l1: u64): u64
+    move_loc l1
+    move_loc l0
+    call_closure <|u64|u64>
+    ret
+
+// Function definition at index 3
+fun apply_generic<T0>(l0: |T0|T0, l1: T0): T0
+    move_loc l1
+    move_loc l0
+    call_closure <|T0|T0>
+    ret
+
+// Function definition at index 4
+fun apply_requires(l0: |u64|u64, l1: u64): u64
+    move_loc l1
+    move_loc l0
+    call_closure <|u64|u64>
+    ret
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/checking-lang-v2.4/specs/behavior_predicates_param_valid.move
+++ b/third_party/move/move-compiler-v2/tests/checking-lang-v2.4/specs/behavior_predicates_param_valid.move
@@ -1,0 +1,53 @@
+// Tests for behavior predicates with function parameter targets.
+// These generate uninterpreted specification functions.
+
+module 0x42::M {
+
+    // Test requires_of with function parameter
+    fun apply_requires(f: |u64| u64, x: u64): u64 {
+        f(x)
+    }
+
+    spec apply_requires {
+        ensures requires_of<f>(x);
+    }
+
+    // Test aborts_of with function parameter
+    fun apply_aborts(f: |u64| u64, x: u64): u64 {
+        f(x)
+    }
+
+    spec apply_aborts {
+        aborts_if aborts_of<f>(x);
+    }
+
+    // Test ensures_of with function parameter
+    fun apply_ensures(f: |u64| u64, x: u64): u64 {
+        f(x)
+    }
+
+    spec apply_ensures {
+        ensures ensures_of<f>(x, result);
+    }
+
+    // Test with binary function parameter
+    fun apply_binary(f: |u64, u64| u64, a: u64, b: u64): u64 {
+        f(a, b)
+    }
+
+    spec apply_binary {
+        ensures requires_of<f>(a, b);
+        ensures ensures_of<f>(a, b, result);
+        aborts_if aborts_of<f>(a, b);
+    }
+
+    // Test with generic function parameter - verifies type instantiation is preserved
+    fun apply_generic<T>(f: |T| T, x: T): T {
+        f(x)
+    }
+
+    spec apply_generic {
+        ensures requires_of<f>(x);
+        ensures ensures_of<f>(x, result);
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/checking-lang-v2.4/specs/behavior_predicates_static_valid.exp
+++ b/third_party/move/move-compiler-v2/tests/checking-lang-v2.4/specs/behavior_predicates_static_valid.exp
@@ -22,43 +22,6 @@ module 0x42::M {
       ensures Eq<u64>(result0(), Add($t0, $t1));
     }
 
-    private fun apply_aborts(f: |u64|u64,x: u64): u64 {
-        (f)(x)
-    }
-    spec {
-      aborts_if aborts_of<f>($t1);
-    }
-
-    private fun apply_binary(f: |u64, u64|u64,a: u64,b: u64): u64 {
-        (f)(a, b)
-    }
-    spec {
-      ensures requires_of<f>($t1, $t2);
-      ensures ensures_of<f>($t1, $t2, result0());
-      aborts_if aborts_of<f>($t1, $t2);
-    }
-
-    private fun apply_ensures(f: |u64|u64,x: u64): u64 {
-        (f)(x)
-    }
-    spec {
-      ensures ensures_of<f>($t1, result0());
-    }
-
-    private fun apply_modifies(f: |address|,addr: address) {
-        (f)(addr)
-    }
-    spec {
-      ensures modifies_of<f>(global<0x42::M::Counter>($t1));
-    }
-
-    private fun apply_requires(f: |u64|u64,x: u64): u64 {
-        (f)(x)
-    }
-    spec {
-      ensures requires_of<f>($t1);
-    }
-
     private fun do_nothing(_x: u64) {
         Tuple()
     }
@@ -142,78 +105,78 @@ module 0x42::M {
         M::increment(x)
     }
     spec {
-      aborts_if aborts_of<M::increment>($t0);
+      aborts_if false;
     }
 
     private fun test_aborts_generic_explicit(x: u64): u64 {
         M::identity<u64>(x)
     }
     spec {
-      aborts_if aborts_of<M::identity><u64>($t0);
+      aborts_if false;
     }
 
     private fun test_aborts_generic_inferred(x: u64): u64 {
         M::identity<u64>(x)
     }
     spec {
-      aborts_if aborts_of<M::identity><u64>($t0);
+      aborts_if false;
     }
 
     private fun test_ensures_binary(a: u64,b: u64): u64 {
         M::add(a, b)
     }
     spec {
-      ensures ensures_of<M::add>($t0, $t1, result0());
+      ensures Eq<u64>(result0(), Add($t0, $t1));
     }
 
     private fun test_ensures_generic_explicit(x: u64): u64 {
         M::identity<u64>(x)
     }
     spec {
-      ensures ensures_of<M::identity><u64>($t0, result0());
+      ensures Eq<u64>(result0(), $t0);
     }
 
     private fun test_ensures_generic_inferred(x: u64): u64 {
         M::identity<u64>(x)
     }
     spec {
-      ensures ensures_of<M::identity><u64>($t0, result0());
+      ensures Eq<_>(result0(), $t0);
     }
 
     private fun test_ensures_generic_unit(x: u64) {
         M::generic_noop<u64>(x)
     }
     spec {
-      ensures ensures_of<M::generic_noop><u64>($t0);
+      ensures true;
     }
 
     private fun test_ensures_multi(x: u64): (u64, u64) {
         M::split(x)
     }
     spec {
-      ensures ensures_of<M::split>($t0, result0(), result1());
+      ensures Eq<num>(Add(result0(), result1()), $t0);
     }
 
     private fun test_ensures_unary(x: u64): u64 {
         M::increment(x)
     }
     spec {
-      ensures ensures_of<M::increment>($t0, result0());
+      ensures Eq<u64>(result0(), Add($t0, 1));
     }
 
     private fun test_ensures_unit(x: u64) {
         M::do_nothing(x)
     }
     spec {
-      ensures ensures_of<M::do_nothing>($t0);
+      ensures true;
     }
 
     private fun test_mixed_params(x: u64,b: bool): u64 {
         M::mixed_params(x, b)
     }
     spec {
-      ensures requires_of<M::mixed_params>($t0, $t1);
-      ensures ensures_of<M::mixed_params>($t0, $t1, result0());
+      ensures true;
+      ensures true;
     }
 
     private fun test_modifies_multi(addr1: address,addr2: address)
@@ -222,7 +185,7 @@ module 0x42::M {
         M::swap_counters(addr1, addr2)
     }
     spec {
-      ensures modifies_of<M::swap_counters>(global<0x42::M::Counter>($t0), global<0x42::M::Counter>($t1));
+      ensures true;
     }
 
     private fun test_modifies_single(addr: address)
@@ -231,67 +194,67 @@ module 0x42::M {
         M::increment_counter(addr)
     }
     spec {
-      ensures modifies_of<M::increment_counter>(global<0x42::M::Counter>($t0));
+      ensures true;
     }
 
     private fun test_pair_generic_explicit(x: u64,y: bool): (u64, bool) {
         M::pair<u64, bool>(x, y)
     }
     spec {
-      ensures requires_of<M::pair><u64, bool>($t0, $t1);
-      ensures ensures_of<M::pair><u64, bool>($t0, $t1, result0(), result1());
+      ensures true;
+      ensures And<u64>(Eq<u64>(result0(), $t0), Eq<bool>(result1(), $t1));
     }
 
     private fun test_requires_binary(a: u64,b: u64): u64 {
         M::add(a, b)
     }
     spec {
-      ensures requires_of<M::add>($t0, $t1);
+      ensures Le(Add($t0, $t1), 18446744073709551615);
     }
 
     private fun test_requires_generic_explicit(x: u64): u64 {
         M::identity<u64>(x)
     }
     spec {
-      ensures requires_of<M::identity><u64>($t0);
+      ensures true;
     }
 
     private fun test_requires_generic_inferred(x: u64): u64 {
         M::identity<u64>(x)
     }
     spec {
-      ensures requires_of<M::identity><u64>($t0);
+      ensures true;
     }
 
     private fun test_requires_unary(x: u64): u64 {
         M::increment(x)
     }
     spec {
-      ensures requires_of<M::increment>($t0);
+      ensures Lt($t0, 18446744073709551615);
     }
 
     private fun test_swap_generic_explicit(a: u64,b: u64): (u64, u64) {
         M::swap<u64>(a, b)
     }
     spec {
-      ensures requires_of<M::swap><u64>($t0, $t1);
-      ensures ensures_of<M::swap><u64>($t0, $t1, result0(), result1());
+      ensures true;
+      ensures And<u64>(Eq<u64>(result0(), $t1), Eq<u64>(result1(), $t0));
     }
 
     private fun test_swap_generic_inferred(a: u64,b: u64): (u64, u64) {
         M::swap<u64>(a, b)
     }
     spec {
-      ensures requires_of<M::swap><u64>($t0, $t1);
-      ensures ensures_of<M::swap><u64>($t0, $t1, result0(), result1());
+      ensures true;
+      ensures And<_>(Eq<_>(result0(), $t1), Eq<_>(result1(), $t0));
     }
 
     private fun test_unbox_inferred(b: Box<u64>): u64 {
         M::unbox<u64>(b)
     }
     spec {
-      ensures requires_of<M::unbox><u64>($t0);
-      ensures ensures_of<M::unbox><u64>($t0, result0());
+      ensures true;
+      ensures Eq<_>(result0(), select M::Box.value<0x42::M::Box<_>>($t0));
     }
 
     public fun unbox<T>(b: Box<T>): T {
@@ -308,16 +271,16 @@ module 0x42::N {
         M::add(a, b)
     }
     spec {
-      ensures requires_of<M::add>($t0, $t1);
-      ensures ensures_of<M::add>($t0, $t1, result0());
+      ensures Le(Add($t0, $t1), 18446744073709551615);
+      ensures Eq<u64>(result0(), Add($t0, $t1));
     }
 
     private fun call_increment(x: u64): u64 {
         M::increment(x)
     }
     spec {
-      ensures requires_of<M::increment>($t0);
-      ensures ensures_of<M::increment>($t0, result0());
+      ensures Lt($t0, 18446744073709551615);
+      ensures Eq<u64>(result0(), Add($t0, 1));
     }
 
 } // end 0x42::N
@@ -335,21 +298,6 @@ module 0x42::M {
     }
     public fun add(a: u64, b: u64): u64 {
         a + b
-    }
-    fun apply_aborts(f: |u64|u64, x: u64): u64 {
-        f(x)
-    }
-    fun apply_binary(f: |u64, u64|u64, a: u64, b: u64): u64 {
-        f(a, b)
-    }
-    fun apply_ensures(f: |u64|u64, x: u64): u64 {
-        f(x)
-    }
-    fun apply_modifies(f: |address|, addr: address) {
-        f(addr)
-    }
-    fun apply_requires(f: |u64|u64, x: u64): u64 {
-        f(x)
     }
     fun do_nothing(_x: u64) {
     }
@@ -484,47 +432,6 @@ public fun M::add($t0: u64, $t1: u64): u64 {
   0: $t3 := infer($t0)
   1: $t2 := +($t3, $t1)
   2: return $t2
-}
-
-
-[variant baseline]
-fun M::apply_aborts($t0: |u64|u64, $t1: u64): u64 {
-     var $t2: u64
-  0: $t2 := invoke($t1, $t0)
-  1: return $t2
-}
-
-
-[variant baseline]
-fun M::apply_binary($t0: |u64, u64|u64, $t1: u64, $t2: u64): u64 {
-     var $t3: u64
-     var $t4: u64
-  0: $t4 := infer($t1)
-  1: $t3 := invoke($t4, $t2, $t0)
-  2: return $t3
-}
-
-
-[variant baseline]
-fun M::apply_ensures($t0: |u64|u64, $t1: u64): u64 {
-     var $t2: u64
-  0: $t2 := invoke($t1, $t0)
-  1: return $t2
-}
-
-
-[variant baseline]
-fun M::apply_modifies($t0: |address|, $t1: address) {
-  0: invoke($t1, $t0)
-  1: return ()
-}
-
-
-[variant baseline]
-fun M::apply_requires($t0: |u64|u64, $t1: u64): u64 {
-     var $t2: u64
-  0: $t2 := invoke($t1, $t0)
-  1: return $t2
 }
 
 
@@ -892,43 +799,6 @@ module 0x42::M {
       ensures Eq<u64>(result0(), Add($t0, $t1));
     }
 
-    private fun apply_aborts(f: |u64|u64,x: u64): u64 {
-        (f)(x)
-    }
-    spec {
-      aborts_if aborts_of<f>($t1);
-    }
-
-    private fun apply_binary(f: |u64, u64|u64,a: u64,b: u64): u64 {
-        (f)(a, b)
-    }
-    spec {
-      ensures requires_of<f>($t1, $t2);
-      ensures ensures_of<f>($t1, $t2, result0());
-      aborts_if aborts_of<f>($t1, $t2);
-    }
-
-    private fun apply_ensures(f: |u64|u64,x: u64): u64 {
-        (f)(x)
-    }
-    spec {
-      ensures ensures_of<f>($t1, result0());
-    }
-
-    private fun apply_modifies(f: |address|,addr: address) {
-        (f)(addr)
-    }
-    spec {
-      ensures modifies_of<f>(global<0x42::M::Counter>($t1));
-    }
-
-    private fun apply_requires(f: |u64|u64,x: u64): u64 {
-        (f)(x)
-    }
-    spec {
-      ensures requires_of<f>($t1);
-    }
-
     private fun do_nothing(_x: u64) {
         Tuple()
     }
@@ -1012,78 +882,78 @@ module 0x42::M {
         M::increment(x)
     }
     spec {
-      aborts_if aborts_of<M::increment>($t0);
+      aborts_if false;
     }
 
     private fun test_aborts_generic_explicit(x: u64): u64 {
         M::identity<u64>(x)
     }
     spec {
-      aborts_if aborts_of<M::identity><u64>($t0);
+      aborts_if false;
     }
 
     private fun test_aborts_generic_inferred(x: u64): u64 {
         M::identity<u64>(x)
     }
     spec {
-      aborts_if aborts_of<M::identity><u64>($t0);
+      aborts_if false;
     }
 
     private fun test_ensures_binary(a: u64,b: u64): u64 {
         M::add(a, b)
     }
     spec {
-      ensures ensures_of<M::add>($t0, $t1, result0());
+      ensures Eq<u64>(result0(), Add($t0, $t1));
     }
 
     private fun test_ensures_generic_explicit(x: u64): u64 {
         M::identity<u64>(x)
     }
     spec {
-      ensures ensures_of<M::identity><u64>($t0, result0());
+      ensures Eq<u64>(result0(), $t0);
     }
 
     private fun test_ensures_generic_inferred(x: u64): u64 {
         M::identity<u64>(x)
     }
     spec {
-      ensures ensures_of<M::identity><u64>($t0, result0());
+      ensures Eq<_>(result0(), $t0);
     }
 
     private fun test_ensures_generic_unit(x: u64) {
         M::generic_noop<u64>(x)
     }
     spec {
-      ensures ensures_of<M::generic_noop><u64>($t0);
+      ensures true;
     }
 
     private fun test_ensures_multi(x: u64): (u64, u64) {
         M::split(x)
     }
     spec {
-      ensures ensures_of<M::split>($t0, result0(), result1());
+      ensures Eq<num>(Add(result0(), result1()), $t0);
     }
 
     private fun test_ensures_unary(x: u64): u64 {
         M::increment(x)
     }
     spec {
-      ensures ensures_of<M::increment>($t0, result0());
+      ensures Eq<u64>(result0(), Add($t0, 1));
     }
 
     private fun test_ensures_unit(x: u64) {
         M::do_nothing(x)
     }
     spec {
-      ensures ensures_of<M::do_nothing>($t0);
+      ensures true;
     }
 
     private fun test_mixed_params(x: u64,b: bool): u64 {
         M::mixed_params(x, b)
     }
     spec {
-      ensures requires_of<M::mixed_params>($t0, $t1);
-      ensures ensures_of<M::mixed_params>($t0, $t1, result0());
+      ensures true;
+      ensures true;
     }
 
     private fun test_modifies_multi(addr1: address,addr2: address)
@@ -1092,7 +962,7 @@ module 0x42::M {
         M::swap_counters(addr1, addr2)
     }
     spec {
-      ensures modifies_of<M::swap_counters>(global<0x42::M::Counter>($t0), global<0x42::M::Counter>($t1));
+      ensures true;
     }
 
     private fun test_modifies_single(addr: address)
@@ -1101,67 +971,67 @@ module 0x42::M {
         M::increment_counter(addr)
     }
     spec {
-      ensures modifies_of<M::increment_counter>(global<0x42::M::Counter>($t0));
+      ensures true;
     }
 
     private fun test_pair_generic_explicit(x: u64,y: bool): (u64, bool) {
         M::pair<u64, bool>(x, y)
     }
     spec {
-      ensures requires_of<M::pair><u64, bool>($t0, $t1);
-      ensures ensures_of<M::pair><u64, bool>($t0, $t1, result0(), result1());
+      ensures true;
+      ensures And<u64>(Eq<u64>(result0(), $t0), Eq<bool>(result1(), $t1));
     }
 
     private fun test_requires_binary(a: u64,b: u64): u64 {
         M::add(a, b)
     }
     spec {
-      ensures requires_of<M::add>($t0, $t1);
+      ensures Le(Add($t0, $t1), 18446744073709551615);
     }
 
     private fun test_requires_generic_explicit(x: u64): u64 {
         M::identity<u64>(x)
     }
     spec {
-      ensures requires_of<M::identity><u64>($t0);
+      ensures true;
     }
 
     private fun test_requires_generic_inferred(x: u64): u64 {
         M::identity<u64>(x)
     }
     spec {
-      ensures requires_of<M::identity><u64>($t0);
+      ensures true;
     }
 
     private fun test_requires_unary(x: u64): u64 {
         M::increment(x)
     }
     spec {
-      ensures requires_of<M::increment>($t0);
+      ensures Lt($t0, 18446744073709551615);
     }
 
     private fun test_swap_generic_explicit(a: u64,b: u64): (u64, u64) {
         M::swap<u64>(a, b)
     }
     spec {
-      ensures requires_of<M::swap><u64>($t0, $t1);
-      ensures ensures_of<M::swap><u64>($t0, $t1, result0(), result1());
+      ensures true;
+      ensures And<u64>(Eq<u64>(result0(), $t1), Eq<u64>(result1(), $t0));
     }
 
     private fun test_swap_generic_inferred(a: u64,b: u64): (u64, u64) {
         M::swap<u64>(a, b)
     }
     spec {
-      ensures requires_of<M::swap><u64>($t0, $t1);
-      ensures ensures_of<M::swap><u64>($t0, $t1, result0(), result1());
+      ensures true;
+      ensures And<_>(Eq<_>(result0(), $t1), Eq<_>(result1(), $t0));
     }
 
     private fun test_unbox_inferred(b: Box<u64>): u64 {
         M::unbox<u64>(b)
     }
     spec {
-      ensures requires_of<M::unbox><u64>($t0);
-      ensures ensures_of<M::unbox><u64>($t0, result0());
+      ensures true;
+      ensures Eq<_>(result0(), select M::Box.value<0x42::M::Box<_>>($t0));
     }
 
     public fun unbox<T>(b: Box<T>): T {
@@ -1178,16 +1048,16 @@ module 0x42::N {
         M::add(a, b)
     }
     spec {
-      ensures requires_of<M::add>($t0, $t1);
-      ensures ensures_of<M::add>($t0, $t1, result0());
+      ensures Le(Add($t0, $t1), 18446744073709551615);
+      ensures Eq<u64>(result0(), Add($t0, $t1));
     }
 
     private fun call_increment(x: u64): u64 {
         M::increment(x)
     }
     spec {
-      ensures requires_of<M::increment>($t0);
-      ensures ensures_of<M::increment>($t0, result0());
+      ensures Lt($t0, 18446744073709551615);
+      ensures Eq<u64>(result0(), Add($t0, 1));
     }
 
 } // end 0x42::N
@@ -1211,47 +1081,6 @@ public fun M::add($t0: u64, $t1: u64): u64 {
   0: $t3 := infer($t0)
   1: $t2 := +($t3, $t1)
   2: return $t2
-}
-
-
-[variant baseline]
-fun M::apply_aborts($t0: |u64|u64, $t1: u64): u64 {
-     var $t2: u64
-  0: $t2 := invoke($t1, $t0)
-  1: return $t2
-}
-
-
-[variant baseline]
-fun M::apply_binary($t0: |u64, u64|u64, $t1: u64, $t2: u64): u64 {
-     var $t3: u64
-     var $t4: u64
-  0: $t4 := infer($t1)
-  1: $t3 := invoke($t4, $t2, $t0)
-  2: return $t3
-}
-
-
-[variant baseline]
-fun M::apply_ensures($t0: |u64|u64, $t1: u64): u64 {
-     var $t2: u64
-  0: $t2 := invoke($t1, $t0)
-  1: return $t2
-}
-
-
-[variant baseline]
-fun M::apply_modifies($t0: |address|, $t1: address) {
-  0: invoke($t1, $t0)
-  1: return ()
-}
-
-
-[variant baseline]
-fun M::apply_requires($t0: |u64|u64, $t1: u64): u64 {
-     var $t2: u64
-  0: $t2 := invoke($t1, $t0)
-  1: return $t2
 }
 
 
@@ -1619,62 +1448,26 @@ struct Counter has key
     ret
 
 // Function definition at index 2
-fun apply_aborts(l0: |u64|u64, l1: u64): u64
-    move_loc l1
-    move_loc l0
-    call_closure <|u64|u64>
-    ret
-
-// Function definition at index 3
-fun apply_binary(l0: |u64, u64|u64, l1: u64, l2: u64): u64
-    move_loc l1
-    move_loc l2
-    move_loc l0
-    call_closure <|u64, u64|u64>
-    ret
-
-// Function definition at index 4
-fun apply_ensures(l0: |u64|u64, l1: u64): u64
-    move_loc l1
-    move_loc l0
-    call_closure <|u64|u64>
-    ret
-
-// Function definition at index 5
-fun apply_modifies(l0: |address|, l1: address)
-    move_loc l1
-    move_loc l0
-    call_closure <|address|>
-    ret
-
-// Function definition at index 6
-fun apply_requires(l0: |u64|u64, l1: u64): u64
-    move_loc l1
-    move_loc l0
-    call_closure <|u64|u64>
-    ret
-
-// Function definition at index 7
 fun do_nothing(l0: u64)
     ret
 
-// Function definition at index 8
+// Function definition at index 3
 fun generic_noop<T0: drop>(l0: T0)
     ret
 
-// Function definition at index 9
+// Function definition at index 4
 #[persistent] public fun identity<T0>(l0: T0): T0
     move_loc l0
     ret
 
-// Function definition at index 10
+// Function definition at index 5
 #[persistent] public fun increment(l0: u64): u64
     move_loc l0
     ld_u64 1
     add
     ret
 
-// Function definition at index 11
+// Function definition at index 6
 #[persistent] public fun increment_counter(l0: address) acquires Counter
     local l1: &mut Counter
     move_loc l0
@@ -1692,7 +1485,7 @@ fun generic_noop<T0: drop>(l0: T0)
     write_ref
     ret
 
-// Function definition at index 12
+// Function definition at index 7
 fun mixed_params(l0: u64, l1: bool): u64
     move_loc l1
     br_false l0
@@ -1704,13 +1497,13 @@ fun mixed_params(l0: u64, l1: bool): u64
 l0: move_loc l0
     ret
 
-// Function definition at index 13
+// Function definition at index 8
 #[persistent] public fun pair<T0, T1>(l0: T0, l1: T1): (T0, T1)
     move_loc l0
     move_loc l1
     ret
 
-// Function definition at index 14
+// Function definition at index 9
 fun split(l0: u64): (u64, u64)
     copy_loc l0
     ld_u64 2
@@ -1723,7 +1516,7 @@ fun split(l0: u64): (u64, u64)
     sub
     ret
 
-// Function definition at index 15
+// Function definition at index 10
 #[persistent] public fun swap_counters(l0: address, l1: address) acquires Counter
     copy_loc l0
     borrow_global Counter
@@ -1746,140 +1539,140 @@ fun split(l0: u64): (u64, u64)
     write_ref
     ret
 
-// Function definition at index 16
+// Function definition at index 11
 fun test_aborts(l0: u64): u64
     move_loc l0
     call increment
     ret
 
-// Function definition at index 17
+// Function definition at index 12
 fun test_aborts_generic_explicit(l0: u64): u64
     move_loc l0
     call identity<u64>
     ret
 
-// Function definition at index 18
+// Function definition at index 13
 fun test_aborts_generic_inferred(l0: u64): u64
     move_loc l0
     call identity<u64>
     ret
 
-// Function definition at index 19
+// Function definition at index 14
 fun test_ensures_binary(l0: u64, l1: u64): u64
     move_loc l0
     move_loc l1
     call add
     ret
 
-// Function definition at index 20
+// Function definition at index 15
 fun test_ensures_generic_explicit(l0: u64): u64
     move_loc l0
     call identity<u64>
     ret
 
-// Function definition at index 21
+// Function definition at index 16
 fun test_ensures_generic_inferred(l0: u64): u64
     move_loc l0
     call identity<u64>
     ret
 
-// Function definition at index 22
+// Function definition at index 17
 fun test_ensures_generic_unit(l0: u64)
     move_loc l0
     call generic_noop<u64>
     ret
 
-// Function definition at index 23
+// Function definition at index 18
 fun test_ensures_multi(l0: u64): (u64, u64)
     move_loc l0
     call split
     ret
 
-// Function definition at index 24
+// Function definition at index 19
 fun test_ensures_unary(l0: u64): u64
     move_loc l0
     call increment
     ret
 
-// Function definition at index 25
+// Function definition at index 20
 fun test_ensures_unit(l0: u64)
     move_loc l0
     call do_nothing
     ret
 
-// Function definition at index 26
+// Function definition at index 21
 fun test_mixed_params(l0: u64, l1: bool): u64
     move_loc l0
     move_loc l1
     call mixed_params
     ret
 
-// Function definition at index 27
+// Function definition at index 22
 fun test_modifies_multi(l0: address, l1: address) acquires Counter
     move_loc l0
     move_loc l1
     call swap_counters
     ret
 
-// Function definition at index 28
+// Function definition at index 23
 fun test_modifies_single(l0: address) acquires Counter
     move_loc l0
     call increment_counter
     ret
 
-// Function definition at index 29
+// Function definition at index 24
 fun test_pair_generic_explicit(l0: u64, l1: bool): (u64, bool)
     move_loc l0
     move_loc l1
     call pair<u64, bool>
     ret
 
-// Function definition at index 30
+// Function definition at index 25
 fun test_requires_binary(l0: u64, l1: u64): u64
     move_loc l0
     move_loc l1
     call add
     ret
 
-// Function definition at index 31
+// Function definition at index 26
 fun test_requires_generic_explicit(l0: u64): u64
     move_loc l0
     call identity<u64>
     ret
 
-// Function definition at index 32
+// Function definition at index 27
 fun test_requires_generic_inferred(l0: u64): u64
     move_loc l0
     call identity<u64>
     ret
 
-// Function definition at index 33
+// Function definition at index 28
 fun test_requires_unary(l0: u64): u64
     move_loc l0
     call increment
     ret
 
-// Function definition at index 34
+// Function definition at index 29
 fun test_swap_generic_explicit(l0: u64, l1: u64): (u64, u64)
     move_loc l0
     move_loc l1
     call swap<u64>
     ret
 
-// Function definition at index 35
+// Function definition at index 30
 fun test_swap_generic_inferred(l0: u64, l1: u64): (u64, u64)
     move_loc l0
     move_loc l1
     call swap<u64>
     ret
 
-// Function definition at index 36
+// Function definition at index 31
 fun test_unbox_inferred(l0: Box<u64>): u64
     move_loc l0
     call unbox<u64>
     ret
 
-// Function definition at index 37
+// Function definition at index 32
 #[persistent] public fun unbox<T0: copy + drop>(l0: Box<T0>): T0
     borrow_loc l0
     borrow_field Box<T0>, value

--- a/third_party/move/move-compiler-v2/tests/checking-lang-v2.4/specs/behavior_predicates_static_valid.move
+++ b/third_party/move/move-compiler-v2/tests/checking-lang-v2.4/specs/behavior_predicates_static_valid.move
@@ -349,57 +349,6 @@ module 0x42::M {
         ensures requires_of<unbox>(b);
         ensures ensures_of<unbox>(b, result);
     }
-
-    // ========================================
-    // Tests: Function parameters (no type args allowed)
-    // ========================================
-
-    // Test requires_of with function parameter
-    fun apply_requires(f: |u64| u64, x: u64): u64 {
-        f(x)
-    }
-
-    spec apply_requires {
-        ensures requires_of<f>(x);
-    }
-
-    // Test aborts_of with function parameter
-    fun apply_aborts(f: |u64| u64, x: u64): u64 {
-        f(x)
-    }
-
-    spec apply_aborts {
-        aborts_if aborts_of<f>(x);
-    }
-
-    // Test ensures_of with function parameter
-    fun apply_ensures(f: |u64| u64, x: u64): u64 {
-        f(x)
-    }
-
-    spec apply_ensures {
-        ensures ensures_of<f>(x, result);
-    }
-
-    // Test with binary function parameter
-    fun apply_binary(f: |u64, u64| u64, a: u64, b: u64): u64 {
-        f(a, b)
-    }
-
-    spec apply_binary {
-        ensures requires_of<f>(a, b);
-        ensures ensures_of<f>(a, b, result);
-        aborts_if aborts_of<f>(a, b);
-    }
-
-    // Test modifies_of with function parameter
-    fun apply_modifies(f: |address|, addr: address) {
-        f(addr)
-    }
-
-    spec apply_modifies {
-        ensures modifies_of<f>(global<Counter>(addr));
-    }
 }
 
 // Test cross-module function references

--- a/third_party/move/move-prover/bytecode-pipeline/src/mono_analysis.rs
+++ b/third_party/move/move-prover/bytecode-pipeline/src/mono_analysis.rs
@@ -594,8 +594,8 @@ impl Analyzer<'_> {
             Type::Vector(et) => {
                 self.info.vec_inst.insert(et.as_ref().clone());
             },
-            Type::Tuple(elems) if elems.len() >= 2 && elems.len() <= 8 => {
-                // Only collect tuples with valid size (2-8 elements, matching MAX_TUPLE_SIZE)
+            Type::Tuple(elems) if elems.len() >= 2 => {
+                // Only collect proper tuples, tuples of size 0 and 1 do not exist.
                 self.info.tuple_inst.insert(elems.clone());
             },
             Type::Struct(mid, sid, targs) => {


### PR DESCRIPTION
## Summary

This implements the spec rewriter pass for behavioral predicates (`requires_of`, `aborts_of`, `ensures_of`, `modifies_of`).

- For **known function targets**, behavioral predicates are reduced to their corresponding specification conditions by inlining the target function's spec
- For **function-typed parameter targets**, uninterpreted specification functions are generated (e.g., `$requires_of$apply$f`) that represent the behavioral predicate semantically
- `modifies_of` is not supported for parameter targets and produces a compile error

## Test plan

- Existing `behavior_predicates_valid` tests verify reduction for known function targets
- New `behavior_predicates_param` tests verify uninterpreted spec function generation for parameter targets
- Error handling tests verify appropriate compile errors

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces behavioral predicate handling in the spec rewriter and supporting utilities.
> 
> - Reduce `requires_of/aborts_of/ensures_of/modifies_of` on known function targets to plain predicates via `SpecTranslator` in `spec_rewriter.rs`
> - For function-typed parameter targets, auto-generate uninterpreted spec functions (e.g., `$requires_of$apply$f`); `modifies_of` on parameters now errors
> - Add minimal `BehaviorExpGenerator` and extend `ExpBuilder` with `bool_const`, `and_n`, `or_n`
> - Update monomorphization: collect tuple instantiations for tuples of size ≥2 (remove 8-elem cap)
> - Add/adjust tests: new `behavior_predicates_param_{valid,err}`; update `behavior_predicates_static_valid` expectations
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f659764732180b6f64518f29d6aa50ad747e2d93. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->