### PR TITLE
[Hot State] Enable pruner for hot state merkle db

### DIFF
--- a/storage/aptosdb/src/db/aptosdb_reader.rs
+++ b/storage/aptosdb/src/db/aptosdb_reader.rs
@@ -926,6 +926,7 @@ impl DbReader for AptosDB {
             Ok(self
                 .state_store
                 .state_db
+                .state_pruner
                 .state_merkle_pruner
                 .is_pruner_enabled())
         })
@@ -936,6 +937,7 @@ impl DbReader for AptosDB {
             Ok(self
                 .state_store
                 .state_db
+                .state_pruner
                 .epoch_snapshot_pruner
                 .get_prune_window() as usize)
         })

--- a/storage/aptosdb/src/db/aptosdb_test.rs
+++ b/storage/aptosdb/src/db/aptosdb_test.rs
@@ -128,6 +128,7 @@ fn test_error_if_version_pruned() {
     let db = AptosDB::new_for_test(&tmp_dir);
     db.state_store
         .state_db
+        .state_pruner
         .state_merkle_pruner
         .save_min_readable_version(5)
         .unwrap();
@@ -292,8 +293,8 @@ pub fn test_state_merkle_pruning_impl(
             .collect();
 
         // Prune till the oldest snapshot readable.
-        let pruner = &db.state_store.state_db.state_merkle_pruner;
-        let epoch_snapshot_pruner = &db.state_store.state_db.epoch_snapshot_pruner;
+        let pruner = &db.state_store.state_db.state_pruner.state_merkle_pruner;
+        let epoch_snapshot_pruner = &db.state_store.state_db.state_pruner.epoch_snapshot_pruner;
         pruner.set_worker_target_version(*snapshots.first().unwrap());
         epoch_snapshot_pruner.set_worker_target_version(std::cmp::min(
             *snapshots.first().unwrap(),

--- a/storage/aptosdb/src/db/aptosdb_writer.rs
+++ b/storage/aptosdb/src/db/aptosdb_writer.rs
@@ -224,12 +224,15 @@ impl DbWriter for AptosDB {
 
             self.ledger_pruner.save_min_readable_version(version)?;
             self.state_store
+                .state_pruner
                 .state_merkle_pruner
                 .save_min_readable_version(version)?;
             self.state_store
+                .state_pruner
                 .epoch_snapshot_pruner
                 .save_min_readable_version(version)?;
             self.state_store
+                .state_pruner
                 .state_kv_pruner
                 .save_min_readable_version(version)?;
 
@@ -628,6 +631,7 @@ impl AptosDB {
             self.ledger_pruner
                 .maybe_set_pruner_target_db_version(version);
             self.state_store
+                .state_pruner
                 .state_kv_pruner
                 .maybe_set_pruner_target_db_version(version);
 

--- a/storage/aptosdb/src/state_store/state_merkle_batch_committer.rs
+++ b/storage/aptosdb/src/state_store/state_merkle_batch_committer.rs
@@ -88,12 +88,18 @@ impl StateMerkleBatchCommitter {
                         "State snapshot committed."
                     );
                     LATEST_SNAPSHOT_VERSION.set(current_version as i64);
-                    // TODO(HotState): no pruning for hot state right now, since we always reset it
-                    // upon restart.
+                    if let Some(pruner) = &self.state_db.state_pruner.hot_state_merkle_pruner {
+                        pruner.maybe_set_pruner_target_db_version(current_version);
+                    }
+                    if let Some(pruner) = &self.state_db.state_pruner.hot_epoch_snapshot_pruner {
+                        pruner.maybe_set_pruner_target_db_version(current_version);
+                    }
                     self.state_db
+                        .state_pruner
                         .state_merkle_pruner
                         .maybe_set_pruner_target_db_version(current_version);
                     self.state_db
+                        .state_pruner
                         .epoch_snapshot_pruner
                         .maybe_set_pruner_target_db_version(current_version);
 


### PR DESCRIPTION

Just instantiate two more pruners, since we need to prune the hot state merkle
db as well. They share the same config with the existing state merkle db
pruners, since the window size should be the same.

Slight refactor to put all state db related pruners in a struct, since clippy is
(rightfully) complaining about having too many arguments in a few functions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds pruning support for the hot state merkle DB and refactors state pruner wiring.
> 
> - Introduces `StatePruner` to group `state_merkle_pruner`, `epoch_snapshot_pruner`, `state_kv_pruner`, plus new optional `hot_state_merkle_pruner` and `hot_epoch_snapshot_pruner`
> - Wires pruner creation in `AptosDB::new_with_dbs`/`StateStore::new` and debugger path; updates accesses via `state_pruner`
> - On startup and snapshot commit, sets pruner target versions for all relevant pruners; persists min readable versions in writer
> - Updates reader/error checks to reference pruners through `state_pruner`; adjusts tests accordingly
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eee11f0668cf0d67a18719b53c7e885cd8f2a4b5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->