### PR TITLE
[prover] Support tuple results in spec functions

### DIFF
--- a/third_party/move/move-prover/boogie-backend/src/prelude/prelude.bpl
+++ b/third_party/move/move-prover/boogie-backend/src/prelude/prelude.bpl
@@ -460,6 +460,43 @@ datatype $Memory<T> {
     $Memory(domain: [int]bool, contents: [int]T)
 }
 
+// Tuple Types (2-8 elements) for spec functions returning multiple values
+datatype $Tuple2<T1, T2> {
+    $Tuple2($0: T1, $1: T2)
+}
+
+datatype $Tuple3<T1, T2, T3> {
+    $Tuple3($0: T1, $1: T2, $2: T3)
+}
+
+datatype $Tuple4<T1, T2, T3, T4> {
+    $Tuple4($0: T1, $1: T2, $2: T3, $3: T4)
+}
+
+datatype $Tuple5<T1, T2, T3, T4, T5> {
+    $Tuple5($0: T1, $1: T2, $2: T3, $3: T4, $4: T5)
+}
+
+datatype $Tuple6<T1, T2, T3, T4, T5, T6> {
+    $Tuple6($0: T1, $1: T2, $2: T3, $3: T4, $4: T5, $5: T6)
+}
+
+datatype $Tuple7<T1, T2, T3, T4, T5, T6, T7> {
+    $Tuple7($0: T1, $1: T2, $2: T3, $3: T4, $4: T5, $5: T6, $6: T7)
+}
+
+datatype $Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> {
+    $Tuple8($0: T1, $1: T2, $2: T3, $3: T4, $4: T5, $5: T6, $6: T7, $7: T8)
+}
+
+{%- for tuple in tuple_instances %}
+
+function {:inline} $IsValid'$tup{{tuple.arity}}'{{tuple.suffix}}''(t: $Tuple{{tuple.arity}}{% for e in tuple.elements %} {{e.name}}{% endfor %}): bool {
+    {% for e in tuple.elements %}$IsValid'{{e.suffix}}'(t->${{loop.index0}}){% if not loop.last %} && {% endif %}{% endfor %}
+
+}
+{%- endfor %}
+
 function {:builtin "MapConst"} $ConstMemoryDomain(v: bool): [int]bool;
 function {:builtin "MapConst"} $ConstMemoryContent<T>(v: T): [int]T;
 axiom $ConstMemoryDomain(false) == (lambda i: int :: false);

--- a/third_party/move/move-prover/bytecode-pipeline/src/mono_analysis.rs
+++ b/third_party/move/move-prover/bytecode-pipeline/src/mono_analysis.rs
@@ -43,6 +43,7 @@ pub struct MonoInfo {
     pub spec_vars: BTreeMap<QualifiedId<SpecVarId>, BTreeSet<Vec<Type>>>,
     pub type_params: BTreeSet<u16>,
     pub vec_inst: BTreeSet<Type>,
+    pub tuple_inst: BTreeSet<Vec<Type>>,
     pub table_inst: BTreeMap<QualifiedId<StructId>, BTreeSet<(Type, Type)>>,
     pub native_inst: BTreeMap<ModuleId, BTreeSet<Vec<Type>>>,
     pub all_types: BTreeSet<Type>,
@@ -592,6 +593,10 @@ impl Analyzer<'_> {
             },
             Type::Vector(et) => {
                 self.info.vec_inst.insert(et.as_ref().clone());
+            },
+            Type::Tuple(elems) if elems.len() >= 2 && elems.len() <= 8 => {
+                // Only collect tuples with valid size (2-8 elements, matching MAX_TUPLE_SIZE)
+                self.info.tuple_inst.insert(elems.clone());
             },
             Type::Struct(mid, sid, targs) => {
                 self.add_struct(self.env.get_module(*mid).into_struct(*sid), targs)

--- a/third_party/move/move-prover/tests/sources/functional/loops_with_memory_ops.exp
+++ b/third_party/move/move-prover/tests/sources/functional/loops_with_memory_ops.exp
@@ -46,7 +46,6 @@ error: induction case of the loop invariant does not hold
    =         a = <redacted>
    =     at tests/sources/functional/loops_with_memory_ops.move:81: nested_loop2
    =         b = <redacted>
-   =     at tests/sources/functional/loops_with_memory_ops.move:81: nested_loop2
    =     at tests/sources/functional/loops_with_memory_ops.move:85: nested_loop2
    =         i = <redacted>
    =     at tests/sources/functional/loops_with_memory_ops.move:86: nested_loop2
@@ -108,7 +107,6 @@ error: unknown assertion failed
    =         y = <redacted>
    =     at tests/sources/functional/loops_with_memory_ops.move:80: nested_loop2
    =     at tests/sources/functional/loops_with_memory_ops.move:81: nested_loop2
-   =         a = <redacted>
    =         b = <redacted>
    =     at tests/sources/functional/loops_with_memory_ops.move:85: nested_loop2
    =         i = <redacted>

--- a/third_party/move/move-prover/tests/sources/functional/restrictions.exp
+++ b/third_party/move/move-prover/tests/sources/functional/restrictions.exp
@@ -1,36 +1,30 @@
 Move prover returns: exiting with condition generation errors
-error: [boogie translator] tuple result type not yet supported
+error: [boogie translator] function result type not yet supported
   ┌─ tests/sources/functional/restrictions.move:9:9
   │
-9 │         fun f1(): (u64, u64) { (1u64, 2u64) }
-  │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: [boogie translator] function result type not yet supported
-   ┌─ tests/sources/functional/restrictions.move:12:9
-   │
-12 │         fun f2(): | |num { | | 1 }
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+9 │         fun f2(): | |num { | | 1 }
+  │         ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: [boogie translator] current restriction: a function value cannot be used in a specification expression.
-   ┌─ tests/sources/functional/restrictions.move:16:13
+   ┌─ tests/sources/functional/restrictions.move:13:13
    │
-16 │             f(1u64)
+13 │             f(1u64)
    │             ^^^^^^^
 
-error: [boogie translator] `|x|e` (lambda) currently only supported as argument for `all` or `any`
-   ┌─ tests/sources/functional/restrictions.move:21:21
+error: [boogie translator] lambda not supported in spec expressions
+   ┌─ tests/sources/functional/restrictions.move:18:21
    │
-21 │             let f = |x| x + 1;
+18 │             let f = |x| x + 1;
    │                     ^^^^^^^^^
 
 error: bug: operation closure#0M::__lambda__1__use_them is not supported in the current context
-   ┌─ tests/sources/functional/restrictions.move:50:20
+   ┌─ tests/sources/functional/restrictions.move:46:20
    │
-50 │         ensures f3(|x|x) == f3(|x|x);
+46 │         ensures f3(|x|x) == f3(|x|x);
    │                    ^^^^
 
 error: bug: operation closure#0M::__lambda__2__use_them is not supported in the current context
-   ┌─ tests/sources/functional/restrictions.move:50:32
+   ┌─ tests/sources/functional/restrictions.move:46:32
    │
-50 │         ensures f3(|x|x) == f3(|x|x);
+46 │         ensures f3(|x|x) == f3(|x|x);
    │                                ^^^^

--- a/third_party/move/move-prover/tests/sources/functional/restrictions.move
+++ b/third_party/move/move-prover/tests/sources/functional/restrictions.move
@@ -5,9 +5,6 @@ module 0x42::M {
         f: u64
     }
     spec module {
-        // Tuples as result type.
-        fun f1(): (u64, u64) { (1u64, 2u64) }
-
         // Functions as result type.
         fun f2(): | |num { | | 1 }
 
@@ -42,10 +39,9 @@ module 0x42::M {
         //}
     }
 
-    /// Need to use the specctions, otherwise the monomorphizer will eliminate them.
+    /// Need to use the spec functions, otherwise the monomorphizer will eliminate them.
     fun use_them(): bool { true }
     spec use_them {
-        ensures f1() == f1();
         ensures f2() == f2();
         ensures f3(|x|x) == f3(|x|x);
         ensures f4() == f4();

--- a/third_party/move/move-prover/tests/sources/functional/spec_fun_tuple.move
+++ b/third_party/move/move-prover/tests/sources/functional/spec_fun_tuple.move
@@ -1,0 +1,101 @@
+// Tests for spec function tuple return types
+module 0x42::TupleTest {
+
+    // === Spec functions returning tuples ===
+
+    // 2-tuple
+    spec fun pair(x: u64, y: u64): (u64, u64) { (x, y) }
+
+    // 3-tuple
+    spec fun triple(x: u64, y: u64, z: u64): (u64, u64, u64) { (x, y, z) }
+
+    // 4-tuple
+    spec fun quad(a: u64, b: u64, c: u64, d: u64): (u64, u64, u64, u64) { (a, b, c, d) }
+
+    // 8-tuple (max size)
+    spec fun octet(a: u64, b: u64, c: u64, d: u64, e: u64, f: u64, g: u64, h: u64):
+        (u64, u64, u64, u64, u64, u64, u64, u64) {
+        (a, b, c, d, e, f, g, h)
+    }
+
+    // Swap using tuple - returns the arguments in reverse order
+    spec fun swap(x: u64, y: u64): (u64, u64) {
+        (y, x)
+    }
+
+    // === Generic spec functions returning tuples ===
+
+    // Generic 2-tuple
+    spec fun generic_pair<T1, T2>(x: T1, y: T2): (T1, T2) { (x, y) }
+
+    // Generic swap
+    spec fun generic_swap<T1, T2>(x: T1, y: T2): (T2, T1) { (y, x) }
+
+    // Mixed generic and concrete types
+    spec fun mixed_pair<T>(x: T, y: u64): (T, u64) { (x, y) }
+
+    // === Test functions with specs ===
+
+    fun test_pair(): bool { true }
+    spec test_pair {
+        // Test tuple equality
+        ensures pair(1, 2) == (1, 2);
+    }
+
+    fun test_triple(): bool { true }
+    spec test_triple {
+        // Test tuple equality
+        ensures triple(1, 2, 3) == (1, 2, 3);
+    }
+
+    fun test_quad(): bool { true }
+    spec test_quad {
+        ensures quad(1, 2, 3, 4) == (1, 2, 3, 4);
+    }
+
+    fun test_octet(): bool { true }
+    spec test_octet {
+        // Test 8-tuple (max size)
+        ensures octet(1, 2, 3, 4, 5, 6, 7, 8) == (1, 2, 3, 4, 5, 6, 7, 8);
+    }
+
+    fun test_swap(): bool { true }
+    spec test_swap {
+        // Test that swap(1, 2) returns (2, 1)
+        ensures swap(1, 2) == (2, 1);
+    }
+
+    // Test that spec functions can be compared
+    fun test_comparison(): bool { true }
+    spec test_comparison {
+        ensures pair(1, 2) == pair(1, 2);
+        ensures triple(1, 2, 3) == triple(1, 2, 3);
+        ensures swap(1, 2) == swap(1, 2);
+    }
+
+    // Test negative case - swapped values are different
+    fun test_swap_neq(): bool { true }
+    spec test_swap_neq {
+        ensures swap(1, 2) != (1, 2);
+    }
+
+    // === Tests for generic spec functions ===
+
+    fun test_generic_pair(): bool { true }
+    spec test_generic_pair {
+        ensures generic_pair<u64, bool>(42, true) == (42, true);
+        ensures generic_pair<address, u128>(@0x1, 100) == (@0x1, 100);
+    }
+
+    fun test_generic_swap(): bool { true }
+    spec test_generic_swap {
+        ensures generic_swap<u64, bool>(42, true) == (true, 42);
+        ensures generic_swap<bool, u64>(true, 42) == (42, true);
+    }
+
+    fun test_mixed_pair(): bool { true }
+    spec test_mixed_pair {
+        ensures mixed_pair<bool>(true, 42) == (true, 42);
+        ensures mixed_pair<address>(@0x1, 100) == (@0x1, 100);
+    }
+}

--- a/third_party/move/move-prover/tests/sources/functional/spec_fun_tuple_errors.exp
+++ b/third_party/move/move-prover/tests/sources/functional/spec_fun_tuple_errors.exp
@@ -1,0 +1,34 @@
+Move prover returns: exiting with condition generation errors
+error: [boogie translator] unit type (empty tuple) not supported
+  ┌─ tests/sources/functional/spec_fun_tuple_errors.move:6:28
+  │
+6 │     spec fun empty(): () { () }
+  │                            ^^
+
+error: [boogie translator] tuple has 9 elements, maximum supported is 8
+   ┌─ tests/sources/functional/spec_fun_tuple_errors.move:12:10
+   │
+12 │       spec fun too_large(a: u64, b: u64, c: u64, d: u64, e: u64,
+   │ ╭──────────^
+13 │ │                        f: u64, g: u64, h: u64, i: u64):
+14 │ │         (u64, u64, u64, u64, u64, u64, u64, u64, u64) {
+15 │ │         (a, b, c, d, e, f, g, h, i)
+16 │ │     }
+   │ ╰─────^
+
+error: [boogie translator] tuple has 10 elements, maximum supported is 8
+   ┌─ tests/sources/functional/spec_fun_tuple_errors.move:19:10
+   │
+19 │       spec fun way_too_large(a: u64, b: u64, c: u64, d: u64, e: u64,
+   │ ╭──────────^
+20 │ │                            f: u64, g: u64, h: u64, i: u64, j: u64):
+21 │ │         (u64, u64, u64, u64, u64, u64, u64, u64, u64, u64) {
+22 │ │         (a, b, c, d, e, f, g, h, i, j)
+23 │ │     }
+   │ ╰─────^
+
+error: [boogie translator] unit type (empty tuple) not supported
+   ┌─ tests/sources/functional/spec_fun_tuple_errors.move:29:28
+   │
+29 │         ensures empty() == ();
+   │                            ^^

--- a/third_party/move/move-prover/tests/sources/functional/spec_fun_tuple_errors.move
+++ b/third_party/move/move-prover/tests/sources/functional/spec_fun_tuple_errors.move
@@ -1,0 +1,35 @@
+// no-boogie-test
+// Tests for spec function tuple error cases
+module 0x42::TupleErrors {
+
+    // Error: 0-tuple (unit type) - not a real tuple
+    spec fun empty(): () { () }
+
+    // Error: 1-tuple - parentheses don't create a tuple, just grouping
+    spec fun single(x: u64): (u64) { (x) }
+
+    // Error: tuple too large (9 elements)
+    spec fun too_large(a: u64, b: u64, c: u64, d: u64, e: u64,
+                       f: u64, g: u64, h: u64, i: u64):
+        (u64, u64, u64, u64, u64, u64, u64, u64, u64) {
+        (a, b, c, d, e, f, g, h, i)
+    }
+
+    // Error: tuple way too large (10 elements)
+    spec fun way_too_large(a: u64, b: u64, c: u64, d: u64, e: u64,
+                           f: u64, g: u64, h: u64, i: u64, j: u64):
+        (u64, u64, u64, u64, u64, u64, u64, u64, u64, u64) {
+        (a, b, c, d, e, f, g, h, i, j)
+    }
+
+    /// Need to use the spec functions, otherwise the monomorphizer will eliminate them.
+    fun use_them(): bool { true }
+    spec use_them {
+        // These are valid - empty() returns unit, single() returns u64
+        ensures empty() == ();
+        ensures single(42) == 42;
+        // These are errors - tuples too large
+        ensures too_large(1, 2, 3, 4, 5, 6, 7, 8, 9) == too_large(1, 2, 3, 4, 5, 6, 7, 8, 9);
+        ensures way_too_large(1, 2, 3, 4, 5, 6, 7, 8, 9, 10) == way_too_large(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+    }
+}


### PR DESCRIPTION
## Summary

Enable spec functions in Move to return tuples (up to 8 elements) by adding Boogie tuple datatypes and updating the type translation and spec translator.

- Add `$Tuple2` through `$Tuple8` datatypes to Boogie prelude
- Update `boogie_type()` and `boogie_bv_type()` to generate tuple types
- Update `boogie_type_suffix_bv()` to generate tuple type suffixes  
- Allow spec functions with tuple return types (up to 8 elements)
- Handle tuple construction with `$Tuple{n}` constructor in specs
- Handle tuple destructuring in let bindings for function calls returning tuples
- Use native Boogie equality for tuple comparisons
- Add test files for tuple functionality and error cases
- Clean up lambda error message in spec expressions

## Test plan

- Added `spec_fun_tuple.move` with positive tests for 2/3/4/8-tuples
- Added `spec_fun_tuple_errors.move` with error tests for tuples > 8 elements
- Updated `restrictions.move` baseline (removed tuple test since now supported)
- All 169 prover tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables tuple return types in Move spec functions with full Boogie backend support.
> 
> - Add `$Tuple2`–`$Tuple8` datatypes and per-instance `$IsValid'...` in `prelude.bpl` (templated via collected `tuple_instances`)
> - Extend type translation: tuple handling in `boogie_type`, `boogie_bv_type`, and tuple suffixes in `boogie_type_suffix_bv`; define `MAX_TUPLE_SIZE = 8`
> - Plumb tuple instance info: new `TupleInfo` struct; gather in `mono_analysis` and inject into prelude context in `lib.rs`
> - Spec translation: allow tuple results (<=8), emit `$Tuple{n}` constructors, support tuple destructuring in `let` bindings, and use native equality for tuples; reject empty/1-tuples and oversize tuples; simplify lambda error text
> - Tests: add positive `spec_fun_tuple.move` and negative `spec_fun_tuple_errors.move`; update baselines (restrictions, loops)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3dfddbbb49ddf776939d6bbe884c304334b28051. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->