### PR TITLE
[cli] Fix MOVE_VM_STEP/MOVE_VM_TRACE for aptos move replay

### DIFF
--- a/crates/aptos/src/common/local_simulation.rs
+++ b/crates/aptos/src/common/local_simulation.rs
@@ -7,7 +7,7 @@ use aptos_gas_profiling::FrameName;
 use aptos_move_debugger::aptos_debugger::AptosDebugger;
 use aptos_types::transaction::{AuxiliaryInfo, PersistedAuxiliaryInfo, SignedTransaction};
 use aptos_vm::{data_cache::AsMoveResolver, AptosVM};
-use aptos_vm_environment::environment::AptosEnvironment;
+use aptos_vm_environment::{environment::AptosEnvironment, prod_configs};
 use aptos_vm_logging::log_schema::AdapterLogSchema;
 use aptos_vm_types::{
     module_and_script_storage::AsAptosCodeStorage, output::VMOutput, resolver::StateStorageView,
@@ -22,6 +22,9 @@ pub fn run_transaction_using_debugger(
     _hash: HashValue,
     persisted_auxiliary_info: PersistedAuxiliaryInfo,
 ) -> CliTypedResult<(VMStatus, VMOutput)> {
+    // Enable debugging so MOVE_VM_STEP and MOVE_VM_TRACE environment variables are recognized.
+    prod_configs::set_debugging_enabled(true);
+
     let state_view = debugger.state_view_at_version(version);
     let env = AptosEnvironment::new(&state_view);
     let vm = AptosVM::new(&env);


### PR DESCRIPTION
## Description

Enable debugging in local_simulation so that the MOVE_VM_STEP and
MOVE_VM_TRACE environment variables are recognized when using
`aptos move replay`. This was broken by PR #18337 which added
a VMConfig.enable_debugging flag that gates the tracing functionality.

## How Has This Been Tested?

Manual testing with `MOVE_VM_STEP=1 aptos move replay`.

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [x] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>