### PR TITLE
[vm] Support abort messages in native functions

### DIFF
--- a/aptos-move/aptos-native-interface/src/builder.rs
+++ b/aptos-move/aptos-native-interface/src/builder.rs
@@ -131,9 +131,14 @@ impl SafeNativeBuilder {
             match res {
                 Ok(ret_vals) => Ok(NativeResult::ok(context.legacy_gas_used, ret_vals)),
                 Err(err) => match err {
-                    Abort { abort_code } => {
-                        Ok(NativeResult::err(context.legacy_gas_used, abort_code))
-                    },
+                    Abort {
+                        abort_code,
+                        abort_message,
+                    } => Ok(NativeResult::Abort {
+                        cost: context.legacy_gas_used,
+                        abort_code,
+                        abort_message,
+                    }),
                     LimitExceeded(err) => match err {
                         LimitExceededError::LegacyOutOfGas => {
                             assert!(!context.has_direct_gas_meter_access_in_native_context());

--- a/aptos-move/aptos-native-interface/src/errors.rs
+++ b/aptos-move/aptos-native-interface/src/errors.rs
@@ -54,7 +54,10 @@ pub enum SafeNativeError {
     ///
     /// Equivalent to aborting in a regular Move function, so the same error convention should
     /// be followed.
-    Abort { abort_code: u64 },
+    Abort {
+        abort_code: u64,
+        abort_message: Option<String>,
+    },
 
     /// Indicating that the native function has exceeded execution limits.
     ///
@@ -92,6 +95,22 @@ pub enum SafeNativeError {
     ///
     /// Note: not used once metering in native context is enabled.
     LoadModule { module_name: ModuleId },
+}
+
+impl SafeNativeError {
+    pub fn abort(abort_code: u64) -> Self {
+        SafeNativeError::Abort {
+            abort_code,
+            abort_message: None,
+        }
+    }
+
+    pub fn abort_with_message(abort_code: u64, abort_message: impl ToString) -> Self {
+        SafeNativeError::Abort {
+            abort_code,
+            abort_message: Some(abort_message.to_string()),
+        }
+    }
 }
 
 // Allows us to keep using the `?` operator on function calls that return `PartialVMResult` inside safe natives.

--- a/aptos-move/framework/move-stdlib/src/natives/bcs.rs
+++ b/aptos-move/framework/move-stdlib/src/natives/bcs.rs
@@ -81,9 +81,7 @@ fn native_to_bytes(
             Ok(layout) => layout,
             Err(_) => {
                 context.charge(BCS_TO_BYTES_FAILURE)?;
-                return Err(SafeNativeError::Abort {
-                    abort_code: NFE_BCS_SERIALIZATION_FAILURE,
-                });
+                return Err(SafeNativeError::abort(NFE_BCS_SERIALIZATION_FAILURE));
             },
         }
     };
@@ -102,9 +100,7 @@ fn native_to_bytes(
         Some(serialized_value) => serialized_value,
         None => {
             context.charge(BCS_TO_BYTES_FAILURE)?;
-            return Err(SafeNativeError::Abort {
-                abort_code: NFE_BCS_SERIALIZATION_FAILURE,
-            });
+            return Err(SafeNativeError::abort(NFE_BCS_SERIALIZATION_FAILURE));
         },
     };
     context
@@ -141,9 +137,7 @@ fn native_serialized_size(
             context.charge(BCS_SERIALIZED_SIZE_FAILURE)?;
 
             // Re-use the same abort code as bcs::to_bytes.
-            return Err(SafeNativeError::Abort {
-                abort_code: NFE_BCS_SERIALIZATION_FAILURE,
-            });
+            return Err(SafeNativeError::abort(NFE_BCS_SERIALIZATION_FAILURE));
         },
     };
     context.charge(BCS_SERIALIZED_SIZE_PER_BYTE_SERIALIZED * NumBytes::new(serialized_size))?;
@@ -193,9 +187,7 @@ fn native_constant_serialized_size(
             context.charge(BCS_SERIALIZED_SIZE_FAILURE)?;
 
             // Re-use the same abort code as bcs::to_bytes.
-            return Err(SafeNativeError::Abort {
-                abort_code: NFE_BCS_SERIALIZATION_FAILURE,
-            });
+            return Err(SafeNativeError::abort(NFE_BCS_SERIALIZATION_FAILURE));
         },
     };
 

--- a/aptos-move/framework/move-stdlib/src/natives/string.rs
+++ b/aptos-move/framework/move-stdlib/src/natives/string.rs
@@ -100,7 +100,7 @@ fn native_sub_string(
 
     if j < i {
         // TODO: The abort code should follow the error convention.
-        return Err(aptos_native_interface::SafeNativeError::Abort { abort_code: 1 });
+        return Err(aptos_native_interface::SafeNativeError::abort(1));
     }
 
     context.charge(STRING_SUB_STRING_PER_BYTE * NumBytes::new((j - i) as u64))?;

--- a/aptos-move/framework/move-stdlib/src/natives/vector.rs
+++ b/aptos-move/framework/move-stdlib/src/natives/vector.rs
@@ -43,9 +43,7 @@ fn native_move_range(
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     context.charge(VECTOR_MOVE_RANGE_BASE)?;
 
-    let map_err = |_| SafeNativeError::Abort {
-        abort_code: error::invalid_argument(EINDEX_OUT_OF_BOUNDS),
-    };
+    let map_err = |_| SafeNativeError::abort(error::invalid_argument(EINDEX_OUT_OF_BOUNDS));
     let insert_position = usize::try_from(safely_pop_arg!(args, u64)).map_err(map_err)?;
     let to = safely_pop_arg!(args, VectorRef);
     let length = usize::try_from(safely_pop_arg!(args, u64)).map_err(map_err)?;
@@ -63,9 +61,7 @@ fn native_move_range(
         .is_none_or(|end| end > from_len)
         || insert_position > to_len
     {
-        return Err(SafeNativeError::Abort {
-            abort_code: EINDEX_OUT_OF_BOUNDS,
-        });
+        return Err(SafeNativeError::abort(EINDEX_OUT_OF_BOUNDS));
     }
 
     // We are moving all elements in the range, all elements after range, and all elements after insertion point.
@@ -77,9 +73,8 @@ fn native_move_range(
                 (from_len - removal_position)
                     .checked_add(to_len - insert_position)
                     .and_then(|v| v.checked_add(length))
-                    .ok_or_else(|| SafeNativeError::Abort {
-                        abort_code: EINDEX_OUT_OF_BOUNDS,
-                    })? as u64,
+                    .ok_or_else(|| SafeNativeError::abort(EINDEX_OUT_OF_BOUNDS))?
+                    as u64,
             ),
     )?;
 

--- a/aptos-move/framework/src/natives/account.rs
+++ b/aptos-move/framework/src/natives/account.rs
@@ -39,9 +39,9 @@ fn native_create_address(
     if let Ok(address) = address {
         Ok(smallvec![Value::address(address)])
     } else {
-        Err(SafeNativeError::Abort {
-            abort_code: super::status::NFE_UNABLE_TO_PARSE_ADDRESS,
-        })
+        Err(SafeNativeError::abort(
+            super::status::NFE_UNABLE_TO_PARSE_ADDRESS,
+        ))
     }
 }
 

--- a/aptos-move/framework/src/natives/account_abstraction.rs
+++ b/aptos-move/framework/src/natives/account_abstraction.rs
@@ -30,7 +30,7 @@ pub(crate) fn native_dispatch(
     context
         .traversal_context()
         .check_is_special_or_visited(module_name.address(), module_name.name())
-        .map_err(|_| SafeNativeError::Abort { abort_code: 4 })?;
+        .map_err(|_| SafeNativeError::abort(4))?;
 
     context.charge(DISPATCHABLE_AUTHENTICATE_DISPATCH_BASE)?;
 

--- a/aptos-move/framework/src/natives/aggregator_natives/aggregator_v2.rs
+++ b/aptos-move/framework/src/natives/aggregator_natives/aggregator_v2.rs
@@ -57,9 +57,7 @@ fn get_width_by_type(ty_arg: &Type, error_code_if_incorrect: u64) -> SafeNativeR
     match ty_arg {
         Type::U128 => Ok(16),
         Type::U64 => Ok(8),
-        _ => Err(SafeNativeError::Abort {
-            abort_code: error_code_if_incorrect,
-        }),
+        _ => Err(SafeNativeError::abort(error_code_if_incorrect)),
     }
 }
 
@@ -72,9 +70,7 @@ fn pop_value_by_type(
     match ty_arg {
         Type::U128 => Ok(safely_pop_arg!(args, u128)),
         Type::U64 => Ok(safely_pop_arg!(args, u64) as u128),
-        _ => Err(SafeNativeError::Abort {
-            abort_code: error_code_if_incorrect,
-        }),
+        _ => Err(SafeNativeError::abort(error_code_if_incorrect)),
     }
 }
 
@@ -86,9 +82,7 @@ fn create_value_by_type(
     match value_ty {
         Type::U128 => Ok(Value::u128(value)),
         Type::U64 => Ok(Value::u64(u128_to_u64(value)?)),
-        _ => Err(SafeNativeError::Abort {
-            abort_code: error_code_if_incorrect,
-        }),
+        _ => Err(SafeNativeError::abort(error_code_if_incorrect)),
     }
 }
 
@@ -409,9 +403,9 @@ fn native_copy_snapshot(
     _ty_args: &[Type],
     _args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
-    Err(SafeNativeError::Abort {
-        abort_code: EAGGREGATOR_FUNCTION_NOT_YET_SUPPORTED,
-    })
+    Err(SafeNativeError::abort(
+        EAGGREGATOR_FUNCTION_NOT_YET_SUPPORTED,
+    ))
 }
 
 /***************************************************************************************************
@@ -453,9 +447,9 @@ fn native_string_concat(
     _args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     // Deprecated function in favor of `derive_string_concat`.
-    Err(SafeNativeError::Abort {
-        abort_code: EAGGREGATOR_FUNCTION_NOT_YET_SUPPORTED,
-    })
+    Err(SafeNativeError::abort(
+        EAGGREGATOR_FUNCTION_NOT_YET_SUPPORTED,
+    ))
 }
 
 /***************************************************************************************************
@@ -502,9 +496,7 @@ fn native_create_derived_string(
         .charge(AGGREGATOR_V2_CREATE_SNAPSHOT_PER_BYTE * NumBytes::new(value_bytes.len() as u64))?;
 
     if value_bytes.len() > DERIVED_STRING_INPUT_MAX_LENGTH {
-        return Err(SafeNativeError::Abort {
-            abort_code: EINPUT_STRING_LENGTH_TOO_LARGE,
-        });
+        return Err(SafeNativeError::abort(EINPUT_STRING_LENGTH_TOO_LARGE));
     }
 
     let derived_string_snapshot =
@@ -554,9 +546,7 @@ fn native_derive_string_concat(
         .checked_add(suffix.len())
         .is_some_and(|v| v > DERIVED_STRING_INPUT_MAX_LENGTH)
     {
-        return Err(SafeNativeError::Abort {
-            abort_code: EINPUT_STRING_LENGTH_TOO_LARGE,
-        });
+        return Err(SafeNativeError::abort(EINPUT_STRING_LENGTH_TOO_LARGE));
     }
 
     let derived_string_snapshot = if let Some((resolver, mut delayed_field_data)) =

--- a/aptos-move/framework/src/natives/aggregator_natives/helpers_v2.rs
+++ b/aptos-move/framework/src/natives/aggregator_natives/helpers_v2.rs
@@ -30,7 +30,7 @@ macro_rules! get_value_impl {
             Ok(match ty {
                 Type::U128 => safely_get_struct_field_as!(struct_ref, $idx, u128),
                 Type::U64 => safely_get_struct_field_as!(struct_ref, $idx, u64) as u128,
-                _ => return Err(SafeNativeError::Abort { abort_code: $e }),
+                _ => return Err(SafeNativeError::abort($e)),
             })
         }
     };
@@ -65,7 +65,7 @@ macro_rules! get_value_as_id_impl {
                 Type::U64 | Type::U128 => {
                     safely_get_struct_field_as!(struct_ref, $idx, DelayedFieldID)
                 },
-                _ => return Err(SafeNativeError::Abort { abort_code: $e }),
+                _ => return Err(SafeNativeError::abort($e)),
             };
 
             // Make sure we validate generated id is correct, i.e. it lies within the
@@ -104,11 +104,7 @@ pub(crate) fn unbounded_aggregator_max_value(ty: &Type) -> SafeNativeResult<u128
     Ok(match ty {
         Type::U128 => u128::MAX,
         Type::U64 => u64::MAX as u128,
-        _ => {
-            return Err(SafeNativeError::Abort {
-                abort_code: EUNSUPPORTED_AGGREGATOR_TYPE,
-            })
-        },
+        _ => return Err(SafeNativeError::abort(EUNSUPPORTED_AGGREGATOR_TYPE)),
     })
 }
 

--- a/aptos-move/framework/src/natives/code.rs
+++ b/aptos-move/framework/src/natives/code.rs
@@ -346,9 +346,7 @@ fn native_request_publish(
     let code_context = context.extensions_mut().get_mut::<NativeCodeContext>();
     if code_context.requested_module_bundle.is_some() || !code_context.enabled {
         // Can't request second time or if publish requests are not allowed.
-        return Err(SafeNativeError::Abort {
-            abort_code: EALREADY_REQUESTED,
-        });
+        return Err(SafeNativeError::abort(EALREADY_REQUESTED));
     }
     code_context.requested_module_bundle = Some(PublishRequest {
         destination,

--- a/aptos-move/framework/src/natives/cryptography/algebra/arithmetics/add.rs
+++ b/aptos-move/framework/src/natives/cryptography/algebra/arithmetics/add.rs
@@ -98,8 +98,6 @@ pub fn add_internal(
             mul,
             ALGEBRA_ARK_BN254_FQ12_MUL
         ),
-        _ => Err(SafeNativeError::Abort {
-            abort_code: MOVE_ABORT_CODE_NOT_IMPLEMENTED,
-        }),
+        _ => Err(SafeNativeError::abort(MOVE_ABORT_CODE_NOT_IMPLEMENTED)),
     }
 }

--- a/aptos-move/framework/src/natives/cryptography/algebra/arithmetics/div.rs
+++ b/aptos-move/framework/src/natives/cryptography/algebra/arithmetics/div.rs
@@ -84,8 +84,6 @@ pub fn div_internal(
             ALGEBRA_ARK_BN254_FQ12_EQ,
             ALGEBRA_ARK_BN254_FQ12_DIV
         ),
-        _ => Err(SafeNativeError::Abort {
-            abort_code: MOVE_ABORT_CODE_NOT_IMPLEMENTED,
-        }),
+        _ => Err(SafeNativeError::abort(MOVE_ABORT_CODE_NOT_IMPLEMENTED)),
     }
 }

--- a/aptos-move/framework/src/natives/cryptography/algebra/arithmetics/double.rs
+++ b/aptos-move/framework/src/natives/cryptography/algebra/arithmetics/double.rs
@@ -68,8 +68,6 @@ pub fn double_internal(
             square,
             ALGEBRA_ARK_BN254_FQ12_SQUARE
         ),
-        _ => Err(SafeNativeError::Abort {
-            abort_code: MOVE_ABORT_CODE_NOT_IMPLEMENTED,
-        }),
+        _ => Err(SafeNativeError::abort(MOVE_ABORT_CODE_NOT_IMPLEMENTED)),
     }
 }

--- a/aptos-move/framework/src/natives/cryptography/algebra/arithmetics/inv.rs
+++ b/aptos-move/framework/src/natives/cryptography/algebra/arithmetics/inv.rs
@@ -62,8 +62,6 @@ pub fn inv_internal(
         Some(Structure::BN254Fq12) => {
             ark_inverse_internal!(context, args, ark_bn254::Fq12, ALGEBRA_ARK_BN254_FQ12_INV)
         },
-        _ => Err(SafeNativeError::Abort {
-            abort_code: MOVE_ABORT_CODE_NOT_IMPLEMENTED,
-        }),
+        _ => Err(SafeNativeError::abort(MOVE_ABORT_CODE_NOT_IMPLEMENTED)),
     }
 }

--- a/aptos-move/framework/src/natives/cryptography/algebra/arithmetics/mul.rs
+++ b/aptos-move/framework/src/natives/cryptography/algebra/arithmetics/mul.rs
@@ -54,8 +54,6 @@ pub fn mul_internal(
                 ALGEBRA_ARK_BN254_FQ12_MUL
             )
         },
-        _ => Err(SafeNativeError::Abort {
-            abort_code: MOVE_ABORT_CODE_NOT_IMPLEMENTED,
-        }),
+        _ => Err(SafeNativeError::abort(MOVE_ABORT_CODE_NOT_IMPLEMENTED)),
     }
 }

--- a/aptos-move/framework/src/natives/cryptography/algebra/arithmetics/neg.rs
+++ b/aptos-move/framework/src/natives/cryptography/algebra/arithmetics/neg.rs
@@ -99,8 +99,6 @@ pub fn neg_internal(
             let new_handle = store_element!(context, new_element)?;
             Ok(smallvec![Value::u64(new_handle as u64)])
         },
-        _ => Err(SafeNativeError::Abort {
-            abort_code: MOVE_ABORT_CODE_NOT_IMPLEMENTED,
-        }),
+        _ => Err(SafeNativeError::abort(MOVE_ABORT_CODE_NOT_IMPLEMENTED)),
     }
 }

--- a/aptos-move/framework/src/natives/cryptography/algebra/arithmetics/scalar_mul.rs
+++ b/aptos-move/framework/src/natives/cryptography/algebra/arithmetics/scalar_mul.rs
@@ -178,9 +178,7 @@ pub fn scalar_mul_internal(
             let new_handle = store_element!(context, new_element)?;
             Ok(smallvec![Value::u64(new_handle as u64)])
         },
-        _ => Err(SafeNativeError::Abort {
-            abort_code: MOVE_ABORT_CODE_NOT_IMPLEMENTED,
-        }),
+        _ => Err(SafeNativeError::abort(MOVE_ABORT_CODE_NOT_IMPLEMENTED)),
     }
 }
 
@@ -199,9 +197,9 @@ macro_rules! ark_msm_internal {
         let num_elements = element_handles.len();
         let num_scalars = scalar_handles.len();
         if num_elements != num_scalars {
-            return Err(SafeNativeError::Abort {
-                abort_code: MOVE_ABORT_CODE_INPUT_VECTOR_SIZES_NOT_MATCHING,
-            });
+            return Err(SafeNativeError::abort(
+                MOVE_ABORT_CODE_INPUT_VECTOR_SIZES_NOT_MATCHING,
+            ));
         }
         let mut bases = Vec::with_capacity(num_elements);
         $context.charge($proj_to_affine_cost * NumArgs::from(num_elements as u64))?;
@@ -286,8 +284,6 @@ pub fn multi_scalar_mul_internal(
                 ark_bn254::Fr
             )
         },
-        _ => Err(SafeNativeError::Abort {
-            abort_code: MOVE_ABORT_CODE_NOT_IMPLEMENTED,
-        }),
+        _ => Err(SafeNativeError::abort(MOVE_ABORT_CODE_NOT_IMPLEMENTED)),
     }
 }

--- a/aptos-move/framework/src/natives/cryptography/algebra/arithmetics/sqr.rs
+++ b/aptos-move/framework/src/natives/cryptography/algebra/arithmetics/sqr.rs
@@ -66,8 +66,6 @@ pub fn sqr_internal(
                 ALGEBRA_ARK_BN254_FQ12_SQUARE
             )
         },
-        _ => Err(SafeNativeError::Abort {
-            abort_code: MOVE_ABORT_CODE_NOT_IMPLEMENTED,
-        }),
+        _ => Err(SafeNativeError::abort(MOVE_ABORT_CODE_NOT_IMPLEMENTED)),
     }
 }

--- a/aptos-move/framework/src/natives/cryptography/algebra/arithmetics/sub.rs
+++ b/aptos-move/framework/src/natives/cryptography/algebra/arithmetics/sub.rs
@@ -99,8 +99,6 @@ pub fn sub_internal(
             div,
             ALGEBRA_ARK_BN254_FQ12_DIV
         ),
-        _ => Err(SafeNativeError::Abort {
-            abort_code: MOVE_ABORT_CODE_NOT_IMPLEMENTED,
-        }),
+        _ => Err(SafeNativeError::abort(MOVE_ABORT_CODE_NOT_IMPLEMENTED)),
     }
 }

--- a/aptos-move/framework/src/natives/cryptography/algebra/casting.rs
+++ b/aptos-move/framework/src/natives/cryptography/algebra/casting.rs
@@ -72,9 +72,7 @@ pub fn downcast_internal(
                 Ok(smallvec![Value::bool(false), Value::u64(handle as u64)])
             }
         },
-        _ => Err(SafeNativeError::Abort {
-            abort_code: MOVE_ABORT_CODE_NOT_IMPLEMENTED,
-        }),
+        _ => Err(SafeNativeError::abort(MOVE_ABORT_CODE_NOT_IMPLEMENTED)),
     }
 }
 
@@ -96,8 +94,6 @@ pub fn upcast_internal(
             let handle = safely_pop_arg!(args, u64);
             Ok(smallvec![Value::u64(handle)])
         },
-        _ => Err(SafeNativeError::Abort {
-            abort_code: MOVE_ABORT_CODE_NOT_IMPLEMENTED,
-        }),
+        _ => Err(SafeNativeError::abort(MOVE_ABORT_CODE_NOT_IMPLEMENTED)),
     }
 }

--- a/aptos-move/framework/src/natives/cryptography/algebra/constants.rs
+++ b/aptos-move/framework/src/natives/cryptography/algebra/constants.rs
@@ -91,9 +91,7 @@ pub fn zero_internal(
         Some(Structure::BN254Gt) => {
             ark_constant_op_internal!(context, ark_bn254::Fq12, one, ALGEBRA_ARK_BN254_FQ12_ONE)
         },
-        _ => Err(SafeNativeError::Abort {
-            abort_code: MOVE_ABORT_CODE_NOT_IMPLEMENTED,
-        }),
+        _ => Err(SafeNativeError::abort(MOVE_ABORT_CODE_NOT_IMPLEMENTED)),
     }
 }
 
@@ -162,9 +160,7 @@ pub fn one_internal(
             let handle = store_element!(context, element)?;
             Ok(smallvec![Value::u64(handle as u64)])
         },
-        _ => Err(SafeNativeError::Abort {
-            abort_code: MOVE_ABORT_CODE_NOT_IMPLEMENTED,
-        }),
+        _ => Err(SafeNativeError::abort(MOVE_ABORT_CODE_NOT_IMPLEMENTED)),
     }
 }
 
@@ -192,8 +188,6 @@ pub fn order_internal(
         | Some(Structure::BN254G2) => Ok(smallvec![Value::vector_u8(BN254_R_LENDIAN.clone())]),
         Some(Structure::BN254Fq) => Ok(smallvec![Value::vector_u8(BN254_Q_LENDIAN.clone())]),
         Some(Structure::BN254Fq12) => Ok(smallvec![Value::vector_u8(BN254_Q12_LENDIAN.clone())]),
-        _ => Err(SafeNativeError::Abort {
-            abort_code: MOVE_ABORT_CODE_NOT_IMPLEMENTED,
-        }),
+        _ => Err(SafeNativeError::abort(MOVE_ABORT_CODE_NOT_IMPLEMENTED)),
     }
 }

--- a/aptos-move/framework/src/natives/cryptography/algebra/eq.rs
+++ b/aptos-move/framework/src/natives/cryptography/algebra/eq.rs
@@ -96,8 +96,6 @@ pub fn eq_internal(
         Some(Structure::BN254Gt) => {
             ark_eq_internal!(context, args, ark_bn254::Fq12, ALGEBRA_ARK_BN254_FQ12_EQ)
         },
-        _ => Err(SafeNativeError::Abort {
-            abort_code: MOVE_ABORT_CODE_NOT_IMPLEMENTED,
-        }),
+        _ => Err(SafeNativeError::abort(MOVE_ABORT_CODE_NOT_IMPLEMENTED)),
     }
 }

--- a/aptos-move/framework/src/natives/cryptography/algebra/hash_to_structure.rs
+++ b/aptos-move/framework/src/natives/cryptography/algebra/hash_to_structure.rs
@@ -132,8 +132,6 @@ pub fn hash_to_internal(
             let new_handle = store_element!(context, new_element)?;
             Ok(smallvec![Value::u64(new_handle as u64)])
         },
-        _ => Err(SafeNativeError::Abort {
-            abort_code: MOVE_ABORT_CODE_NOT_IMPLEMENTED,
-        }),
+        _ => Err(SafeNativeError::abort(MOVE_ABORT_CODE_NOT_IMPLEMENTED)),
     }
 }

--- a/aptos-move/framework/src/natives/cryptography/algebra/mod.rs
+++ b/aptos-move/framework/src/natives/cryptography/algebra/mod.rs
@@ -246,9 +246,7 @@ macro_rules! store_element {
         let context = &mut $context.extensions_mut().get_mut::<AlgebraContext>();
         let new_size = context.bytes_used + std::mem::size_of_val(&$obj);
         if new_size > MEMORY_LIMIT_IN_BYTES {
-            Err(SafeNativeError::Abort {
-                abort_code: E_TOO_MUCH_MEMORY_USED,
-            })
+            Err(SafeNativeError::abort(E_TOO_MUCH_MEMORY_USED))
         } else {
             let target_vec = &mut context.objs;
             context.bytes_used = new_size;
@@ -292,9 +290,7 @@ macro_rules! abort_unless_feature_flag_enabled {
                 // Continue.
             },
             _ => {
-                return Err(SafeNativeError::Abort {
-                    abort_code: MOVE_ABORT_CODE_NOT_IMPLEMENTED,
-                });
+                return Err(SafeNativeError::abort(MOVE_ABORT_CODE_NOT_IMPLEMENTED));
             },
         }
     };

--- a/aptos-move/framework/src/natives/cryptography/algebra/new.rs
+++ b/aptos-move/framework/src/natives/cryptography/algebra/new.rs
@@ -60,8 +60,6 @@ pub fn from_u64_internal(
             ark_bn254::Fq12,
             ALGEBRA_ARK_BN254_FQ12_FROM_U64
         ),
-        _ => Err(SafeNativeError::Abort {
-            abort_code: MOVE_ABORT_CODE_NOT_IMPLEMENTED,
-        }),
+        _ => Err(SafeNativeError::abort(MOVE_ABORT_CODE_NOT_IMPLEMENTED)),
     }
 }

--- a/aptos-move/framework/src/natives/cryptography/algebra/pairing.rs
+++ b/aptos-move/framework/src/natives/cryptography/algebra/pairing.rs
@@ -97,9 +97,9 @@ macro_rules! multi_pairing_internal {
         let g1_element_handles = safely_pop_arg!($args, Vec<u64>);
         let num_entries = g1_element_handles.len();
         if num_entries != g2_element_handles.len() {
-            return Err(SafeNativeError::Abort {
-                abort_code: MOVE_ABORT_CODE_INPUT_VECTOR_SIZES_NOT_MATCHING,
-            });
+            return Err(SafeNativeError::abort(
+                MOVE_ABORT_CODE_INPUT_VECTOR_SIZES_NOT_MATCHING,
+            ));
         }
 
         $context.charge($g1_proj_to_affine_gas.per::<Arg>() * NumArgs::from(num_entries as u64))?;
@@ -162,9 +162,7 @@ pub fn multi_pairing_internal(
                 ALGEBRA_ARK_BN254_G2_PROJ_TO_AFFINE
             )
         },
-        _ => Err(SafeNativeError::Abort {
-            abort_code: MOVE_ABORT_CODE_NOT_IMPLEMENTED,
-        }),
+        _ => Err(SafeNativeError::abort(MOVE_ABORT_CODE_NOT_IMPLEMENTED)),
     }
 }
 
@@ -203,8 +201,6 @@ pub fn pairing_internal(
                 ALGEBRA_ARK_BN254_G2_PROJ_TO_AFFINE
             )
         },
-        _ => Err(SafeNativeError::Abort {
-            abort_code: MOVE_ABORT_CODE_NOT_IMPLEMENTED,
-        }),
+        _ => Err(SafeNativeError::abort(MOVE_ABORT_CODE_NOT_IMPLEMENTED)),
     }
 }

--- a/aptos-move/framework/src/natives/cryptography/algebra/rand.rs
+++ b/aptos-move/framework/src/natives/cryptography/algebra/rand.rs
@@ -43,7 +43,7 @@ macro_rules! ark_rand_internal {
         let element = <$typ>::rand(&mut test_rng());
         match store_element!($context, element) {
             Ok(new_handle) => Ok(smallvec![Value::u64(new_handle as u64)]),
-            Err(abort_code) => Err(SafeNativeError::Abort { abort_code }),
+            Err(abort_code) => Err(SafeNativeError::abort(abort_code)),
         }
     }};
 }
@@ -75,7 +75,7 @@ pub fn rand_insecure_internal(
             let element = BLS12381_GT_GENERATOR.pow(k_bigint);
             match store_element!(context, element) {
                 Ok(handle) => Ok(smallvec![Value::u64(handle as u64)]),
-                Err(abort_code) => Err(SafeNativeError::Abort { abort_code }),
+                Err(abort_code) => Err(SafeNativeError::abort(abort_code)),
             }
         },
         Some(Structure::BN254Fr) => {
@@ -99,7 +99,7 @@ pub fn rand_insecure_internal(
             let element = BN254_GT_GENERATOR.pow(k_bigint);
             match store_element!(context, element) {
                 Ok(handle) => Ok(smallvec![Value::u64(handle as u64)]),
-                Err(abort_code) => Err(SafeNativeError::Abort { abort_code }),
+                Err(abort_code) => Err(SafeNativeError::abort(abort_code)),
             }
         },
         _ => unreachable!(),

--- a/aptos-move/framework/src/natives/cryptography/algebra/serialization.rs
+++ b/aptos-move/framework/src/natives/cryptography/algebra/serialization.rs
@@ -115,9 +115,7 @@ macro_rules! serialize_element {
             Ok(smallvec![Value::vector_u8(buf)])
           }
         )*
-          _ => Err(SafeNativeError::Abort {
-            abort_code: MOVE_ABORT_CODE_NOT_IMPLEMENTED,
-          })
+          _ => Err(SafeNativeError::abort(MOVE_ABORT_CODE_NOT_IMPLEMENTED,))
         }
     };
 }
@@ -287,9 +285,7 @@ pub fn serialize_internal(
             ]
         )
     } else {
-        Err(SafeNativeError::Abort {
-            abort_code: MOVE_ABORT_CODE_NOT_IMPLEMENTED,
-        })
+        Err(SafeNativeError::abort(MOVE_ABORT_CODE_NOT_IMPLEMENTED))
     }
 }
 
@@ -601,8 +597,6 @@ pub fn deserialize_internal(
                 _ => Ok(smallvec![Value::bool(false), Value::u64(0)]),
             }
         },
-        _ => Err(SafeNativeError::Abort {
-            abort_code: MOVE_ABORT_CODE_NOT_IMPLEMENTED,
-        }),
+        _ => Err(SafeNativeError::abort(MOVE_ABORT_CODE_NOT_IMPLEMENTED)),
     }
 }

--- a/aptos-move/framework/src/natives/cryptography/bulletproofs.rs
+++ b/aptos-move/framework/src/natives/cryptography/bulletproofs.rs
@@ -88,9 +88,7 @@ fn native_verify_range_proof(
     let comm_point = CompressedRistretto::from_slice(comm_bytes.as_slice());
 
     if !is_supported_number_of_bits(num_bits) {
-        return Err(SafeNativeError::Abort {
-            abort_code: abort_codes::NFE_RANGE_NOT_SUPPORTED,
-        });
+        return Err(SafeNativeError::abort(abort_codes::NFE_RANGE_NOT_SUPPORTED));
     }
 
     let pg = {
@@ -131,14 +129,12 @@ fn native_verify_batch_range_proof(
         .collect::<Vec<_>>();
 
     if !is_supported_number_of_bits(num_bits) {
-        return Err(SafeNativeError::Abort {
-            abort_code: abort_codes::NFE_RANGE_NOT_SUPPORTED,
-        });
+        return Err(SafeNativeError::abort(abort_codes::NFE_RANGE_NOT_SUPPORTED));
     }
     if !is_supported_batch_size(comm_points.len()) {
-        return Err(SafeNativeError::Abort {
-            abort_code: abort_codes::NFE_BATCH_SIZE_NOT_SUPPORTED,
-        });
+        return Err(SafeNativeError::abort(
+            abort_codes::NFE_BATCH_SIZE_NOT_SUPPORTED,
+        ));
     }
 
     let pg = {
@@ -176,16 +172,12 @@ fn native_test_only_prove_range(
     let v = pop_scalar_from_bytes(&mut args)?;
 
     if !is_supported_number_of_bits(num_bits) {
-        return Err(SafeNativeError::Abort {
-            abort_code: abort_codes::NFE_RANGE_NOT_SUPPORTED,
-        });
+        return Err(SafeNativeError::abort(abort_codes::NFE_RANGE_NOT_SUPPORTED));
     }
 
     // Make sure only the first 64 bits are set.
     if !v.as_bytes()[8..].iter().all(|&byte| byte == 0u8) {
-        return Err(SafeNativeError::Abort {
-            abort_code: abort_codes::NFE_VALUE_OUTSIDE_RANGE,
-        });
+        return Err(SafeNativeError::abort(abort_codes::NFE_VALUE_OUTSIDE_RANGE));
     }
 
     // Convert Scalar to u64.
@@ -242,19 +234,17 @@ fn native_test_only_batch_prove_range(
     let vs = pop_scalars_from_bytes(&mut args)?;
 
     if !is_supported_number_of_bits(num_bits) {
-        return Err(SafeNativeError::Abort {
-            abort_code: abort_codes::NFE_RANGE_NOT_SUPPORTED,
-        });
+        return Err(SafeNativeError::abort(abort_codes::NFE_RANGE_NOT_SUPPORTED));
     }
     if !is_supported_batch_size(vs.len()) {
-        return Err(SafeNativeError::Abort {
-            abort_code: abort_codes::NFE_BATCH_SIZE_NOT_SUPPORTED,
-        });
+        return Err(SafeNativeError::abort(
+            abort_codes::NFE_BATCH_SIZE_NOT_SUPPORTED,
+        ));
     }
     if vs.len() != v_blindings.len() {
-        return Err(SafeNativeError::Abort {
-            abort_code: abort_codes::NFE_VECTOR_LENGTHS_MISMATCH,
-        });
+        return Err(SafeNativeError::abort(
+            abort_codes::NFE_VECTOR_LENGTHS_MISMATCH,
+        ));
     }
 
     // Make sure only the first 64 bits are set for each Scalar.
@@ -262,9 +252,7 @@ fn native_test_only_batch_prove_range(
         .iter()
         .all(|v| v.as_bytes()[8..].iter().all(|&byte| byte == 0u8))
     {
-        return Err(SafeNativeError::Abort {
-            abort_code: abort_codes::NFE_VALUE_OUTSIDE_RANGE,
-        });
+        return Err(SafeNativeError::abort(abort_codes::NFE_VALUE_OUTSIDE_RANGE));
     }
 
     // Convert each Scalar to u64.
@@ -334,9 +322,9 @@ fn verify_range_proof(
     let range_proof = match bulletproofs::RangeProof::from_bytes(proof_bytes) {
         Ok(proof) => proof,
         Err(_) => {
-            return Err(SafeNativeError::Abort {
-                abort_code: abort_codes::NFE_DESERIALIZE_RANGE_PROOF,
-            })
+            return Err(SafeNativeError::abort(
+                abort_codes::NFE_DESERIALIZE_RANGE_PROOF,
+            ))
         },
     };
 
@@ -373,9 +361,9 @@ fn verify_batch_range_proof(
     let range_proof = match bulletproofs::RangeProof::from_bytes(proof_bytes) {
         Ok(proof) => proof,
         Err(_) => {
-            return Err(SafeNativeError::Abort {
-                abort_code: abort_codes::NFE_DESERIALIZE_RANGE_PROOF,
-            })
+            return Err(SafeNativeError::abort(
+                abort_codes::NFE_DESERIALIZE_RANGE_PROOF,
+            ))
         },
     };
 

--- a/aptos-move/framework/src/natives/cryptography/ed25519.rs
+++ b/aptos-move/framework/src/natives/cryptography/ed25519.rs
@@ -57,9 +57,7 @@ fn native_public_key_validate(
             {
                 return Ok(smallvec![Value::bool(false)]);
             } else {
-                return Err(SafeNativeError::Abort {
-                    abort_code: abort_codes::E_WRONG_PUBKEY_SIZE,
-                });
+                return Err(SafeNativeError::abort(abort_codes::E_WRONG_PUBKEY_SIZE));
             }
         },
     };

--- a/aptos-move/framework/src/natives/cryptography/ristretto255_point.rs
+++ b/aptos-move/framework/src/natives/cryptography/ristretto255_point.rs
@@ -157,9 +157,7 @@ impl PointStore {
     fn safe_add_point(&mut self, point: RistrettoPoint) -> SafeNativeResult<u64> {
         let id = self.points.len();
         if id >= NUM_POINTS_LIMIT {
-            Err(SafeNativeError::Abort {
-                abort_code: E_TOO_MANY_POINTS_CREATED,
-            })
+            Err(SafeNativeError::abort(E_TOO_MANY_POINTS_CREATED))
         } else {
             self.points.push(point);
             Ok(id as u64)

--- a/aptos-move/framework/src/natives/cryptography/secp256k1.rs
+++ b/aptos-move/framework/src/natives/cryptography/secp256k1.rs
@@ -44,9 +44,7 @@ fn native_ecdsa_recover(
     let msg = match libsecp256k1::Message::parse_slice(&msg) {
         Ok(msg) => msg,
         Err(_) => {
-            return Err(SafeNativeError::Abort {
-                abort_code: abort_codes::NFE_DESERIALIZE,
-            });
+            return Err(SafeNativeError::abort(abort_codes::NFE_DESERIALIZE));
         },
     };
 
@@ -54,9 +52,7 @@ fn native_ecdsa_recover(
     let rid = match libsecp256k1::RecoveryId::parse(recovery_id) {
         Ok(rid) => rid,
         Err(_) => {
-            return Err(SafeNativeError::Abort {
-                abort_code: abort_codes::NFE_DESERIALIZE,
-            });
+            return Err(SafeNativeError::abort(abort_codes::NFE_DESERIALIZE));
         },
     };
 
@@ -65,9 +61,7 @@ fn native_ecdsa_recover(
     let sig = match libsecp256k1::Signature::parse_standard_slice(&signature) {
         Ok(sig) => sig,
         Err(_) => {
-            return Err(SafeNativeError::Abort {
-                abort_code: abort_codes::NFE_DESERIALIZE,
-            });
+            return Err(SafeNativeError::abort(abort_codes::NFE_DESERIALIZE));
         },
     };
 

--- a/aptos-move/framework/src/natives/dispatchable_fungible_asset.rs
+++ b/aptos-move/framework/src/natives/dispatchable_fungible_asset.rs
@@ -42,7 +42,7 @@ pub(crate) fn native_dispatch(
         }
     };
     check_visited(module_name.address(), module_name.name())
-        .map_err(|_| SafeNativeError::Abort { abort_code: 4 })?;
+        .map_err(|_| SafeNativeError::abort(4))?;
 
     context.charge(DISPATCHABLE_FUNGIBLE_ASSET_DISPATCH_BASE)?;
 

--- a/aptos-move/framework/src/natives/event.rs
+++ b/aptos-move/framework/src/natives/event.rs
@@ -138,10 +138,8 @@ fn native_write_to_event_store(
     })?;
 
     let ctx = context.extensions_mut().get_mut::<NativeEventContext>();
-    let event =
-        ContractEvent::new_v1(key, seq_num, ty_tag, blob).map_err(|_| SafeNativeError::Abort {
-            abort_code: ECANNOT_CREATE_EVENT,
-        })?;
+    let event = ContractEvent::new_v1(key, seq_num, ty_tag, blob)
+        .map_err(|_| SafeNativeError::abort(ECANNOT_CREATE_EVENT))?;
     // TODO(layouts): avoid cloning layouts for events with delayed fields.
     ctx.events.push((
         event,
@@ -310,9 +308,8 @@ fn native_write_module_event_to_store(
         })?;
 
     let ctx = context.extensions_mut().get_mut::<NativeEventContext>();
-    let event = ContractEvent::new_v2(type_tag, blob).map_err(|_| SafeNativeError::Abort {
-        abort_code: ECANNOT_CREATE_EVENT,
-    })?;
+    let event = ContractEvent::new_v2(type_tag, blob)
+        .map_err(|_| SafeNativeError::abort(ECANNOT_CREATE_EVENT))?;
     // TODO(layouts): avoid cloning layouts for events with delayed fields.
     ctx.events.push((
         event,

--- a/aptos-move/framework/src/natives/function_info.rs
+++ b/aptos-move/framework/src/natives/function_info.rs
@@ -28,7 +28,7 @@ fn identifier_from_ref(v: Value) -> SafeNativeResult<Identifier> {
         .map_err(SafeNativeError::InvariantViolation)?
         .as_bytes_ref()
         .to_vec();
-    Identifier::from_utf8(bytes).map_err(|_| SafeNativeError::Abort { abort_code: 1 })
+    Identifier::from_utf8(bytes).map_err(|_| SafeNativeError::abort(1))
 }
 
 pub(crate) fn extract_function_info(
@@ -99,13 +99,12 @@ fn native_check_dispatch_type_compatibility_impl(
                 context.traversal_context().legacy_check_visited(a, n)
             }
         };
-        check_visited(module.address(), module.name())
-            .map_err(|_| SafeNativeError::Abort { abort_code: 2 })?;
+        check_visited(module.address(), module.name()).map_err(|_| SafeNativeError::abort(2))?;
 
         (
             context
                 .load_function(&module, &func)
-                .map_err(|_| SafeNativeError::Abort { abort_code: 2 })?,
+                .map_err(|_| SafeNativeError::abort(2))?,
             module,
         )
     };
@@ -114,13 +113,13 @@ fn native_check_dispatch_type_compatibility_impl(
         (
             context
                 .load_function(&module, &func)
-                .map_err(|_| SafeNativeError::Abort { abort_code: 2 })?,
+                .map_err(|_| SafeNativeError::abort(2))?,
             module,
         )
     };
 
     if lhs.param_tys().is_empty() {
-        return Err(SafeNativeError::Abort { abort_code: 2 });
+        return Err(SafeNativeError::abort(2));
     }
 
     Ok(smallvec![Value::bool(

--- a/aptos-move/framework/src/natives/permissioned_signer.rs
+++ b/aptos-move/framework/src/natives/permissioned_signer.rs
@@ -39,9 +39,7 @@ fn native_is_permissioned_signer_impl(
         .get_feature_flags()
         .is_enabled(aptos_types::on_chain_config::FeatureFlag::PERMISSIONED_SIGNER)
     {
-        return SafeNativeResult::Err(SafeNativeError::Abort {
-            abort_code: EPERMISSION_SIGNER_DISABLED,
-        });
+        return SafeNativeResult::Err(SafeNativeError::abort(EPERMISSION_SIGNER_DISABLED));
     }
 
     let signer = safely_pop_arg!(arguments, SignerRef);
@@ -70,16 +68,14 @@ fn native_permission_address(
         .get_feature_flags()
         .is_enabled(aptos_types::on_chain_config::FeatureFlag::PERMISSIONED_SIGNER)
     {
-        return SafeNativeResult::Err(SafeNativeError::Abort {
-            abort_code: EPERMISSION_SIGNER_DISABLED,
-        });
+        return SafeNativeResult::Err(SafeNativeError::abort(EPERMISSION_SIGNER_DISABLED));
     }
 
     let signer = safely_pop_arg!(args, SignerRef);
 
     context.charge(PERMISSION_ADDRESS_BASE)?;
     if !signer.is_permissioned()? {
-        return Err(SafeNativeError::Abort { abort_code: 3 });
+        return Err(SafeNativeError::abort(3));
     }
 
     Ok(smallvec![signer.permission_address()?])
@@ -103,9 +99,7 @@ fn native_signer_from_permissioned(
         .get_feature_flags()
         .is_enabled(aptos_types::on_chain_config::FeatureFlag::PERMISSIONED_SIGNER)
     {
-        return SafeNativeResult::Err(SafeNativeError::Abort {
-            abort_code: EPERMISSION_SIGNER_DISABLED,
-        });
+        return SafeNativeResult::Err(SafeNativeError::abort(EPERMISSION_SIGNER_DISABLED));
     }
 
     let permission_addr = safely_pop_arg!(arguments, AccountAddress);
@@ -140,9 +134,7 @@ fn native_borrow_address(
         .is_enabled(aptos_types::on_chain_config::FeatureFlag::PERMISSIONED_SIGNER)
         && signer_reference.is_permissioned()?
     {
-        return SafeNativeResult::Err(SafeNativeError::Abort {
-            abort_code: EPERMISSION_SIGNER_DISABLED,
-        });
+        return SafeNativeResult::Err(SafeNativeError::abort(EPERMISSION_SIGNER_DISABLED));
     }
 
     context.charge(SIGNER_BORROW_ADDRESS_BASE)?;

--- a/aptos-move/framework/src/natives/randomness.rs
+++ b/aptos-move/framework/src/natives/randomness.rs
@@ -87,9 +87,9 @@ pub fn fetch_and_increment_txn_counter(
 
     let ctx = context.extensions_mut().get_mut::<RandomnessContext>();
     if !ctx.is_unbiasable() {
-        return Err(SafeNativeError::Abort {
-            abort_code: E_API_USE_SUSCEPTIBLE_TO_TEST_AND_ABORT,
-        });
+        return Err(SafeNativeError::abort(
+            E_API_USE_SUSCEPTIBLE_TO_TEST_AND_ABORT,
+        ));
     }
 
     let ret = ctx.txn_local_state.to_vec();

--- a/aptos-move/framework/src/natives/transaction_context.rs
+++ b/aptos-move/framework/src/natives/transaction_context.rs
@@ -171,11 +171,9 @@ fn native_monotonically_increasing_counter_internal(
         .extensions_mut()
         .get_mut::<NativeTransactionContext>();
     if transaction_context.local_counter == u16::MAX {
-        return Err(SafeNativeError::Abort {
-            abort_code: error::invalid_state(
-                abort_codes::EMONOTONICALLY_INCREASING_COUNTER_OVERFLOW,
-            ),
-        });
+        return Err(SafeNativeError::abort(error::invalid_state(
+            abort_codes::EMONOTONICALLY_INCREASING_COUNTER_OVERFLOW,
+        )));
     }
     transaction_context.local_counter += 1;
     let local_counter = transaction_context.local_counter as u128;
@@ -197,9 +195,9 @@ fn native_monotonically_increasing_counter_internal(
                 (1u128, transaction_index)
             },
             TransactionIndexKind::NotAvailable => {
-                return Err(SafeNativeError::Abort {
-                    abort_code: error::invalid_state(abort_codes::ETRANSACTION_INDEX_NOT_AVAILABLE),
-                });
+                return Err(SafeNativeError::abort(error::invalid_state(
+                    abort_codes::ETRANSACTION_INDEX_NOT_AVAILABLE,
+                )));
             },
         };
 
@@ -211,9 +209,9 @@ fn native_monotonically_increasing_counter_internal(
         Ok(smallvec![Value::u128(monotonically_increasing_counter)])
     } else {
         // When transaction context is not available, return an error
-        Err(SafeNativeError::Abort {
-            abort_code: error::invalid_state(abort_codes::ETRANSACTION_CONTEXT_NOT_AVAILABLE),
-        })
+        Err(SafeNativeError::abort(error::invalid_state(
+            abort_codes::ETRANSACTION_CONTEXT_NOT_AVAILABLE,
+        )))
     }
 }
 
@@ -237,11 +235,9 @@ fn native_monotonically_increasing_counter_internal_for_test_only(
         .extensions_mut()
         .get_mut::<NativeTransactionContext>();
     if transaction_context.local_counter == u16::MAX {
-        return Err(SafeNativeError::Abort {
-            abort_code: error::invalid_state(
-                abort_codes::EMONOTONICALLY_INCREASING_COUNTER_OVERFLOW,
-            ),
-        });
+        return Err(SafeNativeError::abort(error::invalid_state(
+            abort_codes::EMONOTONICALLY_INCREASING_COUNTER_OVERFLOW,
+        )));
     }
     transaction_context.local_counter += 1;
     let local_counter = transaction_context.local_counter as u128;
@@ -281,9 +277,9 @@ fn native_sender_internal(
     if let Some(transaction_context) = user_transaction_context_opt {
         Ok(smallvec![Value::address(transaction_context.sender())])
     } else {
-        Err(SafeNativeError::Abort {
-            abort_code: error::invalid_state(abort_codes::ETRANSACTION_CONTEXT_NOT_AVAILABLE),
-        })
+        Err(SafeNativeError::abort(error::invalid_state(
+            abort_codes::ETRANSACTION_CONTEXT_NOT_AVAILABLE,
+        )))
     }
 }
 
@@ -303,9 +299,9 @@ fn native_secondary_signers_internal(
         )?;
         Ok(smallvec![Value::vector_address(secondary_signers)])
     } else {
-        Err(SafeNativeError::Abort {
-            abort_code: error::invalid_state(abort_codes::ETRANSACTION_CONTEXT_NOT_AVAILABLE),
-        })
+        Err(SafeNativeError::abort(error::invalid_state(
+            abort_codes::ETRANSACTION_CONTEXT_NOT_AVAILABLE,
+        )))
     }
 }
 
@@ -320,9 +316,9 @@ fn native_gas_payer_internal(
     if let Some(transaction_context) = user_transaction_context_opt {
         Ok(smallvec![Value::address(transaction_context.gas_payer())])
     } else {
-        Err(SafeNativeError::Abort {
-            abort_code: error::invalid_state(abort_codes::ETRANSACTION_CONTEXT_NOT_AVAILABLE),
-        })
+        Err(SafeNativeError::abort(error::invalid_state(
+            abort_codes::ETRANSACTION_CONTEXT_NOT_AVAILABLE,
+        )))
     }
 }
 
@@ -337,9 +333,9 @@ fn native_max_gas_amount_internal(
     if let Some(transaction_context) = user_transaction_context_opt {
         Ok(smallvec![Value::u64(transaction_context.max_gas_amount())])
     } else {
-        Err(SafeNativeError::Abort {
-            abort_code: error::invalid_state(abort_codes::ETRANSACTION_CONTEXT_NOT_AVAILABLE),
-        })
+        Err(SafeNativeError::abort(error::invalid_state(
+            abort_codes::ETRANSACTION_CONTEXT_NOT_AVAILABLE,
+        )))
     }
 }
 
@@ -354,9 +350,9 @@ fn native_gas_unit_price_internal(
     if let Some(transaction_context) = user_transaction_context_opt {
         Ok(smallvec![Value::u64(transaction_context.gas_unit_price())])
     } else {
-        Err(SafeNativeError::Abort {
-            abort_code: error::invalid_state(abort_codes::ETRANSACTION_CONTEXT_NOT_AVAILABLE),
-        })
+        Err(SafeNativeError::abort(error::invalid_state(
+            abort_codes::ETRANSACTION_CONTEXT_NOT_AVAILABLE,
+        )))
     }
 }
 
@@ -371,9 +367,9 @@ fn native_chain_id_internal(
     if let Some(transaction_context) = user_transaction_context_opt {
         Ok(smallvec![Value::u8(transaction_context.chain_id())])
     } else {
-        Err(SafeNativeError::Abort {
-            abort_code: error::invalid_state(abort_codes::ETRANSACTION_CONTEXT_NOT_AVAILABLE),
-        })
+        Err(SafeNativeError::abort(error::invalid_state(
+            abort_codes::ETRANSACTION_CONTEXT_NOT_AVAILABLE,
+        )))
     }
 }
 
@@ -462,9 +458,9 @@ fn native_entry_function_payload_internal(
             Ok(smallvec![create_option_none(enum_option_enabled)?])
         }
     } else {
-        Err(SafeNativeError::Abort {
-            abort_code: error::invalid_state(abort_codes::ETRANSACTION_CONTEXT_NOT_AVAILABLE),
-        })
+        Err(SafeNativeError::abort(error::invalid_state(
+            abort_codes::ETRANSACTION_CONTEXT_NOT_AVAILABLE,
+        )))
     }
 }
 
@@ -504,9 +500,9 @@ fn native_multisig_payload_internal(
             Ok(smallvec![create_option_none(enum_option_enabled)?])
         }
     } else {
-        Err(SafeNativeError::Abort {
-            abort_code: error::invalid_state(abort_codes::ETRANSACTION_CONTEXT_NOT_AVAILABLE),
-        })
+        Err(SafeNativeError::abort(error::invalid_state(
+            abort_codes::ETRANSACTION_CONTEXT_NOT_AVAILABLE,
+        )))
     }
 }
 

--- a/aptos-move/framework/src/natives/type_info.rs
+++ b/aptos-move/framework/src/natives/type_info.rs
@@ -67,9 +67,9 @@ fn native_type_of(
     if let TypeTag::Struct(struct_tag) = type_tag {
         Ok(type_of_internal(&struct_tag).expect("type_of should never fail."))
     } else {
-        Err(SafeNativeError::Abort {
-            abort_code: super::status::NFE_EXPECTED_STRUCT_TYPE_TAG,
-        })
+        Err(SafeNativeError::abort(
+            super::status::NFE_EXPECTED_STRUCT_TYPE_TAG,
+        ))
     }
 }
 

--- a/aptos-move/framework/src/natives/util.rs
+++ b/aptos-move/framework/src/natives/util.rs
@@ -51,11 +51,7 @@ fn native_from_bytes(
         .deserialize(&bytes, &layout)
     {
         Some(val) => val,
-        None => {
-            return Err(SafeNativeError::Abort {
-                abort_code: EFROM_BYTES,
-            })
-        },
+        None => return Err(SafeNativeError::abort(EFROM_BYTES)),
     };
 
     Ok(smallvec![val])

--- a/aptos-move/framework/table-natives/src/lib.rs
+++ b/aptos-move/framework/table-natives/src/lib.rs
@@ -427,9 +427,7 @@ fn native_add_box(
 
     let res = match gv.move_to(val) {
         Ok(_) => Ok(smallvec![]),
-        Err(_) => Err(SafeNativeError::Abort {
-            abort_code: ALREADY_EXISTS,
-        }),
+        Err(_) => Err(SafeNativeError::abort(ALREADY_EXISTS)),
     };
 
     drop(table_data);
@@ -487,9 +485,7 @@ fn native_borrow_box(
 
     let res = match gv.borrow_global() {
         Ok(ref_val) => Ok(smallvec![ref_val]),
-        Err(_) => Err(SafeNativeError::Abort {
-            abort_code: NOT_FOUND,
-        }),
+        Err(_) => Err(SafeNativeError::abort(NOT_FOUND)),
     };
 
     drop(table_data);
@@ -601,9 +597,7 @@ fn native_remove_box(
 
     let res = match gv.move_from() {
         Ok(val) => Ok(smallvec![val]),
-        Err(_) => Err(SafeNativeError::Abort {
-            abort_code: NOT_FOUND,
-        }),
+        Err(_) => Err(SafeNativeError::abort(NOT_FOUND)),
     };
 
     drop(table_data);

--- a/third_party/move/move-vm/integration-tests/src/tests/native_tests.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/native_tests.rs
@@ -23,10 +23,7 @@ const TEST_ADDR: AccountAddress = AccountAddress::new([42; AccountAddress::LENGT
 
 fn make_failed_native() -> NativeFunction {
     Arc::new(move |_, _, _| -> PartialVMResult<NativeResult> {
-        Ok(NativeResult::Abort {
-            cost: InternalGas::new(0),
-            abort_code: 12,
-        })
+        Ok(NativeResult::err(InternalGas::new(0), 12))
     })
 }
 

--- a/third_party/move/move-vm/runtime/src/interpreter.rs
+++ b/third_party/move/move-vm/runtime/src/interpreter.rs
@@ -1176,9 +1176,17 @@ where
                 current_frame.pc += 1; // advance past the Call instruction in the caller
                 Ok(false)
             },
-            NativeResult::Abort { cost, abort_code } => {
+            NativeResult::Abort {
+                cost,
+                abort_code,
+                abort_message,
+            } => {
                 gas_meter.charge_native_function(cost, Option::<std::iter::Empty<&Value>>::None)?;
-                Err(PartialVMError::new(StatusCode::ABORTED).with_sub_status(abort_code))
+                let mut err = PartialVMError::new(StatusCode::ABORTED).with_sub_status(abort_code);
+                if let Some(abort_message) = abort_message {
+                    err = err.with_message(abort_message);
+                }
+                Err(err)
             },
             NativeResult::OutOfGas { partial_cost } => {
                 let err = match gas_meter


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

This PR adds support for abort messages in native functions.

Native function implementations can now call `SafeNativeError::abort_with_message` to abort with a message. These abort messages are propagated through the Move VM in the same way as abort messages originating from Move code.

### Scope

This change does **not** modify any existing native functions to include abort messages.

The large diff is primarily due to refactoring existing code from:

```
SafeNativeError::Abort { abort_code: … }
```
to
```
SafeNativeError::abort(…)
```

As a result, existing native functions behaviour remains completely unchanged. This PR only introduces the underlying support needed for future use of abort messages in native functions.

Note that abort messages are currently discarded by the VM (see `VMStatus::keep_or_discard` function) unless the `VM_BINARY_FORMAT_V10` feature is enabled.

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

- No new tests were added, since this feature is not used anywhere.
- All existing tests should pass.

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

- Changes to `SafeNativeError` in the Aptos VM and `NativeResult` in the Move VM.
- Refactoring of framework native functions (no behavioral changes intended).

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [x] Move/Aptos Virtual Machine
- [x] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces infrastructure for propagating abort messages from native functions through the VM pipeline.
> 
> - Extends `SafeNativeError::Abort` and `NativeResult::Abort` to carry optional `abort_message`; adds `SafeNativeError::abort` and `abort_with_message` helpers
> - Updates Aptos VM builder to translate native aborts (with message) into `NativeResult::Abort`; interpreter now attaches message to `PartialVMError`
> - Adjusts Move VM `NativeResult` API and mapping (`map_partial_vm_result_one`) to include abort messages
> - Large mechanical refactor across framework natives to replace `SafeNativeError::Abort { abort_code }` with `SafeNativeError::abort(code)` (no functional changes)
> - Minor test update to align with new `NativeResult` API
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 724e6d05e9765e33648903f38cb09d802ec44f4a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->