### PR TITLE
Fix the lint issue related to prometheus v0.13.4 in etna

### DIFF
--- a/crates/aptos-metrics-core/src/const_metric.rs
+++ b/crates/aptos-metrics-core/src/const_metric.rs
@@ -1,6 +1,9 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
+// Allow useless conversion lint - these conversions are needed for some prometheus versions
+#![allow(clippy::useless_conversion)]
+
 use anyhow::{anyhow, Result};
 use prometheus::{
     core::{Collector, Desc},


### PR DESCRIPTION
•  aptos-core: prometheus v0.13.3
•  etna: prometheus v0.13.4

Prometheus v0.13.4 changed the API to accept Vec<T> directly instead of requiring RepeatedField<T>, making the .into() calls unnecessary.

## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Suppresses a lint to align with mixed Prometheus versions without changing runtime behavior.
> 
> - Adds `#![allow(clippy::useless_conversion)]` to `aptos-metrics-core/src/const_metric.rs` so `.into()` remains for compatibility across Prometheus `0.13.3` and `0.13.4` APIs
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ac780f0a57bca2363558ef78b2db0acea3f04579. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->