### PR TITLE
[docs] Clarify third_party/move/move-stdlib is for testing only

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,7 @@ cargo build -p aptos-cached-packages   # REQUIRED: rebuild cached packages
 - `aptos-move/framework/aptos-stdlib/` - Aptos-specific stdlib
 - `aptos-move/framework/aptos-framework/` - Core chain modules (coin, account, staking)
 - `aptos-move/framework/aptos-token-objects/` - NFT standards
+- `third_party/move/move-stdlib` - Not the Move production standard library; only a subset used for testing
 
 ### Key Crates
 - `aptos-types` - Core type definitions used everywhere


### PR DESCRIPTION
Add note to CLAUDE.md explaining that third_party/move/move-stdlib is not the Move production standard library but only a subset used for testing purposes.

https://claude.ai/code/session_01QrxUofzinkeeNwiuS6fpqF

## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [x] Documentation update
- [ ] Tests



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates documentation only.
> 
> - Adds clarification in `CLAUDE.md` that `third_party/move/move-stdlib` is not the production Move stdlib and is a testing-only subset within the Move Framework Stack section
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2e94a43baca0b5f0409c8a6c1258c9968d7a3a31. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->