### PR TITLE
[framework] Add fee field to BulkOrderFilledEvent

### DIFF
--- a/aptos-move/framework/aptos-experimental/doc/market_types.md
+++ b/aptos-move/framework/aptos-experimental/doc/market_types.md
@@ -45,6 +45,7 @@
 -  [Function `get_maker_cancellation_reason`](#0x7_market_types_get_maker_cancellation_reason)
 -  [Function `get_taker_cancellation_reason`](#0x7_market_types_get_taker_cancellation_reason)
 -  [Function `get_callback_result`](#0x7_market_types_get_callback_result)
+-  [Function `get_maker_fee`](#0x7_market_types_get_maker_fee)
 -  [Function `is_validation_result_valid`](#0x7_market_types_is_validation_result_valid)
 -  [Function `get_validation_failure_reason`](#0x7_market_types_get_validation_failure_reason)
 -  [Function `get_place_maker_order_actions`](#0x7_market_types_get_place_maker_order_actions)
@@ -591,6 +592,12 @@ Reasons why an order was cancelled
 </dt>
 <dd>
 
+</dd>
+<dt>
+<code>maker_fee: i64</code>
+</dt>
+<dd>
+ Fee charged to the maker for the fill. Negative means rebate.
 </dd>
 </dl>
 
@@ -1367,6 +1374,12 @@ enum <a href="market_types.md#0x7_market_types_BulkOrderFilledEvent">BulkOrderFi
 <dd>
 
 </dd>
+<dt>
+<code>fee: i64</code>
+</dt>
+<dd>
+ Fee charged for the fill. Negative means rebate.
+</dd>
 </dl>
 
 
@@ -1913,7 +1926,7 @@ enum <a href="market_types.md#0x7_market_types_BulkOrderRejectionEvent">BulkOrde
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="market_types.md#0x7_market_types_new_settle_trade_result">new_settle_trade_result</a>&lt;R: <b>copy</b>, drop, store&gt;(settled_size: u64, maker_cancellation_reason: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a>&gt;, taker_cancellation_reason: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a>&gt;, callback_result: <a href="market_types.md#0x7_market_types_CallbackResult">market_types::CallbackResult</a>&lt;R&gt;): <a href="market_types.md#0x7_market_types_SettleTradeResult">market_types::SettleTradeResult</a>&lt;R&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="market_types.md#0x7_market_types_new_settle_trade_result">new_settle_trade_result</a>&lt;R: <b>copy</b>, drop, store&gt;(settled_size: u64, maker_cancellation_reason: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a>&gt;, taker_cancellation_reason: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a>&gt;, callback_result: <a href="market_types.md#0x7_market_types_CallbackResult">market_types::CallbackResult</a>&lt;R&gt;, maker_fee: i64): <a href="market_types.md#0x7_market_types_SettleTradeResult">market_types::SettleTradeResult</a>&lt;R&gt;
 </code></pre>
 
 
@@ -1926,13 +1939,15 @@ enum <a href="market_types.md#0x7_market_types_BulkOrderRejectionEvent">BulkOrde
     settled_size: u64,
     maker_cancellation_reason: Option&lt;String&gt;,
     taker_cancellation_reason: Option&lt;String&gt;,
-    callback_result: <a href="market_types.md#0x7_market_types_CallbackResult">CallbackResult</a>&lt;R&gt;
+    callback_result: <a href="market_types.md#0x7_market_types_CallbackResult">CallbackResult</a>&lt;R&gt;,
+    maker_fee: i64,
 ): <a href="market_types.md#0x7_market_types_SettleTradeResult">SettleTradeResult</a>&lt;R&gt; {
     SettleTradeResult::V1 {
         settled_size,
         maker_cancellation_reason,
         taker_cancellation_reason,
-        callback_result
+        callback_result,
+        maker_fee,
     }
 }
 </code></pre>
@@ -2130,6 +2145,30 @@ enum <a href="market_types.md#0x7_market_types_BulkOrderRejectionEvent">BulkOrde
 
 <pre><code><b>public</b> <b>fun</b> <a href="market_types.md#0x7_market_types_get_callback_result">get_callback_result</a>&lt;R: store + <b>copy</b> + drop&gt;(self: &<a href="market_types.md#0x7_market_types_SettleTradeResult">SettleTradeResult</a>&lt;R&gt;): &<a href="market_types.md#0x7_market_types_CallbackResult">CallbackResult</a>&lt;R&gt; {
     &self.callback_result
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x7_market_types_get_maker_fee"></a>
+
+## Function `get_maker_fee`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="market_types.md#0x7_market_types_get_maker_fee">get_maker_fee</a>&lt;R: <b>copy</b>, drop, store&gt;(self: &<a href="market_types.md#0x7_market_types_SettleTradeResult">market_types::SettleTradeResult</a>&lt;R&gt;): i64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="market_types.md#0x7_market_types_get_maker_fee">get_maker_fee</a>&lt;R: store + <b>copy</b> + drop&gt;(self: &<a href="market_types.md#0x7_market_types_SettleTradeResult">SettleTradeResult</a>&lt;R&gt;): i64 {
+    self.maker_fee
 }
 </code></pre>
 
@@ -3341,7 +3380,7 @@ call the <code>place_order_with_order_id</code> API to place the order with the 
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="market_types.md#0x7_market_types_emit_event_for_bulk_order_filled">emit_event_for_bulk_order_filled</a>&lt;M: <b>copy</b>, drop, store&gt;(self: &<a href="market_types.md#0x7_market_types_Market">market_types::Market</a>&lt;M&gt;, order_id: <a href="order_book_types.md#0x7_order_book_types_OrderId">order_book_types::OrderId</a>, sequence_number: u64, user: <b>address</b>, filled_size: u64, price: u64, orig_price: u64, is_bid: bool, fill_id: u128)
+<pre><code><b>public</b> <b>fun</b> <a href="market_types.md#0x7_market_types_emit_event_for_bulk_order_filled">emit_event_for_bulk_order_filled</a>&lt;M: <b>copy</b>, drop, store&gt;(self: &<a href="market_types.md#0x7_market_types_Market">market_types::Market</a>&lt;M&gt;, order_id: <a href="order_book_types.md#0x7_order_book_types_OrderId">order_book_types::OrderId</a>, sequence_number: u64, user: <b>address</b>, filled_size: u64, price: u64, orig_price: u64, is_bid: bool, fill_id: u128, fee: i64)
 </code></pre>
 
 
@@ -3360,6 +3399,7 @@ call the <code>place_order_with_order_id</code> API to place the order with the 
     orig_price: u64,
     is_bid: bool,
     fill_id: u128,
+    fee: i64,
 ) {
     // Final check whether <a href="../../aptos-framework/doc/event.md#0x1_event">event</a> sending is enabled
     <b>if</b> (self.config.allow_events_emission) {
@@ -3375,6 +3415,7 @@ call the <code>place_order_with_order_id</code> API to place the order with the 
                 orig_price,
                 is_bid,
                 fill_id,
+                fee,
             }
         );
     };

--- a/aptos-move/framework/aptos-experimental/doc/order_placement.md
+++ b/aptos-move/framework/aptos-experimental/doc/order_placement.md
@@ -1243,7 +1243,8 @@ Places a market order - The order is guaranteed to be a taker order and will be 
                 maker_order.get_price_from_match_details(),
                 maker_order.get_price_from_match_details(),
                 !is_bid,
-                fill_id
+                fill_id,
+                settle_result.get_maker_fee(),
             );
         } <b>else</b> {
             market.emit_event_for_order(

--- a/aptos-move/framework/aptos-experimental/sources/trading/market/market_types.move
+++ b/aptos-move/framework/aptos-experimental/sources/trading/market/market_types.move
@@ -151,7 +151,9 @@ module aptos_experimental::market_types {
             settled_size: u64,
             maker_cancellation_reason: Option<String>,
             taker_cancellation_reason: Option<String>,
-            callback_result: CallbackResult<R>
+            callback_result: CallbackResult<R>,
+            /// Fee charged to the maker for the fill. Negative means rebate.
+            maker_fee: i64,
         }
     }
 
@@ -194,13 +196,15 @@ module aptos_experimental::market_types {
         settled_size: u64,
         maker_cancellation_reason: Option<String>,
         taker_cancellation_reason: Option<String>,
-        callback_result: CallbackResult<R>
+        callback_result: CallbackResult<R>,
+        maker_fee: i64,
     ): SettleTradeResult<R> {
         SettleTradeResult::V1 {
             settled_size,
             maker_cancellation_reason,
             taker_cancellation_reason,
-            callback_result
+            callback_result,
+            maker_fee,
         }
     }
 
@@ -258,6 +262,10 @@ module aptos_experimental::market_types {
 
     public fun get_callback_result<R: store + copy + drop>(self: &SettleTradeResult<R>): &CallbackResult<R> {
         &self.callback_result
+    }
+
+    public fun get_maker_fee<R: store + copy + drop>(self: &SettleTradeResult<R>): i64 {
+        self.maker_fee
     }
 
     public fun is_validation_result_valid(self: &ValidationResult): bool {
@@ -493,6 +501,8 @@ module aptos_experimental::market_types {
             orig_price: u64,
             is_bid: bool,
             fill_id: u128,
+            /// Fee charged for the fill. Negative means rebate.
+            fee: i64,
         }
     }
 
@@ -806,6 +816,7 @@ module aptos_experimental::market_types {
         orig_price: u64,
         is_bid: bool,
         fill_id: u128,
+        fee: i64,
     ) {
         // Final check whether event sending is enabled
         if (self.config.allow_events_emission) {
@@ -821,6 +832,7 @@ module aptos_experimental::market_types {
                     orig_price,
                     is_bid,
                     fill_id,
+                    fee,
                 }
             );
         };

--- a/aptos-move/framework/aptos-experimental/sources/trading/market/order_placement.move
+++ b/aptos-move/framework/aptos-experimental/sources/trading/market/order_placement.move
@@ -767,7 +767,8 @@ module aptos_experimental::order_placement {
                     maker_order.get_price_from_match_details(),
                     maker_order.get_price_from_match_details(),
                     !is_bid,
-                    fill_id
+                    fill_id,
+                    settle_result.get_maker_fee(),
                 );
             } else {
                 market.emit_event_for_order(

--- a/aptos-move/framework/aptos-experimental/sources/trading/tests/market/clearinghouse_test.move
+++ b/aptos-move/framework/aptos-experimental/sources/trading/tests/market/clearinghouse_test.move
@@ -136,7 +136,7 @@ module aptos_experimental::clearinghouse_test {
                 maker, Position { size: 0, is_long: true }
             );
         update_position(maker_position, size, !is_taker_long);
-        new_settle_trade_result(size, option::none(), option::none(), new_callback_result_continue_matching(size))
+        new_settle_trade_result(size, option::none(), option::none(), new_callback_result_continue_matching(size), 0)
     }
 
     public(friend) fun place_maker_order(order_id: OrderId): PlaceMakerOrderResult<u64> acquires GlobalState {
@@ -196,7 +196,8 @@ module aptos_experimental::clearinghouse_test {
             size / 2,
             option::none(),
             option::some(std::string::utf8(b"Max open interest violation")),
-            new_callback_result_stop_matching(size)
+            new_callback_result_stop_matching(size),
+            0,
         )
     }
 


### PR DESCRIPTION
## Description
Add `fee: i64` field to `BulkOrderFilledEvent` to track fees/rebates on bulk order fills. The fee follows the same semantics as other fee fields where negative values represent rebates, enabling more accurate accounting and clearinghouse settlement.

## How Has This Been Tested?
All 167 existing Move tests pass, including market order tests and bulk order tests that exercise the event emission code path.

## Key Areas to Review
The change flows through three key areas:
1. `SettleTradeResult` now includes a `maker_fee` field that clearinghouses populate during settlement
2. `BulkOrderFilledEvent` includes the fee in its emitted event
3. `order_placement.move` passes the fee through to event emission

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [x] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces maker fee propagation for bulk fills.
> 
> - Extends `SettleTradeResult::V1` with `maker_fee: i64` and adds `get_maker_fee`; updates `new_settle_trade_result` to accept `maker_fee`
> - Adds `fee: i64` to `BulkOrderFilledEvent` and updates `emit_event_for_bulk_order_filled` signature; `order_placement.move` now passes `settle_result.get_maker_fee()` when emitting bulk fill events
> - Updates docs and tests to reflect the new field and function signatures
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1bf1ad085e543659deffcfd95681237cacb9bb4e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->