### PR TITLE
[Network] Add access control policies to network configs.

### DIFF
--- a/config/src/config/network_config.rs
+++ b/config/src/config/network_config.rs
@@ -52,6 +52,28 @@ pub const CONNECTION_BACKOFF_BASE: u64 = 2;
 pub const IP_BYTE_BUCKET_RATE: usize = 102400 /* 100 KiB */;
 pub const IP_BYTE_BUCKET_SIZE: usize = IP_BYTE_BUCKET_RATE;
 
+/// Access control policy for peer connections.
+/// Determines which peers are allowed or blocked from connecting.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AccessControlPolicy {
+    /// Only allow connections from peers in this list. All others are blocked.
+    AllowList(HashSet<PeerId>),
+    /// Block connections from peers in this list. All others are allowed.
+    BlockList(HashSet<PeerId>),
+}
+
+impl AccessControlPolicy {
+    /// Check if a peer is allowed based on this access control policy.
+    /// Returns true if the peer should be allowed, false if blocked.
+    pub fn is_peer_allowed(&self, peer_id: &PeerId) -> bool {
+        match self {
+            AccessControlPolicy::AllowList(allowed_peers) => allowed_peers.contains(peer_id),
+            AccessControlPolicy::BlockList(blocked_peers) => !blocked_peers.contains(peer_id),
+        }
+    }
+}
+
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct NetworkConfig {
@@ -123,6 +145,9 @@ pub struct NetworkConfig {
     pub max_parallel_deserialization_tasks: Option<usize>,
     /// Whether or not to enable latency aware peer dialing
     pub enable_latency_aware_dialing: bool,
+    /// Access control policy for peer connections. If not specified, all
+    /// peers are allowed. Otherwise, the specified policy is enforced.
+    pub access_control_policy: Option<AccessControlPolicy>,
 }
 
 impl Default for NetworkConfig {
@@ -164,6 +189,7 @@ impl NetworkConfig {
             outbound_tx_buffer_size_bytes: None,
             max_parallel_deserialization_tasks: None,
             enable_latency_aware_dialing: true,
+            access_control_policy: None,
         };
 
         // Configure the number of parallel deserialization tasks
@@ -507,6 +533,7 @@ impl Peer {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use maplit::hashset;
 
     #[test]
     fn test_num_parallel_deserialization_tasks() {
@@ -526,5 +553,107 @@ mod tests {
         // Configure the number of deserialization tasks and verify that it is not overridden
         network_config.configure_num_deserialization_tasks();
         assert_eq!(network_config.max_parallel_deserialization_tasks, Some(1));
+    }
+
+    #[test]
+    fn test_access_control_policy_default() {
+        // Default config should have no access control policy
+        let network_config = NetworkConfig::default();
+        assert!(network_config.access_control_policy.is_none());
+    }
+
+    #[test]
+    fn test_access_control_policy_allow_list_serialization() {
+        // Create peer IDs for testing
+        let peer_1 = PeerId::random();
+        let peer_2 = PeerId::random();
+
+        // Create an access control policy with an allow list
+        let access_control_policy_yaml = format!(
+            r#"
+            allow_list:
+              - "{}"
+              - "{}"
+            "#,
+            peer_1, peer_2
+        );
+        let access_control_policy: AccessControlPolicy =
+            serde_yaml::from_str(&access_control_policy_yaml).unwrap();
+
+        // Verify the access control policy is correctly parsed
+        match access_control_policy {
+            AccessControlPolicy::AllowList(peers) => {
+                assert_eq!(peers.len(), 2);
+                assert!(peers.contains(&peer_1));
+                assert!(peers.contains(&peer_2));
+            },
+            _ => panic!("Expected allow list policy!"),
+        }
+    }
+
+    #[test]
+    fn test_access_control_policy_block_list_serialization() {
+        // Create peer IDs for testing
+        let peer_1 = PeerId::random();
+        let peer_2 = PeerId::random();
+        let peer_3 = PeerId::random();
+
+        // Create an access control policy with a block list
+        let access_control_policy_yaml = format!(
+            r#"
+            block_list:
+              - "{}"
+              - "{}"
+              - "{}"
+            "#,
+            peer_1, peer_2, peer_3
+        );
+        let access_control_policy: AccessControlPolicy =
+            serde_yaml::from_str(&access_control_policy_yaml).unwrap();
+
+        // Verify the access control policy is correctly parsed
+        match access_control_policy {
+            AccessControlPolicy::BlockList(peers) => {
+                assert_eq!(peers.len(), 3);
+                assert!(peers.contains(&peer_1));
+                assert!(peers.contains(&peer_2));
+                assert!(peers.contains(&peer_3));
+            },
+            _ => panic!("Expected block list policy!"),
+        }
+    }
+
+    #[test]
+    fn test_access_control_policy_allow_list() {
+        // Create an access control policy with an allow list
+        let peer_1 = PeerId::random();
+        let peer_2 = PeerId::random();
+        let peer_3 = PeerId::random();
+        let allow_list = hashset! {peer_1, peer_2};
+        let access_control_policy = AccessControlPolicy::AllowList(allow_list);
+
+        // Peers in the allow list should be allowed
+        assert!(access_control_policy.is_peer_allowed(&peer_1));
+        assert!(access_control_policy.is_peer_allowed(&peer_2));
+
+        // Peer not in the allow list should be blocked
+        assert!(!access_control_policy.is_peer_allowed(&peer_3));
+    }
+
+    #[test]
+    fn test_access_control_policy_block_list() {
+        // Create an access control policy with a block list
+        let peer_1 = PeerId::random();
+        let peer_2 = PeerId::random();
+        let peer_3 = PeerId::random();
+        let block_list = hashset! {peer_3};
+        let access_control_policy = AccessControlPolicy::BlockList(block_list);
+
+        // Peers not in the block list should be allowed
+        assert!(access_control_policy.is_peer_allowed(&peer_1));
+        assert!(access_control_policy.is_peer_allowed(&peer_2));
+
+        // Peer in the block list should be blocked
+        assert!(!access_control_policy.is_peer_allowed(&peer_3));
     }
 }

--- a/network/framework/src/connectivity_manager/builder.rs
+++ b/network/framework/src/connectivity_manager/builder.rs
@@ -7,7 +7,10 @@ use crate::{
     counters,
     peer_manager::{conn_notifs_channel, ConnectionRequestSender},
 };
-use aptos_config::{config::PeerSet, network_id::NetworkContext};
+use aptos_config::{
+    config::{AccessControlPolicy, PeerSet},
+    network_id::NetworkContext,
+};
 use aptos_time_service::TimeService;
 use std::{sync::Arc, time::Duration};
 use tokio::runtime::Handle;
@@ -35,6 +38,7 @@ impl ConnectivityManagerBuilder {
         outbound_connection_limit: Option<usize>,
         mutual_authentication: bool,
         enable_latency_aware_dialing: bool,
+        access_control_policy: Option<Arc<AccessControlPolicy>>,
     ) -> Self {
         let (conn_mgr_reqs_tx, conn_mgr_reqs_rx) = aptos_channels::new(
             channel_size,
@@ -57,6 +61,7 @@ impl ConnectivityManagerBuilder {
                 outbound_connection_limit,
                 mutual_authentication,
                 enable_latency_aware_dialing,
+                access_control_policy,
             )),
         }
     }

--- a/network/framework/src/peer_manager/builder.rs
+++ b/network/framework/src/peer_manager/builder.rs
@@ -17,7 +17,10 @@ use crate::{
     ProtocolId,
 };
 use aptos_channels::{self, aptos_channel, message_queues::QueueStyle};
-use aptos_config::{config::HANDSHAKE_VERSION, network_id::NetworkContext};
+use aptos_config::{
+    config::{AccessControlPolicy, HANDSHAKE_VERSION},
+    network_id::NetworkContext,
+};
 use aptos_crypto::x25519;
 use aptos_logger::prelude::*;
 #[cfg(any(test, feature = "testing", feature = "fuzzing"))]
@@ -77,6 +80,7 @@ struct PeerManagerContext {
     max_message_size: usize,
     inbound_connection_limit: usize,
     tcp_buffer_cfg: TCPBufferCfg,
+    access_control_policy: Option<Arc<AccessControlPolicy>>,
 }
 
 impl PeerManagerContext {
@@ -99,6 +103,7 @@ impl PeerManagerContext {
         max_message_size: usize,
         inbound_connection_limit: usize,
         tcp_buffer_cfg: TCPBufferCfg,
+        access_control_policy: Option<Arc<AccessControlPolicy>>,
     ) -> Self {
         Self {
             pm_reqs_tx,
@@ -115,6 +120,7 @@ impl PeerManagerContext {
             max_message_size,
             inbound_connection_limit,
             tcp_buffer_cfg,
+            access_control_policy,
         }
     }
 
@@ -172,6 +178,7 @@ impl PeerManagerBuilder {
         enable_proxy_protocol: bool,
         inbound_connection_limit: usize,
         tcp_buffer_cfg: TCPBufferCfg,
+        access_control_policy: Option<Arc<AccessControlPolicy>>,
     ) -> Self {
         // Setup channel to send requests to peer manager.
         let (pm_reqs_tx, pm_reqs_rx) = aptos_channel::new(
@@ -206,6 +213,7 @@ impl PeerManagerBuilder {
                 max_message_size,
                 inbound_connection_limit,
                 tcp_buffer_cfg,
+                access_control_policy,
             )),
             peer_manager: None,
             listen_address,
@@ -339,6 +347,7 @@ impl PeerManagerBuilder {
             pm_context.max_frame_size,
             pm_context.max_message_size,
             pm_context.inbound_connection_limit,
+            pm_context.access_control_policy,
         );
 
         // PeerManager constructor appends a public key to the listen_address.


### PR DESCRIPTION
## Description
This PR adds support for access control policies in the node network configs. With this, we can specify simple allow and block lists (based on peer IDs).

## Testing Plan
New and existing test infrastructure (as well as manual verification).


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces configurable peer access control and wires it through the networking stack.
> 
> - Adds `AccessControlPolicy` (`allow_list`/`block_list`) with `is_peer_allowed()` and optional `NetworkConfig.access_control_policy` (default: none)
> - Plumbs policy via `NetworkBuilder` → `PeerManagerBuilder`/`ConnectivityManagerBuilder` into `PeerManager` and `ConnectivityManager`
> - Enforces policy:
>   - `ConnectivityManager::choose_peers_to_dial()` filters peers using `is_peer_allowed`
>   - `PeerManager` rejects inbound connections not permitted by the policy and increments rejection metrics
> - Extensive tests: YAML (de)serialization, policy evaluation, dialing filters, and peer manager acceptance/rejection
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e613069451638e46776342a9afea5622d8e7740b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->