### PR TITLE
[qs] Handle BatchV2 network messages

### DIFF
--- a/config/src/config/quorum_store_config.rs
+++ b/config/src/config/quorum_store_config.rs
@@ -99,9 +99,14 @@ pub struct QuorumStoreConfig {
     pub enable_opt_quorum_store: bool,
     pub opt_qs_minimum_batch_age_usecs: u64,
     pub enable_payload_v2: bool,
-    pub enable_batch_v2: bool,
-    pub enable_opt_qs_v2_tx: bool,
-    pub enable_opt_qs_v2_rx: bool,
+    /// Enables sending of Batch V2
+    pub enable_batch_v2_tx: bool,
+    /// Enables receving/handling of Batch V2
+    pub enable_batch_v2_rx: bool,
+    /// Enables creating proposals with OptQS V2 Payload with Batch V2
+    pub enable_opt_qs_v2_payload_tx: bool,
+    /// Enables handling of proposals with OptQS V2 Payload with Batch V2
+    pub enable_opt_qs_v2_payload_rx: bool,
 }
 
 impl Default for QuorumStoreConfig {
@@ -143,9 +148,10 @@ impl Default for QuorumStoreConfig {
             enable_opt_quorum_store: true,
             opt_qs_minimum_batch_age_usecs: Duration::from_millis(50).as_micros() as u64,
             enable_payload_v2: false,
-            enable_batch_v2: false,
-            enable_opt_qs_v2_tx: false,
-            enable_opt_qs_v2_rx: false,
+            enable_batch_v2_tx: false,
+            enable_batch_v2_rx: false,
+            enable_opt_qs_v2_payload_tx: false,
+            enable_opt_qs_v2_payload_rx: false,
         }
     }
 }

--- a/consensus/consensus-types/src/payload_pull_params.rs
+++ b/consensus/consensus-types/src/payload_pull_params.rs
@@ -11,7 +11,7 @@ use std::{collections::HashSet, time::Duration};
 pub struct OptQSPayloadPullParams {
     pub exclude_authors: HashSet<Author>,
     pub minimum_batch_age_usecs: u64,
-    pub use_batch_v2: bool,
+    pub enable_opt_qs_v2_payload: bool,
 }
 
 pub struct PayloadPullParameters {
@@ -33,7 +33,7 @@ impl std::fmt::Debug for OptQSPayloadPullParams {
         f.debug_struct("OptQSPayloadPullParams")
             .field("exclude_authors", &self.exclude_authors)
             .field("minimum_batch_age_useds", &self.minimum_batch_age_usecs)
-            .field("use_batch_v2", &self.use_batch_v2)
+            .field("enable_opt_qs_v2_payload", &self.enable_opt_qs_v2_payload)
             .finish()
     }
 }

--- a/consensus/src/liveness/proposal_status_tracker.rs
+++ b/consensus/src/liveness/proposal_status_tracker.rs
@@ -108,6 +108,7 @@ pub struct OptQSPullParamsProvider {
     enable_opt_qs: bool,
     minimum_batch_age_usecs: u64,
     failure_tracker: Arc<Mutex<ExponentialWindowFailureTracker>>,
+    enable_opt_qs_v2_payload: bool,
 }
 
 impl OptQSPullParamsProvider {
@@ -115,11 +116,13 @@ impl OptQSPullParamsProvider {
         enable_opt_qs: bool,
         minimum_batch_age_usecs: u64,
         failure_tracker: Arc<Mutex<ExponentialWindowFailureTracker>>,
+        enable_opt_qs_v2_payload: bool,
     ) -> Self {
         Self {
             enable_opt_qs,
             minimum_batch_age_usecs,
             failure_tracker,
+            enable_opt_qs_v2_payload,
         }
     }
 }
@@ -156,7 +159,7 @@ impl TOptQSPullParamsProvider for OptQSPullParamsProvider {
         Some(OptQSPayloadPullParams {
             exclude_authors,
             minimum_batch_age_usecs: self.minimum_batch_age_usecs,
-            use_batch_v2: false,
+            enable_opt_qs_v2_payload: self.enable_opt_qs_v2_payload,
         })
     }
 }

--- a/consensus/src/quorum_store/batch_generator.rs
+++ b/consensus/src/quorum_store/batch_generator.rs
@@ -249,7 +249,7 @@ impl BatchGenerator {
         counters::CREATED_BATCHES_COUNT.inc();
         counters::num_txn_per_batch(bucket_start.to_string().as_str(), txns.len());
 
-        if self.config.enable_batch_v2 {
+        if self.config.enable_batch_v2_tx {
             Batch::new_v2(
                 batch_id,
                 txns,
@@ -336,7 +336,7 @@ impl BatchGenerator {
         let mut batches = vec![];
 
         // Only categorize and separate transactions when BatchV2 is enabled
-        if self.config.enable_batch_v2 {
+        if self.config.enable_batch_v2_tx {
             // Group transactions by their batch kind
             let mut txns_by_kind: HashMap<BatchKind, Vec<SignedTransaction>> = HashMap::new();
 
@@ -570,7 +570,7 @@ impl BatchGenerator {
                             self.batch_writer.persist(persist_requests);
                             counters::BATCH_CREATION_PERSIST_LATENCY.observe_duration(persist_start.elapsed());
 
-                            if self.config.enable_batch_v2 {
+                            if self.config.enable_batch_v2_tx {
                                 network_sender.broadcast_batch_msg_v2(batches).await;
                             } else {
                                 let batches = batches.into_iter().map(|batch| {

--- a/consensus/src/quorum_store/batch_requester.rs
+++ b/consensus/src/quorum_store/batch_requester.rs
@@ -150,8 +150,10 @@ impl<T: QuorumStoreSender + Sync + 'static> BatchRequester<T> {
                                     return Err(ExecutorError::CouldNotGetData);
                                 }
                             }
-                            Ok(BatchResponse::BatchV2(_)) => {
-                                error!("Batch V2 response is not supported");
+                            Ok(BatchResponse::BatchV2(batch)) => {
+                                counters::RECEIVED_BATCH_RESPONSE_COUNT.inc();
+                                let payload = batch.into_transactions();
+                                return Ok(payload)
                             }
                             Err(e) => {
                                 counters::RECEIVED_BATCH_RESPONSE_ERROR_COUNT.inc();

--- a/consensus/src/quorum_store/quorum_store_builder.rs
+++ b/consensus/src/quorum_store/quorum_store_builder.rs
@@ -409,10 +409,14 @@ impl InnerBuilder {
                     batch_store.get_batch_from_local(&rpc_request.req.digest())
                 {
                     let batch: Batch<BatchInfoExt> = value.try_into().unwrap();
-                    let batch: Batch<BatchInfo> = batch
-                        .try_into()
-                        .expect("Batch retieval requests must be for V1 batch");
-                    BatchResponse::Batch(batch)
+                    if batch.is_v2() {
+                        BatchResponse::BatchV2(batch)
+                    } else {
+                        let batch: Batch<BatchInfo> = batch
+                            .try_into()
+                            .expect("Batch retrieval requests must be for V1 batch");
+                        BatchResponse::Batch(batch)
+                    }
                 } else {
                     match aptos_db_clone.get_latest_ledger_info() {
                         Ok(ledger_info) => BatchResponse::NotFound(ledger_info),

--- a/consensus/src/quorum_store/tests/batch_generator_test.rs
+++ b/consensus/src/quorum_store/tests/batch_generator_test.rs
@@ -851,7 +851,7 @@ async fn test_encrypted_transactions_separated_with_batch_v2() {
     let (batch_coordinator_cmd_tx, mut batch_coordinator_cmd_rx) = TokioChannel(100);
 
     let config = QuorumStoreConfig {
-        enable_batch_v2: true,
+        enable_batch_v2_tx: true,
         ..Default::default()
     };
     let max_batch_bytes = config.sender_max_batch_bytes;
@@ -925,7 +925,7 @@ async fn test_encrypted_transactions_filtered_without_batch_v2() {
     let (batch_coordinator_cmd_tx, mut batch_coordinator_cmd_rx) = TokioChannel(100);
 
     let config = QuorumStoreConfig {
-        enable_batch_v2: false, // V2 disabled
+        enable_batch_v2_tx: false, // V2 disabled
         ..Default::default()
     };
     let max_batch_bytes = config.sender_max_batch_bytes;
@@ -989,7 +989,7 @@ async fn test_encrypted_transactions_with_gas_buckets() {
     let (batch_coordinator_cmd_tx, mut batch_coordinator_cmd_rx) = TokioChannel(100);
 
     let config = QuorumStoreConfig {
-        enable_batch_v2: true,
+        enable_batch_v2_tx: true,
         ..Default::default()
     };
     let max_batch_bytes = config.sender_max_batch_bytes;
@@ -1085,7 +1085,7 @@ async fn test_only_encrypted_transactions() {
     let (batch_coordinator_cmd_tx, mut batch_coordinator_cmd_rx) = TokioChannel(100);
 
     let config = QuorumStoreConfig {
-        enable_batch_v2: true,
+        enable_batch_v2_tx: true,
         ..Default::default()
     };
     let max_batch_bytes = config.sender_max_batch_bytes;


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

This PR wires the handling of the new V2 Batch messages in the network and epoch manager -- `BatchMsgV2`, `SignedBatchMsgV2`, and `ProofOfStoreMsgV2`. The  `enable_batch_v2` flag is split into `enable_batch_v2_tx` and `enable_batch_v2_rx` to split the sending/receiving flags to make rollout safe and compatible.

Batch Requester returns V2 batch in a BatchResponse::BatchV2 enum when the batch if of type V2.