### PR TITLE
[REST API] Add `chain_id` and `node_type` to the `/info` endpoint

### DIFF
--- a/api/src/basic.rs
+++ b/api/src/basic.rs
@@ -10,6 +10,7 @@ use crate::{
 };
 use anyhow::Context as AnyhowContext;
 use aptos_api_types::AptosErrorCode;
+use aptos_config::config::NodeType;
 use poem_openapi::{
     param::Query,
     payload::{Html, Json},
@@ -74,6 +75,17 @@ impl BasicApi {
     )]
     async fn info(&self) -> Json<HashMap<String, serde_json::Value>> {
         let mut info = HashMap::new();
+
+        // Insert chain ID and node type
+        info.insert(
+            "chain_id".to_string(),
+            serde_json::to_value(format!("{:?}", self.context.chain_id())).unwrap(),
+        );
+        let node_type = NodeType::extract_from_config(&self.context.node_config);
+        info.insert(
+            "node_type".to_string(),
+            serde_json::to_value(node_type).unwrap(),
+        );
 
         // Insert state sync configuration information
         info.insert(

--- a/config/src/config/node_config_loader.rs
+++ b/config/src/config/node_config_loader.rs
@@ -14,12 +14,13 @@ use aptos_types::{
     state_store::state_key::StateKey,
     transaction::{Transaction, WriteSetPayload},
 };
+use serde::{Deserialize, Serialize};
 use serde_yaml::Value;
 use std::path::Path;
 
 /// A simple enum to represent the type of a node
 /// as determined from the config file.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub enum NodeType {
     Validator,
     ValidatorFullnode,


### PR DESCRIPTION
## Description
Adds the node's `chain_id` and `node_type` to the `/info` endpoint of the REST API. This provides useful node metadata for debugging and runtime verification.

## How Has This Been Tested?
Existing test infrastructure.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds two new metadata fields to the `/info` endpoint and derives `NodeType` from config; changes are additive but could impact clients that assume a fixed `/info` schema.
> 
> **Overview**
> The `/info` REST endpoint now returns additional node metadata: `chain_id` (from `Context::chain_id()`) and `node_type` (derived via `NodeType::extract_from_config`).
> 
> To support returning `node_type` cleanly, `NodeType` is updated to derive `Serialize`/`Deserialize` so it can be encoded into the JSON response.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ac25b1ede5530d134d28ed45884f0fda1c8c3e66. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->