### PR TITLE
[compiler] Add format string validation for assert macros

### DIFF
--- a/third_party/move/move-compiler-v2/tests/macros/assert.exp
+++ b/third_party/move/move-compiler-v2/tests/macros/assert.exp
@@ -15,6 +15,13 @@ module 0x1::string_utils {
     }
 } // end 0x1::string_utils
 module 0x42::M {
+    private fun bar<T0>(cond: bool,a: T0) {
+        if cond {
+          Tuple()
+        } else {
+          Abort(14566554180833181696, string::into_bytes(string_utils::format1<T0>(Borrow(Immutable)([97, 32, 61, 32, 123, 123, 123, 125, 125, 125]), a)))
+        }
+    }
     private fun foo1(cond: bool) {
         if cond {
           Tuple()
@@ -83,6 +90,9 @@ module 0x1::string_utils {
     }
 }
 module 0x42::M {
+    fun bar<T0: drop>(cond: bool, a: T0) {
+        if (cond) () else abort 0x1::string::into_bytes(0x1::string_utils::format1<T0>(&vector[97u8, 32u8, 61u8, 32u8, 123u8, 123u8, 123u8, 125u8, 125u8, 125u8], a))
+    }
     fun foo1(cond: bool) {
         if (cond) () else abort 14566554180833181696
     }
@@ -123,6 +133,13 @@ module 0x1::string_utils {
     }
 } // end 0x1::string_utils
 module 0x42::M {
+    private fun bar<T0>(cond: bool,a: T0) {
+        if cond {
+          Tuple()
+        } else {
+          Abort(14566554180833181696, string::into_bytes(string_utils::format1<T0>(Borrow(Immutable)([97, 32, 61, 32, 123, 123, 123, 125, 125, 125]), a)))
+        }
+    }
     private fun foo1(cond: bool) {
         if cond {
           Tuple()

--- a/third_party/move/move-compiler-v2/tests/macros/assert.move
+++ b/third_party/move/move-compiler-v2/tests/macros/assert.move
@@ -48,4 +48,8 @@ module 0x42::M {
     fun foo7<T0: drop, T1: drop, T2: drop, T3: drop>(cond: bool, a: T0, b: T1, c: T2, d: T3) {
         assert!(cond, b"a = {}, b = {}, c = {}, d = {}", a, b, c, d)
     }
+
+    fun bar<T0: drop>(cond: bool, a: T0) {
+        assert!(cond, b"a = {{{}}}", a)
+    }
 }

--- a/third_party/move/move-compiler-v2/tests/macros/assert_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/macros/assert_invalid.exp
@@ -23,3 +23,57 @@ error: invalid argument to `abort`: unsupported type `T`
    │
 37 │         assert!(cond, x)
    │                       ^
+
+error: Unmatched '{' in format string
+   ┌─ tests/macros/assert_invalid.move:41:23
+   │
+41 │         assert!(cond, b"a = {", a);
+   │                       ^^^^^^^^
+
+error: Unmatched '}' in format string
+   ┌─ tests/macros/assert_invalid.move:45:23
+   │
+45 │         assert!(cond, b"a = }", a);
+   │                       ^^^^^^^^
+
+error: Invalid placeholder in format string
+   ┌─ tests/macros/assert_invalid.move:49:23
+   │
+49 │         assert!(cond, b"a = {a}", a);
+   │                       ^^^^^^^^^^
+
+error: Format string has 1 placeholder, but 2 arguments were provided
+   ┌─ tests/macros/assert_invalid.move:53:23
+   │
+53 │         assert!(cond, b"a = {}", a, b);
+   │                       ^^^^^^^^^
+
+error: Format string has 2 placeholders, but 1 argument was provided
+   ┌─ tests/macros/assert_invalid.move:57:23
+   │
+57 │         assert!(cond, b"a = {}, b = {}", a);
+   │                       ^^^^^^^^^^^^^^^^^
+
+error: Format string has 1 placeholder, but 0 arguments were provided
+   ┌─ tests/macros/assert_invalid.move:61:23
+   │
+61 │         assert!(cond, b"{}");
+   │                       ^^^^^
+
+error: Unmatched '}' in format string
+   ┌─ tests/macros/assert_invalid.move:65:23
+   │
+65 │         assert!(cond, b"a = {{}", a);
+   │                       ^^^^^^^^^^
+
+error: Unmatched '}' in format string
+   ┌─ tests/macros/assert_invalid.move:69:23
+   │
+69 │         assert!(cond, b"a = {}}", a);
+   │                       ^^^^^^^^^^
+
+error: Format string has 0 placeholders, but 1 argument was provided
+   ┌─ tests/macros/assert_invalid.move:73:23
+   │
+73 │         assert!(cond, b"a = {{}}", a);
+   │                       ^^^^^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/macros/assert_invalid.move
+++ b/third_party/move/move-compiler-v2/tests/macros/assert_invalid.move
@@ -36,4 +36,40 @@ module 0x42::M {
     fun wrong_type_argument<T>(cond: bool, x: T) {
         assert!(cond, x)
     }
+
+    fun unmatched_opening_brace<T0: drop>(cond: bool, a: T0) {
+        assert!(cond, b"a = {", a);
+    }
+
+    fun unmatched_closing_brace<T0: drop>(cond: bool, a: T0) {
+        assert!(cond, b"a = }", a);
+    }
+
+    fun invalid_placeholder<T0: drop>(cond: bool, a: T0) {
+        assert!(cond, b"a = {a}", a);
+    }
+
+    fun too_many_format_arguments<T0: drop, T1: drop>(cond: bool, a: T0, b: T1) {
+        assert!(cond, b"a = {}", a, b);
+    }
+
+    fun too_few_format_arguments<T0: drop>(cond: bool, a: T0) {
+        assert!(cond, b"a = {}, b = {}", a);
+    }
+
+    fun placeholder_with_no_arguments(cond: bool) {
+        assert!(cond, b"{}");
+    }
+
+    fun extra_opening_brace<T0: drop>(cond: bool, a: T0) {
+        assert!(cond, b"a = {{}", a);
+    }
+
+    fun extra_closing_brace<T0: drop>(cond: bool, a: T0) {
+        assert!(cond, b"a = {}}", a);
+    }
+
+    fun escaped_braces_args_mismatch<T0: drop>(cond: bool, a: T0) {
+        assert!(cond, b"a = {{}}", a);
+    }
 }

--- a/third_party/move/move-model/src/builder/macros.rs
+++ b/third_party/move/move-model/src/builder/macros.rs
@@ -159,6 +159,9 @@ impl ExpTranslator<'_, '_, '_> {
             },
             1 => {
                 // assert!(cond, exp)
+                if check_string_literal(&rest[0]).is_some() {
+                    self.check_format_string(&rest[0], 0);
+                }
                 rest[0].clone()
             },
             n if n <= MAX_FORMAT_ARGS => {
@@ -168,7 +171,7 @@ impl ExpTranslator<'_, '_, '_> {
                     "`assert!` macro with string formatting",
                     LanguageVersion::V2_4,
                 );
-                self.check_string_literal(&rest[0]);
+                self.check_format_string(&rest[0], n - 1);
                 self.call_into_bytes(
                     loc,
                     self.call_format(loc, rest[0].clone(), rest[1..].to_vec()),
@@ -298,7 +301,7 @@ impl ExpTranslator<'_, '_, '_> {
             n if n <= MAX_FORMAT_ARGS => {
                 // assert_eq!(left, right, fmt, arg1, ..., argN)
                 let assertion_failed_message = Self::assertion_failed_message(loc, kind, true);
-                self.check_string_literal(&rest[0]);
+                self.check_format_string(&rest[0], n - 1);
                 let message = self.call_format(loc, rest[0].clone(), rest[1..].to_vec());
                 self.call_into_bytes(
                     loc,
@@ -447,16 +450,117 @@ impl ExpTranslator<'_, '_, '_> {
         )
     }
 
-    /// Checks that the expression is a string literal.
-    /// If so, returns the byte array. Otherwise, reports an error and returns `None`.
-    fn check_string_literal<'a>(&self, exp: &'a Exp) -> Option<&'a Vec<u8>> {
-        if let Exp_::Value(val) = &exp.value
-            && let Value_::Bytearray(bytes) = &val.value
-        {
-            Some(bytes)
-        } else {
+    fn check_format_string(&self, exp: &Exp, args: usize) {
+        let Some(bytes) = check_string_literal(exp) else {
             self.error(&self.to_loc(&exp.loc), "Expected a string literal");
-            None
+            return;
+        };
+
+        // Check that the format string is valid and count the number of placeholders.
+        let placeholders = match count_placeholders(bytes) {
+            Ok(n) => n,
+            Err(err) => {
+                self.error(&self.to_loc(&exp.loc), &err.to_string());
+                return;
+            },
+        };
+
+        // Check that the number of placeholders matches the number of arguments.
+        if placeholders != args {
+            let placeholders_str = if placeholders == 1 {
+                "placeholder"
+            } else {
+                "placeholders"
+            };
+            let args_str = if args == 1 {
+                "argument was"
+            } else {
+                "arguments were"
+            };
+            self.error(
+                &self.to_loc(&exp.loc),
+                &format!(
+                    "Format string has {} {}, but {} {} provided",
+                    placeholders, placeholders_str, args, args_str
+                ),
+            );
         }
     }
+}
+
+/// Checks that the expression is a string literal.
+/// If so, returns the byte array. Otherwise, returns `None`.
+fn check_string_literal(exp: &Exp) -> Option<&Vec<u8>> {
+    if let Exp_::Value(val) = &exp.value
+        && let Value_::Bytearray(bytes) = &val.value
+    {
+        Some(bytes)
+    } else {
+        None
+    }
+}
+
+enum BraceError {
+    UnmatchedOpening,
+    UnmatchedClosing,
+    InvalidPlaceholder,
+}
+
+impl Display for BraceError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            BraceError::UnmatchedOpening => write!(f, "Unmatched '{{' in format string"),
+            BraceError::UnmatchedClosing => write!(f, "Unmatched '}}' in format string"),
+            BraceError::InvalidPlaceholder => write!(f, "Invalid placeholder in format string"),
+        }
+    }
+}
+
+/// Counts the number of valid `{}` placeholders in a format string.
+///
+/// Literal braces must be escaped: `{{` becomes `{` and `}}` becomes `}`.
+/// Any other brace sequence is invalid (e.g., `{foo}`, unmatched braces).
+///
+/// Returns an error if the format string contains unmatched or invalid braces.
+fn count_placeholders(bytes: &[u8]) -> Result<usize, BraceError> {
+    let mut i = 0;
+    let mut count = 0;
+
+    while i < bytes.len() {
+        match bytes[i] {
+            b'{' => {
+                if i + 1 >= bytes.len() {
+                    return Err(BraceError::UnmatchedOpening);
+                }
+
+                match bytes[i + 1] {
+                    b'{' => {
+                        // Escaped '{'
+                        i += 2;
+                    },
+                    b'}' => {
+                        // Valid "{}" placeholder
+                        count += 1;
+                        i += 2;
+                    },
+                    _ => {
+                        return Err(BraceError::InvalidPlaceholder);
+                    },
+                }
+            },
+            b'}' => {
+                if i + 1 < bytes.len() && bytes[i + 1] == b'}' {
+                    // Escaped '}'
+                    i += 2;
+                } else {
+                    return Err(BraceError::UnmatchedClosing);
+                }
+            },
+            _ => {
+                i += 1;
+            },
+        }
+    }
+
+    Ok(count)
 }


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

Follow up to https://github.com/aptos-labs/aptos-core/pull/18412#discussion_r2721958060

This commit adds compile-time validation for format strings used in `assert!`, `assert_eq!`, and `assert_ne!` macros in the Move compiler. Th compiler now detects mismatched braces, invalid placeholders, and ensures the number of `{}` placeholders matches the number of arguments provided. This prevents runtime errors by catching issues early.

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

Added new tests for invalid forms.

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [x] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Move compiler macro expansion to reject previously-accepted `assert!`/`assert_eq!`/`assert_ne!` format strings (brace/placeholder/arg-count issues), which may surface new compile errors for existing code.
> 
> **Overview**
> **Compiler behavior change:** `assert!`, `assert_eq!`, and `assert_ne!` now validate format strings at expansion time, detecting unmatched/invalid braces, counting `{}` placeholders (with `{{`/`}}` escaping), and enforcing that placeholder count matches the number of provided format arguments.
> 
> **Tests:** Extends macro tests with an escaped-brace formatting case and adds new negative tests/expected diagnostics for malformed format strings and argument-count mismatches.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3dfb9576830e30272b32308dfce8ad347b7097ca. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->