### PR TITLE
[vm] Avoid deep copies in BCS serialization by using serialize_ref (#14175)

### DIFF
--- a/aptos-move/framework/move-stdlib/src/natives/bcs.rs
+++ b/aptos-move/framework/move-stdlib/src/natives/bcs.rs
@@ -51,6 +51,10 @@ pub fn create_option_u64(enum_option_enabled: bool, value: Option<u64>) -> Value
  *
  **************************************************************************************************/
 /// Rust implementation of Move's `native public fun to_bytes<T>(&T): vector<u8>`
+///
+/// Serializes the value reference `&T` into BCS bytes.
+/// Returns a vector of u8 bytes representing the serialized value.
+/// Aborts if serialization fails.
 fn native_to_bytes(
     context: &mut SafeNativeContext,
     ty_args: &[Type],
@@ -84,16 +88,13 @@ fn native_to_bytes(
         }
     };
 
-    // TODO(#14175): Reading the reference performs a deep copy, and we can
-    //               implement it in a more efficient way.
-    let val = ref_to_val.read_ref()?;
-
+    // Use `serialize_ref` to avoid deep copying the value before serialization.
     let function_value_extension = context.function_value_extension();
     let max_value_nest_depth = context.max_value_nest_depth();
     let serialized_value = match ValueSerDeContext::new(max_value_nest_depth)
         .with_legacy_signer()
         .with_func_args_deserialization(&function_value_extension)
-        .serialize(&val, &layout)?
+        .serialize_ref(&ref_to_val, &layout)?
     {
         Some(serialized_value) => serialized_value,
         None => {
@@ -116,6 +117,10 @@ fn native_to_bytes(
  *   cost is charged.
  *
  **************************************************************************************************/
+/// Rust implementation of Move's `native public fun serialized_size<T>(&T): u64`
+///
+/// Returns the size of the serialized value in bytes.
+/// Aborts if serialization fails (e.g., due to cycle detection or depth limit).
 fn native_serialized_size(
     context: &mut SafeNativeContext,
     ty_args: &[Type],
@@ -148,9 +153,7 @@ fn serialized_size_impl(
     reference: Reference,
     ty: &Type,
 ) -> PartialVMResult<usize> {
-    // TODO(#14175): Reading the reference performs a deep copy, and we can
-    //               implement it in a more efficient way.
-    let value = reference.read_ref()?;
+    // Use `serialized_size_ref` to avoid deep copying the value.
     let ty_layout = context.type_to_type_layout(ty)?;
 
     let function_value_extension = context.function_value_extension();
@@ -159,7 +162,7 @@ fn serialized_size_impl(
         .with_legacy_signer()
         .with_func_args_deserialization(&function_value_extension)
         .with_delayed_fields_serde()
-        .serialized_size(&value, &ty_layout)
+        .serialized_size_ref(&reference, &ty_layout)
 }
 
 fn native_constant_serialized_size(

--- a/third_party/move/move-vm/types/src/value_serde.rs
+++ b/third_party/move/move-vm/types/src/value_serde.rs
@@ -6,8 +6,8 @@
 use crate::{
     delayed_values::delayed_field_id::DelayedFieldID,
     values::{
-        AbstractFunction, DeserializationSeed, SerializationReadyValue, SerializedFunctionData,
-        Value,
+        AbstractFunction, DeserializationSeed, Reference, SerializationReadyValue,
+        SerializedFunctionData, Value,
     },
 };
 #[cfg(test)]
@@ -149,10 +149,7 @@ impl<'a> ValueSerDeContext<'a> {
     }
 
     pub(crate) fn check_depth(&self, depth: u64) -> PartialVMResult<()> {
-        if self
-            .max_value_nested_depth
-            .is_some_and(|max_depth| depth > max_depth)
-        {
+        if self.max_value_nested_depth.unwrap_or(2048).lt(&depth) {
             return Err(PartialVMError::new(StatusCode::VM_MAX_VALUE_DEPTH_REACHED));
         }
         Ok(())
@@ -219,9 +216,65 @@ impl<'a> ValueSerDeContext<'a> {
         }
     }
 
+    /// Serializes a [Reference] based on the provided layout. For legacy reasons, all serialization
+    /// errors are mapped to [None]. If [DelayedFieldsExtension] is set, and there are too many
+    /// delayed fields, an error may be returned.
+    pub fn serialize_ref(
+        self,
+        value: &Reference,
+        layout: &MoveTypeLayout,
+    ) -> PartialVMResult<Option<Vec<u8>>> {
+        let value = SerializationReadyValue {
+            ctx: &self,
+            layout,
+            value,
+            depth: 1,
+        };
+
+        match bcs::to_bytes(&value).ok() {
+            Some(bytes) => Ok(Some(bytes)),
+            None => {
+                // Check if the error is due to too many delayed fields. If so, to be compatible
+                // with the older implementation return an error.
+                if let Some(delayed_fields_extension) = self.delayed_fields_extension {
+                    if delayed_fields_extension.delayed_fields_count.into_inner()
+                        > DelayedFieldsExtension::MAX_DELAYED_FIELDS_PER_RESOURCE
+                    {
+                        return Err(PartialVMError::new(StatusCode::TOO_MANY_DELAYED_FIELDS)
+                            .with_message(
+                                "Too many Delayed fields in a single resource.".to_string(),
+                            ));
+                    }
+                }
+                Ok(None)
+            },
+        }
+    }
+
     /// Returns the serialized size of a [Value] with the associated layout. All errors are mapped
     /// to [StatusCode::VALUE_SERIALIZATION_ERROR].
     pub fn serialized_size(self, value: &Value, layout: &MoveTypeLayout) -> PartialVMResult<usize> {
+        let value = SerializationReadyValue {
+            ctx: &self,
+            layout,
+            value,
+            depth: 1,
+        };
+        bcs::serialized_size(&value).map_err(|e| {
+            PartialVMError::new(StatusCode::VALUE_SERIALIZATION_ERROR).with_message(format!(
+                "failed to compute serialized size of a value: {:?}",
+                e
+            ))
+        })
+    }
+
+    /// Returns the serialized size of a [Reference] with the associated layout. All errors are mapped
+    /// to [StatusCode::VALUE_SERIALIZATION_ERROR].
+    pub fn serialized_size_ref(
+        self,
+        value: &Reference,
+        layout: &MoveTypeLayout,
+    ) -> PartialVMResult<usize> {
         let value = SerializationReadyValue {
             ctx: &self,
             layout,

--- a/third_party/move/move-vm/types/src/value_serde.rs
+++ b/third_party/move/move-vm/types/src/value_serde.rs
@@ -195,25 +195,7 @@ impl<'a> ValueSerDeContext<'a> {
             value,
             depth: 1,
         };
-
-        match bcs::to_bytes(&value).ok() {
-            Some(bytes) => Ok(Some(bytes)),
-            None => {
-                // Check if the error is due to too many delayed fields. If so, to be compatible
-                // with the older implementation return an error.
-                if let Some(delayed_fields_extension) = self.delayed_fields_extension {
-                    if delayed_fields_extension.delayed_fields_count.into_inner()
-                        > DelayedFieldsExtension::MAX_DELAYED_FIELDS_PER_RESOURCE
-                    {
-                        return Err(PartialVMError::new(StatusCode::TOO_MANY_DELAYED_FIELDS)
-                            .with_message(
-                                "Too many Delayed fields in a single resource.".to_string(),
-                            ));
-                    }
-                }
-                Ok(None)
-            },
-        }
+        self.serialize_internal(&value)
     }
 
     /// Serializes a [Reference] based on the provided layout. For legacy reasons, all serialization
@@ -230,14 +212,20 @@ impl<'a> ValueSerDeContext<'a> {
             value,
             depth: 1,
         };
+        self.serialize_internal(&value)
+    }
 
-        match bcs::to_bytes(&value).ok() {
+    fn serialize_internal<V: serde::Serialize>(
+        &self,
+        value: &V,
+    ) -> PartialVMResult<Option<Vec<u8>>> {
+        match bcs::to_bytes(value).ok() {
             Some(bytes) => Ok(Some(bytes)),
             None => {
                 // Check if the error is due to too many delayed fields. If so, to be compatible
                 // with the older implementation return an error.
-                if let Some(delayed_fields_extension) = self.delayed_fields_extension {
-                    if delayed_fields_extension.delayed_fields_count.into_inner()
+                if let Some(delayed_fields_extension) = &self.delayed_fields_extension {
+                    if *delayed_fields_extension.delayed_fields_count.borrow()
                         > DelayedFieldsExtension::MAX_DELAYED_FIELDS_PER_RESOURCE
                     {
                         return Err(PartialVMError::new(StatusCode::TOO_MANY_DELAYED_FIELDS)
@@ -260,12 +248,7 @@ impl<'a> ValueSerDeContext<'a> {
             value,
             depth: 1,
         };
-        bcs::serialized_size(&value).map_err(|e| {
-            PartialVMError::new(StatusCode::VALUE_SERIALIZATION_ERROR).with_message(format!(
-                "failed to compute serialized size of a value: {:?}",
-                e
-            ))
-        })
+        self.serialized_size_internal(&value)
     }
 
     /// Returns the serialized size of a [Reference] with the associated layout. All errors are mapped
@@ -281,7 +264,11 @@ impl<'a> ValueSerDeContext<'a> {
             value,
             depth: 1,
         };
-        bcs::serialized_size(&value).map_err(|e| {
+        self.serialized_size_internal(&value)
+    }
+
+    fn serialized_size_internal<V: serde::Serialize>(&self, value: &V) -> PartialVMResult<usize> {
+        bcs::serialized_size(value).map_err(|e| {
             PartialVMError::new(StatusCode::VALUE_SERIALIZATION_ERROR).with_message(format!(
                 "failed to compute serialized size of a value: {:?}",
                 e

--- a/third_party/move/move-vm/types/src/value_serde.rs
+++ b/third_party/move/move-vm/types/src/value_serde.rs
@@ -149,7 +149,10 @@ impl<'a> ValueSerDeContext<'a> {
     }
 
     pub(crate) fn check_depth(&self, depth: u64) -> PartialVMResult<()> {
-        if self.max_value_nested_depth.unwrap_or(2048).lt(&depth) {
+        if self
+            .max_value_nested_depth
+            .is_some_and(|max_depth| depth > max_depth)
+        {
             return Err(PartialVMError::new(StatusCode::VM_MAX_VALUE_DEPTH_REACHED));
         }
         Ok(())

--- a/third_party/move/move-vm/types/src/values/values_impl.rs
+++ b/third_party/move/move-vm/types/src/values/values_impl.rs
@@ -5295,43 +5295,8 @@ impl serde::Serialize for SerializationReadyValue<'_, '_, '_, MoveTypeLayout, Va
             },
 
             // Signer.
-            (L::Signer, Value::Container(Container::Struct(r))) => {
-                if self.ctx.legacy_signer {
-                    // Only allow serialization of master signer.
-                    if *r.borrow()[0].as_value_ref::<u16>().map_err(|_| {
-                        invariant_violation::<S>(format!(
-                            "First field of a signer needs to be an enum descriminator, got {:?}",
-                            self.value
-                        ))
-                    })? != MASTER_SIGNER_VARIANT
-                    {
-                        return Err(S::Error::custom(PartialVMError::new(StatusCode::ABORTED)));
-                    }
-                    r.borrow()
-                        .get(MASTER_ADDRESS_FIELD_OFFSET)
-                        .ok_or_else(|| {
-                            invariant_violation::<S>(format!(
-                                "cannot serialize container {:?} as {:?}",
-                                self.value, self.layout
-                            ))
-                        })?
-                        .as_value_ref::<AccountAddress>()
-                        .map_err(|_| {
-                            invariant_violation::<S>(format!(
-                                "cannot serialize container {:?} as {:?}",
-                                self.value, self.layout
-                            ))
-                        })?
-                        .serialize(serializer)
-                } else {
-                    (SerializationReadyValue {
-                        ctx: self.ctx,
-                        layout: &MoveStructLayout::signer_serialization_layout(),
-                        value: &*r.borrow(),
-                        depth: self.depth,
-                    })
-                    .serialize(serializer)
-                }
+            (L::Signer, Value::Container(c)) => {
+                serialize_signer_container(self.ctx, self.depth, c, serializer)
             },
 
             // Delayed values. For their serialization, we must have custom
@@ -5383,6 +5348,60 @@ impl serde::Serialize for SerializationReadyValue<'_, '_, '_, MoveTypeLayout, Va
                 value, layout
             ))),
         }
+    }
+}
+
+fn serialize_signer_container<S: serde::Serializer>(
+    ctx: &ValueSerDeContext,
+    depth: u64,
+    container: &Container,
+    serializer: S,
+) -> Result<S::Ok, S::Error> {
+    use serde::Serialize;
+
+    match container {
+        Container::Struct(r) => {
+            if ctx.legacy_signer {
+                // Only allow serialization of master signer.
+                if *r.borrow()[0].as_value_ref::<u16>().map_err(|_| {
+                    invariant_violation::<S>(format!(
+                        "First field of a signer needs to be an enum descriminator, got {:?}",
+                        container
+                    ))
+                })? != MASTER_SIGNER_VARIANT
+                {
+                    return Err(S::Error::custom(PartialVMError::new(StatusCode::ABORTED)));
+                }
+                r.borrow()
+                    .get(MASTER_ADDRESS_FIELD_OFFSET)
+                    .ok_or_else(|| {
+                        invariant_violation::<S>(format!(
+                            "cannot serialize container {:?} as signer",
+                            container
+                        ))
+                    })?
+                    .as_value_ref::<AccountAddress>()
+                    .map_err(|_| {
+                        invariant_violation::<S>(format!(
+                            "cannot serialize container {:?} as signer",
+                            container
+                        ))
+                    })?
+                    .serialize(serializer)
+            } else {
+                (SerializationReadyValue {
+                    ctx,
+                    layout: &MoveStructLayout::signer_serialization_layout(),
+                    value: &*r.borrow(),
+                    depth,
+                })
+                .serialize(serializer)
+            }
+        },
+        _ => Err(invariant_violation::<S>(format!(
+            "cannot serialize container {:?} as signer",
+            container
+        ))),
     }
 }
 
@@ -5590,44 +5609,7 @@ impl serde::Serialize for SerializationReadyValue<'_, '_, '_, MoveTypeLayout, Co
                 serialize_vector_container(self.ctx, self.depth, layout, c, serializer)
             },
             // Signer.
-            (L::Signer, Container::Struct(r)) => {
-                if self.ctx.legacy_signer {
-                    // Only allow serialization of master signer.
-                    if *r.borrow()[0].as_value_ref::<u16>().map_err(|_| {
-                        invariant_violation::<S>(format!(
-                            "First field of a signer needs to be an enum descriminator, got {:?}",
-                            self.value
-                        ))
-                    })? != MASTER_SIGNER_VARIANT
-                    {
-                        return Err(S::Error::custom(PartialVMError::new(StatusCode::ABORTED)));
-                    }
-                    r.borrow()
-                        .get(MASTER_ADDRESS_FIELD_OFFSET)
-                        .ok_or_else(|| {
-                            invariant_violation::<S>(format!(
-                                "cannot serialize container {:?} as {:?}",
-                                self.value, self.layout
-                            ))
-                        })?
-                        .as_value_ref::<AccountAddress>()
-                        .map_err(|_| {
-                            invariant_violation::<S>(format!(
-                                "cannot serialize container {:?} as {:?}",
-                                self.value, self.layout
-                            ))
-                        })?
-                        .serialize(serializer)
-                } else {
-                    (SerializationReadyValue {
-                        ctx: self.ctx,
-                        layout: &MoveStructLayout::signer_serialization_layout(),
-                        value: &*r.borrow(),
-                        depth: self.depth,
-                    })
-                    .serialize(serializer)
-                }
-            },
+            (L::Signer, c) => serialize_signer_container(self.ctx, self.depth, c, serializer),
             (layout, value) => Err(invariant_violation::<S>(format!(
                 "cannot serialize value {:?} as {:?}",
                 value, layout

--- a/third_party/move/move-vm/types/src/values/values_impl.rs
+++ b/third_party/move/move-vm/types/src/values/values_impl.rs
@@ -5564,7 +5564,7 @@ impl serde::Serialize for SerializationReadyValue<'_, '_, '_, MoveTypeLayout, Re
                     ctx: self.ctx,
                     layout: self.layout,
                     value: container,
-                    depth: self.depth + 1,
+                    depth: self.depth,
                 })
                 .serialize(serializer)
             },
@@ -5582,7 +5582,7 @@ impl serde::Serialize for SerializationReadyValue<'_, '_, '_, MoveTypeLayout, Re
                             ctx: self.ctx,
                             layout: self.layout,
                             value: val,
-                            depth: self.depth + 1,
+                            depth: self.depth,
                         })
                         .serialize(serializer)
                     },

--- a/third_party/move/move-vm/types/src/values/values_impl.rs
+++ b/third_party/move/move-vm/types/src/values/values_impl.rs
@@ -5291,39 +5291,7 @@ impl serde::Serialize for SerializationReadyValue<'_, '_, '_, MoveTypeLayout, Va
             // Vectors.
             (L::Vector(layout), Value::Container(c)) => {
                 let layout = layout.as_ref();
-                match (layout, c) {
-                    (L::U8, Container::VecU8(r)) => r.borrow().serialize(serializer),
-                    (L::U16, Container::VecU16(r)) => r.borrow().serialize(serializer),
-                    (L::U32, Container::VecU32(r)) => r.borrow().serialize(serializer),
-                    (L::U64, Container::VecU64(r)) => r.borrow().serialize(serializer),
-                    (L::U128, Container::VecU128(r)) => r.borrow().serialize(serializer),
-                    (L::U256, Container::VecU256(r)) => r.borrow().serialize(serializer),
-                    (L::I8, Container::VecI8(r)) => r.borrow().serialize(serializer),
-                    (L::I16, Container::VecI16(r)) => r.borrow().serialize(serializer),
-                    (L::I32, Container::VecI32(r)) => r.borrow().serialize(serializer),
-                    (L::I64, Container::VecI64(r)) => r.borrow().serialize(serializer),
-                    (L::I128, Container::VecI128(r)) => r.borrow().serialize(serializer),
-                    (L::I256, Container::VecI256(r)) => r.borrow().serialize(serializer),
-                    (L::Bool, Container::VecBool(r)) => r.borrow().serialize(serializer),
-                    (L::Address, Container::VecAddress(r)) => r.borrow().serialize(serializer),
-                    (_, Container::Vec(r)) => {
-                        let v = r.borrow();
-                        let mut t = serializer.serialize_seq(Some(v.len()))?;
-                        for value in v.iter() {
-                            t.serialize_element(&SerializationReadyValue {
-                                ctx: self.ctx,
-                                layout,
-                                value,
-                                depth: self.depth + 1,
-                            })?;
-                        }
-                        t.end()
-                    },
-                    (layout, container) => Err(invariant_violation::<S>(format!(
-                        "cannot serialize container {:?} as {:?}",
-                        container, layout
-                    ))),
-                }
+                serialize_vector_container(self.ctx, self.depth, layout, c, serializer)
             },
 
             // Signer.
@@ -5415,6 +5383,52 @@ impl serde::Serialize for SerializationReadyValue<'_, '_, '_, MoveTypeLayout, Va
                 value, layout
             ))),
         }
+    }
+}
+
+fn serialize_vector_container<S: serde::Serializer>(
+    ctx: &ValueSerDeContext,
+    depth: u64,
+    layout: &MoveTypeLayout,
+    container: &Container,
+    serializer: S,
+) -> Result<S::Ok, S::Error> {
+    use serde::Serialize;
+    use MoveTypeLayout as L;
+    // layout is already &MoveTypeLayout
+
+    match (layout, container) {
+        (L::U8, Container::VecU8(r)) => r.borrow().serialize(serializer),
+        (L::U16, Container::VecU16(r)) => r.borrow().serialize(serializer),
+        (L::U32, Container::VecU32(r)) => r.borrow().serialize(serializer),
+        (L::U64, Container::VecU64(r)) => r.borrow().serialize(serializer),
+        (L::U128, Container::VecU128(r)) => r.borrow().serialize(serializer),
+        (L::U256, Container::VecU256(r)) => r.borrow().serialize(serializer),
+        (L::I8, Container::VecI8(r)) => r.borrow().serialize(serializer),
+        (L::I16, Container::VecI16(r)) => r.borrow().serialize(serializer),
+        (L::I32, Container::VecI32(r)) => r.borrow().serialize(serializer),
+        (L::I64, Container::VecI64(r)) => r.borrow().serialize(serializer),
+        (L::I128, Container::VecI128(r)) => r.borrow().serialize(serializer),
+        (L::I256, Container::VecI256(r)) => r.borrow().serialize(serializer),
+        (L::Bool, Container::VecBool(r)) => r.borrow().serialize(serializer),
+        (L::Address, Container::VecAddress(r)) => r.borrow().serialize(serializer),
+        (_, Container::Vec(r)) => {
+            let v = r.borrow();
+            let mut t = serializer.serialize_seq(Some(v.len()))?;
+            for value in v.iter() {
+                t.serialize_element(&SerializationReadyValue {
+                    ctx,
+                    layout,
+                    value,
+                    depth: depth + 1,
+                })?;
+            }
+            t.end()
+        },
+        (layout, container) => Err(invariant_violation::<S>(format!(
+            "cannot serialize container {:?} as {:?}",
+            container, layout
+        ))),
     }
 }
 
@@ -5573,39 +5587,7 @@ impl serde::Serialize for SerializationReadyValue<'_, '_, '_, MoveTypeLayout, Co
             },
             (L::Vector(layout), c) => {
                 let layout = layout.as_ref();
-                match (layout, c) {
-                    (L::U8, Container::VecU8(r)) => r.borrow().serialize(serializer),
-                    (L::U16, Container::VecU16(r)) => r.borrow().serialize(serializer),
-                    (L::U32, Container::VecU32(r)) => r.borrow().serialize(serializer),
-                    (L::U64, Container::VecU64(r)) => r.borrow().serialize(serializer),
-                    (L::U128, Container::VecU128(r)) => r.borrow().serialize(serializer),
-                    (L::U256, Container::VecU256(r)) => r.borrow().serialize(serializer),
-                    (L::I8, Container::VecI8(r)) => r.borrow().serialize(serializer),
-                    (L::I16, Container::VecI16(r)) => r.borrow().serialize(serializer),
-                    (L::I32, Container::VecI32(r)) => r.borrow().serialize(serializer),
-                    (L::I64, Container::VecI64(r)) => r.borrow().serialize(serializer),
-                    (L::I128, Container::VecI128(r)) => r.borrow().serialize(serializer),
-                    (L::I256, Container::VecI256(r)) => r.borrow().serialize(serializer),
-                    (L::Bool, Container::VecBool(r)) => r.borrow().serialize(serializer),
-                    (L::Address, Container::VecAddress(r)) => r.borrow().serialize(serializer),
-                    (_, Container::Vec(r)) => {
-                        let v = r.borrow();
-                        let mut t = serializer.serialize_seq(Some(v.len()))?;
-                        for value in v.iter() {
-                            t.serialize_element(&SerializationReadyValue {
-                                ctx: self.ctx,
-                                layout,
-                                value,
-                                depth: self.depth + 1,
-                            })?;
-                        }
-                        t.end()
-                    },
-                    (layout, container) => Err(invariant_violation::<S>(format!(
-                        "cannot serialize container {:?} as {:?}",
-                        container, layout
-                    ))),
-                }
+                serialize_vector_container(self.ctx, self.depth, layout, c, serializer)
             },
             // Signer.
             (L::Signer, Container::Struct(r)) => {

--- a/third_party/move/move-vm/types/src/values/values_impl.rs
+++ b/third_party/move/move-vm/types/src/values/values_impl.rs
@@ -5491,6 +5491,223 @@ impl serde::Serialize for SerializationReadyValue<'_, '_, '_, MoveStructLayout, 
     }
 }
 
+impl serde::Serialize for SerializationReadyValue<'_, '_, '_, MoveTypeLayout, Container> {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        use MoveTypeLayout as L;
+
+        self.ctx.check_depth(self.depth).map_err(S::Error::custom)?;
+        match (self.layout, self.value) {
+            (L::Struct(struct_layout), Container::Struct(r)) => {
+                let values = r.borrow();
+                let field_layouts = struct_layout.fields(None);
+                if field_layouts.len() != values.len() {
+                    return Err(invariant_violation::<S>(format!(
+                        "cannot serialize struct value {:?} as {:?} -- number of fields mismatch",
+                        self.value, self.layout
+                    )));
+                }
+                let mut t = serializer.serialize_tuple(values.len())?;
+                for (layout, value) in field_layouts.iter().zip(values.iter()) {
+                    t.serialize_element(&SerializationReadyValue {
+                        ctx: self.ctx,
+                        layout,
+                        value,
+                        depth: self.depth + 1,
+                    })?;
+                }
+                t.end()
+            },
+            (L::Vector(layout), c) => {
+                let layout = layout.as_ref();
+                match (layout, c) {
+                    (L::U8, Container::VecU8(r)) => r.borrow().serialize(serializer),
+                    (L::U16, Container::VecU16(r)) => r.borrow().serialize(serializer),
+                    (L::U32, Container::VecU32(r)) => r.borrow().serialize(serializer),
+                    (L::U64, Container::VecU64(r)) => r.borrow().serialize(serializer),
+                    (L::U128, Container::VecU128(r)) => r.borrow().serialize(serializer),
+                    (L::U256, Container::VecU256(r)) => r.borrow().serialize(serializer),
+                    (L::I8, Container::VecI8(r)) => r.borrow().serialize(serializer),
+                    (L::I16, Container::VecI16(r)) => r.borrow().serialize(serializer),
+                    (L::I32, Container::VecI32(r)) => r.borrow().serialize(serializer),
+                    (L::I64, Container::VecI64(r)) => r.borrow().serialize(serializer),
+                    (L::I128, Container::VecI128(r)) => r.borrow().serialize(serializer),
+                    (L::I256, Container::VecI256(r)) => r.borrow().serialize(serializer),
+                    (L::Bool, Container::VecBool(r)) => r.borrow().serialize(serializer),
+                    (L::Address, Container::VecAddress(r)) => r.borrow().serialize(serializer),
+                    (_, Container::Vec(r)) => {
+                        let v = r.borrow();
+                        let mut t = serializer.serialize_seq(Some(v.len()))?;
+                        for value in v.iter() {
+                            t.serialize_element(&SerializationReadyValue {
+                                ctx: self.ctx,
+                                layout,
+                                value,
+                                depth: self.depth + 1,
+                            })?;
+                        }
+                        t.end()
+                    },
+                    (layout, container) => Err(invariant_violation::<S>(format!(
+                        "cannot serialize container {:?} as {:?}",
+                        container, layout
+                    ))),
+                }
+            },
+            // Signer.
+            (L::Signer, Container::Struct(r)) => {
+                if self.ctx.legacy_signer {
+                    // Only allow serialization of master signer.
+                    if *r.borrow()[0].as_value_ref::<u16>().map_err(|_| {
+                        invariant_violation::<S>(format!(
+                            "First field of a signer needs to be an enum descriminator, got {:?}",
+                            self.value
+                        ))
+                    })? != MASTER_SIGNER_VARIANT
+                    {
+                        return Err(S::Error::custom(PartialVMError::new(StatusCode::ABORTED)));
+                    }
+                    r.borrow()
+                        .get(MASTER_ADDRESS_FIELD_OFFSET)
+                        .ok_or_else(|| {
+                            invariant_violation::<S>(format!(
+                                "cannot serialize container {:?} as {:?}",
+                                self.value, self.layout
+                            ))
+                        })?
+                        .as_value_ref::<AccountAddress>()
+                        .map_err(|_| {
+                            invariant_violation::<S>(format!(
+                                "cannot serialize container {:?} as {:?}",
+                                self.value, self.layout
+                            ))
+                        })?
+                        .serialize(serializer)
+                } else {
+                    (SerializationReadyValue {
+                        ctx: self.ctx,
+                        layout: &MoveStructLayout::signer_serialization_layout(),
+                        value: &*r.borrow(),
+                        depth: self.depth,
+                    })
+                    .serialize(serializer)
+                }
+            },
+            (layout, value) => Err(invariant_violation::<S>(format!(
+                "cannot serialize value {:?} as {:?}",
+                value, layout
+            ))),
+        }
+    }
+}
+
+impl serde::Serialize for SerializationReadyValue<'_, '_, '_, MoveTypeLayout, Reference> {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        self.ctx.check_depth(self.depth).map_err(S::Error::custom)?;
+        match &self.value.0 {
+            ReferenceImpl::ContainerRef(r) => {
+                let container = r.container();
+                (SerializationReadyValue {
+                    ctx: self.ctx,
+                    layout: self.layout,
+                    value: container,
+                    depth: self.depth + 1,
+                })
+                .serialize(serializer)
+            },
+            ReferenceImpl::IndexedRef(r) => {
+                // Check tag first!
+                r.check_tag().map_err(S::Error::custom)?;
+                let container = r.container_ref.container();
+                match container {
+                    Container::Vec(vals) | Container::Locals(vals) | Container::Struct(vals) => {
+                        let vals = vals.borrow();
+                        let val = vals.get(r.idx as usize).ok_or_else(|| {
+                            invariant_violation::<S>("index out of bounds".to_string())
+                        })?;
+                        (SerializationReadyValue {
+                            ctx: self.ctx,
+                            layout: self.layout,
+                            value: val,
+                            depth: self.depth + 1,
+                        })
+                        .serialize(serializer)
+                    },
+                    Container::VecU8(vals) => {
+                        serializer.serialize_u8(*vals.borrow().get(r.idx as usize).ok_or_else(
+                            || invariant_violation::<S>("index out of bounds".to_string()),
+                        )?)
+                    },
+                    Container::VecU64(vals) => {
+                        serializer.serialize_u64(*vals.borrow().get(r.idx as usize).ok_or_else(
+                            || invariant_violation::<S>("index out of bounds".to_string()),
+                        )?)
+                    },
+                    Container::VecU128(vals) => {
+                        serializer.serialize_u128(*vals.borrow().get(r.idx as usize).ok_or_else(
+                            || invariant_violation::<S>("index out of bounds".to_string()),
+                        )?)
+                    },
+                    Container::VecBool(vals) => {
+                        serializer.serialize_bool(*vals.borrow().get(r.idx as usize).ok_or_else(
+                            || invariant_violation::<S>("index out of bounds".to_string()),
+                        )?)
+                    },
+                    Container::VecAddress(vals) => vals
+                        .borrow()
+                        .get(r.idx as usize)
+                        .ok_or_else(|| invariant_violation::<S>("index out of bounds".to_string()))?
+                        .serialize(serializer),
+                    Container::VecU16(vals) => {
+                        serializer.serialize_u16(*vals.borrow().get(r.idx as usize).ok_or_else(
+                            || invariant_violation::<S>("index out of bounds".to_string()),
+                        )?)
+                    },
+                    Container::VecU32(vals) => {
+                        serializer.serialize_u32(*vals.borrow().get(r.idx as usize).ok_or_else(
+                            || invariant_violation::<S>("index out of bounds".to_string()),
+                        )?)
+                    },
+                    Container::VecU256(vals) => vals
+                        .borrow()
+                        .get(r.idx as usize)
+                        .ok_or_else(|| invariant_violation::<S>("index out of bounds".to_string()))?
+                        .serialize(serializer),
+                    Container::VecI8(vals) => {
+                        serializer.serialize_i8(*vals.borrow().get(r.idx as usize).ok_or_else(
+                            || invariant_violation::<S>("index out of bounds".to_string()),
+                        )?)
+                    },
+                    Container::VecI16(vals) => {
+                        serializer.serialize_i16(*vals.borrow().get(r.idx as usize).ok_or_else(
+                            || invariant_violation::<S>("index out of bounds".to_string()),
+                        )?)
+                    },
+                    Container::VecI32(vals) => {
+                        serializer.serialize_i32(*vals.borrow().get(r.idx as usize).ok_or_else(
+                            || invariant_violation::<S>("index out of bounds".to_string()),
+                        )?)
+                    },
+                    Container::VecI64(vals) => {
+                        serializer.serialize_i64(*vals.borrow().get(r.idx as usize).ok_or_else(
+                            || invariant_violation::<S>("index out of bounds".to_string()),
+                        )?)
+                    },
+                    Container::VecI128(vals) => {
+                        serializer.serialize_i128(*vals.borrow().get(r.idx as usize).ok_or_else(
+                            || invariant_violation::<S>("index out of bounds".to_string()),
+                        )?)
+                    },
+                    Container::VecI256(vals) => vals
+                        .borrow()
+                        .get(r.idx as usize)
+                        .ok_or_else(|| invariant_violation::<S>("index out of bounds".to_string()))?
+                        .serialize(serializer),
+                }
+            },
+        }
+    }
+}
+
 // Seed used by deserializer to ensure there is information about the value
 // being deserialized.
 pub(crate) struct DeserializationSeed<'c, L> {

--- a/third_party/move/move-vm/types/src/values/values_impl.rs
+++ b/third_party/move/move-vm/types/src/values/values_impl.rs
@@ -5531,78 +5531,14 @@ impl serde::Serialize for SerializationReadyValue<'_, '_, '_, MoveTypeLayout, Co
         self.ctx.check_depth(self.depth).map_err(S::Error::custom)?;
         match (self.layout, self.value) {
             (L::Struct(struct_layout), Container::Struct(r)) => {
-                let values_ref = r.borrow();
-                let mut values = values_ref.as_slice();
-
-                if let Some((tag, variant_layouts)) =
-                    try_get_variant_field_layouts(struct_layout, values)
-                {
-                    let tag_idx = tag as usize;
-                    let variant_tag = tag_idx as u32;
-                    let variant_names = value::variant_name_placeholder((tag + 1) as usize)
-                        .map_err(|e| serde::ser::Error::custom(format!("{}", e)))?;
-                    let variant_name = variant_names[tag_idx];
-                    values = &values[1..];
-                    if variant_layouts.len() != values.len() {
-                        return Err(invariant_violation::<S>(format!(
-                            "cannot serialize struct value {:?} as {:?} -- number of fields mismatch",
-                            self.value, self.layout
-                        )));
-                    }
-                    match values.len() {
-                        0 => serializer.serialize_unit_variant(
-                            value::MOVE_ENUM_NAME,
-                            variant_tag,
-                            variant_name,
-                        ),
-                        1 => serializer.serialize_newtype_variant(
-                            value::MOVE_ENUM_NAME,
-                            variant_tag,
-                            variant_name,
-                            &SerializationReadyValue {
-                                ctx: self.ctx,
-                                layout: &variant_layouts[0],
-                                value: &values[0],
-                                depth: self.depth + 1,
-                            },
-                        ),
-                        _ => {
-                            let mut t = serializer.serialize_tuple_variant(
-                                value::MOVE_ENUM_NAME,
-                                variant_tag,
-                                variant_name,
-                                values.len(),
-                            )?;
-                            for (layout, value) in variant_layouts.iter().zip(values) {
-                                t.serialize_field(&SerializationReadyValue {
-                                    ctx: self.ctx,
-                                    layout,
-                                    value,
-                                    depth: self.depth + 1,
-                                })?
-                            }
-                            t.end()
-                        },
-                    }
-                } else {
-                    let field_layouts = struct_layout.fields(None);
-                    if field_layouts.len() != values.len() {
-                        return Err(invariant_violation::<S>(format!(
-                            "cannot serialize struct value {:?} as {:?} -- number of fields mismatch",
-                            self.value, self.layout
-                        )));
-                    }
-                    let mut t = serializer.serialize_tuple(values.len())?;
-                    for (layout, value) in field_layouts.iter().zip(values.iter()) {
-                        t.serialize_element(&SerializationReadyValue {
-                            ctx: self.ctx,
-                            layout,
-                            value,
-                            depth: self.depth + 1,
-                        })?;
-                    }
-                    t.end()
-                }
+                let values = r.borrow();
+                (SerializationReadyValue {
+                    ctx: self.ctx,
+                    layout: struct_layout,
+                    value: &*values,
+                    depth: self.depth,
+                })
+                .serialize(serializer)
             },
             (L::Vector(layout), c) => {
                 let layout = layout.as_ref();

--- a/third_party/move/move-vm/types/src/values/values_impl.rs
+++ b/third_party/move/move-vm/types/src/values/values_impl.rs
@@ -5498,24 +5498,78 @@ impl serde::Serialize for SerializationReadyValue<'_, '_, '_, MoveTypeLayout, Co
         self.ctx.check_depth(self.depth).map_err(S::Error::custom)?;
         match (self.layout, self.value) {
             (L::Struct(struct_layout), Container::Struct(r)) => {
-                let values = r.borrow();
-                let field_layouts = struct_layout.fields(None);
-                if field_layouts.len() != values.len() {
-                    return Err(invariant_violation::<S>(format!(
-                        "cannot serialize struct value {:?} as {:?} -- number of fields mismatch",
-                        self.value, self.layout
-                    )));
+                let values_ref = r.borrow();
+                let mut values = values_ref.as_slice();
+
+                if let Some((tag, variant_layouts)) =
+                    try_get_variant_field_layouts(struct_layout, values)
+                {
+                    let tag_idx = tag as usize;
+                    let variant_tag = tag_idx as u32;
+                    let variant_names = value::variant_name_placeholder((tag + 1) as usize)
+                        .map_err(|e| serde::ser::Error::custom(format!("{}", e)))?;
+                    let variant_name = variant_names[tag_idx];
+                    values = &values[1..];
+                    if variant_layouts.len() != values.len() {
+                        return Err(invariant_violation::<S>(format!(
+                            "cannot serialize struct value {:?} as {:?} -- number of fields mismatch",
+                            self.value, self.layout
+                        )));
+                    }
+                    match values.len() {
+                        0 => serializer.serialize_unit_variant(
+                            value::MOVE_ENUM_NAME,
+                            variant_tag,
+                            variant_name,
+                        ),
+                        1 => serializer.serialize_newtype_variant(
+                            value::MOVE_ENUM_NAME,
+                            variant_tag,
+                            variant_name,
+                            &SerializationReadyValue {
+                                ctx: self.ctx,
+                                layout: &variant_layouts[0],
+                                value: &values[0],
+                                depth: self.depth + 1,
+                            },
+                        ),
+                        _ => {
+                            let mut t = serializer.serialize_tuple_variant(
+                                value::MOVE_ENUM_NAME,
+                                variant_tag,
+                                variant_name,
+                                values.len(),
+                            )?;
+                            for (layout, value) in variant_layouts.iter().zip(values) {
+                                t.serialize_field(&SerializationReadyValue {
+                                    ctx: self.ctx,
+                                    layout,
+                                    value,
+                                    depth: self.depth + 1,
+                                })?
+                            }
+                            t.end()
+                        },
+                    }
+                } else {
+                    let field_layouts = struct_layout.fields(None);
+                    if field_layouts.len() != values.len() {
+                        return Err(invariant_violation::<S>(format!(
+                            "cannot serialize struct value {:?} as {:?} -- number of fields mismatch",
+                            self.value, self.layout
+                        )));
+                    }
+                    let mut t = serializer.serialize_tuple(values.len())?;
+                    for (layout, value) in field_layouts.iter().zip(values.iter()) {
+                        t.serialize_element(&SerializationReadyValue {
+                            ctx: self.ctx,
+                            layout,
+                            value,
+                            depth: self.depth + 1,
+                        })?;
+                    }
+                    t.end()
                 }
-                let mut t = serializer.serialize_tuple(values.len())?;
-                for (layout, value) in field_layouts.iter().zip(values.iter()) {
-                    t.serialize_element(&SerializationReadyValue {
-                        ctx: self.ctx,
-                        layout,
-                        value,
-                        depth: self.depth + 1,
-                    })?;
-                }
-                t.end()
             },
             (L::Vector(layout), c) => {
                 let layout = layout.as_ref();


### PR DESCRIPTION
Resolves #14175

Replaced read_ref() deep copies with serialize_ref and serialized_size_ref to avoid cloning Move values during BCS serialization.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches VM value serialization paths and adds new `Reference`-based serialization, which could subtly affect BCS output or error mapping if any layout/container cases are missed. Main impact is performance/memory, but it sits on a frequently used and consensus-sensitive code path.
> 
> **Overview**
> Updates Move stdlib BCS natives to serialize directly from `&T` references, replacing `read_ref()` deep copies with new `ValueSerDeContext::{serialize_ref, serialized_size_ref}` calls.
> 
> Extends Move VM serde to support `Reference`-based serialization and size computation, refactoring shared BCS encode/size logic and adding `serde::Serialize` implementations/helpers for serializing `Reference`/`Container` (including vector and signer handling) without materializing full `Value` copies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 533a2f004ee5091b20581c85fbbe82ed0bfef120. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->