### PR TITLE
[crypto] Rename SecretSharingConfig trait to TSecretSharingConfig

### DIFF
--- a/crates/aptos-batch-encryption/src/schemes/fptx_weighted.rs
+++ b/crates/aptos-batch-encryption/src/schemes/fptx_weighted.rs
@@ -21,7 +21,7 @@ use anyhow::{anyhow, Result};
 use aptos_crypto::{
     arkworks::serialization::{ark_de, ark_se},
     weighted_config::WeightedConfigArkworks,
-    SecretSharingConfig as _,
+    TSecretSharingConfig as _,
 };
 use aptos_dkg::pvss::{
     traits::{Reconstructable as _, Subtranscript},

--- a/crates/aptos-batch-encryption/src/tests/fptx_weighted_smoke.rs
+++ b/crates/aptos-batch-encryption/src/tests/fptx_weighted_smoke.rs
@@ -6,7 +6,7 @@ use crate::{
     traits::BatchThresholdEncryption,
 };
 use anyhow::Result;
-use aptos_crypto::{weighted_config::WeightedConfigArkworks, SecretSharingConfig as _};
+use aptos_crypto::{weighted_config::WeightedConfigArkworks, TSecretSharingConfig as _};
 use ark_ec::AffineRepr as _;
 use ark_std::rand::{seq::SliceRandom, thread_rng, CryptoRng, Rng as _, RngCore};
 

--- a/crates/aptos-batch-encryption/src/traits.rs
+++ b/crates/aptos-batch-encryption/src/traits.rs
@@ -8,7 +8,7 @@ use serde::{de::DeserializeOwned, Serialize};
 use std::hash::Hash;
 
 pub trait BatchThresholdEncryption {
-    type ThresholdConfig: aptos_crypto::SecretSharingConfig;
+    type ThresholdConfig: aptos_crypto::TSecretSharingConfig;
     type SubTranscript: Subtranscript;
 
     /// An encryption key for the scheme. Allows for generating ciphertexts. If we want to actually

--- a/crates/aptos-crypto/src/arkworks/shamir.rs
+++ b/crates/aptos-crypto/src/arkworks/shamir.rs
@@ -7,7 +7,7 @@ use crate::{
     arkworks::{differentiate::DifferentiableFn, vanishing_poly, weighted_sum::WeightedSum},
     player::Player,
     traits,
-    traits::SecretSharingConfig,
+    traits::TSecretSharingConfig,
 };
 use anyhow::{anyhow, Result};
 use ark_ec::CurveGroup;
@@ -27,7 +27,7 @@ pub type ShamirShare<F: WeightedSum> = (Player, F);
 pub type ShamirGroupShare<G: CurveGroup> = ShamirShare<G>;
 
 /// All dealt secret keys should be reconstructable from a subset of \[dealt secret key\] shares.
-pub trait Reconstructable<SSC: traits::SecretSharingConfig>: Sized {
+pub trait Reconstructable<SSC: traits::TSecretSharingConfig>: Sized {
     /// The "share" type. Minor nit: this is a slight misnomer; you can't actually reconstruct
     /// using just a vec of shares, you need a vec of pairs (Player, Self::Share). So the pair
     /// itself corresponds more closely to the definition of a share
@@ -52,7 +52,7 @@ pub struct ShamirThresholdConfig<F: FftField> {
     pub domain: Radix2EvaluationDomain<F>,
 }
 
-impl<F: FftField> traits::SecretSharingConfig for ShamirThresholdConfig<F> {
+impl<F: FftField> traits::TSecretSharingConfig for ShamirThresholdConfig<F> {
     /// For testing only.
     fn get_random_player<R>(&self, rng: &mut R) -> Player
     where

--- a/crates/aptos-crypto/src/blstrs/scalar_secret_key.rs
+++ b/crates/aptos-crypto/src/blstrs/scalar_secret_key.rs
@@ -6,7 +6,7 @@
 use crate::{
     arkworks::shamir::{Reconstructable, ShamirShare},
     blstrs::{lagrange::lagrange_coefficients, threshold_config::ThresholdConfigBlstrs},
-    traits::{SecretSharingConfig as _, ThresholdConfig as _},
+    traits::{TSecretSharingConfig as _, ThresholdConfig as _},
 };
 use blstrs::Scalar;
 use ff::Field;

--- a/crates/aptos-crypto/src/blstrs/threshold_config.rs
+++ b/crates/aptos-crypto/src/blstrs/threshold_config.rs
@@ -71,7 +71,7 @@ impl Display for ThresholdConfigBlstrs {
     }
 }
 
-impl traits::SecretSharingConfig for ThresholdConfigBlstrs {
+impl traits::TSecretSharingConfig for ThresholdConfigBlstrs {
     /// For testing only.
     fn get_random_player<R>(&self, rng: &mut R) -> Player
     where

--- a/crates/aptos-crypto/src/traits/mod.rs
+++ b/crates/aptos-crypto/src/traits/mod.rs
@@ -319,7 +319,7 @@ pub trait Genesis: PrivateKey {
 }
 
 /// Trait defining the interface for secret sharing schemes.
-pub trait SecretSharingConfig: Display {
+pub trait TSecretSharingConfig: Display {
     /// Creates a new player ID; a number from 0 to `n-1`, where `n = get_total_num_players(&self)`.
     fn get_player(&self, i: usize) -> Player {
         let n = self.get_total_num_players();
@@ -354,7 +354,7 @@ pub trait SecretSharingConfig: Display {
 }
 
 /// Trait for secret sharing schemes that expose a threshold `t`.
-pub trait ThresholdConfig: SecretSharingConfig + Sized {
+pub trait ThresholdConfig: TSecretSharingConfig + Sized {
     /// Constructs a new threshold configuration given `t` (threshold) and `n` (number of players). Only used in `get_threshold_configs_for_testing()`, maybe not ideal here
     fn new(t: usize, n: usize) -> anyhow::Result<Self>;
 

--- a/crates/aptos-crypto/src/weighted_config.rs
+++ b/crates/aptos-crypto/src/weighted_config.rs
@@ -13,7 +13,7 @@ use crate::{
         threshold_config::ThresholdConfigBlstrs,
     },
     player::Player,
-    traits::{self, SecretSharingConfig as _, ThresholdConfig},
+    traits::{self, TSecretSharingConfig as _, ThresholdConfig},
 };
 use anyhow::anyhow;
 use ark_ec::CurveGroup;
@@ -319,7 +319,7 @@ impl<TC: ThresholdConfig> Display for WeightedConfig<TC> {
     }
 }
 
-impl<TC: ThresholdConfig> traits::SecretSharingConfig for WeightedConfig<TC> {
+impl<TC: ThresholdConfig> traits::TSecretSharingConfig for WeightedConfig<TC> {
     /// For testing only.
     fn get_random_player<R>(&self, rng: &mut R) -> Player
     where

--- a/crates/aptos-dkg/benches/pvss.rs
+++ b/crates/aptos-dkg/benches/pvss.rs
@@ -4,7 +4,7 @@
 #![allow(clippy::ptr_arg)]
 #![allow(clippy::needless_borrow)]
 
-use aptos_crypto::{SecretSharingConfig, Uniform};
+use aptos_crypto::{TSecretSharingConfig, Uniform};
 use aptos_dkg::pvss::{
     chunky::{UnsignedWeightedTranscript as Chunky_v1, UnsignedWeightedTranscriptv2 as Chunky_v2},
     das,

--- a/crates/aptos-dkg/benches/weighted_vuf.rs
+++ b/crates/aptos-dkg/benches/weighted_vuf.rs
@@ -6,7 +6,7 @@
 #![allow(clippy::extra_unused_type_parameters)]
 #![allow(clippy::needless_borrow)]
 
-use aptos_crypto::traits::SecretSharingConfig as _;
+use aptos_crypto::traits::TSecretSharingConfig as _;
 use aptos_dkg::{
     pvss::{
         das,

--- a/crates/aptos-dkg/src/pvss/chunky/hkzg_chunked_elgamal.rs
+++ b/crates/aptos-dkg/src/pvss/chunky/hkzg_chunked_elgamal.rs
@@ -20,7 +20,7 @@ use aptos_crypto::{
         unsafe_random_points_group, UniformRand,
     },
     weighted_config::WeightedConfigArkworks,
-    SecretSharingConfig,
+    TSecretSharingConfig,
 };
 use aptos_crypto_derive::SigmaProtocolWitness;
 use ark_ec::{pairing::Pairing, AdditiveGroup, AffineRepr, CurveGroup};

--- a/crates/aptos-dkg/src/pvss/chunky/hkzg_chunked_elgamal_commit.rs
+++ b/crates/aptos-dkg/src/pvss/chunky/hkzg_chunked_elgamal_commit.rs
@@ -17,7 +17,7 @@ use crate::{
 };
 use aptos_crypto::{
     arkworks::random::unsafe_random_points_group, weighted_config::WeightedConfigArkworks,
-    SecretSharingConfig,
+    TSecretSharingConfig,
 };
 use ark_ec::{pairing::Pairing, AffineRepr, CurveGroup};
 

--- a/crates/aptos-dkg/src/pvss/chunky/weighted_transcript.rs
+++ b/crates/aptos-dkg/src/pvss/chunky/weighted_transcript.rs
@@ -43,7 +43,7 @@ use aptos_crypto::{
     bls12381::{self},
     utils,
     weighted_config::WeightedConfigArkworks,
-    CryptoMaterialError, SecretSharingConfig as _, ValidCryptoMaterial,
+    CryptoMaterialError, TSecretSharingConfig as _, ValidCryptoMaterial,
 };
 use ark_ec::{
     pairing::{Pairing, PairingOutput},

--- a/crates/aptos-dkg/src/pvss/chunky/weighted_transcriptv2.rs
+++ b/crates/aptos-dkg/src/pvss/chunky/weighted_transcriptv2.rs
@@ -40,7 +40,7 @@ use aptos_crypto::{
     },
     bls12381::{self},
     weighted_config::WeightedConfigArkworks,
-    CryptoMaterialError, SecretSharingConfig as _, ValidCryptoMaterial,
+    CryptoMaterialError, TSecretSharingConfig, ValidCryptoMaterial,
 };
 use ark_ec::{pairing::Pairing, AffineRepr, CurveGroup};
 use ark_ff::{AdditiveGroup, Fp, FpConfig};

--- a/crates/aptos-dkg/src/pvss/das/unweighted_protocol.rs
+++ b/crates/aptos-dkg/src/pvss/das/unweighted_protocol.rs
@@ -26,7 +26,7 @@ use anyhow::bail;
 use aptos_crypto::{
     bls12381,
     blstrs::{multi_pairing, random_scalar},
-    traits::SecretSharingConfig as _,
+    traits::TSecretSharingConfig as _,
     CryptoMaterialError, Genesis, SigningKey, ValidCryptoMaterial,
 };
 use aptos_crypto_derive::{BCSCryptoHash, CryptoHasher};

--- a/crates/aptos-dkg/src/pvss/das/weighted_protocol.rs
+++ b/crates/aptos-dkg/src/pvss/das/weighted_protocol.rs
@@ -26,7 +26,7 @@ use anyhow::bail;
 use aptos_crypto::{
     bls12381,
     blstrs::{multi_pairing, random_scalar},
-    traits::SecretSharingConfig as _,
+    traits::TSecretSharingConfig as _,
     weighted_config::WeightedConfig,
     CryptoMaterialError, Genesis, SigningKey, ValidCryptoMaterial,
 };

--- a/crates/aptos-dkg/src/pvss/dealt_secret_key.rs
+++ b/crates/aptos-dkg/src/pvss/dealt_secret_key.rs
@@ -23,7 +23,7 @@ macro_rules! dealt_secret_key_impl {
         use blstrs::{$GTProjective, Scalar};
         use ff::Field;
         use more_asserts::{assert_ge, assert_le};
-        use aptos_crypto::traits::{SecretSharingConfig as _};
+        use aptos_crypto::traits::{TSecretSharingConfig as _};
         use aptos_crypto::traits::{ThresholdConfig as _};
         use aptos_crypto::arkworks::shamir::Reconstructable;
         use aptos_crypto::arkworks::shamir::ShamirShare;

--- a/crates/aptos-dkg/src/pvss/insecure_field/transcript.rs
+++ b/crates/aptos-dkg/src/pvss/insecure_field/transcript.rs
@@ -16,7 +16,7 @@ use crate::{
 };
 use anyhow::bail;
 use aptos_crypto::{
-    bls12381, traits::SecretSharingConfig as _, CryptoMaterialError, ValidCryptoMaterial,
+    bls12381, traits::TSecretSharingConfig as _, CryptoMaterialError, ValidCryptoMaterial,
 };
 use aptos_crypto_derive::{BCSCryptoHash, CryptoHasher};
 use blstrs::{G2Projective, Scalar};

--- a/crates/aptos-dkg/src/pvss/test_utils.rs
+++ b/crates/aptos-dkg/src/pvss/test_utils.rs
@@ -10,7 +10,7 @@ use crate::pvss::{
 };
 use aptos_crypto::{
     arkworks::shamir::Reconstructable,
-    traits::{self, SecretSharingConfig as _, ThresholdConfig as _},
+    traits::{self, TSecretSharingConfig as _, ThresholdConfig as _},
     weighted_config::{WeightedConfig, WeightedConfigArkworks},
     SigningKey, Uniform,
 };

--- a/crates/aptos-dkg/src/pvss/traits/transcript.rs
+++ b/crates/aptos-dkg/src/pvss/traits/transcript.rs
@@ -53,7 +53,7 @@ use crate::pvss::{
 };
 use anyhow::bail;
 use aptos_crypto::{
-    arkworks::shamir::Reconstructable, SecretSharingConfig, SigningKey, Uniform,
+    arkworks::shamir::Reconstructable, SigningKey, TSecretSharingConfig, Uniform,
     ValidCryptoMaterial, VerifyingKey,
 };
 use num_traits::Zero;
@@ -71,7 +71,7 @@ pub trait Subtranscript: Debug + ValidCryptoMaterial + Clone + PartialEq + Eq {
         + Debug
         + PartialEq
         + Eq;
-    type SecretSharingConfig: SecretSharingConfig
+    type SecretSharingConfig: TSecretSharingConfig
         + DeserializeOwned
         + Serialize
         + Debug
@@ -145,7 +145,7 @@ pub trait Transcript: Debug + ValidCryptoMaterial + Clone + PartialEq + Eq {
         + Debug
         + PartialEq
         + Eq;
-    type SecretSharingConfig: SecretSharingConfig
+    type SecretSharingConfig: TSecretSharingConfig
         + DeserializeOwned
         + Serialize
         + Debug

--- a/crates/aptos-dkg/src/pvss/weighted/generic_weighting.rs
+++ b/crates/aptos-dkg/src/pvss/weighted/generic_weighting.rs
@@ -14,7 +14,7 @@ use crate::pvss::{
 };
 use crate::traits::transcript::Aggregatable;
 use aptos_crypto::{
-    traits::SecretSharingConfig as _, weighted_config::WeightedConfig, CryptoMaterialError,
+    traits::TSecretSharingConfig as _, weighted_config::WeightedConfig, CryptoMaterialError,
     ValidCryptoMaterial,
 };
 use aptos_crypto_derive::{BCSCryptoHash, CryptoHasher};

--- a/crates/aptos-dkg/tests/dkg.rs
+++ b/crates/aptos-dkg/tests/dkg.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-use aptos_crypto::{blstrs::random_scalar, hash::CryptoHash, traits::SecretSharingConfig as _};
+use aptos_crypto::{blstrs::random_scalar, hash::CryptoHash, traits::TSecretSharingConfig as _};
 use aptos_dkg::pvss::{
     das::{self, unweighted_protocol},
     insecure_field,

--- a/crates/aptos-dkg/tests/pvss.rs
+++ b/crates/aptos-dkg/tests/pvss.rs
@@ -7,7 +7,7 @@
 
 //! PVSS scheme-independent testing
 #[cfg(test)]
-use aptos_crypto::SecretSharingConfig;
+use aptos_crypto::TSecretSharingConfig;
 use aptos_crypto::{
     blstrs::{random_scalar, G1_PROJ_NUM_BYTES, G2_PROJ_NUM_BYTES},
     weighted_config::WeightedConfigArkworks,

--- a/crates/aptos-dkg/tests/secret_sharing_config.rs
+++ b/crates/aptos-dkg/tests/secret_sharing_config.rs
@@ -4,7 +4,7 @@
 #![allow(clippy::ptr_arg)]
 #![allow(clippy::needless_borrow)]
 
-use aptos_crypto::{arkworks::shamir::ShamirThresholdConfig, traits::SecretSharingConfig as _};
+use aptos_crypto::{arkworks::shamir::ShamirThresholdConfig, traits::TSecretSharingConfig as _};
 use aptos_dkg::pvss::test_utils::get_weighted_configs_for_benchmarking;
 use rand::thread_rng;
 

--- a/crates/aptos-dkg/tests/weighted_vuf.rs
+++ b/crates/aptos-dkg/tests/weighted_vuf.rs
@@ -4,7 +4,7 @@
 #![allow(clippy::ptr_arg)]
 #![allow(clippy::needless_borrow)]
 
-use aptos_crypto::{blstrs::random_scalar, traits::SecretSharingConfig as _};
+use aptos_crypto::{blstrs::random_scalar, traits::TSecretSharingConfig as _};
 use aptos_dkg::{
     pvss::{
         self,


### PR DESCRIPTION
## Summary

The name SecretSharingConfig makes it confusing for a trait name, because I usually associate config with a welldefined struct. Renaming to  TSecretSharingConfig to make this distinction clear.

- Renamed `SecretSharingConfig` trait to `TSecretSharingConfig` in aptos-crypto
- Updated all references in aptos-crypto, aptos-dkg, and aptos-batch-encryption crates

This renames the SecretSharingConfig trait to TSecretSharingConfig to follow the naming convention for traits (T prefix) and avoid confusion with associated types of the same name in PVSS transcript traits.

## Test plan
- `cargo check -p aptos-crypto -p aptos-dkg -p aptos-batch-encryption` passes
- No functional changes, pure rename refactoring

## Type of Change
- [x] Refactoring

## Which Components or Systems Does This Change Impact?
- [x] Other (crypto crates)

🤖 Generated with [Claude Code](https://claude.ai/code)