### PR TITLE
[consensus] Add ValidatorTransaction::ChunkyDKGResult and consensus hooks

### DIFF
--- a/api/doc/spec.json
+++ b/api/doc/spec.json
@@ -16373,6 +16373,73 @@
           }
         }
       },
+      "ChunkyDKGResultTransaction": {
+        "type": "object",
+        "required": [
+          "version",
+          "hash",
+          "state_change_hash",
+          "event_root_hash",
+          "gas_used",
+          "success",
+          "vm_status",
+          "accumulator_root_hash",
+          "changes",
+          "events",
+          "timestamp",
+          "certified_subtrx"
+        ],
+        "properties": {
+          "version": {
+            "$ref": "#/components/schemas/U64"
+          },
+          "hash": {
+            "$ref": "#/components/schemas/HashValue"
+          },
+          "state_change_hash": {
+            "$ref": "#/components/schemas/HashValue"
+          },
+          "event_root_hash": {
+            "$ref": "#/components/schemas/HashValue"
+          },
+          "state_checkpoint_hash": {
+            "$ref": "#/components/schemas/HashValue"
+          },
+          "gas_used": {
+            "$ref": "#/components/schemas/U64"
+          },
+          "success": {
+            "type": "boolean",
+            "description": "Whether the transaction was successful"
+          },
+          "vm_status": {
+            "type": "string",
+            "description": "The VM status of the transaction, can tell useful information in a failure"
+          },
+          "accumulator_root_hash": {
+            "$ref": "#/components/schemas/HashValue"
+          },
+          "changes": {
+            "type": "array",
+            "description": "Final state of resources changed by the transaction",
+            "items": {
+              "$ref": "#/components/schemas/WriteSetChange"
+            }
+          },
+          "events": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Event"
+            }
+          },
+          "timestamp": {
+            "$ref": "#/components/schemas/U64"
+          },
+          "certified_subtrx": {
+            "$ref": "#/components/schemas/ExportedCertifiedAggregatedChunkySubtranscript"
+          }
+        }
+      },
       "DKGResultTransaction": {
         "type": "object",
         "required": [
@@ -16727,6 +16794,30 @@
           },
           "sig": {
             "$ref": "#/components/schemas/HexEncodedBytes"
+          }
+        }
+      },
+      "ExportedCertifiedAggregatedChunkySubtranscript": {
+        "type": "object",
+        "description": "A more API-friendly representation of the on-chain\n`aptos_types::dkg::chunky_dkg::CertifiedAggregatedChunkySubtranscript`.",
+        "required": [
+          "epoch",
+          "author",
+          "subtrx",
+          "signature"
+        ],
+        "properties": {
+          "epoch": {
+            "$ref": "#/components/schemas/U64"
+          },
+          "author": {
+            "$ref": "#/components/schemas/Address"
+          },
+          "subtrx": {
+            "$ref": "#/components/schemas/HexEncodedBytes"
+          },
+          "signature": {
+            "$ref": "#/components/schemas/ExportedAggregateSignature"
           }
         }
       },
@@ -18998,15 +19089,41 @@
           },
           {
             "$ref": "#/components/schemas/ValidatorTransaction_DKGResultTransaction"
+          },
+          {
+            "$ref": "#/components/schemas/ValidatorTransaction_ChunkyDKGResultTransaction"
           }
         ],
         "discriminator": {
           "propertyName": "validator_transaction_type",
           "mapping": {
             "observed_jwk_update": "#/components/schemas/ValidatorTransaction_JWKUpdateTransaction",
-            "dkg_result": "#/components/schemas/ValidatorTransaction_DKGResultTransaction"
+            "dkg_result": "#/components/schemas/ValidatorTransaction_DKGResultTransaction",
+            "chunky_d_k_g_result": "#/components/schemas/ValidatorTransaction_ChunkyDKGResultTransaction"
           }
         }
+      },
+      "ValidatorTransaction_ChunkyDKGResultTransaction": {
+        "allOf": [
+          {
+            "type": "object",
+            "required": [
+              "validator_transaction_type"
+            ],
+            "properties": {
+              "validator_transaction_type": {
+                "type": "string",
+                "enum": [
+                  "chunky_d_k_g_result"
+                ],
+                "example": "chunky_d_k_g_result"
+              }
+            }
+          },
+          {
+            "$ref": "#/components/schemas/ChunkyDKGResultTransaction"
+          }
+        ]
       },
       "ValidatorTransaction_DKGResultTransaction": {
         "allOf": [

--- a/api/doc/spec.yaml
+++ b/api/doc/spec.yaml
@@ -12234,6 +12234,55 @@ components:
 
               NOTE: `oai` does not support `flatten` together with `skip_serializing_if`.
             default: null
+    ChunkyDKGResultTransaction:
+      type: object
+      required:
+      - version
+      - hash
+      - state_change_hash
+      - event_root_hash
+      - gas_used
+      - success
+      - vm_status
+      - accumulator_root_hash
+      - changes
+      - events
+      - timestamp
+      - certified_subtrx
+      properties:
+        version:
+          $ref: '#/components/schemas/U64'
+        hash:
+          $ref: '#/components/schemas/HashValue'
+        state_change_hash:
+          $ref: '#/components/schemas/HashValue'
+        event_root_hash:
+          $ref: '#/components/schemas/HashValue'
+        state_checkpoint_hash:
+          $ref: '#/components/schemas/HashValue'
+        gas_used:
+          $ref: '#/components/schemas/U64'
+        success:
+          type: boolean
+          description: Whether the transaction was successful
+        vm_status:
+          type: string
+          description: The VM status of the transaction, can tell useful information in a failure
+        accumulator_root_hash:
+          $ref: '#/components/schemas/HashValue'
+        changes:
+          type: array
+          description: Final state of resources changed by the transaction
+          items:
+            $ref: '#/components/schemas/WriteSetChange'
+        events:
+          type: array
+          items:
+            $ref: '#/components/schemas/Event'
+        timestamp:
+          $ref: '#/components/schemas/U64'
+        certified_subtrx:
+          $ref: '#/components/schemas/ExportedCertifiedAggregatedChunkySubtranscript'
     DKGResultTransaction:
       type: object
       required:
@@ -12492,6 +12541,25 @@ components:
             format: uint64
         sig:
           $ref: '#/components/schemas/HexEncodedBytes'
+    ExportedCertifiedAggregatedChunkySubtranscript:
+      type: object
+      description: |-
+        A more API-friendly representation of the on-chain
+        `aptos_types::dkg::chunky_dkg::CertifiedAggregatedChunkySubtranscript`.
+      required:
+      - epoch
+      - author
+      - subtrx
+      - signature
+      properties:
+        epoch:
+          $ref: '#/components/schemas/U64'
+        author:
+          $ref: '#/components/schemas/Address'
+        subtrx:
+          $ref: '#/components/schemas/HexEncodedBytes'
+        signature:
+          $ref: '#/components/schemas/ExportedAggregateSignature'
     ExportedDKGTranscript:
       type: object
       required:
@@ -14091,11 +14159,25 @@ components:
       oneOf:
       - $ref: '#/components/schemas/ValidatorTransaction_JWKUpdateTransaction'
       - $ref: '#/components/schemas/ValidatorTransaction_DKGResultTransaction'
+      - $ref: '#/components/schemas/ValidatorTransaction_ChunkyDKGResultTransaction'
       discriminator:
         propertyName: validator_transaction_type
         mapping:
           observed_jwk_update: '#/components/schemas/ValidatorTransaction_JWKUpdateTransaction'
           dkg_result: '#/components/schemas/ValidatorTransaction_DKGResultTransaction'
+          chunky_d_k_g_result: '#/components/schemas/ValidatorTransaction_ChunkyDKGResultTransaction'
+    ValidatorTransaction_ChunkyDKGResultTransaction:
+      allOf:
+      - type: object
+        required:
+        - validator_transaction_type
+        properties:
+          validator_transaction_type:
+            type: string
+            enum:
+            - chunky_d_k_g_result
+            example: chunky_d_k_g_result
+      - $ref: '#/components/schemas/ChunkyDKGResultTransaction'
     ValidatorTransaction_DKGResultTransaction:
       allOf:
       - type: object

--- a/aptos-move/aptos-vm/src/validator_txns/mod.rs
+++ b/aptos-move/aptos-vm/src/validator_txns/mod.rs
@@ -32,6 +32,13 @@ impl AptosVM {
                 session_id,
                 jwk_update,
             ),
+            ValidatorTransaction::ChunkyDKGResult(_) => {
+                // TODO: Implement in a future PR
+                Err(VMStatus::error(
+                    move_core_types::vm_status::StatusCode::FEATURE_NOT_ENABLED,
+                    Some("ChunkyDKGResult processing not yet implemented".to_string()),
+                ))
+            },
         }
     }
 }

--- a/consensus/src/dag/rb_handler.rs
+++ b/consensus/src/dag/rb_handler.rs
@@ -24,7 +24,10 @@ use aptos_infallible::Mutex;
 use aptos_logger::{debug, error};
 use aptos_types::{
     epoch_state::EpochState,
-    on_chain_config::{OnChainJWKConsensusConfig, OnChainRandomnessConfig, ValidatorTxnConfig},
+    on_chain_config::{
+        OnChainChunkyDKGConfig, OnChainJWKConsensusConfig, OnChainRandomnessConfig,
+        ValidatorTxnConfig,
+    },
     validator_signer::ValidatorSigner,
     validator_txn::ValidatorTransaction,
 };
@@ -48,6 +51,7 @@ pub(crate) struct NodeBroadcastHandler {
     vtxn_config: ValidatorTxnConfig,
     randomness_config: OnChainRandomnessConfig,
     jwk_consensus_config: OnChainJWKConsensusConfig,
+    chunky_dkg_config: OnChainChunkyDKGConfig,
     health_backoff: HealthBackoff,
 }
 
@@ -81,6 +85,7 @@ impl NodeBroadcastHandler {
             vtxn_config,
             randomness_config,
             jwk_consensus_config,
+            chunky_dkg_config: OnChainChunkyDKGConfig::Off,
             health_backoff,
         }
     }
@@ -122,7 +127,12 @@ impl NodeBroadcastHandler {
         for vtxn in node.validator_txns() {
             let vtxn_type_name = vtxn.type_name();
             ensure!(
-                is_vtxn_expected(&self.randomness_config, &self.jwk_consensus_config, vtxn),
+                is_vtxn_expected(
+                    &self.randomness_config,
+                    &self.jwk_consensus_config,
+                    &self.chunky_dkg_config,
+                    vtxn
+                ),
                 "unexpected validator transaction: {:?}",
                 vtxn_type_name
             );

--- a/consensus/src/round_manager.rs
+++ b/consensus/src/round_manager.rs
@@ -66,8 +66,8 @@ use aptos_types::{
     block_info::BlockInfo,
     epoch_state::EpochState,
     on_chain_config::{
-        OnChainConsensusConfig, OnChainJWKConsensusConfig, OnChainRandomnessConfig,
-        ValidatorTxnConfig,
+        OnChainChunkyDKGConfig, OnChainConsensusConfig, OnChainJWKConsensusConfig,
+        OnChainRandomnessConfig, ValidatorTxnConfig,
     },
     randomness::RandMetadata,
     validator_verifier::ValidatorVerifier,
@@ -329,6 +329,7 @@ pub struct RoundManager {
     local_config: ConsensusConfig,
     randomness_config: OnChainRandomnessConfig,
     jwk_consensus_config: OnChainJWKConsensusConfig,
+    chunky_dkg_config: OnChainChunkyDKGConfig,
     fast_rand_config: Option<RandConfig>,
     // Stores the order votes from all the rounds above highest_ordered_round
     pending_order_votes: PendingOrderVotes,
@@ -391,6 +392,7 @@ impl RoundManager {
             local_config,
             randomness_config,
             jwk_consensus_config,
+            chunky_dkg_config: OnChainChunkyDKGConfig::Off,
             fast_rand_config,
             pending_order_votes: PendingOrderVotes::new(),
             blocks_with_broadcasted_fast_shares: LruCache::new(
@@ -1140,7 +1142,12 @@ impl RoundManager {
             for vtxn in vtxns {
                 let vtxn_type_name = vtxn.type_name();
                 ensure!(
-                    is_vtxn_expected(&self.randomness_config, &self.jwk_consensus_config, vtxn),
+                    is_vtxn_expected(
+                        &self.randomness_config,
+                        &self.jwk_consensus_config,
+                        &self.chunky_dkg_config,
+                        vtxn
+                    ),
                     "unexpected validator txn: {:?}",
                     vtxn_type_name
                 );

--- a/consensus/src/util/mod.rs
+++ b/consensus/src/util/mod.rs
@@ -3,7 +3,7 @@
 
 use aptos_consensus_types::common::Round;
 use aptos_types::{
-    on_chain_config::{OnChainJWKConsensusConfig, OnChainRandomnessConfig},
+    on_chain_config::{OnChainChunkyDKGConfig, OnChainJWKConsensusConfig, OnChainRandomnessConfig},
     validator_txn::ValidatorTransaction,
 };
 
@@ -15,11 +15,13 @@ pub mod time_service;
 pub fn is_vtxn_expected(
     randomness_config: &OnChainRandomnessConfig,
     jwk_consensus_config: &OnChainJWKConsensusConfig,
+    chunky_dkg_config: &OnChainChunkyDKGConfig,
     vtxn: &ValidatorTransaction,
 ) -> bool {
     match vtxn {
         ValidatorTransaction::DKGResult(_) => randomness_config.randomness_enabled(),
         ValidatorTransaction::ObservedJWKUpdate(_) => jwk_consensus_config.jwk_consensus_enabled(),
+        ValidatorTransaction::ChunkyDKGResult(_) => chunky_dkg_config.chunky_dkg_enabled(),
     }
 }
 

--- a/ecosystem/indexer-grpc/indexer-grpc-fullnode/src/convert.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-fullnode/src/convert.rs
@@ -1021,6 +1021,10 @@ fn convert_validator_transaction(
                     )
                 )
             },
+            ApiValidatorTransactionEnum::ChunkyDKGResult(_) => {
+                // TODO(ibalajiarun): Support indexer
+                None
+            },
         },
         events: convert_events(api_validator_txn.events()),
     })

--- a/testsuite/generate-format/tests/staged/api.yaml
+++ b/testsuite/generate-format/tests/staged/api.yaml
@@ -255,6 +255,13 @@ BlockTxnDecryptionKey:
     - metadata:
         TYPENAME: DecKeyMetadata
     - decryption_key: BYTES
+CertifiedAggregatedChunkySubtranscript:
+  STRUCT:
+    - metadata:
+        TYPENAME: DKGTranscriptMetadata
+    - transcript_bytes: BYTES
+    - signature:
+        TYPENAME: AggregateSignature
 ChainId:
   NEWTYPESTRUCT: U8
 ChangeSet:
@@ -1036,6 +1043,10 @@ ValidatorTransaction:
       ObservedJWKUpdate:
         NEWTYPE:
           TYPENAME: QuorumCertifiedUpdate
+    2:
+      ChunkyDKGResult:
+        NEWTYPE:
+          TYPENAME: CertifiedAggregatedChunkySubtranscript
 WithdrawEvent:
   STRUCT:
     - amount: U64

--- a/testsuite/generate-format/tests/staged/aptos.yaml
+++ b/testsuite/generate-format/tests/staged/aptos.yaml
@@ -243,6 +243,13 @@ BlockTxnDecryptionKey:
     - metadata:
         TYPENAME: DecKeyMetadata
     - decryption_key: BYTES
+CertifiedAggregatedChunkySubtranscript:
+  STRUCT:
+    - metadata:
+        TYPENAME: DKGTranscriptMetadata
+    - transcript_bytes: BYTES
+    - signature:
+        TYPENAME: AggregateSignature
 ChainId:
   NEWTYPESTRUCT: U8
 ChangeSet:
@@ -921,6 +928,10 @@ ValidatorTransaction:
       ObservedJWKUpdate:
         NEWTYPE:
           TYPENAME: QuorumCertifiedUpdate
+    2:
+      ChunkyDKGResult:
+        NEWTYPE:
+          TYPENAME: CertifiedAggregatedChunkySubtranscript
 WriteOp:
   ENUM:
     0:

--- a/testsuite/generate-format/tests/staged/consensus.yaml
+++ b/testsuite/generate-format/tests/staged/consensus.yaml
@@ -426,6 +426,13 @@ BlockType:
       OptimisticProposal:
         NEWTYPE:
           TYPENAME: OptBlockBody
+CertifiedAggregatedChunkySubtranscript:
+  STRUCT:
+    - metadata:
+        TYPENAME: DKGTranscriptMetadata
+    - transcript_bytes: BYTES
+    - signature:
+        TYPENAME: AggregateSignature
 ChainId:
   NEWTYPESTRUCT: U8
 ChangeSet:
@@ -1538,6 +1545,10 @@ ValidatorTransaction:
       ObservedJWKUpdate:
         NEWTYPE:
           TYPENAME: QuorumCertifiedUpdate
+    2:
+      ChunkyDKGResult:
+        NEWTYPE:
+          TYPENAME: CertifiedAggregatedChunkySubtranscript
 ValidatorVerifier:
   STRUCT:
     - validator_infos:

--- a/types/src/validator_txn.rs
+++ b/types/src/validator_txn.rs
@@ -3,7 +3,11 @@
 
 #[cfg(any(test, feature = "fuzzing"))]
 use crate::dkg::DKGTranscriptMetadata;
-use crate::{dkg::DKGTranscript, jwks, validator_verifier::ValidatorVerifier};
+use crate::{
+    dkg::{chunky_dkg::CertifiedAggregatedChunkySubtranscript, DKGTranscript},
+    jwks,
+    validator_verifier::ValidatorVerifier,
+};
 use anyhow::Context;
 use aptos_crypto_derive::{BCSCryptoHash, CryptoHasher};
 #[cfg(any(test, feature = "fuzzing"))]
@@ -15,6 +19,7 @@ use std::fmt::Debug;
 pub enum ValidatorTransaction {
     DKGResult(DKGTranscript),
     ObservedJWKUpdate(jwks::QuorumCertifiedUpdate),
+    ChunkyDKGResult(CertifiedAggregatedChunkySubtranscript),
 }
 
 impl ValidatorTransaction {
@@ -39,6 +44,7 @@ impl ValidatorTransaction {
             ValidatorTransaction::ObservedJWKUpdate(_) => {
                 "validator_transaction__observed_jwk_update"
             },
+            ValidatorTransaction::ChunkyDKGResult(_) => "validator_transaction__chunky_dkg_result",
         }
     }
 
@@ -48,6 +54,10 @@ impl ValidatorTransaction {
                 .verify(verifier)
                 .context("DKGResult verification failed"),
             ValidatorTransaction::ObservedJWKUpdate(_) => Ok(()),
+            ValidatorTransaction::ChunkyDKGResult(_) => {
+                // TODO: Implement verification for ChunkyDKGResult
+                Ok(())
+            },
         }
     }
 }


### PR DESCRIPTION
## Summary

Adds `ValidatorTransaction::ChunkyDKGResult` variant and consensus hooks to check `OnChainChunkyDKGConfig` when validating validator transactions.