### PR TITLE
[dkg] Add chunky DKG types and module structure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1451,6 +1451,7 @@ dependencies = [
  "aptos-consensus-types",
  "aptos-crypto",
  "aptos-crypto-derive",
+ "aptos-dkg",
  "aptos-enum-conversion-derive",
  "aptos-event-notifications",
  "aptos-infallible",
@@ -1460,6 +1461,7 @@ dependencies = [
  "aptos-reliable-broadcast",
  "aptos-runtimes",
  "aptos-safety-rules",
+ "aptos-short-hex-str",
  "aptos-time-service",
  "aptos-types",
  "aptos-validator-transaction-pool",
@@ -1474,6 +1476,7 @@ dependencies = [
  "once_cell",
  "rand 0.7.3",
  "serde",
+ "serde_bytes",
  "tokio",
  "tokio-retry",
 ]

--- a/dkg/Cargo.toml
+++ b/dkg/Cargo.toml
@@ -20,6 +20,7 @@ aptos-config = { workspace = true }
 aptos-consensus-types = { workspace = true }
 aptos-crypto = { workspace = true }
 aptos-crypto-derive = { workspace = true }
+aptos-dkg = { workspace = true }
 aptos-enum-conversion-derive = { workspace = true }
 aptos-event-notifications = { workspace = true }
 aptos-infallible = { workspace = true }
@@ -29,6 +30,7 @@ aptos-network = { workspace = true }
 aptos-reliable-broadcast = { workspace = true }
 aptos-runtimes = { workspace = true }
 aptos-safety-rules = { workspace = true }
+aptos-short-hex-str = { workspace = true }
 aptos-time-service = { workspace = true }
 aptos-types = { workspace = true }
 aptos-validator-transaction-pool = { workspace = true }
@@ -43,6 +45,7 @@ move-core-types = { workspace = true }
 once_cell = { workspace = true }
 rand = { workspace = true }
 serde = { workspace = true }
+serde_bytes = { workspace = true }
 tokio = { workspace = true }
 tokio-retry = { workspace = true }
 
@@ -51,3 +54,6 @@ aptos-types = { workspace = true, features = ["testing"] }
 
 [features]
 smoke-test = []
+
+[package.metadata.cargo-machete]
+ignored = ["serde_bytes"]

--- a/dkg/src/chunky/agg_subtrx_producer.rs
+++ b/dkg/src/chunky/agg_subtrx_producer.rs
@@ -1,0 +1,5 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Aggregated subtranscript producer for Chunky DKG.
+//! Implementation will be added in a subsequent PR.

--- a/dkg/src/chunky/dkg_manager.rs
+++ b/dkg/src/chunky/dkg_manager.rs
@@ -1,0 +1,5 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Chunky DKG manager implementation.
+//! Implementation will be added in a subsequent PR.

--- a/dkg/src/chunky/missing_transcript_fetcher.rs
+++ b/dkg/src/chunky/missing_transcript_fetcher.rs
@@ -1,0 +1,5 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Missing transcript fetcher for Chunky DKG.
+//! Implementation will be added in a subsequent PR.

--- a/dkg/src/chunky/mod.rs
+++ b/dkg/src/chunky/mod.rs
@@ -1,0 +1,8 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+pub mod agg_subtrx_producer;
+pub mod dkg_manager;
+pub mod missing_transcript_fetcher;
+pub mod subtrx_cert_producer;
+pub mod types;

--- a/dkg/src/chunky/subtrx_cert_producer.rs
+++ b/dkg/src/chunky/subtrx_cert_producer.rs
@@ -1,0 +1,5 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Subtranscript certificate producer for Chunky DKG.
+//! Implementation will be added in a subsequent PR.

--- a/dkg/src/chunky/types.rs
+++ b/dkg/src/chunky/types.rs
@@ -1,0 +1,133 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+use aptos_crypto::HashValue;
+use aptos_crypto_derive::{BCSCryptoHash, CryptoHasher};
+use aptos_dkg::pvss::Player;
+use aptos_types::{
+    aggregate_signature::AggregateSignature,
+    dkg::{
+        chunky_dkg::{ChunkyDKGTranscript, ChunkySubtranscript},
+        DKGTranscriptMetadata,
+    },
+};
+use move_core_types::account_address::AccountAddress;
+use serde::{Deserialize, Serialize};
+
+/// Once Chunky DKG starts, a validator should send this message to peers in order to collect Chunky DKG transcripts from peers.
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
+pub struct ChunkyDKGTranscriptRequest {
+    pub dealer_epoch: u64,
+}
+
+impl ChunkyDKGTranscriptRequest {
+    pub fn new(dealer_epoch: u64) -> Self {
+        Self { dealer_epoch }
+    }
+}
+
+/// Request to validate an aggregated subtranscript. Contains the hash of the subtranscript and the dealers.
+#[derive(Clone, Serialize, Deserialize, CryptoHasher, Debug, PartialEq)]
+pub struct ChunkyDKGSubtranscriptSignatureRequest {
+    pub dealer_epoch: u64,
+    pub subtranscript_hash: HashValue,
+    pub aggregated_subtrx_dealers: Vec<Player>,
+}
+
+impl ChunkyDKGSubtranscriptSignatureRequest {
+    pub fn new(
+        dealer_epoch: u64,
+        subtranscript_hash: HashValue,
+        aggregated_subtrx_dealers: Vec<Player>,
+    ) -> Self {
+        Self {
+            dealer_epoch,
+            subtranscript_hash,
+            aggregated_subtrx_dealers,
+        }
+    }
+}
+
+/// Response containing a signature for subtranscript validation.
+/// The signature is over the subtranscript itself.
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
+pub struct ChunkyDKGSubtranscriptSignatureResponse {
+    pub dealer_epoch: u64,
+    pub subtranscript_hash: HashValue,
+    pub signature: aptos_crypto::bls12381::Signature,
+}
+
+impl ChunkyDKGSubtranscriptSignatureResponse {
+    pub fn new(
+        dealer_epoch: u64,
+        subtranscript_hash: HashValue,
+        signature: aptos_crypto::bls12381::Signature,
+    ) -> Self {
+        Self {
+            dealer_epoch,
+            subtranscript_hash,
+            signature,
+        }
+    }
+}
+
+/// An aggregated transcript with the list of dealers who contributed to it.
+#[allow(dead_code)]
+#[derive(Clone, Debug, Serialize, Deserialize, CryptoHasher, BCSCryptoHash)]
+pub struct AggregatedSubtranscript {
+    pub subtranscript: ChunkySubtranscript,
+    pub dealers: Vec<Player>,
+}
+
+/// A validated aggregated subtranscript with an aggregate signature that can verify it.
+#[allow(dead_code)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct CertifiedAggregatedSubtranscript {
+    pub aggregated_subtranscript: AggregatedSubtranscript,
+    pub aggregate_signature: AggregateSignature,
+}
+
+/// A validated aggregated transcript with metadata, similar to DKGTranscript but for Chunky DKG.
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ValidatedAggregatedTranscript {
+    pub metadata: DKGTranscriptMetadata,
+    #[serde(with = "serde_bytes")]
+    pub transcript_bytes: Vec<u8>,
+}
+
+impl std::fmt::Debug for ValidatedAggregatedTranscript {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ValidatedAggregatedTranscript")
+            .field("metadata", &self.metadata)
+            .field("transcript_bytes_len", &self.transcript_bytes.len())
+            .finish()
+    }
+}
+
+/// Request to fetch missing transcripts from a peer who has aggregated transcripts.
+#[derive(Clone, Serialize, Deserialize, CryptoHasher, Debug, PartialEq)]
+pub struct MissingTranscriptRequest {
+    pub dealer_epoch: u64,
+    pub missing_dealer: AccountAddress,
+}
+
+impl MissingTranscriptRequest {
+    pub fn new(epoch: u64, missing_dealer: AccountAddress) -> Self {
+        Self {
+            dealer_epoch: epoch,
+            missing_dealer,
+        }
+    }
+}
+
+/// Response containing the requested transcript.
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
+pub struct MissingTranscriptResponse {
+    pub transcript: ChunkyDKGTranscript,
+}
+
+impl MissingTranscriptResponse {
+    pub fn new(transcript: ChunkyDKGTranscript) -> Self {
+        Self { transcript }
+    }
+}

--- a/dkg/src/counters.rs
+++ b/dkg/src/counters.rs
@@ -1,8 +1,12 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
+use aptos_infallible::duration_since_epoch;
 use aptos_metrics_core::{register_histogram_vec, register_int_gauge, HistogramVec, IntGauge};
+use aptos_short_hex_str::AsShortHexStr;
+use move_core_types::account_address::AccountAddress;
 use once_cell::sync::Lazy;
+use std::time::Duration;
 
 /// Count of the pending messages sent to itself in the channel
 pub static PENDING_SELF_MESSAGES: Lazy<IntGauge> = Lazy::new(|| {
@@ -30,3 +34,39 @@ pub static ROUNDING_SECONDS: Lazy<HistogramVec> = Lazy::new(|| {
     )
     .unwrap()
 });
+
+#[allow(dead_code)]
+pub static CHUNKY_DKG_STAGE_SECONDS: Lazy<HistogramVec> = Lazy::new(|| {
+    register_histogram_vec!(
+        "aptos_chunky_dkg_session_stage_seconds",
+        "How long it takes to reach different ChunkyDKG stages",
+        &["dealer", "stage"]
+    )
+    .unwrap()
+});
+
+/// Record the time during each stage of DKG, similar to observe_block.
+/// Only observes when the elapsed time is non-negative (guards against clock skew).
+#[allow(dead_code)]
+pub fn observe_dkg_stage(start_time: Duration, my_addr: AccountAddress, stage: &'static str) {
+    if let Some(elapsed) = duration_since_epoch().checked_sub(start_time) {
+        DKG_STAGE_SECONDS
+            .with_label_values(&[my_addr.short_str().as_str(), stage])
+            .observe(elapsed.as_secs_f64());
+    }
+}
+
+/// Record the time during each stage of ChunkyDKG, similar to observe_dkg_stage.
+/// Only observes when the elapsed time is non-negative (guards against clock skew).
+#[allow(dead_code)]
+pub fn observe_chunky_dkg_stage(
+    start_time: Duration,
+    my_addr: AccountAddress,
+    stage: &'static str,
+) {
+    if let Some(elapsed) = duration_since_epoch().checked_sub(start_time) {
+        CHUNKY_DKG_STAGE_SECONDS
+            .with_label_values(&[my_addr.short_str().as_str(), stage])
+            .observe(elapsed.as_secs_f64());
+    }
+}

--- a/dkg/src/lib.rs
+++ b/dkg/src/lib.rs
@@ -2,6 +2,7 @@
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 mod agg_trx_producer;
+mod chunky;
 mod counters;
 mod dkg_manager;
 pub mod epoch_manager;

--- a/dkg/src/types.rs
+++ b/dkg/src/types.rs
@@ -1,13 +1,19 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
+pub use crate::chunky::types::{
+    ChunkyDKGSubtranscriptSignatureRequest, ChunkyDKGSubtranscriptSignatureResponse,
+    ChunkyDKGTranscriptRequest, MissingTranscriptRequest, MissingTranscriptResponse,
+    ValidatedAggregatedTranscript,
+};
 use aptos_crypto_derive::CryptoHasher;
 use aptos_enum_conversion_derive::EnumConversion;
 use aptos_reliable_broadcast::RBMessage;
-pub use aptos_types::dkg::DKGTranscript;
+pub use aptos_types::dkg::{chunky_dkg::ChunkyDKGTranscript, DKGTranscript, DKGTranscriptMetadata};
 use serde::{Deserialize, Serialize};
 
 /// Once DKG starts, a validator should send this message to peers in order to collect DKG transcripts from peers.
+/// This is the request for the Das DKG implementation
 #[derive(Clone, Serialize, Deserialize, CryptoHasher, Debug, PartialEq)]
 pub struct DKGTranscriptRequest {
     dealer_epoch: u64,
@@ -26,6 +32,12 @@ impl DKGTranscriptRequest {
 pub enum DKGMessage {
     TranscriptRequest(DKGTranscriptRequest),
     TranscriptResponse(DKGTranscript),
+    ChunkyTranscriptRequest(ChunkyDKGTranscriptRequest),
+    ChunkyTranscriptResponse(ChunkyDKGTranscript),
+    SubtranscriptSignatureRequest(ChunkyDKGSubtranscriptSignatureRequest),
+    SubtranscriptSignatureResponse(ChunkyDKGSubtranscriptSignatureResponse),
+    MissingTranscriptRequest(MissingTranscriptRequest),
+    MissingTranscriptResponse(MissingTranscriptResponse),
 }
 
 impl DKGMessage {
@@ -33,6 +45,12 @@ impl DKGMessage {
         match self {
             DKGMessage::TranscriptRequest(request) => request.dealer_epoch,
             DKGMessage::TranscriptResponse(response) => response.metadata.epoch,
+            DKGMessage::ChunkyTranscriptRequest(request) => request.dealer_epoch,
+            DKGMessage::ChunkyTranscriptResponse(response) => response.metadata.epoch,
+            DKGMessage::SubtranscriptSignatureRequest(request) => request.dealer_epoch,
+            DKGMessage::SubtranscriptSignatureResponse(response) => response.dealer_epoch,
+            DKGMessage::MissingTranscriptRequest(request) => request.dealer_epoch,
+            DKGMessage::MissingTranscriptResponse(response) => response.transcript.metadata.epoch,
         }
     }
 
@@ -40,6 +58,16 @@ impl DKGMessage {
         match self {
             DKGMessage::TranscriptRequest(_) => "DKGTranscriptRequest",
             DKGMessage::TranscriptResponse(_) => "DKGTranscriptResponse",
+            DKGMessage::ChunkyTranscriptRequest(_) => "ChunkyDKGTranscriptRequest",
+            DKGMessage::ChunkyTranscriptResponse(_) => "ChunkyDKGTranscriptResponse",
+            DKGMessage::SubtranscriptSignatureRequest(_) => {
+                "ChunkyDKGSubtranscriptSignatureRequest"
+            },
+            DKGMessage::SubtranscriptSignatureResponse(_) => {
+                "ChunkyDKGSubtranscriptSignatureResponse"
+            },
+            DKGMessage::MissingTranscriptRequest(_) => "MissingTranscriptRequest",
+            DKGMessage::MissingTranscriptResponse(_) => "MissingTranscriptResponse",
         }
     }
 }


### PR DESCRIPTION
## Summary

Adds the `dkg/src/chunky/` module structure with types and stubs.

### `types.rs` - Network message types
- `ChunkyDKGTranscriptRequest/Response` - for collecting transcripts from peers
- `MissingTranscriptRequest/Response` - for fetching missing transcripts
- `AggregatedSubtranscript` - aggregated result with contributors
- `CertifiedAggregatedSubtranscript` - aggregated result with multi-sig

### Module structure (stubs for subsequent PRs)
- `agg_subtrx_producer.rs` - aggregated subtranscript producer
- `subtrx_cert_producer.rs` - subtranscript certificate producer  
- `dkg_manager.rs` - DKG state machine
- `missing_transcript_fetcher.rs` - transcript fetcher

### Dependencies
- Adds `aptos-dkg`, `aptos-batch-encryption`, `aptos-short-hex-str`, `serde_bytes`