### PR TITLE
[dkg] Integrate ChunkyDKGManager with epoch manager

### DIFF
--- a/aptos-node/src/state_sync.rs
+++ b/aptos-node/src/state_sync.rs
@@ -94,7 +94,10 @@ pub fn create_event_subscription_service(
             .subscribe_to_reconfigurations()
             .expect("DKG must subscribe to reconfigurations");
         let dkg_start_events = event_subscription_service
-            .subscribe_to_events(vec![], vec!["0x1::dkg::DKGStartEvent".to_string()])
+            .subscribe_to_events(vec![], vec![
+                "0x1::dkg::DKGStartEvent".to_string(),
+                "0x1::chunky_dkg::ChunkyDKGStartEvent".to_string(),
+            ])
             .expect("Consensus must subscribe to DKG events");
         Some((reconfig_events, dkg_start_events))
     } else {

--- a/dkg/src/agg_trx_producer.rs
+++ b/dkg/src/agg_trx_producer.rs
@@ -35,10 +35,8 @@ pub struct AggTranscriptProducer {
 }
 
 impl AggTranscriptProducer {
-    pub fn new(reliable_broadcast: ReliableBroadcast<DKGMessage, ExponentialBackoff>) -> Self {
-        Self {
-            reliable_broadcast: Arc::new(reliable_broadcast),
-        }
+    pub fn new(reliable_broadcast: Arc<ReliableBroadcast<DKGMessage, ExponentialBackoff>>) -> Self {
+        Self { reliable_broadcast }
     }
 }
 

--- a/dkg/src/epoch_manager.rs
+++ b/dkg/src/epoch_manager.rs
@@ -3,6 +3,7 @@
 
 use crate::{
     agg_trx_producer::AggTranscriptProducer,
+    chunky::dkg_manager::ChunkyDKGManager,
     dkg_manager::DKGManager,
     network::{IncomingRpcRequest, NetworkReceivers, NetworkSender},
     network_interface::DKGNetworkClient,
@@ -16,17 +17,21 @@ use aptos_event_notifications::{
     EventNotification, EventNotificationListener, ReconfigNotification,
     ReconfigNotificationListener,
 };
-use aptos_logger::{debug, error, info, warn};
+use aptos_logger::{error, info, warn};
 use aptos_network::{application::interface::NetworkClient, protocols::network::Event};
 use aptos_reliable_broadcast::ReliableBroadcast;
 use aptos_safety_rules::{safety_rules_manager::storage, PersistentSafetyStorage};
 use aptos_types::{
     account_address::AccountAddress,
-    dkg::{DKGStartEvent, DKGState, DefaultDKG},
+    dkg::{
+        chunky_dkg::{ChunkyDKGStartEvent, ChunkyDKGState},
+        DKGStartEvent, DKGState, DefaultDKG,
+    },
     epoch_state::EpochState,
     on_chain_config::{
-        OnChainConfigPayload, OnChainConfigProvider, OnChainConsensusConfig,
-        OnChainRandomnessConfig, RandomnessConfigMoveStruct, RandomnessConfigSeqNum, ValidatorSet,
+        ChunkyDKGConfigMoveStruct, OnChainChunkyDKGConfig, OnChainConfigPayload,
+        OnChainConfigProvider, OnChainConsensusConfig, OnChainRandomnessConfig,
+        RandomnessConfigMoveStruct, RandomnessConfigSeqNum, ValidatorSet,
     },
 };
 use aptos_validator_transaction_pool::VTxnPoolState;
@@ -34,6 +39,9 @@ use futures::StreamExt;
 use futures_channel::oneshot;
 use std::{sync::Arc, time::Duration};
 use tokio_retry::strategy::ExponentialBackoff;
+
+const DKG_START_EVENT_TYPE_TAG: &str = "0x1::dkg::DKGStartEvent";
+const CHUNKY_DKG_START_EVENT_TYPE_TAG: &str = "0x1::chunky_dkg::ChunkyDKGStartEvent";
 
 pub struct EpochManager<P: OnChainConfigProvider> {
     // Some useful metadata
@@ -49,7 +57,13 @@ pub struct EpochManager<P: OnChainConfigProvider> {
         Option<aptos_channel::Sender<AccountAddress, (AccountAddress, IncomingRpcRequest)>>,
     dkg_manager_close_tx: Option<oneshot::Sender<oneshot::Sender<()>>>,
     dkg_start_event_tx: Option<aptos_channel::Sender<(), DKGStartEvent>>,
+
     vtxn_pool: VTxnPoolState,
+
+    chunky_dkg_rpc_msg_tx:
+        Option<aptos_channel::Sender<AccountAddress, (AccountAddress, IncomingRpcRequest)>>,
+    chunky_dkg_manager_close_tx: Option<oneshot::Sender<oneshot::Sender<()>>>,
+    chunky_dkg_start_event_tx: Option<aptos_channel::Sender<(), ChunkyDKGStartEvent>>,
 
     // Network utils
     self_sender: aptos_channels::Sender<Event<DKGMessage>>,
@@ -81,10 +95,13 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
             dkg_start_events,
             dkg_rpc_msg_tx: None,
             dkg_manager_close_tx: None,
+            dkg_start_event_tx: None,
             self_sender,
             network_sender,
             vtxn_pool,
-            dkg_start_event_tx: None,
+            chunky_dkg_manager_close_tx: None,
+            chunky_dkg_rpc_msg_tx: None,
+            chunky_dkg_start_event_tx: None,
             rb_config,
             randomness_override_seq_num,
             key_storage: storage(safety_rules_config),
@@ -96,7 +113,27 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
         peer_id: AccountAddress,
         dkg_request: IncomingRpcRequest,
     ) -> Result<()> {
-        if Some(dkg_request.msg.epoch()) == self.epoch_state.as_ref().map(|s| s.epoch) {
+        if Some(dkg_request.msg.epoch()) != self.epoch_state.as_ref().map(|s| s.epoch) {
+            return Ok(());
+        }
+
+        // Check if this is a Chunky message and forward to the appropriate channel
+        let is_chunky_message = matches!(
+            &dkg_request.msg,
+            DKGMessage::ChunkyTranscriptRequest(_)
+                | DKGMessage::ChunkyTranscriptResponse(_)
+                | DKGMessage::SubtranscriptSignatureRequest(_)
+                | DKGMessage::SubtranscriptSignatureResponse(_)
+                | DKGMessage::MissingTranscriptRequest(_)
+                | DKGMessage::MissingTranscriptResponse(_),
+        );
+
+        if is_chunky_message {
+            // Forward to ChunkyDKGManager if it is alive.
+            if let Some(tx) = &self.chunky_dkg_rpc_msg_tx {
+                let _ = tx.push(peer_id, (peer_id, dkg_request));
+            }
+        } else {
             // Forward to DKGManager if it is alive.
             if let Some(tx) = &self.dkg_rpc_msg_tx {
                 let _ = tx.push(peer_id, (peer_id, dkg_request));
@@ -106,17 +143,40 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
     }
 
     fn on_dkg_start_notification(&mut self, notification: EventNotification) -> Result<()> {
-        if let Some(tx) = self.dkg_start_event_tx.as_ref() {
-            let EventNotification {
-                subscribed_events, ..
-            } = notification;
-            for event in subscribed_events {
-                if let Ok(dkg_start_event) = DKGStartEvent::try_from(&event) {
-                    let _ = tx.push((), dkg_start_event);
-                    return Ok(());
-                } else {
-                    debug!("[DKG] on_dkg_start_notification: failed in converting a contract event to a dkg start event!");
-                }
+        let EventNotification {
+            subscribed_events, ..
+        } = notification;
+        for event in subscribed_events {
+            let type_tag_str = event.type_tag().to_canonical_string();
+            match type_tag_str.as_str() {
+                DKG_START_EVENT_TYPE_TAG => {
+                    if let Some(tx) = self.dkg_start_event_tx.as_ref() {
+                        if let Ok(dkg_start_event) = DKGStartEvent::try_from(&event) {
+                            let _ = tx.push((), dkg_start_event);
+                            return Ok(());
+                        } else {
+                            error!("[DKG] on_dkg_start_notification: failed in converting a contract event to a DKGStartEvent!");
+                        }
+                    }
+                },
+                CHUNKY_DKG_START_EVENT_TYPE_TAG => {
+                    // TODO(ibalajiarun): Use unbounded sender for tx for simplicity
+                    if let Some(tx) = self.chunky_dkg_start_event_tx.as_ref() {
+                        match ChunkyDKGStartEvent::try_from(&event) {
+                            Ok(dkg_start_event) => {
+                                let _ = tx.push((), dkg_start_event);
+                                return Ok(());
+                            },
+                            Err(e) => {
+                                error!("[DKG] Failed conversion to ChunkyDKGStartEvent: {}", e);
+                            },
+                        }
+                    }
+                },
+                unknown_type_tag => error!(
+                    "[DKG] on_dkg_start_notification for unknown type tag: {}",
+                    unknown_type_tag
+                ),
             }
         }
         Ok(())
@@ -161,11 +221,18 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
 
         let epoch_state = Arc::new(EpochState::new(payload.epoch(), (&validator_set).into()));
         self.epoch_state = Some(epoch_state.clone());
-        let my_index = epoch_state
+        let Some(my_index) = epoch_state
             .verifier
             .address_to_validator_index()
             .get(&self.my_addr)
-            .copied();
+            .copied()
+        else {
+            warn!(
+                "This validator is not in current epoch {}",
+                epoch_state.epoch
+            );
+            return Ok(());
+        };
 
         let onchain_randomness_config_seq_num = payload
             .get::<RandomnessConfigSeqNum>()
@@ -189,74 +256,161 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
             randomness_config_move_struct.ok(),
         );
 
-        let onchain_consensus_config: anyhow::Result<OnChainConsensusConfig> = payload.get();
-        if let Err(error) = &onchain_consensus_config {
-            error!("Failed to read on-chain consensus config {}", error);
-        }
-        let consensus_config = onchain_consensus_config.unwrap_or_default();
+        let chunky_dkg_config_move_struct = payload.get::<ChunkyDKGConfigMoveStruct>();
+
+        let onchain_chunky_dkg_config =
+            OnChainChunkyDKGConfig::from_configs(chunky_dkg_config_move_struct.ok());
+
+        let onchain_consensus_config = payload
+            .get::<OnChainConsensusConfig>()
+            .inspect_err(|e| {
+                error!("Failed to read on-chain consensus config {}", e);
+            })
+            .unwrap_or_default();
+
+        // Create shared network sender and reliable broadcast for both DKG managers
+        let network_sender = Arc::new(self.create_network_sender());
+        let rb = Arc::new(ReliableBroadcast::new(
+            self.my_addr,
+            epoch_state.verifier.get_ordered_account_addresses(),
+            network_sender.clone(),
+            ExponentialBackoff::from_millis(self.rb_config.backoff_policy_base_ms)
+                .factor(self.rb_config.backoff_policy_factor)
+                .max_delay(Duration::from_millis(
+                    self.rb_config.backoff_policy_max_delay_ms,
+                )),
+            aptos_time_service::TimeService::real(),
+            Duration::from_millis(self.rb_config.rpc_timeout_ms),
+            BoundedExecutor::new(8, tokio::runtime::Handle::current()),
+        ));
 
         // Check both validator txn and randomness features are enabled
-        let randomness_enabled =
-            consensus_config.is_vtxn_enabled() && onchain_randomness_config.randomness_enabled();
-        if let (true, Some(my_index)) = (randomness_enabled, my_index) {
-            let DKGState {
-                in_progress: in_progress_session,
-                ..
-            } = payload.get::<DKGState>().unwrap_or_default();
+        if onchain_consensus_config.is_vtxn_enabled()
+            && onchain_randomness_config.randomness_enabled()
+        {
+            self.start_dkg_manager(epoch_state.clone(), my_index, &payload, rb.clone())
+                .await?;
+        }
 
-            let network_sender = self.create_network_sender();
-            let rb = ReliableBroadcast::new(
-                self.my_addr,
-                epoch_state.verifier.get_ordered_account_addresses(),
-                Arc::new(network_sender),
-                ExponentialBackoff::from_millis(self.rb_config.backoff_policy_base_ms)
-                    .factor(self.rb_config.backoff_policy_factor)
-                    .max_delay(Duration::from_millis(
-                        self.rb_config.backoff_policy_max_delay_ms,
-                    )),
-                aptos_time_service::TimeService::real(),
-                Duration::from_millis(self.rb_config.rpc_timeout_ms),
-                BoundedExecutor::new(8, tokio::runtime::Handle::current()),
-            );
-            let agg_trx_producer = AggTranscriptProducer::new(rb);
-
-            let (dkg_start_event_tx, dkg_start_event_rx) =
-                aptos_channel::new(QueueStyle::KLAST, 1, None);
-            self.dkg_start_event_tx = Some(dkg_start_event_tx);
-
-            let (dkg_rpc_msg_tx, dkg_rpc_msg_rx) = aptos_channel::new::<
-                AccountAddress,
-                (AccountAddress, IncomingRpcRequest),
-            >(QueueStyle::FIFO, 100, None);
-            self.dkg_rpc_msg_tx = Some(dkg_rpc_msg_tx);
-            let (dkg_manager_close_tx, dkg_manager_close_rx) = oneshot::channel();
-            self.dkg_manager_close_tx = Some(dkg_manager_close_tx);
-            let my_pk = epoch_state
-                .verifier
-                .get_public_key(&self.my_addr)
-                .ok_or_else(|| anyhow!("my pk not found in validator set"))?;
-            let dealer_sk = self
-                .key_storage
-                .consensus_sk_by_pk(my_pk.clone())
-                .map_err(|e| {
-                    anyhow!("dkg new epoch handling failed with consensus sk lookup err: {e}")
-                })?;
-            let dkg_manager = DKGManager::<DefaultDKG>::new(
-                Arc::new(dealer_sk),
-                Arc::new(my_pk),
+        // Check both validator txn and chunky dkg features are enabled
+        if onchain_consensus_config.is_vtxn_enabled()
+            && onchain_chunky_dkg_config.chunky_dkg_enabled()
+        {
+            self.start_chunky_dkg_manager(
+                epoch_state.clone(),
                 my_index,
-                self.my_addr,
-                epoch_state,
-                Arc::new(agg_trx_producer),
-                self.vtxn_pool.clone(),
-            );
-            tokio::spawn(dkg_manager.run(
-                in_progress_session,
-                dkg_start_event_rx,
-                dkg_rpc_msg_rx,
-                dkg_manager_close_rx,
-            ));
-        };
+                &payload,
+                rb.clone(),
+                network_sender,
+            )
+            .await?;
+        }
+        Ok(())
+    }
+
+    async fn start_dkg_manager(
+        &mut self,
+        epoch_state: Arc<EpochState>,
+        my_index: usize,
+        payload: &OnChainConfigPayload<P>,
+        rb: Arc<ReliableBroadcast<DKGMessage, ExponentialBackoff>>,
+    ) -> Result<()> {
+        let DKGState {
+            in_progress: in_progress_session,
+            ..
+        } = payload.get::<DKGState>().unwrap_or_default();
+
+        let agg_trx_producer = AggTranscriptProducer::new(rb);
+
+        let (dkg_start_event_tx, dkg_start_event_rx) =
+            aptos_channel::new(QueueStyle::KLAST, 1, None);
+        self.dkg_start_event_tx = Some(dkg_start_event_tx);
+
+        let (dkg_rpc_msg_tx, dkg_rpc_msg_rx) = aptos_channel::new::<
+            AccountAddress,
+            (AccountAddress, IncomingRpcRequest),
+        >(QueueStyle::FIFO, 100, None);
+        self.dkg_rpc_msg_tx = Some(dkg_rpc_msg_tx);
+        let (dkg_manager_close_tx, dkg_manager_close_rx) = oneshot::channel();
+        self.dkg_manager_close_tx = Some(dkg_manager_close_tx);
+        let my_pk = epoch_state
+            .verifier
+            .get_public_key(&self.my_addr)
+            .ok_or_else(|| anyhow!("my pk not found in validator set"))?;
+        let dealer_sk = self
+            .key_storage
+            .consensus_sk_by_pk(my_pk.clone())
+            .map_err(|e| {
+                anyhow!("dkg new epoch handling failed with consensus sk lookup err: {e}")
+            })?;
+        let dkg_manager = DKGManager::<DefaultDKG>::new(
+            Arc::new(dealer_sk),
+            Arc::new(my_pk),
+            my_index,
+            self.my_addr,
+            epoch_state,
+            Arc::new(agg_trx_producer),
+            self.vtxn_pool.clone(),
+        );
+        tokio::spawn(dkg_manager.run(
+            in_progress_session,
+            dkg_start_event_rx,
+            dkg_rpc_msg_rx,
+            dkg_manager_close_rx,
+        ));
+        Ok(())
+    }
+
+    async fn start_chunky_dkg_manager(
+        &mut self,
+        epoch_state: Arc<EpochState>,
+        my_index: usize,
+        payload: &OnChainConfigPayload<P>,
+        rb: Arc<ReliableBroadcast<DKGMessage, ExponentialBackoff>>,
+        network_sender: Arc<NetworkSender>,
+    ) -> Result<()> {
+        let ChunkyDKGState {
+            in_progress: in_progress_session,
+            ..
+        } = payload.get::<ChunkyDKGState>().unwrap_or_default();
+
+        let (chunky_dkg_start_event_tx, chunky_dkg_start_event_rx) =
+            aptos_channel::new(QueueStyle::KLAST, 1, None);
+        self.chunky_dkg_start_event_tx = Some(chunky_dkg_start_event_tx);
+
+        let (chunky_dkg_rpc_msg_tx, chunky_dkg_rpc_msg_rx) = aptos_channel::new::<
+            AccountAddress,
+            (AccountAddress, IncomingRpcRequest),
+        >(QueueStyle::FIFO, 100, None);
+        self.chunky_dkg_rpc_msg_tx = Some(chunky_dkg_rpc_msg_tx);
+        let (chunky_dkg_manager_close_tx, chunky_dkg_manager_close_rx) = oneshot::channel();
+        self.chunky_dkg_manager_close_tx = Some(chunky_dkg_manager_close_tx);
+        let my_pk = epoch_state
+            .verifier
+            .get_public_key(&self.my_addr)
+            .ok_or_else(|| anyhow!("my pk not found in validator set"))?;
+        let dealer_sk = self
+            .key_storage
+            .consensus_sk_by_pk(my_pk.clone())
+            .map_err(|e| {
+                anyhow!("chunky dkg new epoch handling failed with consensus sk lookup err: {e}")
+            })?;
+        let chunky_dkg_manager = ChunkyDKGManager::new(
+            Arc::new(dealer_sk),
+            Arc::new(my_pk),
+            my_index,
+            self.my_addr,
+            epoch_state,
+            self.vtxn_pool.clone(),
+            rb,
+            network_sender,
+        );
+        tokio::spawn(chunky_dkg_manager.run(
+            in_progress_session,
+            chunky_dkg_start_event_rx,
+            chunky_dkg_rpc_msg_rx,
+            chunky_dkg_manager_close_rx,
+        ));
         Ok(())
     }
 
@@ -269,6 +423,11 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
 
     async fn shutdown_current_processor(&mut self) {
         if let Some(tx) = self.dkg_manager_close_tx.take() {
+            let (ack_tx, ack_rx) = oneshot::channel();
+            tx.send(ack_tx).unwrap();
+            ack_rx.await.unwrap();
+        }
+        if let Some(tx) = self.chunky_dkg_manager_close_tx.take() {
             let (ack_tx, ack_rx) = oneshot::channel();
             tx.send(ack_tx).unwrap();
             ack_rx.await.unwrap();

--- a/execution/executor-types/src/lib.rs
+++ b/execution/executor-types/src/lib.rs
@@ -13,7 +13,7 @@ use aptos_types::{
     },
     block_executor::{config::BlockExecutorConfigFromOnchain, partitioner::ExecutableBlock},
     contract_event::ContractEvent,
-    dkg::DKG_START_EVENT_MOVE_TYPE_TAG,
+    dkg::{chunky_dkg::CHUNKY_DKG_START_EVENT_MOVE_TYPE_TAG, DKG_START_EVENT_MOVE_TYPE_TAG},
     jwks::OBSERVED_JWK_UPDATED_MOVE_TYPE_TAG,
     ledger_info::LedgerInfoWithSignatures,
     state_store::state_key::StateKey,
@@ -279,6 +279,7 @@ pub fn should_forward_to_subscription_service(event: &ContractEvent) -> bool {
         || type_tag == NEW_EPOCH_EVENT_MOVE_TYPE_TAG.deref()
         || type_tag == NEW_EPOCH_EVENT_V2_MOVE_TYPE_TAG.deref()
         || type_tag == RANDOMNESS_GENERATED_EVENT_MOVE_TYPE_TAG.deref()
+        || type_tag == CHUNKY_DKG_START_EVENT_MOVE_TYPE_TAG.deref()
 }
 
 #[cfg(feature = "bench")]

--- a/types/src/dkg/chunky_dkg.rs
+++ b/types/src/dkg/chunky_dkg.rs
@@ -26,8 +26,10 @@ use aptos_dkg::pvss::{
     Player,
 };
 use move_core_types::{
-    account_address::AccountAddress, ident_str, identifier::IdentStr, move_resource::MoveStructType,
+    account_address::AccountAddress, ident_str, identifier::IdentStr, language_storage::TypeTag,
+    move_resource::MoveStructType,
 };
+use once_cell::sync::Lazy;
 use rand::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
 use std::fmt::{Debug, Formatter};
@@ -128,6 +130,9 @@ impl MoveStructType for ChunkyDKGStartEvent {
     const MODULE_NAME: &'static IdentStr = ident_str!("chunky_dkg");
     const STRUCT_NAME: &'static IdentStr = ident_str!("ChunkyDKGStartEvent");
 }
+
+pub static CHUNKY_DKG_START_EVENT_MOVE_TYPE_TAG: Lazy<TypeTag> =
+    Lazy::new(|| TypeTag::Struct(Box::new(ChunkyDKGStartEvent::struct_tag())));
 
 pub struct ChunkyDKG {
     threshold_config: ChunkyDKGThresholdConfig,


### PR DESCRIPTION
## Summary

Integrates `ChunkyDKGManager` with the epoch manager to run chunky DKG during reconfiguration.

### `epoch_manager.rs`
- Adds `ChunkyDKGManager` lifecycle management (start/stop)
- Routes chunky DKG messages (`ChunkyTranscriptRequest`, `SubtranscriptSignatureRequest`, etc.) to the manager
- Handles `ChunkyDKGStartEvent` to trigger new DKG sessions
- Manages separate RPC channels for regular DKG vs chunky DKG

### `state_sync.rs`
- Subscribes to `0x1::chunky_dkg::ChunkyDKGStartEvent` in addition to regular DKG events

### `agg_trx_producer.rs`
- Refactors to accept `Arc<ReliableBroadcast>` for sharing with chunky DKG

### `api/types/transaction.rs`
- Adds placeholder for `ChunkyDKGResult` API type conversion

<!-- BUGBOT_STATUS --><sup><a href="https://cursor.com/dashboard?tab=bugbot">Cursor Bugbot</a> reviewed your changes and found no issues for commit <u>92c0c23</u></sup><!-- /BUGBOT_STATUS -->