### PR TITLE
[Peer Monitoring] Support peer metadata sanitization. 

### DIFF
--- a/config/src/config/peer_monitoring_config.rs
+++ b/config/src/config/peer_monitoring_config.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq, Serialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct PeerMonitoringServiceConfig {
+    pub enable_metadata_sanitization: bool, // Whether to sanitize (omit) metadata from responses
     pub enable_peer_monitoring_client: bool, // Whether or not to spawn the monitoring client
     pub latency_monitoring: LatencyMonitoringConfig,
     pub max_concurrent_requests: u64, // Max num of concurrent server tasks
@@ -22,6 +23,7 @@ pub struct PeerMonitoringServiceConfig {
 impl Default for PeerMonitoringServiceConfig {
     fn default() -> Self {
         Self {
+            enable_metadata_sanitization: true, // Enabled by default
             enable_peer_monitoring_client: true,
             latency_monitoring: LatencyMonitoringConfig::default(),
             max_concurrent_requests: 1000,


### PR DESCRIPTION
## Description
This PR introduces a config flag for sharing potentially sensitive metadata fields in the Peer Monitoring Service. By default, this information will not be shared with peers.

## How Has This Been Tested?
New and existing test infrastructure.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the default shape/content of peer-monitoring RPC responses, which could impact downstream consumers expecting `connected_peers` or `build_information`; logic itself is small and covered by new tests.
> 
> **Overview**
> Adds a new `PeerMonitoringServiceConfig.enable_metadata_sanitization` flag (default **true**) to control whether the peer monitoring server returns potentially sensitive metadata.
> 
> When enabled, `GetNetworkInformation` omits `connected_peers` and `GetNodeInformation` omits `build_information`; tests are updated to explicitly disable sanitization where prior expectations depended on these fields and new tests assert the sanitized behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 67d807b92614d8b9bdcb694b98cfc5cb0139a8fa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->