### PR TITLE
[Execution] Implement Copy for a few onchain config types

### DIFF
--- a/aptos-move/block-executor/src/executor.rs
+++ b/aptos-move/block-executor/src/executor.rs
@@ -1739,7 +1739,7 @@ where
         );
 
         let block_limit_processor = ExplicitSyncWrapper::new(BlockGasLimitProcessor::new(
-            self.config.onchain.block_gas_limit_type.clone(),
+            self.config.onchain.block_gas_limit_type,
             self.config.onchain.block_gas_limit_override(),
             num_txns,
         ));
@@ -1890,7 +1890,7 @@ where
 
         let num_workers = self.config.local.concurrency_level.min(num_txns / 2).max(2);
         let block_limit_processor = ExplicitSyncWrapper::new(BlockGasLimitProcessor::new(
-            self.config.onchain.block_gas_limit_type.clone(),
+            self.config.onchain.block_gas_limit_type,
             self.config.onchain.block_gas_limit_override(),
             num_txns + 1,
         ));
@@ -2222,7 +2222,7 @@ where
         let mut ret = Vec::with_capacity(num_txns + 1);
 
         let mut block_limit_processor = BlockGasLimitProcessor::<T>::new(
-            self.config.onchain.block_gas_limit_type.clone(),
+            self.config.onchain.block_gas_limit_type,
             self.config.onchain.block_gas_limit_override(),
             num_txns + 1,
         );

--- a/types/src/on_chain_config/execution_config.rs
+++ b/types/src/on_chain_config/execution_config.rs
@@ -29,13 +29,13 @@ impl OnChainExecutionConfig {
     pub fn transaction_shuffler_type(&self) -> TransactionShufflerType {
         match &self {
             OnChainExecutionConfig::Missing => TransactionShufflerType::NoShuffling,
-            OnChainExecutionConfig::V1(config) => config.transaction_shuffler_type.clone(),
-            OnChainExecutionConfig::V2(config) => config.transaction_shuffler_type.clone(),
-            OnChainExecutionConfig::V3(config) => config.transaction_shuffler_type.clone(),
-            OnChainExecutionConfig::V4(config) => config.transaction_shuffler_type.clone(),
-            OnChainExecutionConfig::V5(config) => config.transaction_shuffler_type.clone(),
-            OnChainExecutionConfig::V6(config) => config.transaction_shuffler_type.clone(),
-            OnChainExecutionConfig::V7(config) => config.transaction_shuffler_type.clone(),
+            OnChainExecutionConfig::V1(config) => config.transaction_shuffler_type,
+            OnChainExecutionConfig::V2(config) => config.transaction_shuffler_type,
+            OnChainExecutionConfig::V3(config) => config.transaction_shuffler_type,
+            OnChainExecutionConfig::V4(config) => config.transaction_shuffler_type,
+            OnChainExecutionConfig::V5(config) => config.transaction_shuffler_type,
+            OnChainExecutionConfig::V6(config) => config.transaction_shuffler_type,
+            OnChainExecutionConfig::V7(config) => config.transaction_shuffler_type,
         }
     }
 
@@ -50,10 +50,10 @@ impl OnChainExecutionConfig {
             OnChainExecutionConfig::V3(config) => config
                 .block_gas_limit
                 .map_or(BlockGasLimitType::NoLimit, BlockGasLimitType::Limit),
-            OnChainExecutionConfig::V4(config) => config.block_gas_limit_type.clone(),
-            OnChainExecutionConfig::V5(config) => config.block_gas_limit_type.clone(),
-            OnChainExecutionConfig::V6(config) => config.block_gas_limit_type.clone(),
-            OnChainExecutionConfig::V7(config) => config.block_gas_limit_type.clone(),
+            OnChainExecutionConfig::V4(config) => config.block_gas_limit_type,
+            OnChainExecutionConfig::V5(config) => config.block_gas_limit_type,
+            OnChainExecutionConfig::V6(config) => config.block_gas_limit_type,
+            OnChainExecutionConfig::V7(config) => config.block_gas_limit_type,
         }
     }
 
@@ -111,11 +111,11 @@ impl OnChainExecutionConfig {
             OnChainExecutionConfig::Missing => TransactionDeduperType::TxnHashAndAuthenticatorV1,
             OnChainExecutionConfig::V1(_config) => TransactionDeduperType::NoDedup,
             OnChainExecutionConfig::V2(_config) => TransactionDeduperType::NoDedup,
-            OnChainExecutionConfig::V3(config) => config.transaction_deduper_type.clone(),
-            OnChainExecutionConfig::V4(config) => config.transaction_deduper_type.clone(),
-            OnChainExecutionConfig::V5(config) => config.transaction_deduper_type.clone(),
-            OnChainExecutionConfig::V6(config) => config.transaction_deduper_type.clone(),
-            OnChainExecutionConfig::V7(config) => config.transaction_deduper_type.clone(),
+            OnChainExecutionConfig::V3(config) => config.transaction_deduper_type,
+            OnChainExecutionConfig::V4(config) => config.transaction_deduper_type,
+            OnChainExecutionConfig::V5(config) => config.transaction_deduper_type,
+            OnChainExecutionConfig::V6(config) => config.transaction_deduper_type,
+            OnChainExecutionConfig::V7(config) => config.transaction_deduper_type,
         }
     }
 
@@ -225,7 +225,7 @@ pub struct ExecutionConfigV7 {
     pub persisted_auxiliary_info_version: u8,
 }
 
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")] // cannot use tag = "type" as nested enums cannot work, and bcs doesn't support it
 pub enum TransactionShufflerType {
     NoShuffling,
@@ -262,14 +262,14 @@ impl TransactionShufflerType {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")] // cannot use tag = "type" as nested enums cannot work, and bcs doesn't support it
 pub enum TransactionDeduperType {
     NoDedup,
     TxnHashAndAuthenticatorV1,
 }
 
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")] // cannot use tag = "type" as nested enums cannot work, and bcs doesn't support it
 pub enum BlockGasLimitType {
     NoLimit,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Behavior should be unchanged; this is a mechanical trait/ownership change, though it touches execution configuration plumbing used during block execution.
> 
> **Overview**
> Removes repeated `.clone()` calls by making `TransactionShufflerType`, `TransactionDeduperType`, and `BlockGasLimitType` `Copy`, and updating `OnChainExecutionConfig` getters to return these values directly.
> 
> Updates `block-executor` initialization paths to pass `block_gas_limit_type` by value into `BlockGasLimitProcessor::new` (parallel v1/v2 and sequential), relying on the new `Copy` semantics.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 62f5aced195060e7903ca6c6686934237aa5e8d3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->