### PR TITLE
[Hot State] Add onchain config

### DIFF
--- a/testsuite/forge-cli/src/suites/dag.rs
+++ b/testsuite/forge-cli/src/suites/dag.rs
@@ -126,6 +126,10 @@ fn dag_realistic_env_max_load_test(
                     config_v7.block_gas_limit_type = BlockGasLimitType::NoLimit;
                     config_v7.transaction_shuffler_type = TransactionShufflerType::default_for_genesis();
                 }
+                OnChainExecutionConfig::V8(config_v8) => {
+                    config_v8.block_gas_limit_type = BlockGasLimitType::NoLimit;
+                    config_v8.transaction_shuffler_type = TransactionShufflerType::default_for_genesis();
+                }
             }
             helm_values["chain"]["on_chain_execution_config"] =
                 serde_yaml::to_value(on_chain_execution_config).expect("must serialize");
@@ -235,6 +239,9 @@ fn dag_reconfig_enable_test() -> ForgeConfig {
                     }
                     OnChainExecutionConfig::V7(config_v7) => {
                         config_v7.block_gas_limit_type = BlockGasLimitType::NoLimit;
+                    }
+                    OnChainExecutionConfig::V8(config_v8) => {
+                        config_v8.block_gas_limit_type = BlockGasLimitType::NoLimit;
                     }
             }
             helm_values["chain"]["on_chain_execution_config"] =

--- a/testsuite/forge-cli/src/suites/realistic_environment.rs
+++ b/testsuite/forge-cli/src/suites/realistic_environment.rs
@@ -567,6 +567,14 @@ pub(crate) fn realistic_network_tuned_for_throughput_test() -> ForgeConfig {
                             user_use_case_spread_factor: 0,
                         };
                     }
+                    OnChainExecutionConfig::V8(config_v8) => {
+                        config_v8.block_gas_limit_type = BlockGasLimitType::NoLimit;
+                        config_v8.transaction_shuffler_type = TransactionShufflerType::UseCaseAware {
+                            sender_spread_factor: 256,
+                            platform_use_case_spread_factor: 0,
+                            user_use_case_spread_factor: 0,
+                        };
+                    }
                 }
                 helm_values["chain"]["on_chain_execution_config"] =
                     serde_yaml::to_value(on_chain_execution_config).expect("must serialize");


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Updates the default on-chain execution config version and adds new serialized fields, which can affect genesis config generation and on-chain config compatibility if downstream components aren’t updated to understand `V8`.
> 
> **Overview**
> Adds `OnChainExecutionConfig::V8` and a new `HotStateConfig` enum (with genesis defaults) to carry hot-state tuning parameters on-chain, and switches `default_for_genesis()` to emit `V8`.
> 
> Updates forge suite genesis overrides (`dag.rs`, `realistic_environment.rs`) to handle `V8` when mutating execution config fields (e.g., `block_gas_limit_type`, `transaction_shuffler_type`) so tests continue to work with the new default version.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3f36b73accb7cf3530948b33e7705e65df8e6b5d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->