### PR TITLE
Rust 1.91

### DIFF
--- a/api/src/tests/account_abstraction_test.rs
+++ b/api/src/tests/account_abstraction_test.rs
@@ -51,7 +51,7 @@ async fn test_account_abstraction_single_signer(
     context.publish_package(&mut account, txn).await;
 
     let txn0 = context.mint_user_account(&account).await;
-    context.commit_block(&vec![txn0]).await;
+    context.commit_block(&[txn0]).await;
 
     context
         .api_execute_entry_function(
@@ -70,7 +70,7 @@ async fn test_account_abstraction_single_signer(
     let txn3 = context
         .add_dispatchable_authentication_function(&account, func_info.clone())
         .await;
-    context.commit_block(&vec![txn3]).await;
+    context.commit_block(&[txn3]).await;
 
     let factory = context.transaction_factory();
 
@@ -90,7 +90,7 @@ async fn test_account_abstraction_single_signer(
             ),
     );
 
-    let txn_status = context.try_commit_block(&vec![aa_txn]).await;
+    let txn_status = context.try_commit_block(&[aa_txn]).await;
     assert!(matches!(
         txn_status.last(),
         Some(TransactionStatus::Discard(StatusCode::ABORTED))
@@ -168,11 +168,11 @@ async fn test_account_abstraction_multi_agent_with_abstracted_sender(
     context.publish_package(&mut a, txn).await;
 
     let txn1 = context.mint_user_account(&a).await;
-    context.commit_block(&vec![txn1]).await;
+    context.commit_block(&[txn1]).await;
     let txn2 = context.mint_user_account(&b).await;
-    context.commit_block(&vec![txn2]).await;
+    context.commit_block(&[txn2]).await;
     let txn3 = context.mint_user_account(&c).await;
-    context.commit_block(&vec![txn3]).await;
+    context.commit_block(&[txn3]).await;
 
     // Convert c to aa
     context
@@ -187,7 +187,7 @@ async fn test_account_abstraction_multi_agent_with_abstracted_sender(
     let txn = context
         .add_dispatchable_authentication_function(&c, func_info.clone())
         .await;
-    context.commit_block(&vec![txn]).await;
+    context.commit_block(&[txn]).await;
 
     let sign_func = Arc::new(move |x: &[u8]| {
         key_pair

--- a/api/src/tests/accounts_test.rs
+++ b/api/src/tests/accounts_test.rs
@@ -136,7 +136,7 @@ async fn test_account_resources_by_ledger_version_with_context(mut context: Test
 
     let account = context.gen_account();
     let txn = context.create_user_account(&account).await;
-    context.commit_block(&vec![txn.clone()]).await;
+    context.commit_block(std::slice::from_ref(&txn)).await;
 
     if let Some(indexer_reader) = context.context.indexer_reader.as_ref() {
         // Waiting for the above transaction, block metadata and state checkpoint to get indexed.
@@ -270,9 +270,7 @@ async fn test_account_auto_creation() {
     let txn2 = root_account.sign_with_transaction_builder(context.transaction_factory().payload(
         aptos_stdlib::aptos_account_fungible_transfer_only(account.address(), 10_000_000_000),
     ));
-    context
-        .commit_block(&vec![txn1.clone(), txn2.clone()])
-        .await;
+    context.commit_block(&[txn1.clone(), txn2.clone()]).await;
     let txn = account.sign_with_transaction_builder(
         context
             .transaction_factory()
@@ -282,7 +280,7 @@ async fn test_account_auto_creation() {
             ))
             .gas_unit_price(1),
     );
-    context.commit_block(&vec![txn.clone()]).await;
+    context.commit_block(std::slice::from_ref(&txn)).await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -324,7 +322,7 @@ async fn test_get_account_balance(
                 context.use_orderless_transactions,
             ),
     );
-    context.commit_block(&vec![txn.clone()]).await;
+    context.commit_block(std::slice::from_ref(&txn)).await;
 
     // Check coin balance after migration
     let coin_balance_after = context
@@ -363,7 +361,7 @@ async fn test_get_account_balance(
                 context.use_orderless_transactions,
             ),
     );
-    context.commit_block(&vec![txn.clone()]).await;
+    context.commit_block(std::slice::from_ref(&txn)).await;
 
     // Check concurrent fungible asset balance
     let concurrent_fa_balance = context
@@ -392,7 +390,7 @@ async fn test_get_account_modules_by_ledger_version_with_context(mut context: Te
                 context.use_orderless_transactions,
             ),
     );
-    context.commit_block(&vec![txn.clone()]).await;
+    context.commit_block(std::slice::from_ref(&txn)).await;
 
     if let Some(indexer_reader) = context.context.indexer_reader.as_ref() {
         // Waiting for the above transaction, block metadata, and state checkpoint to be indexed.

--- a/api/src/tests/secp256k1_ecdsa.rs
+++ b/api/src/tests/secp256k1_ecdsa.rs
@@ -58,11 +58,11 @@ async fn test_multi_secp256k1_ecdsa(
     let mut account = LocalAccount::new(address, ed25519_private_key, 0);
 
     let txn0 = context.create_user_account(&account).await;
-    context.commit_block(&vec![txn0]).await;
+    context.commit_block(&[txn0]).await;
     let txn1 = context.mint_user_account(&account).await;
-    context.commit_block(&vec![txn1]).await;
+    context.commit_block(&[txn1]).await;
     let txn2 = context.create_user_account(&other).await;
-    context.commit_block(&vec![txn2]).await;
+    context.commit_block(&[txn2]).await;
 
     let current_ledger_version = u64::from(context.get_latest_ledger_info().ledger_version);
     let ed22519_txn = context.account_transfer(&mut account, &other, 5);
@@ -136,11 +136,11 @@ async fn test_secp256k1_ecdsa(
     let mut account = LocalAccount::new(address, ed25519_private_key, 0);
 
     let txn0 = context.create_user_account(&account).await;
-    context.commit_block(&vec![txn0]).await;
+    context.commit_block(&[txn0]).await;
     let txn1 = context.mint_user_account(&account).await;
-    context.commit_block(&vec![txn1]).await;
+    context.commit_block(&[txn1]).await;
     let txn2 = context.create_user_account(&other).await;
-    context.commit_block(&vec![txn2]).await;
+    context.commit_block(&[txn2]).await;
 
     let current_ledger_version = u64::from(context.get_latest_ledger_info().ledger_version);
     let ed22519_txn = context.account_transfer(&mut account, &other, 5);

--- a/api/src/tests/simulation_test.rs
+++ b/api/src/tests/simulation_test.rs
@@ -26,7 +26,7 @@ async fn simulate_aptos_transfer(
     let alice = &mut context.gen_account();
     let bob = &mut context.gen_account();
     let txn = context.mint_user_account(alice).await;
-    context.commit_block(&vec![txn]).await;
+    context.commit_block(&[txn]).await;
 
     let txn = context.account_transfer_to(alice, bob.address(), transfer_amount);
 
@@ -104,7 +104,7 @@ async fn simulate_aptos_transfer_bcs(
     let alice = &mut context.gen_account();
     let bob = &mut context.gen_account();
     let txn = context.mint_user_account(alice).await;
-    context.commit_block(&vec![txn]).await;
+    context.commit_block(&[txn]).await;
 
     let txn = context.account_transfer_to(alice, bob.address(), transfer_amount);
 
@@ -297,7 +297,7 @@ async fn test_simulate_txn_with_aggregator(
     let path = PathBuf::from(std::env!("CARGO_MANIFEST_DIR")).join("src/tests/move/pack_counter");
     let payload = TestContext::build_package(path, named_addresses);
     let txn = account.sign_with_transaction_builder(context.transaction_factory().payload(payload));
-    context.commit_block(&vec![txn]).await;
+    context.commit_block(&[txn]).await;
 
     let payload = TransactionPayload::EntryFunction(EntryFunction::new(
         ModuleId::new(account.address(), ident_str!("counter").to_owned()),
@@ -379,7 +379,7 @@ async fn test_bcs_simulate_simple(
     let alice = &mut context.gen_account();
     let bob = &mut context.gen_account();
     let txn = context.mint_user_account(alice).await;
-    context.commit_block(&vec![txn]).await;
+    context.commit_block(&[txn]).await;
 
     let txn = context.account_transfer_to(alice, bob.address(), transfer_amount);
     let body = bcs::to_bytes(&txn).unwrap();
@@ -439,7 +439,7 @@ async fn test_bcs_simulate_without_auth_key_check(
     let alice = &mut context.gen_account();
     let bob = &mut context.gen_account();
     let txn = context.mint_user_account(alice).await;
-    context.commit_block(&vec![txn]).await;
+    context.commit_block(&[txn]).await;
 
     // Construct a signed transaction.
     let txn = context.account_transfer_to(alice, bob.address(), transfer_amount);
@@ -465,7 +465,7 @@ async fn bcs_simulate_fee_payer_transaction_without_gas_fee_check(context: &mut 
     let alice = &mut context.gen_account();
     let bob = &mut context.gen_account();
     let txn = context.mint_user_account(alice).await;
-    context.commit_block(&vec![txn]).await;
+    context.commit_block(&[txn]).await;
 
     let transfer_amount: u64 = SMALL_TRANSFER_AMOUNT;
     let txn = context.account_transfer_to(alice, bob.address(), transfer_amount);
@@ -553,31 +553,14 @@ async fn test_bcs_simulate_automated_account_creation(
         .post_bcs_txn("/transactions/simulate", body)
         .await;
     assert!(!resp[0]["success"].as_bool().unwrap(), "{}", pretty(&resp));
-    if !context.use_orderless_transactions
-        && !context
-            .is_feature_enabled(
-                aptos_types::on_chain_config::FeatureFlag::ORDERLESS_TRANSACTIONS as u64,
-            )
-            .await
-    {
-        assert!(
-            resp[0]["vm_status"]
-                .as_str()
-                .unwrap()
-                .contains("INSUFFICIENT_BALANCE_FOR_TRANSACTION_FEE"),
-            "{}",
-            pretty(&resp)
-        );
-    } else {
-        assert!(
-            resp[0]["vm_status"]
-                .as_str()
-                .unwrap()
-                .contains("INSUFFICIENT_BALANCE_FOR_TRANSACTION_FEE"),
-            "{}",
-            pretty(&resp)
-        );
-    }
+    assert!(
+        resp[0]["vm_status"]
+            .as_str()
+            .unwrap()
+            .contains("INSUFFICIENT_BALANCE_FOR_TRANSACTION_FEE"),
+        "{}",
+        pretty(&resp)
+    );
 
     let txn =
         SignedTransaction::new_signed_transaction(raw_txn, TransactionAuthenticator::FeePayer {
@@ -617,7 +600,7 @@ async fn test_bcs_execute_simple_no_authenticator_fail(
     let alice = &mut context.gen_account();
     let bob = &mut context.gen_account();
     let txn = context.mint_user_account(alice).await;
-    context.commit_block(&vec![txn]).await;
+    context.commit_block(&[txn]).await;
 
     // Construct a signed transaction.
     let txn = context.account_transfer_to(alice, bob.address(), transfer_amount);
@@ -662,7 +645,7 @@ async fn test_bcs_execute_fee_payer_transaction_no_authenticator_fail(
     let alice = &mut context.gen_account();
     let bob = &mut context.gen_account();
     let txn = context.mint_user_account(alice).await;
-    context.commit_block(&vec![txn]).await;
+    context.commit_block(&[txn]).await;
 
     let transfer_amount: u64 = SMALL_TRANSFER_AMOUNT;
     let txn = context.account_transfer_to(alice, bob.address(), transfer_amount);
@@ -697,7 +680,7 @@ async fn test_simulate_txn_with_randomness() {
     let path = PathBuf::from(std::env!("CARGO_MANIFEST_DIR")).join("src/tests/move/pack_rand");
     let payload = TestContext::build_package(path, named_addresses);
     let txn = account.sign_with_transaction_builder(context.transaction_factory().payload(payload));
-    context.commit_block(&vec![txn]).await;
+    context.commit_block(&[txn]).await;
 
     let payload = TransactionPayload::EntryFunction(EntryFunction::new(
         ModuleId::new(account.address(), ident_str!("rand").to_owned()),

--- a/api/src/tests/slh_dsa_sha2_128s.rs
+++ b/api/src/tests/slh_dsa_sha2_128s.rs
@@ -64,11 +64,11 @@ async fn test_multi_slh_dsa_sha2_128s(
     let mut account = LocalAccount::new(address, ed25519_private_key, 0);
 
     let txn0 = context.create_user_account(&account).await;
-    context.commit_block(&vec![txn0]).await;
+    context.commit_block(&[txn0]).await;
     let txn1 = context.mint_user_account(&account).await;
-    context.commit_block(&vec![txn1]).await;
+    context.commit_block(&[txn1]).await;
     let txn2 = context.create_user_account(&other).await;
-    context.commit_block(&vec![txn2]).await;
+    context.commit_block(&[txn2]).await;
 
     let current_ledger_version = u64::from(context.get_latest_ledger_info().ledger_version);
     let ed22519_txn = context.account_transfer(&mut account, &other, 5);
@@ -147,11 +147,11 @@ async fn test_slh_dsa_sha2_128s(
     let mut account = LocalAccount::new(address, ed25519_private_key, 0);
 
     let txn0 = context.create_user_account(&account).await;
-    context.commit_block(&vec![txn0]).await;
+    context.commit_block(&[txn0]).await;
     let txn1 = context.mint_user_account(&account).await;
-    context.commit_block(&vec![txn1]).await;
+    context.commit_block(&[txn1]).await;
     let txn2 = context.create_user_account(&other).await;
-    context.commit_block(&vec![txn2]).await;
+    context.commit_block(&[txn2]).await;
 
     let current_ledger_version = u64::from(context.get_latest_ledger_info().ledger_version);
     let ed22519_txn = context.account_transfer(&mut account, &other, 5);

--- a/api/src/tests/state_test.rs
+++ b/api/src/tests/state_test.rs
@@ -193,7 +193,7 @@ async fn test_merkle_leaves_with_nft_transfer(
 
     let token_txn = creator.sign_with_transaction_builder(token_builder);
 
-    ctx.commit_block(&vec![txn1, txn2, collection_txn, token_txn])
+    ctx.commit_block(&[txn1, txn2, collection_txn, token_txn])
         .await;
 
     let num_leaves_at_beginning = ctx
@@ -218,7 +218,7 @@ async fn test_merkle_leaves_with_nft_transfer(
                 use_orderless_transactions,
             ),
     );
-    ctx.commit_block(&vec![transfer_to_owner_txn]).await;
+    ctx.commit_block(&[transfer_to_owner_txn]).await;
     let num_leaves_after_transfer_nft = ctx
         .db
         .get_state_item_count(ctx.db.get_latest_ledger_info_version().unwrap())
@@ -245,7 +245,7 @@ async fn test_merkle_leaves_with_nft_transfer(
                 use_orderless_transactions,
             ),
     );
-    ctx.commit_block(&vec![transfer_to_creator_txn]).await;
+    ctx.commit_block(&[transfer_to_creator_txn]).await;
     let num_leaves_after_return_nft = ctx
         .db
         .get_state_item_count(ctx.db.get_latest_ledger_info_version().unwrap())

--- a/api/src/tests/string_resource_test.rs
+++ b/api/src/tests/string_resource_test.rs
@@ -42,7 +42,7 @@ async fn test_renders_move_acsii_string_into_utf8_string(
                 context.use_orderless_transactions,
             ),
     );
-    context.commit_block(&vec![txn]).await;
+    context.commit_block(&[txn]).await;
 
     context
         .api_execute_entry_function(

--- a/api/src/tests/transactions_test.rs
+++ b/api/src/tests/transactions_test.rs
@@ -74,7 +74,7 @@ async fn test_get_transactions_returns_last_page_when_start_version_is_not_speci
     for _i in 0..20 {
         let account = context.gen_account();
         let txn = context.create_user_account_by(&mut root_account, &account);
-        context.commit_block(&vec![txn.clone()]).await;
+        context.commit_block(std::slice::from_ref(&txn)).await;
     }
 
     let resp = context.get("/transactions").await;
@@ -152,7 +152,7 @@ async fn test_get_transactions_output_user_transaction_with_entry_function_paylo
     let initial_ledger_version = u64::from(context.get_latest_ledger_info().ledger_version);
     let account = context.gen_account();
     let txn = context.create_user_account(&account).await;
-    context.commit_block(&vec![txn.clone()]).await;
+    context.commit_block(std::slice::from_ref(&txn)).await;
 
     let txns = context.get("/transactions?start=1").await;
     assert_eq!(
@@ -481,7 +481,7 @@ async fn test_post_batch_entry_function_api_validation(
     );
     let account = context.gen_account();
     let txn1 = context.create_user_account(&account).await;
-    context.commit_block(&vec![txn1]).await;
+    context.commit_block(&[txn1]).await;
 
     // This is a way to get around the Identifier checks!
     #[derive(serde::Serialize)]
@@ -819,7 +819,7 @@ async fn test_multi_ed25519_signed_transaction() {
                 context.use_orderless_transactions,
             ),
     );
-    context.commit_block(&vec![create_account_txn]).await;
+    context.commit_block(&[create_account_txn]).await;
 
     let raw_txn = factory
         .mint(auth_key.account_address(), 1000)
@@ -896,7 +896,7 @@ async fn test_get_transaction_by_hash(
     );
     let account = context.gen_account();
     let txn = context.create_user_account(&account).await;
-    context.commit_block(&vec![txn.clone()]).await;
+    context.commit_block(std::slice::from_ref(&txn)).await;
 
     let txns = context.get("/transactions?start=2&limit=1").await;
     assert_eq!(1, txns.as_array().unwrap().len());
@@ -962,7 +962,7 @@ async fn test_get_transaction_by_version(
     );
     let account = context.gen_account();
     let txn = context.create_user_account(&account).await;
-    context.commit_block(&vec![txn.clone()]).await;
+    context.commit_block(std::slice::from_ref(&txn)).await;
 
     let txns = context.get("/transactions?start=2&limit=1").await;
     assert_eq!(1, txns.as_array().unwrap().len());
@@ -1042,7 +1042,7 @@ async fn test_wait_transaction_by_hash(
     );
     let account = context.gen_account();
     let txn = context.create_user_account(&account).await;
-    context.commit_block(&vec![txn.clone()]).await;
+    context.commit_block(std::slice::from_ref(&txn)).await;
 
     let txns = context.get("/transactions?start=2&limit=1").await;
     assert_eq!(1, txns.as_array().unwrap().len());
@@ -1327,7 +1327,7 @@ async fn test_account_transaction_with_context(mut context: TestContext) {
     let initial_ledger_version = u64::from(context.get_latest_ledger_info().ledger_version);
     let account = context.gen_account();
     let txn = context.create_user_account(&account).await;
-    context.commit_block(&vec![txn]).await;
+    context.commit_block(&[txn]).await;
 
     if let Some(indexer_reader) = context.context.indexer_reader.as_ref() {
         indexer_reader
@@ -1392,7 +1392,7 @@ async fn test_get_account_transactions_filter_transactions_by_start_sequence_num
     let initial_sequence_number = context.root_account().await.sequence_number();
     let account = context.gen_account();
     let txn = context.create_user_account(&account).await;
-    context.commit_block(&vec![txn.clone()]).await;
+    context.commit_block(std::slice::from_ref(&txn)).await;
 
     let txns = context
         .get(
@@ -1426,7 +1426,7 @@ async fn test_get_account_transactions_filter_transactions_by_start_sequence_num
     );
     let account = context.gen_account();
     let txn = context.create_user_account(&account).await;
-    context.commit_block(&vec![txn]).await;
+    context.commit_block(&[txn]).await;
 
     let txns = context
         .get(
@@ -1464,7 +1464,7 @@ async fn test_get_account_transactions_filter_transactions_by_limit(
     let txn1 = context.create_user_account_by(&mut root_account, &account1);
     let account2 = context.gen_account();
     let txn2 = context.create_user_account_by(&mut root_account, &account2);
-    context.commit_block(&vec![txn1, txn2]).await;
+    context.commit_block(&[txn1, txn2]).await;
 
     if !context.use_orderless_transactions {
         let txns = context
@@ -1740,7 +1740,7 @@ async fn test_get_txn_execute_failed_by_entry_function_validation(
     );
     let account = context.gen_account();
     let txn1 = context.create_user_account(&account).await;
-    context.commit_block(&vec![txn1]).await;
+    context.commit_block(&[txn1]).await;
 
     test_get_txn_execute_failed_by_invalid_entry_function(
         context,
@@ -1776,7 +1776,7 @@ async fn test_get_txn_execute_failed_by_entry_function_invalid_module_name(
     );
     let account = context.gen_account();
     let txn1 = context.create_user_account(&account).await;
-    context.commit_block(&vec![txn1]).await;
+    context.commit_block(&[txn1]).await;
 
     test_submit_entry_function_api_validation(
         context,
@@ -1812,7 +1812,7 @@ async fn test_get_txn_execute_failed_by_entry_function_invalid_function_name(
     );
     let account = context.gen_account();
     let txn1 = context.create_user_account(&account).await;
-    context.commit_block(&vec![txn1]).await;
+    context.commit_block(&[txn1]).await;
 
     test_submit_entry_function_api_validation(
         context,
@@ -2827,7 +2827,7 @@ async fn test_get_transactions_auxiliary_info_with_valid_params() {
 
     // Commit all transactions in a single block with auxiliary info
     // This will create: [BlockMetadata(idx=0), UserTxn1(idx=1), UserTxn2(idx=2), UserTxn3(idx=3)]
-    context.try_commit_block(&vec![txn1, txn2, txn3]).await;
+    context.try_commit_block(&[txn1, txn2, txn3]).await;
 
     // Based on debug output, we know we have versions 0-5 after the commit
     // Test starting from version 1 (skip genesis) to version 4

--- a/api/src/tests/view_function.rs
+++ b/api/src/tests/view_function.rs
@@ -48,7 +48,7 @@ async fn test_simple_view(use_txn_payload_v2_format: bool, use_orderless_transac
     let txn1 = context.mint_user_account(creator).await;
     let txn2 = context.account_transfer(creator, owner, 100_000);
 
-    context.commit_block(&vec![txn1, txn2]).await;
+    context.commit_block(&[txn1, txn2]).await;
 
     let resp = context
         .post("/view", build_coin_balance_request(&owner.address()))
@@ -79,7 +79,7 @@ async fn test_view_gas_used_header(
     let txn1 = context.mint_user_account(creator).await;
     let txn2 = context.account_transfer(creator, owner, 100_000);
 
-    context.commit_block(&vec![txn1, txn2]).await;
+    context.commit_block(&[txn1, txn2]).await;
     context.wait_for_internal_indexer_caught_up().await;
 
     let req = warp::test::request()
@@ -133,7 +133,7 @@ async fn test_view_allowlist(use_txn_payload_v2_format: bool, use_orderless_tran
     let txn1 = context.mint_user_account(creator).await;
     let txn2 = context.account_transfer(creator, owner, 100_000);
 
-    context.commit_block(&vec![txn1, txn2]).await;
+    context.commit_block(&[txn1, txn2]).await;
 
     // See that an allowed function works.
     let resp1 = context
@@ -180,7 +180,7 @@ async fn test_view_blocklist(use_txn_payload_v2_format: bool, use_orderless_tran
     let txn1 = context.mint_user_account(creator).await;
     let txn2 = context.account_transfer(creator, owner, 100_000);
 
-    context.commit_block(&vec![txn1, txn2]).await;
+    context.commit_block(&[txn1, txn2]).await;
 
     // See that a blocked function is rejected.
     let resp1 = context
@@ -219,7 +219,7 @@ async fn test_view_error_move_abort(
     let txn1 = context.mint_user_account(creator).await;
     let txn2 = context.account_transfer(creator, owner, 100_000);
 
-    context.commit_block(&vec![txn1, txn2]).await;
+    context.commit_block(&[txn1, txn2]).await;
 
     let resp = context
         .expect_status_code(400)
@@ -257,7 +257,7 @@ async fn test_view_error_type_resolution_error(
     let txn1 = context.mint_user_account(creator).await;
     let txn2 = context.account_transfer(creator, owner, 100_000);
 
-    context.commit_block(&vec![txn1, txn2]).await;
+    context.commit_block(&[txn1, txn2]).await;
 
     let resp = context
         .expect_status_code(400)
@@ -281,7 +281,7 @@ async fn test_view_does_not_exist() {
     let txn1 = context.mint_user_account(creator).await;
     let txn2 = context.account_transfer(creator, owner, 100_000);
 
-    context.commit_block(&vec![txn1, txn2]).await;
+    context.commit_block(&[txn1, txn2]).await;
 
     let resp = context
         .expect_status_code(400)
@@ -320,7 +320,7 @@ async fn test_simple_view_invalid(
     let txn1 = context.mint_user_account(creator).await;
     let txn2 = context.account_transfer(creator, owner, 100_000);
 
-    context.commit_block(&vec![txn1, txn2]).await;
+    context.commit_block(&[txn1, txn2]).await;
 
     let resp = context
         .expect_status_code(400)
@@ -361,7 +361,7 @@ async fn test_versioned_simple_view(
     let txn2 = context.account_transfer(creator, owner, 100_000);
     let txn3 = context.account_transfer(creator, owner, 100_000);
 
-    context.commit_block(&vec![txn1, txn2, txn3]).await;
+    context.commit_block(&[txn1, txn2, txn3]).await;
 
     let resp = context
         .post(
@@ -416,7 +416,7 @@ async fn test_view_tuple(use_txn_payload_v2_format: bool, use_orderless_transact
             ),
     );
 
-    context.commit_block(&vec![module_txn]).await;
+    context.commit_block(&[module_txn]).await;
 
     let resp = context
         .post(
@@ -461,7 +461,7 @@ async fn test_view_aggregator(use_txn_payload_v2_format: bool, use_orderless_tra
                 context.use_orderless_transactions,
             ),
     );
-    context.commit_block(&vec![txn]).await;
+    context.commit_block(&[txn]).await;
 
     let function = format!("{}::counter::add_and_get_counter_value", account.address());
     let resp = context

--- a/api/src/tests/webauthn_secp256r1_ecdsa.rs
+++ b/api/src/tests/webauthn_secp256r1_ecdsa.rs
@@ -115,11 +115,11 @@ mod tests {
         let mut account = LocalAccount::new(address, ed25519_private_key, 0);
 
         let txn0 = context.create_user_account(&account).await;
-        context.commit_block(&vec![txn0]).await;
+        context.commit_block(&[txn0]).await;
         let txn1 = context.mint_user_account(&account).await;
-        context.commit_block(&vec![txn1]).await;
+        context.commit_block(&[txn1]).await;
         let txn2 = context.create_user_account(&other).await;
-        context.commit_block(&vec![txn2]).await;
+        context.commit_block(&[txn2]).await;
 
         let ed22519_txn = context.account_transfer(&mut account, &other, 5);
         let raw_txn = ed22519_txn.into_raw_transaction();
@@ -180,11 +180,11 @@ mod tests {
         let mut account = LocalAccount::new(address, ed25519_private_key, 0);
 
         let txn0 = context.create_user_account(&account).await;
-        context.commit_block(&vec![txn0]).await;
+        context.commit_block(&[txn0]).await;
         let txn1 = context.mint_user_account(&account).await;
-        context.commit_block(&vec![txn1]).await;
+        context.commit_block(&[txn1]).await;
         let txn2 = context.create_user_account(&other).await;
-        context.commit_block(&vec![txn2]).await;
+        context.commit_block(&[txn2]).await;
 
         let ed22519_txn = context.account_transfer(&mut account, &other, 5);
         let raw_txn = ed22519_txn.into_raw_transaction();

--- a/api/test-context/src/test_context.rs
+++ b/api/test-context/src/test_context.rs
@@ -627,7 +627,7 @@ impl TestContext {
                 ),
         );
         let txn2 = self.account_transfer_to(account, multisig_address, initial_balance);
-        self.commit_block(&vec![create_multisig_txn, txn2]).await;
+        self.commit_block(&[create_multisig_txn, txn2]).await;
         multisig_address
     }
 
@@ -651,7 +651,7 @@ impl TestContext {
         );
         let txn2 = self.account_transfer_to(account, account.address(), initial_balance);
 
-        self.commit_block(&vec![txn1, txn2]).await;
+        self.commit_block(&[txn1, txn2]).await;
     }
 
     pub async fn create_multisig_transaction(
@@ -671,7 +671,7 @@ impl TestContext {
                     self.use_orderless_transactions,
                 ),
         );
-        self.commit_block(&vec![txn]).await;
+        self.commit_block(&[txn]).await;
     }
 
     pub async fn approve_multisig_transaction(
@@ -691,7 +691,7 @@ impl TestContext {
                     self.use_orderless_transactions,
                 ),
         );
-        self.commit_block(&vec![txn]).await;
+        self.commit_block(&[txn]).await;
     }
 
     pub async fn reject_multisig_transaction(
@@ -711,7 +711,7 @@ impl TestContext {
                     self.use_orderless_transactions,
                 ),
         );
-        self.commit_block(&vec![txn]).await;
+        self.commit_block(&[txn]).await;
     }
 
     pub async fn create_multisig_transaction_with_payload_hash(
@@ -731,7 +731,7 @@ impl TestContext {
                     self.use_orderless_transactions,
                 ),
         );
-        self.commit_block(&vec![txn]).await;
+        self.commit_block(&[txn]).await;
     }
 
     pub fn account_transfer(

--- a/aptos-move/aptos-e2e-comparison-testing/src/execution.rs
+++ b/aptos-move/aptos-e2e-comparison-testing/src/execution.rs
@@ -62,8 +62,9 @@ pub(crate) fn add_aptos_packages_to_state_store(
     }
 }
 
-#[derive(ValueEnum, Clone, Copy, Debug, Eq, PartialEq, PartialOrd)]
+#[derive(ValueEnum, Clone, Copy, Debug, Default, Eq, PartialEq, PartialOrd)]
 pub enum ExecutionMode {
+    #[default]
     V1,
     V2,
     Compare,
@@ -88,12 +89,6 @@ impl ExecutionMode {
 
     pub fn is_v2_or_compare(&self) -> bool {
         self.is_v2() || self.is_compare()
-    }
-}
-
-impl Default for ExecutionMode {
-    fn default() -> Self {
-        Self::V1
     }
 }
 

--- a/aptos-move/e2e-testsuite/src/tests/transaction_fuzzer.rs
+++ b/aptos-move/e2e-testsuite/src/tests/transaction_fuzzer.rs
@@ -12,7 +12,7 @@ proptest! {
         txns in vec(any::<EntryFunctionCall>(), 0..10),
     ) {
         let executor = FakeExecutor::from_head_genesis();
-        let accounts = vec![
+        let accounts = [
             (Account::new_aptos_root(), 0),
         ];
         let num_accounts = accounts.len();

--- a/aptos-move/replay-benchmark/src/diff.rs
+++ b/aptos-move/replay-benchmark/src/diff.rs
@@ -422,7 +422,7 @@ mod tests {
             ContractEvent::new_v2_with_type_tag_str("0x1::event::EventD", vec![0, 1, 3]),
         ];
 
-        let expected_diffs = vec![
+        let expected_diffs = [
             Diff::Event {
                 left: Some(ContractEvent::new_v2_with_type_tag_str(
                     "0x1::event::EventB",
@@ -534,7 +534,7 @@ mod tests {
         .freeze()
         .unwrap();
 
-        let expected_diffs = vec![
+        let expected_diffs = [
             Diff::WriteSet {
                 state_key: StateKey::raw(b"key-2"),
                 left: Some(WriteOp::legacy_creation(vec![0, 1, 2].into())),

--- a/consensus/src/quorum_store/tests/batch_proof_queue_test.rs
+++ b/consensus/src/quorum_store/tests/batch_proof_queue_test.rs
@@ -159,7 +159,7 @@ async fn test_proof_calculate_remaining_txns_and_proofs() {
     let now_in_usecs = aptos_infallible::duration_since_epoch().as_micros() as u64;
     let author_0 = PeerId::random();
     let author_1 = PeerId::random();
-    let txns = vec![
+    let txns = [
         TxnSummaryWithExpiration::new(
             PeerId::ONE,
             ReplayProtector::SequenceNumber(0),
@@ -186,7 +186,7 @@ async fn test_proof_calculate_remaining_txns_and_proofs() {
         ),
     ];
 
-    let author_0_batches = vec![
+    let author_0_batches = [
         proof_of_store(
             author_0,
             BatchId::new_for_test(0),
@@ -208,7 +208,7 @@ async fn test_proof_calculate_remaining_txns_and_proofs() {
         ),
     ];
 
-    let author_1_batches = vec![
+    let author_1_batches = [
         proof_of_store(
             author_1,
             BatchId::new_for_test(4),
@@ -437,7 +437,7 @@ async fn test_proof_pull_proofs_with_duplicates() {
     let mut proof_queue = BatchProofQueue::new(my_peer_id, batch_store, 1);
     let now_in_secs = aptos_infallible::duration_since_epoch().as_secs() as u64;
     let now_in_usecs = now_in_secs * 1_000_000;
-    let txns = vec![
+    let txns = [
         TxnSummaryWithExpiration::new(
             PeerId::ONE,
             ReplayProtector::SequenceNumber(0),
@@ -467,7 +467,7 @@ async fn test_proof_pull_proofs_with_duplicates() {
     let author_0 = PeerId::random();
     let author_1 = PeerId::random();
 
-    let author_0_batches = vec![
+    let author_0_batches = [
         proof_of_store(
             author_0,
             BatchId::new_for_test(0),
@@ -494,7 +494,7 @@ async fn test_proof_pull_proofs_with_duplicates() {
         ),
     ];
 
-    let author_1_batches = vec![
+    let author_1_batches = [
         proof_of_store(
             author_1,
             BatchId::new_for_test(4),

--- a/consensus/src/quorum_store/tests/proof_manager_test.rs
+++ b/consensus/src/quorum_store/tests/proof_manager_test.rs
@@ -138,7 +138,7 @@ async fn test_block_request() {
     let proof = create_proof(PeerId::random(), 10, 1);
     proof_manager.receive_proofs(vec![proof.clone()]);
 
-    get_proposal_and_assert(&mut proof_manager, 100, &[], &vec![proof]).await;
+    get_proposal_and_assert(&mut proof_manager, 100, &[], &[proof]).await;
 }
 
 #[tokio::test]
@@ -157,7 +157,7 @@ async fn test_max_txns_from_block_to_execute() {
             Some(max_txns_from_block_to_execute),
             Some(block_gas_limit),
         ),
-        &vec![proof],
+        &[proof],
         Some(max_txns_from_block_to_execute),
         Some(block_gas_limit),
     );
@@ -171,7 +171,7 @@ async fn test_block_timestamp_expiration() {
     proof_manager.receive_proofs(vec![proof.clone()]);
 
     proof_manager.handle_commit_notification(1, vec![]);
-    get_proposal_and_assert(&mut proof_manager, 100, &[], &vec![proof]).await;
+    get_proposal_and_assert(&mut proof_manager, 100, &[], &[proof]).await;
 
     proof_manager.handle_commit_notification(20, vec![]);
     get_proposal_and_assert(&mut proof_manager, 100, &[], &[]).await;
@@ -188,7 +188,7 @@ async fn test_batch_commit() {
     proof_manager.receive_proofs(vec![proof1.clone()]);
 
     proof_manager.handle_commit_notification(1, vec![proof1.info().clone()]);
-    get_proposal_and_assert(&mut proof_manager, 100, &[], &vec![proof0]).await;
+    get_proposal_and_assert(&mut proof_manager, 100, &[], &[proof0]).await;
 }
 
 #[tokio::test]
@@ -242,14 +242,14 @@ async fn test_proposal_fairness() {
     get_proposal_and_assert(&mut proof_manager, 100, &[], &expected).await;
 
     // The first two proofs are taken fairly from each peer
-    get_proposal_and_assert(&mut proof_manager, 2, &[], &vec![
+    get_proposal_and_assert(&mut proof_manager, 2, &[], &[
         peer0_proofs[0].clone(),
         peer1_proof_0.clone(),
     ])
     .await;
 
     // The next two proofs are taken from the remaining peer
-    let filter = vec![peer0_proofs[0].clone(), peer1_proof_0.clone()];
+    let filter = [peer0_proofs[0].clone(), peer1_proof_0.clone()];
     let filter: Vec<_> = filter.iter().map(ProofOfStore::info).cloned().collect();
     get_proposal_and_assert(&mut proof_manager, 2, &filter, &peer0_proofs[1..3]).await;
 
@@ -285,7 +285,7 @@ async fn test_duplicate_batches_on_commit() {
     proof_manager.receive_proofs(vec![proof1.clone()]);
 
     // Only one copy of the batch exists
-    get_proposal_and_assert(&mut proof_manager, 10, &[], &vec![proof0.clone()]).await;
+    get_proposal_and_assert(&mut proof_manager, 10, &[], std::slice::from_ref(&proof0)).await;
 
     // Nothing goes wrong on commits
     proof_manager.handle_commit_notification(4, vec![batch.clone().into()]);
@@ -323,11 +323,11 @@ async fn test_duplicate_batches_on_expiration() {
     proof_manager.receive_proofs(vec![proof1.clone()]);
 
     // Only one copy of the batch exists
-    get_proposal_and_assert(&mut proof_manager, 10, &[], &vec![proof0.clone()]).await;
+    get_proposal_and_assert(&mut proof_manager, 10, &[], std::slice::from_ref(&proof0)).await;
 
     // Nothing goes wrong on expiration
     proof_manager.handle_commit_notification(5, vec![]);
-    get_proposal_and_assert(&mut proof_manager, 10, &[], &vec![proof0.clone()]).await;
+    get_proposal_and_assert(&mut proof_manager, 10, &[], std::slice::from_ref(&proof0)).await;
     proof_manager.handle_commit_notification(12, vec![]);
     get_proposal_and_assert(&mut proof_manager, 10, &[], &[]).await;
 }

--- a/crates/aptos-batch-encryption/src/tests/fptx_smoke.rs
+++ b/crates/aptos-batch-encryption/src/tests/fptx_smoke.rs
@@ -22,7 +22,7 @@ fn smoke_with_setup<R: RngCore + CryptoRng>(
     let ct = FPTX::encrypt(&ek, rng, &plaintext, &associated_data).unwrap();
     FPTX::verify_ct(&ct, &associated_data).unwrap();
 
-    let (d, pfs_promise) = FPTX::digest(&dk, &vec![ct.clone()], 0).unwrap();
+    let (d, pfs_promise) = FPTX::digest(&dk, std::slice::from_ref(&ct), 0).unwrap();
     let pfs = FPTX::eval_proofs_compute_all(&pfs_promise, &dk);
 
     let dk_shares: Vec<<FPTX as BatchThresholdEncryption>::DecryptionKeyShare> = msk_shares
@@ -49,7 +49,7 @@ fn smoke_with_setup<R: RngCore + CryptoRng>(
     ek.verify_decryption_key(&d, &dk).unwrap();
 
     let decrypted_plaintexts: Vec<String> =
-        FPTX::decrypt(&dk, &vec![ct.prepare(&d, &pfs).unwrap()]).unwrap();
+        FPTX::decrypt(&dk, &[ct.prepare(&d, &pfs).unwrap()]).unwrap();
 
     assert_eq!(decrypted_plaintexts[0], plaintext);
 

--- a/crates/aptos-batch-encryption/src/tests/fptx_succinct_smoke.rs
+++ b/crates/aptos-batch-encryption/src/tests/fptx_succinct_smoke.rs
@@ -22,7 +22,7 @@ fn smoke_with_setup<R: RngCore + CryptoRng>(
     let ct = FPTXSuccinct::encrypt(&ek, rng, &plaintext, &associated_data).unwrap();
     FPTXSuccinct::verify_ct(&ct, &associated_data).unwrap();
 
-    let (d, pfs_promise) = FPTXSuccinct::digest(&dk, &vec![ct.clone()], 0).unwrap();
+    let (d, pfs_promise) = FPTXSuccinct::digest(&dk, std::slice::from_ref(&ct), 0).unwrap();
     let pfs = FPTXSuccinct::eval_proofs_compute_all(&pfs_promise, &dk);
 
     let dk_shares: Vec<<FPTXSuccinct as BatchThresholdEncryption>::DecryptionKeyShare> = msk_shares
@@ -49,7 +49,7 @@ fn smoke_with_setup<R: RngCore + CryptoRng>(
     ek.verify_decryption_key(&d, &dk).unwrap();
 
     let decrypted_plaintexts: Vec<String> =
-        FPTXSuccinct::decrypt(&dk, &vec![ct.prepare(&d, &pfs).unwrap()]).unwrap();
+        FPTXSuccinct::decrypt(&dk, &[ct.prepare(&d, &pfs).unwrap()]).unwrap();
 
     assert_eq!(decrypted_plaintexts[0], plaintext);
 

--- a/crates/aptos-batch-encryption/src/tests/fptx_weighted_smoke.rs
+++ b/crates/aptos-batch-encryption/src/tests/fptx_weighted_smoke.rs
@@ -24,7 +24,7 @@ fn weighted_smoke_with_setup<R: RngCore + CryptoRng>(
     let ct = FPTXWeighted::encrypt(&ek, rng, &plaintext, &associated_data).unwrap();
     FPTXWeighted::verify_ct(&ct, &associated_data).unwrap();
 
-    let (d, pfs_promise) = FPTXWeighted::digest(&dk, &vec![ct.clone()], 0).unwrap();
+    let (d, pfs_promise) = FPTXWeighted::digest(&dk, std::slice::from_ref(&ct), 0).unwrap();
     let pfs = FPTXWeighted::eval_proofs_compute_all(&pfs_promise, &dk);
 
     let dk_shares: Vec<<FPTXWeighted as BatchThresholdEncryption>::DecryptionKeyShare> = msk_shares
@@ -51,7 +51,7 @@ fn weighted_smoke_with_setup<R: RngCore + CryptoRng>(
     ek.verify_decryption_key(&d, &dk).unwrap();
 
     let decrypted_plaintexts: Vec<String> =
-        FPTXWeighted::decrypt(&dk, &vec![ct.prepare(&d, &pfs).unwrap()]).unwrap();
+        FPTXWeighted::decrypt(&dk, &[ct.prepare(&d, &pfs).unwrap()]).unwrap();
 
     assert_eq!(decrypted_plaintexts[0], plaintext);
 

--- a/crates/aptos-dkg/src/pvss/das/unweighted_protocol.rs
+++ b/crates/aptos-dkg/src/pvss/das/unweighted_protocol.rs
@@ -300,9 +300,9 @@ impl AggregatableTranscript for Transcript {
         let g_1_inverse = pp.get_encryption_public_params().pubkey_base().neg();
 
         // The vector of left-hand-side ($\mathbb{G}_1$) inputs to each pairing in the multi-pairing.
-        let lhs = vec![h_1, ek.add(g_1_inverse), self.C_0.add(c.neg())];
+        let lhs = [h_1, ek.add(g_1_inverse), self.C_0.add(c.neg())];
         // The vector of right-hand-side ($\mathbb{G}_2$) inputs to each pairing in the multi-pairing.
-        let rhs = vec![v, self.hat_w, g_2];
+        let rhs = [v, self.hat_w, g_2];
 
         let res = multi_pairing(lhs.iter(), rhs.iter());
         if res != Gt::identity() {

--- a/crates/aptos-dkg/tests/crypto.rs
+++ b/crates/aptos-dkg/tests/crypto.rs
@@ -187,7 +187,7 @@ fn test_parallel_multi_pairing() {
     let pool1 = spawn_rayon_thread_pool("testmultpair".to_string(), Some(1));
     let pool32 = spawn_rayon_thread_pool("testmultpair".to_string(), Some(32));
 
-    for (g1, g2) in vec![
+    for (g1, g2) in [
         ([G1Projective::identity(), r1[0]], r2),
         (r1, r2),
         (r1, [G2Projective::identity(), r2[0]]),

--- a/crates/aptos-jwk-consensus/src/jwk_manager/tests.rs
+++ b/crates/aptos-jwk-consensus/src/jwk_manager/tests.rs
@@ -417,7 +417,7 @@ async fn test_jwk_manager_state_transition() {
         };
     }
     assert_eq!(expected_states, jwk_manager.states_by_issuer);
-    let expected_vtxn_hashes = vec![
+    let expected_vtxn_hashes = [
         ValidatorTransaction::ObservedJWKUpdate(qc_update_for_alice),
         ValidatorTransaction::ObservedJWKUpdate(qc_update_for_carl),
     ]

--- a/crates/aptos-jwk-consensus/src/types.rs
+++ b/crates/aptos-jwk-consensus/src/types.rs
@@ -100,8 +100,9 @@ impl Drop for QuorumCertProcessGuard {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub enum ConsensusState<T: Debug + Clone + Eq + PartialEq> {
+    #[default]
     NotStarted,
     InProgress {
         my_proposal: T,
@@ -161,11 +162,5 @@ impl<T: Debug + Clone + Eq + PartialEq> ConsensusState<T> {
             | ConsensusState::Finished { my_proposal, .. } => my_proposal.clone(),
             _ => panic!("my_proposal unavailable"),
         }
-    }
-}
-
-impl<T: Debug + Clone + Eq + PartialEq> Default for ConsensusState<T> {
-    fn default() -> Self {
-        Self::NotStarted
     }
 }

--- a/crates/aptos/src/common/init.rs
+++ b/crates/aptos/src/common/init.rs
@@ -456,10 +456,11 @@ impl InitTool {
 /// A simplified list of all networks supported by the CLI
 ///
 /// Any command using this, will be simpler to setup as profiles
-#[derive(Copy, Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Default, Serialize, Deserialize, Eq, PartialEq)]
 pub enum Network {
     Mainnet,
     Testnet,
+    #[default]
     Devnet,
     Local,
     Custom,
@@ -494,11 +495,5 @@ impl FromStr for Network {
                 )));
             },
         })
-    }
-}
-
-impl Default for Network {
-    fn default() -> Self {
-        Self::Devnet
     }
 }

--- a/crates/aptos/src/common/types.rs
+++ b/crates/aptos/src/common/types.rs
@@ -1157,20 +1157,15 @@ impl RestOptions {
 }
 
 /// Options for optimization level
-#[derive(Debug, Clone, Parser)]
+#[derive(Debug, Clone, Default, Parser)]
 pub enum OptimizationLevel {
     /// No optimizations
     None,
     /// Default optimization level
+    #[default]
     Default,
     /// Extra optimizations, that may take more time
     Extra,
-}
-
-impl Default for OptimizationLevel {
-    fn default() -> Self {
-        Self::Default
-    }
 }
 
 impl FromStr for OptimizationLevel {

--- a/crates/aptos/src/config/mod.rs
+++ b/crates/aptos/src/config/mod.rs
@@ -418,19 +418,14 @@ const WORKSPACE: &str = "workspace";
 ///
 /// Workspace allows for multiple configs based on location, where
 /// Global allows for one config for every part of the code
-#[derive(Debug, Copy, Clone, Serialize, Deserialize, ValueEnum)]
+#[derive(Debug, Copy, Clone, Default, Serialize, Deserialize, ValueEnum)]
 pub enum ConfigType {
     /// Per system user configuration put in `<HOME>/.aptos`
     Global,
     /// Per directory configuration put in `<CURRENT_DIR>/.aptos`
+    // TODO: When we version up, we can change this to global
+    #[default]
     Workspace,
-}
-
-impl Default for ConfigType {
-    fn default() -> Self {
-        // TODO: When we version up, we can change this to global
-        Self::Workspace
-    }
 }
 
 impl std::fmt::Display for ConfigType {
@@ -464,20 +459,15 @@ const ASSUME_NO: &str = "no";
 ///
 /// Option can be one of ["yes", "no", "prompt"], "yes" runs cli with "--assume-yes", where
 /// "no" runs cli with "--assume-no", default: "prompt"
-#[derive(Debug, Copy, Clone, Serialize, Deserialize, ValueEnum)]
+#[derive(Debug, Copy, Clone, Default, Serialize, Deserialize, ValueEnum)]
 pub enum PromptResponseType {
     /// normal prompt
+    #[default]
     Prompt,
     /// `--assume-yes`
     Yes,
     /// `--assume-no`
     No,
-}
-
-impl Default for PromptResponseType {
-    fn default() -> Self {
-        Self::Prompt
-    }
 }
 
 impl std::fmt::Display for PromptResponseType {

--- a/crates/channel/src/message_queues.rs
+++ b/crates/channel/src/message_queues.rs
@@ -19,17 +19,12 @@ const POPS_PER_GC: u32 = 50;
 /// With LIFO, oldest messages are dropped.
 /// With FIFO, newest messages are dropped.
 /// With KLAST, oldest messages are dropped, but remaining are retrieved in FIFO order
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Default)]
 pub enum QueueStyle {
+    #[default]
     FIFO,
     LIFO,
     KLAST,
-}
-
-impl Default for QueueStyle {
-    fn default() -> Self {
-        Self::FIFO
-    }
 }
 
 /// PerKeyQueue maintains a queue of messages per key. It

--- a/dkg/src/chunky/dkg_manager.rs
+++ b/dkg/src/chunky/dkg_manager.rs
@@ -53,8 +53,9 @@ use std::{
 use tokio_retry::strategy::ExponentialBackoff;
 
 #[allow(dead_code)]
-#[derive(Debug)]
+#[derive(Debug, Default)]
 enum InnerState {
+    #[default]
     Init,
     AwaitSubtranscriptAggregation {
         start_time: Duration,
@@ -75,12 +76,6 @@ enum InnerState {
         my_transcript: ChunkyDKGTranscript,
         proposed: bool,
     },
-}
-
-impl Default for InnerState {
-    fn default() -> Self {
-        Self::Init
-    }
 }
 
 impl InnerState {

--- a/dkg/src/dkg_manager/mod.rs
+++ b/dkg/src/dkg_manager/mod.rs
@@ -28,8 +28,9 @@ use move_core_types::account_address::AccountAddress;
 use rand::{prelude::StdRng, thread_rng, SeedableRng};
 use std::{sync::Arc, time::Duration};
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 enum InnerState {
+    #[default]
     NotStarted,
     InProgress {
         start_time: Duration,
@@ -42,12 +43,6 @@ enum InnerState {
         my_transcript: DKGTranscript,
         proposed: bool,
     },
-}
-
-impl Default for InnerState {
-    fn default() -> Self {
-        Self::NotStarted
-    }
 }
 
 pub struct DKGManager<DKG: DKGTrait> {

--- a/docker/builder/builder.Dockerfile
+++ b/docker/builder/builder.Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /aptos
 RUN rm -f /etc/apt/apt.conf.d/docker-clean; echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
 # NOTE: the version of LLVM installed here MUST match the version of LLVM rustc
 # uses internally, so we may need to upgrade this when upgrading Rust versions.
-ARG CLANG_VERSION=20
+ARG CLANG_VERSION=21
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
     sed -i 's|http://deb.debian.org/debian|http://cloudfront.debian.net/debian|g' /etc/apt/sources.list \

--- a/keyless/pepper/common/src/vuf/bls12381_g1_bls.rs
+++ b/keyless/pepper/common/src/vuf/bls12381_g1_bls.rs
@@ -101,8 +101,8 @@ impl VUF for Bls12381G1Bls {
 
         ensure!(
             multi_pairing(
-                vec![-output_g1, input_g1.into()].iter(),
-                vec![G2Projective::generator(), *pk_g2].iter()
+                [-output_g1, input_g1.into()].iter(),
+                [G2Projective::generator(), *pk_g2].iter()
             ) == Gt::identity(),
             "Bls12381G1Bls::verify failed with final check failure"
         );

--- a/mempool/src/tests/core_mempool_test.rs
+++ b/mempool/src/tests/core_mempool_test.rs
@@ -92,7 +92,7 @@ fn test_transaction_ordering_seqnos_and_nonces() {
     );
 
     // Expected transaction order in priority queue
-    let ordered_transactions = vec![
+    let ordered_transactions = [
         TestTransaction::new(0, ReplayProtector::Nonce(200), 7),
         TestTransaction::new(0, ReplayProtector::SequenceNumber(1), 5),
         TestTransaction::new(0, ReplayProtector::Nonce(150), 3),

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.90.0"
+channel = "1.91.1"
 
 # Note: we don't specify cargofmt in our toolchain because we rely on
 # the nightly version of cargofmt and verify formatting in CI/CD.

--- a/scripts/dev_setup.sh
+++ b/scripts/dev_setup.sh
@@ -122,7 +122,7 @@ function install_build_essentials {
 
 function install_clang {
   PACKAGE_MANAGER=$1
-  VERSION=${2:-20}
+  VERSION=${2:-21}
 
   if [[ "$PACKAGE_MANAGER" == "apt-get" ]]; then
     "${PRE_COMMAND[@]}" apt-get install -y gnupg lsb-release software-properties-common wget

--- a/storage/aptosdb/src/ledger_db/ledger_metadata_db_test.rs
+++ b/storage/aptosdb/src/ledger_db/ledger_metadata_db_test.rs
@@ -236,7 +236,7 @@ fn test_block_api() {
     let mut batch = SchemaBatch::new();
     let proposer_1 = AccountAddress::random();
     let proposer_2 = AccountAddress::random();
-    let events = vec![
+    let events = [
         NewBlockEvent::new(
             AccountAddress::random(),
             0,

--- a/storage/aptosdb/src/state_restore/mod.rs
+++ b/storage/aptosdb/src/state_restore/mod.rs
@@ -46,20 +46,15 @@ pub trait StateValueWriter<K, V>: Send + Sync {
     fn get_progress(&self, version: Version) -> Result<Option<StateSnapshotProgress>>;
 }
 
-#[derive(Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, Deserialize, Serialize, PartialEq, Eq)]
 pub enum StateSnapshotRestoreMode {
     /// Restore both KV and Tree by default
+    #[default]
     Default,
     /// Only restore the state KV
     KvOnly,
     /// Only restore the state tree
     TreeOnly,
-}
-
-impl Default for StateSnapshotRestoreMode {
-    fn default() -> Self {
-        Self::Default
-    }
 }
 
 impl FromStr for StateSnapshotRestoreMode {

--- a/third_party/move/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/bounds_tests.rs
+++ b/third_party/move/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/bounds_tests.rs
@@ -307,7 +307,7 @@ fn invalid_signature_for_vector_operation() {
 
     let skeleton = basic_test_module();
     let sig_index = SignatureIndex(skeleton.signatures.len() as u16);
-    for bytecode in vec![
+    for bytecode in [
         VecPack(sig_index, 0),
         VecLen(sig_index),
         VecImmBorrow(sig_index),
@@ -336,7 +336,7 @@ fn invalid_struct_for_vector_operation() {
         .signatures
         .push(Signature(vec![Struct(StructHandleIndex::new(3))]));
     let sig_index = SignatureIndex((skeleton.signatures.len() - 1) as u16);
-    for bytecode in vec![
+    for bytecode in [
         VecPack(sig_index, 0),
         VecLen(sig_index),
         VecImmBorrow(sig_index),
@@ -363,7 +363,7 @@ fn invalid_type_param_for_vector_operation() {
     let mut skeleton = basic_test_module();
     skeleton.signatures.push(Signature(vec![TypeParameter(0)]));
     let sig_index = SignatureIndex((skeleton.signatures.len() - 1) as u16);
-    for bytecode in vec![
+    for bytecode in [
         VecPack(sig_index, 0),
         VecLen(sig_index),
         VecImmBorrow(sig_index),

--- a/third_party/move/move-model/src/model.rs
+++ b/third_party/move/move-model/src/model.rs
@@ -491,9 +491,10 @@ impl QualifiedInstId<StructId> {
 /// # Verification Scope
 
 /// Defines what functions to verify.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub enum VerificationScope {
     /// Verify only public functions.
+    #[default]
     Public,
     /// Verify all functions.
     All,
@@ -503,12 +504,6 @@ pub enum VerificationScope {
     OnlyModule(String),
     /// Verify no functions
     None,
-}
-
-impl Default for VerificationScope {
-    fn default() -> Self {
-        Self::Public
-    }
 }
 
 impl VerificationScope {

--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -1740,17 +1740,12 @@ pub struct TransactionAuxiliaryDataV1 {
     pub detail_error_message: Option<VMErrorDetail>,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
 pub enum TransactionAuxiliaryData {
+    #[default]
     None,
     V1(TransactionAuxiliaryDataV1),
-}
-
-impl Default for TransactionAuxiliaryData {
-    fn default() -> Self {
-        Self::None
-    }
 }
 
 impl TransactionAuxiliaryData {


### PR DESCRIPTION

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Toolchain and compiler (Rust/Clang) bumps can surface new lints or behavioral differences across the workspace; code changes are mostly mechanical but touch many modules and test paths.
> 
> **Overview**
> Upgrades the Rust toolchain to `1.91.1` and updates build/setup tooling to use Clang/LLVM `21` (Docker builder + `scripts/dev_setup.sh`).
> 
> Refactors numerous tests and helpers to pass transactions/events via slice/array literals (e.g. `&[txn]` / `std::slice::from_ref`) instead of allocating `Vec`s, and simplifies a simulation test assertion.
> 
> Replaces manual `impl Default` blocks with `#[derive(Default)]` + `#[default]` variants across multiple enums (CLI/config options, consensus/DKG state machines, execution mode, restore mode, verification scope, transaction auxiliary data), aligning with newer Rust idioms.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5bcfc8c2833eaf57f5f0945a42084def5c579757. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->