### PR TITLE
[TSS] add support for randomness in local mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,7 +304,7 @@ dependencies = [
 
 [[package]]
 name = "aptos"
-version = "7.14.1"
+version = "7.14.2"
 dependencies = [
  "anyhow",
  "aptos-api-types",
@@ -4710,6 +4710,7 @@ dependencies = [
  "bcs 0.1.4",
  "hex",
  "move-core-types",
+ "rand 0.7.3",
  "serde",
  "serde_json",
  "tempfile",

--- a/aptos-move/aptos-transaction-simulation-session/Cargo.toml
+++ b/aptos-move/aptos-transaction-simulation-session/Cargo.toml
@@ -16,6 +16,7 @@ rust-version = { workspace = true }
 anyhow = { workspace = true }
 bcs = { workspace = true }
 hex = { workspace = true }
+rand = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 tokio = { workspace = true }

--- a/crates/aptos/CHANGELOG.md
+++ b/crates/aptos/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to the Aptos CLI will be captured in this file. This project
 
 # Unreleased
 
+## [7.14.2]
+- Transaction Simulation Session: fix support for simulating transactions that use on-chain randomness (local mode only)
+
 ## [7.14.1]
 - Transaction simulation: fix bug in `fund_apt_fungible_store`
 

--- a/crates/aptos/Cargo.toml
+++ b/crates/aptos/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aptos"
 description = "Aptos tool for management of nodes and interacting with the blockchain"
-version = "7.14.1"
+version = "7.14.2"
 
 # Workspace inherited keys
 authors = { workspace = true }


### PR DESCRIPTION
This fixes Transaction Simulation Session to support transactions that use on-chain randomness in local mode.

Previously, simulating random transactions would fail because the randomness seed was not set. Now we patch a random seed when initializing local sessions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: change is scoped to local Transaction Simulation Session initialization, but it introduces nondeterministic seeding which could affect reproducibility of simulations/tests.
> 
> **Overview**
> Local Transaction Simulation Sessions now **seed on-chain randomness** by writing a synthetic `PerBlockRandomness` config during `Session::init`, enabling simulation of transactions that call randomness APIs (remote/forked sessions intentionally remain unchanged).
> 
> Adds `rand` as a dependency, includes a regression test asserting the seed is present and 32 bytes, and bumps the Aptos CLI version/changelog to `7.14.2`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9b41605e97d2291cf3574507e6bd0867b411c7a0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->