### PR TITLE
[Storage] Fix for panics in state update code

### DIFF
--- a/execution/executor/src/workflow/do_get_execution_output.rs
+++ b/execution/executor/src/workflow/do_get_execution_output.rs
@@ -422,7 +422,7 @@ impl Parser {
             base_state_view.persisted_state(),
             to_commit.state_update_refs(),
             base_state_view.memorized_reads(),
-        );
+        )?;
         let state_reads = base_state_view.into_memorized_reads();
 
         let out = ExecutionOutput::new(

--- a/storage/aptosdb/src/state_store/tests/speculative_state_workflow.rs
+++ b/storage/aptosdb/src/state_store/tests/speculative_state_workflow.rs
@@ -563,12 +563,14 @@ fn update_state(
         });
         let memorized_reads = state_view.into_memorized_reads();
 
-        let (next_state, hot_state_updates) = parent_state.update_with_memorized_reads(
-            hot_state.clone(),
-            &persisted_state,
-            block.update_refs(),
-            &memorized_reads,
-        );
+        let (next_state, hot_state_updates) = parent_state
+            .update_with_memorized_reads(
+                hot_state.clone(),
+                &persisted_state,
+                block.update_refs(),
+                &memorized_reads,
+            )
+            .unwrap();
 
         state_by_version.assert_ledger_state(&next_state);
 

--- a/storage/storage-interface/src/state_store/state.rs
+++ b/storage/storage-interface/src/state_store/state.rs
@@ -18,9 +18,10 @@ use crate::{
     },
     DbReader,
 };
-use anyhow::Result;
+use anyhow::{bail, Result};
 use aptos_config::config::HotStateConfig;
 use aptos_experimental_layered_map::{LayeredMap, MapLayer};
+use aptos_logger::warn;
 use aptos_metrics_core::TimerHelper;
 use aptos_types::{
     state_store::{
@@ -161,7 +162,7 @@ impl State {
         per_version_updates: &PerVersionStateUpdateRefs,
         all_checkpoint_versions: &[Version],
         state_cache: &ShardedStateCache,
-    ) -> (Self, [HotStateShardUpdates; NUM_STATE_SHARDS]) {
+    ) -> Result<(Self, [HotStateShardUpdates; NUM_STATE_SHARDS])> {
         let _timer = TIMER.timer_with(&["state__update"]);
 
         // 1. The update batch must begin at self.next_version().
@@ -170,12 +171,15 @@ impl State {
         // 2. The cache must be at a version equal or newer than `persisted`, otherwise
         //    updates between the cached version and the persisted version are potentially
         //    missed during the usage calculation.
-        assert!(
-            persisted.next_version() <= state_cache.next_version(),
-            "persisted: {}, cache: {}",
-            persisted.next_version(),
-            state_cache.next_version(),
-        );
+        if persisted.next_version() > state_cache.next_version() {
+            let msg = format!(
+                "Persisted version ({}) is ahead of cache version ({}), possibly due to a fork.",
+                persisted.next_version(),
+                state_cache.next_version(),
+            );
+            warn!("{}", msg);
+            bail!("{}", msg);
+        }
         // 3. `self` must be at a version equal or newer than the cache, because we assume
         //    it is overlaid on top of the cache.
         assert!(self.next_version() >= state_cache.next_version());
@@ -268,7 +272,7 @@ impl State {
             .expect("Known to be 16 shards.");
 
         // TODO(HotState): extract and pass new hot state onchain config if needed.
-        (
+        Ok((
             State::new_with_updates(
                 batched_updates.last_version(),
                 shards,
@@ -277,7 +281,7 @@ impl State {
                 self.hot_state_config,
             ),
             hot_state_updates,
-        )
+        ))
     }
 
     /// Applies the update the returns the `HotStateValue` that will later go into the hot state
@@ -428,7 +432,7 @@ impl LedgerState {
         persisted_snapshot: &State,
         updates: &StateUpdateRefs,
         reads: &ShardedStateCache,
-    ) -> (LedgerState, HotStateUpdates) {
+    ) -> Result<(LedgerState, HotStateUpdates)> {
         let _timer = TIMER.timer_with(&["ledger_state__update"]);
 
         let mut all_hot_state_updates = HotStateUpdates::new_empty();
@@ -443,7 +447,7 @@ impl LedgerState {
                 per_version,
                 updates.all_checkpoint_versions(),
                 reads,
-            );
+            )?;
             all_hot_state_updates.for_last_checkpoint = Some(hot_state_updates);
             new_ckpt
         } else {
@@ -466,17 +470,17 @@ impl LedgerState {
                 per_version,
                 &[],
                 reads,
-            );
+            )?;
             all_hot_state_updates.for_latest = Some(hot_state_updates);
             new_latest
         } else {
             base_of_latest.clone()
         };
 
-        (
+        Ok((
             LedgerState::new(latest, last_checkpoint),
             all_hot_state_updates,
-        )
+        ))
     }
 
     /// Old values of the updated keys are read from the DbReader at the version of the
@@ -502,7 +506,7 @@ impl LedgerState {
             persisted_snapshot,
             updates,
             state_view.memorized_reads(),
-        );
+        )?;
         let state_reads = state_view.into_memorized_reads();
         Ok((updated, state_reads, hot_state_updates))
     }


### PR DESCRIPTION

I've seen this panic in `StateSummary::update` happen once or twice. Hard to
tell the exact root cause, and it's very rare and hard to reproduce, but what
happens in the following hypothesis could theoretically cause some issue.

Occasionally we might run into a fork. Let's say we have block `A` and two
descendants `B` and `C`:

```
A ---- B
 |_____C
```

It's possible that `B` and `C` are both scheduled for speculative execution. If
`B` gets pre-committed, the background thread will eventually advance the
"persisted" version to `B`'s version. This could happen even faster if `B` is a
reconfig block, since we set `sync_commit` to true in this case.

If the execution of `C` happens a bit slower, it's possible that by the time we
are about to calculate `C`'s state, the "persisted" version has already moved
past `A`'s version. Therefore invariant `persisted <= C` would break.

To address this, we simply relax these assertions a bit and replace them with
`ensure` instead. If `B` gets pre-committed, `C` probably will be discarded
anyway, so failing to execute it isn't a big deal and probably saves a bit
resources too. The error will be propagated and handled by consensus.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core state update paths used by execution and state summary computation; new early-error conditions could cause blocks to fail execution instead of panicking, so behavior changes under rare fork/version-skew scenarios.
> 
> **Overview**
> **Avoids panics in speculative state updates under rare fork/version-skew scenarios.** `State::update`, `LedgerState::update_with_memorized_reads`, and `StateSummary::update` now return `Result` and replace version-ordering `assert!`s with `warn!` + `bail!` when persisted versions are ahead of the cache/current state.
> 
> Call sites in the executor (`do_get_execution_output`) and storage tests are updated to propagate/unwrap the new `Result`, ensuring the pipeline errors out cleanly instead of crashing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 58074e49f22ab4717c9600728c3b4302fd551574. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->