### PR TITLE
[storage] Add StateKey to HotStateValue schema for reconstruction

### DIFF
--- a/storage/aptosdb/src/schema/hot_state_value_by_key_hash/mod.rs
+++ b/storage/aptosdb/src/schema/hot_state_value_by_key_hash/mod.rs
@@ -18,7 +18,10 @@ use aptos_schemadb::{
     define_schema,
     schema::{KeyCodec, ValueCodec},
 };
-use aptos_types::{state_store::state_value::StateValue, transaction::Version};
+use aptos_types::{
+    state_store::{state_key::StateKey, state_value::StateValue},
+    transaction::Version,
+};
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 #[cfg(any(test, feature = "fuzzing"))]
 use proptest_derive::Arbitrary;
@@ -33,10 +36,13 @@ type Key = (HashValue, Version);
 #[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
 pub(crate) enum HotStateValue {
     Occupied {
+        state_key: StateKey,
         value_version: Version,
         value: StateValue,
     },
-    Vacant,
+    Vacant {
+        state_key: StateKey,
+    },
 }
 define_schema!(
     HotStateValueByKeyHashSchema,


### PR DESCRIPTION

Include StateKey in both Occupied and Vacant variants of HotStateValue.
This is needed to reconstruct the in-memory DashMap<StateKey, StateSlot>
from the persisted hot state KV DB upon node restart. The schema key only
contains the StateKey hash, so without storing the full StateKey in the
value, we cannot rebuild the in-memory hot state data structure.

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/aptos-labs/aptos-core/pull/18576).
* #18577
* __->__ #18576