### PR TITLE
[consensus] Deprecate old Payload enum variants

### DIFF
--- a/consensus/consensus-types/src/block.rs
+++ b/consensus/consensus-types/src/block.rs
@@ -112,16 +112,11 @@ impl Block {
         match self.block_data.payload() {
             None => 0,
             Some(payload) => match payload {
-                Payload::InQuorumStore(pos) => pos.proofs.len(),
                 Payload::DirectMempool(_txns) => 0,
-                Payload::InQuorumStoreWithLimit(pos) => pos.proof_with_data.proofs.len(),
-                Payload::QuorumStoreInlineHybrid(inline_batches, proof_with_data, _)
-                | Payload::QuorumStoreInlineHybridV2(inline_batches, proof_with_data, _) => {
-                    inline_batches.len() + proof_with_data.proofs.len()
-                },
                 Payload::OptQuorumStore(opt_quorum_store_payload) => {
                     opt_quorum_store_payload.num_txns()
                 },
+                _ => 0,
             },
         }
     }
@@ -131,19 +126,6 @@ impl Block {
         match self.block_data.payload() {
             None => (0, 0, 0),
             Some(payload) => match payload {
-                Payload::InQuorumStore(pos) => (pos.num_proofs(), pos.num_txns(), pos.num_bytes()),
-                Payload::DirectMempool(_txns) => (0, 0, 0),
-                Payload::InQuorumStoreWithLimit(pos) => (
-                    pos.proof_with_data.num_proofs(),
-                    pos.proof_with_data.num_txns(),
-                    pos.proof_with_data.num_bytes(),
-                ),
-                Payload::QuorumStoreInlineHybrid(_inline_batches, proof_with_data, _)
-                | Payload::QuorumStoreInlineHybridV2(_inline_batches, proof_with_data, _) => (
-                    proof_with_data.num_proofs(),
-                    proof_with_data.num_txns(),
-                    proof_with_data.num_bytes(),
-                ),
                 Payload::OptQuorumStore(opt_quorum_store_payload) => match opt_quorum_store_payload
                 {
                     OptQuorumStorePayload::V1(p) => (
@@ -157,6 +139,7 @@ impl Block {
                         p.proof_with_data().num_bytes(),
                     ),
                 },
+                _ => (0, 0, 0),
             },
         }
     }
@@ -166,18 +149,6 @@ impl Block {
         match self.block_data.payload() {
             None => (0, 0, 0),
             Some(payload) => match payload {
-                Payload::QuorumStoreInlineHybrid(inline_batches, _proof_with_data, _)
-                | Payload::QuorumStoreInlineHybridV2(inline_batches, _proof_with_data, _) => (
-                    inline_batches.len(),
-                    inline_batches
-                        .iter()
-                        .map(|(b, _)| b.num_txns() as usize)
-                        .sum(),
-                    inline_batches
-                        .iter()
-                        .map(|(b, _)| b.num_bytes() as usize)
-                        .sum(),
-                ),
                 Payload::OptQuorumStore(opt_quorum_store_payload) => match opt_quorum_store_payload
                 {
                     OptQuorumStorePayload::V1(p) => (

--- a/consensus/consensus-types/src/payload.rs
+++ b/consensus/consensus-types/src/payload.rs
@@ -443,6 +443,15 @@ impl OptQuorumStorePayload {
         })
     }
 
+    pub fn empty() -> Self {
+        Self::new(
+            Vec::<(BatchInfo, Vec<SignedTransaction>)>::new().into(),
+            Vec::<BatchInfo>::new().into(),
+            Vec::<ProofOfStore<BatchInfo>>::new().into(),
+            PayloadExecutionLimit::None,
+        )
+    }
+
     pub(crate) fn extend(self, other: Self) -> Self {
         match (self, other) {
             (Self::V1(p1), Self::V1(p2)) => Self::V1(p1.extend(p2)),

--- a/consensus/src/consensus_observer/network/observer_message.rs
+++ b/consensus/src/consensus_observer/network/observer_message.rs
@@ -684,46 +684,13 @@ impl BlockTransactionPayload {
                     "Direct mempool payloads are not supported for consensus observer!".into(),
                 ));
             },
-            Payload::InQuorumStore(proof_with_data) => {
-                // Verify the batches in the requested block
-                self.verify_batches(&proof_with_data.proofs)?;
-            },
-            Payload::InQuorumStoreWithLimit(proof_with_data) => {
-                // Verify the batches in the requested block
-                self.verify_batches(&proof_with_data.proof_with_data.proofs)?;
-
-                // Verify the transaction limit
-                self.verify_transaction_limit(proof_with_data.max_txns_to_execute)?;
-            },
-            Payload::QuorumStoreInlineHybrid(
-                inline_batches,
-                proof_with_data,
-                max_txns_to_execute,
-            ) => {
-                // Verify the batches in the requested block
-                self.verify_batches(&proof_with_data.proofs)?;
-
-                // Verify the inline batches
-                self.verify_inline_batches(inline_batches)?;
-
-                // Verify the transaction limit
-                self.verify_transaction_limit(*max_txns_to_execute)?;
-            },
-            Payload::QuorumStoreInlineHybridV2(
-                inline_batches,
-                proof_with_data,
-                execution_limits,
-            ) => {
-                // Verify the batches in the requested block
-                self.verify_batches(&proof_with_data.proofs)?;
-
-                // Verify the inline batches
-                self.verify_inline_batches(inline_batches)?;
-
-                // Verify the transaction limit
-                self.verify_transaction_limit(execution_limits.max_txns_to_execute())?;
-
-                // TODO: verify the block gas limit?
+            Payload::DeprecatedInQuorumStore(_)
+            | Payload::DeprecatedInQuorumStoreWithLimit(_)
+            | Payload::DeprecatedQuorumStoreInlineHybrid(..)
+            | Payload::DeprecatedQuorumStoreInlineHybridV2(..) => {
+                return Err(Error::InvalidMessageError(
+                    "Deprecated payload variants are not supported!".into(),
+                ));
             },
             Payload::OptQuorumStore(OptQuorumStorePayload::V1(p)) => {
                 // Verify the batches in the requested block
@@ -1168,7 +1135,7 @@ mod test {
     use aptos_consensus_types::{
         block::Block,
         block_data::{BlockData, BlockType},
-        common::{Author, ProofWithData, ProofWithDataWithTxnLimit},
+        common::Author,
         payload::{
             BatchPointer, InlineBatch, OptBatches, OptQuorumStorePayload, PayloadExecutionLimit,
             ProofBatches,
@@ -1213,28 +1180,14 @@ mod test {
         let transaction_payload =
             BlockTransactionPayload::new_in_quorum_store(vec![], proofs.clone());
 
-        // Create a quorum store payload with a single proof
-        let batch_info = create_batch_info();
-        let proof_with_data = ProofWithData::new(vec![ProofOfStore::new(
-            batch_info,
-            AggregateSignature::empty(),
-        )]);
-        let ordered_payload = Payload::InQuorumStore(proof_with_data);
+        // Create a deprecated quorum store payload
+        let ordered_payload = Payload::DeprecatedInQuorumStore(());
 
-        // Verify the transaction payload and ensure it fails (the batch infos don't match)
+        // Verify the transaction payload and ensure it fails (deprecated payloads are not supported)
         let error = transaction_payload
             .verify_against_ordered_payload(&ordered_payload)
             .unwrap_err();
         assert_matches!(error, Error::InvalidMessageError(_));
-
-        // Create a quorum store payload with no proofs
-        let proof_with_data = ProofWithData::new(proofs);
-        let ordered_payload = Payload::InQuorumStore(proof_with_data);
-
-        // Verify the transaction payload and ensure it passes
-        transaction_payload
-            .verify_against_ordered_payload(&ordered_payload)
-            .unwrap();
     }
 
     #[test]
@@ -1248,43 +1201,14 @@ mod test {
             transaction_limit,
         );
 
-        // Create a quorum store payload with a single proof
-        let batch_info = create_batch_info();
-        let proof_with_data = ProofWithDataWithTxnLimit::new(
-            ProofWithData::new(vec![ProofOfStore::new(
-                batch_info,
-                AggregateSignature::empty(),
-            )]),
-            transaction_limit,
-        );
-        let ordered_payload = Payload::InQuorumStoreWithLimit(proof_with_data);
+        // Create a deprecated quorum store payload
+        let ordered_payload = Payload::DeprecatedInQuorumStoreWithLimit(());
 
-        // Verify the transaction payload and ensure it fails (the batch infos don't match)
+        // Verify the transaction payload and ensure it fails (deprecated payloads are not supported)
         let error = transaction_payload
             .verify_against_ordered_payload(&ordered_payload)
             .unwrap_err();
         assert_matches!(error, Error::InvalidMessageError(_));
-
-        // Create a quorum store payload with no proofs and no transaction limit
-        let proof_with_data =
-            ProofWithDataWithTxnLimit::new(ProofWithData::new(proofs.clone()), None);
-        let ordered_payload = Payload::InQuorumStoreWithLimit(proof_with_data);
-
-        // Verify the transaction payload and ensure it fails (the transaction limit doesn't match)
-        let error = transaction_payload
-            .verify_against_ordered_payload(&ordered_payload)
-            .unwrap_err();
-        assert_matches!(error, Error::InvalidMessageError(_));
-
-        // Create a quorum store payload with no proofs and the correct limit
-        let proof_with_data =
-            ProofWithDataWithTxnLimit::new(ProofWithData::new(proofs), transaction_limit);
-        let ordered_payload = Payload::InQuorumStoreWithLimit(proof_with_data);
-
-        // Verify the transaction payload and ensure it passes
-        transaction_payload
-            .verify_against_ordered_payload(&ordered_payload)
-            .unwrap();
     }
 
     #[test]
@@ -1303,59 +1227,14 @@ mod test {
             true,
         );
 
-        // Create a quorum store payload with a single proof
-        let inline_batches = vec![];
-        let batch_info = create_batch_info();
-        let proof_with_data = ProofWithData::new(vec![ProofOfStore::new(
-            batch_info,
-            AggregateSignature::empty(),
-        )]);
-        let ordered_payload = Payload::QuorumStoreInlineHybrid(
-            inline_batches.clone(),
-            proof_with_data,
-            transaction_limit,
-        );
+        // Create a deprecated quorum store payload
+        let ordered_payload = Payload::DeprecatedQuorumStoreInlineHybrid(());
 
-        // Verify the transaction payload and ensure it fails (the batch infos don't match)
+        // Verify the transaction payload and ensure it fails (deprecated payloads are not supported)
         let error = transaction_payload
             .verify_against_ordered_payload(&ordered_payload)
             .unwrap_err();
         assert_matches!(error, Error::InvalidMessageError(_));
-
-        // Create a quorum store payload with no transaction limit
-        let proof_with_data = ProofWithData::new(vec![]);
-        let ordered_payload =
-            Payload::QuorumStoreInlineHybrid(inline_batches.clone(), proof_with_data, None);
-
-        // Verify the transaction payload and ensure it fails (the transaction limit doesn't match)
-        let error = transaction_payload
-            .verify_against_ordered_payload(&ordered_payload)
-            .unwrap_err();
-        assert_matches!(error, Error::InvalidMessageError(_));
-
-        // Create a quorum store payload with a single inline batch
-        let proof_with_data = ProofWithData::new(vec![]);
-        let ordered_payload = Payload::QuorumStoreInlineHybrid(
-            vec![(create_batch_info(), vec![])],
-            proof_with_data,
-            transaction_limit,
-        );
-
-        // Verify the transaction payload and ensure it fails (the inline batches don't match)
-        let error = transaction_payload
-            .verify_against_ordered_payload(&ordered_payload)
-            .unwrap_err();
-        assert_matches!(error, Error::InvalidMessageError(_));
-
-        // Create an empty quorum store payload
-        let proof_with_data = ProofWithData::new(vec![]);
-        let ordered_payload =
-            Payload::QuorumStoreInlineHybrid(vec![], proof_with_data, transaction_limit);
-
-        // Verify the transaction payload and ensure it passes
-        transaction_payload
-            .verify_against_ordered_payload(&ordered_payload)
-            .unwrap();
     }
 
     #[test]

--- a/consensus/src/quorum_store/quorum_store_builder.rs
+++ b/consensus/src/quorum_store/quorum_store_builder.rs
@@ -460,7 +460,6 @@ impl InnerBuilder {
                 consensus_publisher,
                 self.verifier.get_ordered_account_addresses(),
                 self.verifier.address_to_validator_index().clone(),
-                self.config.enable_payload_v2,
             )),
             Some(self.quorum_store_msg_tx.clone()),
         )

--- a/consensus/src/quorum_store/tests/proof_manager_test.rs
+++ b/consensus/src/quorum_store/tests/proof_manager_test.rs
@@ -6,6 +6,7 @@ use crate::quorum_store::{
 };
 use aptos_consensus_types::{
     common::{Payload, PayloadFilter},
+    payload::OptQuorumStorePayload,
     proof_of_store::{BatchInfo, BatchInfoExt, ProofOfStore},
     request_response::{GetPayloadCommand, GetPayloadRequest, GetPayloadResponse},
     utils::PayloadTxnsSize,
@@ -83,7 +84,7 @@ fn assert_payload_response(
 ) {
     match payload {
         Payload::OptQuorumStore(opt_qs) => match opt_qs {
-            aptos_consensus_types::payload::OptQuorumStorePayload::V1(p) => {
+            OptQuorumStorePayload::V1(p) => {
                 let proofs = &p.proof_with_data().batch_summary;
                 assert_eq!(proofs.len(), expected.len());
                 for proof in proofs {
@@ -93,7 +94,7 @@ fn assert_payload_response(
                 assert_eq!(p.max_txns_to_execute(), max_txns_from_block_to_execute);
                 assert_eq!(p.block_gas_limit(), expected_block_gas_limit);
             },
-            aptos_consensus_types::payload::OptQuorumStorePayload::V2(p) => {
+            OptQuorumStorePayload::V2(p) => {
                 let proofs = &p.proof_with_data().batch_summary;
                 assert_eq!(proofs.len(), expected.len());
                 for proof in proofs {

--- a/consensus/src/round_manager_tests/mod.rs
+++ b/consensus/src/round_manager_tests/mod.rs
@@ -399,7 +399,6 @@ impl NodeSetup {
                 None,
                 vec![],
                 hashmap![],
-                false,
             ))
         } else {
             Arc::new(DirectMempoolPayloadManager::new())

--- a/consensus/src/round_manager_tests/txn_filter_proposal_test.rs
+++ b/consensus/src/round_manager_tests/txn_filter_proposal_test.rs
@@ -9,7 +9,8 @@ use crate::{
 use aptos_config::config::BlockTransactionFilterConfig;
 use aptos_consensus_types::{
     block::{block_test_utils::certificate_for_genesis, Block},
-    common::{Payload, ProofWithData},
+    common::Payload,
+    payload::{OptQuorumStorePayload, PayloadExecutionLimit},
     proof_of_store::BatchInfo,
 };
 use aptos_crypto::{
@@ -237,7 +238,12 @@ fn create_payload(
 ) -> Payload {
     if use_quorum_store_payloads {
         let inline_batch = (create_batch_info(transactions.len()), transactions);
-        Payload::QuorumStoreInlineHybrid(vec![inline_batch], ProofWithData::empty(), None)
+        Payload::OptQuorumStore(OptQuorumStorePayload::new(
+            vec![inline_batch].into(),
+            Vec::<BatchInfo>::new().into(),
+            Vec::new().into(),
+            PayloadExecutionLimit::None,
+        ))
     } else {
         Payload::DirectMempool(transactions)
     }

--- a/consensus/src/util/db_tool.rs
+++ b/consensus/src/util/db_tool.rs
@@ -94,29 +94,11 @@ pub fn extract_txns_from_block<'a>(
             Payload::DirectMempool(_) => {
                 bail!("DirectMempool is not supported.");
             },
-            Payload::InQuorumStore(proof_with_data) => extract_txns_from_quorum_store(
-                proof_with_data.proofs.iter().map(|proof| *proof.digest()),
-                all_batches,
-            ),
-            Payload::InQuorumStoreWithLimit(proof_with_data) => extract_txns_from_quorum_store(
-                proof_with_data
-                    .proof_with_data
-                    .proofs
-                    .iter()
-                    .map(|proof| *proof.digest()),
-                all_batches,
-            ),
-            Payload::QuorumStoreInlineHybrid(inline_batches, proof_with_data, _)
-            | Payload::QuorumStoreInlineHybridV2(inline_batches, proof_with_data, _) => {
-                let mut all_txns = extract_txns_from_quorum_store(
-                    proof_with_data.proofs.iter().map(|proof| *proof.digest()),
-                    all_batches,
-                )
-                .unwrap();
-                for (_, txns) in inline_batches {
-                    all_txns.extend(txns);
-                }
-                Ok(all_txns)
+            Payload::DeprecatedInQuorumStore(_)
+            | Payload::DeprecatedInQuorumStoreWithLimit(_)
+            | Payload::DeprecatedQuorumStoreInlineHybrid(..)
+            | Payload::DeprecatedQuorumStoreInlineHybridV2(..) => {
+                bail!("Deprecated payload variants are not supported.");
             },
             Payload::OptQuorumStore(OptQuorumStorePayload::V1(p)) => {
                 let mut all_txns = extract_txns_from_quorum_store(

--- a/testsuite/generate-format/tests/staged/consensus.yaml
+++ b/testsuite/generate-format/tests/staged/consensus.yaml
@@ -994,37 +994,21 @@ Payload:
           SEQ:
             TYPENAME: SignedTransaction
     1:
-      InQuorumStore:
-        NEWTYPE:
-          TYPENAME: ProofWithData
+      DeprecatedInQuorumStore:
+        NEWTYPE: UNIT
     2:
-      InQuorumStoreWithLimit:
-        NEWTYPE:
-          TYPENAME: ProofWithDataWithTxnLimit
+      DeprecatedInQuorumStoreWithLimit:
+        NEWTYPE: UNIT
     3:
-      QuorumStoreInlineHybrid:
-        TUPLE:
-          - SEQ:
-              TUPLE:
-                - TYPENAME: BatchInfo
-                - SEQ:
-                    TYPENAME: SignedTransaction
-          - TYPENAME: ProofWithData
-          - OPTION: U64
+      DeprecatedQuorumStoreInlineHybrid:
+        NEWTYPE: UNIT
     4:
       OptQuorumStore:
         NEWTYPE:
           TYPENAME: OptQuorumStorePayload
     5:
-      QuorumStoreInlineHybridV2:
-        TUPLE:
-          - SEQ:
-              TUPLE:
-                - TYPENAME: BatchInfo
-                - SEQ:
-                    TYPENAME: SignedTransaction
-          - TYPENAME: ProofWithData
-          - TYPENAME: PayloadExecutionLimit
+      DeprecatedQuorumStoreInlineHybridV2:
+        NEWTYPE: UNIT
 PayloadExecutionLimit:
   ENUM:
     0:
@@ -1052,17 +1036,6 @@ ProofOfStoreMsg:
     - proofs:
         SEQ:
           TYPENAME: ProofOfStore
-ProofWithData:
-  STRUCT:
-    - proofs:
-        SEQ:
-          TYPENAME: ProofOfStore
-ProofWithDataWithTxnLimit:
-  STRUCT:
-    - proof_with_data:
-        TYPENAME: ProofWithData
-    - max_txns_to_execute:
-        OPTION: U64
 ProposalExt:
   ENUM:
     0:


### PR DESCRIPTION
## Summary
- Deprecate the following Payload variants that are no longer in use by renaming them with `Deprecated` prefix:
  - `InQuorumStore` → `DeprecatedInQuorumStore`
  - `InQuorumStoreWithLimit` → `DeprecatedInQuorumStoreWithLimit`
  - `QuorumStoreInlineHybrid` → `DeprecatedQuorumStoreInlineHybrid`
  - `QuorumStoreInlineHybridV2` → `DeprecatedQuorumStoreInlineHybridV2`
- Replace inner types with a single stub struct `DeprecatedPayload` (unit struct) for BCS variant index compatibility
- Remove `ProofWithData` and `ProofWithDataWithTxnLimit` types entirely
- Add `OptQuorumStorePayload::empty()` helper method for cleaner construction of empty payloads
- Update all pattern matches and tests to use the new simplified structure

## Test plan
- [x] Existing tests pass with updated payload construction
- [x] `cargo check` passes
- [x] CI tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)