### PR TITLE
[Storage] Fix for panics in state update code and improve error messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3791,19 +3791,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "aptos-rate-limiter"
-version = "0.1.0"
-dependencies = [
- "aptos-infallible",
- "aptos-logger",
- "aptos-metrics-core",
- "futures",
- "pin-project 1.1.3",
- "tokio",
- "tokio-util 0.7.10",
-]
-
-[[package]]
 name = "aptos-release-builder"
 version = "0.1.0"
 dependencies = [

--- a/execution/executor/src/workflow/do_get_execution_output.rs
+++ b/execution/executor/src/workflow/do_get_execution_output.rs
@@ -422,7 +422,7 @@ impl Parser {
             base_state_view.persisted_state(),
             to_commit.state_update_refs(),
             base_state_view.memorized_reads(),
-        );
+        )?;
         let state_reads = base_state_view.into_memorized_reads();
 
         let out = ExecutionOutput::new(

--- a/storage/aptosdb/src/state_store/tests/speculative_state_workflow.rs
+++ b/storage/aptosdb/src/state_store/tests/speculative_state_workflow.rs
@@ -563,12 +563,14 @@ fn update_state(
         });
         let memorized_reads = state_view.into_memorized_reads();
 
-        let (next_state, hot_state_updates) = parent_state.update_with_memorized_reads(
-            hot_state.clone(),
-            &persisted_state,
-            block.update_refs(),
-            &memorized_reads,
-        );
+        let (next_state, hot_state_updates) = parent_state
+            .update_with_memorized_reads(
+                hot_state.clone(),
+                &persisted_state,
+                block.update_refs(),
+                &memorized_reads,
+            )
+            .unwrap();
 
         state_by_version.assert_ledger_state(&next_state);
 

--- a/storage/storage-interface/src/state_store/state.rs
+++ b/storage/storage-interface/src/state_store/state.rs
@@ -18,9 +18,10 @@ use crate::{
     },
     DbReader,
 };
-use anyhow::Result;
+use anyhow::{bail, Result};
 use aptos_config::config::HotStateConfig;
 use aptos_experimental_layered_map::{LayeredMap, MapLayer};
+use aptos_logger::warn;
 use aptos_metrics_core::TimerHelper;
 use aptos_types::{
     state_store::{
@@ -161,7 +162,7 @@ impl State {
         per_version_updates: &PerVersionStateUpdateRefs,
         all_checkpoint_versions: &[Version],
         state_cache: &ShardedStateCache,
-    ) -> (Self, [HotStateShardUpdates; NUM_STATE_SHARDS]) {
+    ) -> Result<(Self, [HotStateShardUpdates; NUM_STATE_SHARDS])> {
         let _timer = TIMER.timer_with(&["state__update"]);
 
         // 1. The update batch must begin at self.next_version().
@@ -170,12 +171,15 @@ impl State {
         // 2. The cache must be at a version equal or newer than `persisted`, otherwise
         //    updates between the cached version and the persisted version are potentially
         //    missed during the usage calculation.
-        assert!(
-            persisted.next_version() <= state_cache.next_version(),
-            "persisted: {}, cache: {}",
-            persisted.next_version(),
-            state_cache.next_version(),
-        );
+        if persisted.next_version() > state_cache.next_version() {
+            let msg = format!(
+                "Persisted version ({}) is ahead of cache version ({}), possibly due to a fork.",
+                persisted.next_version(),
+                state_cache.next_version(),
+            );
+            warn!("{}", msg);
+            bail!("{}", msg);
+        }
         // 3. `self` must be at a version equal or newer than the cache, because we assume
         //    it is overlaid on top of the cache.
         assert!(self.next_version() >= state_cache.next_version());
@@ -268,7 +272,7 @@ impl State {
             .expect("Known to be 16 shards.");
 
         // TODO(HotState): extract and pass new hot state onchain config if needed.
-        (
+        Ok((
             State::new_with_updates(
                 batched_updates.last_version(),
                 shards,
@@ -277,7 +281,7 @@ impl State {
                 self.hot_state_config,
             ),
             hot_state_updates,
-        )
+        ))
     }
 
     /// Applies the update the returns the `HotStateValue` that will later go into the hot state
@@ -428,7 +432,7 @@ impl LedgerState {
         persisted_snapshot: &State,
         updates: &StateUpdateRefs,
         reads: &ShardedStateCache,
-    ) -> (LedgerState, HotStateUpdates) {
+    ) -> Result<(LedgerState, HotStateUpdates)> {
         let _timer = TIMER.timer_with(&["ledger_state__update"]);
 
         let mut all_hot_state_updates = HotStateUpdates::new_empty();
@@ -443,7 +447,7 @@ impl LedgerState {
                 per_version,
                 updates.all_checkpoint_versions(),
                 reads,
-            );
+            )?;
             all_hot_state_updates.for_last_checkpoint = Some(hot_state_updates);
             new_ckpt
         } else {
@@ -466,17 +470,17 @@ impl LedgerState {
                 per_version,
                 &[],
                 reads,
-            );
+            )?;
             all_hot_state_updates.for_latest = Some(hot_state_updates);
             new_latest
         } else {
             base_of_latest.clone()
         };
 
-        (
+        Ok((
             LedgerState::new(latest, last_checkpoint),
             all_hot_state_updates,
-        )
+        ))
     }
 
     /// Old values of the updated keys are read from the DbReader at the version of the
@@ -502,7 +506,7 @@ impl LedgerState {
             persisted_snapshot,
             updates,
             state_view.memorized_reads(),
-        );
+        )?;
         let state_reads = state_view.into_memorized_reads();
         Ok((updated, state_reads, hot_state_updates))
     }

--- a/storage/storage-interface/src/state_store/state_summary.rs
+++ b/storage/storage-interface/src/state_store/state_summary.rs
@@ -10,12 +10,13 @@ use crate::{
     },
     DbReader,
 };
-use anyhow::Result;
+use anyhow::{bail, Result};
 use aptos_config::config::HotStateConfig;
 use aptos_crypto::{
     hash::{CryptoHash, CORRUPTION_SENTINEL},
     HashValue,
 };
+use aptos_logger::warn;
 use aptos_metrics_core::TimerHelper;
 use aptos_scratchpad::{ProofRead, SparseMerkleTree};
 use aptos_types::{
@@ -93,9 +94,23 @@ impl StateSummary {
         assert_ne!(self.global_state_summary.root_hash(), *CORRUPTION_SENTINEL);
 
         // Persisted must be before or at my version.
-        assert!(persisted.next_version() <= self.next_version());
+        if persisted.next_version() > self.next_version() {
+            let msg = format!(
+                "Persisted version ({}) is ahead of current version ({}), possibly due to a fork.",
+                persisted.next_version(),
+                self.next_version(),
+            );
+            warn!("{}", msg);
+            bail!("{}", msg);
+        }
         // Updates must start at exactly my version.
-        assert_eq!(updates.first_version(), self.next_version());
+        assert_eq!(
+            updates.first_version(),
+            self.next_version(),
+            "updates first version: {}, self next version: {}",
+            updates.first_version(),
+            self.next_version(),
+        );
 
         let (hot_smt_result, smt_result) = rayon::join(
             || self.update_hot_state_summary(persisted, hot_updates),


### PR DESCRIPTION
## Summary
- Cherry-pick of be2fc5a62b (`[Storage] Improve error message in assertions`) and 069beddb1e (`[Storage] Fix for panics in state update code`) into the v1.41 release branch.
- Relaxes panicking assertions in `StateSummary::update` and `State::update` to `ensure`, handling rare fork scenarios where the persisted version advances past a block's parent version during speculative execution.
- Improves error messages in related storage assertions.

## Test plan
- [ ] Existing tests in `speculative_state_workflow` updated and passing
- [ ] CI passes on release branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core state update paths by converting previously panicking assertions into runtime errors; behavior changes under rare fork/version-skew scenarios could affect execution/commit flow if not handled correctly upstream.
> 
> **Overview**
> Prevents rare speculative-execution panics by turning version-ordering `assert!`s in `State::update` and `StateSummary::update` into logged, descriptive errors (`warn!` + `bail!`) when the persisted version is ahead (e.g., fork/version skew).
> 
> Propagates these new `Result` return types through the execution pipeline: `LedgerState::update_with_memorized_reads`/`State::update` now return `Result`, callers in `do_get_execution_output` handle failures with `?`, and the `speculative_state_workflow` test is updated to unwrap the new fallible API. Also removes the unused `aptos-rate-limiter` entry from `Cargo.lock`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 40b62ac997a12c3c997c2ba31e66255a6ec550d2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->