### PR TITLE
Fix dkg imports

### DIFF
--- a/dkg/src/chunky/agg_subtrx_producer.rs
+++ b/dkg/src/chunky/agg_subtrx_producer.rs
@@ -10,10 +10,7 @@ use anyhow::{anyhow, ensure, Context};
 use aptos_channels::aptos_channel;
 use aptos_consensus_types::common::Author;
 use aptos_dkg::pvss::{
-    traits::{
-        transcript::{HasAggregatableSubtranscript, Transcript},
-        Aggregatable,
-    },
+    traits::transcript::{Aggregated, HasAggregatableSubtranscript, Transcript},
     Player,
 };
 use aptos_infallible::{Mutex, RwLock};

--- a/dkg/src/chunky/dkg_manager.rs
+++ b/dkg/src/chunky/dkg_manager.rs
@@ -20,7 +20,7 @@ use anyhow::{anyhow, bail, ensure, Context, Result};
 use aptos_channels::{aptos_channel, message_queues::QueueStyle};
 use aptos_crypto::{hash::CryptoHash, SigningKey, Uniform};
 use aptos_dkg::pvss::{
-    traits::{transcript::HasAggregatableSubtranscript, Aggregatable},
+    traits::transcript::{Aggregated, HasAggregatableSubtranscript},
     Player,
 };
 use aptos_infallible::{duration_since_epoch, Mutex};


### PR DESCRIPTION
## Description
This quick PR fixes the previous one - `main` does not currently compile. Balaji: "I think your CI passed on an earlier version of main and GH merged it as it did not have any conflicts."

## How Has This Been Tested?
Existing tests.

## Key Areas to Review
Should be fine.

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Import-only changes updating to the new `aptos_dkg::pvss::traits::transcript::Aggregated` path; no behavior changes expected.
> 
> **Overview**
> Updates Chunky DKG modules to use the newer PVSS transcript trait import layout, replacing the older `Aggregatable`/`Aggregated` import paths.
> 
> No functional logic is changed; this is a compile-time fix in `agg_subtrx_producer.rs` and `dkg_manager.rs` to align with the current `aptos_dkg` trait exports.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8d5c6bb5c9a28cd79ddbd972465aa3b2e891bdb6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->