### PR TITLE
[execution] Add global context placeholder with guards

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9993,6 +9993,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
+name = "global-context"
+version = "0.1.0"
+dependencies = [
+ "parking_lot 0.12.1",
+]
+
+[[package]]
 name = "globset"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -204,6 +204,7 @@ members = [
     "testsuite/smoke-test",
     "testsuite/testcases",
     "third_party/move/extensions/move-table-extension",
+    "third_party/move/mono-move/global-context",
     "third_party/move/move-binary-format",
     "third_party/move/move-binary-format/serializer-tests",
     "third_party/move/move-borrow-graph",
@@ -865,6 +866,7 @@ x25519-dalek = { git = "https://github.com/aptos-labs/x25519-dalek", rev = "b9cd
 z3tracer = "0.8.0"
 
 # MOVE DEPENDENCIES
+mono-move-global-context = { path = "third_party/move/mono-move/global-context" }
 move-abigen = { path = "third_party/move/move-prover/move-abigen" }
 move-asm = { path = "third_party/move/tools/move-asm" }
 move-binary-format = { path = "third_party/move/move-binary-format" }

--- a/third_party/move/mono-move/global-context/Cargo.toml
+++ b/third_party/move/mono-move/global-context/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "global-context"
+version = "0.1.0"
+authors = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+repository = { workspace = true }
+rust-version = { workspace = true }
+
+[dependencies]
+parking_lot = { workspace = true }

--- a/third_party/move/mono-move/global-context/src/context.rs
+++ b/third_party/move/mono-move/global-context/src/context.rs
@@ -1,0 +1,85 @@
+// Copyright (c) Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+//! Core types and implementation for the global execution context.
+
+use parking_lot::{RwLock, RwLockReadGuard, RwLockWriteGuard};
+
+/// Placeholder struct for global context data.
+#[derive(Debug, Default)]
+struct Context {
+    // TODO: add data here
+}
+
+/// Global execution context with a two-phase state machine.
+///
+/// # Phases
+///
+/// 1. **Execution Phase**: Multiple [`ExecutionContext`] guards can be obtained
+///    concurrently across threads. This allows parallel transaction execution
+///    where each thread can read from shared caches and concurrently allocate
+///    data.
+///
+/// 2. **Maintenance Phase**: A single [`MaintenanceContext`] guard provides
+///    exclusive write access for inter-block maintenance operations such as
+///    cache cleanup or data de-allocation.
+pub struct GlobalContext {
+    inner: RwLock<Context>,
+}
+
+impl GlobalContext {
+    /// Creates a new global context with an empty internal state.
+    #[allow(clippy::new_without_default)]
+    pub fn new() -> Self {
+        Self {
+            inner: RwLock::new(Context {}),
+        }
+    }
+
+    /// Transitions to execution mode by obtaining a read guard.
+    ///
+    /// Multiple execution contexts can be held concurrently across
+    /// threads, enabling parallel transaction execution.
+    ///
+    /// Returns [None] is a [`MaintenanceContext`] is currently held.
+    pub fn execution_context(&self) -> Option<ExecutionContext<'_>> {
+        Some(ExecutionContext {
+            guard: self.inner.try_read()?,
+        })
+    }
+
+    /// Transitions to maintenance mode by obtaining a write guard.
+    ///
+    /// Only one maintenance context can be held at a time, providing
+    /// exclusive access to the internal state for maintenance operations.
+    ///
+    /// Returns [None] is a [`ExecutionContext`] is currently held.
+    pub fn maintenance_context(&self) -> Option<MaintenanceContext<'_>> {
+        Some(MaintenanceContext {
+            guard: self.inner.try_write()?,
+        })
+    }
+}
+
+/// RAII guard for the execution phase providing concurrent read access
+/// or data allocation.
+///
+/// Multiple execution contexts can exist simultaneously across threads,
+/// allowing parallel transaction execution. The read lock is held for
+/// the lifetime of this guard and automatically released when dropped.
+#[derive(Debug)]
+pub struct ExecutionContext<'a> {
+    #[allow(dead_code)]
+    guard: RwLockReadGuard<'a, Context>,
+}
+
+/// RAII guard for the maintenance phase providing exclusive write access.
+///
+/// Only one maintenance context can exist at a time, ensuring exclusive
+/// access to the internal state for maintenance operations. The write lock
+/// is held for the lifetime of this guard and automatically released when dropped.
+#[derive(Debug)]
+pub struct MaintenanceContext<'a> {
+    #[allow(dead_code)]
+    guard: RwLockWriteGuard<'a, Context>,
+}

--- a/third_party/move/mono-move/global-context/src/lib.rs
+++ b/third_party/move/mono-move/global-context/src/lib.rs
@@ -1,0 +1,13 @@
+// Copyright (c) Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+//! Global execution context for MonoMove.
+//!
+//! This crate provides a two-phase state machine for managing the global state:
+//! - **Execution phase**: Multiple [`ExecutionContext`] guards can be held concurrently
+//!   across threads for parallel transaction execution.
+//! - **Maintenance phase**: A single exclusive [`MaintenanceContext`] guard for inter-block
+//!   maintenance operations.
+
+mod context;
+pub use context::{ExecutionContext, GlobalContext, MaintenanceContext};

--- a/third_party/move/mono-move/global-context/tests/context_tests.rs
+++ b/third_party/move/mono-move/global-context/tests/context_tests.rs
@@ -1,0 +1,185 @@
+// Copyright (c) Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+//! Integration tests for the global context.
+
+use global_context::GlobalContext;
+use std::{
+    sync::{Arc, Barrier},
+    thread,
+    time::Duration,
+};
+
+#[test]
+fn test_different_contexts() {
+    let ctx = GlobalContext::new();
+
+    {
+        let _guard = ctx
+            .execution_context()
+            .expect("Execution context must be acquired");
+    }
+    {
+        let _guard = ctx
+            .maintenance_context()
+            .expect("Maintenance context must be acquired");
+    }
+    {
+        let _guard1 = ctx
+            .execution_context()
+            .expect("Execution context must be acquired");
+        let _guard2 = ctx
+            .execution_context()
+            .expect("Execution context must be acquired");
+        let _guard3 = ctx
+            .execution_context()
+            .expect("Execution context must be acquired");
+    }
+}
+
+#[test]
+fn test_concurrent_execution_contexts() {
+    let ctx = Arc::new(GlobalContext::new());
+
+    let num_threads = 4;
+    let barrier = Arc::new(Barrier::new(num_threads));
+
+    let handles: Vec<_> = (0..num_threads)
+        .map(|_| {
+            let ctx = Arc::clone(&ctx);
+            let barrier = Arc::clone(&barrier);
+            thread::spawn(move || {
+                // Wait for all threads to be ready.
+                barrier.wait();
+
+                // All threads should be able to acquire execution context simultaneously.
+                let _guard = ctx
+                    .execution_context()
+                    .expect("Execution context must be acquired");
+                thread::sleep(Duration::from_millis(100));
+            })
+        })
+        .collect();
+
+    for handle in handles {
+        handle.join().unwrap();
+    }
+}
+
+#[test]
+fn test_maintenance_blocks_maintenance() {
+    let ctx = Arc::new(GlobalContext::new());
+    let barrier = Arc::new(Barrier::new(2));
+
+    let handle = thread::spawn({
+        let ctx = Arc::clone(&ctx);
+        let barrier = Arc::clone(&barrier);
+        move || {
+            let _guard = ctx
+                .maintenance_context()
+                .expect("Maintenance context must be acquired");
+
+            // Signal that we have the lock.
+            barrier.wait();
+            thread::sleep(Duration::from_millis(2000));
+        }
+    });
+
+    // Wait for thread 1 to be in maintenance mode.
+    barrier.wait();
+    thread::sleep(Duration::from_millis(10));
+    assert!(ctx.maintenance_context().is_none());
+
+    handle.join().unwrap();
+}
+
+#[test]
+fn test_maintenance_blocks_execution() {
+    let ctx = Arc::new(GlobalContext::new());
+    let barrier = Arc::new(Barrier::new(2));
+
+    // Thread 1: Hold execution context for 100ms
+    let handle1 = thread::spawn({
+        let ctx = Arc::clone(&ctx);
+        let barrier = Arc::clone(&barrier);
+        move || {
+            let _guard = ctx
+                .maintenance_context()
+                .expect("Maintenance context must be acquired");
+
+            // Signal that we have the lock.
+            barrier.wait();
+            thread::sleep(Duration::from_millis(2000));
+        }
+    });
+
+    // Wait for thread 1 to be in maintenance mode.
+    barrier.wait();
+    thread::sleep(Duration::from_millis(10));
+    assert!(ctx.execution_context().is_none());
+
+    handle1.join().unwrap();
+}
+
+#[test]
+fn test_execution_blocks_maintenance() {
+    let num_threads = 4;
+
+    let ctx = Arc::new(GlobalContext::new());
+    let barrier = Arc::new(Barrier::new(num_threads + 1)); // +1 for main thread
+
+    // Spawn multiple threads holding execution contexts
+    let handles: Vec<_> = (0..num_threads)
+        .map(|_| {
+            let ctx = Arc::clone(&ctx);
+            let barrier = Arc::clone(&barrier);
+            thread::spawn(move || {
+                let _guard = ctx
+                    .execution_context()
+                    .expect("Execution context must be acquired");
+
+                // Signal that we have the lock.
+                barrier.wait();
+                thread::sleep(Duration::from_millis(2000));
+            })
+        })
+        .collect();
+
+    barrier.wait();
+    thread::sleep(Duration::from_millis(10));
+
+    assert!(ctx.maintenance_context().is_none());
+
+    for handle in handles {
+        handle.join().unwrap();
+    }
+}
+
+#[test]
+fn test_block_execution_simulation() {
+    let num_threads = 4;
+    let num_iterations = 5;
+
+    let ctx = Arc::new(GlobalContext::new());
+
+    for _ in 0..num_iterations {
+        // Execution phase: concurrent execution.
+        let handles: Vec<_> = (0..num_threads)
+            .map(|_| {
+                let ctx = Arc::clone(&ctx);
+                thread::spawn(move || {
+                    let _guard = ctx.execution_context();
+                    thread::sleep(Duration::from_millis(100));
+                })
+            })
+            .collect();
+
+        for handle in handles {
+            handle.join().unwrap();
+        }
+
+        // Maintenance phase: single thread with exclusive access.
+        let _guard = ctx.maintenance_context();
+        thread::sleep(Duration::from_millis(100));
+    }
+}


### PR DESCRIPTION
## Description

Global context template for execution, as described in design doc but simpler. Instead of atomics, implemented via `RwLock` so no unsafe is needed. On execution (block), read-lock is acquired. For maintenance (between blocks), write-lock is acquired. Added a few tests for that. Note: `Context` will be populated with data and caches, with unsafe APIs which are safe through execution or maintenance guard implementations.

## How Has This Been Tested?

Unit tests added.

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [x] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new cross-thread synchronization primitives and timing-based concurrency tests; while currently a placeholder, future consumers may rely on the lock semantics and could hit contention/starvation issues if misused.
> 
> **Overview**
> Adds a new `global-context` MonoMove crate that introduces a `GlobalContext` with a two-phase locking API: non-blocking acquisition of shared `ExecutionContext` read guards for parallel execution, and exclusive `MaintenanceContext` write guards for between-block maintenance.
> 
> Wires the crate into the workspace (`Cargo.toml` and `Cargo.lock`) and adds integration tests validating concurrent execution access and mutual exclusion between execution and maintenance phases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e753a18118146d06bc42699726162d73cc9f6a20. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->