### PR TITLE
randomness dkg maintenance

### DIFF
--- a/aptos-move/framework/aptos-framework/doc/stake.md
+++ b/aptos-move/framework/aptos-framework/doc/stake.md
@@ -4207,7 +4207,7 @@ Return the <code>ValidatorConsensusInfo</code> of each current validator, sorted
         <b>let</b> candidate = <b>if</b> (candidate_idx &lt; num_cur_actives) {
             cur_validator_set.active_validators.borrow(candidate_idx)
         } <b>else</b> {
-            cur_validator_set.pending_active.borrow(candidate_idx - num_cur_actives)
+            cur_validator_set.pending_active.borrow(num_candidates - 1 - candidate_idx)
         };
         <b>let</b> stake_pool = <b>borrow_global</b>&lt;<a href="stake.md#0x1_stake_StakePool">StakePool</a>&gt;(candidate.addr);
         <b>let</b> cur_active = <a href="coin.md#0x1_coin_value">coin::value</a>(&stake_pool.active);

--- a/aptos-move/framework/aptos-framework/sources/stake.move
+++ b/aptos-move/framework/aptos-framework/sources/stake.move
@@ -1498,7 +1498,7 @@ module aptos_framework::stake {
             let candidate = if (candidate_idx < num_cur_actives) {
                 cur_validator_set.active_validators.borrow(candidate_idx)
             } else {
-                cur_validator_set.pending_active.borrow(candidate_idx - num_cur_actives)
+                cur_validator_set.pending_active.borrow(num_candidates - 1 - candidate_idx)
             };
             let stake_pool = borrow_global<StakePool>(candidate.addr);
             let cur_active = coin::value(&stake_pool.active);
@@ -3391,7 +3391,10 @@ module aptos_framework::stake {
         set_validator_perf_at_least_one_block();
         timestamp::fast_forward_seconds(EPOCH_DURATION);
         reconfiguration_state::on_reconfig_start();
+        let actual = next_validator_consensus_infos().map(|i|validator_consensus_info::get_addr(&i));
         on_new_epoch();
+        let expected = cur_validator_consensus_infos().map(|i|validator_consensus_info::get_addr(&i));
+        assert!(expected == actual, 999);
         reconfiguration_state::on_reconfig_finish();
     }
 


### PR DESCRIPTION
## Description

stake.move helper function maintenance.

## How Has This Been Tested?
existing tests.

## Key Areas to Review
n/a

## Type of Change
- [x] Refactoring

## Which Components or Systems Does This Change Impact?
- [x] Aptos Framework

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches validator-set selection logic, which can affect epoch transitions and consensus membership if incorrect. Scope is small and now guarded by an added invariant-style assertion in tests.
> 
> **Overview**
> Fixes an indexing bug in `next_validator_consensus_infos()` so the loop selects `pending_active` candidates using the correct reversed index (`num_candidates - 1 - candidate_idx`) rather than `candidate_idx - num_cur_actives`.
> 
> Updates the generated `stake.md` docs to match, and strengthens the `#[test_only] end_epoch()` helper by asserting that the validator addresses computed by `next_validator_consensus_infos()` match the post-`on_new_epoch()` current validator set.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 92e2ff0a8f3dd7e76ef8eb0dc525c497915566e8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->