### PR TITLE
Add governance proposal to disable randomness fast path

### DIFF
--- a/aptos-move/aptos-release-builder/data/proposals/disable_randomness_fast_path.move
+++ b/aptos-move/aptos-release-builder/data/proposals/disable_randomness_fast_path.move
@@ -1,0 +1,22 @@
+// Disable randomness fast path by downgrading from V2 to V1.
+// V1 keeps standard randomness enabled but does not include the fast path.
+script {
+    use aptos_framework::aptos_governance;
+    use aptos_framework::randomness_config;
+    use aptos_std::fixed_point64;
+
+    fun main(proposal_id: u64) {
+        let framework = aptos_governance::resolve_multi_step_proposal(
+            proposal_id,
+            @0x1,
+            {{ script_hash }},
+        );
+
+        let config = randomness_config::new_v1(
+            fixed_point64::create_from_rational(1, 2), // secrecy_threshold: 1/2
+            fixed_point64::create_from_rational(2, 3), // reconstruct_threshold: 2/3
+        );
+        randomness_config::set_for_next_epoch(&framework, config);
+        aptos_governance::reconfigure(&framework);
+    }
+}


### PR DESCRIPTION
## Summary
- Add a Move script governance proposal that downgrades the on-chain randomness config from V2 to V1
- V1 keeps standard randomness enabled (secrecy threshold 1/2, reconstruction threshold 2/3) but removes the fast path
- This is the on-chain counterpart to #18644 which changes the code defaults

## Test plan
- [ ] Review the Move script for correctness against `randomness_config.move` API
- [ ] Validate proposal through release builder simulation before mainnet submission

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes an on-chain governance action that updates the network’s randomness configuration and forces a reconfiguration, so incorrect parameters or misuse could impact consensus/randomness behavior at epoch boundaries.
> 
> **Overview**
> Adds a new on-chain governance proposal script `disable_randomness_fast_path.move` that resolves a multi-step proposal, sets `RandomnessConfig` for the next epoch to `new_v1` (secrecy 1/2, reconstruction 2/3), and triggers `aptos_governance::reconfigure()`.
> 
> This effectively downgrades randomness config from V2 to V1 to remove the fast path while keeping randomness enabled.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d3f9ee85b35b14aea2b4e66045a548113cf2c0fa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->