### PR TITLE
je smoke

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17634,6 +17634,7 @@ dependencies = [
  "serde_json",
  "serde_yaml 0.8.26",
  "tempfile",
+ "tikv-jemallocator",
  "tokio",
  "url",
  "walkdir",

--- a/testsuite/smoke-test/Cargo.toml
+++ b/testsuite/smoke-test/Cargo.toml
@@ -67,6 +67,9 @@ tokio = { workspace = true }
 url = { workspace = true }
 walkdir = { workspace = true }
 
+[target.'cfg(unix)'.dependencies]
+jemallocator = { workspace = true }
+
 [dev-dependencies]
 aptos-backup-cli = { workspace = true }
 aptos-db-indexer = { workspace = true, features = ["fuzzing"] }

--- a/testsuite/smoke-test/src/lib.rs
+++ b/testsuite/smoke-test/src/lib.rs
@@ -3,6 +3,10 @@
 
 extern crate core;
 
+#[cfg(unix)]
+#[global_allocator]
+static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
+
 #[cfg(test)]
 mod account_abstraction;
 #[cfg(test)]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Test-only change that alters memory allocation behavior on Unix; main risk is allocator-related performance/regression or platform-specific build issues.
> 
> **Overview**
> Configures the `testsuite/smoke-test` crate to use `jemallocator` as the **global allocator** on Unix via a `cfg(unix)`-gated `#[global_allocator]`.
> 
> Updates dependencies/lockfile accordingly by adding `jemallocator` (and `tikv-jemallocator` in `Cargo.lock`) to support the allocator change.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c27a03695f61868fc2cbad22566970c1ead137e7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->