### PR TITLE
Rust 1.92

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -916,7 +916,6 @@ name = "aptos-compression"
 version = "0.1.0"
 dependencies = [
  "aptos-crypto",
- "aptos-logger",
  "aptos-metrics-core",
  "aptos-types",
  "bcs 0.1.4",

--- a/api/src/tests/multisig_transactions_test.rs
+++ b/api/src/tests/multisig_transactions_test.rs
@@ -895,7 +895,6 @@ async fn assert_owners(
         .as_array()
         .unwrap()
         .iter()
-        .cloned()
         .map(|address| AccountAddress::from_hex_literal(address.as_str().unwrap()).unwrap())
         .collect::<Vec<_>>();
     owners.sort();

--- a/aptos-move/aptos-e2e-comparison-testing/src/data_collection.rs
+++ b/aptos-move/aptos-e2e-comparison-testing/src/data_collection.rs
@@ -161,8 +161,8 @@ impl DataCollection {
                 base_experiments,
                 &[],
             );
-            if res.is_err() {
-                eprintln!("{} at: {}", res.unwrap_err(), version);
+            if let Err(err) = res {
+                eprintln!("{} at: {}", err, version);
                 return None;
             }
         }

--- a/aptos-move/aptos-e2e-comparison-testing/src/online_execution.rs
+++ b/aptos-move/aptos-e2e-comparison-testing/src/online_execution.rs
@@ -126,8 +126,8 @@ impl OnlineExecutor {
                 base_experiments,
                 compared_experiments,
             );
-            if res.is_err() {
-                eprintln!("{} at:{}", res.unwrap_err(), version);
+            if let Err(err) = res {
+                eprintln!("{} at:{}", err, version);
                 return None;
             }
         }
@@ -187,13 +187,11 @@ impl OnlineExecutor {
                 )
                 .await;
             // if error happens when collecting txns, log the version range
-            if res_txns.is_err() {
-                index_writer.lock().unwrap().write_err(&format!(
-                    "{}:{}:{:?}",
-                    cur_version,
-                    batch,
-                    res_txns.unwrap_err()
-                ));
+            if let Err(err) = &res_txns {
+                index_writer
+                    .lock()
+                    .unwrap()
+                    .write_err(&format!("{}:{}:{:?}", cur_version, batch, err));
                 cur_version += batch;
                 continue;
             }

--- a/aptos-move/block-executor/src/code_cache_global_manager.rs
+++ b/aptos-move/block-executor/src/code_cache_global_manager.rs
@@ -20,7 +20,6 @@ use aptos_types::{
     vm::modules::AptosModuleExtension,
 };
 use aptos_vm_environment::environment::AptosEnvironment;
-use aptos_vm_logging::alert;
 use aptos_vm_types::module_and_script_storage::AsAptosCodeStorage;
 use cfg_if::cfg_if;
 use move_binary_format::{

--- a/aptos-move/replay-benchmark/src/diff.rs
+++ b/aptos-move/replay-benchmark/src/diff.rs
@@ -117,22 +117,20 @@ impl TransactionDiff {
                     let left = left.as_ref();
                     let right = right.as_ref();
 
-                    if left.is_none() {
-                        println!("{}", "========".yellow());
-                        println!("{}", format!("write {:?}", state_key).red());
-                    } else if right.is_none() {
-                        println!("{}", format!("write {:?}", state_key).green());
-                        println!("{}", "========".yellow());
-                    } else {
-                        println!(
-                            "{}",
-                            format!("write {:?} op {:?}", state_key, left.unwrap()).green()
-                        );
-                        println!("{}", "========".yellow());
-                        println!(
-                            "{}",
-                            format!("write {:?} op {:?}", state_key, right.unwrap()).red()
-                        );
+                    match (left, right) {
+                        (None, _) => {
+                            println!("{}", "========".yellow());
+                            println!("{}", format!("write {:?}", state_key).red());
+                        },
+                        (_, None) => {
+                            println!("{}", format!("write {:?}", state_key).green());
+                            println!("{}", "========".yellow());
+                        },
+                        (Some(l), Some(r)) => {
+                            println!("{}", format!("write {:?} op {:?}", state_key, l).green());
+                            println!("{}", "========".yellow());
+                            println!("{}", format!("write {:?} op {:?}", state_key, r).red());
+                        },
                     }
                 },
             }

--- a/aptos-move/vm-genesis/src/lib.rs
+++ b/aptos-move/vm-genesis/src/lib.rs
@@ -996,7 +996,7 @@ fn initialize_keyless_accounts(
         ]),
     );
 
-    if vk.is_some() {
+    if let Some(vk_value) = vk {
         exec_function(
             session,
             module_storage,
@@ -1006,7 +1006,7 @@ fn initialize_keyless_accounts(
             vec![],
             serialize_values(&vec![
                 MoveValue::Signer(CORE_CODE_ADDRESS),
-                vk.unwrap().as_move_value(),
+                vk_value.as_move_value(),
             ]),
         );
     }

--- a/aptos-node/src/lib.rs
+++ b/aptos-node/src/lib.rs
@@ -4,6 +4,9 @@
 #![allow(unexpected_cfgs)]
 #![forbid(unsafe_code)]
 
+#[cfg(any(feature = "testing", feature = "fuzzing"))]
+compile_error!("Testing features shouldn't be compiled for production aptos-node");
+
 mod consensus;
 mod indexer;
 mod logger;
@@ -246,11 +249,6 @@ pub fn start_and_report_ports(
     ensure_max_open_files_limit(
         config.storage.ensure_rlimit_nofile,
         config.storage.assert_rlimit_nofile,
-    );
-
-    assert!(
-        !cfg!(feature = "testing") && !cfg!(feature = "fuzzing"),
-        "Testing features shouldn't be compiled"
     );
 
     // Ensure failpoints are configured correctly

--- a/crates/aptos-compression/Cargo.toml
+++ b/crates/aptos-compression/Cargo.toml
@@ -13,7 +13,6 @@ repository = { workspace = true }
 rust-version = { workspace = true }
 
 [dependencies]
-aptos-logger = { workspace = true }
 aptos-metrics-core = { workspace = true }
 lz4 = { workspace = true }
 once_cell = { workspace = true }

--- a/crates/aptos-compression/src/lib.rs
+++ b/crates/aptos-compression/src/lib.rs
@@ -5,7 +5,6 @@ use crate::{
     client::CompressionClient,
     Error::{CompressionError, DecompressionError},
 };
-use aptos_logger::prelude::*;
 use lz4::block::CompressionMode;
 use std::time::Instant;
 use thiserror::Error;

--- a/crates/aptos/src/node/analyze/fetch_metadata.rs
+++ b/crates/aptos/src/node/analyze/fetch_metadata.rs
@@ -227,11 +227,10 @@ impl FetchMetadata {
                 .get_new_block_events_bcs(Some(cursor), Some(MAX_FETCH_BATCH_SIZE))
                 .await;
 
-            if response.is_err() {
+            if let Err(err) = &response {
                 println!(
                     "Failed to read new_block_events beyond {}, stopping. {:?}",
-                    cursor,
-                    response.unwrap_err()
+                    cursor, err
                 );
                 assert!(!validators.is_empty());
                 result.push(EpochInfo {

--- a/crates/node-resource-metrics/src/collectors/linux_collectors.rs
+++ b/crates/node-resource-metrics/src/collectors/linux_collectors.rs
@@ -90,17 +90,14 @@ impl Collector for LinuxCpuMetricsCollector {
 
         let mut mfs = Vec::with_capacity(LINUX_CPU_METRICS_COUNT);
 
-        let kernel_stats = KernelStats::new();
-        if kernel_stats.is_err() {
-            warn!(
-                "unable to collect cpu metrics for linux: {}",
-                kernel_stats.unwrap_err()
-            );
-            return mfs;
-        }
-
-        let kernal_stats = kernel_stats.unwrap();
-        let cpu_time = kernal_stats.total;
+        let kernel_stats = match KernelStats::new() {
+            Ok(stats) => stats,
+            Err(err) => {
+                warn!("unable to collect cpu metrics for linux: {}", err);
+                return mfs;
+            },
+        };
+        let cpu_time = kernel_stats.total;
 
         cpu_time_counter!(mfs, cpu_time.user_ms(), "user_ms");
         cpu_time_counter!(mfs, cpu_time.nice_ms(), "nice_ms");
@@ -112,7 +109,7 @@ impl Collector for LinuxCpuMetricsCollector {
         cpu_time_counter_opt!(mfs, cpu_time.steal_ms(), "steal_ms");
         cpu_time_counter_opt!(mfs, cpu_time.guest_ms(), "guest_ms");
         cpu_time_counter_opt!(mfs, cpu_time.guest_nice_ms(), "guest_nice_ms");
-        cpu_time_counter!(mfs, kernal_stats.ctxt, "context_switches");
+        cpu_time_counter!(mfs, kernel_stats.ctxt, "context_switches");
 
         mfs
     }

--- a/devtools/aptos-cargo-cli/src/lib.rs
+++ b/devtools/aptos-cargo-cli/src/lib.rs
@@ -7,7 +7,7 @@ mod common;
 use crate::common::PACKAGE_NAME_DELIMITER;
 use camino::Utf8PathBuf;
 use cargo::Cargo;
-use clap::{command, Args, Parser, Subcommand};
+use clap::{Args, Parser, Subcommand};
 pub use common::SelectedPackageArgs;
 use determinator::Utf8Paths0;
 use log::{debug, trace};

--- a/docker/builder/docker-bake-rust-all.hcl
+++ b/docker/builder/docker-bake-rust-all.hcl
@@ -77,8 +77,8 @@ target "builder-base" {
   target     = "builder-base"
   context    = "."
   contexts = {
-    # Run `docker buildx imagetools inspect rust:1.91.0-trixie` to find the latest multi-platform hash
-    rust = "docker-image://rust:1.91.0-trixie@sha256:a0dba1c1b2c90585fc44421b55ddf8063323760dc644ba1d35f5b389ad3e8e14"
+    # Run `docker buildx imagetools inspect rust:1.92.0-trixie` to find the latest multi-platform hash
+    rust = "docker-image://rust:1.92.0-trixie@sha256:f58923369ba295ae1f60bc49d03f2c955a5c93a0b7d49acfb2b2a65bebaf350d"
   }
   args = {
     PROFILE            = "${PROFILE}"

--- a/ecosystem/indexer-grpc/indexer-grpc-fullnode/src/fullnode_data_service.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-fullnode/src/fullnode_data_service.rs
@@ -223,8 +223,8 @@ impl FullnodeData for FullnodeDataService {
             .as_ref()
             .and_then(|r| r.get_latest_table_info_ledger_version().ok().flatten());
 
-        if known_latest_version.is_some() && table_info_version.is_some() {
-            let version = std::cmp::min(known_latest_version.unwrap(), table_info_version.unwrap());
+        if let (Some(klv), Some(tiv)) = (known_latest_version, table_info_version) {
+            let version = std::cmp::min(klv, tiv);
             if let Ok(timestamp_us) = self.service_context.context.db.get_block_timestamp(version) {
                 let latency = SystemTime::now().duration_since(UNIX_EPOCH).unwrap()
                     - Duration::from_micros(timestamp_us);

--- a/ecosystem/nft-metadata-crawler/src/utils/uri_parser.rs
+++ b/ecosystem/nft-metadata-crawler/src/utils/uri_parser.rs
@@ -30,11 +30,7 @@ impl URIParser {
             uri.to_string()
         };
 
-        let ipfs_auth_param = if ipfs_auth_key.is_some() {
-            Some(format!("?{}={}", IPFS_AUTH_KEY, ipfs_auth_key.unwrap()))
-        } else {
-            None
-        };
+        let ipfs_auth_param = ipfs_auth_key.map(|key| format!("?{}={}", IPFS_AUTH_KEY, key));
 
         // Expects the following format for provided URIs `ipfs/{CID}/{path}`
         let re = Regex::new(r"^(ipfs/)(?P<cid>[a-zA-Z0-9]+)(?P<path>/.*)?$")?;

--- a/mempool/src/tests/core_mempool_test.rs
+++ b/mempool/src/tests/core_mempool_test.rs
@@ -574,7 +574,6 @@ fn test_reset_sequence_number_on_failure() {
     ];
     let hashes: Vec<_> = txns
         .iter()
-        .cloned()
         .map(|txn| txn.make_signed_transaction().committed_hash())
         .collect();
     // Add two transactions for account.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.91.1"
+channel = "1.92.0"
 
 # Note: we don't specify cargofmt in our toolchain because we rely on
 # the nightly version of cargofmt and verify formatting in CI/CD.

--- a/scripts/update_docker_images.py
+++ b/scripts/update_docker_images.py
@@ -10,7 +10,7 @@ OS = "linux"
 
 IMAGES = {
     "debian": "debian:trixie",
-    "rust": "rust:1.91.0-trixie",
+    "rust": "rust:1.92.0-trixie",
 }
 
 

--- a/state-sync/data-streaming-service/src/tests/streaming_service.rs
+++ b/state-sync/data-streaming-service/src/tests/streaming_service.rs
@@ -574,8 +574,8 @@ async fn test_notifications_continuous_transactions_or_outputs_target() {
         }
 
         // Update the next expected version
-        let num_transactions = if transactions_with_proof.is_some() {
-            transactions_with_proof.unwrap().get_num_transactions() as u64
+        let num_transactions = if let Some(txns) = transactions_with_proof {
+            txns.get_num_transactions() as u64
         } else {
             outputs_with_proof.unwrap().get_num_outputs() as u64
         };
@@ -641,8 +641,8 @@ async fn test_notifications_continuous_transactions_or_outputs_multiple_streams(
         assert_eq!(Some(next_expected_version), first_version);
 
         // Update the next expected version
-        let num_transactions = if transactions_with_proof.is_some() {
-            transactions_with_proof.unwrap().get_num_transactions() as u64
+        let num_transactions = if let Some(txns) = transactions_with_proof {
+            txns.get_num_transactions() as u64
         } else {
             outputs_with_proof.unwrap().get_num_outputs() as u64
         };

--- a/storage/aptosdb/src/ledger_db/persisted_auxiliary_info_db.rs
+++ b/storage/aptosdb/src/ledger_db/persisted_auxiliary_info_db.rs
@@ -63,9 +63,8 @@ impl PersistedAuxiliaryInfoDb {
         let mut iter = self.db.iter::<PersistedAuxiliaryInfoSchema>()?;
         iter.seek(&start_version)?;
         let mut iter = iter.peekable();
-        let item = iter.peek();
-        let version = if item.is_some() {
-            item.unwrap().as_ref().map_err(|e| e.clone())?.0
+        let version = if let Some(item) = iter.peek() {
+            item.as_ref().map_err(|e| e.clone())?.0
         } else {
             let mut iter = self.db.iter::<PersistedAuxiliaryInfoSchema>()?;
             iter.seek_to_last();

--- a/storage/aptosdb/src/transaction_store/mod.rs
+++ b/storage/aptosdb/src/transaction_store/mod.rs
@@ -91,12 +91,12 @@ impl TransactionStore {
         // Question[Orderless]: When start version is specified, we are current scanning forward from start version.
         // When start version is not specified we are scanning backward, so as to return the most recent transactions.
         // This doesn't seem to be a good design. Should we instead let the API take scan direction as input?
-        if start_version.is_some() {
+        if let Some(sv) = start_version {
             let mut iter = self
                 .ledger_db
                 .transaction_db_raw()
                 .iter::<TransactionSummariesByAccountSchema>()?;
-            iter.seek(&(address, start_version.unwrap()))?;
+            iter.seek(&(address, sv))?;
             Ok(AccountTransactionSummariesIter::new(
                 iter,
                 address,
@@ -106,12 +106,12 @@ impl TransactionStore {
                 ScanDirection::Forward,
                 ledger_version,
             ))
-        } else if end_version.is_some() {
+        } else if let Some(ev) = end_version {
             let mut iter = self
                 .ledger_db
                 .transaction_db_raw()
                 .rev_iter::<TransactionSummariesByAccountSchema>()?;
-            iter.seek_for_prev(&(address, end_version.unwrap()))?;
+            iter.seek_for_prev(&(address, ev))?;
             Ok(AccountTransactionSummariesIter::new(
                 iter,
                 address,

--- a/storage/backup/backup-cli/Cargo.toml
+++ b/storage/backup/backup-cli/Cargo.toml
@@ -71,3 +71,4 @@ warp = { workspace = true }
 [features]
 testing = []
 fuzzing = ["aptos-db/fuzzing"]
+consensus-only-perf-test = []

--- a/storage/jellyfish-merkle/src/node_type/mod.rs
+++ b/storage/jellyfish-merkle/src/node_type/mod.rs
@@ -367,10 +367,10 @@ impl InternalNode {
     }
 
     pub fn serialize(&self, binary: &mut Vec<u8>) -> Result<()> {
-        let (mut existence_bitmap, leaf_bitmap) = self.generate_bitmaps();
+        let (existence_bitmap, leaf_bitmap) = self.generate_bitmaps();
         binary.write_u16::<LittleEndian>(existence_bitmap)?;
         binary.write_u16::<LittleEndian>(leaf_bitmap)?;
-        for (next_child, child) in self.children.iter() {
+        for (_, child) in self.children.iter() {
             serialize_u64_varint(child.version, binary);
             binary.extend(child.hash.to_vec());
             match child.node_type {
@@ -380,7 +380,6 @@ impl InternalNode {
                 },
                 NodeType::Null => unreachable!("Child cannot be Null"),
             };
-            existence_bitmap &= !(1 << next_child.as_usize());
         }
         Ok(())
     }

--- a/third_party/move/move-core/types/src/value.rs
+++ b/third_party/move/move-core/types/src/value.rs
@@ -3,9 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // The below is to deal with a strange problem with derive(Dearbitrary), which creates warnings
-// of unused variables in derived code which cannot be turned off by applying the attribute
-// just at the type in question. (Here, MoveStructLayout.)
-#![allow(unused_variables)]
+// of unused variables and unused assignments in derived code which cannot be turned off by
+// applying the attribute just at the type in question. (Here, MoveStructLayout.)
+#![allow(unused_variables, unused_assignments)]
 
 use crate::{
     account_address::AccountAddress,

--- a/third_party/move/move-ir-compiler/move-ir-to-bytecode/syntax/src/lexer.rs
+++ b/third_party/move/move-ir-compiler/move-ir-to-bytecode/syntax/src/lexer.rs
@@ -249,12 +249,13 @@ impl<'input> Lexer<'input> {
                     match &text[len..].chars().next() {
                         Some('"') => {
                             // Special case for ByteArrayValue: h\"[0-9A-Fa-f]*\"
-                            let mut bvlen = 0;
-                            if name == "h" && {
-                                bvlen = get_byte_array_value_len(&text[(len + 1)..]);
-                                bvlen > 0
-                            } {
-                                (Tok::ByteArrayValue, 2 + bvlen)
+                            if name == "h" {
+                                let bvlen = get_byte_array_value_len(&text[(len + 1)..]);
+                                if bvlen > 0 {
+                                    (Tok::ByteArrayValue, 2 + bvlen)
+                                } else {
+                                    (get_name_token(name), len)
+                                }
                             } else {
                                 (get_name_token(name), len)
                             }

--- a/third_party/move/move-stdlib/src/tests.rs
+++ b/third_party/move/move-stdlib/src/tests.rs
@@ -26,11 +26,11 @@ fn check_that_docs_are_updated() {
 
     let res = check_dirs_not_diff(&temp_dir, crate::move_stdlib_docs_full_path());
 
-    if res.is_err() {
+    if let Err(err) = res {
         assert!(
                 !read_bool_env_var(UB),
                 "Generated docs differ from the ones checked in {}. Call this test with env variable UB=1 to regenerate or remove old baseline files.",
-                res.unwrap_err()
+                err
             );
     }
 }

--- a/types/src/on_chain_config/validator_set.rs
+++ b/types/src/on_chain_config/validator_set.rs
@@ -71,7 +71,6 @@ impl ValidatorSet {
     pub fn active_validators(&self) -> Vec<AccountAddress> {
         self.active_validators
             .iter()
-            .cloned()
             .map(|v| v.account_address)
             .collect()
     }
@@ -79,7 +78,6 @@ impl ValidatorSet {
     pub fn pending_active_validators(&self) -> Vec<AccountAddress> {
         self.pending_active
             .iter()
-            .cloned()
             .map(|v| v.account_address)
             .collect()
     }
@@ -87,7 +85,6 @@ impl ValidatorSet {
     pub fn pending_inactive_validators(&self) -> Vec<AccountAddress> {
         self.pending_inactive
             .iter()
-            .cloned()
             .map(|v| v.account_address)
             .collect()
     }


### PR DESCRIPTION

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Upgrades the Rust toolchain and builder images, which can surface new compiler/lint behaviors and subtly affect builds across the workspace. The remaining changes are mostly mechanical refactors to satisfy new warnings and should be low runtime risk.
> 
> **Overview**
> Moves the project to **Rust `1.92.0`** by updating `rust-toolchain.toml`, the Docker builder base (`rust:1.92.0-trixie`), and the image update script.
> 
> Hardens `aptos-node` builds by **failing compilation** if `testing`/`fuzzing` features are enabled in production, replacing the previous runtime assert.
> 
> Applies a set of compiler/lint-driven cleanups across crates: removes `aptos-logger` from `aptos-compression`, refactors multiple `is_err()/unwrap_err()` patterns to `if let Err(err)`/`match`, simplifies iterator usage (dropping unnecessary `.cloned()`), and addresses new warnings (e.g., `#![allow(unused_assignments)]`, lexer parsing tweak, minor variable/unused value fixes).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0979d496d12faa24cb3c3cf29e2737a828cf7027. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->