### PR TITLE
Aptos CLI upgrade changelog

### DIFF
--- a/crates/aptos/src/update/mod.rs
+++ b/crates/aptos/src/update/mod.rs
@@ -19,6 +19,10 @@ pub use movefmt::get_movefmt_path;
 use self_update::{update::ReleaseUpdate, version::bump_is_greater, Status};
 pub use tool::UpdateTool;
 
+/// URL to the Aptos CLI CHANGELOG for directing users to review breaking changes.
+const CHANGELOG_URL: &str =
+    "https://github.com/aptos-labs/aptos-core/blob/main/crates/aptos/CHANGELOG.md";
+
 /// Things that implement this trait are able to update a binary.
 trait BinaryUpdater {
     /// For checking the version but not updating
@@ -51,10 +55,10 @@ trait BinaryUpdater {
             .update()
             .map_err(|e| anyhow!("Failed to update {}: {:#}", self.pretty_name(), e))?;
 
-        let message = match result {
+        let mut message = match result {
             Status::UpToDate(_) => unreachable!("We should have caught this already"),
             Status::Updated(_) => match info.current_version {
-                Some(current_version) => format!(
+                Some(ref current_version) => format!(
                     "Successfully updated {} from v{} to v{}",
                     self.pretty_name(),
                     current_version,
@@ -69,6 +73,14 @@ trait BinaryUpdater {
                 },
             },
         };
+
+        if info.is_major_version_bump() {
+            message.push_str(&format!(
+                "\n\nThis is a major version update which may include breaking changes. \
+                 Please review the changelog for details:\n  {}",
+                CHANGELOG_URL
+            ));
+        }
 
         Ok(message)
     }
@@ -104,6 +116,20 @@ impl UpdateRequiredInfo {
             None => Ok(true),
         }
     }
+
+    /// Returns true if the update involves a major version change (e.g. 6.x.x -> 7.x.x).
+    pub fn is_major_version_bump(&self) -> bool {
+        if let Some(ref current_version) = self.current_version {
+            let current_major = current_version.split('.').next();
+            let target_major = self.target_version.split('.').next();
+            match (current_major, target_major) {
+                (Some(c), Some(t)) => c != t,
+                _ => false,
+            }
+        } else {
+            false
+        }
+    }
 }
 
 async fn update_binary<Updater: BinaryUpdater + Sync + Send + 'static>(
@@ -114,8 +140,16 @@ async fn update_binary<Updater: BinaryUpdater + Sync + Send + 'static>(
         let info = tokio::task::spawn_blocking(move || updater.get_update_info())
             .await
             .context(format!("Failed to check {} version", name))??;
-        if info.current_version.unwrap_or_default() != info.target_version {
-            return Ok(format!("Update is available ({})", info.target_version));
+        if info.current_version.as_deref().unwrap_or_default() != info.target_version {
+            let mut message = format!("Update is available ({})", info.target_version);
+            if info.is_major_version_bump() {
+                message.push_str(&format!(
+                    "\n\nThis is a major version update which may include breaking changes. \
+                     Please review the changelog for details:\n  {}",
+                    CHANGELOG_URL
+                ));
+            }
+            return Ok(message);
         }
 
         return Ok(format!("Already up to date ({})", info.target_version));


### PR DESCRIPTION
## Description
This PR enhances the `aptos CLI` upgrade experience by informing users about major version changes and directing them to the `CHANGELOG.md` for details. When a major version bump is detected during an update or an update check, a message is appended to the output, providing the URL to the CLI's changelog. This helps users understand potential breaking changes.

## How Has This Been Tested?
The Rust code compiles successfully. Full integration tests involving actual CLI updates were not performed in the assistant's environment due to native dependency compilation issues, but the logic for detecting major version bumps and appending the message is straightforward and has been verified at the code level.

## Key Areas to Review
- The `is_major_version_bump()` method in `UpdateRequiredInfo` to ensure correct major version detection.
- The placement and wording of the CHANGELOG reference message in both the `update()` and `update_binary()` functions.

## Type of Change
- [x] New feature

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [x] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

---
<p><a href="https://cursor.com/background-agent?bcId=bc-d243dcdb-1317-4c2f-9d07-7bb15c976020"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d243dcdb-1317-4c2f-9d07-7bb15c976020"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

