### PR TITLE
cherry-pick recent hotfixes (1.40)

### DIFF
--- a/aptos-move/aptos-vm-environment/src/prod_configs.rs
+++ b/aptos-move/aptos-vm-environment/src/prod_configs.rs
@@ -227,6 +227,7 @@ pub fn aptos_prod_vm_config(
     let enable_depth_checks = features.is_enabled(FeatureFlag::ENABLE_FUNCTION_VALUES);
     let enable_capture_option = !timed_features.is_enabled(TimedFeatureFlag::DisabledCaptureOption)
         || features.is_enabled(FeatureFlag::ENABLE_CAPTURE_OPTION);
+    let enable_closure_depth_check = timed_features.is_enabled(TimedFeatureFlag::ClosureDepthCheck);
 
     // Some feature gating was missed, so for native dynamic dispatch the feature is always on for
     // testnet after 1.38 release.
@@ -263,6 +264,7 @@ pub fn aptos_prod_vm_config(
         enable_framework_for_option,
         enable_function_caches_for_native_dynamic_dispatch,
         enable_debugging,
+        enable_closure_depth_check,
     };
 
     // Note: if max_value_nest_depth changed, make sure the constant is in-sync. Do not remove this

--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -350,7 +350,7 @@ impl AptosVM {
     }
 
     #[inline(always)]
-    fn timed_features(&self) -> &TimedFeatures {
+    pub(crate) fn timed_features(&self) -> &TimedFeatures {
         self.move_vm.env.timed_features()
     }
 
@@ -2134,7 +2134,7 @@ impl AptosVM {
         G: AptosGasMeter,
         F: FnOnce(u64, VMGasParameters, StorageGasParameters, bool, Gas, &'a C) -> G,
     {
-        let txn_metadata = TransactionMetadata::new(txn, auxiliary_info);
+        let txn_metadata = TransactionMetadata::new(txn, auxiliary_info, self.timed_features());
 
         let is_approved_gov_script = is_approved_gov_script(resolver, txn, &txn_metadata);
 
@@ -3212,7 +3212,7 @@ impl VMValidator for AptosVM {
             },
         };
         let auxiliary_info = AuxiliaryInfo::new_timestamp_not_yet_assigned(0);
-        let txn_data = TransactionMetadata::new(&txn, &auxiliary_info);
+        let txn_data = TransactionMetadata::new(&txn, &auxiliary_info, self.timed_features());
 
         let resolver = self.as_move_resolver(&state_view);
         let is_approved_gov_script = is_approved_gov_script(&resolver, &txn, &txn_data);

--- a/aptos-move/aptos-vm/src/move_vm_ext/session/mod.rs
+++ b/aptos-move/aptos-vm/src/move_vm_ext/session/mod.rs
@@ -197,8 +197,19 @@ where
                 } else {
                     StatusCode::INTERNAL_TYPE_ERROR
                 };
-                PartialVMError::new(status_code)
-                    .with_message(format!("Error when serializing resource {}.", value))
+                // Note: When enable_closure_depth_check is enabled, do not format
+                // `value` here - deeply nested closures can cause stack overflow
+                // during Display formatting.
+                let enable_closure_depth_check = module_storage
+                    .runtime_environment()
+                    .vm_config()
+                    .enable_closure_depth_check;
+                let message = if enable_closure_depth_check {
+                    "Error when serializing resource.".to_string()
+                } else {
+                    format!("Error when serializing resource {}.", value)
+                };
+                PartialVMError::new(status_code).with_message(message)
             })
         };
 

--- a/aptos-move/aptos-vm/src/testing.rs
+++ b/aptos-move/aptos-vm/src/testing.rs
@@ -81,7 +81,8 @@ impl AptosVM {
         use aptos_types::transaction::AuxiliaryInfo;
         use move_vm_runtime::module_traversal::{TraversalContext, TraversalStorage};
 
-        let txn_data = TransactionMetadata::new(txn, &AuxiliaryInfo::default());
+        let txn_data =
+            TransactionMetadata::new(txn, &AuxiliaryInfo::default(), self.timed_features());
         let log_context = AdapterLogSchema::new(state_view.id(), 0);
 
         let vm_gas_params = self

--- a/aptos-move/aptos-vm/src/transaction_metadata.rs
+++ b/aptos-move/aptos-vm/src/transaction_metadata.rs
@@ -6,6 +6,7 @@ use aptos_gas_algebra::{FeePerGasUnit, Gas, NumBytes};
 use aptos_types::{
     account_address::AccountAddress,
     chain_id::ChainId,
+    on_chain_config::{TimedFeatureFlag, TimedFeatures},
     transaction::{
         authenticator::AuthenticationProof,
         user_transaction_context::{TransactionIndexKind, UserTransactionContext},
@@ -40,7 +41,20 @@ pub struct TransactionMetadata {
 }
 
 impl TransactionMetadata {
-    pub fn new(txn: &SignedTransaction, auxiliary_info: &AuxiliaryInfo) -> Self {
+    pub fn new(
+        txn: &SignedTransaction,
+        auxiliary_info: &AuxiliaryInfo,
+        timed_features: &TimedFeatures,
+    ) -> Self {
+        // Use full transaction size (including authenticator) when the feature is enabled,
+        // otherwise use the raw transaction size for backwards compatibility.
+        let transaction_size =
+            if timed_features.is_enabled(TimedFeatureFlag::UseFullTransactionSizeForGasCheck) {
+                txn.txn_bytes_len()
+            } else {
+                txn.raw_txn_bytes_len()
+            };
+
         Self {
             sender: txn.sender(),
             authentication_proof: txn.authenticator().sender().authentication_proof(),
@@ -59,7 +73,7 @@ impl TransactionMetadata {
                 .map(|signer| signer.authentication_proof()),
             max_gas_amount: txn.max_gas_amount().into(),
             gas_unit_price: txn.gas_unit_price().into(),
-            transaction_size: (txn.raw_txn_bytes_len() as u64).into(),
+            transaction_size: (transaction_size as u64).into(),
             expiration_timestamp_secs: txn.expiration_timestamp_secs(),
             chain_id: txn.chain_id(),
             script_hash: if let Ok(TransactionExecutableRef::Script(s)) =

--- a/aptos-move/e2e-move-tests/src/tests/cryptoalgebra.data/p/Move.toml
+++ b/aptos-move/e2e-move-tests/src/tests/cryptoalgebra.data/p/Move.toml
@@ -1,0 +1,7 @@
+[package]
+name = "p"
+version = "0.0.0"
+
+[dependencies]
+MoveStdlib = { local = "../../../../../framework/move-stdlib" }
+AptosStdlib = { local = "../../../../../framework/aptos-stdlib" }

--- a/aptos-move/e2e-move-tests/src/tests/cryptoalgebra.data/p/sources/test.move
+++ b/aptos-move/e2e-move-tests/src/tests/cryptoalgebra.data/p/sources/test.move
@@ -1,0 +1,27 @@
+module 0xbeef::test {
+    use aptos_std::crypto_algebra;
+    use aptos_std::bls12381_algebra::G1;
+
+    // A phantom struct with 8 type parameters (valid type tag).
+    struct W<
+        phantom T1, phantom T2, phantom T3, phantom T4,
+        phantom T5, phantom T6, phantom T7, phantom T8
+    > {}
+
+    /// Creates a type that exceeded type tag budget during type to tag conversion.
+    public entry fun run() {
+        crypto_algebra::hash_to<
+            G1,
+            W<
+                W<u8, u8, u8, u8, u8, u8, u8, u8>,
+                W<u8, u8, u8, u8, u8, u8, u8, u8>,
+                W<u8, u8, u8, u8, u8, u8, u8, u8>,
+                W<u8, u8, u8, u8, u8, u8, u8, u8>,
+                W<u8, u8, u8, u8, u8, u8, u8, u8>,
+                W<u8, u8, u8, u8, u8, u8, u8, u8>,
+                W<u8, u8, u8, u8, u8, u8, u8, u8>,
+                W<u8, u8, u8, u8, u8, u8, u8, u8>
+            >
+        >(&b"DST", &b"message");
+    }
+}

--- a/aptos-move/e2e-move-tests/src/tests/cryptoalgebra.rs
+++ b/aptos-move/e2e-move-tests/src/tests/cryptoalgebra.rs
@@ -1,0 +1,43 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+use crate::{assert_success, tests::common, MoveHarness};
+use aptos_types::{
+    account_address::AccountAddress,
+    transaction::{ExecutionStatus, TransactionStatus},
+};
+
+fn crypto_algebra_type_tag_limit_exceeded(harness: &mut MoveHarness) -> TransactionStatus {
+    let acc = harness.new_account_at(AccountAddress::from_hex_literal("0xbeef").unwrap());
+    assert_success!(harness.publish_package(&acc, &common::test_dir_path("cryptoalgebra.data/p"),));
+
+    harness.run_entry_function(
+        &acc,
+        str::parse("0xbeef::test::run").unwrap(),
+        vec![],
+        vec![],
+    )
+}
+
+#[test]
+#[should_panic]
+fn crypto_algebra_type_tag_limit_exceeded_not_handled() {
+    let mut h = MoveHarness::new();
+    crypto_algebra_type_tag_limit_exceeded(&mut h);
+}
+
+#[test]
+fn crypto_algebra_type_tag_limit_exceeded_handled() {
+    let mut h = MoveHarness::new();
+    h.new_epoch();
+    let result = crypto_algebra_type_tag_limit_exceeded(&mut h);
+
+    assert!(
+        matches!(
+            result,
+            TransactionStatus::Keep(ExecutionStatus::MoveAbort { .. })
+        ),
+        "result: {:?}",
+        result
+    );
+}

--- a/aptos-move/e2e-move-tests/src/tests/mod.rs
+++ b/aptos-move/e2e-move-tests/src/tests/mod.rs
@@ -16,6 +16,7 @@ mod chain_id;
 mod code_publishing;
 mod common;
 mod constructor_args;
+mod cryptoalgebra;
 mod dependencies;
 mod enum_upgrade;
 mod enum_upgrade_fv;

--- a/aptos-move/framework/src/natives/cryptography/algebra/hash_to_structure.rs
+++ b/aptos-move/framework/src/natives/cryptography/algebra/hash_to_structure.rs
@@ -13,7 +13,7 @@ use aptos_gas_schedule::gas_params::natives::{aptos_framework::*, move_stdlib::*
 use aptos_native_interface::{
     safely_pop_arg, SafeNativeContext, SafeNativeError, SafeNativeResult,
 };
-use aptos_types::on_chain_config::FeatureFlag;
+use aptos_types::on_chain_config::{FeatureFlag, TimedFeatureFlag};
 use ark_ec::hashing::HashToCurve;
 use either::Either;
 use move_core_types::gas_algebra::{InternalGas, NumBytes};
@@ -23,6 +23,10 @@ use move_vm_types::{
 };
 use smallvec::{smallvec, SmallVec};
 use std::{collections::VecDeque, rc::Rc};
+
+/// Equivalent to `std::error::internal(99)` in Move.
+/// Used when type to type tag conversion fails unexpectedly.
+const E_TYPE_TO_TYPE_TAG_CONVERSION_FAILED: u64 = 0x0B_0063;
 
 fn feature_flag_of_hash_to_structure(
     structure_opt: Option<Structure>,
@@ -44,11 +48,24 @@ macro_rules! abort_unless_hash_to_structure_enabled {
     };
 }
 
-macro_rules! suite_from_ty_arg {
-    ($context:expr, $typ:expr) => {{
-        let type_tag = $context.type_to_type_tag($typ).unwrap();
-        HashToStructureSuite::try_from(type_tag).ok()
-    }};
+fn suite_from_ty_arg(
+    context: &SafeNativeContext,
+    ty: &Type,
+) -> SafeNativeResult<Option<HashToStructureSuite>> {
+    let result = context.type_to_type_tag(ty);
+    let type_tag =
+        if context.timed_feature_enabled(TimedFeatureFlag::FixCryptoAlgebraNativesResultHandling) {
+            if let Ok(type_tag) = result {
+                type_tag
+            } else {
+                return Err(SafeNativeError::Abort {
+                    abort_code: E_TYPE_TO_TYPE_TAG_CONVERSION_FAILED,
+                });
+            }
+        } else {
+            result.unwrap()
+        };
+    Ok(HashToStructureSuite::try_from(type_tag).ok())
 }
 
 macro_rules! hash_to_bls12381gx_cost {
@@ -85,7 +102,7 @@ pub fn hash_to_internal(
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     assert_eq!(2, ty_args.len());
     let structure_opt = structure_from_ty_arg!(context, &ty_args[0]);
-    let suite_opt = suite_from_ty_arg!(context, &ty_args[1]);
+    let suite_opt = suite_from_ty_arg(context, &ty_args[1])?;
     abort_unless_hash_to_structure_enabled!(context, structure_opt, suite_opt);
     let vector_ref = safely_pop_arg!(args, VectorRef);
     let bytes_ref = vector_ref.as_bytes_ref();

--- a/third_party/move/move-vm/runtime/src/config.rs
+++ b/third_party/move/move-vm/runtime/src/config.rs
@@ -56,6 +56,11 @@ pub struct VMConfig {
     /// Whether this VM should support debugging. If set, environment variables
     /// `MOVE_VM_TRACE` and `MOVE_VM_STEP` will be recognized.
     pub enable_debugging: bool,
+    /// When enabled, checks the depth of captured values when packing closures.
+    /// This prevents deeply nested closure chains that could cause stack overflow.
+    /// Also controls whether error messages format values (which could cause stack
+    /// overflow during Display formatting).
+    pub enable_closure_depth_check: bool,
 }
 
 impl Default for VMConfig {
@@ -85,6 +90,7 @@ impl Default for VMConfig {
             enable_framework_for_option: true,
             enable_function_caches_for_native_dynamic_dispatch: true,
             enable_debugging: false,
+            enable_closure_depth_check: true,
         }
     }
 }

--- a/third_party/move/move-vm/runtime/src/interpreter.rs
+++ b/third_party/move/move-vm/runtime/src/interpreter.rs
@@ -1711,6 +1711,28 @@ where
     fn get_internal_state(&self) -> ExecutionState {
         self.get_stack_frames(usize::MAX)
     }
+
+    /// Check that the depth of captured closure values does not exceed the configured maximum.
+    ///
+    /// Closures can capture other closures, creating arbitrary nesting depth that is not visible
+    /// in the type system (all closures have the same function type regardless of what they capture).
+    /// This check ensures that deeply nested closure chains cannot be created, preventing potential
+    /// stack overflows or excessive resource consumption when operating on such values.
+    ///
+    /// The check uses `max_depth - 1` because the closure being packed adds one additional level
+    /// of nesting on top of its captured values.
+    fn check_depth_of_closure_captured_values(&self, captured: &[Value]) -> PartialVMResult<()> {
+        if !self.vm_config.enable_closure_depth_check {
+            return Ok(());
+        }
+        if let Some(max_depth) = self.vm_config.max_value_nest_depth {
+            let limit = max_depth.saturating_sub(1);
+            for v in captured.iter() {
+                v.check_depth_of_value(limit)?;
+            }
+        }
+        Ok(())
+    }
 }
 
 impl<LoaderImpl> InterpreterDebugInterface for InterpreterImpl<'_, LoaderImpl>
@@ -2506,6 +2528,7 @@ impl Frame {
                             )?;
                         }
                         let captured = interpreter.operand_stack.popn(mask.captured_count())?;
+                        interpreter.check_depth_of_closure_captured_values(&captured)?;
                         let lazy_function = LazyLoadedFunction::new_resolved(
                             interpreter.layout_converter,
                             gas_meter,
@@ -2543,6 +2566,7 @@ impl Frame {
                         RTTCheck::check_pack_closure_visibility(&self.function, &function)?;
 
                         let captured = interpreter.operand_stack.popn(mask.captured_count())?;
+                        interpreter.check_depth_of_closure_captured_values(&captured)?;
                         let lazy_function = LazyLoadedFunction::new_resolved(
                             interpreter.layout_converter,
                             gas_meter,

--- a/third_party/move/move-vm/types/src/values/values_impl.rs
+++ b/third_party/move/move-vm/types/src/values/values_impl.rs
@@ -6169,3 +6169,116 @@ fn check_depth(depth: u64, max_depth: Option<u64>) -> PartialVMResult<()> {
     }
     Ok(())
 }
+
+/// A visitor that checks the depth of values does not exceed a maximum.
+struct DepthCheckingVisitor {
+    max_depth: u64,
+}
+
+impl DepthCheckingVisitor {
+    #[inline]
+    fn check(&self, depth: u64) -> PartialVMResult<()> {
+        if depth > self.max_depth {
+            return Err(PartialVMError::new(StatusCode::VM_MAX_VALUE_DEPTH_REACHED));
+        }
+        Ok(())
+    }
+}
+
+impl ValueVisitor for DepthCheckingVisitor {
+    fn visit_delayed(&mut self, depth: u64, _id: DelayedFieldID) -> PartialVMResult<()> {
+        self.check(depth)
+    }
+
+    fn visit_u8(&mut self, depth: u64, _val: u8) -> PartialVMResult<()> {
+        self.check(depth)
+    }
+
+    fn visit_u16(&mut self, depth: u64, _val: u16) -> PartialVMResult<()> {
+        self.check(depth)
+    }
+
+    fn visit_u32(&mut self, depth: u64, _val: u32) -> PartialVMResult<()> {
+        self.check(depth)
+    }
+
+    fn visit_u64(&mut self, depth: u64, _val: u64) -> PartialVMResult<()> {
+        self.check(depth)
+    }
+
+    fn visit_u128(&mut self, depth: u64, _val: u128) -> PartialVMResult<()> {
+        self.check(depth)
+    }
+
+    fn visit_u256(
+        &mut self,
+        depth: u64,
+        _val: &move_core_types::int256::U256,
+    ) -> PartialVMResult<()> {
+        self.check(depth)
+    }
+
+    fn visit_i8(&mut self, depth: u64, _val: i8) -> PartialVMResult<()> {
+        self.check(depth)
+    }
+
+    fn visit_i16(&mut self, depth: u64, _val: i16) -> PartialVMResult<()> {
+        self.check(depth)
+    }
+
+    fn visit_i32(&mut self, depth: u64, _val: i32) -> PartialVMResult<()> {
+        self.check(depth)
+    }
+
+    fn visit_i64(&mut self, depth: u64, _val: i64) -> PartialVMResult<()> {
+        self.check(depth)
+    }
+
+    fn visit_i128(&mut self, depth: u64, _val: i128) -> PartialVMResult<()> {
+        self.check(depth)
+    }
+
+    fn visit_i256(
+        &mut self,
+        depth: u64,
+        _val: &move_core_types::int256::I256,
+    ) -> PartialVMResult<()> {
+        self.check(depth)
+    }
+
+    fn visit_bool(&mut self, depth: u64, _val: bool) -> PartialVMResult<()> {
+        self.check(depth)
+    }
+
+    fn visit_address(&mut self, depth: u64, _val: &AccountAddress) -> PartialVMResult<()> {
+        self.check(depth)
+    }
+
+    fn visit_struct(&mut self, depth: u64, _len: usize) -> PartialVMResult<bool> {
+        self.check(depth)?;
+        Ok(true) // continue into fields
+    }
+
+    fn visit_closure(&mut self, depth: u64, _len: usize) -> PartialVMResult<bool> {
+        self.check(depth)?;
+        Ok(true) // continue into captured values
+    }
+
+    fn visit_vec(&mut self, depth: u64, _len: usize) -> PartialVMResult<bool> {
+        self.check(depth)?;
+        Ok(true) // continue into elements
+    }
+
+    fn visit_ref(&mut self, depth: u64, _is_global: bool) -> PartialVMResult<bool> {
+        self.check(depth)?;
+        Ok(true) // continue into referenced value
+    }
+}
+
+impl Value {
+    /// Check that the depth of this value does not exceed `max_depth`.
+    /// Returns an error with `VM_MAX_VALUE_DEPTH_REACHED` if the depth is exceeded.
+    pub fn check_depth_of_value(&self, max_depth: u64) -> PartialVMResult<()> {
+        self.visit(&mut DepthCheckingVisitor { max_depth })
+    }
+}

--- a/types/src/on_chain_config/timed_features.rs
+++ b/types/src/on_chain_config/timed_features.rs
@@ -25,6 +25,17 @@ pub enum TimedFeatureFlag {
 
     /// Fixes the bug that table natives double count the memory usage of the global values.
     FixTableNativesMemoryDoubleCounting,
+
+    /// Enables depth checking for captured values when packing closures.
+    /// This prevents deeply nested closure chains that could cause stack overflow.
+    ClosureDepthCheck,
+
+    /// Fixes handling of results in crypto algebra natives.
+    FixCryptoAlgebraNativesResultHandling,
+
+    /// Use the full transaction size (including authenticator) for gas checks
+    /// instead of just the raw transaction size.
+    UseFullTransactionSizeForGasCheck,
 }
 
 /// Representation of features that are gated by the block timestamps.
@@ -131,6 +142,43 @@ impl TimedFeatureFlag {
                 .with_timezone(&Utc),
             (FixTableNativesMemoryDoubleCounting, MAINNET) => Los_Angeles
                 .with_ymd_and_hms(2025, 10, 21, 10, 0, 0)
+                .unwrap()
+                .with_timezone(&Utc),
+
+            // Security fix: check depth of captured values when packing closures.
+            (ClosureDepthCheck, TESTNET) => Los_Angeles
+                .with_ymd_and_hms(2026, 2, 2, 22, 0, 0)
+                .unwrap()
+                .with_timezone(&Utc),
+            (ClosureDepthCheck, MAINNET) => Los_Angeles
+                .with_ymd_and_hms(2026, 2, 5, 10, 0, 0)
+                .unwrap()
+                .with_timezone(&Utc),
+
+            // For testing, time set to 1 hour after the beginning of time to test the old and new behaviors in tests.
+            (FixCryptoAlgebraNativesResultHandling, TESTING) => {
+                Utc.with_ymd_and_hms(1970, 1, 1, 1, 0, 0).unwrap()
+            },
+            (FixCryptoAlgebraNativesResultHandling, TESTNET) => Los_Angeles
+                .with_ymd_and_hms(2026, 2, 2, 22, 0, 0)
+                .unwrap()
+                .with_timezone(&Utc),
+            (FixCryptoAlgebraNativesResultHandling, MAINNET) => Los_Angeles
+                .with_ymd_and_hms(2026, 2, 5, 10, 0, 0)
+                .unwrap()
+                .with_timezone(&Utc),
+
+            // Note: This is needed to allow forge to undergo a gated transition as well.
+            (UseFullTransactionSizeForGasCheck, TESTING) => Los_Angeles
+                .with_ymd_and_hms(2026, 4, 10, 10, 0, 0)
+                .unwrap()
+                .with_timezone(&Utc),
+            (UseFullTransactionSizeForGasCheck, TESTNET) => Los_Angeles
+                .with_ymd_and_hms(2026, 2, 2, 22, 0, 0)
+                .unwrap()
+                .with_timezone(&Utc),
+            (UseFullTransactionSizeForGasCheck, MAINNET) => Los_Angeles
+                .with_ymd_and_hms(2026, 2, 5, 10, 0, 0)
                 .unwrap()
                 .with_timezone(&Utc),
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches consensus-critical VM execution and gas validation, but behavior changes are gated behind new timed features with scheduled activation and include targeted tests to reduce rollout risk.
> 
> **Overview**
> Introduces three new *timed* feature gates: `ClosureDepthCheck`, `FixCryptoAlgebraNativesResultHandling`, and `UseFullTransactionSizeForGasCheck`, with scheduled activation times.
> 
> When `ClosureDepthCheck` is enabled, the Move VM now enforces a depth limit on values captured into closures during `pack_closure`, and avoids formatting deeply nested `Value`s in serialization error messages to prevent potential stack overflows.
> 
> Gas validation now optionally uses the *full signed transaction size* (including authenticator) via `TransactionMetadata::new(..., timed_features)`, and Aptos VM call sites are updated accordingly. Crypto algebra `hash_to` natives now return a Move abort (instead of panicking) when `type_to_type_tag` conversion fails under the new timed gate, with a new e2e test covering the handled vs unhandled behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1f6565b53c97eaf35a462e40db8d2520a336167f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->