### PR TITLE
cherry-pick recent hotfixes (1.41)

### DIFF
--- a/aptos-move/aptos-vm-environment/src/prod_configs.rs
+++ b/aptos-move/aptos-vm-environment/src/prod_configs.rs
@@ -227,6 +227,7 @@ pub fn aptos_prod_vm_config(
     let enable_depth_checks = features.is_enabled(FeatureFlag::ENABLE_FUNCTION_VALUES);
     let enable_capture_option = !timed_features.is_enabled(TimedFeatureFlag::DisabledCaptureOption)
         || features.is_enabled(FeatureFlag::ENABLE_CAPTURE_OPTION);
+    let enable_closure_depth_check = timed_features.is_enabled(TimedFeatureFlag::ClosureDepthCheck);
 
     // Some feature gating was missed, so for native dynamic dispatch the feature is always on for
     // testnet after 1.38 release.
@@ -263,6 +264,7 @@ pub fn aptos_prod_vm_config(
         enable_framework_for_option,
         enable_function_caches_for_native_dynamic_dispatch,
         enable_debugging,
+        enable_closure_depth_check,
     };
 
     // Note: if max_value_nest_depth changed, make sure the constant is in-sync. Do not remove this

--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -350,7 +350,7 @@ impl AptosVM {
     }
 
     #[inline(always)]
-    fn timed_features(&self) -> &TimedFeatures {
+    pub(crate) fn timed_features(&self) -> &TimedFeatures {
         self.move_vm.env.timed_features()
     }
 
@@ -2140,7 +2140,7 @@ impl AptosVM {
         G: AptosGasMeter,
         F: FnOnce(u64, VMGasParameters, StorageGasParameters, bool, Gas, &'a C) -> G,
     {
-        let txn_metadata = TransactionMetadata::new(txn, auxiliary_info);
+        let txn_metadata = TransactionMetadata::new(txn, auxiliary_info, self.timed_features());
 
         let is_approved_gov_script = is_approved_gov_script(resolver, txn, &txn_metadata);
 
@@ -3236,7 +3236,7 @@ impl VMValidator for AptosVM {
             },
         };
         let auxiliary_info = AuxiliaryInfo::new_timestamp_not_yet_assigned(0);
-        let txn_data = TransactionMetadata::new(&txn, &auxiliary_info);
+        let txn_data = TransactionMetadata::new(&txn, &auxiliary_info, self.timed_features());
 
         let resolver = self.as_move_resolver(&state_view);
         let is_approved_gov_script = is_approved_gov_script(&resolver, &txn, &txn_data);

--- a/aptos-move/aptos-vm/src/gas.rs
+++ b/aptos-move/aptos-vm/src/gas.rs
@@ -78,7 +78,7 @@ pub(crate) fn check_gas(
     log_context: &AdapterLogSchema,
 ) -> Result<(), VMStatus> {
     let txn_gas_params = &gas_params.vm.txn;
-    let raw_bytes_len = txn_metadata.transaction_size;
+    let txn_bytes_len = txn_metadata.transaction_size;
 
     if is_approved_gov_script {
         let max_txn_size_gov = if gas_feature_version >= RELEASE_V1_13 {
@@ -87,18 +87,18 @@ pub(crate) fn check_gas(
             MAXIMUM_APPROVED_TRANSACTION_SIZE_LEGACY.into()
         };
 
-        if txn_metadata.transaction_size > max_txn_size_gov
+        if txn_bytes_len > max_txn_size_gov
             // Ensure that it is only the approved payload that exceeds the
             // maximum. The (unknown) user input should be restricted to the original
             // maximum transaction size.
-            || txn_metadata.transaction_size
+            || txn_bytes_len
                 > txn_metadata.script_size + txn_gas_params.max_transaction_size_in_bytes
         {
             speculative_warn!(
                 log_context,
                 format!(
                     "[VM] Governance transaction size too big {} payload size {}",
-                    txn_metadata.transaction_size, txn_metadata.script_size,
+                    txn_bytes_len, txn_metadata.script_size,
                 ),
             );
             return Err(VMStatus::error(
@@ -106,12 +106,12 @@ pub(crate) fn check_gas(
                 None,
             ));
         }
-    } else if txn_metadata.transaction_size > txn_gas_params.max_transaction_size_in_bytes {
+    } else if txn_bytes_len > txn_gas_params.max_transaction_size_in_bytes {
         speculative_warn!(
             log_context,
             format!(
                 "[VM] Transaction size too big {} (max {})",
-                txn_metadata.transaction_size, txn_gas_params.max_transaction_size_in_bytes
+                txn_bytes_len, txn_gas_params.max_transaction_size_in_bytes
             ),
         );
         return Err(VMStatus::error(
@@ -139,8 +139,7 @@ pub(crate) fn check_gas(
     }
 
     // The submitted transactions max gas units needs to be at least enough to cover the
-    // intrinsic cost of the transaction as calculated against the size of the
-    // underlying `RawTransaction`.
+    // intrinsic cost of the transaction as calculated against the transaction size.
     let keyless = if txn_metadata.is_keyless() {
         KEYLESS_BASE_COST.evaluate(gas_feature_version, &gas_params.vm)
     } else {
@@ -152,7 +151,7 @@ pub(crate) fn check_gas(
         InternalGas::zero()
     };
     let intrinsic_gas = txn_gas_params
-        .calculate_intrinsic_gas(raw_bytes_len)
+        .calculate_intrinsic_gas(txn_bytes_len)
         .evaluate(gas_feature_version, &gas_params.vm);
     let total_rounded: Gas =
         (intrinsic_gas + keyless + slh_dsa_sha2_128s).to_unit_round_up_with_params(txn_gas_params);

--- a/aptos-move/aptos-vm/src/move_vm_ext/session/mod.rs
+++ b/aptos-move/aptos-vm/src/move_vm_ext/session/mod.rs
@@ -197,8 +197,19 @@ where
                 } else {
                     StatusCode::INTERNAL_TYPE_ERROR
                 };
-                PartialVMError::new(status_code)
-                    .with_message(format!("Error when serializing resource {}.", value))
+                // Note: When enable_closure_depth_check is enabled, do not format
+                // `value` here - deeply nested closures can cause stack overflow
+                // during Display formatting.
+                let enable_closure_depth_check = module_storage
+                    .runtime_environment()
+                    .vm_config()
+                    .enable_closure_depth_check;
+                let message = if enable_closure_depth_check {
+                    "Error when serializing resource.".to_string()
+                } else {
+                    format!("Error when serializing resource {}.", value)
+                };
+                PartialVMError::new(status_code).with_message(message)
             })
         };
 

--- a/aptos-move/aptos-vm/src/testing.rs
+++ b/aptos-move/aptos-vm/src/testing.rs
@@ -81,7 +81,8 @@ impl AptosVM {
         use aptos_types::transaction::AuxiliaryInfo;
         use move_vm_runtime::module_traversal::{TraversalContext, TraversalStorage};
 
-        let txn_data = TransactionMetadata::new(txn, &AuxiliaryInfo::default());
+        let txn_data =
+            TransactionMetadata::new(txn, &AuxiliaryInfo::default(), self.timed_features());
         let log_context = AdapterLogSchema::new(state_view.id(), 0);
 
         let vm_gas_params = self

--- a/aptos-move/e2e-move-tests/src/tests/cryptoalgebra.data/p/Move.toml
+++ b/aptos-move/e2e-move-tests/src/tests/cryptoalgebra.data/p/Move.toml
@@ -1,0 +1,7 @@
+[package]
+name = "p"
+version = "0.0.0"
+
+[dependencies]
+MoveStdlib = { local = "../../../../../framework/move-stdlib" }
+AptosStdlib = { local = "../../../../../framework/aptos-stdlib" }

--- a/aptos-move/e2e-move-tests/src/tests/cryptoalgebra.data/p/sources/test.move
+++ b/aptos-move/e2e-move-tests/src/tests/cryptoalgebra.data/p/sources/test.move
@@ -1,0 +1,27 @@
+module 0xbeef::test {
+    use aptos_std::crypto_algebra;
+    use aptos_std::bls12381_algebra::G1;
+
+    // A phantom struct with 8 type parameters (valid type tag).
+    struct W<
+        phantom T1, phantom T2, phantom T3, phantom T4,
+        phantom T5, phantom T6, phantom T7, phantom T8
+    > {}
+
+    /// Creates a type that exceeded type tag budget during type to tag conversion.
+    public entry fun run() {
+        crypto_algebra::hash_to<
+            G1,
+            W<
+                W<u8, u8, u8, u8, u8, u8, u8, u8>,
+                W<u8, u8, u8, u8, u8, u8, u8, u8>,
+                W<u8, u8, u8, u8, u8, u8, u8, u8>,
+                W<u8, u8, u8, u8, u8, u8, u8, u8>,
+                W<u8, u8, u8, u8, u8, u8, u8, u8>,
+                W<u8, u8, u8, u8, u8, u8, u8, u8>,
+                W<u8, u8, u8, u8, u8, u8, u8, u8>,
+                W<u8, u8, u8, u8, u8, u8, u8, u8>
+            >
+        >(&b"DST", &b"message");
+    }
+}

--- a/aptos-move/e2e-move-tests/src/tests/cryptoalgebra.rs
+++ b/aptos-move/e2e-move-tests/src/tests/cryptoalgebra.rs
@@ -1,0 +1,43 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+use crate::{assert_success, tests::common, MoveHarness};
+use aptos_types::{
+    account_address::AccountAddress,
+    transaction::{ExecutionStatus, TransactionStatus},
+};
+
+fn crypto_algebra_type_tag_limit_exceeded(harness: &mut MoveHarness) -> TransactionStatus {
+    let acc = harness.new_account_at(AccountAddress::from_hex_literal("0xbeef").unwrap());
+    assert_success!(harness.publish_package(&acc, &common::test_dir_path("cryptoalgebra.data/p"),));
+
+    harness.run_entry_function(
+        &acc,
+        str::parse("0xbeef::test::run").unwrap(),
+        vec![],
+        vec![],
+    )
+}
+
+#[test]
+#[should_panic]
+fn crypto_algebra_type_tag_limit_exceeded_not_handled() {
+    let mut h = MoveHarness::new();
+    crypto_algebra_type_tag_limit_exceeded(&mut h);
+}
+
+#[test]
+fn crypto_algebra_type_tag_limit_exceeded_handled() {
+    let mut h = MoveHarness::new();
+    h.new_epoch();
+    let result = crypto_algebra_type_tag_limit_exceeded(&mut h);
+
+    assert!(
+        matches!(
+            result,
+            TransactionStatus::Keep(ExecutionStatus::MoveAbort { .. })
+        ),
+        "result: {:?}",
+        result
+    );
+}

--- a/aptos-move/e2e-move-tests/src/tests/mod.rs
+++ b/aptos-move/e2e-move-tests/src/tests/mod.rs
@@ -16,6 +16,7 @@ mod chain_id;
 mod code_publishing;
 mod common;
 mod constructor_args;
+mod cryptoalgebra;
 mod dependencies;
 mod enum_upgrade;
 mod enum_upgrade_fv;

--- a/third_party/move/move-vm/runtime/src/config.rs
+++ b/third_party/move/move-vm/runtime/src/config.rs
@@ -56,6 +56,11 @@ pub struct VMConfig {
     /// Whether this VM should support debugging. If set, environment variables
     /// `MOVE_VM_TRACE` and `MOVE_VM_STEP` will be recognized.
     pub enable_debugging: bool,
+    /// When enabled, checks the depth of captured values when packing closures.
+    /// This prevents deeply nested closure chains that could cause stack overflow.
+    /// Also controls whether error messages format values (which could cause stack
+    /// overflow during Display formatting).
+    pub enable_closure_depth_check: bool,
 }
 
 impl Default for VMConfig {
@@ -85,6 +90,7 @@ impl Default for VMConfig {
             enable_framework_for_option: true,
             enable_function_caches_for_native_dynamic_dispatch: true,
             enable_debugging: false,
+            enable_closure_depth_check: true,
         }
     }
 }

--- a/third_party/move/move-vm/types/src/values/values_impl.rs
+++ b/third_party/move/move-vm/types/src/values/values_impl.rs
@@ -6169,3 +6169,116 @@ fn check_depth(depth: u64, max_depth: Option<u64>) -> PartialVMResult<()> {
     }
     Ok(())
 }
+
+/// A visitor that checks the depth of values does not exceed a maximum.
+struct DepthCheckingVisitor {
+    max_depth: u64,
+}
+
+impl DepthCheckingVisitor {
+    #[inline]
+    fn check(&self, depth: u64) -> PartialVMResult<()> {
+        if depth > self.max_depth {
+            return Err(PartialVMError::new(StatusCode::VM_MAX_VALUE_DEPTH_REACHED));
+        }
+        Ok(())
+    }
+}
+
+impl ValueVisitor for DepthCheckingVisitor {
+    fn visit_delayed(&mut self, depth: u64, _id: DelayedFieldID) -> PartialVMResult<()> {
+        self.check(depth)
+    }
+
+    fn visit_u8(&mut self, depth: u64, _val: u8) -> PartialVMResult<()> {
+        self.check(depth)
+    }
+
+    fn visit_u16(&mut self, depth: u64, _val: u16) -> PartialVMResult<()> {
+        self.check(depth)
+    }
+
+    fn visit_u32(&mut self, depth: u64, _val: u32) -> PartialVMResult<()> {
+        self.check(depth)
+    }
+
+    fn visit_u64(&mut self, depth: u64, _val: u64) -> PartialVMResult<()> {
+        self.check(depth)
+    }
+
+    fn visit_u128(&mut self, depth: u64, _val: u128) -> PartialVMResult<()> {
+        self.check(depth)
+    }
+
+    fn visit_u256(
+        &mut self,
+        depth: u64,
+        _val: &move_core_types::int256::U256,
+    ) -> PartialVMResult<()> {
+        self.check(depth)
+    }
+
+    fn visit_i8(&mut self, depth: u64, _val: i8) -> PartialVMResult<()> {
+        self.check(depth)
+    }
+
+    fn visit_i16(&mut self, depth: u64, _val: i16) -> PartialVMResult<()> {
+        self.check(depth)
+    }
+
+    fn visit_i32(&mut self, depth: u64, _val: i32) -> PartialVMResult<()> {
+        self.check(depth)
+    }
+
+    fn visit_i64(&mut self, depth: u64, _val: i64) -> PartialVMResult<()> {
+        self.check(depth)
+    }
+
+    fn visit_i128(&mut self, depth: u64, _val: i128) -> PartialVMResult<()> {
+        self.check(depth)
+    }
+
+    fn visit_i256(
+        &mut self,
+        depth: u64,
+        _val: &move_core_types::int256::I256,
+    ) -> PartialVMResult<()> {
+        self.check(depth)
+    }
+
+    fn visit_bool(&mut self, depth: u64, _val: bool) -> PartialVMResult<()> {
+        self.check(depth)
+    }
+
+    fn visit_address(&mut self, depth: u64, _val: &AccountAddress) -> PartialVMResult<()> {
+        self.check(depth)
+    }
+
+    fn visit_struct(&mut self, depth: u64, _len: usize) -> PartialVMResult<bool> {
+        self.check(depth)?;
+        Ok(true) // continue into fields
+    }
+
+    fn visit_closure(&mut self, depth: u64, _len: usize) -> PartialVMResult<bool> {
+        self.check(depth)?;
+        Ok(true) // continue into captured values
+    }
+
+    fn visit_vec(&mut self, depth: u64, _len: usize) -> PartialVMResult<bool> {
+        self.check(depth)?;
+        Ok(true) // continue into elements
+    }
+
+    fn visit_ref(&mut self, depth: u64, _is_global: bool) -> PartialVMResult<bool> {
+        self.check(depth)?;
+        Ok(true) // continue into referenced value
+    }
+}
+
+impl Value {
+    /// Check that the depth of this value does not exceed `max_depth`.
+    /// Returns an error with `VM_MAX_VALUE_DEPTH_REACHED` if the depth is exceeded.
+    pub fn check_depth_of_value(&self, max_depth: u64) -> PartialVMResult<()> {
+        self.visit(&mut DepthCheckingVisitor { max_depth })
+    }
+}

--- a/types/src/on_chain_config/timed_features.rs
+++ b/types/src/on_chain_config/timed_features.rs
@@ -25,6 +25,17 @@ pub enum TimedFeatureFlag {
 
     /// Fixes the bug that table natives double count the memory usage of the global values.
     FixTableNativesMemoryDoubleCounting,
+
+    /// Enables depth checking for captured values when packing closures.
+    /// This prevents deeply nested closure chains that could cause stack overflow.
+    ClosureDepthCheck,
+
+    /// Fixes handling of results in crypto algebra natives.
+    FixCryptoAlgebraNativesResultHandling,
+
+    /// Use the full transaction size (including authenticator) for gas checks
+    /// instead of just the raw transaction size.
+    UseFullTransactionSizeForGasCheck,
 }
 
 /// Representation of features that are gated by the block timestamps.
@@ -131,6 +142,43 @@ impl TimedFeatureFlag {
                 .with_timezone(&Utc),
             (FixTableNativesMemoryDoubleCounting, MAINNET) => Los_Angeles
                 .with_ymd_and_hms(2025, 10, 21, 10, 0, 0)
+                .unwrap()
+                .with_timezone(&Utc),
+
+            // Security fix: check depth of captured values when packing closures.
+            (ClosureDepthCheck, TESTNET) => Los_Angeles
+                .with_ymd_and_hms(2026, 2, 2, 22, 0, 0)
+                .unwrap()
+                .with_timezone(&Utc),
+            (ClosureDepthCheck, MAINNET) => Los_Angeles
+                .with_ymd_and_hms(2026, 2, 5, 10, 0, 0)
+                .unwrap()
+                .with_timezone(&Utc),
+
+            // For testing, time set to 1 hour after the beginning of time to test the old and new behaviors in tests.
+            (FixCryptoAlgebraNativesResultHandling, TESTING) => {
+                Utc.with_ymd_and_hms(1970, 1, 1, 1, 0, 0).unwrap()
+            },
+            (FixCryptoAlgebraNativesResultHandling, TESTNET) => Los_Angeles
+                .with_ymd_and_hms(2026, 2, 2, 22, 0, 0)
+                .unwrap()
+                .with_timezone(&Utc),
+            (FixCryptoAlgebraNativesResultHandling, MAINNET) => Los_Angeles
+                .with_ymd_and_hms(2026, 2, 5, 10, 0, 0)
+                .unwrap()
+                .with_timezone(&Utc),
+
+            // Note: This is needed to allow forge to undergo a gated transition as well.
+            (UseFullTransactionSizeForGasCheck, TESTING) => Los_Angeles
+                .with_ymd_and_hms(2026, 2, 16, 10, 0, 0)
+                .unwrap()
+                .with_timezone(&Utc),
+            (UseFullTransactionSizeForGasCheck, TESTNET) => Los_Angeles
+                .with_ymd_and_hms(2026, 2, 2, 22, 0, 0)
+                .unwrap()
+                .with_timezone(&Utc),
+            (UseFullTransactionSizeForGasCheck, MAINNET) => Los_Angeles
+                .with_ymd_and_hms(2026, 2, 5, 10, 0, 0)
                 .unwrap()
                 .with_timezone(&Utc),
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches VM execution safety checks and transaction gas validation; while feature-gated, it can change failure modes and gas/size accounting once the timed flags activate.
> 
> **Overview**
> Introduces three new **timestamp-gated hotfixes** via `TimedFeatureFlag`: `ClosureDepthCheck`, `FixCryptoAlgebraNativesResultHandling`, and `UseFullTransactionSizeForGasCheck` (with activation schedules added for testnet/mainnet).
> 
> When `ClosureDepthCheck` is enabled, the Move VM enforces a max-depth check over values captured when packing closures and avoids formatting deeply nested `Value`s in resource-serialization error messages to prevent potential stack overflows.
> 
> When `UseFullTransactionSizeForGasCheck` is enabled, gas/size checks switch from raw-transaction bytes to *full* signed transaction size (including authenticator) by threading `TimedFeatures` into `TransactionMetadata::new` and updating callers.
> 
> When `FixCryptoAlgebraNativesResultHandling` is enabled, crypto algebra `hash_to_structure` no longer `unwrap()`s failed type-to-type-tag conversion; it aborts with a deterministic internal error instead, and adds a new e2e test covering the previously unhandled failure case.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1d6f981306942fbcf41b7f6bde12abcf02bdf607. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->