### PR TITLE
[staking_contract] accurate staker and operator pending attributions

### DIFF
--- a/aptos-move/framework/aptos-framework/sources/staking_contract.move
+++ b/aptos-move/framework/aptos-framework/sources/staking_contract.move
@@ -376,6 +376,37 @@ module aptos_framework::staking_contract {
         account::create_resource_address(&staker, seed)
     }
 
+    #[view]
+    /// Returns the current pending amount attributable to a specific account
+    /// as recorded in the staking contract's distribution_pool.
+    ///
+    /// IMPORTANT SEMANTICS:
+    /// - This function returns a SNAPSHOT of the staking contract's attribution ledger.
+    ///   It reflects amounts that have been unlocked and recorded via the contract,
+    ///   but NOT necessarily the stake pool's latest withdrawable balances.
+    /// - The returned value does NOT automatically reflect newly unlocked stake or commission
+    ///   unless the contract state has been advanced (e.g. via unlock or distribute paths).
+    /// - Operator commission is recorded under the operator address in the distribution_pool,
+    ///   but may ultimately be paid to a separate beneficiary address during distribution.
+    ///   Call `beneficiary_for_operator(operator)` to determine the final recipient.
+    ///
+    /// USAGE NOTES:
+    /// - To query the staker's pending amount, pass `account = staker`.
+    /// - To query the operator's pending commission, pass `account = operator`.
+    /// - In operator-switch scenarios, the previous operator may still have a
+    ///   non-zero pending attribution; in that case, pass `account = old_operator`.
+    ///
+    /// This function MUST NOT be interpreted as a real-time or pool-level balance.
+    public fun pending_attribution_snapshot(
+        staker: address, operator: address, account: address
+    ): u64 {
+        assert_staking_contract_exists(staker, operator);
+        let staking_contracts = &Store[staker].staking_contracts;
+        let staking_contract = staking_contracts.borrow(&operator);
+
+        staking_contract.distribution_pool.balance(account)
+    }
+
     /// Staker can call this function to create a simple staking contract with a specified operator.
     public entry fun create_staking_contract(
         staker: &signer,
@@ -453,7 +484,9 @@ module aptos_framework::staking_contract {
 
         // Create the contract record.
         let pool_address = signer::address_of(&stake_pool_signer);
-        staking_contracts.add(operator, StakingContract {
+        staking_contracts.add(
+            operator,
+            StakingContract {
                 principal,
                 pool_address,
                 owner_cap,
@@ -463,7 +496,8 @@ module aptos_framework::staking_contract {
                 // many pending distributions. This can lead to out-of-gas failure whenever distribute() is called.
                 distribution_pool: pool_u64::create(MAXIMUM_PENDING_DISTRIBUTIONS),
                 signer_cap: stake_pool_signer_cap
-            });
+            }
+        );
 
         if (std::features::module_event_migration_enabled()) {
             emit(
@@ -498,8 +532,7 @@ module aptos_framework::staking_contract {
         assert_staking_contract_exists(staker_address, operator);
 
         let store = borrow_global_mut<Store>(staker_address);
-        let staking_contract =
-            store.staking_contracts.borrow_mut(&operator);
+        let staking_contract = store.staking_contracts.borrow_mut(&operator);
 
         // Add the stake to the stake pool.
         let staked_coins = coin::withdraw<AptosCoin>(staker, amount);
@@ -525,8 +558,7 @@ module aptos_framework::staking_contract {
         assert_staking_contract_exists(staker_address, operator);
 
         let store = borrow_global_mut<Store>(staker_address);
-        let staking_contract =
-            store.staking_contracts.borrow_mut(&operator);
+        let staking_contract = store.staking_contracts.borrow_mut(&operator);
         let pool_address = staking_contract.pool_address;
         let old_voter = stake::get_delegated_voter(pool_address);
         stake::set_delegated_voter_with_cap(&staking_contract.owner_cap, new_voter);
@@ -549,8 +581,7 @@ module aptos_framework::staking_contract {
         assert_staking_contract_exists(staker_address, operator);
 
         let store = borrow_global_mut<Store>(staker_address);
-        let staking_contract =
-            store.staking_contracts.borrow_mut(&operator);
+        let staking_contract = store.staking_contracts.borrow_mut(&operator);
         let pool_address = staking_contract.pool_address;
         stake::increase_lockup_with_cap(&staking_contract.owner_cap);
 
@@ -581,8 +612,7 @@ module aptos_framework::staking_contract {
         );
 
         let store = borrow_global_mut<Store>(staker_address);
-        let staking_contract =
-            store.staking_contracts.borrow_mut(&operator);
+        let staking_contract = store.staking_contracts.borrow_mut(&operator);
         distribute_internal(
             staker_address,
             operator,
@@ -645,8 +675,7 @@ module aptos_framework::staking_contract {
         assert_staking_contract_exists(staker, operator);
 
         let store = borrow_global_mut<Store>(staker);
-        let staking_contract =
-            store.staking_contracts.borrow_mut(&operator);
+        let staking_contract = store.staking_contracts.borrow_mut(&operator);
         // Short-circuit if zero commission.
         if (staking_contract.commission_percentage == 0) { return };
 
@@ -732,8 +761,7 @@ module aptos_framework::staking_contract {
         assert_staking_contract_exists(staker_address, operator);
 
         let store = borrow_global_mut<Store>(staker_address);
-        let staking_contract =
-            store.staking_contracts.borrow_mut(&operator);
+        let staking_contract = store.staking_contracts.borrow_mut(&operator);
 
         // Force distribution of any already inactive stake.
         distribute_internal(
@@ -913,8 +941,7 @@ module aptos_framework::staking_contract {
     ) acquires Store, BeneficiaryForOperator {
         assert_staking_contract_exists(staker, operator);
         let store = borrow_global_mut<Store>(staker);
-        let staking_contract =
-            store.staking_contracts.borrow_mut(&operator);
+        let staking_contract = store.staking_contracts.borrow_mut(&operator);
         distribute_internal(
             staker,
             operator,
@@ -1102,13 +1129,12 @@ module aptos_framework::staking_contract {
         // Charge all stakeholders (except for the operator themselves) commission on any rewards earnt relatively to the
         // previous value of the distribution pool.
         let shareholders = &distribution_pool.shareholders();
-        shareholders.for_each_ref(|shareholder| {
+        shareholders.for_each_ref(
+            |shareholder| {
                 let shareholder: address = *shareholder;
                 if (shareholder != operator) {
                     let shares = pool_u64::shares(distribution_pool, shareholder);
-                    let previous_worth = pool_u64::balance(
-                        distribution_pool, shareholder
-                    );
+                    let previous_worth = pool_u64::balance(distribution_pool, shareholder);
                     let current_worth =
                         pool_u64::shares_to_amount_with_total_coins(
                             distribution_pool, shares, updated_total_coins
@@ -1122,13 +1148,11 @@ module aptos_framework::staking_contract {
                             distribution_pool, unpaid_commission, updated_total_coins
                         );
                     pool_u64::transfer_shares(
-                        distribution_pool,
-                        shareholder,
-                        operator,
-                        shares_to_transfer
+                        distribution_pool, shareholder, operator, shares_to_transfer
                     );
                 };
-            });
+            }
+        );
 
         distribution_pool.update_total_coins(updated_total_coins);
     }
@@ -2242,8 +2266,7 @@ module aptos_framework::staking_contract {
     ) acquires Store {
         let staking_contract =
             borrow_global<Store>(staker).staking_contracts.borrow(&operator);
-        let distribution_balance =
-            staking_contract.distribution_pool.balance(recipient);
+        let distribution_balance = staking_contract.distribution_pool.balance(recipient);
         assert!(distribution_balance == coins_amount, distribution_balance);
     }
 }

--- a/aptos-move/framework/aptos-framework/sources/staking_contract.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/staking_contract.spec.move
@@ -79,7 +79,8 @@ spec aptos_framework::staking_contract {
     spec stake_pool_address(staker: address, operator: address): address {
         include ContractExistsAbortsIf;
         let staking_contracts = global<Store>(staker).staking_contracts;
-        ensures result == simple_map::spec_get(staking_contracts, operator).pool_address;
+        ensures result
+            == simple_map::spec_get(staking_contracts, operator).pool_address;
 
     }
 
@@ -94,7 +95,8 @@ spec aptos_framework::staking_contract {
     spec commission_percentage(staker: address, operator: address): u64 {
         include ContractExistsAbortsIf;
         let staking_contracts = global<Store>(staker).staking_contracts;
-        ensures result == simple_map::spec_get(staking_contracts, operator).commission_percentage;
+        ensures result
+            == simple_map::spec_get(staking_contracts, operator).commission_percentage;
     }
 
     /// Staking_contract exists the stacker/operator pair.
@@ -140,9 +142,8 @@ spec aptos_framework::staking_contract {
     }
 
     spec fun spec_staking_contract_exists(staker: address, operator: address): bool {
-        if (!exists<Store>(staker)) {
-            false
-        } else {
+        if (!exists<Store>(staker)) { false }
+        else {
             let store = global<Store>(staker);
             simple_map::spec_contains_key(store.staking_contracts, operator)
         }
@@ -150,12 +151,12 @@ spec aptos_framework::staking_contract {
 
     /// Account is not frozen and sufficient to withdraw.
     spec create_staking_contract(
-    staker: &signer,
-    operator: address,
-    voter: address,
-    amount: u64,
-    commission_percentage: u64,
-    contract_creation_seed: vector<u8>,
+        staker: &signer,
+        operator: address,
+        voter: address,
+        amount: u64,
+        commission_percentage: u64,
+        contract_creation_seed: vector<u8>
     ) {
         pragma aborts_if_is_partial;
         pragma verify_duration_estimate = 120;
@@ -168,12 +169,12 @@ spec aptos_framework::staking_contract {
     /// Initialize Store resource if this is the first time the staker has delegated to anyone.
     /// Cannot create the staking contract if it already exists.
     spec create_staking_contract_with_coins(
-    staker: &signer,
-    operator: address,
-    voter: address,
-    coins: Coin<AptosCoin>,
-    commission_percentage: u64,
-    contract_creation_seed: vector<u8>,
+        staker: &signer,
+        operator: address,
+        voter: address,
+        coins: Coin<AptosCoin>,
+        commission_percentage: u64,
+        contract_creation_seed: vector<u8>
     ): address {
         pragma verify_duration_estimate = 120;
         pragma aborts_if_is_partial;
@@ -215,7 +216,9 @@ spec aptos_framework::staking_contract {
         include stake::AddStakeWithCapAbortsIfAndEnsures { owner_cap };
 
         let post post_store = global<Store>(staker_address);
-        let post post_staking_contract = simple_map::spec_get(post_store.staking_contracts, operator);
+        let post post_staking_contract = simple_map::spec_get(
+            post_store.staking_contracts, operator
+        );
         aborts_if staking_contract.principal + amount > MAX_U64;
 
         // property 3: Adding stake to the stake pool increases the principal value of the pool, reflecting the
@@ -230,7 +233,9 @@ spec aptos_framework::staking_contract {
         include UpdateVoterSchema { staker: staker_address };
 
         let post store = global<Store>(staker_address);
-        let post staking_contract = simple_map::spec_get(store.staking_contracts, operator);
+        let post staking_contract = simple_map::spec_get(
+            store.staking_contracts, operator
+        );
         let post pool_address = staking_contract.owner_cap.pool_address;
         let post new_delegated_voter = global<stake::StakePool>(pool_address).delegated_voter;
         // property 4: The staker may update the voter of a staking contract, enabling them
@@ -248,7 +253,7 @@ spec aptos_framework::staking_contract {
         include IncreaseLockupWithCapAbortsIf { staker: staker_address };
     }
 
-    spec update_commision (staker: &signer, operator: address, new_commission_percentage: u64) {
+    spec update_commision(staker: &signer, operator: address, new_commission_percentage: u64) {
         // TODO: Call `distribute_internal` and could not verify `update_distribution_pool`.
         // TODO: A data invariant not hold happened here involve with 'pool_u64' #L16.
         pragma verify = false;
@@ -268,10 +273,10 @@ spec aptos_framework::staking_contract {
     }
 
     spec request_commission_internal(
-    operator: address,
-    staking_contract: &mut StakingContract,
-    add_distribution_events: &mut EventHandle<AddDistributionEvent>,
-    request_commission_events: &mut EventHandle<RequestCommissionEvent>,
+        operator: address,
+        staking_contract: &mut StakingContract,
+        add_distribution_events: &mut EventHandle<AddDistributionEvent>,
+        request_commission_events: &mut EventHandle<RequestCommissionEvent>
     ): u64 {
         // TODO: A data invariant not hold happened here involve with 'pool_u64' #L16.
         pragma verify = false;
@@ -299,9 +304,7 @@ spec aptos_framework::staking_contract {
 
     /// Staking_contract exists the stacker/operator pair.
     spec switch_operator_with_same_commission(
-    staker: &signer,
-    old_operator: address,
-    new_operator: address,
+        staker: &signer, old_operator: address, new_operator: address
     ) {
         // TODO: These function passed locally however failed in github CI
         pragma verify_duration_estimate = 120;
@@ -313,10 +316,10 @@ spec aptos_framework::staking_contract {
 
     /// Staking_contract exists the stacker/operator pair.
     spec switch_operator(
-    staker: &signer,
-    old_operator: address,
-    new_operator: address,
-    new_commission_percentage: u64,
+        staker: &signer,
+        old_operator: address,
+        new_operator: address,
+        new_commission_percentage: u64
     ) {
         // TODO: Call `update_distribution_pool` and could not verify `update_distribution_pool`.
         // TODO: Set because of timeout (estimate unknown).
@@ -338,6 +341,10 @@ spec aptos_framework::staking_contract {
         pragma verify = false;
     }
 
+    spec pending_attribution_snapshot(staker: address, operator: address, account: address): u64 {
+        pragma verify = false;
+    }
+
     /// Staking_contract exists the stacker/operator pair.
     spec distribute(staker: address, operator: address) {
         // TODO: These function passed locally however failed in github CI
@@ -351,10 +358,10 @@ spec aptos_framework::staking_contract {
     /// The StakePool exists under the pool_address of StakingContract.
     /// The value of inactive and pending_inactive in the stake_pool is up to MAX_U64.
     spec distribute_internal(
-    staker: address,
-    operator: address,
-    staking_contract: &mut StakingContract,
-    distribute_events: &mut EventHandle<DistributeEvent>,
+        staker: address,
+        operator: address,
+        staking_contract: &mut StakingContract,
+        distribute_events: &mut EventHandle<DistributeEvent>
     ) {
         // TODO: These function passed locally however failed in github CI
         pragma verify_duration_estimate = 120;
@@ -363,7 +370,8 @@ spec aptos_framework::staking_contract {
         let pool_address = staking_contract.pool_address;
         let stake_pool = borrow_global<stake::StakePool>(pool_address);
         aborts_if !exists<stake::StakePool>(pool_address);
-        aborts_if stake_pool.inactive.value + stake_pool.pending_inactive.value > MAX_U64;
+        aborts_if stake_pool.inactive.value + stake_pool.pending_inactive.value
+            > MAX_U64;
         aborts_if !exists<stake::StakePool>(staking_contract.owner_cap.pool_address);
     }
 
@@ -373,18 +381,20 @@ spec aptos_framework::staking_contract {
     }
 
     spec add_distribution(
-    operator: address,
-    staking_contract: &mut StakingContract,
-    recipient: address,
-    coins_amount: u64,
-    add_distribution_events: &mut EventHandle<AddDistributionEvent>,
+        operator: address,
+        staking_contract: &mut StakingContract,
+        recipient: address,
+        coins_amount: u64,
+        add_distribution_events: &mut EventHandle<AddDistributionEvent>
     ) {
         // TODO: Call `update_distribution_pool` and could not verify `update_distribution_pool`.
         pragma verify = false;
     }
 
     /// The StakePool exists under the pool_address of StakingContract.
-    spec get_staking_contract_amounts_internal(staking_contract: &StakingContract): (u64, u64, u64) {
+    spec get_staking_contract_amounts_internal(staking_contract: &StakingContract): (
+        u64, u64, u64
+    ) {
         pragma verify_duration_estimate = 120;
         include GetStakingContractAmountsAbortsIf;
 
@@ -394,17 +404,18 @@ spec aptos_framework::staking_contract {
         let pending_active = coin::value(stake_pool.pending_active);
         let total_active_stake = active + pending_active;
         let accumulated_rewards = total_active_stake - staking_contract.principal;
-        let commission_amount = accumulated_rewards * staking_contract.commission_percentage / 100;
+        let commission_amount = accumulated_rewards
+            * staking_contract.commission_percentage / 100;
         ensures result_1 == total_active_stake;
         ensures result_2 == accumulated_rewards;
         ensures result_3 == commission_amount;
     }
 
     spec create_stake_pool(
-    staker: &signer,
-    operator: address,
-    voter: address,
-    contract_creation_seed: vector<u8>,
+        staker: &signer,
+        operator: address,
+        voter: address,
+        contract_creation_seed: vector<u8>
     ): (signer, SignerCapability, OwnerCapability) {
         pragma verify_duration_estimate = 120;
         include stake::ResourceRequirement;
@@ -412,13 +423,19 @@ spec aptos_framework::staking_contract {
         // postconditions account::create_resource_account()
 
         let seed_0 = bcs::to_bytes(staker_address);
-        let seed_1 = concat(concat(concat(seed_0, bcs::to_bytes(operator)), SALT), contract_creation_seed);
-        let resource_addr = account::spec_create_resource_address(staker_address, seed_1);
+        let seed_1 = concat(
+            concat(concat(seed_0, bcs::to_bytes(operator)), SALT),
+            contract_creation_seed
+        );
+        let resource_addr = account::spec_create_resource_address(
+            staker_address, seed_1
+        );
         include CreateStakePoolAbortsIf { resource_addr };
         ensures exists<account::Account>(resource_addr);
         let post post_account = global<account::Account>(resource_addr);
         ensures post_account.authentication_key == account::ZERO_AUTH_KEY;
-        ensures post_account.signer_capability_offer.for == std::option::spec_some(resource_addr);
+        ensures post_account.signer_capability_offer.for
+            == std::option::spec_some(resource_addr);
 
         // postconditions stake::initialize_stake_owner()
         ensures exists<stake::StakePool>(resource_addr);
@@ -427,18 +444,20 @@ spec aptos_framework::staking_contract {
         let post post_stake_pool = global<stake::StakePool>(post_pool_address);
         let post post_operator = post_stake_pool.operator_address;
         let post post_delegated_voter = post_stake_pool.delegated_voter;
-        ensures resource_addr != operator ==> post_operator == operator;
-        ensures resource_addr != voter ==> post_delegated_voter == voter;
+        ensures resource_addr != operator ==>
+            post_operator == operator;
+        ensures resource_addr != voter ==>
+            post_delegated_voter == voter;
         ensures signer::address_of(result_1) == resource_addr;
         ensures result_2 == SignerCapability { account: resource_addr };
         ensures result_3 == OwnerCapability { pool_address: resource_addr };
     }
 
     spec update_distribution_pool(
-    distribution_pool: &mut Pool,
-    updated_total_coins: u64,
-    operator: address,
-    commission_percentage: u64,
+        distribution_pool: &mut Pool,
+        updated_total_coins: u64,
+        operator: address,
+        commission_percentage: u64
     ) {
         // TODO: complex aborts conditions in the cycle.
         // pragma verify = false;
@@ -511,7 +530,8 @@ spec aptos_framework::staking_contract {
         aborts_if active + pending_active > MAX_U64;
         // TODO: These function causes the timeout
         aborts_if total_active_stake < staking_contract.principal;
-        aborts_if accumulated_rewards * staking_contract.commission_percentage > MAX_U64;
+        aborts_if accumulated_rewards * staking_contract.commission_percentage
+            > MAX_U64;
     }
 
     spec schema IncreaseLockupWithCapAbortsIf {
@@ -530,17 +550,21 @@ spec aptos_framework::staking_contract {
         let config = global<staking_config::StakingConfig>(@aptos_framework);
         let stake_pool = global<stake::StakePool>(pool_address);
         let old_locked_until_secs = stake_pool.locked_until_secs;
-        let seconds = global<timestamp::CurrentTimeMicroseconds>(
-            @aptos_framework
-        ).microseconds / timestamp::MICRO_CONVERSION_FACTOR;
+        let seconds = global<timestamp::CurrentTimeMicroseconds>(@aptos_framework).microseconds
+            / timestamp::MICRO_CONVERSION_FACTOR;
         let new_locked_until_secs = seconds + config.recurring_lockup_duration_secs;
         aborts_if seconds + config.recurring_lockup_duration_secs > MAX_U64;
-        aborts_if old_locked_until_secs > new_locked_until_secs || old_locked_until_secs == new_locked_until_secs;
+        aborts_if old_locked_until_secs > new_locked_until_secs
+            || old_locked_until_secs == new_locked_until_secs;
         aborts_if !exists<timestamp::CurrentTimeMicroseconds>(@aptos_framework);
 
         let post post_store = global<Store>(staker);
-        let post post_staking_contract = simple_map::spec_get(post_store.staking_contracts, operator);
-        let post post_stake_pool = global<stake::StakePool>(post_staking_contract.owner_cap.pool_address);
+        let post post_staking_contract = simple_map::spec_get(
+            post_store.staking_contracts, operator
+        );
+        let post post_stake_pool = global<stake::StakePool>(
+            post_staking_contract.owner_cap.pool_address
+        );
         ensures post_stake_pool.locked_until_secs == new_locked_until_secs;
     }
 
@@ -560,8 +584,10 @@ spec aptos_framework::staking_contract {
 
         let staker_address = signer::address_of(staker);
         let account = global<account::Account>(staker_address);
-        aborts_if !exists<Store>(staker_address) && !exists<account::Account>(staker_address);
-        aborts_if !exists<Store>(staker_address) && account.guid_creation_num + 9 >= account::MAX_GUID_CREATION_NUM;
+        aborts_if !exists<Store>(staker_address)
+            && !exists<account::Account>(staker_address);
+        aborts_if !exists<Store>(staker_address)
+            && account.guid_creation_num + 9 >= account::MAX_GUID_CREATION_NUM;
         /// [high-level-req-1]
         ensures exists<Store>(staker_address);
 
@@ -577,7 +603,6 @@ spec aptos_framework::staking_contract {
         // let resource_addr = account::spec_create_resource_address(staker_address, seed_1);
         // include CreateStakePoolAbortsIf {resource_addr};
 
-
         // Verify stake::add_stake_with_cap()
         let owner_cap = simple_map::spec_get(store.staking_contracts, operator).owner_cap;
         // TODO: this property causes timeout
@@ -591,10 +616,11 @@ spec aptos_framework::staking_contract {
     spec schema PreconditionsInCreateContract {
         requires exists<stake::ValidatorPerformance>(@aptos_framework);
         requires exists<stake::ValidatorSet>(@aptos_framework);
-        requires exists<staking_config::StakingRewardsConfig>(
+        requires exists<staking_config::StakingRewardsConfig>(@aptos_framework)
+            || !std::features::spec_periodical_reward_rate_decrease_enabled();
+        requires exists<aptos_framework::timestamp::CurrentTimeMicroseconds>(
             @aptos_framework
-        ) || !std::features::spec_periodical_reward_rate_decrease_enabled();
-        requires exists<aptos_framework::timestamp::CurrentTimeMicroseconds>(@aptos_framework);
+        );
         requires exists<stake::AptosCoinCapabilities>(@aptos_framework);
     }
 
@@ -606,19 +632,24 @@ spec aptos_framework::staking_contract {
 
         // postconditions account::create_resource_account()
         let acc = global<account::Account>(resource_addr);
-        aborts_if exists<account::Account>(resource_addr) && (std::option::is_some(acc.signer_capability_offer.for) || acc.sequence_number != 0);
-        aborts_if !exists<account::Account>(resource_addr) && len(bcs::to_bytes(resource_addr)) != 32;
+        aborts_if exists<account::Account>(resource_addr)
+            && (
+                std::option::is_some(acc.signer_capability_offer.for)
+                    || acc.sequence_number != 0
+            );
+        aborts_if !exists<account::Account>(resource_addr)
+            && len(bcs::to_bytes(resource_addr)) != 32;
         aborts_if len(account::ZERO_AUTH_KEY) != 32;
 
         // postconditions stake::initialize_stake_owner()
         aborts_if exists<stake::ValidatorConfig>(resource_addr);
         let allowed = global<stake::AllowedValidators>(@aptos_framework);
-        aborts_if exists<stake::AllowedValidators>(@aptos_framework) && !contains(allowed.accounts, resource_addr);
+        aborts_if exists<stake::AllowedValidators>(@aptos_framework)
+            && !contains(allowed.accounts, resource_addr);
         aborts_if exists<stake::StakePool>(resource_addr);
         aborts_if exists<stake::OwnerCapability>(resource_addr);
         // 12 is the times that calls 'events::guids'
-        aborts_if exists<account::Account>(
-            resource_addr
-        ) && acc.guid_creation_num + 12 >= account::MAX_GUID_CREATION_NUM;
+        aborts_if exists<account::Account>(resource_addr)
+            && acc.guid_creation_num + 12 >= account::MAX_GUID_CREATION_NUM;
     }
 }


### PR DESCRIPTION
## Description
Add a view function to reflect the pending attributions.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new on-chain view into staking contract attribution state and switches Rosetta’s `pending_inactive` balance calculation to depend on it; incorrect semantics or API/BCS handling could surface wrong balances to clients.
> 
> **Overview**
> Adds `pending_attribution_snapshot` as a new `#[view]` in `staking_contract` to return the current per-account pending amount recorded in the contract’s `distribution_pool` (documented as a ledger snapshot, not a live pool balance), with spec/docs updates and `pragma verify = false` for the new spec.
> 
> Updates `aptos-rosetta` to compute `pending_inactive_stake` by calling the new view (handling the `Vec<u64>`-wrapped BCS response) instead of using `stake_pool.pending_inactive`, and includes minor formatting-only refactors in staking contract/spec code.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 29961b3d343ddb32b82a30ebb10d52c3a27073f7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->