### PR TITLE
[Storage] Add a tool to check stale nodes that should be pruned but haven't.

### DIFF
--- a/storage/aptosdb/src/db_debugger/state_tree/check_stale_nodes.rs
+++ b/storage/aptosdb/src/db_debugger/state_tree/check_stale_nodes.rs
@@ -1,0 +1,141 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+use crate::{
+    db_debugger::common::DbDir,
+    schema::{
+        db_metadata::DbMetadataKey, stale_node_index::StaleNodeIndexSchema,
+        stale_node_index_cross_epoch::StaleNodeIndexCrossEpochSchema,
+    },
+    utils::get_progress,
+};
+use aptos_jellyfish_merkle::StaleNodeIndex;
+use aptos_schemadb::{schema::Schema, DB};
+use aptos_storage_interface::Result;
+use clap::Parser;
+use std::collections::BTreeMap;
+
+const DEFAULT_LIMIT_PER_DB: usize = 20;
+
+#[derive(Parser)]
+#[clap(about = "Check for stale JMT nodes that should have been pruned.")]
+pub struct Cmd {
+    #[clap(flatten)]
+    db_dir: DbDir,
+
+    #[clap(long, default_value_t = DEFAULT_LIMIT_PER_DB)]
+    limit_per_db: usize,
+}
+
+impl Cmd {
+    pub fn run(self) -> Result<()> {
+        let state_merkle_db = self.db_dir.open_state_merkle_db()?;
+
+        // Step 1: Read pruner progress.
+        let p1 = get_progress(
+            state_merkle_db.metadata_db(),
+            &DbMetadataKey::StateMerklePrunerProgress,
+        )?
+        .unwrap_or(0);
+        let p2 = get_progress(
+            state_merkle_db.metadata_db(),
+            &DbMetadataKey::EpochEndingStateMerklePrunerProgress,
+        )?
+        .unwrap_or(0);
+
+        println!("State Merkle Pruner progress: {p1}");
+        println!("Epoch Ending State Merkle Pruner progress: {p2}");
+
+        // Step 2: Collect DB handles.
+        let num_shards = state_merkle_db.hack_num_real_shards();
+        let mut dbs: Vec<(String, &DB)> =
+            vec![("metadata".to_string(), state_merkle_db.metadata_db())];
+        for shard_id in 0..num_shards {
+            dbs.push((
+                format!("shard_{shard_id}"),
+                state_merkle_db.db_shard(shard_id),
+            ));
+        }
+
+        // Step 3: Collect leaked stale node indices per DB.
+        let mut regular_leaked: BTreeMap<String, Vec<StaleNodeIndex>> = BTreeMap::new();
+        let mut cross_epoch_leaked: BTreeMap<String, Vec<StaleNodeIndex>> = BTreeMap::new();
+
+        for (db_name, db) in &dbs {
+            println!("Scanning {db_name} for stale node indices...");
+
+            let regular = collect_stale_indices::<StaleNodeIndexSchema>(db, p1, self.limit_per_db)?;
+            let cross_epoch =
+                collect_stale_indices::<StaleNodeIndexCrossEpochSchema>(db, p2, self.limit_per_db)?;
+
+            println!(
+                "Done scanning {db_name}. regular: {}, cross_epoch: {}",
+                regular.len(),
+                cross_epoch.len(),
+            );
+
+            if !regular.is_empty() {
+                regular_leaked.insert(db_name.clone(), regular);
+            }
+            if !cross_epoch.is_empty() {
+                cross_epoch_leaked.insert(db_name.clone(), cross_epoch);
+            }
+        }
+
+        // Step 4: Report.
+        let regular_total: usize = regular_leaked.values().map(|v| v.len()).sum();
+        println!(
+            "\nLeaked regular stale node indices (stale_since_version <= {p1}): {regular_total}"
+        );
+        for (db_name, indices) in &regular_leaked {
+            println!("  {db_name}: {}", indices.len());
+            for index in indices {
+                println!(
+                    "    stale_since_version: {}, node_key: {:?}",
+                    index.stale_since_version, index.node_key,
+                );
+            }
+        }
+
+        let cross_epoch_total: usize = cross_epoch_leaked.values().map(|v| v.len()).sum();
+        println!(
+            "\nLeaked cross-epoch stale node indices (stale_since_version <= {p2}): {cross_epoch_total}"
+        );
+        for (db_name, indices) in &cross_epoch_leaked {
+            println!("  {db_name}: {}", indices.len());
+            for index in indices {
+                println!(
+                    "    stale_since_version: {}, node_key: {:?}",
+                    index.stale_since_version, index.node_key,
+                );
+            }
+        }
+
+        println!("\nTotal leaked: {}", regular_total + cross_epoch_total);
+
+        Ok(())
+    }
+}
+
+/// Collects stale node index entries with `stale_since_version <= progress` in the given DB,
+/// returning at most `limit` entries.
+fn collect_stale_indices<S>(db: &DB, progress: u64, limit: usize) -> Result<Vec<StaleNodeIndex>>
+where
+    S: Schema<Key = StaleNodeIndex, Value = ()>,
+    StaleNodeIndex: aptos_schemadb::schema::KeyCodec<S>,
+{
+    let mut result = Vec::new();
+    let mut iter = db.iter::<S>()?;
+    iter.seek_to_first();
+    for item in iter {
+        let (index, _) = item?;
+        if index.stale_since_version > progress {
+            break;
+        }
+        result.push(index);
+        if result.len() >= limit {
+            break;
+        }
+    }
+    Ok(result)
+}

--- a/storage/aptosdb/src/db_debugger/state_tree/mod.rs
+++ b/storage/aptosdb/src/db_debugger/state_tree/mod.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
+mod check_stale_nodes;
 mod get_leaf;
 mod get_path;
 mod get_snapshots;
@@ -12,6 +13,7 @@ pub enum Cmd {
     GetSnapshots(get_snapshots::Cmd),
     GetPath(get_path::Cmd),
     GetLeaf(get_leaf::Cmd),
+    CheckStaleNodes(check_stale_nodes::Cmd),
 }
 
 impl Cmd {
@@ -20,6 +22,7 @@ impl Cmd {
             Self::GetSnapshots(cmd) => Ok(cmd.run()?),
             Self::GetPath(cmd) => cmd.run(),
             Self::GetLeaf(cmd) => cmd.run(),
+            Self::CheckStaleNodes(cmd) => cmd.run(),
         }
     }
 }


### PR DESCRIPTION


## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Debug-only CLI addition that reads DB state and reports findings; no write-path or pruning logic is modified.
> 
> **Overview**
> Adds a new `db_debugger state_tree` subcommand, `CheckStaleNodes`, to scan the state merkle DB (metadata + all shards) for stale node index entries that have `stale_since_version` at or before the recorded pruner progress.
> 
> The command reads both regular and epoch-ending pruner progress, collects up to a configurable per-DB limit of suspect entries from `StaleNodeIndexSchema` and `StaleNodeIndexCrossEpochSchema`, and prints a per-shard/total report to help diagnose pruning leaks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0826c3373a7a3768b9f66da8b6736d8c46a7c561. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->