### PR TITLE
[Storage] Start a thread to cleanup some stale JMT nodes.

### DIFF
--- a/config/src/config/storage_config.rs
+++ b/config/src/config/storage_config.rs
@@ -320,6 +320,7 @@ pub const NO_OP_STORAGE_PRUNER_CONFIG: PrunerConfig = PrunerConfig {
         prune_window: 0,
         batch_size: 0,
     },
+    stale_node_cleanup_batch_size: 50_000,
 };
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -376,12 +377,26 @@ impl From<EpochSnapshotPrunerConfig> for StateMerklePrunerConfig {
     }
 }
 
-#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize, Default)]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct PrunerConfig {
     pub ledger_pruner_config: LedgerPrunerConfig,
     pub state_merkle_pruner_config: StateMerklePrunerConfig,
     pub epoch_snapshot_pruner_config: EpochSnapshotPrunerConfig,
+    /// Batch size for the one-time leaked stale node cleanup that runs on startup.
+    /// Set to 0 to disable.
+    pub stale_node_cleanup_batch_size: usize,
+}
+
+impl Default for PrunerConfig {
+    fn default() -> Self {
+        Self {
+            ledger_pruner_config: LedgerPrunerConfig::default(),
+            state_merkle_pruner_config: StateMerklePrunerConfig::default(),
+            epoch_snapshot_pruner_config: EpochSnapshotPrunerConfig::default(),
+            stale_node_cleanup_batch_size: 50_000,
+        }
+    }
 }
 
 impl Default for LedgerPrunerConfig {

--- a/execution/executor-benchmark/src/main.rs
+++ b/execution/executor-benchmark/src/main.rs
@@ -105,6 +105,7 @@ impl PrunerOpt {
                 batch_size: self.ledger_pruning_batch_size,
                 user_pruning_window_offset: 0,
             },
+            ..Default::default()
         }
     }
 }

--- a/storage/aptosdb/src/db/aptosdb_test.rs
+++ b/storage/aptosdb/src/db/aptosdb_test.rs
@@ -251,6 +251,7 @@ pub fn test_state_merkle_pruning_impl(
                 prune_window: 10,
                 batch_size: 1,
             },
+            ..Default::default()
         },
         RocksdbConfigs::default(),
         false, /* enable_indexer */

--- a/storage/aptosdb/src/metrics.rs
+++ b/storage/aptosdb/src/metrics.rs
@@ -3,8 +3,8 @@
 
 use aptos_metrics_core::{
     exponential_buckets, make_thread_local_histogram_vec, make_thread_local_int_counter_vec,
-    register_histogram_vec, register_int_counter, register_int_gauge, register_int_gauge_vec,
-    HistogramVec, IntCounter, IntGauge, IntGaugeVec,
+    register_histogram_vec, register_int_counter, register_int_counter_vec, register_int_gauge,
+    register_int_gauge_vec, HistogramVec, IntCounter, IntCounterVec, IntGauge, IntGaugeVec,
 };
 use once_cell::sync::Lazy;
 
@@ -224,6 +224,24 @@ pub static BACKUP_TIMER: Lazy<HistogramVec> = Lazy::new(|| {
         "Various timers for performance analysis.",
         &["name"],
         exponential_buckets(/*start=*/ 1e-6, /*factor=*/ 2.0, /*count=*/ 32).unwrap(),
+    )
+    .unwrap()
+});
+
+pub static STALE_NODE_CLEANUP: Lazy<IntGaugeVec> = Lazy::new(|| {
+    register_int_gauge_vec!(
+        "aptos_storage_stale_node_cleanup",
+        "Stale node cleanup status.",
+        &["db_name", "tag"]
+    )
+    .unwrap()
+});
+
+pub static STALE_NODE_CLEANUP_COUNT: Lazy<IntCounterVec> = Lazy::new(|| {
+    register_int_counter_vec!(
+        "aptos_storage_stale_node_cleanup_count",
+        "Number of stale nodes cleaned up.",
+        &["label"]
     )
     .unwrap()
 });

--- a/storage/aptosdb/src/pruner/mod.rs
+++ b/storage/aptosdb/src/pruner/mod.rs
@@ -13,4 +13,6 @@ mod state_merkle_pruner;
 pub(crate) use ledger_pruner::ledger_pruner_manager::LedgerPrunerManager;
 pub(crate) use pruner_manager::PrunerManager;
 pub(crate) use state_kv_pruner::state_kv_pruner_manager::StateKvPrunerManager;
-pub(crate) use state_merkle_pruner::state_merkle_pruner_manager::StateMerklePrunerManager;
+pub(crate) use state_merkle_pruner::{
+    leaked_stale_node_cleaner, state_merkle_pruner_manager::StateMerklePrunerManager,
+};

--- a/storage/aptosdb/src/pruner/state_merkle_pruner/leaked_stale_node_cleaner.rs
+++ b/storage/aptosdb/src/pruner/state_merkle_pruner/leaked_stale_node_cleaner.rs
@@ -1,0 +1,287 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+use crate::{
+    metrics::{STALE_NODE_CLEANUP, STALE_NODE_CLEANUP_COUNT},
+    schema::{
+        db_metadata::{DbMetadataKey, DbMetadataSchema, DbMetadataValue},
+        jellyfish_merkle_node::JellyfishMerkleNodeSchema,
+        stale_node_index::StaleNodeIndexSchema,
+        stale_node_index_cross_epoch::StaleNodeIndexCrossEpochSchema,
+    },
+    state_merkle_db::StateMerkleDb,
+    utils::get_progress,
+};
+use aptos_jellyfish_merkle::StaleNodeIndex;
+use aptos_logger::{info, warn};
+use aptos_schemadb::{
+    batch::SchemaBatch,
+    schema::{KeyCodec, Schema},
+    DB,
+};
+use aptos_storage_interface::Result;
+use std::sync::Arc;
+
+pub(crate) fn maybe_start_cleaner(state_merkle_db: Arc<StateMerkleDb>, batch_size: usize) {
+    if batch_size == 0 {
+        info!("Stale node cleanup disabled (batch_size=0).");
+        return;
+    }
+
+    let metadata_db = state_merkle_db.metadata_db();
+
+    // Check if cleanup has already been done.
+    match metadata_db.get::<DbMetadataSchema>(&DbMetadataKey::StaleNodeCleanupDone) {
+        Ok(Some(_)) => {
+            info!("Stale node cleanup already done, skipping.");
+            STALE_NODE_CLEANUP
+                .with_label_values(&["overall", "done"])
+                .set(1);
+            return;
+        },
+        Err(e) => {
+            warn!(
+                error = ?e,
+                "Failed to read StaleNodeCleanupDone marker, skipping cleanup."
+            );
+            return;
+        },
+        Ok(None) => {
+            // Marker not found, proceed with cleanup.
+        },
+    }
+
+    // Read or initialize cleanup progress. On first run, snapshot the current pruner progress
+    // and persist it so the same values are used across restarts.
+    let (regular_target_version, epoch_target_version) =
+        match get_or_init_cleanup_progress(metadata_db) {
+            Ok(Some(v)) => v,
+            Ok(None) => {
+                info!("No pruner progress found, skipping stale node cleanup.");
+                return;
+            },
+            Err(e) => {
+                warn!(error = ?e, "Failed to read cleanup progress, skipping stale node cleanup.");
+                return;
+            },
+        };
+
+    STALE_NODE_CLEANUP
+        .with_label_values(&["overall", "target_regular_version"])
+        .set(regular_target_version as i64);
+    STALE_NODE_CLEANUP
+        .with_label_values(&["overall", "target_epoch_version"])
+        .set(epoch_target_version as i64);
+
+    info!(
+        regular_target_version = regular_target_version,
+        epoch_target_version = epoch_target_version,
+        "Starting leaked stale node cleanup background thread."
+    );
+
+    std::thread::Builder::new()
+        .name("stale_node_cleaner".to_string())
+        .spawn(move || {
+            if let Err(e) = run_cleanup(
+                &state_merkle_db,
+                regular_target_version,
+                epoch_target_version,
+                batch_size,
+            ) {
+                warn!(error = ?e, "Stale node cleanup failed.");
+            }
+        })
+        .expect("Failed to spawn stale_node_cleaner thread.");
+}
+
+fn run_cleanup(
+    state_merkle_db: &StateMerkleDb,
+    regular_target_version: u64,
+    epoch_target_version: u64,
+    batch_size: usize,
+) -> Result<()> {
+    let num_shards = state_merkle_db.hack_num_real_shards();
+
+    // Clean shard DBs first.
+    for shard_id in 0..num_shards {
+        let db = state_merkle_db.db_shard(shard_id);
+        let db_name = format!("shard_{shard_id}");
+        clean_single_db(
+            db,
+            regular_target_version,
+            epoch_target_version,
+            &db_name,
+            batch_size,
+        )?;
+    }
+
+    // Clean metadata DB last. Its done marker also serves as the overall done signal.
+    let metadata_db = state_merkle_db.metadata_db();
+    clean_single_db(
+        metadata_db,
+        regular_target_version,
+        epoch_target_version,
+        "metadata",
+        batch_size,
+    )?;
+
+    STALE_NODE_CLEANUP
+        .with_label_values(&["overall", "done"])
+        .set(1);
+
+    info!("Stale node cleanup completed.");
+
+    Ok(())
+}
+
+/// Returns the cleanup progress values, or None if no pruner progress exists.
+/// On first call, snapshots the current pruner progress and persists it. On subsequent
+/// calls (after restart), reads back the persisted values.
+fn get_or_init_cleanup_progress(metadata_db: &DB) -> Result<Option<(u64, u64)>> {
+    // Check if cleanup progress was already persisted from a previous run.
+    let existing_regular =
+        get_progress(metadata_db, &DbMetadataKey::StaleNodeCleanupRegularProgress)?;
+    let existing_epoch = get_progress(metadata_db, &DbMetadataKey::StaleNodeCleanupEpochProgress)?;
+
+    if let (Some(regular), Some(epoch)) = (existing_regular, existing_epoch) {
+        info!(
+            regular_target_version = regular,
+            epoch_target_version = epoch,
+            "Resuming stale node cleanup with persisted progress."
+        );
+        return Ok(Some((regular, epoch)));
+    }
+
+    // First run: snapshot the current pruner progress.
+    let regular = match get_progress(metadata_db, &DbMetadataKey::StateMerklePrunerProgress)? {
+        Some(v) => v,
+        None => return Ok(None),
+    };
+    let epoch = match get_progress(
+        metadata_db,
+        &DbMetadataKey::EpochEndingStateMerklePrunerProgress,
+    )? {
+        Some(v) => v,
+        None => return Ok(None),
+    };
+
+    // Persist the snapshot.
+    let mut batch = SchemaBatch::new();
+    batch.put::<DbMetadataSchema>(
+        &DbMetadataKey::StaleNodeCleanupRegularProgress,
+        &DbMetadataValue::Version(regular),
+    )?;
+    batch.put::<DbMetadataSchema>(
+        &DbMetadataKey::StaleNodeCleanupEpochProgress,
+        &DbMetadataValue::Version(epoch),
+    )?;
+    metadata_db.write_schemas(batch)?;
+
+    info!(
+        regular_target_version = regular,
+        epoch_target_version = epoch,
+        "Persisted stale node cleanup progress for the first time."
+    );
+
+    Ok(Some((regular, epoch)))
+}
+
+fn clean_single_db(
+    db: &DB,
+    regular_target_version: u64,
+    epoch_target_version: u64,
+    db_name: &str,
+    batch_size: usize,
+) -> Result<()> {
+    // Check per-DB done marker.
+    if db
+        .get::<DbMetadataSchema>(&DbMetadataKey::StaleNodeCleanupDone)?
+        .is_some()
+    {
+        info!(
+            db_name = db_name,
+            "Stale node cleanup already done, skipping."
+        );
+        STALE_NODE_CLEANUP
+            .with_label_values(&[db_name, "done"])
+            .set(1);
+        return Ok(());
+    }
+
+    let regular_label = format!("{db_name}_regular");
+    clean_stale_indices::<StaleNodeIndexSchema>(
+        db,
+        regular_target_version,
+        &regular_label,
+        batch_size,
+    )?;
+
+    let cross_epoch_label = format!("{db_name}_cross_epoch");
+    clean_stale_indices::<StaleNodeIndexCrossEpochSchema>(
+        db,
+        epoch_target_version,
+        &cross_epoch_label,
+        batch_size,
+    )?;
+
+    // Write per-DB done marker.
+    let mut batch = SchemaBatch::new();
+    batch.put::<DbMetadataSchema>(
+        &DbMetadataKey::StaleNodeCleanupDone,
+        &DbMetadataValue::Version(0),
+    )?;
+    db.write_schemas(batch)?;
+
+    STALE_NODE_CLEANUP
+        .with_label_values(&[db_name, "done"])
+        .set(1);
+
+    info!(db_name = db_name, "Finished cleaning stale nodes for db.");
+
+    Ok(())
+}
+
+fn clean_stale_indices<S>(
+    db: &DB,
+    target_version: u64,
+    label: &str,
+    batch_size: usize,
+) -> Result<()>
+where
+    S: Schema<Key = StaleNodeIndex, Value = ()>,
+    StaleNodeIndex: KeyCodec<S>,
+{
+    let counter = STALE_NODE_CLEANUP_COUNT.with_label_values(&[label]);
+    let current_version_gauge = STALE_NODE_CLEANUP.with_label_values(&[label, "current_version"]);
+    loop {
+        let mut batch = SchemaBatch::new();
+        let mut count = 0u64;
+        let mut last_version = 0u64;
+
+        let mut iter = db.iter::<S>()?;
+        iter.seek_to_first();
+        for item in iter {
+            let (index, _) = item?;
+            if index.stale_since_version > target_version {
+                break;
+            }
+            last_version = index.stale_since_version;
+            batch.delete::<JellyfishMerkleNodeSchema>(&index.node_key)?;
+            batch.delete::<S>(&index)?;
+            count += 1;
+            if count >= batch_size as u64 {
+                break;
+            }
+        }
+
+        if count == 0 {
+            break;
+        }
+
+        db.write_schemas(batch)?;
+        counter.inc_by(count);
+        current_version_gauge.set(last_version as i64);
+    }
+
+    Ok(())
+}

--- a/storage/aptosdb/src/pruner/state_merkle_pruner/mod.rs
+++ b/storage/aptosdb/src/pruner/state_merkle_pruner/mod.rs
@@ -2,6 +2,7 @@
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 pub(in crate::pruner) mod generics;
+pub(crate) mod leaked_stale_node_cleaner;
 mod state_merkle_metadata_pruner;
 pub(crate) mod state_merkle_pruner_manager;
 mod state_merkle_shard_pruner;

--- a/storage/aptosdb/src/schema/db_metadata/mod.rs
+++ b/storage/aptosdb/src/schema/db_metadata/mod.rs
@@ -69,6 +69,9 @@ pub enum DbMetadataKey {
     StateMerkleShardRestoreProgress(ShardId, Version),
     TransactionAuxiliaryDataPrunerProgress,
     PersistedAuxiliaryInfoPrunerProgress,
+    StaleNodeCleanupDone,
+    StaleNodeCleanupRegularProgress,
+    StaleNodeCleanupEpochProgress,
 }
 
 define_schema!(


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Runs destructive DB deletions in a new background thread at startup; bugs or misconfiguration could cause performance impact on boot or unintended data removal despite being gated by persisted progress/done markers.
> 
> **Overview**
> Adds a one-time background thread on DB startup to scan stale-node indices and delete leaked Jellyfish Merkle Tree nodes from both shard DBs and the metadata DB, persisting per-run progress and done markers in `DbMetadataKey` to make the cleanup restart-safe.
> 
> Extends `PrunerConfig` with `stale_node_cleanup_batch_size` (default `50_000`, `0` disables), wires it into `StatePruner::new`, and updates benchmarks/tests to inherit the new default. Introduces new storage metrics (`aptos_storage_stale_node_cleanup*`) to track cleanup status and deletion counts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 37ab0c9bcd514c43cf5dc6cd9d20aa89944ccc8d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->