### PR TITLE
[TSS] implement new_block + advance_epoch and add tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4699,6 +4699,7 @@ version = "0.0.1"
 dependencies = [
  "anyhow",
  "aptos-api-types",
+ "aptos-crypto",
  "aptos-resource-viewer",
  "aptos-rest-client",
  "aptos-transaction-simulation",
@@ -4715,7 +4716,6 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "tokio",
  "url",
 ]
 

--- a/aptos-move/aptos-transaction-simulation-session/Cargo.toml
+++ b/aptos-move/aptos-transaction-simulation-session/Cargo.toml
@@ -19,12 +19,12 @@ hex = { workspace = true }
 rand = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
-tokio = { workspace = true }
 url = { workspace = true }
 
 move-core-types = { workspace = true }
 
 aptos-api-types = { workspace = true }
+aptos-crypto = { workspace = true }
 aptos-resource-viewer = { workspace = true }
 aptos-rest-client = { workspace = true }
 aptos-transaction-simulation = { workspace = true }
@@ -36,4 +36,11 @@ aptos-vm-logging = { workspace = true }
 aptos-vm-types = { workspace = true }
 
 [dev-dependencies]
+bcs = { workspace = true }
+serde_json = { workspace = true }
 tempfile = { workspace = true }
+url = { workspace = true }
+
+aptos-transaction-simulation = { workspace = true }
+aptos-types = { workspace = true }
+move-core-types = { workspace = true }

--- a/aptos-move/aptos-transaction-simulation-session/src/lib.rs
+++ b/aptos-move/aptos-transaction-simulation-session/src/lib.rs
@@ -7,4 +7,4 @@ mod session;
 mod state_store;
 mod txn_output;
 
-pub use session::Session;
+pub use session::{BlockTimestamp, NewBlockResult, Session};

--- a/aptos-move/aptos-transaction-simulation-session/src/session.rs
+++ b/aptos-move/aptos-transaction-simulation-session/src/session.rs
@@ -7,6 +7,7 @@ use crate::{
     txn_output::{save_events, save_write_set},
 };
 use anyhow::Result;
+use aptos_crypto::HashValue;
 use aptos_resource_viewer::{AnnotatedMoveValue, AptosValueAnnotator};
 use aptos_rest_client::{AptosBaseUrl, Client};
 use aptos_transaction_simulation::{
@@ -14,11 +15,15 @@ use aptos_transaction_simulation::{
 };
 use aptos_types::{
     account_address::{create_derived_object_address, AccountAddress},
+    account_config::events::new_block::BlockResource,
+    block_metadata::BlockMetadata,
     fee_statement::FeeStatement,
+    on_chain_config::{ConfigurationResource, CurrentTimeMicroseconds, ValidatorSet},
     randomness::PerBlockRandomness,
     state_store::{state_key::StateKey, TStateView},
     transaction::{
-        AuxiliaryInfo, SignedTransaction, TransactionExecutable, TransactionOutput,
+        signature_verified_transaction::SignatureVerifiedTransaction, AuxiliaryInfo,
+        SignedTransaction, Transaction, TransactionExecutable, TransactionOutput,
         TransactionPayload, TransactionPayloadInner, TransactionStatus,
     },
     vm_status::VMStatus,
@@ -96,6 +101,36 @@ enum Summary {
         group_type: String,
         group_value: Option<serde_json::Value>,
     },
+    NewBlock {
+        old_timestamp_usecs: u64,
+        new_timestamp_usecs: u64,
+        old_epoch: u64,
+        new_epoch: u64,
+    },
+}
+
+/// Specifies the timestamp for a new block.
+#[derive(Debug, Clone, Copy, Default)]
+pub enum BlockTimestamp {
+    /// Use the current on-chain timestamp plus 1 microsecond.
+    #[default]
+    Default,
+    /// Use an absolute timestamp in microseconds.
+    Absolute(u64),
+    /// Advance the current on-chain timestamp by the given number of microseconds.
+    Offset(u64),
+}
+
+/// Information about the result of executing a new block.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct NewBlockResult {
+    /// The new block timestamp in microseconds.
+    pub new_timestamp_usecs: u64,
+    /// The epoch before the block.
+    pub old_epoch: u64,
+    /// The epoch after the block. May differ from `old_epoch` if the block
+    /// triggered a reconfiguration.
+    pub new_epoch: u64,
 }
 
 /// A session for simulating transactions, with data being persisted to a directory, allowing the session
@@ -140,9 +175,10 @@ impl Session {
         let state_store = DeltaStateStore::new_with_base(EitherStateView::Left(EmptyStateView));
         state_store.apply_write_set(GENESIS_CHANGE_SET_HEAD.write_set())?;
 
-        // Patch randomness seed so that transactions using on-chain randomness can be simulated.
-        // In normal block execution, the block prologue sets the seed, but since we're simulating
-        // transactions directly without a block prologue, we need to provide a synthetic seed.
+        // Patch a synthetic randomness seed so transactions using on-chain randomness can
+        // be simulated. On a real network the seed is derived from validator consensus,
+        // which we can't reproduce locally. See also the re-patch in
+        // `execute_block_metadata_transaction`.
         Self::patch_randomness_seed(&state_store)?;
 
         // Save delta to file
@@ -156,11 +192,12 @@ impl Session {
         })
     }
 
-    /// Patches the randomness seed in the state store.
+    /// Injects a synthetic randomness seed into the state store.
     ///
-    /// This is needed because in simulation mode, there's no block prologue to set the
-    /// `PerBlockRandomness` seed. Without a valid seed, transactions that use on-chain
-    /// randomness APIs will fail when trying to access the seed.
+    /// Called at session init and after each block metadata transaction. Without a valid
+    /// seed, transactions that use on-chain randomness APIs would abort. On a real network
+    /// the seed is derived from validator consensus, which we can't reproduce locally, so
+    /// randomness-dependent behavior will always differ from production.
     fn patch_randomness_seed(state_store: &impl SimulationStateStore) -> Result<()> {
         let mut seed = vec![0u8; 32];
         rand::thread_rng().fill_bytes(&mut seed);
@@ -259,6 +296,20 @@ impl Session {
         })
     }
 
+    /// Completes an operation by incrementing the op counter and persisting session state.
+    ///
+    /// If `save_state` is true, the state delta is also saved. This should be set for
+    /// operations that modify state (e.g., fund, execute, new_block), but not for read-only
+    /// operations (e.g., view).
+    fn finish_op(&mut self, save_state: bool) -> Result<()> {
+        self.config.ops += 1;
+        self.config.save_to_file(&self.path.join("config.json"))?;
+        if save_state {
+            save_delta(&self.path.join("delta.json"), &self.state_store.delta())?;
+        }
+        Ok(())
+    }
+
     /// Funds an account with APT.
     ///
     /// This counts as a session operation but is not a real transaction, as it modifies the
@@ -282,12 +333,231 @@ impl Session {
         std::fs::create_dir_all(summary_path.parent().unwrap())?;
         std::fs::write(summary_path, serde_json::to_string_pretty(&summary)?)?;
 
-        self.config.ops += 1;
-
-        self.config.save_to_file(&self.path.join("config.json"))?;
-        save_delta(&self.path.join("delta.json"), &self.state_store.delta())?;
+        self.finish_op(true)?;
 
         Ok(())
+    }
+
+    /// Executes a new block at the given timestamp.
+    ///
+    /// This creates and executes a `BlockMetadata` transaction through the VM, triggering
+    /// the full block prologue in Move, which:
+    /// - Updates `CurrentTimeMicroseconds` to `timestamp_usecs`
+    /// - Emits a `NewBlockEvent`
+    /// - May trigger an epoch change if enough time has passed since the last reconfiguration
+    /// - Updates staking performance statistics
+    ///
+    /// The resulting timestamp must be strictly greater than the current on-chain timestamp.
+    pub fn new_block(&mut self, timestamp: BlockTimestamp) -> Result<NewBlockResult> {
+        let config_resource: ConfigurationResource = self.state_store.get_on_chain_config()?;
+        let old_epoch = config_resource.epoch();
+
+        let current_timestamp: CurrentTimeMicroseconds = self.state_store.get_on_chain_config()?;
+        let old_timestamp_usecs = current_timestamp.microseconds;
+
+        let new_timestamp_usecs = match timestamp {
+            BlockTimestamp::Default => old_timestamp_usecs.checked_add(1).ok_or_else(|| {
+                anyhow::anyhow!("timestamp overflow: current timestamp is u64::MAX")
+            })?,
+            BlockTimestamp::Absolute(ts) => {
+                if ts <= old_timestamp_usecs {
+                    anyhow::bail!(
+                        "timestamp must be strictly greater than the current on-chain \
+                         timestamp ({old_timestamp_usecs}), got {ts}"
+                    );
+                }
+                ts
+            },
+            BlockTimestamp::Offset(delta) => {
+                if delta == 0 {
+                    anyhow::bail!(
+                        "offset must be greater than zero to ensure the new timestamp is \
+                         strictly greater than the current on-chain timestamp \
+                         ({old_timestamp_usecs})"
+                    );
+                }
+                old_timestamp_usecs.checked_add(delta).ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "timestamp overflow: {old_timestamp_usecs} + {delta} exceeds u64::MAX"
+                    )
+                })?
+            },
+        };
+
+        self.run_new_block(new_timestamp_usecs, old_timestamp_usecs, old_epoch)
+    }
+
+    /// Advances the simulation to the next epoch.
+    ///
+    /// This calculates the minimum timestamp needed to cross the epoch boundary and
+    /// executes a new block at that timestamp. The block prologue detects that enough
+    /// time has passed since the last reconfiguration and calls `reconfiguration::reconfigure()`.
+    ///
+    /// The epoch interval is read from the on-chain `BlockResource`, so this works
+    /// correctly even if the epoch interval has been modified.
+    pub fn advance_epoch(&mut self) -> Result<NewBlockResult> {
+        let config_resource: ConfigurationResource = self.state_store.get_on_chain_config()?;
+        let old_epoch = config_resource.epoch();
+        let last_reconfig_time = config_resource.last_reconfiguration_time_micros();
+
+        let current_timestamp: CurrentTimeMicroseconds = self.state_store.get_on_chain_config()?;
+        let old_timestamp_usecs = current_timestamp.microseconds;
+
+        let block_resource: BlockResource = self
+            .state_store
+            .get_resource(AccountAddress::ONE)?
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "BlockResource not found at 0x1 -- is the chain properly initialized?"
+                )
+            })?;
+        let epoch_interval_usecs = block_resource.epoch_interval();
+
+        // The block prologue triggers reconfiguration when:
+        //   timestamp - last_reconfiguration_time >= epoch_interval
+        //
+        // The timestamp must also be strictly greater than the current one.
+        let epoch_boundary = last_reconfig_time
+            .checked_add(epoch_interval_usecs)
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "timestamp overflow: last_reconfig_time ({last_reconfig_time}) + \
+                 epoch_interval ({epoch_interval_usecs}) exceeds u64::MAX"
+                )
+            })?;
+        let min_next = old_timestamp_usecs
+            .checked_add(1)
+            .ok_or_else(|| anyhow::anyhow!("timestamp overflow: current timestamp is u64::MAX"))?;
+        let new_timestamp_usecs = epoch_boundary.max(min_next);
+
+        self.run_new_block(new_timestamp_usecs, old_timestamp_usecs, old_epoch)
+    }
+
+    /// Shared implementation for [`new_block`](Self::new_block) and
+    /// [`advance_epoch`](Self::advance_epoch).
+    fn run_new_block(
+        &mut self,
+        new_timestamp_usecs: u64,
+        old_timestamp_usecs: u64,
+        old_epoch: u64,
+    ) -> Result<NewBlockResult> {
+        let txn_output = self.execute_block_metadata_transaction(old_epoch, new_timestamp_usecs)?;
+
+        let new_epoch = self
+            .state_store
+            .get_on_chain_config::<ConfigurationResource>()?
+            .epoch();
+
+        // Save summary and artifacts.
+        let output_path = self.path.join(format!("[{}] new block", self.config.ops));
+        std::fs::create_dir_all(&output_path)?;
+
+        let summary = Summary::NewBlock {
+            old_timestamp_usecs,
+            new_timestamp_usecs,
+            old_epoch,
+            new_epoch,
+        };
+        std::fs::write(
+            output_path.join("summary.json"),
+            serde_json::to_string_pretty(&summary)?,
+        )?;
+        save_events(
+            &output_path.join("events.json"),
+            &self.state_store,
+            txn_output.events(),
+        )?;
+        save_write_set(
+            &self.state_store,
+            &output_path.join("write_set.json"),
+            txn_output.write_set(),
+        )?;
+
+        self.finish_op(true)?;
+
+        Ok(NewBlockResult {
+            new_timestamp_usecs,
+            old_epoch,
+            new_epoch,
+        })
+    }
+
+    /// Executes a `BlockMetadata` transaction through the VM.
+    ///
+    /// This is the low-level helper used by [`new_block`](Self::new_block). It handles
+    /// constructing the `BlockMetadata`, running it through the VM, applying the write set,
+    /// and re-patching the randomness seed.
+    ///
+    /// We use the legacy `Transaction::BlockMetadata` rather than the newer
+    /// `Transaction::BlockMetadataExt` used by production validators with
+    /// randomness enabled. The key difference is that the legacy path calls
+    /// `reconfiguration::reconfigure()` (immediate) while the ext path calls
+    /// `reconfiguration_with_dkg::try_start()` (multi-round DKG that requires validator
+    /// participation across multiple blocks). Immediate reconfiguration is more practical
+    /// for simulation since epoch changes complete in a single block. This is the same
+    /// approach used by `FakeExecutor` in the e2e test harness.
+    fn execute_block_metadata_transaction(
+        &mut self,
+        epoch: u64,
+        timestamp_usecs: u64,
+    ) -> Result<TransactionOutput> {
+        // The block prologue requires a non-zero proposer when updating the timestamp.
+        let validator_set: ValidatorSet = self.state_store.get_on_chain_config()?;
+        let proposer = *validator_set
+            .payload()
+            .next()
+            .ok_or_else(|| {
+                anyhow::anyhow!("validator set is empty -- cannot create block metadata")
+            })?
+            .account_address();
+
+        let num_validators = validator_set.num_validators();
+        let previous_block_votes_bitvec = vec![0u8; num_validators.div_ceil(8)];
+
+        let block_metadata = BlockMetadata::new(
+            HashValue::zero(),
+            epoch,
+            0, // round (not tracked in simulation)
+            proposer,
+            previous_block_votes_bitvec,
+            vec![], // no failed proposers
+            timestamp_usecs,
+        );
+
+        let env = AptosEnvironment::new(&self.state_store);
+        let vm = AptosVM::new(&env);
+        let log_context = AdapterLogSchema::new(self.state_store.id(), 0);
+        let resolver = self.state_store.as_move_resolver();
+        let code_storage = self.state_store.as_aptos_code_storage(&env);
+
+        let txn = SignatureVerifiedTransaction::Valid(Transaction::BlockMetadata(block_metadata));
+        let (vm_status, vm_output) = vm
+            .execute_single_transaction(
+                &txn,
+                &resolver,
+                &code_storage,
+                &log_context,
+                &AuxiliaryInfo::new_timestamp_not_yet_assigned(0),
+            )
+            .map_err(|e| anyhow::anyhow!("block prologue execution failed: {:?}", e))?;
+
+        if vm_status != VMStatus::Executed {
+            anyhow::bail!(
+                "block prologue execution returned non-success status: {:?}",
+                vm_status
+            );
+        }
+
+        let txn_output = vm_output.try_materialize_into_transaction_output(&resolver)?;
+        self.state_store.apply_write_set(txn_output.write_set())?;
+
+        // Re-patch the randomness seed. The block prologue clears it because our
+        // BlockMetadata doesn't carry a real seed (on a real network this comes from
+        // validator consensus). Without re-patching, subsequent transactions that use
+        // on-chain randomness would abort.
+        Self::patch_randomness_seed(&self.state_store)?;
+
+        Ok(txn_output)
     }
 
     /// Executes a transaction and updates the session state.
@@ -364,16 +634,13 @@ impl Session {
         let summary_path = output_path.join("summary.json");
         std::fs::write(summary_path, serde_json::to_string_pretty(&summary)?)?;
 
-        // Dump events to file
         let events_path = output_path.join("events.json");
         save_events(&events_path, &self.state_store, txn_output.events())?;
 
         let write_set_path = output_path.join("write_set.json");
         save_write_set(&self.state_store, &write_set_path, txn_output.write_set())?;
 
-        self.config.ops += 1;
-        self.config.save_to_file(&self.path.join("config.json"))?;
-        save_delta(&self.path.join("delta.json"), &self.state_store.delta())?;
+        self.finish_op(true)?;
 
         Ok((vm_status, txn_output))
     }
@@ -440,8 +707,7 @@ impl Session {
         std::fs::create_dir_all(summary_path.parent().unwrap())?;
         std::fs::write(summary_path, serde_json::to_string_pretty(&summary)?)?;
 
-        self.config.ops += 1;
-        self.config.save_to_file(&self.path.join("config.json"))?;
+        self.finish_op(false)?;
 
         res
     }
@@ -483,12 +749,12 @@ impl Session {
         std::fs::create_dir_all(summary_path.parent().unwrap())?;
         std::fs::write(summary_path, serde_json::to_string_pretty(&summary)?)?;
 
-        self.config.ops += 1;
-        self.config.save_to_file(&self.path.join("config.json"))?;
+        self.finish_op(false)?;
 
         Ok(json_val)
     }
 
+    /// Views a Move resource group.
     pub fn view_resource_group(
         &mut self,
         account_addr: AccountAddress,
@@ -542,72 +808,8 @@ impl Session {
         std::fs::create_dir_all(summary_path.parent().unwrap())?;
         std::fs::write(summary_path, serde_json::to_string_pretty(&summary)?)?;
 
-        self.config.ops += 1;
-        self.config.save_to_file(&self.path.join("config.json"))?;
+        self.finish_op(false)?;
 
         Ok(json_val)
     }
-}
-
-#[test]
-fn test_init_then_load_session_local() -> Result<()> {
-    let temp_dir = tempfile::tempdir()?;
-    let session_path = temp_dir.path();
-
-    let session = Session::init(session_path)?;
-    let session_loaded = Session::load(session_path)?;
-
-    assert_eq!(session.config, session_loaded.config);
-    assert_eq!(
-        session.state_store.delta(),
-        session_loaded.state_store.delta()
-    );
-
-    Ok(())
-}
-
-#[tokio::test]
-async fn test_init_then_load_session_remote() -> Result<()> {
-    let temp_dir = tempfile::tempdir()?;
-    let session_path = temp_dir.path();
-
-    let session = Session::init_with_remote_state(
-        session_path,
-        Url::parse("https://mainnet.aptoslabs.com")?,
-        12345,
-        Some("my_api_key_12345".to_string()),
-    )?;
-    let session_loaded = Session::load(session_path)?;
-
-    assert_eq!(session.config, session_loaded.config);
-    assert_eq!(
-        session.state_store.delta(),
-        session_loaded.state_store.delta()
-    );
-
-    Ok(())
-}
-
-#[test]
-fn test_local_session_has_randomness_seed() -> Result<()> {
-    let temp_dir = tempfile::tempdir()?;
-    let session_path = temp_dir.path();
-
-    let session = Session::init(session_path)?;
-
-    // Verify that the PerBlockRandomness seed is set (not None)
-    let randomness_config = session
-        .state_store
-        .get_on_chain_config::<PerBlockRandomness>()?;
-
-    assert!(
-        randomness_config.seed.is_some(),
-        "Local session should have randomness seed patched"
-    );
-    assert_eq!(
-        randomness_config.seed.as_ref().unwrap().len(),
-        32,
-        "Randomness seed should be 32 bytes"
-    );
-    Ok(())
 }

--- a/aptos-move/aptos-transaction-simulation-session/tests/advance_epoch.rs
+++ b/aptos-move/aptos-transaction-simulation-session/tests/advance_epoch.rs
@@ -1,0 +1,92 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+use anyhow::Result;
+use aptos_transaction_simulation::SimulationStateStore;
+use aptos_transaction_simulation_session::Session;
+use aptos_types::{
+    on_chain_config::{ConfigurationResource, CurrentTimeMicroseconds},
+    randomness::PerBlockRandomness,
+};
+
+#[test]
+fn test_advance_epoch() -> Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+    let mut session = Session::init(temp_dir.path())?;
+
+    let initial: ConfigurationResource = session.state_store().get_on_chain_config()?;
+
+    let result = session.advance_epoch()?;
+    assert_eq!(result.old_epoch, initial.epoch());
+    assert_eq!(result.new_epoch, initial.epoch() + 1);
+
+    Ok(())
+}
+
+#[test]
+fn test_advance_epoch_twice() -> Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+    let mut session = Session::init(temp_dir.path())?;
+
+    let initial: ConfigurationResource = session.state_store().get_on_chain_config()?;
+
+    session.advance_epoch()?;
+    let result = session.advance_epoch()?;
+
+    assert_eq!(result.new_epoch, initial.epoch() + 2);
+
+    Ok(())
+}
+
+#[test]
+fn test_advance_epoch_preserves_randomness_seed() -> Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+    let mut session = Session::init(temp_dir.path())?;
+
+    session.advance_epoch()?;
+
+    let randomness: PerBlockRandomness = session.state_store().get_on_chain_config()?;
+    assert!(randomness.seed.is_some());
+
+    Ok(())
+}
+
+#[test]
+fn test_advance_epoch_advances_timestamp() -> Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+    let mut session = Session::init(temp_dir.path())?;
+
+    let before: CurrentTimeMicroseconds = session.state_store().get_on_chain_config()?;
+    let result = session.advance_epoch()?;
+
+    assert!(
+        result.new_timestamp_usecs > before.microseconds,
+        "timestamp should advance past the previous value"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_advance_epoch_emits_new_epoch_event() -> Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+    let mut session = Session::init(temp_dir.path())?;
+
+    session.advance_epoch()?;
+
+    let events_path = temp_dir.path().join("[0] new block").join("events.json");
+    let events_json: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&events_path)?)?;
+    let events = events_json.as_array().expect("events should be an array");
+
+    // Look for a NewEpoch event (V1 or V2).
+    let has_new_epoch_event = events.iter().any(|e| {
+        let type_tag = e
+            .pointer("/V1/type_tag")
+            .or_else(|| e.pointer("/V2/type_tag"));
+        matches!(type_tag, Some(serde_json::Value::String(s)) if s.contains("reconfiguration::NewEpoch"))
+    });
+    assert!(has_new_epoch_event, "should emit a NewEpoch event");
+
+    Ok(())
+}

--- a/aptos-move/aptos-transaction-simulation-session/tests/execute_transaction.rs
+++ b/aptos-move/aptos-transaction-simulation-session/tests/execute_transaction.rs
@@ -1,0 +1,80 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+use anyhow::Result;
+use aptos_transaction_simulation::{Account, SimulationStateStore};
+use aptos_transaction_simulation_session::Session;
+use aptos_types::{
+    account_address::AccountAddress,
+    account_config::AccountResource,
+    transaction::{EntryFunction, SignedTransaction, TransactionPayload},
+    vm_status::VMStatus,
+};
+use move_core_types::{identifier::Identifier, language_storage::ModuleId};
+
+/// Creates a signed transaction that calls `0x1::aptos_account::transfer`.
+fn transfer_txn(sender: &Account, recipient: AccountAddress, amount: u64) -> SignedTransaction {
+    let payload = TransactionPayload::EntryFunction(EntryFunction::new(
+        ModuleId::new(
+            AccountAddress::ONE,
+            Identifier::new("aptos_account").unwrap(),
+        ),
+        Identifier::new("transfer").unwrap(),
+        vec![],
+        vec![
+            bcs::to_bytes(&recipient).unwrap(),
+            bcs::to_bytes(&amount).unwrap(),
+        ],
+    ));
+    sender
+        .transaction()
+        .sequence_number(0)
+        .gas_unit_price(100)
+        .payload(payload)
+        .sign()
+}
+
+#[test]
+fn test_execute_transfer() -> Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+    let mut session = Session::init(temp_dir.path())?;
+
+    let sender = Account::new();
+    let recipient = Account::new();
+
+    // Create account and fund with 1 APT.
+    session
+        .state_store()
+        .store_and_fund_account(sender.clone(), 100_000_000, 0)?;
+
+    let txn = transfer_txn(&sender, *recipient.address(), 1_000);
+    let (vm_status, output) = session.execute_transaction(txn)?;
+
+    assert_eq!(vm_status, VMStatus::Executed, "transfer should succeed");
+    assert!(output.gas_used() > 0, "should use some gas");
+
+    Ok(())
+}
+
+#[test]
+fn test_execute_transaction_increments_sequence_number() -> Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+    let mut session = Session::init(temp_dir.path())?;
+
+    let sender = Account::new();
+    session
+        .state_store()
+        .store_and_fund_account(sender.clone(), 100_000_000, 0)?;
+
+    let txn = transfer_txn(&sender, *sender.address(), 100);
+    session.execute_transaction(txn)?;
+
+    // After one transaction, sequence number should be 1.
+    let account_resource: AccountResource = session
+        .state_store()
+        .get_resource(*sender.address())?
+        .expect("account resource should exist");
+    assert_eq!(account_resource.sequence_number(), 1);
+
+    Ok(())
+}

--- a/aptos-move/aptos-transaction-simulation-session/tests/fund_account.rs
+++ b/aptos-move/aptos-transaction-simulation-session/tests/fund_account.rs
@@ -1,0 +1,35 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+use anyhow::Result;
+use aptos_transaction_simulation::{Account, SimulationStateStore};
+use aptos_transaction_simulation_session::Session;
+
+#[test]
+fn test_fund_account() -> Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+    let mut session = Session::init(temp_dir.path())?;
+
+    let account = Account::new();
+    session.fund_account(*account.address(), 1_000_000)?;
+
+    let balance = session.state_store().get_apt_balance(*account.address())?;
+    assert_eq!(balance, 1_000_000);
+
+    Ok(())
+}
+
+#[test]
+fn test_fund_account_twice_accumulates() -> Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+    let mut session = Session::init(temp_dir.path())?;
+
+    let account = Account::new();
+    session.fund_account(*account.address(), 500)?;
+    session.fund_account(*account.address(), 300)?;
+
+    let balance = session.state_store().get_apt_balance(*account.address())?;
+    assert_eq!(balance, 800);
+
+    Ok(())
+}

--- a/aptos-move/aptos-transaction-simulation-session/tests/new_block.rs
+++ b/aptos-move/aptos-transaction-simulation-session/tests/new_block.rs
@@ -1,0 +1,115 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+use anyhow::Result;
+use aptos_transaction_simulation::SimulationStateStore;
+use aptos_transaction_simulation_session::{BlockTimestamp, Session};
+use aptos_types::{
+    account_address::AccountAddress, account_config::events::new_block::BlockResource,
+    on_chain_config::CurrentTimeMicroseconds, randomness::PerBlockRandomness,
+};
+
+#[test]
+fn test_new_block_default_timestamp() -> Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+    let mut session = Session::init(temp_dir.path())?;
+
+    let before: CurrentTimeMicroseconds = session.state_store().get_on_chain_config()?;
+    let result = session.new_block(BlockTimestamp::Default)?;
+
+    assert_eq!(result.new_timestamp_usecs, before.microseconds + 1);
+    assert_eq!(result.old_epoch, result.new_epoch);
+
+    Ok(())
+}
+
+#[test]
+fn test_new_block_with_absolute_timestamp() -> Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+    let mut session = Session::init(temp_dir.path())?;
+
+    let new_time = 1_000_000; // 1 second
+    let result = session.new_block(BlockTimestamp::Absolute(new_time))?;
+
+    assert_eq!(result.new_timestamp_usecs, new_time);
+
+    let updated: CurrentTimeMicroseconds = session.state_store().get_on_chain_config()?;
+    assert_eq!(updated.microseconds, new_time);
+
+    Ok(())
+}
+
+#[test]
+fn test_new_block_crossing_epoch_boundary() -> Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+    let mut session = Session::init(temp_dir.path())?;
+
+    let block_resource: BlockResource = session
+        .state_store()
+        .get_resource(AccountAddress::ONE)?
+        .expect("BlockResource should exist");
+    let epoch_interval = block_resource.epoch_interval();
+
+    let result = session.new_block(BlockTimestamp::Absolute(epoch_interval))?;
+    assert_eq!(result.new_epoch, result.old_epoch + 1);
+
+    Ok(())
+}
+
+#[test]
+fn test_new_block_not_crossing_epoch_boundary() -> Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+    let mut session = Session::init(temp_dir.path())?;
+
+    let block_resource: BlockResource = session
+        .state_store()
+        .get_resource(AccountAddress::ONE)?
+        .expect("BlockResource should exist");
+    let epoch_interval = block_resource.epoch_interval();
+
+    // 1 microsecond before the boundary.
+    let result = session.new_block(BlockTimestamp::Absolute(epoch_interval - 1))?;
+    assert_eq!(result.old_epoch, result.new_epoch);
+
+    Ok(())
+}
+
+#[test]
+fn test_new_block_preserves_randomness_seed() -> Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+    let mut session = Session::init(temp_dir.path())?;
+
+    session.new_block(BlockTimestamp::Default)?;
+
+    let randomness: PerBlockRandomness = session.state_store().get_on_chain_config()?;
+    assert!(
+        randomness.seed.is_some(),
+        "randomness seed should be re-patched after new_block"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_new_block_emits_new_block_event() -> Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+    let mut session = Session::init(temp_dir.path())?;
+
+    session.new_block(BlockTimestamp::Default)?;
+
+    let events_path = temp_dir.path().join("[0] new block").join("events.json");
+    let events_json: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&events_path)?)?;
+    let events = events_json.as_array().expect("events should be an array");
+
+    // Look for a NewBlockEvent (V1) or NewBlock (V2).
+    let has_new_block_event = events.iter().any(|e| {
+        let type_tag = e
+            .pointer("/V1/type_tag")
+            .or_else(|| e.pointer("/V2/type_tag"));
+        matches!(type_tag, Some(serde_json::Value::String(s)) if s.contains("block::NewBlock"))
+    });
+    assert!(has_new_block_event, "should emit a NewBlock event");
+
+    Ok(())
+}

--- a/aptos-move/aptos-transaction-simulation-session/tests/session_lifecycle.rs
+++ b/aptos-move/aptos-transaction-simulation-session/tests/session_lifecycle.rs
@@ -1,0 +1,45 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+use anyhow::Result;
+use aptos_transaction_simulation::SimulationStateStore;
+use aptos_transaction_simulation_session::Session;
+use aptos_types::{on_chain_config::CurrentTimeMicroseconds, randomness::PerBlockRandomness};
+
+#[test]
+fn test_init_then_load_local() -> Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+
+    let _session = Session::init(temp_dir.path())?;
+    let loaded = Session::load(temp_dir.path())?;
+
+    // Verify the loaded session can read on-chain state from genesis.
+    let timestamp: CurrentTimeMicroseconds = loaded.state_store().get_on_chain_config()?;
+    assert_eq!(timestamp.microseconds, 0);
+
+    Ok(())
+}
+
+#[test]
+fn test_init_local_patches_randomness_seed() -> Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+
+    let session = Session::init(temp_dir.path())?;
+
+    let randomness: PerBlockRandomness = session.state_store().get_on_chain_config()?;
+    assert!(randomness.seed.is_some(), "randomness seed should be set");
+    assert_eq!(randomness.seed.unwrap().len(), 32);
+
+    Ok(())
+}
+
+#[test]
+fn test_init_fails_on_nonempty_directory() -> Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+    std::fs::write(temp_dir.path().join("existing_file"), "data")?;
+
+    let result = Session::init(temp_dir.path());
+    assert!(result.is_err());
+
+    Ok(())
+}

--- a/aptos-move/aptos-transaction-simulation-session/tests/view_function.rs
+++ b/aptos-move/aptos-transaction-simulation-session/tests/view_function.rs
@@ -1,0 +1,49 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+use anyhow::Result;
+use aptos_transaction_simulation::{Account, SimulationStateStore};
+use aptos_transaction_simulation_session::Session;
+use aptos_types::account_address::AccountAddress;
+use move_core_types::{identifier::Identifier, language_storage::ModuleId};
+
+#[test]
+fn test_view_function_get_sequence_number() -> Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+    let mut session = Session::init(temp_dir.path())?;
+
+    let account = Account::new();
+    session
+        .state_store()
+        .store_and_fund_account(account.clone(), 0, 42)?;
+
+    let result = session.execute_view_function(
+        ModuleId::new(AccountAddress::ONE, Identifier::new("account")?),
+        Identifier::new("get_sequence_number")?,
+        vec![],
+        vec![bcs::to_bytes(account.address())?],
+    )?;
+
+    assert_eq!(result.len(), 1);
+    // The view function returns a JSON string of the u64 value.
+    assert_eq!(result[0], serde_json::json!("42"));
+
+    Ok(())
+}
+
+#[test]
+fn test_view_function_nonexistent_module() -> Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+    let mut session = Session::init(temp_dir.path())?;
+
+    let result = session.execute_view_function(
+        ModuleId::new(AccountAddress::ONE, Identifier::new("nonexistent_module")?),
+        Identifier::new("some_function")?,
+        vec![],
+        vec![],
+    );
+
+    assert!(result.is_err(), "calling a nonexistent module should fail");
+
+    Ok(())
+}

--- a/aptos-move/aptos-transaction-simulation-session/tests/view_resource.rs
+++ b/aptos-move/aptos-transaction-simulation-session/tests/view_resource.rs
@@ -1,0 +1,66 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+use anyhow::Result;
+use aptos_transaction_simulation::{Account, SimulationStateStore};
+use aptos_transaction_simulation_session::Session;
+use aptos_types::account_address::AccountAddress;
+use move_core_types::language_storage::StructTag;
+use std::str::FromStr;
+
+#[test]
+fn test_view_resource_exists() -> Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+    let mut session = Session::init(temp_dir.path())?;
+
+    let account = Account::new();
+    session
+        .state_store()
+        .store_and_fund_account(account.clone(), 0, 0)?;
+
+    let tag = StructTag::from_str("0x1::account::Account")?;
+    let result = session.view_resource(*account.address(), &tag)?;
+
+    assert!(result.is_some(), "account resource should exist");
+
+    Ok(())
+}
+
+#[test]
+fn test_view_resource_not_found() -> Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+    let mut session = Session::init(temp_dir.path())?;
+
+    let tag = StructTag::from_str("0x1::account::Account")?;
+    // Random address that has no account.
+    let result = session.view_resource(AccountAddress::from_hex_literal("0x12345")?, &tag)?;
+
+    assert!(
+        result.is_none(),
+        "resource should not exist for random address"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_view_resource_group_for_funded_account() -> Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+    let mut session = Session::init(temp_dir.path())?;
+
+    // Fund an account — this creates an ObjectGroup with a FungibleStore at
+    // the primary APT store address (derived from account address + 0xA).
+    let account = Account::new();
+    session.fund_account(*account.address(), 1_000_000)?;
+
+    let group_tag = StructTag::from_str("0x1::object::ObjectGroup")?;
+    let result =
+        session.view_resource_group(*account.address(), &group_tag, Some(AccountAddress::TEN))?;
+
+    assert!(
+        result.is_some(),
+        "ObjectGroup should exist at the primary APT store address"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
### Summary

This PR adds **`new_block`** and **`advance_epoch`** to the transaction simulation session (TSS). Sessions can now advance time and trigger block/epoch boundaries by running a `BlockMetadata` transaction through the VM, so simulations can exercise block prologue behavior, reconfiguration, and time-dependent logic.

### Changes

- **Session API (`session.rs`)**
  - **`new_block(timestamp_usecs: Option<u64>)`** — Executes a new block at the given timestamp (or current + 1 μs if `None`). Runs a `BlockMetadata` transaction so the full block prologue runs: updates `CurrentTimeMicroseconds`, emits `NewBlockEvent`, may trigger epoch change if past `epoch_interval`, and updates staking stats. Returns `NewBlockResult` and persists summary/events/write set under `[N] new block`.
  - **`advance_epoch()`** — Advances the simulation to the next epoch by computing the minimum timestamp to cross the epoch boundary (using on-chain `BlockResource.epoch_interval` and `ConfigurationResource.last_reconfiguration_time_micros`) and calling the shared `run_new_block` path.

- **CLI (`crates/aptos/src/move_tool/sim.rs`)**
  - **`aptos move sim new-block`** — `--session <path>` and optional `--timestamp-usecs`
  - **`aptos move sim advance-epoch`** — `--session <path>`

- **Tests** — New tests for `new_block` (timestamps, epoch boundaries, events, randomness) and `advance_epoch` (single/double advance, timestamp/epoch events). Additional tests for session lifecycle, execute, fund, and view operations.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces VM-executed `BlockMetadata` transactions that mutate simulated chain time/epoch state and reconfiguration behavior, which could affect downstream simulation assumptions despite being well-covered by new tests.
> 
> **Overview**
> Adds first-class block/epoch progression to transaction simulation sessions by executing a `BlockMetadata` transaction through the VM (`Session::new_block`, `Session::advance_epoch`) and persisting the resulting summaries/events/write-sets as session operations.
> 
> Refactors session persistence with a shared `finish_op(save_state)` helper, re-patches synthetic `PerBlockRandomness` after block execution, exports `BlockTimestamp`/`NewBlockResult`, and wires new CLI commands `aptos move sim new-block` and `aptos move sim advance-epoch`.
> 
> Replaces inline unit tests in `session.rs` with a broader `tests/` suite covering lifecycle, funding, transaction execution, view calls, block timestamp rules, epoch advancement, and emitted events.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 22cbb0a26a809e73f9e7e223bedd1a732146b3b4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->