### PR TITLE
Display compiler errors when framework tests are run

### DIFF
--- a/aptos-move/framework/tests/move_unit_test.rs
+++ b/aptos-move/framework/tests/move_unit_test.rs
@@ -29,6 +29,7 @@ fn run_tests_for_pkg(path_to_pkg: impl Into<String>, use_latest_language: bool) 
     let pkg_path = path_in_crate(path_to_pkg);
     let compiler_config = CompilerConfig {
         known_attributes: extended_checks::get_all_attribute_names().clone(),
+        print_errors: true,
         ..Default::default()
     };
     let mut build_config = move_package::BuildConfig {
@@ -63,8 +64,10 @@ fn run_tests_for_pkg(path_to_pkg: impl Into<String>, use_latest_language: bool) 
         &mut std::io::stdout(),
         true,
     );
-    if ok.is_err() || ok.is_ok_and(|r| r == UnitTestResult::Failure) {
-        panic!("move unit tests failed")
+    match ok {
+        Err(e) => panic!("move unit tests failed:\n{:#}", e),
+        Ok(UnitTestResult::Failure) => panic!("move unit tests failed"),
+        Ok(UnitTestResult::Success) => {},
     }
 }
 


### PR DESCRIPTION
## Description

When running `cargo test` in aptos-move/framework, compilation failures were being eaten up and not displayed. This PR fixes it.

## How Has This Been Tested?

- manually made a compilation error in the framework, ran the `cargo test`, verified that with this change, we do print the errors

## Type of Change
- [x] Bug fix

## Which Components or Systems Does This Change Impact?
- [x] Aptos Framework development

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes that affect logging/diagnostics and panic messages, with no impact on production code paths.
> 
> **Overview**
> Framework Move unit tests now enable compiler error printing by setting `CompilerConfig.print_errors = true`, so compilation failures aren’t swallowed during `cargo test`.
> 
> The test runner also improves failure reporting by formatting and surfacing the underlying error (`{:#}`) when `run_move_unit_tests` returns `Err`, while keeping explicit panics for test `Failure` results.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cd24719a0ee88b283e45e88a428ec6a15f8a24b4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->