### PR TITLE
[consensus] Add aggregation failure recovery for optimistic randomness verification

### DIFF
--- a/consensus/src/rand/rand_gen/block_queue.rs
+++ b/consensus/src/rand/rand_gen/block_queue.rs
@@ -66,6 +66,12 @@ impl QueueItem {
             .collect()
     }
 
+    pub fn add_broadcast_handle(&mut self, handle: DropGuard) {
+        self.broadcast_handle
+            .get_or_insert_with(Vec::new)
+            .push(handle);
+    }
+
     pub fn set_randomness(&mut self, round: Round, rand: Randomness) -> bool {
         let offset = self.offset(round);
         if !self.blocks()[offset].has_randomness() {

--- a/consensus/src/rand/rand_gen/types.rs
+++ b/consensus/src/rand/rand_gen/types.rs
@@ -28,7 +28,7 @@ use std::{collections::HashSet, fmt::Debug, sync::Arc};
 pub const NUM_THREADS_FOR_WVUF_DERIVATION: usize = 8;
 pub const FUTURE_ROUNDS_TO_ACCEPT: u64 = 200;
 
-#[derive(PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum PathType {
     Fast,
     Slow,
@@ -818,6 +818,10 @@ impl RandConfig {
 
     pub fn add_to_pessimistic_set(&self, author: Author) {
         self.pessimistic_verify_set.insert(author);
+    }
+
+    pub fn is_in_pessimistic_set(&self, author: &Author) -> bool {
+        self.pessimistic_verify_set.contains(author)
     }
 
     pub fn pk(&self) -> &PK {


### PR DESCRIPTION
## Summary

Add retry mechanism for randomness share aggregation failures, with async `pre_aggregate_verify` and an `Aggregating` buffer state.

### Changes

**`rand_store.rs`**
- Add `AggregationResult<S>` enum (`Success`/`Failure`) to replace the raw `Randomness` channel, carrying path type, metadata, and valid shares on failure.
- Move `pre_aggregate_verify` into the `spawn_blocking` task alongside `aggregate` so neither blocks the RandManager event loop.
- On slow-path `pre_aggregate_verify` dropping weight below threshold, send `Failure` instead of silently returning (fast path still silently drops).
- On slow-path `aggregate` error, filter pessimistic-set authors from shares and send `Failure`.
- Add `Aggregating` state to `RandItem` that buffers incoming shares while the async task runs. `has_decision()` returns true to stop reliable broadcast.
- Add `handle_aggregation_success`: transitions `Aggregating` → `Decided`.
- Add `handle_aggregation_failure`: merges valid shares from failed attempt with buffered shares, filters pessimistic-set authors, retries if threshold met, otherwise falls back to `PendingDecision`.
- Rename `decision_tx`/`decision_rx` to `result_tx`/`result_rx`.

**`rand_manager.rs`**
- Match on `AggregationResult::Success` vs `Failure` in the event loop.
- On failure: call `handle_aggregation_failure`; if insufficient shares for retry, spawn a new slow-path reliable broadcast for the round.

**`block_queue.rs`**
- Add `add_broadcast_handle` to `QueueItem` for attaching recovery broadcast handles.

**`types.rs`**
- Derive `Clone, Copy, Debug` on `PathType`.
- Add `is_in_pessimistic_set` public getter on `RandConfig`.
- Remove unused `force_aggregation_failure` failpoint.

**`optimistic_verification.rs` (smoke test)**
- Add version advancement assertions in Phase 2 (corrupt share window) to verify the chain progressed during the fault.
- Remove redundant `optimistic_verification_aggregation_recovery` test (unhappy path already covered by Phase 3/4 of the main test).

## Test Plan

- Unit tests A-J covering: `FailingMockShare` aggregate error → `Failure` on channel, pessimistic-set filtering, full store roundtrip, `Aggregating` state buffering, `handle_aggregation_success`, `handle_aggregation_failure` with sufficient/insufficient shares, stale metadata guard, reset safety, `try_aggregate` no-op in `Aggregating`
- Smoke test: 4-phase (happy path → corrupt share → stall → recovery) with version advancement and randomness correctness checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches consensus randomness aggregation state machine and retry/broadcast behavior; bugs could cause stalls, repeated broadcasts, or incorrect round transitions, though changes are scoped and covered by new unit + smoke tests.
> 
> **Overview**
> Improves resilience of randomness generation when *optimistic share verification/aggregation fails* by introducing an explicit failure/retry path instead of silently stalling.
> 
> `RandStore` now emits `AggregationResult` (success or failure) and adds an `Aggregating` state that buffers late-arriving shares while an async aggregation task is in flight; on slow-path aggregation errors it filters pessimistic-set authors and returns the remaining valid shares/weight for recovery. `RandManager` consumes these results to mark rounds decided on success, attempt re-aggregation on failure, and if still below threshold re-spawn slow-path share-request broadcast (tracked via new `QueueItem::add_broadcast_handle`).
> 
> Updates `PathType` derives and adds `RandConfig::is_in_pessimistic_set`, plus expands unit tests around failure recovery and tightens the optimistic verification smoke test to assert the chain keeps advancing during corrupt-share windows.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0425c572ceaf7c1f4cafbe8f92482d46b66a65a7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->