### PR TITLE
[State Sync] Update default state sync config values.

### DIFF
--- a/config/src/config/state_sync_config.rs
+++ b/config/src/config/state_sync_config.rs
@@ -16,6 +16,10 @@ const SERVER_MAX_MESSAGE_SIZE: usize = 10 * 1024 * 1024; // 10 MiB
 const CLIENT_MAX_MESSAGE_SIZE_V2: usize = 40 * 1024 * 1024; // 40 MiB (used for v2 data requests)
 const SERVER_MAX_MESSAGE_SIZE_V2: usize = 50 * 1024 * 1024; // 50 MiB (used for v2 data requests)
 
+// The maximum transaction and output chunk sizes (for v2 data requests)
+const CLIENT_MAX_TRANSACTION_CHUNK_SIZE_V2: usize = 1000;
+const CLIENT_MAX_TRANSACTION_OUTPUT_CHUNK_SIZE_V2: usize = 1000;
+
 // The maximum chunk sizes for data client requests and response
 const MAX_EPOCH_CHUNK_SIZE: u64 = 200;
 const MAX_STATE_CHUNK_SIZE: u64 = 4000;
@@ -469,8 +473,8 @@ impl Default for AptosDataClientConfig {
             max_response_timeout_ms: 60_000, // 60 seconds
             max_state_chunk_size: MAX_STATE_CHUNK_SIZE,
             max_subscription_lag_secs: 20, // 20 seconds
-            max_transaction_chunk_size: MAX_TRANSACTION_CHUNK_SIZE,
-            max_transaction_output_chunk_size: MAX_TRANSACTION_OUTPUT_CHUNK_SIZE,
+            max_transaction_chunk_size: CLIENT_MAX_TRANSACTION_CHUNK_SIZE_V2 as u64,
+            max_transaction_output_chunk_size: CLIENT_MAX_TRANSACTION_OUTPUT_CHUNK_SIZE_V2 as u64,
             optimistic_fetch_timeout_ms: 5000,         // 5 seconds
             progress_check_max_stall_time_secs: 86400, // 24 hours (long enough to debug any issues at runtime)
             response_timeout_ms: 10_000,               // 10 seconds


### PR DESCRIPTION
## Description
This PR updates the default state sync config values, specifically the default syncing modes, default max client chunk sizes, and max client message sizes.

## Testing Plan

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default state sync modes and request sizing, which can materially impact node sync performance and resource usage (bandwidth/memory) across deployments.
> 
> **Overview**
> Switches the default state sync behavior to prefer applying transaction outputs: `StateSyncDriverConfig` now defaults to `ApplyTransactionOutputsFromGenesis` for bootstrapping and `ApplyTransactionOutputs` for continuous syncing (instead of the execute-or-apply hybrid modes).
> 
> Raises v2 data request size ceilings by increasing `CLIENT_MAX_MESSAGE_SIZE_V2`/`SERVER_MAX_MESSAGE_SIZE_V2`, and caps v2 client transaction/output chunk sizes to new 1000-item limits (replacing the previous 3000-item defaults in `AptosDataClientConfig`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8434f8b7d51e47097d47aa99ed0839c6e619c223. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->