### PR TITLE
[consensus] Replace dummy StateComputeResult in PipelinedBlock with OnceCell

### DIFF
--- a/consensus/src/block_storage/block_store.rs
+++ b/consensus/src/block_storage/block_store.rs
@@ -221,16 +221,14 @@ impl BlockStore {
                 PipelinedBlock::new(
                     *commit_root_block,
                     vec![],
-                    // Create a dummy state_compute_result with necessary fields filled in.
-                    result.clone(),
+                    Some(result.clone()),
                 )
             },
             Some(window_block) => {
                 PipelinedBlock::new(
                     *window_block,
                     vec![],
-                    // Create a dummy state_compute_result with necessary fields filled in.
-                    result.clone(),
+                    Some(result.clone()),
                 )
             },
         };

--- a/consensus/src/block_storage/block_store_test.rs
+++ b/consensus/src/block_storage/block_store_test.rs
@@ -291,11 +291,7 @@ async fn test_insert_vote() {
     for (i, voter) in signers.iter().enumerate().take(10).skip(1) {
         let vote = Vote::new(
             VoteData::new(
-                block.block().gen_block_info(
-                    block.compute_result().root_hash(),
-                    block.compute_result().last_version_or_0(),
-                    block.compute_result().epoch_state().clone(),
-                ),
+                block.block_info(),
                 block.quorum_cert().certified_block().clone(),
             ),
             voter.author(),
@@ -320,11 +316,7 @@ async fn test_insert_vote() {
     let final_voter = &signers[0];
     let vote = Vote::new(
         VoteData::new(
-            block.block().gen_block_info(
-                block.compute_result().root_hash(),
-                block.compute_result().last_version_or_0(),
-                block.compute_result().epoch_state().clone(),
-            ),
+            block.block_info(),
             block.quorum_cert().certified_block().clone(),
         ),
         final_voter.author(),

--- a/consensus/src/dag/adapter.rs
+++ b/consensus/src/dag/adapter.rs
@@ -24,7 +24,6 @@ use aptos_consensus_types::{
     quorum_cert::QuorumCert,
 };
 use aptos_crypto::HashValue;
-use aptos_executor_types::state_compute_result::StateComputeResult;
 use aptos_infallible::RwLock;
 use aptos_logger::{error, info};
 use aptos_storage_interface::DbReader;
@@ -195,7 +194,7 @@ impl OrderedNotifier for OrderedNotifierAdapter {
                 node_digests,
             ),
             vec![],
-            StateComputeResult::new_dummy(),
+            None,
         ));
         let block_info = block.block_info();
         *self.parent_block_info.write() = block_info.clone();

--- a/consensus/src/pipeline/buffer_item.rs
+++ b/consensus/src/pipeline/buffer_item.rs
@@ -458,7 +458,6 @@ mod test {
     use super::*;
     use aptos_consensus_types::{block::Block, block_data::BlockData};
     use aptos_crypto::HashValue;
-    use aptos_executor_types::state_compute_result::StateComputeResult;
     use aptos_types::{
         aggregate_signature::AggregateSignature,
         ledger_info::LedgerInfo,
@@ -497,7 +496,7 @@ mod test {
                 None,
             ),
             vec![],
-            StateComputeResult::new_dummy(),
+            None,
         ))
     }
 

--- a/consensus/src/pipeline/tests/test_utils.rs
+++ b/consensus/src/pipeline/tests/test_utils.rs
@@ -114,7 +114,7 @@ pub fn prepare_executed_blocks_with_ledger_info(
             Arc::new(PipelinedBlock::new(
                 proposal.block().clone(),
                 vec![],
-                compute_result.clone(),
+                Some(compute_result.clone()),
             ))
         })
         .collect();

--- a/consensus/src/rand/rand_gen/test_utils.rs
+++ b/consensus/src/rand/rand_gen/test_utils.rs
@@ -13,7 +13,6 @@ use aptos_consensus_types::{
     quorum_cert::QuorumCert,
 };
 use aptos_crypto::HashValue;
-use aptos_executor_types::state_compute_result::StateComputeResult;
 use aptos_types::{
     aggregate_signature::AggregateSignature,
     ledger_info::{LedgerInfo, LedgerInfoWithSignatures},
@@ -38,7 +37,7 @@ pub fn create_ordered_blocks(rounds: Vec<Round>) -> OrderedBlocks {
                     None,
                 ),
                 vec![],
-                StateComputeResult::new_dummy(),
+                None,
             ))
         })
         .collect();


### PR DESCRIPTION

PipelinedBlock::new_ordered() previously created a StateComputeResult::new_dummy()
for every block entering the consensus pipeline. Each dummy contained fresh
generation-0 SparseMerkleTree objects that polluted the scratchpad SMT GENERATION
"drop" gauge metric, causing it to repeatedly go to zero.

Change state_compute_result from Mutex<StateComputeResult> to OnceCell<StateComputeResult>.
Blocks created via new_ordered() now start with an empty OnceCell instead of
allocating a dummy. Methods that may be called before execution (block_info,
vote_proposal, is_reconfiguration_suffix, subscribable_events) handle the
unset case with the same default values the dummy previously produced.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
