### PR TITLE
[storage] Fix incorrect assertion in LedgerState::new

### DIFF
--- a/storage/storage-interface/src/state_store/state.rs
+++ b/storage/storage-interface/src/state_store/state.rs
@@ -399,7 +399,7 @@ pub struct LedgerState {
 
 impl LedgerState {
     pub fn new(latest: State, last_checkpoint: State) -> Self {
-        assert!(latest.is_descendant_of(&latest));
+        assert!(latest.is_descendant_of(&last_checkpoint));
 
         Self {
             latest,


### PR DESCRIPTION

The assertion was checking `latest.is_descendant_of(&latest)` which
always passes. Changed to check `latest.is_descendant_of(&last_checkpoint)`
to properly validate that the latest state is a descendant of the
last checkpoint state.

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line assertion fix that only strengthens invariant validation and should only cause failures when callers provide inconsistent states.
> 
> **Overview**
> Fixes a broken invariant check in `LedgerState::new` by asserting the `latest` `State` is a descendant of `last_checkpoint` (instead of incorrectly comparing `latest` to itself), so invalid ledger state pairings are caught at construction time.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b23cb5bc4ee627da5682a2604b49b0eca2012762. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->