### PR TITLE
[consensus] Use spawn_blocking for CPU-intensive verification

### DIFF
--- a/consensus/src/epoch_manager.rs
+++ b/consensus/src/epoch_manager.rs
@@ -1587,7 +1587,7 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
             let payload_manager = self.payload_manager.clone();
             let pending_blocks = self.pending_blocks.clone();
             self.bounded_executor
-                .spawn(async move {
+                .spawn_blocking(move || {
                     match monitor!(
                         "verify_message",
                         unverified_event.clone().verify(

--- a/consensus/src/pipeline/buffer_manager.rs
+++ b/consensus/src/pipeline/buffer_manager.rs
@@ -921,7 +921,7 @@ impl BufferManager {
                 let tx = verified_commit_msg_tx.clone();
                 let epoch_state_clone = epoch_state.clone();
                 bounded_executor
-                    .spawn(async move {
+                    .spawn_blocking(move || {
                         match commit_msg.req.verify(sender, &epoch_state_clone.verifier) {
                             Ok(_) => {
                                 let _ = tx.unbounded_send(commit_msg);

--- a/consensus/src/rand/rand_gen/rand_manager.rs
+++ b/consensus/src/rand/rand_gen/rand_manager.rs
@@ -232,7 +232,7 @@ impl<S: TShare, D: TAugmentedData> RandManager<S, D> {
             let config_clone = rand_config.clone();
             let fast_config_clone = fast_rand_config.clone();
             bounded_executor
-                .spawn(async move {
+                .spawn_blocking(move || {
                     match bcs::from_bytes::<RandMessage<S, D>>(rand_gen_msg.req.data()) {
                         Ok(msg) => {
                             if msg

--- a/consensus/src/rand/secret_sharing/secret_share_manager.rs
+++ b/consensus/src/rand/secret_sharing/secret_share_manager.rs
@@ -214,7 +214,7 @@ impl SecretShareManager {
             let epoch_state_clone = epoch_state.clone();
             let config_clone = config.clone();
             bounded_executor
-                .spawn(async move {
+                .spawn_blocking(move || {
                     match bcs::from_bytes::<SecretShareMessage>(dec_msg.req.data()) {
                         Ok(msg) => {
                             if msg.verify(&epoch_state_clone, &config_clone).is_ok() {


### PR DESCRIPTION
## Summary
- Changed 4 `BoundedExecutor::spawn` callsites to `spawn_blocking` in the consensus crate where the spawned closures perform synchronous, CPU-intensive cryptographic verification (BLS signature checks, DKG verification, BCS deserialization)
- This moves blocking work off the async executor's worker threads and onto tokio's dedicated blocking thread pool, preventing it from starving async I/O tasks
- 3 callsites in `dag_handler.rs` are left unchanged as they spawn genuinely async futures with `.await` points

## Test plan
- [x] `cargo check -p aptos-consensus` passes
- [ ] Existing consensus unit tests pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized concurrency change that only alters where verification runs; main risk is subtle scheduling/throughput differences or blocking-pool saturation under load.
> 
> **Overview**
> Moves four CPU-bound verification callsites in consensus (epoch message verification, buffer manager commit message verification, rand gen RPC verification, and secret share RPC verification) from `BoundedExecutor::spawn(async ...)` to `spawn_blocking(...)`.
> 
> This offloads synchronous crypto/BCS-deserialization work from the async runtime worker threads to the blocking thread pool, reducing the chance of starving I/O-driven consensus tasks while keeping the verification/forwarding logic otherwise unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0298009187f9ba50a723526f6f23fdc0a7bb47f3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->