### PR TITLE
[jemalloc] Add background thread for periodic jemalloc stats as Prometheus gauges

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2796,6 +2796,10 @@ dependencies = [
 name = "aptos-jemalloc"
 version = "0.1.0"
 dependencies = [
+ "aptos-logger",
+ "aptos-metrics-core",
+ "once_cell",
+ "tikv-jemalloc-ctl",
  "tikv-jemallocator",
 ]
 

--- a/aptos-node/src/lib.rs
+++ b/aptos-node/src/lib.rs
@@ -697,6 +697,10 @@ pub fn setup_environment_and_start_node(
     // Log the node config at node startup
     node_config.log_all_configs();
 
+    // Start periodic jemalloc metrics collection
+    #[cfg(unix)]
+    aptos_jemalloc::start_jemalloc_metrics_thread();
+
     // Starts the admin service
     let mut admin_service = services::start_admin_service(&node_config);
 

--- a/crates/aptos-jemalloc/Cargo.toml
+++ b/crates/aptos-jemalloc/Cargo.toml
@@ -14,3 +14,7 @@ rust-version = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
 jemallocator = { workspace = true }
+jemalloc-ctl = { workspace = true, features = ["stats"] }
+aptos-metrics-core = { workspace = true }
+aptos-logger = { workspace = true }
+once_cell = { workspace = true }

--- a/crates/aptos-jemalloc/src/lib.rs
+++ b/crates/aptos-jemalloc/src/lib.rs
@@ -4,6 +4,11 @@
 #[cfg(unix)]
 pub use jemallocator;
 
+#[cfg(unix)]
+mod metrics;
+#[cfg(unix)]
+pub use metrics::start_jemalloc_metrics_thread;
+
 /// Sets up jemalloc as the global allocator and configures `malloc_conf`.
 ///
 /// Invoke at the top level of a binary crate (`main.rs`).

--- a/crates/aptos-jemalloc/src/metrics.rs
+++ b/crates/aptos-jemalloc/src/metrics.rs
@@ -1,0 +1,77 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+use aptos_metrics_core::{register_int_gauge_vec, IntGaugeVec, IntGaugeVecHelper};
+use jemalloc_ctl::Error;
+use once_cell::sync::Lazy;
+use std::{sync::OnceLock, thread, time::Duration};
+
+const COLLECTION_INTERVAL: Duration = Duration::from_secs(30);
+
+/// Merged arena index that aggregates stats across all arenas.
+/// This is `MALLCTL_ARENAS_ALL` from jemalloc's public API.
+const ARENAS_ALL: usize = 4096;
+
+static JEMALLOC_BYTES: Lazy<IntGaugeVec> = Lazy::new(|| {
+    register_int_gauge_vec!(
+        "aptos_jemalloc_bytes",
+        "jemalloc allocator statistics in bytes",
+        &["stat"]
+    )
+    .unwrap()
+});
+
+/// Spawns a background thread that periodically collects jemalloc statistics
+/// and exports them as Prometheus gauges.
+pub fn start_jemalloc_metrics_thread() {
+    thread::Builder::new()
+        .name("jemalloc-stats".into())
+        .spawn(|| loop {
+            thread::sleep(COLLECTION_INTERVAL);
+            if let Err(e) = collect_once() {
+                aptos_logger::warn!("jemalloc-stats: collection error: {}", e);
+            }
+        })
+        .expect("failed to spawn jemalloc-stats thread");
+}
+
+fn page_size() -> usize {
+    static PAGE_SIZE: OnceLock<usize> = OnceLock::new();
+    *PAGE_SIZE.get_or_init(|| {
+        let key = b"arenas.page\0";
+        unsafe { jemalloc_ctl::raw::read(key) }.expect("failed to read arenas.page")
+    })
+}
+
+/// Reads a `usize` from a mallctl key under the merged arena namespace.
+unsafe fn read_arena_usize(name: &str) -> Result<usize, Error> {
+    let key = format!("stats.arenas.{ARENAS_ALL}.{name}\0");
+    unsafe { jemalloc_ctl::raw::read(key.as_bytes()) }
+}
+
+fn collect_once() -> Result<(), Error> {
+    // Advance the epoch so subsequent reads return fresh values.
+    jemalloc_ctl::epoch::advance()?;
+
+    let gauge = |name: &str, val: usize| {
+        JEMALLOC_BYTES.set_with(&[name], val as i64);
+    };
+
+    // Global stats (bytes).
+    gauge("allocated", jemalloc_ctl::stats::allocated::read()?);
+    gauge("active", jemalloc_ctl::stats::active::read()?);
+    gauge("metadata", jemalloc_ctl::stats::metadata::read()?);
+    gauge("resident", jemalloc_ctl::stats::resident::read()?);
+    gauge("mapped", jemalloc_ctl::stats::mapped::read()?);
+    gauge("retained", jemalloc_ctl::stats::retained::read()?);
+
+    // Per-arena stats aggregated across all arenas (raw mallctl).
+    unsafe {
+        let page_size = page_size();
+        gauge("dirty", read_arena_usize("pdirty")? * page_size);
+        gauge("muzzy", read_arena_usize("pmuzzy")? * page_size);
+        gauge("tcache", read_arena_usize("tcache_bytes")?);
+    }
+
+    Ok(())
+}


### PR DESCRIPTION

Export a single `IntGaugeVec` named `aptos_jemalloc_bytes` with a `stat`
label covering: `allocated`, `active`, `metadata`, `resident`, `mapped`,
`retained`, `dirty`, `muzzy`, and `tcache`. A dedicated `jemalloc-metrics`
thread wakes every 30 seconds, advances the jemalloc epoch, reads the
stats via `jemalloc-ctl`, and updates the gauges. Dirty/muzzy page counts
are converted to bytes using the runtime page size.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a long-lived background thread and unsafe jemalloc `mallctl` reads; failures should be non-fatal but could impact stability/perf or metrics correctness on Unix builds.
> 
> **Overview**
> Starts a Unix-only background thread during node startup to periodically collect jemalloc allocator statistics and expose them via Prometheus.
> 
> Adds a new `aptos-jemalloc` metrics module that registers `aptos_jemalloc_bytes{stat=...}` and updates it every 30s using `jemalloc-ctl` (including aggregated arena stats for dirty/muzzy/tcache), plus the required new dependencies.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1a43e91a1939a34aaa904d6f317902a1a3164160. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->