### PR TITLE
First-class StorageSlot type and derived StorageSlotOrInline 

### DIFF
--- a/aptos-move/aptos-gas-schedule/src/gas_schedule/aptos_framework.rs
+++ b/aptos-move/aptos-gas-schedule/src/gas_schedule/aptos_framework.rs
@@ -362,5 +362,11 @@ crate::gas_schedule::macros::define_gas_parameters!(
 
         // Reflection
         [reflect_resolve_base: InternalGas, { RELEASE_V1_39.. => "reflect.resolve_base" }, 40960],
+
+        // Storage slot
+        [storage_slot_borrow_base: InternalGas, "storage_slot.borrow.base", 9190],
+        [storage_slot_borrow_per_byte_loaded: InternalGasPerByte, "storage_slot.borrow.per_byte_loaded", 1830],
+        [storage_slot_borrow_mut_base: InternalGas, "storage_slot.borrow_mut.base", 9190],
+        [storage_slot_borrow_mut_per_byte_loaded: InternalGasPerByte, "storage_slot.borrow_mut.per_byte_loaded", 1830],
     ]
 );

--- a/aptos-move/aptos-gas-schedule/src/gas_schedule/aptos_framework.rs
+++ b/aptos-move/aptos-gas-schedule/src/gas_schedule/aptos_framework.rs
@@ -4,11 +4,11 @@
 //! This module defines the gas parameters for Aptos Framework & Stdlib.
 
 use crate::{
-    gas_feature_versions::{RELEASE_V1_14, RELEASE_V1_8, RELEASE_V1_9_SKIPPED},
     gas_schedule::NativeGasParameters,
     ver::gas_feature_versions::{
-        RELEASE_V1_12, RELEASE_V1_13, RELEASE_V1_23, RELEASE_V1_26, RELEASE_V1_28, RELEASE_V1_36,
-        RELEASE_V1_39, RELEASE_V1_45,
+        RELEASE_V1_12, RELEASE_V1_13, RELEASE_V1_14, RELEASE_V1_23, RELEASE_V1_26, RELEASE_V1_28,
+        RELEASE_V1_36, RELEASE_V1_39, RELEASE_V1_45, RELEASE_V1_46, RELEASE_V1_8,
+        RELEASE_V1_9_SKIPPED,
     },
 };
 use aptos_gas_algebra::{
@@ -364,9 +364,9 @@ crate::gas_schedule::macros::define_gas_parameters!(
         [reflect_resolve_base: InternalGas, { RELEASE_V1_39.. => "reflect.resolve_base" }, 40960],
 
         // Storage slot
-        [storage_slot_borrow_base: InternalGas, "storage_slot.borrow.base", 9190],
-        [storage_slot_borrow_per_byte_loaded: InternalGasPerByte, "storage_slot.borrow.per_byte_loaded", 1830],
-        [storage_slot_borrow_mut_base: InternalGas, "storage_slot.borrow_mut.base", 9190],
-        [storage_slot_borrow_mut_per_byte_loaded: InternalGasPerByte, "storage_slot.borrow_mut.per_byte_loaded", 1830],
+        [storage_slot_borrow_base: InternalGas, { RELEASE_V1_46.. => "storage_slot.borrow.base" }, 9190],
+        [storage_slot_borrow_per_byte_loaded: InternalGasPerByte, { RELEASE_V1_46.. => "storage_slot.borrow.per_byte_loaded" }, 1830],
+        [storage_slot_borrow_mut_base: InternalGas, { RELEASE_V1_46.. => "storage_slot.borrow_mut.base" }, 9190],
+        [storage_slot_borrow_mut_per_byte_loaded: InternalGasPerByte, { RELEASE_V1_46.. => "storage_slot.borrow_mut.per_byte_loaded" }, 1830],
     ]
 );

--- a/aptos-move/aptos-release-builder/src/components/feature_flags.rs
+++ b/aptos-move/aptos-release-builder/src/components/feature_flags.rs
@@ -164,6 +164,7 @@ pub enum FeatureFlag {
     MultisigScript,
     TransactionLimits,
     VersionedTransactionValidation,
+    StorageSlotNatives,
 }
 
 fn generate_features_blob(writer: &CodeWriter, data: &[u64]) {
@@ -429,6 +430,7 @@ impl From<FeatureFlag> for AptosFeatureFlag {
             FeatureFlag::VersionedTransactionValidation => {
                 AptosFeatureFlag::VERSIONED_TRANSACTION_VALIDATION
             },
+            FeatureFlag::StorageSlotNatives => AptosFeatureFlag::STORAGE_SLOT_NATIVES,
         }
     }
 }
@@ -621,6 +623,7 @@ impl From<AptosFeatureFlag> for FeatureFlag {
             AptosFeatureFlag::VERSIONED_TRANSACTION_VALIDATION => {
                 FeatureFlag::VersionedTransactionValidation
             },
+            AptosFeatureFlag::STORAGE_SLOT_NATIVES => FeatureFlag::StorageSlotNatives,
         }
     }
 }

--- a/aptos-move/framework/aptos-framework/Prover.toml
+++ b/aptos-move/framework/aptos-framework/Prover.toml
@@ -1,2 +1,5 @@
 [backend]
 shards = 5
+
+[prover]
+borrow_natives = ["storage_slot::borrow_storage_slot_resource_mut"]

--- a/aptos-move/framework/aptos-framework/doc/overview.md
+++ b/aptos-move/framework/aptos-framework/doc/overview.md
@@ -95,6 +95,8 @@ This is the reference documentation of the Aptos framework.
 -  [`0x1::staking_proxy`](staking_proxy.md#0x1_staking_proxy)
 -  [`0x1::state_storage`](state_storage.md#0x1_state_storage)
 -  [`0x1::storage_gas`](storage_gas.md#0x1_storage_gas)
+-  [`0x1::storage_slot`](storage_slot.md#0x1_storage_slot)
+-  [`0x1::storage_slot_or_inline`](storage_slot_or_inline.md#0x1_storage_slot_or_inline)
 -  [`0x1::sui_derivable_account`](sui_derivable_account.md#0x1_sui_derivable_account)
 -  [`0x1::system_addresses`](system_addresses.md#0x1_system_addresses)
 -  [`0x1::timestamp`](timestamp.md#0x1_timestamp)

--- a/aptos-move/framework/aptos-framework/doc/storage_slot.md
+++ b/aptos-move/framework/aptos-framework/doc/storage_slot.md
@@ -1,0 +1,267 @@
+
+<a id="0x1_storage_slot"></a>
+
+# Module `0x1::storage_slot`
+
+
+
+-  [Resource `StorageSlotResource`](#0x1_storage_slot_StorageSlotResource)
+-  [Struct `StorageSlot`](#0x1_storage_slot_StorageSlot)
+-  [Constants](#@Constants_0)
+-  [Function `new`](#0x1_storage_slot_new)
+-  [Function `borrow_storage_slot_resource`](#0x1_storage_slot_borrow_storage_slot_resource)
+-  [Function `borrow_storage_slot_resource_mut`](#0x1_storage_slot_borrow_storage_slot_resource_mut)
+-  [Function `borrow`](#0x1_storage_slot_borrow)
+-  [Function `borrow_mut`](#0x1_storage_slot_borrow_mut)
+-  [Function `copy_storage_slot`](#0x1_storage_slot_copy_storage_slot)
+-  [Function `destroy`](#0x1_storage_slot_destroy)
+
+
+<pre><code><b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features">0x1::features</a>;
+<b>use</b> <a href="object.md#0x1_object">0x1::object</a>;
+<b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">0x1::signer</a>;
+</code></pre>
+
+
+
+<a id="0x1_storage_slot_StorageSlotResource"></a>
+
+## Resource `StorageSlotResource`
+
+
+
+<pre><code><b>struct</b> <a href="storage_slot.md#0x1_storage_slot_StorageSlotResource">StorageSlotResource</a>&lt;T&gt; <b>has</b> key
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>val: T</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a id="0x1_storage_slot_StorageSlot"></a>
+
+## Struct `StorageSlot`
+
+
+
+<pre><code><b>struct</b> <a href="storage_slot.md#0x1_storage_slot_StorageSlot">StorageSlot</a>&lt;T&gt; <b>has</b> store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>addr: <b>address</b></code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a id="@Constants_0"></a>
+
+## Constants
+
+
+<a id="0x1_storage_slot_ESTORAGE_SLOT_NATIVES_NOT_ENABLED"></a>
+
+Storage slot natives are not enabled.
+
+
+<pre><code><b>const</b> <a href="storage_slot.md#0x1_storage_slot_ESTORAGE_SLOT_NATIVES_NOT_ENABLED">ESTORAGE_SLOT_NATIVES_NOT_ENABLED</a>: u64 = 1;
+</code></pre>
+
+
+
+<a id="0x1_storage_slot_new"></a>
+
+## Function `new`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="storage_slot.md#0x1_storage_slot_new">new</a>&lt;T: store&gt;(value: T): <a href="storage_slot.md#0x1_storage_slot_StorageSlot">storage_slot::StorageSlot</a>&lt;T&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="storage_slot.md#0x1_storage_slot_new">new</a>&lt;T: store&gt;(value: T): <a href="storage_slot.md#0x1_storage_slot_StorageSlot">StorageSlot</a>&lt;T&gt; {
+    <b>let</b> unique_signer = <a href="object.md#0x1_object_create_unique_onchain_signer">object::create_unique_onchain_signer</a>().generate_signer_for_extending();
+    <b>move_to</b>(&unique_signer, <a href="storage_slot.md#0x1_storage_slot_StorageSlotResource">StorageSlotResource</a> { val: value });
+    <a href="storage_slot.md#0x1_storage_slot_StorageSlot">StorageSlot</a> { addr: unique_signer.address_of() }
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_storage_slot_borrow_storage_slot_resource"></a>
+
+## Function `borrow_storage_slot_resource`
+
+
+
+<pre><code><b>fun</b> <a href="storage_slot.md#0x1_storage_slot_borrow_storage_slot_resource">borrow_storage_slot_resource</a>&lt;T: store, BR&gt;(self: &<a href="storage_slot.md#0x1_storage_slot_StorageSlot">storage_slot::StorageSlot</a>&lt;T&gt;): &BR
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>native</b> <b>fun</b> <a href="storage_slot.md#0x1_storage_slot_borrow_storage_slot_resource">borrow_storage_slot_resource</a>&lt;T: store, BR&gt;(self: &<a href="storage_slot.md#0x1_storage_slot_StorageSlot">StorageSlot</a>&lt;T&gt;): &BR;
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_storage_slot_borrow_storage_slot_resource_mut"></a>
+
+## Function `borrow_storage_slot_resource_mut`
+
+
+
+<pre><code><b>fun</b> <a href="storage_slot.md#0x1_storage_slot_borrow_storage_slot_resource_mut">borrow_storage_slot_resource_mut</a>&lt;T: store, BR&gt;(self: &<b>mut</b> <a href="storage_slot.md#0x1_storage_slot_StorageSlot">storage_slot::StorageSlot</a>&lt;T&gt;): &<b>mut</b> BR
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>native</b> <b>fun</b> <a href="storage_slot.md#0x1_storage_slot_borrow_storage_slot_resource_mut">borrow_storage_slot_resource_mut</a>&lt;T: store, BR&gt;(self: &<b>mut</b> <a href="storage_slot.md#0x1_storage_slot_StorageSlot">StorageSlot</a>&lt;T&gt;): &<b>mut</b> BR;
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_storage_slot_borrow"></a>
+
+## Function `borrow`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="storage_slot.md#0x1_storage_slot_borrow">borrow</a>&lt;T: store&gt;(self: &<a href="storage_slot.md#0x1_storage_slot_StorageSlot">storage_slot::StorageSlot</a>&lt;T&gt;): &T
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="storage_slot.md#0x1_storage_slot_borrow">borrow</a>&lt;T: store&gt;(self: &<a href="storage_slot.md#0x1_storage_slot_StorageSlot">StorageSlot</a>&lt;T&gt;): &T {
+    <b>assert</b>!(std::features::is_storage_slot_natives_enabled(), <a href="storage_slot.md#0x1_storage_slot_ESTORAGE_SLOT_NATIVES_NOT_ENABLED">ESTORAGE_SLOT_NATIVES_NOT_ENABLED</a>);
+    &self.<a href="storage_slot.md#0x1_storage_slot_borrow_storage_slot_resource">borrow_storage_slot_resource</a>&lt;T, <a href="storage_slot.md#0x1_storage_slot_StorageSlotResource">StorageSlotResource</a>&lt;T&gt;&gt;().val
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_storage_slot_borrow_mut"></a>
+
+## Function `borrow_mut`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="storage_slot.md#0x1_storage_slot_borrow_mut">borrow_mut</a>&lt;T: store&gt;(self: &<b>mut</b> <a href="storage_slot.md#0x1_storage_slot_StorageSlot">storage_slot::StorageSlot</a>&lt;T&gt;): &<b>mut</b> T
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="storage_slot.md#0x1_storage_slot_borrow_mut">borrow_mut</a>&lt;T: store&gt;(self: &<b>mut</b> <a href="storage_slot.md#0x1_storage_slot_StorageSlot">StorageSlot</a>&lt;T&gt;): &<b>mut</b> T {
+    <b>assert</b>!(std::features::is_storage_slot_natives_enabled(), <a href="storage_slot.md#0x1_storage_slot_ESTORAGE_SLOT_NATIVES_NOT_ENABLED">ESTORAGE_SLOT_NATIVES_NOT_ENABLED</a>);
+    &<b>mut</b> self.<a href="storage_slot.md#0x1_storage_slot_borrow_storage_slot_resource_mut">borrow_storage_slot_resource_mut</a>&lt;T, <a href="storage_slot.md#0x1_storage_slot_StorageSlotResource">StorageSlotResource</a>&lt;T&gt;&gt;().val
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_storage_slot_copy_storage_slot"></a>
+
+## Function `copy_storage_slot`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="storage_slot.md#0x1_storage_slot_copy_storage_slot">copy_storage_slot</a>&lt;T: <b>copy</b>, store&gt;(self: &<a href="storage_slot.md#0x1_storage_slot_StorageSlot">storage_slot::StorageSlot</a>&lt;T&gt;): <a href="storage_slot.md#0x1_storage_slot_StorageSlot">storage_slot::StorageSlot</a>&lt;T&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="storage_slot.md#0x1_storage_slot_copy_storage_slot">copy_storage_slot</a>&lt;T: store + <b>copy</b>&gt;(self: &<a href="storage_slot.md#0x1_storage_slot_StorageSlot">StorageSlot</a>&lt;T&gt;): <a href="storage_slot.md#0x1_storage_slot_StorageSlot">StorageSlot</a>&lt;T&gt; {
+    <a href="storage_slot.md#0x1_storage_slot_new">new</a>(*self.<a href="storage_slot.md#0x1_storage_slot_borrow">borrow</a>())
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_storage_slot_destroy"></a>
+
+## Function `destroy`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="storage_slot.md#0x1_storage_slot_destroy">destroy</a>&lt;T: store&gt;(self: <a href="storage_slot.md#0x1_storage_slot_StorageSlot">storage_slot::StorageSlot</a>&lt;T&gt;): T
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="storage_slot.md#0x1_storage_slot_destroy">destroy</a>&lt;T: store&gt;(self: <a href="storage_slot.md#0x1_storage_slot_StorageSlot">StorageSlot</a>&lt;T&gt;): T {
+    <b>let</b> <a href="storage_slot.md#0x1_storage_slot_StorageSlot">StorageSlot</a> { addr } = self;
+    <b>let</b> <a href="storage_slot.md#0x1_storage_slot_StorageSlotResource">StorageSlotResource</a> { val } = <b>move_from</b>&lt;<a href="storage_slot.md#0x1_storage_slot_StorageSlotResource">StorageSlotResource</a>&lt;T&gt;&gt;(addr);
+    val
+}
+</code></pre>
+
+
+
+</details>
+
+
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/aptos-framework/doc/storage_slot_or_inline.md
+++ b/aptos-move/framework/aptos-framework/doc/storage_slot_or_inline.md
@@ -1,0 +1,340 @@
+
+<a id="0x1_storage_slot_or_inline"></a>
+
+# Module `0x1::storage_slot_or_inline`
+
+
+
+-  [Enum `StorageSlotOrInline`](#0x1_storage_slot_or_inline_StorageSlotOrInline)
+-  [Struct `Dummy`](#0x1_storage_slot_or_inline_Dummy)
+-  [Constants](#@Constants_0)
+-  [Function `new_inline`](#0x1_storage_slot_or_inline_new_inline)
+-  [Function `new_storage_slot`](#0x1_storage_slot_or_inline_new_storage_slot)
+-  [Function `borrow`](#0x1_storage_slot_or_inline_borrow)
+-  [Function `borrow_mut`](#0x1_storage_slot_or_inline_borrow_mut)
+-  [Function `destroy`](#0x1_storage_slot_or_inline_destroy)
+-  [Function `move_to_inline`](#0x1_storage_slot_or_inline_move_to_inline)
+-  [Function `move_to_storage_slot`](#0x1_storage_slot_or_inline_move_to_storage_slot)
+
+
+<pre><code><b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/mem.md#0x1_mem">0x1::mem</a>;
+<b>use</b> <a href="storage_slot.md#0x1_storage_slot">0x1::storage_slot</a>;
+</code></pre>
+
+
+
+<a id="0x1_storage_slot_or_inline_StorageSlotOrInline"></a>
+
+## Enum `StorageSlotOrInline`
+
+
+
+<pre><code>enum <a href="storage_slot_or_inline.md#0x1_storage_slot_or_inline_StorageSlotOrInline">StorageSlotOrInline</a>&lt;T&gt; <b>has</b> store
+</code></pre>
+
+
+
+<details>
+<summary>Variants</summary>
+
+
+<details>
+<summary>Inline</summary>
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>value: T</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+</details>
+
+<details>
+<summary>StorageSlot</summary>
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>slot: <a href="storage_slot.md#0x1_storage_slot_StorageSlot">storage_slot::StorageSlot</a>&lt;T&gt;</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+</details>
+
+<details>
+<summary>Transient</summary>
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+</dl>
+
+
+</details>
+
+</details>
+
+</details>
+
+<a id="0x1_storage_slot_or_inline_Dummy"></a>
+
+## Struct `Dummy`
+
+
+
+<pre><code><b>struct</b> <a href="storage_slot_or_inline.md#0x1_storage_slot_or_inline_Dummy">Dummy</a> <b>has</b> store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>dummy_field: bool</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a id="@Constants_0"></a>
+
+## Constants
+
+
+<a id="0x1_storage_slot_or_inline_ESTORAGE_SLOT_INCORRECTLY_IN_TRANSIENT_STATE"></a>
+
+StorageSlotOrInline found in inconsistent (transient) state, should never happen.
+
+
+<pre><code><b>const</b> <a href="storage_slot_or_inline.md#0x1_storage_slot_or_inline_ESTORAGE_SLOT_INCORRECTLY_IN_TRANSIENT_STATE">ESTORAGE_SLOT_INCORRECTLY_IN_TRANSIENT_STATE</a>: u64 = 1;
+</code></pre>
+
+
+
+<a id="0x1_storage_slot_or_inline_new_inline"></a>
+
+## Function `new_inline`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="storage_slot_or_inline.md#0x1_storage_slot_or_inline_new_inline">new_inline</a>&lt;T: store&gt;(value: T): <a href="storage_slot_or_inline.md#0x1_storage_slot_or_inline_StorageSlotOrInline">storage_slot_or_inline::StorageSlotOrInline</a>&lt;T&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="storage_slot_or_inline.md#0x1_storage_slot_or_inline_new_inline">new_inline</a>&lt;T: store&gt;(value: T): <a href="storage_slot_or_inline.md#0x1_storage_slot_or_inline_StorageSlotOrInline">StorageSlotOrInline</a>&lt;T&gt; {
+    StorageSlotOrInline::Inline { value }
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_storage_slot_or_inline_new_storage_slot"></a>
+
+## Function `new_storage_slot`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="storage_slot_or_inline.md#0x1_storage_slot_or_inline_new_storage_slot">new_storage_slot</a>&lt;T: store&gt;(value: T): <a href="storage_slot_or_inline.md#0x1_storage_slot_or_inline_StorageSlotOrInline">storage_slot_or_inline::StorageSlotOrInline</a>&lt;T&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="storage_slot_or_inline.md#0x1_storage_slot_or_inline_new_storage_slot">new_storage_slot</a>&lt;T: store&gt;(value: T): <a href="storage_slot_or_inline.md#0x1_storage_slot_or_inline_StorageSlotOrInline">StorageSlotOrInline</a>&lt;T&gt; {
+    StorageSlotOrInline::StorageSlot { slot: <a href="storage_slot.md#0x1_storage_slot_new">storage_slot::new</a>(value) }
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_storage_slot_or_inline_borrow"></a>
+
+## Function `borrow`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="storage_slot_or_inline.md#0x1_storage_slot_or_inline_borrow">borrow</a>&lt;T: store&gt;(self: &<a href="storage_slot_or_inline.md#0x1_storage_slot_or_inline_StorageSlotOrInline">storage_slot_or_inline::StorageSlotOrInline</a>&lt;T&gt;): &T
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="storage_slot_or_inline.md#0x1_storage_slot_or_inline_borrow">borrow</a>&lt;T: store&gt;(self: &<a href="storage_slot_or_inline.md#0x1_storage_slot_or_inline_StorageSlotOrInline">StorageSlotOrInline</a>&lt;T&gt;): &T {
+    match (self) {
+        StorageSlotOrInline::Inline { value } =&gt; value,
+        StorageSlotOrInline::StorageSlot { slot } =&gt; slot.<a href="storage_slot_or_inline.md#0x1_storage_slot_or_inline_borrow">borrow</a>(),
+        StorageSlotOrInline::Transient =&gt; <b>abort</b> <a href="storage_slot_or_inline.md#0x1_storage_slot_or_inline_ESTORAGE_SLOT_INCORRECTLY_IN_TRANSIENT_STATE">ESTORAGE_SLOT_INCORRECTLY_IN_TRANSIENT_STATE</a>,
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_storage_slot_or_inline_borrow_mut"></a>
+
+## Function `borrow_mut`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="storage_slot_or_inline.md#0x1_storage_slot_or_inline_borrow_mut">borrow_mut</a>&lt;T: store&gt;(self: &<b>mut</b> <a href="storage_slot_or_inline.md#0x1_storage_slot_or_inline_StorageSlotOrInline">storage_slot_or_inline::StorageSlotOrInline</a>&lt;T&gt;): &<b>mut</b> T
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="storage_slot_or_inline.md#0x1_storage_slot_or_inline_borrow_mut">borrow_mut</a>&lt;T: store&gt;(self: &<b>mut</b> <a href="storage_slot_or_inline.md#0x1_storage_slot_or_inline_StorageSlotOrInline">StorageSlotOrInline</a>&lt;T&gt;): &<b>mut</b> T {
+    match (self) {
+        StorageSlotOrInline::Inline { value } =&gt; value,
+        StorageSlotOrInline::StorageSlot { slot } =&gt; slot.<a href="storage_slot_or_inline.md#0x1_storage_slot_or_inline_borrow_mut">borrow_mut</a>(),
+        StorageSlotOrInline::Transient =&gt; <b>abort</b> <a href="storage_slot_or_inline.md#0x1_storage_slot_or_inline_ESTORAGE_SLOT_INCORRECTLY_IN_TRANSIENT_STATE">ESTORAGE_SLOT_INCORRECTLY_IN_TRANSIENT_STATE</a>,
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_storage_slot_or_inline_destroy"></a>
+
+## Function `destroy`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="storage_slot_or_inline.md#0x1_storage_slot_or_inline_destroy">destroy</a>&lt;T: store&gt;(self: <a href="storage_slot_or_inline.md#0x1_storage_slot_or_inline_StorageSlotOrInline">storage_slot_or_inline::StorageSlotOrInline</a>&lt;T&gt;): T
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="storage_slot_or_inline.md#0x1_storage_slot_or_inline_destroy">destroy</a>&lt;T: store&gt;(self: <a href="storage_slot_or_inline.md#0x1_storage_slot_or_inline_StorageSlotOrInline">StorageSlotOrInline</a>&lt;T&gt;): T {
+    match (self) {
+        StorageSlotOrInline::Inline { value } =&gt; value,
+        StorageSlotOrInline::StorageSlot { slot } =&gt; slot.<a href="storage_slot_or_inline.md#0x1_storage_slot_or_inline_destroy">destroy</a>(),
+        StorageSlotOrInline::Transient =&gt; <b>abort</b> <a href="storage_slot_or_inline.md#0x1_storage_slot_or_inline_ESTORAGE_SLOT_INCORRECTLY_IN_TRANSIENT_STATE">ESTORAGE_SLOT_INCORRECTLY_IN_TRANSIENT_STATE</a>,
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_storage_slot_or_inline_move_to_inline"></a>
+
+## Function `move_to_inline`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="storage_slot_or_inline.md#0x1_storage_slot_or_inline_move_to_inline">move_to_inline</a>&lt;T: store&gt;(self: &<b>mut</b> <a href="storage_slot_or_inline.md#0x1_storage_slot_or_inline_StorageSlotOrInline">storage_slot_or_inline::StorageSlotOrInline</a>&lt;T&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="storage_slot_or_inline.md#0x1_storage_slot_or_inline_move_to_inline">move_to_inline</a>&lt;T: store&gt;(self: &<b>mut</b> <a href="storage_slot_or_inline.md#0x1_storage_slot_or_inline_StorageSlotOrInline">StorageSlotOrInline</a>&lt;T&gt;) {
+    match (self) {
+        StorageSlotOrInline::Inline { value: _ } =&gt; {},
+        StorageSlotOrInline::StorageSlot { slot: _ } =&gt; {
+            <b>let</b> StorageSlotOrInline::StorageSlot { slot } = <a href="../../aptos-stdlib/../move-stdlib/doc/mem.md#0x1_mem_replace">mem::replace</a>(self, StorageSlotOrInline::Transient);
+            <b>let</b> StorageSlotOrInline::Transient = <a href="../../aptos-stdlib/../move-stdlib/doc/mem.md#0x1_mem_replace">mem::replace</a>(self, <a href="storage_slot_or_inline.md#0x1_storage_slot_or_inline_new_inline">new_inline</a>(slot.<a href="storage_slot_or_inline.md#0x1_storage_slot_or_inline_destroy">destroy</a>()));
+        },
+        StorageSlotOrInline::Transient =&gt; <b>abort</b> <a href="storage_slot_or_inline.md#0x1_storage_slot_or_inline_ESTORAGE_SLOT_INCORRECTLY_IN_TRANSIENT_STATE">ESTORAGE_SLOT_INCORRECTLY_IN_TRANSIENT_STATE</a>,
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_storage_slot_or_inline_move_to_storage_slot"></a>
+
+## Function `move_to_storage_slot`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="storage_slot_or_inline.md#0x1_storage_slot_or_inline_move_to_storage_slot">move_to_storage_slot</a>&lt;T: store&gt;(self: &<b>mut</b> <a href="storage_slot_or_inline.md#0x1_storage_slot_or_inline_StorageSlotOrInline">storage_slot_or_inline::StorageSlotOrInline</a>&lt;T&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="storage_slot_or_inline.md#0x1_storage_slot_or_inline_move_to_storage_slot">move_to_storage_slot</a>&lt;T: store&gt;(self: &<b>mut</b> <a href="storage_slot_or_inline.md#0x1_storage_slot_or_inline_StorageSlotOrInline">StorageSlotOrInline</a>&lt;T&gt;) {
+    match (self) {
+        StorageSlotOrInline::Inline { value: _ } =&gt; {
+            <b>let</b> StorageSlotOrInline::Inline { value } = <a href="../../aptos-stdlib/../move-stdlib/doc/mem.md#0x1_mem_replace">mem::replace</a>(self, StorageSlotOrInline::Transient);
+            <b>let</b> StorageSlotOrInline::Transient = <a href="../../aptos-stdlib/../move-stdlib/doc/mem.md#0x1_mem_replace">mem::replace</a>(self, <a href="storage_slot_or_inline.md#0x1_storage_slot_or_inline_new_storage_slot">new_storage_slot</a>(value));
+        },
+        StorageSlotOrInline::StorageSlot { slot: _ } =&gt; {},
+        StorageSlotOrInline::Transient =&gt; <b>abort</b> <a href="storage_slot_or_inline.md#0x1_storage_slot_or_inline_ESTORAGE_SLOT_INCORRECTLY_IN_TRANSIENT_STATE">ESTORAGE_SLOT_INCORRECTLY_IN_TRANSIENT_STATE</a>,
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/aptos-framework/sources/datastructures/storage_slot.move
+++ b/aptos-move/framework/aptos-framework/sources/datastructures/storage_slot.move
@@ -1,0 +1,56 @@
+module aptos_framework::storage_slot {
+    use aptos_framework::object;
+
+    /// Storage slot natives are not enabled.
+    const ESTORAGE_SLOT_NATIVES_NOT_ENABLED: u64 = 1;
+    /// Resource under storage slot not found, this should never happen.
+    /// Emitted by native functions.
+    const ESTORAGE_SLOT_NOT_FOUND: u64 = 2;
+
+    struct StorageSlotResource<T> has key {
+        val: T
+    }
+
+    struct StorageSlot<phantom T> has store {
+        addr: address
+    }
+
+    public fun new<T: store>(value: T): StorageSlot<T> {
+        let unique_signer = object::create_unique_onchain_signer().generate_signer_for_extending();
+        move_to(&unique_signer, StorageSlotResource { val: value });
+        StorageSlot { addr: unique_signer.address_of() }
+    }
+
+    // Internal natives that take StorageSlotResource<T> as a type parameter (like table's borrow_box)
+    native fun borrow_storage_slot_resource<T: store, BR>(self: &StorageSlot<T>): &BR;
+    native fun borrow_storage_slot_resource_mut<T: store, BR>(self: &mut StorageSlot<T>): &mut BR;
+
+    public fun borrow<T: store>(self: &StorageSlot<T>): &T {
+        assert!(std::features::is_storage_slot_natives_enabled(), ESTORAGE_SLOT_NATIVES_NOT_ENABLED);
+        &self.borrow_storage_slot_resource<T, StorageSlotResource<T>>().val
+    }
+
+    public fun borrow_mut<T: store>(self: &mut StorageSlot<T>): &mut T {
+        assert!(std::features::is_storage_slot_natives_enabled(), ESTORAGE_SLOT_NATIVES_NOT_ENABLED);
+        &mut self.borrow_storage_slot_resource_mut<T, StorageSlotResource<T>>().val
+    }
+
+    public fun copy_storage_slot<T: store + copy>(self: &StorageSlot<T>): StorageSlot<T> {
+        new(*self.borrow())
+    }
+
+    public fun destroy<T: store>(self: StorageSlot<T>): T {
+        let StorageSlot { addr } = self;
+        let StorageSlotResource { val } = move_from<StorageSlotResource<T>>(addr);
+        val
+    }
+
+    #[test]
+    public fun test_storage_slot() {
+        let slot = new(1u64);
+        assert!(slot.borrow() == &1);
+        *slot.borrow_mut() += 1;
+        assert!(slot.borrow() == &2);
+        assert!(slot.destroy() == 2);
+    }
+}

--- a/aptos-move/framework/aptos-framework/sources/datastructures/storage_slot.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/datastructures/storage_slot.spec.move
@@ -1,0 +1,37 @@
+// Copyright (c) Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+/// Spec for storage_slot module.
+/// The native functions `borrow_storage_slot_resource` and `borrow_storage_slot_resource_mut`
+/// do not have Boogie models, so we mark `borrow` and `borrow_mut` as opaque and unverified.
+/// The other functions are skipped from verification due to difficulty in reasoning about
+/// the dynamically allocated address created by `transaction_context::generate_unique_signer`.
+spec aptos_framework::storage_slot {
+    spec module {
+        pragma verify = false;
+    }
+
+    spec borrow<T: store>(self: &StorageSlot<T>): &T {
+        pragma opaque;
+        pragma verify = false;
+        aborts_if [abstract] false;
+    }
+
+    spec borrow_mut<T: store>(self: &mut StorageSlot<T>): &mut T {
+        pragma opaque;
+        pragma verify = false;
+        aborts_if [abstract] false;
+    }
+
+    spec new<T: store>(value: T): StorageSlot<T> {
+        pragma verify = false;
+    }
+
+    spec destroy<T: store>(self: StorageSlot<T>): T {
+        pragma verify = false;
+    }
+
+    spec copy_storage_slot<T: store + copy>(self: &StorageSlot<T>): StorageSlot<T> {
+        pragma verify = false;
+    }
+}

--- a/aptos-move/framework/aptos-framework/sources/datastructures/storage_slot_or_inline.move
+++ b/aptos-move/framework/aptos-framework/sources/datastructures/storage_slot_or_inline.move
@@ -1,0 +1,78 @@
+module aptos_framework::storage_slot_or_inline {
+    use std::mem;
+    use aptos_framework::storage_slot::{Self, StorageSlot};
+
+    /// StorageSlotOrInline found in inconsistent (transient) state, should never happen.
+    const ESTORAGE_SLOT_INCORRECTLY_IN_TRANSIENT_STATE: u64 = 1;
+
+    enum StorageSlotOrInline<T> has store {
+        Inline{ value: T },
+        StorageSlot { slot: StorageSlot<T> },
+        Transient,
+    }
+
+    public fun new_inline<T: store>(value: T): StorageSlotOrInline<T> {
+        StorageSlotOrInline::Inline { value }
+    }
+
+    public fun new_storage_slot<T: store>(value: T): StorageSlotOrInline<T> {
+        StorageSlotOrInline::StorageSlot { slot: storage_slot::new(value) }
+    }
+
+    public fun borrow<T: store>(self: &StorageSlotOrInline<T>): &T {
+        match (self) {
+            StorageSlotOrInline::Inline { value } => value,
+            StorageSlotOrInline::StorageSlot { slot } => slot.borrow(),
+            StorageSlotOrInline::Transient => abort ESTORAGE_SLOT_INCORRECTLY_IN_TRANSIENT_STATE,
+        }
+    }
+
+    public fun borrow_mut<T: store>(self: &mut StorageSlotOrInline<T>): &mut T {
+        match (self) {
+            StorageSlotOrInline::Inline { value } => value,
+            StorageSlotOrInline::StorageSlot { slot } => slot.borrow_mut(),
+            StorageSlotOrInline::Transient => abort ESTORAGE_SLOT_INCORRECTLY_IN_TRANSIENT_STATE,
+        }
+    }
+
+    public fun destroy<T: store>(self: StorageSlotOrInline<T>): T {
+        match (self) {
+            StorageSlotOrInline::Inline { value } => value,
+            StorageSlotOrInline::StorageSlot { slot } => slot.destroy(),
+            StorageSlotOrInline::Transient => abort ESTORAGE_SLOT_INCORRECTLY_IN_TRANSIENT_STATE,
+        }
+    }
+
+    public fun move_to_inline<T: store>(self: &mut StorageSlotOrInline<T>) {
+        match (self) {
+            StorageSlotOrInline::Inline { value: _ } => {},
+            StorageSlotOrInline::StorageSlot { slot: _ } => {
+                let StorageSlotOrInline::StorageSlot { slot } = mem::replace(self, StorageSlotOrInline::Transient);
+                let StorageSlotOrInline::Transient = mem::replace(self, new_inline(slot.destroy()));
+            },
+            StorageSlotOrInline::Transient => abort ESTORAGE_SLOT_INCORRECTLY_IN_TRANSIENT_STATE,
+        }
+    }
+
+    public fun move_to_storage_slot<T: store>(self: &mut StorageSlotOrInline<T>) {
+        match (self) {
+            StorageSlotOrInline::Inline { value: _ } => {
+                let StorageSlotOrInline::Inline { value } = mem::replace(self, StorageSlotOrInline::Transient);
+                let StorageSlotOrInline::Transient = mem::replace(self, new_storage_slot(value));
+            },
+            StorageSlotOrInline::StorageSlot { slot: _ } => {},
+            StorageSlotOrInline::Transient => abort ESTORAGE_SLOT_INCORRECTLY_IN_TRANSIENT_STATE,
+        }
+    }
+
+    #[test]
+    fun test_storage_slot_or_inline() {
+        let value = new_storage_slot(Dummy {});
+        value.move_to_inline();
+        value.move_to_storage_slot();
+        value.move_to_inline();
+        let Dummy {} = value.destroy();
+    }
+
+    struct Dummy has store {}
+}

--- a/aptos-move/framework/aptos-framework/sources/datastructures/storage_slot_or_inline.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/datastructures/storage_slot_or_inline.spec.move
@@ -1,0 +1,10 @@
+// Copyright (c) Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+/// Spec for storage_slot_or_inline module.
+/// Verification is disabled as this module uses Move enums which the prover does not yet support.
+spec aptos_framework::storage_slot_or_inline {
+    spec module {
+        pragma verify = false;
+    }
+}

--- a/aptos-move/framework/move-stdlib/doc/features.md
+++ b/aptos-move/framework/move-stdlib/doc/features.md
@@ -165,6 +165,7 @@ return true.
 -  [Function `is_encrypted_transactions_enabled`](#0x1_features_is_encrypted_transactions_enabled)
 -  [Function `get_transaction_limits_feature`](#0x1_features_get_transaction_limits_feature)
 -  [Function `is_transaction_limits_enabled`](#0x1_features_is_transaction_limits_enabled)
+-  [Function `is_storage_slot_natives_enabled`](#0x1_features_is_storage_slot_natives_enabled)
 -  [Function `change_feature_flags`](#0x1_features_change_feature_flags)
 -  [Function `change_feature_flags_internal`](#0x1_features_change_feature_flags_internal)
 -  [Function `change_feature_flags_for_next_epoch`](#0x1_features_change_feature_flags_for_next_epoch)
@@ -908,6 +909,16 @@ Lifetime: transient
 
 
 <pre><code><b>const</b> <a href="features.md#0x1_features_SPONSORED_AUTOMATIC_ACCOUNT_CREATION">SPONSORED_AUTOMATIC_ACCOUNT_CREATION</a>: u64 = 34;
+</code></pre>
+
+
+
+<a id="0x1_features_STORAGE_SLOT_NATIVES"></a>
+
+Whether the storage slot natives are enabled.
+
+
+<pre><code><b>const</b> <a href="features.md#0x1_features_STORAGE_SLOT_NATIVES">STORAGE_SLOT_NATIVES</a>: u64 = 113;
 </code></pre>
 
 
@@ -4207,6 +4218,30 @@ Deprecated feature
 
 <pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_is_transaction_limits_enabled">is_transaction_limits_enabled</a>(): bool {
     <a href="features.md#0x1_features_is_enabled">is_enabled</a>(<a href="features.md#0x1_features_TRANSACTION_LIMITS">TRANSACTION_LIMITS</a>)
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_features_is_storage_slot_natives_enabled"></a>
+
+## Function `is_storage_slot_natives_enabled`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_is_storage_slot_natives_enabled">is_storage_slot_natives_enabled</a>(): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_is_storage_slot_natives_enabled">is_storage_slot_natives_enabled</a>(): bool {
+    <a href="features.md#0x1_features_is_enabled">is_enabled</a>(<a href="features.md#0x1_features_STORAGE_SLOT_NATIVES">STORAGE_SLOT_NATIVES</a>)
 }
 </code></pre>
 

--- a/aptos-move/framework/move-stdlib/sources/configs/features.move
+++ b/aptos-move/framework/move-stdlib/sources/configs/features.move
@@ -858,6 +858,13 @@ module std::features {
         is_enabled(TRANSACTION_LIMITS)
     }
 
+    /// Whether the storage slot natives are enabled.
+    const STORAGE_SLOT_NATIVES: u64 = 113;
+
+    public fun is_storage_slot_natives_enabled(): bool {
+        is_enabled(STORAGE_SLOT_NATIVES)
+    }
+
     // ============================================================================================
     // Feature Flag Implementation
 

--- a/aptos-move/framework/move-stdlib/sources/configs/features.spec.move
+++ b/aptos-move/framework/move-stdlib/sources/configs/features.spec.move
@@ -129,4 +129,10 @@ spec std::features {
     spec fun spec_sha_512_and_ripemd_160_enabled(): bool {
         spec_is_enabled(SHA_512_AND_RIPEMD_160_NATIVES)
     }
+
+    spec is_storage_slot_natives_enabled {
+        pragma opaque;
+        aborts_if [abstract] false;
+        ensures [abstract] result == spec_is_enabled(STORAGE_SLOT_NATIVES);
+    }
 }

--- a/aptos-move/framework/natives/src/lib.rs
+++ b/aptos-move/framework/natives/src/lib.rs
@@ -21,6 +21,7 @@ pub mod object_code_deployment;
 pub mod permissioned_signer;
 pub mod randomness;
 pub mod state_storage;
+pub mod storage_slot;
 pub mod string_utils;
 pub mod transaction_context;
 pub mod type_info;
@@ -97,6 +98,7 @@ pub fn all_natives(
     add_natives_from_module!("string_utils", string_utils::make_all(builder));
     add_natives_from_module!("consensus_config", consensus_config::make_all(builder));
     add_natives_from_module!("function_info", function_info::make_all(builder));
+    add_natives_from_module!("storage_slot", storage_slot::make_all(builder));
     add_natives_from_module!(
         "dispatchable_fungible_asset",
         dispatchable_fungible_asset::make_all(builder)

--- a/aptos-move/framework/natives/src/storage_slot.rs
+++ b/aptos-move/framework/natives/src/storage_slot.rs
@@ -1,0 +1,153 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Native implementation for storage_slot::borrow_storage_slot_resource and storage_slot::borrow_storage_slot_resource_mut
+//!
+//! These natives borrow StorageSlotResource<T> from Move global storage and return references.
+//! They work by using the VM's newly exposed borrow_resource APIs.
+
+use aptos_gas_schedule::gas_params::natives::aptos_framework::*;
+use aptos_native_interface::{
+    safely_assert_eq, safely_pop_arg, RawSafeNative, SafeNativeBuilder, SafeNativeContext,
+    SafeNativeError, SafeNativeResult,
+};
+use move_core_types::{account_address::AccountAddress, vm_status::StatusCode};
+use move_vm_runtime::native_functions::NativeFunction;
+use move_vm_types::{
+    loaded_data::runtime_types::Type,
+    values::{Reference, StructRef, Value},
+};
+use smallvec::{smallvec, SmallVec};
+use std::collections::VecDeque;
+
+// Error codes
+const ESTORAGE_SLOT_NOT_FOUND: u64 = 0x2;
+
+/***************************************************************************************************
+ * native fun borrow_storage_slot_resource<T: store, BR>(self: &StorageSlot<T>): &BR
+ *
+ * Borrows StorageSlotResource<T> from global storage.
+ * Called from Move as: borrow_storage_slot_resource<T, StorageSlotResource<T>>(storage_slot)
+ *
+ * Type args: [T, StorageSlotResource<T>]
+ *   - ty_args[0] = T (the value type)
+ *   - ty_args[1] = StorageSlotResource<T> (the resource type to borrow from global storage)
+ **************************************************************************************************/
+fn native_borrow_storage_slot_resource(
+    context: &mut SafeNativeContext,
+    ty_args: &[Type],
+    mut args: VecDeque<Value>,
+) -> SafeNativeResult<SmallVec<[Value; 1]>> {
+    safely_assert_eq!(ty_args.len(), 2);
+    safely_assert_eq!(args.len(), 1);
+
+    context.charge(STORAGE_SLOT_BORROW_BASE)?;
+
+    // Get the address from StorageSlot.addr field
+    let storage_slot_ref = safely_pop_arg!(args, StructRef);
+    let addr = storage_slot_ref
+        .borrow_field(0)?
+        .value_as::<Reference>()?
+        .read_ref()?
+        .value_as::<AccountAddress>()?;
+
+    // ty_args[1] is StorageSlotResource<T> - the type we want to borrow from global storage
+    let storage_slot_resource_ty = &ty_args[1];
+
+    // Borrow the resource from global storage
+    let (ref_val, num_bytes) = context
+        .borrow_resource(addr, storage_slot_resource_ty)
+        .map_err(|err| {
+            // Check if resource doesn't exist
+            if err.major_status() == StatusCode::MISSING_DATA {
+                SafeNativeError::abort_with_message(
+                    ESTORAGE_SLOT_NOT_FOUND,
+                    format!("StorageSlotResource at address {} not found", addr),
+                )
+            } else {
+                err.into()
+            }
+        })?;
+
+    // Charge for loaded bytes
+    if let Some(num_bytes) = num_bytes {
+        context.charge(STORAGE_SLOT_BORROW_PER_BYTE_LOADED * num_bytes)?;
+    }
+
+    Ok(smallvec![ref_val])
+}
+
+/***************************************************************************************************
+ * native fun borrow_storage_slot_resource_mut<T: store, BR>(self: &mut StorageSlot<T>): &mut BR
+ *
+ * Borrows StorageSlotResource<T> mutably from global storage.
+ * Called from Move as: borrow_storage_slot_resource_mut<T, StorageSlotResource<T>>(storage_slot)
+ *
+ * Type args: [T, StorageSlotResource<T>]
+ *   - ty_args[0] = T (the value type)
+ *   - ty_args[1] = StorageSlotResource<T> (the resource type to borrow from global storage)
+ **************************************************************************************************/
+fn native_borrow_storage_slot_resource_mut(
+    context: &mut SafeNativeContext,
+    ty_args: &[Type],
+    mut args: VecDeque<Value>,
+) -> SafeNativeResult<SmallVec<[Value; 1]>> {
+    safely_assert_eq!(ty_args.len(), 2);
+    safely_assert_eq!(args.len(), 1);
+
+    context.charge(STORAGE_SLOT_BORROW_MUT_BASE)?;
+
+    // Get the address from StorageSlot.addr field
+    let storage_slot_ref = safely_pop_arg!(args, StructRef);
+    let addr = storage_slot_ref
+        .borrow_field(0)?
+        .value_as::<Reference>()?
+        .read_ref()?
+        .value_as::<AccountAddress>()?;
+
+    // ty_args[1] is StorageSlotResource<T> - the type we want to borrow from global storage
+    let storage_slot_resource_ty = &ty_args[1];
+
+    // Borrow the resource mutably from global storage
+    let (ref_val, num_bytes) = context
+        .borrow_resource_mut(addr, storage_slot_resource_ty)
+        .map_err(|err| {
+            // Check if resource doesn't exist
+            if err.major_status() == StatusCode::MISSING_DATA {
+                SafeNativeError::abort_with_message(
+                    ESTORAGE_SLOT_NOT_FOUND,
+                    format!("StorageSlotResource at address {} not found", addr),
+                )
+            } else {
+                err.into()
+            }
+        })?;
+
+    // Charge for loaded bytes
+    if let Some(num_bytes) = num_bytes {
+        context.charge(STORAGE_SLOT_BORROW_MUT_PER_BYTE_LOADED * num_bytes)?;
+    }
+
+    Ok(smallvec![ref_val])
+}
+
+/***************************************************************************************************
+ * module
+ *
+ **************************************************************************************************/
+pub fn make_all(
+    builder: &SafeNativeBuilder,
+) -> impl Iterator<Item = (String, NativeFunction)> + '_ {
+    let natives = [
+        (
+            "borrow_storage_slot_resource",
+            native_borrow_storage_slot_resource as RawSafeNative,
+        ),
+        (
+            "borrow_storage_slot_resource_mut",
+            native_borrow_storage_slot_resource_mut,
+        ),
+    ];
+
+    builder.make_named_natives(natives)
+}

--- a/third_party/move/move-vm/runtime/src/data_cache.rs
+++ b/third_party/move/move-vm/runtime/src/data_cache.rs
@@ -45,6 +45,26 @@ pub trait NativeContextMoveVmDataCache {
         addr: &AccountAddress,
         ty: &Type,
     ) -> PartialVMResult<(bool, Option<NumBytes>)>;
+
+    /// Loads resource from global storage and borrows an immutable reference to it.
+    /// Returns the borrowed value and the number of bytes loaded (if any).
+    fn native_borrow_resource(
+        &mut self,
+        gas_meter: &mut dyn DependencyGasMeter,
+        traversal_context: &mut TraversalContext,
+        addr: &AccountAddress,
+        ty: &Type,
+    ) -> PartialVMResult<(Value, Option<NumBytes>)>;
+
+    /// Loads resource from global storage and borrows a mutable reference to it.
+    /// Returns the borrowed value and the number of bytes loaded (if any).
+    fn native_borrow_resource_mut(
+        &mut self,
+        gas_meter: &mut dyn DependencyGasMeter,
+        traversal_context: &mut TraversalContext,
+        addr: &AccountAddress,
+        ty: &Type,
+    ) -> PartialVMResult<(Value, Option<NumBytes>)>;
 }
 
 /// Provides access to global storage for Move VM.
@@ -99,6 +119,33 @@ where
         let (gv, bytes_loaded) = self.load_resource(&mut gas_meter, traversal_context, addr, ty)?;
         let exists = gv.exists();
         Ok((exists, bytes_loaded))
+    }
+
+    fn native_borrow_resource(
+        &mut self,
+        gas_meter: &mut dyn DependencyGasMeter,
+        traversal_context: &mut TraversalContext,
+        addr: &AccountAddress,
+        ty: &Type,
+    ) -> PartialVMResult<(Value, Option<NumBytes>)> {
+        let mut gas_meter = DependencyGasMeterWrapper::new(gas_meter);
+        let (gv, bytes_loaded) = self.load_resource(&mut gas_meter, traversal_context, addr, ty)?;
+        let ref_val = gv.borrow_global()?;
+        Ok((ref_val, bytes_loaded))
+    }
+
+    fn native_borrow_resource_mut(
+        &mut self,
+        gas_meter: &mut dyn DependencyGasMeter,
+        traversal_context: &mut TraversalContext,
+        addr: &AccountAddress,
+        ty: &Type,
+    ) -> PartialVMResult<(Value, Option<NumBytes>)> {
+        let mut gas_meter = DependencyGasMeterWrapper::new(gas_meter);
+        let (gv, bytes_loaded) =
+            self.load_resource_mut(&mut gas_meter, traversal_context, addr, ty)?;
+        let ref_val = gv.borrow_global()?;
+        Ok((ref_val, bytes_loaded))
     }
 }
 

--- a/third_party/move/move-vm/runtime/src/native_functions.rs
+++ b/third_party/move/move-vm/runtime/src/native_functions.rs
@@ -162,6 +162,32 @@ impl<'b, 'c> NativeContext<'_, 'b, 'c> {
         )
     }
 
+    /// Borrows an immutable reference to a resource in global storage.
+    /// Returns the reference value and the number of bytes loaded.
+    pub fn borrow_resource(
+        &mut self,
+        address: AccountAddress,
+        ty: &Type,
+    ) -> PartialVMResult<(Value, Option<NumBytes>)> {
+        self.data_cache
+            .native_borrow_resource(self.gas_meter, self.traversal_context, &address, ty)
+    }
+
+    /// Borrows a mutable reference to a resource in global storage.
+    /// Returns the reference value and the number of bytes loaded.
+    pub fn borrow_resource_mut(
+        &mut self,
+        address: AccountAddress,
+        ty: &Type,
+    ) -> PartialVMResult<(Value, Option<NumBytes>)> {
+        self.data_cache.native_borrow_resource_mut(
+            self.gas_meter,
+            self.traversal_context,
+            &address,
+            ty,
+        )
+    }
+
     pub fn type_to_type_tag(&self, ty: &Type) -> PartialVMResult<TypeTag> {
         self.module_storage.runtime_environment().ty_to_ty_tag(ty)
     }

--- a/third_party/move/move-vm/runtime/src/native_models_for_runtime_ref_checks.rs
+++ b/third_party/move/move-vm/runtime/src/native_models_for_runtime_ref_checks.rs
@@ -49,6 +49,14 @@ impl Default for NativeRuntimeRefChecksModel {
         let single_return_derived_from_first_ref_param = vec![0];
         let models = BTreeMap::from([
             (
+                ("storage_slot", "borrow_storage_slot_resource"),
+                single_return_derived_from_first_ref_param.clone(),
+            ),
+            (
+                ("storage_slot", "borrow_storage_slot_resource_mut"),
+                single_return_derived_from_first_ref_param.clone(),
+            ),
+            (
                 ("signer", "borrow_address"),
                 single_return_derived_from_first_ref_param.clone(),
             ),

--- a/types/src/on_chain_config/aptos_features.rs
+++ b/types/src/on_chain_config/aptos_features.rs
@@ -175,6 +175,8 @@ pub enum FeatureFlag {
     TRANSACTION_LIMITS = 111,
     /// Whether versioned enum-based transaction validation is enabled.
     VERSIONED_TRANSACTION_VALIDATION = 112,
+    /// Whether storage_slot move natives are enabled.
+    STORAGE_SLOT_NATIVES = 113,
 }
 
 impl FeatureFlag {
@@ -287,6 +289,7 @@ impl FeatureFlag {
             Self::MULTISIG_SCRIPT,
             Self::TRANSACTION_LIMITS,
             Self::VERSIONED_TRANSACTION_VALIDATION,
+            Self::STORAGE_SLOT_NATIVES,
         ]
     }
 }


### PR DESCRIPTION
## Description
Sometimes it's useful to be able to store a value in a struct in a separate resource (due to move 1mb resource limit, or BigOrderedMap value limit, or smaller write set size, or parallelism). 

Currently, you can either write a resource yourself, and use object::create_object to get a signer to store it at random address, or you can create a new `table<bool, V>`, and store it under "`true`" key (but then you cannot destroy the table when empty, so you need table_with_length, and it constantly needs to hash to compute the address value is stored at, etc)

It's cleaner to just have a Box type - which is equivalent to singleton Table. 
User cannot implement that due to borrow and borrow_mut not being able to return a reference - so we need same semantics as the Table calls do.

(note that all the special code for tables wouldn't be needed if we were implementing them today, with ability to get a special signer and store resources at an address, which would simplify the VM substantially)



## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Introduces new Move natives that borrow arbitrary resources from global storage and wires them through the Move VM runtime, which is core execution infrastructure and could impact safety, gas charging, and reference semantics. Although gated behind a new on-chain feature flag, misconfiguration or bugs could affect transaction correctness and gas accounting.
> 
> **Overview**
> Adds a **new Framework container**: `aptos_framework::storage_slot` (a Box-like type backed by a uniquely-addressed on-chain resource) and `storage_slot_or_inline` (an enum that can hold the value inline or in a `StorageSlot`), plus generated docs and disabled prover specs for these modules.
> 
> Implements **new VM-native functions** (`storage_slot::borrow_storage_slot_resource` / `_mut`) that borrow the underlying `StorageSlotResource<T>` directly from global storage, including new Move VM data-cache/native-context APIs (`borrow_resource`/`borrow_resource_mut`) and runtime reference-check models.
> 
> Wires in **feature gating + pricing**: introduces `STORAGE_SLOT_NATIVES` feature flag across on-chain config + release builder mappings, adds `std::features::is_storage_slot_natives_enabled`, and adds new gas schedule entries (enabled from `RELEASE_V1_46`) for storage-slot borrows, along with a prover config tweak for borrowing the new native.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4d4199f696a30c1edf93fba5e07a8d7591600d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->