### PR TITLE
Create release aptos-trading proposal

### DIFF
--- a/aptos-move/aptos-release-builder/data/release_aptos_trading.yaml
+++ b/aptos-move/aptos-release-builder/data/release_aptos_trading.yaml
@@ -1,0 +1,17 @@
+---
+remote_endpoint: https://fullnode.mainnet.aptoslabs.com
+# replace with below for actual release, compat test needs concrete URL above:
+# remote_endpoint: ~
+name: "v1.41.0-aptos-trading"
+proposals:
+  - name: proposal_deploy_aptos_trading
+    metadata:
+      title: "Deploy aptos-trading (AIP 120) to mainnet"
+      description: "This includes initial deployment of aptos-trading to mainnet"
+    execution_mode: MultiStep
+    update_sequence:
+      - Framework:
+          bytecode_version: 8
+          git_hash: ~
+          packages:
+            - "aptos-trading"


### PR DESCRIPTION
## Description
Initial deployment to aptos-trading - only basic structs (Order and Matching types) part of AIP-120 for OrderBook/Market to use. 

## How Has This Been Tested?

Integrated in OrderBook and Market, and tested fully.

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [+] New feature

## Which Components or Systems Does This Change Impact?
- [+] Aptos Framework

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces mainnet release/proposal configuration that could trigger an on-chain deployment if executed; correctness of endpoint, package name, and bytecode version is critical.
> 
> **Overview**
> Adds a new `aptos-release-builder` release config (`release_aptos_trading.yaml`) defining a multi-step mainnet proposal to deploy the `aptos-trading` framework package (AIP-120) under release name `v1.41.0-aptos-trading`.
> 
> The proposal targets `https://fullnode.mainnet.aptoslabs.com`, sets `bytecode_version: 8`, and leaves `git_hash` unset (`~`) for the framework update sequence.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b42b5de9d788c2c075ac2c4aca992e2d6699da8a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->