### PR TITLE
[fix] cherry pick missed feature activation times

### DIFF
--- a/types/src/on_chain_config/timed_features.rs
+++ b/types/src/on_chain_config/timed_features.rs
@@ -151,7 +151,7 @@ impl TimedFeatureFlag {
                 .unwrap()
                 .with_timezone(&Utc),
             (ClosureDepthCheck, MAINNET) => Los_Angeles
-                .with_ymd_and_hms(2026, 2, 5, 10, 0, 0)
+                .with_ymd_and_hms(2026, 2, 9, 12, 0, 0)
                 .unwrap()
                 .with_timezone(&Utc),
 
@@ -164,7 +164,7 @@ impl TimedFeatureFlag {
                 .unwrap()
                 .with_timezone(&Utc),
             (FixCryptoAlgebraNativesResultHandling, MAINNET) => Los_Angeles
-                .with_ymd_and_hms(2026, 2, 5, 10, 0, 0)
+                .with_ymd_and_hms(2026, 2, 9, 12, 0, 0)
                 .unwrap()
                 .with_timezone(&Utc),
 
@@ -178,7 +178,7 @@ impl TimedFeatureFlag {
                 .unwrap()
                 .with_timezone(&Utc),
             (UseFullTransactionSizeForGasCheck, MAINNET) => Los_Angeles
-                .with_ymd_and_hms(2026, 2, 5, 10, 0, 0)
+                .with_ymd_and_hms(2026, 2, 9, 12, 0, 0)
                 .unwrap()
                 .with_timezone(&Utc),
 


### PR DESCRIPTION
## Description

Correctly set activation time for hotfix features

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect when safety/gas-checking behavior flips on mainnet; an incorrect timestamp could enable features too early/late and impact network behavior around the cutover.
> 
> **Overview**
> Adjusts mainnet activation times in `timed_features.rs` for three timed flags—`ClosureDepthCheck`, `FixCryptoAlgebraNativesResultHandling`, and `UseFullTransactionSizeForGasCheck`—moving their enablement from 2026-02-05 to 2026-02-09 (Los Angeles time).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2539de55d4ffc4aa0794d722e5d9a5a4a0f985ed. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->