### PR TITLE
[storage] Add RocksDB BlobDB value separation config

### DIFF
--- a/storage/aptosdb/src/rocksdb_property_reporter.rs
+++ b/storage/aptosdb/src/rocksdb_property_reporter.rs
@@ -63,6 +63,11 @@ static ROCKSDB_PROPERTY_MAP: Lazy<HashMap<&str, String>> = Lazy::new(|| {
         "rocksdb.block-cache-capacity",
         "rocksdb.block-cache-usage",
         "rocksdb.block-cache-pinned-usage",
+        "rocksdb.num-blob-files",
+        "rocksdb.blob-stats",
+        "rocksdb.total-blob-file-size",
+        "rocksdb.live-blob-file-size",
+        "rocksdb.live-blob-file-garbage-size",
     ]
     .iter()
     .map(|x| (*x, format!("aptos_{}", x.replace('.', "_"))))


### PR DESCRIPTION
## Summary

- Adds configurable RocksDB BlobDB (value separation) support to AptosDB storage layer
- When enabled, values larger than `min_blob_size` (default 256 bytes) are stored in append-only blob files instead of inline in LSM SST files, reducing compaction write amplification
- Disabled by default for backward compatibility; can be enabled per-DB (state_kv, state_merkle, ledger) via node config

## Motivation

RocksDB's LSM compaction rewrites all data at each level, causing ~10-30x write amplification. Since each state update produces multiple RocksDB writes (value + JMT nodes + stale indices), the effective write amplification per logical state update is very high. BlobDB separates large values into append-only blob files, keeping only small keys in the LSM tree — compaction then only rewrites small keys (~40B), not full values (100B-1KB+). Expected improvement: 2-4x write throughput.

## Changes

- `config/src/config/storage_config.rs`: New `BlobDbConfig` struct with 7 tunable parameters (min_blob_size, blob_file_size, GC settings, readahead, enable flag). Added as field on `RocksdbConfig`.
- `storage/aptosdb/src/db_options.rs`: New `apply_blob_db_config()` function wired into `gen_cfds()` to apply blob settings per column family. Shares existing block cache for blob reads.
- `storage/aptosdb/src/rocksdb_property_reporter.rs`: Added 5 blob-related RocksDB properties for operational monitoring.

## Test plan

- [x] `cargo check -p aptos-config` — compiles
- [x] `cargo test -p aptos-config` — 4/4 config tests pass (backward compat verified)
- [x] `cargo check -p aptos-db` — compiles  
- [x] `cargo test -p aptos-db` — 104/104 tests pass
- [ ] Benchmark with BlobDB enabled on state_kv_db and state_merkle_db against production-like workload

🤖 Generated with [Claude Code](https://claude.com/claude-code)