### PR TITLE
[vm] Use async type checks as default

### DIFF
--- a/config/src/config/execution_config.rs
+++ b/config/src/config/execution_config.rs
@@ -92,8 +92,7 @@ impl Default for ExecutionConfig {
             genesis_waypoint: None,
             blockstm_v2_enabled: false,
             layout_caches_enabled: true,
-            // TODO: consider setting to be true by default.
-            async_runtime_checks: false,
+            async_runtime_checks: true,
             enable_pre_write: true,
         }
     }

--- a/execution/executor-benchmark/src/main.rs
+++ b/execution/executor-benchmark/src/main.rs
@@ -648,6 +648,7 @@ fn main() {
     set_layout_caches(true);
     if opt.skip_paranoid_checks {
         set_paranoid_type_checks(false);
+        set_async_runtime_checks(false);
     } else {
         // If we do paranoid checks, then they are allowed to run async in post-commit hook.
         set_paranoid_type_checks(true);

--- a/testsuite/forge-cli/src/suites/realistic_environment.rs
+++ b/testsuite/forge-cli/src/suites/realistic_environment.rs
@@ -329,8 +329,6 @@ pub(crate) fn realistic_env_graceful_overload(duration: Duration) -> ForgeConfig
         )
         .with_validator_override_node_config_fn(Arc::new(|config, _| {
             config.execution.processed_transactions_detailed_counters = true;
-            // TODO(georgemitenkov): remove once features are added to default config.
-            config.execution.async_runtime_checks = true;
         }))
         .with_genesis_helm_config_fn(Arc::new(|helm_values| {
             helm_values["chain"]["epoch_duration_secs"] = 300.into();
@@ -464,8 +462,6 @@ pub(crate) fn realistic_env_max_load_test(
             config
                 .consensus_observer
                 .observer_fallback_sync_lag_threshold_ms = 45_000; // 45 seconds
-                                                                   // TODO(georgemitenkov): remove once features are added to default config.
-            config.execution.async_runtime_checks = true;
         }))
         // First start higher gas-fee traffic, to not cause issues with TxnEmitter setup - account creation
         .with_emit_job(
@@ -521,9 +517,6 @@ pub(crate) fn realistic_network_tuned_for_throughput_test() -> ForgeConfig {
                 if USE_CRAZY_MACHINES {
                     config.execution.concurrency_level = 48;
                 }
-
-                // TODO(georgemitenkov): remove once features are added to default config.
-                config.execution.async_runtime_checks = true;
             }))
             .with_genesis_helm_config_fn(Arc::new(move |helm_values| {
                 let mut on_chain_execution_config = OnChainExecutionConfig::default_for_genesis();


### PR DESCRIPTION
## Description

Enabling async paranoid mode as default for 1.41+

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes a default execution/verification behavior that can affect performance and post-commit execution timing under Block-STM; misconfigurations could surface as new overhead or concurrency-related issues in some environments.
> 
> **Overview**
> Enables `execution.async_runtime_checks` by default in `ExecutionConfig`, making paranoid runtime verification eligible to run asynchronously (e.g., via post-commit hooks) without requiring per-environment overrides.
> 
> Updates `executor-benchmark` to explicitly disable async runtime checks when `--skip-paranoid-checks` is used, and removes redundant `async_runtime_checks = true` overrides from several realistic-environment Forge suites now that the default is enabled.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2aa88da5aa0da89e727b4ad7705f243e2644a5b2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->