### PR TITLE
[test] Add encrypted transaction decryption smoke test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17635,6 +17635,7 @@ dependencies = [
  "blake2-rfc",
  "diesel",
  "digest 0.9.0",
+ "env_logger",
  "ethers",
  "futures",
  "hex",

--- a/dkg/src/chunky/dkg_manager.rs
+++ b/dkg/src/chunky/dkg_manager.rs
@@ -219,8 +219,7 @@ impl ChunkyDKGManager {
                         .map_err(|e|anyhow!("[ChunkyDKG] process_aggregated_subtranscript failed: {e}"))
                 },
                 certified_transcript = certified_subtrx_rx.select_next_some() => {
-                    self.process_certified_aggregated_subtranscript(certified_transcript)
-                        .await
+                    self.process_certified_aggregated_subtranscript(certified_transcript).await
                         .map_err(|e|anyhow!("[ChunkyDKG] process_certified_aggregated_subtranscript failed: {e}"))
                 },
                 dkg_txn = self.pull_notification_rx.select_next_some() => {
@@ -496,10 +495,12 @@ impl ChunkyDKGManager {
 
         counters::observe_chunky_dkg_stage(start_time, self.my_addr, "agg_subtrx_certified");
 
+        info!("deriving encryption key");
         // Derive encryption key from subtranscript + DigestKey
         let encryption_key_bytes =
             aggregated_subtranscript.derive_encryption_key_bytes(TEST_DIGEST_KEY.tau_g2)?;
 
+        info!("forming ceritified_transcript struct");
         let certified_transcript = CertifiedAggregatedChunkySubtranscript {
             metadata: DKGTranscriptMetadata {
                 epoch: self.epoch_state.epoch,

--- a/testsuite/smoke-test/Cargo.toml
+++ b/testsuite/smoke-test/Cargo.toml
@@ -55,6 +55,7 @@ diesel = { workspace = true, features = [
     "serde_json",
 ] }
 digest = { workspace = true }
+env_logger = { workspace = true }
 ethers = { workspace = true }
 hex = { workspace = true }
 hyper = { workspace = true }

--- a/testsuite/smoke-test/src/consensus/consensus_only.rs
+++ b/testsuite/smoke-test/src/consensus/consensus_only.rs
@@ -25,6 +25,8 @@ async fn test_consensus_only_with_txn_emitter() {
                 20,
             ),
         ]],
+        false,
+        None,
     )
     .await
     .unwrap();

--- a/testsuite/smoke-test/src/consensus/helpers.rs
+++ b/testsuite/smoke-test/src/consensus/helpers.rs
@@ -20,27 +20,35 @@ pub async fn generate_traffic_and_assert_committed(
         .await
         .unwrap();
 
-    let txn_stat = generate_traffic(swarm, nodes, duration, 100, vec![vec![
-        (
-            TransactionType::CoinTransfer {
-                invalid_transaction_ratio: 0,
-                sender_use_account_pool: false,
-                non_conflicting: false,
-                use_fa_transfer: true,
-                use_txn_payload_v2_format: false,
-                use_orderless_transactions: false,
-            },
-            70,
-        ),
-        (
-            TransactionType::AccountGeneration {
-                add_created_accounts_to_pool: true,
-                max_account_working_set: 1_000_000,
-                creation_balance: 5_000_000,
-            },
-            20,
-        ),
-    ]])
+    let txn_stat = generate_traffic(
+        swarm,
+        nodes,
+        duration,
+        100,
+        vec![vec![
+            (
+                TransactionType::CoinTransfer {
+                    invalid_transaction_ratio: 0,
+                    sender_use_account_pool: false,
+                    non_conflicting: false,
+                    use_fa_transfer: true,
+                    use_txn_payload_v2_format: false,
+                    use_orderless_transactions: false,
+                },
+                70,
+            ),
+            (
+                TransactionType::AccountGeneration {
+                    add_created_accounts_to_pool: true,
+                    max_account_working_set: 1_000_000,
+                    creation_balance: 5_000_000,
+                },
+                20,
+            ),
+        ]],
+        false,
+        None,
+    )
     .await
     .unwrap();
     println!("{:?}", txn_stat.rate());

--- a/testsuite/smoke-test/src/consensus/quorum_store_fault_tolerance.rs
+++ b/testsuite/smoke-test/src/consensus/quorum_store_fault_tolerance.rs
@@ -316,6 +316,8 @@ async fn test_swarm_with_bad_non_qs_node() {
                     20,
                 ),
             ]],
+            false,
+            None,
         ),
     )
     .await;

--- a/testsuite/smoke-test/src/decryption.rs
+++ b/testsuite/smoke-test/src/decryption.rs
@@ -1,0 +1,215 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+use crate::{smoke_test_environment::SwarmBuilder, txn_emitter::generate_traffic};
+use aptos_forge::{EmitJobMode, LocalSwarm, NodeExt, TransactionType};
+use aptos_logger::info;
+use aptos_rest_client::Client;
+use aptos_types::on_chain_config::{
+    FeatureFlag, Features, OnChainChunkyDKGConfig, OnChainRandomnessConfig,
+};
+use std::{sync::Arc, time::Duration};
+
+/// Wait until the ledger reaches the given epoch, returning the encryption key bytes if present.
+async fn wait_for_epoch(client: &Client, target_epoch: u64, timeout_secs: u64) -> Option<Vec<u8>> {
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(timeout_secs);
+    loop {
+        let state = client
+            .get_ledger_information()
+            .await
+            .expect("failed to get ledger info")
+            .into_inner();
+        if state.epoch >= target_epoch {
+            return state.encryption_key;
+        }
+        if tokio::time::Instant::now() > deadline {
+            panic!(
+                "timed out waiting for epoch {}, current epoch is {}",
+                target_epoch, state.epoch
+            );
+        }
+        tokio::time::sleep(Duration::from_secs(1)).await;
+    }
+}
+
+/// Count the number of encrypted user transactions in the range [start_version, end_version).
+async fn count_encrypted_txns(client: &Client, start_version: u64, end_version: u64) -> (u64, u64) {
+    let mut count = 0u64;
+    let mut decrypted_count = 0u64;
+    let page_size = 100u16;
+    let mut cursor = start_version;
+    while cursor < end_version {
+        let limit = std::cmp::min(page_size as u64, end_version - cursor) as u16;
+        let txns = client
+            .get_transactions_bcs(Some(cursor), Some(limit))
+            .await
+            .expect("failed to get transactions")
+            .into_inner();
+        for txn_data in &txns {
+            if let Some(signed_txn) = txn_data.transaction.try_as_signed_user_txn() {
+                if let Some(payload) = signed_txn.payload().as_encrypted_payload() {
+                    count += 1;
+                    if !payload.is_encrypted() {
+                        decrypted_count += 1;
+                    }
+                }
+            }
+        }
+        cursor += txns.len() as u64;
+        if txns.is_empty() {
+            break;
+        }
+    }
+    (count, decrypted_count)
+}
+
+async fn create_swarm_with_encryption(num_validators: usize) -> LocalSwarm {
+    SwarmBuilder::new_local(num_validators)
+        .with_aptos()
+        .with_init_config(Arc::new(|_, config, _| {
+            config.api.failpoints_enabled = true;
+            config.api.allow_encrypted_txns_submission = true;
+            config.consensus.quorum_store.enable_batch_v2_tx = true;
+            config.consensus.quorum_store.enable_batch_v2_rx = true;
+            config.consensus.quorum_store.enable_opt_qs_v2_payload_tx = true;
+            config.consensus.quorum_store.enable_opt_qs_v2_payload_rx = true;
+            config
+                .state_sync
+                .state_sync_driver
+                .enable_auto_bootstrapping = true;
+            config
+                .state_sync
+                .state_sync_driver
+                .max_connection_deadline_secs = 3;
+        }))
+        .with_init_genesis_config(Arc::new(|conf| {
+            conf.epoch_duration_secs = 10;
+            conf.consensus_config.enable_validator_txns();
+            conf.randomness_config_override = Some(OnChainRandomnessConfig::default_enabled());
+            conf.chunky_dkg_config_override = Some(OnChainChunkyDKGConfig::default_enabled());
+            let mut features = Features::default();
+            features.enable(FeatureFlag::ENCRYPTED_TRANSACTIONS);
+            conf.initial_features_override = Some(features);
+        }))
+        .build()
+        .await
+}
+
+/// Smoke test that verifies:
+/// 1. An encryption key exists after epoch 2.
+/// 2. The encryption key changes between epochs.
+/// 3. Encrypted transactions are committed (via the emitter).
+#[tokio::test]
+async fn test_encryption_key_rotation_and_encrypted_txns() {
+    let num_validators = 4;
+    let mut swarm = create_swarm_with_encryption(num_validators).await;
+
+    let client = swarm.validators().last().unwrap().rest_client();
+
+    // ---- Wait for epoch 2 and record the encryption key ----
+    info!("Waiting for epoch 2...");
+    let key_at_epoch2 = wait_for_epoch(&client, 2, 90).await;
+    let epoch2 = client
+        .get_ledger_information()
+        .await
+        .unwrap()
+        .into_inner()
+        .epoch;
+    info!(
+        "Reached epoch {} with encryption key present: {}",
+        epoch2,
+        key_at_epoch2.is_some()
+    );
+    assert!(
+        key_at_epoch2.is_some(),
+        "Encryption key should exist after epoch 2, but was None"
+    );
+
+    // Record the ledger version so we can scan transactions later.
+    let version_before_traffic = client
+        .get_ledger_information()
+        .await
+        .unwrap()
+        .into_inner()
+        .version;
+
+    // ---- Use the emitter to generate encrypted traffic ----
+    info!("Emitting encrypted traffic...");
+    let all_validators: Vec<_> = swarm.validators().map(|v| v.peer_id()).collect();
+    let stats = generate_traffic(
+        &mut swarm,
+        &all_validators,
+        Duration::from_secs(20),
+        100,
+        vec![vec![(TransactionType::default(), 1)]],
+        true,
+        Some(EmitJobMode::MaxLoad {
+            mempool_backlog: 20,
+        }),
+    )
+    .await
+    .unwrap();
+    info!(
+        "Emitter stats: submitted={}, committed={}",
+        stats.submitted, stats.committed
+    );
+    assert!(
+        stats.committed > 0,
+        "Expected some committed transactions from the emitter, got 0"
+    );
+
+    // ---- Wait for the next epoch and check the key changed ----
+    info!("Waiting for epoch {}...", epoch2 + 1);
+    let key_at_next_epoch = wait_for_epoch(&client, epoch2 + 1, 60).await;
+    let next_epoch = client
+        .get_ledger_information()
+        .await
+        .unwrap()
+        .into_inner()
+        .epoch;
+    info!(
+        "Reached epoch {} with encryption key present: {}",
+        next_epoch,
+        key_at_next_epoch.is_some()
+    );
+
+    assert!(
+        key_at_next_epoch.is_some(),
+        "Encryption key should exist at epoch {}, but was None",
+        next_epoch
+    );
+    assert_ne!(
+        key_at_epoch2.unwrap(),
+        key_at_next_epoch.unwrap(),
+        "Encryption key must change between epoch {} and epoch {}",
+        epoch2,
+        next_epoch,
+    );
+
+    // ---- Count encrypted transactions in the committed history ----
+    let final_version = client
+        .get_ledger_information()
+        .await
+        .unwrap()
+        .into_inner()
+        .version;
+
+    let (encrypted_count, decrypted_count) =
+        count_encrypted_txns(&client, version_before_traffic, final_version).await;
+    info!(
+        "Found {} encrypted transactions ({} decrypted) between version {} and {}",
+        encrypted_count, decrypted_count, version_before_traffic, final_version
+    );
+    assert!(
+        encrypted_count > 0,
+        "Expected encrypted transactions to be committed, but found 0 in versions [{}, {})",
+        version_before_traffic,
+        final_version
+    );
+    assert!(
+        decrypted_count > 0,
+        "Expected decrypted encrypted transactions to be committed, but found 0 in versions [{}, {})",
+        version_before_traffic,
+        final_version
+    );
+}

--- a/testsuite/smoke-test/src/lib.rs
+++ b/testsuite/smoke-test/src/lib.rs
@@ -18,6 +18,8 @@ mod consensus_key_rotation;
 #[cfg(test)]
 mod consensus_observer;
 #[cfg(test)]
+mod decryption;
+#[cfg(test)]
 mod execution;
 #[cfg(test)]
 mod full_nodes;

--- a/testsuite/smoke-test/src/priority_fee.rs
+++ b/testsuite/smoke-test/src/priority_fee.rs
@@ -82,6 +82,8 @@ async fn test_impl(block_gas_limit: u64, concurrency_level: u16) {
                 20,
             ),
         ]],
+        false,
+        None,
     )
     .await
     .unwrap();

--- a/testsuite/smoke-test/src/rest_api.rs
+++ b/testsuite/smoke-test/src/rest_api.rs
@@ -135,6 +135,8 @@ async fn test_gas_estimation_inner(swarm: &mut LocalSwarm) {
             },
             100,
         )]],
+        false,
+        None,
     )
     .await
     .unwrap();

--- a/testsuite/smoke-test/src/smoke_test_environment.rs
+++ b/testsuite/smoke-test/src/smoke_test_environment.rs
@@ -86,6 +86,7 @@ impl SwarmBuilder {
     // Gas is not enabled with this setup, it's enabled via forge instance.
     pub async fn build_inner(&mut self) -> anyhow::Result<LocalSwarm> {
         ::aptos_logger::Logger::new().init();
+        env_logger::init();
         info!("Preparing to finish compiling");
         // TODO change to return Swarm trait
         // Add support for forge


### PR DESCRIPTION
## Description

Add an end-to-end smoke test that validates the full encrypted transaction lifecycle:

1. Spin up a 4-validator local swarm with DKG and randomness enabled.
2. Wait for epoch 2 and verify an encryption key is present in the ledger info.
3. Use the transaction emitter to generate encrypted traffic and confirm commits.
4. Wait for the next epoch and verify the encryption key rotates.
5. Scan committed transactions to confirm encrypted payloads were included on-chain.

New file: `testsuite/smoke-test/src/decryption.rs`

## How Has This Been Tested?

This *is* the test. Run with:
```
cargo test -p smoke-test -- test_encryption_key_rotation_and_encrypted_txns
```

## Type of Change
- [x] Tests

## Which Components or Systems Does This Change Impact?
- [x] Validator Node