### PR TITLE
[storage] Export RocksDB statistics tickers as Prometheus metrics

### DIFF
--- a/storage/aptosdb/src/ledger_db/mod.rs
+++ b/storage/aptosdb/src/ledger_db/mod.rs
@@ -464,14 +464,14 @@ impl LedgerDb {
     ) -> Result<DB> {
         let db = if readonly {
             DB::open_cf_readonly(
-                &gen_rocksdb_options(db_config, env, true),
+                gen_rocksdb_options(db_config, env, true),
                 path.clone(),
                 name,
                 Self::gen_cfds_by_name(db_config, block_cache, name),
             )?
         } else {
             DB::open_cf(
-                &gen_rocksdb_options(db_config, env, false),
+                gen_rocksdb_options(db_config, env, false),
                 path.clone(),
                 name,
                 Self::gen_cfds_by_name(db_config, block_cache, name),

--- a/storage/aptosdb/src/metrics.rs
+++ b/storage/aptosdb/src/metrics.rs
@@ -167,6 +167,14 @@ pub static ROCKSDB_SHARD_PROPERTIES: Lazy<IntGaugeVec> = Lazy::new(|| {
     .unwrap()
 });
 
+pub static ROCKSDB_TICKERS: Lazy<IntGaugeVec> = Lazy::new(|| {
+    register_int_gauge_vec!("aptos_rocksdb_tickers", "rocksdb statistics tickers", &[
+        "db_name",
+        "ticker_name"
+    ])
+    .unwrap()
+});
+
 // Async committer gauges:
 pub(crate) static LATEST_SNAPSHOT_VERSION: Lazy<IntGauge> = Lazy::new(|| {
     register_int_gauge!(

--- a/storage/aptosdb/src/rocksdb_property_reporter.rs
+++ b/storage/aptosdb/src/rocksdb_property_reporter.rs
@@ -10,7 +10,7 @@ use crate::{
         write_set_db_column_families,
     },
     ledger_db::LedgerDb,
-    metrics::{OTHER_TIMERS_SECONDS, ROCKSDB_PROPERTIES, ROCKSDB_SHARD_PROPERTIES},
+    metrics::{OTHER_TIMERS_SECONDS, ROCKSDB_PROPERTIES, ROCKSDB_SHARD_PROPERTIES, ROCKSDB_TICKERS},
     state_kv_db::StateKvDb,
     state_merkle_db::StateMerkleDb,
 };
@@ -18,7 +18,7 @@ use anyhow::Result;
 use aptos_infallible::Mutex;
 use aptos_logger::prelude::*;
 use aptos_metrics_core::TimerHelper;
-use aptos_schemadb::{ColumnFamilyName, DB};
+use aptos_schemadb::{ColumnFamilyName, Ticker, DB};
 use aptos_types::state_store::NUM_STATE_SHARDS;
 use once_cell::sync::Lazy;
 use std::{
@@ -83,6 +83,52 @@ fn set_property(cf_name: &str, db: &DB) -> Result<()> {
 const SHARD_NAME_BY_ID: [&str; NUM_STATE_SHARDS] = [
     "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15",
 ];
+
+const ROCKSDB_TICKER_LIST: &[(Ticker, &str)] = &[
+    // Compaction health
+    (Ticker::StallMicros, "stall_micros"),
+    (Ticker::CompactReadBytes, "compact_read_bytes"),
+    (Ticker::CompactWriteBytes, "compact_write_bytes"),
+    (Ticker::FlushWriteBytes, "flush_write_bytes"),
+    // Bloom filters (full key lookups)
+    (Ticker::BloomFilterUseful, "bloom_filter_useful"),
+    (
+        Ticker::BloomFilterFullPositive,
+        "bloom_filter_full_positive",
+    ),
+    (
+        Ticker::BloomFilterFullTruePositive,
+        "bloom_filter_full_true_positive",
+    ),
+    // Bloom filters (prefix seeks)
+    (
+        Ticker::BloomFilterPrefixChecked,
+        "bloom_filter_prefix_checked",
+    ),
+    (
+        Ticker::BloomFilterPrefixUseful,
+        "bloom_filter_prefix_useful",
+    ),
+    (
+        Ticker::BloomFilterPrefixTruePositive,
+        "bloom_filter_prefix_true_positive",
+    ),
+    // Block cache
+    (Ticker::BlockCacheHit, "block_cache_hit"),
+    (Ticker::BlockCacheMiss, "block_cache_miss"),
+    (Ticker::BlockCacheDataHit, "block_cache_data_hit"),
+    (Ticker::BlockCacheDataMiss, "block_cache_data_miss"),
+    (Ticker::BlockCacheFilterHit, "block_cache_filter_hit"),
+    (Ticker::BlockCacheFilterMiss, "block_cache_filter_miss"),
+];
+
+fn set_db_tickers(db: &DB) {
+    for (ticker, name) in ROCKSDB_TICKER_LIST {
+        ROCKSDB_TICKERS
+            .with_label_values(&[db.name(), name])
+            .set(db.get_ticker_count(*ticker) as i64);
+    }
+}
 
 fn set_shard_property(cf_name: ColumnFamilyName, db: &DB, shard: usize) -> Result<()> {
     if !skip_reporting_cf(cf_name) {
@@ -159,6 +205,33 @@ fn update_rocksdb_properties(
             }
         }
     }
+
+    // Collect RocksDB statistics tickers
+    if enable_storage_sharding {
+        set_db_tickers(&ledger_db.metadata_db_arc());
+        set_db_tickers(ledger_db.write_set_db_raw());
+        set_db_tickers(ledger_db.transaction_info_db_raw());
+        set_db_tickers(ledger_db.transaction_db_raw());
+        set_db_tickers(ledger_db.event_db_raw());
+        set_db_tickers(ledger_db.transaction_accumulator_db_raw());
+
+        set_db_tickers(state_kv_db.metadata_db());
+        if state_kv_db.enabled_sharding() {
+            for shard in 0..NUM_STATE_SHARDS {
+                set_db_tickers(state_kv_db.db_shard(shard));
+            }
+        }
+    } else {
+        set_db_tickers(&ledger_db.metadata_db_arc());
+    }
+
+    set_db_tickers(state_merkle_db.metadata_db());
+    if state_merkle_db.sharding_enabled() {
+        for shard in 0..NUM_STATE_SHARDS {
+            set_db_tickers(state_merkle_db.db_shard(shard));
+        }
+    }
+
     Ok(())
 }
 

--- a/storage/aptosdb/src/state_kv_db.rs
+++ b/storage/aptosdb/src/state_kv_db.rs
@@ -337,11 +337,6 @@ impl StateKvDb {
         readonly: bool,
         is_hot: bool,
     ) -> Result<DB> {
-        let open_func = if readonly {
-            DB::open_cf_readonly
-        } else {
-            DB::open_cf
-        };
         let rocksdb_opts = gen_rocksdb_options(state_kv_db_config, env, readonly);
         let cfds = if is_hot {
             gen_hot_state_kv_shard_cfds
@@ -349,7 +344,11 @@ impl StateKvDb {
             gen_state_kv_shard_cfds
         }(state_kv_db_config, block_cache);
 
-        open_func(&rocksdb_opts, path, name, cfds)
+        if readonly {
+            DB::open_cf_readonly(rocksdb_opts, path, name, cfds)
+        } else {
+            DB::open_cf(rocksdb_opts, path, name, cfds)
+        }
     }
 
     fn db_shard_path<P: AsRef<Path>>(db_root_path: P, shard_id: usize, is_hot: bool) -> PathBuf {

--- a/storage/aptosdb/src/state_merkle_db.rs
+++ b/storage/aptosdb/src/state_merkle_db.rs
@@ -722,14 +722,14 @@ impl StateMerkleDb {
 
         Ok(if readonly {
             DB::open_cf_readonly(
-                &gen_rocksdb_options(state_merkle_db_config, env, true),
+                gen_rocksdb_options(state_merkle_db_config, env, true),
                 path,
                 name,
                 gen_state_merkle_cfds(state_merkle_db_config, block_cache),
             )?
         } else {
             DB::open_cf(
-                &gen_rocksdb_options(state_merkle_db_config, env, false),
+                gen_rocksdb_options(state_merkle_db_config, env, false),
                 path,
                 name,
                 gen_state_merkle_cfds(state_merkle_db_config, block_cache),

--- a/storage/indexer/src/db_ops.rs
+++ b/storage/indexer/src/db_ops.rs
@@ -22,14 +22,14 @@ pub fn open_db<P: AsRef<Path>>(
             db_path,
             TABLE_INFO_DB_NAME,
             column_families(),
-            &gen_rocksdb_options(rocksdb_config, env, readonly),
+            gen_rocksdb_options(rocksdb_config, env, readonly),
         )?)
     } else {
         Ok(DB::open(
             db_path,
             TABLE_INFO_DB_NAME,
             column_families(),
-            &gen_rocksdb_options(rocksdb_config, env, readonly),
+            gen_rocksdb_options(rocksdb_config, env, readonly),
         )?)
     }
 }
@@ -43,7 +43,7 @@ pub fn open_internal_indexer_db<P: AsRef<Path>>(
         db_path,
         INTERNAL_INDEXER_DB_NAME,
         internal_indexer_column_families(),
-        &gen_rocksdb_options(rocksdb_config, env, false),
+        gen_rocksdb_options(rocksdb_config, env, false),
     )?)
 }
 

--- a/storage/indexer/src/lib.rs
+++ b/storage/indexer/src/lib.rs
@@ -67,7 +67,7 @@ impl Indexer {
             db_path,
             "index_db",
             column_families(),
-            &gen_rocksdb_options(&rocksdb_config, env, false),
+            gen_rocksdb_options(&rocksdb_config, env, false),
         )?;
 
         let next_version = db

--- a/storage/schemadb/src/lib.rs
+++ b/storage/schemadb/src/lib.rs
@@ -35,8 +35,8 @@ use batch::{IntoRawBatch, NativeBatch, WriteBatch};
 use iterator::{ScanDirection, SchemaIterator};
 /// Type alias to `rocksdb::ReadOptions`. See [`rocksdb doc`](https://github.com/pingcap/rust-rocksdb/blob/master/src/rocksdb_options.rs)
 pub use rocksdb::{
-    BlockBasedIndexType, BlockBasedOptions, Cache, ColumnFamilyDescriptor, DBCompressionType, Env,
-    Options, ReadOptions, SliceTransform, DEFAULT_COLUMN_FAMILY_NAME,
+    statistics::Ticker, BlockBasedIndexType, BlockBasedOptions, Cache, ColumnFamilyDescriptor,
+    DBCompressionType, Env, Options, ReadOptions, SliceTransform, DEFAULT_COLUMN_FAMILY_NAME,
 };
 use rocksdb::{ErrorKind, WriteOptions};
 use std::{collections::HashSet, fmt::Debug, iter::Iterator, path::Path};
@@ -52,10 +52,16 @@ enum OpenMode<'a> {
 
 /// This DB is a schematized RocksDB wrapper where all data passed in and out are typed according to
 /// [`Schema`]s.
-#[derive(Debug)]
 pub struct DB {
     name: String, // for logging
     inner: rocksdb::DB,
+    db_opts: Options,
+}
+
+impl std::fmt::Debug for DB {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DB").field("name", &self.name).finish()
+    }
 }
 
 impl DB {
@@ -63,7 +69,7 @@ impl DB {
         path: impl AsRef<Path>,
         name: &str,
         column_families: Vec<ColumnFamilyName>,
-        db_opts: &Options,
+        db_opts: Options,
     ) -> DbResult<Self> {
         Self::open_impl(path, name, column_families, db_opts, OpenMode::ReadWrite)
     }
@@ -72,13 +78,13 @@ impl DB {
         path: impl AsRef<Path>,
         name: &str,
         column_families: Vec<ColumnFamilyName>,
-        db_opts: &Options,
+        db_opts: Options,
     ) -> DbResult<Self> {
         Self::open_impl(path, name, column_families, db_opts, OpenMode::ReadOnly)
     }
 
     pub fn open_cf(
-        db_opts: &Options,
+        db_opts: Options,
         path: impl AsRef<Path>,
         name: &str,
         cfds: Vec<ColumnFamilyDescriptor>,
@@ -90,7 +96,7 @@ impl DB {
     /// Note that this still assumes there's only one process that opens the same DB.
     /// See `open_as_secondary`
     pub fn open_cf_readonly(
-        opts: &Options,
+        opts: Options,
         path: impl AsRef<Path>,
         name: &str,
         cfds: Vec<ColumnFamilyDescriptor>,
@@ -99,7 +105,7 @@ impl DB {
     }
 
     pub fn open_cf_as_secondary<P: AsRef<Path>>(
-        opts: &Options,
+        opts: Options,
         primary_path: P,
         secondary_path: P,
         name: &str,
@@ -118,7 +124,7 @@ impl DB {
         path: impl AsRef<Path>,
         name: &str,
         column_families: Vec<ColumnFamilyName>,
-        db_opts: &Options,
+        db_opts: Options,
         open_mode: OpenMode,
     ) -> DbResult<Self> {
         let db = DB::open_cf_impl(
@@ -139,14 +145,14 @@ impl DB {
     }
 
     fn open_cf_impl(
-        db_opts: &Options,
+        db_opts: Options,
         path: impl AsRef<Path>,
         name: &str,
         cfds: Vec<ColumnFamilyDescriptor>,
         open_mode: OpenMode,
     ) -> DbResult<DB> {
         // ignore error, since it'll fail to list cfs on the first open
-        let existing_cfs: HashSet<String> = rocksdb::DB::list_cf(db_opts, path.de_unc())
+        let existing_cfs: HashSet<String> = rocksdb::DB::list_cf(&db_opts, path.de_unc())
             .unwrap_or_default()
             .into_iter()
             .collect();
@@ -170,17 +176,17 @@ impl DB {
             use OpenMode::*;
 
             match open_mode {
-                ReadWrite => DB::open_cf_descriptors(db_opts, path.de_unc(), all_cfds),
+                ReadWrite => DB::open_cf_descriptors(&db_opts, path.de_unc(), all_cfds),
                 ReadOnly => {
                     DB::open_cf_descriptors_read_only(
-                        db_opts,
+                        &db_opts,
                         path.de_unc(),
                         all_cfds.filter(|cfd| !missing_cfs.contains(cfd.name())),
                         false, /* error_if_log_file_exist */
                     )
                 },
                 Secondary(secondary_path) => DB::open_cf_descriptors_as_secondary(
-                    db_opts,
+                    &db_opts,
                     path.de_unc(),
                     secondary_path,
                     all_cfds,
@@ -189,7 +195,7 @@ impl DB {
         }
         .into_db_res()?;
 
-        Ok(Self::log_construct(name, open_mode, inner))
+        Ok(Self::log_construct(name, open_mode, inner, db_opts))
     }
 
     fn cfd_for_unrecognized_cf(cf: &String) -> ColumnFamilyDescriptor {
@@ -200,7 +206,7 @@ impl DB {
         ColumnFamilyDescriptor::new(cf.to_string(), cf_opts)
     }
 
-    fn log_construct(name: &str, open_mode: OpenMode, inner: rocksdb::DB) -> DB {
+    fn log_construct(name: &str, open_mode: OpenMode, inner: rocksdb::DB, db_opts: Options) -> DB {
         info!(
             rocksdb_name = name,
             open_mode = ?open_mode,
@@ -209,6 +215,7 @@ impl DB {
         DB {
             name: name.to_string(),
             inner,
+            db_opts,
         }
     }
 
@@ -335,6 +342,14 @@ impl DB {
         self.inner
             .flush_cf(self.get_cf_handle(cf_name)?)
             .into_db_res()
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn get_ticker_count(&self, ticker: Ticker) -> u64 {
+        self.db_opts.get_ticker_count(ticker)
     }
 
     pub fn get_property(&self, cf_name: &str, property_name: &str) -> DbResult<u64> {

--- a/storage/schemadb/tests/db.rs
+++ b/storage/schemadb/tests/db.rs
@@ -92,17 +92,17 @@ fn open_db(dir: &aptos_temppath::TempPath) -> DB {
     let mut db_opts = rocksdb::Options::default();
     db_opts.create_if_missing(true);
     db_opts.create_missing_column_families(true);
-    DB::open(dir.path(), "test", get_column_families(), &db_opts).expect("Failed to open DB.")
+    DB::open(dir.path(), "test", get_column_families(), db_opts).expect("Failed to open DB.")
 }
 
 fn open_db_read_only(dir: &aptos_temppath::TempPath) -> DB {
-    DB::open_cf_readonly(&rocksdb::Options::default(), dir.path(), "test", get_cfds())
+    DB::open_cf_readonly(rocksdb::Options::default(), dir.path(), "test", get_cfds())
         .expect("Failed to open DB.")
 }
 
 fn open_db_as_secondary(dir: &aptos_temppath::TempPath, dir_sec: &aptos_temppath::TempPath) -> DB {
     DB::open_cf_as_secondary(
-        &rocksdb::Options::default(),
+        rocksdb::Options::default(),
         dir.path(),
         dir_sec.path(),
         "test",
@@ -398,8 +398,12 @@ fn test_unrecognised_column_family() {
     opts.create_if_missing(true);
     opts.create_missing_column_families(true);
 
-    let db = DB::open(tmpdir.path(), "test", vec!["cf1", "cf2"], &opts).unwrap();
+    let mut opts2 = rocksdb::Options::default();
+    opts2.create_if_missing(true);
+    opts2.create_missing_column_families(true);
+
+    let db = DB::open(tmpdir.path(), "test", vec!["cf1", "cf2"], opts).unwrap();
     drop(db);
 
-    DB::open(tmpdir.path(), "test", vec!["cf1"], &opts).unwrap();
+    DB::open(tmpdir.path(), "test", vec!["cf1"], opts2).unwrap();
 }

--- a/storage/schemadb/tests/iterator.rs
+++ b/storage/schemadb/tests/iterator.rs
@@ -110,7 +110,7 @@ impl TestDB {
         let mut db_opts = rocksdb::Options::default();
         db_opts.create_if_missing(true);
         db_opts.create_missing_column_families(true);
-        let db = DB::open(tmpdir.path(), "test", column_families, &db_opts).unwrap();
+        let db = DB::open(tmpdir.path(), "test", column_families, db_opts).unwrap();
 
         db.put::<TestSchema>(&TestKey(1, 0, 0), &TestValue(100))
             .unwrap();
@@ -299,7 +299,7 @@ impl TestDBWithPrefixExtractor {
         let mut db_opts = rocksdb::Options::default();
         db_opts.create_if_missing(true);
         db_opts.create_missing_column_families(true);
-        let db = DB::open_cf(&db_opts, tmpdir.path(), "test_with_prefix", vec![
+        let db = DB::open_cf(db_opts, tmpdir.path(), "test_with_prefix", vec![
             ColumnFamilyDescriptor::new(DEFAULT_COLUMN_FAMILY_NAME, rocksdb::Options::default()),
             ColumnFamilyDescriptor::new(TestSchema::COLUMN_FAMILY_NAME, {
                 let mut opts = rocksdb::Options::default();


### PR DESCRIPTION

Report key RocksDB statistics tickers (compaction health, bloom filter
effectiveness, block cache hit rates) via Prometheus `IntGaugeVec` metrics,
collected alongside the existing property reporter every 10 seconds.

To support `get_ticker_count`, `DB::open*` APIs now take `Options` by value
so the `Options` (which owns the statistics handle) can be stored in the `DB`
struct.
