### PR TITLE
[TSS] add gas profiler support and bump CLI version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,7 +304,7 @@ dependencies = [
 
 [[package]]
 name = "aptos"
-version = "8.0.0"
+version = "8.1.0"
 dependencies = [
  "anyhow",
  "aptos-api-types",
@@ -4700,6 +4700,7 @@ dependencies = [
  "anyhow",
  "aptos-api-types",
  "aptos-crypto",
+ "aptos-gas-profiling",
  "aptos-resource-viewer",
  "aptos-rest-client",
  "aptos-transaction-simulation",

--- a/aptos-move/aptos-transaction-simulation-session/Cargo.toml
+++ b/aptos-move/aptos-transaction-simulation-session/Cargo.toml
@@ -25,6 +25,7 @@ move-core-types = { workspace = true }
 
 aptos-api-types = { workspace = true }
 aptos-crypto = { workspace = true }
+aptos-gas-profiling = { workspace = true }
 aptos-resource-viewer = { workspace = true }
 aptos-rest-client = { workspace = true }
 aptos-transaction-simulation = { workspace = true }

--- a/aptos-move/aptos-transaction-simulation-session/src/session.rs
+++ b/aptos-move/aptos-transaction-simulation-session/src/session.rs
@@ -8,6 +8,7 @@ use crate::{
 };
 use anyhow::Result;
 use aptos_crypto::HashValue;
+use aptos_gas_profiling::GasProfiler;
 use aptos_resource_viewer::{AnnotatedMoveValue, AptosValueAnnotator};
 use aptos_rest_client::{AptosBaseUrl, Client};
 use aptos_transaction_simulation::{
@@ -565,9 +566,14 @@ impl Session {
     /// After execution, selected parts of the transaction output get saved to a dedicated directory for inspection:
     /// - Write set changes
     /// - Emitted events
+    ///
+    /// If `profile_gas` is `true`, the transaction is executed with the gas profiler enabled.
+    /// A `gas-report` directory is generated under the transaction output directory containing
+    /// an HTML report with flamegraphs and detailed gas breakdowns.
     pub fn execute_transaction(
         &mut self,
         txn: SignedTransaction,
+        profile_gas: bool,
     ) -> Result<(VMStatus, TransactionOutput)> {
         let env = AptosEnvironment::new(&self.state_store);
         let vm = AptosVM::new(&env);
@@ -576,14 +582,41 @@ impl Session {
         let resolver = self.state_store.as_move_resolver();
         let code_storage = self.state_store.as_aptos_code_storage(&env);
 
-        let (vm_status, vm_output) = vm.execute_user_transaction(
-            &resolver,
-            &code_storage,
-            &txn,
-            &log_context,
-            &AuxiliaryInfo::new_timestamp_not_yet_assigned(0),
-        );
-        let txn_output = vm_output.try_materialize_into_transaction_output(&resolver)?;
+        // Execute the transaction, optionally with gas profiling.
+        let (vm_status, txn_output, gas_log) = if profile_gas {
+            let (vm_status, vm_output, gas_profiler) = vm
+                .execute_user_transaction_with_modified_gas_meter(
+                    &resolver,
+                    &code_storage,
+                    &txn,
+                    &log_context,
+                    |gas_meter| match txn.payload() {
+                        TransactionPayload::EntryFunction(entry_function) => {
+                            GasProfiler::new_function(
+                                gas_meter,
+                                entry_function.module().clone(),
+                                entry_function.function().to_owned(),
+                                entry_function.ty_args().to_vec(),
+                            )
+                        },
+                        _ => GasProfiler::new_script(gas_meter),
+                    },
+                    &AuxiliaryInfo::new_timestamp_not_yet_assigned(0),
+                )
+                .map_err(|e| anyhow::anyhow!("transaction execution failed: {:?}", e))?;
+            let txn_output = vm_output.try_materialize_into_transaction_output(&resolver)?;
+            (vm_status, txn_output, Some(gas_profiler.finish()))
+        } else {
+            let (vm_status, vm_output) = vm.execute_user_transaction(
+                &resolver,
+                &code_storage,
+                &txn,
+                &log_context,
+                &AuxiliaryInfo::new_timestamp_not_yet_assigned(0),
+            );
+            let txn_output = vm_output.try_materialize_into_transaction_output(&resolver)?;
+            (vm_status, txn_output, None)
+        };
 
         self.state_store.apply_write_set(txn_output.write_set())?;
 
@@ -639,6 +672,11 @@ impl Session {
 
         let write_set_path = output_path.join("write_set.json");
         save_write_set(&self.state_store, &write_set_path, txn_output.write_set())?;
+
+        // Generate gas profiling report if enabled.
+        if let Some(gas_log) = gas_log {
+            gas_log.generate_html_report(output_path.join("gas-report"), name)?;
+        }
 
         self.finish_op(true)?;
 

--- a/aptos-move/aptos-transaction-simulation-session/tests/execute_transaction.rs
+++ b/aptos-move/aptos-transaction-simulation-session/tests/execute_transaction.rs
@@ -48,7 +48,7 @@ fn test_execute_transfer() -> Result<()> {
         .store_and_fund_account(sender.clone(), 100_000_000, 0)?;
 
     let txn = transfer_txn(&sender, *recipient.address(), 1_000);
-    let (vm_status, output) = session.execute_transaction(txn)?;
+    let (vm_status, output) = session.execute_transaction(txn, false)?;
 
     assert_eq!(vm_status, VMStatus::Executed, "transfer should succeed");
     assert!(output.gas_used() > 0, "should use some gas");
@@ -67,7 +67,7 @@ fn test_execute_transaction_increments_sequence_number() -> Result<()> {
         .store_and_fund_account(sender.clone(), 100_000_000, 0)?;
 
     let txn = transfer_txn(&sender, *sender.address(), 100);
-    session.execute_transaction(txn)?;
+    session.execute_transaction(txn, false)?;
 
     // After one transaction, sequence number should be 1.
     let account_resource: AccountResource = session
@@ -75,6 +75,44 @@ fn test_execute_transaction_increments_sequence_number() -> Result<()> {
         .get_resource(*sender.address())?
         .expect("account resource should exist");
     assert_eq!(account_resource.sequence_number(), 1);
+
+    Ok(())
+}
+
+#[test]
+fn test_execute_transaction_with_gas_profiling() -> Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+    let session_path = temp_dir.path();
+    let mut session = Session::init(session_path)?;
+
+    let sender = Account::new();
+    let recipient = Account::new();
+
+    session
+        .state_store()
+        .store_and_fund_account(sender.clone(), 100_000_000, 0)?;
+
+    let txn = transfer_txn(&sender, *recipient.address(), 1_000);
+    let (vm_status, output) = session.execute_transaction(txn, true)?;
+
+    assert_eq!(vm_status, VMStatus::Executed, "transfer should succeed");
+    assert!(output.gas_used() > 0, "should use some gas");
+
+    // Verify the gas-report directory was created under the transaction output.
+    let gas_report_dir = session_path.join("[0] execute 0x1::aptos_account::transfer/gas-report");
+    assert!(
+        gas_report_dir.exists(),
+        "gas-report directory should exist: {}",
+        gas_report_dir.display()
+    );
+    assert!(
+        gas_report_dir.join("index.html").exists(),
+        "gas-report/index.html should exist"
+    );
+    assert!(
+        gas_report_dir.join("assets").exists(),
+        "gas-report/assets directory should exist"
+    );
 
     Ok(())
 }

--- a/crates/aptos/CHANGELOG.md
+++ b/crates/aptos/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the Aptos CLI will be captured in this file. This project
 
 # Unreleased
 
+## [8.1.0]
+- Transaction Simulation Session: add gas profiler support
+- Transaction Simulation Session: add `new-block` and `advance-epoch` commands
+
 ## [8.0.0]
 - [**Breaking Change**] (Breaking only for the localnet) Updated localnet indexer processors to aptos-indexer-processors-v2.3.0 and processor SDK to aptos-indexer-processor-sdk-v2.1.4. This removes the events processor and upgrades diesel to v2.3. Also updated Hasura metadata accordingly. This is breaking because old v1 tables are now gone (e.g. `events`).
 

--- a/crates/aptos/Cargo.toml
+++ b/crates/aptos/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aptos"
 description = "Aptos tool for management of nodes and interacting with the blockchain"
-version = "8.0.0"
+version = "8.1.0"
 
 # Workspace inherited keys
 authors = { workspace = true }

--- a/crates/aptos/src/common/types.rs
+++ b/crates/aptos/src/common/types.rs
@@ -2216,6 +2216,7 @@ impl TransactionOptions {
         &self,
         session_path: &Path,
         payload: TransactionPayload,
+        profile_gas: bool,
     ) -> CliTypedResult<TransactionSummary> {
         let mut sess = Session::load(session_path)?;
 
@@ -2258,7 +2259,7 @@ impl TransactionOptions {
             sender_account.sign_with_transaction_builder(transaction_factory.payload(payload));
         let hash = transaction.committed_hash();
 
-        let (vm_status, txn_output) = sess.execute_transaction(transaction)?;
+        let (vm_status, txn_output) = sess.execute_transaction(transaction, profile_gas)?;
 
         let success = match txn_output.status() {
             TransactionStatus::Keep(exec_status) => Some(exec_status.is_success()),

--- a/crates/aptos/src/common/utils.rs
+++ b/crates/aptos/src/common/utils.rs
@@ -509,21 +509,15 @@ pub async fn dispatch_transaction(
         ));
     }
 
-    if txn_options_ref.session.is_some() && txn_options_ref.profile_gas {
-        return Err(CliError::UnexpectedError(
-            "`--profile-gas` cannot be used with `--session yet`".to_string(),
-        ));
-    }
-
     if txn_options_ref.session.is_some() && txn_options_ref.benchmark {
         return Err(CliError::UnexpectedError(
-            "`--benchmark` cannot be used with `--session yet`".to_string(),
+            "`--benchmark` cannot be used with `--session`".to_string(),
         ));
     }
 
     if let Some(session_path) = &txn_options_ref.session {
         txn_options_ref
-            .simulate_using_session(session_path, payload)
+            .simulate_using_session(session_path, payload, txn_options_ref.profile_gas)
             .await
     } else if txn_options_ref.profile_gas {
         txn_options_ref.profile_gas(payload).await


### PR DESCRIPTION
This adds gas profiling support to Transaction Simulation Sessions. 
- `Session::execute_transaction` now accepts a flag to enable gas profiling. When enabled, it runs the transaction through the Aptos gas profiler and writes an HTML gas report (with assets) to the session output directory

Also bumps the CLI version from 8.0.0 to 8.1.0, in preparation for an upcoming release.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how session-based transaction simulation is executed and adds a new profiler codepath that writes additional on-disk artifacts, which could affect performance or output structure.
> 
> **Overview**
> **Transaction Simulation Session now supports optional gas profiling.** `Session::execute_transaction` takes a new `profile_gas` flag; when enabled it runs via `execute_user_transaction_with_modified_gas_meter` and writes an HTML flamegraph report under `gas-report/` alongside the usual `events.json`/`write_set.json` artifacts.
> 
> The Aptos CLI is bumped to `8.1.0` and the `--session` execution path now allows `--profile-gas` (threaded through `simulate_using_session`/`dispatch_transaction`), with tests updated and a new test asserting `gas-report` output creation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b4c23197b20ada05de2059e9fd1ccdc2fddc663e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->