### PR TITLE
[compiler-v2] Fix parsing of signed int returns

### DIFF
--- a/third_party/move/move-compiler-v2/legacy-move-compiler/src/parser/syntax.rs
+++ b/third_party/move/move-compiler-v2/legacy-move-compiler/src/parser/syntax.rs
@@ -1275,7 +1275,7 @@ fn parse_term(context: &mut Context) -> Result<Exp, Box<Diagnostic>> {
 
             if at_start_of_exp(context) {
                 let mut diag = unexpected_token_error(context.tokens, "the end of an expression");
-                diag.add_note("'break' with a value is not yet supported");
+                diag.add_note("`break` with a value is not yet supported");
                 return Err(diag);
             }
             Exp_::Break(label)
@@ -1999,6 +1999,7 @@ fn at_start_of_exp(context: &mut Context) -> bool {
             | Tok::AmpMut
             | Tok::Star
             | Tok::Exclaim
+            | Tok::Minus
             | Tok::LParen
             | Tok::LBrace
             | Tok::Abort
@@ -2294,6 +2295,7 @@ fn parse_binop_exp(context: &mut Context, lhs: Exp, min_prec: u32) -> Result<Exp
 // Parse a unary expression:
 //      UnaryExp =
 //          "!" <UnaryExp>
+//          | "-" <UnaryExp>
 //          | "&mut" <UnaryExp>
 //          | "&" <UnaryExp>
 //          | "*" <UnaryExp>

--- a/third_party/move/move-compiler-v2/tests/more-v1/parser/break_with_value.exp
+++ b/third_party/move/move-compiler-v2/tests/more-v1/parser/break_with_value.exp
@@ -9,4 +9,4 @@ error: unexpected token
   │                      Unexpected '0'
   │                      Expected the end of an expression
   │
-  = 'break' with a value is not yet supported
+  = `break` with a value is not yet supported

--- a/third_party/move/move-compiler-v2/tests/more-v1/parser/return_in_binop.move
+++ b/third_party/move/move-compiler-v2/tests/more-v1/parser/return_in_binop.move
@@ -5,7 +5,6 @@ module 0x42::M {
         return || false;
         return && false;
         return + 0;
-        return - 0;
         return % 0;
         return / 1;
         return < 0;

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/signed-int/return_negative_nums.baseline.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/signed-int/return_negative_nums.baseline.exp
@@ -1,0 +1,4 @@
+processed 2 tasks
+task 0 lines 1-7:  publish [module 0xc0ffee::m {]
+task 1 lines 9-9:  run 0xc0ffee::m::test --args true 100
+return values: 44

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/signed-int/return_negative_nums.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/signed-int/return_negative_nums.move
@@ -1,0 +1,9 @@
+//# publish
+module 0xc0ffee::m {
+    public fun test(p: bool, q: i64): i64 {
+        if (p) return -56 + q;
+        -88
+    }
+}
+
+//# run 0xc0ffee::m::test --args true 100

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/signed-int/return_negative_nums.no-optimize.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/signed-int/return_negative_nums.no-optimize.exp
@@ -1,0 +1,4 @@
+processed 2 tasks
+task 0 lines 1-7:  publish [module 0xc0ffee::m {]
+task 1 lines 9-9:  run 0xc0ffee::m::test --args true 100
+return values: 44

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/signed-int/return_negative_nums.opt-extra.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/signed-int/return_negative_nums.opt-extra.exp
@@ -1,0 +1,4 @@
+processed 2 tasks
+task 0 lines 1-7:  publish [module 0xc0ffee::m {]
+task 1 lines 9-9:  run 0xc0ffee::m::test --args true 100
+return values: 44

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/signed-int/return_negative_nums.optimize.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/signed-int/return_negative_nums.optimize.exp
@@ -1,0 +1,4 @@
+processed 2 tasks
+task 0 lines 1-7:  publish [module 0xc0ffee::m {]
+task 1 lines 9-9:  run 0xc0ffee::m::test --args true 100
+return values: 44

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/signed-int/round-trip/return_negative_nums.decompiled
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/signed-int/round-trip/return_negative_nums.decompiled
@@ -1,0 +1,12 @@
+//**** Cross-compiled for `move` syntax from `tests/signed-int/return_negative_nums.move`
+
+//# publish
+module 0xc0ffee::m {
+    public fun test(p0: bool, p1: i64): i64 {
+        if (p0) return -56i64 + p1;
+        -88i64
+    }
+}
+
+
+//# run 0xc0ffee::m::test --args true 100

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/signed-int/round-trip/return_negative_nums.decompiled.baseline.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/signed-int/round-trip/return_negative_nums.decompiled.baseline.exp
@@ -1,0 +1,4 @@
+processed 2 tasks
+task 0 lines 3-9:  publish [module 0xc0ffee::m {]
+task 1 lines 12-12:  run 0xc0ffee::m::test --args true 100
+return values: 44


### PR DESCRIPTION
## Description

Currently, explicit returns of signed integers are not parsed correctly, leading to compiler errors down the line.

For example,

```move
    public fun test(p: bool, q: i64): i64 {
        if (p) return -56 + q;
        -88
    }
```
gives an unexpected type error:
```
 error: cannot return nothing from a function with result type `i64`
  ┌─ TEMPFILE:4:16
  │
4 │         if (p) return -56 + q;
  │                ^^^^^^
```

This PR fixes this error.

## How Has This Been Tested?
- added new test
- modified an existing test to remove `return - 0` (because this causes an error and violates the spirit of the rest of the test)
- existing tests pass

## Type of Change
- [x] Bug fix

## Which Components or Systems Does This Change Impact?
- [x] Move Compiler

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core expression parsing/precedence handling, so regressions could affect how `-` binds across many syntactic contexts, though changes are well-covered by added/updated tests.
> 
> **Overview**
> Fixes Move compiler v2 parsing so expressions like `return -56 + q` are treated as returning a signed numeric expression rather than a `return` with no value.
> 
> This updates the parser to accept `Tok::Minus` at the start of expressions and implements unary negation in `parse_unary_exp` (folding `-` into numeric literals when possible). Tests are adjusted: the `break` diagnostic note is reworded, `return - 0` is removed from `return_in_binop.move`, and new transactional tests validate returning negative `i64` values (including round-trip decompilation baselines).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 937fb11bdb12522a38ae920116a9c3e05372cecc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->