### PR TITLE
[state-sync] Combine 4 state-sync tokio runtimes into one shared runtime

### DIFF
--- a/aptos-node/src/lib.rs
+++ b/aptos-node/src/lib.rs
@@ -25,7 +25,7 @@ use aptos_config::config::{merge_node_config, NodeConfig, PersistableConfig};
 use aptos_framework::ReleaseBundle;
 use aptos_genesis::builder::GenesisConfiguration;
 use aptos_logger::{prelude::*, telemetry_log_writer::TelemetryLog, Level, LoggerFilterUpdater};
-use aptos_state_sync_driver::driver_factory::StateSyncRuntimes;
+use aptos_state_sync_driver::driver_factory::StateSyncRuntime;
 use aptos_types::{
     chain_id::ChainId, keyless::Groth16VerificationKey, on_chain_config::OnChainJWKConsensusConfig,
 };
@@ -209,7 +209,7 @@ pub struct AptosHandle {
     _mempool_runtime: Runtime,
     _network_runtimes: Vec<Runtime>,
     _peer_monitoring_service_runtime: Runtime,
-    _state_sync_runtimes: StateSyncRuntimes,
+    _state_sync_runtime: StateSyncRuntime,
     _telemetry_runtime: Option<Runtime>,
     _indexer_db_runtime: Option<Runtime>,
 }
@@ -763,7 +763,7 @@ pub fn setup_environment_and_start_node(
     );
 
     // Start state sync and get the notification endpoints for mempool and consensus
-    let (aptos_data_client, state_sync_runtimes, mempool_listener, consensus_notifier) =
+    let (aptos_data_client, state_sync_runtime, mempool_listener, consensus_notifier) =
         state_sync::start_state_sync_and_get_notification_handles(
             &node_config,
             storage_service_network_interfaces,
@@ -827,7 +827,7 @@ pub fn setup_environment_and_start_node(
 
     // Wait until state sync has been initialized
     debug!("Waiting until state sync is initialized!");
-    state_sync_runtimes.block_until_initialized();
+    state_sync_runtime.block_until_initialized();
     debug!("State sync initialization complete.");
 
     // Create the consensus observer and publisher (if enabled)
@@ -869,7 +869,7 @@ pub fn setup_environment_and_start_node(
         _mempool_runtime: mempool_runtime,
         _network_runtimes: network_runtimes,
         _peer_monitoring_service_runtime: peer_monitoring_service_runtime,
-        _state_sync_runtimes: state_sync_runtimes,
+        _state_sync_runtime: state_sync_runtime,
         _telemetry_runtime: telemetry_runtime,
         _indexer_db_runtime: internal_indexer_db_runtime,
     })

--- a/config/src/config/state_sync_config.rs
+++ b/config/src/config/state_sync_config.rs
@@ -30,13 +30,31 @@ const MAX_TRANSACTION_OUTPUT_CHUNK_SIZE: u64 = 3000;
 const MAX_CONCURRENT_REQUESTS: u64 = 6;
 const MAX_CONCURRENT_STATE_REQUESTS: u64 = 6;
 
-#[derive(Clone, Copy, Debug, Default, Deserialize, PartialEq, Eq, Serialize)]
+// The default number of threads for the state sync runtime
+const DEFAULT_STATE_SYNC_RUNTIME_THREADS: usize = 16;
+
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq, Serialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct StateSyncConfig {
     pub data_streaming_service: DataStreamingServiceConfig,
     pub aptos_data_client: AptosDataClientConfig,
     pub state_sync_driver: StateSyncDriverConfig,
     pub storage_service: StorageServiceConfig,
+    /// Number of worker threads for the shared state sync runtime.
+    /// Defaults to 16. Set to `None` to use the tokio default (num_cpus).
+    pub num_runtime_threads: Option<usize>,
+}
+
+impl Default for StateSyncConfig {
+    fn default() -> Self {
+        Self {
+            data_streaming_service: DataStreamingServiceConfig::default(),
+            aptos_data_client: AptosDataClientConfig::default(),
+            state_sync_driver: StateSyncDriverConfig::default(),
+            storage_service: StorageServiceConfig::default(),
+            num_runtime_threads: Some(DEFAULT_STATE_SYNC_RUNTIME_THREADS),
+        }
+    }
 }
 
 /// The bootstrapping mode determines how the node will bootstrap to the latest

--- a/state-sync/state-sync-driver/src/storage_synchronizer.rs
+++ b/state-sync/state-sync-driver/src/storage_synchronizer.rs
@@ -43,10 +43,7 @@ use std::{
     },
     time::Instant,
 };
-use tokio::{
-    runtime::{Handle, Runtime},
-    task::JoinHandle,
-};
+use tokio::{runtime::Handle, task::JoinHandle};
 
 /// Synchronizes the storage of the node by verifying and storing new data
 /// (e.g., transactions and outputs).
@@ -209,7 +206,7 @@ impl<
         >,
         metadata_storage: MetadataStorage,
         storage: DbReaderWriter,
-        runtime: Option<&Runtime>,
+        runtime: Option<Handle>,
     ) -> (Self, StorageSynchronizerHandles) {
         // Create a channel to notify the executor when data chunks are ready
         let max_pending_data_chunks = driver_config.max_pending_data_chunks as usize;
@@ -228,9 +225,6 @@ impl<
 
         // Create a shared pending data chunk counter
         let pending_data_chunks = Arc::new(AtomicU64::new(0));
-
-        // Spawn the executor that executes/applies storage data chunks
-        let runtime = runtime.map(|runtime| runtime.handle().clone());
         let executor_handle = spawn_executor(
             chunk_executor.clone(),
             error_notification_sender.clone(),

--- a/state-sync/state-sync-driver/src/tests/driver.rs
+++ b/state-sync/state-sync-driver/src/tests/driver.rs
@@ -392,7 +392,7 @@ async fn create_driver_for_tests(
     // Create and spawn the driver
     let (driver_factory, commit_notification_sender) =
         DriverFactory::create_and_spawn_driver_internal(
-            false,
+            None,
             &node_config,
             waypoint,
             db_rw,

--- a/state-sync/state-sync-driver/src/tests/driver_factory.rs
+++ b/state-sync/state-sync-driver/src/tests/driver_factory.rs
@@ -88,8 +88,9 @@ fn test_new_initialized_configs() {
     // Create the state sync driver factory
     let chunk_executor = Arc::new(ChunkExecutor::<AptosVMBlockExecutor>::new(db_rw.clone()));
     let metadata_storage = PersistentMetadataStorage::new(tmp_dir.path());
+    let runtime = aptos_runtimes::spawn_named_runtime("state-sync".into(), Some(2));
     let _ = DriverFactory::create_and_spawn_driver(
-        true,
+        Some(runtime.handle().clone()),
         &node_config,
         node_config.base.waypoint.waypoint(),
         db_rw,


### PR DESCRIPTION

State sync previously created 4 separate tokio runtimes (`sync-driver`,
`stream-serv`, `data-client`, `stor-server`), each defaulting to `num_cpus`
worker threads. On a 44-core machine this means **176 threads** for state
sync alone. These subsystems are mostly I/O-bound and form a single logical
pipeline, so sharing one runtime is both safe and efficient.

Changes:
- Add `num_runtime_threads: Option<usize>` to `StateSyncConfig`
  (default: 16)
- Create a single `state-sync` runtime in `start_state_sync_and_get_notification_handles()`
  and pass its `Handle` to all subsystem setup functions
- Remove the internal `_driver_runtime: Option<Runtime>` from `DriverFactory`;
  change `create_runtime: bool` → `runtime: Option<Handle>`
- Collapse `StateSyncRuntimes` from 3 runtime fields to 1
- Simplify `StorageSynchronizer::new()` parameter from `Option<&Runtime>` to
  `Option<Handle>`

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how core state-sync tasks are scheduled and executed; misconfiguration or handle/lifetime issues could cause startup, performance, or liveness regressions under load.
> 
> **Overview**
> Reduces state sync thread overhead by replacing the separate tokio runtimes for the driver, data client, streaming service, and storage server with a **single shared `state-sync` runtime** that all subsystems spawn onto.
> 
> Introduces `state_sync.num_runtime_threads` (default **16**, `None` = tokio default) to size the shared runtime, updates `DriverFactory`/`StorageSynchronizer` to accept an optional `tokio::runtime::Handle` instead of creating/holding their own runtimes, and adjusts node startup and tests to use the new `StateSyncRuntime` wrapper and initialization flow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e8d9ea14318ec3613b47094302d24ce7a79af441. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->