### PR TITLE
[node] Reduce default thread counts for backup and index-db runtimes

### DIFF
--- a/aptos-node/src/storage.rs
+++ b/aptos-node/src/storage.rs
@@ -67,8 +67,11 @@ pub(crate) fn bootstrap_db(
     )? {
         Either::Left(db) => {
             let (db_arc, db_rw) = DbReaderWriter::wrap(db);
-            let db_backup_service =
-                start_backup_service(node_config.storage.backup_service_address, db_arc.clone());
+            let db_backup_service = start_backup_service(
+                node_config.storage.backup_service_address,
+                db_arc.clone(),
+                node_config.storage.backup_service_runtime_threads,
+            );
             maybe_apply_genesis(&db_rw, node_config)?;
             (db_arc as Arc<dyn DbReader>, db_rw, Some(db_backup_service))
         },
@@ -92,8 +95,11 @@ pub(crate) fn bootstrap_db(
                 // commit the genesis ledger info to the DB.
                 fast_sync_db.commit_genesis_ledger_info(&ledger_info)?;
             }
-            let db_backup_service =
-                start_backup_service(node_config.storage.backup_service_address, fast_sync_db);
+            let db_backup_service = start_backup_service(
+                node_config.storage.backup_service_address,
+                fast_sync_db,
+                node_config.storage.backup_service_runtime_threads,
+            );
             (db_arc as Arc<dyn DbReader>, db_rw, Some(db_backup_service))
         },
     };

--- a/config/src/config/internal_indexer_db_config.rs
+++ b/config/src/config/internal_indexer_db_config.rs
@@ -16,6 +16,7 @@ pub struct InternalIndexerDBConfig {
     pub event_v2_translation_ignores_below_version: u64,
     pub enable_statekeys: bool,
     pub batch_size: usize,
+    pub runtime_threads: Option<usize>,
 }
 
 impl InternalIndexerDBConfig {
@@ -34,6 +35,7 @@ impl InternalIndexerDBConfig {
             event_v2_translation_ignores_below_version,
             enable_statekeys,
             batch_size,
+            runtime_threads: Some(2),
         }
     }
 
@@ -75,6 +77,7 @@ impl Default for InternalIndexerDBConfig {
             event_v2_translation_ignores_below_version: 0,
             enable_statekeys: false,
             batch_size: 10_000,
+            runtime_threads: Some(2),
         }
     }
 }

--- a/config/src/config/storage_config.rs
+++ b/config/src/config/storage_config.rs
@@ -268,6 +268,7 @@ impl Default for HotStateConfig {
 #[serde(default, deny_unknown_fields)]
 pub struct StorageConfig {
     pub backup_service_address: SocketAddr,
+    pub backup_service_runtime_threads: Option<usize>,
     /// Top level directory to store the RocksDB
     pub dir: PathBuf,
     /// Hot state configuration
@@ -449,6 +450,7 @@ impl Default for StorageConfig {
     fn default() -> StorageConfig {
         StorageConfig {
             backup_service_address: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 6186),
+            backup_service_runtime_threads: Some(2),
             dir: PathBuf::from("db"),
             hot_state_config: HotStateConfig::default(),
             // The prune window must at least out live a RPC request because its sub requests are

--- a/ecosystem/indexer-grpc/indexer-grpc-table-info/src/runtime.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-table-info/src/runtime.rs
@@ -29,7 +29,10 @@ pub fn bootstrap_internal_indexer_db(
     if !config.indexer_db_config.is_internal_indexer_db_enabled() || internal_indexer_db.is_none() {
         return None;
     }
-    let runtime = aptos_runtimes::spawn_named_runtime("index-db".to_string(), None);
+    let runtime = aptos_runtimes::spawn_named_runtime(
+        "index-db".to_string(),
+        config.indexer_db_config.runtime_threads,
+    );
     // Set up db config and open up the db initially to read metadata
     let mut indexer_service = InternalIndexerDBService::new(
         db_rw.reader,

--- a/storage/backup/backup-cli/src/backup_types/epoch_ending/tests.rs
+++ b/storage/backup/backup-cli/src/backup_types/epoch_ending/tests.rs
@@ -50,6 +50,7 @@ fn end_to_end() {
     let rt = start_backup_service(
         SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port),
         src_db,
+        None,
     );
     let client = Arc::new(BackupServiceClient::new(format!(
         "http://localhost:{}",

--- a/storage/backup/backup-cli/src/utils/test_utils.rs
+++ b/storage/backup/backup-cli/src/utils/test_utils.rs
@@ -47,6 +47,10 @@ pub fn tmp_db_with_random_content() -> (
 
 pub fn start_local_backup_service(db: Arc<AptosDB>) -> (Runtime, u16) {
     let port = get_available_port();
-    let rt = start_backup_service(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port), db);
+    let rt = start_backup_service(
+        SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port),
+        db,
+        None,
+    );
     (rt, port)
 }


### PR DESCRIPTION

On a 44-core machine, `aptos-node` spawns ~800 threads (~18x oversubscription).
Many tokio runtimes default to `num_cpus` despite having minimal workloads. This
change right-sizes two of the most egregious pools, saving ~84 threads.

- **backup**: 44 → 2 threads. The backup service runs a single `warp` HTTP
  server task that serves infrequent backup requests. 44 worker threads sit
  permanently idle. Add `backup_service_runtime_threads` to `StorageConfig`
  (default: `Some(2)`, configurable).

- **index-db**: 44 → 2 threads. The internal indexer DB service runs a single
  sequential loop that watches for new committed versions and processes them
  synchronously via `db_indexer.process()` on one worker thread at a time.
  Add `runtime_threads` to `InternalIndexerDBConfig` (default: `Some(2)`,
  configurable).

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Configuration-only change that adjusts runtime sizing and adds optional knobs; main risk is under-provisioning threads in atypical high-throughput backup/indexer workloads.
> 
> **Overview**
> Reduces thread oversubscription by **right-sizing two Tokio runtimes**: the storage backup service and the internal indexer DB runtime now take an optional configured thread count instead of defaulting to `num_cpus`.
> 
> This introduces `storage.backup_service_runtime_threads` and `indexer_db_config.runtime_threads` (both default to `Some(2)`), wires them through `aptos-node`/`indexer-grpc` runtime creation, and updates backup service call sites/tests to pass the new parameter.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1727a8e28263dafb21a6f3758f1840a749753b52. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->