### PR TITLE
Signed integer support in transactional test arguments

### DIFF
--- a/third_party/move/move-compiler-v2/transactional-tests/tests/signed-int/round-trip/signed_args.decompiled
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/signed-int/round-trip/signed_args.decompiled
@@ -1,0 +1,14 @@
+//**** Cross-compiled for `move` syntax from `tests/signed-int/signed_args.move`
+
+//# publish
+module 0xc0ffee::m {
+    public fun test(p0: i64, p1: i64): i64 {
+        if (p0 == -1i64) return -12i64 + p1;
+        8i64
+    }
+}
+
+
+//# run 0xc0ffee::m::test --args -1i64 -12i64
+
+//# run 0xc0ffee::m::test --args 0i64 55i64

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/signed-int/round-trip/signed_args.decompiled.baseline.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/signed-int/round-trip/signed_args.decompiled.baseline.exp
@@ -1,0 +1,6 @@
+processed 3 tasks
+task 0 lines 3-9:  publish [module 0xc0ffee::m {]
+task 1 lines 12-12:  run 0xc0ffee::m::test --args -1i64 -12i64
+return values: -24
+task 2 lines 14-14:  run 0xc0ffee::m::test --args 0i64 55i64
+return values: 8

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/signed-int/signed_args.baseline.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/signed-int/signed_args.baseline.exp
@@ -1,0 +1,6 @@
+processed 3 tasks
+task 0 lines 1-10:  publish [module 0xc0ffee::m {]
+task 1 lines 12-12:  run 0xc0ffee::m::test --args -1i64 -12i64
+return values: -24
+task 2 lines 14-14:  run 0xc0ffee::m::test --args 0i64 55i64
+return values: 8

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/signed-int/signed_args.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/signed-int/signed_args.move
@@ -1,0 +1,14 @@
+//# publish
+module 0xc0ffee::m {
+    public fun test(x: i64, y: i64): i64 {
+        if (x == -1) {
+            -12 + y
+        } else {
+            8
+        }
+    }
+}
+
+//# run 0xc0ffee::m::test --args -1i64 -12i64
+
+//# run 0xc0ffee::m::test --args 0i64 55i64

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/signed-int/signed_args.no-optimize.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/signed-int/signed_args.no-optimize.exp
@@ -1,0 +1,6 @@
+processed 3 tasks
+task 0 lines 1-10:  publish [module 0xc0ffee::m {]
+task 1 lines 12-12:  run 0xc0ffee::m::test --args -1i64 -12i64
+return values: -24
+task 2 lines 14-14:  run 0xc0ffee::m::test --args 0i64 55i64
+return values: 8

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/signed-int/signed_args.opt-extra.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/signed-int/signed_args.opt-extra.exp
@@ -1,0 +1,6 @@
+processed 3 tasks
+task 0 lines 1-10:  publish [module 0xc0ffee::m {]
+task 1 lines 12-12:  run 0xc0ffee::m::test --args -1i64 -12i64
+return values: -24
+task 2 lines 14-14:  run 0xc0ffee::m::test --args 0i64 55i64
+return values: 8

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/signed-int/signed_args.optimize.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/signed-int/signed_args.optimize.exp
@@ -1,0 +1,6 @@
+processed 3 tasks
+task 0 lines 1-10:  publish [module 0xc0ffee::m {]
+task 1 lines 12-12:  run 0xc0ffee::m::test --args -1i64 -12i64
+return values: -24
+task 2 lines 14-14:  run 0xc0ffee::m::test --args 0i64 55i64
+return values: 8

--- a/third_party/move/testing-infra/transactional-test-runner/src/tasks.rs
+++ b/third_party/move/testing-infra/transactional-test-runner/src/tasks.rs
@@ -37,6 +37,54 @@ pub struct TaskInput<Command> {
     pub data: Option<NamedTempFile>,
 }
 
+/// Preprocesses command tokens so that negative number values for `--args` use the
+/// `--args=VALUE` syntax. This avoids clap interpreting `-1i64` as a flag.
+///
+/// For example, `["--args", "-1i64", "2u64"]` becomes `["--args=-1i64", "--args", "2u64"]`.
+fn preprocess_args_with_negative_numbers(tokens: Vec<&str>) -> Vec<String> {
+    let mut result: Vec<String> = Vec::with_capacity(tokens.len());
+    let mut i = 0;
+    while i < tokens.len() {
+        if tokens[i] == "--args" {
+            i += 1;
+            // Collect values that belong to --args: anything that isn't a flag or `--`.
+            let mut values = vec![];
+            while i < tokens.len() && is_args_value(tokens[i]) {
+                values.push(tokens[i]);
+                i += 1;
+            }
+            let has_negative = values.iter().any(|v| v.starts_with('-'));
+            if has_negative {
+                // Use --args=VALUE for negatives, --args VALUE for positives.
+                for v in values {
+                    if v.starts_with('-') {
+                        result.push(format!("--args={}", v));
+                    } else {
+                        result.push("--args".to_string());
+                        result.push(v.to_string());
+                    }
+                }
+            } else {
+                result.push("--args".to_string());
+                for v in values {
+                    result.push(v.to_string());
+                }
+            }
+        } else {
+            result.push(tokens[i].to_string());
+            i += 1;
+        }
+    }
+    result
+}
+
+/// Returns true if `s` looks like a value for `--args` rather than a flag or `--` terminator.
+/// Values are tokens that don't start with `-`, or tokens that start with `-` followed by a
+/// digit (i.e., negative numbers like `-1i64`).
+fn is_args_value(s: &str) -> bool {
+    !s.starts_with('-') || (s.len() > 1 && s.as_bytes()[1].is_ascii_digit())
+}
+
 #[allow(clippy::needless_collect)]
 pub fn taskify<Command: Debug + Parser>(filename: &Path) -> Result<Vec<TaskInput<Command>>> {
     use regex::Regex;
@@ -122,7 +170,8 @@ pub fn taskify<Command: Debug + Parser>(filename: &Path) -> Result<Vec<TaskInput
         }
         let command_split = command_text.split_ascii_whitespace().collect::<Vec<_>>();
         let name_opt = command_split.get(1).map(|s| (*s).to_owned());
-        let command = match Command::try_parse_from(command_split) {
+        let command_split = preprocess_args_with_negative_numbers(command_split);
+        let command = match Command::try_parse_from(&command_split) {
             Ok(command) => command,
             Err(e) => {
                 let mut spit_iter = command_text.split_ascii_whitespace();
@@ -263,7 +312,7 @@ pub struct RunCommand<ExtraValueArgs: ParsableValue> {
     pub signers: Vec<ParsedAddress>,
     #[clap(
         long = "args",
-     value_parser = ParsedValue::<ExtraValueArgs>::parse,
+        value_parser = ParsedValue::<ExtraValueArgs>::parse,
         num_args = 0..,
     )]
     pub args: Vec<ParsedValue<ExtraValueArgs>>,


### PR DESCRIPTION
## Description

In this PR, we allow signed integers to be passed as args in transactional tests, e.g.,

```
//# run 0xc0ffee::m::test --args -1i64 -12i64
```

Previously, stuff starting with `-` would be considered a flag parsed by clap, thus causing a command error.

## How Has This Been Tested?

- Added a new test to demonstrate the fix.

## Type of Change
- [x] Bug fix

## Which Components or Systems Does This Change Impact?
- [x] Move Compiler

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core command tokenization and numeric literal parsing used by multiple tools, so subtle regressions in CLI argument parsing are possible despite added tests.
> 
> **Overview**
> Transactional tests can now pass *signed integer literals* via `--args` (e.g. `--args -1i64 -12i64`) by preprocessing task command tokens to rewrite negative values into `--args=...`, avoiding clap treating them as flags.
> 
> The Move CLI value lexer/parser is updated to recognize `i*` numeric suffixes, tokenize negative numeric literals (including hex like `-0xFFi64`), and to **reject untyped negative integers** with a clearer error message. New transactional tests and parser unit tests cover signed argument round-trips and failure cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c5592c0d180d835a9cb4c21809efc850e72f7c2f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->