### PR TITLE
[Network] Replace the network health checker with the peer monitoring service.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3670,6 +3670,7 @@ dependencies = [
 name = "aptos-peer-monitoring-service-client"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "aptos-build-info",
  "aptos-channels",
  "aptos-config",
@@ -3683,7 +3684,9 @@ dependencies = [
  "aptos-peer-monitoring-service-types",
  "aptos-time-service",
  "aptos-types",
+ "async-trait",
  "bcs 0.1.4",
+ "bytes",
  "enum_dispatch",
  "futures",
  "maplit",

--- a/config/src/config/network_config.rs
+++ b/config/src/config/network_config.rs
@@ -129,6 +129,8 @@ pub struct NetworkConfig {
     pub ping_timeout_ms: u64,
     /// Number of failed healthcheck pings until a peer is marked unhealthy
     pub ping_failures_tolerated: u64,
+    /// Whether to disconnect from peers on health check failures
+    pub disconnect_on_health_check_failure: bool,
     /// Maximum number of outbound connections, limited by ConnectivityManager
     pub max_outbound_connections: usize,
     /// Maximum number of outbound connections, limited by PeerManager
@@ -172,6 +174,7 @@ impl NetworkConfig {
             ping_interval_ms: PING_INTERVAL_MS,
             ping_timeout_ms: PING_TIMEOUT_MS,
             ping_failures_tolerated: PING_FAILURES_TOLERATED,
+            disconnect_on_health_check_failure: false, // Disabled by default
             max_outbound_connections: MAX_FULLNODE_OUTBOUND_CONNECTIONS,
             max_inbound_connections: MAX_INBOUND_CONNECTIONS,
             max_message_size: MAX_MESSAGE_SIZE,

--- a/config/src/config/peer_monitoring_config.rs
+++ b/config/src/config/peer_monitoring_config.rs
@@ -42,6 +42,7 @@ impl Default for PeerMonitoringServiceConfig {
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq, Serialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct LatencyMonitoringConfig {
+    pub disconnect_from_peers_on_failures: bool, // Whether to disconnect from peers on failures
     pub latency_ping_interval_ms: u64, // The interval (ms) between latency pings for each peer
     pub latency_ping_timeout_ms: u64,  // The timeout (ms) for each latency ping
     pub max_latency_ping_failures: u64, // Max ping failures before the peer connection fails
@@ -51,8 +52,9 @@ pub struct LatencyMonitoringConfig {
 impl Default for LatencyMonitoringConfig {
     fn default() -> Self {
         Self {
-            latency_ping_interval_ms: 30_000, // 30 seconds
-            latency_ping_timeout_ms: 20_000,  // 20 seconds
+            disconnect_from_peers_on_failures: true, // Disconnect from peers on failures by default
+            latency_ping_interval_ms: 20_000,        // 20 seconds
+            latency_ping_timeout_ms: 20_000,         // 20 seconds
             max_latency_ping_failures: 3,
             max_num_latency_pings_to_retain: 10,
         }

--- a/network/builder/src/builder.rs
+++ b/network/builder/src/builder.rs
@@ -209,6 +209,7 @@ impl NetworkBuilder {
             config.ping_interval_ms,
             config.ping_timeout_ms,
             config.ping_failures_tolerated,
+            config.disconnect_on_health_check_failure,
             config.max_parallel_deserialization_tasks,
         );
 
@@ -412,6 +413,7 @@ impl NetworkBuilder {
         ping_interval_ms: u64,
         ping_timeout_ms: u64,
         ping_failures_tolerated: u64,
+        disconnect_on_failure: bool,
         max_parallel_deserialization_tasks: Option<usize>,
     ) -> &mut Self {
         // Initialize and start HealthChecker.
@@ -426,6 +428,7 @@ impl NetworkBuilder {
             ping_interval_ms,
             ping_timeout_ms,
             ping_failures_tolerated,
+            disconnect_on_failure,
             hc_network_tx,
             hc_network_rx,
             self.peers_and_metadata.clone(),

--- a/network/framework/src/application/interface.rs
+++ b/network/framework/src/application/interface.rs
@@ -38,7 +38,6 @@ pub trait NetworkClientInterface<Message: NetworkMessageTrait>: Clone + Send + S
 
     /// Requests that the network connection for the specified peer
     /// is disconnected.
-    // TODO: support disconnect reasons.
     async fn disconnect_from_peer(
         &self,
         _peer: PeerNetworkId,

--- a/network/framework/src/peer/mod.rs
+++ b/network/framework/src/peer/mod.rs
@@ -76,6 +76,7 @@ pub enum DisconnectReason {
     ConnectionClosed, // The connection was gracefully closed (e.g., by the peer)
     InputOutputError, // An I/O error occurred on the connection (e.g., when reading messages)
     NetworkHealthCheckFailure, // The connection failed the network health check (e.g., pings)
+    PeerMonitoringPingFailure, // The connection failed the peer monitoring ping check
     RequestedByPeerManager, // The peer manager requested the connection to be closed
     StaleConnection,  // The connection is stale (e.g., when a validator leaves the validator set)
 }
@@ -87,6 +88,7 @@ impl DisconnectReason {
             DisconnectReason::ConnectionClosed => "ConnectionClosed",
             DisconnectReason::InputOutputError => "InputOutputError",
             DisconnectReason::NetworkHealthCheckFailure => "NetworkHealthCheckFailure",
+            DisconnectReason::PeerMonitoringPingFailure => "PeerMonitoringPingFailure",
             DisconnectReason::RequestedByPeerManager => "RequestedByPeerManager",
             DisconnectReason::StaleConnection => "StaleConnection",
         };

--- a/network/framework/src/protocols/health_checker/builder.rs
+++ b/network/framework/src/protocols/health_checker/builder.rs
@@ -30,6 +30,7 @@ impl HealthCheckerBuilder {
         ping_interval_ms: u64,
         ping_timeout_ms: u64,
         ping_failures_tolerated: u64,
+        disconnect_on_failure: bool,
         network_sender: NetworkSender<HealthCheckerMsg>,
         network_rx: HealthCheckerNetworkEvents,
         peers_and_metadata: Arc<PeersAndMetadata>,
@@ -48,6 +49,7 @@ impl HealthCheckerBuilder {
             Duration::from_millis(ping_interval_ms),
             Duration::from_millis(ping_timeout_ms),
             ping_failures_tolerated,
+            disconnect_on_failure,
         );
         Self {
             service: Some(service),

--- a/network/framework/src/protocols/health_checker/test.rs
+++ b/network/framework/src/protocols/health_checker/test.rs
@@ -70,6 +70,7 @@ impl TestHarness {
             PING_INTERVAL,
             PING_TIMEOUT,
             ping_failures_tolerated,
+            true, // disconnect_on_failure (enabled for tests)
         );
 
         (

--- a/peer-monitoring-service/client/Cargo.toml
+++ b/peer-monitoring-service/client/Cargo.toml
@@ -33,11 +33,14 @@ thiserror = { workspace = true }
 tokio = { workspace = true }
 
 [dev-dependencies]
+anyhow = { workspace = true }
 aptos-build-info = { workspace = true }
 aptos-config = { workspace = true }
 aptos-netcore = { workspace = true }
 aptos-network = { workspace = true, features = ["fuzzing"] }
 aptos-peer-monitoring-service-server = { workspace = true }
+async-trait = { workspace = true }
 bcs = { workspace = true }
+bytes = { workspace = true }
 maplit = { workspace = true }
 tokio-stream = { workspace = true }

--- a/peer-monitoring-service/client/src/lib.rs
+++ b/peer-monitoring-service/client/src/lib.rs
@@ -134,6 +134,7 @@ async fn start_peer_monitor_with_state(
         // Ensure all peers have a state (and create one for newly connected peers)
         create_states_for_new_peers(
             &node_config,
+            peer_monitoring_client.clone(),
             &peer_monitor_state,
             &time_service,
             &connected_peers_and_metadata,
@@ -159,6 +160,9 @@ async fn start_peer_monitor_with_state(
 /// Creates a new peer state for peers that don't yet have one
 fn create_states_for_new_peers(
     node_config: &NodeConfig,
+    peer_monitoring_client: PeerMonitoringServiceClient<
+        NetworkClient<PeerMonitoringServiceMessage>,
+    >,
     peer_monitor_state: &PeerMonitorState,
     time_service: &TimeService,
     connected_peers_and_metadata: &HashMap<PeerNetworkId, PeerMetadata>,
@@ -171,7 +175,11 @@ fn create_states_for_new_peers(
         if !state_exists {
             peer_monitor_state.peer_states.write().insert(
                 *peer_network_id,
-                PeerState::new(node_config.clone(), time_service.clone()),
+                PeerState::new(
+                    node_config.clone(),
+                    peer_monitoring_client.clone(),
+                    time_service.clone(),
+                ),
             );
         }
     }

--- a/peer-monitoring-service/client/src/network.rs
+++ b/peer-monitoring-service/client/src/network.rs
@@ -7,9 +7,12 @@ use crate::{
 };
 use aptos_config::network_id::PeerNetworkId;
 use aptos_logger::{trace, warn};
-use aptos_network::application::{
-    interface::{NetworkClient, NetworkClientInterface},
-    storage::PeersAndMetadata,
+use aptos_network::{
+    application::{
+        interface::{NetworkClient, NetworkClientInterface},
+        storage::PeersAndMetadata,
+    },
+    peer::DisconnectReason,
 };
 use aptos_peer_monitoring_service_types::{
     request::PeerMonitoringServiceRequest, response::PeerMonitoringServiceResponse,
@@ -62,6 +65,18 @@ impl<NetworkClient: NetworkClientInterface<PeerMonitoringServiceMessage>>
     /// Returns the peers and metadata struct
     pub fn get_peers_and_metadata(&self) -> Arc<PeersAndMetadata> {
         self.network_client.get_peers_and_metadata()
+    }
+
+    /// Disconnects from the specified peer with the given reason
+    pub async fn disconnect_from_peer(
+        &self,
+        peer_network_id: PeerNetworkId,
+        disconnect_reason: DisconnectReason,
+    ) -> Result<(), Error> {
+        self.network_client
+            .disconnect_from_peer(peer_network_id, disconnect_reason)
+            .await
+            .map_err(|error| Error::NetworkError(error.to_string()))
     }
 }
 

--- a/peer-monitoring-service/client/src/peer_states/peer_state.rs
+++ b/peer-monitoring-service/client/src/peer_states/peer_state.rs
@@ -40,12 +40,22 @@ pub struct PeerState {
 }
 
 impl PeerState {
-    pub fn new(node_config: NodeConfig, time_service: TimeService) -> Self {
+    pub fn new(
+        node_config: NodeConfig,
+        peer_monitoring_client: PeerMonitoringServiceClient<
+            NetworkClient<PeerMonitoringServiceMessage>,
+        >,
+        time_service: TimeService,
+    ) -> Self {
         // Create a state entry for each peer state key
         let state_entries = Arc::new(RwLock::new(HashMap::new()));
         for peer_state_key in PeerStateKey::get_all_keys() {
-            let peer_state_value =
-                PeerStateValue::new(node_config.clone(), time_service.clone(), &peer_state_key);
+            let peer_state_value = PeerStateValue::new(
+                node_config.clone(),
+                peer_monitoring_client.clone(),
+                time_service.clone(),
+                &peer_state_key,
+            );
             state_entries
                 .write()
                 .insert(peer_state_key, Arc::new(RwLock::new(peer_state_value)));

--- a/peer-monitoring-service/client/src/tests/multiple_peers.rs
+++ b/peer-monitoring-service/client/src/tests/multiple_peers.rs
@@ -58,7 +58,11 @@ async fn test_peer_updater_loop_multiple_peers() {
     let node_config = NodeConfig::default();
     let all_peers = vec![validator_peer, vfn_peer, fullnode_peer];
     for peer in &all_peers {
-        let peer_state = PeerState::new(node_config.clone(), time_service.clone());
+        let peer_state = PeerState::new(
+            node_config.clone(),
+            peer_monitoring_client.clone(),
+            time_service.clone(),
+        );
         peer_monitor_state
             .peer_states
             .write()

--- a/peer-monitoring-service/client/src/tests/single_peer.rs
+++ b/peer-monitoring-service/client/src/tests/single_peer.rs
@@ -135,7 +135,11 @@ async fn test_basic_peer_updater_loop() {
 
     // Create a peer state for the fullnode
     let node_config = NodeConfig::default();
-    let mut peer_state = PeerState::new(node_config.clone(), time_service.clone());
+    let mut peer_state = PeerState::new(
+        node_config.clone(),
+        peer_monitoring_client.clone(),
+        time_service.clone(),
+    );
     peer_monitor_state
         .peer_states
         .write()


### PR DESCRIPTION
## Description
This PR replaces the disconnect logic in the network health checker with the peer monitoring service, i.e., the peer monitoring service now disconnects from peers that fail to respond to ping messages. This is something that was previously done by the network health checker.

Note: The goal is to eventually remove the network health checker, as the peer monitoring service is already doing ping message verification. So, health check messages are now unnecessary.

## How Has This Been Tested?
New and existing unit tests, as well as manual verification.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes peer liveness failure handling and introduces new disconnect paths/config flags; misconfiguration or threshold changes could cause unexpected peer churn or reduced health enforcement.
> 
> **Overview**
> Shifts responsibility for disconnecting unresponsive peers from the network `HealthChecker` to the peer monitoring service’s latency ping logic.
> 
> Adds config knobs for both systems: `NetworkConfig.disconnect_on_health_check_failure` (default *off*) gates health-checker disconnects, while `LatencyMonitoringConfig.disconnect_from_peers_on_failures` (default *on*) plus shorter default ping interval enables peer-monitor-driven disconnects after repeated failures.
> 
> Extends networking with a new `DisconnectReason::PeerMonitoringPingFailure`, exposes a disconnect API on `PeerMonitoringServiceClient`, and updates peer-state construction and tests (including new mock-based async tests) to validate disconnect behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ce491dfc78a3e03478a83ce9af21bb790f50b4b8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->