### PR TITLE
[execution] Fix executor benchmark: derive timestamps from DB state

### DIFF
--- a/execution/executor-benchmark/src/transaction_generator.rs
+++ b/execution/executor-benchmark/src/transaction_generator.rs
@@ -6,7 +6,7 @@ use crate::{
     metrics::{NUM_TXNS, TIMER},
 };
 use aptos_crypto::{ed25519::Ed25519PrivateKey, HashValue, PrivateKey, Uniform};
-use aptos_logger::info;
+use aptos_logger::{debug, info};
 use aptos_metrics_core::{IntCounterVecHelper, TimerHelper};
 use aptos_sdk::{
     transaction_builder::{aptos_stdlib, TransactionFactory},
@@ -17,10 +17,12 @@ use aptos_storage_interface::{
 };
 use aptos_types::{
     account_address::AccountAddress,
-    account_config::{aptos_test_root_address, AccountResource},
+    account_config::{aptos_test_root_address, AccountResource, BlockResource, CORE_CODE_ADDRESS},
     block_metadata::BlockMetadata,
     chain_id::ChainId,
+    on_chain_config::ConfigurationResource,
     state_store::MoveResourceExt,
+    timestamp::TimestampResource,
     transaction::{
         authenticator::AuthenticationKey, EntryFunction, Transaction, TransactionPayload,
     },
@@ -44,7 +46,7 @@ use std::{
     io::{Read, Write},
     path::Path,
     sync::{
-        atomic::{AtomicUsize, Ordering},
+        atomic::{AtomicU64, AtomicUsize, Ordering},
         mpsc, Arc, Mutex,
     },
 };
@@ -101,51 +103,140 @@ fn get_genesis_validator_address(db: &DbReaderWriter) -> AccountAddress {
     validator_address()
 }
 
-pub(crate) fn create_block_metadata_transaction(epoch: u64, db: &DbReaderWriter) -> Transaction {
-    // Use incremental timestamps to avoid triggering epoch reconfigurations
-    // Large real timestamps cause immediate epoch changes since last_reconfiguration_time is small
-    use std::sync::atomic::{AtomicU64, Ordering};
-    static ROUND_COUNTER: AtomicU64 = AtomicU64::new(0);
-    static LAST_TIMESTAMP: AtomicU64 = AtomicU64::new(0);
-    static LAST_EPOCH: AtomicU64 = AtomicU64::new(0);
+/// Manages blockchain timestamps for the executor benchmark.
+///
+/// Derives all timestamps from the DB state instead of wall-clock time,
+/// preventing epoch reconfiguration issues when the benchmark is run long
+/// after the DB was created.
+pub struct BenchmarkTimestamp {
+    /// DB's CurrentTimeMicroseconds at construction time.
+    base_usecs: u64,
+    /// Incremented per block to produce strictly increasing timestamps.
+    next_offset: AtomicU64,
+    /// Current epoch from ConfigurationResource.
+    epoch: u64,
+}
 
-    // Check if epoch has changed and reset round counter if needed
-    let last_epoch = LAST_EPOCH.load(Ordering::SeqCst);
-    if last_epoch != epoch {
-        ROUND_COUNTER.store(0, Ordering::SeqCst);
-        LAST_EPOCH.store(epoch, Ordering::SeqCst);
+impl BenchmarkTimestamp {
+    /// Reads `TimestampResource` and `ConfigurationResource` from the DB
+    /// to initialize timestamp state.
+    pub fn from_db(db: &DbReaderWriter) -> Self {
+        let state_view = db.reader.latest_state_checkpoint_view().unwrap();
+
+        let ts = TimestampResource::fetch_move_resource(&state_view, &CORE_CODE_ADDRESS)
+            .expect("failed to read TimestampResource")
+            .expect("TimestampResource not found");
+
+        let config = ConfigurationResource::fetch_move_resource(&state_view, &CORE_CODE_ADDRESS)
+            .expect("failed to read ConfigurationResource")
+            .expect("ConfigurationResource not found");
+
+        info!(
+            "BenchmarkTimestamp::from_db: base_usecs={}, epoch={}",
+            ts.timestamp.microseconds,
+            config.epoch()
+        );
+
+        Self {
+            base_usecs: ts.timestamp.microseconds,
+            next_offset: AtomicU64::new(1),
+            epoch: config.epoch(),
+        }
     }
 
-    let round = ROUND_COUNTER.fetch_add(1, Ordering::SeqCst);
+    /// Returns a `(round, timestamp)` pair for the next block.
+    ///
+    /// Timestamps are strictly increasing: `base_usecs + 1`, `+2`, `+3`, ...
+    /// Rounds are 0-indexed and correspond one-to-one with offsets.
+    fn next_round_and_timestamp(&self) -> (u64, u64) {
+        let offset = self.next_offset.fetch_add(1, Ordering::SeqCst);
+        let round = offset - 1; // offset starts at 1, round starts at 0
+        (round, self.base_usecs + offset)
+    }
 
-    // Get current real time to keep blockchain time close to real time for orderless transactions
-    let current_time_usecs = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_micros() as u64;
+    pub fn epoch(&self) -> u64 {
+        self.epoch
+    }
 
-    // Ensure strictly increasing timestamps by comparing with last used timestamp
-    let last_timestamp = LAST_TIMESTAMP.load(Ordering::SeqCst);
-    let timestamp_usecs = if current_time_usecs > last_timestamp {
-        current_time_usecs
-    } else {
-        // If current time is not greater, increment by 1 microsecond to maintain strict ordering
-        last_timestamp + 1
-    };
+    /// Returns a transaction expiration timestamp in seconds.
+    /// Uses `base_usecs/1_000_000 + 60` (60-second window).
+    ///
+    /// This must be within `MAX_EXP_TIME_SECONDS_FOR_ORDERLESS_TXNS` (100s)
+    /// of the current blockchain time for orderless transactions, and well
+    /// beyond any benchmark duration for normal transactions. Since block
+    /// timestamps only advance by 1 microsecond per block, 60 seconds is
+    /// sufficient for both.
+    pub fn txn_expiration_timestamp_secs(&self) -> u64 {
+        self.base_usecs / 1_000_000 + 60
+    }
 
-    // Update the last timestamp atomically
-    LAST_TIMESTAMP.store(timestamp_usecs, Ordering::SeqCst);
-    info!("block metadata timestamp: {}", timestamp_usecs);
+    /// Creates a `BlockMetadata` transaction for the next block, using a
+    /// strictly increasing timestamp derived from this `BenchmarkTimestamp`.
+    pub fn next_block_metadata_txn(&self, db: &DbReaderWriter) -> Transaction {
+        let (round, timestamp_usecs) = self.next_round_and_timestamp();
 
-    Transaction::BlockMetadata(BlockMetadata::new(
-        HashValue::random(),
-        epoch,                             // use provided epoch
-        round, // proper incrementing round number (resets on epoch change)
-        get_genesis_validator_address(db), // use actual validator from genesis
-        vec![],
-        vec![],
-        timestamp_usecs, // real time with strict ordering guarantee
-    ))
+        debug!(
+            "block metadata: epoch={}, round={}, timestamp={}",
+            self.epoch(),
+            round,
+            timestamp_usecs
+        );
+
+        Transaction::BlockMetadata(BlockMetadata::new(
+            HashValue::random(),
+            self.epoch(),
+            round,
+            get_genesis_validator_address(db),
+            vec![],
+            vec![],
+            timestamp_usecs,
+        ))
+    }
+
+    /// Creates a single-transaction epoch-change block.
+    ///
+    /// Reads `BlockResource` and `ConfigurationResource` from the DB,
+    /// computes a timestamp that triggers reconfiguration
+    /// (`last_reconfig_time + epoch_interval + 1`), and returns the
+    /// block (a `Vec<Transaction>` with one `BlockMetadata` entry).
+    ///
+    /// After committing this block, callers should use
+    /// `BenchmarkTimestamp::from_db()` to get a fresh timestamp state
+    /// that reflects the new epoch.
+    pub fn epoch_change_block(db: &DbReaderWriter) -> Vec<Transaction> {
+        let state_view = db.reader.latest_state_checkpoint_view().unwrap();
+
+        let block_resource = BlockResource::fetch_move_resource(&state_view, &CORE_CODE_ADDRESS)
+            .expect("failed to read BlockResource")
+            .expect("BlockResource not found");
+
+        let config = ConfigurationResource::fetch_move_resource(&state_view, &CORE_CODE_ADDRESS)
+            .expect("failed to read ConfigurationResource")
+            .expect("ConfigurationResource not found");
+
+        let epoch_interval = block_resource.epoch_interval();
+        let last_reconfig_time = config.last_reconfiguration_time_micros();
+        let epoch_change_timestamp = last_reconfig_time + epoch_interval + 1;
+
+        info!(
+            "epoch_change_block: last_reconfig_time={}, epoch_interval={}, \
+             epoch_change_timestamp={}, current_epoch={}",
+            last_reconfig_time,
+            epoch_interval,
+            epoch_change_timestamp,
+            config.epoch()
+        );
+
+        vec![Transaction::BlockMetadata(BlockMetadata::new(
+            HashValue::random(),
+            config.epoch(),
+            0, // round 0 for epoch change block
+            get_genesis_validator_address(db),
+            vec![],
+            vec![],
+            epoch_change_timestamp,
+        ))]
+    }
 }
 
 pub(crate) fn get_progress_bar(num_accounts: usize) -> ProgressBar {
@@ -214,6 +305,9 @@ pub struct TransactionGenerator {
 
     /// Database reader-writer for accessing validator information
     db: DbReaderWriter,
+
+    /// Benchmark timestamp state derived from the DB
+    ts: Arc<BenchmarkTimestamp>,
 }
 
 impl TransactionGenerator {
@@ -296,6 +390,7 @@ impl TransactionGenerator {
         num_main_signer_accounts: Option<usize>,
         num_workers: usize,
         is_keyless: bool,
+        ts: Arc<BenchmarkTimestamp>,
     ) -> Self {
         let num_existing_accounts = TransactionGenerator::read_meta(&db_dir);
 
@@ -309,21 +404,20 @@ impl TransactionGenerator {
             }),
             num_existing_accounts,
             block_sender: Some(block_sender),
-            transaction_factory: Self::create_transaction_factory(),
+            transaction_factory: Self::create_transaction_factory(&ts),
             num_workers,
             worker_pool: ThreadPoolBuilder::new()
                 .num_threads(num_workers)
                 .build()
                 .unwrap(),
             db,
+            ts,
         }
     }
 
-    pub fn create_transaction_factory() -> TransactionFactory {
+    pub fn create_transaction_factory(ts: &BenchmarkTimestamp) -> TransactionFactory {
         TransactionFactory::new(ChainId::test())
-            // Use relative expiration: current time + 60 seconds
-            // This ensures transactions have reasonable expiration window regardless of blockchain time
-            .with_transaction_expiration_time(60)
+            .with_absolute_transaction_expiration_timestamp(ts.txn_expiration_timestamp_secs())
             .with_gas_unit_price(100)
     }
 
@@ -509,7 +603,7 @@ impl TransactionGenerator {
             bar.inc(transactions.len() as u64 - 1);
             if let Some(sender) = &self.block_sender {
                 // Add BlockMetadata transaction at the beginning of the block
-                let mut block_transactions = vec![create_block_metadata_transaction(1, &self.db)];
+                let mut block_transactions = vec![self.ts.next_block_metadata_txn(&self.db)];
                 block_transactions.extend(transactions);
                 sender.send(block_transactions).unwrap();
             }
@@ -819,7 +913,7 @@ impl TransactionGenerator {
         }
 
         let mut transactions = Vec::new();
-        transactions.push(create_block_metadata_transaction(1, &self.db));
+        transactions.push(self.ts.next_block_metadata_txn(&self.db));
 
         let init_size = transactions.len();
         for i in 0..block_size {


### PR DESCRIPTION

Eliminate all `SystemTime::now()` usage in the executor benchmark.
When `run_benchmark` is executed >24 hours after `create_db`, block
metadata timestamps based on real wall-clock time exceed the DB's
`last_reconfiguration_time + epoch_interval`, triggering an unwanted
epoch reconfiguration that panics the benchmark.

**Fix**: Introduce `BenchmarkTimestamp` struct that reads
`TimestampResource`, `ConfigurationResource`, and `BlockResource` from
the DB to derive all timestamps:

- Block timestamps: `base_usecs + 1, +2, +3, ...` (strictly increasing,
  advances microseconds instead of real time)
- Transaction expiration: `base_usecs/10^6 + 60s` (within the 100s
  orderless txn limit)
- Epoch change block: computed as
  `last_reconfiguration_time + epoch_interval + 1`

This ensures block timestamps stay close to the DB's blockchain time
regardless of when the benchmark runs, preventing both epoch
reconfiguration panics and `TRANSACTION_EXPIRATION_TOO_FAR_IN_FUTURE`
discards.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches benchmark block metadata and transaction-expiration generation across multiple call sites; mistakes could cause invalid timestamps or unexpected epoch/round behavior, but scope is limited to benchmark codepaths.
> 
> **Overview**
> Switches executor-benchmark timestamping to be **DB-derived instead of wall-clock**, preventing unintended epoch reconfigurations and transaction-expiration issues when benchmarks run long after DB creation.
> 
> Introduces `BenchmarkTimestamp` (reads `TimestampResource`/`ConfigurationResource`, computes a deterministic epoch-change block from `BlockResource`) and threads it through the benchmark pipeline so all `BlockMetadata` txns and transaction expiration timestamps are generated from this shared state (`DbReliableTransactionSubmitter`, `TransactionGenerator`, init/add-accounts flows, and tests).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e49d63b51a315da760dd96aaf31cef4e159985e3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->