### PR TITLE
[storage] Set fill_cache(false) on pruner RocksDB reads

### DIFF
--- a/storage/aptosdb/src/pruner/ledger_pruner/transaction_pruner.rs
+++ b/storage/aptosdb/src/pruner/ledger_pruner/transaction_pruner.rs
@@ -16,7 +16,7 @@ use aptos_db_indexer_schemas::{
     schema::indexer_metadata::InternalIndexerMetadataSchema,
 };
 use aptos_logger::info;
-use aptos_schemadb::batch::SchemaBatch;
+use aptos_schemadb::{batch::SchemaBatch, ReadOptions};
 use aptos_storage_interface::{db_ensure as ensure, AptosDbError, Result};
 use aptos_types::transaction::{Transaction, Version};
 use std::sync::Arc;
@@ -111,10 +111,12 @@ impl TransactionPruner {
     ) -> Result<Vec<(Version, Transaction)>> {
         ensure!(end >= start, "{} must be >= {}", end, start);
 
+        let mut read_opts = ReadOptions::default();
+        read_opts.fill_cache(false);
         let mut iter = self
             .ledger_db
             .transaction_db_raw()
-            .iter::<TransactionSchema>()?;
+            .iter_with_opts::<TransactionSchema>(read_opts)?;
         iter.seek(&start)?;
 
         // The capacity is capped by the max number of txns we prune in a single batch. It's a

--- a/storage/aptosdb/src/pruner/state_kv_pruner/state_kv_shard_pruner.rs
+++ b/storage/aptosdb/src/pruner/state_kv_pruner/state_kv_shard_pruner.rs
@@ -10,7 +10,7 @@ use crate::{
     },
 };
 use aptos_logger::info;
-use aptos_schemadb::{batch::SchemaBatch, DB};
+use aptos_schemadb::{batch::SchemaBatch, ReadOptions, DB};
 use aptos_storage_interface::Result;
 use aptos_types::transaction::Version;
 use std::sync::Arc;
@@ -51,9 +51,11 @@ impl StateKvShardPruner {
     ) -> Result<()> {
         let mut batch = SchemaBatch::new();
 
+        let mut read_opts = ReadOptions::default();
+        read_opts.fill_cache(false);
         let mut iter = self
             .db_shard
-            .iter::<StaleStateValueIndexByKeyHashSchema>()?;
+            .iter_with_opts::<StaleStateValueIndexByKeyHashSchema>(read_opts)?;
         iter.seek(&current_progress)?;
         for item in iter {
             let (index, _) = item?;

--- a/storage/aptosdb/src/pruner/state_merkle_pruner/mod.rs
+++ b/storage/aptosdb/src/pruner/state_merkle_pruner/mod.rs
@@ -26,7 +26,7 @@ use aptos_experimental_runtimes::thread_manager::THREAD_MANAGER;
 use aptos_jellyfish_merkle::{node_type::NodeKey, StaleNodeIndex};
 use aptos_logger::info;
 use aptos_metrics_core::TimerHelper;
-use aptos_schemadb::{schema::KeyCodec, DB};
+use aptos_schemadb::{schema::KeyCodec, ReadOptions, DB};
 use aptos_storage_interface::Result;
 use aptos_types::transaction::{AtomicVersion, Version};
 use rayon::prelude::*;
@@ -196,7 +196,9 @@ where
         limit: usize,
     ) -> Result<(Vec<StaleNodeIndex>, Option<Version>)> {
         let mut indices = Vec::new();
-        let mut iter = state_merkle_db_shard.iter::<S>()?;
+        let mut read_opts = ReadOptions::default();
+        read_opts.fill_cache(false);
+        let mut iter = state_merkle_db_shard.iter_with_opts::<S>(read_opts)?;
         iter.seek(&StaleNodeIndex {
             stale_since_version: start_version,
             node_key: NodeKey::new_empty_path(0),


### PR DESCRIPTION

Pruners continuously scan stale data via iterators to determine what to
delete. This data is old, about to be deleted, and will never be read
again by the serving path. Without `fill_cache(false)`, every block
touched by pruner iterators is loaded into the shared RocksDB block
cache — evicting hot data that serves user queries.

Changes applied to all pruner iterator call sites:

- `StateMerklePruner::get_stale_node_indices` (covers both metadata and
  shard pruners)
- `StateKvShardPruner::prune`
- `StateKvMetadataPruner::prune` (both sharded and non-sharded branches)
- `TransactionPruner::get_pruning_candidate_transactions`
- `EventDb::prune_event_indices` (inlined iterator to avoid changing the
  shared `get_events_by_version_iter` used by API/backup paths)
- `EventStore::prune_event_accumulator`

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavioral change is limited to RocksDB read caching hints during pruning/iteration; data semantics and deletion logic are otherwise unchanged.
> 
> **Overview**
> Pruning-related RocksDB scans now construct `ReadOptions` with `fill_cache(false)` and use `iter_with_opts` so iterator reads of soon-to-be-deleted data don’t pollute the shared block cache.
> 
> This is applied across event accumulator pruning, event index pruning (by inlining an iterator rather than changing `get_events_by_version_iter`), transaction pruning candidate scans, state KV metadata/shard pruning (sharded and non-sharded), and state merkle stale-node index scanning.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4ca4b26b49718e5e0c34b36103403688676e8365. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->