### PR TITLE
[Network] Remove subscription logic from PeersAndMetadata.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3357,7 +3357,6 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tokio-retry",
- "tokio-stream",
  "tokio-util 0.7.10",
 ]
 

--- a/network/builder/src/dummy.rs
+++ b/network/builder/src/dummy.rs
@@ -13,7 +13,7 @@ use aptos_crypto::{test_utils::TEST_SEED, x25519, Uniform};
 use aptos_netcore::transport::ConnectionOrigin;
 use aptos_network::{
     application::{interface::NetworkClient, storage::PeersAndMetadata},
-    peer_manager::{builder::AuthenticationMode, ConnectionNotification},
+    peer_manager::builder::AuthenticationMode,
     protocols::network::{
         NetworkApplicationConfig, NetworkClientConfig, NetworkEvents, NetworkServiceConfig,
     },
@@ -25,7 +25,7 @@ use futures::executor::block_on;
 use maplit::hashmap;
 use rand::{rngs::StdRng, SeedableRng};
 use serde::{Deserialize, Serialize};
-use std::collections::HashSet;
+use std::{collections::HashSet, sync::Arc, time::Duration};
 use tokio::runtime::Runtime;
 
 const TEST_RPC_PROTOCOL: ProtocolId = ProtocolId::ConsensusRpcBcs;
@@ -97,7 +97,6 @@ pub fn setup_network() -> DummyNetwork {
 
     let authentication_mode = AuthenticationMode::Mutual(listener_identity_private_key);
     let listener_peers_and_metadata = PeersAndMetadata::new(&[network_id]);
-    let mut listener_connection_events = listener_peers_and_metadata.subscribe();
     // Set up the listener network
     let network_context = NetworkContext::new(role, network_id, listener_peer.peer_id());
     let mut network_builder = NetworkBuilder::new_for_test(
@@ -143,8 +142,6 @@ pub fn setup_network() -> DummyNetwork {
         peers_and_metadata.clone(),
     );
 
-    let mut connection_events = peers_and_metadata.subscribe();
-
     let (dialer_sender, dialer_events) = network_builder
         .add_client_and_service::<_, DummyNetworkEvents>(&dummy_network_config(), None, true);
     network_builder.build(runtime.handle().clone()).start();
@@ -152,33 +149,26 @@ pub fn setup_network() -> DummyNetwork {
         vec![TEST_DIRECT_SEND_PROTOCOL],
         vec![TEST_RPC_PROTOCOL],
         hashmap! {network_id => dialer_sender},
-        peers_and_metadata,
+        peers_and_metadata.clone(),
     );
 
     // Wait for establishing connection
-    let first_dialer_event = block_on(connection_events.recv()).unwrap();
-    if let ConnectionNotification::NewPeer(metadata, _network_id) = first_dialer_event {
-        assert_eq!(metadata.remote_peer_id, listener_peer.peer_id());
-        assert_eq!(metadata.origin, ConnectionOrigin::Outbound);
-        assert_eq!(metadata.role, PeerRole::Validator);
-    } else {
-        panic!(
-            "No NewPeer event on dialer received instead: {:?}",
-            first_dialer_event
-        );
-    }
+    block_on(wait_for_connection_established(
+        peers_and_metadata.clone(),
+        network_id,
+        listener_peer.peer_id(),
+        ConnectionOrigin::Outbound,
+        PeerRole::Validator,
+    ));
 
-    let first_listener_event = block_on(listener_connection_events.recv()).unwrap();
-    if let ConnectionNotification::NewPeer(metadata, _network_id) = first_listener_event {
-        assert_eq!(metadata.remote_peer_id, dialer_peer.peer_id());
-        assert_eq!(metadata.origin, ConnectionOrigin::Inbound);
-        assert_eq!(metadata.role, PeerRole::Validator);
-    } else {
-        panic!(
-            "No NewPeer event on listener received instead: {:?}",
-            first_listener_event
-        );
-    }
+    // Wait for connection to be established on listener side
+    block_on(wait_for_connection_established(
+        listener_peers_and_metadata.clone(),
+        network_id,
+        dialer_peer.peer_id(),
+        ConnectionOrigin::Inbound,
+        PeerRole::Validator,
+    ));
 
     DummyNetwork {
         runtime,
@@ -189,4 +179,38 @@ pub fn setup_network() -> DummyNetwork {
         listener_events,
         listener_network_client,
     }
+}
+
+/// Helper function to wait for a connection to be established
+async fn wait_for_connection_established(
+    peers_and_metadata: Arc<PeersAndMetadata>,
+    network_id: NetworkId,
+    expected_peer_id: PeerId,
+    expected_origin: ConnectionOrigin,
+    expected_role: PeerRole,
+) {
+    let timeout_duration = Duration::from_secs(10);
+    let peer_network_id = PeerNetworkId::new(network_id, expected_peer_id);
+
+    tokio::time::timeout(timeout_duration, async {
+        loop {
+            let connected = peers_and_metadata
+                .get_connected_peers_and_metadata()
+                .unwrap();
+
+            if let Some(metadata) = connected.get(&peer_network_id) {
+                assert_eq!(
+                    metadata.get_connection_metadata().remote_peer_id,
+                    expected_peer_id
+                );
+                assert_eq!(metadata.get_connection_metadata().origin, expected_origin);
+                assert_eq!(metadata.get_connection_metadata().role, expected_role);
+                return;
+            }
+
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("Timed out waiting for connection to be established");
 }

--- a/network/framework/Cargo.toml
+++ b/network/framework/Cargo.toml
@@ -56,7 +56,6 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tokio-retry = { workspace = true }
-tokio-stream = { workspace = true }
 tokio-util = { workspace = true }
 
 [dev-dependencies]

--- a/network/framework/src/application/storage.rs
+++ b/network/framework/src/application/storage.rs
@@ -7,7 +7,6 @@ use crate::{
         metadata::{ConnectionState, PeerMetadata},
     },
     counters,
-    peer_manager::ConnectionNotification,
     transport::{ConnectionId, ConnectionMetadata},
     ProtocolId,
 };
@@ -15,8 +14,7 @@ use aptos_config::{
     config::{Peer, PeerSet},
     network_id::{NetworkId, PeerNetworkId},
 };
-use aptos_infallible::{Mutex, RwLock};
-use aptos_logger::{sample, sample::SampleRate, warn};
+use aptos_infallible::RwLock;
 use aptos_peer_monitoring_service_types::PeerMonitoringMetadata;
 use aptos_types::{account_address::AccountAddress, PeerId};
 use arc_swap::ArcSwap;
@@ -24,15 +22,7 @@ use std::{
     collections::{hash_map::Entry, HashMap},
     ops::Deref,
     sync::{Arc, RwLockWriteGuard},
-    time::Duration,
 };
-use tokio::sync::mpsc::error::TrySendError;
-
-// notification_backlog is how many ConnectionNotification items can be queued waiting for an app to receive them.
-// Beyond this, new messages will be dropped if the app is not handling them fast enough.
-// We make this big enough to fit an initial burst of _all_ the connected peers getting notified.
-// Having 100 connected peers is common, 500 not unexpected
-const NOTIFICATION_BACKLOG: usize = 1000;
 
 /// A simple container that tracks all peers and peer metadata for the node.
 /// This container is updated by both the networking code (e.g., for new
@@ -49,8 +39,6 @@ pub struct PeersAndMetadata {
     //
     // TODO: should we remove this when generational versioning is supported?
     cached_peers_and_metadata: Arc<ArcSwap<HashMap<NetworkId, HashMap<PeerId, PeerMetadata>>>>,
-
-    subscribers: Mutex<Vec<tokio::sync::mpsc::Sender<ConnectionNotification>>>,
 }
 
 impl PeersAndMetadata {
@@ -60,7 +48,6 @@ impl PeersAndMetadata {
             peers_and_metadata: RwLock::new(HashMap::new()),
             trusted_peers: HashMap::new(),
             cached_peers_and_metadata: Arc::new(ArcSwap::from(Arc::new(HashMap::new()))),
-            subscribers: Mutex::new(vec![]),
         };
 
         // Initialize each network mapping and trusted peer set
@@ -206,10 +193,6 @@ impl PeersAndMetadata {
         // Update the cached peers and metadata
         self.set_cached_peers_and_metadata(peers_and_metadata.clone());
 
-        let event =
-            ConnectionNotification::NewPeer(connection_metadata, peer_network_id.network_id());
-        self.broadcast(event);
-
         Ok(())
     }
 
@@ -237,13 +220,7 @@ impl PeersAndMetadata {
             // have multiple connections for a peer
             let active_connection_id = entry.get().connection_metadata.connection_id;
             if active_connection_id == connection_id {
-                let peer_metadata = entry.remove();
-                let event = ConnectionNotification::LostPeer(
-                    peer_metadata.connection_metadata.clone(),
-                    peer_network_id.network_id(),
-                );
-                self.broadcast(event);
-                peer_metadata
+                entry.remove()
             } else {
                 return Err(Error::UnexpectedError(format!(
                     "The peer connection id did not match! Given: {:?}, found: {:?}.",
@@ -366,63 +343,6 @@ impl PeersAndMetadata {
         let trusted_peers = self.get_trusted_peer_set_for_network(network_id)?;
         trusted_peers.store(Arc::new(trusted_peer_set));
         Ok(())
-    }
-
-    fn broadcast(&self, event: ConnectionNotification) {
-        let mut listeners = self.subscribers.lock();
-        let mut to_del = vec![];
-        for i in 0..listeners.len() {
-            let dest = listeners.get_mut(i).unwrap();
-            if let Err(err) = dest.try_send(event.clone()) {
-                match err {
-                    TrySendError::Full(_) => {
-                        // Tried to send to an app, but the app isn't handling its messages fast enough.
-                        // Drop message. Maybe increment a metrics counter?
-                        sample!(
-                            SampleRate::Duration(Duration::from_secs(1)),
-                            warn!("PeersAndMetadata.broadcast() failed, some app is slow"),
-                        );
-                    },
-                    TrySendError::Closed(_) => {
-                        to_del.push(i);
-                    },
-                }
-            }
-        }
-        for evict in to_del.into_iter() {
-            listeners.swap_remove(evict);
-        }
-    }
-
-    /// subscribe() returns a channel for receiving NewPeer/LostPeer events.
-    /// subscribe() immediately sends all* current connections as NewPeer events.
-    /// (* capped at NOTIFICATION_BACKLOG, currently 1000, use get_connected_peers() to be sure)
-    pub fn subscribe(&self) -> tokio::sync::mpsc::Receiver<ConnectionNotification> {
-        let (sender, receiver) = tokio::sync::mpsc::channel(NOTIFICATION_BACKLOG);
-        let peers_and_metadata = self.peers_and_metadata.read();
-        'outer: for (network_id, network_peers_and_metadata) in peers_and_metadata.iter() {
-            for (_addr, peer_metadata) in network_peers_and_metadata.iter() {
-                let event = ConnectionNotification::NewPeer(
-                    peer_metadata.connection_metadata.clone(),
-                    *network_id,
-                );
-                if let Err(err) = sender.try_send(event) {
-                    warn!("could not send initial NewPeer on subscribe(): {:?}", err);
-                    break 'outer;
-                }
-            }
-        }
-        // I expect the peers_and_metadata read lock to still be in effect until after listeners.push() below
-        let mut listeners = self.subscribers.lock();
-        listeners.push(sender);
-        receiver
-    }
-
-    #[cfg(test)]
-    pub fn close_subscribers(&self) {
-        let mut listeners = self.subscribers.lock();
-        // drop all the senders to close them
-        listeners.clear();
     }
 
     #[cfg(test)]


### PR DESCRIPTION
## Description
This PR removes the subscription logic from `PeersAndMetadata` (this is a legacy feature that introduced more tech-debt than necessary). More specifically, it: (i) removes the `subscribe()` and `broadcast()` methods; (ii) removes the dependency on the `NewPeer` and `LostPeer` events in the network health checker; (iii) cleans up a bunch of code related to this feature; and (iv) adds new and missing unit tests.

Note: in the future, the network health checker will be completely removed and replaced by the peer monitoring service.

## Testing Plan
New and existing test infrastructure.




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes connection tracking semantics from event-driven to polling in the health checker and tests; risk is mainly around missed/late peer detection timing or increased polling overhead, but scoped to networking internals.
> 
> **Overview**
> Removes legacy connection subscription/broadcast support from `PeersAndMetadata` (drops `subscribe()`/`broadcast()` and associated locking/logging), shifting callers to query `get_connected_peers_and_metadata()` instead.
> 
> Updates the health checker to stop consuming `NewPeer`/`LostPeer` streams and instead periodically diffs the current connected-peer set against an internal `known_peers` cache, with expanded unit tests for new/lost peer detection.
> 
> Adjusts network test utilities (`dummy.rs` and application tests) to wait for connections by polling metadata, and removes the now-unused `tokio-stream` dependency.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 12299aeb58a82ae7c07c12285e91f15c13114fa3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->