### PR TITLE
Fix small typo in `features.move` comment

### DIFF
--- a/aptos-move/framework/move-stdlib/sources/configs/features.move
+++ b/aptos-move/framework/move-stdlib/sources/configs/features.move
@@ -868,7 +868,7 @@ module std::features {
         is_enabled(SLH_DSA_SHA2_128S_SIGNATURE)
     }
 
-    /// Whether the monotonically increasing counter native function is enabled.
+    /// Whether the encrypted mempool feature is enabled.
     const ENCRYPTED_TRANSACTIONS: u64 = 108;
 
     public fun get_encrypted_transactions_feature(): u64 {


### PR DESCRIPTION
<img width="924" height="124" alt="image" src="https://github.com/user-attachments/assets/625f0d5b-a420-46eb-8d7a-b5aaf04ce991" />