### PR TITLE
[Storage] Fix HotState crash on stale merged_state

### DIFF
--- a/experimental/storage/layered-map/src/tests.rs
+++ b/experimental/storage/layered-map/src/tests.rs
@@ -132,6 +132,56 @@ fn test_is_descendant_of() {
     assert!(!other_root.is_descendant_of(&child1));
 }
 
+#[test]
+fn test_can_view_after() {
+    //  Build a chain with an advancing base:
+    //
+    //       root (layer 0)
+    //        |
+    //      child1 (layer 1, base_layer=0)  -- spawned from LayeredMap(root, root)
+    //        |
+    //      child2 (layer 2, base_layer=0)  -- spawned from LayeredMap(root, child1)
+    //        |
+    //      child3 (layer 3, base_layer=1)  -- spawned from LayeredMap(child1, child2)
+    //        |
+    //      child4 (layer 4, base_layer=2)  -- spawned from LayeredMap(child2, child3)
+    //
+    let root = MapLayer::<u8, u8>::new_family("test");
+    let child1 = root.view_layers_after(&root).new_layer(&[(1, 10)]);
+    let child2 = child1.view_layers_after(&root).new_layer(&[(2, 20)]);
+    let child3 = child2.view_layers_after(&child1).new_layer(&[(3, 30)]);
+    let child4 = child3.view_layers_after(&child2).new_layer(&[(4, 40)]);
+
+    // A layer can always be viewed after itself.
+    assert!(root.can_view_after(&root));
+    assert!(child3.can_view_after(&child3));
+
+    // child1 and child2 have base_layer=0, so root (layer 0) is a valid base.
+    assert!(child1.can_view_after(&root));
+    assert!(child2.can_view_after(&root));
+
+    // child3 has base_layer=1, so child1 (layer 1) is the earliest valid base.
+    assert!(child3.can_view_after(&child1));
+    assert!(child3.can_view_after(&child2));
+    // root (layer 0) is too old for child3.
+    assert!(!child3.can_view_after(&root));
+
+    // child4 has base_layer=2, so child2 (layer 2) is the earliest valid base.
+    assert!(child4.can_view_after(&child2));
+    assert!(child4.can_view_after(&child3));
+    assert!(!child4.can_view_after(&root));
+    assert!(!child4.can_view_after(&child1));
+
+    // A base cannot be newer than the top layer.
+    assert!(!root.can_view_after(&child1));
+    assert!(!child1.can_view_after(&child2));
+
+    // Different family is always invalid.
+    let other = MapLayer::<u8, u8>::new_family("other");
+    assert!(!child1.can_view_after(&other));
+    assert!(!other.can_view_after(&child1));
+}
+
 proptest! {
     #[test]
     fn test_layered_map_get(

--- a/storage/storage-interface/src/state_store/state.rs
+++ b/storage/storage-interface/src/state_store/state.rs
@@ -142,6 +142,15 @@ impl State {
         self.shards[0].is_descendant_of(&rhs.shards[0])
     }
 
+    /// Returns true if `self` can serve as the base (older) side of a `StateDelta`
+    /// with `current` as the newer side.
+    pub fn can_be_delta_base_of(&self, current: &State) -> bool {
+        self.shards
+            .iter()
+            .zip(current.shards.iter())
+            .all(|(base_shard, top_shard)| top_shard.can_view_after(base_shard))
+    }
+
     pub fn latest_hot_key(&self, shard_id: usize) -> Option<StateKey> {
         self.hot_state_metadata[shard_id].latest.clone()
     }


### PR DESCRIPTION

The `Committer` thread could panic at `layer.rs:123` (`base_layer.inner.layer >= self.inner.base_layer`)
when building a delta between `merged_state` and an incoming `to_commit` state.

**Root cause**: `State::update()` spawns new `MapLayer` shards with
`base_layer = persisted_snapshot.shard.layer()`. When old
`LayeredHotStateView` readers prevent `try_merge()` from advancing
`merged_state`, the committer's `merged_state` falls behind
`persisted_snapshot`. Subsequent `to_commit.make_delta(&merged_state)` then
violates the layer compatibility invariant.

**Fix**: Before building the delta, spin-wait for old views to drain so
`try_merge()` can advance `merged_state` to a compatible layer. One successful
merge is always sufficient since `persisted.layer <= previous_committed.layer`.

- Add `MapLayer::can_view_after()` — non-panicking compatibility check
- Add `State::can_be_delta_base_of()` — checks all 16 shards
- `Committer::try_merge()` now returns `bool` (`false` = blocked by old views)
- `Committer::run()` waits for merge before `make_delta` when incompatible

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/aptos-labs/aptos-core/pull/18802).
* #18805
* __->__ #18802

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches HotState commit/merge control flow and introduces a spin-wait loop, which could impact liveness/performance under long-lived readers, though the change is localized and covered by new regression tests.
> 
> **Overview**
> Prevents a HotState committer panic when `merged_state` lags behind an incoming commit’s `base_layer` by **waiting for deferred merges to catch up before building `StateDelta`**.
> 
> Adds non-panicking layer compatibility checks (`MapLayer::can_view_after`, `State::can_be_delta_base_of`) and changes `Committer::try_merge()` to return whether it made progress, enabling a retry/sleep loop; includes targeted regression tests for the advanced-`base_layer` scenario and the new compatibility helper.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fd1d799f58fdd75c6c64dcbe65cdd49ad796e258. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->