### PR TITLE
[execution] Simplify cold validation pending requirements to single entry

### DIFF
--- a/aptos-move/block-executor/src/cold_validation.rs
+++ b/aptos-move/block-executor/src/cold_validation.rs
@@ -466,11 +466,13 @@ impl<R: Clone + Ord> ColdValidationRequirements<R> {
     ///
     /// Returns Some(prev_min) when an update was performed (pending was empty at the
     /// time of the swap), None when skipped (pending was non-empty).
-    fn advance_min_unprocessed_idx(
-        &self,
-        active_reqs: &mut ActiveRequirements<R>,
-    ) -> Option<u32> {
-        let new_min = active_reqs.versions.keys().min().copied().unwrap_or(u32::MAX);
+    fn advance_min_unprocessed_idx(&self, active_reqs: &mut ActiveRequirements<R>) -> Option<u32> {
+        let new_min = active_reqs
+            .versions
+            .keys()
+            .min()
+            .copied()
+            .unwrap_or(u32::MAX);
         let pending_reqs = self.pending_requirements.lock();
         if pending_reqs.is_some() {
             return None;

--- a/aptos-move/block-executor/src/scheduler_v2.rs
+++ b/aptos-move/block-executor/src/scheduler_v2.rs
@@ -487,6 +487,17 @@ enum CommitMarkerFlag {
     Committed = 2,
 }
 
+/// Result of [SchedulerV2::start_commit], distinguishing why no transaction was returned.
+#[derive(Debug)]
+pub(crate) enum CommitResult {
+    /// A transaction is ready to commit.
+    Ready(TxnIndex, Incarnation),
+    /// No transaction to commit because cold validation is blocking the next one.
+    BlockedByValidation,
+    /// No transaction to commit for other reasons (not executed yet, halted, done).
+    None,
+}
+
 pub(crate) struct SchedulerV2 {
     /// Total number of transactions in the block. This is immutable after scheduler creation.
     num_txns: TxnIndex,
@@ -603,14 +614,14 @@ impl SchedulerV2 {
     /// An important invariant check: Before attempting to dispatch transaction `i`, it verifies
     /// that transaction `i-1` has its `committed_marker` as `Committed`. This ensures strict
     /// sequential processing of commit hooks.
-    pub(crate) fn start_commit(&self) -> Result<Option<(TxnIndex, Incarnation)>, PanicError> {
+    pub(crate) fn start_commit(&self) -> Result<CommitResult, PanicError> {
         // Relaxed ordering due to armed lock acq-rel.
         let next_to_commit_idx = self.next_to_commit_idx.load(Ordering::Relaxed);
         assert!(next_to_commit_idx <= self.num_txns);
 
         if self.is_halted() || next_to_commit_idx == self.num_txns {
             // All sequential commit hooks are already dispatched.
-            return Ok(None);
+            return Ok(CommitResult::None);
         }
 
         let incarnation = self.txn_statuses.incarnation(next_to_commit_idx);
@@ -634,7 +645,7 @@ impl SchedulerV2 {
             {
                 // May not commit a txn with an unsatisfied validation requirement. This will be
                 // more rare than !is_executed in the common case, hence the order of checks.
-                return Ok(None);
+                return Ok(CommitResult::BlockedByValidation);
             }
             // The check might have passed after the validation requirement has been fulfilled.
             // Yet, if validation failed, the status would be aborted before removing the block,
@@ -642,7 +653,7 @@ impl SchedulerV2 {
             // blocking happens during sequential commit hook, while holding the lock (which is
             // also held here), hence before the call of this method.
             if incarnation != self.txn_statuses.incarnation(next_to_commit_idx) {
-                return Ok(None);
+                return Ok(CommitResult::None);
             }
 
             if self
@@ -670,13 +681,13 @@ impl SchedulerV2 {
                 )));
             }
 
-            return Ok(Some((
+            return Ok(CommitResult::Ready(
                 next_to_commit_idx,
                 self.txn_statuses.incarnation(next_to_commit_idx),
-            )));
+            ));
         }
 
-        Ok(None)
+        Ok(CommitResult::None)
     }
 
     /// Called by a worker after it has successfully executed sequential commit hook logic
@@ -1336,6 +1347,16 @@ mod tests {
     use super::*;
     use crate::scheduler_status::{ExecutionStatus, SchedulingStatus, StatusWithIncarnation};
     use claims::{assert_err, assert_none, assert_ok, assert_ok_eq, assert_some_eq};
+
+    impl CommitResult {
+        /// Returns the (txn_idx, incarnation) if Ready, None otherwise.
+        pub(crate) fn ready(self) -> Option<(TxnIndex, Incarnation)> {
+            match self {
+                CommitResult::Ready(txn_idx, incarnation) => Some((txn_idx, incarnation)),
+                _ => None,
+            }
+        }
+    }
     use fail::FailScenario;
     use rand::{rngs::StdRng, Rng, SeedableRng};
     use std::cmp::min;
@@ -1784,7 +1805,7 @@ mod tests {
             );
             assert_err!(scheduler.end_commit(i));
 
-            assert_some_eq!(scheduler.start_commit().unwrap(), (i, 0));
+            assert_some_eq!(scheduler.start_commit().unwrap().ready(), (i, 0));
             assert_eq!(
                 scheduler.committed_marker[i as usize].load(Ordering::Relaxed),
                 CommitMarkerFlag::CommitStarted as u8
@@ -1796,7 +1817,7 @@ mod tests {
                 // check which returns Ok(None).
                 assert_err!(scheduler.start_commit());
             } else {
-                assert_none!(scheduler.start_commit().unwrap());
+                assert_none!(scheduler.start_commit().unwrap().ready());
             }
             assert_ok!(scheduler.end_commit(i));
             assert_eq!(
@@ -1859,10 +1880,10 @@ mod tests {
 
         // Test txn index 0.
         assert_eq!(scheduler.next_to_commit_idx.load(Ordering::Relaxed), 0);
-        assert_none!(scheduler.start_commit().unwrap());
+        assert_none!(scheduler.start_commit().unwrap().ready());
         // Next task should start executing (0, 0).
         assert_ok_eq!(scheduler.next_task(0), TaskKind::Execute(0, 0));
-        assert_none!(scheduler.start_commit().unwrap());
+        assert_none!(scheduler.start_commit().unwrap().ready());
         // After execution is finished, commit hook can be dispatched.
         assert_ok!(scheduler.finish_execution(AbortManager::new(0, 0, &scheduler)));
         assert_eq!(
@@ -1870,7 +1891,7 @@ mod tests {
             CommitMarkerFlag::NotCommitted as u8
         );
 
-        assert_some_eq!(scheduler.start_commit().unwrap(), (0, 0));
+        assert_some_eq!(scheduler.start_commit().unwrap().ready(), (0, 0));
         assert_eq!(scheduler.next_to_commit_idx.load(Ordering::Relaxed), 1);
         assert_eq!(
             scheduler.committed_marker[0].load(Ordering::Relaxed),
@@ -1878,7 +1899,7 @@ mod tests {
         );
 
         // Ok(None) because txn 1 has not finished execution yet.
-        assert_none!(scheduler.start_commit().unwrap());
+        assert_none!(scheduler.start_commit().unwrap().ready());
         scheduler.next_to_commit_idx.store(0, Ordering::Relaxed);
         // But calling it again with index 0 would lead to an error.
         assert_err!(scheduler.start_commit());
@@ -1886,7 +1907,7 @@ mod tests {
         scheduler.next_to_commit_idx.store(3, Ordering::Relaxed);
         // Execution status is checked first, so start_commit returns Ok(None).
 
-        assert_none!(scheduler.start_commit().unwrap());
+        assert_none!(scheduler.start_commit().unwrap().ready());
 
         *scheduler.txn_statuses.get_status_mut(3) = ExecutionStatus::new_for_test(
             StatusWithIncarnation::new_for_test(SchedulingStatus::Executed, 5),
@@ -1901,11 +1922,11 @@ mod tests {
             CommitMarkerFlag::NotCommitted as u8
         );
         // No longer an error, but should commit despite being currently stalled.
-        assert_some_eq!(scheduler.start_commit().unwrap(), (3, 5));
+        assert_some_eq!(scheduler.start_commit().unwrap().ready(), (3, 5));
 
         scheduler.next_to_commit_idx.store(10, Ordering::Relaxed);
         scheduler.committed_marker[9].store(CommitMarkerFlag::Committed as u8, Ordering::Relaxed);
-        assert_none!(scheduler.start_commit().unwrap());
+        assert_none!(scheduler.start_commit().unwrap().ready());
     }
 
     // This test generates a DAG of dependencies, where each transaction depends on
@@ -1956,7 +1977,7 @@ mod tests {
                     s.spawn(|_| loop {
                         while scheduler.commit_hooks_try_lock() {
                             while let Some((txn_idx, incarnation)) =
-                                scheduler.start_commit().unwrap()
+                                scheduler.start_commit().unwrap().ready()
                             {
                                 assert!(incarnation < 2);
                                 assert!(scheduler.txn_statuses.is_executed(txn_idx));


### PR DESCRIPTION
## Summary
Fixes the BlockSTM v2 deterministic deadlock where the cold validation threshold heuristic (`next_to_commit + num_workers * 3 + 4`) permanently blocks commit progress when deferred requirements create gaps in the active set.

### Root cause
When a module publish transaction records cold validation requirements for a range of transactions:
1. Many requirements get deferred (transaction still Executing) and removed from the active set
2. `validation_requirement_processed` advanced `min_idx` linearly (`txn_idx + 1`), leaving it pointing at gap indices with no active requirements
3. The dedicated worker's threshold (`next_to_commit + num_workers * 3 + 4`) was exceeded by the actual minimum active index
4. Commits blocked by `min_idx_with_unprocessed <= next_to_commit`, but `next_to_commit` couldn't advance → threshold frozen → permanent deadlock

### Changes

**1. `Vec<PendingRequirement>` → `Option<PendingRequirement>` (cold_validation.rs)**
- At most one pending requirement can exist: `record_requirements` is called exclusively during sequential commit, and after recording, `is_commit_blocked` prevents further commits until the pending requirement is activated and processed.
- Adds a runtime invariant check that errors if a second pending requirement is recorded while one exists.

**2. Extract `advance_min_unprocessed_idx` (cold_validation.rs)**
- New helper that sets `min_idx_with_unprocessed` to the actual minimum of active versions (skipping gap indices), or `u32::MAX` if empty.
- Used from both `validation_requirement_processed` and `activate_pending_requirements`, replacing the old linear `txn_idx + 1` advancement that caused the deadlock.
- Adds `prev_min == starting_idx` invariant check in `activate_pending_requirements`.

**3. Break out of commit-hooks loop (executor.rs)**
- After `commit_hooks_unlock`, breaks instead of looping back to `start_commit`. This avoids spinning when the next txn is blocked by cold validation (the lock gets re-armed because the txn is Executed, but `start_commit` returns None until validation completes).

**4. Documentation**
- Adds `***IMPORTANT***` documentation at file-level, `record_requirements`, and `activate_pending_requirements` explaining the single-pending invariant and its dependency on commit-only recording.

This fix was validated against a production block (with module publish + block gas limit exceeded at the same transaction) that caused two nodes to hang at the exact same block.

## Test plan
- [x] All existing `scheduler_v2` tests pass
- [x] All existing `cold_validation` tests pass
- [x] Verified with production replay benchmark (`aptos-replay-benchmark` with `blockstm_v2: true`, gas limit 20000) — completes successfully with fix, hangs without

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches BlockSTMv2 scheduler/commit gating and cold-validation synchronization; mistakes could reintroduce hangs or allow commits without required validation, though changes are localized and add invariants/tests.
> 
> **Overview**
> Fixes a BlockSTMv2 hang where cold-validation created *gap indices* that kept `min_idx_with_unprocessed_validation_requirement` pointing at non-existent work, permanently blocking commit progress.
> 
> Cold validation now allows **at most one pending requirement** (`Option<PendingRequirement>`), adds invariant checks around `record_requirements`, and updates `min_idx_with_unprocessed_validation_requirement` by advancing to the **true minimum active requirement index** (new `advance_min_unprocessed_idx`) instead of `txn_idx + 1`, so gaps don’t block commits.
> 
> The v2 commit path is updated to surface why `start_commit` can’t return a txn (`CommitResult::{Ready,BlockedByValidation,None}`), and the v2 executor commit-hook loop breaks when blocked by validation to avoid spinning; related tests are adjusted to the new semantics.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4119404909a5da45d42d3daf43932910f5676d07. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->