### PR TITLE
[execution] Parallelize account cache generation in executor benchmark

### DIFF
--- a/execution/executor-benchmark/src/transaction_generator.rs
+++ b/execution/executor-benchmark/src/transaction_generator.rs
@@ -312,8 +312,10 @@ pub struct TransactionGenerator {
 
 impl TransactionGenerator {
     fn gen_account_cache(
-        generator: AccountGenerator,
+        root_seed: u64,
+        num_to_skip: u64,
         num_accounts: usize,
+        is_keyless: bool,
         name: &str,
     ) -> AccountCache {
         println!(
@@ -322,7 +324,7 @@ impl TransactionGenerator {
             num_accounts,
             name,
         );
-        AccountCache::new(generator, num_accounts)
+        AccountCache::generate_parallel(root_seed, num_to_skip, num_accounts, is_keyless)
     }
 
     pub fn resync_sequence_numbers(
@@ -358,8 +360,10 @@ impl TransactionGenerator {
         Self::resync_sequence_numbers(
             reader,
             Self::gen_account_cache(
-                AccountGenerator::new_for_user_accounts(num_to_skip as u64, is_keyless),
+                AccountGenerator::USER_ACCOUNTS_ROOT_SEED,
+                num_to_skip as u64,
                 num_accounts,
+                is_keyless,
                 "user",
             ),
             "user",
@@ -374,8 +378,10 @@ impl TransactionGenerator {
         Self::resync_sequence_numbers(
             reader,
             Self::gen_account_cache(
-                AccountGenerator::new_for_seed_accounts(is_keyless),
+                AccountGenerator::SEED_ACCOUNTS_ROOT_SEED,
+                0,
                 num_accounts,
+                is_keyless,
                 "seed",
             ),
             "seed",


### PR DESCRIPTION

The benchmark generates large numbers of `LocalAccount`s (Ed25519 keypairs)
sequentially on a single thread, which could take a long time. The existing
`AccountGenerator` already rotates its RNG every 40k accounts using
independent seeds from a root RNG, so each 40k chunk can be generated
independently.

- Add `AccountCache::generate_parallel()` that pre-computes all chunk seeds,
  then uses `rayon::into_par_iter().flat_map()` to generate chunks
  concurrently. Produces identical accounts in identical order.
- Update `gen_account_cache()` to use the parallel path.
- E.g. for 600k accounts this creates ~15 rayon tasks that can run on all
  available cores simultaneously.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/aptos-labs/aptos-core/pull/18826).
* __->__ #18826
* #18825