### PR TITLE
[Execution] Fix seed account balance exhaustion in executor benchmark

### DIFF
--- a/execution/executor-benchmark/src/transaction_generator.rs
+++ b/execution/executor-benchmark/src/transaction_generator.rs
@@ -467,13 +467,17 @@ impl TransactionGenerator {
         is_keyless: bool,
     ) {
         assert!(self.block_sender.is_some());
-        // Ensure that seed accounts have enough balance to transfer money to at least 10000 account with
-        // balance init_account_balance.
+        // Compute seed account balance based on the actual number of accounts
+        // each seed account needs to create, with 50% margin for gas fees and
+        // random distribution variance across seed accounts.
+        let num_seed_accounts = (num_new_accounts / 1000).clamp(1, 100_000);
+        let accounts_per_seed = num_new_accounts.div_ceil(num_seed_accounts);
+        let seed_account_balance = init_account_balance * (accounts_per_seed as u64) * 3 / 2;
         self.create_seed_accounts(
             reader,
-            num_new_accounts,
+            num_seed_accounts,
             block_size,
-            init_account_balance * 10_000,
+            seed_account_balance,
             is_keyless,
         );
         self.create_and_fund_accounts(
@@ -558,14 +562,13 @@ impl TransactionGenerator {
     pub fn create_seed_accounts(
         &mut self,
         reader: Arc<dyn DbReader>,
-        num_new_accounts: usize,
+        num_seed_accounts: usize,
         block_size: usize,
         seed_account_balance: u64,
         is_keyless: bool,
     ) {
         // We don't store the # of existing seed accounts now. Thus here we just blindly re-create
         // and re-mint seed accounts here.
-        let num_seed_accounts = (num_new_accounts / 1000).clamp(1, 100000);
         let seed_accounts_cache =
             Self::gen_seed_account_cache(reader.clone(), num_seed_accounts, is_keyless);
 


### PR DESCRIPTION

The seed account balance was hardcoded as `init_account_balance * 10_000`,
which doesn't scale when the number of accounts per seed account exceeds
10,000 (e.g. creating 1 billion accounts with 100K seed accounts). This
caused `EINSUFFICIENT_BALANCE` aborts as seed accounts ran out of funds.

Compute seed account balance dynamically based on the actual expected
number of accounts per seed, with a large margin for gas fees and random
distribution variance.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to benchmark-only account-funding math; main risk is potential under/over-funding due to arithmetic edge cases for extreme inputs.
> 
> **Overview**
> Fixes executor-benchmark minting failures by replacing the hardcoded seed funding assumption ("enough for 10k accounts") with a dynamic calculation based on `num_new_accounts` and the derived `num_seed_accounts`.
> 
> `run_mint` now computes both the seed account count and per-seed balance (with a 50% buffer), and `create_seed_accounts` is updated to accept `num_seed_accounts` directly rather than recomputing it, preventing `EINSUFFICIENT_BALANCE` when scaling to very large account creation runs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3ddd069d1e2ec00f41806b96a00c4ed9921093aa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->