### PR TITLE
[indexer] Fix potential overflow in ending version calculation

### DIFF
--- a/ecosystem/indexer-grpc/indexer-grpc-data-service-v2/src/historical_data_service.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-data-service-v2/src/historical_data_service.rs
@@ -107,7 +107,7 @@ impl HistoricalDataService {
 
                 let ending_version = request
                     .transactions_count
-                    .map(|count| starting_version + count);
+                    .map(|count| starting_version.saturating_add(count));
 
                 scope.spawn(async move {
                     self.start_streaming(

--- a/ecosystem/indexer-grpc/indexer-grpc-data-service-v2/src/live_data_service/mod.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-data-service-v2/src/live_data_service/mod.rs
@@ -122,7 +122,7 @@ impl<'a> LiveDataService<'a> {
 
                 let ending_version = request
                     .transactions_count
-                    .map(|count| starting_version + count);
+                    .map(|count| starting_version.saturating_add(count));
 
                 scope.spawn(async move {
                     self.start_streaming(


### PR DESCRIPTION
## Summary

- Fix potential integer overflow when calculating `ending_version` from `starting_version + transactions_count` in the indexer-grpc data service v2
- Use `saturating_add` instead of unchecked `+` operator in both `LiveDataService` and `HistoricalDataService`, preventing wraparound when both values are large `u64`s

## Test plan

- [ ] Existing tests pass (`cargo test -p indexer-grpc-data-service-v2`)
- [ ] Verified the fix is consistent with the existing pattern in `fullnode_data_service.rs:84` which already uses `saturating_add`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized arithmetic change in request handling; behavior only differs for extreme values where overflow would have occurred.
> 
> **Overview**
> Prevents potential `u64` overflow when deriving `ending_version` from `starting_version` and `transactions_count` in indexer-grpc data service v2.
> 
> Both `HistoricalDataService` and `LiveDataService` now use `saturating_add` instead of `+`, avoiding wraparound for extremely large request values and ensuring streams cap at `u64::MAX` rather than producing an invalid lower ending version.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c605ac7db8c2c0bca99eb3ebea413e9e3104f0b1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->