### PR TITLE
fix warnings in natives

### DIFF
--- a/aptos-move/framework/src/natives/cryptography/algebra/mod.rs
+++ b/aptos-move/framework/src/natives/cryptography/algebra/mod.rs
@@ -59,7 +59,9 @@ pub(crate) const E_CONSTANTS_BLS12381FQ12_Q12_ORDER_LOADING_FAILED: u64 = 0x0A_0
 pub(crate) const E_CONSTANTS_BN254FQ12_Q12_ORDER_LOADING_FAILED: u64 = 0x0A_0005;
 pub(crate) const E_CASTING_BLS12381_R_SCALAR_LOADING_FAILED: u64 = 0x0A_0006;
 pub(crate) const E_SERIALIZATION_BLS12381GT_CONST_LOADING_FAILED: u64 = 0x0A_0007;
+#[cfg(feature = "testing")]
 pub(crate) const E_RAND_BLS12381GT_GT_GENERATOR_LOADING_FAILED: u64 = 0x0A_0008;
+#[cfg(feature = "testing")]
 pub(crate) const E_RAND_BN254GT_GT_GENERATOR_LOADING_FAILED: u64 = 0x0A_0009;
 pub(crate) const E_SCALAR_MUL_MSM_WINDOW_SIZE_FAILED: u64 = 0x0A_000A;
 pub(crate) const E_SCALAR_MUL_MSM_COMPUTATION_FAILED: u64 = 0x0A_000B;
@@ -67,6 +69,7 @@ pub(crate) const E_HASH_TO_STRUCTURE_BLS12381G1_MAPPER_FAILED: u64 = 0x0A_000C;
 pub(crate) const E_HASH_TO_STRUCTURE_BLS12381G1_HASH_FAILED: u64 = 0x0A_000D;
 pub(crate) const E_HASH_TO_STRUCTURE_BLS12381G2_MAPPER_FAILED: u64 = 0x0A_000E;
 pub(crate) const E_HASH_TO_STRUCTURE_BLS12381G2_HASH_FAILED: u64 = 0x0A_000F;
+#[cfg(feature = "testing")]
 pub(crate) const E_RAND_INSECURE_NOT_IMPLEMENTED: u64 = 0x0A_0010;
 
 /// This encodes an algebraic structure defined in `*_algebra.move`.

--- a/aptos-move/framework/src/natives/cryptography/bls12381.rs
+++ b/aptos-move/framework/src/natives/cryptography/bls12381.rs
@@ -9,9 +9,11 @@ use aptos_crypto::{
     SigningKey, Uniform,
 };
 use aptos_gas_schedule::gas_params::natives::aptos_framework::*;
+#[cfg(feature = "testing")]
+use aptos_native_interface::SafeNativeError;
 use aptos_native_interface::{
     safely_pop_arg, safely_pop_vec_arg, RawSafeNative, SafeNativeBuilder, SafeNativeContext,
-    SafeNativeError, SafeNativeResult,
+    SafeNativeResult,
 };
 use move_binary_format::errors::PartialVMError;
 use move_core_types::{
@@ -29,8 +31,10 @@ use smallvec::{smallvec, SmallVec};
 use std::{collections::VecDeque, convert::TryFrom};
 
 /// Equivalent to `std::errors::internal(1)` in Move.
+#[cfg(feature = "testing")]
 const E_BLS12381_SIGN_COMPUTATION_FAILED: u64 = 0x0A_0001;
 /// Equivalent to `std::errors::internal(2)` in Move.
+#[cfg(feature = "testing")]
 const E_BLS12381_POP_SK_DESERIALIZATION_FAILED: u64 = 0x0A_0002;
 
 /// Pops a `Vec<T>` off the argument stack and converts it to a `Vec<Vec<u8>>` by reading the first

--- a/aptos-move/framework/src/natives/cryptography/multi_ed25519.rs
+++ b/aptos-move/framework/src/natives/cryptography/multi_ed25519.rs
@@ -13,9 +13,11 @@ use aptos_crypto::{
 };
 use aptos_gas_algebra::{Arg, GasExpression};
 use aptos_gas_schedule::gas_params::natives::aptos_framework::*;
+#[cfg(feature = "testing")]
+use aptos_native_interface::SafeNativeError;
 use aptos_native_interface::{
     safely_assert_eq, safely_pop_arg, RawSafeNative, SafeNativeBuilder, SafeNativeContext,
-    SafeNativeError, SafeNativeResult,
+    SafeNativeResult,
 };
 use curve25519_dalek::edwards::CompressedEdwardsY;
 use move_core_types::gas_algebra::{NumArgs, NumBytes};
@@ -27,10 +29,13 @@ use smallvec::{smallvec, SmallVec};
 use std::{collections::VecDeque, convert::TryFrom};
 
 /// Equivalent to `std::errors::internal(1)` in Move.
+#[cfg(feature = "testing")]
 const E_MULTI_ED25519_SK_CREATE_FAILED: u64 = 0x0A_0001;
 /// Equivalent to `std::errors::internal(2)` in Move.
+#[cfg(feature = "testing")]
 const E_MULTI_ED25519_PK_CREATE_FAILED: u64 = 0x0A_0002;
 /// Equivalent to `std::errors::internal(3)` in Move.
+#[cfg(feature = "testing")]
 const E_MULTI_ED25519_SK_DESERIALIZATION_FAILED: u64 = 0x0A_0003;
 
 /// See `public_key_validate_v2_internal` comments in `multi_ed25519.move`.


### PR DESCRIPTION
introduced by accident in #18713 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Purely conditional-compilation cleanup to silence warnings; no functional changes to production code paths.
> 
> **Overview**
> **Fixes build warnings in cryptography natives** by gating test-only error constants and imports behind `#[cfg(feature = "testing")]`.
> 
> This keeps `algebra` rand-related abort codes and the `bls12381`/`multi_ed25519` `SafeNativeError` usage (and associated error codes) compiled only for testing, without changing runtime native behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cedbe39f2e11850bbc81f93aa732fe5fec214c84. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->