### PR TITLE
[Network] Add priority inbound peer support and eviction.

### DIFF
--- a/config/src/config/network_config.rs
+++ b/config/src/config/network_config.rs
@@ -144,6 +144,8 @@ pub struct NetworkConfig {
     /// Access control policy for peer connections. If not specified, all
     /// peers are allowed. Otherwise, the specified policy is enforced.
     pub access_control_policy: Option<AccessControlPolicy>,
+    /// Priority inbound peers that can bypass connection limits
+    pub priority_inbound_peers: Vec<PeerId>,
 }
 
 impl Default for NetworkConfig {
@@ -185,6 +187,7 @@ impl NetworkConfig {
             max_parallel_deserialization_tasks: None,
             enable_latency_aware_dialing: true,
             access_control_policy: None,
+            priority_inbound_peers: Vec::new(),
         };
 
         // Configure the number of parallel deserialization tasks

--- a/network/builder/src/builder.rs
+++ b/network/builder/src/builder.rs
@@ -40,7 +40,7 @@ use aptos_network::{
 };
 use aptos_network_discovery::DiscoveryChangeListener;
 use aptos_time_service::TimeService;
-use aptos_types::{chain_id::ChainId, network_address::NetworkAddress};
+use aptos_types::{chain_id::ChainId, network_address::NetworkAddress, PeerId};
 use std::{clone::Clone, collections::HashSet, sync::Arc, time::Duration};
 use tokio::runtime::Handle;
 
@@ -86,6 +86,7 @@ impl NetworkBuilder {
         inbound_connection_limit: usize,
         tcp_buffer_cfg: TCPBufferCfg,
         access_control_policy: Option<Arc<AccessControlPolicy>>,
+        priority_inbound_peers: Vec<PeerId>,
     ) -> Self {
         // A network cannot exist without a PeerManager
         // TODO:  construct this in create and pass it to new() as a parameter. The complication is manual construction of NetworkBuilder in various tests.
@@ -103,6 +104,7 @@ impl NetworkBuilder {
             inbound_connection_limit,
             tcp_buffer_cfg,
             access_control_policy,
+            priority_inbound_peers,
         );
 
         NetworkBuilder {
@@ -142,7 +144,8 @@ impl NetworkBuilder {
             NETWORK_CHANNEL_SIZE,
             MAX_INBOUND_CONNECTIONS,
             TCPBufferCfg::default(),
-            None, /* access_control_policy */
+            None,       /* access_control_policy */
+            Vec::new(), /* priority_inbound_peers */
         );
 
         builder.add_connectivity_manager(
@@ -203,6 +206,7 @@ impl NetworkBuilder {
                 config.outbound_tx_buffer_size_bytes,
             ),
             access_control_policy.clone(),
+            config.priority_inbound_peers.clone(),
         );
 
         network_builder.add_connection_monitoring(

--- a/network/framework/src/counters.rs
+++ b/network/framework/src/counters.rs
@@ -83,6 +83,25 @@ pub fn connections_rejected(
     ])
 }
 
+static APTOS_PRIORITY_PEER_EVICTIONS: Lazy<IntCounterVec> = Lazy::new(|| {
+    register_int_counter_vec!(
+        "aptos_priority_peer_evictions",
+        "Number of non-priority peers evicted to make room for priority peers",
+        &["role_type", "network_id"]
+    )
+    .unwrap()
+});
+
+/// Updates the counter for priority peer evictions
+pub fn update_priority_peer_evictions(network_context: &NetworkContext) {
+    APTOS_PRIORITY_PEER_EVICTIONS
+        .with_label_values(&[
+            network_context.role().as_str(),
+            network_context.network_id().as_str(),
+        ])
+        .inc();
+}
+
 pub static APTOS_NETWORK_PEER_CONNECTED: Lazy<IntGaugeVec> = Lazy::new(|| {
     register_int_gauge_vec!(
         "aptos_network_peer_connected",

--- a/network/framework/src/peer_manager/builder.rs
+++ b/network/framework/src/peer_manager/builder.rs
@@ -81,6 +81,7 @@ struct PeerManagerContext {
     inbound_connection_limit: usize,
     tcp_buffer_cfg: TCPBufferCfg,
     access_control_policy: Option<Arc<AccessControlPolicy>>,
+    priority_inbound_peers: Vec<PeerId>,
 }
 
 impl PeerManagerContext {
@@ -104,6 +105,7 @@ impl PeerManagerContext {
         inbound_connection_limit: usize,
         tcp_buffer_cfg: TCPBufferCfg,
         access_control_policy: Option<Arc<AccessControlPolicy>>,
+        priority_inbound_peers: Vec<PeerId>,
     ) -> Self {
         Self {
             pm_reqs_tx,
@@ -121,6 +123,7 @@ impl PeerManagerContext {
             inbound_connection_limit,
             tcp_buffer_cfg,
             access_control_policy,
+            priority_inbound_peers,
         }
     }
 
@@ -179,6 +182,7 @@ impl PeerManagerBuilder {
         inbound_connection_limit: usize,
         tcp_buffer_cfg: TCPBufferCfg,
         access_control_policy: Option<Arc<AccessControlPolicy>>,
+        priority_inbound_peers: Vec<PeerId>,
     ) -> Self {
         // Setup channel to send requests to peer manager.
         let (pm_reqs_tx, pm_reqs_rx) = aptos_channel::new(
@@ -214,6 +218,7 @@ impl PeerManagerBuilder {
                 inbound_connection_limit,
                 tcp_buffer_cfg,
                 access_control_policy,
+                priority_inbound_peers,
             )),
             peer_manager: None,
             listen_address,
@@ -348,6 +353,7 @@ impl PeerManagerBuilder {
             pm_context.max_message_size,
             pm_context.inbound_connection_limit,
             pm_context.access_control_policy,
+            pm_context.priority_inbound_peers,
         );
 
         // PeerManager constructor appends a public key to the listen_address.


### PR DESCRIPTION
## Description
This PR adds priority inbound peer support to the network configs. Specifically, it allows nodes to specify priority inbound peers that should always be allowed to connect, even when the inbound connection limit has been reached. 

When a priority peer attempts to connect and all slots are full, the system will randomly evict a non-priority peer to make room. Note: if all peers are priority peers, then no connections will be evicted, and the new connection attempt will fail.

## Testing Plan
New and existing test infrastructure.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core inbound connection admission logic in `PeerManager` by adding eviction behavior, which could affect network stability and peer churn if misconfigured or if eviction edge cases occur.
> 
> **Overview**
> Adds `NetworkConfig.priority_inbound_peers` and plumbs it through `NetworkBuilder`/`PeerManagerBuilder` into `PeerManager`.
> 
> When the unknown inbound connection limit is exceeded, inbound connections from configured *priority peers* are now accepted by randomly evicting an existing inbound, `PeerRole::Unknown`, non-priority peer; if no evictable peer exists, the priority connection is rejected as before. This also refactors disconnect handling into a shared internal path and introduces a new `aptos_priority_peer_evictions` counter plus targeted unit tests covering accept/evict/reject and eviction randomness/cleanup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6b23c768471979cb1a97bcbc1b81ef2b12a42bb1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->