### PR TITLE
Try to fix secret_share_manager queue backlog problem

### DIFF
--- a/consensus/src/rand/secret_sharing/secret_share_manager.rs
+++ b/consensus/src/rand/secret_sharing/secret_share_manager.rs
@@ -116,9 +116,11 @@ impl SecretShareManager {
         let mut share_requester_handles = Vec::new();
         let mut pending_secret_key_rounds = HashSet::new();
         for block in blocks.ordered_blocks.iter() {
-            let handle = self.process_incoming_block(block).await?;
-            share_requester_handles.push(handle);
-            pending_secret_key_rounds.insert(block.round());
+            if block.secret_shared_key().is_none() {
+                let handle = self.process_incoming_block(block).await?;
+                share_requester_handles.push(handle);
+                pending_secret_key_rounds.insert(block.round());
+            }
         }
 
         let queue_item = QueueItem::new(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small, localized conditional change that only bypasses redundant secret-sharing work when a key is already present.
> 
> **Overview**
> Skips secret-sharing processing for incoming blocks that already carry a `secret_shared_key`, avoiding spawning share-request tasks and marking those rounds as pending.
> 
> This reduces unnecessary work and helps prevent `SecretShareManager`’s `BlockQueue` from backing up on already-secret-shared blocks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8701f7b17d22b65c2fc51ad7d5103d34a525d2da. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->