### PR TITLE
[execution] Fetch persisted auxiliary info in replay-benchmark download

### DIFF
--- a/aptos-move/replay-benchmark/src/commands/download.rs
+++ b/aptos-move/replay-benchmark/src/commands/download.rs
@@ -6,7 +6,7 @@ use crate::{
     workload::TransactionBlock,
 };
 use anyhow::{anyhow, bail};
-use aptos_types::transaction::{Transaction, Version};
+use aptos_types::transaction::{PersistedAuxiliaryInfo, Transaction, Version};
 use clap::Parser;
 use std::path::PathBuf;
 use tokio::fs;
@@ -50,7 +50,7 @@ impl DownloadCommand {
         // Explicitly get transaction corresponding to the end, so we can verify that blocks are
         // fully selected.
         let limit = self.end_version - self.begin_version + 1;
-        let (mut txns, _, _) = debugger
+        let (mut txns, _, mut auxiliary_infos) = debugger
             .get_committed_transactions(self.begin_version, limit)
             .await?;
 
@@ -67,8 +67,10 @@ impl DownloadCommand {
                 self.end_version - 1
             );
         }
+        // Remove auxiliary info for the popped end transaction.
+        auxiliary_infos.pop();
 
-        let txn_blocks = partition(self.begin_version, txns);
+        let txn_blocks = partition(self.begin_version, txns, auxiliary_infos);
         println!(
             "Downloaded {} blocks with {} transactions in total: versions [{}, {})",
             txn_blocks.len(),
@@ -84,28 +86,38 @@ impl DownloadCommand {
     }
 }
 
-/// Partitions a sequence of transactions into blocks.
-fn partition(begin_version: Version, txns: Vec<Transaction>) -> Vec<TransactionBlock> {
+/// Partitions a sequence of transactions (and their auxiliary infos) into blocks.
+fn partition(
+    begin_version: Version,
+    txns: Vec<Transaction>,
+    auxiliary_infos: Vec<PersistedAuxiliaryInfo>,
+) -> Vec<TransactionBlock> {
+    assert_eq!(txns.len(), auxiliary_infos.len());
+
     let mut begin_versions_and_blocks = Vec::with_capacity(txns.len());
 
     let mut curr_begin = begin_version;
     let mut curr_block = Vec::with_capacity(txns.len());
+    let mut curr_aux_infos = Vec::with_capacity(txns.len());
 
-    for txn in txns {
+    for (txn, aux_info) in txns.into_iter().zip(auxiliary_infos) {
         if txn.is_block_start() && !curr_block.is_empty() {
             let block_size = curr_block.len();
             begin_versions_and_blocks.push(TransactionBlock {
                 begin_version: curr_begin,
                 transactions: std::mem::take(&mut curr_block),
+                persisted_auxiliary_infos: std::mem::take(&mut curr_aux_infos),
             });
             curr_begin += block_size as Version;
         }
         curr_block.push(txn);
+        curr_aux_infos.push(aux_info);
     }
     if !curr_block.is_empty() {
         begin_versions_and_blocks.push(TransactionBlock {
             begin_version: curr_begin,
             transactions: curr_block,
+            persisted_auxiliary_infos: curr_aux_infos,
         });
     }
 
@@ -175,20 +187,32 @@ mod tests {
         Transaction::BlockMetadata(block_metadata)
     }
 
+    fn aux_infos(n: usize) -> Vec<PersistedAuxiliaryInfo> {
+        (0..n)
+            .map(|i| PersistedAuxiliaryInfo::V1 {
+                transaction_index: i as u32,
+            })
+            .collect()
+    }
+
     #[test]
     fn test_block_partition_1() {
         let txns = vec![block_metadata(), block_metadata(), block_metadata()];
-        let blocks = partition(1, txns);
+        let infos = aux_infos(txns.len());
+        let blocks = partition(1, txns, infos);
         assert_eq!(blocks.len(), 3);
 
         assert_eq!(blocks[0].begin_version, 1);
         assert_eq!(blocks[0].transactions.len(), 1);
+        assert_eq!(blocks[0].persisted_auxiliary_infos.len(), 1);
 
         assert_eq!(blocks[1].begin_version, 2);
         assert_eq!(blocks[1].transactions.len(), 1);
+        assert_eq!(blocks[1].persisted_auxiliary_infos.len(), 1);
 
         assert_eq!(blocks[2].begin_version, 3);
         assert_eq!(blocks[2].transactions.len(), 1);
+        assert_eq!(blocks[2].persisted_auxiliary_infos.len(), 1);
     }
 
     #[test]
@@ -202,24 +226,29 @@ mod tests {
             user_transaction(),
             user_transaction(),
         ];
+        let infos = aux_infos(txns.len());
 
-        let blocks = partition(0, txns);
+        let blocks = partition(0, txns, infos);
         assert_eq!(blocks.len(), 2);
 
         assert_eq!(blocks[0].begin_version, 0);
         assert_eq!(blocks[0].transactions.len(), 3);
+        assert_eq!(blocks[0].persisted_auxiliary_infos.len(), 3);
 
         assert_eq!(blocks[1].begin_version, 3);
         assert_eq!(blocks[1].transactions.len(), 4);
+        assert_eq!(blocks[1].persisted_auxiliary_infos.len(), 4);
     }
 
     #[test]
     fn test_block_partition_3() {
         let txns = vec![user_transaction(), user_transaction(), user_transaction()];
-        let blocks = partition(10, txns);
+        let infos = aux_infos(txns.len());
+        let blocks = partition(10, txns, infos);
         assert_eq!(blocks.len(), 1);
 
         assert_eq!(blocks[0].begin_version, 10);
         assert_eq!(blocks[0].transactions.len(), 3);
+        assert_eq!(blocks[0].persisted_auxiliary_infos.len(), 3);
     }
 }


### PR DESCRIPTION
## Summary
- The replay-benchmark download command was discarding `PersistedAuxiliaryInfo` returned by `get_committed_transactions()`, causing benchmarks to always use empty auxiliary info (`PersistedAuxiliaryInfo::None`)
- Now captures auxiliary infos during download, partitions them alongside transactions into blocks, and serializes them to disk
- `Workload::from(TransactionBlock)` uses `DefaultTxnProvider::new()` with the real auxiliary infos instead of `new_without_info()`
- Added `#[serde(default)]` on the new field for backward compatibility with previously downloaded transaction files

## Test plan
- [x] All 13 existing tests in `aptos-replay-benchmark` pass (including updated partition tests)
- [x] `cargo check -p aptos-replay-benchmark` succeeds
- [ ] Manual test: download transactions and verify auxiliary infos are serialized in the output file

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped change to benchmark data serialization and in-memory provider construction; main risk is misaligned aux-info/txn vectors leading to incorrect replay behavior, but logic is straightforward and covered by updated tests.
> 
> **Overview**
> Replay-benchmark downloads now retain and serialize `PersistedAuxiliaryInfo` alongside transactions, partitioning auxiliary infos into the same on-disk `TransactionBlock`s (and keeping vectors aligned when trimming the end sentinel).
> 
> `Workload::from(TransactionBlock)` now uses the persisted infos to build a `DefaultTxnProvider` with real `AuxiliaryInfo` when present, while keeping backward compatibility via `#[serde(default)]` for older transaction files; partitioning tests were updated accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b9f2376f4339c69cf99b4d33fff9ea5208fbaaab. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->