### PR TITLE
[Storage] Reduce RocksDB property reporter overhead

### DIFF
--- a/storage/aptosdb/src/rocksdb_property_reporter.rs
+++ b/storage/aptosdb/src/rocksdb_property_reporter.rs
@@ -37,20 +37,8 @@ static ROCKSDB_PROPERTY_MAP: Lazy<HashMap<&str, String>> = Lazy::new(|| {
         "rocksdb.cur-size-active-mem-table",
         "rocksdb.cur-size-all-mem-tables",
         "rocksdb.size-all-mem-tables",
-        "rocksdb.num-entries-active-mem-table",
-        "rocksdb.num-entries-imm-mem-tables",
-        "rocksdb.num-deletes-active-mem-table",
-        "rocksdb.num-deletes-imm-mem-tables",
-        "rocksdb.estimate-num-keys",
         "rocksdb.estimate-table-readers-mem",
-        "rocksdb.is-file-deletions-enabled",
-        "rocksdb.num-snapshots",
-        "rocksdb.oldest-snapshot-time",
-        "rocksdb.num-live-versions",
-        "rocksdb.current-super-version-number",
         "rocksdb.estimate-live-data-size",
-        "rocksdb.min-log-number-to-keep",
-        "rocksdb.min-obsolete-sst-number-to-keep",
         "rocksdb.total-sst-files-size",
         "rocksdb.live-sst-files-size",
         "rocksdb.base-level",
@@ -61,7 +49,6 @@ static ROCKSDB_PROPERTY_MAP: Lazy<HashMap<&str, String>> = Lazy::new(|| {
         "rocksdb.is-write-stopped",
         "rocksdb.block-cache-capacity",
         "rocksdb.block-cache-usage",
-        "rocksdb.block-cache-pinned-usage",
     ]
     .iter()
     .map(|x| (*x, format!("aptos_{}", x.replace('.', "_"))))
@@ -165,8 +152,8 @@ impl RocksdbPropertyReporter {
                     "Updating rocksdb property failed."
                 );
             }
-            // report rocksdb properties each 10 seconds
-            const TIMEOUT_MS: u64 = if cfg!(test) { 10 } else { 10000 };
+            // report rocksdb properties each 60 seconds
+            const TIMEOUT_MS: u64 = if cfg!(test) { 10 } else { 60000 };
 
             match recv.recv_timeout(Duration::from_millis(TIMEOUT_MS)) {
                 Ok(_) => break,


### PR DESCRIPTION

Each invocation of the property reporter takes 10–15 seconds in production
(sometimes nearly 20), causing the reporter thread to consume roughly half a
core just for metrics collection.

Remove 13 low-value properties from `RocksdbPropertyReporter` and increase the
reporting interval from 10s to 60s.

The most impactful removal is `rocksdb.block-cache-pinned-usage`, which performs
a full O(cache_size) scan of the shared HyperClockCache **while holding the
per-DB mutex**, directly blocking concurrent writes. The remaining removed
properties (`num-entries-*`, `num-deletes-*`, `estimate-num-keys`,
`num-snapshots`, `num-live-versions`, etc.) still acquire the per-DB mutex on
each call but are rarely consulted and provide little actionable benefit.

- Properties queried per cycle: 32 → 19 (~41% fewer)
- Sleep between cycles: 10s → 60s

For reference, removing the property reporter entirely and running the executor
benchmark (20 baseline vs 20 test runs, 10M txns each) showed +3.3% overall
TPS and +13.2% commit TPS (p < 0.001, Cohen's d = 1.64). This commit should
capture most of that improvement.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metrics-only change that reduces sampling frequency and queried properties; main risk is losing visibility into the removed RocksDB metrics.
> 
> **Overview**
> Reduces `RocksdbPropertyReporter` overhead by removing a set of RocksDB properties from `ROCKSDB_PROPERTY_MAP` (including `rocksdb.block-cache-pinned-usage` and several entry/delete/snapshot-related stats), lowering the number of per-CF/per-shard `get_property` calls made each cycle.
> 
> Increases the production reporting interval from 10s to 60s (tests remain effectively unchanged), reducing mutex contention and background CPU spent on metrics collection.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b24e3e7cf4f5d4cecdb6ee7a6d23dba7e5d5e669. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->