### PR TITLE
[storage] Update hot state deferred merge metrics more frequently

### DIFF
--- a/storage/aptosdb/src/state_store/hot_state.rs
+++ b/storage/aptosdb/src/state_store/hot_state.rs
@@ -10,11 +10,12 @@ use aptos_metrics_core::{IntCounterVecHelper, IntGaugeVecHelper, TimerHelper};
 use aptos_storage_interface::state_store::{
     state::State, state_delta::StateDelta, state_view::hot_state_view::HotStateView,
 };
-use aptos_types::state_store::{
-    hot_state::THotStateSlot, state_key::StateKey, state_slot::StateSlot, NUM_STATE_SHARDS,
+use aptos_types::{
+    state_store::{
+        hot_state::THotStateSlot, state_key::StateKey, state_slot::StateSlot, NUM_STATE_SHARDS,
+    },
+    transaction::Version,
 };
-#[cfg(test)]
-use aptos_types::transaction::Version;
 use arr_macro::arr;
 use dashmap::{mapref::one::Ref, DashMap};
 #[cfg(test)]
@@ -343,8 +344,6 @@ impl Committer {
                 }
             }
 
-            let committed_version = to_commit.next_version();
-
             // Build a layered view: delta(merged_state -> to_commit) over base DashMaps.
             let delta = to_commit.make_delta(&self.merged_state);
             let new_view = Arc::new(LayeredHotStateView {
@@ -360,18 +359,6 @@ impl Committer {
             }
 
             self.try_merge();
-
-            GAUGE.set_with(&["hot_state_items"], self.base.len() as i64);
-            GAUGE.set_with(&["hot_state_key_bytes"], self.total_key_bytes as i64);
-            GAUGE.set_with(&["hot_state_value_bytes"], self.total_value_bytes as i64);
-            GAUGE.set_with(
-                &["hot_state_deferred_merge_old_views"],
-                self.old_views.len() as i64,
-            );
-            GAUGE.set_with(
-                &["hot_state_deferred_merge_version_lag"],
-                (committed_version - self.merged_state.next_version()) as i64,
-            );
         }
 
         self.try_merge(); // flush any remaining deferred merge before exit
@@ -456,11 +443,13 @@ impl Committer {
     fn try_merge(&mut self) -> bool {
         self.old_views.retain(|v| v.strong_count() > 0);
         if !self.old_views.is_empty() {
+            self.update_deferred_merge_gauges(self.committed.lock().state.next_version());
             return false;
         }
 
         let target = self.committed.lock().state.clone();
         if self.merged_state.is_the_same(&target) {
+            self.update_deferred_merge_gauges(self.merged_state.next_version());
             return true;
         }
 
@@ -480,7 +469,20 @@ impl Committer {
             base: Arc::clone(&self.base),
         });
         Self::swap_view(&mut self.old_views, &mut self.committed.lock(), clean_view);
+        self.update_deferred_merge_gauges(self.merged_state.next_version());
+
         true
+    }
+
+    fn update_deferred_merge_gauges(&self, committed_version: Version) {
+        GAUGE.set_with(
+            &["hot_state_deferred_merge_old_views"],
+            self.old_views.len() as i64,
+        );
+        GAUGE.set_with(
+            &["hot_state_deferred_merge_version_lag"],
+            (committed_version - self.merged_state.next_version()) as i64,
+        );
     }
 
     /// Apply the delta between `merged_state` and `target` to the base DashMaps.
@@ -524,6 +526,9 @@ impl Committer {
         COUNTER.inc_with_by(&["hot_state_insert"], n_insert);
         COUNTER.inc_with_by(&["hot_state_update"], n_update);
         COUNTER.inc_with_by(&["hot_state_evict"], n_evict);
+        GAUGE.set_with(&["hot_state_items"], self.base.len() as i64);
+        GAUGE.set_with(&["hot_state_key_bytes"], self.total_key_bytes as i64);
+        GAUGE.set_with(&["hot_state_value_bytes"], self.total_value_bytes as i64);
     }
 
     /// Traverses the entire map and checks if all the pointers are correctly linked.


### PR DESCRIPTION

The `hot_state_deferred_merge_old_views` and `hot_state_deferred_merge_version_lag`
gauges were only updated at the end of each `run` iteration, right after publishing
a new commit. At that point `try_merge` typically fails because readers still hold
the previous view, so the metrics always showed `old_views=1` and a non-zero version
lag (equal to the batch size), even though the merge succeeds a few milliseconds
later in `next_to_commit`'s timeout retry loop.

- Extract `update_deferred_merge_gauges()` helper to avoid duplication.
- Call it in `try_merge` on both the success path (lag=0 after merge) and the
  `return false` path (accurate lag while blocked by lingering readers).
- Move `hot_state_items` / `hot_state_key_bytes` / `hot_state_value_bytes` gauges
  into `apply_delta_to_base`, since that's the only place that mutates DashMaps
  and byte counters.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metrics-only refactor with minor control-flow changes around when gauges are updated; no changes to merge logic or persisted data paths.
> 
> **Overview**
> Improves hot-state deferred-merge observability by updating `hot_state_deferred_merge_old_views` and `hot_state_deferred_merge_version_lag` inside `try_merge()` on both blocked and success paths, rather than only after publishing a new commit.
> 
> Refactors metric updates by extracting `update_deferred_merge_gauges()` and moving `hot_state_items`/`hot_state_key_bytes`/`hot_state_value_bytes` gauge updates into `apply_delta_to_base()` (the only place that mutates the DashMaps/byte counters).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a81a6fddc31b2dc0fb0cc4a7496f6710e5fcf4ef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->