### PR TITLE
Development environment setup

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -317,15 +317,15 @@ Areas: `vm`, `framework`, `consensus`, `storage`, `api`, `network`, `types`, `cl
 
 ### System dependencies
 
-The VM snapshot includes all required system packages pre-installed. The update script (run automatically on VM startup) only refreshes Rust toolchains and cargo tools. If a fresh VM image is ever rebuilt from scratch, these apt packages are required: `lld`, `libssl-dev`, `libudev-dev`, `libdw-dev`, `libpq-dev`, `libstdc++-14-dev`, `build-essential`. Protoc 3.21.4 must be at `/usr/local/bin/protoc`.
+The update script runs `scripts/dev_setup.sh -b -k` on each VM startup to install/refresh all build tools (Rust toolchains, clang, protoc, cargo-sort, cargo-machete, cargo-nextest, grcov, etc.). Two extra packages (`libstdc++-14-dev`, `libpq-dev`) are installed separately since `dev_setup.sh` does not cover them by default.
 
 ### Key gotchas
 
-- **clang++ C++ headers**: The environment ships clang 18 which selects GCC 14 headers. `libstdc++-14-dev` must be installed or RocksDB (used by storage) will fail to compile with `'memory' file not found`.
+- **clang++ C++ headers**: `libstdc++-14-dev` must be installed or RocksDB will fail to compile with `'memory' file not found`. This happens because clang selects GCC 14 headers but only GCC 13 headers may be present.
 - **`cargo xclippy`** is a workspace-wide alias defined in `.cargo/config.toml`. It does **not** accept `-p <package>`. To lint a single package, use `cargo clippy -p <package>` with the appropriate allow/deny flags from the alias definition.
 - **`cargo +nightly fmt`** is used for formatting (not stable fmt). The nightly toolchain must have the `rustfmt` component.
-- **cargo-sort** (v1.0.7) and **cargo-machete** (v0.7.0) are needed for the full `./scripts/rust_lint.sh` pipeline.
 - **Localnet startup** takes ~60s for the first run (compilation is the bottleneck). Subsequent starts (with binary already built) are fast. Use `--no-txn-stream` to skip the transaction stream service which requires no additional dependencies.
+- The `-k` flag skips pre-commit hook installation in `dev_setup.sh` since cloud agents don't need git hooks.
 
 ### Running services
 

--- a/agents.md
+++ b/agents.md
@@ -317,14 +317,14 @@ Areas: `vm`, `framework`, `consensus`, `storage`, `api`, `network`, `types`, `cl
 
 ### System dependencies
 
-The update script runs `scripts/dev_setup.sh -b -k` on each VM startup to install/refresh all build tools (Rust toolchains, clang, protoc, cargo-sort, cargo-machete, cargo-nextest, grcov, etc.). Two extra packages (`libstdc++-14-dev`, `libpq-dev`) are installed separately since `dev_setup.sh` does not cover them by default.
+The VM’s startup/update script (managed by the Cursor Cloud environment, not this repo) runs `./scripts/dev_setup.sh -b -k` on each VM startup to install/refresh all build tools (Rust toolchains, clang, protoc, cargo-sort, cargo-machete, cargo-nextest, grcov, etc.). Two extra packages (`libstdc++-14-dev`, `libpq-dev`) are installed separately because this specific `./scripts/dev_setup.sh -b -k` invocation does not install them by default (they are only installed when `dev_setup.sh` is run with additional flags such as `-P` for PostgreSQL support).
 
 ### Key gotchas
 
 - **clang++ C++ headers**: `libstdc++-14-dev` must be installed or RocksDB will fail to compile with `'memory' file not found`. This happens because clang selects GCC 14 headers but only GCC 13 headers may be present.
 - **`cargo xclippy`** is a workspace-wide alias defined in `.cargo/config.toml`. It does **not** accept `-p <package>`. To lint a single package, use `cargo clippy -p <package>` with the appropriate allow/deny flags from the alias definition.
 - **`cargo +nightly fmt`** is used for formatting (not stable fmt). The nightly toolchain must have the `rustfmt` component.
-- **Localnet startup** takes ~60s for the first run (compilation is the bottleneck). Subsequent starts (with binary already built) are fast. Use `--no-txn-stream` to skip the transaction stream service which requires no additional dependencies.
+- **Localnet startup** takes ~60s for the first run (compilation is the bottleneck). Subsequent starts (with binary already built) are fast. Use `--no-txn-stream` to skip the transaction stream gRPC service, which is not required for basic local testing and slightly reduces resource usage.
 - The `-k` flag skips pre-commit hook installation in `dev_setup.sh` since cloud agents don't need git hooks.
 
 ### CI lint gate

--- a/agents.md
+++ b/agents.md
@@ -327,6 +327,10 @@ The update script runs `scripts/dev_setup.sh -b -k` on each VM startup to instal
 - **Localnet startup** takes ~60s for the first run (compilation is the bottleneck). Subsequent starts (with binary already built) are fast. Use `--no-txn-stream` to skip the transaction stream service which requires no additional dependencies.
 - The `-k` flag skips pre-commit hook installation in `dev_setup.sh` since cloud agents don't need git hooks.
 
+### CI lint gate
+
+`./scripts/rust_lint.sh` must pass in full before pushing PRs — it is a required CI check. Run it locally to catch issues early. It executes clippy (`cargo xclippy`), formatting (`cargo +nightly fmt --check`), dependency sorting (`cargo sort --grouped --workspace --check`), and unused-dependency detection (`cargo machete`). Use `./scripts/rust_lint.sh --check` for a check-only (non-modifying) run.
+
 ### Running services
 
 - **Localnet (validator + faucet)**: `cargo run -p aptos -- node run-localnet --force-restart --assume-yes --no-txn-stream`

--- a/agents.md
+++ b/agents.md
@@ -312,3 +312,25 @@ Example:
 ```
 
 Areas: `vm`, `framework`, `consensus`, `storage`, `api`, `network`, `types`, `cli`, `docs`, `test`
+
+## Cursor Cloud specific instructions
+
+### System dependencies
+
+The VM snapshot includes all required system packages pre-installed. The update script (run automatically on VM startup) only refreshes Rust toolchains and cargo tools. If a fresh VM image is ever rebuilt from scratch, these apt packages are required: `lld`, `libssl-dev`, `libudev-dev`, `libdw-dev`, `libpq-dev`, `libstdc++-14-dev`, `build-essential`. Protoc 3.21.4 must be at `/usr/local/bin/protoc`.
+
+### Key gotchas
+
+- **clang++ C++ headers**: The environment ships clang 18 which selects GCC 14 headers. `libstdc++-14-dev` must be installed or RocksDB (used by storage) will fail to compile with `'memory' file not found`.
+- **`cargo xclippy`** is a workspace-wide alias defined in `.cargo/config.toml`. It does **not** accept `-p <package>`. To lint a single package, use `cargo clippy -p <package>` with the appropriate allow/deny flags from the alias definition.
+- **`cargo +nightly fmt`** is used for formatting (not stable fmt). The nightly toolchain must have the `rustfmt` component.
+- **cargo-sort** (v1.0.7) and **cargo-machete** (v0.7.0) are needed for the full `./scripts/rust_lint.sh` pipeline.
+- **Localnet startup** takes ~60s for the first run (compilation is the bottleneck). Subsequent starts (with binary already built) are fast. Use `--no-txn-stream` to skip the transaction stream service which requires no additional dependencies.
+
+### Running services
+
+- **Localnet (validator + faucet)**: `cargo run -p aptos -- node run-localnet --force-restart --assume-yes --no-txn-stream`
+  - REST API: `http://127.0.0.1:8080`
+  - Faucet: `http://127.0.0.1:8081`
+  - Readiness: `http://127.0.0.1:8070`
+- See `CLAUDE.md` for build, test, and lint commands.


### PR DESCRIPTION
## Description
This PR streamlines the development environment setup by leveraging `scripts/dev_setup.sh` and updates the relevant documentation.

The changes include:
*   Running `scripts/dev_setup.sh -b -k` to install/update system dependencies (e.g., clang-21, protoc 3.21.4), Rust toolchains, and cargo tools (`cargo-sort`, `cargo-machete`, `cargo-nextest`, `grcov`).
*   Updating `agents.md` with Cloud-specific instructions that now reference `scripts/dev_setup.sh` for environment setup.
*   Updating the VM environment setup to use `scripts/dev_setup.sh` as the primary setup mechanism, complemented by explicit installation of `libstdc++-14-dev` and `libpq-dev`.

This ensures a consistent and automated approach to setting up the development environment.

## How Has This Been Tested?
The environment setup was thoroughly tested:
*   `scripts/dev_setup.sh -b -k` executed successfully.
*   Verified C++ headers resolve correctly with clang-21 using `clang++ -std=c++17`.
*   Confirmed RocksDB (via `aptos-schemadb`) compiles successfully with the new clang version using `cargo check -p aptos-schemadb`.
*   Verified `protoc --version` reports `libprotoc 3.21.4`.
*   Confirmed the presence of all required cargo tools (`cargo-sort`, `cargo-machete`, `cargo-nextest`, `grcov`).
*   An initial "hello world" demonstration was performed, including building the Aptos CLI, running a localnet, creating/funding accounts, and executing a coin transfer.

## Key Areas to Review
*   **`agents.md`**: Review the updated Cloud-specific instructions to ensure clarity and accuracy for new developers setting up their environment.
*   **VM Setup Logic**: While not directly in the diff, the underlying VM setup script logic was updated to use `dev_setup.sh`. Ensure the combination of `dev_setup.sh` and additional package installations (`libstdc++-14-dev`, `libpq-dev`) covers all necessary dependencies.

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [x] Refactoring
- [x] Dependency update
- [x] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [x] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

---
<p><a href="https://cursor.com/agents/bc-37593685-961e-4f89-b88b-d66846fec11b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-37593685-961e-4f89-b88b-d66846fec11b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

