### PR TITLE
[node] Name all unnamed threads on the aptos-node path

### DIFF
--- a/aptos-node/src/lib.rs
+++ b/aptos-node/src/lib.rs
@@ -206,6 +206,7 @@ pub struct AptosHandle {
     _dkg_runtime: Option<Runtime>,
     _indexer_grpc_runtime: Option<Runtime>,
     _indexer_table_info_runtime: Option<Runtime>,
+    _inspection_service_runtime: Runtime,
     _jwk_consensus_runtime: Option<Runtime>,
     _mempool_runtime: Runtime,
     _network_runtimes: Vec<Runtime>,
@@ -769,7 +770,7 @@ pub fn setup_environment_and_start_node(
         )?;
 
     // Start the node inspection service
-    services::start_node_inspection_service(
+    let inspection_service_runtime = services::start_node_inspection_service(
         &node_config,
         aptos_data_client,
         peers_and_metadata.clone(),
@@ -859,6 +860,7 @@ pub fn setup_environment_and_start_node(
         _dkg_runtime: dkg_runtime,
         _indexer_grpc_runtime: indexer_grpc_runtime,
         _indexer_table_info_runtime: indexer_table_info_runtime,
+        _inspection_service_runtime: inspection_service_runtime,
         _jwk_consensus_runtime: jwk_consensus_runtime,
         _mempool_runtime: mempool_runtime,
         _network_runtimes: network_runtimes,

--- a/aptos-node/src/services.rs
+++ b/aptos-node/src/services.rs
@@ -202,12 +202,12 @@ pub fn start_admin_service(node_config: &NodeConfig) -> AdminService {
     AdminService::new(node_config)
 }
 
-/// Spawns a new thread for the node inspection service
+/// Starts the node inspection service and returns the runtime
 pub fn start_node_inspection_service(
     node_config: &NodeConfig,
     aptos_data_client: AptosDataClient,
     peers_and_metadata: Arc<PeersAndMetadata>,
-) {
+) -> Runtime {
     aptos_inspection_service::start_inspection_service(
         node_config.clone(),
         aptos_data_client,

--- a/consensus/safety-rules/src/thread.rs
+++ b/consensus/safety-rules/src/thread.rs
@@ -31,7 +31,10 @@ impl ThreadService {
         let listen_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), listen_port);
         let server_addr = listen_addr;
 
-        let child = thread::spawn(move || remote_service::execute(storage, listen_addr, timeout));
+        let child = thread::Builder::new()
+            .name("safety-rules".into())
+            .spawn(move || remote_service::execute(storage, listen_addr, timeout))
+            .expect("failed to spawn safety-rules thread");
 
         Self {
             _child: child,

--- a/crates/aptos-logger/src/aptos_logger.rs
+++ b/crates/aptos-logger/src/aptos_logger.rs
@@ -474,7 +474,10 @@ impl AptosDataBuilder {
                 remote_tx,
             };
 
-            thread::spawn(move || service.run());
+            thread::Builder::new()
+                .name("logger-svc".into())
+                .spawn(move || service.run())
+                .expect("failed to spawn logger-svc thread");
             logger
         } else {
             Arc::new(AptosData {

--- a/storage/indexer/src/db_indexer.rs
+++ b/storage/indexer/src/db_indexer.rs
@@ -329,10 +329,13 @@ impl DBIndexer {
 
         let db = indexer_db.get_inner_db_ref().to_owned();
         let internal_indexer_db = db.clone();
-        let committer_handle = thread::spawn(move || {
-            let committer = DBCommitter::new(db, reciver);
-            committer.run();
-        });
+        let committer_handle = thread::Builder::new()
+            .name("db-idx-commit".into())
+            .spawn(move || {
+                let committer = DBCommitter::new(db, reciver);
+                committer.run();
+            })
+            .expect("failed to spawn db-idx-commit thread");
 
         Self {
             indexer_db,


### PR DESCRIPTION

Unnamed threads make debugging harder — stack traces, `/proc/<pid>/task/*/comm`,
and logging all show unhelpful default names. This names all `thread::spawn` calls
on the aptos-node execution path using `thread::Builder::new().name(...)`.

Changes:
- `rocksdb_property_reporter.rs`: named `"rocksdb-prop"`
- `db_indexer.rs`: named `"db-idx-commit"`
- `aptos_logger.rs`: named `"logger-svc"`
- `safety-rules/thread.rs`: named `"safety-rules"`
- `inspection-service/server/mod.rs`: refactored from `thread::spawn` +
  `runtime.block_on()` to `runtime.spawn()`, returning the `Runtime` to the
  caller (stored in `AptosHandle`), consistent with every other service in
  aptos-node. This eliminates the unnamed thread entirely.

All names are ≤15 chars to fit the Linux `comm` limit.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly operational/debuggability changes (thread naming and runtime ownership) with minimal impact on business logic; primary risk is inadvertently changing inspection service lifecycle/shutdown behavior.
> 
> **Overview**
> Ensures background threads on the `aptos-node` execution path have stable, human-readable names to improve debuggability in stack traces and `/proc`.
> 
> Replaces several `thread::spawn` calls with `thread::Builder::name(...).spawn(...)` (logger service, safety rules thread service, RocksDB property reporter, and internal indexer DB committer). The node inspection service is refactored to run via `runtime.spawn()` and now returns its `Runtime`, which is stored in `AptosHandle` to keep the service alive instead of relying on an unnamed OS thread.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8f84e104e616c23348c80fdd13e88b1ad8946089. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->