### PR TITLE
[storage] Distinguish hot vs cold metrics in StateMerkleDb and StateKvDb

### DIFF
--- a/storage/aptosdb/src/metrics.rs
+++ b/storage/aptosdb/src/metrics.rs
@@ -137,7 +137,7 @@ make_thread_local_histogram_vec!(
     // metric description
     "Latency of node cache.",
     // metric labels (dimensions)
-    &["tag", "name"],
+    &["tag", "name", "db_type"],
     exponential_buckets(/*start=*/ 1e-9, /*factor=*/ 2.0, /*count=*/ 30).unwrap(),
 );
 

--- a/storage/aptosdb/src/state_merkle_db.rs
+++ b/storage/aptosdb/src/state_merkle_db.rs
@@ -75,9 +75,18 @@ pub struct StateMerkleDb {
     version_caches: HashMap<Option<usize>, VersionedNodeCache>,
     // `None` means the cache is not enabled.
     lru_cache: Option<LruNodeCache>,
+    is_hot: bool,
 }
 
 impl StateMerkleDb {
+    fn db_tag(&self) -> &'static str {
+        if self.is_hot {
+            "hot"
+        } else {
+            "cold"
+        }
+    }
+
     pub(crate) fn new(
         db_paths: &StorageDirPaths,
         state_merkle_db_config: RocksdbConfig,
@@ -308,7 +317,10 @@ impl StateMerkleDb {
         tree_update_batch: &TreeUpdateBatch<StateKey>,
         previous_epoch_ending_version: Option<Version>,
     ) -> Result<RawBatch> {
-        let _timer = OTHER_TIMERS_SECONDS.timer_with(&["create_jmt_commit_batch_for_shard"]);
+        let _timer = OTHER_TIMERS_SECONDS.timer_with(&[&format!(
+            "{}__create_jmt_commit_batch_for_shard",
+            self.db_tag()
+        )]);
 
         let mut batch = self.db(shard_id).new_native_batch();
 
@@ -423,7 +435,8 @@ impl StateMerkleDb {
         }
 
         let (shard_root_node, tree_update_batch) = {
-            let _timer = OTHER_TIMERS_SECONDS.timer_with(&["jmt_update"]);
+            let _timer =
+                OTHER_TIMERS_SECONDS.timer_with(&[&format!("{}__jmt_update", self.db_tag())]);
 
             self.batch_put_value_set_for_shard(
                 shard_id,
@@ -603,6 +616,7 @@ impl StateMerkleDb {
             state_merkle_db_shards,
             version_caches,
             lru_cache,
+            is_hot,
         };
 
         if !readonly {
@@ -794,8 +808,10 @@ impl TreeReader<StateKey> for StateMerkleDb {
             let node_opt = self
                 .db_by_key(node_key)
                 .get::<JellyfishMerkleNodeSchema>(node_key)?;
-            NODE_CACHE_SECONDS
-                .observe_with(&[tag, "cache_disabled"], start_time.elapsed().as_secs_f64());
+            NODE_CACHE_SECONDS.observe_with(
+                &[tag, "cache_disabled", self.db_tag()],
+                start_time.elapsed().as_secs_f64(),
+            );
             return Ok(node_opt);
         }
         if let Some(node_cache) = self
@@ -806,7 +822,7 @@ impl TreeReader<StateKey> for StateMerkleDb {
         {
             let node = node_cache.get(node_key).cloned();
             NODE_CACHE_SECONDS.observe_with(
-                &[tag, "versioned_cache_hit"],
+                &[tag, "versioned_cache_hit", self.db_tag()],
                 start_time.elapsed().as_secs_f64(),
             );
             return Ok(node);
@@ -814,8 +830,10 @@ impl TreeReader<StateKey> for StateMerkleDb {
 
         if let Some(lru_cache) = &self.lru_cache {
             if let Some(node) = lru_cache.get(node_key) {
-                NODE_CACHE_SECONDS
-                    .observe_with(&[tag, "lru_cache_hit"], start_time.elapsed().as_secs_f64());
+                NODE_CACHE_SECONDS.observe_with(
+                    &[tag, "lru_cache_hit", self.db_tag()],
+                    start_time.elapsed().as_secs_f64(),
+                );
                 return Ok(Some(node));
             }
         }
@@ -828,7 +846,10 @@ impl TreeReader<StateKey> for StateMerkleDb {
                 lru_cache.put(node_key.clone(), node.clone());
             }
         }
-        NODE_CACHE_SECONDS.observe_with(&[tag, "cache_miss"], start_time.elapsed().as_secs_f64());
+        NODE_CACHE_SECONDS.observe_with(
+            &[tag, "cache_miss", self.db_tag()],
+            start_time.elapsed().as_secs_f64(),
+        );
         Ok(node_opt)
     }
 
@@ -851,7 +872,8 @@ impl TreeReader<StateKey> for StateMerkleDb {
 
 impl TreeWriter<StateKey> for StateMerkleDb {
     fn write_node_batch(&self, node_batch: &NodeBatch) -> Result<()> {
-        let _timer = OTHER_TIMERS_SECONDS.timer_with(&["tree_writer_write_batch"]);
+        let _timer = OTHER_TIMERS_SECONDS
+            .timer_with(&[&format!("{}__tree_writer_write_batch", self.db_tag())]);
         // Get the top level batch and sharded batch from raw NodeBatch
         let mut top_level_batch = SchemaBatch::new();
         let mut jmt_shard_batches: Vec<SchemaBatch> = Vec::with_capacity(NUM_STATE_SHARDS);


### PR DESCRIPTION

Both hot and cold instances of `StateMerkleDb` and `StateKvDb` were recording
to the same Prometheus metrics with identical label values, making it impossible
to distinguish their performance characteristics (cache hit rates, commit
latencies, etc.).

Fix:
- Store `is_hot` in both structs and add a `db_tag()` helper returning
  `"hot"` or `"cold"`
- `NODE_CACHE_SECONDS`: add a `"db_type"` label dimension (only used by
  `StateMerkleDb`, so safe to evolve)
- `OTHER_TIMERS_SECONDS`: prefix timer `name` values with the db tag
  (e.g. `"hot__jmt_update"` vs `"cold__jmt_update"`), avoiding an
  invasive label change to this broadly-shared metric

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Metrics schema changes can break existing dashboards/alerts and increase series cardinality (new `db_type` label and renamed timer values), but runtime behavior is otherwise unchanged.
> 
> **Overview**
> Distinguishes **hot vs cold** `StateMerkleDb` and `StateKvDb` performance metrics so both instances no longer emit identical label sets.
> 
> `NODE_CACHE_SECONDS` gains a new `db_type` label and `StateMerkleDb` now records node-cache observations with `db_tag()` ("hot"/"cold"). For broader `OTHER_TIMERS_SECONDS`, timers in `StateMerkleDb` and `StateKvDb` are renamed by prefixing the existing `name` label value (e.g. `hot__jmt_update`, `cold__state_kv_db__commit`) to avoid a breaking label-schema change.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e3d1b1c2f922044044da600897596a18d829e6aa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->