### PR TITLE
[Storage] Add hot state cache age metrics

### DIFF
--- a/storage/aptosdb/src/metrics.rs
+++ b/storage/aptosdb/src/metrics.rs
@@ -6,6 +6,7 @@ use aptos_metrics_core::{
     register_histogram_vec, register_int_counter, register_int_counter_vec, register_int_gauge,
     register_int_gauge_vec, HistogramVec, IntCounter, IntCounterVec, IntGauge, IntGaugeVec,
 };
+use aptos_types::state_store::NUM_STATE_SHARDS;
 use once_cell::sync::Lazy;
 
 pub static LEDGER_COUNTER: Lazy<IntGaugeVec> = Lazy::new(|| {
@@ -258,6 +259,19 @@ pub static CONCURRENCY_GAUGE: Lazy<IntGaugeVec> = Lazy::new(|| {
 pub static GAUGE: Lazy<IntGaugeVec> = Lazy::new(|| {
     register_int_gauge_vec!("aptos_storage_gauge", "Various gauges", &["name"]).unwrap()
 });
+
+pub(crate) static HOT_STATE_SHARD_GAUGE: Lazy<IntGaugeVec> = Lazy::new(|| {
+    register_int_gauge_vec!(
+        "aptos_hot_state_shard_gauge",
+        "Per-shard gauges for the hot state cache.",
+        &["shard_id", "name"]
+    )
+    .unwrap()
+});
+
+pub(crate) const SHARD_NAME_BY_ID: [&str; NUM_STATE_SHARDS] = [
+    "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15",
+];
 
 make_thread_local_int_counter_vec!(
     pub,

--- a/storage/aptosdb/src/rocksdb_property_reporter.rs
+++ b/storage/aptosdb/src/rocksdb_property_reporter.rs
@@ -9,7 +9,9 @@ use crate::{
         transaction_info_db_column_families, write_set_db_column_families,
     },
     ledger_db::LedgerDb,
-    metrics::{OTHER_TIMERS_SECONDS, ROCKSDB_PROPERTIES, ROCKSDB_SHARD_PROPERTIES},
+    metrics::{
+        OTHER_TIMERS_SECONDS, ROCKSDB_PROPERTIES, ROCKSDB_SHARD_PROPERTIES, SHARD_NAME_BY_ID,
+    },
     state_kv_db::StateKvDb,
     state_merkle_db::StateMerkleDb,
 };
@@ -65,10 +67,6 @@ fn set_property(cf_name: &str, db: &DB) -> Result<()> {
     }
     Ok(())
 }
-
-const SHARD_NAME_BY_ID: [&str; NUM_STATE_SHARDS] = [
-    "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15",
-];
 
 fn set_shard_property(cf_name: ColumnFamilyName, db: &DB, shard: usize) -> Result<()> {
     if !skip_reporting_cf(cf_name) {

--- a/storage/aptosdb/src/state_store/hot_state.rs
+++ b/storage/aptosdb/src/state_store/hot_state.rs
@@ -1,7 +1,9 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-use crate::metrics::{COUNTER, GAUGE, OTHER_TIMERS_SECONDS};
+use crate::metrics::{
+    COUNTER, GAUGE, HOT_STATE_SHARD_GAUGE, OTHER_TIMERS_SECONDS, SHARD_NAME_BY_ID,
+};
 use anyhow::{ensure, Result};
 use aptos_config::config::HotStateConfig;
 use aptos_infallible::Mutex;
@@ -529,6 +531,47 @@ impl Committer {
         GAUGE.set_with(&["hot_state_items"], self.base.len() as i64);
         GAUGE.set_with(&["hot_state_key_bytes"], self.total_key_bytes as i64);
         GAUGE.set_with(&["hot_state_value_bytes"], self.total_value_bytes as i64);
+
+        self.report_age_metrics();
+    }
+
+    /// Reports per-shard MRU/LRU `hot_since_version` gauges and aggregate max/min LRU across shards.
+    fn report_age_metrics(&self) {
+        let mut global_min_lru: Option<Version> = None;
+        let mut global_max_lru: Option<Version> = None;
+
+        for (shard_id, shard_label) in SHARD_NAME_BY_ID.iter().enumerate() {
+            let mru_version = self.heads[shard_id].as_ref().map(|k| {
+                self.base.shards[shard_id]
+                    .get(k)
+                    .expect("head must exist in base")
+                    .expect_hot_since_version()
+            });
+            let lru_version = self.tails[shard_id].as_ref().map(|k| {
+                self.base.shards[shard_id]
+                    .get(k)
+                    .expect("tail must exist in base")
+                    .expect_hot_since_version()
+            });
+
+            if let Some(v) = mru_version {
+                HOT_STATE_SHARD_GAUGE
+                    .with_label_values(&[*shard_label, "mru_hot_since_version"])
+                    .set(v as i64);
+            }
+            if let Some(v) = lru_version {
+                HOT_STATE_SHARD_GAUGE
+                    .with_label_values(&[*shard_label, "lru_hot_since_version"])
+                    .set(v as i64);
+                global_min_lru = Some(global_min_lru.map_or(v, |cur| cur.min(v)));
+                global_max_lru = Some(global_max_lru.map_or(v, |cur| cur.max(v)));
+            }
+        }
+
+        if let (Some(max_lru), Some(min_lru)) = (global_max_lru, global_min_lru) {
+            GAUGE.set_with(&["hot_state_max_lru_hot_since_version"], max_lru as i64);
+            GAUGE.set_with(&["hot_state_min_lru_hot_since_version"], min_lru as i64);
+        }
     }
 
     /// Traverses the entire map and checks if all the pointers are correctly linked.


### PR DESCRIPTION

Report per-shard MRU/LRU `hot_since_version` gauges to help assess whether
the hot state cache capacity is adequate. A small version span between MRU
and LRU indicates items are being evicted too quickly (cache too small).

New metrics:
- `aptos_hot_state_shard_gauge{shard_id, name="mru_hot_since_version"}`
- `aptos_hot_state_shard_gauge{shard_id, name="lru_hot_since_version"}`
- `aptos_storage_gauge{name="hot_state_max_lru_hot_since_version"}` (aggregate)
- `aptos_storage_gauge{name="hot_state_min_lru_hot_since_version"}` (aggregate)

The aggregate metrics track the max and min LRU across shards rather than
MRU, since MRU versions are similar across shards (all near the latest
committed version). Max LRU identifies the shard under the most eviction
pressure (shallowest cache depth), which is more useful for capacity planning.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metrics-only changes (new gauges and shared constants) with minimal behavioral impact beyond extra reporting work in the hot state committer loop.
> 
> **Overview**
> Adds new metrics to track hot state cache *age* by reporting per-shard MRU/LRU `hot_since_version` via `aptos_hot_state_shard_gauge{shard_id,name}` and aggregate min/max LRU across shards via `aptos_storage_gauge`.
> 
> Centralizes shard label mapping by moving `SHARD_NAME_BY_ID` into `metrics.rs` and reusing it from both hot state metric reporting and RocksDB shard property reporting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a090ab825d9f4256aea89643c92328d5382c44cd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->