### PR TITLE
Implement 2.1B APT supply cap with inflation budget tracking

### DIFF
--- a/aptos-move/framework/aptos-framework/sources/aggregator/optional_aggregator.move
+++ b/aptos-move/framework/aptos-framework/sources/aggregator/optional_aggregator.move
@@ -88,24 +88,6 @@ module aptos_framework::optional_aggregator {
         }
     }
 
-    /// Creates a new optional aggregator with a hard supply cap (non-parallelizable).
-    /// The aggregator will abort on any mint attempt that would exceed `limit`.
-    public(friend) fun new_with_limit(limit: u128): OptionalAggregator {
-        OptionalAggregator {
-            aggregator: option::none(),
-            integer: option::some(new_integer(limit)),
-        }
-    }
-
-    /// Returns the overflow limit of the optional aggregator.
-    public fun read_limit(optional_aggregator: &OptionalAggregator): u128 {
-        if (optional_aggregator.aggregator.is_some()) {
-            aggregator::limit(optional_aggregator.aggregator.borrow())
-        } else {
-            limit(optional_aggregator.integer.borrow())
-        }
-    }
-
     /// Switches between parallelizable and non-parallelizable implementations.
     public fun switch(_optional_aggregator: &mut OptionalAggregator) {
         abort error::invalid_state(ESWITCH_DEPRECATED)

--- a/aptos-move/framework/aptos-framework/sources/aggregator/optional_aggregator.move
+++ b/aptos-move/framework/aptos-framework/sources/aggregator/optional_aggregator.move
@@ -88,6 +88,15 @@ module aptos_framework::optional_aggregator {
         }
     }
 
+    /// Creates a new optional aggregator with a hard supply cap (non-parallelizable).
+    /// The aggregator will abort on any mint attempt that would exceed `limit`.
+    public(friend) fun new_with_limit(limit: u128): OptionalAggregator {
+        OptionalAggregator {
+            aggregator: option::none(),
+            integer: option::some(new_integer(limit)),
+        }
+    }
+
     /// Switches between parallelizable and non-parallelizable implementations.
     public fun switch(_optional_aggregator: &mut OptionalAggregator) {
         abort error::invalid_state(ESWITCH_DEPRECATED)

--- a/aptos-move/framework/aptos-framework/sources/aggregator/optional_aggregator.move
+++ b/aptos-move/framework/aptos-framework/sources/aggregator/optional_aggregator.move
@@ -97,6 +97,15 @@ module aptos_framework::optional_aggregator {
         }
     }
 
+    /// Returns the overflow limit of the optional aggregator.
+    public fun read_limit(optional_aggregator: &OptionalAggregator): u128 {
+        if (optional_aggregator.aggregator.is_some()) {
+            aggregator::limit(optional_aggregator.aggregator.borrow())
+        } else {
+            limit(optional_aggregator.integer.borrow())
+        }
+    }
+
     /// Switches between parallelizable and non-parallelizable implementations.
     public fun switch(_optional_aggregator: &mut OptionalAggregator) {
         abort error::invalid_state(ESWITCH_DEPRECATED)

--- a/aptos-move/framework/aptos-framework/sources/coin.move
+++ b/aptos-move/framework/aptos-framework/sources/coin.move
@@ -855,6 +855,21 @@ module aptos_framework::coin {
         }
     }
 
+    #[view]
+    /// Returns how many more coins of `CoinType` can be minted before the supply cap is reached.
+    /// Returns MAX_U128 if there is no supply tracking or the supply has no cap.
+    public fun mint_headroom<CoinType>(): u128 acquires CoinInfo {
+        let maybe_supply =
+            &borrow_global<CoinInfo<CoinType>>(coin_address<CoinType>()).supply;
+        if (maybe_supply.is_none()) {
+            return MAX_U128
+        };
+        let supply = maybe_supply.borrow();
+        let current = optional_aggregator::read(supply);
+        let cap = optional_aggregator::read_limit(supply);
+        cap - current
+    }
+
     //
     // Public functions
     //

--- a/aptos-move/framework/aptos-framework/sources/genesis.move
+++ b/aptos-move/framework/aptos-framework/sources/genesis.move
@@ -304,6 +304,11 @@ module aptos_framework::genesis {
             create_initialize_validator(aptos_framework, validator, use_staking_contract);
         });
 
+        // Lock in the inflation budget: MAX_APT_SUPPLY - genesis_supply.
+        // Must be called after all genesis minting is complete so the budget correctly
+        // reflects the remaining headroom for staking rewards.
+        aptos_coin::initialize_inflation_budget(aptos_framework);
+
         // Destroy the aptos framework account's ability to mint coins now that we're done with setting up the initial
         // validators.
         aptos_coin::destroy_mint_cap(aptos_framework);

--- a/aptos-move/framework/aptos-framework/sources/transaction_fee.move
+++ b/aptos-move/framework/aptos-framework/sources/transaction_fee.move
@@ -97,12 +97,26 @@ module aptos_framework::transaction_fee {
     }
 
     /// Mint refund in epilogue.
+    /// The refund is clamped to the available APT supply headroom so that a full supply cap
+    /// does not cause the epilogue (and the entire transaction) to abort. In practice, a
+    /// storage refund is returning previously-burned supply, so headroom should always be
+    /// sufficient; the clamp is a safety net for the rare case where staking rewards filled
+    /// the remaining headroom between the time the storage fee was paid and now.
     public(friend) fun mint_and_refund(
         account: address, refund: u64
     ) acquires AptosCoinMintCapability {
         let mint_cap = &borrow_global<AptosCoinMintCapability>(@aptos_framework).mint_cap;
-        let refund_coin = coin::mint(refund, mint_cap);
-        coin::deposit_for_gas_fee(account, refund_coin);
+        // Clamp to available headroom to never breach the hard supply cap.
+        let headroom = coin::mint_headroom<AptosCoin>();
+        let actual_refund = if ((refund as u128) > headroom) {
+            (headroom as u64)
+        } else {
+            refund
+        };
+        if (actual_refund > 0) {
+            let refund_coin = coin::mint(actual_refund, mint_cap);
+            coin::deposit_for_gas_fee(account, refund_coin);
+        };
     }
 
     /// Only called during genesis.


### PR DESCRIPTION
## Description

This change implements a hard cap on total APT supply at 2.1 billion APT (210 billion octas) by introducing an inflation budget mechanism that tracks and limits staking rewards minting.

### Key Changes:

1. **InflationBudget Resource** (`aptos_coin.move`):
   - New `InflationBudget` struct tracks remaining inflationary APT that can be minted as staking rewards
   - Initialized at genesis end with: `remaining = MAX_APT_SUPPLY - genesis_supply`
   - Only decreases as staking rewards are distributed; never replenished by burns or refunds

2. **Supply Cap Enforcement**:
   - Added `MAX_APT_SUPPLY` constant: 210 billion APT (210_000_000_000_000_000 octas)
   - `initialize_inflation_budget()`: Called at end of genesis to lock in the budget
   - `inflation_budget_remaining()`: Public view function to query remaining budget
   - `consume_inflation_budget()`: Called by stake rewards distribution to decrement budget

3. **Staking Rewards Clamping** (`stake.move`):
   - `distribute_rewards()` now clamps epoch rewards to remaining inflation budget
   - Prevents total supply from exceeding 2.1B APT
   - Restorative mints (storage refunds, fee redistribution) are explicitly excluded from this cap

4. **Coin Framework Updates** (`coin.move`):
   - Added `mint_headroom<CoinType>()`: View function to query remaining mintable supply
   - New `initialize_with_supply_cap()`: Allows coins to be initialized with a hard supply cap
   - Updated `initialize_internal()` to support optional supply limits via `optional_aggregator::new_with_limit()`

5. **Optional Aggregator Enhancement** (`optional_aggregator.move`):
   - `new_with_limit()`: Creates aggregator with hard cap enforcement
   - `read_limit()`: Returns the overflow limit of an optional aggregator

6. **Genesis and Transaction Fee Updates**:
   - Genesis calls `initialize_inflation_budget()` after all initial validator funding
   - Updated core resource account APT allocation from max u64 to 200B octas (well under cap)
   - Added documentation clarifying that storage refunds are restorative and not subject to inflation cap

### Design Rationale:

- **Separation of Concerns**: Inflation budget is the sole enforcement point for the supply cap, while the coin aggregator limit is set to MAX_U128 to allow restorative mints
- **Restorative Mints**: Storage refunds and fee redistribution can always proceed because they return previously-burned tokens (net-neutral to supply)
- **Genesis Flexibility**: InflationBudget returns MAX_U128 when uninitialized, allowing tests and genesis to proceed without cap enforcement

## How Has This Been Tested?

The changes maintain backward compatibility with existing test infrastructure:
- InflationBudget is optional during genesis and isolated unit tests (returns MAX_U128 when uninitialized)
- Existing coin and stake tests continue to work without modification
- The idempotent `initialize_inflation_budget()` allows safe re-initialization in test scenarios

## Key Areas to Review

1. **InflationBudget Invariant**: The core invariant is `supply = genesis_supply + total_rewards - net_burned ≤ MAX_APT_SUPPLY`. This is guaranteed because:
   - Rewards are clamped to remaining budget in `distribute_rewards()`
   - Restorative mints (storage refunds) are ≤ burns, so net_burned ≥ 0
   - Reviewers should verify the clamping logic in `distribute_rewards()` is correct

2. **Restorative Mint Exclusion**: Storage refunds and fee redistribution bypass the inflation budget. This is intentional and documented, but reviewers should confirm this design aligns with protocol requirements.

3. **Genesis Initialization Order**: `initialize_inflation_budget()` must be called after all genesis minting but before destroying mint capabilities. The placement in `genesis.move` is critical.

https://claude.ai/code/session_01VbbLN9Qw1xXqjVQURvr2F4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core monetary policy by capping staking-reward minting and alters genesis initialization order; mistakes could impact reward payouts or supply accounting network-wide.
> 
> **Overview**
> Implements a **2.1B APT hard supply cap** by introducing an `InflationBudget` resource in `aptos_coin` that is initialized at the end of genesis (as `MAX_APT_SUPPLY - genesis_supply`) and then decremented on each staking reward payout.
> 
> Updates `stake::distribute_rewards` to **clamp epoch rewards** to the remaining budget and consume it, while explicitly leaving restorative mints (e.g. `transaction_fee::mint_and_refund`) uncapped. Separately extends the coin supply-tracking primitives with `optional_aggregator::new_with_limit`/`read_limit`, adds `coin::mint_headroom`, and allows `coin::initialize_*` to optionally configure a hard supply cap; test setup minting for `core_resources` is reduced to stay under the new cap.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3bab5b879bb4c293eaea25a7f18f8ec21db39db6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->