### PR TITLE
[storage] Set fill_cache(false) on backup handler RocksDB reads

### DIFF
--- a/storage/aptosdb/src/ledger_db/event_db.rs
+++ b/storage/aptosdb/src/ledger_db/event_db.rs
@@ -102,7 +102,21 @@ impl EventDb {
         start_version: Version,
         num_versions: usize,
     ) -> Result<EventsByVersionIter<'_>> {
-        let mut iter = self.db.iter::<EventSchema>()?;
+        self.get_events_by_version_iter_with_opts(
+            start_version,
+            num_versions,
+            ReadOptions::default(),
+        )
+    }
+
+    /// Same as `get_events_by_version_iter`, but with custom `ReadOptions`.
+    pub(crate) fn get_events_by_version_iter_with_opts(
+        &self,
+        start_version: Version,
+        num_versions: usize,
+        opts: ReadOptions,
+    ) -> Result<EventsByVersionIter<'_>> {
+        let mut iter = self.db.iter_with_opts::<EventSchema>(opts)?;
         iter.seek(&start_version)?;
 
         Ok(EventsByVersionIter::new(

--- a/storage/aptosdb/src/ledger_db/ledger_metadata_db.rs
+++ b/storage/aptosdb/src/ledger_db/ledger_metadata_db.rs
@@ -13,7 +13,7 @@ use crate::{
     utils::{get_progress, iterators::EpochEndingLedgerInfoIter},
 };
 use anyhow::anyhow;
-use aptos_schemadb::{batch::SchemaBatch, DB};
+use aptos_schemadb::{batch::SchemaBatch, ReadOptions, DB};
 use aptos_storage_interface::{block_info::BlockInfo, db_ensure as ensure, AptosDbError, Result};
 use aptos_types::{
     account_config::NewBlockEvent, block_info::BlockHeight, contract_event::ContractEvent,
@@ -126,7 +126,21 @@ impl LedgerMetadataDb {
         start_epoch: u64,
         end_epoch: u64,
     ) -> Result<EpochEndingLedgerInfoIter<'_>> {
-        let mut iter = self.db.iter::<LedgerInfoSchema>()?;
+        self.get_epoch_ending_ledger_info_iter_with_opts(
+            start_epoch,
+            end_epoch,
+            ReadOptions::default(),
+        )
+    }
+
+    /// Same as `get_epoch_ending_ledger_info_iter`, but with custom `ReadOptions`.
+    pub(crate) fn get_epoch_ending_ledger_info_iter_with_opts(
+        &self,
+        start_epoch: u64,
+        end_epoch: u64,
+        opts: ReadOptions,
+    ) -> Result<EpochEndingLedgerInfoIter<'_>> {
+        let mut iter = self.db.iter_with_opts::<LedgerInfoSchema>(opts)?;
         iter.seek(&start_epoch)?;
         Ok(EpochEndingLedgerInfoIter::new(iter, start_epoch, end_epoch))
     }

--- a/storage/aptosdb/src/ledger_db/persisted_auxiliary_info_db.rs
+++ b/storage/aptosdb/src/ledger_db/persisted_auxiliary_info_db.rs
@@ -10,7 +10,7 @@ use crate::{
     utils::iterators::ExpectContinuousVersions,
 };
 use aptos_metrics_core::TimerHelper;
-use aptos_schemadb::{batch::SchemaBatch, DB};
+use aptos_schemadb::{batch::SchemaBatch, ReadOptions, DB};
 use aptos_storage_interface::Result;
 use aptos_types::transaction::{PersistedAuxiliaryInfo, Version};
 use std::{path::Path, sync::Arc};
@@ -60,13 +60,35 @@ impl PersistedAuxiliaryInfoDb {
         start_version: Version,
         num_persisted_auxiliary_info: usize,
     ) -> Result<Box<dyn Iterator<Item = Result<PersistedAuxiliaryInfo>> + '_>> {
-        let mut iter = self.db.iter::<PersistedAuxiliaryInfoSchema>()?;
+        self.get_persisted_auxiliary_info_iter_with_opts(
+            start_version,
+            num_persisted_auxiliary_info,
+            ReadOptions::default,
+        )
+    }
+
+    /// Same as `get_persisted_auxiliary_info_iter`, but with custom `ReadOptions`.
+    ///
+    /// Takes a factory closure instead of a single `ReadOptions` because this method
+    /// may create more than one RocksDB iterator internally, and `ReadOptions` is not
+    /// `Clone`.
+    pub(crate) fn get_persisted_auxiliary_info_iter_with_opts(
+        &self,
+        start_version: Version,
+        num_persisted_auxiliary_info: usize,
+        read_opts_factory: impl Fn() -> ReadOptions,
+    ) -> Result<Box<dyn Iterator<Item = Result<PersistedAuxiliaryInfo>> + '_>> {
+        let mut iter = self
+            .db
+            .iter_with_opts::<PersistedAuxiliaryInfoSchema>(read_opts_factory())?;
         iter.seek(&start_version)?;
         let mut iter = iter.peekable();
         let version = if let Some(item) = iter.peek() {
             item.as_ref().map_err(|e| e.clone())?.0
         } else {
-            let mut iter = self.db.iter::<PersistedAuxiliaryInfoSchema>()?;
+            let mut iter = self
+                .db
+                .iter_with_opts::<PersistedAuxiliaryInfoSchema>(read_opts_factory())?;
             iter.seek_to_last();
             if iter.next().transpose()?.is_some() {
                 return Ok(Box::new(std::iter::empty()));

--- a/storage/aptosdb/src/ledger_db/transaction_info_db.rs
+++ b/storage/aptosdb/src/ledger_db/transaction_info_db.rs
@@ -9,7 +9,7 @@ use crate::{
     },
     utils::iterators::ExpectContinuousVersions,
 };
-use aptos_schemadb::{batch::SchemaBatch, DB};
+use aptos_schemadb::{batch::SchemaBatch, ReadOptions, DB};
 use aptos_storage_interface::{AptosDbError, Result};
 use aptos_types::{
     proof::TransactionInfoWithProof,
@@ -64,7 +64,21 @@ impl TransactionInfoDb {
         start_version: Version,
         num_transaction_infos: usize,
     ) -> Result<impl Iterator<Item = Result<TransactionInfo>> + '_> {
-        let mut iter = self.db.iter::<TransactionInfoSchema>()?;
+        self.get_transaction_info_iter_with_opts(
+            start_version,
+            num_transaction_infos,
+            ReadOptions::default(),
+        )
+    }
+
+    /// Same as `get_transaction_info_iter`, but with custom `ReadOptions`.
+    pub(crate) fn get_transaction_info_iter_with_opts(
+        &self,
+        start_version: Version,
+        num_transaction_infos: usize,
+        opts: ReadOptions,
+    ) -> Result<impl Iterator<Item = Result<TransactionInfo>> + '_> {
+        let mut iter = self.db.iter_with_opts::<TransactionInfoSchema>(opts)?;
         iter.seek(&start_version)?;
         iter.expect_continuous_versions(start_version, num_transaction_infos)
     }

--- a/storage/aptosdb/src/ledger_db/write_set_db.rs
+++ b/storage/aptosdb/src/ledger_db/write_set_db.rs
@@ -12,7 +12,7 @@ use crate::{
 use aptos_metrics_core::TimerHelper;
 use aptos_schemadb::{
     batch::{SchemaBatch, WriteBatch},
-    DB,
+    ReadOptions, DB,
 };
 use aptos_storage_interface::{db_ensure as ensure, AptosDbError, Result};
 use aptos_types::{
@@ -66,7 +66,17 @@ impl WriteSetDb {
         start_version: Version,
         num_transactions: usize,
     ) -> Result<impl Iterator<Item = Result<WriteSet>> + '_> {
-        let mut iter = self.db.iter::<WriteSetSchema>()?;
+        self.get_write_set_iter_with_opts(start_version, num_transactions, ReadOptions::default())
+    }
+
+    /// Same as `get_write_set_iter`, but with custom `ReadOptions`.
+    pub(crate) fn get_write_set_iter_with_opts(
+        &self,
+        start_version: Version,
+        num_transactions: usize,
+        opts: ReadOptions,
+    ) -> Result<impl Iterator<Item = Result<WriteSet>> + '_> {
+        let mut iter = self.db.iter_with_opts::<WriteSetSchema>(opts)?;
         iter.seek(&start_version)?;
         iter.expect_continuous_versions(start_version, num_transactions)
     }


### PR DESCRIPTION

Similar to the pruner change in fff4e8a2, backup handler scans large ranges
of data via RocksDB iterators for export. This data is read once and will not
be needed again on the serving path. Without `fill_cache(false)`, every block
touched by backup iterators gets loaded into the shared RocksDB block cache,
evicting hot data used by API queries and state sync.

This primarily benefits fullnodes that run backup alongside serving traffic
(e.g. state sync and API queries), where bulk scans can blow out the working
set of the cache.

Add `_with_opts` companion methods to each sub-DB iterator method:
- `TransactionDb::get_transaction_iter_with_opts`
- `TransactionInfoDb::get_transaction_info_iter_with_opts`
- `WriteSetDb::get_write_set_iter_with_opts`
- `EventDb::get_events_by_version_iter_with_opts`
- `PersistedAuxiliaryInfoDb::get_persisted_auxiliary_info_iter_with_opts`
- `LedgerMetadataDb::get_epoch_ending_ledger_info_iter_with_opts`

The originals delegate to the new variants with `ReadOptions::default()`,
so there are zero changes to existing callers. The backup handler calls
the `_with_opts` variants with `fill_cache(false)`.

Note: the state snapshot path (`get_state_key_and_value_iter`) is out of
scope — it uses `JellyfishMerkleIterator` which traverses the Merkle tree
via point reads (`.get_node()`), not RocksDB iterators. Threading
`ReadOptions` through the `TreeReader` trait is a larger change.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavioral changes are limited to RocksDB read options for backup-related iterators; output data should be unchanged, with low risk aside from potential performance/regression in iterator usage.
> 
> **Overview**
> Backup export scans now use RocksDB `ReadOptions` with `fill_cache(false)` so large backup iterators don’t evict hot data from the shared block cache.
> 
> To support this, the ledger sub-DBs add `_with_opts` iterator variants (transactions, txn infos, write sets, events, epoch-ending ledger infos, and persisted auxiliary info) while keeping existing APIs by delegating to defaults; `BackupHandler` switches to the new variants for its bulk reads.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 525fdd1a70a45dc2f903911ace685608a5bc931c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->