### PR TITLE
[storage] Document commit_no_progress in StateMerkleDb

### DIFF
--- a/storage/aptosdb/src/state_merkle_db.rs
+++ b/storage/aptosdb/src/state_merkle_db.rs
@@ -150,7 +150,19 @@ impl StateMerkleDb {
         self.commit_top_levels(version, top_levels_batch)
     }
 
-    /// Only used by fast sync / restore.
+    /// Commits JMT node data without writing any commit progress metadata
+    /// (`StateMerkleCommitProgress` / `StateMerkleShardCommitProgress`).
+    ///
+    /// Only used by `TreeWriter::write_node_batch` during fast-sync / state snapshot restore,
+    /// where the caller (JMT restore) writes raw `NodeBatch` data that contains only JMT nodes —
+    /// no progress bookkeeping. Progress is tracked externally by the restore framework instead.
+    ///
+    /// Unlike [`Self::commit`] which writes shards in parallel, this method commits shards
+    /// sequentially from left (shard 0) to right (shard N-1). This is because JMT restore
+    /// processes keys in hash order (left to right), so each `write_node_batch` call contains
+    /// frozen nodes spanning a contiguous range of shards. Sequential left-to-right writes
+    /// ensure that on crash, all fully-committed shards form a prefix, making it
+    /// straightforward to determine a consistent resume point.
     pub(crate) fn commit_no_progress(
         &self,
         top_level_batch: SchemaBatch,


### PR DESCRIPTION

- Clarify that "no progress" means the batches contain no
  `StateMerkleCommitProgress` / `StateMerkleShardCommitProgress`
  metadata — only raw JMT nodes. Progress is tracked externally by the
  restore framework.
- Document why the function uses sequential left-to-right shard commits
  (crash consistency: fully-committed shards form a prefix for resume).

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that clarifies fast-sync restore behavior and shard commit ordering; no functional logic is modified.
> 
> **Overview**
> Improves the docs for `StateMerkleDb::commit_no_progress` to clarify that it commits raw JMT `NodeBatch` data *without* writing `StateMerkleCommitProgress` / `StateMerkleShardCommitProgress`, and that restore progress is tracked externally.
> 
> Also documents why shard commits are performed sequentially left-to-right (crash consistency: fully committed shards form a prefix for easier resume), contrasting with `commit`’s parallel shard writes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 611e951ee98fc7be5017900c118beab1d422785b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->