### PR TITLE
[State Sync] Account for validator-PFN connections.

### DIFF
--- a/config/src/config/base_config.rs
+++ b/config/src/config/base_config.rs
@@ -19,6 +19,7 @@ pub struct BaseConfig {
     pub working_dir: Option<PathBuf>,
     pub role: RoleType,
     pub waypoint: WaypointConfig,
+    pub enable_validator_pfn_connections: bool,
 }
 
 impl Default for BaseConfig {
@@ -28,6 +29,7 @@ impl Default for BaseConfig {
             working_dir: None,
             role: RoleType::Validator,
             waypoint: WaypointConfig::None,
+            enable_validator_pfn_connections: false, // Whether to allow direct connections between validators and PFNs
         }
     }
 }

--- a/state-sync/aptos-data-client/src/priority.rs
+++ b/state-sync/aptos-data-client/src/priority.rs
@@ -63,8 +63,7 @@ pub fn get_peer_priority(
             return PeerPriority::HighPriority;
         }
 
-        // VFNs should be prioritized over PFNs. Note: having PFNs
-        // connected to a validator is a rare (but possible) scenario.
+        // VFNs should be prioritized over PFNs
         return if peer_network_id.is_vfn_network() {
             PeerPriority::MediumPriority
         } else {
@@ -82,14 +81,12 @@ pub fn get_peer_priority(
             return PeerPriority::HighPriority;
         }
 
-        // Trusted peers should be prioritized over untrusted peers.
-        // This prioritizes other VFNs/seed peers over regular PFNs.
+        // Trusted peers should be prioritized over untrusted peers
         if is_trusted_peer(peers_and_metadata.clone(), peer) {
             return PeerPriority::MediumPriority;
         }
 
-        // Outbound connections should be prioritized over inbound connections.
-        // This prioritizes other VFNs/seed peers over regular PFNs.
+        // Outbound connections should be prioritized (medium priority) over inbound connections (low priority)
         return if let Some(metadata) = utils::get_metadata_for_peer(&peers_and_metadata, *peer) {
             if metadata.get_connection_metadata().is_outbound_connection() {
                 PeerPriority::MediumPriority
@@ -101,15 +98,13 @@ pub fn get_peer_priority(
         };
     }
 
-    // Otherwise, this node is a PFN. PFNs should highly
-    // prioritize trusted peers (i.e., VFNs and seed peers).
+    // Otherwise, this node is a PFN. PFNs should highly prioritize
+    // trusted peers (i.e., validators, VFNs, and seed peers).
     if is_trusted_peer(peers_and_metadata.clone(), peer) {
         return PeerPriority::HighPriority;
     }
 
-    // Outbound connections should be prioritized. This prioritizes
-    // other VFNs/seed peers over regular PFNs. Inbound connections
-    // are always low priority (as they are generally unreliable).
+    // Outbound connections should be prioritized (high priority) over inbound connections (low priority)
     if let Some(metadata) = utils::get_metadata_for_peer(&peers_and_metadata, *peer) {
         if metadata.get_connection_metadata().is_outbound_connection() {
             PeerPriority::HighPriority

--- a/state-sync/aptos-data-client/src/tests/utils.rs
+++ b/state-sync/aptos-data-client/src/tests/utils.rs
@@ -168,6 +168,16 @@ pub fn create_fullnode_base_config() -> BaseConfig {
 pub fn create_validator_base_config() -> BaseConfig {
     BaseConfig {
         role: RoleType::Validator,
+        enable_validator_pfn_connections: false, // Disable PFN connections by default
+        ..Default::default()
+    }
+}
+
+/// Creates and returns a base config for a validator node with pfn connections enabled
+pub fn create_validator_base_config_with_pfn_connections() -> BaseConfig {
+    BaseConfig {
+        role: RoleType::Validator,
+        enable_validator_pfn_connections: true, // Enable PFN connections
         ..Default::default()
     }
 }


### PR DESCRIPTION
## Description
This PR updates the aptos data client in state sync to better account for validator-PFN connections. Thankfully, nothing needs to change in the data client (aside from documentation and a new config flag we've added to help gate the feature). This config flag will be used across all components.

## Testing Plan
New test infrastructure.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a new `BaseConfig` field that changes the serialized config schema (though it defaults safely), and expands state-sync tests; no peer-selection logic is modified.
> 
> **Overview**
> Introduces a new `BaseConfig.enable_validator_pfn_connections` flag (default `false`) to gate/describe direct validator↔PFN connectivity.
> 
> Updates state-sync data client coverage to explicitly validate validator peer selection behavior when only PFN peers are available and when VFNs appear/disconnect, and tightens prioritization documentation/comments in `priority.rs` without changing logic.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 50d6c12edbc0585a55b35c004e560be7ba9fc138. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->