### PR TITLE
[State Sync] Add simple state sync request rate limiting.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4338,6 +4338,7 @@ dependencies = [
  "aptos-storage-service-notifications",
  "aptos-storage-service-types",
  "aptos-time-service",
+ "aptos-token-bucket",
  "aptos-types",
  "arc-swap",
  "bcs 0.1.4",

--- a/config/src/config/state_sync_config.rs
+++ b/config/src/config/state_sync_config.rs
@@ -180,6 +180,9 @@ pub struct StorageServiceConfig {
     pub max_epoch_chunk_size: u64,
     /// Maximum number of invalid requests per peer
     pub max_invalid_requests_per_peer: u64,
+    /// Maximum number of requests per second per peer (if None, then no rate limiting is applied).
+    /// Note: this currently only applies for peers on the public network.
+    pub max_requests_per_second_per_peer: Option<u64>,
     /// Maximum number of items in the lru cache before eviction
     pub max_lru_cache_size: u64,
     /// Maximum number of pending network messages
@@ -202,7 +205,8 @@ pub struct StorageServiceConfig {
     pub max_transaction_chunk_size: u64,
     /// Maximum number of transaction outputs per chunk
     pub max_transaction_output_chunk_size: u64,
-    /// Minimum time (secs) to ignore peers after too many invalid requests
+    /// Minimum time (secs) to ignore peers after too many invalid requests.
+    /// Note: this currently only applies for peers on the public network.
     pub min_time_to_ignore_peers_secs: u64,
     /// The interval (ms) to refresh the request moderator state
     pub request_moderator_refresh_interval_ms: u64,
@@ -217,6 +221,7 @@ impl Default for StorageServiceConfig {
             enable_transaction_data_v2: true,
             max_epoch_chunk_size: MAX_EPOCH_CHUNK_SIZE,
             max_invalid_requests_per_peer: 500,
+            max_requests_per_second_per_peer: None,
             max_lru_cache_size: 500, // At ~0.6MiB per chunk, this should take no more than 0.5GiB
             max_network_channel_size: 4000,
             max_network_chunk_bytes: SERVER_MAX_MESSAGE_SIZE as u64,

--- a/state-sync/storage-service/server/Cargo.toml
+++ b/state-sync/storage-service/server/Cargo.toml
@@ -24,6 +24,7 @@ aptos-storage-interface = { workspace = true }
 aptos-storage-service-notifications = { workspace = true }
 aptos-storage-service-types = { workspace = true }
 aptos-time-service = { workspace = true }
+aptos-token-bucket = { workspace = true }
 aptos-types = { workspace = true }
 arc-swap = { workspace = true }
 bcs = { workspace = true }

--- a/state-sync/storage-service/server/src/error.rs
+++ b/state-sync/storage-service/server/src/error.rs
@@ -12,6 +12,8 @@ pub enum Error {
     StorageErrorEncountered(String),
     #[error("Too many invalid requests: {0}")]
     TooManyInvalidRequests(String),
+    #[error("Too many requests: {0}")]
+    TooManyRequests(String),
     #[error("Unexpected error encountered: {0}")]
     UnexpectedErrorEncountered(String),
 }
@@ -23,6 +25,7 @@ impl Error {
             Error::InvalidRequest(_) => "invalid_request",
             Error::StorageErrorEncountered(_) => "storage_error",
             Error::TooManyInvalidRequests(_) => "too_many_invalid_requests",
+            Error::TooManyRequests(_) => "too_many_requests",
             Error::UnexpectedErrorEncountered(_) => "unexpected_error",
         }
     }

--- a/state-sync/storage-service/server/src/handler.rs
+++ b/state-sync/storage-service/server/src/handler.rs
@@ -198,6 +198,7 @@ impl<T: StorageReaderInterface> Handler<T> {
             Error::TooManyInvalidRequests(error) => {
                 StorageServiceError::TooManyInvalidRequests(error)
             },
+            Error::TooManyRequests(error) => StorageServiceError::TooManyRequests(error),
             error => StorageServiceError::InternalError(error.to_string()),
         })
     }

--- a/state-sync/storage-service/server/src/metrics.rs
+++ b/state-sync/storage-service/server/src/metrics.rs
@@ -111,6 +111,16 @@ pub static STORAGE_ERRORS_ENCOUNTERED: Lazy<IntCounterVec> = Lazy::new(|| {
     .unwrap()
 });
 
+/// Counter for rate limited storage service requests
+pub static STORAGE_REQUESTS_RATE_LIMITED: Lazy<IntCounterVec> = Lazy::new(|| {
+    register_int_counter_vec!(
+        "aptos_storage_service_server_requests_rate_limited",
+        "Counters related to the storage server requests that were rate limited",
+        &["network_id", "request_type"]
+    )
+    .unwrap()
+});
+
 /// Counter for received storage service requests
 pub static STORAGE_REQUESTS_RECEIVED: Lazy<IntCounterVec> = Lazy::new(|| {
     register_int_counter_vec!(

--- a/state-sync/storage-service/server/src/moderator.rs
+++ b/state-sync/storage-service/server/src/moderator.rs
@@ -12,6 +12,7 @@ use aptos_storage_service_types::{
     requests::StorageServiceRequest, responses::StorageServerSummary,
 };
 use aptos_time_service::{TimeService, TimeServiceTrait};
+use aptos_token_bucket::TokenBucket;
 use arc_swap::ArcSwap;
 use dashmap::DashMap;
 use std::{
@@ -106,6 +107,7 @@ pub struct RequestModerator {
     aptos_data_client_config: AptosDataClientConfig,
     cached_storage_server_summary: Arc<ArcSwap<StorageServerSummary>>,
     peers_and_metadata: Arc<PeersAndMetadata>,
+    peer_rate_limit_states: Arc<DashMap<PeerNetworkId, TokenBucket>>,
     storage_service_config: StorageServiceConfig,
     time_service: TimeService,
     unhealthy_peer_states: Arc<DashMap<PeerNetworkId, UnhealthyPeerState>>,
@@ -122,6 +124,7 @@ impl RequestModerator {
         Self {
             aptos_data_client_config,
             cached_storage_server_summary,
+            peer_rate_limit_states: Arc::new(DashMap::new()),
             unhealthy_peer_states: Arc::new(DashMap::new()),
             peers_and_metadata,
             storage_service_config,
@@ -138,6 +141,23 @@ impl RequestModerator {
     ) -> Result<(), Error> {
         // Validate the request and time the operation
         let validate_request = || {
+            // Check request rate limiting for the peer
+            if !self.check_request_rate_limit_allowed(peer_network_id) {
+                // Update the rate limiting metrics
+                metrics::increment_counter(
+                    &metrics::STORAGE_REQUESTS_RATE_LIMITED,
+                    peer_network_id.network_id(),
+                    request.get_label(),
+                );
+
+                // Return an error
+                return Err(Error::TooManyRequests(format!(
+                    "Peer has exceeded the request rate limit ({:?} req/s). Request: {}",
+                    self.storage_service_config.max_requests_per_second_per_peer,
+                    request.get_label()
+                )));
+            }
+
             // If the peer is being ignored, return an error
             if let Some(peer_state) = self.unhealthy_peer_states.get(peer_network_id) {
                 if peer_state.is_ignored() {
@@ -195,6 +215,42 @@ impl RequestModerator {
         )
     }
 
+    /// Checks the rate limit for the given peer and request.
+    /// Returns true iff the request is allowed.
+    fn check_request_rate_limit_allowed(&self, peer_network_id: &PeerNetworkId) -> bool {
+        // If the peer is not on the public network, we shouldn't rate limit it
+        if !peer_network_id.network_id().is_public_network() {
+            return true;
+        }
+
+        // Get the max requests per second for the peer
+        let max_requests_per_second =
+            match self.storage_service_config.max_requests_per_second_per_peer {
+                Some(max_requests_per_second) => max_requests_per_second,
+                None => {
+                    return true; // Rate limiting is disabled
+                },
+            };
+
+        // Get the rate limit state for the peer (or create one if it doesn't exist)
+        let mut peer_rate_limit_state = self
+            .peer_rate_limit_states
+            .entry(*peer_network_id)
+            .or_insert_with(|| {
+                // Create a new token bucket with the specified max requests per
+                // second. Note: the capacity is set to the max requests per second,
+                // which allows for bursting up to 1 second of requests.
+                TokenBucket::new(
+                    max_requests_per_second,
+                    max_requests_per_second,
+                    self.time_service.clone(),
+                )
+            });
+
+        // Check if the request is allowed under the rate limit
+        peer_rate_limit_state.try_acquire_all(1).is_ok()
+    }
+
     /// Refresh the unhealthy peer states and garbage collect disconnected peers
     pub fn refresh_unhealthy_peer_states(&self) -> Result<(), Error> {
         // Get the currently connected peers
@@ -208,7 +264,7 @@ impl RequestModerator {
                 ))
             })?;
 
-        // Remove disconnected peers and refresh ignored peer states
+        // Refresh the unhealthy peer states and garbage collect disconnected peers
         let mut num_ignored_peers = 0;
         self.unhealthy_peer_states
             .retain(|peer_network_id, unhealthy_peer_state| {
@@ -227,6 +283,11 @@ impl RequestModerator {
                 }
             });
 
+        // Garbage collect the rate limit states for disconnected peers
+        self.peer_rate_limit_states.retain(|peer_network_id, _| {
+            connected_peers_and_metadata.contains_key(peer_network_id)
+        });
+
         // Update the number of ignored peers
         metrics::set_gauge(
             &metrics::IGNORED_PEER_COUNT,
@@ -235,6 +296,12 @@ impl RequestModerator {
         );
 
         Ok(())
+    }
+
+    #[cfg(test)]
+    /// Returns a copy of the rate limit states for testing
+    pub(crate) fn get_peer_rate_limit_states(&self) -> Arc<DashMap<PeerNetworkId, TokenBucket>> {
+        self.peer_rate_limit_states.clone()
     }
 
     #[cfg(test)]

--- a/state-sync/storage-service/server/src/tests/mod.rs
+++ b/state-sync/storage-service/server/src/tests/mod.rs
@@ -12,6 +12,7 @@ mod new_transactions_or_outputs;
 mod number_of_states;
 mod optimistic_fetch;
 mod protocol_version;
+mod rate_limiter;
 mod request_moderator;
 mod response_progress_tracker;
 mod state_values;

--- a/state-sync/storage-service/server/src/tests/rate_limiter.rs
+++ b/state-sync/storage-service/server/src/tests/rate_limiter.rs
@@ -1,0 +1,279 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+use crate::tests::{mock::MockClient, utils};
+use aptos_config::{
+    config::{PeerRole, StorageServiceConfig},
+    network_id::{NetworkId, PeerNetworkId},
+};
+use aptos_netcore::transport::ConnectionOrigin;
+use aptos_network::{
+    application::metadata::ConnectionState,
+    protocols::wire::handshake::v1::{MessagingProtocolVersion, ProtocolIdSet},
+    transport::{ConnectionId, ConnectionMetadata},
+};
+use aptos_storage_service_types::{
+    requests::{DataRequest, StorageServiceRequest},
+    responses::StorageServiceResponse,
+    StorageServiceError,
+};
+use aptos_types::{network_address::NetworkAddress, PeerId};
+use claims::assert_matches;
+use std::str::FromStr;
+
+#[tokio::test]
+async fn test_rate_limiter_disabled_by_default() {
+    // Create a default storage service config (rate limiting disabled)
+    let highest_synced_version = 100;
+    let highest_synced_epoch = 10;
+    let storage_service_config = StorageServiceConfig::default();
+    assert!(storage_service_config
+        .max_requests_per_second_per_peer
+        .is_none());
+
+    // Create the storage client and server
+    let (mut mock_client, mut service, _, _, _) =
+        MockClient::new(None, Some(storage_service_config));
+    utils::update_storage_server_summary(
+        &mut service,
+        highest_synced_version,
+        highest_synced_epoch,
+    );
+
+    // Verify the rate limit states are initially empty
+    let peer_rate_limit_states = service.get_request_moderator().get_peer_rate_limit_states();
+    assert!(peer_rate_limit_states.is_empty());
+
+    // Spawn the server
+    tokio::spawn(service.start());
+
+    // Send many requests from a public peer and verify none are rate limited
+    let peer_network_id = PeerNetworkId::new(NetworkId::Public, PeerId::random());
+    for _ in 0..100 {
+        let response = send_storage_server_summary_request(&mut mock_client, peer_network_id).await;
+        assert!(response.is_ok());
+    }
+
+    // Verify no rate limit state was created
+    assert!(peer_rate_limit_states.is_empty());
+}
+
+#[tokio::test]
+async fn test_rate_limiter_enforced_for_public_peers() {
+    // Create a storage service config with rate limiting enabled (1 req/sec)
+    let max_requests_per_second = 1;
+    let storage_service_config = StorageServiceConfig {
+        max_requests_per_second_per_peer: Some(max_requests_per_second),
+        ..Default::default()
+    };
+
+    // Create the storage client and server
+    let (mut mock_client, service, _, _, _) = MockClient::new(None, Some(storage_service_config));
+
+    // Spawn the server
+    tokio::spawn(service.start());
+
+    // The first request from a public peer should succeed
+    let peer_network_id = PeerNetworkId::new(NetworkId::Public, PeerId::random());
+    let response = send_storage_server_summary_request(&mut mock_client, peer_network_id).await;
+    assert!(response.is_ok());
+
+    // Subsequent requests in the same second should be rate limited
+    let response = send_storage_server_summary_request(&mut mock_client, peer_network_id).await;
+    assert_matches!(
+        response.unwrap_err(),
+        StorageServiceError::TooManyRequests(_)
+    );
+}
+
+#[tokio::test]
+async fn test_rate_limiter_not_enforced_for_non_public_peers() {
+    // Create a storage service config with rate limiting enabled (1 req/sec)
+    let storage_service_config = StorageServiceConfig {
+        max_requests_per_second_per_peer: Some(1),
+        ..Default::default()
+    };
+
+    // Create the storage client and server
+    let (mut mock_client, service, _, _, _) = MockClient::new(None, Some(storage_service_config));
+
+    // Spawn the server
+    tokio::spawn(service.start());
+
+    // Verify that validator and VFN peers are never rate limited regardless of request volume
+    for network_id in [NetworkId::Validator, NetworkId::Vfn] {
+        let peer_network_id = PeerNetworkId::new(network_id, PeerId::random());
+        for _ in 0..10 {
+            let response =
+                send_storage_server_summary_request(&mut mock_client, peer_network_id).await;
+            assert!(
+                response.is_ok(),
+                "Expected no rate limiting for {:?}",
+                network_id
+            );
+        }
+    }
+}
+
+#[tokio::test]
+async fn test_rate_limiter_independent_per_peer() {
+    // Create a storage service config with rate limiting enabled (2 reqs/sec)
+    let storage_service_config = StorageServiceConfig {
+        max_requests_per_second_per_peer: Some(2),
+        ..Default::default()
+    };
+
+    // Create the storage client and server
+    let (mut mock_client, service, _, _, _) = MockClient::new(None, Some(storage_service_config));
+
+    // Spawn the server
+    tokio::spawn(service.start());
+
+    // Exhaust the token bucket for the first peer
+    let peer_network_id_1 = PeerNetworkId::new(NetworkId::Public, PeerId::random());
+    for _ in 0..2 {
+        let response =
+            send_storage_server_summary_request(&mut mock_client, peer_network_id_1).await;
+        assert!(response.is_ok());
+    }
+
+    // The third request from peer 1 should be rate limited
+    let response = send_storage_server_summary_request(&mut mock_client, peer_network_id_1).await;
+    assert_matches!(
+        response.unwrap_err(),
+        StorageServiceError::TooManyRequests(_)
+    );
+
+    // A request from a different peer should succeed since rate limiting is per peer
+    let peer_network_id_2 = PeerNetworkId::new(NetworkId::Public, PeerId::random());
+    let response = send_storage_server_summary_request(&mut mock_client, peer_network_id_2).await;
+    assert!(response.is_ok());
+
+    // Verify that peer 1 is still rate limited
+    let response = send_storage_server_summary_request(&mut mock_client, peer_network_id_1).await;
+    assert_matches!(
+        response.unwrap_err(),
+        StorageServiceError::TooManyRequests(_)
+    );
+
+    // Verify that peer 2 is not rate limited
+    let response = send_storage_server_summary_request(&mut mock_client, peer_network_id_2).await;
+    assert!(response.is_ok());
+}
+
+#[tokio::test]
+async fn test_rate_limiter_garbage_collect_disconnected_peers() {
+    // Create a storage service config with rate limiting enabled
+    let storage_service_config = StorageServiceConfig {
+        max_requests_per_second_per_peer: Some(1),
+        ..Default::default()
+    };
+
+    // Create the storage client and server
+    let (mut mock_client, service, _, time_service, peers_and_metadata) =
+        MockClient::new(None, Some(storage_service_config));
+
+    // Register a public peer connection
+    let peer_network_id = PeerNetworkId::new(NetworkId::Public, PeerId::random());
+    let connection_metadata = ConnectionMetadata::new(
+        peer_network_id.peer_id(),
+        ConnectionId::from(0),
+        NetworkAddress::from_str("/ip4/127.0.0.1/tcp/8081").unwrap(),
+        ConnectionOrigin::Inbound,
+        MessagingProtocolVersion::V1,
+        ProtocolIdSet::empty(),
+        PeerRole::Unknown,
+    );
+    peers_and_metadata
+        .insert_connection_metadata(peer_network_id, connection_metadata)
+        .unwrap();
+
+    // Get the rate limit states
+    let peer_rate_limit_states = service.get_request_moderator().get_peer_rate_limit_states();
+
+    // Spawn the server
+    tokio::spawn(service.start());
+
+    // Send a request to populate the rate limit state for the peer
+    send_storage_server_summary_request(&mut mock_client, peer_network_id)
+        .await
+        .ok();
+    assert!(peer_rate_limit_states.contains_key(&peer_network_id));
+
+    // Disconnect the peer and wait for the moderator to garbage collect
+    peers_and_metadata
+        .update_connection_state(peer_network_id, ConnectionState::Disconnecting)
+        .unwrap();
+
+    // Advance time to trigger the moderator refresh loop
+    let default_config = StorageServiceConfig::default();
+    loop {
+        time_service
+            .advance_ms_async(default_config.request_moderator_refresh_interval_ms)
+            .await;
+        if !peer_rate_limit_states.contains_key(&peer_network_id) {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
+    assert!(!peer_rate_limit_states.contains_key(&peer_network_id));
+}
+
+#[tokio::test]
+async fn test_rate_limiter_refill_allows_new_requests() {
+    // Create a storage service config with rate limiting enabled (2 reqs/sec)
+    let max_requests_per_second = 2;
+    let storage_service_config = StorageServiceConfig {
+        max_requests_per_second_per_peer: Some(max_requests_per_second),
+        ..Default::default()
+    };
+
+    // Create the storage client and server
+    let (mut mock_client, service, _, _, _) = MockClient::new(None, Some(storage_service_config));
+
+    // Get the rate limit states before spawning the server
+    let peer_rate_limit_states = service.get_request_moderator().get_peer_rate_limit_states();
+
+    // Spawn the server
+    tokio::spawn(service.start());
+
+    // Exhaust the token bucket for the peer
+    let peer_network_id = PeerNetworkId::new(NetworkId::Public, PeerId::random());
+    for _ in 0..max_requests_per_second {
+        let response = send_storage_server_summary_request(&mut mock_client, peer_network_id).await;
+        assert!(response.is_ok());
+    }
+
+    // Verify the peer is now rate limited
+    let response = send_storage_server_summary_request(&mut mock_client, peer_network_id).await;
+    assert_matches!(
+        response.unwrap_err(),
+        StorageServiceError::TooManyRequests(_)
+    );
+
+    // Manually return tokens to simulate the bucket refilling
+    peer_rate_limit_states
+        .get_mut(&peer_network_id)
+        .unwrap()
+        .return_tokens(max_requests_per_second);
+
+    // Verify the peer can now send requests again
+    let response = send_storage_server_summary_request(&mut mock_client, peer_network_id).await;
+    assert!(response.is_ok());
+}
+
+/// Sends a storage server summary request from the given peer and returns the response
+async fn send_storage_server_summary_request(
+    mock_client: &mut MockClient,
+    peer_network_id: PeerNetworkId,
+) -> Result<StorageServiceResponse, StorageServiceError> {
+    let request = StorageServiceRequest::new(DataRequest::GetStorageServerSummary, false);
+    let receiver = mock_client
+        .send_request(
+            request,
+            Some(peer_network_id.peer_id()),
+            Some(peer_network_id.network_id()),
+        )
+        .await;
+    mock_client.wait_for_response(receiver).await
+}

--- a/state-sync/storage-service/types/src/lib.rs
+++ b/state-sync/storage-service/types/src/lib.rs
@@ -34,6 +34,8 @@ pub enum StorageServiceError {
     InvalidRequest(String),
     #[error("Too many invalid requests! Back off required: {0}")]
     TooManyInvalidRequests(String),
+    #[error("Too many requests! Back off required: {0}")]
+    TooManyRequests(String),
 }
 
 /// A single storage service message sent or received over AptosNet.


### PR DESCRIPTION
## Description
This PR adds a configurable state sync request rate limiter to the storage service. Using this, we can rate limit the number of requests per second (per peer) to the storage service. This is useful for responding to malicious peers that may attempt to make many state sync requests to slow down the node.

Note: the rate limit currently only applies to peers on the `public` network, as these are untrusted. 

## Testing Plan
New and existing test infrastructure.




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new request-throttling behavior and a new error path in the state sync storage service; misconfiguration could unintentionally reject legitimate public-network traffic, though the feature is disabled by default.
> 
> **Overview**
> Adds an optional **per-peer request rate limiter** for the state sync storage service, configurable via `StorageServiceConfig.max_requests_per_second_per_peer` (disabled by default and only enforced for `public` network peers).
> 
> The server now tracks per-peer token buckets in `RequestModerator`, returns a new `TooManyRequests` error mapped through to `StorageServiceError`, and exports a `STORAGE_REQUESTS_RATE_LIMITED` metric; rate-limit state is garbage-collected for disconnected peers and covered by new `rate_limiter` tests. Separately, `aptos-token-bucket` relaxes constructor assertions and adds handling/tests for zero refill-rate edge cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 87db276333dad133daed678f35697e50592ed460. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->