### PR TITLE
[storage] Enable ribbon filters for state merkle db

### DIFF
--- a/config/src/config/storage_config.rs
+++ b/config/src/config/storage_config.rs
@@ -220,7 +220,11 @@ impl Default for RocksdbConfigs {
     fn default() -> Self {
         Self {
             ledger_db_config: RocksdbConfig::default(),
-            state_merkle_db_config: RocksdbConfig::default(),
+            state_merkle_db_config: RocksdbConfig {
+                bloom_filter_bits: Some(10.0),
+                bloom_before_level: Some(2),
+                ..Default::default()
+            },
             state_kv_db_config: RocksdbConfig {
                 bloom_filter_bits: Some(10.0),
                 bloom_before_level: Some(2),


### PR DESCRIPTION

`state_kv_db` already had bloom/ribbon filters enabled, but `state_merkle_db`
did not — it relied purely on RocksDB index lookups for every point read. This
is a significant oversight since the Jellyfish Merkle Tree workload involves
frequent point lookups across multiple SST files (especially during compaction
and stale node pruning), where most probed files do *not* contain the target
key.

Enable the same hybrid filter config as `state_kv_db`:
- 10 bits per key (bloom on L0–L1, ribbon on L2+)

### Motivation

During compaction and pruning, RocksDB must probe many SST files per lookup.
Without filters, every probe requires reading an index block + data block
even when the key is absent. Filters let RocksDB skip absent-key files
without touching data blocks at all.

### Test results (fullnode, 16 shards, ~95 min session)

- **72% of all lookups** (2.0M out of 2.8M) were filtered — avoided data
  block I/O entirely
- False positive rate: **0.9%** among true negatives
- Filter space overhead: **<1%** of SST data size
- Biggest beneficiaries: `stale_node_index` (pruning) and
  `jellyfish_merkle_node` (compaction reads)

### Trade-offs

- Slightly higher SST file size (<1% increase) and minor CPU cost to
  build/query filters — negligible relative to the I/O saved.
- Ribbon filters on L2+ are more space-efficient than bloom for the same
  FP rate, while bloom on L0–L1 avoids the higher ribbon build cost on
  frequently-flushed levels.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change, but it alters default RocksDB table settings for `state_merkle_db`, which may affect performance and disk usage and should be validated in production-like workloads.
> 
> **Overview**
> **Enables hybrid bloom/ribbon filters for `state_merkle_db` by default.**
> 
> Updates `RocksdbConfigs::default()` so `state_merkle_db_config` now sets `bloom_filter_bits: 10.0` and `bloom_before_level: 2`, matching the existing defaults already used for `state_kv_db_config` to reduce point-read SST probing overhead.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 774aa5522d1fdfe7e213caa565feea7ba073590e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->