### PR TITLE
[storage] Report RocksDB ticker statistics via Prometheus

### DIFF
--- a/consensus/src/consensusdb/mod.rs
+++ b/consensus/src/consensusdb/mod.rs
@@ -65,7 +65,7 @@ impl ConsensusDB {
         let mut opts = Options::default();
         opts.create_if_missing(true);
         opts.create_missing_column_families(true);
-        let db = DB::open(path.clone(), "consensus", column_families, &opts)
+        let db = DB::open(path.clone(), "consensus", column_families, opts)
             .expect("ConsensusDB open failed; unable to continue");
 
         info!(

--- a/consensus/src/quorum_store/quorum_store_db.rs
+++ b/consensus/src/quorum_store/quorum_store_db.rs
@@ -67,7 +67,7 @@ impl QuorumStoreDB {
         let mut opts = Options::default();
         opts.create_if_missing(true);
         opts.create_missing_column_families(true);
-        let db = DB::open(path.clone(), QUORUM_STORE_DB_NAME, column_families, &opts)
+        let db = DB::open(path.clone(), QUORUM_STORE_DB_NAME, column_families, opts)
             .expect("QuorumstoreDB open failed; unable to continue");
 
         info!(

--- a/consensus/src/rand/rand_gen/storage/db.rs
+++ b/consensus/src/rand/rand_gen/storage/db.rs
@@ -39,7 +39,7 @@ impl RandDb {
         opts.create_if_missing(true);
         opts.create_missing_column_families(true);
         let db = Arc::new(
-            DB::open(path.clone(), RAND_DB_NAME, column_families, &opts)
+            DB::open(path.clone(), RAND_DB_NAME, column_families, opts)
                 .expect("RandDB open failed; unable to continue"),
         );
 

--- a/experimental/storage/layered-map/benches/maps.rs
+++ b/experimental/storage/layered-map/benches/maps.rs
@@ -279,13 +279,9 @@ fn get_rocksdb(
                         let mut options = rocksdb::Options::default();
                         options.create_if_missing(true);
 
-                        let db = DB::open(
-                            &db_path,
-                            "bench",
-                            vec![DEFAULT_COLUMN_FAMILY_NAME],
-                            &options,
-                        )
-                        .unwrap();
+                        let db =
+                            DB::open(&db_path, "bench", vec![DEFAULT_COLUMN_FAMILY_NAME], options)
+                                .unwrap();
 
                         let mut total = 0;
                         items.iter().chunks(1_000_000).into_iter().for_each(|kvs| {

--- a/state-sync/state-sync-driver/src/metadata_storage.rs
+++ b/state-sync/state-sync-driver/src/metadata_storage.rs
@@ -76,7 +76,7 @@ impl PersistentMetadataStorage {
             state_sync_db_path.clone(),
             "state_sync",
             vec![METADATA_CF_NAME],
-            &options,
+            options,
         )
         .unwrap_or_else(|error| {
             panic!(

--- a/storage/aptosdb/src/ledger_db/mod.rs
+++ b/storage/aptosdb/src/ledger_db/mod.rs
@@ -341,6 +341,10 @@ impl LedgerDb {
         &self.ledger_metadata_db
     }
 
+    pub(crate) fn metadata_db_raw(&self) -> &DB {
+        self.ledger_metadata_db.db()
+    }
+
     // TODO(grao): Remove this after sharding migration.
     pub(crate) fn metadata_db_arc(&self) -> Arc<DB> {
         self.ledger_metadata_db.db_arc()
@@ -414,14 +418,14 @@ impl LedgerDb {
     ) -> Result<DB> {
         let db = if readonly {
             DB::open_cf_readonly(
-                &gen_rocksdb_options(db_config, env, true),
+                gen_rocksdb_options(db_config, env, true),
                 path.clone(),
                 name,
                 Self::gen_cfds_by_name(db_config, block_cache, name),
             )?
         } else {
             DB::open_cf(
-                &gen_rocksdb_options(db_config, env, false),
+                gen_rocksdb_options(db_config, env, false),
                 path.clone(),
                 name,
                 Self::gen_cfds_by_name(db_config, block_cache, name),

--- a/storage/aptosdb/src/metrics.rs
+++ b/storage/aptosdb/src/metrics.rs
@@ -168,6 +168,18 @@ pub static ROCKSDB_SHARD_PROPERTIES: Lazy<IntGaugeVec> = Lazy::new(|| {
     .unwrap()
 });
 
+/// Rocksdb ticker metrics (per-DB cumulative counters).
+/// Unlike properties (which are per-CF), tickers are per-DB-instance.
+/// The db_name already encodes shard info for sharded DBs (e.g. "state_kv_db_shard_0").
+pub static ROCKSDB_TICKERS: Lazy<IntGaugeVec> = Lazy::new(|| {
+    register_int_gauge_vec!(
+        "aptos_rocksdb_tickers",
+        "rocksdb cumulative ticker counters",
+        &["db_name", "ticker_name"]
+    )
+    .unwrap()
+});
+
 // Async committer gauges:
 pub(crate) static LATEST_SNAPSHOT_VERSION: Lazy<IntGauge> = Lazy::new(|| {
     register_int_gauge!(

--- a/storage/aptosdb/src/rocksdb_property_reporter.rs
+++ b/storage/aptosdb/src/rocksdb_property_reporter.rs
@@ -10,7 +10,8 @@ use crate::{
     },
     ledger_db::LedgerDb,
     metrics::{
-        OTHER_TIMERS_SECONDS, ROCKSDB_PROPERTIES, ROCKSDB_SHARD_PROPERTIES, SHARD_NAME_BY_ID,
+        OTHER_TIMERS_SECONDS, ROCKSDB_PROPERTIES, ROCKSDB_SHARD_PROPERTIES, ROCKSDB_TICKERS,
+        SHARD_NAME_BY_ID,
     },
     state_kv_db::StateKvDb,
     state_merkle_db::StateMerkleDb,
@@ -19,7 +20,7 @@ use anyhow::Result;
 use aptos_infallible::Mutex;
 use aptos_logger::prelude::*;
 use aptos_metrics_core::TimerHelper;
-use aptos_schemadb::{ColumnFamilyName, DB};
+use aptos_schemadb::{ColumnFamilyName, Ticker, DB};
 use aptos_types::state_store::NUM_STATE_SHARDS;
 use once_cell::sync::Lazy;
 use std::{
@@ -57,6 +58,50 @@ static ROCKSDB_PROPERTY_MAP: Lazy<HashMap<&str, String>> = Lazy::new(|| {
     .collect()
 });
 
+/// RocksDB tickers to report. These are per-DB cumulative counters (not per-CF).
+static ROCKSDB_TICKERS_TO_REPORT: &[(Ticker, &str)] = &[
+    (Ticker::StallMicros, "stall_micros"),
+    (Ticker::CompactReadBytes, "compact_read_bytes"),
+    (Ticker::CompactWriteBytes, "compact_write_bytes"),
+    (Ticker::FlushWriteBytes, "flush_write_bytes"),
+    (Ticker::BloomFilterUseful, "bloom_filter_useful"),
+    (
+        Ticker::BloomFilterFullPositive,
+        "bloom_filter_full_positive",
+    ),
+    (
+        Ticker::BloomFilterFullTruePositive,
+        "bloom_filter_full_true_positive",
+    ),
+    (
+        Ticker::BloomFilterPrefixChecked,
+        "bloom_filter_prefix_checked",
+    ),
+    (
+        Ticker::BloomFilterPrefixUseful,
+        "bloom_filter_prefix_useful",
+    ),
+    (
+        Ticker::BloomFilterPrefixTruePositive,
+        "bloom_filter_prefix_true_positive",
+    ),
+    (Ticker::BlockCacheHit, "block_cache_hit"),
+    (Ticker::BlockCacheMiss, "block_cache_miss"),
+    (Ticker::BlockCacheDataHit, "block_cache_data_hit"),
+    (Ticker::BlockCacheDataMiss, "block_cache_data_miss"),
+    (Ticker::BlockCacheFilterHit, "block_cache_filter_hit"),
+    (Ticker::BlockCacheFilterMiss, "block_cache_filter_miss"),
+];
+
+fn set_tickers(db: &DB) {
+    let db_name = db.name();
+    for (ticker, ticker_name) in ROCKSDB_TICKERS_TO_REPORT {
+        ROCKSDB_TICKERS
+            .with_label_values(&[db_name, ticker_name])
+            .set(db.get_ticker_count(*ticker) as i64);
+    }
+}
+
 fn set_property(cf_name: &str, db: &DB) -> Result<()> {
     if !skip_reporting_cf(cf_name) {
         for (rockdb_property_name, aptos_rocksdb_property_name) in &*ROCKSDB_PROPERTY_MAP {
@@ -91,7 +136,7 @@ fn update_rocksdb_properties(
     let _timer = OTHER_TIMERS_SECONDS.timer_with(&["update_rocksdb_properties"]);
 
     for cf in ledger_metadata_db_column_families() {
-        set_property(cf, &ledger_db.metadata_db_arc())?;
+        set_property(cf, ledger_db.metadata_db_raw())?;
     }
 
     for cf in write_set_db_column_families() {
@@ -127,6 +172,25 @@ fn update_rocksdb_properties(
             set_shard_property(cf_name, state_merkle_db.db_shard(shard), shard)?;
         }
     }
+
+    // Report per-DB tickers (not per-CF — tickers are DB-level statistics).
+    set_tickers(ledger_db.metadata_db_raw());
+    set_tickers(ledger_db.write_set_db_raw());
+    set_tickers(ledger_db.transaction_info_db_raw());
+    set_tickers(ledger_db.transaction_db_raw());
+    set_tickers(ledger_db.event_db_raw());
+    set_tickers(ledger_db.transaction_accumulator_db_raw());
+
+    set_tickers(state_kv_db.metadata_db());
+    for shard in 0..NUM_STATE_SHARDS {
+        set_tickers(state_kv_db.db_shard(shard));
+    }
+
+    set_tickers(state_merkle_db.metadata_db());
+    for shard in 0..NUM_STATE_SHARDS {
+        set_tickers(state_merkle_db.db_shard(shard));
+    }
+
     Ok(())
 }
 

--- a/storage/aptosdb/src/state_kv_db.rs
+++ b/storage/aptosdb/src/state_kv_db.rs
@@ -337,9 +337,9 @@ impl StateKvDb {
         let cfds = gen_state_kv_shard_cfds(state_kv_db_config, block_cache);
 
         if readonly {
-            DB::open_cf_readonly(&rocksdb_opts, path, name, cfds)
+            DB::open_cf_readonly(rocksdb_opts, path, name, cfds)
         } else {
-            DB::open_cf(&rocksdb_opts, path, name, cfds)
+            DB::open_cf(rocksdb_opts, path, name, cfds)
         }
     }
 

--- a/storage/aptosdb/src/state_merkle_db.rs
+++ b/storage/aptosdb/src/state_merkle_db.rs
@@ -676,14 +676,14 @@ impl StateMerkleDb {
 
         Ok(if readonly {
             DB::open_cf_readonly(
-                &gen_rocksdb_options(state_merkle_db_config, env, true),
+                gen_rocksdb_options(state_merkle_db_config, env, true),
                 path,
                 name,
                 gen_state_merkle_cfds(state_merkle_db_config, block_cache),
             )?
         } else {
             DB::open_cf(
-                &gen_rocksdb_options(state_merkle_db_config, env, false),
+                gen_rocksdb_options(state_merkle_db_config, env, false),
                 path,
                 name,
                 gen_state_merkle_cfds(state_merkle_db_config, block_cache),

--- a/storage/indexer/src/db_ops.rs
+++ b/storage/indexer/src/db_ops.rs
@@ -22,14 +22,14 @@ pub fn open_db<P: AsRef<Path>>(
             db_path,
             TABLE_INFO_DB_NAME,
             column_families(),
-            &gen_rocksdb_options(rocksdb_config, env, readonly),
+            gen_rocksdb_options(rocksdb_config, env, readonly),
         )?)
     } else {
         Ok(DB::open(
             db_path,
             TABLE_INFO_DB_NAME,
             column_families(),
-            &gen_rocksdb_options(rocksdb_config, env, readonly),
+            gen_rocksdb_options(rocksdb_config, env, readonly),
         )?)
     }
 }
@@ -43,7 +43,7 @@ pub fn open_internal_indexer_db<P: AsRef<Path>>(
         db_path,
         INTERNAL_INDEXER_DB_NAME,
         internal_indexer_column_families(),
-        &gen_rocksdb_options(rocksdb_config, env, false),
+        gen_rocksdb_options(rocksdb_config, env, false),
     )?)
 }
 

--- a/storage/indexer/src/lib.rs
+++ b/storage/indexer/src/lib.rs
@@ -67,7 +67,7 @@ impl Indexer {
             db_path,
             "index_db",
             column_families(),
-            &gen_rocksdb_options(&rocksdb_config, env, false),
+            gen_rocksdb_options(&rocksdb_config, env, false),
         )?;
 
         let next_version = db

--- a/storage/schemadb/tests/db.rs
+++ b/storage/schemadb/tests/db.rs
@@ -92,17 +92,17 @@ fn open_db(dir: &aptos_temppath::TempPath) -> DB {
     let mut db_opts = rocksdb::Options::default();
     db_opts.create_if_missing(true);
     db_opts.create_missing_column_families(true);
-    DB::open(dir.path(), "test", get_column_families(), &db_opts).expect("Failed to open DB.")
+    DB::open(dir.path(), "test", get_column_families(), db_opts).expect("Failed to open DB.")
 }
 
 fn open_db_read_only(dir: &aptos_temppath::TempPath) -> DB {
-    DB::open_cf_readonly(&rocksdb::Options::default(), dir.path(), "test", get_cfds())
+    DB::open_cf_readonly(rocksdb::Options::default(), dir.path(), "test", get_cfds())
         .expect("Failed to open DB.")
 }
 
 fn open_db_as_secondary(dir: &aptos_temppath::TempPath, dir_sec: &aptos_temppath::TempPath) -> DB {
     DB::open_cf_as_secondary(
-        &rocksdb::Options::default(),
+        rocksdb::Options::default(),
         dir.path(),
         dir_sec.path(),
         "test",
@@ -398,8 +398,8 @@ fn test_unrecognised_column_family() {
     opts.create_if_missing(true);
     opts.create_missing_column_families(true);
 
-    let db = DB::open(tmpdir.path(), "test", vec!["cf1", "cf2"], &opts).unwrap();
+    let db = DB::open(tmpdir.path(), "test", vec!["cf1", "cf2"], opts.clone()).unwrap();
     drop(db);
 
-    DB::open(tmpdir.path(), "test", vec!["cf1"], &opts).unwrap();
+    DB::open(tmpdir.path(), "test", vec!["cf1"], opts).unwrap();
 }

--- a/storage/schemadb/tests/iterator.rs
+++ b/storage/schemadb/tests/iterator.rs
@@ -110,7 +110,7 @@ impl TestDB {
         let mut db_opts = rocksdb::Options::default();
         db_opts.create_if_missing(true);
         db_opts.create_missing_column_families(true);
-        let db = DB::open(tmpdir.path(), "test", column_families, &db_opts).unwrap();
+        let db = DB::open(tmpdir.path(), "test", column_families, db_opts).unwrap();
 
         db.put::<TestSchema>(&TestKey(1, 0, 0), &TestValue(100))
             .unwrap();
@@ -299,7 +299,7 @@ impl TestDBWithPrefixExtractor {
         let mut db_opts = rocksdb::Options::default();
         db_opts.create_if_missing(true);
         db_opts.create_missing_column_families(true);
-        let db = DB::open_cf(&db_opts, tmpdir.path(), "test_with_prefix", vec![
+        let db = DB::open_cf(db_opts, tmpdir.path(), "test_with_prefix", vec![
             ColumnFamilyDescriptor::new(DEFAULT_COLUMN_FAMILY_NAME, rocksdb::Options::default()),
             ColumnFamilyDescriptor::new(TestSchema::COLUMN_FAMILY_NAME, {
                 let mut opts = rocksdb::Options::default();


### PR DESCRIPTION

Add periodic reporting of per-DB RocksDB ticker counters in
`RocksdbPropertyReporter`. Unlike properties (which are per-column-family),
tickers are per-DB-instance cumulative counters.

To support querying them, `DB::open*` now takes `Options` by value instead of
by reference, and retains the `Options` in the `DB` struct. The retained
`Options` shares the same underlying `Statistics` object as the live DB, so
`Options::get_ticker_count()` returns live values. A new `DB::get_ticker_count`
method is exposed for callers. A `DB::name()` accessor is also added so the
reporter can label metrics by DB name.

Add `LedgerDb::metadata_db_raw()` for consistency with the other sub-DB
accessors (`event_db_raw`, `write_set_db_raw`, etc.), and use it in the
reporter instead of `metadata_db_arc()` to avoid unnecessary `Arc` refcount
bumps.

**Tickers reported** (metric: `aptos_rocksdb_tickers{db_name, ticker_name}`):
- `stall_micros` — total write stall time
- `compact_read_bytes` / `compact_write_bytes` — compaction I/O
- `flush_write_bytes` — memtable flush I/O
- `bloom_filter_useful`, `bloom_filter_full_positive`,
  `bloom_filter_full_true_positive` — full-key bloom filter stats
- `bloom_filter_prefix_checked`, `bloom_filter_prefix_useful`,
  `bloom_filter_prefix_true_positive` — prefix bloom filter stats
- `block_cache_hit` / `block_cache_miss` — overall block cache
- `block_cache_data_hit` / `block_cache_data_miss` — data block cache
- `block_cache_filter_hit` / `block_cache_filter_miss` — filter block cache

A single gauge is used for all DBs (no separate shard gauge) because the
`db_name` label already encodes shard info (e.g. `"state_kv_db_shard_0"`).

Requires `stats_level` to be set in the RocksDB config for non-zero values.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the core `aptos_schemadb::DB` open APIs and threads `Options` ownership through many storage components, so mistakes could affect DB initialization or metrics correctness. Runtime behavior change is mostly additive (new metrics) but spans multiple DB open call sites.
> 
> **Overview**
> Adds periodic Prometheus reporting of **per-DB RocksDB ticker counters** via a new `aptos_rocksdb_tickers{db_name,ticker_name}` gauge, wired into `RocksdbPropertyReporter` alongside existing property reporting.
> 
> To support live ticker reads, `aptos_schemadb::DB` now **takes RocksDB `Options` by value**, retains them in the `DB` struct, and exposes `DB::name()` and `DB::get_ticker_count()`; storage/indexer/consensus DB open call sites are updated accordingly. Also adds `LedgerDb::metadata_db_raw()` and switches the reporter to use raw DB refs to avoid unnecessary `Arc` cloning.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a6c226076247815675d7a39d1ed94e2b023653d6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->