### PR TITLE
[gas] Add configurable multipliers for gas costs and storage fees

### DIFF
--- a/aptos-move/aptos-gas-schedule/src/gas_schedule/macros.rs
+++ b/aptos-move/aptos-gas-schedule/src/gas_schedule/macros.rs
@@ -78,7 +78,7 @@ macro_rules! define_gas_parameters {
         impl $crate::traits::InitialGasSchedule for $params_name {
             fn initial() -> Self {
                 Self {
-                    $($name: $initial.into()),*
+                    $($name: <$ty as $crate::traits::InitialGasParam>::from_raw($initial)),*
                 }
             }
         }

--- a/aptos-move/aptos-gas-schedule/src/lib.rs
+++ b/aptos-move/aptos-gas-schedule/src/lib.rs
@@ -27,9 +27,12 @@
 //! which can be then used in gas expressions once imported.
 
 mod gas_schedule;
+mod scaling;
 mod traits;
 mod ver;
 
 pub use gas_schedule::*;
-pub use traits::{FromOnChainGasSchedule, InitialGasSchedule, ToOnChainGasSchedule};
+pub use traits::{
+    FromOnChainGasSchedule, InitialGasParam, InitialGasSchedule, ToOnChainGasSchedule,
+};
 pub use ver::{gas_feature_versions, LATEST_GAS_FEATURE_VERSION};

--- a/aptos-move/aptos-gas-schedule/src/scaling.rs
+++ b/aptos-move/aptos-gas-schedule/src/scaling.rs
@@ -1,0 +1,69 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+use crate::traits::InitialGasParam;
+use aptos_gas_algebra::{
+    AbstractValueSize, AbstractValueSizePerArg, Fee, FeePerByte, FeePerGasUnit, FeePerSlot, Gas,
+    GasScalingFactor, InternalGasPerAbstractValueUnit, InternalGasPerTypeNode, NumModules,
+    NumSlots, NumTypeNodes,
+};
+use move_core_types::gas_algebra::{InternalGas, InternalGasPerArg, InternalGasPerByte, NumBytes};
+
+/// Multiplier applied to the initial values of gas cost parameters:
+/// - `InternalGas`
+/// - `InternalGasPerAbstractValueUnit`
+/// - `InternalGasPerArg`
+/// - `InternalGasPerByte`
+/// - `InternalGasPerTypeNode`
+pub(crate) const GAS_COST_MULTIPLIER: u64 = 1;
+
+/// Multiplier applied to the initial values of storage fee parameters:
+/// - `Fee`
+/// - `FeePerByte`
+/// - `FeePerSlot`
+pub(crate) const STORAGE_FEE_MULTIPLIER: u64 = 1;
+
+macro_rules! impl_initial_gas_param {
+    // Applies a multiplier to the raw value before converting to the gas parameter type.
+    ($multiplier:expr => $($ty:ty),+ $(,)?) => {$(
+        impl InitialGasParam for $ty {
+            fn from_raw(raw: u64) -> Self {
+                (raw * $multiplier).into()
+            }
+        }
+    )+};
+    // Directly converts the raw value to the gas parameter type without applying a multiplier.
+    ($($ty:ty),+ $(,)?) => {$(
+        impl InitialGasParam for $ty {
+            fn from_raw(raw: u64) -> Self {
+                raw.into()
+            }
+        }
+    )+};
+}
+
+impl_initial_gas_param!(GAS_COST_MULTIPLIER =>
+    InternalGas,
+    InternalGasPerAbstractValueUnit,
+    InternalGasPerArg,
+    InternalGasPerByte,
+    InternalGasPerTypeNode,
+);
+
+impl_initial_gas_param!(STORAGE_FEE_MULTIPLIER =>
+    Fee,
+    FeePerByte,
+    FeePerSlot,
+);
+
+impl_initial_gas_param!(
+    AbstractValueSize,
+    AbstractValueSizePerArg,
+    Gas,
+    GasScalingFactor,
+    FeePerGasUnit,
+    NumBytes,
+    NumModules,
+    NumSlots,
+    NumTypeNodes,
+);

--- a/aptos-move/aptos-gas-schedule/src/traits.rs
+++ b/aptos-move/aptos-gas-schedule/src/traits.rs
@@ -22,6 +22,16 @@ pub trait ToOnChainGasSchedule {
     fn to_on_chain_gas_schedule(&self, feature_version: u64) -> Vec<(String, u64)>;
 }
 
+/// Constructs an initial gas parameter from a raw `u64`, applying a multiplier where appropriate.
+///
+/// Implemented for all gas parameter types used in this crate:
+/// - Gas cost types apply [`crate::scaling::GAS_COST_MULTIPLIER`].
+/// - Storage fee types apply [`crate::scaling::STORAGE_FEE_MULTIPLIER`].
+/// - Limit, quota, and unit-conversion types pass the value through unchanged.
+pub trait InitialGasParam: Sized {
+    fn from_raw(raw: u64) -> Self;
+}
+
 /// A trait for defining an initial value to be used in the genesis.
 pub trait InitialGasSchedule: Sized {
     /// Returns the initial value of this type, which is used in the genesis.


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

This PR adds configurable multipliers for execution gas costs and storage fees, applied to the base values:
* Gas cost types apply `GAS_COST_MULTIPLIER`.
* Storage fee types apply `STORAGE_FEE_MULTIPLIER`.
* Limit, quota, and unit-conversion types pass values through unchanged.
* Both multipliers are currently set to 1, so there is no functional change (they will be updated in a follow-up PR).

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

Ran tests in `aptos-gas-schedule`.

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

The changes are primarily confined to the `InitialGasParam` trait and its implementations.

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [x] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that only affects how *genesis/initial* gas parameter values are constructed; multipliers are currently `1`, so behavior should be unchanged aside from potential arithmetic overflow if raised later.
> 
> **Overview**
> Introduces a new `InitialGasParam` trait and `scaling` module so initial gas parameters can be derived from raw `u64` values with optional category-specific multipliers.
> 
> Updates the gas-parameter macro’s `InitialGasSchedule::initial()` generation to call `InitialGasParam::from_raw(...)` (instead of plain `.into()`), and wires the trait/module into `lib.rs`, enabling future tuning of initial execution gas costs vs. storage fees via `GAS_COST_MULTIPLIER` and `STORAGE_FEE_MULTIPLIER`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c83a5015559b07c74e17db358fb80fa5a7ac1668. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->