### PR TITLE
[storage] Add missing RocksDB ticker stats to Prometheus reporter

### DIFF
--- a/storage/aptosdb/src/rocksdb_property_reporter.rs
+++ b/storage/aptosdb/src/rocksdb_property_reporter.rs
@@ -91,6 +91,41 @@ static ROCKSDB_TICKERS_TO_REPORT: &[(Ticker, &str)] = &[
     (Ticker::BlockCacheDataMiss, "block_cache_data_miss"),
     (Ticker::BlockCacheFilterHit, "block_cache_filter_hit"),
     (Ticker::BlockCacheFilterMiss, "block_cache_filter_miss"),
+    (Ticker::BlockCacheIndexHit, "block_cache_index_hit"),
+    (Ticker::BlockCacheIndexMiss, "block_cache_index_miss"),
+    // Per-level seek filter stats — most meaningful for state KV DB which has
+    // bloom/ribbon filters and uses prefix seeks.
+    (Ticker::LastLevelSeekFiltered, "last_level_seek_filtered"),
+    (
+        Ticker::LastLevelSeekFilterMatch,
+        "last_level_seek_filter_match",
+    ),
+    (Ticker::LastLevelSeekData, "last_level_seek_data"),
+    (
+        Ticker::LastLevelSeekDataUsefulNoFilter,
+        "last_level_seek_data_useful_no_filter",
+    ),
+    (
+        Ticker::LastLevelSeekDataUsefulFilterMatch,
+        "last_level_seek_data_useful_filter_match",
+    ),
+    (
+        Ticker::NonLastLevelSeekFiltered,
+        "non_last_level_seek_filtered",
+    ),
+    (
+        Ticker::NonLastLevelSeekFilterMatch,
+        "non_last_level_seek_filter_match",
+    ),
+    (Ticker::NonLastLevelSeekData, "non_last_level_seek_data"),
+    (
+        Ticker::NonLastLevelSeekDataUsefulNoFilter,
+        "non_last_level_seek_data_useful_no_filter",
+    ),
+    (
+        Ticker::NonLastLevelSeekDataUsefulFilterMatch,
+        "non_last_level_seek_data_useful_filter_match",
+    ),
 ];
 
 fn set_tickers(db: &DB) {


### PR DESCRIPTION

Add block cache index hit/miss tickers (`block_cache_index_hit`,
`block_cache_index_miss`) that were missed alongside the existing data
and filter block cache tickers. Among the block cache metrics, index hit
rate is the most important — index blocks are consulted on every
seek/get to locate data, so a miss forces an extra I/O before the filter
or data block can even be read.

Add per-level seek filter tickers for both last and non-last levels:
- `{last,non_last}_level_seek_filtered` — seeks skipped by filter
- `{last,non_last}_level_seek_filter_match` — seeks where filter matched
- `{last,non_last}_level_seek_data` — seeks that read data blocks
- `{last,non_last}_level_seek_data_useful_no_filter` — useful with no filter
- `{last,non_last}_level_seek_data_useful_filter_match` — useful after filter match

These are most meaningful for state KV DB, which is the only DB with
bloom/ribbon filters configured and uses prefix seeks for state value
lookups.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only expands Prometheus reporting with additional RocksDB ticker counters and does not affect DB reads/writes or correctness, aside from slightly increasing metrics collection work.
> 
> **Overview**
> Expands the RocksDB Prometheus ticker reporter to include **block cache index hit/miss** counters (`block_cache_index_hit`, `block_cache_index_miss`) alongside existing data/filter cache metrics.
> 
> Adds **per-level seek/filter tickers** for both last and non-last levels (filtered, filter matches, data reads, and “useful” seek variants), providing more detailed insight into seek behavior—particularly for state KV workloads using bloom/ribbon filters.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a0b26ec71462061a4630effc71c2a5d3bbda64b1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->