### PR TITLE
[toolchain] Upgrade Rust toolchain to 1.93.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -291,7 +291,7 @@ license = "LicenseRef-Aptos"
 license-file = "LICENSE"
 publish = false
 repository = "https://github.com/aptos-labs/aptos-core"
-rust-version = "1.85"
+rust-version = "1.88"
 
 [workspace.dependencies]
 # Internal crate dependencies.

--- a/aptos-move/aptos-e2e-comparison-testing/src/lib.rs
+++ b/aptos-move/aptos-e2e-comparison-testing/src/lib.rs
@@ -388,8 +388,8 @@ pub(crate) struct PackageInfo {
 impl fmt::Display for PackageInfo {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let mut name = format!("{}.{}", self.package_name, self.address);
-        if self.upgrade_number.is_some() {
-            name = format!("{}.{}", name, self.upgrade_number.unwrap());
+        if let Some(upgrade_number) = self.upgrade_number {
+            name = format!("{}.{}", name, upgrade_number);
         }
         write!(f, "{}", name)?;
         Ok(())

--- a/aptos-move/aptos-gas-meter/src/algebra.rs
+++ b/aptos-move/aptos-gas-meter/src/algebra.rs
@@ -251,7 +251,7 @@ where
         // u128 is used to protect against overflow and preserve as much precision as
         // possible in the extreme cases.
         fn div_ceil(n: u128, d: u128) -> u128 {
-            if n % d == 0 {
+            if n.is_multiple_of(d) {
                 n / d
             } else {
                 n / d + 1

--- a/aptos-move/aptos-vm/src/keyless_validation.rs
+++ b/aptos-move/aptos-vm/src/keyless_validation.rs
@@ -298,8 +298,8 @@ pub fn verify_keyless_signature_without_ephemeral_signature_check(
 
                 // If an `aud` override was set for account recovery purposes, check that it is
                 // in the allow-list on-chain.
-                if zksig.override_aud_val.is_some() {
-                    config.is_allowed_override_aud(zksig.override_aud_val.as_ref().unwrap())?;
+                if let Some(override_aud_val) = &zksig.override_aud_val {
+                    config.is_allowed_override_aud(override_aud_val)?;
                 }
                 match &zksig.proof {
                     ZKP::Groth16(groth16proof) => {

--- a/aptos-move/block-executor/src/combinatorial_tests/types.rs
+++ b/aptos-move/block-executor/src/combinatorial_tests/types.rs
@@ -594,7 +594,7 @@ impl<V: Into<Vec<u8>> + Arbitrary + Clone + Debug + Eq + Sync + Send> Transactio
                 .unwrap();
 
             // Not all values become deltas - some remain as normal writes
-            if val_u128 % 10 != 0 {
+            if !val_u128.is_multiple_of(10) {
                 let delta = if val_u128 % 10 < 5 {
                     delta_sub(val_u128 % 100, u128::MAX)
                 } else {
@@ -609,7 +609,7 @@ impl<V: Into<Vec<u8>> + Arbitrary + Clone + Debug + Eq + Sync + Send> Transactio
             .as_u128()
             .unwrap()
             .unwrap();
-        let is_deletion = allow_deletes && val_u128 % 23 == 0;
+        let is_deletion = allow_deletes && val_u128.is_multiple_of(23);
         let mut write_value = ValueType::from_value(value.clone(), !is_deletion);
         write_value.metadata = raw_metadata((val_u128 >> 64) as u64);
 

--- a/consensus/src/quorum_store/tests/batch_store_test.rs
+++ b/consensus/src/quorum_store/tests/batch_store_test.rs
@@ -163,7 +163,7 @@ async fn test_extend_expiration_vs_save() {
 
     for (i, &digest) in digests.iter().enumerate().take(num_experiments) {
         // Set the conditions for experiment (both threads waiting).
-        while start_flag.load(Ordering::Acquire) % 3 != 0 {
+        while !start_flag.load(Ordering::Acquire).is_multiple_of(3) {
             assert!(!save_error.load(Ordering::Acquire));
         }
 
@@ -175,7 +175,7 @@ async fn test_extend_expiration_vs_save() {
         start_flag.fetch_add(1, Ordering::Relaxed);
     }
     // Finish the experiment
-    while start_flag.load(Ordering::Acquire) % 3 != 0 {}
+    while !start_flag.load(Ordering::Acquire).is_multiple_of(3) {}
 
     // Expire everything, call for higher times as well.
     for i in 35..50 {

--- a/crates/aptos-batch-encryption/src/shared/digest.rs
+++ b/crates/aptos-batch-encryption/src/shared/digest.rs
@@ -59,7 +59,7 @@ impl DigestKey {
     pub fn new(rng: &mut impl RngCore, batch_size: usize, num_rounds: usize) -> Result<Self> {
         let mut i = batch_size;
         while i > 1 {
-            (i % 2 == 0)
+            i.is_multiple_of(2)
                 .then_some(())
                 .ok_or(BatchEncryptionError::DigestInitError(
                     DigestKeyInitError::BatchSizeMustBePowerOfTwo,

--- a/crates/aptos-crypto/src/hash.rs
+++ b/crates/aptos-crypto/src/hash.rs
@@ -213,7 +213,7 @@ impl HashValue {
     pub fn nibble(&self, index: usize) -> u8 {
         debug_assert!(index < Self::LENGTH * 2); // assumed precondition
         let pos = index / 2;
-        let shift = if index % 2 == 0 { 4 } else { 0 };
+        let shift = if index.is_multiple_of(2) { 4 } else { 0 };
         (self.hash[pos] >> shift) & 0x0F
     }
 

--- a/crates/aptos-telemetry/src/telemetry_log_sender.rs
+++ b/crates/aptos-telemetry/src/telemetry_log_sender.rs
@@ -125,7 +125,7 @@ mod tests {
             // Create batch that reaches max bytes
             let bytes_per_string = 11;
             let mut num_strings = (MAX_BYTES + 1) / bytes_per_string;
-            if (MAX_BYTES + 1) % bytes_per_string != 0 {
+            if !(MAX_BYTES + 1).is_multiple_of(bytes_per_string) {
                 num_strings += 1;
             }
             let to_send: Vec<_> = (0..num_strings).map(|i| format!("{:11}", i)).collect();

--- a/crates/aptos/src/genesis/git.rs
+++ b/crates/aptos/src/genesis/git.rs
@@ -108,22 +108,16 @@ pub struct GitOptions {
 
 impl GitOptions {
     pub fn get_client(self) -> CliTypedResult<Client> {
-        if self.github_repository.is_none()
-            && self.github_token_file.is_none()
-            && self.local_repository_dir.is_some()
-        {
-            Ok(Client::local(self.local_repository_dir.unwrap()))
-        } else if self.github_repository.is_some()
-            && self.github_token_file.is_some()
-            && self.local_repository_dir.is_none()
-        {
-            Client::github(
-                self.github_repository.unwrap(),
-                self.github_branch,
-                self.github_token_file.unwrap(),
-            )
-        } else {
-            Err(CliError::CommandArgumentError("Must provide either only --local-repository-dir or both --github-repository and --github-token-path".to_string()))
+        match (
+            self.local_repository_dir,
+            self.github_repository,
+            self.github_token_file,
+        ) {
+            (Some(local_dir), None, None) => Ok(Client::local(local_dir)),
+            (None, Some(repo), Some(token_file)) => {
+                Client::github(repo, self.github_branch, token_file)
+            },
+            _ => Err(CliError::CommandArgumentError("Must provide either only --local-repository-dir or both --github-repository and --github-token-path".to_string())),
         }
     }
 }

--- a/crates/transaction-emitter-lib/src/wrappers.rs
+++ b/crates/transaction-emitter-lib/src/wrappers.rs
@@ -31,51 +31,55 @@ pub async fn emit_transactions(
     emit_args: &EmitArgs,
     transaction_mix_per_phase: Vec<Vec<(TransactionType, usize)>>,
 ) -> Result<TxnStats> {
-    if emit_args.coordination_delay_between_instances.is_none() {
-        let cluster = Cluster::try_from_cluster_args(cluster_args)
-            .await
-            .context("Failed to build cluster")?;
-        emit_transactions_with_cluster(&cluster, emit_args, transaction_mix_per_phase).await
-    } else {
-        let initial_delay_after_minting = emit_args.coordination_delay_between_instances.unwrap();
-        let start_time = Instant::now();
-        let mut i = 0;
-        loop {
-            let cur_emit_args = if i > 0 {
-                let mut cur_emit_args = emit_args.clone();
-                cur_emit_args.coordination_delay_between_instances =
-                    initial_delay_after_minting.checked_sub(start_time.elapsed().as_secs());
-                if cur_emit_args.coordination_delay_between_instances.is_none() {
-                    bail!("txn_emitter couldn't succeed after {} runs", i);
-                }
-                info!(
-                    "Reduced coordination_delay_between_instances to {} for run {}",
-                    cur_emit_args.coordination_delay_between_instances.unwrap(),
-                    i
-                );
-                cur_emit_args
-            } else {
-                emit_args.clone()
-            };
-
+    let initial_delay_after_minting = match emit_args.coordination_delay_between_instances {
+        Some(delay) => delay,
+        None => {
             let cluster = Cluster::try_from_cluster_args(cluster_args)
                 .await
                 .context("Failed to build cluster")?;
-
-            let result = emit_transactions_with_cluster(
-                &cluster,
-                &cur_emit_args,
-                transaction_mix_per_phase.clone(),
-            )
-            .await;
-            match result {
-                Ok(value) => return Ok(value),
-                Err(e) => {
-                    error!("Couldn't run txn emitter: {:?}, retrying", e)
+            return emit_transactions_with_cluster(&cluster, emit_args, transaction_mix_per_phase)
+                .await;
+        },
+    };
+    let start_time = Instant::now();
+    let mut i = 0;
+    loop {
+        let cur_emit_args = if i > 0 {
+            let mut cur_emit_args = emit_args.clone();
+            let remaining_delay =
+                initial_delay_after_minting.checked_sub(start_time.elapsed().as_secs());
+            match remaining_delay {
+                Some(delay) => {
+                    cur_emit_args.coordination_delay_between_instances = Some(delay);
+                    info!(
+                        "Reduced coordination_delay_between_instances to {} for run {}",
+                        delay, i
+                    );
                 },
+                None => bail!("txn_emitter couldn't succeed after {} runs", i),
             }
-            i += 1;
+            cur_emit_args
+        } else {
+            emit_args.clone()
+        };
+
+        let cluster = Cluster::try_from_cluster_args(cluster_args)
+            .await
+            .context("Failed to build cluster")?;
+
+        let result = emit_transactions_with_cluster(
+            &cluster,
+            &cur_emit_args,
+            transaction_mix_per_phase.clone(),
+        )
+        .await;
+        match result {
+            Ok(value) => return Ok(value),
+            Err(e) => {
+                error!("Couldn't run txn emitter: {:?}, retrying", e)
+            },
         }
+        i += 1;
     }
 }
 

--- a/docker/builder/docker-bake-rust-all.hcl
+++ b/docker/builder/docker-bake-rust-all.hcl
@@ -82,8 +82,8 @@ target "builder-base" {
   target     = "builder-base"
   context    = "."
   contexts = {
-    # Run `docker buildx imagetools inspect rust:1.92.0-trixie` to find the latest multi-platform hash
-    rust = "docker-image://rust:1.92.0-trixie@sha256:f58923369ba295ae1f60bc49d03f2c955a5c93a0b7d49acfb2b2a65bebaf350d"
+    # Run `docker buildx imagetools inspect rust:1.93.1-trixie` to find the latest multi-platform hash
+    rust = "docker-image://rust:1.93.1-trixie@sha256:51c04d7a2b38418ba23ecbfb373c40d3bd493dec1ddfae00ab5669527320195e"
   }
   args = {
     PROFILE            = "${PROFILE}"

--- a/ecosystem/indexer-grpc/indexer-grpc-manager/src/file_store_uploader.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-manager/src/file_store_uploader.rs
@@ -211,17 +211,18 @@ impl FileStoreUploader {
 
         let mut update_batch_metadata = false;
         let max_update_frequency = self.writer.max_update_frequency();
-        if self.last_batch_metadata_update_time.is_none()
-            || Instant::now() - self.last_batch_metadata_update_time.unwrap()
-                >= MIN_UPDATE_FREQUENCY
-        {
-            update_batch_metadata = true;
-        } else if end_batch {
-            update_batch_metadata = true;
-            tokio::time::sleep_until(
-                self.last_batch_metadata_update_time.unwrap() + max_update_frequency,
-            )
-            .await;
+        match self.last_batch_metadata_update_time {
+            None => {
+                update_batch_metadata = true;
+            },
+            Some(last_update_time) if Instant::now() - last_update_time >= MIN_UPDATE_FREQUENCY => {
+                update_batch_metadata = true;
+            },
+            Some(last_update_time) if end_batch => {
+                update_batch_metadata = true;
+                tokio::time::sleep_until(last_update_time + max_update_frequency).await;
+            },
+            _ => {},
         }
 
         if !update_batch_metadata {

--- a/ecosystem/indexer-grpc/indexer-grpc-utils/src/file_store_operator/gcs.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-utils/src/file_store_operator/gcs.rs
@@ -213,7 +213,7 @@ impl FileStoreOperator for GcsFileStoreOperator {
         let end_version = transactions.last().unwrap().version;
         let batch_size = transactions.len();
         anyhow::ensure!(
-            start_version % FILE_ENTRY_TRANSACTION_COUNT == 0,
+            start_version.is_multiple_of(FILE_ENTRY_TRANSACTION_COUNT),
             "Starting version has to be a multiple of BLOB_STORAGE_SIZE."
         );
         anyhow::ensure!(

--- a/ecosystem/indexer-grpc/indexer-grpc-utils/src/file_store_operator/local.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-utils/src/file_store_operator/local.rs
@@ -154,11 +154,11 @@ impl FileStoreOperator for LocalFileStoreOperator {
         let start_version = transactions.first().unwrap().version;
         let batch_size = transactions.len();
         anyhow::ensure!(
-            start_version % FILE_ENTRY_TRANSACTION_COUNT == 0,
+            start_version.is_multiple_of(FILE_ENTRY_TRANSACTION_COUNT),
             "Starting version has to be a multiple of BLOB_STORAGE_SIZE."
         );
         anyhow::ensure!(
-            batch_size % FILE_ENTRY_TRANSACTION_COUNT as usize == 0,
+            batch_size.is_multiple_of(FILE_ENTRY_TRANSACTION_COUNT as usize),
             "The number of transactions to upload has to be multiplier of BLOB_STORAGE_SIZE."
         );
         let mut tasks = vec![];

--- a/ecosystem/indexer-grpc/indexer-grpc-utils/src/file_store_operator_v2/file_store_operator.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-utils/src/file_store_operator_v2/file_store_operator.rs
@@ -45,7 +45,7 @@ impl FileStoreOperatorV2 {
         transaction: Transaction,
         tx: Sender<(Vec<Transaction>, BatchMetadata, bool)>,
     ) -> Result<()> {
-        let end_batch = (transaction.version + 1) % self.num_txns_per_folder == 0;
+        let end_batch = (transaction.version + 1).is_multiple_of(self.num_txns_per_folder);
         let size_bytes = transaction.encoded_len();
         ensure!(
             self.version == transaction.version,

--- a/ecosystem/indexer-grpc/indexer-grpc-v2-file-store-backfiller/src/processor.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-v2-file-store-backfiller/src/processor.rs
@@ -66,8 +66,8 @@ impl Processor {
         ensure!(metadata.chain_id == chain_id, "Chain ID mismatch.");
         let num_transactions_per_folder = metadata.num_transactions_per_folder;
         ensure!(
-            starting_version % num_transactions_per_folder == 0
-                && ending_version % num_transactions_per_folder == 0,
+            starting_version.is_multiple_of(num_transactions_per_folder)
+                && ending_version.is_multiple_of(num_transactions_per_folder),
             "starting_version and ending_version must be multiply of num_transactions_per_folder ({num_transactions_per_folder})."
         );
 
@@ -91,7 +91,7 @@ impl Processor {
         };
 
         ensure!(
-            progress_file.version % num_transactions_per_folder == 0,
+            progress_file.version.is_multiple_of(num_transactions_per_folder),
             "version in the progress file must be the multiply of num_transactions_per_folder ({num_transactions_per_folder})."
         );
 

--- a/experimental/storage/hexy/src/in_mem/base.rs
+++ b/experimental/storage/hexy/src/in_mem/base.rs
@@ -85,7 +85,7 @@ impl HexyBase {
             if level_size == 1 {
                 break;
             } else {
-                level_size = level_size / ARITY + (level_size % ARITY != 0) as usize;
+                level_size = level_size / ARITY + (!level_size.is_multiple_of(ARITY)) as usize;
             }
         }
 

--- a/keyless/pepper/service/src/external_resources/jwk_fetcher.rs
+++ b/keyless/pepper/service/src/external_resources/jwk_fetcher.rs
@@ -272,7 +272,7 @@ pub fn start_jwk_refresh_loop(
             match &fetch_result {
                 Ok(key_set) => {
                     // Log the successful fetch
-                    if loop_iteration_counter % JWK_REFRESH_LOOP_LOG_FREQUENCY == 0 {
+                    if loop_iteration_counter.is_multiple_of(JWK_REFRESH_LOOP_LOG_FREQUENCY) {
                         info!(
                             "Successfully fetched the JWK in {:?}! Issuer: {}, URL: {}, Key set: {:?}",
                             fetch_time,

--- a/keyless/pepper/service/src/external_resources/resource_fetcher.rs
+++ b/keyless/pepper/service/src/external_resources/resource_fetcher.rs
@@ -240,7 +240,7 @@ pub fn start_external_resource_refresh_loop<T: DeserializeOwned + Send + Sync + 
             match fetch_result {
                 Ok(resource) => {
                     // Log the successful fetch
-                    if loop_iteration_counter % RESOURCE_REFRESH_LOOP_LOG_FREQUENCY == 0 {
+                    if loop_iteration_counter.is_multiple_of(RESOURCE_REFRESH_LOOP_LOG_FREQUENCY) {
                         info!(
                             "Successfully fetched resource {} from {} in {:?}",
                             resource_name, resource_url, fetch_time

--- a/mempool/src/tests/core_mempool_test.rs
+++ b/mempool/src/tests/core_mempool_test.rs
@@ -1269,7 +1269,7 @@ fn test_parking_lot_eviction_benchmark() {
     add_signed_txn(&mut pool, huge_signed_txn).unwrap();
     let time_to_evict_ms = now.elapsed().as_millis();
 
-    let has_remainder = huge_txn_size % small_txn_size != 0;
+    let has_remainder = !huge_txn_size.is_multiple_of(small_txn_size);
     let num_expected_evicted = num_small_txns / 2 + has_remainder as usize;
     assert_eq!(
         pool.get_parking_lot_size(),

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.92.0"
+channel = "1.93.1"
 
 # Note: we don't specify cargofmt in our toolchain because we rely on
 # the nightly version of cargofmt and verify formatting in CI/CD.

--- a/scripts/update_docker_images.py
+++ b/scripts/update_docker_images.py
@@ -10,7 +10,7 @@ OS = "linux"
 
 IMAGES = {
     "debian": "debian:trixie",
-    "rust": "rust:1.92.0-trixie",
+    "rust": "rust:1.93.1-trixie",
 }
 
 

--- a/state-sync/aptos-data-client/src/poller.rs
+++ b/state-sync/aptos-data-client/src/poller.rs
@@ -308,7 +308,7 @@ pub async fn start_poller(poller: DataSummaryPoller) {
         // Determine the peers to poll this round. If the round is even, poll
         // the priority peers. Otherwise, poll the regular peers. This allows
         // us to alternate between peer types and load balance requests.
-        let poll_priority_peers = polling_round % 2 == 0;
+        let poll_priority_peers = polling_round.is_multiple_of(2);
 
         // Identify the peers to poll (if any)
         let peers_to_poll = match poller.identify_peers_to_poll(poll_priority_peers) {

--- a/state-sync/aptos-data-client/src/tests/utils.rs
+++ b/state-sync/aptos-data-client/src/tests/utils.rs
@@ -321,7 +321,7 @@ pub fn get_peer_priority_for_polling(poll_priority_peers: bool) -> PeerPriority 
 
         // If the random number is even, return medium priority.
         // Otherwise, return low priority.
-        if random_number % 2 == 0 {
+        if random_number.is_multiple_of(2) {
             PeerPriority::MediumPriority
         } else {
             PeerPriority::LowPriority

--- a/state-sync/data-streaming-service/src/tests/data_stream.rs
+++ b/state-sync/data-streaming-service/src/tests/data_stream.rs
@@ -3636,7 +3636,7 @@ fn set_epoch_ending_response_for_indices(
         let random_number = create_random_u64(100);
         if indices.contains(&index) {
             set_epoch_ending_response_in_queue(data_stream, index as usize, 0); // Set a valid response
-        } else if random_number % 3 == 0 {
+        } else if random_number.is_multiple_of(3) {
             set_timeout_response_in_queue(data_stream, index as usize); // Set a timeout response
         } else if random_number % 3 == 1 {
             set_failure_response_in_queue(data_stream, index as usize); // Set a failure response

--- a/state-sync/data-streaming-service/src/tests/utils.rs
+++ b/state-sync/data-streaming-service/src/tests/utils.rs
@@ -1120,5 +1120,5 @@ pub fn create_output_list_with_proof(
 ///
 /// Note: there's a 50-50 chance of this occurring.
 fn return_transactions_instead_of_outputs() -> bool {
-    (create_random_u64(u64::MAX) % 2) == 0
+    create_random_u64(u64::MAX).is_multiple_of(2)
 }

--- a/state-sync/storage-service/server/src/tests/utils.rs
+++ b/state-sync/storage-service/server/src/tests/utils.rs
@@ -755,7 +755,7 @@ pub async fn force_cache_update_notification(
     // a state sync notification. Otherwise, advance enough time
     // to refresh the storage cache manually.
     let random_number: u8 = OsRng.r#gen();
-    if always_advance_time || random_number % 2 != 0 {
+    if always_advance_time || !random_number.is_multiple_of(2) {
         // Advance the storage refresh time manually
         advance_storage_refresh_time(mock_time).await;
     } else {

--- a/state-sync/storage-service/types/src/tests.rs
+++ b/state-sync/storage-service/types/src/tests.rs
@@ -620,7 +620,7 @@ fn create_optimistic_fetch_request(
     let random_number = get_random_u64();
 
     // Determine the data request type based on the random number
-    let data_request = if random_number % 3 == 0 {
+    let data_request = if random_number.is_multiple_of(3) {
         DataRequest::GetNewTransactionsWithProof(NewTransactionsWithProofRequest {
             known_version,
             known_epoch: get_random_u64(),
@@ -653,7 +653,7 @@ fn create_optimistic_fetch_request_v2(
     let random_number = get_random_u64();
 
     // Determine the data request type based on the random number
-    let data_request = if random_number % 3 == 0 {
+    let data_request = if random_number.is_multiple_of(3) {
         DataRequest::get_new_transaction_data_with_proof(
             known_version,
             get_random_u64(),
@@ -722,7 +722,7 @@ fn create_subscription_request(known_version: u64, use_compression: bool) -> Sto
     let random_number = get_random_u64();
 
     // Determine the data request type based on the random number
-    let data_request = if random_number % 3 == 0 {
+    let data_request = if random_number.is_multiple_of(3) {
         DataRequest::SubscribeTransactionsWithProof(SubscribeTransactionsWithProofRequest {
             subscription_stream_metadata,
             include_events: false,
@@ -764,7 +764,7 @@ fn create_subscription_request_v2(
     let random_number = get_random_u64();
 
     // Determine the data request type based on the random number
-    let data_request = if random_number % 3 == 0 {
+    let data_request = if random_number.is_multiple_of(3) {
         DataRequest::subscribe_transaction_data_with_proof(
             subscription_stream_metadata,
             get_random_u64(),

--- a/storage/aptosdb/src/db_debugger/ledger/check_txn_info_hashes.rs
+++ b/storage/aptosdb/src/db_debugger/ledger/check_txn_info_hashes.rs
@@ -50,7 +50,7 @@ impl Cmd {
                 leaf_hash,
             );
 
-            if version % 10_000 == 0 {
+            if version.is_multiple_of(10_000) {
                 println!("Good until version {}.", version);
             }
 

--- a/storage/aptosdb/src/db_debugger/validation.rs
+++ b/storage/aptosdb/src/db_debugger/validation.rs
@@ -186,7 +186,7 @@ fn verify_state_kv(
             );
         }
         counter += 1;
-        if counter as usize % SAMPLE_RATE == 0 {
+        if (counter as usize).is_multiple_of(SAMPLE_RATE) {
             println!(
                 "Processed {} keys, the current sample is {} at version {}",
                 counter, state_key_hash, version
@@ -248,7 +248,7 @@ fn verify_event_by_key(
         },
         Ok(Some((version, idx))) => {
             assert!(idx as usize == expected_idx && version == expected_version);
-            if version as usize % SAMPLE_RATE == 0 {
+            if (version as usize).is_multiple_of(SAMPLE_RATE) {
                 println!(
                     "Processed {} at {:?}, {:?}",
                     version, event_key, expected_idx

--- a/storage/aptosdb/src/state_store/mod.rs
+++ b/storage/aptosdb/src/state_store/mod.rs
@@ -1216,18 +1216,11 @@ impl StateValueWriter<StateKey, StateValue> for StateStore {
             &DbMetadataValue::StateSnapshotProgress(progress),
         )?;
 
-        if self.internal_indexer_db.is_some()
-            && self
-                .internal_indexer_db
-                .as_ref()
-                .unwrap()
-                .statekeys_enabled()
+        if let Some(internal_indexer_db) = self.internal_indexer_db.as_ref()
+            && internal_indexer_db.statekeys_enabled()
         {
             let keys = node_batch.keys().map(|key| key.0.clone()).collect();
-            self.internal_indexer_db
-                .as_ref()
-                .unwrap()
-                .write_keys_to_indexer_db(&keys, version, progress)?;
+            internal_indexer_db.write_keys_to_indexer_db(&keys, version, progress)?;
         }
         self.shard_state_value_batch(&mut sharded_schema_batch, node_batch)?;
         self.state_kv_db
@@ -1278,18 +1271,10 @@ impl StateValueWriter<StateKey, StateValue> for StateStore {
             .map(|v| v.expect_state_snapshot_progress());
 
         // verify if internal indexer db and main db are consistent before starting the restore
-        if self.internal_indexer_db.is_some()
-            && self
-                .internal_indexer_db
-                .as_ref()
-                .unwrap()
-                .statekeys_enabled()
+        if let Some(internal_indexer_db) = self.internal_indexer_db.as_ref()
+            && internal_indexer_db.statekeys_enabled()
         {
-            let progress_opt = self
-                .internal_indexer_db
-                .as_ref()
-                .unwrap()
-                .get_restore_progress(version)?;
+            let progress_opt = internal_indexer_db.get_restore_progress(version)?;
 
             match (main_db_progress, progress_opt) {
                 (None, None) => (),

--- a/storage/backup/backup-cli/src/storage/mod.rs
+++ b/storage/backup/backup-cli/src/storage/mod.rs
@@ -233,8 +233,8 @@ pub struct DBToolStorageOpt {
 
 impl DBToolStorageOpt {
     pub async fn init_storage(self) -> Result<Arc<dyn BackupStorage>> {
-        Ok(if self.local_fs_dir.is_some() {
-            Arc::new(LocalFs::new_with_opt(self.local_fs_dir.unwrap()))
+        Ok(if let Some(local_fs_dir) = self.local_fs_dir {
+            Arc::new(LocalFs::new_with_opt(local_fs_dir))
         } else {
             Arc::new(CommandAdapter::new_with_opt(self.command_adapter_config.unwrap()).await?)
         })

--- a/storage/jellyfish-merkle/src/jellyfish_merkle_test.rs
+++ b/storage/jellyfish-merkle/src/jellyfish_merkle_test.rs
@@ -19,7 +19,7 @@ use rand::{rngs::StdRng, Rng, SeedableRng};
 fn update_nibble(original_key: &HashValue, n: usize, nibble: u8) -> HashValue {
     assert!(nibble < 16);
     let mut key = original_key.to_vec();
-    key[n / 2] = if n % 2 == 0 {
+    key[n / 2] = if n.is_multiple_of(2) {
         key[n / 2] & 0x0F | (nibble << 4)
     } else {
         key[n / 2] & 0xF0 | nibble

--- a/storage/jellyfish-merkle/src/lib.rs
+++ b/storage/jellyfish-merkle/src/lib.rs
@@ -1058,7 +1058,7 @@ impl NibbleExt for HashValue {
     /// Returns the `index`-th nibble.
     fn get_nibble(&self, index: usize) -> Nibble {
         Nibble::from(
-            if index % 2 == 0 {
+            if index.is_multiple_of(2) {
                 self[index / 2] >> 4
             } else {
                 self[index / 2] & 0x0F

--- a/storage/jellyfish-merkle/src/node_type/mod.rs
+++ b/storage/jellyfish-merkle/src/node_type/mod.rs
@@ -126,7 +126,7 @@ impl NodeKey {
             num_nibbles,
             nibble_bytes
         );
-        let nibble_path = if num_nibbles % 2 == 0 {
+        let nibble_path = if num_nibbles.is_multiple_of(2) {
             NibblePath::new_even(nibble_bytes)
         } else {
             let padding = nibble_bytes.last().unwrap() & 0x0F;
@@ -464,7 +464,7 @@ impl InternalNode {
 
     /// Given a range [start, start + width), returns the sub-bitmap of that range.
     fn range_bitmaps(start: u8, width: u8, bitmaps: (u16, u16)) -> (u16, u16) {
-        assert!(start < 16 && width.count_ones() == 1 && start % width == 0);
+        assert!(start < 16 && width.count_ones() == 1 && start.is_multiple_of(width));
         assert!(width <= 16 && (start + width) <= 16);
         // A range with `start == 8` and `width == 4` will generate a mask 0b0000111100000000.
         // use as converting to smaller integer types when 'width == 16'

--- a/storage/scratchpad/src/sparse_merkle/mod.rs
+++ b/storage/scratchpad/src/sparse_merkle/mod.rs
@@ -368,9 +368,9 @@ impl SparseMerkleTree {
     fn maybe_to_nibble_path(pos: &NodePosition) -> Option<NibblePath> {
         assert!(pos.len() <= HashValue::LENGTH_IN_BITS);
 
-        if pos.len() % BITS_IN_NIBBLE == 0 {
+        if pos.len().is_multiple_of(BITS_IN_NIBBLE) {
             let mut bytes = pos.clone().into_vec();
-            if pos.len() % BITS_IN_BYTE == 0 {
+            if pos.len().is_multiple_of(BITS_IN_BYTE) {
                 Some(NibblePath::new_even(bytes))
             } else {
                 // Unused bits in `BitVec` is uninitialized, setting to 0 to make sure.

--- a/storage/storage-interface/src/state_store/state_summary.rs
+++ b/storage/storage-interface/src/state_store/state_summary.rs
@@ -316,7 +316,7 @@ impl<'db> ProvableStateSummary<'db> {
         // fetch and construct the corresponding `HotStateValue` for `key` at `version`, including
         // `hot_since_version`. However, the current in-memory hot state does not support this
         // query, and we might need persist hot state KV to db first.
-        if !use_hot_state && rand::random::<usize>() % 10000 == 0 {
+        if !use_hot_state && rand::random::<usize>().is_multiple_of(10000) {
             // 1 out of 10000 times, verify the proof.
             let (val_opt, proof) = self
                 .db

--- a/testsuite/smoke-test/src/storage.rs
+++ b/testsuite/smoke-test/src/storage.rs
@@ -527,7 +527,7 @@ async fn test_db_restart() {
             let validator = swarm.validator_mut(*vid).unwrap();
             // sometimes trigger reconfig right before the restart, to expose edge cases around
             // epoch change
-            if rand::random::<usize>() % 3 == 0 {
+            if rand::random::<usize>().is_multiple_of(3) {
                 info!(
                     "{LINE} Triggering reconfig right before restarting. Root account seq_num: {}. Ledger info: {:?}",
                     pub_chain_info.root_account().sequence_number(),

--- a/testsuite/smoke-test/src/utils.rs
+++ b/testsuite/smoke-test/src/utils.rs
@@ -181,7 +181,7 @@ pub async fn transfer_and_maybe_reconfig(
 ) {
     for _ in 0..num_transfers {
         // Reconfigurations have a 20% chance of being executed
-        if random::<u16>() % 5 == 0 {
+        if random::<u16>().is_multiple_of(5) {
             reconfig(client, transaction_factory, root_account.clone()).await;
         }
 

--- a/testsuite/testcases/src/multi_region_network_test.rs
+++ b/testsuite/testcases/src/multi_region_network_test.rs
@@ -40,7 +40,7 @@ fn get_link_stats_table(csv: &[u8]) -> BTreeMap<String, BTreeMap<String, (u64, f
 }
 
 fn div_ceil(dividend: usize, divisor: usize) -> usize {
-    if dividend % divisor == 0 {
+    if dividend.is_multiple_of(divisor) {
         dividend / divisor
     } else {
         dividend / divisor + 1

--- a/third_party/move/move-prover/bytecode-pipeline/src/number_operation_analysis.rs
+++ b/third_party/move/move-prover/bytecode-pipeline/src/number_operation_analysis.rs
@@ -374,8 +374,7 @@ impl NumberOperationAnalysis<'_> {
                                     // Default num oper is determined by the actual arguments
                                     para_vec.append(&mut arg_oper);
                                     ret_vec.push(Bottom);
-                                    if callee_spec_fun.body.is_some() {
-                                        let body_exp = callee_spec_fun.body.as_ref().unwrap();
+                                    if let Some(body_exp) = &callee_spec_fun.body {
                                         let local_map = body_exp.bound_local_vars_with_node_id();
                                         for (i, Parameter(sym, _, loc)) in
                                             callee_spec_fun.params.iter().enumerate()

--- a/types/src/dkg/real_dkg/mod.rs
+++ b/types/src/dkg/real_dkg/mod.rs
@@ -489,14 +489,14 @@ impl DKGTrait for RealDKG {
             .clone()
             .into_iter()
             .all(|(_, y)| y.fast.is_some())
-            && pub_params.pvss_config.fast_wconfig.is_some()
+            && let Some(fast_wconfig) = &pub_params.pvss_config.fast_wconfig
         {
             let fast_player_share_pairs: Vec<_> = input_player_share_pairs
                 .into_iter()
                 .map(|(x, y)| (Player { id: x as usize }, y.fast.unwrap()))
                 .collect();
             let fast_reconstructed_secret = <WTrx as TranscriptCore>::DealtSecretKey::reconstruct(
-                pub_params.pvss_config.fast_wconfig.as_ref().unwrap(),
+                fast_wconfig,
                 &fast_player_share_pairs,
             )
             .unwrap();

--- a/types/src/nibble/nibble_path/mod.rs
+++ b/types/src/nibble/nibble_path/mod.rs
@@ -132,7 +132,7 @@ impl NibblePath {
     /// Adds a nibble to the end of the nibble path.
     pub fn push(&mut self, nibble: Nibble) {
         assert!(ROOT_NIBBLE_HEIGHT > self.num_nibbles);
-        if self.num_nibbles % 2 == 0 {
+        if self.num_nibbles.is_multiple_of(2) {
             self.bytes.push(u8::from(nibble) << 4);
         } else {
             self.bytes[self.num_nibbles / 2] |= u8::from(nibble);
@@ -142,7 +142,7 @@ impl NibblePath {
 
     /// Pops a nibble from the end of the nibble path.
     pub fn pop(&mut self) -> Option<Nibble> {
-        let poped_nibble = if self.num_nibbles % 2 == 0 {
+        let poped_nibble = if self.num_nibbles.is_multiple_of(2) {
             self.bytes.last_mut().map(|last_byte| {
                 let nibble = *last_byte & 0x0F;
                 *last_byte &= 0xF0;
@@ -160,7 +160,7 @@ impl NibblePath {
     /// Returns the last nibble.
     pub fn last(&self) -> Option<Nibble> {
         let last_byte_option = self.bytes.last();
-        if self.num_nibbles % 2 == 0 {
+        if self.num_nibbles.is_multiple_of(2) {
             last_byte_option.map(|last_byte| Nibble::from(*last_byte & 0x0F))
         } else {
             let last_byte = last_byte_option.expect("Last byte must exist if num_nibbles is odd.");
@@ -214,7 +214,7 @@ impl NibblePath {
         assert!(len <= self.num_nibbles);
         self.num_nibbles = len;
         self.bytes.truncate(len.div_ceil(2));
-        if len % 2 != 0 {
+        if !len.is_multiple_of(2) {
             *self.bytes.last_mut().expect("must exist.") &= 0xF0;
         }
     }


### PR DESCRIPTION

- Update `rust-toolchain.toml` from 1.92.0 to 1.93.1
- Update Docker image references in `docker-bake-rust-all.hcl` and
  `update_docker_images.py` to `rust:1.93.1-trixie`
- Fix `clippy::unnecessary_unwrap` violations introduced by the new
  toolchain across multiple crates, replacing `.is_some()` + `.unwrap()`
  patterns with `if let Some(...)` or `match`
- Fix `clippy::manual_is_multiple_of` violations, replacing
  `x % n == 0` / `x % n != 0` patterns with `.is_multiple_of()`
- Update `rust-version` (MSRV) from 1.85 to 1.88, reflecting existing
  use of let chains (`&& let`) which were stabilized in Rust 1.88.0

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Toolchain/MSRV bump can introduce new compiler/clippy behavior and affect downstream build environments; small control-flow refactors (e.g., txn emitter retry/coordination delay) should be revalidated in CI/runtime tests.
> 
> **Overview**
> Upgrades the Rust toolchain to `1.93.1` (including Docker builder image references) and bumps the workspace `rust-version` to `1.88`.
> 
> Across the codebase, replaces clippy-triggering patterns with safer/clearer equivalents: `% n == 0` checks become `.is_multiple_of(n)`, and many `is_some()` + `unwrap()` sequences are rewritten to `if let`/`match` (including a small control-flow refactor in `transaction-emitter-lib`’s `emit_transactions` retry/coordination-delay handling).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1166067635004dac4821ea8596aacda39bfa2505. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->