### PR TITLE
Add lints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12982,6 +12982,7 @@ dependencies = [
 name = "move-linter"
 version = "0.1.0"
 dependencies = [
+ "codespan",
  "codespan-reporting",
  "datatest-stable",
  "legacy-move-compiler",

--- a/third_party/move/move-compiler-v2/src/env_pipeline/model_ast_lints.rs
+++ b/third_party/move/move-compiler-v2/src/env_pipeline/model_ast_lints.rs
@@ -4,13 +4,13 @@
 //! This module exercises externally provided model-AST-based lint checks.
 
 use crate::{
-    external_checks::{known_checker_names, ExpChecker},
+    external_checks::{known_checker_names, ExpChecker, ModuleChecker},
     lint_common::lint_skips_from_attributes,
     Options,
 };
 use move_model::{
     ast::ExpData,
-    model::{FunctionEnv, GlobalEnv},
+    model::{FunctionEnv, GlobalEnv, ModuleEnv},
 };
 use std::collections::BTreeSet;
 
@@ -33,6 +33,7 @@ pub fn checker(env: &mut GlobalEnv) {
                 }
                 check_function(&function, &module_lint_skips, &known_checker_names);
             }
+            run_module_checkers(env, &module, &module_lint_skips, &known_checker_names);
         }
     }
 }
@@ -86,4 +87,76 @@ fn get_applicable_lints(
                 .filter(|lint| !lint_skips.contains(&lint.get_name()))
         })
         .collect()
+}
+
+/// Run module-level checkers on the given module and its declarations.
+fn run_module_checkers(
+    env: &GlobalEnv,
+    module: &ModuleEnv,
+    module_lint_skips: &BTreeSet<String>,
+    known_checker_names: &BTreeSet<String>,
+) {
+    let options = env
+        .get_extension::<Options>()
+        .expect("Options is available");
+    let all_module_checkers: Vec<Box<dyn ModuleChecker>> = options
+        .external_checks
+        .iter()
+        .flat_map(|checks| checks.get_module_checkers())
+        .collect();
+    if all_module_checkers.is_empty() {
+        return;
+    }
+
+    // Visit the module itself with checkers not skipped at module level.
+    for checker in &all_module_checkers {
+        if !module_lint_skips.contains(&checker.get_name()) {
+            checker.visit_module(env, module);
+        }
+    }
+
+    // Visit functions (non-native, non-test).
+    for function in module.get_functions() {
+        if function.is_native() || function.is_test_or_verify_only() {
+            continue;
+        }
+        let function_skips =
+            lint_skips_from_attributes(env, function.get_attributes(), known_checker_names);
+        for checker in &all_module_checkers {
+            let name = checker.get_name();
+            if !module_lint_skips.contains(&name) && !function_skips.contains(&name) {
+                checker.visit_function(env, &function);
+            }
+        }
+    }
+
+    // Visit named constants (non-test).
+    for constant in module.get_named_constants() {
+        if constant.is_test_or_verify_only() {
+            continue;
+        }
+        let constant_skips =
+            lint_skips_from_attributes(env, constant.get_attributes(), known_checker_names);
+        for checker in &all_module_checkers {
+            let name = checker.get_name();
+            if !module_lint_skips.contains(&name) && !constant_skips.contains(&name) {
+                checker.visit_named_constant(env, &constant);
+            }
+        }
+    }
+
+    // Visit structs/enums (non-test, non-ghost).
+    for struct_env in module.get_structs() {
+        if struct_env.is_test_or_verify_only() || struct_env.is_ghost_memory() {
+            continue;
+        }
+        let struct_skips =
+            lint_skips_from_attributes(env, struct_env.get_attributes(), known_checker_names);
+        for checker in &all_module_checkers {
+            let name = checker.get_name();
+            if !module_lint_skips.contains(&name) && !struct_skips.contains(&name) {
+                checker.visit_struct(env, &struct_env);
+            }
+        }
+    }
 }

--- a/third_party/move/move-compiler-v2/src/external_checks.rs
+++ b/third_party/move/move-compiler-v2/src/external_checks.rs
@@ -7,7 +7,7 @@
 use legacy_move_compiler::shared::known_attributes::LintAttribute;
 use move_model::{
     ast::ExpData,
-    model::{FunctionEnv, GlobalEnv, Loc},
+    model::{FunctionEnv, GlobalEnv, Loc, ModuleEnv, NamedConstantEnv, StructEnv},
 };
 use move_stackless_bytecode::function_target::FunctionTarget;
 use std::{collections::BTreeSet, fmt, sync::Arc};
@@ -22,6 +22,11 @@ pub trait ExternalChecks {
 
     /// Get all the stackless bytecode checkers.
     fn get_stackless_bytecode_checkers(&self) -> Vec<Box<dyn StacklessBytecodeChecker>>;
+
+    /// Get all the module-level checkers.
+    fn get_module_checkers(&self) -> Vec<Box<dyn ModuleChecker>> {
+        vec![]
+    }
 }
 
 impl fmt::Debug for dyn ExternalChecks {
@@ -38,10 +43,16 @@ impl fmt::Debug for dyn ExternalChecks {
             .map(|c| c.get_name())
             .collect::<Vec<_>>()
             .join(", ");
+        let module_checkers = self
+            .get_module_checkers()
+            .into_iter()
+            .map(|c| c.get_name())
+            .collect::<Vec<_>>()
+            .join(", ");
         write!(
             f,
-            "dyn ExternalChecks {{ exp_checkers: [{}], stackless_bytecode_checkers: [{}] }}",
-            exp_checkers, stackless_bytecode_checkers
+            "dyn ExternalChecks {{ exp_checkers: [{}], stackless_bytecode_checkers: [{}], module_checkers: [{}] }}",
+            exp_checkers, stackless_bytecode_checkers, module_checkers
         )
     }
 }
@@ -81,6 +92,32 @@ pub trait StacklessBytecodeChecker {
     }
 }
 
+/// Implement this trait for checks on module-level declarations (modules, functions, constants,
+/// structs). Unlike `ExpChecker` which visits expressions within function bodies, this trait
+/// visits the declarations themselves.
+/// Implement at least one of the `visit` methods to be a useful checker.
+pub trait ModuleChecker {
+    /// Name of the module checker.
+    fn get_name(&self) -> String;
+
+    /// Examine a module declaration. Called once per module.
+    fn visit_module(&self, _env: &GlobalEnv, _module: &ModuleEnv) {}
+
+    /// Examine a function declaration (not its body).
+    fn visit_function(&self, _env: &GlobalEnv, _func: &FunctionEnv) {}
+
+    /// Examine a named constant declaration.
+    fn visit_named_constant(&self, _env: &GlobalEnv, _constant: &NamedConstantEnv) {}
+
+    /// Examine a struct or enum declaration.
+    fn visit_struct(&self, _env: &GlobalEnv, _struct_env: &StructEnv) {}
+
+    /// Report the `msg` highlighting the `loc`.
+    fn report(&self, env: &GlobalEnv, loc: &Loc, msg: &str) {
+        report(env, loc, msg, self.get_name().as_str());
+    }
+}
+
 /// Get the set of known checker names from the given external checkers.
 pub fn known_checker_names(external_checkers: &Vec<Arc<dyn ExternalChecks>>) -> BTreeSet<String> {
     let mut names = BTreeSet::new();
@@ -89,6 +126,9 @@ pub fn known_checker_names(external_checkers: &Vec<Arc<dyn ExternalChecks>>) -> 
             names.insert(checker.get_name());
         }
         for checker in checkers.get_stackless_bytecode_checkers() {
+            names.insert(checker.get_name());
+        }
+        for checker in checkers.get_module_checkers() {
             names.insert(checker.get_name());
         }
     }

--- a/third_party/move/tools/move-linter/Cargo.toml
+++ b/third_party/move/tools/move-linter/Cargo.toml
@@ -19,6 +19,7 @@ doctest = false
 default = []
 
 [dependencies]
+codespan = { workspace = true }
 codespan-reporting = { workspace = true }
 legacy-move-compiler = { workspace = true }
 move-binary-format = { workspace = true }

--- a/third_party/move/tools/move-linter/src/lib.rs
+++ b/third_party/move/tools/move-linter/src/lib.rs
@@ -2,10 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 mod model_ast_lints;
+mod module_lints;
 mod stackless_bytecode_lints;
 mod utils;
 
-use move_compiler_v2::external_checks::{ExpChecker, ExternalChecks, StacklessBytecodeChecker};
+use move_compiler_v2::external_checks::{
+    ExpChecker, ExternalChecks, ModuleChecker, StacklessBytecodeChecker,
+};
 use std::{collections::BTreeMap, sync::Arc};
 
 /// Holds collection of lint checks for Move.
@@ -20,6 +23,10 @@ impl ExternalChecks for MoveLintChecks {
 
     fn get_stackless_bytecode_checkers(&self) -> Vec<Box<dyn StacklessBytecodeChecker>> {
         stackless_bytecode_lints::get_default_linter_pipeline(&self.config)
+    }
+
+    fn get_module_checkers(&self) -> Vec<Box<dyn ModuleChecker>> {
+        module_lints::get_default_linter_pipeline(&self.config)
     }
 }
 

--- a/third_party/move/tools/move-linter/src/module_lints.rs
+++ b/third_party/move/tools/move-linter/src/module_lints.rs
@@ -1,0 +1,52 @@
+// Copyright (c) Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+//! This module (and its submodules) contain various module-level lint checks.
+//! These check declarations (modules, functions, constants, structs) rather than
+//! expressions within function bodies.
+
+mod error_constant_naming;
+mod error_message_too_long;
+mod missing_doc_constant;
+mod missing_doc_error_constant;
+mod missing_doc_module;
+mod missing_doc_public_function;
+mod missing_doc_struct;
+mod prefer_doc_comment;
+
+use move_compiler_v2::external_checks::ModuleChecker;
+use std::collections::BTreeMap;
+
+/// Returns a pipeline of module-level linters to run.
+pub fn get_default_linter_pipeline(
+    config: &BTreeMap<String, String>,
+) -> Vec<Box<dyn ModuleChecker>> {
+    // Start with the default set of checks.
+    let mut checks: Vec<Box<dyn ModuleChecker>> = vec![];
+    let checks_category = config.get("checks").map_or("default", |s| s.as_str());
+    if checks_category == "strict" || checks_category == "experimental" {
+        // Push strict checks to `checks`.
+    }
+    if checks_category == "experimental" {
+        checks.push(Box::new(
+            missing_doc_public_function::MissingDocPublicFunction,
+        ));
+        checks.push(Box::new(missing_doc_constant::MissingDocConstant));
+        checks.push(Box::new(
+            missing_doc_error_constant::MissingDocErrorConstant,
+        ));
+        checks.push(Box::new(error_constant_naming::ErrorConstantNaming));
+        checks.push(Box::new(error_message_too_long::ErrorMessageTooLong));
+        checks.push(Box::new(missing_doc_module::MissingDocModule));
+        checks.push(Box::new(missing_doc_struct::MissingDocStruct));
+        checks.push(Box::new(prefer_doc_comment::PreferDocComment));
+    }
+    checks
+}
+
+/// Returns true if the constant name matches an error constant pattern:
+/// starts with `E_` or starts with `E` followed by an uppercase letter.
+pub(crate) fn is_error_constant(name: &str) -> bool {
+    name.starts_with("E_")
+        || (name.starts_with('E') && name.len() > 1 && name.as_bytes()[1].is_ascii_uppercase())
+}

--- a/third_party/move/tools/move-linter/src/module_lints/error_constant_naming.rs
+++ b/third_party/move/tools/move-linter/src/module_lints/error_constant_naming.rs
@@ -1,0 +1,43 @@
+// Copyright (c) Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+//! Lint: error constants must follow `E_ERROR_NAME` or `EERROR_NAME` naming conventions.
+//! A constant is considered an error constant if its name starts with `E` followed by
+//! either `_` or an uppercase letter. This lint warns when neither convention is followed.
+
+use move_compiler_v2::external_checks::ModuleChecker;
+use move_model::model::{GlobalEnv, NamedConstantEnv};
+
+pub struct ErrorConstantNaming;
+
+impl ModuleChecker for ErrorConstantNaming {
+    fn get_name(&self) -> String {
+        "error_constant_naming".to_string()
+    }
+
+    fn visit_named_constant(&self, env: &GlobalEnv, constant: &NamedConstantEnv) {
+        let name = env.symbol_pool().string(constant.get_name());
+        let name = name.as_str();
+
+        // Only check constants that start with 'E' (potential error constants).
+        if !name.starts_with('E') || name.len() <= 1 {
+            return;
+        }
+
+        let second_char = name.as_bytes()[1];
+
+        // Accepted patterns:
+        // - E_ followed by anything (e.g., E_NOT_FOUND)
+        // - E followed by an uppercase letter (e.g., ENOT_FOUND)
+        if second_char == b'_' || second_char.is_ascii_uppercase() {
+            return;
+        }
+
+        // If we get here, it starts with E but doesn't follow either convention.
+        self.report(
+            env,
+            &constant.get_loc(),
+            "Error constant name does not follow the naming convention. Use `E_ERROR_NAME` or `EERROR_NAME`.",
+        );
+    }
+}

--- a/third_party/move/tools/move-linter/src/module_lints/error_message_too_long.rs
+++ b/third_party/move/tools/move-linter/src/module_lints/error_message_too_long.rs
@@ -1,0 +1,37 @@
+// Copyright (c) Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+//! Lint: error constant doc comments must be at most 128 bytes long.
+
+use crate::module_lints::is_error_constant;
+use move_compiler_v2::external_checks::ModuleChecker;
+use move_model::model::{GlobalEnv, NamedConstantEnv};
+
+const MAX_ERROR_MESSAGE_BYTES: usize = 128;
+
+pub struct ErrorMessageTooLong;
+
+impl ModuleChecker for ErrorMessageTooLong {
+    fn get_name(&self) -> String {
+        "error_message_too_long".to_string()
+    }
+
+    fn visit_named_constant(&self, env: &GlobalEnv, constant: &NamedConstantEnv) {
+        let name = env.symbol_pool().string(constant.get_name());
+        if !is_error_constant(name.as_str()) {
+            return;
+        }
+        let doc = constant.get_doc();
+        if doc.len() > MAX_ERROR_MESSAGE_BYTES {
+            self.report(
+                env,
+                &constant.get_loc(),
+                &format!(
+                    "Error constant doc comment is {} bytes, which exceeds the {} byte limit.",
+                    doc.len(),
+                    MAX_ERROR_MESSAGE_BYTES
+                ),
+            );
+        }
+    }
+}

--- a/third_party/move/tools/move-linter/src/module_lints/missing_doc_constant.rs
+++ b/third_party/move/tools/move-linter/src/module_lints/missing_doc_constant.rs
@@ -1,0 +1,32 @@
+// Copyright (c) Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+//! Lint: every constant must have a doc comment.
+//! Error constants (E-prefix) are skipped here to avoid overlap with `missing_doc_error_constant`.
+
+use crate::module_lints::is_error_constant;
+use move_compiler_v2::external_checks::ModuleChecker;
+use move_model::model::{GlobalEnv, NamedConstantEnv};
+
+pub struct MissingDocConstant;
+
+impl ModuleChecker for MissingDocConstant {
+    fn get_name(&self) -> String {
+        "missing_doc_constant".to_string()
+    }
+
+    fn visit_named_constant(&self, env: &GlobalEnv, constant: &NamedConstantEnv) {
+        let name = env.symbol_pool().string(constant.get_name());
+        // Skip error constants — handled by missing_doc_error_constant lint.
+        if is_error_constant(name.as_str()) {
+            return;
+        }
+        if constant.get_doc().is_empty() {
+            self.report(
+                env,
+                &constant.get_loc(),
+                "Constant is missing a doc comment.",
+            );
+        }
+    }
+}

--- a/third_party/move/tools/move-linter/src/module_lints/missing_doc_error_constant.rs
+++ b/third_party/move/tools/move-linter/src/module_lints/missing_doc_error_constant.rs
@@ -1,0 +1,31 @@
+// Copyright (c) Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+//! Lint: error constants (E-prefix) must have a doc comment.
+//! The doc comment serves as a human-readable error message.
+
+use crate::module_lints::is_error_constant;
+use move_compiler_v2::external_checks::ModuleChecker;
+use move_model::model::{GlobalEnv, NamedConstantEnv};
+
+pub struct MissingDocErrorConstant;
+
+impl ModuleChecker for MissingDocErrorConstant {
+    fn get_name(&self) -> String {
+        "missing_doc_error_constant".to_string()
+    }
+
+    fn visit_named_constant(&self, env: &GlobalEnv, constant: &NamedConstantEnv) {
+        let name = env.symbol_pool().string(constant.get_name());
+        if !is_error_constant(name.as_str()) {
+            return;
+        }
+        if constant.get_doc().is_empty() {
+            self.report(
+                env,
+                &constant.get_loc(),
+                "Error constant is missing a doc comment. The doc comment is used as a human-readable error message.",
+            );
+        }
+    }
+}

--- a/third_party/move/tools/move-linter/src/module_lints/missing_doc_module.rs
+++ b/third_party/move/tools/move-linter/src/module_lints/missing_doc_module.rs
@@ -1,0 +1,21 @@
+// Copyright (c) Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+//! Lint (strict): modules must have a doc comment.
+
+use move_compiler_v2::external_checks::ModuleChecker;
+use move_model::model::{GlobalEnv, ModuleEnv};
+
+pub struct MissingDocModule;
+
+impl ModuleChecker for MissingDocModule {
+    fn get_name(&self) -> String {
+        "missing_doc_module".to_string()
+    }
+
+    fn visit_module(&self, env: &GlobalEnv, module: &ModuleEnv) {
+        if module.get_doc().is_empty() {
+            self.report(env, &module.get_loc(), "Module is missing a doc comment.");
+        }
+    }
+}

--- a/third_party/move/tools/move-linter/src/module_lints/missing_doc_public_function.rs
+++ b/third_party/move/tools/move-linter/src/module_lints/missing_doc_public_function.rs
@@ -1,0 +1,36 @@
+// Copyright (c) Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+//! Lint: public, entry, or `#[view]` functions must have doc comments.
+
+use move_compiler_v2::external_checks::ModuleChecker;
+use move_model::model::{FunctionEnv, GlobalEnv};
+
+pub struct MissingDocPublicFunction;
+
+impl ModuleChecker for MissingDocPublicFunction {
+    fn get_name(&self) -> String {
+        "missing_doc_public_function".to_string()
+    }
+
+    fn visit_function(&self, env: &GlobalEnv, func: &FunctionEnv) {
+        let is_public = func.visibility() == move_model::model::Visibility::Public;
+        let is_entry = func.is_entry();
+        let is_view =
+            func.has_attribute(|attr| env.symbol_pool().string(attr.name()).as_str() == "view");
+        if (is_public || is_entry || is_view) && func.get_doc().is_empty() {
+            let kind = if is_entry {
+                "Entry"
+            } else if is_view {
+                "View"
+            } else {
+                "Public"
+            };
+            self.report(
+                env,
+                &func.get_id_loc(),
+                &format!("{} function is missing a doc comment.", kind),
+            );
+        }
+    }
+}

--- a/third_party/move/tools/move-linter/src/module_lints/missing_doc_struct.rs
+++ b/third_party/move/tools/move-linter/src/module_lints/missing_doc_struct.rs
@@ -1,0 +1,30 @@
+// Copyright (c) Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+//! Lint (strict): structs and enums must have doc comments.
+
+use move_compiler_v2::external_checks::ModuleChecker;
+use move_model::model::{GlobalEnv, StructEnv};
+
+pub struct MissingDocStruct;
+
+impl ModuleChecker for MissingDocStruct {
+    fn get_name(&self) -> String {
+        "missing_doc_struct".to_string()
+    }
+
+    fn visit_struct(&self, env: &GlobalEnv, struct_env: &StructEnv) {
+        if struct_env.get_doc().is_empty() {
+            let kind = if struct_env.has_variants() {
+                "Enum"
+            } else {
+                "Struct"
+            };
+            self.report(
+                env,
+                &struct_env.get_loc(),
+                &format!("{} is missing a doc comment.", kind),
+            );
+        }
+    }
+}

--- a/third_party/move/tools/move-linter/src/module_lints/prefer_doc_comment.rs
+++ b/third_party/move/tools/move-linter/src/module_lints/prefer_doc_comment.rs
@@ -1,0 +1,113 @@
+// Copyright (c) Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+//! Lint (strict): regular `//` comments immediately before a documentable item should be `///`.
+
+use codespan::{ByteIndex, Span};
+use move_compiler_v2::external_checks::ModuleChecker;
+use move_model::model::{FunctionEnv, GlobalEnv, Loc, NamedConstantEnv, StructEnv};
+
+pub struct PreferDocComment;
+
+impl ModuleChecker for PreferDocComment {
+    fn get_name(&self) -> String {
+        "prefer_doc_comment".to_string()
+    }
+
+    fn visit_function(&self, env: &GlobalEnv, func: &FunctionEnv) {
+        check_for_regular_comment(self, env, &func.get_id_loc());
+    }
+
+    fn visit_named_constant(&self, env: &GlobalEnv, constant: &NamedConstantEnv) {
+        check_for_regular_comment(self, env, &constant.get_loc());
+    }
+
+    fn visit_struct(&self, env: &GlobalEnv, struct_env: &StructEnv) {
+        check_for_regular_comment(self, env, &struct_env.get_loc());
+    }
+}
+
+/// Check if there are regular `//` comments (not `///`) immediately preceding the item at `loc`.
+fn check_for_regular_comment(checker: &PreferDocComment, env: &GlobalEnv, loc: &Loc) {
+    let file_id = loc.file_id();
+    let source = env.get_file_source(file_id);
+    let item_start = loc.span().start().to_usize();
+
+    // Find the start of the line containing the item.
+    let line_start = source[..item_start]
+        .rfind('\n')
+        .map(|pos| pos + 1)
+        .unwrap_or(0);
+
+    // Now scan backwards from the line before the item to find comment lines.
+    // We want to find regular // comments that are immediately preceding (no blank line gap).
+    let mut scan_pos = line_start;
+    let mut found_regular_comment = false;
+    let mut comment_start = scan_pos;
+    let mut comment_end = scan_pos;
+
+    loop {
+        if scan_pos == 0 {
+            break;
+        }
+        // Go to the previous line.
+        let prev_line_end = scan_pos; // this is the start of the current line = end of prev content
+                                      // Find start of the previous line.
+        let prev_line_start = if scan_pos >= 2 {
+            // scan_pos - 1 should be '\n', so look before that
+            source[..scan_pos - 1]
+                .rfind('\n')
+                .map(|pos| pos + 1)
+                .unwrap_or(0)
+        } else {
+            0
+        };
+
+        let prev_line = &source[prev_line_start..prev_line_end];
+        let trimmed = prev_line.trim();
+
+        if trimmed.is_empty() {
+            // Blank line — stop scanning.
+            break;
+        }
+
+        if trimmed.starts_with("///") {
+            // Doc comment — this is fine, skip past it and keep scanning.
+            scan_pos = prev_line_start;
+            continue;
+        }
+
+        if trimmed.starts_with("//") && !trimmed.starts_with("///") {
+            // Regular comment that's not a doc comment.
+            found_regular_comment = true;
+            comment_start = prev_line_start;
+            if comment_end == line_start {
+                comment_end = prev_line_end;
+            }
+            scan_pos = prev_line_start;
+            continue;
+        }
+
+        // Attributes (lines starting with #[) — skip past them and keep scanning.
+        if trimmed.starts_with("#[") {
+            scan_pos = prev_line_start;
+            continue;
+        }
+
+        // Any other content — stop scanning.
+        break;
+    }
+
+    if found_regular_comment {
+        let span = Span::new(
+            ByteIndex(comment_start as u32),
+            ByteIndex(comment_end as u32),
+        );
+        let comment_loc = Loc::new(file_id, span);
+        checker.report(
+            env,
+            &comment_loc,
+            "Use doc comment `///` instead of regular comment `//` for documentable items.",
+        );
+    }
+}

--- a/third_party/move/tools/move-linter/tests/model_ast_lints/aborting_overflow_checks.exp
+++ b/third_party/move/tools/move-linter/tests/model_ast_lints/aborting_overflow_checks.exp
@@ -1,5 +1,54 @@
 
 Diagnostics:
+warning: [lint] Struct is missing a doc comment.
+  ┌─ tests/model_ast_lints/aborting_overflow_checks.move:3:3
+  │
+3 │   struct Counter has key, store { i: u64 }
+  │   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  │
+  = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_struct)]`.
+  = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_struct.
+
+warning: [lint] Struct is missing a doc comment.
+  ┌─ tests/model_ast_lints/aborting_overflow_checks.move:5:3
+  │
+5 │ ╭   struct NestedCounter has key, store {
+6 │ │     n: Counter
+7 │ │   }
+  │ ╰───^
+  │
+  = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_struct)]`.
+  = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_struct.
+
+warning: [lint] Struct is missing a doc comment.
+   ┌─ tests/model_ast_lints/aborting_overflow_checks.move:9:3
+   │
+ 9 │ ╭   struct HyperNestedCounter has key, store {
+10 │ │     n: NestedCounter
+11 │ │   }
+   │ ╰───^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_struct)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_struct.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/aborting_overflow_checks.move:14:14
+   │
+14 │   public fun ignore(a: u64, b: u64) : u64 {
+   │              ^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/aborting_overflow_checks.move:23:14
+   │
+23 │   public fun arg_cmp(a: u64, b: u64, addr: address) : u64 acquires Counter, NestedCounter, HyperNestedCounter {
+   │              ^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] This looks like a C-style overflow check. In Move, overflows abort, and such checks are unnecessary.
    ┌─ tests/model_ast_lints/aborting_overflow_checks.move:24:9
    │
@@ -99,6 +148,15 @@ warning: [lint] This looks like a C-style overflow check. In Move, overflows abo
     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(aborting_overflow_checks)]`.
     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#aborting_overflow_checks.
 
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/aborting_overflow_checks.move:122:14
+    │
+122 │   public fun overflows(a: u64, b: u64) : bool {
+    │              ^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] This looks like a C-style overflow check. In Move, overflows abort, and such checks are unnecessary.
     ┌─ tests/model_ast_lints/aborting_overflow_checks.move:123:5
     │
@@ -107,3 +165,27 @@ warning: [lint] This looks like a C-style overflow check. In Move, overflows abo
     │
     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(aborting_overflow_checks)]`.
     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#aborting_overflow_checks.
+
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/aborting_overflow_checks.move:126:14
+    │
+126 │   public fun a_fn(a: u64) : u64 {
+    │              ^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Module is missing a doc comment.
+    ┌─ tests/model_ast_lints/aborting_overflow_checks.move:1:1
+    │
+  1 │ ╭ module 0xc0ffee::m {
+  2 │ │
+  3 │ │   struct Counter has key, store { i: u64 }
+  4 │ │
+    · │
+128 │ │   }
+129 │ │ }
+    │ ╰─^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_module)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_module.

--- a/third_party/move/tools/move-linter/tests/model_ast_lints/almost_swapped.exp
+++ b/third_party/move/tools/move-linter/tests/model_ast_lints/almost_swapped.exp
@@ -1,5 +1,41 @@
 
 Diagnostics:
+warning: [lint] Struct is missing a doc comment.
+  ┌─ tests/model_ast_lints/almost_swapped.move:4:3
+  │
+4 │   struct X has drop, copy { f: u64 }
+  │   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  │
+  = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_struct)]`.
+  = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_struct.
+
+warning: [lint] Struct is missing a doc comment.
+  ┌─ tests/model_ast_lints/almost_swapped.move:5:3
+  │
+5 │   struct Y has drop, copy { x1: X, x2: X }
+  │   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  │
+  = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_struct)]`.
+  = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_struct.
+
+warning: [lint] Struct is missing a doc comment.
+  ┌─ tests/model_ast_lints/almost_swapped.move:6:3
+  │
+6 │   struct Pair(u64, u8) has copy, drop;
+  │   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  │
+  = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_struct)]`.
+  = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_struct.
+
+warning: [lint] Public function is missing a doc comment.
+  ┌─ tests/model_ast_lints/almost_swapped.move:8:14
+  │
+8 │   public fun assign_assign_swap_var() {
+  │              ^^^^^^^^^^^^^^^^^^^^^^
+  │
+  = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+  = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] This looks like a swap, but one assignment overwrites the other.
    ┌─ tests/model_ast_lints/almost_swapped.move:11:5
    │
@@ -18,6 +54,15 @@ warning: [lint] Empty `if` branch. Consider simplifying by removing or rewriting
    │
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(empty_if)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#empty_if.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/almost_swapped.move:16:14
+   │
+16 │   public fun assign_assign_swap_struct() {
+   │              ^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
 
 warning: [lint] This looks like a swap, but one assignment overwrites the other.
    ┌─ tests/model_ast_lints/almost_swapped.move:19:5
@@ -38,6 +83,15 @@ warning: [lint] Empty `if` branch. Consider simplifying by removing or rewriting
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(empty_if)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#empty_if.
 
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/almost_swapped.move:24:14
+   │
+24 │   public fun mutate_mutate_swap_struct() {
+   │              ^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] This looks like a swap, but one assignment overwrites the other.
    ┌─ tests/model_ast_lints/almost_swapped.move:27:5
    │
@@ -47,6 +101,15 @@ warning: [lint] This looks like a swap, but one assignment overwrites the other.
    │
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(almost_swapped)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#almost_swapped.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/almost_swapped.move:31:14
+   │
+31 │   public fun mutate_mutate_swap_struct_deep() {
+   │              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
 
 warning: [lint] This looks like a swap, but one assignment overwrites the other.
    ┌─ tests/model_ast_lints/almost_swapped.move:34:5
@@ -68,6 +131,15 @@ warning: [lint] This looks like a swap, but one assignment overwrites the other.
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(almost_swapped)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#almost_swapped.
 
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/almost_swapped.move:40:14
+   │
+40 │   public fun assign_mutate_swap() {
+   │              ^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] This looks like a swap, but one assignment overwrites the other.
    ┌─ tests/model_ast_lints/almost_swapped.move:44:5
    │
@@ -77,6 +149,15 @@ warning: [lint] This looks like a swap, but one assignment overwrites the other.
    │
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(almost_swapped)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#almost_swapped.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/almost_swapped.move:48:14
+   │
+48 │   public fun mutate_assign_swap() {
+   │              ^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
 
 warning: [lint] This looks like a swap, but one assignment overwrites the other.
    ┌─ tests/model_ast_lints/almost_swapped.move:52:5
@@ -97,6 +178,15 @@ warning: [lint] Empty `if` branch. Consider simplifying by removing or rewriting
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(empty_if)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#empty_if.
 
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/almost_swapped.move:57:14
+   │
+57 │   public fun inner_swap() {
+   │              ^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] This looks like a swap, but one assignment overwrites the other.
    ┌─ tests/model_ast_lints/almost_swapped.move:61:5
    │
@@ -106,6 +196,15 @@ warning: [lint] This looks like a swap, but one assignment overwrites the other.
    │
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(almost_swapped)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#almost_swapped.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/almost_swapped.move:65:14
+   │
+65 │   public fun inner_deref() {
+   │              ^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
 
 warning: [lint] This looks like a swap, but one assignment overwrites the other.
    ┌─ tests/model_ast_lints/almost_swapped.move:70:5
@@ -136,6 +235,15 @@ warning: [lint] Empty `if` branch. Consider simplifying by removing or rewriting
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(empty_if)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#empty_if.
 
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/almost_swapped.move:77:14
+   │
+77 │   public fun positional_struct_swap() {
+   │              ^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] This looks like a swap, but one assignment overwrites the other.
    ┌─ tests/model_ast_lints/almost_swapped.move:80:5
    │
@@ -145,6 +253,15 @@ warning: [lint] This looks like a swap, but one assignment overwrites the other.
    │
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(almost_swapped)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#almost_swapped.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/almost_swapped.move:84:14
+   │
+84 │   public fun double_swap() {
+   │              ^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
 
 warning: [lint] This looks like a swap, but one assignment overwrites the other.
    ┌─ tests/model_ast_lints/almost_swapped.move:87:5
@@ -175,6 +292,15 @@ warning: [lint] Empty `if` branch. Consider simplifying by removing or rewriting
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(empty_if)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#empty_if.
 
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/almost_swapped.move:93:14
+   │
+93 │   public fun entire_vector_swap() {
+   │              ^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] This looks like a swap, but one assignment overwrites the other.
    ┌─ tests/model_ast_lints/almost_swapped.move:98:5
    │
@@ -194,6 +320,18 @@ warning: [lint] Empty `if` branch. Consider simplifying by removing or rewriting
     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(empty_if)]`.
     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#empty_if.
 
+warning: [lint] Enum is missing a doc comment.
+    ┌─ tests/model_ast_lints/almost_swapped.move:103:3
+    │
+103 │ ╭   enum E has drop {
+104 │ │     A { x: u64 },
+105 │ │     B { x: u64 },
+106 │ │   }
+    │ ╰───^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_struct)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_struct.
+
 warning: [lint] This looks like a swap, but one assignment overwrites the other.
     ┌─ tests/model_ast_lints/almost_swapped.move:111:5
     │
@@ -204,6 +342,15 @@ warning: [lint] This looks like a swap, but one assignment overwrites the other.
     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(almost_swapped)]`.
     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#almost_swapped.
 
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/almost_swapped.move:115:14
+    │
+115 │   public fun no_swap_no_warn() {
+    │              ^^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] Empty `if` branch. Consider simplifying by removing or rewriting.
     ┌─ tests/model_ast_lints/almost_swapped.move:120:5
     │
@@ -212,6 +359,33 @@ warning: [lint] Empty `if` branch. Consider simplifying by removing or rewriting
     │
     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(empty_if)]`.
     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#empty_if.
+
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/almost_swapped.move:127:14
+    │
+127 │   public fun out_of_scope_vector_swap_no_warn() {
+    │              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/almost_swapped.move:136:14
+    │
+136 │   public fun out_of_scope_vector_swap_no_warn_2(): vector<u64> {
+    │              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/almost_swapped.move:148:14
+    │
+148 │   public fun out_of_scope_function_swap_no_warn() {
+    │              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
 
 warning: [lint] Empty `if` branch. Consider simplifying by removing or rewriting.
     ┌─ tests/model_ast_lints/almost_swapped.move:153:5
@@ -222,6 +396,15 @@ warning: [lint] Empty `if` branch. Consider simplifying by removing or rewriting
     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(empty_if)]`.
     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#empty_if.
 
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/almost_swapped.move:157:14
+    │
+157 │   public fun test_no_warn() {
+    │              ^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] Empty `if` branch. Consider simplifying by removing or rewriting.
     ┌─ tests/model_ast_lints/almost_swapped.move:162:5
     │
@@ -230,3 +413,18 @@ warning: [lint] Empty `if` branch. Consider simplifying by removing or rewriting
     │
     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(empty_if)]`.
     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#empty_if.
+
+warning: [lint] Module is missing a doc comment.
+    ┌─ tests/model_ast_lints/almost_swapped.move:1:1
+    │
+  1 │ ╭ module 0xc0ffee::m {
+  2 │ │   use std::vector;
+  3 │ │
+  4 │ │   struct X has drop, copy { f: u64 }
+    · │
+163 │ │   }
+164 │ │ }
+    │ ╰─^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_module)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_module.

--- a/third_party/move/tools/move-linter/tests/model_ast_lints/assert_const.exp
+++ b/third_party/move/tools/move-linter/tests/model_ast_lints/assert_const.exp
@@ -1,5 +1,32 @@
 
 Diagnostics:
+warning: [lint] Constant is missing a doc comment.
+  ┌─ tests/model_ast_lints/assert_const.move:2:5
+  │
+2 │     const CONSTANT_TRUE: bool = true;
+  │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  │
+  = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_constant)]`.
+  = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_constant.
+
+warning: [lint] Constant is missing a doc comment.
+  ┌─ tests/model_ast_lints/assert_const.move:3:5
+  │
+3 │     const CONSTANT_FALSE: bool = false;
+  │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  │
+  = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_constant)]`.
+  = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_constant.
+
+warning: [lint] Public function is missing a doc comment.
+  ┌─ tests/model_ast_lints/assert_const.move:5:16
+  │
+5 │     public fun test1_warn() {
+  │                ^^^^^^^^^^
+  │
+  = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+  = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] This `assert!` can be removed
   ┌─ tests/model_ast_lints/assert_const.move:6:9
   │
@@ -8,6 +35,15 @@ warning: [lint] This `assert!` can be removed
   │
   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(assert_const)]`.
   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#assert_const.
+
+warning: [lint] Public function is missing a doc comment.
+  ┌─ tests/model_ast_lints/assert_const.move:9:16
+  │
+9 │     public fun test2_warn() {
+  │                ^^^^^^^^^^
+  │
+  = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+  = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
 
 warning: [lint] This `assert!` can replaced with an `abort`
    ┌─ tests/model_ast_lints/assert_const.move:10:9
@@ -18,6 +54,15 @@ warning: [lint] This `assert!` can replaced with an `abort`
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(assert_const)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#assert_const.
 
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/assert_const.move:13:16
+   │
+13 │     public fun test3_warn() {
+   │                ^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] This `assert!` can be removed
    ┌─ tests/model_ast_lints/assert_const.move:14:9
    │
@@ -26,6 +71,15 @@ warning: [lint] This `assert!` can be removed
    │
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(assert_const)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#assert_const.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/assert_const.move:17:16
+   │
+17 │     public fun test4_warn() {
+   │                ^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
 
 warning: [lint] This `assert!` can replaced with an `abort`
    ┌─ tests/model_ast_lints/assert_const.move:18:9
@@ -36,6 +90,15 @@ warning: [lint] This `assert!` can replaced with an `abort`
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(assert_const)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#assert_const.
 
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/assert_const.move:21:16
+   │
+21 │     public fun test5_warn() {
+   │                ^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] This `assert!` can be removed
    ┌─ tests/model_ast_lints/assert_const.move:22:9
    │
@@ -44,6 +107,15 @@ warning: [lint] This `assert!` can be removed
    │
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(assert_const)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#assert_const.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/assert_const.move:25:16
+   │
+25 │     public fun test6_warn() {
+   │                ^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
 
 warning: [lint] This `assert!` can replaced with an `abort`
    ┌─ tests/model_ast_lints/assert_const.move:26:9
@@ -54,6 +126,15 @@ warning: [lint] This `assert!` can replaced with an `abort`
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(assert_const)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#assert_const.
 
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/assert_const.move:29:16
+   │
+29 │     public fun test7_warn() {
+   │                ^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] This `assert!` can be removed
    ┌─ tests/model_ast_lints/assert_const.move:30:9
    │
@@ -63,6 +144,15 @@ warning: [lint] This `assert!` can be removed
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(assert_const)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#assert_const.
 
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/assert_const.move:33:16
+   │
+33 │     public fun test8_warn() {
+   │                ^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] This `assert!` can replaced with an `abort`
    ┌─ tests/model_ast_lints/assert_const.move:34:9
    │
@@ -71,6 +161,15 @@ warning: [lint] This `assert!` can replaced with an `abort`
    │
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(assert_const)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#assert_const.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/assert_const.move:37:16
+   │
+37 │     public fun test9_warn() {
+   │                ^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
 
 warning: [lint] This `assert!` can be removed
    ┌─ tests/model_ast_lints/assert_const.move:38:9
@@ -84,6 +183,15 @@ warning: [lint] This `assert!` can be removed
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(assert_const)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#assert_const.
 
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/assert_const.move:44:16
+   │
+44 │     public fun test10_warn() {
+   │                ^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] This `assert!` can replaced with an `abort`
    ┌─ tests/model_ast_lints/assert_const.move:45:9
    │
@@ -95,6 +203,15 @@ warning: [lint] This `assert!` can replaced with an `abort`
    │
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(assert_const)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#assert_const.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/assert_const.move:51:16
+   │
+51 │     public fun test11_warn() {
+   │                ^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
 
 warning: [lint] This `assert!` can be removed
    ┌─ tests/model_ast_lints/assert_const.move:52:9
@@ -108,6 +225,15 @@ warning: [lint] This `assert!` can be removed
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(assert_const)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#assert_const.
 
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/assert_const.move:58:16
+   │
+58 │     public fun test12_warn() {
+   │                ^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] This `assert!` can replaced with an `abort`
    ┌─ tests/model_ast_lints/assert_const.move:59:9
    │
@@ -119,3 +245,126 @@ warning: [lint] This `assert!` can replaced with an `abort`
    │
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(assert_const)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#assert_const.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/assert_const.move:66:16
+   │
+66 │     public fun test1_no_warn() {
+   │                ^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/assert_const.move:71:16
+   │
+71 │     public fun test2_no_warn() {
+   │                ^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/assert_const.move:76:16
+   │
+76 │     public fun test3_no_warn() {
+   │                ^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/assert_const.move:81:16
+   │
+81 │     public fun test4_no_warn() {
+   │                ^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/assert_const.move:86:16
+   │
+86 │     public fun test5_no_warn() {
+   │                ^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/assert_const.move:91:16
+   │
+91 │     public fun test6_no_warn() {
+   │                ^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/assert_const.move:96:16
+   │
+96 │     public fun test7_no_warn() {
+   │                ^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/assert_const.move:101:16
+    │
+101 │     public fun test8_no_warn() {
+    │                ^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/assert_const.move:106:16
+    │
+106 │     public fun test9_no_warn() {
+    │                ^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/assert_const.move:114:16
+    │
+114 │     public fun test10_no_warn() {
+    │                ^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/assert_const.move:122:16
+    │
+122 │     public fun test11_no_warn() {
+    │                ^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/assert_const.move:130:16
+    │
+130 │     public fun test12_no_warn() {
+    │                ^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Module is missing a doc comment.
+    ┌─ tests/model_ast_lints/assert_const.move:1:1
+    │
+  1 │ ╭ module 0xc0ffee::m {
+  2 │ │     const CONSTANT_TRUE: bool = true;
+  3 │ │     const CONSTANT_FALSE: bool = false;
+  4 │ │
+    · │
+135 │ │     }
+136 │ │ }
+    │ ╰─^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_module)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_module.

--- a/third_party/move/tools/move-linter/tests/model_ast_lints/bad_lint_attribute_01.exp
+++ b/third_party/move/tools/move-linter/tests/model_ast_lints/bad_lint_attribute_01.exp
@@ -5,3 +5,24 @@ error: expected `#[lint::skip(...)]`, not an assigned value
   │
 2 │     #[lint::skip = true]
   │       ^^^^^^^^^^^^^^^^^
+
+warning: [lint] Public function is missing a doc comment.
+  ┌─ tests/model_ast_lints/bad_lint_attribute_01.move:3:16
+  │
+3 │     public fun bad() {}
+  │                ^^^
+  │
+  = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+  = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Module is missing a doc comment.
+  ┌─ tests/model_ast_lints/bad_lint_attribute_01.move:1:1
+  │
+1 │ ╭ module 0xc0ffee::m {
+2 │ │     #[lint::skip = true]
+3 │ │     public fun bad() {}
+4 │ │ }
+  │ ╰─^
+  │
+  = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_module)]`.
+  = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_module.

--- a/third_party/move/tools/move-linter/tests/model_ast_lints/bad_lint_attribute_02.exp
+++ b/third_party/move/tools/move-linter/tests/model_ast_lints/bad_lint_attribute_02.exp
@@ -5,3 +5,25 @@ error: no lint checks are specified to be skipped
   │
 2 │     #[lint::skip]
   │       ^^^^^^^^^^
+
+warning: [lint] Public function is missing a doc comment.
+  ┌─ tests/model_ast_lints/bad_lint_attribute_02.move:3:16
+  │
+3 │     public fun test() {
+  │                ^^^^
+  │
+  = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+  = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Module is missing a doc comment.
+  ┌─ tests/model_ast_lints/bad_lint_attribute_02.move:1:1
+  │
+1 │ ╭ module 0xc0ffee::m {
+2 │ │     #[lint::skip]
+3 │ │     public fun test() {
+4 │ │     }
+5 │ │ }
+  │ ╰─^
+  │
+  = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_module)]`.
+  = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_module.

--- a/third_party/move/tools/move-linter/tests/model_ast_lints/bad_lint_attribute_03.exp
+++ b/third_party/move/tools/move-linter/tests/model_ast_lints/bad_lint_attribute_03.exp
@@ -5,3 +5,24 @@ error: no lint checks are specified to be skipped
   │
 2 │     #[lint::skip()]
   │       ^^^^^^^^^^^^
+
+warning: [lint] Public function is missing a doc comment.
+  ┌─ tests/model_ast_lints/bad_lint_attribute_03.move:3:16
+  │
+3 │     public fun test() {}
+  │                ^^^^
+  │
+  = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+  = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Module is missing a doc comment.
+  ┌─ tests/model_ast_lints/bad_lint_attribute_03.move:1:1
+  │
+1 │ ╭ module 0xc0ffee::m {
+2 │ │     #[lint::skip()]
+3 │ │     public fun test() {}
+4 │ │ }
+  │ ╰─^
+  │
+  = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_module)]`.
+  = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_module.

--- a/third_party/move/tools/move-linter/tests/model_ast_lints/bad_lint_attribute_04.exp
+++ b/third_party/move/tools/move-linter/tests/model_ast_lints/bad_lint_attribute_04.exp
@@ -5,3 +5,24 @@ error: unknown lint check: `unknown_lint`
   │
 2 │     #[lint::skip(unknown_lint)]
   │                  ^^^^^^^^^^^^
+
+warning: [lint] Public function is missing a doc comment.
+  ┌─ tests/model_ast_lints/bad_lint_attribute_04.move:3:16
+  │
+3 │     public fun test() {}
+  │                ^^^^
+  │
+  = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+  = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Module is missing a doc comment.
+  ┌─ tests/model_ast_lints/bad_lint_attribute_04.move:1:1
+  │
+1 │ ╭ module 0xc0ffee::m {
+2 │ │     #[lint::skip(unknown_lint)]
+3 │ │     public fun test() {}
+4 │ │ }
+  │ ╰─^
+  │
+  = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_module)]`.
+  = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_module.

--- a/third_party/move/tools/move-linter/tests/model_ast_lints/bad_lint_attribute_05.exp
+++ b/third_party/move/tools/move-linter/tests/model_ast_lints/bad_lint_attribute_05.exp
@@ -5,3 +5,27 @@ error: did not expect an assigned value, expected only the names of the lint che
   │
 2 │     #[lint::skip(while_true=1)]
   │                  ^^^^^^^^^^^^
+
+warning: [lint] Public function is missing a doc comment.
+  ┌─ tests/model_ast_lints/bad_lint_attribute_05.move:3:16
+  │
+3 │     public fun test() {
+  │                ^^^^
+  │
+  = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+  = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Module is missing a doc comment.
+  ┌─ tests/model_ast_lints/bad_lint_attribute_05.move:1:1
+  │
+1 │ ╭ module 0xc0ffee::m {
+2 │ │     #[lint::skip(while_true=1)]
+3 │ │     public fun test() {
+4 │ │
+5 │ │     }
+6 │ │
+7 │ │ }
+  │ ╰─^
+  │
+  = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_module)]`.
+  = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_module.

--- a/third_party/move/tools/move-linter/tests/model_ast_lints/bad_lint_attribute_06.exp
+++ b/third_party/move/tools/move-linter/tests/model_ast_lints/bad_lint_attribute_06.exp
@@ -5,3 +5,24 @@ error: unexpected nested attributes
   │
 2 │     #[lint::skip(while_true(yes=1))]
   │                  ^^^^^^^^^^^^^^^^^
+
+warning: [lint] Public function is missing a doc comment.
+  ┌─ tests/model_ast_lints/bad_lint_attribute_06.move:3:16
+  │
+3 │     public fun test() {}
+  │                ^^^^
+  │
+  = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+  = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Module is missing a doc comment.
+  ┌─ tests/model_ast_lints/bad_lint_attribute_06.move:1:1
+  │
+1 │ ╭ module 0xc0ffee::m {
+2 │ │     #[lint::skip(while_true(yes=1))]
+3 │ │     public fun test() {}
+4 │ │ }
+  │ ╰─^
+  │
+  = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_module)]`.
+  = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_module.

--- a/third_party/move/tools/move-linter/tests/model_ast_lints/blocks_in_conditions_warn.exp
+++ b/third_party/move/tools/move-linter/tests/model_ast_lints/blocks_in_conditions_warn.exp
@@ -1,5 +1,26 @@
 
 Diagnostics:
+warning: [lint] Enum is missing a doc comment.
+   ┌─ tests/model_ast_lints/blocks_in_conditions_warn.move:8:5
+   │
+ 8 │ ╭     enum Blah {
+ 9 │ │         Baz(u64),
+10 │ │         Qux(u64),
+11 │ │     }
+   │ ╰─────^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_struct)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_struct.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/blocks_in_conditions_warn.move:19:16
+   │
+19 │     public fun test_warn_1() {
+   │                ^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] Having blocks in conditions make code harder to read. Consider rewriting this code.
    ┌─ tests/model_ast_lints/blocks_in_conditions_warn.move:20:13
    │
@@ -8,6 +29,15 @@ warning: [lint] Having blocks in conditions make code harder to read. Consider r
    │
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(blocks_in_conditions)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#blocks_in_conditions.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/blocks_in_conditions_warn.move:25:16
+   │
+25 │     public fun test_warn_2(x: bool) {
+   │                ^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
 
 warning: [lint] Having blocks in conditions make code harder to read. Consider rewriting this code.
    ┌─ tests/model_ast_lints/blocks_in_conditions_warn.move:26:13
@@ -18,6 +48,15 @@ warning: [lint] Having blocks in conditions make code harder to read. Consider r
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(blocks_in_conditions)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#blocks_in_conditions.
 
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/blocks_in_conditions_warn.move:31:16
+   │
+31 │     public fun test_warn_3() {
+   │                ^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] Having blocks in conditions make code harder to read. Consider rewriting this code.
    ┌─ tests/model_ast_lints/blocks_in_conditions_warn.move:32:16
    │
@@ -26,6 +65,15 @@ warning: [lint] Having blocks in conditions make code harder to read. Consider r
    │
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(blocks_in_conditions)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#blocks_in_conditions.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/blocks_in_conditions_warn.move:38:16
+   │
+38 │     public fun test_warn_4() {
+   │                ^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
 
 warning: [lint] Having blocks in conditions make code harder to read. Consider rewriting this code.
    ┌─ tests/model_ast_lints/blocks_in_conditions_warn.move:39:13
@@ -54,6 +102,15 @@ warning: [lint] Having blocks in conditions make code harder to read. Consider r
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(blocks_in_conditions)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#blocks_in_conditions.
 
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/blocks_in_conditions_warn.move:50:16
+   │
+50 │     public fun test_warn_5() {
+   │                ^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] Having blocks in conditions make code harder to read. Consider rewriting this code.
    ┌─ tests/model_ast_lints/blocks_in_conditions_warn.move:52:13
    │
@@ -62,6 +119,15 @@ warning: [lint] Having blocks in conditions make code harder to read. Consider r
    │
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(blocks_in_conditions)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#blocks_in_conditions.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/blocks_in_conditions_warn.move:57:16
+   │
+57 │     public fun test_warn_6(x: u64) {
+   │                ^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
 
 warning: [lint] Having blocks in conditions make code harder to read. Consider rewriting this code.
    ┌─ tests/model_ast_lints/blocks_in_conditions_warn.move:58:16
@@ -72,6 +138,15 @@ warning: [lint] Having blocks in conditions make code harder to read. Consider r
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(blocks_in_conditions)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#blocks_in_conditions.
 
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/blocks_in_conditions_warn.move:63:16
+   │
+63 │     public fun test_warn_7(x: u64) {
+   │                ^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] Having blocks in conditions make code harder to read. Consider rewriting this code.
    ┌─ tests/model_ast_lints/blocks_in_conditions_warn.move:64:13
    │
@@ -80,3 +155,123 @@ warning: [lint] Having blocks in conditions make code harder to read. Consider r
    │
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(blocks_in_conditions)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#blocks_in_conditions.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/blocks_in_conditions_warn.move:71:16
+   │
+71 │     public fun test_no_warn_1(x: u64) {
+   │                ^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/blocks_in_conditions_warn.move:77:16
+   │
+77 │     public fun test_no_warn_2(x: u64) {
+   │                ^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/blocks_in_conditions_warn.move:83:16
+   │
+83 │     public fun test_no_warn_3(x: u64) {
+   │                ^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Module is missing a doc comment.
+   ┌─ tests/model_ast_lints/blocks_in_conditions_warn.move:1:1
+   │
+ 1 │ ╭ module 0xc0ffee::m {
+ 2 │ │     fun foo(): bool {
+ 3 │ │         true
+ 4 │ │     }
+   · │
+87 │ │     }
+88 │ │ }
+   │ ╰─^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_module)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_module.
+
+warning: [lint] Enum is missing a doc comment.
+    ┌─ tests/model_ast_lints/blocks_in_conditions_warn.move:98:5
+    │
+ 98 │ ╭     enum Blah {
+ 99 │ │         Baz(u64),
+100 │ │         Qux(u64),
+101 │ │     }
+    │ ╰─────^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_struct)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_struct.
+
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/blocks_in_conditions_warn.move:109:16
+    │
+109 │     public fun test_warn_1() {
+    │                ^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/blocks_in_conditions_warn.move:116:16
+    │
+116 │     public fun test_warn_2(x: bool) {
+    │                ^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/blocks_in_conditions_warn.move:122:16
+    │
+122 │     public fun test_warn_3() {
+    │                ^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Module is missing a doc comment.
+    ┌─ tests/model_ast_lints/blocks_in_conditions_warn.move:91:1
+    │
+ 91 │ ╭ module 0xc0ffee::no_warn_1 {
+ 92 │ │     fun foo(): bool {
+ 93 │ │         true
+ 94 │ │     }
+    · │
+127 │ │     }
+128 │ │ }
+    │ ╰─^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_module)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_module.
+
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/blocks_in_conditions_warn.move:140:16
+    │
+140 │     public fun test_warn_1() {
+    │                ^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Module is missing a doc comment.
+    ┌─ tests/model_ast_lints/blocks_in_conditions_warn.move:130:1
+    │
+130 │ ╭ module 0xc0ffee::no_warn_2 {
+131 │ │     fun foo(): bool {
+132 │ │         true
+133 │ │     }
+    · │
+144 │ │     }
+145 │ │ }
+    │ ╰─^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_module)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_module.

--- a/third_party/move/tools/move-linter/tests/model_ast_lints/collapsible_if.exp
+++ b/third_party/move/tools/move-linter/tests/model_ast_lints/collapsible_if.exp
@@ -1,5 +1,24 @@
 
 Diagnostics:
+warning: [lint] Use doc comment `///` instead of regular comment `//` for documentable items.
+   ┌─ tests/model_ast_lints/collapsible_if.move:10:1
+   │
+10 │ ╭     // Simple nested if case
+11 │ │     public fun test_warn_1(a: bool, b: bool) {
+   │ ╰^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(prefer_doc_comment)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#prefer_doc_comment.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/collapsible_if.move:11:16
+   │
+11 │     public fun test_warn_1(a: bool, b: bool) {
+   │                ^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] Nested `if` statements can be collapsed into a single `if` by using logical conjunction (`&&`) of the conditions
    ┌─ tests/model_ast_lints/collapsible_if.move:12:9
    │
@@ -12,6 +31,25 @@ warning: [lint] Nested `if` statements can be collapsed into a single `if` by us
    │
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(collapsible_if)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#collapsible_if.
+
+warning: [lint] Use doc comment `///` instead of regular comment `//` for documentable items.
+   ┌─ tests/model_ast_lints/collapsible_if.move:19:1
+   │
+19 │ ╭     // Nested if with function calls in conditions
+20 │ │     public fun test_warn_2(x: u64, y: u64) {
+   │ ╰^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(prefer_doc_comment)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#prefer_doc_comment.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/collapsible_if.move:20:16
+   │
+20 │     public fun test_warn_2(x: u64, y: u64) {
+   │                ^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
 
 warning: [lint] Nested `if` statements can be collapsed into a single `if` by using logical conjunction (`&&`) of the conditions
    ┌─ tests/model_ast_lints/collapsible_if.move:21:9
@@ -26,6 +64,25 @@ warning: [lint] Nested `if` statements can be collapsed into a single `if` by us
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(collapsible_if)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#collapsible_if.
 
+warning: [lint] Use doc comment `///` instead of regular comment `//` for documentable items.
+   ┌─ tests/model_ast_lints/collapsible_if.move:28:1
+   │
+28 │ ╭     // Nested if with complex conditions
+29 │ │     public fun test_warn_3(x: u64, y: u64) {
+   │ ╰^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(prefer_doc_comment)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#prefer_doc_comment.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/collapsible_if.move:29:16
+   │
+29 │     public fun test_warn_3(x: u64, y: u64) {
+   │                ^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] Nested `if` statements can be collapsed into a single `if` by using logical conjunction (`&&`) of the conditions
    ┌─ tests/model_ast_lints/collapsible_if.move:30:9
    │
@@ -38,6 +95,25 @@ warning: [lint] Nested `if` statements can be collapsed into a single `if` by us
    │
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(collapsible_if)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#collapsible_if.
+
+warning: [lint] Use doc comment `///` instead of regular comment `//` for documentable items.
+   ┌─ tests/model_ast_lints/collapsible_if.move:37:1
+   │
+37 │ ╭     // Multiple levels of nesting (should warn on the first level)
+38 │ │     public fun test_warn_4(a: bool, b: bool, c: bool) {
+   │ ╰^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(prefer_doc_comment)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#prefer_doc_comment.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/collapsible_if.move:38:16
+   │
+38 │     public fun test_warn_4(a: bool, b: bool, c: bool) {
+   │                ^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
 
 warning: [lint] Nested `if` statements can be collapsed into a single `if` by using logical conjunction (`&&`) of the conditions
    ┌─ tests/model_ast_lints/collapsible_if.move:39:9
@@ -54,6 +130,25 @@ warning: [lint] Nested `if` statements can be collapsed into a single `if` by us
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(collapsible_if)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#collapsible_if.
 
+warning: [lint] Use doc comment `///` instead of regular comment `//` for documentable items.
+   ┌─ tests/model_ast_lints/collapsible_if.move:48:1
+   │
+48 │ ╭     // Nested if with empty else branch
+49 │ │     public fun test_warn_5(a: bool, b: bool) {
+   │ ╰^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(prefer_doc_comment)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#prefer_doc_comment.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/collapsible_if.move:49:16
+   │
+49 │     public fun test_warn_5(a: bool, b: bool) {
+   │                ^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] Nested `if` statements can be collapsed into a single `if` by using logical conjunction (`&&`) of the conditions
    ┌─ tests/model_ast_lints/collapsible_if.move:50:9
    │
@@ -68,3 +163,122 @@ warning: [lint] Nested `if` statements can be collapsed into a single `if` by us
    │
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(collapsible_if)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#collapsible_if.
+
+warning: [lint] Use doc comment `///` instead of regular comment `//` for documentable items.
+   ┌─ tests/model_ast_lints/collapsible_if.move:61:1
+   │
+61 │ ╭     // Outer if has else clause
+62 │ │     public fun test_no_warn_1(a: bool, b: bool) {
+   │ ╰^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(prefer_doc_comment)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#prefer_doc_comment.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/collapsible_if.move:62:16
+   │
+62 │     public fun test_no_warn_1(a: bool, b: bool) {
+   │                ^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Use doc comment `///` instead of regular comment `//` for documentable items.
+   ┌─ tests/model_ast_lints/collapsible_if.move:72:1
+   │
+72 │ ╭     // Inner if has else clause
+73 │ │     public fun test_no_warn_2(a: bool, b: bool) {
+   │ ╰^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(prefer_doc_comment)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#prefer_doc_comment.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/collapsible_if.move:73:16
+   │
+73 │     public fun test_no_warn_2(a: bool, b: bool) {
+   │                ^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Use doc comment `///` instead of regular comment `//` for documentable items.
+   ┌─ tests/model_ast_lints/collapsible_if.move:83:1
+   │
+83 │ ╭     // Both ifs have else clauses
+84 │ │     public fun test_no_warn_3(a: bool, b: bool) {
+   │ ╰^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(prefer_doc_comment)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#prefer_doc_comment.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/collapsible_if.move:84:16
+   │
+84 │     public fun test_no_warn_3(a: bool, b: bool) {
+   │                ^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Use doc comment `///` instead of regular comment `//` for documentable items.
+   ┌─ tests/model_ast_lints/collapsible_if.move:96:1
+   │
+96 │ ╭     // No nesting - just a single if
+97 │ │     public fun test_no_warn_4(a: bool) {
+   │ ╰^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(prefer_doc_comment)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#prefer_doc_comment.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/collapsible_if.move:97:16
+   │
+97 │     public fun test_no_warn_4(a: bool) {
+   │                ^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Use doc comment `///` instead of regular comment `//` for documentable items.
+    ┌─ tests/model_ast_lints/collapsible_if.move:103:1
+    │
+103 │ ╭     // Different statements between ifs
+104 │ │     public fun test_no_warn_5(a: bool, b: bool) {
+    │ ╰^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(prefer_doc_comment)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#prefer_doc_comment.
+
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/collapsible_if.move:104:16
+    │
+104 │     public fun test_no_warn_5(a: bool, b: bool) {
+    │                ^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/collapsible_if.move:114:16
+    │
+114 │     public fun test_no_warn_6(a: bool, b: bool) {
+    │                ^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Module is missing a doc comment.
+    ┌─ tests/model_ast_lints/collapsible_if.move:1:1
+    │
+  1 │ ╭ module 0xc0ffee::m {
+  2 │ │     fun foo(x: u64): bool {
+  3 │ │         x > 10
+  4 │ │     }
+    · │
+120 │ │     }
+121 │ │ }
+    │ ╰─^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_module)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_module.

--- a/third_party/move/tools/move-linter/tests/model_ast_lints/cyclomatic_complexity_warn.exp
+++ b/third_party/move/tools/move-linter/tests/model_ast_lints/cyclomatic_complexity_warn.exp
@@ -1,5 +1,24 @@
 
 Diagnostics:
+warning: [lint] Use doc comment `///` instead of regular comment `//` for documentable items.
+  ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:2:1
+  │
+2 │ ╭     // complexity: 12
+3 │ │     public fun high_complexity(a: bool, b: bool): bool {
+  │ ╰^
+  │
+  = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(prefer_doc_comment)]`.
+  = For more information, see https://aptos.dev/en/build/smart-contracts/linter#prefer_doc_comment.
+
+warning: [lint] Public function is missing a doc comment.
+  ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:3:16
+  │
+3 │     public fun high_complexity(a: bool, b: bool): bool {
+  │                ^^^^^^^^^^^^^^^
+  │
+  = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+  = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] Function `complexity::high_complexity` has cyclomatic complexity 12, which exceeds the allowed threshold of 10
    ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:3:5
    │
@@ -14,6 +33,35 @@ warning: [lint] Function `complexity::high_complexity` has cyclomatic complexity
    │
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(cyclomatic_complexity)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#cyclomatic_complexity.
+
+warning: [lint] Use doc comment `///` instead of regular comment `//` for documentable items.
+   ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:29:1
+   │
+29 │ ╭     // complexity: 1
+30 │ │     public fun low_complexity(): bool {
+   │ ╰^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(prefer_doc_comment)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#prefer_doc_comment.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:30:16
+   │
+30 │     public fun low_complexity(): bool {
+   │                ^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Use doc comment `///` instead of regular comment `//` for documentable items.
+   ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:35:1
+   │
+35 │ ╭     // complexity: 11
+36 │ │     inline fun inline_fun(b: u64): u64 {
+   │ ╰^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(prefer_doc_comment)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#prefer_doc_comment.
 
 warning: [lint] Function `complexity::inline_fun` has cyclomatic complexity 11, which exceeds the allowed threshold of 10
    ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:36:5
@@ -30,6 +78,386 @@ warning: [lint] Function `complexity::inline_fun` has cyclomatic complexity 11, 
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(cyclomatic_complexity)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#cyclomatic_complexity.
 
+warning: [lint] Use doc comment `///` instead of regular comment `//` for documentable items.
+   ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:62:1
+   │
+62 │ ╭     // complexity: 1
+63 │ │     public fun simple_function(): u64 {
+   │ ╰^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(prefer_doc_comment)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#prefer_doc_comment.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:63:16
+   │
+63 │     public fun simple_function(): u64 {
+   │                ^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Use doc comment `///` instead of regular comment `//` for documentable items.
+   ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:67:1
+   │
+67 │ ╭     // complexity: 2
+68 │ │     public fun single_if(x: u64): u64 {
+   │ ╰^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(prefer_doc_comment)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#prefer_doc_comment.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:68:16
+   │
+68 │     public fun single_if(x: u64): u64 {
+   │                ^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Use doc comment `///` instead of regular comment `//` for documentable items.
+   ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:76:1
+   │
+76 │ ╭     // complexity: 4
+77 │ │     public fun multiple_if_else(x: u64): u64 {
+   │ ╰^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(prefer_doc_comment)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#prefer_doc_comment.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:77:16
+   │
+77 │     public fun multiple_if_else(x: u64): u64 {
+   │                ^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Use doc comment `///` instead of regular comment `//` for documentable items.
+   ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:89:1
+   │
+89 │ ╭     // complexity: 4
+90 │ │     public fun simple_while(x: u64): u64 {
+   │ ╰^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(prefer_doc_comment)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#prefer_doc_comment.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:90:16
+   │
+90 │     public fun simple_while(x: u64): u64 {
+   │                ^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Use doc comment `///` instead of regular comment `//` for documentable items.
+    ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:101:1
+    │
+101 │ ╭     // complexity: 4
+102 │ │     public fun while_with_conditions(x: u64): u64 {
+    │ ╰^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(prefer_doc_comment)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#prefer_doc_comment.
+
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:102:16
+    │
+102 │     public fun while_with_conditions(x: u64): u64 {
+    │                ^^^^^^^^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Use doc comment `///` instead of regular comment `//` for documentable items.
+    ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:116:1
+    │
+116 │ ╭     // complexity: 4
+117 │ │     public fun while_with_nested_conditions(x: u64): u64 {
+    │ ╰^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(prefer_doc_comment)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#prefer_doc_comment.
+
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:117:16
+    │
+117 │     public fun while_with_nested_conditions(x: u64): u64 {
+    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Use doc comment `///` instead of regular comment `//` for documentable items.
+    ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:131:1
+    │
+131 │ ╭     // complexity: 5
+132 │ │     public fun while_with_nested_ifs(n: u64): u64 {
+    │ ╰^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(prefer_doc_comment)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#prefer_doc_comment.
+
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:132:16
+    │
+132 │     public fun while_with_nested_ifs(n: u64): u64 {
+    │                ^^^^^^^^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Use doc comment `///` instead of regular comment `//` for documentable items.
+    ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:154:1
+    │
+154 │ ╭     // complexity: 8
+155 │ │     public fun complex_nested_structure(x: u64, y: u64): u64 {
+    │ ╰^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(prefer_doc_comment)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#prefer_doc_comment.
+
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:155:16
+    │
+155 │     public fun complex_nested_structure(x: u64, y: u64): u64 {
+    │                ^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Use doc comment `///` instead of regular comment `//` for documentable items.
+    ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:179:1
+    │
+179 │ ╭     // complexity: 7
+180 │ │     public fun nested_while_loops(n: u64): u64 {
+    │ ╰^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(prefer_doc_comment)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#prefer_doc_comment.
+
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:180:16
+    │
+180 │     public fun nested_while_loops(n: u64): u64 {
+    │                ^^^^^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Use doc comment `///` instead of regular comment `//` for documentable items.
+    ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:206:1
+    │
+206 │ ╭     // complexity: 7
+207 │ │     public fun very_complex_while(): u64 {
+    │ ╰^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(prefer_doc_comment)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#prefer_doc_comment.
+
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:207:16
+    │
+207 │     public fun very_complex_while(): u64 {
+    │                ^^^^^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Use doc comment `///` instead of regular comment `//` for documentable items.
+    ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:235:1
+    │
+235 │ ╭     // complexity: 6
+236 │ │     public fun while_with_early_returns(x: u64): u64 {
+    │ ╰^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(prefer_doc_comment)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#prefer_doc_comment.
+
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:236:16
+    │
+236 │     public fun while_with_early_returns(x: u64): u64 {
+    │                ^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Use doc comment `///` instead of regular comment `//` for documentable items.
+    ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:253:1
+    │
+253 │ ╭     // complexity: 10
+254 │ │     public fun switch_like_structure(n: u64): u64 {
+    │ ╰^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(prefer_doc_comment)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#prefer_doc_comment.
+
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:254:16
+    │
+254 │     public fun switch_like_structure(n: u64): u64 {
+    │                ^^^^^^^^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Use doc comment `///` instead of regular comment `//` for documentable items.
+    ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:282:1
+    │
+282 │ ╭     // complexity: 5
+283 │ │     public fun double_nested_while_loops(n: u64, m: u64): u64 {
+    │ ╰^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(prefer_doc_comment)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#prefer_doc_comment.
+
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:283:16
+    │
+283 │     public fun double_nested_while_loops(n: u64, m: u64): u64 {
+    │                ^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Use doc comment `///` instead of regular comment `//` for documentable items.
+    ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:303:1
+    │
+303 │ ╭     // complexity: 3
+304 │ │     public fun while_with_nested_while(x: u64): u64 {
+    │ ╰^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(prefer_doc_comment)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#prefer_doc_comment.
+
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:304:16
+    │
+304 │     public fun while_with_nested_while(x: u64): u64 {
+    │                ^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Use doc comment `///` instead of regular comment `//` for documentable items.
+    ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:315:1
+    │
+315 │ ╭     // complexity: 10
+316 │ │     public fun extremely_complex_function(a: u64, b: u64, c: bool): u64 {
+    │ ╰^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(prefer_doc_comment)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#prefer_doc_comment.
+
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:316:16
+    │
+316 │     public fun extremely_complex_function(a: u64, b: u64, c: bool): u64 {
+    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Use doc comment `///` instead of regular comment `//` for documentable items.
+    ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:356:1
+    │
+356 │ ╭     // complexity: 3
+357 │ │     public fun simple_while_loop(n: u64): u64 {
+    │ ╰^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(prefer_doc_comment)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#prefer_doc_comment.
+
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:357:16
+    │
+357 │     public fun simple_while_loop(n: u64): u64 {
+    │                ^^^^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Use doc comment `///` instead of regular comment `//` for documentable items.
+    ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:369:1
+    │
+369 │ ╭     // complexity: 7
+370 │ │     public fun nested_while_with_many_conditions(n: u64, m: u64): u64 {
+    │ ╰^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(prefer_doc_comment)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#prefer_doc_comment.
+
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:370:16
+    │
+370 │     public fun nested_while_with_many_conditions(n: u64, m: u64): u64 {
+    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Use doc comment `///` instead of regular comment `//` for documentable items.
+    ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:394:1
+    │
+394 │ ╭     // complexity: 6
+395 │ │     public fun while_while_combination(x: u64): u64 {
+    │ ╰^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(prefer_doc_comment)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#prefer_doc_comment.
+
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:395:16
+    │
+395 │     public fun while_while_combination(x: u64): u64 {
+    │                ^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Use doc comment `///` instead of regular comment `//` for documentable items.
+    ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:417:1
+    │
+417 │ ╭     // complexity: 10
+418 │ │     public fun complex_state_machine(): u64 {
+    │ ╰^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(prefer_doc_comment)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#prefer_doc_comment.
+
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:418:16
+    │
+418 │     public fun complex_state_machine(): u64 {
+    │                ^^^^^^^^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Use doc comment `///` instead of regular comment `//` for documentable items.
+    ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:454:1
+    │
+454 │ ╭     // complexity: 14
+455 │ │     public fun triple_nested_while_loops(a: u64, b: u64, c: u64): u64 {
+    │ ╰^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(prefer_doc_comment)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#prefer_doc_comment.
+
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:455:16
+    │
+455 │     public fun triple_nested_while_loops(a: u64, b: u64, c: u64): u64 {
+    │                ^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] Function `complexity::triple_nested_while_loops` has cyclomatic complexity 14, which exceeds the allowed threshold of 10
     ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:455:5
     │
@@ -44,6 +472,120 @@ warning: [lint] Function `complexity::triple_nested_while_loops` has cyclomatic 
     │
     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(cyclomatic_complexity)]`.
     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#cyclomatic_complexity.
+
+warning: [lint] Use doc comment `///` instead of regular comment `//` for documentable items.
+    ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:495:1
+    │
+495 │ ╭     // complexity: 8
+496 │ │     public fun nested_while_combination(x: u64, y: u64): u64 {
+    │ ╰^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(prefer_doc_comment)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#prefer_doc_comment.
+
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:496:16
+    │
+496 │     public fun nested_while_combination(x: u64, y: u64): u64 {
+    │                ^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Use doc comment `///` instead of regular comment `//` for documentable items.
+    ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:518:1
+    │
+518 │ ╭     // complexity: 10
+519 │ │     public fun while_with_early_returns_v2(n: u64): u64 {
+    │ ╰^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(prefer_doc_comment)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#prefer_doc_comment.
+
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:519:16
+    │
+519 │     public fun while_with_early_returns_v2(n: u64): u64 {
+    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Use doc comment `///` instead of regular comment `//` for documentable items.
+    ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:536:1
+    │
+536 │ ╭     // complexity: 10
+537 │ │     public fun deeply_nested_conditions(x: u64, y: u64, z: bool): u64 {
+    │ ╰^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(prefer_doc_comment)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#prefer_doc_comment.
+
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:537:16
+    │
+537 │     public fun deeply_nested_conditions(x: u64, y: u64, z: bool): u64 {
+    │                ^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Use doc comment `///` instead of regular comment `//` for documentable items.
+    ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:578:1
+    │
+578 │ ╭     // complexity: 4
+579 │ │     public fun while_with_breaks_and_continues(n: u64): u64 {
+    │ ╰^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(prefer_doc_comment)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#prefer_doc_comment.
+
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:579:16
+    │
+579 │     public fun while_with_breaks_and_continues(n: u64): u64 {
+    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Use doc comment `///` instead of regular comment `//` for documentable items.
+    ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:599:1
+    │
+599 │ ╭     // complexity: 8
+600 │ │     public fun double_while_loops(a: u64, b: u64): u64 {
+    │ ╰^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(prefer_doc_comment)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#prefer_doc_comment.
+
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:600:16
+    │
+600 │     public fun double_while_loops(a: u64, b: u64): u64 {
+    │                ^^^^^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Use doc comment `///` instead of regular comment `//` for documentable items.
+    ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:622:1
+    │
+622 │ ╭     // complexity: 13
+623 │ │     public fun massive_switch_like(n: u64): u64 {
+    │ ╰^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(prefer_doc_comment)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#prefer_doc_comment.
+
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:623:16
+    │
+623 │     public fun massive_switch_like(n: u64): u64 {
+    │                ^^^^^^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
 
 warning: [lint] Function `complexity::massive_switch_like` has cyclomatic complexity 13, which exceeds the allowed threshold of 10
     ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:623:5
@@ -60,6 +602,44 @@ warning: [lint] Function `complexity::massive_switch_like` has cyclomatic comple
     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(cyclomatic_complexity)]`.
     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#cyclomatic_complexity.
 
+warning: [lint] Use doc comment `///` instead of regular comment `//` for documentable items.
+    ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:657:1
+    │
+657 │ ╭     // complexity: 10
+658 │ │     public fun while_while_nested_complex(n: u64): u64 {
+    │ ╰^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(prefer_doc_comment)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#prefer_doc_comment.
+
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:658:16
+    │
+658 │     public fun while_while_nested_complex(n: u64): u64 {
+    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Use doc comment `///` instead of regular comment `//` for documentable items.
+    ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:686:1
+    │
+686 │ ╭     // complexity: 16
+687 │ │     public fun ultra_complex_nested(x: u64, y: u64, z: u64): u64 {
+    │ ╰^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(prefer_doc_comment)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#prefer_doc_comment.
+
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:687:16
+    │
+687 │     public fun ultra_complex_nested(x: u64, y: u64, z: u64): u64 {
+    │                ^^^^^^^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] Function `complexity::ultra_complex_nested` has cyclomatic complexity 16, which exceeds the allowed threshold of 10
     ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:687:5
     │
@@ -74,6 +654,63 @@ warning: [lint] Function `complexity::ultra_complex_nested` has cyclomatic compl
     │
     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(cyclomatic_complexity)]`.
     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#cyclomatic_complexity.
+
+warning: [lint] Use doc comment `///` instead of regular comment `//` for documentable items.
+    ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:746:1
+    │
+746 │ ╭     // complexity: 4
+747 │ │     public fun simple_triple_while(a: u64, b: u64, c: u64): u64 {
+    │ ╰^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(prefer_doc_comment)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#prefer_doc_comment.
+
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:747:16
+    │
+747 │     public fun simple_triple_while(a: u64, b: u64, c: u64): u64 {
+    │                ^^^^^^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Use doc comment `///` instead of regular comment `//` for documentable items.
+    ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:765:1
+    │
+765 │ ╭     // complexity: 6
+766 │ │     public fun mixed_while_with_conditions(n: u64): u64 {
+    │ ╰^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(prefer_doc_comment)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#prefer_doc_comment.
+
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:766:16
+    │
+766 │     public fun mixed_while_with_conditions(n: u64): u64 {
+    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Use doc comment `///` instead of regular comment `//` for documentable items.
+    ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:788:1
+    │
+788 │ ╭     // complexity: 17
+789 │ │     public fun enormous_switch(n: u64): u64 {
+    │ ╰^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(prefer_doc_comment)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#prefer_doc_comment.
+
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:789:16
+    │
+789 │     public fun enormous_switch(n: u64): u64 {
+    │                ^^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
 
 warning: [lint] Function `complexity::enormous_switch` has cyclomatic complexity 17, which exceeds the allowed threshold of 10
     ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:789:5
@@ -90,6 +727,25 @@ warning: [lint] Function `complexity::enormous_switch` has cyclomatic complexity
     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(cyclomatic_complexity)]`.
     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#cyclomatic_complexity.
 
+warning: [lint] Use doc comment `///` instead of regular comment `//` for documentable items.
+    ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:831:1
+    │
+831 │ ╭     // complexity: 16
+832 │ │     public fun maximum_complexity_test(a: u64, b: u64, c: u64, flag: bool): u64 {
+    │ ╰^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(prefer_doc_comment)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#prefer_doc_comment.
+
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:832:16
+    │
+832 │     public fun maximum_complexity_test(a: u64, b: u64, c: u64, flag: bool): u64 {
+    │                ^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] Function `complexity::maximum_complexity_test` has cyclomatic complexity 16, which exceeds the allowed threshold of 10
     ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:832:5
     │
@@ -104,6 +760,234 @@ warning: [lint] Function `complexity::maximum_complexity_test` has cyclomatic co
     │
     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(cyclomatic_complexity)]`.
     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#cyclomatic_complexity.
+
+warning: [lint] Use doc comment `///` instead of regular comment `//` for documentable items.
+    ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:900:1
+    │
+900 │ ╭     // complexity: 2
+901 │ │     public fun simple_for_loop(n: u64): u64 {
+    │ ╰^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(prefer_doc_comment)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#prefer_doc_comment.
+
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:901:16
+    │
+901 │     public fun simple_for_loop(n: u64): u64 {
+    │                ^^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Use doc comment `///` instead of regular comment `//` for documentable items.
+    ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:909:1
+    │
+909 │ ╭     // complexity: 3
+910 │ │     public fun for_with_simple_if(n: u64): u64 {
+    │ ╰^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(prefer_doc_comment)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#prefer_doc_comment.
+
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:910:16
+    │
+910 │     public fun for_with_simple_if(n: u64): u64 {
+    │                ^^^^^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Use doc comment `///` instead of regular comment `//` for documentable items.
+    ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:920:1
+    │
+920 │ ╭     // complexity: 4
+921 │ │     public fun for_with_multiple_conditions(n: u64): u64 {
+    │ ╰^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(prefer_doc_comment)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#prefer_doc_comment.
+
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:921:16
+    │
+921 │     public fun for_with_multiple_conditions(n: u64): u64 {
+    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Use doc comment `///` instead of regular comment `//` for documentable items.
+    ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:935:1
+    │
+935 │ ╭     // complexity: 4
+936 │ │     public fun nested_for_loops(n: u64, m: u64): u64 {
+    │ ╰^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(prefer_doc_comment)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#prefer_doc_comment.
+
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:936:16
+    │
+936 │     public fun nested_for_loops(n: u64, m: u64): u64 {
+    │                ^^^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Use doc comment `///` instead of regular comment `//` for documentable items.
+    ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:948:1
+    │
+948 │ ╭     // complexity: 6
+949 │ │     public fun nested_for_with_conditions(n: u64, m: u64): u64 {
+    │ ╰^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(prefer_doc_comment)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#prefer_doc_comment.
+
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:949:16
+    │
+949 │     public fun nested_for_with_conditions(n: u64, m: u64): u64 {
+    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Use doc comment `///` instead of regular comment `//` for documentable items.
+    ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:967:1
+    │
+967 │ ╭     // complexity: 6
+968 │ │     public fun triple_for_loops(a: u64, b: u64, c: u64): u64 {
+    │ ╰^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(prefer_doc_comment)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#prefer_doc_comment.
+
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:968:16
+    │
+968 │     public fun triple_for_loops(a: u64, b: u64, c: u64): u64 {
+    │                ^^^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Use doc comment `///` instead of regular comment `//` for documentable items.
+    ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:984:1
+    │
+984 │ ╭     // complexity: 4
+985 │ │     public fun for_with_continue(n: u64): u64 {
+    │ ╰^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(prefer_doc_comment)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#prefer_doc_comment.
+
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:985:16
+    │
+985 │     public fun for_with_continue(n: u64): u64 {
+    │                ^^^^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Use doc comment `///` instead of regular comment `//` for documentable items.
+    ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:996:1
+    │
+996 │ ╭     // complexity: 4
+997 │ │     public fun for_with_break(n: u64): u64 {
+    │ ╰^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(prefer_doc_comment)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#prefer_doc_comment.
+
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:997:16
+    │
+997 │     public fun for_with_break(n: u64): u64 {
+    │                ^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Use doc comment `///` instead of regular comment `//` for documentable items.
+     ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:1008:1
+     │
+1008 │ ╭     // complexity: 6
+1009 │ │     public fun for_with_break_and_continue(n: u64): u64 {
+     │ ╰^
+     │
+     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(prefer_doc_comment)]`.
+     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#prefer_doc_comment.
+
+warning: [lint] Public function is missing a doc comment.
+     ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:1009:16
+     │
+1009 │     public fun for_with_break_and_continue(n: u64): u64 {
+     │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+     │
+     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Use doc comment `///` instead of regular comment `//` for documentable items.
+     ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:1023:1
+     │
+1023 │ ╭     // complexity: 4
+1024 │ │     public fun for_with_while(n: u64): u64 {
+     │ ╰^
+     │
+     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(prefer_doc_comment)]`.
+     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#prefer_doc_comment.
+
+warning: [lint] Public function is missing a doc comment.
+     ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:1024:16
+     │
+1024 │     public fun for_with_while(n: u64): u64 {
+     │                ^^^^^^^^^^^^^^
+     │
+     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Use doc comment `///` instead of regular comment `//` for documentable items.
+     ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:1038:1
+     │
+1038 │ ╭     // complexity: 7
+1039 │ │     public fun for_while_complex(n: u64): u64 {
+     │ ╰^
+     │
+     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(prefer_doc_comment)]`.
+     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#prefer_doc_comment.
+
+warning: [lint] Public function is missing a doc comment.
+     ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:1039:16
+     │
+1039 │     public fun for_while_complex(n: u64): u64 {
+     │                ^^^^^^^^^^^^^^^^^
+     │
+     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Use doc comment `///` instead of regular comment `//` for documentable items.
+     ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:1061:1
+     │
+1061 │ ╭     // complexity: 11
+1062 │ │     public fun for_with_early_return(n: u64): u64 {
+     │ ╰^
+     │
+     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(prefer_doc_comment)]`.
+     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#prefer_doc_comment.
+
+warning: [lint] Public function is missing a doc comment.
+     ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:1062:16
+     │
+1062 │     public fun for_with_early_return(n: u64): u64 {
+     │                ^^^^^^^^^^^^^^^^^^^^^
+     │
+     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
 
 warning: [lint] Function `complexity::for_with_early_return` has cyclomatic complexity 11, which exceeds the allowed threshold of 10
      ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:1062:5
@@ -120,6 +1004,25 @@ warning: [lint] Function `complexity::for_with_early_return` has cyclomatic comp
      = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(cyclomatic_complexity)]`.
      = For more information, see https://aptos.dev/en/build/smart-contracts/linter#cyclomatic_complexity.
 
+warning: [lint] Use doc comment `///` instead of regular comment `//` for documentable items.
+     ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:1088:1
+     │
+1088 │ ╭     // complexity: 13
+1089 │ │     public fun complex_nested_for_with_boolean_ops(n: u64, m: u64): u64 {
+     │ ╰^
+     │
+     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(prefer_doc_comment)]`.
+     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#prefer_doc_comment.
+
+warning: [lint] Public function is missing a doc comment.
+     ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:1089:16
+     │
+1089 │     public fun complex_nested_for_with_boolean_ops(n: u64, m: u64): u64 {
+     │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+     │
+     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] Function `complexity::complex_nested_for_with_boolean_ops` has cyclomatic complexity 13, which exceeds the allowed threshold of 10
      ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:1089:5
      │
@@ -134,6 +1037,25 @@ warning: [lint] Function `complexity::complex_nested_for_with_boolean_ops` has c
      │
      = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(cyclomatic_complexity)]`.
      = For more information, see https://aptos.dev/en/build/smart-contracts/linter#cyclomatic_complexity.
+
+warning: [lint] Use doc comment `///` instead of regular comment `//` for documentable items.
+     ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:1121:1
+     │
+1121 │ ╭     // complexity: 15
+1122 │ │     public fun massive_triple_for_with_conditions(a: u64, b: u64, c: u64): u64 {
+     │ ╰^
+     │
+     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(prefer_doc_comment)]`.
+     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#prefer_doc_comment.
+
+warning: [lint] Public function is missing a doc comment.
+     ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:1122:16
+     │
+1122 │     public fun massive_triple_for_with_conditions(a: u64, b: u64, c: u64): u64 {
+     │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+     │
+     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
 
 warning: [lint] Function `complexity::massive_triple_for_with_conditions` has cyclomatic complexity 15, which exceeds the allowed threshold of 10
      ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:1122:5
@@ -150,6 +1072,63 @@ warning: [lint] Function `complexity::massive_triple_for_with_conditions` has cy
      = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(cyclomatic_complexity)]`.
      = For more information, see https://aptos.dev/en/build/smart-contracts/linter#cyclomatic_complexity.
 
+warning: [lint] Use doc comment `///` instead of regular comment `//` for documentable items.
+     ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:1158:1
+     │
+1158 │ ╭     // complexity: 9
+1159 │ │     public fun for_with_inner_loop(n: u64): u64 {
+     │ ╰^
+     │
+     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(prefer_doc_comment)]`.
+     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#prefer_doc_comment.
+
+warning: [lint] Public function is missing a doc comment.
+     ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:1159:16
+     │
+1159 │     public fun for_with_inner_loop(n: u64): u64 {
+     │                ^^^^^^^^^^^^^^^^^^^
+     │
+     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Use doc comment `///` instead of regular comment `//` for documentable items.
+     ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:1183:1
+     │
+1183 │ ╭     // complexity: 10
+1184 │ │     public fun for_while_switch_like(n: u64): u64 {
+     │ ╰^
+     │
+     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(prefer_doc_comment)]`.
+     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#prefer_doc_comment.
+
+warning: [lint] Public function is missing a doc comment.
+     ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:1184:16
+     │
+1184 │     public fun for_while_switch_like(n: u64): u64 {
+     │                ^^^^^^^^^^^^^^^^^^^^^
+     │
+     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Use doc comment `///` instead of regular comment `//` for documentable items.
+     ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:1212:1
+     │
+1212 │ ╭     // complexity: 62
+1213 │ │     public fun comprehensive_control_flow_test(x: u64, y: u64, z: u64, flag: bool): u64 {
+     │ ╰^
+     │
+     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(prefer_doc_comment)]`.
+     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#prefer_doc_comment.
+
+warning: [lint] Public function is missing a doc comment.
+     ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:1213:16
+     │
+1213 │     public fun comprehensive_control_flow_test(x: u64, y: u64, z: u64, flag: bool): u64 {
+     │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+     │
+     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] Function `complexity::comprehensive_control_flow_test` has cyclomatic complexity 62, which exceeds the allowed threshold of 10
      ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:1213:5
      │
@@ -165,6 +1144,91 @@ warning: [lint] Function `complexity::comprehensive_control_flow_test` has cyclo
      = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(cyclomatic_complexity)]`.
      = For more information, see https://aptos.dev/en/build/smart-contracts/linter#cyclomatic_complexity.
 
+warning: [lint] Public function is missing a doc comment.
+     ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:1368:16
+     │
+1368 │     public fun skipped_function(b: u64): u64 {
+     │                ^^^^^^^^^^^^^^^^
+     │
+     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Use doc comment `///` instead of regular comment `//` for documentable items.
+     ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:1394:1
+     │
+1394 │ ╭     // complexity: 10
+1395 │ │     public fun block_return_1(b: u64): u64 {
+     │ ╰^
+     │
+     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(prefer_doc_comment)]`.
+     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#prefer_doc_comment.
+
+warning: [lint] Public function is missing a doc comment.
+     ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:1395:16
+     │
+1395 │     public fun block_return_1(b: u64): u64 {
+     │                ^^^^^^^^^^^^^^
+     │
+     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Use doc comment `///` instead of regular comment `//` for documentable items.
+     ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:1420:1
+     │
+1420 │ ╭     // complexity: 10
+1421 │ │         public fun block_return_2(b: u64): u64 {
+     │ ╰^
+     │
+     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(prefer_doc_comment)]`.
+     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#prefer_doc_comment.
+
+warning: [lint] Public function is missing a doc comment.
+     ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:1421:20
+     │
+1421 │         public fun block_return_2(b: u64): u64 {
+     │                    ^^^^^^^^^^^^^^
+     │
+     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Use doc comment `///` instead of regular comment `//` for documentable items.
+     ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:1446:1
+     │
+1446 │ ╭     // complexity: 10
+1447 │ │     public fun block_return_3(b: u64): u64 {
+     │ ╰^
+     │
+     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(prefer_doc_comment)]`.
+     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#prefer_doc_comment.
+
+warning: [lint] Public function is missing a doc comment.
+     ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:1447:16
+     │
+1447 │     public fun block_return_3(b: u64): u64 {
+     │                ^^^^^^^^^^^^^^
+     │
+     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Use doc comment `///` instead of regular comment `//` for documentable items.
+     ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:1472:1
+     │
+1472 │ ╭         //complexity: 11
+1473 │ │         public fun block_return_4(b: u64): u64 {
+     │ ╰^
+     │
+     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(prefer_doc_comment)]`.
+     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#prefer_doc_comment.
+
+warning: [lint] Public function is missing a doc comment.
+     ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:1473:20
+     │
+1473 │         public fun block_return_4(b: u64): u64 {
+     │                    ^^^^^^^^^^^^^^
+     │
+     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] Function `complexity::block_return_4` has cyclomatic complexity 11, which exceeds the allowed threshold of 10
      ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:1473:9
      │
@@ -179,3 +1243,18 @@ warning: [lint] Function `complexity::block_return_4` has cyclomatic complexity 
      │
      = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(cyclomatic_complexity)]`.
      = For more information, see https://aptos.dev/en/build/smart-contracts/linter#cyclomatic_complexity.
+
+warning: [lint] Module is missing a doc comment.
+     ┌─ tests/model_ast_lints/cyclomatic_complexity_warn.move:1:1
+     │
+   1 │ ╭ module 0xc0ffee::complexity {
+   2 │ │     // complexity: 12
+   3 │ │     public fun high_complexity(a: bool, b: bool): bool {
+   4 │ │         assert!(a || b, 100); // +1
+     · │
+1498 │ │
+1499 │ │ }
+     │ ╰─^
+     │
+     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_module)]`.
+     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_module.

--- a/third_party/move/tools/move-linter/tests/model_ast_lints/empty_if.exp
+++ b/third_party/move/tools/move-linter/tests/model_ast_lints/empty_if.exp
@@ -1,5 +1,14 @@
 
 Diagnostics:
+warning: [lint] Public function is missing a doc comment.
+  ┌─ tests/model_ast_lints/empty_if.move:3:16
+  │
+3 │     public fun empty_if(x: u64) {
+  │                ^^^^^^^^
+  │
+  = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+  = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] Empty `if` branch. Consider simplifying this `if-else`.
   ┌─ tests/model_ast_lints/empty_if.move:4:9
   │
@@ -12,6 +21,15 @@ warning: [lint] Empty `if` branch. Consider simplifying this `if-else`.
   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(empty_if)]`.
   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#empty_if.
 
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/empty_if.move:10:16
+   │
+10 │     public fun empty_if_no_else(x: u64) {
+   │                ^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] Empty `if` branch. Consider simplifying by removing or rewriting.
    ┌─ tests/model_ast_lints/empty_if.move:11:9
    │
@@ -21,6 +39,24 @@ warning: [lint] Empty `if` branch. Consider simplifying by removing or rewriting
    │
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(empty_if)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#empty_if.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/empty_if.move:15:16
+   │
+15 │     public fun non_empty_if(x: u64): u64 {
+   │                ^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/empty_if.move:22:16
+   │
+22 │     public fun empty_if_with_void(x: u64): u64 {
+   │                ^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
 
 warning: [lint] Empty `if` branch. Consider simplifying by removing or rewriting.
    ┌─ tests/model_ast_lints/empty_if.move:23:9
@@ -33,6 +69,15 @@ warning: [lint] Empty `if` branch. Consider simplifying by removing or rewriting
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(empty_if)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#empty_if.
 
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/empty_if.move:29:16
+   │
+29 │     public fun empty_if_with_empty_else(x: u64): u64 {
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] Empty `if` branch. Consider simplifying by removing or rewriting.
    ┌─ tests/model_ast_lints/empty_if.move:30:9
    │
@@ -42,6 +87,15 @@ warning: [lint] Empty `if` branch. Consider simplifying by removing or rewriting
    │
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(empty_if)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#empty_if.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/empty_if.move:35:16
+   │
+35 │     public fun empty_if_with_non_empty_else(x: u64): u64 {
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
 
 warning: [lint] Empty `if` branch. Consider simplifying this `if-else`.
    ┌─ tests/model_ast_lints/empty_if.move:36:9
@@ -54,3 +108,45 @@ warning: [lint] Empty `if` branch. Consider simplifying this `if-else`.
    │
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(empty_if)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#empty_if.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/empty_if.move:43:16
+   │
+43 │     public fun aborts(x: u64) {
+   │                ^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/empty_if.move:48:16
+   │
+48 │     public fun skip_empty_if(x: u64) {
+   │                ^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/empty_if.move:53:16
+   │
+53 │     public fun dont_flag_abort_on_else(x: u64) {
+   │                ^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Module is missing a doc comment.
+   ┌─ tests/model_ast_lints/empty_if.move:1:1
+   │
+ 1 │ ╭ module 0xc0ffee::m {
+ 2 │ │
+ 3 │ │     public fun empty_if(x: u64) {
+ 4 │ │         if (x > 0) {
+   · │
+59 │ │
+60 │ │ }
+   │ ╰─^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_module)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_module.

--- a/third_party/move/tools/move-linter/tests/model_ast_lints/equal_operands_in_bin_op.exp
+++ b/third_party/move/tools/move-linter/tests/model_ast_lints/equal_operands_in_bin_op.exp
@@ -1,5 +1,54 @@
 
 Diagnostics:
+warning: [lint] Struct is missing a doc comment.
+  ┌─ tests/model_ast_lints/equal_operands_in_bin_op.move:4:5
+  │
+4 │     struct Counter has key, store, drop { i: u64 }
+  │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  │
+  = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_struct)]`.
+  = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_struct.
+
+warning: [lint] Struct is missing a doc comment.
+  ┌─ tests/model_ast_lints/equal_operands_in_bin_op.move:6:5
+  │
+6 │ ╭     struct NestedCounter has key, store, drop {
+7 │ │         n: Counter
+8 │ │     }
+  │ ╰─────^
+  │
+  = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_struct)]`.
+  = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_struct.
+
+warning: [lint] Struct is missing a doc comment.
+   ┌─ tests/model_ast_lints/equal_operands_in_bin_op.move:10:5
+   │
+10 │ ╭     struct HyperNestedCounter has key, store, drop {
+11 │ │         n: NestedCounter
+12 │ │     }
+   │ ╰─────^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_struct)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_struct.
+
+warning: [lint] Constant is missing a doc comment.
+   ┌─ tests/model_ast_lints/equal_operands_in_bin_op.move:14:5
+   │
+14 │     const TWO: u64 = 2;
+   │     ^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_constant)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_constant.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/equal_operands_in_bin_op.move:17:16
+   │
+17 │     public fun test1(x: u64) {
+   │                ^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] This operation always evaluates to `0`.
    ┌─ tests/model_ast_lints/equal_operands_in_bin_op.move:18:13
    │
@@ -134,3 +183,36 @@ warning: [lint] This boolean expression can be simplified using idempotence (`a 
    │
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(simpler_bool_expression)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#simpler_bool_expression.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/equal_operands_in_bin_op.move:90:16
+   │
+90 │     public fun test2(x: u64) {
+   │                ^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/equal_operands_in_bin_op.move:96:16
+   │
+96 │     public fun a_fn(a: u64): u64 {
+   │                ^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Module is missing a doc comment.
+    ┌─ tests/model_ast_lints/equal_operands_in_bin_op.move:1:1
+    │
+  1 │ ╭ module 0xc0ffee::m {
+  2 │ │     use std::vector;
+  3 │ │
+  4 │ │     struct Counter has key, store, drop { i: u64 }
+    · │
+100 │ │
+101 │ │ }
+    │ ╰─^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_module)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_module.

--- a/third_party/move/tools/move-linter/tests/model_ast_lints/exists_bool_equality.exp
+++ b/third_party/move/tools/move-linter/tests/model_ast_lints/exists_bool_equality.exp
@@ -1,5 +1,59 @@
 
 Diagnostics:
+warning: [lint] Struct is missing a doc comment.
+  ┌─ tests/model_ast_lints/exists_bool_equality.move:2:5
+  │
+2 │     struct A(bool) has key, drop;
+  │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  │
+  = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_struct)]`.
+  = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_struct.
+
+warning: [lint] Struct is missing a doc comment.
+  ┌─ tests/model_ast_lints/exists_bool_equality.move:3:5
+  │
+3 │     struct B(bool) has key, drop;
+  │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  │
+  = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_struct)]`.
+  = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_struct.
+
+warning: [lint] Public function is missing a doc comment.
+  ┌─ tests/model_ast_lints/exists_bool_equality.move:6:16
+  │
+6 │     public fun no_warn_1(): bool {
+  │                ^^^^^^^^^
+  │
+  = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+  = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/exists_bool_equality.move:10:16
+   │
+10 │     public fun no_warn_2(): bool {
+   │                ^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/exists_bool_equality.move:14:16
+   │
+14 │     public fun no_warn_3(): bool {
+   │                ^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/exists_bool_equality.move:18:16
+   │
+18 │     public fun warn_1(): bool {
+   │                ^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] This boolean expression can be simplified using idempotence (`a && a` is equivalent to `a`).
    ┌─ tests/model_ast_lints/exists_bool_equality.move:19:9
    │
@@ -8,6 +62,15 @@ warning: [lint] This boolean expression can be simplified using idempotence (`a 
    │
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(simpler_bool_expression)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#simpler_bool_expression.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/exists_bool_equality.move:22:16
+   │
+22 │     public fun warn_2(): bool {
+   │                ^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
 
 warning: [lint] This boolean expression can be simplified using idempotence (`a && a` is equivalent to `a`).
    ┌─ tests/model_ast_lints/exists_bool_equality.move:23:9
@@ -18,6 +81,15 @@ warning: [lint] This boolean expression can be simplified using idempotence (`a 
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(simpler_bool_expression)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#simpler_bool_expression.
 
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/exists_bool_equality.move:26:16
+   │
+26 │     public fun warn_3(): bool {
+   │                ^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] This boolean expression can be simplified using idempotence (`a && a` is equivalent to `a`).
    ┌─ tests/model_ast_lints/exists_bool_equality.move:27:9
    │
@@ -26,3 +98,18 @@ warning: [lint] This boolean expression can be simplified using idempotence (`a 
    │
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(simpler_bool_expression)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#simpler_bool_expression.
+
+warning: [lint] Module is missing a doc comment.
+   ┌─ tests/model_ast_lints/exists_bool_equality.move:1:1
+   │
+ 1 │ ╭ module 0xc0ffee::m {
+ 2 │ │     struct A(bool) has key, drop;
+ 3 │ │     struct B(bool) has key, drop;
+ 4 │ │
+   · │
+28 │ │     }
+29 │ │ }
+   │ ╰─^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_module)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_module.

--- a/third_party/move/tools/move-linter/tests/model_ast_lints/find_unnecessary_casts_test.exp
+++ b/third_party/move/tools/move-linter/tests/model_ast_lints/find_unnecessary_casts_test.exp
@@ -1,5 +1,32 @@
 Aborting with compilation errors:
 exiting with env checking errors
+warning: [lint] Constant is missing a doc comment.
+  ┌─ tests/model_ast_lints/find_unnecessary_casts_test.move:3:5
+  │
+3 │     const U8_VALUE: u8 = 255;
+  │     ^^^^^^^^^^^^^^^^^^^^^^^^^
+  │
+  = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_constant)]`.
+  = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_constant.
+
+warning: [lint] Constant is missing a doc comment.
+  ┌─ tests/model_ast_lints/find_unnecessary_casts_test.move:4:5
+  │
+4 │     const U64_VALUE: u64 = 1000;
+  │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  │
+  = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_constant)]`.
+  = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_constant.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/find_unnecessary_casts_test.move:11:16
+   │
+11 │     public fun test_cast_in_let_warn() {
+   │                ^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] Unnecessary cast: the expression is already of the target type. Consider removing the cast for better readability.
    ┌─ tests/model_ast_lints/find_unnecessary_casts_test.move:13:17
    │
@@ -8,6 +35,15 @@ warning: [lint] Unnecessary cast: the expression is already of the target type. 
    │
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_cast)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#unnecessary_cast.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/find_unnecessary_casts_test.move:16:16
+   │
+16 │     public fun test_cast_in_function_arg_warn() {
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
 
 warning: [lint] Unnecessary cast: the expression is already of the target type. Consider removing the cast for better readability.
    ┌─ tests/model_ast_lints/find_unnecessary_casts_test.move:18:33
@@ -18,6 +54,15 @@ warning: [lint] Unnecessary cast: the expression is already of the target type. 
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_cast)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#unnecessary_cast.
 
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/find_unnecessary_casts_test.move:21:16
+   │
+21 │     public fun test_cast_in_return_warn(): u64 {
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] Unnecessary cast: the expression is already of the target type. Consider removing the cast for better readability.
    ┌─ tests/model_ast_lints/find_unnecessary_casts_test.move:23:9
    │
@@ -26,6 +71,15 @@ warning: [lint] Unnecessary cast: the expression is already of the target type. 
    │
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_cast)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#unnecessary_cast.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/find_unnecessary_casts_test.move:26:16
+   │
+26 │     public fun test_cast_in_expression_warn() {
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
 
 warning: [lint] Unnecessary cast: the expression is already of the target type. Consider removing the cast for better readability.
    ┌─ tests/model_ast_lints/find_unnecessary_casts_test.move:29:22
@@ -36,6 +90,15 @@ warning: [lint] Unnecessary cast: the expression is already of the target type. 
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_cast)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#unnecessary_cast.
 
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/find_unnecessary_casts_test.move:32:16
+   │
+32 │     public fun test_cast_const_warn() {
+   │                ^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] Unnecessary cast: the expression is already of the target type. Consider removing the cast for better readability.
    ┌─ tests/model_ast_lints/find_unnecessary_casts_test.move:33:17
    │
@@ -44,6 +107,15 @@ warning: [lint] Unnecessary cast: the expression is already of the target type. 
    │
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_cast)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#unnecessary_cast.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/find_unnecessary_casts_test.move:36:16
+   │
+36 │     public fun test_cast_in_conditional_warn() {
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
 
 warning: [lint] Unnecessary cast: the expression is already of the target type. Consider removing the cast for better readability.
    ┌─ tests/model_ast_lints/find_unnecessary_casts_test.move:38:13
@@ -63,6 +135,15 @@ warning: [lint] Empty `if` branch. Consider simplifying by removing or rewriting
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(empty_if)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#empty_if.
 
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/find_unnecessary_casts_test.move:41:16
+   │
+41 │     public fun test_cast_in_assert_warn() {
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] Unnecessary cast: the expression is already of the target type. Consider removing the cast for better readability.
    ┌─ tests/model_ast_lints/find_unnecessary_casts_test.move:43:17
    │
@@ -71,6 +152,15 @@ warning: [lint] Unnecessary cast: the expression is already of the target type. 
    │
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_cast)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#unnecessary_cast.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/find_unnecessary_casts_test.move:46:16
+   │
+46 │     public fun test_multiple_casts_warn() {
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
 
 warning: [lint] Unnecessary cast: the expression is already of the target type. Consider removing the cast for better readability.
    ┌─ tests/model_ast_lints/find_unnecessary_casts_test.move:49:19
@@ -90,6 +180,15 @@ warning: [lint] Unnecessary cast: the expression is already of the target type. 
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_cast)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#unnecessary_cast.
 
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/find_unnecessary_casts_test.move:52:16
+   │
+52 │     public fun test_cast_nested_warn() {
+   │                ^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] Unnecessary cast: the expression is already of the target type. Consider removing the cast for better readability.
    ┌─ tests/model_ast_lints/find_unnecessary_casts_test.move:54:18
    │
@@ -108,11 +207,74 @@ warning: [lint] Unnecessary cast: the expression is already of the target type. 
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_cast)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#unnecessary_cast.
 
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/find_unnecessary_casts_test.move:59:16
+   │
+59 │     public fun test_necessary_cast_no_warn() {
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/find_unnecessary_casts_test.move:64:16
+   │
+64 │     public fun test_different_types_no_warn() {
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/find_unnecessary_casts_test.move:69:16
+   │
+69 │     public fun test_const_different_type_no_warn() {
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/find_unnecessary_casts_test.move:73:16
+   │
+73 │     public fun test_no_cast_no_warn() {
+   │                ^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/find_unnecessary_casts_test.move:78:16
+   │
+78 │     public fun test_downcast_no_warn() {
+   │                ^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/find_unnecessary_casts_test.move:83:16
+   │
+83 │     public fun test_cross_type_cast_no_warn() {
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 error: unknown lint check: `unnecessary_casts`
    ┌─ tests/model_ast_lints/find_unnecessary_casts_test.move:90:18
    │
 90 │     #[lint::skip(unnecessary_casts)]
    │                  ^^^^^^^^^^^^^^^^^
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/find_unnecessary_casts_test.move:91:16
+   │
+91 │     public fun test_skip_function_no_warn() {
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
 
 warning: [lint] Unnecessary cast: the expression is already of the target type. Consider removing the cast for better readability.
    ┌─ tests/model_ast_lints/find_unnecessary_casts_test.move:93:17
@@ -128,6 +290,15 @@ error: unknown lint check: `unnecessary_casts`
    │
 96 │     #[lint::skip(unnecessary_casts)]
    │                  ^^^^^^^^^^^^^^^^^
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/find_unnecessary_casts_test.move:97:16
+   │
+97 │     public fun test_skip_multiple_casts_no_warn() {
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
 
 warning: [lint] Unnecessary cast: the expression is already of the target type. Consider removing the cast for better readability.
     ┌─ tests/model_ast_lints/find_unnecessary_casts_test.move:100:19
@@ -147,11 +318,35 @@ warning: [lint] Unnecessary cast: the expression is already of the target type. 
     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_cast)]`.
     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#unnecessary_cast.
 
+warning: [lint] Module is missing a doc comment.
+    ┌─ tests/model_ast_lints/find_unnecessary_casts_test.move:1:1
+    │
+  1 │ ╭ module 0xc0ffee::unnecessary_casts_test {
+  2 │ │
+  3 │ │     const U8_VALUE: u8 = 255;
+  4 │ │     const U64_VALUE: u64 = 1000;
+    · │
+101 │ │     }
+102 │ │ }
+    │ ╰─^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_module)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_module.
+
 error: unknown lint check: `unnecessary_casts`
     ┌─ tests/model_ast_lints/find_unnecessary_casts_test.move:105:14
     │
 105 │ #[lint::skip(unnecessary_casts)]
     │              ^^^^^^^^^^^^^^^^^
+
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/find_unnecessary_casts_test.move:108:16
+    │
+108 │     public fun test_module_skip_no_warn() {
+    │                ^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
 
 warning: [lint] Unnecessary cast: the expression is already of the target type. Consider removing the cast for better readability.
     ┌─ tests/model_ast_lints/find_unnecessary_casts_test.move:110:17
@@ -161,6 +356,15 @@ warning: [lint] Unnecessary cast: the expression is already of the target type. 
     │
     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_cast)]`.
     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#unnecessary_cast.
+
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/find_unnecessary_casts_test.move:113:16
+    │
+113 │     public fun test_module_skip_multiple_no_warn() {
+    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
 
 warning: [lint] Unnecessary cast: the expression is already of the target type. Consider removing the cast for better readability.
     ┌─ tests/model_ast_lints/find_unnecessary_casts_test.move:116:22
@@ -179,3 +383,18 @@ warning: [lint] Unnecessary cast: the expression is already of the target type. 
     │
     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_cast)]`.
     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#unnecessary_cast.
+
+warning: [lint] Module is missing a doc comment.
+    ┌─ tests/model_ast_lints/find_unnecessary_casts_test.move:106:1
+    │
+106 │ ╭ module 0xc0ffee::unnecessary_casts_skip_module {
+107 │ │
+108 │ │     public fun test_module_skip_no_warn() {
+109 │ │         let x: u64 = 100;
+    · │
+117 │ │     }
+118 │ │ }
+    │ ╰─^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_module)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_module.

--- a/third_party/move/tools/move-linter/tests/model_ast_lints/known_to_abort.exp
+++ b/third_party/move/tools/move-linter/tests/model_ast_lints/known_to_abort.exp
@@ -1,5 +1,51 @@
 
 Diagnostics:
+warning: [lint] Use doc comment `///` instead of regular comment `//` for documentable items.
+  ┌─ tests/model_ast_lints/known_to_abort.move:2:1
+  │
+2 │ ╭     // Constants for testing
+3 │ │     const OVERFLOW_VALUE: u16 = 256;
+  │ ╰^
+  │
+  = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(prefer_doc_comment)]`.
+  = For more information, see https://aptos.dev/en/build/smart-contracts/linter#prefer_doc_comment.
+
+warning: [lint] Constant is missing a doc comment.
+  ┌─ tests/model_ast_lints/known_to_abort.move:3:5
+  │
+3 │     const OVERFLOW_VALUE: u16 = 256;
+  │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  │
+  = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_constant)]`.
+  = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_constant.
+
+warning: [lint] Constant is missing a doc comment.
+  ┌─ tests/model_ast_lints/known_to_abort.move:4:5
+  │
+4 │     const LARGE_U32: u64 = 4_294_967_296;
+  │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  │
+  = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_constant)]`.
+  = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_constant.
+
+warning: [lint] Constant is missing a doc comment.
+  ┌─ tests/model_ast_lints/known_to_abort.move:5:5
+  │
+5 │     const SHIFT_AMOUNT: u8 = 8;
+  │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  │
+  = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_constant)]`.
+  = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_constant.
+
+warning: [lint] Public function is missing a doc comment.
+  ┌─ tests/model_ast_lints/known_to_abort.move:7:16
+  │
+7 │     public fun test_divide_by_zero(x: u64): u64 {
+  │                ^^^^^^^^^^^^^^^^^^^
+  │
+  = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+  = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] Division by zero will abort
   ┌─ tests/model_ast_lints/known_to_abort.move:8:9
   │
@@ -8,6 +54,15 @@ warning: [lint] Division by zero will abort
   │
   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(known_to_abort)]`.
   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#known_to_abort.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/known_to_abort.move:11:16
+   │
+11 │     public fun test_modulo_by_zero(x: u64): u64 {
+   │                ^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
 
 warning: [lint] Modulo by zero will abort
    ┌─ tests/model_ast_lints/known_to_abort.move:12:9
@@ -18,6 +73,15 @@ warning: [lint] Modulo by zero will abort
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(known_to_abort)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#known_to_abort.
 
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/known_to_abort.move:15:16
+   │
+15 │     public fun test_cast_u8_overflow(): u8 {
+   │                ^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] Cast operation will abort because the value is outside the target type's range
    ┌─ tests/model_ast_lints/known_to_abort.move:16:9
    │
@@ -26,6 +90,15 @@ warning: [lint] Cast operation will abort because the value is outside the targe
    │
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(known_to_abort)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#known_to_abort.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/known_to_abort.move:19:16
+   │
+19 │     public fun test_cast_u16_overflow(): u16 {
+   │                ^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
 
 warning: [lint] Cast operation will abort because the value is outside the target type's range
    ┌─ tests/model_ast_lints/known_to_abort.move:20:9
@@ -36,6 +109,15 @@ warning: [lint] Cast operation will abort because the value is outside the targe
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(known_to_abort)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#known_to_abort.
 
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/known_to_abort.move:23:16
+   │
+23 │     public fun test_cast_u32_overflow(): u32 {
+   │                ^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] Cast operation will abort because the value is outside the target type's range
    ┌─ tests/model_ast_lints/known_to_abort.move:24:9
    │
@@ -44,6 +126,15 @@ warning: [lint] Cast operation will abort because the value is outside the targe
    │
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(known_to_abort)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#known_to_abort.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/known_to_abort.move:27:16
+   │
+27 │     public fun test_cast_u64_overflow(): u64 {
+   │                ^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
 
 warning: [lint] Cast operation will abort because the value is outside the target type's range
    ┌─ tests/model_ast_lints/known_to_abort.move:28:9
@@ -54,6 +145,15 @@ warning: [lint] Cast operation will abort because the value is outside the targe
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(known_to_abort)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#known_to_abort.
 
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/known_to_abort.move:31:16
+   │
+31 │     public fun test_cast_u128_overflow(): u128 {
+   │                ^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] Cast operation will abort because the value is outside the target type's range
    ┌─ tests/model_ast_lints/known_to_abort.move:32:9
    │
@@ -62,6 +162,15 @@ warning: [lint] Cast operation will abort because the value is outside the targe
    │
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(known_to_abort)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#known_to_abort.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/known_to_abort.move:35:16
+   │
+35 │     public fun test_const_cast_overflow(): u8 {
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
 
 warning: [lint] Cast operation will abort because the value is outside the target type's range
    ┌─ tests/model_ast_lints/known_to_abort.move:36:9
@@ -72,6 +181,15 @@ warning: [lint] Cast operation will abort because the value is outside the targe
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(known_to_abort)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#known_to_abort.
 
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/known_to_abort.move:39:16
+   │
+39 │     public fun test_const_large_cast(): u32 {
+   │                ^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] Cast operation will abort because the value is outside the target type's range
    ┌─ tests/model_ast_lints/known_to_abort.move:40:9
    │
@@ -80,6 +198,15 @@ warning: [lint] Cast operation will abort because the value is outside the targe
    │
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(known_to_abort)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#known_to_abort.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/known_to_abort.move:43:16
+   │
+43 │     public fun test_expr_cast_overflow(): u8 {
+   │                ^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
 
 warning: [lint] Cast operation will abort because the value is outside the target type's range
    ┌─ tests/model_ast_lints/known_to_abort.move:44:9
@@ -90,6 +217,15 @@ warning: [lint] Cast operation will abort because the value is outside the targe
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(known_to_abort)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#known_to_abort.
 
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/known_to_abort.move:47:16
+   │
+47 │     public fun test_expr_cast_overflow_2(): u16 {
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] Cast operation will abort because the value is outside the target type's range
    ┌─ tests/model_ast_lints/known_to_abort.move:48:9
    │
@@ -98,6 +234,15 @@ warning: [lint] Cast operation will abort because the value is outside the targe
    │
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(known_to_abort)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#known_to_abort.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/known_to_abort.move:51:16
+   │
+51 │     public fun test_expr_cast_overflow_3(): u32 {
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
 
 warning: [lint] Cast operation will abort because the value is outside the target type's range
    ┌─ tests/model_ast_lints/known_to_abort.move:52:9
@@ -108,6 +253,15 @@ warning: [lint] Cast operation will abort because the value is outside the targe
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(known_to_abort)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#known_to_abort.
 
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/known_to_abort.move:55:16
+   │
+55 │     public fun test_mul_expr_cast_overflow(): u8 {
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] Cast operation will abort because the value is outside the target type's range
    ┌─ tests/model_ast_lints/known_to_abort.move:56:9
    │
@@ -125,6 +279,15 @@ warning: [lint] Unnecessary cast: the expression is already of the target type. 
    │
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_cast)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#unnecessary_cast.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/known_to_abort.move:59:16
+   │
+59 │     public fun test_mul_expr_cast_overflow_2(): u16 {
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
 
 warning: [lint] Cast operation will abort because the value is outside the target type's range
    ┌─ tests/model_ast_lints/known_to_abort.move:60:9
@@ -144,6 +307,15 @@ warning: [lint] Unnecessary cast: the expression is already of the target type. 
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_cast)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#unnecessary_cast.
 
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/known_to_abort.move:63:16
+   │
+63 │     public fun test_mixed_expr_cast_overflow(): u8 {
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] Cast operation will abort because the value is outside the target type's range
    ┌─ tests/model_ast_lints/known_to_abort.move:64:9
    │
@@ -161,6 +333,15 @@ warning: [lint] Unnecessary cast: the expression is already of the target type. 
    │
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_cast)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#unnecessary_cast.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/known_to_abort.move:67:16
+   │
+67 │     public fun test_mixed_expr_cast_overflow_2(): u16 {
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
 
 warning: [lint] Cast operation will abort because the value is outside the target type's range
    ┌─ tests/model_ast_lints/known_to_abort.move:68:9
@@ -180,6 +361,15 @@ warning: [lint] Unnecessary cast: the expression is already of the target type. 
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_cast)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#unnecessary_cast.
 
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/known_to_abort.move:71:16
+   │
+71 │     public fun test_nested_mul_expr_cast_overflow(): u8 {
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] Cast operation will abort because the value is outside the target type's range
    ┌─ tests/model_ast_lints/known_to_abort.move:72:9
    │
@@ -197,6 +387,15 @@ warning: [lint] Unnecessary cast: the expression is already of the target type. 
    │
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_cast)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#unnecessary_cast.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/known_to_abort.move:75:16
+   │
+75 │     public fun test_complex_expr_1(flag: bool): u8 {
+   │                ^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
 
 warning: [lint] Cast operation will abort because the value is outside the target type's range
    ┌─ tests/model_ast_lints/known_to_abort.move:77:13
@@ -207,6 +406,15 @@ warning: [lint] Cast operation will abort because the value is outside the targe
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(known_to_abort)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#known_to_abort.
 
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/known_to_abort.move:83:16
+   │
+83 │     public fun test_left_shift_u8_overflow(x: u8): u8 {
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] Shift by an amount greater than or equal to the type's bit width will abort
    ┌─ tests/model_ast_lints/known_to_abort.move:84:9
    │
@@ -215,6 +423,15 @@ warning: [lint] Shift by an amount greater than or equal to the type's bit width
    │
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(known_to_abort)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#known_to_abort.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/known_to_abort.move:87:16
+   │
+87 │     public fun test_left_shift_u16_overflow(x: u16): u16 {
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
 
 warning: [lint] Shift by an amount greater than or equal to the type's bit width will abort
    ┌─ tests/model_ast_lints/known_to_abort.move:88:9
@@ -225,6 +442,15 @@ warning: [lint] Shift by an amount greater than or equal to the type's bit width
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(known_to_abort)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#known_to_abort.
 
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/known_to_abort.move:91:16
+   │
+91 │     public fun test_left_shift_u32_overflow(x: u32): u32 {
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] Shift by an amount greater than or equal to the type's bit width will abort
    ┌─ tests/model_ast_lints/known_to_abort.move:92:9
    │
@@ -233,6 +459,15 @@ warning: [lint] Shift by an amount greater than or equal to the type's bit width
    │
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(known_to_abort)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#known_to_abort.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/known_to_abort.move:95:16
+   │
+95 │     public fun test_left_shift_u64_overflow(x: u64): u64 {
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
 
 warning: [lint] Shift by an amount greater than or equal to the type's bit width will abort
    ┌─ tests/model_ast_lints/known_to_abort.move:96:9
@@ -243,6 +478,15 @@ warning: [lint] Shift by an amount greater than or equal to the type's bit width
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(known_to_abort)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#known_to_abort.
 
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/known_to_abort.move:99:16
+   │
+99 │     public fun test_left_shift_u128_overflow(x: u128): u128 {
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] Shift by an amount greater than or equal to the type's bit width will abort
     ┌─ tests/model_ast_lints/known_to_abort.move:100:9
     │
@@ -251,6 +495,15 @@ warning: [lint] Shift by an amount greater than or equal to the type's bit width
     │
     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(known_to_abort)]`.
     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#known_to_abort.
+
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/known_to_abort.move:103:16
+    │
+103 │     public fun test_shift_const_amount(x: u8): u8 {
+    │                ^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
 
 warning: [lint] Shift by an amount greater than or equal to the type's bit width will abort
     ┌─ tests/model_ast_lints/known_to_abort.move:104:9
@@ -261,6 +514,15 @@ warning: [lint] Shift by an amount greater than or equal to the type's bit width
     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(known_to_abort)]`.
     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#known_to_abort.
 
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/known_to_abort.move:107:16
+    │
+107 │     public fun test_right_shift_u8_overflow(x: u8): u8 {
+    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] Shift by an amount greater than or equal to the type's bit width will abort
     ┌─ tests/model_ast_lints/known_to_abort.move:108:9
     │
@@ -269,6 +531,15 @@ warning: [lint] Shift by an amount greater than or equal to the type's bit width
     │
     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(known_to_abort)]`.
     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#known_to_abort.
+
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/known_to_abort.move:111:16
+    │
+111 │     public fun test_right_shift_u16_overflow(x: u16): u16 {
+    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
 
 warning: [lint] Shift by an amount greater than or equal to the type's bit width will abort
     ┌─ tests/model_ast_lints/known_to_abort.move:112:9
@@ -279,6 +550,15 @@ warning: [lint] Shift by an amount greater than or equal to the type's bit width
     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(known_to_abort)]`.
     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#known_to_abort.
 
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/known_to_abort.move:115:16
+    │
+115 │     public fun test_right_shift_u32_overflow(x: u32): u32 {
+    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] Shift by an amount greater than or equal to the type's bit width will abort
     ┌─ tests/model_ast_lints/known_to_abort.move:116:9
     │
@@ -287,6 +567,15 @@ warning: [lint] Shift by an amount greater than or equal to the type's bit width
     │
     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(known_to_abort)]`.
     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#known_to_abort.
+
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/known_to_abort.move:119:16
+    │
+119 │     public fun test_right_shift_u64_overflow(x: u64): u64 {
+    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
 
 warning: [lint] Shift by an amount greater than or equal to the type's bit width will abort
     ┌─ tests/model_ast_lints/known_to_abort.move:120:9
@@ -297,6 +586,15 @@ warning: [lint] Shift by an amount greater than or equal to the type's bit width
     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(known_to_abort)]`.
     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#known_to_abort.
 
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/known_to_abort.move:123:16
+    │
+123 │     public fun test_right_shift_u128_overflow(x: u128): u128 {
+    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] Shift by an amount greater than or equal to the type's bit width will abort
     ┌─ tests/model_ast_lints/known_to_abort.move:124:9
     │
@@ -305,6 +603,51 @@ warning: [lint] Shift by an amount greater than or equal to the type's bit width
     │
     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(known_to_abort)]`.
     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#known_to_abort.
+
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/known_to_abort.move:130:16
+    │
+130 │     public fun test_divide_by_zero_skip(x: u64): u64 {
+    │                ^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/known_to_abort.move:135:16
+    │
+135 │     public fun test_modulo_by_zero_skip(x: u64): u64 {
+    │                ^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/known_to_abort.move:140:16
+    │
+140 │     public fun test_cast_u8_overflow_skip(): u8 {
+    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/known_to_abort.move:145:16
+    │
+145 │     public fun test_cast_u16_overflow_skip(): u16 {
+    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/known_to_abort.move:151:16
+    │
+151 │     public fun test_complex_expr(x: u8): u8 {
+    │                ^^^^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
 
 warning: [lint] Unnecessary cast: the expression is already of the target type. Consider removing the cast for better readability.
     ┌─ tests/model_ast_lints/known_to_abort.move:152:9
@@ -315,6 +658,51 @@ warning: [lint] Unnecessary cast: the expression is already of the target type. 
     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_cast)]`.
     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#unnecessary_cast.
 
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/known_to_abort.move:155:16
+    │
+155 │     public fun test_max_u8_cast(): u8 {
+    │                ^^^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/known_to_abort.move:159:16
+    │
+159 │     public fun test_max_u16_cast(): u16 {
+    │                ^^^^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/known_to_abort.move:163:16
+    │
+163 │     public fun test_max_u32_cast(): u32 {
+    │                ^^^^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/known_to_abort.move:167:16
+    │
+167 │     public fun test_max_u64_cast(): u64 {
+    │                ^^^^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/known_to_abort.move:171:16
+    │
+171 │     public fun test_valid_mixed_expr(): u8 {
+    │                ^^^^^^^^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] Unnecessary cast: the expression is already of the target type. Consider removing the cast for better readability.
     ┌─ tests/model_ast_lints/known_to_abort.move:172:9
     │
@@ -323,6 +711,15 @@ warning: [lint] Unnecessary cast: the expression is already of the target type. 
     │
     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_cast)]`.
     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#unnecessary_cast.
+
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/known_to_abort.move:175:16
+    │
+175 │     public fun test_valid_nested_mul(): u8 {
+    │                ^^^^^^^^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
 
 warning: [lint] Unnecessary cast: the expression is already of the target type. Consider removing the cast for better readability.
     ┌─ tests/model_ast_lints/known_to_abort.move:176:9
@@ -333,6 +730,15 @@ warning: [lint] Unnecessary cast: the expression is already of the target type. 
     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_cast)]`.
     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#unnecessary_cast.
 
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/known_to_abort.move:179:16
+    │
+179 │     public fun test_valid_large_expr(): u16 {
+    │                ^^^^^^^^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] Unnecessary cast: the expression is already of the target type. Consider removing the cast for better readability.
     ┌─ tests/model_ast_lints/known_to_abort.move:180:9
     │
@@ -341,6 +747,15 @@ warning: [lint] Unnecessary cast: the expression is already of the target type. 
     │
     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_cast)]`.
     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#unnecessary_cast.
+
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/known_to_abort.move:183:16
+    │
+183 │     public fun test_conditional_cast(x: u8, y: u8): u8 {
+    │                ^^^^^^^^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
 
 warning: [lint] Unnecessary cast: the expression is already of the target type. Consider removing the cast for better readability.
     ┌─ tests/model_ast_lints/known_to_abort.move:185:13
@@ -359,6 +774,15 @@ warning: [lint] Unnecessary cast: the expression is already of the target type. 
     │
     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_cast)]`.
     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#unnecessary_cast.
+
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/known_to_abort.move:191:16
+    │
+191 │     public fun test_nested_conditional_cast(x: u8, y: u8, z: u8): u8 {
+    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
 
 warning: [lint] Unnecessary cast: the expression is already of the target type. Consider removing the cast for better readability.
     ┌─ tests/model_ast_lints/known_to_abort.move:194:17
@@ -386,3 +810,72 @@ warning: [lint] Unnecessary cast: the expression is already of the target type. 
     │
     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_cast)]`.
     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#unnecessary_cast.
+
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/known_to_abort.move:203:16
+    │
+203 │     public fun test_valid_shift_u8(x: u8): u8 {
+    │                ^^^^^^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/known_to_abort.move:207:16
+    │
+207 │     public fun test_valid_shift_u16(x: u16): u16 {
+    │                ^^^^^^^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/known_to_abort.move:211:16
+    │
+211 │     public fun test_valid_shift_u32(x: u32): u32 {
+    │                ^^^^^^^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/known_to_abort.move:215:16
+    │
+215 │     public fun test_valid_shift_u64(x: u64): u64 {
+    │                ^^^^^^^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/known_to_abort.move:219:16
+    │
+219 │     public fun test_valid_shift_u128(x: u128): u128 {
+    │                ^^^^^^^^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/known_to_abort.move:223:16
+    │
+223 │     public fun test_valid_shift_u256(x: u256): u256 {
+    │                ^^^^^^^^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Module is missing a doc comment.
+    ┌─ tests/model_ast_lints/known_to_abort.move:1:1
+    │
+  1 │ ╭ module 0xc0ffee::m {
+  2 │ │     // Constants for testing
+  3 │ │     const OVERFLOW_VALUE: u16 = 256;
+  4 │ │     const LARGE_U32: u64 = 4_294_967_296;
+    · │
+225 │ │     }
+226 │ │ }
+    │ ╰─^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_module)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_module.

--- a/third_party/move/tools/move-linter/tests/model_ast_lints/multi_attributes_01.exp
+++ b/third_party/move/tools/move-linter/tests/model_ast_lints/multi_attributes_01.exp
@@ -1,5 +1,14 @@
 
 Diagnostics:
+warning: [lint] Public function is missing a doc comment.
+  ┌─ tests/model_ast_lints/multi_attributes_01.move:3:16
+  │
+3 │     public fun test1(x: u64) {
+  │                ^^^^^
+  │
+  = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+  = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] Empty `if` branch. Consider simplifying by removing or rewriting.
   ┌─ tests/model_ast_lints/multi_attributes_01.move:4:9
   │
@@ -10,6 +19,15 @@ warning: [lint] Empty `if` branch. Consider simplifying by removing or rewriting
   │
   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(empty_if)]`.
   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#empty_if.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/multi_attributes_01.move:12:16
+   │
+12 │     public fun test2(x: u64) {
+   │                ^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
 
 warning: [lint] Having blocks in conditions make code harder to read. Consider rewriting this code.
    ┌─ tests/model_ast_lints/multi_attributes_01.move:13:13
@@ -41,3 +59,18 @@ warning: [lint] Use the more explicit `loop` instead.
    │
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(while_true)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#while_true.
+
+warning: [lint] Module is missing a doc comment.
+   ┌─ tests/model_ast_lints/multi_attributes_01.move:1:1
+   │
+ 1 │ ╭ module 0xc0ffee::m {
+ 2 │ │     #[lint::skip(while_true, blocks_in_conditions)]
+ 3 │ │     public fun test1(x: u64) {
+ 4 │ │         if ({let y = x + 1; y < 5}) {
+   · │
+19 │ │     }
+20 │ │ }
+   │ ╰─^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_module)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_module.

--- a/third_party/move/tools/move-linter/tests/model_ast_lints/multi_attributes_02.exp
+++ b/third_party/move/tools/move-linter/tests/model_ast_lints/multi_attributes_02.exp
@@ -1,5 +1,14 @@
 
 Diagnostics:
+warning: [lint] Public function is missing a doc comment.
+  ┌─ tests/model_ast_lints/multi_attributes_02.move:4:16
+  │
+4 │     public fun test1(x: u64) {
+  │                ^^^^^
+  │
+  = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+  = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] Empty `if` branch. Consider simplifying by removing or rewriting.
   ┌─ tests/model_ast_lints/multi_attributes_02.move:5:9
   │
@@ -11,6 +20,15 @@ warning: [lint] Empty `if` branch. Consider simplifying by removing or rewriting
   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(empty_if)]`.
   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#empty_if.
 
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/multi_attributes_02.move:14:16
+   │
+14 │     public fun test2(x: u64) {
+   │                ^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] Empty `if` branch. Consider simplifying by removing or rewriting.
    ┌─ tests/model_ast_lints/multi_attributes_02.move:15:9
    │
@@ -21,3 +39,18 @@ warning: [lint] Empty `if` branch. Consider simplifying by removing or rewriting
    │
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(empty_if)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#empty_if.
+
+warning: [lint] Module is missing a doc comment.
+   ┌─ tests/model_ast_lints/multi_attributes_02.move:2:1
+   │
+ 2 │ ╭ module 0xc0ffee::m {
+ 3 │ │     #[lint::skip(blocks_in_conditions)]
+ 4 │ │     public fun test1(x: u64) {
+ 5 │ │         if ({let y = x + 1; y < 5}) {
+   · │
+21 │ │     }
+22 │ │ }
+   │ ╰─^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_module)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_module.

--- a/third_party/move/tools/move-linter/tests/model_ast_lints/needless_bool_warn.exp
+++ b/third_party/move/tools/move-linter/tests/model_ast_lints/needless_bool_warn.exp
@@ -1,5 +1,14 @@
 
 Diagnostics:
+warning: [lint] Public function is missing a doc comment.
+  ┌─ tests/model_ast_lints/needless_bool_warn.move:6:16
+  │
+6 │     public fun test1_warn(): bool {
+  │                ^^^^^^^^^^
+  │
+  = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+  = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] This if-else can be replaced with just the condition
   ┌─ tests/model_ast_lints/needless_bool_warn.move:7:9
   │
@@ -8,6 +17,15 @@ warning: [lint] This if-else can be replaced with just the condition
   │
   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(needless_bool)]`.
   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#needless_bool.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/needless_bool_warn.move:10:16
+   │
+10 │     public fun test2_warn(): bool {
+   │                ^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
 
 warning: [lint] This if-else can be replaced with just the negation of the condition
    ┌─ tests/model_ast_lints/needless_bool_warn.move:11:9
@@ -21,6 +39,15 @@ warning: [lint] This if-else can be replaced with just the negation of the condi
    │
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(needless_bool)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#needless_bool.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/needless_bool_warn.move:18:16
+   │
+18 │     public fun test3_warn(): bool {
+   │                ^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
 
 warning: [lint] The `return` keyword is unnecessary here and can be removed.
    ┌─ tests/model_ast_lints/needless_bool_warn.move:20:13
@@ -53,6 +80,15 @@ warning: [lint] This if-else can be replaced with just returning the condition
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(needless_bool)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#needless_bool.
 
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/needless_bool_warn.move:26:16
+   │
+26 │     public fun test4_warn(x: bool): bool {
+   │                ^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] This if-else can be replaced with just returning the negation of the condition
    ┌─ tests/model_ast_lints/needless_bool_warn.move:28:13
    │
@@ -65,6 +101,15 @@ warning: [lint] This if-else can be replaced with just returning the negation of
    │
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(needless_bool)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#needless_bool.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/needless_bool_warn.move:37:16
+   │
+37 │     public fun test5_warn(x: bool): bool {
+   │                ^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
 
 warning: [lint] The `return` keyword is unnecessary here and can be removed.
    ┌─ tests/model_ast_lints/needless_bool_warn.move:38:18
@@ -93,6 +138,15 @@ warning: [lint] This if-else has the same bool expression in both branches, cons
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(needless_bool)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#needless_bool.
 
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/needless_bool_warn.move:41:16
+   │
+41 │     public fun test6_no_warn(): bool {
+   │                ^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] The `return` keyword is unnecessary here and can be removed.
    ┌─ tests/model_ast_lints/needless_bool_warn.move:43:13
    │
@@ -101,3 +155,36 @@ warning: [lint] The `return` keyword is unnecessary here and can be removed.
    │
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(needless_return)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#needless_return.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/needless_bool_warn.move:47:16
+   │
+47 │     public fun test7_no_warn(): bool {
+   │                ^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/needless_bool_warn.move:55:16
+   │
+55 │     public fun test1_no_warn(): bool {
+   │                ^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Module is missing a doc comment.
+   ┌─ tests/model_ast_lints/needless_bool_warn.move:1:1
+   │
+ 1 │ ╭ module 0xc0ffee::m {
+ 2 │ │     fun foo(): bool {
+ 3 │ │         true
+ 4 │ │     }
+   · │
+57 │ │     }
+58 │ │ }
+   │ ╰─^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_module)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_module.

--- a/third_party/move/tools/move-linter/tests/model_ast_lints/needless_deref_ref_warn.exp
+++ b/third_party/move/tools/move-linter/tests/model_ast_lints/needless_deref_ref_warn.exp
@@ -1,5 +1,40 @@
 
 Diagnostics:
+warning: [lint] Struct is missing a doc comment.
+  ┌─ tests/model_ast_lints/needless_deref_ref_warn.move:2:5
+  │
+2 │ ╭     struct S has key, drop {
+3 │ │         x: u64,
+4 │ │         y: U
+5 │ │     }
+  │ ╰─────^
+  │
+  = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_struct)]`.
+  = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_struct.
+
+warning: [lint] Struct is missing a doc comment.
+  ┌─ tests/model_ast_lints/needless_deref_ref_warn.move:7:5
+  │
+7 │ ╭     struct U has copy, store, drop {
+8 │ │         a: u64
+9 │ │     }
+  │ ╰─────^
+  │
+  = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_struct)]`.
+  = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_struct.
+
+warning: [lint] Enum is missing a doc comment.
+   ┌─ tests/model_ast_lints/needless_deref_ref_warn.move:11:5
+   │
+11 │ ╭     enum E has drop {
+12 │ │         A { x: u64 },
+13 │ │         B { x: u64 },
+14 │ │     }
+   │ ╰─────^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_struct)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_struct.
+
 warning: [lint] Needless pair of `*` and `&mut` operators: consider removing them
    ┌─ tests/model_ast_lints/needless_deref_ref_warn.move:18:9
    │
@@ -135,6 +170,44 @@ warning: [lint] Needless pair of `*` and `&mut` operators: consider removing the
     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(needless_deref_ref)]`.
     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#needless_deref_ref.
 
+warning: [lint] Module is missing a doc comment.
+    ┌─ tests/model_ast_lints/needless_deref_ref_warn.move:1:1
+    │
+  1 │ ╭ module 0xc0ffee::m {
+  2 │ │     struct S has key, drop {
+  3 │ │         x: u64,
+  4 │ │         y: U
+    · │
+154 │ │     }
+155 │ │ }
+    │ ╰─^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_module)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_module.
+
+warning: [lint] Struct is missing a doc comment.
+    ┌─ tests/model_ast_lints/needless_deref_ref_warn.move:158:5
+    │
+158 │ ╭     struct Foo has copy, drop {
+159 │ │         x: u64,
+160 │ │         y: bool
+161 │ │     }
+    │ ╰─────^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_struct)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_struct.
+
+warning: [lint] Struct is missing a doc comment.
+    ┌─ tests/model_ast_lints/needless_deref_ref_warn.move:163:5
+    │
+163 │ ╭     struct Bar has copy, drop {
+164 │ │         foo: Foo
+165 │ │     }
+    │ ╰─────^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_struct)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_struct.
+
 warning: [lint] Needless pair of `*` and `&` operators: consider removing them
     ┌─ tests/model_ast_lints/needless_deref_ref_warn.move:170:26
     │
@@ -143,6 +216,21 @@ warning: [lint] Needless pair of `*` and `&` operators: consider removing them
     │
     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(needless_deref_ref)]`.
     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#needless_deref_ref.
+
+warning: [lint] Module is missing a doc comment.
+    ┌─ tests/model_ast_lints/needless_deref_ref_warn.move:157:1
+    │
+157 │ ╭ module 0xc0ffee::n {
+158 │ │     struct Foo has copy, drop {
+159 │ │         x: u64,
+160 │ │         y: bool
+    · │
+187 │ │     }
+188 │ │ }
+    │ ╰─^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_module)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_module.
 
 warning: [lint] Needless mutable reference or borrow: consider using immutable reference or borrow instead
    ┌─ tests/model_ast_lints/needless_deref_ref_warn.move:35:15

--- a/third_party/move/tools/move-linter/tests/model_ast_lints/needless_ref_deref_warn.exp
+++ b/third_party/move/tools/move-linter/tests/model_ast_lints/needless_ref_deref_warn.exp
@@ -17,3 +17,18 @@ warning: [lint] Needless pair of `&` and `*` operators: consider removing them
    │
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(needless_ref_deref)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#needless_ref_deref.
+
+warning: [lint] Module is missing a doc comment.
+   ┌─ tests/model_ast_lints/needless_ref_deref_warn.move:1:1
+   │
+ 1 │ ╭ module 0xc0ffee::m {
+ 2 │ │     use std::string::{Self, String};
+ 3 │ │     use std::vector;
+ 4 │ │
+   · │
+41 │ │     }
+42 │ │ }
+   │ ╰─^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_module)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_module.

--- a/third_party/move/tools/move-linter/tests/model_ast_lints/needless_ref_in_field_access_warn.exp
+++ b/third_party/move/tools/move-linter/tests/model_ast_lints/needless_ref_in_field_access_warn.exp
@@ -1,5 +1,46 @@
 
 Diagnostics:
+warning: [lint] Struct is missing a doc comment.
+  ┌─ tests/model_ast_lints/needless_ref_in_field_access_warn.move:2:5
+  │
+2 │ ╭     struct S has key, drop {
+3 │ │         x: u64,
+4 │ │         y: U,
+5 │ │     }
+  │ ╰─────^
+  │
+  = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_struct)]`.
+  = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_struct.
+
+warning: [lint] Struct is missing a doc comment.
+  ┌─ tests/model_ast_lints/needless_ref_in_field_access_warn.move:7:5
+  │
+7 │ ╭     struct U has copy, store, drop {
+8 │ │         a: u64
+9 │ │     }
+  │ ╰─────^
+  │
+  = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_struct)]`.
+  = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_struct.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/needless_ref_in_field_access_warn.move:11:16
+   │
+11 │     public fun make_S(): S {
+   │                ^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/needless_ref_in_field_access_warn.move:18:16
+   │
+18 │     public fun test1_warn(s: S): u64 {
+   │                ^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] Needless `&` taken for field access: consider removing `&` and directly accessing the field `x`
    ┌─ tests/model_ast_lints/needless_ref_in_field_access_warn.move:19:9
    │
@@ -8,6 +49,24 @@ warning: [lint] Needless `&` taken for field access: consider removing `&` and d
    │
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(needless_ref_in_field_access)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#needless_ref_in_field_access.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/needless_ref_in_field_access_warn.move:22:16
+   │
+22 │     public fun test1_no_warn(s: S): u64 {
+   │                ^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/needless_ref_in_field_access_warn.move:26:16
+   │
+26 │     public fun test2_warn(s: S): u64 {
+   │                ^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
 
 warning: [lint] Needless `&` taken for field access: consider removing `&` and directly accessing the field `y`
    ┌─ tests/model_ast_lints/needless_ref_in_field_access_warn.move:27:11
@@ -44,6 +103,24 @@ warning: [lint] Needless `&` taken for field access: consider removing `&` and d
    │
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(needless_ref_in_field_access)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#needless_ref_in_field_access.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/needless_ref_in_field_access_warn.move:30:16
+   │
+30 │     public fun test2_no_warn(s: S): u64 {
+   │                ^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/needless_ref_in_field_access_warn.move:34:16
+   │
+34 │     public fun test3_warn(s: S): u64 {
+   │                ^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
 
 warning: [lint] Needless `&` taken for field access: consider removing `&` and directly accessing the field `y`
    ┌─ tests/model_ast_lints/needless_ref_in_field_access_warn.move:35:9
@@ -90,6 +167,24 @@ warning: [lint] Needless `&` taken for field access: consider removing `&` and d
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(needless_ref_in_field_access)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#needless_ref_in_field_access.
 
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/needless_ref_in_field_access_warn.move:38:16
+   │
+38 │     public fun test3_no_warn(s: S): u64 {
+   │                ^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/needless_ref_in_field_access_warn.move:42:16
+   │
+42 │     public fun test4_warn(): u64 {
+   │                ^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] Needless `&` taken for field access: consider removing `&` and directly accessing the field `y`
    ┌─ tests/model_ast_lints/needless_ref_in_field_access_warn.move:43:9
    │
@@ -98,6 +193,24 @@ warning: [lint] Needless `&` taken for field access: consider removing `&` and d
    │
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(needless_ref_in_field_access)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#needless_ref_in_field_access.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/needless_ref_in_field_access_warn.move:46:16
+   │
+46 │     public fun test4_no_warn(): u64 {
+   │                ^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/needless_ref_in_field_access_warn.move:50:16
+   │
+50 │     public fun test5_warn(s: S): u64 {
+   │                ^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
 
 warning: [lint] Needless `&mut` taken for field access: consider removing `&mut` and directly accessing the field `y`
    ┌─ tests/model_ast_lints/needless_ref_in_field_access_warn.move:51:9
@@ -126,6 +239,24 @@ warning: [lint] Needless `&mut` taken for field access: consider removing `&mut`
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(needless_ref_in_field_access)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#needless_ref_in_field_access.
 
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/needless_ref_in_field_access_warn.move:54:16
+   │
+54 │     public fun test5_no_warn(s: S): u64 {
+   │                ^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/needless_ref_in_field_access_warn.move:58:16
+   │
+58 │     public fun test6_warn(s: S) {
+   │                ^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] Needless `&mut` taken for field access: consider removing `&mut` and directly accessing the field `x`
    ┌─ tests/model_ast_lints/needless_ref_in_field_access_warn.move:59:9
    │
@@ -134,6 +265,24 @@ warning: [lint] Needless `&mut` taken for field access: consider removing `&mut`
    │
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(needless_ref_in_field_access)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#needless_ref_in_field_access.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/needless_ref_in_field_access_warn.move:62:16
+   │
+62 │     public fun test6_no_warn(s: S) {
+   │                ^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/needless_ref_in_field_access_warn.move:66:16
+   │
+66 │     public fun test7_warn(s: S) {
+   │                ^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
 
 warning: [lint] Needless `&mut` taken for field access: consider removing `&mut` and directly accessing the field `y`
    ┌─ tests/model_ast_lints/needless_ref_in_field_access_warn.move:67:15
@@ -162,6 +311,24 @@ warning: [lint] Needless `&mut` taken for field access: consider removing `&mut`
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(needless_ref_in_field_access)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#needless_ref_in_field_access.
 
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/needless_ref_in_field_access_warn.move:71:16
+   │
+71 │     public fun test7_no_warn(s: S) {
+   │                ^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/needless_ref_in_field_access_warn.move:76:16
+   │
+76 │     public fun test8_warn() {
+   │                ^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] Needless `&mut` taken for field access: consider removing `&mut` and directly accessing the field `a`
    ┌─ tests/model_ast_lints/needless_ref_in_field_access_warn.move:77:9
    │
@@ -170,6 +337,36 @@ warning: [lint] Needless `&mut` taken for field access: consider removing `&mut`
    │
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(needless_ref_in_field_access)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#needless_ref_in_field_access.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/needless_ref_in_field_access_warn.move:80:16
+   │
+80 │     public fun test8_no_warn() {
+   │                ^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Enum is missing a doc comment.
+   ┌─ tests/model_ast_lints/needless_ref_in_field_access_warn.move:84:5
+   │
+84 │ ╭     enum E has drop {
+85 │ │         A(u64),
+86 │ │         B(u64),
+87 │ │     }
+   │ ╰─────^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_struct)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_struct.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/needless_ref_in_field_access_warn.move:89:16
+   │
+89 │     public fun test_9_warn(e: E): u64 {
+   │                ^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
 
 warning: [lint] Needless `&` taken for field access: consider removing `&` and directly accessing the field `0`
    ┌─ tests/model_ast_lints/needless_ref_in_field_access_warn.move:90:9
@@ -189,6 +386,24 @@ warning: [lint] Needless `&mut` taken for field access: consider removing `&mut`
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(needless_ref_in_field_access)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#needless_ref_in_field_access.
 
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/needless_ref_in_field_access_warn.move:93:16
+   │
+93 │     public fun test_9_no_warn(e: E): u64 {
+   │                ^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/needless_ref_in_field_access_warn.move:97:16
+   │
+97 │     public fun test_10_warn(e: E) {
+   │                ^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] Needless `&mut` taken for field access: consider removing `&mut` and directly accessing the field `0`
    ┌─ tests/model_ast_lints/needless_ref_in_field_access_warn.move:98:9
    │
@@ -197,6 +412,100 @@ warning: [lint] Needless `&mut` taken for field access: consider removing `&mut`
    │
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(needless_ref_in_field_access)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#needless_ref_in_field_access.
+
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/needless_ref_in_field_access_warn.move:101:16
+    │
+101 │     public fun test_10_no_warn(e: E) {
+    │                ^^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Module is missing a doc comment.
+    ┌─ tests/model_ast_lints/needless_ref_in_field_access_warn.move:1:1
+    │
+  1 │ ╭ module 0xc0ffee::m {
+  2 │ │     struct S has key, drop {
+  3 │ │         x: u64,
+  4 │ │         y: U,
+    · │
+103 │ │     }
+104 │ │ }
+    │ ╰─^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_module)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_module.
+
+warning: [lint] Struct is missing a doc comment.
+    ┌─ tests/model_ast_lints/needless_ref_in_field_access_warn.move:108:5
+    │
+108 │ ╭     struct S has key, drop {
+109 │ │         x: u64,
+110 │ │     }
+    │ ╰─────^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_struct)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_struct.
+
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/needless_ref_in_field_access_warn.move:113:16
+    │
+113 │     public fun test1_warn(s: S): u64 {
+    │                ^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Module is missing a doc comment.
+    ┌─ tests/model_ast_lints/needless_ref_in_field_access_warn.move:107:1
+    │
+107 │ ╭ module 0xc0ffee::no_warn_1 {
+108 │ │     struct S has key, drop {
+109 │ │         x: u64,
+110 │ │     }
+    · │
+115 │ │     }
+116 │ │ }
+    │ ╰─^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_module)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_module.
+
+warning: [lint] Struct is missing a doc comment.
+    ┌─ tests/model_ast_lints/needless_ref_in_field_access_warn.move:120:5
+    │
+120 │ ╭     struct S has key, drop {
+121 │ │         x: u64,
+122 │ │     }
+    │ ╰─────^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_struct)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_struct.
+
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/needless_ref_in_field_access_warn.move:124:16
+    │
+124 │     public fun test1_warn(s: S): u64 {
+    │                ^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Module is missing a doc comment.
+    ┌─ tests/model_ast_lints/needless_ref_in_field_access_warn.move:119:1
+    │
+119 │ ╭ module 0xc0ffee::no_warn_2 {
+120 │ │     struct S has key, drop {
+121 │ │         x: u64,
+122 │ │     }
+    · │
+126 │ │     }
+127 │ │ }
+    │ ╰─^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_module)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_module.
 
 warning: [lint] Needless mutable reference or borrow: consider using immutable reference or borrow instead
    ┌─ tests/model_ast_lints/needless_ref_in_field_access_warn.move:51:9

--- a/third_party/move/tools/move-linter/tests/model_ast_lints/needless_return.exp
+++ b/third_party/move/tools/move-linter/tests/model_ast_lints/needless_return.exp
@@ -1,5 +1,24 @@
 
 Diagnostics:
+warning: [lint] Use doc comment `///` instead of regular comment `//` for documentable items.
+  ┌─ tests/model_ast_lints/needless_return.move:5:1
+  │
+5 │ ╭     // Tests with only return statements in the body of the function
+6 │ │     public fun with_return_void(_x : bool) {
+  │ ╰^
+  │
+  = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(prefer_doc_comment)]`.
+  = For more information, see https://aptos.dev/en/build/smart-contracts/linter#prefer_doc_comment.
+
+warning: [lint] Public function is missing a doc comment.
+  ┌─ tests/model_ast_lints/needless_return.move:6:16
+  │
+6 │     public fun with_return_void(_x : bool) {
+  │                ^^^^^^^^^^^^^^^^
+  │
+  = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+  = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] The `return` keyword is unnecessary here and can be removed.
   ┌─ tests/model_ast_lints/needless_return.move:7:9
   │
@@ -8,6 +27,15 @@ warning: [lint] The `return` keyword is unnecessary here and can be removed.
   │
   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(needless_return)]`.
   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#needless_return.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/needless_return.move:10:16
+   │
+10 │     public fun with_return_void_sc(_x : bool) {
+   │                ^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
 
 warning: [lint] The `return` keyword is unnecessary here and can be removed.
    ┌─ tests/model_ast_lints/needless_return.move:11:9
@@ -18,6 +46,15 @@ warning: [lint] The `return` keyword is unnecessary here and can be removed.
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(needless_return)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#needless_return.
 
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/needless_return.move:14:16
+   │
+14 │     public fun with_return_non_void(x : bool): Option<bool> {
+   │                ^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] The `return` keyword is unnecessary here and can be removed.
    ┌─ tests/model_ast_lints/needless_return.move:15:9
    │
@@ -26,6 +63,25 @@ warning: [lint] The `return` keyword is unnecessary here and can be removed.
    │
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(needless_return)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#needless_return.
+
+warning: [lint] Use doc comment `///` instead of regular comment `//` for documentable items.
+   ┌─ tests/model_ast_lints/needless_return.move:17:1
+   │
+17 │ ╭     // Tests with only return statements in the body of the function
+18 │ │     // Should warn only in the last return statement
+   │ ╰^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(prefer_doc_comment)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#prefer_doc_comment.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/needless_return.move:19:16
+   │
+19 │     public fun with_return_void_bigger_body(x : bool){
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
 
 warning: [lint] The `return` keyword is unnecessary here and can be removed.
    ┌─ tests/model_ast_lints/needless_return.move:24:9
@@ -36,6 +92,15 @@ warning: [lint] The `return` keyword is unnecessary here and can be removed.
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(needless_return)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#needless_return.
 
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/needless_return.move:27:16
+   │
+27 │     public fun with_return_non_void_bigger_body(x : bool): Option<bool> {
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] The `return` keyword is unnecessary here and can be removed.
    ┌─ tests/model_ast_lints/needless_return.move:32:9
    │
@@ -44,6 +109,43 @@ warning: [lint] The `return` keyword is unnecessary here and can be removed.
    │
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(needless_return)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#needless_return.
+
+warning: [lint] Use doc comment `///` instead of regular comment `//` for documentable items.
+   ┌─ tests/model_ast_lints/needless_return.move:36:1
+   │
+36 │ ╭     // Without return statements - should not warn
+37 │ │     public fun no_return_void(_x : bool) {
+   │ ╰^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(prefer_doc_comment)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#prefer_doc_comment.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/needless_return.move:37:16
+   │
+37 │     public fun no_return_void(_x : bool) {
+   │                ^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/needless_return.move:41:16
+   │
+41 │     public fun no_return_non_void(x : bool): Option<bool> {
+   │                ^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/needless_return.move:49:16
+   │
+49 │     public fun return_tuple_multiple_params(x: bool): (u8, u8) {
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
 
 warning: [lint] The `return` keyword is unnecessary here and can be removed.
    ┌─ tests/model_ast_lints/needless_return.move:58:13
@@ -90,6 +192,15 @@ warning: [lint] The `return` keyword is unnecessary here and can be removed.
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(needless_return)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#needless_return.
 
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/needless_return.move:89:16
+   │
+89 │     public fun with_return_void_and_tuple(_x : bool) {
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] The `return` keyword is unnecessary here and can be removed.
    ┌─ tests/model_ast_lints/needless_return.move:90:9
    │
@@ -98,3 +209,18 @@ warning: [lint] The `return` keyword is unnecessary here and can be removed.
    │
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(needless_return)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#needless_return.
+
+warning: [lint] Module is missing a doc comment.
+   ┌─ tests/model_ast_lints/needless_return.move:1:1
+   │
+ 1 │ ╭ module 0xc0ffee::m {
+ 2 │ │
+ 3 │ │     use std::option::{Option, none, some};
+ 4 │ │
+   · │
+97 │ │     }
+98 │ │ }
+   │ ╰─^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_module)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_module.

--- a/third_party/move/tools/move-linter/tests/model_ast_lints/nonminimal_bool.exp
+++ b/third_party/move/tools/move-linter/tests/model_ast_lints/nonminimal_bool.exp
@@ -1,5 +1,14 @@
 
 Diagnostics:
+warning: [lint] Public function is missing a doc comment.
+  ┌─ tests/model_ast_lints/nonminimal_bool.move:3:16
+  │
+3 │     public fun test_warn_and(x : bool) {
+  │                ^^^^^^^^^^^^^
+  │
+  = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+  = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] The left-hand side of `&&` evaluates to `true`. Recall that the expression `true && bexpr` is logically equivalent to `bexpr`. Consider simplifying.
   ┌─ tests/model_ast_lints/nonminimal_bool.move:4:13
   │
@@ -71,6 +80,15 @@ warning: [lint] Empty `if` branch. Consider simplifying by removing or rewriting
   │
   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(empty_if)]`.
   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#empty_if.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/nonminimal_bool.move:10:16
+   │
+10 │     public fun test_warn_or(x : bool) {
+   │                ^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
 
 warning: [lint] The left-hand side of `||` evaluates to `true`. Recall that the expression `true || bexpr` is logically equivalent to `true`. Consider simplifying.
    ┌─ tests/model_ast_lints/nonminimal_bool.move:11:13
@@ -144,6 +162,15 @@ warning: [lint] Empty `if` branch. Consider simplifying by removing or rewriting
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(empty_if)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#empty_if.
 
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/nonminimal_bool.move:17:16
+   │
+17 │     public fun test_warn_iff(x : bool) {
+   │                ^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] The right-hand side of `<==>` evaluates to `true`. Recall that the expression `bexpr <==> true` is logically equivalent to `bexpr`. Consider simplifying.
    ┌─ tests/model_ast_lints/nonminimal_bool.move:19:20
    │
@@ -179,6 +206,15 @@ warning: [lint] The left-hand side of `<==>` evaluates to `false`. Recall that t
    │
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(nonminimal_bool)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#nonminimal_bool.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/nonminimal_bool.move:26:16
+   │
+26 │     public fun test_warn_implies(x : bool) {
+   │                ^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
 
 warning: [lint] The right-hand side of `==>` evaluates to `true`. Recall that the expression `bexpr ==> true` is logically equivalent to `true`. Consider simplifying.
    ┌─ tests/model_ast_lints/nonminimal_bool.move:28:20
@@ -216,6 +252,15 @@ warning: [lint] The left-hand side of `==>` evaluates to `false`. Recall that th
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(nonminimal_bool)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#nonminimal_bool.
 
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/nonminimal_bool.move:35:16
+   │
+35 │     public fun test_warn_not() {
+   │                ^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] This expression evaluates to `false`. Recall that the expression `!true` is logically equivalent to `false`. Consider simplifying.
    ┌─ tests/model_ast_lints/nonminimal_bool.move:36:13
    │
@@ -252,6 +297,15 @@ warning: [lint] Empty `if` branch. Consider simplifying by removing or rewriting
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(empty_if)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#empty_if.
 
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/nonminimal_bool.move:41:16
+   │
+41 │     public fun combo() {
+   │                ^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] This expression evaluates to `false`. Recall that the expression `!true` is logically equivalent to `false`. Consider simplifying.
    ┌─ tests/model_ast_lints/nonminimal_bool.move:42:13
    │
@@ -287,3 +341,18 @@ warning: [lint] Empty `if` branch. Consider simplifying by removing or rewriting
    │
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(empty_if)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#empty_if.
+
+warning: [lint] Module is missing a doc comment.
+   ┌─ tests/model_ast_lints/nonminimal_bool.move:1:1
+   │
+ 1 │ ╭ module 0xc0ffee::m {
+ 2 │ │
+ 3 │ │     public fun test_warn_and(x : bool) {
+ 4 │ │         if (true && x) ();
+   · │
+48 │ │     }
+49 │ │ }
+   │ ╰─^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_module)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_module.

--- a/third_party/move/tools/move-linter/tests/model_ast_lints/self_assignment.exp
+++ b/third_party/move/tools/move-linter/tests/model_ast_lints/self_assignment.exp
@@ -1,5 +1,41 @@
 
 Diagnostics:
+warning: [lint] Struct is missing a doc comment.
+  ┌─ tests/model_ast_lints/self_assignment.move:4:3
+  │
+4 │   struct X has drop, copy { f: u64 }
+  │   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  │
+  = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_struct)]`.
+  = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_struct.
+
+warning: [lint] Struct is missing a doc comment.
+  ┌─ tests/model_ast_lints/self_assignment.move:5:3
+  │
+5 │   struct Y has drop, copy { x1: X, x2: X }
+  │   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  │
+  = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_struct)]`.
+  = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_struct.
+
+warning: [lint] Struct is missing a doc comment.
+  ┌─ tests/model_ast_lints/self_assignment.move:6:3
+  │
+6 │   struct Pair(u64, u8) has copy, drop;
+  │   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  │
+  = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_struct)]`.
+  = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_struct.
+
+warning: [lint] Public function is missing a doc comment.
+  ┌─ tests/model_ast_lints/self_assignment.move:8:14
+  │
+8 │   public fun local() : u64 {
+  │              ^^^^^
+  │
+  = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+  = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] This is an unnecessary self assignment. Consider removing it.
    ┌─ tests/model_ast_lints/self_assignment.move:10:5
    │
@@ -8,6 +44,15 @@ warning: [lint] This is an unnecessary self assignment. Consider removing it.
    │
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(self_assignment)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#self_assignment.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/self_assignment.move:14:14
+   │
+14 │   public fun strct() {
+   │              ^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
 
 warning: [lint] This is an unnecessary self assignment. Consider removing it.
    ┌─ tests/model_ast_lints/self_assignment.move:16:5
@@ -36,6 +81,15 @@ warning: [lint] This is an unnecessary self assignment. Consider removing it.
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(self_assignment)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#self_assignment.
 
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/self_assignment.move:22:14
+   │
+22 │   public fun vardec() : X {
+   │              ^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] This is an unnecessary self assignment. Consider removing it.
    ┌─ tests/model_ast_lints/self_assignment.move:24:9
    │
@@ -53,6 +107,15 @@ warning: [lint] This is an unnecessary self assignment. Consider removing it.
    │
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(self_assignment)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#self_assignment.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/self_assignment.move:31:14
+   │
+31 │   public fun references() {
+   │              ^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
 
 warning: [lint] This is an unnecessary self assignment. Consider removing it.
    ┌─ tests/model_ast_lints/self_assignment.move:34:5
@@ -90,6 +153,15 @@ warning: [lint] This is an unnecessary self assignment. Consider removing it.
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(self_assignment)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#self_assignment.
 
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/self_assignment.move:41:14
+   │
+41 │   public fun inner_ref() {
+   │              ^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] This is an unnecessary self assignment. Consider removing it.
    ┌─ tests/model_ast_lints/self_assignment.move:44:5
    │
@@ -117,6 +189,15 @@ warning: [lint] This is an unnecessary self assignment. Consider removing it.
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(self_assignment)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#self_assignment.
 
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/self_assignment.move:49:14
+   │
+49 │   public fun positional() : Pair {
+   │              ^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] This is an unnecessary self assignment. Consider removing it.
    ┌─ tests/model_ast_lints/self_assignment.move:51:5
    │
@@ -135,6 +216,15 @@ warning: [lint] This is an unnecessary self assignment. Consider removing it.
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(self_assignment)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#self_assignment.
 
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/self_assignment.move:56:14
+   │
+56 │   public fun vect() : vector<u64> {
+   │              ^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] This is an unnecessary self assignment. Consider removing it.
    ┌─ tests/model_ast_lints/self_assignment.move:59:5
    │
@@ -143,6 +233,18 @@ warning: [lint] This is an unnecessary self assignment. Consider removing it.
    │
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(self_assignment)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#self_assignment.
+
+warning: [lint] Enum is missing a doc comment.
+   ┌─ tests/model_ast_lints/self_assignment.move:63:3
+   │
+63 │ ╭   enum E has drop {
+64 │ │     A { x: u64 },
+65 │ │     B { x: u64 },
+66 │ │   }
+   │ ╰───^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_struct)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_struct.
 
 warning: [lint] This is an unnecessary self assignment. Consider removing it.
    ┌─ tests/model_ast_lints/self_assignment.move:70:5
@@ -161,3 +263,63 @@ warning: [lint] This is an unnecessary self assignment. Consider removing it.
    │
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(self_assignment)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#self_assignment.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/self_assignment.move:74:14
+   │
+74 │   public fun no_self_assign_no_warn() {
+   │              ^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/self_assignment.move:85:14
+   │
+85 │   public fun out_of_scope_vector_no_warn() {
+   │              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/self_assignment.move:96:14
+   │
+96 │   public fun out_of_scope_function_no_warn() {
+   │              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/self_assignment.move:102:14
+    │
+102 │   public fun test_no_warn() : u64 {
+    │              ^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/self_assignment.move:108:14
+    │
+108 │   public fun no_warn_deref(): u64 {
+    │              ^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Module is missing a doc comment.
+    ┌─ tests/model_ast_lints/self_assignment.move:1:1
+    │
+  1 │ ╭ module 0xc0ffee::m {
+  2 │ │   use std::vector;
+  3 │ │
+  4 │ │   struct X has drop, copy { f: u64 }
+    · │
+112 │ │   }
+113 │ │ }
+    │ ╰─^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_module)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_module.

--- a/third_party/move/tools/move-linter/tests/model_ast_lints/simpler_bool_expression.exp
+++ b/third_party/move/tools/move-linter/tests/model_ast_lints/simpler_bool_expression.exp
@@ -1,5 +1,75 @@
 
 Diagnostics:
+warning: [lint] Constant is missing a doc comment.
+  ┌─ tests/model_ast_lints/simpler_bool_expression.move:3:5
+  │
+3 │     const TRUE_CONST: bool = true;
+  │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  │
+  = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_constant)]`.
+  = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_constant.
+
+warning: [lint] Constant is missing a doc comment.
+  ┌─ tests/model_ast_lints/simpler_bool_expression.move:4:5
+  │
+4 │     const FALSE_CONST: bool = false;
+  │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  │
+  = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_constant)]`.
+  = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_constant.
+
+warning: [lint] Struct is missing a doc comment.
+   ┌─ tests/model_ast_lints/simpler_bool_expression.move:6:5
+   │
+ 6 │ ╭     struct BoolFlags has copy, drop {
+ 7 │ │         a: bool,
+ 8 │ │         b: bool,
+ 9 │ │         c: bool,
+10 │ │     }
+   │ ╰─────^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_struct)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_struct.
+
+warning: [lint] Struct is missing a doc comment.
+   ┌─ tests/model_ast_lints/simpler_bool_expression.move:12:5
+   │
+12 │ ╭     struct NestedStruct has copy, drop {
+13 │ │         flags: BoolFlags,
+14 │ │         enabled: bool,
+15 │ │     }
+   │ ╰─────^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_struct)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_struct.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/simpler_bool_expression.move:17:16
+   │
+17 │     public fun helper_function(): bool {
+   │                ^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/simpler_bool_expression.move:21:16
+   │
+21 │     public fun get_bool_flags(): BoolFlags {
+   │                ^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/simpler_bool_expression.move:28:16
+   │
+28 │     public fun test_double_negation_parameters(a: bool) {
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] This boolean expression can be simplified using double negation law (`!!a` is equivalent to `a`).
    ┌─ tests/model_ast_lints/simpler_bool_expression.move:29:13
    │
@@ -17,6 +87,15 @@ warning: [lint] Empty `if` branch. Consider simplifying by removing or rewriting
    │
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(empty_if)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#empty_if.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/simpler_bool_expression.move:32:16
+   │
+32 │     public fun test_double_negation_variables() {
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
 
 warning: [lint] This boolean expression can be simplified using double negation law (`!!a` is equivalent to `a`).
    ┌─ tests/model_ast_lints/simpler_bool_expression.move:36:13
@@ -54,6 +133,15 @@ warning: [lint] Empty `if` branch. Consider simplifying by removing or rewriting
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(empty_if)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#empty_if.
 
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/simpler_bool_expression.move:40:16
+   │
+40 │     public fun test_double_negation_struct_field() {
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] This boolean expression can be simplified using double negation law (`!!a` is equivalent to `a`).
    ┌─ tests/model_ast_lints/simpler_bool_expression.move:43:13
    │
@@ -89,6 +177,15 @@ warning: [lint] Empty `if` branch. Consider simplifying by removing or rewriting
    │
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(empty_if)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#empty_if.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/simpler_bool_expression.move:47:16
+   │
+47 │     public fun test_double_negation_nested_struct() {
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
 
 warning: [lint] This boolean expression can be simplified using double negation law (`!!a` is equivalent to `a`).
    ┌─ tests/model_ast_lints/simpler_bool_expression.move:53:13
@@ -126,6 +223,15 @@ warning: [lint] Empty `if` branch. Consider simplifying by removing or rewriting
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(empty_if)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#empty_if.
 
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/simpler_bool_expression.move:61:16
+   │
+61 │     public fun test_absorption_law_parameters(a: bool, b: bool) {
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] This boolean expression can be simplified using absorption law (`a && b || a` is equivalent to `a`).
    ┌─ tests/model_ast_lints/simpler_bool_expression.move:62:13
    │
@@ -162,6 +268,15 @@ warning: [lint] Empty `if` branch. Consider simplifying by removing or rewriting
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(empty_if)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#empty_if.
 
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/simpler_bool_expression.move:66:16
+   │
+66 │     public fun test_absorption_law_variables() {
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] This boolean expression can be simplified using absorption law (`a && b || a` is equivalent to `a`).
    ┌─ tests/model_ast_lints/simpler_bool_expression.move:70:13
    │
@@ -197,6 +312,15 @@ warning: [lint] Empty `if` branch. Consider simplifying by removing or rewriting
    │
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(empty_if)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#empty_if.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/simpler_bool_expression.move:74:16
+   │
+74 │     public fun test_absorption_law_constants() {
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
 
 warning: [lint] The left-hand side of `&&` evaluates to `true`. Recall that the expression `true && bexpr` is logically equivalent to `bexpr`. Consider simplifying.
    ┌─ tests/model_ast_lints/simpler_bool_expression.move:75:13
@@ -270,6 +394,15 @@ warning: [lint] Empty `if` branch. Consider simplifying by removing or rewriting
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(empty_if)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#empty_if.
 
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/simpler_bool_expression.move:79:16
+   │
+79 │     public fun test_absorption_law_struct_field() {
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] This boolean expression can be simplified using absorption law (`a && b || a` is equivalent to `a`).
    ┌─ tests/model_ast_lints/simpler_bool_expression.move:82:13
    │
@@ -305,6 +438,15 @@ warning: [lint] Empty `if` branch. Consider simplifying by removing or rewriting
    │
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(empty_if)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#empty_if.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/simpler_bool_expression.move:86:16
+   │
+86 │     public fun test_absorption_law_nested_struct() {
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
 
 warning: [lint] This boolean expression can be simplified using absorption law (`a && b || a` is equivalent to `a`).
    ┌─ tests/model_ast_lints/simpler_bool_expression.move:92:13
@@ -342,6 +484,25 @@ warning: [lint] Empty `if` branch. Consider simplifying by removing or rewriting
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(empty_if)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#empty_if.
 
+warning: [lint] Use doc comment `///` instead of regular comment `//` for documentable items.
+   ┌─ tests/model_ast_lints/simpler_bool_expression.move:96:1
+   │
+96 │ ╭     // This test should not trigger the lint, since helper_function() might have side effects
+97 │ │     public fun test_absorption_law_mixed() {
+   │ ╰^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(prefer_doc_comment)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#prefer_doc_comment.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/simpler_bool_expression.move:97:16
+   │
+97 │     public fun test_absorption_law_mixed() {
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] Empty `if` branch. Consider simplifying by removing or rewriting.
     ┌─ tests/model_ast_lints/simpler_bool_expression.move:101:9
     │
@@ -359,6 +520,15 @@ warning: [lint] Empty `if` branch. Consider simplifying by removing or rewriting
     │
     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(empty_if)]`.
     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#empty_if.
+
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/simpler_bool_expression.move:109:16
+    │
+109 │     public fun test_idempotence_parameters(a: bool) {
+    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
 
 warning: [lint] This boolean expression can be simplified using double negation law (`!!a` is equivalent to `a`).
     ┌─ tests/model_ast_lints/simpler_bool_expression.move:110:13
@@ -423,6 +593,15 @@ warning: [lint] Empty `if` branch. Consider simplifying by removing or rewriting
     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(empty_if)]`.
     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#empty_if.
 
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/simpler_bool_expression.move:115:16
+    │
+115 │     public fun test_idempotence_variables() {
+    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] This boolean expression can be simplified using idempotence (`a && a` is equivalent to `a`).
     ┌─ tests/model_ast_lints/simpler_bool_expression.move:118:13
     │
@@ -458,6 +637,25 @@ warning: [lint] Empty `if` branch. Consider simplifying by removing or rewriting
     │
     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(empty_if)]`.
     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#empty_if.
+
+warning: [lint] Use doc comment `///` instead of regular comment `//` for documentable items.
+    ┌─ tests/model_ast_lints/simpler_bool_expression.move:122:1
+    │
+122 │ ╭     // This test should not trigger the lint, since it's already implemented in `nonminimal_bool`
+123 │ │     public fun test_idempotence_constants() {
+    │ ╰^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(prefer_doc_comment)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#prefer_doc_comment.
+
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/simpler_bool_expression.move:123:16
+    │
+123 │     public fun test_idempotence_constants() {
+    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
 
 warning: [lint] The left-hand side of `&&` evaluates to `true`. Recall that the expression `true && bexpr` is logically equivalent to `bexpr`. Consider simplifying.
     ┌─ tests/model_ast_lints/simpler_bool_expression.move:124:13
@@ -495,6 +693,15 @@ warning: [lint] Empty `if` branch. Consider simplifying by removing or rewriting
     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(empty_if)]`.
     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#empty_if.
 
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/simpler_bool_expression.move:128:16
+    │
+128 │     public fun test_idempotence_struct_field() {
+    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] This boolean expression can be simplified using idempotence (`a && a` is equivalent to `a`).
     ┌─ tests/model_ast_lints/simpler_bool_expression.move:131:13
     │
@@ -530,6 +737,15 @@ warning: [lint] Empty `if` branch. Consider simplifying by removing or rewriting
     │
     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(empty_if)]`.
     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#empty_if.
+
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/simpler_bool_expression.move:135:16
+    │
+135 │     public fun test_idempotence_nested_struct() {
+    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
 
 warning: [lint] This boolean expression can be simplified using idempotence (`a && a` is equivalent to `a`).
     ┌─ tests/model_ast_lints/simpler_bool_expression.move:141:13
@@ -567,6 +783,25 @@ warning: [lint] Empty `if` branch. Consider simplifying by removing or rewriting
     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(empty_if)]`.
     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#empty_if.
 
+warning: [lint] Use doc comment `///` instead of regular comment `//` for documentable items.
+    ┌─ tests/model_ast_lints/simpler_bool_expression.move:145:1
+    │
+145 │ ╭     // This test should not trigger the lint, since helper_function() might have side effects
+146 │ │     public fun test_idempotence_mixed() {
+    │ ╰^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(prefer_doc_comment)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#prefer_doc_comment.
+
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/simpler_bool_expression.move:146:16
+    │
+146 │     public fun test_idempotence_mixed() {
+    │                ^^^^^^^^^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] Empty `if` branch. Consider simplifying by removing or rewriting.
     ┌─ tests/model_ast_lints/simpler_bool_expression.move:149:9
     │
@@ -584,6 +819,15 @@ warning: [lint] Empty `if` branch. Consider simplifying by removing or rewriting
     │
     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(empty_if)]`.
     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#empty_if.
+
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/simpler_bool_expression.move:159:16
+    │
+159 │     public fun test_contradiction_tautology_parameters(a: bool) {
+    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
 
 warning: [lint] This boolean expression can be simplified using contradiction (`a && !a` is equivalent to `false`).
     ┌─ tests/model_ast_lints/simpler_bool_expression.move:160:13
@@ -657,6 +901,15 @@ warning: [lint] Empty `if` branch. Consider simplifying by removing or rewriting
     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(empty_if)]`.
     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#empty_if.
 
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/simpler_bool_expression.move:166:16
+    │
+166 │     public fun test_contradiction_tautology_variables() {
+    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] This boolean expression can be simplified using contradiction (`a && !a` is equivalent to `false`).
     ┌─ tests/model_ast_lints/simpler_bool_expression.move:169:13
     │
@@ -728,6 +981,25 @@ warning: [lint] Empty `if` branch. Consider simplifying by removing or rewriting
     │
     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(empty_if)]`.
     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#empty_if.
+
+warning: [lint] Use doc comment `///` instead of regular comment `//` for documentable items.
+    ┌─ tests/model_ast_lints/simpler_bool_expression.move:175:1
+    │
+175 │ ╭     // This test should not trigger the lint, since it's already implemented in `nonminimal_bool`
+176 │ │     public fun test_contradiction_tautology_constants() {
+    │ ╰^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(prefer_doc_comment)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#prefer_doc_comment.
+
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/simpler_bool_expression.move:176:16
+    │
+176 │     public fun test_contradiction_tautology_constants() {
+    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
 
 warning: [lint] This expression evaluates to `false`. Recall that the expression `!true` is logically equivalent to `false`. Consider simplifying.
     ┌─ tests/model_ast_lints/simpler_bool_expression.move:177:27
@@ -837,6 +1109,15 @@ warning: [lint] Empty `if` branch. Consider simplifying by removing or rewriting
     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(empty_if)]`.
     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#empty_if.
 
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/simpler_bool_expression.move:183:16
+    │
+183 │     public fun test_contradiction_tautology_struct_field() {
+    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] This boolean expression can be simplified using contradiction (`a && !a` is equivalent to `false`).
     ┌─ tests/model_ast_lints/simpler_bool_expression.move:186:13
     │
@@ -908,6 +1189,15 @@ warning: [lint] Empty `if` branch. Consider simplifying by removing or rewriting
     │
     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(empty_if)]`.
     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#empty_if.
+
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/simpler_bool_expression.move:192:16
+    │
+192 │     public fun test_contradiction_tautology_nested_struct() {
+    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
 
 warning: [lint] This boolean expression can be simplified using contradiction (`a && !a` is equivalent to `false`).
     ┌─ tests/model_ast_lints/simpler_bool_expression.move:198:13
@@ -981,6 +1271,25 @@ warning: [lint] Empty `if` branch. Consider simplifying by removing or rewriting
     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(empty_if)]`.
     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#empty_if.
 
+warning: [lint] Use doc comment `///` instead of regular comment `//` for documentable items.
+    ┌─ tests/model_ast_lints/simpler_bool_expression.move:204:1
+    │
+204 │ ╭     // This test should not trigger the lint, since helper_function() might have side effects
+205 │ │     public fun test_contradiction_tautology_mixed() {
+    │ ╰^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(prefer_doc_comment)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#prefer_doc_comment.
+
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/simpler_bool_expression.move:205:16
+    │
+205 │     public fun test_contradiction_tautology_mixed() {
+    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] Empty `if` branch. Consider simplifying by removing or rewriting.
     ┌─ tests/model_ast_lints/simpler_bool_expression.move:208:9
     │
@@ -1016,6 +1325,15 @@ warning: [lint] Empty `if` branch. Consider simplifying by removing or rewriting
     │
     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(empty_if)]`.
     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#empty_if.
+
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/simpler_bool_expression.move:218:16
+    │
+218 │     public fun test_distributive_law_parameters(a: bool, b: bool, c: bool) {
+    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
 
 warning: [lint] This boolean expression can be simplified using distributive law (`(a && b) || (a && c)` is equivalent to `a && (b || c)`).
     ┌─ tests/model_ast_lints/simpler_bool_expression.move:219:13
@@ -1053,6 +1371,15 @@ warning: [lint] Empty `if` branch. Consider simplifying by removing or rewriting
     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(empty_if)]`.
     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#empty_if.
 
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/simpler_bool_expression.move:223:16
+    │
+223 │     public fun test_distributive_law_variables() {
+    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] This boolean expression can be simplified using distributive law (`(a && b) || (a && c)` is equivalent to `a && (b || c)`).
     ┌─ tests/model_ast_lints/simpler_bool_expression.move:228:13
     │
@@ -1088,6 +1415,15 @@ warning: [lint] Empty `if` branch. Consider simplifying by removing or rewriting
     │
     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(empty_if)]`.
     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#empty_if.
+
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/simpler_bool_expression.move:232:16
+    │
+232 │     public fun test_distributive_law_constants() {
+    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
 
 warning: [lint] The left-hand side of `&&` evaluates to `true`. Recall that the expression `true && bexpr` is logically equivalent to `bexpr`. Consider simplifying.
     ┌─ tests/model_ast_lints/simpler_bool_expression.move:233:13
@@ -1161,6 +1497,15 @@ warning: [lint] Empty `if` branch. Consider simplifying by removing or rewriting
     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(empty_if)]`.
     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#empty_if.
 
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/simpler_bool_expression.move:237:16
+    │
+237 │     public fun test_distributive_law_struct_field() {
+    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] This boolean expression can be simplified using distributive law (`(a && b) || (a && c)` is equivalent to `a && (b || c)`).
     ┌─ tests/model_ast_lints/simpler_bool_expression.move:241:13
     │
@@ -1196,6 +1541,15 @@ warning: [lint] Empty `if` branch. Consider simplifying by removing or rewriting
     │
     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(empty_if)]`.
     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#empty_if.
+
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/simpler_bool_expression.move:245:16
+    │
+245 │     public fun test_distributive_law_nested_struct() {
+    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
 
 warning: [lint] This boolean expression can be simplified using distributive law (`(a && b) || (a && c)` is equivalent to `a && (b || c)`).
     ┌─ tests/model_ast_lints/simpler_bool_expression.move:251:13
@@ -1233,6 +1587,25 @@ warning: [lint] Empty `if` branch. Consider simplifying by removing or rewriting
     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(empty_if)]`.
     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#empty_if.
 
+warning: [lint] Use doc comment `///` instead of regular comment `//` for documentable items.
+    ┌─ tests/model_ast_lints/simpler_bool_expression.move:255:1
+    │
+255 │ ╭     // This test should not trigger the lint, since helper_function() might have side effects
+256 │ │     public fun test_distributive_law_mixed() {
+    │ ╰^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(prefer_doc_comment)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#prefer_doc_comment.
+
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/simpler_bool_expression.move:256:16
+    │
+256 │     public fun test_distributive_law_mixed() {
+    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] The right-hand side of `&&` evaluates to `true`. Recall that the expression `bexpr && true` is logically equivalent to `bexpr`. Consider simplifying.
     ┌─ tests/model_ast_lints/simpler_bool_expression.move:259:13
     │
@@ -1269,6 +1642,15 @@ warning: [lint] Empty `if` branch. Consider simplifying by removing or rewriting
     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(empty_if)]`.
     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#empty_if.
 
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/simpler_bool_expression.move:267:16
+    │
+267 │     public fun test_skipped_simplifiable() {
+    │                ^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] Empty `if` branch. Consider simplifying by removing or rewriting.
     ┌─ tests/model_ast_lints/simpler_bool_expression.move:271:9
     │
@@ -1296,6 +1678,15 @@ warning: [lint] Empty `if` branch. Consider simplifying by removing or rewriting
     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(empty_if)]`.
     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#empty_if.
 
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/simpler_bool_expression.move:278:16
+    │
+278 │     public fun test_parameters_no_lint(a: bool, b: bool, c: bool) {
+    │                ^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] Empty `if` branch. Consider simplifying by removing or rewriting.
     ┌─ tests/model_ast_lints/simpler_bool_expression.move:279:9
     │
@@ -1314,6 +1705,15 @@ warning: [lint] Empty `if` branch. Consider simplifying by removing or rewriting
     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(empty_if)]`.
     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#empty_if.
 
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/simpler_bool_expression.move:283:16
+    │
+283 │     public fun test_variables_no_lint() {
+    │                ^^^^^^^^^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] Empty `if` branch. Consider simplifying by removing or rewriting.
     ┌─ tests/model_ast_lints/simpler_bool_expression.move:287:9
     │
@@ -1331,6 +1731,15 @@ warning: [lint] Empty `if` branch. Consider simplifying by removing or rewriting
     │
     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(empty_if)]`.
     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#empty_if.
+
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/simpler_bool_expression.move:291:16
+    │
+291 │     public fun test_constants_no_lint() {
+    │                ^^^^^^^^^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
 
 warning: [lint] The left-hand side of `&&` evaluates to `true`. Recall that the expression `true && bexpr` is logically equivalent to `bexpr`. Consider simplifying.
     ┌─ tests/model_ast_lints/simpler_bool_expression.move:292:13
@@ -1368,6 +1777,15 @@ warning: [lint] Empty `if` branch. Consider simplifying by removing or rewriting
     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(empty_if)]`.
     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#empty_if.
 
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/simpler_bool_expression.move:296:16
+    │
+296 │     public fun test_different_struct_fields_no_lint() {
+    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] Empty `if` branch. Consider simplifying by removing or rewriting.
     ┌─ tests/model_ast_lints/simpler_bool_expression.move:299:9
     │
@@ -1403,6 +1821,15 @@ warning: [lint] Empty `if` branch. Consider simplifying by removing or rewriting
     │
     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(empty_if)]`.
     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#empty_if.
+
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/simpler_bool_expression.move:305:16
+    │
+305 │     public fun test_nested_struct_no_lint() {
+    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
 
 warning: [lint] Empty `if` branch. Consider simplifying by removing or rewriting.
     ┌─ tests/model_ast_lints/simpler_bool_expression.move:311:9
@@ -1440,6 +1867,15 @@ warning: [lint] Empty `if` branch. Consider simplifying by removing or rewriting
     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(empty_if)]`.
     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#empty_if.
 
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/simpler_bool_expression.move:317:16
+    │
+317 │     public fun test_function_call_no_lint() {
+    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] Empty `if` branch. Consider simplifying by removing or rewriting.
     ┌─ tests/model_ast_lints/simpler_bool_expression.move:321:9
     │
@@ -1458,6 +1894,15 @@ warning: [lint] Empty `if` branch. Consider simplifying by removing or rewriting
     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(empty_if)]`.
     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#empty_if.
 
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/simpler_bool_expression.move:328:16
+    │
+328 │     public fun test_vector_no_lint() {
+    │                ^^^^^^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] Empty `if` branch. Consider simplifying by removing or rewriting.
     ┌─ tests/model_ast_lints/simpler_bool_expression.move:331:9
     │
@@ -1475,3 +1920,18 @@ warning: [lint] Empty `if` branch. Consider simplifying by removing or rewriting
     │
     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(empty_if)]`.
     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#empty_if.
+
+warning: [lint] Module is missing a doc comment.
+    ┌─ tests/model_ast_lints/simpler_bool_expression.move:1:1
+    │
+  1 │ ╭ module 0xc0ffee::m {
+  2 │ │
+  3 │ │     const TRUE_CONST: bool = true;
+  4 │ │     const FALSE_CONST: bool = false;
+    · │
+333 │ │     }
+334 │ │ }
+    │ ╰─^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_module)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_module.

--- a/third_party/move/tools/move-linter/tests/model_ast_lints/simpler_numeric_expression_warn.exp
+++ b/third_party/move/tools/move-linter/tests/model_ast_lints/simpler_numeric_expression_warn.exp
@@ -1,5 +1,14 @@
 
 Diagnostics:
+warning: [lint] Public function is missing a doc comment.
+  ┌─ tests/model_ast_lints/simpler_numeric_expression_warn.move:2:16
+  │
+2 │     public fun test1(x: u64): u64 {
+  │                ^^^^^
+  │
+  = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+  = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] This expression can be simplified to just `0`
   ┌─ tests/model_ast_lints/simpler_numeric_expression_warn.move:3:9
   │
@@ -8,6 +17,15 @@ warning: [lint] This expression can be simplified to just `0`
   │
   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(simpler_numeric_expression)]`.
   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#simpler_numeric_expression.
+
+warning: [lint] Public function is missing a doc comment.
+  ┌─ tests/model_ast_lints/simpler_numeric_expression_warn.move:6:16
+  │
+6 │     public fun test2(x: u64): u64 {
+  │                ^^^^^
+  │
+  = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+  = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
 
 warning: [lint] This expression can be simplified to just `0`
   ┌─ tests/model_ast_lints/simpler_numeric_expression_warn.move:7:9
@@ -26,6 +44,15 @@ warning: [lint] This expression can be simplified to just `0`
   │
   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(simpler_numeric_expression)]`.
   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#simpler_numeric_expression.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/simpler_numeric_expression_warn.move:10:16
+   │
+10 │     public fun test3(x: u64): u64 {
+   │                ^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
 
 warning: [lint] This expression can be simplified to just `0`
    ┌─ tests/model_ast_lints/simpler_numeric_expression_warn.move:11:10
@@ -53,6 +80,15 @@ warning: [lint] This binary operation can be simplified to just the left-hand si
    │
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(simpler_numeric_expression)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#simpler_numeric_expression.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/simpler_numeric_expression_warn.move:14:16
+   │
+14 │     public fun test4(x: u64): u64 {
+   │                ^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
 
 warning: [lint] This binary operation can be simplified to just the left-hand side
    ┌─ tests/model_ast_lints/simpler_numeric_expression_warn.move:15:9
@@ -99,6 +135,15 @@ warning: [lint] This binary operation can be simplified to just the left-hand si
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(simpler_numeric_expression)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#simpler_numeric_expression.
 
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/simpler_numeric_expression_warn.move:18:16
+   │
+18 │     public fun test5(x: u64): u64 {
+   │                ^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] This binary operation can be simplified to just the left-hand side
    ┌─ tests/model_ast_lints/simpler_numeric_expression_warn.move:19:9
    │
@@ -116,6 +161,15 @@ warning: [lint] This binary operation can be simplified to just the left-hand si
    │
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(simpler_numeric_expression)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#simpler_numeric_expression.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/simpler_numeric_expression_warn.move:22:16
+   │
+22 │     public fun test6(x: u64): u64 {
+   │                ^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
 
 warning: [lint] This binary operation can be simplified to just the right-hand side
    ┌─ tests/model_ast_lints/simpler_numeric_expression_warn.move:23:13
@@ -144,6 +198,15 @@ warning: [lint] This binary operation can be simplified to just the right-hand s
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(simpler_numeric_expression)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#simpler_numeric_expression.
 
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/simpler_numeric_expression_warn.move:26:16
+   │
+26 │     public fun test7(x: u64): u64 {
+   │                ^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] This binary operation can be simplified to just the right-hand side
    ┌─ tests/model_ast_lints/simpler_numeric_expression_warn.move:27:9
    │
@@ -152,6 +215,15 @@ warning: [lint] This binary operation can be simplified to just the right-hand s
    │
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(simpler_numeric_expression)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#simpler_numeric_expression.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/simpler_numeric_expression_warn.move:30:16
+   │
+30 │     public fun test8(x: u8): u64 {
+   │                ^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
 
 warning: [lint] This binary operation can be simplified to just the left-hand side
    ┌─ tests/model_ast_lints/simpler_numeric_expression_warn.move:31:14
@@ -170,3 +242,63 @@ warning: [lint] This expression can be simplified to just `0`
    │
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(simpler_numeric_expression)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#simpler_numeric_expression.
+
+warning: [lint] Module is missing a doc comment.
+   ┌─ tests/model_ast_lints/simpler_numeric_expression_warn.move:1:1
+   │
+ 1 │ ╭ module 0xc0ffee::m {
+ 2 │ │     public fun test1(x: u64): u64 {
+ 3 │ │         (x & 0) + 1
+ 4 │ │     }
+   · │
+32 │ │     }
+33 │ │ }
+   │ ╰─^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_module)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_module.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/simpler_numeric_expression_warn.move:37:16
+   │
+37 │     public fun test8(x: u8): u64 {
+   │                ^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Module is missing a doc comment.
+   ┌─ tests/model_ast_lints/simpler_numeric_expression_warn.move:36:1
+   │
+36 │ ╭ module 0xc0ffee::no_warn1 {
+37 │ │     public fun test8(x: u8): u64 {
+38 │ │         0 >> x + 0 << x
+39 │ │     }
+40 │ │ }
+   │ ╰─^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_module)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_module.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/simpler_numeric_expression_warn.move:44:16
+   │
+44 │     public fun test8(x: u8): u64 {
+   │                ^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Module is missing a doc comment.
+   ┌─ tests/model_ast_lints/simpler_numeric_expression_warn.move:42:1
+   │
+42 │ ╭ module 0xc0ffee::no_warn2 {
+43 │ │     #[lint::skip(simpler_numeric_expression)]
+44 │ │     public fun test8(x: u8): u64 {
+45 │ │         0 >> x + 0 << x
+46 │ │     }
+47 │ │ }
+   │ ╰─^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_module)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_module.

--- a/third_party/move/tools/move-linter/tests/model_ast_lints/unnecessary_boolean_identity_comparison.exp
+++ b/third_party/move/tools/move-linter/tests/model_ast_lints/unnecessary_boolean_identity_comparison.exp
@@ -1,5 +1,23 @@
 
 Diagnostics:
+warning: [lint] Constant is missing a doc comment.
+  ┌─ tests/model_ast_lints/unnecessary_boolean_identity_comparison.move:2:5
+  │
+2 │     const TRUE: bool = true;
+  │     ^^^^^^^^^^^^^^^^^^^^^^^^
+  │
+  = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_constant)]`.
+  = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_constant.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/unnecessary_boolean_identity_comparison.move:13:16
+   │
+13 │     public fun test1(x: u64) {
+   │                ^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] Directly use the boolean expression, instead of comparing it with `true`.
    ┌─ tests/model_ast_lints/unnecessary_boolean_identity_comparison.move:14:13
    │
@@ -117,6 +135,15 @@ warning: [lint] Directly use the boolean expression, instead of comparing it wit
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_boolean_identity_comparison)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#unnecessary_boolean_identity_comparison.
 
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/unnecessary_boolean_identity_comparison.move:29:16
+   │
+29 │     public fun test2(x: &bool, y: &bool) {
+   │                ^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] Directly use the boolean expression, instead of comparing it with `true`.
    ┌─ tests/model_ast_lints/unnecessary_boolean_identity_comparison.move:30:13
    │
@@ -125,3 +152,41 @@ warning: [lint] Directly use the boolean expression, instead of comparing it wit
    │
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_boolean_identity_comparison)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#unnecessary_boolean_identity_comparison.
+
+warning: [lint] Module is missing a doc comment.
+   ┌─ tests/model_ast_lints/unnecessary_boolean_identity_comparison.move:1:1
+   │
+ 1 │ ╭ module 0xc0ffee::m {
+ 2 │ │     const TRUE: bool = true;
+ 3 │ │
+ 4 │ │     fun foo(x: u64): bool {
+   · │
+31 │ │     }
+32 │ │ }
+   │ ╰─^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_module)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_module.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/unnecessary_boolean_identity_comparison.move:36:16
+   │
+36 │     public fun test(x: bool) {
+   │                ^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Module is missing a doc comment.
+   ┌─ tests/model_ast_lints/unnecessary_boolean_identity_comparison.move:34:1
+   │
+34 │ ╭ module 0xc0ffee::no_warn {
+35 │ │     #[lint::skip(unnecessary_boolean_identity_comparison)]
+36 │ │     public fun test(x: bool) {
+37 │ │         if (x == true) abort 1;
+38 │ │     }
+39 │ │ }
+   │ ╰─^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_module)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_module.

--- a/third_party/move/tools/move-linter/tests/model_ast_lints/unnecessary_numerical_extreme_comparisons_warn.exp
+++ b/third_party/move/tools/move-linter/tests/model_ast_lints/unnecessary_numerical_extreme_comparisons_warn.exp
@@ -1,5 +1,14 @@
 
 Diagnostics:
+warning: [lint] Public function is missing a doc comment.
+  ┌─ tests/model_ast_lints/unnecessary_numerical_extreme_comparisons_warn.move:8:16
+  │
+8 │     public fun test1(x: u8) {
+  │                ^^^^^
+  │
+  = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+  = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] Comparison is always false, consider rewriting the code to remove the redundant comparison
   ┌─ tests/model_ast_lints/unnecessary_numerical_extreme_comparisons_warn.move:9:13
   │
@@ -8,6 +17,15 @@ warning: [lint] Comparison is always false, consider rewriting the code to remov
   │
   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_numerical_extreme_comparison)]`.
   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#unnecessary_numerical_extreme_comparison.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/unnecessary_numerical_extreme_comparisons_warn.move:12:16
+   │
+12 │     public fun test2(x: &u8, y: &u8) {
+   │                ^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
 
 warning: [lint] Comparison is always false, consider rewriting the code to remove the redundant comparison
    ┌─ tests/model_ast_lints/unnecessary_numerical_extreme_comparisons_warn.move:13:13
@@ -26,6 +44,15 @@ warning: [lint] Directly use the boolean expression, instead of comparing it wit
    │
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_boolean_identity_comparison)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#unnecessary_boolean_identity_comparison.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/unnecessary_numerical_extreme_comparisons_warn.move:16:16
+   │
+16 │     public fun test3(x: u8) {
+   │                ^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
 
 warning: [lint] Comparison is always false, consider rewriting the code to remove the redundant comparison
    ┌─ tests/model_ast_lints/unnecessary_numerical_extreme_comparisons_warn.move:17:13
@@ -62,6 +89,70 @@ warning: [lint] Comparison is always true, consider rewriting the code to remove
    │
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_numerical_extreme_comparison)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#unnecessary_numerical_extreme_comparison.
+
+warning: [lint] Constant is missing a doc comment.
+   ┌─ tests/model_ast_lints/unnecessary_numerical_extreme_comparisons_warn.move:26:5
+   │
+26 │     const U8_MAX: u8 = 255;
+   │     ^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_constant)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_constant.
+
+warning: [lint] Constant is missing a doc comment.
+   ┌─ tests/model_ast_lints/unnecessary_numerical_extreme_comparisons_warn.move:27:5
+   │
+27 │     const U16_MAX: u16 = 65535;
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_constant)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_constant.
+
+warning: [lint] Constant is missing a doc comment.
+   ┌─ tests/model_ast_lints/unnecessary_numerical_extreme_comparisons_warn.move:28:5
+   │
+28 │     const U32_MAX: u32 = 4294967295;
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_constant)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_constant.
+
+warning: [lint] Constant is missing a doc comment.
+   ┌─ tests/model_ast_lints/unnecessary_numerical_extreme_comparisons_warn.move:29:5
+   │
+29 │     const U64_MAX: u64 = 18446744073709551615;
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_constant)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_constant.
+
+warning: [lint] Constant is missing a doc comment.
+   ┌─ tests/model_ast_lints/unnecessary_numerical_extreme_comparisons_warn.move:30:5
+   │
+30 │     const U128_MAX: u128 = 340282366920938463463374607431768211455;
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_constant)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_constant.
+
+warning: [lint] Constant is missing a doc comment.
+   ┌─ tests/model_ast_lints/unnecessary_numerical_extreme_comparisons_warn.move:31:5
+   │
+31 │ ╭     const U256_MAX: u256 =
+32 │ │         115792089237316195423570985008687907853269984665640564039457584007913129639935;
+   │ ╰───────────────────────────────────────────────────────────────────────────────────────^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_constant)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_constant.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/unnecessary_numerical_extreme_comparisons_warn.move:34:16
+   │
+34 │     public fun test4(a: u8, b: u16, c: u32, d: u64, e: u128, f: u256) {
+   │                ^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
 
 warning: [lint] Comparison is always false, consider rewriting the code to remove the redundant comparison
    ┌─ tests/model_ast_lints/unnecessary_numerical_extreme_comparisons_warn.move:36:13
@@ -108,6 +199,15 @@ warning: [lint] Comparison is always true, consider rewriting the code to remove
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_numerical_extreme_comparison)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#unnecessary_numerical_extreme_comparison.
 
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/unnecessary_numerical_extreme_comparisons_warn.move:53:16
+   │
+53 │     public fun test5(x: u8): bool {
+   │                ^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] Comparison is always false, consider rewriting the code to remove the redundant comparison
    ┌─ tests/model_ast_lints/unnecessary_numerical_extreme_comparisons_warn.move:54:19
    │
@@ -117,6 +217,15 @@ warning: [lint] Comparison is always false, consider rewriting the code to remov
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_numerical_extreme_comparison)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#unnecessary_numerical_extreme_comparison.
 
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/unnecessary_numerical_extreme_comparisons_warn.move:57:16
+   │
+57 │     public fun test6(x: i8) {
+   │                ^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] Comparison is always false, consider rewriting the code to remove the redundant comparison
    ┌─ tests/model_ast_lints/unnecessary_numerical_extreme_comparisons_warn.move:58:13
    │
@@ -125,6 +234,15 @@ warning: [lint] Comparison is always false, consider rewriting the code to remov
    │
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_numerical_extreme_comparison)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#unnecessary_numerical_extreme_comparison.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/unnecessary_numerical_extreme_comparisons_warn.move:61:16
+   │
+61 │     public fun test7(x: &i8, y: &i8) {
+   │                ^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
 
 warning: [lint] Comparison is always false, consider rewriting the code to remove the redundant comparison
    ┌─ tests/model_ast_lints/unnecessary_numerical_extreme_comparisons_warn.move:62:13
@@ -143,6 +261,183 @@ warning: [lint] Directly use the boolean expression, instead of comparing it wit
    │
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_boolean_identity_comparison)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#unnecessary_boolean_identity_comparison.
+
+warning: [lint] Use doc comment `///` instead of regular comment `//` for documentable items.
+   ┌─ tests/model_ast_lints/unnecessary_numerical_extreme_comparisons_warn.move:65:1
+   │
+65 │ ╭         // 8-bit
+66 │ │     const I8_MIN: i8 = -128;
+   │ ╰^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(prefer_doc_comment)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#prefer_doc_comment.
+
+warning: [lint] Constant is missing a doc comment.
+   ┌─ tests/model_ast_lints/unnecessary_numerical_extreme_comparisons_warn.move:66:5
+   │
+66 │     const I8_MIN: i8 = -128;
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_constant)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_constant.
+
+warning: [lint] Constant is missing a doc comment.
+   ┌─ tests/model_ast_lints/unnecessary_numerical_extreme_comparisons_warn.move:67:5
+   │
+67 │     const I8_MAX: i8 = 127;
+   │     ^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_constant)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_constant.
+
+warning: [lint] Use doc comment `///` instead of regular comment `//` for documentable items.
+   ┌─ tests/model_ast_lints/unnecessary_numerical_extreme_comparisons_warn.move:69:1
+   │
+69 │ ╭     // 16-bit
+70 │ │     const I16_MIN: i16 = -32768;
+   │ ╰^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(prefer_doc_comment)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#prefer_doc_comment.
+
+warning: [lint] Constant is missing a doc comment.
+   ┌─ tests/model_ast_lints/unnecessary_numerical_extreme_comparisons_warn.move:70:5
+   │
+70 │     const I16_MIN: i16 = -32768;
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_constant)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_constant.
+
+warning: [lint] Constant is missing a doc comment.
+   ┌─ tests/model_ast_lints/unnecessary_numerical_extreme_comparisons_warn.move:71:5
+   │
+71 │     const I16_MAX: i16 = 32767;
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_constant)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_constant.
+
+warning: [lint] Use doc comment `///` instead of regular comment `//` for documentable items.
+   ┌─ tests/model_ast_lints/unnecessary_numerical_extreme_comparisons_warn.move:73:1
+   │
+73 │ ╭     // 32-bit
+74 │ │     const I32_MIN: i32 = -2147483648;
+   │ ╰^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(prefer_doc_comment)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#prefer_doc_comment.
+
+warning: [lint] Constant is missing a doc comment.
+   ┌─ tests/model_ast_lints/unnecessary_numerical_extreme_comparisons_warn.move:74:5
+   │
+74 │     const I32_MIN: i32 = -2147483648;
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_constant)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_constant.
+
+warning: [lint] Constant is missing a doc comment.
+   ┌─ tests/model_ast_lints/unnecessary_numerical_extreme_comparisons_warn.move:75:5
+   │
+75 │     const I32_MAX: i32 = 2147483647;
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_constant)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_constant.
+
+warning: [lint] Use doc comment `///` instead of regular comment `//` for documentable items.
+   ┌─ tests/model_ast_lints/unnecessary_numerical_extreme_comparisons_warn.move:77:1
+   │
+77 │ ╭     // 64-bit
+78 │ │     const I64_MIN: i64 = -9223372036854775808;
+   │ ╰^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(prefer_doc_comment)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#prefer_doc_comment.
+
+warning: [lint] Constant is missing a doc comment.
+   ┌─ tests/model_ast_lints/unnecessary_numerical_extreme_comparisons_warn.move:78:5
+   │
+78 │     const I64_MIN: i64 = -9223372036854775808;
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_constant)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_constant.
+
+warning: [lint] Constant is missing a doc comment.
+   ┌─ tests/model_ast_lints/unnecessary_numerical_extreme_comparisons_warn.move:79:5
+   │
+79 │     const I64_MAX: i64 = 9223372036854775807;
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_constant)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_constant.
+
+warning: [lint] Use doc comment `///` instead of regular comment `//` for documentable items.
+   ┌─ tests/model_ast_lints/unnecessary_numerical_extreme_comparisons_warn.move:81:1
+   │
+81 │ ╭     // 128-bit
+82 │ │     const I128_MIN: i128 = -170141183460469231731687303715884105728;
+   │ ╰^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(prefer_doc_comment)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#prefer_doc_comment.
+
+warning: [lint] Constant is missing a doc comment.
+   ┌─ tests/model_ast_lints/unnecessary_numerical_extreme_comparisons_warn.move:82:5
+   │
+82 │     const I128_MIN: i128 = -170141183460469231731687303715884105728;
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_constant)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_constant.
+
+warning: [lint] Constant is missing a doc comment.
+   ┌─ tests/model_ast_lints/unnecessary_numerical_extreme_comparisons_warn.move:83:5
+   │
+83 │     const I128_MAX: i128 = 170141183460469231731687303715884105727;
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_constant)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_constant.
+
+warning: [lint] Use doc comment `///` instead of regular comment `//` for documentable items.
+   ┌─ tests/model_ast_lints/unnecessary_numerical_extreme_comparisons_warn.move:85:1
+   │
+85 │ ╭     // 256-bit (custom / nonstandard)
+86 │ │     const I256_MIN: i256 = -57896044618658097711785492504343953926634992332820282019728792003956564819968;
+   │ ╰^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(prefer_doc_comment)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#prefer_doc_comment.
+
+warning: [lint] Constant is missing a doc comment.
+   ┌─ tests/model_ast_lints/unnecessary_numerical_extreme_comparisons_warn.move:86:5
+   │
+86 │     const I256_MIN: i256 = -57896044618658097711785492504343953926634992332820282019728792003956564819968;
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_constant)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_constant.
+
+warning: [lint] Constant is missing a doc comment.
+   ┌─ tests/model_ast_lints/unnecessary_numerical_extreme_comparisons_warn.move:87:5
+   │
+87 │     const I256_MAX: i256 = 57896044618658097711785492504343953926634992332820282019728792003956564819967;
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_constant)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_constant.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/unnecessary_numerical_extreme_comparisons_warn.move:89:16
+   │
+89 │     public fun test8(x: i8) {
+   │                ^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
 
 warning: [lint] Comparison is always false, consider rewriting the code to remove the redundant comparison
    ┌─ tests/model_ast_lints/unnecessary_numerical_extreme_comparisons_warn.move:90:13
@@ -179,6 +474,15 @@ warning: [lint] Comparison is always true, consider rewriting the code to remove
    │
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_numerical_extreme_comparison)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#unnecessary_numerical_extreme_comparison.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/unnecessary_numerical_extreme_comparisons_warn.move:99:16
+   │
+99 │     public fun test9(a: i8, b: i16, c: i32, d: i64, e: i128, f: i256) {
+   │                ^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
 
 warning: [lint] Comparison is always false, consider rewriting the code to remove the redundant comparison
     ┌─ tests/model_ast_lints/unnecessary_numerical_extreme_comparisons_warn.move:100:13
@@ -224,3 +528,60 @@ warning: [lint] Comparison is always true, consider rewriting the code to remove
     │
     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_numerical_extreme_comparison)]`.
     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#unnecessary_numerical_extreme_comparison.
+
+warning: [lint] Use doc comment `///` instead of regular comment `//` for documentable items.
+    ┌─ tests/model_ast_lints/unnecessary_numerical_extreme_comparisons_warn.move:113:1
+    │
+113 │ ╭     // simulate `abs`
+114 │ │     public fun test_abs(x: i64): i64 {
+    │ ╰^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(prefer_doc_comment)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#prefer_doc_comment.
+
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/unnecessary_numerical_extreme_comparisons_warn.move:114:16
+    │
+114 │     public fun test_abs(x: i64): i64 {
+    │                ^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Module is missing a doc comment.
+    ┌─ tests/model_ast_lints/unnecessary_numerical_extreme_comparisons_warn.move:1:1
+    │
+  1 │ ╭ module 0xc0ffee::m {
+  2 │ │     fun bar() {}
+  3 │ │
+  4 │ │     fun foo<T>(x: T): T {
+    · │
+122 │ │
+123 │ │ }
+    │ ╰─^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_module)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_module.
+
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/model_ast_lints/unnecessary_numerical_extreme_comparisons_warn.move:127:16
+    │
+127 │     public fun test(x: u8) {
+    │                ^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Module is missing a doc comment.
+    ┌─ tests/model_ast_lints/unnecessary_numerical_extreme_comparisons_warn.move:125:1
+    │
+125 │ ╭ module 0xc0ffee::no_warn {
+126 │ │     #[lint::skip(unnecessary_numerical_extreme_comparison)]
+127 │ │     public fun test(x: u8) {
+128 │ │         if (x < 0) abort 1;
+129 │ │     }
+130 │ │ }
+    │ ╰─^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_module)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_module.

--- a/third_party/move/tools/move-linter/tests/model_ast_lints/while_true_warn.exp
+++ b/third_party/move/tools/move-linter/tests/model_ast_lints/while_true_warn.exp
@@ -1,5 +1,14 @@
 
 Diagnostics:
+warning: [lint] Public function is missing a doc comment.
+  ┌─ tests/model_ast_lints/while_true_warn.move:2:16
+  │
+2 │     public fun test_warn_1(x: u64) {
+  │                ^^^^^^^^^^^
+  │
+  = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+  = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] Use the more explicit `loop` instead.
   ┌─ tests/model_ast_lints/while_true_warn.move:3:9
   │
@@ -11,6 +20,15 @@ warning: [lint] Use the more explicit `loop` instead.
   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(while_true)]`.
   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#while_true.
 
+warning: [lint] Public function is missing a doc comment.
+  ┌─ tests/model_ast_lints/while_true_warn.move:8:16
+  │
+8 │     public fun test_warn_2(x: u64) {
+  │                ^^^^^^^^^^^
+  │
+  = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+  = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
 warning: [lint] Use the more explicit `loop` instead.
    ┌─ tests/model_ast_lints/while_true_warn.move:11:9
    │
@@ -21,3 +39,60 @@ warning: [lint] Use the more explicit `loop` instead.
    │
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(while_true)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#while_true.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/while_true_warn.move:16:16
+   │
+16 │     public fun test_no_warn_1(x: u64) {
+   │                ^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/while_true_warn.move:22:16
+   │
+22 │     public fun test_no_warn_2(x: u64) {
+   │                ^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Module is missing a doc comment.
+   ┌─ tests/model_ast_lints/while_true_warn.move:1:1
+   │
+ 1 │ ╭ module 0xc0ffee::m {
+ 2 │ │     public fun test_warn_1(x: u64) {
+ 3 │ │         while (true) {
+ 4 │ │             if (x > 10) { break; } else { test_warn_1(x + 1); }
+   · │
+26 │ │     }
+27 │ │ }
+   │ ╰─^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_module)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_module.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/model_ast_lints/while_true_warn.move:31:16
+   │
+31 │     public fun test_warn_1(x: u64) {
+   │                ^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Module is missing a doc comment.
+   ┌─ tests/model_ast_lints/while_true_warn.move:29:1
+   │
+29 │ ╭ module 0xc0ffee::no_warn {
+30 │ │     #[lint::skip(while_true)]
+31 │ │     public fun test_warn_1(x: u64) {
+32 │ │         while (true) {
+   · │
+35 │ │     }
+36 │ │ }
+   │ ╰─^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_module)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_module.

--- a/third_party/move/tools/move-linter/tests/module_lints/error_constant_naming.exp
+++ b/third_party/move/tools/move-linter/tests/module_lints/error_constant_naming.exp
@@ -1,0 +1,10 @@
+
+Diagnostics:
+warning: [lint] Error constant name does not follow the naming convention. Use `E_ERROR_NAME` or `EERROR_NAME`.
+   ┌─ tests/module_lints/error_constant_naming.move:16:5
+   │
+16 │     const Efoo: u64 = 100;
+   │     ^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(error_constant_naming)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#error_constant_naming.

--- a/third_party/move/tools/move-linter/tests/module_lints/error_constant_naming.move
+++ b/third_party/move/tools/move-linter/tests/module_lints/error_constant_naming.move
@@ -1,0 +1,21 @@
+/// Test module for error_constant_naming lint.
+module 0xc0ffee::error_constant_naming {
+    /// Good: follows EERROR_NAME convention.
+    const ENOT_FOUND: u64 = 1;
+
+    /// Good: follows E_ERROR_NAME convention.
+    const E_NOT_FOUND: u64 = 2;
+
+    /// Good: follows EERROR_NAME convention.
+    const EPERMISSION_DENIED: u64 = 3;
+
+    /// Not an error constant (doesn't start with E).
+    const MY_CONSTANT: u64 = 42;
+
+    /// Bad: lowercase after E does not follow convention.
+    const Efoo: u64 = 100;
+
+    #[lint::skip(error_constant_naming)]
+    /// Skipped bad naming.
+    const Ebar: u64 = 101;
+}

--- a/third_party/move/tools/move-linter/tests/module_lints/error_message_too_long.exp
+++ b/third_party/move/tools/move-linter/tests/module_lints/error_message_too_long.exp
@@ -1,0 +1,10 @@
+
+Diagnostics:
+warning: [lint] Error constant doc comment is 193 bytes, which exceeds the 128 byte limit.
+  ┌─ tests/module_lints/error_message_too_long.move:7:5
+  │
+7 │     const ETOO_LONG: u64 = 2;
+  │     ^^^^^^^^^^^^^^^^^^^^^^^^^
+  │
+  = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(error_message_too_long)]`.
+  = For more information, see https://aptos.dev/en/build/smart-contracts/linter#error_message_too_long.

--- a/third_party/move/tools/move-linter/tests/module_lints/error_message_too_long.move
+++ b/third_party/move/tools/move-linter/tests/module_lints/error_message_too_long.move
@@ -1,0 +1,15 @@
+/// Test module for error_message_too_long lint.
+module 0xc0ffee::error_message_too_long {
+    /// Short error message.
+    const ESHORT: u64 = 1;
+
+    /// This is a very long error message that exceeds the 128 byte limit. It contains a lot of unnecessary detail that makes the error description overly verbose and hard to read quickly at a glance.
+    const ETOO_LONG: u64 = 2;
+
+    /// This is a very long doc comment on a non-error constant. It exceeds the byte limit but that should be fine since this is not an error constant at all, so length does not matter here.
+    const MY_LONG_CONSTANT: u64 = 42;
+
+    #[lint::skip(error_message_too_long)]
+    /// This is another very long error message that exceeds the 128 byte limit and contains too much verbosity. It should not trigger a warning because of the skip annotation though.
+    const ESKIPPED_LONG: u64 = 99;
+}

--- a/third_party/move/tools/move-linter/tests/module_lints/missing_doc_constant.exp
+++ b/third_party/move/tools/move-linter/tests/module_lints/missing_doc_constant.exp
@@ -1,0 +1,19 @@
+
+Diagnostics:
+warning: [lint] Constant is missing a doc comment.
+  ┌─ tests/module_lints/missing_doc_constant.move:3:5
+  │
+3 │     const MY_CONSTANT: u64 = 42;
+  │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  │
+  = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_constant)]`.
+  = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_constant.
+
+warning: [lint] Constant is missing a doc comment.
+  ┌─ tests/module_lints/missing_doc_constant.move:5:5
+  │
+5 │     const SOME_VALUE: u64 = 100;
+  │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  │
+  = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_constant)]`.
+  = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_constant.

--- a/third_party/move/tools/move-linter/tests/module_lints/missing_doc_constant.move
+++ b/third_party/move/tools/move-linter/tests/module_lints/missing_doc_constant.move
@@ -1,0 +1,18 @@
+/// Test module for missing_doc_constant lint.
+module 0xc0ffee::missing_doc_constant {
+    const MY_CONSTANT: u64 = 42;
+
+    const SOME_VALUE: u64 = 100;
+
+    /// This constant has a doc comment.
+    const DOCUMENTED_CONSTANT: u64 = 1;
+
+    /// Error constants are handled by missing_doc_error_constant lint.
+    const ENOT_FOUND: u64 = 1;
+
+    /// Error constants are handled by missing_doc_error_constant lint.
+    const E_NOT_FOUND: u64 = 2;
+
+    #[lint::skip(missing_doc_constant)]
+    const SKIPPED_CONSTANT: u64 = 99;
+}

--- a/third_party/move/tools/move-linter/tests/module_lints/missing_doc_error_constant.exp
+++ b/third_party/move/tools/move-linter/tests/module_lints/missing_doc_error_constant.exp
@@ -1,0 +1,19 @@
+
+Diagnostics:
+warning: [lint] Error constant is missing a doc comment. The doc comment is used as a human-readable error message.
+  ┌─ tests/module_lints/missing_doc_error_constant.move:3:5
+  │
+3 │     const ENOT_FOUND: u64 = 1;
+  │     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+  │
+  = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_error_constant)]`.
+  = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_error_constant.
+
+warning: [lint] Error constant is missing a doc comment. The doc comment is used as a human-readable error message.
+  ┌─ tests/module_lints/missing_doc_error_constant.move:5:5
+  │
+5 │     const E_PERMISSION_DENIED: u64 = 2;
+  │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  │
+  = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_error_constant)]`.
+  = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_error_constant.

--- a/third_party/move/tools/move-linter/tests/module_lints/missing_doc_error_constant.move
+++ b/third_party/move/tools/move-linter/tests/module_lints/missing_doc_error_constant.move
@@ -1,0 +1,18 @@
+/// Test module for missing_doc_error_constant lint.
+module 0xc0ffee::missing_doc_error_constant {
+    const ENOT_FOUND: u64 = 1;
+
+    const E_PERMISSION_DENIED: u64 = 2;
+
+    /// The requested resource was not found.
+    const ERESOURCE_NOT_FOUND: u64 = 3;
+
+    /// Permission was denied for this operation.
+    const E_UNAUTHORIZED: u64 = 4;
+
+    /// Not an error constant.
+    const MY_CONSTANT: u64 = 42;
+
+    #[lint::skip(missing_doc_error_constant)]
+    const ESKIPPED: u64 = 99;
+}

--- a/third_party/move/tools/move-linter/tests/module_lints/missing_doc_module.exp
+++ b/third_party/move/tools/move-linter/tests/module_lints/missing_doc_module.exp
@@ -1,0 +1,13 @@
+
+Diagnostics:
+warning: [lint] Module is missing a doc comment.
+  ┌─ tests/module_lints/missing_doc_module.move:1:1
+  │
+1 │ ╭ module 0xc0ffee::missing_doc_module {
+2 │ │     /// Dummy.
+3 │ │     const DUMMY: u64 = 0;
+4 │ │ }
+  │ ╰─^
+  │
+  = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_module)]`.
+  = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_module.

--- a/third_party/move/tools/move-linter/tests/module_lints/missing_doc_module.move
+++ b/third_party/move/tools/move-linter/tests/module_lints/missing_doc_module.move
@@ -1,0 +1,16 @@
+module 0xc0ffee::missing_doc_module {
+    /// Dummy.
+    const DUMMY: u64 = 0;
+}
+
+/// This module has a doc comment.
+module 0xc0ffee::documented_module {
+    /// Dummy.
+    const DUMMY: u64 = 0;
+}
+
+#[lint::skip(missing_doc_module)]
+module 0xc0ffee::skipped_module {
+    /// Dummy.
+    const DUMMY: u64 = 0;
+}

--- a/third_party/move/tools/move-linter/tests/module_lints/missing_doc_public_function.exp
+++ b/third_party/move/tools/move-linter/tests/module_lints/missing_doc_public_function.exp
@@ -1,0 +1,19 @@
+
+Diagnostics:
+warning: [lint] Public function is missing a doc comment.
+  ┌─ tests/module_lints/missing_doc_public_function.move:9:16
+  │
+9 │     public fun no_doc_public() {}
+  │                ^^^^^^^^^^^^^
+  │
+  = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+  = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Entry function is missing a doc comment.
+   ┌─ tests/module_lints/missing_doc_public_function.move:11:15
+   │
+11 │     entry fun no_doc_entry() {}
+   │               ^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.

--- a/third_party/move/tools/move-linter/tests/module_lints/missing_doc_public_function.move
+++ b/third_party/move/tools/move-linter/tests/module_lints/missing_doc_public_function.move
@@ -1,0 +1,25 @@
+/// Test module for missing_doc_public_function lint.
+module 0xc0ffee::missing_doc_public_function {
+    /// Documented error constant.
+    const EDUMMY: u64 = 0;
+
+    /// Documented constant.
+    const DUMMY: u64 = 0;
+
+    public fun no_doc_public() {}
+
+    entry fun no_doc_entry() {}
+
+    /// This function has a doc comment.
+    public fun has_doc_public() {}
+
+    /// This entry function has a doc comment.
+    entry fun has_doc_entry() {}
+
+    fun private_no_doc() {}
+
+    public(friend) fun friend_no_doc() {}
+
+    #[lint::skip(missing_doc_public_function)]
+    public fun skipped_no_doc() {}
+}

--- a/third_party/move/tools/move-linter/tests/module_lints/missing_doc_struct.exp
+++ b/third_party/move/tools/move-linter/tests/module_lints/missing_doc_struct.exp
@@ -1,0 +1,24 @@
+
+Diagnostics:
+warning: [lint] Struct is missing a doc comment.
+  ┌─ tests/module_lints/missing_doc_struct.move:3:5
+  │
+3 │ ╭     struct MyStruct has copy, drop {
+4 │ │         value: u64,
+5 │ │     }
+  │ ╰─────^
+  │
+  = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_struct)]`.
+  = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_struct.
+
+warning: [lint] Enum is missing a doc comment.
+   ┌─ tests/module_lints/missing_doc_struct.move:7:5
+   │
+ 7 │ ╭     enum MyEnum has copy, drop {
+ 8 │ │         A,
+ 9 │ │         B(u64),
+10 │ │     }
+   │ ╰─────^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_struct)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_struct.

--- a/third_party/move/tools/move-linter/tests/module_lints/missing_doc_struct.move
+++ b/third_party/move/tools/move-linter/tests/module_lints/missing_doc_struct.move
@@ -1,0 +1,27 @@
+/// Test module for missing_doc_struct lint.
+module 0xc0ffee::missing_doc_struct {
+    struct MyStruct has copy, drop {
+        value: u64,
+    }
+
+    enum MyEnum has copy, drop {
+        A,
+        B(u64),
+    }
+
+    /// This struct has a doc comment.
+    struct DocumentedStruct has copy, drop {
+        value: u64,
+    }
+
+    /// This enum has a doc comment.
+    enum DocumentedEnum has copy, drop {
+        X,
+        Y(u64),
+    }
+
+    #[lint::skip(missing_doc_struct)]
+    struct SkippedStruct has copy, drop {
+        value: u64,
+    }
+}

--- a/third_party/move/tools/move-linter/tests/module_lints/prefer_doc_comment.exp
+++ b/third_party/move/tools/move-linter/tests/module_lints/prefer_doc_comment.exp
@@ -1,0 +1,79 @@
+
+Diagnostics:
+warning: [lint] Use doc comment `///` instead of regular comment `//` for documentable items.
+  ┌─ tests/module_lints/prefer_doc_comment.move:3:1
+  │
+3 │ ╭     // This should be a doc comment on a public function.
+4 │ │     public fun regular_comment_func() {}
+  │ ╰^
+  │
+  = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(prefer_doc_comment)]`.
+  = For more information, see https://aptos.dev/en/build/smart-contracts/linter#prefer_doc_comment.
+
+warning: [lint] Public function is missing a doc comment.
+  ┌─ tests/module_lints/prefer_doc_comment.move:4:16
+  │
+4 │     public fun regular_comment_func() {}
+  │                ^^^^^^^^^^^^^^^^^^^^
+  │
+  = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+  = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Use doc comment `///` instead of regular comment `//` for documentable items.
+   ┌─ tests/module_lints/prefer_doc_comment.move:9:1
+   │
+ 9 │ ╭     // This should be a doc comment on a constant.
+10 │ │     const MY_CONSTANT: u64 = 42;
+   │ ╰^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(prefer_doc_comment)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#prefer_doc_comment.
+
+warning: [lint] Constant is missing a doc comment.
+   ┌─ tests/module_lints/prefer_doc_comment.move:10:5
+   │
+10 │     const MY_CONSTANT: u64 = 42;
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_constant)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_constant.
+
+warning: [lint] Use doc comment `///` instead of regular comment `//` for documentable items.
+   ┌─ tests/module_lints/prefer_doc_comment.move:15:1
+   │
+15 │ ╭     // This should be a doc comment on a struct.
+16 │ │     struct MyStruct has copy, drop {
+   │ ╰^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(prefer_doc_comment)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#prefer_doc_comment.
+
+warning: [lint] Struct is missing a doc comment.
+   ┌─ tests/module_lints/prefer_doc_comment.move:16:5
+   │
+16 │ ╭     struct MyStruct has copy, drop {
+17 │ │         value: u64,
+18 │ │     }
+   │ ╰─────^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_struct)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_struct.
+
+warning: [lint] Use doc comment `///` instead of regular comment `//` for documentable items.
+   ┌─ tests/module_lints/prefer_doc_comment.move:25:1
+   │
+25 │ ╭     // This should be a doc comment on a private function.
+26 │ │     fun private_func() {}
+   │ ╰^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(prefer_doc_comment)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#prefer_doc_comment.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/module_lints/prefer_doc_comment.move:30:16
+   │
+30 │     public fun skipped_func() {}
+   │                ^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.

--- a/third_party/move/tools/move-linter/tests/module_lints/prefer_doc_comment.move
+++ b/third_party/move/tools/move-linter/tests/module_lints/prefer_doc_comment.move
@@ -1,0 +1,31 @@
+/// Test module for prefer_doc_comment lint.
+module 0xc0ffee::prefer_doc_comment {
+    // This should be a doc comment on a public function.
+    public fun regular_comment_func() {}
+
+    /// This is a proper doc comment.
+    public fun doc_comment_func() {}
+
+    // This should be a doc comment on a constant.
+    const MY_CONSTANT: u64 = 42;
+
+    /// Properly documented constant.
+    const DOCUMENTED: u64 = 1;
+
+    // This should be a doc comment on a struct.
+    struct MyStruct has copy, drop {
+        value: u64,
+    }
+
+    /// Properly documented struct.
+    struct DocumentedStruct has copy, drop {
+        value: u64,
+    }
+
+    // This should be a doc comment on a private function.
+    fun private_func() {}
+
+    #[lint::skip(prefer_doc_comment)]
+    // Not flagged: skipped via lint::skip.
+    public fun skipped_func() {}
+}

--- a/third_party/move/tools/move-linter/tests/stackless_bytecode_lints/avoid_copy_on_identity_comparison_warn_01.exp
+++ b/third_party/move/tools/move-linter/tests/stackless_bytecode_lints/avoid_copy_on_identity_comparison_warn_01.exp
@@ -1,5 +1,200 @@
 
 Diagnostics:
+warning: [lint] Struct is missing a doc comment.
+   ┌─ tests/stackless_bytecode_lints/avoid_copy_on_identity_comparison_warn_01.move:10:5
+   │
+10 │ ╭     struct S has copy, drop {
+11 │ │         a: vector<u8>,
+12 │ │         b: vector<u8>,
+13 │ │         c: vector<u8>,
+14 │ │         d: vector<u8>
+15 │ │     }
+   │ ╰─────^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_struct)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_struct.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/stackless_bytecode_lints/avoid_copy_on_identity_comparison_warn_01.move:17:16
+   │
+17 │     public fun test1_warn_no_ref(): (bool, bool) {
+   │                ^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/stackless_bytecode_lints/avoid_copy_on_identity_comparison_warn_01.move:25:16
+   │
+25 │     public fun test2_no_warn_no_ref(): bool {
+   │                ^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/stackless_bytecode_lints/avoid_copy_on_identity_comparison_warn_01.move:31:16
+   │
+31 │     public fun test3_warn_no_ref(a: S, b: S): S {
+   │                ^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/stackless_bytecode_lints/avoid_copy_on_identity_comparison_warn_01.move:37:16
+   │
+37 │     public fun test4_warn_no_ref(a: S, b: S) {
+   │                ^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/stackless_bytecode_lints/avoid_copy_on_identity_comparison_warn_01.move:45:16
+   │
+45 │     public fun test5_warn_no_ref(a: S, b: S) {
+   │                ^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/stackless_bytecode_lints/avoid_copy_on_identity_comparison_warn_01.move:50:16
+   │
+50 │     public fun test1_no_warn_ref(): (bool, bool) {
+   │                ^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/stackless_bytecode_lints/avoid_copy_on_identity_comparison_warn_01.move:58:16
+   │
+58 │     public fun test2_no_warn_ref(): bool {
+   │                ^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/stackless_bytecode_lints/avoid_copy_on_identity_comparison_warn_01.move:64:16
+   │
+64 │     public fun test3_no_warn_ref(a: S, b: S): S {
+   │                ^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/stackless_bytecode_lints/avoid_copy_on_identity_comparison_warn_01.move:68:16
+   │
+68 │     public fun test4_no_warn_ref(a: S, b: S) {
+   │                ^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/stackless_bytecode_lints/avoid_copy_on_identity_comparison_warn_01.move:76:16
+   │
+76 │     public fun test5_no_warn_ref(a: S, b: S) {
+   │                ^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Module is missing a doc comment.
+   ┌─ tests/stackless_bytecode_lints/avoid_copy_on_identity_comparison_warn_01.move:1:1
+   │
+ 1 │ ╭ module 0xc0ffee::m {
+ 2 │ │     fun get_vector_1(): vector<u8> {
+ 3 │ │         vector[1, 2, 3]
+ 4 │ │     }
+   · │
+79 │ │     }
+80 │ │ }
+   │ ╰─^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_module)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_module.
+
+warning: [lint] Struct is missing a doc comment.
+   ┌─ tests/stackless_bytecode_lints/avoid_copy_on_identity_comparison_warn_01.move:84:5
+   │
+84 │ ╭     struct S has copy, drop {
+85 │ │         a: vector<u8>,
+86 │ │         b: vector<u8>,
+87 │ │         c: vector<u8>,
+88 │ │         d: vector<u8>
+89 │ │     }
+   │ ╰─────^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_struct)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_struct.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/stackless_bytecode_lints/avoid_copy_on_identity_comparison_warn_01.move:93:16
+   │
+93 │     public fun test4_warn_no_ref(a: S, b: S) {
+   │                ^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Module is missing a doc comment.
+    ┌─ tests/stackless_bytecode_lints/avoid_copy_on_identity_comparison_warn_01.move:83:1
+    │
+ 83 │ ╭ module 0xc0ffee::no_warn1 {
+ 84 │ │     struct S has copy, drop {
+ 85 │ │         a: vector<u8>,
+ 86 │ │         b: vector<u8>,
+    · │
+ 99 │ │     }
+100 │ │ }
+    │ ╰─^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_module)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_module.
+
+warning: [lint] Struct is missing a doc comment.
+    ┌─ tests/stackless_bytecode_lints/avoid_copy_on_identity_comparison_warn_01.move:103:5
+    │
+103 │ ╭     struct S has copy, drop {
+104 │ │         a: vector<u8>,
+105 │ │         b: vector<u8>,
+106 │ │         c: vector<u8>,
+107 │ │         d: vector<u8>
+108 │ │     }
+    │ ╰─────^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_struct)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_struct.
+
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/stackless_bytecode_lints/avoid_copy_on_identity_comparison_warn_01.move:113:16
+    │
+113 │     public fun test4_warn_no_ref(a: S, b: S) {
+    │                ^^^^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Module is missing a doc comment.
+    ┌─ tests/stackless_bytecode_lints/avoid_copy_on_identity_comparison_warn_01.move:102:1
+    │
+102 │ ╭ module 0xc0ffee::no_warn2 {
+103 │ │     struct S has copy, drop {
+104 │ │         a: vector<u8>,
+105 │ │         b: vector<u8>,
+    · │
+119 │ │     }
+120 │ │ }
+    │ ╰─^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_module)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_module.
+
 warning: [lint] Compare using references of these values instead (i.e., place `&` on both the operands), to avoid unnecessary copies.
    ┌─ tests/stackless_bytecode_lints/avoid_copy_on_identity_comparison_warn_01.move:20:17
    │

--- a/third_party/move/tools/move-linter/tests/stackless_bytecode_lints/needless_mutable_reference_fv.exp
+++ b/third_party/move/tools/move-linter/tests/stackless_bytecode_lints/needless_mutable_reference_fv.exp
@@ -1,2 +1,16 @@
 
-No errors or warnings!
+Diagnostics:
+warning: [lint] Module is missing a doc comment.
+   ┌─ tests/stackless_bytecode_lints/needless_mutable_reference_fv.move:1:1
+   │
+ 1 │ ╭ module 0x42::loop_invalid {
+ 2 │ │
+ 3 │ │     fun apply_to_position_and_return<T>(f: |&mut u64, u64| T): T {
+ 4 │ │         let x = 42;
+   · │
+17 │ │     }
+18 │ │ }
+   │ ╰─^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_module)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_module.

--- a/third_party/move/tools/move-linter/tests/stackless_bytecode_lints/needless_mutable_reference_warn.exp
+++ b/third_party/move/tools/move-linter/tests/stackless_bytecode_lints/needless_mutable_reference_warn.exp
@@ -1,5 +1,175 @@
 
 Diagnostics:
+warning: [lint] Struct is missing a doc comment.
+   ┌─ tests/stackless_bytecode_lints/needless_mutable_reference_warn.move:28:5
+   │
+28 │ ╭     struct S {
+29 │ │         x: u64,
+30 │ │         y: U,
+31 │ │     }
+   │ ╰─────^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_struct)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_struct.
+
+warning: [lint] Struct is missing a doc comment.
+   ┌─ tests/stackless_bytecode_lints/needless_mutable_reference_warn.move:33:5
+   │
+33 │ ╭     struct U {
+34 │ │         u: u64,
+35 │ │     }
+   │ ╰─────^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_struct)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_struct.
+
+warning: [lint] Module is missing a doc comment.
+   ┌─ tests/stackless_bytecode_lints/needless_mutable_reference_warn.move:1:1
+   │
+ 1 │ ╭ module 0xc0ffee::m {
+ 2 │ │     fun consume_mut(x: &mut u64) {
+ 3 │ │         *x = 10;
+ 4 │ │     }
+   · │
+62 │ │     }
+63 │ │ }
+   │ ╰─^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_module)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_module.
+
+warning: [lint] Struct is missing a doc comment.
+   ┌─ tests/stackless_bytecode_lints/needless_mutable_reference_warn.move:67:5
+   │
+67 │ ╭     struct R has key, store {
+68 │ │         x: u64
+69 │ │     }
+   │ ╰─────^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_struct)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_struct.
+
+warning: [lint] Struct is missing a doc comment.
+   ┌─ tests/stackless_bytecode_lints/needless_mutable_reference_warn.move:71:5
+   │
+71 │ ╭     struct S has key {
+72 │ │         r: R
+73 │ │     }
+   │ ╰─────^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_struct)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_struct.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/stackless_bytecode_lints/needless_mutable_reference_warn.move:75:16
+   │
+75 │     public fun test_no_warn_1(addr: address) acquires R {
+   │                ^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/stackless_bytecode_lints/needless_mutable_reference_warn.move:80:16
+   │
+80 │     public fun test_no_warn_2(addr: address): u64 acquires R {
+   │                ^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/stackless_bytecode_lints/needless_mutable_reference_warn.move:87:16
+   │
+87 │     public fun test_no_warn_3(addr: address) acquires S {
+   │                ^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Public function is missing a doc comment.
+   ┌─ tests/stackless_bytecode_lints/needless_mutable_reference_warn.move:99:16
+   │
+99 │     public fun test_no_warn_4(addr: address, p: bool) acquires R {
+   │                ^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/stackless_bytecode_lints/needless_mutable_reference_warn.move:108:16
+    │
+108 │     public fun test_warn_1(addr: address) acquires R {
+    │                ^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/stackless_bytecode_lints/needless_mutable_reference_warn.move:113:16
+    │
+113 │     public fun test_warn_2(addr: address): u64 acquires R {
+    │                ^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Module is missing a doc comment.
+    ┌─ tests/stackless_bytecode_lints/needless_mutable_reference_warn.move:66:1
+    │
+ 66 │ ╭ module 0xc0ffee::n {
+ 67 │ │     struct R has key, store {
+ 68 │ │         x: u64
+ 69 │ │     }
+    · │
+133 │ │     }
+134 │ │ }
+    │ ╰─^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_module)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_module.
+
+warning: [lint] Enum is missing a doc comment.
+    ┌─ tests/stackless_bytecode_lints/needless_mutable_reference_warn.move:137:5
+    │
+137 │ ╭     enum E has drop {
+138 │ │         A(u64),
+139 │ │         B(u64),
+140 │ │     }
+    │ ╰─────^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_struct)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_struct.
+
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/stackless_bytecode_lints/needless_mutable_reference_warn.move:173:16
+    │
+173 │     public fun test_warn_3(x: &mut u64) {
+    │                ^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/stackless_bytecode_lints/needless_mutable_reference_warn.move:178:16
+    │
+178 │     public fun test_no_warn_3(x: &mut u64) {
+    │                ^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Struct is missing a doc comment.
+    ┌─ tests/stackless_bytecode_lints/needless_mutable_reference_warn.move:195:5
+    │
+195 │ ╭     struct S has drop {
+196 │ │         x: u64,
+197 │ │     }
+    │ ╰─────^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_struct)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_struct.
+
 warning: [lint] Needless pair of `*` and `&mut` operators: consider removing them
     ┌─ tests/stackless_bytecode_lints/needless_mutable_reference_warn.move:200:9
     │
@@ -18,6 +188,17 @@ warning: [lint] Needless pair of `*` and `&mut` operators: consider removing the
     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(needless_deref_ref)]`.
     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#needless_deref_ref.
 
+warning: [lint] Struct is missing a doc comment.
+    ┌─ tests/stackless_bytecode_lints/needless_mutable_reference_warn.move:207:5
+    │
+207 │ ╭     struct U has copy, drop {
+208 │ │         x: u64,
+209 │ │     }
+    │ ╰─────^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_struct)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_struct.
+
 warning: [lint] Needless pair of `*` and `&mut` operators: consider removing them
     ┌─ tests/stackless_bytecode_lints/needless_mutable_reference_warn.move:212:9
     │
@@ -26,6 +207,124 @@ warning: [lint] Needless pair of `*` and `&mut` operators: consider removing the
     │
     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(needless_deref_ref)]`.
     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#needless_deref_ref.
+
+warning: [lint] Use doc comment `///` instead of regular comment `//` for documentable items.
+    ┌─ tests/stackless_bytecode_lints/needless_mutable_reference_warn.move:215:1
+    │
+215 │ ╭     // This should produce a warning once `vector::borrow_mut` is added to origins.
+216 │ │     fun test_warn_7(): u64 {
+    │ ╰^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(prefer_doc_comment)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#prefer_doc_comment.
+
+warning: [lint] Module is missing a doc comment.
+    ┌─ tests/stackless_bytecode_lints/needless_mutable_reference_warn.move:136:1
+    │
+136 │ ╭ module 0xc0ffee::o {
+137 │ │     enum E has drop {
+138 │ │         A(u64),
+139 │ │         B(u64),
+    · │
+220 │ │     }
+221 │ │ }
+    │ ╰─^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_module)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_module.
+
+warning: [lint] Struct is missing a doc comment.
+    ┌─ tests/stackless_bytecode_lints/needless_mutable_reference_warn.move:224:5
+    │
+224 │ ╭     struct S has copy, drop {
+225 │ │         x: u64
+226 │ │     }
+    │ ╰─────^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_struct)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_struct.
+
+warning: [lint] Module is missing a doc comment.
+    ┌─ tests/stackless_bytecode_lints/needless_mutable_reference_warn.move:223:1
+    │
+223 │ ╭ module 0xc0ffee::more_struct_tests {
+224 │ │     struct S has copy, drop {
+225 │ │         x: u64
+226 │ │     }
+    · │
+254 │ │     }
+255 │ │ }
+    │ ╰─^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_module)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_module.
+
+warning: [lint] Module is missing a doc comment.
+    ┌─ tests/stackless_bytecode_lints/needless_mutable_reference_warn.move:257:1
+    │
+257 │ ╭ module 0xc0ffee::p {
+258 │ │     fun no_warn_01(_x: &mut u64) {
+259 │ │         let x = 1;
+260 │ │         let _y = &mut x;
+261 │ │     }
+262 │ │ }
+    │ ╰─^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_module)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_module.
+
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/stackless_bytecode_lints/needless_mutable_reference_warn.move:265:16
+    │
+265 │     public fun no_warn_01(x: &mut u64): &mut u64 {
+    │                ^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Struct is missing a doc comment.
+    ┌─ tests/stackless_bytecode_lints/needless_mutable_reference_warn.move:269:5
+    │
+269 │ ╭     struct W {
+270 │ │         x: u64,
+271 │ │     }
+    │ ╰─────^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_struct)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_struct.
+
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/stackless_bytecode_lints/needless_mutable_reference_warn.move:273:16
+    │
+273 │     public fun no_warn_02(w: &mut W): &mut u64 {
+    │                ^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Public function is missing a doc comment.
+    ┌─ tests/stackless_bytecode_lints/needless_mutable_reference_warn.move:277:16
+    │
+277 │     public fun warn_01(x: &mut u64): &u64 {
+    │                ^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_public_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_public_function.
+
+warning: [lint] Module is missing a doc comment.
+    ┌─ tests/stackless_bytecode_lints/needless_mutable_reference_warn.move:264:1
+    │
+264 │ ╭ module 0xc0ffee::q {
+265 │ │     public fun no_warn_01(x: &mut u64): &mut u64 {
+266 │ │         x
+267 │ │     }
+    · │
+279 │ │     }
+280 │ │ }
+    │ ╰─^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(missing_doc_module)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#missing_doc_module.
 
 warning: [lint] Needless mutable reference or borrow: consider using immutable reference or borrow instead
    ┌─ tests/stackless_bytecode_lints/needless_mutable_reference_warn.move:14:17


### PR DESCRIPTION
## Description
Fixes some clippy errors that was happening locally, as well as:

Add some experimental lints based around doc comments, and error messages

```

  ┌─────┬─────────────────────────────┬─────────┬───────────────────────────────────────────────────────────────┐
  │  #  │            Lint             │  Level  │                        What it checks                         │
  ├─────┼─────────────────────────────┼─────────┼───────────────────────────────────────────────────────────────┤
  │ 1   │ missing_doc_public_function │ default │ Public/entry functions need /// doc comments                  │
  ├─────┼─────────────────────────────┼─────────┼───────────────────────────────────────────────────────────────┤
  │ 2   │ missing_doc_constant        │ default │ Non-error constants need doc comments                         │
  ├─────┼─────────────────────────────┼─────────┼───────────────────────────────────────────────────────────────┤
  │ 3   │ missing_doc_error_constant  │ default │ E-prefix constants need doc comments (used as error messages) │
  ├─────┼─────────────────────────────┼─────────┼───────────────────────────────────────────────────────────────┤
  │ 4   │ error_constant_naming       │ default │ E-prefix constants must use E_FOO or EFOO pattern             │
  ├─────┼─────────────────────────────┼─────────┼───────────────────────────────────────────────────────────────┤
  │ 5   │ error_message_too_long      │ default │ Error constant doc comments max 128 bytes                     │
  ├─────┼─────────────────────────────┼─────────┼───────────────────────────────────────────────────────────────┤
  │ 6   │ missing_doc_module          │ strict  │ Modules need doc comments                                     │
  ├─────┼─────────────────────────────┼─────────┼───────────────────────────────────────────────────────────────┤
  │ 7   │ missing_doc_struct          │ strict  │ Structs/enums need doc comments                               │
  ├─────┼─────────────────────────────┼─────────┼───────────────────────────────────────────────────────────────┤
  │ 8   │ prefer_doc_comment          │ strict  │ // before items should be ///                                 │
  └─────┴─────────────────────────────┴─────────┴───────────────────────────────────────────────────────────────┘
```

## How Has This Been Tested?
See generated tests

## Key Areas to Review
These should all be experimental.  They're more like pedantic checks (except the error lint)

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [x] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
