### PR TITLE
[vm] Update activation times for revised bounds feature

### DIFF
--- a/types/src/on_chain_config/timed_features.rs
+++ b/types/src/on_chain_config/timed_features.rs
@@ -213,7 +213,7 @@ impl TimedFeatureFlag {
                 .with_timezone(&Utc),
 
             (RevisedBoundsInProdConfig, TESTNET) => Los_Angeles
-                .with_ymd_and_hms(2026, 3, 3, 12, 0, 0)
+                .with_ymd_and_hms(2026, 3, 3, 21, 0, 0)
                 .unwrap()
                 .with_timezone(&Utc),
             (RevisedBoundsInProdConfig, MAINNET) => Los_Angeles


### PR DESCRIPTION
Update timing

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the scheduled activation timestamps for a production verifier-bounds feature on testnet/mainnet, which can alter when stricter verification behavior takes effect. Risk is limited to timing/rollout but could impact transaction validation around the cutover.
> 
> **Overview**
> Adjusts the on-chain timed feature schedule for `RevisedBoundsInProdConfig`.
> 
> Testnet activation is moved earlier (to `2026-03-03 21:00` Los Angeles), and mainnet activation is moved later (to `2026-03-05 10:00` Los Angeles). Removes the temporary “DO NOT SUBMIT” timing comment.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1da2cdc7886b0603bacdc32ec1d28719cad69852. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->