### PR TITLE
[forge] Clean up deployer resources on start

### DIFF
--- a/testsuite/forge/src/backend/k8s/kube_api.rs
+++ b/testsuite/forge/src/backend/k8s/kube_api.rs
@@ -3,7 +3,7 @@
 
 use async_trait::async_trait;
 use kube::{
-    api::{Api, ListParams, PostParams},
+    api::{Api, DeleteParams, ListParams, PostParams},
     client::Client as K8sClient,
     Error as KubeError, Resource as ApiResource,
 };
@@ -40,6 +40,7 @@ where
 pub trait ReadWrite<K>: Send + Sync {
     async fn get(&self, name: &str) -> Result<K, KubeError>;
     async fn create(&self, pp: &PostParams, k: &K) -> Result<K, KubeError>;
+    async fn delete(&self, name: &str, dp: &DeleteParams) -> Result<(), KubeError>;
     async fn get_status(&self, name: &str) -> Result<K, KubeError>;
     async fn list(&self, lp: &ListParams) -> Result<Vec<K>, KubeError>;
 }
@@ -57,6 +58,10 @@ where
 
     async fn create(&self, pp: &PostParams, k: &K) -> Result<K, KubeError> {
         self.api.create(pp, k).await
+    }
+
+    async fn delete(&self, name: &str, dp: &DeleteParams) -> Result<(), KubeError> {
+        self.api.delete(name, dp).await.map(|_| ())
     }
 
     async fn get_status(&self, name: &str) -> Result<K, KubeError> {
@@ -78,7 +83,7 @@ pub mod mocks {
     use hyper::StatusCode;
     use k8s_openapi::Metadata;
     use kube::{
-        api::{ListParams, ObjectMeta, PostParams},
+        api::{DeleteParams, ListParams, ObjectMeta, PostParams},
         error::ErrorResponse,
         Error as KubeError,
     };
@@ -188,6 +193,20 @@ pub mod mocks {
             Ok(resource.clone())
         }
 
+        async fn delete(&self, name: &str, _dp: &DeleteParams) -> Result<(), KubeError> {
+            let mut resources = self.resources.lock();
+            if resources.remove(name).is_some() {
+                Ok(())
+            } else {
+                Err(KubeError::Api(ErrorResponse {
+                    status: "failed".to_string(),
+                    message: format!("Resource with name {} could not be found", name),
+                    reason: "not_found".to_string(),
+                    code: 404,
+                }))
+            }
+        }
+
         async fn get_status(&self, _name: &str) -> Result<T, KubeError> {
             todo!()
         }
@@ -230,6 +249,16 @@ pub mod mocks {
                 status: status.to_string(),
                 code: status.as_u16(),
                 message: "Failed to create resource".to_string(),
+                reason: "Failed to parse error data".into(),
+            }))
+        }
+
+        async fn delete(&self, _name: &str, _dp: &DeleteParams) -> Result<(), KubeError> {
+            let status = StatusCode::from_u16(self.status_code).unwrap();
+            Err(KubeError::Api(ErrorResponse {
+                status: status.to_string(),
+                code: status.as_u16(),
+                message: "Failed to delete resource".to_string(),
                 reason: "Failed to parse error data".into(),
             }))
         }

--- a/testsuite/forge/src/backend/k8s_deployer/deployer.rs
+++ b/testsuite/forge/src/backend/k8s_deployer/deployer.rs
@@ -13,7 +13,7 @@ use k8s_openapi::api::{
     rbac::v1::RoleBinding,
 };
 use kube::{
-    api::{ObjectMeta, PostParams},
+    api::{DeleteParams, ObjectMeta, PostParams},
     ResourceExt,
 };
 use log::info;
@@ -162,11 +162,13 @@ impl ForgeDeployerManager {
     }
 
     /**
-     * Start the deployer job in the cluster. Ensures the namespace is prepared and then creates the configmap and job.
-     * This will fail if the job or configmap already exists in the namespace.
+     * Start the deployer job in the cluster. Ensures the namespace is prepared, cleans up any
+     * pre-existing deployer resources (from interrupted previous runs), then creates the
+     * configmap and job.
      */
     pub async fn start(&self, config: serde_json::Value) -> Result<()> {
         self.ensure_namespace_prepared().await?;
+        self.cleanup_deployer_resources().await;
         let config_map = self.build_forge_deployer_k8s_config_map(config)?;
         let job = self.build_forge_deployer_k8s_job(config_map.name())?;
         info!("Creating forge deployer configmap: {}", config_map.name());
@@ -176,6 +178,46 @@ impl ForgeDeployerManager {
         info!("Creating forge deployer job: {}", job.name());
         self.jobs_api.create(&PostParams::default(), &job).await?;
         Ok(())
+    }
+
+    /// Clean up any pre-existing deployer resources (configmap and job) from a previous run.
+    /// This handles the case where a CI run was interrupted before cleanup could happen,
+    /// leaving behind resources that would cause 409 AlreadyExists errors.
+    /// Errors are logged and ignored since the resources may not exist.
+    async fn cleanup_deployer_resources(&self) {
+        let name = self.get_name();
+        info!("Cleaning up pre-existing deployer resources for: {}", &name);
+
+        // Delete the job first, then the configmap (reverse order of creation)
+        match self.jobs_api.delete(&name, &DeleteParams::default()).await {
+            Ok(_) => info!("Deleted pre-existing deployer job: {}", &name),
+            Err(kube::Error::Api(api_err)) if api_err.code == 404 => {
+                info!("No pre-existing deployer job found: {}", &name);
+            },
+            Err(e) => {
+                info!(
+                    "Failed to delete pre-existing deployer job {}: {:?}. Continuing anyway.",
+                    &name, e
+                );
+            },
+        }
+
+        match self
+            .config_maps_api
+            .delete(&name, &DeleteParams::default())
+            .await
+        {
+            Ok(_) => info!("Deleted pre-existing deployer configmap: {}", &name),
+            Err(kube::Error::Api(api_err)) if api_err.code == 404 => {
+                info!("No pre-existing deployer configmap found: {}", &name);
+            },
+            Err(e) => {
+                info!(
+                    "Failed to delete pre-existing deployer configmap {}: {:?}. Continuing anyway.",
+                    &name, e
+                );
+            },
+        }
     }
 
     fn build_namespace(&self) -> Namespace {
@@ -301,8 +343,8 @@ mod tests {
             .unwrap_or_else(|_| panic!("Expected configmap {} to exist", indexer_deployer_name));
     }
 
-    /// Test starting a deployer with an existing job in the namespace. This should fail as the job already exists
-    /// and we cannot override/mutate it.
+    /// Test starting a deployer with an existing job in the namespace. The deployer should
+    /// clean up the pre-existing resources and succeed.
     #[tokio::test]
     async fn test_start_deployer_existing_job() {
         let mut manager = get_mock_forge_deployer_manager();
@@ -322,8 +364,41 @@ mod tests {
             },
             ..Default::default()
         }));
-        let result = manager.start(config).await;
-        assert!(result.is_err());
+        // Should succeed because start() cleans up pre-existing resources
+        manager.start(config).await.unwrap();
+    }
+
+    /// Test starting a deployer with both an existing job and configmap. The deployer should
+    /// clean up both pre-existing resources and succeed.
+    #[tokio::test]
+    async fn test_start_deployer_existing_job_and_configmap() {
+        let mut manager = get_mock_forge_deployer_manager();
+        let config = serde_json::from_value(json!(
+            {
+                "profile": "large-banana",
+                "era": "1",
+                "namespace": manager.namespace.clone(),
+            }
+        ))
+        .expect("Issue creating Forge deployer config");
+        manager.jobs_api = Arc::new(MockK8sResourceApi::from_resource(Job {
+            metadata: ObjectMeta {
+                name: Some(manager.get_name()),
+                namespace: Some(manager.namespace.clone()),
+                ..Default::default()
+            },
+            ..Default::default()
+        }));
+        manager.config_maps_api = Arc::new(MockK8sResourceApi::from_resource(ConfigMap {
+            metadata: ObjectMeta {
+                name: Some(manager.get_name()),
+                namespace: Some(manager.namespace.clone()),
+                ..Default::default()
+            },
+            ..Default::default()
+        }));
+        // Should succeed because start() cleans up pre-existing resources
+        manager.start(config).await.unwrap();
     }
 
     /// Test ensure_namespace_prepared creates the namespace, serviceaccount, and rolebinding


### PR DESCRIPTION
## Summary
- Adds a `delete` method to the `ReadWrite` K8s API trait
- `ForgeDeployerManager::start()` now cleans up pre-existing deployer configmaps and jobs before creating new ones
- Fixes 409 `AlreadyExists` errors when CI is restarted mid-forge-run, since the `Drop` cleanup on `K8sSwarm` may not execute when CI kills the process

Context: https://github.com/aptos-labs/aptos-core/actions/runs/22594419582/job/65465081972?pr=18900

## Test plan
- [x] Existing deployer tests pass (5/5)
- [x] New test `test_start_deployer_existing_job_and_configmap` verifies cleanup of both pre-existing configmap and job
- [x] `test_start_deployer_existing_job` updated to verify success (previously expected failure)
- [ ] Verify on CI that forge runs succeed after restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds automatic deletion of existing deployer `Job`/`ConfigMap` before creating new ones, which can remove unexpected in-flight resources if names collide or deletion semantics differ across clusters. The change is localized to forge deployer startup but touches k8s lifecycle behavior and test mocks via a new `ReadWrite::delete` trait method.
> 
> **Overview**
> Forge deployer startup is now **idempotent across interrupted CI runs** by deleting any pre-existing deployer `Job` and `ConfigMap` before recreating them, avoiding 409 *AlreadyExists* failures.
> 
> To support this, the k8s API abstraction (`ReadWrite`) adds a `delete` method with implementations in `K8sApi` and the test mocks, and deployer tests are updated/extended to assert startup succeeds when prior resources already exist.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 882c7419803198cb9a6c32f384f4f6dc583d881f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->