### PR TITLE
[deps] Remove jemalloc-sys shim and upgrade indexer-grpc-gateway to tikv-jemalloc 0.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2432,8 +2432,8 @@ dependencies = [
  "futures",
  "http-body-util",
  "hyper-util",
- "jemallocator",
  "serde",
+ "tikv-jemallocator",
  "tokio",
  "tonic 0.12.3",
  "tracing",
@@ -11472,24 +11472,6 @@ name = "itoa"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
-
-[[package]]
-name = "jemalloc-sys"
-version = "0.5.4+5.3.0-patched"
-source = "git+https://github.com/aptos-labs/jemalloc-sys-shim?rev=e0920246dd74303fab9a14b990768c6ac990a59b#e0920246dd74303fab9a14b990768c6ac990a59b"
-dependencies = [
- "tikv-jemalloc-sys",
-]
-
-[[package]]
-name = "jemallocator"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0de374a9f8e63150e6f5e8a60cc14c668226d7a347d8aee1a45766e3c4dd3bc"
-dependencies = [
- "jemalloc-sys",
- "libc",
-]
 
 [[package]]
 name = "jobserver"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -973,8 +973,3 @@ ark-ff-macros = { git = "https://github.com/aptos-labs/algebra", branch = "fix-f
 ark-ff-asm = { git = "https://github.com/aptos-labs/algebra", branch = "fix-fft-parallelism-cutoff" }
 ark-poly = { git = "https://github.com/aptos-labs/algebra", branch = "fix-fft-parallelism-cutoff" }
 ark-serialize = { git = "https://github.com/aptos-labs/algebra", branch = "fix-fft-parallelism-cutoff" }
-
-# There is a circular dependency between aptos-core, aptos-indexer-processor-sdk, and aptos-indexer-processors-v2,
-# so we cannot simply change the version and package for `jemalloc-sys` in one repo without running into conflicts.
-# We have to keep this shim until everything uses the same jemalloc dependency.
-jemalloc-sys = { git = "https://github.com/aptos-labs/jemalloc-sys-shim", rev = "e0920246dd74303fab9a14b990768c6ac990a59b" }

--- a/ecosystem/indexer-grpc/indexer-grpc-gateway/Cargo.toml
+++ b/ecosystem/indexer-grpc/indexer-grpc-gateway/Cargo.toml
@@ -29,7 +29,4 @@ tracing = { workspace = true }
 url = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
-jemallocator = { version = "0.5.0", features = [
-    "profiling",
-    "unprefixed_malloc_on_supported_platforms",
-] }
+jemallocator = { workspace = true }


### PR DESCRIPTION

`aptos-indexer-grpc-gateway` was the last crate hardcoding `jemallocator = "0.5.0"` instead
of using the workspace dependency (`tikv-jemallocator` 0.6.1). This forced a `jemalloc-sys`
shim (from `aptos-labs/jemalloc-sys-shim`) to bridge the old `jemalloc-sys` 0.5 with
`tikv-jemalloc-sys` 0.6 to avoid duplicate native `links = "jemalloc"` conflicts.

Now that both external repos (`aptos-indexer-processor-sdk` and `aptos-indexer-processors-v2`)
have already upgraded to tikv-jemalloc 0.6, switching the gateway to `jemallocator = { workspace = true }`
eliminates the last consumer of the old path and allows removing the shim entirely.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the global allocator dependency wiring for `aptos-indexer-grpc-gateway`, which can affect runtime memory behavior and native linking, but it’s a targeted dependency unification with no functional logic changes.
> 
> **Overview**
> Aligns `aptos-indexer-grpc-gateway`’s unix allocator dependency to `jemallocator = { workspace = true }` (workspace `tikv-jemallocator` 0.6.x) instead of pinning `jemallocator` 0.5.
> 
> Removes the workspace `[patch.crates-io]` override for the `jemalloc-sys` shim and updates `Cargo.lock` to drop the old `jemallocator`/`jemalloc-sys` entries in favor of `tikv-jemallocator`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bbb6418a4690566e669fbaa705d3e37fea271aa5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->