### PR TITLE
[vm] Fix sequence number for failed encrypted transactions

### DIFF
--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -1099,14 +1099,15 @@ impl AptosVM {
             },
             TransactionExecutableRef::Encrypted => {
                 // If the executable is still `Encrypted` here, it means that decryption
-                // failed. The transaction is kept on chain as aborted.
-                // TODO(ibalajiarun): Figure out better status code
-                let status_code = StatusCode::ABORTED;
-                let vm_status = VMStatus::Executed;
-                let txn_status =
-                    TransactionStatus::Keep(ExecutionStatus::MiscellaneousError(Some(status_code)));
-                let vm_output = VMOutput::empty_with_status(txn_status);
-                return Ok((vm_status, vm_output));
+                // failed. Return an error so the caller runs the failure epilogue, which
+                // increments the sequence number and charges gas.
+                return Err(VMStatus::error(
+                    StatusCode::FAILED_TO_DESERIALIZE_ARGUMENT,
+                    Some(
+                        "Encrypted transaction decryption failed; payload not available"
+                            .to_string(),
+                    ),
+                ));
             },
             // Not reachable as this function should only be invoked for entry or script
             // transaction payload.

--- a/aptos-move/e2e-move-tests/src/tests/vm.rs
+++ b/aptos-move/e2e-move-tests/src/tests/vm.rs
@@ -3,8 +3,16 @@
 
 use crate::MoveHarness;
 use aptos_cached_packages::aptos_stdlib::aptos_account_transfer;
+use aptos_crypto::HashValue;
 use aptos_types::{
-    state_store::state_key::StateKey, transaction::ExecutionStatus, write_set::WriteOp,
+    on_chain_config::FeatureFlag,
+    secret_sharing::{Ciphertext, EvalProof},
+    state_store::state_key::StateKey,
+    transaction::{
+        encrypted_payload::EncryptedPayload, ExecutionStatus, TransactionExtraConfig,
+        TransactionPayload,
+    },
+    write_set::WriteOp,
 };
 use aptos_vm::AptosVM;
 use aptos_vm_environment::environment::AptosEnvironment;
@@ -51,5 +59,63 @@ fn failed_transaction_cleanup_charges_gas(status_code: StatusCode) {
     assert_ok_eq!(
         output.status().as_kept_status(),
         ExecutionStatus::MiscellaneousError(Some(status_code))
+    );
+}
+
+// When an encrypted transaction fails decryption, it should still be kept on chain
+// with the sequence number incremented and gas charged.
+#[test]
+fn failed_encrypted_transaction_increments_sequence_number() {
+    let mut h = MoveHarness::new_with_features(vec![FeatureFlag::ENCRYPTED_TRANSACTIONS], vec![]);
+
+    let initial_seq_num = 10;
+    // Needs sufficient balance to cover max_gas_amount (2M) * gas_unit_price (100) = 200M octas.
+    let sender = h.new_account_with_balance_and_sequence_number(1_000_000_000, initial_seq_num);
+
+    let ciphertext = Ciphertext::random();
+    let extra_config = TransactionExtraConfig::V1 {
+        multisig_address: None,
+        replay_protection_nonce: None,
+    };
+    let payload_hash = HashValue::random();
+
+    // Sign the transaction in the Encrypted state (the original state before decryption
+    // is attempted). The signature is verified against this state.
+    let encrypted_payload = EncryptedPayload::Encrypted {
+        ciphertext: ciphertext.clone(),
+        extra_config: extra_config.clone(),
+        payload_hash,
+    };
+    let payload = TransactionPayload::EncryptedPayload(encrypted_payload);
+    let mut txn = h.create_transaction_payload(&sender, payload);
+
+    // Mutate the payload to simulate a failed decryption attempt, as the block executor
+    // would do after failing to decrypt the ciphertext.
+    let failed_payload = EncryptedPayload::FailedDecryption {
+        ciphertext,
+        extra_config,
+        payload_hash,
+        eval_proof: EvalProof::random(),
+    };
+    *txn.payload_mut() = TransactionPayload::EncryptedPayload(failed_payload);
+
+    let output = h.run_raw(txn);
+
+    // Transaction should be kept, not discarded.
+    assert!(
+        !output.status().is_discarded(),
+        "Expected transaction to be kept, but got: {:?}",
+        output.status()
+    );
+
+    // Gas should be charged.
+    assert!(output.gas_used() > 0);
+
+    // Sequence number should have been incremented.
+    let new_seq_num = h.sequence_number(sender.address());
+    assert_eq!(
+        new_seq_num,
+        initial_seq_num + 1,
+        "Sequence number should be incremented after failed encrypted transaction"
     );
 }


### PR DESCRIPTION
## Summary
- Fixed a bug where failed encrypted transactions were kept on chain but the sequence number was not incremented
- The `Encrypted` arm in `execute_script_or_entry_function` was returning an early `Ok(VMOutput::empty_with_status(...))`, bypassing the failure epilogue (which increments sequence number and charges gas)
- Changed to return `Err(VMStatus::error(FAILED_TO_DESERIALIZE_ARGUMENT, ...))` so the caller routes through `failed_transaction_cleanup` → failure epilogue
- Added e2e test verifying the transaction is kept, gas is charged, and sequence number is incremented

## Test plan
- [x] Added `failed_encrypted_transaction_increments_sequence_number` test in `e2e-move-tests`
- [ ] Existing `failed_transaction_cleanup_charges_gas` tests still pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)