### PR TITLE
[vm] Charge minimum gas for encrypted transactions

### DIFF
--- a/aptos-move/aptos-abstract-gas-usage/src/algebra.rs
+++ b/aptos-move/aptos-abstract-gas-usage/src/algebra.rs
@@ -11,6 +11,7 @@ use aptos_vm_types::storage::{
     io_pricing::IoPricing, space_pricing::DiskSpacePricing, StorageGasParameters,
 };
 use move_binary_format::errors::PartialVMResult;
+use std::fmt::Debug;
 use std::sync::{Arc, Mutex};
 
 /// Algebra to record abstract gas usage
@@ -50,6 +51,17 @@ impl<A: GasAlgebra> GasAlgebra for CalibrationAlgebra<A> {
 
     fn check_consistency(&self) -> PartialVMResult<()> {
         self.base.check_consistency()
+    }
+
+    fn charge_additional_fee(
+        &mut self,
+        abstract_amount: impl GasExpression<VMGasParameters, Unit = InternalGasUnit> + Debug,
+    ) -> PartialVMResult<()> {
+        self.base.charge_additional_fee(abstract_amount)
+    }
+
+    fn additional_fee_used(&self) -> InternalGas {
+        self.base.additional_fee_used()
     }
 
     fn charge_execution(

--- a/aptos-move/aptos-gas-meter/src/algebra.rs
+++ b/aptos-move/aptos-gas-meter/src/algebra.rs
@@ -42,6 +42,8 @@ where
     // The storage fee consumed by the storage operations.
     storage_fee_used: Fee,
 
+    additional_fee_used: InternalGas,
+
     num_dependencies: NumModules,
     total_dependency_size: NumBytes,
 
@@ -99,6 +101,7 @@ where
             max_storage_fee,
             storage_fee_in_internal_units: 0.into(),
             storage_fee_used: 0.into(),
+            additional_fee_used: 0.into(),
             num_dependencies: 0.into(),
             total_dependency_size: 0.into(),
             block_synchronization_kill_switch,
@@ -150,17 +153,18 @@ where
             })?;
 
         let total_calculated =
-            self.execution_gas_used + self.io_gas_used + self.storage_fee_in_internal_units;
+            self.execution_gas_used + self.io_gas_used + self.storage_fee_in_internal_units + self.additional_fee_used;
         if total != total_calculated {
             return Err(
                 PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR).with_message(
                     format!(
-                        "The per-category costs do not add up. {} (total) != {} = {} (exec) + {} (io) + {} (storage)",
+                        "The per-category costs do not add up. {} (total) != {} = {} (exec) + {} (io) + {} (storage) + {} (additional)",
                         total,
                         total_calculated,
                         self.execution_gas_used,
                         self.io_gas_used,
                         self.storage_fee_in_internal_units,
+                        self.additional_fee_used,
                     ),
                 ),
             );
@@ -206,6 +210,32 @@ where
         } else {
             Ok(())
         }
+    }
+
+    fn charge_additional_fee(
+        &mut self,
+        abstract_amount: impl GasExpression<VMGasParameters, Unit = InternalGasUnit> + Debug,
+    ) -> PartialVMResult<()> {
+        let amount = abstract_amount.evaluate(self.feature_version, &self.vm_gas_params);
+
+        match self.balance.checked_sub(amount) {
+            Some(new_balance) => {
+                self.balance = new_balance;
+                self.additional_fee_used += amount;
+            },
+            None => {
+                let old_balance = self.balance;
+                self.balance = 0.into();
+                self.additional_fee_used += old_balance;
+                return Err(PartialVMError::new(StatusCode::OUT_OF_GAS));
+            },
+        };
+
+        Ok(())
+    }
+
+    fn additional_fee_used(&self) -> InternalGas {
+        self.additional_fee_used
     }
 
     fn charge_io(

--- a/aptos-move/aptos-gas-meter/src/meter.rs
+++ b/aptos-move/aptos-gas-meter/src/meter.rs
@@ -640,7 +640,7 @@ where
         }
 
         self.algebra
-            .charge_execution(ENCRYPTED_TXN_BASE_COST)
+            .charge_additional_fee(ENCRYPTED_TXN_BASE_COST)
             .map_err(|e| e.finish(Location::Undefined))
     }
 }

--- a/aptos-move/aptos-gas-meter/src/meter.rs
+++ b/aptos-move/aptos-gas-meter/src/meter.rs
@@ -633,6 +633,16 @@ where
             .charge_execution(SLH_DSA_SHA2_128S_BASE_COST)
             .map_err(|e| e.finish(Location::Undefined))
     }
+
+    fn charge_encrypted_txn(&mut self) -> VMResult<()> {
+        if self.feature_version() < RELEASE_V1_44 {
+            return Ok(());
+        }
+
+        self.algebra
+            .charge_execution(ENCRYPTED_TXN_BASE_COST)
+            .map_err(|e| e.finish(Location::Undefined))
+    }
 }
 
 impl<A> CacheValueSizes for StandardGasMeter<A>

--- a/aptos-move/aptos-gas-meter/src/traits.rs
+++ b/aptos-move/aptos-gas-meter/src/traits.rs
@@ -132,6 +132,10 @@ pub trait AptosGasMeter: MoveGasMeter {
     /// expensive computation required (5x more expensive than ed25519).
     fn charge_slh_dsa_sha2_128s(&mut self) -> VMResult<()>;
 
+    /// Charges an additional cost for encrypted transactions to compensate for
+    /// the decryption computation required.
+    fn charge_encrypted_txn(&mut self) -> VMResult<()>;
+
     /// Charges IO gas for the transaction itself.
     fn charge_io_gas_for_transaction(&mut self, txn_size: NumBytes) -> VMResult<()>;
 

--- a/aptos-move/aptos-gas-meter/src/traits.rs
+++ b/aptos-move/aptos-gas-meter/src/traits.rs
@@ -56,6 +56,17 @@ pub trait GasAlgebra {
         abstract_amount: impl GasExpression<VMGasParameters, Unit = InternalGasUnit> + Debug,
     ) -> PartialVMResult<()>;
 
+    /// Charges a fee that reduces the user's gas balance but does NOT count as
+    /// execution or IO gas. Used for overhead costs (e.g., encrypted txn decryption)
+    /// that should not affect the block gas limit.
+    fn charge_additional_fee(
+        &mut self,
+        abstract_amount: impl GasExpression<VMGasParameters, Unit = InternalGasUnit> + Debug,
+    ) -> PartialVMResult<()>;
+
+    /// Returns the amount of additional fee used.
+    fn additional_fee_used(&self) -> InternalGas;
+
     /// Charges gas charge under the IO category.
     ///
     /// The amount charged can be a quantity or an abstract expression containing

--- a/aptos-move/aptos-gas-profiling/src/erased.rs
+++ b/aptos-move/aptos-gas-profiling/src/erased.rs
@@ -221,6 +221,8 @@ impl ExecutionAndIOCosts {
 
         nodes.push(Node::new("slh_dsa_sha2_128s", self.slh_dsa_sha2_128s_cost));
 
+        nodes.push(Node::new("encrypted_txn", self.encrypted_txn_cost));
+
         if !self.dependencies.is_empty() {
             let deps = Node::new_with_children(
                 "dependencies",

--- a/aptos-move/aptos-gas-profiling/src/flamegraph.rs
+++ b/aptos-move/aptos-gas-profiling/src/flamegraph.rs
@@ -118,6 +118,8 @@ impl ExecutionAndIOCosts {
 
         lines.push("slh_dsa_sha2_128s", self.slh_dsa_sha2_128s_cost);
 
+        lines.push("encrypted_txn", self.encrypted_txn_cost);
+
         let mut path = vec![];
 
         struct Rec<'a> {

--- a/aptos-move/aptos-gas-profiling/src/log.rs
+++ b/aptos-move/aptos-gas-profiling/src/log.rs
@@ -133,6 +133,8 @@ pub struct ExecutionAndIOCosts {
     pub execution_gas: InternalGas,
     /// IO gas - corresponds to FeeStatement::io_gas_units.
     pub io_gas: InternalGas,
+    /// Additional fee that reduces balance but does not count as execution/IO gas.
+    pub additional_fee: InternalGas,
 
     pub intrinsic_cost: InternalGas,
     pub keyless_cost: InternalGas,
@@ -259,7 +261,7 @@ impl StorageFees {
 impl ExecutionAndIOCosts {
     /// Returns the total execution + IO gas.
     pub fn total(&self) -> InternalGas {
-        self.execution_gas + self.io_gas
+        self.execution_gas + self.io_gas + self.additional_fee
     }
 
     #[allow(clippy::needless_lifetimes)]

--- a/aptos-move/aptos-gas-profiling/src/log.rs
+++ b/aptos-move/aptos-gas-profiling/src/log.rs
@@ -137,6 +137,7 @@ pub struct ExecutionAndIOCosts {
     pub intrinsic_cost: InternalGas,
     pub keyless_cost: InternalGas,
     pub slh_dsa_sha2_128s_cost: InternalGas,
+    pub encrypted_txn_cost: InternalGas,
     pub dependencies: Vec<Dependency>,
     pub call_graph: CallFrame,
     pub transaction_transient: Option<InternalGas>,
@@ -276,6 +277,7 @@ impl ExecutionAndIOCosts {
         total += self.intrinsic_cost;
         total += self.keyless_cost;
         total += self.slh_dsa_sha2_128s_cost;
+        total += self.encrypted_txn_cost;
 
         for dep in &self.dependencies {
             total += dep.cost;

--- a/aptos-move/aptos-gas-profiling/src/profiler.rs
+++ b/aptos-move/aptos-gas-profiling/src/profiler.rs
@@ -38,6 +38,7 @@ pub struct GasProfiler<G> {
     intrinsic_cost: Option<InternalGas>,
     keyless_cost: Option<InternalGas>,
     slh_dsa_sha2_128s_cost: Option<InternalGas>,
+    encrypted_txn_cost: Option<InternalGas>,
     dependencies: Vec<Dependency>,
     frames: Vec<CallFrame>,
     transaction_transient: Option<InternalGas>,
@@ -96,6 +97,7 @@ impl<G> GasProfiler<G> {
             intrinsic_cost: None,
             keyless_cost: None,
             slh_dsa_sha2_128s_cost: None,
+            encrypted_txn_cost: None,
             dependencies: vec![],
             frames: vec![CallFrame::new_script()],
             transaction_transient: None,
@@ -117,6 +119,7 @@ impl<G> GasProfiler<G> {
             intrinsic_cost: None,
             keyless_cost: None,
             slh_dsa_sha2_128s_cost: None,
+            encrypted_txn_cost: None,
             dependencies: vec![],
             frames: vec![CallFrame::new_function(module_id, func_name, ty_args)],
             transaction_transient: None,
@@ -726,6 +729,18 @@ where
 
         res
     }
+
+    fn charge_encrypted_txn(&mut self) -> VMResult<()> {
+        let (cost, res) = self.delegate_charge(|base| base.charge_encrypted_txn());
+
+        self.encrypted_txn_cost = Some(
+            self.encrypted_txn_cost
+                .unwrap_or_else(InternalGas::zero)
+                + cost,
+        );
+
+        res
+    }
 }
 
 impl<G> GasProfiler<G>
@@ -747,6 +762,9 @@ where
             keyless_cost: self.keyless_cost.unwrap_or_else(InternalGas::zero),
             slh_dsa_sha2_128s_cost: self
                 .slh_dsa_sha2_128s_cost
+                .unwrap_or_else(InternalGas::zero),
+            encrypted_txn_cost: self
+                .encrypted_txn_cost
                 .unwrap_or_else(InternalGas::zero),
             dependencies: self.dependencies,
             call_graph: self.frames.pop().expect("frame must exist"),

--- a/aptos-move/aptos-gas-profiling/src/profiler.rs
+++ b/aptos-move/aptos-gas-profiling/src/profiler.rs
@@ -758,6 +758,7 @@ where
             gas_scaling_factor: self.base.gas_unit_scaling_factor(),
             execution_gas: self.algebra().execution_gas_used(),
             io_gas: self.algebra().io_gas_used(),
+            additional_fee: self.algebra().additional_fee_used(),
             intrinsic_cost: self.intrinsic_cost.unwrap_or_else(InternalGas::zero),
             keyless_cost: self.keyless_cost.unwrap_or_else(InternalGas::zero),
             slh_dsa_sha2_128s_cost: self

--- a/aptos-move/aptos-gas-profiling/src/report.rs
+++ b/aptos-move/aptos-gas-profiling/src/report.rs
@@ -238,6 +238,18 @@ impl TransactionGasLog {
             );
         }
 
+        // Encrypted transaction cost (execution category)
+        if !self.exec_io.encrypted_txn_cost.is_zero() {
+            data.insert(
+                "encrypted_txn".to_string(),
+                json!(fmt_gas(self.exec_io.encrypted_txn_cost)),
+            );
+            data.insert(
+                "encrypted_txn-percentage".to_string(),
+                json!(exec_percentage(self.exec_io.encrypted_txn_cost)),
+            );
+        }
+
         // Dependencies (execution category - loading modules is CPU work)
         let mut deps = self.exec_io.dependencies.clone();
         deps.sort_by(|lhs, rhs| rhs.cost.cmp(&lhs.cost));

--- a/aptos-move/aptos-gas-profiling/src/unique_stack.rs
+++ b/aptos-move/aptos-gas-profiling/src/unique_stack.rs
@@ -84,6 +84,7 @@ impl ExecutionAndIOCosts {
             intrinsic_cost: self.intrinsic_cost + other.intrinsic_cost,
             keyless_cost: self.keyless_cost + other.keyless_cost,
             slh_dsa_sha2_128s_cost: self.slh_dsa_sha2_128s_cost + other.slh_dsa_sha2_128s_cost,
+            encrypted_txn_cost: self.encrypted_txn_cost + other.encrypted_txn_cost,
             dependencies: dependencies
                 .into_iter()
                 .map(|((kind, id, size), cost)| Dependency {

--- a/aptos-move/aptos-gas-profiling/src/unique_stack.rs
+++ b/aptos-move/aptos-gas-profiling/src/unique_stack.rs
@@ -81,6 +81,7 @@ impl ExecutionAndIOCosts {
             gas_scaling_factor: self.gas_scaling_factor,
             execution_gas: self.execution_gas + other.execution_gas,
             io_gas: self.io_gas + other.io_gas,
+            additional_fee: self.additional_fee + other.additional_fee,
             intrinsic_cost: self.intrinsic_cost + other.intrinsic_cost,
             keyless_cost: self.keyless_cost + other.keyless_cost,
             slh_dsa_sha2_128s_cost: self.slh_dsa_sha2_128s_cost + other.slh_dsa_sha2_128s_cost,

--- a/aptos-move/aptos-gas-profiling/templates/index.html
+++ b/aptos-move/aptos-gas-profiling/templates/index.html
@@ -245,6 +245,11 @@
             {{slh_dsa_sha2_128s}} gas units, {{slh_dsa_sha2_128s-percentage}} of execution gas.
             {{/if}}
 
+            {{#if encrypted_txn}}
+            <h4>Encrypted Transaction Cost</h4>
+            {{encrypted_txn}} gas units, {{encrypted_txn-percentage}} of execution gas.
+            {{/if}}
+
             <h4>Dependencies</h4>
             {{#if deps}}
             <table data-name="exec_dependencies">

--- a/aptos-move/aptos-gas-schedule/src/gas_schedule/transaction.rs
+++ b/aptos-move/aptos-gas-schedule/src/gas_schedule/transaction.rs
@@ -8,7 +8,7 @@ use crate::{
     gas_schedule::VMGasParameters,
     ver::gas_feature_versions::{
         RELEASE_V1_10, RELEASE_V1_11, RELEASE_V1_12, RELEASE_V1_13, RELEASE_V1_15, RELEASE_V1_26,
-        RELEASE_V1_41,
+        RELEASE_V1_41, RELEASE_V1_44,
     },
 };
 use aptos_gas_algebra::{
@@ -281,6 +281,11 @@ crate::gas_schedule::macros::define_gas_parameters!(
             slh_dsa_sha2_128s_base_cost: InternalGas,
             { RELEASE_V1_41.. => "slh_dsa_sha2_128s.base" },
             13_800_000,
+        ],
+        [
+            encrypted_txn_base_cost: InternalGas,
+            { RELEASE_V1_44.. => "encrypted_txn.base" },
+            10_000_000,
         ],
     ]
 );

--- a/aptos-move/aptos-gas-schedule/src/ver.rs
+++ b/aptos-move/aptos-gas-schedule/src/ver.rs
@@ -8,6 +8,8 @@
 ///   - Changing how gas is calculated in any way
 ///
 /// Change log:
+/// - V44:
+///    - Gas charging for encrypted transaction decryption
 /// - V41:
 ///    - Gas charging for SLH-DSA-SHA2-128s signature verification
 /// - V31:
@@ -111,4 +113,5 @@ pub mod gas_feature_versions {
     pub const RELEASE_V1_41: u64 = 45;
     pub const RELEASE_V1_42: u64 = 46;
     pub const RELEASE_V1_43: u64 = 47;
+    pub const RELEASE_V1_44: u64 = 48;
 }

--- a/aptos-move/aptos-memory-usage-tracker/src/lib.rs
+++ b/aptos-move/aptos-memory-usage-tracker/src/lib.rs
@@ -710,5 +710,7 @@ where
         fn charge_keyless(&mut self) -> VMResult<()>;
 
         fn charge_slh_dsa_sha2_128s(&mut self) -> VMResult<()>;
+
+        fn charge_encrypted_txn(&mut self) -> VMResult<()>;
     }
 }

--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -1069,6 +1069,9 @@ impl AptosVM {
         if txn_data.is_slh_dsa_sha2_128s() {
             gas_meter.charge_slh_dsa_sha2_128s()?;
         }
+        if txn_data.is_encrypted() {
+            gas_meter.charge_encrypted_txn()?;
+        }
 
         match executable {
             TransactionExecutableRef::Script(script) => {
@@ -1236,6 +1239,9 @@ impl AptosVM {
         }
         if txn_data.is_slh_dsa_sha2_128s() {
             gas_meter.charge_slh_dsa_sha2_128s()?;
+        }
+        if txn_data.is_encrypted() {
+            gas_meter.charge_encrypted_txn()?;
         }
 
         // Step 1: Obtain the payload. If any errors happen here, the entire transaction should fail

--- a/aptos-move/aptos-vm/src/gas.rs
+++ b/aptos-move/aptos-vm/src/gas.rs
@@ -6,7 +6,7 @@ use aptos_gas_algebra::{Gas, GasExpression, InternalGas};
 use aptos_gas_meter::{StandardGasAlgebra, StandardGasMeter};
 use aptos_gas_schedule::{
     gas_feature_versions::RELEASE_V1_13,
-    gas_params::txn::{KEYLESS_BASE_COST, SLH_DSA_SHA2_128S_BASE_COST},
+    gas_params::txn::{ENCRYPTED_TXN_BASE_COST, KEYLESS_BASE_COST, SLH_DSA_SHA2_128S_BASE_COST},
     AptosGasParameters, VMGasParameters,
 };
 use aptos_logger::{enabled, Level};
@@ -150,11 +150,16 @@ pub(crate) fn check_gas(
     } else {
         InternalGas::zero()
     };
+    let encrypted_txn = if txn_metadata.is_encrypted() {
+        ENCRYPTED_TXN_BASE_COST.evaluate(gas_feature_version, &gas_params.vm)
+    } else {
+        InternalGas::zero()
+    };
     let intrinsic_gas = txn_gas_params
         .calculate_intrinsic_gas(txn_bytes_len)
         .evaluate(gas_feature_version, &gas_params.vm);
-    let total_rounded: Gas =
-        (intrinsic_gas + keyless + slh_dsa_sha2_128s).to_unit_round_up_with_params(txn_gas_params);
+    let total_rounded: Gas = (intrinsic_gas + keyless + slh_dsa_sha2_128s + encrypted_txn)
+        .to_unit_round_up_with_params(txn_gas_params);
     if txn_metadata.max_gas_amount() < total_rounded {
         speculative_warn!(
             log_context,

--- a/aptos-move/aptos-vm/src/transaction_metadata.rs
+++ b/aptos-move/aptos-vm/src/transaction_metadata.rs
@@ -35,6 +35,7 @@ pub struct TransactionMetadata {
     pub script_size: NumBytes,
     pub is_keyless: bool,
     pub is_slh_dsa_sha2_128s: bool,
+    pub is_encrypted: bool,
     pub entry_function_payload: Option<EntryFunction>,
     pub multisig_payload: Option<Multisig>,
     /// The transaction index context for the monotonically increasing counter.
@@ -103,6 +104,7 @@ impl TransactionMetadata {
                         .any(|auth| matches!(auth.signature(), aptos_types::transaction::authenticator::AnySignature::SlhDsa_Sha2_128s { .. }))
                 })
                 .unwrap_or(false),
+            is_encrypted: txn.payload().is_encrypted_variant(),
             entry_function_payload: if txn.payload().is_multisig() {
                 None
             } else if let Ok(TransactionExecutableRef::EntryFunction(e)) =
@@ -210,6 +212,10 @@ impl TransactionMetadata {
 
     pub fn is_slh_dsa_sha2_128s(&self) -> bool {
         self.is_slh_dsa_sha2_128s
+    }
+
+    pub fn is_encrypted(&self) -> bool {
+        self.is_encrypted
     }
 
     pub fn entry_function_payload(&self) -> Option<EntryFunction> {


### PR DESCRIPTION
## Summary
- Adds a base gas charge (`encrypted_txn_base_cost = 10,000,000` internal gas) for encrypted transactions to account for decryption overhead
- Follows the same pattern as `charge_keyless()` and `charge_slh_dsa_sha2_128s()` across the gas meter trait, implementation, gas schedule, and gas profiling
- Charges in both `execute_script_or_entry_function` and `execute_multisig_transaction`, regardless of whether decryption succeeded or failed
- Gated behind `RELEASE_V1_44` (version constant added but `LATEST_GAS_FEATURE_VERSION` not bumped — to be done at branch cut)

## Test plan
- [ ] `cargo check -p aptos-vm -p aptos-gas-meter -p aptos-gas-schedule -p aptos-gas-profiling -p aptos-memory-usage-tracker` passes
- [ ] `cargo test -p e2e-move-tests -- failed_encrypted_transaction` passes
- [ ] Verify gas is charged for both successful and failed decryption scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)