### PR TITLE
[vm] Add flat per-transaction gas charge for randomness transactions

### DIFF
--- a/aptos-move/aptos-gas-meter/src/meter.rs
+++ b/aptos-move/aptos-gas-meter/src/meter.rs
@@ -633,6 +633,16 @@ where
             .charge_execution(SLH_DSA_SHA2_128S_BASE_COST)
             .map_err(|e| e.finish(Location::Undefined))
     }
+
+    fn charge_randomness_txn(&mut self) -> VMResult<()> {
+        if self.feature_version() < RELEASE_V1_44 {
+            return Ok(());
+        }
+
+        self.algebra
+            .charge_execution(RANDOMNESS_TXN_BASE_COST)
+            .map_err(|e| e.finish(Location::Undefined))
+    }
 }
 
 impl<A> CacheValueSizes for StandardGasMeter<A>

--- a/aptos-move/aptos-gas-meter/src/traits.rs
+++ b/aptos-move/aptos-gas-meter/src/traits.rs
@@ -132,6 +132,11 @@ pub trait AptosGasMeter: MoveGasMeter {
     /// expensive computation required (5x more expensive than ed25519).
     fn charge_slh_dsa_sha2_128s(&mut self) -> VMResult<()>;
 
+    /// Charges an additional cost for randomness transactions to account for the
+    /// network-wide overhead of randomness generation (pipeline serialization,
+    /// DKG share aggregation, zaptos optimization bypass).
+    fn charge_randomness_txn(&mut self) -> VMResult<()>;
+
     /// Charges IO gas for the transaction itself.
     fn charge_io_gas_for_transaction(&mut self, txn_size: NumBytes) -> VMResult<()>;
 

--- a/aptos-move/aptos-gas-profiling/src/erased.rs
+++ b/aptos-move/aptos-gas-profiling/src/erased.rs
@@ -221,6 +221,8 @@ impl ExecutionAndIOCosts {
 
         nodes.push(Node::new("slh_dsa_sha2_128s", self.slh_dsa_sha2_128s_cost));
 
+        nodes.push(Node::new("randomness_txn", self.randomness_txn_cost));
+
         if !self.dependencies.is_empty() {
             let deps = Node::new_with_children(
                 "dependencies",

--- a/aptos-move/aptos-gas-profiling/src/flamegraph.rs
+++ b/aptos-move/aptos-gas-profiling/src/flamegraph.rs
@@ -118,6 +118,8 @@ impl ExecutionAndIOCosts {
 
         lines.push("slh_dsa_sha2_128s", self.slh_dsa_sha2_128s_cost);
 
+        lines.push("randomness_txn", self.randomness_txn_cost);
+
         let mut path = vec![];
 
         struct Rec<'a> {

--- a/aptos-move/aptos-gas-profiling/src/log.rs
+++ b/aptos-move/aptos-gas-profiling/src/log.rs
@@ -137,6 +137,7 @@ pub struct ExecutionAndIOCosts {
     pub intrinsic_cost: InternalGas,
     pub keyless_cost: InternalGas,
     pub slh_dsa_sha2_128s_cost: InternalGas,
+    pub randomness_txn_cost: InternalGas,
     pub dependencies: Vec<Dependency>,
     pub call_graph: CallFrame,
     pub transaction_transient: Option<InternalGas>,
@@ -276,6 +277,7 @@ impl ExecutionAndIOCosts {
         total += self.intrinsic_cost;
         total += self.keyless_cost;
         total += self.slh_dsa_sha2_128s_cost;
+        total += self.randomness_txn_cost;
 
         for dep in &self.dependencies {
             total += dep.cost;

--- a/aptos-move/aptos-gas-profiling/src/profiler.rs
+++ b/aptos-move/aptos-gas-profiling/src/profiler.rs
@@ -38,6 +38,7 @@ pub struct GasProfiler<G> {
     intrinsic_cost: Option<InternalGas>,
     keyless_cost: Option<InternalGas>,
     slh_dsa_sha2_128s_cost: Option<InternalGas>,
+    randomness_txn_cost: Option<InternalGas>,
     dependencies: Vec<Dependency>,
     frames: Vec<CallFrame>,
     transaction_transient: Option<InternalGas>,
@@ -96,6 +97,7 @@ impl<G> GasProfiler<G> {
             intrinsic_cost: None,
             keyless_cost: None,
             slh_dsa_sha2_128s_cost: None,
+            randomness_txn_cost: None,
             dependencies: vec![],
             frames: vec![CallFrame::new_script()],
             transaction_transient: None,
@@ -117,6 +119,7 @@ impl<G> GasProfiler<G> {
             intrinsic_cost: None,
             keyless_cost: None,
             slh_dsa_sha2_128s_cost: None,
+            randomness_txn_cost: None,
             dependencies: vec![],
             frames: vec![CallFrame::new_function(module_id, func_name, ty_args)],
             transaction_transient: None,
@@ -726,6 +729,18 @@ where
 
         res
     }
+
+    fn charge_randomness_txn(&mut self) -> VMResult<()> {
+        let (cost, res) = self.delegate_charge(|base| base.charge_randomness_txn());
+
+        self.randomness_txn_cost = Some(
+            self.randomness_txn_cost
+                .unwrap_or_else(InternalGas::zero)
+                + cost,
+        );
+
+        res
+    }
 }
 
 impl<G> GasProfiler<G>
@@ -747,6 +762,9 @@ where
             keyless_cost: self.keyless_cost.unwrap_or_else(InternalGas::zero),
             slh_dsa_sha2_128s_cost: self
                 .slh_dsa_sha2_128s_cost
+                .unwrap_or_else(InternalGas::zero),
+            randomness_txn_cost: self
+                .randomness_txn_cost
                 .unwrap_or_else(InternalGas::zero),
             dependencies: self.dependencies,
             call_graph: self.frames.pop().expect("frame must exist"),

--- a/aptos-move/aptos-gas-profiling/src/report.rs
+++ b/aptos-move/aptos-gas-profiling/src/report.rs
@@ -238,6 +238,18 @@ impl TransactionGasLog {
             );
         }
 
+        // Randomness transaction cost (execution category)
+        if !self.exec_io.randomness_txn_cost.is_zero() {
+            data.insert(
+                "randomness_txn".to_string(),
+                json!(fmt_gas(self.exec_io.randomness_txn_cost)),
+            );
+            data.insert(
+                "randomness_txn-percentage".to_string(),
+                json!(exec_percentage(self.exec_io.randomness_txn_cost)),
+            );
+        }
+
         // Dependencies (execution category - loading modules is CPU work)
         let mut deps = self.exec_io.dependencies.clone();
         deps.sort_by(|lhs, rhs| rhs.cost.cmp(&lhs.cost));

--- a/aptos-move/aptos-gas-profiling/src/unique_stack.rs
+++ b/aptos-move/aptos-gas-profiling/src/unique_stack.rs
@@ -84,6 +84,7 @@ impl ExecutionAndIOCosts {
             intrinsic_cost: self.intrinsic_cost + other.intrinsic_cost,
             keyless_cost: self.keyless_cost + other.keyless_cost,
             slh_dsa_sha2_128s_cost: self.slh_dsa_sha2_128s_cost + other.slh_dsa_sha2_128s_cost,
+            randomness_txn_cost: self.randomness_txn_cost + other.randomness_txn_cost,
             dependencies: dependencies
                 .into_iter()
                 .map(|((kind, id, size), cost)| Dependency {

--- a/aptos-move/aptos-gas-profiling/templates/index.html
+++ b/aptos-move/aptos-gas-profiling/templates/index.html
@@ -245,6 +245,11 @@
             {{slh_dsa_sha2_128s}} gas units, {{slh_dsa_sha2_128s-percentage}} of execution gas.
             {{/if}}
 
+            {{#if randomness_txn}}
+            <h4>Randomness Transaction Cost</h4>
+            {{randomness_txn}} gas units, {{randomness_txn-percentage}} of execution gas.
+            {{/if}}
+
             <h4>Dependencies</h4>
             {{#if deps}}
             <table data-name="exec_dependencies">

--- a/aptos-move/aptos-gas-schedule/src/gas_schedule/transaction.rs
+++ b/aptos-move/aptos-gas-schedule/src/gas_schedule/transaction.rs
@@ -8,7 +8,7 @@ use crate::{
     gas_schedule::VMGasParameters,
     ver::gas_feature_versions::{
         RELEASE_V1_10, RELEASE_V1_11, RELEASE_V1_12, RELEASE_V1_13, RELEASE_V1_15, RELEASE_V1_26,
-        RELEASE_V1_41,
+        RELEASE_V1_41, RELEASE_V1_44,
     },
 };
 use aptos_gas_algebra::{
@@ -281,6 +281,11 @@ crate::gas_schedule::macros::define_gas_parameters!(
             slh_dsa_sha2_128s_base_cost: InternalGas,
             { RELEASE_V1_41.. => "slh_dsa_sha2_128s.base" },
             13_800_000,
+        ],
+        [
+            randomness_txn_base_cost: InternalGas,
+            { RELEASE_V1_44.. => "randomness_txn.base" },
+            10_000_000,
         ],
     ]
 );

--- a/aptos-move/aptos-gas-schedule/src/ver.rs
+++ b/aptos-move/aptos-gas-schedule/src/ver.rs
@@ -8,6 +8,8 @@
 ///   - Changing how gas is calculated in any way
 ///
 /// Change log:
+/// - V48:
+///    - Flat per-transaction gas charge for randomness transactions
 /// - V41:
 ///    - Gas charging for SLH-DSA-SHA2-128s signature verification
 /// - V31:
@@ -73,7 +75,7 @@
 ///       global operations.
 /// - V1
 ///   - TBA
-pub const LATEST_GAS_FEATURE_VERSION: u64 = gas_feature_versions::RELEASE_V1_43;
+pub const LATEST_GAS_FEATURE_VERSION: u64 = gas_feature_versions::RELEASE_V1_44;
 
 pub mod gas_feature_versions {
     pub const RELEASE_V1_8: u64 = 11;
@@ -111,4 +113,5 @@ pub mod gas_feature_versions {
     pub const RELEASE_V1_41: u64 = 45;
     pub const RELEASE_V1_42: u64 = 46;
     pub const RELEASE_V1_43: u64 = 47;
+    pub const RELEASE_V1_44: u64 = 48;
 }

--- a/aptos-move/aptos-memory-usage-tracker/src/lib.rs
+++ b/aptos-move/aptos-memory-usage-tracker/src/lib.rs
@@ -710,5 +710,7 @@ where
         fn charge_keyless(&mut self) -> VMResult<()>;
 
         fn charge_slh_dsa_sha2_128s(&mut self) -> VMResult<()>;
+
+        fn charge_randomness_txn(&mut self) -> VMResult<()>;
     }
 }

--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -1012,6 +1012,7 @@ impl AptosVM {
                 );
                 if maybe_randomness_annotation.is_some() {
                     session.mark_unbiasable();
+                    gas_meter.charge_randomness_txn()?;
                 }
             }
 


### PR DESCRIPTION
## Summary

- Adds a flat 10M internal gas (10 external gas, ~0.00001 APT) charge per transaction that uses on-chain randomness
- Follows the existing pattern used for keyless (32M) and SLH-DSA (13.8M) per-transaction charges
- Gated behind gas feature version V1_44 (version 48)

## Motivation

Randomness transactions incur significant **per-block** network costs that are roughly constant regardless of how many randomness calls a transaction makes:
- Disables zaptos execution optimization
- Creates a pipeline serialization point (execution blocks until randomness is aggregated)
- Adds 7ms+ for cryptographic share verification
- Can trigger 300ms share request delays

The current gas charge of 1 internal gas per `fetch_and_increment_txn_counter` call is essentially free and doesn't reflect this overhead. The per-call charge stays as-is (it's cheap, matching the cheap per-call compute). This PR adds the missing flat per-transaction cost.

## Changes

| File | Change |
|------|--------|
| `aptos-gas-schedule/src/ver.rs` | Add `RELEASE_V1_44 = 48`, update `LATEST_GAS_FEATURE_VERSION` |
| `aptos-gas-schedule/src/gas_schedule/transaction.rs` | Add `randomness_txn_base_cost` parameter (10M internal gas) |
| `aptos-gas-meter/src/traits.rs` | Add `charge_randomness_txn()` to `AptosGasMeter` trait |
| `aptos-gas-meter/src/meter.rs` | Implement `charge_randomness_txn()` in `StandardGasMeter` |
| `aptos-vm/src/aptos_vm.rs` | Call `gas_meter.charge_randomness_txn()` after randomness annotation detected |
| `aptos-memory-usage-tracker/src/lib.rs` | Add delegate for new trait method |
| `aptos-gas-profiling/src/*` | Add `randomness_txn_cost` to gas profiling/reporting (6 files + template) |

## Production Note

This code change affects genesis/test defaults only. Production chains require a governance proposal to set `randomness_txn.base` to `10000000` in the on-chain gas schedule.

## Test plan

- [x] `cargo check -p aptos-gas-schedule` passes
- [x] `cargo check -p aptos-gas-meter` passes
- [x] `cargo check -p aptos-gas-profiling` passes
- [x] `cargo check -p aptos-vm` passes
- [x] `cargo test -p aptos-gas-schedule` — 6/6 tests pass
- [ ] CI: full test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)