### PR TITLE
[vm] Charge randomness as a feature fee separate from gas

### DIFF
--- a/aptos-move/aptos-abstract-gas-usage/src/algebra.rs
+++ b/aptos-move/aptos-abstract-gas-usage/src/algebra.rs
@@ -107,6 +107,19 @@ impl<A: GasAlgebra> GasAlgebra for CalibrationAlgebra<A> {
         self.base.storage_fee_used()
     }
 
+    fn charge_feature_fee(
+        &mut self,
+        abstract_amount: impl GasExpression<VMGasParameters, Unit = Octa>,
+        gas_unit_price: FeePerGasUnit,
+    ) -> PartialVMResult<()> {
+        self.base
+            .charge_feature_fee(abstract_amount, gas_unit_price)
+    }
+
+    fn feature_fee_used(&self) -> Fee {
+        self.base.feature_fee_used()
+    }
+
     fn inject_balance(&mut self, new_initial_gas: impl Into<Gas>) -> PartialVMResult<()> {
         self.base.inject_balance(new_initial_gas)
     }

--- a/aptos-move/aptos-gas-meter/src/algebra.rs
+++ b/aptos-move/aptos-gas-meter/src/algebra.rs
@@ -2,7 +2,9 @@
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::traits::GasAlgebra;
-use aptos_gas_algebra::{Fee, FeePerGasUnit, Gas, GasExpression, NumBytes, NumModules, Octa};
+use aptos_gas_algebra::{
+    Fee, FeePerGasUnit, Gas, GasExpression, GasScalingFactor, NumBytes, NumModules, Octa,
+};
 use aptos_gas_schedule::{gas_feature_versions, VMGasParameters};
 use aptos_logger::error;
 use aptos_vm_types::{
@@ -41,6 +43,11 @@ where
     storage_fee_in_internal_units: InternalGas,
     // The storage fee consumed by the storage operations.
     storage_fee_used: Fee,
+
+    // The gas consumed by feature fees (e.g., randomness).
+    feature_fee_in_internal_units: InternalGas,
+    // The feature fee consumed.
+    feature_fee_used: Fee,
 
     num_dependencies: NumModules,
     total_dependency_size: NumBytes,
@@ -99,12 +106,35 @@ where
             max_storage_fee,
             storage_fee_in_internal_units: 0.into(),
             storage_fee_used: 0.into(),
+            feature_fee_in_internal_units: 0.into(),
+            feature_fee_used: 0.into(),
             num_dependencies: 0.into(),
             total_dependency_size: 0.into(),
             block_synchronization_kill_switch,
             counter_for_kill_switch: 0,
         }
     }
+}
+
+/// Convert an Octa-denominated fee to internal gas units using the gas unit price
+/// and scaling factor. Used by both storage fee and feature fee charging.
+fn octa_to_internal_gas(
+    amount: Fee,
+    gas_unit_scaling_factor: GasScalingFactor,
+    gas_unit_price: FeePerGasUnit,
+) -> InternalGas {
+    let gas_consumed_internal = ((u64::from(amount) as u128)
+        * (u64::from(gas_unit_scaling_factor) as u128))
+    .div_ceil(u64::from(gas_unit_price) as u128);
+    InternalGas::new(if gas_consumed_internal > u64::MAX as u128 {
+        error!(
+            "Something's wrong in the gas schedule: gas_consumed_internal ({}) > u64::MAX",
+            gas_consumed_internal
+        );
+        u64::MAX
+    } else {
+        gas_consumed_internal as u64
+    })
 }
 
 impl<T> GasAlgebra for StandardGasAlgebra<'_, T>
@@ -150,17 +180,18 @@ where
             })?;
 
         let total_calculated =
-            self.execution_gas_used + self.io_gas_used + self.storage_fee_in_internal_units;
+            self.execution_gas_used + self.io_gas_used + self.storage_fee_in_internal_units + self.feature_fee_in_internal_units;
         if total != total_calculated {
             return Err(
                 PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR).with_message(
                     format!(
-                        "The per-category costs do not add up. {} (total) != {} = {} (exec) + {} (io) + {} (storage)",
+                        "The per-category costs do not add up. {} (total) != {} = {} (exec) + {} (io) + {} (storage) + {} (feature)",
                         total,
                         total_calculated,
                         self.execution_gas_used,
                         self.io_gas_used,
                         self.storage_fee_in_internal_units,
+                        self.feature_fee_in_internal_units,
                     ),
                 ),
             );
@@ -243,34 +274,10 @@ where
     ) -> PartialVMResult<()> {
         let amount = abstract_amount.evaluate(self.feature_version, &self.vm_gas_params);
 
-        let txn_params = &self.vm_gas_params.txn;
-
-        // Because the storage fees are defined in terms of fixed APT costs, we need
-        // to convert them into gas units.
-        //
-        // u128 is used to protect against overflow and preserve as much precision as
-        // possible in the extreme cases.
-        fn div_ceil(n: u128, d: u128) -> u128 {
-            if n.is_multiple_of(d) {
-                n / d
-            } else {
-                n / d + 1
-            }
-        }
-        let gas_consumed_internal = div_ceil(
-            (u64::from(amount) as u128) * (u64::from(txn_params.gas_unit_scaling_factor) as u128),
-            u64::from(gas_unit_price) as u128,
-        );
-        let gas_consumed_internal = InternalGas::new(
-            if gas_consumed_internal > u64::MAX as u128 {
-                error!(
-                    "Something's wrong in the gas schedule: gas_consumed_internal ({}) > u64::MAX",
-                    gas_consumed_internal
-                );
-                u64::MAX
-            } else {
-                gas_consumed_internal as u64
-            },
+        let gas_consumed_internal = octa_to_internal_gas(
+            amount,
+            self.vm_gas_params.txn.gas_unit_scaling_factor,
+            gas_unit_price,
         );
 
         match self.balance.checked_sub(gas_consumed_internal) {
@@ -295,6 +302,52 @@ where
         }
 
         Ok(())
+    }
+
+    fn charge_feature_fee(
+        &mut self,
+        abstract_amount: impl GasExpression<VMGasParameters, Unit = Octa>,
+        gas_unit_price: FeePerGasUnit,
+    ) -> PartialVMResult<()> {
+        // Some tests use a unit price of 0. Skip charging to avoid division by zero,
+        // consistent with how process_storage_fee_for_all guards charge_storage_fee.
+        if gas_unit_price.is_zero() {
+            return Ok(());
+        }
+
+        let amount = abstract_amount.evaluate(self.feature_version, &self.vm_gas_params);
+
+        let gas_consumed_internal = octa_to_internal_gas(
+            amount,
+            self.vm_gas_params.txn.gas_unit_scaling_factor,
+            gas_unit_price,
+        );
+
+        match self.balance.checked_sub(gas_consumed_internal) {
+            Some(new_balance) => {
+                self.balance = new_balance;
+                self.feature_fee_in_internal_units += gas_consumed_internal;
+                self.feature_fee_used += amount;
+            },
+            None => {
+                let old_balance = self.balance;
+                self.balance = 0.into();
+                // Match charge_storage_fee: only record partial accounting in v12+.
+                // Always true when charge_feature_fee is reachable (gated on v48+),
+                // but kept for consistency with the storage fee code path.
+                if self.feature_version >= 12 {
+                    self.feature_fee_in_internal_units += old_balance;
+                    self.feature_fee_used += amount;
+                }
+                return Err(PartialVMError::new(StatusCode::OUT_OF_GAS));
+            },
+        };
+
+        Ok(())
+    }
+
+    fn feature_fee_used(&self) -> Fee {
+        self.feature_fee_used
     }
 
     fn count_dependency(&mut self, size: NumBytes) -> PartialVMResult<()> {
@@ -336,5 +389,91 @@ where
         self.initial_balance.add_assign(extra_unit);
         self.balance.add_assign(extra_unit);
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aptos_gas_schedule::{InitialGasSchedule, LATEST_GAS_FEATURE_VERSION, VMGasParameters};
+    use aptos_vm_types::{
+        resolver::NoopBlockSynchronizationKillSwitch,
+        storage::StorageGasParameters,
+    };
+
+    fn make_algebra(
+        balance_gas_units: u64,
+    ) -> StandardGasAlgebra<'static, NoopBlockSynchronizationKillSwitch> {
+        static KILL_SWITCH: NoopBlockSynchronizationKillSwitch =
+            NoopBlockSynchronizationKillSwitch {};
+        StandardGasAlgebra::new(
+            LATEST_GAS_FEATURE_VERSION,
+            VMGasParameters::initial(),
+            StorageGasParameters::unlimited(),
+            false,
+            Gas::new(balance_gas_units),
+            &KILL_SWITCH,
+        )
+    }
+
+    #[test]
+    fn charge_feature_fee_normal() {
+        // 10_000 external gas units balance; gas_unit_price = 100 octas/gas-unit.
+        let mut algebra = make_algebra(10_000);
+        let gas_unit_price = FeePerGasUnit::new(100);
+
+        // Charge 100_000 octas = 1000 gas units at price 100.
+        let result = algebra.charge_feature_fee(Fee::new(100_000), gas_unit_price);
+        assert!(result.is_ok());
+        assert_eq!(u64::from(algebra.feature_fee_used()), 100_000);
+        assert!(algebra.balance > InternalGas::zero());
+    }
+
+    #[test]
+    fn charge_feature_fee_out_of_gas() {
+        // 1 external gas unit balance; gas_unit_price = 100 octas/gas-unit.
+        let mut algebra = make_algebra(1);
+        let gas_unit_price = FeePerGasUnit::new(100);
+
+        // Charge 100_000 octas = 1000 gas units, but only 1 available → OOG.
+        let result = algebra.charge_feature_fee(Fee::new(100_000), gas_unit_price);
+        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err().major_status(),
+            StatusCode::OUT_OF_GAS
+        );
+        assert_eq!(algebra.balance, InternalGas::zero());
+        // The full fee is still recorded (for accounting), matching storage fee behavior.
+        assert_eq!(u64::from(algebra.feature_fee_used()), 100_000);
+    }
+
+    #[test]
+    fn charge_feature_fee_zero_gas_unit_price() {
+        let mut algebra = make_algebra(10_000);
+        let gas_unit_price = FeePerGasUnit::new(0);
+
+        // Should return Ok and not charge anything (avoid division by zero).
+        let result = algebra.charge_feature_fee(Fee::new(100_000), gas_unit_price);
+        assert!(result.is_ok());
+        assert_eq!(u64::from(algebra.feature_fee_used()), 0);
+    }
+
+    #[test]
+    fn charge_feature_fee_not_in_block_gas_limit() {
+        let mut algebra = make_algebra(10_000);
+        let gas_unit_price = FeePerGasUnit::new(100);
+
+        let balance_before = algebra.balance;
+        algebra
+            .charge_feature_fee(Fee::new(100_000), gas_unit_price)
+            .unwrap();
+
+        // Feature fee should not contribute to execution or IO gas.
+        assert_eq!(algebra.execution_gas_used(), InternalGas::zero());
+        assert_eq!(algebra.io_gas_used(), InternalGas::zero());
+        // But should deduct from overall balance.
+        assert!(algebra.balance < balance_before);
+        // And the internal-unit counter should be non-zero.
+        assert!(algebra.feature_fee_in_internal_units > InternalGas::zero());
     }
 }

--- a/aptos-move/aptos-gas-meter/src/meter.rs
+++ b/aptos-move/aptos-gas-meter/src/meter.rs
@@ -633,6 +633,16 @@ where
             .charge_execution(SLH_DSA_SHA2_128S_BASE_COST)
             .map_err(|e| e.finish(Location::Undefined))
     }
+
+    fn charge_randomness_txn(&mut self, gas_unit_price: FeePerGasUnit) -> VMResult<()> {
+        if self.feature_version() < RELEASE_V1_44 {
+            return Ok(());
+        }
+
+        self.algebra
+            .charge_feature_fee(RANDOMNESS_TXN_FEE, gas_unit_price)
+            .map_err(|e| e.finish(Location::Undefined))
+    }
 }
 
 impl<A> CacheValueSizes for StandardGasMeter<A>

--- a/aptos-move/aptos-gas-meter/src/traits.rs
+++ b/aptos-move/aptos-gas-meter/src/traits.rs
@@ -90,6 +90,19 @@ pub trait GasAlgebra {
     /// Returns the amount of storage fee used.
     fn storage_fee_used(&self) -> Fee;
 
+    /// Charges a feature fee (e.g., randomness).
+    ///
+    /// The amount charged is denominated in Octa (fixed APT cost) and does not
+    /// count toward the block gas limit.
+    fn charge_feature_fee(
+        &mut self,
+        abstract_amount: impl GasExpression<VMGasParameters, Unit = Octa>,
+        gas_unit_price: FeePerGasUnit,
+    ) -> PartialVMResult<()>;
+
+    /// Returns the amount of feature fee used.
+    fn feature_fee_used(&self) -> Fee;
+
     /// Bump the `extra_balance`.
     fn inject_balance(&mut self, extra_balance: impl Into<Gas>) -> PartialVMResult<()>;
 }
@@ -131,6 +144,11 @@ pub trait AptosGasMeter: MoveGasMeter {
     /// Charges an additional cost for SLH-DSA signature verification to compensate for the
     /// expensive computation required (5x more expensive than ed25519).
     fn charge_slh_dsa_sha2_128s(&mut self) -> VMResult<()>;
+
+    /// Charges an additional cost for randomness transactions to account for the
+    /// network-wide overhead of randomness generation (pipeline serialization,
+    /// DKG share aggregation, zaptos optimization bypass).
+    fn charge_randomness_txn(&mut self, gas_unit_price: FeePerGasUnit) -> VMResult<()>;
 
     /// Charges IO gas for the transaction itself.
     fn charge_io_gas_for_transaction(&mut self, txn_size: NumBytes) -> VMResult<()>;
@@ -265,6 +283,11 @@ pub trait AptosGasMeter: MoveGasMeter {
     /// Return the total fee used for storage.
     fn storage_fee_used(&self) -> Fee {
         self.algebra().storage_fee_used()
+    }
+
+    /// Return the total feature fee used.
+    fn feature_fee_used(&self) -> Fee {
+        self.algebra().feature_fee_used()
     }
 
     /// Bump the `extra_balance`.

--- a/aptos-move/aptos-gas-profiling/src/erased.rs
+++ b/aptos-move/aptos-gas-profiling/src/erased.rs
@@ -221,6 +221,8 @@ impl ExecutionAndIOCosts {
 
         nodes.push(Node::new("slh_dsa_sha2_128s", self.slh_dsa_sha2_128s_cost));
 
+        nodes.push(Node::new("randomness_txn", self.randomness_txn_cost));
+
         if !self.dependencies.is_empty() {
             let deps = Node::new_with_children(
                 "dependencies",

--- a/aptos-move/aptos-gas-profiling/src/flamegraph.rs
+++ b/aptos-move/aptos-gas-profiling/src/flamegraph.rs
@@ -118,6 +118,8 @@ impl ExecutionAndIOCosts {
 
         lines.push("slh_dsa_sha2_128s", self.slh_dsa_sha2_128s_cost);
 
+        lines.push("randomness_txn", self.randomness_txn_cost);
+
         let mut path = vec![];
 
         struct Rec<'a> {

--- a/aptos-move/aptos-gas-profiling/src/log.rs
+++ b/aptos-move/aptos-gas-profiling/src/log.rs
@@ -137,6 +137,7 @@ pub struct ExecutionAndIOCosts {
     pub intrinsic_cost: InternalGas,
     pub keyless_cost: InternalGas,
     pub slh_dsa_sha2_128s_cost: InternalGas,
+    pub randomness_txn_cost: InternalGas,
     pub dependencies: Vec<Dependency>,
     pub call_graph: CallFrame,
     pub transaction_transient: Option<InternalGas>,
@@ -256,9 +257,9 @@ impl StorageFees {
 }
 
 impl ExecutionAndIOCosts {
-    /// Returns the total execution + IO gas.
+    /// Returns the total execution + IO + feature-fee gas.
     pub fn total(&self) -> InternalGas {
-        self.execution_gas + self.io_gas
+        self.execution_gas + self.io_gas + self.randomness_txn_cost
     }
 
     #[allow(clippy::needless_lifetimes)]
@@ -276,6 +277,7 @@ impl ExecutionAndIOCosts {
         total += self.intrinsic_cost;
         total += self.keyless_cost;
         total += self.slh_dsa_sha2_128s_cost;
+        total += self.randomness_txn_cost;
 
         for dep in &self.dependencies {
             total += dep.cost;

--- a/aptos-move/aptos-gas-profiling/src/profiler.rs
+++ b/aptos-move/aptos-gas-profiling/src/profiler.rs
@@ -38,6 +38,7 @@ pub struct GasProfiler<G> {
     intrinsic_cost: Option<InternalGas>,
     keyless_cost: Option<InternalGas>,
     slh_dsa_sha2_128s_cost: Option<InternalGas>,
+    randomness_txn_cost: Option<InternalGas>,
     dependencies: Vec<Dependency>,
     frames: Vec<CallFrame>,
     transaction_transient: Option<InternalGas>,
@@ -96,6 +97,7 @@ impl<G> GasProfiler<G> {
             intrinsic_cost: None,
             keyless_cost: None,
             slh_dsa_sha2_128s_cost: None,
+            randomness_txn_cost: None,
             dependencies: vec![],
             frames: vec![CallFrame::new_script()],
             transaction_transient: None,
@@ -117,6 +119,7 @@ impl<G> GasProfiler<G> {
             intrinsic_cost: None,
             keyless_cost: None,
             slh_dsa_sha2_128s_cost: None,
+            randomness_txn_cost: None,
             dependencies: vec![],
             frames: vec![CallFrame::new_function(module_id, func_name, ty_args)],
             transaction_transient: None,
@@ -726,6 +729,18 @@ where
 
         res
     }
+
+    fn charge_randomness_txn(&mut self, gas_unit_price: FeePerGasUnit) -> VMResult<()> {
+        let (cost, res) = self.delegate_charge(|base| base.charge_randomness_txn(gas_unit_price));
+
+        self.randomness_txn_cost = Some(
+            self.randomness_txn_cost
+                .unwrap_or_else(InternalGas::zero)
+                + cost,
+        );
+
+        res
+    }
 }
 
 impl<G> GasProfiler<G>
@@ -747,6 +762,9 @@ where
             keyless_cost: self.keyless_cost.unwrap_or_else(InternalGas::zero),
             slh_dsa_sha2_128s_cost: self
                 .slh_dsa_sha2_128s_cost
+                .unwrap_or_else(InternalGas::zero),
+            randomness_txn_cost: self
+                .randomness_txn_cost
                 .unwrap_or_else(InternalGas::zero),
             dependencies: self.dependencies,
             call_graph: self.frames.pop().expect("frame must exist"),

--- a/aptos-move/aptos-gas-profiling/src/report.rs
+++ b/aptos-move/aptos-gas-profiling/src/report.rs
@@ -238,6 +238,18 @@ impl TransactionGasLog {
             );
         }
 
+        // Randomness transaction cost (execution category)
+        if !self.exec_io.randomness_txn_cost.is_zero() {
+            data.insert(
+                "randomness_txn".to_string(),
+                json!(fmt_gas(self.exec_io.randomness_txn_cost)),
+            );
+            data.insert(
+                "randomness_txn-percentage".to_string(),
+                json!(exec_percentage(self.exec_io.randomness_txn_cost)),
+            );
+        }
+
         // Dependencies (execution category - loading modules is CPU work)
         let mut deps = self.exec_io.dependencies.clone();
         deps.sort_by(|lhs, rhs| rhs.cost.cmp(&lhs.cost));

--- a/aptos-move/aptos-gas-profiling/src/unique_stack.rs
+++ b/aptos-move/aptos-gas-profiling/src/unique_stack.rs
@@ -84,6 +84,7 @@ impl ExecutionAndIOCosts {
             intrinsic_cost: self.intrinsic_cost + other.intrinsic_cost,
             keyless_cost: self.keyless_cost + other.keyless_cost,
             slh_dsa_sha2_128s_cost: self.slh_dsa_sha2_128s_cost + other.slh_dsa_sha2_128s_cost,
+            randomness_txn_cost: self.randomness_txn_cost + other.randomness_txn_cost,
             dependencies: dependencies
                 .into_iter()
                 .map(|((kind, id, size), cost)| Dependency {

--- a/aptos-move/aptos-gas-profiling/templates/index.html
+++ b/aptos-move/aptos-gas-profiling/templates/index.html
@@ -245,6 +245,11 @@
             {{slh_dsa_sha2_128s}} gas units, {{slh_dsa_sha2_128s-percentage}} of execution gas.
             {{/if}}
 
+            {{#if randomness_txn}}
+            <h4>Randomness Transaction Cost</h4>
+            {{randomness_txn}} gas units, {{randomness_txn-percentage}} of execution gas.
+            {{/if}}
+
             <h4>Dependencies</h4>
             {{#if deps}}
             <table data-name="exec_dependencies">

--- a/aptos-move/aptos-gas-schedule/src/gas_schedule/transaction.rs
+++ b/aptos-move/aptos-gas-schedule/src/gas_schedule/transaction.rs
@@ -8,7 +8,7 @@ use crate::{
     gas_schedule::VMGasParameters,
     ver::gas_feature_versions::{
         RELEASE_V1_10, RELEASE_V1_11, RELEASE_V1_12, RELEASE_V1_13, RELEASE_V1_15, RELEASE_V1_26,
-        RELEASE_V1_41,
+        RELEASE_V1_41, RELEASE_V1_44,
     },
 };
 use aptos_gas_algebra::{
@@ -281,6 +281,11 @@ crate::gas_schedule::macros::define_gas_parameters!(
             slh_dsa_sha2_128s_base_cost: InternalGas,
             { RELEASE_V1_41.. => "slh_dsa_sha2_128s.base" },
             13_800_000,
+        ],
+        [
+            randomness_txn_fee: Fee,
+            { RELEASE_V1_44.. => "randomness_txn.fee" },
+            100_000,
         ],
     ]
 );

--- a/aptos-move/aptos-gas-schedule/src/ver.rs
+++ b/aptos-move/aptos-gas-schedule/src/ver.rs
@@ -8,6 +8,8 @@
 ///   - Changing how gas is calculated in any way
 ///
 /// Change log:
+/// - V48:
+///    - Flat per-transaction gas charge for randomness transactions
 /// - V41:
 ///    - Gas charging for SLH-DSA-SHA2-128s signature verification
 /// - V31:
@@ -73,7 +75,7 @@
 ///       global operations.
 /// - V1
 ///   - TBA
-pub const LATEST_GAS_FEATURE_VERSION: u64 = gas_feature_versions::RELEASE_V1_43;
+pub const LATEST_GAS_FEATURE_VERSION: u64 = gas_feature_versions::RELEASE_V1_44;
 
 pub mod gas_feature_versions {
     pub const RELEASE_V1_8: u64 = 11;
@@ -111,4 +113,5 @@ pub mod gas_feature_versions {
     pub const RELEASE_V1_41: u64 = 45;
     pub const RELEASE_V1_42: u64 = 46;
     pub const RELEASE_V1_43: u64 = 47;
+    pub const RELEASE_V1_44: u64 = 48;
 }

--- a/aptos-move/aptos-memory-usage-tracker/src/lib.rs
+++ b/aptos-move/aptos-memory-usage-tracker/src/lib.rs
@@ -710,5 +710,7 @@ where
         fn charge_keyless(&mut self) -> VMResult<()>;
 
         fn charge_slh_dsa_sha2_128s(&mut self) -> VMResult<()>;
+
+        fn charge_randomness_txn(&mut self, gas_unit_price: FeePerGasUnit) -> VMResult<()>;
     }
 }

--- a/aptos-move/aptos-release-builder/src/components/feature_flags.rs
+++ b/aptos-move/aptos-release-builder/src/components/feature_flags.rs
@@ -160,6 +160,7 @@ pub enum FeatureFlag {
     VMBinaryFormatV10,
     SlhDsaSha2_128sSignature,
     EncryptedTransactions,
+    EmitFeatureFee,
 }
 
 fn generate_features_blob(writer: &CodeWriter, data: &[u64]) {
@@ -419,6 +420,7 @@ impl From<FeatureFlag> for AptosFeatureFlag {
             FeatureFlag::EnableFunctionReflection => AptosFeatureFlag::ENABLE_FUNCTION_REFLECTION,
             FeatureFlag::VMBinaryFormatV10 => AptosFeatureFlag::VM_BINARY_FORMAT_V10,
             FeatureFlag::EncryptedTransactions => AptosFeatureFlag::ENCRYPTED_TRANSACTIONS,
+            FeatureFlag::EmitFeatureFee => AptosFeatureFlag::EMIT_FEATURE_FEE,
         }
     }
 }
@@ -605,6 +607,7 @@ impl From<AptosFeatureFlag> for FeatureFlag {
             AptosFeatureFlag::ENABLE_FUNCTION_REFLECTION => FeatureFlag::EnableFunctionReflection,
             AptosFeatureFlag::VM_BINARY_FORMAT_V10 => FeatureFlag::VMBinaryFormatV10,
             AptosFeatureFlag::ENCRYPTED_TRANSACTIONS => FeatureFlag::EncryptedTransactions,
+            AptosFeatureFlag::EMIT_FEATURE_FEE => FeatureFlag::EmitFeatureFee,
         }
     }
 }

--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -39,7 +39,7 @@ use aptos_block_executor::{
 };
 use aptos_crypto::HashValue;
 use aptos_framework_natives::code::PublishRequest;
-use aptos_gas_algebra::{Gas, GasQuantity, NumBytes, Octa};
+use aptos_gas_algebra::{FeePerGasUnit, Gas, GasQuantity, NumBytes, Octa};
 use aptos_gas_meter::{AptosGasMeter, GasAlgebra, StandardGasAlgebra, StandardGasMeter};
 use aptos_gas_schedule::{
     gas_feature_versions::{self, RELEASE_V1_10, RELEASE_V1_27, RELEASE_V1_38},
@@ -572,15 +572,17 @@ impl AptosVM {
         txn_data: &TransactionMetadata,
         gas_meter: &impl AptosGasMeter,
         storage_fee_refund: u64,
-    ) -> FeeStatement {
+    ) -> (FeeStatement, u64) {
         let gas_used = Self::gas_used(txn_data.max_gas_amount(), gas_meter);
-        FeeStatement::new(
+        let feature_fee_octas = u64::from(gas_meter.feature_fee_used());
+        let fee_statement = FeeStatement::new(
             gas_used,
             u64::from(gas_meter.execution_gas_used()),
             u64::from(gas_meter.io_gas_used()),
             u64::from(gas_meter.storage_fee_used()),
             storage_fee_refund,
-        )
+        );
+        (fee_statement, feature_fee_octas)
     }
 
     pub(crate) fn failed_transaction_cleanup(
@@ -730,7 +732,7 @@ impl AptosVM {
         let should_create_account_resource =
             should_create_account_resource(txn_data, self.features(), resolver, module_storage)?;
 
-        let (previous_session_change_set, fee_statement) = if should_create_account_resource {
+        let (previous_session_change_set, fee_statement, feature_fee_octas) = if should_create_account_resource {
             let mut abort_hook_session =
                 AbortHookSession::new(self, txn_data, resolver, prologue_session_change_set);
 
@@ -778,7 +780,7 @@ impl AptosVM {
                 );
             };
 
-            let fee_statement =
+            let (fee_statement, feature_fee_octas) =
                 AptosVM::fee_statement_from_gas_meter(txn_data, gas_meter, ZERO_STORAGE_REFUND);
 
             // Verify we charged sufficiently for creating an account slot
@@ -808,11 +810,11 @@ impl AptosVM {
                     )?;
                 }
             }
-            (abort_hook_session_change_set, fee_statement)
+            (abort_hook_session_change_set, fee_statement, feature_fee_octas)
         } else {
-            let fee_statement =
+            let (fee_statement, feature_fee_octas) =
                 AptosVM::fee_statement_from_gas_meter(txn_data, gas_meter, ZERO_STORAGE_REFUND);
-            (prologue_session_change_set, fee_statement)
+            (prologue_session_change_set, fee_statement, feature_fee_octas)
         };
 
         let mut epilogue_session = EpilogueSession::on_user_session_failure(
@@ -836,6 +838,7 @@ impl AptosVM {
                 serialized_signers,
                 gas_meter.balance(),
                 fee_statement,
+                feature_fee_octas,
                 self.features(),
                 txn_data,
                 log_context,
@@ -872,7 +875,7 @@ impl AptosVM {
             }
         }
 
-        let fee_statement = AptosVM::fee_statement_from_gas_meter(
+        let (fee_statement, feature_fee_octas) = AptosVM::fee_statement_from_gas_meter(
             txn_data,
             gas_meter,
             u64::from(epilogue_session.get_storage_fee_refund()),
@@ -884,6 +887,7 @@ impl AptosVM {
                 serialized_signers,
                 gas_meter.balance(),
                 fee_statement,
+                feature_fee_octas,
                 self.features(),
                 txn_data,
                 log_context,
@@ -975,6 +979,7 @@ impl AptosVM {
         gas_meter: &mut impl AptosGasMeter,
         traversal_context: &mut TraversalContext,
         entry_fn: &EntryFunction,
+        gas_unit_price: FeePerGasUnit,
         trace_recorder: &mut impl TraceRecorder,
     ) -> Result<(), VMStatus> {
         dispatch_loader!(module_storage, loader, {
@@ -1012,6 +1017,7 @@ impl AptosVM {
                 );
                 if maybe_randomness_annotation.is_some() {
                     session.mark_unbiasable();
+                    gas_meter.charge_randomness_txn(gas_unit_price)?;
                 }
             }
 
@@ -1093,6 +1099,7 @@ impl AptosVM {
                         gas_meter,
                         traversal_context,
                         entry_fn,
+                        txn_data.gas_unit_price(),
                         trace_recorder,
                     )
                 })?;
@@ -1341,6 +1348,7 @@ impl AptosVM {
                     traversal_context,
                     multisig_address,
                     &entry_function,
+                    txn_data.gas_unit_price(),
                     change_set_configs,
                     trace_recorder,
                 ),
@@ -1416,6 +1424,7 @@ impl AptosVM {
         traversal_context: &mut TraversalContext,
         multisig_address: AccountAddress,
         payload: &EntryFunction,
+        gas_unit_price: FeePerGasUnit,
         change_set_configs: &ChangeSetConfigs,
         trace_recorder: &mut impl TraceRecorder,
     ) -> Result<UserSessionChangeSet, VMStatus> {
@@ -1429,6 +1438,7 @@ impl AptosVM {
                 gas_meter,
                 traversal_context,
                 payload,
+                gas_unit_price,
                 trace_recorder,
             )
         })?;

--- a/aptos-move/aptos-vm/src/system_module_names.rs
+++ b/aptos-move/aptos-vm/src/system_module_names.rs
@@ -80,3 +80,4 @@ pub static TRANSACTION_FEE_MODULE: Lazy<ModuleId> = Lazy::new(|| {
 });
 
 pub const EMIT_FEE_STATEMENT: &IdentStr = ident_str!("emit_fee_statement");
+pub const EMIT_FEATURE_FEE: &IdentStr = ident_str!("emit_feature_fee");

--- a/aptos-move/aptos-vm/src/transaction_validation.rs
+++ b/aptos-move/aptos-vm/src/transaction_validation.rs
@@ -6,7 +6,7 @@ use crate::{
     errors::{convert_epilogue_error, convert_prologue_error, expect_only_successful_execution},
     move_vm_ext::{AptosMoveResolver, SessionExt},
     system_module_names::{
-        EMIT_FEE_STATEMENT, MULTISIG_ACCOUNT_MODULE, TRANSACTION_FEE_MODULE,
+        EMIT_FEE_STATEMENT, EMIT_FEATURE_FEE, MULTISIG_ACCOUNT_MODULE, TRANSACTION_FEE_MODULE,
         VALIDATE_MULTISIG_TRANSACTION,
     },
     testing::{maybe_raise_injected_error, InjectedError},
@@ -15,7 +15,7 @@ use crate::{
 use aptos_gas_algebra::Gas;
 use aptos_types::{
     account_config::constants::CORE_CODE_ADDRESS,
-    fee_statement::FeeStatement,
+    fee_statement::{FeatureFee, FeeStatement},
     move_utils::as_move_value::AsMoveValue,
     on_chain_config::Features,
     transaction::{MultisigTransactionPayload, ReplayProtector, TransactionExecutableRef},
@@ -456,6 +456,7 @@ fn run_epilogue(
     serialized_signers: &SerializedSigners,
     gas_remaining: Gas,
     fee_statement: FeeStatement,
+    feature_fee_octas: u64,
     txn_data: &TransactionMetadata,
     features: &Features,
     traversal_context: &mut TraversalContext,
@@ -592,7 +593,14 @@ fn run_epilogue(
 
     // Emit the FeeStatement event
     if features.is_emit_fee_statement_enabled() {
-        emit_fee_statement(session, module_storage, fee_statement, traversal_context)?;
+        emit_fee_statement(session, module_storage, &fee_statement, traversal_context)?;
+        emit_feature_fee(
+            session,
+            module_storage,
+            feature_fee_octas,
+            features,
+            traversal_context,
+        )?;
     }
 
     maybe_raise_injected_error(InjectedError::EndOfRunEpilogue)?;
@@ -603,14 +611,44 @@ fn run_epilogue(
 fn emit_fee_statement(
     session: &mut SessionExt<impl AptosMoveResolver>,
     module_storage: &impl ModuleStorage,
-    fee_statement: FeeStatement,
+    fee_statement: &FeeStatement,
     traversal_context: &mut TraversalContext,
 ) -> VMResult<()> {
+    let bytes = bcs::to_bytes(fee_statement).expect("Failed to serialize fee statement");
     session.execute_function_bypass_visibility(
         &TRANSACTION_FEE_MODULE,
         EMIT_FEE_STATEMENT,
         vec![],
-        vec![bcs::to_bytes(&fee_statement).expect("Failed to serialize fee statement")],
+        vec![bytes],
+        &mut UnmeteredGasMeter,
+        traversal_context,
+        module_storage,
+    )?;
+    Ok(())
+}
+
+fn emit_feature_fee(
+    session: &mut SessionExt<impl AptosMoveResolver>,
+    module_storage: &impl ModuleStorage,
+    feature_fee_octas: u64,
+    features: &Features,
+    traversal_context: &mut TraversalContext,
+) -> VMResult<()> {
+    if !features.is_emit_feature_fee_enabled() {
+        return Ok(());
+    }
+    if feature_fee_octas == 0 {
+        return Ok(());
+    }
+    let bytes = bcs::to_bytes(&FeatureFee::Randomness {
+        fee_octas: feature_fee_octas,
+    })
+    .expect("Failed to serialize feature fee");
+    session.execute_function_bypass_visibility(
+        &TRANSACTION_FEE_MODULE,
+        EMIT_FEATURE_FEE,
+        vec![],
+        vec![bytes],
         &mut UnmeteredGasMeter,
         traversal_context,
         module_storage,
@@ -626,6 +664,7 @@ pub(crate) fn run_success_epilogue(
     serialized_signers: &SerializedSigners,
     gas_remaining: Gas,
     fee_statement: FeeStatement,
+    feature_fee_octas: u64,
     features: &Features,
     txn_data: &TransactionMetadata,
     log_context: &AdapterLogSchema,
@@ -645,6 +684,7 @@ pub(crate) fn run_success_epilogue(
         serialized_signers,
         gas_remaining,
         fee_statement,
+        feature_fee_octas,
         txn_data,
         features,
         traversal_context,
@@ -661,6 +701,7 @@ pub(crate) fn run_failure_epilogue(
     serialized_signers: &SerializedSigners,
     gas_remaining: Gas,
     fee_statement: FeeStatement,
+    feature_fee_octas: u64,
     features: &Features,
     txn_data: &TransactionMetadata,
     log_context: &AdapterLogSchema,
@@ -673,6 +714,7 @@ pub(crate) fn run_failure_epilogue(
         serialized_signers,
         gas_remaining,
         fee_statement,
+        feature_fee_octas,
         txn_data,
         features,
         traversal_context,

--- a/aptos-move/framework/aptos-framework/sources/transaction_fee.move
+++ b/aptos-move/framework/aptos-framework/sources/transaction_fee.move
@@ -72,7 +72,14 @@ module aptos_framework::transaction_fee {
         /// Storage fee charge.
         storage_fee_octas: u64,
         /// Storage fee refund.
-        storage_fee_refund_octas: u64
+        storage_fee_refund_octas: u64,
+    }
+
+    #[event]
+    /// Separate event for feature-specific fees (e.g., randomness).
+    /// Emitted alongside FeeStatement when a feature fee is charged.
+    enum FeatureFee has drop, store {
+        Randomness { fee_octas: u64 },
     }
 
     /// Burn transaction fees in epilogue.
@@ -143,6 +150,11 @@ module aptos_framework::transaction_fee {
     // Called by the VM after epilogue.
     fun emit_fee_statement(fee_statement: FeeStatement) {
         event::emit(fee_statement)
+    }
+
+    // Called by the VM after epilogue when a feature fee is charged.
+    fun emit_feature_fee(feature_fee: FeatureFee) {
+        event::emit(feature_fee)
     }
 
     // DEPRECATED section:

--- a/aptos-move/framework/move-stdlib/sources/configs/features.move
+++ b/aptos-move/framework/move-stdlib/sources/configs/features.move
@@ -879,6 +879,17 @@ module std::features {
         is_enabled(ENCRYPTED_TRANSACTIONS)
     }
 
+    /// Whether the FeatureFee event emission is enabled.
+    const EMIT_FEATURE_FEE: u64 = 109;
+
+    public fun get_emit_feature_fee_feature(): u64 {
+        EMIT_FEATURE_FEE
+    }
+
+    public fun is_emit_feature_fee_enabled(): bool acquires Features {
+        is_enabled(EMIT_FEATURE_FEE)
+    }
+
     // ============================================================================================
     // Feature Flag Implementation
 

--- a/types/src/fee_statement.rs
+++ b/types/src/fee_statement.rs
@@ -100,6 +100,13 @@ impl FeeStatement {
     }
 }
 
+/// Separate event for feature-specific fees (e.g., randomness).
+/// Mirrors the Move `FeatureFee` enum in `transaction_fee.move`.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum FeatureFee {
+    Randomness { fee_octas: u64 },
+}
+
 impl MoveEventV2Type for FeeStatement {}
 
 impl MoveStructType for FeeStatement {

--- a/types/src/on_chain_config/aptos_features.rs
+++ b/types/src/on_chain_config/aptos_features.rs
@@ -167,6 +167,8 @@ pub enum FeatureFlag {
     SLH_DSA_SHA2_128S_SIGNATURE = 107,
     /// Whether EncryptedTransactions is enabled
     ENCRYPTED_TRANSACTIONS = 108,
+    /// Whether the FeatureFee event emission is enabled
+    EMIT_FEATURE_FEE = 109,
 }
 
 impl FeatureFlag {
@@ -478,6 +480,10 @@ impl Features {
 
     pub fn is_encrypted_transactions_enabled(&self) -> bool {
         self.is_enabled(FeatureFlag::ENCRYPTED_TRANSACTIONS)
+    }
+
+    pub fn is_emit_feature_fee_enabled(&self) -> bool {
+        self.is_emit_fee_statement_enabled() && self.is_enabled(FeatureFlag::EMIT_FEATURE_FEE)
     }
 
     pub fn get_max_identifier_size(&self) -> u64 {


### PR DESCRIPTION
## Summary

Randomness transactions currently pay for the network-wide overhead of randomness generation (pipeline serialization, DKG share aggregation, zaptos optimization bypass) through execution gas. This PR changes that to charge a **fixed APT fee** (100,000 octas = 0.001 APT) that does **not** count toward the block gas limit, ensuring randomness overhead doesn't crowd out other transactions.

### Design

- Introduces a new **"feature fee"** category in the gas algebra — a separate charging path (`charge_feature_fee` / `feature_fee_used`) that deducts from the user's gas balance but does not contribute to execution/IO gas or the block gas limit. This is extensible for future feature fees (e.g., encrypted transactions).
- The randomness fee is charged in `execute_entry_function` when `#[randomness]` annotation is detected, using `gas_meter.charge_randomness_txn(gas_unit_price)`.
- A new `FeatureFee` enum event (`FeatureFee::Randomness { fee_octas }`) is emitted as a separate Move event alongside `FeeStatement`, gated on the `EMIT_FEATURE_FEE` feature flag (flag 109).
- The `FeeStatement` struct remains unchanged (5 fields) both in Move and Rust. The feature fee is tracked internally by the gas meter and passed as a separate `u64` through the epilogue call chain for event emission.

### Key changes

| Area | Change |
|------|--------|
| `GasAlgebra` trait | New `charge_feature_fee()` and `feature_fee_used()` methods |
| `StandardGasAlgebra` | Tracks `feature_fee_in_internal_units` and `feature_fee_used`; includes feature fee in balance invariant check |
| Gas schedule | New `randomness_txn_fee: Fee` param (100,000 octas), gas feature version bumped to V48 (`RELEASE_V1_44`) |
| `AptosGasMeter` | New `charge_randomness_txn()` method, gated on `RELEASE_V1_44` |
| `AptosVM` | Calls `charge_randomness_txn` in `execute_entry_function` when randomness annotation is present; passes feature fee as separate `u64` to epilogue |
| Move framework | New `FeatureFee` enum event + `emit_feature_fee()` in `transaction_fee.move` |
| Feature flags | New `EMIT_FEATURE_FEE` (109) gates `FeatureFee` event emission |
| Gas profiling | Tracks and reports `randomness_txn_cost` in flamegraphs, reports, and HTML templates |
| Helper refactor | Extracted `octa_to_internal_gas()` shared by `charge_storage_fee` and `charge_feature_fee` |

## Test plan

- [x] Unit tests for `charge_feature_fee` (normal, out-of-gas, zero price, not-in-block-limit) in `aptos-gas-meter`
- [x] `cargo check` passes for all modified packages
- [x] `cargo test -p aptos-gas-schedule` — passes
- [x] `cargo test -p aptos-types` — passes
- [ ] CI: full test suite
- [ ] Verify randomness e2e tests pass with the new fee path