### PR TITLE
[consensus] Add tests for secret_sharing module

### DIFF
--- a/consensus/src/rand/rand_gen/mod.rs
+++ b/consensus/src/rand/rand_gen/mod.rs
@@ -2,7 +2,7 @@
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 #[cfg(test)]
-mod test_utils;
+pub(crate) mod test_utils;
 
 pub mod block_queue;
 pub mod network_messages;

--- a/consensus/src/rand/secret_sharing/block_queue.rs
+++ b/consensus/src/rand/secret_sharing/block_queue.rs
@@ -22,7 +22,7 @@ pub struct QueueItem {
 }
 
 impl QueueItem {
-    pub fn new(ordered_blocks: OrderedBlocks, pending_secret_key_rounds: HashSet<Round>) -> Self {
+    pub fn new(ordered_blocks: OrderedBlocks) -> Self {
         assert!(!ordered_blocks.ordered_blocks.is_empty());
         let offsets_by_round: HashMap<Round, usize> = ordered_blocks
             .ordered_blocks
@@ -30,6 +30,7 @@ impl QueueItem {
             .enumerate()
             .map(|(idx, b)| (b.round(), idx))
             .collect();
+        let pending_secret_key_rounds: HashSet<Round> = offsets_by_round.keys().copied().collect();
         Self {
             ordered_blocks,
             offsets_by_round,
@@ -132,5 +133,134 @@ impl BlockQueue {
             .last()
             .map(|(_, item)| item)
             .filter(|item| item.offsets_by_round.contains_key(&round))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::rand::{
+        rand_gen::test_utils::create_ordered_blocks,
+        secret_sharing::test_utils::{create_metadata, create_secret_shared_key, TestContext},
+    };
+
+    /// Helper: mark all rounds in a QueueItem as secret-shared so it becomes ready.
+    fn mark_all_ready(ctx: &TestContext, item: &mut QueueItem) {
+        let rounds: Vec<Round> = item.pending_secret_key_rounds.iter().copied().collect();
+        for round in rounds {
+            let metadata = create_metadata(ctx.epoch, round);
+            let key = create_secret_shared_key(ctx, &metadata);
+            item.set_secret_shared_key(round, key);
+        }
+    }
+
+    #[test]
+    fn test_queue_item_basic() {
+        let blocks = create_ordered_blocks(vec![1, 2, 3]);
+        let item = QueueItem::new(blocks);
+
+        assert_eq!(item.first_round(), 1);
+        assert_eq!(item.offset(1), 0);
+        assert_eq!(item.offset(2), 1);
+        assert_eq!(item.offset(3), 2);
+        // All block rounds are pending secret sharing
+        assert!(!item.is_fully_secret_shared());
+        assert_eq!(item.pending_secret_key_rounds.len(), 3);
+    }
+
+    #[test]
+    fn test_queue_item_pending_rounds_match_blocks() {
+        // Verify that new() populates pending_secret_key_rounds from block rounds
+        let blocks = create_ordered_blocks(vec![5, 6]);
+        let item = QueueItem::new(blocks);
+        assert_eq!(item.pending_secret_key_rounds, HashSet::from([5, 6]));
+        assert!(!item.is_fully_secret_shared());
+    }
+
+    #[test]
+    fn test_queue_item_set_secret_shared_key() {
+        let ctx = TestContext::new(vec![1, 1, 1, 1]);
+        let blocks = create_ordered_blocks(vec![10]);
+        let mut item = QueueItem::new(blocks);
+
+        assert!(!item.is_fully_secret_shared());
+
+        let metadata = create_metadata(ctx.epoch, 10);
+        let key = create_secret_shared_key(&ctx, &metadata);
+        item.set_secret_shared_key(10, key);
+
+        assert!(item.is_fully_secret_shared());
+    }
+
+    #[test]
+    fn test_block_queue_push_and_dequeue() {
+        let ctx = TestContext::new(vec![1, 1, 1, 1]);
+        let mut queue = BlockQueue::new();
+
+        // Push an item and mark all rounds ready
+        let blocks = create_ordered_blocks(vec![1, 2]);
+        let mut item = QueueItem::new(blocks);
+        mark_all_ready(&ctx, &mut item);
+        queue.push_back(item);
+
+        let ready = queue.dequeue_ready_prefix();
+        assert_eq!(ready.len(), 1);
+        assert!(queue.queue().is_empty());
+    }
+
+    #[test]
+    fn test_block_queue_dequeue_prefix_only() {
+        let ctx = TestContext::new(vec![1, 1, 1, 1]);
+        let mut queue = BlockQueue::new();
+
+        // First item: ready
+        let blocks1 = create_ordered_blocks(vec![1, 2]);
+        let mut item1 = QueueItem::new(blocks1);
+        mark_all_ready(&ctx, &mut item1);
+        queue.push_back(item1);
+
+        // Second item: NOT ready (pending round 3)
+        let blocks2 = create_ordered_blocks(vec![3]);
+        let item2 = QueueItem::new(blocks2);
+        queue.push_back(item2);
+
+        // Third item: ready
+        let blocks3 = create_ordered_blocks(vec![5, 6]);
+        let mut item3 = QueueItem::new(blocks3);
+        mark_all_ready(&ctx, &mut item3);
+        queue.push_back(item3);
+
+        // Only first item should dequeue (second blocks third)
+        let ready = queue.dequeue_ready_prefix();
+        assert_eq!(ready.len(), 1);
+        assert_eq!(queue.queue().len(), 2);
+
+        // Mark second item as ready
+        let metadata = create_metadata(ctx.epoch, 3);
+        let key = create_secret_shared_key(&ctx, &metadata);
+        queue.item_mut(3).unwrap().set_secret_shared_key(3, key);
+
+        // Now both remaining items should dequeue
+        let ready = queue.dequeue_ready_prefix();
+        assert_eq!(ready.len(), 2);
+        assert!(queue.queue().is_empty());
+    }
+
+    #[test]
+    fn test_block_queue_item_mut() {
+        let mut queue = BlockQueue::new();
+
+        let blocks = create_ordered_blocks(vec![10, 11, 12]);
+        let item = QueueItem::new(blocks);
+        queue.push_back(item);
+
+        // Finds correct item by round
+        assert!(queue.item_mut(10).is_some());
+        assert!(queue.item_mut(11).is_some());
+        assert!(queue.item_mut(12).is_some());
+
+        // None for gap / non-existent rounds
+        assert!(queue.item_mut(5).is_none());
+        assert!(queue.item_mut(13).is_none());
     }
 }

--- a/consensus/src/rand/secret_sharing/mod.rs
+++ b/consensus/src/rand/secret_sharing/mod.rs
@@ -6,4 +6,6 @@ pub mod network_messages;
 pub mod reliable_broadcast_state;
 pub mod secret_share_manager;
 pub mod secret_share_store;
+#[cfg(test)]
+mod test_utils;
 pub mod types;

--- a/consensus/src/rand/secret_sharing/reliable_broadcast_state.rs
+++ b/consensus/src/rand/secret_sharing/reliable_broadcast_state.rs
@@ -59,3 +59,86 @@ impl BroadcastStatus<SecretShareMessage, SecretShareMessage> for Arc<SecretShare
         Ok(aggregated)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::rand::secret_sharing::{
+        secret_share_store::SecretShareStore,
+        test_utils::{create_metadata, create_secret_share, TestContext},
+    };
+    use aptos_types::secret_sharing::SecretSharedKey;
+    use futures_channel::mpsc::{unbounded, UnboundedReceiver};
+
+    fn make_state(
+        ctx: &TestContext,
+        metadata: &SecretShareMetadata,
+    ) -> (
+        Arc<SecretShareAggregateState>,
+        UnboundedReceiver<SecretSharedKey>,
+    ) {
+        let (tx, rx) = unbounded();
+        let mut store = SecretShareStore::new(
+            ctx.epoch,
+            ctx.authors[0],
+            ctx.secret_share_config.clone(),
+            tx,
+        );
+        store.update_highest_known_round(metadata.round);
+
+        // Add self share so the store is in PendingDecision state
+        let self_share = create_secret_share(ctx, 0, metadata);
+        store.add_self_share(self_share).unwrap();
+
+        let state = Arc::new(SecretShareAggregateState::new(
+            Arc::new(Mutex::new(store)),
+            metadata.clone(),
+            ctx.secret_share_config.clone(),
+        ));
+        (state, rx)
+    }
+
+    #[test]
+    fn test_broadcast_add_happy_path() {
+        let ctx = TestContext::new(vec![1, 1, 1, 1]);
+        let metadata = create_metadata(ctx.epoch, 5);
+        let (state, _rx) = make_state(&ctx, &metadata);
+
+        // Valid share accepted, returns Ok(None) when below threshold
+        let share = create_secret_share(&ctx, 1, &metadata);
+        let result = state.add(ctx.authors[1], share);
+        assert!(result.is_ok());
+        assert!(result.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn test_broadcast_add_triggers_aggregation() {
+        let ctx = TestContext::new(vec![1, 1, 1, 1]);
+        let metadata = create_metadata(ctx.epoch, 5);
+        let (state, mut rx) = make_state(&ctx, &metadata);
+
+        // Add enough shares to trigger aggregation
+        // With 4 validators weight 1 each and threshold 3, we need 3 shares total.
+        // Self share (weight 1) is already in the store. We need 2 more peer shares.
+        for i in 1..=2 {
+            let share = create_secret_share(&ctx, i, &metadata);
+            let result = state.add(ctx.authors[i], share).unwrap();
+            if i < 2 {
+                assert!(result.is_none());
+            } else {
+                // The aggregation is triggered asynchronously via spawn_blocking,
+                // so add_share returns decided=true but the channel delivery is async
+                assert!(result.is_some());
+            }
+        }
+
+        // Verify decision arrives on channel
+        use futures::StreamExt;
+        let key: SecretSharedKey =
+            tokio::time::timeout(std::time::Duration::from_secs(5), rx.next())
+                .await
+                .expect("Timed out waiting for decision")
+                .expect("Channel closed unexpectedly");
+        assert_eq!(key.metadata, metadata);
+    }
+}

--- a/consensus/src/rand/secret_sharing/secret_share_manager.rs
+++ b/consensus/src/rand/secret_sharing/secret_share_manager.rs
@@ -40,7 +40,7 @@ use futures_channel::{
     mpsc::{unbounded, UnboundedReceiver, UnboundedSender},
     oneshot,
 };
-use std::{collections::HashSet, future::Future, pin::Pin, sync::Arc, time::Duration};
+use std::{future::Future, pin::Pin, sync::Arc, time::Duration};
 use tokio_retry::strategy::ExponentialBackoff;
 
 pub type Sender<T> = UnboundedSender<T>;
@@ -128,13 +128,11 @@ impl SecretShareManager {
             "Processing incoming blocks."
         );
 
-        let pending_secret_key_rounds = HashSet::from_iter(rounds);
         for block in blocks.ordered_blocks.iter() {
             self.enqueue_self_derive(block)?;
         }
 
-        self.block_queue
-            .push_back(QueueItem::new(blocks, pending_secret_key_rounds));
+        self.block_queue.push_back(QueueItem::new(blocks));
         Ok(())
     }
 

--- a/consensus/src/rand/secret_sharing/secret_share_store.rs
+++ b/consensus/src/rand/secret_sharing/secret_share_store.rs
@@ -319,3 +319,192 @@ impl SecretShareStore {
             .filter(|share| &share.metadata == metadata))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::rand::secret_sharing::test_utils::{
+        create_metadata, create_secret_share, TestContext,
+    };
+    use aptos_types::secret_sharing::SecretSharedKey;
+    use futures_channel::mpsc::{unbounded, UnboundedReceiver};
+
+    fn make_store(ctx: &TestContext) -> (SecretShareStore, UnboundedReceiver<SecretSharedKey>) {
+        let (tx, rx) = unbounded();
+        let store = SecretShareStore::new(
+            ctx.epoch,
+            ctx.authors[0],
+            ctx.secret_share_config.clone(),
+            tx,
+        );
+        (store, rx)
+    }
+
+    #[test]
+    fn test_store_update_highest_known_round() {
+        let ctx = TestContext::new(vec![1, 1, 1, 1]);
+        let (mut store, _rx) = make_store(&ctx);
+
+        assert_eq!(store.highest_known_round, 0);
+        store.update_highest_known_round(5);
+        assert_eq!(store.highest_known_round, 5);
+        // Should take max
+        store.update_highest_known_round(3);
+        assert_eq!(store.highest_known_round, 5);
+        store.update_highest_known_round(10);
+        assert_eq!(store.highest_known_round, 10);
+    }
+
+    #[test]
+    fn test_store_add_self_share_validation() {
+        let ctx = TestContext::new(vec![1, 1, 1, 1]);
+        let (mut store, _rx) = make_store(&ctx);
+        store.update_highest_known_round(10);
+
+        // Wrong epoch fails
+        let bad_epoch_meta = create_metadata(99, 5);
+        let share = create_secret_share(&ctx, 0, &bad_epoch_meta);
+        assert!(store.add_self_share(share).is_err());
+
+        // Round too far in future fails (> highest + 200)
+        let far_future_meta = create_metadata(ctx.epoch, 10 + FUTURE_ROUNDS_TO_ACCEPT + 1);
+        let share = create_secret_share(&ctx, 0, &far_future_meta);
+        assert!(store.add_self_share(share).is_err());
+
+        // Valid round succeeds
+        let valid_meta = create_metadata(ctx.epoch, 5);
+        let share = create_secret_share(&ctx, 0, &valid_meta);
+        assert!(store.add_self_share(share).is_ok());
+    }
+
+    #[test]
+    fn test_store_add_share_validation() {
+        let ctx = TestContext::new(vec![1, 1, 1, 1]);
+        let (mut store, _rx) = make_store(&ctx);
+        store.update_highest_known_round(10);
+
+        // Wrong epoch fails
+        let bad_epoch_meta = create_metadata(99, 5);
+        let share = create_secret_share(&ctx, 1, &bad_epoch_meta);
+        assert!(store.add_share(share).is_err());
+
+        // Future round fails
+        let far_future_meta = create_metadata(ctx.epoch, 10 + FUTURE_ROUNDS_TO_ACCEPT + 1);
+        let share = create_secret_share(&ctx, 1, &far_future_meta);
+        assert!(store.add_share(share).is_err());
+
+        // Valid share succeeds
+        let valid_meta = create_metadata(ctx.epoch, 5);
+        let share = create_secret_share(&ctx, 1, &valid_meta);
+        assert!(store.add_share(share).is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_store_self_share_then_peer_shares() {
+        let ctx = TestContext::new(vec![1, 1, 1, 1]);
+        let (mut store, mut rx) = make_store(&ctx);
+        let round = 5;
+        store.update_highest_known_round(round);
+        let metadata = create_metadata(ctx.epoch, round);
+
+        // Add self share first -> PendingDecision
+        let self_share = create_secret_share(&ctx, 0, &metadata);
+        store.add_self_share(self_share).unwrap();
+
+        // Add peer shares until aggregation triggers
+        for i in 1..ctx.authors.len() {
+            let share = create_secret_share(&ctx, i, &metadata);
+            let decided = store.add_share(share).unwrap();
+            if decided {
+                break;
+            }
+        }
+
+        // Verify decision arrives on channel
+        use futures::StreamExt;
+        let key = tokio::time::timeout(std::time::Duration::from_secs(5), rx.next())
+            .await
+            .expect("Timed out waiting for decision")
+            .expect("Channel closed unexpectedly");
+        assert_eq!(key.metadata, metadata);
+    }
+
+    #[tokio::test]
+    async fn test_store_peer_shares_then_self_share() {
+        let ctx = TestContext::new(vec![1, 1, 1, 1]);
+        let (mut store, mut rx) = make_store(&ctx);
+        let round = 5;
+        store.update_highest_known_round(round);
+        let metadata = create_metadata(ctx.epoch, round);
+
+        // Add peer shares first (PendingMetadata accumulates)
+        for i in 1..ctx.authors.len() {
+            let share = create_secret_share(&ctx, i, &metadata);
+            store.add_share(share).unwrap();
+        }
+
+        // Add self share with metadata -> triggers transition + aggregation
+        let self_share = create_secret_share(&ctx, 0, &metadata);
+        store.add_self_share(self_share).unwrap();
+
+        // Verify decision arrives on channel
+        use futures::StreamExt;
+        let key = tokio::time::timeout(std::time::Duration::from_secs(5), rx.next())
+            .await
+            .expect("Timed out waiting for decision")
+            .expect("Channel closed unexpectedly");
+        assert_eq!(key.metadata, metadata);
+    }
+
+    #[test]
+    fn test_store_get_all_shares_authors() {
+        let ctx = TestContext::new(vec![1, 1, 1, 1]);
+        let (mut store, _rx) = make_store(&ctx);
+        let round = 5;
+        store.update_highest_known_round(round);
+        let metadata = create_metadata(ctx.epoch, round);
+
+        // Add self share
+        let self_share = create_secret_share(&ctx, 0, &metadata);
+        store.add_self_share(self_share).unwrap();
+
+        // Add one peer share
+        let peer_share = create_secret_share(&ctx, 1, &metadata);
+        store.add_share(peer_share).unwrap();
+
+        // Should return authors who have contributed shares
+        let authors = store.get_all_shares_authors(&metadata).unwrap();
+        assert!(authors.contains(&ctx.authors[0]));
+        assert!(authors.contains(&ctx.authors[1]));
+        assert_eq!(authors.len(), 2);
+    }
+
+    #[test]
+    fn test_store_get_self_share() {
+        let ctx = TestContext::new(vec![1, 1, 1, 1]);
+        let (mut store, _rx) = make_store(&ctx);
+        let round = 5;
+        store.update_highest_known_round(round);
+        let metadata = create_metadata(ctx.epoch, round);
+
+        // Future round errors
+        let future_meta = create_metadata(ctx.epoch, round + 1);
+        assert!(store.get_self_share(&future_meta).is_err());
+
+        // No share yet -> None
+        assert!(store.get_self_share(&metadata).unwrap().is_none());
+
+        // Add self share
+        let self_share = create_secret_share(&ctx, 0, &metadata);
+        store.add_self_share(self_share).unwrap();
+
+        // Matching metadata returns share
+        let retrieved = store.get_self_share(&metadata).unwrap();
+        assert!(retrieved.is_some());
+        assert_eq!(retrieved.unwrap().author, ctx.authors[0]);
+
+        // Mismatched metadata returns None
+        let other_meta = create_metadata(ctx.epoch, round);
+        assert!(store.get_self_share(&other_meta).unwrap().is_none());
+    }
+}

--- a/consensus/src/rand/secret_sharing/test_utils.rs
+++ b/consensus/src/rand/secret_sharing/test_utils.rs
@@ -1,0 +1,87 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+use aptos_batch_encryption::{
+    group::Fr, schemes::fptx_weighted::FPTXWeighted, traits::BatchThresholdEncryption,
+};
+use aptos_consensus_types::common::Author;
+use aptos_crypto::{weighted_config::WeightedConfigArkworks, HashValue};
+use aptos_types::{
+    secret_sharing::{
+        Digest, MasterSecretKeyShare, SecretShare, SecretShareConfig, SecretShareMetadata,
+        SecretSharedKey,
+    },
+    validator_verifier::random_validator_verifier_with_voting_power,
+};
+use std::sync::Arc;
+
+pub struct TestContext {
+    pub authors: Vec<Author>,
+    pub epoch: u64,
+    pub secret_share_config: SecretShareConfig,
+    pub msk_shares: Vec<MasterSecretKeyShare>,
+}
+
+impl TestContext {
+    pub fn new(weights: Vec<u64>) -> Self {
+        let num_validators = weights.len();
+        let (signers, validator_verifier) =
+            random_validator_verifier_with_voting_power(num_validators, None, false, &weights);
+        let authors: Vec<Author> = signers.iter().map(|s| s.author()).collect();
+
+        let total_weight: usize = weights.iter().map(|w| *w as usize).sum();
+        let threshold = total_weight * 2 / 3 + 1;
+
+        let tc = WeightedConfigArkworks::<Fr>::new(
+            threshold,
+            weights.iter().map(|w| *w as usize).collect(),
+        )
+        .expect("Failed to create weighted config");
+
+        let (ek, dk, vks, msk_shares) =
+            FPTXWeighted::setup_for_testing(8, 1, 1, &tc).expect("Failed to setup crypto");
+
+        let secret_share_config = SecretShareConfig::new(
+            Arc::new(validator_verifier),
+            dk,
+            msk_shares[0].clone(),
+            vks,
+            tc,
+            ek,
+        );
+
+        Self {
+            authors,
+            epoch: 1,
+            secret_share_config,
+            msk_shares,
+        }
+    }
+}
+
+pub fn create_metadata(epoch: u64, round: u64) -> SecretShareMetadata {
+    SecretShareMetadata::new(epoch, round, 0, HashValue::random(), Digest::default())
+}
+
+pub fn create_secret_share(
+    ctx: &TestContext,
+    author_index: usize,
+    metadata: &SecretShareMetadata,
+) -> SecretShare {
+    let share =
+        FPTXWeighted::derive_decryption_key_share(&ctx.msk_shares[author_index], &metadata.digest)
+            .expect("Failed to derive key share");
+    SecretShare::new(ctx.authors[author_index], metadata.clone(), share)
+}
+
+pub fn create_secret_shared_key(
+    ctx: &TestContext,
+    metadata: &SecretShareMetadata,
+) -> SecretSharedKey {
+    let shares: Vec<SecretShare> = (0..ctx.authors.len())
+        .map(|i| create_secret_share(ctx, i, metadata))
+        .collect();
+    let key = SecretShare::aggregate(shares.iter(), &ctx.secret_share_config)
+        .expect("Failed to aggregate");
+    SecretSharedKey::new(metadata.clone(), key)
+}


### PR DESCRIPTION
## Summary
- Add 15 unit tests for the `rand/secret_sharing` module covering `SecretShareStore`, `BlockQueue`, and `SecretShareAggregateState`
- Create shared test infrastructure (`test_utils.rs`) with `TestContext` for crypto setup and helpers for creating metadata, shares, and aggregated keys
- Improve `QueueItem::new` API: compute `pending_secret_key_rounds` internally from block rounds instead of accepting it as a parameter, making the API safer by construction

## Test plan
- [x] `cargo test -p aptos-consensus --lib rand::secret_sharing` — 15 tests pass
- [x] `cargo clippy -p aptos-consensus --lib --tests` — no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)