### PR TITLE
[compiler-v2] Fix type inference to allow unifying struct constraints and receiver function constraints

### DIFF
--- a/third_party/move/move-compiler-v2/tests/checking/receiver/constraint_compatible.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/receiver/constraint_compatible.exp
@@ -1,0 +1,39 @@
+// -- Model dump before first bytecode pipeline
+module 0x42::m {
+    struct S {
+        value: u64,
+    }
+    private inline fun apply<T>(s: &T,f: |&T|u64): u64 {
+        (f)(s)
+    }
+    private fun get_value(self: &S): u64 {
+        select m::S.value<&S>(self)
+    }
+    private fun test(s: &S): u64 {
+        {
+          let (s: &S): (&S) = Tuple(s);
+          {
+            let (x: &S): (&S) = Tuple(s);
+            Add<u64>(select m::S.value<&S>(x), m::get_value(x))
+          }
+        }
+    }
+} // end 0x42::m
+
+// -- Sourcified model before first bytecode pipeline
+module 0x42::m {
+    struct S {
+        value: u64,
+    }
+    inline fun apply<T>(s: &T, f: |&T|u64): u64 {
+        f(s)
+    }
+    fun get_value(self: &S): u64 {
+        self.value
+    }
+    fun test(s: &S): u64 {
+        let s = s;
+        let x = s;
+        x.value + get_value(x)
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/checking/receiver/constraint_compatible.move
+++ b/third_party/move/move-compiler-v2/tests/checking/receiver/constraint_compatible.move
@@ -1,0 +1,19 @@
+module 0x42::m {
+
+    struct S { value: u64 }
+
+    fun get_value(self: &S): u64 {
+        self.value
+    }
+
+    inline fun apply<T>(s: &T, f: |&T|u64): u64 {
+        f(s)
+    }
+
+    // The lambda parameter `x` gets both a SomeStruct{value} constraint (from
+    // field access) and a SomeReceiverFunction(get_value) constraint (from
+    // receiver call). These should coexist and we should be able to infer x's type.
+    fun test(s: &S): u64 {
+        apply(s, |x| x.value + x.get_value())
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/checking/receiver/constraint_incompatible.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/receiver/constraint_incompatible.exp
@@ -1,0 +1,13 @@
+
+Diagnostics:
+error: unable to infer instantiation of type `&fun self.get_nav(&..):u64 + struct{is_isolated}` (consider providing type arguments or annotating the type)
+   ┌─ tests/checking/receiver/constraint_incompatible.move:19:16
+   │
+19 │         apply(|x| {
+   │                ^
+
+error: unable to infer instantiation of type `_` (consider providing type arguments or annotating the type)
+   ┌─ tests/checking/receiver/constraint_incompatible.move:20:21
+   │
+20 │             let _ = x.is_isolated;
+   │                     ^^^^^^^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/checking/receiver/constraint_incompatible.move
+++ b/third_party/move/move-compiler-v2/tests/checking/receiver/constraint_incompatible.move
@@ -1,0 +1,24 @@
+module 0x42::m {
+
+    struct Position { is_isolated: bool }
+    struct Market { nav: u64 }
+
+    fun get_nav(self: &Market): u64 {
+        self.nav
+    }
+
+    inline fun apply<T>(f: |&T|u64): u64 {
+        abort 0
+    }
+
+    // The lambda parameter type is unconstrained. The field access `x.is_isolated`
+    // adds a SomeStruct{is_isolated} constraint, and the receiver call `x.get_nav()`
+    // adds a SomeReceiverFunction constraint. These coexist on the type variable,
+    // but no struct in scope satisfies both, so the type cannot be inferred.
+    fun test(): u64 {
+        apply(|x| {
+            let _ = x.is_isolated;
+            x.get_nav()
+        })
+    }
+}

--- a/third_party/move/move-model/src/ty.rs
+++ b/third_party/move/move-model/src/ty.rs
@@ -640,6 +640,10 @@ impl Constraint {
                 }
                 Ok(false)
             },
+            // SomeStruct and SomeReceiverFunction constrain orthogonal aspects of a type
+            // (field existence vs receiver function existence), so they can coexist.
+            (Constraint::SomeStruct(..), Constraint::SomeReceiverFunction(..))
+            | (Constraint::SomeReceiverFunction(..), Constraint::SomeStruct(..)) => Ok(false),
             // After the above checks, if one of the constraints is
             // accumulating, indicate its compatible but cannot be joined.
             (c1, c2) if c1.accumulating() || c2.accumulating() => Ok(false),


### PR DESCRIPTION
## Description

In this PR, we change the type inference to allow `SomeStruct` and `SomeReceiverFunction` to co-exist, as they are orthogonal constraints that should not cancel each other out. This allows us to infer types (without requiring explicit type annotations) in cases like the below program:

```move
module 0x42::m {

    struct S { value: u64 }

    fun get_value(self: &S): u64 {
        self.value
    }

    inline fun apply<T>(s: &T, f: |&T|u64): u64 {
        f(s)
    }

    // The lambda parameter `x` gets both a SomeStruct{value} constraint (from
    // field access) and a SomeReceiverFunction(get_value) constraint (from
    // receiver call). These should coexist and we should be able to infer x's type.
    fun test(s: &S): u64 {
        apply(s, |x| x.value + x.get_value())
    }
}
```

closes #18420 

## How Has This Been Tested?

- added new tests
- all existing tests pass

## Type of Change
- [x] Bug fix

## Which Components or Systems Does This Change Impact?
- [x] Move Compiler


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core type unification behavior in `move-model` by treating `SomeStruct` and `SomeReceiverFunction` constraints as compatible, which can affect inference outcomes and downstream diagnostics across the compiler.
> 
> **Overview**
> Fixes Move compiler v2 type inference by making `Constraint::SomeStruct` and `Constraint::SomeReceiverFunction` compatible during constraint joining, instead of immediately producing a `ConstraintsIncompatible` error.
> 
> Adds new receiver-checking tests: one proving a lambda parameter can be inferred when it has both a field-access struct constraint and a receiver-call constraint, and one ensuring inference still fails (with clear diagnostics) when no in-scope struct can satisfy both constraints.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit df0b7a08622acaee363809e189696b83d92ebda0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->