### PR TITLE
[trivial] Fix `NaN` in move code coverage output

### DIFF
--- a/third_party/move/tools/move-coverage/src/lib.rs
+++ b/third_party/move/tools/move-coverage/src/lib.rs
@@ -10,6 +10,15 @@ pub mod coverage_map;
 pub mod source_coverage;
 pub mod summary;
 
+/// Compute coverage percentage. Returns 100% when there are no instructions (vacuous coverage).
+pub fn coverage_percentage(covered: u64, total: u64) -> f64 {
+    if total == 0 {
+        100f64
+    } else {
+        (covered as f64) / (total as f64) * 100f64
+    }
+}
+
 pub fn format_human_summary<M, F, W: Write>(
     modules: &[CompiledModule],
     coverage_map: &M,
@@ -39,7 +48,7 @@ pub fn format_human_summary<M, F, W: Write>(
     writeln!(
         summary_writer,
         "| % Move Coverage: {:.2}  |",
-        (total_covered as f64 / total_instructions as f64) * 100f64
+        coverage_percentage(total_covered, total_instructions)
     )
     .unwrap();
     writeln!(summary_writer, "+-------------------------+").unwrap();

--- a/third_party/move/tools/move-coverage/src/summary.rs
+++ b/third_party/move/tools/move-coverage/src/summary.rs
@@ -4,8 +4,9 @@
 
 #![forbid(unsafe_code)]
 
-use crate::coverage_map::{
-    ExecCoverageMap, ExecCoverageMapWithModules, ModuleCoverageMap, TraceMap,
+use crate::{
+    coverage_map::{ExecCoverageMap, ExecCoverageMapWithModules, ModuleCoverageMap, TraceMap},
+    coverage_percentage,
 };
 use move_binary_format::{
     access::ModuleAccess,
@@ -103,24 +104,18 @@ impl ModuleSummary {
                 writeln!(
                     summary_writer,
                     "\t\t% coverage: {:.2}",
-                    fn_summary.percent_coverage()
+                    coverage_percentage(fn_summary.covered, fn_summary.total)
                 )?;
             }
         }
 
-        let covered_percentage = (all_covered as f64) / (all_total as f64) * 100f64;
+        let covered_percentage = coverage_percentage(all_covered, all_total);
         writeln!(
             summary_writer,
             ">>> % Module coverage: {:.2}",
             covered_percentage
         )?;
         Ok((all_total, all_covered))
-    }
-}
-
-impl FunctionSummary {
-    pub fn percent_coverage(&self) -> f64 {
-        (self.covered as f64) / (self.total as f64) * 100f64
     }
 }
 


### PR DESCRIPTION
## Description

Before, on running `aptos move test --coverage`, we could see:
<img width="791" height="44" alt="image" src="https://github.com/user-attachments/assets/2c1feaf8-bce0-4c4b-a31c-ee12f70432da" />

Now, we get:
<img width="791" height="44" alt="image" src="https://github.com/user-attachments/assets/728a8cb2-78e8-4938-a819-f3b5949a4e2a" />

## How Has This Been Tested?

Manual testing, see images above

## Type of Change
- [x] Bug fix

## Which Components or Systems Does This Change Impact?
- [x] Aptos CLI/SDK

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small arithmetic change to guard divide-by-zero in coverage reporting; affects only displayed coverage percentages.
> 
> **Overview**
> Fixes `NaN` coverage output by centralizing percentage calculation in a new `coverage_percentage` helper that returns `100.0` when the instruction count is `0`.
> 
> Updates both module/function summaries and the overall human summary footer to use this helper, and removes the old `FunctionSummary::percent_coverage` method.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ea86c3897ec4438b2f4c6b3d3792501099f95f3a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->