### PR TITLE
[Forge] Reduce VFN count in realistic_env_max_load_test.

### DIFF
--- a/testsuite/forge-cli/src/suites/land_blocking.rs
+++ b/testsuite/forge-cli/src/suites/land_blocking.rs
@@ -17,7 +17,7 @@ pub(crate) fn get_land_blocking_test(
 ) -> Option<ForgeConfig> {
     let test = match test_name {
         "land_blocking" | "realistic_env_max_load" => {
-            realistic_env_max_load_test(duration, test_cmd, 7, 5)
+            realistic_env_max_load_test(duration, test_cmd, 7, 2)
         },
         "compat" => compat(),
         "framework_upgrade" => framework_upgrade(),


### PR DESCRIPTION
## Description
This PR reduces the VFN count in `realistic_env_max_load_test` from 5 -> 2.

## Testing Plan
Existing test infrastructure.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a single test-suite configuration tweak reducing load-test topology; no production logic changes. Main risk is reduced coverage/representativeness of `realistic_env_max_load_test` during land-blocking runs.
> 
> **Overview**
> Reduces the `realistic_env_max_load_test` land-blocking configuration to run with fewer fullnodes/VFNs by changing the invocation in `land_blocking.rs` from `..., 7, 5` to `..., 7, 2`, lowering the scale of this load test in CI.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 85417e76f16df0ae5c4bec12c3918bc5675bc867. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->