### PR TITLE
[move flow] add new tests for plugin validation

### DIFF
--- a/aptos-move/flow/cont/agents/move-check.md
+++ b/aptos-move/flow/cont/agents/move-check.md
@@ -1,7 +1,4 @@
----
-name: move-check
-description: Check and fix compilation errors in a Move package
----
+{{ frontmatter(name="move-check", description="Check and fix compilation errors in a Move package") }}
 
 {#
  # This agent allows to ask something like 'check compilation in a subagent'.

--- a/aptos-move/flow/cont/agents/move-inf-v2.md
+++ b/aptos-move/flow/cont/agents/move-inf-v2.md
@@ -1,7 +1,4 @@
----
-name: move-inf-v2
-description: Infer specifications for a Move package (v2 — loop invariants first)
----
+{{ frontmatter(name="move-inf-v2", description="Infer specifications for a Move package (v2 — loop invariants first)") }}
 
 {#
  # This agent allows to ask something like 'infer specs v2 in a subagent'

--- a/aptos-move/flow/cont/agents/move-inf-v3.md
+++ b/aptos-move/flow/cont/agents/move-inf-v3.md
@@ -1,7 +1,4 @@
----
-name: move-inf-v3
-description: Infer specifications for a Move package (v3 — synthesize specs directly)
----
+{{ frontmatter(name="move-inf-v3", description="Infer specifications for a Move package (v3 — synthesize specs directly)") }}
 
 {#
  # This agent allows to ask something like 'infer specs v3 in a subagent'

--- a/aptos-move/flow/cont/agents/move-inf.md
+++ b/aptos-move/flow/cont/agents/move-inf.md
@@ -1,7 +1,4 @@
----
-name: move-inf
-description: Infer specifications for a Move package
----
+{{ frontmatter(name="move-inf", description="Infer specifications for a Move package") }}
 
 {#
  # This agent allows to ask something like 'infer specs in a subagent'

--- a/aptos-move/flow/cont/agents/move-verify.md
+++ b/aptos-move/flow/cont/agents/move-verify.md
@@ -1,7 +1,4 @@
----
-name: move-verify
-description: Verify Move specifications using the Move Prover
----
+{{ frontmatter(name="move-verify", description="Verify Move specifications using the Move Prover") }}
 
 {#
  # This agent allows to ask something like 'verify specs in a subagent'.

--- a/aptos-move/flow/cont/hooks/hooks.json
+++ b/aptos-move/flow/cont/hooks/hooks.json
@@ -1,5 +1,15 @@
 {
   "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "command -v \"${MOVE_FLOW:-move-flow}\" >/dev/null 2>&1 || echo '[move-flow plugin] move-flow binary not found. Install move-flow or set MOVE_FLOW env var. Please warn the user.'"
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "Edit|Write",

--- a/aptos-move/flow/cont/skills/move-check/SKILL.md
+++ b/aptos-move/flow/cont/skills/move-check/SKILL.md
@@ -1,7 +1,4 @@
----
-name: move-check
-description: Check a Move package for compilation errors
----
+{{ frontmatter(name="move-check", description="Check a Move package for compilation errors") }}
 
 {% include "templates/move_editing_workflow.md" %}
 

--- a/aptos-move/flow/cont/skills/move-inf-v2/SKILL.md
+++ b/aptos-move/flow/cont/skills/move-inf-v2/SKILL.md
@@ -1,7 +1,4 @@
----
-name: move-inf-v2
-description: Infer specifications for a Move package (v2 — loop invariants first)
----
+{{ frontmatter(name="move-inf-v2", description="Infer specifications for a Move package (v2 — loop invariants first)") }}
 
 {% include "templates/spec_inf_workflow_v2.md" %}
 

--- a/aptos-move/flow/cont/skills/move-inf-v3/SKILL.md
+++ b/aptos-move/flow/cont/skills/move-inf-v3/SKILL.md
@@ -1,7 +1,4 @@
----
-name: move-inf-v3
-description: Infer specifications for a Move package (v3 — synthesize specs directly)
----
+{{ frontmatter(name="move-inf-v3", description="Infer specifications for a Move package (v3 — synthesize specs directly)") }}
 
 {% include "templates/spec_inf_workflow_v3.md" %}
 

--- a/aptos-move/flow/cont/skills/move-inf/SKILL.md
+++ b/aptos-move/flow/cont/skills/move-inf/SKILL.md
@@ -1,7 +1,4 @@
----
-name: move-inf
-description: Infer specifications for a Move package
----
+{{ frontmatter(name="move-inf", description="Infer specifications for a Move package") }}
 
 {% include "templates/spec_inf_workflow.md" %}
 

--- a/aptos-move/flow/cont/skills/move-prove/SKILL.md
+++ b/aptos-move/flow/cont/skills/move-prove/SKILL.md
@@ -1,7 +1,4 @@
----
-name: move-prove
-description: Run the Move Prover to formally verify specifications
----
+{{ frontmatter(name="move-prove", description="Run the Move Prover to formally verify specifications") }}
 
 {% include "templates/move_lang.md" %}
 {% include "templates/status_tool.md" %}

--- a/aptos-move/flow/cont/skills/move/SKILL.md
+++ b/aptos-move/flow/cont/skills/move/SKILL.md
@@ -1,7 +1,4 @@
----
-name: move
-description: Move development on Aptos
----
+{{ frontmatter(name="move", description="Move development on Aptos") }}
 
 {% include "templates/move_lang.md" %}
 {% include "templates/spec_lang.md" %}

--- a/aptos-move/flow/src/mcp/tools/package_manifest.rs
+++ b/aptos-move/flow/src/mcp/tools/package_manifest.rs
@@ -20,7 +20,10 @@ struct MovePackageManifestResult {
 
 #[tool_router(router = package_manifest_router, vis = "pub(crate)")]
 impl FlowSession {
-    #[tool(description = "Get information about the current Move package")]
+    #[tool(
+        description = "Get information about the current Move package",
+        annotations(read_only_hint = false, destructive_hint = false)
+    )]
     async fn move_package_manifest(
         &self,
         Parameters(params): Parameters<MovePackageManifestParams>,

--- a/aptos-move/flow/src/mcp/tools/package_spec_infer.rs
+++ b/aptos-move/flow/src/mcp/tools/package_spec_infer.rs
@@ -23,10 +23,13 @@ struct MovePackageSpecInferParams {
 
 #[tool_router(router = package_spec_infer_router, vis = "pub(crate)")]
 impl FlowSession {
-    #[tool(description = "Low-level WP inference tool — not for direct use. \
+    #[tool(
+        description = "Low-level WP inference tool — not for direct use. \
                        Requires multi-phase workflow context (loop-invariant synthesis, \
                        simplification, verification) that is only available through \
-                       subagent delegation.")]
+                       subagent delegation.",
+        annotations(read_only_hint = false, destructive_hint = true)
+    )]
     async fn move_package_spec_infer(
         &self,
         Parameters(params): Parameters<MovePackageSpecInferParams>,

--- a/aptos-move/flow/src/mcp/tools/package_status.rs
+++ b/aptos-move/flow/src/mcp/tools/package_status.rs
@@ -16,7 +16,10 @@ struct MovePackageStatusParams {
 
 #[tool_router(router = package_status_router, vis = "pub(crate)")]
 impl FlowSession {
-    #[tool(description = "Check a Move package for compilation errors and warnings")]
+    #[tool(
+        description = "Check a Move package for compilation errors and warnings",
+        annotations(read_only_hint = false, destructive_hint = false)
+    )]
     async fn move_package_status(
         &self,
         Parameters(params): Parameters<MovePackageStatusParams>,

--- a/aptos-move/flow/src/mcp/tools/package_verify.rs
+++ b/aptos-move/flow/src/mcp/tools/package_verify.rs
@@ -30,10 +30,13 @@ const MAX_VC_TIMEOUT: usize = 60;
 
 #[tool_router(router = package_verify_router, vis = "pub(crate)")]
 impl FlowSession {
-    #[tool(description = "Low-level prover tool — not for direct use. \
+    #[tool(
+        description = "Low-level prover tool — not for direct use. \
                        Requires phased verification workflow context (timeout handling, \
                        diagnostic interpretation) that is only available through \
-                       subagent delegation.")]
+                       subagent delegation.",
+        annotations(read_only_hint = false, destructive_hint = false)
+    )]
     async fn move_package_verify(
         &self,
         Parameters(params): Parameters<MovePackageVerifyParams>,

--- a/aptos-move/flow/src/plugin/mod.rs
+++ b/aptos-move/flow/src/plugin/mod.rs
@@ -84,6 +84,24 @@ pub fn run(args: &PluginArgs, global: &GlobalOpts) -> Result<()> {
         serde_json::to_string_pretty(&mcp_config).context("failed to serialize .mcp.json")?,
     ));
 
+    // Claude Code plugin manifest (required by `claude plugin validate`).
+    if global.platform == crate::Platform::Claude {
+        let plugin_manifest = serde_json::json!({
+            "name": "move-flow",
+            "description": "Move smart contract development for Aptos",
+            "version": env!("CARGO_PKG_VERSION"),
+            "author": {
+                "name": "Aptos Labs",
+                "url": "https://github.com/aptos-labs/aptos-core/tree/main/aptos-move/flow"
+            }
+        });
+        files.push((
+            PathBuf::from(".claude-plugin/plugin.json"),
+            serde_json::to_string_pretty(&plugin_manifest)
+                .context("failed to serialize plugin.json")?,
+        ));
+    }
+
     output::write_output(&args.output_dir, &files)?;
 
     println!(
@@ -140,6 +158,62 @@ mod tests {
             .exists());
         assert!(output_dir.path().join("hooks/hooks.json").exists());
 
+        // Verify hooks.json is valid JSON with expected event names.
+        let hooks_content =
+            std::fs::read_to_string(output_dir.path().join("hooks/hooks.json")).unwrap();
+        let hooks_json: serde_json::Value =
+            serde_json::from_str(&hooks_content).expect("hooks.json must be valid JSON");
+        let hooks_obj = hooks_json["hooks"]
+            .as_object()
+            .expect("hooks.json must contain a 'hooks' object");
+        let valid_events = [
+            "PreToolUse",
+            "PostToolUse",
+            "PostToolUseFailure",
+            "PermissionRequest",
+            "UserPromptSubmit",
+            "Notification",
+            "Stop",
+            "SubagentStart",
+            "SubagentStop",
+            "SessionStart",
+            "SessionEnd",
+            "TeammateIdle",
+            "TaskCompleted",
+            "PreCompact",
+            "ConfigChange",
+            "WorktreeCreate",
+            "WorktreeRemove",
+            "InstructionsLoaded",
+        ];
+        let valid_hook_types = ["command", "prompt", "agent"];
+        for key in hooks_obj.keys() {
+            assert!(
+                valid_events.contains(&key.as_str()),
+                "hooks.json contains unknown event name: {key}"
+            );
+        }
+        // Validate hook type values.
+        for (event, entries) in hooks_obj {
+            let entries = entries
+                .as_array()
+                .unwrap_or_else(|| panic!("hooks.json {event}: expected array"));
+            for entry in entries {
+                let inner = entry["hooks"]
+                    .as_array()
+                    .unwrap_or_else(|| panic!("hooks.json {event}: expected 'hooks' array"));
+                for hook in inner {
+                    let hook_type = hook["type"]
+                        .as_str()
+                        .unwrap_or_else(|| panic!("hooks.json {event}: hook missing 'type'"));
+                    assert!(
+                        valid_hook_types.contains(&hook_type),
+                        "hooks.json {event}: unknown hook type: {hook_type}"
+                    );
+                }
+            }
+        }
+
         // Verify agent files were generated with correct names
         let verify_content =
             std::fs::read_to_string(output_dir.path().join("agents/move-verify.md")).unwrap();
@@ -160,6 +234,29 @@ mod tests {
         assert!(
             skill_content.contains("Move Language"),
             "expected move skill to contain language reference"
+        );
+
+        // Verify .claude-plugin/plugin.json manifest is generated
+        let manifest_path = output_dir.path().join(".claude-plugin/plugin.json");
+        assert!(manifest_path.exists(), "plugin.json should exist");
+        let manifest: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&manifest_path).unwrap()).unwrap();
+        assert_eq!(manifest["name"], "move-flow");
+        assert!(
+            manifest["description"]
+                .as_str()
+                .is_some_and(|s| !s.is_empty()),
+            "plugin.json should have a description"
+        );
+        assert!(
+            manifest["version"].as_str().is_some_and(|s| !s.is_empty()),
+            "plugin.json should have a version"
+        );
+        assert!(
+            manifest["author"]["name"]
+                .as_str()
+                .is_some_and(|s| !s.is_empty()),
+            "plugin.json should have an author name"
         );
 
         // Verify .mcp.json is generated at the output root

--- a/aptos-move/flow/src/plugin/render.rs
+++ b/aptos-move/flow/src/plugin/render.rs
@@ -5,7 +5,10 @@ use anyhow::{Context, Result};
 use std::{
     collections::{HashMap, HashSet},
     path::{Path, PathBuf},
-    sync::{Arc, Mutex},
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc, Mutex,
+    },
 };
 use tera::Tera;
 use walkdir::WalkDir;
@@ -42,6 +45,7 @@ pub fn render_all(
     let mut tera = Tera::default();
     tera.register_function("tool", make_tool_function(tool_names.to_vec()));
     let once_seen = make_once_function(&mut tera);
+    let frontmatter_seen = make_frontmatter_function(&mut tera);
 
     // First pass: register all templates in a shared Tera instance.
     let mut output_names = Vec::new();
@@ -79,11 +83,23 @@ pub fn render_all(
     // Second pass: render output-producing templates.
     let mut results = Vec::new();
     for (out_path, template_name) in output_names {
-        // Reset include onces so each output file deduplicates independently.
+        // Reset per-file state so each output file deduplicates independently.
         once_seen.lock().unwrap().clear();
+        frontmatter_seen.store(false, Ordering::Relaxed);
         let rendered = tera
             .render(&template_name, context)
             .with_context(|| format!("failed to render template {}", out_path.display()))?;
+
+        // Skills and agents must call frontmatter() to declare their metadata.
+        let needs_frontmatter = out_path.starts_with("skills") || out_path.starts_with("agents");
+        if needs_frontmatter {
+            anyhow::ensure!(
+                frontmatter_seen.load(Ordering::Relaxed),
+                "{} does not call frontmatter(name=..., description=...)",
+                out_path.display()
+            );
+        }
+
         results.push((out_path, rendered));
     }
 
@@ -104,6 +120,7 @@ fn render_one(
     let mut tera = Tera::default();
     tera.register_function("tool", make_tool_function(tool_names.to_vec()));
     make_once_function(&mut tera);
+    make_frontmatter_function(&mut tera);
     let template_name = path.to_string_lossy();
     tera.add_raw_template(&template_name, content)
         .with_context(|| format!("failed to parse template {}", path.display()))?;
@@ -132,6 +149,49 @@ fn make_once_function(tera: &mut Tera) -> Arc<Mutex<HashSet<String>>> {
                 .ok_or_else(|| tera::Error::msg("once() requires a `name` argument"))?;
             let first = seen_clone.lock().unwrap().insert(name.to_string());
             Ok(tera::Value::Bool(first))
+        },
+    );
+    seen
+}
+
+/// Creates a Tera function `frontmatter(name="...", description="...")` that
+/// renders YAML frontmatter and validates that both fields are non-empty.
+///
+/// Returns a shared flag that is set during rendering. The caller resets it
+/// between render passes and checks that skill/agent files have called this
+/// function exactly once.
+fn make_frontmatter_function(tera: &mut Tera) -> Arc<AtomicBool> {
+    let seen = Arc::new(AtomicBool::new(false));
+    let seen_clone = Arc::clone(&seen);
+    tera.register_function(
+        "frontmatter",
+        move |args: &HashMap<String, tera::Value>| -> tera::Result<tera::Value> {
+            if seen_clone.swap(true, Ordering::Relaxed) {
+                return Err(tera::Error::msg(
+                    "frontmatter() must be called exactly once per file",
+                ));
+            }
+            let name = args
+                .get("name")
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| tera::Error::msg("frontmatter() requires a `name` argument"))?;
+            if name.is_empty() {
+                return Err(tera::Error::msg("frontmatter() `name` must not be empty"));
+            }
+            let description = args
+                .get("description")
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| {
+                    tera::Error::msg("frontmatter() requires a `description` argument")
+                })?;
+            if description.is_empty() {
+                return Err(tera::Error::msg(
+                    "frontmatter() `description` must not be empty",
+                ));
+            }
+            Ok(tera::Value::String(format!(
+                "---\nname: {name}\ndescription: {description}\n---"
+            )))
         },
     );
     seen
@@ -217,15 +277,27 @@ mod tests {
         assert!(!files.is_empty(), "should discover at least one file");
 
         let paths: Vec<_> = files.iter().map(|(p, _)| p.clone()).collect();
-        assert!(
-            paths.iter().any(|p| p.starts_with("skills")),
-            "should find files under skills/"
-        );
+        // Verify all expected plugin directories are represented in output.
+        for dir in &["skills", "agents", "hooks"] {
+            assert!(
+                paths.iter().any(|p| p.starts_with(dir)),
+                "should find files under {dir}/"
+            );
+        }
 
         // Verify that templates/ partials are NOT in the output.
         assert!(
             !paths.iter().any(|p| p.starts_with("templates")),
             "templates/ partials should not appear in output"
         );
+
+        // Verify no output file is empty.
+        for (path, content) in &files {
+            assert!(
+                !content.trim().is_empty(),
+                "{} rendered to empty content",
+                path.display()
+            );
+        }
     }
 }

--- a/aptos-move/flow/src/tests/list_tools/annotations.rs
+++ b/aptos-move/flow/src/tests/list_tools/annotations.rs
@@ -1,0 +1,33 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+use crate::tests::common;
+
+/// Every MCP tool must declare `readOnlyHint` and `destructiveHint` annotations.
+/// These are required for Anthropic marketplace submission.
+#[tokio::test]
+async fn all_tools_have_annotations() {
+    let client = common::make_client().await;
+    let result = client.list_tools(None).await.expect("list_tools");
+
+    for tool in &result.tools {
+        let name = &tool.name;
+        let desc = tool
+            .description
+            .as_ref()
+            .unwrap_or_else(|| panic!("{name}: missing description"));
+        assert!(!desc.is_empty(), "{name}: empty description");
+        let ann = tool
+            .annotations
+            .as_ref()
+            .unwrap_or_else(|| panic!("{name}: missing annotations"));
+        assert!(
+            ann.read_only_hint.is_some(),
+            "{name}: missing read_only_hint"
+        );
+        assert!(
+            ann.destructive_hint.is_some(),
+            "{name}: missing destructive_hint"
+        );
+    }
+}

--- a/aptos-move/flow/src/tests/list_tools/mod.rs
+++ b/aptos-move/flow/src/tests/list_tools/mod.rs
@@ -1,4 +1,5 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
+mod annotations;
 mod success;

--- a/aptos-move/flow/src/tests/list_tools/success.exp
+++ b/aptos-move/flow/src/tests/list_tools/success.exp
@@ -15,6 +15,10 @@
       "required": [
         "package_path"
       ]
+    },
+    "annotations": {
+      "readOnlyHint": false,
+      "destructiveHint": false
     }
   },
   {
@@ -38,6 +42,10 @@
       "required": [
         "package_path"
       ]
+    },
+    "annotations": {
+      "readOnlyHint": false,
+      "destructiveHint": true
     }
   },
   {
@@ -56,6 +64,10 @@
       "required": [
         "package_path"
       ]
+    },
+    "annotations": {
+      "readOnlyHint": false,
+      "destructiveHint": false
     }
   },
   {
@@ -94,6 +106,10 @@
       "required": [
         "package_path"
       ]
+    },
+    "annotations": {
+      "readOnlyHint": false,
+      "destructiveHint": false
     }
   }
 ]


### PR DESCRIPTION
## Description
This PR adds more tests on validity of the move-flow plugin. When generated for Claude Code, we now check the following validation properties:

 ### MCP Tool Compliance                                                                                                                                                   
  - Every tool declares `readOnlyHint` and `destructiveHint` annotations (required for marketplace submission)                                                              
  - Every tool has a non-empty description                                                                                                                                  
                                                            
  ### Template Rendering Integrity
  - All skills and agents call `frontmatter(name=..., description=...)` with non-empty values
  - Tool references in templates (`{{ tool(name="...") }}`) resolve to real MCP tool names
  - No rendered file is empty

  ### Plugin Structure
  - Output directories exist: `skills/`, `agents/`, `hooks/`
  - `.claude-plugin/plugin.json` generated with name, description, version, author  (required for marketplace submission)
  - `.mcp.json` generated with valid server config (command, args)

  ### Hooks Validation
  - `hooks.json` is valid JSON with a `hooks` object
  - All event names are known Claude Code events (18 valid names)
  - All hook entries have a valid `type` (`command`, `prompt`, or `agent`)

## How Has This Been Tested?
This adds tests. All expected results are manually checked.

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [x] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [x] Other (move flow)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly adds/strengthens validation and metadata in plugin generation (templates, hook config, tool annotations) with minimal runtime impact; risk is limited to stricter generation failing if templates/tool definitions are incomplete.
> 
> **Overview**
> Ensures Claude Code plugin output is *marketplace-compliant* by adding a generated `.claude-plugin/plugin.json`, extending `hooks.json` with a `SessionStart` binary-availability check, and tightening template rendering rules.
> 
> All agent/skill templates are migrated to a new `{{ frontmatter(...) }}` helper, and rendering now enforces that `skills/` and `agents/` call it exactly once and that no rendered output file is empty.
> 
> MCP tool definitions now declare `readOnlyHint`/`destructiveHint` annotations, and new/updated tests assert tool descriptions+annotations exist, hooks JSON uses known event/type values, and the `list_tools` expected output includes the new annotations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c529d8c47d5bf59f44b55947c2affe932b6ccb2b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->