### PR TITLE
[crypto] Optimize CryptoHash for Merkle tree nodes with single-permutation SHA3-256

### DIFF
--- a/crates/aptos-crypto/Cargo.toml
+++ b/crates/aptos-crypto/Cargo.toml
@@ -140,6 +140,10 @@ name = "hash"
 harness = false
 
 [[bench]]
+name = "hash_pair"
+harness = false
+
+[[bench]]
 name = "noise"
 harness = false
 

--- a/crates/aptos-crypto/benches/hash_pair.rs
+++ b/crates/aptos-crypto/benches/hash_pair.rs
@@ -1,0 +1,66 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Benchmarks for the optimized `hash_two_children` path vs. the generic hasher
+//! path for hashing two 32-byte hash values (the Merkle tree internal node pattern).
+
+use aptos_crypto::{
+    hash::{
+        CryptoHasher, EventAccumulatorHasher, SparseMerkleInternalHasher,
+        TransactionAccumulatorHasher,
+    },
+    HashValue,
+};
+use criterion::{
+    criterion_group, criterion_main, measurement::Measurement, BenchmarkGroup, BenchmarkId,
+    Criterion,
+};
+use rand::{rngs::StdRng, SeedableRng};
+
+/// Hash two HashValues using the generic (old) hasher path.
+fn hash_two_children_generic<H: CryptoHasher>(h1: &HashValue, h2: &HashValue) -> HashValue {
+    let mut state = H::default();
+    state.update(h1.as_ref());
+    state.update(h2.as_ref());
+    state.finish()
+}
+
+fn bench_hash_pair(c: &mut Criterion) {
+    let mut group = c.benchmark_group("hash_pair");
+    group.sample_size(5000);
+
+    // Generate deterministic random inputs
+    let mut rng = StdRng::seed_from_u64(0xDEAD_BEEF);
+    let h1 = HashValue::random_with_rng(&mut rng);
+    let h2 = HashValue::random_with_rng(&mut rng);
+
+    bench_hasher::<SparseMerkleInternalHasher>(&mut group, "SparseMerkleInternal", &h1, &h2);
+    bench_hasher::<TransactionAccumulatorHasher>(&mut group, "TransactionAccumulator", &h1, &h2);
+    bench_hasher::<EventAccumulatorHasher>(&mut group, "EventAccumulator", &h1, &h2);
+
+    group.finish();
+}
+
+fn bench_hasher<H: CryptoHasher>(
+    g: &mut BenchmarkGroup<impl Measurement>,
+    name: &str,
+    h1: &HashValue,
+    h2: &HashValue,
+) {
+    g.bench_function(BenchmarkId::new("optimized", name), |b| {
+        b.iter(|| H::hash_two_children(criterion::black_box(h1), criterion::black_box(h2)))
+    });
+
+    g.bench_function(BenchmarkId::new("generic", name), |b| {
+        b.iter(|| {
+            hash_two_children_generic::<H>(criterion::black_box(h1), criterion::black_box(h2))
+        })
+    });
+}
+
+criterion_group!(
+    name = hash_pair_benches;
+    config = Criterion::default();
+    targets = bench_hash_pair
+);
+criterion_main!(hash_pair_benches);

--- a/crates/aptos-crypto/src/hash.rs
+++ b/crates/aptos-crypto/src/hash.rs
@@ -114,6 +114,77 @@ use std::{
 };
 use tiny_keccak::{Hasher, Sha3};
 
+/// SHA3-256 rate in bytes: 200 - 2*32 = 136.
+const SHA3_256_RATE: usize = 136;
+
+/// Computes `SHA3-256(seed || h1 || h2)` using a single Keccak-f[1600] permutation.
+///
+/// This is an optimized specialization for the common case of hashing exactly two
+/// 32-byte hash values with a 32-byte domain separator seed. The total input
+/// (96 bytes) fits within the SHA3-256 rate (136 bytes), so only one permutation
+/// is needed. This avoids the overhead of the generic hasher (cloning state,
+/// multiple update calls with loop/branch overhead, etc.).
+#[inline]
+#[allow(clippy::needless_range_loop)]
+fn hash_sha3_256_two_x32b(seed: &[u8; 32], h1: &[u8; 32], h2: &[u8; 32]) -> HashValue {
+    // SHA3-256 parameters:
+    //   state  = 1600 bits = 200 bytes = 25 u64 words
+    //   rate   = 1088 bits = 136 bytes = 17 u64 words
+    //   capacity = 512 bits = 64 bytes = 8 u64 words
+    //   delimiter = 0x06
+    //
+    // Input layout in the state (as byte offsets):
+    //   [0..32)   = seed   -> words [0..4)
+    //   [32..64)  = h1     -> words [4..8)
+    //   [64..96)  = h2     -> words [8..12)
+    //   [96]      = 0x06   (SHA3 delimiter) -> word 12, byte 0
+    //   [135]     = 0x80   (final pad bit)  -> word 16, byte 7
+    //
+    // Total: 96 bytes < 136 bytes (rate), so exactly one keccak-f permutation.
+
+    #[inline(always)]
+    fn load_u64_le(bytes: &[u8; 32], word_idx: usize) -> u64 {
+        let o = word_idx * 8;
+        u64::from_le_bytes([
+            bytes[o],
+            bytes[o + 1],
+            bytes[o + 2],
+            bytes[o + 3],
+            bytes[o + 4],
+            bytes[o + 5],
+            bytes[o + 6],
+            bytes[o + 7],
+        ])
+    }
+
+    let mut state = [0u64; 25];
+
+    // Load seed, h1, h2 into state as little-endian u64 words.
+    // Since state starts as all-zero, XOR is equivalent to assignment.
+    for i in 0..4 {
+        state[i] = load_u64_le(seed, i);
+    }
+    for i in 0..4 {
+        state[4 + i] = load_u64_le(h1, i);
+    }
+    for i in 0..4 {
+        state[8 + i] = load_u64_le(h2, i);
+    }
+
+    // SHA3-256 multi-rate padding: 0x06 at byte 96, 0x80 at byte 135.
+    state[12] = 0x06;
+    state[SHA3_256_RATE / 8 - 1] = 0x80u64 << 56; // byte 135 = word 16, MSB
+
+    tiny_keccak::keccakf(&mut state);
+
+    // Extract the first 32 bytes (4 u64 LE words) as the hash output.
+    let mut output = [0u8; 32];
+    for i in 0..4 {
+        output[i * 8..i * 8 + 8].copy_from_slice(&state[i].to_le_bytes());
+    }
+    HashValue::new(output)
+}
+
 /// A prefix used to begin the salt of every hashable structure. The salt
 /// consists in this global prefix, concatenated with the specified
 /// serialization name of the struct.
@@ -505,6 +576,13 @@ pub trait CryptoHasher: Default + std::io::Write {
         hasher.update(bytes);
         hasher.finish()
     }
+
+    /// Optimized method to hash exactly two 32-byte values (e.g. child hashes in
+    /// a Merkle tree node). Uses a single Keccak-f permutation since the total
+    /// input (32-byte seed + 32 + 32 = 96 bytes) fits within the SHA3-256 rate.
+    fn hash_two_children(h1: &HashValue, h2: &HashValue) -> HashValue {
+        hash_sha3_256_two_x32b(Self::seed(), h1.as_ref(), h2.as_ref())
+    }
 }
 
 /// The default hasher underlying generated implementations of `CryptoHasher`.
@@ -594,6 +672,20 @@ macro_rules! define_hasher {
 
             fn finish(self) -> HashValue {
                 self.0.finish()
+            }
+
+            fn hash_two_children(h1: &HashValue, h2: &HashValue) -> HashValue {
+                // When salt is empty (only TestOnlyHasher), no seed is absorbed
+                // into the hasher state, so we fall back to the generic path.
+                // The compiler will constant-fold this check away.
+                if ($salt as &[u8]).is_empty() {
+                    let mut state = Self::default();
+                    state.update(h1.as_ref());
+                    state.update(h2.as_ref());
+                    state.finish()
+                } else {
+                    hash_sha3_256_two_x32b(Self::seed(), h1.as_ref(), h2.as_ref())
+                }
             }
         }
 
@@ -723,5 +815,62 @@ impl<T: ser::Serialize + ?Sized> TestOnlyHash for T {
         let mut hasher = TestOnlyHasher::default();
         hasher.update(&bytes);
         hasher.finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+
+    /// Reference implementation using the generic hasher path.
+    fn hash_two_children_reference<H: CryptoHasher>(h1: &HashValue, h2: &HashValue) -> HashValue {
+        let mut state = H::default();
+        state.update(h1.as_ref());
+        state.update(h2.as_ref());
+        state.finish()
+    }
+
+    proptest! {
+        #[test]
+        fn hash_two_children_matches_reference_sparse_merkle_internal(
+            h1 in any::<HashValue>(),
+            h2 in any::<HashValue>(),
+        ) {
+            let optimized = SparseMerkleInternalHasher::hash_two_children(&h1, &h2);
+            let reference = hash_two_children_reference::<SparseMerkleInternalHasher>(&h1, &h2);
+            prop_assert_eq!(optimized, reference);
+        }
+
+        #[test]
+        fn hash_two_children_matches_reference_transaction_accumulator(
+            h1 in any::<HashValue>(),
+            h2 in any::<HashValue>(),
+        ) {
+            let optimized = TransactionAccumulatorHasher::hash_two_children(&h1, &h2);
+            let reference = hash_two_children_reference::<TransactionAccumulatorHasher>(&h1, &h2);
+            prop_assert_eq!(optimized, reference);
+        }
+
+        #[test]
+        fn hash_two_children_matches_reference_event_accumulator(
+            h1 in any::<HashValue>(),
+            h2 in any::<HashValue>(),
+        ) {
+            let optimized = EventAccumulatorHasher::hash_two_children(&h1, &h2);
+            let reference = hash_two_children_reference::<EventAccumulatorHasher>(&h1, &h2);
+            prop_assert_eq!(optimized, reference);
+        }
+
+        #[test]
+        fn hash_two_children_matches_reference_test_only(
+            h1 in any::<HashValue>(),
+            h2 in any::<HashValue>(),
+        ) {
+            let optimized = TestOnlyHasher::hash_two_children(&h1, &h2);
+            let reference = hash_two_children_reference::<TestOnlyHasher>(&h1, &h2);
+            prop_assert_eq!(optimized, reference);
+        }
+
     }
 }

--- a/types/src/proof/mod.rs
+++ b/types/src/proof/mod.rs
@@ -80,10 +80,7 @@ impl<H: CryptoHasher> CryptoHash for MerkleTreeInternalNode<H> {
     type Hasher = H;
 
     fn hash(&self) -> HashValue {
-        let mut state = Self::Hasher::default();
-        state.update(self.left_child.as_ref());
-        state.update(self.right_child.as_ref());
-        state.finish()
+        H::hash_two_children(&self.left_child, &self.right_child)
     }
 }
 
@@ -121,9 +118,6 @@ impl CryptoHash for SparseMerkleLeafNode {
     type Hasher = SparseMerkleLeafNodeHasher;
 
     fn hash(&self) -> HashValue {
-        let mut state = Self::Hasher::default();
-        state.update(self.key.as_ref());
-        state.update(self.value_hash.as_ref());
-        state.finish()
+        Self::Hasher::hash_two_children(&self.key, &self.value_hash)
     }
 }

--- a/types/src/proof/unit_tests/proof_test.rs
+++ b/types/src/proof/unit_tests/proof_test.rs
@@ -624,3 +624,28 @@ fn create_event() -> ContractEvent {
     let event_key = EventKey::new(0, AccountAddress::random());
     ContractEvent::new_v1(event_key, 0, TypeTag::Bool, bcs::to_bytes(&0).unwrap()).unwrap()
 }
+
+mod hash_two_children_tests {
+    use super::super::super::SparseMerkleLeafNodeHasher;
+    use aptos_crypto::{hash::CryptoHasher, HashValue};
+    use proptest::prelude::*;
+
+    fn hash_two_children_reference<H: CryptoHasher>(h1: &HashValue, h2: &HashValue) -> HashValue {
+        let mut state = H::default();
+        state.update(h1.as_ref());
+        state.update(h2.as_ref());
+        state.finish()
+    }
+
+    proptest! {
+        #[test]
+        fn matches_reference_sparse_merkle_leaf_node(
+            h1 in any::<HashValue>(),
+            h2 in any::<HashValue>(),
+        ) {
+            let optimized = SparseMerkleLeafNodeHasher::hash_two_children(&h1, &h2);
+            let reference = hash_two_children_reference::<SparseMerkleLeafNodeHasher>(&h1, &h2);
+            prop_assert_eq!(optimized, reference);
+        }
+    }
+}


### PR DESCRIPTION

Aptos nodes spend significant time on Merkle tree computation — hashing
internal nodes is one of the hottest paths in execution and state sync.

The hash of `MerkleTreeInternalNode` and `SparseMerkleLeafNode` computes
`SHA3-256(seed || h1 || h2)` where all three inputs are 32 bytes. The total
input (96 bytes) fits within the SHA3-256 rate (136 bytes), so only a single
Keccak-f[1600] permutation is needed.

Added `hash_sha3_256_two_x32b()` that directly constructs the Keccak state
with the seed, two hash values, and SHA3 padding, then calls one `keccakf`
permutation. This avoids the generic hasher overhead (cloning 200-byte state,
multiple `update()` calls with loop/branch logic, finalization).

Exposed as `CryptoHasher::hash_two_children()` default trait method, with an
override in `define_hasher!` that falls back to the generic path for
empty-salt hashers (`TestOnlyHasher`).

### Benchmark results

| Hasher                 | Optimized | Generic | Improvement |
|------------------------|-----------|---------|-------------|
| SparseMerkleInternal   | 317 ns    | 344 ns  | **7.8%**    |
| TransactionAccumulator | 317 ns    | 344 ns  | **7.8%**    |
| EventAccumulator       | 318 ns    | 344 ns  | **7.5%**    |

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core hashing used by Merkle proofs/accumulators; any subtle padding/endianness bug would change root hashes and break verification despite added property tests and benchmarks.
> 
> **Overview**
> **Optimizes Merkle node hashing** by adding a specialized `SHA3-256(seed || h1 || h2)` implementation (`hash_sha3_256_two_x32b`) that builds the Keccak state directly and runs a single permutation.
> 
> Exposes this as `CryptoHasher::hash_two_children()` (with a `define_hasher!` override that falls back for empty-salt `TestOnlyHasher`) and switches `MerkleTreeInternalNode` and `SparseMerkleLeafNode` hashing to use it.
> 
> Adds proptest coverage to ensure the optimized path matches the prior generic hasher output, plus a new Criterion bench `hash_pair` to compare optimized vs generic performance.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6968aad666d281d88744bbc862de6cafdf99d526. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->