### PR TITLE
[consensus] Update consensus, pipeline, and quorum store READMEs

### DIFF
--- a/consensus/README.md
+++ b/consensus/README.md
@@ -4,56 +4,230 @@ title: Consensus
 custom_edit_url: https://github.com/aptos-labs/aptos-core/edit/main/consensus/README.md
 ---
 
-
 The consensus component supports state machine replication using the AptosBFT consensus protocol.
 
 ## Overview
 
-A consensus protocol allows a set of validators to create the logical appearance of a single database. The consensus protocol replicates submitted transactions among the validators, executes potential transactions against the current database, and then agrees on a binding commitment to the ordering of transactions and resulting execution. As a result, all validators can maintain an identical database for a given version number following the [state machine replication paradigm](https://dl.acm.org/citation.cfm?id=98167). The Aptos protocol uses a variant of the [Jolteon consensus protocol](https://arxiv.org/pdf/2106.10362.pdf), a recent Byzantine fault-tolerant ([BFT](https://en.wikipedia.org/wiki/Byzantine_fault)) consensus protocol, called AptosBFT. It provides safety (all honest validators agree on commits and execution) and liveness (commits are continually produced) in the partial synchrony model defined in the paper "Consensus in the Presence of Partial Synchrony" by Dwork, Lynch, and Stockmeyer ([DLS](https://groups.csail.mit.edu/tds/papers/Lynch/jacm88.pdf)) and mentioned in the paper ["Practical Byzantine Fault Tolerance" (PBFT)](http://pmg.csail.mit.edu/papers/osdi99.pdf) by Castro and Liskov, as well as newer protocols such as [Tendermint](https://arxiv.org/abs/1807.04938). In this document, we present a high-level description of the AptosBFT protocol and discuss how the code is organized. For details on the specifications and proofs of AptosBFT, read the full [technical report](../developer-docs-site/static/papers/aptos-consensus-state-machine-replication-in-the-aptos-blockchain/).
+AptosBFT is a BFT state machine replication protocol for n = 3f+1 validators, tolerating up to f Byzantine faults. It provides safety always and liveness during periods of synchrony (partial synchrony model). The protocol incorporates ideas from [Jolteon](https://arxiv.org/pdf/2106.10362.pdf) (2-chain commit), order votes ([AIP-89](https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-89.md)), and optimistic proposals ([AIP-131](https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-131.md)).
 
-Agreement on the database state must be reached between validators, even if
-there are Byzantine faults. The Byzantine failures model allows some validators
-to arbitrarily deviate from the protocol without constraint, with the exception
-of being computationally bound (and thus not able to break cryptographic assumptions). Byzantine faults are worst-case errors where validators collude and behave maliciously to try to sabotage system behavior. A consensus protocol that tolerates Byzantine faults caused by malicious or hacked validators can also mitigate arbitrary hardware and software failures.
+## AptosBFT Protocol
 
-AptosBFT assumes that a set of 3f + 1 votes is distributed among a set of validators that may be honest or Byzantine. AptosBFT remains safe, preventing attacks such as double spends and forks when at most f votes are controlled by Byzantine validators &mdash; also implying that at least 2f+1 votes are honest.  AptosBFT remains live, committing transactions from clients, as long as there exists a global stabilization time (GST), after which all messages between honest validators are delivered to other honest validators within a maximal network delay $\Delta$ (this is the partial synchrony model introduced in [DLS](https://groups.csail.mit.edu/tds/papers/Lynch/jacm88.pdf)). In addition to traditional guarantees, AptosBFT maintains safety when validators crash and restart — even if all validators restart at the same time.
+### Rounds and Proposals
 
-### AptosBFT Overview
+Consensus proceeds in rounds. Each round has a designated leader who proposes a block. In the **happy path**, a leader can send an **optimistic proposal** extending the parent block *before* the parent's QC arrives — the leader only needs to have seen the parent proposal and trust it will be certified. This reduces block time to a single network hop.
 
-In AptosBFT, validators receive transactions from clients and share them with each other through a shared mempool protocol. The AptosBFT protocol then proceeds in a sequence of rounds. In each round, a validator takes the role of leader and proposes a block of transactions to extend a certified sequence of blocks (see quorum certificates below) that contain the full previous transaction history. A validator receives the proposed block and checks their voting rules to determine if it should vote for certifying this block. These simple rules ensure the safety of AptosBFT — and their implementation can be cleanly separated and audited. If the validator intends to vote for this block, it executes the block’s transactions speculatively and without external effect. This results in the computation of an authenticator for the database that results from the execution of the block. The validator then sends a signed vote for the block and the database authenticator to the leader. The leader gathers these votes to form a quorum certificate that provides evidence of $\ge$ 2f + 1 votes for this block and broadcasts the quorum certificate to all validators.
+An optimistic proposal contains a `grandparent_qc` (QC of block r-2) instead of the usual parent QC, since the parent QC doesn't exist yet. Validators buffer optimistic proposals until the parent QC arrives, then convert to a regular proposal and apply standard safety rules.
 
-A block is committed when a contiguous 3-chain commit rule is met. A block at round k is committed if it has a quorum certificate and is confirmed by two more blocks and quorum certificates at rounds k + 1 and k + 2. The commit rule eventually allows honest validators to commit a block. AptosBFT guarantees that all honest validators will eventually commit the block (and proceeding sequence of blocks linked from it). Once a sequence of blocks has committed, the state resulting from executing their transactions can be persisted and forms a replicated database.
+When optimistic proposals are not possible (e.g. under backpressure, or after a timeout), the leader falls back to a **regular proposal** that includes the parent QC directly.
 
-### Advantages of Jolteon 
+### Voting and QC Formation
 
-We evaluated several BFT-based protocols against the dimensions of performance, reliability, security, ease of robust implementation, and operational overhead for validators. Our goal was to choose a protocol that would initially support at least 100 validators and would be able to evolve over time to support 500–1,000 validators. The initial AptosBFT protocol was based on HotStuff for the following reasons: (i) simplicity and modularity; (ii) ability to easily integrate consensus with execution; and (iii) promising performance in early experiments. Later we switched to Jolteon as it reduces latency by 33% without sacrificing throughput.
+Validators vote on proposals after checking safety rules (voting rules are cleanly separated for auditability). With decoupled execution, votes are on the proposed block itself — not on execution results. Execution happens asynchronously after ordering. 2f+1 votes form a **Quorum Certificate** (QC), which proves a supermajority agreed on a block.
 
-The AptosBFT protocol decomposes into modules for safety (voting and commit rules) and liveness (round_state). This decoupling provides the ability to develop and experiment independently and on different modules in parallel. Due to the simple voting and commit rules, protocol safety is easy to implement and verify. It is straightforward to integrate execution as a part of consensus to avoid forking issues that arise from non-deterministic execution in a leader-based protocol. We did not consider proof-of-work based protocols, such as [Bitcoin](https://bitcoin.org/bitcoin.pdf), due to their poor performance and high energy (and environmental) costs.
+### Ordering via Order Votes
 
-### Extensions and Modifications
+After forming QC(r), validators immediately broadcast an **order vote** on that QC to all validators. When 2f+1 order votes are collected, block r is ordered. This achieves the theoretical minimum of 3 network hops for BFT ordering under partial synchrony:
 
-We reformulate the safety conditions and provide extended proofs of safety, liveness, and optimistic responsiveness. We also implement a number of additional features. First, we make the protocol more resistant to non-determinism bugs, by having validators collectively sign the resulting state of a block rather than just the sequence of transactions. This also allows clients to use quorum certificates to authenticate reads from the database. Second, we design a round_state that emits explicit timeouts, and validators rely on a quorum of those to move to the next round — without requiring synchronized clocks. Third, we intend to design an unpredictable leader election mechanism in which the leader of a round is determined by the proposer of the latest committed block using a verifiable random function [VRF](https://people.csail.mit.edu/silvio/Selected%20Scientific%20Papers/Pseudo%20Randomness/Verifiable_Random_Functions.pdf). This mechanism limits the window of time in which an adversary can launch an effective denial-of-service attack against a leader. Fourth, we use aggregate signatures that preserve the identity of validators who sign quorum certificates. This allows us to provide incentives to validators that contribute to quorum certificates. Aggregate signatures also do not require a complex [threshold key setup](https://www.cypherpunks.ca/~iang/pubs/DKG.pdf).
+1. Leader proposes block B(r) (optimistically, without waiting for parent QC)
+2. Validators vote on B(r)
+3. QC(r) forms; validators broadcast order votes on QC(r)
+4. 2f+1 order votes → block r is ordered
+
+The order vote safety rule (`safe_for_order_vote`) prevents a validator from order-voting for a round if it has already timed out at that round (tracked via `highest_timeout_round`). This prevents conflicting ordering decisions across forks.
+
+2f+1 order votes form a `WrappedLedgerInfo` — a commit certificate.
+
+Without order votes, the **2-chain commit rule** applies as fallback: B(r) is committed when B(r) has a QC and its direct child B(r+1) also has a QC.
+
+### Timeout and View-Change
+
+When a round times out without a QC:
+
+- Validators broadcast a `RoundTimeout` message containing their highest QC and a timeout signature.
+- Receiving f+1 timeout messages from other validators triggers a local timeout, accelerating round advancement without waiting for the full timeout duration.
+- 2f+1 timeout signatures form a `TwoChainTimeoutCertificate` (TC).
+- The TC allows the next leader to propose without the previous round's QC, ensuring liveness.
+
+### Round State
+
+The `RoundState` drives round advancement. A `NewRoundEvent` is triggered either by receiving a QC (happy path) or a TC (unhappy path). Timeouts use exponential backoff: `base_ms * exponent_base^min(round_index, max_exponent)`.
+
+### Leader Election
+
+Multiple strategies are supported — round-robin rotation and reputation-based (where validators that fail to produce blocks are penalized).
+
+### Safety Rules (persisted across restarts)
+
+- `last_voted_round`: prevents voting twice in the same round (no equivocation)
+- `preferred_round`: only vote for blocks whose parent QC round >= preferred_round (the round of the highest 2-chain head seen), preventing votes on forks that could conflict with committed blocks
+- `highest_timeout_round`: prevents order-voting after timeout in the same round
+
+### Liveness
+
+Requires two consecutive honest leaders to order a block after GST (because the first leader sends an optimistic proposal that the second leader builds on). Without optimistic proposals, one honest leader suffices.
+
+### Epoch Boundaries
+
+Consensus operates within epochs. An epoch defines the validator set and configuration. When a reconfiguration transaction is committed, the current epoch ends and a new one begins. All consensus state (rounds, QCs, block tree) is reset at epoch boundaries.
+
+## Architecture
+
+```
+                         Network Layer
+                             |
+                    +--------v---------+
+                    |   EpochManager   |  Lifecycle: epoch init, validator set, channels
+                    +--------+---------+
+                             |
+                    +--------v---------+
+                    |  RoundManager    |  Core event loop: proposals, votes, timeouts
+                    +--------+---------+
+                             |
+          +------------------+------------------+
+          |                  |                  |
+  +-------v------+  +-------v-------+  +-------v--------+
+  |  BlockStore  |  | SafetyRules   |  |  RoundState    |
+  | (block tree) |  | (vote rules,  |  |  (timeouts,    |
+  |              |  |  persistence) |  |   round mgmt)  |
+  +--------------+  +---------------+  +----------------+
+                                                |
+  +--------------+                     +--------v--------+
+  | PendingVotes |                     | ProposalGen +   |
+  | + OrderVotes |                     | ProposerElect   |
+  | (aggregation)|                     | (leader duty)   |
+  +--------------+                     +-----------------+
+```
+
+### Consensus Message Types
+
+| Message           | Purpose                                | Happy-path sender → receiver   |
+| ----------------- | -------------------------------------- | ------------------------------ |
+| `ProposalMsg`     | Block proposal with parent QC          | Leader → all validators        |
+| `OptProposalMsg`  | Optimistic proposal (no parent QC yet) | Leader → all validators        |
+| `VoteMsg`         | Vote on a proposal                     | Validator → all validators     |
+| `OrderVoteMsg`    | Order vote on a QC                     | Validator → all validators     |
+| `RoundTimeoutMsg` | Timeout vote with highest QC           | Validator → all validators     |
+| `SyncInfo`        | Sync metadata (highest QC, TC, commit) | Piggybacked on other messages  |
 
 ## Implementation Details
 
-The consensus component is mostly implemented in the [Actor](https://en.wikipedia.org/wiki/Actor_model) programming model &mdash; i.e., it uses message-passing to communicate between different subcomponents with the [tokio](https://tokio.rs/) framework used as the task runtime. The primary exception to the actor model (as it is accessed in parallel by several subcomponents) is the consensus data structure *BlockStore* which manages the blocks, execution, quorum certificates, and other shared data structures. The major subcomponents in the consensus component are:
+The consensus component is mostly implemented in the [Actor](https://en.wikipedia.org/wiki/Actor_model) programming model — i.e., it uses message-passing to communicate between different subcomponents with the [tokio](https://tokio.rs/) framework used as the task runtime. The primary exception to the actor model (as it is accessed in parallel by several subcomponents) is the consensus data structure *BlockStore* which manages the blocks, execution, quorum certificates, and other shared data structures. The major subcomponents in the consensus component are:
 
-* **PayloadClient** is the interface to the mempool component and supports the pulling of transactions as well as removing committed transactions. A proposer uses on-demand pull transactions from mempool to form a proposal block.
-* **StateComputer** is the interface for accessing the execution component. It can execute blocks, commit blocks, and can synchronize state.
+* **EpochManager** manages epoch lifecycle, validator set initialization, and channel wiring between subcomponents.
+* **RoundManager** is the core event processor — it handles all consensus messages (proposals, votes, timeouts) and drives the protocol.
 * **BlockStore** maintains the tree of proposal blocks, block execution, votes, quorum certificates, and persistent storage. It is responsible for maintaining the consistency of the combination of these data structures and can be concurrently accessed by other subcomponents.
-* **RoundManager** is responsible for processing the individual events (e.g., process_new_round, process_proposal, process_vote). It exposes the async processing functions for each event type and drives the protocol.
 * **RoundState** is responsible for the liveness of the consensus protocol. It changes rounds due to timeout certificates or quorum certificates and proposes blocks when it is the proposer for the current round.
-* **SafetyRules** is responsible for the safety of the consensus protocol. It processes quorum certificates and LedgerInfo to learn about new commits and guarantees that the two voting rules are followed &mdash; even in the case of restart (since all safety data is persisted to local storage).
+* **SafetyRules** is responsible for the safety of the consensus protocol. It processes quorum certificates and LedgerInfo to learn about new commits and guarantees that the voting rules are followed — even in the case of restart (since all safety data is persisted to local storage).
+* **PendingVotes / PendingOrderVotes** aggregate votes and order votes into QCs, TCs, and commit certificates.
 
 All consensus messages are signed by their creators and verified by their receivers. Message verification occurs closest to the network layer to avoid invalid or unnecessary data from entering the consensus protocol.
 
+## Safety Invariants
+
+1. **No equivocation**: A validator votes at most once per round. Enforced by persisting `last_voted_round` in SafetyRules.
+
+2. **Preferred round**: A validator only votes for a block whose parent QC round >= its `preferred_round`. This prevents voting on forks that could conflict with the committed chain.
+
+3. **Order vote safety**: A validator must not order-vote for a round where it has timed out (`highest_timeout_round` check). This prevents conflicting ordering decisions across forks.
+
+4. **Deterministic execution**: All validators must produce identical execution results for the same ordered block sequence. Corollary: use deterministic data structures (`BTreeMap`, not `HashMap`) when iteration order affects serialization.
+
+5. **Rolling deployment safety**: During rolling upgrades, all nodes must produce identical `BlockMetadataTransaction`s regardless of code version. Gate new behavior on on-chain feature flags.
+
+## Configuration
+
+Key parameters (in `ConsensusConfig` and on-chain `OnChainConsensusConfig`):
+
+| Parameter                             | Purpose                                     |
+| ------------------------------------- | ------------------------------------------- |
+| `max_block_txns`                      | Max transactions per proposed block         |
+| `max_receiving_block_txns`            | Max transactions accepted in received block |
+| `round_initial_timeout_ms`            | Base timeout for rounds                     |
+| `round_timeout_backoff_exponent_base` | Exponential backoff multiplier              |
+| `round_timeout_backoff_max_exponent`  | Max exponent for timeout backoff            |
+| `enable_optimistic_proposal_rx`       | Accept optimistic proposals                 |
+| `enable_optimistic_proposal_tx`       | Send optimistic proposals                   |
+| `order_vote_enabled`                  | Enable 3-hop ordering via order votes       |
+
 ## How is this module organized?
 
-    consensus
-    ├── src
-    │   ├── block_storage          # In-memory storage of blocks and related data structures
-    │   ├── consensusdb            # Database interaction to persist consensus data for safety and liveness
-    │   ├── liveness               # RoundState, proposer, and other liveness related code
-    │   └── test_utils             # Mock implementations that are used for testing only
-    ├── consensus-types            # Consensus data types (i.e. quorum certificates)
-    └── safety-rules               # Safety (voting) rules
+### Core Consensus
+
+| File                                   | Purpose                                               |
+| -------------------------------------- | ----------------------------------------------------- |
+| `consensus/src/round_manager.rs`       | Core event processor — handles all consensus messages |
+| `consensus/src/epoch_manager.rs`       | Epoch lifecycle, validator set init, channel wiring   |
+| `consensus/src/network.rs`             | Network message sending/receiving                     |
+| `consensus/src/pending_votes.rs`       | Vote aggregation → QC/TC formation                    |
+| `consensus/src/pending_order_votes.rs` | Order vote aggregation                                |
+| `consensus/src/state_computer.rs`      | Execution interface                                   |
+
+### Block Storage
+
+| File                                          | Purpose                                  |
+| --------------------------------------------- | ---------------------------------------- |
+| `consensus/src/block_storage/block_store.rs`  | Block tree, QC tracking, execution state |
+| `consensus/src/block_storage/block_tree.rs`   | Tree structure with parent/QC links      |
+| `consensus/src/block_storage/sync_manager.rs` | Missing block synchronization            |
+
+### Liveness
+
+| File                                           | Purpose                                 |
+| ---------------------------------------------- | --------------------------------------- |
+| `consensus/src/liveness/round_state.rs`        | Pacemaker — round progression, timeouts |
+| `consensus/src/liveness/proposal_generator.rs` | Block proposal generation, backpressure |
+| `consensus/src/liveness/proposer_election.rs`  | Leader election trait                   |
+| `consensus/src/liveness/leader_reputation.rs`  | Reputation-based leader selection       |
+
+### Safety
+
+| File                                                | Purpose                              |
+| --------------------------------------------------- | ------------------------------------ |
+| `consensus/safety-rules/src/safety_rules.rs`        | Voting rules — prevents equivocation |
+| `consensus/safety-rules/src/safety_rules_2chain.rs` | 2-chain timeout rules                |
+| `consensus/safety-rules/src/consensus_state.rs`     | Persistent safety state              |
+
+### Consensus Types
+
+| File                                                   | Purpose                                          |
+| ------------------------------------------------------ | ------------------------------------------------ |
+| `consensus/consensus-types/src/block.rs`               | Block structure                                  |
+| `consensus/consensus-types/src/quorum_cert.rs`         | QuorumCert (2f+1 vote signatures)                |
+| `consensus/consensus-types/src/vote.rs`                | Vote message                                     |
+| `consensus/consensus-types/src/order_vote.rs`          | Order vote for 3-hop ordering                    |
+| `consensus/consensus-types/src/wrapped_ledger_info.rs` | Commit cert from order votes                     |
+| `consensus/consensus-types/src/timeout_2chain.rs`      | Timeout certificate                              |
+| `consensus/consensus-types/src/opt_proposal_msg.rs`    | Optimistic proposal message                      |
+| `consensus/consensus-types/src/safety_data.rs`         | Persistent safety state                          |
+| `consensus/consensus-types/src/payload.rs`             | Payload types (DirectMempool, QuorumStore, etc.) |
+
+### Related Subsystems
+
+See separate READMEs for:
+- `consensus/src/pipeline/` — Decoupled execution pipeline (execute, sign, persist, broadcast)
+- `consensus/src/quorum_store/` — QuorumStore for data dissemination
+
+### Directory Structure
+
+```
+consensus
+├── src
+│   ├── block_storage          # In-memory storage of blocks and related data structures
+│   ├── consensusdb            # Database interaction to persist consensus data for safety and liveness
+│   ├── liveness               # RoundState, proposer, and other liveness related code
+│   ├── pipeline               # Decoupled execution pipeline
+│   ├── quorum_store           # QuorumStore for data dissemination
+│   └── test_utils             # Mock implementations that are used for testing only
+├── consensus-types            # Consensus data types (i.e. quorum certificates)
+└── safety-rules               # Safety (voting) rules
+```
+
+## Testing
+
+```bash
+cargo test -p aptos-consensus          # Consensus unit tests
+cargo test -p aptos-consensus-types    # Type tests
+cargo test -p aptos-safety-rules       # Safety rules tests
+cargo test -p smoke-test               # E2E smoke tests
+# Forge tests: see testsuite/forge-cli/src/suites/
+```

--- a/consensus/src/pipeline/README.md
+++ b/consensus/src/pipeline/README.md
@@ -1,0 +1,200 @@
+# Pipeline
+
+The blockchain pipeline decouples block ordering from execution, certification, and persistence. Different blocks progress through stages in parallel, exploiting distinct resource utilization (network for consensus, CPU for execution, IO for storage). See the [Zaptos paper](https://arxiv.org/pdf/2501.10612) for the full design.
+
+## Overview
+
+A transaction on Aptos goes through four major stages:
+
+1. **Consensus** — orders transactions into blocks (network-bound)
+2. **Execution** — executes transactions in a block via Block-STM (CPU-bound)
+3. **Certification** — validators sign and aggregate signatures on execution results (network-bound)
+4. **Commit** — persists certified blocks to storage (IO-bound)
+
+### Baseline Pipeline
+
+The baseline Aptos pipeline overlaps these stages across consecutive blocks. At any given time, block i is being ordered, block i-1 is being executed, block i-2 is being certified, and block i-3 is being committed:
+
+```
+Time ──────────────────────────────────────────────────────────────────────────────►
+
+Block N:   [ Consensus ][ Execution ][ Certification ][ Commit ]
+Block N+1:              [ Consensus ][ Execution     ][ Certification ][ Commit ]
+Block N+2:                           [ Consensus     ][ Execution     ][ Cert.. ][ Commit ]
+```
+
+This achieves high throughput by keeping CPU, network, and IO resources busy simultaneously.
+
+### Zaptos Optimizations
+
+Zaptos reduces end-to-end latency through three optimizations that **shadow** execution, certification, and commit under the consensus latency — so by the time a block is ordered, it has already been executed, certified, and persisted:
+
+```
+            propose         vote      order vote       ordered
+               │              │            │               │
+               ▼              ▼            ▼               ▼
+Consensus:     [──────────────┼────────────┼───────────────]
+               │              │            │               │
+Execution:     │              [============]               │  opt. execution (starts on vote)
+               │              │            │               │
+Commit:        │              │            [====]          │  opt. commit (pre-commit)
+               │              │            │               │
+Certify:       │              │            [===============]  early certification
+               │              │            │               │
+               │              │            │  all 3 done   │
+               │              │            │  by ordered   │
+```
+
+Execution, certification, and commit are **shadowed** within the consensus latency. By the time a block is ordered, it has already been executed, certified, and persisted.
+
+**1. Optimistic Execution** — validators begin executing a block immediately upon receiving the proposal, before consensus ordering completes. Execution runs in parallel with the remaining voting rounds.
+
+**2. Optimistic Commit (Pre-Commit)** — once execution completes, the new state is written to storage immediately, before certification finishes. The state is marked as `OptCommitted` and later promoted to `Committed` when certification completes. If the block is not ordered, the optimistically committed state is reverted.
+
+**3. Early Certification** — validators broadcast their certification vote (commit vote) when sending their order vote, if execution has already completed. This overlaps certification with the final consensus round, effectively reducing latency by one round.
+
+The result: end-to-end blockchain latency ≈ consensus latency, with execution, certification, and commit hidden within it.
+
+## Implementation
+
+`PipelineBuilder` constructs a graph of async futures for each block. Each stage is a spawned task that awaits its dependencies before executing. Dependencies are of two kinds:
+
+1. **Intra-block** — later stages await earlier stages of the same block (e.g., execute waits for prepare)
+2. **Inter-block** — each stage awaits the same stage of its parent block (e.g., block N+1's execute waits for block N's execute), ensuring sequential state transitions while allowing different stages to overlap across blocks
+
+### Per-Block Pipeline Stages
+
+| Stage                  | Waits for                                     | What it does                                                       |
+| ---------------------- | --------------------------------------------- | ------------------------------------------------------------------ |
+| **Materialize**        | QC arrives for block                          | Resolves payload (fetches batches from QuorumStore)                |
+| **Prepare**            | Materialize, Decryption (if enabled)          | Prepares block for execution, verifies transaction signatures      |
+| **Rand Txns Check**    | Prepare, parent Execute                       | Scans transactions for randomness annotations                      |
+| **Wait for Rand**      | Rand Txns Check, rand_rx                      | Waits for randomness value if block needs it; no-op otherwise      |
+| **Execute**            | Prepare, Wait for Rand, parent Execute        | Runs Block-STM parallel execution                                  |
+| **Ledger Update**      | Execute, parent Ledger Update                 | Generates `StateComputeResult` from execution output               |
+| **Commit Vote**        | Ledger Update, order vote/proof/commit proof  | Signs execution result and broadcasts `CommitVote`                 |
+| **Pre-Commit**         | Ledger Update, parent Pre-Commit, order proof | Writes result to storage after ordering but before commit proof    |
+| **Commit Ledger**      | Pre-Commit, commit proof, parent Commit       | Finalizes committed state — makes data visible to clients          |
+| **Post Ledger Update** | Ledger Update                                 | Notifies mempool about failed transactions (off critical path)     |
+| **Notify State Sync**  | Pre-Commit, Commit Ledger                     | Notifies state synchronizer about committed transactions           |
+| **Post Commit**        | Commit Ledger, parent Post Commit             | Updates counters, notifies block store                             |
+
+### How Zaptos Optimizations Map to Stages
+
+**Optimistic Execution**: Materialize starts as soon as the QC for the block arrives (via `qc_rx`), which happens when the validator votes — before the block is ordered. Prepare, execute, and ledger update then proceed immediately, overlapping with the remaining consensus rounds.
+
+**Early Certification**: Commit Vote waits for ledger update AND any one of: order vote (`order_vote_rx`), order proof, or commit proof. When order votes are enabled, the commit vote is broadcast as soon as the validator sends its order vote and execution is complete — overlapping certification with the final consensus round.
+
+**Pre-Commit**: In production, pre-commit waits for the **order proof** before writing to storage, avoiding the need to roll back optimistically committed state. This means pre-commit happens after ordering but before the full commit proof, still saving latency. For epoch-ending blocks or when pre-commit is paused (e.g., during state sync), it additionally waits for the commit proof.
+
+### Randomness
+
+When on-chain randomness is enabled, the randomness check is split into two futures:
+
+1. **Rand Txns Check** (`has_rand_txns_fut`) — scans the block's transactions for randomness annotations after prepare and parent execute complete. This determines whether the block needs randomness.
+2. **Wait for Rand** (`rand_check_fut`) — if the block needs randomness, waits for the randomness value delivered via `rand_rx` (which depends on consensus-driven randomness aggregation). If no randomness is needed, this is a no-op.
+
+If any transaction requires randomness, execution **cannot** proceed optimistically — it must wait for the randomness value, which blocks the Execute stage and prevents optimistic execution from overlapping with consensus. As a result, the Zaptos latency optimizations do not apply to blocks containing randomness transactions.
+
+### Pipeline Inputs
+
+Each block receives external signals via `PipelineInputTx` channels:
+- **qc_rx** — QC for this block (triggers materialize)
+- **rand_rx** — randomness value (if block needs randomness)
+- **order_vote_rx** — order vote received for this block
+- **order_proof_tx** — order proof (WrappedLedgerInfo) for this block
+- **commit_proof_tx** — commit proof (LedgerInfoWithSignatures) for this block
+
+## BufferManager
+
+The `BufferManager` manages a linked buffer of ordered blocks and orchestrates commit vote aggregation. It receives ordered blocks from consensus, feeds them into the `PipelineBuilder` futures, and handles commit messages from the network.
+
+### BufferItem States
+
+| State        | Description                                        |
+| ------------ | -------------------------------------------------- |
+| `Ordered`    | Received from consensus, pipeline futures created  |
+| `Executed`   | Execution complete, collecting commit votes        |
+| `Signed`     | Own commit vote broadcast, aggregating signatures  |
+| `Aggregated` | 2f+1 commit votes collected, ready to persist      |
+
+### Commit Vote Aggregation
+
+Commit votes can arrive before a block is executed (e.g., if other validators are faster). The `BufferManager` caches these as pending votes and applies them when the block reaches the appropriate state. A full `CommitDecision` can fast-forward a block directly to the Aggregated state.
+
+### Reliable Broadcast
+
+Commit votes use reliable broadcast with:
+- Exponential backoff starting at 2ms, max 5 seconds
+- Broadcast interval: 1500ms
+- Rebroadcast of stale votes: every 30 seconds
+- Tracks ACKs from all validators; completes when all respond
+
+### Backpressure
+
+Backpressure operates at two levels:
+
+**1. BufferManager (block intake)**
+
+The `BufferManager` stops accepting new ordered blocks when the gap between the latest ordered round and the highest committed round exceeds `MAX_BACKLOG` (20 rounds). This is implemented as a `tokio::select!` guard on the block intake channel — when backpressure is active, the `block_rx.next()` branch is disabled, so consensus blocks waiting to enter the pipeline are queued until commits catch up.
+
+This was originally introduced to prevent state sync from receiving a ledger info older than the pre-committed version — if the buffer grew unboundedly, pre-commit could advance far ahead of the commit root, and a state sync trigger would conflict with already pre-committed state. This root cause has since been fixed by adding `pre_commit_status` to connect `sync_manager` and the pipeline (`413db84eeb`), which pauses pre-commit when state sync is needed. The backpressure remains as a general safety bound on buffer size.
+
+**2. ProposalGenerator (block size reduction)**
+
+The `ProposalGenerator` applies finer-grained backpressure on proposals using two signals:
+
+- **Pipeline pending latency**: Measures the time since the oldest unexecuted block was ordered. When this exceeds configured thresholds, the proposal generator reduces `max_sending_block_txns_after_filtering`, `max_sending_block_bytes`, and adds a `backpressure_proposal_delay_ms` before proposing. This slows down consensus to let the pipeline drain.
+
+- **Execution time**: Looks at recent block execution times (configurable window via `num_blocks_to_look_at`). When execution is slow, the proposal generator reduces the transaction limit and gas limit for new blocks, producing smaller blocks that execute faster.
+
+Both signals take the minimum across all backpressure sources, so the most restrictive limit applies.
+
+### Reset and State Sync
+
+Resets are triggered via `ResetRequest` with two variants:
+
+- **`TargetRound(round)`** — sent by `sync_to_target` when the node falls behind and needs state sync. Updates `highest_committed_round` and `latest_round` to the target, and drains any pending commit proofs up to that round.
+- **`Stop`** — sent by `end_epoch` at epoch boundaries. Sets a stop flag that terminates the `BufferManager` main loop after cleanup.
+
+Both variants then execute the same cleanup sequence:
+
+1. **Wait for pending commits** — blocks in `pending_commit_blocks` (already aggregated and handed off for commit) are awaited to completion, since they have no remaining dependencies and aborting them can cause errors at epoch boundaries.
+2. **Abort buffered blocks** — all remaining items in the buffer have their pipeline futures aborted via `abort_pipeline()`, then awaited until finished.
+3. **Clear buffer state** — the buffer is replaced with a fresh empty buffer, and `execution_root`, `signing_root`, and `commit_proof_rb_handle` are cleared.
+4. **Drain incoming block queue** — any blocks queued in `block_rx` that haven't been processed yet are popped and their pipeline futures aborted.
+5. **Wait for ongoing tasks** — polls `ongoing_tasks` counter until it reaches zero, ensuring all spawned tasks have completed.
+6. **Send ack** — sends `ResetAck` back to the caller (state sync or epoch manager), which blocks until this point.
+
+The reset order is: rand manager first, then secret share manager, then buffer manager — each awaiting its ack before proceeding to the next. For state sync (`TargetRound`), after all managers are reset, the execution proxy performs the actual state sync to the target ledger info. For epoch end (`Stop`), the execution proxy's `end_epoch` is called after all managers stop.
+
+### Message Types
+
+| Message          | Purpose                                            | Sender → Receiver              |
+| ---------------- | -------------------------------------------------- | ------------------------------ |
+| `CommitVote`     | Validator's signature on execution result          | Validator → all validators     |
+| `CommitDecision` | 2f+1 commit vote signatures (commit proof)         | Any validator → all validators |
+
+## Key Files
+
+| File                           | Purpose                                                                                    |
+| ------------------------------ | ------------------------------------------------------------------------------------------ |
+| `pipeline_builder.rs`          | Constructs per-block future graph (the Zaptos pipeline) — materialize through post-commit  |
+| `buffer_manager.rs`            | Central orchestrator — ordered buffer, commit vote aggregation, reliable broadcast         |
+| `buffer_item.rs`               | BufferItem enum with state transitions (Ordered → Executed → Signed → Aggregated)          |
+| `buffer.rs`                    | Hash-based ordered linked buffer data structure                                            |
+| `commit_reliable_broadcast.rs` | Reliable broadcast for commit votes with retries                                           |
+| `execution_schedule_phase.rs`  | Sends blocks to execution, creates futures                                                 |
+| `execution_wait_phase.rs`      | Awaits execution future completion                                                         |
+| `signing_phase.rs`             | Signs commit ledger info via safety rules                                                  |
+| `persisting_phase.rs`          | Finalizes committed state to ledger DB                                                     |
+| `pipeline_phase.rs`            | `StatelessPipeline` trait and task counting                                                |
+| `execution_client.rs`          | `ExecutionClient` interface and `BufferManagerHandle`                                      |
+| `decoupled_execution_utils.rs` | Channel wiring between phases                                                              |
+| `errors.rs`                    | Pipeline error types                                                                       |
+
+## Testing
+
+```bash
+cargo test -p aptos-consensus -- pipeline
+```

--- a/consensus/src/quorum_store/README.md
+++ b/consensus/src/quorum_store/README.md
@@ -1,0 +1,181 @@
+# Quorum Store
+
+Quorum Store (QS) is a data dissemination layer based on [Narwhal](https://arxiv.org/abs/2105.11827). It separates transaction dissemination from consensus ordering, enabling all validators to broadcast transactions concurrently rather than relying solely on the leader. See [AIP-26](https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-26.md) for the original design and [AIP-106](https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-106.md) for Optimistic Quorum Store.
+
+## Overview
+
+Without Quorum Store, the consensus leader is the bottleneck — it must pull transactions from mempool and broadcast them to all validators in the proposal. With Quorum Store, every validator continuously creates **batches** of transactions and broadcasts them to all peers. When 2f+1 validators sign a batch, a **Proof of Store** (PoS) is formed, certifying the batch is available. The leader then proposes blocks containing only batch references (PoS), not raw transactions.
+
+This maximizes network bandwidth utilization across all validators and reduces proposal size.
+
+### Optimistic Quorum Store
+
+[AIP-106](https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-106.md) introduces Optimistic Quorum Store. In the standard flow, the leader must wait for 2f+1 signatures to form a Proof of Store before including a batch in a proposal. Optimistic QS removes this wait — the leader proposes **batch summaries without proofs**. Since batch authors broadcast batch data to all validators, by the triangle inequality of the network, the batch data likely arrives at validators by the time the leader's proposal arrives. If a validator does not have a batch locally, it fetches it from the batch author or PoS signers via `BatchRequester`. Batches that never receive a proof are garbage-collected on expiration.
+
+The proposal payload (`OptQuorumStorePayload`) contains three tiers:
+1. **Proof batches** — batches with full PoS (guaranteed available from signers)
+2. **Optimistic batches** — batch summaries without proofs (fetched on demand if missing)
+3. **Inline batches** — full transactions included directly (used when proof queue is fully utilized)
+
+## Protocol
+
+### Batch Lifecycle
+
+**1. Batch Creation (BatchGenerator)**
+
+- Pulls transactions from mempool at a configurable interval
+- Sorts by gas price and buckets into batches respecting size limits (`sender_max_batch_txns`, `sender_max_batch_bytes`)
+- Assigns a monotonically increasing `BatchId`
+- Persists the batch to local DB
+- Broadcasts `BatchMsg` to all validators
+
+**2. Batch Reception (BatchCoordinator)**
+
+- Receives remote `BatchMsg` from network
+- Validates size limits and transaction filters
+- Persists to `BatchStore`
+- Signs the batch metadata with validator key, producing a `SignedBatchInfo`
+- Sends `SignedBatchInfo` back to the batch author
+
+**3. Proof Aggregation (ProofCoordinator)**
+
+- Collects `SignedBatchInfo` from validators
+- Aggregates signatures using `SignatureAggregator`
+- When 2f+1 signatures are collected, forms a `ProofOfStore` (aggregate BLS signature over batch metadata)
+- Broadcasts the `ProofOfStore` to all validators
+
+**4. Proof Queuing (ProofManager)**
+
+- Receives `ProofOfStore` and inserts into `BatchProofQueue`
+- Queue is sorted by author and gas bucket for fair, prioritized pulling
+- Deduplicates transactions across batches using `TxnSummary` occurrence tracking
+
+### Consensus Integration
+
+When the leader needs to create a proposal:
+
+1. `ProposalGenerator` sends a `GetPayloadCommand` to `ProofManager`
+2. `ProofManager` pulls from `BatchProofQueue`:
+   - **Proof batches**: batches with full `ProofOfStore` (guaranteed available)
+   - **Optimistic batches**: batch summaries without proofs (OptQS, lower latency)
+   - **Inline batches**: full transactions when queue has capacity
+3. Returns `OptQuorumStorePayload` containing all three types
+4. If a validator lacks a batch during execution, it fetches from peers using the PoS signatures
+
+### Backpressure
+
+`ProofManager` tracks `remaining_total_txn_num` and `remaining_total_proof_num`. When either exceeds configured thresholds, it sends a backpressure signal to `BatchGenerator` (sampled every 200ms to avoid constant updates). `BatchGenerator` responds with:
+- **Multiplicative decrease** (×0.9) on pull rate when backpressured
+- **Additive increase** (+delta) when backpressure clears
+
+### Batch V2
+
+Batch V2 adds support for transaction classification (`BatchKind`: Normal or Encrypted), with separate creation and network paths controlled by `enable_batch_v2_tx`.
+
+## Implementation
+
+### QuorumStoreCoordinator
+
+The top-level orchestrator runs a main loop processing `CoordinatorCommand` messages:
+
+- **`CommitNotification(block_timestamp, batches)`** — fans out to `ProofCoordinator`, `ProofManager`, and `BatchGenerator` so each can garbage-collect committed batches and update timestamps.
+- **`Shutdown(ack_tx)`** — orchestrates graceful shutdown in reverse pipeline order (network listener → proof manager → proof coordinator → batch coordinator → batch generator) to ensure senders close before receivers.
+
+### BatchProofQueue
+
+The core data structure for managing proofs and batches with fairness and deduplication.
+
+**Sorting**: Batches are keyed by `(gas_bucket_start ASC, batch_id DESC)` — higher gas buckets are pulled first, and within a bucket, newer batches take priority.
+
+**Per-peer fairness**: Each author has a separate `BTreeMap`, so no single validator can monopolize the queue.
+
+**Deduplication**: Tracks transaction summaries `(sender, replay_protector, hash, expiration)` with occurrence counts across all batches. When pulling, transactions already seen in earlier batches are counted as duplicates and subtracted from the effective batch size.
+
+**Expiration**: A `TimeExpirations` binary heap tracks batch lifetimes. When `handle_updated_block_timestamp` is called, expired batches are removed and their transaction occurrence counts decremented.
+
+### BatchStore
+
+Persistent batch storage with per-peer quotas to prevent any single validator from monopolizing resources.
+
+**Quota system**: Each peer has a `QuotaManager` tracking `db_balance`, `memory_balance`, and `batch_balance`. Based on available quota, batches are stored in one of two modes:
+- `MemoryAndPersisted` — both in-memory cache and DB (preferred)
+- `PersistedOnly` — only in database, metadata in cache (when memory quota exhausted)
+- Rejected if both quotas are exhausted
+
+**Concurrency**: Uses `DashMap` for lock-free concurrent access. Lock ordering (cache entry before peer quota) prevents deadlocks.
+
+**Subscriber mechanism**: When a batch is needed but not yet available, callers register via `subscribe()`. When the batch arrives, all subscribers are notified via oneshot channels. This handles races between batch fetching and batch reception.
+
+**Bootstrap**: On startup, loads previous epoch batches from DB, garbage-collects expired ones, and repopulates the in-memory cache.
+
+### BatchRequester
+
+Fetches missing batches from the network when a validator needs a batch it doesn't have locally.
+
+**Request strategy**: Starts with a random peer from the batch's PoS signers, then cycles through validators on retries (up to `retry_limit`). Sends to `request_num_peers` validators concurrently.
+
+**Completion conditions**: The request completes when either:
+- A valid `BatchResponse` arrives from a peer
+- The batch is received via subscription (another code path fetched it)
+- The batch has expired (ledger info timestamp > batch expiration)
+
+## Architecture
+
+```
+                    ┌──────────────────────────────────────────┐
+                    │         QuorumStoreCoordinator           │
+                    │  (dispatches commands to all components) │
+                    └──────┬──────┬──────┬──────┬──────────────┘
+                           │      │      │      │
+              ┌────────────▼┐  ┌──▼──────▼──┐  ┌▼──────────────┐
+              │   Batch     │  │   Proof    │  │    Proof      │
+  Mempool ──► │  Generator  │  │ Coordinator│  │   Manager     │◄── GetPayloadCommand
+              │  (create +  │  │ (aggregate │  │  (queue +     │       (from consensus)
+              │   broadcast)│  │  signatures│  │   pull proofs)│
+              └─────────────┘  │  → PoS)    │  └───────────────┘
+                               └────────────┘
+              ┌─────────────┐
+  Network ──► │   Batch     │  ┌────────────┐
+              │ Coordinator │  │  Batch     │
+              │ (receive +  │  │  Store     │
+              │  sign +     ├─►│ (persist + │
+              │  persist)   │  │  cache)    │
+              └─────────────┘  └────────────┘
+
+              ┌─────────────┐
+  Network ──► │  Network    │  Routes: BatchMsg → BatchCoordinator
+              │  Listener   │          SignedBatchInfo → ProofCoordinator
+              └─────────────┘          ProofOfStoreMsg → ProofManager
+```
+
+### Message Types
+
+| Message           | Purpose                              | Sender → Receiver           |
+| ----------------- | ------------------------------------ | --------------------------- |
+| `BatchMsg`        | Batch of transactions                | Creator → all validators    |
+| `SignedBatchInfo` | Validator signature on batch         | Receiver → batch author     |
+| `ProofOfStoreMsg` | Aggregated proof (2f+1 signatures)   | Author → all validators     |
+| `BatchRequest`    | Request missing batch by digest      | Any validator → PoS signers |
+| `BatchResponse`   | Batch payload or NotFound            | Signer → requester          |
+
+## Key Files
+
+| File                          | Purpose                                                        |
+| ----------------------------- | -------------------------------------------------------------- |
+| `quorum_store_coordinator.rs` | Top-level coordinator, dispatches commands and shutdown        |
+| `batch_generator.rs`          | Pulls from mempool, creates and broadcasts batches             |
+| `batch_coordinator.rs`        | Receives remote batches, validates, persists, signs            |
+| `proof_coordinator.rs`        | Aggregates signatures into ProofOfStore                        |
+| `proof_manager.rs`            | Manages proof queue, serves proposals, backpressure            |
+| `batch_proof_queue.rs`        | Core queue: sorted by gas bucket, per-peer fairness, dedup     |
+| `batch_store.rs`              | In-memory cache + DB persistence with per-peer quotas          |
+| `batch_requester.rs`          | Fetches missing batches from PoS signers with retries          |
+| `network_listener.rs`         | Routes network messages to handlers                            |
+| `types.rs`                    | Core types: Batch, BatchMsg, BatchRequest, etc.                |
+| `quorum_store_db.rs`          | Database layer for batch persistence                           |
+
+## Testing
+
+```bash
+cargo test -p aptos-consensus -- quorum_store
+```


### PR DESCRIPTION
## Summary
- Rewrites the consensus README with current protocol details: 2-chain commit rule, order votes (AIP-89), optimistic proposals (AIP-131), f+1 timeout mechanism, and updated architecture diagram
- Creates pipeline README documenting the blockchain pipeline and Zaptos optimizations (optimistic execution, pre-commit, early certification), PipelineBuilder implementation, randomness handling, BufferManager, backpressure, and reset/state sync
- Creates quorum store README documenting batch lifecycle, proof aggregation, Optimistic QS (AIP-106), BatchProofQueue, BatchStore per-peer quotas, and BatchRequester

## Test plan
- [ ] Verify READMEs render correctly on GitHub
- Documentation-only change, no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)