### PR TITLE
[storage] Raise L0 write stall triggers on sequential-key ledger CFs

### DIFF
--- a/storage/aptosdb/src/db_options.rs
+++ b/storage/aptosdb/src/db_options.rs
@@ -205,12 +205,20 @@ fn convert_index_type(index_type: IndexType) -> BlockBasedIndexType {
     }
 }
 
-/// Disable pending compaction bytes based write stalling. This is for append-only DBs (ledger
-/// sub-DBs keyed by sequential version) where compaction is done entirely via trivial moves —
-/// the estimated pending compaction bytes is fictional and should not trigger stalls.
+/// Disable write stalling for append-only, sequential-key CFs (ledger sub-DBs keyed by version).
+/// Compaction on these CFs is entirely trivial moves (file renames, no I/O), but they share the
+/// background compaction thread pool with state DBs. When the pool is saturated by state DB
+/// compactions, these CFs can't get scheduled and would otherwise stall writes.
+///
+/// We disable both stall vectors:
+///   - Pending compaction bytes: set to 0 (unlimited) — the estimate is fictional for trivial moves.
+///   - L0 file count: set very high — non-overlapping L0 files from sequential keys don't hurt
+///     read performance, and auto-compaction will catch up when the pool has spare capacity.
 fn with_no_compaction_stalling(cf_opts: &mut Options) {
     cf_opts.set_soft_pending_compaction_bytes_limit(0);
     cf_opts.set_hard_pending_compaction_bytes_limit(0);
+    cf_opts.set_level_zero_slowdown_writes_trigger(1000);
+    cf_opts.set_level_zero_stop_writes_trigger(2000);
 }
 
 fn with_state_key_extractor_processor(cf_name: ColumnFamilyName, cf_opts: &mut Options) {

--- a/storage/aptosdb/src/rocksdb_property_reporter.rs
+++ b/storage/aptosdb/src/rocksdb_property_reporter.rs
@@ -52,6 +52,7 @@ static ROCKSDB_PROPERTY_MAP: Lazy<HashMap<&str, String>> = Lazy::new(|| {
         "rocksdb.is-write-stopped",
         "rocksdb.block-cache-capacity",
         "rocksdb.block-cache-usage",
+        "rocksdb.num-files-at-level0",
     ]
     .iter()
     .map(|x| (*x, format!("aptos_{}", x.replace('.', "_"))))


### PR DESCRIPTION

While stress-testing with higher TPS using the executor benchmark,
significant write stalls were observed on the ledger DB commit path.

These append-only, version-keyed column families (write_set, transaction,
transaction_info, transaction_accumulator, event, etc.) only ever need
trivial-move compactions (file renames, zero I/O). However, they share
the background compaction thread pool with state_merkle and state_kv DBs
(32+ shards). Under high TPS, the shared pool becomes saturated by state
DB compactions, starving these ledger CFs of scheduling slots.

We previously disabled pending-compaction-bytes stalls (set to 0) on
these CFs, but it turned out that's not enough — we still hit L0 file
count stalls from the default triggers (slowdown=20, stop=36), which
block the synchronous ledger commit path and stall the entire pipeline.

This change raises the L0 file count triggers to 1000/2000 on these CFs.
Since L0 files from sequential keys are non-overlapping, high L0 counts
don't degrade read performance. Auto-compaction will still clear them
when pool capacity is available.

Other approaches considered but not taken:
- **Separate `Env` (thread pool) for ledger DBs**: most correct fix, but
  requires C/C++ binding changes since the Rust `rocksdb` crate only
  exposes the default shared `Env`.
- **`compact_range` on a dedicated thread**: does not actually bypass the
  shared pool — it schedules on background threads and blocks the caller.
  `CompactFiles` runs on the caller's thread but isn't in the C API.
- **Increasing total low-priority threads**: works (tested with 12) but
  adds more I/O from state DB compactions. Doesn't address the root
  scheduling fairness issue.
- **Reducing `max_background_jobs` per state shard**: tested with 2, not
  sufficient — 32 shards × 2 = 64 potential jobs still starves ledger
  DBs with only 4-8 pool threads.

Also adds `rocksdb.num-files-at-level0` to the property reporter for
monitoring.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes RocksDB write-stall thresholds for several ledger column families, which can affect write backpressure and L0 file growth under load. Mis-tuning could increase disk usage or compaction pressure even though it should reduce commit-path stalls.
> 
> **Overview**
> Reduces write stalls on append-only, sequential-key ledger column families by expanding `with_no_compaction_stalling` to also raise RocksDB L0 write-stall triggers (slowdown/stop) in addition to the existing pending-compaction-bytes limits.
> 
> Adds `rocksdb.num-files-at-level0` to the RocksDB property reporter so L0 growth can be monitored alongside existing compaction/write-stall metrics.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6b874d0f02125eb2a8e509219da99099284ed0da. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->