### PR TITLE
[aptos-release-v1.42] Revert PipelinedBlock BCS serialization breakage

### DIFF
--- a/consensus/consensus-types/src/pipelined_block.rs
+++ b/consensus/consensus-types/src/pipelined_block.rs
@@ -217,7 +217,6 @@ pub struct PipelinedBlock {
     /// pending blocks upon restart.
     state_compute_result: Mutex<StateComputeResult>,
     randomness: OnceCell<Randomness>,
-    secret_shared_key: OnceCell<SecretSharedKey>,
     pipeline_insertion_time: OnceCell<Instant>,
     execution_summary: OnceCell<ExecutionSummary>,
     /// pipeline related fields
@@ -232,7 +231,6 @@ impl PartialEq for PipelinedBlock {
         self.block == other.block
             && self.input_transactions == other.input_transactions
             && self.randomness.get() == other.randomness.get()
-            && self.secret_shared_key.get() == other.secret_shared_key.get()
     }
 }
 impl Eq for PipelinedBlock {}
@@ -248,14 +246,12 @@ impl Serialize for PipelinedBlock {
             block: &'a Block,
             input_transactions: &'a Vec<SignedTransaction>,
             randomness: Option<&'a Randomness>,
-            secret_shared_key: Option<&'a SecretSharedKey>,
         }
 
         let serialized = SerializedBlock {
             block: &self.block,
             input_transactions: &self.input_transactions,
             randomness: self.randomness.get(),
-            secret_shared_key: self.secret_shared_key.get(),
         };
         serialized.serialize(serializer)
     }
@@ -272,22 +268,16 @@ impl<'de> Deserialize<'de> for PipelinedBlock {
             block: Block,
             input_transactions: Vec<SignedTransaction>,
             randomness: Option<Randomness>,
-            #[serde(default)]
-            secret_shared_key: Option<SecretSharedKey>,
         }
 
         let SerializedBlock {
             block,
             input_transactions,
             randomness,
-            secret_shared_key,
         } = SerializedBlock::deserialize(deserializer)?;
         let block = PipelinedBlock::new(block, input_transactions, StateComputeResult::new_dummy());
         if let Some(r) = randomness {
             block.set_randomness(r);
-        }
-        if let Some(key) = secret_shared_key {
-            block.set_decryption_key(key);
         }
         Ok(block)
     }
@@ -353,20 +343,6 @@ impl PipelinedBlock {
         assert!(self.randomness.set(randomness.clone()).is_ok());
     }
 
-    /// Stores the decryption key on the block and eagerly sends it via the pipeline channel
-    /// to unblock the decryption phase as early as possible. The execution_schedule_phase also
-    /// sends via this channel as a fallback (using take(), so only one send actually occurs).
-    pub fn set_decryption_key(&self, key: SecretSharedKey) {
-        assert!(self.secret_shared_key.set(key.clone()).is_ok());
-        if let Some(tx) = self.pipeline_tx().lock().as_mut() {
-            tx.secret_shared_key_tx.take().map(|tx| tx.send(Some(key)));
-        }
-    }
-
-    pub fn secret_shared_key(&self) -> Option<&SecretSharedKey> {
-        self.secret_shared_key.get()
-    }
-
     pub fn set_insertion_time(&self) {
         assert!(self.pipeline_insertion_time.set(Instant::now()).is_ok());
     }
@@ -410,7 +386,6 @@ impl PipelinedBlock {
             input_transactions,
             state_compute_result: Mutex::new(state_compute_result),
             randomness: OnceCell::new(),
-            secret_shared_key: OnceCell::new(),
             pipeline_insertion_time: OnceCell::new(),
             execution_summary: OnceCell::new(),
             pipeline_futs: Mutex::new(None),

--- a/consensus/src/consensus_observer/observer/consensus_observer.rs
+++ b/consensus/src/consensus_observer/observer/consensus_observer.rs
@@ -51,7 +51,7 @@ use aptos_storage_interface::DbReader;
 use aptos_time_service::TimeService;
 use aptos_types::{
     block_info::Round, epoch_state::EpochState, ledger_info::LedgerInfoWithSignatures,
-    validator_signer::ValidatorSigner,
+    on_chain_config::OnChainChunkyDKGConfig, validator_signer::ValidatorSigner,
 };
 use futures::StreamExt;
 use futures_channel::oneshot;
@@ -1065,13 +1065,7 @@ impl ConsensusObserver {
     async fn wait_for_epoch_start(&mut self) {
         // Wait for the epoch state to update
         let block_payloads = self.observer_block_data.lock().get_block_payloads();
-        let (
-            payload_manager,
-            consensus_config,
-            execution_config,
-            randomness_config,
-            chunky_dkg_config,
-        ) = self
+        let (payload_manager, consensus_config, execution_config, randomness_config) = self
             .observer_epoch_state
             .wait_for_epoch_start(block_payloads)
             .await;
@@ -1089,6 +1083,7 @@ impl ConsensusObserver {
             AccountAddress,
             IncomingSecretShareRequest,
         >(QueueStyle::FIFO, 1, None);
+        let chunky_dkg_config = OnChainChunkyDKGConfig::default_disabled();
         self.execution_client
             .start_epoch(
                 sk,

--- a/consensus/src/consensus_observer/observer/epoch_state.rs
+++ b/consensus/src/consensus_observer/observer/epoch_state.rs
@@ -18,9 +18,8 @@ use aptos_logger::{error, info, warn};
 use aptos_types::{
     epoch_state::EpochState,
     on_chain_config::{
-        ChunkyDKGConfigMoveStruct, OnChainChunkyDKGConfig, OnChainConsensusConfig,
-        OnChainExecutionConfig, OnChainRandomnessConfig, RandomnessConfigMoveStruct,
-        RandomnessConfigSeqNum, ValidatorSet,
+        OnChainConsensusConfig, OnChainExecutionConfig, OnChainRandomnessConfig,
+        RandomnessConfigMoveStruct, RandomnessConfigSeqNum, ValidatorSet,
     },
 };
 use futures::StreamExt;
@@ -92,10 +91,9 @@ impl ObserverEpochState {
         OnChainConsensusConfig,
         OnChainExecutionConfig,
         OnChainRandomnessConfig,
-        OnChainChunkyDKGConfig,
     ) {
         // Extract the epoch state and on-chain configs
-        let (epoch_state, consensus_config, execution_config, randomness_config, chunky_dkg_config) =
+        let (epoch_state, consensus_config, execution_config, randomness_config) =
             extract_on_chain_configs(&self.node_config, &mut self.reconfig_events).await;
 
         // Update the local epoch state and quorum store config
@@ -125,7 +123,6 @@ impl ObserverEpochState {
             consensus_config,
             execution_config,
             randomness_config,
-            chunky_dkg_config,
         )
     }
 }
@@ -139,7 +136,6 @@ async fn extract_on_chain_configs(
     OnChainConsensusConfig,
     OnChainExecutionConfig,
     OnChainRandomnessConfig,
-    OnChainChunkyDKGConfig,
 ) {
     // Fetch the next reconfiguration notification
     let reconfig_notification = reconfig_events
@@ -213,26 +209,12 @@ async fn extract_on_chain_configs(
         onchain_randomness_config.ok(),
     );
 
-    // Extract the chunky DKG config
-    let onchain_chunky_dkg_config: anyhow::Result<ChunkyDKGConfigMoveStruct> =
-        on_chain_configs.get();
-    if let Err(error) = &onchain_chunky_dkg_config {
-        error!(
-            LogSchema::new(LogEntry::ConsensusObserver).message(&format!(
-                "Failed to read on-chain chunky DKG config! Error: {:?}",
-                error
-            ))
-        );
-    }
-    let chunky_dkg_config = OnChainChunkyDKGConfig::from_configs(onchain_chunky_dkg_config.ok());
-
     // Return the extracted epoch state and on-chain configs
     (
         epoch_state,
         consensus_config,
         execution_config,
         onchain_randomness_config,
-        chunky_dkg_config,
     )
 }
 

--- a/consensus/src/pipeline/decryption_pipeline_builder.rs
+++ b/consensus/src/pipeline/decryption_pipeline_builder.rs
@@ -53,30 +53,15 @@ impl PipelineBuilder {
                 None,
             ));
         }
-        // If the config is None, then we are on the observer path:
-        // no local secret share config available, so receive the pre-computed
-        // decryption key via channel instead of deriving locally.
-        // Assumption: `input_txns` is free of Encrypted Transactions
-        // due to VM validation checks
+        // If the config is None, then decryption is disabled.
         let Some(secret_share_config) = maybe_secret_share_config else {
-            let _ = derived_self_key_share_tx.send(None);
-            let maybe_key = secret_shared_key_rx
-                .await
-                .map_err(|_| anyhow!("secret_shared_key_rx dropped in observer path"))?;
-            let dec_key = maybe_key.map(|key| {
-                BlockTxnDecryptionKey::new(
-                    DecKeyMetadata {
-                        epoch: key.metadata.epoch,
-                        round: key.metadata.round,
-                    },
-                    bcs::to_bytes(&key.key).expect("SecretSharedKey serialization"),
-                )
-            });
+            // Assumption: `input_txns` is free of Encrypted Transactions
+            // due to VM validation checks
             return Ok((
                 input_txns,
                 max_txns_from_block_to_execute,
                 block_gas_limit,
-                Some(dec_key),
+                Some(None),
             ));
         };
 

--- a/consensus/src/pipeline/execution_schedule_phase.rs
+++ b/consensus/src/pipeline/execution_schedule_phase.rs
@@ -64,9 +64,6 @@ impl StatelessPipeline for ExecutionSchedulePhase {
         for b in &ordered_blocks {
             if let Some(tx) = b.pipeline_tx().lock().as_mut() {
                 tx.rand_tx.take().map(|tx| tx.send(b.randomness().cloned()));
-                tx.secret_shared_key_tx
-                    .take()
-                    .map(|tx| tx.send(b.secret_shared_key().cloned()));
             }
         }
 

--- a/consensus/src/rand/secret_sharing/block_queue.rs
+++ b/consensus/src/rand/secret_sharing/block_queue.rs
@@ -70,7 +70,9 @@ impl QueueItem {
                 BlockStage::SECRET_SHARING_ADD_DECISION,
             );
             let block = &self.blocks_mut()[offset];
-            block.set_decryption_key(key);
+            if let Some(tx) = block.pipeline_tx().lock().as_mut() {
+                tx.secret_shared_key_tx.take().map(|tx| tx.send(Some(key)));
+            }
             self.pending_secret_key_rounds.remove(&round);
         }
     }


### PR DESCRIPTION
## Summary
- Reverts commit ef31b3044f which added `secret_shared_key: Option<SecretSharedKey>` as a 4th serialized field to `PipelinedBlock`
- BCS has no schema evolution — structs are flat byte sequences with no delimiters, so adding a field breaks cross-version deserialization between v1.41 and v1.42
- `#[serde(default)]` is ineffective because BCS reads fields positionally, not by name

## Test plan
- [x] `cargo check -p aptos-consensus-types` passes
- [x] `cargo check -p aptos-consensus` passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)