### PR TITLE
[consensus] Enforce sender-author binding for rand share messages

### DIFF
--- a/consensus/src/rand/rand_gen/network_messages.rs
+++ b/consensus/src/rand/rand_gen/network_messages.rs
@@ -43,18 +43,19 @@ impl<S: TShare, D: TAugmentedData> RandMessage<S, D> {
         ensure!(self.epoch() == epoch_state.epoch);
         match self {
             RandMessage::RequestShare(_) => Ok(()),
-            RandMessage::Share(share) => share.optimistic_verify(rand_config),
+            RandMessage::Share(share) => share.optimistic_verify(rand_config, &sender),
             RandMessage::AugData(aug_data) => {
                 aug_data.verify(rand_config, fast_rand_config, sender)
             },
             RandMessage::CertifiedAugData(certified_aug_data) => {
                 certified_aug_data.verify(&epoch_state.verifier)
             },
-            RandMessage::FastShare(share) => {
-                share.optimistic_verify(fast_rand_config.as_ref().ok_or_else(|| {
+            RandMessage::FastShare(share) => share.optimistic_verify(
+                fast_rand_config.as_ref().ok_or_else(|| {
                     anyhow::anyhow!("[RandMessage] rand config for fast path not found")
-                })?)
-            },
+                })?,
+                &sender,
+            ),
             _ => bail!("[RandMessage] unexpected message type"),
         }
     }
@@ -123,6 +124,203 @@ impl core::fmt::Debug for RandGenMessage {
 
 pub struct RpcRequest<S, D> {
     pub req: RandMessage<S, D>,
+    pub sender: Author,
     pub protocol: ProtocolId,
     pub response_sender: oneshot::Sender<Result<Bytes, RpcError>>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::rand::rand_gen::types::{MockAugData, MockShare, RandConfig, RandShare};
+    use aptos_consensus_types::common::Author;
+    use aptos_crypto::{bls12381, Uniform};
+    use aptos_dkg::{
+        pvss::{traits::TranscriptCore, Player, WeightedConfigBlstrs},
+        weighted_vuf::traits::WeightedVUF,
+    };
+    use aptos_types::{
+        dkg::{real_dkg::maybe_dk_from_bls_sk, DKGSessionMetadata, DKGTrait, DefaultDKG},
+        epoch_state::EpochState,
+        on_chain_config::OnChainRandomnessConfig,
+        randomness::{RandKeys, RandMetadata, WvufPP, WVUF},
+        validator_verifier::{
+            ValidatorConsensusInfo, ValidatorConsensusInfoMoveStruct, ValidatorVerifier,
+        },
+    };
+    use rand::thread_rng;
+    use std::{str::FromStr, sync::Arc};
+
+    struct TestContext {
+        authors: Vec<Author>,
+        epoch_state: Arc<EpochState>,
+        rand_config: RandConfig,
+    }
+
+    fn build_test_context(weights: Vec<u64>, my_index: usize) -> TestContext {
+        let target_epoch = 1;
+        let num_validators = weights.len();
+        let mut rng = thread_rng();
+        let authors: Vec<_> = (0..num_validators)
+            .map(|i| Author::from_str(&format!("{:x}", i)).unwrap())
+            .collect();
+        let private_keys: Vec<bls12381::PrivateKey> = (0..num_validators)
+            .map(|_| bls12381::PrivateKey::generate_for_testing())
+            .collect();
+        let public_keys: Vec<bls12381::PublicKey> =
+            private_keys.iter().map(bls12381::PublicKey::from).collect();
+        let dkg_decrypt_keys: Vec<<DefaultDKG as DKGTrait>::NewValidatorDecryptKey> = private_keys
+            .iter()
+            .map(|sk| maybe_dk_from_bls_sk(sk).unwrap())
+            .collect();
+        let consensus_infos: Vec<ValidatorConsensusInfo> = (0..num_validators)
+            .map(|idx| {
+                ValidatorConsensusInfo::new(authors[idx], public_keys[idx].clone(), weights[idx])
+            })
+            .collect();
+        let consensus_info_move_structs = consensus_infos
+            .clone()
+            .into_iter()
+            .map(ValidatorConsensusInfoMoveStruct::from)
+            .collect::<Vec<_>>();
+        let verifier = Arc::new(ValidatorVerifier::new(consensus_infos));
+        let epoch_state = Arc::new(EpochState {
+            epoch: target_epoch,
+            verifier: verifier.clone(),
+        });
+        let dkg_session_metadata = DKGSessionMetadata {
+            dealer_epoch: 0,
+            randomness_config: OnChainRandomnessConfig::default_enabled().into(),
+            dealer_validator_set: consensus_info_move_structs.clone(),
+            target_validator_set: consensus_info_move_structs,
+        };
+        let dkg_pub_params = DefaultDKG::new_public_params(&dkg_session_metadata);
+        let input_secret = <DefaultDKG as DKGTrait>::InputSecret::generate_for_testing();
+        let transcript = DefaultDKG::generate_transcript(
+            &mut rng,
+            &dkg_pub_params,
+            &input_secret,
+            0,
+            &private_keys[0],
+            &public_keys[0],
+        );
+        let (sk, pk) = DefaultDKG::decrypt_secret_share_from_transcript(
+            &dkg_pub_params,
+            &transcript,
+            my_index as u64,
+            &dkg_decrypt_keys[my_index],
+        )
+        .unwrap();
+        let pk_shares = (0..num_validators)
+            .map(|id| {
+                transcript
+                    .main
+                    .get_public_key_share(&dkg_pub_params.pvss_config.wconfig, &Player { id })
+            })
+            .collect::<Vec<_>>();
+        let vuf_pub_params = WvufPP::from(&dkg_pub_params.pvss_config.pp);
+        let aggregate_pk = transcript.main.get_dealt_public_key();
+        let (ask, apk) = WVUF::augment_key_pair(&vuf_pub_params, sk.main, pk.main, &mut rng);
+        let rand_keys = RandKeys::new(ask, apk, pk_shares, num_validators);
+        let weights_usize: Vec<usize> = weights.into_iter().map(|x| x as usize).collect();
+        let half_total_weights = weights_usize.iter().sum::<usize>() / 2;
+        let weighted_config = WeightedConfigBlstrs::new(half_total_weights, weights_usize).unwrap();
+        let rand_config = RandConfig::new(
+            authors[my_index],
+            target_epoch,
+            verifier,
+            vuf_pub_params,
+            rand_keys,
+            weighted_config,
+            aggregate_pk,
+            false,
+        );
+
+        TestContext {
+            authors,
+            epoch_state,
+            rand_config,
+        }
+    }
+
+    #[test]
+    fn test_share_verify_rejects_mismatched_sender() {
+        let ctx = build_test_context(vec![100, 100, 100], 0);
+        let victim = ctx.authors[0];
+        let attacker = ctx.authors[2];
+        let metadata = RandMetadata {
+            epoch: ctx.epoch_state.epoch,
+            round: 1,
+        };
+
+        // Create a share claiming to be from victim
+        let forged_share = RandShare::<MockShare>::new(victim, metadata, MockShare);
+        let msg = RandMessage::<MockShare, MockAugData>::Share(forged_share);
+
+        // Verify with attacker as sender should fail
+        let result = msg.verify(&ctx.epoch_state, &ctx.rand_config, &None, attacker);
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("does not match sender"),);
+
+        // Verify with victim as sender should succeed
+        let result = msg.verify(&ctx.epoch_state, &ctx.rand_config, &None, victim);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_fast_share_verify_rejects_mismatched_sender() {
+        let ctx = build_test_context(vec![100, 100, 100], 0);
+        let victim = ctx.authors[0];
+        let attacker = ctx.authors[2];
+        let metadata = RandMetadata {
+            epoch: ctx.epoch_state.epoch,
+            round: 1,
+        };
+
+        // Create a fast share claiming to be from victim
+        let forged_share = RandShare::<MockShare>::new(victim, metadata, MockShare);
+        let forged_fast_share = super::super::types::FastShare::new(forged_share);
+        let msg = RandMessage::<MockShare, MockAugData>::FastShare(forged_fast_share);
+
+        // Verify with attacker as sender should fail
+        let result = msg.verify(
+            &ctx.epoch_state,
+            &ctx.rand_config,
+            &Some(ctx.rand_config.clone()),
+            attacker,
+        );
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("does not match sender"),);
+
+        // Verify with victim as sender should succeed
+        let result = msg.verify(
+            &ctx.epoch_state,
+            &ctx.rand_config,
+            &Some(ctx.rand_config.clone()),
+            victim,
+        );
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_share_verify_accepts_matching_sender() {
+        let ctx = build_test_context(vec![100, 100, 100], 0);
+        let author = ctx.authors[0];
+        let metadata = RandMetadata {
+            epoch: ctx.epoch_state.epoch,
+            round: 1,
+        };
+
+        let share = RandShare::<MockShare>::new(author, metadata, MockShare);
+        let msg = RandMessage::<MockShare, MockAugData>::Share(share);
+
+        let result = msg.verify(&ctx.epoch_state, &ctx.rand_config, &None, author);
+        assert!(result.is_ok());
+    }
 }

--- a/consensus/src/rand/rand_gen/rand_manager.rs
+++ b/consensus/src/rand/rand_gen/rand_manager.rs
@@ -292,6 +292,7 @@ impl<S: TShare, D: TAugmentedData> RandManager<S, D> {
                             {
                                 let _ = tx.unbounded_send(RpcRequest {
                                     req: msg,
+                                    sender: rand_gen_msg.sender,
                                     protocol: rand_gen_msg.protocol,
                                     response_sender: rand_gen_msg.response_sender,
                                 });
@@ -445,6 +446,7 @@ impl<S: TShare, D: TAugmentedData> RandManager<S, D> {
                 Some(request) = verified_msg_rx.next() => {
                     let RpcRequest {
                         req: rand_gen_msg,
+                        sender,
                         protocol,
                         response_sender,
                     } = request;
@@ -473,7 +475,13 @@ impl<S: TShare, D: TAugmentedData> RandManager<S, D> {
                                 .round(share.metadata().round)
                                 .remote_peer(*share.author()));
 
-                            if let Err(e) = self.rand_store.lock().add_share(share, PathType::Slow) {
+                            if share.author() != &sender {
+                                warn!(
+                                    "[RandManager] Share author {:?} does not match sender {:?}, dropping",
+                                    share.author(),
+                                    sender,
+                                );
+                            } else if let Err(e) = self.rand_store.lock().add_share(share, PathType::Slow) {
                                 warn!("[RandManager] Failed to add share: {}", e);
                             }
                         }
@@ -484,7 +492,13 @@ impl<S: TShare, D: TAugmentedData> RandManager<S, D> {
                                 .round(share.metadata().round)
                                 .remote_peer(*share.share.author()));
 
-                            if let Err(e) = self.rand_store.lock().add_share(share.rand_share(), PathType::Fast) {
+                            if share.author() != &sender {
+                                warn!(
+                                    "[RandManager] FastShare author {:?} does not match sender {:?}, dropping",
+                                    share.author(),
+                                    sender,
+                                );
+                            } else if let Err(e) = self.rand_store.lock().add_share(share.rand_share(), PathType::Fast) {
                                 warn!("[RandManager] Failed to add share for fast path: {}", e);
                             }
                         }

--- a/consensus/src/rand/rand_gen/reliable_broadcast_state.rs
+++ b/consensus/src/rand/rand_gen/reliable_broadcast_state.rs
@@ -129,14 +129,13 @@ impl<S: TShare, D: TAugmentedData> BroadcastStatus<RandMessage<S, D>, RandMessag
     type Response = RandShare<S>;
 
     fn add(&self, peer: Author, share: Self::Response) -> anyhow::Result<Option<()>> {
-        ensure!(share.author() == &peer, "Author does not match");
         ensure!(
             share.metadata() == &self.rand_metadata,
             "Metadata does not match: local {:?}, received {:?}",
             self.rand_metadata,
             share.metadata()
         );
-        share.optimistic_verify(&self.rand_config)?;
+        share.optimistic_verify(&self.rand_config, &peer)?;
         info!(LogSchema::new(LogEvent::ReceiveReactiveRandShare)
             .epoch(share.epoch())
             .round(share.metadata().round)

--- a/consensus/src/rand/rand_gen/types.rs
+++ b/consensus/src/rand/rand_gen/types.rs
@@ -460,7 +460,17 @@ impl<S: TShare> RandShare<S> {
         self.share.verify(rand_config, &self.metadata, &self.author)
     }
 
-    pub fn optimistic_verify(&self, rand_config: &RandConfig) -> anyhow::Result<()> {
+    pub fn optimistic_verify(
+        &self,
+        rand_config: &RandConfig,
+        sender: &Author,
+    ) -> anyhow::Result<()> {
+        ensure!(
+            &self.author == sender,
+            "[RandShare] Share author {:?} does not match sender {:?}",
+            self.author,
+            sender,
+        );
         if rand_config.should_verify_optimistically(&self.author) {
             // Still perform cheap structural checks (author exists, APK certified)
             // to prevent invalid shares from reaching aggregation where they would
@@ -538,8 +548,12 @@ impl<S: TShare> FastShare<S> {
         self.share.verify(rand_config)
     }
 
-    pub fn optimistic_verify(&self, rand_config: &RandConfig) -> anyhow::Result<()> {
-        self.share.optimistic_verify(rand_config)
+    pub fn optimistic_verify(
+        &self,
+        rand_config: &RandConfig,
+        sender: &Author,
+    ) -> anyhow::Result<()> {
+        self.share.optimistic_verify(rand_config, sender)
     }
 
     pub fn share_id(&self) -> ShareId {
@@ -1068,7 +1082,9 @@ mod tests {
         let share = Share::generate(&ctx.rand_configs[0], metadata);
 
         // optimistic_verify should succeed (deferred verification)
-        assert!(share.optimistic_verify(&ctx.rand_configs[0]).is_ok());
+        assert!(share
+            .optimistic_verify(&ctx.rand_configs[0], share.author())
+            .is_ok());
     }
 
     #[test]
@@ -1085,7 +1101,9 @@ mod tests {
         let share = RandShare::new(bad_author, metadata, wrong_share.share().clone());
 
         // optimistic_verify should fail (falls through to individual verification)
-        assert!(share.optimistic_verify(&ctx.rand_configs[0]).is_err());
+        assert!(share
+            .optimistic_verify(&ctx.rand_configs[0], &bad_author)
+            .is_err());
     }
 
     #[test]
@@ -1098,7 +1116,9 @@ mod tests {
         let share = RandShare::new(ctx.authors[0], metadata, wrong_share.share().clone());
 
         // With optimization disabled, every share is verified individually
-        assert!(share.optimistic_verify(&ctx.rand_configs[0]).is_err());
+        assert!(share
+            .optimistic_verify(&ctx.rand_configs[0], share.author())
+            .is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- **Fixes a vulnerability** where a malicious validator could forge `RandGenMessage::Share`/`FastShare` with a victim's author, bypassing optimistic verification and overwriting the victim's self-share in the `ShareAggregator`
- Adds `ensure!(author == sender)` checks inside `RandShare::optimistic_verify` and `FastShare::optimistic_verify`, enforcing the invariant at the share level across all call sites (proactive and reactive paths)
- Propagates the authenticated sender through `RpcRequest` and adds defense-in-depth checks before `add_share` in `RandManager`
- Adds unit tests verifying that forged shares with mismatched sender/author are rejected

## Test plan
- [x] `cargo test -p aptos-consensus -- rand_gen::network_messages::tests` — 3 new tests pass
- [x] `cargo test -p aptos-consensus -- rand_gen::rand_store::tests` — 8 existing tests pass (no regressions)
- [x] `cargo test -p aptos-consensus -- rand_gen::types::tests::test_optimistic` — existing optimistic_verify tests pass
- [ ] CI land checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches consensus randomness message verification/ingestion and can cause previously-accepted `Share`/`FastShare` messages to be dropped if sender identity plumbing is incorrect, impacting randomness aggregation/liveness. The change is otherwise a narrow validation hardening with added tests.
> 
> **Overview**
> Fixes a spoofing hole in rand-share handling by **binding the share’s embedded `author` to the authenticated network `sender`**.
> 
> `RandShare::optimistic_verify` (and `FastShare` via delegation) now requires a matching sender, `RandMessage::verify` passes the sender through for `Share`/`FastShare`, and `RpcRequest`/`RandManager` propagate and re-check the sender before calling `add_share` (proactive path) and during reliable-broadcast aggregation (reactive path).
> 
> Adds targeted unit tests to ensure forged shares with mismatched `sender`/`author` are rejected, and updates existing optimistic-verification tests to use the new API.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1d3c8d74e76ab61e430575af1b7407f0e5a67815. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->