### PR TITLE
[compiler-v2] Allow receiver functions on fully concrete struct instantiations

### DIFF
--- a/third_party/move/move-compiler-v2/tests/checking/receiver/concrete_receiver.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/receiver/concrete_receiver.exp
@@ -1,0 +1,144 @@
+// -- Model dump before first bytecode pipeline
+module 0x42::m {
+    struct G<T,R> {
+        x: T,
+        y: R,
+    }
+    struct Inner {
+        val: u64,
+    }
+    private fun consume(self: G<u64, bool>): u64 {
+        select m::G.x<G<u64, bool>>(self)
+    }
+    private fun get_inner_val(self: &G<Inner, u64>): u64 {
+        select m::Inner.val<Inner>(select m::G.x<&G<Inner, u64>>(self))
+    }
+    private fun get_x(self: &G<u64, bool>): u64 {
+        select m::G.x<&G<u64, bool>>(self)
+    }
+    private fun get_y(self: &G<u64, bool>): bool {
+        select m::G.y<&G<u64, bool>>(self)
+    }
+    private fun set_x(self: &mut G<u64, bool>,v: u64) {
+        select m::G.x<&mut G<u64, bool>>(self) = v
+    }
+    private fun sum_first(self: &G<vector<u64>, bool>): u64 {
+        Deref(vector::borrow<u64>(Borrow(Immutable)(select m::G.x<&G<vector<u64>, bool>>(self)), 0))
+    }
+    private fun test_basic_call() {
+        {
+          let g: G<u64, bool> = pack m::G<u64, bool>(42, true);
+          if Eq<u64>(m::get_x(Borrow(Immutable)(g)), 42) {
+            Tuple()
+          } else {
+            Abort(0)
+          };
+          if Eq<bool>(m::get_y(Borrow(Immutable)(g)), true) {
+            Tuple()
+          } else {
+            Abort(1)
+          };
+          Tuple()
+        }
+    }
+    private fun test_consume_call() {
+        {
+          let g: G<u64, bool> = pack m::G<u64, bool>(42, true);
+          if Eq<u64>(m::consume(g), 42) {
+            Tuple()
+          } else {
+            Abort(0)
+          };
+          Tuple()
+        }
+    }
+    private fun test_mut_ref_call() {
+        {
+          let g: G<u64, bool> = pack m::G<u64, bool>(42, true);
+          m::set_x(Borrow(Mutable)(g), 99);
+          if Eq<u64>(m::get_x(Borrow(Immutable)(g)), 99) {
+            Tuple()
+          } else {
+            Abort(0)
+          };
+          Tuple()
+        }
+    }
+    private fun test_nested_type_arg() {
+        {
+          let g: G<Inner, u64> = pack m::G<Inner, u64>(pack m::Inner(10), 20);
+          if Eq<u64>(m::get_inner_val(Borrow(Immutable)(g)), 10) {
+            Tuple()
+          } else {
+            Abort(0)
+          };
+          Tuple()
+        }
+    }
+    private fun test_ref_call() {
+        {
+          let g: G<u64, bool> = pack m::G<u64, bool>(42, true);
+          {
+            let r: &G<u64, bool> = Borrow(Immutable)(g);
+            if Eq<u64>(m::get_x(r), 42) {
+              Tuple()
+            } else {
+              Abort(0)
+            };
+            Tuple()
+          }
+        }
+    }
+} // end 0x42::m
+
+// -- Sourcified model before first bytecode pipeline
+module 0x42::m {
+    struct G<T, R> has copy, drop {
+        x: T,
+        y: R,
+    }
+    struct Inner has copy, drop {
+        val: u64,
+    }
+    fun consume(self: G<u64, bool>): u64 {
+        self.x
+    }
+    fun get_inner_val(self: &G<Inner, u64>): u64 {
+        self.x.val
+    }
+    fun get_x(self: &G<u64, bool>): u64 {
+        self.x
+    }
+    fun get_y(self: &G<u64, bool>): bool {
+        self.y
+    }
+    fun set_x(self: &mut G<u64, bool>, v: u64) {
+        self.x = v
+    }
+    fun sum_first(self: &G<vector<u64>, bool>): u64 {
+        *0x1::vector::borrow<u64>(&self.x, 0)
+    }
+    fun test_basic_call() {
+        let g = G<u64, bool>{x: 42, y: true};
+        if (get_x(&g) == 42) () else abort 0;
+        if (get_y(&g) == true) () else abort 1;
+    }
+    fun test_consume_call() {
+        let g = G<u64, bool>{x: 42, y: true};
+        if (consume(g) == 42) () else abort 0;
+    }
+    fun test_mut_ref_call() {
+        let g = G<u64, bool>{x: 42, y: true};
+        set_x(&mut g, 99);
+        if (get_x(&g) == 99) () else abort 0;
+    }
+    fun test_nested_type_arg() {
+        let g = G<Inner, u64>{x: Inner{val: 10}, y: 20};
+        if (get_inner_val(&g) == 10) () else abort 0;
+    }
+    fun test_ref_call() {
+        let g = G<u64, bool>{x: 42, y: true};
+        let r = &g;
+        if (get_x(r) == 42) () else abort 0;
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/checking/receiver/concrete_receiver.move
+++ b/third_party/move/move-compiler-v2/tests/checking/receiver/concrete_receiver.move
@@ -1,0 +1,45 @@
+module 0x42::m {
+    struct G<T, R> has drop, copy { x: T, y: R }
+
+    // === Positive: basic concrete receiver ===
+    fun get_x(self: &G<u64, bool>): u64 { self.x }
+    fun get_y(self: &G<u64, bool>): bool { self.y }
+    fun consume(self: G<u64, bool>): u64 { self.x }
+    fun set_x(self: &mut G<u64, bool>, v: u64) { self.x = v }
+
+    // === Positive: concrete with nested types ===
+    struct Inner has drop, copy { val: u64 }
+    fun get_inner_val(self: &G<Inner, u64>): u64 { self.x.val }
+
+    // === Positive: concrete with vector type arg ===
+    fun sum_first(self: &G<vector<u64>, bool>): u64 { *&self.x[0] }
+
+    // === Positive: call site tests ===
+    fun test_basic_call() {
+        let g = G<u64, bool> { x: 42, y: true };
+        assert!(g.get_x() == 42, 0);
+        assert!(g.get_y() == true, 1);
+    }
+
+    fun test_ref_call() {
+        let g = G<u64, bool> { x: 42, y: true };
+        let r = &g;
+        assert!(r.get_x() == 42, 0);
+    }
+
+    fun test_mut_ref_call() {
+        let g = G<u64, bool> { x: 42, y: true };
+        g.set_x(99);
+        assert!(g.get_x() == 99, 0);
+    }
+
+    fun test_consume_call() {
+        let g = G<u64, bool> { x: 42, y: true };
+        assert!(g.consume() == 42, 0);
+    }
+
+    fun test_nested_type_arg() {
+        let g = G<Inner, u64> { x: Inner { val: 10 }, y: 20 };
+        assert!(g.get_inner_val() == 10, 0);
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/checking/receiver/concrete_receiver_chain.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/receiver/concrete_receiver_chain.exp
@@ -1,0 +1,67 @@
+// -- Model dump before first bytecode pipeline
+module 0x42::m {
+    struct Pair {
+        a: u64,
+        b: u64,
+    }
+    struct Wrapper<T> {
+        inner: T,
+    }
+    private fun get_pair(self: &Wrapper<Pair>): Pair {
+        select m::Wrapper.inner<&Wrapper<Pair>>(self)
+    }
+    private fun sum(self: &Pair): u64 {
+        Add<u64>(select m::Pair.a<&Pair>(self), select m::Pair.b<&Pair>(self))
+    }
+    private fun test_chain() {
+        {
+          let w: Wrapper<Pair> = pack m::Wrapper<Pair>(pack m::Pair(3, 4));
+          if Eq<u64>(m::sum(Borrow(Immutable)(m::get_pair(Borrow(Immutable)(w)))), 7) {
+            Tuple()
+          } else {
+            Abort(0)
+          };
+          Tuple()
+        }
+    }
+    private fun test_chain_vector() {
+        {
+          let w: Wrapper<Pair> = pack m::Wrapper<Pair>(pack m::Pair(10, 20));
+          {
+            let v: vector<Wrapper<Pair>> = Vector<Wrapper<Pair>>(w);
+            if Eq<u64>(m::sum(Borrow(Immutable)(m::get_pair(vector::borrow<Wrapper<Pair>>(Borrow(Immutable)(v), 0)))), 30) {
+              Tuple()
+            } else {
+              Abort(0)
+            };
+            Tuple()
+          }
+        }
+    }
+} // end 0x42::m
+
+// -- Sourcified model before first bytecode pipeline
+module 0x42::m {
+    struct Pair has copy, drop {
+        a: u64,
+        b: u64,
+    }
+    struct Wrapper<T> has copy, drop {
+        inner: T,
+    }
+    fun get_pair(self: &Wrapper<Pair>): Pair {
+        self.inner
+    }
+    fun sum(self: &Pair): u64 {
+        self.a + self.b
+    }
+    fun test_chain() {
+        let w = Wrapper<Pair>{inner: Pair{a: 3, b: 4}};
+        if (sum(&get_pair(&w)) == 7) () else abort 0;
+    }
+    fun test_chain_vector() {
+        let w = Wrapper<Pair>{inner: Pair{a: 10, b: 20}};
+        let v = vector[w];
+        if (sum(&get_pair(0x1::vector::borrow<Wrapper<Pair>>(&v, 0))) == 30) () else abort 0;
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/checking/receiver/concrete_receiver_chain.move
+++ b/third_party/move/move-compiler-v2/tests/checking/receiver/concrete_receiver_chain.move
@@ -1,0 +1,24 @@
+module 0x42::m {
+    struct Pair has drop, copy { a: u64, b: u64 }
+    struct Wrapper<T> has drop, copy { inner: T }
+
+    // Concrete receiver on Wrapper<Pair>
+    fun get_pair(self: &Wrapper<Pair>): Pair { self.inner }
+
+    // Regular receiver on Pair (non-generic struct)
+    fun sum(self: &Pair): u64 { self.a + self.b }
+
+    // === Chaining: concrete receiver result feeds into another receiver ===
+    fun test_chain() {
+        let w = Wrapper<Pair> { inner: Pair { a: 3, b: 4 } };
+        // Chain: w.get_pair() returns Pair, then .sum() on Pair
+        assert!(w.get_pair().sum() == 7, 0);
+    }
+
+    // === Chaining through vector index ===
+    fun test_chain_vector() {
+        let w = Wrapper<Pair> { inner: Pair { a: 10, b: 20 } };
+        let v = vector[w];
+        assert!(v[0].get_pair().sum() == 30, 0);
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/checking/receiver/concrete_receiver_cross_module.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/receiver/concrete_receiver_cross_module.exp
@@ -1,0 +1,46 @@
+// -- Model dump before first bytecode pipeline
+module 0x42::definer {
+    struct Box<T> {
+        val: T,
+    }
+    public fun new_u64(val: u64): Box<u64> {
+        pack definer::Box<u64>(val)
+    }
+    public fun unbox_u64(self: Box<u64>): u64 {
+        select definer::Box.val<Box<u64>>(self)
+    }
+} // end 0x42::definer
+module 0x42::caller {
+    use 0x42::definer; // resolved as: 0x42::definer
+    private fun test_cross_module_call() {
+        {
+          let b: definer::Box<u64> = definer::new_u64(42);
+          if Eq<u64>(definer::unbox_u64(b), 42) {
+            Tuple()
+          } else {
+            Abort(0)
+          };
+          Tuple()
+        }
+    }
+} // end 0x42::caller
+
+// -- Sourcified model before first bytecode pipeline
+module 0x42::definer {
+    struct Box<T> has copy, drop, store {
+        val: T,
+    }
+    public fun new_u64(val: u64): Box<u64> {
+        Box<u64>{val: val}
+    }
+    public fun unbox_u64(self: Box<u64>): u64 {
+        self.val
+    }
+}
+module 0x42::caller {
+    use 0x42::definer;
+    fun test_cross_module_call() {
+        let b = definer::new_u64(42);
+        if (definer::unbox_u64(b) == 42) () else abort 0;
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/checking/receiver/concrete_receiver_cross_module.move
+++ b/third_party/move/move-compiler-v2/tests/checking/receiver/concrete_receiver_cross_module.move
@@ -1,0 +1,18 @@
+module 0x42::definer {
+    struct Box<T> has drop, copy, store { val: T }
+
+    // OK: concrete receiver in the defining module
+    public fun unbox_u64(self: Box<u64>): u64 { self.val }
+
+    public fun new_u64(val: u64): Box<u64> { Box { val } }
+}
+
+module 0x42::caller {
+    use 0x42::definer;
+
+    // Cross-module CALL (not definition) — should work
+    fun test_cross_module_call() {
+        let b = definer::new_u64(42);
+        assert!(b.unbox_u64() == 42, 0);
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/checking/receiver/concrete_receiver_cross_module_errors.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/receiver/concrete_receiver_cross_module_errors.exp
@@ -1,0 +1,13 @@
+
+Diagnostics:
+warning: parameter name `self` indicates a receiver function but the type `0x42::types::Box<u64>` is declared outside of this module and new receiver functions cannot be added. Consider using a different name.
+  ┌─ tests/checking/receiver/concrete_receiver_cross_module_errors.move:9:9
+  │
+9 │     fun unbox(self: Box<u64>): u64 { abort 0 }
+  │         ^^^^^
+
+error: undeclared receiver function `unbox` for type `types::Box<u64>`
+   ┌─ tests/checking/receiver/concrete_receiver_cross_module_errors.move:14:9
+   │
+14 │         b.unbox();
+   │         ^^^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/checking/receiver/concrete_receiver_cross_module_errors.move
+++ b/third_party/move/move-compiler-v2/tests/checking/receiver/concrete_receiver_cross_module_errors.move
@@ -1,0 +1,16 @@
+module 0x42::types {
+    struct Box<T> has drop, copy, store { val: T }
+}
+
+module 0x42::impl_mod {
+    use 0x42::types::Box;
+
+    // Warning: Box is defined in 0x42::types, not here — not registered as receiver
+    fun unbox(self: Box<u64>): u64 { abort 0 }
+
+    // Error: unbox is not a receiver on Box, so dot-call fails
+    fun test_unbox_as_receiver() {
+        let b = Box<u64> { val: 42 };
+        b.unbox();
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/checking/receiver/concrete_receiver_errors.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/receiver/concrete_receiver_errors.exp
@@ -1,0 +1,25 @@
+
+Diagnostics:
+error: cannot pass `G<bool, bool>` to a function which expects argument of type `G<u64, bool>`
+   ┌─ tests/checking/receiver/concrete_receiver_errors.move:10:9
+   │
+10 │         g.process();
+   │         ^
+
+error: cannot pass `G<u64, u64>` to a function which expects argument of type `G<u64, bool>`
+   ┌─ tests/checking/receiver/concrete_receiver_errors.move:15:9
+   │
+15 │         g.process();
+   │         ^
+
+error: cannot pass `G<bool, u64>` to a function which expects argument of type `G<u64, bool>`
+   ┌─ tests/checking/receiver/concrete_receiver_errors.move:20:9
+   │
+20 │         g.process();
+   │         ^
+
+warning: parameter name `self` indicates a receiver function but the type `0x42::m::G<u64, T>` must use either all type parameters or all concrete types in the instantiation. Consider using a different name.
+   ┌─ tests/checking/receiver/concrete_receiver_errors.move:24:9
+   │
+24 │     fun partial_bad<T>(self: G<u64, T>) {}
+   │         ^^^^^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/checking/receiver/concrete_receiver_errors.move
+++ b/third_party/move/move-compiler-v2/tests/checking/receiver/concrete_receiver_errors.move
@@ -1,0 +1,25 @@
+module 0x42::m {
+    struct G<T, R> has drop, copy { x: T, y: R }
+
+    // Concrete receiver defined for G<u64, bool>
+    fun process(self: G<u64, bool>) {}
+
+    // === Negative: type mismatch at call site ===
+    fun test_wrong_first_arg() {
+        let g = G<bool, bool> { x: true, y: false };
+        g.process();
+    }
+
+    fun test_wrong_second_arg() {
+        let g = G<u64, u64> { x: 1, y: 2 };
+        g.process();
+    }
+
+    fun test_both_wrong() {
+        let g = G<bool, u64> { x: true, y: 1 };
+        g.process();
+    }
+
+    // === Negative: partial instantiation still rejected at declaration ===
+    fun partial_bad<T>(self: G<u64, T>) {}
+}

--- a/third_party/move/move-compiler-v2/tests/checking/receiver/decl_errors.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/receiver/decl_errors.exp
@@ -18,7 +18,7 @@ warning: parameter name `self` indicates a receiver function but the type `vecto
 17 │     fun receiver_for_external_vector(self: vector<u64>) {}
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: parameter name `self` indicates a receiver function but the type `0x42::m::G<u64, T>` must only use type parameters but instead uses `u64`. Consider using a different name.
+warning: parameter name `self` indicates a receiver function but the type `0x42::m::G<u64, T>` must use either all type parameters or all concrete types in the instantiation. Consider using a different name.
    ┌─ tests/checking/receiver/decl_errors.move:20:9
    │
 20 │     fun receiver_partial_instantiated<T>(self: G<u64, T>) {}
@@ -30,16 +30,22 @@ warning: parameter name `self` indicates a receiver function but the type `0x42:
 23 │     fun receiver_non_linear_instantiated<T>(self: G<T, T>) {}
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: parameter name `self` indicates a receiver function but the type `signer` is associated with the standard signer module and new receiver functions cannot be added. Consider using a different name.
+warning: parameter name `self` indicates a receiver function but the type `0x42::m::G<vector<T>, T>` must only use type parameters but instead uses `vector<T>`. Consider using a different name.
    ┌─ tests/checking/receiver/decl_errors.move:26:9
    │
-26 │     fun receiver_for_signer(self: &signer): address { abort 0 }
-   │         ^^^^^^^^^^^^^^^^^^^
+26 │     fun receiver_nested_generic<T>(self: G<vector<T>, T>) {}
+   │         ^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: parameter name `self` indicates a receiver function but the type `signer` is associated with the standard signer module and new receiver functions cannot be added. Consider using a different name.
    ┌─ tests/checking/receiver/decl_errors.move:29:9
    │
-29 │     fun address_of(self: &signer): address { abort 0 }
+29 │     fun receiver_for_signer(self: &signer): address { abort 0 }
+   │         ^^^^^^^^^^^^^^^^^^^
+
+warning: parameter name `self` indicates a receiver function but the type `signer` is associated with the standard signer module and new receiver functions cannot be added. Consider using a different name.
+   ┌─ tests/checking/receiver/decl_errors.move:32:9
+   │
+32 │     fun address_of(self: &signer): address { abort 0 }
    │         ^^^^^^^^^^
 
 // -- Model dump before first bytecode pipeline
@@ -74,6 +80,9 @@ module 0x42::m {
     }
     private fun receiver_for_signer(self: &signer): address {
         Abort(0)
+    }
+    private fun receiver_nested_generic<T>(self: G<vector<T>, T>) {
+        Tuple()
     }
     private fun receiver_non_linear_instantiated<T>(self: G<T, T>) {
         Tuple()
@@ -111,6 +120,8 @@ module 0x42::m {
     }
     fun receiver_for_signer(self: &signer): address {
         abort 0
+    }
+    fun receiver_nested_generic<T>(self: G<vector<T>, T>) {
     }
     fun receiver_non_linear_instantiated<T>(self: G<T, T>) {
     }

--- a/third_party/move/move-compiler-v2/tests/checking/receiver/decl_errors.move
+++ b/third_party/move/move-compiler-v2/tests/checking/receiver/decl_errors.move
@@ -22,6 +22,9 @@ module 0x42::m {
     // Error
     fun receiver_non_linear_instantiated<T>(self: G<T, T>) {}
 
+    // Error: nested generic is still open, not a plain type parameter
+    fun receiver_nested_generic<T>(self: G<vector<T>, T>) {}
+
     // Error: external module cannot add receiver functions on signer
     fun receiver_for_signer(self: &signer): address { abort 0 }
 

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/concrete_receiver.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/concrete_receiver.exp
@@ -1,0 +1,8 @@
+processed 7 tasks
+task 0 lines 1-70:  publish [module 0x42::concrete_test {]
+task 1 lines 72-72:  run --verbose -- 0x42::concrete_test::test_basic
+task 2 lines 74-74:  run --verbose -- 0x42::concrete_test::test_mut_receiver
+task 3 lines 76-76:  run --verbose -- 0x42::concrete_test::test_consume_receiver
+task 4 lines 78-78:  run --verbose -- 0x42::concrete_test::test_chain
+task 5 lines 80-80:  run --verbose -- 0x42::concrete_test::test_vector_index
+task 6 lines 82-82:  run --verbose -- 0x42::concrete_test::test_mut_through_vector

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/concrete_receiver.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/concrete_receiver.move
@@ -1,0 +1,82 @@
+//# publish
+module 0x42::concrete_test {
+    struct Pair<T, R> has drop, copy, store, key {
+        first: T,
+        second: R,
+    }
+
+    // Concrete receiver: only works for Pair<u64, bool>
+    fun describe(self: &Pair<u64, bool>): u64 {
+        if (self.second) { self.first } else { 0 }
+    }
+
+    fun flip(self: &mut Pair<u64, bool>) {
+        self.second = !self.second;
+    }
+
+    fun into_first(self: Pair<u64, bool>): u64 {
+        self.first
+    }
+
+    // Chain test helper — generic receiver on a different struct
+    struct Wrapper<T> has drop, copy {
+        inner: T,
+    }
+
+    fun unwrap<T: copy + drop>(self: Wrapper<T>): T {
+        self.inner
+    }
+
+    // === Test functions ===
+
+    fun test_basic() {
+        let p = Pair<u64, bool> { first: 42, second: true };
+        assert!(p.describe() == 42, 0);
+    }
+
+    fun test_mut_receiver() {
+        let p = Pair<u64, bool> { first: 42, second: true };
+        assert!(p.describe() == 42, 0);
+        p.flip();
+        assert!(p.describe() == 0, 1);
+    }
+
+    fun test_consume_receiver() {
+        let p = Pair<u64, bool> { first: 99, second: true };
+        assert!(p.into_first() == 99, 0);
+    }
+
+    fun test_chain() {
+        let p = Pair<u64, bool> { first: 7, second: true };
+        let w = Wrapper { inner: p };
+        // Chain: unwrap (generic) then describe (concrete)
+        assert!(w.unwrap().describe() == 7, 0);
+    }
+
+    fun test_vector_index() {
+        let p1 = Pair<u64, bool> { first: 10, second: true };
+        let p2 = Pair<u64, bool> { first: 20, second: false };
+        let v = vector[p1, p2];
+        assert!(v[0].describe() == 10, 0);
+        assert!(v[1].describe() == 0, 1);  // second is false → returns 0
+    }
+
+    fun test_mut_through_vector() {
+        let p = Pair<u64, bool> { first: 5, second: false };
+        let v = vector[p];
+        v[0].flip();
+        assert!(v[0].describe() == 5, 0);
+    }
+}
+
+//# run --verbose -- 0x42::concrete_test::test_basic
+
+//# run --verbose -- 0x42::concrete_test::test_mut_receiver
+
+//# run --verbose -- 0x42::concrete_test::test_consume_receiver
+
+//# run --verbose -- 0x42::concrete_test::test_chain
+
+//# run --verbose -- 0x42::concrete_test::test_vector_index
+
+//# run --verbose -- 0x42::concrete_test::test_mut_through_vector

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/round-trip/concrete_receiver.decompiled
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/round-trip/concrete_receiver.decompiled
@@ -1,0 +1,76 @@
+//**** Cross-compiled for `move` syntax from `tests/no-v1-comparison/concrete_receiver.move`
+
+//# publish
+module 0x42::concrete_test {
+    struct Pair<T0, T1> has copy, drop, store, key {
+        first: T0,
+        second: T1,
+    }
+    struct Wrapper<T0> has copy, drop {
+        inner: T0,
+    }
+    fun describe(p0: &Pair<u64, bool>): u64 {
+        if (*&p0.second) return *&p0.first;
+        0
+    }
+    fun flip(p0: &mut Pair<u64, bool>) {
+        let _v0 = !*&p0.second;
+        let _v1 = &mut p0.second;
+        *_v1 = _v0;
+    }
+    fun into_first(p0: Pair<u64, bool>): u64 {
+        *&(&p0).first
+    }
+    fun test_basic() {
+        let _v0 = Pair<u64, bool>{first: 42, second: true};
+        assert!(describe(&_v0) == 42, 0);
+    }
+    fun test_chain() {
+        let _v0 = unwrap<Pair<u64, bool>>(Wrapper<Pair<u64, bool>>{inner: Pair<u64, bool>{first: 7, second: true}});
+        assert!(describe(&_v0) == 7, 0);
+    }
+    fun unwrap<T0: copy + drop>(p0: Wrapper<T0>): T0 {
+        *&(&p0).inner
+    }
+    fun test_consume_receiver() {
+        assert!(into_first(Pair<u64, bool>{first: 99, second: true}) == 99, 0);
+    }
+    fun test_mut_receiver() {
+        let _v0 = Pair<u64, bool>{first: 42, second: true};
+        assert!(describe(&_v0) == 42, 0);
+        flip(&mut _v0);
+        assert!(describe(&_v0) == 0, 1);
+    }
+    fun test_mut_through_vector() {
+        let _v0 = Pair<u64, bool>{first: 5, second: false};
+        let _v1 = 0x1::vector::empty<Pair<u64, bool>>();
+        0x1::vector::push_back<Pair<u64, bool>>(&mut _v1, _v0);
+        let _v2 = _v1;
+        flip(0x1::vector::borrow_mut<Pair<u64, bool>>(&mut _v2, 0));
+        assert!(describe(0x1::vector::borrow<Pair<u64, bool>>(&_v2, 0)) == 5, 0);
+    }
+    fun test_vector_index() {
+        let _v0 = Pair<u64, bool>{first: 10, second: true};
+        let _v1 = Pair<u64, bool>{first: 20, second: false};
+        let _v2 = 0x1::vector::empty<Pair<u64, bool>>();
+        let _v3 = &mut _v2;
+        0x1::vector::push_back<Pair<u64, bool>>(_v3, _v0);
+        0x1::vector::push_back<Pair<u64, bool>>(_v3, _v1);
+        let _v4 = _v2;
+        assert!(describe(0x1::vector::borrow<Pair<u64, bool>>(&_v4, 0)) == 10, 0);
+        assert!(describe(0x1::vector::borrow<Pair<u64, bool>>(&_v4, 1)) == 0, 1);
+    }
+}
+
+
+//# run --verbose -- 0x42::concrete_test::test_basic
+
+//# run --verbose -- 0x42::concrete_test::test_mut_receiver
+
+//# run --verbose -- 0x42::concrete_test::test_consume_receiver
+
+//# run --verbose -- 0x42::concrete_test::test_chain
+
+//# run --verbose -- 0x42::concrete_test::test_vector_index
+
+//# run --verbose -- 0x42::concrete_test::test_mut_through_vector

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/round-trip/concrete_receiver.decompiled.baseline.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/round-trip/concrete_receiver.decompiled.baseline.exp
@@ -1,0 +1,8 @@
+processed 7 tasks
+task 0 lines 3-63:  publish [module 0x42::concrete_test {]
+task 1 lines 66-66:  run --verbose -- 0x42::concrete_test::test_basic
+task 2 lines 68-68:  run --verbose -- 0x42::concrete_test::test_mut_receiver
+task 3 lines 70-70:  run --verbose -- 0x42::concrete_test::test_consume_receiver
+task 4 lines 72-72:  run --verbose -- 0x42::concrete_test::test_chain
+task 5 lines 74-74:  run --verbose -- 0x42::concrete_test::test_vector_index
+task 6 lines 76-76:  run --verbose -- 0x42::concrete_test::test_mut_through_vector

--- a/third_party/move/move-model/src/builder/model_builder.rs
+++ b/third_party/move/move-model/src/builder/model_builder.rs
@@ -465,23 +465,34 @@ impl<'env> ModelBuilder<'env> {
                     )
                 };
                 let check_generics = |tys: &[Type]| {
-                    // TODO(#12221): Determine whether we may want to relax this check
-                    let mut seen = BTreeSet::new();
-                    for ty in tys {
-                        if !matches!(ty, Type::TypeParameter(_)) {
-                            diag(&format!(
-                                "must only use type parameters \
-                                 but instead uses `{}`",
-                                ty.display(&type_ctx())
-                            ))
-                        } else if !seen.insert(ty) {
-                            // We cannot repeat type parameters
-                            diag(&format!(
-                                "cannot use type parameter `{}` more than once",
-                                ty.display(&type_ctx())
-                            ))
+                    let has_open = tys.iter().any(|ty| ty.is_open());
+                    let has_closed = tys.iter().any(|ty| !ty.is_open());
+
+                    if has_open && has_closed {
+                        // Partial instantiation: mix of open and closed type args
+                        diag(
+                            "must use either all type parameters \
+                             or all concrete types in the instantiation",
+                        )
+                    } else if has_open {
+                        // Fully generic: each arg must be a plain, distinct type parameter
+                        let mut seen = BTreeSet::new();
+                        for ty in tys {
+                            if !matches!(ty, Type::TypeParameter(_)) {
+                                diag(&format!(
+                                    "must only use type parameters \
+                                     but instead uses `{}`",
+                                    ty.display(&type_ctx())
+                                ))
+                            } else if !seen.insert(ty) {
+                                diag(&format!(
+                                    "cannot use type parameter `{}` more than once",
+                                    ty.display(&type_ctx())
+                                ))
+                            }
                         }
                     }
+                    // Fully concrete (all closed types): allowed, no check needed
                 };
                 match &base_type {
                     Type::Struct(mid, sid, inst) => {
@@ -494,7 +505,7 @@ impl<'env> ModelBuilder<'env> {
                                  and new receiver functions cannot be added",
                             )
                         } else {
-                            // The instantiation must be fully generic.
+                            // The instantiation must be fully generic or fully concrete.
                             check_generics(inst);
                             // At this point, there cannot be any other function in the module of the type
                             // which has the same name, as function overloading in a module is not allowed.


### PR DESCRIPTION
## Description

Previously, Move receiver functions (dot-call syntax with self) on generic structs required a fully generic identity instantiation — every type argument had to be a distinct type parameter (e.g., `fun foo(self: S<T, R>)`). This blocked patterns like `fun foo(self: S<u64, bool>)`.

This PR relaxes the requirement to also accept fully concrete instantiations where all type arguments are closed types with no type parameters anywhere in them.

What's allowed now:
  - `fun get_x(self: &MyStruct<u64, bool>): u64` — all type args are concrete types

What's still rejected:
  - Partial instantiation (`G<u64, T>`) — mix of concrete and type params
  - Non-linear type params (`G<T, T>`) — duplicate type parameters
  - Nested generics as type args (`G<vector<T>, T>`) — open but not plain type parameters

## How Has This Been Tested?
- new tests added to show both positive and negative cases

## Type of Change
- [x] New feature

## Which Components or Systems Does This Change Impact?
- [x] Move Compiler

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts compiler receiver-function registration rules for generic structs, which can change which functions are eligible for dot-call dispatch and may affect diagnostics/backward compatibility at compile time.
> 
> **Overview**
> Enables Move receiver (dot-call) functions to be declared on *fully concrete* instantiations of generic structs (e.g. `fun f(self: S<u64, bool>)`), in addition to the existing fully-generic “all distinct type parameters” form.
> 
> Updates the receiver validation logic in `move-model` to reject only *mixed open/closed* (partial) instantiations and keeps rejecting non-linear and nested-open generic arguments, and adds new positive/negative compiler + transactional tests covering concrete receivers, chaining (including through vector indexing), and cross-module behavior with updated diagnostics expectations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 69ccdc11190e1602bdf7a56efc7d8938fc837b4a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->