### PR TITLE
[storage] Disable LZ4 compression for state merkle DB

### DIFF
--- a/config/src/config/storage_config.rs
+++ b/config/src/config/storage_config.rs
@@ -119,6 +119,15 @@ pub enum IndexType {
     TwoLevelIndexSearch,
 }
 
+/// Compression algorithm for RocksDB.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub enum DBCompressionType {
+    /// No compression. Best for data that doesn't compress well (e.g. hashes).
+    None,
+    /// LZ4 compression. Good balance of speed and compression ratio.
+    Lz4,
+}
+
 /// Port selected RocksDB options for tuning underlying rocksdb instance of AptosDB.
 /// see <https://github.com/facebook/rocksdb/blob/master/include/rocksdb/options.h>
 /// for detailed explanations.
@@ -155,6 +164,8 @@ pub struct RocksdbConfig {
     pub bloom_filter_bits: Option<f64>,
     /// If not `None`, use hybrid ribbon filter policy.
     pub bloom_before_level: Option<i32>,
+    /// Compression type for SST files.
+    pub compression_type: DBCompressionType,
 }
 
 impl RocksdbConfig {
@@ -187,6 +198,7 @@ impl Default for RocksdbConfig {
             stats_dump_period_sec: None,
             bloom_filter_bits: None,
             bloom_before_level: None,
+            compression_type: DBCompressionType::Lz4,
         }
     }
 }
@@ -220,7 +232,10 @@ impl Default for RocksdbConfigs {
     fn default() -> Self {
         Self {
             ledger_db_config: RocksdbConfig::default(),
-            state_merkle_db_config: RocksdbConfig::default(),
+            state_merkle_db_config: RocksdbConfig {
+                compression_type: DBCompressionType::None,
+                ..Default::default()
+            },
             state_kv_db_config: RocksdbConfig {
                 bloom_filter_bits: Some(10.0),
                 bloom_before_level: Some(2),

--- a/storage/aptosdb/src/db_options.rs
+++ b/storage/aptosdb/src/db_options.rs
@@ -2,10 +2,11 @@
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::schema::*;
-use aptos_config::config::{IndexType, RocksdbConfig};
+use aptos_config::config::{DBCompressionType, IndexType, RocksdbConfig};
 use aptos_schemadb::{
     BlockBasedIndexType, BlockBasedOptions, Cache, ColumnFamilyDescriptor, ColumnFamilyName,
-    DBCompressionType, Options, SliceTransform, DEFAULT_COLUMN_FAMILY_NAME,
+    DBCompressionType as RocksDBCompressionType, Options, SliceTransform,
+    DEFAULT_COLUMN_FAMILY_NAME,
 };
 use aptos_types::transaction::Version;
 
@@ -152,7 +153,10 @@ where
         let table_options = gen_table_options(rocksdb_config, block_cache, cf_name);
 
         let mut cf_opts = Options::default();
-        cf_opts.set_compression_type(DBCompressionType::Lz4);
+        cf_opts.set_compression_type(match rocksdb_config.compression_type {
+            DBCompressionType::None => RocksDBCompressionType::None,
+            DBCompressionType::Lz4 => RocksDBCompressionType::Lz4,
+        });
         cf_opts.set_block_based_table_factory(&table_options);
         cf_opts.add_compact_on_deletion_collector_factory(0, 0, 0.4);
         cf_opts_post_processor(cf_name, &mut cf_opts);


### PR DESCRIPTION

Merkle tree nodes are primarily hashes (near-random bytes) that compress
poorly with LZ4. Benchmarking with 10M accounts + 15M transfer
transactions shows:

- **Disk**: +5-8% for `state_merkle_db`
- **Compaction CPU**: ~35% reduction in `CompMergeCPU` time
- **Compaction wall time**: ~15% reduction

This adds a `DBCompressionType` enum (`None` / `Lz4`) to `RocksdbConfig`
and sets it to `None` for `state_merkle_db_config`. Other DBs continue
to use LZ4.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes RocksDB option wiring to allow per-DB compression selection and defaults the state merkle DB to no compression, which can materially affect storage size and compaction behavior. Risk is moderate due to touching core DB configuration, but the change is scoped to compression settings.
> 
> **Overview**
> **Makes RocksDB SST compression configurable via node config.** Adds `DBCompressionType` (`None`/`Lz4`) to `RocksdbConfig`, defaulting to `Lz4`.
> 
> **Disables compression for the state merkle DB by default.** `RocksdbConfigs::default()` now sets `state_merkle_db_config.compression_type` to `None` while leaving other DBs on `Lz4`, and `aptosdb` now applies the configured compression type when building column-family `Options` instead of always forcing LZ4.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 415809b626b5fd42f01478fc8b32abb1b6cacf26. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->