### PR TITLE
separating move harness, so it can be included without feature="testing"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1484,9 +1484,9 @@ name = "aptos-dynamic-transaction-composer"
 version = "0.1.4"
 dependencies = [
  "anyhow",
+ "aptos-move-e2e-test-harness",
  "aptos-types",
  "bcs 0.1.4",
- "e2e-move-tests",
  "getrandom 0.2.11",
  "move-binary-format",
  "move-bytecode-verifier",
@@ -3223,6 +3223,7 @@ dependencies = [
  "aptos-gas-profiling",
  "aptos-language-e2e-tests",
  "aptos-logger",
+ "aptos-move-e2e-test-harness",
  "aptos-sdk",
  "aptos-transaction-generator-lib",
  "aptos-transaction-workloads-lib",
@@ -3230,10 +3231,33 @@ dependencies = [
  "aptos-vm-environment",
  "async-trait",
  "clap 4.5.60",
- "e2e-move-tests",
  "rand 0.7.3",
  "serde_json",
  "tokio",
+]
+
+[[package]]
+name = "aptos-move-e2e-test-harness"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "aptos-cached-packages",
+ "aptos-framework",
+ "aptos-gas-profiling",
+ "aptos-gas-schedule",
+ "aptos-language-e2e-tests",
+ "aptos-rest-client",
+ "aptos-transaction-simulation",
+ "aptos-types",
+ "bcs 0.1.4",
+ "claims",
+ "move-core-types",
+ "move-package",
+ "move-symbol-pool",
+ "once_cell",
+ "project-root",
+ "proptest",
+ "serde",
 ]
 
 [[package]]
@@ -8636,6 +8660,7 @@ dependencies = [
  "aptos-gas-profiling",
  "aptos-gas-schedule",
  "aptos-language-e2e-tests",
+ "aptos-move-e2e-test-harness",
  "aptos-package-builder",
  "aptos-rest-client",
  "aptos-sdk",
@@ -8653,9 +8678,7 @@ dependencies = [
  "move-coverage",
  "move-model",
  "move-package",
- "move-symbol-pool",
  "once_cell",
- "project-root",
  "proptest",
  "rstest",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ members = [
     "aptos-move/block-executor",
     "aptos-move/cli",
     "aptos-move/e2e-benchmark",
+    "aptos-move/e2e-move-test-harness",
     "aptos-move/e2e-move-tests",
     "aptos-move/e2e-tests",
     "aptos-move/e2e-testsuite",
@@ -404,6 +405,7 @@ aptos-move-debugger = { path = "aptos-move/aptos-debugger" }
 aptos-move-examples = { path = "aptos-move/move-examples" }
 aptos-move-flow = { path = "aptos-move/flow" }
 aptos-move-e2e-benchmark = { path = "aptos-move/e2e-benchmark" }
+aptos-move-e2e-test-harness = { path = "aptos-move/e2e-move-test-harness" }
 aptos-mvhashmap = { path = "aptos-move/mvhashmap" }
 aptos-native-interface = { path = "aptos-move/aptos-native-interface" }
 aptos-netcore = { path = "network/netcore" }

--- a/aptos-move/aptos-vm-environment/Cargo.toml
+++ b/aptos-move/aptos-vm-environment/Cargo.toml
@@ -40,3 +40,4 @@ serde = { workspace = true }
 [features]
 default = []
 testing = ["aptos-move-stdlib/testing"]
+profiling = ["move-vm-runtime/profiling"]

--- a/aptos-move/e2e-benchmark/Cargo.toml
+++ b/aptos-move/e2e-benchmark/Cargo.toml
@@ -19,6 +19,7 @@ aptos-gas-algebra = { workspace = true }
 aptos-gas-profiling = { workspace = true }
 aptos-language-e2e-tests = { workspace = true }
 aptos-logger = { workspace = true }
+aptos-move-e2e-test-harness = { workspace = true }
 aptos-sdk = { workspace = true }
 aptos-transaction-generator-lib = { workspace = true }
 aptos-transaction-workloads-lib = { workspace = true }
@@ -26,11 +27,10 @@ aptos-types = { workspace = true }
 aptos-vm-environment = { workspace = true }
 async-trait = { workspace = true }
 clap = { workspace = true }
-e2e-move-tests = { path = "../e2e-move-tests" }
 rand = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }
 
 [features]
 default = []
-profiling = ["e2e-move-tests/profiling"]
+profiling = ["aptos-vm-environment/profiling"]

--- a/aptos-move/e2e-benchmark/src/gas_profiling.rs
+++ b/aptos-move/e2e-benchmark/src/gas_profiling.rs
@@ -4,6 +4,7 @@
 use aptos_gas_algebra::GasQuantity;
 use aptos_gas_profiling::TransactionGasLog;
 use aptos_language_e2e_tests::account::Account;
+use aptos_move_e2e_test_harness::MoveHarnessSend;
 use aptos_sdk::{
     transaction_builder::TransactionFactory,
     types::{AccountKey, LocalAccount},
@@ -24,7 +25,6 @@ use aptos_types::{
     fee_statement::FeeStatement,
     transaction::{AuxiliaryInfo, SignedTransaction, TransactionExecutableRef},
 };
-use e2e_move_tests::MoveHarnessSend;
 use std::{
     collections::HashMap,
     path::Path,
@@ -519,6 +519,7 @@ mod tests {
     };
     use aptos_cached_packages::{aptos_stdlib, aptos_token_sdk_builder};
     use aptos_crypto::{bls12381, PrivateKey, Uniform};
+    use aptos_move_e2e_test_harness::MoveHarnessSend;
     use aptos_sdk::move_types::{identifier::Identifier, language_storage::ModuleId};
     use aptos_transaction_generator_lib::{
         entry_point_trait::EntryPointTrait, publishing::publish_util::PackageHandler,
@@ -531,7 +532,6 @@ mod tests {
         transaction::{EntryFunction, TransactionPayload},
     };
     use aptos_vm_environment::prod_configs::{set_layout_caches, set_paranoid_type_checks};
-    use e2e_move_tests::MoveHarnessSend;
     use rand::{rngs::StdRng, SeedableRng};
     use std::path::PathBuf;
 

--- a/aptos-move/e2e-move-test-harness/Cargo.toml
+++ b/aptos-move/e2e-move-test-harness/Cargo.toml
@@ -1,0 +1,39 @@
+[package]
+name = "aptos-move-e2e-test-harness"
+description = "Move e2e test harness"
+version = "0.1.0"
+
+# Workspace inherited keys
+authors = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+repository = { workspace = true }
+rust-version = { workspace = true }
+
+[dependencies]
+anyhow = { workspace = true }
+aptos-cached-packages = { workspace = true }
+aptos-framework = { workspace = true }
+aptos-gas-profiling = { workspace = true }
+aptos-gas-schedule = { workspace = true }
+aptos-language-e2e-tests = { workspace = true }
+aptos-rest-client = { workspace = true }
+aptos-transaction-simulation = { workspace = true }
+aptos-types = { workspace = true }
+bcs = { workspace = true }
+claims = { workspace = true }
+move-core-types = { workspace = true }
+move-package = { workspace = true }
+move-symbol-pool = { workspace = true }
+once_cell = { workspace = true }
+project-root = { workspace = true }
+proptest = { workspace = true }
+serde = { workspace = true }
+
+[lib]
+doctest = false
+
+[features]
+testing = ["aptos-gas-schedule/testing"]

--- a/aptos-move/e2e-move-test-harness/src/lib.rs
+++ b/aptos-move/e2e-move-test-harness/src/lib.rs
@@ -1,7 +1,6 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-use crate::{assert_success, AptosPackageHooks};
 use aptos_cached_packages::aptos_stdlib;
 use aptos_framework::{natives::code::PackageMetadata, BuildOptions, BuiltPackage};
 use aptos_gas_profiling::TransactionGasLog;
@@ -1371,6 +1370,26 @@ macro_rules! assert_move_abort {
             $($arg)+
         );
     }};
+}
+
+pub(crate) struct AptosPackageHooks {}
+
+impl move_package::package_hooks::PackageHooks for AptosPackageHooks {
+    fn custom_package_info_fields(&self) -> Vec<String> {
+        vec![aptos_framework::UPGRADE_POLICY_CUSTOM_FIELD.to_string()]
+    }
+
+    fn custom_dependency_key(&self) -> Option<String> {
+        Some("aptos".to_string())
+    }
+
+    fn resolve_custom_dependency(
+        &self,
+        _dep_name: move_symbol_pool::Symbol,
+        _info: &move_package::source_package::parsed_manifest::CustomDepInfo,
+    ) -> anyhow::Result<()> {
+        anyhow::bail!("not used")
+    }
 }
 
 #[cfg(test)]

--- a/aptos-move/e2e-move-tests/Cargo.toml
+++ b/aptos-move/e2e-move-tests/Cargo.toml
@@ -21,6 +21,7 @@ aptos-gas-algebra = { workspace = true }
 aptos-gas-profiling = { workspace = true }
 aptos-gas-schedule = { workspace = true, features = ["testing"] }
 aptos-language-e2e-tests = { workspace = true }
+aptos-move-e2e-test-harness = { workspace = true, features = ["testing"] }
 aptos-package-builder = { workspace = true }
 aptos-rest-client = { workspace = true }
 aptos-sdk = { workspace = true }
@@ -36,9 +37,7 @@ move-core-types = { workspace = true }
 move-coverage = { workspace = true }
 move-model = { workspace = true }
 move-package = { workspace = true }
-move-symbol-pool = { workspace = true }
 once_cell = { workspace = true }
-project-root = { workspace = true }
 proptest = { workspace = true }
 rstest = { workspace = true }
 serde = { workspace = true }

--- a/aptos-move/e2e-move-tests/src/aggregator.rs
+++ b/aptos-move/e2e-move-tests/src/aggregator.rs
@@ -1,8 +1,8 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-use crate::{assert_success, harness::MoveHarness};
 use aptos_language_e2e_tests::{account::Account, executor::FakeExecutor};
+use aptos_move_e2e_test_harness::{assert_success, MoveHarness};
 use aptos_types::{account_address::AccountAddress, transaction::SignedTransaction};
 use std::path::PathBuf;
 

--- a/aptos-move/e2e-move-tests/src/aggregator_v2.rs
+++ b/aptos-move/e2e-move-tests/src/aggregator_v2.rs
@@ -1,11 +1,11 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-use crate::{assert_success, harness::MoveHarness, BlockSplit};
 use aptos_language_e2e_tests::{
     account::Account,
     executor::{assert_outputs_equal, ExecutorMode, FakeExecutor},
 };
+use aptos_move_e2e_test_harness::{assert_success, BlockSplit, MoveHarness};
 use aptos_types::{
     account_address::AccountAddress,
     on_chain_config::FeatureFlag,

--- a/aptos-move/e2e-move-tests/src/aptos_governance.rs
+++ b/aptos-move/e2e-move-tests/src/aptos_governance.rs
@@ -1,9 +1,9 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-use crate::harness::MoveHarness;
 use aptos_cached_packages::aptos_stdlib;
 use aptos_language_e2e_tests::account::Account;
+use aptos_move_e2e_test_harness::MoveHarness;
 use aptos_types::{
     account_address::AccountAddress, move_utils::MemberId, transaction::TransactionStatus,
 };

--- a/aptos-move/e2e-move-tests/src/lib.rs
+++ b/aptos-move/e2e-move-tests/src/lib.rs
@@ -4,36 +4,10 @@
 pub mod aggregator;
 pub mod aggregator_v2;
 pub mod aptos_governance;
-pub mod harness;
 pub mod resource_groups;
 pub mod stake;
 
-use anyhow::bail;
-use aptos_framework::UPGRADE_POLICY_CUSTOM_FIELD;
-pub use harness::*;
-use move_package::{package_hooks::PackageHooks, source_package::parsed_manifest::CustomDepInfo};
-use move_symbol_pool::Symbol;
-pub use stake::*;
+pub use aptos_move_e2e_test_harness::*;
 
 #[cfg(test)]
 pub mod tests;
-
-pub(crate) struct AptosPackageHooks {}
-
-impl PackageHooks for AptosPackageHooks {
-    fn custom_package_info_fields(&self) -> Vec<String> {
-        vec![UPGRADE_POLICY_CUSTOM_FIELD.to_string()]
-    }
-
-    fn custom_dependency_key(&self) -> Option<String> {
-        Some("aptos".to_string())
-    }
-
-    fn resolve_custom_dependency(
-        &self,
-        _dep_name: Symbol,
-        _info: &CustomDepInfo,
-    ) -> anyhow::Result<()> {
-        bail!("not used")
-    }
-}

--- a/aptos-move/e2e-move-tests/src/resource_groups.rs
+++ b/aptos-move/e2e-move-tests/src/resource_groups.rs
@@ -1,11 +1,11 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-use crate::{assert_success, harness::MoveHarness, BlockSplit};
 use aptos_language_e2e_tests::{
     account::Account,
     executor::{assert_outputs_equal, ExecutorMode, FakeExecutor},
 };
+use aptos_move_e2e_test_harness::{assert_success, BlockSplit, MoveHarness};
 use aptos_types::{
     account_address::AccountAddress, on_chain_config::FeatureFlag, transaction::SignedTransaction,
 };

--- a/aptos-move/e2e-move-tests/src/stake.rs
+++ b/aptos-move/e2e-move-tests/src/stake.rs
@@ -1,10 +1,10 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-use crate::harness::MoveHarness;
 use aptos_cached_packages::aptos_stdlib;
 use aptos_crypto::{bls12381, PrivateKey, Uniform};
 use aptos_language_e2e_tests::account::Account;
+use aptos_move_e2e_test_harness::MoveHarness;
 use aptos_types::{
     account_address::AccountAddress, account_config::CORE_CODE_ADDRESS,
     on_chain_config::ValidatorSet, stake_pool::StakePool, transaction::TransactionStatus,

--- a/aptos-move/e2e-move-tests/src/tests/stake.rs
+++ b/aptos-move/e2e-move-tests/src/tests/stake.rs
@@ -2,11 +2,15 @@
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
-    assert_success, get_stake_pool, get_validator_config, get_validator_set, initialize_staking,
-    join_validator_set, leave_validator_set, rotate_consensus_key, setup_staking, tests::common,
-    unlock_stake, withdraw_stake, MoveHarness,
+    stake::{
+        get_stake_pool, get_validator_config, get_validator_set, initialize_staking,
+        join_validator_set, leave_validator_set, rotate_consensus_key, setup_staking, unlock_stake,
+        withdraw_stake,
+    },
+    tests::common,
 };
 use aptos_cached_packages::aptos_stdlib;
+use aptos_move_e2e_test_harness::{assert_success, MoveHarness};
 use aptos_types::account_address::{default_stake_pool_address, AccountAddress};
 use once_cell::sync::Lazy;
 use std::collections::BTreeMap;

--- a/aptos-move/e2e-move-tests/src/tests/transaction_context.rs
+++ b/aptos-move/e2e-move-tests/src/tests/transaction_context.rs
@@ -1,8 +1,9 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-use crate::{assert_success, harness::MoveHarness, tests::common, BlockSplit, SUCCESS};
+use crate::{tests::common, BlockSplit, SUCCESS};
 use aptos_language_e2e_tests::account::{Account, TransactionBuilder};
+use aptos_move_e2e_test_harness::{assert_success, MoveHarness};
 use aptos_types::{
     move_utils::MemberId,
     on_chain_config::FeatureFlag,

--- a/aptos-move/script-composer/Cargo.toml
+++ b/aptos-move/script-composer/Cargo.toml
@@ -28,8 +28,8 @@ wasm-bindgen = { workspace = true }
 wasm-bindgen-futures = { workspace = true }
 
 [dev-dependencies]
+aptos-move-e2e-test-harness = { workspace = true }
 aptos-types = { workspace = true }
-e2e-move-tests = { path = "../e2e-move-tests" }
 
 [package.metadata.cargo-machete]
 ignored = ["serde_bytes", "wasm-bindgen-futures", "getrandom"]

--- a/aptos-move/script-composer/src/tests/mod.rs
+++ b/aptos-move/script-composer/src/tests/mod.rs
@@ -2,11 +2,11 @@
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{CallArgument, TransactionComposer};
+use aptos_move_e2e_test_harness::MoveHarness;
 use aptos_types::{
     state_store::state_key::StateKey,
     transaction::{ExecutionStatus, TransactionStatus},
 };
-use e2e_move_tests::MoveHarness;
 use move_binary_format::CompiledModule;
 use move_core_types::{
     account_address::AccountAddress, language_storage::ModuleId, value::MoveValue,


### PR DESCRIPTION
## Description
e2e-move-tests hardcodes feature="testing".
I assume it was not meant to be included, but Etna rust code included it. 
Which made the whole rust workspace (including production services) to run with feature="testing", which is undesirable. We had to hardcode gas and unit prices etc. 


## How Has This Been Tested?
pulled in Etna, and confirmed testing feature is not included any more 

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly dependency/feature-flag plumbing, but it touches workspace membership and feature propagation (notably profiling/testing), which can subtly affect build configurations and downstream consumers.
> 
> **Overview**
> Separates the Move e2e harness into a new `aptos-move-e2e-test-harness` crate so consumers can depend on the harness without pulling `e2e-move-tests` (and its implicit `testing` feature).
> 
> Updates `e2e-move-tests`, `e2e-benchmark`, `script-composer` (tests), and `script-composer`/`aptos-dynamic-transaction-composer` dev usage to import/re-export the harness from the new crate, and adjusts profiling feature wiring by adding `aptos-vm-environment/profiling` and pointing `e2e-benchmark`’s `profiling` feature at it.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 802c820a2d30b247f7e03240ce0e64db2def152a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->