### PR TITLE
[storage] Persist hot state KV insertions/evictions to DB

### DIFF
--- a/execution/executor-types/src/state_compute_result.rs
+++ b/execution/executor-types/src/state_compute_result.rs
@@ -166,6 +166,7 @@ impl StateComputeResult {
             state_summary: &self.state_checkpoint_output.state_summary,
             state_update_refs: self.execution_output.to_commit.state_update_refs(),
             state_reads: &self.execution_output.state_reads,
+            hot_state_updates: &self.execution_output.hot_state_updates,
             is_reconfig: self.execution_output.next_epoch_state.is_some(),
         }
     }

--- a/storage/aptosdb/src/db/aptosdb_internal.rs
+++ b/storage/aptosdb/src/db/aptosdb_internal.rs
@@ -73,7 +73,7 @@ impl AptosDB {
             Arc::clone(&ledger_db),
             hot_state_merkle_db,
             Arc::clone(&state_merkle_db),
-            hot_state_kv_db,
+            hot_state_kv_db.clone(),
             Arc::clone(&state_kv_db),
             state_pruner,
             buffered_state_target_items,
@@ -92,6 +92,7 @@ impl AptosDB {
 
         AptosDB {
             ledger_db: Arc::clone(&ledger_db),
+            hot_state_kv_db,
             state_kv_db: Arc::clone(&state_kv_db),
             event_store: Arc::new(EventStore::new(ledger_db.event_db().db_arc())),
             state_store,

--- a/storage/aptosdb/src/db/aptosdb_testonly.rs
+++ b/storage/aptosdb/src/db/aptosdb_testonly.rs
@@ -156,6 +156,7 @@ impl AptosDB {
             state_summary: &new_state_summary,
             state_update_refs: transactions_to_keep.state_update_refs(),
             state_reads: &reads,
+            hot_state_updates: &hot_state_updates,
             is_reconfig: transactions_to_keep.is_reconfig(),
         };
 

--- a/storage/aptosdb/src/db/aptosdb_writer.rs
+++ b/storage/aptosdb/src/db/aptosdb_writer.rs
@@ -327,6 +327,14 @@ impl AptosDB {
             &mut sharded_state_kv_batches,
         )?;
 
+        let hot_state_kv_db = self
+            .hot_state_kv_db
+            .as_ref()
+            .expect("hot_state_kv_db must exist on the write path");
+        let mut sharded_hot_state_kv_batches = hot_state_kv_db.new_sharded_native_batches();
+        self.state_store
+            .put_hot_state_updates(chunk.hot_state_updates, &mut sharded_hot_state_kv_batches)?;
+
         // Write block index.
         for (i, txn_out) in chunk.transaction_outputs.iter().enumerate() {
             for event in txn_out.events() {
@@ -362,6 +370,15 @@ impl AptosDB {
             s.spawn(|_| {
                 self.state_kv_db
                     .commit(chunk.expect_last_version(), None, sharded_state_kv_batches)
+                    .unwrap();
+            });
+            s.spawn(|_| {
+                hot_state_kv_db
+                    .commit(
+                        chunk.expect_last_version(),
+                        None,
+                        sharded_hot_state_kv_batches,
+                    )
                     .unwrap();
             });
         });

--- a/storage/aptosdb/src/db/mod.rs
+++ b/storage/aptosdb/src/db/mod.rs
@@ -25,6 +25,7 @@ pub mod test_helper;
 /// access to the core Aptos data structures.
 pub struct AptosDB {
     pub(crate) ledger_db: Arc<LedgerDb>,
+    pub(crate) hot_state_kv_db: Option<Arc<StateKvDb>>,
     pub(crate) state_kv_db: Arc<StateKvDb>,
     pub(crate) event_store: Arc<EventStore>,
     pub(crate) state_store: Arc<StateStore>,

--- a/storage/aptosdb/src/db_options.rs
+++ b/storage/aptosdb/src/db_options.rs
@@ -110,6 +110,14 @@ pub(super) fn state_kv_db_new_key_column_families() -> Vec<ColumnFamilyName> {
     ]
 }
 
+pub(super) fn hot_state_kv_db_column_families() -> Vec<ColumnFamilyName> {
+    vec![
+        /* empty cf */ DEFAULT_COLUMN_FAMILY_NAME,
+        DB_METADATA_CF_NAME,
+        HOT_STATE_VALUE_BY_KEY_HASH_CF_NAME,
+    ]
+}
+
 fn gen_cfds<F>(
     rocksdb_config: &RocksdbConfig,
     block_cache: Option<&Cache>,
@@ -312,6 +320,19 @@ pub(super) fn gen_state_kv_shard_cfds(
     block_cache: Option<&Cache>,
 ) -> Vec<ColumnFamilyDescriptor> {
     let cfs = state_kv_db_new_key_column_families();
+    gen_cfds(
+        rocksdb_config,
+        block_cache,
+        cfs,
+        with_state_key_extractor_processor,
+    )
+}
+
+pub(super) fn gen_hot_state_kv_shard_cfds(
+    rocksdb_config: &RocksdbConfig,
+    block_cache: Option<&Cache>,
+) -> Vec<ColumnFamilyDescriptor> {
+    let cfs = hot_state_kv_db_column_families();
     gen_cfds(
         rocksdb_config,
         block_cache,

--- a/storage/aptosdb/src/schema/hot_state_value_by_key_hash/mod.rs
+++ b/storage/aptosdb/src/schema/hot_state_value_by_key_hash/mod.rs
@@ -7,9 +7,12 @@
 //! refreshed in the hot state.
 //!
 //! ```text
-//! |<---------- key ----------->|<--- value --->|
-//! |  state key hash | version  |  state value  |
+//! |<--------------- key ---------------->|<-------- value -------->|
+//! |  state key hash | hot since version  |  Option<HotStateEntry>  |
 //! ```
+//!
+//! `HotStateEntry` is either `Occupied { value, value_version }` or `Vacant`.
+//! `None` means the key was evicted from hot state at that version.
 
 use crate::schema::{ensure_slice_len_eq, HOT_STATE_VALUE_BY_KEY_HASH_CF_NAME};
 use anyhow::Result;
@@ -31,17 +34,18 @@ type Key = (HashValue, Version);
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
-pub(crate) enum HotStateValue {
+pub(crate) enum HotStateEntry {
     Occupied {
-        value_version: Version,
         value: StateValue,
+        value_version: Version,
     },
     Vacant,
 }
+
 define_schema!(
     HotStateValueByKeyHashSchema,
     Key,
-    Option<HotStateValue>, // None means being evicted.
+    Option<HotStateEntry>,
     HOT_STATE_VALUE_BY_KEY_HASH_CF_NAME
 );
 
@@ -63,7 +67,7 @@ impl KeyCodec<HotStateValueByKeyHashSchema> for Key {
     }
 }
 
-impl ValueCodec<HotStateValueByKeyHashSchema> for Option<HotStateValue> {
+impl ValueCodec<HotStateValueByKeyHashSchema> for Option<HotStateEntry> {
     fn encode_value(&self) -> Result<Vec<u8>> {
         bcs::to_bytes(self).map_err(Into::into)
     }

--- a/storage/aptosdb/src/schema/hot_state_value_by_key_hash/test.rs
+++ b/storage/aptosdb/src/schema/hot_state_value_by_key_hash/test.rs
@@ -11,9 +11,9 @@ proptest! {
     fn test_encode_decode(
         state_key in any::<HashValue>(),
         version in any::<Version>(),
-        v in any::<Option<HotStateValue>>(),
+        entry in any::<Option<HotStateEntry>>(),
     ) {
-        assert_encode_decode::<HotStateValueByKeyHashSchema>(&(state_key, version), &v);
+        assert_encode_decode::<HotStateValueByKeyHashSchema>(&(state_key, version), &entry);
     }
 }
 

--- a/storage/aptosdb/src/state_kv_db.rs
+++ b/storage/aptosdb/src/state_kv_db.rs
@@ -3,8 +3,10 @@
 
 #![forbid(unsafe_code)]
 
+#[cfg(test)]
+use crate::schema::hot_state_value_by_key_hash::{HotStateEntry, HotStateValueByKeyHashSchema};
 use crate::{
-    db_options::gen_state_kv_shard_cfds,
+    db_options::{gen_hot_state_kv_shard_cfds, gen_state_kv_shard_cfds},
     metrics::OTHER_TIMERS_SECONDS,
     schema::{
         db_metadata::{DbMetadataKey, DbMetadataSchema, DbMetadataValue},
@@ -115,6 +117,7 @@ impl StateKvDb {
             env,
             block_cache,
             readonly,
+            is_hot,
             delete_on_restart,
         )?);
 
@@ -158,7 +161,9 @@ impl StateKvDb {
             is_hot,
         };
 
-        if !readonly && !delete_on_restart {
+        // TODO(HotState): Integrate hot state KV DB with pruner and add truncation support
+        // (stale index tracking, etc.) for the hot state DB.
+        if !readonly && !delete_on_restart && !is_hot {
             if let Some(overall_kv_commit_progress) = get_state_kv_commit_progress(&state_kv_db)? {
                 truncate_state_kv_db_shards(&state_kv_db, overall_kv_commit_progress)?;
             }
@@ -314,6 +319,7 @@ impl StateKvDb {
             env,
             block_cache,
             readonly,
+            is_hot,
             delete_on_restart,
         )
     }
@@ -325,6 +331,7 @@ impl StateKvDb {
         env: Option<&Env>,
         block_cache: Option<&Cache>,
         readonly: bool,
+        is_hot: bool,
         delete_on_restart: bool,
     ) -> Result<DB> {
         if delete_on_restart {
@@ -334,7 +341,11 @@ impl StateKvDb {
         }
 
         let rocksdb_opts = gen_rocksdb_options(state_kv_db_config, env, readonly);
-        let cfds = gen_state_kv_shard_cfds(state_kv_db_config, block_cache);
+        let cfds = if is_hot {
+            gen_hot_state_kv_shard_cfds(state_kv_db_config, block_cache)
+        } else {
+            gen_state_kv_shard_cfds(state_kv_db_config, block_cache)
+        };
 
         if readonly {
             DB::open_cf_readonly(rocksdb_opts, path, name, cfds)
@@ -375,5 +386,26 @@ impl StateKvDb {
             .next()
             .transpose()?
             .and_then(|((_, version), value_opt)| value_opt.map(|value| (version, value))))
+    }
+
+    /// Returns the latest hot state entry for the given key at or before the
+    /// given version. Outer `None` means no entry found; inner `None` means the
+    /// key was evicted at that version.
+    #[cfg(test)]
+    pub(crate) fn get_hot_state_entry_by_version(
+        &self,
+        state_key: &StateKey,
+        version: Version,
+    ) -> Result<Option<(Version, Option<HotStateEntry>)>> {
+        let mut read_opts = ReadOptions::default();
+        read_opts.set_prefix_same_as_start(true);
+        let mut iter = self
+            .db_shard(state_key.get_shard_id())
+            .iter_with_opts::<HotStateValueByKeyHashSchema>(read_opts)?;
+        iter.seek(&(state_key.hash(), version))?;
+        Ok(iter
+            .next()
+            .transpose()?
+            .map(|((_, version), entry_opt)| (version, entry_opt)))
     }
 }

--- a/storage/aptosdb/src/state_store/mod.rs
+++ b/storage/aptosdb/src/state_store/mod.rs
@@ -9,6 +9,7 @@ use crate::{
     pruner::{leaked_stale_node_cleaner, StateKvPrunerManager, StateMerklePrunerManager},
     schema::{
         db_metadata::{DbMetadataKey, DbMetadataSchema, DbMetadataValue},
+        hot_state_value_by_key_hash::{HotStateEntry, HotStateValueByKeyHashSchema},
         stale_node_index::StaleNodeIndexSchema,
         stale_node_index_cross_epoch::StaleNodeIndexCrossEpochSchema,
         stale_state_value_index_by_key_hash::StaleStateValueIndexByKeyHashSchema,
@@ -59,7 +60,7 @@ use aptos_storage_interface::{
         },
         state_with_summary::{LedgerStateWithSummary, StateWithSummary},
         versioned_state_value::StateUpdateRef,
-        HotStateUpdates,
+        HotStateShardUpdates, HotStateUpdates,
     },
     AptosDbError, DbReader, Result, StateSnapshotReceiver,
 };
@@ -833,6 +834,63 @@ impl StateStore {
                         )
                     })
             })
+    }
+
+    // TODO(HotState): multiple writes to the same key are batched (within `for_last_checkpoint`
+    // and `for_latest`) and only the last one is persisted. Revisit later if necessary.
+    pub fn put_hot_state_updates(
+        &self,
+        hot_state_updates: &HotStateUpdates,
+        sharded_hot_state_kv_batches: &mut ShardedStateKvSchemaBatch,
+    ) -> Result<()> {
+        let _timer = OTHER_TIMERS_SECONDS.timer_with(&["put_hot_state_updates"]);
+
+        fn write_shard_updates(
+            shard_updates: &[HotStateShardUpdates; NUM_STATE_SHARDS],
+            batches: &mut ShardedStateKvSchemaBatch,
+        ) -> Result<()> {
+            batches
+                .par_iter_mut()
+                .zip_eq(shard_updates.par_iter())
+                .try_for_each(|(batch, shard)| {
+                    for (key, (hot_val, value_version_opt)) in &shard.insertions {
+                        let schema_value = match hot_val.value_opt() {
+                            Some(value) => HotStateEntry::Occupied {
+                                value: value.clone(),
+                                value_version: value_version_opt
+                                    .expect("occupied must have value_version"),
+                            },
+                            None => {
+                                assert!(
+                                    value_version_opt.is_none(),
+                                    "vacant must not have value_version"
+                                );
+                                HotStateEntry::Vacant
+                            },
+                        };
+                        batch.put::<HotStateValueByKeyHashSchema>(
+                            &(CryptoHash::hash(key), hot_val.hot_since_version()),
+                            &Some(schema_value),
+                        )?;
+                    }
+                    for (key, eviction_version) in &shard.evictions {
+                        batch.put::<HotStateValueByKeyHashSchema>(
+                            &(CryptoHash::hash(key), *eviction_version),
+                            &None,
+                        )?;
+                    }
+                    Ok(())
+                })
+        }
+
+        if let Some(updates) = &hot_state_updates.for_last_checkpoint {
+            write_shard_updates(updates, sharded_hot_state_kv_batches)?;
+        }
+        if let Some(updates) = &hot_state_updates.for_latest {
+            write_shard_updates(updates, sharded_hot_state_kv_batches)?;
+        }
+
+        Ok(())
     }
 
     pub fn get_usage(&self, version: Option<Version>) -> Result<StateStorageUsage> {

--- a/storage/aptosdb/src/state_store/tests/hot_state_kv.rs
+++ b/storage/aptosdb/src/state_store/tests/hot_state_kv.rs
@@ -1,0 +1,222 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+use crate::{
+    db::AptosDB,
+    schema::hot_state_value_by_key_hash::{HotStateEntry, HotStateValueByKeyHashSchema},
+    state_kv_db::StateKvDb,
+};
+use aptos_config::config::{RocksdbConfig, StorageDirPaths};
+use aptos_crypto::hash::CryptoHash;
+use aptos_schemadb::batch::WriteBatch;
+use aptos_storage_interface::state_store::{HotStateShardUpdates, HotStateUpdates};
+use aptos_temppath::TempPath;
+use aptos_types::{
+    state_store::{
+        hot_state::HotStateValue, state_key::StateKey, state_value::StateValue, NUM_STATE_SHARDS,
+    },
+    transaction::Version,
+};
+use std::collections::HashMap;
+
+fn create_hot_state_kv_db(path: &TempPath) -> StateKvDb {
+    StateKvDb::new(
+        &StorageDirPaths::from_path(path.path()),
+        RocksdbConfig::default(),
+        /* env = */ None,
+        /* block_cache = */ None,
+        /* readonly = */ false,
+        /* is_hot = */ true,
+        /* delete_on_restart = */ false,
+    )
+    .unwrap()
+}
+
+fn make_state_key(seed: u8) -> StateKey {
+    StateKey::raw(&[seed])
+}
+
+fn make_state_value(seed: u8) -> StateValue {
+    StateValue::new_legacy(vec![seed, seed].into())
+}
+
+fn put_hot_state_entry(
+    db: &StateKvDb,
+    key: &StateKey,
+    version: Version,
+    entry: Option<HotStateEntry>,
+) {
+    let shard_id = key.get_shard_id();
+    let mut batch = db.db_shard(shard_id).new_native_batch();
+    batch
+        .put::<HotStateValueByKeyHashSchema>(&(CryptoHash::hash(key), version), &entry)
+        .unwrap();
+    db.db_shard(shard_id).write_schemas(batch).unwrap();
+}
+
+fn get_hot_state_entry(db: &StateKvDb, key: &StateKey, version: Version) -> Option<HotStateEntry> {
+    db.db_shard(key.get_shard_id())
+        .get::<HotStateValueByKeyHashSchema>(&(CryptoHash::hash(key), version))
+        .unwrap()
+        .unwrap()
+}
+
+#[test]
+fn test_insertion_write_read() {
+    let tmp = TempPath::new();
+    let db = create_hot_state_kv_db(&tmp);
+
+    // Occupied entry
+    let key1 = make_state_key(1);
+    let value = make_state_value(1);
+    put_hot_state_entry(
+        &db,
+        &key1,
+        10,
+        Some(HotStateEntry::Occupied {
+            value: value.clone(),
+            value_version: 5,
+        }),
+    );
+    assert_eq!(
+        get_hot_state_entry(&db, &key1, 10),
+        Some(HotStateEntry::Occupied {
+            value,
+            value_version: 5,
+        })
+    );
+
+    // Vacant entry
+    let key2 = make_state_key(2);
+    put_hot_state_entry(&db, &key2, 20, Some(HotStateEntry::Vacant));
+    assert_eq!(
+        get_hot_state_entry(&db, &key2, 20),
+        Some(HotStateEntry::Vacant),
+    );
+}
+
+#[test]
+fn test_eviction_write_read() {
+    let tmp = TempPath::new();
+    let db = create_hot_state_kv_db(&tmp);
+
+    let key = make_state_key(3);
+
+    // Insertion at V10, eviction at V20.
+    put_hot_state_entry(
+        &db,
+        &key,
+        10,
+        Some(HotStateEntry::Occupied {
+            value: make_state_value(3),
+            value_version: 5,
+        }),
+    );
+    put_hot_state_entry(&db, &key, 20, None);
+
+    // The latest entry should be the eviction.
+    let (found_version, found_value) = db
+        .get_hot_state_entry_by_version(&key, Version::MAX)
+        .unwrap()
+        .unwrap();
+    assert_eq!(found_version, 20);
+    assert!(found_value.is_none(), "Eviction should be None");
+}
+
+#[test]
+fn test_multiple_versions() {
+    let tmp = TempPath::new();
+    let db = create_hot_state_kv_db(&tmp);
+
+    let key = make_state_key(4);
+    let entry = HotStateEntry::Occupied {
+        value: make_state_value(41),
+        value_version: 1,
+    };
+
+    // Insertion at V1, refresh at V2.
+    put_hot_state_entry(&db, &key, 1, Some(entry.clone()));
+    put_hot_state_entry(&db, &key, 2, Some(entry));
+
+    let expected_entry = Some(HotStateEntry::Occupied {
+        value: make_state_value(41),
+        value_version: 1,
+    });
+
+    // Querying at Version::MAX should return the latest (V2).
+    let (latest_version, latest_entry) = db
+        .get_hot_state_entry_by_version(&key, Version::MAX)
+        .unwrap()
+        .unwrap();
+    assert_eq!(latest_version, 2);
+    assert_eq!(latest_entry, expected_entry);
+
+    // Querying at V1 should return the older entry.
+    let (older_version, older_entry) = db.get_hot_state_entry_by_version(&key, 1).unwrap().unwrap();
+    assert_eq!(older_version, 1);
+    assert_eq!(older_entry, expected_entry);
+}
+
+#[test]
+fn test_put_hot_state_updates_integration() {
+    let tmp = TempPath::new();
+    let aptos_db = AptosDB::new_for_test(&tmp);
+    let hot_state_kv_db = aptos_db.hot_state_kv_db.as_ref().unwrap();
+
+    let key1 = make_state_key(10);
+    let val1 = make_state_value(10);
+    let key2 = make_state_key(20);
+    let key3 = make_state_key(30);
+
+    let mut shards: [HotStateShardUpdates; NUM_STATE_SHARDS] =
+        std::array::from_fn(|_| HotStateShardUpdates::new(HashMap::new(), HashMap::new()));
+
+    // key1: occupied insertion at hot_since_version=100, value_version=50
+    shards[key1.get_shard_id()].insertions.insert(
+        key1.clone(),
+        (HotStateValue::new(Some(val1.clone()), 100), Some(50)),
+    );
+
+    // key2: vacant insertion at hot_since_version=200
+    shards[key2.get_shard_id()]
+        .insertions
+        .insert(key2.clone(), (HotStateValue::new(None, 200), None));
+
+    // key3: eviction at version=300
+    shards[key3.get_shard_id()]
+        .evictions
+        .insert(key3.clone(), 300);
+
+    let hot_state_updates = HotStateUpdates {
+        for_last_checkpoint: Some(shards),
+        for_latest: None,
+    };
+
+    let mut sharded_batches = hot_state_kv_db.new_sharded_native_batches();
+    aptos_db
+        .state_store
+        .put_hot_state_updates(&hot_state_updates, &mut sharded_batches)
+        .unwrap();
+    hot_state_kv_db.commit(999, None, sharded_batches).unwrap();
+
+    // Verify key1: occupied
+    assert_eq!(
+        get_hot_state_entry(hot_state_kv_db, &key1, 100).unwrap(),
+        HotStateEntry::Occupied {
+            value: val1,
+            value_version: 50,
+        }
+    );
+
+    // Verify key2: vacant
+    assert_eq!(
+        get_hot_state_entry(hot_state_kv_db, &key2, 200).unwrap(),
+        HotStateEntry::Vacant,
+    );
+
+    // Verify key3: eviction (None)
+    assert!(
+        get_hot_state_entry(hot_state_kv_db, &key3, 300).is_none(),
+        "Eviction should be None"
+    );
+}

--- a/storage/aptosdb/src/state_store/tests/mod.rs
+++ b/storage/aptosdb/src/state_store/tests/mod.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
+mod hot_state_kv;
 mod speculative_state_workflow;
 
 use super::*;

--- a/storage/storage-interface/src/chunk_to_commit.rs
+++ b/storage/storage-interface/src/chunk_to_commit.rs
@@ -7,6 +7,7 @@ use crate::state_store::{
     state_update_refs::StateUpdateRefs,
     state_view::cached_state_view::ShardedStateCache,
     state_with_summary::{LedgerStateWithSummary, StateWithSummary},
+    HotStateUpdates,
 };
 use aptos_types::transaction::{
     PersistedAuxiliaryInfo, Transaction, TransactionInfo, TransactionOutput, Version,
@@ -23,6 +24,7 @@ pub struct ChunkToCommit<'a> {
     pub state_summary: &'a LedgerStateSummary,
     pub state_update_refs: &'a StateUpdateRefs<'a>,
     pub state_reads: &'a ShardedStateCache,
+    pub hot_state_updates: &'a HotStateUpdates,
     pub is_reconfig: bool,
 }
 

--- a/storage/storage-interface/src/state_store/mod.rs
+++ b/storage/storage-interface/src/state_store/mod.rs
@@ -10,18 +10,27 @@ pub mod state_view;
 pub mod state_with_summary;
 pub mod versioned_state_value;
 
-use aptos_types::state_store::{hot_state::HotStateValue, state_key::StateKey, NUM_STATE_SHARDS};
-use std::collections::{HashMap, HashSet};
+use aptos_types::{
+    state_store::{hot_state::HotStateValue, state_key::StateKey, NUM_STATE_SHARDS},
+    transaction::Version,
+};
+use std::collections::HashMap;
 
 #[derive(Debug)]
-pub(crate) struct HotStateShardUpdates {
-    insertions: HashMap<StateKey, HotStateValue>,
-    // TODO(HotState): only keys are needed for now, since evictions do not affect cold state.
-    evictions: HashSet<StateKey>,
+pub struct HotStateShardUpdates {
+    /// Each insertion carries the `HotStateValue` and an optional `value_version`.
+    /// `value_version` is `Some(version)` for occupied entries and `None` for vacant.
+    pub insertions: HashMap<StateKey, (HotStateValue, Option<Version>)>,
+    /// Each eviction carries the checkpoint version at which eviction happened.
+    // TODO(HotState): per-block eviction tracking will be needed for cold-write elimination.
+    pub evictions: HashMap<StateKey, Version>,
 }
 
 impl HotStateShardUpdates {
-    pub fn new(insertions: HashMap<StateKey, HotStateValue>, evictions: HashSet<StateKey>) -> Self {
+    pub fn new(
+        insertions: HashMap<StateKey, (HotStateValue, Option<Version>)>,
+        evictions: HashMap<StateKey, Version>,
+    ) -> Self {
         Self {
             insertions,
             evictions,
@@ -31,8 +40,8 @@ impl HotStateShardUpdates {
 
 #[derive(Debug)]
 pub struct HotStateUpdates {
-    for_last_checkpoint: Option<[HotStateShardUpdates; NUM_STATE_SHARDS]>,
-    for_latest: Option<[HotStateShardUpdates; NUM_STATE_SHARDS]>,
+    pub for_last_checkpoint: Option<[HotStateShardUpdates; NUM_STATE_SHARDS]>,
+    pub for_latest: Option<[HotStateShardUpdates; NUM_STATE_SHARDS]>,
 }
 
 impl HotStateUpdates {

--- a/storage/storage-interface/src/state_store/state.rs
+++ b/storage/storage-interface/src/state_store/state.rs
@@ -34,11 +34,7 @@ use arr_macro::arr;
 use derive_more::Deref;
 use itertools::Itertools;
 use rayon::prelude::*;
-use std::{
-    collections::{HashMap, HashSet},
-    num::NonZeroUsize,
-    sync::Arc,
-};
+use std::{collections::HashMap, num::NonZeroUsize, sync::Arc};
 
 #[derive(Clone, Debug, Default)]
 pub struct HotStateMetadata {
@@ -217,13 +213,13 @@ impl State {
                     );
                     let mut all_updates = per_version.iter();
                     let mut insertions = HashMap::new();
-                    let mut evictions = HashSet::new();
+                    let mut evictions = HashMap::new();
                     for ckpt_version in all_checkpoint_versions {
                         for (key, update) in
                             all_updates.take_while_ref(|(_k, u)| u.version <= *ckpt_version)
                         {
                             evictions.remove(*key);
-                            if let Some(hot_state_value) = Self::apply_one_update(
+                            if let Some(insertion) = Self::apply_one_update(
                                 &mut lru,
                                 overlay,
                                 cache,
@@ -231,19 +227,19 @@ impl State {
                                 update,
                                 self.hot_state_config.refresh_interval_versions,
                             ) {
-                                insertions.insert((*key).clone(), hot_state_value);
+                                insertions.insert((*key).clone(), insertion);
                             }
                         }
                         // Only evict at the checkpoints.
-                        evictions.extend(lru.maybe_evict().into_iter().map(|(key, slot)| {
+                        for (key, slot) in lru.maybe_evict() {
                             insertions.remove(&key);
                             assert!(slot.is_hot());
-                            key
-                        }));
+                            evictions.insert(key, *ckpt_version);
+                        }
                     }
                     for (key, update) in all_updates {
                         evictions.remove(*key);
-                        if let Some(hot_state_value) = Self::apply_one_update(
+                        if let Some(insertion) = Self::apply_one_update(
                             &mut lru,
                             overlay,
                             cache,
@@ -251,7 +247,7 @@ impl State {
                             update,
                             self.hot_state_config.refresh_interval_versions,
                         ) {
-                            insertions.insert((*key).clone(), hot_state_value);
+                            insertions.insert((*key).clone(), insertion);
                         }
                     }
 
@@ -293,9 +289,9 @@ impl State {
         ))
     }
 
-    /// Applies the update the returns the `HotStateValue` that will later go into the hot state
-    /// Merkle tree. `None` if the op is `MakeHot` and it's determined that refresh is not
-    /// necessary.
+    /// Applies the update and returns `(HotStateValue, Option<value_version>)` that will later
+    /// go into the hot state Merkle tree and DB. `None` if the op is `MakeHot` and it's
+    /// determined that refresh is not necessary.
     fn apply_one_update(
         lru: &mut HotStateLRU,
         overlay: &LayeredMap<StateKey, StateSlot>,
@@ -303,10 +299,14 @@ impl State {
         key: &StateKey,
         update: &StateUpdateRef,
         refresh_interval: Version,
-    ) -> Option<HotStateValue> {
+    ) -> Option<(HotStateValue, Option<Version>)> {
         if let Some(state_value_opt) = update.state_op.as_state_value_opt() {
             lru.insert((*key).clone(), update.to_result_slot().unwrap());
-            return Some(HotStateValue::new(state_value_opt.cloned(), update.version));
+            let value_version = state_value_opt.map(|_| update.version);
+            return Some((
+                HotStateValue::new(state_value_opt.cloned(), update.version),
+                value_version,
+            ));
         }
 
         if let Some(mut slot) = lru.get_slot(key) {
@@ -322,19 +322,21 @@ impl State {
                 slot.to_hot(update.version)
             };
             if refreshed {
+                let value_version = slot_to_insert.value_version_opt();
                 let ret = HotStateValue::clone_from_slot(&slot_to_insert);
                 lru.insert((*key).clone(), slot_to_insert);
-                Some(ret)
+                Some((ret, value_version))
             } else {
                 None
             }
         } else {
             let slot = Self::expect_old_slot(overlay, read_cache, key);
             assert!(slot.is_cold());
+            let value_version = slot.value_version_opt();
             let slot = slot.to_hot(update.version);
             let ret = HotStateValue::clone_from_slot(&slot);
             lru.insert((*key).clone(), slot);
-            Some(ret)
+            Some((ret, value_version))
         }
     }
 

--- a/storage/storage-interface/src/state_store/state_summary.rs
+++ b/storage/storage-interface/src/state_store/state_summary.rs
@@ -140,8 +140,8 @@ impl StateSummary {
                 shard
                     .insertions
                     .iter()
-                    .map(|(k, value)| (k, Some(value.hash())))
-                    .chain(shard.evictions.iter().map(|k| (k, None)))
+                    .map(|(k, (value, _))| (k, Some(value.hash())))
+                    .chain(shard.evictions.keys().map(|k| (k, None)))
                     .sorted_by_key(|(k, _)| k.crypto_hash_ref())
                     .collect_vec()
             })

--- a/types/src/state_store/hot_state.rs
+++ b/types/src/state_store/hot_state.rs
@@ -57,6 +57,14 @@ impl HotStateValue {
         }
     }
 
+    pub fn hot_since_version(&self) -> Version {
+        self.hot_since_version
+    }
+
+    pub fn value_opt(&self) -> Option<&StateValue> {
+        self.value.as_ref()
+    }
+
     pub fn clone_from_slot(slot: &StateSlot) -> Self {
         match slot {
             StateSlot::HotOccupied {

--- a/types/src/state_store/state_slot.rs
+++ b/types/src/state_store/state_slot.rs
@@ -185,13 +185,17 @@ impl StateSlot {
         }
     }
 
-    pub fn expect_value_version(&self) -> Version {
+    pub fn value_version_opt(&self) -> Option<Version> {
         match self {
-            ColdVacant | HotVacant { .. } => unreachable!("expecting occupied"),
+            ColdVacant | HotVacant { .. } => None,
             ColdOccupied { value_version, .. } | HotOccupied { value_version, .. } => {
-                *value_version
+                Some(*value_version)
             },
         }
+    }
+
+    pub fn expect_value_version(&self) -> Version {
+        self.value_version_opt().expect("expecting occupied")
     }
 
     pub fn to_hot(self, hot_since_version: Version) -> Self {


### PR DESCRIPTION

Wire the hot state KV write path end-to-end so that hot state changes
are persisted to `hot_state_kv_db` during `pre_commit_ledger`.

The schema value is `Option<HotStateKvValue>` — `Some(Occupied{..})` or
`Some(Vacant)` for insertions/refreshes, `None` for evictions.
`HotStateShardUpdates` is enriched with `value_version` on insertions and
checkpoint version on evictions so the DB entries carry all the
information needed for reconstruction on load.

Hot state KV batches are built alongside cold state KV batches and
committed in parallel within the same rayon scope, mirroring the existing
cold state pattern.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the storage write path and introduces a new RocksDB column family/schema for persisting hot-state changes; bugs could affect commit correctness or introduce write amplification, though changes are scoped to the new hot-state DB and include targeted tests.
> 
> **Overview**
> **Persists hot-state KV changes to disk during transaction pre-commit.** `ChunkToCommit` now carries `hot_state_updates`, which `AptosDB::pre_commit_ledger` writes into the `hot_state_kv_db` in parallel with the existing cold `state_kv_db` commits.
> 
> Adds a dedicated hot-state KV RocksDB schema/CF (`HOT_STATE_VALUE_BY_KEY_HASH_CF_NAME`) storing `Option<HotStateEntry>` to represent insert/refresh (`Occupied`/`Vacant`) vs eviction (`None`), updates `HotStateShardUpdates` to include `value_version` for insertions and checkpoint version for evictions, and adds tests plus hot-db opening/CFD wiring to support the new persistence path.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 79055791964f488c1110a7a14138e402a26e4c1d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->