### PR TITLE
[storage] Add API to load hot state KVs from DB on restart

### DIFF
--- a/storage/aptosdb/src/state_kv_db.rs
+++ b/storage/aptosdb/src/state_kv_db.rs
@@ -3,13 +3,12 @@
 
 #![forbid(unsafe_code)]
 
-#[cfg(test)]
-use crate::schema::hot_state_value_by_key_hash::{HotStateEntry, HotStateValueByKeyHashSchema};
 use crate::{
     db_options::{gen_hot_state_kv_shard_cfds, gen_state_kv_shard_cfds},
     metrics::OTHER_TIMERS_SECONDS,
     schema::{
         db_metadata::{DbMetadataKey, DbMetadataSchema, DbMetadataValue},
+        hot_state_value_by_key_hash::{HotStateEntry, HotStateValueByKeyHashSchema},
         state_value_by_key_hash::StateValueByKeyHashSchema,
     },
     utils::{
@@ -18,7 +17,7 @@ use crate::{
     },
 };
 use aptos_config::config::{RocksdbConfig, StorageDirPaths};
-use aptos_crypto::hash::CryptoHash;
+use aptos_crypto::{hash::CryptoHash, HashValue};
 use aptos_experimental_runtimes::thread_manager::THREAD_MANAGER;
 use aptos_logger::prelude::info;
 use aptos_metrics_core::TimerHelper;
@@ -29,13 +28,21 @@ use aptos_schemadb::{
 };
 use aptos_storage_interface::Result;
 use aptos_types::{
-    state_store::{state_key::StateKey, state_value::StateValue, NUM_STATE_SHARDS},
+    state_store::{
+        hot_state::{LRUEntry, THotStateSlot},
+        state_key::StateKey,
+        state_slot::{StateSlot, StateSlotKind},
+        state_value::StateValue,
+        NUM_STATE_SHARDS,
+    },
     transaction::Version,
 };
+use dashmap::DashMap;
 use rayon::prelude::*;
 use std::{
     path::{Path, PathBuf},
     sync::Arc,
+    time::Instant,
 };
 
 fn db_folder_name(is_hot: bool) -> &'static str {
@@ -407,5 +414,239 @@ impl StateKvDb {
             .next()
             .transpose()?
             .map(|((_, version), entry_opt)| (version, entry_opt)))
+    }
+
+    /// Loads all hot state KV entries from the DB, given the most recently committed version.
+    ///
+    /// All entries in the DB must have `hot_since_version <= committed_version` (crash recovery
+    /// truncation is assumed to have already run). For each unique key hash, picks the most
+    /// recent entry. Evicted entries are excluded. The returned shards have correctly assembled
+    /// LRU doubly-linked list pointers, ordered by `hot_since_version`.
+    #[allow(dead_code)]
+    pub(crate) fn load_hot_state_kvs(
+        &self,
+        committed_version: Version,
+    ) -> Result<[LoadedHotStateShard; NUM_STATE_SHARDS]> {
+        assert!(
+            self.is_hot,
+            "load_hot_state_kvs can only be called on hot state KV DB"
+        );
+
+        let start = Instant::now();
+
+        let shards: [_; NUM_STATE_SHARDS] = (0..NUM_STATE_SHARDS)
+            .into_par_iter()
+            .map(|shard_id| self.load_shard(shard_id, committed_version))
+            .collect::<Result<Vec<_>>>()?
+            .try_into()
+            .expect("Collected exactly NUM_STATE_SHARDS results");
+
+        let total_items: usize = shards.iter().map(|s| s.num_items).sum();
+        let elapsed = start.elapsed();
+        info!(
+            total_items = total_items,
+            duration_ms = elapsed.as_millis() as u64,
+            shard_counts = ?shards.iter().map(|s| s.num_items).collect::<Vec<_>>(),
+            "Loaded hot state KVs from DB.",
+        );
+
+        Ok(shards)
+    }
+
+    fn load_shard(
+        &self,
+        shard_id: usize,
+        committed_version: Version,
+    ) -> Result<LoadedHotStateShard> {
+        let entries = self.scan_shard_entries(shard_id, committed_version)?;
+        let loaded = Self::assemble_lru_chain(entries);
+        Ok(loaded)
+    }
+
+    // TODO(HotState): The current implementation does a full scan per shard. This can be
+    // further sped up (e.g. parallel within-shard scan, prefix-seek per key group, or maintaining
+    // a separate index), but is left for later since correctness matters more at this stage.
+    /// Scans a single shard DB and returns the most recent hot entry per key_hash.
+    /// Evicted keys are excluded. The returned entries have uninitialized LRU pointers.
+    fn scan_shard_entries(
+        &self,
+        shard_id: usize,
+        committed_version: Version,
+    ) -> Result<Vec<(HashValue, Version, StateSlotKind)>> {
+        let mut iter = self
+            .db_shard(shard_id)
+            .iter::<HotStateValueByKeyHashSchema>()?;
+        iter.seek_to_first();
+
+        let mut entries = Vec::new();
+        let mut current_key_hash: Option<HashValue> = None;
+        let mut found_for_current = false;
+
+        for item in iter {
+            let ((key_hash, hot_since_version), entry_opt) = item?;
+
+            // After crash recovery truncation, no entry should exist beyond the
+            // committed version.
+            assert!(
+                hot_since_version <= committed_version,
+                "Entry {key_hash} has hot_since_version {hot_since_version} > \
+                 committed_version {committed_version}; \
+                 DB should have been truncated during crash recovery.",
+            );
+
+            // New key group?
+            if current_key_hash != Some(key_hash) {
+                current_key_hash = Some(key_hash);
+                found_for_current = false;
+            }
+
+            if found_for_current {
+                continue;
+            }
+
+            // This is the most recent entry for this key_hash.
+            found_for_current = true;
+
+            let kind = match entry_opt {
+                None => continue, // Evicted — not hot.
+                Some(HotStateEntry::Occupied {
+                    value,
+                    value_version,
+                }) => StateSlotKind::HotOccupied {
+                    value_version,
+                    value,
+                    hot_since_version,
+                    lru_info: LRUEntry::uninitialized(),
+                },
+                Some(HotStateEntry::Vacant) => StateSlotKind::HotVacant {
+                    hot_since_version,
+                    lru_info: LRUEntry::uninitialized(),
+                },
+            };
+
+            entries.push((key_hash, hot_since_version, kind));
+        }
+
+        Ok(entries)
+    }
+
+    /// Sorts entries by `(hot_since_version, key_hash)`, assembles LRU doubly-linked list
+    /// pointers, and builds the `DashMap`. Validates the chain before returning.
+    fn assemble_lru_chain(
+        mut entries: Vec<(HashValue, Version, StateSlotKind)>,
+    ) -> LoadedHotStateShard {
+        // Sort by (hot_since_version, key_hash) ascending.
+        // Index 0 = oldest (LRU tail), last = newest (MRU head).
+        entries.sort_by(|a, b| (a.1, a.0).cmp(&(b.1, b.0)));
+
+        let num_items = entries.len();
+        let map = DashMap::with_capacity(num_items);
+
+        // Collect key_hashes for neighbor lookups before consuming entries.
+        let key_hashes: Vec<_> = entries.iter().map(|(kh, _, _)| *kh).collect();
+
+        for (i, (key_hash, _hot_since_version, kind)) in entries.into_iter().enumerate() {
+            let prev = if i + 1 < num_items {
+                Some(key_hashes[i + 1])
+            } else {
+                None
+            };
+            let next = if i > 0 { Some(key_hashes[i - 1]) } else { None };
+            let slot =
+                StateSlot::new_without_state_key(kind.with_lru_info(LRUEntry { prev, next }));
+            map.insert(key_hash, slot);
+        }
+
+        let head = key_hashes.last().copied();
+        let tail = key_hashes.first().copied();
+
+        let loaded = LoadedHotStateShard {
+            map,
+            head,
+            tail,
+            num_items,
+        };
+        loaded.validate_lru_chain();
+        loaded
+    }
+}
+
+/// Per-shard data recovered from the hot state KV DB.
+#[allow(dead_code)]
+#[derive(Debug)]
+pub(crate) struct LoadedHotStateShard {
+    /// All hot entries keyed by state key hash.
+    pub map: DashMap<HashValue, StateSlot>,
+    /// The newest (MRU) entry's key hash. `None` if the shard is empty.
+    pub head: Option<HashValue>,
+    /// The oldest (LRU) entry's key hash. `None` if the shard is empty.
+    pub tail: Option<HashValue>,
+    /// Total number of items in this shard.
+    pub num_items: usize,
+}
+
+impl LoadedHotStateShard {
+    /// Validates the LRU doubly-linked list by traversing in both directions and
+    /// checking bidirectional pointer consistency.
+    pub fn validate_lru_chain(&self) {
+        if self.num_items == 0 {
+            assert!(self.head.is_none(), "empty shard must have head=None");
+            assert!(self.tail.is_none(), "empty shard must have tail=None");
+            assert!(self.map.is_empty(), "empty shard must have empty map");
+            return;
+        }
+
+        assert!(self.head.is_some(), "non-empty shard must have head");
+        assert!(self.tail.is_some(), "non-empty shard must have tail");
+        assert_eq!(self.map.len(), self.num_items, "map.len() != num_items");
+
+        // Traverse head → tail (following `next` pointers), verifying prev backlinks.
+        let mut count = 0;
+        let mut prev_key: Option<HashValue> = None;
+        let mut current = self.head;
+        while let Some(key_hash) = current {
+            let slot = self
+                .map
+                .get(&key_hash)
+                .unwrap_or_else(|| panic!("LRU chain: key {key_hash} not found in map"));
+            assert!(slot.is_hot(), "LRU chain: entry {key_hash} is not hot");
+            assert_eq!(
+                slot.prev().copied(),
+                prev_key,
+                "prev pointer mismatch at {key_hash}"
+            );
+            prev_key = Some(key_hash);
+            current = slot.next().copied();
+            count += 1;
+        }
+        assert_eq!(
+            count, self.num_items,
+            "LRU chain head→tail traversal visited {count} entries, expected {}",
+            self.num_items,
+        );
+
+        // Traverse tail → head (following `prev` pointers), verifying next backlinks.
+        count = 0;
+        let mut next_key: Option<HashValue> = None;
+        current = self.tail;
+        while let Some(key_hash) = current {
+            let slot = self
+                .map
+                .get(&key_hash)
+                .unwrap_or_else(|| panic!("LRU chain (reverse): key {key_hash} not found in map"));
+            assert_eq!(
+                slot.next().copied(),
+                next_key,
+                "next pointer mismatch at {key_hash}"
+            );
+            next_key = Some(key_hash);
+            current = slot.prev().copied();
+            count += 1;
+        }
+        assert_eq!(
+            count, self.num_items,
+            "LRU chain tail→head traversal visited {count} entries, expected {}",
+            self.num_items,
+        );
     }
 }

--- a/storage/aptosdb/src/state_store/state_snapshot_committer.rs
+++ b/storage/aptosdb/src/state_store/state_snapshot_committer.rs
@@ -114,7 +114,7 @@ impl StateSnapshotCommitter {
                                         key_hash,
                                         Some((
                                             HotStateValueRef::from_slot(&slot).hash(),
-                                            slot.state_key().clone(),
+                                            slot.expect_state_key().clone(),
                                         )),
                                     ));
                                 } else {

--- a/storage/aptosdb/src/state_store/tests/hot_state_kv.rs
+++ b/storage/aptosdb/src/state_store/tests/hot_state_kv.rs
@@ -4,16 +4,20 @@
 use crate::{
     db::AptosDB,
     schema::hot_state_value_by_key_hash::{HotStateEntry, HotStateValueByKeyHashSchema},
-    state_kv_db::StateKvDb,
+    state_kv_db::{LoadedHotStateShard, StateKvDb},
 };
 use aptos_config::config::{RocksdbConfig, StorageDirPaths};
-use aptos_crypto::hash::CryptoHash;
+use aptos_crypto::{hash::CryptoHash, HashValue};
 use aptos_schemadb::batch::WriteBatch;
 use aptos_storage_interface::state_store::{HotStateShardUpdates, HotStateUpdates};
 use aptos_temppath::TempPath;
 use aptos_types::{
     state_store::{
-        hot_state::HotStateValue, state_key::StateKey, state_value::StateValue, NUM_STATE_SHARDS,
+        hot_state::{HotStateValue, THotStateSlot},
+        state_key::StateKey,
+        state_slot::StateSlotKind,
+        state_value::StateValue,
+        NUM_STATE_SHARDS,
     },
     transaction::Version,
 };
@@ -220,4 +224,405 @@ fn test_put_hot_state_updates_integration() {
         get_hot_state_entry(hot_state_kv_db, &key3, 300).is_none(),
         "Eviction should be None"
     );
+}
+
+// ---------------------------------------------------------------------------
+// load_hot_state_kvs tests
+// ---------------------------------------------------------------------------
+
+/// Collect the LRU chain from head→tail as a list of (key_hash, hot_since_version).
+fn collect_lru_order(shard: &LoadedHotStateShard) -> Vec<(HashValue, Version)> {
+    let mut result = Vec::new();
+    let mut current = shard.head;
+    while let Some(kh) = current {
+        let slot = shard.map.get(&kh).unwrap();
+        let hsv = slot.expect_hot_since_version();
+        result.push((kh, hsv));
+        current = slot.next().copied();
+    }
+    result
+}
+
+#[test]
+fn test_load_empty_db() {
+    let tmp = TempPath::new();
+    let db = create_hot_state_kv_db(&tmp);
+
+    let shards = db.load_hot_state_kvs(100).unwrap();
+    for shard in &shards {
+        assert_eq!(shard.num_items, 0);
+        assert!(shard.head.is_none());
+        assert!(shard.tail.is_none());
+        assert!(shard.map.is_empty());
+    }
+}
+
+#[test]
+fn test_load_single_entry() {
+    let tmp = TempPath::new();
+    let db = create_hot_state_kv_db(&tmp);
+
+    let key = make_state_key(1);
+    let key_hash = CryptoHash::hash(&key);
+    put_hot_state_entry(
+        &db,
+        &key,
+        10,
+        Some(HotStateEntry::Occupied {
+            value: make_state_value(1),
+            value_version: 5,
+        }),
+    );
+
+    let shards = db.load_hot_state_kvs(100).unwrap();
+    let shard = &shards[key.get_shard_id()];
+    assert_eq!(shard.num_items, 1);
+    assert_eq!(shard.head, Some(key_hash));
+    assert_eq!(shard.tail, Some(key_hash));
+
+    let slot = shard.map.get(&key_hash).unwrap();
+    assert!(slot.is_hot());
+    assert!(slot.prev().is_none()); // Only entry: head.
+    assert!(slot.next().is_none()); // Only entry: tail.
+    match slot.kind() {
+        StateSlotKind::HotOccupied {
+            value_version,
+            value,
+            hot_since_version,
+            ..
+        } => {
+            assert_eq!(*value_version, 5);
+            assert_eq!(*value, make_state_value(1));
+            assert_eq!(*hot_since_version, 10);
+        },
+        other => panic!("Expected HotOccupied, got {other:?}"),
+    }
+    shard.validate_lru_chain();
+}
+
+#[test]
+fn test_load_occupied_and_vacant() {
+    let tmp = TempPath::new();
+    let db = create_hot_state_kv_db(&tmp);
+
+    let key_occ = make_state_key(10);
+    put_hot_state_entry(
+        &db,
+        &key_occ,
+        100,
+        Some(HotStateEntry::Occupied {
+            value: make_state_value(10),
+            value_version: 50,
+        }),
+    );
+
+    let key_vac = make_state_key(20);
+    put_hot_state_entry(&db, &key_vac, 200, Some(HotStateEntry::Vacant));
+
+    let shards = db.load_hot_state_kvs(300).unwrap();
+
+    // Check occupied.
+    let shard_occ = &shards[key_occ.get_shard_id()];
+    let slot_occ = shard_occ.map.get(&CryptoHash::hash(&key_occ)).unwrap();
+    assert!(matches!(slot_occ.kind(), StateSlotKind::HotOccupied { .. }));
+    shard_occ.validate_lru_chain();
+
+    // Check vacant.
+    let shard_vac = &shards[key_vac.get_shard_id()];
+    let slot_vac = shard_vac.map.get(&CryptoHash::hash(&key_vac)).unwrap();
+    assert!(matches!(slot_vac.kind(), StateSlotKind::HotVacant { .. }));
+    shard_vac.validate_lru_chain();
+}
+
+#[test]
+fn test_load_evicted_excluded() {
+    let tmp = TempPath::new();
+    let db = create_hot_state_kv_db(&tmp);
+
+    let key = make_state_key(5);
+    // Insert at V10, evict at V20.
+    put_hot_state_entry(
+        &db,
+        &key,
+        10,
+        Some(HotStateEntry::Occupied {
+            value: make_state_value(5),
+            value_version: 3,
+        }),
+    );
+    put_hot_state_entry(&db, &key, 20, None);
+
+    let shards = db.load_hot_state_kvs(100).unwrap();
+    let shard = &shards[key.get_shard_id()];
+    // The key's most recent entry is an eviction — should not appear.
+    assert!(!shard.map.contains_key(&CryptoHash::hash(&key)));
+}
+
+#[test]
+fn test_load_at_exact_committed_version() {
+    let tmp = TempPath::new();
+    let db = create_hot_state_kv_db(&tmp);
+
+    let key = make_state_key(6);
+    put_hot_state_entry(
+        &db,
+        &key,
+        50,
+        Some(HotStateEntry::Occupied {
+            value: make_state_value(6),
+            value_version: 40,
+        }),
+    );
+
+    // Load at the committed version — entry should appear.
+    let shards = db.load_hot_state_kvs(50).unwrap();
+    assert!(shards[key.get_shard_id()]
+        .map
+        .contains_key(&CryptoHash::hash(&key)));
+}
+
+#[test]
+fn test_load_multiple_versions_same_key() {
+    let tmp = TempPath::new();
+    let db = create_hot_state_kv_db(&tmp);
+
+    let key = make_state_key(7);
+    // V10: occupied with value_version=5
+    put_hot_state_entry(
+        &db,
+        &key,
+        10,
+        Some(HotStateEntry::Occupied {
+            value: make_state_value(71),
+            value_version: 5,
+        }),
+    );
+    // V20: refresh — same value but new hot_since_version
+    put_hot_state_entry(
+        &db,
+        &key,
+        20,
+        Some(HotStateEntry::Occupied {
+            value: make_state_value(72),
+            value_version: 15,
+        }),
+    );
+
+    // Load at V20 — should pick V20 (the most recent entry).
+    let shards = db.load_hot_state_kvs(20).unwrap();
+    let shard = &shards[key.get_shard_id()];
+    let slot = shard.map.get(&CryptoHash::hash(&key)).unwrap();
+    match slot.kind() {
+        StateSlotKind::HotOccupied {
+            value_version,
+            hot_since_version,
+            value,
+            ..
+        } => {
+            assert_eq!(*hot_since_version, 20);
+            assert_eq!(*value_version, 15);
+            assert_eq!(*value, make_state_value(72));
+        },
+        other => panic!("Expected HotOccupied, got {other:?}"),
+    }
+    shard.validate_lru_chain();
+}
+
+#[test]
+fn test_load_evict_then_reinsert() {
+    let tmp = TempPath::new();
+    let db = create_hot_state_kv_db(&tmp);
+
+    let key = make_state_key(8);
+    // V10: insert.
+    put_hot_state_entry(
+        &db,
+        &key,
+        10,
+        Some(HotStateEntry::Occupied {
+            value: make_state_value(81),
+            value_version: 5,
+        }),
+    );
+    // V20: evict.
+    put_hot_state_entry(&db, &key, 20, None);
+    // V30: re-insert.
+    put_hot_state_entry(
+        &db,
+        &key,
+        30,
+        Some(HotStateEntry::Occupied {
+            value: make_state_value(82),
+            value_version: 25,
+        }),
+    );
+
+    // Load at V30 — should pick the re-insertion (most recent entry).
+    let shards = db.load_hot_state_kvs(30).unwrap();
+    let shard = &shards[key.get_shard_id()];
+    let slot = shard.map.get(&CryptoHash::hash(&key)).unwrap();
+    match slot.kind() {
+        StateSlotKind::HotOccupied {
+            hot_since_version,
+            value,
+            ..
+        } => {
+            assert_eq!(*hot_since_version, 30);
+            assert_eq!(*value, make_state_value(82));
+        },
+        other => panic!("Expected HotOccupied, got {other:?}"),
+    }
+    shard.validate_lru_chain();
+}
+
+#[test]
+fn test_load_lru_chain_ordering() {
+    let tmp = TempPath::new();
+    let db = create_hot_state_kv_db(&tmp);
+
+    // Insert several keys with distinct hot_since_versions into the same shard.
+    // We use seeds that happen to hash to the same shard.
+    // Since we can't predict shards, insert many keys and test whichever shard has > 1 entry.
+    let mut keys_by_shard: Vec<Vec<(StateKey, Version)>> =
+        (0..NUM_STATE_SHARDS).map(|_| Vec::new()).collect();
+
+    for seed in 0..50u8 {
+        let key = make_state_key(seed);
+        let shard_id = key.get_shard_id();
+        let hot_since = (seed as u64 + 1) * 10;
+        put_hot_state_entry(
+            &db,
+            &key,
+            hot_since,
+            Some(HotStateEntry::Occupied {
+                value: make_state_value(seed),
+                value_version: hot_since.saturating_sub(5),
+            }),
+        );
+        keys_by_shard[shard_id].push((key, hot_since));
+    }
+
+    let shards = db.load_hot_state_kvs(1000).unwrap();
+
+    for (shard_id, shard_keys) in keys_by_shard.iter().enumerate() {
+        let shard = &shards[shard_id];
+        assert_eq!(shard.num_items, shard_keys.len());
+        shard.validate_lru_chain();
+
+        if shard_keys.len() > 1 {
+            // Verify ordering: head→tail should be descending hot_since_version.
+            let chain = collect_lru_order(shard);
+            for pair in chain.windows(2) {
+                assert!(
+                    (pair[0].1, pair[0].0) >= (pair[1].1, pair[1].0),
+                    "LRU chain not in descending hot_since_version order: {:?} followed by {:?}",
+                    pair[0],
+                    pair[1],
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn test_load_cross_shard() {
+    let tmp = TempPath::new();
+    let db = create_hot_state_kv_db(&tmp);
+
+    // Insert keys that go to different shards.
+    let mut expected_per_shard: [usize; NUM_STATE_SHARDS] = [0; NUM_STATE_SHARDS];
+    for seed in 0..32u8 {
+        let key = make_state_key(seed);
+        expected_per_shard[key.get_shard_id()] += 1;
+        put_hot_state_entry(
+            &db,
+            &key,
+            seed as u64 + 1,
+            Some(HotStateEntry::Occupied {
+                value: make_state_value(seed),
+                value_version: 1,
+            }),
+        );
+    }
+
+    let shards = db.load_hot_state_kvs(100).unwrap();
+    for (shard_id, expected) in expected_per_shard.iter().enumerate() {
+        assert_eq!(
+            shards[shard_id].num_items, *expected,
+            "Shard {shard_id} item count mismatch"
+        );
+        shards[shard_id].validate_lru_chain();
+    }
+}
+
+#[test]
+fn test_load_write_then_load_roundtrip() {
+    let tmp = TempPath::new();
+    let aptos_db = AptosDB::new_for_test(&tmp);
+    let hot_state_kv_db = aptos_db.hot_state_kv_db.as_ref().unwrap();
+
+    let key1 = make_state_key(10);
+    let val1 = make_state_value(10);
+    let key2 = make_state_key(20);
+
+    let mut shards: [HotStateShardUpdates; NUM_STATE_SHARDS] =
+        std::array::from_fn(|_| HotStateShardUpdates::new(HashMap::new(), HashMap::new()));
+
+    // key1: occupied at hot_since_version=100, value_version=50
+    shards[key1.get_shard_id()].insertions.insert(
+        *key1.crypto_hash_ref(),
+        (HotStateValue::new(Some(val1.clone()), 100), Some(50)),
+    );
+
+    // key2: vacant at hot_since_version=200
+    shards[key2.get_shard_id()].insertions.insert(
+        *key2.crypto_hash_ref(),
+        (HotStateValue::new(None, 200), None),
+    );
+
+    let hot_state_updates = HotStateUpdates {
+        for_last_checkpoint: Some(shards),
+        for_latest: None,
+    };
+
+    let mut sharded_batches = hot_state_kv_db.new_sharded_native_batches();
+    aptos_db
+        .state_store
+        .put_hot_state_updates(&hot_state_updates, &mut sharded_batches)
+        .unwrap();
+    hot_state_kv_db.commit(999, None, sharded_batches).unwrap();
+
+    // Load back.
+    let loaded_shards = hot_state_kv_db.load_hot_state_kvs(999).unwrap();
+
+    // Verify key1.
+    let shard1 = &loaded_shards[key1.get_shard_id()];
+    let slot1 = shard1.map.get(&CryptoHash::hash(&key1)).unwrap();
+    match slot1.kind() {
+        StateSlotKind::HotOccupied {
+            value_version,
+            value,
+            hot_since_version,
+            ..
+        } => {
+            assert_eq!(*value_version, 50);
+            assert_eq!(*value, val1);
+            assert_eq!(*hot_since_version, 100);
+        },
+        other => panic!("Expected HotOccupied for key1, got {other:?}"),
+    }
+    shard1.validate_lru_chain();
+
+    // Verify key2.
+    let shard2 = &loaded_shards[key2.get_shard_id()];
+    let slot2 = shard2.map.get(&CryptoHash::hash(&key2)).unwrap();
+    match slot2.kind() {
+        StateSlotKind::HotVacant {
+            hot_since_version, ..
+        } => {
+            assert_eq!(*hot_since_version, 200);
+        },
+        other => panic!("Expected HotVacant for key2, got {other:?}"),
+    }
+    shard2.validate_lru_chain();
 }

--- a/storage/storage-interface/src/state_store/hot_state.rs
+++ b/storage/storage-interface/src/state_store/hot_state.rs
@@ -47,16 +47,20 @@ impl<'a> HotStateLRU<'a> {
         }
     }
 
-    pub fn insert(&mut self, key: &StateKey, slot: StateSlot) {
+    pub fn insert(&mut self, key: &StateKey, mut slot: StateSlot) {
         assert!(
             slot.is_hot(),
             "Should not insert cold slots into hot state."
         );
-        assert_eq!(
-            key,
-            slot.state_key(),
+        assert!(
+            slot.state_key().is_none_or(|sk| key == sk),
             "Map key and embedded state_key must match."
         );
+        // Ensure state_key is populated. Slots loaded from the hot state DB don't carry
+        // the full key (only the hash), so patch it here while we have the key available.
+        if slot.state_key().is_none() {
+            slot.set_state_key(key.clone());
+        }
         let key_hash = *key.crypto_hash_ref();
         if self.delete(&key_hash).is_none() {
             self.num_items += 1;

--- a/types/src/state_store/mod.rs
+++ b/types/src/state_store/mod.rs
@@ -147,14 +147,19 @@ impl<K: Eq + Hash> MockStateView<K> {
         }
     }
 
-    // TODO(HotState): StateSlot now embeds a StateKey, but the generic MockStateView
-    // doesn't know how to derive one from K. Uses a placeholder for now; will be
-    // cleaned up when StateSlot.state_key becomes Option<StateKey>.
     pub fn new(data: std::collections::HashMap<K, StateValue>) -> Self {
         Self {
             data: data
                 .into_iter()
-                .map(|(k, v)| (k, StateSlot::from_db_get(StateKey::raw(b""), Some((0, v)))))
+                .map(|(k, v)| {
+                    (
+                        k,
+                        StateSlot::new_without_state_key(StateSlotKind::ColdOccupied {
+                            value_version: 0,
+                            value: v,
+                        }),
+                    )
+                })
                 .collect(),
         }
     }
@@ -173,7 +178,7 @@ impl<K: Clone + Eq + Hash> TStateView for MockStateView<K> {
             .data
             .get(state_key)
             .cloned()
-            .unwrap_or_else(|| StateSlot::new(StateKey::raw(b""), StateSlotKind::ColdVacant)))
+            .unwrap_or_else(|| StateSlot::new_without_state_key(StateSlotKind::ColdVacant)))
     }
 
     fn get_usage(&self) -> StateViewResult<StateStorageUsage> {

--- a/types/src/state_store/state_slot.rs
+++ b/types/src/state_store/state_slot.rs
@@ -14,9 +14,12 @@ use StateSlotKind::*;
 
 /// Represents the content of a state slot along with its key and information about
 /// whether the slot is present in the cold or/and hot state.
+///
+/// `state_key` is `None` when the slot is loaded from the persisted hot state KV DB,
+/// which stores only the key hash, not the full key.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct StateSlot {
-    state_key: StateKey,
+    state_key: Option<StateKey>,
     kind: StateSlotKind,
 }
 
@@ -44,13 +47,61 @@ pub enum StateSlotKind {
     },
 }
 
+impl StateSlotKind {
+    /// Returns a copy of this kind with the LRU info replaced. Panics on cold variants.
+    pub fn with_lru_info(self, lru_info: LRUEntry<HashValue>) -> Self {
+        match self {
+            StateSlotKind::HotOccupied {
+                value_version,
+                value,
+                hot_since_version,
+                ..
+            } => StateSlotKind::HotOccupied {
+                value_version,
+                value,
+                hot_since_version,
+                lru_info,
+            },
+            StateSlotKind::HotVacant {
+                hot_since_version, ..
+            } => StateSlotKind::HotVacant {
+                hot_since_version,
+                lru_info,
+            },
+            _ => panic!("with_lru_info called on cold variant"),
+        }
+    }
+}
+
 impl StateSlot {
     pub fn new(state_key: StateKey, kind: StateSlotKind) -> Self {
-        Self { state_key, kind }
+        Self {
+            state_key: Some(state_key),
+            kind,
+        }
     }
 
-    pub fn state_key(&self) -> &StateKey {
-        &self.state_key
+    /// Creates a `StateSlot` without a `StateKey`. Used when loading from the hot state
+    /// KV DB, which only stores the key hash.
+    pub fn new_without_state_key(kind: StateSlotKind) -> Self {
+        Self {
+            state_key: None,
+            kind,
+        }
+    }
+
+    pub fn state_key(&self) -> Option<&StateKey> {
+        self.state_key.as_ref()
+    }
+
+    pub fn set_state_key(&mut self, state_key: StateKey) {
+        self.state_key = Some(state_key);
+    }
+
+    pub fn expect_state_key(&self) -> &StateKey {
+        self.state_key
+            .as_ref()
+            .expect("StateSlot: state_key is None (loaded from DB without key)")
     }
 
     pub fn kind(&self) -> &StateSlotKind {
@@ -99,10 +150,11 @@ impl StateSlot {
         &self,
         min_version: Version,
     ) -> Option<(HashValue, Option<(HashValue, StateKey)>)> {
+        let state_key = self.expect_state_key();
         self.maybe_update_cold_state(min_version).map(|value_opt| {
             (
-                *self.state_key.crypto_hash_ref(),
-                value_opt.map(|v| (CryptoHash::hash(v), self.state_key.clone())),
+                *state_key.crypto_hash_ref(),
+                value_opt.map(|v| (CryptoHash::hash(v), state_key.clone())),
             )
         })
     }
@@ -116,7 +168,10 @@ impl StateSlot {
                 value,
             },
         };
-        Self { state_key, kind }
+        Self {
+            state_key: Some(state_key),
+            kind,
+        }
     }
 
     pub fn into_state_value_and_version_opt(self) -> Option<(Version, StateValue)> {


### PR DESCRIPTION

Add `StateKvDb::load_hot_state_kvs(version)` which reconstructs the in-memory
hot state from persisted KV data. For each shard (processed in parallel), it
scans `HotStateValueByKeyHashSchema` entries, finds the most recent
`hot_since_version <= version` per key hash, excludes evicted keys, and
assembles the LRU doubly-linked list pointers by sorting on
`(hot_since_version, key_hash)`.

Returns `[LoadedHotStateShard; NUM_STATE_SHARDS]` containing a `DashMap` plus
per-shard LRU metadata (head, tail, num_items). Includes chain validation
assertions that traverse both directions.

Also makes `StateSlot.state_key` optional (`Option<StateKey>`) since the DB
schema only stores key hashes, not full keys. Existing callers are unaffected
(`StateSlot::new` wraps in `Some`); the load path uses
`StateSlot::new_without_state_key`.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core state-slot types and hot state persistence/recovery paths; incorrect reconstruction or missing `state_key` population could break hot state behavior or JMT updates despite added validation and tests.
> 
> **Overview**
> Adds `StateKvDb::load_hot_state_kvs(committed_version)` to rebuild in-memory hot state from the persisted hot-state KV shards on restart by scanning for the latest non-evicted entry per key hash, then sorting by `hot_since_version` to reassemble and validate the per-shard LRU chain (returned as `LoadedHotStateShard` with a `DashMap`, `head`/`tail`, and counts).
> 
> Updates `StateSlot` to store `state_key` as `Option<StateKey>` (with `new_without_state_key`, `expect_state_key`, and `StateSlotKind::with_lru_info`) to support DB-loaded hot entries that only have key hashes, and adjusts hot-state insertion and snapshot commit code to populate/require keys as needed. Expands hot-state KV tests to cover load/ordering/eviction and write→load roundtrips.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eb3fad108e0bab399a610c0485bc0c838a96cbcc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->