### PR TITLE
[execution] Fix executor benchmark failing with >10M accounts

### DIFF
--- a/execution/executor-benchmark/src/transaction_generator.rs
+++ b/execution/executor-benchmark/src/transaction_generator.rs
@@ -37,8 +37,6 @@ use rayon::{
     ThreadPool, ThreadPoolBuilder,
 };
 use serde::{Deserialize, Serialize};
-#[cfg(test)]
-use std::collections::HashSet;
 use std::{
     cell::RefCell,
     collections::{BTreeMap, HashMap},
@@ -591,11 +589,6 @@ impl TransactionGenerator {
             .collect::<Vec<_>>()
             .chunks(block_size)
         {
-            // Refresh root account sequence number once per block from database
-            // This ensures we stay in sync even if BlockMetadata or other transactions affected the account
-            let current_seq_num = get_sequence_number(self.root_account.address(), reader.clone());
-            self.root_account.set_sequence_number(current_seq_num);
-
             let transactions: Vec<_> = chunk
                 .iter()
                 .map(|new_account| {
@@ -1051,58 +1044,149 @@ fn rand_with_hotspot<R: Rng>(rng: &mut R, n: usize, h: usize) -> usize {
     }
 }
 
-#[test]
-fn test_get_conflicting_grps_transfer_indices() {
-    let mut rng = StdRng::from_entropy();
+#[cfg(test)]
+mod tests {
+    use super::{BenchmarkTimestamp, TransactionGenerator};
+    use crate::{db_generator::bootstrap_with_genesis, default_benchmark_features, init_db};
+    use aptos_config::config::NO_OP_STORAGE_PRUNER_CONFIG;
+    use aptos_temppath::TempPath;
+    use aptos_types::{account_config::aptos_test_root_address, transaction::Transaction};
+    use rand::{rngs::StdRng, SeedableRng};
+    use std::{
+        collections::{HashMap, HashSet},
+        fs,
+        sync::{mpsc, Arc},
+    };
 
-    fn dfs(node: usize, adj_list: &HashMap<usize, HashSet<usize>>, visited: &mut HashSet<usize>) {
-        visited.insert(node);
-        for &n in adj_list.get(&node).unwrap() {
-            if !visited.contains(&n) {
-                dfs(n, adj_list, visited);
+    #[test]
+    fn test_get_conflicting_grps_transfer_indices() {
+        let mut rng = StdRng::from_entropy();
+
+        fn dfs(
+            node: usize,
+            adj_list: &HashMap<usize, HashSet<usize>>,
+            visited: &mut HashSet<usize>,
+        ) {
+            visited.insert(node);
+            for &n in adj_list.get(&node).unwrap() {
+                if !visited.contains(&n) {
+                    dfs(n, adj_list, visited);
+                }
+            }
+        }
+
+        fn get_num_connected_components(adj_list: &HashMap<usize, HashSet<usize>>) -> usize {
+            let mut visited = HashSet::new();
+            let mut num_connected_components = 0;
+            for node in adj_list.keys() {
+                if !visited.contains(node) {
+                    dfs(*node, adj_list, &mut visited);
+                    num_connected_components += 1;
+                }
+            }
+            num_connected_components
+        }
+
+        {
+            let block_size = 100;
+            let num_signer_accounts = 1000;
+            // we check for (i) block_size not divisible by connected_txn_grps (ii) when divisible
+            // (iii) when all txns in the block are independent (iv) all txns are dependent
+            for connected_txn_grps in [3, block_size / 10, block_size, 1] {
+                let transfer_indices = TransactionGenerator::get_conflicting_grps_transfer_indices(
+                    &mut rng,
+                    num_signer_accounts,
+                    block_size,
+                    connected_txn_grps,
+                    true,
+                );
+
+                let mut adj_list: HashMap<usize, HashSet<usize>> = HashMap::new();
+                assert_eq!(
+                    transfer_indices.len(),
+                    (block_size / connected_txn_grps) * connected_txn_grps
+                );
+                for (sender_idx, receiver_idx) in transfer_indices {
+                    assert!(sender_idx < num_signer_accounts);
+                    assert!(receiver_idx < num_signer_accounts);
+                    adj_list.entry(sender_idx).or_default().insert(receiver_idx);
+                    adj_list.entry(receiver_idx).or_default().insert(sender_idx);
+                }
+
+                assert_eq!(get_num_connected_components(&adj_list), connected_txn_grps);
             }
         }
     }
 
-    fn get_num_connected_components(adj_list: &HashMap<usize, HashSet<usize>>) -> usize {
-        let mut visited = HashSet::new();
-        let mut num_connected_components = 0;
-        for node in adj_list.keys() {
-            if !visited.contains(node) {
-                dfs(*node, adj_list, &mut visited);
-                num_connected_components += 1;
+    /// Verifies that `create_seed_accounts` produces strictly increasing sequence
+    /// numbers for the root account even when seed accounts span multiple blocks.
+    ///
+    /// This is a regression test for a bug where the root account's sequence number
+    /// was re-read from the DB at the start of each block. Because previously
+    /// generated blocks hadn't been committed yet, the DB returned a stale value,
+    /// resetting the sequence counter and causing SEQUENCE_NUMBER_TOO_OLD discards.
+    #[test]
+    fn test_create_seed_accounts_multi_block_seq_numbers() {
+        let db_dir = TempPath::new();
+        fs::create_dir_all(db_dir.as_ref()).unwrap();
+
+        let features = default_benchmark_features();
+        bootstrap_with_genesis(&db_dir, features);
+
+        let (mut config, genesis_key) = aptos_genesis::test_utils::test_config_with_custom_features(
+            default_benchmark_features(),
+        );
+        config.storage.dir = db_dir.as_ref().to_path_buf();
+        config.storage.storage_pruner_config = NO_OP_STORAGE_PRUNER_CONFIG;
+
+        let db = init_db(&config);
+        let ts = Arc::new(BenchmarkTimestamp::from_db(&db));
+        let root_account = TransactionGenerator::read_root_account(genesis_key, &db);
+        let initial_seq_num = root_account.sequence_number();
+
+        let (block_sender, block_receiver) = mpsc::sync_channel::<Vec<Transaction>>(50);
+
+        let mut generator = TransactionGenerator::new_with_existing_db(
+            db.clone(),
+            root_account,
+            block_sender,
+            db_dir.as_ref(),
+            None,
+            1,
+            false,
+            ts,
+        );
+
+        // block_size=5, num_seed_accounts=12 → 3 blocks (5+5+2)
+        let block_size = 5;
+        let num_seed_accounts = 12;
+        generator.create_seed_accounts(
+            db.reader.clone(),
+            num_seed_accounts,
+            block_size,
+            1_000_000_000,
+            false,
+        );
+        generator.drop_sender();
+
+        // Collect root-account sequence numbers from all generated blocks.
+        let mut all_seq_nums = Vec::new();
+        while let Ok(block) = block_receiver.recv() {
+            for txn in &block {
+                if let Transaction::UserTransaction(signed_txn) = txn {
+                    if signed_txn.sender() == aptos_test_root_address() {
+                        all_seq_nums.push(signed_txn.sequence_number());
+                    }
+                }
             }
         }
-        num_connected_components
-    }
 
-    {
-        let block_size = 100;
-        let num_signer_accounts = 1000;
-        // we check for (i) block_size not divisible by connected_txn_grps (ii) when divisible
-        // (iii) when all txns in the block are independent (iv) all txns are dependent
-        for connected_txn_grps in [3, block_size / 10, block_size, 1] {
-            let transfer_indices = TransactionGenerator::get_conflicting_grps_transfer_indices(
-                &mut rng,
-                num_signer_accounts,
-                block_size,
-                connected_txn_grps,
-                true,
-            );
-
-            let mut adj_list: HashMap<usize, HashSet<usize>> = HashMap::new();
-            assert_eq!(
-                transfer_indices.len(),
-                (block_size / connected_txn_grps) * connected_txn_grps
-            );
-            for (sender_idx, receiver_idx) in transfer_indices {
-                assert!(sender_idx < num_signer_accounts);
-                assert!(receiver_idx < num_signer_accounts);
-                adj_list.entry(sender_idx).or_default().insert(receiver_idx);
-                adj_list.entry(receiver_idx).or_default().insert(sender_idx);
-            }
-
-            assert_eq!(get_num_connected_components(&adj_list), connected_txn_grps);
-        }
+        assert_eq!(all_seq_nums.len(), num_seed_accounts);
+        let expected: Vec<u64> =
+            (initial_seq_num..initial_seq_num + num_seed_accounts as u64).collect();
+        assert_eq!(
+            all_seq_nums, expected,
+            "Sequence numbers must be strictly increasing across all seed account blocks"
+        );
     }
 }


### PR DESCRIPTION

In `create_seed_accounts`, the root account's sequence number was re-read
from the DB at the start of each block of seed account creation. Since
previously generated blocks hadn't been committed yet (the pipeline hasn't
even started processing), the DB returned a stale value, resetting the
sequence counter. This caused all transactions in the 2nd+ seed block to
be discarded with `SEQUENCE_NUMBER_TOO_OLD`.

The bug triggers when `num_seed_accounts > block_size`, i.e.
`num_new_accounts / 1000 > block_size`. With the default block size of
10,000, this means >10M accounts. A larger block size masked the issue by
fitting all seed accounts into a single block.

Fix: remove the per-block DB refresh — `LocalAccount::sign_with_transaction_builder`
already auto-increments the sequence number correctly.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes seed-account transaction generation to rely on local sequence number progression instead of re-reading from storage; if incorrect, it could break benchmark account-minting at scale. Impact is limited to executor benchmark tooling, but it affects core transaction generation logic there.
> 
> **Overview**
> Fixes executor benchmark seed-account creation when `num_seed_accounts > block_size` by **removing the per-block root account sequence-number refresh from the DB**, avoiding stale reads that caused `SEQUENCE_NUMBER_TOO_OLD` discards in later blocks.
> 
> Reorganizes unit tests into a `#[cfg(test)] mod tests` and adds a **regression test** asserting root-account sequence numbers are strictly increasing across multiple generated seed-account blocks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 023c2dffc68f12c0c9b85659fd94dbffa09f2db7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->