### PR TITLE
[move] Skip cross-process package lock in aptos-move-cli tests

### DIFF
--- a/aptos-move/cli/Cargo.toml
+++ b/aptos-move/cli/Cargo.toml
@@ -70,6 +70,7 @@ jemallocator = { workspace = true }
 [dev-dependencies]
 aptos-package-builder = { workspace = true }
 mockall = { workspace = true }
+move-package = { workspace = true, features = ["testing"] }
 move-prover-test-utils = { workspace = true }
 regex = { workspace = true }
 termcolor = { workspace = true }

--- a/third_party/move/tools/move-package/Cargo.toml
+++ b/third_party/move/tools/move-package/Cargo.toml
@@ -35,6 +35,9 @@ toml = { workspace = true }
 walkdir = { workspace = true }
 whoami = { workspace = true }
 
+[features]
+testing = []
+
 [dev-dependencies]
 datatest-stable = { workspace = true }
 move-stdlib = { path = "../../move-stdlib" }

--- a/third_party/move/tools/move-package/src/package_lock.rs
+++ b/third_party/move/tools/move-package/src/package_lock.rs
@@ -33,9 +33,14 @@ pub(crate) enum PackageLock {
 
 impl PackageLock {
     pub(crate) fn lock() -> PackageLock {
-        if cfg!(test) {
+        if cfg!(any(test, feature = "testing")) {
             // In tests we assume that the test logic avoids file conflicts. Otherwise
             // global locks will lead to contention.
+            //
+            // Note: `cfg!(test)` alone only fires when *this* crate is the test target.
+            // The `testing` feature allows downstream test binaries (e.g. `aptos-move-cli`)
+            // that compile `move-package` as a regular dependency to opt in to the same
+            // lock-skip behavior.
             PackageLock::Inactive
         } else {
             Self::strict_lock()


### PR DESCRIPTION

`move-package` uses a system-wide named lock (`flock`) to serialize
package operations across processes. It had a `cfg!(test)` guard to skip
this in tests, but `cfg!(test)` only evaluates to `true` when the crate
*itself* is the test target — not when it's compiled as a dependency.

When nextest ran ~20 `aptos-move-cli` tests as separate processes, each
acquired this lock twice (resolution + compilation), fully serializing
them. This turned 20 x ~0.03s of actual work into ~170s of sequential
waiting per test, consuming ~3 minutes of CI wall clock while blocking
~20 nextest slots.

The fix adds a `testing` feature to `move-package` and checks
`cfg!(any(test, feature = "testing"))`. The feature is enabled via
`[dev-dependencies]` in `aptos-move-cli` so it only applies to test
builds.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk since behavior changes only when `move-package` is built with the new `testing` feature (enabled only for `aptos-move-cli` dev/test builds). Main downside is reduced locking in tests, which could expose flakiness if tests share package paths.
> 
> **Overview**
> Speeds up `aptos-move-cli` tests by allowing downstream test binaries to opt out of `move-package`’s cross-process named lock.
> 
> This introduces a `testing` feature in `move-package` and updates `PackageLock::lock()` to skip the global process/thread lock when `cfg!(any(test, feature = "testing"))` is true, while leaving `strict_lock()` unchanged. The `aptos-move-cli` crate enables this feature only under `[dev-dependencies]` so production builds keep the strict locking behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 66bd7ebaca4b31018871ba4c45dd146979929ecc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->