### PR TITLE
[storage] Skip BLS signing in ledger_metadata_db tests

### DIFF
--- a/storage/aptosdb/src/ledger_db/ledger_metadata_db_test.rs
+++ b/storage/aptosdb/src/ledger_db/ledger_metadata_db_test.rs
@@ -8,9 +8,10 @@ use aptos_temppath::TempPath;
 use aptos_types::{
     account_address::AccountAddress,
     account_config::events::new_block::{new_block_event_key, NewBlockEvent},
+    aggregate_signature::AggregateSignature,
     contract_event::ContractEvent,
     ledger_info::LedgerInfoWithSignatures,
-    proptest_types::{AccountInfoUniverse, LedgerInfoWithSignaturesGen},
+    proptest_types::{AccountInfoUniverse, LedgerInfoGen},
     state_store::state_storage_usage::StateStorageUsage,
     transaction::Version,
 };
@@ -25,13 +26,16 @@ use std::path::Path;
 fn arb_ledger_infos_with_sigs() -> impl Strategy<Value = Vec<LedgerInfoWithSignatures>> {
     (
         any_with::<AccountInfoUniverse>(3),
-        vec((any::<LedgerInfoWithSignaturesGen>(), 1..50usize), 1..50),
+        vec((any::<LedgerInfoGen>(), 1..50usize), 1..50),
     )
         .prop_map(|(mut universe, gens)| {
             let ledger_infos_with_sigs: Vec<_> = gens
                 .into_iter()
                 .map(|(ledger_info_gen, block_size)| {
-                    ledger_info_gen.materialize(&mut universe, block_size)
+                    let ledger_info = ledger_info_gen.materialize(&mut universe, block_size);
+                    // Skip expensive BLS signing — these tests verify DB operations, not signature
+                    // validity.
+                    LedgerInfoWithSignatures::new(ledger_info, AggregateSignature::empty())
                 })
                 .collect();
             assert_eq!(get_first_epoch(&ledger_infos_with_sigs), 0);


### PR DESCRIPTION

Use `LedgerInfoGen` directly with `AggregateSignature::empty()` instead
of `LedgerInfoWithSignaturesGen` which performs real BLS12-381 signing
via `generate_ledger_info_with_sig()`.

These 7 proptest-based tests verify DB storage/retrieval correctness,
not signature validity. The BLS signing (up to ~1000 sign+aggregate ops
across 20 proptest cases × up to 49 LedgerInfos each) was the dominant
cost, adding 50-150s per test on top of the ~50s AptosDB baseline. In
CI, they ranged from 102s to 198s each (714s total). After this change,
all 9 tests in the file complete in ~15s total in release mode.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk since this only changes test data generation, replacing real BLS signing with `AggregateSignature::empty()` to reduce runtime. The main risk is slightly reduced coverage of signature generation/verification behavior in these DB tests.
> 
> **Overview**
> Speeds up `storage/aptosdb` `ledger_metadata_db_test.rs` proptests by switching from `LedgerInfoWithSignaturesGen` (which performs real BLS sign+aggregate) to `LedgerInfoGen` and explicitly wrapping materialized ledger infos with `LedgerInfoWithSignatures::new(..., AggregateSignature::empty())`.
> 
> This keeps the tests focused on metadata DB write/read behavior while removing signature-creation cost from the test setup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5be8be8b22c02eeb9bd54c1c10f580f0e5121574. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->