### PR TITLE
[storage] Batch init_store in state_store restore tests

### DIFF
--- a/storage/aptosdb/src/ledger_db/ledger_metadata_db_test.rs
+++ b/storage/aptosdb/src/ledger_db/ledger_metadata_db_test.rs
@@ -8,9 +8,10 @@ use aptos_temppath::TempPath;
 use aptos_types::{
     account_address::AccountAddress,
     account_config::events::new_block::{new_block_event_key, NewBlockEvent},
+    aggregate_signature::AggregateSignature,
     contract_event::ContractEvent,
     ledger_info::LedgerInfoWithSignatures,
-    proptest_types::{AccountInfoUniverse, LedgerInfoWithSignaturesGen},
+    proptest_types::{AccountInfoUniverse, LedgerInfoGen},
     state_store::state_storage_usage::StateStorageUsage,
     transaction::Version,
 };
@@ -25,13 +26,16 @@ use std::path::Path;
 fn arb_ledger_infos_with_sigs() -> impl Strategy<Value = Vec<LedgerInfoWithSignatures>> {
     (
         any_with::<AccountInfoUniverse>(3),
-        vec((any::<LedgerInfoWithSignaturesGen>(), 1..50usize), 1..50),
+        vec((any::<LedgerInfoGen>(), 1..50usize), 1..50),
     )
         .prop_map(|(mut universe, gens)| {
             let ledger_infos_with_sigs: Vec<_> = gens
                 .into_iter()
                 .map(|(ledger_info_gen, block_size)| {
-                    ledger_info_gen.materialize(&mut universe, block_size)
+                    let ledger_info = ledger_info_gen.materialize(&mut universe, block_size);
+                    // Skip expensive BLS signing — these tests verify DB operations, not signature
+                    // validity.
+                    LedgerInfoWithSignatures::new(ledger_info, AggregateSignature::empty())
                 })
                 .collect();
             assert_eq!(get_first_epoch(&ledger_infos_with_sigs), 0);

--- a/storage/aptosdb/src/state_store/tests/mod.rs
+++ b/storage/aptosdb/src/state_store/tests/mod.rs
@@ -232,7 +232,7 @@ proptest! {
         let store1 = &db1.state_store;
         init_store(store1, input.clone().into_iter());
 
-        let version = (input.len() - 1) as Version;
+        let version = 1;
         let expected_root_hash = store1.get_root_hash(version).unwrap();
 
         let tmp_dir2 = TempPath::new();
@@ -289,7 +289,7 @@ proptest! {
         let store1 = &db1.state_store;
         init_store(store1, input.clone().into_iter());
 
-        let version = (input.len() - 1) as Version;
+        let version = 1;
         let expected_root_hash = store1.get_root_hash(version).unwrap();
         prop_assert_eq!(
             store1.get_value_count(version).unwrap(),
@@ -330,7 +330,7 @@ proptest! {
         let store1 = &db1.state_store;
         init_store(store1, input.clone().into_iter());
 
-        let version = (input.len() - 1) as Version;
+        let version = 1;
         let expected_root_hash = store1.get_root_hash(version).unwrap();
 
         let tmp_dir2 = TempPath::new();
@@ -383,7 +383,7 @@ proptest! {
         let store1 = &db1.state_store;
         init_store(store1, input.clone().into_iter());
 
-        let version = (input.len() - 1) as Version;
+        let version = 1;
         let expected_root_hash = store1.get_root_hash(version).unwrap();
 
         let tmp_dir2 = TempPath::new();
@@ -476,7 +476,10 @@ proptest! {
     }
 }
 
-// Initializes the state store by inserting one key at each version.
+// Initializes the state store by inserting all items in a single version (version 1).
+// Version 0 is left empty so that rightmost_leaf tests can put dummy data at NodeKey
+// version 0 without conflicting with the real data lookup at version 1.
 fn init_store(store: &StateStore, input: impl Iterator<Item = (StateKey, StateValue)>) {
-    update_store(store, input.into_iter().map(|(k, v)| (k, Some(v))), 0);
+    let kvs: Vec<_> = input.map(|(k, v)| (k, Some(v))).collect();
+    store.commit_block_for_test(0, [vec![], kvs]);
 }


### PR DESCRIPTION

Previously `init_store` inserted each key-value pair as a separate
version, causing up to 999 sequential JMT tree updates per proptest
case. These tests (`test_raw_restore`, `test_restore`,
`test_get_rightmost_leaf`, `test_get_rightmost_leaf_with_sharding`)
only need a populated tree at a single version — they test restore
correctness, not multi-version behavior.

Now `init_store` batches all items into a single version (version 1),
replacing up to 999 incremental JMT builds with one batch update.
Version 0 is left empty so that the rightmost_leaf tests' dummy
`merklize_value_set` data (committed with NodeKey at version 0) doesn't
conflict with the real data lookup at version 1.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/aptos-labs/aptos-core/pull/18992).
* __->__ #18992
* #18990