### PR TITLE
Faucet Redis key prefix

### DIFF
--- a/crates/aptos-faucet/core/src/checkers/redis_ratelimit.rs
+++ b/crates/aptos-faucet/core/src/checkers/redis_ratelimit.rs
@@ -71,6 +71,11 @@ pub struct RedisRatelimitCheckerConfig {
     /// The password of the given user, if necessary.
     pub database_password: Option<String>,
 
+    /// Optional prefix for all Redis keys. This allows multiple faucets to share
+    /// a single Redis instance without key collisions.
+    #[serde(default)]
+    pub key_prefix: Option<String>,
+
     /// Max number of requests per key per day. 500s are not counted, because they are
     /// not the user's fault, but everything else is.
     pub max_requests_per_day: u32,
@@ -182,7 +187,6 @@ impl RedisRatelimitChecker {
         })
     }
 
-    // Returns the key and the seconds until the next day.
     fn get_key_and_secs_until_next_day(
         &self,
         ratelimit_key_prefix: &str,
@@ -190,12 +194,21 @@ impl RedisRatelimitChecker {
     ) -> (String, u64) {
         let now_secs = get_current_time_secs();
         let seconds_until_next_day = seconds_until_next_day(now_secs);
-        let key = format!(
-            "{}:{}:{}",
-            ratelimit_key_prefix,
-            ratelimit_key_value,
-            days_since_tap_epoch(now_secs)
-        );
+        let key = match &self.args.key_prefix {
+            Some(prefix) => format!(
+                "{}:{}:{}:{}",
+                prefix,
+                ratelimit_key_prefix,
+                ratelimit_key_value,
+                days_since_tap_epoch(now_secs)
+            ),
+            None => format!(
+                "{}:{}:{}",
+                ratelimit_key_prefix,
+                ratelimit_key_value,
+                days_since_tap_epoch(now_secs)
+            ),
+        };
         (key, seconds_until_next_day)
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description
Adds an optional `key_prefix` to the `RedisRatelimitCheckerConfig` to enable multiple Aptos Faucet instances to share a single Redis server without key collisions. When configured, all Redis keys used by the ratelimiter will be prefixed with the specified string. This field defaults to `None` for backward compatibility. A review of the faucet codebase confirmed that the ratelimit checker is the only component interacting with Redis, addressing all identified potential collision points.

## How Has This Been Tested?
- Code successfully compiled.
- `clippy` was run on the `aptos-faucet` crate with no new warnings introduced.

## Key Areas to Review
- `RedisRatelimitCheckerConfig` for the new `key_prefix: Option<String>` field and its `#[serde(default)]` attribute.
- The `get_key_and_secs_until_next_day` method in `redis_ratelimit.rs` to ensure the `key_prefix` is correctly applied to Redis keys.
- Verification that existing configurations without `key_prefix` remain functional.

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [x] Other (specify): Aptos Faucet

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

---
<p><a href="https://cursor.com/agents/bc-ddbb43e2-65a8-47ed-b3a2-ae25a416b63f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ddbb43e2-65a8-47ed-b3a2-ae25a416b63f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->