### PR TITLE
[Network] Ignore flaky test.

### DIFF
--- a/network/framework/src/protocols/health_checker/test.rs
+++ b/network/framework/src/protocols/health_checker/test.rs
@@ -250,6 +250,7 @@ async fn inbound() {
 }
 
 #[tokio::test]
+#[ignore]
 async fn outbound_failure_permissive() {
     let ping_failures_tolerated = 10;
     let (mut harness, health_checker) = TestHarness::new_permissive(ping_failures_tolerated);


### PR DESCRIPTION
## Description
This PR ignores a flaky network test.

## Testing Plan
Existing test infrastructure.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low code-change risk (test-only), but it reduces CI coverage for permissive outbound failure/disconnect behavior and may hide regressions in that path.
> 
> **Overview**
> Marks the `outbound_failure_permissive` health-checker test as `#[ignore]`, removing it from the default test run due to flakiness.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 70d827e9ec52b97c349f1bf1601d37b615f5856f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->