### PR TITLE
[forge] Enable encrypted txn submission on fullnodes

### DIFF
--- a/testsuite/forge-cli/src/suites/realistic_environment.rs
+++ b/testsuite/forge-cli/src/suites/realistic_environment.rs
@@ -544,6 +544,9 @@ pub(crate) fn realistic_env_max_load_encrypted_test(
             config.consensus.quorum_store.enable_opt_qs_v2_payload_tx = true;
             config.consensus.quorum_store.enable_opt_qs_v2_payload_rx = true;
         }))
+        .with_fullnode_override_node_config_fn(Arc::new(|config, _| {
+            config.api.allow_encrypted_txns_submission = true;
+        }))
         .with_emit_job(
             EmitJobRequest::default()
                 .mode(EmitJobMode::ConstTps { tps: 100 })


### PR DESCRIPTION
## Summary
- Enable `allow_encrypted_txns_submission = true` on fullnode configs in the `realistic_env_max_load_encrypted` Forge test
- Without this, clients submitting encrypted transactions through fullnode APIs get rejected with "Encrypted Transaction submission is not allowed yet"

## Test plan
- [x] Run `realistic_env_max_load_encrypted` Forge test and verify encrypted transactions are accepted by fullnodes

🤖 Generated with [Claude Code](https://claude.com/claude-code)