### PR TITLE
[storage] Use HashValue as hot state DashMap key

### DIFF
--- a/storage/aptosdb/src/state_store/hot_state.rs
+++ b/storage/aptosdb/src/state_store/hot_state.rs
@@ -6,6 +6,7 @@ use crate::metrics::{
 };
 use anyhow::{ensure, Result};
 use aptos_config::config::HotStateConfig;
+use aptos_crypto::{hash::CryptoHash, HashValue};
 use aptos_infallible::Mutex;
 use aptos_logger::prelude::*;
 use aptos_metrics_core::{IntCounterVecHelper, IntGaugeVecHelper, TimerHelper};
@@ -78,7 +79,7 @@ where
 }
 
 #[derive(Debug)]
-struct HotStateBase<K = StateKey, V = StateSlot>
+struct HotStateBase<K = HashValue, V = StateSlot>
 where
     K: Eq + std::hash::Hash,
 {
@@ -127,7 +128,7 @@ impl HotStateView for LayeredHotStateView {
         // Key not in delta (unchanged) — read from base DashMap.
         let shard_id = state_key.get_shard_id();
         self.base
-            .get_from_shard(shard_id, state_key)
+            .get_from_shard(shard_id, &CryptoHash::hash(state_key))
             .map(|v| v.clone())
     }
 }
@@ -232,7 +233,7 @@ impl HotState {
     }
 
     #[cfg(test)]
-    pub fn get_all_entries(&self, shard_id: usize) -> BTreeMap<StateKey, StateSlot> {
+    pub fn get_all_entries(&self, shard_id: usize) -> BTreeMap<HashValue, StateSlot> {
         self.base.shards[shard_id].iter().collect()
     }
 }
@@ -268,10 +269,10 @@ struct Committer {
     rx: Receiver<CommitMsg>,
     total_key_bytes: usize,
     total_value_bytes: usize,
-    /// Points to the newest entry. `None` if empty.
-    heads: [Option<StateKey>; NUM_STATE_SHARDS],
-    /// Points to the oldest entry. `None` if empty.
-    tails: [Option<StateKey>; NUM_STATE_SHARDS],
+    /// Points to the newest entry (by hash). `None` if empty.
+    heads: [Option<HashValue>; NUM_STATE_SHARDS],
+    /// Points to the oldest entry (by hash). `None` if empty.
+    tails: [Option<HashValue>; NUM_STATE_SHARDS],
 
     /// What the base DashMaps currently reflect. May lag behind `committed.state` while a merge
     /// is deferred.
@@ -498,25 +499,31 @@ impl Committer {
         let delta = target.make_delta(&self.merged_state);
         for shard_id in 0..NUM_STATE_SHARDS {
             for (key, slot) in delta.shards[shard_id].iter() {
+                let key_hash = CryptoHash::hash(&key);
                 if slot.is_hot() {
                     let key_size = key.size();
                     self.total_key_bytes += key_size;
                     self.total_value_bytes += slot.size();
-                    if let Some(old_slot) = self.base.shards[shard_id].insert(key, slot) {
+                    if let Some(old_slot) = self.base.shards[shard_id].insert(key_hash, slot) {
                         self.total_key_bytes -= key_size;
                         self.total_value_bytes -= old_slot.size();
                         n_update += 1;
                     } else {
                         n_insert += 1;
                     }
-                } else if let Some((key, old_slot)) = self.base.shards[shard_id].remove(&key) {
+                } else if let Some((_hash, old_slot)) = self.base.shards[shard_id].remove(&key_hash)
+                {
                     self.total_key_bytes -= key.size();
                     self.total_value_bytes -= old_slot.size();
                     n_evict += 1;
                 }
             }
-            self.heads[shard_id] = target.latest_hot_key(shard_id);
-            self.tails[shard_id] = target.oldest_hot_key(shard_id);
+            self.heads[shard_id] = target
+                .latest_hot_key(shard_id)
+                .map(|k| CryptoHash::hash(&k));
+            self.tails[shard_id] = target
+                .oldest_hot_key(shard_id)
+                .map(|k| CryptoHash::hash(&k));
             assert_eq!(
                 self.base.shards[shard_id].len(),
                 target.num_hot_items(shard_id)
@@ -541,15 +548,15 @@ impl Committer {
         let mut global_max_lru: Option<Version> = None;
 
         for (shard_id, shard_label) in SHARD_NAME_BY_ID.iter().enumerate() {
-            let mru_version = self.heads[shard_id].as_ref().map(|k| {
+            let mru_version = self.heads[shard_id].as_ref().map(|h| {
                 self.base.shards[shard_id]
-                    .get(k)
+                    .get(h)
                     .expect("head must exist in base")
                     .expect_hot_since_version()
             });
-            let lru_version = self.tails[shard_id].as_ref().map(|k| {
+            let lru_version = self.tails[shard_id].as_ref().map(|h| {
                 self.base.shards[shard_id]
-                    .get(k)
+                    .get(h)
                     .expect("tail must exist in base")
                     .expect_hot_since_version()
             });
@@ -584,12 +591,12 @@ impl Committer {
         {
             let mut num_visited = 0;
             let mut current = head.clone();
-            while let Some(key) = current {
-                let entry = shard.get(&key).expect("Must exist.");
+            while let Some(hash) = current {
+                let entry = shard.get(&hash).expect("Must exist.");
                 num_visited += 1;
                 ensure!(num_visited <= shard.len());
                 ensure!(entry.is_hot());
-                current = entry.next().cloned();
+                current = entry.next().map(|k| CryptoHash::hash(k));
             }
             ensure!(num_visited == shard.len());
         }
@@ -597,12 +604,12 @@ impl Committer {
         {
             let mut num_visited = 0;
             let mut current = tail.clone();
-            while let Some(key) = current {
-                let entry = shard.get(&key).expect("Must exist.");
+            while let Some(hash) = current {
+                let entry = shard.get(&hash).expect("Must exist.");
                 num_visited += 1;
                 ensure!(num_visited <= shard.len());
                 ensure!(entry.is_hot());
-                current = entry.prev().cloned();
+                current = entry.prev().map(|k| CryptoHash::hash(k));
             }
             ensure!(num_visited == shard.len());
         }
@@ -697,7 +704,7 @@ mod tests {
         let key = StateKey::raw(b"key_a");
         let shard_id = key.get_shard_id();
         let slot = make_hot_slot(1, b"value_a");
-        base.shards[shard_id].insert(key.clone(), slot.clone());
+        base.shards[shard_id].insert(CryptoHash::hash(&key), slot.clone());
 
         let view = LayeredHotStateView {
             delta: None,
@@ -724,18 +731,20 @@ mod tests {
         // key_base_only: in base DashMap, NOT in delta.
         let key_base_only = StateKey::raw(b"base_only");
         let slot_base = make_hot_slot(1, b"base_value");
-        base.shards[key_base_only.get_shard_id()].insert(key_base_only.clone(), slot_base.clone());
+        base.shards[key_base_only.get_shard_id()]
+            .insert(CryptoHash::hash(&key_base_only), slot_base.clone());
 
         // key_updated: in base DashMap AND in delta (hot) -> delta wins.
         let key_updated = StateKey::raw(b"updated");
         let slot_old = make_hot_slot(1, b"old_value");
         let slot_new = make_hot_slot(2, b"new_value");
-        base.shards[key_updated.get_shard_id()].insert(key_updated.clone(), slot_old);
+        base.shards[key_updated.get_shard_id()].insert(CryptoHash::hash(&key_updated), slot_old);
 
         // key_evicted: in base DashMap AND in delta (cold) -> returns None.
         let key_evicted = StateKey::raw(b"evicted");
         let slot_was_hot = make_hot_slot(1, b"was_hot");
-        base.shards[key_evicted.get_shard_id()].insert(key_evicted.clone(), slot_was_hot);
+        base.shards[key_evicted.get_shard_id()]
+            .insert(CryptoHash::hash(&key_evicted), slot_was_hot);
 
         // key_new: NOT in base, in delta (hot) -> returns delta value.
         let key_new = StateKey::raw(b"new_key");

--- a/storage/aptosdb/src/state_store/tests/speculative_state_workflow.rs
+++ b/storage/aptosdb/src/state_store/tests/speculative_state_workflow.rs
@@ -672,8 +672,14 @@ fn commit_state_buffer(
                 &state_by_version.get_state(Some(next_version - 1)).hot_state[shard_id];
             assert_eq!(all_entries.len(), naive_hot_state.len());
 
-            for (key, slot) in &all_entries {
-                let slot2 = naive_hot_state.peek(key).unwrap();
+            // Build a hash-keyed lookup from the naive LRU for comparison.
+            let naive_by_hash: std::collections::HashMap<HashValue, &StateSlot> = naive_hot_state
+                .iter()
+                .map(|(k, v)| (CryptoHash::hash(k), v))
+                .collect();
+
+            for (hash, slot) in &all_entries {
+                let slot2 = naive_by_hash.get(hash).unwrap();
                 StateByVersion::assert_state_slot(slot, slot2);
             }
         });


### PR DESCRIPTION

Replace the `StateKey` key in the hot state base `DashMap`s with
`HashValue` (the crypto hash of the `StateKey`). All lookups and
insertions now hash the `StateKey` at the DashMap boundary.

This decouples the in-memory hot state cache from the `StateKey`
identity, so that future DB persistence of hot state KV entries does not
need to carry the full `StateKey` in the value — the schema key
(`HashValue`) is sufficient for reconstruction on load.

The `StateSlot` values (including their `LRUEntry<StateKey>` prev/next
pointers) are unchanged. The LRU traversal in `validate_lru` and
`report_age_metrics` simply hashes the `StateKey` pointers to perform
DashMap lookups.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
