### PR TITLE
[forge] Canary: validate YAML config override (4 validators)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -36,6 +36,7 @@
 !scripts/
 !terraform/helm/aptos-node/
 !terraform/helm/genesis/
+!testsuite/forge-cli/config/*.yaml
 !testsuite/forge/src/backend/k8s/
 !third_party/move/move-prover/boogie-backend/**/*.bpl
 !testsuite/testcases/src/data/

--- a/testsuite/forge-cli/config/changing_working_quorum_test.yaml
+++ b/testsuite/forge-cli/config/changing_working_quorum_test.yaml
@@ -1,0 +1,31 @@
+test_name: changing_working_quorum
+initial_validator_count: 16
+emit_job:
+  mode:
+    type: ConstTps
+    tps: 100
+  transaction_mix:
+    - transaction_type: CoinTransfer
+      weight: 80
+    - transaction_type: AccountGeneration
+      weight: 20
+genesis_helm_config:
+  chain:
+    epoch_duration_secs: 120
+success_criteria:
+  min_avg_tps: 70
+  check_no_restarts: true
+  check_no_errors: false
+  wait_for_catchup_s: 30
+  chain_progress:
+    max_non_epoch_no_progress_secs: 40.0
+    max_epoch_no_progress_secs: 40.0
+    max_non_epoch_round_gap: 60
+    max_epoch_round_gap: 60
+extra:
+  min_tps: 15
+  always_healthy_nodes: 0
+  max_down_nodes: 16
+  num_large_validators: 0
+  add_execution_delay: false
+  check_period_s: 53

--- a/testsuite/forge-cli/config/changing_working_quorum_test_high_load.yaml
+++ b/testsuite/forge-cli/config/changing_working_quorum_test_high_load.yaml
@@ -1,0 +1,31 @@
+test_name: changing_working_quorum
+initial_validator_count: 16
+emit_job:
+  mode:
+    type: ConstTps
+    tps: 500
+  transaction_mix:
+    - transaction_type: CoinTransfer
+      weight: 80
+    - transaction_type: AccountGeneration
+      weight: 20
+genesis_helm_config:
+  chain:
+    epoch_duration_secs: 120
+success_criteria:
+  min_avg_tps: 300
+  check_no_restarts: true
+  check_no_errors: false
+  wait_for_catchup_s: 30
+  chain_progress:
+    max_non_epoch_no_progress_secs: 40.0
+    max_epoch_no_progress_secs: 40.0
+    max_non_epoch_round_gap: 60
+    max_epoch_round_gap: 60
+extra:
+  min_tps: 50
+  always_healthy_nodes: 0
+  max_down_nodes: 16
+  num_large_validators: 0
+  add_execution_delay: false
+  check_period_s: 53

--- a/testsuite/forge-cli/config/compat.yaml
+++ b/testsuite/forge-cli/config/compat.yaml
@@ -1,0 +1,8 @@
+test_name: simple_validator_upgrade
+initial_validator_count: 4
+genesis_helm_config:
+  chain:
+    epoch_duration_secs: 60
+success_criteria:
+  min_avg_tps: 5000
+  wait_for_catchup_s: 240

--- a/testsuite/forge-cli/config/consensus_only_realistic_env_max_tps.yaml
+++ b/testsuite/forge-cli/config/consensus_only_realistic_env_max_tps.yaml
@@ -1,0 +1,23 @@
+test_name: consensus_only_realistic_env
+initial_validator_count: 20
+emit_job:
+  mode:
+    type: MaxLoad
+    mempool_backlog: 300000
+  txn_expiration_time_secs: 300
+genesis_helm_config:
+  chain:
+    epoch_duration_secs: 86400
+success_criteria:
+  min_avg_tps: 10000
+  check_no_restarts: true
+  wait_for_catchup_s: 240
+  chain_progress:
+    max_non_epoch_no_progress_secs: 20.0
+    max_epoch_no_progress_secs: 20.0
+    max_non_epoch_round_gap: 6
+    max_epoch_round_gap: 6
+extra:
+  target_tps: 20000
+  max_txns_per_block: 4500
+  vn_latency: 3.0

--- a/testsuite/forge-cli/config/consensus_stress_test.yaml
+++ b/testsuite/forge-cli/config/consensus_stress_test.yaml
@@ -1,0 +1,30 @@
+test_name: changing_working_quorum
+initial_validator_count: 10
+emit_job:
+  mode:
+    type: ConstTps
+    tps: 100
+  transaction_mix:
+    - transaction_type: CoinTransfer
+      weight: 80
+    - transaction_type: AccountGeneration
+      weight: 20
+genesis_helm_config:
+  chain:
+    epoch_duration_secs: 60
+success_criteria:
+  min_avg_tps: 80
+  check_no_restarts: true
+  wait_for_catchup_s: 30
+  chain_progress:
+    max_non_epoch_no_progress_secs: 3.0
+    max_epoch_no_progress_secs: 3.0
+    max_non_epoch_round_gap: 60
+    max_epoch_round_gap: 60
+extra:
+  min_tps: 50
+  always_healthy_nodes: 10
+  max_down_nodes: 0
+  num_large_validators: 0
+  add_execution_delay: false
+  check_period_s: 27

--- a/testsuite/forge-cli/config/framework_upgrade.yaml
+++ b/testsuite/forge-cli/config/framework_upgrade.yaml
@@ -1,0 +1,8 @@
+test_name: framework_upgrade
+initial_validator_count: 4
+genesis_helm_config:
+  chain:
+    epoch_duration_secs: 30
+success_criteria:
+  min_avg_tps: 5000
+  wait_for_catchup_s: 240

--- a/testsuite/forge-cli/config/fullnode_reboot_stress_test.yaml
+++ b/testsuite/forge-cli/config/fullnode_reboot_stress_test.yaml
@@ -1,0 +1,10 @@
+test_name: fullnode_reboot_stress_test
+initial_validator_count: 7
+initial_fullnode_count: 7
+emit_job:
+  mode:
+    type: ConstTps
+    tps: 5000
+success_criteria:
+  min_avg_tps: 2000
+  wait_for_catchup_s: 600

--- a/testsuite/forge-cli/config/multiregion_benchmark_test.yaml
+++ b/testsuite/forge-cli/config/multiregion_benchmark_test.yaml
@@ -1,0 +1,25 @@
+test_name: multiregion_benchmark
+initial_validator_count: 20
+multi_region_config: true
+genesis_helm_config:
+  chain:
+    epoch_duration_secs: 300
+  genesis:
+    multicluster:
+      enabled: true
+success_criteria:
+  min_avg_tps: 4500
+  check_no_restarts: true
+  wait_for_catchup_s: 180
+  system_metrics:
+    cpu_threshold:
+      max: 12.0
+      max_breach_pct: 30
+    memory_threshold:
+      max: 10737418240.0
+      max_breach_pct: 30
+  chain_progress:
+    max_non_epoch_no_progress_secs: 10.0
+    max_epoch_no_progress_secs: 10.0
+    max_non_epoch_round_gap: 4
+    max_epoch_round_gap: 4

--- a/testsuite/forge-cli/config/pfn_const_tps_with_realistic_env.yaml
+++ b/testsuite/forge-cli/config/pfn_const_tps_with_realistic_env.yaml
@@ -1,0 +1,32 @@
+test_name: pfn_const_tps
+initial_validator_count: 7
+initial_fullnode_count: 7
+emit_job:
+  mode:
+    type: ConstTps
+    tps: 5000
+genesis_helm_config:
+  chain:
+    epoch_duration_secs: 7200
+success_criteria:
+  min_avg_tps: 4500
+  check_no_restarts: true
+  max_expired_tps: 0.0
+  max_failed_submission_tps: 0.0
+  latency_thresholds:
+    - threshold_s: 3.5
+      latency_type: P50
+    - threshold_s: 4.5
+      latency_type: P90
+    - threshold_s: 5.5
+      latency_type: P99
+  wait_for_catchup_s: 90
+  chain_progress:
+    max_non_epoch_no_progress_secs: 10.0
+    max_epoch_no_progress_secs: 10.0
+    max_non_epoch_round_gap: 4
+    max_epoch_round_gap: 4
+extra:
+  num_pfns: 7
+  add_cpu_chaos: true
+  add_network_emulation: true

--- a/testsuite/forge-cli/config/realistic_env_fairness_workload_sweep.yaml
+++ b/testsuite/forge-cli/config/realistic_env_fairness_workload_sweep.yaml
@@ -1,0 +1,20 @@
+test_name: fairness_workload_sweep_realistic_env
+initial_validator_count: 7
+initial_fullnode_count: 3
+emit_job:
+  mode:
+    type: MaxLoad
+    mempool_backlog: 40000
+  latency_polling_interval_ms: 100
+genesis_helm_config:
+  chain:
+    epoch_duration_secs: 86400
+success_criteria:
+  min_avg_tps: 0
+  check_no_restarts: true
+  wait_for_catchup_s: 60
+  chain_progress:
+    max_non_epoch_no_progress_secs: 30.0
+    max_epoch_no_progress_secs: 30.0
+    max_non_epoch_round_gap: 10
+    max_epoch_round_gap: 10

--- a/testsuite/forge-cli/config/realistic_env_graceful_overload.yaml
+++ b/testsuite/forge-cli/config/realistic_env_graceful_overload.yaml
@@ -1,0 +1,37 @@
+test_name: two_traffics_realistic_env_const_tps
+initial_validator_count: 20
+initial_fullnode_count: 20
+genesis_helm_config:
+  chain:
+    epoch_duration_secs: 300
+emit_job:
+  mode:
+    type: ConstTps
+    tps: 1000
+  gas_price: 500
+success_criteria:
+  min_avg_tps: 900
+  check_no_restarts: true
+  wait_for_catchup_s: 180
+  latency_thresholds:
+    - threshold_s: 10.0
+      latency_type: P50
+    - threshold_s: 30.0
+      latency_type: P90
+  system_metrics:
+    cpu_threshold:
+      max: 28.0
+      max_breach_pct: 20
+    memory_threshold:
+      # 16 GB base (adjust for duration)
+      max: 17179869184.0
+      max_breach_pct: 20
+  chain_progress:
+    max_non_epoch_no_progress_secs: 30.0
+    max_epoch_no_progress_secs: 30.0
+    max_non_epoch_round_gap: 10
+    max_epoch_round_gap: 10
+extra:
+  inner_tps: 30000
+  inner_min_tps: 7500
+  inner_gas_price_multiplier: 20

--- a/testsuite/forge-cli/config/realistic_env_graceful_workload_sweep.yaml
+++ b/testsuite/forge-cli/config/realistic_env_graceful_workload_sweep.yaml
@@ -1,0 +1,23 @@
+test_name: graceful_workload_sweep_realistic_env
+initial_validator_count: 7
+initial_fullnode_count: 3
+emit_job:
+  mode:
+    type: MaxLoad
+    mempool_backlog: 40000
+  txn_expiration_time_secs: 20
+  init_gas_price_multiplier: 5
+  init_expiration_multiplier: 6.0
+  latency_polling_interval_ms: 100
+genesis_helm_config:
+  chain:
+    epoch_duration_secs: 86400
+success_criteria:
+  min_avg_tps: 0
+  check_no_restarts: true
+  wait_for_catchup_s: 60
+  chain_progress:
+    max_non_epoch_no_progress_secs: 30.0
+    max_epoch_no_progress_secs: 30.0
+    max_non_epoch_round_gap: 10
+    max_epoch_round_gap: 10

--- a/testsuite/forge-cli/config/realistic_env_load_sweep.yaml
+++ b/testsuite/forge-cli/config/realistic_env_load_sweep.yaml
@@ -1,0 +1,20 @@
+test_name: load_sweep_realistic_env
+initial_validator_count: 20
+initial_fullnode_count: 10
+emit_job:
+  mode:
+    type: MaxLoad
+    mempool_backlog: 40000
+  latency_polling_interval_ms: 100
+genesis_helm_config:
+  chain:
+    epoch_duration_secs: 86400
+success_criteria:
+  min_avg_tps: 0
+  check_no_restarts: true
+  wait_for_catchup_s: 60
+  chain_progress:
+    max_non_epoch_no_progress_secs: 30.0
+    max_epoch_no_progress_secs: 30.0
+    max_non_epoch_round_gap: 10
+    max_epoch_round_gap: 10

--- a/testsuite/forge-cli/config/realistic_env_max_load.yaml
+++ b/testsuite/forge-cli/config/realistic_env_max_load.yaml
@@ -1,0 +1,49 @@
+test_name: two_traffics_realistic_env
+initial_validator_count: 7
+initial_fullnode_count: 2
+num_pfns: 1
+genesis_helm_config:
+  chain:
+    epoch_duration_secs: 300
+emit_job:
+  mode:
+    type: ConstTps
+    tps: 100
+  gas_price: 500
+  latency_polling_interval_ms: 100
+success_criteria:
+  min_avg_tps: 85
+  check_no_restarts: true
+  check_no_fullnode_failures: true
+  wait_for_catchup_s: 60
+  latency_thresholds:
+    - threshold_s: 3.6
+      latency_type: P50
+    - threshold_s: 4.8
+      latency_type: P70
+  latency_breakdown_thresholds:
+    max_breach_pct: 5
+    thresholds:
+      - slice: MempoolToBlockCreation
+        max_s: 3.6
+      - slice: ConsensusProposalToOrdered
+        max_s: 0.85
+      - slice: ConsensusOrderedToCommit
+        max_s: 1.0
+  chain_progress:
+    max_non_epoch_no_progress_secs: 15.0
+    max_epoch_no_progress_secs: 16.0
+    max_non_epoch_round_gap: 4
+    max_epoch_round_gap: 4
+  system_metrics:
+    cpu_threshold:
+      max: 25.0
+      max_breach_pct: 15
+    memory_threshold:
+      # ~16 GB base + growth
+      max: 17179869184.0
+      max_breach_pct: 20
+extra:
+  inner_mempool_backlog: 38000
+  inner_min_tps: 10000
+  inner_gas_price_multiplier: 20

--- a/testsuite/forge-cli/config/realistic_env_max_load.yaml
+++ b/testsuite/forge-cli/config/realistic_env_max_load.yaml
@@ -1,5 +1,5 @@
 test_name: two_traffics_realistic_env
-initial_validator_count: 7
+initial_validator_count: 4
 initial_fullnode_count: 2
 num_pfns: 1
 genesis_helm_config:

--- a/testsuite/forge-cli/config/realistic_env_max_load_large.yaml
+++ b/testsuite/forge-cli/config/realistic_env_max_load_large.yaml
@@ -1,0 +1,43 @@
+test_name: two_traffics_realistic_env
+initial_validator_count: 20
+initial_fullnode_count: 10
+num_pfns: 1
+genesis_helm_config:
+  chain:
+    epoch_duration_secs: 600
+emit_job:
+  mode:
+    type: ConstTps
+    tps: 100
+  gas_price: 500
+  latency_polling_interval_ms: 100
+success_criteria:
+  min_avg_tps: 85
+  check_no_restarts: true
+  wait_for_catchup_s: 720
+  latency_thresholds:
+    - threshold_s: 3.6
+      latency_type: P50
+    - threshold_s: 4.8
+      latency_type: P70
+  chain_progress:
+    max_non_epoch_no_progress_secs: 15.0
+    max_epoch_no_progress_secs: 16.0
+    max_non_epoch_round_gap: 4
+    max_epoch_round_gap: 4
+  system_metrics:
+    cpu_threshold:
+      max: 25.0
+      max_breach_pct: 15
+    memory_threshold:
+      # 16 GB base + 8 GB/hr * 2hr
+      max: 34359738368.0
+      max_breach_pct: 20
+validator_resource_override:
+  storage_gib: 1000
+fullnode_resource_override:
+  storage_gib: 1000
+extra:
+  inner_mempool_backlog: 38000
+  inner_min_tps: 11000
+  inner_gas_price_multiplier: 20

--- a/testsuite/forge-cli/config/realistic_env_orderbook_workload_sweep.yaml
+++ b/testsuite/forge-cli/config/realistic_env_orderbook_workload_sweep.yaml
@@ -1,0 +1,20 @@
+test_name: orderbook_workload_sweep_realistic_env
+initial_validator_count: 7
+initial_fullnode_count: 3
+emit_job:
+  mode:
+    type: MaxLoad
+    mempool_backlog: 40000
+  latency_polling_interval_ms: 100
+genesis_helm_config:
+  chain:
+    epoch_duration_secs: 86400
+success_criteria:
+  min_avg_tps: 0
+  check_no_restarts: true
+  wait_for_catchup_s: 60
+  chain_progress:
+    max_non_epoch_no_progress_secs: 30.0
+    max_epoch_no_progress_secs: 30.0
+    max_non_epoch_round_gap: 10
+    max_epoch_round_gap: 10

--- a/testsuite/forge-cli/config/realistic_env_workload_sweep.yaml
+++ b/testsuite/forge-cli/config/realistic_env_workload_sweep.yaml
@@ -1,0 +1,20 @@
+test_name: workload_sweep_realistic_env
+initial_validator_count: 7
+initial_fullnode_count: 3
+emit_job:
+  mode:
+    type: MaxLoad
+    mempool_backlog: 40000
+  latency_polling_interval_ms: 100
+genesis_helm_config:
+  chain:
+    epoch_duration_secs: 86400
+success_criteria:
+  min_avg_tps: 0
+  check_no_restarts: true
+  wait_for_catchup_s: 60
+  chain_progress:
+    max_non_epoch_no_progress_secs: 30.0
+    max_epoch_no_progress_secs: 30.0
+    max_non_epoch_round_gap: 10
+    max_epoch_round_gap: 10

--- a/testsuite/forge-cli/config/realistic_network_tuned_for_throughput.yaml
+++ b/testsuite/forge-cli/config/realistic_network_tuned_for_throughput.yaml
@@ -1,0 +1,15 @@
+test_name: realistic_network_tuned_for_throughput
+initial_validator_count: 12
+initial_fullnode_count: 12
+emit_job:
+  mode:
+    type: MaxLoad
+    mempool_backlog: 60000
+success_criteria:
+  min_avg_tps: 11000
+  check_no_restarts: true
+  wait_for_catchup_s: 120
+extra:
+  target_tps: 15000
+  max_txns_per_block: 3500
+  vn_latency: 2.5

--- a/testsuite/forge-cli/config/single_vfn_perf.yaml
+++ b/testsuite/forge-cli/config/single_vfn_perf.yaml
@@ -1,0 +1,7 @@
+test_name: single_vfn_perf
+initial_validator_count: 1
+initial_fullnode_count: 1
+success_criteria:
+  min_avg_tps: 5000
+  check_no_restarts: true
+  wait_for_catchup_s: 240

--- a/testsuite/forge-cli/config/workload_mix.yaml
+++ b/testsuite/forge-cli/config/workload_mix.yaml
@@ -1,0 +1,12 @@
+test_name: workload_mix
+initial_validator_count: 5
+initial_fullnode_count: 3
+success_criteria:
+  min_avg_tps: 3000
+  check_no_restarts: true
+  wait_for_catchup_s: 240
+  chain_progress:
+    max_non_epoch_no_progress_secs: 20.0
+    max_epoch_no_progress_secs: 20.0
+    max_non_epoch_round_gap: 6
+    max_epoch_round_gap: 6

--- a/testsuite/forge-cli/src/embedded_configs.rs
+++ b/testsuite/forge-cli/src/embedded_configs.rs
@@ -8,27 +8,84 @@ static EMBEDDED_CONFIGS: Lazy<HashMap<&str, &str>> = Lazy::new(|| {
     let mut m = HashMap::new();
     // Land blocking / docker-build-test
     m.insert("compat", include_str!("../config/compat.yaml"));
-    m.insert("framework_upgrade", include_str!("../config/framework_upgrade.yaml"));
-    m.insert("realistic_env_max_load", include_str!("../config/realistic_env_max_load.yaml"));
-    m.insert("land_blocking", include_str!("../config/realistic_env_max_load.yaml")); // alias
-    m.insert("realistic_env_max_load_large", include_str!("../config/realistic_env_max_load_large.yaml"));
-    m.insert("consensus_only_realistic_env_max_tps", include_str!("../config/consensus_only_realistic_env_max_tps.yaml"));
-    m.insert("multiregion_benchmark_test", include_str!("../config/multiregion_benchmark_test.yaml"));
+    m.insert(
+        "framework_upgrade",
+        include_str!("../config/framework_upgrade.yaml"),
+    );
+    m.insert(
+        "realistic_env_max_load",
+        include_str!("../config/realistic_env_max_load.yaml"),
+    );
+    m.insert(
+        "land_blocking",
+        include_str!("../config/realistic_env_max_load.yaml"),
+    ); // alias
+    m.insert(
+        "realistic_env_max_load_large",
+        include_str!("../config/realistic_env_max_load_large.yaml"),
+    );
+    m.insert(
+        "consensus_only_realistic_env_max_tps",
+        include_str!("../config/consensus_only_realistic_env_max_tps.yaml"),
+    );
+    m.insert(
+        "multiregion_benchmark_test",
+        include_str!("../config/multiregion_benchmark_test.yaml"),
+    );
     // Forge stable
-    m.insert("realistic_env_load_sweep", include_str!("../config/realistic_env_load_sweep.yaml"));
-    m.insert("realistic_env_workload_sweep", include_str!("../config/realistic_env_workload_sweep.yaml"));
-    m.insert("realistic_env_orderbook_workload_sweep", include_str!("../config/realistic_env_orderbook_workload_sweep.yaml"));
-    m.insert("realistic_env_graceful_overload", include_str!("../config/realistic_env_graceful_overload.yaml"));
-    m.insert("realistic_env_graceful_workload_sweep", include_str!("../config/realistic_env_graceful_workload_sweep.yaml"));
-    m.insert("realistic_env_fairness_workload_sweep", include_str!("../config/realistic_env_fairness_workload_sweep.yaml"));
-    m.insert("realistic_network_tuned_for_throughput", include_str!("../config/realistic_network_tuned_for_throughput.yaml"));
-    m.insert("consensus_stress_test", include_str!("../config/consensus_stress_test.yaml"));
+    m.insert(
+        "realistic_env_load_sweep",
+        include_str!("../config/realistic_env_load_sweep.yaml"),
+    );
+    m.insert(
+        "realistic_env_workload_sweep",
+        include_str!("../config/realistic_env_workload_sweep.yaml"),
+    );
+    m.insert(
+        "realistic_env_orderbook_workload_sweep",
+        include_str!("../config/realistic_env_orderbook_workload_sweep.yaml"),
+    );
+    m.insert(
+        "realistic_env_graceful_overload",
+        include_str!("../config/realistic_env_graceful_overload.yaml"),
+    );
+    m.insert(
+        "realistic_env_graceful_workload_sweep",
+        include_str!("../config/realistic_env_graceful_workload_sweep.yaml"),
+    );
+    m.insert(
+        "realistic_env_fairness_workload_sweep",
+        include_str!("../config/realistic_env_fairness_workload_sweep.yaml"),
+    );
+    m.insert(
+        "realistic_network_tuned_for_throughput",
+        include_str!("../config/realistic_network_tuned_for_throughput.yaml"),
+    );
+    m.insert(
+        "consensus_stress_test",
+        include_str!("../config/consensus_stress_test.yaml"),
+    );
     m.insert("workload_mix", include_str!("../config/workload_mix.yaml"));
-    m.insert("single_vfn_perf", include_str!("../config/single_vfn_perf.yaml"));
-    m.insert("fullnode_reboot_stress_test", include_str!("../config/fullnode_reboot_stress_test.yaml"));
-    m.insert("changing_working_quorum_test", include_str!("../config/changing_working_quorum_test.yaml"));
-    m.insert("changing_working_quorum_test_high_load", include_str!("../config/changing_working_quorum_test_high_load.yaml"));
-    m.insert("pfn_const_tps_with_realistic_env", include_str!("../config/pfn_const_tps_with_realistic_env.yaml"));
+    m.insert(
+        "single_vfn_perf",
+        include_str!("../config/single_vfn_perf.yaml"),
+    );
+    m.insert(
+        "fullnode_reboot_stress_test",
+        include_str!("../config/fullnode_reboot_stress_test.yaml"),
+    );
+    m.insert(
+        "changing_working_quorum_test",
+        include_str!("../config/changing_working_quorum_test.yaml"),
+    );
+    m.insert(
+        "changing_working_quorum_test_high_load",
+        include_str!("../config/changing_working_quorum_test_high_load.yaml"),
+    );
+    m.insert(
+        "pfn_const_tps_with_realistic_env",
+        include_str!("../config/pfn_const_tps_with_realistic_env.yaml"),
+    );
     m
 });
 

--- a/testsuite/forge-cli/src/embedded_configs.rs
+++ b/testsuite/forge-cli/src/embedded_configs.rs
@@ -1,0 +1,38 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+use once_cell::sync::Lazy;
+use std::collections::HashMap;
+
+static EMBEDDED_CONFIGS: Lazy<HashMap<&str, &str>> = Lazy::new(|| {
+    let mut m = HashMap::new();
+    // Land blocking / docker-build-test
+    m.insert("compat", include_str!("../config/compat.yaml"));
+    m.insert("framework_upgrade", include_str!("../config/framework_upgrade.yaml"));
+    m.insert("realistic_env_max_load", include_str!("../config/realistic_env_max_load.yaml"));
+    m.insert("land_blocking", include_str!("../config/realistic_env_max_load.yaml")); // alias
+    m.insert("realistic_env_max_load_large", include_str!("../config/realistic_env_max_load_large.yaml"));
+    m.insert("consensus_only_realistic_env_max_tps", include_str!("../config/consensus_only_realistic_env_max_tps.yaml"));
+    m.insert("multiregion_benchmark_test", include_str!("../config/multiregion_benchmark_test.yaml"));
+    // Forge stable
+    m.insert("realistic_env_load_sweep", include_str!("../config/realistic_env_load_sweep.yaml"));
+    m.insert("realistic_env_workload_sweep", include_str!("../config/realistic_env_workload_sweep.yaml"));
+    m.insert("realistic_env_orderbook_workload_sweep", include_str!("../config/realistic_env_orderbook_workload_sweep.yaml"));
+    m.insert("realistic_env_graceful_overload", include_str!("../config/realistic_env_graceful_overload.yaml"));
+    m.insert("realistic_env_graceful_workload_sweep", include_str!("../config/realistic_env_graceful_workload_sweep.yaml"));
+    m.insert("realistic_env_fairness_workload_sweep", include_str!("../config/realistic_env_fairness_workload_sweep.yaml"));
+    m.insert("realistic_network_tuned_for_throughput", include_str!("../config/realistic_network_tuned_for_throughput.yaml"));
+    m.insert("consensus_stress_test", include_str!("../config/consensus_stress_test.yaml"));
+    m.insert("workload_mix", include_str!("../config/workload_mix.yaml"));
+    m.insert("single_vfn_perf", include_str!("../config/single_vfn_perf.yaml"));
+    m.insert("fullnode_reboot_stress_test", include_str!("../config/fullnode_reboot_stress_test.yaml"));
+    m.insert("changing_working_quorum_test", include_str!("../config/changing_working_quorum_test.yaml"));
+    m.insert("changing_working_quorum_test_high_load", include_str!("../config/changing_working_quorum_test_high_load.yaml"));
+    m.insert("pfn_const_tps_with_realistic_env", include_str!("../config/pfn_const_tps_with_realistic_env.yaml"));
+    m
+});
+
+/// Get an embedded YAML config by suite name
+pub fn get(name: &str) -> Option<&'static str> {
+    EMBEDDED_CONFIGS.get(name).copied()
+}

--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -27,9 +27,9 @@ use suites::{
 };
 use tokio::runtime::Runtime;
 
+mod embedded_configs;
 mod suites;
 mod test_registry;
-mod embedded_configs;
 
 #[cfg(unix)]
 #[global_allocator]
@@ -255,11 +255,14 @@ fn main() -> Result<()> {
             // If FORGE_TEST_CONFIG env var is set, load from that YAML file.
             // Otherwise, use the normal suite resolution (embedded YAML -> Rust code).
             let mut test_suite = if let Ok(config_path) = std::env::var("FORGE_TEST_CONFIG") {
-                let config = aptos_forge::ForgeTestConfig::from_file(std::path::Path::new(&config_path))?;
+                let config =
+                    aptos_forge::ForgeTestConfig::from_file(std::path::Path::new(&config_path))?;
                 let registry = test_registry::TestRegistry::build_default();
                 let code = registry
                     .get_with_config(&config.test_name, &config)
-                    .ok_or_else(|| format_err!("Unknown test_name in config: {}", config.test_name))?;
+                    .ok_or_else(|| {
+                        format_err!("Unknown test_name in config: {}", config.test_name)
+                    })?;
                 config.to_forge_config(code)?
             } else {
                 get_test_suite(suite_name, duration, test_cmd)?
@@ -610,17 +613,25 @@ mod test {
             let yaml = embedded_configs::get(suite_name)
                 .unwrap_or_else(|| panic!("Missing embedded config for suite: {}", suite_name));
 
-            let config = ForgeTestConfig::from_yaml(yaml)
-                .unwrap_or_else(|e| panic!("Failed to parse YAML for suite '{}': {}", suite_name, e));
+            let config = ForgeTestConfig::from_yaml(yaml).unwrap_or_else(|e| {
+                panic!("Failed to parse YAML for suite '{}': {}", suite_name, e)
+            });
 
-            let code = registry.get_with_config(&config.test_name, &config)
-                .unwrap_or_else(|| panic!(
-                    "Test name '{}' (from suite '{}') not found in registry",
-                    config.test_name, suite_name
-                ));
+            let code = registry
+                .get_with_config(&config.test_name, &config)
+                .unwrap_or_else(|| {
+                    panic!(
+                        "Test name '{}' (from suite '{}') not found in registry",
+                        config.test_name, suite_name
+                    )
+                });
 
-            config.to_forge_config(code)
-                .unwrap_or_else(|e| panic!("Failed to assemble ForgeConfig for suite '{}': {}", suite_name, e));
+            config.to_forge_config(code).unwrap_or_else(|e| {
+                panic!(
+                    "Failed to assemble ForgeConfig for suite '{}': {}",
+                    suite_name, e
+                )
+            });
         }
     }
 
@@ -629,12 +640,18 @@ mod test {
         use aptos_forge::ForgeTestConfig;
 
         // "land_blocking" should resolve to the same config as "realistic_env_max_load"
-        let land_blocking = embedded_configs::get("land_blocking").expect("land_blocking config missing");
-        let realistic = embedded_configs::get("realistic_env_max_load").expect("realistic_env_max_load config missing");
-        assert_eq!(land_blocking, realistic, "land_blocking should alias realistic_env_max_load");
+        let land_blocking =
+            embedded_configs::get("land_blocking").expect("land_blocking config missing");
+        let realistic = embedded_configs::get("realistic_env_max_load")
+            .expect("realistic_env_max_load config missing");
+        assert_eq!(
+            land_blocking, realistic,
+            "land_blocking should alias realistic_env_max_load"
+        );
 
         // And it should parse correctly
-        let config = ForgeTestConfig::from_yaml(land_blocking).expect("Failed to parse land_blocking YAML");
+        let config =
+            ForgeTestConfig::from_yaml(land_blocking).expect("Failed to parse land_blocking YAML");
         assert_eq!(config.test_name, "two_traffics_realistic_env");
     }
 }

--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -28,6 +28,8 @@ use suites::{
 use tokio::runtime::Runtime;
 
 mod suites;
+mod test_registry;
+mod embedded_configs;
 
 #[cfg(unix)]
 #[global_allocator]
@@ -249,8 +251,19 @@ fn main() -> Result<()> {
     match args.cli_cmd {
         // cmd input for test
         CliCommand::Test(ref test_cmd) => {
-            // Identify the test suite to run
-            let mut test_suite = get_test_suite(suite_name, duration, test_cmd)?;
+            // Identify the test suite to run.
+            // If FORGE_TEST_CONFIG env var is set, load from that YAML file.
+            // Otherwise, use the normal suite resolution (embedded YAML -> Rust code).
+            let mut test_suite = if let Ok(config_path) = std::env::var("FORGE_TEST_CONFIG") {
+                let config = aptos_forge::ForgeTestConfig::from_file(std::path::Path::new(&config_path))?;
+                let registry = test_registry::TestRegistry::build_default();
+                let code = registry
+                    .get_with_config(&config.test_name, &config)
+                    .ok_or_else(|| format_err!("Unknown test_name in config: {}", config.test_name))?;
+                config.to_forge_config(code)?
+            } else {
+                get_test_suite(suite_name, duration, test_cmd)?
+            };
 
             // Identify the number of validators and fullnodes to run
             // (if overriding what test has specified)
@@ -491,14 +504,23 @@ pub fn run_forge<F: Factory>(forge: Forge<F>, options: &Options) -> Result<()> {
     }
 }
 
-// TODO: can we clean this function up?
-/// Returns the test suite for the given test name
+/// Returns the test suite for the given test name.
+/// First tries embedded YAML configs, then falls back to Rust-defined suites.
 fn get_test_suite(
     test_name: &str,
     duration: Duration,
     test_cmd: &TestCommand,
 ) -> Result<ForgeConfig> {
-    // These are high level suite aliases that express an intent
+    // Try embedded YAML config first
+    if let Some(yaml) = embedded_configs::get(test_name) {
+        let config = aptos_forge::ForgeTestConfig::from_yaml(yaml)?;
+        let registry = test_registry::TestRegistry::build_default();
+        if let Some(code) = registry.get_with_config(&config.test_name, &config) {
+            return config.to_forge_config(code);
+        }
+    }
+
+    // Fall back to Rust-defined suite aliases
     let suite_aliases = hmap! {
         "local_test_suite" => boxed!(local_test_suite) as Box<dyn Fn() -> ForgeConfig>,
         "pre_release" => boxed!(pre_release_suite),
@@ -511,9 +533,7 @@ fn get_test_suite(
         return Ok(test_suite());
     }
 
-    // Otherwise, check the test name against the grouped test suites
-    // This is done in order of priority
-    // A match higher up in the list will take precedence
+    // Fall back to Rust-defined grouped test suites
     let named_test_suites = [
         boxed!(|| get_land_blocking_test(test_name, duration, test_cmd))
             as Box<dyn Fn() -> Option<ForgeConfig>>,
@@ -554,5 +574,67 @@ mod test {
     fn verify_tool() {
         use clap::CommandFactory;
         Args::command().debug_assert()
+    }
+
+    #[test]
+    fn test_all_embedded_configs_parse_and_assemble() {
+        use aptos_forge::ForgeTestConfig;
+
+        let registry = test_registry::TestRegistry::build_default();
+
+        // All suite names that have embedded YAML configs (excluding aliases like "land_blocking")
+        let suite_names = vec![
+            "compat",
+            "framework_upgrade",
+            "realistic_env_max_load",
+            "realistic_env_max_load_large",
+            "consensus_only_realistic_env_max_tps",
+            "multiregion_benchmark_test",
+            "realistic_env_load_sweep",
+            "realistic_env_workload_sweep",
+            "realistic_env_orderbook_workload_sweep",
+            "realistic_env_graceful_overload",
+            "realistic_env_graceful_workload_sweep",
+            "realistic_env_fairness_workload_sweep",
+            "realistic_network_tuned_for_throughput",
+            "consensus_stress_test",
+            "workload_mix",
+            "single_vfn_perf",
+            "fullnode_reboot_stress_test",
+            "changing_working_quorum_test",
+            "changing_working_quorum_test_high_load",
+            "pfn_const_tps_with_realistic_env",
+        ];
+
+        for suite_name in &suite_names {
+            let yaml = embedded_configs::get(suite_name)
+                .unwrap_or_else(|| panic!("Missing embedded config for suite: {}", suite_name));
+
+            let config = ForgeTestConfig::from_yaml(yaml)
+                .unwrap_or_else(|e| panic!("Failed to parse YAML for suite '{}': {}", suite_name, e));
+
+            let code = registry.get_with_config(&config.test_name, &config)
+                .unwrap_or_else(|| panic!(
+                    "Test name '{}' (from suite '{}') not found in registry",
+                    config.test_name, suite_name
+                ));
+
+            config.to_forge_config(code)
+                .unwrap_or_else(|e| panic!("Failed to assemble ForgeConfig for suite '{}': {}", suite_name, e));
+        }
+    }
+
+    #[test]
+    fn test_land_blocking_alias() {
+        use aptos_forge::ForgeTestConfig;
+
+        // "land_blocking" should resolve to the same config as "realistic_env_max_load"
+        let land_blocking = embedded_configs::get("land_blocking").expect("land_blocking config missing");
+        let realistic = embedded_configs::get("realistic_env_max_load").expect("realistic_env_max_load config missing");
+        assert_eq!(land_blocking, realistic, "land_blocking should alias realistic_env_max_load");
+
+        // And it should parse correctly
+        let config = ForgeTestConfig::from_yaml(land_blocking).expect("Failed to parse land_blocking YAML");
+        assert_eq!(config.test_name, "two_traffics_realistic_env");
     }
 }

--- a/testsuite/forge-cli/src/test_registry.rs
+++ b/testsuite/forge-cli/src/test_registry.rs
@@ -1,0 +1,534 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+use aptos_config::config::NodeConfig;
+use aptos_forge::{
+    test_config::{ForgeTestConfig, TestCodeComponents},
+    EmitJobMode, EmitJobRequest,
+};
+use aptos_testcases::{
+    compatibility_test::SimpleValidatorUpgrade,
+    consensus_reliability_tests::ChangingWorkingQuorumTest,
+    framework_upgrade::FrameworkUpgrade,
+    fullnode_reboot_stress_test::FullNodeRebootStressTest,
+    load_vs_perf_benchmark::{LoadVsPerfBenchmark, TransactionWorkload, Workloads},
+    modifiers::CpuChaosTest,
+    multi_region_network_test::MultiRegionNetworkEmulationTest,
+    performance_test::PerformanceBenchmark,
+    public_fullnode_performance::PFNPerformance,
+    three_region_simulation_test::ThreeRegionSameCloudSimulationTest,
+    two_traffics_test::TwoTrafficsTest,
+    CompositeNetworkTest,
+};
+use std::{collections::HashMap, sync::Arc};
+
+use crate::suites::{
+    realistic_environment::wrap_with_realistic_env,
+    ungrouped::{
+        background_traffic_for_sweep, background_traffic_for_sweep_with_latency,
+        optimize_for_maximum_throughput, optimize_state_sync_for_throughput,
+    },
+};
+
+use aptos_forge::{
+    args::TransactionTypeArg,
+    prometheus_metrics::LatencyBreakdownSlice,
+    success_criteria::{
+        LatencyBreakdownThreshold, LatencyType, SuccessCriteria,
+    },
+};
+
+type TestFactory = Box<dyn Fn(&ForgeTestConfig) -> TestCodeComponents + Send + Sync>;
+
+pub struct TestRegistry {
+    tests: HashMap<String, TestFactory>,
+}
+
+impl TestRegistry {
+    pub fn new() -> Self {
+        Self {
+            tests: HashMap::new(),
+        }
+    }
+
+    pub fn register(&mut self, name: &str, factory: TestFactory) {
+        self.tests.insert(name.to_string(), factory);
+    }
+
+    pub fn get_with_config(&self, name: &str, config: &ForgeTestConfig) -> Option<TestCodeComponents> {
+        self.tests.get(name).map(|factory| factory(config))
+    }
+
+    /// Build the default registry with all known test types
+    pub fn build_default() -> Self {
+        let mut registry = Self::new();
+
+        // === Simple test types (no extra closures needed) ===
+
+        registry.register("performance_benchmark", Box::new(|_| TestCodeComponents {
+            network_tests: vec![Box::new(PerformanceBenchmark)],
+            ..Default::default()
+        }));
+
+        registry.register("simple_validator_upgrade", Box::new(|_| TestCodeComponents {
+            network_tests: vec![Box::new(SimpleValidatorUpgrade)],
+            ..Default::default()
+        }));
+
+        registry.register("framework_upgrade", Box::new(|_| TestCodeComponents {
+            network_tests: vec![Box::new(FrameworkUpgrade)],
+            ..Default::default()
+        }));
+
+        registry.register("fullnode_reboot_stress_test", Box::new(|_| TestCodeComponents {
+            network_tests: vec![Box::new(FullNodeRebootStressTest)],
+            ..Default::default()
+        }));
+
+        registry.register("three_region_simulation", Box::new(|_| TestCodeComponents {
+            network_tests: vec![Box::new(ThreeRegionSameCloudSimulationTest)],
+            ..Default::default()
+        }));
+
+        // === Tests requiring realistic env wrapping ===
+
+        registry.register("two_traffics_realistic_env", Box::new(|config| {
+            let num_validators = config.initial_validator_count;
+            let extra = config.extra.as_ref();
+
+            let inner_mempool_backlog = extra
+                .and_then(|e| e["inner_mempool_backlog"].as_u64())
+                .map(|v| v as usize)
+                .unwrap_or(38000);
+            let inner_min_tps = extra
+                .and_then(|e| e["inner_min_tps"].as_u64())
+                .map(|v| v as usize)
+                .unwrap_or(10000);
+            let inner_gas_price_multiplier = extra
+                .and_then(|e| e["inner_gas_price_multiplier"].as_u64())
+                .unwrap_or(20);
+
+            TestCodeComponents {
+                network_tests: vec![Box::new(wrap_with_realistic_env(
+                    num_validators,
+                    TwoTrafficsTest {
+                        inner_traffic: EmitJobRequest::default()
+                            .mode(EmitJobMode::MaxLoad {
+                                mempool_backlog: inner_mempool_backlog,
+                            })
+                            .init_gas_price_multiplier(inner_gas_price_multiplier),
+                        inner_success_criteria: aptos_forge::success_criteria::SuccessCriteria::new(
+                            inner_min_tps,
+                        ),
+                    },
+                ))],
+                ..Default::default()
+            }
+        }));
+
+        registry.register("two_traffics_realistic_env_const_tps", Box::new(|config| {
+            let num_validators = config.initial_validator_count;
+            let extra = config.extra.as_ref();
+
+            let inner_tps = extra
+                .and_then(|e| e["inner_tps"].as_u64())
+                .map(|v| v as usize)
+                .unwrap_or(30000);
+            let inner_min_tps = extra
+                .and_then(|e| e["inner_min_tps"].as_u64())
+                .map(|v| v as usize)
+                .unwrap_or(7500);
+            let inner_gas_price_multiplier = extra
+                .and_then(|e| e["inner_gas_price_multiplier"].as_u64())
+                .unwrap_or(20);
+
+            TestCodeComponents {
+                network_tests: vec![Box::new(wrap_with_realistic_env(
+                    num_validators,
+                    TwoTrafficsTest {
+                        inner_traffic: EmitJobRequest::default()
+                            .mode(EmitJobMode::ConstTps { tps: inner_tps })
+                            .init_gas_price_multiplier(inner_gas_price_multiplier),
+                        inner_success_criteria: aptos_forge::success_criteria::SuccessCriteria::new(
+                            inner_min_tps,
+                        ),
+                    },
+                ))],
+                ..Default::default()
+            }
+        }));
+
+        // === Consensus tests ===
+
+        registry.register("consensus_only_realistic_env", Box::new(|config| {
+            let num_validators = config.initial_validator_count;
+            let extra = config.extra.as_ref();
+
+            let target_tps = extra
+                .and_then(|e| e["target_tps"].as_u64())
+                .map(|v| v as usize)
+                .unwrap_or(20_000);
+            let max_txns_per_block = extra
+                .and_then(|e| e["max_txns_per_block"].as_u64())
+                .map(|v| v as usize)
+                .unwrap_or(4_500);
+            let vn_latency = extra
+                .and_then(|e| e["vn_latency"].as_f64())
+                .unwrap_or(3.0);
+
+            TestCodeComponents {
+                network_tests: vec![Box::new(CompositeNetworkTest::new(
+                    MultiRegionNetworkEmulationTest::default_for_validator_count(num_validators),
+                    CpuChaosTest::default(),
+                ))],
+                extra_validator_override_fn: Some(Arc::new(move |config, _| {
+                    optimize_for_maximum_throughput(config, target_tps, max_txns_per_block, vn_latency);
+                    crate::suites::state_sync::state_sync_config_execute_transactions(
+                        &mut config.state_sync,
+                    );
+                })),
+                ..Default::default()
+            }
+        }));
+
+        // === Changing working quorum test ===
+
+        registry.register("changing_working_quorum", Box::new(|config| {
+            let extra = config.extra.as_ref();
+
+            let min_tps = extra
+                .and_then(|e| e["min_tps"].as_u64())
+                .map(|v| v as usize)
+                .unwrap_or(15);
+            let always_healthy_nodes = extra
+                .and_then(|e| e["always_healthy_nodes"].as_u64())
+                .map(|v| v as usize)
+                .unwrap_or(0);
+            let max_down_nodes = extra
+                .and_then(|e| e["max_down_nodes"].as_u64())
+                .map(|v| v as usize)
+                .unwrap_or(16);
+            let num_large_validators = extra
+                .and_then(|e| e["num_large_validators"].as_u64())
+                .map(|v| v as usize)
+                .unwrap_or(0);
+            let add_execution_delay = extra
+                .and_then(|e| e["add_execution_delay"].as_bool())
+                .unwrap_or(false);
+            let check_period_s = extra
+                .and_then(|e| e["check_period_s"].as_u64())
+                .map(|v| v as usize)
+                .unwrap_or(53);
+
+            TestCodeComponents {
+                network_tests: vec![Box::new(ChangingWorkingQuorumTest {
+                    min_tps,
+                    always_healthy_nodes,
+                    max_down_nodes,
+                    num_large_validators,
+                    add_execution_delay,
+                    check_period_s,
+                })],
+                ..Default::default()
+            }
+        }));
+
+        // === Multi-region benchmark ===
+
+        registry.register("multiregion_benchmark", Box::new(|_| TestCodeComponents {
+            network_tests: vec![Box::new(PerformanceBenchmark)],
+            ..Default::default()
+        }));
+
+        // === PFN tests ===
+
+        registry.register("pfn_const_tps", Box::new(|config| {
+            let extra = config.extra.as_ref();
+
+            let num_pfns = extra
+                .and_then(|e| e["num_pfns"].as_u64())
+                .unwrap_or(7);
+            let add_cpu_chaos = extra
+                .and_then(|e| e["add_cpu_chaos"].as_bool())
+                .unwrap_or(false);
+            let add_network_emulation = extra
+                .and_then(|e| e["add_network_emulation"].as_bool())
+                .unwrap_or(true);
+
+            TestCodeComponents {
+                network_tests: vec![Box::new(PFNPerformance::new(
+                    num_pfns,
+                    add_cpu_chaos,
+                    add_network_emulation,
+                    Some(Arc::new(|config: &mut NodeConfig, _| {
+                        config.indexer_db_config.enable_event = true;
+                    })),
+                ))],
+                ..Default::default()
+            }
+        }));
+
+        // === Load vs perf sweep tests ===
+
+        registry.register("load_sweep_realistic_env", Box::new(|config| {
+            let num_validators = config.initial_validator_count;
+            TestCodeComponents {
+                network_tests: vec![Box::new(wrap_with_realistic_env(
+                    num_validators,
+                    LoadVsPerfBenchmark {
+                        test: Box::new(PerformanceBenchmark),
+                        workloads: Workloads::TPS(vec![10, 100, 1000, 3000, 5000, 7000]),
+                        criteria: [
+                            (9, 0.9, 1.0, 1.2, 0),
+                            (95, 0.9, 1.1, 1.2, 0),
+                            (950, 1.2, 1.3, 2.0, 0),
+                            (2900, 1.4, 2.2, 2.5, 0),
+                            (4800, 2.0, 2.5, 3.0, 0),
+                            (6700, 2.5, 3.5, 5.0, 0),
+                        ]
+                        .into_iter()
+                        .map(|(min_tps, max_lat_p50, max_lat_p90, max_lat_p99, max_expired_tps)| {
+                            SuccessCriteria::new(min_tps)
+                                .add_max_expired_tps(max_expired_tps as f64)
+                                .add_max_failed_submission_tps(0.0)
+                                .add_latency_threshold(max_lat_p50, LatencyType::P50)
+                                .add_latency_threshold(max_lat_p90, LatencyType::P90)
+                                .add_latency_threshold(max_lat_p99, LatencyType::P99)
+                        })
+                        .collect(),
+                        background_traffic: background_traffic_for_sweep(5),
+                    },
+                ))],
+                extra_validator_override_fn: Some(Arc::new(|config, _| {
+                    config.execution.processed_transactions_detailed_counters = true;
+                })),
+                ..Default::default()
+            }
+        }));
+
+        registry.register("workload_sweep_realistic_env", Box::new(|config| {
+            let num_validators = config.initial_validator_count;
+            TestCodeComponents {
+                network_tests: vec![Box::new(wrap_with_realistic_env(
+                    num_validators,
+                    LoadVsPerfBenchmark {
+                        test: Box::new(PerformanceBenchmark),
+                        workloads: Workloads::TRANSACTIONS(vec![
+                            TransactionWorkload::new(TransactionTypeArg::CoinTransfer, 20000),
+                            TransactionWorkload::new(TransactionTypeArg::NoOp, 20000).with_num_modules(100),
+                            TransactionWorkload::new(TransactionTypeArg::ModifyGlobalResource, 6000)
+                                .with_transactions_per_account(1),
+                            TransactionWorkload::new(TransactionTypeArg::TokenV2AmbassadorMint, 20000)
+                                .with_unique_senders(),
+                            TransactionWorkload::new(TransactionTypeArg::PublishPackage, 200)
+                                .with_transactions_per_account(1),
+                        ]),
+                        criteria: [
+                            (7000, 100, 0.3 + 0.5, 0.5, 0.5),
+                            (8500, 100, 0.3 + 0.5, 0.5, 0.4),
+                            (2000, 300, 0.3 + 1.0, 0.6, 1.0),
+                            (3200, 500, 0.3 + 1.0, 0.7, 0.8),
+                            (28, 5, 0.3 + 5.0, 0.7, 1.0),
+                        ]
+                        .into_iter()
+                        .map(|(min_tps, max_expired, mempool_to_block, proposal_to_ordered, ordered_to_commit)| {
+                            SuccessCriteria::new(min_tps)
+                                .add_max_expired_tps(max_expired as f64)
+                                .add_max_failed_submission_tps(200.0)
+                                .add_no_restarts()
+                                .add_latency_breakdown_threshold(LatencyBreakdownThreshold::new_strict(vec![
+                                    (LatencyBreakdownSlice::MempoolToBlockCreation, mempool_to_block),
+                                    (LatencyBreakdownSlice::ConsensusProposalToOrdered, proposal_to_ordered),
+                                    (LatencyBreakdownSlice::ConsensusOrderedToCommit, ordered_to_commit),
+                                ]))
+                        })
+                        .collect(),
+                        background_traffic: background_traffic_for_sweep(5),
+                    },
+                ))],
+                extra_validator_override_fn: Some(Arc::new(|config, _| {
+                    config.execution.processed_transactions_detailed_counters = true;
+                })),
+                ..Default::default()
+            }
+        }));
+
+        registry.register("orderbook_workload_sweep_realistic_env", Box::new(|config| {
+            let num_validators = config.initial_validator_count;
+            TestCodeComponents {
+                network_tests: vec![Box::new(wrap_with_realistic_env(
+                    num_validators,
+                    LoadVsPerfBenchmark {
+                        test: Box::new(PerformanceBenchmark),
+                        workloads: Workloads::TRANSACTIONS(vec![
+                            TransactionWorkload::new(TransactionTypeArg::OrderBookBalancedMatches25Pct1Market, 1000),
+                            TransactionWorkload::new(TransactionTypeArg::OrderBookBalancedMatches25Pct50Markets, 5000),
+                            TransactionWorkload::new(TransactionTypeArg::OrderBookBalancedMatches80Pct1Market, 1000),
+                            TransactionWorkload::new(TransactionTypeArg::OrderBookBalancedMatches80Pct50Markets, 5000),
+                            TransactionWorkload::new(TransactionTypeArg::OrderBookBalancedSizeSkewed80Pct1Market, 1000),
+                            TransactionWorkload::new(TransactionTypeArg::OrderBookBalancedSizeSkewed80Pct50Markets, 5000),
+                            TransactionWorkload::new(TransactionTypeArg::OrderBookNoMatches1Market, 1000),
+                            TransactionWorkload::new(TransactionTypeArg::OrderBookNoMatches50Markets, 5000),
+                        ]),
+                        criteria: [
+                            (350, 100, 0.3 + 1.0, 0.4, 0.2),
+                            (1700, 100, 0.3 + 1.0, 0.4, 0.5),
+                            (350, 300, 0.3 + 1.0, 0.4, 0.2),
+                            (2000, 500, 0.3 + 1.0, 0.4, 0.5),
+                            (320, 5, 0.3 + 1.0, 0.4, 0.25),
+                            (1500, 5, 0.3 + 1.5, 0.4, 0.5),
+                            (320, 100, 0.3 + 1.0, 0.4, 0.2),
+                            (1700, 100, 0.3 + 1.0, 0.4, 0.7),
+                        ]
+                        .into_iter()
+                        .map(|(min_tps, max_expired, mempool_to_block, proposal_to_ordered, ordered_to_commit)| {
+                            SuccessCriteria::new(min_tps)
+                                .add_max_expired_tps(max_expired as f64)
+                                .add_max_failed_submission_tps(200.0)
+                                .add_no_restarts()
+                                .add_latency_breakdown_threshold(LatencyBreakdownThreshold::new_strict(vec![
+                                    (LatencyBreakdownSlice::MempoolToBlockCreation, mempool_to_block),
+                                    (LatencyBreakdownSlice::ConsensusProposalToOrdered, proposal_to_ordered),
+                                    (LatencyBreakdownSlice::ConsensusOrderedToCommit, ordered_to_commit),
+                                ]))
+                        })
+                        .collect(),
+                        background_traffic: background_traffic_for_sweep(5),
+                    },
+                ))],
+                extra_validator_override_fn: Some(Arc::new(|config, _| {
+                    config.execution.processed_transactions_detailed_counters = true;
+                })),
+                ..Default::default()
+            }
+        }));
+
+        registry.register("fairness_workload_sweep_realistic_env", Box::new(|config| {
+            let num_validators = config.initial_validator_count;
+            TestCodeComponents {
+                network_tests: vec![Box::new(wrap_with_realistic_env(
+                    num_validators,
+                    LoadVsPerfBenchmark {
+                        test: Box::new(PerformanceBenchmark),
+                        workloads: Workloads::TRANSACTIONS(vec![
+                            TransactionWorkload::new(TransactionTypeArg::ResourceGroupsGlobalWriteAndReadTag1KB, 100000),
+                            TransactionWorkload::new(TransactionTypeArg::VectorPicture30k, 20000),
+                            TransactionWorkload::new(TransactionTypeArg::SmartTablePicture1MWith256Change, 4000)
+                                .with_transactions_per_account(1),
+                        ]),
+                        criteria: Vec::new(),
+                        background_traffic: background_traffic_for_sweep_with_latency(
+                            &[(2.0, 3.0, 8.0), (0.1, 25.0, 30.0), (0.1, 30.0, 45.0)],
+                            false,
+                        ),
+                    },
+                ))],
+                extra_validator_override_fn: Some(Arc::new(|config, _| {
+                    config.execution.processed_transactions_detailed_counters = true;
+                })),
+                ..Default::default()
+            }
+        }));
+
+        registry.register("graceful_workload_sweep_realistic_env", Box::new(|config| {
+            let num_validators = config.initial_validator_count;
+            TestCodeComponents {
+                network_tests: vec![Box::new(wrap_with_realistic_env(
+                    num_validators,
+                    LoadVsPerfBenchmark {
+                        test: Box::new(PerformanceBenchmark),
+                        workloads: Workloads::TRANSACTIONS(vec![
+                            TransactionWorkload::new_const_tps(TransactionTypeArg::AccountGeneration, 2 * 7000),
+                            TransactionWorkload::new_const_tps(TransactionTypeArg::ResourceGroupsGlobalWriteAndReadTag1KB, 3 * 1800),
+                            TransactionWorkload::new_const_tps(TransactionTypeArg::SmartTablePicture1MWith256Change, 3 * 14),
+                            TransactionWorkload::new_const_tps(TransactionTypeArg::SmartTablePicture1MWith1KChangeExceedsLimit, 3 * 12),
+                            TransactionWorkload::new_const_tps(TransactionTypeArg::VectorPicture30k, 3 * 150),
+                            TransactionWorkload::new_const_tps(TransactionTypeArg::ModifyGlobalFlagAggV2, 3 * 3500),
+                            TransactionWorkload::new_const_tps(TransactionTypeArg::PublishPackage, 3 * 150)
+                                .with_transactions_per_account(1),
+                        ]),
+                        criteria: Vec::new(),
+                        background_traffic: background_traffic_for_sweep_with_latency(
+                            &[
+                                (0.1, 4.0, 5.0),
+                                (0.1, 2.2, 3.0),
+                                (0.1, 3.5, 5.0),
+                                (0.1, 4.0, 6.0),
+                                (0.1, 3.0, 5.0),
+                                (0.1, 5.0, 10.0),
+                                (0.1, 3.0, 10.0),
+                            ],
+                            true,
+                        ),
+                    },
+                ))],
+                extra_validator_override_fn: Some(Arc::new(|config, _| {
+                    config.execution.processed_transactions_detailed_counters = true;
+                })),
+                ..Default::default()
+            }
+        }));
+
+        // === Throughput tuned test ===
+
+        registry.register("realistic_network_tuned_for_throughput", Box::new(|config| {
+            let num_validators = config.initial_validator_count;
+            let extra = config.extra.as_ref();
+
+            let target_tps = extra
+                .and_then(|e| e["target_tps"].as_u64())
+                .map(|v| v as usize)
+                .unwrap_or(15_000);
+            let max_txns_per_block = extra
+                .and_then(|e| e["max_txns_per_block"].as_u64())
+                .map(|v| v as usize)
+                .unwrap_or(3_500);
+            let vn_latency = extra
+                .and_then(|e| e["vn_latency"].as_f64())
+                .unwrap_or(2.5);
+
+            TestCodeComponents {
+                network_tests: vec![Box::new(
+                    MultiRegionNetworkEmulationTest::default_for_validator_count(num_validators),
+                )],
+                extra_validator_override_fn: Some(Arc::new(move |config, _| {
+                    optimize_state_sync_for_throughput(config, 15_000);
+                    optimize_for_maximum_throughput(config, target_tps, max_txns_per_block, vn_latency);
+                    config.consensus.quorum_store_pull_timeout_ms = 200;
+                    config.storage.rocksdb_configs.enable_storage_sharding = true;
+                })),
+                extra_fullnode_override_fn: Some(Arc::new(|config, _| {
+                    optimize_state_sync_for_throughput(config, 15_000);
+                    config.storage.rocksdb_configs.enable_storage_sharding = true;
+                })),
+                ..Default::default()
+            }
+        }));
+
+        // === Workload mix test ===
+
+        registry.register("workload_mix", Box::new(|_| TestCodeComponents {
+            network_tests: vec![Box::new(PerformanceBenchmark)],
+            extra_validator_override_fn: Some(Arc::new(|config, _| {
+                config.execution.processed_transactions_detailed_counters = true;
+            })),
+            ..Default::default()
+        }));
+
+        // === Single VFN perf ===
+
+        registry.register("single_vfn_perf", Box::new(|_| TestCodeComponents {
+            network_tests: vec![Box::new(PerformanceBenchmark)],
+            extra_validator_override_fn: Some(Arc::new(|config, _| {
+                config
+                    .consensus
+                    .quorum_store
+                    .back_pressure
+                    .dynamic_max_txn_per_s = 5500;
+            })),
+            ..Default::default()
+        }));
+
+        registry
+    }
+}

--- a/testsuite/forge-cli/src/test_registry.rs
+++ b/testsuite/forge-cli/src/test_registry.rs
@@ -1,8 +1,18 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
+use crate::suites::{
+    realistic_environment::wrap_with_realistic_env,
+    ungrouped::{
+        background_traffic_for_sweep, background_traffic_for_sweep_with_latency,
+        optimize_for_maximum_throughput, optimize_state_sync_for_throughput,
+    },
+};
 use aptos_config::config::NodeConfig;
 use aptos_forge::{
+    args::TransactionTypeArg,
+    prometheus_metrics::LatencyBreakdownSlice,
+    success_criteria::{LatencyBreakdownThreshold, LatencyType, SuccessCriteria},
     test_config::{ForgeTestConfig, TestCodeComponents},
     EmitJobMode, EmitJobRequest,
 };
@@ -22,22 +32,6 @@ use aptos_testcases::{
 };
 use std::{collections::HashMap, sync::Arc};
 
-use crate::suites::{
-    realistic_environment::wrap_with_realistic_env,
-    ungrouped::{
-        background_traffic_for_sweep, background_traffic_for_sweep_with_latency,
-        optimize_for_maximum_throughput, optimize_state_sync_for_throughput,
-    },
-};
-
-use aptos_forge::{
-    args::TransactionTypeArg,
-    prometheus_metrics::LatencyBreakdownSlice,
-    success_criteria::{
-        LatencyBreakdownThreshold, LatencyType, SuccessCriteria,
-    },
-};
-
 type TestFactory = Box<dyn Fn(&ForgeTestConfig) -> TestCodeComponents + Send + Sync>;
 
 pub struct TestRegistry {
@@ -55,7 +49,11 @@ impl TestRegistry {
         self.tests.insert(name.to_string(), factory);
     }
 
-    pub fn get_with_config(&self, name: &str, config: &ForgeTestConfig) -> Option<TestCodeComponents> {
+    pub fn get_with_config(
+        &self,
+        name: &str,
+        config: &ForgeTestConfig,
+    ) -> Option<TestCodeComponents> {
         self.tests.get(name).map(|factory| factory(config))
     }
 
@@ -65,246 +63,291 @@ impl TestRegistry {
 
         // === Simple test types (no extra closures needed) ===
 
-        registry.register("performance_benchmark", Box::new(|_| TestCodeComponents {
-            network_tests: vec![Box::new(PerformanceBenchmark)],
-            ..Default::default()
-        }));
+        registry.register(
+            "performance_benchmark",
+            Box::new(|_| TestCodeComponents {
+                network_tests: vec![Box::new(PerformanceBenchmark)],
+                ..Default::default()
+            }),
+        );
 
-        registry.register("simple_validator_upgrade", Box::new(|_| TestCodeComponents {
-            network_tests: vec![Box::new(SimpleValidatorUpgrade)],
-            ..Default::default()
-        }));
+        registry.register(
+            "simple_validator_upgrade",
+            Box::new(|_| TestCodeComponents {
+                network_tests: vec![Box::new(SimpleValidatorUpgrade)],
+                ..Default::default()
+            }),
+        );
 
-        registry.register("framework_upgrade", Box::new(|_| TestCodeComponents {
-            network_tests: vec![Box::new(FrameworkUpgrade)],
-            ..Default::default()
-        }));
+        registry.register(
+            "framework_upgrade",
+            Box::new(|_| TestCodeComponents {
+                network_tests: vec![Box::new(FrameworkUpgrade)],
+                ..Default::default()
+            }),
+        );
 
-        registry.register("fullnode_reboot_stress_test", Box::new(|_| TestCodeComponents {
-            network_tests: vec![Box::new(FullNodeRebootStressTest)],
-            ..Default::default()
-        }));
+        registry.register(
+            "fullnode_reboot_stress_test",
+            Box::new(|_| TestCodeComponents {
+                network_tests: vec![Box::new(FullNodeRebootStressTest)],
+                ..Default::default()
+            }),
+        );
 
-        registry.register("three_region_simulation", Box::new(|_| TestCodeComponents {
-            network_tests: vec![Box::new(ThreeRegionSameCloudSimulationTest)],
-            ..Default::default()
-        }));
+        registry.register(
+            "three_region_simulation",
+            Box::new(|_| TestCodeComponents {
+                network_tests: vec![Box::new(ThreeRegionSameCloudSimulationTest)],
+                ..Default::default()
+            }),
+        );
 
         // === Tests requiring realistic env wrapping ===
 
-        registry.register("two_traffics_realistic_env", Box::new(|config| {
-            let num_validators = config.initial_validator_count;
-            let extra = config.extra.as_ref();
+        registry.register(
+            "two_traffics_realistic_env",
+            Box::new(|config| {
+                let num_validators = config.initial_validator_count;
+                let extra = config.extra.as_ref();
 
-            let inner_mempool_backlog = extra
-                .and_then(|e| e["inner_mempool_backlog"].as_u64())
-                .map(|v| v as usize)
-                .unwrap_or(38000);
-            let inner_min_tps = extra
-                .and_then(|e| e["inner_min_tps"].as_u64())
-                .map(|v| v as usize)
-                .unwrap_or(10000);
-            let inner_gas_price_multiplier = extra
-                .and_then(|e| e["inner_gas_price_multiplier"].as_u64())
-                .unwrap_or(20);
+                let inner_mempool_backlog = extra
+                    .and_then(|e| e["inner_mempool_backlog"].as_u64())
+                    .map(|v| v as usize)
+                    .unwrap_or(38000);
+                let inner_min_tps = extra
+                    .and_then(|e| e["inner_min_tps"].as_u64())
+                    .map(|v| v as usize)
+                    .unwrap_or(10000);
+                let inner_gas_price_multiplier = extra
+                    .and_then(|e| e["inner_gas_price_multiplier"].as_u64())
+                    .unwrap_or(20);
 
-            TestCodeComponents {
-                network_tests: vec![Box::new(wrap_with_realistic_env(
-                    num_validators,
-                    TwoTrafficsTest {
-                        inner_traffic: EmitJobRequest::default()
-                            .mode(EmitJobMode::MaxLoad {
-                                mempool_backlog: inner_mempool_backlog,
-                            })
-                            .init_gas_price_multiplier(inner_gas_price_multiplier),
-                        inner_success_criteria: aptos_forge::success_criteria::SuccessCriteria::new(
-                            inner_min_tps,
-                        ),
-                    },
-                ))],
-                ..Default::default()
-            }
-        }));
+                TestCodeComponents {
+                    network_tests: vec![Box::new(wrap_with_realistic_env(
+                        num_validators,
+                        TwoTrafficsTest {
+                            inner_traffic: EmitJobRequest::default()
+                                .mode(EmitJobMode::MaxLoad {
+                                    mempool_backlog: inner_mempool_backlog,
+                                })
+                                .init_gas_price_multiplier(inner_gas_price_multiplier),
+                            inner_success_criteria:
+                                aptos_forge::success_criteria::SuccessCriteria::new(inner_min_tps),
+                        },
+                    ))],
+                    ..Default::default()
+                }
+            }),
+        );
 
-        registry.register("two_traffics_realistic_env_const_tps", Box::new(|config| {
-            let num_validators = config.initial_validator_count;
-            let extra = config.extra.as_ref();
+        registry.register(
+            "two_traffics_realistic_env_const_tps",
+            Box::new(|config| {
+                let num_validators = config.initial_validator_count;
+                let extra = config.extra.as_ref();
 
-            let inner_tps = extra
-                .and_then(|e| e["inner_tps"].as_u64())
-                .map(|v| v as usize)
-                .unwrap_or(30000);
-            let inner_min_tps = extra
-                .and_then(|e| e["inner_min_tps"].as_u64())
-                .map(|v| v as usize)
-                .unwrap_or(7500);
-            let inner_gas_price_multiplier = extra
-                .and_then(|e| e["inner_gas_price_multiplier"].as_u64())
-                .unwrap_or(20);
+                let inner_tps = extra
+                    .and_then(|e| e["inner_tps"].as_u64())
+                    .map(|v| v as usize)
+                    .unwrap_or(30000);
+                let inner_min_tps = extra
+                    .and_then(|e| e["inner_min_tps"].as_u64())
+                    .map(|v| v as usize)
+                    .unwrap_or(7500);
+                let inner_gas_price_multiplier = extra
+                    .and_then(|e| e["inner_gas_price_multiplier"].as_u64())
+                    .unwrap_or(20);
 
-            TestCodeComponents {
-                network_tests: vec![Box::new(wrap_with_realistic_env(
-                    num_validators,
-                    TwoTrafficsTest {
-                        inner_traffic: EmitJobRequest::default()
-                            .mode(EmitJobMode::ConstTps { tps: inner_tps })
-                            .init_gas_price_multiplier(inner_gas_price_multiplier),
-                        inner_success_criteria: aptos_forge::success_criteria::SuccessCriteria::new(
-                            inner_min_tps,
-                        ),
-                    },
-                ))],
-                ..Default::default()
-            }
-        }));
+                TestCodeComponents {
+                    network_tests: vec![Box::new(wrap_with_realistic_env(
+                        num_validators,
+                        TwoTrafficsTest {
+                            inner_traffic: EmitJobRequest::default()
+                                .mode(EmitJobMode::ConstTps { tps: inner_tps })
+                                .init_gas_price_multiplier(inner_gas_price_multiplier),
+                            inner_success_criteria:
+                                aptos_forge::success_criteria::SuccessCriteria::new(inner_min_tps),
+                        },
+                    ))],
+                    ..Default::default()
+                }
+            }),
+        );
 
         // === Consensus tests ===
 
-        registry.register("consensus_only_realistic_env", Box::new(|config| {
-            let num_validators = config.initial_validator_count;
-            let extra = config.extra.as_ref();
+        registry.register(
+            "consensus_only_realistic_env",
+            Box::new(|config| {
+                let num_validators = config.initial_validator_count;
+                let extra = config.extra.as_ref();
 
-            let target_tps = extra
-                .and_then(|e| e["target_tps"].as_u64())
-                .map(|v| v as usize)
-                .unwrap_or(20_000);
-            let max_txns_per_block = extra
-                .and_then(|e| e["max_txns_per_block"].as_u64())
-                .map(|v| v as usize)
-                .unwrap_or(4_500);
-            let vn_latency = extra
-                .and_then(|e| e["vn_latency"].as_f64())
-                .unwrap_or(3.0);
+                let target_tps = extra
+                    .and_then(|e| e["target_tps"].as_u64())
+                    .map(|v| v as usize)
+                    .unwrap_or(20_000);
+                let max_txns_per_block = extra
+                    .and_then(|e| e["max_txns_per_block"].as_u64())
+                    .map(|v| v as usize)
+                    .unwrap_or(4_500);
+                let vn_latency = extra.and_then(|e| e["vn_latency"].as_f64()).unwrap_or(3.0);
 
-            TestCodeComponents {
-                network_tests: vec![Box::new(CompositeNetworkTest::new(
-                    MultiRegionNetworkEmulationTest::default_for_validator_count(num_validators),
-                    CpuChaosTest::default(),
-                ))],
-                extra_validator_override_fn: Some(Arc::new(move |config, _| {
-                    optimize_for_maximum_throughput(config, target_tps, max_txns_per_block, vn_latency);
-                    crate::suites::state_sync::state_sync_config_execute_transactions(
-                        &mut config.state_sync,
-                    );
-                })),
-                ..Default::default()
-            }
-        }));
+                TestCodeComponents {
+                    network_tests: vec![Box::new(CompositeNetworkTest::new(
+                        MultiRegionNetworkEmulationTest::default_for_validator_count(
+                            num_validators,
+                        ),
+                        CpuChaosTest::default(),
+                    ))],
+                    extra_validator_override_fn: Some(Arc::new(move |config, _| {
+                        optimize_for_maximum_throughput(
+                            config,
+                            target_tps,
+                            max_txns_per_block,
+                            vn_latency,
+                        );
+                        crate::suites::state_sync::state_sync_config_execute_transactions(
+                            &mut config.state_sync,
+                        );
+                    })),
+                    ..Default::default()
+                }
+            }),
+        );
 
         // === Changing working quorum test ===
 
-        registry.register("changing_working_quorum", Box::new(|config| {
-            let extra = config.extra.as_ref();
+        registry.register(
+            "changing_working_quorum",
+            Box::new(|config| {
+                let extra = config.extra.as_ref();
 
-            let min_tps = extra
-                .and_then(|e| e["min_tps"].as_u64())
-                .map(|v| v as usize)
-                .unwrap_or(15);
-            let always_healthy_nodes = extra
-                .and_then(|e| e["always_healthy_nodes"].as_u64())
-                .map(|v| v as usize)
-                .unwrap_or(0);
-            let max_down_nodes = extra
-                .and_then(|e| e["max_down_nodes"].as_u64())
-                .map(|v| v as usize)
-                .unwrap_or(16);
-            let num_large_validators = extra
-                .and_then(|e| e["num_large_validators"].as_u64())
-                .map(|v| v as usize)
-                .unwrap_or(0);
-            let add_execution_delay = extra
-                .and_then(|e| e["add_execution_delay"].as_bool())
-                .unwrap_or(false);
-            let check_period_s = extra
-                .and_then(|e| e["check_period_s"].as_u64())
-                .map(|v| v as usize)
-                .unwrap_or(53);
+                let min_tps = extra
+                    .and_then(|e| e["min_tps"].as_u64())
+                    .map(|v| v as usize)
+                    .unwrap_or(15);
+                let always_healthy_nodes = extra
+                    .and_then(|e| e["always_healthy_nodes"].as_u64())
+                    .map(|v| v as usize)
+                    .unwrap_or(0);
+                let max_down_nodes = extra
+                    .and_then(|e| e["max_down_nodes"].as_u64())
+                    .map(|v| v as usize)
+                    .unwrap_or(16);
+                let num_large_validators = extra
+                    .and_then(|e| e["num_large_validators"].as_u64())
+                    .map(|v| v as usize)
+                    .unwrap_or(0);
+                let add_execution_delay = extra
+                    .and_then(|e| e["add_execution_delay"].as_bool())
+                    .unwrap_or(false);
+                let check_period_s = extra
+                    .and_then(|e| e["check_period_s"].as_u64())
+                    .map(|v| v as usize)
+                    .unwrap_or(53);
 
-            TestCodeComponents {
-                network_tests: vec![Box::new(ChangingWorkingQuorumTest {
-                    min_tps,
-                    always_healthy_nodes,
-                    max_down_nodes,
-                    num_large_validators,
-                    add_execution_delay,
-                    check_period_s,
-                })],
-                ..Default::default()
-            }
-        }));
+                TestCodeComponents {
+                    network_tests: vec![Box::new(ChangingWorkingQuorumTest {
+                        min_tps,
+                        always_healthy_nodes,
+                        max_down_nodes,
+                        num_large_validators,
+                        add_execution_delay,
+                        check_period_s,
+                    })],
+                    ..Default::default()
+                }
+            }),
+        );
 
         // === Multi-region benchmark ===
 
-        registry.register("multiregion_benchmark", Box::new(|_| TestCodeComponents {
-            network_tests: vec![Box::new(PerformanceBenchmark)],
-            ..Default::default()
-        }));
+        registry.register(
+            "multiregion_benchmark",
+            Box::new(|_| TestCodeComponents {
+                network_tests: vec![Box::new(PerformanceBenchmark)],
+                ..Default::default()
+            }),
+        );
 
         // === PFN tests ===
 
-        registry.register("pfn_const_tps", Box::new(|config| {
-            let extra = config.extra.as_ref();
+        registry.register(
+            "pfn_const_tps",
+            Box::new(|config| {
+                let extra = config.extra.as_ref();
 
-            let num_pfns = extra
-                .and_then(|e| e["num_pfns"].as_u64())
-                .unwrap_or(7);
-            let add_cpu_chaos = extra
-                .and_then(|e| e["add_cpu_chaos"].as_bool())
-                .unwrap_or(false);
-            let add_network_emulation = extra
-                .and_then(|e| e["add_network_emulation"].as_bool())
-                .unwrap_or(true);
+                let num_pfns = extra.and_then(|e| e["num_pfns"].as_u64()).unwrap_or(7);
+                let add_cpu_chaos = extra
+                    .and_then(|e| e["add_cpu_chaos"].as_bool())
+                    .unwrap_or(false);
+                let add_network_emulation = extra
+                    .and_then(|e| e["add_network_emulation"].as_bool())
+                    .unwrap_or(true);
 
-            TestCodeComponents {
-                network_tests: vec![Box::new(PFNPerformance::new(
-                    num_pfns,
-                    add_cpu_chaos,
-                    add_network_emulation,
-                    Some(Arc::new(|config: &mut NodeConfig, _| {
-                        config.indexer_db_config.enable_event = true;
-                    })),
-                ))],
-                ..Default::default()
-            }
-        }));
+                TestCodeComponents {
+                    network_tests: vec![Box::new(PFNPerformance::new(
+                        num_pfns,
+                        add_cpu_chaos,
+                        add_network_emulation,
+                        Some(Arc::new(|config: &mut NodeConfig, _| {
+                            config.indexer_db_config.enable_event = true;
+                        })),
+                    ))],
+                    ..Default::default()
+                }
+            }),
+        );
 
         // === Load vs perf sweep tests ===
 
-        registry.register("load_sweep_realistic_env", Box::new(|config| {
-            let num_validators = config.initial_validator_count;
-            TestCodeComponents {
-                network_tests: vec![Box::new(wrap_with_realistic_env(
-                    num_validators,
-                    LoadVsPerfBenchmark {
-                        test: Box::new(PerformanceBenchmark),
-                        workloads: Workloads::TPS(vec![10, 100, 1000, 3000, 5000, 7000]),
-                        criteria: [
-                            (9, 0.9, 1.0, 1.2, 0),
-                            (95, 0.9, 1.1, 1.2, 0),
-                            (950, 1.2, 1.3, 2.0, 0),
-                            (2900, 1.4, 2.2, 2.5, 0),
-                            (4800, 2.0, 2.5, 3.0, 0),
-                            (6700, 2.5, 3.5, 5.0, 0),
-                        ]
-                        .into_iter()
-                        .map(|(min_tps, max_lat_p50, max_lat_p90, max_lat_p99, max_expired_tps)| {
-                            SuccessCriteria::new(min_tps)
-                                .add_max_expired_tps(max_expired_tps as f64)
-                                .add_max_failed_submission_tps(0.0)
-                                .add_latency_threshold(max_lat_p50, LatencyType::P50)
-                                .add_latency_threshold(max_lat_p90, LatencyType::P90)
-                                .add_latency_threshold(max_lat_p99, LatencyType::P99)
-                        })
-                        .collect(),
-                        background_traffic: background_traffic_for_sweep(5),
-                    },
-                ))],
-                extra_validator_override_fn: Some(Arc::new(|config, _| {
-                    config.execution.processed_transactions_detailed_counters = true;
-                })),
-                ..Default::default()
-            }
-        }));
+        registry.register(
+            "load_sweep_realistic_env",
+            Box::new(|config| {
+                let num_validators = config.initial_validator_count;
+                TestCodeComponents {
+                    network_tests: vec![Box::new(wrap_with_realistic_env(
+                        num_validators,
+                        LoadVsPerfBenchmark {
+                            test: Box::new(PerformanceBenchmark),
+                            workloads: Workloads::TPS(vec![10, 100, 1000, 3000, 5000, 7000]),
+                            criteria: [
+                                (9, 0.9, 1.0, 1.2, 0),
+                                (95, 0.9, 1.1, 1.2, 0),
+                                (950, 1.2, 1.3, 2.0, 0),
+                                (2900, 1.4, 2.2, 2.5, 0),
+                                (4800, 2.0, 2.5, 3.0, 0),
+                                (6700, 2.5, 3.5, 5.0, 0),
+                            ]
+                            .into_iter()
+                            .map(
+                                |(
+                                    min_tps,
+                                    max_lat_p50,
+                                    max_lat_p90,
+                                    max_lat_p99,
+                                    max_expired_tps,
+                                )| {
+                                    SuccessCriteria::new(min_tps)
+                                        .add_max_expired_tps(max_expired_tps as f64)
+                                        .add_max_failed_submission_tps(0.0)
+                                        .add_latency_threshold(max_lat_p50, LatencyType::P50)
+                                        .add_latency_threshold(max_lat_p90, LatencyType::P90)
+                                        .add_latency_threshold(max_lat_p99, LatencyType::P99)
+                                },
+                            )
+                            .collect(),
+                            background_traffic: background_traffic_for_sweep(5),
+                        },
+                    ))],
+                    extra_validator_override_fn: Some(Arc::new(|config, _| {
+                        config.execution.processed_transactions_detailed_counters = true;
+                    })),
+                    ..Default::default()
+                }
+            }),
+        );
 
         registry.register("workload_sweep_realistic_env", Box::new(|config| {
             let num_validators = config.initial_validator_count;
@@ -403,131 +446,181 @@ impl TestRegistry {
             }
         }));
 
-        registry.register("fairness_workload_sweep_realistic_env", Box::new(|config| {
-            let num_validators = config.initial_validator_count;
-            TestCodeComponents {
-                network_tests: vec![Box::new(wrap_with_realistic_env(
-                    num_validators,
-                    LoadVsPerfBenchmark {
-                        test: Box::new(PerformanceBenchmark),
-                        workloads: Workloads::TRANSACTIONS(vec![
-                            TransactionWorkload::new(TransactionTypeArg::ResourceGroupsGlobalWriteAndReadTag1KB, 100000),
-                            TransactionWorkload::new(TransactionTypeArg::VectorPicture30k, 20000),
-                            TransactionWorkload::new(TransactionTypeArg::SmartTablePicture1MWith256Change, 4000)
+        registry.register(
+            "fairness_workload_sweep_realistic_env",
+            Box::new(|config| {
+                let num_validators = config.initial_validator_count;
+                TestCodeComponents {
+                    network_tests: vec![Box::new(wrap_with_realistic_env(
+                        num_validators,
+                        LoadVsPerfBenchmark {
+                            test: Box::new(PerformanceBenchmark),
+                            workloads: Workloads::TRANSACTIONS(vec![
+                                TransactionWorkload::new(
+                                    TransactionTypeArg::ResourceGroupsGlobalWriteAndReadTag1KB,
+                                    100000,
+                                ),
+                                TransactionWorkload::new(
+                                    TransactionTypeArg::VectorPicture30k,
+                                    20000,
+                                ),
+                                TransactionWorkload::new(
+                                    TransactionTypeArg::SmartTablePicture1MWith256Change,
+                                    4000,
+                                )
                                 .with_transactions_per_account(1),
-                        ]),
-                        criteria: Vec::new(),
-                        background_traffic: background_traffic_for_sweep_with_latency(
-                            &[(2.0, 3.0, 8.0), (0.1, 25.0, 30.0), (0.1, 30.0, 45.0)],
-                            false,
-                        ),
-                    },
-                ))],
-                extra_validator_override_fn: Some(Arc::new(|config, _| {
-                    config.execution.processed_transactions_detailed_counters = true;
-                })),
-                ..Default::default()
-            }
-        }));
+                            ]),
+                            criteria: Vec::new(),
+                            background_traffic: background_traffic_for_sweep_with_latency(
+                                &[(2.0, 3.0, 8.0), (0.1, 25.0, 30.0), (0.1, 30.0, 45.0)],
+                                false,
+                            ),
+                        },
+                    ))],
+                    extra_validator_override_fn: Some(Arc::new(|config, _| {
+                        config.execution.processed_transactions_detailed_counters = true;
+                    })),
+                    ..Default::default()
+                }
+            }),
+        );
 
-        registry.register("graceful_workload_sweep_realistic_env", Box::new(|config| {
-            let num_validators = config.initial_validator_count;
-            TestCodeComponents {
-                network_tests: vec![Box::new(wrap_with_realistic_env(
-                    num_validators,
-                    LoadVsPerfBenchmark {
-                        test: Box::new(PerformanceBenchmark),
-                        workloads: Workloads::TRANSACTIONS(vec![
-                            TransactionWorkload::new_const_tps(TransactionTypeArg::AccountGeneration, 2 * 7000),
-                            TransactionWorkload::new_const_tps(TransactionTypeArg::ResourceGroupsGlobalWriteAndReadTag1KB, 3 * 1800),
-                            TransactionWorkload::new_const_tps(TransactionTypeArg::SmartTablePicture1MWith256Change, 3 * 14),
-                            TransactionWorkload::new_const_tps(TransactionTypeArg::SmartTablePicture1MWith1KChangeExceedsLimit, 3 * 12),
-                            TransactionWorkload::new_const_tps(TransactionTypeArg::VectorPicture30k, 3 * 150),
-                            TransactionWorkload::new_const_tps(TransactionTypeArg::ModifyGlobalFlagAggV2, 3 * 3500),
-                            TransactionWorkload::new_const_tps(TransactionTypeArg::PublishPackage, 3 * 150)
+        registry.register(
+            "graceful_workload_sweep_realistic_env",
+            Box::new(|config| {
+                let num_validators = config.initial_validator_count;
+                TestCodeComponents {
+                    network_tests: vec![Box::new(wrap_with_realistic_env(
+                        num_validators,
+                        LoadVsPerfBenchmark {
+                            test: Box::new(PerformanceBenchmark),
+                            workloads: Workloads::TRANSACTIONS(vec![
+                                TransactionWorkload::new_const_tps(
+                                    TransactionTypeArg::AccountGeneration,
+                                    2 * 7000,
+                                ),
+                                TransactionWorkload::new_const_tps(
+                                    TransactionTypeArg::ResourceGroupsGlobalWriteAndReadTag1KB,
+                                    3 * 1800,
+                                ),
+                                TransactionWorkload::new_const_tps(
+                                    TransactionTypeArg::SmartTablePicture1MWith256Change,
+                                    3 * 14,
+                                ),
+                                TransactionWorkload::new_const_tps(
+                                    TransactionTypeArg::SmartTablePicture1MWith1KChangeExceedsLimit,
+                                    3 * 12,
+                                ),
+                                TransactionWorkload::new_const_tps(
+                                    TransactionTypeArg::VectorPicture30k,
+                                    3 * 150,
+                                ),
+                                TransactionWorkload::new_const_tps(
+                                    TransactionTypeArg::ModifyGlobalFlagAggV2,
+                                    3 * 3500,
+                                ),
+                                TransactionWorkload::new_const_tps(
+                                    TransactionTypeArg::PublishPackage,
+                                    3 * 150,
+                                )
                                 .with_transactions_per_account(1),
-                        ]),
-                        criteria: Vec::new(),
-                        background_traffic: background_traffic_for_sweep_with_latency(
-                            &[
-                                (0.1, 4.0, 5.0),
-                                (0.1, 2.2, 3.0),
-                                (0.1, 3.5, 5.0),
-                                (0.1, 4.0, 6.0),
-                                (0.1, 3.0, 5.0),
-                                (0.1, 5.0, 10.0),
-                                (0.1, 3.0, 10.0),
-                            ],
-                            true,
-                        ),
-                    },
-                ))],
-                extra_validator_override_fn: Some(Arc::new(|config, _| {
-                    config.execution.processed_transactions_detailed_counters = true;
-                })),
-                ..Default::default()
-            }
-        }));
+                            ]),
+                            criteria: Vec::new(),
+                            background_traffic: background_traffic_for_sweep_with_latency(
+                                &[
+                                    (0.1, 4.0, 5.0),
+                                    (0.1, 2.2, 3.0),
+                                    (0.1, 3.5, 5.0),
+                                    (0.1, 4.0, 6.0),
+                                    (0.1, 3.0, 5.0),
+                                    (0.1, 5.0, 10.0),
+                                    (0.1, 3.0, 10.0),
+                                ],
+                                true,
+                            ),
+                        },
+                    ))],
+                    extra_validator_override_fn: Some(Arc::new(|config, _| {
+                        config.execution.processed_transactions_detailed_counters = true;
+                    })),
+                    ..Default::default()
+                }
+            }),
+        );
 
         // === Throughput tuned test ===
 
-        registry.register("realistic_network_tuned_for_throughput", Box::new(|config| {
-            let num_validators = config.initial_validator_count;
-            let extra = config.extra.as_ref();
+        registry.register(
+            "realistic_network_tuned_for_throughput",
+            Box::new(|config| {
+                let num_validators = config.initial_validator_count;
+                let extra = config.extra.as_ref();
 
-            let target_tps = extra
-                .and_then(|e| e["target_tps"].as_u64())
-                .map(|v| v as usize)
-                .unwrap_or(15_000);
-            let max_txns_per_block = extra
-                .and_then(|e| e["max_txns_per_block"].as_u64())
-                .map(|v| v as usize)
-                .unwrap_or(3_500);
-            let vn_latency = extra
-                .and_then(|e| e["vn_latency"].as_f64())
-                .unwrap_or(2.5);
+                let target_tps = extra
+                    .and_then(|e| e["target_tps"].as_u64())
+                    .map(|v| v as usize)
+                    .unwrap_or(15_000);
+                let max_txns_per_block = extra
+                    .and_then(|e| e["max_txns_per_block"].as_u64())
+                    .map(|v| v as usize)
+                    .unwrap_or(3_500);
+                let vn_latency = extra.and_then(|e| e["vn_latency"].as_f64()).unwrap_or(2.5);
 
-            TestCodeComponents {
-                network_tests: vec![Box::new(
-                    MultiRegionNetworkEmulationTest::default_for_validator_count(num_validators),
-                )],
-                extra_validator_override_fn: Some(Arc::new(move |config, _| {
-                    optimize_state_sync_for_throughput(config, 15_000);
-                    optimize_for_maximum_throughput(config, target_tps, max_txns_per_block, vn_latency);
-                    config.consensus.quorum_store_pull_timeout_ms = 200;
-                    config.storage.rocksdb_configs.enable_storage_sharding = true;
-                })),
-                extra_fullnode_override_fn: Some(Arc::new(|config, _| {
-                    optimize_state_sync_for_throughput(config, 15_000);
-                    config.storage.rocksdb_configs.enable_storage_sharding = true;
-                })),
-                ..Default::default()
-            }
-        }));
+                TestCodeComponents {
+                    network_tests: vec![Box::new(
+                        MultiRegionNetworkEmulationTest::default_for_validator_count(
+                            num_validators,
+                        ),
+                    )],
+                    extra_validator_override_fn: Some(Arc::new(move |config, _| {
+                        optimize_state_sync_for_throughput(config, 15_000);
+                        optimize_for_maximum_throughput(
+                            config,
+                            target_tps,
+                            max_txns_per_block,
+                            vn_latency,
+                        );
+                        config.consensus.quorum_store_pull_timeout_ms = 200;
+                        config.storage.rocksdb_configs.enable_storage_sharding = true;
+                    })),
+                    extra_fullnode_override_fn: Some(Arc::new(|config, _| {
+                        optimize_state_sync_for_throughput(config, 15_000);
+                        config.storage.rocksdb_configs.enable_storage_sharding = true;
+                    })),
+                    ..Default::default()
+                }
+            }),
+        );
 
         // === Workload mix test ===
 
-        registry.register("workload_mix", Box::new(|_| TestCodeComponents {
-            network_tests: vec![Box::new(PerformanceBenchmark)],
-            extra_validator_override_fn: Some(Arc::new(|config, _| {
-                config.execution.processed_transactions_detailed_counters = true;
-            })),
-            ..Default::default()
-        }));
+        registry.register(
+            "workload_mix",
+            Box::new(|_| TestCodeComponents {
+                network_tests: vec![Box::new(PerformanceBenchmark)],
+                extra_validator_override_fn: Some(Arc::new(|config, _| {
+                    config.execution.processed_transactions_detailed_counters = true;
+                })),
+                ..Default::default()
+            }),
+        );
 
         // === Single VFN perf ===
 
-        registry.register("single_vfn_perf", Box::new(|_| TestCodeComponents {
-            network_tests: vec![Box::new(PerformanceBenchmark)],
-            extra_validator_override_fn: Some(Arc::new(|config, _| {
-                config
-                    .consensus
-                    .quorum_store
-                    .back_pressure
-                    .dynamic_max_txn_per_s = 5500;
-            })),
-            ..Default::default()
-        }));
+        registry.register(
+            "single_vfn_perf",
+            Box::new(|_| TestCodeComponents {
+                network_tests: vec![Box::new(PerformanceBenchmark)],
+                extra_validator_override_fn: Some(Arc::new(|config, _| {
+                    config
+                        .consensus
+                        .quorum_store
+                        .back_pressure
+                        .dynamic_max_txn_per_s = 5500;
+                })),
+                ..Default::default()
+            }),
+        );
 
         registry
     }

--- a/testsuite/forge/src/interface/prometheus_metrics.rs
+++ b/testsuite/forge/src/interface/prometheus_metrics.rs
@@ -120,7 +120,7 @@ pub async fn fetch_system_metrics(
     Ok(SystemMetrics::new(cpu_samples, memory_samples))
 }
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, serde::Serialize, serde::Deserialize)]
 pub enum LatencyBreakdownSlice {
     MempoolToBlockCreation,
     ConsensusProposalToOrdered,

--- a/testsuite/forge/src/interface/prometheus_metrics.rs
+++ b/testsuite/forge/src/interface/prometheus_metrics.rs
@@ -120,7 +120,9 @@ pub async fn fetch_system_metrics(
     Ok(SystemMetrics::new(cpu_samples, memory_samples))
 }
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, serde::Serialize, serde::Deserialize)]
+#[derive(
+    Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, serde::Serialize, serde::Deserialize,
+)]
 pub enum LatencyBreakdownSlice {
     MempoolToBlockCreation,
     ConsensusProposalToOrdered,

--- a/testsuite/forge/src/lib.rs
+++ b/testsuite/forge/src/lib.rs
@@ -36,3 +36,6 @@ pub mod test_utils;
 
 pub mod config;
 pub use config::ForgeConfig;
+
+pub mod test_config;
+pub use test_config::{ForgeTestConfig, TestCodeComponents};

--- a/testsuite/forge/src/runner.rs
+++ b/testsuite/forge/src/runner.rs
@@ -130,7 +130,7 @@ pub type GenesisConfigFn = Arc<dyn Fn(&mut serde_yaml::Value) + Send + Sync>;
 /// override_config, base_config (see OverrideNodeConfig)
 pub type OverrideNodeConfigFn = Arc<dyn Fn(&mut NodeConfig, &mut NodeConfig) + Send + Sync>;
 
-#[derive(Clone, Copy, Default)]
+#[derive(Clone, Copy, Debug, Default, serde::Serialize, serde::Deserialize)]
 pub struct NodeResourceOverride {
     pub cpu_cores: Option<usize>,
     pub memory_gib: Option<usize>,

--- a/testsuite/forge/src/success_criteria.rs
+++ b/testsuite/forge/src/success_criteria.rs
@@ -15,6 +15,7 @@ use aptos_logger::info as aptos_logger_info;
 use aptos_transaction_emitter_lib::{TxnStats, TxnStatsRate};
 use log::info;
 use prometheus_http_query::response::Sample;
+use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::{
     collections::BTreeMap,
@@ -23,7 +24,7 @@ use std::{
     time::Duration,
 };
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct StateProgressThreshold {
     pub max_non_epoch_no_progress_secs: f32,
     pub max_epoch_no_progress_secs: f32,
@@ -31,7 +32,7 @@ pub struct StateProgressThreshold {
     pub max_epoch_round_gap: u64,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum LatencyType {
     Average,
     P50,
@@ -40,13 +41,14 @@ pub enum LatencyType {
     P99,
 }
 
-#[derive(Default, Clone, Debug)]
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
 pub struct MetricsThreshold {
-    max: f64,
+    pub max: f64,
     // % of the data point that can breach the max threshold
-    max_breach_pct: usize,
+    pub max_breach_pct: usize,
 
-    expect_empty: bool,
+    #[serde(default)]
+    pub expect_empty: bool,
 }
 
 impl MetricsThreshold {
@@ -107,10 +109,10 @@ impl MetricsThreshold {
     }
 }
 
-#[derive(Default, Clone, Debug)]
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
 pub struct SystemMetricsThreshold {
-    cpu_threshold: MetricsThreshold,
-    memory_threshold: MetricsThreshold,
+    pub cpu_threshold: MetricsThreshold,
+    pub memory_threshold: MetricsThreshold,
 }
 
 impl SystemMetricsThreshold {
@@ -130,7 +132,7 @@ impl SystemMetricsThreshold {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct LatencyBreakdownThreshold {
     pub thresholds: BTreeMap<LatencyBreakdownSlice, MetricsThreshold>,
 }
@@ -170,20 +172,20 @@ impl LatencyBreakdownThreshold {
     }
 }
 
-#[derive(Default, Clone, Debug)]
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
 pub struct SuccessCriteria {
     pub min_avg_tps: f64,
-    latency_thresholds: Vec<(Duration, LatencyType)>,
-    latency_breakdown_thresholds: Option<LatencyBreakdownThreshold>,
-    check_no_restarts: bool,
-    check_no_errors: bool,
-    check_no_fullnode_failures: bool,
-    max_expired_tps: Option<f64>,
-    max_failed_submission_tps: Option<f64>,
-    wait_for_all_nodes_to_catchup: Option<Duration>,
+    pub latency_thresholds: Vec<(Duration, LatencyType)>,
+    pub latency_breakdown_thresholds: Option<LatencyBreakdownThreshold>,
+    pub check_no_restarts: bool,
+    pub check_no_errors: bool,
+    pub check_no_fullnode_failures: bool,
+    pub max_expired_tps: Option<f64>,
+    pub max_failed_submission_tps: Option<f64>,
+    pub wait_for_all_nodes_to_catchup: Option<Duration>,
     // Maximum amount of CPU cores and memory bytes used by the nodes.
-    system_metrics_threshold: Option<SystemMetricsThreshold>,
-    chain_progress_check: Option<StateProgressThreshold>,
+    pub system_metrics_threshold: Option<SystemMetricsThreshold>,
+    pub chain_progress_check: Option<StateProgressThreshold>,
 }
 
 impl SuccessCriteria {

--- a/testsuite/forge/src/test_config.rs
+++ b/testsuite/forge/src/test_config.rs
@@ -1,0 +1,571 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+use crate::{
+    config::ForgeConfig,
+    success_criteria::{
+        LatencyBreakdownThreshold, LatencyType, MetricsThreshold, StateProgressThreshold,
+        SuccessCriteria, SystemMetricsThreshold,
+    },
+    AdminTest, AptosTest, EmitJobMode, EmitJobRequest, GenesisConfigFn, NetworkTest,
+    NodeResourceOverride, OverrideNodeConfigFn,
+};
+use anyhow::{Context, Result};
+use aptos_config::config::NodeConfig;
+use aptos_transaction_workloads_lib::args::TransactionTypeArg;
+use serde::{Deserialize, Serialize};
+use std::{num::NonZeroUsize, path::Path, sync::Arc, time::Duration};
+
+/// Components provided by the test code registry (not serializable)
+pub struct TestCodeComponents {
+    pub network_tests: Vec<Box<dyn NetworkTest>>,
+    pub admin_tests: Vec<Box<dyn AdminTest>>,
+    pub aptos_tests: Vec<Box<dyn AptosTest>>,
+    /// Extra genesis helm config closure from the registry (composed with YAML overrides)
+    pub extra_genesis_helm_config_fn: Option<GenesisConfigFn>,
+    /// Extra validator override closure from the registry (composed with YAML overrides)
+    pub extra_validator_override_fn: Option<OverrideNodeConfigFn>,
+    /// Extra fullnode override closure from the registry (composed with YAML overrides)
+    pub extra_fullnode_override_fn: Option<OverrideNodeConfigFn>,
+}
+
+impl Default for TestCodeComponents {
+    fn default() -> Self {
+        Self {
+            network_tests: vec![],
+            admin_tests: vec![],
+            aptos_tests: vec![],
+            extra_genesis_helm_config_fn: None,
+            extra_validator_override_fn: None,
+            extra_fullnode_override_fn: None,
+        }
+    }
+}
+
+/// Serializable forge test configuration that can be loaded from YAML files.
+/// This contains all the "data" portions of a ForgeConfig that don't require
+/// closures or trait objects.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ForgeTestConfig {
+    /// Name that maps to a test code registry entry
+    pub test_name: String,
+
+    /// Number of validators
+    #[serde(default = "default_validator_count")]
+    pub initial_validator_count: usize,
+
+    /// Number of validator fullnodes
+    #[serde(default)]
+    pub initial_fullnode_count: usize,
+
+    /// Number of PFNs
+    #[serde(default)]
+    pub num_pfns: usize,
+
+    /// Whether to enable multi-region config
+    #[serde(default)]
+    pub multi_region_config: bool,
+
+    /// Whether to retain debug logs for all nodes
+    #[serde(default)]
+    pub retain_debug_logs: bool,
+
+    /// Existing DB tag to use
+    #[serde(default)]
+    pub existing_db_tag: Option<String>,
+
+    /// Genesis helm config overrides (merged into helm values)
+    #[serde(default)]
+    pub genesis_helm_config: Option<serde_yaml::Value>,
+
+    /// Validator node config overrides (partial NodeConfig YAML merged onto defaults)
+    #[serde(default)]
+    pub validator_config_override: Option<serde_yaml::Value>,
+
+    /// Fullnode node config overrides (partial NodeConfig YAML merged onto defaults)
+    #[serde(default)]
+    pub fullnode_config_override: Option<serde_yaml::Value>,
+
+    /// Emit job configuration
+    #[serde(default)]
+    pub emit_job: Option<EmitJobConfig>,
+
+    /// Success criteria
+    pub success_criteria: SuccessCriteriaConfig,
+
+    /// Validator resource overrides
+    #[serde(default)]
+    pub validator_resource_override: Option<NodeResourceOverride>,
+
+    /// Fullnode resource overrides
+    #[serde(default)]
+    pub fullnode_resource_override: Option<NodeResourceOverride>,
+
+    /// Extra test-specific parameters (consumed by the registry factory)
+    #[serde(default)]
+    pub extra: Option<serde_yaml::Value>,
+}
+
+fn default_validator_count() -> usize {
+    1
+}
+
+/// Serializable emit job configuration
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EmitJobConfig {
+    /// Emit job mode
+    pub mode: EmitJobModeConfig,
+
+    /// Gas price override
+    #[serde(default)]
+    pub gas_price: Option<u64>,
+
+    /// Init gas price multiplier
+    #[serde(default)]
+    pub init_gas_price_multiplier: Option<u64>,
+
+    /// Transaction expiration time in seconds
+    #[serde(default)]
+    pub txn_expiration_time_secs: Option<u64>,
+
+    /// Init expiration multiplier
+    #[serde(default)]
+    pub init_expiration_multiplier: Option<f64>,
+
+    /// Latency polling interval in milliseconds
+    #[serde(default)]
+    pub latency_polling_interval_ms: Option<u64>,
+
+    /// Single transaction type
+    #[serde(default)]
+    pub transaction_type: Option<TransactionTypeArg>,
+
+    /// Mix of transaction types with weights
+    #[serde(default)]
+    pub transaction_mix: Option<Vec<TransactionMixEntry>>,
+}
+
+/// A single entry in a transaction mix
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TransactionMixEntry {
+    pub transaction_type: TransactionTypeArg,
+    pub weight: usize,
+}
+
+/// Serializable emit job mode
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum EmitJobModeConfig {
+    MaxLoad { mempool_backlog: usize },
+    ConstTps { tps: usize },
+    WaveTps {
+        average_tps: usize,
+        wave_ratio: f32,
+        num_waves: usize,
+    },
+}
+
+/// Serializable success criteria config
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SuccessCriteriaConfig {
+    pub min_avg_tps: f64,
+
+    #[serde(default)]
+    pub check_no_restarts: bool,
+
+    #[serde(default = "default_check_no_errors")]
+    pub check_no_errors: bool,
+
+    #[serde(default)]
+    pub check_no_fullnode_failures: bool,
+
+    #[serde(default)]
+    pub max_expired_tps: Option<f64>,
+
+    #[serde(default)]
+    pub max_failed_submission_tps: Option<f64>,
+
+    #[serde(default)]
+    pub wait_for_catchup_s: Option<u64>,
+
+    #[serde(default)]
+    pub latency_thresholds: Vec<LatencyThresholdEntry>,
+
+    #[serde(default)]
+    pub latency_breakdown_thresholds: Option<LatencyBreakdownThresholdConfig>,
+
+    #[serde(default)]
+    pub system_metrics: Option<SystemMetricsConfig>,
+
+    #[serde(default)]
+    pub chain_progress: Option<StateProgressThreshold>,
+}
+
+fn default_check_no_errors() -> bool {
+    true
+}
+
+/// A single latency threshold entry
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LatencyThresholdEntry {
+    pub threshold_s: f32,
+    pub latency_type: LatencyType,
+}
+
+/// Latency breakdown threshold config
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LatencyBreakdownThresholdConfig {
+    pub thresholds: Vec<LatencyBreakdownEntry>,
+    #[serde(default)]
+    pub max_breach_pct: usize,
+}
+
+/// A single latency breakdown entry
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LatencyBreakdownEntry {
+    pub slice: crate::prometheus_metrics::LatencyBreakdownSlice,
+    pub max_s: f64,
+}
+
+/// System metrics threshold config
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SystemMetricsConfig {
+    pub cpu_threshold: MetricsThreshold,
+    pub memory_threshold: MetricsThreshold,
+}
+
+impl ForgeTestConfig {
+    /// Parse from YAML string
+    pub fn from_yaml(yaml: &str) -> Result<Self> {
+        serde_yaml::from_str(yaml).context("Failed to parse ForgeTestConfig YAML")
+    }
+
+    /// Load from file path
+    pub fn from_file(path: &Path) -> Result<Self> {
+        let contents = std::fs::read_to_string(path)
+            .with_context(|| format!("Failed to read config file: {}", path.display()))?;
+        Self::from_yaml(&contents)
+    }
+
+    /// Convert emit job config to EmitJobRequest
+    fn build_emit_job_request(&self) -> EmitJobRequest {
+        let Some(ref emit_config) = self.emit_job else {
+            return EmitJobRequest::default().mode(EmitJobMode::MaxLoad {
+                mempool_backlog: 40000,
+            });
+        };
+
+        let mut req = EmitJobRequest::default();
+
+        // Set mode
+        req = req.mode(match &emit_config.mode {
+            EmitJobModeConfig::MaxLoad { mempool_backlog } => EmitJobMode::MaxLoad {
+                mempool_backlog: *mempool_backlog,
+            },
+            EmitJobModeConfig::ConstTps { tps } => EmitJobMode::ConstTps { tps: *tps },
+            EmitJobModeConfig::WaveTps {
+                average_tps,
+                wave_ratio,
+                num_waves,
+            } => EmitJobMode::WaveTps {
+                average_tps: *average_tps,
+                wave_ratio: *wave_ratio,
+                num_waves: *num_waves,
+            },
+        });
+
+        if let Some(gas_price) = emit_config.gas_price {
+            req = req.gas_price(gas_price);
+        }
+        if let Some(mult) = emit_config.init_gas_price_multiplier {
+            req = req.init_gas_price_multiplier(mult);
+        }
+        if let Some(secs) = emit_config.txn_expiration_time_secs {
+            req = req.txn_expiration_time_secs(secs);
+        }
+        if let Some(mult) = emit_config.init_expiration_multiplier {
+            req = req.init_expiration_multiplier(mult);
+        }
+        if let Some(ms) = emit_config.latency_polling_interval_ms {
+            req = req.latency_polling_interval(Duration::from_millis(ms));
+        }
+        if let Some(ref txn_type) = emit_config.transaction_type {
+            req = req.transaction_type(txn_type.materialize_default());
+        }
+        if let Some(ref mix) = emit_config.transaction_mix {
+            let mix_vec: Vec<_> = mix
+                .iter()
+                .map(|e| (e.transaction_type.materialize_default(), e.weight))
+                .collect();
+            req = req.transaction_mix(mix_vec);
+        }
+
+        req
+    }
+
+    /// Convert success criteria config to SuccessCriteria
+    fn build_success_criteria(&self) -> SuccessCriteria {
+        let sc = &self.success_criteria;
+        let mut criteria = SuccessCriteria::new_float(sc.min_avg_tps);
+
+        if sc.check_no_restarts {
+            criteria = criteria.add_no_restarts();
+        }
+        if !sc.check_no_errors {
+            criteria = criteria.allow_errors();
+        }
+        if sc.check_no_fullnode_failures {
+            criteria = criteria.add_no_fullnode_failures();
+        }
+        if let Some(max) = sc.max_expired_tps {
+            criteria = criteria.add_max_expired_tps(max);
+        }
+        if let Some(max) = sc.max_failed_submission_tps {
+            criteria = criteria.add_max_failed_submission_tps(max);
+        }
+        if let Some(secs) = sc.wait_for_catchup_s {
+            criteria = criteria.add_wait_for_catchup_s(secs);
+        }
+        for entry in &sc.latency_thresholds {
+            criteria = criteria.add_latency_threshold(entry.threshold_s, entry.latency_type.clone());
+        }
+        if let Some(ref breakdown) = sc.latency_breakdown_thresholds {
+            let thresholds: Vec<_> = breakdown
+                .thresholds
+                .iter()
+                .map(|e| (e.slice.clone(), e.max_s))
+                .collect();
+            criteria = criteria.add_latency_breakdown_threshold(
+                LatencyBreakdownThreshold::new_with_breach_pct(thresholds, breakdown.max_breach_pct),
+            );
+        }
+        if let Some(ref sys) = sc.system_metrics {
+            criteria = criteria.add_system_metrics_threshold(SystemMetricsThreshold::new(
+                sys.cpu_threshold.clone(),
+                sys.memory_threshold.clone(),
+            ));
+        }
+        if let Some(ref progress) = sc.chain_progress {
+            criteria = criteria.add_chain_progress(progress.clone());
+        }
+
+        criteria
+    }
+
+    /// Build a genesis_helm_config_fn from the YAML overrides
+    fn build_genesis_helm_config_fn(&self) -> Option<GenesisConfigFn> {
+        self.genesis_helm_config.clone().map(|overrides| {
+            Arc::new(move |helm_values: &mut serde_yaml::Value| {
+                deep_merge_yaml(helm_values, &overrides);
+            }) as GenesisConfigFn
+        })
+    }
+
+    /// Build a validator override node config fn from partial NodeConfig YAML
+    fn build_node_config_override_fn(
+        override_yaml: &Option<serde_yaml::Value>,
+    ) -> Option<OverrideNodeConfigFn> {
+        override_yaml.clone().map(|yaml_override| {
+            Arc::new(move |config: &mut NodeConfig, _base: &mut NodeConfig| {
+                // Serialize current config to YAML value, merge, deserialize back
+                let mut config_value =
+                    serde_yaml::to_value(&*config).expect("NodeConfig must serialize");
+                deep_merge_yaml(&mut config_value, &yaml_override);
+                *config =
+                    serde_yaml::from_value(config_value).expect("Merged NodeConfig must deserialize");
+            }) as OverrideNodeConfigFn
+        })
+    }
+
+    /// Assemble a ForgeConfig from this test config and test code components.
+    /// The YAML-derived overrides run first, then any extra closures from the registry.
+    pub fn to_forge_config(self, code: TestCodeComponents) -> Result<ForgeConfig> {
+        let mut config = ForgeConfig::default();
+
+        // Set data fields
+        config.initial_validator_count =
+            NonZeroUsize::new(self.initial_validator_count).unwrap_or(NonZeroUsize::new(1).unwrap());
+        config.initial_fullnode_count = self.initial_fullnode_count;
+        config.num_pfns = self.num_pfns;
+        config.multi_region_config = self.multi_region_config;
+        config.retain_debug_logs = self.retain_debug_logs;
+        config.existing_db_tag = self.existing_db_tag.clone();
+        config.emit_job_request = self.build_emit_job_request();
+        config.success_criteria = self.build_success_criteria();
+
+        if let Some(res) = self.validator_resource_override {
+            config.validator_resource_override = res;
+        }
+        if let Some(res) = self.fullnode_resource_override {
+            config.fullnode_resource_override = res;
+        }
+
+        // Build genesis helm config fn: compose YAML overrides + extra code
+        let yaml_genesis_fn = self.build_genesis_helm_config_fn();
+        config.genesis_helm_config_fn = compose_config_fns(yaml_genesis_fn, code.extra_genesis_helm_config_fn);
+
+        // Build validator override fn: compose YAML overrides + extra code
+        let yaml_validator_fn = Self::build_node_config_override_fn(&self.validator_config_override);
+        config.validator_override_node_config_fn =
+            compose_override_fns(yaml_validator_fn, code.extra_validator_override_fn);
+
+        // Build fullnode override fn: compose YAML overrides + extra code
+        let yaml_fullnode_fn = Self::build_node_config_override_fn(&self.fullnode_config_override);
+        config.fullnode_override_node_config_fn =
+            compose_override_fns(yaml_fullnode_fn, code.extra_fullnode_override_fn);
+
+        // Set test objects from registry
+        config.network_tests = code.network_tests;
+        config.admin_tests = code.admin_tests;
+        config.aptos_tests = code.aptos_tests;
+
+        Ok(config)
+    }
+}
+
+/// Compose two optional GenesisConfigFn closures (YAML first, then code)
+fn compose_config_fns(
+    yaml_fn: Option<GenesisConfigFn>,
+    code_fn: Option<GenesisConfigFn>,
+) -> Option<GenesisConfigFn> {
+    match (yaml_fn, code_fn) {
+        (None, None) => None,
+        (Some(f), None) | (None, Some(f)) => Some(f),
+        (Some(yaml_f), Some(code_f)) => Some(Arc::new(move |helm_values: &mut serde_yaml::Value| {
+            yaml_f(helm_values);
+            code_f(helm_values);
+        })),
+    }
+}
+
+/// Compose two optional OverrideNodeConfigFn closures (YAML first, then code)
+fn compose_override_fns(
+    yaml_fn: Option<OverrideNodeConfigFn>,
+    code_fn: Option<OverrideNodeConfigFn>,
+) -> Option<OverrideNodeConfigFn> {
+    match (yaml_fn, code_fn) {
+        (None, None) => None,
+        (Some(f), None) | (None, Some(f)) => Some(f),
+        (Some(yaml_f), Some(code_f)) => {
+            Some(Arc::new(move |config: &mut NodeConfig, base: &mut NodeConfig| {
+                yaml_f(config, base);
+                code_f(config, base);
+            }))
+        },
+    }
+}
+
+/// Recursively merge `source` YAML into `target`.
+/// For mappings, values from source override target.
+/// For non-mapping values, source replaces target.
+fn deep_merge_yaml(target: &mut serde_yaml::Value, source: &serde_yaml::Value) {
+    match (target, source) {
+        (serde_yaml::Value::Mapping(target_map), serde_yaml::Value::Mapping(source_map)) => {
+            for (key, source_val) in source_map {
+                if let Some(target_val) = target_map.get_mut(key) {
+                    deep_merge_yaml(target_val, source_val);
+                } else {
+                    target_map.insert(key.clone(), source_val.clone());
+                }
+            }
+        },
+        (target, source) => {
+            *target = source.clone();
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_deep_merge_yaml() {
+        let mut target: serde_yaml::Value = serde_yaml::from_str(
+            r#"
+            chain:
+              epoch_duration_secs: 300
+              name: test
+            validator:
+              count: 4
+            "#,
+        )
+        .unwrap();
+
+        let source: serde_yaml::Value = serde_yaml::from_str(
+            r#"
+            chain:
+              epoch_duration_secs: 600
+            validator:
+              memory: 8Gi
+            "#,
+        )
+        .unwrap();
+
+        deep_merge_yaml(&mut target, &source);
+
+        assert_eq!(
+            target["chain"]["epoch_duration_secs"],
+            serde_yaml::Value::Number(600.into())
+        );
+        assert_eq!(
+            target["chain"]["name"],
+            serde_yaml::Value::String("test".to_string())
+        );
+        assert_eq!(
+            target["validator"]["count"],
+            serde_yaml::Value::Number(4.into())
+        );
+        assert_eq!(
+            target["validator"]["memory"],
+            serde_yaml::Value::String("8Gi".to_string())
+        );
+    }
+
+    #[test]
+    fn test_parse_simple_yaml_config() {
+        let yaml = r#"
+test_name: simple_validator_upgrade
+initial_validator_count: 4
+success_criteria:
+  min_avg_tps: 5000
+  wait_for_catchup_s: 240
+genesis_helm_config:
+  chain:
+    epoch_duration_secs: 60
+"#;
+        let config = ForgeTestConfig::from_yaml(yaml).unwrap();
+        assert_eq!(config.test_name, "simple_validator_upgrade");
+        assert_eq!(config.initial_validator_count, 4);
+        assert_eq!(config.success_criteria.min_avg_tps, 5000.0);
+        assert_eq!(config.success_criteria.wait_for_catchup_s, Some(240));
+        assert!(config.genesis_helm_config.is_some());
+    }
+
+    #[test]
+    fn test_parse_config_with_emit_job() {
+        let yaml = r#"
+test_name: performance_test
+initial_validator_count: 7
+emit_job:
+  mode:
+    type: ConstTps
+    tps: 5000
+  gas_price: 500
+success_criteria:
+  min_avg_tps: 4500
+  check_no_restarts: true
+  latency_thresholds:
+    - threshold_s: 3.5
+      latency_type: P50
+    - threshold_s: 4.5
+      latency_type: P90
+"#;
+        let config = ForgeTestConfig::from_yaml(yaml).unwrap();
+        assert_eq!(config.initial_validator_count, 7);
+        let emit = config.emit_job.as_ref().unwrap();
+        assert!(matches!(emit.mode, EmitJobModeConfig::ConstTps { tps: 5000 }));
+        assert_eq!(emit.gas_price, Some(500));
+        assert_eq!(config.success_criteria.latency_thresholds.len(), 2);
+    }
+}

--- a/testsuite/forge/src/test_config.rs
+++ b/testsuite/forge/src/test_config.rs
@@ -144,8 +144,12 @@ pub struct TransactionMixEntry {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type")]
 pub enum EmitJobModeConfig {
-    MaxLoad { mempool_backlog: usize },
-    ConstTps { tps: usize },
+    MaxLoad {
+        mempool_backlog: usize,
+    },
+    ConstTps {
+        tps: usize,
+    },
     WaveTps {
         average_tps: usize,
         wave_ratio: f32,
@@ -315,7 +319,8 @@ impl ForgeTestConfig {
             criteria = criteria.add_wait_for_catchup_s(secs);
         }
         for entry in &sc.latency_thresholds {
-            criteria = criteria.add_latency_threshold(entry.threshold_s, entry.latency_type.clone());
+            criteria =
+                criteria.add_latency_threshold(entry.threshold_s, entry.latency_type.clone());
         }
         if let Some(ref breakdown) = sc.latency_breakdown_thresholds {
             let thresholds: Vec<_> = breakdown
@@ -324,7 +329,10 @@ impl ForgeTestConfig {
                 .map(|e| (e.slice.clone(), e.max_s))
                 .collect();
             criteria = criteria.add_latency_breakdown_threshold(
-                LatencyBreakdownThreshold::new_with_breach_pct(thresholds, breakdown.max_breach_pct),
+                LatencyBreakdownThreshold::new_with_breach_pct(
+                    thresholds,
+                    breakdown.max_breach_pct,
+                ),
             );
         }
         if let Some(ref sys) = sc.system_metrics {
@@ -359,8 +367,8 @@ impl ForgeTestConfig {
                 let mut config_value =
                     serde_yaml::to_value(&*config).expect("NodeConfig must serialize");
                 deep_merge_yaml(&mut config_value, &yaml_override);
-                *config =
-                    serde_yaml::from_value(config_value).expect("Merged NodeConfig must deserialize");
+                *config = serde_yaml::from_value(config_value)
+                    .expect("Merged NodeConfig must deserialize");
             }) as OverrideNodeConfigFn
         })
     }
@@ -371,8 +379,8 @@ impl ForgeTestConfig {
         let mut config = ForgeConfig::default();
 
         // Set data fields
-        config.initial_validator_count =
-            NonZeroUsize::new(self.initial_validator_count).unwrap_or(NonZeroUsize::new(1).unwrap());
+        config.initial_validator_count = NonZeroUsize::new(self.initial_validator_count)
+            .unwrap_or(NonZeroUsize::new(1).unwrap());
         config.initial_fullnode_count = self.initial_fullnode_count;
         config.num_pfns = self.num_pfns;
         config.multi_region_config = self.multi_region_config;
@@ -390,10 +398,12 @@ impl ForgeTestConfig {
 
         // Build genesis helm config fn: compose YAML overrides + extra code
         let yaml_genesis_fn = self.build_genesis_helm_config_fn();
-        config.genesis_helm_config_fn = compose_config_fns(yaml_genesis_fn, code.extra_genesis_helm_config_fn);
+        config.genesis_helm_config_fn =
+            compose_config_fns(yaml_genesis_fn, code.extra_genesis_helm_config_fn);
 
         // Build validator override fn: compose YAML overrides + extra code
-        let yaml_validator_fn = Self::build_node_config_override_fn(&self.validator_config_override);
+        let yaml_validator_fn =
+            Self::build_node_config_override_fn(&self.validator_config_override);
         config.validator_override_node_config_fn =
             compose_override_fns(yaml_validator_fn, code.extra_validator_override_fn);
 
@@ -419,10 +429,12 @@ fn compose_config_fns(
     match (yaml_fn, code_fn) {
         (None, None) => None,
         (Some(f), None) | (None, Some(f)) => Some(f),
-        (Some(yaml_f), Some(code_f)) => Some(Arc::new(move |helm_values: &mut serde_yaml::Value| {
-            yaml_f(helm_values);
-            code_f(helm_values);
-        })),
+        (Some(yaml_f), Some(code_f)) => {
+            Some(Arc::new(move |helm_values: &mut serde_yaml::Value| {
+                yaml_f(helm_values);
+                code_f(helm_values);
+            }))
+        },
     }
 }
 
@@ -434,12 +446,12 @@ fn compose_override_fns(
     match (yaml_fn, code_fn) {
         (None, None) => None,
         (Some(f), None) | (None, Some(f)) => Some(f),
-        (Some(yaml_f), Some(code_f)) => {
-            Some(Arc::new(move |config: &mut NodeConfig, base: &mut NodeConfig| {
+        (Some(yaml_f), Some(code_f)) => Some(Arc::new(
+            move |config: &mut NodeConfig, base: &mut NodeConfig| {
                 yaml_f(config, base);
                 code_f(config, base);
-            }))
-        },
+            },
+        )),
     }
 }
 
@@ -552,7 +564,9 @@ success_criteria:
         let config = ForgeTestConfig::from_yaml(yaml).unwrap();
         assert_eq!(config.initial_validator_count, 7);
         let emit = config.emit_job.as_ref().unwrap();
-        assert!(matches!(emit.mode, EmitJobModeConfig::ConstTps { tps: 5000 }));
+        assert!(matches!(emit.mode, EmitJobModeConfig::ConstTps {
+            tps: 5000
+        }));
         assert_eq!(emit.gas_price, Some(500));
         assert_eq!(config.success_criteria.latency_thresholds.len(), 2);
     }

--- a/testsuite/forge/src/test_config.rs
+++ b/testsuite/forge/src/test_config.rs
@@ -17,6 +17,7 @@ use serde::{Deserialize, Serialize};
 use std::{num::NonZeroUsize, path::Path, sync::Arc, time::Duration};
 
 /// Components provided by the test code registry (not serializable)
+#[derive(Default)]
 pub struct TestCodeComponents {
     pub network_tests: Vec<Box<dyn NetworkTest>>,
     pub admin_tests: Vec<Box<dyn AdminTest>>,
@@ -27,19 +28,6 @@ pub struct TestCodeComponents {
     pub extra_validator_override_fn: Option<OverrideNodeConfigFn>,
     /// Extra fullnode override closure from the registry (composed with YAML overrides)
     pub extra_fullnode_override_fn: Option<OverrideNodeConfigFn>,
-}
-
-impl Default for TestCodeComponents {
-    fn default() -> Self {
-        Self {
-            network_tests: vec![],
-            admin_tests: vec![],
-            aptos_tests: vec![],
-            extra_genesis_helm_config_fn: None,
-            extra_validator_override_fn: None,
-            extra_fullnode_override_fn: None,
-        }
-    }
 }
 
 /// Serializable forge test configuration that can be loaded from YAML files.


### PR DESCRIPTION
## Canary PR

This PR is based on #18962 and makes a single YAML-only change to validate that forge picks up config file changes without recompilation.

### What changed

`testsuite/forge-cli/config/realistic_env_max_load.yaml`:
```diff
- initial_validator_count: 7
+ initial_validator_count: 4
```

### What to look for

The `realistic_env_max_load` forge test (land-blocking) should run with **4 validators** instead of the usual 7. If the YAML config system is working correctly, this change is picked up at compile time via `include_str!` — no Rust code changes needed.

**DO NOT MERGE** — this is a throwaway canary test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)