### PR TITLE
[ci] Fix rust lint CI for edition2024

### DIFF
--- a/.github/actions/rust-lints/action.yaml
+++ b/.github/actions/rust-lints/action.yaml
@@ -13,6 +13,13 @@ runs:
     # Run the pre-commit checks
     - uses: pre-commit/action@v3.0.0
 
+    # Install a recent nightly toolchain with rustfmt (the pre-built image may have
+    # an older nightly that doesn't support edition2024).
+    - name: Install nightly toolchain with rustfmt
+      shell: bash
+      run: |
+        rustup toolchain install nightly -c rustfmt
+
     # Run the rust linters and cargo checks
     - name: Run cargo sort and rust lint checks
       shell: bash

--- a/scripts/dev_setup.sh
+++ b/scripts/dev_setup.sh
@@ -492,12 +492,12 @@ function install_rustup_components_and_nightly {
   if ! rustup toolchain install nightly; then
     if [[ "$(uname)" == "Linux" ]]; then
       # TODO: remove this once we have an answer: https://github.com/rust-lang/rustup/issues/3390
-      echo "Failed to install the nightly toolchain using rustup! Falling back to an older linux build at 2023-06-01."
-      rustup toolchain install nightly-2023-06-01 # Fix the date to avoid flakiness
+      echo "Failed to install the nightly toolchain using rustup! Falling back to an older linux build at 2025-01-01."
+      rustup toolchain install nightly-2025-01-01 # Fix the date to avoid flakiness
 
       # Rename the toolchain to nightly (crazy... see: https://github.com/rust-lang/rustup/issues/1299).
       # Note: this only works for linux. The primary purpose is to unblock CI/CD on flakes.
-      mv ~/.rustup/toolchains/nightly-2023-06-01-x86_64-unknown-linux-gnu ~/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu
+      mv ~/.rustup/toolchains/nightly-2025-01-01-x86_64-unknown-linux-gnu ~/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu
     else
       echo "Failed to install the nightly toolchain using rustup! Manual installation is required!"
     fi


### PR DESCRIPTION
## Summary
- The `rust-lints` CI job fails because the pre-built CI image has a nightly toolchain (1.83.0-nightly, 2024-09-19) that doesn't support `edition = "2024"` in Cargo.toml
- Added a step in `.github/actions/rust-lints/action.yaml` to install the latest nightly with rustfmt before running lint checks
- Updated the fallback nightly date in `scripts/dev_setup.sh` from `2023-06-01` to `2025-01-01` so local dev setup also gets edition2024 support

## Test plan
- [ ] CI `rust-lints` job passes on this PR
- [ ] `cargo +nightly fmt --check` succeeds locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI/dev tooling change that only affects how Rust toolchains are provisioned for lint/format checks; main risk is potential flakiness from pulling latest nightly in CI.
> 
> **Overview**
> Unblocks Rust lint CI for `edition2024` by **explicitly installing the latest `nightly` toolchain with `rustfmt`** in the `rust-lints` composite GitHub Action before running `scripts/rust_lint.sh --check`.
> 
> Updates `scripts/dev_setup.sh` to fall back to a newer pinned Linux nightly (`nightly-2025-01-01`) when `rustup toolchain install nightly` fails, keeping local setup compatible with `edition2024`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit afb2ff19212e5bac345067fcf77a2e5652416da2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->