### PR TITLE
[storage] Key state data structures by HashValue instead of StateKey

### DIFF
--- a/aptos-move/aptos-resource-viewer/src/module_view.rs
+++ b/aptos-move/aptos-resource-viewer/src/module_view.rs
@@ -381,20 +381,32 @@ mod tests {
             // New code:
             (
                 StateKey::module_id(&a_new.self_id()),
-                StateSlot::from_db_get(Some((1, module_state_value(a_new.clone())))),
+                StateSlot::from_db_get(
+                    StateKey::module_id(&a_new.self_id()),
+                    Some((1, module_state_value(a_new.clone()))),
+                ),
             ),
             (
                 StateKey::module_id(&d.self_id()),
-                StateSlot::from_db_get(Some((0, module_state_value(d.clone())))),
+                StateSlot::from_db_get(
+                    StateKey::module_id(&d.self_id()),
+                    Some((0, module_state_value(d.clone()))),
+                ),
             ),
             // Old code:
             (
                 StateKey::module_id(&b.self_id()),
-                StateSlot::from_db_get(Some((0, module_state_value(b.clone())))),
+                StateSlot::from_db_get(
+                    StateKey::module_id(&b.self_id()),
+                    Some((0, module_state_value(b.clone()))),
+                ),
             ),
             (
                 StateKey::module_id(&c.self_id()),
-                StateSlot::from_db_get(Some((0, module_state_value(c.clone())))),
+                StateSlot::from_db_get(
+                    StateKey::module_id(&c.self_id()),
+                    Some((0, module_state_value(c.clone()))),
+                ),
             ),
         ]));
         state.reset_state_view(new_state_view);

--- a/aptos-move/aptos-transaction-simulation/src/state_store.rs
+++ b/aptos-move/aptos-transaction-simulation/src/state_store.rs
@@ -450,7 +450,7 @@ where
 
     fn get_state_slot(&self, state_key: &Self::Key) -> StateViewResult<StateSlot> {
         let value_opt = self.get_state_value(state_key)?.map(|value| (0, value));
-        Ok(StateSlot::from_db_get(value_opt))
+        Ok(StateSlot::from_db_get(state_key.clone(), value_opt))
     }
 
     fn get_state_value(&self, state_key: &Self::Key) -> StateViewResult<Option<StateValue>> {

--- a/aptos-move/aptos-validator-interface/src/lib.rs
+++ b/aptos-move/aptos-validator-interface/src/lib.rs
@@ -164,6 +164,7 @@ impl DebuggerStateView {
         result.map(|s| match s {
             None => StateSlot::ColdVacant,
             Some(value) => StateSlot::ColdOccupied {
+                state_key: state_key.clone(),
                 value_version: version,
                 value,
             },

--- a/aptos-move/replay-benchmark/src/state_view.rs
+++ b/aptos-move/replay-benchmark/src/state_view.rs
@@ -28,6 +28,7 @@ impl TStateView for ReadSet {
     fn get_state_slot(&self, state_key: &Self::Key) -> StateViewResult<StateSlot> {
         let slot = match self.data.get(state_key) {
             Some(state_value) => StateSlot::ColdOccupied {
+                state_key: state_key.clone(),
                 value_version: 0,
                 value: state_value.clone(),
             },
@@ -93,6 +94,7 @@ impl<S: StateView> TStateView for ReadSetCapturingStateView<'_, S> {
         // Check the read-set first.
         if let Some(state_value) = self.captured_reads.lock().get(state_key) {
             return Ok(StateSlot::ColdOccupied {
+                state_key: state_key.clone(),
                 value_version: 0,
                 value: state_value.clone(),
             });

--- a/storage/aptosdb/src/state_store/hot_state.rs
+++ b/storage/aptosdb/src/state_store/hot_state.rs
@@ -6,6 +6,7 @@ use crate::metrics::{
 };
 use anyhow::{ensure, Result};
 use aptos_config::config::HotStateConfig;
+use aptos_crypto::HashValue;
 use aptos_infallible::Mutex;
 use aptos_logger::prelude::*;
 use aptos_metrics_core::{IntCounterVecHelper, IntGaugeVecHelper, TimerHelper};
@@ -78,7 +79,7 @@ where
 }
 
 #[derive(Debug)]
-struct HotStateBase<K = StateKey, V = StateSlot>
+struct HotStateBase<K = HashValue, V = StateSlot>
 where
     K: Eq + std::hash::Hash,
 {
@@ -117,18 +118,21 @@ struct LayeredHotStateView {
 
 impl HotStateView for LayeredHotStateView {
     fn get_state_slot(&self, state_key: &StateKey) -> Option<StateSlot> {
+        let hash = state_key.crypto_hash_ref();
+        self.get_state_slot_by_hash(hash)
+    }
+
+    fn get_state_slot_by_hash(&self, hash: &HashValue) -> Option<StateSlot> {
         if let Some(delta) = &self.delta {
-            if let Some(slot) = delta.get_state_slot(state_key) {
+            if let Some(slot) = delta.get_state_slot_by_hash(hash) {
                 // Delta says this key changed. If hot, return it. If cold/evicted, return None —
                 // do NOT fall through to base, the key was explicitly evicted in committed state.
                 return if slot.is_hot() { Some(slot) } else { None };
             }
         }
-        // Key not in delta (unchanged) — read from base DashMap.
-        let shard_id = state_key.get_shard_id();
-        self.base
-            .get_from_shard(shard_id, state_key)
-            .map(|v| v.clone())
+        // Key not in delta (unchanged) — read from base DashMap by hash.
+        let shard_id = hash.nibble(0) as usize;
+        self.base.get_from_shard(shard_id, hash).map(|v| v.clone())
     }
 }
 
@@ -232,7 +236,7 @@ impl HotState {
     }
 
     #[cfg(test)]
-    pub fn get_all_entries(&self, shard_id: usize) -> BTreeMap<StateKey, StateSlot> {
+    pub fn get_all_entries(&self, shard_id: usize) -> BTreeMap<HashValue, StateSlot> {
         self.base.shards[shard_id].iter().collect()
     }
 }
@@ -268,10 +272,10 @@ struct Committer {
     rx: Receiver<CommitMsg>,
     total_key_bytes: usize,
     total_value_bytes: usize,
-    /// Points to the newest entry. `None` if empty.
-    heads: [Option<StateKey>; NUM_STATE_SHARDS],
-    /// Points to the oldest entry. `None` if empty.
-    tails: [Option<StateKey>; NUM_STATE_SHARDS],
+    /// Points to the newest entry (by hash). `None` if empty.
+    heads: [Option<HashValue>; NUM_STATE_SHARDS],
+    /// Points to the oldest entry (by hash). `None` if empty.
+    tails: [Option<HashValue>; NUM_STATE_SHARDS],
 
     /// What the base DashMaps currently reflect. May lag behind `committed.state` while a merge
     /// is deferred.
@@ -497,20 +501,20 @@ impl Committer {
 
         let delta = target.make_delta(&self.merged_state);
         for shard_id in 0..NUM_STATE_SHARDS {
-            for (key, slot) in delta.shards[shard_id].iter() {
+            for (hash, slot) in delta.shards[shard_id].iter() {
                 if slot.is_hot() {
-                    let key_size = key.size();
+                    let key_size = HashValue::LENGTH;
                     self.total_key_bytes += key_size;
                     self.total_value_bytes += slot.size();
-                    if let Some(old_slot) = self.base.shards[shard_id].insert(key, slot) {
+                    if let Some(old_slot) = self.base.shards[shard_id].insert(hash, slot) {
                         self.total_key_bytes -= key_size;
                         self.total_value_bytes -= old_slot.size();
                         n_update += 1;
                     } else {
                         n_insert += 1;
                     }
-                } else if let Some((key, old_slot)) = self.base.shards[shard_id].remove(&key) {
-                    self.total_key_bytes -= key.size();
+                } else if let Some((_hash, old_slot)) = self.base.shards[shard_id].remove(&hash) {
+                    self.total_key_bytes -= HashValue::LENGTH;
                     self.total_value_bytes -= old_slot.size();
                     n_evict += 1;
                 }
@@ -541,15 +545,15 @@ impl Committer {
         let mut global_max_lru: Option<Version> = None;
 
         for (shard_id, shard_label) in SHARD_NAME_BY_ID.iter().enumerate() {
-            let mru_version = self.heads[shard_id].as_ref().map(|k| {
+            let mru_version = self.heads[shard_id].as_ref().map(|hash| {
                 self.base.shards[shard_id]
-                    .get(k)
+                    .get(hash)
                     .expect("head must exist in base")
                     .expect_hot_since_version()
             });
-            let lru_version = self.tails[shard_id].as_ref().map(|k| {
+            let lru_version = self.tails[shard_id].as_ref().map(|hash| {
                 self.base.shards[shard_id]
-                    .get(k)
+                    .get(hash)
                     .expect("tail must exist in base")
                     .expect_hot_since_version()
             });
@@ -583,26 +587,26 @@ impl Committer {
 
         {
             let mut num_visited = 0;
-            let mut current = head.clone();
-            while let Some(key) = current {
-                let entry = shard.get(&key).expect("Must exist.");
+            let mut current = *head;
+            while let Some(hash) = current {
+                let entry = shard.get(&hash).expect("Must exist.");
                 num_visited += 1;
                 ensure!(num_visited <= shard.len());
                 ensure!(entry.is_hot());
-                current = entry.next().cloned();
+                current = entry.next().copied();
             }
             ensure!(num_visited == shard.len());
         }
 
         {
             let mut num_visited = 0;
-            let mut current = tail.clone();
-            while let Some(key) = current {
-                let entry = shard.get(&key).expect("Must exist.");
+            let mut current = *tail;
+            while let Some(hash) = current {
+                let entry = shard.get(&hash).expect("Must exist.");
                 num_visited += 1;
                 ensure!(num_visited <= shard.len());
                 ensure!(entry.is_hot());
-                current = entry.prev().cloned();
+                current = entry.prev().copied();
             }
             ensure!(num_visited == shard.len());
         }
@@ -615,6 +619,7 @@ impl Committer {
 mod tests {
     use super::*;
     use aptos_config::config::HotStateConfig;
+    use aptos_crypto::hash::CryptoHash;
     use aptos_experimental_layered_map::MapLayer;
     use aptos_storage_interface::state_store::{state::State, state_delta::StateDelta};
     use aptos_types::state_store::{
@@ -629,8 +634,9 @@ mod tests {
         compute_root_hash: true,
     };
 
-    fn make_hot_slot(version: Version, value: &[u8]) -> StateSlot {
+    fn make_hot_slot(key: &StateKey, version: Version, value: &[u8]) -> StateSlot {
         StateSlot::HotOccupied {
+            state_key: key.clone(),
             value_version: version,
             value: StateValue::new_legacy(value.to_vec().into()),
             hot_since_version: version,
@@ -638,8 +644,9 @@ mod tests {
         }
     }
 
-    fn make_hot_vacant(version: Version) -> StateSlot {
+    fn make_hot_vacant(key: &StateKey, version: Version) -> StateSlot {
         StateSlot::HotVacant {
+            state_key: key.clone(),
             hot_since_version: version,
             lru_info: LRUEntry::uninitialized(),
         }
@@ -648,10 +655,10 @@ mod tests {
     /// Create a `StateDelta` for testing `LayeredHotStateView`.
     /// The delta's shards contain exactly the given entries.
     fn make_test_delta(entries: &[(StateKey, StateSlot)]) -> StateDelta {
-        let mut shard_entries: [Vec<(StateKey, StateSlot)>; NUM_STATE_SHARDS] =
+        let mut shard_entries: [Vec<(HashValue, StateSlot)>; NUM_STATE_SHARDS] =
             std::array::from_fn(|_| Vec::new());
         for (key, slot) in entries {
-            shard_entries[key.get_shard_id()].push((key.clone(), slot.clone()));
+            shard_entries[key.get_shard_id()].push((CryptoHash::hash(key), slot.clone()));
         }
 
         let empty = State::new_empty(TEST_CONFIG);
@@ -674,7 +681,7 @@ mod tests {
     /// be the original ancestor — it's used as the base layer when spawning children so that
     /// `make_delta(root)` remains valid for all descendants.
     fn build_empty_descendant(root: &State, parent: &State, version: Version) -> State {
-        let shards: [MapLayer<StateKey, StateSlot>; NUM_STATE_SHARDS] =
+        let shards: [MapLayer<HashValue, StateSlot>; NUM_STATE_SHARDS] =
             std::array::from_fn(|shard_id| {
                 parent.shards()[shard_id]
                     .view_layers_after(&root.shards()[shard_id])
@@ -696,8 +703,9 @@ mod tests {
         let base = Arc::new(HotStateBase::new_empty(100));
         let key = StateKey::raw(b"key_a");
         let shard_id = key.get_shard_id();
-        let slot = make_hot_slot(1, b"value_a");
-        base.shards[shard_id].insert(key.clone(), slot.clone());
+        let hash = CryptoHash::hash(&key);
+        let slot = make_hot_slot(&key, 1, b"value_a");
+        base.shards[shard_id].insert(hash, slot.clone());
 
         let view = LayeredHotStateView {
             delta: None,
@@ -723,23 +731,25 @@ mod tests {
 
         // key_base_only: in base DashMap, NOT in delta.
         let key_base_only = StateKey::raw(b"base_only");
-        let slot_base = make_hot_slot(1, b"base_value");
-        base.shards[key_base_only.get_shard_id()].insert(key_base_only.clone(), slot_base.clone());
+        let slot_base = make_hot_slot(&key_base_only, 1, b"base_value");
+        base.shards[key_base_only.get_shard_id()]
+            .insert(CryptoHash::hash(&key_base_only), slot_base.clone());
 
         // key_updated: in base DashMap AND in delta (hot) -> delta wins.
         let key_updated = StateKey::raw(b"updated");
-        let slot_old = make_hot_slot(1, b"old_value");
-        let slot_new = make_hot_slot(2, b"new_value");
-        base.shards[key_updated.get_shard_id()].insert(key_updated.clone(), slot_old);
+        let slot_old = make_hot_slot(&key_updated, 1, b"old_value");
+        let slot_new = make_hot_slot(&key_updated, 2, b"new_value");
+        base.shards[key_updated.get_shard_id()].insert(CryptoHash::hash(&key_updated), slot_old);
 
         // key_evicted: in base DashMap AND in delta (cold) -> returns None.
         let key_evicted = StateKey::raw(b"evicted");
-        let slot_was_hot = make_hot_slot(1, b"was_hot");
-        base.shards[key_evicted.get_shard_id()].insert(key_evicted.clone(), slot_was_hot);
+        let slot_was_hot = make_hot_slot(&key_evicted, 1, b"was_hot");
+        base.shards[key_evicted.get_shard_id()]
+            .insert(CryptoHash::hash(&key_evicted), slot_was_hot);
 
         // key_new: NOT in base, in delta (hot) -> returns delta value.
         let key_new = StateKey::raw(b"new_key");
-        let slot_new_key = make_hot_slot(2, b"brand_new");
+        let slot_new_key = make_hot_slot(&key_new, 2, b"brand_new");
 
         // key_missing: NOT in base, NOT in delta -> returns None.
         let key_missing = StateKey::raw(b"missing");
@@ -791,7 +801,7 @@ mod tests {
         // HotVacant in delta -> is_hot() is true -> returns Some(HotVacant).
         let base = Arc::new(HotStateBase::new_empty(100));
         let key = StateKey::raw(b"hot_vacant");
-        let slot = make_hot_vacant(5);
+        let slot = make_hot_vacant(&key, 5);
 
         let delta = make_test_delta(&[(key.clone(), slot)]);
         let view = LayeredHotStateView {

--- a/storage/aptosdb/src/state_store/mod.rs
+++ b/storage/aptosdb/src/state_store/mod.rs
@@ -945,7 +945,7 @@ impl StateStore {
                     .insert(
                         (*key).clone(),
                         update_to_cold
-                            .to_result_slot()
+                            .to_result_slot((*key).clone())
                             .expect("hot state ops should have been filtered out above"),
                     )
                     .unwrap_or_else(|| {

--- a/storage/aptosdb/src/state_store/state_snapshot_committer.rs
+++ b/storage/aptosdb/src/state_store/state_snapshot_committer.rs
@@ -108,19 +108,19 @@ impl StateSnapshotCommitter {
                             let _timer = OTHER_TIMERS_SECONDS.timer_with(&["hash_jmt_updates"]);
                             let mut hot_updates = Vec::new();
                             let mut all_updates = Vec::new();
-                            for (key, slot) in updates.iter() {
+                            for (hash, slot) in updates.iter() {
                                 if slot.is_hot() {
                                     hot_updates.push((
-                                        CryptoHash::hash(&key),
+                                        hash,
                                         Some((
                                             HotStateValueRef::from_slot(&slot).hash(),
-                                            key.clone(),
+                                            slot.expect_state_key().clone(),
                                         )),
                                     ));
                                 } else {
-                                    hot_updates.push((CryptoHash::hash(&key), None));
+                                    hot_updates.push((hash, None));
                                 }
-                                if let Some(value) = slot.maybe_update_jmt(key, min_version) {
+                                if let Some(value) = slot.maybe_update_jmt(hash, min_version) {
                                     all_updates.push(value);
                                 }
                             }

--- a/storage/aptosdb/src/state_store/tests/speculative_state_workflow.rs
+++ b/storage/aptosdb/src/state_store/tests/speculative_state_workflow.rs
@@ -210,6 +210,7 @@ impl VersionState {
             match v_opt {
                 None => {
                     let slot = StateSlot::HotVacant {
+                        state_key: k.clone(),
                         hot_since_version: version,
                         lru_info: LRUEntry::uninitialized(),
                     };
@@ -221,6 +222,7 @@ impl VersionState {
                 },
                 Some(v) => {
                     let slot = StateSlot::HotOccupied {
+                        state_key: k.clone(),
                         value_version: version,
                         value: v.clone(),
                         hot_since_version: version,
@@ -250,12 +252,14 @@ impl VersionState {
             } else {
                 let slot = match state.get(k) {
                     Some((value_version, value)) => StateSlot::HotOccupied {
+                        state_key: k.clone(),
                         value_version: *value_version,
                         value: value.clone(),
                         hot_since_version: version,
                         lru_info: LRUEntry::uninitialized(),
                     },
                     None => StateSlot::HotVacant {
+                        state_key: k.clone(),
                         hot_since_version: version,
                         lru_info: LRUEntry::uninitialized(),
                     },
@@ -305,7 +309,7 @@ impl TStateView for VersionState {
     type Key = StateKey;
 
     fn get_state_slot(&self, key: &Self::Key) -> StateViewResult<StateSlot> {
-        let from_cold = StateSlot::from_db_get(self.state.get(key).cloned());
+        let from_cold = StateSlot::from_db_get(key.clone(), self.state.get(key).cloned());
         let shard_id = key.get_shard_id();
         let slot = match self.hot_state[shard_id].peek(key) {
             Some(slot) => {
@@ -672,9 +676,10 @@ fn commit_state_buffer(
                 &state_by_version.get_state(Some(next_version - 1)).hot_state[shard_id];
             assert_eq!(all_entries.len(), naive_hot_state.len());
 
-            for (key, slot) in &all_entries {
-                let slot2 = naive_hot_state.peek(key).unwrap();
-                StateByVersion::assert_state_slot(slot, slot2);
+            for (key, slot) in naive_hot_state.iter() {
+                let hash = key.hash();
+                let actual_slot = all_entries.get(&hash).expect("Entry must exist in DashMap");
+                StateByVersion::assert_state_slot(actual_slot, slot);
             }
         });
     }

--- a/storage/storage-interface/src/state_store/hot_state.rs
+++ b/storage/storage-interface/src/state_store/hot_state.rs
@@ -2,10 +2,9 @@
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::state_store::state_view::hot_state_view::HotStateView;
+use aptos_crypto::HashValue;
 use aptos_experimental_layered_map::LayeredMap;
-use aptos_types::state_store::{
-    hot_state::THotStateSlot, state_key::StateKey, state_slot::StateSlot,
-};
+use aptos_types::state_store::{hot_state::THotStateSlot, state_slot::StateSlot};
 use std::{collections::HashMap, num::NonZeroUsize, sync::Arc};
 
 pub(crate) struct HotStateLRU<'a> {
@@ -15,13 +14,13 @@ pub(crate) struct HotStateLRU<'a> {
     /// to handle a single shard.
     committed: Arc<dyn HotStateView>,
     /// Additional entries resulted from previous speculative execution.
-    overlay: &'a LayeredMap<StateKey, StateSlot>,
+    overlay: &'a LayeredMap<HashValue, StateSlot>,
     /// The new entries from current execution.
-    pending: HashMap<StateKey, StateSlot>,
+    pending: HashMap<HashValue, StateSlot>,
     /// Points to the latest entry. `None` if empty.
-    head: Option<StateKey>,
+    head: Option<HashValue>,
     /// Points to the oldest entry. `None` if empty.
-    tail: Option<StateKey>,
+    tail: Option<HashValue>,
     /// Total number of items.
     num_items: usize,
 }
@@ -30,9 +29,9 @@ impl<'a> HotStateLRU<'a> {
     pub fn new(
         capacity: NonZeroUsize,
         committed: Arc<dyn HotStateView>,
-        overlay: &'a LayeredMap<StateKey, StateSlot>,
-        head: Option<StateKey>,
-        tail: Option<StateKey>,
+        overlay: &'a LayeredMap<HashValue, StateSlot>,
+        head: Option<HashValue>,
+        tail: Option<HashValue>,
         num_items: usize,
     ) -> Self {
         Self {
@@ -46,42 +45,42 @@ impl<'a> HotStateLRU<'a> {
         }
     }
 
-    pub fn insert(&mut self, key: StateKey, slot: StateSlot) {
+    pub fn insert(&mut self, hash: HashValue, slot: StateSlot) {
         assert!(
             slot.is_hot(),
             "Should not insert cold slots into hot state."
         );
-        if self.delete(&key).is_none() {
+        if self.delete(&hash).is_none() {
             self.num_items += 1;
         }
-        self.insert_as_head(key, slot);
+        self.insert_as_head(hash, slot);
     }
 
-    fn insert_as_head(&mut self, key: StateKey, mut slot: StateSlot) {
+    fn insert_as_head(&mut self, hash: HashValue, mut slot: StateSlot) {
         match self.head.take() {
-            Some(head) => {
-                let mut old_head_slot = self.expect_hot_slot(&head);
-                old_head_slot.set_prev(Some(key.clone()));
+            Some(head_hash) => {
+                let mut old_head_slot = self.expect_hot_slot(&head_hash);
+                old_head_slot.set_prev(Some(hash));
                 slot.set_prev(None);
-                slot.set_next(Some(head.clone()));
-                self.pending.insert(head, old_head_slot);
-                self.pending.insert(key.clone(), slot);
-                self.head = Some(key);
+                slot.set_next(Some(head_hash));
+                self.pending.insert(head_hash, old_head_slot);
+                self.pending.insert(hash, slot);
+                self.head = Some(hash);
             },
             None => {
                 slot.set_prev(None);
                 slot.set_next(None);
-                self.pending.insert(key.clone(), slot);
-                self.head = Some(key.clone());
-                self.tail = Some(key);
+                self.pending.insert(hash, slot);
+                self.head = Some(hash);
+                self.tail = Some(hash);
             },
         }
     }
 
     /// Returns the list of entries evicted, beginning from the LRU.
-    pub fn maybe_evict(&mut self) -> Vec<(StateKey, StateSlot)> {
-        let mut current = match &self.tail {
-            Some(tail) => tail.clone(),
+    pub fn maybe_evict(&mut self) -> Vec<(HashValue, StateSlot)> {
+        let mut current = match self.tail {
+            Some(tail) => tail,
             None => {
                 assert_eq!(self.num_items, 0);
                 return Vec::new();
@@ -93,69 +92,70 @@ impl<'a> HotStateLRU<'a> {
             let slot = self
                 .delete(&current)
                 .expect("There must be entries to evict when current size is above capacity.");
-            let prev_key = slot
+            let prev_hash = *slot
                 .prev()
-                .cloned()
                 .expect("There must be at least one newer entry (num_items > capacity >= 1).");
-            evicted.push((current.clone(), slot.clone()));
+            evicted.push((current, slot.clone()));
             self.pending.insert(current, slot.to_cold());
-            current = prev_key;
+            current = prev_hash;
             self.num_items -= 1;
         }
         evicted
     }
 
     /// Returns the deleted slot, or `None` if the key doesn't exist or is not hot.
-    fn delete(&mut self, key: &StateKey) -> Option<StateSlot> {
+    fn delete(&mut self, hash: &HashValue) -> Option<StateSlot> {
         // Fetch the slot corresponding to the given key. Note that `self.pending` and
         // `self.overlay` may contain cold slots, like the ones recently evicted, and we need to
         // ignore them.
-        let old_slot = match self.get_slot(key) {
+        let old_slot = match self.get_slot(hash) {
             Some(slot) if slot.is_hot() => slot,
             _ => return None,
         };
 
         match old_slot.prev() {
-            Some(prev_key) => {
-                let mut prev_slot = self.expect_hot_slot(prev_key);
-                prev_slot.set_next(old_slot.next().cloned());
-                self.pending.insert(prev_key.clone(), prev_slot);
+            Some(prev_hash) => {
+                let mut prev_slot = self.expect_hot_slot(prev_hash);
+                prev_slot.set_next(old_slot.next().copied());
+                self.pending.insert(*prev_hash, prev_slot);
             },
             None => {
                 // There is no newer entry. The current key was the head.
-                self.head = old_slot.next().cloned();
+                self.head = old_slot.next().copied();
             },
         }
 
         match old_slot.next() {
-            Some(next_key) => {
-                let mut next_slot = self.expect_hot_slot(next_key);
-                next_slot.set_prev(old_slot.prev().cloned());
-                self.pending.insert(next_key.clone(), next_slot);
+            Some(next_hash) => {
+                let mut next_slot = self.expect_hot_slot(next_hash);
+                next_slot.set_prev(old_slot.prev().copied());
+                self.pending.insert(*next_hash, next_slot);
             },
             None => {
                 // There is no older entry. The current key was the tail.
-                self.tail = old_slot.prev().cloned();
+                self.tail = old_slot.prev().copied();
             },
         }
 
         Some(old_slot)
     }
 
-    pub(crate) fn get_slot(&self, key: &StateKey) -> Option<StateSlot> {
-        if let Some(slot) = self.pending.get(key) {
+    pub(crate) fn get_slot(&self, hash: &HashValue) -> Option<StateSlot> {
+        if let Some(slot) = self.pending.get(hash) {
             return Some(slot.clone());
         }
 
-        if let Some(slot) = self.overlay.get(key) {
+        if let Some(slot) = self.overlay.get(hash) {
             return Some(slot);
         }
 
-        self.committed.get_state_slot(key)
+        self.committed.get_state_slot_by_hash(hash)
     }
 
-    fn expect_hot_slot(&self, key: &StateKey) -> StateSlot {
-        let slot = self.get_slot(key).expect("Given key is expected to exist.");
+    fn expect_hot_slot(&self, hash: &HashValue) -> StateSlot {
+        let slot = self
+            .get_slot(hash)
+            .expect("Given key is expected to exist.");
         assert!(slot.is_hot(), "Given key is expected to be hot.");
         slot
     }
@@ -163,9 +163,9 @@ impl<'a> HotStateLRU<'a> {
     pub fn into_updates(
         self,
     ) -> (
-        HashMap<StateKey, StateSlot>,
-        Option<StateKey>,
-        Option<StateKey>,
+        HashMap<HashValue, StateSlot>,
+        Option<HashValue>,
+        Option<HashValue>,
         usize,
     ) {
         (self.pending, self.head, self.tail, self.num_items)
@@ -174,29 +174,29 @@ impl<'a> HotStateLRU<'a> {
     #[cfg(test)]
     fn iter(&self) -> Iter<'_, '_> {
         Iter {
-            current_key: self.head.clone(),
+            current_hash: self.head,
             lru: self,
         }
     }
 
     #[cfg(test)]
     fn validate(&self) {
-        self.validate_impl(self.head.clone(), |slot| slot.next());
-        self.validate_impl(self.tail.clone(), |slot| slot.prev());
+        self.validate_impl(self.head, |slot| slot.next());
+        self.validate_impl(self.tail, |slot| slot.prev());
     }
 
     #[cfg(test)]
     fn validate_impl(
         &self,
-        start: Option<StateKey>,
-        func: impl Fn(&StateSlot) -> Option<&StateKey>,
+        start: Option<HashValue>,
+        func: impl Fn(&StateSlot) -> Option<&HashValue>,
     ) {
         let mut current = start;
         let mut num_visited = 0;
-        while let Some(key) = current {
-            let slot = self.expect_hot_slot(&key);
+        while let Some(hash) = current {
+            let slot = self.expect_hot_slot(&hash);
             num_visited += 1;
-            current = func(&slot).cloned();
+            current = func(&slot).copied();
         }
         assert_eq!(num_visited, self.num_items);
     }
@@ -204,19 +204,19 @@ impl<'a> HotStateLRU<'a> {
 
 #[cfg(test)]
 struct Iter<'a, 'b> {
-    current_key: Option<StateKey>,
+    current_hash: Option<HashValue>,
     lru: &'a HotStateLRU<'b>,
 }
 
 #[cfg(test)]
 impl<'a, 'b> Iterator for Iter<'a, 'b> {
-    type Item = (StateKey, StateSlot);
+    type Item = (HashValue, StateSlot);
 
-    fn next(&mut self) -> Option<(StateKey, StateSlot)> {
-        let key = self.current_key.take()?;
-        let slot = self.lru.expect_hot_slot(&key);
-        self.current_key = slot.next().cloned();
-        Some((key, slot))
+    fn next(&mut self) -> Option<(HashValue, StateSlot)> {
+        let hash = self.current_hash.take()?;
+        let slot = self.lru.expect_hot_slot(&hash);
+        self.current_hash = slot.next().copied();
+        Some((hash, slot))
     }
 }
 
@@ -224,6 +224,7 @@ impl<'a, 'b> Iterator for Iter<'a, 'b> {
 mod tests {
     use super::HotStateLRU;
     use crate::state_store::state_view::hot_state_view::HotStateView;
+    use aptos_crypto::{hash::CryptoHash, HashValue};
     use aptos_experimental_layered_map::{LayeredMap, MapLayer};
     use aptos_types::{
         state_store::{
@@ -247,22 +248,27 @@ mod tests {
 
     #[derive(Debug)]
     struct HotState {
-        inner: HashMap<StateKey, StateSlot>,
-        head: Option<StateKey>,
-        tail: Option<StateKey>,
+        inner: HashMap<HashValue, StateSlot>,
+        head: Option<HashValue>,
+        tail: Option<HashValue>,
     }
 
     impl HotStateView for Mutex<HotState> {
         fn get_state_slot(&self, state_key: &StateKey) -> Option<StateSlot> {
-            self.lock().unwrap().inner.get(state_key).cloned()
+            let hash = CryptoHash::hash(state_key);
+            self.lock().unwrap().inner.get(&hash).cloned()
+        }
+
+        fn get_state_slot_by_hash(&self, hash: &HashValue) -> Option<StateSlot> {
+            self.lock().unwrap().inner.get(hash).cloned()
         }
     }
 
     struct LRUTest {
         hot_state: Arc<Mutex<HotState>>,
-        _base_layer: MapLayer<StateKey, StateSlot>,
-        _top_layer: MapLayer<StateKey, StateSlot>,
-        overlay: LayeredMap<StateKey, StateSlot>,
+        _base_layer: MapLayer<HashValue, StateSlot>,
+        _top_layer: MapLayer<HashValue, StateSlot>,
+        overlay: LayeredMap<HashValue, StateSlot>,
     }
 
     impl LRUTest {
@@ -286,20 +292,20 @@ mod tests {
 
         fn commit_updates(
             &self,
-            updates: HashMap<StateKey, StateSlot>,
-            head: Option<StateKey>,
-            tail: Option<StateKey>,
+            updates: HashMap<HashValue, StateSlot>,
+            head: Option<HashValue>,
+            tail: Option<HashValue>,
             num_items: usize,
         ) {
             // For most of the logic we don't really care whether the data is in committed state or
             // in the overlay, so we just merge everything directly to committed state, and keep
             // the overlay empty.
             let mut locked = self.hot_state.lock().unwrap();
-            for (key, slot) in updates {
+            for (hash, slot) in updates {
                 if slot.is_hot() {
-                    locked.inner.insert(key, slot);
+                    locked.inner.insert(hash, slot);
                 } else {
-                    locked.inner.remove(&key);
+                    locked.inner.remove(&hash);
                 }
             }
             locked.head = head;
@@ -308,16 +314,20 @@ mod tests {
         }
     }
 
-    fn arb_hot_slot() -> impl Strategy<Value = StateSlot> {
-        (any::<Version>(), any::<StateValue>()).prop_flat_map(|(version, value)| {
+    fn arb_hot_slot(state_key: StateKey) -> impl Strategy<Value = StateSlot> {
+        (any::<Version>(), any::<StateValue>()).prop_flat_map(move |(version, value)| {
+            let sk = state_key.clone();
+            let sk2 = state_key.clone();
             prop_oneof![
                 4 => Just(StateSlot::HotOccupied {
+                    state_key: sk,
                     value_version: version,
                     value,
                     hot_since_version: version,
                     lru_info: LRUEntry::uninitialized(),
                 }),
                 1 => Just(StateSlot::HotVacant {
+                    state_key: sk2,
                     hot_since_version: version,
                     lru_info: LRUEntry::uninitialized(),
                 }),
@@ -325,20 +335,20 @@ mod tests {
         })
     }
 
-    fn assert_lru_equal(actual: &HotStateLRU, expected: &LruCache<StateKey, StateSlot>) {
+    fn assert_lru_equal(actual: &HotStateLRU, expected: &LruCache<HashValue, StateSlot>) {
         assert_eq!(
             actual
                 .iter()
-                .map(|(key, slot)| {
+                .map(|(hash, slot)| {
                     assert!(slot.is_hot());
-                    (key, slot.into_state_value_opt())
+                    (hash, slot.into_state_value_opt())
                 })
                 .collect::<Vec<_>>(),
             expected
                 .iter()
-                .map(|(key, slot)| {
+                .map(|(hash, slot)| {
                     assert!(slot.is_hot());
-                    (key.clone(), slot.clone().into_state_value_opt())
+                    (*hash, slot.clone().into_state_value_opt())
                 })
                 .collect::<Vec<_>>(),
         );
@@ -354,7 +364,12 @@ mod tests {
                     let pool: Vec<_> = keys.into_iter().collect();
                     let mut blocks = Vec::new();
                     for _i in 0..num_blocks {
-                        let block = vec((sample::select(pool.clone()), arb_hot_slot()), 1..100);
+                        let block = vec(
+                            sample::select(pool.clone()).prop_flat_map(|key| {
+                                arb_hot_slot(key.clone()).prop_map(move |slot| (key.clone(), slot))
+                            }),
+                            1..100,
+                        );
                         blocks.push(block);
                     }
                     blocks
@@ -381,8 +396,9 @@ mod tests {
                 lru.validate();
 
                 for (key, slot) in updates {
-                    lru.insert(key.clone(), slot.clone());
-                    naive_lru.put(key, slot);
+                    let hash = CryptoHash::hash(&key);
+                    lru.insert(hash, slot.clone());
+                    naive_lru.put(hash, slot);
                     lru.validate();
                     assert_lru_equal(&lru, &naive_lru);
                 }
@@ -400,7 +416,7 @@ mod tests {
                 assert_lru_equal(&lru, &naive_lru);
 
                 let (updates, new_head, new_tail, new_num_items) = lru.into_updates();
-                test_obj.commit_updates(updates, new_head.clone(), new_tail.clone(), new_num_items);
+                test_obj.commit_updates(updates, new_head, new_tail, new_num_items);
                 head = new_head;
                 tail = new_tail;
                 num_items = new_num_items;

--- a/storage/storage-interface/src/state_store/mod.rs
+++ b/storage/storage-interface/src/state_store/mod.rs
@@ -10,18 +10,22 @@ pub mod state_view;
 pub mod state_with_summary;
 pub mod versioned_state_value;
 
-use aptos_types::state_store::{hot_state::HotStateValue, state_key::StateKey, NUM_STATE_SHARDS};
+use aptos_crypto::HashValue;
+use aptos_types::state_store::{hot_state::HotStateValue, NUM_STATE_SHARDS};
 use std::collections::{HashMap, HashSet};
 
 #[derive(Debug)]
 pub(crate) struct HotStateShardUpdates {
-    insertions: HashMap<StateKey, HotStateValue>,
+    insertions: HashMap<HashValue, HotStateValue>,
     // TODO(HotState): only keys are needed for now, since evictions do not affect cold state.
-    evictions: HashSet<StateKey>,
+    evictions: HashSet<HashValue>,
 }
 
 impl HotStateShardUpdates {
-    pub fn new(insertions: HashMap<StateKey, HotStateValue>, evictions: HashSet<StateKey>) -> Self {
+    pub fn new(
+        insertions: HashMap<HashValue, HotStateValue>,
+        evictions: HashSet<HashValue>,
+    ) -> Self {
         Self {
             insertions,
             evictions,

--- a/storage/storage-interface/src/state_store/state.rs
+++ b/storage/storage-interface/src/state_store/state.rs
@@ -20,6 +20,7 @@ use crate::{
 };
 use anyhow::{bail, Result};
 use aptos_config::config::HotStateConfig;
+use aptos_crypto::{hash::CryptoHash, HashValue};
 use aptos_experimental_layered_map::{LayeredMap, MapLayer};
 use aptos_logger::warn;
 use aptos_metrics_core::TimerHelper;
@@ -42,8 +43,8 @@ use std::{
 
 #[derive(Clone, Debug, Default)]
 pub struct HotStateMetadata {
-    latest: Option<StateKey>,
-    oldest: Option<StateKey>,
+    latest: Option<HashValue>,
+    oldest: Option<HashValue>,
     num_items: usize,
 }
 
@@ -67,7 +68,7 @@ pub struct State {
     ///  N.b. this is not directly iterable, one needs to make a `StateDelta`
     ///       between this and a `base_version` to list the updates or create a
     ///       new `State` at a descendant version.
-    shards: Arc<[MapLayer<StateKey, StateSlot>; NUM_STATE_SHARDS]>,
+    shards: Arc<[MapLayer<HashValue, StateSlot>; NUM_STATE_SHARDS]>,
     hot_state_metadata: [HotStateMetadata; NUM_STATE_SHARDS],
     /// The total usage of the state at the current version.
     usage: StateStorageUsage,
@@ -77,7 +78,7 @@ pub struct State {
 impl State {
     pub fn new_with_updates(
         version: Option<Version>,
-        shards: Arc<[MapLayer<StateKey, StateSlot>; NUM_STATE_SHARDS]>,
+        shards: Arc<[MapLayer<HashValue, StateSlot>; NUM_STATE_SHARDS]>,
         hot_state_metadata: [HotStateMetadata; NUM_STATE_SHARDS],
         usage: StateStorageUsage,
         hot_state_config: HotStateConfig,
@@ -121,7 +122,7 @@ impl State {
         self.usage
     }
 
-    pub fn shards(&self) -> &[MapLayer<StateKey, StateSlot>; NUM_STATE_SHARDS] {
+    pub fn shards(&self) -> &[MapLayer<HashValue, StateSlot>; NUM_STATE_SHARDS] {
         &self.shards
     }
 
@@ -151,12 +152,12 @@ impl State {
             .all(|(base_shard, top_shard)| top_shard.can_view_after(base_shard))
     }
 
-    pub fn latest_hot_key(&self, shard_id: usize) -> Option<StateKey> {
-        self.hot_state_metadata[shard_id].latest.clone()
+    pub fn latest_hot_key(&self, shard_id: usize) -> Option<HashValue> {
+        self.hot_state_metadata[shard_id].latest
     }
 
-    pub fn oldest_hot_key(&self, shard_id: usize) -> Option<StateKey> {
-        self.hot_state_metadata[shard_id].oldest.clone()
+    pub fn oldest_hot_key(&self, shard_id: usize) -> Option<HashValue> {
+        self.hot_state_metadata[shard_id].oldest
     }
 
     pub fn num_hot_items(&self, shard_id: usize) -> usize {
@@ -211,8 +212,8 @@ impl State {
                         NonZeroUsize::new(self.hot_state_config.max_items_per_shard).unwrap(),
                         Arc::clone(&persisted_hot_state),
                         overlay,
-                        hot_metadata.latest.clone(),
-                        hot_metadata.oldest.clone(),
+                        hot_metadata.latest,
+                        hot_metadata.oldest,
                         hot_metadata.num_items,
                     );
                     let mut all_updates = per_version.iter();
@@ -222,7 +223,8 @@ impl State {
                         for (key, update) in
                             all_updates.take_while_ref(|(_k, u)| u.version <= *ckpt_version)
                         {
-                            evictions.remove(*key);
+                            let hash = CryptoHash::hash(*key);
+                            evictions.remove(&hash);
                             if let Some(hot_state_value) = Self::apply_one_update(
                                 &mut lru,
                                 overlay,
@@ -231,18 +233,19 @@ impl State {
                                 update,
                                 self.hot_state_config.refresh_interval_versions,
                             ) {
-                                insertions.insert((*key).clone(), hot_state_value);
+                                insertions.insert(hash, hot_state_value);
                             }
                         }
                         // Only evict at the checkpoints.
-                        evictions.extend(lru.maybe_evict().into_iter().map(|(key, slot)| {
-                            insertions.remove(&key);
+                        evictions.extend(lru.maybe_evict().into_iter().map(|(hash, slot)| {
+                            insertions.remove(&hash);
                             assert!(slot.is_hot());
-                            key
+                            hash
                         }));
                     }
                     for (key, update) in all_updates {
-                        evictions.remove(*key);
+                        let hash = CryptoHash::hash(*key);
+                        evictions.remove(&hash);
                         if let Some(hot_state_value) = Self::apply_one_update(
                             &mut lru,
                             overlay,
@@ -251,7 +254,7 @@ impl State {
                             update,
                             self.hot_state_config.refresh_interval_versions,
                         ) {
-                            insertions.insert((*key).clone(), hot_state_value);
+                            insertions.insert(hash, hot_state_value);
                         }
                     }
 
@@ -298,18 +301,19 @@ impl State {
     /// necessary.
     fn apply_one_update(
         lru: &mut HotStateLRU,
-        overlay: &LayeredMap<StateKey, StateSlot>,
+        overlay: &LayeredMap<HashValue, StateSlot>,
         read_cache: &StateCacheShard,
         key: &StateKey,
         update: &StateUpdateRef,
         refresh_interval: Version,
     ) -> Option<HotStateValue> {
+        let hash = CryptoHash::hash(key);
         if let Some(state_value_opt) = update.state_op.as_state_value_opt() {
-            lru.insert((*key).clone(), update.to_result_slot().unwrap());
+            lru.insert(hash, update.to_result_slot((*key).clone()).unwrap());
             return Some(HotStateValue::new(state_value_opt.cloned(), update.version));
         }
 
-        if let Some(mut slot) = lru.get_slot(key) {
+        if let Some(mut slot) = lru.get_slot(&hash) {
             let mut refreshed = true;
             let slot_to_insert = if slot.is_hot() {
                 if slot.expect_hot_since_version() + refresh_interval <= update.version {
@@ -319,11 +323,11 @@ impl State {
                 }
                 slot
             } else {
-                slot.to_hot(update.version)
+                slot.to_hot(update.version, (*key).clone())
             };
             if refreshed {
                 let ret = HotStateValue::clone_from_slot(&slot_to_insert);
-                lru.insert((*key).clone(), slot_to_insert);
+                lru.insert(hash, slot_to_insert);
                 Some(ret)
             } else {
                 None
@@ -331,9 +335,9 @@ impl State {
         } else {
             let slot = Self::expect_old_slot(overlay, read_cache, key);
             assert!(slot.is_cold());
-            let slot = slot.to_hot(update.version);
+            let slot = slot.to_hot(update.version, (*key).clone());
             let ret = HotStateValue::clone_from_slot(&slot);
-            lru.insert((*key).clone(), slot);
+            lru.insert(hash, slot);
             Some(ret)
         }
     }
@@ -352,7 +356,7 @@ impl State {
 
     fn usage_delta_for_shard<'kv>(
         cache: &StateCacheShard,
-        overlay: &LayeredMap<StateKey, StateSlot>,
+        overlay: &LayeredMap<HashValue, StateSlot>,
         updates: &HashMap<&'kv StateKey, StateUpdateRef<'kv>>,
     ) -> (i64, i64) {
         let mut items_delta: i64 = 0;
@@ -381,11 +385,12 @@ impl State {
     }
 
     fn expect_old_slot(
-        overlay: &LayeredMap<StateKey, StateSlot>,
+        overlay: &LayeredMap<HashValue, StateSlot>,
         cache: &StateCacheShard,
         key: &StateKey,
     ) -> StateSlot {
-        if let Some(slot) = overlay.get(key) {
+        let hash = CryptoHash::hash(key);
+        if let Some(slot) = overlay.get(&hash) {
             return slot;
         }
 

--- a/storage/storage-interface/src/state_store/state_delta.rs
+++ b/storage/storage-interface/src/state_store/state_delta.rs
@@ -2,6 +2,7 @@
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::state_store::state::State;
+use aptos_crypto::{hash::CryptoHash, HashValue};
 use aptos_experimental_layered_map::LayeredMap;
 use aptos_types::{
     state_store::{state_key::StateKey, state_slot::StateSlot, NUM_STATE_SHARDS},
@@ -20,7 +21,7 @@ use std::sync::Arc;
 pub struct StateDelta {
     pub base: State,
     pub current: State,
-    pub shards: Arc<[LayeredMap<StateKey, StateSlot>; NUM_STATE_SHARDS]>,
+    pub shards: Arc<[LayeredMap<HashValue, StateSlot>; NUM_STATE_SHARDS]>,
 }
 
 impl StateDelta {
@@ -49,14 +50,21 @@ impl StateDelta {
     /// Get the state update for a given state key.
     /// `None` indicates the key is not updated in the delta.
     pub fn get_state_slot(&self, state_key: &StateKey) -> Option<StateSlot> {
-        self.shards[state_key.get_shard_id()].get(state_key)
+        let hash = CryptoHash::hash(state_key);
+        self.shards[state_key.get_shard_id()].get(&hash)
     }
 
-    pub fn latest_hot_key(&self, shard_id: usize) -> Option<StateKey> {
+    /// Get the state update by hash.
+    pub fn get_state_slot_by_hash(&self, hash: &HashValue) -> Option<StateSlot> {
+        let shard_id = hash.nibble(0) as usize;
+        self.shards[shard_id].get(hash)
+    }
+
+    pub fn latest_hot_key(&self, shard_id: usize) -> Option<HashValue> {
         self.current.latest_hot_key(shard_id)
     }
 
-    pub fn oldest_hot_key(&self, shard_id: usize) -> Option<StateKey> {
+    pub fn oldest_hot_key(&self, shard_id: usize) -> Option<HashValue> {
         self.current.oldest_hot_key(shard_id)
     }
 }

--- a/storage/storage-interface/src/state_store/state_summary.rs
+++ b/storage/storage-interface/src/state_store/state_summary.rs
@@ -140,9 +140,9 @@ impl StateSummary {
                 shard
                     .insertions
                     .iter()
-                    .map(|(k, value)| (k, Some(value.hash())))
-                    .chain(shard.evictions.iter().map(|k| (k, None)))
-                    .sorted_by_key(|(k, _)| k.crypto_hash_ref())
+                    .map(|(k, value)| (*k, Some(value.hash())))
+                    .chain(shard.evictions.iter().map(|k| (*k, None)))
+                    .sorted_by_key(|(k, _)| *k)
                     .collect_vec()
             })
             .collect::<Vec<_>>();

--- a/storage/storage-interface/src/state_store/state_view/cached_state_view.rs
+++ b/storage/storage-interface/src/state_store/state_view/cached_state_view.rs
@@ -242,6 +242,7 @@ impl CachedStateView {
         } else if let Some(base_version) = self.base_version() {
             COUNTER.inc_with(&["sv_cold"]);
             StateSlot::from_db_get(
+                state_key.clone(),
                 self.cold
                     .get_state_value_with_version_by_version(state_key, base_version)?,
             )

--- a/storage/storage-interface/src/state_store/state_view/db_state_view.rs
+++ b/storage/storage-interface/src/state_store/state_view/db_state_view.rs
@@ -60,7 +60,10 @@ impl TStateView for DbStateView {
     }
 
     fn get_state_slot(&self, state_key: &StateKey) -> StateViewResult<StateSlot> {
-        Ok(StateSlot::from_db_get(self.get(state_key)?))
+        Ok(StateSlot::from_db_get(
+            state_key.clone(),
+            self.get(state_key)?,
+        ))
     }
 
     fn get_usage(&self) -> StateViewResult<StateStorageUsage> {

--- a/storage/storage-interface/src/state_store/state_view/hot_state_view.rs
+++ b/storage/storage-interface/src/state_store/state_view/hot_state_view.rs
@@ -1,17 +1,24 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
+use aptos_crypto::HashValue;
 use aptos_types::state_store::{state_key::StateKey, state_slot::StateSlot};
 
 /// A view into the hot state store, whose content overlays on top of the cold state store content.
 pub trait HotStateView: Send + Sync {
     fn get_state_slot(&self, state_key: &StateKey) -> Option<StateSlot>;
+
+    fn get_state_slot_by_hash(&self, hash: &HashValue) -> Option<StateSlot>;
 }
 
 pub struct EmptyHotState;
 
 impl HotStateView for EmptyHotState {
     fn get_state_slot(&self, _state_key: &StateKey) -> Option<StateSlot> {
+        None
+    }
+
+    fn get_state_slot_by_hash(&self, _hash: &HashValue) -> Option<StateSlot> {
         None
     }
 }

--- a/storage/storage-interface/src/state_store/versioned_state_value.rs
+++ b/storage/storage-interface/src/state_store/versioned_state_value.rs
@@ -2,7 +2,7 @@
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use aptos_types::{
-    state_store::{hot_state::LRUEntry, state_slot::StateSlot},
+    state_store::{hot_state::LRUEntry, state_key::StateKey, state_slot::StateSlot},
     transaction::Version,
     write_set::BaseStateOp,
 };
@@ -16,10 +16,11 @@ pub struct StateUpdateRef<'kv> {
 
 impl StateUpdateRef<'_> {
     /// NOTE: the lru_info in the result is not initialized yet.
-    pub fn to_result_slot(&self) -> Option<StateSlot> {
+    pub fn to_result_slot(&self, state_key: StateKey) -> Option<StateSlot> {
         match self.state_op.clone() {
             BaseStateOp::Creation(value) | BaseStateOp::Modification(value) => {
                 Some(StateSlot::HotOccupied {
+                    state_key: state_key.clone(),
                     value_version: self.version,
                     value,
                     hot_since_version: self.version,
@@ -27,6 +28,7 @@ impl StateUpdateRef<'_> {
                 })
             },
             BaseStateOp::Deletion(_) => Some(StateSlot::HotVacant {
+                state_key,
                 hot_since_version: self.version,
                 lru_info: LRUEntry::uninitialized(),
             }),

--- a/types/src/state_store/mod.rs
+++ b/types/src/state_store/mod.rs
@@ -149,7 +149,14 @@ impl<K: Eq + Hash> MockStateView<K> {
         Self {
             data: data
                 .into_iter()
-                .map(|(k, v)| (k, StateSlot::from_db_get(Some((0, v)))))
+                .map(|(k, v)| {
+                    let slot = StateSlot::ColdOccupied {
+                        state_key: StateKey::raw(b"mock"),
+                        value_version: 0,
+                        value: v,
+                    };
+                    (k, slot)
+                })
                 .collect(),
         }
     }

--- a/types/src/state_store/state_slot.rs
+++ b/types/src/state_store/state_slot.rs
@@ -17,6 +17,8 @@ use StateSlot::*;
 /// Represents the content of a state slot, or the lack there of, along with information indicating
 /// whether the slot is present in the cold or/and hot state.
 ///
+/// state_key: the original key, stored in non-ColdVacant variants so that JMT persistence can
+///            recover the key when iterating HashValue-keyed shards.
 /// value_version: non-empty value changed at this version
 /// hot_since_version: the timestamp of a hot value / vacancy in the hot state, which determines
 ///                    the order of eviction
@@ -24,18 +26,21 @@ use StateSlot::*;
 pub enum StateSlot {
     ColdVacant,
     HotVacant {
+        state_key: StateKey,
         hot_since_version: Version,
-        lru_info: LRUEntry<StateKey>,
+        lru_info: LRUEntry<HashValue>,
     },
     ColdOccupied {
+        state_key: StateKey,
         value_version: Version,
         value: StateValue,
     },
     HotOccupied {
+        state_key: StateKey,
         value_version: Version,
         value: StateValue,
         hot_since_version: Version,
-        lru_info: LRUEntry<StateKey>,
+        lru_info: LRUEntry<HashValue>,
     },
 }
 
@@ -60,6 +65,7 @@ impl StateSlot {
             ColdOccupied {
                 value_version,
                 value,
+                ..
             }
             | HotOccupied {
                 value_version,
@@ -78,29 +84,46 @@ impl StateSlot {
     }
 
     /// When committing speculative state to the DB, determine if to make changes to the JMT.
+    /// `key_hash` is the hash of the state key (the map key in HashValue-keyed shards).
+    /// For occupied variants, the StateKey is recovered from the slot itself.
     pub fn maybe_update_jmt(
         &self,
-        key: StateKey,
+        key_hash: HashValue,
         min_version: Version,
     ) -> Option<(HashValue, Option<(HashValue, StateKey)>)> {
         let maybe_value_opt = self.maybe_update_cold_state(min_version);
         maybe_value_opt.map(|value_opt| {
             (
-                CryptoHash::hash(&key),
-                value_opt.map(|v| (CryptoHash::hash(v), key)),
+                key_hash,
+                value_opt.map(|v| (CryptoHash::hash(v), self.expect_state_key().clone())),
             )
         })
     }
 
     // TODO(HotState): db returns cold slot directly
-    pub fn from_db_get(tuple_opt: Option<(Version, StateValue)>) -> Self {
+    pub fn from_db_get(state_key: StateKey, tuple_opt: Option<(Version, StateValue)>) -> Self {
         match tuple_opt {
             None => Self::ColdVacant,
             Some((value_version, value)) => Self::ColdOccupied {
+                state_key,
                 value_version,
                 value,
             },
         }
+    }
+
+    pub fn state_key(&self) -> Option<&StateKey> {
+        match self {
+            ColdVacant => None,
+            HotVacant { state_key, .. }
+            | ColdOccupied { state_key, .. }
+            | HotOccupied { state_key, .. } => Some(state_key),
+        }
+    }
+
+    pub fn expect_state_key(&self) -> &StateKey {
+        self.state_key()
+            .expect("StateKey expected (not ColdVacant)")
     }
 
     pub fn into_state_value_and_version_opt(self) -> Option<(Version, StateValue)> {
@@ -109,6 +132,7 @@ impl StateSlot {
             ColdOccupied {
                 value_version,
                 value,
+                ..
             }
             | HotOccupied {
                 value_version,
@@ -194,18 +218,21 @@ impl StateSlot {
         }
     }
 
-    pub fn to_hot(self, hot_since_version: Version) -> Self {
+    pub fn to_hot(self, hot_since_version: Version, state_key: StateKey) -> Self {
         match self {
             ColdOccupied {
                 value_version,
                 value,
+                ..
             } => HotOccupied {
+                state_key,
                 value_version,
                 value,
                 hot_since_version,
                 lru_info: LRUEntry::uninitialized(),
             },
             ColdVacant => HotVacant {
+                state_key,
                 hot_since_version,
                 lru_info: LRUEntry::uninitialized(),
             },
@@ -216,10 +243,12 @@ impl StateSlot {
     pub fn to_cold(self) -> Self {
         match self {
             HotOccupied {
+                state_key,
                 value_version,
                 value,
                 ..
             } => ColdOccupied {
+                state_key,
                 value_version,
                 value,
             },
@@ -230,7 +259,7 @@ impl StateSlot {
 }
 
 impl THotStateSlot for StateSlot {
-    type Key = StateKey;
+    type Key = HashValue;
 
     fn prev(&self) -> Option<&Self::Key> {
         match self {
@@ -267,31 +296,39 @@ impl Arbitrary for StateSlot {
     type Strategy = BoxedStrategy<Self>;
 
     fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
-        let hot_vacant = any::<Version>().prop_map(|hot_since_version| HotVacant {
-            hot_since_version,
-            lru_info: LRUEntry::uninitialized(),
-        });
-        let cold_occupied =
-            (any::<Version>(), any::<StateValue>()).prop_map(|(value_version, value)| {
-                ColdOccupied {
-                    value_version,
-                    value,
+        let hot_vacant =
+            (any::<StateKey>(), any::<Version>()).prop_map(|(state_key, hot_since_version)| {
+                HotVacant {
+                    state_key,
+                    hot_since_version,
+                    lru_info: LRUEntry::uninitialized(),
                 }
             });
-        let hot_occupied = (any::<Version>(), any::<StateValue>())
-            .prop_flat_map(|(value_version, value)| {
+        let cold_occupied = (any::<StateKey>(), any::<Version>(), any::<StateValue>()).prop_map(
+            |(state_key, value_version, value)| ColdOccupied {
+                state_key,
+                value_version,
+                value,
+            },
+        );
+        let hot_occupied = (any::<StateKey>(), any::<Version>(), any::<StateValue>())
+            .prop_flat_map(|(state_key, value_version, value)| {
                 (
+                    Just(state_key),
                     Just(value_version),
                     (value_version..Version::MAX),
                     Just(value),
                 )
             })
-            .prop_map(|(value_version, hot_since_version, value)| HotOccupied {
-                value_version,
-                value,
-                hot_since_version,
-                lru_info: LRUEntry::uninitialized(),
-            });
+            .prop_map(
+                |(state_key, value_version, hot_since_version, value)| HotOccupied {
+                    state_key,
+                    value_version,
+                    value,
+                    hot_since_version,
+                    lru_info: LRUEntry::uninitialized(),
+                },
+            );
         prop_oneof![
             1 => Just(ColdVacant),
             1 => hot_vacant,


### PR DESCRIPTION

Refactor all state management data structures (MapLayers, StateDelta,
HotStateLRU, HotStateBase DashMaps, HotStateMetadata, HotStateShardUpdates)
to be keyed by `HashValue` instead of `StateKey`.

This reduces memory overhead since `HashValue` is a fixed 32-byte `Copy` type,
while `StateKey` is an `Arc<Entry>` with variable-length key bytes plus a
cached hash. Shard routing already uses the hash, so there's no functional
change in how keys are distributed.

To preserve the ability to recover the original `StateKey` for JMT leaf
persistence and other operations, `StateKey` is now stored inside `StateSlot`
for all non-`ColdVacant` variants. High-level read APIs used by the
VM/executor still accept `StateKey` and hash internally, keeping that
interface unchanged. A new `get_state_slot_by_hash` method is added to
`HotStateView` and `StateDelta` for internal hash-based lookups.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
