### PR TITLE
Add hidden encrypted flag to txn emitter CLI

### DIFF
--- a/crates/transaction-emitter-lib/src/args.rs
+++ b/crates/transaction-emitter-lib/src/args.rs
@@ -188,6 +188,9 @@ pub struct EmitArgs {
 
     #[clap(flatten)]
     pub account_type_args: AccountTypeArgs,
+
+    #[clap(long, default_value = "false", hide = true)]
+    pub encrypt_transactions: bool,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Parser, Serialize)]

--- a/crates/transaction-emitter-lib/src/wrappers.rs
+++ b/crates/transaction-emitter-lib/src/wrappers.rs
@@ -191,6 +191,10 @@ pub async fn emit_transactions_with_cluster(
         emit_job_request = emit_job_request.skip_funding_accounts();
     }
 
+    if args.encrypt_transactions {
+        emit_job_request = emit_job_request.encrypt_transactions(true);
+    }
+
     let coin_source_account = std::sync::Arc::new(coin_source_account);
     let stats = emitter
         .emit_txn_for_with_stats(


### PR DESCRIPTION
## Summary
- Add `--encrypt-transactions` hidden CLI flag to `EmitArgs`
- Wire the flag through to `EmitJobRequest::encrypt_transactions()` in the emitter wrappers

## Test plan
- [x] `cargo check -p aptos-transaction-emitter` passes
- [ ] Verify flag is not shown in `--help` output
- [ ] Test with `--encrypt-transactions` flag enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)