### PR TITLE
[storage] Clean up all #[allow(dead_code)] under storage/

### DIFF
--- a/storage/aptosdb/src/db/aptosdb_writer.rs
+++ b/storage/aptosdb/src/db/aptosdb_writer.rs
@@ -1,13 +1,14 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
+#[cfg(any(test, feature = "fuzzing"))]
+use crate::ledger_db::transaction_auxiliary_data_db::TransactionAuxiliaryDataDb;
 use crate::{
     backup::restore_utils,
     db::{aptosdb_internal::gauged_api, AptosDB},
     ledger_db::{
-        ledger_metadata_db::LedgerMetadataDb,
-        transaction_auxiliary_data_db::TransactionAuxiliaryDataDb,
-        transaction_info_db::TransactionInfoDb, LedgerDbSchemaBatches,
+        ledger_metadata_db::LedgerMetadataDb, transaction_info_db::TransactionInfoDb,
+        LedgerDbSchemaBatches,
     },
     metrics::{
         COMMITTED_TXNS, LATEST_TXN_VERSION, LEDGER_VERSION, NEXT_BLOCK_EPOCH, OTHER_TIMERS_SECONDS,
@@ -26,13 +27,14 @@ use aptos_storage_interface::{
     chunk_to_commit::ChunkToCommit, db_ensure as ensure, AptosDbError, DbReader, DbWriter, Result,
     StateSnapshotReceiver,
 };
+#[cfg(any(test, feature = "fuzzing"))]
+use aptos_types::transaction::TransactionAuxiliaryData;
 use aptos_types::{
     account_config::new_block_event_key,
     ledger_info::LedgerInfoWithSignatures,
     state_store::{state_key::StateKey, state_value::StateValue},
     transaction::{
-        Transaction, TransactionAuxiliaryData, TransactionInfo, TransactionOutput,
-        TransactionOutputListWithProofV2, Version,
+        Transaction, TransactionInfo, TransactionOutput, TransactionOutputListWithProofV2, Version,
     },
     write_set::WriteSet,
 };
@@ -451,7 +453,7 @@ impl AptosDB {
         Ok(root_hash)
     }
 
-    #[allow(dead_code)]
+    #[cfg(any(test, feature = "fuzzing"))]
     pub(super) fn commit_transaction_auxiliary_data<'a>(
         &self,
         first_version: Version,

--- a/storage/aptosdb/src/ledger_db/ledger_metadata_db.rs
+++ b/storage/aptosdb/src/ledger_db/ledger_metadata_db.rs
@@ -97,12 +97,6 @@ impl LedgerMetadataDb {
         ledger_info.clone()
     }
 
-    pub(crate) fn get_committed_version(&self) -> Option<Version> {
-        let ledger_info_ptr = self.latest_ledger_info.load();
-        let ledger_info: &Option<_> = ledger_info_ptr.deref();
-        ledger_info.as_ref().map(|li| li.ledger_info().version())
-    }
-
     /// Returns the latest ledger info, or NOT_FOUND if it doesn't exist.
     pub(crate) fn get_latest_ledger_info(&self) -> Result<LedgerInfoWithSignatures> {
         self.get_latest_ledger_info_option()
@@ -338,6 +332,7 @@ impl LedgerMetadataDb {
         self.db.put::<VersionDataSchema>(&version, &usage.into())
     }
 
+    #[cfg(feature = "db-debugger")]
     pub(crate) fn get_usage_before_or_at(
         &self,
         version: Version,

--- a/storage/aptosdb/src/ledger_db/mod.rs
+++ b/storage/aptosdb/src/ledger_db/mod.rs
@@ -2,17 +2,13 @@
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 #![forbid(unsafe_code)]
-#![allow(dead_code)]
 
 use crate::{
     db_options::{
-        event_db_column_families, gen_event_cfds, gen_ledger_cfds, gen_ledger_metadata_cfds,
+        gen_event_cfds, gen_ledger_cfds, gen_ledger_metadata_cfds,
         gen_persisted_auxiliary_info_cfds, gen_transaction_accumulator_cfds,
         gen_transaction_auxiliary_data_cfds, gen_transaction_cfds, gen_transaction_info_cfds,
-        gen_write_set_cfds, ledger_db_column_families, ledger_metadata_db_column_families,
-        persisted_auxiliary_info_db_column_families, transaction_accumulator_db_column_families,
-        transaction_auxiliary_data_db_column_families, transaction_db_column_families,
-        transaction_info_db_column_families, write_set_db_column_families,
+        gen_write_set_cfds,
     },
     event_store::EventStore,
     ledger_db::{
@@ -22,15 +18,12 @@ use crate::{
         transaction_auxiliary_data_db::TransactionAuxiliaryDataDb, transaction_db::TransactionDb,
         transaction_info_db::TransactionInfoDb, write_set_db::WriteSetDb,
     },
-    schema::db_metadata::{DbMetadataKey, DbMetadataSchema},
 };
 use aptos_config::config::RocksdbConfig;
 use aptos_experimental_runtimes::thread_manager::THREAD_MANAGER;
 use aptos_logger::prelude::info;
 use aptos_rocksdb_options::gen_rocksdb_options;
-use aptos_schemadb::{
-    batch::SchemaBatch, Cache, ColumnFamilyDescriptor, ColumnFamilyName, Env, DB,
-};
+use aptos_schemadb::{batch::SchemaBatch, Cache, ColumnFamilyDescriptor, Env, DB};
 use aptos_storage_interface::Result;
 use aptos_types::transaction::Version;
 use std::{
@@ -261,17 +254,6 @@ impl LedgerDb {
         })
     }
 
-    pub(crate) fn get_in_progress_state_kv_snapshot_version(&self) -> Result<Option<Version>> {
-        let mut iter = self.ledger_metadata_db.db().iter::<DbMetadataSchema>()?;
-        iter.seek_to_first();
-        while let Some((k, _v)) = iter.next().transpose()? {
-            if let DbMetadataKey::StateSnapshotKvRestoreProgress(version) = k {
-                return Ok(Some(version));
-            }
-        }
-        Ok(None)
-    }
-
     pub(crate) fn create_checkpoint(
         db_root_path: impl AsRef<Path>,
         cp_root_path: impl AsRef<Path>,
@@ -435,21 +417,6 @@ impl LedgerDb {
         info!("Opened {name} at {path:?}!");
 
         Ok(db)
-    }
-
-    fn get_column_families_by_name(name: &str) -> Vec<ColumnFamilyName> {
-        match name {
-            LEDGER_DB_NAME => ledger_db_column_families(),
-            LEDGER_METADATA_DB_NAME => ledger_metadata_db_column_families(),
-            EVENT_DB_NAME => event_db_column_families(),
-            PERSISTED_AUXILIARY_INFO_DB_NAME => persisted_auxiliary_info_db_column_families(),
-            TRANSACTION_ACCUMULATOR_DB_NAME => transaction_accumulator_db_column_families(),
-            TRANSACTION_AUXILIARY_DATA_DB_NAME => transaction_auxiliary_data_db_column_families(),
-            TRANSACTION_DB_NAME => transaction_db_column_families(),
-            TRANSACTION_INFO_DB_NAME => transaction_info_db_column_families(),
-            WRITE_SET_DB_NAME => write_set_db_column_families(),
-            _ => unreachable!(),
-        }
     }
 
     fn gen_cfds_by_name(

--- a/storage/aptosdb/src/ledger_db/transaction_auxiliary_data_db.rs
+++ b/storage/aptosdb/src/ledger_db/transaction_auxiliary_data_db.rs
@@ -1,13 +1,12 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-use crate::{
-    schema::{
-        db_metadata::{DbMetadataKey, DbMetadataSchema, DbMetadataValue},
-        transaction_auxiliary_data::TransactionAuxiliaryDataSchema,
-    },
-    utils::iterators::ExpectContinuousVersions,
+use crate::schema::{
+    db_metadata::{DbMetadataKey, DbMetadataSchema, DbMetadataValue},
+    transaction_auxiliary_data::TransactionAuxiliaryDataSchema,
 };
+#[cfg(test)]
+use crate::utils::iterators::ExpectContinuousVersions;
 use aptos_schemadb::{batch::SchemaBatch, DB};
 use aptos_storage_interface::Result;
 use aptos_types::transaction::{TransactionAuxiliaryData, Version};
@@ -51,6 +50,7 @@ impl TransactionAuxiliaryDataDb {
 
     /// Returns an iterator that yields `num_transaction_infos` transaction infos starting from
     /// `start_version`.
+    #[cfg(test)]
     pub(crate) fn get_transaction_auxiliary_data_iter(
         &self,
         start_version: Version,
@@ -62,6 +62,7 @@ impl TransactionAuxiliaryDataDb {
     }
 
     /// Saves transaction inf at `version`.
+    #[cfg(any(test, feature = "fuzzing"))]
     pub(crate) fn put_transaction_auxiliary_data(
         version: Version,
         transaction_auxiliary_data: &TransactionAuxiliaryData,

--- a/storage/aptosdb/src/pruner/ledger_pruner/ledger_pruner_manager.rs
+++ b/storage/aptosdb/src/pruner/ledger_pruner/ledger_pruner_manager.rs
@@ -88,6 +88,7 @@ impl PrunerManager for LedgerPrunerManager {
         self.ledger_db.write_pruner_progress(min_readable_version)
     }
 
+    #[cfg(test)]
     fn is_pruning_pending(&self) -> bool {
         self.pruner_worker
             .as_ref()

--- a/storage/aptosdb/src/pruner/pruner_manager.rs
+++ b/storage/aptosdb/src/pruner/pruner_manager.rs
@@ -34,7 +34,7 @@ pub trait PrunerManager: Sync {
     // in memory progress.
     fn save_min_readable_version(&self, min_readable_version: Version) -> Result<()>;
 
-    #[allow(unused)]
+    #[cfg(test)]
     fn is_pruning_pending(&self) -> bool;
 
     /// (For tests only.) Notifies the worker thread and waits for it to finish its job by polling

--- a/storage/aptosdb/src/pruner/pruner_worker.rs
+++ b/storage/aptosdb/src/pruner/pruner_worker.rs
@@ -58,7 +58,7 @@ impl PrunerWorker {
         }
     }
 
-    #[allow(dead_code)]
+    #[cfg(test)]
     pub fn is_pruning_pending(&self) -> bool {
         self.pruner.is_pruning_pending()
     }

--- a/storage/aptosdb/src/pruner/state_kv_pruner/state_kv_pruner_manager.rs
+++ b/storage/aptosdb/src/pruner/state_kv_pruner/state_kv_pruner_manager.rs
@@ -65,6 +65,7 @@ impl PrunerManager for StateKvPrunerManager {
         self.state_kv_db.write_pruner_progress(min_readable_version)
     }
 
+    #[cfg(test)]
     fn is_pruning_pending(&self) -> bool {
         self.pruner_worker
             .as_ref()

--- a/storage/aptosdb/src/pruner/state_merkle_pruner/state_merkle_pruner_manager.rs
+++ b/storage/aptosdb/src/pruner/state_merkle_pruner/state_merkle_pruner_manager.rs
@@ -83,6 +83,7 @@ where
             .write_pruner_progress(&S::progress_metadata_key(None), min_readable_version)
     }
 
+    #[cfg(test)]
     fn is_pruning_pending(&self) -> bool {
         self.pruner_worker
             .as_ref()

--- a/storage/aptosdb/src/state_store/hot_state.rs
+++ b/storage/aptosdb/src/state_store/hot_state.rs
@@ -154,7 +154,7 @@ pub struct HotState {
     commit_tx: SyncSender<CommitMsg>,
     /// Updated by the Committer after each successful DashMap merge. Tests use this to wait for
     /// the merge to complete before inspecting DashMaps. Only read by test helpers.
-    #[allow(dead_code)]
+    #[cfg(test)]
     merged_version: Arc<AtomicU64>,
 }
 
@@ -181,6 +181,7 @@ impl HotState {
             base,
             committed,
             commit_tx,
+            #[cfg(test)]
             merged_version,
         }
     }

--- a/storage/aptosdb/src/utils/truncation_helper.rs
+++ b/storage/aptosdb/src/utils/truncation_helper.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-#![allow(dead_code)]
-
 use crate::{
     ledger_db::{
         ledger_metadata_db::LedgerMetadataDb, transaction_db::TransactionDb, LedgerDb,

--- a/storage/backup/backup-cli/src/coordinators/restore.rs
+++ b/storage/backup/backup-cli/src/coordinators/restore.rs
@@ -8,14 +8,14 @@ use crate::{
         transaction::restore::TransactionRestoreBatchController,
     },
     metadata,
-    metadata::{cache::MetadataCacheOpt, TransactionBackupMeta},
+    metadata::cache::MetadataCacheOpt,
     metrics::restore::{
         COORDINATOR_FAIL_TS, COORDINATOR_START_TS, COORDINATOR_SUCC_TS, COORDINATOR_TARGET_VERSION,
     },
     storage::BackupStorage,
     utils::{unix_timestamp_sec, GlobalRestoreOptions},
 };
-use anyhow::{anyhow, bail, ensure, Result};
+use anyhow::{anyhow, ensure, Result};
 use aptos_db::state_restore::StateSnapshotRestoreMode;
 use aptos_executor_types::VerifyExecutionMode;
 use aptos_logger::prelude::*;
@@ -383,25 +383,5 @@ impl RestoreCoordinator {
     fn ledger_history_start_version(&self) -> Version {
         self.ledger_history_start_version
             .unwrap_or_else(|| self.target_version())
-    }
-
-    #[allow(dead_code)]
-    fn get_actual_target_version(
-        &self,
-        transaction_backups: &[TransactionBackupMeta],
-    ) -> Result<Version> {
-        if let Some(b) = transaction_backups.last() {
-            if b.last_version > self.target_version() {
-                Ok(self.target_version())
-            } else {
-                warn!(
-                    "Can't find transaction backup containing the target version, \
-                    will restore as much as possible"
-                );
-                Ok(b.last_version)
-            }
-        } else {
-            bail!("No transaction backup found.")
-        }
     }
 }

--- a/storage/backup/backup-cli/src/utils/stream/futures_ordered_x.rs
+++ b/storage/backup/backup-cli/src/utils/stream/futures_ordered_x.rs
@@ -97,7 +97,7 @@ impl<Fut: Future> FuturesOrderedX<Fut> {
     }
 
     /// Returns `true` if the queue contains no futures
-    #[allow(dead_code)]
+    #[cfg(test)]
     pub fn is_empty(&self) -> bool {
         self.in_progress_queue.is_empty() && self.queued_outputs.is_empty()
     }

--- a/storage/backup/backup-cli/src/utils/stream/futures_unordered_x.rs
+++ b/storage/backup/backup-cli/src/utils/stream/futures_unordered_x.rs
@@ -45,6 +45,7 @@ impl<Fut: Future> FuturesUnorderedX<Fut> {
     }
 
     /// Returns `true` if the queue contains no futures
+    #[cfg(test)]
     pub fn is_empty(&self) -> bool {
         self.queued.is_empty() && self.in_progress.is_empty() && self.queued_outputs.is_empty()
     }


### PR DESCRIPTION

Replace blanket `#[allow(dead_code)]` suppressions with proper fixes:

- Gate test-only code with `#[cfg(test)]` or `#[cfg(any(test, feature = "fuzzing"))]`
- Gate `get_usage_before_or_at` with `#[cfg(feature = "db-debugger")]` matching its only caller
- Remove genuinely dead code: `get_actual_target_version`, `get_committed_version`,
  `get_in_progress_state_kv_snapshot_version`, `get_column_families_by_name`
- Remove stale module-level `#![allow(dead_code)]` from `truncation_helper.rs` and
  `ledger_db/mod.rs`
- Clean up imports that became unused as a result

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly compile-time cleanup (removing unused helpers and narrowing visibility via `cfg`), with minimal runtime impact; risk is limited to potential build/feature-flag mismatches.
> 
> **Overview**
> Removes blanket `#[allow(dead_code)]` usage under `storage/` by deleting genuinely unused helpers (e.g. ledger metadata/version and restore/ledger DB utility functions) and tightening module APIs.
> 
> Test/fuzz-only code paths are now explicitly gated with `#[cfg(test)]` or `#[cfg(any(test, feature = "fuzzing"))]` (e.g. pruner pending checks, hot-state merge tracking, transaction auxiliary data helpers), and `LedgerMetadataDb::get_usage_before_or_at` is gated behind `db-debugger` to match its only caller. Imports and minor structure are adjusted accordingly to keep non-test builds warning-free.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2c65e70825af01520e8fd9c4cf3578bb439262fd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->