### PR TITLE
[Smoke Tests] Ignore some unnecessary tests.

### DIFF
--- a/testsuite/smoke-test/src/consensus_observer.rs
+++ b/testsuite/smoke-test/src/consensus_observer.rs
@@ -24,6 +24,7 @@ async fn test_consensus_observer_fast_sync_epoch_changes() {
 }
 
 #[tokio::test]
+#[ignore] // Ignore this test because it is a subset of test_consensus_observer_fast_sync_epoch_changes
 async fn test_consensus_observer_fast_sync_no_epoch_changes() {
     // Test fast syncing with consensus observer and without epoch changes
     state_sync_utils::test_fullnode_fast_sync(false, true).await;

--- a/testsuite/smoke-test/src/execution_pool.rs
+++ b/testsuite/smoke-test/src/execution_pool.rs
@@ -86,6 +86,7 @@ async fn initialize_swarm_with_window(
 }
 
 #[tokio::test]
+#[ignore] // Ignored until execution pool is deployed
 async fn test_window_size_onchain_config_change() {
     let window_size = Some(4u64);
     let (mut swarm, cli, _faucet, root_cli_index, ..) =

--- a/testsuite/smoke-test/src/state_sync.rs
+++ b/testsuite/smoke-test/src/state_sync.rs
@@ -50,6 +50,7 @@ async fn test_fullnode_output_sync_epoch_changes() {
 }
 
 #[tokio::test]
+#[ignore] // Ignored as compression is now the default
 async fn test_fullnode_output_sync_no_compression() {
     // Create a validator swarm of 1 validator node
     let mut swarm = new_local_swarm_with_aptos(1).await;
@@ -170,6 +171,7 @@ async fn test_fullnode_execution_sync_epoch_changes() {
 }
 
 #[tokio::test]
+#[ignore] // Ignore this test because it is a subset of test_fullnode_output_sync_epoch_changes
 async fn test_fullnode_output_sync_no_epoch_changes() {
     // Create a validator swarm of 1 validator node
     let mut swarm = new_local_swarm_with_aptos(1).await;
@@ -187,6 +189,7 @@ async fn test_fullnode_output_sync_no_epoch_changes() {
 }
 
 #[tokio::test]
+#[ignore] // Ignore this test because it is a subset of test_fullnode_execution_sync_epoch_changes
 async fn test_fullnode_execution_sync_no_epoch_changes() {
     // Create a validator swarm of 1 validator node
     let mut swarm = new_local_swarm_with_aptos(1).await;
@@ -266,6 +269,7 @@ async fn test_validator_sync_and_participate_epoch_changes() {
 }
 
 #[tokio::test]
+#[ignore] // Ignore this test because it is a subset of test_validator_sync_and_participate_epoch_changes
 async fn test_validator_sync_and_participate_no_epoch_changes() {
     // Test the default syncing method without epoch changes
     test_validator_sync_and_participate(false, false).await;
@@ -278,6 +282,7 @@ async fn test_validator_fast_sync_and_participate_epoch_changes() {
 }
 
 #[tokio::test]
+#[ignore] // Ignore this test because it is a subset of test_validator_fast_sync_and_participate_epoch_changes
 async fn test_validator_fast_sync_and_participate_no_epoch_changes() {
     // Test fast syncing without epoch changes
     test_validator_sync_and_participate(true, false).await;
@@ -325,6 +330,7 @@ async fn test_validator_output_sync_unrealistic_network_limit() {
 }
 
 #[tokio::test]
+#[ignore] // Ignored as compression is now the default
 async fn test_validator_fast_sync_no_compression() {
     // Create a swarm of 4 validators using fast syncing and no compression
     let mut swarm = SwarmBuilder::new_local(4)
@@ -391,6 +397,7 @@ async fn test_validator_fast_sync_exponential_backoff_epoch_changes() {
 }
 
 #[tokio::test]
+#[ignore] // Ignore this test because it is a subset of test_validator_fast_sync_exponential_backoff_epoch_changes
 async fn test_validator_fast_sync_exponential_backoff_no_epoch_changes() {
     // Test fast syncing without exponential backoff and no epoch changes
     test_validator_sync_exponential_backoff(false).await;
@@ -499,6 +506,7 @@ async fn test_validator_output_sync_exponential_backoff() {
 }
 
 #[tokio::test]
+#[ignore] // Ignored as compression is now the default
 async fn test_validator_execution_sync_no_compression() {
     // Create a swarm of 4 validators using transaction syncing and no compression
     let mut swarm = SwarmBuilder::new_local(4)


### PR DESCRIPTION
## Description
This PR ignores some unnecessary smoke tests.

## Testing Plan
Existing test infrastructure.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts the smoke-test suite by marking several tests as ignored, without changing production code paths.
> 
> **Overview**
> Reduces CI smoke-test load by marking several state sync and consensus observer tests as `#[ignore]` when they are redundant (subset of the epoch-change variants) or no longer meaningful (compression now default).
> 
> Also ignores the execution-pool on-chain `window_size` config-change test until the execution pool feature is deployed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 13ee3e09dccc9fa721134a57bf41359c1d2aa455. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->