### PR TITLE
[QS] Add per-author batch inclusion metrics

### DIFF
--- a/consensus/src/quorum_store/batch_proof_queue.rs
+++ b/consensus/src/quorum_store/batch_proof_queue.rs
@@ -759,8 +759,7 @@ impl BatchProofQueue {
                     .info
                     .expiration()
                     .saturating_sub(self.batch_expiry_gap_when_init_usecs);
-                let age_ms =
-                    now_usecs.saturating_sub(batch_create_ts_usecs) as f64 / 1_000.0;
+                let age_ms = now_usecs.saturating_sub(batch_create_ts_usecs) as f64 / 1_000.0;
                 counters::BATCH_AGE_WHEN_PULLED
                     .with_label_values(&[author, pull_kind])
                     .observe(age_ms);

--- a/consensus/src/quorum_store/counters.rs
+++ b/consensus/src/quorum_store/counters.rs
@@ -56,8 +56,8 @@ const QUORUM_STORE_LATENCY_BUCKETS: &[f64] = &[
 
 // Same as QUORUM_STORE_LATENCY_BUCKETS but in milliseconds
 const QUORUM_STORE_LATENCY_BUCKETS_IN_MS: &[f64] = &[
-    5.0, 10.0, 25.0, 50.0, 100.0, 150.0, 200.0, 250.0, 300.0, 350.0, 400.0, 450.0, 500.0,
-    550.0, 650.0, 700.0, 750.0, 1000.0, 1250.0, 1500.0, 2000.0, 2500.0, 5000.0, 10000.0,
+    5.0, 10.0, 25.0, 50.0, 100.0, 150.0, 200.0, 250.0, 300.0, 350.0, 400.0, 450.0, 500.0, 550.0,
+    650.0, 700.0, 750.0, 1000.0, 1250.0, 1500.0, 2000.0, 2500.0, 5000.0, 10000.0,
 ];
 
 /// Counter for tracking latency of quorum store processing requests from consensus


### PR DESCRIPTION
## Summary
- Adds 5 new per-author metrics to the batch proof queue for diagnosing mempool queuing latency differences across validators
- `quorum_store_batch_pulled_by_author` (counter): tracks batch pulls by author and pull_kind (proof/optbatch/inline)
- `quorum_store_batch_age_when_pulled_ms` (histogram): batch age when pulled, by author and pull_kind
- `quorum_store_batch_queue_duration` (histogram): time from batch insertion to pull, by author
- `quorum_store_proof_delay_after_batch` (histogram): delay between batch and proof insertion, by author
- `quorum_store_batch_skipped_too_young` (counter): batches filtered by min_batch_age, by author

## Test plan
- [x] `cargo check -p aptos-consensus` passes
- [x] All 6 `batch_proof_queue` tests pass
- [ ] Deploy to testnet and verify metrics appear in Grafana with ~300 series for pull metrics and ~100 series for author-only metrics

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily adds new Prometheus metrics and a timestamp field in `BatchProofQueue`; functional behavior is largely unchanged aside from minor pull filtering refactor and extra per-pull work.
> 
> **Overview**
> Adds per-author observability to Quorum Store’s `BatchProofQueue` by tracking when batch summaries first enter the queue and emitting new metrics for batch pulls and latency.
> 
> Specifically, the queue now records `batch_insertion_time`, measures proof arrival delay after batch insertion, counts batches skipped by the `min_batch_age` filter, and emits per-author pull counters/histograms (`pulled_by_author`, `age_when_pulled`, `queue_duration`) tagged by pull kind (`proof`/`optbatch`/`inline`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6d9c51e4d21b41203b99ac9e83b0d864054dcbde. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->