### PR TITLE
[ci] Add smoke-test feature to CI pre-build

### DIFF
--- a/.github/actions/rust-smoke-tests/action.yaml
+++ b/.github/actions/rust-smoke-tests/action.yaml
@@ -20,7 +20,7 @@ runs:
       # Prebuild the aptos-node binary so that tests don't start before the node is built.
       # Also, prebuild the aptos-node binary as a separate step to avoid feature unification issues.
       # Note: --test-threads is intentionally set to reduce resource contention in ci jobs. Increasing this, increases job failures and retries.
-      run: cargo build --locked --package=aptos-node --features=failpoints --release && LOCAL_SWARM_NODE_RELEASE=1 cargo nextest run --release --profile smoke-test --package smoke-test
+      run: cargo build --locked --package=aptos-node --features=failpoints,smoke-test --release && LOCAL_SWARM_NODE_RELEASE=1 cargo nextest run --release --profile smoke-test --package smoke-test
       shell: bash
 
     # We always try to create the artifact, but it only creates on flaky or failed smoke tests -- when the directories are empty.


### PR DESCRIPTION

The CI pre-build step was building `aptos-node` with only `--features=failpoints`,
but forge's `cargo_build_aptos_node()` builds with `--features=failpoints,smoke-test`.
The feature mismatch caused a redundant recompilation during test execution, defeating
the purpose of the pre-build step.

The `smoke-test` feature has real `cfg!` gating in `aptos-jwk-consensus`,
`aptos-dkg-runtime`, and `aptos-config`, so the differing feature set triggers
a rebuild of those crates and their dependents.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change that adjusts Cargo build flags; risk is limited to potentially surfacing feature-gated build issues earlier in the smoke-test job.
> 
> **Overview**
> Updates the `rust-smoke-tests` composite action to prebuild `aptos-node` with `--features=failpoints,smoke-test` instead of only `failpoints`, aligning the CI pre-build with the feature set used by the smoke-test run to avoid redundant recompilation during tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8ff3c3dccddc93b0d1a35a91c008af6e6d72d7c6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->