### PR TITLE
[ci] Prioritize slow smoke tests to reduce wall-clock time

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -31,3 +31,11 @@ fail-fast = true
 test-threads = 6
 retries = 3
 slow-timeout = { period = "1800s", terminate-after = 1 }
+
+# Run the slowest smoke tests first so they start filling slots immediately
+# instead of waiting behind alphabetically-earlier fast tests.
+# This avoids the "long tail" problem (e.g. test_db_restart starting 29 min
+# late and being the sole test running for the last 4 min).
+[[profile.smoke-test.overrides]]
+filter = 'test(jwk_consensus_basic) | test(jwk_consensus_per_issuer) | test(jwk_consensus_per_key) | test(jwk_consensus_provider_change_mind) | test(test_validator_genesis_transaction) | test(test_db_restart)'
+priority = 10

--- a/.github/actions/rust-smoke-tests/action.yaml
+++ b/.github/actions/rust-smoke-tests/action.yaml
@@ -10,6 +10,10 @@ runs:
   steps:
     # The source code must be checkout out by the workflow that invokes this action.
 
+    - name: Print cargo-nextest version
+      run: cargo nextest --version
+      shell: bash
+
     # Run a postgres database
     - name: Run postgres database
       run: docker run --detach -p 5432:5432 cimg/postgres:14.2


### PR DESCRIPTION

nextest runs tests alphabetically, which causes the slowest smoke tests
(`storage::test_db_restart`, `genesis::*`, `jwks::*`) to start late and
create a long tail. For example, `test_db_restart` started 29 minutes
into the run and was the sole test running for the last 4 minutes.

Use nextest's `priority` feature to start these 6 tests first. As each
finishes, its slot is immediately filled by the next pending fast test —
achieving LPT (Longest Processing Time first) scheduling without wasting
any slots between phases.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/aptos-labs/aptos-core/pull/19026).
* __->__ #19026
* #19025