### PR TITLE
[Forge] Disable flaky fullnode checks in forge land blocking.

### DIFF
--- a/testsuite/forge-cli/src/suites/realistic_environment.rs
+++ b/testsuite/forge-cli/src/suites/realistic_environment.rs
@@ -31,6 +31,10 @@ use aptos_testcases::{
 };
 use std::{num::NonZeroUsize, sync::Arc, time::Duration};
 
+/// Whether to enable the fullnode failure test in the max load test
+// TODO: re-enable this after the flakes are removed!
+const ENABLE_FULLNODE_FAILURE_TEST: bool = false;
+
 /// Attempts to match the test name to a realistic-env test
 pub(crate) fn get_realistic_env_test(
     test_name: &str,
@@ -406,7 +410,7 @@ pub(crate) fn realistic_env_max_load_test(
         });
 
     // If the test is short lived, we should verify that there are no fullnode failures
-    if !long_running {
+    if !long_running && ENABLE_FULLNODE_FAILURE_TEST {
         success_criteria = success_criteria.add_no_fullnode_failures();
     }
 


### PR DESCRIPTION
## Description
This PR disables the flaky fullnode checks in forge land blocking. These have started flaking (i.e., consensus observer is falling back to state sync). I need to debug the flakes, but until then, let's stop blocking PRs.

## Testing Plan
Existing test infrastructure.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, test-only change that relaxes a CI success criterion; main risk is reduced detection of real fullnode instability/regressions during land-blocking runs.
> 
> **Overview**
> Disables the short-lived realistic-env max-load test’s `add_no_fullnode_failures()` gate by introducing `ENABLE_FULLNODE_FAILURE_TEST` (default `false`) and guarding the check behind it.
> 
> This effectively stops fullnode-failure-based test failures from blocking PRs until the underlying flakiness is addressed (with a TODO to re-enable).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ff89943691224fd7ed7f711f5d5b9542fe059414. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->