### PR TITLE
[test] Fix flaky test_db_restore smoke test

### DIFF
--- a/testsuite/smoke-test/src/storage.rs
+++ b/testsuite/smoke-test/src/storage.rs
@@ -13,7 +13,7 @@ use crate::{
 use anyhow::{bail, Result};
 use aptos_backup_cli::metadata::view::BackupStorageState;
 use aptos_forge::{reconfig, AptosPublicInfo, Node, NodeExt, Swarm, SwarmExt};
-use aptos_logger::info;
+use aptos_logger::{error, info};
 use aptos_temppath::TempPath;
 use aptos_types::{transaction::Version, waypoint::Waypoint};
 use itertools::Itertools;
@@ -90,8 +90,8 @@ async fn test_db_restore() {
         5,
     )
     .await;
-    // explicit reconfigs: we are at least at epoch 5
-    for _ in 0..4 {
+    // explicit reconfigs: we are at least at epoch 6 (epoch ending 5 exists)
+    for _ in 0..5 {
         reconfig(
             &client_1,
             &transaction_factory,
@@ -113,7 +113,7 @@ async fn test_db_restore() {
     assert_balance(&client_1, &account_0, expected_balance_0).await;
     assert_balance(&client_1, &account_1, expected_balance_1).await;
 
-    info!("---------- 2. reached at least epoch 5, starting backup coordinator.");
+    info!("---------- 2. reached at least epoch 6, starting backup coordinator.");
     // make a backup from node 1
     let node1_config = swarm.validator(validator_peer_ids[1]).unwrap().config();
     let port = node1_config.storage.backup_service_address.port();
@@ -267,21 +267,20 @@ fn wait_for_backups(
             i, target_epoch, target_version,
         );
         let state = get_backup_storage_state(bin_path, metadata_cache_path, backup_path)?;
-        if state.latest_epoch_ending_epoch.is_some()
-            && state.latest_transaction_version.is_some()
+        if let Some(epoch_ending) = state.latest_epoch_ending_epoch
+            && let Some(txn_version) = state.latest_transaction_version
             && state.latest_state_snapshot_epoch.is_some()
-            && state.latest_state_snapshot_epoch.is_some()
-            && state.latest_epoch_ending_epoch.unwrap() >= target_epoch
-            && state.latest_transaction_version.unwrap() >= target_version
-            && state.latest_transaction_version.unwrap()
-                >= state.latest_state_snapshot_version.unwrap()
+            && let Some(snapshot_version) = state.latest_state_snapshot_version
+            && epoch_ending >= target_epoch
+            && txn_version >= target_version
+            && txn_version >= snapshot_version
         {
             info!(
                 "Backup created in {} seconds. backup storage state: {}",
                 now.elapsed().as_secs(),
                 state
             );
-            return Ok(state.latest_state_snapshot_version.unwrap());
+            return Ok(snapshot_version);
         }
         info!("Backup storage state: {}", state);
         if state.latest_transaction_version.is_some() {
@@ -291,6 +290,10 @@ fn wait_for_backups(
         std::thread::sleep(Duration::from_secs(1));
     }
 
+    error!(
+        "Timed out waiting for backup to reach epoch {}, version {}.",
+        target_epoch, target_version
+    );
     bail!("Failed to create backup.");
 }
 


### PR DESCRIPTION

`db_backup` requires `latest_epoch_ending_epoch >= 5`, which means
epoch 5 must have **ended** (chain in epoch 6+). With only 4 explicit
reconfigs from epoch 1, the chain reaches epoch 5 but epoch 5 is still
open — `latest_epoch_ending_epoch` is only 4. The test relied on
probabilistic reconfigs (20% chance per transfer, 10 transfers) to push
past epoch 5, but ~10.7% of the time none fired, causing `wait_for_backups`
to spin for its full 120-iteration timeout (~10-15 min) before bailing.

- Bump the explicit reconfig count from 4 to 5 so the chain
  deterministically reaches epoch 6.
- Fix duplicate `latest_state_snapshot_epoch.is_some()` check in
  `wait_for_backups` — the second was meant to be
  `latest_state_snapshot_version.is_some()`.
- Add `error!` log before `bail!` on timeout for easier debugging.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to the `test_db_restore` smoke test and its backup-wait helper, making the test more deterministic and improving diagnostics without impacting production logic.
> 
> **Overview**
> Makes `test_db_restore` deterministic by increasing explicit `reconfig` calls so the chain reliably reaches epoch 6 before starting backups (ensuring epoch-ending 5 exists), and updates related log messaging.
> 
> Hardens `wait_for_backups` by fixing the readiness predicate to require `latest_state_snapshot_version` (removing a duplicate epoch check), using safer `if let` binding instead of `unwrap()`, and emitting an `error!` log before timing out and bailing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4eccbdd520125302e968b66da1aa9f6037182255. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->