### PR TITLE
[test] Add timeout to backup commands in wait_for_backups

### DIFF
--- a/testsuite/smoke-test/src/genesis.rs
+++ b/testsuite/smoke-test/src/genesis.rs
@@ -354,7 +354,8 @@ async fn delete_db_and_execute_restore(
         current_version as usize, // txn batch size (version 0 is in its own batch)
         previous_epoch as usize,  // state snapshot interval
         &[waypoint],
-    );
+    )
+    .await;
 
     // Stop the specified validator
     let validator = env.validators_mut().nth(validator_index).unwrap();

--- a/testsuite/smoke-test/src/storage.rs
+++ b/testsuite/smoke-test/src/storage.rs
@@ -4,8 +4,9 @@
 use crate::{
     smoke_test_environment::SwarmBuilder,
     utils::{
-        assert_balance, create_and_fund_account, swarm_utils::insert_waypoint,
-        transfer_and_maybe_reconfig, transfer_coins, MAX_CATCH_UP_WAIT_SECS, MAX_HEALTHY_WAIT_SECS,
+        assert_balance, create_and_fund_account, run_command_with_timeout,
+        swarm_utils::insert_waypoint, transfer_and_maybe_reconfig, transfer_coins,
+        MAX_CATCH_UP_WAIT_SECS, MAX_HEALTHY_WAIT_SECS,
     },
     workspace_builder,
     workspace_builder::workspace_root,
@@ -117,7 +118,7 @@ async fn test_db_restore() {
     // make a backup from node 1
     let node1_config = swarm.validator(validator_peer_ids[1]).unwrap().config();
     let port = node1_config.storage.backup_service_address.port();
-    let (backup_path, _) = db_backup(port, 5, 400, 200, 5, &[]);
+    let (backup_path, _) = db_backup(port, 5, 400, 200, 5, &[]).await;
     // take down node 0
     let node_to_restart = validator_peer_ids[0];
     swarm.validator_mut(node_to_restart).unwrap().stop();
@@ -178,7 +179,7 @@ async fn test_db_restore() {
     info!("6. Done");
 }
 
-fn db_backup_verify(backup_path: &Path, trusted_waypoints: &[Waypoint]) {
+async fn db_backup_verify(backup_path: &Path, trusted_waypoints: &[Waypoint]) {
     info!("---------- running aptos-debugger aptos-db backup-verify");
     let now = Instant::now();
     let bin_path = workspace_builder::get_bin("aptos-debugger");
@@ -186,26 +187,30 @@ fn db_backup_verify(backup_path: &Path, trusted_waypoints: &[Waypoint]) {
 
     metadata_cache_path.create_as_dir().unwrap();
 
-    let mut cmd = Command::new(bin_path.as_path());
-    cmd.args(["aptos-db", "backup", "verify"]);
+    let mut cmd = tokio::process::Command::new(bin_path.as_path());
+    cmd.current_dir(workspace_root())
+        .args(["aptos-db", "backup", "verify"]);
     trusted_waypoints.iter().for_each(|w| {
         cmd.arg("--trust-waypoint");
         cmd.arg(w.to_string());
     });
+    cmd.args([
+        "--metadata-cache-dir",
+        metadata_cache_path.path().to_str().unwrap(),
+        "--concurrent-downloads",
+        "4",
+        "--local-fs-dir",
+        backup_path.to_str().unwrap(),
+    ]);
 
-    let status = cmd
-        .args([
-            "--metadata-cache-dir",
-            metadata_cache_path.path().to_str().unwrap(),
-            "--concurrent-downloads",
-            "4",
-            "--local-fs-dir",
-            backup_path.to_str().unwrap(),
-        ])
-        .current_dir(workspace_root())
-        .status()
+    let output = run_command_with_timeout(cmd, Duration::from_secs(15), "backup verify")
+        .await
         .unwrap();
-    assert!(status.success(), "{}", status);
+    assert!(
+        output.status.success(),
+        "backup verify failed:\nstderr: {}",
+        String::from_utf8_lossy(&output.stderr),
+    );
     info!("Backup verified in {} seconds.", now.elapsed().as_secs());
 }
 
@@ -252,7 +257,7 @@ fn replay_verify(backup_path: &Path, trusted_waypoints: &[Waypoint]) {
     );
 }
 
-fn wait_for_backups(
+async fn wait_for_backups(
     target_epoch: u64,
     target_version: u64,
     now: Instant,
@@ -266,7 +271,7 @@ fn wait_for_backups(
             "{}th wait for the backup to reach epoch {}, version {}.",
             i, target_epoch, target_version,
         );
-        let state = get_backup_storage_state(bin_path, metadata_cache_path, backup_path)?;
+        let state = get_backup_storage_state(bin_path, metadata_cache_path, backup_path).await?;
         if let Some(epoch_ending) = state.latest_epoch_ending_epoch
             && let Some(txn_version) = state.latest_transaction_version
             && state.latest_state_snapshot_epoch.is_some()
@@ -285,9 +290,9 @@ fn wait_for_backups(
         info!("Backup storage state: {}", state);
         if state.latest_transaction_version.is_some() {
             // the verify should always succeed unless backup storage is completely empty.
-            db_backup_verify(backup_path, trusted_waypoints);
+            db_backup_verify(backup_path, trusted_waypoints).await;
         }
-        std::thread::sleep(Duration::from_secs(1));
+        tokio::time::sleep(Duration::from_secs(1)).await;
     }
 
     error!(
@@ -297,32 +302,32 @@ fn wait_for_backups(
     bail!("Failed to create backup.");
 }
 
-fn get_backup_storage_state(
+async fn get_backup_storage_state(
     bin_path: &Path,
     metadata_cache_path: &Path,
     backup_path: &Path,
 ) -> Result<BackupStorageState> {
-    let output = Command::new(bin_path)
-        .current_dir(workspace_root())
-        .args([
-            "aptos-db",
-            "backup",
-            "query",
-            "backup-storage-state",
-            "--metadata-cache-dir",
-            metadata_cache_path.to_str().unwrap(),
-            "--concurrent-downloads",
-            "4",
-            "--local-fs-dir",
-            backup_path.to_str().unwrap(),
-        ])
-        .output()?
-        .stdout;
-    std::str::from_utf8(&output)?.parse()
+    let mut cmd = tokio::process::Command::new(bin_path);
+    cmd.current_dir(workspace_root()).args([
+        "aptos-db",
+        "backup",
+        "query",
+        "backup-storage-state",
+        "--metadata-cache-dir",
+        metadata_cache_path.to_str().unwrap(),
+        "--concurrent-downloads",
+        "4",
+        "--local-fs-dir",
+        backup_path.to_str().unwrap(),
+    ]);
+    let output =
+        run_command_with_timeout(cmd, Duration::from_secs(15), "query backup-storage-state")
+            .await?;
+    std::str::from_utf8(&output.stdout)?.parse()
 }
 
 #[allow(clippy::zombie_processes)]
-pub(crate) fn db_backup(
+pub(crate) async fn db_backup(
     backup_service_port: u16,
     target_epoch: u64,
     target_version: Version,
@@ -343,7 +348,9 @@ pub(crate) fn db_backup(
 
     // Initialize backup storage, avoid race between the coordinator and wait_for_backups to create
     // the identity file.
-    get_backup_storage_state(&bin_path, metadata_cache_path2.path(), backup_path.path()).unwrap();
+    get_backup_storage_state(&bin_path, metadata_cache_path2.path(), backup_path.path())
+        .await
+        .unwrap();
 
     // spawn the backup coordinator
     let mut backup_coordinator = Command::new(bin_path.as_path())
@@ -377,7 +384,8 @@ pub(crate) fn db_backup(
         metadata_cache_path2.path(),
         backup_path.path(),
         trusted_waypoints,
-    );
+    )
+    .await;
 
     // start the backup compaction
     let compaction = Command::new(bin_path.as_path())

--- a/testsuite/smoke-test/src/utils.rs
+++ b/testsuite/smoke-test/src/utils.rs
@@ -2,6 +2,7 @@
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::aptos_cli::validator::generate_blob;
+use anyhow::{bail, Context, Result};
 use aptos::test::CliTestFramework;
 use aptos_cached_packages::aptos_stdlib;
 use aptos_config::{
@@ -21,11 +22,69 @@ use aptos_types::{
 };
 use move_core_types::language_storage::CORE_CODE_ADDRESS;
 use rand::random;
-use std::{collections::HashSet, net::Ipv4Addr, sync::Arc, time::Duration};
+use std::{collections::HashSet, net::Ipv4Addr, process::Stdio, sync::Arc, time::Duration};
+use tokio::io::AsyncReadExt;
 
 pub const MAX_CATCH_UP_WAIT_SECS: u64 = 180; // The max time we'll wait for nodes to catch up
 pub const MAX_CONNECTIVITY_WAIT_SECS: u64 = 180; // The max time we'll wait for nodes to gain connectivity
 pub const MAX_HEALTHY_WAIT_SECS: u64 = 120; // The max time we'll wait for nodes to become healthy
+
+/// Runs a [`tokio::process::Command`] with a timeout. On timeout the child is
+/// killed and whatever stdout/stderr was produced is included in the error.
+pub async fn run_command_with_timeout(
+    mut cmd: tokio::process::Command,
+    timeout: Duration,
+    description: &str,
+) -> Result<std::process::Output> {
+    let mut child = cmd
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true)
+        .spawn()
+        .with_context(|| format!("Failed to spawn: {description}"))?;
+
+    let mut stdout_pipe = child.stdout.take().expect("stdout was piped");
+    let mut stderr_pipe = child.stderr.take().expect("stderr was piped");
+
+    // Spawn tasks to collect stdout/stderr concurrently with waiting.
+    let stdout_task = tokio::spawn(async move {
+        let mut buf = Vec::new();
+        let _ = stdout_pipe.read_to_end(&mut buf).await;
+        buf
+    });
+    let stderr_task = tokio::spawn(async move {
+        let mut buf = Vec::new();
+        let _ = stderr_pipe.read_to_end(&mut buf).await;
+        buf
+    });
+
+    match tokio::time::timeout(timeout, child.wait()).await {
+        Ok(Ok(status)) => {
+            let stdout = stdout_task.await.unwrap_or_default();
+            let stderr = stderr_task.await.unwrap_or_default();
+            Ok(std::process::Output {
+                status,
+                stdout,
+                stderr,
+            })
+        },
+        Ok(Err(e)) => bail!("Command '{description}' failed to run: {e}"),
+        Err(_) => {
+            // Kill the child; this closes its pipes, unblocking the reader
+            // tasks so we can retrieve whatever partial output was produced.
+            let _ = child.kill().await;
+            let _ = child.wait().await;
+            let stdout = stdout_task.await.unwrap_or_default();
+            let stderr = stderr_task.await.unwrap_or_default();
+            bail!(
+                "Command '{description}' timed out after {timeout:?}\n\
+                 stdout:\n{}\nstderr:\n{}",
+                String::from_utf8_lossy(&stdout),
+                String::from_utf8_lossy(&stderr),
+            )
+        },
+    }
+}
 
 pub fn add_node_to_seeds(
     dest_config: &mut NodeConfig,


### PR DESCRIPTION

`get_backup_storage_state` and `db_backup_verify` are called repeatedly
inside `wait_for_backups`'s polling loop. If either subprocess hangs the
whole smoke test blocks indefinitely. Switch them to
`tokio::process::Command` + a new `run_command_with_timeout` helper
(15 s timeout). On timeout the child is killed and its captured
stdout/stderr is included in the error message.

Observed in CI ([run](https://github.com/aptos-labs/aptos-core/actions/runs/22975562753/job/66703173815)):
`test_db_restore` try 1 timed out at 1800 s. The test stuck after the
15th `wait_for_backups` iteration — `db_backup_verify` exited
successfully but the test never advanced to iteration 16, suggesting
the next `get_backup_storage_state` (`.output()`) call hung. The
backup coordinator kept running for ~29 min until the harness killed
the test. Try 2 passed in 82 s.

- `get_backup_storage_state` and `db_backup_verify` are now async and
  use `run_command_with_timeout`.
- `wait_for_backups` and `db_backup` become async to propagate the
  change. The blocking `std::thread::sleep` in the polling loop is
  replaced with `tokio::time::sleep`.
- `run_command_with_timeout` is added to `utils.rs` for reuse.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
