### PR TITLE
[vm] Security nits for Move VM

### DIFF
--- a/third_party/move/move-vm/runtime/src/interpreter.rs
+++ b/third_party/move/move-vm/runtime/src/interpreter.rs
@@ -1272,13 +1272,12 @@ where
                     CallType::NativeDynamicDispatch,
                 )?;
 
-                // Checking type of the dispatch target function
-                //
-                // MoveVM will check that the native function that performs the dispatch will have the same
-                // type signature as the dispatch target function except the native function will have an extra argument
-                // in the end to determine which function to jump to. The native function shouldn't switch ordering of arguments.
-                //
-                // Runtime will use such convention to reconstruct the type stack required to perform paranoid mode checks.
+                if function.param_tys().is_empty() {
+                    return Err(PartialVMError::new_invariant_violation(
+                        "Dispatch functions have at least 1 argument (function information)",
+                    ));
+                }
+
                 if function.ty_param_abilities() != target_func.ty_param_abilities()
                     || function.return_tys() != target_func.return_tys()
                     || &function.param_tys()[0..function.param_tys().len() - 1]
@@ -2701,20 +2700,6 @@ impl Frame {
                             )
                             .map(Rc::new)?;
                         RTTCheck::check_pack_closure_visibility(&self.function, &function)?;
-
-                        let captured = interpreter.operand_stack.popn(mask.captured_count())?;
-                        interpreter.check_depth_of_closure_captured_values(&captured)?;
-                        let lazy_function = LazyLoadedFunction::new_resolved(
-                            interpreter.layout_converter,
-                            gas_meter,
-                            traversal_context,
-                            function.clone(),
-                            *mask,
-                        )?;
-                        interpreter
-                            .operand_stack
-                            .push(Value::closure(Box::new(lazy_function), captured))?;
-
                         if RTTCheck::should_perform_checks(&self.function.function) {
                             verify_pack_closure(
                                 self.ty_builder(),
@@ -2732,6 +2717,19 @@ impl Frame {
                                 *mask,
                             )?;
                         }
+
+                        let captured = interpreter.operand_stack.popn(mask.captured_count())?;
+                        interpreter.check_depth_of_closure_captured_values(&captured)?;
+                        let lazy_function = LazyLoadedFunction::new_resolved(
+                            interpreter.layout_converter,
+                            gas_meter,
+                            traversal_context,
+                            function.clone(),
+                            *mask,
+                        )?;
+                        interpreter
+                            .operand_stack
+                            .push(Value::closure(Box::new(lazy_function), captured))?;
                     },
                     Instruction::ReadRef => {
                         let reference = interpreter.operand_stack.pop_as::<Reference>()?;
@@ -3137,7 +3135,7 @@ impl Frame {
                         )?;
                         gas_meter
                             .charge_vec_pack(interpreter.operand_stack.last_n(*num as usize)?)?;
-                        let elements = interpreter.operand_stack.popn(*num as u16)?;
+                        let elements = interpreter.operand_stack.popn(*num)?;
                         let value = Vector::pack(ty, elements)?;
                         interpreter.operand_stack.push(value)?;
                     },

--- a/third_party/move/move-vm/runtime/src/loader/function.rs
+++ b/third_party/move/move-vm/runtime/src/loader/function.rs
@@ -697,7 +697,11 @@ impl Function {
 
         // Native functions do not have a code unit
         let code = match &def.code {
-            Some(code) => code.code.iter().map(|b| b.clone().into()).collect(),
+            Some(code) => code
+                .code
+                .iter()
+                .map(|b| Instruction::try_from(b.clone()))
+                .collect::<PartialVMResult<Vec<_>>>()?,
             None => vec![],
         };
         let ty_param_abilities = handle.type_parameters.clone();

--- a/third_party/move/move-vm/runtime/src/loader/script.rs
+++ b/third_party/move/move-vm/runtime/src/loader/script.rs
@@ -17,6 +17,7 @@ use move_core_types::{
     language_storage::{pseudo_script_module_id, ModuleId},
 };
 use move_vm_types::{
+    instr::Instruction,
     loaded_data::{
         runtime_access_specifier::AccessSpecifier,
         runtime_types::{StructIdentifier, Type},
@@ -103,7 +104,12 @@ impl Script {
             });
         }
 
-        let code = script.code.code.iter().map(|b| b.clone().into()).collect();
+        let code = script
+            .code
+            .code
+            .iter()
+            .map(|b| Instruction::try_from(b.clone()))
+            .collect::<PartialVMResult<Vec<_>>>()?;
         let parameters = script.signature_at(script.parameters).clone();
 
         let param_tys = parameters

--- a/third_party/move/move-vm/runtime/src/runtime_ref_checks.rs
+++ b/third_party/move/move-vm/runtime/src/runtime_ref_checks.rs
@@ -686,7 +686,7 @@ impl RuntimeRefCheck for FullRuntimeRefCheck {
                 ref_state.move_to()?;
             },
             VecPack(_, n) => {
-                ref_state.pop_many_from_shadow_stack(safe_unwrap_err!((*n).try_into()))?;
+                ref_state.pop_many_from_shadow_stack(*n as usize)?;
                 ref_state.push_non_refs_to_shadow_stack(1);
             },
             VecLen(_) => {

--- a/third_party/move/move-vm/runtime/src/runtime_type_checks.rs
+++ b/third_party/move/move-vm/runtime/src/runtime_type_checks.rs
@@ -846,6 +846,12 @@ impl RuntimeTypeCheck for FullRuntimeTypeCheck {
             },
             Instruction::Exists(_) | Instruction::ExistsGeneric(_) => {
                 operand_stack.pop_ty()?.paranoid_check_is_address_ty()?;
+                // Note:
+                //   We **explicitly** do not check for key ability here because
+                //   checking if resource exists is not exploitable. Even if the
+                //   struct we check does not have key ability, nothing bad happens,
+                //   unlike with operations that **do** something with this struct,
+                //   like move_to, move_from or global borrows.
 
                 let bool_ty = ty_builder.create_bool_ty();
                 operand_stack.push_ty(bool_ty)?;
@@ -888,7 +894,7 @@ impl RuntimeTypeCheck for FullRuntimeTypeCheck {
             },
             Instruction::VecPack(si, num) => {
                 let (ty, _, _) = ty_cache.get_signature_index_type(*si, frame)?;
-                let elem_tys = operand_stack.popn_tys(*num as u16)?;
+                let elem_tys = operand_stack.popn_tys(*num)?;
                 for elem_ty in elem_tys.iter() {
                     // For vector element types, use assignability
                     elem_ty.paranoid_check_assignable(ty)?;

--- a/third_party/move/move-vm/runtime/src/storage/ty_layout_converter.rs
+++ b/third_party/move/move-vm/runtime/src/storage/ty_layout_converter.rs
@@ -631,12 +631,18 @@ where
                         return Err(PartialVMError::new_invariant_violation(msg));
                     },
                     (Some(kind), false) => {
-                        // Note: for delayed fields, simply never output annotated layout. The
-                        // callers should not be able to handle it in any case.
-
+                        // Note 1:
+                        //   For delayed fields, simply never output annotated layout. The
+                        //   callers should not be able to handle it in any case.
+                        //
+                        // Note 2:
+                        //   For derived strings, aggregators or snapshots, do not use the
+                        //   cache to reduce bounds on count/depth by resolving by struct
+                        //   identity (see below). All these layouts are small (few nodes),
+                        //   the cost of reconstructing them on cache miss is negligible,
+                        //   and it is not worth additional feature gating.
                         use IdentifierMappingKind::*;
                         let layout = match &kind {
-                            // For derived strings, replace the whole struct.
                             DerivedString => {
                                 let inner_layout = MoveTypeLayout::new_struct(
                                     MoveStructLayout::new(field_layouts),

--- a/third_party/move/move-vm/types/src/instr.rs
+++ b/third_party/move/move-vm/types/src/instr.rs
@@ -1,15 +1,19 @@
 // Copyright (c) Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use move_binary_format::file_format::{
-    Bytecode, CodeOffset, ConstantPoolIndex, FieldHandleIndex, FieldInstantiationIndex,
-    FunctionHandleIndex, FunctionInstantiationIndex, LocalIndex, SignatureIndex,
-    StructDefInstantiationIndex, StructDefinitionIndex, StructVariantHandleIndex,
-    StructVariantInstantiationIndex, VariantFieldHandleIndex, VariantFieldInstantiationIndex,
+use move_binary_format::{
+    errors::{PartialVMError, PartialVMResult},
+    file_format::{
+        Bytecode, CodeOffset, ConstantPoolIndex, FieldHandleIndex, FieldInstantiationIndex,
+        FunctionHandleIndex, FunctionInstantiationIndex, LocalIndex, SignatureIndex,
+        StructDefInstantiationIndex, StructDefinitionIndex, StructVariantHandleIndex,
+        StructVariantInstantiationIndex, VariantFieldHandleIndex, VariantFieldInstantiationIndex,
+    },
 };
 use move_core_types::{
     function::ClosureMask,
     int256::{I256, U256},
+    vm_status::StatusCode,
 };
 
 /// The VM's internal representation of instructions.
@@ -94,7 +98,7 @@ pub enum Instruction {
     MoveToGeneric(StructDefInstantiationIndex),
     Shl,
     Shr,
-    VecPack(SignatureIndex, u64),
+    VecPack(SignatureIndex, u16),
     VecLen(SignatureIndex),
     VecImmBorrow(SignatureIndex),
     VecMutBorrow(SignatureIndex),
@@ -238,12 +242,14 @@ impl Instruction {
     }
 }
 
-impl From<Bytecode> for Instruction {
-    fn from(bytecode: Bytecode) -> Self {
+impl TryFrom<Bytecode> for Instruction {
+    type Error = PartialVMError;
+
+    fn try_from(bytecode: Bytecode) -> PartialVMResult<Self> {
         use Bytecode as B;
         use Instruction as O;
 
-        match bytecode {
+        Ok(match bytecode {
             B::Pop => O::Pop,
             B::Ret => O::Ret,
             B::BrTrue(offset) => O::BrTrue(offset),
@@ -318,7 +324,15 @@ impl From<Bytecode> for Instruction {
             B::MoveToGeneric(idx) => O::MoveToGeneric(idx),
             B::Shl => O::Shl,
             B::Shr => O::Shr,
-            B::VecPack(idx, n) => O::VecPack(idx, n),
+            B::VecPack(idx, n) => {
+                let n = u16::try_from(n).map_err(|_| {
+                    // The bytecode verifier guarantees n <= u16::MAX; reaching here
+                    // means the verifier was bypassed.
+                    PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
+                        .with_message(format!("VecPack count {} exceeds u16::MAX", n))
+                })?;
+                O::VecPack(idx, n)
+            },
             B::VecLen(idx) => O::VecLen(idx),
             B::VecImmBorrow(idx) => O::VecImmBorrow(idx),
             B::VecMutBorrow(idx) => O::VecMutBorrow(idx),
@@ -348,7 +362,7 @@ impl From<Bytecode> for Instruction {
             B::CastI128 => O::CastI128,
             B::CastI256 => O::CastI256,
             B::Negate => O::Negate,
-        }
+        })
     }
 }
 


### PR DESCRIPTION
## Summary

- **PackClosureGeneric stack order**: verification was running after the operand stack was already mutated (captured values popped, closure pushed). If verification failed the stacks were inconsistent. Fixed to mirror `PackClosure` — verify first, then mutate.
- **Native dynamic dispatch**: `param_tys().len() - 1` would panic/wrap if the function had no parameters. Added an explicit guard.
- **VecPack count type**: changed `Instruction::VecPack(SignatureIndex, u64)` → `u16`. The bytecode verifier already guarantees `n <= u16::MAX`; storing `u64` and silently truncating at `popn(*num as u16)` was a latent bug. `From<Bytecode>` becomes `TryFrom` so a bypassed verifier surfaces an explicit invariant violation.
- **ty_layout_converter**: added a note explaining why `DerivedString` (and other delayed-field kinds) skip the struct layout cache.
- **Paranoid checker Exists/ExistsGeneric**: the key-ability check that `MutBorrowGlobal`/`ImmBorrowGlobal`/`MoveFrom` perform is intentionally absent here — checking existence of a resource that lacks `key` can't cause harm. Added a comment so this doesn't look like an oversight.

## Test plan

- `cargo check -p move-vm-types`
- `cargo check -p move-vm-runtime`
- `cargo test -p move-vm-types`
- `cargo test -p move-vm-runtime`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Move VM instruction decoding and interpreter stack/type-checking paths; mistakes could impact bytecode execution correctness, though changes are narrowly scoped to invariant-violation guards and order-of-operations fixes.
> 
> **Overview**
> **Hardens several Move VM runtime safety edges** to avoid panics and inconsistent interpreter state under malformed or verifier-bypassed bytecode.
> 
> In the interpreter, `PackClosureGeneric` now performs verification/checks *before* mutating the operand stack, and native dynamic dispatch adds an explicit non-empty-params guard to prevent `len()-1` underflow. `VecPack`’s element count is tightened from `u64` to `u16`, with decoding switched to `Instruction::try_from(Bytecode)` so out-of-range counts raise an invariant violation instead of silently truncating during `popn`/type/ref checks; loader paths (module + script) are updated accordingly. Minor clarifying comments are added around `Exists` paranoid checks (no `key` ability check) and layout caching behavior for delayed-field-derived layouts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e96d506ac89231180ac9e62109936950d404ee51. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->