### PR TITLE
[mono-move] Global context template

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12620,6 +12620,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "mono-move-global-context"
+version = "0.1.0"
+dependencies = [
+ "parking_lot 0.12.1",
+]
+
+[[package]]
 name = "mono-move-micro-ops"
 version = "0.1.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -206,6 +206,7 @@ members = [
     "testsuite/smoke-test",
     "testsuite/testcases",
     "third_party/move/extensions/move-table-extension",
+    "third_party/move/mono-move/global-context",
     "third_party/move/mono-move/micro-ops",
     "third_party/move/move-binary-format",
     "third_party/move/move-binary-format/serializer-tests",

--- a/third_party/move/mono-move/global-context/Cargo.toml
+++ b/third_party/move/mono-move/global-context/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "mono-move-global-context"
+version = "0.1.0"
+
+# Workspace inherited keys
+authors = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+repository = { workspace = true }
+rust-version = { workspace = true }
+
+[dependencies]
+parking_lot = { workspace = true }

--- a/third_party/move/mono-move/global-context/src/context.rs
+++ b/third_party/move/mono-move/global-context/src/context.rs
@@ -1,0 +1,162 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Core types and implementation for the global execution context.
+//!
+//! # Safety Contract & Design Principles
+//!
+//! ## Two-Phase State Machine
+//!
+//! The global context operates in two exclusive phases:
+//!
+//! 1. **Execution Phase**
+//!
+//!    Multiple [`ExecutionGuard`] guards can be held concurrently. Guards
+//!    provide read-only access to interners via [`RwLockReadGuard`] that may
+//!    allocate new data but never deallocates, making arena allocations
+//!    stable (no reset or drop possible). Pointers returned from the guard are
+//!    valid for the guard's lifetime.
+//!
+//! 2. **Maintenance Phase**
+//!    A single exclusive [`MaintenanceGuard`] guard exists with write access
+//!    via [`RwLockWriteGuard`]. During this phase caches can be reset. Because
+//!    no execution contexts can co-exist, there can be no dangling pointers,
+//!    making deallocation safe.
+
+use crate::maintenance_config::MaintenanceConfig;
+use parking_lot::{RwLock, RwLockReadGuard, RwLockWriteGuard};
+
+/// Global execution context with a two-phase state machine.
+///
+/// # Phases
+///
+/// 1. **Execution Phase**: Multiple [`ExecutionGuard`] guards can be
+///    obtained concurrently across threads. Each worker gets access to global
+///    arena. This allows parallel execution where each thread can read from
+///    the shared caches, allocate data, and safely use raw pointers (addresses
+///    are guaranteed to be stable).
+///
+/// 2. **Maintenance Phase**: A single [`MaintenanceGuard`] guard provides
+///    exclusive write access for maintenance operations (scheduled between
+///    execution phases, e.g., between blocks of transactions) such as cache
+///    cleanup or data deallocation.
+pub struct GlobalContext {
+    /// Shared caches protected by read-write lock.
+    ctx: RwLock<Context>,
+    // TODO: global arena here.
+    /// Configuration controlling maintenance behavior.
+    maintenance_config: MaintenanceConfig,
+}
+
+/// Shared context containing interned data structures. Global arena where the
+/// data is allocated is kept separately.
+struct Context {
+    // TODO: add caches here.
+}
+
+/// RAII guard for the maintenance phase providing exclusive write access.
+///
+/// Only one maintenance context can exist at a time, ensuring exclusive
+/// access to the internal state for maintenance operations. The write lock
+/// is held for the lifetime of this guard and automatically released when
+/// dropped.
+pub struct MaintenanceGuard<'a> {
+    /// Write guard on shared data (disallows obtaining concurrent execution
+    /// guard).
+    #[allow(dead_code)]
+    ctx_guard: RwLockWriteGuard<'a, Context>,
+
+    // TODO: mut reference to global arena here.
+    /// Configuration controlling maintenance behavior.
+    #[allow(dead_code)]
+    maintenance_config: &'a MaintenanceConfig,
+}
+
+/// RAII guard for the execution phase providing concurrent read access
+/// to shared interned data and exclusive access to a dedicated arena.
+/// Multiple execution contexts can exist simultaneously across threads.
+pub struct ExecutionGuard<'a> {
+    /// Read guard on shared interned data (prevents maintenance phase).
+    #[allow(dead_code)]
+    ctx_guard: RwLockReadGuard<'a, Context>,
+    // TODO: reference to global arena (shard) here.
+}
+
+impl GlobalContext {
+    /// Creates a new global context with the specified number of workers that
+    /// can acquire [`ExecutionGuard`] and default maintenance config.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the number of workers is 0, greater than 128 or is not a
+    /// power of two.
+    pub fn with_num_execution_workers(num_workers: usize) -> Self {
+        Self::with_num_execution_workers_and_config(num_workers, MaintenanceConfig::default())
+    }
+
+    /// Creates a new global context with the specified number of execution
+    /// workers that can acquire [`ExecutionGuard`] and the maintenance config.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the number of workers is 0, greater than 128 or is not a
+    /// power of two.
+    pub fn with_num_execution_workers_and_config(
+        num_workers: usize,
+        maintenance_config: MaintenanceConfig,
+    ) -> Self {
+        assert!(
+            num_workers > 0 && num_workers <= 128,
+            "Number of workers must be between 1 and 128, got {num_workers}"
+        );
+        assert!(
+            num_workers.is_power_of_two(),
+            "Number of workers must be a power of two, got {num_workers}"
+        );
+
+        Self {
+            ctx: RwLock::new(Context {}),
+            maintenance_config,
+        }
+    }
+
+    /// Transitions to maintenance mode by obtaining a [`MaintenanceGuard`]
+    /// guard. Only one maintenance context can be held at a time, providing
+    /// exclusive access to the internal state for maintenance operations. No
+    /// execution context can be held concurrently.
+    ///
+    /// Returns [`None`] if [`ExecutionGuard`] is currently held or there is
+    /// an ongoing maintenance.
+    #[must_use]
+    pub fn try_maintenance_context(&self) -> Option<MaintenanceGuard<'_>> {
+        // TODO: acquire arena as well.
+        Some(MaintenanceGuard {
+            ctx_guard: self.ctx.try_write()?,
+            maintenance_config: &self.maintenance_config,
+        })
+    }
+
+    /// Transitions to execution mode by obtaining an [`ExecutionGuard`] guard
+    /// and locking the arena for the given worker. Multiple execution contexts
+    /// can be held concurrently across threads for different workers.
+    ///
+    /// Returns [`None`] if
+    ///   - there is an ongoing maintenance phase.
+    pub fn try_execution_context(&self, _worker_id: usize) -> Option<ExecutionGuard<'_>> {
+        let ctx_guard = self.ctx.try_read()?;
+        // TODO: acquire arena as well.
+        Some(ExecutionGuard { ctx_guard })
+    }
+}
+
+impl<'a> MaintenanceGuard<'a> {}
+
+impl<'a> ExecutionGuard<'a> {}
+
+//
+// Only private APIs below.
+// ------------------------
+
+impl<'a> MaintenanceGuard<'a> {}
+
+impl<'a> ExecutionGuard<'a> {}

--- a/third_party/move/mono-move/global-context/src/lib.rs
+++ b/third_party/move/mono-move/global-context/src/lib.rs
@@ -1,0 +1,6 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+mod context;
+pub use context::{ExecutionGuard, GlobalContext, MaintenanceGuard};
+pub mod maintenance_config;

--- a/third_party/move/mono-move/global-context/src/maintenance_config.rs
+++ b/third_party/move/mono-move/global-context/src/maintenance_config.rs
@@ -1,0 +1,15 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+/// Configuration for maintenance phase of [`crate::GlobalContext`].
+#[derive(Clone)]
+pub struct MaintenanceConfig {
+    // TODO: add actual configs here.
+    pub dummy: u64,
+}
+
+impl Default for MaintenanceConfig {
+    fn default() -> Self {
+        Self { dummy: 123 }
+    }
+}

--- a/third_party/move/mono-move/global-context/tests/context_tests.rs
+++ b/third_party/move/mono-move/global-context/tests/context_tests.rs
@@ -1,0 +1,171 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Integration tests for acquiring execution or maintenance guards from global
+//! context.
+
+use mono_move_global_context::GlobalContext;
+use std::{
+    sync::{Arc, Barrier},
+    thread,
+    time::Duration,
+};
+
+#[test]
+fn test_contexts() {
+    let ctx = GlobalContext::with_num_execution_workers(4);
+
+    {
+        let _guard = ctx.try_execution_context(0).unwrap();
+    }
+    {
+        let _guard = ctx.try_maintenance_context().unwrap();
+    }
+    {
+        let _guard1 = ctx.try_execution_context(0).unwrap();
+        let _guard2 = ctx.try_execution_context(1).unwrap();
+        let _guard3 = ctx.try_execution_context(2).unwrap();
+        let _guard4 = ctx.try_execution_context(3).unwrap();
+    }
+}
+
+#[test]
+fn test_concurrent_execution_contexts() {
+    let num_threads = 4;
+
+    let ctx = Arc::new(GlobalContext::with_num_execution_workers(num_threads));
+    let barrier = Arc::new(Barrier::new(num_threads));
+
+    let handles: Vec<_> = (0..num_threads)
+        .map(|worker_id| {
+            let ctx: Arc<GlobalContext> = Arc::clone(&ctx);
+            let barrier = Arc::clone(&barrier);
+            thread::spawn(move || {
+                // Wait for all threads to be ready.
+                barrier.wait();
+
+                // All threads should be able to acquire execution context simultaneously.
+                let _guard = ctx.try_execution_context(worker_id).unwrap();
+                thread::sleep(Duration::from_millis(1000));
+            })
+        })
+        .collect();
+
+    for handle in handles {
+        handle.join().unwrap();
+    }
+}
+
+#[test]
+fn test_maintenance_blocks_maintenance() {
+    let num_threads = 2;
+
+    let ctx = Arc::new(GlobalContext::with_num_execution_workers(num_threads));
+    let barrier = Arc::new(Barrier::new(num_threads));
+
+    let handle = thread::spawn({
+        let ctx: Arc<GlobalContext> = Arc::clone(&ctx);
+        let barrier = Arc::clone(&barrier);
+        move || {
+            let _guard = ctx.try_maintenance_context().unwrap();
+
+            // Signal that we have the lock. Sleep for long enough to ensure
+            // the main thread has enough time to try to acquire the guard.
+            barrier.wait();
+            thread::sleep(Duration::from_millis(2000));
+        }
+    });
+
+    // Wait for thread 1 to be in maintenance mode.
+    barrier.wait();
+    thread::sleep(Duration::from_millis(10));
+    assert!(ctx.try_maintenance_context().is_none());
+
+    handle.join().unwrap();
+}
+
+#[test]
+fn test_maintenance_blocks_execution() {
+    let num_threads = 2;
+
+    let ctx = Arc::new(GlobalContext::with_num_execution_workers(num_threads));
+    let barrier = Arc::new(Barrier::new(num_threads));
+
+    let handle = thread::spawn({
+        let ctx: Arc<GlobalContext> = Arc::clone(&ctx);
+        let barrier = Arc::clone(&barrier);
+        move || {
+            let _guard = ctx.try_maintenance_context().unwrap();
+
+            // Signal that we have the lock. Sleep for long enough to ensure
+            // the main thread has enough time to try to acquire the guard.
+            barrier.wait();
+            thread::sleep(Duration::from_millis(2000));
+        }
+    });
+
+    // Wait for thread 1 to be in maintenance mode.
+    barrier.wait();
+    thread::sleep(Duration::from_millis(10));
+    assert!(ctx.try_execution_context(0).is_none());
+
+    handle.join().unwrap();
+}
+
+#[test]
+fn test_execution_blocks_maintenance() {
+    let num_threads = 4;
+
+    let ctx = Arc::new(GlobalContext::with_num_execution_workers(num_threads));
+    let barrier = Arc::new(Barrier::new(num_threads + 1));
+
+    // Spawn multiple threads holding execution guards.
+    let handles: Vec<_> = (0..num_threads)
+        .map(|worker_id| {
+            let ctx: Arc<GlobalContext> = Arc::clone(&ctx);
+            let barrier = Arc::clone(&barrier);
+            thread::spawn(move || {
+                let _guard = ctx.try_execution_context(worker_id).unwrap();
+
+                // Signal that we have the lock.
+                barrier.wait();
+                thread::sleep(Duration::from_millis(2000));
+            })
+        })
+        .collect();
+
+    barrier.wait();
+    thread::sleep(Duration::from_millis(10));
+    assert!(ctx.try_maintenance_context().is_none());
+
+    for handle in handles {
+        handle.join().unwrap();
+    }
+}
+
+#[test]
+fn test_block_execution_simulation() {
+    let num_threads = 4;
+    let ctx = Arc::new(GlobalContext::with_num_execution_workers(num_threads));
+
+    for _ in 0..5 {
+        // Execution phase: concurrent execution.
+        let handles: Vec<_> = (0..num_threads)
+            .map(|worker_id| {
+                let ctx: Arc<GlobalContext> = Arc::clone(&ctx);
+                thread::spawn(move || {
+                    let _guard = ctx.try_execution_context(worker_id).unwrap();
+                    thread::sleep(Duration::from_millis(100));
+                })
+            })
+            .collect();
+
+        for handle in handles {
+            handle.join().unwrap();
+        }
+
+        // Maintenance phase: single thread with exclusive access.
+        let _guard = ctx.try_maintenance_context().unwrap();
+        thread::sleep(Duration::from_millis(100));
+    }
+}


### PR DESCRIPTION
## Description
Adds the `global-context` crate under `third_party/move/mono-move/`, implementing
the Global Execution Context described in Section 1 of the MonoMove design doc.

Rather than the atomic-based sketch in the design doc, this implementation opts for
a simpler RwLock-based model to enforce the 2-phase state machine at compile time:

- **Execution phase** — multiple `ExecutionGuard` RAII guards can be held concurrently
  across workers. The read lock prevents any maintenance from running.
- **Maintenance phase** — a single `MaintenanceGuard` holds the write lock, blocking
  all new execution guards and ensuring no concurrent allocations or reads are in flight.

## How Has This Been Tested?
- `tests/context_tests.rs` covers:
  - Sequential acquisition of execution and maintenance guards.
  - Concurrent execution guards across multiple threads.
  - Maintenance blocking a second maintenance attempt.
  - Maintenance blocking new execution guards.
  - Execution guards blocking maintenance.
  - Full block-execution simulation (alternating execution and maintenance phases).

## Key Areas to Review
- `src/context.rs`: `GlobalContext`, `ExecutionGuard`, `MaintenanceGuard` — the
  RwLock usage and `try_read`/`try_write` non-blocking acquisition semantics.

## Type of Change
- [x] New feature

## Which Components or Systems Does This Change Impact?
- [x] Move/Aptos Virtual Machine

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: introduces a new standalone crate and workspace member with basic `RwLock`-guarded phase switching plus tests, without wiring it into existing execution paths.
> 
> **Overview**
> Adds a new `mono-move-global-context` workspace crate that defines a `GlobalContext` API with RAII-based `ExecutionGuard` (shared/read) vs `MaintenanceGuard` (exclusive/write) acquisition using `parking_lot::RwLock` and non-blocking `try_read`/`try_write` semantics.
> 
> Includes a simple `MaintenanceConfig` stub and integration tests validating concurrent execution guard acquisition and mutual exclusion between execution and maintenance phases. Updates the workspace `Cargo.toml` and `Cargo.lock` to include the new crate.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 83741a650f5572289070f7706e7a7a2dadb11957. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->