### PR TITLE
[mono-move] Interning for identifiers and module IDs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12624,8 +12624,11 @@ dependencies = [
 name = "mono-move-global-context"
 version = "0.1.0"
 dependencies = [
+ "ahash 0.8.12",
  "bumpalo",
  "crossbeam-utils",
+ "dashmap 7.0.0-rc2",
+ "move-core-types",
  "parking_lot 0.12.1",
 ]
 

--- a/third_party/move/mono-move/global-context/Cargo.toml
+++ b/third_party/move/mono-move/global-context/Cargo.toml
@@ -12,6 +12,9 @@ repository = { workspace = true }
 rust-version = { workspace = true }
 
 [dependencies]
+ahash = { workspace = true }
 bumpalo = { workspace = true }
 crossbeam-utils = { workspace = true }
+dashmap = { workspace = true }
+move-core-types = { workspace = true }
 parking_lot = { workspace = true }

--- a/third_party/move/mono-move/global-context/src/alloc.rs
+++ b/third_party/move/mono-move/global-context/src/alloc.rs
@@ -17,8 +17,10 @@
 //! - [`GlobalArenaPtr::as_ref_unchecked`] — caller must ensure that the arena
 //!   that owns the data has not been reset or dropped, and that the pointer
 //!   has not been invalidated.
-//! - [`GlobalArenaPool::reset_unchecked`] — caller must ensure there are no
-//!   live pointers derived from the allocations that is about to be reset.
+//! - [`GlobalArenaPool::reset_all_arenas_unchecked`] — caller must ensure
+//!   there are no live pointers derived from the allocations that is about to
+//!   be reset and that it is called from single-threaded context (exclusive
+//!   access required).
 
 use bumpalo::Bump;
 use crossbeam_utils::CachePadded;
@@ -56,6 +58,11 @@ impl<T: ?Sized> GlobalArenaPtr<T> {
         //
         // Caller must ensure safety preconditions.
         unsafe { self.0.as_ref() }
+    }
+
+    /// Returns the inner non-null pointer to the allocated data.
+    pub fn into_inner(self) -> NonNull<T> {
+        self.0
     }
 
     /// Returns the raw const pointer to the allocated data.
@@ -194,7 +201,7 @@ impl GlobalArenaPool {
     ///    **must** ensure that the access is exclusive and there are no race
     ///    conditions.
     // TODO: Consider using &mut to enforce exclusive access at compile-time.
-    pub unsafe fn reset_unchecked(&self) {
+    pub unsafe fn reset_all_arenas_unchecked(&self) {
         for arena in self.arenas.iter() {
             arena.lock().reset();
         }

--- a/third_party/move/mono-move/global-context/src/context.rs
+++ b/third_party/move/mono-move/global-context/src/context.rs
@@ -21,9 +21,37 @@
 //!    via [`RwLockWriteGuard`]. During this phase caches can be reset. Because
 //!    no execution contexts can co-exist, there can be no dangling pointers,
 //!    making deallocation safe.
+//!
+//! ## Global Allocation Race Window
+//!
+//! When interning, allocation happens **outside the [`DashMap`] lock** to
+//! reduce contention. This creates a race window where multiple threads may
+//! allocate the same interned data. This is intentional and safe:
+//!
+//!   - Only one pointer is stored in the interner's map.
+//!   - Duplicate allocations leak but are bounded (interning converges).
+//!   - Trade-off: minor memory waste for lower lock contention.
 
-use crate::{alloc::GlobalArenaShard, maintenance_config::MaintenanceConfig, GlobalArenaPool};
+use crate::{
+    alloc::{GlobalArenaPtr, GlobalArenaShard},
+    maintenance_config::MaintenanceConfig,
+    GlobalArenaPool,
+};
+use dashmap::DashMap;
 use parking_lot::{RwLock, RwLockReadGuard, RwLockWriteGuard};
+use std::{
+    hash::{Hash, Hasher},
+    marker::PhantomData,
+    ptr,
+    ptr::NonNull,
+};
+
+// Submodules: to split implementation into smaller pieces.
+mod identifiers;
+use identifiers::IdentifierInternerKey;
+mod executable_ids;
+pub use executable_ids::ExecutableId;
+use executable_ids::ExecutableIdInternerKey;
 
 /// Global execution context with a two-phase state machine.
 ///
@@ -56,7 +84,9 @@ pub struct GlobalContext {
 /// Shared context containing interned data structures. Global arena where the
 /// data is allocated is kept separately.
 struct Context {
-    // TODO: add caches here.
+    identifiers: DashMap<IdentifierInternerKey, GlobalArenaPtr<str>, ahash::RandomState>,
+    executable_ids:
+        DashMap<ExecutableIdInternerKey, GlobalArenaPtr<ExecutableId>, ahash::RandomState>,
 }
 
 /// RAII guard for the maintenance phase providing exclusive write access.
@@ -65,37 +95,50 @@ struct Context {
 /// access to the internal state for maintenance operations. The write lock
 /// is held for the lifetime of this guard and automatically released when
 /// dropped.
-pub struct MaintenanceGuard<'a> {
+pub struct MaintenanceGuard<'ctx> {
     /// Reference to the caches stored in context.
-    #[allow(dead_code)]
-    ctx: &'a Context,
+    ctx: &'ctx Context,
     /// Pool of all arenas managing global allocations.
-    #[allow(dead_code)]
-    global_arena: &'a GlobalArenaPool,
+    global_arena: &'ctx GlobalArenaPool,
     /// Configuration controlling maintenance behavior.
     #[allow(dead_code)]
-    maintenance_config: &'a MaintenanceConfig,
+    maintenance_config: &'ctx MaintenanceConfig,
 
     /// Write guard that disallows obtaining concurrent execution
     /// guard. **Must** be dropped last.
-    _guard: RwLockWriteGuard<'a, ()>,
+    _guard: RwLockWriteGuard<'ctx, ()>,
 }
 
 /// RAII guard for the execution phase providing concurrent read access
 /// to shared interned data and exclusive access to a dedicated arena.
 /// Multiple execution contexts can exist simultaneously across threads.
-pub struct ExecutionGuard<'a> {
+pub struct ExecutionGuard<'ctx> {
     /// Reference to the caches stored in context.
-    #[allow(dead_code)]
-    ctx: &'a Context,
+    ctx: &'ctx Context,
     /// Arena dedicated for this execution guard with exclusive access.
     /// During execution, data can be allocated here without contention.
-    #[allow(dead_code)]
-    global_arena: GlobalArenaShard<'a>,
+    global_arena: GlobalArenaShard<'ctx>,
 
     /// Read guard preventing maintenance phase, but allowing concurrent
     /// execution phases. **Must** be dropped last.
-    _guard: RwLockReadGuard<'a, ()>,
+    _guard: RwLockReadGuard<'ctx, ()>,
+}
+
+/// A scoped reference to data obtained from [`ExecutionGuard`] and is guaranteed
+/// to be alive until the guard is dropped.
+///
+/// # Safety model
+///
+/// The reference lifetime is tied to the lifetime of the [`ExecutionGuard`].
+/// It is guaranteed that the data it points to is kept alive as long as the
+/// guard is alive.
+///
+/// The pointer stored behind the reference is guaranteed to be valid and
+/// safe to dereference.
+#[repr(transparent)]
+pub struct ArenaRef<'guard, T: ?Sized> {
+    ptr: NonNull<T>,
+    _guard: PhantomData<&'guard ()>,
 }
 
 impl GlobalContext {
@@ -131,7 +174,10 @@ impl GlobalContext {
         );
 
         Self {
-            ctx: Context {},
+            ctx: Context {
+                identifiers: DashMap::default(),
+                executable_ids: DashMap::default(),
+            },
             global_arena: GlobalArenaPool::with_num_arenas(num_workers),
             maintenance_config,
             phase: RwLock::new(()),
@@ -169,6 +215,7 @@ impl GlobalContext {
     ///
     /// Panics if the worker ID is out of bounds when trying to get an arena
     /// from the pool.
+    #[must_use]
     pub fn try_execution_context(&self, worker_id: usize) -> Option<ExecutionGuard<'_>> {
         let _guard = self.phase.try_read()?;
 
@@ -180,14 +227,126 @@ impl GlobalContext {
     }
 }
 
-impl<'a> MaintenanceGuard<'a> {}
+impl<'ctx> MaintenanceGuard<'ctx> {
+    /// Returns the total number of bytes used across all arenas in the global
+    /// arena pool.
+    pub fn global_arena_allocated_bytes_sum(&self) -> usize {
+        (0..self.global_arena.num_arenas())
+            .map(|idx| self.global_arena.allocated_bytes(idx))
+            .sum()
+    }
 
-impl<'a> ExecutionGuard<'a> {}
+    /// Returns the number of entries in interner's map for identifiers.
+    pub fn interned_identifiers_count(&self) -> usize {
+        self.ctx.identifiers.len()
+    }
+
+    /// Returns the number of entries in interner's map for executable IDs.
+    pub fn interned_executable_ids_count(&self) -> usize {
+        self.ctx.executable_ids.len()
+    }
+
+    /// Resets all caches that store pointers to the arenas, and then resets
+    /// the arenas as well.
+    pub fn reset_arena_pool(&mut self) {
+        // SAFETY: Arena is only reset **after** caches are cleared.
+        unsafe {
+            self.reset_all_caches();
+        }
+
+        // SAFETY: We are in maintenance phase, so there are no concurrent
+        // execution contexts and therefore no live pointers to arena other
+        // than ones that were stored in caches. All caches were cleared (see
+        // above), and so there are no live pointers making reset safe.
+        unsafe {
+            self.global_arena.reset_all_arenas_unchecked();
+        }
+    }
+}
+
+impl<'ctx> ExecutionGuard<'ctx> {}
 
 //
 // Only private APIs below.
 // ------------------------
 
-impl<'a> MaintenanceGuard<'a> {}
+impl<'ctx> MaintenanceGuard<'ctx> {
+    /// Clears all caches stored in [`Context`]. Triggered when the global
+    /// arena requires a full reset (and thus, any cache that stores pointers
+    /// to that arena must be invalidated).
+    ///
+    /// # Safety
+    ///
+    /// Should be called **before** arena backing allocations is reset or
+    /// dropped.
+    unsafe fn reset_all_caches(&mut self) {
+        // Exhaustive destructuring so that there is a compile-time error if a
+        // new field is added without being explicitly handled here.
+        //
+        // CRITICAL: caches can store pointers to arenas which can be reset, it
+        // is important to ensure these caches are cleared before that.
+        let Context {
+            identifiers,
+            executable_ids,
+        } = self.ctx;
 
-impl<'a> ExecutionGuard<'a> {}
+        identifiers.clear();
+        executable_ids.clear();
+    }
+}
+
+impl<'ctx> ExecutionGuard<'ctx> {
+    /// Returns a reference scoped to the lifetime of the guard.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure the pointer points to stable data and will not
+    /// be deallocated during guard's lifetime.
+    unsafe fn arena_ref<'guard, T: ?Sized>(
+        &'guard self,
+        ptr: GlobalArenaPtr<T>,
+    ) -> ArenaRef<'guard, T>
+    where
+        'ctx: 'guard,
+    {
+        ArenaRef {
+            ptr: ptr.into_inner(),
+            _guard: Default::default(),
+        }
+    }
+}
+
+impl<'guard, T: ?Sized> ArenaRef<'guard, T> {
+    /// Returns the raw address of the allocation of the pointer. For testing
+    /// purposes only.
+    pub fn raw_address_for_testing(&self) -> usize {
+        self.ptr.as_ptr().addr()
+    }
+}
+
+// Arena reference uses pointer hash. Because of interning, pointer hash
+// equality implies structural hash equality (ignoring hash collisions).
+impl<'guard, T: ?Sized> Hash for ArenaRef<'guard, T> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.ptr.hash(state)
+    }
+}
+
+// Arena reference uses pointer equality. Because of interning, pointer
+// equality implies structural equality.
+impl<'guard, T: ?Sized> PartialEq for ArenaRef<'guard, T> {
+    fn eq(&self, other: &Self) -> bool {
+        ptr::eq(self.ptr.as_ptr(), other.ptr.as_ptr())
+    }
+}
+
+impl<'guard, T: ?Sized> Eq for ArenaRef<'guard, T> {}
+
+// Arena reference can be duplicated with bitwise copy.
+impl<'guard, T: ?Sized> Copy for ArenaRef<'guard, T> {}
+
+impl<'guard, T: ?Sized> Clone for ArenaRef<'guard, T> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}

--- a/third_party/move/mono-move/global-context/src/context/executable_ids.rs
+++ b/third_party/move/mono-move/global-context/src/context/executable_ids.rs
@@ -1,0 +1,211 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! This submodule defines APIs to intern Move module IDs as arena-allocated
+//! executable IDs.
+//!
+//! # Safety model
+//!
+//! IDs are interned as canonical pointers. Public APIs return a scoped pointer
+//! ([`ArenaRef`]) with lifetime of the execution guard. This prevents any
+//! use-after-free for interned IDs at compile-time.
+//!
+//! Interning may happen concurrently, in which case it is guaranteed that all
+//! workers agree on a single canonical pointer. To reduce contention for
+//! better performance, arena allocations for IDs happen outside the lock, and
+//! so may leak memory. However, any extra allocated memory for any unique
+//! address-pair and concurrent worker is at most ~40 bytes (address plus
+//! pointer sizes).
+//!
+//! The deduplication map where interned IDs are stored is **always** cleared
+//! when the arena backing the allocation is reset. It is safe to dereference
+//! any arena-based pointers stored in the map.
+
+use crate::{alloc::GlobalArenaPtr, context::ArenaRef, ExecutionGuard};
+use dashmap::{Entry, Equivalent};
+use move_core_types::{
+    account_address::AccountAddress, identifier::IdentStr, language_storage::ModuleId,
+};
+use std::hash::{Hash, Hasher};
+
+impl<'guard> ArenaRef<'guard, ExecutableId> {
+    /// Returns the account address of this executable.
+    pub fn address(&self) -> &'guard AccountAddress {
+        // SAFETY: The lifetime on this reference guarantees that the execution
+        // guard is still alive, which guarantees that the arena allocation is
+        // still valid and there were no deallocations.
+        unsafe { &self.ptr.as_ref().address }
+    }
+
+    /// Returns the name of this executable.
+    pub fn name(&self) -> &'guard str {
+        // SAFETY: The guard guarantees that we are still in execution phase
+        // and the pointer to ID is still valid. Because the name was arena
+        // allocated before this ID was created (enforced by global arena
+        // allocator APIs), the name allocation is  also valid for the same
+        // lifetime.
+        unsafe {
+            let id = self.ptr.as_ref();
+            id.name.as_ref_unchecked()
+        }
+    }
+}
+
+#[allow(private_interfaces)]
+impl<'ctx> ExecutionGuard<'ctx> {
+    /// Interns [`ModuleId`] as an arena-allocated executable ID and returns a
+    /// reference to it, with lifetime scoped to the lifetime of the execution
+    /// guard.
+    ///
+    /// On cache hit, returns a canonical pointer interned previously.
+    /// On cache miss, interns the module name and allocates the ID in the
+    /// global arena, returning a pointer to:
+    ///   - Allocated ID if the ID was not interned before.
+    ///   - Existing canonical pointer if the interned ID exists. Note that the
+    ///     entry can exist due to a race condition because allocation is done
+    ///     outside the lock (by design). In this case, extra allocations are
+    ///     bounded: we allocate extra address and a name pointer (40 bytes)
+    ///     per worker in the worst case for each unique address-name pair.
+    ///
+    /// # Safety precondition
+    ///
+    /// During global arena reset, identifiers map must be cleared as well.
+    pub fn intern_module_id<'guard>(
+        &'guard self,
+        module_id: &ModuleId,
+    ) -> ArenaRef<'guard, ExecutableId>
+    where
+        'ctx: 'guard,
+    {
+        self.intern_address_name(&module_id.address, &module_id.name)
+    }
+
+    /// Interns [`AccountAddress`]-[`IdentStr`] pair as an arena-allocated
+    /// executable ID and returns a reference to it, with lifetime scoped to
+    /// the lifetime of the execution guard.
+    ///
+    /// On cache hit, returns a canonical pointer interned previously.
+    /// On cache miss, interns the module name and allocates the ID in the
+    /// global arena, returning a pointer to:
+    ///   - Allocated ID if the ID was not interned before.
+    ///   - Existing canonical pointer if the interned ID exists. Note that the
+    ///     entry can exist due to a race condition because allocation is done
+    ///     outside the lock (by design). In this case, extra allocations are
+    ///     bounded: we allocate extra address and a name pointer (40 bytes)
+    ///     per worker in the worst case for each unique address-name pair.
+    ///
+    /// # Safety precondition
+    ///
+    /// During global arena reset, identifiers map must be cleared as well.
+    pub fn intern_address_name<'guard>(
+        &'guard self,
+        address: &AccountAddress,
+        name: &IdentStr,
+    ) -> ArenaRef<'guard, ExecutableId>
+    where
+        'ctx: 'guard,
+    {
+        let ptr = self.intern_address_name_internal(*address, name);
+
+        // SAFETY: If the returned pointer is the one that was allocated, it is
+        // trivially valid until the next maintenance phase, and it is safe to
+        // cast it to the lifetime of the execution guard. If the returned
+        // pointer already existed in the map, it also must be valid until the
+        // next maintenance (and previous maintenance phase has not invalidated
+        // it because then the map would have been cleared).
+        unsafe { self.arena_ref(ptr) }
+    }
+}
+
+//
+// Only private APIs below.
+// ------------------------
+
+/// Identifies an executable (module or script) by its address and name.
+///   - For modules, constructed from module address and name.
+///   - For scripts: TODO
+///
+/// # Safety
+///
+/// Must be created from a valid global arena pointer to executable's name.
+pub struct ExecutableId {
+    address: AccountAddress,
+    name: GlobalArenaPtr<str>,
+}
+
+#[allow(private_interfaces)]
+impl<'ctx> ExecutionGuard<'ctx> {
+    fn intern_address_name_internal(
+        &self,
+        address: AccountAddress,
+        name: &IdentStr,
+    ) -> GlobalArenaPtr<ExecutableId> {
+        // SAFETY: All existing keys/values are valid pointers because the map
+        // is guaranteed to be cleared on arena's reset.
+        if let Some(entry) = self.ctx.executable_ids.get(&(&address, name)) {
+            return *entry.value();
+        }
+
+        // SAFETY: Name pointer has been just interned - it is valid and can be
+        // used safely for ID construction.
+        let name = self.intern_identifier_impl(name);
+        let ptr = self.global_arena.alloc(ExecutableId { address, name });
+
+        // SAFETY: We have just allocated the pointer, hence it is safe to wrap
+        // it as a key and compute hash / equality. All existing keys are also
+        // valid pointers because the map is cleared on arena's reset.
+        let key = ExecutableIdInternerKey(ptr);
+        match self.ctx.executable_ids.entry(key) {
+            Entry::Occupied(entry) => *entry.get(),
+            Entry::Vacant(entry) => *entry.insert(ptr),
+        }
+    }
+}
+
+/// Wraps allocated executable ID pointer to implement structural hash and
+/// equality.
+///
+/// # Safety
+///
+/// Constructor must enforce the pointer points to the valid data and can be
+/// safely dereferenced.
+pub(super) struct ExecutableIdInternerKey(GlobalArenaPtr<ExecutableId>);
+
+impl Hash for ExecutableIdInternerKey {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        // SAFETY: It is safe to dereference the pointer because the caller
+        // ensures it remains valid during the lifetime of the key.
+        unsafe {
+            let id = self.0.as_ref_unchecked();
+            id.address.hash(state);
+            id.name.as_ref_unchecked().hash(state);
+        }
+    }
+}
+
+impl PartialEq for ExecutableIdInternerKey {
+    fn eq(&self, other: &Self) -> bool {
+        // SAFETY: It is safe to dereference the pointer because the caller
+        // ensures it remains valid during the lifetime of the key.
+        unsafe {
+            let this_id = self.0.as_ref_unchecked();
+            let other_id = other.0.as_ref_unchecked();
+            this_id.address == other_id.address
+                && this_id.name.as_ref_unchecked() == other_id.name.as_ref_unchecked()
+        }
+    }
+}
+
+// PartialEq implementation above is a full equivalence relation.
+impl Eq for ExecutableIdInternerKey {}
+
+impl Equivalent<ExecutableIdInternerKey> for (&AccountAddress, &IdentStr) {
+    fn equivalent(&self, key: &ExecutableIdInternerKey) -> bool {
+        // SAFETY: It is safe to dereference the pointer because the caller
+        // ensures it remains valid during the lifetime of the key.
+        unsafe {
+            let key = key.0.as_ref_unchecked();
+            self.0 == &key.address && self.1.as_str() == key.name.as_ref_unchecked()
+        }
+    }
+}

--- a/third_party/move/mono-move/global-context/src/context/identifiers.rs
+++ b/third_party/move/mono-move/global-context/src/context/identifiers.rs
@@ -1,0 +1,154 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! This submodule defines APIs to intern Move identifiers as arena-allocated
+//! strings.
+//!
+//! # Safety model
+//!
+//! Identifiers are interned as canonical pointers. Public APIs return a scoped
+//! pointer ([`ArenaRef`]) with lifetime of the execution guard. This prevents
+//! use-after-free for interned identifiers at compile-time.
+//!
+//! Interning may happen concurrently, in which case it is guaranteed that all
+//! workers agree on a single canonical pointer. To reduce contention for
+//! better performance, arena allocations happen outside the lock, and so may
+//! leak memory. However, any extra allocated memory is always bounded by the
+//! number of concurrent workers and unique identifiers.
+//!
+//! The deduplication map where interned identifiers are stored is **always**
+//! cleared when the arena backing the allocation is reset. Hence, it is safe
+//! to dereference any arena-based pointers stored in the map.
+
+use crate::{alloc::GlobalArenaPtr, context::ArenaRef, ExecutionGuard};
+use dashmap::{Entry, Equivalent};
+use move_core_types::identifier::IdentStr;
+use std::hash::{Hash, Hasher};
+
+impl<'guard> ArenaRef<'guard, str> {
+    /// Returns the inner string stored behind the reference.
+    pub fn as_str(&self) -> &'guard str {
+        // SAFETY: The lifetime on this reference guarantees that the execution
+        // guard is still alive, which guarantees that the arena allocation is
+        // still valid and there were no deallocations.
+        unsafe { self.ptr.as_ref() }
+    }
+}
+
+impl<'ctx> ExecutionGuard<'ctx> {
+    /// Interns Move identifier as a string and returns a reference to it, with
+    /// lifetime scoped to the lifetime of [`ExecutionGuard`].
+    ///
+    /// On cache hit, returns a canonical pointer interned previously.
+    /// On cache miss, allocates the string in the global arena and
+    /// returns a pointer to:
+    ///   - Allocated data if the string was not interned before.
+    ///   - Existing canonical pointer if the interned string exists. Note that
+    ///     the entry can exist due to a race condition because allocation is
+    ///     done outside the lock (by design). In this case, extra allocations
+    ///     are bounded to O(unique identifiers * number of workers) which is
+    ///     negligible in practice.
+    ///
+    /// # Safety precondition
+    ///
+    /// During global arena reset, identifiers map must be cleared as well.
+    pub fn intern_identifier<'guard>(&'guard self, identifier: &IdentStr) -> ArenaRef<'guard, str>
+    where
+        'ctx: 'guard,
+    {
+        let ptr = self.intern_identifier_impl(identifier);
+
+        // SAFETY: If the returned pointer is the one that was allocated, it is
+        // trivially valid until the next maintenance phase, and it is safe to
+        // cast it to the lifetime of the execution guard. If the returned
+        // pointer already existed in the map, it also must be valid until the
+        // next maintenance (and previous maintenance phase has not invalidated
+        // it because then the map would have been cleared).
+        unsafe { self.arena_ref(ptr) }
+    }
+}
+
+//
+// Only private APIs below.
+// ------------------------
+
+impl<'ctx> ExecutionGuard<'ctx> {
+    pub(super) fn intern_identifier_impl(&self, identifier: &IdentStr) -> GlobalArenaPtr<str> {
+        // TODO:
+        //   Consider checking that the identifier size is within bounds. While
+        //   CompiledModule / CompiledScript deserializer enforces 256 byte
+        //   limit (in new config), when coming from deserialized TypeTag from
+        //   transaction payload there is no bound. It is not a big problem,
+        //   but just makes spam attacks easier to intern some dummy data in the
+        //   pool. In general, for type tag interning we might want to enforce
+        //   that the modules which are specified actually exist on-chain. In
+        //   existing VM we already do that to get ability information, but not
+        //   here (for now), so that we ensure that there is no spam that can
+        //   get in. However, there still can be a problem with speculative
+        //   module publishing: if we speculatively intern new names, but the
+        //   publish actually fails, we end up with spam on-chain.
+        //   Note: this DoS is only possible via `init_module`. If we remove it
+        //   or ensure no speculative data even for names ever get on-chain, we
+        //   limit interned set to the on-chain data, so for DoS one actually
+        //   has to publish modules (expensive).
+        let str = identifier.as_str();
+
+        // SAFETY: All existing keys/values are valid pointers because the map
+        // is guaranteed to be cleared on arena's reset.
+        if let Some(entry) = self.ctx.identifiers.get(&LookupKey(str)) {
+            return *entry.value();
+        }
+
+        let ptr = self.global_arena.alloc_str(str);
+
+        // SAFETY: We have just allocated the pointer, hence it is safe to wrap
+        // it as a key and compute hash / equality. All existing keys are also
+        // valid pointers because the map is cleared on arena's reset.
+        let key = IdentifierInternerKey(ptr);
+        match self.ctx.identifiers.entry(key) {
+            Entry::Occupied(entry) => *entry.get(),
+            Entry::Vacant(entry) => *entry.insert(ptr),
+        }
+    }
+}
+
+/// Wraps allocated string pointer to implement structural hash and equality.
+///
+/// # Safety
+///
+/// Constructor must enforce the pointer points to the valid data and can be
+/// safely dereferenced.
+pub(super) struct IdentifierInternerKey(GlobalArenaPtr<str>);
+
+// Wrapper to avoid orphan rule.
+#[derive(Hash, PartialEq, Eq)]
+struct LookupKey<'a>(&'a str);
+
+impl Hash for IdentifierInternerKey {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        // SAFETY: It is safe to dereference the pointer because the caller
+        // ensures it remains valid during the lifetime of the key.
+        let str = unsafe { self.0.as_ref_unchecked() };
+        str.hash(state);
+    }
+}
+
+impl PartialEq for IdentifierInternerKey {
+    fn eq(&self, other: &Self) -> bool {
+        // SAFETY: It is safe to dereference the pointer because the caller
+        // ensures it remains valid during the lifetime of the key.
+        unsafe { self.0.as_ref_unchecked() == other.0.as_ref_unchecked() }
+    }
+}
+
+// PartialEq implementation above is a full equivalence relation.
+impl Eq for IdentifierInternerKey {}
+
+impl Equivalent<IdentifierInternerKey> for LookupKey<'_> {
+    fn equivalent(&self, key: &IdentifierInternerKey) -> bool {
+        // SAFETY: It is safe to dereference the pointer because the caller
+        // ensures it remains valid during the lifetime of the key.
+        let key = unsafe { key.0.as_ref_unchecked() };
+        self.0 == key
+    }
+}

--- a/third_party/move/mono-move/global-context/src/lib.rs
+++ b/third_party/move/mono-move/global-context/src/lib.rs
@@ -4,5 +4,6 @@
 mod alloc;
 pub use alloc::GlobalArenaPool;
 mod context;
-pub use context::{ExecutionGuard, GlobalContext, MaintenanceGuard};
+pub use context::{ArenaRef, ExecutableId, ExecutionGuard, GlobalContext, MaintenanceGuard};
+pub use move_core_types::identifier::Identifier;
 pub mod maintenance_config;

--- a/third_party/move/mono-move/global-context/tests/context_tests.rs
+++ b/third_party/move/mono-move/global-context/tests/context_tests.rs
@@ -5,6 +5,7 @@
 //! context.
 
 use mono_move_global_context::GlobalContext;
+use move_core_types::{account_address::AccountAddress, ident_str};
 use std::{
     sync::{Arc, Barrier},
     thread,
@@ -26,6 +27,9 @@ fn test_contexts() {
         let _guard2 = ctx.try_execution_context(1).unwrap();
         let _guard3 = ctx.try_execution_context(2).unwrap();
         let _guard4 = ctx.try_execution_context(3).unwrap();
+
+        // Arena shard at 0 is already locked.
+        assert!(ctx.try_execution_context(0).is_none())
     }
 }
 
@@ -168,4 +172,23 @@ fn test_block_execution_simulation() {
         let _guard = ctx.try_maintenance_context().unwrap();
         thread::sleep(Duration::from_millis(100));
     }
+}
+
+#[test]
+fn test_global_arena_reset() {
+    let ctx = GlobalContext::with_num_execution_workers(1);
+
+    {
+        let guard = ctx.try_execution_context(0).unwrap();
+        guard.intern_identifier(ident_str!("foo"));
+        guard.intern_address_name(&AccountAddress::ZERO, ident_str!("bar"));
+    }
+
+    let mut guard = ctx.try_maintenance_context().unwrap();
+    assert_eq!(guard.interned_identifiers_count(), 2);
+    assert_eq!(guard.interned_executable_ids_count(), 1);
+
+    guard.reset_arena_pool();
+    assert_eq!(guard.interned_identifiers_count(), 0);
+    assert_eq!(guard.interned_executable_ids_count(), 0);
 }

--- a/third_party/move/mono-move/global-context/tests/executable_id_tests.rs
+++ b/third_party/move/mono-move/global-context/tests/executable_id_tests.rs
@@ -1,0 +1,122 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Tests for interning of module IDs.
+
+use mono_move_global_context::GlobalContext;
+use move_core_types::{account_address::AccountAddress, ident_str, language_storage::ModuleId};
+use parking_lot::Mutex;
+use std::{
+    collections::HashSet,
+    str::FromStr,
+    sync::{Arc, Barrier},
+    thread,
+};
+
+#[test]
+fn test_same_executable_id() {
+    let ctx = GlobalContext::with_num_execution_workers(1);
+    let guard = ctx.try_execution_context(0).unwrap();
+
+    let module_id = ModuleId::new(AccountAddress::ONE, ident_str!("foo").to_owned());
+
+    let id1 = guard.intern_module_id(&module_id);
+    let id2 = guard.intern_address_name(&module_id.address, &module_id.name);
+
+    assert!(id1 == id2);
+    assert_eq!(id1.address(), id2.address());
+    assert_eq!(id1.name(), id2.name());
+}
+
+#[test]
+fn test_different_executable_ids() {
+    let ctx = GlobalContext::with_num_execution_workers(1);
+    let guard = ctx.try_execution_context(0).unwrap();
+
+    let module_id1 = ModuleId::new(AccountAddress::ONE, ident_str!("foo").to_owned());
+    let module_id2 = ModuleId::new(AccountAddress::ONE, ident_str!("bar").to_owned());
+
+    let id1 = guard.intern_module_id(&module_id1);
+    let id2 = guard.intern_module_id(&module_id2);
+
+    assert!(id1 != id2);
+    assert_ne!(id1.name(), id2.name());
+
+    let id3 = guard.intern_address_name(&AccountAddress::ZERO, ident_str!("bar"));
+    assert!(id1 != id3 && id2 != id3);
+    assert_ne!(id1.name(), id3.name());
+    assert_ne!(id2.address(), id3.address());
+}
+
+#[test]
+fn test_concurrent_same_executable_ids() {
+    let num_threads = 4;
+
+    let ctx = Arc::new(GlobalContext::with_num_execution_workers(num_threads));
+    let barrier = Arc::new(Barrier::new(num_threads));
+    let module_id = Arc::new(ModuleId::new(
+        AccountAddress::ONE,
+        ident_str!("foo").to_owned(),
+    ));
+
+    let addresses = Arc::new(Mutex::new(HashSet::new()));
+    let handles = (0..num_threads)
+        .map(|tid| {
+            let ctx = Arc::clone(&ctx);
+            let barrier = Arc::clone(&barrier);
+            let module_id = Arc::clone(&module_id);
+            let addresses = Arc::clone(&addresses);
+
+            thread::spawn(move || {
+                let execution_ctx = ctx.try_execution_context(tid).unwrap();
+
+                barrier.wait();
+                let id = execution_ctx.intern_module_id(&module_id);
+                assert_eq!(id.address(), &module_id.address);
+                assert_eq!(id.name(), module_id.name.as_str());
+                addresses.lock().insert(id.raw_address_for_testing());
+            })
+        })
+        .collect::<Vec<_>>();
+
+    for handle in handles {
+        handle.join().unwrap();
+    }
+    let addresses = Arc::into_inner(addresses).unwrap().into_inner();
+    assert_eq!(addresses.len(), 1);
+}
+
+#[test]
+fn test_concurrent_different_executable_ids() {
+    let num_threads = 4;
+
+    let ctx = Arc::new(GlobalContext::with_num_execution_workers(num_threads));
+    let barrier = Arc::new(Barrier::new(num_threads));
+    let addresses = Arc::new(Mutex::new(HashSet::new()));
+
+    let handles: Vec<_> = (0..num_threads)
+        .map(|tid| {
+            let ctx = Arc::clone(&ctx);
+            let barrier = Arc::clone(&barrier);
+            let addresses = Arc::clone(&addresses);
+
+            thread::spawn(move || {
+                let execution_ctx = ctx.try_execution_context(tid).unwrap();
+
+                barrier.wait();
+
+                let addr = AccountAddress::from_str(&format!("0x{}", tid)).unwrap();
+                let id = execution_ctx.intern_address_name(&addr, ident_str!("foo"));
+                assert_eq!(id.address(), &addr);
+                assert_eq!(id.name(), "foo");
+                addresses.lock().insert(id.raw_address_for_testing());
+            })
+        })
+        .collect();
+
+    for handle in handles {
+        handle.join().unwrap();
+    }
+    let addresses = Arc::into_inner(addresses).unwrap().into_inner();
+    assert_eq!(addresses.len(), num_threads);
+}

--- a/third_party/move/mono-move/global-context/tests/identifiers_tests.rs
+++ b/third_party/move/mono-move/global-context/tests/identifiers_tests.rs
@@ -1,0 +1,105 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Tests for interning of Move identifiers.
+
+use mono_move_global_context::GlobalContext;
+use move_core_types::{ident_str, identifier::Identifier};
+use parking_lot::Mutex;
+use std::{
+    collections::HashSet,
+    sync::{Arc, Barrier},
+    thread,
+};
+
+#[test]
+fn test_same_identifiers() {
+    let ctx = GlobalContext::with_num_execution_workers(1);
+    let guard = ctx.try_execution_context(0).unwrap();
+
+    let name1 = guard.intern_identifier(ident_str!("transfer"));
+    let name2 = guard.intern_identifier(ident_str!("transfer"));
+
+    assert!(name1 == name2);
+    assert_eq!(name1.as_str(), name2.as_str());
+}
+
+#[test]
+fn test_different_identifiers() {
+    let ctx = GlobalContext::with_num_execution_workers(1);
+    let guard = ctx.try_execution_context(0).unwrap();
+
+    let name1 = guard.intern_identifier(ident_str!("transfer"));
+    let name2 = guard.intern_identifier(ident_str!("coin"));
+
+    assert!(name1 != name2);
+    assert_ne!(name1.as_str(), name2.as_str());
+}
+
+#[test]
+fn test_concurrent_same_identifiers() {
+    let num_threads = 4;
+
+    let ctx = Arc::new(GlobalContext::with_num_execution_workers(num_threads));
+    let barrier = Arc::new(Barrier::new(num_threads));
+    let name = Arc::new(ident_str!("foo").to_owned());
+
+    let addresses = Arc::new(Mutex::new(HashSet::new()));
+    let handles = (0..num_threads)
+        .map(|tid| {
+            let ctx = Arc::clone(&ctx);
+            let barrier = Arc::clone(&barrier);
+            let name = Arc::clone(&name);
+            let addresses = Arc::clone(&addresses);
+
+            thread::spawn(move || {
+                let execution_ctx = ctx.try_execution_context(tid).unwrap();
+
+                barrier.wait();
+                let str = execution_ctx.intern_identifier(&name);
+                assert_eq!(str.as_str(), name.as_str());
+                addresses.lock().insert(str.raw_address_for_testing());
+            })
+        })
+        .collect::<Vec<_>>();
+
+    for handle in handles {
+        handle.join().unwrap();
+    }
+    let addresses = Arc::into_inner(addresses).unwrap().into_inner();
+    assert_eq!(addresses.len(), 1);
+}
+
+#[test]
+fn test_concurrent_different_identifiers() {
+    let num_threads = 4;
+
+    let ctx = Arc::new(GlobalContext::with_num_execution_workers(num_threads));
+    let barrier = Arc::new(Barrier::new(num_threads));
+    let addresses = Arc::new(Mutex::new(HashSet::new()));
+
+    let handles: Vec<_> = (0..num_threads)
+        .map(|tid| {
+            let ctx = Arc::clone(&ctx);
+            let barrier = Arc::clone(&barrier);
+            let addresses = Arc::clone(&addresses);
+
+            thread::spawn(move || {
+                let execution_ctx = ctx.try_execution_context(tid).unwrap();
+
+                barrier.wait();
+
+                let name = Identifier::new(format!("name_{}", tid)).unwrap();
+                let str = execution_ctx.intern_identifier(&name);
+                assert_eq!(str.as_str(), name.as_str());
+                addresses.lock().insert(str.raw_address_for_testing());
+            })
+        })
+        .collect();
+
+    for handle in handles {
+        handle.join().unwrap();
+    }
+    let addresses = Arc::into_inner(addresses).unwrap().into_inner();
+    assert_eq!(addresses.len(), num_threads);
+}


### PR DESCRIPTION
## Description

Builds the identifier interning layer for the global execution context, on top of the arena and guard infrastructure from the previous PRs.

**`..Ref<'a>` abstraction.** All public guard APIs return `..Ref<'a, T>` — a lifetime-scoped wrapper around raw arena pointer(s). The `'a` lifetime is tied to the `ExecutionGuard`, so the borrow checker statically prevents any use of an arena allocation after the guard is dropped. `..Ref` uses pointer-based `Hash`/`PartialEq`, making it suitable as a cache key without dereferencing. It is also trivially copyable. Currently added `NameRef` and `ExecutableIdRef` for string identifiers (function or struct names) and executable IDs.

**`DashMap` interners.** A concurrent interner backed by `DashMap` that deduplicates arena allocations by structural equality. `...InternerKey(..)` wraps a `GlobalArenaPtr` and implements structural hash/equality by dereferencing it. Dereferencing is safe as long as arena has not been reset while interner's pointers are kept alive. The safety invariant is only enforced via exhaustive destructor in maintenance phase during reset. It is responsibility of the implementation to clear the cache though.

## How Has This Been Tested?

- `cargo test -p mono-move-global-context` — existing arena and context tests pass.
- New tests were added for arena reset + interning of identifiers and executable IDs.

## Key Areas to Review

All.

## Type of Change
- [x] New feature

## Which Components or Systems Does This Change Impact?
- [x] Move/Aptos Virtual Machine

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new concurrent interning caches backed by arena pointers plus maintenance-time cache/arena reset, involving `unsafe` pointer/lifetime handling and lock-free race windows that could lead to subtle correctness or memory issues if invariants are violated.
> 
> **Overview**
> Adds `DashMap`-backed interners to `mono-move-global-context` for Move identifiers and module/executable IDs, allocating canonicalized values in the per-worker global arena and returning lifetime-scoped `ArenaRef<'guard, T>` handles (pointer-based `Hash`/`Eq`) from `ExecutionGuard` APIs.
> 
> Extends the maintenance phase with cache statistics and a `reset_arena_pool` flow that first clears all interner caches and then unsafely resets all arenas (`reset_all_arenas_unchecked`), and updates tests to cover interning correctness, concurrency behavior, and reset invalidation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f472126515b33b816d57b30ff6334bc868683e47. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->