### PR TITLE
fix(rust-sdk): prevent integer overflow in `expiration_timestamp_secs`

### DIFF
--- a/crates/aptos-rest-client/src/lib.rs
+++ b/crates/aptos-rest-client/src/lib.rs
@@ -826,7 +826,7 @@ impl Client {
 
             if let Some(max_server_lag_wait_duration) = max_server_lag_wait {
                 if aptos_infallible::duration_since_epoch().as_secs()
-                    > expiration_timestamp_secs + max_server_lag_wait_duration.as_secs()
+                    > expiration_timestamp_secs.saturating_add(max_server_lag_wait_duration.as_secs())
                 {
                     return Err(anyhow!(
                         "Ledger on endpoint ({}) is more than {}s behind current time, timing out waiting for the transaction. Warning, transaction ({}) might still succeed.",


### PR DESCRIPTION
### Problem
When submitting a transaction using the Rust SDK with an `expiration_timestamp_secs` of `u64::MAX`, `Client::wait_for_transaction_by_hash_inner` panics due to an integer overflow when adding the maximum server lag wait duration:
`attempt to add with overflow`

Fixes #10440 

### Solution
Use `saturating_add` instead of standard addition when checking the expiration timestamp combined with the max server lag wait duration. This ensures the client gracefully waits out the period without panicking and crashing the thread.

_AI Disclosure: This PR was generated autonomously by anzzyspeaksgit._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small arithmetic change in timeout checking that only affects an edge case (near-`u64::MAX` expirations) and makes the client more robust against panics.
> 
> **Overview**
> Prevents an integer overflow panic in `Client::wait_for_transaction_by_hash_inner` by changing the server-lag timeout comparison to use `expiration_timestamp_secs.saturating_add(max_server_lag_wait_duration.as_secs())` instead of normal addition.
> 
> Behavior is otherwise unchanged, but extreme expiration timestamps no longer crash the SDK thread during the lag/timeout check.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c4f7b2fe33e48ba971d65689a6d3ea9e9271f1b1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->