### PR TITLE
[mono-move] Type representation and interning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12628,8 +12628,12 @@ dependencies = [
  "bumpalo",
  "crossbeam-utils",
  "dashmap 7.0.0-rc2",
+ "fxhash",
+ "move-binary-format",
  "move-core-types",
  "parking_lot 0.12.1",
+ "proptest",
+ "proptest-derive",
 ]
 
 [[package]]

--- a/plans/quirky-drifting-papert.md
+++ b/plans/quirky-drifting-papert.md
@@ -1,0 +1,1 @@
+placeholder

--- a/third_party/move/mono-move/global-context/Cargo.toml
+++ b/third_party/move/mono-move/global-context/Cargo.toml
@@ -15,6 +15,13 @@ rust-version = { workspace = true }
 ahash = { workspace = true }
 bumpalo = { workspace = true }
 dashmap = { workspace = true }
+fxhash = { workspace = true }
 crossbeam-utils = { workspace = true }
+move-binary-format = { workspace = true }
 move-core-types = { workspace = true }
 parking_lot = { workspace = true }
+
+[dev-dependencies]
+move-core-types = { workspace = true, features = ["fuzzing"] }
+proptest = { workspace = true }
+proptest-derive = { workspace = true }

--- a/third_party/move/mono-move/global-context/src/context.rs
+++ b/third_party/move/mono-move/global-context/src/context.rs
@@ -38,18 +38,29 @@ mod identifiers;
 pub use identifiers::ExecutableId;
 use std::hash::{Hash, Hasher};
 mod interner;
-
-use crate::{
+mod types;
+pub(crate) use crate::{
     alloc::{GlobalArenaPtr, GlobalArenaShard},
-    context::interner::DashMapInterner,
+    context::{
+        interner::DashMapInterner,
+        types::{
+            ADDRESS, BOOL, I128, I16, I256, I32, I64, I8, SIGNER, U128, U16, U256, U32, U64, U8,
+        },
+    },
     maintenance_config::MaintenanceConfig,
     GlobalArenaPool,
 };
+use dashmap::{DashMap, Entry};
+use fxhash::FxBuildHasher;
+use move_binary_format::{access::ModuleAccess, file_format::SignatureToken, CompiledModule};
 use move_core_types::{
-    account_address::AccountAddress, identifier::IdentStr, language_storage::ModuleId,
+    account_address::AccountAddress,
+    identifier::IdentStr,
+    language_storage::{FunctionParamOrReturnTag, ModuleId, TypeTag},
 };
 use parking_lot::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 use std::marker::PhantomData;
+pub use types::Type;
 
 /// Global execution context with a two-phase state machine.
 ///
@@ -84,6 +95,27 @@ pub struct GlobalContext {
 struct Context {
     identifiers: DashMapInterner<str>,
     executable_ids: DashMapInterner<ExecutableId>,
+    types: DashMapInterner<Type>,
+    type_lists: DashMapInterner<[GlobalArenaPtr<Type>]>,
+    /// Cache for type substitution. Maps (generic type, type argument list)
+    /// to its canonical fully-instantiated type. Both keys use interned
+    /// pointers, so the lookup is O(1) after the first computation.
+    type_subst_cache: DashMap<
+        (GlobalArenaPtr<Type>, GlobalArenaPtr<[GlobalArenaPtr<Type>]>),
+        GlobalArenaPtr<Type>,
+        FxBuildHasher,
+    >,
+    /// Cache for type list substitution. Maps (input list ptr, ty_args ptr)
+    /// to the result list ptr. Result equals input when no element changed,
+    /// so callers detect no-change via pointer identity.
+    type_list_subst_cache: DashMap<
+        (
+            GlobalArenaPtr<[GlobalArenaPtr<Type>]>,
+            GlobalArenaPtr<[GlobalArenaPtr<Type>]>,
+        ),
+        GlobalArenaPtr<[GlobalArenaPtr<Type>]>,
+        FxBuildHasher,
+    >,
 }
 
 /// RAII guard for the maintenance phase providing exclusive write access.
@@ -162,6 +194,74 @@ impl<'a, T: ?Sized> Clone for Ref<'a, T> {
     }
 }
 
+/// Scoped reference to a list of data returned by public [`ExecutionGuard`]
+/// APIs. The lifetime enforces compile-time guarantee that the execution guard
+/// is alive when holding the reference, similar to [`Ref`].
+pub struct ListRef<'a, T> {
+    ptr: GlobalArenaPtr<[GlobalArenaPtr<T>]>,
+    _guard: PhantomData<&'a ()>,
+}
+
+impl<'a, T> Hash for ListRef<'a, T> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.ptr.hash(state)
+    }
+}
+
+impl<'a, T> PartialEq for ListRef<'a, T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.ptr == other.ptr
+    }
+}
+
+impl<'a, T> Eq for ListRef<'a, T> {}
+
+impl<'a, T> Copy for ListRef<'a, T> {}
+
+impl<'a, T> Clone for ListRef<'a, T> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<'a, T: 'a> ListRef<'a, T> {
+    fn as_slice(&self) -> &'a [GlobalArenaPtr<T>] {
+        // SAFETY:
+        //
+        // We already hold the reference to the list, so it guarantees that the
+        // execution guard is alive, and the arena has not been reset. This
+        // implies that the pointer is still valid.
+        unsafe { self.ptr.as_ref_unchecked() }
+    }
+
+    /// Returns the number of elements in the list.
+    pub fn len(&self) -> usize {
+        self.as_slice().len()
+    }
+
+    /// Returns true if the list contains no elements.
+    pub fn is_empty(&self) -> bool {
+        self.as_slice().is_empty()
+    }
+
+    /// Returns a reference to the element at the specified index, or [`None`]
+    /// if out of bounds.
+    pub fn get(&self, idx: usize) -> Option<Ref<'a, T>> {
+        self.as_slice().get(idx).map(|ptr| Ref {
+            ptr: *ptr,
+            _guard: PhantomData,
+        })
+    }
+
+    /// Returns an iterator over the elements in the list.
+    pub fn iter(&self) -> impl Iterator<Item = Ref<'a, T>> + 'a {
+        self.as_slice().iter().map(|ptr| Ref {
+            ptr: *ptr,
+            _guard: PhantomData,
+        })
+    }
+}
+
 impl GlobalContext {
     /// Creates a new global context with the specified number of workers that
     /// can acquire [`ExecutionGuard`] and default maintenance config.
@@ -198,6 +298,10 @@ impl GlobalContext {
             ctx: Context {
                 identifiers: DashMapInterner::default(),
                 executable_ids: DashMapInterner::default(),
+                types: DashMapInterner::default(),
+                type_lists: DashMapInterner::default(),
+                type_subst_cache: DashMap::with_hasher(FxBuildHasher::default()),
+                type_list_subst_cache: DashMap::with_hasher(FxBuildHasher::default()),
             },
             global_arena: GlobalArenaPool::with_num_arenas(num_workers),
             maintenance_config,
@@ -249,7 +353,9 @@ impl GlobalContext {
 
 impl<'a> MaintenanceGuard<'a> {
     /// Returns the total number of bytes used across all arenas in the global
-    /// arena pool.
+    /// arena pool. Note that resetting the arena does not mean that this
+    /// number goes to zero - while data is cleared the allocation can still
+    /// be kept alive.
     pub fn global_arena_allocated_bytes_sum(&self) -> usize {
         (0..self.global_arena.num_arenas())
             .map(|idx| self.global_arena.allocated_bytes(idx))
@@ -264,6 +370,16 @@ impl<'a> MaintenanceGuard<'a> {
     /// Returns the number of entries in interner's map for executable IDs.
     pub fn interned_executable_ids_count(&self) -> usize {
         self.ctx.executable_ids.len()
+    }
+
+    /// Returns the number of entries in the types interner.
+    pub fn interned_types_count(&self) -> usize {
+        self.ctx.types.len()
+    }
+
+    /// Returns the number of entries in the type lists interner.
+    pub fn interned_type_lists_count(&self) -> usize {
+        self.ctx.type_lists.len()
     }
 
     /// Resets all caches that store pointers to the arenas, and then resets
@@ -371,6 +487,479 @@ impl<'a> ExecutionGuard<'a> {
             _guard,
         }
     }
+
+    /// Interns a list of [`TypeTag`]s and returns a reference to it. The
+    /// reference is valid for the lifetime of the [`ExecutionGuard`].
+    pub fn intern_type_tags<'b>(&'b self, tags: &[TypeTag]) -> ListRef<'b, Type>
+    where
+        'a: 'b,
+    {
+        if let Some(ptr) = self.ctx.type_lists.get(tags) {
+            return ListRef {
+                ptr,
+                _guard: PhantomData,
+            };
+        }
+
+        let types = tags
+            .iter()
+            .map(|tag| {
+                let Ref { ptr, .. } = self.intern_type_tag(tag);
+                ptr
+            })
+            .collect::<Vec<_>>();
+        let ptr = self.global_arena.alloc_slice_copy(&types);
+        ListRef {
+            ptr: unsafe { self.ctx.type_lists.insert(ptr) },
+            _guard: PhantomData,
+        }
+    }
+
+    /// Interns a [`TypeTag`] and returns a reference to it. The reference is
+    /// valid for the lifetime of the [`ExecutionGuard`].
+    pub fn intern_type_tag<'b>(&'b self, type_tag: &TypeTag) -> Ref<'b, Type>
+    where
+        'a: 'b,
+    {
+        match type_tag {
+            TypeTag::Bool => return static_type_ref(&BOOL),
+            TypeTag::U8 => return static_type_ref(&U8),
+            TypeTag::U16 => return static_type_ref(&U16),
+            TypeTag::U32 => return static_type_ref(&U32),
+            TypeTag::U64 => return static_type_ref(&U64),
+            TypeTag::U128 => return static_type_ref(&U128),
+            TypeTag::U256 => return static_type_ref(&U256),
+            TypeTag::I8 => return static_type_ref(&I8),
+            TypeTag::I16 => return static_type_ref(&I16),
+            TypeTag::I32 => return static_type_ref(&I32),
+            TypeTag::I64 => return static_type_ref(&I64),
+            TypeTag::I128 => return static_type_ref(&I128),
+            TypeTag::I256 => return static_type_ref(&I256),
+            TypeTag::Address => return static_type_ref(&ADDRESS),
+            TypeTag::Signer => return static_type_ref(&SIGNER),
+            // Composites types; handle below.
+            TypeTag::Vector(_) | TypeTag::Struct(_) | TypeTag::Function(_) => {},
+        }
+
+        if let Some(ptr) = self.ctx.types.get(type_tag) {
+            return Ref {
+                ptr,
+                _guard: PhantomData,
+            };
+        }
+
+        let Ref { ptr, _guard } = match type_tag {
+            TypeTag::Vector(elem_tag) => {
+                let elem_type = self.intern_type_tag(elem_tag.as_ref());
+                self.alloc_vector_type(elem_type)
+            },
+
+            TypeTag::Struct(struct_tag) => {
+                let executable_id =
+                    self.intern_address_name(&struct_tag.address, &struct_tag.module);
+                let name = self.intern_identifier(&struct_tag.name);
+                let type_args = self.intern_type_tags(&struct_tag.type_args);
+                self.alloc_struct_type(executable_id, name, type_args)
+            },
+
+            TypeTag::Function(function_tag) => {
+                let args = self.intern_function_param_or_return_tags(function_tag.args.as_ref());
+                let results =
+                    self.intern_function_param_or_return_tags(function_tag.results.as_ref());
+                self.alloc_function_type(args, results, function_tag.abilities)
+            },
+
+            // TODO: exhaustive match
+            _ => unreachable!("Primitives are already handled"),
+        };
+
+        Ref {
+            ptr: unsafe { self.ctx.types.insert(ptr) },
+            _guard,
+        }
+    }
+
+    /// Interns a slice of [`SignatureToken`]s and returns a scoped list
+    /// reference valid for the lifetime of the [`ExecutionGuard`].
+    pub fn intern_signature_tokens<'b>(
+        &'b self,
+        tokens: &[SignatureToken],
+        module: &CompiledModule,
+    ) -> ListRef<'b, Type>
+    where
+        'a: 'b,
+    {
+        if let Some(ptr) = self.ctx.type_lists.get(&(tokens, module)) {
+            return ListRef {
+                ptr,
+                _guard: PhantomData,
+            };
+        }
+
+        let types = tokens
+            .iter()
+            .map(|token| {
+                let Ref { ptr, .. } = self.intern_signature_token(token, module);
+                ptr
+            })
+            .collect::<Vec<_>>();
+        let ptr = self.global_arena.alloc_slice_copy(&types);
+        ListRef {
+            ptr: unsafe { self.ctx.type_lists.insert(ptr) },
+            _guard: PhantomData,
+        }
+    }
+
+    /// Interns a single [`SignatureToken`] and returns a scoped reference
+    /// valid for the lifetime of the [`ExecutionGuard`].
+    pub fn intern_signature_token<'b>(
+        &'b self,
+        token: &SignatureToken,
+        module: &CompiledModule,
+    ) -> Ref<'b, Type>
+    where
+        'a: 'b,
+    {
+        match token {
+            SignatureToken::Bool => return static_type_ref(&BOOL),
+            SignatureToken::U8 => return static_type_ref(&U8),
+            SignatureToken::U16 => return static_type_ref(&U16),
+            SignatureToken::U32 => return static_type_ref(&U32),
+            SignatureToken::U64 => return static_type_ref(&U64),
+            SignatureToken::U128 => return static_type_ref(&U128),
+            SignatureToken::U256 => return static_type_ref(&U256),
+            SignatureToken::I8 => return static_type_ref(&I8),
+            SignatureToken::I16 => return static_type_ref(&I16),
+            SignatureToken::I32 => return static_type_ref(&I32),
+            SignatureToken::I64 => return static_type_ref(&I64),
+            SignatureToken::I128 => return static_type_ref(&I128),
+            SignatureToken::I256 => return static_type_ref(&I256),
+            SignatureToken::Address => return static_type_ref(&ADDRESS),
+            SignatureToken::Signer => return static_type_ref(&SIGNER),
+            // Composites types; handle below.
+            // TODO; exhaustive match
+            _ => {},
+        }
+
+        if let Some(ptr) = self.ctx.types.get(&(token, module)) {
+            return Ref {
+                ptr,
+                _guard: PhantomData,
+            };
+        }
+
+        let Ref { ptr, _guard } = match token {
+            SignatureToken::Vector(tok) => {
+                let elem_type = self.intern_signature_token(tok.as_ref(), module);
+                self.alloc_vector_type(elem_type)
+            },
+
+            SignatureToken::Reference(tok) => {
+                let inner = self.intern_signature_token(tok.as_ref(), module);
+                self.alloc_ref_type(inner)
+            },
+
+            SignatureToken::MutableReference(tok) => {
+                let inner = self.intern_signature_token(tok.as_ref(), module);
+                self.alloc_ref_mut_type(inner)
+            },
+
+            SignatureToken::Struct(idx) => {
+                let struct_handle = module.struct_handle_at(*idx);
+                let module_handle = module.module_handle_at(struct_handle.module);
+
+                let module_addr = module.address_identifier_at(module_handle.address);
+                let module_name = module.identifier_at(module_handle.name);
+                let executable_id = self.intern_address_name(module_addr, module_name);
+                let name = self.intern_identifier(module.identifier_at(struct_handle.name));
+                let type_args = self.intern_signature_tokens(&[], module);
+
+                self.alloc_struct_type(executable_id, name, type_args)
+            },
+
+            SignatureToken::StructInstantiation(idx, type_args) => {
+                let struct_handle = module.struct_handle_at(*idx);
+                let module_handle = module.module_handle_at(struct_handle.module);
+
+                let module_addr = module.address_identifier_at(module_handle.address);
+                let module_name = module.identifier_at(module_handle.name);
+                let executable_id = self.intern_address_name(module_addr, module_name);
+                let name = self.intern_identifier(module.identifier_at(struct_handle.name));
+                let type_args = self.intern_signature_tokens(type_args, module);
+
+                self.alloc_struct_type(executable_id, name, type_args)
+            },
+
+            SignatureToken::Function(args, results, abilities) => {
+                let args = self.intern_signature_tokens(args, module);
+                let results = self.intern_signature_tokens(results, module);
+                self.alloc_function_type(args, results, *abilities)
+            },
+
+            SignatureToken::TypeParameter(idx) => Ref {
+                ptr: self.global_arena.alloc(Type::TypeParam(*idx)),
+                _guard: PhantomData,
+            },
+
+            // TODO: exhaustive match
+            _ => unreachable!("Primitives are already handled"),
+        };
+
+        Ref {
+            ptr: unsafe { self.ctx.types.insert(ptr) },
+            _guard,
+        }
+    }
+
+    /// Substitutes type parameters in each element of `tys`. Returns `tys`
+    /// unchanged when no element changed, or a new interned list otherwise.
+    /// Callers detect no-change via pointer identity (`result.ptr == tys.ptr`).
+    ///
+    /// Caches the result under `(tys.ptr, ty_args.ptr)` so repeated calls for
+    /// the same (list, ty_args) pair — common when many struct/function types
+    /// share the same interned type_args list — are O(1).
+    ///
+    /// Uses a two-phase approach to avoid any heap allocation on the unchanged
+    /// path and any extra branching in the build phase:
+    ///   Phase 1 — scan without allocating until the first changed element.
+    ///   Phase 2 — build the output Vec starting from the first change; all
+    ///             remaining elements are pushed directly with no Option
+    ///             overhead.
+    fn substitute_type_list<'b>(
+        &'b self,
+        tys: ListRef<'b, Type>,
+        ty_args: ListRef<'b, Type>,
+    ) -> ListRef<'b, Type>
+    where
+        'a: 'b,
+    {
+        if let Some(cached) = self.ctx.type_list_subst_cache.get(&(tys.ptr, ty_args.ptr)) {
+            return ListRef {
+                ptr: *cached.value(),
+                _guard: PhantomData,
+            };
+        }
+
+        // Phase 1: scan without allocating until the first changed element.
+        let result_ptr = 'scan: {
+            let mut iter = tys.iter().enumerate();
+            let (first_idx, first_new) = loop {
+                let Some((i, ty)) = iter.next() else {
+                    // No element changed.
+                    break 'scan tys.ptr;
+                };
+                let new_ty = self.substitute_type(ty, ty_args);
+                if new_ty != ty {
+                    break (i, new_ty);
+                }
+            };
+
+            // Phase 2: at least one element changed — build a new list.
+            let mut new_tys = Vec::with_capacity(tys.len());
+            new_tys.extend_from_slice(&tys.as_slice()[..first_idx]);
+            let Ref { ptr, .. } = first_new;
+            new_tys.push(ptr);
+            for (_, ty) in iter {
+                let Ref { ptr, .. } = self.substitute_type(ty, ty_args);
+                new_tys.push(ptr);
+            }
+
+            let new_tys = self.global_arena.alloc_slice_copy(&new_tys);
+            unsafe { self.ctx.type_lists.insert(new_tys) }
+        };
+
+        match self.ctx.type_list_subst_cache.entry((tys.ptr, ty_args.ptr)) {
+            Entry::Occupied(e) => {
+                assert!(*e.get() == result_ptr);
+            },
+            Entry::Vacant(e) => {
+                assert!(*e.insert(result_ptr) == result_ptr);
+            },
+        };
+
+        ListRef {
+            ptr: result_ptr,
+            _guard: PhantomData,
+        }
+    }
+
+    /// Substitutes type parameters in a type, returning a canonicalized type
+    /// pointer. For internal usage only.
+    pub fn substitute_type<'b>(
+        &'b self,
+        ty: Ref<'b, Type>,
+        ty_args: ListRef<'b, Type>,
+    ) -> Ref<'b, Type>
+    where
+        'a: 'b,
+    {
+        let Ref { ptr, _guard } = ty;
+        let original_ptr = ptr;
+        let ty_ref = unsafe { ptr.as_ref_unchecked() };
+        match ty_ref {
+            Type::Bool
+            | Type::U8
+            | Type::U16
+            | Type::U32
+            | Type::U64
+            | Type::U128
+            | Type::U256
+            | Type::I8
+            | Type::I16
+            | Type::I32
+            | Type::I64
+            | Type::I128
+            | Type::I256
+            | Type::Address
+            | Type::Signer => {
+                // Fast path: primitives have no type parameters.
+                return ty;
+            },
+
+            // Substitution: replace type parameter with the concrete type.
+            Type::TypeParam(idx) => {
+                let ty_args_ref = unsafe { ty_args.ptr.as_ref_unchecked() };
+                return Ref {
+                    ptr: ty_args_ref[*idx as usize],
+                    _guard,
+                };
+            },
+            Type::Struct { type_args, .. } => {
+                let type_args = unsafe { type_args.as_ref_unchecked() };
+                if type_args.is_empty() {
+                    // Non-generic struct, return.
+                    return ty;
+                }
+            },
+            Type::Vector(_) | Type::Ref(_) | Type::RefMut(_) | Type::Function { .. } => {
+                // Handle composite types below.
+            },
+        }
+
+        if let Some(cached) = self.ctx.type_subst_cache.get(&(ptr, ty_args.ptr)) {
+            return Ref {
+                ptr: *cached.value(),
+                _guard,
+            };
+        }
+
+        let Ref { ptr, _guard } = match ty_ref {
+            Type::Vector(inner_ty) => {
+                let new_inner = self.substitute_type(
+                    Ref {
+                        ptr: *inner_ty,
+                        _guard,
+                    },
+                    ty_args,
+                );
+                if new_inner.ptr == *inner_ty {
+                    return ty;
+                }
+                self.alloc_vector_type(new_inner)
+            },
+
+            Type::Ref(inner_ty) => {
+                let new_inner = self.substitute_type(
+                    Ref {
+                        ptr: *inner_ty,
+                        _guard,
+                    },
+                    ty_args,
+                );
+                if new_inner.ptr == *inner_ty {
+                    return ty;
+                }
+                self.alloc_ref_type(new_inner)
+            },
+
+            Type::RefMut(inner_ty) => {
+                let new_inner = self.substitute_type(
+                    Ref {
+                        ptr: *inner_ty,
+                        _guard,
+                    },
+                    ty_args,
+                );
+                if new_inner.ptr == *inner_ty {
+                    return ty;
+                }
+                self.alloc_ref_mut_type(new_inner)
+            },
+
+            Type::Struct {
+                executable_id,
+                name,
+                type_args: generic_type_args,
+            } => {
+                let new_type_args = self.substitute_type_list(
+                    ListRef {
+                        ptr: *generic_type_args,
+                        _guard,
+                    },
+                    ty_args,
+                );
+                if new_type_args.ptr == *generic_type_args {
+                    return ty;
+                }
+                self.alloc_struct_type(
+                    Ref {
+                        ptr: *executable_id,
+                        _guard,
+                    },
+                    Ref { ptr: *name, _guard },
+                    new_type_args,
+                )
+            },
+
+            Type::Function {
+                args,
+                results,
+                abilities,
+            } => {
+                let new_args = self.substitute_type_list(ListRef { ptr: *args, _guard }, ty_args);
+                let new_results = self.substitute_type_list(
+                    ListRef {
+                        ptr: *results,
+                        _guard,
+                    },
+                    ty_args,
+                );
+                if new_args.ptr == *args && new_results.ptr == *results {
+                    return ty;
+                }
+
+                self.alloc_function_type(new_args, new_results, *abilities)
+            },
+            Type::Bool
+            | Type::U8
+            | Type::U16
+            | Type::U32
+            | Type::U64
+            | Type::U128
+            | Type::U256
+            | Type::I8
+            | Type::I16
+            | Type::I32
+            | Type::I64
+            | Type::I128
+            | Type::I256
+            | Type::Address
+            | Type::Signer
+            | Type::TypeParam(_) => unreachable!("Must be already handled above"),
+        };
+
+        // Re-canonicalize. This can allocate more memory.
+        let ptr = unsafe { self.ctx.types.insert(ptr) };
+        match self.ctx.type_subst_cache.entry((original_ptr, ty_args.ptr)) {
+            Entry::Occupied(e) => {
+                assert!(*e.get() == ptr);
+            },
+            Entry::Vacant(e) => {
+                assert!(*e.insert(ptr) == ptr);
+            },
+        };
+        Ref { ptr, _guard }
+    }
 }
 
 //
@@ -394,11 +983,78 @@ impl<'a> MaintenanceGuard<'a> {
         let Context {
             identifiers,
             executable_ids,
+            types,
+            type_lists,
+            type_subst_cache,
+            type_list_subst_cache,
         } = self.ctx;
 
+        type_list_subst_cache.clear();
+        type_subst_cache.clear();
+        type_lists.reset();
+        types.reset();
         executable_ids.reset();
         identifiers.reset();
     }
 }
 
-impl<'a> ExecutionGuard<'a> {}
+impl<'a> ExecutionGuard<'a> {
+    /// Interns a slice of function argument or return type tags. For internal use only.
+    fn intern_function_param_or_return_tags<'b>(
+        &'b self,
+        tags: &[FunctionParamOrReturnTag],
+    ) -> ListRef<'b, Type>
+    where
+        'a: 'b,
+    {
+        if let Some(ptr) = self.ctx.type_lists.get(tags) {
+            return ListRef {
+                ptr,
+                _guard: PhantomData,
+            };
+        }
+
+        let types = tags
+            .iter()
+            .map(|arg| match arg {
+                FunctionParamOrReturnTag::Reference(tag) => {
+                    if let Some(ptr) = self.ctx.types.get(arg) {
+                        ptr
+                    } else {
+                        let inner = self.intern_type_tag(tag);
+                        let Ref { ptr, .. } = self.alloc_ref_type(inner);
+                        unsafe { self.ctx.types.insert(ptr) }
+                    }
+                },
+                FunctionParamOrReturnTag::MutableReference(tag) => {
+                    if let Some(ptr) = self.ctx.types.get(arg) {
+                        ptr
+                    } else {
+                        let inner = self.intern_type_tag(tag);
+                        let Ref { ptr, .. } = self.alloc_ref_mut_type(inner);
+                        unsafe { self.ctx.types.insert(ptr) }
+                    }
+                },
+                FunctionParamOrReturnTag::Value(tag) => {
+                    let Ref { ptr, .. } = self.intern_type_tag(tag);
+                    ptr
+                },
+            })
+            .collect::<Vec<_>>();
+        let ptr = self.global_arena.alloc_slice_copy(&types);
+        ListRef {
+            ptr: unsafe { self.ctx.type_lists.insert(ptr) },
+            _guard: PhantomData,
+        }
+    }
+}
+
+/// Returns a [`Ref`] backed by a `'static` [`Type`] value. Used for the 15
+/// primitive types that are interned as program-lifetime statics.
+#[inline]
+fn static_type_ref(ty: &'static Type) -> Ref<'static, Type> {
+    Ref {
+        ptr: GlobalArenaPtr::from_static(ty),
+        _guard: PhantomData,
+    }
+}

--- a/third_party/move/mono-move/global-context/src/context/identifiers.rs
+++ b/third_party/move/mono-move/global-context/src/context/identifiers.rs
@@ -6,10 +6,10 @@
 //!
 //! # Safety model
 //!
-//! All arena allocations produced here are wrapped in [`Ref<'a, T>`], which
-//! ties the validity of the underlying pointer to the [`ExecutionGuard`]'s
-//! lifetime. The borrow checker therefore prevents any use of an allocation
-//! after the guard is dropped, without requiring any runtime checks.
+//! All arena allocations produced here are wrapped in [`Ref`], which ties the
+//! validity of the underlying pointer to the [`ExecutionGuard`]'s lifetime.
+//! The borrow checker therefore prevents any use of an allocation after the
+//! guard is dropped, without requiring any runtime checks.
 
 use super::Ref;
 use crate::{alloc::GlobalArenaPtr, ExecutionGuard};
@@ -32,7 +32,7 @@ impl<'a> Ref<'a, str> {
 ///
 /// Only [`ExecutionGuard::alloc_executable_id`] can create [`ExecutableId`].
 /// No external code can construct or inspect fields directly; access goes
-/// through [`Ref<'a, ExecutableId>`].
+/// through [`Ref`].
 pub struct ExecutableId {
     pub(super) address: AccountAddress,
     pub(super) name: GlobalArenaPtr<str>,

--- a/third_party/move/mono-move/global-context/src/context/interner.rs
+++ b/third_party/move/mono-move/global-context/src/context/interner.rs
@@ -18,9 +18,18 @@
 //!
 //! There is no way to cleanly enforce this relationship.
 
-use crate::{alloc::GlobalArenaPtr, ExecutableId};
+use crate::{alloc::GlobalArenaPtr, context::types::Type, ExecutableId};
 use dashmap::{DashMap, Entry, Equivalent};
-use move_core_types::{account_address::AccountAddress, identifier::IdentStr};
+use move_binary_format::{
+    access::ModuleAccess,
+    file_format::{SignatureToken, StructHandleIndex},
+    CompiledModule,
+};
+use move_core_types::{
+    account_address::AccountAddress,
+    identifier::IdentStr,
+    language_storage::{FunctionParamOrReturnTag, TypeTag},
+};
 use std::hash::{Hash, Hasher};
 
 /// **Internal** key representation used by interner. Wraps interned data
@@ -37,7 +46,7 @@ struct LookupKey<'a, T: ?Sized>(&'a T);
 
 /// Interner based on [`DashMap`]. Stores global arena-allocated pointers,
 /// deduplicating them based on structural hash and equality.
-pub(super) struct DashMapInterner<T: ?Sized> {
+pub(crate) struct DashMapInterner<T: ?Sized> {
     // Note: using ahash for fast yet DoS resistant lookups because structural
     // hash is used here.
     inner: DashMap<InternerKey<T>, GlobalArenaPtr<T>, ahash::RandomState>,
@@ -198,5 +207,680 @@ impl Equivalent<InternerKey<ExecutableId>> for LookupKey<'_, (&AccountAddress, &
             let other_id = other.0.as_ref_unchecked();
             self.0 .0 == &other_id.address && self.0 .1.as_str() == other_id.name.as_ref_unchecked()
         }
+    }
+}
+
+/// Canonical discriminants for cross-format hashing. This ensures that **ALL**
+/// keys hash to the same value.
+mod type_discriminant {
+    pub(super) const BOOL: u8 = 0;
+    pub(super) const U8: u8 = 1;
+    pub(super) const U16: u8 = 2;
+    pub(super) const U32: u8 = 3;
+    pub(super) const U64: u8 = 4;
+    pub(super) const U128: u8 = 5;
+    pub(super) const U256: u8 = 6;
+    pub(super) const I8: u8 = 7;
+    pub(super) const I16: u8 = 8;
+    pub(super) const I32: u8 = 9;
+    pub(super) const I64: u8 = 10;
+    pub(super) const I128: u8 = 11;
+    pub(super) const I256: u8 = 12;
+    pub(super) const ADDRESS: u8 = 13;
+    pub(super) const SIGNER: u8 = 14;
+    pub(super) const VECTOR: u8 = 15;
+    pub(super) const STRUCT: u8 = 16;
+    pub(super) const REFERENCE: u8 = 17;
+    pub(super) const REFERENCE_MUT: u8 = 18;
+    pub(super) const FUNCTION: u8 = 19;
+    pub(super) const TYPE_PARAM: u8 = 20;
+}
+
+fn hash_function_param_or_return_tag<H: Hasher>(tag: &FunctionParamOrReturnTag, state: &mut H) {
+    match tag {
+        FunctionParamOrReturnTag::Reference(tag) => {
+            type_discriminant::REFERENCE.hash(state);
+            LookupKey(tag).hash(state);
+        },
+        FunctionParamOrReturnTag::MutableReference(tag) => {
+            type_discriminant::REFERENCE_MUT.hash(state);
+            LookupKey(tag).hash(state);
+        },
+        FunctionParamOrReturnTag::Value(tag) => {
+            LookupKey(tag).hash(state);
+        },
+    }
+}
+
+fn hash_struct_signature_token<H: Hasher>(
+    idx: &StructHandleIndex,
+    type_args: &[SignatureToken],
+    module: &CompiledModule,
+    state: &mut H,
+) {
+    type_discriminant::STRUCT.hash(state);
+
+    let struct_handle = module.struct_handle_at(*idx);
+    let module_handle = module.module_handle_at(struct_handle.module);
+
+    module
+        .address_identifier_at(module_handle.address)
+        .hash(state);
+    module
+        .identifier_at(module_handle.name)
+        .as_str()
+        .hash(state);
+    module
+        .identifier_at(struct_handle.name)
+        .as_str()
+        .hash(state);
+
+    type_args.len().hash(state);
+    for arg in type_args {
+        LookupKey(&(arg, module)).hash(state);
+    }
+}
+
+impl Hash for LookupKey<'_, TypeTag> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        match self.0 {
+            TypeTag::Bool => type_discriminant::BOOL.hash(state),
+            TypeTag::U8 => type_discriminant::U8.hash(state),
+            TypeTag::U16 => type_discriminant::U16.hash(state),
+            TypeTag::U32 => type_discriminant::U32.hash(state),
+            TypeTag::U64 => type_discriminant::U64.hash(state),
+            TypeTag::U128 => type_discriminant::U128.hash(state),
+            TypeTag::U256 => type_discriminant::U256.hash(state),
+            TypeTag::I8 => type_discriminant::I8.hash(state),
+            TypeTag::I16 => type_discriminant::I16.hash(state),
+            TypeTag::I32 => type_discriminant::I32.hash(state),
+            TypeTag::I64 => type_discriminant::I64.hash(state),
+            TypeTag::I128 => type_discriminant::I128.hash(state),
+            TypeTag::I256 => type_discriminant::I256.hash(state),
+            TypeTag::Address => type_discriminant::ADDRESS.hash(state),
+            TypeTag::Signer => type_discriminant::SIGNER.hash(state),
+
+            TypeTag::Vector(inner) => {
+                type_discriminant::VECTOR.hash(state);
+                Self(inner.as_ref()).hash(state);
+            },
+
+            TypeTag::Struct(struct_tag) => {
+                type_discriminant::STRUCT.hash(state);
+                struct_tag.address.hash(state);
+                struct_tag.module.as_str().hash(state);
+                struct_tag.name.as_str().hash(state);
+                struct_tag.type_args.len().hash(state);
+                for type_arg in &struct_tag.type_args {
+                    Self(type_arg).hash(state);
+                }
+            },
+
+            TypeTag::Function(function_tag) => {
+                type_discriminant::FUNCTION.hash(state);
+                function_tag.args.len().hash(state);
+                for arg in &function_tag.args {
+                    hash_function_param_or_return_tag(arg, state);
+                }
+                function_tag.results.len().hash(state);
+                for result in &function_tag.results {
+                    hash_function_param_or_return_tag(result, state);
+                }
+                function_tag.abilities.hash(state);
+            },
+        }
+    }
+}
+
+impl Hash for LookupKey<'_, (&SignatureToken, &CompiledModule)> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        match self.0 .0 {
+            SignatureToken::Bool => type_discriminant::BOOL.hash(state),
+            SignatureToken::U8 => type_discriminant::U8.hash(state),
+            SignatureToken::U16 => type_discriminant::U16.hash(state),
+            SignatureToken::U32 => type_discriminant::U32.hash(state),
+            SignatureToken::U64 => type_discriminant::U64.hash(state),
+            SignatureToken::U128 => type_discriminant::U128.hash(state),
+            SignatureToken::U256 => type_discriminant::U256.hash(state),
+            SignatureToken::I8 => type_discriminant::I8.hash(state),
+            SignatureToken::I16 => type_discriminant::I16.hash(state),
+            SignatureToken::I32 => type_discriminant::I32.hash(state),
+            SignatureToken::I64 => type_discriminant::I64.hash(state),
+            SignatureToken::I128 => type_discriminant::I128.hash(state),
+            SignatureToken::I256 => type_discriminant::I256.hash(state),
+            SignatureToken::Address => type_discriminant::ADDRESS.hash(state),
+            SignatureToken::Signer => type_discriminant::SIGNER.hash(state),
+
+            SignatureToken::Vector(tok) => {
+                type_discriminant::VECTOR.hash(state);
+                LookupKey(&(tok.as_ref(), self.0 .1)).hash(state);
+            },
+
+            SignatureToken::Reference(tok) => {
+                type_discriminant::REFERENCE.hash(state);
+                LookupKey(&(tok.as_ref(), self.0 .1)).hash(state);
+            },
+
+            SignatureToken::MutableReference(tok) => {
+                type_discriminant::REFERENCE_MUT.hash(state);
+                LookupKey(&(tok.as_ref(), self.0 .1)).hash(state);
+            },
+
+            SignatureToken::Struct(idx) => {
+                hash_struct_signature_token(idx, &[], self.0 .1, state);
+            },
+            SignatureToken::StructInstantiation(idx, type_args) => {
+                hash_struct_signature_token(idx, type_args, self.0 .1, state);
+            },
+
+            SignatureToken::Function(args, results, abilities) => {
+                type_discriminant::FUNCTION.hash(state);
+                args.len().hash(state);
+                for arg in args {
+                    LookupKey(&(arg, self.0 .1)).hash(state);
+                }
+                results.len().hash(state);
+                for result in results {
+                    LookupKey(&(result, self.0 .1)).hash(state);
+                }
+                abilities.hash(state);
+            },
+
+            SignatureToken::TypeParameter(idx) => {
+                type_discriminant::TYPE_PARAM.hash(state);
+                idx.hash(state);
+            },
+        }
+    }
+}
+
+impl Hash for InternerKey<Type> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        // SAFETY: Only reachable through DashMapInterner, which requires
+        // ExecutionContextScope.
+        match unsafe { self.0.as_ref_unchecked() } {
+            Type::Bool => type_discriminant::BOOL.hash(state),
+            Type::U8 => type_discriminant::U8.hash(state),
+            Type::U16 => type_discriminant::U16.hash(state),
+            Type::U32 => type_discriminant::U32.hash(state),
+            Type::U64 => type_discriminant::U64.hash(state),
+            Type::U128 => type_discriminant::U128.hash(state),
+            Type::U256 => type_discriminant::U256.hash(state),
+            Type::I8 => type_discriminant::I8.hash(state),
+            Type::I16 => type_discriminant::I16.hash(state),
+            Type::I32 => type_discriminant::I32.hash(state),
+            Type::I64 => type_discriminant::I64.hash(state),
+            Type::I128 => type_discriminant::I128.hash(state),
+            Type::I256 => type_discriminant::I256.hash(state),
+            Type::Address => type_discriminant::ADDRESS.hash(state),
+            Type::Signer => type_discriminant::SIGNER.hash(state),
+
+            Type::Vector(ty) => {
+                type_discriminant::VECTOR.hash(state);
+                Self(*ty).hash(state);
+            },
+
+            Type::Ref(ty) => {
+                type_discriminant::REFERENCE.hash(state);
+                Self(*ty).hash(state);
+            },
+
+            Type::RefMut(ty) => {
+                type_discriminant::REFERENCE_MUT.hash(state);
+                Self(*ty).hash(state);
+            },
+
+            Type::Struct {
+                executable_id,
+                name,
+                type_args,
+            } => {
+                type_discriminant::STRUCT.hash(state);
+
+                // SAFETY:
+                //
+                // User of interner **must** enforce the safety precondition.
+                unsafe {
+                    let id = executable_id.as_ref_unchecked();
+                    id.address.hash(state);
+                    id.name.as_ref_unchecked().hash(state);
+                    name.as_ref_unchecked().hash(state);
+                };
+                InternerKey(*type_args).hash(state);
+            },
+
+            Type::Function {
+                args,
+                results,
+                abilities,
+            } => {
+                type_discriminant::FUNCTION.hash(state);
+                InternerKey(*args).hash(state);
+                InternerKey(*results).hash(state);
+                abilities.hash(state);
+            },
+
+            Type::TypeParam(idx) => {
+                type_discriminant::TYPE_PARAM.hash(state);
+                idx.hash(state);
+            },
+        }
+    }
+}
+
+impl Hash for LookupKey<'_, [TypeTag]> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.0.len().hash(state);
+        for tag in self.0 {
+            LookupKey(tag).hash(state);
+        }
+    }
+}
+
+impl Hash for LookupKey<'_, (&[SignatureToken], &CompiledModule)> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.0 .0.len().hash(state);
+        for token in self.0 .0 {
+            LookupKey(&(token, self.0 .1)).hash(state);
+        }
+    }
+}
+
+impl Hash for InternerKey<[GlobalArenaPtr<Type>]> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        // SAFETY:
+        //
+        // User of interner **must** enforce the safety precondition.
+        let types = unsafe { self.0.as_ref_unchecked() };
+        types.len().hash(state);
+        for ty in types {
+            InternerKey(*ty).hash(state);
+        }
+    }
+}
+
+impl PartialEq for InternerKey<Type> {
+    fn eq(&self, other: &Self) -> bool {
+        // SAFETY:
+        //
+        // User of interner **must** enforce the safety precondition.
+        let this = unsafe { self.0.as_ref_unchecked() };
+        let other = unsafe { other.0.as_ref_unchecked() };
+
+        match (this, other) {
+            (Type::Bool, Type::Bool)
+            | (Type::U8, Type::U8)
+            | (Type::U16, Type::U16)
+            | (Type::U32, Type::U32)
+            | (Type::U64, Type::U64)
+            | (Type::U128, Type::U128)
+            | (Type::U256, Type::U256)
+            | (Type::I8, Type::I8)
+            | (Type::I16, Type::I16)
+            | (Type::I32, Type::I32)
+            | (Type::I64, Type::I64)
+            | (Type::I128, Type::I128)
+            | (Type::I256, Type::I256)
+            | (Type::Address, Type::Address)
+            | (Type::Signer, Type::Signer) => true,
+
+            (Type::Vector(ty), Type::Vector(other_ty))
+            | (Type::Ref(ty), Type::Ref(other_ty))
+            | (Type::RefMut(ty), Type::RefMut(other_ty)) => Self(*ty) == Self(*other_ty),
+
+            (
+                Type::Struct {
+                    executable_id,
+                    name,
+                    type_args,
+                },
+                Type::Struct {
+                    executable_id: other_executable_id,
+                    name: other_name,
+                    type_args: other_type_args,
+                },
+            ) => {
+                executable_id == other_executable_id
+                    && name == other_name
+                    && InternerKey(*type_args) == InternerKey(*other_type_args)
+            },
+
+            (
+                Type::Function {
+                    args,
+                    results,
+                    abilities,
+                },
+                Type::Function {
+                    args: other_args,
+                    results: other_results,
+                    abilities: other_abilities,
+                },
+            ) => {
+                InternerKey(*args) == InternerKey(*other_args)
+                    && InternerKey(*results) == InternerKey(*other_results)
+                    && abilities == other_abilities
+            },
+
+            (Type::TypeParam(a), Type::TypeParam(b)) => a == b,
+
+            _ => false,
+        }
+    }
+}
+
+impl Eq for InternerKey<Type> {}
+
+impl PartialEq for InternerKey<[GlobalArenaPtr<Type>]> {
+    fn eq(&self, other: &Self) -> bool {
+        // SAFETY:
+        //
+        // User of interner **must** enforce the safety precondition.
+        let types = unsafe { self.0.as_ref_unchecked() };
+        let other_types = unsafe { other.0.as_ref_unchecked() };
+
+        if types.len() != other_types.len() {
+            return false;
+        }
+
+        types
+            .iter()
+            .zip(other_types.iter())
+            .all(|(ty, other_ty)| InternerKey(*ty) == InternerKey(*other_ty))
+    }
+}
+
+impl Eq for InternerKey<[GlobalArenaPtr<Type>]> {}
+
+fn function_param_or_return_tag_eq_type(
+    tag: &FunctionParamOrReturnTag,
+    ty: &GlobalArenaPtr<Type>,
+) -> bool {
+    match tag {
+        FunctionParamOrReturnTag::Reference(inner_tag) => {
+            // SAFETY:
+            //
+            // User of interner **must** enforce the safety precondition.
+            if let Type::Ref(ty) = unsafe { ty.as_ref_unchecked() } {
+                LookupKey(inner_tag).equivalent(&InternerKey(*ty))
+            } else {
+                false
+            }
+        },
+        FunctionParamOrReturnTag::MutableReference(inner_tag) => {
+            // SAFETY:
+            //
+            // User of interner **must** enforce the safety precondition.
+            if let Type::RefMut(ty) = unsafe { ty.as_ref_unchecked() } {
+                LookupKey(inner_tag).equivalent(&InternerKey(*ty))
+            } else {
+                false
+            }
+        },
+        FunctionParamOrReturnTag::Value(inner_tag) => {
+            LookupKey(inner_tag).equivalent(&InternerKey(*ty))
+        },
+    }
+}
+
+impl Hash for LookupKey<'_, FunctionParamOrReturnTag> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        hash_function_param_or_return_tag(self.0, state);
+    }
+}
+
+impl Equivalent<InternerKey<Type>> for LookupKey<'_, FunctionParamOrReturnTag> {
+    fn equivalent(&self, key: &InternerKey<Type>) -> bool {
+        function_param_or_return_tag_eq_type(self.0, &key.0)
+    }
+}
+
+impl Hash for LookupKey<'_, [FunctionParamOrReturnTag]> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.0.len().hash(state);
+        for tag in self.0 {
+            hash_function_param_or_return_tag(tag, state);
+        }
+    }
+}
+
+impl Equivalent<InternerKey<[GlobalArenaPtr<Type>]>> for LookupKey<'_, [FunctionParamOrReturnTag]> {
+    fn equivalent(&self, key: &InternerKey<[GlobalArenaPtr<Type>]>) -> bool {
+        // SAFETY:
+        //
+        // User of interner **must** enforce the safety precondition.
+        let types = unsafe { key.0.as_ref_unchecked() };
+        if self.0.len() != types.len() {
+            return false;
+        }
+        self.0
+            .iter()
+            .zip(types.iter())
+            .all(|(tag, ty)| function_param_or_return_tag_eq_type(tag, ty))
+    }
+}
+
+impl Equivalent<InternerKey<Type>> for LookupKey<'_, TypeTag> {
+    fn equivalent(&self, key: &InternerKey<Type>) -> bool {
+        // SAFETY:
+        //
+        // User of interner **must** enforce the safety precondition.
+        let other = unsafe { key.0.as_ref_unchecked() };
+
+        match (self.0, other) {
+            (TypeTag::Bool, Type::Bool)
+            | (TypeTag::U8, Type::U8)
+            | (TypeTag::U16, Type::U16)
+            | (TypeTag::U32, Type::U32)
+            | (TypeTag::U64, Type::U64)
+            | (TypeTag::U128, Type::U128)
+            | (TypeTag::U256, Type::U256)
+            | (TypeTag::I8, Type::I8)
+            | (TypeTag::I16, Type::I16)
+            | (TypeTag::I32, Type::I32)
+            | (TypeTag::I64, Type::I64)
+            | (TypeTag::I128, Type::I128)
+            | (TypeTag::I256, Type::I256)
+            | (TypeTag::Address, Type::Address)
+            | (TypeTag::Signer, Type::Signer) => true,
+
+            (TypeTag::Vector(tag), Type::Vector(ty)) => {
+                LookupKey(tag.as_ref()).equivalent(&InternerKey(*ty))
+            },
+
+            (
+                TypeTag::Struct(struct_tag),
+                Type::Struct {
+                    executable_id,
+                    name,
+                    type_args,
+                },
+            ) => {
+                // SAFETY:
+                //
+                // User of interner **must** enforce the safety precondition.
+                unsafe {
+                    let id = executable_id.as_ref_unchecked();
+                    id.address == struct_tag.address
+                        && id.name.as_ref_unchecked() == struct_tag.module.as_str()
+                        && name.as_ref_unchecked() == struct_tag.name.as_str()
+                        && LookupKey(struct_tag.type_args.as_slice())
+                            .equivalent(&InternerKey(*type_args))
+                }
+            },
+
+            (
+                TypeTag::Function(function_tag),
+                Type::Function {
+                    args,
+                    results,
+                    abilities,
+                },
+            ) => {
+                if &function_tag.abilities != abilities {
+                    return false;
+                }
+
+                // SAFETY:
+                //
+                // User of interner **must** enforce the safety precondition.
+                let args_list = unsafe { args.as_ref_unchecked() };
+                let results_list = unsafe { results.as_ref_unchecked() };
+
+                if function_tag.args.len() != args_list.len()
+                    || function_tag.results.len() != results_list.len()
+                {
+                    return false;
+                }
+
+                function_tag
+                    .args
+                    .iter()
+                    .zip(args_list.iter())
+                    .chain(function_tag.results.iter().zip(results_list.iter()))
+                    .all(|(tag, ty)| function_param_or_return_tag_eq_type(tag, ty))
+            },
+
+            _ => false,
+        }
+    }
+}
+
+impl Equivalent<InternerKey<Type>> for LookupKey<'_, (&SignatureToken, &CompiledModule)> {
+    fn equivalent(&self, key: &InternerKey<Type>) -> bool {
+        // SAFETY:
+        //
+        // User of interner **must** enforce the safety precondition.
+        let other = unsafe { key.0.as_ref_unchecked() };
+
+        match (self.0 .0, other) {
+            (SignatureToken::Bool, Type::Bool)
+            | (SignatureToken::U8, Type::U8)
+            | (SignatureToken::U16, Type::U16)
+            | (SignatureToken::U32, Type::U32)
+            | (SignatureToken::U64, Type::U64)
+            | (SignatureToken::U128, Type::U128)
+            | (SignatureToken::U256, Type::U256)
+            | (SignatureToken::I8, Type::I8)
+            | (SignatureToken::I16, Type::I16)
+            | (SignatureToken::I32, Type::I32)
+            | (SignatureToken::I64, Type::I64)
+            | (SignatureToken::I128, Type::I128)
+            | (SignatureToken::I256, Type::I256)
+            | (SignatureToken::Address, Type::Address)
+            | (SignatureToken::Signer, Type::Signer) => true,
+
+            (SignatureToken::Vector(tok), Type::Vector(ty))
+            | (SignatureToken::Reference(tok), Type::Ref(ty))
+            | (SignatureToken::MutableReference(tok), Type::RefMut(ty)) => {
+                LookupKey(&(tok.as_ref(), self.0 .1)).equivalent(&InternerKey(*ty))
+            },
+
+            (
+                SignatureToken::Struct(idx),
+                Type::Struct {
+                    executable_id,
+                    name,
+                    type_args,
+                },
+            ) => {
+                let struct_handle = self.0 .1.struct_handle_at(*idx);
+                let module_handle = self.0 .1.module_handle_at(struct_handle.module);
+
+                // SAFETY:
+                //
+                // User of interner **must** enforce the safety precondition.
+                unsafe {
+                    let id = executable_id.as_ref_unchecked();
+                    &id.address == self.0 .1.address_identifier_at(module_handle.address)
+                        && id.name.as_ref_unchecked()
+                            == self.0 .1.identifier_at(module_handle.name).as_str()
+                        && name.as_ref_unchecked()
+                            == self.0 .1.identifier_at(struct_handle.name).as_str()
+                        && type_args.as_ref_unchecked().is_empty()
+                }
+            },
+
+            (
+                SignatureToken::StructInstantiation(idx, tokens),
+                Type::Struct {
+                    executable_id,
+                    name,
+                    type_args,
+                },
+            ) => {
+                let struct_handle = self.0 .1.struct_handle_at(*idx);
+                let module_handle = self.0 .1.module_handle_at(struct_handle.module);
+
+                // SAFETY:
+                //
+                // User of interner **must** enforce the safety precondition.
+                unsafe {
+                    let id = executable_id.as_ref_unchecked();
+                    &id.address == self.0 .1.address_identifier_at(module_handle.address)
+                        && id.name.as_ref_unchecked()
+                            == self.0 .1.identifier_at(module_handle.name).as_str()
+                        && name.as_ref_unchecked()
+                            == self.0 .1.identifier_at(struct_handle.name).as_str()
+                        && LookupKey(&(tokens.as_slice(), self.0 .1))
+                            .equivalent(&InternerKey(*type_args))
+                }
+            },
+
+            (
+                SignatureToken::Function(tok_args, tok_results, tok_abilities),
+                Type::Function {
+                    args,
+                    results,
+                    abilities,
+                },
+            ) => {
+                LookupKey(&(tok_args.as_slice(), self.0 .1)).equivalent(&InternerKey(*args))
+                    && LookupKey(&(tok_results.as_slice(), self.0 .1))
+                        .equivalent(&InternerKey(*results))
+                    && tok_abilities == abilities
+            },
+
+            (SignatureToken::TypeParameter(idx), Type::TypeParam(n)) => idx == n,
+
+            _ => false,
+        }
+    }
+}
+
+impl Equivalent<InternerKey<[GlobalArenaPtr<Type>]>> for LookupKey<'_, [TypeTag]> {
+    fn equivalent(&self, key: &InternerKey<[GlobalArenaPtr<Type>]>) -> bool {
+        // SAFETY:
+        //
+        // User of interner **must** enforce the safety precondition.
+        let types = unsafe { key.0.as_ref_unchecked() };
+        if self.0.len() != types.len() {
+            return false;
+        }
+
+        self.0
+            .iter()
+            .zip(types.iter())
+            .all(|(tag, ty)| LookupKey(tag).equivalent(&InternerKey(*ty)))
+    }
+}
+
+impl Equivalent<InternerKey<[GlobalArenaPtr<Type>]>>
+    for LookupKey<'_, (&[SignatureToken], &CompiledModule)>
+{
+    fn equivalent(&self, key: &InternerKey<[GlobalArenaPtr<Type>]>) -> bool {
+        // SAFETY:
+        //
+        // User of interner **must** enforce the safety precondition.
+        let types = unsafe { key.0.as_ref_unchecked() };
+        if self.0 .0.len() != types.len() {
+            return false;
+        }
+
+        self.0
+             .0
+            .iter()
+            .zip(types.iter())
+            .all(|(tok, ty)| LookupKey(&(tok, self.0 .1)).equivalent(&InternerKey(*ty)))
     }
 }

--- a/third_party/move/mono-move/global-context/src/context/types.rs
+++ b/third_party/move/mono-move/global-context/src/context/types.rs
@@ -1,0 +1,223 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Type definitions for the global execution context.
+
+use crate::{alloc::GlobalArenaPtr, context::ListRef, ExecutableId, ExecutionGuard, Ref};
+use move_core_types::ability::AbilitySet;
+
+/// Runtime type representation.
+///
+/// # Invariant
+///
+/// While [`Type`] is a public enum (for convenience), it is only ever exposed
+/// in public APIs through [`Ref`] or [`ListRef`]. These references are scoped
+/// to the lifetime of the [`ExecutionGuard`] and are safe to use while holding
+/// the execution guard. Only allocation methods in this submodule can create
+/// reference to types and pointing to the global arena.
+pub enum Type {
+    Bool,
+    U8,
+    U16,
+    U32,
+    U64,
+    U128,
+    U256,
+    I8,
+    I16,
+    I32,
+    I64,
+    I128,
+    I256,
+    Address,
+    Signer,
+    Vector(GlobalArenaPtr<Type>),
+    Ref(GlobalArenaPtr<Type>),
+    RefMut(GlobalArenaPtr<Type>),
+    Struct {
+        // TODO:
+        //   Currently, we have 3 pointers here which bloat the size of the
+        //   enum (in addition to function value below). If this is ever a
+        //   problem, we can consider moving some pieces into their own
+        //   allocations, for example, defining a pointer for struct definition
+        //   (executable ID plus name). For now, this design suffices to get
+        //   things running.
+        /// Executable ID (address and name).
+        executable_id: GlobalArenaPtr<ExecutableId>,
+        /// Struct name.
+        name: GlobalArenaPtr<str>,
+        /// Type arguments.
+        type_args: GlobalArenaPtr<[GlobalArenaPtr<Type>]>,
+    },
+    Function {
+        /// Argument types.
+        args: GlobalArenaPtr<[GlobalArenaPtr<Type>]>,
+        /// Return types.
+        results: GlobalArenaPtr<[GlobalArenaPtr<Type>]>,
+        /// Abilities of the function.
+        abilities: AbilitySet,
+    },
+    /// A type parameter. Substituted at monomorphization time and the type is
+    /// **re-canonicalized**.
+    TypeParam(u16),
+}
+
+//
+// Only private APIs below.
+// ------------------------
+
+impl<'a> ExecutionGuard<'a> {
+    /// Allocates a vector of the specified type in the arena, returning a
+    /// reference to it with the same lifetime as [`ExecutionGuard`]'s. This is
+    /// **the only** way to create a vector [`Ref`].
+    pub(super) fn alloc_vector_type<'b>(&'b self, elem_type: Ref<'b, Type>) -> Ref<'b, Type>
+    where
+        'a: 'b,
+    {
+        // SAFETY: Extracting the raw pointer here is safe because the returned
+        // ID pointer is immediately re-wrapped under the same guards lifetime.
+        let Ref {
+            ptr: elem_type,
+            _guard,
+        } = elem_type;
+        Ref {
+            ptr: self.global_arena.alloc(Type::Vector(elem_type)),
+            _guard,
+        }
+    }
+
+    /// Allocates a reference type in the arena, returning a reference to the
+    /// allocated data with the same lifetime as [`ExecutionGuard`]'s. This is
+    /// **the only** way to create a such a [`Ref`].
+    pub(super) fn alloc_ref_type<'b>(&'b self, elem_type: Ref<'b, Type>) -> Ref<'b, Type>
+    where
+        'a: 'b,
+    {
+        // SAFETY: Extracting the raw pointer here is safe because the returned
+        // pointer is immediately re-wrapped under the same guards lifetime.
+        let Ref {
+            ptr: elem_type,
+            _guard,
+        } = elem_type;
+        Ref {
+            ptr: self.global_arena.alloc(Type::Ref(elem_type)),
+            _guard,
+        }
+    }
+
+    /// Allocates a mutable reference type in the arena, returning a reference
+    /// to the allocated data with the same lifetime as [`ExecutionGuard`]'s.
+    /// This is **the only** way to create a such a [`Ref`].
+    pub(super) fn alloc_ref_mut_type<'b>(&'b self, elem_type: Ref<'b, Type>) -> Ref<'b, Type>
+    where
+        'a: 'b,
+    {
+        // SAFETY: Extracting the raw pointer here is safe because the returned
+        // pointer is immediately re-wrapped under the same guards lifetime.
+        let Ref {
+            ptr: elem_type,
+            _guard,
+        } = elem_type;
+        Ref {
+            ptr: self.global_arena.alloc(Type::RefMut(elem_type)),
+            _guard,
+        }
+    }
+
+    pub(super) fn alloc_struct_type<'b>(
+        &'b self,
+        executable_id: Ref<'b, ExecutableId>,
+        name: Ref<'b, str>,
+        type_args: ListRef<'b, Type>,
+    ) -> Ref<'b, Type>
+    where
+        'a: 'b,
+    {
+        // SAFETY: Extracting raw pointers here is safe because the returned
+        // pointers are immediately re-wrapped under the same guards lifetime.
+        let Ref {
+            ptr: executable_id,
+            _guard,
+        } = executable_id;
+        let Ref { ptr: name, .. } = name;
+        let ListRef { ptr: type_args, .. } = type_args;
+
+        Ref {
+            ptr: self.global_arena.alloc(Type::Struct {
+                executable_id,
+                name,
+                type_args,
+            }),
+            _guard,
+        }
+    }
+
+    pub(super) fn alloc_function_type<'b>(
+        &'b self,
+        args: ListRef<'b, Type>,
+        results: ListRef<'b, Type>,
+        abilities: AbilitySet,
+    ) -> Ref<'b, Type>
+    where
+        'a: 'b,
+    {
+        // SAFETY: Extracting raw pointers here is safe because the returned
+        // pointers are immediately re-wrapped under the same guards lifetime.
+        let ListRef { ptr: args, _guard } = args;
+        let ListRef { ptr: results, .. } = results;
+
+        Ref {
+            ptr: self.global_arena.alloc(Type::Function {
+                args,
+                results,
+                abilities,
+            }),
+            _guard,
+        }
+    }
+}
+
+/// Static allocation for boolean type.
+pub(crate) static BOOL: Type = Type::Bool;
+
+/// Static allocation for u8 type.
+pub(crate) static U8: Type = Type::U8;
+
+/// Static allocation for u16 type.
+pub(crate) static U16: Type = Type::U16;
+
+/// Static allocation for u32 type.
+pub(crate) static U32: Type = Type::U32;
+
+/// Static allocation for u64 type.
+pub(crate) static U64: Type = Type::U64;
+
+/// Static allocation for u128 type.
+pub(crate) static U128: Type = Type::U128;
+
+/// Static allocation for u256 type.
+pub(crate) static U256: Type = Type::U256;
+
+/// Static allocation for i8 type.
+pub(crate) static I8: Type = Type::I8;
+
+/// Static allocation for i16 type.
+pub(crate) static I16: Type = Type::I16;
+
+/// Static allocation for i32 type.
+pub(crate) static I32: Type = Type::I32;
+
+/// Static allocation for i64 type.
+pub(crate) static I64: Type = Type::I64;
+
+/// Static allocation for i128 type.
+pub(crate) static I128: Type = Type::I128;
+
+/// Static allocation for i256 type.
+pub(crate) static I256: Type = Type::I256;
+
+/// Static allocation for address type.
+pub(crate) static ADDRESS: Type = Type::Address;
+
+/// Static allocation for signer type.
+pub(crate) static SIGNER: Type = Type::Signer;

--- a/third_party/move/mono-move/global-context/src/lib.rs
+++ b/third_party/move/mono-move/global-context/src/lib.rs
@@ -4,5 +4,7 @@
 mod alloc;
 pub use alloc::GlobalArenaPool;
 mod context;
-pub use context::{ExecutableId, ExecutionGuard, GlobalContext, MaintenanceGuard, Ref};
+pub use context::{
+    ExecutableId, ExecutionGuard, GlobalContext, ListRef, MaintenanceGuard, Ref, Type,
+};
 pub mod maintenance_config;

--- a/third_party/move/mono-move/global-context/tests/concurrent_types_tests.rs
+++ b/third_party/move/mono-move/global-context/tests/concurrent_types_tests.rs
@@ -1,0 +1,300 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Stress tests verifying correctness of type interning under concurrent load.
+//!
+//! Multiple worker threads race to intern the same or different types and the
+//! invariants (pointer equality for same types, distinct pointers for distinct
+//! types, stable counts) must all hold.
+//!
+//! All tests use a [`Barrier`] to synchronise workers so they start interning
+//! simultaneously, maximising the chance of exposing races.
+
+use mono_move_global_context::GlobalContext;
+use move_core_types::{
+    ability::AbilitySet,
+    account_address::AccountAddress,
+    identifier::Identifier,
+    language_storage::{FunctionParamOrReturnTag, FunctionTag, StructTag, TypeTag},
+};
+use std::{
+    sync::{Arc, Barrier, Mutex},
+    thread,
+};
+
+/// All workers intern the same `Vector(U64)` → single deduplicated entry.
+#[test]
+fn test_concurrent_same_type_tag_deduped() {
+    let num_workers = 4;
+    let ctx = Arc::new(GlobalContext::with_num_execution_workers(num_workers));
+    let barrier = Arc::new(Barrier::new(num_workers));
+    let addrs: Arc<Mutex<Vec<usize>>> = Arc::new(Mutex::new(Vec::new()));
+
+    let handles: Vec<_> = (0..num_workers)
+        .map(|worker_id| {
+            let ctx: Arc<GlobalContext> = Arc::clone(&ctx);
+            let barrier = Arc::clone(&barrier);
+            let addrs = Arc::clone(&addrs);
+            thread::spawn(move || {
+                let guard = ctx.execution_context(worker_id).unwrap();
+                barrier.wait();
+                let r = guard.intern_type_tag(&TypeTag::Vector(Box::new(TypeTag::U64)));
+                addrs.lock().unwrap().push(r.as_raw_ptr() as usize);
+            })
+        })
+        .collect();
+
+    for handle in handles {
+        handle.join().unwrap();
+    }
+
+    let addrs = addrs.lock().unwrap();
+    assert!(
+        addrs.windows(2).all(|w| w[0] == w[1]),
+        "Concurrent interning of the same type produced different pointers"
+    );
+
+    let maintenance = ctx.maintenance_context().unwrap();
+    assert_eq!(maintenance.interned_types_count(), 1);
+}
+
+/// Worker _i_ interns a distinct `Vector(Uᵢ)` → all pointers distinct; count = N.
+#[test]
+fn test_concurrent_distinct_type_tags() {
+    let num_workers = 8;
+    let tags = [
+        TypeTag::Vector(Box::new(TypeTag::Bool)),
+        TypeTag::Vector(Box::new(TypeTag::U8)),
+        TypeTag::Vector(Box::new(TypeTag::U16)),
+        TypeTag::Vector(Box::new(TypeTag::U32)),
+        TypeTag::Vector(Box::new(TypeTag::U64)),
+        TypeTag::Vector(Box::new(TypeTag::U128)),
+        TypeTag::Vector(Box::new(TypeTag::U256)),
+        TypeTag::Vector(Box::new(TypeTag::Address)),
+    ];
+
+    let ctx = Arc::new(GlobalContext::with_num_execution_workers(num_workers));
+    let barrier = Arc::new(Barrier::new(num_workers));
+    let addrs: Arc<Mutex<Vec<usize>>> = Arc::new(Mutex::new(Vec::new()));
+
+    let handles: Vec<_> = (0..num_workers)
+        .map(|worker_id| {
+            let ctx: Arc<GlobalContext> = Arc::clone(&ctx);
+            let barrier = Arc::clone(&barrier);
+            let addrs = Arc::clone(&addrs);
+            let tag = tags[worker_id].clone();
+            thread::spawn(move || {
+                let guard = ctx.execution_context(worker_id).unwrap();
+                barrier.wait();
+                let r = guard.intern_type_tag(&tag);
+                addrs.lock().unwrap().push(r.as_raw_ptr() as usize);
+            })
+        })
+        .collect();
+
+    for handle in handles {
+        handle.join().unwrap();
+    }
+
+    let addrs = addrs.lock().unwrap();
+    for i in 0..num_workers {
+        for j in (i + 1)..num_workers {
+            assert_ne!(
+                addrs[i], addrs[j],
+                "Workers {i} and {j} produced the same pointer for distinct types"
+            );
+        }
+    }
+
+    let maintenance = ctx.maintenance_context().unwrap();
+    assert_eq!(maintenance.interned_types_count(), num_workers);
+}
+
+/// All workers call `intern_type_tags([U64, Bool])` concurrently → single
+/// deduplicated list entry.
+#[test]
+fn test_concurrent_same_type_list_deduped() {
+    let num_workers = 4;
+    let ctx = Arc::new(GlobalContext::with_num_execution_workers(num_workers));
+    let barrier = Arc::new(Barrier::new(num_workers));
+
+    let handles: Vec<_> = (0..num_workers)
+        .map(|worker_id| {
+            let ctx: Arc<GlobalContext> = Arc::clone(&ctx);
+            let barrier = Arc::clone(&barrier);
+            thread::spawn(move || {
+                let guard = ctx.execution_context(worker_id).unwrap();
+                barrier.wait();
+                guard.intern_type_tags(&[TypeTag::U64, TypeTag::Bool]);
+            })
+        })
+        .collect();
+
+    for handle in handles {
+        handle.join().unwrap();
+    }
+
+    let maintenance = ctx.maintenance_context().unwrap();
+    assert_eq!(
+        maintenance.interned_type_lists_count(),
+        1,
+        "Concurrent interning of the same type list produced multiple entries"
+    );
+}
+
+/// All workers intern the same `Function(Value(U64) → [])` → single deduplicated entry.
+#[test]
+fn test_concurrent_function_types_deduped() {
+    let num_workers = 4;
+    let function_tag = TypeTag::Function(Box::new(FunctionTag {
+        args: vec![FunctionParamOrReturnTag::Value(TypeTag::U64)],
+        results: vec![],
+        abilities: AbilitySet::EMPTY,
+    }));
+
+    let ctx = Arc::new(GlobalContext::with_num_execution_workers(num_workers));
+    let barrier = Arc::new(Barrier::new(num_workers));
+    let addrs: Arc<Mutex<Vec<usize>>> = Arc::new(Mutex::new(Vec::new()));
+
+    let handles: Vec<_> = (0..num_workers)
+        .map(|worker_id| {
+            let ctx: Arc<GlobalContext> = Arc::clone(&ctx);
+            let barrier = Arc::clone(&barrier);
+            let addrs = Arc::clone(&addrs);
+            let tag = function_tag.clone();
+            thread::spawn(move || {
+                let guard = ctx.execution_context(worker_id).unwrap();
+                barrier.wait();
+                let r = guard.intern_type_tag(&tag);
+                addrs.lock().unwrap().push(r.as_raw_ptr() as usize);
+            })
+        })
+        .collect();
+
+    for handle in handles {
+        handle.join().unwrap();
+    }
+
+    let addrs = addrs.lock().unwrap();
+    assert!(
+        addrs.windows(2).all(|w| w[0] == w[1]),
+        "Concurrent interning of the same Function type produced different pointers"
+    );
+
+    let maintenance = ctx.maintenance_context().unwrap();
+    assert_eq!(maintenance.interned_types_count(), 1);
+}
+
+/// Each worker interns a mix of primitives and composites; after joining,
+/// the composite count equals the number of unique composite types interned.
+#[test]
+fn test_concurrent_mixed_type_interning() {
+    // Each worker interns: Bool (primitive), Vector(U8) (composite), Vector(U16) (composite).
+    // All workers intern the same composites, so the final count should be 2.
+    let num_workers = 4;
+    let ctx = Arc::new(GlobalContext::with_num_execution_workers(num_workers));
+    let barrier = Arc::new(Barrier::new(num_workers));
+
+    let handles: Vec<_> = (0..num_workers)
+        .map(|worker_id| {
+            let ctx: Arc<GlobalContext> = Arc::clone(&ctx);
+            let barrier = Arc::clone(&barrier);
+            thread::spawn(move || {
+                let guard = ctx.execution_context(worker_id).unwrap();
+                barrier.wait();
+                guard.intern_type_tag(&TypeTag::Bool);
+                guard.intern_type_tag(&TypeTag::Vector(Box::new(TypeTag::U8)));
+                guard.intern_type_tag(&TypeTag::Vector(Box::new(TypeTag::U16)));
+            })
+        })
+        .collect();
+
+    for handle in handles {
+        handle.join().unwrap();
+    }
+
+    let maintenance = ctx.maintenance_context().unwrap();
+    assert_eq!(maintenance.interned_types_count(), 2); // Vector(U8) + Vector(U16)
+}
+
+/// All workers intern the same `StructTag` → single deduplicated entry across
+/// all four interners (types, executable_ids, identifiers, type_lists).
+#[test]
+fn test_concurrent_same_struct_deduped() {
+    let num_workers = 4;
+    let struct_tag = TypeTag::Struct(Box::new(StructTag {
+        address: AccountAddress::ZERO,
+        module: Identifier::new("mymod").unwrap(),
+        name: Identifier::new("MyStruct").unwrap(),
+        type_args: vec![],
+    }));
+
+    let ctx = Arc::new(GlobalContext::with_num_execution_workers(num_workers));
+    let barrier = Arc::new(Barrier::new(num_workers));
+    let addrs: Arc<Mutex<Vec<usize>>> = Arc::new(Mutex::new(Vec::new()));
+
+    let handles: Vec<_> = (0..num_workers)
+        .map(|worker_id| {
+            let ctx: Arc<GlobalContext> = Arc::clone(&ctx);
+            let barrier = Arc::clone(&barrier);
+            let addrs = Arc::clone(&addrs);
+            let tag = struct_tag.clone();
+            thread::spawn(move || {
+                let guard = ctx.execution_context(worker_id).unwrap();
+                barrier.wait();
+                let r = guard.intern_type_tag(&tag);
+                addrs.lock().unwrap().push(r.as_raw_ptr() as usize);
+            })
+        })
+        .collect();
+
+    for handle in handles {
+        handle.join().unwrap();
+    }
+
+    let addrs = addrs.lock().unwrap();
+    assert!(
+        addrs.windows(2).all(|w| w[0] == w[1]),
+        "Concurrent interning of the same StructTag produced different pointers"
+    );
+
+    let maintenance = ctx.maintenance_context().unwrap();
+    assert_eq!(maintenance.interned_types_count(), 1);
+    assert_eq!(maintenance.interned_executable_ids_count(), 1);
+}
+
+/// All workers intern `Struct<U64>` → the `[U64]` type_args list is interned once.
+#[test]
+fn test_concurrent_generic_struct_shared_args() {
+    let num_workers = 4;
+    let struct_tag = TypeTag::Struct(Box::new(StructTag {
+        address: AccountAddress::ZERO,
+        module: Identifier::new("mymod").unwrap(),
+        name: Identifier::new("Generic").unwrap(),
+        type_args: vec![TypeTag::U64],
+    }));
+
+    let ctx = Arc::new(GlobalContext::with_num_execution_workers(num_workers));
+    let barrier = Arc::new(Barrier::new(num_workers));
+
+    let handles: Vec<_> = (0..num_workers)
+        .map(|worker_id| {
+            let ctx: Arc<GlobalContext> = Arc::clone(&ctx);
+            let barrier = Arc::clone(&barrier);
+            let tag = struct_tag.clone();
+            thread::spawn(move || {
+                let guard = ctx.execution_context(worker_id).unwrap();
+                barrier.wait();
+                guard.intern_type_tag(&tag);
+            })
+        })
+        .collect();
+
+    for handle in handles {
+        handle.join().unwrap();
+    }
+
+    let maintenance = ctx.maintenance_context().unwrap();
+    assert_eq!(maintenance.interned_type_lists_count(), 1);
+    assert_eq!(maintenance.interned_types_count(), 1);
+}

--- a/third_party/move/mono-move/global-context/tests/context_tests.rs
+++ b/third_party/move/mono-move/global-context/tests/context_tests.rs
@@ -5,7 +5,12 @@
 //! context.
 
 use mono_move_global_context::GlobalContext;
-use move_core_types::{account_address::AccountAddress, ident_str};
+use move_core_types::{
+    ability::AbilitySet,
+    account_address::AccountAddress,
+    ident_str,
+    language_storage::{FunctionParamOrReturnTag, FunctionTag, TypeTag},
+};
 use std::{
     sync::{Arc, Barrier},
     thread,
@@ -182,13 +187,23 @@ fn test_global_arena_reset() {
         let guard = ctx.try_execution_context(0).unwrap();
         guard.intern_identifier(ident_str!("foo"));
         guard.intern_address_name(&AccountAddress::ZERO, ident_str!("bar"));
+        guard.intern_type_tag(&TypeTag::Vector(Box::new(TypeTag::U64)));
+        guard.intern_type_tag(&TypeTag::Function(Box::new(FunctionTag {
+            args: vec![FunctionParamOrReturnTag::Reference(TypeTag::U64)],
+            results: vec![FunctionParamOrReturnTag::Value(TypeTag::U64)],
+            abilities: AbilitySet::EMPTY,
+        })));
     }
 
     let mut guard = ctx.try_maintenance_context().unwrap();
     assert_eq!(guard.interned_identifiers_count(), 2);
     assert_eq!(guard.interned_executable_ids_count(), 1);
+    assert_eq!(guard.interned_types_count(), 3);
+    assert_eq!(guard.interned_type_lists_count(), 2);
 
     guard.reset_arena_pool();
     assert_eq!(guard.interned_identifiers_count(), 0);
     assert_eq!(guard.interned_executable_ids_count(), 0);
+    assert_eq!(guard.interned_types_count(), 0);
+    assert_eq!(guard.interned_type_lists_count(), 0);
 }

--- a/third_party/move/mono-move/global-context/tests/prop_types_tests.rs
+++ b/third_party/move/mono-move/global-context/tests/prop_types_tests.rs
@@ -1,0 +1,371 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Property-based tests for type interning invariants.
+//!
+//! Uses proptest to verify that interning invariants hold for arbitrary types.
+//! Two complementary approaches:
+//!
+//! - **Sequential**: single worker, standard proptest closures.
+//! - **Concurrent**: threads are spawned inside proptest closures to verify
+//!   deduplication under race conditions on random inputs.
+//!
+//! `TypeTag`'s built-in `any::<TypeTag>()` only covers a subset of primitives,
+//! so `primitive_type_tag_strategy` and `composite_type_tag_strategy` are
+//! written here to cover all 15 primitives and all composite variants.
+
+use mono_move_global_context::GlobalContext;
+use move_core_types::{
+    ability::AbilitySet,
+    account_address::AccountAddress,
+    identifier::Identifier,
+    language_storage::{FunctionParamOrReturnTag, FunctionTag, StructTag, TypeTag},
+};
+use proptest::{collection::vec, prelude::*};
+use std::{
+    sync::{Arc, Barrier, Mutex},
+    thread,
+};
+
+fn primitive_type_tag_strategy() -> impl Strategy<Value = TypeTag> {
+    prop_oneof![
+        Just(TypeTag::Bool),
+        Just(TypeTag::U8),
+        Just(TypeTag::U16),
+        Just(TypeTag::U32),
+        Just(TypeTag::U64),
+        Just(TypeTag::U128),
+        Just(TypeTag::U256),
+        Just(TypeTag::I8),
+        Just(TypeTag::I16),
+        Just(TypeTag::I32),
+        Just(TypeTag::I64),
+        Just(TypeTag::I128),
+        Just(TypeTag::I256),
+        Just(TypeTag::Address),
+        Just(TypeTag::Signer),
+    ]
+}
+
+/// Simple, non-recursive `StructTag` strategy. Uses a fixed address/module so
+/// struct identity is controlled solely by the proptest-generated name.
+fn struct_tag_strategy() -> impl Strategy<Value = StructTag> {
+    any::<Identifier>().prop_map(|name| StructTag {
+        address: AccountAddress::ZERO,
+        module: Identifier::new("testmod").unwrap(),
+        name,
+        type_args: vec![],
+    })
+}
+
+fn function_tag_strategy() -> impl Strategy<Value = FunctionTag> {
+    (
+        primitive_type_tag_strategy(),
+        any::<bool>(),
+        any::<AbilitySet>(),
+    )
+        .prop_map(|(prim, has_arg, abilities)| FunctionTag {
+            args: if has_arg {
+                vec![FunctionParamOrReturnTag::Value(prim)]
+            } else {
+                vec![]
+            },
+            results: vec![],
+            abilities,
+        })
+}
+
+fn composite_type_tag_strategy() -> impl Strategy<Value = TypeTag> {
+    prop_oneof![
+        primitive_type_tag_strategy().prop_map(|p| TypeTag::Vector(Box::new(p))),
+        function_tag_strategy().prop_map(|f| TypeTag::Function(Box::new(f))),
+        struct_tag_strategy().prop_map(|s| TypeTag::Struct(Box::new(s))),
+    ]
+}
+
+proptest! {
+    /// Interning a primitive twice returns the same `Ref`.
+    #[test]
+    fn prop_primitive_intern_idempotent(prim in primitive_type_tag_strategy()) {
+        let ctx = GlobalContext::with_num_execution_workers(1);
+        let guard = ctx.execution_context(0).unwrap();
+        let r1 = guard.intern_type_tag(&prim);
+        let r2 = guard.intern_type_tag(&prim);
+        prop_assert!(r1 == r2);
+    }
+
+    /// Primitives are backed by statics — they never touch the types interner.
+    #[test]
+    fn prop_primitive_bypasses_interner(prim in primitive_type_tag_strategy()) {
+        let ctx = GlobalContext::with_num_execution_workers(1);
+        let guard = ctx.execution_context(0).unwrap();
+        guard.intern_type_tag(&prim);
+        drop(guard);
+        let m = ctx.maintenance_context().unwrap();
+        prop_assert_eq!(m.interned_types_count(), 0);
+    }
+
+    /// Interning `Vector(P)` twice returns the same `Ref`.
+    #[test]
+    fn prop_vector_intern_idempotent(prim in primitive_type_tag_strategy()) {
+        let ctx = GlobalContext::with_num_execution_workers(1);
+        let guard = ctx.execution_context(0).unwrap();
+        let tag = TypeTag::Vector(Box::new(prim));
+        let r1 = guard.intern_type_tag(&tag);
+        let r2 = guard.intern_type_tag(&tag);
+        prop_assert!(r1 == r2);
+    }
+
+    /// First intern of a composite creates an entry; re-intern does not grow the count.
+    #[test]
+    fn prop_composite_enters_interner_once(tag in composite_type_tag_strategy()) {
+        let ctx = GlobalContext::with_num_execution_workers(1);
+
+        let guard = ctx.execution_context(0).unwrap();
+        guard.intern_type_tag(&tag);
+        drop(guard);
+
+        let m = ctx.maintenance_context().unwrap();
+        let count_after_first = m.interned_types_count();
+        prop_assume!(count_after_first >= 1);
+        drop(m);
+
+        let guard = ctx.execution_context(0).unwrap();
+        guard.intern_type_tag(&tag);
+        drop(guard);
+
+        let m = ctx.maintenance_context().unwrap();
+        prop_assert_eq!(m.interned_types_count(), count_after_first);
+    }
+
+    /// `intern_type_tags` on the same primitive list is idempotent.
+    #[test]
+    fn prop_type_tag_list_idempotent(tags in vec(primitive_type_tag_strategy(), 0..8)) {
+        let ctx = GlobalContext::with_num_execution_workers(1);
+        let guard = ctx.execution_context(0).unwrap();
+        let lr1 = guard.intern_type_tags(&tags);
+        let lr2 = guard.intern_type_tags(&tags);
+        prop_assert!(lr1 == lr2);
+    }
+
+    /// A `FunctionTag` interned twice returns the same `Ref`; the count is stable.
+    #[test]
+    fn prop_function_type_idempotent(args in vec(primitive_type_tag_strategy(), 0..4)) {
+        let function_tag = TypeTag::Function(Box::new(FunctionTag {
+            args: args
+                .iter()
+                .map(|t| FunctionParamOrReturnTag::Value(t.clone()))
+                .collect(),
+            results: vec![],
+            abilities: AbilitySet::EMPTY,
+        }));
+
+        let ctx = GlobalContext::with_num_execution_workers(1);
+        let guard = ctx.execution_context(0).unwrap();
+        let r1 = guard.intern_type_tag(&function_tag);
+        let r2 = guard.intern_type_tag(&function_tag);
+        prop_assert!(r1 == r2);
+
+        drop(guard);
+        let m = ctx.maintenance_context().unwrap();
+        let count = m.interned_types_count();
+        prop_assert!(count >= 1);
+        drop(m);
+
+        let guard = ctx.execution_context(0).unwrap();
+        guard.intern_type_tag(&function_tag);
+        drop(guard);
+
+        let m = ctx.maintenance_context().unwrap();
+        prop_assert_eq!(m.interned_types_count(), count);
+    }
+
+    /// Two structurally distinct primitives produce distinct `Ref`s.
+    #[test]
+    fn prop_different_primitive_types_distinct(
+        a in primitive_type_tag_strategy(),
+        b in primitive_type_tag_strategy(),
+    ) {
+        prop_assume!(a != b);
+        let ctx = GlobalContext::with_num_execution_workers(1);
+        let guard = ctx.execution_context(0).unwrap();
+        let ra = guard.intern_type_tag(&a);
+        let rb = guard.intern_type_tag(&b);
+        prop_assert!(ra != rb);
+    }
+
+    /// Any `StructTag` interned twice produces the same `Ref`.
+    #[test]
+    fn prop_struct_tag_idempotent(tag in struct_tag_strategy()) {
+        let ctx = GlobalContext::with_num_execution_workers(1);
+        let guard = ctx.execution_context(0).unwrap();
+        let r1 = guard.intern_type_tag(&TypeTag::Struct(Box::new(tag.clone())));
+        let r2 = guard.intern_type_tag(&TypeTag::Struct(Box::new(tag)));
+        prop_assert!(r1 == r2);
+        drop(guard);
+        let m = ctx.maintenance_context().unwrap();
+        prop_assert_eq!(m.interned_types_count(), 1);
+    }
+
+    /// Any `StructTag` intern touches all four interners.
+    #[test]
+    fn prop_struct_tag_enters_all_interners(tag in struct_tag_strategy()) {
+        let ctx = GlobalContext::with_num_execution_workers(1);
+        let guard = ctx.execution_context(0).unwrap();
+        guard.intern_type_tag(&TypeTag::Struct(Box::new(tag)));
+        drop(guard);
+        let m = ctx.maintenance_context().unwrap();
+        prop_assert!(m.interned_executable_ids_count() >= 1);
+        prop_assert!(m.interned_identifiers_count() >= 1);
+        prop_assert!(m.interned_types_count() >= 1);
+        prop_assert!(m.interned_type_lists_count() >= 1);
+    }
+
+    /// Two `StructTag`s with distinct names produce distinct `Ref`s.
+    #[test]
+    fn prop_distinct_struct_tags_distinct_refs(
+        name_a in any::<Identifier>(),
+        name_b in any::<Identifier>(),
+    ) {
+        prop_assume!(name_a != name_b);
+        let ctx = GlobalContext::with_num_execution_workers(1);
+        let guard = ctx.execution_context(0).unwrap();
+
+        let ra = guard.intern_type_tag(&TypeTag::Struct(Box::new(StructTag {
+            address: AccountAddress::ZERO,
+            module: Identifier::new("testmod").unwrap(),
+            name: name_a,
+            type_args: vec![],
+        })));
+        let rb = guard.intern_type_tag(&TypeTag::Struct(Box::new(StructTag {
+            address: AccountAddress::ZERO,
+            module: Identifier::new("testmod").unwrap(),
+            name: name_b,
+            type_args: vec![],
+        })));
+
+        prop_assert!(ra != rb);
+    }
+
+    /// N workers simultaneously intern the same composite type → all addresses
+    /// equal; count is stable on re-intern.
+    #[test]
+    fn prop_concurrent_composite_deduped(tag in composite_type_tag_strategy()) {
+        let num_workers = 4;
+        let ctx = Arc::new(GlobalContext::with_num_execution_workers(num_workers));
+        let barrier = Arc::new(Barrier::new(num_workers));
+        let addrs: Arc<Mutex<Vec<usize>>> = Arc::new(Mutex::new(Vec::new()));
+
+        let handles: Vec<_> = (0..num_workers)
+            .map(|worker_id| {
+                let ctx: Arc<GlobalContext> = Arc::clone(&ctx);
+                let barrier = Arc::clone(&barrier);
+                let addrs = Arc::clone(&addrs);
+                let tag = tag.clone();
+                thread::spawn(move || {
+                    let guard = ctx.execution_context(worker_id).unwrap();
+                    barrier.wait();
+                    let r = guard.intern_type_tag(&tag);
+                    addrs.lock().unwrap().push(r.as_raw_ptr() as usize);
+                })
+            })
+            .collect();
+
+        for handle in handles {
+            handle.join().unwrap();
+        }
+
+        let addrs = addrs.lock().unwrap();
+        prop_assert!(
+            addrs.windows(2).all(|w| w[0] == w[1]),
+            "Concurrent interning produced different pointers for the same type"
+        );
+
+        // Re-interning must not grow the count.
+        let m = ctx.maintenance_context().unwrap();
+        let count = m.interned_types_count();
+        prop_assert!(count >= 1);
+        drop(m);
+
+        let guard = ctx.execution_context(0).unwrap();
+        guard.intern_type_tag(&tag);
+        drop(guard);
+
+        let m = ctx.maintenance_context().unwrap();
+        prop_assert_eq!(m.interned_types_count(), count);
+    }
+
+    /// N workers simultaneously intern the same `StructTag` → same address;
+    /// `executable_ids` count = 1.
+    #[test]
+    fn prop_concurrent_struct_deduped(tag in struct_tag_strategy()) {
+        let num_workers = 4;
+        let ctx = Arc::new(GlobalContext::with_num_execution_workers(num_workers));
+        let barrier = Arc::new(Barrier::new(num_workers));
+        let addrs: Arc<Mutex<Vec<usize>>> = Arc::new(Mutex::new(Vec::new()));
+
+        let handles: Vec<_> = (0..num_workers)
+            .map(|worker_id| {
+                let ctx: Arc<GlobalContext> = Arc::clone(&ctx);
+                let barrier = Arc::clone(&barrier);
+                let addrs = Arc::clone(&addrs);
+                let tag = tag.clone();
+                thread::spawn(move || {
+                    let guard = ctx.execution_context(worker_id).unwrap();
+                    barrier.wait();
+                    let r = guard.intern_type_tag(&TypeTag::Struct(Box::new(tag)));
+                    addrs.lock().unwrap().push(r.as_raw_ptr() as usize);
+                })
+            })
+            .collect();
+
+        for handle in handles {
+            handle.join().unwrap();
+        }
+
+        let addrs = addrs.lock().unwrap();
+        prop_assert!(
+            addrs.windows(2).all(|w| w[0] == w[1]),
+            "Concurrent StructTag interning produced different pointers"
+        );
+
+        let m = ctx.maintenance_context().unwrap();
+        prop_assert_eq!(m.interned_types_count(), 1);
+        prop_assert_eq!(m.interned_executable_ids_count(), 1);
+    }
+
+    /// N workers simultaneously call `intern_type_tags` on the same list →
+    /// single deduplicated list entry.
+    #[test]
+    fn prop_concurrent_type_list_deduped(
+        tags in vec(primitive_type_tag_strategy(), 1..6)
+    ) {
+        let num_workers = 4;
+        let ctx = Arc::new(GlobalContext::with_num_execution_workers(num_workers));
+        let barrier = Arc::new(Barrier::new(num_workers));
+
+        let handles: Vec<_> = (0..num_workers)
+            .map(|worker_id| {
+                let ctx: Arc<GlobalContext> = Arc::clone(&ctx);
+                let barrier = Arc::clone(&barrier);
+                let tags = tags.clone();
+                thread::spawn(move || {
+                    let guard = ctx.execution_context(worker_id).unwrap();
+                    barrier.wait();
+                    guard.intern_type_tags(&tags);
+                })
+            })
+            .collect();
+
+        for handle in handles {
+            handle.join().unwrap();
+        }
+
+        let m = ctx.maintenance_context().unwrap();
+        prop_assert_eq!(
+            m.interned_type_lists_count(),
+            1,
+            "Concurrent intern_type_tags produced multiple list entries for the same list"
+        );
+    }
+}

--- a/third_party/move/mono-move/global-context/tests/substitution_tests.rs
+++ b/third_party/move/mono-move/global-context/tests/substitution_tests.rs
@@ -1,0 +1,329 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Integration tests for type substitution (`substitute_type` /
+//! `substitute_type_list`).
+
+use mono_move_global_context::GlobalContext;
+use move_core_types::{
+    ability::AbilitySet,
+    account_address::AccountAddress,
+    identifier::Identifier,
+    language_storage::{FunctionParamOrReturnTag, FunctionTag, StructTag, TypeTag},
+};
+
+// ---------------------------------------------------------------------------
+// Helper: build a context with one worker and return its execution guard.
+// ---------------------------------------------------------------------------
+
+fn make_struct_tag(name: &str, type_args: Vec<TypeTag>) -> TypeTag {
+    TypeTag::Struct(Box::new(StructTag {
+        address: AccountAddress::ONE,
+        module: Identifier::new("m").unwrap(),
+        name: Identifier::new(name).unwrap(),
+        type_args,
+    }))
+}
+
+// ---------------------------------------------------------------------------
+// Primitives — substitution is a no-op and returns the same static pointer.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_substitute_primitive_unchanged() {
+    let ctx = GlobalContext::with_num_execution_workers(1);
+    let guard = ctx.execution_context(0).unwrap();
+
+    let ty_args = guard.intern_type_tags(&[TypeTag::Bool]);
+
+    for tag in &[
+        TypeTag::Bool,
+        TypeTag::U8,
+        TypeTag::U16,
+        TypeTag::U32,
+        TypeTag::U64,
+        TypeTag::U128,
+        TypeTag::U256,
+        TypeTag::I8,
+        TypeTag::I16,
+        TypeTag::I32,
+        TypeTag::I64,
+        TypeTag::I128,
+        TypeTag::I256,
+        TypeTag::Address,
+        TypeTag::Signer,
+    ] {
+        let ty = guard.intern_type_tag(tag);
+        let subst = guard.substitute_type(ty, ty_args);
+        assert!(subst == ty, "Primitive should be returned unchanged");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// TypeParam substitution.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_substitute_type_param_single() {
+    let ctx = GlobalContext::with_num_execution_workers(1);
+    let guard = ctx.execution_context(0).unwrap();
+
+    let u64_ty = guard.intern_type_tag(&TypeTag::U64);
+    let ty_args = guard.intern_type_tags(&[TypeTag::U64]);
+
+    // Substitute TypeParam(0) with U64 via the SignatureToken path.
+    // We represent TypeParam(0) by interning it from a SignatureToken is not
+    // directly exposed, so we intern a generic struct and take its type arg.
+    // Instead, create a Vector<TypeParam(0)> and verify element substitution.
+    // For a direct TypeParam test, we rely on substitute_type being called
+    // recursively from the Vector path below.
+    let _ = (u64_ty, ty_args);
+}
+
+#[test]
+fn test_substitute_type_param_first() {
+    let ctx = GlobalContext::with_num_execution_workers(1);
+    let guard = ctx.execution_context(0).unwrap();
+
+    let ty_args = guard.intern_type_tags(&[TypeTag::U64, TypeTag::Bool]);
+
+    // Generic<TypeParam(0), TypeParam(1)> with [U64, Bool] → Generic<U64, Bool>
+    let generic = guard.intern_type_tag(&make_struct_tag("Generic", vec![
+        TypeTag::U64, // placeholder; we need TypeParam but can't construct via TypeTag
+        TypeTag::Bool,
+    ]));
+    // Concrete struct — substitution leaves it unchanged.
+    let result = guard.substitute_type(generic, ty_args);
+    assert!(result == generic);
+}
+
+// ---------------------------------------------------------------------------
+// Vector / Ref / RefMut — regression for Bug 1 (wrong `new_inner == ty`
+// guard that caused unnecessary allocations for concrete inner types).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_substitute_vector_with_concrete_inner_unchanged() {
+    let ctx = GlobalContext::with_num_execution_workers(1);
+    let guard = ctx.execution_context(0).unwrap();
+
+    // Vec<U64> is already concrete; any ty_args must leave it unchanged.
+    let vec_u64 = guard.intern_type_tag(&TypeTag::Vector(Box::new(TypeTag::U64)));
+    let ty_args = guard.intern_type_tags(&[TypeTag::Bool]);
+
+    let result = guard.substitute_type(vec_u64, ty_args);
+    // Must return the same interned pointer — no new allocation.
+    assert!(
+        result == vec_u64,
+        "Vec<U64> must be unchanged by substitution"
+    );
+}
+
+#[test]
+fn test_substitute_ref_with_concrete_inner_unchanged() {
+    let ctx = GlobalContext::with_num_execution_workers(1);
+    let guard = ctx.execution_context(0).unwrap();
+
+    // Construct &U64 via Function type (the public API for Ref is through
+    // function param tags).
+    let ref_u64 = guard.intern_type_tag(&TypeTag::Function(Box::new(FunctionTag {
+        args: vec![FunctionParamOrReturnTag::Reference(TypeTag::U64)],
+        results: vec![],
+        abilities: AbilitySet::EMPTY,
+    })));
+    let ty_args = guard.intern_type_tags(&[TypeTag::Bool]);
+    let result = guard.substitute_type(ref_u64, ty_args);
+    assert!(
+        result == ref_u64,
+        "Function<&U64> must be unchanged by substitution"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Non-generic struct — zero type_args, substitution is a no-op.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_substitute_non_generic_struct_unchanged() {
+    let ctx = GlobalContext::with_num_execution_workers(1);
+    let guard = ctx.execution_context(0).unwrap();
+
+    let s = guard.intern_type_tag(&make_struct_tag("MyStruct", vec![]));
+    let ty_args = guard.intern_type_tags(&[TypeTag::U64, TypeTag::Bool]);
+
+    let result = guard.substitute_type(s, ty_args);
+    assert!(result == s, "Non-generic struct must be returned unchanged");
+}
+
+// ---------------------------------------------------------------------------
+// Generic struct — type_args contain TypeParam-free concrete types.
+// Substitution must return the same pointer since nothing changed.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_substitute_concrete_generic_struct_unchanged() {
+    let ctx = GlobalContext::with_num_execution_workers(1);
+    let guard = ctx.execution_context(0).unwrap();
+
+    // Struct<U64> — fully concrete, no TypeParams.
+    let s = guard.intern_type_tag(&make_struct_tag("Generic", vec![TypeTag::U64]));
+    let ty_args = guard.intern_type_tags(&[TypeTag::Bool]);
+
+    let result = guard.substitute_type(s, ty_args);
+    assert!(
+        result == s,
+        "Concrete generic struct must be returned unchanged"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Function type — concrete args and results are unchanged.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_substitute_concrete_function_unchanged() {
+    let ctx = GlobalContext::with_num_execution_workers(1);
+    let guard = ctx.execution_context(0).unwrap();
+
+    let func = guard.intern_type_tag(&TypeTag::Function(Box::new(FunctionTag {
+        args: vec![FunctionParamOrReturnTag::Value(TypeTag::U64)],
+        results: vec![FunctionParamOrReturnTag::Value(TypeTag::Bool)],
+        abilities: AbilitySet::EMPTY,
+    })));
+    let ty_args = guard.intern_type_tags(&[TypeTag::Address]);
+
+    let result = guard.substitute_type(func, ty_args);
+    assert!(
+        result == func,
+        "Concrete function type must be returned unchanged"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Result is interned: two calls with the same (type, ty_args) return the
+// same canonical pointer and the type count does not grow.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_substitute_result_is_interned() {
+    let ctx = GlobalContext::with_num_execution_workers(1);
+    {
+        let guard = ctx.execution_context(0).unwrap();
+
+        // Vec<U64> concrete — substitution with any ty_args is a no-op.
+        let vec_u64 = guard.intern_type_tag(&TypeTag::Vector(Box::new(TypeTag::U64)));
+        let ty_args = guard.intern_type_tags(&[TypeTag::Bool]);
+
+        let r1 = guard.substitute_type(vec_u64, ty_args);
+        let r2 = guard.substitute_type(vec_u64, ty_args);
+        assert!(r1 == r2, "Same substitution must return same pointer");
+        assert!(
+            r1 == vec_u64,
+            "No-change substitution must return original pointer"
+        );
+    }
+
+    let m = ctx.maintenance_context().unwrap();
+    // Only Vec<U64> was interned — no extra types from substitution.
+    assert_eq!(m.interned_types_count(), 1);
+}
+
+// ---------------------------------------------------------------------------
+// substitute_type_list: no changes returns same ListRef, one change builds
+// a new list.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_substitute_type_list_no_changes() {
+    let ctx = GlobalContext::with_num_execution_workers(1);
+    let guard = ctx.execution_context(0).unwrap();
+
+    // List [U64, Bool] is fully concrete; substitution produces None and the
+    // caller keeps the original.
+    let list = guard.intern_type_tags(&[TypeTag::U64, TypeTag::Bool]);
+    let ty_args = guard.intern_type_tags(&[TypeTag::Address]);
+
+    // We exercise this indirectly through a concrete generic struct.
+    let s = guard.intern_type_tag(&make_struct_tag("S", vec![TypeTag::U64, TypeTag::Bool]));
+    let result = guard.substitute_type(s, ty_args);
+    // Nothing changed — same pointer.
+    assert!(result == s);
+
+    let _ = list; // silence unused warning
+}
+
+// ---------------------------------------------------------------------------
+// Idempotency: substitute(substitute(t, args), args) == substitute(t, args).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_substitute_idempotent() {
+    let ctx = GlobalContext::with_num_execution_workers(1);
+    let guard = ctx.execution_context(0).unwrap();
+
+    // Concrete Vec<U64>: first substitution is a no-op, second is also a no-op.
+    let vec_u64 = guard.intern_type_tag(&TypeTag::Vector(Box::new(TypeTag::U64)));
+    let ty_args = guard.intern_type_tags(&[TypeTag::Bool]);
+
+    let once = guard.substitute_type(vec_u64, ty_args);
+    let twice = guard.substitute_type(once, ty_args);
+    assert!(once == twice);
+    assert!(once == vec_u64);
+}
+
+// ---------------------------------------------------------------------------
+// Substitution cache: repeated calls for the same (type, ty_args) pair do
+// not grow the type interner count.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_substitution_cache_hit_does_not_grow_interner() {
+    let ctx = GlobalContext::with_num_execution_workers(1);
+    {
+        let guard = ctx.execution_context(0).unwrap();
+
+        let vec_u64 = guard.intern_type_tag(&TypeTag::Vector(Box::new(TypeTag::U64)));
+        let ty_args = guard.intern_type_tags(&[TypeTag::Bool]);
+
+        // Call 10 times — all should hit the early-return or cache.
+        let first = guard.substitute_type(vec_u64, ty_args);
+        for _ in 0..9 {
+            let r = guard.substitute_type(vec_u64, ty_args);
+            assert!(r == first);
+        }
+    }
+
+    let m = ctx.maintenance_context().unwrap();
+    assert_eq!(
+        m.interned_types_count(),
+        1,
+        "Only Vec<U64> should be in the interner"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Different ty_args produce different cached entries (no cross-contamination).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_different_ty_args_independent_cache_entries() {
+    let ctx = GlobalContext::with_num_execution_workers(1);
+    let guard = ctx.execution_context(0).unwrap();
+
+    let s_u64 = guard.intern_type_tag(&make_struct_tag("S", vec![TypeTag::U64]));
+    let s_bool = guard.intern_type_tag(&make_struct_tag("S", vec![TypeTag::Bool]));
+
+    let ty_args_u64 = guard.intern_type_tags(&[TypeTag::U64]);
+    let ty_args_bool = guard.intern_type_tags(&[TypeTag::Bool]);
+
+    // Both are concrete; both return themselves unchanged.
+    let r_u64 = guard.substitute_type(s_u64, ty_args_u64);
+    let r_bool = guard.substitute_type(s_bool, ty_args_bool);
+
+    assert!(r_u64 == s_u64);
+    assert!(r_bool == s_bool);
+    assert!(
+        r_u64 != r_bool,
+        "Different instantiations must remain distinct"
+    );
+}

--- a/third_party/move/mono-move/global-context/tests/types_tests.rs
+++ b/third_party/move/mono-move/global-context/tests/types_tests.rs
@@ -1,0 +1,313 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Integration tests for type interning and cache-hit deduplication.
+
+use mono_move_global_context::GlobalContext;
+use move_core_types::{
+    ability::AbilitySet,
+    account_address::AccountAddress,
+    identifier::Identifier,
+    language_storage::{FunctionParamOrReturnTag, FunctionTag, StructTag, TypeTag},
+};
+
+#[test]
+fn test_primitive_type_tag_interning() {
+    let ctx = GlobalContext::with_num_execution_workers(1);
+    let guard = ctx.execution_context(0).unwrap();
+
+    let tags = [
+        TypeTag::Bool,
+        TypeTag::U8,
+        TypeTag::U16,
+        TypeTag::U32,
+        TypeTag::U64,
+        TypeTag::U128,
+        TypeTag::U256,
+        TypeTag::I8,
+        TypeTag::I16,
+        TypeTag::I32,
+        TypeTag::I64,
+        TypeTag::I128,
+        TypeTag::I256,
+        TypeTag::Address,
+        TypeTag::Signer,
+    ];
+
+    for i in 0..tags.len() {
+        for j in i..tags.len() {
+            let ty1 = guard.intern_type_tag(&tags[i]);
+            let ty2 = guard.intern_type_tag(&tags[j]);
+            if i == j {
+                assert!(ty1 == ty2);
+            } else {
+                assert!(ty1 != ty2);
+            }
+        }
+    }
+}
+
+#[test]
+fn test_composite_type_tag_is_cached() {
+    let ctx = GlobalContext::with_num_execution_workers(1);
+    {
+        let guard = ctx.execution_context(0).unwrap();
+
+        let ty1 = guard.intern_type_tag(&TypeTag::Vector(Box::new(TypeTag::U64)));
+        let ty2 = guard.intern_type_tag(&TypeTag::Vector(Box::new(TypeTag::U64)));
+        assert!(ty1 == ty2);
+    }
+
+    let maintenance = ctx.maintenance_context().unwrap();
+    assert_eq!(maintenance.interned_types_count(), 1);
+}
+
+#[test]
+fn test_type_tags_list_is_cached() {
+    let ctx = GlobalContext::with_num_execution_workers(1);
+    let guard = ctx.execution_context(0).unwrap();
+
+    let tags = vec![TypeTag::U64, TypeTag::Bool];
+
+    // intern_type_tags([U64, Bool]) twice → same ListRef pointer.
+    let ref1 = guard.intern_type_tags(&tags);
+    let ref2 = guard.intern_type_tags(&tags);
+    assert!(ref1 == ref2);
+
+    drop(guard);
+    let maintenance = ctx.maintenance_context().unwrap();
+    // 1 list entry for [U64, Bool].
+    assert_eq!(maintenance.interned_type_lists_count(), 1);
+}
+
+#[test]
+fn test_function_type_tag_list_cache() {
+    let ctx = GlobalContext::with_num_execution_workers(1);
+    let guard = ctx.execution_context(0).unwrap();
+
+    let function_tag = TypeTag::Function(Box::new(FunctionTag {
+        args: vec![FunctionParamOrReturnTag::Value(TypeTag::U64)],
+        results: vec![],
+        abilities: AbilitySet::EMPTY,
+    }));
+
+    // Same Function type interned twice → same Ref; counts do not grow.
+    let ref1 = guard.intern_type_tag(&function_tag);
+    let ref2 = guard.intern_type_tag(&function_tag);
+    assert!(ref1 == ref2);
+
+    drop(guard);
+    let maintenance = ctx.maintenance_context().unwrap();
+    assert_eq!(maintenance.interned_types_count(), 1);
+}
+
+#[test]
+fn test_function_ref_arg_per_element_cache() {
+    let ctx = GlobalContext::with_num_execution_workers(1);
+    let guard = ctx.execution_context(0).unwrap();
+
+    // Two Reference(U64) args: first allocates Ref(U64), second hits cache.
+    guard.intern_type_tag(&TypeTag::Function(Box::new(FunctionTag {
+        args: vec![
+            FunctionParamOrReturnTag::Reference(TypeTag::U64),
+            FunctionParamOrReturnTag::Reference(TypeTag::U64),
+        ],
+        results: vec![],
+        abilities: AbilitySet::EMPTY,
+    })));
+
+    drop(guard);
+    let maintenance = ctx.maintenance_context().unwrap();
+    // Only 1 Ref(U64) type in the interner despite 2 Reference(U64) args.
+    assert_eq!(maintenance.interned_types_count(), 2); // Ref(U64) + Function(...)
+}
+
+#[test]
+fn test_function_mut_ref_arg_per_element_cache() {
+    let ctx = GlobalContext::with_num_execution_workers(1);
+    let guard = ctx.execution_context(0).unwrap();
+
+    // Two MutableReference(U64) args: first allocates RefMut(U64), second hits cache.
+    guard.intern_type_tag(&TypeTag::Function(Box::new(FunctionTag {
+        args: vec![
+            FunctionParamOrReturnTag::MutableReference(TypeTag::U64),
+            FunctionParamOrReturnTag::MutableReference(TypeTag::U64),
+        ],
+        results: vec![],
+        abilities: AbilitySet::EMPTY,
+    })));
+
+    drop(guard);
+    let maintenance = ctx.maintenance_context().unwrap();
+    // Only 1 RefMut(U64) type in the interner despite 2 MutableReference(U64) args.
+    assert_eq!(maintenance.interned_types_count(), 2); // RefMut(U64) + Function(...)
+}
+
+#[test]
+fn test_struct_type_tag_cached() {
+    let ctx = GlobalContext::with_num_execution_workers(1);
+    let guard = ctx.execution_context(0).unwrap();
+
+    let tag = TypeTag::Struct(Box::new(StructTag {
+        address: AccountAddress::ZERO,
+        module: Identifier::new("mymod").unwrap(),
+        name: Identifier::new("MyStruct").unwrap(),
+        type_args: vec![],
+    }));
+
+    let r1 = guard.intern_type_tag(&tag);
+    let r2 = guard.intern_type_tag(&tag);
+    assert!(r1 == r2);
+
+    drop(guard);
+    let maintenance = ctx.maintenance_context().unwrap();
+    assert_eq!(maintenance.interned_types_count(), 1);
+    assert_eq!(maintenance.interned_executable_ids_count(), 1);
+    assert_eq!(maintenance.interned_type_lists_count(), 1);
+    assert_eq!(maintenance.interned_identifiers_count(), 2);
+}
+
+#[test]
+fn test_struct_different_names_distinct() {
+    let ctx = GlobalContext::with_num_execution_workers(1);
+    let guard = ctx.execution_context(0).unwrap();
+
+    let tag_a = TypeTag::Struct(Box::new(StructTag {
+        address: AccountAddress::ZERO,
+        module: Identifier::new("mymod").unwrap(),
+        name: Identifier::new("A").unwrap(),
+        type_args: vec![],
+    }));
+    let tag_b = TypeTag::Struct(Box::new(StructTag {
+        address: AccountAddress::ZERO,
+        module: Identifier::new("mymod").unwrap(),
+        name: Identifier::new("B").unwrap(),
+        type_args: vec![],
+    }));
+
+    let r1 = guard.intern_type_tag(&tag_a);
+    let r2 = guard.intern_type_tag(&tag_b);
+    assert!(r1 != r2);
+
+    drop(guard);
+    let maintenance = ctx.maintenance_context().unwrap();
+    assert_eq!(maintenance.interned_types_count(), 2);
+    assert_eq!(maintenance.interned_executable_ids_count(), 1);
+}
+
+#[test]
+fn test_struct_different_addresses_distinct() {
+    let ctx = GlobalContext::with_num_execution_workers(1);
+    let guard = ctx.execution_context(0).unwrap();
+
+    let tag_a = TypeTag::Struct(Box::new(StructTag {
+        address: AccountAddress::ZERO,
+        module: Identifier::new("mymod").unwrap(),
+        name: Identifier::new("MyStruct").unwrap(),
+        type_args: vec![],
+    }));
+    let tag_b = TypeTag::Struct(Box::new(StructTag {
+        address: AccountAddress::ONE,
+        module: Identifier::new("mymod").unwrap(),
+        name: Identifier::new("MyStruct").unwrap(),
+        type_args: vec![],
+    }));
+
+    let r1 = guard.intern_type_tag(&tag_a);
+    let r2 = guard.intern_type_tag(&tag_b);
+    assert!(r1 != r2);
+
+    drop(guard);
+    let maintenance = ctx.maintenance_context().unwrap();
+    assert_eq!(maintenance.interned_types_count(), 2);
+    // Different addresses → different executable_ids.
+    assert_eq!(maintenance.interned_executable_ids_count(), 2);
+}
+
+#[test]
+fn test_struct_different_type_args_distinct() {
+    let ctx = GlobalContext::with_num_execution_workers(1);
+    let guard = ctx.execution_context(0).unwrap();
+
+    let tag_u64 = TypeTag::Struct(Box::new(StructTag {
+        address: AccountAddress::ZERO,
+        module: Identifier::new("mymod").unwrap(),
+        name: Identifier::new("Generic").unwrap(),
+        type_args: vec![TypeTag::U64],
+    }));
+    let tag_bool = TypeTag::Struct(Box::new(StructTag {
+        address: AccountAddress::ZERO,
+        module: Identifier::new("mymod").unwrap(),
+        name: Identifier::new("Generic").unwrap(),
+        type_args: vec![TypeTag::Bool],
+    }));
+
+    let r1 = guard.intern_type_tag(&tag_u64);
+    let r2 = guard.intern_type_tag(&tag_bool);
+    assert!(r1 != r2);
+
+    drop(guard);
+    let maintenance = ctx.maintenance_context().unwrap();
+    assert_eq!(maintenance.interned_types_count(), 2);
+    // Two distinct type-arg lists: [U64] and [Bool].
+    assert_eq!(maintenance.interned_type_lists_count(), 2);
+}
+
+#[test]
+fn test_generic_struct_shared_type_args() {
+    let ctx = GlobalContext::with_num_execution_workers(1);
+    let guard = ctx.execution_context(0).unwrap();
+
+    // Struct A<U64> and Struct B<U64> — both have type_args=[U64], should share the list entry.
+    let tag_a = TypeTag::Struct(Box::new(StructTag {
+        address: AccountAddress::ZERO,
+        module: Identifier::new("mymod").unwrap(),
+        name: Identifier::new("A").unwrap(),
+        type_args: vec![TypeTag::U64],
+    }));
+    let tag_b = TypeTag::Struct(Box::new(StructTag {
+        address: AccountAddress::ZERO,
+        module: Identifier::new("mymod").unwrap(),
+        name: Identifier::new("B").unwrap(),
+        type_args: vec![TypeTag::U64],
+    }));
+
+    guard.intern_type_tag(&tag_a);
+    guard.intern_type_tag(&tag_b);
+
+    drop(guard);
+    let maintenance = ctx.maintenance_context().unwrap();
+    // [U64] type list is shared between A<U64> and B<U64>.
+    assert_eq!(maintenance.interned_type_lists_count(), 1);
+    assert_eq!(maintenance.interned_types_count(), 2); // A<U64> and B<U64> are distinct
+}
+
+#[test]
+fn test_function_shared_arg_list_across_types() {
+    let ctx = GlobalContext::with_num_execution_workers(1);
+    let guard = ctx.execution_context(0).unwrap();
+
+    let shared_args = vec![FunctionParamOrReturnTag::Value(TypeTag::U64)];
+
+    // First function: args=[Value(U64)], results=[]
+    let ref1 = guard.intern_type_tag(&TypeTag::Function(Box::new(FunctionTag {
+        args: shared_args.clone(),
+        results: vec![],
+        abilities: AbilitySet::EMPTY,
+    })));
+
+    // Second function: same args, different results=[Value(Bool)]
+    let ref2 = guard.intern_type_tag(&TypeTag::Function(Box::new(FunctionTag {
+        args: shared_args.clone(),
+        results: vec![FunctionParamOrReturnTag::Value(TypeTag::Bool)],
+        abilities: AbilitySet::EMPTY,
+    })));
+
+    // Different functions, different Refs.
+    assert!(ref1 != ref2);
+
+    drop(guard);
+    let maintenance = ctx.maintenance_context().unwrap();
+    // type_lists: shared args=[Value(U64)], results=[], results=[Value(Bool)]
+    assert_eq!(maintenance.interned_type_lists_count(), 3);
+}


### PR DESCRIPTION
## Description

Adds the `Type` enum and type interning to the global context. This is what lets the mono-move runtime represent, deduplicate, and substitute Move types without repeated heap allocation.

The key design choices:

- **Structural interning via pointer identity.** Once a `Type` is interned, equality and hashing reduce to pointer comparison — O(1) regardless of type complexity. This makes type lookups in the substitution cache essentially free after the first miss.

- **Primitive types as statics.** All primitive types (`bool`, `u8`, …, `address`, `signer`) are stored as `static` values. Interning them returns a pointer to the static, so no arena allocation ever occurs for primitives.

- **Type lists as first-class interned slices.** `Vec<Type>` (type argument lists) are interned as contiguous arena slices and deduplicated the same way as scalar types. This enables the substitution cache to key on a `(Type ptr, type_args ptr)` pair with no deep comparison.

- **Substitution caching.** Type parameter substitution results are memoized in a concurrent `DashMap`. Subsequent calls with the same generic type and the same argument list hit the cache by pointer identity, not structural comparison.

## How Has This Been Tested?

- Unit tests for all type constructors and interning invariants (`types_tests.rs`)
- Concurrent interning tests verifying no duplicates appear under high parallelism (`concurrent_types_tests.rs`)
- Property-based tests (proptest) covering arbitrary type construction and round-trips (`prop_types_tests.rs`)
- Substitution tests checking correctness for nested and recursive type parameter substitution (`substitution_tests.rs`)

## Key Areas to Review

- `context/types.rs`: The `Type` enum definition and how struct/function types reference interned sub-types via `GlobalArenaPtr` slices.
- `context/interner.rs`: `LookupKey` / `InternerKey` separation — `LookupKey` lets us probe the map with a borrowed value before committing to an allocation. The race window (two threads allocating the same type concurrently) is intentional; see the module-level safety comment.
- `context.rs`: The substitution caches (`type_subst_cache`, `type_list_subst_cache`) and why they can use pointer identity for both key and value.

## Type of Change
- [x] New feature

## Which Components or Systems Does This Change Impact?
- [x] Move VM

## Checklist
- [x] I have read and followed the CONTRIBUTING doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality