### PR TITLE
[CLI] Encryption, Better docs for AI, fix Network vs URL ergonomics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -871,6 +871,7 @@ dependencies = [
  "serde_json",
  "serde_yaml 0.8.26",
  "sha2 0.10.9",
+ "subtle",
  "thiserror 1.0.69",
  "zeroize",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -839,6 +839,7 @@ dependencies = [
 name = "aptos-cli-common"
 version = "1.0.0"
 dependencies = [
+ "aes-gcm",
  "anstyle",
  "anyhow",
  "aptos-api-types",
@@ -850,6 +851,7 @@ dependencies = [
  "aptos-logger",
  "aptos-rest-client",
  "aptos-types",
+ "argon2",
  "async-trait",
  "base64 0.13.1",
  "bcs 0.1.4",
@@ -857,13 +859,18 @@ dependencies = [
  "clap_complete",
  "dirs 5.0.1",
  "hex",
+ "hmac 0.12.1",
  "indoc",
  "itertools 0.13.0",
+ "keyring",
  "move-core-types",
+ "rand 0.7.3",
  "reqwest 0.11.23",
+ "rpassword",
  "serde",
  "serde_json",
  "serde_yaml 0.8.26",
+ "sha2 0.10.9",
  "thiserror 1.0.69",
 ]
 
@@ -5253,6 +5260,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6"
 
 [[package]]
+name = "argon2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
+dependencies = [
+ "base64ct",
+ "blake2",
+ "cpufeatures",
+ "password-hash 0.5.0",
+]
+
+[[package]]
 name = "ark-bls12-381"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8082,6 +8101,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dbus"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b3aa68d7e7abee336255bd7248ea965cc393f3e70411135a6f6a4b651345d4"
+dependencies = [
+ "libc",
+ "libdbus-sys",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "dbus-secret-service"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "708b509edf7889e53d7efb0ffadd994cc6c2345ccb62f55cfd6b0682165e4fa6"
+dependencies = [
+ "dbus",
+ "zeroize",
+]
+
+[[package]]
 name = "deadpool"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8350,7 +8390,7 @@ dependencies = [
  "pq-sys",
  "r2d2",
  "serde_json",
- "uuid 0.8.2",
+ "uuid 1.11.0",
 ]
 
 [[package]]
@@ -9534,7 +9574,7 @@ checksum = "e29e5681dc8556fb9df1409e95eae050e12e8776394313da3546dcb8cf390c73"
 dependencies = [
  "az",
  "bytemuck",
- "half 1.8.2",
+ "half 2.2.1",
  "typenum",
 ]
 
@@ -11747,6 +11787,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "keyring"
+version = "3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
+dependencies = [
+ "byteorder",
+ "dbus-secret-service",
+ "log",
+ "security-framework 2.9.2",
+ "security-framework 3.7.0",
+ "windows-sys 0.60.2",
+ "zeroize",
+]
+
+[[package]]
 name = "kqueue"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12023,6 +12078,15 @@ name = "libc"
 version = "0.2.182"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+
+[[package]]
+name = "libdbus-sys"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043"
+dependencies = [
+ "pkg-config",
+]
 
 [[package]]
 name = "libfuzzer-sys"
@@ -14508,6 +14572,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "pasta_curves"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14588,7 +14663,7 @@ checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
 dependencies = [
  "digest 0.10.7",
  "hmac 0.12.1",
- "password-hash",
+ "password-hash 0.4.2",
  "sha2 0.10.9",
 ]
 
@@ -16615,6 +16690,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rpassword"
+version = "7.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66d4c8b64f049c6721ec8ccec37ddfc3d641c4a7fca57e8f2a89de509c73df39"
+dependencies = [
+ "libc",
+ "rtoolbox",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "rsa"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -16716,6 +16802,16 @@ dependencies = [
  "quote",
  "rustc_version",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "rtoolbox"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7cc970b249fbe527d6e02e0a227762c9108b2f49d81094fe357ffc6d14d7f6f"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -19944,7 +20040,7 @@ dependencies = [
  "errno",
  "js-sys",
  "libc",
- "rustix 0.37.27",
+ "rustix 0.38.28",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "wasm-bindgen",
  "winapi 0.3.9",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -872,6 +872,7 @@ dependencies = [
  "serde_yaml 0.8.26",
  "sha2 0.10.9",
  "thiserror 1.0.69",
+ "zeroize",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -496,6 +496,7 @@ atty = "0.2.14"
 nalgebra = "0.32"
 float-cmp = "0.9.0"
 again = "0.1.2"
+argon2 = "0.5"
 ambassador = "0.4.1"
 annotate-snippets = "0.11.5"
 anyhow = "1.0.98"
@@ -669,6 +670,7 @@ jemalloc-ctl = { package = "tikv-jemalloc-ctl", version = "0.6.1" }
 jemalloc-sys = { package = "tikv-jemalloc-sys", version = "0.6.1" }
 json-patch = "0.2.6"
 jsonwebtoken = "8.1"
+keyring = { version = "3", features = ["apple-native", "windows-native", "sync-secret-service"] }
 jwt = "0.16.0"
 lazy_static = "1.4.0"
 libc = "0.2.147"
@@ -756,6 +758,7 @@ redis = { version = "0.22.3", features = [
 redis-test = { version = "0.1.1", features = ["aio"] }
 ref-cast = "1.0.6"
 regex = "1.9.3"
+rpassword = "7"
 reqwest = { version = "0.11.11", features = [
     "blocking",
     "cookies",

--- a/crates/aptos-cli-common/Cargo.toml
+++ b/crates/aptos-cli-common/Cargo.toml
@@ -50,3 +50,4 @@ serde_json = { workspace = true }
 serde_yaml = { workspace = true }
 sha2 = { version = "0.10.6" }
 thiserror = { workspace = true }
+zeroize = "1"

--- a/crates/aptos-cli-common/Cargo.toml
+++ b/crates/aptos-cli-common/Cargo.toml
@@ -13,7 +13,7 @@ repository = { workspace = true }
 rust-version = { workspace = true }
 
 [features]
-default = ["keyring-cache"]
+default = []
 keyring-cache = ["keyring"]
 
 [dependencies]

--- a/crates/aptos-cli-common/Cargo.toml
+++ b/crates/aptos-cli-common/Cargo.toml
@@ -48,6 +48,8 @@ rpassword = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
+# Pinned: workspace sha2 0.9.3 is incompatible with hmac 0.12 (needs digest 0.10)
 sha2 = { version = "0.10.6" }
+subtle = "2"
 thiserror = { workspace = true }
 zeroize = "1"

--- a/crates/aptos-cli-common/Cargo.toml
+++ b/crates/aptos-cli-common/Cargo.toml
@@ -12,7 +12,12 @@ publish = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }
 
+[features]
+default = ["keyring-cache"]
+keyring-cache = ["keyring"]
+
 [dependencies]
+aes-gcm = { workspace = true }
 anstyle = { workspace = true }
 anyhow = { workspace = true }
 aptos-api-types = { workspace = true }
@@ -24,6 +29,7 @@ aptos-ledger = { workspace = true }
 aptos-logger = { workspace = true }
 aptos-rest-client = { workspace = true }
 aptos-types = { workspace = true }
+argon2 = { workspace = true }
 async-trait = { workspace = true }
 base64 = { workspace = true }
 bcs = { workspace = true }
@@ -31,11 +37,16 @@ clap = { workspace = true, features = ["env", "unstable-styles", "wrap_help"] }
 clap_complete = { workspace = true }
 dirs = { workspace = true }
 hex = { workspace = true }
+hmac = { workspace = true }
 indoc = { workspace = true }
 itertools = { workspace = true }
+keyring = { workspace = true, optional = true }
 move-core-types = { workspace = true }
+rand = { workspace = true }
 reqwest = { workspace = true }
+rpassword = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
+sha2 = { version = "0.10.6" }
 thiserror = { workspace = true }

--- a/crates/aptos-cli-common/src/config.rs
+++ b/crates/aptos-cli-common/src/config.rs
@@ -315,6 +315,75 @@ impl CliConfig {
         })
     }
 
+    /// Load config without decrypting sensitive fields.
+    ///
+    /// Encrypted fields become `None` in the resulting `ProfileConfig`.
+    /// Use this for commands that only need public config data (rest_url,
+    /// network, account, public_key) and don't need private_key, node_api_key,
+    /// or faucet_auth_token.
+    pub fn load_public(mode: ConfigSearchMode) -> CliTypedResult<Self> {
+        let folder = Self::aptos_folder(mode)?;
+        let config_file = folder.join(CONFIG_FILE);
+        let old_config_file = folder.join(LEGACY_CONFIG_FILE);
+
+        let yaml_str = if config_file.exists() {
+            String::from_utf8(read_from_file(config_file.as_path())?).map_err(CliError::from)?
+        } else if old_config_file.exists() {
+            String::from_utf8(read_from_file(old_config_file.as_path())?).map_err(CliError::from)?
+        } else {
+            return Err(CliError::ConfigNotFoundError(format!(
+                "{}",
+                config_file.display()
+            )));
+        };
+
+        let raw: RawCliConfig = serde_yaml::from_str(&yaml_str)
+            .map_err(|e| CliError::UnexpectedError(e.to_string()))?;
+
+        // Skip password/KDF — pass None as key so encrypted fields become None.
+        let profiles = raw
+            .profiles
+            .map(|raw_profiles| {
+                raw_profiles
+                    .into_iter()
+                    .map(|(name, raw_profile)| {
+                        let typed = raw_profile.into_profile_config(None)?;
+                        Ok((name, typed))
+                    })
+                    .collect::<CliTypedResult<BTreeMap<String, ProfileConfig>>>()
+            })
+            .transpose()?;
+
+        Ok(CliConfig {
+            encryption: raw.encryption,
+            profiles,
+        })
+    }
+
+    /// Load a single profile without decrypting sensitive fields.
+    ///
+    /// Encrypted fields become `None`. Use for commands that only need
+    /// public config data.
+    pub fn load_profile_public(
+        profile: Option<&str>,
+        mode: ConfigSearchMode,
+    ) -> CliTypedResult<Option<ProfileConfig>> {
+        let mut config = Self::load_public(mode)?;
+
+        if let Some(profile) = profile {
+            if let Some(account_profile) = config.remove_profile(profile) {
+                Ok(Some(account_profile))
+            } else {
+                Err(CliError::CommandArgumentError(format!(
+                    "Profile {} not found",
+                    profile
+                )))
+            }
+        } else {
+            Ok(config.remove_profile(DEFAULT_PROFILE))
+        }
+    }
+
     pub fn load_profile(
         profile: Option<&str>,
         mode: ConfigSearchMode,

--- a/crates/aptos-cli-common/src/config.rs
+++ b/crates/aptos-cli-common/src/config.rs
@@ -391,6 +391,44 @@ impl CliConfig {
         }
     }
 
+    /// Check whether a specific field in a profile is encrypted in the raw YAML.
+    pub fn is_profile_field_encrypted(
+        profile: Option<&str>,
+        mode: ConfigSearchMode,
+        field_name: &str,
+    ) -> bool {
+        let Ok(folder) = Self::aptos_folder(mode) else {
+            return false;
+        };
+        let config_file = folder.join(CONFIG_FILE);
+        let old_config_file = folder.join(LEGACY_CONFIG_FILE);
+
+        let yaml_str = if config_file.exists() {
+            read_from_file(config_file.as_path())
+                .ok()
+                .and_then(|b| String::from_utf8(b).ok())
+        } else if old_config_file.exists() {
+            read_from_file(old_config_file.as_path())
+                .ok()
+                .and_then(|b| String::from_utf8(b).ok())
+        } else {
+            None
+        };
+
+        let Some(yaml_str) = yaml_str else {
+            return false;
+        };
+        let Ok(raw) = serde_yaml::from_str::<RawCliConfig>(&yaml_str) else {
+            return false;
+        };
+
+        let profile_name = profile.unwrap_or(DEFAULT_PROFILE);
+        raw.profiles
+            .as_ref()
+            .and_then(|p| p.get(profile_name))
+            .is_some_and(|p| p.is_field_encrypted(field_name))
+    }
+
     pub fn load_profile(
         profile: Option<&str>,
         mode: ConfigSearchMode,

--- a/crates/aptos-cli-common/src/config.rs
+++ b/crates/aptos-cli-common/src/config.rs
@@ -437,9 +437,7 @@ impl CliConfig {
             let password = get_password(enc_config, &aptos_folder)?;
             let key = DerivedKey::derive(&password, enc_config)?;
             if !key.verify_key_check(enc_config) {
-                return Err(CliError::UnexpectedError(
-                    "Wrong password: derived key does not match stored key check".to_string(),
-                ));
+                return Err(CliError::WrongPassword);
             }
             Some(key)
         } else {

--- a/crates/aptos-cli-common/src/config.rs
+++ b/crates/aptos-cli-common/src/config.rs
@@ -285,7 +285,7 @@ impl CliConfig {
                     "Config contains encrypted fields but no encryption section".to_string(),
                 )
             })?;
-            let password = get_password(enc_config)?;
+            let password = get_password(enc_config, &folder)?;
             let key = DerivedKey::derive(&password, enc_config)?;
             if !key.verify_key_check(enc_config) {
                 return Err(CliError::WrongPassword);
@@ -432,10 +432,15 @@ impl CliConfig {
             )?;
         }
 
-        // Derive key if encryption is enabled
+        // Derive key if encryption is enabled, and verify it matches the stored key check
         let derived_key = if let Some(ref enc_config) = self.encryption {
-            let password = get_password(enc_config)?;
+            let password = get_password(enc_config, &aptos_folder)?;
             let key = DerivedKey::derive(&password, enc_config)?;
+            if !key.verify_key_check(enc_config) {
+                return Err(CliError::UnexpectedError(
+                    "Wrong password: derived key does not match stored key check".to_string(),
+                ));
+            }
             Some(key)
         } else {
             None
@@ -478,7 +483,7 @@ impl CliConfig {
     }
 
     /// Finds the current directory's .aptos folder
-    fn aptos_folder(mode: ConfigSearchMode) -> CliTypedResult<PathBuf> {
+    pub fn aptos_folder(mode: ConfigSearchMode) -> CliTypedResult<PathBuf> {
         let global_config = GlobalConfig::load()?;
         global_config.get_config_location(mode)
     }

--- a/crates/aptos-cli-common/src/config.rs
+++ b/crates/aptos-cli-common/src/config.rs
@@ -44,6 +44,28 @@ pub enum Network {
     Custom,
 }
 
+impl Network {
+    /// Returns the default REST API URL for well-known networks.
+    pub fn default_rest_url(&self) -> Option<&'static str> {
+        match self {
+            Network::Mainnet => Some("https://api.mainnet.aptoslabs.com"),
+            Network::Testnet => Some("https://api.testnet.aptoslabs.com"),
+            Network::Devnet => Some("https://api.devnet.aptoslabs.com"),
+            Network::Local => Some("http://localhost:8080"),
+            Network::Custom => None,
+        }
+    }
+
+    /// Returns the default faucet URL for networks that have one.
+    pub fn default_faucet_url(&self) -> Option<&'static str> {
+        match self {
+            Network::Devnet => Some("https://faucet.devnet.aptoslabs.com"),
+            Network::Local => Some("http://localhost:8081"),
+            _ => None,
+        }
+    }
+}
+
 impl Display for Network {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", match self {

--- a/crates/aptos-cli-common/src/config.rs
+++ b/crates/aptos-cli-common/src/config.rs
@@ -340,6 +340,13 @@ impl CliConfig {
         let raw: RawCliConfig = serde_yaml::from_str(&yaml_str)
             .map_err(|e| CliError::UnexpectedError(e.to_string()))?;
 
+        // Detect corrupted config: encrypted fields without encryption section
+        if raw.has_any_encrypted_fields() && raw.encryption.is_none() {
+            return Err(CliError::EncryptionError(
+                "Config contains encrypted fields but no encryption section".to_string(),
+            ));
+        }
+
         // Skip password/KDF — pass None as key so encrypted fields become None.
         let profiles = raw
             .profiles

--- a/crates/aptos-cli-common/src/config.rs
+++ b/crates/aptos-cli-common/src/config.rs
@@ -4,10 +4,14 @@
 //! CLI configuration management: profiles, network selection, and persistent settings.
 //!
 //! Handles loading and saving `CliConfig` profiles (stored in `.aptos/config.yaml`),
-//! including network endpoints, keys, and account addresses.
+//! including network endpoints, keys, and account addresses. Supports optional
+//! password-based encryption for sensitive fields.
 
 use crate::{
-    create_dir_if_not_exist, current_dir, read_from_file,
+    create_dir_if_not_exist, current_dir,
+    encryption::{get_password, DerivedKey, EncryptionConfig},
+    raw_config::{profile_config_to_raw, RawCliConfig},
+    read_from_file,
     types::{APTOS_FOLDER_GIT_IGNORE, CONFIG_FOLDER, DEFAULT_PROFILE, GIT_IGNORE},
     utils::{
         deserialize_address_str, deserialize_material_with_prefix, serialize_material_with_prefix,
@@ -75,8 +79,11 @@ impl FromStr for Network {
 // ── ProfileConfig ──
 
 /// An individual profile
-#[derive(Debug, Default, Serialize, DeserializeTrait)]
+#[derive(Debug, Serialize, DeserializeTrait)]
 pub struct ProfileConfig {
+    /// Profile schema version (managed by the raw config layer, not serialized directly).
+    #[serde(skip, default = "crate::raw_config::default_profile_version")]
+    pub version: u32,
     /// Name of network being used, if setup from aptos init
     #[serde(skip_serializing_if = "Option::is_none")]
     pub network: Option<Network>,
@@ -110,6 +117,29 @@ pub struct ProfileConfig {
     /// Derivation path index of the account on ledger
     #[serde(skip_serializing_if = "Option::is_none")]
     pub derivation_path: Option<String>,
+    /// API key for the node REST endpoint (encrypted when encryption is enabled)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub node_api_key: Option<String>,
+    /// Auth token for the faucet endpoint (encrypted when encryption is enabled)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub faucet_auth_token: Option<String>,
+}
+
+impl Default for ProfileConfig {
+    fn default() -> Self {
+        Self {
+            version: crate::raw_config::CURRENT_PROFILE_VERSION,
+            network: None,
+            private_key: None,
+            public_key: None,
+            account: None,
+            rest_url: None,
+            faucet_url: None,
+            derivation_path: None,
+            node_api_key: None,
+            faucet_auth_token: None,
+        }
+    }
 }
 
 // ── ProfileSummary ──
@@ -117,6 +147,7 @@ pub struct ProfileConfig {
 /// ProfileConfig but without the private parts
 #[derive(Debug, Serialize)]
 pub struct ProfileSummary {
+    pub version: u32,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub network: Option<Network>,
     pub has_private_key: bool,
@@ -135,17 +166,24 @@ pub struct ProfileSummary {
     pub rest_url: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub faucet_url: Option<String>,
+    pub has_node_api_key: bool,
+    pub has_faucet_auth_token: bool,
+    pub encrypted: bool,
 }
 
 impl From<&ProfileConfig> for ProfileSummary {
     fn from(config: &ProfileConfig) -> Self {
         ProfileSummary {
+            version: config.version,
             network: config.network,
             has_private_key: config.private_key.is_some(),
             public_key: config.public_key.clone(),
             account: config.account,
             rest_url: config.rest_url.clone(),
             faucet_url: config.faucet_url.clone(),
+            has_node_api_key: config.node_api_key.is_some(),
+            has_faucet_auth_token: config.faucet_auth_token.is_some(),
+            encrypted: false, // Will be set by the caller when applicable
         }
     }
 }
@@ -166,6 +204,9 @@ const LEGACY_CONFIG_FILE: &str = "config.yml";
 /// Config saved to `.aptos/config.yaml`
 #[derive(Debug, Serialize, DeserializeTrait)]
 pub struct CliConfig {
+    /// Encryption metadata (present when config fields are encrypted)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub encryption: Option<EncryptionConfig>,
     /// Map of profile configs
     #[serde(skip_serializing_if = "Option::is_none")]
     pub profiles: Option<BTreeMap<String, ProfileConfig>>,
@@ -174,6 +215,7 @@ pub struct CliConfig {
 impl Default for CliConfig {
     fn default() -> Self {
         CliConfig {
+            encryption: None,
             profiles: Some(BTreeMap::new()),
         }
     }
@@ -191,30 +233,64 @@ impl CliConfig {
         }
     }
 
-    /// Loads the config from the current working directory or one of its parents.
+    /// Two-phase load: read YAML as raw strings, detect encryption, decrypt if needed,
+    /// then parse into typed ProfileConfig. All downstream code sees typed profiles.
     pub fn load(mode: ConfigSearchMode) -> CliTypedResult<Self> {
         let folder = Self::aptos_folder(mode)?;
-
         let config_file = folder.join(CONFIG_FILE);
         let old_config_file = folder.join(LEGACY_CONFIG_FILE);
-        if config_file.exists() {
-            serde_yaml::from_str(
-                &String::from_utf8(read_from_file(config_file.as_path())?)
-                    .map_err(CliError::from)?,
-            )
-            .map_err(|e| CliError::UnexpectedError(e.to_string()))
+
+        let yaml_str = if config_file.exists() {
+            String::from_utf8(read_from_file(config_file.as_path())?).map_err(CliError::from)?
         } else if old_config_file.exists() {
-            serde_yaml::from_str(
-                &String::from_utf8(read_from_file(old_config_file.as_path())?)
-                    .map_err(CliError::from)?,
-            )
-            .map_err(|e| CliError::UnexpectedError(e.to_string()))
+            String::from_utf8(read_from_file(old_config_file.as_path())?).map_err(CliError::from)?
         } else {
-            Err(CliError::ConfigNotFoundError(format!(
+            return Err(CliError::ConfigNotFoundError(format!(
                 "{}",
                 config_file.display()
-            )))
-        }
+            )));
+        };
+
+        // Phase 1: Deserialize to raw config (all string values).
+        let raw: RawCliConfig = serde_yaml::from_str(&yaml_str)
+            .map_err(|e| CliError::UnexpectedError(e.to_string()))?;
+
+        // Phase 2: If encryption section is present and fields are encrypted, derive key.
+        let has_encrypted = raw.has_any_encrypted_fields();
+        let derived_key = if has_encrypted {
+            let enc_config = raw.encryption.as_ref().ok_or_else(|| {
+                CliError::EncryptionError(
+                    "Config contains encrypted fields but no encryption section".to_string(),
+                )
+            })?;
+            let password = get_password(enc_config)?;
+            let key = DerivedKey::derive(&password, enc_config)?;
+            if !key.verify_key_check(enc_config) {
+                return Err(CliError::WrongPassword);
+            }
+            Some(key)
+        } else {
+            None
+        };
+
+        // Phase 3: Convert raw profiles to typed ProfileConfig.
+        let profiles = raw
+            .profiles
+            .map(|raw_profiles| {
+                raw_profiles
+                    .into_iter()
+                    .map(|(name, raw_profile)| {
+                        let typed = raw_profile.into_profile_config(derived_key.as_ref())?;
+                        Ok((name, typed))
+                    })
+                    .collect::<CliTypedResult<BTreeMap<String, ProfileConfig>>>()
+            })
+            .transpose()?;
+
+        Ok(CliConfig {
+            encryption: raw.encryption,
+            profiles,
+        })
     }
 
     pub fn load_profile(
@@ -246,7 +322,8 @@ impl CliConfig {
         }
     }
 
-    /// Saves the config to ./.aptos/config.yaml
+    /// Two-phase save: convert typed profiles to raw strings, encrypt sensitive fields
+    /// if encryption is enabled, then serialize to YAML.
     pub fn save(&self) -> CliTypedResult<()> {
         let aptos_folder = Self::aptos_folder(ConfigSearchMode::CurrentDir)?;
 
@@ -264,9 +341,38 @@ impl CliConfig {
             )?;
         }
 
+        // Derive key if encryption is enabled
+        let derived_key = if let Some(ref enc_config) = self.encryption {
+            let password = get_password(enc_config)?;
+            let key = DerivedKey::derive(&password, enc_config)?;
+            Some(key)
+        } else {
+            None
+        };
+
+        // Convert typed profiles to raw (encrypting sensitive fields if needed)
+        let raw_profiles = self
+            .profiles
+            .as_ref()
+            .map(|profiles| {
+                profiles
+                    .iter()
+                    .map(|(name, profile)| {
+                        let raw = profile_config_to_raw(profile, derived_key.as_ref())?;
+                        Ok((name.clone(), raw))
+                    })
+                    .collect::<CliTypedResult<BTreeMap<String, _>>>()
+            })
+            .transpose()?;
+
+        let raw_config = RawCliConfig {
+            encryption: self.encryption.clone(),
+            profiles: raw_profiles,
+        };
+
         // Save over previous config file
         let config_file = aptos_folder.join(CONFIG_FILE);
-        let config_bytes = serde_yaml::to_string(&self).map_err(|err| {
+        let config_bytes = serde_yaml::to_string(&raw_config).map_err(|err| {
             CliError::UnexpectedError(format!("Failed to serialize config {}", err))
         })?;
         write_to_user_only_file(&config_file, CONFIG_FILE, config_bytes.as_bytes())?;

--- a/crates/aptos-cli-common/src/encryption.rs
+++ b/crates/aptos-cli-common/src/encryption.rs
@@ -1,0 +1,415 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Password-based encryption for sensitive CLI config fields.
+//!
+//! Sensitive values (private keys, API keys, auth tokens) are encrypted with AES-256-GCM
+//! using a key derived from a user password via Argon2id. Encrypted fields are stored in
+//! `config.yaml` with the prefix `enc:v1:<base64(nonce ∥ ciphertext ∥ tag)>`.
+
+use crate::{CliError, CliTypedResult};
+use aes_gcm::{aead::Aead, Aes256Gcm, Nonce};
+use argon2::Argon2;
+use hmac::{Hmac, Mac};
+use serde::{Deserialize, Serialize};
+use sha2::Sha256;
+use std::sync::OnceLock;
+
+/// Prefix that identifies an encrypted field value.
+const ENC_PREFIX: &str = "enc:v1:";
+
+/// Fields that should be encrypted when encryption is enabled.
+pub const SENSITIVE_FIELDS: &[&str] = &["private_key", "node_api_key", "faucet_auth_token"];
+
+/// Default Argon2 parameters — tuned for ~0.5-1s on modern hardware.
+const DEFAULT_ARGON2_T_COST: u32 = 2;
+const DEFAULT_ARGON2_M_COST: u32 = 19456; // KiB
+const DEFAULT_ARGON2_P_COST: u32 = 1;
+
+/// Salt length in bytes.
+const SALT_LEN: usize = 16;
+
+/// AES-GCM nonce length.
+const NONCE_LEN: usize = 12;
+
+/// Derived key length for AES-256.
+const KEY_LEN: usize = 32;
+
+/// Domain-separation tag for the key-check HMAC.
+const KEY_CHECK_TAG: &[u8] = b"aptos-cli-config-key-check";
+
+/// Process-level cache for the password so we don't re-prompt within a single invocation.
+static PASSWORD_CACHE: OnceLock<String> = OnceLock::new();
+
+// ── EncryptionConfig ──
+
+/// Metadata stored in the `encryption:` section of `config.yaml`.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct EncryptionConfig {
+    pub version: u32,
+    /// 16-byte salt encoded as hex.
+    pub salt: String,
+    pub argon2_t_cost: u32,
+    pub argon2_m_cost: u32,
+    pub argon2_p_cost: u32,
+    /// HMAC-SHA256 of the derived key, hex-encoded. Used for fast password verification.
+    pub key_check: String,
+    #[serde(default)]
+    pub use_keyring: bool,
+}
+
+impl EncryptionConfig {
+    /// Create a new config with a random salt and derive a key check from the password.
+    pub fn new(password: &str, use_keyring: bool) -> CliTypedResult<Self> {
+        let salt = generate_random_salt();
+        let salt_hex = hex::encode(salt);
+
+        let config = EncryptionConfig {
+            version: 1,
+            salt: salt_hex,
+            argon2_t_cost: DEFAULT_ARGON2_T_COST,
+            argon2_m_cost: DEFAULT_ARGON2_M_COST,
+            argon2_p_cost: DEFAULT_ARGON2_P_COST,
+            key_check: String::new(),
+            use_keyring,
+        };
+
+        let derived = DerivedKey::derive(password, &config)?;
+        let key_check = derived.compute_key_check();
+
+        Ok(EncryptionConfig {
+            key_check,
+            ..config
+        })
+    }
+}
+
+// ── DerivedKey ──
+
+/// A 32-byte AES-256 key derived from a user password via Argon2id.
+pub struct DerivedKey {
+    key: [u8; KEY_LEN],
+}
+
+impl DerivedKey {
+    /// Derive the AES-256 key from a password and the encryption config.
+    pub fn derive(password: &str, config: &EncryptionConfig) -> CliTypedResult<Self> {
+        let salt = hex::decode(&config.salt).map_err(|e| {
+            CliError::EncryptionError(format!("Invalid salt in encryption config: {}", e))
+        })?;
+
+        let argon2 = Argon2::new(
+            argon2::Algorithm::Argon2id,
+            argon2::Version::V0x13,
+            argon2::Params::new(
+                config.argon2_m_cost,
+                config.argon2_t_cost,
+                config.argon2_p_cost,
+                Some(KEY_LEN),
+            )
+            .map_err(|e| CliError::EncryptionError(format!("Invalid Argon2 params: {}", e)))?,
+        );
+
+        let mut key = [0u8; KEY_LEN];
+        argon2
+            .hash_password_into(password.as_bytes(), &salt, &mut key)
+            .map_err(|e| CliError::EncryptionError(format!("Argon2 key derivation failed: {}", e)))?;
+
+        Ok(DerivedKey { key })
+    }
+
+    /// Compute an HMAC-SHA256 key check value for fast password verification.
+    pub fn compute_key_check(&self) -> String {
+        let mut mac =
+            Hmac::<Sha256>::new_from_slice(&self.key).expect("HMAC accepts any key size");
+        mac.update(KEY_CHECK_TAG);
+        hex::encode(mac.finalize().into_bytes())
+    }
+
+    /// Verify the derived key against the stored key check.
+    pub fn verify_key_check(&self, config: &EncryptionConfig) -> bool {
+        self.compute_key_check() == config.key_check
+    }
+
+    /// Encrypt a plaintext string, returning `enc:v1:<base64(nonce ∥ ciphertext ∥ tag)>`.
+    pub fn encrypt_field(&self, plaintext: &str) -> CliTypedResult<String> {
+        use aes_gcm::KeyInit as _;
+
+        let cipher = Aes256Gcm::new((&self.key).into());
+        let nonce_bytes = generate_random_nonce();
+        let nonce = Nonce::from_slice(&nonce_bytes);
+
+        let ciphertext = cipher
+            .encrypt(nonce, plaintext.as_bytes())
+            .map_err(|e| CliError::EncryptionError(format!("AES-GCM encryption failed: {}", e)))?;
+
+        // Wire format: nonce ∥ ciphertext (which already includes the 16-byte auth tag)
+        let mut combined = Vec::with_capacity(NONCE_LEN + ciphertext.len());
+        combined.extend_from_slice(&nonce_bytes);
+        combined.extend_from_slice(&ciphertext);
+
+        Ok(format!("{}{}", ENC_PREFIX, base64::encode(&combined)))
+    }
+
+    /// Decrypt an `enc:v1:...` value back to plaintext.
+    pub fn decrypt_field(&self, encrypted: &str) -> CliTypedResult<String> {
+        use aes_gcm::KeyInit as _;
+
+        let encoded = encrypted
+            .strip_prefix(ENC_PREFIX)
+            .ok_or_else(|| CliError::EncryptionError("Missing enc:v1: prefix".to_string()))?;
+
+        let combined = base64::decode(encoded).map_err(|e| {
+            CliError::EncryptionError(format!("Invalid base64 in encrypted field: {}", e))
+        })?;
+
+        if combined.len() < NONCE_LEN + 16 {
+            // At minimum: 12-byte nonce + 16-byte auth tag
+            return Err(CliError::EncryptionError(
+                "Encrypted field too short".to_string(),
+            ));
+        }
+
+        let (nonce_bytes, ciphertext) = combined.split_at(NONCE_LEN);
+        let nonce = Nonce::from_slice(nonce_bytes);
+
+        let cipher = Aes256Gcm::new((&self.key).into());
+        let plaintext = cipher
+            .decrypt(nonce, ciphertext)
+            .map_err(|_| CliError::WrongPassword)?;
+
+        String::from_utf8(plaintext)
+            .map_err(|e| CliError::EncryptionError(format!("Decrypted value is not UTF-8: {}", e)))
+    }
+}
+
+// ── Password retrieval ──
+
+/// Get the encryption password for an encrypted config.
+///
+/// Priority: process cache → env var → OS keyring → interactive prompt.
+pub fn get_password(config: &EncryptionConfig) -> CliTypedResult<String> {
+    // 1. Process-level cache
+    if let Some(cached) = PASSWORD_CACHE.get() {
+        return Ok(cached.clone());
+    }
+
+    // 2. Environment variable
+    if let Ok(pw) = std::env::var("APTOS_CONFIG_PASSWORD") {
+        cache_password(pw.clone());
+        return Ok(pw);
+    }
+
+    // 3. OS keyring
+    #[cfg(feature = "keyring-cache")]
+    if config.use_keyring && let Some(pw) = try_keyring_get() {
+        cache_password(pw.clone());
+        return Ok(pw);
+    }
+
+    // Suppress unused variable warning when keyring feature is disabled
+    let _ = config;
+
+    // 4. Interactive prompt
+    let pw = prompt_password("Enter config password: ")?;
+    cache_password(pw.clone());
+    Ok(pw)
+}
+
+/// Get or prompt for a new password with confirmation.
+///
+/// Priority: process cache → `APTOS_CONFIG_PASSWORD` env var → interactive prompt (with confirm).
+/// The env-var path skips confirmation since CI environments can't do interactive prompts.
+pub fn prompt_new_password() -> CliTypedResult<String> {
+    // Process cache (e.g. already set earlier in this invocation)
+    if let Some(cached) = PASSWORD_CACHE.get() {
+        return Ok(cached.clone());
+    }
+
+    // Environment variable — trusted; skip confirmation
+    if let Ok(pw) = std::env::var("APTOS_CONFIG_PASSWORD") {
+        if pw.is_empty() {
+            return Err(CliError::EncryptionError(
+                "APTOS_CONFIG_PASSWORD is set but empty".to_string(),
+            ));
+        }
+        cache_password(pw.clone());
+        return Ok(pw);
+    }
+
+    // Interactive prompt with confirmation
+    let pw = prompt_password("Create config password: ")?;
+    let confirm = prompt_password("Confirm config password: ")?;
+    if pw != confirm {
+        return Err(CliError::EncryptionError(
+            "Passwords do not match".to_string(),
+        ));
+    }
+    if pw.is_empty() {
+        return Err(CliError::EncryptionError(
+            "Password cannot be empty".to_string(),
+        ));
+    }
+    cache_password(pw.clone());
+    Ok(pw)
+}
+
+fn prompt_password(prompt: &str) -> CliTypedResult<String> {
+    rpassword::prompt_password(prompt)
+        .map_err(|e| CliError::EncryptionError(format!("Failed to read password: {}", e)))
+}
+
+fn cache_password(pw: String) {
+    let _ = PASSWORD_CACHE.set(pw);
+}
+
+// ── Keyring helpers ──
+
+#[cfg(feature = "keyring-cache")]
+fn keyring_key() -> String {
+    // Use a fixed key; unique per config path would require passing the path in.
+    "config-password".to_string()
+}
+
+#[cfg(feature = "keyring-cache")]
+fn try_keyring_get() -> Option<String> {
+    let entry = keyring::Entry::new("aptos-cli", &keyring_key()).ok()?;
+    entry.get_password().ok()
+}
+
+#[cfg(feature = "keyring-cache")]
+pub fn keyring_store(password: &str) -> CliTypedResult<()> {
+    let entry = keyring::Entry::new("aptos-cli", &keyring_key())
+        .map_err(|e| CliError::EncryptionError(format!("Keyring error: {}", e)))?;
+    entry
+        .set_password(password)
+        .map_err(|e| CliError::EncryptionError(format!("Failed to store password in keyring: {}", e)))
+}
+
+#[cfg(feature = "keyring-cache")]
+pub fn keyring_clear() -> CliTypedResult<()> {
+    let entry = keyring::Entry::new("aptos-cli", &keyring_key())
+        .map_err(|e| CliError::EncryptionError(format!("Keyring error: {}", e)))?;
+    // Ignore "not found" errors — the entry may not exist.
+    let _ = entry.delete_credential();
+    Ok(())
+}
+
+// ── Predicate helpers ──
+
+/// Returns true if the value is an encrypted field (`enc:v1:...`).
+pub fn is_encrypted(value: &str) -> bool {
+    value.starts_with(ENC_PREFIX)
+}
+
+/// Returns true if the field name should be encrypted.
+pub fn is_sensitive_field(name: &str) -> bool {
+    SENSITIVE_FIELDS.contains(&name)
+}
+
+// ── Random helpers ──
+
+fn generate_random_salt() -> [u8; SALT_LEN] {
+    let mut salt = [0u8; SALT_LEN];
+    rand::RngCore::fill_bytes(&mut rand::thread_rng(), &mut salt);
+    salt
+}
+
+fn generate_random_nonce() -> [u8; NONCE_LEN] {
+    let mut nonce = [0u8; NONCE_LEN];
+    rand::RngCore::fill_bytes(&mut rand::thread_rng(), &mut nonce);
+    nonce
+}
+
+// ── Tests ──
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_encrypt_decrypt_round_trip() {
+        let config = EncryptionConfig::new("test-password", false).unwrap();
+        let key = DerivedKey::derive("test-password", &config).unwrap();
+
+        let plaintext = "ed25519-priv-0xabcdef1234567890";
+        let encrypted = key.encrypt_field(plaintext).unwrap();
+
+        assert!(is_encrypted(&encrypted));
+        assert!(encrypted.starts_with(ENC_PREFIX));
+
+        let decrypted = key.decrypt_field(&encrypted).unwrap();
+        assert_eq!(decrypted, plaintext);
+    }
+
+    #[test]
+    fn test_wrong_password() {
+        let config = EncryptionConfig::new("correct-password", false).unwrap();
+        let correct_key = DerivedKey::derive("correct-password", &config).unwrap();
+        let wrong_key = DerivedKey::derive("wrong-password", &config).unwrap();
+
+        let encrypted = correct_key.encrypt_field("secret").unwrap();
+
+        // Wrong key should fail decryption
+        let result = wrong_key.decrypt_field(&encrypted);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_key_check_verification() {
+        let config = EncryptionConfig::new("my-password", false).unwrap();
+
+        let correct = DerivedKey::derive("my-password", &config).unwrap();
+        assert!(correct.verify_key_check(&config));
+
+        let wrong = DerivedKey::derive("wrong-password", &config).unwrap();
+        assert!(!wrong.verify_key_check(&config));
+    }
+
+    #[test]
+    fn test_key_derivation_determinism() {
+        let config = EncryptionConfig {
+            version: 1,
+            salt: hex::encode([1u8; SALT_LEN]),
+            argon2_t_cost: DEFAULT_ARGON2_T_COST,
+            argon2_m_cost: DEFAULT_ARGON2_M_COST,
+            argon2_p_cost: DEFAULT_ARGON2_P_COST,
+            key_check: String::new(),
+            use_keyring: false,
+        };
+
+        let key1 = DerivedKey::derive("password", &config).unwrap();
+        let key2 = DerivedKey::derive("password", &config).unwrap();
+        assert_eq!(key1.key, key2.key);
+    }
+
+    #[test]
+    fn test_is_encrypted() {
+        assert!(is_encrypted("enc:v1:SGVsbG8="));
+        assert!(!is_encrypted("ed25519-priv-0xabc"));
+        assert!(!is_encrypted("plain-text"));
+    }
+
+    #[test]
+    fn test_is_sensitive_field() {
+        assert!(is_sensitive_field("private_key"));
+        assert!(is_sensitive_field("node_api_key"));
+        assert!(is_sensitive_field("faucet_auth_token"));
+        assert!(!is_sensitive_field("network"));
+        assert!(!is_sensitive_field("rest_url"));
+    }
+
+    #[test]
+    fn test_encrypted_field_format() {
+        let config = EncryptionConfig::new("pw", false).unwrap();
+        let key = DerivedKey::derive("pw", &config).unwrap();
+        let encrypted = key.encrypt_field("hello").unwrap();
+
+        // Should have prefix
+        let encoded = encrypted.strip_prefix(ENC_PREFIX).unwrap();
+        let decoded = base64::decode(encoded).unwrap();
+
+        // At least 12 (nonce) + 5 (plaintext "hello") + 16 (tag) = 33 bytes
+        assert!(decoded.len() >= 33);
+    }
+}

--- a/crates/aptos-cli-common/src/encryption.rs
+++ b/crates/aptos-cli-common/src/encryption.rs
@@ -22,9 +22,9 @@ const ENC_PREFIX: &str = "enc:v1:";
 /// Fields that should be encrypted when encryption is enabled.
 pub const SENSITIVE_FIELDS: &[&str] = &["private_key", "node_api_key", "faucet_auth_token"];
 
-/// Default Argon2 parameters — tuned for ~0.5-1s on modern hardware.
+/// Default Argon2 parameters — ~2-5s on modern hardware with 128 MiB memory.
 const DEFAULT_ARGON2_T_COST: u32 = 2;
-const DEFAULT_ARGON2_M_COST: u32 = 19456; // KiB
+const DEFAULT_ARGON2_M_COST: u32 = 131072; // 128 MiB
 const DEFAULT_ARGON2_P_COST: u32 = 1;
 
 /// Salt length in bytes.

--- a/crates/aptos-cli-common/src/encryption.rs
+++ b/crates/aptos-cli-common/src/encryption.rs
@@ -14,6 +14,7 @@ use hmac::{Hmac, Mac};
 use serde::{Deserialize, Serialize};
 use sha2::Sha256;
 use std::{path::Path, sync::OnceLock};
+use zeroize::{Zeroize, Zeroizing};
 
 /// Prefix that identifies an encrypted field value.
 const ENC_PREFIX: &str = "enc:v1:";
@@ -87,8 +88,16 @@ impl EncryptionConfig {
 // ── DerivedKey ──
 
 /// A 32-byte AES-256 key derived from a user password via Argon2id.
+///
+/// The key material is zeroed on drop to minimize time secrets reside in memory.
 pub struct DerivedKey {
     key: [u8; KEY_LEN],
+}
+
+impl Drop for DerivedKey {
+    fn drop(&mut self) {
+        self.key.zeroize();
+    }
 }
 
 impl DerivedKey {
@@ -192,16 +201,22 @@ impl DerivedKey {
 ///
 /// `config_dir` is the resolved `.aptos/` directory — used to scope keyring
 /// entries so different project configs don't collide.
-pub fn get_password(config: &EncryptionConfig, config_dir: &Path) -> CliTypedResult<String> {
+///
+/// Returns a `Zeroizing<String>` so the password is zeroed when the caller drops it.
+/// The process-level cache retains a copy for the lifetime of the process.
+pub fn get_password(
+    config: &EncryptionConfig,
+    config_dir: &Path,
+) -> CliTypedResult<Zeroizing<String>> {
     // 1. Process-level cache
     if let Some(cached) = PASSWORD_CACHE.get() {
-        return Ok(cached.clone());
+        return Ok(Zeroizing::new(cached.clone()));
     }
 
     // 2. Environment variable
     if let Ok(pw) = std::env::var("APTOS_CONFIG_PASSWORD") {
         cache_password(pw.clone());
-        return Ok(pw);
+        return Ok(Zeroizing::new(pw));
     }
 
     // 3. OS keyring
@@ -210,7 +225,7 @@ pub fn get_password(config: &EncryptionConfig, config_dir: &Path) -> CliTypedRes
         && let Some(pw) = try_keyring_get(config_dir)
     {
         cache_password(pw.clone());
-        return Ok(pw);
+        return Ok(Zeroizing::new(pw));
     }
 
     // Suppress unused variable warnings when keyring feature is disabled
@@ -219,7 +234,7 @@ pub fn get_password(config: &EncryptionConfig, config_dir: &Path) -> CliTypedRes
 
     // 4. Interactive prompt
     let pw = prompt_password("Enter config password: ")?;
-    cache_password(pw.clone());
+    cache_password(pw.to_string());
     Ok(pw)
 }
 
@@ -227,10 +242,10 @@ pub fn get_password(config: &EncryptionConfig, config_dir: &Path) -> CliTypedRes
 ///
 /// Priority: process cache → `APTOS_CONFIG_PASSWORD` env var → interactive prompt (with confirm).
 /// The env-var path skips confirmation since CI environments can't do interactive prompts.
-pub fn prompt_new_password() -> CliTypedResult<String> {
+pub fn prompt_new_password() -> CliTypedResult<Zeroizing<String>> {
     // Process cache (e.g. already set earlier in this invocation)
     if let Some(cached) = PASSWORD_CACHE.get() {
-        return Ok(cached.clone());
+        return Ok(Zeroizing::new(cached.clone()));
     }
 
     // Environment variable — trusted; skip confirmation
@@ -241,13 +256,14 @@ pub fn prompt_new_password() -> CliTypedResult<String> {
             ));
         }
         cache_password(pw.clone());
+        let pw = Zeroizing::new(pw);
         return Ok(pw);
     }
 
     // Interactive prompt with confirmation
     let pw = prompt_password("Create config password: ")?;
     let confirm = prompt_password("Confirm config password: ")?;
-    if pw != confirm {
+    if *pw != *confirm {
         return Err(CliError::EncryptionError(
             "Passwords do not match".to_string(),
         ));
@@ -257,12 +273,13 @@ pub fn prompt_new_password() -> CliTypedResult<String> {
             "Password cannot be empty".to_string(),
         ));
     }
-    cache_password(pw.clone());
+    cache_password(pw.to_string());
     Ok(pw)
 }
 
-fn prompt_password(prompt: &str) -> CliTypedResult<String> {
+fn prompt_password(prompt: &str) -> CliTypedResult<Zeroizing<String>> {
     rpassword::prompt_password(prompt)
+        .map(Zeroizing::new)
         .map_err(|e| CliError::EncryptionError(format!("Failed to read password: {}", e)))
 }
 

--- a/crates/aptos-cli-common/src/encryption.rs
+++ b/crates/aptos-cli-common/src/encryption.rs
@@ -137,20 +137,33 @@ impl DerivedKey {
     }
 
     /// Verify the derived key against the stored key check.
+    ///
+    /// Uses constant-time comparison to prevent timing side-channel attacks.
     pub fn verify_key_check(&self, config: &EncryptionConfig) -> bool {
-        self.compute_key_check() == config.key_check
+        use subtle::ConstantTimeEq;
+        let computed = self.compute_key_check();
+        computed
+            .as_bytes()
+            .ct_eq(config.key_check.as_bytes())
+            .into()
     }
 
     /// Encrypt a plaintext string, returning `enc:v1:<base64(nonce ∥ ciphertext ∥ tag)>`.
-    pub fn encrypt_field(&self, plaintext: &str) -> CliTypedResult<String> {
-        use aes_gcm::KeyInit as _;
+    ///
+    /// `field_name` is bound as AAD so ciphertexts can't be swapped between fields.
+    pub fn encrypt_field(&self, plaintext: &str, field_name: &str) -> CliTypedResult<String> {
+        use aes_gcm::{aead::Payload, KeyInit as _};
 
         let cipher = Aes256Gcm::new((&self.key).into());
         let nonce_bytes = generate_random_nonce();
         let nonce = Nonce::from_slice(&nonce_bytes);
 
+        let payload = Payload {
+            msg: plaintext.as_bytes(),
+            aad: field_name.as_bytes(),
+        };
         let ciphertext = cipher
-            .encrypt(nonce, plaintext.as_bytes())
+            .encrypt(nonce, payload)
             .map_err(|e| CliError::EncryptionError(format!("AES-GCM encryption failed: {}", e)))?;
 
         // Wire format: nonce ∥ ciphertext (which already includes the 16-byte auth tag)
@@ -162,8 +175,10 @@ impl DerivedKey {
     }
 
     /// Decrypt an `enc:v1:...` value back to plaintext.
-    pub fn decrypt_field(&self, encrypted: &str) -> CliTypedResult<String> {
-        use aes_gcm::KeyInit as _;
+    ///
+    /// `field_name` must match the value used during encryption (AAD binding).
+    pub fn decrypt_field(&self, encrypted: &str, field_name: &str) -> CliTypedResult<String> {
+        use aes_gcm::{aead::Payload, KeyInit as _};
 
         let encoded = encrypted
             .strip_prefix(ENC_PREFIX)
@@ -184,8 +199,12 @@ impl DerivedKey {
         let nonce = Nonce::from_slice(nonce_bytes);
 
         let cipher = Aes256Gcm::new((&self.key).into());
+        let payload = Payload {
+            msg: ciphertext,
+            aad: field_name.as_bytes(),
+        };
         let plaintext = cipher
-            .decrypt(nonce, ciphertext)
+            .decrypt(nonce, payload)
             .map_err(|_| CliError::WrongPassword)?;
 
         String::from_utf8(plaintext)
@@ -368,12 +387,12 @@ mod tests {
         let key = DerivedKey::derive("test-password", &config).unwrap();
 
         let plaintext = "ed25519-priv-0xabcdef1234567890";
-        let encrypted = key.encrypt_field(plaintext).unwrap();
+        let encrypted = key.encrypt_field(plaintext, "private_key").unwrap();
 
         assert!(is_encrypted(&encrypted));
         assert!(encrypted.starts_with(ENC_PREFIX));
 
-        let decrypted = key.decrypt_field(&encrypted).unwrap();
+        let decrypted = key.decrypt_field(&encrypted, "private_key").unwrap();
         assert_eq!(decrypted, plaintext);
     }
 
@@ -383,11 +402,25 @@ mod tests {
         let correct_key = DerivedKey::derive("correct-password", &config).unwrap();
         let wrong_key = DerivedKey::derive("wrong-password", &config).unwrap();
 
-        let encrypted = correct_key.encrypt_field("secret").unwrap();
+        let encrypted = correct_key.encrypt_field("secret", "private_key").unwrap();
 
         // Wrong key should fail decryption
-        let result = wrong_key.decrypt_field(&encrypted);
+        let result = wrong_key.decrypt_field(&encrypted, "private_key");
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_aad_field_binding() {
+        let config = EncryptionConfig::new("password", false).unwrap();
+        let key = DerivedKey::derive("password", &config).unwrap();
+
+        let encrypted = key.encrypt_field("secret-value", "private_key").unwrap();
+
+        // Decrypting with the correct field name succeeds
+        assert!(key.decrypt_field(&encrypted, "private_key").is_ok());
+
+        // Decrypting with a different field name fails (AAD mismatch)
+        assert!(key.decrypt_field(&encrypted, "node_api_key").is_err());
     }
 
     #[test]
@@ -438,7 +471,7 @@ mod tests {
     fn test_encrypted_field_format() {
         let config = EncryptionConfig::new("pw", false).unwrap();
         let key = DerivedKey::derive("pw", &config).unwrap();
-        let encrypted = key.encrypt_field("hello").unwrap();
+        let encrypted = key.encrypt_field("hello", "private_key").unwrap();
 
         // Should have prefix
         let encoded = encrypted.strip_prefix(ENC_PREFIX).unwrap();

--- a/crates/aptos-cli-common/src/encryption.rs
+++ b/crates/aptos-cli-common/src/encryption.rs
@@ -39,8 +39,9 @@ const KEY_LEN: usize = 32;
 /// Domain-separation tag for the key-check HMAC.
 const KEY_CHECK_TAG: &[u8] = b"aptos-cli-config-key-check";
 
-/// Process-level cache for the password so we don't re-prompt within a single invocation.
-static PASSWORD_CACHE: OnceLock<String> = OnceLock::new();
+/// Process-level cache so we don't re-prompt within a single invocation.
+/// Wrapped in `Zeroizing` so the password is zeroed during process teardown.
+static PASSWORD_CACHE: OnceLock<Zeroizing<String>> = OnceLock::new();
 
 // ── EncryptionConfig ──
 
@@ -229,13 +230,13 @@ pub fn get_password(
 ) -> CliTypedResult<Zeroizing<String>> {
     // 1. Process-level cache
     if let Some(cached) = PASSWORD_CACHE.get() {
-        return Ok(Zeroizing::new(cached.clone()));
+        return Ok(cached.clone());
     }
 
     // 2. Environment variable
     if let Ok(pw) = std::env::var("APTOS_CONFIG_PASSWORD") {
-        cache_password(pw.clone());
-        return Ok(Zeroizing::new(pw));
+        cache_password(pw);
+        return Ok(PASSWORD_CACHE.get().unwrap().clone());
     }
 
     // 3. OS keyring
@@ -243,8 +244,8 @@ pub fn get_password(
     if config.use_keyring
         && let Some(pw) = try_keyring_get(config_dir)
     {
-        cache_password(pw.clone());
-        return Ok(Zeroizing::new(pw));
+        cache_password(pw);
+        return Ok(PASSWORD_CACHE.get().unwrap().clone());
     }
 
     // Suppress unused variable warnings when keyring feature is disabled
@@ -254,7 +255,7 @@ pub fn get_password(
     // 4. Interactive prompt
     let pw = prompt_password("Enter config password: ")?;
     cache_password(pw.to_string());
-    Ok(pw)
+    Ok(PASSWORD_CACHE.get().unwrap().clone())
 }
 
 /// Get or prompt for a new password with confirmation.
@@ -264,7 +265,7 @@ pub fn get_password(
 pub fn prompt_new_password() -> CliTypedResult<Zeroizing<String>> {
     // Process cache (e.g. already set earlier in this invocation)
     if let Some(cached) = PASSWORD_CACHE.get() {
-        return Ok(Zeroizing::new(cached.clone()));
+        return Ok(cached.clone());
     }
 
     // Environment variable — trusted; skip confirmation
@@ -274,9 +275,8 @@ pub fn prompt_new_password() -> CliTypedResult<Zeroizing<String>> {
                 "APTOS_CONFIG_PASSWORD is set but empty".to_string(),
             ));
         }
-        cache_password(pw.clone());
-        let pw = Zeroizing::new(pw);
-        return Ok(pw);
+        cache_password(pw);
+        return Ok(PASSWORD_CACHE.get().unwrap().clone());
     }
 
     // Interactive prompt with confirmation
@@ -293,7 +293,7 @@ pub fn prompt_new_password() -> CliTypedResult<Zeroizing<String>> {
         ));
     }
     cache_password(pw.to_string());
-    Ok(pw)
+    Ok(PASSWORD_CACHE.get().unwrap().clone())
 }
 
 fn prompt_password(prompt: &str) -> CliTypedResult<Zeroizing<String>> {
@@ -303,7 +303,7 @@ fn prompt_password(prompt: &str) -> CliTypedResult<Zeroizing<String>> {
 }
 
 fn cache_password(pw: String) {
-    let _ = PASSWORD_CACHE.set(pw);
+    let _ = PASSWORD_CACHE.set(Zeroizing::new(pw));
 }
 
 // ── Keyring helpers ──

--- a/crates/aptos-cli-common/src/encryption.rs
+++ b/crates/aptos-cli-common/src/encryption.rs
@@ -13,7 +13,7 @@ use argon2::Argon2;
 use hmac::{Hmac, Mac};
 use serde::{Deserialize, Serialize};
 use sha2::Sha256;
-use std::sync::OnceLock;
+use std::{path::Path, sync::OnceLock};
 
 /// Prefix that identifies an encrypted field value.
 const ENC_PREFIX: &str = "enc:v1:";
@@ -113,15 +113,16 @@ impl DerivedKey {
         let mut key = [0u8; KEY_LEN];
         argon2
             .hash_password_into(password.as_bytes(), &salt, &mut key)
-            .map_err(|e| CliError::EncryptionError(format!("Argon2 key derivation failed: {}", e)))?;
+            .map_err(|e| {
+                CliError::EncryptionError(format!("Argon2 key derivation failed: {}", e))
+            })?;
 
         Ok(DerivedKey { key })
     }
 
     /// Compute an HMAC-SHA256 key check value for fast password verification.
     pub fn compute_key_check(&self) -> String {
-        let mut mac =
-            Hmac::<Sha256>::new_from_slice(&self.key).expect("HMAC accepts any key size");
+        let mut mac = Hmac::<Sha256>::new_from_slice(&self.key).expect("HMAC accepts any key size");
         mac.update(KEY_CHECK_TAG);
         hex::encode(mac.finalize().into_bytes())
     }
@@ -188,7 +189,10 @@ impl DerivedKey {
 /// Get the encryption password for an encrypted config.
 ///
 /// Priority: process cache → env var → OS keyring → interactive prompt.
-pub fn get_password(config: &EncryptionConfig) -> CliTypedResult<String> {
+///
+/// `config_dir` is the resolved `.aptos/` directory — used to scope keyring
+/// entries so different project configs don't collide.
+pub fn get_password(config: &EncryptionConfig, config_dir: &Path) -> CliTypedResult<String> {
     // 1. Process-level cache
     if let Some(cached) = PASSWORD_CACHE.get() {
         return Ok(cached.clone());
@@ -202,13 +206,16 @@ pub fn get_password(config: &EncryptionConfig) -> CliTypedResult<String> {
 
     // 3. OS keyring
     #[cfg(feature = "keyring-cache")]
-    if config.use_keyring && let Some(pw) = try_keyring_get() {
+    if config.use_keyring
+        && let Some(pw) = try_keyring_get(config_dir)
+    {
         cache_password(pw.clone());
         return Ok(pw);
     }
 
-    // Suppress unused variable warning when keyring feature is disabled
+    // Suppress unused variable warnings when keyring feature is disabled
     let _ = config;
+    let _ = config_dir;
 
     // 4. Interactive prompt
     let pw = prompt_password("Enter config password: ")?;
@@ -265,30 +272,41 @@ fn cache_password(pw: String) {
 
 // ── Keyring helpers ──
 
+/// Build a keyring entry name scoped to the given `.aptos/` directory so that
+/// different project configs don't collide in the OS credential store.
 #[cfg(feature = "keyring-cache")]
-fn keyring_key() -> String {
-    // Use a fixed key; unique per config path would require passing the path in.
-    "config-password".to_string()
+fn keyring_key(config_dir: &Path) -> String {
+    use std::{
+        collections::hash_map::DefaultHasher,
+        hash::{Hash, Hasher},
+    };
+
+    let canonical = config_dir
+        .canonicalize()
+        .unwrap_or_else(|_| config_dir.to_path_buf());
+    let mut hasher = DefaultHasher::new();
+    canonical.hash(&mut hasher);
+    format!("aptos-config-password-{:x}", hasher.finish())
 }
 
 #[cfg(feature = "keyring-cache")]
-fn try_keyring_get() -> Option<String> {
-    let entry = keyring::Entry::new("aptos-cli", &keyring_key()).ok()?;
+fn try_keyring_get(config_dir: &Path) -> Option<String> {
+    let entry = keyring::Entry::new("aptos-cli", &keyring_key(config_dir)).ok()?;
     entry.get_password().ok()
 }
 
 #[cfg(feature = "keyring-cache")]
-pub fn keyring_store(password: &str) -> CliTypedResult<()> {
-    let entry = keyring::Entry::new("aptos-cli", &keyring_key())
+pub fn keyring_store(password: &str, config_dir: &Path) -> CliTypedResult<()> {
+    let entry = keyring::Entry::new("aptos-cli", &keyring_key(config_dir))
         .map_err(|e| CliError::EncryptionError(format!("Keyring error: {}", e)))?;
-    entry
-        .set_password(password)
-        .map_err(|e| CliError::EncryptionError(format!("Failed to store password in keyring: {}", e)))
+    entry.set_password(password).map_err(|e| {
+        CliError::EncryptionError(format!("Failed to store password in keyring: {}", e))
+    })
 }
 
 #[cfg(feature = "keyring-cache")]
-pub fn keyring_clear() -> CliTypedResult<()> {
-    let entry = keyring::Entry::new("aptos-cli", &keyring_key())
+pub fn keyring_clear(config_dir: &Path) -> CliTypedResult<()> {
+    let entry = keyring::Entry::new("aptos-cli", &keyring_key(config_dir))
         .map_err(|e| CliError::EncryptionError(format!("Keyring error: {}", e)))?;
     // Ignore "not found" errors — the entry may not exist.
     let _ = entry.delete_credential();

--- a/crates/aptos-cli-common/src/lib.rs
+++ b/crates/aptos-cli-common/src/lib.rs
@@ -5,7 +5,9 @@
 //! and the standalone Move CLI.
 
 mod config;
+pub mod encryption;
 mod options;
+pub mod raw_config;
 mod types;
 mod utils;
 

--- a/crates/aptos-cli-common/src/options.rs
+++ b/crates/aptos-cli-common/src/options.rs
@@ -785,15 +785,11 @@ impl RestOptions {
             .timeout(Duration::from_secs(self.connection_timeout_secs))
             .header(aptos_api_types::X_APTOS_CLIENT, X_APTOS_CLIENT_VALUE)?;
 
-        // Priority: CLI flag / env var → profile config
+        // Priority: CLI flag / env var → profile config.
+        // Try public load first (no password prompt). If the config is encrypted
+        // and the field was set, it'll be None — fall back to full decrypting load.
         let api_key = self.node_api_key.clone().or_else(|| {
-            CliConfig::load_profile_public(
-                profile.profile_name(),
-                ConfigSearchMode::CurrentDirAndParents,
-            )
-            .ok()
-            .flatten()
-            .and_then(|p| p.node_api_key)
+            load_optional_sensitive_field(profile.profile_name(), |p| p.node_api_key.clone())
         });
         if let Some(node_api_key) = &api_key {
             client = client.api_key(node_api_key)?;
@@ -980,15 +976,10 @@ impl FaucetOptions {
         num_octas: u64,
         address: AccountAddress,
     ) -> CliTypedResult<()> {
-        // Priority: CLI flag / env var → profile config
+        // Priority: CLI flag / env var → profile config.
+        // Try public load first; fall back to decrypting load if encrypted.
         let auth_token = self.faucet_auth_token.clone().or_else(|| {
-            CliConfig::load_profile_public(
-                profile.profile_name(),
-                ConfigSearchMode::CurrentDirAndParents,
-            )
-            .ok()
-            .flatten()
-            .and_then(|p| p.faucet_auth_token)
+            load_optional_sensitive_field(profile.profile_name(), |p| p.faucet_auth_token.clone())
         });
         crate::fund_account(
             rest_client,
@@ -1218,6 +1209,44 @@ pub struct MultisigAccountWithSequenceNumber {
 // ────────────────────────────────────────────────────────────────────────────
 // get_mint_site_url
 // ────────────────────────────────────────────────────────────────────────────
+
+/// Load an optional sensitive field from the profile config.
+///
+/// Tries `load_profile_public` first (no password prompt). If the config is
+/// encrypted and the field came back `None`, retries with the full decrypting
+/// `load_profile` so encrypted API keys and auth tokens are still usable.
+fn load_optional_sensitive_field(
+    profile: Option<&str>,
+    extract: impl Fn(&ProfileConfig) -> Option<String>,
+) -> Option<String> {
+    // Fast path: public load (no password prompt)
+    let public_profile =
+        CliConfig::load_profile_public(profile, ConfigSearchMode::CurrentDirAndParents)
+            .ok()
+            .flatten();
+
+    if let Some(ref p) = public_profile {
+        if let Some(value) = extract(p) {
+            return Some(value);
+        }
+    }
+
+    // If the config has encryption, the field might be encrypted (returned as None).
+    // Fall back to full decrypting load.
+    let is_encrypted = CliConfig::load_public(ConfigSearchMode::CurrentDirAndParents)
+        .ok()
+        .and_then(|c| c.encryption)
+        .is_some();
+
+    if is_encrypted {
+        CliConfig::load_profile(profile, ConfigSearchMode::CurrentDirAndParents)
+            .ok()
+            .flatten()
+            .and_then(|p| extract(&p))
+    } else {
+        None
+    }
+}
 
 /// For minting testnet APT.
 pub fn get_mint_site_url(address: Option<AccountAddress>) -> String {

--- a/crates/aptos-cli-common/src/options.rs
+++ b/crates/aptos-cli-common/src/options.rs
@@ -704,10 +704,11 @@ pub struct RestOptions {
     #[clap(long)]
     pub url: Option<reqwest::Url>,
 
-    /// Target network (mainnet, testnet, devnet, local)
+    /// Target network (mainnet, testnet, devnet, local, custom)
     ///
     /// Sets the REST URL (and faucet URL where applicable) to the well-known
     /// endpoint for the given network. Overridden by an explicit `--url`.
+    /// `custom` has no default URLs and requires an explicit `--url`.
     #[clap(long)]
     pub network: Option<Network>,
 
@@ -789,7 +790,9 @@ impl RestOptions {
         // Try public load first (no password prompt). If the config is encrypted
         // and the field was set, it'll be None — fall back to full decrypting load.
         let api_key = self.node_api_key.clone().or_else(|| {
-            load_optional_sensitive_field(profile.profile_name(), |p| p.node_api_key.clone())
+            load_optional_sensitive_field(profile.profile_name(), "node_api_key", |p| {
+                p.node_api_key.clone()
+            })
         });
         if let Some(node_api_key) = &api_key {
             client = client.api_key(node_api_key)?;
@@ -979,7 +982,9 @@ impl FaucetOptions {
         // Priority: CLI flag / env var → profile config.
         // Try public load first; fall back to decrypting load if encrypted.
         let auth_token = self.faucet_auth_token.clone().or_else(|| {
-            load_optional_sensitive_field(profile.profile_name(), |p| p.faucet_auth_token.clone())
+            load_optional_sensitive_field(profile.profile_name(), "faucet_auth_token", |p| {
+                p.faucet_auth_token.clone()
+            })
         });
         crate::fund_account(
             rest_client,
@@ -1217,6 +1222,7 @@ pub struct MultisigAccountWithSequenceNumber {
 /// `load_profile` so encrypted API keys and auth tokens are still usable.
 fn load_optional_sensitive_field(
     profile: Option<&str>,
+    field_name: &str,
     extract: impl Fn(&ProfileConfig) -> Option<String>,
 ) -> Option<String> {
     // Fast path: public load (no password prompt)
@@ -1231,14 +1237,13 @@ fn load_optional_sensitive_field(
         }
     }
 
-    // If the config has encryption, the field might be encrypted (returned as None).
-    // Fall back to full decrypting load.
-    let is_encrypted = CliConfig::load_public(ConfigSearchMode::CurrentDirAndParents)
-        .ok()
-        .and_then(|c| c.encryption)
-        .is_some();
-
-    if is_encrypted {
+    // Only fall back to the decrypting load if this specific field is encrypted.
+    // This avoids prompting for a password when the field is simply absent.
+    if CliConfig::is_profile_field_encrypted(
+        profile,
+        ConfigSearchMode::CurrentDirAndParents,
+        field_name,
+    ) {
         CliConfig::load_profile(profile, ConfigSearchMode::CurrentDirAndParents)
             .ok()
             .flatten()

--- a/crates/aptos-cli-common/src/options.rs
+++ b/crates/aptos-cli-common/src/options.rs
@@ -702,6 +702,13 @@ pub struct RestOptions {
     #[clap(long)]
     pub url: Option<reqwest::Url>,
 
+    /// Target network (mainnet, testnet, devnet, local)
+    ///
+    /// Sets the REST URL (and faucet URL where applicable) to the well-known
+    /// endpoint for the given network. Overridden by an explicit `--url`.
+    #[clap(long)]
+    pub network: Option<Network>,
+
     /// Connection timeout in seconds, used for the REST endpoint of the fullnode
     #[clap(long, default_value_t = DEFAULT_EXPIRATION_SECS, alias = "connection-timeout-s")]
     pub connection_timeout_secs: u64,
@@ -717,6 +724,7 @@ impl Default for RestOptions {
     fn default() -> Self {
         Self {
             url: None,
+            network: None,
             connection_timeout_secs: DEFAULT_EXPIRATION_SECS,
             node_api_key: None,
         }
@@ -727,26 +735,47 @@ impl RestOptions {
     pub fn new(url: Option<reqwest::Url>, connection_timeout_secs: Option<u64>) -> Self {
         RestOptions {
             url,
+            network: None,
             connection_timeout_secs: connection_timeout_secs.unwrap_or(DEFAULT_EXPIRATION_SECS),
             node_api_key: None,
         }
     }
 
-    /// Retrieve the URL from the profile or the command line
+    /// Retrieve the URL from the command line, network flag, or profile.
+    ///
+    /// Resolution order: `--url` → `--network` default → profile `rest_url` → profile `network` default → error
     pub fn url(&self, profile: &ProfileOptions) -> CliTypedResult<reqwest::Url> {
+        // 1. Explicit --url flag
         if let Some(ref url) = self.url {
-            Ok(url.clone())
-        } else if let Some(Some(url)) = CliConfig::load_profile(
+            return Ok(url.clone());
+        }
+
+        // 2. --network flag → well-known URL
+        if let Some(ref network) = self.network {
+            if let Some(url) = network.default_rest_url() {
+                return reqwest::Url::parse(url)
+                    .map_err(|err| CliError::UnableToParse("Rest URL", err.to_string()));
+            }
+        }
+
+        // 3-4. Profile rest_url, then profile network default
+        if let Some(profile_config) = CliConfig::load_profile(
             profile.profile_name(),
             ConfigSearchMode::CurrentDirAndParents,
-        )?
-        .map(|p| p.rest_url)
-        {
-            reqwest::Url::parse(&url)
-                .map_err(|err| CliError::UnableToParse("Rest URL", err.to_string()))
-        } else {
-            Err(CliError::CommandArgumentError("No rest url given.  Please add --url or add a rest_url to the .aptos/config.yaml for the current profile".to_string()))
+        )? {
+            if let Some(url) = profile_config.rest_url {
+                return reqwest::Url::parse(&url)
+                    .map_err(|err| CliError::UnableToParse("Rest URL", err.to_string()));
+            }
+            if let Some(url) = profile_config.network.and_then(|n| n.default_rest_url()) {
+                return reqwest::Url::parse(url)
+                    .map_err(|err| CliError::UnableToParse("Rest URL", err.to_string()));
+            }
         }
+
+        Err(CliError::CommandArgumentError(
+            "No rest url given. Please add --url, --network, or set rest_url in .aptos/config.yaml for the current profile".to_string(),
+        ))
     }
 
     pub fn client(&self, profile: &ProfileOptions) -> CliTypedResult<Client> {
@@ -877,10 +906,30 @@ impl FaucetOptions {
         }
     }
 
-    pub fn faucet_url(&self, profile_options: &ProfileOptions) -> CliTypedResult<reqwest::Url> {
+    /// Resolve the faucet URL.
+    ///
+    /// Resolution order: `--faucet-url` → `network` default → profile `faucet_url` → profile `network` error messages → error
+    pub fn faucet_url(
+        &self,
+        profile_options: &ProfileOptions,
+        network: Option<Network>,
+    ) -> CliTypedResult<reqwest::Url> {
+        // 1. Explicit --faucet-url flag
         if let Some(ref faucet_url) = self.faucet_url {
             return Ok(faucet_url.clone());
         }
+
+        // 2. --network flag → well-known faucet URL
+        if let Some(ref net) = network {
+            if let Some(url) = net.default_faucet_url() {
+                return reqwest::Url::parse(url)
+                    .map_err(|err| CliError::UnableToParse("Faucet URL", err.to_string()));
+            }
+            // Network was specified but has no faucet — give a targeted error
+            return Self::no_faucet_error(*net);
+        }
+
+        // 3-4. Profile faucet_url, then profile network error messages
         let profile = CliConfig::load_profile(
             profile_options.profile_name(),
             ConfigSearchMode::CurrentDirAndParents,
@@ -895,19 +944,24 @@ impl FaucetOptions {
             },
         };
 
-        match profile.faucet_url {
-            Some(url) => reqwest::Url::parse(&url)
-                .map_err(|err| CliError::UnableToParse("config faucet_url", err.to_string())),
-            None => match profile.network {
-                Some(Network::Mainnet) => {
-                    Err(CliError::CommandArgumentError("There is no faucet for mainnet. Please create and fund the account by transferring funds from another account. If you are confident you want to use a faucet, set --faucet-url or add a faucet URL to .aptos/config.yaml for the current profile".to_string()))
-                },
-                Some(Network::Testnet) => {
-                    Err(CliError::CommandArgumentError(format!("To get testnet APT you must visit {}. If you are confident you want to use a faucet programmatically, set --faucet-url or add a faucet URL to .aptos/config.yaml for the current profile", get_mint_site_url(None))))
-                },
-                _ => {
-                    Err(CliError::CommandArgumentError("No faucet given. Please set --faucet-url or add a faucet URL to .aptos/config.yaml for the current profile".to_string()))
-                },
+        if let Some(url) = profile.faucet_url {
+            return reqwest::Url::parse(&url)
+                .map_err(|err| CliError::UnableToParse("config faucet_url", err.to_string()));
+        }
+
+        Self::no_faucet_error(profile.network.unwrap_or(Network::Custom))
+    }
+
+    fn no_faucet_error(network: Network) -> CliTypedResult<reqwest::Url> {
+        match network {
+            Network::Mainnet => {
+                Err(CliError::CommandArgumentError("There is no faucet for mainnet. Please create and fund the account by transferring funds from another account. If you are confident you want to use a faucet, set --faucet-url or add a faucet URL to .aptos/config.yaml for the current profile".to_string()))
+            },
+            Network::Testnet => {
+                Err(CliError::CommandArgumentError(format!("To get testnet APT you must visit {}. If you are confident you want to use a faucet programmatically, set --faucet-url or add a faucet URL to .aptos/config.yaml for the current profile", get_mint_site_url(None))))
+            },
+            _ => {
+                Err(CliError::CommandArgumentError("No faucet given. Please set --faucet-url, --network, or add a faucet URL to .aptos/config.yaml for the current profile".to_string()))
             },
         }
     }
@@ -917,6 +971,7 @@ impl FaucetOptions {
         &self,
         rest_client: Client,
         profile: &ProfileOptions,
+        network: Option<Network>,
         num_octas: u64,
         address: AccountAddress,
     ) -> CliTypedResult<()> {
@@ -929,7 +984,7 @@ impl FaucetOptions {
         });
         crate::fund_account(
             rest_client,
-            self.faucet_url(profile)?,
+            self.faucet_url(profile, network)?,
             auth_token.as_deref(),
             address,
             num_octas,

--- a/crates/aptos-cli-common/src/options.rs
+++ b/crates/aptos-cli-common/src/options.rs
@@ -753,7 +753,15 @@ impl RestOptions {
         let mut client = Client::builder(AptosBaseUrl::Custom(self.url(profile)?))
             .timeout(Duration::from_secs(self.connection_timeout_secs))
             .header(aptos_api_types::X_APTOS_CLIENT, X_APTOS_CLIENT_VALUE)?;
-        if let Some(node_api_key) = &self.node_api_key {
+
+        // Priority: CLI flag / env var → profile config
+        let api_key = self.node_api_key.clone().or_else(|| {
+            CliConfig::load_profile(profile.profile_name(), ConfigSearchMode::CurrentDirAndParents)
+                .ok()
+                .flatten()
+                .and_then(|p| p.node_api_key)
+        });
+        if let Some(node_api_key) = &api_key {
             client = client.api_key(node_api_key)?;
         }
         Ok(client.build())
@@ -912,10 +920,17 @@ impl FaucetOptions {
         num_octas: u64,
         address: AccountAddress,
     ) -> CliTypedResult<()> {
+        // Priority: CLI flag / env var → profile config
+        let auth_token = self.faucet_auth_token.clone().or_else(|| {
+            CliConfig::load_profile(profile.profile_name(), ConfigSearchMode::CurrentDirAndParents)
+                .ok()
+                .flatten()
+                .and_then(|p| p.faucet_auth_token)
+        });
         crate::fund_account(
             rest_client,
             self.faucet_url(profile)?,
-            self.faucet_auth_token.as_deref(),
+            auth_token.as_deref(),
             address,
             num_octas,
         )

--- a/crates/aptos-cli-common/src/options.rs
+++ b/crates/aptos-cli-common/src/options.rs
@@ -293,7 +293,7 @@ impl ExtractEd25519PublicKey for PublicKeyInputOptions {
         } else if let Some(ref key) = self.public_key {
             let key = key.as_bytes().to_vec();
             Ok(encoding.decode_key("--public-key", key)?)
-        } else if let Some(Some(public_key)) = CliConfig::load_profile(
+        } else if let Some(Some(public_key)) = CliConfig::load_profile_public(
             profile.profile_name(),
             ConfigSearchMode::CurrentDirAndParents,
         )?
@@ -449,11 +449,12 @@ impl PrivateKeyInputOptions {
                 let address = account_address_from_public_key(&private_key.public_key());
                 Ok((private_key.public_key(), address))
             }
-        } else if let Some((Some(public_key), maybe_config_address)) = CliConfig::load_profile(
-            profile.profile_name(),
-            ConfigSearchMode::CurrentDirAndParents,
-        )?
-        .map(|p| (p.public_key, p.account))
+        } else if let Some((Some(public_key), maybe_config_address)) =
+            CliConfig::load_profile_public(
+                profile.profile_name(),
+                ConfigSearchMode::CurrentDirAndParents,
+            )?
+            .map(|p| (p.public_key, p.account))
         {
             match (maybe_address, maybe_config_address) {
                 (Some(address), _) => Ok((public_key, address)),
@@ -489,11 +490,12 @@ impl PrivateKeyInputOptions {
             // If we use the CLI inputs, then we should derive or use the address from the input
             let address = account_address_from_public_key(&private_key.public_key());
             Ok(address)
-        } else if let Some((Some(public_key), maybe_config_address)) = CliConfig::load_profile(
-            profile.profile_name(),
-            ConfigSearchMode::CurrentDirAndParents,
-        )?
-        .map(|p| (p.public_key, p.account))
+        } else if let Some((Some(public_key), maybe_config_address)) =
+            CliConfig::load_profile_public(
+                profile.profile_name(),
+                ConfigSearchMode::CurrentDirAndParents,
+            )?
+            .map(|p| (p.public_key, p.account))
         {
             if let Some(address) = maybe_config_address {
                 Ok(address)
@@ -624,7 +626,7 @@ impl ExtractEd25519PublicKey for PrivateKeyInputOptions {
         // 3. Else error
         if let Some(key) = private_key {
             Ok(key.public_key())
-        } else if let Some(Some(public_key)) = CliConfig::load_profile(
+        } else if let Some(Some(public_key)) = CliConfig::load_profile_public(
             profile.profile_name(),
             ConfigSearchMode::CurrentDirAndParents,
         )?
@@ -759,7 +761,7 @@ impl RestOptions {
         }
 
         // 3-4. Profile rest_url, then profile network default
-        if let Some(profile_config) = CliConfig::load_profile(
+        if let Some(profile_config) = CliConfig::load_profile_public(
             profile.profile_name(),
             ConfigSearchMode::CurrentDirAndParents,
         )? {
@@ -785,10 +787,13 @@ impl RestOptions {
 
         // Priority: CLI flag / env var → profile config
         let api_key = self.node_api_key.clone().or_else(|| {
-            CliConfig::load_profile(profile.profile_name(), ConfigSearchMode::CurrentDirAndParents)
-                .ok()
-                .flatten()
-                .and_then(|p| p.node_api_key)
+            CliConfig::load_profile_public(
+                profile.profile_name(),
+                ConfigSearchMode::CurrentDirAndParents,
+            )
+            .ok()
+            .flatten()
+            .and_then(|p| p.node_api_key)
         });
         if let Some(node_api_key) = &api_key {
             client = client.api_key(node_api_key)?;
@@ -826,7 +831,7 @@ pub fn load_account_arg(str: &str) -> Result<AccountAddress, CliError> {
     if let Ok(account_address) = AccountAddress::from_str(str) {
         Ok(account_address)
     } else if let Some(Some(account_address)) =
-        CliConfig::load_profile(Some(str), ConfigSearchMode::CurrentDirAndParents)?
+        CliConfig::load_profile_public(Some(str), ConfigSearchMode::CurrentDirAndParents)?
             .map(|p| p.account)
     {
         Ok(account_address)
@@ -930,7 +935,7 @@ impl FaucetOptions {
         }
 
         // 3-4. Profile faucet_url, then profile network error messages
-        let profile = CliConfig::load_profile(
+        let profile = CliConfig::load_profile_public(
             profile_options.profile_name(),
             ConfigSearchMode::CurrentDirAndParents,
         )?;
@@ -977,10 +982,13 @@ impl FaucetOptions {
     ) -> CliTypedResult<()> {
         // Priority: CLI flag / env var → profile config
         let auth_token = self.faucet_auth_token.clone().or_else(|| {
-            CliConfig::load_profile(profile.profile_name(), ConfigSearchMode::CurrentDirAndParents)
-                .ok()
-                .flatten()
-                .and_then(|p| p.faucet_auth_token)
+            CliConfig::load_profile_public(
+                profile.profile_name(),
+                ConfigSearchMode::CurrentDirAndParents,
+            )
+            .ok()
+            .flatten()
+            .and_then(|p| p.faucet_auth_token)
         });
         crate::fund_account(
             rest_client,

--- a/crates/aptos-cli-common/src/raw_config.rs
+++ b/crates/aptos-cli-common/src/raw_config.rs
@@ -198,12 +198,12 @@ impl RawCliConfig {
 /// Decrypt a field value if it has the `enc:v1:` prefix and a key is available.
 fn maybe_decrypt(
     value: Option<String>,
-    _field_name: &str,
+    field_name: &str,
     key: Option<&DerivedKey>,
 ) -> CliTypedResult<Option<String>> {
     match value {
         Some(v) if is_encrypted(&v) => match key {
-            Some(key) => Ok(Some(key.decrypt_field(&v)?)),
+            Some(key) => Ok(Some(key.decrypt_field(&v, field_name)?)),
             None => Ok(None), // encrypted field, no key → skip
         },
         other => Ok(other),
@@ -217,7 +217,9 @@ fn maybe_encrypt(
     key: Option<&DerivedKey>,
 ) -> CliTypedResult<Option<String>> {
     match (value, key) {
-        (Some(v), Some(key)) if is_sensitive_field(field_name) => Ok(Some(key.encrypt_field(&v)?)),
+        (Some(v), Some(key)) if is_sensitive_field(field_name) => {
+            Ok(Some(key.encrypt_field(&v, field_name)?))
+        },
         (v, _) => Ok(v),
     }
 }

--- a/crates/aptos-cli-common/src/raw_config.rs
+++ b/crates/aptos-cli-common/src/raw_config.rs
@@ -117,6 +117,18 @@ impl RawProfileConfig {
         .iter()
         .any(|f| f.as_deref().is_some_and(is_encrypted))
     }
+
+    /// Returns true if the named field is present and encrypted.
+    pub fn is_field_encrypted(&self, field_name: &str) -> bool {
+        let value = match field_name {
+            "private_key" => &self.private_key,
+            "public_key" => &self.public_key,
+            "node_api_key" => &self.node_api_key,
+            "faucet_auth_token" => &self.faucet_auth_token,
+            _ => return false,
+        };
+        value.as_deref().is_some_and(is_encrypted)
+    }
 }
 
 /// Convert a typed `ProfileConfig` into a `RawProfileConfig`, encrypting sensitive fields

--- a/crates/aptos-cli-common/src/raw_config.rs
+++ b/crates/aptos-cli-common/src/raw_config.rs
@@ -129,7 +129,7 @@ pub fn profile_config_to_raw(
         .private_key
         .as_ref()
         .map(|k| {
-            k.to_encoded_string().map_err(|e| {
+            k.to_aip_80_string().map_err(|e| {
                 CliError::UnexpectedError(format!("Failed to encode private key: {}", e))
             })
         })
@@ -139,7 +139,7 @@ pub fn profile_config_to_raw(
         .public_key
         .as_ref()
         .map(|k| {
-            k.to_encoded_string().map_err(|e| {
+            k.to_aip_80_string().map_err(|e| {
                 CliError::UnexpectedError(format!("Failed to encode public key: {}", e))
             })
         })

--- a/crates/aptos-cli-common/src/raw_config.rs
+++ b/crates/aptos-cli-common/src/raw_config.rs
@@ -1,0 +1,492 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Raw intermediate config types for two-phase deserialization.
+//!
+//! These types mirror `ProfileConfig` / `CliConfig` but keep all values as strings,
+//! allowing us to detect and decrypt `enc:v1:...` fields before parsing them into
+//! their typed representations.
+
+use crate::{
+    encryption::{is_encrypted, is_sensitive_field, DerivedKey, EncryptionConfig},
+    CliError, CliTypedResult, Network, ProfileConfig,
+};
+use aptos_crypto::{
+    ed25519::{Ed25519PrivateKey, Ed25519PublicKey},
+    ValidCryptoMaterialStringExt,
+};
+use aptos_types::account_address::AccountAddress;
+use serde::{Deserialize, Serialize};
+use std::{collections::BTreeMap, str::FromStr};
+
+/// The current profile schema version, stamped on every save.
+pub const CURRENT_PROFILE_VERSION: u32 = 1;
+
+pub fn default_profile_version() -> u32 {
+    1
+}
+
+// ── RawProfileConfig ──
+
+/// A profile where all values are strings — used as the intermediate serde layer.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RawProfileConfig {
+    #[serde(default = "default_profile_version")]
+    pub version: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub network: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub private_key: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub public_key: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub account: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rest_url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub faucet_url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub derivation_path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub node_api_key: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub faucet_auth_token: Option<String>,
+}
+
+impl Default for RawProfileConfig {
+    fn default() -> Self {
+        Self {
+            version: CURRENT_PROFILE_VERSION,
+            network: None,
+            private_key: None,
+            public_key: None,
+            account: None,
+            rest_url: None,
+            faucet_url: None,
+            derivation_path: None,
+            node_api_key: None,
+            faucet_auth_token: None,
+        }
+    }
+}
+
+impl RawProfileConfig {
+    /// Convert to a typed `ProfileConfig`, decrypting sensitive fields if a key is provided.
+    pub fn into_profile_config(
+        self,
+        key: Option<&DerivedKey>,
+    ) -> CliTypedResult<ProfileConfig> {
+        let private_key_str = maybe_decrypt(self.private_key, "private_key", key)?;
+        let public_key_str = maybe_decrypt(self.public_key, "public_key", key)?;
+
+        let private_key = private_key_str
+            .map(|s| parse_private_key(&s))
+            .transpose()?;
+        let public_key = public_key_str
+            .map(|s| parse_public_key(&s))
+            .transpose()?;
+
+        let account = self
+            .account
+            .map(|s| {
+                AccountAddress::from_str(&s)
+                    .map_err(|e| CliError::UnableToParse("account address", e.to_string()))
+            })
+            .transpose()?;
+
+        let network = self
+            .network
+            .map(|s| Network::from_str(&s))
+            .transpose()?;
+
+        let node_api_key = maybe_decrypt(self.node_api_key, "node_api_key", key)?;
+        let faucet_auth_token =
+            maybe_decrypt(self.faucet_auth_token, "faucet_auth_token", key)?;
+
+        Ok(ProfileConfig {
+            version: self.version,
+            network,
+            private_key,
+            public_key,
+            account,
+            rest_url: self.rest_url,
+            faucet_url: self.faucet_url,
+            derivation_path: self.derivation_path,
+            node_api_key,
+            faucet_auth_token,
+        })
+    }
+
+    /// Returns true if any field in this profile is encrypted.
+    pub fn has_encrypted_fields(&self) -> bool {
+        [
+            &self.private_key,
+            &self.public_key,
+            &self.node_api_key,
+            &self.faucet_auth_token,
+        ]
+        .iter()
+        .any(|f| f.as_deref().is_some_and(is_encrypted))
+    }
+}
+
+/// Convert a typed `ProfileConfig` into a `RawProfileConfig`, encrypting sensitive fields
+/// if a key is provided.
+pub fn profile_config_to_raw(
+    config: &ProfileConfig,
+    key: Option<&DerivedKey>,
+) -> CliTypedResult<RawProfileConfig> {
+    let private_key_str = config
+        .private_key
+        .as_ref()
+        .map(|k| {
+            k.to_encoded_string()
+                .map_err(|e| CliError::UnexpectedError(format!("Failed to encode private key: {}", e)))
+        })
+        .transpose()?;
+
+    let public_key_str = config
+        .public_key
+        .as_ref()
+        .map(|k| {
+            k.to_encoded_string()
+                .map_err(|e| CliError::UnexpectedError(format!("Failed to encode public key: {}", e)))
+        })
+        .transpose()?;
+
+    let account_str = config.account.map(|a| a.to_standard_string());
+    // Use serde serialization format for network (e.g. "Devnet") to match existing config files
+    let network_str = config
+        .network
+        .map(|n| {
+            serde_yaml::to_value(n)
+                .ok()
+                .and_then(|v| v.as_str().map(String::from))
+                .unwrap_or_else(|| n.to_string())
+        });
+
+    Ok(RawProfileConfig {
+        version: CURRENT_PROFILE_VERSION,
+        network: network_str,
+        private_key: maybe_encrypt(private_key_str, "private_key", key)?,
+        public_key: public_key_str, // public_key is never encrypted
+        account: account_str,
+        rest_url: config.rest_url.clone(),
+        faucet_url: config.faucet_url.clone(),
+        derivation_path: config.derivation_path.clone(),
+        node_api_key: maybe_encrypt(config.node_api_key.clone(), "node_api_key", key)?,
+        faucet_auth_token: maybe_encrypt(
+            config.faucet_auth_token.clone(),
+            "faucet_auth_token",
+            key,
+        )?,
+    })
+}
+
+// ── RawCliConfig ──
+
+/// Top-level config with raw string profiles and optional encryption metadata.
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub struct RawCliConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub encryption: Option<EncryptionConfig>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub profiles: Option<BTreeMap<String, RawProfileConfig>>,
+}
+
+impl RawCliConfig {
+    /// Returns true if any profile contains encrypted fields.
+    pub fn has_any_encrypted_fields(&self) -> bool {
+        self.profiles
+            .as_ref()
+            .map(|profiles| profiles.values().any(|p| p.has_encrypted_fields()))
+            .unwrap_or(false)
+    }
+}
+
+// ── Helpers ──
+
+/// Decrypt a field value if it has the `enc:v1:` prefix and a key is available.
+fn maybe_decrypt(
+    value: Option<String>,
+    field_name: &str,
+    key: Option<&DerivedKey>,
+) -> CliTypedResult<Option<String>> {
+    match value {
+        Some(v) if is_encrypted(&v) => {
+            let key = key.ok_or_else(|| {
+                CliError::EncryptionError(format!(
+                    "Field '{}' is encrypted but no decryption key available",
+                    field_name
+                ))
+            })?;
+            Ok(Some(key.decrypt_field(&v)?))
+        },
+        other => Ok(other),
+    }
+}
+
+/// Encrypt a field value if a key is provided and the field is sensitive.
+fn maybe_encrypt(
+    value: Option<String>,
+    field_name: &str,
+    key: Option<&DerivedKey>,
+) -> CliTypedResult<Option<String>> {
+    match (value, key) {
+        (Some(v), Some(key)) if is_sensitive_field(field_name) => {
+            Ok(Some(key.encrypt_field(&v)?))
+        },
+        (v, _) => Ok(v),
+    }
+}
+
+fn parse_private_key(s: &str) -> CliTypedResult<Ed25519PrivateKey> {
+    // Handle AIP-80 prefix
+    let stripped = crate::strip_private_key_prefix(s)?;
+    Ed25519PrivateKey::from_encoded_string(stripped)
+        .map_err(|e| CliError::UnableToParse("Ed25519PrivateKey", e.to_string()))
+}
+
+fn parse_public_key(s: &str) -> CliTypedResult<Ed25519PublicKey> {
+    // Handle AIP-80 prefix: strip "ed25519-pub-" if present
+    let stripped = s.strip_prefix("ed25519-pub-").unwrap_or(s);
+    Ed25519PublicKey::from_encoded_string(stripped)
+        .map_err(|e| CliError::UnableToParse("Ed25519PublicKey", e.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::encryption::EncryptionConfig;
+
+    #[test]
+    fn test_plaintext_round_trip() {
+        let raw = RawProfileConfig {
+            network: Some("devnet".to_string()),
+            rest_url: Some("https://fullnode.devnet.aptoslabs.com".to_string()),
+            ..Default::default()
+        };
+
+        let typed = raw.into_profile_config(None).unwrap();
+        assert_eq!(typed.network, Some(Network::Devnet));
+        assert_eq!(
+            typed.rest_url.as_deref(),
+            Some("https://fullnode.devnet.aptoslabs.com")
+        );
+    }
+
+    #[test]
+    fn test_encrypted_round_trip() {
+        let config = EncryptionConfig::new("test-pw", false).unwrap();
+        let key = DerivedKey::derive("test-pw", &config).unwrap();
+
+        // Build a profile and convert to raw (encrypting)
+        let profile = ProfileConfig {
+            network: Some(Network::Devnet),
+            rest_url: Some("https://example.com".to_string()),
+            node_api_key: Some("secret-api-key".to_string()),
+            ..Default::default()
+        };
+
+        let raw = profile_config_to_raw(&profile, Some(&key)).unwrap();
+
+        // node_api_key should be encrypted
+        assert!(raw.node_api_key.as_ref().unwrap().starts_with("enc:v1:"));
+        // rest_url should NOT be encrypted
+        assert_eq!(raw.rest_url.as_deref(), Some("https://example.com"));
+        // network should be plain (serde format uses capitalized variant name)
+        assert_eq!(raw.network.as_deref(), Some("Devnet"));
+
+        // Round-trip back
+        let restored = raw.into_profile_config(Some(&key)).unwrap();
+        assert_eq!(
+            restored.node_api_key.as_deref(),
+            Some("secret-api-key")
+        );
+        assert_eq!(restored.network, Some(Network::Devnet));
+    }
+
+    #[test]
+    fn test_has_encrypted_fields() {
+        let raw = RawProfileConfig {
+            private_key: Some("enc:v1:AAAA".to_string()),
+            ..Default::default()
+        };
+        assert!(raw.has_encrypted_fields());
+
+        let raw_plain = RawProfileConfig {
+            private_key: Some("ed25519-priv-0xabc".to_string()),
+            ..Default::default()
+        };
+        assert!(!raw_plain.has_encrypted_fields());
+    }
+
+    /// Full YAML round-trip: build a RawCliConfig with encrypted fields,
+    /// serialize to YAML, deserialize back, and decrypt — verifying all
+    /// sensitive fields survive and non-sensitive fields stay readable.
+    #[test]
+    fn test_yaml_round_trip_with_encryption() {
+        let password = "yaml-round-trip-pw";
+        let enc_config = EncryptionConfig::new(password, false).unwrap();
+        let key = DerivedKey::derive(password, &enc_config).unwrap();
+
+        // Build a typed profile with both sensitive and non-sensitive fields
+        let profile = ProfileConfig {
+            network: Some(Network::Testnet),
+            rest_url: Some("https://fullnode.testnet.aptoslabs.com".to_string()),
+            faucet_url: Some("https://faucet.testnet.aptoslabs.com".to_string()),
+            node_api_key: Some("my-secret-api-key".to_string()),
+            faucet_auth_token: Some("my-faucet-token".to_string()),
+            ..Default::default()
+        };
+
+        // Convert to raw (encrypts sensitive fields)
+        let raw_profile = profile_config_to_raw(&profile, Some(&key)).unwrap();
+
+        let raw_config = RawCliConfig {
+            encryption: Some(enc_config.clone()),
+            profiles: Some(
+                [("default".to_string(), raw_profile)]
+                    .into_iter()
+                    .collect(),
+            ),
+        };
+
+        // Serialize to YAML
+        let yaml = serde_yaml::to_string(&raw_config).unwrap();
+
+        // Verify: sensitive fields are encrypted in the YAML
+        assert!(yaml.contains("enc:v1:"), "YAML should contain encrypted fields");
+        assert!(
+            !yaml.contains("my-secret-api-key"),
+            "Plaintext API key must NOT appear in YAML"
+        );
+        assert!(
+            !yaml.contains("my-faucet-token"),
+            "Plaintext faucet token must NOT appear in YAML"
+        );
+        // Non-sensitive fields remain readable
+        assert!(yaml.contains("fullnode.testnet.aptoslabs.com"));
+        assert!(yaml.contains("faucet.testnet.aptoslabs.com"));
+
+        // Deserialize back to raw
+        let loaded_raw: RawCliConfig = serde_yaml::from_str(&yaml).unwrap();
+        assert!(loaded_raw.has_any_encrypted_fields());
+        assert!(loaded_raw.encryption.is_some());
+
+        // Derive key from the same password (simulating APTOS_CONFIG_PASSWORD env var path)
+        let loaded_enc = loaded_raw.encryption.as_ref().unwrap();
+        let loaded_key = DerivedKey::derive(password, loaded_enc).unwrap();
+        assert!(loaded_key.verify_key_check(loaded_enc));
+
+        // Decrypt profiles
+        let loaded_profiles = loaded_raw.profiles.unwrap();
+        let default_raw = loaded_profiles.get("default").unwrap();
+        let restored = default_raw.clone().into_profile_config(Some(&loaded_key)).unwrap();
+
+        assert_eq!(restored.network, Some(Network::Testnet));
+        assert_eq!(
+            restored.rest_url.as_deref(),
+            Some("https://fullnode.testnet.aptoslabs.com")
+        );
+        assert_eq!(restored.node_api_key.as_deref(), Some("my-secret-api-key"));
+        assert_eq!(
+            restored.faucet_auth_token.as_deref(),
+            Some("my-faucet-token")
+        );
+    }
+
+    /// Verifying that a wrong password fails key_check before even attempting decryption.
+    #[test]
+    fn test_wrong_password_detected_by_key_check() {
+        let enc_config = EncryptionConfig::new("correct-pw", false).unwrap();
+        let wrong_key = DerivedKey::derive("wrong-pw", &enc_config).unwrap();
+        assert!(
+            !wrong_key.verify_key_check(&enc_config),
+            "Wrong password should fail key_check"
+        );
+    }
+
+    #[test]
+    fn test_missing_version_defaults_to_1() {
+        // Simulate an existing config.yaml that predates the version field
+        let yaml = r#"
+network: Devnet
+rest_url: "https://example.com"
+"#;
+        let raw: RawProfileConfig = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(raw.version, 1);
+
+        let typed = raw.into_profile_config(None).unwrap();
+        assert_eq!(typed.version, 1);
+    }
+
+    #[test]
+    fn test_profile_config_to_raw_stamps_current_version() {
+        let profile = ProfileConfig {
+            version: 0, // intentionally wrong — save should overwrite
+            network: Some(Network::Devnet),
+            ..Default::default()
+        };
+        let raw = profile_config_to_raw(&profile, None).unwrap();
+        assert_eq!(raw.version, CURRENT_PROFILE_VERSION);
+    }
+
+    #[test]
+    fn test_version_survives_yaml_round_trip() {
+        let profile = ProfileConfig {
+            network: Some(Network::Testnet),
+            rest_url: Some("https://example.com".to_string()),
+            ..Default::default()
+        };
+        let raw = profile_config_to_raw(&profile, None).unwrap();
+        assert_eq!(raw.version, CURRENT_PROFILE_VERSION);
+
+        // Serialize to YAML and back
+        let yaml = serde_yaml::to_string(&raw).unwrap();
+        assert!(yaml.contains("version: 1"), "YAML should contain version field");
+
+        let raw2: RawProfileConfig = serde_yaml::from_str(&yaml).unwrap();
+        assert_eq!(raw2.version, CURRENT_PROFILE_VERSION);
+
+        let typed = raw2.into_profile_config(None).unwrap();
+        assert_eq!(typed.version, CURRENT_PROFILE_VERSION);
+    }
+
+    /// Plaintext config (no encryption section) loads without needing a password.
+    #[test]
+    fn test_plaintext_config_needs_no_password() {
+        let raw_config = RawCliConfig {
+            encryption: None,
+            profiles: Some(
+                [(
+                    "default".to_string(),
+                    RawProfileConfig {
+                        network: Some("Devnet".to_string()),
+                        rest_url: Some("https://example.com".to_string()),
+                        ..Default::default()
+                    },
+                )]
+                .into_iter()
+                .collect(),
+            ),
+        };
+
+        // Serialize + deserialize
+        let yaml = serde_yaml::to_string(&raw_config).unwrap();
+        let loaded: RawCliConfig = serde_yaml::from_str(&yaml).unwrap();
+
+        assert!(!loaded.has_any_encrypted_fields());
+        assert!(loaded.encryption.is_none());
+
+        // Should convert without any key
+        let profiles = loaded.profiles.unwrap();
+        let restored = profiles
+            .get("default")
+            .unwrap()
+            .clone()
+            .into_profile_config(None)
+            .unwrap();
+        assert_eq!(restored.network, Some(Network::Devnet));
+    }
+}

--- a/crates/aptos-cli-common/src/raw_config.rs
+++ b/crates/aptos-cli-common/src/raw_config.rs
@@ -72,19 +72,12 @@ impl Default for RawProfileConfig {
 
 impl RawProfileConfig {
     /// Convert to a typed `ProfileConfig`, decrypting sensitive fields if a key is provided.
-    pub fn into_profile_config(
-        self,
-        key: Option<&DerivedKey>,
-    ) -> CliTypedResult<ProfileConfig> {
+    pub fn into_profile_config(self, key: Option<&DerivedKey>) -> CliTypedResult<ProfileConfig> {
         let private_key_str = maybe_decrypt(self.private_key, "private_key", key)?;
         let public_key_str = maybe_decrypt(self.public_key, "public_key", key)?;
 
-        let private_key = private_key_str
-            .map(|s| parse_private_key(&s))
-            .transpose()?;
-        let public_key = public_key_str
-            .map(|s| parse_public_key(&s))
-            .transpose()?;
+        let private_key = private_key_str.map(|s| parse_private_key(&s)).transpose()?;
+        let public_key = public_key_str.map(|s| parse_public_key(&s)).transpose()?;
 
         let account = self
             .account
@@ -94,14 +87,10 @@ impl RawProfileConfig {
             })
             .transpose()?;
 
-        let network = self
-            .network
-            .map(|s| Network::from_str(&s))
-            .transpose()?;
+        let network = self.network.map(|s| Network::from_str(&s)).transpose()?;
 
         let node_api_key = maybe_decrypt(self.node_api_key, "node_api_key", key)?;
-        let faucet_auth_token =
-            maybe_decrypt(self.faucet_auth_token, "faucet_auth_token", key)?;
+        let faucet_auth_token = maybe_decrypt(self.faucet_auth_token, "faucet_auth_token", key)?;
 
         Ok(ProfileConfig {
             version: self.version,
@@ -140,8 +129,9 @@ pub fn profile_config_to_raw(
         .private_key
         .as_ref()
         .map(|k| {
-            k.to_encoded_string()
-                .map_err(|e| CliError::UnexpectedError(format!("Failed to encode private key: {}", e)))
+            k.to_encoded_string().map_err(|e| {
+                CliError::UnexpectedError(format!("Failed to encode private key: {}", e))
+            })
         })
         .transpose()?;
 
@@ -149,21 +139,20 @@ pub fn profile_config_to_raw(
         .public_key
         .as_ref()
         .map(|k| {
-            k.to_encoded_string()
-                .map_err(|e| CliError::UnexpectedError(format!("Failed to encode public key: {}", e)))
+            k.to_encoded_string().map_err(|e| {
+                CliError::UnexpectedError(format!("Failed to encode public key: {}", e))
+            })
         })
         .transpose()?;
 
     let account_str = config.account.map(|a| a.to_standard_string());
     // Use serde serialization format for network (e.g. "Devnet") to match existing config files
-    let network_str = config
-        .network
-        .map(|n| {
-            serde_yaml::to_value(n)
-                .ok()
-                .and_then(|v| v.as_str().map(String::from))
-                .unwrap_or_else(|| n.to_string())
-        });
+    let network_str = config.network.map(|n| {
+        serde_yaml::to_value(n)
+            .ok()
+            .and_then(|v| v.as_str().map(String::from))
+            .unwrap_or_else(|| n.to_string())
+    });
 
     Ok(RawProfileConfig {
         version: CURRENT_PROFILE_VERSION,
@@ -228,9 +217,7 @@ fn maybe_encrypt(
     key: Option<&DerivedKey>,
 ) -> CliTypedResult<Option<String>> {
     match (value, key) {
-        (Some(v), Some(key)) if is_sensitive_field(field_name) => {
-            Ok(Some(key.encrypt_field(&v)?))
-        },
+        (Some(v), Some(key)) if is_sensitive_field(field_name) => Ok(Some(key.encrypt_field(&v)?)),
         (v, _) => Ok(v),
     }
 }
@@ -294,10 +281,7 @@ mod tests {
 
         // Round-trip back
         let restored = raw.into_profile_config(Some(&key)).unwrap();
-        assert_eq!(
-            restored.node_api_key.as_deref(),
-            Some("secret-api-key")
-        );
+        assert_eq!(restored.node_api_key.as_deref(), Some("secret-api-key"));
         assert_eq!(restored.network, Some(Network::Devnet));
     }
 
@@ -340,18 +324,17 @@ mod tests {
 
         let raw_config = RawCliConfig {
             encryption: Some(enc_config.clone()),
-            profiles: Some(
-                [("default".to_string(), raw_profile)]
-                    .into_iter()
-                    .collect(),
-            ),
+            profiles: Some([("default".to_string(), raw_profile)].into_iter().collect()),
         };
 
         // Serialize to YAML
         let yaml = serde_yaml::to_string(&raw_config).unwrap();
 
         // Verify: sensitive fields are encrypted in the YAML
-        assert!(yaml.contains("enc:v1:"), "YAML should contain encrypted fields");
+        assert!(
+            yaml.contains("enc:v1:"),
+            "YAML should contain encrypted fields"
+        );
         assert!(
             !yaml.contains("my-secret-api-key"),
             "Plaintext API key must NOT appear in YAML"
@@ -377,7 +360,10 @@ mod tests {
         // Decrypt profiles
         let loaded_profiles = loaded_raw.profiles.unwrap();
         let default_raw = loaded_profiles.get("default").unwrap();
-        let restored = default_raw.clone().into_profile_config(Some(&loaded_key)).unwrap();
+        let restored = default_raw
+            .clone()
+            .into_profile_config(Some(&loaded_key))
+            .unwrap();
 
         assert_eq!(restored.network, Some(Network::Testnet));
         assert_eq!(
@@ -439,7 +425,10 @@ rest_url: "https://example.com"
 
         // Serialize to YAML and back
         let yaml = serde_yaml::to_string(&raw).unwrap();
-        assert!(yaml.contains("version: 1"), "YAML should contain version field");
+        assert!(
+            yaml.contains("version: 1"),
+            "YAML should contain version field"
+        );
 
         let raw2: RawProfileConfig = serde_yaml::from_str(&yaml).unwrap();
         assert_eq!(raw2.version, CURRENT_PROFILE_VERSION);
@@ -454,14 +443,11 @@ rest_url: "https://example.com"
         let raw_config = RawCliConfig {
             encryption: None,
             profiles: Some(
-                [(
-                    "default".to_string(),
-                    RawProfileConfig {
-                        network: Some("Devnet".to_string()),
-                        rest_url: Some("https://example.com".to_string()),
-                        ..Default::default()
-                    },
-                )]
+                [("default".to_string(), RawProfileConfig {
+                    network: Some("Devnet".to_string()),
+                    rest_url: Some("https://example.com".to_string()),
+                    ..Default::default()
+                })]
                 .into_iter()
                 .collect(),
             ),

--- a/crates/aptos-cli-common/src/raw_config.rs
+++ b/crates/aptos-cli-common/src/raw_config.rs
@@ -209,18 +209,13 @@ impl RawCliConfig {
 /// Decrypt a field value if it has the `enc:v1:` prefix and a key is available.
 fn maybe_decrypt(
     value: Option<String>,
-    field_name: &str,
+    _field_name: &str,
     key: Option<&DerivedKey>,
 ) -> CliTypedResult<Option<String>> {
     match value {
-        Some(v) if is_encrypted(&v) => {
-            let key = key.ok_or_else(|| {
-                CliError::EncryptionError(format!(
-                    "Field '{}' is encrypted but no decryption key available",
-                    field_name
-                ))
-            })?;
-            Ok(Some(key.decrypt_field(&v)?))
+        Some(v) if is_encrypted(&v) => match key {
+            Some(key) => Ok(Some(key.decrypt_field(&v)?)),
+            None => Ok(None), // encrypted field, no key → skip
         },
         other => Ok(other),
     }

--- a/crates/aptos-cli-common/src/types.rs
+++ b/crates/aptos-cli-common/src/types.rs
@@ -88,6 +88,10 @@ pub enum CliError {
     SimulationError(String),
     #[error("Coverage failed with status: {0}")]
     CoverageError(String),
+    #[error("Encryption error: {0}")]
+    EncryptionError(String),
+    #[error("Wrong password or corrupted encrypted config")]
+    WrongPassword,
 }
 
 impl CliError {
@@ -109,6 +113,8 @@ impl CliError {
             CliError::UnexpectedError(_) => "UnexpectedError",
             CliError::SimulationError(_) => "SimulationError",
             CliError::CoverageError(_) => "CoverageError",
+            CliError::EncryptionError(_) => "EncryptionError",
+            CliError::WrongPassword => "WrongPassword",
         }
     }
 }

--- a/crates/aptos/CHANGELOG.md
+++ b/crates/aptos/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to the Aptos CLI will be captured in this file. This project
 
 # Unreleased
 - Add linter rules `unused_function`, `unused_struct`, and `unused_constant`.
+- **Config encryption**: Encrypt sensitive fields (`private_key`, `node_api_key`, `faucet_auth_token`) in `.aptos/config.yaml` with AES-256-GCM using a password-derived key (Argon2id, 128 MiB memory cost). New commands: `aptos config encrypt` and `aptos config decrypt`.
+- **Optional OS keyring caching**: Pass `--use-keyring` during encryption to store the password in macOS Keychain, Windows Credential Manager, or Linux Secret Service. Requires the `keyring-cache` build feature (opt-in, not default).
+- **`--network` flag**: `--network mainnet|testnet|devnet` auto-resolves well-known REST and faucet URLs, so `--rest-url` and `--faucet-url` are no longer required for standard networks.
+- **Lazy decryption**: Read-only commands (`account balance`, `account list`, `config show-profiles`, etc.) skip encrypted fields entirely and never prompt for a password.
+- **`aptos init --encrypt`**: Encrypt the config immediately after initialization.
+- Improved `--help` documentation across CLI commands (governance, staking, accounts, config).
+- Security: constant-time key verification, AES-GCM AAD field binding, zeroized key/password material on drop.
 
 ## [8.1.0]
 - Transaction Simulation Session: add gas profiler support

--- a/crates/aptos/CHANGELOG.md
+++ b/crates/aptos/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to the Aptos CLI will be captured in this file. This project
 - **Lazy decryption**: Read-only commands (`account balance`, `account list`, `config show-profiles`, etc.) skip encrypted fields entirely and never prompt for a password.
 - **`aptos init --encrypt`**: Encrypt the config immediately after initialization.
 - Improved `--help` documentation across CLI commands (governance, staking, accounts, config).
-- Security: constant-time key verification, AES-GCM AAD field binding, zeroized key/password material on drop.
+- Security: constant-time key verification, AES-GCM AAD field binding, `DerivedKey` zeroized on drop, password cache wrapped in `Zeroizing<String>`, AIP-80 key format preserved during encryption round-trips.
 
 ## [8.1.0]
 - Transaction Simulation Session: add gas profiler support

--- a/crates/aptos/Cargo.toml
+++ b/crates/aptos/Cargo.toml
@@ -91,7 +91,8 @@ url = { workspace = true }
 jemallocator = { workspace = true }
 
 [features]
-default = []
+default = ["keyring-cache"]
+keyring-cache = ["aptos-cli-common/keyring-cache"]
 fuzzing = []
 no-upload-proposal = []
 cli-framework-test-move = []

--- a/crates/aptos/Cargo.toml
+++ b/crates/aptos/Cargo.toml
@@ -91,7 +91,7 @@ url = { workspace = true }
 jemallocator = { workspace = true }
 
 [features]
-default = ["keyring-cache"]
+default = []
 keyring-cache = ["aptos-cli-common/keyring-cache"]
 fuzzing = []
 no-upload-proposal = []

--- a/crates/aptos/README.md
+++ b/crates/aptos/README.md
@@ -3,3 +3,52 @@
 The `aptos` tool is a command line interface (CLI) for debugging, development, and node operation.
 
 See [Aptos CLI Documentation](https://aptos.dev/tools/aptos-cli/) for how to install the `aptos` CLI tool and how to use it.
+
+## Config Encryption
+
+The CLI can encrypt sensitive fields in `.aptos/config.yaml` (private keys, API keys, auth tokens) while keeping non-sensitive fields (network, URLs, public keys, account addresses) in plaintext.
+
+### Enable encryption
+
+```bash
+aptos config encrypt
+```
+
+You'll be prompted to enter and confirm a password. The password is used to derive an AES-256-GCM key via Argon2id.
+
+### Enable encryption with OS keyring caching
+
+```bash
+aptos config encrypt --use-keyring
+```
+
+This stores the password in your OS keyring (macOS Keychain, Windows Credential Manager, or Linux Secret Service) so you don't have to re-enter it for commands that need sensitive fields.
+
+> **Note:** Keyring support requires the `keyring-cache` build feature. Pre-built releases include it for macOS and Windows. On Linux, install `libdbus-1-dev` (Debian/Ubuntu) or `dbus-devel` (Fedora) and build with `cargo build -p aptos --features keyring-cache`.
+
+### Disable encryption
+
+```bash
+aptos config decrypt
+```
+
+This decrypts all fields, removes the `encryption:` section, and clears any stored keyring entry.
+
+### Password entry
+
+When a command needs to decrypt sensitive fields, the password is resolved in order:
+
+1. `APTOS_CONFIG_PASSWORD` environment variable
+2. OS keyring (if `--use-keyring` was used during encryption)
+3. Interactive terminal prompt
+
+Read-only commands like `aptos account balance` or `aptos account list` skip encrypted fields entirely and never prompt for a password.
+
+### Changing the password
+
+Decrypt first, then re-encrypt:
+
+```bash
+aptos config decrypt
+aptos config encrypt
+```

--- a/crates/aptos/scripts/check_dynamic_deps.sh
+++ b/crates/aptos/scripts/check_dynamic_deps.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # This script checks if the CLI depends on external deps that it shouldn't. We run this
 # in CI to make sure we don't accidentally reintroduce deps that would make the CLI
@@ -24,7 +24,7 @@ for dep in "${deps[@]}"; do
     echo "Checking for banned dependency $dep..."
 
     # Check for deps. As you can see, we only check for MacOS right now.
-    out=`cargo tree -e features,no-build,no-dev --target aarch64-apple-darwin -p aptos -i "$dep"`
+    out=$(cargo tree -e features,no-build,no-dev --target aarch64-apple-darwin -p aptos -i "$dep")
 
     # If the exit status was non-zero, great, the dep couldn't be found.
     if [ $? -ne 0 ]; then

--- a/crates/aptos/src/account/balance.rs
+++ b/crates/aptos/src/account/balance.rs
@@ -16,15 +16,16 @@ use move_core_types::{
 use serde::Serialize;
 
 /// Show the account's balance of different coins
-///
-/// TODO: Fungible assets
 #[derive(Debug, Parser)]
 pub struct Balance {
     /// Address of the account you want to list resources/modules/balance for
     #[clap(long, value_parser = crate::common::types::load_account_arg)]
     pub(crate) account: Option<AccountAddress>,
 
-    /// Coin type to lookup.  Defaults to 0x1::aptos_coin::AptosCoin
+    /// Coin type or fungible asset address to look up
+    ///
+    /// Accepts a Move type tag (e.g. `0x1::aptos_coin::AptosCoin`) or a fungible asset
+    /// object address (hex literal). Defaults to `0x1::aptos_coin::AptosCoin`.
     #[clap(long)]
     pub(crate) coin_type: Option<String>,
 

--- a/crates/aptos/src/account/balance.rs
+++ b/crates/aptos/src/account/balance.rs
@@ -51,7 +51,7 @@ impl CliCommand<Vec<AccountBalance>> for Balance {
     async fn execute(self) -> CliTypedResult<Vec<AccountBalance>> {
         let account = if let Some(account) = self.account {
             account
-        } else if let Some(Some(account)) = CliConfig::load_profile(
+        } else if let Some(Some(account)) = CliConfig::load_profile_public(
             self.profile_options.profile_name(),
             ConfigSearchMode::CurrentDirAndParents,
         )?

--- a/crates/aptos/src/account/fund.rs
+++ b/crates/aptos/src/account/fund.rs
@@ -50,7 +50,13 @@ impl CliCommand<String> for FundWithFaucet {
         };
         let client = self.rest_options.client(&self.profile_options)?;
         self.faucet_options
-            .fund_account(client, &self.profile_options, self.amount, address)
+            .fund_account(
+                client,
+                &self.profile_options,
+                self.rest_options.network,
+                self.amount,
+                address,
+            )
             .await?;
         return Ok(format!(
             "Added {} Octas to account {}",

--- a/crates/aptos/src/account/key_rotation.rs
+++ b/crates/aptos/src/account/key_rotation.rs
@@ -57,6 +57,9 @@ pub(crate) struct NewAuthKeyOptions {
     pub(crate) new_private_key_file: Option<PathBuf>,
 
     /// New private key encoded in the type from `--encoding`
+    ///
+    /// Mutually exclusive with `--new-private-key-file`, `--new-derivation-path`,
+    /// and `--new-derivation-index`
     #[clap(long)]
     pub(crate) new_private_key: Option<String>,
 
@@ -81,7 +84,7 @@ pub(crate) struct NewProfileOptions {
     #[clap(long)]
     pub(crate) skip_saving_profile: bool,
 
-    /// Name of new the profile to save for the new authentication key
+    /// Name of the new profile to save for the new authentication key
     #[clap(long)]
     pub(crate) save_to_profile: Option<String>,
 }

--- a/crates/aptos/src/account/list.rs
+++ b/crates/aptos/src/account/list.rs
@@ -73,7 +73,7 @@ impl CliCommand<Vec<serde_json::Value>> for ListAccount {
     async fn execute(self) -> CliTypedResult<Vec<serde_json::Value>> {
         let account = if let Some(account) = self.account {
             account
-        } else if let Some(Some(account)) = CliConfig::load_profile(
+        } else if let Some(Some(account)) = CliConfig::load_profile_public(
             self.profile_options.profile_name(),
             ConfigSearchMode::CurrentDirAndParents,
         )?

--- a/crates/aptos/src/account/mod.rs
+++ b/crates/aptos/src/account/mod.rs
@@ -47,7 +47,10 @@ impl AccountTool {
     }
 }
 
-/// Tool for interacting with multisig accounts
+/// Tool for interacting with multisig (v2) accounts
+///
+/// Multisig accounts require multiple owner signatures to execute transactions.
+/// The typical workflow is: create → create-transaction → approve → execute.
 #[derive(Debug, Subcommand)]
 pub enum MultisigAccountTool {
     Approve(multisig_account::Approve),

--- a/crates/aptos/src/account/multisig_account.rs
+++ b/crates/aptos/src/account/multisig_account.rs
@@ -147,7 +147,10 @@ impl CliCommand<TransactionSummary> for CreateTransaction {
     }
 }
 
-/// Verify entry function matches on-chain transaction proposal.
+/// Verify that a local entry function matches an on-chain multisig transaction proposal
+///
+/// Compares the payload hash of the provided entry function arguments against the on-chain
+/// transaction proposal to confirm they match before approving or executing.
 #[derive(Debug, Parser)]
 pub struct VerifyProposal {
     #[clap(flatten)]

--- a/crates/aptos/src/account/transfer.rs
+++ b/crates/aptos/src/account/transfer.rs
@@ -13,10 +13,10 @@ use clap::Parser;
 use serde::Serialize;
 use std::collections::BTreeMap;
 
-// TODO: Add ability to transfer non-APT coins
-// TODO: Add ability to not create account by default
 /// Transfer APT between accounts
 ///
+/// If the receiving account does not exist, it will be created automatically.
+/// Amounts are specified in Octas (10^-8 APT).
 #[derive(Debug, Parser)]
 pub struct TransferCoins {
     /// Address of account to send APT to

--- a/crates/aptos/src/common/init.rs
+++ b/crates/aptos/src/common/init.rs
@@ -91,6 +91,16 @@ impl CliCommand<()> for InitTool {
 
     #[allow(clippy::literal_string_with_formatting_args)]
     async fn execute(self) -> CliTypedResult<()> {
+        #[cfg(not(feature = "keyring-cache"))]
+        if self.use_keyring {
+            return Err(CliError::CommandArgumentError(
+                "--use-keyring requires the `keyring-cache` build feature. Pre-built releases \
+                 for macOS and Windows include it. On Linux, build with \
+                 `--features keyring-cache` after installing libdbus-1-dev."
+                    .to_string(),
+            ));
+        }
+
         let mut config = if CliConfig::config_exists(ConfigSearchMode::CurrentDir) {
             CliConfig::load(ConfigSearchMode::CurrentDir)?
         } else {

--- a/crates/aptos/src/common/init.rs
+++ b/crates/aptos/src/common/init.rs
@@ -365,10 +365,21 @@ impl CliCommand<()> for InitTool {
         if self.encrypt {
             let mut config = CliConfig::load(ConfigSearchMode::CurrentDir)?;
             let password = encryption::prompt_new_password()?;
-            let enc_config = EncryptionConfig::new(&password, self.use_keyring)?;
+
+            let use_keyring = self.use_keyring;
+            #[cfg(feature = "keyring-cache")]
+            let use_keyring = if !use_keyring && std::env::var("APTOS_CONFIG_PASSWORD").is_err() {
+                crate::common::utils::prompt_yes(
+                    "Would you like to store the password in your OS keyring?",
+                )
+            } else {
+                use_keyring
+            };
+
+            let enc_config = EncryptionConfig::new(&password, use_keyring)?;
 
             #[cfg(feature = "keyring-cache")]
-            if self.use_keyring {
+            if use_keyring {
                 let config_dir = CliConfig::aptos_folder(ConfigSearchMode::CurrentDir)?;
                 encryption::keyring_store(&password, &config_dir)?;
                 eprintln!("Password stored in OS keyring.");

--- a/crates/aptos/src/common/init.rs
+++ b/crates/aptos/src/common/init.rs
@@ -17,6 +17,7 @@ use crate::{
         },
     },
 };
+use aptos_cli_common::encryption::{self, EncryptionConfig};
 use aptos_crypto::{ed25519::Ed25519PrivateKey, PrivateKey, ValidCryptoMaterialStringExt};
 use aptos_ledger;
 use async_trait::async_trait;
@@ -69,6 +70,17 @@ pub struct InitTool {
     pub(crate) prompt_options: PromptOptions,
     #[clap(flatten)]
     pub(crate) encoding_options: EncodingOptions,
+
+    /// Encrypt the config with a password after initialization
+    ///
+    /// Sensitive fields (private keys, API keys, auth tokens) will be encrypted
+    /// using AES-256-GCM with a key derived from your password via Argon2id.
+    #[clap(long)]
+    pub encrypt: bool,
+
+    /// Cache the encryption password in the OS keyring (requires --encrypt)
+    #[clap(long, requires = "encrypt")]
+    pub use_keyring: bool,
 }
 
 #[async_trait]
@@ -366,6 +378,23 @@ impl CliCommand<()> for InitTool {
                 "See the account here: {}",
                 explorer_account_link(address, Some(network))
             );
+        }
+
+        // Encrypt config if requested
+        if self.encrypt {
+            let mut config = CliConfig::load(ConfigSearchMode::CurrentDir)?;
+            let password = encryption::prompt_new_password()?;
+            let enc_config = EncryptionConfig::new(&password, self.use_keyring)?;
+
+            #[cfg(feature = "keyring-cache")]
+            if self.use_keyring {
+                encryption::keyring_store(&password)?;
+                eprintln!("Password stored in OS keyring.");
+            }
+
+            config.encryption = Some(enc_config);
+            config.save()?;
+            eprintln!("Config encrypted successfully.");
         }
 
         Ok(())

--- a/crates/aptos/src/common/init.rs
+++ b/crates/aptos/src/common/init.rs
@@ -369,7 +369,8 @@ impl CliCommand<()> for InitTool {
 
             #[cfg(feature = "keyring-cache")]
             if self.use_keyring {
-                encryption::keyring_store(&password)?;
+                let config_dir = CliConfig::aptos_folder(ConfigSearchMode::CurrentDir)?;
+                encryption::keyring_store(&password, &config_dir)?;
                 eprintln!("Password stored in OS keyring.");
             }
 

--- a/crates/aptos/src/common/init.rs
+++ b/crates/aptos/src/common/init.rs
@@ -147,30 +147,11 @@ impl CliCommand<()> for InitTool {
 
         // Ensure that there is at least a REST URL set for the network
         match network {
-            Network::Mainnet => {
-                profile_config.rest_url =
-                    Some("https://fullnode.mainnet.aptoslabs.com".to_string());
-                profile_config.faucet_url = None;
-            },
-            Network::Testnet => {
-                profile_config.rest_url =
-                    Some("https://fullnode.testnet.aptoslabs.com".to_string());
-                // The faucet in testnet is only accessible with some kind of bypass.
-                // For regular users this can only really mean an auth token. So if
-                // there is no auth token set, we don't set the faucet URL. If the user
-                // is confident they want to use the testnet faucet without a token
-                // they can set it manually with `--network custom` and `--faucet-url`.
-                profile_config.faucet_url = None;
-            },
-            Network::Devnet => {
-                profile_config.rest_url = Some("https://fullnode.devnet.aptoslabs.com".to_string());
-                profile_config.faucet_url = Some("https://faucet.devnet.aptoslabs.com".to_string());
-            },
-            Network::Local => {
-                profile_config.rest_url = Some("http://localhost:8080".to_string());
-                profile_config.faucet_url = Some("http://localhost:8081".to_string());
-            },
             Network::Custom => self.custom_network(&mut profile_config)?,
+            _ => {
+                profile_config.rest_url = network.default_rest_url().map(|s| s.to_string());
+                profile_config.faucet_url = network.default_faucet_url().map(|s| s.to_string());
+            },
         }
 
         // Check if any ledger flag is set

--- a/crates/aptos/src/config/mod.rs
+++ b/crates/aptos/src/config/mod.rs
@@ -127,6 +127,9 @@ impl CliCommand<GlobalConfig> for SetGlobalConfig {
 }
 
 /// Show the private key for the given profile
+///
+/// WARNING: This outputs the private key to stdout in plaintext. Anyone with access
+/// to this key can control the associated account. Use with caution.
 #[derive(Parser, Debug)]
 pub struct ShowPrivateKey {
     /// Which profile's private key to show
@@ -210,7 +213,7 @@ impl CliCommand<BTreeMap<String, ProfileSummary>> for ShowProfiles {
     }
 }
 
-/// Delete the specified profile.
+/// Delete the specified profile
 #[derive(Parser, Debug)]
 pub struct DeleteProfile {
     /// Which profile to delete
@@ -250,7 +253,7 @@ impl CliCommand<String> for DeleteProfile {
     }
 }
 
-/// Rename the specified profile.
+/// Rename the specified profile
 #[derive(Parser, Debug)]
 pub struct RenameProfile {
     /// Which profile to rename
@@ -386,7 +389,7 @@ impl CliCommand<()> for DecryptConfig {
     }
 }
 
-/// Shows the properties in the global config
+/// Show the global configuration stored in ~/.aptos/global_config.yaml
 #[derive(Parser, Debug)]
 pub struct ShowGlobalConfig {}
 

--- a/crates/aptos/src/config/mod.rs
+++ b/crates/aptos/src/config/mod.rs
@@ -12,7 +12,10 @@ use crate::{
     genesis::git::{from_yaml, to_yaml},
     Tool,
 };
-use aptos_cli_common::generate_cli_completions;
+use aptos_cli_common::{
+    encryption::{self, EncryptionConfig},
+    generate_cli_completions,
+};
 use aptos_crypto::ValidCryptoMaterialStringExt;
 use async_trait::async_trait;
 use clap::{Parser, ValueEnum};
@@ -33,12 +36,16 @@ pub enum ConfigTool {
     ShowPrivateKey(ShowPrivateKey),
     RenameProfile(RenameProfile),
     DeleteProfile(DeleteProfile),
+    Encrypt(EncryptConfig),
+    Decrypt(DecryptConfig),
 }
 
 impl ConfigTool {
     pub async fn execute(self) -> CliResult {
         match self {
             ConfigTool::DeleteProfile(tool) => tool.execute_serialized().await,
+            ConfigTool::Encrypt(tool) => tool.execute_serialized_success().await,
+            ConfigTool::Decrypt(tool) => tool.execute_serialized_success().await,
             ConfigTool::GenerateShellCompletions(tool) => tool.execute_serialized_success().await,
             ConfigTool::RenameProfile(tool) => tool.execute_serialized().await,
             ConfigTool::SetGlobalConfig(tool) => tool.execute_serialized().await,
@@ -182,6 +189,7 @@ impl CliCommand<BTreeMap<String, ProfileSummary>> for ShowProfiles {
     async fn execute(self) -> CliTypedResult<BTreeMap<String, ProfileSummary>> {
         // Load the profile config
         let config = CliConfig::load(ConfigSearchMode::CurrentDir)?;
+        let is_encrypted = config.encryption.is_some();
         Ok(config
             .profiles
             .unwrap_or_default()
@@ -193,7 +201,11 @@ impl CliCommand<BTreeMap<String, ProfileSummary>> for ShowProfiles {
                     true
                 }
             })
-            .map(|(key, profile)| (key, ProfileSummary::from(&profile)))
+            .map(|(key, profile)| {
+                let mut summary = ProfileSummary::from(&profile);
+                summary.encrypted = is_encrypted;
+                (key, summary)
+            })
             .collect())
     }
 }
@@ -288,6 +300,89 @@ impl CliCommand<String> for RenameProfile {
                 "Config has no profiles".to_string(),
             ))
         }
+    }
+}
+
+/// Encrypt all sensitive fields in the current config
+///
+/// Prompts for a password, derives an AES-256-GCM encryption key via Argon2id,
+/// and encrypts private keys, API keys, and auth tokens in place. Non-sensitive
+/// fields (network, URLs, public keys, account addresses) remain readable.
+#[derive(Parser, Debug)]
+pub struct EncryptConfig {
+    /// Cache the password in the OS keyring so you don't have to re-enter it
+    #[clap(long)]
+    pub use_keyring: bool,
+}
+
+#[async_trait]
+impl CliCommand<()> for EncryptConfig {
+    fn command_name(&self) -> &'static str {
+        "EncryptConfig"
+    }
+
+    async fn execute(self) -> CliTypedResult<()> {
+        // Load existing config (plaintext — will fail if already encrypted and no password)
+        let mut config = CliConfig::load(ConfigSearchMode::CurrentDir)?;
+
+        if config.encryption.is_some() {
+            return Err(CliError::CommandArgumentError(
+                "Config is already encrypted. Decrypt first with `aptos config decrypt`."
+                    .to_string(),
+            ));
+        }
+
+        let password = encryption::prompt_new_password()?;
+        let enc_config = EncryptionConfig::new(&password, self.use_keyring)?;
+
+        #[cfg(feature = "keyring-cache")]
+        if self.use_keyring {
+            encryption::keyring_store(&password)?;
+            eprintln!("Password stored in OS keyring.");
+        }
+
+        config.encryption = Some(enc_config);
+        config.save()?;
+
+        eprintln!("Config encrypted successfully.");
+        Ok(())
+    }
+}
+
+/// Decrypt all sensitive fields and remove encryption from the config
+///
+/// Prompts for the config password, decrypts all encrypted fields, removes the
+/// `encryption:` section, and saves as plaintext. Also clears the OS keyring entry
+/// if one was stored.
+#[derive(Parser, Debug)]
+pub struct DecryptConfig {}
+
+#[async_trait]
+impl CliCommand<()> for DecryptConfig {
+    fn command_name(&self) -> &'static str {
+        "DecryptConfig"
+    }
+
+    async fn execute(self) -> CliTypedResult<()> {
+        // Load will decrypt in memory
+        let mut config = CliConfig::load(ConfigSearchMode::CurrentDir)?;
+
+        if config.encryption.is_none() {
+            return Err(CliError::CommandArgumentError(
+                "Config is not encrypted.".to_string(),
+            ));
+        }
+
+        // Clear keyring entry if it was stored
+        #[cfg(feature = "keyring-cache")]
+        encryption::keyring_clear()?;
+
+        // Remove encryption section and save as plaintext
+        config.encryption = None;
+        config.save()?;
+
+        eprintln!("Config decrypted successfully.");
+        Ok(())
     }
 }
 

--- a/crates/aptos/src/config/mod.rs
+++ b/crates/aptos/src/config/mod.rs
@@ -7,7 +7,9 @@ use crate::{
             CliCommand, CliConfig, CliError, CliResult, CliTypedResult, ConfigSearchMode,
             ProfileSummary, APTOS_FOLDER_GIT_IGNORE, CONFIG_FOLDER, GIT_IGNORE,
         },
-        utils::{create_dir_if_not_exist, current_dir, read_from_file, write_to_user_only_file},
+        utils::{
+            create_dir_if_not_exist, current_dir, read_from_file, write_to_user_only_file,
+        },
     },
     genesis::git::{from_yaml, to_yaml},
     Tool,
@@ -359,10 +361,23 @@ impl CliCommand<()> for EncryptConfig {
         }
 
         let password = encryption::prompt_new_password()?;
-        let enc_config = EncryptionConfig::new(&password, self.use_keyring)?;
+
+        // If keyring feature is available and user didn't pass --use-keyring,
+        // offer it interactively (skip if password came from env var / cache).
+        let use_keyring = self.use_keyring;
+        #[cfg(feature = "keyring-cache")]
+        let use_keyring = if !use_keyring && std::env::var("APTOS_CONFIG_PASSWORD").is_err() {
+            crate::common::utils::prompt_yes(
+                "Would you like to store the password in your OS keyring?",
+            )
+        } else {
+            use_keyring
+        };
+
+        let enc_config = EncryptionConfig::new(&password, use_keyring)?;
 
         #[cfg(feature = "keyring-cache")]
-        if self.use_keyring {
+        if use_keyring {
             let config_dir = CliConfig::aptos_folder(ConfigSearchMode::CurrentDir)?;
             encryption::keyring_store(&password, &config_dir)?;
             eprintln!("Password stored in OS keyring.");

--- a/crates/aptos/src/config/mod.rs
+++ b/crates/aptos/src/config/mod.rs
@@ -190,8 +190,8 @@ impl CliCommand<BTreeMap<String, ProfileSummary>> for ShowProfiles {
     }
 
     async fn execute(self) -> CliTypedResult<BTreeMap<String, ProfileSummary>> {
-        // Load the profile config
-        let config = CliConfig::load(ConfigSearchMode::CurrentDir)?;
+        // Use load_public so listing profiles never requires a password
+        let config = CliConfig::load_public(ConfigSearchMode::CurrentDir)?;
         let is_encrypted = config.encryption.is_some();
         Ok(config
             .profiles
@@ -348,8 +348,8 @@ impl CliCommand<()> for EncryptConfig {
     }
 
     async fn execute(self) -> CliTypedResult<()> {
-        // Load existing config (plaintext — will fail if already encrypted and no password)
-        let mut config = CliConfig::load(ConfigSearchMode::CurrentDir)?;
+        // Use load_public to avoid prompting for password just to detect already-encrypted state
+        let mut config = CliConfig::load_public(ConfigSearchMode::CurrentDir)?;
 
         if config.encryption.is_some() {
             return Err(CliError::CommandArgumentError(

--- a/crates/aptos/src/config/mod.rs
+++ b/crates/aptos/src/config/mod.rs
@@ -7,9 +7,7 @@ use crate::{
             CliCommand, CliConfig, CliError, CliResult, CliTypedResult, ConfigSearchMode,
             ProfileSummary, APTOS_FOLDER_GIT_IGNORE, CONFIG_FOLDER, GIT_IGNORE,
         },
-        utils::{
-            create_dir_if_not_exist, current_dir, read_from_file, write_to_user_only_file,
-        },
+        utils::{create_dir_if_not_exist, current_dir, read_from_file, write_to_user_only_file},
     },
     genesis::git::{from_yaml, to_yaml},
     Tool,

--- a/crates/aptos/src/config/mod.rs
+++ b/crates/aptos/src/config/mod.rs
@@ -348,6 +348,16 @@ impl CliCommand<()> for EncryptConfig {
     }
 
     async fn execute(self) -> CliTypedResult<()> {
+        #[cfg(not(feature = "keyring-cache"))]
+        if self.use_keyring {
+            return Err(CliError::CommandArgumentError(
+                "--use-keyring requires the `keyring-cache` build feature. Pre-built releases \
+                 for macOS and Windows include it. On Linux, build with \
+                 `--features keyring-cache` after installing libdbus-1-dev."
+                    .to_string(),
+            ));
+        }
+
         // Use load_public to avoid prompting for password just to detect already-encrypted state
         let mut config = CliConfig::load_public(ConfigSearchMode::CurrentDir)?;
 

--- a/crates/aptos/src/config/mod.rs
+++ b/crates/aptos/src/config/mod.rs
@@ -308,12 +308,35 @@ impl CliCommand<String> for RenameProfile {
 
 /// Encrypt all sensitive fields in the current config
 ///
-/// Prompts for a password, derives an AES-256-GCM encryption key via Argon2id,
-/// and encrypts private keys, API keys, and auth tokens in place. Non-sensitive
-/// fields (network, URLs, public keys, account addresses) remain readable.
+/// Prompts for a new password (entered twice for confirmation), derives an
+/// AES-256-GCM encryption key via Argon2id, and encrypts sensitive fields in
+/// `.aptos/config.yaml` in place.
+///
+/// Encrypted fields: `private_key`, `node_api_key`, `faucet_auth_token`.
+/// Non-sensitive fields remain in plaintext: `network`, `rest_url`, `faucet_url`,
+/// `public_key`, `account`, `derivation_path`.
+///
+/// Read-only commands (e.g. `account balance`, `account list`) do not require
+/// the password — they skip encrypted fields automatically.
+///
+/// The password can be provided in three ways (checked in order):
+///   1. `APTOS_CONFIG_PASSWORD` environment variable
+///   2. OS keyring (if `--use-keyring` was set during encryption)
+///   3. Interactive terminal prompt
+///
+/// To change your password, decrypt first then re-encrypt:
+///   `aptos config decrypt && aptos config encrypt`
 #[derive(Parser, Debug)]
 pub struct EncryptConfig {
     /// Cache the password in the OS keyring so you don't have to re-enter it
+    ///
+    /// Uses macOS Keychain, Windows Credential Manager, or Linux Secret Service.
+    /// The password persists across terminal sessions until you decrypt or
+    /// clear it manually.
+    ///
+    /// Requires the `keyring-cache` build feature (included in pre-built releases
+    /// for macOS and Windows). On Linux, build with `--features keyring-cache`
+    /// after installing libdbus-1-dev.
     #[clap(long)]
     pub use_keyring: bool,
 }
@@ -340,7 +363,8 @@ impl CliCommand<()> for EncryptConfig {
 
         #[cfg(feature = "keyring-cache")]
         if self.use_keyring {
-            encryption::keyring_store(&password)?;
+            let config_dir = CliConfig::aptos_folder(ConfigSearchMode::CurrentDir)?;
+            encryption::keyring_store(&password, &config_dir)?;
             eprintln!("Password stored in OS keyring.");
         }
 
@@ -354,9 +378,13 @@ impl CliCommand<()> for EncryptConfig {
 
 /// Decrypt all sensitive fields and remove encryption from the config
 ///
-/// Prompts for the config password, decrypts all encrypted fields, removes the
-/// `encryption:` section, and saves as plaintext. Also clears the OS keyring entry
-/// if one was stored.
+/// Prompts for the config password (or reads it from `APTOS_CONFIG_PASSWORD` /
+/// OS keyring), decrypts all encrypted fields, removes the `encryption:` section
+/// from `.aptos/config.yaml`, and saves as plaintext. Also clears the OS keyring
+/// entry if one was stored.
+///
+/// After decryption, sensitive fields (private keys, API keys, auth tokens) will
+/// be visible in plaintext in the config file.
 #[derive(Parser, Debug)]
 pub struct DecryptConfig {}
 
@@ -378,7 +406,10 @@ impl CliCommand<()> for DecryptConfig {
 
         // Clear keyring entry if it was stored
         #[cfg(feature = "keyring-cache")]
-        encryption::keyring_clear()?;
+        {
+            let config_dir = CliConfig::aptos_folder(ConfigSearchMode::CurrentDir)?;
+            encryption::keyring_clear(&config_dir)?;
+        }
 
         // Remove encryption section and save as plaintext
         config.encryption = None;

--- a/crates/aptos/src/governance/mod.rs
+++ b/crates/aptos/src/governance/mod.rs
@@ -280,6 +280,10 @@ async fn get_proposal(
 }
 
 /// Submit a governance proposal
+///
+/// The proposer must have a staked amount that meets the on-chain minimum proposal threshold.
+/// Requires a compiled Move script and JSON metadata hosted at a publicly accessible URL.
+/// Use `--is-multi-step` for proposals that require multiple execution steps (e.g. framework upgrades).
 #[derive(Parser)]
 pub struct SubmitProposal {
     #[clap(flatten)]
@@ -305,6 +309,7 @@ pub struct SubmitProposalArgs {
     #[clap(long)]
     pub(crate) metadata_path: Option<PathBuf>,
 
+    /// Use multi-step proposal format (required for framework upgrades and large packages)
     #[clap(long)]
     pub(crate) is_multi_step: bool,
 
@@ -717,11 +722,14 @@ impl CliCommand<Vec<TransactionSummary>> for SubmitVote {
     }
 }
 
-/// Submit a transaction to approve a proposal's script hash to bypass the transaction size limit.
-/// This is needed for upgrading large packages such as aptos-framework.
+/// Approve a proposal's execution hash for multi-step execution
+///
+/// Registers the script hash on-chain so the proposal can be executed without including
+/// the full script in the execution transaction. Required for large packages like
+/// aptos-framework that exceed the transaction size limit.
 #[derive(Parser)]
 pub struct ApproveExecutionHash {
-    /// Id of the proposal to vote on
+    /// Id of the proposal to approve the execution hash for
     #[clap(long)]
     pub(crate) proposal_id: u64,
 
@@ -806,7 +814,11 @@ impl CliCommand<TransactionSummary> for ExecuteProposal {
     }
 }
 
-/// Generates a package upgrade proposal script.
+/// Generate a Move script for a framework upgrade governance proposal
+///
+/// Builds the specified Move package, then generates a proposal script that can be
+/// submitted via `aptos governance propose`. Use `--testnet` for testnet single-step
+/// proposals, or provide `--next-execution-hash` for multi-step proposals.
 #[derive(Parser)]
 pub struct GenerateUpgradeProposal {
     /// Address of the account which the proposal addresses.
@@ -827,10 +839,13 @@ pub struct GenerateUpgradeProposal {
     #[clap(long, default_value_t = IncludedArtifacts::Sparse)]
     pub(crate) included_artifacts: IncludedArtifacts,
 
-    /// Generate the script for mainnet governance proposal by default or generate the upgrade script for testnet.
+    /// Generate a single-step testnet upgrade script instead of the default mainnet format
     #[clap(long)]
     pub(crate) testnet: bool,
 
+    /// Hex-encoded hash of the next execution step for multi-step proposals
+    ///
+    /// When provided, generates a multi-step proposal script. Leave empty for single-step proposals.
     #[clap(long, default_value = "")]
     pub(crate) next_execution_hash: String,
 

--- a/crates/aptos/src/stake/mod.rs
+++ b/crates/aptos/src/stake/mod.rs
@@ -22,7 +22,6 @@ use async_trait::async_trait;
 use clap::Parser;
 
 /// Tool for manipulating stake and stake pools
-///
 #[derive(Parser)]
 pub enum StakeTool {
     AddStake(AddStake),
@@ -495,22 +494,23 @@ impl CliCommand<Vec<TransactionSummary>> for SetDelegatedVoter {
 
 /// Create a staking contract stake pool
 ///
-///
+/// Creates a new staking contract between an owner, operator, and voter.
+/// The operator runs the validator node, and the voter participates in governance.
 #[derive(Parser)]
 pub struct CreateStakingContract {
-    /// Account Address of operator
+    /// Account address of the operator who will run the validator
     #[clap(long, value_parser = crate::common::types::load_account_arg)]
     pub operator: AccountAddress,
 
-    /// Account Address of delegated voter
+    /// Account address of the delegated voter for governance
     #[clap(long, value_parser = crate::common::types::load_account_arg)]
     pub voter: AccountAddress,
 
-    /// Amount to create the staking contract with
+    /// Amount of Octas (10^-8 APT) to stake in the new contract
     #[clap(long)]
     pub amount: u64,
 
-    /// Percentage of accumulated rewards to pay the operator as commission
+    /// Percentage of accumulated rewards to pay the operator as commission (0-100)
     #[clap(long)]
     pub commission_percentage: u64,
 

--- a/crates/aptos/src/test/mod.rs
+++ b/crates/aptos/src/test/mod.rs
@@ -555,6 +555,8 @@ impl CliTestFramework {
             skip_faucet: false,
             ledger: false,
             hardware_wallet_options: Default::default(),
+            encrypt: false,
+            use_keyring: false,
         }
         .execute()
         .await


### PR DESCRIPTION
## Summary

- **Config encryption**: New `aptos config encrypt` / `aptos config decrypt` commands that encrypt sensitive fields (`private_key`, `node_api_key`, `faucet_auth_token`) in `.aptos/config.yaml` with AES-256-GCM. Key derived from a user password via Argon2id (128 MiB, t=2, p=1). Non-sensitive fields (network, URLs, public key, account) remain in plaintext.
- **Lazy decryption**: Read-only commands (`account balance`, `account list`, `config show-profiles`, etc.) skip encrypted fields and never prompt for a password.
- **`--network` flag**: `--network mainnet|testnet|devnet` auto-resolves well-known REST and faucet URLs, removing the need to pass `--rest-url` / `--faucet-url` for standard networks.
- **Optional OS keyring caching**: `--use-keyring` stores the password in macOS Keychain / Windows Credential Manager / Linux Secret Service. Gated behind the opt-in `keyring-cache` build feature to avoid libdbus dependency on Linux.
- **`aptos init --encrypt`**: Encrypt the config immediately after initialization.
- **Security hardening**: Constant-time key verification (`subtle`), AES-GCM AAD field binding (prevents ciphertext swapping between fields), `zeroize` for key material and passwords on drop.
- **Help documentation**: Improved `--help` text across governance, staking, account, and config commands.
- **Misc**: Fix `check_dynamic_deps.sh` shebang to use bash, update CHANGELOG.

## Architecture

Config loading uses a two-phase serde approach:
1. YAML → `RawCliConfig` (all values as raw strings)
2. Detect `enc:v1:` prefixed fields → derive key from password → decrypt → parse into typed `ProfileConfig`

`load_public()` / `load_profile_public()` skip phase 2 entirely, returning `None` for encrypted fields. This lets read-only commands avoid the password prompt. Commands needing sensitive fields (signing, key export) use the full `load()` path.

Password resolution order: process cache → `APTOS_CONFIG_PASSWORD` env var → OS keyring → interactive prompt.

## Test plan

- [x] `cargo test -p aptos-cli-common` — encryption round-trip, wrong password, key check verification, AAD field binding, key derivation determinism, YAML round-trip with encryption
- [x] `./scripts/rust_lint.sh` passes
- [x] Manual: `aptos init`, `aptos config encrypt`, verify `config.yaml` has `enc:v1:` fields, `aptos account balance` works without password, `aptos config decrypt` restores plaintext