### PR TITLE
[forge] Add local swarm enhancements: NUMA affinity, concurrency, Sapling support

### DIFF
--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -87,6 +87,22 @@ enum OperatorCommand {
 struct LocalSwarm {
     #[clap(long, help = "directory to build local swarm under")]
     swarmdir: Option<String>,
+    #[clap(
+        long,
+        help = "Per-node CPU affinity (colon-separated). E.g. '0-5,7-8:10-20,23' pins node 0 to CPUs 0-5,7-8 and node 1 to CPUs 10-20,23"
+    )]
+    cpu_affinity: Option<String>,
+    #[clap(
+        long,
+        help = "Per-node NUMA memory binding (colon-separated). E.g. '0:1-2:1,3' binds node 0 to NUMA node 0, node 1 to 1-2, node 2 to 1,3"
+    )]
+    mem_bind: Option<String>,
+    #[clap(
+        long,
+        help = "Execution concurrency level for each node",
+        default_value_t = 1
+    )]
+    concurrency_level: u16,
 }
 
 #[derive(Parser, Debug)]
@@ -284,12 +300,20 @@ fn main() -> Result<()> {
                             mempool_backlog: 5000,
                         }));
                     let swarm_dir = local_cfg.swarmdir.clone();
-                    let forge = Forge::new(
-                        &args.options,
-                        test_suite,
-                        duration,
-                        LocalFactory::from_workspace(swarm_dir)?,
-                    );
+                    let cpu_affinities = local_cfg
+                        .cpu_affinity
+                        .as_deref()
+                        .map(|s| s.split(':').map(String::from).collect())
+                        .unwrap_or_default();
+                    let mem_binds = local_cfg
+                        .mem_bind
+                        .as_deref()
+                        .map(|s| s.split(':').map(String::from).collect())
+                        .unwrap_or_default();
+                    let factory = LocalFactory::from_workspace(swarm_dir)?
+                        .with_node_affinities(cpu_affinities, mem_binds)
+                        .with_concurrency_level(local_cfg.concurrency_level);
+                    let forge = Forge::new(&args.options, test_suite, duration, factory);
                     run_forge(forge, &args.options)
                 },
                 TestCommand::K8sSwarm(k8s) => {

--- a/testsuite/forge/src/backend/local/cargo.rs
+++ b/testsuite/forge/src/backend/local/cargo.rs
@@ -29,6 +29,11 @@ pub fn build_consensus_only_node() -> bool {
     option_env!("CONSENSUS_ONLY_PERF_TEST").is_some()
 }
 
+/// at _forge_ compile time, override the features used to build `aptos-node`
+fn custom_node_features() -> Option<&'static str> {
+    option_env!("LOCAL_SWARM_NODE_FEATURES")
+}
+
 pub fn metadata() -> Result<Metadata> {
     let output = Command::new("cargo")
         .arg("metadata")
@@ -43,14 +48,21 @@ pub fn metadata() -> Result<Metadata> {
 /// Get the aptos node binary from the current working directory
 pub fn get_aptos_node_binary_from_worktree() -> Result<(String, PathBuf)> {
     let metadata = metadata()?;
-    let mut revision = git_rev_parse(&metadata, "HEAD")?;
-    if git_is_worktree_dirty()? {
-        revision.push_str("-dirty");
-    }
-
+    let revision = get_worktree_revision(&metadata);
     let bin_path = cargo_build_aptos_node(&metadata.workspace_root, &metadata.target_directory)?;
 
     Ok((revision, bin_path))
+}
+
+/// Best-effort revision detection. Falls back to "workspace" for non-git repos (e.g. Sapling).
+fn get_worktree_revision(metadata: &Metadata) -> String {
+    if let Ok(mut rev) = git_rev_parse(metadata, "HEAD") {
+        if git_is_worktree_dirty().unwrap_or(false) {
+            rev.push_str("-dirty");
+        }
+        return rev;
+    }
+    "workspace".to_string()
 }
 
 /// This function will attempt to build the aptos-node binary at an arbitrary revision.
@@ -159,9 +171,17 @@ pub fn git_merge_base<R: AsRef<str>>(rev: R) -> Result<String> {
 }
 
 pub fn cargo_build_common_args() -> Vec<&'static str> {
-    let mut args = vec!["build", "--features=failpoints,smoke-test"];
-    if build_consensus_only_node() {
-        args.push("--features=consensus-only-perf-test");
+    let mut args = vec!["build"];
+    if let Some(features) = custom_node_features() {
+        if !features.is_empty() {
+            args.push("--features");
+            args.push(features);
+        }
+    } else {
+        args.push("--features=failpoints,smoke-test");
+        if build_consensus_only_node() {
+            args.push("--features=consensus-only-perf-test");
+        }
     }
     if use_release() {
         args.push("--release");

--- a/testsuite/forge/src/backend/local/mod.rs
+++ b/testsuite/forge/src/backend/local/mod.rs
@@ -47,6 +47,9 @@ impl LocalVersion {
 pub struct LocalFactory {
     versions: Arc<HashMap<Version, LocalVersion>>,
     swarm_dir: Option<String>,
+    cpu_affinities: Vec<String>,
+    mem_binds: Vec<String>,
+    concurrency_level: u16,
 }
 
 impl LocalFactory {
@@ -54,7 +57,25 @@ impl LocalFactory {
         Self {
             versions: Arc::new(versions),
             swarm_dir,
+            cpu_affinities: Vec::new(),
+            mem_binds: Vec::new(),
+            concurrency_level: 1,
         }
+    }
+
+    pub fn with_concurrency_level(mut self, concurrency_level: u16) -> Self {
+        self.concurrency_level = concurrency_level;
+        self
+    }
+
+    pub fn with_node_affinities(
+        mut self,
+        cpu_affinities: Vec<String>,
+        mem_binds: Vec<String>,
+    ) -> Self {
+        self.cpu_affinities = cpu_affinities;
+        self.mem_binds = mem_binds;
+        self
     }
 
     pub fn from_workspace(swarm_dir: Option<String>) -> Result<Self> {
@@ -141,6 +162,9 @@ impl LocalFactory {
             swarmdir,
             genesis_framework,
             guard,
+            self.cpu_affinities.clone(),
+            self.mem_binds.clone(),
+            self.concurrency_level,
         )?;
 
         // Launch the swarm

--- a/testsuite/forge/src/backend/local/node.rs
+++ b/testsuite/forge/src/backend/local/node.rs
@@ -56,6 +56,8 @@ pub struct LocalNode {
     peer_id: AccountAddress,
     directory: PathBuf,
     config: NodeConfig,
+    cpu_affinity: Option<String>,
+    mem_bind: Option<String>,
 }
 
 impl LocalNode {
@@ -65,6 +67,8 @@ impl LocalNode {
         index: usize,
         directory: PathBuf,
         account_private_key: Option<ConfigKey<Ed25519PrivateKey>>,
+        cpu_affinity: Option<String>,
+        mem_bind: Option<String>,
     ) -> Result<Self> {
         let config_path = directory.join("node.yaml");
         let config = NodeConfig::load_from_path(&config_path).map_err(|error| {
@@ -87,6 +91,8 @@ impl LocalNode {
             peer_id,
             directory,
             config,
+            cpu_affinity,
+            mem_bind,
         })
     }
 
@@ -128,8 +134,20 @@ impl LocalNode {
             .append(true)
             .open(self.log_path())?;
 
-        // Start node process
-        let mut node_command = Command::new(self.version.bin());
+        // Start node process, optionally wrapped with numactl for CPU/memory affinity
+        let mut node_command = if self.cpu_affinity.is_some() || self.mem_bind.is_some() {
+            let mut cmd = Command::new("numactl");
+            if let Some(ref cpus) = self.cpu_affinity {
+                cmd.arg(format!("--physcpubind={}", cpus));
+            }
+            if let Some(ref mem) = self.mem_bind {
+                cmd.arg(format!("--membind={}", mem));
+            }
+            cmd.arg(self.version.bin());
+            cmd
+        } else {
+            Command::new(self.version.bin())
+        };
         node_command
             .current_dir(&self.directory)
             .arg("-f")

--- a/testsuite/forge/src/backend/local/swarm.rs
+++ b/testsuite/forge/src/backend/local/swarm.rs
@@ -98,6 +98,8 @@ pub struct LocalSwarm {
     root_account: Arc<LocalAccount>,
     chain_id: ChainId,
     root_key: ConfigKey<Ed25519PrivateKey>,
+    cpu_affinities: Vec<String>,
+    mem_binds: Vec<String>,
 
     launched: bool,
     #[allow(dead_code)]
@@ -116,6 +118,9 @@ impl LocalSwarm {
         dir: Option<PathBuf>,
         genesis_framework: Option<ReleaseBundle>,
         guard: ActiveNodesGuard,
+        cpu_affinities: Vec<String>,
+        mem_binds: Vec<String>,
+        concurrency_level: u16,
     ) -> Result<LocalSwarm>
     where
         R: ::rand::RngCore + ::rand::CryptoRng,
@@ -139,8 +144,7 @@ impl LocalSwarm {
             )?
             .with_num_validators(number_of_validators)
             .with_init_config(Some(Arc::new(move |index, config, base| {
-                // for local tests, turn off parallel execution:
-                config.execution.concurrency_level = 1;
+                config.execution.concurrency_level = concurrency_level;
 
                 // Single node orders blocks too fast which would trigger backpressure and stall for 1 sec
                 // which cause flakiness in tests.
@@ -186,6 +190,8 @@ impl LocalSwarm {
                     v.index,
                     v.dir,
                     v.account_private_key,
+                    cpu_affinities.get(v.index).cloned(),
+                    mem_binds.get(v.index).cloned(),
                 )?;
                 Ok((node.peer_id(), node))
             })
@@ -258,6 +264,8 @@ impl LocalSwarm {
             root_account,
             chain_id: ChainId::test(),
             root_key,
+            cpu_affinities,
+            mem_binds,
             launched: false,
             guard,
         })
@@ -373,6 +381,8 @@ impl LocalSwarm {
             index,
             fullnode_config.dir,
             None,
+            self.cpu_affinities.get(index).cloned(),
+            self.mem_binds.get(index).cloned(),
         )?;
 
         let peer_id = fullnode.peer_id();
@@ -403,6 +413,8 @@ impl LocalSwarm {
             index,
             fullnode_config.dir,
             None,
+            self.cpu_affinities.get(index).cloned(),
+            self.mem_binds.get(index).cloned(),
         )?;
 
         let peer_id = fullnode.peer_id();


### PR DESCRIPTION

- Make git revision detection best-effort so forge works in non-git repos
  (e.g. Sapling), falling back to "workspace" as the version identifier
- Add --cpu-affinity and --mem-bind CLI args for per-node NUMA pinning
  via numactl (colon-separated, indexed by node order)
- Add --concurrency-level CLI arg to override execution concurrency
  (default 1, matching previous hardcoded behavior)
- Add LOCAL_SWARM_NODE_FEATURES compile-time env var to override the
  default cargo features (failpoints,smoke-test) when building aptos-node

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes how local swarm nodes are built/versioned and launched (optional `numactl` wrapping and execution concurrency), which can affect local test reliability and requires `numactl` when affinities are used.
> 
> **Overview**
> Improves the local Forge swarm workflow by adding CLI support for per-node CPU affinity and NUMA memory binding (colon-separated lists) and passing these settings through to node startup, where nodes are optionally launched via `numactl`.
> 
> Makes local swarm execution concurrency configurable (instead of hardcoded `1`) and adds a compile-time override (`LOCAL_SWARM_NODE_FEATURES`) for the cargo feature set used to build `aptos-node`.
> 
> Updates local worktree version detection to be best-effort: if git revision lookup fails (e.g. non-git/Sapling checkouts), Forge falls back to using `"workspace"` as the revision string.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4f77222e78503852813591f99cfd1d25820e86d9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->