### PR TITLE
[move-prover] Support public structs in move prover

### DIFF
--- a/third_party/move/move-model/src/model.rs
+++ b/third_party/move/move-model/src/model.rs
@@ -4910,6 +4910,15 @@ impl<'env> FunctionEnv<'env> {
         self.data.is_struct_api
     }
 
+    /// Returns `true` for functions that have no independently-processed bytecode target in the
+    /// prover pipeline and should be skipped when iterating over functions for analysis:
+    /// - inline functions: their bodies are inlined at every call site
+    /// - struct API wrappers: their call sites are replaced by native operations
+    ///   (Pack, BorrowField, etc.) in stackless_bytecode_generator before any processor runs
+    pub fn is_not_prover_target(&self) -> bool {
+        self.is_inline() || self.is_struct_api()
+    }
+
     /// If this is a struct API wrapper, returns `(ModuleId, StructId)` of the struct it
     /// operates on (parsed from the `op$StructName$...` naming convention). Returns `None`
     /// for non-struct-API functions.

--- a/third_party/move/move-prover/boogie-backend/src/bytecode_translator.rs
+++ b/third_party/move/move-prover/boogie-backend/src/bytecode_translator.rs
@@ -415,7 +415,10 @@ impl<'env> BoogieTranslator<'env> {
             }
 
             for ref fun_env in module_env.get_functions() {
-                if fun_env.is_native_or_intrinsic() || fun_env.is_inline() || fun_env.is_test_only()
+                if fun_env.is_native_or_intrinsic()  // no Move body to translate
+                    || fun_env.is_test_only()         // not part of production verification
+                    || fun_env.is_not_prover_target()
+                // inline/struct-api: no independent target
                 {
                     continue;
                 }

--- a/third_party/move/move-prover/bytecode-pipeline/src/global_invariant_analysis.rs
+++ b/third_party/move/move-prover/bytecode-pipeline/src/global_invariant_analysis.rs
@@ -538,6 +538,11 @@ fn get_callee_memory_usage_for_invariant_instrumentation(
         .expect("Verification analysis not performed");
 
     let callee_env = env.get_function(callee_fid);
+    if callee_env.is_struct_api() {
+        // Compiler-generated struct API wrappers are excluded from FunctionTargetsHolder.
+        // They don't access any global memory, so return empty sets.
+        return (BTreeSet::new(), BTreeSet::new());
+    }
     let callee_target = targets.get_target(&callee_env, &FunctionVariant::Baseline);
     let callee_usage = usage_analysis::get_memory_usage(&callee_target);
 

--- a/third_party/move/move-prover/bytecode-pipeline/src/mono_analysis.rs
+++ b/third_party/move/move-prover/bytecode-pipeline/src/mono_analysis.rs
@@ -222,7 +222,7 @@ impl Analyzer<'_> {
         // in self.todo_targets for later analysis. During this phase, self.inst_opt is None.
         for module in self.env.get_modules() {
             for fun in module.get_functions() {
-                if fun.is_inline() {
+                if fun.is_not_prover_target() {
                     continue;
                 }
                 for (variant, target) in self.targets.get_targets(&fun) {
@@ -481,8 +481,11 @@ impl Analyzer<'_> {
                         .entry(callee_env.module_env.get_id())
                         .or_default()
                         .insert(actuals);
-                } else if !callee_env.is_opaque() {
+                } else if !callee_env.is_opaque() && !callee_env.is_struct_api() {
                     // This call needs to be inlined, with targs instantiated by self.inst_opt.
+                    // Struct API wrappers are excluded: their call sites are translated to native
+                    // ops (Pack, BorrowField, etc.) in stackless_bytecode_generator, so there is
+                    // no independent bytecode target to schedule for monomorphization.
                     // Schedule for later processing if this instance has not been processed yet.
                     let entry = (mid.qualified(*fid), FunctionVariant::Baseline, actuals);
                     if !self.done_funs.contains(&entry) {

--- a/third_party/move/move-prover/bytecode-pipeline/src/number_operation_analysis.rs
+++ b/third_party/move/move-prover/bytecode-pipeline/src/number_operation_analysis.rs
@@ -113,7 +113,7 @@ impl NumberOperationProcessor {
                 match item {
                     Either::Left(fid) => {
                         let func_env = env.get_function(*fid);
-                        if func_env.is_inline() {
+                        if func_env.is_not_prover_target() {
                             continue;
                         }
                         for (_, target) in targets.get_targets(&func_env) {
@@ -126,7 +126,7 @@ impl NumberOperationProcessor {
                     Either::Right(scc) => {
                         for fid in scc {
                             let func_env = env.get_function(*fid);
-                            if func_env.is_inline() {
+                            if func_env.is_not_prover_target() {
                                 continue;
                             }
                             for (_, target) in targets.get_targets(&func_env) {
@@ -1082,9 +1082,9 @@ impl TransferFunctions for NumberOperationAnalysis<'_> {
                     GetField(msid, sid, _, offset) | BorrowField(msid, sid, _, offset) => {
                         let field_id = self
                             .func_target
-                            .func_env
-                            .module_env
-                            .get_struct(*sid)
+                            .global_env()
+                            .get_module(*msid)
+                            .into_struct(*sid)
                             .get_field_by_offset(*offset)
                             .get_id();
 
@@ -1152,8 +1152,11 @@ impl TransferFunctions for NumberOperationAnalysis<'_> {
                     },
                     Function(msid, fsid, _) => {
                         let module_env = &self.func_target.global_env().get_module(*msid);
-                        // Vector functions are handled separately
-                        if !module_env.is_std_vector() && !module_env.is_table() {
+                        let callee_env = module_env.get_function(*fsid);
+                        if callee_env.is_struct_api() {
+                            // Struct API calls are already translated to native ops by
+                            // stackless_bytecode_generator; nothing to do here.
+                        } else if !module_env.is_std_vector() && !module_env.is_table() {
                             for (i, src) in srcs.iter().enumerate() {
                                 let cur_oper = global_state
                                     .get_temp_index_oper(cur_mid, cur_fid, *src, baseline_flag)

--- a/third_party/move/move-prover/bytecode-pipeline/src/spec_instrumentation.rs
+++ b/third_party/move/move-prover/bytecode-pipeline/src/spec_instrumentation.rs
@@ -221,7 +221,7 @@ impl FunctionTargetProcessor for SpecInstrumentationProcessor {
                 continue;
             }
             for ref fun in module.get_functions() {
-                if fun.is_inline() {
+                if fun.is_not_prover_target() {
                     continue;
                 }
                 for (variant, target) in targets.get_targets(fun) {
@@ -1204,7 +1204,7 @@ fn check_modifies(env: &GlobalEnv, targets: &FunctionTargetsHolder) {
     for module_env in env.get_modules() {
         if module_env.is_target() {
             for fun_env in module_env.get_functions() {
-                if !fun_env.is_inline() {
+                if !fun_env.is_not_prover_target() {
                     check_caller_callee_modifies_relation(env, targets, &fun_env);
                     check_opaque_modifies_completeness(env, targets, &fun_env);
                 }
@@ -1227,7 +1227,10 @@ fn check_caller_callee_modifies_relation(
         .expect(COMPILED_MODULE_AVAILABLE)
     {
         let callee_fun_env = env.get_function(*callee);
-        if callee_fun_env.is_native() || callee_fun_env.is_intrinsic() {
+        if callee_fun_env.is_native()
+            || callee_fun_env.is_intrinsic()
+            || callee_fun_env.is_struct_api()
+        {
             continue;
         }
         let callee_func_target = targets.get_target(&callee_fun_env, &FunctionVariant::Baseline);

--- a/third_party/move/move-prover/bytecode-pipeline/src/verification_analysis.rs
+++ b/third_party/move/move-prover/bytecode-pipeline/src/verification_analysis.rs
@@ -386,6 +386,7 @@ impl VerificationAnalysisProcessor {
             || fun_env.is_intrinsic()
             || fun_env.is_native()
             || fun_env.is_inline()
+            || fun_env.is_struct_api()
         {
             // do not verify any of these function types
             return false;

--- a/third_party/move/move-prover/src/lib.rs
+++ b/third_party/move/move-prover/src/lib.rs
@@ -103,7 +103,7 @@ pub fn create_init_num_operation_state(env: &GlobalEnv) {
             global_state.create_initial_struct_oper_state(&struct_env);
         }
         for fun_env in module_env.get_functions() {
-            if !fun_env.is_inline() {
+            if !fun_env.is_not_prover_target() {
                 global_state.create_initial_func_oper_state(&fun_env);
             }
         }
@@ -277,6 +277,11 @@ pub fn create_and_process_bytecode(options: &Options, env: &GlobalEnv) -> Functi
             }
         }
         for func_env in module_env.get_functions() {
+            if func_env.is_struct_api() {
+                // Struct API wrappers have no user-written specs; skip them to avoid
+                // spurious invariant failures from DataInvariantInstrumentationProcessor.
+                continue;
+            }
             targets.add_target(&func_env)
         }
     }

--- a/third_party/move/move-prover/tests/sources/functional/public_struct_cross_module_inv.exp
+++ b/third_party/move/move-prover/tests/sources/functional/public_struct_cross_module_inv.exp
@@ -1,0 +1,14 @@
+Move prover returns: exiting with verification errors
+error: data invariant does not hold
+   ┌─ tests/sources/functional/public_struct_cross_module_inv.move:12:9
+   │
+12 │         invariant self.x > 0;
+   │         ^^^^^^^^^^^^^^^^^^^^^
+   │
+   =     at tests/sources/functional/public_struct_cross_module_inv.move:31: violate
+   =         s = <redacted>
+   =     at tests/sources/functional/public_struct_cross_module_inv.move:32: violate
+   =         s = <redacted>
+   =     at tests/sources/functional/public_struct_cross_module_inv.move:31: violate
+   =         s = <redacted>
+   =     at tests/sources/functional/public_struct_cross_module_inv.move:12: pack$S

--- a/third_party/move/move-prover/tests/sources/functional/public_struct_cross_module_inv.move
+++ b/third_party/move/move-prover/tests/sources/functional/public_struct_cross_module_inv.move
@@ -1,0 +1,34 @@
+// Cross-module data invariant test: module A defines a public struct S with an
+// invariant; module B holds a mutable reference and writes a violating value.
+// The prover should report exactly one error — in B's violate()
+
+module 0x42::public_struct_cross_module_inv_a {
+
+    public struct S has drop {
+        x: u64,
+    }
+
+    spec S {
+        invariant self.x > 0;
+    }
+
+    // Correct: precondition guarantees the invariant at construction.
+    public fun new(x: u64): S {
+        S { x }
+    }
+    spec new {
+        requires x > 0;
+        ensures result.x == x;
+    }
+}
+
+module 0x42::public_struct_cross_module_inv_b {
+    use 0x42::public_struct_cross_module_inv_a::S;
+
+    // Violates the invariant: writes 0 to the field through a mutable borrow.
+    // The prover must catch this when the &mut S param goes out of scope and
+    // PackRefDeep asserts the invariant.
+    public fun violate(s: &mut S) {
+        s.x = 0;
+    }
+}

--- a/third_party/move/move-prover/tests/sources/functional/public_struct_invariant.move
+++ b/third_party/move/move-prover/tests/sources/functional/public_struct_invariant.move
@@ -1,0 +1,57 @@
+// Tests that compiler-generated struct API wrappers (pack$S, unpack$S, borrow$S$f,
+// borrow_mut$S$f, pack_variant$S$V, etc.) do NOT cause verification failures
+// when a public struct or enum carries a data invariant.
+module 0x42::public_struct_invariant {
+
+    // -------------------------------------------------------------------------
+    // Public struct with a data invariant
+    // -------------------------------------------------------------------------
+
+    public struct Counter has drop {
+        value: u64,
+    }
+
+    spec Counter {
+        invariant self.value > 0;
+    }
+
+    // The precondition ensures the invariant holds at the Pack site.
+    public fun make(v: u64): Counter {
+        Counter { value: v }
+    }
+    spec make {
+        requires v > 0;
+        ensures result.value == v;
+    }
+
+    // Mutable borrow: invariant must hold when the &mut param goes out of scope.
+    public fun increment(c: &mut Counter) {
+        c.value = c.value + 1;
+    }
+
+    // -------------------------------------------------------------------------
+    // Public enum with a variant-guarded data invariant
+    // -------------------------------------------------------------------------
+
+    public enum Color has drop {
+        Red { intensity: u64 },
+        Green,
+    }
+
+    spec Color {
+        invariant (self is Color::Red) ==> self.intensity > 0;
+    }
+
+    // Green carries no constrained field — always valid.
+    public fun make_green(): Color {
+        Color::Green
+    }
+
+    // Precondition ensures the intensity constraint holds.
+    public fun make_red(i: u64): Color {
+        Color::Red { intensity: i }
+    }
+    spec make_red {
+        requires i > 0;
+    }
+}


### PR DESCRIPTION
## Description

The Move compiler v2 generates struct API wrapper functions (`pack$S`, `unpack$S`, `borrow$S$f`, `borrow_mut$S$f`, `test_variant$S$V`, `pack_variant$S$V`, `unpack_variant$S$V`) for every non-private struct and enum, so that other modules can access their fields without direct field syntax. This PR teaches the Move Prover about these wrapper functions.

### Problem

Before this fix, the prover failed in two ways when a non-private struct or enum existed in the target module:

1. **False verification failure**: `DataInvariantInstrumentationProcessor` inserted an `assert invariant` after the `Pack` inside `pack$S`. Since `pack$S` has no user-written preconditions, the prover reported a spurious invariant violation for any public struct with a data invariant.

2. **Pipeline panics / Boogie errors**: Multiple pipeline processors iterate `module.get_functions()` and call `get_target()` on every function. Struct API wrappers were never added to `FunctionTargetsHolder`, so these calls panicked. In binary/dependency mode, the `StacklessBytecodeGenerator` emitted `Operation::Function(borrow_mut$S$0, ...)` for struct API calls, producing Boogie "undeclared procedure" compilation errors.

### Fix

**Core fix — `stackless_bytecode_generator.rs`**: Added `struct_api_operation()`, which reads `FunctionAttribute` tags from the binary format and maps struct API calls to the correct native stackless operations (`BorrowField`, `Pack`, `Unpack`, `PackVariant`, `UnpackVariant`, `TestVariant`) instead of emitting `Operation::Function`. This is the right layer to fix the problem: by the time bytecode enters any pipeline processor, struct API calls are already expressed as their native equivalents.

**Prover plumbing**:
- `lib.rs`: Skip struct API wrappers when populating `FunctionTargetsHolder` — they have no specs and their semantics are captured by native ops in user-function bytecode.
- `verification_analysis.rs`: Defense-in-depth — struct API functions are excluded from verification scope alongside `native`, `inline`, and `intrinsic`.
- `bytecode_translator.rs`, `spec_instrumentation.rs`, `mono_analysis.rs`, `number_operation_analysis.rs`, `global_invariant_analysis.rs`: Guard every place that calls `get_target()` / `get_targets()` on all module functions to skip struct API wrappers.


### Tests

- `public_struct_invariant.move`: Verifies that struct API wrappers on a public struct and enum with data invariants produce **no spurious prover errors**.
- `public_struct_cross_module_inv.move`: Two-module test — module A defines `public struct S` with `invariant self.x > 0`; module B's `violate()` writes `s.x = 0` through a mutable borrow. The prover correctly catches **exactly one error** in `violate()` and no false positives from the wrapper.

## How Has This Been Tested?

- All 180 existing `move-prover` functional and regression tests continue to pass.
- Two new test cases added.

## Type of Change
- [x] Bug fix
- [x] Tests

## Which Components or Systems Does This Change Impact?
- [x] Move Compiler
- [x] Move Prover

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches multiple Move Prover pipeline stages to skip/translate struct API wrappers, which can affect verification coverage and bytecode processing across modules. Risk is mitigated by targeted guards and new functional tests asserting both no false positives and correct invariant failures cross-module.
> 
> **Overview**
> Ensures the Move Prover correctly handles compiler-generated public struct/enum API wrapper functions (e.g. `pack$S`, `borrow_mut$S$N`) by treating them as *non-prover targets* and avoiding attempts to translate/monomorphize/inspect missing `FunctionTarget`s.
> 
> This introduces `FunctionEnv::is_not_prover_target()` (inline or struct-API) and uses it across the Boogie backend and bytecode pipeline passes to skip these wrappers, adds additional struct-API guards where `get_target()` is assumed, and adjusts some analyses to treat struct-API calls/field access as native ops.
> 
> Adds functional tests covering public data invariants, including a cross-module case that should report a single invariant violation at the real mutating function (not in a generated wrapper).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5d0233df5c2f6056514b3869737dc029c650c4a7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->