### PR TITLE
[vm] Fix extract_abort_info for compiler-generated abort codes

### DIFF
--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -691,7 +691,16 @@ impl AptosVM {
                 .ok()
                 .flatten()
                 .and_then(|module| get_metadata(&module.metadata))
-                .and_then(|m| m.extract_abort_info(code));
+                .and_then(|m| {
+                    if self
+                        .features()
+                        .is_enabled(FeatureFlag::VM_BINARY_FORMAT_V10)
+                    {
+                        m.extract_abort_info(code)
+                    } else {
+                        m.extract_abort_info_legacy(code)
+                    }
+                });
 
             // If the abort had a message, override the description with the message.
             if let Some(mut current_info) = current_info {

--- a/aptos-move/e2e-move-tests/src/tests/error_map.data/pack_assert/Move.toml
+++ b/aptos-move/e2e-move-tests/src/tests/error_map.data/pack_assert/Move.toml
@@ -1,0 +1,7 @@
+[package]
+name = "test_package_assert"
+version = "0.0.0"
+upgrade_policy = "compatible"
+
+[dependencies]
+AptosFramework = { local = "../../../../../framework/aptos-framework" }

--- a/aptos-move/e2e-move-tests/src/tests/error_map.data/pack_assert/sources/test.move
+++ b/aptos-move/e2e-move-tests/src/tests/error_map.data/pack_assert/sources/test.move
@@ -1,0 +1,18 @@
+module 0xcafe::test_assert {
+    use std::error;
+
+    /// Some error that happens to have code 0.
+    const E_SOME_ERROR: u64 = 0;
+
+    public entry fun entry_assert(_s: &signer) {
+        assert!(false);
+    }
+
+    public entry fun entry_error(_s: &signer) {
+        abort E_SOME_ERROR
+    }
+
+    public entry fun entry_canonical_error(_s: &signer) {
+        abort error::not_found(E_SOME_ERROR)
+    }
+}

--- a/aptos-move/e2e-move-tests/src/tests/error_map.rs
+++ b/aptos-move/e2e-move-tests/src/tests/error_map.rs
@@ -52,6 +52,68 @@ fn error_map() {
     );
 }
 
+/// Tests that a single-argument `assert!` — which aborts with `UNSPECIFIED_ABORT_CODE` — does not
+/// incorrectly return abort info for a user-defined error constant that happens to have code 0.
+#[test]
+fn error_map_unspecified_abort_code() {
+    let mut h = MoveHarness::new();
+
+    let acc = h.new_account_at(AccountAddress::from_hex_literal("0xcafe").unwrap());
+    assert_success!(h.publish_package_with_options(
+        &acc,
+        &common::test_dir_path("error_map.data/pack_assert"),
+        BuildOptions {
+            with_error_map: true,
+            ..BuildOptions::default()
+        }
+    ));
+
+    // assert!(false) uses UNSPECIFIED_ABORT_CODE. Even though the module has E_SOME_ERROR = 0,
+    // no abort info should be returned.
+    let result = h.run_entry_function(
+        &acc,
+        str::parse("0xcafe::test_assert::entry_assert").unwrap(),
+        vec![],
+        vec![],
+    );
+    match result {
+        TransactionStatus::Keep(ExecutionStatus::MoveAbort { info, .. }) => {
+            assert!(
+                info.is_none(),
+                "expected no AbortInfo for UNSPECIFIED_ABORT_CODE"
+            );
+        },
+        _ => panic!("expected MoveAbort"),
+    }
+
+    // Sanity check: aborting with E_SOME_ERROR directly should still return abort info.
+    let result = h.run_entry_function(
+        &acc,
+        str::parse("0xcafe::test_assert::entry_error").unwrap(),
+        vec![],
+        vec![],
+    );
+    check_error(
+        result,
+        "E_SOME_ERROR",
+        "Some error that happens to have code 0.",
+    );
+
+    // Sanity check: aborting with a canonical std::error code whose reason is 0 should also
+    // return abort info, via the reason fallback.
+    let result = h.run_entry_function(
+        &acc,
+        str::parse("0xcafe::test_assert::entry_canonical_error").unwrap(),
+        vec![],
+        vec![],
+    );
+    check_error(
+        result,
+        "E_SOME_ERROR",
+        "Some error that happens to have code 0.",
+    );
+}
+
 fn check_error(status: TransactionStatus, reason_name: &str, description: &str) {
     match status {
         TransactionStatus::Keep(ExecutionStatus::MoveAbort { info, .. }) => {

--- a/types/src/vm/module_metadata.rs
+++ b/types/src/vm/module_metadata.rs
@@ -545,10 +545,33 @@ impl RuntimeModuleMetadataV1 {
             && self.struct_attributes.is_empty()
     }
 
-    pub fn extract_abort_info(&self, code: u64) -> Option<AbortInfo> {
+    pub fn extract_abort_info_legacy(&self, code: u64) -> Option<AbortInfo> {
         self.error_map
             .get(&(code & 0xFFF))
             .or_else(|| self.error_map.get(&code))
+            .map(|descr| AbortInfo {
+                reason_name: descr.code_name.clone(),
+                description: descr.code_description.clone(),
+            })
+    }
+
+    /// Returns the abort info for the given abort code, if any. Tries the full code first, then
+    /// falls back to the lower 2 bytes (the reason) if the upper 5 bytes are zero.
+    ///
+    /// This skips compiler-generated codes such as `UNSPECIFIED_ABORT_CODE`, which have a
+    /// non-zero upper 5 bytes and are not associated with any user-defined error.
+    pub fn extract_abort_info(&self, code: u64) -> Option<AbortInfo> {
+        self.error_map
+            .get(&code)
+            .or_else(|| {
+                // Only extract the reason for canonical std::error codes (upper 5 bytes zero).
+                if code >> 24 == 0 {
+                    let reason = code & 0xFFFF;
+                    self.error_map.get(&reason)
+                } else {
+                    None
+                }
+            })
             .map(|descr| AbortInfo {
                 reason_name: descr.code_name.clone(),
                 description: descr.code_description.clone(),


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

Fixes a bug in `extract_abort_info` where compiler-generated abort codes could incorrectly match user-defined error codes in the error map.

### Background

`extract_abort_info` looks up human-readable abort info (name and description) from module metadata when a transaction aborts. The error map in the metadata is keyed by the user's raw error constants, e.g.:

```move
const E_NOT_FOUND: u64 = 3;
abort error::not_found(E_NOT_FOUND); // runtime abort code = 0x60003
```

Since the abort code at runtime includes the `std::error` category in bits 23:16, the error map lookup needs to consider just the lower 2 bytes (the reason) to find the matching entry, so key `3` is found for abort code `0x60003`.

### The Bug

The old implementation applied the mask unconditionally and before the exact match:

```rust
self.error_map.get(&(code & 0xFFF)).or_else(|| self.error_map.get(&code))
```

Two issues:
1. `0xFFF` is 12 bits, but the reason field is 16 bits — the correct mask is `0xFFFF`.
2. The mask is applied unconditionally, including for compiler-generated abort codes. `UNSPECIFIED_ABORT_CODE` (used for single-argument `assert!`) has reason `0`, so `UNSPECIFIED_ABORT_CODE & 0xFFF == 0` and the lookup incorrectly matches any user error constant with value `0`:

```move
const E_SOME_ERROR: u64 = 0;

assert!(some_condition); // aborts with UNSPECIFIED_ABORT_CODE
```

The same issue affects abort messages, which also use `UNSPECIFIED_ABORT_CODE`.

### The Fix

The new `extract_abort_info` tries the full code first, then falls back to the lower 2 bytes only if the upper 5 bytes are zero. Compiler-generated codes have a non-zero upper 5 bytes (the magic), so the fallback is skipped for them.

The old behavior is preserved as `extract_abort_info_legacy`. The fix is gated on `VM_BINARY_FORMAT_V10` to avoid changing the `AbortInfo` in `TransactionInfo` for historical transactions, which would break replay.

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

A new e2e test (`error_map_unspecified_abort_code`) deploys a module with an error constant `E_SOME_ERROR = 0` and verifies three cases: (1) `assert!(false)` aborts with `UNSPECIFIED_ABORT_CODE` and returns no abort info, (2) `abort E_SOME_ERROR` returns the correct abort info via exact match, and (3) aborting with a canonical `std::error` code whose reason is `0` also returns the correct abort info via the reason fallback.

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [x] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x]  I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches VM abort-info extraction and can change `AbortInfo` surfaced in transaction/view outputs for new binary format v10, so incorrect gating or logic could affect error reporting and replay behavior.
> 
> **Overview**
> Fixes abort-info lookup so compiler-generated abort codes (e.g., `UNSPECIFIED_ABORT_CODE` from single-arg `assert!`) no longer incorrectly match user-defined error constants in module metadata.
> 
> `RuntimeModuleMetadataV1` now has a new `extract_abort_info` that prefers exact-code matches and only falls back to the 16-bit reason for canonical `std::error`-style codes; the prior behavior is preserved as `extract_abort_info_legacy` and `AptosVM::inject_abort_info_if_available` selects between them via `FeatureFlag::VM_BINARY_FORMAT_V10`.
> 
> Adds an e2e Move package and test (`error_map_unspecified_abort_code`) to cover the regression and ensure direct user aborts and canonical error codes still populate `AbortInfo`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1b679aa83e0da2f5cd910ef06c0ceea2c1d7f9b0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->