### PR TITLE
[vm] Enforce abort message size limit for native function aborts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,6 +99,9 @@ Areas: consensus, mempool, network, storage, execution, vm, framework, api, cli,
 - Use checked arithmetic (`checked_add`, `saturating_sub`, etc.)
 - Infallible locks via `aptos-infallible` crate
 
+### Pattern Matching
+- Always use exhaustive `match` — never use a wildcard `_` arm to silence new enum variants
+
 ### Conditional Test Code
 ```rust
 #[cfg(any(test, feature = "fuzzing"))]

--- a/aptos-move/aptos-native-interface/src/builder.rs
+++ b/aptos-move/aptos-native-interface/src/builder.rs
@@ -10,7 +10,8 @@ use aptos_gas_schedule::{MiscGasParameters, NativeGasParameters};
 use aptos_types::on_chain_config::{Features, TimedFeatures};
 use move_vm_runtime::native_functions::{NativeContext, NativeFunction};
 use move_vm_types::{
-    loaded_data::runtime_types::Type, natives::function::NativeResult, values::Value,
+    limits::check_abort_message_limit, loaded_data::runtime_types::Type,
+    natives::function::NativeResult, values::Value,
 };
 use smallvec::SmallVec;
 use std::{collections::VecDeque, sync::Arc};
@@ -134,11 +135,16 @@ impl SafeNativeBuilder {
                     Abort {
                         abort_code,
                         abort_message,
-                    } => Ok(NativeResult::Abort {
-                        cost: context.legacy_gas_used,
-                        abort_code,
-                        abort_message,
-                    }),
+                    } => {
+                        if let Some(abort_message) = abort_message.as_ref() {
+                            check_abort_message_limit(abort_message.len())?;
+                        }
+                        Ok(NativeResult::Abort {
+                            cost: context.legacy_gas_used,
+                            abort_code,
+                            abort_message,
+                        })
+                    },
                     LimitExceeded(err) => match err {
                         LimitExceededError::LegacyOutOfGas => {
                             assert!(!context.has_direct_gas_meter_access_in_native_context());

--- a/aptos-move/framework/natives/src/type_info.rs
+++ b/aptos-move/framework/natives/src/type_info.rs
@@ -55,9 +55,9 @@ fn native_type_of(
     context.charge(TYPE_INFO_TYPE_OF_BASE)?;
 
     let type_tag = context.type_to_type_tag(&ty_args[0])?;
-    let type_tag_str = type_tag.to_canonical_string();
 
     if context.eval_gas(TYPE_INFO_TYPE_OF_PER_BYTE_IN_STR) > 0.into() {
+        let type_tag_str = type_tag.to_canonical_string();
         // Ideally, we would charge *before* the `type_to_type_tag()` and `type_tag.to_string()` calls above.
         // But there are other limits in place that prevent this native from being called with too much work.
         context
@@ -69,7 +69,10 @@ fn native_type_of(
     } else {
         Err(SafeNativeError::abort_with_message(
             super::status::NFE_EXPECTED_STRUCT_TYPE_TAG,
-            format!("Expected a struct type, found: {}", type_tag_str),
+            format!(
+                "Expected a struct type, found: {}",
+                type_tag.to_short_string()
+            ),
         ))
     }
 }

--- a/third_party/move/move-core/types/src/language_storage.rs
+++ b/third_party/move/move-core/types/src/language_storage.rs
@@ -160,6 +160,32 @@ impl TypeTag {
         }
     }
 
+    /// Returns a short string for the top-level type without any type parameters.
+    /// Useful for error messages where the full canonical string would be unbounded in size.
+    pub fn to_short_string(&self) -> &'static str {
+        use TypeTag::*;
+        match self {
+            Bool => "bool",
+            U8 => "u8",
+            U16 => "u16",
+            U32 => "u32",
+            U64 => "u64",
+            U128 => "u128",
+            U256 => "u256",
+            I8 => "i8",
+            I16 => "i16",
+            I32 => "i32",
+            I64 => "i64",
+            I128 => "i128",
+            I256 => "i256",
+            Address => "address",
+            Signer => "signer",
+            Vector(_) => "vector",
+            Struct(_) => "struct",
+            Function(_) => "function",
+        }
+    }
+
     pub fn struct_tag(&self) -> Option<&StructTag> {
         use TypeTag::*;
         match self {

--- a/third_party/move/move-vm/runtime/src/interpreter.rs
+++ b/third_party/move/move-vm/runtime/src/interpreter.rs
@@ -46,6 +46,7 @@ use move_vm_types::{
     debug_write, debug_writeln,
     gas::{GasMeter, SimpleInstruction},
     instr::Instruction,
+    limits::check_abort_message_limit,
     loaded_data::{runtime_access_specifier::AccessInstance, runtime_types::Type},
     natives::function::NativeResult,
     ty_interner::InternedTypePool,
@@ -1867,8 +1868,6 @@ const OPERAND_STACK_SIZE_LIMIT: usize = 1024;
 const CALL_STACK_SIZE_LIMIT: usize = 1024;
 pub(crate) const ACCESS_STACK_SIZE_LIMIT: usize = 256;
 
-const ABORT_MESSAGE_SIZE_LIMIT: usize = 1024;
-
 /// The operand and runtime-type stacks.
 pub(crate) struct Stack {
     pub(crate) value: Vec<Value>,
@@ -2932,16 +2931,7 @@ impl Frame {
                         // Gas is charged per byte to account for the cost of UTF-8 validation.
                         gas_meter.charge_abort_message(&bytes)?;
 
-                        if bytes.len() > ABORT_MESSAGE_SIZE_LIMIT {
-                            return Err(PartialVMError::new(
-                                StatusCode::ABORT_MESSAGE_LIMIT_EXCEEDED,
-                            )
-                            .with_message(format!(
-                                "Expected at most {} bytes, got {} bytes",
-                                ABORT_MESSAGE_SIZE_LIMIT,
-                                bytes.len()
-                            )));
-                        }
+                        check_abort_message_limit(bytes.len())?;
 
                         let error_message = String::from_utf8(bytes).map_err(|err| {
                             PartialVMError::new(StatusCode::INVALID_ABORT_MESSAGE)

--- a/third_party/move/move-vm/types/src/lib.rs
+++ b/third_party/move/move-vm/types/src/lib.rs
@@ -36,6 +36,7 @@ pub mod delayed_values;
 pub mod gas;
 pub mod instr;
 pub mod interner;
+pub mod limits;
 pub mod loaded_data;
 pub mod module_id_interner;
 pub mod natives;

--- a/third_party/move/move-vm/types/src/limits.rs
+++ b/third_party/move/move-vm/types/src/limits.rs
@@ -1,0 +1,20 @@
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use move_binary_format::errors::PartialVMError;
+use move_core_types::vm_status::StatusCode;
+
+pub const ABORT_MESSAGE_SIZE_LIMIT: usize = 1024;
+
+/// Returns `Err` if `bytes_len` exceeds [`ABORT_MESSAGE_SIZE_LIMIT`].
+pub fn check_abort_message_limit(bytes_len: usize) -> Result<(), PartialVMError> {
+    if bytes_len > ABORT_MESSAGE_SIZE_LIMIT {
+        return Err(
+            PartialVMError::new(StatusCode::ABORT_MESSAGE_LIMIT_EXCEEDED).with_message(format!(
+                "Expected at most {} bytes, got {} bytes",
+                ABORT_MESSAGE_SIZE_LIMIT, bytes_len
+            )),
+        );
+    }
+    Ok(())
+}


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

* Enforce the 1024-byte abort message size limit for native function aborts (previously only checked in the interpreter)
* Extract the check into a shared `move-vm-types::limits` module so it's applied consistently in both paths
* Fix `type_info::type_of` to use only the top-level type variant name in abort messages to prevent unbounded sizes from deeply nested types, e.g. `vector` instead of `vector<vector<0x1::foo::Bar<u64>>>`.

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [x] Move/Aptos Virtual Machine
- [x] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Move VM error/abort handling, which can affect transaction execution outcomes and error propagation, though the change is narrowly scoped to message-size validation and formatting.
> 
> **Overview**
> **Enforces the 1024-byte abort message limit for native function aborts**, not just `AbortMsg` in the interpreter, by validating `abort_message` sizes in `SafeNativeBuilder`.
> 
> Extracts the shared limit and validation into a new `move-vm-types::limits` module and updates the interpreter to use it, ensuring consistent behavior across abort paths.
> 
> Tightens `type_info::type_of` abort messages to use `TypeTag::to_short_string()` (top-level variant only) to avoid potentially unbounded error message sizes from deeply nested types.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 00cbd6df7fbae437887d1ad39f5d38ff6fc12dbc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->