### PR TITLE
Fix typos

### DIFF
--- a/crates/aptos-batch-encryption/src/schemes/fptx.rs
+++ b/crates/aptos-batch-encryption/src/schemes/fptx.rs
@@ -134,7 +134,7 @@ impl BatchThresholdEncryption for FPTX {
         proofs: &Self::EvalProofsPromise,
         digest_key: &DigestKey,
     ) -> Self::EvalProofs {
-        proofs.compute_all_vgzz_multi_point_eval(digest_key)
+        proofs.compute_all_vzgg_multi_point_eval(digest_key)
     }
 
     fn eval_proof_for_ct(

--- a/crates/aptos-batch-encryption/src/shared/digest.rs
+++ b/crates/aptos-batch-encryption/src/shared/digest.rs
@@ -187,7 +187,7 @@ impl EvalProofsPromise {
         }
     }
 
-    pub fn compute_all_vgzz_multi_point_eval(&self, digest_key: &DigestKey) -> EvalProofs {
+    pub fn compute_all_vzgg_multi_point_eval(&self, digest_key: &DigestKey) -> EvalProofs {
         EvalProofs {
             computed_proofs: self
                 .ids

--- a/crates/aptos-batch-encryption/ts-batch-encrypt/src/ciphertext.ts
+++ b/crates/aptos-batch-encryption/ts-batch-encrypt/src/ciphertext.ts
@@ -71,14 +71,14 @@ export class BIBECiphertext extends Serializable {
 export class Ciphertext extends Serializable {
   vk: Uint8Array;
   bibe_ct: BIBECiphertext;
-  assocated_data_bytes: Uint8Array;
+  associated_data_bytes: Uint8Array;
   signature: Uint8Array;
 
   constructor(vk: Uint8Array, bibe_ct: BIBECiphertext, assocated_data_bytes: Uint8Array, signature: Uint8Array) {
     super();
     this.vk = vk;
     this.bibe_ct = bibe_ct;
-    this.assocated_data_bytes = assocated_data_bytes;
+    this.associated_data_bytes = assocated_data_bytes;
     this.signature = signature;
   }
 
@@ -86,7 +86,7 @@ export class Ciphertext extends Serializable {
     // For some reason, on the rust side, ed25519 VKs are serialized as variable bytes, even though they don't need to be.
     serializer.serializeBytes(this.vk);
     this.bibe_ct.serialize(serializer);
-    serializer.serializeBytes(this.assocated_data_bytes);
+    serializer.serializeBytes(this.associated_data_bytes);
     // Signatures, however, are serialized as fixed bytes on the rust side.
     serializer.serializeFixedBytes(this.signature);
   }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Mostly typo fixes, but they rename a Rust API (`compute_all_vzgg_multi_point_eval`) and a TS `Ciphertext` property (`associated_data_bytes`), which could break downstream callers relying on the old names.
> 
> **Overview**
> Fixes a misnamed multi-point evaluation proof computation call by consistently using `vzgg` (renaming `compute_all_vgzz_multi_point_eval` to `compute_all_vzgg_multi_point_eval` and updating the `FPTX` scheme wrapper to call it).
> 
> In the TS batch-encrypt bindings, corrects the `Ciphertext` field name from `assocated_data_bytes` to `associated_data_bytes` and updates serialization to use the corrected property.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 88fe728a285b0c3812d6f4054d434cb5d3e5b340. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->