### PR TITLE
Add num_rounds() fn to DigestKey, and rename capacity() to max_batch_size()

### DIFF
--- a/crates/aptos-batch-encryption/src/shared/ciphertext/bibe.rs
+++ b/crates/aptos-batch-encryption/src/shared/ciphertext/bibe.rs
@@ -218,10 +218,10 @@ pub mod tests {
         let tc = ShamirThresholdConfig::new(1, 1);
         let (ek, dk, _, msk_shares) = FPTX::setup_for_testing(rng.r#gen(), 8, 1, &tc).unwrap();
 
-        let mut ids = IdSet::with_capacity(dk.capacity());
+        let mut ids = IdSet::with_capacity(dk.max_batch_size());
         let mut counter = Fr::zero();
 
-        for _ in 0..dk.capacity() {
+        for _ in 0..dk.max_batch_size() {
             ids.add(&Id::new(counter));
             counter += Fr::one();
         }

--- a/crates/aptos-batch-encryption/src/shared/ciphertext/bibe_succinct.rs
+++ b/crates/aptos-batch-encryption/src/shared/ciphertext/bibe_succinct.rs
@@ -148,10 +148,10 @@ pub mod tests {
 
         let ek = AugmentedEncryptionKey::new(mpk, dk.tau_g2, (dk.tau_g2 * msk).into());
 
-        let mut ids = IdSet::with_capacity(dk.capacity());
+        let mut ids = IdSet::with_capacity(dk.max_batch_size());
         let mut counter = Fr::zero();
 
-        for _ in 0..dk.capacity() {
+        for _ in 0..dk.max_batch_size() {
             ids.add(&Id::new(counter));
             counter += Fr::one();
         }

--- a/crates/aptos-batch-encryption/src/shared/ciphertext/mod.rs
+++ b/crates/aptos-batch-encryption/src/shared/ciphertext/mod.rs
@@ -204,7 +204,7 @@ pub mod tests {
         let associated_data = String::from("");
         let ct: StandardCiphertext = ek.encrypt(&mut rng, &plaintext, &associated_data).unwrap();
 
-        let mut ids = IdSet::with_capacity(dk.capacity());
+        let mut ids = IdSet::with_capacity(dk.max_batch_size());
         ids.add(&ct.id());
 
         ids.compute_poly_coeffs();
@@ -236,7 +236,7 @@ pub mod tests {
         let associated_data = String::from("");
         let ct: SuccinctCiphertext = ek.encrypt(&mut rng, &plaintext, &associated_data).unwrap();
 
-        let mut ids = IdSet::with_capacity(dk.capacity());
+        let mut ids = IdSet::with_capacity(dk.max_batch_size());
         ids.add(&ct.id());
 
         ids.compute_poly_coeffs();

--- a/crates/aptos-batch-encryption/src/shared/digest.rs
+++ b/crates/aptos-batch-encryption/src/shared/digest.rs
@@ -111,8 +111,12 @@ impl DigestKey {
         })
     }
 
-    pub fn capacity(&self) -> usize {
+    pub fn max_batch_size(&self) -> usize {
         self.tau_powers_g1[0].len() - 1
+    }
+
+    pub fn num_rounds(&self) -> usize {
+        self.tau_powers_g1.len()
     }
 
     pub fn digest(
@@ -249,10 +253,10 @@ pub(crate) mod tests {
 
     #[allow(unused)]
     pub(crate) fn digest_and_pfs_for_testing(dk: &DigestKey) -> (Digest, EvalProofsPromise) {
-        let mut ids = IdSet::with_capacity(dk.capacity());
+        let mut ids = IdSet::with_capacity(dk.max_batch_size());
         let mut counter = Fr::zero();
 
-        for _ in 0..dk.capacity() {
+        for _ in 0..dk.max_batch_size() {
             ids.add(&Id::new(counter));
             counter += Fr::one();
         }
@@ -291,6 +295,6 @@ pub(crate) mod tests {
     fn test_digest_key_capacity() {
         let mut rng = thread_rng();
         let dk = DigestKey::new(&mut rng, 8, 1).unwrap();
-        assert_eq!(dk.capacity(), 8);
+        assert_eq!(dk.max_batch_size(), 8);
     }
 }

--- a/crates/aptos-batch-encryption/src/tests/typescript/ciphertext.rs
+++ b/crates/aptos-batch-encryption/src/tests/typescript/ciphertext.rs
@@ -50,10 +50,10 @@ fn test_bibe_ct_encrypt_decrypt_ts() {
     let tc = ShamirThresholdConfig::new(1, 1);
     let (ek, dk, _, msk_shares) = FPTX::setup_for_testing(rng.r#gen(), 8, 1, &tc).unwrap();
 
-    let mut ids = IdSet::with_capacity(dk.capacity());
+    let mut ids = IdSet::with_capacity(dk.max_batch_size());
     let mut counter = Fr::zero();
 
-    for _ in 0..dk.capacity() {
+    for _ in 0..dk.max_batch_size() {
         ids.add(&Id::new(counter));
         counter += Fr::one();
     }
@@ -149,7 +149,7 @@ fn test_ct_encrypt_decrypt_ts() {
     let ct_bytes = run_ts("ciphertext_encrypt", &ek_bytes).unwrap();
     let ct: StandardCiphertext = bcs::from_bytes(&ct_bytes).unwrap();
 
-    let mut ids = IdSet::with_capacity(dk.capacity());
+    let mut ids = IdSet::with_capacity(dk.max_batch_size());
     ids.add(&ct.id());
 
     ids.compute_poly_coeffs();


### PR DESCRIPTION
As requested by @ibalajiarun 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk API refactor: renames a `DigestKey` accessor and updates tests/callers; behavior is unchanged aside from exposing a new `num_rounds()` getter.
> 
> **Overview**
> Renames `DigestKey::capacity()` to `DigestKey::max_batch_size()` and updates all affected unit/TypeScript integration tests and ciphertext test helpers to use the new API.
> 
> Adds `DigestKey::num_rounds()` to expose the number of configured digest rounds (backed by `tau_powers_g1.len()`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 510feefab916c733cd25c95a121360b11f5511c7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->