### PR TITLE
[Forge] Remove VFNs from land blocking performance test.

### DIFF
--- a/testsuite/forge-cli/src/suites/land_blocking.rs
+++ b/testsuite/forge-cli/src/suites/land_blocking.rs
@@ -17,7 +17,7 @@ pub(crate) fn get_land_blocking_test(
 ) -> Option<ForgeConfig> {
     let test = match test_name {
         "land_blocking" | "realistic_env_max_load" => {
-            realistic_env_max_load_test(duration, test_cmd, 7, 0, 2)
+            realistic_env_max_load_test(duration, test_cmd, 7, 0, 3)
         },
         "compat" => compat(),
         "framework_upgrade" => framework_upgrade(),

--- a/testsuite/forge-cli/src/suites/realistic_environment.rs
+++ b/testsuite/forge-cli/src/suites/realistic_environment.rs
@@ -480,7 +480,8 @@ pub(crate) fn realistic_env_max_load_test(
             // Allow validator-PFN connections
             config.base.enable_validator_pfn_connections = true;
 
-            // Increase the consensus observer fallback thresholds
+            // Enable consensus observer and increase fallback thresholds
+            config.consensus_observer.observer_enabled = true;
             config
                 .consensus_observer
                 .observer_fallback_progress_threshold_ms = 30_000; // 30 seconds

--- a/testsuite/forge/src/backend/k8s/swarm.rs
+++ b/testsuite/forge/src/backend/k8s/swarm.rs
@@ -15,6 +15,7 @@ use crate::{
 };
 use anyhow::{anyhow, bail, format_err};
 use aptos_config::config::{NodeConfig, OverrideNodeConfig};
+use aptos_rest_client::{AptosBaseUrl, Client as RestClient};
 use aptos_retrier::fixed_retry_strategy;
 use aptos_sdk::{
     crypto::ed25519::Ed25519PrivateKey,
@@ -32,6 +33,7 @@ use prometheus_http_query::{
     Client as PrometheusClient,
 };
 use regex::Regex;
+use reqwest::Url;
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
     convert::TryFrom,
@@ -43,6 +45,10 @@ use tokio::{
     task::block_in_place,
     time::Duration,
 };
+
+// Useful PFN constants
+const PFN_STS_LABEL: &str = "app.kubernetes.io/part-of=aptos-fullnode";
+const PFN_STS_METADATA_NAME_PREFIX: &str = "pfn-";
 
 pub struct K8sSwarm {
     validators: HashMap<PeerId, K8sNode>,
@@ -158,6 +164,32 @@ impl K8sSwarm {
     #[allow(dead_code)]
     fn get_kube_client(&self) -> K8sClient {
         self.kube_client.clone()
+    }
+
+    /// Returns all PFN stateful sets in the namespace.
+    /// Note: PFNs are deployed externally (via the forge-pfn-deployer).
+    async fn get_pfn_stateful_sets(&self) -> Result<Vec<StatefulSet>> {
+        // Get all fullnode stateful sets
+        let all_stateful_sets: Api<StatefulSet> =
+            Api::namespaced(self.kube_client.clone(), &self.kube_namespace);
+        let fullnode_sts_list = all_stateful_sets
+            .list(&ListParams::default().labels(PFN_STS_LABEL))
+            .await?;
+
+        // Get all PFN stateful sets
+        let pfn_sts_list = fullnode_sts_list
+            .items
+            .into_iter()
+            .filter(|sts| {
+                sts.metadata
+                    .name
+                    .as_deref()
+                    .unwrap_or_default()
+                    .starts_with(PFN_STS_METADATA_NAME_PREFIX)
+            })
+            .collect();
+
+        Ok(pfn_sts_list)
     }
 }
 
@@ -344,6 +376,61 @@ impl Swarm for K8sSwarm {
         }
         info!("Found no fullnode restarts");
         Ok(())
+    }
+
+    async fn ensure_no_pfn_restart(&self) -> Result<()> {
+        // Get all PFN stateful sets
+        let pfn_sts_list = self.get_pfn_stateful_sets().await?;
+
+        // If there are no PFN stateful sets, skip the check
+        if pfn_sts_list.is_empty() {
+            info!("No PFN stateful sets found, skipping PFN restart check!");
+            return Ok(());
+        }
+        info!(
+            "Found {} PFN stateful sets, checking for restarts!",
+            pfn_sts_list.len()
+        );
+
+        for sts in &pfn_sts_list {
+            let sts_name = sts.metadata.name.as_deref().unwrap_or_default();
+            check_for_container_restart(&self.kube_client, &self.kube_namespace, sts_name).await?;
+        }
+
+        info!("Found no PFN restarts!");
+        Ok(())
+    }
+
+    async fn get_pfn_rest_clients(&self, client_timeout: Duration) -> Vec<RestClient> {
+        // Get all PFN stateful sets
+        let pfn_sts_list = match self.get_pfn_stateful_sets().await {
+            Ok(pfn_sts_list) => pfn_sts_list,
+            Err(error) => {
+                // No stateful sets were found, return an empty list
+                warn!("Failed to list PFN stateful sets! Error: {}", error);
+                return vec![];
+            },
+        };
+
+        // For each PFN stateful set, construct a rest client to its REST API
+        pfn_sts_list
+            .iter()
+            .filter_map(|sts| {
+                let sts_name = sts.metadata.name.as_deref()?;
+                let service_name = format!("{}-lb.{}.svc", sts_name, self.kube_namespace);
+                let url: Url = format!(
+                    "http://{}:{}/v1",
+                    service_name, REST_API_HAPROXY_SERVICE_PORT
+                )
+                .parse()
+                .ok()?;
+                Some(
+                    RestClient::builder(AptosBaseUrl::Custom(url))
+                        .timeout(client_timeout)
+                        .build(),
+                )
+            })
+            .collect()
     }
 
     async fn query_metrics(

--- a/testsuite/forge/src/backend/local/swarm.rs
+++ b/testsuite/forge/src/backend/local/swarm.rs
@@ -17,6 +17,7 @@ use aptos_genesis::builder::{
 };
 use aptos_infallible::Mutex;
 use aptos_logger::{info, warn};
+use aptos_rest_client::Client as RestClient;
 use aptos_sdk::{
     crypto::{ed25519::Ed25519PrivateKey, encoding_type::EncodingType},
     types::{
@@ -655,6 +656,14 @@ impl Swarm for LocalSwarm {
 
     async fn ensure_no_fullnode_restart(&self) -> Result<()> {
         todo!()
+    }
+
+    async fn ensure_no_pfn_restart(&self) -> Result<()> {
+        todo!()
+    }
+
+    async fn get_pfn_rest_clients(&self, _client_timeout: Duration) -> Vec<RestClient> {
+        vec![] // Return an empty list (PFNs aren't supported for local swarms)
     }
 
     async fn query_metrics(

--- a/testsuite/forge/src/interface/swarm.rs
+++ b/testsuite/forge/src/interface/swarm.rs
@@ -76,6 +76,8 @@ pub trait Swarm: Sync + Send {
 
     async fn ensure_no_validator_restart(&self) -> Result<()>;
     async fn ensure_no_fullnode_restart(&self) -> Result<()>;
+    async fn ensure_no_pfn_restart(&self) -> Result<()>;
+    async fn get_pfn_rest_clients(&self, client_timeout: Duration) -> Vec<RestClient>;
 
     // Get prometheus metrics from the swarm
     async fn query_metrics(

--- a/testsuite/forge/src/success_criteria.rs
+++ b/testsuite/forge/src/success_criteria.rs
@@ -492,6 +492,14 @@ impl SuccessCriteriaChecker {
                     .await
                     .context("Failed ensuring no fullnode restarted")
             });
+
+            results.add_result("Check no PFN restart", CheckType::Hard, {
+                let swarm_read = swarm.read().await;
+                swarm_read
+                    .ensure_no_pfn_restart()
+                    .await
+                    .context("Failed ensuring no PFN restarted")
+            });
         }
 
         if success_criteria.check_no_errors {

--- a/testsuite/testcases/src/lib.rs
+++ b/testsuite/testcases/src/lib.rs
@@ -47,6 +47,7 @@ use std::{
 };
 use tokio::runtime::{Handle, Runtime};
 
+const DEFAULT_REST_CLIENT_TIMEOUT_SECS: u64 = 30;
 pub const WARMUP_DURATION_FRACTION: f32 = 0.07;
 pub const COOLDOWN_DURATION_FRACTION: f32 = 0.04;
 
@@ -135,12 +136,9 @@ async fn batch_update_gradually(
 pub async fn create_emitter_and_request(
     swarm: Arc<tokio::sync::RwLock<Box<dyn Swarm>>>,
     mut emit_job_request: EmitJobRequest,
-    nodes: &[PeerId],
+    clients: Vec<RestClient>,
     rng: StdRng,
 ) -> Result<(TxnEmitter, EmitJobRequest)> {
-    // as we are loading nodes, use higher client timeout
-    let client_timeout = Duration::from_secs(30);
-
     let chain_info = swarm.read().await.chain_info();
     let transaction_factory = TransactionFactory::new(chain_info.chain_id);
     let rest_cli = swarm
@@ -152,12 +150,7 @@ pub async fn create_emitter_and_request(
         .rest_client();
     let emitter = TxnEmitter::new(transaction_factory, rng, rest_cli);
 
-    emit_job_request = emit_job_request.rest_clients(
-        swarm
-            .read()
-            .await
-            .get_clients_for_peers(nodes, client_timeout),
-    );
+    emit_job_request = emit_job_request.rest_clients(clients);
     Ok((emitter, emit_job_request))
 }
 
@@ -173,8 +166,13 @@ pub async fn generate_traffic(
 ) -> Result<TxnStats> {
     let emit_job_request = ctx.emit_job.clone();
     let rng = SeedableRng::from_rng(ctx.core().rng())?;
+    let clients = ctx
+        .swarm
+        .read()
+        .await
+        .get_clients_for_peers(nodes, Duration::from_secs(DEFAULT_REST_CLIENT_TIMEOUT_SECS));
     let (emitter, emit_job_request) =
-        create_emitter_and_request(ctx.swarm.clone(), emit_job_request, nodes, rng).await?;
+        create_emitter_and_request(ctx.swarm.clone(), emit_job_request, clients, rng).await?;
 
     let stats = emitter
         .emit_txn_for(
@@ -187,36 +185,77 @@ pub async fn generate_traffic(
     Ok(stats)
 }
 
+#[derive(Debug)]
 pub enum LoadDestination {
     AllNodes,
     AllValidators,
     AllFullnodes,
     // Send to AllFullnodes, if any exist, otherwise to AllValidators
     FullnodesOtherwiseValidators,
+    // Send to PFNs if any exist, otherwise AllFullnodes, otherwise AllValidators
+    PfnsOtherwiseFullnodesOtherwiseValidators,
     Peers(Vec<PeerId>),
 }
 
 impl LoadDestination {
-    async fn get_destination_nodes(
+    pub async fn get_destination_clients(
         self,
         swarm: Arc<tokio::sync::RwLock<Box<dyn Swarm>>>,
-    ) -> Vec<PeerId> {
-        let swarm = swarm.read().await;
-        let all_validators = swarm.validators().map(|v| v.peer_id()).collect::<Vec<_>>();
-        let all_fullnodes = swarm.full_nodes().map(|v| v.peer_id()).collect::<Vec<_>>();
+    ) -> Vec<RestClient> {
+        // Collect validator and fullnode clients
+        let client_timeout = Duration::from_secs(DEFAULT_REST_CLIENT_TIMEOUT_SECS);
+        let (all_validator_clients, all_fullnode_clients) = {
+            let swarm_lock = swarm.read().await;
+            let validator_clients = swarm_lock
+                .validators()
+                .map(|v| v.rest_client_with_timeout(client_timeout))
+                .collect::<Vec<_>>();
+            let fullnode_clients = swarm_lock
+                .full_nodes()
+                .map(|f| f.rest_client_with_timeout(client_timeout))
+                .collect::<Vec<_>>();
+            (validator_clients, fullnode_clients)
+        };
+
+        // Determine the clients based on the specified destination
+        info!(
+            "Load destination: {:?}, validator clients found: {:?}, fullnode clients found: {:?}",
+            self, all_validator_clients, all_fullnode_clients
+        );
 
         match self {
-            LoadDestination::AllNodes => [&all_validators[..], &all_fullnodes[..]].concat(),
-            LoadDestination::AllValidators => all_validators,
-            LoadDestination::AllFullnodes => all_fullnodes,
+            LoadDestination::AllNodes => [all_validator_clients, all_fullnode_clients].concat(),
+            LoadDestination::AllValidators => all_validator_clients,
+            LoadDestination::AllFullnodes => all_fullnode_clients,
             LoadDestination::FullnodesOtherwiseValidators => {
-                if all_fullnodes.is_empty() {
-                    all_validators
+                if all_fullnode_clients.is_empty() {
+                    all_validator_clients
                 } else {
-                    all_fullnodes
+                    all_fullnode_clients
                 }
             },
-            LoadDestination::Peers(peers) => peers,
+            LoadDestination::Peers(peers) => swarm
+                .read()
+                .await
+                .get_clients_for_peers(&peers, client_timeout),
+            LoadDestination::PfnsOtherwiseFullnodesOtherwiseValidators => {
+                // Get the PFN clients
+                let pfn_clients = swarm
+                    .read()
+                    .await
+                    .get_pfn_rest_clients(client_timeout)
+                    .await;
+                info!("PFN destination clients found: {:?}", pfn_clients);
+
+                // Determine the clients based on the specified destination
+                if !pfn_clients.is_empty() {
+                    pfn_clients
+                } else if !all_fullnode_clients.is_empty() {
+                    all_fullnode_clients
+                } else {
+                    all_validator_clients
+                }
+            },
         }
     }
 }
@@ -340,7 +379,7 @@ impl NetworkTest for dyn NetworkLoadTest {
 
 pub async fn create_buffered_load(
     swarm: Arc<tokio::sync::RwLock<Box<dyn Swarm>>>,
-    nodes_to_send_load_to: &[PeerId],
+    clients_to_send_load_to: Vec<RestClient>,
     emit_job_request: EmitJobRequest,
     duration: Duration,
     warmup_duration_fraction: f32,
@@ -349,19 +388,15 @@ pub async fn create_buffered_load(
     mut synchronized_with_job: Option<&mut EmitJob>,
 ) -> Result<Vec<LoadTestPhaseStats>> {
     // Generate some traffic
+    let clients = clients_to_send_load_to.clone();
     let (mut emitter, emit_job_request) = create_emitter_and_request(
         swarm.clone(),
         emit_job_request,
-        nodes_to_send_load_to,
+        clients_to_send_load_to,
         StdRng::from_entropy(),
     )
     .await
     .context("create emitter")?;
-
-    let clients = swarm
-        .read()
-        .await
-        .get_clients_for_peers(nodes_to_send_load_to, Duration::from_secs(10));
 
     let mut stats_tracking_phases = emit_job_request.get_num_phases();
     assert!(stats_tracking_phases > 0 && stats_tracking_phases != 2);
@@ -520,11 +555,11 @@ impl dyn NetworkLoadTest + '_ {
         synchronized_with_job: Option<&mut EmitJob>,
     ) -> Result<Vec<LoadTestPhaseStats>> {
         let destination = self.setup(ctx).await.context("setup NetworkLoadTest")?;
-        let nodes_to_send_load_to = destination.get_destination_nodes(ctx.swarm.clone()).await;
+        let clients_to_send_load_to = destination.get_destination_clients(ctx.swarm.clone()).await;
 
         create_buffered_load(
             ctx.swarm.clone(),
-            &nodes_to_send_load_to,
+            clients_to_send_load_to,
             emit_job_request,
             duration,
             warmup_duration_fraction,

--- a/testsuite/testcases/src/load_vs_perf_benchmark.rs
+++ b/testsuite/testcases/src/load_vs_perf_benchmark.rs
@@ -342,14 +342,14 @@ impl NetworkTest for LoadVsPerfBenchmark {
         let ctx = ctx_locker.deref_mut();
 
         let mut background_job = if let Some(background_traffic) = &self.background_traffic {
-            let nodes_to_send_load_to = LoadDestination::FullnodesOtherwiseValidators
-                .get_destination_nodes(ctx.swarm.clone())
+            let clients_to_send_load_to = LoadDestination::FullnodesOtherwiseValidators
+                .get_destination_clients(ctx.swarm.clone())
                 .await;
             let rng = SeedableRng::from_rng(ctx.core().rng())?;
             let (mut emitter, emit_job_request) = create_emitter_and_request(
                 ctx.swarm.clone(),
                 background_traffic.traffic.clone(),
-                &nodes_to_send_load_to,
+                clients_to_send_load_to,
                 rng,
             )
             .await

--- a/testsuite/testcases/src/two_traffics_test.rs
+++ b/testsuite/testcases/src/two_traffics_test.rs
@@ -7,7 +7,8 @@ use crate::{
 };
 use aptos_forge::{
     success_criteria::{SuccessCriteria, SuccessCriteriaChecker},
-    EmitJobRequest, NetworkContextSynchronizer, NetworkTest, Result, Swarm, Test, TestReport,
+    EmitJobRequest, NetworkContext, NetworkContextSynchronizer, NetworkTest, Result, Swarm, Test,
+    TestReport,
 };
 use async_trait::async_trait;
 use log::info;
@@ -26,6 +27,10 @@ impl Test for TwoTrafficsTest {
 
 #[async_trait]
 impl NetworkLoadTest for TwoTrafficsTest {
+    async fn setup<'a>(&self, _ctx: &mut NetworkContext<'a>) -> Result<LoadDestination> {
+        Ok(LoadDestination::PfnsOtherwiseFullnodesOtherwiseValidators)
+    }
+
     async fn test(
         &self,
         swarm: Arc<tokio::sync::RwLock<Box<dyn Swarm>>>,
@@ -36,13 +41,14 @@ impl NetworkLoadTest for TwoTrafficsTest {
             "Running TwoTrafficsTest test for duration {}s",
             duration.as_secs_f32()
         );
-        let nodes_to_send_load_to = LoadDestination::FullnodesOtherwiseValidators
-            .get_destination_nodes(swarm.clone())
+
+        let clients_to_send_load_to = LoadDestination::PfnsOtherwiseFullnodesOtherwiseValidators
+            .get_destination_clients(swarm.clone())
             .await;
 
         let stats_by_phase = create_buffered_load(
             swarm,
-            &nodes_to_send_load_to,
+            clients_to_send_load_to,
             self.inner_traffic.clone(),
             duration,
             WARMUP_DURATION_FRACTION,


### PR DESCRIPTION
## Description
This PR removes VFNs from the forge land blocking performance test (`realistic_env_max_load`), and increases the PFN count to 3 (resulting in 7 validators, 0 VFNs, and 3 PFNs).

The PR offers the following commits:
1. Make the number of PFNs configurable for `realistic_env_max_load`.
2. Enable validator-PFN connections for `realistic_env_max_load`.
3. Add transaction emitter support for PFNs (to ensure transactions are routed to PFNs), and ensure that PFNs are included in the `no machine restart` check.

## Testing Plan
New and existing test infrastructure.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes Forge swarm interfaces and traffic-emitter routing, and introduces K8s PFN discovery/restart checks that could break or alter test behavior in CI if PFN services/labels differ.
> 
> **Overview**
> Switches the land-blocking `realistic_env_max_load` topology to **7 validators, 0 VFNs, and a configurable number of PFNs** (set to 3 for land-blocking), and updates the realistic-env large variant to pass the new PFN parameter.
> 
> Extends Forge to treat PFNs as first-class load targets: load tests now select **REST clients** (optionally PFNs-first) instead of peer IDs, `TwoTrafficsTest` prefers PFNs for traffic, and the `Swarm` interface gains `get_pfn_rest_clients()` plus a **PFN restart check** that is enforced by `SuccessCriteria::add_no_restarts()`.
> 
> On K8s, PFNs are discovered by StatefulSet label/prefix and used to build REST clients via `*-lb` services; local swarms stub PFN support (no-op clients and TODO restart check).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f1aa70f21681962d4f5ad246ebd7c46fcaae76a2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->