### PR TITLE
[move-package] Replace dev address uniqueness error with warning

### DIFF
--- a/third_party/move/tools/move-package/src/resolution/resolution_graph.rs
+++ b/third_party/move/tools/move-package/src/resolution/resolution_graph.rs
@@ -354,18 +354,6 @@ impl ResolvingGraph {
         }
 
         if self.build_options.dev_mode && is_root_package {
-            let mut addr_to_name_mapping: BTreeMap<AccountAddress, Vec<NamedAddress>> =
-                BTreeMap::new();
-            for (name, addr) in resolution_table
-                .iter()
-                .filter(|(_name, addr)| addr.value.borrow().is_some())
-            {
-                addr_to_name_mapping
-                    .entry(addr.value.borrow().unwrap())
-                    .or_default()
-                    .push(*name);
-            }
-
             for (name, addr) in package
                 .dev_address_assignments
                 .clone()
@@ -392,24 +380,40 @@ impl ResolvingGraph {
                         );
                     },
                 }
+            }
 
-                if let Some(conflicts) = addr_to_name_mapping.insert(addr, vec![name]) {
-                    let conflict_names = conflicts
-                        .into_iter()
+            let dev_names: BTreeSet<NamedAddress> = package
+                .dev_address_assignments
+                .as_ref()
+                .map(|m| m.keys().copied().collect())
+                .unwrap_or_default();
+
+            let mut addr_to_names: BTreeMap<AccountAddress, Vec<NamedAddress>> = BTreeMap::new();
+            for (name, addr) in resolution_table
+                .iter()
+                .filter(|(_name, addr)| addr.value.borrow().is_some())
+            {
+                addr_to_names
+                    .entry(addr.value.borrow().unwrap())
+                    .or_default()
+                    .push(*name);
+            }
+            for (addr, names) in &addr_to_names {
+                if names.len() > 1 && names.iter().any(|n| dev_names.contains(n)) {
+                    let names_str = names
+                        .iter()
                         .map(|n| n.to_string())
                         .collect::<Vec<_>>()
                         .join(", ");
                     writeln!(
                         writer,
-                        "{} Dev address assignment '{name} = 0x{addr}' in package \
-                         '{pkg}' has the same address as: {conflicts}. If these addresses \
-                         are different in a non-dev build, the package may behave differently \
-                         than in dev mode / testing.",
+                        "{} Multiple named addresses in package '{}' share the \
+                         same address 0x{}: [{}]. If these addresses are different in a \
+                         non-dev build, the package may behave differently than in testing.",
                         "WARNING".bold().yellow(),
-                        name = name,
-                        addr = addr.short_str_lossless(),
-                        pkg = package_name,
-                        conflicts = conflict_names,
+                        package_name,
+                        addr.short_str_lossless(),
+                        names_str,
                     )?;
                 }
             }

--- a/third_party/move/tools/move-package/src/resolution/resolution_graph.rs
+++ b/third_party/move/tools/move-package/src/resolution/resolution_graph.rs
@@ -353,17 +353,6 @@ impl ResolvingGraph {
         }
 
         if self.build_options.dev_mode && is_root_package {
-            let mut addr_to_name_mapping = BTreeMap::new();
-            for (name, addr) in resolution_table
-                .iter()
-                .filter(|(_name, addr)| addr.value.borrow().is_some())
-            {
-                let names = addr_to_name_mapping
-                    .entry(addr.value.borrow().unwrap())
-                    .or_insert_with(Vec::new);
-                names.push(*name);
-            }
-
             for (name, addr) in package
                 .dev_address_assignments
                 .clone()
@@ -389,24 +378,6 @@ impl ResolvingGraph {
                             package_name
                         );
                     },
-                }
-
-                if let Some(conflicts) = addr_to_name_mapping.insert(addr, vec![name]) {
-                    bail!(
-                        "Found non-unique dev address assignment '{name} = 0x{addr}' in root \
-                        package '{pkg}'. Dev address assignments must not conflict with any other \
-                        assignments in order to ensure that the package will compile with any \
-                        possible address assignment. \
-                        Assignment conflicts with previous assignments: {conflicts} = 0x{addr}",
-                        name = name,
-                        addr = addr.short_str_lossless(),
-                        pkg = package_name,
-                        conflicts = conflicts
-                            .into_iter()
-                            .map(|n| n.to_string())
-                            .collect::<Vec<_>>()
-                            .join(", "),
-                    )
                 }
             }
         }

--- a/third_party/move/tools/move-package/src/resolution/resolution_graph.rs
+++ b/third_party/move/tools/move-package/src/resolution/resolution_graph.rs
@@ -301,7 +301,7 @@ impl ResolvingGraph {
             })?;
         }
 
-        self.unify_addresses_in_package(&package, &mut resolution_table, is_root_package)?;
+        self.unify_addresses_in_package(&package, &mut resolution_table, is_root_package, writer)?;
 
         let source_digest =
             ResolvingPackage::get_package_digest_for_config(&package_path, &self.build_options)?;
@@ -318,11 +318,12 @@ impl ResolvingGraph {
         Ok(())
     }
 
-    fn unify_addresses_in_package(
+    fn unify_addresses_in_package<W: Write>(
         &mut self,
         package: &SourceManifest,
         resolution_table: &mut ResolvingTable,
         is_root_package: bool,
+        writer: &mut W,
     ) -> Result<()> {
         let package_name = &package.package.name;
         for (name, addr_opt) in package.addresses.clone().unwrap_or_default().into_iter() {
@@ -353,6 +354,18 @@ impl ResolvingGraph {
         }
 
         if self.build_options.dev_mode && is_root_package {
+            let mut addr_to_name_mapping: BTreeMap<AccountAddress, Vec<NamedAddress>> =
+                BTreeMap::new();
+            for (name, addr) in resolution_table
+                .iter()
+                .filter(|(_name, addr)| addr.value.borrow().is_some())
+            {
+                addr_to_name_mapping
+                    .entry(addr.value.borrow().unwrap())
+                    .or_default()
+                    .push(*name);
+            }
+
             for (name, addr) in package
                 .dev_address_assignments
                 .clone()
@@ -378,6 +391,26 @@ impl ResolvingGraph {
                             package_name
                         );
                     },
+                }
+
+                if let Some(conflicts) = addr_to_name_mapping.insert(addr, vec![name]) {
+                    let conflict_names = conflicts
+                        .into_iter()
+                        .map(|n| n.to_string())
+                        .collect::<Vec<_>>()
+                        .join(", ");
+                    writeln!(
+                        writer,
+                        "{} Dev address assignment '{name} = 0x{addr}' in package \
+                         '{pkg}' has the same address as: {conflicts}. If these addresses \
+                         are different in a non-dev build, the package may behave differently \
+                         than in dev mode / testing.",
+                        "WARNING".bold().yellow(),
+                        name = name,
+                        addr = addr.short_str_lossless(),
+                        pkg = package_name,
+                        conflicts = conflict_names,
+                    )?;
                 }
             }
         }

--- a/third_party/move/tools/move-package/tests/test_runner.rs
+++ b/third_party/move/tools/move-package/tests/test_runner.rs
@@ -52,6 +52,7 @@ fn run_test_impl(
     let should_compile = path.with_extension(COMPILE_EXT).is_file();
     let should_model = path.with_extension(MODEL_EXT).is_file();
     let contents = fs::read_to_string(path)?;
+    let mut writer_buf = Vec::new();
     let output = match MP::parse_move_manifest_string(contents)
         .and_then(MP::parse_source_manifest)
         .and_then(|parsed_manifest| {
@@ -69,7 +70,7 @@ fn run_test_impl(
                     compiler_config: compiler_config.clone(),
                     ..Default::default()
                 },
-                &mut Vec::new(), /* empty writer as no diags needed */
+                &mut writer_buf,
             )
         })
         .and_then(|rg| rg.resolve())
@@ -122,7 +123,13 @@ fn run_test_impl(
         },
         Err(error) => format!("{:#}\n", error),
     };
-    Ok(output)
+    let writer_output = String::from_utf8(writer_buf).unwrap_or_default();
+    let warnings: String = writer_output
+        .lines()
+        .filter(|line| line.contains("WARNING"))
+        .map(|line| format!("{}\n", line))
+        .collect();
+    Ok(format!("{}{}", warnings, output))
 }
 
 fn check_or_update(

--- a/third_party/move/tools/move-package/tests/test_sources/resolution/conflicting_dev_address_with_dep/Move.exp
+++ b/third_party/move/tools/move-package/tests/test_sources/resolution/conflicting_dev_address_with_dep/Move.exp
@@ -1,1 +1,185 @@
-Unable to resolve packages for package 'Root': Found non-unique dev address assignment 'B = 0x1' in root package 'Root'. Dev address assignments must not conflict with any other assignments in order to ensure that the package will compile with any possible address assignment. Assignment conflicts with previous assignments: A = 0x1
+ResolutionGraph {
+    root_package_path: "tests/test_sources/resolution/conflicting_dev_address_with_dep",
+    build_options: BuildConfig {
+        dev_mode: true,
+        test_mode: false,
+        verify_mode: false,
+        override_std: None,
+        generate_docs: false,
+        generate_abis: false,
+        generate_move_model: false,
+        full_model_generation: false,
+        install_dir: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        force_recompilation: false,
+        additional_named_addresses: {},
+        fetch_deps_only: false,
+        skip_fetch_latest_git_deps: false,
+        compiler_config: CompilerConfig {
+            bytecode_version: None,
+            known_attributes: {
+                "bytecode_instruction",
+                "deprecated",
+                "expected_failure",
+                "lint::skip",
+                "module_lock",
+                "native_interface",
+                "persistent",
+                "test",
+                "test_only",
+                "verify_only",
+            },
+            skip_attribute_checks: false,
+            compiler_version: Some(
+                V2_0,
+            ),
+            language_version: None,
+            experiments: [],
+            print_errors: false,
+        },
+    },
+    root_package: SourceManifest {
+        package: PackageInfo {
+            name: "Root",
+            version: (
+                0,
+                0,
+                0,
+            ),
+            authors: [],
+            license: None,
+            custom_properties: {},
+        },
+        addresses: Some(
+            {
+                "B": None,
+            },
+        ),
+        dev_address_assignments: Some(
+            {
+                "B": 0000000000000000000000000000000000000000000000000000000000000001,
+            },
+        ),
+        build: None,
+        dependencies: {
+            "A": Dependency {
+                local: "./deps_only/A",
+                subst: None,
+                version: None,
+                digest: None,
+                git_info: None,
+                node_info: None,
+            },
+        },
+        dev_dependencies: {},
+    },
+    graph: {
+        "Root": [
+            (
+                "A",
+                Outgoing,
+            ),
+        ],
+        "A": [
+            (
+                "Root",
+                Incoming,
+            ),
+        ],
+    },
+    package_table: {
+        "A": ResolutionPackage {
+            resolution_graph_index: "A",
+            source_package: SourceManifest {
+                package: PackageInfo {
+                    name: "A",
+                    version: (
+                        0,
+                        0,
+                        0,
+                    ),
+                    authors: [],
+                    license: None,
+                    custom_properties: {},
+                },
+                addresses: Some(
+                    {
+                        "A": Some(
+                            0000000000000000000000000000000000000000000000000000000000000001,
+                        ),
+                    },
+                ),
+                dev_address_assignments: None,
+                build: None,
+                dependencies: {},
+                dev_dependencies: {},
+            },
+            package_path: "ELIDED_FOR_TEST",
+            resolution_table: {
+                "A": 0000000000000000000000000000000000000000000000000000000000000001,
+            },
+            source_digest: "ELIDED_FOR_TEST",
+        },
+        "Root": ResolutionPackage {
+            resolution_graph_index: "Root",
+            source_package: SourceManifest {
+                package: PackageInfo {
+                    name: "Root",
+                    version: (
+                        0,
+                        0,
+                        0,
+                    ),
+                    authors: [],
+                    license: None,
+                    custom_properties: {},
+                },
+                addresses: Some(
+                    {
+                        "B": None,
+                    },
+                ),
+                dev_address_assignments: Some(
+                    {
+                        "B": 0000000000000000000000000000000000000000000000000000000000000001,
+                    },
+                ),
+                build: None,
+                dependencies: {
+                    "A": Dependency {
+                        local: "./deps_only/A",
+                        subst: None,
+                        version: None,
+                        digest: None,
+                        git_info: None,
+                        node_info: None,
+                    },
+                },
+                dev_dependencies: {},
+            },
+            package_path: "ELIDED_FOR_TEST",
+            resolution_table: {
+                "A": 0000000000000000000000000000000000000000000000000000000000000001,
+                "B": 0000000000000000000000000000000000000000000000000000000000000001,
+            },
+            source_digest: "ELIDED_FOR_TEST",
+        },
+    },
+    global_named_address_pool: {
+        "A": ResolvingNamedAddress {
+            value: RefCell {
+                value: Some(
+                    0000000000000000000000000000000000000000000000000000000000000001,
+                ),
+            },
+        },
+        "B": ResolvingNamedAddress {
+            value: RefCell {
+                value: Some(
+                    0000000000000000000000000000000000000000000000000000000000000001,
+                ),
+            },
+        },
+    },
+}

--- a/third_party/move/tools/move-package/tests/test_sources/resolution/conflicting_dev_address_with_dep/Move.exp
+++ b/third_party/move/tools/move-package/tests/test_sources/resolution/conflicting_dev_address_with_dep/Move.exp
@@ -1,3 +1,4 @@
+WARNING Multiple named addresses in package 'Root' share the same address 0x1: [A, B]. If these addresses are different in a non-dev build, the package may behave differently than in testing.
 ResolutionGraph {
     root_package_path: "tests/test_sources/resolution/conflicting_dev_address_with_dep",
     build_options: BuildConfig {

--- a/third_party/move/tools/move-package/tests/test_sources/resolution/conflicting_dev_address_with_dev_dep/Move.exp
+++ b/third_party/move/tools/move-package/tests/test_sources/resolution/conflicting_dev_address_with_dev_dep/Move.exp
@@ -1,3 +1,4 @@
+WARNING Multiple named addresses in package 'Root' share the same address 0x1: [A, B]. If these addresses are different in a non-dev build, the package may behave differently than in testing.
 ResolutionGraph {
     root_package_path: "tests/test_sources/resolution/conflicting_dev_address_with_dev_dep",
     build_options: BuildConfig {

--- a/third_party/move/tools/move-package/tests/test_sources/resolution/conflicting_dev_address_with_dev_dep/Move.exp
+++ b/third_party/move/tools/move-package/tests/test_sources/resolution/conflicting_dev_address_with_dev_dep/Move.exp
@@ -1,1 +1,193 @@
-Unable to resolve packages for package 'Root': Found non-unique dev address assignment 'B = 0x1' in root package 'Root'. Dev address assignments must not conflict with any other assignments in order to ensure that the package will compile with any possible address assignment. Assignment conflicts with previous assignments: A = 0x1
+ResolutionGraph {
+    root_package_path: "tests/test_sources/resolution/conflicting_dev_address_with_dev_dep",
+    build_options: BuildConfig {
+        dev_mode: true,
+        test_mode: false,
+        verify_mode: false,
+        override_std: None,
+        generate_docs: false,
+        generate_abis: false,
+        generate_move_model: false,
+        full_model_generation: false,
+        install_dir: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        force_recompilation: false,
+        additional_named_addresses: {},
+        fetch_deps_only: false,
+        skip_fetch_latest_git_deps: false,
+        compiler_config: CompilerConfig {
+            bytecode_version: None,
+            known_attributes: {
+                "bytecode_instruction",
+                "deprecated",
+                "expected_failure",
+                "lint::skip",
+                "module_lock",
+                "native_interface",
+                "persistent",
+                "test",
+                "test_only",
+                "verify_only",
+            },
+            skip_attribute_checks: false,
+            compiler_version: Some(
+                V2_0,
+            ),
+            language_version: None,
+            experiments: [],
+            print_errors: false,
+        },
+    },
+    root_package: SourceManifest {
+        package: PackageInfo {
+            name: "Root",
+            version: (
+                0,
+                0,
+                0,
+            ),
+            authors: [],
+            license: None,
+            custom_properties: {},
+        },
+        addresses: Some(
+            {
+                "A": Some(
+                    0000000000000000000000000000000000000000000000000000000000000001,
+                ),
+                "B": None,
+            },
+        ),
+        dev_address_assignments: Some(
+            {
+                "B": 0000000000000000000000000000000000000000000000000000000000000001,
+            },
+        ),
+        build: None,
+        dependencies: {},
+        dev_dependencies: {
+            "A": Dependency {
+                local: "./deps_only/A",
+                subst: None,
+                version: None,
+                digest: None,
+                git_info: None,
+                node_info: None,
+            },
+        },
+    },
+    graph: {
+        "Root": [
+            (
+                "A",
+                Outgoing,
+            ),
+        ],
+        "A": [
+            (
+                "Root",
+                Incoming,
+            ),
+        ],
+    },
+    package_table: {
+        "A": ResolutionPackage {
+            resolution_graph_index: "A",
+            source_package: SourceManifest {
+                package: PackageInfo {
+                    name: "A",
+                    version: (
+                        0,
+                        0,
+                        0,
+                    ),
+                    authors: [],
+                    license: None,
+                    custom_properties: {},
+                },
+                addresses: Some(
+                    {
+                        "A": None,
+                    },
+                ),
+                dev_address_assignments: Some(
+                    {
+                        "A": 0000000000000000000000000000000000000000000000000000000000000001,
+                    },
+                ),
+                build: None,
+                dependencies: {},
+                dev_dependencies: {},
+            },
+            package_path: "ELIDED_FOR_TEST",
+            resolution_table: {
+                "A": 0000000000000000000000000000000000000000000000000000000000000001,
+            },
+            source_digest: "ELIDED_FOR_TEST",
+        },
+        "Root": ResolutionPackage {
+            resolution_graph_index: "Root",
+            source_package: SourceManifest {
+                package: PackageInfo {
+                    name: "Root",
+                    version: (
+                        0,
+                        0,
+                        0,
+                    ),
+                    authors: [],
+                    license: None,
+                    custom_properties: {},
+                },
+                addresses: Some(
+                    {
+                        "A": Some(
+                            0000000000000000000000000000000000000000000000000000000000000001,
+                        ),
+                        "B": None,
+                    },
+                ),
+                dev_address_assignments: Some(
+                    {
+                        "B": 0000000000000000000000000000000000000000000000000000000000000001,
+                    },
+                ),
+                build: None,
+                dependencies: {},
+                dev_dependencies: {
+                    "A": Dependency {
+                        local: "./deps_only/A",
+                        subst: None,
+                        version: None,
+                        digest: None,
+                        git_info: None,
+                        node_info: None,
+                    },
+                },
+            },
+            package_path: "ELIDED_FOR_TEST",
+            resolution_table: {
+                "A": 0000000000000000000000000000000000000000000000000000000000000001,
+                "B": 0000000000000000000000000000000000000000000000000000000000000001,
+            },
+            source_digest: "ELIDED_FOR_TEST",
+        },
+    },
+    global_named_address_pool: {
+        "A": ResolvingNamedAddress {
+            value: RefCell {
+                value: Some(
+                    0000000000000000000000000000000000000000000000000000000000000001,
+                ),
+            },
+        },
+        "B": ResolvingNamedAddress {
+            value: RefCell {
+                value: Some(
+                    0000000000000000000000000000000000000000000000000000000000000001,
+                ),
+            },
+        },
+    },
+}

--- a/third_party/move/tools/move-package/tests/test_sources/resolution/conflicting_dev_addresses/Move.exp
+++ b/third_party/move/tools/move-package/tests/test_sources/resolution/conflicting_dev_addresses/Move.exp
@@ -1,1 +1,128 @@
-Unable to resolve packages for package 'Root': Found non-unique dev address assignment 'B = 0x1' in root package 'Root'. Dev address assignments must not conflict with any other assignments in order to ensure that the package will compile with any possible address assignment. Assignment conflicts with previous assignments: A = 0x1
+ResolutionGraph {
+    root_package_path: "tests/test_sources/resolution/conflicting_dev_addresses",
+    build_options: BuildConfig {
+        dev_mode: true,
+        test_mode: false,
+        verify_mode: false,
+        override_std: None,
+        generate_docs: false,
+        generate_abis: false,
+        generate_move_model: false,
+        full_model_generation: false,
+        install_dir: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        force_recompilation: false,
+        additional_named_addresses: {},
+        fetch_deps_only: false,
+        skip_fetch_latest_git_deps: false,
+        compiler_config: CompilerConfig {
+            bytecode_version: None,
+            known_attributes: {
+                "bytecode_instruction",
+                "deprecated",
+                "expected_failure",
+                "lint::skip",
+                "module_lock",
+                "native_interface",
+                "persistent",
+                "test",
+                "test_only",
+                "verify_only",
+            },
+            skip_attribute_checks: false,
+            compiler_version: Some(
+                V2_0,
+            ),
+            language_version: None,
+            experiments: [],
+            print_errors: false,
+        },
+    },
+    root_package: SourceManifest {
+        package: PackageInfo {
+            name: "Root",
+            version: (
+                0,
+                0,
+                0,
+            ),
+            authors: [],
+            license: None,
+            custom_properties: {},
+        },
+        addresses: Some(
+            {
+                "A": None,
+                "B": None,
+            },
+        ),
+        dev_address_assignments: Some(
+            {
+                "A": 0000000000000000000000000000000000000000000000000000000000000001,
+                "B": 0000000000000000000000000000000000000000000000000000000000000001,
+            },
+        ),
+        build: None,
+        dependencies: {},
+        dev_dependencies: {},
+    },
+    graph: {
+        "Root": [],
+    },
+    package_table: {
+        "Root": ResolutionPackage {
+            resolution_graph_index: "Root",
+            source_package: SourceManifest {
+                package: PackageInfo {
+                    name: "Root",
+                    version: (
+                        0,
+                        0,
+                        0,
+                    ),
+                    authors: [],
+                    license: None,
+                    custom_properties: {},
+                },
+                addresses: Some(
+                    {
+                        "A": None,
+                        "B": None,
+                    },
+                ),
+                dev_address_assignments: Some(
+                    {
+                        "A": 0000000000000000000000000000000000000000000000000000000000000001,
+                        "B": 0000000000000000000000000000000000000000000000000000000000000001,
+                    },
+                ),
+                build: None,
+                dependencies: {},
+                dev_dependencies: {},
+            },
+            package_path: "ELIDED_FOR_TEST",
+            resolution_table: {
+                "A": 0000000000000000000000000000000000000000000000000000000000000001,
+                "B": 0000000000000000000000000000000000000000000000000000000000000001,
+            },
+            source_digest: "ELIDED_FOR_TEST",
+        },
+    },
+    global_named_address_pool: {
+        "A": ResolvingNamedAddress {
+            value: RefCell {
+                value: Some(
+                    0000000000000000000000000000000000000000000000000000000000000001,
+                ),
+            },
+        },
+        "B": ResolvingNamedAddress {
+            value: RefCell {
+                value: Some(
+                    0000000000000000000000000000000000000000000000000000000000000001,
+                ),
+            },
+        },
+    },
+}

--- a/third_party/move/tools/move-package/tests/test_sources/resolution/conflicting_dev_addresses/Move.exp
+++ b/third_party/move/tools/move-package/tests/test_sources/resolution/conflicting_dev_addresses/Move.exp
@@ -1,3 +1,4 @@
+WARNING Multiple named addresses in package 'Root' share the same address 0x1: [A, B]. If these addresses are different in a non-dev build, the package may behave differently than in testing.
 ResolutionGraph {
     root_package_path: "tests/test_sources/resolution/conflicting_dev_addresses",
     build_options: BuildConfig {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Relaxes the requirement that dev address assignments must have unique values. Previously, if two different named addresses in `[dev-addresses]` were assigned the same account address value, the Move package resolver would reject the package with:

```
Found non-unique dev address assignment 'aptos_names_v2_1 = 0x867ed...' in root package 'bulk'.
Dev address assignments must not conflict with any other assignments...
```

This is a valid use case — for example, `aptos_names` and `aptos_names_v2_1` may legitimately point to the same on-chain account. Regular (non-dev) addresses already allow duplicate values; this change makes dev addresses consistent with that behavior.

Instead of a hard error, a **warning** is now emitted when duplicate dev address values are detected, noting that if these addresses differ in a non-dev build, the package may behave differently than in dev mode / testing. One warning is emitted per group of conflicting names (not per assignment).

## How Has This Been Tested?

- All 76 existing `move-package` tests pass (`cargo test -p move-package`).
- The three `conflicting_dev_address*` test cases that previously expected errors now successfully resolve with duplicate address values, and their baselines include the warning text for formatting verification.
- `cargo check -p move-package` passes with no warnings.

## Key Areas to Review

- `third_party/move/tools/move-package/src/resolution/resolution_graph.rs` — the `bail!` in `unify_addresses_in_package` for duplicate dev address values was replaced with a `writeln!` warning. Conflict detection happens after the unification loop, emitting one warning per group of names sharing an address (only when at least one is a dev address assignment).
- `third_party/move/tools/move-package/tests/test_runner.rs` — the test runner now captures writer output and includes WARNING lines in `.exp` baselines.

## Type of Change
- [x] Bug fix

## Which Components or Systems Does This Change Impact?
- [x] Move Compiler

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1c9ec013-99e3-4eae-acfa-a1507f217d23"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1c9ec013-99e3-4eae-acfa-a1507f217d23"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

