### PR TITLE
[aptos-framework] resolving warnings from unused linters

### DIFF
--- a/aptos-move/framework/aptos-framework/sources/account/account.move
+++ b/aptos-move/framework/aptos-framework/sources/account/account.move
@@ -120,12 +120,14 @@ module aptos_framework::account {
         // the new public key that the account owner wants to rotate to
     }
 
+    #[deprecated]
     /// Deprecated struct - newest version is `RotationCapabilityOfferProofChallengeV2`
     struct RotationCapabilityOfferProofChallenge has drop {
         sequence_number: u64,
         recipient_address: address,
     }
 
+    #[deprecated]
     /// Deprecated struct - newest version is `SignerCapabilityOfferProofChallengeV2`
     struct SignerCapabilityOfferProofChallenge has drop {
         sequence_number: u64,

--- a/aptos-move/framework/aptos-framework/sources/account/account_abstraction.move
+++ b/aptos-move/framework/aptos-framework/sources/account/account_abstraction.move
@@ -41,8 +41,6 @@ module aptos_framework::account_abstraction {
     /// source is defined in Scheme enum in types/src/transaction/authenticator.rs
     const DERIVABLE_ABSTRACTION_DERIVED_SCHEME: u8 = 5;
 
-    const MAX_U64: u128 = 18446744073709551615;
-
     #[event]
     struct UpdateDispatchableAuthenticator has store, drop {
         account: address,
@@ -271,6 +269,7 @@ module aptos_framework::account_abstraction {
         &DerivableDispatchableAuthenticator[@aptos_framework].auth_functions
    }
 
+    #[lint::skip(unused_function)]
     fun authenticate(
         account: signer,
         func_info: FunctionInfo,

--- a/aptos-move/framework/aptos-framework/sources/account/common_account_abstractions/solana_derivable_account.move
+++ b/aptos-move/framework/aptos-framework/sources/account/common_account_abstractions/solana_derivable_account.move
@@ -42,7 +42,6 @@ module aptos_framework::solana_derivable_account {
     // a 58-character alphabet consisting of numbers (1-9) and almost all (A-Z, a-z) letters,
     // excluding 0, O, I, and l to avoid confusion between similar-looking characters.
     const BASE_58_ALPHABET: vector<u8> = b"123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
-    const HEX_ALPHABET: vector<u8> = b"0123456789abcdef";
     const PUBLIC_KEY_NUM_BYTES: u64 = 32;
 
     enum SIWSAbstractSignature has drop {

--- a/aptos-move/framework/aptos-framework/sources/aptos_governance.move
+++ b/aptos-move/framework/aptos-framework/sources/aptos_governance.move
@@ -210,6 +210,7 @@ module aptos_framework::aptos_governance {
         signer_caps.add(signer_address, signer_cap);
     }
 
+    #[lint::skip(unused_function)]
     /// Initializes the state for Aptos Governance. Can only be called during Genesis with a signer
     /// for the aptos_framework (0x1) account.
     /// This function is private because it's called directly from the vm.

--- a/aptos-move/framework/aptos-framework/sources/block.move
+++ b/aptos-move/framework/aptos-framework/sources/block.move
@@ -59,6 +59,7 @@ module aptos_framework::block {
     }
 
     #[event]
+    #[deprecated]
     /// Should be in-sync with NewBlockEvent rust struct in new_block.rs
     struct NewBlock has drop, store {
         hash: address,
@@ -199,6 +200,7 @@ module aptos_framework::block {
         block_metadata_ref.epoch_interval
     }
 
+    #[lint::skip(unused_function)]
     /// Set the metadata for the current block.
     /// The runtime always runs this before executing the transactions in a block.
     fun block_prologue(
@@ -230,6 +232,7 @@ module aptos_framework::block {
         };
     }
 
+    #[lint::skip(unused_function)]
     /// `block_prologue()` but trigger reconfiguration with DKG after epoch timed out.
     fun block_prologue_ext(
         vm: signer,
@@ -261,6 +264,7 @@ module aptos_framework::block {
         };
     }
 
+    #[lint::skip(unused_function)]
     /// `block_prologue()` but also update the decryption key and trigger
     /// reconfiguration with DKG and Chunky DKG after epoch timed out.
     fun block_prologue_ext_v2(
@@ -294,6 +298,7 @@ module aptos_framework::block {
         };
     }
 
+    #[lint::skip(unused_function)]
     fun block_epilogue(
         vm: &signer,
         fee_distribution_validator_indices: vector<u64>,
@@ -336,6 +341,7 @@ module aptos_framework::block {
         event::emit_event<NewBlockEvent>(event_handle, new_block_event);
     }
 
+    #[lint::skip(unused_function)]
     /// Emit a `NewBlockEvent` event. This function will be invoked by genesis directly to generate the very first
     /// reconfiguration event.
     fun emit_genesis_block_event(vm: signer) acquires BlockResource, CommitHistory {

--- a/aptos-move/framework/aptos-framework/sources/code.move
+++ b/aptos-move/framework/aptos-framework/sources/code.move
@@ -151,6 +151,7 @@ module aptos_framework::code {
         from.policy <= to.policy
     }
 
+    #[lint::skip(unused_function)]
     /// Initialize package metadata for Genesis.
     fun initialize(aptos_framework: &signer, package_owner: &signer, metadata: PackageMetadata)
     acquires PackageRegistry {

--- a/aptos-move/framework/aptos-framework/sources/coin.move
+++ b/aptos-move/framework/aptos-framework/sources/coin.move
@@ -139,6 +139,7 @@ module aptos_framework::coin {
         value: Aggregator
     }
 
+    #[lint::skip(unused_constant)]
     /// Maximum possible aggregatable coin value.
     const MAX_U64: u128 = 18446744073709551615;
 
@@ -173,6 +174,7 @@ module aptos_framework::coin {
     }
 
     #[event]
+    #[deprecated]
     /// Module event emitted when some amount of a coin is deposited into an account.
     struct CoinDeposit has drop, store {
         coin_type: String,
@@ -181,6 +183,7 @@ module aptos_framework::coin {
     }
 
     #[event]
+    #[deprecated]
     /// Module event emitted when some amount of a coin is withdrawn from an account.
     struct CoinWithdraw has drop, store {
         coin_type: String,
@@ -620,23 +623,6 @@ module aptos_framework::coin {
         _aptos_framework: &signer, _allowed: bool
     ) {
         abort error::invalid_state(ECOIN_SUPPLY_UPGRADE_NOT_SUPPORTED)
-    }
-
-    inline fun calculate_amount_to_withdraw<CoinType>(
-        account_addr: address, amount: u64
-    ): (u64, u64) {
-        let coin_balance = coin_balance<CoinType>(account_addr);
-        if (coin_balance >= amount) {
-            (amount, 0)
-        } else {
-            let metadata = paired_metadata<CoinType>();
-            if (metadata.is_some()
-                && primary_fungible_store::primary_store_exists(
-                    account_addr, metadata.destroy_some()
-                ))
-                (coin_balance, amount - coin_balance)
-            else abort error::invalid_argument(EINSUFFICIENT_BALANCE)
-        }
     }
 
     fun maybe_convert_to_fungible_store<CoinType>(

--- a/aptos-move/framework/aptos-framework/sources/configs/randomness_api_v0_config.move
+++ b/aptos-move/framework/aptos-framework/sources/configs/randomness_api_v0_config.move
@@ -14,6 +14,7 @@ module aptos_framework::randomness_api_v0_config {
         value: bool,
     }
 
+    #[lint::skip(unused_function)]
     /// Only used in genesis.
     fun initialize(framework: &signer, required_amount: RequiredGasDeposit, allow_custom_max_gas_flag: AllowCustomMaxGasFlag) {
         system_addresses::assert_aptos_framework(framework);

--- a/aptos-move/framework/aptos-framework/sources/configs/staking_config.move
+++ b/aptos-move/framework/aptos-framework/sources/configs/staking_config.move
@@ -37,6 +37,7 @@ module aptos_framework::staking_config {
 
     /// Limit the maximum value of `rewards_rate` in order to avoid any arithmetic overflow.
     const MAX_REWARDS_RATE: u64 = 1000000;
+    #[lint::skip(unused_constant)]
     /// Denominator of number in basis points. 1 bps(basis points) = 0.01%.
     const BPS_DENOMINATOR: u64 = 10000;
     /// 1 year => 365 * 24 * 60 * 60

--- a/aptos-move/framework/aptos-framework/sources/configs/version.move
+++ b/aptos-move/framework/aptos-framework/sources/configs/version.move
@@ -76,6 +76,7 @@ module aptos_framework::version {
         }
     }
 
+    #[lint::skip(unused_function)]
     /// Only called in tests and testnets. This allows the core resources account, which only exists in tests/testnets,
     /// to update the version.
     fun initialize_for_test(core_resources: &signer) {

--- a/aptos-move/framework/aptos-framework/sources/fungible_asset.move
+++ b/aptos-move/framework/aptos-framework/sources/fungible_asset.move
@@ -1384,11 +1384,6 @@ module aptos_framework::fungible_asset {
         borrow_global<Metadata>(addr)
     }
 
-    inline fun borrow_fungible_metadata_mut<T: key>(metadata: &Object<T>): &mut Metadata {
-        let addr = metadata.object_address();
-        borrow_global_mut<Metadata>(addr)
-    }
-
     inline fun borrow_store_resource<T: key>(store: &Object<T>): &FungibleStore {
         let store_addr = store.object_address();
         assert!(

--- a/aptos-move/framework/aptos-framework/sources/genesis.move
+++ b/aptos-move/framework/aptos-framework/sources/genesis.move
@@ -64,6 +64,7 @@ module aptos_framework::genesis {
         join_during_genesis: bool,
     }
 
+    #[lint::skip(unused_function)]
     /// Genesis step 1: Initialize aptos framework account and core modules on chain.
     fun initialize(
         gas_schedule: vector<u8>,
@@ -134,6 +135,7 @@ module aptos_framework::genesis {
         nonce_validation::initialize(&aptos_framework_account);
     }
 
+    #[lint::skip(unused_function)]
     /// Genesis step 2: Initialize Aptos coin.
     fun initialize_aptos_coin(aptos_framework: &signer) {
         let (burn_cap, mint_cap) = aptos_coin::initialize(aptos_framework);
@@ -149,6 +151,7 @@ module aptos_framework::genesis {
         transaction_fee::store_aptos_coin_mint_cap(aptos_framework, mint_cap);
     }
 
+    #[lint::skip(unused_function)]
     /// Only called for testnets and e2e tests.
     fun initialize_core_resources_and_aptos_coin(
         aptos_framework: &signer,
@@ -172,6 +175,7 @@ module aptos_framework::genesis {
         aptos_coin::configure_accounts_for_test(aptos_framework, &core_resources, mint_cap);
     }
 
+    #[lint::skip(unused_function)]
     fun create_accounts(aptos_framework: &signer, accounts: vector<AccountMap>) {
         let unique_accounts = vector::empty();
         accounts.for_each_ref(|account_map| {
@@ -206,6 +210,7 @@ module aptos_framework::genesis {
         account
     }
 
+    #[lint::skip(unused_function)]
     fun create_employee_validators(
         employee_vesting_start: u64,
         employee_vesting_period_duration: u64,
@@ -311,6 +316,7 @@ module aptos_framework::genesis {
         stake::on_new_epoch();
     }
 
+    #[lint::skip(unused_function)]
     /// Sets up the initial validator set for the network.
     /// The validator "owner" accounts, and their authentication
     /// Addresses (and keys) are encoded in the `owners`
@@ -390,6 +396,7 @@ module aptos_framework::genesis {
         stake::join_validator_set_internal(operator, pool_address);
     }
 
+    #[lint::skip(unused_function)]
     /// The last step of genesis.
     fun set_genesis_end(aptos_framework: &signer) {
         chain_status::set_genesis_end(aptos_framework);

--- a/aptos-move/framework/aptos-framework/sources/keyless_account.move
+++ b/aptos-move/framework/aptos-framework/sources/keyless_account.move
@@ -1,12 +1,10 @@
 /// This module is responsible for configuring keyless blockchain accounts which were introduced in
 /// [AIP-61](https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-61.md).
 module aptos_framework::keyless_account {
-    use std::bn254_algebra;
     use std::config_buffer;
     use std::option::Option;
     use std::signer;
     use std::string::String;
-    use aptos_std::crypto_algebra;
     use aptos_std::ed25519;
     use aptos_framework::chain_status;
     use aptos_framework::system_addresses;
@@ -175,18 +173,6 @@ module aptos_framework::keyless_account {
             max_extra_field_bytes,
             max_jwt_header_b64_bytes,
         }
-    }
-
-    /// Pre-validate the VK to actively-prevent incorrect VKs from being set on-chain.
-    fun validate_groth16_vk(vk: &Groth16VerificationKey) {
-        // Could be leveraged to speed up the VM deserialization of the VK by 2x, since it can assume the points are valid.
-        assert!(crypto_algebra::deserialize<bn254_algebra::G1, bn254_algebra::FormatG1Compr>(&vk.alpha_g1).is_some(), E_INVALID_BN254_G1_SERIALIZATION);
-        assert!(crypto_algebra::deserialize<bn254_algebra::G2, bn254_algebra::FormatG2Compr>(&vk.beta_g2).is_some(), E_INVALID_BN254_G2_SERIALIZATION);
-        assert!(crypto_algebra::deserialize<bn254_algebra::G2, bn254_algebra::FormatG2Compr>(&vk.gamma_g2).is_some(), E_INVALID_BN254_G2_SERIALIZATION);
-        assert!(crypto_algebra::deserialize<bn254_algebra::G2, bn254_algebra::FormatG2Compr>(&vk.delta_g2).is_some(), E_INVALID_BN254_G2_SERIALIZATION);
-        for (i in 0..vk.gamma_abc_g1.length()) {
-            assert!(crypto_algebra::deserialize<bn254_algebra::G1, bn254_algebra::FormatG1Compr>(vk.gamma_abc_g1.borrow(i)).is_some(), E_INVALID_BN254_G1_SERIALIZATION);
-        };
     }
 
     /// Sets the Groth16 verification key, only callable during genesis. To call during governance proposals, use

--- a/aptos-move/framework/aptos-framework/sources/multisig_account.move
+++ b/aptos-move/framework/aptos-framework/sources/multisig_account.move
@@ -1100,6 +1100,7 @@ module aptos_framework::multisig_account {
 
     ////////////////////////// To be called by VM only ///////////////////////////////
 
+    #[lint::skip(unused_function)]
     /// Called by the VM as part of transaction prologue, which is invoked during mempool transaction validation and as
     /// the first step of transaction execution.
     ///
@@ -1150,6 +1151,7 @@ module aptos_framework::multisig_account {
         }
     }
 
+    #[lint::skip(unused_function)]
     /// Post-execution cleanup for a successful multisig transaction execution.
     /// This function is private so no other code can call this beside the VM itself as part of MultisigTransaction.
     fun successful_transaction_execution_cleanup(
@@ -1170,6 +1172,7 @@ module aptos_framework::multisig_account {
         );
     }
 
+    #[lint::skip(unused_function)]
     /// Post-execution cleanup for a failed multisig transaction execution.
     /// This function is private so no other code can call this beside the VM itself as part of MultisigTransaction.
     fun failed_transaction_execution_cleanup(

--- a/aptos-move/framework/aptos-framework/sources/object.move
+++ b/aptos-move/framework/aptos-framework/sources/object.move
@@ -59,9 +59,11 @@ module aptos_framework::object {
     /// nesting, but any checks such as transfer will only be evaluated this deep.
     const MAXIMUM_OBJECT_NESTING: u8 = 8;
 
+    #[test_only]
     /// generate_unique_address uses this for domain separation within its native implementation
     const DERIVE_AUID_ADDRESS_SCHEME: u8 = 0xFB;
 
+    #[test_only]
     /// Scheme identifier used to generate an object's address `obj_addr` as derived from another object.
     /// The object's address is generated as:
     /// ```

--- a/aptos-move/framework/aptos-framework/sources/permissioned_signer.move
+++ b/aptos-move/framework/aptos-framework/sources/permissioned_signer.move
@@ -383,21 +383,6 @@ module aptos_framework::permissioned_signer {
         }
     }
 
-    /// merge the two stored permission
-    fun merge(lhs: &mut StoredPermission, rhs: StoredPermission) {
-        match (rhs) {
-            StoredPermission::Capacity(new_capacity) => {
-                match (lhs) {
-                    StoredPermission::Capacity(current_capacity) => {
-                        *current_capacity += new_capacity;
-                    }
-                    StoredPermission::Unlimited => (),
-                }
-            }
-            StoredPermission::Unlimited => *lhs = StoredPermission::Unlimited,
-        }
-    }
-
     /// =====================================================================================================
     /// Permission Management
     ///

--- a/aptos-move/framework/aptos-framework/sources/randomness.move
+++ b/aptos-move/framework/aptos-framework/sources/randomness.move
@@ -25,9 +25,6 @@ module aptos_framework::randomness {
     /// `#[randomness]` annotation. Otherwise, malicious users can bias randomness result.
     const E_API_USE_IS_BIASIBLE: u64 = 1;
 
-    const MAX_U256: u256 =
-        115792089237316195423570985008687907853269984665640564039457584007913129639935;
-
     /// 32-byte randomness seed unique to every block.
     /// This resource is updated in every block prologue.
     struct PerBlockRandomness has drop, key {

--- a/aptos-move/framework/aptos-framework/sources/reconfiguration.move
+++ b/aptos-move/framework/aptos-framework/sources/reconfiguration.move
@@ -83,6 +83,7 @@ module aptos_framework::reconfiguration {
         );
     }
 
+    #[lint::skip(unused_function)]
     /// Private function to temporarily halt reconfiguration.
     /// This function should only be used for offline WriteSet generation purpose and should never be invoked on chain.
     fun disable_reconfiguration(aptos_framework: &signer) {
@@ -91,6 +92,7 @@ module aptos_framework::reconfiguration {
         move_to(aptos_framework, DisableReconfiguration {})
     }
 
+    #[lint::skip(unused_function)]
     /// Private function to resume reconfiguration.
     /// This function should only be used for offline WriteSet generation purpose and should never be invoked on chain.
     fun enable_reconfiguration(aptos_framework: &signer) acquires DisableReconfiguration {
@@ -163,6 +165,7 @@ module aptos_framework::reconfiguration {
         borrow_global<Configuration>(@aptos_framework).epoch
     }
 
+    #[lint::skip(unused_function)]
     /// Emit a `NewEpochEvent` event. This function will be invoked by genesis directly to generate the very first
     /// reconfiguration event.
     fun emit_genesis_reconfiguration_event() acquires Configuration {

--- a/aptos-move/framework/aptos-framework/sources/reconfiguration_with_dkg.move
+++ b/aptos-move/framework/aptos-framework/sources/reconfiguration_with_dkg.move
@@ -100,6 +100,7 @@ module aptos_framework::reconfiguration_with_dkg {
         }
     }
 
+    #[lint::skip(unused_function)]
     /// Complete the current DKG session with the given result.
     /// Aborts if no DKG session is in progress.
     /// If Chunky DKG is enabled, finish(account) is invoked only once both DKG and Chunky DKG
@@ -113,6 +114,7 @@ module aptos_framework::reconfiguration_with_dkg {
         }
     }
 
+    #[lint::skip(unused_function)]
     /// Complete the current Chunky DKG session with the given result.
     /// No-op if Chunky DKG is not enabled.
     /// Buffers the derived encryption key for the next epoch.

--- a/aptos-move/framework/aptos-framework/sources/stake.move
+++ b/aptos-move/framework/aptos-framework/sources/stake.move
@@ -99,6 +99,7 @@ module aptos_framework::stake {
     /// https://github.com/aptos-labs/aptos-core/blob/main/crates/aptos-bitvec/src/lib.rs#L20
     const MAX_VALIDATOR_SET_SIZE: u64 = 65536;
 
+    #[lint::skip(unused_constant)]
     /// Limit the maximum value of `rewards_rate` in order to avoid any arithmetic overflow.
     const MAX_REWARDS_RATE: u64 = 1000000;
 
@@ -232,6 +233,7 @@ module aptos_framework::stake {
     struct StakeManagementPermission has copy, drop, store {}
 
     #[event]
+    #[deprecated]
     struct RegisterValidatorCandidate has drop, store {
         pool_address: address
     }
@@ -1780,13 +1782,6 @@ module aptos_framework::stake {
         );
 
         validator_consensus_infos
-    }
-
-    fun addresses_from_validator_infos(infos: &vector<ValidatorInfo>): vector<address> {
-        infos.map_ref(|obj| {
-            let info: &ValidatorInfo = obj;
-            info.addr
-        })
     }
 
     /// Calculate the stake amount of a stake pool for the next epoch.

--- a/aptos-move/framework/aptos-framework/sources/state_storage.move
+++ b/aptos-move/framework/aptos-framework/sources/state_storage.move
@@ -80,6 +80,7 @@ module aptos_framework::state_storage {
     // ======================== deprecated ============================
     friend aptos_framework::reconfiguration;
 
+    #[deprecated]
     struct GasParameter has key, store {
         usage: Usage,
     }

--- a/aptos-move/framework/aptos-framework/sources/transaction_fee.move
+++ b/aptos-move/framework/aptos-framework/sources/transaction_fee.move
@@ -110,6 +110,7 @@ module aptos_framework::transaction_fee {
     }
 
     // Called by the VM after epilogue.
+    #[lint::skip(unused_function)]
     fun emit_fee_statement(fee_statement: FeeStatement) {
         event::emit(fee_statement)
     }

--- a/aptos-move/framework/aptos-framework/sources/transaction_validation.move
+++ b/aptos-move/framework/aptos-framework/sources/transaction_validation.move
@@ -64,7 +64,6 @@ module aptos_framework::transaction_validation {
     const PROLOGUE_EBAD_CHAIN_ID: u64 = 1007;
     const PROLOGUE_ESEQUENCE_NUMBER_TOO_BIG: u64 = 1008;
     const PROLOGUE_ESECONDARY_KEYS_ADDRESSES_COUNT_MISMATCH: u64 = 1009;
-    const PROLOGUE_EFEE_PAYER_NOT_ENABLED: u64 = 1010;
     const PROLOGUE_PERMISSIONED_GAS_LIMIT_INSUFFICIENT: u64 = 1011;
     const PROLOGUE_ENONCE_ALREADY_USED: u64 = 1012;
     const PROLOGUE_ETRANSACTION_EXPIRATION_TOO_FAR_IN_FUTURE: u64 = 1013;
@@ -251,6 +250,7 @@ module aptos_framework::transaction_validation {
         assert!(nonce_validation::check_and_insert_nonce(sender, nonce, txn_expiration_time), error::invalid_argument(PROLOGUE_ENONCE_ALREADY_USED));
     }
 
+    #[lint::skip(unused_function)]
     fun script_prologue(
         sender: signer,
         txn_sequence_number: u64,
@@ -278,6 +278,7 @@ module aptos_framework::transaction_validation {
     // This function extends the script_prologue by adding a parameter to indicate simulation mode.
     // Once the transaction_simulation_enhancement feature is enabled, the Aptos VM will invoke this function instead.
     // Eventually, this function will be consolidated with the original function once the feature is fully enabled.
+    #[lint::skip(unused_function)]
     fun script_prologue_extended(
         sender: signer,
         txn_sequence_number: u64,
@@ -302,6 +303,7 @@ module aptos_framework::transaction_validation {
         )
     }
 
+    #[lint::skip(unused_function)]
     fun multi_agent_script_prologue(
         sender: signer,
         txn_sequence_number: u64,
@@ -336,6 +338,7 @@ module aptos_framework::transaction_validation {
     // This function extends the multi_agent_script_prologue by adding a parameter to indicate simulation mode.
     // Once the transaction_simulation_enhancement feature is enabled, the Aptos VM will invoke this function instead.
     // Eventually, this function will be consolidated with the original function once the feature is fully enabled.
+    #[lint::skip(unused_function)]
     fun multi_agent_script_prologue_extended(
         sender: signer,
         txn_sequence_number: u64,
@@ -426,6 +429,7 @@ module aptos_framework::transaction_validation {
         }
     }
 
+    #[lint::skip(unused_function)]
     fun fee_payer_script_prologue(
         sender: signer,
         txn_sequence_number: u64,
@@ -466,6 +470,7 @@ module aptos_framework::transaction_validation {
     // This function extends the fee_payer_script_prologue by adding a parameter to indicate simulation mode.
     // Once the transaction_simulation_enhancement feature is enabled, the Aptos VM will invoke this function instead.
     // Eventually, this function will be consolidated with the original function once the feature is fully enabled.
+    #[lint::skip(unused_function)]
     fun fee_payer_script_prologue_extended(
         sender: signer,
         txn_sequence_number: u64,
@@ -504,6 +509,7 @@ module aptos_framework::transaction_validation {
         }
     }
 
+    #[lint::skip(unused_function)]
     /// Epilogue function is run after a transaction is successfully executed.
     /// Called by the Adapter
     fun epilogue(
@@ -527,6 +533,7 @@ module aptos_framework::transaction_validation {
     // This function extends the epilogue by adding a parameter to indicate simulation mode.
     // Once the transaction_simulation_enhancement feature is enabled, the Aptos VM will invoke this function instead.
     // Eventually, this function will be consolidated with the original function once the feature is fully enabled.
+    #[lint::skip(unused_function)]
     fun epilogue_extended(
         account: signer,
         storage_fee_refunded: u64,
@@ -622,9 +629,10 @@ module aptos_framework::transaction_validation {
     }
 
     ///////////////////////////////////////////////////////////
-    /// new set of functions
+    // new set of functions
     ///////////////////////////////////////////////////////////
 
+    #[lint::skip(unused_function)]
     fun unified_prologue(
         sender: signer,
         // None means no need to check, i.e. either AA (where it is already checked) or simulation
@@ -653,6 +661,7 @@ module aptos_framework::transaction_validation {
         )
     }
 
+    #[lint::skip(unused_function)]
     /// If there is no fee_payer, fee_payer = sender
     fun unified_prologue_fee_payer(
         sender: signer,
@@ -686,6 +695,7 @@ module aptos_framework::transaction_validation {
         )
     }
 
+    #[lint::skip(unused_function)]
     fun unified_epilogue(
         account: signer,
         gas_payer: signer,

--- a/aptos-move/framework/aptos-framework/sources/vesting.move
+++ b/aptos-move/framework/aptos-framework/sources/vesting.move
@@ -221,6 +221,7 @@ module aptos_framework::vesting {
     }
 
     #[event]
+    #[deprecated]
     struct UnlockRewards has drop, store {
         admin: address,
         vesting_contract_address: address,


### PR DESCRIPTION
## Description
This PR gets rid of the warnings from the unused linters on `aptos-framework`. 
- remove truly unused private functions and constants
- add #[deprecated] on unused but published structs
- add #[test_only] on items that are used for test only
- add #[lint::skip(unused_function)] for vm-called-only functions and otherwise needed functions
- #[lint::skip(unused_constant)] on constants used as error codes


## How Has This Been Tested?
- existing tests

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [x] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily adds lint/deprecation/test-only annotations and removes dead private helpers/constants; behavioral impact should be minimal, but deprecating on-chain event/struct types could affect downstream indexers relying on legacy types.
> 
> **Overview**
> Cleans up Aptos Framework unused-lint warnings by **removing truly-unused private helpers/constants** (e.g., in `coin`, `fungible_asset`, `permissioned_signer`, `stake`, `randomness`, and `transaction_validation`) and trimming unused imports.
> 
> Adds **`#[lint::skip(unused_function|unused_constant)]`** to VM-/genesis-invoked but otherwise unreferenced functions/constants across modules (e.g., `block` prologues/epilogue, `genesis` init steps, `code::initialize`, `reconfiguration` helpers, multisig VM hooks, `transaction_fee::emit_fee_statement`, and `transaction_validation` prologue/epilogue variants).
> 
> Marks legacy/published types as **`#[deprecated]`** (e.g., old proof challenge structs in `account`, `block::NewBlock`, `coin` deposit/withdraw events, `stake::RegisterValidatorCandidate`, `vesting::UnlockRewards`, and `state_storage::GasParameter`) and tags a couple of derivation scheme constants in `object` as **`#[test_only]`**.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8957dfb952a3b917f00e65532735782841c03963. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->