### PR TITLE
[cli] Update default move formatter version to 1.5.1

### DIFF
--- a/crates/aptos/CHANGELOG.md
+++ b/crates/aptos/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to the Aptos CLI will be captured in this file. This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) and the format set out by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Unreleased
+- Updated default formatter version to 1.5.1.
 
 ## [9.0.0]
 - Add linter rules `unused_function`, `unused_struct`, and `unused_constant` to detect unused items.

--- a/crates/aptos/src/update/movefmt.rs
+++ b/crates/aptos/src/update/movefmt.rs
@@ -13,7 +13,7 @@ use self_update::update::ReleaseUpdate;
 use std::path::PathBuf;
 
 const FORMATTER_BINARY_NAME: &str = "movefmt";
-const TARGET_FORMATTER_VERSION: &str = "1.4.9";
+const TARGET_FORMATTER_VERSION: &str = "1.5.1";
 
 const FORMATTER_EXE_ENV: &str = "FORMATTER_EXE";
 #[cfg(target_os = "windows")]


### PR DESCRIPTION
## Description

The latest move formatter version is 1.5.1, we update the CLI's default version to this.

## How Has This Been Tested?

Manually.

## Type of Change
- [x] Dependency update

## Which Components or Systems Does This Change Impact?
- [x] Aptos CLI/SDK

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only changes the CLI’s default `movefmt` target version used by `aptos update movefmt`, with no runtime logic changes beyond pulling a newer formatter binary.
> 
> **Overview**
> Updates the Aptos CLI’s default Move formatter (`movefmt`) version from `1.4.9` to `1.5.1`, so `aptos update movefmt` installs/targets the newer release by default.
> 
> Documents the version bump in `crates/aptos/CHANGELOG.md` under *Unreleased*.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 23def3f72b7e241a1253979eb19ac60298e4fe8b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->