### PR TITLE
fix: trim and skip empty entries in no_proxy parsing

### DIFF
--- a/crates/proxy/src/lib.rs
+++ b/crates/proxy/src/lib.rs
@@ -83,8 +83,11 @@ impl NoProxy {
         }
         let mut ips = Vec::new();
         let mut domains = Vec::new();
-        let parts = raw.split(',');
-        for part in parts {
+        for part in raw.split(',') {
+            let part = part.trim();
+            if part.is_empty() {
+                continue;
+            }
             match part.parse::<IpNet>() {
                 // If we can parse an IP net or address, then use it, otherwise, assume it is a domain
                 Ok(ip) => ips.push(Ip::Network(ip)),


### PR DESCRIPTION
Handle whitespace and empty entries in NO_PROXY parsing

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small parsing tweak limited to `NO_PROXY` handling; behavior changes only for inputs with whitespace or empty comma-separated entries.
> 
> **Overview**
> Improves `NO_PROXY`/`no_proxy` parsing by trimming whitespace around comma-separated entries and ignoring empty segments before attempting IP/CIDR/domain parsing.
> 
> This prevents malformed or blank tokens from being treated as domains and makes proxy bypass rules more robust to user formatting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit efd861457ce574aebf531996745032831fdb2382. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->