### PR TITLE
[Framework] Release yaml upgrade for v1.42.1.

### DIFF
--- a/aptos-move/aptos-release-builder/data/release.yaml
+++ b/aptos-move/aptos-release-builder/data/release.yaml
@@ -1,20 +1,20 @@
 ---
-remote_endpoint: https://fullnode.mainnet.aptoslabs.com
+remote_endpoint: https://fullnode.testnet.aptoslabs.com
 # replace with below for actual release, compat test needs concrete URL above:
 # remote_endpoint: ~
-name: "vX.YY.Z"
+name: "v1.42.1"
 proposals:
   - name: proposal_1_upgrade_framework
     metadata:
-      title: "Multi-step proposal to upgrade mainnet framework, version vX.YY.Z"
-      description: "This includes changes in https://github.com/aptos-labs/aptos-core/releases/tag/aptos-node-vX.YY.Z"
+      title: "Multi-step proposal to upgrade testnet framework, version v1.42.1"
+      description: "This includes changes in https://github.com/aptos-labs/aptos-core/releases/tag/aptos-node-v1.42.1"
     execution_mode: MultiStep
     update_sequence:
       - Gas:
-          new: current
+          # new: current
           # replace with below for actual release, above "current" is needed for compat tests:
-          # old: https://raw.githubusercontent.com/aptos-labs/aptos-networks/main/gas/vX.WW.Z.json
-          # new: https://raw.githubusercontent.com/aptos-labs/aptos-networks/main/gas/vX.YY.Z.json
+          old: https://raw.githubusercontent.com/aptos-labs/aptos-networks/main/gas/v1.41.1.json
+          new: https://raw.githubusercontent.com/aptos-labs/aptos-networks/main/gas/v1.42.1.json
       - Framework:
           bytecode_version: 8
           git_hash: ~


### PR DESCRIPTION
## Description
This PR updates the framework release yaml for v1.42.1.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Updates a release configuration YAML to point at testnet and the v1.42.1 gas/release artifacts; no runtime code changes. Risk is limited to incorrect endpoints/URLs impacting the release/compat pipeline.
> 
> **Overview**
> Updates `aptos-release-builder/data/release.yaml` for the `v1.42.1` framework release by switching the `remote_endpoint` to testnet, updating proposal metadata to reference `aptos-node-v1.42.1`, and setting gas upgrade inputs from `v1.41.1.json` to `v1.42.1.json` (commenting out the `new: current` compat-test setting).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0451d60e8d174ba18e60f55f0fabd8f4f78f5dd5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->