### PR TITLE
[storage] Persist WriteSet hotness in ledger DB behind config flag

### DIFF
--- a/config/src/config/storage_config.rs
+++ b/config/src/config/storage_config.rs
@@ -251,6 +251,8 @@ pub struct HotStateConfig {
     /// Whether we compute root hashes for hot state in executor and commit the resulting JMT to
     /// db.
     pub compute_root_hash: bool,
+    /// Whether to persist hotness data alongside write sets in write set DB.
+    pub persist_hotness_in_write_set: bool,
 }
 
 impl Default for HotStateConfig {
@@ -260,6 +262,7 @@ impl Default for HotStateConfig {
             refresh_interval_versions: 100_000,
             delete_on_restart: true,
             compute_root_hash: true,
+            persist_hotness_in_write_set: true,
         }
     }
 }
@@ -684,6 +687,16 @@ impl ConfigOptimizer for StorageConfig {
                 && config_yaml["hot_state_config"]["compute_root_hash"].as_bool() != Some(true)
             {
                 config.hot_state_config.compute_root_hash = false;
+                modified_config = true;
+            }
+            // TODO(HotState): Hotness persistence in write sets is disabled on mainnet and testnet
+            // unless explicitly enabled.
+            if (chain_id.is_mainnet() || chain_id.is_testnet())
+                && config_yaml["hot_state_config"]["persist_hotness_in_write_set"].as_bool()
+                    != Some(true)
+            {
+                config.hot_state_config.persist_hotness_in_write_set = false;
+                modified_config = true;
             }
         }
 

--- a/storage/aptosdb/src/backup/restore_utils.rs
+++ b/storage/aptosdb/src/backup/restore_utils.rs
@@ -261,6 +261,7 @@ pub(crate) fn save_transactions_impl(
             first_version + idx as Version,
             ws,
             &mut ledger_db_batch.write_set_db_batches,
+            /*persist_hotness=*/ false, // TODO(HotState): revisit.
         )?;
     }
 

--- a/storage/aptosdb/src/db/aptosdb_internal.rs
+++ b/storage/aptosdb/src/db/aptosdb_internal.rs
@@ -141,7 +141,7 @@ impl AptosDB {
                 Some(&block_cache),
                 readonly,
                 max_num_nodes_per_lru_cache_shard,
-                hot_state_config.delete_on_restart,
+                hot_state_config,
             )?;
 
         let myself = Self::new_with_dbs(
@@ -230,7 +230,11 @@ impl AptosDB {
                 None,  // block_cache
                 false, // readonly
                 0,     // max_num_nodes_per_lru_cache_shard
-                true,  // reset_hot_state
+                HotStateConfig {
+                    delete_on_restart: true,
+                    persist_hotness_in_write_set: false,
+                    ..HotStateConfig::default()
+                },
             )?;
 
         let ledger_db = Arc::new(ledger_db);

--- a/storage/aptosdb/src/db/aptosdb_test.rs
+++ b/storage/aptosdb/src/db/aptosdb_test.rs
@@ -439,7 +439,10 @@ proptest! {
                 None,
                 /*readonly=*/ false,
                 /*max_num_nodes_per_lru_cache_shard=*/ 0,
-                /*reset_hot_state=*/ true,
+                HotStateConfig {
+                    delete_on_restart: true,
+                    ..HotStateConfig::default()
+                },
             )
             .unwrap();
 

--- a/storage/aptosdb/src/db/mod.rs
+++ b/storage/aptosdb/src/db/mod.rs
@@ -104,7 +104,7 @@ impl AptosDB {
         block_cache: Option<&Cache>,
         readonly: bool,
         max_num_nodes_per_lru_cache_shard: usize,
-        reset_hot_state: bool,
+        hot_state_config: HotStateConfig,
     ) -> Result<(
         LedgerDb,
         Option<StateMerkleDb>,
@@ -118,6 +118,7 @@ impl AptosDB {
             env,
             block_cache,
             readonly,
+            hot_state_config.persist_hotness_in_write_set,
         )?;
         let hot_state_kv_db = if !readonly {
             Some(StateKvDb::new(
@@ -127,7 +128,7 @@ impl AptosDB {
                 block_cache,
                 readonly,
                 /* is_hot = */ true,
-                reset_hot_state,
+                hot_state_config.delete_on_restart,
             )?)
         } else {
             None
@@ -150,7 +151,7 @@ impl AptosDB {
                 readonly,
                 max_num_nodes_per_lru_cache_shard,
                 /* is_hot = */ true,
-                reset_hot_state,
+                hot_state_config.delete_on_restart,
             )?)
         } else {
             None

--- a/storage/aptosdb/src/db_debugger/common/mod.rs
+++ b/storage/aptosdb/src/db_debugger/common/mod.rs
@@ -55,7 +55,8 @@ impl DbDir {
             RocksdbConfig::default(),
             env,
             block_cache,
-            true,
+            /*readonly=*/ true,
+            /*persist_write_set_hotness=*/ false,
         )
     }
 }

--- a/storage/aptosdb/src/db_debugger/examine/print_db_versions.rs
+++ b/storage/aptosdb/src/db_debugger/examine/print_db_versions.rs
@@ -17,7 +17,7 @@ use crate::{
     },
     AptosDB,
 };
-use aptos_config::config::{RocksdbConfigs, StorageDirPaths};
+use aptos_config::config::{HotStateConfig, RocksdbConfigs, StorageDirPaths};
 use aptos_schemadb::{schema::Schema, DB};
 use aptos_storage_interface::Result;
 use aptos_types::{state_store::NUM_STATE_SHARDS, transaction::Version};
@@ -45,7 +45,11 @@ impl Cmd {
                 block_cache,
                 /*readonly=*/ true,
                 /*max_num_nodes_per_lru_cache_shard=*/ 0,
-                /*reset_hot_state=*/ false,
+                HotStateConfig {
+                    delete_on_restart: false,
+                    persist_hotness_in_write_set: false,
+                    ..HotStateConfig::default()
+                },
             )?;
 
         println!(

--- a/storage/aptosdb/src/db_debugger/examine/print_raw_data_by_version.rs
+++ b/storage/aptosdb/src/db_debugger/examine/print_raw_data_by_version.rs
@@ -2,7 +2,7 @@
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::AptosDB;
-use aptos_config::config::{RocksdbConfigs, StorageDirPaths};
+use aptos_config::config::{HotStateConfig, RocksdbConfigs, StorageDirPaths};
 use aptos_storage_interface::Result;
 use clap::Parser;
 use std::path::PathBuf;
@@ -30,7 +30,11 @@ impl Cmd {
             block_cache,
             /*readonly=*/ true,
             /*max_num_nodes_per_lru_cache_shard=*/ 0,
-            /*reset_hot_state=*/ false,
+            HotStateConfig {
+                delete_on_restart: false,
+                persist_hotness_in_write_set: false,
+                ..HotStateConfig::default()
+            },
         )?;
 
         println!(

--- a/storage/aptosdb/src/db_debugger/truncate/mod.rs
+++ b/storage/aptosdb/src/db_debugger/truncate/mod.rs
@@ -7,7 +7,7 @@ use crate::{
         get_current_version_in_state_merkle_db, get_state_kv_commit_progress,
     },
 };
-use aptos_config::config::{RocksdbConfigs, StorageDirPaths};
+use aptos_config::config::{HotStateConfig, RocksdbConfigs, StorageDirPaths};
 use aptos_storage_interface::{db_ensure as ensure, AptosDbError, Result};
 use claims::assert_le;
 use clap::Parser;
@@ -66,7 +66,11 @@ impl Cmd {
                     None,
                     /*readonly=*/ false,
                     /*max_num_nodes_per_lru_cache_shard=*/ 0,
-                    /*reset_hot_state=*/ true,
+                    HotStateConfig {
+                        delete_on_restart: true,
+                        persist_hotness_in_write_set: false,
+                        ..HotStateConfig::default()
+                    },
                 )?;
 
             let ledger_db = Arc::new(ledger_db);

--- a/storage/aptosdb/src/ledger_db/mod.rs
+++ b/storage/aptosdb/src/ledger_db/mod.rs
@@ -115,6 +115,7 @@ impl LedgerDb {
         env: Option<&Env>,
         block_cache: Option<&Cache>,
         readonly: bool,
+        persist_write_set_hotness: bool,
     ) -> Result<Self> {
         let ledger_metadata_db_path = Self::metadata_db_path(db_root_path.as_ref());
         let ledger_metadata_db = Arc::new(Self::open_rocksdb(
@@ -224,17 +225,20 @@ impl LedgerDb {
                 )));
             });
             s.spawn(|_| {
-                write_set_db = Some(WriteSetDb::new(Arc::new(
-                    Self::open_rocksdb(
-                        ledger_db_folder.join(WRITE_SET_DB_NAME),
-                        WRITE_SET_DB_NAME,
-                        &ledger_db_config,
-                        env,
-                        block_cache,
-                        readonly,
-                    )
-                    .unwrap(),
-                )));
+                write_set_db = Some(WriteSetDb::new(
+                    Arc::new(
+                        Self::open_rocksdb(
+                            ledger_db_folder.join(WRITE_SET_DB_NAME),
+                            WRITE_SET_DB_NAME,
+                            &ledger_db_config,
+                            env,
+                            block_cache,
+                            readonly,
+                        )
+                        .unwrap(),
+                    ),
+                    persist_write_set_hotness,
+                ));
             });
         });
 
@@ -262,6 +266,7 @@ impl LedgerDb {
             None,
             None,
             /*readonly=*/ false,
+            /*persist_write_set_hotness=*/ false,
         )?;
         let cp_ledger_db_folder = cp_root_path.as_ref().join(LEDGER_DB_FOLDER_NAME);
 

--- a/storage/aptosdb/src/ledger_db/write_set_db.rs
+++ b/storage/aptosdb/src/ledger_db/write_set_db.rs
@@ -5,13 +5,15 @@ use crate::{
     metrics::OTHER_TIMERS_SECONDS,
     schema::{
         db_metadata::{DbMetadataKey, DbMetadataSchema, DbMetadataValue},
-        write_set::WriteSetSchema,
+        write_set::{encode_write_set, WriteSetSchema},
+        WRITE_SET_CF_NAME,
     },
     utils::iterators::ExpectContinuousVersions,
 };
 use aptos_metrics_core::TimerHelper;
 use aptos_schemadb::{
     batch::{SchemaBatch, WriteBatch},
+    schema::KeyCodec,
     ReadOptions, DB,
 };
 use aptos_storage_interface::{db_ensure as ensure, AptosDbError, Result};
@@ -25,11 +27,15 @@ use std::{path::Path, sync::Arc};
 #[derive(Debug)]
 pub(crate) struct WriteSetDb {
     db: Arc<DB>,
+    persist_hotness: bool,
 }
 
 impl WriteSetDb {
-    pub(super) fn new(db: Arc<DB>) -> Self {
-        Self { db }
+    pub(super) fn new(db: Arc<DB>, persist_hotness: bool) -> Self {
+        Self {
+            db,
+            persist_hotness,
+        }
     }
 
     pub(super) fn create_checkpoint(&self, path: impl AsRef<Path>) -> Result<()> {
@@ -127,6 +133,7 @@ impl WriteSetDb {
     ) -> Result<()> {
         let _timer = OTHER_TIMERS_SECONDS.timer_with(&["commit_write_sets"]);
 
+        let persist_hotness = self.persist_hotness;
         let chunk_size = transaction_outputs.len() / 4 + 1;
         let batches = transaction_outputs
             .par_chunks(chunk_size)
@@ -140,6 +147,7 @@ impl WriteSetDb {
                         chunk_first_version + i as Version,
                         txn_out.write_set(),
                         &mut batch,
+                        persist_hotness,
                     )
                 })?;
                 Ok(batch)
@@ -160,8 +168,20 @@ impl WriteSetDb {
         version: Version,
         write_set: &WriteSet,
         batch: &mut impl WriteBatch,
+        persist_hotness: bool,
     ) -> Result<()> {
-        batch.put::<WriteSetSchema>(&version, write_set)
+        if persist_hotness {
+            // Bypass `ValueCodec::encode_value` (whose signature doesn't allow passing the
+            // flag) and encode via `encode_write_set` + `raw_put` instead.
+            let key_bytes = <Version as KeyCodec<WriteSetSchema>>::encode_key(&version)?;
+            let value_bytes = encode_write_set(write_set, /*persist_hotness=*/ true)?;
+            batch
+                .stats()
+                .put(WRITE_SET_CF_NAME, key_bytes.len() + value_bytes.len());
+            batch.raw_put(WRITE_SET_CF_NAME, key_bytes, value_bytes)
+        } else {
+            batch.put::<WriteSetSchema>(&version, write_set)
+        }
     }
 
     /// Deletes the write sets between a range of version in [begin, end).

--- a/storage/aptosdb/src/schema/write_set/mod.rs
+++ b/storage/aptosdb/src/schema/write_set/mod.rs
@@ -19,9 +19,14 @@ use aptos_schemadb::{
     define_schema,
     schema::{KeyCodec, ValueCodec},
 };
-use aptos_types::{transaction::Version, write_set::WriteSet};
+use aptos_types::{
+    state_store::state_key::StateKey,
+    transaction::Version,
+    write_set::{HotStateOp, ValueWriteSet, WriteSet, WriteSetV0},
+};
 use byteorder::{BigEndian, ReadBytesExt};
-use std::mem::size_of;
+use serde::{Deserialize, Serialize};
+use std::{collections::BTreeSet, mem::size_of};
 
 define_schema!(WriteSetSchema, Version, WriteSet, WRITE_SET_CF_NAME);
 
@@ -36,13 +41,60 @@ impl KeyCodec<WriteSetSchema> for Version {
     }
 }
 
+/// Storage-only serialization format for `WriteSet`. Separate from `ValueWriteSet` so that the
+/// `BCSCryptoHash` (which goes through `WriteSet::Serialize` → `ValueWriteSet`) is not affected
+/// for now.
+#[derive(Serialize, Deserialize)]
+enum PersistedWriteSet {
+    /// Legacy format: identical BCS layout to `ValueWriteSet::V0`.
+    V0(WriteSetV0),
+    /// Extended format that also persists the set of hot state keys.
+    V1 {
+        value: WriteSetV0,
+        hotness: BTreeSet<StateKey>,
+    },
+}
+
+/// Encode a `WriteSet` for storage. When `persist_hotness` is true, produces the V1 format
+/// (which includes the set of hot state keys); otherwise produces the legacy V0 format
+/// (byte-identical to `bcs::to_bytes(write_set)`).
+pub(crate) fn encode_write_set(
+    write_set: &WriteSet,
+    persist_hotness: bool,
+) -> bcs::Result<Vec<u8>> {
+    if persist_hotness {
+        let persisted = PersistedWriteSet::V1 {
+            value: write_set.as_v0().clone(),
+            hotness: write_set.hotness_keys().cloned().collect(),
+        };
+        bcs::to_bytes(&persisted)
+    } else {
+        // Delegates to WriteSet::Serialize → ValueWriteSet → V0 layout.
+        bcs::to_bytes(write_set)
+    }
+}
+
+/// Decode a `WriteSet` from storage, handling both V0 (legacy) and V1 (with hotness) formats.
+fn decode_write_set(data: &[u8]) -> bcs::Result<WriteSet> {
+    match bcs::from_bytes(data)? {
+        PersistedWriteSet::V0(ws_v0) => Ok(WriteSet::new_from_value(ValueWriteSet::V0(ws_v0))),
+        PersistedWriteSet::V1 { value, hotness } => Ok(WriteSet::new_from_value_with_hotness(
+            ValueWriteSet::V0(value),
+            hotness
+                .into_iter()
+                .map(|key| (key, HotStateOp::make_hot()))
+                .collect(),
+        )),
+    }
+}
+
 impl ValueCodec<WriteSetSchema> for WriteSet {
     fn encode_value(&self) -> Result<Vec<u8>> {
         bcs::to_bytes(self).map_err(Into::into)
     }
 
     fn decode_value(data: &[u8]) -> Result<Self> {
-        bcs::from_bytes(data).map_err(Into::into)
+        decode_write_set(data).map_err(Into::into)
     }
 }
 

--- a/storage/aptosdb/src/schema/write_set/test.rs
+++ b/storage/aptosdb/src/schema/write_set/test.rs
@@ -3,7 +3,9 @@
 
 use super::*;
 use aptos_schemadb::{schema::fuzzing::assert_encode_decode, test_no_panic_decoding};
+use aptos_types::write_set::WriteOp;
 use proptest::prelude::*;
+use std::collections::BTreeMap;
 
 proptest! {
     #[test]
@@ -16,3 +18,74 @@ proptest! {
 }
 
 test_no_panic_decoding!(WriteSetSchema);
+
+/// Data serialized with the old format (`bcs::to_bytes` via the custom `WriteSet::Serialize`,
+/// which only serializes the `value` field) must decode correctly through `decode_write_set`.
+#[test]
+fn test_decode_legacy_format() {
+    let ws = WriteSet::new(vec![
+        (
+            StateKey::raw(b"key1"),
+            WriteOp::legacy_creation(b"val1".to_vec().into()),
+        ),
+        (
+            StateKey::raw(b"key2"),
+            WriteOp::legacy_modification(b"val2".to_vec().into()),
+        ),
+    ])
+    .unwrap();
+
+    // Old encode path: WriteSet::Serialize → ValueWriteSet::V0
+    let old_bytes = bcs::to_bytes(&ws).unwrap();
+    let decoded = decode_write_set(&old_bytes).unwrap();
+
+    assert_eq!(decoded.as_v0(), ws.as_v0());
+    assert_eq!(decoded.hotness_keys().count(), 0);
+}
+
+/// Roundtrip: a `WriteSet` with hotness, encoded via `encode_write_set(..., true)` and decoded
+/// via `decode_write_set`, must preserve both the value write ops and the set of hot keys.
+#[test]
+fn test_roundtrip_with_hotness() {
+    let mut ws = WriteSet::new(vec![(
+        StateKey::raw(b"a"),
+        WriteOp::legacy_creation(b"v".to_vec().into()),
+    )])
+    .unwrap();
+
+    let hot_keys: BTreeMap<StateKey, HotStateOp> = [
+        (StateKey::raw(b"hot1"), HotStateOp::make_hot()),
+        (StateKey::raw(b"hot2"), HotStateOp::make_hot()),
+    ]
+    .into_iter()
+    .collect();
+    ws.add_hotness(hot_keys);
+
+    let encoded = encode_write_set(&ws, true).unwrap();
+    let decoded = decode_write_set(&encoded).unwrap();
+
+    assert_eq!(decoded.as_v0(), ws.as_v0());
+    assert_eq!(
+        decoded.hotness_keys().collect::<BTreeSet<_>>(),
+        ws.hotness_keys().collect::<BTreeSet<_>>(),
+    );
+}
+
+/// `encode_write_set(ws, false)` must produce byte-identical output to the old
+/// `bcs::to_bytes(&ws)` path. This guarantees `PersistedWriteSet::V0` has the same BCS layout
+/// as `ValueWriteSet::V0`.
+#[test]
+fn test_v0_byte_identity() {
+    let ws = WriteSet::new(vec![
+        (
+            StateKey::raw(b"x"),
+            WriteOp::legacy_creation(b"y".to_vec().into()),
+        ),
+        (StateKey::raw(b"z"), WriteOp::legacy_deletion()),
+    ])
+    .unwrap();
+
+    let old_bytes = bcs::to_bytes(&ws).unwrap();
+    let new_bytes = encode_write_set(&ws, false).unwrap();
+    assert_eq!(old_bytes, new_bytes);
+}

--- a/storage/aptosdb/src/state_store/hot_state.rs
+++ b/storage/aptosdb/src/state_store/hot_state.rs
@@ -649,6 +649,7 @@ mod tests {
         refresh_interval_versions: 100,
         delete_on_restart: false,
         compute_root_hash: true,
+        persist_hotness_in_write_set: true,
     };
 
     fn make_hot_slot(version: Version, value: &[u8]) -> StateSlot {

--- a/storage/aptosdb/src/state_store/tests/speculative_state_workflow.rs
+++ b/storage/aptosdb/src/state_store/tests/speculative_state_workflow.rs
@@ -62,6 +62,7 @@ const TEST_CONFIG: HotStateConfig = HotStateConfig {
     refresh_interval_versions: REFRESH_INTERVAL_VERSIONS,
     delete_on_restart: false,
     compute_root_hash: true,
+    persist_hotness_in_write_set: true,
 };
 
 #[derive(Debug)]

--- a/types/src/write_set.rs
+++ b/types/src/write_set.rs
@@ -548,7 +548,8 @@ impl Debug for HotStateOp {
 #[derive(BCSCryptoHash, Clone, CryptoHasher, Debug, Default, Eq, PartialEq)]
 pub struct WriteSet {
     value: ValueWriteSet,
-    /// TODO(HotState): this field is not serialized for now.
+    /// Hot state promotions, non-empty only in block epilogues.
+    /// TODO(HotState): not hashed into `TransactionInfo` for now.
     hotness: BTreeMap<StateKey, HotStateOp>,
 }
 
@@ -595,6 +596,20 @@ impl WriteSet {
 
     pub fn into_mut(self) -> WriteSetMut {
         self.into_v0().0
+    }
+
+    pub fn new_from_value(value: ValueWriteSet) -> Self {
+        Self {
+            value,
+            hotness: BTreeMap::new(),
+        }
+    }
+
+    pub fn new_from_value_with_hotness(
+        value: ValueWriteSet,
+        hotness: BTreeMap<StateKey, HotStateOp>,
+    ) -> Self {
+        Self { value, hotness }
     }
 
     pub fn new(write_ops: impl IntoIterator<Item = (StateKey, WriteOp)>) -> Result<Self> {
@@ -675,6 +690,10 @@ impl WriteSet {
                     EitherOrBoth::Both(e, _) => e,
                 }
             })
+    }
+
+    pub fn hotness_keys(&self) -> impl Iterator<Item = &StateKey> {
+        self.hotness.keys()
     }
 
     pub fn add_hotness(&mut self, hotness: BTreeMap<StateKey, HotStateOp>) {


### PR DESCRIPTION

Optionally store hot state keys alongside write sets in RocksDB, gated
by `HotStateConfig::persist_hotness_in_write_set`. Enabled by default
but overridden to `false` on mainnet and testnet unless the operator
explicitly opts in via config YAML.

The key challenge is that `WriteSet` has a custom `Serialize` impl used
by `BCSCryptoHash` — it only serializes the `value` field, deliberately
skipping `hotness`. Changing this would break the crypto hash of every
write set. To work around this, a separate `PersistedWriteSet` enum in
the storage schema layer handles serialization with two variants:

- **V0**: identical BCS layout to the existing `ValueWriteSet::V0` —
  backward compatible with all existing data.
- **V1**: extends V0 with a `BTreeSet<StateKey>` of hot keys.

The read path (`decode_value`) handles both formats transparently. The
write path uses `raw_put` to bypass `ValueCodec::encode_value` (which
would use the hash-compatible serialization) when hotness needs to be
persisted.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new on-disk encoding path for `WriteSet` and a config-gated change to what gets persisted in RocksDB; mistakes could cause read/restore incompatibilities or larger disk usage, though decoding remains backward compatible.
> 
> **Overview**
> Adds an opt-in `HotStateConfig::persist_hotness_in_write_set` flag to persist hot-state key promotions alongside write sets in the ledger `write_set_db`.
> 
> Implements a versioned storage encoding (`PersistedWriteSet` V0/V1) so existing write-set bytes remain valid while enabling a new format that includes hotness keys; the write path conditionally bypasses the default codec via `raw_put`, and all call sites opening `LedgerDb`/`AptosDB` are updated to plumb the flag (disabled by default on mainnet/testnet unless explicitly enabled).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 98b5d43909f42842f0c482e096d9f0df5708261e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->