### PR TITLE
[localnet] Add --use-internal-fullnode-data-interface

### DIFF
--- a/crates/aptos/src/node/local_testnet/node.rs
+++ b/crates/aptos/src/node/local_testnet/node.rs
@@ -61,6 +61,14 @@ pub struct NodeArgs {
     #[clap(long, default_value_t = DEFAULT_GRPC_STREAM_PORT)]
     txn_stream_port: u16,
 
+    /// Use the internal FullnodeData gRPC interface instead of the RawData (data
+    /// service) interface for the transaction stream. This is needed for example when
+    /// running the indexer-grpc-manager stack against the localnet, since the manager
+    /// expects the FullnodeData interface. If you aren't sure if you need to enable
+    /// this, you almost certainly don't.
+    #[clap(long)]
+    use_internal_fullnode_data_interface: bool,
+
     /// If set we won't run the node at all.
     //
     // Note: I decided that since running multiple partial localnets is a rare
@@ -88,6 +96,7 @@ pub struct NodeManager {
     config: NodeConfig,
     test_dir: PathBuf,
     no_node: bool,
+    use_internal_fullnode_data_interface: bool,
 }
 
 pub fn build_node_config(
@@ -135,6 +144,7 @@ impl NodeManager {
             !args.node_args.no_txn_stream,
             args.node_args.txn_stream_port,
             args.node_args.no_node,
+            args.node_args.use_internal_fullnode_data_interface,
         )
     }
 
@@ -145,12 +155,17 @@ impl NodeManager {
         run_txn_stream: bool,
         txn_stream_port: u16,
         no_node: bool,
+        use_internal_fullnode_data_interface: bool,
     ) -> Result<Self> {
         eprintln!();
 
         // Enable the grpc stream on the node if we will run a txn stream service.
         node_config.indexer_grpc.enabled = run_txn_stream;
-        node_config.indexer_grpc.use_data_service_interface = run_txn_stream;
+        // When use_internal_fullnode_data_interface is set, expose the internal
+        // FullnodeData gRPC interface instead of the RawData interface. The
+        // indexer-grpc-manager expects FullnodeData/GetTransactionsFromNode.
+        node_config.indexer_grpc.use_data_service_interface =
+            run_txn_stream && !use_internal_fullnode_data_interface;
         node_config.indexer_grpc.address.set_port(txn_stream_port);
 
         node_config.indexer_table_info.table_info_service_mode = match run_txn_stream {
@@ -172,6 +187,7 @@ impl NodeManager {
             config: node_config,
             test_dir,
             no_node,
+            use_internal_fullnode_data_interface,
         })
     }
 
@@ -207,7 +223,9 @@ impl ServiceManager for NodeManager {
         let node_api_url = self.get_node_api_url();
         let mut checkers = HashSet::new();
         checkers.insert(HealthChecker::NodeApi(node_api_url));
-        if self.config.indexer_grpc.enabled {
+        // The DataServiceGrpc health check uses the RawData interface, which
+        // is not available when the FullnodeData interface is exposed instead.
+        if self.config.indexer_grpc.enabled && !self.use_internal_fullnode_data_interface {
             let data_service_url = self.get_data_service_url();
             checkers.insert(HealthChecker::DataServiceGrpc(data_service_url));
         }

--- a/ecosystem/indexer-grpc/indexer-transaction-generator/src/managed_node.rs
+++ b/ecosystem/indexer-grpc/indexer-transaction-generator/src/managed_node.rs
@@ -60,6 +60,7 @@ impl ManagedNode {
             true,
             DEFAULT_GRPC_STREAM_PORT,
             false,
+            false,
         )
         .context("Failed to start node service manager")?;
 


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->
This PR adds support for `--use-internal-fullnode-data-interface`. This makes the localnet expose the internal data service interface instead of the one we normally expose to clients in the localnet / hosted data service. This is useful for some testing cases, e.g. using the localnet as the node in front of a grpc v2 stack.

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->
See https://github.com/aptos-labs/aptos-core/pull/18835.

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [x] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes how localnet configures the indexer gRPC transaction stream interface and skips the existing RawData health check when that interface is disabled, which can affect downstream tooling connectivity.
> 
> **Overview**
> Adds a new localnet CLI flag `--use-internal-fullnode-data-interface` to switch the node’s transaction stream from the external RawData (data service) gRPC interface to the internal FullnodeData interface.
> 
> When enabled, localnet now configures `indexer_grpc.use_data_service_interface` accordingly and avoids registering the `DataServiceGrpc` health check (since it relies on the RawData interface). Updates `indexer-transaction-generator` to pass the new `NodeManager::new_with_config` parameter.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 94a937ea61bd82ace0c5906c265ca92245cbf554. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->