### PR TITLE
Fix replay_protection_nonce for encrypted transactions

### DIFF
--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -925,12 +925,7 @@ impl TransactionPayload {
     }
 
     pub fn replay_protection_nonce(&self) -> Option<u64> {
-        match self {
-            Self::Payload(TransactionPayloadInner::V1 { extra_config, .. }) => {
-                extra_config.replay_protection_nonce()
-            },
-            _ => None,
-        }
+        self.extra_config().replay_protection_nonce()
     }
 
     pub fn executable(&self) -> Result<TransactionExecutable> {


### PR DESCRIPTION
## Summary
- `TransactionPayload::replay_protection_nonce()` used a wildcard `_ => None` match that silently returned `None` for `EncryptedPayload`, causing encrypted orderless transactions to have their replay protection nonce ignored.
- Replaced with delegation through `extra_config()`, which already exhaustively handles all payload variants including `EncryptedPayload`.

## Test plan
- [x] `cargo check -p aptos-types` passes
- [x] `cargo test -p aptos-types` passes
- [x] Audited other `_ =>` wildcards on `TransactionPayload` — no similar issues found

🤖 Generated with [Claude Code](https://claude.com/claude-code)