### PR TITLE
[forge] Add auto-restart, pre-built binary support, and use clang linker on Linux

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -26,6 +26,7 @@ x = "run --package aptos-cargo-cli --bin aptos-cargo-cli --"
 rustflags = ["--cfg", "tokio_unstable", "-C", "force-frame-pointers=yes", "-C", "force-unwind-tables=yes"]
 
 [target.x86_64-unknown-linux-gnu]
+linker = "clang"
 # We also need to include `-C linker-plugin-lto` for performance builds to take
 # full advantage of LTO, but we cannot add it here because it would affect dev
 # and release builds as well, so we add it only when building docker images.

--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -10,7 +10,7 @@ use clap::{Parser, Subcommand};
 use futures::{future, FutureExt};
 use rand::{rngs::ThreadRng, seq::SliceRandom, Rng};
 use serde_json::{json, Value};
-use std::{self, num::NonZeroUsize, process, time::Duration};
+use std::{self, num::NonZeroUsize, path::PathBuf, process, time::Duration};
 use sugars::{boxed, hmap};
 use suites::{
     dag::get_dag_test,
@@ -103,6 +103,13 @@ struct LocalSwarm {
         default_value_t = 1
     )]
     concurrency_level: u16,
+    #[clap(
+        long,
+        help = "Path to a pre-built aptos-node binary (skips cargo build)"
+    )]
+    aptos_node_binary: Option<String>,
+    #[clap(long, help = "Automatically restart crashed validator nodes")]
+    auto_restart: bool,
 }
 
 #[derive(Parser, Debug)]
@@ -310,9 +317,14 @@ fn main() -> Result<()> {
                         .as_deref()
                         .map(|s| s.split(':').map(String::from).collect())
                         .unwrap_or_default();
-                    let factory = LocalFactory::from_workspace(swarm_dir)?
-                        .with_node_affinities(cpu_affinities, mem_binds)
-                        .with_concurrency_level(local_cfg.concurrency_level);
+                    let factory = if let Some(ref binary) = local_cfg.aptos_node_binary {
+                        LocalFactory::from_binary(PathBuf::from(binary), swarm_dir)?
+                    } else {
+                        LocalFactory::from_workspace(swarm_dir)?
+                    }
+                    .with_node_affinities(cpu_affinities, mem_binds)
+                    .with_concurrency_level(local_cfg.concurrency_level)
+                    .with_auto_restart(local_cfg.auto_restart);
                     let forge = Forge::new(&args.options, test_suite, duration, factory);
                     run_forge(forge, &args.options)
                 },

--- a/testsuite/forge/src/backend/local/mod.rs
+++ b/testsuite/forge/src/backend/local/mod.rs
@@ -50,6 +50,7 @@ pub struct LocalFactory {
     cpu_affinities: Vec<String>,
     mem_binds: Vec<String>,
     concurrency_level: u16,
+    auto_restart: bool,
 }
 
 impl LocalFactory {
@@ -60,6 +61,7 @@ impl LocalFactory {
             cpu_affinities: Vec::new(),
             mem_binds: Vec::new(),
             concurrency_level: 1,
+            auto_restart: false,
         }
     }
 
@@ -76,6 +78,25 @@ impl LocalFactory {
         self.cpu_affinities = cpu_affinities;
         self.mem_binds = mem_binds;
         self
+    }
+
+    pub fn with_auto_restart(mut self, auto_restart: bool) -> Self {
+        self.auto_restart = auto_restart;
+        self
+    }
+
+    /// Create a LocalFactory with a pre-built aptos-node binary, skipping cargo build.
+    pub fn from_binary(binary_path: PathBuf, swarm_dir: Option<String>) -> Result<Self> {
+        anyhow::ensure!(
+            binary_path.exists(),
+            "aptos-node binary not found: {:?}",
+            binary_path
+        );
+        let version = Version::new(usize::MAX, "prebuilt".to_string());
+        let local_version = LocalVersion::new(binary_path, version.clone());
+        let mut versions = HashMap::new();
+        versions.insert(version, local_version);
+        Ok(Self::new(versions, swarm_dir))
     }
 
     pub fn from_workspace(swarm_dir: Option<String>) -> Result<Self> {
@@ -165,6 +186,7 @@ impl LocalFactory {
             self.cpu_affinities.clone(),
             self.mem_binds.clone(),
             self.concurrency_level,
+            self.auto_restart,
         )?;
 
         // Launch the swarm

--- a/testsuite/forge/src/backend/local/node.rs
+++ b/testsuite/forge/src/backend/local/node.rs
@@ -11,7 +11,7 @@ use aptos_db::{
     common::{LEDGER_DB_NAME, STATE_MERKLE_DB_NAME},
     fast_sync_storage_wrapper::SECONDARY_DB_DIR,
 };
-use aptos_logger::{debug, info};
+use aptos_logger::{debug, error, info};
 use aptos_sdk::{
     crypto::ed25519::Ed25519PrivateKey,
     types::{account_address::AccountAddress, PeerId},
@@ -23,11 +23,16 @@ use std::{
     path::PathBuf,
     process::{Child, Command},
     str::FromStr,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc, Mutex,
+    },
+    time::Duration,
 };
 use url::Url;
 
 #[derive(Debug)]
-struct Process(Child);
+pub(crate) struct Process(Child);
 
 impl Drop for Process {
     // When the Process struct goes out of scope we need to kill the child process
@@ -46,10 +51,113 @@ impl Drop for Process {
     }
 }
 
+/// Information needed to spawn a node process.
+#[derive(Clone, Debug)]
+pub(crate) struct NodeSpawnInfo {
+    pub name: String,
+    pub bin: PathBuf,
+    pub directory: PathBuf,
+    pub config_path: PathBuf,
+    pub log_path: PathBuf,
+    pub cpu_affinity: Option<String>,
+    pub mem_bind: Option<String>,
+}
+
+/// Handle used by the auto-restart monitor to check and restart a node.
+pub(crate) struct NodeMonitor {
+    pub info: NodeSpawnInfo,
+    pub process: Arc<Mutex<Option<Process>>>,
+}
+
+/// Spawn a node process from the given spawn info.
+pub(crate) fn spawn_node_process(info: &NodeSpawnInfo) -> Result<Process> {
+    // Ensure log file exists
+    let log_file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&info.log_path)?;
+
+    // Start node process, optionally wrapped with numactl for CPU/memory affinity
+    let mut node_command = if info.cpu_affinity.is_some() || info.mem_bind.is_some() {
+        let mut cmd = Command::new("numactl");
+        if let Some(ref cpus) = info.cpu_affinity {
+            cmd.arg(format!("--physcpubind={}", cpus));
+        }
+        if let Some(ref mem) = info.mem_bind {
+            cmd.arg(format!("--membind={}", mem));
+        }
+        cmd.arg(&info.bin);
+        cmd
+    } else {
+        Command::new(&info.bin)
+    };
+    node_command
+        .current_dir(&info.directory)
+        .arg("-f")
+        .arg(&info.config_path);
+    if env::var("RUST_LOG").is_err() {
+        // Only set our RUST_LOG if its not present in environment
+        node_command.env("RUST_LOG", "debug");
+    }
+    node_command.stdout(log_file.try_clone()?).stderr(log_file);
+    let process = node_command
+        .spawn()
+        .with_context(|| format!("Error launching node process with binary: {:?}", info.bin))?;
+
+    // We print out the commands and PIDs for debugging of local swarms
+    info!(
+        "Started node {} (PID: {}) with command: {:?}, log_path: {:?}",
+        info.name,
+        process.id(),
+        node_command,
+        info.log_path,
+    );
+
+    Ok(Process(process))
+}
+
+/// Background loop that monitors nodes and restarts any that have crashed.
+/// Runs until `stop` is set to true.
+pub(crate) fn run_restart_monitor(monitors: Vec<NodeMonitor>, stop: Arc<AtomicBool>) {
+    info!("Auto-restart monitor started for {} nodes", monitors.len());
+    while !stop.load(Ordering::Acquire) {
+        std::thread::sleep(Duration::from_secs(5));
+        for monitor in &monitors {
+            let mut lock = monitor.process.lock().unwrap();
+            if let Some(ref mut p) = *lock {
+                match p.0.try_wait() {
+                    Ok(Some(status)) => {
+                        error!(
+                            "Node '{}' exited with: {}. Restarting...",
+                            monitor.info.name, status
+                        );
+                        // Drop the dead process to reap the zombie
+                        *lock = None;
+                        drop(lock);
+                        match spawn_node_process(&monitor.info) {
+                            Ok(new_process) => {
+                                info!("Successfully restarted node '{}'", monitor.info.name);
+                                *monitor.process.lock().unwrap() = Some(new_process);
+                            },
+                            Err(e) => {
+                                error!("Failed to restart node '{}': {}", monitor.info.name, e);
+                            },
+                        }
+                    },
+                    Ok(None) => {}, // Still running
+                    Err(e) => error!("Error checking node '{}' status: {}", monitor.info.name, e),
+                }
+            }
+            // If process is None, the node was intentionally stopped — don't restart
+        }
+    }
+    info!("Auto-restart monitor stopped");
+}
+
 #[derive(Debug)]
 pub struct LocalNode {
     version: LocalVersion,
-    process: std::sync::Mutex<Option<Process>>,
+    process: Arc<Mutex<Option<Process>>>,
     name: String,
     index: usize,
     account_private_key: Option<ConfigKey<Ed25519PrivateKey>>,
@@ -84,7 +192,7 @@ impl LocalNode {
 
         Ok(Self {
             version,
-            process: std::sync::Mutex::new(None),
+            process: Arc::new(Mutex::new(None)),
             name,
             index,
             account_private_key,
@@ -120,6 +228,26 @@ impl LocalNode {
         &self.account_private_key
     }
 
+    fn spawn_info(&self) -> NodeSpawnInfo {
+        NodeSpawnInfo {
+            name: self.name.clone(),
+            bin: self.version.bin().to_path_buf(),
+            directory: self.directory.clone(),
+            config_path: self.config_path(),
+            log_path: self.log_path(),
+            cpu_affinity: self.cpu_affinity.clone(),
+            mem_bind: self.mem_bind.clone(),
+        }
+    }
+
+    /// Returns a monitor handle for the auto-restart thread.
+    pub(crate) fn monitor(&self) -> NodeMonitor {
+        NodeMonitor {
+            info: self.spawn_info(),
+            process: Arc::clone(&self.process),
+        }
+    }
+
     pub fn start(&self) -> Result<()> {
         let mut process_locker = self.process.lock().unwrap();
         ensure!(
@@ -128,50 +256,7 @@ impl LocalNode {
             self.name
         );
 
-        // Ensure log file exists
-        let log_file = OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(self.log_path())?;
-
-        // Start node process, optionally wrapped with numactl for CPU/memory affinity
-        let mut node_command = if self.cpu_affinity.is_some() || self.mem_bind.is_some() {
-            let mut cmd = Command::new("numactl");
-            if let Some(ref cpus) = self.cpu_affinity {
-                cmd.arg(format!("--physcpubind={}", cpus));
-            }
-            if let Some(ref mem) = self.mem_bind {
-                cmd.arg(format!("--membind={}", mem));
-            }
-            cmd.arg(self.version.bin());
-            cmd
-        } else {
-            Command::new(self.version.bin())
-        };
-        node_command
-            .current_dir(&self.directory)
-            .arg("-f")
-            .arg(self.config_path());
-        if env::var("RUST_LOG").is_err() {
-            // Only set our RUST_LOG if its not present in environment
-            node_command.env("RUST_LOG", "debug");
-        }
-        node_command.stdout(log_file.try_clone()?).stderr(log_file);
-        let process = node_command.spawn().with_context(|| {
-            format!(
-                "Error launching node process with binary: {:?}",
-                self.version.bin()
-            )
-        })?;
-
-        // We print out the commands and PIDs for debugging of local swarms
-        info!(
-            "Started node {} (PID: {}) with command: {:?}, log_path: {:?}",
-            self.name,
-            process.id(),
-            node_command,
-            self.log_path(),
-        );
+        let process = spawn_node_process(&self.spawn_info())?;
 
         // We print out the API endpoints of each node for local debugging
         info!(
@@ -193,7 +278,7 @@ impl LocalNode {
             self.config.storage.backup_service_address.port()
         );
 
-        *process_locker = Some(Process(process));
+        *process_locker = Some(process);
 
         Ok(())
     }

--- a/testsuite/forge/src/backend/local/swarm.rs
+++ b/testsuite/forge/src/backend/local/swarm.rs
@@ -2,8 +2,8 @@
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
-    ChainInfo, FullNode, HealthCheckError, LocalNode, LocalVersion, Node, Swarm, SwarmChaos,
-    SwarmExt, Validator, Version,
+    backend::local::node::run_restart_monitor, ChainInfo, FullNode, HealthCheckError, LocalNode,
+    LocalVersion, Node, Swarm, SwarmChaos, SwarmExt, Validator, Version,
 };
 use anyhow::{anyhow, bail, Result};
 use aptos_config::{
@@ -34,7 +34,10 @@ use std::{
     num::NonZeroUsize,
     ops,
     path::{Path, PathBuf},
-    sync::Arc,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
     time::{Duration, Instant},
 };
 use tempfile::TempDir;
@@ -101,6 +104,10 @@ pub struct LocalSwarm {
     cpu_affinities: Vec<String>,
     mem_binds: Vec<String>,
 
+    auto_restart: bool,
+    monitor_stop: Option<Arc<AtomicBool>>,
+    monitor_handle: Option<std::thread::JoinHandle<()>>,
+
     launched: bool,
     #[allow(dead_code)]
     guard: ActiveNodesGuard,
@@ -121,6 +128,7 @@ impl LocalSwarm {
         cpu_affinities: Vec<String>,
         mem_binds: Vec<String>,
         concurrency_level: u16,
+        auto_restart: bool,
     ) -> Result<LocalSwarm>
     where
         R: ::rand::RngCore + ::rand::CryptoRng,
@@ -266,6 +274,9 @@ impl LocalSwarm {
             root_key,
             cpu_affinities,
             mem_binds,
+            auto_restart,
+            monitor_stop: None,
+            monitor_handle: None,
             launched: false,
             guard,
         })
@@ -283,8 +294,28 @@ impl LocalSwarm {
         }
 
         self.wait_all_alive(Duration::from_secs(60)).await?;
+
+        if self.auto_restart {
+            self.start_auto_restart_monitor();
+        }
+
         info!("Swarm launched successfully.");
         Ok(())
+    }
+
+    fn start_auto_restart_monitor(&mut self) {
+        let stop = Arc::new(AtomicBool::new(false));
+        self.monitor_stop = Some(Arc::clone(&stop));
+
+        let monitors = self.validators.values().map(|v| v.monitor()).collect();
+
+        let handle = std::thread::Builder::new()
+            .name("restart-mon".to_string())
+            .spawn(move || run_restart_monitor(monitors, stop))
+            .expect("Failed to spawn auto-restart monitor thread");
+
+        self.monitor_handle = Some(handle);
+        info!("Auto-restart monitor enabled for validators");
     }
 
     pub async fn wait_all_alive(&mut self, timeout: Duration) -> Result<()> {
@@ -480,6 +511,14 @@ impl LocalSwarm {
 
 impl Drop for LocalSwarm {
     fn drop(&mut self) {
+        // Stop the auto-restart monitor before dropping validators
+        if let Some(ref stop) = self.monitor_stop {
+            stop.store(true, Ordering::Release);
+        }
+        if let Some(handle) = self.monitor_handle.take() {
+            handle.join().expect("Auto-restart monitor thread panicked");
+        }
+
         // If panicking, persist logs
         if std::env::var("LOCAL_SWARM_SAVE_LOGS").is_ok() || std::thread::panicking() {
             eprintln!("Logs located at {}", self.logs_location());


### PR DESCRIPTION

Three improvements for local testing and build toolchain:

- **`--auto-restart`**: When enabled, a background monitor thread polls validators
  every 5 seconds. If a process has exited (crash or `kill -9`), it reaps the zombie
  and spawns a fresh process from the same binary, config, and databases. Process
  spawning logic is extracted into a reusable `spawn_node_process()` function, and
  the process handle is shared via `Arc<Mutex>` between the node and the monitor.
  Intentionally stopped nodes (process set to `None`) are not restarted.

- **`--aptos-node-binary <path>`**: Skips `cargo build` entirely and uses the
  provided pre-built `aptos-node` binary, making it faster to iterate on experiments
  with custom builds.

- **`linker = "clang"`** in `.cargo/config.toml` for `x86_64-unknown-linux-gnu`:
  CC/CXX were already set to clang/clang++, and rustflags already specified
  `-fuse-ld=lld`. Adding the linker setting completes the picture so gcc is no
  longer needed for Linux builds.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
