### PR TITLE
[consensus] Carry over unbatched txns in QS batch generator

### DIFF
--- a/config/src/config/quorum_store_config.rs
+++ b/config/src/config/quorum_store_config.rs
@@ -107,6 +107,12 @@ pub struct QuorumStoreConfig {
     pub enable_opt_qs_v2_payload_tx: bool,
     /// Enables handling of proposals with OptQS V2 Payload with Batch V2
     pub enable_opt_qs_v2_payload_rx: bool,
+    /// Maximum number of transactions to carry over from one pull cycle to the next
+    /// when bucket_into_batches() cannot batch all pulled transactions (e.g., due to
+    /// sender_max_num_batches limit). Set to 0 to disable carry-over.
+    pub pending_txns_max_count: usize,
+    /// Maximum duration (ms) that carried-over transactions are retained before being dropped.
+    pub pending_txns_max_age_ms: u64,
 }
 
 impl Default for QuorumStoreConfig {
@@ -152,6 +158,8 @@ impl Default for QuorumStoreConfig {
             enable_batch_v2_rx: false,
             enable_opt_qs_v2_payload_tx: false,
             enable_opt_qs_v2_payload_rx: false,
+            pending_txns_max_count: 2000,
+            pending_txns_max_age_ms: 2000,
         }
     }
 }

--- a/consensus/src/quorum_store/batch_generator.rs
+++ b/consensus/src/quorum_store/batch_generator.rs
@@ -72,6 +72,10 @@ pub struct BatchGenerator {
     last_end_batch_time: Instant,
     // quorum store back pressure, get updated from proof manager
     back_pressure: BackPressure,
+    // Transactions pulled from mempool but not batched due to max_batches limit,
+    // carried over to the next pull cycle to avoid redundant mempool pulls.
+    pending_txns: Vec<SignedTransaction>,
+    pending_txns_inserted_at: Option<Instant>,
 }
 
 impl BatchGenerator {
@@ -178,6 +182,8 @@ impl BatchGenerator {
                 txn_count: false,
                 proof_count: false,
             },
+            pending_txns: Vec::new(),
+            pending_txns_inserted_at: None,
         }
     }
 
@@ -326,11 +332,14 @@ impl BatchGenerator {
         }
     }
 
+    /// Sorts pulled transactions into gas-price buckets and creates batches.
+    /// Returns (created_batches, leftover_txns) where leftover_txns are transactions
+    /// that were pulled but could not be batched (e.g., due to sender_max_num_batches limit).
     fn bucket_into_batches(
         &mut self,
         pulled_txns: &mut Vec<SignedTransaction>,
         expiry_time: u64,
-    ) -> Vec<Batch<BatchInfoExt>> {
+    ) -> (Vec<Batch<BatchInfoExt>>, Vec<SignedTransaction>) {
         // Sort by gas, in descending order. This is a stable sort on existing mempool ordering,
         // so will not reorder accounts or their sequence numbers as long as they have the same gas.
         pulled_txns.sort_by_key(|txn| u64::MAX - txn.gas_unit_price());
@@ -346,6 +355,7 @@ impl BatchGenerator {
 
         let mut max_batches_remaining = self.config.sender_max_num_batches as u64;
         let mut batches = vec![];
+        let mut leftover = Vec::new();
 
         // Only categorize and separate transactions when BatchV2 is enabled
         if self.config.enable_batch_v2_tx {
@@ -377,7 +387,12 @@ impl BatchGenerator {
                         &mut max_batches_remaining,
                         batch_kind,
                     );
+                    leftover.extend(txns);
                 }
+            }
+            // Collect any remaining batch kinds not in the processing order
+            for (_, txns) in txns_by_kind {
+                leftover.extend(txns);
             }
         } else {
             // Legacy path: filter out encrypted transactions (only supported in BatchV2)
@@ -397,9 +412,10 @@ impl BatchGenerator {
                 &mut max_batches_remaining,
                 BatchKind::Normal,
             );
+            leftover.extend(pulled_txns.drain(..));
         }
 
-        batches
+        (batches, leftover)
     }
 
     fn remove_batch_in_progress(&mut self, author: PeerId, batch_id: BatchId) -> bool {
@@ -420,6 +436,51 @@ impl BatchGenerator {
         }
     }
 
+    fn add_pending_to_exclusion_set(&mut self, txns: &[SignedTransaction]) {
+        for txn in txns {
+            let summary = TransactionSummary::new(
+                txn.sender(),
+                txn.replay_protector(),
+                txn.committed_hash(),
+            );
+            let entry = self
+                .txns_in_progress_sorted
+                .entry(summary)
+                .or_insert_with(|| TransactionInProgress::new(txn.gas_unit_price()));
+            entry.increment();
+            entry.gas_unit_price = entry.gas_unit_price.max(txn.gas_unit_price());
+        }
+    }
+
+    fn remove_pending_from_exclusion_set(&mut self, txns: &[SignedTransaction]) {
+        for txn in txns {
+            let summary = TransactionSummary::new(
+                txn.sender(),
+                txn.replay_protector(),
+                txn.committed_hash(),
+            );
+            if let Entry::Occupied(mut o) = self.txns_in_progress_sorted.entry(summary) {
+                if o.get_mut().decrement() == 0 {
+                    o.remove();
+                }
+            }
+        }
+    }
+
+    fn expire_pending_txns(&mut self) {
+        if let Some(inserted_at) = self.pending_txns_inserted_at {
+            if inserted_at.elapsed()
+                > Duration::from_millis(self.config.pending_txns_max_age_ms)
+            {
+                let expired = std::mem::take(&mut self.pending_txns);
+                self.remove_pending_from_exclusion_set(&expired);
+                self.pending_txns_inserted_at = None;
+                counters::BATCH_GENERATOR_PENDING_TXNS_EXPIRED
+                    .inc_by(expired.len() as u64);
+            }
+        }
+    }
+
     #[cfg(test)]
     pub fn remove_batch_in_progress_for_test(&mut self, author: PeerId, batch_id: BatchId) -> bool {
         self.remove_batch_in_progress(author, batch_id)
@@ -430,31 +491,56 @@ impl BatchGenerator {
         self.txns_in_progress_sorted.len()
     }
 
+    #[cfg(test)]
+    pub fn pending_txns_len(&self) -> usize {
+        self.pending_txns.len()
+    }
+
     pub(crate) async fn handle_scheduled_pull(
         &mut self,
         max_count: u64,
     ) -> Vec<Batch<BatchInfoExt>> {
+        // Expire stale pending txns
+        self.expire_pending_txns();
+
         counters::BATCH_PULL_EXCLUDED_TXNS.observe(self.txns_in_progress_sorted.len() as f64);
+        counters::BATCH_GENERATOR_PENDING_TXNS.observe(self.pending_txns.len() as f64);
         trace!(
-            "QS: excluding txs len: {:?}",
-            self.txns_in_progress_sorted.len()
+            "QS: excluding txs len: {:?}, pending txns: {:?}",
+            self.txns_in_progress_sorted.len(),
+            self.pending_txns.len()
         );
 
-        let mut pulled_txns = self
-            .mempool_proxy
-            .pull_internal(
-                max_count,
-                self.config.sender_max_total_bytes as u64,
-                self.txns_in_progress_sorted.clone(),
-            )
-            .await
-            .unwrap_or_default();
+        // Account for pending txns when determining how many fresh txns to pull
+        let pending_count = self.pending_txns.len() as u64;
+        let fresh_pull_count = max_count.saturating_sub(pending_count);
 
-        trace!("QS: pulled_txns len: {:?}", pulled_txns.len());
+        let fresh_txns = if fresh_pull_count > 0 {
+            self.mempool_proxy
+                .pull_internal(
+                    fresh_pull_count,
+                    self.config.sender_max_total_bytes as u64,
+                    self.txns_in_progress_sorted.clone(),
+                )
+                .await
+                .unwrap_or_default()
+        } else {
+            vec![]
+        };
 
-        if pulled_txns.is_empty() {
+        // Take pending txns out of the buffer and remove from exclusion set
+        let old_pending = std::mem::take(&mut self.pending_txns);
+        self.remove_pending_from_exclusion_set(&old_pending);
+        self.pending_txns_inserted_at = None;
+
+        // Combine: pending first (they've waited longer), then fresh
+        let mut all_txns = old_pending;
+        all_txns.extend(fresh_txns);
+
+        trace!("QS: all_txns len: {:?}", all_txns.len());
+
+        if all_txns.is_empty() {
             counters::PULLED_EMPTY_TXNS_COUNT.inc();
-            // Quorum store metrics
             counters::CREATED_EMPTY_BATCHES_COUNT.inc();
 
             counters::EMPTY_BATCH_CREATION_DURATION
@@ -463,8 +549,8 @@ impl BatchGenerator {
             return vec![];
         } else {
             counters::PULLED_TXNS_COUNT.inc();
-            counters::PULLED_TXNS_NUM.observe(pulled_txns.len() as f64);
-            if pulled_txns.len() as u64 == max_count {
+            counters::PULLED_TXNS_NUM.observe(all_txns.len() as f64);
+            if all_txns.len() as u64 == max_count {
                 counters::BATCH_PULL_FULL_TXNS.observe(max_count as f64)
             }
         }
@@ -473,7 +559,21 @@ impl BatchGenerator {
         let bucket_compute_start = Instant::now();
         let expiry_time = aptos_infallible::duration_since_epoch().as_micros() as u64
             + self.config.batch_expiry_gap_when_init_usecs;
-        let batches = self.bucket_into_batches(&mut pulled_txns, expiry_time);
+        let (batches, leftover) = self.bucket_into_batches(&mut all_txns, expiry_time);
+
+        // Store leftovers in pending buffer for next cycle (capped)
+        if !leftover.is_empty() && self.config.pending_txns_max_count > 0 {
+            let capped: Vec<_> = leftover
+                .into_iter()
+                .take(self.config.pending_txns_max_count)
+                .collect();
+            counters::BATCH_GENERATOR_PENDING_TXNS_CARRIED_OVER
+                .observe(capped.len() as f64);
+            self.add_pending_to_exclusion_set(&capped);
+            self.pending_txns = capped;
+            self.pending_txns_inserted_at = Some(Instant::now());
+        }
+
         self.last_end_batch_time = Instant::now();
         counters::BATCH_CREATION_COMPUTE_LATENCY.observe_duration(bucket_compute_start.elapsed());
 

--- a/consensus/src/quorum_store/counters.rs
+++ b/consensus/src/quorum_store/counters.rs
@@ -402,6 +402,32 @@ pub static BATCH_GENERATOR_SKIPPED_OVERSIZED_TXN: Lazy<IntCounter> = Lazy::new(|
     .unwrap()
 });
 
+pub static BATCH_GENERATOR_PENDING_TXNS: Lazy<Histogram> = Lazy::new(|| {
+    register_histogram!(
+        "quorum_store_batch_generator_pending_txns",
+        "Number of transactions in the pending carry-over buffer.",
+        TRANSACTION_COUNT_BUCKETS.clone()
+    )
+    .unwrap()
+});
+
+pub static BATCH_GENERATOR_PENDING_TXNS_CARRIED_OVER: Lazy<Histogram> = Lazy::new(|| {
+    register_histogram!(
+        "quorum_store_batch_generator_pending_txns_carried_over",
+        "Number of transactions carried over to the next pull cycle.",
+        TRANSACTION_COUNT_BUCKETS.clone()
+    )
+    .unwrap()
+});
+
+pub static BATCH_GENERATOR_PENDING_TXNS_EXPIRED: Lazy<IntCounter> = Lazy::new(|| {
+    register_int_counter!(
+        "quorum_store_batch_generator_pending_txns_expired",
+        "Count of pending transactions expired due to age."
+    )
+    .unwrap()
+});
+
 pub static GAP_BETWEEN_BATCH_EXPIRATION_AND_CURRENT_TIME_WHEN_SAVE: Lazy<Histogram> = Lazy::new(
     || {
         register_histogram!(

--- a/consensus/src/quorum_store/tests/batch_generator_test.rs
+++ b/consensus/src/quorum_store/tests/batch_generator_test.rs
@@ -1207,3 +1207,273 @@ async fn test_oversized_transaction_skipped() {
         .unwrap()
         .unwrap();
 }
+
+/// Test that transactions which overflow the max_batches limit are carried over
+/// to the next pull cycle and batched without a redundant mempool pull.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_pending_txns_carry_over() {
+    let (quorum_store_to_mempool_tx, mut quorum_store_to_mempool_rx) = channel(1_024);
+
+    // max_batch_txns=10, max_num_batches=2 → can batch 20 txns per cycle
+    let config = QuorumStoreConfig {
+        sender_max_batch_txns: 10,
+        sender_max_num_batches: 2,
+        pending_txns_max_count: 100,
+        pending_txns_max_age_ms: 5000,
+        ..Default::default()
+    };
+    let max_batch_bytes = config.sender_max_batch_bytes;
+
+    let author = AccountAddress::random();
+    let mut batch_generator = BatchGenerator::new(
+        0,
+        author,
+        config,
+        Arc::new(MockQuorumStoreDB::new()),
+        Arc::new(MockBatchWriter::new()),
+        quorum_store_to_mempool_tx,
+        1000,
+    );
+
+    // Cycle 1: Pull 25 txns, can only batch 20 → 5 should be carried over
+    let signed_txns = create_vec_signed_transactions(25);
+    let join_handle = tokio::spawn(async move {
+        queue_mempool_batch_response(signed_txns, max_batch_bytes, &mut quorum_store_to_mempool_rx)
+            .await;
+        // Cycle 2: mempool returns empty since pending txns cover the remaining
+        queue_mempool_batch_response(vec![], max_batch_bytes, &mut quorum_store_to_mempool_rx)
+            .await;
+    });
+
+    let result1 = batch_generator.handle_scheduled_pull(300).await;
+    assert_eq!(result1.len(), 2, "Should create max 2 batches");
+    assert_eq!(result1[0].num_txns(), 10);
+    assert_eq!(result1[1].num_txns(), 10);
+    // 5 txns should be in pending buffer
+    assert_eq!(batch_generator.pending_txns_len(), 5);
+    // Pending txns should be in exclusion set
+    assert_eq!(batch_generator.txns_in_progress_sorted_len(), 25);
+
+    // Cycle 2: pending txns should be batched without needing mempool to return them
+    let result2 = batch_generator.handle_scheduled_pull(300).await;
+    assert_eq!(result2.len(), 1, "Should batch the 5 pending txns");
+    assert_eq!(result2[0].num_txns(), 5);
+    // Pending buffer should be empty now
+    assert_eq!(batch_generator.pending_txns_len(), 0);
+
+    timeout(Duration::from_millis(10_000), join_handle)
+        .await
+        .unwrap()
+        .unwrap();
+}
+
+/// Test that pending txns are excluded from mempool pulls (in the exclusion set).
+#[tokio::test(flavor = "multi_thread")]
+async fn test_pending_txns_in_exclusion_set() {
+    let (quorum_store_to_mempool_tx, mut quorum_store_to_mempool_rx) = channel(1_024);
+
+    let config = QuorumStoreConfig {
+        sender_max_batch_txns: 5,
+        sender_max_num_batches: 1,
+        pending_txns_max_count: 100,
+        pending_txns_max_age_ms: 5000,
+        ..Default::default()
+    };
+    let max_batch_bytes = config.sender_max_batch_bytes;
+
+    let author = AccountAddress::random();
+    let mut batch_generator = BatchGenerator::new(
+        0,
+        author,
+        config,
+        Arc::new(MockQuorumStoreDB::new()),
+        Arc::new(MockBatchWriter::new()),
+        quorum_store_to_mempool_tx,
+        1000,
+    );
+
+    // Pull 10 txns, can only batch 5 → 5 pending
+    let signed_txns = create_vec_signed_transactions(10);
+    let join_handle = tokio::spawn(async move {
+        // Cycle 1
+        let exclude_txns = queue_mempool_batch_response(
+            signed_txns.clone(),
+            max_batch_bytes,
+            &mut quorum_store_to_mempool_rx,
+        )
+        .await;
+        assert_eq!(exclude_txns.len(), 0, "No txns in progress initially");
+
+        // Cycle 2: exclude_txns should contain all 10 (5 batched + 5 pending)
+        let exclude_txns = queue_mempool_batch_response(
+            vec![],
+            max_batch_bytes,
+            &mut quorum_store_to_mempool_rx,
+        )
+        .await;
+        assert_eq!(
+            exclude_txns.len(),
+            10,
+            "All 10 txns (5 batched + 5 pending) should be in exclusion set"
+        );
+    });
+
+    let _result1 = batch_generator.handle_scheduled_pull(300).await;
+    assert_eq!(batch_generator.pending_txns_len(), 5);
+    assert_eq!(batch_generator.txns_in_progress_sorted_len(), 10);
+
+    let _result2 = batch_generator.handle_scheduled_pull(300).await;
+
+    timeout(Duration::from_millis(10_000), join_handle)
+        .await
+        .unwrap()
+        .unwrap();
+}
+
+/// Test that pending txns are dropped when they exceed max age.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_pending_txns_expiry() {
+    let (quorum_store_to_mempool_tx, mut quorum_store_to_mempool_rx) = channel(1_024);
+
+    let config = QuorumStoreConfig {
+        sender_max_batch_txns: 5,
+        sender_max_num_batches: 1,
+        pending_txns_max_count: 100,
+        pending_txns_max_age_ms: 1, // 1ms TTL — will expire almost immediately
+        ..Default::default()
+    };
+    let max_batch_bytes = config.sender_max_batch_bytes;
+
+    let author = AccountAddress::random();
+    let mut batch_generator = BatchGenerator::new(
+        0,
+        author,
+        config,
+        Arc::new(MockQuorumStoreDB::new()),
+        Arc::new(MockBatchWriter::new()),
+        quorum_store_to_mempool_tx,
+        1000,
+    );
+
+    let signed_txns = create_vec_signed_transactions(10);
+    let join_handle = tokio::spawn(async move {
+        queue_mempool_batch_response(
+            signed_txns.clone(),
+            max_batch_bytes,
+            &mut quorum_store_to_mempool_rx,
+        )
+        .await;
+        // Cycle 2: mempool gets asked again, pending txns should have expired
+        queue_mempool_batch_response(
+            vec![],
+            max_batch_bytes,
+            &mut quorum_store_to_mempool_rx,
+        )
+        .await;
+    });
+
+    let _result1 = batch_generator.handle_scheduled_pull(300).await;
+    assert_eq!(batch_generator.pending_txns_len(), 5);
+
+    // Sleep to ensure TTL expires
+    tokio::time::sleep(Duration::from_millis(5)).await;
+
+    let result2 = batch_generator.handle_scheduled_pull(300).await;
+    // Pending txns should have expired, so nothing to batch
+    assert!(result2.is_empty());
+    assert_eq!(batch_generator.pending_txns_len(), 0);
+    // Expired pending txns should be removed from exclusion set;
+    // only the 5 batched txns from cycle 1 remain
+    assert_eq!(batch_generator.txns_in_progress_sorted_len(), 5);
+
+    timeout(Duration::from_millis(10_000), join_handle)
+        .await
+        .unwrap()
+        .unwrap();
+}
+
+/// Test that pending txns buffer is capped at pending_txns_max_count.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_pending_txns_max_count() {
+    let (quorum_store_to_mempool_tx, mut quorum_store_to_mempool_rx) = channel(1_024);
+
+    let config = QuorumStoreConfig {
+        sender_max_batch_txns: 5,
+        sender_max_num_batches: 1,
+        pending_txns_max_count: 3, // Cap at 3
+        pending_txns_max_age_ms: 5000,
+        ..Default::default()
+    };
+    let max_batch_bytes = config.sender_max_batch_bytes;
+
+    let author = AccountAddress::random();
+    let mut batch_generator = BatchGenerator::new(
+        0,
+        author,
+        config,
+        Arc::new(MockQuorumStoreDB::new()),
+        Arc::new(MockBatchWriter::new()),
+        quorum_store_to_mempool_tx,
+        1000,
+    );
+
+    // Pull 10 txns, batch 5, overflow 5 but cap at 3 pending
+    let signed_txns = create_vec_signed_transactions(10);
+    let join_handle = tokio::spawn(async move {
+        queue_mempool_batch_response(signed_txns, max_batch_bytes, &mut quorum_store_to_mempool_rx)
+            .await;
+    });
+
+    let _result = batch_generator.handle_scheduled_pull(300).await;
+    assert_eq!(
+        batch_generator.pending_txns_len(),
+        3,
+        "Pending buffer should be capped at 3"
+    );
+
+    timeout(Duration::from_millis(10_000), join_handle)
+        .await
+        .unwrap()
+        .unwrap();
+}
+
+/// Test that carry-over is disabled when pending_txns_max_count is 0.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_pending_txns_disabled() {
+    let (quorum_store_to_mempool_tx, mut quorum_store_to_mempool_rx) = channel(1_024);
+
+    let config = QuorumStoreConfig {
+        sender_max_batch_txns: 10,
+        sender_max_num_batches: 2,
+        pending_txns_max_count: 0, // Disabled
+        ..Default::default()
+    };
+    let max_batch_bytes = config.sender_max_batch_bytes;
+
+    let author = AccountAddress::random();
+    let mut batch_generator = BatchGenerator::new(
+        0,
+        author,
+        config,
+        Arc::new(MockQuorumStoreDB::new()),
+        Arc::new(MockBatchWriter::new()),
+        quorum_store_to_mempool_tx,
+        1000,
+    );
+
+    let signed_txns = create_vec_signed_transactions(25);
+    let join_handle = tokio::spawn(async move {
+        queue_mempool_batch_response(signed_txns, max_batch_bytes, &mut quorum_store_to_mempool_rx)
+            .await;
+    });
+
+    let result = batch_generator.handle_scheduled_pull(300).await;
+    assert_eq!(result.len(), 2);
+    // No carry-over when disabled
+    assert_eq!(batch_generator.pending_txns_len(), 0);
+
+    timeout(Duration::from_millis(10_000), join_handle)
+        .await
+        .unwrap()
+        .unwrap();
+}


### PR DESCRIPTION
## Summary

- When `bucket_into_batches()` hits the `sender_max_num_batches` limit, pulled transactions that didn't fit into batches were **silently dropped**. On the next pull cycle, mempool returns the same transactions again — wasting 50-250ms per redundant pull.
- Adds a `pending_txns` carry-over buffer to `BatchGenerator` that retains overflow transactions and batches them on the next cycle without re-pulling from mempool.
- Pending txns are added to the exclusion set (`txns_in_progress_sorted`) to prevent redundant mempool pulls, capped at `pending_txns_max_count` (default 2000), and expire after `pending_txns_max_age_ms` (default 2000ms).
- Set `pending_txns_max_count = 0` to disable the feature.

## Key Changes

1. **`config/src/config/quorum_store_config.rs`**: Added `pending_txns_max_count` and `pending_txns_max_age_ms` config fields
2. **`consensus/src/quorum_store/batch_generator.rs`**:
   - `bucket_into_batches()` now returns `(batches, leftover_txns)` instead of just `batches`
   - `handle_scheduled_pull()` carries over leftover txns in `pending_txns` buffer, prepends them to fresh pulls on next cycle
   - Added `add_pending_to_exclusion_set()`, `remove_pending_from_exclusion_set()`, `expire_pending_txns()` helpers
3. **`consensus/src/quorum_store/counters.rs`**: Added `pending_txns`, `pending_txns_carried_over`, `pending_txns_expired` metrics
4. **Tests**: 5 new tests covering carry-over, exclusion set, expiry, max count cap, and disable behavior

## Test plan

- [x] `cargo check -p aptos-consensus` — compiles
- [x] `cargo test -p aptos-consensus -- batch_generator` — all 20 tests pass (15 existing + 5 new)
- [ ] Monitor `quorum_store_batch_generator_pending_txns` gauge in Grafana after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)