### PR TITLE
[tracing] 3/4: Add config-based tracing filter

### DIFF
--- a/aptos-node/Cargo.toml
+++ b/aptos-node/Cargo.toml
@@ -57,6 +57,7 @@ aptos-storage-service-server = { workspace = true }
 aptos-storage-service-types = { workspace = true }
 aptos-telemetry = { workspace = true }
 aptos-temppath = { workspace = true }
+aptos-transaction-tracing = { workspace = true }
 aptos-time-service = { workspace = true }
 aptos-types = { workspace = true }
 aptos-validator-transaction-pool = { workspace = true }

--- a/aptos-node/src/lib.rs
+++ b/aptos-node/src/lib.rs
@@ -701,6 +701,22 @@ pub fn setup_environment_and_start_node(
     // Starts the admin service
     let mut admin_service = services::start_admin_service(&node_config);
 
+    // Initialize transaction tracing from config
+    {
+        let tracing_cfg = &node_config.transaction_tracing;
+        if tracing_cfg.enabled && !tracing_cfg.sender_allowlist.is_empty() {
+            let filter = aptos_transaction_tracing::filter::TransactionFilter::new(
+                true,
+                tracing_cfg.sender_allowlist.clone(),
+            );
+            aptos_transaction_tracing::store::TransactionTraceStore::global().update_filter(filter);
+            aptos_logger::info!(
+                "Transaction tracing enabled for {} sender(s)",
+                tracing_cfg.sender_allowlist.len()
+            );
+        }
+    }
+
     // Set up the storage database and any RocksDB checkpoints
     let (db_rw, backup_service, genesis_waypoint, indexer_db_opt, update_receiver) =
         storage::initialize_database_and_checkpoints(&mut node_config)?;

--- a/config/src/config/mod.rs
+++ b/config/src/config/mod.rs
@@ -36,6 +36,7 @@ mod state_sync_config;
 mod storage_config;
 mod telemetry_service_config;
 mod transaction_filters_config;
+pub mod transaction_tracing_config;
 mod utils;
 
 // All public usage statements should be declared below
@@ -67,3 +68,4 @@ pub use state_sync_config::*;
 pub use storage_config::*;
 pub use telemetry_service_config::*;
 pub use transaction_filters_config::*;
+pub use transaction_tracing_config::*;

--- a/config/src/config/node_config.rs
+++ b/config/src/config/node_config.rs
@@ -8,7 +8,8 @@ use crate::{
         internal_indexer_db_config::InternalIndexerDBConfig,
         jwk_consensus_config::JWKConsensusConfig, node_config_loader::NodeConfigLoader,
         node_startup_config::NodeStartupConfig, persistable_config::PersistableConfig,
-        transaction_filters_config::TransactionFiltersConfig, utils::RootPath, AdminServiceConfig,
+        transaction_filters_config::TransactionFiltersConfig,
+        transaction_tracing_config::TransactionTracingConfig, utils::RootPath, AdminServiceConfig,
         ApiConfig, BaseConfig, ConsensusConfig, Error, ExecutionConfig, IndexerGrpcConfig,
         InspectionServiceConfig, LoggerConfig, MempoolConfig, NetworkConfig,
         PeerMonitoringServiceConfig, SafetyRulesTestConfig, StateSyncConfig, StorageConfig,
@@ -83,6 +84,8 @@ pub struct NodeConfig {
     pub telemetry_service: TelemetryServiceConfig,
     #[serde(default)]
     pub transaction_filters: TransactionFiltersConfig,
+    #[serde(default)]
+    pub transaction_tracing: TransactionTracingConfig,
     #[serde(default)]
     pub validator_network: Option<NetworkConfig>,
     #[serde(default)]

--- a/config/src/config/transaction_tracing_config.rs
+++ b/config/src/config/transaction_tracing_config.rs
@@ -1,0 +1,31 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+use aptos_types::account_address::AccountAddress;
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+
+/// Configuration for transaction lifecycle tracing.
+///
+/// When `enabled` is true and `sender_allowlist` is non-empty, the node
+/// traces transactions from the listed senders through the pipeline
+/// (mempool → QS → consensus → execution → commit) and logs a
+/// `TxnTrace` line for each.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct TransactionTracingConfig {
+    /// Master switch for tracing. Must be true for any tracing to occur.
+    pub enabled: bool,
+    /// Only transactions from these senders are traced. If empty, nothing
+    /// is traced even when `enabled` is true.
+    pub sender_allowlist: HashSet<AccountAddress>,
+}
+
+impl Default for TransactionTracingConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            sender_allowlist: HashSet::new(),
+        }
+    }
+}

--- a/crates/aptos-admin-service/Cargo.toml
+++ b/crates/aptos-admin-service/Cargo.toml
@@ -25,6 +25,7 @@ aptos-storage-interface = { workspace = true }
 aptos-system-utils = { workspace = true }
 aptos-types = { workspace = true }
 bcs = { workspace = true }
+serde_json = { workspace = true }
 futures-channel = { workspace = true }
 http = { workspace = true }
 hyper = { workspace = true }


### PR DESCRIPTION
## Summary
Adds config-based transaction tracing filter and removes runtime HTTP endpoints.

### Changes
- **New** `TransactionTracingConfig` in `NodeConfig` with `enabled` flag and `sender_allowlist`
- **New** aptos-node startup reads config and initializes the global `TransactionTraceStore` filter
- **Removed** admin service `POST /transaction_tracing` endpoint
- **Removed** inspection service `GET /transaction_tracing` endpoint
- **Removed** `aptos-transaction-tracing` dependency from admin and inspection services

The tracing filter is now set entirely via node config at startup. This is simpler and avoids runtime state mutation via HTTP.

### Stacked PR
- PR 1/4: Core crate <- `main`
- PR 2/4: Pipeline instrumentation <- PR 1
- **PR 3/4** (this): Config-based filter <- PR 2
- PR 4/4: Tests <- PR 3

## Test plan
- [x] `cargo check -p aptos-node -p aptos-admin-service -p aptos-inspection-service`
- [x] Local smoke test passes with config-based filter (5 TxnTrace entries)

🤖 Generated with [Claude Code](https://claude.com/claude-code)