### PR TITLE
Add object_code_deployment::get_code_object_signer

### DIFF
--- a/aptos-move/e2e-move-tests/src/tests/object_code_deployment.rs
+++ b/aptos-move/e2e-move-tests/src/tests/object_code_deployment.rs
@@ -17,7 +17,6 @@ use aptos_types::{
     transaction::{ExecutionStatus, TransactionStatus},
 };
 use move_core_types::{parser::parse_struct_tag, vm_status::StatusCode};
-use rstest::rstest;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 /// This tests the `object_code_deployment.move` module under the `aptos-framework` package.
@@ -130,19 +129,14 @@ const MODULE_ADDRESS_NAME: &str = "object";
 const MUT_DEPS_MODULE_ADDRESS_NAME: &str = "object_mutable_deps";
 const IMMUT_DEPS_MODULE_ADDRESS_NAME: &str = "object_immutable_deps";
 const PACKAGE_REGISTRY_ACCESS_PATH: &str = "0x1::code::PackageRegistry";
-const EOBJECT_CODE_DEPLOYMENT_NOT_SUPPORTED: &str = "EOBJECT_CODE_DEPLOYMENT_NOT_SUPPORTED";
 const ENOT_CODE_OBJECT_OWNER: &str = "ENOT_CODE_OBJECT_OWNER";
 const ENOT_PACKAGE_OWNER: &str = "ENOT_PACKAGE_OWNER";
 const EDEP_WEAKER_POLICY: &str = "EDEP_WEAKER_POLICY";
 
-/// Tests the `publish` object code deployment function with feature flags enabled/disabled.
-/// Deployment should only happen when feature is enabled.
-#[rstest(enabled, disabled,
-    case(vec![], vec![FeatureFlag::OBJECT_CODE_DEPLOYMENT]),
-    case(vec![FeatureFlag::OBJECT_CODE_DEPLOYMENT], vec![]),
-)]
-fn object_code_deployment_publish_package(enabled: Vec<FeatureFlag>, disabled: Vec<FeatureFlag>) {
-    let mut context = TestContext::new(Some(enabled.clone()), Some(disabled));
+/// Tests the `publish` object code deployment function.
+#[test]
+fn object_code_deployment_publish_package() {
+    let mut context = TestContext::new(None, None);
     let acc = context.account.clone();
 
     let status = context.execute_object_code_action(
@@ -151,46 +145,42 @@ fn object_code_deployment_publish_package(enabled: Vec<FeatureFlag>, disabled: V
         ObjectCodeAction::Deploy,
     );
 
-    if enabled.contains(&FeatureFlag::OBJECT_CODE_DEPLOYMENT) {
-        assert_success!(status);
+    assert_success!(status);
 
-        let registry = context
-            .read_resource::<PackageRegistry>(&context.object_address, PACKAGE_REGISTRY_ACCESS_PATH)
-            .unwrap();
-        assert_eq!(registry.packages.len(), 1);
-        assert_eq!(registry.packages[0].name, "test_package");
-        assert_eq!(registry.packages[0].modules.len(), 1);
-        assert_eq!(registry.packages[0].modules[0].name, "test");
+    let registry = context
+        .read_resource::<PackageRegistry>(&context.object_address, PACKAGE_REGISTRY_ACCESS_PATH)
+        .unwrap();
+    assert_eq!(registry.packages.len(), 1);
+    assert_eq!(registry.packages[0].name, "test_package");
+    assert_eq!(registry.packages[0].modules.len(), 1);
+    assert_eq!(registry.packages[0].modules[0].name, "test");
 
-        let code_object: ManagingRefs = context
-            .harness
-            .read_resource_from_resource_group(
-                &context.object_address,
-                parse_struct_tag("0x1::object::ObjectGroup").unwrap(),
-                parse_struct_tag("0x1::object_code_deployment::ManagingRefs").unwrap(),
-            )
-            .unwrap();
-        // Verify the object created owns the `ManagingRefs`
-        assert_eq!(code_object, ManagingRefs::new(context.object_address));
+    let code_object: ManagingRefs = context
+        .harness
+        .read_resource_from_resource_group(
+            &context.object_address,
+            parse_struct_tag("0x1::object::ObjectGroup").unwrap(),
+            parse_struct_tag("0x1::object_code_deployment::ManagingRefs").unwrap(),
+        )
+        .unwrap();
+    // Verify the object created owns the `ManagingRefs`
+    assert_eq!(code_object, ManagingRefs::new(context.object_address));
 
-        let module_address = context.object_address.to_string();
-        assert_success!(context.harness.run_entry_function(
-            &context.account,
-            str::parse(&format!("{}::test::hello", module_address)).unwrap(),
-            vec![],
-            vec![bcs::to_bytes::<u64>(&42).unwrap()]
-        ));
+    let module_address = context.object_address.to_string();
+    assert_success!(context.harness.run_entry_function(
+        &context.account,
+        str::parse(&format!("{}::test::hello", module_address)).unwrap(),
+        vec![],
+        vec![bcs::to_bytes::<u64>(&42).unwrap()]
+    ));
 
-        let state = context
-            .read_resource::<State>(
-                context.account.address(),
-                &format!("{}::test::State", module_address),
-            )
-            .unwrap();
-        assert_eq!(state.value, 42);
-    } else {
-        context.assert_feature_flag_error(status, EOBJECT_CODE_DEPLOYMENT_NOT_SUPPORTED);
-    }
+    let state = context
+        .read_resource::<State>(
+            context.account.address(),
+            &format!("{}::test::State", module_address),
+        )
+        .unwrap();
+    assert_eq!(state.value, 42);
 }
 
 /// Tests the `upgrade` object code deployment function after `publish`ing a package prior calling.

--- a/aptos-move/framework/aptos-framework/doc/object_code_deployment.md
+++ b/aptos-move/framework/aptos-framework/doc/object_code_deployment.md
@@ -44,13 +44,13 @@ Once modules are marked as immutable, they cannot be made mutable again.
 -  [Function `object_seed`](#0x1_object_code_deployment_object_seed)
 -  [Function `upgrade`](#0x1_object_code_deployment_upgrade)
 -  [Function `freeze_code_object`](#0x1_object_code_deployment_freeze_code_object)
+-  [Function `get_code_object_signer`](#0x1_object_code_deployment_get_code_object_signer)
 
 
 <pre><code><b>use</b> <a href="account.md#0x1_account">0x1::account</a>;
 <b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/bcs.md#0x1_bcs">0x1::bcs</a>;
 <b>use</b> <a href="code.md#0x1_code">0x1::code</a>;
 <b>use</b> <a href="event.md#0x1_event">0x1::event</a>;
-<b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features">0x1::features</a>;
 <b>use</b> <a href="object.md#0x1_object">0x1::object</a>;
 <b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">0x1::signer</a>;
 <b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">0x1::vector</a>;
@@ -253,11 +253,6 @@ the code to be published via <code><a href="code.md#0x1_code">code</a></code>. T
     <a href="code.md#0x1_code">code</a>: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;&gt;,
 ) {
     <a href="code.md#0x1_code_check_code_publishing_permission">code::check_code_publishing_permission</a>(publisher);
-    <b>assert</b>!(
-        <a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_is_object_code_deployment_enabled">features::is_object_code_deployment_enabled</a>(),
-        <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_unavailable">error::unavailable</a>(<a href="object_code_deployment.md#0x1_object_code_deployment_EOBJECT_CODE_DEPLOYMENT_NOT_SUPPORTED">EOBJECT_CODE_DEPLOYMENT_NOT_SUPPORTED</a>),
-    );
-
     <b>let</b> publisher_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(publisher);
     <b>let</b> object_seed = <a href="object_code_deployment.md#0x1_object_code_deployment_object_seed">object_seed</a>(publisher_address);
     <b>let</b> constructor_ref = &<a href="object.md#0x1_object_create_named_object">object::create_named_object</a>(publisher, object_seed);
@@ -313,6 +308,9 @@ along with the metadata <code>metadata_serialized</code>.
 Note: If the modules were deployed as immutable when calling <code>publish</code>, the upgrade will fail.
 Requires the publisher to be the owner of the <code>code_object</code>.
 
+Note: In order to publish a new package to an existing code object,
+this <code>upgrade</code> function should be called, rather than <code>publish</code>.
+
 
 <pre><code><b>public</b> entry <b>fun</b> <a href="object_code_deployment.md#0x1_object_code_deployment_upgrade">upgrade</a>(publisher: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, metadata_serialized: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, <a href="code.md#0x1_code">code</a>: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;&gt;, code_object: <a href="object.md#0x1_object_Object">object::Object</a>&lt;<a href="code.md#0x1_code_PackageRegistry">code::PackageRegistry</a>&gt;)
 </code></pre>
@@ -328,7 +326,7 @@ Requires the publisher to be the owner of the <code>code_object</code>.
     metadata_serialized: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
     <a href="code.md#0x1_code">code</a>: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;&gt;,
     code_object: Object&lt;PackageRegistry&gt;,
-) <b>acquires</b> <a href="object_code_deployment.md#0x1_object_code_deployment_ManagingRefs">ManagingRefs</a> {
+) {
     <a href="code.md#0x1_code_check_code_publishing_permission">code::check_code_publishing_permission</a>(publisher);
     <b>let</b> publisher_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(publisher);
     <b>assert</b>!(
@@ -373,6 +371,46 @@ Requires the <code>publisher</code> to be the owner of the <code>code_object</co
     <a href="code.md#0x1_code_freeze_code_object">code::freeze_code_object</a>(publisher, code_object);
 
     <a href="event.md#0x1_event_emit">event::emit</a>(<a href="object_code_deployment.md#0x1_object_code_deployment_Freeze">Freeze</a> { object_address: code_object.object_address(), });
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_object_code_deployment_get_code_object_signer"></a>
+
+## Function `get_code_object_signer`
+
+Returns the signer for the given <code>code_object</code>.
+For example, this can be used if you need to additional initialization
+after upgrading a module.
+
+Requires the publisher to be the owner of the <code>code_object</code>.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object_code_deployment.md#0x1_object_code_deployment_get_code_object_signer">get_code_object_signer</a>(publisher: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, code_object: <a href="object.md#0x1_object_Object">object::Object</a>&lt;<a href="code.md#0x1_code_PackageRegistry">code::PackageRegistry</a>&gt;): <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object_code_deployment.md#0x1_object_code_deployment_get_code_object_signer">get_code_object_signer</a>(publisher: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, code_object: Object&lt;PackageRegistry&gt;): <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a> {
+    <a href="code.md#0x1_code_check_code_publishing_permission">code::check_code_publishing_permission</a>(publisher);
+    <b>let</b> publisher_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(publisher);
+    <b>assert</b>!(
+        code_object.is_owner(publisher_address),
+        <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_permission_denied">error::permission_denied</a>(<a href="object_code_deployment.md#0x1_object_code_deployment_ENOT_CODE_OBJECT_OWNER">ENOT_CODE_OBJECT_OWNER</a>),
+    );
+
+    <b>let</b> code_object_address = code_object.object_address();
+    <b>assert</b>!(<b>exists</b>&lt;<a href="object_code_deployment.md#0x1_object_code_deployment_ManagingRefs">ManagingRefs</a>&gt;(code_object_address), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_not_found">error::not_found</a>(<a href="object_code_deployment.md#0x1_object_code_deployment_ECODE_OBJECT_DOES_NOT_EXIST">ECODE_OBJECT_DOES_NOT_EXIST</a>));
+
+    <b>let</b> extend_ref = &<b>borrow_global</b>&lt;<a href="object_code_deployment.md#0x1_object_code_deployment_ManagingRefs">ManagingRefs</a>&gt;(code_object_address).extend_ref;
+    extend_ref.generate_signer_for_extending()
 }
 </code></pre>
 

--- a/aptos-move/framework/aptos-framework/sources/genesis.move
+++ b/aptos-move/framework/aptos-framework/sources/genesis.move
@@ -532,10 +532,6 @@ module aptos_framework::genesis {
         use aptos_framework::object;
         use aptos_framework::primary_fungible_store;
         use aptos_framework::fungible_asset::Metadata;
-        use std::features;
-
-        let feature = features::get_new_accounts_default_to_fa_apt_store_feature();
-        features::change_feature_flags_for_testing(aptos_framework, vector[feature], vector[]);
 
         aggregator_factory::initialize_aggregator_factory_for_test(aptos_framework);
 

--- a/aptos-move/framework/aptos-framework/sources/object_code_deployment.move
+++ b/aptos-move/framework/aptos-framework/sources/object_code_deployment.move
@@ -31,7 +31,6 @@
 module aptos_framework::object_code_deployment {
     use std::bcs;
     use std::error;
-    use std::features;
     use std::signer;
     use aptos_framework::account;
     use aptos_framework::code;
@@ -86,11 +85,6 @@ module aptos_framework::object_code_deployment {
         code: vector<vector<u8>>,
     ) {
         code::check_code_publishing_permission(publisher);
-        assert!(
-            features::is_object_code_deployment_enabled(),
-            error::unavailable(EOBJECT_CODE_DEPLOYMENT_NOT_SUPPORTED),
-        );
-
         let publisher_address = signer::address_of(publisher);
         let object_seed = object_seed(publisher_address);
         let constructor_ref = &object::create_named_object(publisher, object_seed);
@@ -116,12 +110,15 @@ module aptos_framework::object_code_deployment {
     /// along with the metadata `metadata_serialized`.
     /// Note: If the modules were deployed as immutable when calling `publish`, the upgrade will fail.
     /// Requires the publisher to be the owner of the `code_object`.
+    ///
+    /// Note: In order to publish a new package to an existing code object,
+    /// this `upgrade` function should be called, rather than `publish`.
     public entry fun upgrade(
         publisher: &signer,
         metadata_serialized: vector<u8>,
         code: vector<vector<u8>>,
         code_object: Object<PackageRegistry>,
-    ) acquires ManagingRefs {
+    ) {
         code::check_code_publishing_permission(publisher);
         let publisher_address = signer::address_of(publisher);
         assert!(
@@ -146,5 +143,25 @@ module aptos_framework::object_code_deployment {
         code::freeze_code_object(publisher, code_object);
 
         event::emit(Freeze { object_address: code_object.object_address(), });
+    }
+
+    /// Returns the signer for the given `code_object`.
+    /// For example, this can be used if you need to additional initialization
+    /// after upgrading a module.
+    ///
+    /// Requires the publisher to be the owner of the `code_object`.
+    public fun get_code_object_signer(publisher: &signer, code_object: Object<PackageRegistry>): signer {
+        code::check_code_publishing_permission(publisher);
+        let publisher_address = signer::address_of(publisher);
+        assert!(
+            code_object.is_owner(publisher_address),
+            error::permission_denied(ENOT_CODE_OBJECT_OWNER),
+        );
+
+        let code_object_address = code_object.object_address();
+        assert!(exists<ManagingRefs>(code_object_address), error::not_found(ECODE_OBJECT_DOES_NOT_EXIST));
+
+        let extend_ref = &borrow_global<ManagingRefs>(code_object_address).extend_ref;
+        extend_ref.generate_signer_for_extending()
     }
 }

--- a/aptos-move/framework/move-stdlib/doc/features.md
+++ b/aptos-move/framework/move-stdlib/doc/features.md
@@ -282,15 +282,6 @@ Lifetime: transient
 
 
 
-<a id="0x1_features_AGGREGATOR_V2_IS_AT_LEAST_API"></a>
-
-
-
-<pre><code><b>const</b> <a href="features.md#0x1_features_AGGREGATOR_V2_IS_AT_LEAST_API">AGGREGATOR_V2_IS_AT_LEAST_API</a>: u64 = 66;
-</code></pre>
-
-
-
 <a id="0x1_features_APTOS_STD_CHAIN_ID_NATIVES"></a>
 
 Whether the new <code>aptos_stdlib::type_info::chain_id()</code> native for fetching the chain ID is enabled.
@@ -427,17 +418,6 @@ Lifetime: transient
 
 
 
-<a id="0x1_features_COLLECT_AND_DISTRIBUTE_GAS_FEES"></a>
-
-Deprecated feature
-Lifetime: transient
-
-
-<pre><code><b>const</b> <a href="features.md#0x1_features_COLLECT_AND_DISTRIBUTE_GAS_FEES">COLLECT_AND_DISTRIBUTE_GAS_FEES</a>: u64 = 6;
-</code></pre>
-
-
-
 <a id="0x1_features_COMMISSION_CHANGE_DELEGATION_POOL"></a>
 
 Whether the operator commission rate change in delegation pool is enabled.
@@ -551,18 +531,6 @@ Lifetime: transient
 
 
 
-<a id="0x1_features_DISPATCHABLE_FUNGIBLE_ASSET"></a>
-
-Whether the dispatchable fungible asset standard feature is enabled.
-
-Lifetime: transient
-
-
-<pre><code><b>const</b> <a href="features.md#0x1_features_DISPATCHABLE_FUNGIBLE_ASSET">DISPATCHABLE_FUNGIBLE_ASSET</a>: u64 = 63;
-</code></pre>
-
-
-
 <a id="0x1_features_DISTRIBUTE_TRANSACTION_FEE"></a>
 
 Whether to distribute transaction fee to validators.
@@ -618,19 +586,6 @@ The provided signer has not a framework address.
 
 
 <pre><code><b>const</b> <a href="features.md#0x1_features_EINVALID_FEATURE">EINVALID_FEATURE</a>: u64 = 1;
-</code></pre>
-
-
-
-<a id="0x1_features_ENABLE_FUNCTION_VALUES"></a>
-
-Whether function values are enabled.
-Lifetime: transient
-
-We do not expect use from Move, so for now only for documentation purposes here
-
-
-<pre><code><b>const</b> <a href="features.md#0x1_features_ENABLE_FUNCTION_VALUES">ENABLE_FUNCTION_VALUES</a>: u64 = 89;
 </code></pre>
 
 
@@ -737,15 +692,6 @@ Lifetime: transient
 
 
 
-<a id="0x1_features_LIMIT_MAX_IDENTIFIER_LENGTH"></a>
-
-
-
-<pre><code><b>const</b> <a href="features.md#0x1_features_LIMIT_MAX_IDENTIFIER_LENGTH">LIMIT_MAX_IDENTIFIER_LENGTH</a>: u64 = 38;
-</code></pre>
-
-
-
 <a id="0x1_features_MAX_OBJECT_NESTING_CHECK"></a>
 
 Whether checking the maximum object nesting is enabled.
@@ -776,16 +722,6 @@ Lifetime: transient
 
 
 <pre><code><b>const</b> <a href="features.md#0x1_features_MODULE_EVENT_MIGRATION">MODULE_EVENT_MIGRATION</a>: u64 = 57;
-</code></pre>
-
-
-
-<a id="0x1_features_MONOTONICALLY_INCREASING_COUNTER"></a>
-
-Whether the monotonically increasing counter native function is enabled.
-
-
-<pre><code><b>const</b> <a href="features.md#0x1_features_MONOTONICALLY_INCREASING_COUNTER">MONOTONICALLY_INCREASING_COUNTER</a>: u64 = 98;
 </code></pre>
 
 
@@ -833,16 +769,6 @@ Lifetime: transient
 
 
 
-<a id="0x1_features_NEW_ACCOUNTS_DEFAULT_TO_FA_APT_STORE"></a>
-
-Lifetime: transient
-
-
-<pre><code><b>const</b> <a href="features.md#0x1_features_NEW_ACCOUNTS_DEFAULT_TO_FA_APT_STORE">NEW_ACCOUNTS_DEFAULT_TO_FA_APT_STORE</a>: u64 = 64;
-</code></pre>
-
-
-
 <a id="0x1_features_NEW_ACCOUNTS_DEFAULT_TO_FA_STORE"></a>
 
 Whether new accounts default to the Fungible Asset store.
@@ -850,36 +776,6 @@ Lifetime: transient
 
 
 <pre><code><b>const</b> <a href="features.md#0x1_features_NEW_ACCOUNTS_DEFAULT_TO_FA_STORE">NEW_ACCOUNTS_DEFAULT_TO_FA_STORE</a>: u64 = 90;
-</code></pre>
-
-
-
-<a id="0x1_features_OBJECT_CODE_DEPLOYMENT"></a>
-
-Whether deploying to objects is enabled.
-
-
-<pre><code><b>const</b> <a href="features.md#0x1_features_OBJECT_CODE_DEPLOYMENT">OBJECT_CODE_DEPLOYMENT</a>: u64 = 52;
-</code></pre>
-
-
-
-<a id="0x1_features_OBJECT_NATIVE_DERIVED_ADDRESS"></a>
-
-Whether we use more efficient native implementation of computing object derived address
-
-
-<pre><code><b>const</b> <a href="features.md#0x1_features_OBJECT_NATIVE_DERIVED_ADDRESS">OBJECT_NATIVE_DERIVED_ADDRESS</a>: u64 = 62;
-</code></pre>
-
-
-
-<a id="0x1_features_OPERATIONS_DEFAULT_TO_FA_APT_STORE"></a>
-
-Lifetime: transient
-
-
-<pre><code><b>const</b> <a href="features.md#0x1_features_OPERATIONS_DEFAULT_TO_FA_APT_STORE">OPERATIONS_DEFAULT_TO_FA_APT_STORE</a>: u64 = 65;
 </code></pre>
 
 
@@ -937,15 +833,6 @@ Lifetime: transient
 
 
 
-<a id="0x1_features_PRIMARY_APT_FUNGIBLE_STORE_AT_USER_ADDRESS"></a>
-
-
-
-<pre><code><b>const</b> <a href="features.md#0x1_features_PRIMARY_APT_FUNGIBLE_STORE_AT_USER_ADDRESS">PRIMARY_APT_FUNGIBLE_STORE_AT_USER_ADDRESS</a>: u64 = 61;
-</code></pre>
-
-
-
 <a id="0x1_features_RECONFIGURE_WITH_DKG"></a>
 
 Deprecated by <code>aptos_framework::randomness_config::RandomnessConfig</code>.
@@ -963,33 +850,6 @@ This is needed because of new attributes for structs and a change in storage rep
 
 
 <pre><code><b>const</b> <a href="features.md#0x1_features_RESOURCE_GROUPS">RESOURCE_GROUPS</a>: u64 = 9;
-</code></pre>
-
-
-
-<a id="0x1_features_RESOURCE_GROUPS_SPLIT_IN_VM_CHANGE_SET"></a>
-
-
-
-<pre><code><b>const</b> <a href="features.md#0x1_features_RESOURCE_GROUPS_SPLIT_IN_VM_CHANGE_SET">RESOURCE_GROUPS_SPLIT_IN_VM_CHANGE_SET</a>: u64 = 41;
-</code></pre>
-
-
-
-<a id="0x1_features_SAFER_METADATA"></a>
-
-
-
-<pre><code><b>const</b> <a href="features.md#0x1_features_SAFER_METADATA">SAFER_METADATA</a>: u64 = 32;
-</code></pre>
-
-
-
-<a id="0x1_features_SAFER_RESOURCE_GROUPS"></a>
-
-
-
-<pre><code><b>const</b> <a href="features.md#0x1_features_SAFER_RESOURCE_GROUPS">SAFER_RESOURCE_GROUPS</a>: u64 = 31;
 </code></pre>
 
 
@@ -1024,15 +884,6 @@ Lifetime: transient
 
 
 <pre><code><b>const</b> <a href="features.md#0x1_features_SIGNER_NATIVE_FORMAT_FIX">SIGNER_NATIVE_FORMAT_FIX</a>: u64 = 25;
-</code></pre>
-
-
-
-<a id="0x1_features_SINGLE_SENDER_AUTHENTICATOR"></a>
-
-
-
-<pre><code><b>const</b> <a href="features.md#0x1_features_SINGLE_SENDER_AUTHENTICATOR">SINGLE_SENDER_AUTHENTICATOR</a>: u64 = 33;
 </code></pre>
 
 
@@ -1117,15 +968,6 @@ Lifetime: transient
 
 
 <pre><code><b>const</b> <a href="features.md#0x1_features_VM_BINARY_FORMAT_V6">VM_BINARY_FORMAT_V6</a>: u64 = 5;
-</code></pre>
-
-
-
-<a id="0x1_features_VM_BINARY_FORMAT_V7"></a>
-
-
-
-<pre><code><b>const</b> <a href="features.md#0x1_features_VM_BINARY_FORMAT_V7">VM_BINARY_FORMAT_V7</a>: u64 = 40;
 </code></pre>
 
 
@@ -2716,7 +2558,8 @@ Deprecated feature
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_is_object_code_deployment_enabled">is_object_code_deployment_enabled</a>(): bool
+<pre><code>#[deprecated]
+<b>public</b> <b>fun</b> <a href="features.md#0x1_features_is_object_code_deployment_enabled">is_object_code_deployment_enabled</a>(): bool
 </code></pre>
 
 
@@ -2726,7 +2569,7 @@ Deprecated feature
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_is_object_code_deployment_enabled">is_object_code_deployment_enabled</a>(): bool {
-    <a href="features.md#0x1_features_is_enabled">is_enabled</a>(<a href="features.md#0x1_features_OBJECT_CODE_DEPLOYMENT">OBJECT_CODE_DEPLOYMENT</a>)
+    <b>true</b>
 }
 </code></pre>
 
@@ -3126,7 +2969,8 @@ Deprecated feature
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_aggregator_v2_is_at_least_api_enabled">aggregator_v2_is_at_least_api_enabled</a>(): bool
+<pre><code>#[deprecated]
+<b>public</b> <b>fun</b> <a href="features.md#0x1_features_aggregator_v2_is_at_least_api_enabled">aggregator_v2_is_at_least_api_enabled</a>(): bool
 </code></pre>
 
 
@@ -3150,7 +2994,8 @@ Deprecated feature
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_get_object_native_derived_address_feature">get_object_native_derived_address_feature</a>(): u64
+<pre><code>#[deprecated]
+<b>public</b> <b>fun</b> <a href="features.md#0x1_features_get_object_native_derived_address_feature">get_object_native_derived_address_feature</a>(): u64
 </code></pre>
 
 
@@ -3160,7 +3005,7 @@ Deprecated feature
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_get_object_native_derived_address_feature">get_object_native_derived_address_feature</a>(): u64 {
-    <a href="features.md#0x1_features_OBJECT_NATIVE_DERIVED_ADDRESS">OBJECT_NATIVE_DERIVED_ADDRESS</a>
+    <b>abort</b> <a href="error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="features.md#0x1_features_EINVALID_FEATURE">EINVALID_FEATURE</a>)
 }
 </code></pre>
 
@@ -3174,7 +3019,8 @@ Deprecated feature
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_object_native_derived_address_enabled">object_native_derived_address_enabled</a>(): bool
+<pre><code>#[deprecated]
+<b>public</b> <b>fun</b> <a href="features.md#0x1_features_object_native_derived_address_enabled">object_native_derived_address_enabled</a>(): bool
 </code></pre>
 
 
@@ -3198,7 +3044,8 @@ Deprecated feature
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_get_dispatchable_fungible_asset_feature">get_dispatchable_fungible_asset_feature</a>(): u64
+<pre><code>#[deprecated]
+<b>public</b> <b>fun</b> <a href="features.md#0x1_features_get_dispatchable_fungible_asset_feature">get_dispatchable_fungible_asset_feature</a>(): u64
 </code></pre>
 
 
@@ -3208,7 +3055,7 @@ Deprecated feature
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_get_dispatchable_fungible_asset_feature">get_dispatchable_fungible_asset_feature</a>(): u64 {
-    <a href="features.md#0x1_features_DISPATCHABLE_FUNGIBLE_ASSET">DISPATCHABLE_FUNGIBLE_ASSET</a>
+    <b>abort</b> <a href="error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="features.md#0x1_features_EINVALID_FEATURE">EINVALID_FEATURE</a>)
 }
 </code></pre>
 
@@ -3222,7 +3069,8 @@ Deprecated feature
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_dispatchable_fungible_asset_enabled">dispatchable_fungible_asset_enabled</a>(): bool
+<pre><code>#[deprecated]
+<b>public</b> <b>fun</b> <a href="features.md#0x1_features_dispatchable_fungible_asset_enabled">dispatchable_fungible_asset_enabled</a>(): bool
 </code></pre>
 
 
@@ -3246,7 +3094,8 @@ Deprecated feature
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_get_new_accounts_default_to_fa_apt_store_feature">get_new_accounts_default_to_fa_apt_store_feature</a>(): u64
+<pre><code>#[deprecated]
+<b>public</b> <b>fun</b> <a href="features.md#0x1_features_get_new_accounts_default_to_fa_apt_store_feature">get_new_accounts_default_to_fa_apt_store_feature</a>(): u64
 </code></pre>
 
 
@@ -3256,7 +3105,7 @@ Deprecated feature
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_get_new_accounts_default_to_fa_apt_store_feature">get_new_accounts_default_to_fa_apt_store_feature</a>(): u64 {
-    <a href="features.md#0x1_features_NEW_ACCOUNTS_DEFAULT_TO_FA_APT_STORE">NEW_ACCOUNTS_DEFAULT_TO_FA_APT_STORE</a>
+    <b>abort</b> <a href="error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="features.md#0x1_features_EINVALID_FEATURE">EINVALID_FEATURE</a>)
 }
 </code></pre>
 
@@ -3270,7 +3119,8 @@ Deprecated feature
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_new_accounts_default_to_fa_apt_store_enabled">new_accounts_default_to_fa_apt_store_enabled</a>(): bool
+<pre><code>#[deprecated]
+<b>public</b> <b>fun</b> <a href="features.md#0x1_features_new_accounts_default_to_fa_apt_store_enabled">new_accounts_default_to_fa_apt_store_enabled</a>(): bool
 </code></pre>
 
 
@@ -3280,7 +3130,7 @@ Deprecated feature
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_new_accounts_default_to_fa_apt_store_enabled">new_accounts_default_to_fa_apt_store_enabled</a>(): bool {
-    <a href="features.md#0x1_features_is_enabled">is_enabled</a>(<a href="features.md#0x1_features_NEW_ACCOUNTS_DEFAULT_TO_FA_APT_STORE">NEW_ACCOUNTS_DEFAULT_TO_FA_APT_STORE</a>)
+    <b>true</b>
 }
 </code></pre>
 
@@ -4725,17 +4575,6 @@ Helper to check whether a feature flag is enabled.
 
 <pre><code><b>fun</b> <a href="features.md#0x1_features_spec_abort_if_multisig_payload_mismatch_enabled">spec_abort_if_multisig_payload_mismatch_enabled</a>(): bool {
    <a href="features.md#0x1_features_spec_is_enabled">spec_is_enabled</a>(<a href="features.md#0x1_features_ABORT_IF_MULTISIG_PAYLOAD_MISMATCH">ABORT_IF_MULTISIG_PAYLOAD_MISMATCH</a>)
-}
-</code></pre>
-
-
-
-
-<a id="0x1_features_spec_new_accounts_default_to_fa_apt_store_enabled"></a>
-
-
-<pre><code><b>fun</b> <a href="features.md#0x1_features_spec_new_accounts_default_to_fa_apt_store_enabled">spec_new_accounts_default_to_fa_apt_store_enabled</a>(): bool {
-   <a href="features.md#0x1_features_spec_is_enabled">spec_is_enabled</a>(<a href="features.md#0x1_features_NEW_ACCOUNTS_DEFAULT_TO_FA_APT_STORE">NEW_ACCOUNTS_DEFAULT_TO_FA_APT_STORE</a>)
 }
 </code></pre>
 

--- a/aptos-move/framework/move-stdlib/sources/configs/features.move
+++ b/aptos-move/framework/move-stdlib/sources/configs/features.move
@@ -93,11 +93,6 @@ module std::features {
 
     #[deprecated]
     /// Deprecated feature
-    /// Lifetime: transient
-    const COLLECT_AND_DISTRIBUTE_GAS_FEES: u64 = 6;
-
-    #[deprecated]
-    /// Deprecated feature
     public fun get_collect_and_distribute_gas_fees_feature(): u64 {
         abort error::invalid_argument(EINVALID_FEATURE)
     }
@@ -323,12 +318,6 @@ module std::features {
         abort error::invalid_argument(EINVALID_FEATURE)
     }
 
-    const SAFER_RESOURCE_GROUPS: u64 = 31;
-
-    const SAFER_METADATA: u64 = 32;
-
-    const SINGLE_SENDER_AUTHENTICATOR: u64 = 33;
-
     /// Whether the automatic creation of accounts is enabled for sponsored transactions.
     /// Lifetime: transient
     const SPONSORED_AUTOMATIC_ACCOUNT_CREATION: u64 = 34;
@@ -361,8 +350,6 @@ module std::features {
         abort error::invalid_argument(EFEATURE_CANNOT_BE_DISABLED)
     }
 
-    const LIMIT_MAX_IDENTIFIER_LENGTH: u64 = 38;
-
     /// Whether allow changing beneficiaries for operators.
     /// Lifetime: transient
     const OPERATOR_BENEFICIARY_CHANGE: u64 = 39;
@@ -374,10 +361,6 @@ module std::features {
     public fun operator_beneficiary_change_enabled(): bool {
         is_enabled(OPERATOR_BENEFICIARY_CHANGE)
     }
-
-    const VM_BINARY_FORMAT_V7: u64 = 40;
-
-    const RESOURCE_GROUPS_SPLIT_IN_VM_CHANGE_SET: u64 = 41;
 
     /// Whether the operator commission rate change in delegation pool is enabled.
     /// Lifetime: transient
@@ -465,11 +448,9 @@ module std::features {
         is_enabled(CONCURRENT_FUNGIBLE_ASSETS)
     }
 
-    /// Whether deploying to objects is enabled.
-    const OBJECT_CODE_DEPLOYMENT: u64 = 52;
-
+    #[deprecated]
     public fun is_object_code_deployment_enabled(): bool {
-        is_enabled(OBJECT_CODE_DEPLOYMENT)
+        true
     }
 
     /// Whether checking the maximum object nesting is enabled.
@@ -561,8 +542,6 @@ module std::features {
         is_enabled(COIN_TO_FUNGIBLE_ASSET_MIGRATION)
     }
 
-    const PRIMARY_APT_FUNGIBLE_STORE_AT_USER_ADDRESS: u64 = 61;
-
     #[deprecated]
     public fun get_primary_apt_fungible_store_at_user_address_feature(): u64 {
         abort error::invalid_argument(EINVALID_FEATURE)
@@ -573,49 +552,40 @@ module std::features {
         true
     }
 
-    const AGGREGATOR_V2_IS_AT_LEAST_API: u64 = 66;
-
+    #[deprecated]
     public fun aggregator_v2_is_at_least_api_enabled(): bool {
         true
     }
 
-    /// Whether we use more efficient native implementation of computing object derived address
-    const OBJECT_NATIVE_DERIVED_ADDRESS: u64 = 62;
-
+    #[deprecated]
     public fun get_object_native_derived_address_feature(): u64 {
-        OBJECT_NATIVE_DERIVED_ADDRESS
+        abort error::invalid_argument(EINVALID_FEATURE)
     }
 
+    #[deprecated]
     public fun object_native_derived_address_enabled(): bool {
         true
     }
 
-    /// Whether the dispatchable fungible asset standard feature is enabled.
-    ///
-    /// Lifetime: transient
-    const DISPATCHABLE_FUNGIBLE_ASSET: u64 = 63;
-
+    #[deprecated]
     public fun get_dispatchable_fungible_asset_feature(): u64 {
-        DISPATCHABLE_FUNGIBLE_ASSET
+        abort error::invalid_argument(EINVALID_FEATURE)
     }
 
+    #[deprecated]
     public fun dispatchable_fungible_asset_enabled(): bool {
         true
     }
 
-    /// Lifetime: transient
-    const NEW_ACCOUNTS_DEFAULT_TO_FA_APT_STORE: u64 = 64;
-
+    #[deprecated]
     public fun get_new_accounts_default_to_fa_apt_store_feature(): u64 {
-        NEW_ACCOUNTS_DEFAULT_TO_FA_APT_STORE
+        abort error::invalid_argument(EINVALID_FEATURE)
     }
 
+    #[deprecated]
     public fun new_accounts_default_to_fa_apt_store_enabled(): bool {
-        is_enabled(NEW_ACCOUNTS_DEFAULT_TO_FA_APT_STORE)
+        true
     }
-
-    /// Lifetime: transient
-    const OPERATIONS_DEFAULT_TO_FA_APT_STORE: u64 = 65;
 
     #[deprecated]
     public fun get_operations_default_to_fa_apt_store_feature(): u64 {
@@ -756,12 +726,6 @@ module std::features {
         false
     }
 
-    /// Whether function values are enabled.
-    /// Lifetime: transient
-    ///
-    /// We do not expect use from Move, so for now only for documentation purposes here
-    const ENABLE_FUNCTION_VALUES: u64 = 89;
-
     /// Whether new accounts default to the Fungible Asset store.
     /// Lifetime: transient
     const NEW_ACCOUNTS_DEFAULT_TO_FA_STORE: u64 = 90;
@@ -837,9 +801,6 @@ module std::features {
     public fun is_distribute_transaction_fee_enabled(): bool {
         is_enabled(DISTRIBUTE_TRANSACTION_FEE)
     }
-
-    /// Whether the monotonically increasing counter native function is enabled.
-    const MONOTONICALLY_INCREASING_COUNTER: u64 = 98;
 
     #[deprecated]
     public fun get_monotonically_increasing_counter_feature(): u64 {

--- a/aptos-move/framework/move-stdlib/sources/configs/features.spec.move
+++ b/aptos-move/framework/move-stdlib/sources/configs/features.spec.move
@@ -98,10 +98,6 @@ spec std::features {
         spec_is_enabled(ABORT_IF_MULTISIG_PAYLOAD_MISMATCH)
     }
 
-    spec fun spec_new_accounts_default_to_fa_apt_store_enabled(): bool {
-        spec_is_enabled(NEW_ACCOUNTS_DEFAULT_TO_FA_APT_STORE)
-    }
-
     spec fun spec_new_accounts_default_to_fa_store_enabled(): bool {
         spec_is_enabled(NEW_ACCOUNTS_DEFAULT_TO_FA_STORE)
     }


### PR DESCRIPTION
## Description

Simplify ability to initialize modules after upgrade (when init_module is not called), or replacing init_modules with post-fact initialization.

Note that this functionality exists already - you can always publish a new package with single module containing init_module function - which will give you access to this code signer. It just seems unnecessarily convoluted to be doing that.

But I think we overall need to revamp code publishing with a comprehensive AIP:
- all functions in object_code_deployment.move and code.move are public, so calling any third party code from an account that has published modules is extremely dangerous. 
- Creating a governance module, that would gate code publishing also seems impossible as-is - as getting a signer allows you to directly upgrade a module, bypassing governance. 

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Adds a new public API that returns a `signer` for a code object and simultaneously removes feature-flag gating for object code deployment; both changes touch code-publishing authorization surfaces and could enable unintended upgrade/init flows if misused.
> 
> **Overview**
> `object_code_deployment` now exposes `get_code_object_signer()` to let the code-object owner derive a `signer` for post-upgrade initialization.
> 
> The `OBJECT_CODE_DEPLOYMENT` feature flag is effectively retired: `publish` no longer checks `features::is_object_code_deployment_enabled()`, stdlib `features` APIs/constants around it are removed or marked `#[deprecated]` (often returning `true` or aborting), and tests are updated to stop toggling feature flags (including simplifying the e2e publish test and removing a feature-flag setup from `genesis.move` tests).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3c4ff8ccb3f6de8aa48a899f7ff3c947b89d7021. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->