### PR TITLE
[build] target-cpu=native for Apple Silicon local builds

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -50,9 +50,18 @@ CFLAGS_x86_64_unknown_linux_gnu = "-march=x86-64-v3"
 # Need `-mpclmul` for RocksDB to build until its build script is fixed.
 CXXFLAGS_x86_64_unknown_linux_gnu = "-march=x86-64-v3 -mpclmul"
 
-# Apple Silicon (local dev): tune codegen for the host CPU. Merged with [build].rustflags.
+# Apple Silicon (local dev): same rustc flags as [build] plus host CPU tuning.
 [target.aarch64-apple-darwin]
-rustflags = ["-C", "target-cpu=native"]
+rustflags = [
+  "--cfg",
+  "tokio_unstable",
+  "-C",
+  "force-frame-pointers=yes",
+  "-C",
+  "force-unwind-tables=yes",
+  "-C",
+  "target-cpu=native",
+]
 
 # 64 bit MSVC
 [target.x86_64-pc-windows-msvc]

--- a/scripts/benchmark_aptos_mac_arm_build.sh
+++ b/scripts/benchmark_aptos_mac_arm_build.sh
@@ -29,7 +29,7 @@ run_timed() {
   echo "${label}: $((end - start))s wall time"
 }
 
-echo "=== Baseline: force generic CPU (RUSTFLAGS after config; last target-cpu wins) ==="
+echo "=== Baseline: generic CPU (RUSTFLAGS=-C target-cpu=generic; other flags unchanged from config) ==="
 cargo clean -p "${PKG}"
 run_timed "generic" env RUSTFLAGS="-C target-cpu=generic ${RUSTFLAGS:-}" cargo build -p "${PKG}"
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Adds explicit `rustflags` for `aarch64-apple-darwin` in `.cargo/config.toml`: `--cfg tokio_unstable`, `-C force-frame-pointers=yes`, `-C force-unwind-tables=yes`, and `-C target-cpu=native`. Target-specific rustflags apply for that triple (listed in full so nothing is dropped vs `[build]`).

Adds `scripts/benchmark_aptos_mac_arm_build.sh` to compare `cargo build -p aptos` wall time with `RUSTFLAGS=-C target-cpu=generic` (baseline) versus the repo default with native enabled.

## How Has This Been Tested?

- Configuration-only change.
- **Benchmark on a Mac:** from the repo root run `./scripts/benchmark_aptos_mac_arm_build.sh` (Darwin arm64 only).

## Key Areas to Review

- `.cargo/config.toml`: only affects builds targeting `aarch64-apple-darwin`.
- `native` ties binaries to the host CPU; intended for local dev.

## Type of Change

- [x] Performance improvement

## Which Components or Systems Does This Change Impact?

- [x] Aptos CLI/SDK
- [x] Developer Infrastructure

## Checklist

- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-afd598cf-1462-4e48-87dd-3a08600b5f13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-afd598cf-1462-4e48-87dd-3a08600b5f13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

