### PR TITLE
[Config] Enable validator-PFN connections for non-production networks.

### DIFF
--- a/config/src/config/base_config.rs
+++ b/config/src/config/base_config.rs
@@ -2,13 +2,14 @@
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::config::{
-    config_sanitizer::ConfigSanitizer, node_config_loader::NodeType, Error, NodeConfig,
-    SecureBackend,
+    config_optimizer::ConfigOptimizer, config_sanitizer::ConfigSanitizer,
+    node_config_loader::NodeType, Error, NodeConfig, SecureBackend,
 };
 use aptos_secure_storage::{KVStorage, Storage};
 use aptos_types::{chain_id::ChainId, waypoint::Waypoint};
 use poem_openapi::Enum as PoemEnum;
 use serde::{Deserialize, Serialize};
+use serde_yaml::Value;
 use std::{fmt, fs, path::PathBuf, str::FromStr};
 use thiserror::Error;
 
@@ -52,6 +53,34 @@ impl ConfigSanitizer for BaseConfig {
         }
 
         Ok(())
+    }
+}
+
+impl ConfigOptimizer for BaseConfig {
+    fn optimize(
+        node_config: &mut NodeConfig,
+        local_config_yaml: &Value,
+        _node_type: NodeType,
+        chain_id: Option<ChainId>,
+    ) -> Result<bool, Error> {
+        let base_config = &mut node_config.base;
+        let local_base_config_yaml = &local_config_yaml["base"];
+
+        let mut modified_config = false;
+
+        // Enable validator-PFN connections for all networks except mainnet,
+        // and test environments (e.g., local swarms, and smoke tests).
+        if local_base_config_yaml["enable_validator_pfn_connections"].is_null() {
+            let should_enable = chain_id
+                .map(|id| !id.is_mainnet() && id != ChainId::test())
+                .unwrap_or(true);
+            if should_enable {
+                base_config.enable_validator_pfn_connections = true;
+                modified_config = true;
+            }
+        }
+
+        Ok(modified_config)
     }
 }
 
@@ -229,5 +258,108 @@ mod test {
             RoleType::from_str(invalid_role_type),
             Err(ParseRoleError(_))
         ));
+    }
+
+    #[test]
+    fn test_optimize_validator_pfn_connections() {
+        // Create a node config with PFN validator connections disabled
+        let mut node_config = create_config_with_validator_pfn_connections(false);
+
+        // Optimize for a testing chain (smoke tests) and verify the flag is still disabled
+        let modified = BaseConfig::optimize(
+            &mut node_config,
+            &serde_yaml::from_str("{}").unwrap(), // An empty local config
+            NodeType::Validator,
+            Some(ChainId::test()),
+        )
+        .unwrap();
+        assert!(!modified);
+        assert!(!node_config.base.enable_validator_pfn_connections);
+    }
+
+    #[test]
+    fn test_optimize_validator_pfn_connections_for_testnet() {
+        // Create a node config with PFN validator connections disabled
+        let mut node_config = create_config_with_validator_pfn_connections(false);
+
+        // Optimize for testnet and verify the flag is now enabled
+        let modified = BaseConfig::optimize(
+            &mut node_config,
+            &serde_yaml::from_str("{}").unwrap(),
+            NodeType::Validator,
+            Some(ChainId::testnet()),
+        )
+        .unwrap();
+        assert!(modified);
+        assert!(node_config.base.enable_validator_pfn_connections);
+    }
+
+    #[test]
+    fn test_optimize_validator_pfn_connections_for_mainnet() {
+        // Create a node config with PFN validator connections disabled
+        let mut node_config = create_config_with_validator_pfn_connections(false);
+
+        // Optimize for mainnet and verify the flag is still disabled
+        let modified = BaseConfig::optimize(
+            &mut node_config,
+            &serde_yaml::from_str("{}").unwrap(),
+            NodeType::Validator,
+            Some(ChainId::mainnet()),
+        )
+        .unwrap();
+        assert!(!modified);
+        assert!(!node_config.base.enable_validator_pfn_connections);
+    }
+
+    #[test]
+    fn test_optimize_validator_pfn_connections_local_yaml() {
+        // Create a node config with PFN validator connections disabled
+        let mut node_config = create_config_with_validator_pfn_connections(false);
+
+        // Provide a local YAML that explicitly sets the flag to false
+        let local_config_yaml = serde_yaml::from_str(
+            r#"
+            base:
+                enable_validator_pfn_connections: false
+            "#,
+        )
+        .unwrap();
+
+        // Optimize for a non-production chain and verify the flag is still disabled
+        let modified = BaseConfig::optimize(
+            &mut node_config,
+            &local_config_yaml,
+            NodeType::Validator,
+            Some(ChainId::testnet()),
+        )
+        .unwrap();
+        assert!(!modified);
+        assert!(!node_config.base.enable_validator_pfn_connections);
+    }
+
+    #[test]
+    fn test_optimize_validator_pfn_connections_missing_chain() {
+        // Create a node config with PFN validator connections disabled
+        let mut node_config = create_config_with_validator_pfn_connections(false);
+
+        // Optimize for a missing chain and verify the flag is now enabled
+        let modified = BaseConfig::optimize(
+            &mut node_config,
+            &serde_yaml::from_str("{}").unwrap(),
+            NodeType::Validator,
+            None,
+        )
+        .unwrap();
+        assert!(modified);
+        assert!(node_config.base.enable_validator_pfn_connections);
+    }
+
+    /// Creates a node config with validator PFN connections as specified
+    fn create_config_with_validator_pfn_connections(
+        enable_validator_pfn_connections: bool,
+    ) -> NodeConfig {
+        let mut node_config = NodeConfig::default();
+        node_config.base.enable_validator_pfn_connections = enable_validator_pfn_connections;
+        node_config
     }
 }

--- a/config/src/config/config_optimizer.rs
+++ b/config/src/config/config_optimizer.rs
@@ -7,9 +7,9 @@ use super::{
 };
 use crate::{
     config::{
-        node_config_loader::NodeType, utils::get_config_name, AdminServiceConfig, Error,
-        ExecutionConfig, InspectionServiceConfig, LoggerConfig, MempoolConfig, NodeConfig, Peer,
-        PeerRole, PeerSet, StateSyncConfig,
+        node_config_loader::NodeType, utils::get_config_name, AdminServiceConfig, BaseConfig,
+        Error, ExecutionConfig, InspectionServiceConfig, LoggerConfig, MempoolConfig, NodeConfig,
+        Peer, PeerRole, PeerSet, StateSyncConfig,
     },
     network_id::NetworkId,
 };
@@ -111,6 +111,9 @@ impl ConfigOptimizer for NodeConfig {
         if AdminServiceConfig::optimize(node_config, local_config_yaml, node_type, chain_id)? {
             optimizers_with_modifications.push(AdminServiceConfig::get_optimizer_name());
         }
+        if BaseConfig::optimize(node_config, local_config_yaml, node_type, chain_id)? {
+            optimizers_with_modifications.push(BaseConfig::get_optimizer_name());
+        }
         if ConsensusConfig::optimize(node_config, local_config_yaml, node_type, chain_id)? {
             optimizers_with_modifications.push(ConsensusConfig::get_optimizer_name());
         }
@@ -185,7 +188,6 @@ fn optimize_all_network_configs(
 ///
 /// For validators, a default public network is added if validator-PFN connections
 /// are enabled, and a public network is not already configured.
-// TODO: enable this for testnet and mainnet validators once we're ready.
 fn optimize_public_network_config(
     node_config: &mut NodeConfig,
     local_config_yaml: &Value,
@@ -194,7 +196,7 @@ fn optimize_public_network_config(
 ) -> Result<bool, Error> {
     // If this is a validator, optimize the public network separately
     if node_type.is_validator() {
-        return optimize_validator_public_network(node_config, local_config_yaml, chain_id);
+        return optimize_validator_public_network(node_config, local_config_yaml);
     }
 
     // For VFNs and PFNs: add seeds to existing public network configs and persist identity
@@ -241,24 +243,15 @@ fn optimize_public_network_config(
 }
 
 /// If validator-PFN connections are enabled, this adds a public network
-/// to the validator's full node networks config. This only occurs if the
-/// network is not mainnet or testnet, and if a public network is not
-/// already present in the config or local YAML.
+/// to the validator's full node networks config. This only occurs if a
+/// public network is not already present in the config or local YAML.
 fn optimize_validator_public_network(
     node_config: &mut NodeConfig,
     local_config_yaml: &Value,
-    chain_id: Option<ChainId>,
 ) -> Result<bool, Error> {
     // If validator-PFN connections are disabled, return early
     if !node_config.base.enable_validator_pfn_connections {
         return Ok(false);
-    }
-
-    // If this is mainnet or testnet, return early
-    if let Some(chain_id) = chain_id {
-        if chain_id.is_mainnet() || chain_id.is_testnet() {
-            return Ok(false);
-        }
     }
 
     // If the config already contains a public network, return early
@@ -270,10 +263,7 @@ fn optimize_validator_public_network(
         return Ok(false);
     }
 
-    // If the local YAML config explicitly includes a public network entry, return
-    // early. This check must be done independently of the in-memory config, since
-    // the in-memory full_node_networks list may be empty (e.g., a bare validator
-    // with no VFN configured) even when the user has specified a public network.
+    // If the local YAML config includes a public network, return early
     if let Some(networks) = local_config_yaml["full_node_networks"].as_sequence() {
         for network in networks {
             if let Some(network_id) = network["network_id"].as_str() {
@@ -284,7 +274,7 @@ fn optimize_validator_public_network(
         }
     }
 
-    // Create a public network for the validator
+    // Create a public network for the validator using the default port
     let mut public_network = NetworkConfig::network_with_id(NetworkId::Public);
     public_network.listen_address = format!("/ip4/0.0.0.0/tcp/{}", DEFAULT_PUBLIC_NETWORK_PORT)
         .parse()
@@ -297,10 +287,7 @@ fn optimize_validator_public_network(
     public_network.discovery_method = DiscoveryMethod::None; // Disable discovery for the public network
     public_network.max_outbound_connections = 0; // Disable outbound connections
 
-    // Use the validator network's identity for the public network. PFNs connect
-    // to validators using the noise-ik address format, which embeds the validator's
-    // public key (as registered on-chain). If the public network used a different
-    // ephemeral key, the noise handshake would fail.
+    // Use the validator network's identity for the public network
     if let Some(validator_network) = &node_config.validator_network {
         public_network.identity = validator_network.identity.clone();
     }
@@ -855,56 +842,6 @@ mod tests {
         let mut node_config = NodeConfig {
             base: crate::config::BaseConfig {
                 enable_validator_pfn_connections: false,
-                ..Default::default()
-            },
-            ..Default::default()
-        };
-
-        // Optimize the config
-        let modified = optimize_public_network_config(
-            &mut node_config,
-            &serde_yaml::from_str("{}").unwrap(),
-            NodeType::Validator,
-            Some(ChainId::testnet()),
-        )
-        .unwrap();
-
-        // Verify no modifications were made and no public network was added
-        assert!(!modified);
-        assert!(node_config.full_node_networks.is_empty());
-    }
-
-    #[test]
-    fn test_optimize_validator_pfn_public_network_mainnet_skipped() {
-        // Create a validator config with PFN connections enabled, but on mainnet
-        let mut node_config = NodeConfig {
-            base: crate::config::BaseConfig {
-                enable_validator_pfn_connections: true,
-                ..Default::default()
-            },
-            ..Default::default()
-        };
-
-        // Optimize the config
-        let modified = optimize_public_network_config(
-            &mut node_config,
-            &serde_yaml::from_str("{}").unwrap(),
-            NodeType::Validator,
-            Some(ChainId::mainnet()),
-        )
-        .unwrap();
-
-        // Verify no modifications were made and no public network was added
-        assert!(!modified);
-        assert!(node_config.full_node_networks.is_empty());
-    }
-
-    #[test]
-    fn test_optimize_validator_pfn_public_network_testnet_skipped() {
-        // Create a validator config with PFN connections enabled, but on testnet
-        let mut node_config = NodeConfig {
-            base: crate::config::BaseConfig {
-                enable_validator_pfn_connections: true,
                 ..Default::default()
             },
             ..Default::default()


### PR DESCRIPTION
Note: this PR is based on: https://github.com/aptos-labs/aptos-core/pull/19094

## Description
This PR enables validator-PFN connections for devnet and testnet. For these networks, validators will start listening on the public network port, and PFNs will attempt to connect directly to validators (falling back to VFNs, when connections fail).

To achieve this, we update the config optimizer to set the `enable_validator_pfn_connections` flag to true (for all appropriate networks). Note that VFNs remain unaffected.

## Testing Plan
New and existing test infrastructure.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default validator networking behavior by auto-enabling `enable_validator_pfn_connections` (and thus public network listening) on non-mainnet chains unless explicitly overridden in local YAML, which could affect connectivity in deployed environments.
> 
> **Overview**
> Automatically enables `base.enable_validator_pfn_connections` during config optimization for any chain *except* mainnet and `ChainId::test` (and leaves user-provided YAML values untouched), with new unit tests covering chain-specific and override behavior.
> 
> Updates the optimizer pipeline to run `BaseConfig` optimization, and relaxes validator public-network optimization to no longer skip testnet/mainnet when the flag is enabled (removing the corresponding skip tests).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8e3ac64a9cb953b5f1c49fed55982d844fbda751. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->