### PR TITLE
Add onchain signer utilities

### DIFF
--- a/aptos-move/framework/aptos-framework/doc/object.md
+++ b/aptos-move/framework/aptos-framework/doc/object.md
@@ -57,6 +57,8 @@ make it so that a reference to a global object can be returned from a function.
 -  [Function `create_object_from_object`](#0x1_object_create_object_from_object)
 -  [Function `create_object_from_guid`](#0x1_object_create_object_from_guid)
 -  [Function `create_object_internal`](#0x1_object_create_object_internal)
+-  [Function `create_unique_onchain_signer`](#0x1_object_create_unique_onchain_signer)
+-  [Function `create_named_unowned_onchain_signer`](#0x1_object_create_named_unowned_onchain_signer)
 -  [Function `generate_delete_ref`](#0x1_object_generate_delete_ref)
 -  [Function `generate_extend_ref`](#0x1_object_generate_extend_ref)
 -  [Function `generate_transfer_ref`](#0x1_object_generate_transfer_ref)
@@ -65,6 +67,7 @@ make it so that a reference to a global object can be returned from a function.
 -  [Function `address_from_constructor_ref`](#0x1_object_address_from_constructor_ref)
 -  [Function `object_from_constructor_ref`](#0x1_object_object_from_constructor_ref)
 -  [Function `can_generate_delete_ref`](#0x1_object_can_generate_delete_ref)
+-  [Function `transfer_with_constructor_ref`](#0x1_object_transfer_with_constructor_ref)
 -  [Function `create_guid`](#0x1_object_create_guid)
 -  [Function `new_event_handle`](#0x1_object_new_event_handle)
 -  [Function `address_from_delete_ref`](#0x1_object_address_from_delete_ref)
@@ -143,6 +146,7 @@ make it so that a reference to a global object can be returned from a function.
 <pre><code><b>use</b> <a href="account.md#0x1_account">0x1::account</a>;
 <b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/bcs.md#0x1_bcs">0x1::bcs</a>;
 <b>use</b> <a href="create_signer.md#0x1_create_signer">0x1::create_signer</a>;
+<b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error">0x1::error</a>;
 <b>use</b> <a href="event.md#0x1_event">0x1::event</a>;
 <b>use</b> <a href="../../aptos-stdlib/doc/from_bcs.md#0x1_from_bcs">0x1::from_bcs</a>;
 <b>use</b> <a href="guid.md#0x1_guid">0x1::guid</a>;
@@ -989,6 +993,8 @@ Derives an object address from source material: sha3_256([creator address | seed
 
 Derives an object address from the source address and an object: sha3_256([source | object addr | 0xFC]).
 
+Only used for primary_fungible_store.
+
 
 <pre><code><b>public</b> <b>fun</b> <a href="object.md#0x1_object_create_user_derived_object_address">create_user_derived_object_address</a>(source: <b>address</b>, derive_from: <b>address</b>): <b>address</b>
 </code></pre>
@@ -1115,6 +1121,9 @@ Convert Object<X> to Object<Y>.
 Create a new named object and return the ConstructorRef. Named objects can be queried globally
 by knowing the user generated seed used to create them. Named objects cannot be deleted.
 
+Note that object returned will be owned by creator, and so creator still can do thing directly to the object,
+for example withdraw from fungible stores signer would own.
+
 
 <pre><code><b>public</b> <b>fun</b> <a href="object.md#0x1_object_create_named_object">create_named_object</a>(creator: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, seed: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="object.md#0x1_object_ConstructorRef">object::ConstructorRef</a>
 </code></pre>
@@ -1142,6 +1151,8 @@ by knowing the user generated seed used to create them. Named objects cannot be 
 
 Create a new object whose address is derived based on the creator account address and another object.
 Derivde objects, similar to named objects, cannot be deleted.
+
+Only used for primary_fungible_store.
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="object.md#0x1_object_create_user_derived_object">create_user_derived_object</a>(creator_address: <b>address</b>, derive_ref: &<a href="object.md#0x1_object_DeriveRef">object::DeriveRef</a>): <a href="object.md#0x1_object_ConstructorRef">object::ConstructorRef</a>
@@ -1300,7 +1311,7 @@ doesn't have the same bottlenecks.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x1_object_create_object_from_object">create_object_from_object</a>(creator: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>): <a href="object.md#0x1_object_ConstructorRef">ConstructorRef</a> <b>acquires</b> <a href="object.md#0x1_object_ObjectCore">ObjectCore</a> {
+<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x1_object_create_object_from_object">create_object_from_object</a>(creator: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>): <a href="object.md#0x1_object_ConstructorRef">ConstructorRef</a> {
     <b>let</b> <a href="guid.md#0x1_guid">guid</a> = <a href="object.md#0x1_object_create_guid">create_guid</a>(creator);
     <a href="object.md#0x1_object_create_object_from_guid">create_object_from_guid</a>(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(creator), <a href="guid.md#0x1_guid">guid</a>)
 }
@@ -1373,6 +1384,78 @@ doesn't have the same bottlenecks.
         },
     );
     <a href="object.md#0x1_object_ConstructorRef">ConstructorRef</a> { self: <a href="object.md#0x1_object">object</a>, can_delete }
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_object_create_unique_onchain_signer"></a>
+
+## Function `create_unique_onchain_signer`
+
+Create a unique and lightweight onchain signer.
+Returned ExtendRef can be used to create the signer, and can be stored onchain.
+
+It has no object resources (i.e. ObjectCore, etc) - and so is lightweight.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x1_object_create_unique_onchain_signer">create_unique_onchain_signer</a>(): <a href="object.md#0x1_object_ExtendRef">object::ExtendRef</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x1_object_create_unique_onchain_signer">create_unique_onchain_signer</a>(): <a href="object.md#0x1_object_ExtendRef">ExtendRef</a> {
+    // Equivalent <b>to</b> this snippet, without creating and then deleting <a href="object.md#0x1_object_ObjectCore">ObjectCore</a>:
+    // <b>let</b> constructor_ref = <a href="object.md#0x1_object_create_object">object::create_object</a>(@0x0);
+    // <b>let</b> extend_ref = constructor_ref.<a href="object.md#0x1_object_generate_extend_ref">generate_extend_ref</a>();
+    // constructor_ref.<a href="object.md#0x1_object_generate_delete_ref">generate_delete_ref</a>().<a href="object.md#0x1_object_delete">delete</a>();
+
+    <a href="object.md#0x1_object_ExtendRef">ExtendRef</a> { self: <a href="transaction_context.md#0x1_transaction_context_generate_auid_address">transaction_context::generate_auid_address</a>() }
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_object_create_named_unowned_onchain_signer"></a>
+
+## Function `create_named_unowned_onchain_signer`
+
+Creates a named onchain signer and returns ExtendRef to create it.
+The signer is deterministically created form passed creator and name.
+
+ObjectCore is created (and cannot be deleted), to guarantee that the
+same signer cannot be created again.
+Aborts if same creator has already created a signer or object with same name.
+
+Object is unowned (owner is set to 0x0), to avoid being owned by creator,
+which would allow creator to still do thing directly to the object,
+for example withdraw from fungible stores returned signer would own.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x1_object_create_named_unowned_onchain_signer">create_named_unowned_onchain_signer</a>(creator: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, name: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="object.md#0x1_object_ExtendRef">object::ExtendRef</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x1_object_create_named_unowned_onchain_signer">create_named_unowned_onchain_signer</a>(
+    creator: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, name: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
+): <a href="object.md#0x1_object_ExtendRef">ExtendRef</a> {
+    <b>let</b> constructor_ref = <a href="object.md#0x1_object_create_named_object">create_named_object</a>(creator, name);
+    <b>let</b> extend_ref = constructor_ref.<a href="object.md#0x1_object_generate_extend_ref">generate_extend_ref</a>();
+    constructor_ref.<a href="object.md#0x1_object_transfer_with_constructor_ref">transfer_with_constructor_ref</a>(@0x0);
+    extend_ref
 }
 </code></pre>
 
@@ -1582,6 +1665,30 @@ Returns whether or not the ConstructorRef can be used to create DeleteRef
 
 </details>
 
+<a id="0x1_object_transfer_with_constructor_ref"></a>
+
+## Function `transfer_with_constructor_ref`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x1_object_transfer_with_constructor_ref">transfer_with_constructor_ref</a>(self: &<a href="object.md#0x1_object_ConstructorRef">object::ConstructorRef</a>, <b>to</b>: <b>address</b>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x1_object_transfer_with_constructor_ref">transfer_with_constructor_ref</a>(self: &<a href="object.md#0x1_object_ConstructorRef">ConstructorRef</a>, <b>to</b>: <b>address</b>) {
+    self.<a href="object.md#0x1_object_generate_transfer_ref">generate_transfer_ref</a>().<a href="object.md#0x1_object_generate_linear_transfer_ref">generate_linear_transfer_ref</a>().<a href="object.md#0x1_object_transfer_with_ref">transfer_with_ref</a>(<b>to</b>)
+}
+</code></pre>
+
+
+
+</details>
+
 <a id="0x1_object_create_guid"></a>
 
 ## Function `create_guid`
@@ -1598,7 +1705,7 @@ Create a guid for the object, typically used for events
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x1_object_create_guid">create_guid</a>(<a href="object.md#0x1_object">object</a>: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>): <a href="guid.md#0x1_guid_GUID">guid::GUID</a> <b>acquires</b> <a href="object.md#0x1_object_ObjectCore">ObjectCore</a> {
+<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x1_object_create_guid">create_guid</a>(<a href="object.md#0x1_object">object</a>: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>): <a href="guid.md#0x1_guid_GUID">guid::GUID</a> {
     <b>let</b> addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(<a href="object.md#0x1_object">object</a>);
     <b>let</b> object_data = <b>borrow_global_mut</b>&lt;<a href="object.md#0x1_object_ObjectCore">ObjectCore</a>&gt;(addr);
     <a href="guid.md#0x1_guid_create">guid::create</a>(addr, &<b>mut</b> object_data.guid_creation_num)
@@ -1627,7 +1734,7 @@ Generate a new event handle.
 
 <pre><code><b>public</b> <b>fun</b> <a href="object.md#0x1_object_new_event_handle">new_event_handle</a>&lt;T: drop + store&gt;(
     <a href="object.md#0x1_object">object</a>: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
-): <a href="event.md#0x1_event_EventHandle">event::EventHandle</a>&lt;T&gt; <b>acquires</b> <a href="object.md#0x1_object_ObjectCore">ObjectCore</a> {
+): <a href="event.md#0x1_event_EventHandle">event::EventHandle</a>&lt;T&gt; {
     <a href="event.md#0x1_event_new_event_handle">event::new_event_handle</a>(<a href="object.md#0x1_object_create_guid">create_guid</a>(<a href="object.md#0x1_object">object</a>))
 }
 </code></pre>
@@ -1702,7 +1809,7 @@ Removes from the specified Object from global storage.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x1_object_delete">delete</a>(self: <a href="object.md#0x1_object_DeleteRef">DeleteRef</a>) <b>acquires</b> <a href="object.md#0x1_object_Untransferable">Untransferable</a>, <a href="object.md#0x1_object_ObjectCore">ObjectCore</a> {
+<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x1_object_delete">delete</a>(self: <a href="object.md#0x1_object_DeleteRef">DeleteRef</a>) {
     <b>let</b> object_core = <b>move_from</b>&lt;<a href="object.md#0x1_object_ObjectCore">ObjectCore</a>&gt;(self.self);
     <b>let</b> <a href="object.md#0x1_object_ObjectCore">ObjectCore</a> {
         guid_creation_num: _,
@@ -1789,7 +1896,7 @@ Disable direct transfer, transfers can only be triggered via a TransferRef
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x1_object_disable_ungated_transfer">disable_ungated_transfer</a>(self: &<a href="object.md#0x1_object_TransferRef">TransferRef</a>) <b>acquires</b> <a href="object.md#0x1_object_ObjectCore">ObjectCore</a> {
+<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x1_object_disable_ungated_transfer">disable_ungated_transfer</a>(self: &<a href="object.md#0x1_object_TransferRef">TransferRef</a>) {
     <b>let</b> <a href="object.md#0x1_object">object</a> = <b>borrow_global_mut</b>&lt;<a href="object.md#0x1_object_ObjectCore">ObjectCore</a>&gt;(self.self);
     <a href="object.md#0x1_object">object</a>.allow_ungated_transfer = <b>false</b>;
 }
@@ -1815,7 +1922,7 @@ Prevent moving of the object
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x1_object_set_untransferable">set_untransferable</a>(self: &<a href="object.md#0x1_object_ConstructorRef">ConstructorRef</a>) <b>acquires</b> <a href="object.md#0x1_object_ObjectCore">ObjectCore</a> {
+<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x1_object_set_untransferable">set_untransferable</a>(self: &<a href="object.md#0x1_object_ConstructorRef">ConstructorRef</a>) {
     <b>let</b> <a href="object.md#0x1_object">object</a> = <b>borrow_global_mut</b>&lt;<a href="object.md#0x1_object_ObjectCore">ObjectCore</a>&gt;(self.self);
     <a href="object.md#0x1_object">object</a>.allow_ungated_transfer = <b>false</b>;
     <b>let</b> object_signer = self.<a href="object.md#0x1_object_generate_signer">generate_signer</a>();
@@ -1843,7 +1950,7 @@ Enable direct transfer.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x1_object_enable_ungated_transfer">enable_ungated_transfer</a>(self: &<a href="object.md#0x1_object_TransferRef">TransferRef</a>) <b>acquires</b> <a href="object.md#0x1_object_ObjectCore">ObjectCore</a> {
+<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x1_object_enable_ungated_transfer">enable_ungated_transfer</a>(self: &<a href="object.md#0x1_object_TransferRef">TransferRef</a>) {
     <b>assert</b>!(!<b>exists</b>&lt;<a href="object.md#0x1_object_Untransferable">Untransferable</a>&gt;(self.self), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_permission_denied">error::permission_denied</a>(<a href="object.md#0x1_object_EOBJECT_NOT_TRANSFERRABLE">EOBJECT_NOT_TRANSFERRABLE</a>));
     <b>let</b> <a href="object.md#0x1_object">object</a> = <b>borrow_global_mut</b>&lt;<a href="object.md#0x1_object_ObjectCore">ObjectCore</a>&gt;(self.self);
     <a href="object.md#0x1_object">object</a>.allow_ungated_transfer = <b>true</b>;
@@ -1871,7 +1978,7 @@ time of generation is the owner at the time of transferring.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x1_object_generate_linear_transfer_ref">generate_linear_transfer_ref</a>(self: &<a href="object.md#0x1_object_TransferRef">TransferRef</a>): <a href="object.md#0x1_object_LinearTransferRef">LinearTransferRef</a> <b>acquires</b> <a href="object.md#0x1_object_ObjectCore">ObjectCore</a> {
+<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x1_object_generate_linear_transfer_ref">generate_linear_transfer_ref</a>(self: &<a href="object.md#0x1_object_TransferRef">TransferRef</a>): <a href="object.md#0x1_object_LinearTransferRef">LinearTransferRef</a> {
     <b>assert</b>!(!<b>exists</b>&lt;<a href="object.md#0x1_object_Untransferable">Untransferable</a>&gt;(self.self), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_permission_denied">error::permission_denied</a>(<a href="object.md#0x1_object_EOBJECT_NOT_TRANSFERRABLE">EOBJECT_NOT_TRANSFERRABLE</a>));
     <b>let</b> owner = <a href="object.md#0x1_object_Object">Object</a>&lt;<a href="object.md#0x1_object_ObjectCore">ObjectCore</a>&gt; { inner: self.self }.<a href="object.md#0x1_object_owner">owner</a>();
     <a href="object.md#0x1_object_LinearTransferRef">LinearTransferRef</a> {
@@ -1901,7 +2008,7 @@ Transfer to the destination address using a LinearTransferRef.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x1_object_transfer_with_ref">transfer_with_ref</a>(self: <a href="object.md#0x1_object_LinearTransferRef">LinearTransferRef</a>, <b>to</b>: <b>address</b>) <b>acquires</b> <a href="object.md#0x1_object_ObjectCore">ObjectCore</a>, <a href="object.md#0x1_object_TombStone">TombStone</a> {
+<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x1_object_transfer_with_ref">transfer_with_ref</a>(self: <a href="object.md#0x1_object_LinearTransferRef">LinearTransferRef</a>, <b>to</b>: <b>address</b>) {
     <b>assert</b>!(!<b>exists</b>&lt;<a href="object.md#0x1_object_Untransferable">Untransferable</a>&gt;(self.self), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_permission_denied">error::permission_denied</a>(<a href="object.md#0x1_object_EOBJECT_NOT_TRANSFERRABLE">EOBJECT_NOT_TRANSFERRABLE</a>));
 
     // Undo soft burn <b>if</b> present <b>as</b> we don't want the original owner <b>to</b> be able <b>to</b> reclaim by calling unburn later.
@@ -1949,7 +2056,7 @@ Entry function that can be used to transfer, if allow_ungated_transfer is set tr
     owner: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
     <a href="object.md#0x1_object">object</a>: <b>address</b>,
     <b>to</b>: <b>address</b>,
-) <b>acquires</b> <a href="object.md#0x1_object_ObjectCore">ObjectCore</a> {
+) {
     <a href="object.md#0x1_object_transfer_raw">transfer_raw</a>(owner, <a href="object.md#0x1_object">object</a>, <b>to</b>)
 }
 </code></pre>
@@ -1979,7 +2086,7 @@ for Object<T> to the "to" address.
     owner: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
     <a href="object.md#0x1_object">object</a>: <a href="object.md#0x1_object_Object">Object</a>&lt;T&gt;,
     <b>to</b>: <b>address</b>,
-) <b>acquires</b> <a href="object.md#0x1_object_ObjectCore">ObjectCore</a> {
+) {
     <a href="object.md#0x1_object_transfer_raw">transfer_raw</a>(owner, <a href="object.md#0x1_object">object</a>.inner, <b>to</b>)
 }
 </code></pre>
@@ -2011,7 +2118,7 @@ hierarchy.
     owner: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
     <a href="object.md#0x1_object">object</a>: <b>address</b>,
     <b>to</b>: <b>address</b>,
-) <b>acquires</b> <a href="object.md#0x1_object_ObjectCore">ObjectCore</a> {
+) {
     <b>let</b> owner_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(owner);
     <b>assert</b>!(
         <a href="permissioned_signer.md#0x1_permissioned_signer_check_permission_exists">permissioned_signer::check_permission_exists</a>(owner, <a href="object.md#0x1_object_TransferPermission">TransferPermission</a> { <a href="object.md#0x1_object">object</a> }),
@@ -2080,7 +2187,7 @@ Transfer the given object to another object. See <code>transfer</code> for more 
     owner: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
     <a href="object.md#0x1_object">object</a>: <a href="object.md#0x1_object_Object">Object</a>&lt;O&gt;,
     <b>to</b>: <a href="object.md#0x1_object_Object">Object</a>&lt;T&gt;,
-) <b>acquires</b> <a href="object.md#0x1_object_ObjectCore">ObjectCore</a> {
+) {
     <a href="object.md#0x1_object_transfer">transfer</a>(owner, <a href="object.md#0x1_object">object</a>, <b>to</b>.inner)
 }
 </code></pre>
@@ -2107,7 +2214,7 @@ objects may have cyclic dependencies.
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="object.md#0x1_object_verify_ungated_and_descendant">verify_ungated_and_descendant</a>(owner: <b>address</b>, destination: <b>address</b>) <b>acquires</b> <a href="object.md#0x1_object_ObjectCore">ObjectCore</a> {
+<pre><code><b>fun</b> <a href="object.md#0x1_object_verify_ungated_and_descendant">verify_ungated_and_descendant</a>(owner: <b>address</b>, destination: <b>address</b>) {
     <b>let</b> current_address = destination;
     <b>assert</b>!(
         <b>exists</b>&lt;<a href="object.md#0x1_object_ObjectCore">ObjectCore</a>&gt;(current_address),
@@ -2164,7 +2271,7 @@ Please use the test only [<code>object::burn_object_with_transfer</code>] for te
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="object.md#0x1_object_burn">burn</a>&lt;T: key&gt;(owner: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, <a href="object.md#0x1_object">object</a>: <a href="object.md#0x1_object_Object">Object</a>&lt;T&gt;) <b>acquires</b> <a href="object.md#0x1_object_ObjectCore">ObjectCore</a> {
+<pre><code><b>public</b> entry <b>fun</b> <a href="object.md#0x1_object_burn">burn</a>&lt;T: key&gt;(owner: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, <a href="object.md#0x1_object">object</a>: <a href="object.md#0x1_object_Object">Object</a>&lt;T&gt;) {
     <b>let</b> original_owner = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(owner);
     <b>assert</b>!(<a href="object.md#0x1_object_is_owner">is_owner</a>(<a href="object.md#0x1_object">object</a>, original_owner), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_permission_denied">error::permission_denied</a>(<a href="object.md#0x1_object_ENOT_OBJECT_OWNER">ENOT_OBJECT_OWNER</a>));
     <b>let</b> object_addr = <a href="object.md#0x1_object">object</a>.inner;
@@ -2196,7 +2303,7 @@ Allow origin owners to reclaim any objects they previous burnt.
 <pre><code><b>public</b> entry <b>fun</b> <a href="object.md#0x1_object_unburn">unburn</a>&lt;T: key&gt;(
     original_owner: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
     <a href="object.md#0x1_object">object</a>: <a href="object.md#0x1_object_Object">Object</a>&lt;T&gt;,
-) <b>acquires</b> <a href="object.md#0x1_object_TombStone">TombStone</a>, <a href="object.md#0x1_object_ObjectCore">ObjectCore</a> {
+) {
     <b>let</b> object_addr = <a href="object.md#0x1_object">object</a>.inner;
     <b>assert</b>!(<b>exists</b>&lt;<a href="object.md#0x1_object_TombStone">TombStone</a>&gt;(object_addr), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="object.md#0x1_object_EOBJECT_NOT_BURNT">EOBJECT_NOT_BURNT</a>));
     <b>assert</b>!(
@@ -2243,7 +2350,7 @@ Return true if ungated transfer is allowed.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x1_object_ungated_transfer_allowed">ungated_transfer_allowed</a>&lt;T: key&gt;(self: <a href="object.md#0x1_object_Object">Object</a>&lt;T&gt;): bool <b>acquires</b> <a href="object.md#0x1_object_ObjectCore">ObjectCore</a> {
+<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x1_object_ungated_transfer_allowed">ungated_transfer_allowed</a>&lt;T: key&gt;(self: <a href="object.md#0x1_object_Object">Object</a>&lt;T&gt;): bool {
     <b>assert</b>!(
         <b>exists</b>&lt;<a href="object.md#0x1_object_ObjectCore">ObjectCore</a>&gt;(self.inner),
         <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_not_found">error::not_found</a>(<a href="object.md#0x1_object_EOBJECT_DOES_NOT_EXIST">EOBJECT_DOES_NOT_EXIST</a>),
@@ -2273,7 +2380,7 @@ Return the current owner.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x1_object_owner">owner</a>&lt;T: key&gt;(self: <a href="object.md#0x1_object_Object">Object</a>&lt;T&gt;): <b>address</b> <b>acquires</b> <a href="object.md#0x1_object_ObjectCore">ObjectCore</a> {
+<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x1_object_owner">owner</a>&lt;T: key&gt;(self: <a href="object.md#0x1_object_Object">Object</a>&lt;T&gt;): <b>address</b> {
     <b>assert</b>!(
         <b>exists</b>&lt;<a href="object.md#0x1_object_ObjectCore">ObjectCore</a>&gt;(self.inner),
         <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_not_found">error::not_found</a>(<a href="object.md#0x1_object_EOBJECT_DOES_NOT_EXIST">EOBJECT_DOES_NOT_EXIST</a>),
@@ -2305,7 +2412,7 @@ Note: intentionally not using <code>self</code> as first argument, as a.is_owner
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x1_object_is_owner">is_owner</a>&lt;T: key&gt;(<a href="object.md#0x1_object">object</a>: <a href="object.md#0x1_object_Object">Object</a>&lt;T&gt;, owner: <b>address</b>): bool <b>acquires</b> <a href="object.md#0x1_object_ObjectCore">ObjectCore</a> {
+<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x1_object_is_owner">is_owner</a>&lt;T: key&gt;(<a href="object.md#0x1_object">object</a>: <a href="object.md#0x1_object_Object">Object</a>&lt;T&gt;, owner: <b>address</b>): bool {
     <a href="object.md#0x1_object">object</a>.<a href="object.md#0x1_object_owner">owner</a>() == owner
 }
 </code></pre>
@@ -2333,7 +2440,7 @@ Note: intentionally not using <code>self</code> as first argument, as a.owns(b) 
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x1_object_owns">owns</a>&lt;T: key&gt;(<a href="object.md#0x1_object">object</a>: <a href="object.md#0x1_object_Object">Object</a>&lt;T&gt;, owner: <b>address</b>): bool <b>acquires</b> <a href="object.md#0x1_object_ObjectCore">ObjectCore</a> {
+<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x1_object_owns">owns</a>&lt;T: key&gt;(<a href="object.md#0x1_object">object</a>: <a href="object.md#0x1_object_Object">Object</a>&lt;T&gt;, owner: <b>address</b>): bool {
     <b>let</b> current_address = <a href="object.md#0x1_object">object</a>.<a href="object.md#0x1_object_object_address">object_address</a>();
 
     <b>assert</b>!(
@@ -2385,7 +2492,7 @@ to determine the identity of the starting point of ownership.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x1_object_root_owner">root_owner</a>&lt;T: key&gt;(self: <a href="object.md#0x1_object_Object">Object</a>&lt;T&gt;): <b>address</b> <b>acquires</b> <a href="object.md#0x1_object_ObjectCore">ObjectCore</a> {
+<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x1_object_root_owner">root_owner</a>&lt;T: key&gt;(self: <a href="object.md#0x1_object_Object">Object</a>&lt;T&gt;): <b>address</b> {
     <b>let</b> obj_owner = self.<a href="object.md#0x1_object_owner">owner</a>();
     <b>while</b> (<a href="object.md#0x1_object_is_object">is_object</a>(obj_owner)) {
         obj_owner = <a href="object.md#0x1_object_address_to_object">address_to_object</a>&lt;<a href="object.md#0x1_object_ObjectCore">ObjectCore</a>&gt;(obj_owner).<a href="object.md#0x1_object_owner">owner</a>();

--- a/aptos-move/framework/aptos-framework/sources/object.move
+++ b/aptos-move/framework/aptos-framework/sources/object.move
@@ -222,6 +222,8 @@ module aptos_framework::object {
     native fun create_user_derived_object_address_impl(source: address, derive_from: address): address;
 
     /// Derives an object address from the source address and an object: sha3_256([source | object addr | 0xFC]).
+    ///
+    /// Only used for primary_fungible_store.
     public fun create_user_derived_object_address(source: address, derive_from: address): address {
         create_user_derived_object_address_impl(source, derive_from)
     }
@@ -248,6 +250,9 @@ module aptos_framework::object {
 
     /// Create a new named object and return the ConstructorRef. Named objects can be queried globally
     /// by knowing the user generated seed used to create them. Named objects cannot be deleted.
+    ///
+    /// Note that object returned will be owned by creator, and so creator still can do thing directly to the object,
+    /// for example withdraw from fungible stores signer would own.
     public fun create_named_object(creator: &signer, seed: vector<u8>): ConstructorRef {
         let creator_address = signer::address_of(creator);
         let obj_addr = create_object_address(&creator_address, seed);
@@ -256,6 +261,8 @@ module aptos_framework::object {
 
     /// Create a new object whose address is derived based on the creator account address and another object.
     /// Derivde objects, similar to named objects, cannot be deleted.
+    ///
+    /// Only used for primary_fungible_store.
     public(friend) fun create_user_derived_object(creator_address: address, derive_ref: &DeriveRef): ConstructorRef {
         let obj_addr = create_user_derived_object_address(creator_address, derive_ref.self);
         create_object_internal(creator_address, obj_addr, false)
@@ -303,7 +310,7 @@ module aptos_framework::object {
     /// `create_object_from_object` function for the same creator run sequentially.
     /// Therefore, using `create_object` method for creating objects is preferrable as it
     /// doesn't have the same bottlenecks.
-    public fun create_object_from_object(creator: &signer): ConstructorRef acquires ObjectCore {
+    public fun create_object_from_object(creator: &signer): ConstructorRef {
         let guid = create_guid(creator);
         create_object_from_guid(signer::address_of(creator), guid)
     }
@@ -336,6 +343,35 @@ module aptos_framework::object {
             },
         );
         ConstructorRef { self: object, can_delete }
+    }
+
+    // Onchain Signer related constructors:
+
+    /// Create a unique and lightweight onchain signer.
+    /// Returned ExtendRef can be used to create the signer, and can be stored onchain.
+    ///
+    /// It has no object resources (i.e. ObjectCore, etc) - and so is lightweight.
+    public fun create_unique_onchain_signer(): ExtendRef {
+        ExtendRef { self: transaction_context::generate_auid_address() }
+    }
+
+    /// Creates a named onchain signer and returns ExtendRef to create it.
+    /// The signer is deterministically created form passed creator and name.
+    ///
+    /// Aborts if same creator has already created a signer or object with same name.
+    ///
+    /// Use `owned_by_creator` if you want object to be owned by creator.
+    /// Note that if object is owned by creator, then creator still can do thing directly to the object,
+    /// for example withdraw from fungible stores signer would own.
+    public fun create_named_onchain_signer(
+        creator: &signer, name: vector<u8>, owned_by_creator: bool
+    ): ExtendRef {
+        let constructor_ref = create_named_object(creator, name);
+        let extend_ref = constructor_ref.generate_extend_ref();
+        if (!owned_by_creator) {
+            constructor_ref.transfer_with_constructor_ref(extend_ref.self);
+        };
+        extend_ref
     }
 
     // Creation helpers
@@ -382,10 +418,14 @@ module aptos_framework::object {
         self.can_delete
     }
 
+    public fun transfer_with_constructor_ref(self: &ConstructorRef, to: address) {
+        self.generate_transfer_ref().generate_linear_transfer_ref().transfer_with_ref(to)
+    }
+
     // Signer required functions
 
     /// Create a guid for the object, typically used for events
-    public fun create_guid(object: &signer): guid::GUID acquires ObjectCore {
+    public fun create_guid(object: &signer): guid::GUID {
         let addr = signer::address_of(object);
         let object_data = borrow_global_mut<ObjectCore>(addr);
         guid::create(addr, &mut object_data.guid_creation_num)
@@ -394,7 +434,7 @@ module aptos_framework::object {
     /// Generate a new event handle.
     public fun new_event_handle<T: drop + store>(
         object: &signer,
-    ): event::EventHandle<T> acquires ObjectCore {
+    ): event::EventHandle<T> {
         event::new_event_handle(create_guid(object))
     }
 
@@ -411,7 +451,7 @@ module aptos_framework::object {
     }
 
     /// Removes from the specified Object from global storage.
-    public fun delete(self: DeleteRef) acquires Untransferable, ObjectCore {
+    public fun delete(self: DeleteRef) {
         let object_core = move_from<ObjectCore>(self.self);
         let ObjectCore {
             guid_creation_num: _,
@@ -442,13 +482,13 @@ module aptos_framework::object {
     // Transfer functionality
 
     /// Disable direct transfer, transfers can only be triggered via a TransferRef
-    public fun disable_ungated_transfer(self: &TransferRef) acquires ObjectCore {
+    public fun disable_ungated_transfer(self: &TransferRef) {
         let object = borrow_global_mut<ObjectCore>(self.self);
         object.allow_ungated_transfer = false;
     }
 
     /// Prevent moving of the object
-    public fun set_untransferable(self: &ConstructorRef) acquires ObjectCore {
+    public fun set_untransferable(self: &ConstructorRef) {
         let object = borrow_global_mut<ObjectCore>(self.self);
         object.allow_ungated_transfer = false;
         let object_signer = self.generate_signer();
@@ -456,7 +496,7 @@ module aptos_framework::object {
     }
 
     /// Enable direct transfer.
-    public fun enable_ungated_transfer(self: &TransferRef) acquires ObjectCore {
+    public fun enable_ungated_transfer(self: &TransferRef) {
         assert!(!exists<Untransferable>(self.self), error::permission_denied(EOBJECT_NOT_TRANSFERRABLE));
         let object = borrow_global_mut<ObjectCore>(self.self);
         object.allow_ungated_transfer = true;
@@ -464,7 +504,7 @@ module aptos_framework::object {
 
     /// Create a LinearTransferRef for a one-time transfer. This requires that the owner at the
     /// time of generation is the owner at the time of transferring.
-    public fun generate_linear_transfer_ref(self: &TransferRef): LinearTransferRef acquires ObjectCore {
+    public fun generate_linear_transfer_ref(self: &TransferRef): LinearTransferRef {
         assert!(!exists<Untransferable>(self.self), error::permission_denied(EOBJECT_NOT_TRANSFERRABLE));
         let owner = Object<ObjectCore> { inner: self.self }.owner();
         LinearTransferRef {
@@ -474,7 +514,7 @@ module aptos_framework::object {
     }
 
     /// Transfer to the destination address using a LinearTransferRef.
-    public fun transfer_with_ref(self: LinearTransferRef, to: address) acquires ObjectCore, TombStone {
+    public fun transfer_with_ref(self: LinearTransferRef, to: address) {
         assert!(!exists<Untransferable>(self.self), error::permission_denied(EOBJECT_NOT_TRANSFERRABLE));
 
         // Undo soft burn if present as we don't want the original owner to be able to reclaim by calling unburn later.
@@ -502,7 +542,7 @@ module aptos_framework::object {
         owner: &signer,
         object: address,
         to: address,
-    ) acquires ObjectCore {
+    ) {
         transfer_raw(owner, object, to)
     }
 
@@ -512,7 +552,7 @@ module aptos_framework::object {
         owner: &signer,
         object: Object<T>,
         to: address,
-    ) acquires ObjectCore {
+    ) {
         transfer_raw(owner, object.inner, to)
     }
 
@@ -524,7 +564,7 @@ module aptos_framework::object {
         owner: &signer,
         object: address,
         to: address,
-    ) acquires ObjectCore {
+    ) {
         let owner_address = signer::address_of(owner);
         assert!(
             permissioned_signer::check_permission_exists(owner, TransferPermission { object }),
@@ -553,14 +593,14 @@ module aptos_framework::object {
         owner: &signer,
         object: Object<O>,
         to: Object<T>,
-    ) acquires ObjectCore {
+    ) {
         transfer(owner, object, to.inner)
     }
 
     /// This checks that the destination address is eventually owned by the owner and that each
     /// object between the two allows for ungated transfers. Note, this is limited to a depth of 8
     /// objects may have cyclic dependencies.
-    fun verify_ungated_and_descendant(owner: address, destination: address) acquires ObjectCore {
+    fun verify_ungated_and_descendant(owner: address, destination: address) {
         let current_address = destination;
         assert!(
             exists<ObjectCore>(current_address),
@@ -597,7 +637,7 @@ module aptos_framework::object {
     /// This only works for objects directly owned and for simplicity does not apply to indirectly owned objects.
     /// Original owners can reclaim burnt objects any time in the future by calling unburn.
     /// Please use the test only [`object::burn_object_with_transfer`] for testing with previously burned objects.
-    public entry fun burn<T: key>(owner: &signer, object: Object<T>) acquires ObjectCore {
+    public entry fun burn<T: key>(owner: &signer, object: Object<T>) {
         let original_owner = signer::address_of(owner);
         assert!(is_owner(object, original_owner), error::permission_denied(ENOT_OBJECT_OWNER));
         let object_addr = object.inner;
@@ -609,7 +649,7 @@ module aptos_framework::object {
     public entry fun unburn<T: key>(
         original_owner: &signer,
         object: Object<T>,
-    ) acquires TombStone, ObjectCore {
+    ) {
         let object_addr = object.inner;
         assert!(exists<TombStone>(object_addr), error::invalid_argument(EOBJECT_NOT_BURNT));
         assert!(
@@ -636,7 +676,7 @@ module aptos_framework::object {
 
     /// Accessors
     /// Return true if ungated transfer is allowed.
-    public fun ungated_transfer_allowed<T: key>(self: Object<T>): bool acquires ObjectCore {
+    public fun ungated_transfer_allowed<T: key>(self: Object<T>): bool {
         assert!(
             exists<ObjectCore>(self.inner),
             error::not_found(EOBJECT_DOES_NOT_EXIST),
@@ -646,7 +686,7 @@ module aptos_framework::object {
 
     #[view]
     /// Return the current owner.
-    public fun owner<T: key>(self: Object<T>): address acquires ObjectCore {
+    public fun owner<T: key>(self: Object<T>): address {
         assert!(
             exists<ObjectCore>(self.inner),
             error::not_found(EOBJECT_DOES_NOT_EXIST),
@@ -658,7 +698,7 @@ module aptos_framework::object {
     /// Return true if the provided address is the current owner.
     ///
     /// Note: intentionally not using `self` as first argument, as a.is_owner(b) syntax would be ambiguous.
-    public fun is_owner<T: key>(object: Object<T>, owner: address): bool acquires ObjectCore {
+    public fun is_owner<T: key>(object: Object<T>, owner: address): bool {
         object.owner() == owner
     }
 
@@ -666,7 +706,7 @@ module aptos_framework::object {
     /// Return true if the provided address has indirect or direct ownership of the provided object.
     ///
     /// Note: intentionally not using `self` as first argument, as a.owns(b) syntax would be ambiguous.
-    public fun owns<T: key>(object: Object<T>, owner: address): bool acquires ObjectCore {
+    public fun owns<T: key>(object: Object<T>, owner: address): bool {
         let current_address = object.object_address();
 
         assert!(
@@ -698,7 +738,7 @@ module aptos_framework::object {
     #[view]
     /// Returns the root owner of an object. As objects support nested ownership, it can be useful
     /// to determine the identity of the starting point of ownership.
-    public fun root_owner<T: key>(self: Object<T>): address acquires ObjectCore {
+    public fun root_owner<T: key>(self: Object<T>): address {
         let obj_owner = self.owner();
         while (is_object(obj_owner)) {
             obj_owner = address_to_object<ObjectCore>(obj_owner).owner();
@@ -744,7 +784,7 @@ module aptos_framework::object {
     /// Forcefully transfer an unwanted object to BURN_ADDRESS, ignoring whether ungated_transfer is allowed.
     /// This only works for objects directly owned and for simplicity does not apply to indirectly owned objects.
     /// Original owners can reclaim burnt objects any time in the future by calling unburn.
-    public fun burn_object_with_transfer<T: key>(owner: &signer, object: Object<T>) acquires ObjectCore {
+    public fun burn_object_with_transfer<T: key>(owner: &signer, object: Object<T>) {
         let original_owner = signer::address_of(owner);
         assert!(is_owner(object, original_owner), error::permission_denied(ENOT_OBJECT_OWNER));
         let object_addr = object.inner;
@@ -769,7 +809,7 @@ module aptos_framework::object {
     struct Weapon has key {}
 
     #[test_only]
-    public fun create_hero(creator: &signer): (ConstructorRef, Object<Hero>) acquires ObjectCore {
+    public fun create_hero(creator: &signer): (ConstructorRef, Object<Hero>) {
         let hero_constructor_ref = create_named_object(creator, b"hero");
         let hero_signer = hero_constructor_ref.generate_signer();
         let guid_for_equip_events = create_guid(&hero_signer);
@@ -799,7 +839,7 @@ module aptos_framework::object {
         owner: &signer,
         hero: Object<Hero>,
         weapon: Object<Weapon>,
-    ) acquires Hero, ObjectCore {
+    ) {
         transfer_to_object(owner, weapon, hero);
         let hero_obj = borrow_global_mut<Hero>(hero.object_address());
         hero_obj.weapon.fill(weapon);
@@ -814,7 +854,7 @@ module aptos_framework::object {
         owner: &signer,
         hero: Object<Hero>,
         weapon: Object<Weapon>,
-    ) acquires Hero, ObjectCore {
+    ) {
         transfer(owner, weapon, signer::address_of(owner));
         let hero = borrow_global_mut<Hero>(hero.object_address());
         hero.weapon.extract();
@@ -825,7 +865,7 @@ module aptos_framework::object {
     }
 
     #[test(creator = @0x123)]
-    fun test_object(creator: &signer) acquires Hero, ObjectCore {
+    fun test_object(creator: &signer) {
         let (_, hero) = create_hero(creator);
         let (_, weapon) = create_weapon(creator);
 
@@ -838,7 +878,7 @@ module aptos_framework::object {
     }
 
     #[test(creator = @0x123)]
-    fun test_linear_transfer(creator: &signer) acquires ObjectCore, TombStone {
+    fun test_linear_transfer(creator: &signer) {
         let (hero_constructor, hero) = create_hero(creator);
         assert!(hero.root_owner() == @0x123, 0);
 
@@ -852,7 +892,7 @@ module aptos_framework::object {
 
     #[test(creator = @0x123)]
     #[expected_failure(abort_code = 0x50004, location = Self)]
-    fun test_bad_linear_transfer(creator: &signer) acquires ObjectCore, TombStone {
+    fun test_bad_linear_transfer(creator: &signer) {
         let (hero_constructor, hero) = create_hero(creator);
         let transfer_ref = hero_constructor.generate_transfer_ref();
         let linear_transfer_ref_good = transfer_ref.generate_linear_transfer_ref();
@@ -865,7 +905,7 @@ module aptos_framework::object {
 
     #[test(creator = @0x123)]
     #[expected_failure(abort_code = 0x10008, location = Self)]
-    fun test_cannot_unburn_legacy_after_transfer_with_ref(creator: &signer) acquires ObjectCore, TombStone {
+    fun test_cannot_unburn_legacy_after_transfer_with_ref(creator: &signer) {
         let (hero_constructor, hero) = create_hero(creator);
         burn_object_with_transfer(creator, hero);
         let transfer_ref = hero_constructor.generate_transfer_ref();
@@ -875,7 +915,7 @@ module aptos_framework::object {
 
     #[test(creator = @0x123)]
     #[expected_failure(abort_code = 0x10008, location = Self)]
-    fun test_cannot_unburn_after_transfer_with_ref(creator: &signer) acquires ObjectCore, TombStone {
+    fun test_cannot_unburn_after_transfer_with_ref(creator: &signer) {
         let (hero_constructor, hero) = create_hero(creator);
         burn(creator, hero);
         let transfer_ref = hero_constructor.generate_transfer_ref();
@@ -918,7 +958,7 @@ module aptos_framework::object {
     }
 
     #[test(creator = @0x123)]
-    fun test_burn_and_unburn(creator: &signer) acquires ObjectCore, TombStone {
+    fun test_burn_and_unburn(creator: &signer) {
         let (hero_constructor, hero) = create_hero(creator);
         // Freeze the object.
         let transfer_ref = hero_constructor.generate_transfer_ref();
@@ -940,7 +980,7 @@ module aptos_framework::object {
     }
 
     #[test(creator = @0x123)]
-    fun test_burn_and_unburn_old(creator: &signer) acquires ObjectCore, TombStone {
+    fun test_burn_and_unburn_old(creator: &signer) {
         let (hero_constructor, hero) = create_hero(creator);
         // Freeze the object.
         let transfer_ref = hero_constructor.generate_transfer_ref();
@@ -960,7 +1000,7 @@ module aptos_framework::object {
 
     #[test(creator = @0x123)]
     #[expected_failure(abort_code = 0x50004, location = Self)]
-    fun test_burn_indirectly_owned_should_fail(creator: &signer) acquires ObjectCore {
+    fun test_burn_indirectly_owned_should_fail(creator: &signer) {
         let (_, hero) = create_hero(creator);
         let (_, weapon) = create_weapon(creator);
         transfer_to_object(creator, weapon, hero);
@@ -973,7 +1013,7 @@ module aptos_framework::object {
 
     #[test(creator = @0x123)]
     #[expected_failure(abort_code = 0x10008, location = Self)]
-    fun test_unburn_object_not_burnt_should_fail(creator: &signer) acquires ObjectCore, TombStone {
+    fun test_unburn_object_not_burnt_should_fail(creator: &signer) {
         let (_, hero) = create_hero(creator);
         unburn(creator, hero);
     }
@@ -985,7 +1025,7 @@ module aptos_framework::object {
 
     #[test(creator = @0x123)]
     #[expected_failure(abort_code = 131078, location = Self)]
-    fun test_exceeding_maximum_object_nesting_owns_should_fail(creator: &signer) acquires ObjectCore {
+    fun test_exceeding_maximum_object_nesting_owns_should_fail(creator: &signer) {
         let obj1 = create_simple_object(creator, b"1");
         let obj2 = create_simple_object(creator, b"2");
         let obj3 = create_simple_object(creator, b"3");
@@ -1020,7 +1060,7 @@ module aptos_framework::object {
 
     #[test(creator = @0x123)]
     #[expected_failure(abort_code = 131078, location = Self)]
-    fun test_exceeding_maximum_object_nesting_transfer_should_fail(creator: &signer) acquires ObjectCore {
+    fun test_exceeding_maximum_object_nesting_transfer_should_fail(creator: &signer) {
         let obj1 = create_simple_object(creator, b"1");
         let obj2 = create_simple_object(creator, b"2");
         let obj3 = create_simple_object(creator, b"3");
@@ -1046,7 +1086,7 @@ module aptos_framework::object {
 
     #[test(creator = @0x123)]
     #[expected_failure(abort_code = 131078, location = Self)]
-    fun test_cyclic_ownership_transfer_should_fail(creator: &signer) acquires ObjectCore {
+    fun test_cyclic_ownership_transfer_should_fail(creator: &signer) {
         let obj1 = create_simple_object(creator, b"1");
         // This creates a cycle (self-loop) in ownership.
         transfer(creator, obj1, obj1.object_address());
@@ -1056,7 +1096,7 @@ module aptos_framework::object {
 
     #[test(creator = @0x123)]
     #[expected_failure(abort_code = 131078, location = Self)]
-    fun test_cyclic_ownership_owns_should_fail(creator: &signer) acquires ObjectCore {
+    fun test_cyclic_ownership_owns_should_fail(creator: &signer) {
         let obj1 = create_simple_object(creator, b"1");
         // This creates a cycle (self-loop) in ownership.
         transfer(creator, obj1, obj1.object_address());
@@ -1066,7 +1106,7 @@ module aptos_framework::object {
 
     #[test(creator = @0x123)]
     #[expected_failure(abort_code = 327683, location = Self)]
-    fun test_untransferable_direct_ownership_transfer(creator: &signer) acquires ObjectCore {
+    fun test_untransferable_direct_ownership_transfer(creator: &signer) {
         let (hero_constructor_ref, hero) = create_hero(creator);
         hero_constructor_ref.set_untransferable();
         transfer(creator, hero, @0x456);
@@ -1074,7 +1114,7 @@ module aptos_framework::object {
 
     #[test(creator = @0x123)]
     #[expected_failure(abort_code = 327689, location = Self)]
-    fun test_untransferable_direct_ownership_gen_transfer_ref(creator: &signer) acquires ObjectCore {
+    fun test_untransferable_direct_ownership_gen_transfer_ref(creator: &signer) {
         let (hero_constructor_ref, _) = create_hero(creator);
         hero_constructor_ref.set_untransferable();
         hero_constructor_ref.generate_transfer_ref();
@@ -1082,7 +1122,7 @@ module aptos_framework::object {
 
     #[test(creator = @0x123)]
     #[expected_failure(abort_code = 327689, location = Self)]
-    fun test_untransferable_direct_ownership_gen_linear_transfer_ref(creator: &signer) acquires ObjectCore {
+    fun test_untransferable_direct_ownership_gen_linear_transfer_ref(creator: &signer) {
         let (hero_constructor_ref, _) = create_hero(creator);
         let transfer_ref = hero_constructor_ref.generate_transfer_ref();
         hero_constructor_ref.set_untransferable();
@@ -1091,7 +1131,7 @@ module aptos_framework::object {
 
     #[test(creator = @0x123)]
     #[expected_failure(abort_code = 327689, location = Self)]
-    fun test_untransferable_direct_ownership_with_linear_transfer_ref(creator: &signer) acquires ObjectCore, TombStone {
+    fun test_untransferable_direct_ownership_with_linear_transfer_ref(creator: &signer) {
         let (hero_constructor_ref, _) = create_hero(creator);
         let transfer_ref = hero_constructor_ref.generate_transfer_ref();
         let linear_transfer_ref = transfer_ref.generate_linear_transfer_ref();
@@ -1101,7 +1141,7 @@ module aptos_framework::object {
 
     #[test(creator = @0x123)]
     #[expected_failure(abort_code = 327683, location = Self)]
-    fun test_untransferable_indirect_ownership_transfer(creator: &signer) acquires ObjectCore {
+    fun test_untransferable_indirect_ownership_transfer(creator: &signer) {
         let (_, hero) = create_hero(creator);
         let (weapon_constructor_ref, weapon) = create_weapon(creator);
         transfer_to_object(creator, weapon, hero);
@@ -1111,7 +1151,7 @@ module aptos_framework::object {
 
     #[test(creator = @0x123)]
     #[expected_failure(abort_code = 327689, location = Self)]
-    fun test_untransferable_indirect_ownership_gen_transfer_ref(creator: &signer) acquires ObjectCore {
+    fun test_untransferable_indirect_ownership_gen_transfer_ref(creator: &signer) {
         let (_, hero) = create_hero(creator);
         let (weapon_constructor_ref, weapon) = create_weapon(creator);
         transfer_to_object(creator, weapon, hero);
@@ -1121,7 +1161,7 @@ module aptos_framework::object {
 
     #[test(creator = @0x123)]
     #[expected_failure(abort_code = 327689, location = Self)]
-    fun test_untransferable_indirect_ownership_gen_linear_transfer_ref(creator: &signer) acquires ObjectCore {
+    fun test_untransferable_indirect_ownership_gen_linear_transfer_ref(creator: &signer) {
         let (_, hero) = create_hero(creator);
         let (weapon_constructor_ref, weapon) = create_weapon(creator);
         transfer_to_object(creator, weapon, hero);
@@ -1134,7 +1174,7 @@ module aptos_framework::object {
     #[expected_failure(abort_code = 327689, location = Self)]
     fun test_untransferable_indirect_ownership_with_linear_transfer_ref(
         creator: &signer
-    ) acquires ObjectCore, TombStone {
+    ) {
         let (_, hero) = create_hero(creator);
         let (weapon_constructor_ref, weapon) = create_weapon(creator);
         transfer_to_object(creator, weapon, hero);
@@ -1150,7 +1190,7 @@ module aptos_framework::object {
     #[test(creator = @0x123)]
     fun test_transfer_permission_e2e(
         creator: &signer,
-    ) acquires ObjectCore {
+    ) {
         let aptos_framework = account::create_signer_for_test(@0x1);
         timestamp::set_time_has_started_for_testing(&aptos_framework);
 
@@ -1172,7 +1212,7 @@ module aptos_framework::object {
     #[expected_failure(abort_code = 327689, location = Self)]
     fun test_transfer_no_permission(
         creator: &signer,
-    ) acquires ObjectCore {
+    ) {
         let aptos_framework = account::create_signer_for_test(@0x1);
         timestamp::set_time_has_started_for_testing(&aptos_framework);
 
@@ -1191,7 +1231,7 @@ module aptos_framework::object {
     #[test(creator = @0x123)]
     fun test_create_and_transfer(
         creator: &signer,
-    ) acquires ObjectCore {
+    ) {
         let aptos_framework = account::create_signer_for_test(@0x1);
         timestamp::set_time_has_started_for_testing(&aptos_framework);
 
@@ -1207,5 +1247,64 @@ module aptos_framework::object {
         transfer_to_object(&creator_permission_signer, weapon, hero);
 
         permissioned_signer::destroy_permissioned_handle(creator_permission_handle);
+    }
+
+    #[test_only]
+    struct TestOnchainSigner has key {
+        extend_ref: ExtendRef,
+    }
+
+    #[test(framework = @0x1)]
+    fun test_unique_onchain_signer(
+        framework: &signer,
+    ) {
+        timestamp::set_time_has_started_for_testing(framework);
+
+        let onchain_signer_address = {
+            let extend_ref = create_unique_onchain_signer();
+            let address = extend_ref.address_from_extend_ref();
+            move_to(&extend_ref.generate_signer_for_extending(), TestOnchainSigner { extend_ref });
+            address
+        };
+
+        {
+            let onchain_signer = TestOnchainSigner[onchain_signer_address].extend_ref.generate_signer_for_extending();
+            move_to(&onchain_signer, Weapon {});
+        };
+
+        // unique onchain signer should not be an object
+        assert!(!is_object(onchain_signer_address));
+    }
+
+    #[test(creator = @0x12345)]
+    fun test_named_onchain_signer(
+        creator: &signer,
+    ) {
+        let onchain_signer_address = {
+            let extend_ref = create_named_onchain_signer(creator, b"onchain_signer", false);
+            let address = extend_ref.address_from_extend_ref();
+            move_to(&extend_ref.generate_signer_for_extending(), TestOnchainSigner { extend_ref });
+            address
+        };
+
+        // named onchain signer should be an object
+        assert!(is_object(onchain_signer_address));
+        // not owned by creator
+        assert!(!address_to_object<TestOnchainSigner>(onchain_signer_address).owns(signer::address_of(creator)));
+
+        {
+            let onchain_signer = TestOnchainSigner[onchain_signer_address].extend_ref.generate_signer_for_extending();
+            move_to(&onchain_signer, Weapon {});
+        };
+    }
+
+    #[test(creator = @0x12345)]
+    #[expected_failure(abort_code = 524289, location = Self)]
+    fun test_named_onchain_signer_duplicate(
+        creator: &signer,
+    ) {
+        create_named_onchain_signer(creator, b"onchain_signer", false);
+        // second time fails
+        create_named_onchain_signer(creator, b"onchain_signer", false);
     }
 }

--- a/aptos-move/framework/aptos-framework/sources/object.move
+++ b/aptos-move/framework/aptos-framework/sources/object.move
@@ -352,25 +352,30 @@ module aptos_framework::object {
     ///
     /// It has no object resources (i.e. ObjectCore, etc) - and so is lightweight.
     public fun create_unique_onchain_signer(): ExtendRef {
+        // Equivalent to this snippet, without creating and then deleting ObjectCore:
+        // let constructor_ref = object::create_object(@0x0);
+        // let extend_ref = constructor_ref.generate_extend_ref();
+        // constructor_ref.generate_delete_ref().delete();
+
         ExtendRef { self: transaction_context::generate_auid_address() }
     }
 
     /// Creates a named onchain signer and returns ExtendRef to create it.
     /// The signer is deterministically created form passed creator and name.
     ///
+    /// ObjectCore is created (and cannot be deleted), to guarantee that the
+    /// same signer cannot be created again.
     /// Aborts if same creator has already created a signer or object with same name.
     ///
-    /// Use `owned_by_creator` if you want object to be owned by creator.
-    /// Note that if object is owned by creator, then creator still can do thing directly to the object,
-    /// for example withdraw from fungible stores signer would own.
-    public fun create_named_onchain_signer(
-        creator: &signer, name: vector<u8>, owned_by_creator: bool
+    /// Object is unowned (owner is set to 0x0), to avoid being owned by creator,
+    /// which would allow creator to still do thing directly to the object,
+    /// for example withdraw from fungible stores returned signer would own.
+    public fun create_named_unowned_onchain_signer(
+        creator: &signer, name: vector<u8>
     ): ExtendRef {
         let constructor_ref = create_named_object(creator, name);
         let extend_ref = constructor_ref.generate_extend_ref();
-        if (!owned_by_creator) {
-            constructor_ref.transfer_with_constructor_ref(extend_ref.self);
-        };
+        constructor_ref.transfer_with_constructor_ref(@0x0);
         extend_ref
     }
 
@@ -1281,7 +1286,7 @@ module aptos_framework::object {
         creator: &signer,
     ) {
         let onchain_signer_address = {
-            let extend_ref = create_named_onchain_signer(creator, b"onchain_signer", false);
+            let extend_ref = create_named_unowned_onchain_signer(creator, b"onchain_signer");
             let address = extend_ref.address_from_extend_ref();
             move_to(&extend_ref.generate_signer_for_extending(), TestOnchainSigner { extend_ref });
             address
@@ -1290,7 +1295,7 @@ module aptos_framework::object {
         // named onchain signer should be an object
         assert!(is_object(onchain_signer_address));
         // not owned by creator
-        assert!(!address_to_object<TestOnchainSigner>(onchain_signer_address).owns(signer::address_of(creator)));
+        assert!(!owns(address_to_object<TestOnchainSigner>(onchain_signer_address), signer::address_of(creator)));
 
         {
             let onchain_signer = TestOnchainSigner[onchain_signer_address].extend_ref.generate_signer_for_extending();
@@ -1303,8 +1308,8 @@ module aptos_framework::object {
     fun test_named_onchain_signer_duplicate(
         creator: &signer,
     ) {
-        create_named_onchain_signer(creator, b"onchain_signer", false);
+        create_named_unowned_onchain_signer(creator, b"onchain_signer");
         // second time fails
-        create_named_onchain_signer(creator, b"onchain_signer", false);
+        create_named_unowned_onchain_signer(creator, b"onchain_signer");
     }
 }


### PR DESCRIPTION
## Description
Add a few utility methods to more easily manage onchain signers, when that's all user want's from an "object"

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the core `aptos_framework::object` module and adds new public constructors that affect address derivation and ownership semantics; mistakes could lead to unexpected signer/object ownership or duplicated-name edge cases.
> 
> **Overview**
> Adds new `object` utilities to create onchain signers without requiring a full object lifecycle: `create_unique_onchain_signer()` returns an `ExtendRef` backed by a fresh AUID address with **no `ObjectCore` stored**, and `create_named_unowned_onchain_signer()` deterministically creates a named object then immediately transfers ownership to `@0x0` to prevent the creator from retaining direct control.
> 
> Introduces `transfer_with_constructor_ref()` as a convenience helper, updates docs/comments (including clarifying `create_named_object` ownership and `create_user_derived_object*` intended usage), and adds framework tests covering the new signer flows and duplicate-name failure behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0299c5569233819452e8844faf9dd55a25d59cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->