### PR TITLE
[storage] Use HashValue for LRU linked-list pointers in hot state

### DIFF
--- a/storage/aptosdb/src/state_store/hot_state.rs
+++ b/storage/aptosdb/src/state_store/hot_state.rs
@@ -24,6 +24,7 @@ use dashmap::{mapref::one::Ref, DashMap};
 #[cfg(test)]
 use std::collections::BTreeMap;
 use std::{
+    collections::HashMap,
     sync::{
         atomic::{AtomicU64, Ordering},
         mpsc::{Receiver, RecvTimeoutError, Sender, SyncSender},
@@ -80,25 +81,22 @@ where
 }
 
 #[derive(Debug)]
-struct HotStateBase<K = HashValue, V = StateSlot>
-where
-    K: Eq + std::hash::Hash,
-{
-    shards: [Shard<K, V>; NUM_STATE_SHARDS],
+struct HotStateBase {
+    shards: [Shard<HashValue, (StateKey, StateSlot)>; NUM_STATE_SHARDS],
 }
 
-impl<K, V> HotStateBase<K, V>
-where
-    K: Clone + Eq + std::hash::Hash,
-    V: Clone,
-{
+impl HotStateBase {
     fn new_empty(max_items_per_shard: usize) -> Self {
         Self {
             shards: arr![Shard::new(max_items_per_shard); 16],
         }
     }
 
-    fn get_from_shard(&self, shard_id: usize, key: &K) -> Option<Ref<'_, K, V>> {
+    fn get_from_shard(
+        &self,
+        shard_id: usize,
+        key: &HashValue,
+    ) -> Option<Ref<'_, HashValue, (StateKey, StateSlot)>> {
         self.shards[shard_id].get(key)
     }
 
@@ -112,25 +110,66 @@ where
 /// state. This enables RCU semantics: the new committed state is published immediately via the
 /// delta overlay, while DashMap mutations are deferred until all old readers are gone.
 struct LayeredHotStateView {
-    /// If `Some`, overlay these changes on top of base. If `None`, base is up-to-date.
-    delta: Option<StateDelta>,
+    /// Hash index built from the RCU delta (`merged_state → committed.state`), if present.
+    /// Enables both StateKey-based and hash-based lookups without the original `StateDelta`.
+    delta_index: Option<Box<[HashMap<HashValue, (StateKey, StateSlot)>; NUM_STATE_SHARDS]>>,
     base: Arc<HotStateBase>,
+}
+
+impl LayeredHotStateView {
+    fn new(delta: Option<StateDelta>, base: Arc<HotStateBase>) -> Self {
+        let delta_index = delta.map(|d| {
+            Box::new(std::array::from_fn(|shard_id| {
+                d.shards[shard_id]
+                    .iter()
+                    .map(|(key, slot)| (*key.crypto_hash_ref(), (key, slot)))
+                    .collect()
+            }))
+        });
+        Self { delta_index, base }
+    }
 }
 
 impl HotStateView for LayeredHotStateView {
     fn get_state_slot(&self, state_key: &StateKey) -> Option<StateSlot> {
-        if let Some(delta) = &self.delta {
-            if let Some(slot) = delta.get_state_slot(state_key) {
+        if let Some(index) = &self.delta_index {
+            let shard_id = state_key.get_shard_id();
+            if let Some((_, slot)) = index[shard_id].get(state_key.crypto_hash_ref()) {
                 // Delta says this key changed. If hot, return it. If cold/evicted, return None —
                 // do NOT fall through to base, the key was explicitly evicted in committed state.
-                return if slot.is_hot() { Some(slot) } else { None };
+                return if slot.is_hot() {
+                    Some(slot.clone())
+                } else {
+                    None
+                };
             }
         }
         // Key not in delta (unchanged) — read from base DashMap.
         let shard_id = state_key.get_shard_id();
         self.base
             .get_from_shard(shard_id, state_key.crypto_hash_ref())
-            .map(|v| v.clone())
+            .map(|entry| entry.value().1.clone())
+    }
+
+    fn get_state_entry_by_hash(
+        &self,
+        shard_id: usize,
+        key_hash: &HashValue,
+    ) -> Option<(StateKey, StateSlot)> {
+        if let Some(index) = &self.delta_index {
+            if let Some((key, slot)) = index[shard_id].get(key_hash) {
+                // Delta has this key. Return it only if hot; cold means evicted — do NOT fall
+                // through to the base DashMap which may still have the stale hot entry.
+                return if slot.is_hot() {
+                    Some((key.clone(), slot.clone()))
+                } else {
+                    None
+                };
+            }
+        }
+        self.base
+            .get_from_shard(shard_id, key_hash)
+            .map(|entry| entry.value().clone())
     }
 }
 
@@ -163,10 +202,7 @@ pub struct HotState {
 impl HotState {
     pub fn new(state: State, config: HotStateConfig) -> Self {
         let base = Arc::new(HotStateBase::new_empty(config.max_items_per_shard));
-        let view = Arc::new(LayeredHotStateView {
-            delta: None,
-            base: Arc::clone(&base),
-        });
+        let view = Arc::new(LayeredHotStateView::new(None, Arc::clone(&base)));
         let committed = Arc::new(Mutex::new(CommittedSnapshot {
             state: state.clone(),
             view,
@@ -194,10 +230,7 @@ impl HotState {
             committed.state = state.clone();
             // Reset view to base-only (no delta). hack_reset is only called when no commits are in
             // flight, so DashMaps and committed state are in sync from the readers' perspective.
-            committed.view = Arc::new(LayeredHotStateView {
-                delta: None,
-                base: Arc::clone(&self.base),
-            });
+            committed.view = Arc::new(LayeredHotStateView::new(None, Arc::clone(&self.base)));
         }
         // Synchronously reset the Committer's merged_state and old_views. Block until processed,
         // so the caller has a hard guarantee that no stale Committer state remains.
@@ -235,7 +268,7 @@ impl HotState {
     }
 
     #[cfg(test)]
-    pub fn get_all_entries(&self, shard_id: usize) -> BTreeMap<HashValue, StateSlot> {
+    pub fn get_all_entries(&self, shard_id: usize) -> BTreeMap<HashValue, (StateKey, StateSlot)> {
         self.base.shards[shard_id].iter().collect()
     }
 }
@@ -366,10 +399,10 @@ impl Committer {
 
             // Build a layered view: delta(merged_state -> to_commit) over base DashMaps.
             let delta = to_commit.make_delta(&self.merged_state);
-            let new_view = Arc::new(LayeredHotStateView {
-                delta: Some(delta),
-                base: Arc::clone(&self.base),
-            });
+            let new_view = Arc::new(LayeredHotStateView::new(
+                Some(delta),
+                Arc::clone(&self.base),
+            ));
 
             // Atomically publish new view + state; track the old view for deferred merge.
             {
@@ -484,10 +517,7 @@ impl Committer {
 
         // Publish a clean (delta-free) view so future readers hit the DashMaps directly without
         // the overhead of a delta lookup, now that the DashMaps are up to date.
-        let clean_view = Arc::new(LayeredHotStateView {
-            delta: None,
-            base: Arc::clone(&self.base),
-        });
+        let clean_view = Arc::new(LayeredHotStateView::new(None, Arc::clone(&self.base)));
         Self::swap_view(&mut self.old_views, &mut self.committed.lock(), clean_view);
         self.update_deferred_merge_gauges(self.merged_state.next_version());
 
@@ -520,25 +550,21 @@ impl Committer {
                 if slot.is_hot() {
                     self.total_key_bytes += HashValue::LENGTH;
                     self.total_value_bytes += slot.size();
-                    if let Some(old_slot) = self.base.shards[shard_id].insert(key_hash, slot) {
+                    if let Some(old) = self.base.shards[shard_id].insert(key_hash, (key, slot)) {
                         self.total_key_bytes -= HashValue::LENGTH;
-                        self.total_value_bytes -= old_slot.size();
+                        self.total_value_bytes -= old.1.size();
                         n_update += 1;
                     } else {
                         n_insert += 1;
                     }
-                } else if let Some((_, old_slot)) = self.base.shards[shard_id].remove(&key_hash) {
+                } else if let Some((_, old)) = self.base.shards[shard_id].remove(&key_hash) {
                     self.total_key_bytes -= HashValue::LENGTH;
-                    self.total_value_bytes -= old_slot.size();
+                    self.total_value_bytes -= old.1.size();
                     n_evict += 1;
                 }
             }
-            self.heads[shard_id] = target
-                .latest_hot_key(shard_id)
-                .map(|k| *k.crypto_hash_ref());
-            self.tails[shard_id] = target
-                .oldest_hot_key(shard_id)
-                .map(|k| *k.crypto_hash_ref());
+            self.heads[shard_id] = target.latest_hot_key(shard_id);
+            self.tails[shard_id] = target.oldest_hot_key(shard_id);
             assert_eq!(
                 self.base.shards[shard_id].len(),
                 target.num_hot_items(shard_id)
@@ -567,12 +593,16 @@ impl Committer {
                 self.base.shards[shard_id]
                     .get(k)
                     .expect("head must exist in base")
+                    .value()
+                    .1
                     .expect_hot_since_version()
             });
             let lru_version = self.tails[shard_id].as_ref().map(|k| {
                 self.base.shards[shard_id]
                     .get(k)
                     .expect("tail must exist in base")
+                    .value()
+                    .1
                     .expect_hot_since_version()
             });
 
@@ -608,10 +638,11 @@ impl Committer {
             let mut current = *head;
             while let Some(key_hash) = current {
                 let entry = shard.get(&key_hash).expect("Must exist.");
+                let (_, slot) = entry.value();
                 num_visited += 1;
                 ensure!(num_visited <= shard.len());
-                ensure!(entry.is_hot());
-                current = entry.next().map(|k| *k.crypto_hash_ref());
+                ensure!(slot.is_hot());
+                current = slot.next().copied();
             }
             ensure!(num_visited == shard.len());
         }
@@ -621,10 +652,11 @@ impl Committer {
             let mut current = *tail;
             while let Some(key_hash) = current {
                 let entry = shard.get(&key_hash).expect("Must exist.");
+                let (_, slot) = entry.value();
                 num_visited += 1;
                 ensure!(num_visited <= shard.len());
-                ensure!(entry.is_hot());
-                current = entry.prev().map(|k| *k.crypto_hash_ref());
+                ensure!(slot.is_hot());
+                current = slot.prev().copied();
             }
             ensure!(num_visited == shard.len());
         }
@@ -720,12 +752,9 @@ mod tests {
         let key = StateKey::raw(b"key_a");
         let shard_id = key.get_shard_id();
         let slot = make_hot_slot(1, b"value_a");
-        base.shards[shard_id].insert(*key.crypto_hash_ref(), slot.clone());
+        base.shards[shard_id].insert(*key.crypto_hash_ref(), (key.clone(), slot.clone()));
 
-        let view = LayeredHotStateView {
-            delta: None,
-            base: Arc::clone(&base),
-        };
+        let view = LayeredHotStateView::new(None, Arc::clone(&base));
 
         // Key in base -> returns base value.
         let result = view.get_state_slot(&key);
@@ -747,20 +776,27 @@ mod tests {
         // key_base_only: in base DashMap, NOT in delta.
         let key_base_only = StateKey::raw(b"base_only");
         let slot_base = make_hot_slot(1, b"base_value");
-        base.shards[key_base_only.get_shard_id()]
-            .insert(*key_base_only.crypto_hash_ref(), slot_base.clone());
+        base.shards[key_base_only.get_shard_id()].insert(
+            *key_base_only.crypto_hash_ref(),
+            (key_base_only.clone(), slot_base.clone()),
+        );
 
         // key_updated: in base DashMap AND in delta (hot) -> delta wins.
         let key_updated = StateKey::raw(b"updated");
         let slot_old = make_hot_slot(1, b"old_value");
         let slot_new = make_hot_slot(2, b"new_value");
-        base.shards[key_updated.get_shard_id()].insert(*key_updated.crypto_hash_ref(), slot_old);
+        base.shards[key_updated.get_shard_id()].insert(
+            *key_updated.crypto_hash_ref(),
+            (key_updated.clone(), slot_old),
+        );
 
         // key_evicted: in base DashMap AND in delta (cold) -> returns None.
         let key_evicted = StateKey::raw(b"evicted");
         let slot_was_hot = make_hot_slot(1, b"was_hot");
-        base.shards[key_evicted.get_shard_id()]
-            .insert(*key_evicted.crypto_hash_ref(), slot_was_hot);
+        base.shards[key_evicted.get_shard_id()].insert(
+            *key_evicted.crypto_hash_ref(),
+            (key_evicted.clone(), slot_was_hot),
+        );
 
         // key_new: NOT in base, in delta (hot) -> returns delta value.
         let key_new = StateKey::raw(b"new_key");
@@ -775,10 +811,7 @@ mod tests {
             (key_new.clone(), slot_new_key.clone()),
         ]);
 
-        let view = LayeredHotStateView {
-            delta: Some(delta),
-            base,
-        };
+        let view = LayeredHotStateView::new(Some(delta), base);
 
         // Key only in base -> falls through to base.
         let result = view.get_state_slot(&key_base_only);
@@ -819,10 +852,7 @@ mod tests {
         let slot = make_hot_vacant(5);
 
         let delta = make_test_delta(&[(key.clone(), slot)]);
-        let view = LayeredHotStateView {
-            delta: Some(delta),
-            base,
-        };
+        let view = LayeredHotStateView::new(Some(delta), base);
 
         let result = view.get_state_slot(&key);
         assert!(result.is_some());

--- a/storage/aptosdb/src/state_store/tests/speculative_state_workflow.rs
+++ b/storage/aptosdb/src/state_store/tests/speculative_state_workflow.rs
@@ -674,7 +674,7 @@ fn commit_state_buffer(
             assert_eq!(all_entries.len(), naive_hot_state.len());
 
             for (key, slot) in naive_hot_state.iter() {
-                let slot2 = all_entries.get(key.crypto_hash_ref()).unwrap();
+                let (_, slot2) = all_entries.get(key.crypto_hash_ref()).unwrap();
                 StateByVersion::assert_state_slot(slot, slot2);
             }
         });

--- a/storage/storage-interface/src/state_store/hot_state.rs
+++ b/storage/storage-interface/src/state_store/hot_state.rs
@@ -2,6 +2,7 @@
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::state_store::state_view::hot_state_view::HotStateView;
+use aptos_crypto::HashValue;
 use aptos_experimental_layered_map::LayeredMap;
 use aptos_types::state_store::{
     hot_state::THotStateSlot, state_key::StateKey, state_slot::StateSlot,
@@ -16,12 +17,15 @@ pub(crate) struct HotStateLRU<'a> {
     committed: Arc<dyn HotStateView>,
     /// Additional entries resulted from previous speculative execution.
     overlay: &'a LayeredMap<StateKey, StateSlot>,
-    /// The new entries from current execution.
-    pending: HashMap<StateKey, StateSlot>,
+    /// Hash index of hot entries from the overlay, for hash-based pointer following.
+    overlay_index: HashMap<HashValue, (StateKey, StateSlot)>,
+    /// The new entries from current execution, indexed by key hash. Retains the `StateKey`
+    /// for output (feeding back into the `LayeredMap` overlay).
+    pending: HashMap<HashValue, (StateKey, StateSlot)>,
     /// Points to the latest entry. `None` if empty.
-    head: Option<StateKey>,
+    head: Option<HashValue>,
     /// Points to the oldest entry. `None` if empty.
-    tail: Option<StateKey>,
+    tail: Option<HashValue>,
     /// Total number of items.
     num_items: usize,
 }
@@ -31,14 +35,23 @@ impl<'a> HotStateLRU<'a> {
         capacity: NonZeroUsize,
         committed: Arc<dyn HotStateView>,
         overlay: &'a LayeredMap<StateKey, StateSlot>,
-        head: Option<StateKey>,
-        tail: Option<StateKey>,
+        head: Option<HashValue>,
+        tail: Option<HashValue>,
         num_items: usize,
     ) -> Self {
+        // Build hash index from the overlay so we can look up entries by hash. This must include
+        // cold entries too: a cold overlay entry (evicted key) must shadow a stale hot entry in
+        // the committed view to prevent `delete` from unlinking an already-evicted entry.
+        let overlay_index = overlay
+            .iter()
+            .map(|(key, slot)| (*key.crypto_hash_ref(), (key, slot)))
+            .collect();
+
         Self {
             capacity,
             committed,
             overlay,
+            overlay_index,
             pending: HashMap::new(),
             head,
             tail,
@@ -51,37 +64,39 @@ impl<'a> HotStateLRU<'a> {
             slot.is_hot(),
             "Should not insert cold slots into hot state."
         );
-        if self.delete(&key).is_none() {
+        let key_hash = *key.crypto_hash_ref();
+        if self.delete(key_hash).is_none() {
             self.num_items += 1;
         }
-        self.insert_as_head(key, slot);
+        self.insert_as_head(key, key_hash, slot);
     }
 
-    fn insert_as_head(&mut self, key: StateKey, mut slot: StateSlot) {
+    fn insert_as_head(&mut self, key: StateKey, key_hash: HashValue, mut slot: StateSlot) {
         match self.head.take() {
-            Some(head) => {
-                let mut old_head_slot = self.expect_hot_slot(&head);
-                old_head_slot.set_prev(Some(key.clone()));
+            Some(old_head_hash) => {
+                let (old_head_key, mut old_head_slot) = self.expect_hot_entry(old_head_hash);
+                old_head_slot.set_prev(Some(key_hash));
                 slot.set_prev(None);
-                slot.set_next(Some(head.clone()));
-                self.pending.insert(head, old_head_slot);
-                self.pending.insert(key.clone(), slot);
-                self.head = Some(key);
+                slot.set_next(Some(old_head_hash));
+                self.pending
+                    .insert(old_head_hash, (old_head_key, old_head_slot));
+                self.pending.insert(key_hash, (key, slot));
+                self.head = Some(key_hash);
             },
             None => {
                 slot.set_prev(None);
                 slot.set_next(None);
-                self.pending.insert(key.clone(), slot);
-                self.head = Some(key.clone());
-                self.tail = Some(key);
+                self.pending.insert(key_hash, (key, slot));
+                self.head = Some(key_hash);
+                self.tail = Some(key_hash);
             },
         }
     }
 
     /// Returns the list of entries evicted, beginning from the LRU.
     pub fn maybe_evict(&mut self) -> Vec<(StateKey, StateSlot)> {
-        let mut current = match &self.tail {
-            Some(tail) => tail.clone(),
+        let mut current = match self.tail {
+            Some(tail) => tail,
             None => {
                 assert_eq!(self.num_items, 0);
                 return Vec::new();
@@ -90,60 +105,64 @@ impl<'a> HotStateLRU<'a> {
 
         let mut evicted = Vec::new();
         while self.num_items > self.capacity.get() {
-            let slot = self
-                .delete(&current)
+            let (key, slot) = self
+                .delete(current)
                 .expect("There must be entries to evict when current size is above capacity.");
-            let prev_key = slot
+            let prev_hash = slot
                 .prev()
-                .cloned()
+                .copied()
                 .expect("There must be at least one newer entry (num_items > capacity >= 1).");
-            evicted.push((current.clone(), slot.clone()));
-            self.pending.insert(current, slot.to_cold());
-            current = prev_key;
+            evicted.push((key.clone(), slot.clone()));
+            self.pending.insert(current, (key, slot.to_cold()));
+            current = prev_hash;
             self.num_items -= 1;
         }
         evicted
     }
 
-    /// Returns the deleted slot, or `None` if the key doesn't exist or is not hot.
-    fn delete(&mut self, key: &StateKey) -> Option<StateSlot> {
-        // Fetch the slot corresponding to the given key. Note that `self.pending` and
-        // `self.overlay` may contain cold slots, like the ones recently evicted, and we need to
-        // ignore them.
-        let old_slot = match self.get_slot(key) {
-            Some(slot) if slot.is_hot() => slot,
+    /// Returns the deleted (key, slot) pair, or `None` if the key doesn't exist or is not hot.
+    fn delete(&mut self, key_hash: HashValue) -> Option<(StateKey, StateSlot)> {
+        // Fetch the slot corresponding to the given key hash. Note that `self.pending` and
+        // `self.overlay_index` may contain cold slots, like the ones recently evicted, and we
+        // need to ignore them.
+        let (key, old_slot) = match self.get_entry_by_hash(key_hash) {
+            Some((key, slot)) if slot.is_hot() => (key, slot),
             _ => return None,
         };
 
         match old_slot.prev() {
-            Some(prev_key) => {
-                let mut prev_slot = self.expect_hot_slot(prev_key);
-                prev_slot.set_next(old_slot.next().cloned());
-                self.pending.insert(prev_key.clone(), prev_slot);
+            Some(&prev_hash) => {
+                let (prev_key, mut prev_slot) = self.expect_hot_entry(prev_hash);
+                prev_slot.set_next(old_slot.next().copied());
+                self.pending.insert(prev_hash, (prev_key, prev_slot));
             },
             None => {
                 // There is no newer entry. The current key was the head.
-                self.head = old_slot.next().cloned();
+                self.head = old_slot.next().copied();
             },
         }
 
         match old_slot.next() {
-            Some(next_key) => {
-                let mut next_slot = self.expect_hot_slot(next_key);
-                next_slot.set_prev(old_slot.prev().cloned());
-                self.pending.insert(next_key.clone(), next_slot);
+            Some(&next_hash) => {
+                let (next_key, mut next_slot) = self.expect_hot_entry(next_hash);
+                next_slot.set_prev(old_slot.prev().copied());
+                self.pending.insert(next_hash, (next_key, next_slot));
             },
             None => {
                 // There is no older entry. The current key was the tail.
-                self.tail = old_slot.prev().cloned();
+                self.tail = old_slot.prev().copied();
             },
         }
 
-        Some(old_slot)
+        Some((key, old_slot))
     }
 
+    /// Look up a slot by `StateKey`. Used by callers that have the full key (e.g.
+    /// `State::apply_one_update`).
     pub(crate) fn get_slot(&self, key: &StateKey) -> Option<StateSlot> {
-        if let Some(slot) = self.pending.get(key) {
+        let key_hash = key.crypto_hash_ref();
+
+        if let Some((_, slot)) = self.pending.get(key_hash) {
             return Some(slot.clone());
         }
 
@@ -154,49 +173,66 @@ impl<'a> HotStateLRU<'a> {
         self.committed.get_state_slot(key)
     }
 
-    fn expect_hot_slot(&self, key: &StateKey) -> StateSlot {
-        let slot = self.get_slot(key).expect("Given key is expected to exist.");
+    /// Look up an entry by hash. Used internally for LRU pointer following.
+    fn get_entry_by_hash(&self, key_hash: HashValue) -> Option<(StateKey, StateSlot)> {
+        if let Some((key, slot)) = self.pending.get(&key_hash) {
+            return Some((key.clone(), slot.clone()));
+        }
+
+        if let Some((key, slot)) = self.overlay_index.get(&key_hash) {
+            return Some((key.clone(), slot.clone()));
+        }
+
+        let shard_id = usize::from(key_hash.nibble(0));
+        self.committed.get_state_entry_by_hash(shard_id, &key_hash)
+    }
+
+    fn expect_hot_entry(&self, key_hash: HashValue) -> (StateKey, StateSlot) {
+        let (key, slot) = self
+            .get_entry_by_hash(key_hash)
+            .expect("Given key is expected to exist.");
         assert!(slot.is_hot(), "Given key is expected to be hot.");
-        slot
+        (key, slot)
     }
 
     pub fn into_updates(
         self,
     ) -> (
         HashMap<StateKey, StateSlot>,
-        Option<StateKey>,
-        Option<StateKey>,
+        Option<HashValue>,
+        Option<HashValue>,
         usize,
     ) {
-        (self.pending, self.head, self.tail, self.num_items)
+        let pending = self.pending.into_values().collect();
+        (pending, self.head, self.tail, self.num_items)
     }
 
     #[cfg(test)]
     fn iter(&self) -> Iter<'_, '_> {
         Iter {
-            current_key: self.head.clone(),
+            current_hash: self.head,
             lru: self,
         }
     }
 
     #[cfg(test)]
     fn validate(&self) {
-        self.validate_impl(self.head.clone(), |slot| slot.next());
-        self.validate_impl(self.tail.clone(), |slot| slot.prev());
+        self.validate_impl(self.head, |slot| slot.next());
+        self.validate_impl(self.tail, |slot| slot.prev());
     }
 
     #[cfg(test)]
     fn validate_impl(
         &self,
-        start: Option<StateKey>,
-        func: impl Fn(&StateSlot) -> Option<&StateKey>,
+        start: Option<HashValue>,
+        func: impl Fn(&StateSlot) -> Option<&HashValue>,
     ) {
         let mut current = start;
         let mut num_visited = 0;
-        while let Some(key) = current {
-            let slot = self.expect_hot_slot(&key);
+        while let Some(key_hash) = current {
+            let (_key, slot) = self.expect_hot_entry(key_hash);
             num_visited += 1;
-            current = func(&slot).cloned();
+            current = func(&slot).copied();
         }
         assert_eq!(num_visited, self.num_items);
     }
@@ -204,18 +240,18 @@ impl<'a> HotStateLRU<'a> {
 
 #[cfg(test)]
 struct Iter<'a, 'b> {
-    current_key: Option<StateKey>,
+    current_hash: Option<HashValue>,
     lru: &'a HotStateLRU<'b>,
 }
 
 #[cfg(test)]
-impl<'a, 'b> Iterator for Iter<'a, 'b> {
+impl Iterator for Iter<'_, '_> {
     type Item = (StateKey, StateSlot);
 
     fn next(&mut self) -> Option<(StateKey, StateSlot)> {
-        let key = self.current_key.take()?;
-        let slot = self.lru.expect_hot_slot(&key);
-        self.current_key = slot.next().cloned();
+        let key_hash = self.current_hash.take()?;
+        let (key, slot) = self.lru.expect_hot_entry(key_hash);
+        self.current_hash = slot.next().copied();
         Some((key, slot))
     }
 }
@@ -224,6 +260,7 @@ impl<'a, 'b> Iterator for Iter<'a, 'b> {
 mod tests {
     use super::HotStateLRU;
     use crate::state_store::state_view::hot_state_view::HotStateView;
+    use aptos_crypto::HashValue;
     use aptos_experimental_layered_map::{LayeredMap, MapLayer};
     use aptos_types::{
         state_store::{
@@ -247,14 +284,29 @@ mod tests {
 
     #[derive(Debug)]
     struct HotState {
-        inner: HashMap<StateKey, StateSlot>,
-        head: Option<StateKey>,
-        tail: Option<StateKey>,
+        inner: HashMap<HashValue, (StateKey, StateSlot)>,
     }
 
     impl HotStateView for Mutex<HotState> {
         fn get_state_slot(&self, state_key: &StateKey) -> Option<StateSlot> {
-            self.lock().unwrap().inner.get(state_key).cloned()
+            let key_hash = *state_key.crypto_hash_ref();
+            self.lock()
+                .unwrap()
+                .inner
+                .get(&key_hash)
+                .map(|(_, slot)| slot.clone())
+        }
+
+        fn get_state_entry_by_hash(
+            &self,
+            _shard_id: usize,
+            key_hash: &HashValue,
+        ) -> Option<(StateKey, StateSlot)> {
+            self.lock()
+                .unwrap()
+                .inner
+                .get(key_hash)
+                .map(|(key, slot)| (key.clone(), slot.clone()))
         }
     }
 
@@ -269,8 +321,6 @@ mod tests {
         fn new_empty() -> Self {
             let hot_state = Arc::new(Mutex::new(HotState {
                 inner: HashMap::new(),
-                head: None,
-                tail: None,
             }));
             let base_layer = MapLayer::new_family("test");
             let top_layer = base_layer.clone();
@@ -287,8 +337,8 @@ mod tests {
         fn commit_updates(
             &self,
             updates: HashMap<StateKey, StateSlot>,
-            head: Option<StateKey>,
-            tail: Option<StateKey>,
+            _head: Option<HashValue>,
+            _tail: Option<HashValue>,
             num_items: usize,
         ) {
             // For most of the logic we don't really care whether the data is in committed state or
@@ -296,14 +346,13 @@ mod tests {
             // the overlay empty.
             let mut locked = self.hot_state.lock().unwrap();
             for (key, slot) in updates {
+                let key_hash = *key.crypto_hash_ref();
                 if slot.is_hot() {
-                    locked.inner.insert(key, slot);
+                    locked.inner.insert(key_hash, (key, slot));
                 } else {
-                    locked.inner.remove(&key);
+                    locked.inner.remove(&key_hash);
                 }
             }
-            locked.head = head;
-            locked.tail = tail;
             assert_eq!(locked.inner.len(), num_items);
         }
     }
@@ -392,15 +441,20 @@ mod tests {
                 while naive_lru.len() > capacity.get() {
                     expected_evicted.push(naive_lru.pop_lru().unwrap());
                 }
-                itertools::zip_eq(actual_evicted, expected_evicted).for_each(|(actual, expected)| {
-                    assert_eq!(actual.0, expected.0);
-                    assert_eq!(actual.1.into_state_value_opt(), expected.1.into_state_value_opt());
-                });
+                itertools::zip_eq(actual_evicted, expected_evicted).for_each(
+                    |(actual, expected)| {
+                        assert_eq!(actual.0, expected.0);
+                        assert_eq!(
+                            actual.1.into_state_value_opt(),
+                            expected.1.into_state_value_opt()
+                        );
+                    },
+                );
                 lru.validate();
                 assert_lru_equal(&lru, &naive_lru);
 
                 let (updates, new_head, new_tail, new_num_items) = lru.into_updates();
-                test_obj.commit_updates(updates, new_head.clone(), new_tail.clone(), new_num_items);
+                test_obj.commit_updates(updates, new_head, new_tail, new_num_items);
                 head = new_head;
                 tail = new_tail;
                 num_items = new_num_items;

--- a/storage/storage-interface/src/state_store/state.rs
+++ b/storage/storage-interface/src/state_store/state.rs
@@ -20,6 +20,7 @@ use crate::{
 };
 use anyhow::{bail, Result};
 use aptos_config::config::HotStateConfig;
+use aptos_crypto::HashValue;
 use aptos_experimental_layered_map::{LayeredMap, MapLayer};
 use aptos_logger::warn;
 use aptos_metrics_core::TimerHelper;
@@ -38,8 +39,8 @@ use std::{collections::HashMap, num::NonZeroUsize, sync::Arc};
 
 #[derive(Clone, Debug, Default)]
 pub struct HotStateMetadata {
-    latest: Option<StateKey>,
-    oldest: Option<StateKey>,
+    latest: Option<HashValue>,
+    oldest: Option<HashValue>,
     num_items: usize,
 }
 
@@ -147,12 +148,12 @@ impl State {
             .all(|(base_shard, top_shard)| top_shard.can_view_after(base_shard))
     }
 
-    pub fn latest_hot_key(&self, shard_id: usize) -> Option<StateKey> {
-        self.hot_state_metadata[shard_id].latest.clone()
+    pub fn latest_hot_key(&self, shard_id: usize) -> Option<HashValue> {
+        self.hot_state_metadata[shard_id].latest
     }
 
-    pub fn oldest_hot_key(&self, shard_id: usize) -> Option<StateKey> {
-        self.hot_state_metadata[shard_id].oldest.clone()
+    pub fn oldest_hot_key(&self, shard_id: usize) -> Option<HashValue> {
+        self.hot_state_metadata[shard_id].oldest
     }
 
     pub fn num_hot_items(&self, shard_id: usize) -> usize {
@@ -207,8 +208,8 @@ impl State {
                         NonZeroUsize::new(self.hot_state_config.max_items_per_shard).unwrap(),
                         Arc::clone(&persisted_hot_state),
                         overlay,
-                        hot_metadata.latest.clone(),
-                        hot_metadata.oldest.clone(),
+                        hot_metadata.latest,
+                        hot_metadata.oldest,
                         hot_metadata.num_items,
                     );
                     let mut all_updates = per_version.iter();

--- a/storage/storage-interface/src/state_store/state_delta.rs
+++ b/storage/storage-interface/src/state_store/state_delta.rs
@@ -2,6 +2,7 @@
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::state_store::state::State;
+use aptos_crypto::HashValue;
 use aptos_experimental_layered_map::LayeredMap;
 use aptos_types::{
     state_store::{state_key::StateKey, state_slot::StateSlot, NUM_STATE_SHARDS},
@@ -52,11 +53,11 @@ impl StateDelta {
         self.shards[state_key.get_shard_id()].get(state_key)
     }
 
-    pub fn latest_hot_key(&self, shard_id: usize) -> Option<StateKey> {
+    pub fn latest_hot_key(&self, shard_id: usize) -> Option<HashValue> {
         self.current.latest_hot_key(shard_id)
     }
 
-    pub fn oldest_hot_key(&self, shard_id: usize) -> Option<StateKey> {
+    pub fn oldest_hot_key(&self, shard_id: usize) -> Option<HashValue> {
         self.current.oldest_hot_key(shard_id)
     }
 }

--- a/storage/storage-interface/src/state_store/state_view/hot_state_view.rs
+++ b/storage/storage-interface/src/state_store/state_view/hot_state_view.rs
@@ -1,17 +1,34 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
+use aptos_crypto::HashValue;
 use aptos_types::state_store::{state_key::StateKey, state_slot::StateSlot};
 
 /// A view into the hot state store, whose content overlays on top of the cold state store content.
 pub trait HotStateView: Send + Sync {
     fn get_state_slot(&self, state_key: &StateKey) -> Option<StateSlot>;
+
+    /// Look up a hot state entry by the key's crypto hash. Returns both the `StateKey` and
+    /// `StateSlot` so the LRU can follow prev/next pointers without having the full key upfront.
+    fn get_state_entry_by_hash(
+        &self,
+        shard_id: usize,
+        key_hash: &HashValue,
+    ) -> Option<(StateKey, StateSlot)>;
 }
 
 pub struct EmptyHotState;
 
 impl HotStateView for EmptyHotState {
     fn get_state_slot(&self, _state_key: &StateKey) -> Option<StateSlot> {
+        None
+    }
+
+    fn get_state_entry_by_hash(
+        &self,
+        _shard_id: usize,
+        _key_hash: &HashValue,
+    ) -> Option<(StateKey, StateSlot)> {
         None
     }
 }

--- a/types/src/state_store/state_slot.rs
+++ b/types/src/state_store/state_slot.rs
@@ -25,7 +25,7 @@ pub enum StateSlot {
     ColdVacant,
     HotVacant {
         hot_since_version: Version,
-        lru_info: LRUEntry<StateKey>,
+        lru_info: LRUEntry<HashValue>,
     },
     ColdOccupied {
         value_version: Version,
@@ -35,7 +35,7 @@ pub enum StateSlot {
         value_version: Version,
         value: StateValue,
         hot_since_version: Version,
-        lru_info: LRUEntry<StateKey>,
+        lru_info: LRUEntry<HashValue>,
     },
 }
 
@@ -234,7 +234,7 @@ impl StateSlot {
 }
 
 impl THotStateSlot for StateSlot {
-    type Key = StateKey;
+    type Key = HashValue;
 
     fn prev(&self) -> Option<&Self::Key> {
         match self {


### PR DESCRIPTION

Change the LRU doubly-linked-list pointers (`LRUEntry.prev`/`next`) from
`StateKey` to `HashValue`. This is needed so the LRU can be reconstructed
from `hot_state_kv_db` on node startup — the DB only stores `HashValue`
keys, not full `StateKey`s.

Key changes:
- `StateSlot`'s `lru_info` field: `LRUEntry<StateKey>` → `LRUEntry<HashValue>`
- `HotStateMetadata` head/tail: `Option<StateKey>` → `Option<HashValue>`
- `HotStateLRU` reworked: pending map keyed by `HashValue`, overlay hash
  index built at construction for O(1) pointer-following, dual lookup
  (`get_slot` by `StateKey` for callers, `get_entry_by_hash` for internal
  traversal)
- `HotStateView` trait: added `get_state_entry_by_hash` returning
  `(StateKey, StateSlot)` so the LRU can recover the `StateKey` when
  following hash pointers into the committed view
- `HotStateBase` DashMap value: `StateSlot` → `(StateKey, StateSlot)` —
  `StateKey` is `Arc`-cloned (~8 bytes overhead per entry)
- `LayeredHotStateView`: delta stored as pre-built hash index
  (`HashMap<HashValue, (StateKey, StateSlot)>` per shard) instead of raw
  `StateDelta`, enabling O(1) hash-based lookups

The overlay hash index must include **cold** entries: without them, an
evicted key in the overlay would fail to shadow the stale hot entry in the
committed DashMap, causing `delete` to corrupt the linked list.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
