### PR TITLE
[storage] Key state pipeline by HashValue for hot state KV persistence

### DIFF
--- a/aptos-move/aptos-resource-viewer/src/module_view.rs
+++ b/aptos-move/aptos-resource-viewer/src/module_view.rs
@@ -377,24 +377,28 @@ mod tests {
             .set_default_version();
         assert_ne!(&a, &a_new);
 
+        let key_a = StateKey::module_id(&a_new.self_id());
+        let key_d = StateKey::module_id(&d.self_id());
+        let key_b = StateKey::module_id(&b.self_id());
+        let key_c = StateKey::module_id(&c.self_id());
         let new_state_view = MockStateView::new_with_state_slot(HashMap::from([
             // New code:
             (
-                StateKey::module_id(&a_new.self_id()),
-                StateSlot::from_db_get(Some((1, module_state_value(a_new.clone())))),
+                key_a.clone(),
+                StateSlot::from_db_get(key_a, Some((1, module_state_value(a_new.clone())))),
             ),
             (
-                StateKey::module_id(&d.self_id()),
-                StateSlot::from_db_get(Some((0, module_state_value(d.clone())))),
+                key_d.clone(),
+                StateSlot::from_db_get(key_d, Some((0, module_state_value(d.clone())))),
             ),
             // Old code:
             (
-                StateKey::module_id(&b.self_id()),
-                StateSlot::from_db_get(Some((0, module_state_value(b.clone())))),
+                key_b.clone(),
+                StateSlot::from_db_get(key_b, Some((0, module_state_value(b.clone())))),
             ),
             (
-                StateKey::module_id(&c.self_id()),
-                StateSlot::from_db_get(Some((0, module_state_value(c.clone())))),
+                key_c.clone(),
+                StateSlot::from_db_get(key_c, Some((0, module_state_value(c.clone())))),
             ),
         ]));
         state.reset_state_view(new_state_view);

--- a/aptos-move/aptos-transaction-simulation/src/state_store.rs
+++ b/aptos-move/aptos-transaction-simulation/src/state_store.rs
@@ -450,7 +450,7 @@ where
 
     fn get_state_slot(&self, state_key: &Self::Key) -> StateViewResult<StateSlot> {
         let value_opt = self.get_state_value(state_key)?.map(|value| (0, value));
-        Ok(StateSlot::from_db_get(value_opt))
+        Ok(StateSlot::from_db_get(state_key.clone(), value_opt))
     }
 
     fn get_state_value(&self, state_key: &Self::Key) -> StateViewResult<Option<StateValue>> {

--- a/aptos-move/aptos-validator-interface/src/lib.rs
+++ b/aptos-move/aptos-validator-interface/src/lib.rs
@@ -10,8 +10,11 @@ use aptos_framework::natives::code::PackageMetadata;
 use aptos_types::{
     account_address::AccountAddress,
     state_store::{
-        state_key::StateKey, state_slot::StateSlot, state_storage_usage::StateStorageUsage,
-        state_value::StateValue, StateViewId, StateViewResult, TStateView,
+        state_key::StateKey,
+        state_slot::{StateSlot, StateSlotKind},
+        state_storage_usage::StateStorageUsage,
+        state_value::StateValue,
+        StateViewId, StateViewResult, TStateView,
     },
     transaction::{PersistedAuxiliaryInfo, Transaction, TransactionInfo, Version},
 };
@@ -162,11 +165,11 @@ impl DebuggerStateView {
             .unwrap();
         let result = rx.recv()?;
         result.map(|s| match s {
-            None => StateSlot::ColdVacant,
-            Some(value) => StateSlot::ColdOccupied {
+            None => StateSlot::new(state_key.clone(), StateSlotKind::ColdVacant),
+            Some(value) => StateSlot::new(state_key.clone(), StateSlotKind::ColdOccupied {
                 value_version: version,
                 value,
-            },
+            }),
         })
     }
 }

--- a/aptos-move/replay-benchmark/src/state_view.rs
+++ b/aptos-move/replay-benchmark/src/state_view.rs
@@ -3,8 +3,11 @@
 
 use aptos_types::{
     state_store::{
-        state_key::StateKey, state_slot::StateSlot, state_storage_usage::StateStorageUsage,
-        state_value::StateValue, StateView, StateViewResult, TStateView,
+        state_key::StateKey,
+        state_slot::{StateSlot, StateSlotKind},
+        state_storage_usage::StateStorageUsage,
+        state_value::StateValue,
+        StateView, StateViewResult, TStateView,
     },
     transaction::Version,
 };
@@ -27,11 +30,11 @@ impl TStateView for ReadSet {
 
     fn get_state_slot(&self, state_key: &Self::Key) -> StateViewResult<StateSlot> {
         let slot = match self.data.get(state_key) {
-            Some(state_value) => StateSlot::ColdOccupied {
+            Some(state_value) => StateSlot::new(state_key.clone(), StateSlotKind::ColdOccupied {
                 value_version: 0,
                 value: state_value.clone(),
-            },
-            None => StateSlot::ColdVacant,
+            }),
+            None => StateSlot::new(state_key.clone(), StateSlotKind::ColdVacant),
         };
         Ok(slot)
     }
@@ -92,10 +95,13 @@ impl<S: StateView> TStateView for ReadSetCapturingStateView<'_, S> {
     fn get_state_slot(&self, state_key: &Self::Key) -> StateViewResult<StateSlot> {
         // Check the read-set first.
         if let Some(state_value) = self.captured_reads.lock().get(state_key) {
-            return Ok(StateSlot::ColdOccupied {
-                value_version: 0,
-                value: state_value.clone(),
-            });
+            return Ok(StateSlot::new(
+                state_key.clone(),
+                StateSlotKind::ColdOccupied {
+                    value_version: 0,
+                    value: state_value.clone(),
+                },
+            ));
         }
 
         // We do not allow failures because then benchmarking will not be correct (we miss a read).

--- a/storage/aptosdb/src/state_store/hot_state.rs
+++ b/storage/aptosdb/src/state_store/hot_state.rs
@@ -14,9 +14,7 @@ use aptos_storage_interface::state_store::{
     state::State, state_delta::StateDelta, state_view::hot_state_view::HotStateView,
 };
 use aptos_types::{
-    state_store::{
-        hot_state::THotStateSlot, state_key::StateKey, state_slot::StateSlot, NUM_STATE_SHARDS,
-    },
+    state_store::{hot_state::THotStateSlot, state_slot::StateSlot, NUM_STATE_SHARDS},
     transaction::Version,
 };
 use arr_macro::arr;
@@ -118,18 +116,18 @@ struct LayeredHotStateView {
 }
 
 impl HotStateView for LayeredHotStateView {
-    fn get_state_slot(&self, state_key: &StateKey) -> Option<StateSlot> {
+    fn get_state_slot(&self, key_hash: &HashValue) -> Option<StateSlot> {
+        let shard_id = usize::from(key_hash.nibble(0));
         if let Some(delta) = &self.delta {
-            if let Some(slot) = delta.get_state_slot(state_key) {
+            if let Some(slot) = delta.shards[shard_id].get(key_hash) {
                 // Delta says this key changed. If hot, return it. If cold/evicted, return None —
                 // do NOT fall through to base, the key was explicitly evicted in committed state.
                 return if slot.is_hot() { Some(slot) } else { None };
             }
         }
         // Key not in delta (unchanged) — read from base DashMap.
-        let shard_id = state_key.get_shard_id();
         self.base
-            .get_from_shard(shard_id, state_key.crypto_hash_ref())
+            .get_from_shard(shard_id, key_hash)
             .map(|v| v.clone())
     }
 }
@@ -515,8 +513,7 @@ impl Committer {
 
         let delta = target.make_delta(&self.merged_state);
         for shard_id in 0..NUM_STATE_SHARDS {
-            for (key, slot) in delta.shards[shard_id].iter() {
-                let key_hash = *key.crypto_hash_ref();
+            for (key_hash, slot) in delta.shards[shard_id].iter() {
                 if slot.is_hot() {
                     self.total_key_bytes += HashValue::LENGTH;
                     self.total_value_bytes += slot.size();
@@ -533,12 +530,8 @@ impl Committer {
                     n_evict += 1;
                 }
             }
-            self.heads[shard_id] = target
-                .latest_hot_key(shard_id)
-                .map(|k| *k.crypto_hash_ref());
-            self.tails[shard_id] = target
-                .oldest_hot_key(shard_id)
-                .map(|k| *k.crypto_hash_ref());
+            self.heads[shard_id] = target.latest_hot_key(shard_id);
+            self.tails[shard_id] = target.oldest_hot_key(shard_id);
             assert_eq!(
                 self.base.shards[shard_id].len(),
                 target.num_hot_items(shard_id)
@@ -611,7 +604,7 @@ impl Committer {
                 num_visited += 1;
                 ensure!(num_visited <= shard.len());
                 ensure!(entry.is_hot());
-                current = entry.next().map(|k| *k.crypto_hash_ref());
+                current = entry.next().copied();
             }
             ensure!(num_visited == shard.len());
         }
@@ -624,7 +617,7 @@ impl Committer {
                 num_visited += 1;
                 ensure!(num_visited <= shard.len());
                 ensure!(entry.is_hot());
-                current = entry.prev().map(|k| *k.crypto_hash_ref());
+                current = entry.prev().copied();
             }
             ensure!(num_visited == shard.len());
         }
@@ -640,8 +633,11 @@ mod tests {
     use aptos_experimental_layered_map::MapLayer;
     use aptos_storage_interface::state_store::{state::State, state_delta::StateDelta};
     use aptos_types::state_store::{
-        hot_state::LRUEntry, state_key::StateKey, state_slot::StateSlot,
-        state_storage_usage::StateStorageUsage, state_value::StateValue,
+        hot_state::LRUEntry,
+        state_key::StateKey,
+        state_slot::{StateSlot, StateSlotKind},
+        state_storage_usage::StateStorageUsage,
+        state_value::StateValue,
     };
 
     const TEST_CONFIG: HotStateConfig = HotStateConfig {
@@ -652,29 +648,29 @@ mod tests {
         persist_hotness_in_write_set: true,
     };
 
-    fn make_hot_slot(version: Version, value: &[u8]) -> StateSlot {
-        StateSlot::HotOccupied {
+    fn make_hot_slot(key: &StateKey, version: Version, value: &[u8]) -> StateSlot {
+        StateSlot::new(key.clone(), StateSlotKind::HotOccupied {
             value_version: version,
             value: StateValue::new_legacy(value.to_vec().into()),
             hot_since_version: version,
             lru_info: LRUEntry::uninitialized(),
-        }
+        })
     }
 
-    fn make_hot_vacant(version: Version) -> StateSlot {
-        StateSlot::HotVacant {
+    fn make_hot_vacant(key: &StateKey, version: Version) -> StateSlot {
+        StateSlot::new(key.clone(), StateSlotKind::HotVacant {
             hot_since_version: version,
             lru_info: LRUEntry::uninitialized(),
-        }
+        })
     }
 
     /// Create a `StateDelta` for testing `LayeredHotStateView`.
     /// The delta's shards contain exactly the given entries.
     fn make_test_delta(entries: &[(StateKey, StateSlot)]) -> StateDelta {
-        let mut shard_entries: [Vec<(StateKey, StateSlot)>; NUM_STATE_SHARDS] =
+        let mut shard_entries: [Vec<(HashValue, StateSlot)>; NUM_STATE_SHARDS] =
             std::array::from_fn(|_| Vec::new());
         for (key, slot) in entries {
-            shard_entries[key.get_shard_id()].push((key.clone(), slot.clone()));
+            shard_entries[key.get_shard_id()].push((*key.crypto_hash_ref(), slot.clone()));
         }
 
         let empty = State::new_empty(TEST_CONFIG);
@@ -697,7 +693,7 @@ mod tests {
     /// be the original ancestor — it's used as the base layer when spawning children so that
     /// `make_delta(root)` remains valid for all descendants.
     fn build_empty_descendant(root: &State, parent: &State, version: Version) -> State {
-        let shards: [MapLayer<StateKey, StateSlot>; NUM_STATE_SHARDS] =
+        let shards: [MapLayer<HashValue, StateSlot>; NUM_STATE_SHARDS] =
             std::array::from_fn(|shard_id| {
                 parent.shards()[shard_id]
                     .view_layers_after(&root.shards()[shard_id])
@@ -719,7 +715,7 @@ mod tests {
         let base = Arc::new(HotStateBase::new_empty(100));
         let key = StateKey::raw(b"key_a");
         let shard_id = key.get_shard_id();
-        let slot = make_hot_slot(1, b"value_a");
+        let slot = make_hot_slot(&key, 1, b"value_a");
         base.shards[shard_id].insert(*key.crypto_hash_ref(), slot.clone());
 
         let view = LayeredHotStateView {
@@ -728,7 +724,7 @@ mod tests {
         };
 
         // Key in base -> returns base value.
-        let result = view.get_state_slot(&key);
+        let result = view.get_state_slot(key.crypto_hash_ref());
         assert!(result.is_some());
         assert_eq!(
             result.unwrap().as_state_value_opt(),
@@ -737,7 +733,7 @@ mod tests {
 
         // Key not in base -> returns None.
         let missing = StateKey::raw(b"missing");
-        assert!(view.get_state_slot(&missing).is_none());
+        assert!(view.get_state_slot(missing.crypto_hash_ref()).is_none());
     }
 
     #[test]
@@ -746,32 +742,35 @@ mod tests {
 
         // key_base_only: in base DashMap, NOT in delta.
         let key_base_only = StateKey::raw(b"base_only");
-        let slot_base = make_hot_slot(1, b"base_value");
+        let slot_base = make_hot_slot(&key_base_only, 1, b"base_value");
         base.shards[key_base_only.get_shard_id()]
             .insert(*key_base_only.crypto_hash_ref(), slot_base.clone());
 
         // key_updated: in base DashMap AND in delta (hot) -> delta wins.
         let key_updated = StateKey::raw(b"updated");
-        let slot_old = make_hot_slot(1, b"old_value");
-        let slot_new = make_hot_slot(2, b"new_value");
+        let slot_old = make_hot_slot(&key_updated, 1, b"old_value");
+        let slot_new = make_hot_slot(&key_updated, 2, b"new_value");
         base.shards[key_updated.get_shard_id()].insert(*key_updated.crypto_hash_ref(), slot_old);
 
         // key_evicted: in base DashMap AND in delta (cold) -> returns None.
         let key_evicted = StateKey::raw(b"evicted");
-        let slot_was_hot = make_hot_slot(1, b"was_hot");
+        let slot_was_hot = make_hot_slot(&key_evicted, 1, b"was_hot");
         base.shards[key_evicted.get_shard_id()]
             .insert(*key_evicted.crypto_hash_ref(), slot_was_hot);
 
         // key_new: NOT in base, in delta (hot) -> returns delta value.
         let key_new = StateKey::raw(b"new_key");
-        let slot_new_key = make_hot_slot(2, b"brand_new");
+        let slot_new_key = make_hot_slot(&key_new, 2, b"brand_new");
 
         // key_missing: NOT in base, NOT in delta -> returns None.
         let key_missing = StateKey::raw(b"missing");
 
         let delta = make_test_delta(&[
             (key_updated.clone(), slot_new.clone()),
-            (key_evicted.clone(), StateSlot::ColdVacant),
+            (
+                key_evicted.clone(),
+                StateSlot::new(key_evicted.clone(), StateSlotKind::ColdVacant),
+            ),
             (key_new.clone(), slot_new_key.clone()),
         ]);
 
@@ -781,7 +780,7 @@ mod tests {
         };
 
         // Key only in base -> falls through to base.
-        let result = view.get_state_slot(&key_base_only);
+        let result = view.get_state_slot(key_base_only.crypto_hash_ref());
         assert!(result.is_some());
         assert_eq!(
             result.unwrap().as_state_value_opt(),
@@ -789,7 +788,7 @@ mod tests {
         );
 
         // Key updated in delta -> returns delta value.
-        let result = view.get_state_slot(&key_updated);
+        let result = view.get_state_slot(key_updated.crypto_hash_ref());
         assert!(result.is_some());
         assert_eq!(
             result.unwrap().as_state_value_opt(),
@@ -797,10 +796,10 @@ mod tests {
         );
 
         // Key evicted in delta -> returns None (even though in base).
-        assert!(view.get_state_slot(&key_evicted).is_none());
+        assert!(view.get_state_slot(key_evicted.crypto_hash_ref()).is_none());
 
         // New key in delta -> returns delta value.
-        let result = view.get_state_slot(&key_new);
+        let result = view.get_state_slot(key_new.crypto_hash_ref());
         assert!(result.is_some());
         assert_eq!(
             result.unwrap().as_state_value_opt(),
@@ -808,7 +807,7 @@ mod tests {
         );
 
         // Key neither in delta nor base -> returns None.
-        assert!(view.get_state_slot(&key_missing).is_none());
+        assert!(view.get_state_slot(key_missing.crypto_hash_ref()).is_none());
     }
 
     #[test]
@@ -816,7 +815,7 @@ mod tests {
         // HotVacant in delta -> is_hot() is true -> returns Some(HotVacant).
         let base = Arc::new(HotStateBase::new_empty(100));
         let key = StateKey::raw(b"hot_vacant");
-        let slot = make_hot_vacant(5);
+        let slot = make_hot_vacant(&key, 5);
 
         let delta = make_test_delta(&[(key.clone(), slot)]);
         let view = LayeredHotStateView {
@@ -824,7 +823,7 @@ mod tests {
             base,
         };
 
-        let result = view.get_state_slot(&key);
+        let result = view.get_state_slot(key.crypto_hash_ref());
         assert!(result.is_some());
         assert!(result.unwrap().is_hot());
     }

--- a/storage/aptosdb/src/state_store/mod.rs
+++ b/storage/aptosdb/src/state_store/mod.rs
@@ -68,7 +68,7 @@ use aptos_types::{
     proof::{definition::LeafCount, SparseMerkleProofExt, SparseMerkleRangeProof},
     state_store::{
         state_key::StateKey,
-        state_slot::StateSlot,
+        state_slot::{StateSlot, StateSlotKind},
         state_storage_usage::StateStorageUsage,
         state_value::{StaleStateValueByKeyHashIndex, StateValue, StateValueChunkWithProof},
         NUM_STATE_SHARDS,
@@ -853,7 +853,7 @@ impl StateStore {
                 .par_iter_mut()
                 .zip_eq(shard_updates.par_iter())
                 .try_for_each(|(batch, shard)| {
-                    for (key, (hot_val, value_version_opt)) in &shard.insertions {
+                    for (key_hash, (hot_val, value_version_opt)) in &shard.insertions {
                         let schema_value = match hot_val.value_opt() {
                             Some(value) => HotStateEntry::Occupied {
                                 value: value.clone(),
@@ -869,13 +869,13 @@ impl StateStore {
                             },
                         };
                         batch.put::<HotStateValueByKeyHashSchema>(
-                            &(CryptoHash::hash(key), hot_val.hot_since_version()),
+                            &(*key_hash, hot_val.hot_since_version()),
                             &Some(schema_value),
                         )?;
                     }
-                    for (key, eviction_version) in &shard.evictions {
+                    for (key_hash, eviction_version) in &shard.evictions {
                         batch.put::<HotStateValueByKeyHashSchema>(
-                            &(CryptoHash::hash(key), *eviction_version),
+                            &(*key_hash, *eviction_version),
                             &None,
                         )?;
                     }
@@ -1003,7 +1003,7 @@ impl StateStore {
                     .insert(
                         (*key).clone(),
                         update_to_cold
-                            .to_result_slot()
+                            .to_result_slot((*key).clone())
                             .expect("hot state ops should have been filtered out above"),
                     )
                     .unwrap_or_else(|| {
@@ -1011,7 +1011,7 @@ impl StateStore {
                         // otherwise we can't calculate the correct usage. The is_untracked() hack
                         // is to allow some db tests without real execution layer to pass.
                         assert!(ignore_state_cache_miss, "Must cache read.");
-                        StateSlot::ColdVacant
+                        StateSlot::new((*key).clone(), StateSlotKind::ColdVacant)
                     });
 
                 let old_version = if old_entry.is_occupied() {

--- a/storage/aptosdb/src/state_store/state_snapshot_committer.rs
+++ b/storage/aptosdb/src/state_store/state_snapshot_committer.rs
@@ -108,19 +108,19 @@ impl StateSnapshotCommitter {
                             let _timer = OTHER_TIMERS_SECONDS.timer_with(&["hash_jmt_updates"]);
                             let mut hot_updates = Vec::new();
                             let mut all_updates = Vec::new();
-                            for (key, slot) in updates.iter() {
+                            for (key_hash, slot) in updates.iter() {
                                 if slot.is_hot() {
                                     hot_updates.push((
-                                        CryptoHash::hash(&key),
+                                        key_hash,
                                         Some((
                                             HotStateValueRef::from_slot(&slot).hash(),
-                                            key.clone(),
+                                            slot.state_key().clone(),
                                         )),
                                     ));
                                 } else {
-                                    hot_updates.push((CryptoHash::hash(&key), None));
+                                    hot_updates.push((key_hash, None));
                                 }
-                                if let Some(value) = slot.maybe_update_jmt(key, min_version) {
+                                if let Some(value) = slot.maybe_update_jmt(min_version) {
                                     all_updates.push(value);
                                 }
                             }

--- a/storage/aptosdb/src/state_store/tests/hot_state_kv.rs
+++ b/storage/aptosdb/src/state_store/tests/hot_state_kv.rs
@@ -173,19 +173,20 @@ fn test_put_hot_state_updates_integration() {
 
     // key1: occupied insertion at hot_since_version=100, value_version=50
     shards[key1.get_shard_id()].insertions.insert(
-        key1.clone(),
+        *key1.crypto_hash_ref(),
         (HotStateValue::new(Some(val1.clone()), 100), Some(50)),
     );
 
     // key2: vacant insertion at hot_since_version=200
-    shards[key2.get_shard_id()]
-        .insertions
-        .insert(key2.clone(), (HotStateValue::new(None, 200), None));
+    shards[key2.get_shard_id()].insertions.insert(
+        *key2.crypto_hash_ref(),
+        (HotStateValue::new(None, 200), None),
+    );
 
     // key3: eviction at version=300
     shards[key3.get_shard_id()]
         .evictions
-        .insert(key3.clone(), 300);
+        .insert(*key3.crypto_hash_ref(), 300);
 
     let hot_state_updates = HotStateUpdates {
         for_last_checkpoint: Some(shards),

--- a/storage/aptosdb/src/state_store/tests/speculative_state_workflow.rs
+++ b/storage/aptosdb/src/state_store/tests/speculative_state_workflow.rs
@@ -23,7 +23,7 @@ use aptos_types::{
     state_store::{
         hot_state::{HotStateValueRef, LRUEntry},
         state_key::StateKey,
-        state_slot::StateSlot,
+        state_slot::{StateSlot, StateSlotKind},
         state_storage_usage::StateStorageUsage,
         state_value::StateValue,
         StateViewId, StateViewResult, TStateView, NUM_STATE_SHARDS,
@@ -210,10 +210,10 @@ impl VersionState {
             let shard_id = k.get_shard_id();
             match v_opt {
                 None => {
-                    let slot = StateSlot::HotVacant {
+                    let slot = StateSlot::new(k.clone(), StateSlotKind::HotVacant {
                         hot_since_version: version,
                         lru_info: LRUEntry::uninitialized(),
-                    };
+                    });
                     hot_smt_updates
                         .push((k.hash(), Some(HotStateValueRef::from_slot(&slot).hash())));
                     hot_state[shard_id].put(k.clone(), slot);
@@ -221,12 +221,12 @@ impl VersionState {
                     state.remove(k);
                 },
                 Some(v) => {
-                    let slot = StateSlot::HotOccupied {
+                    let slot = StateSlot::new(k.clone(), StateSlotKind::HotOccupied {
                         value_version: version,
                         value: v.clone(),
                         hot_since_version: version,
                         lru_info: LRUEntry::uninitialized(),
-                    };
+                    });
                     hot_smt_updates
                         .push((k.hash(), Some(HotStateValueRef::from_slot(&slot).hash())));
                     hot_state[shard_id].put(k.clone(), slot);
@@ -250,16 +250,18 @@ impl VersionState {
                 }
             } else {
                 let slot = match state.get(k) {
-                    Some((value_version, value)) => StateSlot::HotOccupied {
-                        value_version: *value_version,
-                        value: value.clone(),
+                    Some((value_version, value)) => {
+                        StateSlot::new(k.clone(), StateSlotKind::HotOccupied {
+                            value_version: *value_version,
+                            value: value.clone(),
+                            hot_since_version: version,
+                            lru_info: LRUEntry::uninitialized(),
+                        })
+                    },
+                    None => StateSlot::new(k.clone(), StateSlotKind::HotVacant {
                         hot_since_version: version,
                         lru_info: LRUEntry::uninitialized(),
-                    },
-                    None => StateSlot::HotVacant {
-                        hot_since_version: version,
-                        lru_info: LRUEntry::uninitialized(),
-                    },
+                    }),
                 };
                 hot_value_hash = Some(HotStateValueRef::from_slot(&slot).hash());
                 hot_state[shard_id].put(k.clone(), slot);
@@ -306,7 +308,7 @@ impl TStateView for VersionState {
     type Key = StateKey;
 
     fn get_state_slot(&self, key: &Self::Key) -> StateViewResult<StateSlot> {
-        let from_cold = StateSlot::from_db_get(self.state.get(key).cloned());
+        let from_cold = StateSlot::from_db_get(key.clone(), self.state.get(key).cloned());
         let shard_id = key.get_shard_id();
         let slot = match self.hot_state[shard_id].peek(key) {
             Some(slot) => {
@@ -364,25 +366,26 @@ impl StateByVersion {
     }
 
     fn assert_state_slot(slot1: &StateSlot, slot2: &StateSlot) {
-        match (slot1, slot2) {
+        assert_eq!(slot1.state_key(), slot2.state_key());
+        match (slot1.kind(), slot2.kind()) {
             (
-                StateSlot::HotVacant {
+                StateSlotKind::HotVacant {
                     hot_since_version: v1,
                     ..
                 },
-                StateSlot::HotVacant {
+                StateSlotKind::HotVacant {
                     hot_since_version: v2,
                     ..
                 },
             ) => assert_eq!(v1, v2),
             (
-                StateSlot::HotOccupied {
+                StateSlotKind::HotOccupied {
                     value_version: vv1,
                     value: v1,
                     hot_since_version: h1,
                     ..
                 },
-                StateSlot::HotOccupied {
+                StateSlotKind::HotOccupied {
                     value_version: vv2,
                     value: v2,
                     hot_since_version: h2,
@@ -393,7 +396,7 @@ impl StateByVersion {
                 assert_eq!(v1, v2);
                 assert_eq!(h1, h2);
             },
-            (s1, s2) => assert_eq!(s1, s2),
+            (k1, k2) => assert_eq!(k1, k2),
         }
     }
 
@@ -439,7 +442,7 @@ impl StateByVersion {
             .shards
             .iter()
             .flat_map(|shard| shard.iter())
-            .filter_map(|(key, slot)| slot.maybe_update_jmt(key, last_snapshot.next_version()))
+            .filter_map(|(_key_hash, slot)| slot.maybe_update_jmt(last_snapshot.next_version()))
             .map(|(key_hash, value_opt)| (key_hash, value_opt.map(|(val_hash, _key)| val_hash)))
             .collect_vec();
 

--- a/storage/storage-interface/src/state_store/hot_state.rs
+++ b/storage/storage-interface/src/state_store/hot_state.rs
@@ -2,6 +2,7 @@
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::state_store::state_view::hot_state_view::HotStateView;
+use aptos_crypto::HashValue;
 use aptos_experimental_layered_map::LayeredMap;
 use aptos_types::state_store::{
     hot_state::THotStateSlot, state_key::StateKey, state_slot::StateSlot,
@@ -15,13 +16,13 @@ pub(crate) struct HotStateLRU<'a> {
     /// to handle a single shard.
     committed: Arc<dyn HotStateView>,
     /// Additional entries resulted from previous speculative execution.
-    overlay: &'a LayeredMap<StateKey, StateSlot>,
+    overlay: &'a LayeredMap<HashValue, StateSlot>,
     /// The new entries from current execution.
-    pending: HashMap<StateKey, StateSlot>,
+    pending: HashMap<HashValue, StateSlot>,
     /// Points to the latest entry. `None` if empty.
-    head: Option<StateKey>,
+    head: Option<HashValue>,
     /// Points to the oldest entry. `None` if empty.
-    tail: Option<StateKey>,
+    tail: Option<HashValue>,
     /// Total number of items.
     num_items: usize,
 }
@@ -30,9 +31,9 @@ impl<'a> HotStateLRU<'a> {
     pub fn new(
         capacity: NonZeroUsize,
         committed: Arc<dyn HotStateView>,
-        overlay: &'a LayeredMap<StateKey, StateSlot>,
-        head: Option<StateKey>,
-        tail: Option<StateKey>,
+        overlay: &'a LayeredMap<HashValue, StateSlot>,
+        head: Option<HashValue>,
+        tail: Option<HashValue>,
         num_items: usize,
     ) -> Self {
         Self {
@@ -46,42 +47,48 @@ impl<'a> HotStateLRU<'a> {
         }
     }
 
-    pub fn insert(&mut self, key: StateKey, slot: StateSlot) {
+    pub fn insert(&mut self, key: &StateKey, slot: StateSlot) {
         assert!(
             slot.is_hot(),
             "Should not insert cold slots into hot state."
         );
-        if self.delete(&key).is_none() {
+        assert_eq!(
+            key,
+            slot.state_key(),
+            "Map key and embedded state_key must match."
+        );
+        let key_hash = *key.crypto_hash_ref();
+        if self.delete(&key_hash).is_none() {
             self.num_items += 1;
         }
-        self.insert_as_head(key, slot);
+        self.insert_as_head(key_hash, slot);
     }
 
-    fn insert_as_head(&mut self, key: StateKey, mut slot: StateSlot) {
+    fn insert_as_head(&mut self, key_hash: HashValue, mut slot: StateSlot) {
         match self.head.take() {
             Some(head) => {
                 let mut old_head_slot = self.expect_hot_slot(&head);
-                old_head_slot.set_prev(Some(key.clone()));
+                old_head_slot.set_prev(Some(key_hash));
                 slot.set_prev(None);
-                slot.set_next(Some(head.clone()));
+                slot.set_next(Some(head));
                 self.pending.insert(head, old_head_slot);
-                self.pending.insert(key.clone(), slot);
-                self.head = Some(key);
+                self.pending.insert(key_hash, slot);
+                self.head = Some(key_hash);
             },
             None => {
                 slot.set_prev(None);
                 slot.set_next(None);
-                self.pending.insert(key.clone(), slot);
-                self.head = Some(key.clone());
-                self.tail = Some(key);
+                self.pending.insert(key_hash, slot);
+                self.head = Some(key_hash);
+                self.tail = Some(key_hash);
             },
         }
     }
 
     /// Returns the list of entries evicted, beginning from the LRU.
-    pub fn maybe_evict(&mut self) -> Vec<(StateKey, StateSlot)> {
-        let mut current = match &self.tail {
-            Some(tail) => tail.clone(),
+    pub fn maybe_evict(&mut self) -> Vec<(HashValue, StateSlot)> {
+        let mut current = match self.tail {
+            Some(tail) => tail,
             None => {
                 assert_eq!(self.num_items, 0);
                 return Vec::new();
@@ -93,69 +100,70 @@ impl<'a> HotStateLRU<'a> {
             let slot = self
                 .delete(&current)
                 .expect("There must be entries to evict when current size is above capacity.");
-            let prev_key = slot
+            let prev_key_hash = *slot
                 .prev()
-                .cloned()
                 .expect("There must be at least one newer entry (num_items > capacity >= 1).");
-            evicted.push((current.clone(), slot.clone()));
+            evicted.push((current, slot.clone()));
             self.pending.insert(current, slot.to_cold());
-            current = prev_key;
+            current = prev_key_hash;
             self.num_items -= 1;
         }
         evicted
     }
 
     /// Returns the deleted slot, or `None` if the key doesn't exist or is not hot.
-    fn delete(&mut self, key: &StateKey) -> Option<StateSlot> {
+    fn delete(&mut self, key_hash: &HashValue) -> Option<StateSlot> {
         // Fetch the slot corresponding to the given key. Note that `self.pending` and
         // `self.overlay` may contain cold slots, like the ones recently evicted, and we need to
         // ignore them.
-        let old_slot = match self.get_slot(key) {
+        let old_slot = match self.get_slot(key_hash) {
             Some(slot) if slot.is_hot() => slot,
             _ => return None,
         };
 
         match old_slot.prev() {
-            Some(prev_key) => {
-                let mut prev_slot = self.expect_hot_slot(prev_key);
-                prev_slot.set_next(old_slot.next().cloned());
-                self.pending.insert(prev_key.clone(), prev_slot);
+            Some(prev_key_hash) => {
+                let mut prev_slot = self.expect_hot_slot(prev_key_hash);
+                prev_slot.set_next(old_slot.next().copied());
+                self.pending.insert(*prev_key_hash, prev_slot);
             },
             None => {
                 // There is no newer entry. The current key was the head.
-                self.head = old_slot.next().cloned();
+                self.head = old_slot.next().copied();
             },
         }
 
         match old_slot.next() {
-            Some(next_key) => {
-                let mut next_slot = self.expect_hot_slot(next_key);
-                next_slot.set_prev(old_slot.prev().cloned());
-                self.pending.insert(next_key.clone(), next_slot);
+            Some(next_key_hash) => {
+                let mut next_slot = self.expect_hot_slot(next_key_hash);
+                next_slot.set_prev(old_slot.prev().copied());
+                self.pending.insert(*next_key_hash, next_slot);
             },
             None => {
                 // There is no older entry. The current key was the tail.
-                self.tail = old_slot.prev().cloned();
+                self.tail = old_slot.prev().copied();
             },
         }
 
         Some(old_slot)
     }
 
-    pub(crate) fn get_slot(&self, key: &StateKey) -> Option<StateSlot> {
-        if let Some(slot) = self.pending.get(key) {
+    pub(crate) fn get_slot(&self, key_hash: &HashValue) -> Option<StateSlot> {
+        if let Some(slot) = self.pending.get(key_hash) {
             return Some(slot.clone());
         }
 
-        if let Some(slot) = self.overlay.get(key) {
+        if let Some(slot) = self.overlay.get(key_hash) {
             return Some(slot);
         }
 
-        self.committed.get_state_slot(key)
+        self.committed.get_state_slot(key_hash)
     }
 
-    fn expect_hot_slot(&self, key: &StateKey) -> StateSlot {
-        let slot = self.get_slot(key).expect("Given key is expected to exist.");
+    fn expect_hot_slot(&self, key_hash: &HashValue) -> StateSlot {
+        let slot = self
+            .get_slot(key_hash)
+            .expect("Given key is expected to exist.");
         assert!(slot.is_hot(), "Given key is expected to be hot.");
         slot
     }
@@ -163,9 +171,9 @@ impl<'a> HotStateLRU<'a> {
     pub fn into_updates(
         self,
     ) -> (
-        HashMap<StateKey, StateSlot>,
-        Option<StateKey>,
-        Option<StateKey>,
+        HashMap<HashValue, StateSlot>,
+        Option<HashValue>,
+        Option<HashValue>,
         usize,
     ) {
         (self.pending, self.head, self.tail, self.num_items)
@@ -174,29 +182,29 @@ impl<'a> HotStateLRU<'a> {
     #[cfg(test)]
     fn iter(&self) -> Iter<'_, '_> {
         Iter {
-            current_key: self.head.clone(),
+            current_key: self.head,
             lru: self,
         }
     }
 
     #[cfg(test)]
     fn validate(&self) {
-        self.validate_impl(self.head.clone(), |slot| slot.next());
-        self.validate_impl(self.tail.clone(), |slot| slot.prev());
+        self.validate_impl(self.head, |slot| slot.next().copied());
+        self.validate_impl(self.tail, |slot| slot.prev().copied());
     }
 
     #[cfg(test)]
     fn validate_impl(
         &self,
-        start: Option<StateKey>,
-        func: impl Fn(&StateSlot) -> Option<&StateKey>,
+        start: Option<HashValue>,
+        func: impl Fn(&StateSlot) -> Option<HashValue>,
     ) {
         let mut current = start;
         let mut num_visited = 0;
-        while let Some(key) = current {
-            let slot = self.expect_hot_slot(&key);
+        while let Some(key_hash) = current {
+            let slot = self.expect_hot_slot(&key_hash);
             num_visited += 1;
-            current = func(&slot).cloned();
+            current = func(&slot);
         }
         assert_eq!(num_visited, self.num_items);
     }
@@ -204,19 +212,19 @@ impl<'a> HotStateLRU<'a> {
 
 #[cfg(test)]
 struct Iter<'a, 'b> {
-    current_key: Option<StateKey>,
+    current_key: Option<HashValue>,
     lru: &'a HotStateLRU<'b>,
 }
 
 #[cfg(test)]
-impl<'a, 'b> Iterator for Iter<'a, 'b> {
-    type Item = (StateKey, StateSlot);
+impl Iterator for Iter<'_, '_> {
+    type Item = (HashValue, StateSlot);
 
-    fn next(&mut self) -> Option<(StateKey, StateSlot)> {
-        let key = self.current_key.take()?;
-        let slot = self.lru.expect_hot_slot(&key);
-        self.current_key = slot.next().cloned();
-        Some((key, slot))
+    fn next(&mut self) -> Option<(HashValue, StateSlot)> {
+        let key_hash = self.current_key.take()?;
+        let slot = self.lru.expect_hot_slot(&key_hash);
+        self.current_key = slot.next().copied();
+        Some((key_hash, slot))
     }
 }
 
@@ -224,10 +232,13 @@ impl<'a, 'b> Iterator for Iter<'a, 'b> {
 mod tests {
     use super::HotStateLRU;
     use crate::state_store::state_view::hot_state_view::HotStateView;
+    use aptos_crypto::HashValue;
     use aptos_experimental_layered_map::{LayeredMap, MapLayer};
     use aptos_types::{
         state_store::{
-            hot_state::LRUEntry, state_key::StateKey, state_slot::StateSlot,
+            hot_state::LRUEntry,
+            state_key::StateKey,
+            state_slot::{StateSlot, StateSlotKind},
             state_value::StateValue,
         },
         transaction::Version,
@@ -247,22 +258,22 @@ mod tests {
 
     #[derive(Debug)]
     struct HotState {
-        inner: HashMap<StateKey, StateSlot>,
-        head: Option<StateKey>,
-        tail: Option<StateKey>,
+        inner: HashMap<HashValue, StateSlot>,
+        head: Option<HashValue>,
+        tail: Option<HashValue>,
     }
 
     impl HotStateView for Mutex<HotState> {
-        fn get_state_slot(&self, state_key: &StateKey) -> Option<StateSlot> {
-            self.lock().unwrap().inner.get(state_key).cloned()
+        fn get_state_slot(&self, key_hash: &HashValue) -> Option<StateSlot> {
+            self.lock().unwrap().inner.get(key_hash).cloned()
         }
     }
 
     struct LRUTest {
         hot_state: Arc<Mutex<HotState>>,
-        _base_layer: MapLayer<StateKey, StateSlot>,
-        _top_layer: MapLayer<StateKey, StateSlot>,
-        overlay: LayeredMap<StateKey, StateSlot>,
+        _base_layer: MapLayer<HashValue, StateSlot>,
+        _top_layer: MapLayer<HashValue, StateSlot>,
+        overlay: LayeredMap<HashValue, StateSlot>,
     }
 
     impl LRUTest {
@@ -286,20 +297,20 @@ mod tests {
 
         fn commit_updates(
             &self,
-            updates: HashMap<StateKey, StateSlot>,
-            head: Option<StateKey>,
-            tail: Option<StateKey>,
+            updates: HashMap<HashValue, StateSlot>,
+            head: Option<HashValue>,
+            tail: Option<HashValue>,
             num_items: usize,
         ) {
             // For most of the logic we don't really care whether the data is in committed state or
             // in the overlay, so we just merge everything directly to committed state, and keep
             // the overlay empty.
             let mut locked = self.hot_state.lock().unwrap();
-            for (key, slot) in updates {
+            for (key_hash, slot) in updates {
                 if slot.is_hot() {
-                    locked.inner.insert(key, slot);
+                    locked.inner.insert(key_hash, slot);
                 } else {
-                    locked.inner.remove(&key);
+                    locked.inner.remove(&key_hash);
                 }
             }
             locked.head = head;
@@ -308,16 +319,16 @@ mod tests {
         }
     }
 
-    fn arb_hot_slot() -> impl Strategy<Value = StateSlot> {
+    fn arb_hot_slot_kind() -> impl Strategy<Value = StateSlotKind> {
         (any::<Version>(), any::<StateValue>()).prop_flat_map(|(version, value)| {
             prop_oneof![
-                4 => Just(StateSlot::HotOccupied {
+                4 => Just(StateSlotKind::HotOccupied {
                     value_version: version,
                     value,
                     hot_since_version: version,
                     lru_info: LRUEntry::uninitialized(),
                 }),
-                1 => Just(StateSlot::HotVacant {
+                1 => Just(StateSlotKind::HotVacant {
                     hot_since_version: version,
                     lru_info: LRUEntry::uninitialized(),
                 }),
@@ -325,20 +336,20 @@ mod tests {
         })
     }
 
-    fn assert_lru_equal(actual: &HotStateLRU, expected: &LruCache<StateKey, StateSlot>) {
+    fn assert_lru_equal(actual: &HotStateLRU, expected: &LruCache<HashValue, StateSlot>) {
         assert_eq!(
             actual
                 .iter()
-                .map(|(key, slot)| {
+                .map(|(key_hash, slot)| {
                     assert!(slot.is_hot());
-                    (key, slot.into_state_value_opt())
+                    (key_hash, slot.into_state_value_opt())
                 })
                 .collect::<Vec<_>>(),
             expected
                 .iter()
-                .map(|(key, slot)| {
+                .map(|(key_hash, slot)| {
                     assert!(slot.is_hot());
-                    (key.clone(), slot.clone().into_state_value_opt())
+                    (*key_hash, slot.clone().into_state_value_opt())
                 })
                 .collect::<Vec<_>>(),
         );
@@ -354,7 +365,7 @@ mod tests {
                     let pool: Vec<_> = keys.into_iter().collect();
                     let mut blocks = Vec::new();
                     for _i in 0..num_blocks {
-                        let block = vec((sample::select(pool.clone()), arb_hot_slot()), 1..100);
+                        let block = vec((sample::select(pool.clone()), arb_hot_slot_kind()), 1..100);
                         blocks.push(block);
                     }
                     blocks
@@ -380,9 +391,11 @@ mod tests {
                 );
                 lru.validate();
 
-                for (key, slot) in updates {
-                    lru.insert(key.clone(), slot.clone());
-                    naive_lru.put(key, slot);
+                for (key, kind) in updates {
+                    let key_hash = *key.crypto_hash_ref();
+                    let slot = StateSlot::new(key.clone(), kind);
+                    lru.insert(&key, slot.clone());
+                    naive_lru.put(key_hash, slot);
                     lru.validate();
                     assert_lru_equal(&lru, &naive_lru);
                 }
@@ -400,7 +413,7 @@ mod tests {
                 assert_lru_equal(&lru, &naive_lru);
 
                 let (updates, new_head, new_tail, new_num_items) = lru.into_updates();
-                test_obj.commit_updates(updates, new_head.clone(), new_tail.clone(), new_num_items);
+                test_obj.commit_updates(updates, new_head, new_tail, new_num_items);
                 head = new_head;
                 tail = new_tail;
                 num_items = new_num_items;

--- a/storage/storage-interface/src/state_store/mod.rs
+++ b/storage/storage-interface/src/state_store/mod.rs
@@ -10,8 +10,9 @@ pub mod state_view;
 pub mod state_with_summary;
 pub mod versioned_state_value;
 
+use aptos_crypto::HashValue;
 use aptos_types::{
-    state_store::{hot_state::HotStateValue, state_key::StateKey, NUM_STATE_SHARDS},
+    state_store::{hot_state::HotStateValue, NUM_STATE_SHARDS},
     transaction::Version,
 };
 use std::collections::HashMap;
@@ -20,16 +21,16 @@ use std::collections::HashMap;
 pub struct HotStateShardUpdates {
     /// Each insertion carries the `HotStateValue` and an optional `value_version`.
     /// `value_version` is `Some(version)` for occupied entries and `None` for vacant.
-    pub insertions: HashMap<StateKey, (HotStateValue, Option<Version>)>,
+    pub insertions: HashMap<HashValue, (HotStateValue, Option<Version>)>,
     /// Each eviction carries the checkpoint version at which eviction happened.
     // TODO(HotState): per-block eviction tracking will be needed for cold-write elimination.
-    pub evictions: HashMap<StateKey, Version>,
+    pub evictions: HashMap<HashValue, Version>,
 }
 
 impl HotStateShardUpdates {
     pub fn new(
-        insertions: HashMap<StateKey, (HotStateValue, Option<Version>)>,
-        evictions: HashMap<StateKey, Version>,
+        insertions: HashMap<HashValue, (HotStateValue, Option<Version>)>,
+        evictions: HashMap<HashValue, Version>,
     ) -> Self {
         Self {
             insertions,

--- a/storage/storage-interface/src/state_store/state.rs
+++ b/storage/storage-interface/src/state_store/state.rs
@@ -20,6 +20,7 @@ use crate::{
 };
 use anyhow::{bail, Result};
 use aptos_config::config::HotStateConfig;
+use aptos_crypto::HashValue;
 use aptos_experimental_layered_map::{LayeredMap, MapLayer};
 use aptos_logger::warn;
 use aptos_metrics_core::TimerHelper;
@@ -38,8 +39,8 @@ use std::{collections::HashMap, num::NonZeroUsize, sync::Arc};
 
 #[derive(Clone, Debug, Default)]
 pub struct HotStateMetadata {
-    latest: Option<StateKey>,
-    oldest: Option<StateKey>,
+    latest: Option<HashValue>,
+    oldest: Option<HashValue>,
     num_items: usize,
 }
 
@@ -63,7 +64,7 @@ pub struct State {
     ///  N.b. this is not directly iterable, one needs to make a `StateDelta`
     ///       between this and a `base_version` to list the updates or create a
     ///       new `State` at a descendant version.
-    shards: Arc<[MapLayer<StateKey, StateSlot>; NUM_STATE_SHARDS]>,
+    shards: Arc<[MapLayer<HashValue, StateSlot>; NUM_STATE_SHARDS]>,
     hot_state_metadata: [HotStateMetadata; NUM_STATE_SHARDS],
     /// The total usage of the state at the current version.
     usage: StateStorageUsage,
@@ -73,7 +74,7 @@ pub struct State {
 impl State {
     pub fn new_with_updates(
         version: Option<Version>,
-        shards: Arc<[MapLayer<StateKey, StateSlot>; NUM_STATE_SHARDS]>,
+        shards: Arc<[MapLayer<HashValue, StateSlot>; NUM_STATE_SHARDS]>,
         hot_state_metadata: [HotStateMetadata; NUM_STATE_SHARDS],
         usage: StateStorageUsage,
         hot_state_config: HotStateConfig,
@@ -117,7 +118,7 @@ impl State {
         self.usage
     }
 
-    pub fn shards(&self) -> &[MapLayer<StateKey, StateSlot>; NUM_STATE_SHARDS] {
+    pub fn shards(&self) -> &[MapLayer<HashValue, StateSlot>; NUM_STATE_SHARDS] {
         &self.shards
     }
 
@@ -147,12 +148,12 @@ impl State {
             .all(|(base_shard, top_shard)| top_shard.can_view_after(base_shard))
     }
 
-    pub fn latest_hot_key(&self, shard_id: usize) -> Option<StateKey> {
-        self.hot_state_metadata[shard_id].latest.clone()
+    pub fn latest_hot_key(&self, shard_id: usize) -> Option<HashValue> {
+        self.hot_state_metadata[shard_id].latest
     }
 
-    pub fn oldest_hot_key(&self, shard_id: usize) -> Option<StateKey> {
-        self.hot_state_metadata[shard_id].oldest.clone()
+    pub fn oldest_hot_key(&self, shard_id: usize) -> Option<HashValue> {
+        self.hot_state_metadata[shard_id].oldest
     }
 
     pub fn num_hot_items(&self, shard_id: usize) -> usize {
@@ -207,8 +208,8 @@ impl State {
                         NonZeroUsize::new(self.hot_state_config.max_items_per_shard).unwrap(),
                         Arc::clone(&persisted_hot_state),
                         overlay,
-                        hot_metadata.latest.clone(),
-                        hot_metadata.oldest.clone(),
+                        hot_metadata.latest,
+                        hot_metadata.oldest,
                         hot_metadata.num_items,
                     );
                     let mut all_updates = per_version.iter();
@@ -218,7 +219,8 @@ impl State {
                         for (key, update) in
                             all_updates.take_while_ref(|(_k, u)| u.version <= *ckpt_version)
                         {
-                            evictions.remove(*key);
+                            let key_hash = *key.crypto_hash_ref();
+                            evictions.remove(&key_hash);
                             if let Some(insertion) = Self::apply_one_update(
                                 &mut lru,
                                 overlay,
@@ -227,18 +229,19 @@ impl State {
                                 update,
                                 self.hot_state_config.refresh_interval_versions,
                             ) {
-                                insertions.insert((*key).clone(), insertion);
+                                insertions.insert(key_hash, insertion);
                             }
                         }
                         // Only evict at the checkpoints.
-                        for (key, slot) in lru.maybe_evict() {
-                            insertions.remove(&key);
+                        for (key_hash, slot) in lru.maybe_evict() {
+                            insertions.remove(&key_hash);
                             assert!(slot.is_hot());
-                            evictions.insert(key, *ckpt_version);
+                            evictions.insert(key_hash, *ckpt_version);
                         }
                     }
                     for (key, update) in all_updates {
-                        evictions.remove(*key);
+                        let key_hash = *key.crypto_hash_ref();
+                        evictions.remove(&key_hash);
                         if let Some(insertion) = Self::apply_one_update(
                             &mut lru,
                             overlay,
@@ -247,7 +250,7 @@ impl State {
                             update,
                             self.hot_state_config.refresh_interval_versions,
                         ) {
-                            insertions.insert((*key).clone(), insertion);
+                            insertions.insert(key_hash, insertion);
                         }
                     }
 
@@ -294,14 +297,15 @@ impl State {
     /// determined that refresh is not necessary.
     fn apply_one_update(
         lru: &mut HotStateLRU,
-        overlay: &LayeredMap<StateKey, StateSlot>,
+        overlay: &LayeredMap<HashValue, StateSlot>,
         read_cache: &StateCacheShard,
         key: &StateKey,
         update: &StateUpdateRef,
         refresh_interval: Version,
     ) -> Option<(HotStateValue, Option<Version>)> {
+        let key_hash = *key.crypto_hash_ref();
         if let Some(state_value_opt) = update.state_op.as_state_value_opt() {
-            lru.insert((*key).clone(), update.to_result_slot().unwrap());
+            lru.insert(key, update.to_result_slot((*key).clone()).unwrap());
             let value_version = state_value_opt.map(|_| update.version);
             return Some((
                 HotStateValue::new(state_value_opt.cloned(), update.version),
@@ -309,7 +313,7 @@ impl State {
             ));
         }
 
-        if let Some(mut slot) = lru.get_slot(key) {
+        if let Some(mut slot) = lru.get_slot(&key_hash) {
             let mut refreshed = true;
             let slot_to_insert = if slot.is_hot() {
                 if slot.expect_hot_since_version() + refresh_interval <= update.version {
@@ -324,7 +328,7 @@ impl State {
             if refreshed {
                 let value_version = slot_to_insert.value_version_opt();
                 let ret = HotStateValue::clone_from_slot(&slot_to_insert);
-                lru.insert((*key).clone(), slot_to_insert);
+                lru.insert(key, slot_to_insert);
                 Some((ret, value_version))
             } else {
                 None
@@ -335,7 +339,7 @@ impl State {
             let value_version = slot.value_version_opt();
             let slot = slot.to_hot(update.version);
             let ret = HotStateValue::clone_from_slot(&slot);
-            lru.insert((*key).clone(), slot);
+            lru.insert(key, slot);
             Some((ret, value_version))
         }
     }
@@ -354,7 +358,7 @@ impl State {
 
     fn usage_delta_for_shard<'kv>(
         cache: &StateCacheShard,
-        overlay: &LayeredMap<StateKey, StateSlot>,
+        overlay: &LayeredMap<HashValue, StateSlot>,
         updates: &HashMap<&'kv StateKey, StateUpdateRef<'kv>>,
     ) -> (i64, i64) {
         let mut items_delta: i64 = 0;
@@ -383,11 +387,11 @@ impl State {
     }
 
     fn expect_old_slot(
-        overlay: &LayeredMap<StateKey, StateSlot>,
+        overlay: &LayeredMap<HashValue, StateSlot>,
         cache: &StateCacheShard,
         key: &StateKey,
     ) -> StateSlot {
-        if let Some(slot) = overlay.get(key) {
+        if let Some(slot) = overlay.get(key.crypto_hash_ref()) {
             return slot;
         }
 

--- a/storage/storage-interface/src/state_store/state_delta.rs
+++ b/storage/storage-interface/src/state_store/state_delta.rs
@@ -2,6 +2,7 @@
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::state_store::state::State;
+use aptos_crypto::HashValue;
 use aptos_experimental_layered_map::LayeredMap;
 use aptos_types::{
     state_store::{state_key::StateKey, state_slot::StateSlot, NUM_STATE_SHARDS},
@@ -20,7 +21,7 @@ use std::sync::Arc;
 pub struct StateDelta {
     pub base: State,
     pub current: State,
-    pub shards: Arc<[LayeredMap<StateKey, StateSlot>; NUM_STATE_SHARDS]>,
+    pub shards: Arc<[LayeredMap<HashValue, StateSlot>; NUM_STATE_SHARDS]>,
 }
 
 impl StateDelta {
@@ -49,14 +50,14 @@ impl StateDelta {
     /// Get the state update for a given state key.
     /// `None` indicates the key is not updated in the delta.
     pub fn get_state_slot(&self, state_key: &StateKey) -> Option<StateSlot> {
-        self.shards[state_key.get_shard_id()].get(state_key)
+        self.shards[state_key.get_shard_id()].get(state_key.crypto_hash_ref())
     }
 
-    pub fn latest_hot_key(&self, shard_id: usize) -> Option<StateKey> {
+    pub fn latest_hot_key(&self, shard_id: usize) -> Option<HashValue> {
         self.current.latest_hot_key(shard_id)
     }
 
-    pub fn oldest_hot_key(&self, shard_id: usize) -> Option<StateKey> {
+    pub fn oldest_hot_key(&self, shard_id: usize) -> Option<HashValue> {
         self.current.oldest_hot_key(shard_id)
     }
 }

--- a/storage/storage-interface/src/state_store/state_summary.rs
+++ b/storage/storage-interface/src/state_store/state_summary.rs
@@ -142,7 +142,7 @@ impl StateSummary {
                     .iter()
                     .map(|(k, (value, _))| (k, Some(value.hash())))
                     .chain(shard.evictions.keys().map(|k| (k, None)))
-                    .sorted_by_key(|(k, _)| k.crypto_hash_ref())
+                    .sorted_by_key(|(k, _)| *k)
                     .collect_vec()
             })
             .collect::<Vec<_>>();

--- a/storage/storage-interface/src/state_store/state_view/cached_state_view.rs
+++ b/storage/storage-interface/src/state_store/state_view/cached_state_view.rs
@@ -18,7 +18,9 @@ use anyhow::Result;
 use aptos_metrics_core::{IntCounterVecHelper, TimerHelper};
 use aptos_types::{
     state_store::{
-        state_key::StateKey, state_slot::StateSlot, state_storage_usage::StateStorageUsage,
+        state_key::StateKey,
+        state_slot::{StateSlot, StateSlotKind},
+        state_storage_usage::StateStorageUsage,
         StateViewId, StateViewResult, TStateView, NUM_STATE_SHARDS,
     },
     transaction::Version,
@@ -236,17 +238,18 @@ impl CachedStateView {
         let ret = if let Some(slot) = self.speculative.get_state_slot(state_key) {
             COUNTER.inc_with(&["sv_hit_speculative"]);
             slot
-        } else if let Some(slot) = self.hot.get_state_slot(state_key) {
+        } else if let Some(slot) = self.hot.get_state_slot(state_key.crypto_hash_ref()) {
             COUNTER.inc_with(&["sv_hit_hot"]);
             slot
         } else if let Some(base_version) = self.base_version() {
             COUNTER.inc_with(&["sv_cold"]);
             StateSlot::from_db_get(
+                state_key.clone(),
                 self.cold
                     .get_state_value_with_version_by_version(state_key, base_version)?,
             )
         } else {
-            StateSlot::ColdVacant
+            StateSlot::new(state_key.clone(), StateSlotKind::ColdVacant)
         };
 
         Ok(ret)

--- a/storage/storage-interface/src/state_store/state_view/db_state_view.rs
+++ b/storage/storage-interface/src/state_store/state_view/db_state_view.rs
@@ -60,7 +60,10 @@ impl TStateView for DbStateView {
     }
 
     fn get_state_slot(&self, state_key: &StateKey) -> StateViewResult<StateSlot> {
-        Ok(StateSlot::from_db_get(self.get(state_key)?))
+        Ok(StateSlot::from_db_get(
+            state_key.clone(),
+            self.get(state_key)?,
+        ))
     }
 
     fn get_usage(&self) -> StateViewResult<StateStorageUsage> {

--- a/storage/storage-interface/src/state_store/state_view/hot_state_view.rs
+++ b/storage/storage-interface/src/state_store/state_view/hot_state_view.rs
@@ -1,17 +1,18 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-use aptos_types::state_store::{state_key::StateKey, state_slot::StateSlot};
+use aptos_crypto::HashValue;
+use aptos_types::state_store::state_slot::StateSlot;
 
 /// A view into the hot state store, whose content overlays on top of the cold state store content.
 pub trait HotStateView: Send + Sync {
-    fn get_state_slot(&self, state_key: &StateKey) -> Option<StateSlot>;
+    fn get_state_slot(&self, key_hash: &HashValue) -> Option<StateSlot>;
 }
 
 pub struct EmptyHotState;
 
 impl HotStateView for EmptyHotState {
-    fn get_state_slot(&self, _state_key: &StateKey) -> Option<StateSlot> {
+    fn get_state_slot(&self, _key_hash: &HashValue) -> Option<StateSlot> {
         None
     }
 }

--- a/storage/storage-interface/src/state_store/versioned_state_value.rs
+++ b/storage/storage-interface/src/state_store/versioned_state_value.rs
@@ -2,7 +2,11 @@
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use aptos_types::{
-    state_store::{hot_state::LRUEntry, state_slot::StateSlot},
+    state_store::{
+        hot_state::LRUEntry,
+        state_key::StateKey,
+        state_slot::{StateSlot, StateSlotKind},
+    },
     transaction::Version,
     write_set::BaseStateOp,
 };
@@ -16,20 +20,20 @@ pub struct StateUpdateRef<'kv> {
 
 impl StateUpdateRef<'_> {
     /// NOTE: the lru_info in the result is not initialized yet.
-    pub fn to_result_slot(&self) -> Option<StateSlot> {
+    pub fn to_result_slot(&self, state_key: StateKey) -> Option<StateSlot> {
         match self.state_op.clone() {
             BaseStateOp::Creation(value) | BaseStateOp::Modification(value) => {
-                Some(StateSlot::HotOccupied {
+                Some(StateSlot::new(state_key, StateSlotKind::HotOccupied {
                     value_version: self.version,
                     value,
                     hot_since_version: self.version,
                     lru_info: LRUEntry::uninitialized(),
-                })
+                }))
             },
-            BaseStateOp::Deletion(_) => Some(StateSlot::HotVacant {
+            BaseStateOp::Deletion(_) => Some(StateSlot::new(state_key, StateSlotKind::HotVacant {
                 hot_since_version: self.version,
                 lru_info: LRUEntry::uninitialized(),
-            }),
+            })),
             BaseStateOp::MakeHot => None,
         }
     }

--- a/types/src/state_store/hot_state.rs
+++ b/types/src/state_store/hot_state.rs
@@ -2,7 +2,10 @@
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
-    state_store::{state_slot::StateSlot, state_value::StateValue},
+    state_store::{
+        state_slot::{StateSlot, StateSlotKind},
+        state_value::StateValue,
+    },
     transaction::Version,
 };
 use aptos_crypto::{
@@ -66,13 +69,13 @@ impl HotStateValue {
     }
 
     pub fn clone_from_slot(slot: &StateSlot) -> Self {
-        match slot {
-            StateSlot::HotOccupied {
+        match slot.kind() {
+            StateSlotKind::HotOccupied {
                 value,
                 hot_since_version,
                 ..
             } => Self::new(Some(value.clone()), *hot_since_version),
-            StateSlot::HotVacant {
+            StateSlotKind::HotVacant {
                 hot_since_version, ..
             } => Self::new(None, *hot_since_version),
             _ => panic!("Must be hot slot"),
@@ -97,13 +100,13 @@ impl<'a> HotStateValueRef<'a> {
     }
 
     pub fn from_slot(slot: &'a StateSlot) -> Self {
-        match slot {
-            StateSlot::HotOccupied {
+        match slot.kind() {
+            StateSlotKind::HotOccupied {
                 value,
                 hot_since_version,
                 ..
             } => Self::new(Some(value), *hot_since_version),
-            StateSlot::HotVacant {
+            StateSlotKind::HotVacant {
                 hot_since_version, ..
             } => Self::new(None, *hot_since_version),
             _ => panic!("Must be hot slot"),

--- a/types/src/state_store/mod.rs
+++ b/types/src/state_store/mod.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
+#[cfg(any(test, feature = "testing"))]
+use crate::state_store::state_slot::StateSlotKind;
 use crate::{
     account_address::AccountAddress,
     state_store::{
@@ -145,11 +147,14 @@ impl<K: Eq + Hash> MockStateView<K> {
         }
     }
 
+    // TODO(HotState): StateSlot now embeds a StateKey, but the generic MockStateView
+    // doesn't know how to derive one from K. Uses a placeholder for now; will be
+    // cleaned up when StateSlot.state_key becomes Option<StateKey>.
     pub fn new(data: std::collections::HashMap<K, StateValue>) -> Self {
         Self {
             data: data
                 .into_iter()
-                .map(|(k, v)| (k, StateSlot::from_db_get(Some((0, v)))))
+                .map(|(k, v)| (k, StateSlot::from_db_get(StateKey::raw(b""), Some((0, v)))))
                 .collect(),
         }
     }
@@ -168,7 +173,7 @@ impl<K: Clone + Eq + Hash> TStateView for MockStateView<K> {
             .data
             .get(state_key)
             .cloned()
-            .unwrap_or(StateSlot::ColdVacant))
+            .unwrap_or_else(|| StateSlot::new(StateKey::raw(b""), StateSlotKind::ColdVacant)))
     }
 
     fn get_usage(&self) -> StateViewResult<StateStorageUsage> {

--- a/types/src/state_store/state_slot.rs
+++ b/types/src/state_store/state_slot.rs
@@ -10,22 +10,27 @@ use crate::{
     transaction::Version,
 };
 use aptos_crypto::{hash::CryptoHash, HashValue};
-#[cfg(any(test, feature = "fuzzing"))]
-use proptest::prelude::*;
-use StateSlot::*;
+use StateSlotKind::*;
 
-/// Represents the content of a state slot, or the lack there of, along with information indicating
+/// Represents the content of a state slot along with its key and information about
 /// whether the slot is present in the cold or/and hot state.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct StateSlot {
+    state_key: StateKey,
+    kind: StateSlotKind,
+}
+
+/// The variant of a state slot.
 ///
 /// value_version: non-empty value changed at this version
 /// hot_since_version: the timestamp of a hot value / vacancy in the hot state, which determines
 ///                    the order of eviction
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub enum StateSlot {
+pub enum StateSlotKind {
     ColdVacant,
     HotVacant {
         hot_since_version: Version,
-        lru_info: LRUEntry<StateKey>,
+        lru_info: LRUEntry<HashValue>,
     },
     ColdOccupied {
         value_version: Version,
@@ -35,13 +40,25 @@ pub enum StateSlot {
         value_version: Version,
         value: StateValue,
         hot_since_version: Version,
-        lru_info: LRUEntry<StateKey>,
+        lru_info: LRUEntry<HashValue>,
     },
 }
 
 impl StateSlot {
+    pub fn new(state_key: StateKey, kind: StateSlotKind) -> Self {
+        Self { state_key, kind }
+    }
+
+    pub fn state_key(&self) -> &StateKey {
+        &self.state_key
+    }
+
+    pub fn kind(&self) -> &StateSlotKind {
+        &self.kind
+    }
+
     fn maybe_update_cold_state(&self, min_version: Version) -> Option<Option<&StateValue>> {
-        match self {
+        match &self.kind {
             ColdVacant => Some(None),
             HotVacant {
                 hot_since_version, ..
@@ -80,31 +97,30 @@ impl StateSlot {
     /// When committing speculative state to the DB, determine if to make changes to the JMT.
     pub fn maybe_update_jmt(
         &self,
-        key: StateKey,
         min_version: Version,
     ) -> Option<(HashValue, Option<(HashValue, StateKey)>)> {
-        let maybe_value_opt = self.maybe_update_cold_state(min_version);
-        maybe_value_opt.map(|value_opt| {
+        self.maybe_update_cold_state(min_version).map(|value_opt| {
             (
-                CryptoHash::hash(&key),
-                value_opt.map(|v| (CryptoHash::hash(v), key)),
+                *self.state_key.crypto_hash_ref(),
+                value_opt.map(|v| (CryptoHash::hash(v), self.state_key.clone())),
             )
         })
     }
 
     // TODO(HotState): db returns cold slot directly
-    pub fn from_db_get(tuple_opt: Option<(Version, StateValue)>) -> Self {
-        match tuple_opt {
-            None => Self::ColdVacant,
-            Some((value_version, value)) => Self::ColdOccupied {
+    pub fn from_db_get(state_key: StateKey, tuple_opt: Option<(Version, StateValue)>) -> Self {
+        let kind = match tuple_opt {
+            None => ColdVacant,
+            Some((value_version, value)) => ColdOccupied {
                 value_version,
                 value,
             },
-        }
+        };
+        Self { state_key, kind }
     }
 
     pub fn into_state_value_and_version_opt(self) -> Option<(Version, StateValue)> {
-        match self {
+        match self.kind {
             ColdVacant | HotVacant { .. } => None,
             ColdOccupied {
                 value_version,
@@ -119,14 +135,14 @@ impl StateSlot {
     }
 
     pub fn into_state_value_opt(self) -> Option<StateValue> {
-        match self {
+        match self.kind {
             ColdVacant | HotVacant { .. } => None,
             ColdOccupied { value, .. } | HotOccupied { value, .. } => Some(value),
         }
     }
 
     pub fn as_state_value_opt(&self) -> Option<&StateValue> {
-        match self {
+        match &self.kind {
             ColdVacant | HotVacant { .. } => None,
             ColdOccupied { value, .. } | HotOccupied { value, .. } => Some(value),
         }
@@ -137,28 +153,22 @@ impl StateSlot {
     }
 
     pub fn is_cold(&self) -> bool {
-        match self {
-            ColdVacant | ColdOccupied { .. } => true,
-            HotVacant { .. } | HotOccupied { .. } => false,
-        }
+        matches!(self.kind, ColdVacant | ColdOccupied { .. })
     }
 
     pub fn is_occupied(&self) -> bool {
-        match self {
-            ColdVacant | HotVacant { .. } => false,
-            ColdOccupied { .. } | HotOccupied { .. } => true,
-        }
+        matches!(self.kind, ColdOccupied { .. } | HotOccupied { .. })
     }
 
     pub fn size(&self) -> usize {
-        match self {
+        match &self.kind {
             ColdVacant | HotVacant { .. } => 0,
             ColdOccupied { value, .. } | HotOccupied { value, .. } => value.size(),
         }
     }
 
     pub fn hot_since_version_opt(&self) -> Option<Version> {
-        match self {
+        match &self.kind {
             ColdVacant | ColdOccupied { .. } => None,
             HotVacant {
                 hot_since_version, ..
@@ -174,7 +184,7 @@ impl StateSlot {
     }
 
     pub fn refresh(&mut self, version: Version) {
-        match self {
+        match &mut self.kind {
             HotOccupied {
                 hot_since_version, ..
             }
@@ -186,7 +196,7 @@ impl StateSlot {
     }
 
     pub fn value_version_opt(&self) -> Option<Version> {
-        match self {
+        match &self.kind {
             ColdVacant | HotVacant { .. } => None,
             ColdOccupied { value_version, .. } | HotOccupied { value_version, .. } => {
                 Some(*value_version)
@@ -199,7 +209,7 @@ impl StateSlot {
     }
 
     pub fn to_hot(self, hot_since_version: Version) -> Self {
-        match self {
+        let kind = match self.kind {
             ColdOccupied {
                 value_version,
                 value,
@@ -214,11 +224,15 @@ impl StateSlot {
                 lru_info: LRUEntry::uninitialized(),
             },
             _ => panic!("Should not be called on hot slots."),
+        };
+        Self {
+            state_key: self.state_key,
+            kind,
         }
     }
 
     pub fn to_cold(self) -> Self {
-        match self {
+        let kind = match self.kind {
             HotOccupied {
                 value_version,
                 value,
@@ -229,79 +243,42 @@ impl StateSlot {
             },
             HotVacant { .. } => ColdVacant,
             _ => panic!("Should not be called on cold slots."),
+        };
+        Self {
+            state_key: self.state_key,
+            kind,
         }
     }
 }
 
 impl THotStateSlot for StateSlot {
-    type Key = StateKey;
+    type Key = HashValue;
 
     fn prev(&self) -> Option<&Self::Key> {
-        match self {
+        match &self.kind {
             HotOccupied { lru_info, .. } | HotVacant { lru_info, .. } => lru_info.prev.as_ref(),
             _ => panic!("Should not be called on cold slots."),
         }
     }
 
     fn next(&self) -> Option<&Self::Key> {
-        match self {
+        match &self.kind {
             HotOccupied { lru_info, .. } | HotVacant { lru_info, .. } => lru_info.next.as_ref(),
             _ => panic!("Should not be called on cold slots."),
         }
     }
 
     fn set_prev(&mut self, prev: Option<Self::Key>) {
-        match self {
+        match &mut self.kind {
             HotOccupied { lru_info, .. } | HotVacant { lru_info, .. } => lru_info.prev = prev,
             _ => panic!("Should not be called on cold slots."),
         }
     }
 
     fn set_next(&mut self, next: Option<Self::Key>) {
-        match self {
+        match &mut self.kind {
             HotOccupied { lru_info, .. } | HotVacant { lru_info, .. } => lru_info.next = next,
             _ => panic!("Should not be called on cold slots."),
         }
-    }
-}
-
-#[cfg(any(test, feature = "fuzzing"))]
-impl Arbitrary for StateSlot {
-    type Parameters = ();
-    type Strategy = BoxedStrategy<Self>;
-
-    fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
-        let hot_vacant = any::<Version>().prop_map(|hot_since_version| HotVacant {
-            hot_since_version,
-            lru_info: LRUEntry::uninitialized(),
-        });
-        let cold_occupied =
-            (any::<Version>(), any::<StateValue>()).prop_map(|(value_version, value)| {
-                ColdOccupied {
-                    value_version,
-                    value,
-                }
-            });
-        let hot_occupied = (any::<Version>(), any::<StateValue>())
-            .prop_flat_map(|(value_version, value)| {
-                (
-                    Just(value_version),
-                    (value_version..Version::MAX),
-                    Just(value),
-                )
-            })
-            .prop_map(|(value_version, hot_since_version, value)| HotOccupied {
-                value_version,
-                value,
-                hot_since_version,
-                lru_info: LRUEntry::uninitialized(),
-            });
-        prop_oneof![
-            1 => Just(ColdVacant),
-            1 => hot_vacant,
-            2 => cold_occupied,
-            2 => hot_occupied,
-        ]
-        .boxed()
     }
 }


### PR DESCRIPTION

Refactor the state tracking pipeline so that `LayeredMap`, `StateDelta`,
`HotStateLRU`, `HotStateView`, and `HotStateBase` DashMaps are all keyed
by `HashValue` instead of `StateKey`. This enables reconstructing the hot
state LRU linked lists from the on-disk `hot_state_kv_db` on node startup,
since the DB schema only stores `HashValue` keys.

**`StateSlot`** becomes a struct wrapping `(StateKey, StateSlotKind)` so
that the `StateKey` travels with the value through the hash-keyed maps.
`StateSlotKind` is the old enum with variants `ColdVacant`, `HotVacant`,
`ColdOccupied`, `HotOccupied`. All existing methods delegate to the inner
kind, and `maybe_update_jmt` now uses the embedded key (no parameter).

**LRU pointers** (`LRUEntry`) change from `StateKey` to `HashValue`, so
`prev`/`next` in the doubly-linked list, `head`/`tail` in
`HotStateMetadata`, and `HotStateLRU.pending` are all `HashValue`-keyed.
This is the core change that makes DB-based LRU reconstruction possible.

**`HotStateView`** trait method changes from `get_state_slot(&StateKey)`
to `get_state_slot(&HashValue)`. The `LayeredHotStateView` (RCU layer in
aptosdb) does delta and DashMap lookups directly by hash.

**`HotStateShardUpdates`** insertions/evictions change from
`HashMap<StateKey, _>` to `HashMap<HashValue, _>`, removing redundant
hashing in the DB write path.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk because it refactors core state storage/hot-state caching and commit paths (LRU pointers, delta overlays, DB persistence) to new keying/slot representations, which could cause subtle state read/write or eviction inconsistencies if any call site is missed.
> 
> **Overview**
> Refactors the hot-state pipeline to be keyed by `HashValue` end-to-end (including `LayeredMap` shards, `StateDelta`, `HotStateLRU`, `HotStateView`, and AptosDB hot-state DashMaps), aligning in-memory structures with the on-disk hot-state KV schema and removing repeated hashing in persistence paths.
> 
> Changes `StateSlot` from an enum into a struct embedding the full `StateKey` plus a new `StateSlotKind` (the old variants), updates constructors/helpers (e.g., `from_db_get`, `maybe_update_jmt`) and updates callers/tests across storage, simulation, replay, validator interface, and resource viewer to pass/propagate the key and use the new `kind()`/`state_key()` APIs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3e3128878b3282188de3c3011415826e22da9ab0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->