### PR TITLE
[consensus] Add receiver-side check for encrypted batch txn limit

### DIFF
--- a/config/src/config/quorum_store_config.rs
+++ b/config/src/config/quorum_store_config.rs
@@ -75,6 +75,9 @@ pub struct QuorumStoreConfig {
     pub sender_max_total_bytes: usize,
     /// The maximum number of transactions a single batch received from peers could contain.
     pub receiver_max_batch_txns: usize,
+    /// The maximum number of transactions an encrypted batch received from peers could contain.
+    /// Stricter limit matching the sender side to protect the decryption pipeline.
+    pub receiver_max_encrypted_batch_txns: usize,
     /// The maximum number of bytes a single batch received from peers could contain.
     pub receiver_max_batch_bytes: usize,
     /// The maximum number of batches a BatchMsg received from peers can contain.
@@ -130,6 +133,7 @@ impl Default for QuorumStoreConfig {
             // TODO: on next release, remove DEFAULT_MAX_NUM_BATCHES * BATCH_PADDING_BYTES
             sender_max_total_bytes: 4 * 1024 * 1024 - DEFAULT_MAX_NUM_BATCHES * BATCH_PADDING_BYTES,
             receiver_max_batch_txns: 100,
+            receiver_max_encrypted_batch_txns: DEFAULT_MAX_ENCRYPTED_BATCH_TXNS,
             receiver_max_batch_bytes: 1024 * 1024 + BATCH_PADDING_BYTES,
             receiver_max_num_batches: 20,
             receiver_max_total_txns: 2000,
@@ -170,11 +174,13 @@ impl QuorumStoreConfig {
     pub fn default_for_dag() -> Self {
         Self {
             sender_max_batch_txns: 300,
+            sender_max_encrypted_batch_txns: 0,
             sender_max_batch_bytes: 4 * 1024 * 1024,
             sender_max_num_batches: 5,
             sender_max_total_txns: 500,
             sender_max_total_bytes: 8 * 1024 * 1024,
             receiver_max_batch_txns: 300,
+            receiver_max_encrypted_batch_txns: 0,
             receiver_max_batch_bytes: 4 * 1024 * 1024,
             receiver_max_num_batches: 5,
             receiver_max_total_txns: 500,
@@ -204,6 +210,11 @@ impl QuorumStoreConfig {
                 config.sender_max_batch_bytes,
                 config.receiver_max_batch_bytes,
                 "bytes",
+            ),
+            (
+                config.sender_max_encrypted_batch_txns,
+                config.receiver_max_encrypted_batch_txns,
+                "encrypted_batch_txns",
             ),
             (
                 config.sender_max_total_txns,
@@ -241,6 +252,11 @@ impl QuorumStoreConfig {
                 config.sender_max_batch_bytes,
                 config.sender_max_total_bytes,
                 "send_bytes",
+            ),
+            (
+                config.receiver_max_encrypted_batch_txns,
+                config.receiver_max_total_txns,
+                "recv_encrypted_txns",
             ),
             (
                 config.receiver_max_batch_txns,
@@ -382,6 +398,56 @@ mod test {
             &node_config,
             NodeType::Validator,
             Some(ChainId::testnet()),
+        )
+        .unwrap_err();
+        assert!(matches!(error, Error::ConfigSanitizerFailed(_, _)));
+    }
+
+    #[test]
+    fn test_send_recv_batch_limits_encrypted_txns() {
+        // Create a node config with invalid encrypted batch txn limits
+        let node_config = NodeConfig {
+            consensus: ConsensusConfig {
+                quorum_store: QuorumStoreConfig {
+                    sender_max_encrypted_batch_txns: 100,
+                    receiver_max_encrypted_batch_txns: 50,
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        // Sanitize the config and verify that it fails
+        let error = QuorumStoreConfig::sanitize(
+            &node_config,
+            NodeType::Validator,
+            Some(ChainId::mainnet()),
+        )
+        .unwrap_err();
+        assert!(matches!(error, Error::ConfigSanitizerFailed(_, _)));
+    }
+
+    #[test]
+    fn test_batch_total_limits_recv_encrypted_txns() {
+        // Create a node config where receiver_max_encrypted_batch_txns > receiver_max_total_txns
+        let node_config = NodeConfig {
+            consensus: ConsensusConfig {
+                quorum_store: QuorumStoreConfig {
+                    receiver_max_encrypted_batch_txns: 3000,
+                    receiver_max_total_txns: 2000,
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        // Sanitize the config and verify that it fails
+        let error = QuorumStoreConfig::sanitize(
+            &node_config,
+            NodeType::Validator,
+            Some(ChainId::mainnet()),
         )
         .unwrap_err();
         assert!(matches!(error, Error::ConfigSanitizerFailed(_, _)));

--- a/consensus/src/quorum_store/batch_coordinator.rs
+++ b/consensus/src/quorum_store/batch_coordinator.rs
@@ -15,7 +15,7 @@ use crate::{
 };
 use anyhow::ensure;
 use aptos_config::config::BatchTransactionFilterConfig;
-use aptos_consensus_types::proof_of_store::{BatchInfoExt, TBatchInfo};
+use aptos_consensus_types::proof_of_store::{BatchInfoExt, BatchKind, TBatchInfo};
 use aptos_logger::prelude::*;
 use aptos_short_hex_str::AsShortHexStr;
 use aptos_types::PeerId;
@@ -39,6 +39,7 @@ pub struct BatchCoordinator {
     sender_to_batch_generator: Arc<Sender<BatchGeneratorCommand>>,
     batch_store: Arc<BatchStore>,
     max_batch_txns: u64,
+    max_encrypted_batch_txns: u64,
     max_batch_bytes: u64,
     max_total_txns: u64,
     max_total_bytes: u64,
@@ -54,6 +55,7 @@ impl BatchCoordinator {
         sender_to_batch_generator: Sender<BatchGeneratorCommand>,
         batch_store: Arc<BatchStore>,
         max_batch_txns: u64,
+        max_encrypted_batch_txns: u64,
         max_batch_bytes: u64,
         max_total_txns: u64,
         max_total_bytes: u64,
@@ -67,6 +69,7 @@ impl BatchCoordinator {
             sender_to_batch_generator: Arc::new(sender_to_batch_generator),
             batch_store,
             max_batch_txns,
+            max_encrypted_batch_txns,
             max_batch_bytes,
             max_total_txns,
             max_total_bytes,
@@ -155,6 +158,14 @@ impl BatchCoordinator {
                 batch.num_txns(),
                 self.max_batch_txns,
             );
+            if batch.batch_info().batch_kind() == Some(BatchKind::Encrypted) {
+                ensure!(
+                    batch.num_txns() <= self.max_encrypted_batch_txns,
+                    "Exceeds encrypted batch txn limit {} > {}",
+                    batch.num_txns(),
+                    self.max_encrypted_batch_txns,
+                );
+            }
             ensure!(
                 batch.num_bytes() <= self.max_batch_bytes,
                 "Exceeds batch bytes limit {} > {}",

--- a/consensus/src/quorum_store/quorum_store_builder.rs
+++ b/consensus/src/quorum_store/quorum_store_builder.rs
@@ -328,6 +328,7 @@ impl InnerBuilder {
                 self.batch_generator_cmd_tx.clone(),
                 self.batch_store.clone().unwrap(),
                 self.config.receiver_max_batch_txns as u64,
+                self.config.receiver_max_encrypted_batch_txns as u64,
                 self.config.receiver_max_batch_bytes as u64,
                 self.config.receiver_max_total_txns as u64,
                 self.config.receiver_max_total_bytes as u64,

--- a/consensus/src/quorum_store/tests/batch_coordinator_test.rs
+++ b/consensus/src/quorum_store/tests/batch_coordinator_test.rs
@@ -137,6 +137,7 @@ fn create_batch_coordinator(
         sender_to_batch_generator,
         batch_store,
         10_000,
+        64,
         10_000,
         10_000,
         10_000,


### PR DESCRIPTION
## Summary
- Adds `receiver_max_encrypted_batch_txns` config field (default: 64) to enforce a stricter limit on encrypted batches received from peers, matching the sender-side limit
- Enforces the new limit in `BatchCoordinator::ensure_max_limits` when a batch has `BatchKind::Encrypted`
- Adds config sanitization checks (sender <= receiver, receiver encrypted <= receiver total) and corresponding tests

## Test plan
- [x] `cargo check -p aptos-config` passes
- [x] `cargo check -p aptos-consensus` passes
- [x] `cargo test -p aptos-config -- quorum_store` — 10 tests pass (2 new)
- [x] `cargo test -p aptos-consensus -- batch_coordinator` — 2 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)