### PR TITLE
better handling of self-ownership in object.move

### DIFF
--- a/aptos-move/framework/aptos-framework/doc/object.md
+++ b/aptos-move/framework/aptos-framework/doc/object.md
@@ -2357,6 +2357,10 @@ Note: intentionally not using <code>self</code> as first argument, as a.owns(b) 
         };
 
         <b>let</b> <a href="object.md#0x1_object">object</a> = <b>borrow_global</b>&lt;<a href="object.md#0x1_object_ObjectCore">ObjectCore</a>&gt;(current_address);
+        <b>if</b> (<a href="object.md#0x1_object">object</a>.owner == current_address) {
+            // hit a self-owned <a href="object.md#0x1_object">object</a>, no need <b>to</b> <b>continue</b>
+            <b>return</b> <b>false</b>;
+        };
         current_address = <a href="object.md#0x1_object">object</a>.owner;
     };
     <b>true</b>
@@ -2388,7 +2392,11 @@ to determine the identity of the starting point of ownership.
 <pre><code><b>public</b> <b>fun</b> <a href="object.md#0x1_object_root_owner">root_owner</a>&lt;T: key&gt;(self: <a href="object.md#0x1_object_Object">Object</a>&lt;T&gt;): <b>address</b> <b>acquires</b> <a href="object.md#0x1_object_ObjectCore">ObjectCore</a> {
     <b>let</b> obj_owner = self.<a href="object.md#0x1_object_owner">owner</a>();
     <b>while</b> (<a href="object.md#0x1_object_is_object">is_object</a>(obj_owner)) {
-        obj_owner = <a href="object.md#0x1_object_address_to_object">address_to_object</a>&lt;<a href="object.md#0x1_object_ObjectCore">ObjectCore</a>&gt;(obj_owner).<a href="object.md#0x1_object_owner">owner</a>();
+        <b>let</b> parent = <a href="object.md#0x1_object_address_to_object">address_to_object</a>&lt;<a href="object.md#0x1_object_ObjectCore">ObjectCore</a>&gt;(obj_owner).<a href="object.md#0x1_object_owner">owner</a>();
+        <b>if</b> (parent == obj_owner) {
+            <b>return</b> obj_owner;
+        };
+        obj_owner = parent;
     };
     obj_owner
 }

--- a/aptos-move/framework/aptos-framework/sources/object.move
+++ b/aptos-move/framework/aptos-framework/sources/object.move
@@ -690,6 +690,10 @@ module aptos_framework::object {
             };
 
             let object = borrow_global<ObjectCore>(current_address);
+            if (object.owner == current_address) {
+                // hit a self-owned object, no need to continue
+                return false;
+            };
             current_address = object.owner;
         };
         true
@@ -701,7 +705,11 @@ module aptos_framework::object {
     public fun root_owner<T: key>(self: Object<T>): address acquires ObjectCore {
         let obj_owner = self.owner();
         while (is_object(obj_owner)) {
-            obj_owner = address_to_object<ObjectCore>(obj_owner).owner();
+            let parent = address_to_object<ObjectCore>(obj_owner).owner();
+            if (parent == obj_owner) {
+                return obj_owner;
+            };
+            obj_owner = parent;
         };
         obj_owner
     }
@@ -984,6 +992,15 @@ module aptos_framework::object {
     }
 
     #[test(creator = @0x123)]
+    fun self_ownership_allowed(creator: &signer) {
+        let obj = create_simple_object(creator, b"1");
+        transfer(creator, obj, obj.object_address());
+
+        assert!(!owns(obj, signer::address_of(creator)));
+        assert!(owns(obj, obj.object_address()));
+    }
+
+    #[test(creator = @0x123)]
     #[expected_failure(abort_code = 131078, location = Self)]
     fun test_exceeding_maximum_object_nesting_owns_should_fail(creator: &signer) acquires ObjectCore {
         let obj1 = create_simple_object(creator, b"1");
@@ -1058,8 +1075,10 @@ module aptos_framework::object {
     #[expected_failure(abort_code = 131078, location = Self)]
     fun test_cyclic_ownership_owns_should_fail(creator: &signer) acquires ObjectCore {
         let obj1 = create_simple_object(creator, b"1");
+        let obj2 = create_simple_object(creator, b"2");
         // This creates a cycle (self-loop) in ownership.
-        transfer(creator, obj1, obj1.object_address());
+        transfer(creator, obj1, obj2.object_address());
+        transfer(creator, obj2, obj1.object_address());
         // This should fails as the ownership is cyclic.
         let _ = owns(obj1, signer::address_of(creator));
     }


### PR DESCRIPTION
## Description
 - `object::owns` currently runs abort if called on a self-owned object for a non-owner address. Fix makes it return false correctly
- `object::root_owner` currently runs infinite loop if called on self-owned object (or object recursively owned by self-owned object). Fix makes it return the address of the self-owned object, when reached

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core object ownership resolution to special-case self-owned ownership nodes, which could affect authorization/transfer checks that rely on `owns` or `root_owner`. Logic is small and covered by added tests, but touches widely used framework primitives.
> 
> **Overview**
> Improves handling of *self-owned objects* in `aptos_framework::object`.
> 
> `owns` now detects a self-owned `ObjectCore` during ownership-walk and returns `false` (instead of looping until max depth/aborting), and `root_owner` stops walking when it encounters a self-owned object and returns that object address as the root. Adds a new unit test asserting self-ownership is allowed and updates the cyclic-ownership test to use a 2-object cycle.
> 
> Docs (`doc/object.md`) are updated to match the new `owns`/`root_owner` behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d2093c7a70a5231ce3e0eeaacce851cd5bad561. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->