### PR TITLE
[replay-verify] Fix broken Humio queries and clarify PVC log messages

### DIFF
--- a/testsuite/replay-verify/main.py
+++ b/testsuite/replay-verify/main.py
@@ -56,7 +56,7 @@ logger = logging.getLogger(__name__)
 
 
 def construct_humio_url(
-    labels_run: str, pod_name: str, start_time: float, end_time: float
+    pod_name: str, start_time: float, end_time: float
 ) -> str:
     query = f'#k8s.cluster = "devinfra-usce1-0" | "k8s.pod_name" = "{pod_name}"'
 
@@ -310,7 +310,7 @@ class WorkerPod:
         return pod_status
 
     def get_humio_log_link(self):
-        return construct_humio_url(self.label, self.name, self.start_time, time.time())
+        return construct_humio_url(self.name, self.start_time, time.time())
 
 
 class TaskStats:


### PR DESCRIPTION
## Summary
- **Fix Humio queries**: The `k8s.labels.run` field is not available in Humio, causing all log links to return empty results. Replaced with `k8s.pod_name` filtering which is reliable — exact match for per-pod links, wildcard prefix match for aggregate mismatch links.
- **Clarify PVC log messages**: The "Waiting for the PVC to be bound..." message now explains that a large disk volume is being cloned from a snapshot and may take several minutes, preventing confusion during debugging.

## Test plan
- [ ] Trigger a replay-verify run and confirm the Humio links in the logs return results
- [ ] Verify the PVC binding log messages are clear during the cloning phase

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts Humio query construction and log messages; no changes to scheduling logic, data handling, or Kubernetes operations.
> 
> **Overview**
> Fixes broken Humio log links in `testsuite/replay-verify/main.py` by switching queries from `k8s.labels.run` to reliable `k8s.pod_name` filtering (exact per-pod links and a wildcard prefix match for aggregate transaction-mismatch searches).
> 
> Improves PVC cloning observability by expanding the “waiting for PVC to be bound” logs to explain the snapshot-clone delay and to indicate when it’s safe to start cloning additional PVCs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bffe66b62b015bb33e980f04ba254a3f9274ddcc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->