### PR TITLE
[execution] Replace ArcSwapOption with Mutex for BlockSTM txn inputs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -726,7 +726,6 @@ dependencies = [
  "aptos-vm-environment",
  "aptos-vm-logging",
  "aptos-vm-types",
- "arc-swap",
  "bcs 0.1.4",
  "bytes",
  "cfg-if",
@@ -745,7 +744,7 @@ dependencies = [
  "move-vm-types",
  "num_cpus",
  "once_cell",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.5",
  "proptest",
  "proptest-derive",
  "rand 0.7.3",
@@ -2213,7 +2212,7 @@ name = "aptos-in-memory-cache"
 version = "0.1.0"
 dependencies = [
  "get-size",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.5",
  "tokio",
 ]
 
@@ -3955,7 +3954,7 @@ dependencies = [
  "clap 4.5.60",
  "colored",
  "move-core-types",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.5",
  "rand 0.7.3",
  "serde",
  "tokio",
@@ -4252,7 +4251,7 @@ dependencies = [
  "aptos-infallible",
  "claims",
  "crossbeam",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.5",
  "proptest",
  "proptest-derive",
  "rayon",
@@ -4327,7 +4326,7 @@ dependencies = [
  "itertools 0.13.0",
  "lru",
  "once_cell",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.5",
  "proptest",
  "proptest-derive",
  "rand 0.7.3",
@@ -4773,7 +4772,7 @@ dependencies = [
  "move-binary-format",
  "move-core-types",
  "once_cell",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.5",
  "proptest",
  "serde",
 ]
@@ -5996,9 +5995,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.1.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "autometrics"
@@ -6231,7 +6230,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "457d7ed3f888dfd2c7af56d4975cade43c622f74bdcddfed6d4352f57acc6310"
 dependencies = [
  "futures-util",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.5",
  "portable-atomic",
  "tokio",
 ]
@@ -6892,9 +6891,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
@@ -8057,7 +8056,7 @@ dependencies = [
  "hashbrown 0.14.3",
  "lock_api",
  "once_cell",
- "parking_lot_core 0.9.10",
+ "parking_lot_core 0.9.12",
 ]
 
 [[package]]
@@ -8071,7 +8070,7 @@ dependencies = [
  "equivalent",
  "hashbrown 0.15.3",
  "lock_api",
- "parking_lot_core 0.9.10",
+ "parking_lot_core 0.9.12",
 ]
 
 [[package]]
@@ -11447,7 +11446,7 @@ dependencies = [
  "dashmap 5.5.3",
  "hashbrown 0.12.3",
  "once_cell",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.5",
 ]
 
 [[package]]
@@ -12031,9 +12030,9 @@ checksum = "db13adb97ab515a3691f56e4dbab09283d0b86cb45abd991d8634a9d6f501760"
 
 [[package]]
 name = "libc"
-version = "0.2.182"
+version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -12258,11 +12257,10 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "lock_api"
-version = "0.4.12"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
 dependencies = [
- "autocfg",
  "scopeguard",
 ]
 
@@ -12637,7 +12635,7 @@ version = "0.1.0"
 dependencies = [
  "bumpalo",
  "crossbeam-utils",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.5",
 ]
 
 [[package]]
@@ -12657,7 +12655,7 @@ dependencies = [
  "move-asm",
  "move-binary-format",
  "move-core-types",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.5",
 ]
 
 [[package]]
@@ -13532,7 +13530,7 @@ dependencies = [
  "move-vm-profiler",
  "move-vm-types",
  "once_cell",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.5",
  "serde",
  "smallbitvec",
  "test-case",
@@ -13589,7 +13587,7 @@ dependencies = [
  "move-binary-format",
  "move-core-types",
  "once_cell",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.5",
  "proptest",
  "rand 0.7.3",
  "serde",
@@ -13670,7 +13668,7 @@ checksum = "40a3eb6b7c682b65d1f631ec3176829d72ab450b3aacdd3f719bf220822e59ac"
 dependencies = [
  "libc",
  "once_cell",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.5",
  "thiserror 1.0.69",
  "widestring",
  "winapi 0.3.9",
@@ -14497,12 +14495,12 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.12.1"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.10",
+ "parking_lot_core 0.9.12",
 ]
 
 [[package]]
@@ -14521,15 +14519,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.10"
+version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.11",
+ "redox_syscall 0.5.18",
  "smallvec",
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
@@ -15158,7 +15156,7 @@ dependencies = [
  "mime",
  "multer 3.1.0",
  "nix 0.29.0",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.5",
  "percent-encoding",
  "pin-project-lite",
  "poem-derive",
@@ -15377,7 +15375,7 @@ dependencies = [
  "log",
  "nix 0.26.4",
  "once_cell",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.5",
  "protobuf",
  "protobuf-codegen-pure",
  "smallvec",
@@ -15699,7 +15697,7 @@ dependencies = [
  "fnv",
  "lazy_static",
  "memchr",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.5",
  "protobuf",
  "thiserror 1.0.69",
 ]
@@ -15712,7 +15710,7 @@ checksum = "504ee9ff529add891127c4827eb481bd69dc0ebc72e9a682e187db4caa60c3ca"
 dependencies = [
  "dtoa",
  "itoa",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.5",
  "prometheus-client-derive-encode",
 ]
 
@@ -16017,7 +16015,7 @@ dependencies = [
  "ahash 0.8.12",
  "equivalent",
  "hashbrown 0.14.3",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.5",
 ]
 
 [[package]]
@@ -16115,7 +16113,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51de85fb3fb6524929c8a2eb85e6b6d363de4e8c48f9e2c2eac4944abc181c93"
 dependencies = [
  "log",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.5",
  "scheduled-thread-pool",
 ]
 
@@ -16371,9 +16369,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.11"
+version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2f103c6d277498fbceb16e84d317e2a400f160f46904d5f5410848c829511a3"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags 2.11.0",
 ]
@@ -17200,7 +17198,7 @@ version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cbc66816425a074528352f5789333ecff06ca41b36b0b0efdfbb29edc391a19"
 dependencies = [
- "parking_lot 0.12.1",
+ "parking_lot 0.12.5",
 ]
 
 [[package]]
@@ -18047,9 +18045,9 @@ checksum = "75ce4f9dc4a41b4c3476cc925f1efb11b66df373a8fde5d4b8915fa91b5d995e"
 
 [[package]]
 name = "smallvec"
-version = "1.13.1"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "smawk"
@@ -18339,7 +18337,7 @@ checksum = "f91138e76242f575eb1d3b38b4f1362f10d3a43f47d182a5b359af488a02293b"
 dependencies = [
  "new_debug_unreachable",
  "once_cell",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.5",
  "phf_shared 0.10.0",
  "precomputed-hash",
 ]
@@ -19090,7 +19088,7 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.5",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2 0.6.2",
@@ -19143,7 +19141,7 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "log",
- "parking_lot 0.12.1",
+ "parking_lot 0.12.5",
  "percent-encoding",
  "phf 0.13.1",
  "pin-project-lite",

--- a/aptos-move/block-executor/Cargo.toml
+++ b/aptos-move/block-executor/Cargo.toml
@@ -27,7 +27,6 @@ aptos-types = { workspace = true }
 aptos-vm-environment = { workspace = true }
 aptos-vm-logging = { workspace = true }
 aptos-vm-types = { workspace = true }
-arc-swap = { workspace = true }
 bcs = { workspace = true }
 bytes = { workspace = true }
 cfg-if = { workspace = true }

--- a/aptos-move/block-executor/src/txn_last_input_output.rs
+++ b/aptos-move/block-executor/src/txn_last_input_output.rs
@@ -12,7 +12,6 @@ use crate::{
     txn_commit_hook::TransactionCommitHook,
     types::ReadWriteSummary,
 };
-use aptos_infallible::Mutex;
 use aptos_logger::error;
 use aptos_mvhashmap::{types::TxnIndex, MVHashMap};
 use aptos_types::{
@@ -23,13 +22,13 @@ use aptos_types::{
     vm::modules::AptosModuleExtension,
     write_set::WriteOp,
 };
-use arc_swap::ArcSwapOption;
 use crossbeam::utils::CachePadded;
 use fail::fail_point;
 use move_binary_format::CompiledModule;
 use move_core_types::{language_storage::ModuleId, value::MoveTypeLayout};
 use move_vm_runtime::{execution_tracing::Trace, Module, RuntimeEnvironment};
 use move_vm_types::delayed_values::delayed_field_id::DelayedFieldID;
+use parking_lot::Mutex;
 use std::{
     collections::{BTreeSet, HashMap, HashSet},
     fmt::Debug,
@@ -210,7 +209,7 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>> OutputWrapper<T, O> {
 }
 
 pub struct TxnLastInputOutput<T: Transaction, O: TransactionOutput<Txn = T>> {
-    inputs: Vec<CachePadded<ArcSwapOption<TxnInput<T>>>>, // txn_idx -> input (read set).
+    inputs: Vec<CachePadded<Mutex<Option<Arc<TxnInput<T>>>>>>, // txn_idx -> input (read set).
 
     output_wrappers: Vec<CachePadded<Mutex<OutputWrapper<T, O>>>>,
     // Used to record if the latest incarnation of a txn was a failure due to the
@@ -224,7 +223,7 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>> TxnLastInputOutput<T, O> {
     pub fn new(num_txns: TxnIndex) -> Self {
         Self {
             inputs: (0..num_txns)
-                .map(|_| CachePadded::new(ArcSwapOption::empty()))
+                .map(|_| CachePadded::new(Mutex::new(None)))
                 .collect(),
             output_wrappers: (0..num_txns)
                 .map(|_| {
@@ -254,7 +253,7 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>> TxnLastInputOutput<T, O> {
             block_gas_limit_type,
             user_txn_bytes_len,
         )?;
-        self.inputs[txn_idx as usize].store(Some(Arc::new(input)));
+        *self.inputs[txn_idx as usize].lock() = Some(Arc::new(input));
 
         Ok(())
     }
@@ -268,30 +267,25 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>> TxnLastInputOutput<T, O> {
         key: &T::Key,
         txn_idx: TxnIndex,
     ) -> Result<(TriompheArc<T::Value>, TriompheArc<MoveTypeLayout>), PanicError> {
-        self.inputs[txn_idx as usize].load().as_ref().map_or_else(
-            || {
-                Err(code_invariant_error(
-                    "Read must be recorded before fetching exchanged data".to_string(),
-                ))
-            },
-            |input| {
-                let data_read = input.get_by_kind(key, None, ReadKind::Value);
-                if let Some(DataRead::Versioned(_, value, Some(layout))) = data_read {
-                    Ok((value, layout))
-                } else {
-                    Err(code_invariant_error(format!(
-                        "Read value needing exchange {:?} not in Exchanged format",
-                        data_read
-                    )))
-                }
-            },
-        )
+        let guard = self.inputs[txn_idx as usize].lock();
+        let input = guard.as_ref().ok_or_else(|| {
+            code_invariant_error("Read must be recorded before fetching exchanged data".to_string())
+        })?;
+        let data_read = input.get_by_kind(key, None, ReadKind::Value);
+        if let Some(DataRead::Versioned(_, value, Some(layout))) = data_read {
+            Ok((value, layout))
+        } else {
+            Err(code_invariant_error(format!(
+                "Read value needing exchange {:?} not in Exchanged format",
+                data_read
+            )))
+        }
     }
 
     // Alongside the latest read set, returns the indicator of whether the latest
     // incarnation of the txn resulted in a speculative failure.
     pub(crate) fn read_set(&self, txn_idx: TxnIndex) -> Option<(Arc<TxnInput<T>>, bool)> {
-        let input = self.inputs[txn_idx as usize].load_full()?;
+        let input = Arc::clone(self.inputs[txn_idx as usize].lock().as_ref()?);
         let speculative_failure =
             self.speculative_failures[txn_idx as usize].load(Ordering::Relaxed);
         Some((input, speculative_failure))


### PR DESCRIPTION

`ArcSwapOption`'s lock-free read mechanism uses a global debt-tracking
array that every `store()` must scan (O(num_threads) with cross-core
cache-line traffic). In BlockSTM, `record()` is called after every
transaction execution by many worker threads, making
`arc_swap::debt::Debt::pay_all` a scalability bottleneck.

Profiling shows that `arc_swap::debt::Debt::pay_all` is among the top
few CPU hot spots, and this change yields a few percent improvement.

Replace with per-slot `Mutex<Option<Arc<...>>>`, similar to the per-slot
Mutex pattern used by the adjacent `output_wrappers` field. Both fields
now use `parking_lot::Mutex` (previously `output_wrappers` used
`aptos_infallible::Mutex`, which wraps `std::sync::Mutex`).

Per-slot contention is near-zero since different `txn_idx` values go to
different locks, and the critical sections are trivial (Arc clone or
brief data access). This also removes the `arc-swap` dependency from the
crate.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches BlockSTM’s concurrent state for recording/fetching per-transaction read sets; while the change is localized, it alters synchronization semantics and could impact performance or introduce subtle contention/ordering issues under load.
> 
> **Overview**
> Replaces lock-free `ArcSwapOption` storage of per-transaction captured read sets in `TxnLastInputOutput` with per-slot `parking_lot::Mutex<Option<Arc<_>>>`, updating `record()`, `read_set()`, and `fetch_exchanged_data()` to use mutex guards.
> 
> Removes the `arc-swap` dependency from `aptos-block-executor` and updates lock-related dependencies in `Cargo.lock` (notably `parking_lot`/`parking_lot_core`, plus minor transitive bumps like `lock_api`, `smallvec`, `libc`, `cfg-if`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2c6d47b34873452ec0809b31423dc7c92d6b33ca. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->