### PR TITLE
Increase gas limits for governance proposal simulation

### DIFF
--- a/aptos-move/aptos-release-builder/src/simulate.rs
+++ b/aptos-move/aptos-release-builder/src/simulate.rs
@@ -415,7 +415,7 @@ pub async fn simulate_multistep_proposal(
     print!("Creating and funding sender account.. ");
     std::io::stdout().flush()?;
     let mut rng = aptos_keygen::KeyGen::from_seed([0; 32]);
-    let balance = 100 * 1_0000_0000; // 100 APT
+    let balance = 1000 * 1_0000_0000; // 1000 APT
     let account = AccountData::new_from_seed(&mut rng, balance, 0);
     state_view.apply_write_set(&account.to_writeset())?;
     // TODO: should update coin info (total supply)
@@ -484,7 +484,7 @@ pub async fn simulate_multistep_proposal(
             .chain_id(chain_id.chain_id())
             .sequence_number(script_idx as u64)
             .gas_unit_price(gas_params.vm.txn.min_price_per_gas_unit.into())
-            .max_gas_amount(100000)
+            .max_gas_amount(5_000_000) // 5 million gas units => 5 APT max at 100 Octa/gas unit
             .ttl(u64::MAX)
             .sign();
 


### PR DESCRIPTION
## Summary
- Bump simulated sender account balance from 100 APT to 1000 APT
- Increase max gas amount from 100k to 5M gas units so larger multi-step governance proposals don't run out of gas during simulation

## Test plan
- [ ] Run governance proposal simulation with a large multi-step proposal and verify it completes without hitting gas limits

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts local governance proposal simulation parameters (account balance and `max_gas_amount`) to reduce false failures from insufficient funds/gas.
> 
> **Overview**
> Governance proposal simulation now provisions the sender with **1000 APT** (up from 100) and executes each script with a higher `max_gas_amount` (**5,000,000** up from 100,000).
> 
> This reduces simulation failures for larger multi-step proposals that previously hit funding or gas ceilings.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e08aff1022b4b5a4f0fe1f882b83f0f823b06352. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->