### PR TITLE
feat: proposal for OWS encrypted key backend

### DIFF
--- a/crates/aptos/src/ows_proposal.md
+++ b/crates/aptos/src/ows_proposal.md
@@ -1,0 +1,2 @@
+# OWS Keystore Proposal
+Proposes adding OWS as a key backend alongside the existing YAML config.


### PR DESCRIPTION
## Problem

\`.aptos/config.yaml\` stores private keys as plaintext hex. No encryption.

## Proposal

Add OWS as an alternative key backend via the \`ows-lib\` crate. Keys encrypted at rest (AES-256-GCM, scrypt KDF), decrypted only during signing.

See [openwallet.sh](https://openwallet.sh) for the standard.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because this PR only adds documentation and does not change runtime code paths or key-handling behavior.
> 
> **Overview**
> Adds `crates/aptos/src/ows_proposal.md`, a brief proposal describing adding OWS as an encrypted key backend alongside the existing YAML config.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b2e69aeb71c12dbcdeaad17827cb3fb38cced66c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->