### PR TITLE
[vm] Avoid cloning ModuleId in caches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3971,6 +3971,7 @@ dependencies = [
  "aptos-vm",
  "aptos-vm-environment",
  "aptos-vm-logging",
+ "hashbrown 0.14.3",
  "move-binary-format",
  "move-bytecode-utils",
  "move-core-types",
@@ -10478,6 +10479,7 @@ checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 dependencies = [
  "ahash 0.8.12",
  "allocator-api2",
+ "equivalent",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -644,7 +644,7 @@ google-cloud-storage = "0.13.0"
 group = "0.13"
 guppy = "0.17.5"
 handlebars = "4.2.2"
-hashbrown = "0.14.3"
+hashbrown = { version = "0.14.3", features = ["equivalent"] }
 heck = "0.4.1"
 hex = { version = "0.4.3", features = ["serde"] }
 hex-literal = "0.3.4"

--- a/aptos-move/aptos-resource-viewer/Cargo.toml
+++ b/aptos-move/aptos-resource-viewer/Cargo.toml
@@ -19,6 +19,7 @@ aptos-types = { workspace = true }
 aptos-vm = { workspace = true }
 aptos-vm-environment = { workspace = true }
 aptos-vm-logging = { workspace = true }
+hashbrown = { workspace = true }
 move-binary-format = { workspace = true }
 move-bytecode-utils = { workspace = true }
 move-core-types = { workspace = true }

--- a/aptos-move/aptos-resource-viewer/src/module_view.rs
+++ b/aptos-move/aptos-resource-viewer/src/module_view.rs
@@ -12,6 +12,7 @@ use aptos_vm_environment::{
     environment::AptosEnvironment, prod_configs::aptos_prod_deserializer_config,
 };
 use aptos_vm_logging::log_schema::AdapterLogSchema;
+use hashbrown::Equivalent;
 use move_binary_format::{
     deserializer::DeserializerConfig,
     errors::{Location, PartialVMError, VMResult},
@@ -29,7 +30,7 @@ use move_vm_types::{
     code::{ModuleCache, ModuleCode, ModuleCodeBuilder, UnsyncModuleCache},
     module_storage_error,
 };
-use std::{cell::RefCell, collections::HashMap, sync::Arc};
+use std::{cell::RefCell, collections::HashMap, hash::Hash, sync::Arc};
 
 pub struct ModuleView<'a, S> {
     module_cache: RefCell<HashMap<ModuleId, Arc<CompiledModule>>>,
@@ -196,9 +197,9 @@ impl<S: StateView> ModuleCache for CachedModuleView<S> {
             .insert_verified_module(key, verified_code, extension, version)
     }
 
-    fn get_module_or_build_with(
+    fn get_module_or_build_with<Q>(
         &self,
-        key: &Self::Key,
+        key: &Q,
         builder: &dyn ModuleCodeBuilder<
             Key = Self::Key,
             Deserialized = Self::Deserialized,
@@ -210,8 +211,11 @@ impl<S: StateView> ModuleCache for CachedModuleView<S> {
             Arc<ModuleCode<Self::Deserialized, Self::Verified, Self::Extension>>,
             Self::Version,
         )>,
-    > {
-        // Get the module that exists in cache.
+    >
+    where
+        Q: Hash + Equivalent<Self::Key>,
+        Self::Key: for<'a> From<&'a Q>,
+    {
         let (module, version) = match self.module_cache.get_module_or_build_with(key, builder)? {
             None => {
                 return Ok(None);
@@ -220,9 +224,10 @@ impl<S: StateView> ModuleCache for CachedModuleView<S> {
         };
 
         // Get the state value that exists in the actual state and compute the hash.
+        let key: Self::Key = Self::Key::from(key);
         let state_slot = self
             .state_view
-            .get_state_slot(&StateKey::module_id(key))
+            .get_state_slot(&StateKey::module_id(&key))
             .map_err(|err| module_storage_error!(key.address(), key.name(), err))?;
         let (value_version, state_value) = match state_slot.into_state_value_and_version_opt() {
             Some((value_version, state_value)) => (value_version as usize, state_value),

--- a/aptos-move/block-executor/src/captured_reads.rs
+++ b/aptos-move/block-executor/src/captured_reads.rs
@@ -33,6 +33,7 @@ use aptos_types::{
 use aptos_vm_types::resolver::ResourceGroupSize;
 use bytes::Bytes;
 use derivative::Derivative;
+use hashbrown::Equivalent;
 use move_binary_format::{
     errors::{Location, PartialVMError, PartialVMResult, VMResult},
     CompiledModule,
@@ -1036,10 +1037,13 @@ where
     }
 
     /// If the module has been previously read, returns it.
-    pub(crate) fn get_module_read(
+    pub(crate) fn get_module_read<Q>(
         &self,
-        key: &K,
-    ) -> CacheRead<Option<(Arc<ModuleCode<DC, VC, S>>, Option<TxnIndex>)>> {
+        key: &Q,
+    ) -> CacheRead<Option<(Arc<ModuleCode<DC, VC, S>>, Option<TxnIndex>)>>
+    where
+        Q: Hash + Equivalent<K>,
+    {
         match self.module_reads.get(key) {
             Some(ModuleRead::PerBlockCache(read)) => CacheRead::Hit(read.clone()),
             Some(ModuleRead::GlobalCache(read)) => {

--- a/aptos-move/block-executor/src/code_cache.rs
+++ b/aptos-move/block-executor/src/code_cache.rs
@@ -19,6 +19,7 @@ use aptos_types::{
 use aptos_vm_types::module_and_script_storage::module_storage::AptosModuleStorage;
 #[cfg(test)]
 use fail::fail_point;
+use hashbrown::Equivalent;
 use move_binary_format::{
     errors::{Location, PartialVMResult, VMResult},
     file_format::CompiledScript,
@@ -35,7 +36,7 @@ use move_vm_types::code::{
     ambassador_impl_ScriptCache, Code, ModuleCache, ModuleCode, ModuleCodeBuilder, ScriptCache,
     WithBytes,
 };
-use std::sync::Arc;
+use std::{hash::Hash, sync::Arc};
 
 impl<T: Transaction, S: TStateView<Key = T::Key>> WithRuntimeEnvironment for LatestView<'_, T, S> {
     fn runtime_environment(&self) -> &RuntimeEnvironment {
@@ -130,9 +131,9 @@ impl<T: Transaction, S: TStateView<Key = T::Key>> ModuleCache for LatestView<'_,
         }
     }
 
-    fn get_module_or_build_with(
+    fn get_module_or_build_with<Q>(
         &self,
-        key: &Self::Key,
+        key: &Q,
         builder: &dyn ModuleCodeBuilder<
             Key = Self::Key,
             Deserialized = Self::Deserialized,
@@ -144,7 +145,11 @@ impl<T: Transaction, S: TStateView<Key = T::Key>> ModuleCache for LatestView<'_,
             Arc<ModuleCode<Self::Deserialized, Self::Verified, Self::Extension>>,
             Self::Version,
         )>,
-    > {
+    >
+    where
+        Q: Hash + Equivalent<Self::Key>,
+        Self::Key: for<'a> From<&'a Q>,
+    {
         match &self.latest_view {
             ViewState::Sync(state) => {
                 // Check the transaction-level cache with already read modules first.
@@ -157,7 +162,7 @@ impl<T: Transaction, S: TStateView<Key = T::Key>> ModuleCache for LatestView<'_,
                     state
                         .captured_reads
                         .borrow_mut()
-                        .capture_global_cache_read(key.clone(), module.clone());
+                        .capture_global_cache_read(Self::Key::from(key), module.clone());
                     return Ok(Some((module, Self::Version::default())));
                 }
 
@@ -170,12 +175,15 @@ impl<T: Transaction, S: TStateView<Key = T::Key>> ModuleCache for LatestView<'_,
                 state
                     .captured_reads
                     .borrow_mut()
-                    .capture_per_block_cache_read(key.clone(), read.clone());
+                    .capture_per_block_cache_read(Self::Key::from(key), read.clone());
                 Ok(read)
             },
             ViewState::Unsync(state) => {
                 if let Some(module) = self.global_module_cache.get(key) {
-                    state.read_set.borrow_mut().capture_module_read(key.clone());
+                    state
+                        .read_set
+                        .borrow_mut()
+                        .capture_module_read(Self::Key::from(key));
                     return Ok(Some((module, Self::Version::default())));
                 }
 
@@ -184,7 +192,10 @@ impl<T: Transaction, S: TStateView<Key = T::Key>> ModuleCache for LatestView<'_,
                     .unsync_map
                     .module_cache()
                     .get_module_or_build_with(key, builder)?;
-                state.read_set.borrow_mut().capture_module_read(key.clone());
+                state
+                    .read_set
+                    .borrow_mut()
+                    .capture_module_read(Self::Key::from(key));
                 Ok(read)
             },
         }
@@ -201,9 +212,8 @@ impl<T: Transaction, S: TStateView<Key = T::Key>> AptosModuleStorage for LatestV
         address: &AccountAddress,
         module_name: &IdentStr,
     ) -> PartialVMResult<Option<StateValueMetadata>> {
-        let id = ModuleId::new(*address, module_name.to_owned());
         let result = self
-            .get_module_or_build_with(&id, self)
+            .get_module_or_build_with(&(address, module_name), self)
             .map_err(|err| err.to_partial())?;
 
         // In order to test the module cache with combinatorial tests, we embed the version

--- a/aptos-move/block-executor/src/code_cache_global.rs
+++ b/aptos-move/block-executor/src/code_cache_global.rs
@@ -9,7 +9,7 @@ use aptos_types::{
 };
 use aptos_vm_types::module_write_set::ModuleWrite;
 use dashmap::DashMap;
-use hashbrown::HashMap;
+use hashbrown::{Equivalent, HashMap};
 use move_binary_format::{errors::PartialVMResult, CompiledModule};
 use move_core_types::language_storage::ModuleId;
 use move_vm_runtime::{LayoutCacheEntry, Module, RuntimeEnvironment, StructKey};
@@ -129,7 +129,10 @@ where
 
     /// Returns the module stored in cache. If the module has not been cached, or it exists but is
     /// overridden, [None] is returned.
-    pub fn get(&self, key: &K) -> Option<Arc<ModuleCode<D, V, E>>> {
+    pub fn get<Q>(&self, key: &Q) -> Option<Arc<ModuleCode<D, V, E>>>
+    where
+        Q: Hash + Equivalent<K>,
+    {
         self.module_cache.get(key).and_then(|entry| {
             entry
                 .is_not_overridden()

--- a/third_party/move/move-core/types/src/language_storage.rs
+++ b/third_party/move/move-core/types/src/language_storage.rs
@@ -512,6 +512,18 @@ impl<'a> hashbrown::Equivalent<ModuleId> for (&'a AccountAddress, &'a IdentStr) 
     }
 }
 
+impl From<&ModuleId> for ModuleId {
+    fn from(id: &ModuleId) -> Self {
+        id.clone()
+    }
+}
+
+impl<'a> From<&(&'a AccountAddress, &'a IdentStr)> for ModuleId {
+    fn from(key: &(&'a AccountAddress, &'a IdentStr)) -> Self {
+        ModuleId::new(*key.0, key.1.to_owned())
+    }
+}
+
 impl Display for ModuleId {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         // Can't change, because it can be part of TransactionExecutionFailedEvent

--- a/third_party/move/move-vm/runtime/src/storage/implementations/unsync_module_storage.rs
+++ b/third_party/move/move-vm/runtime/src/storage/implementations/unsync_module_storage.rs
@@ -16,6 +16,7 @@ use crate::{
 };
 use ambassador::Delegate;
 use bytes::Bytes;
+use hashbrown::Equivalent;
 use move_binary_format::{errors::VMResult, CompiledModule};
 use move_core_types::{
     account_address::AccountAddress, identifier::IdentStr, language_storage::ModuleId,
@@ -27,7 +28,7 @@ use move_vm_types::{
     },
     sha3_256,
 };
-use std::{borrow::Borrow, ops::Deref, sync::Arc};
+use std::{borrow::Borrow, hash::Hash, ops::Deref, sync::Arc};
 
 /// Represents owned or borrowed types, similar to [std::borrow::Cow] but without enforcing
 /// [ToOwned] trait bound on types it stores. We use it to be able to construct different storages

--- a/third_party/move/move-vm/runtime/src/storage/module_storage.rs
+++ b/third_party/move/move-vm/runtime/src/storage/module_storage.rs
@@ -218,8 +218,9 @@ where
         address: &AccountAddress,
         module_name: &IdentStr,
     ) -> VMResult<bool> {
-        let id = ModuleId::new(*address, module_name.to_owned());
-        Ok(self.get_module_or_build_with(&id, self)?.is_some())
+        Ok(self
+            .get_module_or_build_with(&(address, module_name), self)?
+            .is_some())
     }
 
     fn unmetered_get_module_bytes(
@@ -227,9 +228,8 @@ where
         address: &AccountAddress,
         module_name: &IdentStr,
     ) -> VMResult<Option<Bytes>> {
-        let id = ModuleId::new(*address, module_name.to_owned());
         Ok(self
-            .get_module_or_build_with(&id, self)?
+            .get_module_or_build_with(&(address, module_name), self)?
             .map(|(module, _)| module.extension().bytes().clone()))
     }
 
@@ -238,9 +238,8 @@ where
         address: &AccountAddress,
         module_name: &IdentStr,
     ) -> VMResult<Option<([u8; 32], usize)>> {
-        let id = ModuleId::new(*address, module_name.to_owned());
         Ok(self
-            .get_module_or_build_with(&id, self)?
+            .get_module_or_build_with(&(address, module_name), self)?
             .map(|(module, _)| {
                 (
                     *module.extension().hash(),
@@ -254,9 +253,8 @@ where
         address: &AccountAddress,
         module_name: &IdentStr,
     ) -> VMResult<Option<usize>> {
-        let id = ModuleId::new(*address, module_name.to_owned());
         Ok(self
-            .get_module_or_build_with(&id, self)?
+            .get_module_or_build_with(&(address, module_name), self)?
             .map(|(module, _)| module.extension().size_in_bytes()))
     }
 
@@ -265,9 +263,8 @@ where
         address: &AccountAddress,
         module_name: &IdentStr,
     ) -> VMResult<Option<Arc<CompiledModule>>> {
-        let id = ModuleId::new(*address, module_name.to_owned());
         Ok(self
-            .get_module_or_build_with(&id, self)?
+            .get_module_or_build_with(&(address, module_name), self)?
             .map(|(module, _)| module.code().deserialized().clone()))
     }
 
@@ -276,14 +273,13 @@ where
         address: &AccountAddress,
         module_name: &IdentStr,
     ) -> VMResult<Option<Arc<Module>>> {
-        let id = ModuleId::new(*address, module_name.to_owned());
-
         // Look up the verified module in cache, if it is not there, or if the module is not yet
         // verified, we need to load & verify its transitive dependencies.
-        let (module, version) = match self.get_module_or_build_with(&id, self)? {
-            Some(module_and_version) => module_and_version,
-            None => return Ok(None),
-        };
+        let (module, version) =
+            match self.get_module_or_build_with(&(address, module_name), self)? {
+                Some(module_and_version) => module_and_version,
+                None => return Ok(None),
+            };
 
         if module.code().is_verified() {
             return Ok(Some(module.code().verified().clone()));
@@ -291,6 +287,7 @@ where
 
         let _timer =
             VM_TIMER.timer_with_label("unmetered_get_eagerly_verified_module [cache miss]");
+        let id = ModuleId::new(*address, module_name.to_owned());
         let mut visited = HashSet::new();
         visited.insert(id.clone());
         Ok(Some(visit_dependencies_and_verify(
@@ -308,13 +305,12 @@ where
         address: &AccountAddress,
         module_name: &IdentStr,
     ) -> VMResult<Option<Arc<Module>>> {
-        let id = ModuleId::new(*address, module_name.to_owned());
-
         // Look up the module in cache, if it is not there, we need to load it
-        let (module, version) = match self.get_module_or_build_with(&id, self)? {
-            Some(module_and_version) => module_and_version,
-            None => return Ok(None),
-        };
+        let (module, version) =
+            match self.get_module_or_build_with(&(address, module_name), self)? {
+                Some(module_and_version) => module_and_version,
+                None => return Ok(None),
+            };
 
         // If module is already verified, return it
         if module.code().is_verified() {
@@ -322,6 +318,7 @@ where
         }
 
         // Otherwise, load the module and its dependencies without verification
+        let id = ModuleId::new(*address, module_name.to_owned());
         let mut visited = HashSet::new();
         visited.insert(id.clone());
         Ok(Some(visit_dependencies_and_skip_verification(
@@ -425,10 +422,8 @@ where
     // non-local properties of the module.
     let mut verified_dependencies = vec![];
     for (addr, name) in locally_verified_code.immediate_dependencies_iter() {
-        let dependency_id = ModuleId::new(*addr, name.to_owned());
-
         let (dependency, dependency_version) = module_cache_with_context
-            .get_module_or_build_with(&dependency_id, module_cache_with_context)?
+            .get_module_or_build_with(&(addr, name), module_cache_with_context)?
             .ok_or_else(|| module_linker_error!(addr, name))?;
 
         // Dependency is already verified!
@@ -437,10 +432,11 @@ where
             continue;
         }
 
+        let dependency_id = ModuleId::new(*addr, name.to_owned());
         if visited.insert(dependency_id.clone()) {
             // Dependency is not verified, and we have not visited it yet.
             let verified_dependency = visit_dependencies_and_verify(
-                dependency_id.clone(),
+                dependency_id,
                 dependency,
                 dependency_version,
                 visited,
@@ -499,10 +495,8 @@ where
     // Step 2: Traverse and collect all immediate dependencies
     let mut loaded_dependencies = vec![];
     for (addr, name) in module.code().deserialized().immediate_dependencies_iter() {
-        let dependency_id = ModuleId::new(*addr, name.to_owned());
-
         let (dependency, dependency_version) = module_cache_with_context
-            .get_module_or_build_with(&dependency_id, module_cache_with_context)?
+            .get_module_or_build_with(&(addr, name), module_cache_with_context)?
             .ok_or_else(|| module_linker_error!(addr, name))?;
 
         // If dependency is already loaded, use it
@@ -511,10 +505,11 @@ where
             continue;
         }
 
+        let dependency_id = ModuleId::new(*addr, name.to_owned());
         if visited.insert(dependency_id.clone()) {
             // Dependency is not loaded, and we have not visited it yet
             let loaded_dependency = visit_dependencies_and_skip_verification(
-                dependency_id.clone(),
+                dependency_id,
                 dependency,
                 dependency_version,
                 visited,

--- a/third_party/move/move-vm/types/src/code/cache/module_cache.rs
+++ b/third_party/move/move-vm/types/src/code/cache/module_cache.rs
@@ -7,7 +7,7 @@ use crate::code::Code;
 use ambassador::delegatable_trait;
 use crossbeam::utils::CachePadded;
 use dashmap::DashMap;
-use hashbrown::HashMap;
+use hashbrown::{Equivalent, HashMap};
 use move_binary_format::errors::VMResult;
 use std::{cell::RefCell, cmp::Ordering, hash::Hash, mem, ops::Deref, sync::Arc};
 
@@ -120,10 +120,11 @@ pub trait ModuleCache {
 
     /// Ensures that the entry in the module cache is initialized using the provided initializer,
     /// if it was not stored before. Returns the stored module, or [None] if it does not exist. If
-    /// initialization fails, returns the error.
-    fn get_module_or_build_with(
+    /// initialization fails, returns the error. Accepts a generic query type to avoid unnecessary
+    /// key allocation on cache hits.
+    fn get_module_or_build_with<Q>(
         &self,
-        key: &Self::Key,
+        key: &Q,
         builder: &dyn ModuleCodeBuilder<
             Key = Self::Key,
             Deserialized = Self::Deserialized,
@@ -135,7 +136,11 @@ pub trait ModuleCache {
             Arc<ModuleCode<Self::Deserialized, Self::Verified, Self::Extension>>,
             Self::Version,
         )>,
-    >;
+    >
+    where
+        Q: Hash + Equivalent<Self::Key>,
+        Self::Key: for<'a> From<&'a Q>,
+        Self: Sized;
 
     /// Returns the number of modules in cache.
     fn num_modules(&self) -> usize;
@@ -332,9 +337,9 @@ where
         }
     }
 
-    fn get_module_or_build_with(
+    fn get_module_or_build_with<Q>(
         &self,
-        key: &Self::Key,
+        key: &Q,
         builder: &dyn ModuleCodeBuilder<
             Key = Self::Key,
             Deserialized = Self::Deserialized,
@@ -346,16 +351,24 @@ where
             Arc<ModuleCode<Self::Deserialized, Self::Verified, Self::Extension>>,
             Self::Version,
         )>,
-    > {
-        use hashbrown::hash_map::Entry::*;
+    >
+    where
+        Q: Hash + Equivalent<Self::Key>,
+        Self::Key: for<'a> From<&'a Q>,
+    {
+        if let Some(v) = self.module_cache.borrow().get(key) {
+            return Ok(Some(v.as_module_code_and_version()));
+        }
 
-        Ok(match self.module_cache.borrow_mut().entry(key.clone()) {
-            Occupied(entry) => Some(entry.get().as_module_code_and_version()),
-            Vacant(entry) => builder.build(key)?.map(|module| {
-                entry
-                    .insert(VersionedModuleCode::new_with_default_version(module))
-                    .as_module_code_and_version()
-            }),
+        let key = Self::Key::from(key);
+        Ok(match builder.build(&key)? {
+            Some(m) => {
+                let m = VersionedModuleCode::new_with_default_version(m);
+                let result = m.as_module_code_and_version();
+                self.module_cache.borrow_mut().insert(key, m);
+                Some(result)
+            },
+            None => None,
         })
     }
 
@@ -486,9 +499,9 @@ where
         }
     }
 
-    fn get_module_or_build_with(
+    fn get_module_or_build_with<Q>(
         &self,
-        key: &Self::Key,
+        key: &Q,
         builder: &dyn ModuleCodeBuilder<
             Key = Self::Key,
             Deserialized = Self::Deserialized,
@@ -500,16 +513,23 @@ where
             Arc<ModuleCode<Self::Deserialized, Self::Verified, Self::Extension>>,
             Self::Version,
         )>,
-    > {
+    >
+    where
+        Q: Hash + Equivalent<Self::Key>,
+        Self::Key: for<'a> From<&'a Q>,
+    {
         use dashmap::mapref::entry::Entry::*;
 
+        // Fast path: equivalent lookup without key allocation.
         if let Some(v) = self.module_cache.get(key).as_deref() {
             return Ok(Some(v.as_module_code_and_version()));
         }
 
-        Ok(match self.module_cache.entry(key.clone()) {
+        // Slow path: allocate key for insertion.
+        let key = Self::Key::from(key);
+        Ok(match self.module_cache.entry(key) {
             Occupied(entry) => Some(entry.get().as_module_code_and_version()),
-            Vacant(entry) => builder.build(key)?.map(|module| {
+            Vacant(entry) => builder.build(entry.key())?.map(|module| {
                 entry
                     .insert(CachePadded::new(
                         VersionedModuleCode::new_with_default_version(module),
@@ -532,12 +552,21 @@ mod test {
     use move_binary_format::errors::{Location, PartialVMError};
     use move_core_types::vm_status::StatusCode;
 
+    #[derive(Clone, Debug, Eq, Hash, PartialEq)]
+    struct TestKey(usize);
+
+    impl From<&TestKey> for TestKey {
+        fn from(key: &TestKey) -> Self {
+            key.clone()
+        }
+    }
+
     struct Unreachable;
 
     impl ModuleCodeBuilder for Unreachable {
         type Deserialized = MockDeserializedCode;
         type Extension = MockExtension;
-        type Key = usize;
+        type Key = TestKey;
         type Verified = MockVerifiedCode;
 
         fn build(
@@ -554,7 +583,7 @@ mod test {
     impl ModuleCodeBuilder for WithSomeValue {
         type Deserialized = MockDeserializedCode;
         type Extension = MockExtension;
-        type Key = usize;
+        type Key = TestKey;
         type Verified = MockVerifiedCode;
 
         fn build(
@@ -572,7 +601,7 @@ mod test {
     impl ModuleCodeBuilder for WithNone {
         type Deserialized = MockDeserializedCode;
         type Extension = MockExtension;
-        type Key = usize;
+        type Key = TestKey;
         type Verified = MockVerifiedCode;
 
         fn build(
@@ -589,7 +618,7 @@ mod test {
     impl ModuleCodeBuilder for WithError {
         type Deserialized = MockDeserializedCode;
         type Extension = MockExtension;
-        type Key = usize;
+        type Key = TestKey;
         type Verified = MockVerifiedCode;
 
         fn build(
@@ -603,7 +632,7 @@ mod test {
 
     fn insert_deserialized_test_case(
         module_cache: &impl ModuleCache<
-            Key = usize,
+            Key = TestKey,
             Deserialized = MockDeserializedCode,
             Verified = MockVerifiedCode,
             Extension = MockExtension,
@@ -612,13 +641,13 @@ mod test {
     ) {
         // New entries at version 0.
         assert_ok!(module_cache.insert_deserialized_module(
-            1,
+            TestKey(1),
             MockDeserializedCode::new(1),
             mock_extension(8),
             0
         ));
         assert_ok!(module_cache.insert_deserialized_module(
-            2,
+            TestKey(2),
             MockDeserializedCode::new(2),
             mock_extension(8),
             0
@@ -626,47 +655,47 @@ mod test {
 
         assert_eq!(module_cache.num_modules(), 2);
         let deserialized_module_1 = assert_some!(assert_ok!(
-            module_cache.get_module_or_build_with(&1, &Unreachable)
+            module_cache.get_module_or_build_with(&TestKey(1), &Unreachable)
         ))
         .0;
         assert_eq!(deserialized_module_1.code().deserialized().value(), 1);
         let deserialized_module_2 = assert_some!(assert_ok!(
-            module_cache.get_module_or_build_with(&2, &Unreachable)
+            module_cache.get_module_or_build_with(&TestKey(2), &Unreachable)
         ))
         .0;
         assert_eq!(deserialized_module_2.code().deserialized().value(), 2);
 
         // Module cache already stores deserialized code at the same version.
         assert_ok!(module_cache.insert_deserialized_module(
-            1,
+            TestKey(1),
             MockDeserializedCode::new(10),
             mock_extension(8),
             0
         ));
         assert_eq!(module_cache.num_modules(), 2);
         let deserialized_module = assert_some!(assert_ok!(
-            module_cache.get_module_or_build_with(&1, &Unreachable)
+            module_cache.get_module_or_build_with(&TestKey(1), &Unreachable)
         ))
         .0;
         assert_eq!(deserialized_module.code().deserialized().value(), 1);
 
         // Module cache stores deserialized code at lower version, so it should be replaced.
         assert_ok!(module_cache.insert_deserialized_module(
-            1,
+            TestKey(1),
             MockDeserializedCode::new(100),
             mock_extension(8),
             10
         ));
         assert_eq!(module_cache.num_modules(), 2);
         let deserialized_module = assert_some!(assert_ok!(
-            module_cache.get_module_or_build_with(&1, &Unreachable)
+            module_cache.get_module_or_build_with(&TestKey(1), &Unreachable)
         ))
         .0;
         assert_eq!(deserialized_module.code().deserialized().value(), 100);
 
         // We already have higher-versioned deserialized code stored.
         let result = module_cache.insert_deserialized_module(
-            1,
+            TestKey(1),
             MockDeserializedCode::new(100),
             mock_extension(8),
             5,
@@ -675,7 +704,7 @@ mod test {
 
         // Store verified module at version 10.
         assert_ok!(module_cache.insert_verified_module(
-            3,
+            TestKey(3),
             MockVerifiedCode::new(3),
             mock_extension(8),
             10
@@ -684,7 +713,7 @@ mod test {
 
         // Lower-version cannot replace this module.
         let result = module_cache.insert_deserialized_module(
-            3,
+            TestKey(3),
             MockDeserializedCode::new(30),
             mock_extension(8),
             0,
@@ -693,43 +722,43 @@ mod test {
 
         // Same version does not replace the stored module, so old value should be returned.
         assert_ok!(module_cache.insert_deserialized_module(
-            3,
+            TestKey(3),
             MockDeserializedCode::new(300),
             mock_extension(8),
             10
         ));
         assert_eq!(module_cache.num_modules(), 3);
         let deserialized_module = assert_some!(assert_ok!(
-            module_cache.get_module_or_build_with(&3, &Unreachable)
+            module_cache.get_module_or_build_with(&TestKey(3), &Unreachable)
         ))
         .0;
         assert_eq!(deserialized_module.code().deserialized().value(), 3);
 
         // If the version is higher, we replace the module even though it was verified before.
         assert_ok!(module_cache.insert_deserialized_module(
-            3,
+            TestKey(3),
             MockDeserializedCode::new(3000),
             mock_extension(8),
             20
         ));
         assert_eq!(module_cache.num_modules(), 3);
         let deserialized_module = assert_some!(assert_ok!(
-            module_cache.get_module_or_build_with(&3, &Unreachable)
+            module_cache.get_module_or_build_with(&TestKey(3), &Unreachable)
         ))
         .0;
         assert_eq!(deserialized_module.code().deserialized().value(), 3000);
 
         // Check states.
         let module_1 = assert_some!(assert_ok!(
-            module_cache.get_module_or_build_with(&1, &Unreachable)
+            module_cache.get_module_or_build_with(&TestKey(1), &Unreachable)
         ))
         .0;
         let module_2 = assert_some!(assert_ok!(
-            module_cache.get_module_or_build_with(&2, &Unreachable)
+            module_cache.get_module_or_build_with(&TestKey(2), &Unreachable)
         ))
         .0;
         let module_3 = assert_some!(assert_ok!(
-            module_cache.get_module_or_build_with(&3, &Unreachable)
+            module_cache.get_module_or_build_with(&TestKey(3), &Unreachable)
         ))
         .0;
         assert!(matches!(module_1.code(), Code::Deserialized(s) if s.value() == 100));
@@ -739,7 +768,7 @@ mod test {
 
     fn insert_verified_test_case(
         module_cache: &impl ModuleCache<
-            Key = usize,
+            Key = TestKey,
             Deserialized = MockDeserializedCode,
             Verified = MockVerifiedCode,
             Extension = MockExtension,
@@ -748,13 +777,13 @@ mod test {
     ) {
         // New verified entries at version 10.
         let verified_module_1 = assert_ok!(module_cache.insert_verified_module(
-            1,
+            TestKey(1),
             MockVerifiedCode::new(1),
             mock_extension(8),
             10,
         ));
         let verified_module_2 = assert_ok!(module_cache.insert_verified_module(
-            2,
+            TestKey(2),
             MockVerifiedCode::new(2),
             mock_extension(8),
             10
@@ -768,19 +797,19 @@ mod test {
         // Module cache already stores verified code at the same version (10), so inserting new
         // code is a noop.
         assert_ok!(module_cache.insert_deserialized_module(
-            2,
+            TestKey(2),
             MockDeserializedCode::new(20),
             mock_extension(8),
             10
         ));
         assert_eq!(module_cache.num_modules(), 2);
         let deserialized_module = assert_some!(assert_ok!(
-            module_cache.get_module_or_build_with(&2, &Unreachable)
+            module_cache.get_module_or_build_with(&TestKey(2), &Unreachable)
         ))
         .0;
         assert_eq!(deserialized_module.code().deserialized().value(), 2);
         let verified_module = assert_ok!(module_cache.insert_verified_module(
-            2,
+            TestKey(2),
             MockVerifiedCode::new(200),
             mock_extension(8),
             10
@@ -790,14 +819,14 @@ mod test {
 
         // Module cache does not add verified or deserialized code at lower versions (0).
         let result = module_cache.insert_deserialized_module(
-            1,
+            TestKey(1),
             MockDeserializedCode::new(10),
             mock_extension(8),
             0,
         );
         assert!(result.is_err());
         let result = module_cache.insert_verified_module(
-            1,
+            TestKey(1),
             MockVerifiedCode::new(100),
             mock_extension(8),
             0,
@@ -806,21 +835,21 @@ mod test {
 
         // Higher versions should be inserted, whether they are verified or deserialized.
         assert_ok!(module_cache.insert_deserialized_module(
-            1,
+            TestKey(1),
             MockDeserializedCode::new(1000),
             mock_extension(8),
             100
         ));
         assert_eq!(module_cache.num_modules(), 2);
         let deserialized_module = assert_some!(assert_ok!(
-            module_cache.get_module_or_build_with(&1, &Unreachable)
+            module_cache.get_module_or_build_with(&TestKey(1), &Unreachable)
         ))
         .0;
         assert!(!deserialized_module.code().is_verified());
         assert_eq!(deserialized_module.code().deserialized().value(), 1000);
 
         let verified_module = assert_ok!(module_cache.insert_verified_module(
-            1,
+            TestKey(1),
             MockVerifiedCode::new(10_000),
             mock_extension(8),
             1000
@@ -831,11 +860,11 @@ mod test {
 
         // Check states.
         let module_1 = assert_some!(assert_ok!(
-            module_cache.get_module_or_build_with(&1, &Unreachable)
+            module_cache.get_module_or_build_with(&TestKey(1), &Unreachable)
         ))
         .0;
         let module_2 = assert_some!(assert_ok!(
-            module_cache.get_module_or_build_with(&2, &Unreachable)
+            module_cache.get_module_or_build_with(&TestKey(2), &Unreachable)
         ))
         .0;
         assert!(matches!(module_1.code(), Code::Verified(s) if s.value() == 10_000));
@@ -844,7 +873,7 @@ mod test {
 
     fn get_module_or_initialize_with_test_case(
         module_cache: &impl ModuleCache<
-            Key = usize,
+            Key = TestKey,
             Deserialized = MockDeserializedCode,
             Verified = MockVerifiedCode,
             Extension = MockExtension,
@@ -852,49 +881,49 @@ mod test {
         >,
     ) {
         assert_ok!(module_cache.insert_deserialized_module(
-            1,
+            TestKey(1),
             MockDeserializedCode::new(1),
             mock_extension(8),
             0
         ));
         assert_ok!(module_cache.insert_verified_module(
-            2,
+            TestKey(2),
             MockVerifiedCode::new(2),
             mock_extension(8),
             0
         ));
 
         // Get existing deserialized module.
-        let result = module_cache.get_module_or_build_with(&1, &WithSomeValue(100));
+        let result = module_cache.get_module_or_build_with(&TestKey(1), &WithSomeValue(100));
         let module_1 = assert_some!(assert_ok!(result)).0;
         assert!(!module_1.code().is_verified());
         assert_eq!(module_1.code().deserialized().value(), 1);
 
         // Get existing verified module.
-        let result = module_cache.get_module_or_build_with(&2, &WithError);
+        let result = module_cache.get_module_or_build_with(&TestKey(2), &WithError);
         let module_2 = assert_some!(assert_ok!(result)).0;
         assert!(module_2.code().is_verified());
         assert_eq!(module_2.code().deserialized().value(), 2);
 
         // Error when initializing.
         assert!(module_cache
-            .get_module_or_build_with(&3, &WithError)
+            .get_module_or_build_with(&TestKey(3), &WithError)
             .is_err());
         assert_eq!(module_cache.num_modules(), 2);
 
         // Module does not exist.
-        let result = module_cache.get_module_or_build_with(&3, &WithNone);
+        let result = module_cache.get_module_or_build_with(&TestKey(3), &WithNone);
         assert!(assert_ok!(result).is_none());
         assert_eq!(module_cache.num_modules(), 2);
 
         // Successful initialization.
-        let result = module_cache.get_module_or_build_with(&3, &WithSomeValue(300));
+        let result = module_cache.get_module_or_build_with(&TestKey(3), &WithSomeValue(300));
         let module_3 = assert_some!(assert_ok!(result)).0;
         assert!(!module_3.code().is_verified());
         assert_eq!(module_3.code().deserialized().value(), 300);
         assert_eq!(module_cache.num_modules(), 3);
 
-        let result = module_cache.get_module_or_build_with(&3, &WithSomeValue(1000));
+        let result = module_cache.get_module_or_build_with(&TestKey(3), &WithSomeValue(1000));
         let module_3 = assert_some!(assert_ok!(result)).0;
         assert!(!module_3.code().is_verified());
         assert_eq!(module_3.code().deserialized().value(), 300);


### PR DESCRIPTION
## Description

Add support for generic `Equivalent`-based lookups throughout the module cache stack to avoid unnecessary `ModuleId` cloning on read paths.

## How Has This Been Tested?

Existing tests

## Type of Change
- [x] Performance improvement
- [x] Refactoring

## Which Components or Systems Does This Change Impact?
- [x] Move/Aptos Virtual Machine

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core module-loading/cache lookup paths across the VM and block executor; while largely mechanical, mistakes could cause cache misses/hits to change or incorrect module/version validation.
> 
> **Overview**
> **Performance-focused refactor:** module cache lookups now accept generic query keys (`Q: Hash + Equivalent<K>`) so callers can query caches with borrowed forms (e.g. `(&AccountAddress, &IdentStr)`) instead of allocating/cloning full `ModuleId`s on cache hits.
> 
> This change is threaded through `move-vm` (`ModuleCache::get_module_or_build_with`, `ModuleStorage` helpers), Aptos block executor caches (`GlobalModuleCache::get`, captured module read tracking), and `aptos-resource-viewer`, with small supporting additions like `From<&Q> for ModuleId` and enabling `hashbrown`’s `equivalent` feature in workspace deps and lockfile.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cbef5a8ef46db8a0bb395369ed060af3b25971bb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->