### PR TITLE
[vm] Calibrate e2e benchmark

### DIFF
--- a/aptos-move/e2e-benchmark/data/calibration_values.tsv
+++ b/aptos-move/e2e-benchmark/data/calibration_values.tsv
@@ -1,42 +1,42 @@
-Loop { loop_count: Some(100000), loop_type: NoOp }	10	0.992	1.076	25868.8
-Loop { loop_count: Some(10000), loop_type: Arithmetic }	10	0.992	1.090	15738.3
-CreateObjects { num_objects: 10, object_payload_size: 0 }	10	0.989	1.012	73.0
-CreateObjects { num_objects: 10, object_payload_size: 10240 }	10	0.995	1.062	5719.7
-CreateObjects { num_objects: 100, object_payload_size: 0 }	10	0.990	1.013	692.3
-CreateObjects { num_objects: 100, object_payload_size: 10240 }	10	0.995	1.050	6750.8
-InitializeVectorPicture { length: 128 }	10	0.992	1.044	88.1
-VectorPicture { length: 128 }	10	0.995	1.010	26.8
-VectorPictureRead { length: 128 }	10	0.980	1.016	26.2
-InitializeVectorPicture { length: 30720 }	10	0.994	1.061	15708.1
-VectorPicture { length: 30720 }	10	0.993	1.014	4358.4
-VectorPictureRead { length: 30720 }	10	0.986	1.014	4366.9
-SmartTablePicture { length: 30720, num_points_per_txn: 200 }	10	0.992	1.022	10209.3
-SmartTablePicture { length: 1048576, num_points_per_txn: 300 }	10	0.993	1.010	18014.6
-ResourceGroupsSenderWriteTag { string_length: 1024 }	10	0.988	1.010	13.2
-ResourceGroupsSenderMultiChange { string_length: 1024 }	10	0.988	1.006	22.9
-TokenV1MintAndTransferFT	10	0.993	1.016	205.0
-TokenV1MintAndTransferNFTSequential	10	0.987	1.026	289.6
-TokenV2AmbassadorMint { numbered: true }	10	0.984	1.028	190.2
-LiquidityPoolSwap { is_stable: true }	10	0.989	1.010	305.2
-LiquidityPoolSwap { is_stable: false }	10	0.993	1.010	284.2
-CoinInitAndMint	10	0.984	1.028	237.6
-FungibleAssetMint	10	0.979	1.023	98.7
-IncGlobalMilestoneAggV2 { milestone_every: 1 }	10	0.993	1.013	12.9
-IncGlobalMilestoneAggV2 { milestone_every: 2 }	10	0.987	1.021	7.8
-EmitEvents { count: 1000 }	10	0.983	1.042	4599.1
-APTTransferWithPermissionedSigner	10	0.977	1.015	269.2
-APTTransferWithMasterSigner	10	0.984	1.009	40.0
-VectorTrimAppend { vec_len: 3000, element_len: 1, index: 0, repeats: 0 }	10	0.993	1.079	3131.6
-VectorTrimAppend { vec_len: 3000, element_len: 1, index: 100, repeats: 1000 }	10	0.992	1.043	12504.3
-VectorTrimAppend { vec_len: 3000, element_len: 1, index: 2990, repeats: 1000 }	10	0.990	1.042	5969.7
-VectorRemoveInsert { vec_len: 3000, element_len: 1, index: 100, repeats: 1000 }	10	0.988	1.028	8548.3
-VectorRemoveInsert { vec_len: 3000, element_len: 1, index: 2998, repeats: 1000 }	10	0.989	1.037	6263.3
-VectorRangeMove { vec_len: 3000, element_len: 1, index: 1000, move_len: 500, repeats: 1000 }	10	0.993	1.029	13821.2
-VectorTrimAppend { vec_len: 100, element_len: 100, index: 0, repeats: 0 }	10	0.990	1.087	164.5
-VectorTrimAppend { vec_len: 100, element_len: 100, index: 10, repeats: 1000 }	10	0.991	1.024	3109.4
-VectorRangeMove { vec_len: 100, element_len: 100, index: 50, move_len: 10, repeats: 1000 }	10	0.987	1.055	2875.2
-MapInsertRemove { len: 100, repeats: 100, map_type: OrderedMap }	10	0.995	1.009	3076.4
-MapInsertRemove { len: 100, repeats: 100, map_type: SimpleMap }	10	0.991	1.072	10060.6
-MapInsertRemove { len: 100, repeats: 100, map_type: BigOrderedMap { inner_max_degree: 4, leaf_max_degree: 4 } }	10	0.995	1.009	13550.1
-MapInsertRemove { len: 100, repeats: 100, map_type: BigOrderedMap { inner_max_degree: 1024, leaf_max_degree: 1024 } }	10	0.994	1.010	3752.4
-MapInsertRemove { len: 1000, repeats: 100, map_type: OrderedMap }	10	0.995	1.012	15738.3
+Loop { loop_count: Some(100000), loop_type: NoOp }	9	0.988	1.021	26100.6
+Loop { loop_count: Some(10000), loop_type: Arithmetic }	9	0.984	1.013	16142.1
+CreateObjects { num_objects: 10, object_payload_size: 0 }	9	0.987	1.011	83.3
+CreateObjects { num_objects: 10, object_payload_size: 10240 }	9	0.984	1.010	5833.1
+CreateObjects { num_objects: 100, object_payload_size: 0 }	9	0.986	1.017	795.5
+CreateObjects { num_objects: 100, object_payload_size: 10240 }	9	0.985	1.007	6948.2
+InitializeVectorPicture { length: 128 }	9	0.992	1.060	91.0
+VectorPicture { length: 128 }	9	0.975	1.015	26.1
+VectorPictureRead { length: 128 }	9	0.979	1.023	25.2
+InitializeVectorPicture { length: 30720 }	9	0.985	1.006	16110.4
+VectorPicture { length: 30720 }	9	0.976	1.034	3927.0
+VectorPictureRead { length: 30720 }	9	0.977	1.046	3874.7
+SmartTablePicture { length: 30720, num_points_per_txn: 200 }	9	0.985	1.005	10530.6
+SmartTablePicture { length: 1048576, num_points_per_txn: 300 }	9	0.985	1.028	18606.7
+ResourceGroupsSenderWriteTag { string_length: 1024 }	9	0.988	1.012	14.0
+ResourceGroupsSenderMultiChange { string_length: 1024 }	9	0.996	1.028	24.2
+TokenV1MintAndTransferFT	9	0.988	1.014	212.9
+TokenV1MintAndTransferNFTSequential	9	0.976	1.008	296.8
+TokenV2AmbassadorMint { numbered: true }	9	0.980	1.022	196.4
+LiquidityPoolSwap { is_stable: true }	9	0.991	1.024	315.6
+LiquidityPoolSwap { is_stable: false }	9	0.987	1.010	294.0
+CoinInitAndMint	9	0.989	1.014	253.2
+FungibleAssetMint	9	0.979	1.013	106.4
+IncGlobalMilestoneAggV2 { milestone_every: 1 }	9	0.998	1.021	13.8
+IncGlobalMilestoneAggV2 { milestone_every: 2 }	9	0.977	1.026	8.5
+EmitEvents { count: 1000 }	9	0.973	1.027	5179.8
+APTTransferWithPermissionedSigner	9	0.979	1.013	284.7
+APTTransferWithMasterSigner	9	0.980	1.016	40.8
+VectorTrimAppend { vec_len: 3000, element_len: 1, index: 0, repeats: 0 }	9	0.979	1.035	3210.6
+VectorTrimAppend { vec_len: 3000, element_len: 1, index: 100, repeats: 1000 }	9	0.989	1.066	12706.1
+VectorTrimAppend { vec_len: 3000, element_len: 1, index: 2990, repeats: 1000 }	9	0.980	1.022	6207.8
+VectorRemoveInsert { vec_len: 3000, element_len: 1, index: 100, repeats: 1000 }	9	0.986	1.018	8733.7
+VectorRemoveInsert { vec_len: 3000, element_len: 1, index: 2998, repeats: 1000 }	9	0.987	1.045	6421.3
+VectorRangeMove { vec_len: 3000, element_len: 1, index: 1000, move_len: 500, repeats: 1000 }	9	0.987	1.023	13896.3
+VectorTrimAppend { vec_len: 100, element_len: 100, index: 0, repeats: 0 }	9	0.988	1.019	167.9
+VectorTrimAppend { vec_len: 100, element_len: 100, index: 10, repeats: 1000 }	9	0.982	1.034	3239.4
+VectorRangeMove { vec_len: 100, element_len: 100, index: 50, move_len: 10, repeats: 1000 }	9	0.974	1.031	2942.6
+MapInsertRemove { len: 100, repeats: 100, map_type: OrderedMap }	9	0.984	1.005	3227.8
+MapInsertRemove { len: 100, repeats: 100, map_type: SimpleMap }	9	0.985	1.042	10568.9
+MapInsertRemove { len: 100, repeats: 100, map_type: BigOrderedMap { inner_max_degree: 4, leaf_max_degree: 4 } }	9	0.988	1.045	14280.1
+MapInsertRemove { len: 100, repeats: 100, map_type: BigOrderedMap { inner_max_degree: 1024, leaf_max_degree: 1024 } }	9	0.987	1.004	3919.5
+MapInsertRemove { len: 1000, repeats: 100, map_type: OrderedMap }	9	0.982	1.016	16531.9


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only updates the static `calibration_values.tsv` data used by the e2e benchmark to set expected timing/ratio thresholds; no production code or logic changes.
> 
> **Overview**
> Updates `aptos-move/e2e-benchmark/data/calibration_values.tsv` with newly calibrated baseline numbers for all benchmark cases (including the run-count column shifting from `10` to `9` and refreshed min/max ratios and expected time micros). This changes the pass/fail thresholds used by the e2e benchmark harness via `include_str!` in `e2e-benchmark/src/main.rs`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4c400a6318945dd24ad242a08aeed8b771435796. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->