### PR TITLE
[ci] Subsystem-aware test target determination

### DIFF
--- a/.github/actions/test-target-determinator/action.yaml
+++ b/.github/actions/test-target-determinator/action.yaml
@@ -1,16 +1,37 @@
 name: Test Target Determinator
-description: Runs the test target determinator
+description: Runs the test target determinator and outputs a JSON test plan
 inputs:
   GIT_CREDENTIALS:
     description: "Optional credentials to pass to git. Useful if you need to pull private repos for dependencies"
     required: false
 outputs:
+  test_plan:
+    description: "JSON test plan with subsystem-aware test decisions"
+    value: ${{ steps.test_plan.outputs.test_plan }}
   run_execution_performance_test:
     description: "Returns true if the execution performance test should be run"
-    value: ${{ steps.execution_performance_determinator.outputs.run_execution_performance_test }}
+    value: ${{ steps.parse_plan.outputs.run_execution_performance }}
   run_framework_upgrade_test:
     description: "Returns true if the framework upgrade test should be run"
-    value: ${{ steps.framework_upgrade_determinator.outputs.run_framework_upgrade_test }}
+    value: ${{ steps.parse_plan.outputs.run_framework_upgrade }}
+  run_smoke_tests:
+    description: "Returns true if smoke tests should be run"
+    value: ${{ steps.parse_plan.outputs.run_smoke_tests }}
+  run_forge_e2e:
+    description: "Returns true if forge e2e tests should be run"
+    value: ${{ steps.parse_plan.outputs.run_forge_e2e }}
+  run_forge_compat:
+    description: "Returns true if forge compat tests should be run"
+    value: ${{ steps.parse_plan.outputs.run_forge_compat }}
+  safety_override:
+    description: "Returns true if safety-critical changes were detected (all tests must run)"
+    value: ${{ steps.parse_plan.outputs.safety_override }}
+  subsystems_affected:
+    description: "Comma-separated list of affected subsystems"
+    value: ${{ steps.parse_plan.outputs.subsystems_affected }}
+  forge_suites_to_skip:
+    description: "Comma-separated list of Forge suites to skip"
+    value: ${{ steps.parse_plan.outputs.forge_suites_to_skip }}
 
 runs:
   using: composite
@@ -24,18 +45,73 @@ runs:
       with:
         GIT_CREDENTIALS: ${{ inputs.GIT_CREDENTIALS }}
 
-    # Output the changed files
+    # Output the changed files (diagnostic)
     - name: Output the changed files
       run: cargo x changed-files -vv
       shell: bash
 
-    # Output the affected packages
+    # Output the affected packages (diagnostic)
     - name: Output the affected packages
       run: cargo x affected-packages -vv
       shell: bash
 
-    # Run the execution performance test determinator
-    - name: Run the execution performance test determinator
+    # Generate the comprehensive test plan
+    - name: Generate test plan
+      id: test_plan
+      run: |
+        TEST_PLAN=$(cargo x targeted-test-plan)
+        echo "Test plan:"
+        echo "$TEST_PLAN" | jq .
+        # Store as a single-line JSON for GitHub Actions output
+        echo "test_plan=$(echo "$TEST_PLAN" | jq -c .)" >> $GITHUB_OUTPUT
+      shell: bash
+
+    # Parse the test plan into individual outputs for backward compatibility
+    - name: Parse test plan outputs
+      id: parse_plan
+      run: |
+        TEST_PLAN='${{ steps.test_plan.outputs.test_plan }}'
+        echo "run_execution_performance=$(echo "$TEST_PLAN" | jq -r '.run_execution_performance')" >> $GITHUB_OUTPUT
+        echo "run_framework_upgrade=$(echo "$TEST_PLAN" | jq -r '.run_framework_upgrade')" >> $GITHUB_OUTPUT
+        echo "run_smoke_tests=$(echo "$TEST_PLAN" | jq -r '.run_smoke_tests')" >> $GITHUB_OUTPUT
+        echo "run_forge_e2e=$(echo "$TEST_PLAN" | jq -r '.run_forge_e2e')" >> $GITHUB_OUTPUT
+        echo "run_forge_compat=$(echo "$TEST_PLAN" | jq -r '.run_forge_compat')" >> $GITHUB_OUTPUT
+        echo "safety_override=$(echo "$TEST_PLAN" | jq -r '.safety_override')" >> $GITHUB_OUTPUT
+        echo "subsystems_affected=$(echo "$TEST_PLAN" | jq -r '.subsystems_affected | join(",")')" >> $GITHUB_OUTPUT
+        echo "forge_suites_to_skip=$(echo "$TEST_PLAN" | jq -r '.forge_suites_to_skip | join(",")')" >> $GITHUB_OUTPUT
+      shell: bash
+
+    # Write targeting summary to GitHub Step Summary
+    - name: Test targeting summary
+      run: |
+        TEST_PLAN='${{ steps.test_plan.outputs.test_plan }}'
+        echo "## Test Target Determination" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "### Affected Subsystems" >> $GITHUB_STEP_SUMMARY
+        echo "$TEST_PLAN" | jq -r '.subsystems_affected[]' | while read s; do echo "- \`$s\`" >> $GITHUB_STEP_SUMMARY; done
+        if [ "$(echo "$TEST_PLAN" | jq -r '.subsystems_affected | length')" = "0" ]; then
+          echo "_None detected_" >> $GITHUB_STEP_SUMMARY
+        fi
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "### Test Decisions" >> $GITHUB_STEP_SUMMARY
+        echo "| Test | Run? |" >> $GITHUB_STEP_SUMMARY
+        echo "|------|------|" >> $GITHUB_STEP_SUMMARY
+        echo "| Smoke tests | $(echo "$TEST_PLAN" | jq -r '.run_smoke_tests') |" >> $GITHUB_STEP_SUMMARY
+        echo "| Forge E2E | $(echo "$TEST_PLAN" | jq -r '.run_forge_e2e') |" >> $GITHUB_STEP_SUMMARY
+        echo "| Forge Compat | $(echo "$TEST_PLAN" | jq -r '.run_forge_compat') |" >> $GITHUB_STEP_SUMMARY
+        echo "| Framework Upgrade | $(echo "$TEST_PLAN" | jq -r '.run_framework_upgrade') |" >> $GITHUB_STEP_SUMMARY
+        echo "| Execution Performance | $(echo "$TEST_PLAN" | jq -r '.run_execution_performance') |" >> $GITHUB_STEP_SUMMARY
+        echo "| Safety Override | $(echo "$TEST_PLAN" | jq -r '.safety_override') |" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        SKIPS=$(echo "$TEST_PLAN" | jq -r '.forge_suites_to_skip | join(", ")')
+        if [ -n "$SKIPS" ]; then
+          echo "### Forge Suites Skipped" >> $GITHUB_STEP_SUMMARY
+          echo "$SKIPS" >> $GITHUB_STEP_SUMMARY
+        fi
+      shell: bash
+
+    # Legacy: also run the old determinators for backward compatibility during rollout
+    - name: Run the execution performance test determinator (legacy)
       id: execution_performance_determinator
       run: |
           export RESULT=$(cargo x targeted-execution-performance-tests | awk -F'Execution performance test required: ' '{print $2}')
@@ -43,8 +119,7 @@ runs:
           echo "run_execution_performance_test=$RESULT" >> $GITHUB_OUTPUT
       shell: bash
 
-    # Run the framework upgrade test determinator
-    - name: Run the framework upgrade test determinator
+    - name: Run the framework upgrade test determinator (legacy)
       id: framework_upgrade_determinator
       run: |
         export RESULT=$(cargo x targeted-framework-upgrade-tests | awk -F'Framework upgrade test required: ' '{print $2}')

--- a/.github/forge-suite-subsystems.toml
+++ b/.github/forge-suite-subsystems.toml
@@ -1,0 +1,64 @@
+# Forge Suite to Subsystem Mapping
+#
+# This file maps Forge test suites to the subsystems they exercise.
+# The test target determinator uses this to skip suites whose subsystems
+# were not affected by a given PR.
+#
+# safety = "critical" means the suite will never be skipped by the determinator.
+# safety = "normal" means the suite can be skipped if its subsystems aren't affected.
+
+[suites.realistic_env_max_load]
+subsystems = ["consensus", "execution", "mempool", "network", "storage", "state-sync"]
+safety = "normal"
+
+[suites.compat]
+subsystems = ["consensus", "network", "state-sync"]
+safety = "critical"
+
+[suites.framework_upgrade]
+subsystems = ["move-framework", "execution"]
+safety = "critical"
+
+[suites.consensus_only_realistic_env_max_tps]
+subsystems = ["consensus"]
+safety = "normal"
+
+[suites.multiregion_benchmark_test]
+subsystems = ["consensus", "network"]
+safety = "normal"
+
+[suites.realistic_env_load_sweep]
+subsystems = ["consensus", "execution", "mempool"]
+safety = "normal"
+
+[suites.realistic_env_workload_sweep]
+subsystems = ["execution", "move-vm"]
+safety = "normal"
+
+[suites.realistic_env_graceful_overload]
+subsystems = ["consensus", "execution", "mempool"]
+safety = "normal"
+
+[suites.consensus_stress_test]
+subsystems = ["consensus"]
+safety = "normal"
+
+[suites.workload_mix]
+subsystems = ["execution", "move-vm"]
+safety = "normal"
+
+[suites.single_vfn_perf]
+subsystems = ["network", "state-sync"]
+safety = "normal"
+
+[suites.fullnode_reboot_stress_test]
+subsystems = ["state-sync", "storage"]
+safety = "normal"
+
+[suites.changing_working_quorum_test]
+subsystems = ["consensus"]
+safety = "normal"
+
+[suites.pfn_const_tps_with_realistic_env]
+subsystems = ["network", "state-sync"]
+safety = "normal"

--- a/.github/workflows/docker-build-test.yaml
+++ b/.github/workflows/docker-build-test.yaml
@@ -131,6 +131,10 @@ jobs:
     runs-on: 2cpu-gh-ubuntu24-x64
     outputs:
       run_framework_upgrade_test: ${{ steps.determine_test_targets.outputs.run_framework_upgrade_test }}
+      run_forge_e2e: ${{ steps.determine_test_targets.outputs.run_forge_e2e }}
+      run_forge_compat: ${{ steps.determine_test_targets.outputs.run_forge_compat }}
+      run_execution_performance: ${{ steps.determine_test_targets.outputs.run_execution_performance_test }}
+      safety_override: ${{ steps.determine_test_targets.outputs.safety_override }}
     steps:
       - uses: actions/checkout@v4
       - name: Run the test target determinator
@@ -255,6 +259,7 @@ jobs:
       - rust-images-performance
       - rust-images-consensus-only-perf-test
       - file_change_determinator
+      - test-target-determinator
     if: |
       !failure() && !cancelled() && needs.permission-check.result == 'success' && (
         (github.event_name == 'push' && github.ref_name != 'main') ||
@@ -276,7 +281,7 @@ jobs:
       # test lifecycle is separate from that of GHA. This protects us from the case where many Forge tests are triggered
       # by this GHA. If there is a Forge namespace collision, Forge will pre-empt the existing test running in the namespace.
       FORGE_NAMESPACE: forge-e2e-${{ needs.determine-docker-build-metadata.outputs.targetCacheId }}
-      SKIP_JOB: ${{ needs.file_change_determinator.outputs.only_docs_changed == 'true' }}
+      SKIP_JOB: ${{ needs.file_change_determinator.outputs.only_docs_changed == 'true' || (!contains(github.event.pull_request.labels.*.name, 'CICD:run-e2e-tests') && !contains(github.event.pull_request.labels.*.name, 'CICD:run-forge-e2e-perf') && needs.test-target-determinator.outputs.run_forge_e2e == 'false') }}
       SEND_RESULTS_TO_TRUNK: true
   
   # This job determines the last released docker image tag, which is used by forge compat test.
@@ -330,7 +335,7 @@ jobs:
   
   # Run e2e compat test against testnet branch. This is a PR required job.
   forge-compat-test:
-    needs: 
+    needs:
       - permission-check
       - fetch-last-released-docker-image-tag
       - determine-docker-build-metadata
@@ -339,6 +344,7 @@ jobs:
       - rust-images-performance
       - rust-images-consensus-only-perf-test
       - file_change_determinator
+      - test-target-determinator
     if: |
       !failure() && !cancelled() && needs.permission-check.result == 'success' && (
         (github.event_name == 'push' && github.ref_name != 'main') ||
@@ -356,7 +362,7 @@ jobs:
       FORGE_RUNNER_DURATION_SECS: 300
       COMMENT_HEADER: forge-compat
       FORGE_NAMESPACE: forge-compat-${{ needs.determine-docker-build-metadata.outputs.targetCacheId }}
-      SKIP_JOB: ${{ needs.file_change_determinator.outputs.only_docs_changed == 'true' }}
+      SKIP_JOB: ${{ needs.file_change_determinator.outputs.only_docs_changed == 'true' || (!contains(github.event.pull_request.labels.*.name, 'CICD:run-e2e-tests') && needs.test-target-determinator.outputs.run_forge_compat == 'false') }}
       SEND_RESULTS_TO_TRUNK: true
   
   # Run forge framework upgradability test. This is a PR required job.
@@ -386,7 +392,7 @@ jobs:
       FORGE_RUNNER_DURATION_SECS: 3600
       COMMENT_HEADER: forge-framework-upgrade
       FORGE_NAMESPACE: forge-framework-upgrade-${{ needs.determine-docker-build-metadata.outputs.targetCacheId }}
-      SKIP_JOB: ${{ !contains(github.event.pull_request.labels.*.name, 'CICD:run-framework-upgrade-test') && (needs.test-target-determinator.outputs.run_framework_upgrade_test == 'false') }}
+      SKIP_JOB: ${{ !contains(github.event.pull_request.labels.*.name, 'CICD:run-framework-upgrade-test') && !contains(github.event.pull_request.labels.*.name, 'CICD:run-e2e-tests') && (needs.test-target-determinator.outputs.run_framework_upgrade_test == 'false') }}
       SEND_RESULTS_TO_TRUNK: true
 
   forge-consensus-only-perf-test:

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -109,9 +109,26 @@ jobs:
         with:
           GIT_CREDENTIALS: ${{ secrets.GIT_CREDENTIALS }}
 
+  # This job determines which tests to run based on subsystem-aware analysis
+  test-target-determinator:
+    runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
+    outputs:
+      run_smoke_tests: ${{ steps.determine_test_targets.outputs.run_smoke_tests }}
+      safety_override: ${{ steps.determine_test_targets.outputs.safety_override }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+      - name: Run the test target determinator
+        id: determine_test_targets
+        uses: ./.github/actions/test-target-determinator
+
   # Run all rust smoke tests. This is a PR required job.
   rust-smoke-tests:
-    needs: file_change_determinator
+    needs:
+      - file_change_determinator
+      - test-target-determinator
     if: | # Only run on each PR once an appropriate event occurs
       (
         github.event_name == 'workflow_dispatch' ||
@@ -123,14 +140,14 @@ jobs:
     runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
       - uses: actions/checkout@v4
-        if: needs.file_change_determinator.outputs.only_docs_changed != 'true'
+        if: needs.file_change_determinator.outputs.only_docs_changed != 'true' && (contains(github.event.pull_request.labels.*.name, 'CICD:run-e2e-tests') || needs.test-target-determinator.outputs.run_smoke_tests == 'true')
       - name: Run rust smoke tests
         uses: ./.github/actions/rust-smoke-tests
-        if: needs.file_change_determinator.outputs.only_docs_changed != 'true'
+        if: needs.file_change_determinator.outputs.only_docs_changed != 'true' && (contains(github.event.pull_request.labels.*.name, 'CICD:run-e2e-tests') || needs.test-target-determinator.outputs.run_smoke_tests == 'true')
         with:
           GIT_CREDENTIALS: ${{ secrets.GIT_CREDENTIALS }}
       - run: echo "Skipping rust smoke tests! Unrelated changes detected."
-        if: needs.file_change_determinator.outputs.only_docs_changed == 'true'
+        if: needs.file_change_determinator.outputs.only_docs_changed == 'true' || (!contains(github.event.pull_request.labels.*.name, 'CICD:run-e2e-tests') && needs.test-target-determinator.outputs.run_smoke_tests != 'true')
 
   # Check the freshess of the merge base. This is a PR required job.
   rust-check-merge-base:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -820,6 +820,10 @@ dependencies = [
  "guppy",
  "log",
  "reqwest 0.11.23",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "toml 0.7.8",
  "url",
 ]
 

--- a/crates/aptos/Cargo.toml
+++ b/crates/aptos/Cargo.toml
@@ -36,7 +36,7 @@ aptos-logger = { workspace = true }
 aptos-move-cli = { workspace = true, features = ["testing"] }
 aptos-move-debugger = { workspace = true }
 aptos-network-checker = { workspace = true }
-aptos-node = { workspace = true }
+aptos-node = { workspace = true, optional = true }
 aptos-rest-client = { workspace = true }
 aptos-sdk = { workspace = true }
 aptos-telemetry = { workspace = true }
@@ -46,7 +46,7 @@ aptos-transaction-simulation-session = { workspace = true }
 aptos-types = { workspace = true }
 aptos-vm-genesis = { workspace = true }
 aptos-vm-types = { workspace = true }
-aptos-workspace-server = { workspace = true }
+aptos-workspace-server = { workspace = true, optional = true }
 async-trait = { workspace = true }
 backoff = { workspace = true }
 base64 = { workspace = true }
@@ -91,7 +91,8 @@ url = { workspace = true }
 jemallocator = { workspace = true }
 
 [features]
-default = []
+default = ["localnet"]
+localnet = ["dep:aptos-node", "dep:aptos-workspace-server"]
 fuzzing = []
 no-upload-proposal = []
 cli-framework-test-move = []

--- a/crates/aptos/src/lib.rs
+++ b/crates/aptos/src/lib.rs
@@ -15,15 +15,19 @@ pub mod stake;
 #[cfg(any(test, feature = "fuzzing"))]
 pub mod test;
 pub mod update;
+#[cfg(feature = "localnet")]
 pub mod workspace;
 
 use crate::common::{
-    types::{CliCommand, CliError, CliResult, CliTypedResult},
+    types::{CliCommand, CliResult, CliTypedResult},
     utils::cli_build_information,
 };
+#[cfg(feature = "localnet")]
+use crate::common::types::CliError;
 pub use aptos_context::RealAptosContext;
 use aptos_move_cli::MoveEnv;
 use aptos_move_debugger::aptos_debugger::AptosDebugger;
+#[cfg(feature = "localnet")]
 use aptos_workspace_server::WorkspaceCommand;
 use async_trait::async_trait;
 use clap::Parser;
@@ -66,6 +70,7 @@ pub enum Tool {
     Stake(stake::StakeTool),
     #[clap(subcommand)]
     Update(update::UpdateTool),
+    #[cfg(feature = "localnet")]
     #[clap(subcommand, hide(true))]
     Workspace(WorkspaceCommand),
 }
@@ -87,6 +92,7 @@ impl Tool {
             Node(tool) => tool.execute().await,
             Stake(tool) => tool.execute().await,
             Update(tool) => tool.execute().await,
+            #[cfg(feature = "localnet")]
             Workspace(workspace) => {
                 let start_time = std::time::Instant::now();
                 let result: CliTypedResult<()> = workspace

--- a/crates/aptos/src/node/mod.rs
+++ b/crates/aptos/src/node/mod.rs
@@ -2,8 +2,10 @@
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 pub mod analyze;
+#[cfg(feature = "localnet")]
 pub mod local_testnet;
 
+#[cfg(feature = "localnet")]
 use self::local_testnet::RunLocalnet;
 use crate::{
     common::{
@@ -77,6 +79,7 @@ pub enum NodeTool {
     ShowValidatorConfig(ShowValidatorConfig),
     ShowValidatorSet(ShowValidatorSet),
     ShowValidatorStake(ShowValidatorStake),
+    #[cfg(feature = "localnet")]
     #[clap(aliases = &["run-local-testnet"])]
     RunLocalnet(RunLocalnet),
     UpdateConsensusKey(UpdateConsensusKey),
@@ -102,6 +105,7 @@ impl NodeTool {
             ShowValidatorSet(tool) => tool.execute_serialized().await,
             ShowValidatorStake(tool) => tool.execute_serialized().await,
             ShowValidatorConfig(tool) => tool.execute_serialized().await,
+            #[cfg(feature = "localnet")]
             RunLocalnet(tool) => tool
                 .execute_serialized_without_logger()
                 .await

--- a/devtools/aptos-cargo-cli/Cargo.toml
+++ b/devtools/aptos-cargo-cli/Cargo.toml
@@ -23,4 +23,10 @@ env_logger = { workspace = true }
 guppy = { workspace = true }
 log = { workspace = true }
 reqwest = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+toml = { workspace = true }
 url = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/devtools/aptos-cargo-cli/src/common.rs
+++ b/devtools/aptos-cargo-cli/src/common.rs
@@ -28,6 +28,14 @@ use url::Url;
 // The target directory for the devtool
 const DEVTOOL_TARGET_DIRECTORY: &str = "target/aptos-x-tool";
 
+// Packages to omit from the determinator's dependency graph.
+// These are heavy dependencies that are feature-gated (behind `localnet`)
+// in the CLI crate and should not cause transitive affected-package blow-up.
+const OMITTED_PACKAGES_FOR_DETERMINATION: [&str; 2] = [
+    "aptos-node",
+    "aptos-workspace-server",
+];
+
 // File types in `aptos-core` that are not relevant to the rust build and test process.
 // Note: this is a best effort list and will need to be updated as time goes on.
 const IGNORED_DETERMINATOR_FILE_TYPES: [&str; 1] = ["*.md"];
@@ -261,6 +269,24 @@ impl SelectedPackageArgs {
         let mut cargo_options = CargoOptions::new();
         cargo_options.set_resolver(CargoResolverVersion::V2);
         cargo_options.set_include_dev(true); // Include dev-dependencies to ensure test-only packages are handled correctly
+
+        // Omit heavy packages that are feature-gated behind `localnet` in the CLI.
+        // This prevents changes to e.g. consensus from transitively marking the CLI
+        // (and all CLI-dependent test crates) as affected via aptos-node.
+        let omitted_ids: Vec<_> = OMITTED_PACKAGES_FOR_DETERMINATION
+            .iter()
+            .filter_map(|name| {
+                head_package_graph
+                    .packages()
+                    .find(|pkg| pkg.name() == *name)
+                    .map(|pkg| {
+                        info!("Omitting package from determination: {}", name);
+                        pkg.id().clone()
+                    })
+            })
+            .collect();
+        cargo_options.add_omitted_packages(omitted_ids.iter());
+
         determinator.set_cargo_options(&cargo_options);
 
         // Set the ignore rules for the determinator

--- a/devtools/aptos-cargo-cli/src/lib.rs
+++ b/devtools/aptos-cargo-cli/src/lib.rs
@@ -3,6 +3,8 @@
 
 mod cargo;
 mod common;
+mod subsystems;
+mod test_plan;
 
 use crate::common::PACKAGE_NAME_DELIMITER;
 use camino::Utf8PathBuf;
@@ -10,7 +12,8 @@ use cargo::Cargo;
 use clap::{Args, Parser, Subcommand};
 pub use common::SelectedPackageArgs;
 use determinator::Utf8Paths0;
-use log::{debug, trace};
+use log::{debug, info, trace};
+use test_plan::TestPlan;
 
 // Useful package name constants for targeted tests
 const APTOS_CLI_PACKAGE_NAME: &str = "aptos";
@@ -85,6 +88,7 @@ pub enum AptosCargoCommand {
     TargetedCompilerV2Tests(CommonArgs),
     TargetedExecutionPerformanceTests(CommonArgs),
     TargetedFrameworkUpgradeTests(CommonArgs),
+    TargetedTestPlan(CommonArgs),
     TargetedUnitTests(CommonArgs),
     Test(CommonArgs),
 }
@@ -114,6 +118,7 @@ impl AptosCargoCommand {
             AptosCargoCommand::TargetedCompilerV2Tests(args) => args,
             AptosCargoCommand::TargetedExecutionPerformanceTests(args) => args,
             AptosCargoCommand::TargetedFrameworkUpgradeTests(args) => args,
+            AptosCargoCommand::TargetedTestPlan(args) => args,
             AptosCargoCommand::TargetedUnitTests(args) => args,
             AptosCargoCommand::Test(args) => args,
         }
@@ -275,6 +280,39 @@ impl AptosCargoCommand {
                     relevant_changes_detected
                 );
 
+                Ok(())
+            },
+            AptosCargoCommand::TargetedTestPlan(_) => {
+                // Generate a comprehensive JSON test plan for CI consumption.
+                // This replaces the individual targeted-*-tests commands with a single
+                // unified output that maps changed files to subsystems and test decisions.
+                let (_, _, changed_files) = package_args.identify_changed_files()?;
+                let affected_package_paths = package_args.compute_target_packages()?;
+
+                // Collect changed file paths as strings
+                let changed_file_list: Vec<String> = changed_files
+                    .into_iter()
+                    .map(|p| p.to_string())
+                    .collect();
+
+                // Look for the forge suite config relative to workspace root
+                let workspace = std::env::current_dir()
+                    .unwrap_or_default();
+                let forge_config = workspace.join(".github/forge-suite-subsystems.toml");
+                let forge_config_path = if forge_config.exists() {
+                    Some(forge_config.as_path())
+                } else {
+                    info!("No forge suite config found at {}", forge_config.display());
+                    None
+                };
+
+                let plan = TestPlan::generate(
+                    &changed_file_list,
+                    &affected_package_paths,
+                    forge_config_path,
+                );
+
+                println!("{}", plan.to_json());
                 Ok(())
             },
             AptosCargoCommand::TargetedUnitTests(_) => {

--- a/devtools/aptos-cargo-cli/src/subsystems.rs
+++ b/devtools/aptos-cargo-cli/src/subsystems.rs
@@ -1,0 +1,162 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+use std::collections::BTreeSet;
+
+/// A subsystem definition: a name and a set of path prefixes that belong to it.
+pub struct Subsystem {
+    pub name: &'static str,
+    pub path_prefixes: &'static [&'static str],
+}
+
+/// All known subsystems in the aptos-core repository.
+/// Each subsystem maps to directory prefixes that, when changed, indicate that subsystem is affected.
+pub const SUBSYSTEMS: &[Subsystem] = &[
+    Subsystem {
+        name: "consensus",
+        path_prefixes: &["consensus/", "crates/aptos-consensus"],
+    },
+    Subsystem {
+        name: "execution",
+        path_prefixes: &[
+            "execution/",
+            "aptos-move/block-executor/",
+            "aptos-move/aptos-vm",
+        ],
+    },
+    Subsystem {
+        name: "storage",
+        path_prefixes: &["storage/", "crates/aptos-db"],
+    },
+    Subsystem {
+        name: "network",
+        path_prefixes: &["network/", "crates/aptos-network"],
+    },
+    Subsystem {
+        name: "mempool",
+        path_prefixes: &["mempool/"],
+    },
+    Subsystem {
+        name: "api",
+        path_prefixes: &["api/", "crates/aptos-api"],
+    },
+    Subsystem {
+        name: "move-vm",
+        path_prefixes: &["third_party/move/"],
+    },
+    Subsystem {
+        name: "move-framework",
+        path_prefixes: &["aptos-move/framework/"],
+    },
+    Subsystem {
+        name: "state-sync",
+        path_prefixes: &["state-sync/"],
+    },
+    Subsystem {
+        name: "crypto",
+        path_prefixes: &["crates/aptos-crypto/"],
+    },
+    Subsystem {
+        name: "keyless",
+        path_prefixes: &["keyless/", "crates/aptos-keyless"],
+    },
+    Subsystem {
+        name: "secure",
+        path_prefixes: &["secure/", "consensus/safety-rules/"],
+    },
+    Subsystem {
+        name: "indexer",
+        path_prefixes: &["ecosystem/indexer", "crates/aptos-indexer"],
+    },
+    Subsystem {
+        name: "cli",
+        path_prefixes: &["crates/aptos/"],
+    },
+    Subsystem {
+        name: "ci-infra",
+        path_prefixes: &[".github/", "docker/", "terraform/", "scripts/"],
+    },
+];
+
+/// Subsystems that are safety-critical. When any of these are affected,
+/// the test plan sets `safety_override = true` to force all tests to run.
+pub const SAFETY_CRITICAL_SUBSYSTEMS: &[&str] = &["crypto", "secure", "keyless"];
+
+/// Given a list of changed file paths, determine which subsystems are affected.
+pub fn affected_subsystems<'a, I, S>(changed_files: I) -> BTreeSet<String>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    let mut affected = BTreeSet::new();
+    for file in changed_files {
+        let path = file.as_ref();
+        for subsystem in SUBSYSTEMS {
+            for prefix in subsystem.path_prefixes {
+                if path.starts_with(prefix) {
+                    affected.insert(subsystem.name.to_string());
+                    break;
+                }
+            }
+        }
+    }
+    affected
+}
+
+/// Returns true if any safety-critical subsystem is in the affected set.
+pub fn has_safety_critical_changes(affected: &BTreeSet<String>) -> bool {
+    SAFETY_CRITICAL_SUBSYSTEMS
+        .iter()
+        .any(|s| affected.contains(*s))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_affected_subsystems_consensus() {
+        let files = vec!["consensus/src/lib.rs"];
+        let affected = affected_subsystems(files);
+        assert!(affected.contains("consensus"));
+        assert!(!affected.contains("storage"));
+    }
+
+    #[test]
+    fn test_affected_subsystems_multiple() {
+        let files = vec![
+            "consensus/src/lib.rs",
+            "storage/aptosdb/src/lib.rs",
+            "crates/aptos-crypto/src/lib.rs",
+        ];
+        let affected = affected_subsystems(files);
+        assert!(affected.contains("consensus"));
+        assert!(affected.contains("storage"));
+        assert!(affected.contains("crypto"));
+    }
+
+    #[test]
+    fn test_safety_critical() {
+        let mut affected = BTreeSet::new();
+        affected.insert("consensus".to_string());
+        assert!(!has_safety_critical_changes(&affected));
+
+        affected.insert("crypto".to_string());
+        assert!(has_safety_critical_changes(&affected));
+    }
+
+    #[test]
+    fn test_no_subsystem_for_docs() {
+        let files = vec!["developer-docs-site/docs/intro.md"];
+        let affected = affected_subsystems(files);
+        assert!(affected.is_empty());
+    }
+
+    #[test]
+    fn test_safety_rules_maps_to_secure() {
+        let files = vec!["consensus/safety-rules/src/lib.rs"];
+        let affected = affected_subsystems(files);
+        assert!(affected.contains("secure"));
+        assert!(affected.contains("consensus"));
+    }
+}

--- a/devtools/aptos-cargo-cli/src/test_plan.rs
+++ b/devtools/aptos-cargo-cli/src/test_plan.rs
@@ -1,0 +1,268 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+use crate::{
+    common::PACKAGE_NAME_DELIMITER,
+    subsystems::{affected_subsystems, has_safety_critical_changes},
+};
+use log::info;
+use serde::{Deserialize, Serialize};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fs,
+    path::Path,
+};
+
+/// Configuration for a single Forge test suite, loaded from TOML config.
+#[derive(Debug, Deserialize)]
+struct ForgeSuiteConfig {
+    subsystems: Vec<String>,
+    #[serde(default = "default_safety")]
+    safety: String,
+}
+
+fn default_safety() -> String {
+    "normal".to_string()
+}
+
+/// Top-level structure of the forge-suite-subsystems.toml config file.
+#[derive(Debug, Deserialize)]
+struct ForgeSuitesConfig {
+    #[serde(default)]
+    suites: BTreeMap<String, ForgeSuiteConfig>,
+}
+
+/// The JSON test plan output consumed by GitHub Actions.
+#[derive(Debug, Serialize)]
+pub struct TestPlan {
+    /// Which subsystems were detected as affected by the changes.
+    pub subsystems_affected: BTreeSet<String>,
+
+    /// Affected crate package names for targeted unit tests.
+    pub unit_test_packages: Vec<String>,
+
+    /// Whether smoke tests should run.
+    pub run_smoke_tests: bool,
+
+    /// Whether Forge e2e tests should run.
+    pub run_forge_e2e: bool,
+
+    /// Whether Forge compat tests should run.
+    pub run_forge_compat: bool,
+
+    /// Whether framework upgrade tests should run.
+    pub run_framework_upgrade: bool,
+
+    /// Whether execution performance tests should run.
+    pub run_execution_performance: bool,
+
+    /// List of Forge suite names that should be skipped.
+    pub forge_suites_to_skip: Vec<String>,
+
+    /// If true, safety-critical code changed -- all tests must run.
+    pub safety_override: bool,
+}
+
+impl TestPlan {
+    /// Generate a test plan from changed files and affected packages.
+    ///
+    /// `changed_files`: list of file paths changed relative to merge-base.
+    /// `affected_packages`: full package paths from the determinator (with `#name` suffix).
+    /// `forge_config_path`: optional path to the forge-suite-subsystems.toml file.
+    pub fn generate(
+        changed_files: &[String],
+        affected_packages: &[String],
+        forge_config_path: Option<&Path>,
+    ) -> Self {
+        // Determine affected subsystems from changed files
+        let subsystems_affected = affected_subsystems(changed_files.iter().map(|s| s.as_str()));
+        let safety_override = has_safety_critical_changes(&subsystems_affected);
+
+        if safety_override {
+            info!("Safety-critical subsystem changed -- forcing all tests to run");
+        }
+
+        // Extract package names from full paths
+        let package_names: Vec<String> = affected_packages
+            .iter()
+            .filter_map(|p| p.split(PACKAGE_NAME_DELIMITER).last())
+            .filter(|name| !name.is_empty())
+            .map(|s| s.to_string())
+            .collect();
+
+        // Determine which high-level test categories to run based on subsystems
+        let run_smoke_tests = safety_override
+            || subsystems_affected
+                .iter()
+                .any(|s| matches!(s.as_str(), "consensus" | "execution" | "storage" | "network" | "mempool" | "state-sync" | "move-vm" | "move-framework"));
+
+        let run_forge_e2e = run_smoke_tests; // Same subsystem triggers
+
+        let run_forge_compat = safety_override
+            || subsystems_affected
+                .iter()
+                .any(|s| matches!(s.as_str(), "consensus" | "network" | "state-sync"));
+
+        let run_framework_upgrade = safety_override
+            || subsystems_affected
+                .iter()
+                .any(|s| matches!(s.as_str(), "move-framework" | "execution"));
+
+        let run_execution_performance = safety_override
+            || subsystems_affected
+                .iter()
+                .any(|s| matches!(s.as_str(), "execution" | "move-vm" | "storage"));
+
+        // Determine Forge suites to skip from config file
+        let forge_suites_to_skip = if safety_override {
+            vec![] // Don't skip anything when safety-critical
+        } else {
+            compute_forge_skips(&subsystems_affected, forge_config_path)
+        };
+
+        TestPlan {
+            subsystems_affected,
+            unit_test_packages: package_names,
+            run_smoke_tests,
+            run_forge_e2e,
+            run_forge_compat,
+            run_framework_upgrade,
+            run_execution_performance,
+            forge_suites_to_skip,
+            safety_override,
+        }
+    }
+
+    /// Serialize the test plan to JSON.
+    pub fn to_json(&self) -> String {
+        serde_json::to_string_pretty(self).expect("failed to serialize test plan")
+    }
+}
+
+/// Load the Forge suite config and determine which suites can be skipped
+/// because none of their required subsystems are in the affected set.
+fn compute_forge_skips(
+    affected: &BTreeSet<String>,
+    config_path: Option<&Path>,
+) -> Vec<String> {
+    let config_path = match config_path {
+        Some(p) if p.exists() => p,
+        _ => return vec![],
+    };
+
+    let contents = match fs::read_to_string(config_path) {
+        Ok(c) => c,
+        Err(e) => {
+            info!("Could not read forge suite config: {}", e);
+            return vec![];
+        },
+    };
+
+    let config: ForgeSuitesConfig = match toml::from_str(&contents) {
+        Ok(c) => c,
+        Err(e) => {
+            info!("Could not parse forge suite config: {}", e);
+            return vec![];
+        },
+    };
+
+    let mut skips = Vec::new();
+    for (suite_name, suite_config) in &config.suites {
+        // Never skip critical suites unless we're certain
+        if suite_config.safety == "critical" {
+            continue;
+        }
+
+        // Check if any of the suite's required subsystems are affected
+        let suite_affected = suite_config
+            .subsystems
+            .iter()
+            .any(|s| affected.contains(s));
+
+        if !suite_affected {
+            skips.push(suite_name.clone());
+        }
+    }
+
+    skips
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_generate_empty_changes() {
+        let plan = TestPlan::generate(&[], &[], None);
+        assert!(plan.subsystems_affected.is_empty());
+        assert!(!plan.run_smoke_tests);
+        assert!(!plan.run_forge_e2e);
+        assert!(!plan.safety_override);
+    }
+
+    #[test]
+    fn test_generate_consensus_change() {
+        let changed = vec!["consensus/src/lib.rs".to_string()];
+        let packages = vec!["file:///aptos-core/consensus#aptos-consensus".to_string()];
+        let plan = TestPlan::generate(&changed, &packages, None);
+
+        assert!(plan.subsystems_affected.contains("consensus"));
+        assert!(plan.run_smoke_tests);
+        assert!(plan.run_forge_e2e);
+        assert!(plan.run_forge_compat);
+        assert!(!plan.run_framework_upgrade);
+        assert!(!plan.safety_override);
+        assert_eq!(plan.unit_test_packages, vec!["aptos-consensus"]);
+    }
+
+    #[test]
+    fn test_generate_crypto_forces_all() {
+        let changed = vec!["crates/aptos-crypto/src/lib.rs".to_string()];
+        let plan = TestPlan::generate(&changed, &[], None);
+
+        assert!(plan.safety_override);
+        assert!(plan.run_smoke_tests);
+        assert!(plan.run_forge_e2e);
+        assert!(plan.run_forge_compat);
+        assert!(plan.run_framework_upgrade);
+        assert!(plan.run_execution_performance);
+        assert!(plan.forge_suites_to_skip.is_empty());
+    }
+
+    #[test]
+    fn test_forge_skip_from_config() {
+        let affected: BTreeSet<String> = ["consensus".to_string()].into();
+        let config_toml = r#"
+[suites.framework_upgrade]
+subsystems = ["move-framework", "execution"]
+safety = "normal"
+
+[suites.compat]
+subsystems = ["consensus", "network"]
+safety = "critical"
+
+[suites.perf_test]
+subsystems = ["execution"]
+safety = "normal"
+"#;
+        // Write temp config
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("forge-suite-subsystems.toml");
+        fs::write(&config_path, config_toml).unwrap();
+
+        let skips = compute_forge_skips(&affected, Some(&config_path));
+        // framework_upgrade should be skipped (not affected), perf_test should be skipped
+        // compat should NOT be skipped (critical safety)
+        assert!(skips.contains(&"framework_upgrade".to_string()));
+        assert!(skips.contains(&"perf_test".to_string()));
+        assert!(!skips.contains(&"compat".to_string()));
+    }
+
+    #[test]
+    fn test_json_output() {
+        let plan = TestPlan::generate(&[], &[], None);
+        let json = plan.to_json();
+        assert!(json.contains("subsystems_affected"));
+        assert!(json.contains("safety_override"));
+    }
+}


### PR DESCRIPTION
## Summary

- Feature-gate `aptos-node` and `aptos-workspace-server` behind `localnet` feature in the CLI crate to break the dependency fan-in that causes ~150+ packages to be marked affected on nearly every PR
- Add `cargo x targeted-test-plan` command that outputs a JSON test plan mapping changed files to subsystems and making per-suite skip decisions
- Add Forge suite-to-subsystem config for granular test skipping
- Rewrite test-target-determinator GitHub Action to consume JSON test plan

## Test plan

- [x] `cargo check -p aptos --no-default-features` compiles clean (localnet disabled, no aptos-node dep)
- [x] `cargo check -p aptos` compiles clean (default features, backward compatible)
- [x] `cargo test -p aptos-cargo-cli` -- 16 tests pass (9 existing + 7 new)
- [ ] Validate `cargo x targeted-test-plan` output on real PRs with known changes
- [ ] Shadow mode: run new determinator alongside old, compare decisions
- [ ] Remaining phases: Move-aware targeting, test impact analysis, nightly safety net