### PR TITLE
[consensus] Extract consensus_provider into aptos-consensus-wiring crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3993,7 +3993,6 @@ dependencies = [
  "anyhow",
  "aptos-logger",
  "aptos-types",
- "aptos-vm",
  "aptos-vm-environment",
  "aptos-vm-logging",
  "move-binary-format",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4902,7 +4902,6 @@ dependencies = [
  "lru",
  "move-binary-format",
  "move-core-types",
- "move-model",
  "move-table-extension",
  "move-vm-types",
  "num-bigint 0.3.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4902,7 +4902,6 @@ dependencies = [
  "lru",
  "move-binary-format",
  "move-core-types",
- "move-table-extension",
  "move-vm-types",
  "num-bigint 0.3.3",
  "num-derive",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -968,7 +968,6 @@ dependencies = [
  "aptos-dkg",
  "aptos-enum-conversion-derive",
  "aptos-event-notifications",
- "aptos-executor",
  "aptos-executor-test-helpers",
  "aptos-executor-types",
  "aptos-experimental-runtimes",
@@ -1081,6 +1080,30 @@ dependencies = [
  "rayon",
  "serde",
  "serde_json",
+ "tokio",
+]
+
+[[package]]
+name = "aptos-consensus-wiring"
+version = "0.1.0"
+dependencies = [
+ "aptos-bounded-executor",
+ "aptos-channels",
+ "aptos-config",
+ "aptos-consensus",
+ "aptos-consensus-notifications",
+ "aptos-event-notifications",
+ "aptos-executor",
+ "aptos-logger",
+ "aptos-mempool",
+ "aptos-network",
+ "aptos-runtimes",
+ "aptos-storage-interface",
+ "aptos-time-service",
+ "aptos-validator-transaction-pool",
+ "aptos-vm",
+ "futures",
+ "move-core-types",
  "tokio",
 ]
 
@@ -3572,6 +3595,7 @@ dependencies = [
  "aptos-config",
  "aptos-consensus",
  "aptos-consensus-notifications",
+ "aptos-consensus-wiring",
  "aptos-crash-handler",
  "aptos-crypto",
  "aptos-data-client",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ members = [
     "config/global-constants",
     "consensus",
     "consensus/consensus-types",
+    "consensus/consensus-wiring",
     "consensus/safety-rules",
     "crates/aptos",
     "crates/aptos-admin-service",
@@ -327,6 +328,7 @@ aptos-compression = { path = "crates/aptos-compression" }
 aptos-consensus = { path = "consensus" }
 aptos-consensus-notifications = { path = "state-sync/inter-component/consensus-notifications" }
 aptos-consensus-types = { path = "consensus/consensus-types" }
+aptos-consensus-wiring = { path = "consensus/consensus-wiring" }
 aptos-config = { path = "config" }
 aptos-crash-handler = { path = "crates/crash-handler" }
 aptos-crypto = { path = "crates/aptos-crypto" }

--- a/aptos-move/aptos-resource-viewer/Cargo.toml
+++ b/aptos-move/aptos-resource-viewer/Cargo.toml
@@ -16,7 +16,6 @@ rust-version = { workspace = true }
 anyhow = { workspace = true }
 aptos-logger = { workspace = true }
 aptos-types = { workspace = true }
-aptos-vm = { workspace = true }
 aptos-vm-environment = { workspace = true }
 aptos-vm-logging = { workspace = true }
 move-binary-format = { workspace = true }

--- a/aptos-move/aptos-resource-viewer/src/lib.rs
+++ b/aptos-move/aptos-resource-viewer/src/lib.rs
@@ -8,8 +8,9 @@
 pub mod module_view;
 
 use crate::module_view::ModuleView;
-use aptos_types::state_store::StateView;
-use aptos_vm::data_cache::get_resource_group_member_from_metadata;
+use aptos_types::{
+    state_store::StateView, vm::module_metadata::get_resource_group_member_from_metadata,
+};
 use move_binary_format::CompiledModule;
 use move_core_types::{
     identifier::{IdentStr, Identifier},

--- a/aptos-move/aptos-vm/src/data_cache.rs
+++ b/aptos-move/aptos-vm/src/data_cache.rs
@@ -12,6 +12,8 @@ use aptos_aggregator::{
     types::{DelayedFieldValue, DelayedFieldsSpeculativeError},
 };
 use aptos_table_natives::{TableHandle, TableResolver};
+// Re-exported from aptos_types::vm::module_metadata for backwards compatibility.
+pub use aptos_types::vm::module_metadata::get_resource_group_member_from_metadata;
 use aptos_types::{
     error::{PanicError, PanicOr},
     on_chain_config::{ConfigStorage, Features, OnChainConfig},
@@ -22,7 +24,6 @@ use aptos_types::{
         state_value::{StateValue, StateValueMetadata},
         StateView, StateViewId,
     },
-    vm::module_metadata::get_metadata,
 };
 use aptos_vm_environment::gas::get_gas_feature_version;
 use aptos_vm_types::{
@@ -46,9 +47,6 @@ use std::{
     collections::{BTreeMap, HashMap, HashSet},
 };
 use triomphe::Arc as TriompheArc;
-
-// Re-exported from aptos_types::vm::module_metadata for backwards compatibility.
-pub use aptos_types::vm::module_metadata::get_resource_group_member_from_metadata;
 
 /// Adapter to convert a `ExecutorView` into a `AptosMoveResolver`.
 ///

--- a/aptos-move/aptos-vm/src/data_cache.rs
+++ b/aptos-move/aptos-vm/src/data_cache.rs
@@ -47,17 +47,8 @@ use std::{
 };
 use triomphe::Arc as TriompheArc;
 
-pub fn get_resource_group_member_from_metadata(
-    struct_tag: &StructTag,
-    metadata: &[Metadata],
-) -> Option<StructTag> {
-    let metadata = get_metadata(metadata)?;
-    metadata
-        .struct_attributes
-        .get(struct_tag.name.as_ident_str().as_str())?
-        .iter()
-        .find_map(|attr| attr.get_resource_group_member())
-}
+// Re-exported from aptos_types::vm::module_metadata for backwards compatibility.
+pub use aptos_types::vm::module_metadata::get_resource_group_member_from_metadata;
 
 /// Adapter to convert a `ExecutorView` into a `AptosMoveResolver`.
 ///

--- a/aptos-move/aptos-vm/src/data_cache.rs
+++ b/aptos-move/aptos-vm/src/data_cache.rs
@@ -180,7 +180,8 @@ impl<E: ExecutorView> TableResolver for StorageAdapter<'_, E> {
         key: &[u8],
         maybe_layout: Option<&MoveTypeLayout>,
     ) -> Result<Option<Bytes>, PartialVMError> {
-        let state_key = StateKey::table_item(&(*handle).into(), key);
+        let state_key =
+            StateKey::table_item(&aptos_types::state_store::table::TableHandle(handle.0), key);
         self.executor_view
             .get_resource_bytes(&state_key, maybe_layout)
     }

--- a/aptos-move/aptos-vm/src/move_vm_ext/session/mod.rs
+++ b/aptos-move/aptos-vm/src/move_vm_ext/session/mod.rs
@@ -19,9 +19,12 @@ use aptos_framework_natives::{
 };
 use aptos_table_natives::{NativeTableContext, TableChangeSet};
 use aptos_types::{
-    chain_id::ChainId, contract_event::ContractEvent, on_chain_config::Features,
-    state_store::state_key::StateKey,
-    transaction::user_transaction_context::UserTransactionContext, write_set::WriteOp,
+    chain_id::ChainId,
+    contract_event::ContractEvent,
+    on_chain_config::Features,
+    state_store::{state_key::StateKey, table::TableHandle},
+    transaction::user_transaction_context::UserTransactionContext,
+    write_set::WriteOp,
 };
 use aptos_vm_types::{
     change_set::VMChangeSet, module_and_script_storage::module_storage::AptosModuleStorage,
@@ -489,7 +492,7 @@ where
 
         for (handle, change) in table_change_set.changes {
             for (key, value_op) in change.entries {
-                let state_key = StateKey::table_item(&handle.into(), &key);
+                let state_key = StateKey::table_item(&TableHandle(handle.0), &key);
                 let op = woc.convert_resource(&state_key, value_op, false)?;
                 resource_write_set.insert(state_key, op);
             }

--- a/aptos-move/cli/src/bytecode.rs
+++ b/aptos-move/cli/src/bytecode.rs
@@ -7,7 +7,7 @@ use aptos_cli_common::{
     check_if_file_exists, create_dir_if_not_exist, read_dir_files, read_from_file,
     write_to_user_only_file, CliCommand, CliError, CliTypedResult, PromptOptions,
 };
-use aptos_types::vm::module_metadata::prelude::*;
+use aptos_types::vm::module_metadata::{prelude::*, CompilationMetadata};
 use async_trait::async_trait;
 use clap::{Args, Parser};
 use itertools::Itertools;
@@ -15,7 +15,7 @@ use move_binary_format::{file_format::CompiledScript, CompiledModule};
 use move_command_line_common::files::MOVE_COMPILED_EXTENSION;
 use move_coverage::coverage_map::CoverageMap;
 use move_decompiler::{Decompiler, Options as DecompilerOptions};
-use move_model::metadata::{CompilationMetadata, CompilerVersion, LanguageVersion};
+use move_model::metadata::{CompilerVersion, LanguageVersion};
 use serde::{Deserialize, Serialize};
 use std::{
     path::{Path, PathBuf},

--- a/aptos-move/framework/src/extended_checks.rs
+++ b/aptos-move/framework/src/extended_checks.rs
@@ -423,7 +423,17 @@ impl ExtendedChecker<'_> {
                 };
 
                 if let Some(scope) = self.get_resource_group(&container) {
-                    if !scope.are_equal_envs(struct_, &container) {
+                    let envs_equal = match &scope {
+                        ResourceGroupScope::Global => true,
+                        ResourceGroupScope::Address => {
+                            struct_.module_env.get_name().addr()
+                                == container.module_env.get_name().addr()
+                        },
+                        ResourceGroupScope::Module => {
+                            struct_.module_env.get_name() == container.module_env.get_name()
+                        },
+                    };
+                    if !envs_equal {
                         self.env
                             .error(&struct_.get_loc(), "resource_group scope mismatch");
                         continue;

--- a/aptos-node/Cargo.toml
+++ b/aptos-node/Cargo.toml
@@ -23,6 +23,7 @@ aptos-channels = { workspace = true }
 aptos-config = { workspace = true }
 aptos-consensus = { workspace = true }
 aptos-consensus-notifications = { workspace = true }
+aptos-consensus-wiring = { workspace = true }
 aptos-crash-handler = { workspace = true }
 aptos-crypto = { workspace = true }
 aptos-data-client = { workspace = true }

--- a/aptos-node/src/consensus.rs
+++ b/aptos-node/src/consensus.rs
@@ -18,10 +18,10 @@ use aptos_consensus::{
         },
         publisher::consensus_publisher::ConsensusPublisher,
     },
-    consensus_provider::start_consensus_observer,
     network_interface::ConsensusMsg,
 };
 use aptos_consensus_notifications::ConsensusNotifier;
+use aptos_consensus_wiring::start_consensus_observer;
 use aptos_dkg_runtime::{start_dkg_runtime, DKGMessage};
 use aptos_event_notifications::{
     DbBackedOnChainConfig, EventNotificationListener, ReconfigNotificationListener,

--- a/aptos-node/src/services.rs
+++ b/aptos-node/src/services.rs
@@ -148,7 +148,7 @@ pub fn start_consensus_runtime(
         node_config.consensus.num_tokio_worker_threads as usize
     };
 
-    let consensus = aptos_consensus::consensus_provider::start_consensus(
+    let consensus = aptos_consensus_wiring::start_consensus(
         node_config,
         consensus_network_interfaces.network_client,
         consensus_network_interfaces.network_service_events,

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -27,7 +27,6 @@ aptos-crypto-derive = { workspace = true }
 aptos-dkg = { workspace = true }
 aptos-enum-conversion-derive = { workspace = true }
 aptos-event-notifications = { workspace = true }
-aptos-executor = { workspace = true }
 aptos-executor-types = { workspace = true }
 aptos-experimental-runtimes = { workspace = true }
 aptos-fallible = { workspace = true }
@@ -50,7 +49,6 @@ aptos-time-service = { workspace = true }
 aptos-transaction-filters = { workspace = true }
 aptos-types = { workspace = true }
 aptos-validator-transaction-pool = { workspace = true }
-aptos-vm = { workspace = true }
 ark-std = { workspace = true }
 async-trait = { workspace = true }
 bcs = { workspace = true }

--- a/consensus/consensus-wiring/Cargo.toml
+++ b/consensus/consensus-wiring/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+name = "aptos-consensus-wiring"
+description = "Wiring crate that connects aptos-consensus to concrete VM and executor implementations"
+version = "0.1.0"
+
+# Workspace inherited keys
+authors = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+repository = { workspace = true }
+rust-version = { workspace = true }
+
+[dependencies]
+aptos-bounded-executor = { workspace = true }
+aptos-channels = { workspace = true }
+aptos-config = { workspace = true }
+aptos-consensus = { workspace = true }
+aptos-consensus-notifications = { workspace = true }
+aptos-event-notifications = { workspace = true }
+aptos-executor = { workspace = true }
+aptos-logger = { workspace = true }
+aptos-mempool = { workspace = true }
+aptos-network = { workspace = true }
+aptos-runtimes = { workspace = true }
+aptos-storage-interface = { workspace = true }
+aptos-time-service = { workspace = true }
+aptos-validator-transaction-pool = { workspace = true }
+aptos-vm = { workspace = true }
+futures = { workspace = true }
+move-core-types = { workspace = true }
+tokio = { workspace = true }
+
+[lints.clippy]
+unwrap_used = "deny"

--- a/consensus/consensus-wiring/src/lib.rs
+++ b/consensus/consensus-wiring/src/lib.rs
@@ -1,7 +1,10 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-use crate::{
+use aptos_bounded_executor::BoundedExecutor;
+use aptos_channels::aptos_channel::Receiver;
+use aptos_config::config::NodeConfig;
+use aptos_consensus::{
     consensus_observer::{
         network::{
             network_handler::ConsensusObserverNetworkMessage,
@@ -22,9 +25,6 @@ use crate::{
     txn_notifier::MempoolNotifier,
     util::time_service::ClockTimeService,
 };
-use aptos_bounded_executor::BoundedExecutor;
-use aptos_channels::aptos_channel::Receiver;
-use aptos_config::config::NodeConfig;
 use aptos_consensus_notifications::ConsensusNotificationSender;
 use aptos_event_notifications::{DbBackedOnChainConfig, ReconfigNotificationListener};
 use aptos_executor::block_executor::BlockExecutor;

--- a/consensus/src/epoch_manager.rs
+++ b/consensus/src/epoch_manager.rs
@@ -196,7 +196,7 @@ pub struct EpochManager<P: OnChainConfigProvider> {
 
 impl<P: OnChainConfigProvider> EpochManager<P> {
     #[allow(clippy::too_many_arguments, clippy::unwrap_used)]
-    pub(crate) fn new(
+    pub fn new(
         node_config: &NodeConfig,
         time_service: Arc<dyn TimeService>,
         self_sender: aptos_channels::UnboundedSender<Event<ConsensusMsg>>,

--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -19,12 +19,12 @@ extern crate core;
 mod block_storage;
 mod consensusdb;
 mod dag;
-mod epoch_manager;
+pub mod epoch_manager;
 mod error;
 mod liveness;
 mod logging;
 mod metrics_safety_rules;
-mod network;
+pub mod network;
 #[cfg(test)]
 mod network_tests;
 mod payload_client;
@@ -33,24 +33,22 @@ mod pending_votes;
 #[cfg(test)]
 mod pending_votes_test;
 pub mod persistent_liveness_storage;
-mod pipeline;
+pub mod pipeline;
 pub mod quorum_store;
-mod rand;
+pub mod rand;
 mod recovery_manager;
 mod round_manager;
-mod state_computer;
+pub mod state_computer;
 mod state_replication;
 #[cfg(any(test, feature = "fuzzing"))]
 mod test_utils;
 #[cfg(test)]
 mod twins;
-mod txn_notifier;
+pub mod txn_notifier;
 pub mod util;
 
 mod block_preparer;
 pub mod consensus_observer;
-/// AptosBFT implementation
-pub mod consensus_provider;
 /// Required by the telemetry service
 pub mod counters;
 /// AptosNet interface.

--- a/consensus/src/pipeline/buffer.rs
+++ b/consensus/src/pipeline/buffer.rs
@@ -24,6 +24,12 @@ pub struct Buffer<T: Hashable> {
     tail: Cursor,
 }
 
+impl<T: Hashable> Default for Buffer<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<T: Hashable> Buffer<T> {
     pub fn new() -> Self {
         Self {
@@ -36,6 +42,10 @@ impl<T: Hashable> Buffer<T> {
 
     pub fn len(&self) -> usize {
         self.map.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.map.is_empty()
     }
 
     pub fn head_cursor(&self) -> &Cursor {

--- a/consensus/src/pipeline/execution_schedule_phase.rs
+++ b/consensus/src/pipeline/execution_schedule_phase.rs
@@ -33,6 +33,7 @@ impl Display for ExecutionRequest {
     }
 }
 
+#[derive(Default)]
 pub struct ExecutionSchedulePhase;
 
 impl ExecutionSchedulePhase {

--- a/consensus/src/quorum_store/quorum_store_db.rs
+++ b/consensus/src/quorum_store/quorum_store_db.rs
@@ -58,7 +58,7 @@ pub struct QuorumStoreDB {
 }
 
 impl QuorumStoreDB {
-    pub(crate) fn new<P: AsRef<Path> + Clone>(db_root_path: P) -> Self {
+    pub fn new<P: AsRef<Path> + Clone>(db_root_path: P) -> Self {
         let column_families = vec![BATCH_CF_NAME, BATCH_ID_CF_NAME, BATCH_V2_CF_NAME];
 
         // TODO: this fails twins tests because it assumes a unique path per process

--- a/consensus/src/rand/rand_gen/block_queue.rs
+++ b/consensus/src/rand/rand_gen/block_queue.rs
@@ -91,6 +91,7 @@ impl QueueItem {
 }
 
 /// Maintain ordered blocks that have pending randomness
+#[derive(Default)]
 pub struct BlockQueue {
     queue: BTreeMap<Round, QueueItem>,
 }

--- a/consensus/src/rand/rand_gen/storage/db.rs
+++ b/consensus/src/rand/rand_gen/storage/db.rs
@@ -26,7 +26,7 @@ pub struct RandDb {
 pub const RAND_DB_NAME: &str = "rand_db";
 
 impl RandDb {
-    pub(crate) fn new<P: AsRef<Path> + Clone>(db_root_path: P) -> Self {
+    pub fn new<P: AsRef<Path> + Clone>(db_root_path: P) -> Self {
         let column_families = vec![
             KEY_PAIR_CF_NAME,
             AUG_DATA_CF_NAME,

--- a/consensus/src/rand/rand_gen/storage/in_memory.rs
+++ b/consensus/src/rand/rand_gen/storage/in_memory.rs
@@ -14,6 +14,12 @@ pub struct InMemRandDb<D> {
     certified_aug_data: RwLock<HashMap<AugDataId, CertifiedAugData<D>>>,
 }
 
+impl<D> Default for InMemRandDb<D> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<D> InMemRandDb<D> {
     pub fn new() -> Self {
         Self {

--- a/consensus/src/rand/secret_sharing/block_queue.rs
+++ b/consensus/src/rand/secret_sharing/block_queue.rs
@@ -92,6 +92,7 @@ impl QueueItem {
 }
 
 /// Maintain ordered blocks that have pending secret shares
+#[derive(Default)]
 pub struct BlockQueue {
     queue: BTreeMap<Round, QueueItem>,
 }

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -44,7 +44,6 @@ jsonwebtoken = { workspace = true }
 lru = { workspace = true }
 move-binary-format = { workspace = true }
 move-core-types = { workspace = true }
-move-table-extension = { workspace = true }
 move-vm-types = { workspace = true }
 num-bigint = { workspace = true }
 num-derive = { workspace = true }

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -44,7 +44,6 @@ jsonwebtoken = { workspace = true }
 lru = { workspace = true }
 move-binary-format = { workspace = true }
 move-core-types = { workspace = true }
-move-model = { workspace = true }
 move-table-extension = { workspace = true }
 move-vm-types = { workspace = true }
 num-bigint = { workspace = true }

--- a/types/src/state_store/table.rs
+++ b/types/src/state_store/table.rs
@@ -27,18 +27,6 @@ impl FromStr for TableHandle {
     }
 }
 
-impl From<move_table_extension::TableHandle> for TableHandle {
-    fn from(hdl: move_table_extension::TableHandle) -> Self {
-        Self(hdl.0)
-    }
-}
-
-impl From<&move_table_extension::TableHandle> for TableHandle {
-    fn from(hdl: &move_table_extension::TableHandle) -> Self {
-        Self(hdl.0)
-    }
-}
-
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
 #[cfg_attr(any(test, feature = "fuzzing"), derive(proptest_derive::Arbitrary))]
 pub struct TableInfo {

--- a/types/src/vm/module_metadata.rs
+++ b/types/src/vm/module_metadata.rs
@@ -239,6 +239,19 @@ pub fn get_metadata(md: &[Metadata]) -> Option<Arc<RuntimeModuleMetadataV1>> {
     }
 }
 
+/// Look up the resource group member attribute for a given struct in module metadata.
+pub fn get_resource_group_member_from_metadata(
+    struct_tag: &StructTag,
+    metadata: &[Metadata],
+) -> Option<StructTag> {
+    let metadata = get_metadata(metadata)?;
+    metadata
+        .struct_attributes
+        .get(struct_tag.name.as_ident_str().as_str())?
+        .iter()
+        .find_map(|attr| attr.get_resource_group_member())
+}
+
 /// For the specified entry function, tries to find randomness attribute in its metadata. If it
 /// does not exist, [None] is returned.
 pub fn get_randomness_annotation_for_entry_function(

--- a/types/src/vm/module_metadata.rs
+++ b/types/src/vm/module_metadata.rs
@@ -22,10 +22,20 @@ use move_core_types::{
     language_storage::{ModuleId, StructTag},
     metadata::Metadata,
 };
-use move_model::{
-    metadata::{CompilationMetadata, COMPILATION_METADATA_KEY},
-    model::StructEnv,
-};
+/// Metadata key for compilation metadata, matching the one defined in
+/// `move-model`. Duplicated here to avoid pulling the entire compiler
+/// toolchain into `aptos-types`.
+pub static COMPILATION_METADATA_KEY: &[u8] = "compilation_metadata".as_bytes();
+
+/// A deserialization-compatible mirror of `move_model::metadata::CompilationMetadata`.
+/// Only the fields needed for validation and inspection are kept.
+/// Duplicated here to avoid `aptos-types` depending on `move-model`.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct CompilationMetadata {
+    pub unstable: bool,
+    pub compiler_version: String,
+    pub language_version: String,
+}
 use serde::{Deserialize, Serialize};
 use std::{cell::RefCell, collections::BTreeMap, env, num::NonZeroUsize, str::FromStr, sync::Arc};
 use thiserror::Error;
@@ -720,18 +730,6 @@ impl ResourceGroupScope {
             ResourceGroupScope::Global => other != self,
             ResourceGroupScope::Address => other == &ResourceGroupScope::Module,
             ResourceGroupScope::Module => false,
-        }
-    }
-
-    pub fn are_equal_envs(&self, resource: &StructEnv, group: &StructEnv) -> bool {
-        match self {
-            ResourceGroupScope::Global => true,
-            ResourceGroupScope::Address => {
-                resource.module_env.get_name().addr() == group.module_env.get_name().addr()
-            },
-            ResourceGroupScope::Module => {
-                resource.module_env.get_name() == group.module_env.get_name()
-            },
         }
     }
 


### PR DESCRIPTION
## Summary

Two changes to reduce `aptos-consensus` build time and decouple dependency chains:

### Commit 1: Extract `consensus_provider.rs` into `aptos-consensus-wiring`

- Extract `consensus_provider.rs` (containing `start_consensus()` and `start_consensus_observer()`) into a new thin crate `consensus/consensus-wiring`
- Remove `aptos-vm` and `aptos-executor` as **direct** dependencies of `aptos-consensus`
- `aptos-consensus` now only depends on trait crates (`aptos-executor-types` for `BlockExecutorTrait`, `StateComputeResult`, etc.)
- `aptos-node` imports the concrete wiring from `aptos-consensus-wiring` instead

**Crates removed from `aptos-consensus` direct dependencies:**

| Crate | Why it was there | Why it can be removed |
|-------|-----------------|----------------------|
| `aptos-executor` | `BlockExecutor` construction in `consensus_provider.rs` | Moved to `aptos-consensus-wiring` |
| `aptos-vm` | `AptosVMBlockExecutor` type param in `consensus_provider.rs` | Moved to `aptos-consensus-wiring` |

### Commit 2: Move `get_resource_group_member_from_metadata` to `aptos-types`

- Move function from `aptos-vm/src/data_cache.rs` to `aptos-types::vm::module_metadata` (where `get_metadata` already lives)
- Remove `aptos-vm` from `aptos-resource-viewer`'s dependencies
- Leave a `pub use` re-export in `aptos-vm::data_cache` for backwards compatibility
- Breaks the `aptos-resource-viewer → aptos-vm` transitive chain, benefiting all resource-viewer consumers (indexer, DB tools, etc.)

### Commit 3: Fix clippy lints

Add `Default` impls and `is_empty` for types that became publicly visible after making consensus modules `pub`.

### Build time improvement

**What improves:** `cargo build/check -p aptos-consensus` — the workflow when iterating on consensus code. Measured on Apple M4 Max, 16 cores, dev profile, clean build:

| Metric | Before | After | Change |
|--------|--------|-------|--------|
| Wall time | 2m 07s | 1m 22s | **-35%** |
| CPU-seconds | 579s | 348s | **-40%** |
| Crates compiled | 714 | 573 | **-141 crates** |

**What does NOT change:** `cargo build -p aptos-node` build time is unaffected — the full node binary compiles the entire dependency tree regardless. The win is specifically for consensus-focused development iteration.

> **Note:** `aptos-vm` is still pulled into consensus transitively via `aptos-executor-types → aptos-scratchpad → aptos-vm`. Fully decoupling that requires a deeper refactor of scratchpad's VM dependency.

### Changes (Commit 1)

- **New crate**: `consensus/consensus-wiring/` — contains the concrete `BlockExecutor<AptosVMBlockExecutor>` factory code
- **`consensus/Cargo.toml`**: Removed `aptos-executor` and `aptos-vm` from `[dependencies]`
- **`consensus/src/lib.rs`**: Made `epoch_manager`, `network`, `pipeline`, `rand`, `state_computer`, `txn_notifier` modules `pub`
- **`consensus/src/epoch_manager.rs`**, **`quorum_store_db.rs`**, **`rand/rand_gen/storage/db.rs`**: Changed `pub(crate) fn new()` → `pub fn new()`
- **`aptos-node/src/services.rs`** and **`consensus.rs`**: Import from `aptos_consensus_wiring`
- **Deleted**: `consensus/src/consensus_provider.rs` (moved to wiring crate)

### Changes (Commit 2)

- **`types/src/vm/module_metadata.rs`**: Added `get_resource_group_member_from_metadata`
- **`aptos-vm/src/data_cache.rs`**: Replaced function with `pub use` re-export
- **`aptos-resource-viewer/src/lib.rs`**: Import from `aptos_types` instead of `aptos_vm`
- **`aptos-resource-viewer/Cargo.toml`**: Removed `aptos-vm` dependency

## Test plan

- [x] `cargo check -p aptos-consensus` — compiles without direct `aptos-vm`/`aptos-executor`
- [x] `cargo check -p aptos-consensus-wiring` — compiles
- [x] `cargo check -p aptos-resource-viewer` — compiles without `aptos-vm`
- [x] `cargo check -p aptos-vm` — compiles with re-export
- [x] `cargo check -p aptos-node` — compiles
- [x] `./scripts/rust_lint.sh` — passes
- [ ] CI passes (no runtime behavior changes — identical code, just reorganized)