### PR TITLE
[consensus] Add per-author committed batch metrics

### DIFF
--- a/consensus/src/quorum_store/counters.rs
+++ b/consensus/src/quorum_store/counters.rs
@@ -3,12 +3,15 @@
 
 #![allow(clippy::unwrap_used)]
 
-use aptos_consensus_types::block::Block;
+use aptos_consensus_types::{
+    block::Block, common::Payload, payload::OptQuorumStorePayload, proof_of_store::TBatchInfo,
+};
 use aptos_metrics_core::{
     exponential_buckets, op_counters::DurationHistogram, register_avg_counter, register_histogram,
     register_histogram_vec, register_int_counter, register_int_counter_vec, Histogram,
     HistogramVec, IntCounter, IntCounterVec,
 };
+use aptos_short_hex_str::AsShortHexStr;
 use once_cell::sync::Lazy;
 use std::time::Duration;
 
@@ -224,6 +227,57 @@ pub fn update_batch_stats(block: &Block) {
     TXN_BYTES_PER_BATCH_TYPE_PER_BLOCK
         .with_label_values(&["opt_batch"])
         .observe(opt_batch_txn_bytes as f64);
+
+    update_committed_batches_by_author(block);
+}
+
+fn update_committed_batches_by_author(block: &Block) {
+    let Some(payload) = block.payload() else {
+        return;
+    };
+    let Payload::OptQuorumStore(opt_qs) = payload else {
+        return;
+    };
+
+    // Helper to record per-author stats for a batch type
+    fn record_batch_author(author: aptos_types::PeerId, num_txns: u64, batch_type: &str) {
+        let author_str = author.short_str();
+        COMMITTED_BATCHES_BY_AUTHOR
+            .with_label_values(&[author_str.as_str(), batch_type])
+            .inc();
+        COMMITTED_TXNS_BY_AUTHOR
+            .with_label_values(&[author_str.as_str(), batch_type])
+            .inc_by(num_txns);
+    }
+
+    match opt_qs {
+        OptQuorumStorePayload::V1(p) => {
+            for proof in p.proof_with_data().iter() {
+                let info = proof.info();
+                record_batch_author(info.author(), info.num_txns(), "proof");
+            }
+            for batch in p.opt_batches().iter() {
+                record_batch_author(batch.author(), batch.num_txns(), "opt_batch");
+            }
+            for batch in p.inline_batches().iter() {
+                let info = batch.info();
+                record_batch_author(info.author(), TBatchInfo::num_txns(info), "inline_batch");
+            }
+        },
+        OptQuorumStorePayload::V2(p) => {
+            for proof in p.proof_with_data().iter() {
+                let info = proof.info();
+                record_batch_author(info.author(), info.num_txns(), "proof");
+            }
+            for batch in p.opt_batches().iter() {
+                record_batch_author(batch.author(), batch.num_txns(), "opt_batch");
+            }
+            for batch in p.inline_batches().iter() {
+                let info = batch.info();
+                record_batch_author(info.author(), TBatchInfo::num_txns(info), "inline_batch");
+            }
+        },
+    }
 }
 
 /// Histogram for the number of transactions per batch.
@@ -1078,6 +1132,28 @@ pub static BATCH_VOTE_PROGRESS: Lazy<HistogramVec> = Lazy::new(|| {
         "Histogram for vote collection of a QS batch",
         &["author", "vote_pct", "batch_version"],
         BATCH_TRACING_BUCKETS.to_vec()
+    )
+    .unwrap()
+});
+
+/// Counter for committed batches per author and type (proof, opt_batch, inline_batch).
+/// Unlike BATCH_PULLED_BY_AUTHOR which counts at proposal pull time, this counts
+/// batches that are actually committed in blocks.
+pub static COMMITTED_BATCHES_BY_AUTHOR: Lazy<IntCounterVec> = Lazy::new(|| {
+    register_int_counter_vec!(
+        "quorum_store_committed_batches_by_author",
+        "Number of committed batches by author and batch type (proof, opt_batch, inline_batch)",
+        &["author", "type"]
+    )
+    .unwrap()
+});
+
+/// Counter for committed txns per author and type (proof, opt_batch, inline_batch).
+pub static COMMITTED_TXNS_BY_AUTHOR: Lazy<IntCounterVec> = Lazy::new(|| {
+    register_int_counter_vec!(
+        "quorum_store_committed_txns_by_author",
+        "Number of committed transactions by author and batch type (proof, opt_batch, inline_batch)",
+        &["author", "type"]
     )
     .unwrap()
 });


### PR DESCRIPTION
Add two new counters that track committed batches and txns per author and batch type (proof/opt_batch/inline_batch):

- quorum_store_committed_batches_by_author{author, type}
- quorum_store_committed_txns_by_author{author, type}

Unlike the existing BATCH_PULLED_BY_AUTHOR (recorded at proposal pull time), these are recorded at commit time in update_batch_stats(), measuring what actually lands in committed blocks.

This enables measuring the proof vs opt-batch split for specific batch authors (e.g., geographically remote validators) to understand PoS formation latency impact on block inclusion.

## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new per-block commit-time metric updates in the consensus hot path, increasing label cardinality (`author`) and adding iteration over committed payload batches/proofs, which could affect metrics volume/performance if misused.
> 
> **Overview**
> Adds two new Quorum Store counters, `quorum_store_committed_batches_by_author` and `quorum_store_committed_txns_by_author`, labeled by batch `author` and batch `type` (proof/opt_batch/inline_batch).
> 
> `update_batch_stats()` now also inspects committed `OptQuorumStorePayload` (V1/V2) to attribute committed proofs and batches to their authors using short-hex peer IDs, enabling commit-time (not pull-time) per-author inclusion tracking.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 22bec771bcf086fdb76e113b23536a357c6b29a5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->