### PR TITLE
[vm] Limits for entries

### DIFF
--- a/aptos-move/aptos-release-builder/src/components/feature_flags.rs
+++ b/aptos-move/aptos-release-builder/src/components/feature_flags.rs
@@ -303,7 +303,7 @@ impl From<FeatureFlag> for AptosFeatureFlag {
                 AptosFeatureFlag::AGGREGATOR_V2_DELAYED_FIELDS
             },
             FeatureFlag::ConcurrentTokenV2 => AptosFeatureFlag::CONCURRENT_TOKEN_V2,
-            FeatureFlag::LimitMaxIdentifierLength => AptosFeatureFlag::LIMIT_MAX_IDENTIFIER_LENGTH,
+            FeatureFlag::LimitMaxIdentifierLength => AptosFeatureFlag::_LIMIT_MAX_IDENTIFIER_LENGTH,
             FeatureFlag::OperatorBeneficiaryChange => AptosFeatureFlag::OPERATOR_BENEFICIARY_CHANGE,
             FeatureFlag::ResourceGroupsSplitInVmChangeSet => {
                 AptosFeatureFlag::RESOURCE_GROUPS_SPLIT_IN_VM_CHANGE_SET
@@ -492,7 +492,7 @@ impl From<AptosFeatureFlag> for FeatureFlag {
                 FeatureFlag::AggregatorV2DelayedFields
             },
             AptosFeatureFlag::CONCURRENT_TOKEN_V2 => FeatureFlag::ConcurrentTokenV2,
-            AptosFeatureFlag::LIMIT_MAX_IDENTIFIER_LENGTH => FeatureFlag::LimitMaxIdentifierLength,
+            AptosFeatureFlag::_LIMIT_MAX_IDENTIFIER_LENGTH => FeatureFlag::LimitMaxIdentifierLength,
             AptosFeatureFlag::OPERATOR_BENEFICIARY_CHANGE => FeatureFlag::OperatorBeneficiaryChange,
             AptosFeatureFlag::RESOURCE_GROUPS_SPLIT_IN_VM_CHANGE_SET => {
                 FeatureFlag::ResourceGroupsSplitInVmChangeSet

--- a/aptos-move/aptos-resource-viewer/src/module_view.rs
+++ b/aptos-move/aptos-resource-viewer/src/module_view.rs
@@ -41,7 +41,10 @@ pub struct ModuleView<'a, S> {
 impl<'a, S: StateView> ModuleView<'a, S> {
     pub fn new(state_view: &'a S) -> Self {
         let features = Features::fetch_config(state_view).unwrap_or_default();
-        let deserializer_config = aptos_prod_deserializer_config(&features);
+        // gas_feature_version=0 takes the pre-v1.46 path, which keeps
+        // max_identifier_size=255 and leaves payload limits at u64::MAX.
+        // This is correct: the resource viewer only deserializes modules.
+        let deserializer_config = aptos_prod_deserializer_config(0, &features);
 
         Self {
             module_cache: RefCell::new(HashMap::new()),

--- a/aptos-move/aptos-transaction-simulation/src/state_store.rs
+++ b/aptos-move/aptos-transaction-simulation/src/state_store.rs
@@ -176,10 +176,11 @@ pub trait SimulationStateStore: TStateView<Key = StateKey> {
         Self: Sized,
     {
         let features = self.get_features()?;
-        let deserializer_config = DeserializerConfig::new(
-            features.get_max_binary_format_version(),
-            features.get_max_identifier_size(),
-        );
+        let deserializer_config = DeserializerConfig {
+            max_binary_format_version: features.get_max_binary_format_version(),
+            max_identifier_size: features.get_max_identifier_size(),
+            ..DeserializerConfig::default()
+        };
 
         let blob = match self.get_state_value_bytes(&StateKey::module_id(module_id))? {
             Some(bytes) => bytes,

--- a/aptos-move/aptos-vm-environment/src/prod_configs.rs
+++ b/aptos-move/aptos-vm-environment/src/prod_configs.rs
@@ -5,7 +5,7 @@ pub use aptos_gas_schedule::LATEST_GAS_FEATURE_VERSION;
 use aptos_gas_schedule::{
     gas_feature_versions::{
         RELEASE_V1_15, RELEASE_V1_30, RELEASE_V1_34, RELEASE_V1_38, RELEASE_V1_41, RELEASE_V1_42,
-        RELEASE_V1_45,
+        RELEASE_V1_45, RELEASE_V1_46,
     },
     AptosGasParameters,
 };
@@ -143,11 +143,26 @@ pub fn aptos_default_ty_builder(check_depth_on_type_counts_v2: bool) -> TypeBuil
 }
 
 /// Returns [DeserializerConfig] used by the Aptos blockchain in production.
-pub fn aptos_prod_deserializer_config(features: &Features) -> DeserializerConfig {
-    DeserializerConfig::new(
-        features.get_max_binary_format_version(),
-        features.get_max_identifier_size(),
-    )
+pub fn aptos_prod_deserializer_config(
+    gas_feature_version: u64,
+    features: &Features,
+) -> DeserializerConfig {
+    if gas_feature_version >= RELEASE_V1_46 {
+        DeserializerConfig {
+            max_binary_format_version: features.get_max_binary_format_version(),
+            max_identifier_size: 128,
+            max_entry_type_args_count: 32,
+            max_entry_type_tag_nodes: 16,
+        }
+    } else {
+        DeserializerConfig {
+            max_binary_format_version: features.get_max_binary_format_version(),
+            max_identifier_size: features.get_max_identifier_size(),
+            // Irrelevant before 1.46.
+            max_entry_type_args_count: u64::MAX,
+            max_entry_type_tag_nodes: u64::MAX,
+        }
+    }
 }
 
 /// Returns [VerifierConfig] used by the Aptos blockchain in production.
@@ -239,7 +254,7 @@ pub fn aptos_prod_vm_config(
     let enable_layout_caches = get_layout_caches();
     let enable_debugging = get_debugging_enabled();
 
-    let deserializer_config = aptos_prod_deserializer_config(features);
+    let deserializer_config = aptos_prod_deserializer_config(gas_feature_version, features);
     let verifier_config = aptos_prod_verifier_config(gas_feature_version, features, timed_features);
     let enable_enum_option = features.is_enabled(FeatureFlag::ENABLE_ENUM_OPTION);
     let enable_framework_for_option = features.is_enabled(FeatureFlag::ENABLE_FRAMEWORK_FOR_OPTION);

--- a/aptos-move/aptos-vm-environment/src/prod_configs.rs
+++ b/aptos-move/aptos-vm-environment/src/prod_configs.rs
@@ -152,7 +152,7 @@ pub fn aptos_prod_deserializer_config(
             max_binary_format_version: features.get_max_binary_format_version(),
             max_identifier_size: 128,
             max_entry_type_args_count: 32,
-            max_entry_type_tag_nodes: 16,
+            max_entry_type_tag_nodes: 8,
         }
     } else {
         DeserializerConfig {

--- a/aptos-move/aptos-vm-environment/src/prod_configs.rs
+++ b/aptos-move/aptos-vm-environment/src/prod_configs.rs
@@ -152,7 +152,7 @@ pub fn aptos_prod_deserializer_config(
             max_binary_format_version: features.get_max_binary_format_version(),
             max_identifier_size: 128,
             max_entry_type_args_count: 32,
-            max_entry_type_tag_nodes: 8,
+            max_entry_type_tag_nodes: 16,
         }
     } else {
         DeserializerConfig {

--- a/aptos-move/aptos-vm-environment/src/prod_configs.rs
+++ b/aptos-move/aptos-vm-environment/src/prod_configs.rs
@@ -148,6 +148,10 @@ pub fn aptos_prod_deserializer_config(
     features: &Features,
 ) -> DeserializerConfig {
     if gas_feature_version >= RELEASE_V1_46 {
+        // Note: prod tightens `max_identifier_size` to 128, below the binary
+        // format maximum of `IDENTIFIER_SIZE_MAX = 255` returned by
+        // `Features::get_max_identifier_size()`. The feature-gated getter is
+        // no longer consulted for v1.46+ and is effectively superseded here.
         DeserializerConfig {
             max_binary_format_version: features.get_max_binary_format_version(),
             max_identifier_size: 128,

--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -25,6 +25,7 @@ use crate::{
     sharded_block_executor::{executor_client::ExecutorClient, ShardedBlockExecutor},
     system_module_names::*,
     transaction_metadata::TransactionMetadata,
+    transaction_payload_validation::validate_transaction_payload,
     transaction_validation,
     verifier::{
         event_validation, native_validation, resource_groups, transaction_arg_validation,
@@ -42,7 +43,7 @@ use aptos_framework_natives::code::PublishRequest;
 use aptos_gas_algebra::{Gas, GasQuantity, NumBytes, Octa};
 use aptos_gas_meter::{AptosGasMeter, GasAlgebra, StandardGasAlgebra, StandardGasMeter};
 use aptos_gas_schedule::{
-    gas_feature_versions::{self, RELEASE_V1_10, RELEASE_V1_27, RELEASE_V1_38},
+    gas_feature_versions::{self, RELEASE_V1_10, RELEASE_V1_27, RELEASE_V1_38, RELEASE_V1_46},
     AptosGasParameters, VMGasParameters,
 };
 use aptos_logger::{enabled, prelude::*, Level};
@@ -2001,6 +2002,10 @@ impl AptosVM {
             ));
         }
 
+        if self.gas_feature_version() >= RELEASE_V1_46 {
+            validate_transaction_payload(transaction.payload(), self.deserializer_config())?;
+        }
+
         // The prologue MUST be run AFTER any validation. Otherwise you may run prologue and hit
         // SEQUENCE_NUMBER_TOO_NEW if there is more than one transaction from the same sender and
         // end up skipping validation.
@@ -3443,6 +3448,14 @@ impl VMValidator for AptosVM {
             && !self.features().is_encrypted_transactions_enabled()
         {
             return VMValidatorResult::error(StatusCode::FEATURE_UNDER_GATING);
+        }
+
+        if self.gas_feature_version() >= RELEASE_V1_46 {
+            if let Err(status) =
+                validate_transaction_payload(transaction.payload(), self.deserializer_config())
+            {
+                return VMValidatorResult::error(status.status_code());
+            }
         }
 
         let txn = match transaction.check_signature() {

--- a/aptos-move/aptos-vm/src/lib.rs
+++ b/aptos-move/aptos-vm/src/lib.rs
@@ -119,6 +119,7 @@ pub mod sharded_block_executor;
 pub mod system_module_names;
 pub mod testing;
 pub mod transaction_metadata;
+mod transaction_payload_validation;
 mod transaction_validation;
 pub mod validator_txns;
 pub mod verifier;

--- a/aptos-move/aptos-vm/src/transaction_payload_validation.rs
+++ b/aptos-move/aptos-vm/src/transaction_payload_validation.rs
@@ -160,5 +160,14 @@ fn validate_identifier(identifier: &IdentStr, config: &DeserializerConfig) -> Re
             )),
         ));
     }
+    if !IdentStr::is_valid(identifier.as_str()) {
+        return Err(VMStatus::error(
+            StatusCode::MALFORMED_TRANSACTION_PAYLOAD,
+            Some(format!(
+                "Identifier '{}' contains invalid characters",
+                identifier.as_str()
+            )),
+        ));
+    }
     Ok(())
 }

--- a/aptos-move/aptos-vm/src/transaction_payload_validation.rs
+++ b/aptos-move/aptos-vm/src/transaction_payload_validation.rs
@@ -58,7 +58,7 @@ pub fn validate_transaction_payload(
     Ok(())
 }
 
-pub fn validate_executable(
+fn validate_executable(
     executable: &TransactionExecutableRef,
     config: &DeserializerConfig,
 ) -> Result<(), VMStatus> {
@@ -104,6 +104,9 @@ fn validate_type_args(ty_args: &[TypeTag], config: &DeserializerConfig) -> Resul
 fn validate_type_tag(ty: &TypeTag, config: &DeserializerConfig) -> Result<(), VMStatus> {
     let mut node_count: u64 = 0;
     for tag in ty.preorder_traversal_iter() {
+        // Node count check precedes the match below, so an oversized tag
+        // containing a function type reports the node-count error rather
+        // than the function-type error. Both are rejections.
         node_count += 1;
         if node_count > config.max_entry_type_tag_nodes {
             return Err(VMStatus::error(

--- a/aptos-move/aptos-vm/src/transaction_payload_validation.rs
+++ b/aptos-move/aptos-vm/src/transaction_payload_validation.rs
@@ -1,0 +1,164 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+use aptos_types::transaction::{
+    EntryFunction, MultisigTransactionPayload, TransactionExecutableRef, TransactionPayload,
+    TransactionPayloadInner,
+};
+use move_binary_format::deserializer::DeserializerConfig;
+use move_core_types::{
+    identifier::IdentStr,
+    language_storage::TypeTag,
+    vm_status::{StatusCode, VMStatus},
+};
+
+/// Validates structural limits of a transaction payload:
+///   - Identifier lengths inside type tags and entry function module or
+///     function names,
+///   - Type arguments list size,
+///   - Per-tag node count,
+///   - Rejects function type tags.
+pub fn validate_transaction_payload(
+    payload: &TransactionPayload,
+    config: &DeserializerConfig,
+) -> Result<(), VMStatus> {
+    match payload {
+        TransactionPayload::EntryFunction(entry_fn) => {
+            validate_entry_function(entry_fn, config)?;
+        },
+        TransactionPayload::Script(script) => {
+            validate_type_args(script.ty_args(), config)?;
+        },
+        TransactionPayload::Multisig(multisig) => {
+            if let Some(payload) = &multisig.transaction_payload {
+                match payload {
+                    MultisigTransactionPayload::EntryFunction(entry_fn) => {
+                        validate_entry_function(entry_fn, config)?;
+                    },
+                    MultisigTransactionPayload::Script(script) => {
+                        validate_type_args(script.ty_args(), config)?;
+                    },
+                }
+            }
+        },
+        TransactionPayload::Payload(inner) => match inner {
+            TransactionPayloadInner::V1 { executable, .. } => {
+                validate_executable(&executable.as_ref(), config)?;
+            },
+        },
+        TransactionPayload::EncryptedPayload(inner) => {
+            if let Ok(executable) = inner.executable_ref() {
+                validate_executable(&executable, config)?;
+            }
+        },
+        TransactionPayload::ModuleBundle(_) => {
+            // Deprecated: do nothing.
+        },
+    }
+    Ok(())
+}
+
+pub fn validate_executable(
+    executable: &TransactionExecutableRef,
+    config: &DeserializerConfig,
+) -> Result<(), VMStatus> {
+    match executable {
+        TransactionExecutableRef::Script(script) => {
+            validate_type_args(script.ty_args(), config)?;
+        },
+        TransactionExecutableRef::EntryFunction(entry_fn) => {
+            validate_entry_function(entry_fn, config)?;
+        },
+        TransactionExecutableRef::Empty | TransactionExecutableRef::Encrypted => {},
+    }
+    Ok(())
+}
+
+fn validate_entry_function(
+    entry_fn: &EntryFunction,
+    config: &DeserializerConfig,
+) -> Result<(), VMStatus> {
+    validate_identifier(entry_fn.module().name(), config)?;
+    validate_identifier(entry_fn.function(), config)?;
+    validate_type_args(entry_fn.ty_args(), config)
+}
+
+fn validate_type_args(ty_args: &[TypeTag], config: &DeserializerConfig) -> Result<(), VMStatus> {
+    if ty_args.len() as u64 > config.max_entry_type_args_count {
+        return Err(VMStatus::error(
+            StatusCode::MALFORMED_TRANSACTION_PAYLOAD,
+            Some(format!(
+                "Type arguments count {} exceeds limit {}",
+                ty_args.len(),
+                config.max_entry_type_args_count
+            )),
+        ));
+    }
+
+    for ty_arg in ty_args {
+        validate_type_tag(ty_arg, config)?;
+    }
+    Ok(())
+}
+
+fn validate_type_tag(ty: &TypeTag, config: &DeserializerConfig) -> Result<(), VMStatus> {
+    let mut node_count: u64 = 0;
+    for tag in ty.preorder_traversal_iter() {
+        node_count += 1;
+        if node_count > config.max_entry_type_tag_nodes {
+            return Err(VMStatus::error(
+                StatusCode::MALFORMED_TRANSACTION_PAYLOAD,
+                Some(format!(
+                    "Type tag node count exceeds limit {}",
+                    config.max_entry_type_tag_nodes
+                )),
+            ));
+        }
+
+        match tag {
+            TypeTag::Struct(struct_tag) => {
+                validate_identifier(struct_tag.module.as_ident_str(), config)?;
+                validate_identifier(struct_tag.name.as_ident_str(), config)?;
+            },
+            TypeTag::Function(_) => {
+                return Err(VMStatus::error(
+                    StatusCode::MALFORMED_TRANSACTION_PAYLOAD,
+                    Some("Function type tags are not allowed in transaction payloads".to_string()),
+                ));
+            },
+            TypeTag::Bool => {},
+            TypeTag::U8 => {},
+            TypeTag::U16 => {},
+            TypeTag::U32 => {},
+            TypeTag::U64 => {},
+            TypeTag::U128 => {},
+            TypeTag::U256 => {},
+            TypeTag::I8
+            | TypeTag::I16
+            | TypeTag::I32
+            | TypeTag::I64
+            | TypeTag::I128
+            | TypeTag::I256
+            | TypeTag::Address
+            | TypeTag::Signer
+            | TypeTag::Vector(_) => {
+                // Allowed.
+            },
+        }
+    }
+    Ok(())
+}
+
+fn validate_identifier(identifier: &IdentStr, config: &DeserializerConfig) -> Result<(), VMStatus> {
+    let len = identifier.as_str().len() as u64;
+    if len > config.max_identifier_size {
+        return Err(VMStatus::error(
+            StatusCode::MALFORMED_TRANSACTION_PAYLOAD,
+            Some(format!(
+                "Identifier length {} exceeds limit {}",
+                len, config.max_identifier_size
+            )),
+        ));
+    }
+    Ok(())
+}

--- a/aptos-move/e2e-move-tests/src/tests/mod.rs
+++ b/aptos-move/e2e-move-tests/src/tests/mod.rs
@@ -79,6 +79,7 @@ mod token_event_store;
 mod token_objects;
 mod transaction_context;
 mod transaction_limits;
+mod txn_payload_validation;
 mod type_too_large;
 mod upgrade_compatibility;
 mod vm;

--- a/aptos-move/e2e-move-tests/src/tests/txn_payload_validation.rs
+++ b/aptos-move/e2e-move-tests/src/tests/txn_payload_validation.rs
@@ -5,7 +5,8 @@ use crate::MoveHarness;
 use aptos_types::{account_address::AccountAddress, move_utils::MemberId};
 use move_core_types::{
     ability::AbilitySet,
-    language_storage::{FunctionTag, TypeTag},
+    identifier::Identifier,
+    language_storage::{FunctionTag, ModuleId, StructTag, TypeTag},
 };
 use std::str::FromStr;
 
@@ -111,26 +112,27 @@ fn test_txn_payload_validation_discards_bad_inputs() {
     );
     assert!(status.is_discarded());
 
-    // Type tag nesting depth.
-    let nested_vector = |depth: usize| {
-        let mut ty = TypeTag::U8;
-        for _ in 0..depth {
-            ty = TypeTag::Vector(Box::new(ty));
-        }
-        ty
+    // Type tag node count.
+    let struct_with_u8_args = |n: usize| {
+        TypeTag::Struct(Box::new(StructTag {
+            address: AccountAddress::ONE,
+            module: Identifier::new_unchecked("a"),
+            name: Identifier::new_unchecked("B"),
+            type_args: vec![TypeTag::U8; n],
+        }))
     };
     let account = h.new_account_at(AccountAddress::from_hex_literal("0x106").unwrap());
     let status = h.run_entry_function(
         &account,
         MemberId::from_str("0x1::a::b").unwrap(),
-        vec![nested_vector(15)],
+        vec![struct_with_u8_args(7)],
         vec![],
     );
     assert!(status.is_kept());
     let status = h.run_entry_function(
         &account,
         MemberId::from_str("0x1::a::b").unwrap(),
-        vec![nested_vector(16)],
+        vec![struct_with_u8_args(8)],
         vec![],
     );
     assert!(status.is_discarded());
@@ -146,6 +148,48 @@ fn test_txn_payload_validation_discards_bad_inputs() {
         &account,
         MemberId::from_str("0x1::a::b").unwrap(),
         vec![tag],
+        vec![],
+    );
+    assert!(status.is_discarded());
+
+    // Invalid identifier charset in module name.
+    let account = h.new_account_at(AccountAddress::from_hex_literal("0x108").unwrap());
+    let status = h.run_entry_function(
+        &account,
+        MemberId {
+            module_id: ModuleId::new(AccountAddress::ONE, Identifier::new_unchecked("bad name")),
+            member_id: Identifier::new_unchecked("b"),
+        },
+        vec![],
+        vec![],
+    );
+    assert!(status.is_discarded());
+
+    // Invalid identifier charset in function name.
+    let account = h.new_account_at(AccountAddress::from_hex_literal("0x109").unwrap());
+    let status = h.run_entry_function(
+        &account,
+        MemberId {
+            module_id: ModuleId::new(AccountAddress::ONE, Identifier::new_unchecked("a")),
+            member_id: Identifier::new_unchecked("bad name"),
+        },
+        vec![],
+        vec![],
+    );
+    assert!(status.is_discarded());
+
+    // Invalid identifier charset inside a type tag.
+    let account = h.new_account_at(AccountAddress::from_hex_literal("0x10a").unwrap());
+    let bad_struct = TypeTag::Struct(Box::new(StructTag {
+        address: AccountAddress::ONE,
+        module: Identifier::new_unchecked("bad name"),
+        name: Identifier::new_unchecked("B"),
+        type_args: vec![],
+    }));
+    let status = h.run_entry_function(
+        &account,
+        MemberId::from_str("0x1::a::b").unwrap(),
+        vec![bad_struct],
         vec![],
     );
     assert!(status.is_discarded());

--- a/aptos-move/e2e-move-tests/src/tests/txn_payload_validation.rs
+++ b/aptos-move/e2e-move-tests/src/tests/txn_payload_validation.rs
@@ -1,0 +1,152 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+use crate::MoveHarness;
+use aptos_types::{account_address::AccountAddress, move_utils::MemberId};
+use move_core_types::{
+    ability::AbilitySet,
+    language_storage::{FunctionTag, TypeTag},
+};
+use std::str::FromStr;
+
+#[test]
+fn test_txn_payload_validation_discards_bad_inputs() {
+    let mut h = MoveHarness::new();
+
+    // Use a fresh account for each (kept, discarded) pair because discarded
+    // transactions do not consume the on-chain sequence number, but the
+    // harness still increments its internal counter, causing subsequent
+    // transactions to fail with SEQUENCE_NUMBER_TOO_NEW.
+
+    let account = h.new_account_at(AccountAddress::from_hex_literal("0x100").unwrap());
+    let status = h.run_entry_function(
+        &account,
+        MemberId::from_str("0x1::a::b").unwrap(),
+        vec![],
+        vec![],
+    );
+    assert!(status.is_kept());
+
+    // Entry function module name length.
+    let account = h.new_account_at(AccountAddress::from_hex_literal("0x101").unwrap());
+    let status = h.run_entry_function(
+        &account,
+        MemberId::from_str(&format!("0x1::{}::b", "a".repeat(128))).unwrap(),
+        vec![],
+        vec![],
+    );
+    assert!(status.is_kept());
+    let status = h.run_entry_function(
+        &account,
+        MemberId::from_str(&format!("0x1::{}::b", "a".repeat(129))).unwrap(),
+        vec![],
+        vec![],
+    );
+    assert!(status.is_discarded());
+
+    // Entry function name length.
+    let account = h.new_account_at(AccountAddress::from_hex_literal("0x102").unwrap());
+    let status = h.run_entry_function(
+        &account,
+        MemberId::from_str(&format!("0x1::a::{}", "b".repeat(128))).unwrap(),
+        vec![],
+        vec![],
+    );
+    assert!(status.is_kept());
+    let status = h.run_entry_function(
+        &account,
+        MemberId::from_str(&format!("0x1::a::{}", "b".repeat(129))).unwrap(),
+        vec![],
+        vec![],
+    );
+    assert!(status.is_discarded());
+
+    // Type tag identifier length.
+    let account = h.new_account_at(AccountAddress::from_hex_literal("0x103").unwrap());
+    let status = h.run_entry_function(
+        &account,
+        MemberId::from_str("0x1::a::b").unwrap(),
+        vec![TypeTag::from_str(&format!("0x1::{}::B", "a".repeat(128))).unwrap()],
+        vec![],
+    );
+    assert!(status.is_kept());
+    let status = h.run_entry_function(
+        &account,
+        MemberId::from_str("0x1::a::b").unwrap(),
+        vec![TypeTag::from_str(&format!("0x1::{}::B", "a".repeat(129))).unwrap()],
+        vec![],
+    );
+    assert!(status.is_discarded());
+
+    let account = h.new_account_at(AccountAddress::from_hex_literal("0x104").unwrap());
+    let status = h.run_entry_function(
+        &account,
+        MemberId::from_str("0x1::a::b").unwrap(),
+        vec![TypeTag::from_str(&format!("0x1::a::{}", "B".repeat(128))).unwrap()],
+        vec![],
+    );
+    assert!(status.is_kept());
+    let status = h.run_entry_function(
+        &account,
+        MemberId::from_str("0x1::a::b").unwrap(),
+        vec![TypeTag::from_str(&format!("0x1::a::{}", "B".repeat(129))).unwrap()],
+        vec![],
+    );
+    assert!(status.is_discarded());
+
+    // Type arguments count.
+    let account = h.new_account_at(AccountAddress::from_hex_literal("0x105").unwrap());
+    let status = h.run_entry_function(
+        &account,
+        MemberId::from_str("0x1::a::b").unwrap(),
+        vec![TypeTag::U8; 32],
+        vec![],
+    );
+    assert!(status.is_kept());
+    let status = h.run_entry_function(
+        &account,
+        MemberId::from_str("0x1::a::b").unwrap(),
+        vec![TypeTag::U8; 33],
+        vec![],
+    );
+    assert!(status.is_discarded());
+
+    // Type tag nesting depth.
+    let nested_vector = |depth: usize| {
+        let mut ty = TypeTag::U8;
+        for _ in 0..depth {
+            ty = TypeTag::Vector(Box::new(ty));
+        }
+        ty
+    };
+    let account = h.new_account_at(AccountAddress::from_hex_literal("0x106").unwrap());
+    let status = h.run_entry_function(
+        &account,
+        MemberId::from_str("0x1::a::b").unwrap(),
+        vec![nested_vector(15)],
+        vec![],
+    );
+    assert!(status.is_kept());
+    let status = h.run_entry_function(
+        &account,
+        MemberId::from_str("0x1::a::b").unwrap(),
+        vec![nested_vector(16)],
+        vec![],
+    );
+    assert!(status.is_discarded());
+
+    // Function type tags are rejected.
+    let account = h.new_account_at(AccountAddress::from_hex_literal("0x107").unwrap());
+    let tag = TypeTag::Function(Box::new(FunctionTag {
+        args: vec![],
+        results: vec![],
+        abilities: AbilitySet::EMPTY,
+    }));
+    let status = h.run_entry_function(
+        &account,
+        MemberId::from_str("0x1::a::b").unwrap(),
+        vec![tag],
+        vec![],
+    );
+    assert!(status.is_discarded());
+}

--- a/aptos-move/e2e-move-tests/src/tests/txn_payload_validation.rs
+++ b/aptos-move/e2e-move-tests/src/tests/txn_payload_validation.rs
@@ -125,14 +125,14 @@ fn test_txn_payload_validation_discards_bad_inputs() {
     let status = h.run_entry_function(
         &account,
         MemberId::from_str("0x1::a::b").unwrap(),
-        vec![struct_with_u8_args(7)],
+        vec![struct_with_u8_args(15)],
         vec![],
     );
     assert!(status.is_kept());
     let status = h.run_entry_function(
         &account,
         MemberId::from_str("0x1::a::b").unwrap(),
-        vec![struct_with_u8_args(8)],
+        vec![struct_with_u8_args(16)],
         vec![],
     );
     assert!(status.is_discarded());

--- a/crates/transaction-generator-lib/src/publishing/entry_point_trait.rs
+++ b/crates/transaction-generator-lib/src/publishing/entry_point_trait.rs
@@ -30,7 +30,11 @@ pub trait PreBuiltPackages: std::fmt::Debug + Sync + Send {
 
     fn package_modules(&self, package_name: &str) -> Vec<(String, CompiledModule, u32)> {
         let mut results = vec![];
-        let default_config = DeserializerConfig::new(VERSION_DEFAULT, IDENTIFIER_SIZE_MAX);
+        let default_config = DeserializerConfig {
+            max_binary_format_version: VERSION_DEFAULT,
+            max_identifier_size: IDENTIFIER_SIZE_MAX,
+            ..DeserializerConfig::default()
+        };
 
         let modules = &self.package_bundle().get_package(package_name).modules;
         for (module_name, bytes) in modules {

--- a/testsuite/fuzzer/fuzz/fuzz_targets/move/aptosvm_publish_and_run.rs
+++ b/testsuite/fuzzer/fuzz/fuzz_targets/move/aptosvm_publish_and_run.rs
@@ -92,7 +92,11 @@ fn run_case(mut input: RunnableState) -> Result<(), Corpus> {
         &Features::default(),
         &timed_features,
     );
-    let deserializer_config = DeserializerConfig::new(BYTECODE_VERSION, 255);
+    let deserializer_config = DeserializerConfig {
+        max_binary_format_version: BYTECODE_VERSION,
+        max_identifier_size: 255,
+        ..DeserializerConfig::default()
+    };
 
     for m in input.dep_modules.iter_mut() {
         verify_module_fast(m, &verifier_config, &deserializer_config)?;

--- a/testsuite/fuzzer/fuzz/fuzz_targets/move/aptosvm_publish_and_run_transactional.rs
+++ b/testsuite/fuzzer/fuzz/fuzz_targets/move/aptosvm_publish_and_run_transactional.rs
@@ -103,7 +103,11 @@ fn run_case(input: RunnableStateWithOperations) -> Result<(), Corpus> {
         &Features::default(),
         &timed_features,
     );
-    let deserializer_config = DeserializerConfig::new(BYTECODE_VERSION, 255);
+    let deserializer_config = DeserializerConfig {
+        max_binary_format_version: BYTECODE_VERSION,
+        max_identifier_size: 255,
+        ..DeserializerConfig::default()
+    };
 
     let mut dep_modules: Vec<CompiledModule> = vec![];
     // Collect dependency modules and later we will verify runs individually

--- a/third_party/move/move-binary-format/serializer-tests/tests/serializer_tests.rs
+++ b/third_party/move/move-binary-format/serializer-tests/tests/serializer_tests.rs
@@ -28,7 +28,11 @@ proptest! {
 
         let deserialized_module = CompiledModule::deserialize_with_config(
                 &serialized,
-                &DeserializerConfig::new(VERSION_MAX, IDENTIFIER_SIZE_MAX)
+                &DeserializerConfig {
+                max_binary_format_version: VERSION_MAX,
+                max_identifier_size: IDENTIFIER_SIZE_MAX,
+                ..DeserializerConfig::default()
+            }
         ).expect("deserialization should work");
 
         prop_assert_eq!(module, deserialized_module);
@@ -89,11 +93,13 @@ fn simple_generic_module_round_trip() {
     m.serialize_for_version(Some(VERSION_MAX), &mut serialized)
         .expect("serialization should work");
 
-    let deserialized_m = CompiledModule::deserialize_with_config(
-        &serialized,
-        &DeserializerConfig::new(VERSION_MAX, IDENTIFIER_SIZE_MAX),
-    )
-    .expect("deserialization should work");
+    let deserialized_m =
+        CompiledModule::deserialize_with_config(&serialized, &DeserializerConfig {
+            max_binary_format_version: VERSION_MAX,
+            max_identifier_size: IDENTIFIER_SIZE_MAX,
+            ..DeserializerConfig::default()
+        })
+        .expect("deserialization should work");
 
     assert_eq!(m, deserialized_m);
 }
@@ -105,11 +111,13 @@ fn simple_script_round_trip() {
     s.serialize_for_version(Some(VERSION_MAX), &mut serialized)
         .expect("serialization should work");
 
-    let deserialized_s = CompiledScript::deserialize_with_config(
-        &serialized,
-        &DeserializerConfig::new(VERSION_MAX, IDENTIFIER_SIZE_MAX),
-    )
-    .expect("deserialization should work");
+    let deserialized_s =
+        CompiledScript::deserialize_with_config(&serialized, &DeserializerConfig {
+            max_binary_format_version: VERSION_MAX,
+            max_identifier_size: IDENTIFIER_SIZE_MAX,
+            ..DeserializerConfig::default()
+        })
+        .expect("deserialization should work");
 
     assert_eq!(s, deserialized_s);
 }
@@ -189,10 +197,11 @@ fn test_borrow_field_attributes_round_trip() {
         .expect("serialization should work");
 
     // Deserialize and verify
-    let deserialized = CompiledModule::deserialize_with_config(
-        &serialized,
-        &DeserializerConfig::new(VERSION_10, IDENTIFIER_SIZE_MAX),
-    )
+    let deserialized = CompiledModule::deserialize_with_config(&serialized, &DeserializerConfig {
+        max_binary_format_version: VERSION_10,
+        max_identifier_size: IDENTIFIER_SIZE_MAX,
+        ..DeserializerConfig::default()
+    })
     .expect("deserialization should work");
 
     // Verify attributes preserved

--- a/third_party/move/move-binary-format/src/deserializer.rs
+++ b/third_party/move/move-binary-format/src/deserializer.rs
@@ -117,7 +117,7 @@ impl Default for DeserializerConfig {
             max_binary_format_version: VERSION_MAX,
             max_identifier_size: IDENTIFIER_SIZE_MAX,
             max_entry_type_args_count: 32,
-            max_entry_type_tag_nodes: 8,
+            max_entry_type_tag_nodes: 16,
         }
     }
 }

--- a/third_party/move/move-binary-format/src/deserializer.rs
+++ b/third_party/move/move-binary-format/src/deserializer.rs
@@ -117,7 +117,7 @@ impl Default for DeserializerConfig {
             max_binary_format_version: VERSION_MAX,
             max_identifier_size: IDENTIFIER_SIZE_MAX,
             max_entry_type_args_count: 32,
-            max_entry_type_tag_nodes: 16,
+            max_entry_type_tag_nodes: 8,
         }
     }
 }

--- a/third_party/move/move-binary-format/src/deserializer.rs
+++ b/third_party/move/move-binary-format/src/deserializer.rs
@@ -20,7 +20,11 @@ use std::{collections::HashSet, convert::TryInto, io::Read};
 impl CompiledScript {
     /// Deserializes a &[u8] slice into a `CompiledScript` instance.
     pub fn deserialize(binary: &[u8]) -> BinaryLoaderResult<Self> {
-        let config = DeserializerConfig::new(VERSION_MAX, IDENTIFIER_SIZE_MAX);
+        let config = DeserializerConfig {
+            max_binary_format_version: VERSION_MAX,
+            max_identifier_size: IDENTIFIER_SIZE_MAX,
+            ..DeserializerConfig::default()
+        };
         Self::deserialize_with_config(binary, &config)
     }
 
@@ -37,7 +41,11 @@ impl CompiledScript {
     // exposed as a public function to enable testing the deserializer
     #[doc(hidden)]
     pub fn deserialize_no_check_bounds(binary: &[u8]) -> BinaryLoaderResult<Self> {
-        let config = DeserializerConfig::new(VERSION_MAX, LEGACY_IDENTIFIER_SIZE_MAX);
+        let config = DeserializerConfig {
+            max_binary_format_version: VERSION_MAX,
+            max_identifier_size: LEGACY_IDENTIFIER_SIZE_MAX,
+            ..DeserializerConfig::default()
+        };
         deserialize_compiled_script(binary, &config)
     }
 }
@@ -45,7 +53,11 @@ impl CompiledScript {
 impl CompiledModule {
     /// Deserialize a &[u8] slice into a `CompiledModule` instance.
     pub fn deserialize(binary: &[u8]) -> BinaryLoaderResult<Self> {
-        let config = DeserializerConfig::new(VERSION_MAX, IDENTIFIER_SIZE_MAX);
+        let config = DeserializerConfig {
+            max_binary_format_version: VERSION_MAX,
+            max_identifier_size: IDENTIFIER_SIZE_MAX,
+            ..DeserializerConfig::default()
+        };
         Self::deserialize_with_config(binary, &config)
     }
 
@@ -74,7 +86,11 @@ impl CompiledModule {
     // exposed as a public function to enable testing the deserializer
     #[doc(hidden)]
     pub fn deserialize_no_check_bounds(binary: &[u8]) -> BinaryLoaderResult<Self> {
-        let config = DeserializerConfig::new(VERSION_MAX, LEGACY_IDENTIFIER_SIZE_MAX);
+        let config = DeserializerConfig {
+            max_binary_format_version: VERSION_MAX,
+            max_identifier_size: LEGACY_IDENTIFIER_SIZE_MAX,
+            ..DeserializerConfig::default()
+        };
         deserialize_compiled_module(binary, &config)
     }
 }
@@ -82,23 +98,27 @@ impl CompiledModule {
 #[derive(Debug, Clone, Eq, PartialEq, Serialize)]
 pub struct DeserializerConfig {
     pub max_binary_format_version: u32,
+    /// Maximum allowed identifier size in binaries or in entry function or
+    /// script payloads.
     pub max_identifier_size: u64,
-}
-
-impl DeserializerConfig {
-    pub fn new(max_binary_format_version: u32, max_identifier_size: u64) -> Self {
-        Self {
-            max_binary_format_version,
-            max_identifier_size,
-        }
-    }
+    /// Maximum number of type arguments allowed in an entry function or
+    /// a script.
+    pub max_entry_type_args_count: u64,
+    /// Maximum number of nodes allowed per individual type tag in entry
+    /// function ot script type arguments.
+    pub max_entry_type_tag_nodes: u64,
 }
 
 impl Default for DeserializerConfig {
     fn default() -> Self {
         // Note that here version max is used as a default version, as this how
         // it was previously defined in VM config.
-        Self::new(VERSION_MAX, IDENTIFIER_SIZE_MAX)
+        Self {
+            max_binary_format_version: VERSION_MAX,
+            max_identifier_size: IDENTIFIER_SIZE_MAX,
+            max_entry_type_args_count: 32,
+            max_entry_type_tag_nodes: 16,
+        }
     }
 }
 

--- a/third_party/move/move-binary-format/src/unit_tests/deserializer_tests.rs
+++ b/third_party/move/move-binary-format/src/unit_tests/deserializer_tests.rs
@@ -231,10 +231,11 @@ fn max_version_lower_than_hardcoded() {
     binary.push(10); // table count
     binary.push(0); // rest of binary
 
-    let config = DeserializerConfig::new(
-        VERSION_MAX.checked_sub(1).unwrap(),
-        LEGACY_IDENTIFIER_SIZE_MAX,
-    );
+    let config = DeserializerConfig {
+        max_binary_format_version: VERSION_MAX.checked_sub(1).unwrap(),
+        max_identifier_size: LEGACY_IDENTIFIER_SIZE_MAX,
+        ..DeserializerConfig::default()
+    };
     let res = CompiledScript::deserialize_with_config(&binary, &config);
     assert_eq!(
         res.expect_err("Expected unknown version").major_status(),
@@ -269,11 +270,19 @@ static TOO_LONG_IDENTIFIER: &[u8] = include_bytes!("tool_long_identifier.mv");
 #[test]
 fn deserialize_too_long_identifiers() {
     // The deserialization with the legacy limit succeeds.
-    let legacy_config = DeserializerConfig::new(VERSION_MAX, LEGACY_IDENTIFIER_SIZE_MAX);
+    let legacy_config = DeserializerConfig {
+        max_binary_format_version: VERSION_MAX,
+        max_identifier_size: LEGACY_IDENTIFIER_SIZE_MAX,
+        ..DeserializerConfig::default()
+    };
     assert!(CompiledModule::deserialize_with_config(TOO_LONG_IDENTIFIER, &legacy_config).is_ok());
 
     // The deserialization with the reduced limit should fail.
-    let config = DeserializerConfig::new(VERSION_MAX, IDENTIFIER_SIZE_MAX);
+    let config = DeserializerConfig {
+        max_binary_format_version: VERSION_MAX,
+        max_identifier_size: IDENTIFIER_SIZE_MAX,
+        ..DeserializerConfig::default()
+    };
     assert_eq!(
         CompiledModule::deserialize_with_config(TOO_LONG_IDENTIFIER, &config)
             .unwrap_err()

--- a/third_party/move/move-core/types/src/vm_status.rs
+++ b/third_party/move/move-core/types/src/vm_status.rs
@@ -682,11 +682,14 @@ pub enum StatusCode {
 
     // Encrypted transaction gas unit price is below the minimum required.
     ENCRYPTED_TXN_GAS_UNIT_PRICE_BELOW_MIN_BOUND = 54,
+    // Transaction payload failed structural validation (identifier lengths, type arg
+    // count, type tag node count, or disallowed type tag variants).
+    MALFORMED_TRANSACTION_PAYLOAD = 55,
 
     // Reserved error code for future use
-    RESERVED_VALIDATION_ERROR_2 = 55,
-    RESERVED_VALIDATION_ERROR_3 = 56,
-    RESERVED_VALIDATION_ERROR_4 = 57,
+    RESERVED_VALIDATION_ERROR_2 = 56,
+    RESERVED_VALIDATION_ERROR_3 = 57,
+    RESERVED_VALIDATION_ERROR_4 = 58,
 
 
     // When a code module/script is published it is verified. These are the

--- a/third_party/move/move-vm/integration-tests/src/tests/binary_format_version.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/binary_format_version.rs
@@ -18,7 +18,11 @@ use move_vm_test_utils::InMemoryStorage;
 
 fn initialize_storage_with_binary_format_version(binary_format_version: u32) -> InMemoryStorage {
     let vm_config = VMConfig {
-        deserializer_config: DeserializerConfig::new(binary_format_version, IDENTIFIER_SIZE_MAX),
+        deserializer_config: DeserializerConfig {
+            max_binary_format_version: binary_format_version,
+            max_identifier_size: IDENTIFIER_SIZE_MAX,
+            ..DeserializerConfig::default()
+        },
         ..VMConfig::default_for_test()
     };
     let runtime_environment = RuntimeEnvironment::new_with_config(vec![], vm_config);

--- a/third_party/move/move-vm/test-utils/src/storage.rs
+++ b/third_party/move/move-vm/test-utils/src/storage.rs
@@ -116,7 +116,11 @@ impl CompiledModuleView for InMemoryStorage {
     fn view_compiled_module(&self, id: &ModuleId) -> anyhow::Result<Option<Self::Item>> {
         Ok(match self.fetch_module_bytes(id.address(), id.name())? {
             Some(bytes) => {
-                let config = DeserializerConfig::new(VERSION_MAX, IDENTIFIER_SIZE_MAX);
+                let config = DeserializerConfig {
+                    max_binary_format_version: VERSION_MAX,
+                    max_identifier_size: IDENTIFIER_SIZE_MAX,
+                    ..DeserializerConfig::default()
+                };
                 Some(CompiledModule::deserialize_with_config(&bytes, &config)?)
             },
             None => None,

--- a/types/src/on_chain_config/aptos_features.rs
+++ b/types/src/on_chain_config/aptos_features.rs
@@ -2,10 +2,7 @@
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::on_chain_config::OnChainConfig;
-use move_binary_format::{
-    file_format_common,
-    file_format_common::{IDENTIFIER_SIZE_MAX, LEGACY_IDENTIFIER_SIZE_MAX},
-};
+use move_binary_format::{file_format_common, file_format_common::IDENTIFIER_SIZE_MAX};
 use move_core_types::{
     effects::{ChangeSet, Op},
     language_storage::CORE_CODE_ADDRESS,
@@ -55,7 +52,9 @@ pub enum FeatureFlag {
     FEE_PAYER_ACCOUNT_OPTIONAL = 35,
     AGGREGATOR_V2_DELAYED_FIELDS = 36,
     CONCURRENT_TOKEN_V2 = 37,
-    LIMIT_MAX_IDENTIFIER_LENGTH = 38,
+    /// Enabled on mainnet, cannot be disabled. Identifier length limits are now enforced
+    /// via DeserializerConfig in both binary format deserialization and payload validation.
+    _LIMIT_MAX_IDENTIFIER_LENGTH = 38,
     OPERATOR_BENEFICIARY_CHANGE = 39,
     VM_BINARY_FORMAT_V7 = 40,
     RESOURCE_GROUPS_SPLIT_IN_VM_CHANGE_SET = 41,
@@ -217,7 +216,7 @@ impl FeatureFlag {
             Self::FEE_PAYER_ACCOUNT_OPTIONAL,
             Self::AGGREGATOR_V2_DELAYED_FIELDS,
             Self::CONCURRENT_TOKEN_V2,
-            Self::LIMIT_MAX_IDENTIFIER_LENGTH,
+            Self::_LIMIT_MAX_IDENTIFIER_LENGTH,
             Self::OPERATOR_BENEFICIARY_CHANGE,
             Self::BN254_STRUCTURES,
             Self::RESOURCE_GROUPS_SPLIT_IN_VM_CHANGE_SET,
@@ -498,11 +497,9 @@ impl Features {
     }
 
     pub fn get_max_identifier_size(&self) -> u64 {
-        if self.is_enabled(FeatureFlag::LIMIT_MAX_IDENTIFIER_LENGTH) {
-            IDENTIFIER_SIZE_MAX
-        } else {
-            LEGACY_IDENTIFIER_SIZE_MAX
-        }
+        // The LIMIT_MAX_IDENTIFIER_LENGTH feature flag has been enabled on mainnet
+        // and cannot be disabled. Always return the tightened limit.
+        IDENTIFIER_SIZE_MAX
     }
 
     pub fn get_max_binary_format_version(&self) -> u32 {


### PR DESCRIPTION
## What

Add post-deserialization structural validation for transaction payloads. Reject malformed inputs before they reach the prologue.

Checks:
- Identifier length ≤ 128 (tightened from 255)
- Identifier charset (valid Move identifiers only)
- Type args count ≤ 32
- Type tag nodes ≤ 16
- `TypeTag::Function` rejected in payloads

Failures return a new status code `MALFORMED_TRANSACTION_PAYLOAD`.

## Why

BCS deserialization of `Identifier` / `TypeTag` skips the constructors, so payloads can carry oversized, bad-charset, or deeply-nested values. Today these only get caught later. Checking up front keeps the hot path cheap and the error surface small.

## Gating

Behind `gas_feature_version >= RELEASE_V1_46` for replay correctness.

## Tests

New e2e test in `e2e-move-tests/src/tests/txn_payload_validation.rs` covering each limit (keep at boundary, discard one above) plus charset and function-tag rejection.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new pre-prologue payload validation and tightens production deserialization limits under `RELEASE_V1_46`, which can change transaction acceptance and error codes at a consensus-critical boundary. Gating reduces replay risk, but incorrect limits or config wiring could cause unexpected discards on upgrade.
> 
> **Overview**
> **Adds structural validation for transaction payloads (gated by `gas_feature_version >= RELEASE_V1_46`).** The VM now rejects malformed entry-function/script payloads *before* running the prologue via a new `validate_transaction_payload` module, enforcing identifier charset/length (128), type-arg count (32), per-type-tag node count (16), and rejecting `TypeTag::Function`, returning the new `StatusCode::MALFORMED_TRANSACTION_PAYLOAD`.
> 
> **Updates deserialization configuration and feature plumbing to support the new limits.** `DeserializerConfig` gains payload-related limit fields and most call sites switch from `DeserializerConfig::new(...)` to struct init with defaults; prod config (`aptos_prod_deserializer_config`) is version-aware (v1.46 tightens identifier size and sets payload limits), the resource viewer forces the pre-v1.46 path, and the `LIMIT_MAX_IDENTIFIER_LENGTH` feature flag is treated as always-on (renamed internally and getter now always returns `IDENTIFIER_SIZE_MAX`). An e2e test suite (`txn_payload_validation`) is added to cover boundary and rejection cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1eab2754acfc0ae8d245e4afc66b01eb10ea14a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


