### PR TITLE
[compiler-v2] Add support for range patterns in `match` arms

### DIFF
--- a/third_party/move/move-compiler-v2/legacy-move-compiler/src/expansion/ast.rs
+++ b/third_party/move/move-compiler-v2/legacy-move-compiler/src/expansion/ast.rs
@@ -491,6 +491,8 @@ pub enum LValue_ {
     PositionalUnpack(ModuleAccess, Option<Vec<Type>>, LValueOrDotDotList),
     // Literal value pattern (for primitive pattern matching)
     Literal(Value),
+    // Range pattern: (lo, hi, inclusive_upper)
+    Range(Option<Value>, Option<Value>, bool),
 }
 pub type LValue = Spanned<LValue_>;
 pub type LValueList_ = Vec<LValue>;
@@ -2259,6 +2261,19 @@ impl AstDebug for LValue_ {
             },
             L::Literal(val) => {
                 val.value.ast_debug(w);
+            },
+            L::Range(lo, hi, inclusive) => {
+                if let Some(l) = lo {
+                    l.value.ast_debug(w);
+                }
+                if *inclusive {
+                    w.write("..=");
+                } else {
+                    w.write("..");
+                }
+                if let Some(h) = hi {
+                    h.value.ast_debug(w);
+                }
             },
         }
     }

--- a/third_party/move/move-compiler-v2/legacy-move-compiler/src/expansion/translate.rs
+++ b/third_party/move/move-compiler-v2/legacy-move-compiler/src/expansion/translate.rs
@@ -2957,8 +2957,14 @@ fn bind(context: &mut Context, sp!(loc, pb_): P::Bind) -> Option<E::LValue> {
             EL::Literal(eval)
         },
         PB::Range(plo, phi, inclusive) => {
-            let elo = plo.and_then(|v| value(context, v));
-            let ehi = phi.and_then(|v| value(context, v));
+            let elo = match plo {
+                Some(v) => Some(value(context, v)?),
+                None => None,
+            };
+            let ehi = match phi {
+                Some(v) => Some(value(context, v)?),
+                None => None,
+            };
             EL::Range(elo, ehi, inclusive)
         },
     };

--- a/third_party/move/move-compiler-v2/legacy-move-compiler/src/expansion/translate.rs
+++ b/third_party/move/move-compiler-v2/legacy-move-compiler/src/expansion/translate.rs
@@ -2956,6 +2956,11 @@ fn bind(context: &mut Context, sp!(loc, pb_): P::Bind) -> Option<E::LValue> {
             let eval = value(context, pval)?;
             EL::Literal(eval)
         },
+        PB::Range(plo, phi, inclusive) => {
+            let elo = plo.and_then(|v| value(context, v));
+            let ehi = phi.and_then(|v| value(context, v));
+            EL::Range(elo, ehi, inclusive)
+        },
     };
     Some(sp(loc, b_))
 }
@@ -3386,8 +3391,8 @@ fn unbound_names_bind(unbound: &mut UnboundNames, sp!(_, l_): &E::LValue) {
                 .collect();
             unbound_names_binds(unbound, &sp(loc, ls))
         },
-        EL::Literal(_) => {
-            // Literals don't bind any variables
+        EL::Literal(_) | EL::Range(..) => {
+            // Literals and ranges don't bind any variables
         },
     }
 }
@@ -3425,8 +3430,8 @@ fn unbound_names_assign(unbound: &mut UnboundNames, sp!(_, l_): &E::LValue) {
                 .collect();
             unbound_names_assigns(unbound, &sp(loc, ls))
         },
-        EL::Literal(_) => {
-            // Literals don't have variables to assign
+        EL::Literal(_) | EL::Range(..) => {
+            // Literals and ranges don't have variables to assign
         },
     }
 }

--- a/third_party/move/move-compiler-v2/legacy-move-compiler/src/parser/ast.rs
+++ b/third_party/move/move-compiler-v2/legacy-move-compiler/src/parser/ast.rs
@@ -592,6 +592,9 @@ pub enum Bind_ {
     // Literal value pattern (for primitive pattern matching)
     // true, false, 0, 1, byte strings, etc.
     Literal(Value),
+    // Range pattern: (lo, hi, inclusive_upper)
+    // lo..hi, lo..=hi, lo.., ..hi, ..=hi, ..
+    Range(Option<Value>, Option<Value>, bool),
 }
 pub type Bind = Spanned<Bind_>;
 // b1, ..., bn
@@ -2539,6 +2542,19 @@ impl AstDebug for Bind_ {
             },
             B::Literal(val) => {
                 val.value.ast_debug(w);
+            },
+            B::Range(lo, hi, inclusive) => {
+                if let Some(l) = lo {
+                    l.value.ast_debug(w);
+                }
+                if *inclusive {
+                    w.write("..=");
+                } else {
+                    w.write("..");
+                }
+                if let Some(h) = hi {
+                    h.value.ast_debug(w);
+                }
             },
         }
     }

--- a/third_party/move/move-compiler-v2/legacy-move-compiler/src/parser/lexer.rs
+++ b/third_party/move/move-compiler-v2/legacy-move-compiler/src/parser/lexer.rs
@@ -34,6 +34,7 @@ pub enum Tok {
     Minus,
     Period,
     PeriodPeriod,
+    PeriodPeriodEqual,
     Slash,
     Colon,
     ColonColon,
@@ -133,6 +134,7 @@ impl fmt::Display for Tok {
             Minus => "-",
             Period => ".",
             PeriodPeriod => "..",
+            PeriodPeriodEqual => "..=",
             Slash => "/",
             Colon => ":",
             ColonColon => "::",
@@ -654,7 +656,9 @@ fn find_token(
             }
         },
         '.' => {
-            if text.starts_with("..") {
+            if text.starts_with("..=") {
+                (Tok::PeriodPeriodEqual, 3)
+            } else if text.starts_with("..") {
                 (Tok::PeriodPeriod, 2)
             } else {
                 (Tok::Period, 1)

--- a/third_party/move/move-compiler-v2/legacy-move-compiler/src/parser/syntax.rs
+++ b/third_party/move/move-compiler-v2/legacy-move-compiler/src/parser/syntax.rs
@@ -907,9 +907,47 @@ fn maybe_parse_literal_pattern(context: &mut Context) -> Result<Option<Value>, B
     Ok(None)
 }
 
+/// Whether the token could start a literal pattern value (used to disambiguate
+/// `..` as structural DotDot vs. the start of a range pattern).
+fn is_literal_start_token(tok: Tok) -> bool {
+    matches!(
+        tok,
+        Tok::NumValue
+            | Tok::NumTypedValue
+            | Tok::True
+            | Tok::False
+            | Tok::ByteStringValue
+            | Tok::Minus
+    )
+}
+
+/// If the current token is `..` or `..=`, consume it and an optional literal
+/// upper bound.
+/// Returns `Ok(None)` without consuming anything if the current token is
+/// neither `..` nor `..=`.
+fn maybe_parse_range_suffix(
+    context: &mut Context,
+    lo: Option<&Value>,
+) -> Result<Option<Bind_>, Box<Diagnostic>> {
+    if !matches!(
+        context.tokens.peek(),
+        Tok::PeriodPeriod | Tok::PeriodPeriodEqual
+    ) {
+        return Ok(None);
+    }
+    let inclusive = context.tokens.peek() == Tok::PeriodPeriodEqual;
+    context.tokens.advance()?;
+    let hi = maybe_parse_literal_pattern(context)?;
+    Ok(Some(Bind_::Range(lo.cloned(), hi, inclusive)))
+}
+
 // Parse a binding:
 //      Bind =
 //          <Literal>
+//          | <Literal> ".." <Literal>?
+//          | <Literal> "..=" <Literal>
+//          | ".." <Literal>?
+//          | "..=" <Literal>
 //          | <Var>
 //          | <NameAccessChain> <OptionalTypeArgs> "{" Comma<BindFieldOrDotDot> "}"
 //          | <NameAccessChain> <OptionalTypeArgs> "(" Comma<BindOrDotDot> "," ")"
@@ -919,7 +957,28 @@ fn maybe_parse_literal_pattern(context: &mut Context) -> Result<Option<Value>, B
 fn parse_bind(context: &mut Context) -> Result<Bind, Box<Diagnostic>> {
     let start_loc = context.tokens.start_loc();
 
+    // Open-start range: `..hi` or `..=hi` or `..`
+    if let Some(range) = maybe_parse_range_suffix(context, None)? {
+        let end_loc = context.tokens.previous_end_loc();
+        return Ok(spanned(
+            context.tokens.file_hash(),
+            start_loc,
+            end_loc,
+            range,
+        ));
+    }
+
     if let Some(val) = maybe_parse_literal_pattern(context)? {
+        // Check for `lo..hi`, `lo..=hi`, or `lo..` range
+        if let Some(range) = maybe_parse_range_suffix(context, Some(&val))? {
+            let end_loc = context.tokens.previous_end_loc();
+            return Ok(spanned(
+                context.tokens.file_hash(),
+                start_loc,
+                end_loc,
+                range,
+            ));
+        }
         let end_loc = context.tokens.previous_end_loc();
         return Ok(spanned(
             context.tokens.file_hash(),
@@ -1007,30 +1066,42 @@ fn parse_bind_list(context: &mut Context) -> Result<BindList, Box<Diagnostic>> {
 
 /// Parse a <BindField> or a ".."
 /// <BindFieldOrDotDot> = <BindField> | ".."
+/// Note: `..` followed by a literal is parsed as a range pattern (via <BindField>),
+/// not as structural DotDot. `..=` is always a range.
 fn parse_bind_field_or_dotdot(context: &mut Context) -> Result<BindFieldOrDotDot, Box<Diagnostic>> {
     if context.tokens.peek() == Tok::PeriodPeriod {
-        let loc = current_token_loc(context.tokens);
-        require_move_2(context, loc, "`..` patterns");
-        context.tokens.advance()?;
-        Ok(sp(loc, BindFieldOrDotDot_::DotDot))
-    } else {
-        let (f, b) = parse_bind_field(context)?;
-        Ok(sp(f.loc(), BindFieldOrDotDot_::FieldBind(f, b)))
+        if !is_literal_start_token(context.tokens.lookahead()?) {
+            let loc = current_token_loc(context.tokens);
+            require_move_2(context, loc, "`..` patterns");
+            context.tokens.advance()?;
+            return Ok(sp(loc, BindFieldOrDotDot_::DotDot));
+        }
+        // Fall through — `parse_bind_field` will call `parse_bind` which handles ranges
     }
+    let (f, b) = parse_bind_field(context)?;
+    Ok(sp(f.loc(), BindFieldOrDotDot_::FieldBind(f, b)))
 }
 
 /// Parse a <Bind> or a ".."
 /// <BindOrDotDot> = <Bind> | ".."
+/// Note: `..` followed by a literal is parsed as a range pattern (via <Bind>),
+/// not as structural DotDot. `..=` is always a range.
 fn parse_bind_or_dotdot(context: &mut Context) -> Result<BindOrDotDot, Box<Diagnostic>> {
-    if context.tokens.peek() == Tok::PeriodPeriod {
-        let loc = current_token_loc(context.tokens);
-        require_move_2(context, loc, "`..` patterns");
-        context.tokens.advance()?;
-        Ok(sp(loc, BindOrDotDot_::DotDot))
-    } else {
+    if context.tokens.peek() == Tok::PeriodPeriodEqual {
         let b = parse_bind(context)?;
-        Ok(sp(b.loc, BindOrDotDot_::Bind(b)))
+        return Ok(sp(b.loc, BindOrDotDot_::Bind(b)));
     }
+    if context.tokens.peek() == Tok::PeriodPeriod {
+        if !is_literal_start_token(context.tokens.lookahead()?) {
+            let loc = current_token_loc(context.tokens);
+            require_move_2(context, loc, "`..` patterns");
+            context.tokens.advance()?;
+            return Ok(sp(loc, BindOrDotDot_::DotDot));
+        }
+        // Fall through to parse_bind which handles ranges
+    }
+    let b = parse_bind(context)?;
+    Ok(sp(b.loc, BindOrDotDot_::Bind(b)))
 }
 
 // Parse a list of bindings for lambda.

--- a/third_party/move/move-compiler-v2/src/bytecode_generator.rs
+++ b/third_party/move/move-compiler-v2/src/bytecode_generator.rs
@@ -2191,6 +2191,10 @@ impl Generator<'_> {
                 // Value patterns should have been transformed to if-else before bytecode generation
                 self.internal_error(id, "unexpected value pattern in bytecode generation")
             },
+            Pattern::Range(..) => {
+                // Range patterns should have been transformed to if-else before bytecode generation
+                self.internal_error(id, "unexpected range pattern in bytecode generation")
+            },
             Pattern::Error(_) => self.internal_error(id, "unexpected error pattern"),
         }
     }

--- a/third_party/move/move-compiler-v2/src/env_pipeline/function_checker.rs
+++ b/third_party/move/move-compiler-v2/src/env_pipeline/function_checker.rs
@@ -530,6 +530,7 @@ fn collect_struct_op_from_exp(func: &FunctionEnv, exp: &ExpData, ops: &mut Vec<S
                     Pattern::Var(_, _)
                     | Pattern::Wildcard(_)
                     | Pattern::LiteralValue(_, _)
+                    | Pattern::Range(_, _, _, _)
                     | Pattern::Error(_) => vec![],
                 };
                 for sub_pat in sub_pats {

--- a/third_party/move/move-compiler-v2/src/env_pipeline/inliner.rs
+++ b/third_party/move/move-compiler-v2/src/env_pipeline/inliner.rs
@@ -1479,6 +1479,9 @@ impl ExpRewriterFunctions for InlinedRewriter<'_, '_> {
             },
             Pattern::Wildcard(_) => Some(Pattern::Wildcard(new_id)),
             Pattern::LiteralValue(_, val) => Some(Pattern::LiteralValue(new_id, val.clone())),
+            Pattern::Range(_, lo, hi, inc) => {
+                Some(Pattern::Range(new_id, lo.clone(), hi.clone(), *inc))
+            },
             Pattern::Error(_) => None,
         }
     }

--- a/third_party/move/move-compiler-v2/src/env_pipeline/inlining_optimization.rs
+++ b/third_party/move/move-compiler-v2/src/env_pipeline/inlining_optimization.rs
@@ -704,6 +704,9 @@ impl ExpRewriterFunctions for CalleeRewriter<'_> {
             Pattern::Var(_, symbol) => Some(Pattern::Var(new_id, *symbol)),
             Pattern::Wildcard(_) => Some(Pattern::Wildcard(new_id)),
             Pattern::LiteralValue(_, val) => Some(Pattern::LiteralValue(new_id, val.clone())),
+            Pattern::Range(_, lo, hi, inc) => {
+                Some(Pattern::Range(new_id, lo.clone(), hi.clone(), *inc))
+            },
             Pattern::Error(_) => None,
         }
     }

--- a/third_party/move/move-compiler-v2/src/env_pipeline/literal_pattern_checker.rs
+++ b/third_party/move/move-compiler-v2/src/env_pipeline/literal_pattern_checker.rs
@@ -1,9 +1,9 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-//! Reject literal patterns in unsupported positions.
+//! Reject literal and range patterns in unsupported positions.
 //!
-//! Literal patterns are currently supported in match arms:
+//! Literal and range patterns are currently supported in match arms:
 //!
 //! 1. At the top level.
 //! 2. Inside top-level tuples.
@@ -12,13 +12,16 @@
 //! They are NOT supported in let bindings or lambda parameters
 //! (refutable patterns in irrefutable contexts).
 //!
+//! This pass also validates range bounds (empty/inverted ranges).
+//!
 //! This pass runs on the model AST before match coverage checks and
 //! match transforms.
 
 use move_model::{
     ast::{ExpData, Pattern},
     metadata::lang_feature_versions::LANGUAGE_VERSION_FOR_PRIMITIVE_MATCH,
-    model::GlobalEnv,
+    model::{GlobalEnv, NodeId},
+    ty::{PrimitiveType, Type},
 };
 
 /// Check all target functions for literal patterns in unsupported
@@ -42,11 +45,16 @@ fn check_exp(env: &GlobalEnv, exp: &move_model::ast::Exp) {
     exp.visit_pre_order(&mut |e| {
         match e {
             ExpData::Block(_, pat, _, _) | ExpData::Lambda(_, pat, _, _, _) => {
-                check_no_literal(env, pat, "literals are not allowed here");
+                check_no_literal_or_range(
+                    env,
+                    pat,
+                    "literal and range patterns are not allowed here",
+                );
             },
             ExpData::Match(_, _, arms) => {
                 for arm in arms {
                     check_match_arm_pattern(env, &arm.pattern);
+                    check_range_validity(env, &arm.pattern);
                 }
             },
             _ => {},
@@ -55,14 +63,15 @@ fn check_exp(env: &GlobalEnv, exp: &move_model::ast::Exp) {
     });
 }
 
-/// Check a single match arm pattern. Top-level literals and
+/// Check a single match arm pattern. Top-level literals/ranges and
 /// wildcards/vars are fine. For tuples, recurse into each element
-/// (still top-level context). For structs/enums, nested literals are
+/// (still top-level context). For structs/enums, nested literals/ranges are
 /// allowed starting from `LANGUAGE_VERSION_FOR_PRIMITIVE_MATCH`;
-/// on earlier versions any nested literal is invalid.
+/// on earlier versions any nested literal/range is invalid.
 fn check_match_arm_pattern(env: &GlobalEnv, pat: &Pattern) {
     match pat {
         Pattern::LiteralValue(..)
+        | Pattern::Range(..)
         | Pattern::Var(..)
         | Pattern::Wildcard(..)
         | Pattern::Error(..) => {},
@@ -81,7 +90,7 @@ fn check_match_arm_pattern(env: &GlobalEnv, pat: &Pattern) {
                 }
             } else {
                 for p in pats {
-                    check_no_literal(env, p, &format!(
+                    check_no_literal_or_range(env, p, &format!(
                         "literal patterns inside struct/enum variants require language version {} or later",
                         LANGUAGE_VERSION_FOR_PRIMITIVE_MATCH
                     ));
@@ -91,13 +100,71 @@ fn check_match_arm_pattern(env: &GlobalEnv, pat: &Pattern) {
     }
 }
 
-/// Report an error for every `Pattern::LiteralValue` reachable in
-/// `pat`.
-fn check_no_literal(env: &GlobalEnv, pat: &Pattern, msg: &str) {
+/// Report an error for every `Pattern::LiteralValue` or `Pattern::Range`
+/// reachable in `pat`.
+fn check_no_literal_or_range(env: &GlobalEnv, pat: &Pattern, msg: &str) {
     pat.visit_pre_post(&mut |is_post, p| {
         if !is_post {
-            if let Pattern::LiteralValue(id, _) = p {
-                env.error(&env.get_node_loc(*id), msg);
+            match p {
+                Pattern::LiteralValue(id, _) | Pattern::Range(id, _, _, _) => {
+                    env.error(&env.get_node_loc(*id), msg);
+                },
+                _ => {},
+            }
+        }
+    });
+}
+
+/// Get the PrimitiveType from a pattern's type, stripping references.
+fn get_prim_type(env: &GlobalEnv, id: &NodeId) -> Option<PrimitiveType> {
+    let ty = env.get_node_type(*id);
+    match ty.skip_reference() {
+        Type::Primitive(p) => Some(*p),
+        _ => None,
+    }
+}
+
+/// Validate range bounds: detect empty or inverted ranges.
+fn check_range_validity(env: &GlobalEnv, pat: &Pattern) {
+    pat.visit_pre_post(&mut |is_post, p| {
+        if is_post {
+            return;
+        }
+        // A bare `..` (no bounds) is redundant -> use `_` instead.
+        if let Pattern::Range(id, None, None, false) = p {
+            env.error(
+                &env.get_node_loc(*id),
+                "unbounded range pattern `..` is not allowed; use `_` instead",
+            );
+        }
+        // Inclusive ranges must have an explicit upper bound (`..=` and `lo..=` are invalid).
+        if let Pattern::Range(id, _, None, true) = p {
+            env.error(
+                &env.get_node_loc(*id),
+                "inclusive range pattern requires an upper bound",
+            );
+        }
+        if let Pattern::Range(id, lo_opt, hi_opt, inclusive) = p {
+            // Resolve effective bounds and flag errors for empty ranges.
+            let prim = get_prim_type(env, id);
+            let effective_lo = match lo_opt {
+                Some(v) => v.to_bigint(),
+                None => prim.as_ref().and_then(|p| p.get_min_value()),
+            };
+            let effective_hi = match hi_opt {
+                Some(v) => v.to_bigint(),
+                None => prim.as_ref().and_then(|p| p.get_max_value()).map(|m| m + 1),
+            };
+            if let (Some(lo_n), Some(hi_n)) = (&effective_lo, &effective_hi) {
+                let is_empty = if *inclusive && hi_opt.is_some() {
+                    lo_n > hi_n
+                } else {
+                    // Half-open comparison (exclusive upper, or open-ended resolved to max+1)
+                    lo_n >= hi_n
+                };
+                if is_empty {
+                    env.error(&env.get_node_loc(*id), "empty range pattern");
+                }
             }
         }
     });

--- a/third_party/move/move-compiler-v2/src/env_pipeline/literal_pattern_checker.rs
+++ b/third_party/move/move-compiler-v2/src/env_pipeline/literal_pattern_checker.rs
@@ -91,7 +91,7 @@ fn check_match_arm_pattern(env: &GlobalEnv, pat: &Pattern) {
             } else {
                 for p in pats {
                     check_no_literal_or_range(env, p, &format!(
-                        "literal patterns inside struct/enum variants require language version {} or later",
+                        "literal and range patterns inside struct/enum variants require language version {} or later",
                         LANGUAGE_VERSION_FOR_PRIMITIVE_MATCH
                     ));
                 }

--- a/third_party/move/move-compiler-v2/src/env_pipeline/match_coverage_checks.rs
+++ b/third_party/move/move-compiler-v2/src/env_pipeline/match_coverage_checks.rs
@@ -275,9 +275,9 @@ fn split_range_at_matrix_boundaries(
 
 /// Collect Range intervals from a set of constructors and sort by lower bound
 /// (None = -infinity comes first).
-fn collect_and_sort_intervals<'a>(
-    seen: &'a BTreeSet<MConstructor>,
-) -> Vec<(&'a Option<BigInt>, &'a Option<BigInt>)> {
+fn collect_and_sort_intervals(
+    seen: &BTreeSet<MConstructor>,
+) -> Vec<(&Option<BigInt>, &Option<BigInt>)> {
     let mut intervals: Vec<(&Option<BigInt>, &Option<BigInt>)> = seen
         .iter()
         .filter_map(|c| {
@@ -709,8 +709,7 @@ fn contains_range_witness(w: &WitnessPat) -> bool {
     match w {
         WitnessPat::Wild => false,
         WitnessPat::Ctor { ctor, args, .. } => {
-            matches!(ctor, MConstructor::Range(_, _))
-                || args.iter().any(contains_range_witness)
+            matches!(ctor, MConstructor::Range(_, _)) || args.iter().any(contains_range_witness)
         },
     }
 }

--- a/third_party/move/move-compiler-v2/src/env_pipeline/match_coverage_checks.rs
+++ b/third_party/move/move-compiler-v2/src/env_pipeline/match_coverage_checks.rs
@@ -300,6 +300,9 @@ fn collect_and_sort_intervals(
 /// Sweep sorted intervals and find the first gap, if any.
 /// Returns `None` if the intervals fully cover [-inf, +inf).
 /// Returns `Some((gap_lo, gap_hi))` for the first uncovered sub-range.
+///
+/// Assumes intervals have been through `normalize_range`, where `None`
+/// means "extends to the type boundary" (not "unresolved").
 fn find_first_gap(
     intervals: &[(&Option<BigInt>, &Option<BigInt>)],
 ) -> Option<(Option<BigInt>, Option<BigInt>)> {

--- a/third_party/move/move-compiler-v2/src/env_pipeline/match_coverage_checks.rs
+++ b/third_party/move/move-compiler-v2/src/env_pipeline/match_coverage_checks.rs
@@ -17,12 +17,16 @@
 //! The algorithm recursively decomposes the pattern matrix column-by-column, specializing
 //! by each constructor. This avoids a cross-product explosion that would occur with value
 //! enumeration on deeply nested tuple patterns.
+//!
+//! Range patterns are unified with literal number patterns: a literal `n` is treated as the
+//! half-open interval `[n, n+1)`, and all range comparisons use interval arithmetic.
 
 use itertools::Itertools;
 use move_model::{
     ast::{ExpData, MatchArm, Pattern, Value},
     model::{GlobalEnv, NodeId, QualifiedId, StructId},
     symbol::Symbol,
+    ty::{PrimitiveType, Type},
 };
 use num::BigInt;
 use std::collections::BTreeSet;
@@ -57,7 +61,9 @@ enum MConstructor {
     Variant(QualifiedId<StructId>, Symbol),
     Struct(QualifiedId<StructId>),
     Bool(bool),
-    Number(BigInt),
+    /// Half-open interval [lo, hi). `None` = type-based boundary.
+    /// `Number(n)` is represented as `Range(Some(n), Some(n+1))`.
+    Range(Option<BigInt>, Option<BigInt>),
     ByteArray(Vec<u8>),
     Tuple(usize),
 }
@@ -84,13 +90,62 @@ enum WitnessPat {
     },
 }
 
+/// Get the PrimitiveType from a pattern's type, stripping references.
+fn get_prim_type(env: &GlobalEnv, pat: &Pattern) -> Option<PrimitiveType> {
+    let ty = env.get_node_type(pat.node_id());
+    match ty.skip_reference() {
+        Type::Primitive(p) => Some(*p),
+        _ => None,
+    }
+}
+
+/// Normalize a half-open range [lo, hi) at type boundaries:
+/// If `lo == type_min`, replace with `None` (= -inf for coverage purposes).
+/// If `hi == type_max + 1`, replace with `None` (= +inf for coverage purposes).
+fn normalize_range(
+    lo: Option<BigInt>,
+    hi: Option<BigInt>,
+    prim: Option<&PrimitiveType>,
+) -> (Option<BigInt>, Option<BigInt>) {
+    let norm_lo = match (lo, prim) {
+        (Some(l), Some(p)) => {
+            if let Some(min) = p.get_min_value() {
+                if l == min {
+                    None
+                } else {
+                    Some(l)
+                }
+            } else {
+                Some(l)
+            }
+        },
+        (l, _) => l,
+    };
+    let norm_hi = match (hi, prim) {
+        (Some(h), Some(p)) => {
+            if let Some(max) = p.get_max_value() {
+                let type_end = max + 1; // one past the max
+                if h == type_end {
+                    None
+                } else {
+                    Some(h)
+                }
+            } else {
+                Some(h)
+            }
+        },
+        (h, _) => h,
+    };
+    (norm_lo, norm_hi)
+}
+
 /// Convert an AST `Pattern` to a `MatPat`.
-fn pattern_to_matpat(pat: &Pattern) -> MatPat {
+fn pattern_to_matpat(env: &GlobalEnv, pat: &Pattern) -> MatPat {
     match pat {
         Pattern::Var(_, _) | Pattern::Wildcard(_) | Pattern::Error(_) => MatPat::Wild,
         Pattern::Tuple(_, pats) => MatPat::Ctor(
             MConstructor::Tuple(pats.len()),
-            pats.iter().map(pattern_to_matpat).collect(),
+            pats.iter().map(|p| pattern_to_matpat(env, p)).collect(),
         ),
         Pattern::Struct(_, sid, variant, pats) => {
             let ctor = if let Some(v) = variant {
@@ -98,13 +153,41 @@ fn pattern_to_matpat(pat: &Pattern) -> MatPat {
             } else {
                 MConstructor::Struct(sid.to_qualified_id())
             };
-            MatPat::Ctor(ctor, pats.iter().map(pattern_to_matpat).collect())
+            MatPat::Ctor(
+                ctor,
+                pats.iter().map(|p| pattern_to_matpat(env, p)).collect(),
+            )
         },
         Pattern::LiteralValue(_, val) => match val {
             Value::Bool(b) => MatPat::Ctor(MConstructor::Bool(*b), vec![]),
-            Value::Number(n) => MatPat::Ctor(MConstructor::Number(n.clone()), vec![]),
+            Value::Number(n) => {
+                // Represent literal `n` as the half-open interval [n, n+1).
+                let lo = n.clone();
+                let hi = n + 1;
+                let prim = get_prim_type(env, pat);
+                let (norm_lo, norm_hi) = normalize_range(Some(lo), Some(hi), prim.as_ref());
+                MatPat::Ctor(MConstructor::Range(norm_lo, norm_hi), vec![])
+            },
             Value::ByteArray(bytes) => MatPat::Ctor(MConstructor::ByteArray(bytes.clone()), vec![]),
             _ => unreachable!("unsupported literal pattern value"),
+        },
+        Pattern::Range(_, lo, hi, inclusive) => {
+            // Normalize to half-open [lo, hi).
+            let norm_lo = lo.as_ref().and_then(|v| v.to_bigint());
+            let norm_hi = match (hi.as_ref(), inclusive) {
+                (Some(val), true) => {
+                    // inclusive upper: [lo, hi+1)
+                    val.to_bigint().map(|n| n + 1)
+                },
+                (Some(val), false) => {
+                    // exclusive upper: [lo, hi)
+                    val.to_bigint()
+                },
+                (None, _) => None, // open-ended: [lo, +inf)
+            };
+            let prim = get_prim_type(env, pat);
+            let (norm_lo, norm_hi) = normalize_range(norm_lo, norm_hi, prim.as_ref());
+            MatPat::Ctor(MConstructor::Range(norm_lo, norm_hi), vec![])
         },
     }
 }
@@ -114,8 +197,141 @@ fn constructor_arity(env: &GlobalEnv, ctor: &MConstructor) -> usize {
     match ctor {
         MConstructor::Variant(sid, v) => env.get_struct(*sid).get_fields_of_variant(*v).count(),
         MConstructor::Struct(sid) => env.get_struct(*sid).get_fields().count(),
-        MConstructor::Bool(_) | MConstructor::Number(_) | MConstructor::ByteArray(_) => 0,
+        MConstructor::Bool(_) | MConstructor::Range(_, _) | MConstructor::ByteArray(_) => 0,
         MConstructor::Tuple(n) => *n,
+    }
+}
+
+/// Check if a row range [rlo, rhi) contains the constructor range [clo, chi).
+/// `None` for lo means -infinity, `None` for hi means +infinity.
+fn range_contains(
+    rlo: &Option<BigInt>,
+    rhi: &Option<BigInt>,
+    clo: &Option<BigInt>,
+    chi: &Option<BigInt>,
+) -> bool {
+    // Check rlo <= clo
+    let lo_ok = match (rlo, clo) {
+        (None, _) => true,
+        (Some(_), None) => false,
+        (Some(r), Some(c)) => r <= c,
+    };
+    // Check chi <= rhi
+    let hi_ok = match (rhi, chi) {
+        (_, None) => rhi.is_none(),
+        (None, _) => true,
+        (Some(r), Some(c)) => c <= r,
+    };
+    lo_ok && hi_ok
+}
+
+/// Split `[qlo, qhi)` into disjoint sub-ranges at every boundary point from
+/// Range constructors in the matrix's first column that falls strictly inside
+/// the query range. Each resulting sub-range is either fully contained by any
+/// given matrix range or disjoint from it.
+fn split_range_at_matrix_boundaries(
+    matrix: &[Vec<MatPat>],
+    qlo: &Option<BigInt>,
+    qhi: &Option<BigInt>,
+) -> Vec<(Option<BigInt>, Option<BigInt>)> {
+    let mut points = BTreeSet::new();
+    for row in matrix {
+        if let MatPat::Ctor(MConstructor::Range(lo, hi), _) = &row[0] {
+            if let Some(l) = lo {
+                points.insert(l.clone());
+            }
+            if let Some(h) = hi {
+                points.insert(h.clone());
+            }
+        }
+    }
+    // Keep only points strictly inside (qlo, qhi).
+    let split_points: Vec<&BigInt> = points
+        .iter()
+        .filter(|p| {
+            let after_lo = match qlo {
+                None => true,
+                Some(l) => *p > l,
+            };
+            let before_hi = match qhi {
+                None => true,
+                Some(h) => *p < h,
+            };
+            after_lo && before_hi
+        })
+        .collect();
+    if split_points.is_empty() {
+        return vec![(qlo.clone(), qhi.clone())];
+    }
+    let mut result = Vec::new();
+    let mut current_lo = qlo.clone();
+    for p in split_points {
+        result.push((current_lo, Some(p.clone())));
+        current_lo = Some(p.clone());
+    }
+    result.push((current_lo, qhi.clone()));
+    result
+}
+
+/// Collect Range intervals from a set of constructors and sort by lower bound
+/// (None = -infinity comes first).
+fn collect_and_sort_intervals<'a>(
+    seen: &'a BTreeSet<MConstructor>,
+) -> Vec<(&'a Option<BigInt>, &'a Option<BigInt>)> {
+    let mut intervals: Vec<(&Option<BigInt>, &Option<BigInt>)> = seen
+        .iter()
+        .filter_map(|c| {
+            if let MConstructor::Range(lo, hi) = c {
+                Some((lo, hi))
+            } else {
+                None
+            }
+        })
+        .collect();
+    intervals.sort_by(|a, b| match (&a.0, &b.0) {
+        (None, None) => std::cmp::Ordering::Equal,
+        (None, Some(_)) => std::cmp::Ordering::Less,
+        (Some(_), None) => std::cmp::Ordering::Greater,
+        (Some(x), Some(y)) => x.cmp(y),
+    });
+    intervals
+}
+
+/// Sweep sorted intervals and find the first gap, if any.
+/// Returns `None` if the intervals fully cover [-inf, +inf).
+/// Returns `Some((gap_lo, gap_hi))` for the first uncovered sub-range.
+fn find_first_gap(
+    intervals: &[(&Option<BigInt>, &Option<BigInt>)],
+) -> Option<(Option<BigInt>, Option<BigInt>)> {
+    let mut coverage_end: Option<BigInt> = None;
+    let mut started = false;
+    for (lo, hi) in intervals {
+        if !started {
+            if lo.is_some() {
+                return Some((None, lo.as_ref().cloned()));
+            }
+            started = true;
+        } else if let (Some(l), Some(end)) = (lo, &coverage_end)
+            && l > end
+        {
+            return Some((Some(end.clone()), Some(l.clone())));
+        }
+        match (hi, &coverage_end) {
+            (None, _) => return None, // covered to +inf
+            (Some(h), None) => coverage_end = Some(h.clone()),
+            (Some(h), Some(end)) => {
+                if h > end {
+                    coverage_end = Some(h.clone());
+                }
+            },
+        }
+    }
+    if let Some(end) = coverage_end {
+        Some((Some(end), None))
+    } else if !started {
+        Some((None, None))
+    } else {
+        None
     }
 }
 
@@ -143,7 +359,15 @@ fn all_constructors_if_complete(
             // Exactly one constructor — always complete.
             Some(seen.iter().cloned().collect())
         },
-        MConstructor::Number(_) | MConstructor::ByteArray(_) => None, // integers and byte arrays are never complete
+        MConstructor::Range(_, _) => {
+            let intervals = collect_and_sort_intervals(seen);
+            if find_first_gap(&intervals).is_none() {
+                Some(seen.iter().cloned().collect())
+            } else {
+                None
+            }
+        },
+        MConstructor::ByteArray(_) => None, // byte arrays are never complete
     }
 }
 
@@ -155,21 +379,31 @@ fn find_missing_constructor(
     seen: &BTreeSet<MConstructor>,
 ) -> Option<(MConstructor, usize)> {
     let first = seen.iter().next()?;
-    let missing: Vec<MConstructor> = match first {
-        MConstructor::Bool(_) => [MConstructor::Bool(false), MConstructor::Bool(true)]
-            .into_iter()
-            .filter(|c| !seen.contains(c))
-            .collect(),
-        MConstructor::Variant(sid, _) => env
-            .get_struct(*sid)
-            .get_variants()
-            .map(|v| MConstructor::Variant(*sid, v))
-            .filter(|c| !seen.contains(c))
-            .collect(),
-        _ => return None,
-    };
-    let additional = missing.len().saturating_sub(1);
-    missing.into_iter().next().map(|c| (c, additional))
+    match first {
+        MConstructor::Bool(_) => {
+            let missing: Vec<MConstructor> = [MConstructor::Bool(false), MConstructor::Bool(true)]
+                .into_iter()
+                .filter(|c| !seen.contains(c))
+                .collect();
+            let additional = missing.len().saturating_sub(1);
+            missing.into_iter().next().map(|c| (c, additional))
+        },
+        MConstructor::Variant(sid, _) => {
+            let missing: Vec<MConstructor> = env
+                .get_struct(*sid)
+                .get_variants()
+                .map(|v| MConstructor::Variant(*sid, v))
+                .filter(|c| !seen.contains(c))
+                .collect();
+            let additional = missing.len().saturating_sub(1);
+            missing.into_iter().next().map(|c| (c, additional))
+        },
+        MConstructor::Range(_, _) => {
+            let intervals = collect_and_sort_intervals(seen);
+            find_first_gap(&intervals).map(|(lo, hi)| (MConstructor::Range(lo, hi), 0))
+        },
+        _ => None,
+    }
 }
 
 // ---- Matrix operations ------------------------------------------------------------------
@@ -184,12 +418,24 @@ fn specialize(matrix: &[Vec<MatPat>], ctor: &MConstructor, arity: usize) -> Vec<
 
 fn specialize_row(row: &[MatPat], ctor: &MConstructor, arity: usize) -> Option<Vec<MatPat>> {
     match &row[0] {
-        MatPat::Ctor(c, args) if c == ctor => {
-            let mut new_row = args.clone();
-            new_row.extend_from_slice(&row[1..]);
-            Some(new_row)
+        MatPat::Ctor(c, args) => {
+            // For Range constructors, check containment instead of equality.
+            if let (MConstructor::Range(clo, chi), MConstructor::Range(rlo, rhi)) = (ctor, c) {
+                if range_contains(rlo, rhi, clo, chi) {
+                    let mut new_row = args.clone();
+                    new_row.extend_from_slice(&row[1..]);
+                    return Some(new_row);
+                }
+                return None;
+            }
+            if c == ctor {
+                let mut new_row = args.clone();
+                new_row.extend_from_slice(&row[1..]);
+                Some(new_row)
+            } else {
+                None
+            }
         },
-        MatPat::Ctor(_, _) => None,
         MatPat::Wild => {
             let mut new_row = vec![MatPat::Wild; arity];
             new_row.extend_from_slice(&row[1..]);
@@ -232,6 +478,19 @@ fn is_useful(env: &GlobalEnv, matrix: &[Vec<MatPat>], q: &[MatPat]) -> bool {
 
     match &q[0] {
         MatPat::Ctor(c, sub) => {
+            // For Range constructors, split at matrix boundaries so each
+            // sub-range is fully contained by individual matrix rows.
+            // The query is useful iff any sub-range is useful.
+            if let MConstructor::Range(qlo, qhi) = c {
+                let sub_ranges = split_range_at_matrix_boundaries(matrix, qlo, qhi);
+                return sub_ranges.iter().any(|(lo, hi)| {
+                    let sub_ctor = MConstructor::Range(lo.clone(), hi.clone());
+                    let spec = specialize(matrix, &sub_ctor, 0);
+                    let mut new_q: Vec<MatPat> = sub.clone();
+                    new_q.extend_from_slice(&q[1..]);
+                    is_useful(env, &spec, &new_q)
+                });
+            }
             let arity = sub.len();
             let spec = specialize(matrix, c, arity);
             let mut new_q: Vec<MatPat> = sub.clone();
@@ -240,13 +499,23 @@ fn is_useful(env: &GlobalEnv, matrix: &[Vec<MatPat>], q: &[MatPat]) -> bool {
         },
         MatPat::Wild => {
             if let Some(all) = all_constructors_if_complete(env, &head_ctors) {
-                all.iter().any(|c| {
-                    let arity = constructor_arity(env, c);
-                    let spec = specialize(matrix, c, arity);
-                    let mut new_q = vec![MatPat::Wild; arity];
-                    new_q.extend_from_slice(&q[1..]);
-                    is_useful(env, &spec, &new_q)
-                })
+                // For ranges, use atomic intervals to handle partial overlaps.
+                if matches!(all.first(), Some(MConstructor::Range(_, _))) {
+                    let atomic = split_range_at_matrix_boundaries(matrix, &None, &None);
+                    atomic.iter().any(|(lo, hi)| {
+                        let sub_ctor = MConstructor::Range(lo.clone(), hi.clone());
+                        let spec = specialize(matrix, &sub_ctor, 0);
+                        is_useful(env, &spec, &q[1..])
+                    })
+                } else {
+                    all.iter().any(|c| {
+                        let arity = constructor_arity(env, c);
+                        let spec = specialize(matrix, c, arity);
+                        let mut new_q = vec![MatPat::Wild; arity];
+                        new_q.extend_from_slice(&q[1..]);
+                        is_useful(env, &spec, &new_q)
+                    })
+                }
             } else {
                 let def = default_matrix(matrix);
                 is_useful(env, &def, &q[1..])
@@ -284,6 +553,14 @@ fn collect_witnesses(
 
     match &q[0] {
         MatPat::Ctor(c, sub) => {
+            // Range splitting is only implemented in `is_useful`; this branch
+            // is currently unreachable for Range constructors because the entry
+            // point always passes `[Wild]`.
+            assert!(
+                !matches!(c, MConstructor::Range(_, _)),
+                "collect_witnesses should not be called with a Range Ctor query; \
+                 range splitting is only implemented in is_useful"
+            );
             let arity = sub.len();
             let spec = specialize(matrix, c, arity);
             let mut new_q: Vec<MatPat> = sub.clone();
@@ -295,8 +572,25 @@ fn collect_witnesses(
         },
         MatPat::Wild => {
             let mut all_witnesses = Vec::new();
-            // Check each seen constructor (may have internal gaps).
-            for c in &head_ctors {
+            // For Range constructors, split into atomic intervals to
+            // correctly handle partial overlaps between matrix rows.
+            let effective_ctors: Vec<MConstructor> = if head_ctors
+                .iter()
+                .any(|c| matches!(c, MConstructor::Range(_, _)))
+            {
+                let mut atomic = BTreeSet::new();
+                for c in &head_ctors {
+                    if let MConstructor::Range(lo, hi) = c {
+                        for (slo, shi) in split_range_at_matrix_boundaries(matrix, lo, hi) {
+                            atomic.insert(MConstructor::Range(slo, shi));
+                        }
+                    }
+                }
+                atomic.into_iter().collect()
+            } else {
+                head_ctors.iter().cloned().collect()
+            };
+            for c in &effective_ctors {
                 let arity = constructor_arity(env, c);
                 let spec = specialize(matrix, c, arity);
                 let mut new_q = vec![MatPat::Wild; arity];
@@ -361,7 +655,7 @@ fn analyze_match_coverage(env: &GlobalEnv, disc_node_id: NodeId, arms: &[MatchAr
     // Build the unconditional matrix incrementally for reachability checking.
     let mut uncond_matrix: Vec<Vec<MatPat>> = Vec::new();
     for arm in arms {
-        let mp = pattern_to_matpat(&arm.pattern);
+        let mp = pattern_to_matpat(env, &arm.pattern);
         let q = vec![mp.clone()];
         if !is_useful(env, &uncond_matrix, &q) {
             env.error(
@@ -389,8 +683,11 @@ fn analyze_match_coverage(env: &GlobalEnv, disc_node_id: NodeId, arms: &[MatchAr
                     } => *additional_missing,
                     _ => 0,
                 };
+                let is_range_witness = contains_range_witness(&w[0]);
                 if additional > 0 {
                     format!("missing `{}` (and {} more)", pat, additional)
+                } else if is_range_witness {
+                    format!("missing at least `{}`", pat)
                 } else {
                     format!("missing `{}`", pat)
                 }
@@ -406,12 +703,24 @@ fn analyze_match_coverage(env: &GlobalEnv, disc_node_id: NodeId, arms: &[MatchAr
 
 // ---- Witness display --------------------------------------------------------------------
 
+/// Check whether a witness pattern contains a range constructor anywhere
+/// (including nested inside structs/tuples).
+fn contains_range_witness(w: &WitnessPat) -> bool {
+    match w {
+        WitnessPat::Wild => false,
+        WitnessPat::Ctor { ctor, args, .. } => {
+            matches!(ctor, MConstructor::Range(_, _))
+                || args.iter().any(contains_range_witness)
+        },
+    }
+}
+
 fn display_witness_pat(env: &GlobalEnv, w: &WitnessPat) -> String {
     match w {
         WitnessPat::Wild => "_".to_string(),
         WitnessPat::Ctor { ctor, args, .. } => match ctor {
             MConstructor::Bool(b) => format!("{}", b),
-            MConstructor::Number(n) => format!("{}", n),
+            MConstructor::Range(lo, hi) => display_range_witness(lo, hi),
             MConstructor::ByteArray(bytes) => {
                 if let Ok(s) = std::str::from_utf8(bytes) {
                     format!("b\"{}\"", s)
@@ -430,6 +739,24 @@ fn display_witness_pat(env: &GlobalEnv, w: &WitnessPat) -> String {
     }
 }
 
+/// Display a range witness in a human-readable form.
+fn display_range_witness(lo: &Option<BigInt>, hi: &Option<BigInt>) -> String {
+    match (lo, hi) {
+        (Some(l), Some(h)) => {
+            // Check if it's a single value [n, n+1).
+            let one = BigInt::from(1);
+            if h == &(l + &one) {
+                format!("{}", l)
+            } else {
+                format!("{}..{}", l, h)
+            }
+        },
+        (Some(l), None) => format!("{}..", l),
+        (None, Some(h)) => format!("..{}", h),
+        (None, None) => "_".to_string(),
+    }
+}
+
 fn display_witness_struct(
     env: &GlobalEnv,
     sid: QualifiedId<StructId>,
@@ -441,18 +768,35 @@ fn display_witness_struct(
     if let Some(v) = var {
         s.push_str(&format!("::{}", v.display(env.symbol_pool())));
     }
-    // Display struct fields, or {..} if all wildcards.
+    // Display fields: positional uses `(..)` / `(a, b)`, named uses `{..}` / `{f: a}`.
     if var.is_none() || !args.is_empty() {
+        let positional = struct_env
+            .get_fields_optional_variant(var)
+            .any(|f| f.is_positional());
         if args.iter().all(|a| matches!(a, WitnessPat::Wild)) {
-            s.push_str("{..}");
+            if positional {
+                s.push_str("(..)");
+            } else {
+                s.push_str("{..}");
+            }
         } else {
             let fields: Vec<String> = struct_env
                 .get_fields_optional_variant(var)
-                .map(|f| f.get_name().display(env.symbol_pool()).to_string())
                 .zip(args.iter())
-                .map(|(f, a)| format!("{}: {}", f, display_witness_pat(env, a)))
+                .map(|(f, a)| {
+                    if positional {
+                        display_witness_pat(env, a)
+                    } else {
+                        let name = f.get_name().display(env.symbol_pool()).to_string();
+                        format!("{}: {}", name, display_witness_pat(env, a))
+                    }
+                })
                 .collect();
-            s.push_str(&format!("{{{}}}", fields.join(", ")));
+            if positional {
+                s.push_str(&format!("({})", fields.join(", ")));
+            } else {
+                s.push_str(&format!("{{{}}}", fields.join(", ")));
+            }
         }
     }
     s

--- a/third_party/move/move-compiler-v2/src/env_pipeline/match_transforms.rs
+++ b/third_party/move/move-compiler-v2/src/env_pipeline/match_transforms.rs
@@ -115,6 +115,59 @@ fn make_deref_eq(env: &GlobalEnv, loc: &Loc, lhs: Exp, val: &Value) -> Exp {
     make_eq(env, loc, cmp_lhs, val_exp)
 }
 
+/// Create a comparison expression: `lhs op rhs`.
+fn make_cmp(env: &GlobalEnv, loc: &Loc, op: Operation, lhs: Exp, rhs: Exp) -> Exp {
+    let id = env.new_node(loc.clone(), Type::Primitive(PrimitiveType::Bool));
+    ExpData::Call(id, op, vec![lhs, rhs]).into_exp()
+}
+
+/// Create a range check condition for a discriminator against a range pattern.
+/// Handles `Deref` for reference types (same pattern as `make_deref_eq`).
+/// `lo` bound -> `Ge(disc, lo)` condition
+/// `hi` bound -> `Lt(disc, hi)` (exclusive) or `Le(disc, hi)` (inclusive)
+/// Both `None` -> `true` (matches everything)
+fn make_range_check(
+    env: &GlobalEnv,
+    loc: &Loc,
+    disc: Exp,
+    lo: &Option<Value>,
+    hi: &Option<Value>,
+    inclusive: bool,
+) -> Exp {
+    let ty = env.get_node_type(disc.node_id());
+    let (cmp_disc, base_ty) = if let Type::Reference(_, inner) = &ty {
+        let inner_ty = inner.as_ref().clone();
+        let deref_id = env.new_node(loc.clone(), inner_ty.clone());
+        let deref_exp = ExpData::Call(deref_id, Operation::Deref, vec![disc]).into_exp();
+        (deref_exp, inner_ty)
+    } else {
+        (disc, ty)
+    };
+
+    let mut conditions = Vec::new();
+
+    if let Some(lo_val) = lo {
+        // disc >= lo
+        let lo_id = env.new_node(loc.clone(), base_ty.clone());
+        let lo_exp = ExpData::Value(lo_id, lo_val.clone()).into_exp();
+        conditions.push(make_cmp(env, loc, Operation::Ge, cmp_disc.clone(), lo_exp));
+    }
+
+    if let Some(hi_val) = hi {
+        let hi_id = env.new_node(loc.clone(), base_ty.clone());
+        let hi_exp = ExpData::Value(hi_id, hi_val.clone()).into_exp();
+        if inclusive {
+            // disc <= hi
+            conditions.push(make_cmp(env, loc, Operation::Le, cmp_disc, hi_exp));
+        } else {
+            // disc < hi
+            conditions.push(make_cmp(env, loc, Operation::Lt, cmp_disc, hi_exp));
+        }
+    }
+
+    conjoin(env, loc, conditions).unwrap_or_else(|| make_true(env, loc))
+}
+
 /// Combine a list of boolean conditions with `&&`. Returns `None` if the list is empty.
 fn conjoin(env: &GlobalEnv, loc: &Loc, conditions: Vec<Exp>) -> Option<Exp> {
     conditions.into_iter().reduce(|acc, cond| {
@@ -204,12 +257,12 @@ impl ExpRewriterFunctions for MatchTransformer<'_> {
 }
 
 impl MatchTransformer<'_> {
-    /// Flag any remaining literal patterns as a compiler bug.
+    /// Flag any remaining literal or range patterns as a compiler bug.
     fn reject_remaining_literals(&self, arms: &[MatchArm]) {
         for arm in arms {
             arm.pattern.visit_pre_post(&mut |is_post, pat| {
                 if !is_post {
-                    if let Pattern::LiteralValue(id, _) = pat {
+                    if let Pattern::LiteralValue(id, _) | Pattern::Range(id, ..) = pat {
                         self.env.diag(
                             Severity::Bug,
                             &self.env.get_node_loc(*id),
@@ -285,22 +338,29 @@ fn is_suitable_type(ty: &Type) -> bool {
     }
 }
 
-/// Check if a pattern is suitable (literals, wildcards, vars, or tuples thereof).
+/// Check if a pattern is suitable (literals, ranges, wildcards, vars, or tuples thereof).
 fn is_suitable_pattern(pat: &Pattern) -> bool {
     match pat {
-        Pattern::Wildcard(_) | Pattern::Var(_, _) | Pattern::LiteralValue(_, _) => true,
+        Pattern::Wildcard(_)
+        | Pattern::Var(_, _)
+        | Pattern::LiteralValue(_, _)
+        | Pattern::Range(..) => true,
         Pattern::Tuple(_, pats) => pats.iter().all(is_suitable_pattern),
         Pattern::Struct(..) | Pattern::Error(_) => false,
     }
 }
 
 /// Check if a pattern unconditionally matches any value (wildcard, variable,
-/// or a tuple of all catch-all patterns).
+/// unbounded range, or a tuple of all catch-all patterns).
 fn is_catch_all_pattern(pat: &Pattern) -> bool {
     match pat {
         Pattern::Wildcard(_) | Pattern::Var(_, _) => true,
+        Pattern::Range(_, None, None, _) => true,
         Pattern::Tuple(_, pats) => pats.iter().all(is_catch_all_pattern),
-        _ => false,
+        Pattern::LiteralValue(..)
+        | Pattern::Range(..)
+        | Pattern::Struct(..)
+        | Pattern::Error(_) => false,
     }
 }
 
@@ -308,8 +368,13 @@ fn is_catch_all_pattern(pat: &Pattern) -> bool {
 fn pattern_has_vars(pat: &Pattern) -> bool {
     match pat {
         Pattern::Var(..) => true,
-        Pattern::Tuple(_, pats) => pats.iter().any(pattern_has_vars),
-        _ => false,
+        Pattern::Tuple(_, pats) | Pattern::Struct(_, _, _, pats) => {
+            pats.iter().any(pattern_has_vars)
+        },
+        Pattern::Wildcard(_)
+        | Pattern::LiteralValue(..)
+        | Pattern::Range(..)
+        | Pattern::Error(_) => false,
     }
 }
 
@@ -328,10 +393,10 @@ fn has_nested_literals(arms: &[MatchArm]) -> bool {
 /// Recursive check: `inside_struct` tracks whether we're under a Struct node.
 fn has_nested_literal_in(pat: &Pattern, inside_struct: bool) -> bool {
     match pat {
-        Pattern::LiteralValue(..) => inside_struct,
+        Pattern::LiteralValue(..) | Pattern::Range(..) => inside_struct,
         Pattern::Struct(_, _, _, pats) => pats.iter().any(|p| has_nested_literal_in(p, true)),
         Pattern::Tuple(_, pats) => pats.iter().any(|p| has_nested_literal_in(p, inside_struct)),
-        _ => false,
+        Pattern::Wildcard(_) | Pattern::Var(..) | Pattern::Error(_) => false,
     }
 }
 
@@ -396,6 +461,16 @@ fn extract_literals_from_pattern(
             let var_id = env.new_node(loc.clone(), ty.clone());
             let var_exp = make_local_var(env, &loc, ty.clone(), sym);
             conditions.push(make_deref_eq(env, &loc, var_exp, val));
+            Pattern::Var(var_id, sym)
+        },
+        Pattern::Range(id, lo, hi, inclusive) if inside_struct => {
+            let ty = env.get_node_type(*id);
+            let loc = env.get_node_loc(*id);
+            let sym = TempSymbol::NestedLiteralTemp(*counter).create(env);
+            *counter += 1;
+            let var_id = env.new_node(loc.clone(), ty.clone());
+            let var_exp = make_local_var(env, &loc, ty.clone(), sym);
+            conditions.push(make_range_check(env, &loc, var_exp, lo, hi, *inclusive));
             Pattern::Var(var_id, sym)
         },
         Pattern::Struct(id, sid, variant, pats) => {
@@ -529,6 +604,10 @@ fn generate_pattern_condition(env: &GlobalEnv, discriminator: &Exp, pattern: &Pa
 
         Pattern::LiteralValue(_, val) => make_deref_eq(env, &loc, discriminator.clone(), val),
 
+        Pattern::Range(_, lo, hi, inclusive) => {
+            make_range_check(env, &loc, discriminator.clone(), lo, hi, *inclusive)
+        },
+
         Pattern::Tuple(_, pats) => {
             let discriminator_ty = env.get_node_type(discriminator.node_id());
             if let Type::Tuple(_) = discriminator_ty {
@@ -578,16 +657,23 @@ fn generate_tuple_condition(env: &GlobalEnv, tuple_exp: &Exp, patterns: &[Patter
         },
     };
 
-    // Generate Eq conditions for each literal pattern
+    // Generate conditions for each literal or range pattern
     let conditions: Vec<Exp> = patterns
         .iter()
         .enumerate()
-        .filter_map(|(idx, pat)| {
-            if let Pattern::LiteralValue(_, val) = pat {
+        .filter_map(|(idx, pat)| match pat {
+            Pattern::LiteralValue(_, val) => {
                 Some(make_deref_eq(env, &loc, elem_exps[idx].clone(), val))
-            } else {
-                None
-            }
+            },
+            Pattern::Range(_, lo, hi, inclusive) => Some(make_range_check(
+                env,
+                &loc,
+                elem_exps[idx].clone(),
+                lo,
+                hi,
+                *inclusive,
+            )),
+            _ => None,
         })
         .collect();
 
@@ -680,10 +766,13 @@ fn is_mixed_tuple_match(env: &GlobalEnv, discriminator: &Exp, arms: &[MatchArm])
                 // Check each position
                 pats.iter().enumerate().all(|(idx, pat)| {
                     if is_suitable_type(&elem_tys[idx]) {
-                        // Primitive positions: must be literal, wildcard, or var
+                        // Primitive positions: must be literal, range, wildcard, or var
                         matches!(
                             pat,
-                            Pattern::LiteralValue(..) | Pattern::Wildcard(_) | Pattern::Var(_, _)
+                            Pattern::LiteralValue(..)
+                                | Pattern::Range(..)
+                                | Pattern::Wildcard(_)
+                                | Pattern::Var(_, _)
                         )
                     } else {
                         // Non-primitive positions: must be struct, wildcard, or var
@@ -928,6 +1017,11 @@ fn transform_mixed_arm(
                         let (sym, _) = &prim_temps[seq];
                         let var_exp = make_local_var(env, &loc, elem_tys[pos].clone(), *sym);
                         conditions.push(make_deref_eq(env, &loc, var_exp, val));
+                    },
+                    Pattern::Range(_, lo, hi, inclusive) => {
+                        let (sym, _) = &prim_temps[seq];
+                        let var_exp = make_local_var(env, &loc, elem_tys[pos].clone(), *sym);
+                        conditions.push(make_range_check(env, &loc, var_exp, lo, hi, *inclusive));
                     },
                     Pattern::Var(_, var_sym) => {
                         var_bindings.push((*var_sym, seq));

--- a/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/primitive_match_range.exp
+++ b/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/primitive_match_range.exp
@@ -1,0 +1,7 @@
+
+Diagnostics:
+error: match over integers, booleans, or byte strings is not supported before language version 2.4-unstable
+  ┌─ tests/checking-lang-v2.2/primitive_match_range.move:4:16
+  │
+4 │         match (x) {
+  │                ^

--- a/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/primitive_match_range.move
+++ b/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/primitive_match_range.move
@@ -1,0 +1,9 @@
+/// Range patterns in match arms are rejected before the primitive-match language version.
+module 0xc0ffee::primitive_match_range {
+    public fun test(x: u64): u64 {
+        match (x) {
+            1..10 => 1,
+            _ => 0,
+        }
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/struct_literal_not_supported.exp
+++ b/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/struct_literal_not_supported.exp
@@ -1,12 +1,12 @@
 
 Diagnostics:
-error: literal patterns inside struct/enum variants require language version 2.4-unstable or later
+error: literal and range patterns inside struct/enum variants require language version 2.4-unstable or later
    ┌─ tests/checking-lang-v2.2/struct_literal_not_supported.move:11:19
    │
 11 │             E::V1(1) => 1,
    │                   ^
 
-error: literal patterns inside struct/enum variants require language version 2.4-unstable or later
+error: literal and range patterns inside struct/enum variants require language version 2.4-unstable or later
    ┌─ tests/checking-lang-v2.2/struct_literal_not_supported.move:19:20
    │
 19 │             S { x: 42 } => 1,

--- a/third_party/move/move-compiler-v2/tests/match-checks/enum_variant_literal_coverage.exp
+++ b/third_party/move/move-compiler-v2/tests/match-checks/enum_variant_literal_coverage.exp
@@ -6,7 +6,7 @@ error: match not exhaustive
 9 │         match (e) {
   │                ^
   │
-  = missing `E::V1{..}`
+  = missing at least `E::V1(..1)`
 
 error: unreachable pattern
    ┌─ tests/match-checks/enum_variant_literal_coverage.move:19:13

--- a/third_party/move/move-compiler-v2/tests/match-checks/int_non_exhaustive_witness.exp
+++ b/third_party/move/move-compiler-v2/tests/match-checks/int_non_exhaustive_witness.exp
@@ -6,4 +6,4 @@ error: match not exhaustive
 3 │         match (x) {
   │                ^
   │
-  = missing `_`
+  = missing at least `3..`

--- a/third_party/move/move-compiler-v2/tests/match-checks/literal_bind_outside_match.exp
+++ b/third_party/move/move-compiler-v2/tests/match-checks/literal_bind_outside_match.exp
@@ -1,36 +1,36 @@
 
 Diagnostics:
-error: literals are not allowed here
+error: literal and range patterns are not allowed here
    ┌─ tests/match-checks/literal_bind_outside_match.move:12:20
    │
 12 │         let S { x: 1 } = S { x: 1 };
    │                    ^
 
-error: literals are not allowed here
+error: literal and range patterns are not allowed here
    ┌─ tests/match-checks/literal_bind_outside_match.move:17:15
    │
 17 │         let P(1) = P(1);
    │               ^
 
-error: literals are not allowed here
+error: literal and range patterns are not allowed here
    ┌─ tests/match-checks/literal_bind_outside_match.move:22:13
    │
 22 │         let 1u64 = 1;
    │             ^^^^
 
-error: literals are not allowed here
+error: literal and range patterns are not allowed here
    ┌─ tests/match-checks/literal_bind_outside_match.move:29:25
    │
 29 │         let f = |S { x: 1 }| 0;
    │                         ^
 
-error: literals are not allowed here
+error: literal and range patterns are not allowed here
    ┌─ tests/match-checks/literal_bind_outside_match.move:34:20
    │
 34 │         let f = |P(1)| 0;
    │                    ^
 
-error: literals are not allowed here
+error: literal and range patterns are not allowed here
    ┌─ tests/match-checks/literal_bind_outside_match.move:39:18
    │
 39 │         let f = |1u64| 0;

--- a/third_party/move/move-compiler-v2/tests/match-checks/literal_coverage_err.exp
+++ b/third_party/move/move-compiler-v2/tests/match-checks/literal_coverage_err.exp
@@ -6,7 +6,7 @@ error: match not exhaustive
 3 │         match (x) {
   │                ^
   │
-  = missing `_`
+  = missing at least `..1`
 
 error: unreachable pattern
    ┌─ tests/match-checks/literal_coverage_err.move:12:13

--- a/third_party/move/move-compiler-v2/tests/match-checks/match_coverage_algorithm_comparison.exp
+++ b/third_party/move/move-compiler-v2/tests/match-checks/match_coverage_algorithm_comparison.exp
@@ -52,4 +52,4 @@ error: match not exhaustive
 126 │         match (x) {
     │                ^
     │
-    = missing `_`
+    = missing at least `2..`

--- a/third_party/move/move-compiler-v2/tests/match-checks/range_adjacent_exhaustive.move
+++ b/third_party/move/move-compiler-v2/tests/match-checks/range_adjacent_exhaustive.move
@@ -1,0 +1,26 @@
+module 0xc0ffee::range_adjacent_exhaustive {
+    // Two adjacent ranges covering full u8 (should compile)
+    fun two_adjacent_u8(x: u8): u64 {
+        match (x) {
+            0..128 => 1,
+            128..=255 => 2,
+        }
+    }
+
+    // Three adjacent ranges covering full u8 (should compile)
+    fun three_adjacent_u8(x: u8): u64 {
+        match (x) {
+            0..100 => 1,
+            100..200 => 2,
+            200..=255 => 3,
+        }
+    }
+
+    // Literal + range coverage on u8 (should compile)
+    fun literal_plus_range_u8(x: u8): u64 {
+        match (x) {
+            0 => 1,
+            1..=255 => 2,
+        }
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/match-checks/range_coverage_with_wildcard_ok.move
+++ b/third_party/move/move-compiler-v2/tests/match-checks/range_coverage_with_wildcard_ok.move
@@ -1,0 +1,47 @@
+module 0xc0ffee::range_coverage_with_wildcard_ok {
+    // Range + wildcard is exhaustive
+    fun range_with_wildcard(x: u64): u64 {
+        match (x) {
+            0..100 => 1,
+            _ => 2,
+        }
+    }
+
+    // Multiple ranges + wildcard
+    fun multi_range_with_wildcard(x: u8): u64 {
+        match (x) {
+            0..10 => 1,
+            10..20 => 2,
+            _ => 3,
+        }
+    }
+
+    // Open-ended ranges covering all values
+    fun open_ranges_full_coverage(x: u64): u64 {
+        match (x) {
+            ..50 => 1,
+            50.. => 2,
+        }
+    }
+
+    // Inclusive range covering full u8 range
+    fun full_u8_range(x: u8): u64 {
+        match (x) {
+            0..=255 => 1,
+        }
+    }
+
+    enum E has drop {
+        V1(u64),
+        V2,
+    }
+
+    // Range in enum + wildcard for remaining
+    fun enum_range_with_wildcard(e: E): u64 {
+        match (e) {
+            E::V1(0..100) => 1,
+            E::V1(_) => 2,
+            E::V2 => 3,
+        }
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/match-checks/range_empty_error.exp
+++ b/third_party/move/move-compiler-v2/tests/match-checks/range_empty_error.exp
@@ -1,0 +1,25 @@
+
+Diagnostics:
+error: empty range pattern
+  ┌─ tests/match-checks/range_empty_error.move:5:13
+  │
+5 │             5..5 => 1,
+  │             ^^^^
+
+error: empty range pattern
+   ┌─ tests/match-checks/range_empty_error.move:13:13
+   │
+13 │             10..5 => 1,
+   │             ^^^^^
+
+error: empty range pattern
+   ┌─ tests/match-checks/range_empty_error.move:21:13
+   │
+21 │             10..=5 => 1,
+   │             ^^^^^^
+
+error: empty range pattern
+   ┌─ tests/match-checks/range_empty_error.move:29:13
+   │
+29 │             0i8..0i8 => 1,
+   │             ^^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/match-checks/range_empty_error.move
+++ b/third_party/move/move-compiler-v2/tests/match-checks/range_empty_error.move
@@ -1,0 +1,33 @@
+module 0xc0ffee::range_empty_error {
+    // Empty range: exclusive range with equal bounds
+    fun empty_exclusive(x: u8): u64 {
+        match (x) {
+            5..5 => 1,
+            _ => 0,
+        }
+    }
+
+    // Inverted exclusive range
+    fun inverted_exclusive(x: u8): u64 {
+        match (x) {
+            10..5 => 1,
+            _ => 0,
+        }
+    }
+
+    // Inverted inclusive range
+    fun inverted_inclusive(x: u8): u64 {
+        match (x) {
+            10..=5 => 1,
+            _ => 0,
+        }
+    }
+
+    // Empty signed range
+    fun empty_signed(x: i8): u64 {
+        match (x) {
+            0i8..0i8 => 1,
+            _ => 0,
+        }
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/match-checks/range_enum_tuple_mix.exp
+++ b/third_party/move/move-compiler-v2/tests/match-checks/range_enum_tuple_mix.exp
@@ -1,0 +1,15 @@
+
+Diagnostics:
+error: match not exhaustive
+   ┌─ tests/match-checks/range_enum_tuple_mix.move:20:16
+   │
+20 │         match ((c, x)) {
+   │                ^^^^^^
+   │
+   = missing at least `(Color::Green, 100..)`
+
+error: unreachable pattern
+   ┌─ tests/match-checks/range_enum_tuple_mix.move:31:13
+   │
+31 │             (Color::Red, 0..10) => 2,
+   │             ^^^^^^^^^^^^^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/match-checks/range_enum_tuple_mix.move
+++ b/third_party/move/move-compiler-v2/tests/match-checks/range_enum_tuple_mix.move
@@ -1,0 +1,35 @@
+module 0xc0ffee::range_enum_tuple_mix {
+    enum Color {
+        Red,
+        Green,
+        Blue,
+    }
+
+    // Exhaustive: enum + range cover all cases
+    fun exhaustive_enum_range(c: Color, x: u8): u64 {
+        match ((c, x)) {
+            (Color::Red, 0..128) => 1,
+            (Color::Red, 128..=255) => 2,
+            (Color::Green, _) => 3,
+            (Color::Blue, _) => 4,
+        }
+    }
+
+    // Non-exhaustive: missing Green with some range values
+    fun non_exhaustive_enum_range(c: Color, x: u8): u64 {
+        match ((c, x)) {
+            (Color::Red, _) => 1,
+            (Color::Green, 0..100) => 2,
+            (Color::Blue, _) => 3,
+        }
+    }
+
+    // Unreachable: range inside enum column is subsumed
+    fun unreachable_enum_range(c: Color, x: u8): u64 {
+        match ((c, x)) {
+            (Color::Red, _) => 1,
+            (Color::Red, 0..10) => 2,
+            (_, _) => 3,
+        }
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/match-checks/range_full_domain_witness.exp
+++ b/third_party/move/move-compiler-v2/tests/match-checks/range_full_domain_witness.exp
@@ -1,0 +1,9 @@
+
+Diagnostics:
+error: match not exhaustive
+  ┌─ tests/match-checks/range_full_domain_witness.move:3:16
+  │
+3 │         match ((x, b)) {
+  │                ^^^^^^
+  │
+  = missing at least `(_, false)`

--- a/third_party/move/move-compiler-v2/tests/match-checks/range_full_domain_witness.move
+++ b/third_party/move/move-compiler-v2/tests/match-checks/range_full_domain_witness.move
@@ -1,0 +1,7 @@
+module 0xc0ffee::range_full_domain_witness {
+    fun full_range_with_bool(x: u8, b: bool): u64 {
+        match ((x, b)) {
+            (0..=255, true) => 1,
+        }
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/match-checks/range_in_enum_non_exhaustive.exp
+++ b/third_party/move/move-compiler-v2/tests/match-checks/range_in_enum_non_exhaustive.exp
@@ -1,0 +1,17 @@
+
+Diagnostics:
+error: match not exhaustive
+  ┌─ tests/match-checks/range_in_enum_non_exhaustive.move:9:16
+  │
+9 │         match (c) {
+  │                ^
+  │
+  = missing at least `Color::RGB(128.., _, _)`
+
+error: match not exhaustive
+   ┌─ tests/match-checks/range_in_enum_non_exhaustive.move:22:16
+   │
+22 │         match (e) {
+   │                ^
+   │
+   = missing at least `E::V1(100..)`

--- a/third_party/move/move-compiler-v2/tests/match-checks/range_in_enum_non_exhaustive.move
+++ b/third_party/move/move-compiler-v2/tests/match-checks/range_in_enum_non_exhaustive.move
@@ -1,0 +1,27 @@
+module 0xc0ffee::range_in_enum_non_exhaustive {
+    enum Color has drop {
+        RGB(u8, u8, u8),
+        Named,
+    }
+
+    // Missing coverage: 128..=255 for first field
+    fun missing_upper_range(c: Color): u64 {
+        match (c) {
+            Color::RGB(0..128, _, _) => 1,
+            Color::Named => 2,
+        }
+    }
+
+    enum E has drop {
+        V1(u64),
+        V2,
+    }
+
+    // Range in enum field without covering remaining values
+    fun partial_range_in_enum(e: E): u64 {
+        match (e) {
+            E::V1(0..100) => 1,
+            E::V2 => 2,
+        }
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/match-checks/range_inclusive_missing_upper_bound_error.exp
+++ b/third_party/move/move-compiler-v2/tests/match-checks/range_inclusive_missing_upper_bound_error.exp
@@ -1,0 +1,13 @@
+
+Diagnostics:
+error: inclusive range pattern requires an upper bound
+  ┌─ tests/match-checks/range_inclusive_missing_upper_bound_error.move:5:13
+  │
+5 │             ..= => 1,
+  │             ^^^
+
+error: inclusive range pattern requires an upper bound
+   ┌─ tests/match-checks/range_inclusive_missing_upper_bound_error.move:13:13
+   │
+13 │             0..= => 1,
+   │             ^^^^

--- a/third_party/move/move-compiler-v2/tests/match-checks/range_inclusive_missing_upper_bound_error.move
+++ b/third_party/move/move-compiler-v2/tests/match-checks/range_inclusive_missing_upper_bound_error.move
@@ -1,0 +1,17 @@
+module 0xc0ffee::range_inclusive_missing_upper_bound_error {
+    // `..=` should not be accepted without an upper bound.
+    fun open_start_inclusive_without_hi(x: u64): u64 {
+        match (x) {
+            ..= => 1,
+            _ => 0,
+        }
+    }
+
+    // `lo..=` should not be accepted without an upper bound either.
+    fun open_end_inclusive_without_hi(x: u64): u64 {
+        match (x) {
+            0..= => 1,
+            _ => 0,
+        }
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/match-checks/range_non_exhaustive.exp
+++ b/third_party/move/move-compiler-v2/tests/match-checks/range_non_exhaustive.exp
@@ -1,0 +1,33 @@
+
+Diagnostics:
+error: match not exhaustive
+  ┌─ tests/match-checks/range_non_exhaustive.move:4:16
+  │
+4 │         match (x) {
+  │                ^
+  │
+  = missing at least `..1`
+
+error: match not exhaustive
+   ┌─ tests/match-checks/range_non_exhaustive.move:11:16
+   │
+11 │         match (x) {
+   │                ^
+   │
+   = missing at least `10..20`
+
+error: match not exhaustive
+   ┌─ tests/match-checks/range_non_exhaustive.move:19:16
+   │
+19 │         match (x) {
+   │                ^
+   │
+   = missing at least `..5`
+
+error: match not exhaustive
+   ┌─ tests/match-checks/range_non_exhaustive.move:26:16
+   │
+26 │         match (x) {
+   │                ^
+   │
+   = missing at least `100..`

--- a/third_party/move/move-compiler-v2/tests/match-checks/range_non_exhaustive.move
+++ b/third_party/move/move-compiler-v2/tests/match-checks/range_non_exhaustive.move
@@ -1,0 +1,30 @@
+module 0xc0ffee::range_non_exhaustive {
+    // Missing values outside range
+    fun missing_outside_range(x: u64): u64 {
+        match (x) {
+            1..10 => 1,
+        }
+    }
+
+    // Multiple non-overlapping ranges without full coverage
+    fun gaps_between_ranges(x: u8): u64 {
+        match (x) {
+            0..10 => 1,
+            20..30 => 2,
+        }
+    }
+
+    // Open-ended range missing lower values
+    fun missing_lower(x: u64): u64 {
+        match (x) {
+            5.. => 1,
+        }
+    }
+
+    // Open-start range missing upper values
+    fun missing_upper(x: u64): u64 {
+        match (x) {
+            ..100 => 1,
+        }
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/match-checks/range_open_ended_empty_error.exp
+++ b/third_party/move/move-compiler-v2/tests/match-checks/range_open_ended_empty_error.exp
@@ -1,0 +1,25 @@
+
+Diagnostics:
+error: empty range pattern
+  ┌─ tests/match-checks/range_open_ended_empty_error.move:5:13
+  │
+5 │             ..0 => 1,
+  │             ^^^
+
+error: empty range pattern
+   ┌─ tests/match-checks/range_open_ended_empty_error.move:13:13
+   │
+13 │             ..-128i8 => 1,
+   │             ^^^^^^^^
+
+error: empty range pattern
+   ┌─ tests/match-checks/range_open_ended_empty_error.move:21:13
+   │
+21 │             ..0 => 1,
+   │             ^^^
+
+error: empty range pattern
+   ┌─ tests/match-checks/range_open_ended_empty_error.move:29:13
+   │
+29 │             ..0u16 => 1,
+   │             ^^^^^^

--- a/third_party/move/move-compiler-v2/tests/match-checks/range_open_ended_empty_error.move
+++ b/third_party/move/move-compiler-v2/tests/match-checks/range_open_ended_empty_error.move
@@ -1,0 +1,33 @@
+module 0xc0ffee::range_open_ended_empty_error {
+    // ..0 on u8: effective range is [0, 0) which is empty
+    fun open_start_at_u8_min(x: u8): u64 {
+        match (x) {
+            ..0 => 1,
+            _ => 0,
+        }
+    }
+
+    // ..-128 on i8: effective range is [-128, -128) which is empty
+    fun open_start_at_i8_min(x: i8): u64 {
+        match (x) {
+            ..-128i8 => 1,
+            _ => 0,
+        }
+    }
+
+    // ..0 on u64: effective range is [0, 0) which is empty
+    fun open_start_at_u64_min(x: u64): u64 {
+        match (x) {
+            ..0 => 1,
+            _ => 0,
+        }
+    }
+
+    // ..0 on u16: effective range is [0, 0) which is empty
+    fun open_start_at_u16_min(x: u16): u64 {
+        match (x) {
+            ..0u16 => 1,
+            _ => 0,
+        }
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/match-checks/range_overlap_reachability.exp
+++ b/third_party/move/move-compiler-v2/tests/match-checks/range_overlap_reachability.exp
@@ -1,0 +1,13 @@
+
+Diagnostics:
+error: unreachable pattern
+   ┌─ tests/match-checks/range_overlap_reachability.move:15:13
+   │
+15 │             (5..8, true) => 2,
+   │             ^^^^^^^^^^^^
+
+error: unreachable pattern
+   ┌─ tests/match-checks/range_overlap_reachability.move:25:13
+   │
+25 │             5..15 => 3,
+   │             ^^^^^

--- a/third_party/move/move-compiler-v2/tests/match-checks/range_overlap_reachability.move
+++ b/third_party/move/move-compiler-v2/tests/match-checks/range_overlap_reachability.move
@@ -1,0 +1,29 @@
+module 0xc0ffee::range_overlap_reachability {
+    // Partial overlap with different tuple columns: both reachable
+    fun partial_overlap_both_reachable(x: u64, b: bool): u64 {
+        match ((x, b)) {
+            (0..10, true) => 1,
+            (5..15, false) => 2,
+            _ => 3,
+        }
+    }
+
+    // Full overlap in multi-column: second arm unreachable
+    fun full_overlap_unreachable(x: u64, b: bool): u64 {
+        match ((x, b)) {
+            (0..10, _) => 1,
+            (5..8, true) => 2,
+            _ => 3,
+        }
+    }
+
+    // Three overlapping ranges where union covers a fourth
+    fun union_covers_third(x: u64): u64 {
+        match (x) {
+            0..10 => 1,
+            10..20 => 2,
+            5..15 => 3,
+            _ => 4,
+        }
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/match-checks/range_signed_coverage.exp
+++ b/third_party/move/move-compiler-v2/tests/match-checks/range_signed_coverage.exp
@@ -1,0 +1,17 @@
+
+Diagnostics:
+error: match not exhaustive
+   ┌─ tests/match-checks/range_signed_coverage.move:27:16
+   │
+27 │         match (x) {
+   │                ^
+   │
+   = missing at least `..0`
+
+error: match not exhaustive
+   ┌─ tests/match-checks/range_signed_coverage.move:34:16
+   │
+34 │         match (x) {
+   │                ^
+   │
+   = missing at least `-10..10`

--- a/third_party/move/move-compiler-v2/tests/match-checks/range_signed_coverage.move
+++ b/third_party/move/move-compiler-v2/tests/match-checks/range_signed_coverage.move
@@ -1,0 +1,39 @@
+module 0xc0ffee::range_signed_coverage {
+    // Full i8 coverage with ranges crossing zero (should compile)
+    fun full_i8_two_ranges(x: i8): u64 {
+        match (x) {
+            -128i8..0i8 => 1,
+            0i8..=127i8 => 2,
+        }
+    }
+
+    // Full i8 coverage with single inclusive range (should compile)
+    fun full_i8_inclusive(x: i8): u64 {
+        match (x) {
+            -128i8..=127i8 => 1,
+        }
+    }
+
+    // Range crossing zero with wildcard (should compile)
+    fun crossing_zero_with_wildcard(x: i8): u64 {
+        match (x) {
+            -10i8..10i8 => 1,
+            _ => 2,
+        }
+    }
+
+    // Non-exhaustive: missing negative values
+    fun missing_negatives(x: i8): u64 {
+        match (x) {
+            0i8..=127i8 => 1,
+        }
+    }
+
+    // Non-exhaustive: gap crossing zero
+    fun gap_crossing_zero(x: i8): u64 {
+        match (x) {
+            -128i8..-10i8 => 1,
+            10i8..=127i8 => 2,
+        }
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/match-checks/range_type_error.exp
+++ b/third_party/move/move-compiler-v2/tests/match-checks/range_type_error.exp
@@ -1,0 +1,19 @@
+
+Diagnostics:
+error: range patterns are only allowed on integer types, found `bool`
+  ┌─ tests/match-checks/range_type_error.move:7:13
+  │
+7 │             true..false => 1,
+  │             ^^^^^^^^^^^
+
+error: range patterns are only allowed on integer types, found `S`
+   ┌─ tests/match-checks/range_type_error.move:15:13
+   │
+15 │             1..10 => 1,
+   │             ^^^^^
+
+error: range patterns are only allowed on integer types, found `vector<u8>`
+   ┌─ tests/match-checks/range_type_error.move:23:13
+   │
+23 │             1..10 => 1,
+   │             ^^^^^

--- a/third_party/move/move-compiler-v2/tests/match-checks/range_type_error.move
+++ b/third_party/move/move-compiler-v2/tests/match-checks/range_type_error.move
@@ -1,0 +1,27 @@
+module 0xc0ffee::range_type_error {
+    struct S has copy, drop { x: u64 }
+
+    // Range on bool
+    fun range_on_bool(x: bool): u64 {
+        match (x) {
+            true..false => 1,
+            _ => 0,
+        }
+    }
+
+    // Range on struct
+    fun range_on_struct(x: S): u64 {
+        match (x) {
+            1..10 => 1,
+            _ => 0,
+        }
+    }
+
+    // Range on vector
+    fun range_on_vector(x: vector<u8>): u64 {
+        match (x) {
+            1..10 => 1,
+            _ => 0,
+        }
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/match-checks/range_unbounded_error.exp
+++ b/third_party/move/move-compiler-v2/tests/match-checks/range_unbounded_error.exp
@@ -1,0 +1,7 @@
+
+Diagnostics:
+error: unbounded range pattern `..` is not allowed; use `_` instead
+  ┌─ tests/match-checks/range_unbounded_error.move:5:13
+  │
+5 │             .. => 1,
+  │             ^^

--- a/third_party/move/move-compiler-v2/tests/match-checks/range_unbounded_error.move
+++ b/third_party/move/move-compiler-v2/tests/match-checks/range_unbounded_error.move
@@ -1,0 +1,8 @@
+module 0xc0ffee::range_unbounded_error {
+    // Bare `..` should be rejected — use `_` instead.
+    fun bare_dotdot(x: u8): u64 {
+        match (x) {
+            .. => 1,
+        }
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/match-checks/range_union_unreachable.exp
+++ b/third_party/move/move-compiler-v2/tests/match-checks/range_union_unreachable.exp
@@ -1,0 +1,13 @@
+
+Diagnostics:
+error: unreachable pattern
+  ┌─ tests/match-checks/range_union_unreachable.move:7:13
+  │
+7 │             5..15 => 3,
+  │             ^^^^^
+
+error: unreachable pattern
+   ┌─ tests/match-checks/range_union_unreachable.move:17:13
+   │
+17 │             (5..15, false) => 3,
+   │             ^^^^^^^^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/match-checks/range_union_unreachable.move
+++ b/third_party/move/move-compiler-v2/tests/match-checks/range_union_unreachable.move
@@ -1,0 +1,22 @@
+module 0xc0ffee::range_union_unreachable {
+    // The first two ranges cover 5..15 as a union, so the third arm is dead.
+    fun scalar_union_subsumes_range(x: u64): u64 {
+        match (x) {
+            0..10 => 1,
+            10..20 => 2,
+            5..15 => 3,
+            _ => 4,
+        }
+    }
+
+    // Same issue when the range sits in a tuple column.
+    fun tuple_union_subsumes_range(x: u64, flag: bool): u64 {
+        match ((x, flag)) {
+            (0..10, false) => 1,
+            (10..20, false) => 2,
+            (5..15, false) => 3,
+            (_, true) => 4,
+            _ => 5,
+        }
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/match-checks/range_unreachable.exp
+++ b/third_party/move/move-compiler-v2/tests/match-checks/range_unreachable.exp
@@ -1,0 +1,31 @@
+
+Diagnostics:
+error: unreachable pattern
+  ┌─ tests/match-checks/range_unreachable.move:6:13
+  │
+6 │             3..7 => 2,
+  │             ^^^^
+
+error: unreachable pattern
+   ┌─ tests/match-checks/range_unreachable.move:15:13
+   │
+15 │             1..10 => 2,
+   │             ^^^^^
+
+error: unreachable pattern
+   ┌─ tests/match-checks/range_unreachable.move:23:13
+   │
+23 │             5 => 2,
+   │             ^
+
+error: unreachable pattern
+   ┌─ tests/match-checks/range_unreachable.move:31:13
+   │
+31 │             5 => 2,
+   │             ^
+
+error: unreachable pattern
+   ┌─ tests/match-checks/range_unreachable.move:40:13
+   │
+40 │             1..10 => 2,
+   │             ^^^^^

--- a/third_party/move/move-compiler-v2/tests/match-checks/range_unreachable.move
+++ b/third_party/move/move-compiler-v2/tests/match-checks/range_unreachable.move
@@ -1,0 +1,44 @@
+module 0xc0ffee::range_unreachable {
+    // Subsumed range: 3..7 is within 1..10
+    fun subsumed_range(x: u64): u64 {
+        match (x) {
+            1..10 => 1,
+            3..7 => 2,
+            _ => 0,
+        }
+    }
+
+    // Wildcard followed by range
+    fun wildcard_then_range(x: u64): u64 {
+        match (x) {
+            _ => 1,
+            1..10 => 2,
+        }
+    }
+
+    // Full coverage followed by anything
+    fun full_range_then_literal(x: u64): u64 {
+        match (x) {
+            _ => 1,
+            5 => 2,
+        }
+    }
+
+    // Inclusive range subsumes literal
+    fun range_subsumes_literal(x: u64): u64 {
+        match (x) {
+            1..=10 => 1,
+            5 => 2,
+            _ => 0,
+        }
+    }
+
+    // Duplicate identical ranges
+    fun duplicate_ranges(x: u64): u64 {
+        match (x) {
+            1..10 => 1,
+            1..10 => 2,
+            _ => 0,
+        }
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/match-checks/struct_literal_coverage.exp
+++ b/third_party/move/move-compiler-v2/tests/match-checks/struct_literal_coverage.exp
@@ -6,7 +6,7 @@ error: match not exhaustive
 6 │         match (s) {
   │                ^
   │
-  = missing `S{..}`
+  = missing at least `S{x: ..42, y: _}`
 
 error: unreachable pattern
    ┌─ tests/match-checks/struct_literal_coverage.move:15:13

--- a/third_party/move/move-compiler-v2/tests/match-transforms/range_fully_transformable.exp
+++ b/third_party/move/move-compiler-v2/tests/match-transforms/range_fully_transformable.exp
@@ -1,0 +1,123 @@
+// -- Model dump before first bytecode pipeline
+module 0xc0ffee::m {
+    public fun exclusive_ranges(p: u8): u8 {
+        {
+          let _$disc: u8 = p;
+          if And(Ge(_$disc, 0), Lt(_$disc, 5)) {
+            1
+          } else {
+            if And(Ge(_$disc, 5), Lt(_$disc, 10)) {
+              2
+            } else {
+              3
+            }
+          }
+        }
+    }
+    public fun inclusive_range(p: u64): u64 {
+        {
+          let _$disc: u64 = p;
+          if And(Ge(_$disc, 1), Le(_$disc, 5)) {
+            1
+          } else {
+            if And(Ge(_$disc, 6), Le(_$disc, 10)) {
+              2
+            } else {
+              3
+            }
+          }
+        }
+    }
+    public fun mixed_range_literal(p: u8): u8 {
+        {
+          let _$disc: u8 = p;
+          if Eq(_$disc, 0) {
+            1
+          } else {
+            if And(Ge(_$disc, 1), Lt(_$disc, 10)) {
+              2
+            } else {
+              if Eq(_$disc, 10) {
+                3
+              } else {
+                4
+              }
+            }
+          }
+        }
+    }
+    public fun open_end_range(p: u64): u64 {
+        {
+          let _$disc: u64 = p;
+          if Lt(_$disc, 5) {
+            1
+          } else {
+            if Ge(_$disc, 5) {
+              2
+            } else {
+              Abort(14566554180833181697)
+            }
+          }
+        }
+    }
+    public fun open_start_inclusive(p: u64): u64 {
+        {
+          let _$disc: u64 = p;
+          if Le(_$disc, 5) {
+            1
+          } else {
+            if Ge(_$disc, 6) {
+              2
+            } else {
+              Abort(14566554180833181697)
+            }
+          }
+        }
+    }
+    public fun signed_range(p: i64): u64 {
+        {
+          let _$disc: i64 = p;
+          if And(Ge(_$disc, -100), Lt(_$disc, -1)) {
+            1
+          } else {
+            if And(Ge(_$disc, 0), Le(_$disc, 0)) {
+              2
+            } else {
+              if And(Ge(_$disc, 1), Lt(_$disc, 100)) {
+                3
+              } else {
+                4
+              }
+            }
+          }
+        }
+    }
+} // end 0xc0ffee::m
+
+// -- Sourcified model before first bytecode pipeline
+module 0xc0ffee::m {
+    public fun exclusive_ranges(p: u8): u8 {
+        let __disc = p;
+        if (__disc >= 0u8 && __disc < 5u8) 1u8 else if (__disc >= 5u8 && __disc < 10u8) 2u8 else 3u8
+    }
+    public fun inclusive_range(p: u64): u64 {
+        let __disc = p;
+        if (__disc >= 1 && __disc <= 5) 1 else if (__disc >= 6 && __disc <= 10) 2 else 3
+    }
+    public fun mixed_range_literal(p: u8): u8 {
+        let __disc = p;
+        if (__disc == 0u8) 1u8 else if (__disc >= 1u8 && __disc < 10u8) 2u8 else if (__disc == 10u8) 3u8 else 4u8
+    }
+    public fun open_end_range(p: u64): u64 {
+        let __disc = p;
+        if (__disc < 5) 1 else if (__disc >= 5) 2 else abort 14566554180833181697
+    }
+    public fun open_start_inclusive(p: u64): u64 {
+        let __disc = p;
+        if (__disc <= 5) 1 else if (__disc >= 6) 2 else abort 14566554180833181697
+    }
+    public fun signed_range(p: i64): u64 {
+        let __disc = p;
+        if (__disc >= -100i64 && __disc < -1i64) 1 else if (__disc >= 0i64 && __disc <= 0i64) 2 else if (__disc >= 1i64 && __disc < 100i64) 3 else 4
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/match-transforms/range_fully_transformable.move
+++ b/third_party/move/move-compiler-v2/tests/match-transforms/range_fully_transformable.move
@@ -1,0 +1,55 @@
+module 0xc0ffee::m {
+    // Exclusive ranges: 0..5 lowers to (0 <= x && x < 5)
+    public fun exclusive_ranges(p: u8): u8 {
+        match (p) {
+            0..5 => 1,
+            5..10 => 2,
+            _ => 3,
+        }
+    }
+
+    // Inclusive range: 1..=5 lowers to (1 <= x && x <= 5)
+    public fun inclusive_range(p: u64): u64 {
+        match (p) {
+            1..=5 => 1,
+            6..=10 => 2,
+            _ => 3,
+        }
+    }
+
+    // Open-ended range: 5.. lowers to (5 <= x)
+    public fun open_end_range(p: u64): u64 {
+        match (p) {
+            ..5 => 1,
+            5.. => 2,
+        }
+    }
+
+    // Open-start inclusive: ..=5 lowers to (x <= 5)
+    public fun open_start_inclusive(p: u64): u64 {
+        match (p) {
+            ..=5 => 1,
+            6.. => 2,
+        }
+    }
+
+    // Mixed ranges and literals
+    public fun mixed_range_literal(p: u8): u8 {
+        match (p) {
+            0 => 1,
+            1..10 => 2,
+            10 => 3,
+            _ => 4,
+        }
+    }
+
+    // Range on signed integer
+    public fun signed_range(p: i64): u64 {
+        match (p) {
+            -100..-1 => 1,
+            0..=0 => 2,
+            1..100 => 3,
+            _ => 4,
+        }
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/match-transforms/range_in_enum_extraction.exp
+++ b/third_party/move/move-compiler-v2/tests/match-transforms/range_in_enum_extraction.exp
@@ -1,0 +1,208 @@
+// -- Model dump before first bytecode pipeline
+module 0xc0ffee::m {
+    enum E {
+        V1 {
+            0: u64,
+        }
+        V2,
+    }
+    enum Inner {
+        A {
+            0: u64,
+        }
+        B,
+    }
+    enum Outer {
+        W {
+            0: Inner,
+        }
+        X,
+    }
+    enum Pair {
+        P {
+            0: u64,
+            1: u64,
+        }
+        Q,
+    }
+    private fun multi_range_in_enum(p: Pair): u64 {
+        match (p) {
+          m::Pair::P{ 0: _$nlit_0, 1: _$nlit_1 } if And(And(Ge(_$nlit_0, 0), Lt(_$nlit_0, 10)), And(Ge(_$nlit_1, 0), Lt(_$nlit_1, 10))) => {
+            1
+          }
+          m::Pair::P{ 0: _, 1: _ } => {
+            2
+          }
+          m::Pair::Q => {
+            3
+          }
+        }
+
+    }
+    private fun nested_range(o: Outer): u64 {
+        match (o) {
+          m::Outer::W{ 0: m::Inner::A{ 0: _$nlit_0 } } if And(Ge(_$nlit_0, 1), Lt(_$nlit_0, 100)) => {
+            1
+          }
+          m::Outer::W{ 0: m::Inner::A{ 0: _ } } => {
+            2
+          }
+          m::Outer::W{ 0: m::Inner::B } => {
+            3
+          }
+          m::Outer::X => {
+            4
+          }
+        }
+
+    }
+    private fun range_and_literal_in_enum(p: Pair): u64 {
+        match (p) {
+          m::Pair::P{ 0: _$nlit_0, 1: _$nlit_1 } if And(And(Ge(_$nlit_0, 1), Lt(_$nlit_0, 10)), Eq(_$nlit_1, 42)) => {
+            1
+          }
+          m::Pair::P{ 0: _, 1: _ } => {
+            2
+          }
+          m::Pair::Q => {
+            3
+          }
+        }
+
+    }
+    private fun range_and_var_in_enum(p: Pair): u64 {
+        match (p) {
+          m::Pair::P{ 0: _$nlit_0, 1: y } if And(Ge(_$nlit_0, 1), Lt(_$nlit_0, 10)) => {
+            y
+          }
+          m::Pair::P{ 0: _, 1: _ } => {
+            0
+          }
+          m::Pair::Q => {
+            0
+          }
+        }
+
+    }
+    private fun range_in_enum(e: E): u64 {
+        match (e) {
+          m::E::V1{ 0: _$nlit_0 } if And(Ge(_$nlit_0, 1), Lt(_$nlit_0, 10)) => {
+            1
+          }
+          m::E::V1{ 0: _ } => {
+            2
+          }
+          m::E::V2 => {
+            3
+          }
+        }
+
+    }
+    private fun range_with_guard(e: E): u64 {
+        match (e) {
+          m::E::V1{ 0: _$nlit_0 } if And(And(Ge(_$nlit_0, 1), Lt(_$nlit_0, 10)), true) => {
+            1
+          }
+          m::E::V1{ 0: _ } => {
+            2
+          }
+          m::E::V2 => {
+            3
+          }
+        }
+
+    }
+    private fun ref_range_in_enum(e: &E): u64 {
+        match (e) {
+          m::E::V1{ 0: _$nlit_0 } if And(Ge(Deref(_$nlit_0), 0), Lt(Deref(_$nlit_0), 5)) => {
+            1
+          }
+          m::E::V1{ 0: _ } => {
+            2
+          }
+          m::E::V2 => {
+            3
+          }
+        }
+
+    }
+} // end 0xc0ffee::m
+
+// -- Sourcified model before first bytecode pipeline
+module 0xc0ffee::m {
+    enum E has drop {
+        V1 {
+            0: u64,
+        }
+        V2,
+    }
+    enum Inner has drop {
+        A {
+            0: u64,
+        }
+        B,
+    }
+    enum Outer has drop {
+        W {
+            0: Inner,
+        }
+        X,
+    }
+    enum Pair has drop {
+        P {
+            0: u64,
+            1: u64,
+        }
+        Q,
+    }
+    fun multi_range_in_enum(p: Pair): u64 {
+        match (p) {
+            Pair::P(__nlit_0, __nlit_1) if __nlit_0 >= 0 && __nlit_0 < 10 && (__nlit_1 >= 0 && __nlit_1 < 10) => 1,
+            Pair::P(_, _) => 2,
+            Pair::Q{} => 3,
+        }
+    }
+    fun nested_range(o: Outer): u64 {
+        match (o) {
+            Outer::W(Inner::A(__nlit_0)) if __nlit_0 >= 1 && __nlit_0 < 100 => 1,
+            Outer::W(Inner::A(_)) => 2,
+            Outer::W(Inner::B{}) => 3,
+            Outer::X{} => 4,
+        }
+    }
+    fun range_and_literal_in_enum(p: Pair): u64 {
+        match (p) {
+            Pair::P(__nlit_0, __nlit_1) if __nlit_0 >= 1 && __nlit_0 < 10 && __nlit_1 == 42 => 1,
+            Pair::P(_, _) => 2,
+            Pair::Q{} => 3,
+        }
+    }
+    fun range_and_var_in_enum(p: Pair): u64 {
+        match (p) {
+            Pair::P(__nlit_0, y) if __nlit_0 >= 1 && __nlit_0 < 10 => y,
+            Pair::P(_, _) => 0,
+            Pair::Q{} => 0,
+        }
+    }
+    fun range_in_enum(e: E): u64 {
+        match (e) {
+            E::V1(__nlit_0) if __nlit_0 >= 1 && __nlit_0 < 10 => 1,
+            E::V1(_) => 2,
+            E::V2{} => 3,
+        }
+    }
+    fun range_with_guard(e: E): u64 {
+        match (e) {
+            E::V1(__nlit_0) if __nlit_0 >= 1 && __nlit_0 < 10 && true => 1,
+            E::V1(_) => 2,
+            E::V2{} => 3,
+        }
+    }
+    fun ref_range_in_enum(e: &E): u64 {
+        match (e) {
+            E::V1(__nlit_0) if *__nlit_0 >= 0 && *__nlit_0 < 5 => 1,
+            E::V1(_) => 2,
+            E::V2{} => 3,
+        }
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/match-transforms/range_in_enum_extraction.move
+++ b/third_party/move/move-compiler-v2/tests/match-transforms/range_in_enum_extraction.move
@@ -1,0 +1,85 @@
+module 0xc0ffee::m {
+    enum E has drop {
+        V1(u64),
+        V2,
+    }
+
+    enum Pair has drop {
+        P(u64, u64),
+        Q,
+    }
+
+    enum Inner has drop {
+        A(u64),
+        B,
+    }
+
+    enum Outer has drop {
+        W(Inner),
+        X,
+    }
+
+    // Range in single enum field: E::V1(1..10) extracted to guard
+    fun range_in_enum(e: E): u64 {
+        match (e) {
+            E::V1(1..10) => 1,
+            E::V1(_) => 2,
+            E::V2 => 3,
+        }
+    }
+
+    // Multiple ranges in one variant
+    fun multi_range_in_enum(p: Pair): u64 {
+        match (p) {
+            Pair::P(0..10, 0..10) => 1,
+            Pair::P(_, _) => 2,
+            Pair::Q => 3,
+        }
+    }
+
+    // Mix of range + literal in variant
+    fun range_and_literal_in_enum(p: Pair): u64 {
+        match (p) {
+            Pair::P(1..10, 42) => 1,
+            Pair::P(_, _) => 2,
+            Pair::Q => 3,
+        }
+    }
+
+    // Mix of range + variable in variant
+    fun range_and_var_in_enum(p: Pair): u64 {
+        match (p) {
+            Pair::P(1..10, y) => y,
+            Pair::P(_, _) => 0,
+            Pair::Q => 0,
+        }
+    }
+
+    // Range + existing guard
+    fun range_with_guard(e: E): u64 {
+        match (e) {
+            E::V1(1..10) if true => 1,
+            E::V1(_) => 2,
+            E::V2 => 3,
+        }
+    }
+
+    // Nested enum with range
+    fun nested_range(o: Outer): u64 {
+        match (o) {
+            Outer::W(Inner::A(1..100)) => 1,
+            Outer::W(Inner::A(_)) => 2,
+            Outer::W(Inner::B) => 3,
+            Outer::X => 4,
+        }
+    }
+
+    // Reference discriminator with range in enum
+    fun ref_range_in_enum(e: &E): u64 {
+        match (e) {
+            E::V1(0..5) => 1,
+            E::V1(_) => 2,
+            E::V2 => 3,
+        }
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/match-transforms/range_mixed_tuple_enum.exp
+++ b/third_party/move/move-compiler-v2/tests/match-transforms/range_mixed_tuple_enum.exp
@@ -1,0 +1,66 @@
+// -- Model dump before first bytecode pipeline
+module 0xc0ffee::m {
+    enum Color {
+        RGB {
+            0: u8,
+            1: u8,
+            2: u8,
+        }
+        Grayscale {
+            0: u8,
+        }
+        Named,
+    }
+    private fun mixed_range_tuple(c: Color,x: u64): u64 {
+        {
+          let _$np_0: Color = c;
+          {
+            let _$prim_0: u64 = x;
+            match (_$np_0) {
+              m::Color::RGB{ 0: _$nlit_0, 1: _$nlit_1, 2: _$nlit_2 } if And(And(Ge(_$prim_0, 88), Lt(_$prim_0, 99)), And(And(And(Ge(_$nlit_0, 0), Lt(_$nlit_0, 25)), Eq(_$nlit_1, 28)), And(Ge(_$nlit_2, 55), Lt(_$nlit_2, 66)))) => {
+                1
+              }
+              m::Color::RGB{ 0: _, 1: _, 2: _ } => {
+                2
+              }
+              m::Color::Grayscale{ 0: _$nlit_0 } if And(And(Ge(_$prim_0, 0), Lt(_$prim_0, 50)), And(Ge(_$nlit_0, 128), Le(_$nlit_0, 255))) => {
+                3
+              }
+              m::Color::Grayscale{ 0: _ } => {
+                4
+              }
+              m::Color::Named => {
+                5
+              }
+            }
+
+          }
+        }
+    }
+} // end 0xc0ffee::m
+
+// -- Sourcified model before first bytecode pipeline
+module 0xc0ffee::m {
+    enum Color has drop {
+        RGB {
+            0: u8,
+            1: u8,
+            2: u8,
+        }
+        Grayscale {
+            0: u8,
+        }
+        Named,
+    }
+    fun mixed_range_tuple(c: Color, x: u64): u64 {
+        let __np_0 = c;
+        let __prim_0 = x;
+        match (__np_0) {
+            Color::RGB(__nlit_0, __nlit_1, __nlit_2) if __prim_0 >= 88 && __prim_0 < 99 && (__nlit_0 >= 0u8 && __nlit_0 < 25u8 && __nlit_1 == 28u8 && (__nlit_2 >= 55u8 && __nlit_2 < 66u8)) => 1,
+            Color::RGB(_, _, _) => 2,
+            Color::Grayscale(__nlit_0) if __prim_0 >= 0 && __prim_0 < 50 && (__nlit_0 >= 128u8 && __nlit_0 <= MAX_U8) => 3,
+            Color::Grayscale(_) => 4,
+            Color::Named{} => 5,
+        }
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/match-transforms/range_mixed_tuple_enum.move
+++ b/third_party/move/move-compiler-v2/tests/match-transforms/range_mixed_tuple_enum.move
@@ -1,0 +1,18 @@
+module 0xc0ffee::m {
+    enum Color has drop {
+        RGB(u8, u8, u8),
+        Grayscale(u8),
+        Named,
+    }
+
+    // Range inside enum fields + range in tuple position
+    fun mixed_range_tuple(c: Color, x: u64): u64 {
+        match ((c, x)) {
+            (Color::RGB(0..25, 28, 55..66), 88..99) => 1,
+            (Color::RGB(_, _, _), _) => 2,
+            (Color::Grayscale(128..=255), 0..50) => 3,
+            (Color::Grayscale(_), _) => 4,
+            (Color::Named, _) => 5,
+        }
+    }
+}

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/match_extensions/range_adjacent.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/match_extensions/range_adjacent.exp
@@ -1,0 +1,40 @@
+processed 20 tasks
+task 0 lines 1-30:  publish [module 0xc0ffee::m {]
+task 1 lines 32-32:  run 0xc0ffee::m::test_adjacent --args 0u64
+return values: 1
+task 2 lines 34-34:  run 0xc0ffee::m::test_adjacent --args 4u64
+return values: 1
+task 3 lines 36-36:  run 0xc0ffee::m::test_adjacent --args 5u64
+return values: 2
+task 4 lines 38-38:  run 0xc0ffee::m::test_adjacent --args 9u64
+return values: 2
+task 5 lines 40-40:  run 0xc0ffee::m::test_adjacent --args 10u64
+return values: 3
+task 6 lines 42-42:  run 0xc0ffee::m::test_overlapping --args 0u64
+return values: 1
+task 7 lines 44-44:  run 0xc0ffee::m::test_overlapping --args 5u64
+return values: 1
+task 8 lines 46-46:  run 0xc0ffee::m::test_overlapping --args 7u64
+return values: 1
+task 9 lines 48-48:  run 0xc0ffee::m::test_overlapping --args 10u64
+return values: 2
+task 10 lines 50-50:  run 0xc0ffee::m::test_overlapping --args 14u64
+return values: 2
+task 11 lines 52-52:  run 0xc0ffee::m::test_overlapping --args 15u64
+return values: 3
+task 12 lines 54-54:  run 0xc0ffee::m::test_exact_coverage --args 0u8
+return values: 1
+task 13 lines 56-56:  run 0xc0ffee::m::test_exact_coverage --args 63u8
+return values: 1
+task 14 lines 58-58:  run 0xc0ffee::m::test_exact_coverage --args 64u8
+return values: 2
+task 15 lines 60-60:  run 0xc0ffee::m::test_exact_coverage --args 127u8
+return values: 2
+task 16 lines 62-62:  run 0xc0ffee::m::test_exact_coverage --args 128u8
+return values: 3
+task 17 lines 64-64:  run 0xc0ffee::m::test_exact_coverage --args 191u8
+return values: 3
+task 18 lines 66-66:  run 0xc0ffee::m::test_exact_coverage --args 192u8
+return values: 4
+task 19 lines 68-68:  run 0xc0ffee::m::test_exact_coverage --args 255u8
+return values: 4

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/match_extensions/range_adjacent.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/match_extensions/range_adjacent.move
@@ -1,0 +1,68 @@
+//# publish
+module 0xc0ffee::m {
+    // Adjacent ranges: no gap, first-match semantics
+    public fun test_adjacent(x: u64): u64 {
+        match (x) {
+            0..5 => 1,
+            5..10 => 2,
+            _ => 3,
+        }
+    }
+
+    // Overlapping ranges: first match wins
+    public fun test_overlapping(x: u64): u64 {
+        match (x) {
+            0..10 => 1,
+            5..15 => 2,
+            _ => 3,
+        }
+    }
+
+    // Exact coverage with exclusive ranges
+    public fun test_exact_coverage(x: u8): u64 {
+        match (x) {
+            0..64 => 1,
+            64..128 => 2,
+            128..192 => 3,
+            192.. => 4,
+        }
+    }
+}
+
+//# run 0xc0ffee::m::test_adjacent --args 0u64
+
+//# run 0xc0ffee::m::test_adjacent --args 4u64
+
+//# run 0xc0ffee::m::test_adjacent --args 5u64
+
+//# run 0xc0ffee::m::test_adjacent --args 9u64
+
+//# run 0xc0ffee::m::test_adjacent --args 10u64
+
+//# run 0xc0ffee::m::test_overlapping --args 0u64
+
+//# run 0xc0ffee::m::test_overlapping --args 5u64
+
+//# run 0xc0ffee::m::test_overlapping --args 7u64
+
+//# run 0xc0ffee::m::test_overlapping --args 10u64
+
+//# run 0xc0ffee::m::test_overlapping --args 14u64
+
+//# run 0xc0ffee::m::test_overlapping --args 15u64
+
+//# run 0xc0ffee::m::test_exact_coverage --args 0u8
+
+//# run 0xc0ffee::m::test_exact_coverage --args 63u8
+
+//# run 0xc0ffee::m::test_exact_coverage --args 64u8
+
+//# run 0xc0ffee::m::test_exact_coverage --args 127u8
+
+//# run 0xc0ffee::m::test_exact_coverage --args 128u8
+
+//# run 0xc0ffee::m::test_exact_coverage --args 191u8
+
+//# run 0xc0ffee::m::test_exact_coverage --args 192u8
+
+//# run 0xc0ffee::m::test_exact_coverage --args 255u8

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/match_extensions/range_all_unsigned_types.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/match_extensions/range_all_unsigned_types.exp
@@ -1,0 +1,50 @@
+processed 25 tasks
+task 0 lines 1-50:  publish [module 0xc0ffee::m {]
+task 1 lines 52-52:  run 0xc0ffee::m::test_u8 --args 0u8
+return values: 1
+task 2 lines 54-54:  run 0xc0ffee::m::test_u8 --args 5u8
+return values: 1
+task 3 lines 56-56:  run 0xc0ffee::m::test_u8 --args 10u8
+return values: 2
+task 4 lines 58-58:  run 0xc0ffee::m::test_u8 --args 50u8
+return values: 2
+task 5 lines 60-60:  run 0xc0ffee::m::test_u8 --args 200u8
+return values: 3
+task 6 lines 62-62:  run 0xc0ffee::m::test_u16 --args 0u16
+return values: 1
+task 7 lines 64-64:  run 0xc0ffee::m::test_u16 --args 500u16
+return values: 1
+task 8 lines 66-66:  run 0xc0ffee::m::test_u16 --args 1000u16
+return values: 2
+task 9 lines 68-68:  run 0xc0ffee::m::test_u16 --args 3000u16
+return values: 2
+task 10 lines 70-70:  run 0xc0ffee::m::test_u16 --args 10000u16
+return values: 3
+task 11 lines 72-72:  run 0xc0ffee::m::test_u32 --args 0u32
+return values: 1
+task 12 lines 74-74:  run 0xc0ffee::m::test_u32 --args 1000u32
+return values: 2
+task 13 lines 76-76:  run 0xc0ffee::m::test_u32 --args 5000u32
+return values: 2
+task 14 lines 78-78:  run 0xc0ffee::m::test_u32 --args 10000u32
+return values: 3
+task 15 lines 80-80:  run 0xc0ffee::m::test_u64 --args 0u64
+return values: 1
+task 16 lines 82-82:  run 0xc0ffee::m::test_u64 --args 1000u64
+return values: 2
+task 17 lines 84-84:  run 0xc0ffee::m::test_u64 --args 5000u64
+return values: 2
+task 18 lines 86-86:  run 0xc0ffee::m::test_u64 --args 10000u64
+return values: 3
+task 19 lines 88-88:  run 0xc0ffee::m::test_u128 --args 0u128
+return values: 1
+task 20 lines 90-90:  run 0xc0ffee::m::test_u128 --args 1000u128
+return values: 2
+task 21 lines 92-92:  run 0xc0ffee::m::test_u128 --args 5000u128
+return values: 2
+task 22 lines 94-94:  run 0xc0ffee::m::test_u256 --args 0u256
+return values: 1
+task 23 lines 96-96:  run 0xc0ffee::m::test_u256 --args 1000u256
+return values: 2
+task 24 lines 98-98:  run 0xc0ffee::m::test_u256 --args 5000u256
+return values: 2

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/match_extensions/range_all_unsigned_types.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/match_extensions/range_all_unsigned_types.move
@@ -1,0 +1,98 @@
+//# publish
+module 0xc0ffee::m {
+    public fun test_u8(x: u8): u8 {
+        match (x) {
+            0..10 => 1,
+            10..=100 => 2,
+            _ => 3,
+        }
+    }
+
+    public fun test_u16(x: u16): u16 {
+        match (x) {
+            0..1000 => 1,
+            1000..=5000 => 2,
+            _ => 3,
+        }
+    }
+
+    public fun test_u32(x: u32): u32 {
+        match (x) {
+            0..1000 => 1,
+            1000..=5000 => 2,
+            _ => 3,
+        }
+    }
+
+    public fun test_u64(x: u64): u64 {
+        match (x) {
+            0..1000 => 1,
+            1000..=5000 => 2,
+            _ => 3,
+        }
+    }
+
+    public fun test_u128(x: u128): u128 {
+        match (x) {
+            0..1000 => 1,
+            1000..=5000 => 2,
+            _ => 3,
+        }
+    }
+
+    public fun test_u256(x: u256): u256 {
+        match (x) {
+            0..1000 => 1,
+            1000..=5000 => 2,
+            _ => 3,
+        }
+    }
+}
+
+//# run 0xc0ffee::m::test_u8 --args 0u8
+
+//# run 0xc0ffee::m::test_u8 --args 5u8
+
+//# run 0xc0ffee::m::test_u8 --args 10u8
+
+//# run 0xc0ffee::m::test_u8 --args 50u8
+
+//# run 0xc0ffee::m::test_u8 --args 200u8
+
+//# run 0xc0ffee::m::test_u16 --args 0u16
+
+//# run 0xc0ffee::m::test_u16 --args 500u16
+
+//# run 0xc0ffee::m::test_u16 --args 1000u16
+
+//# run 0xc0ffee::m::test_u16 --args 3000u16
+
+//# run 0xc0ffee::m::test_u16 --args 10000u16
+
+//# run 0xc0ffee::m::test_u32 --args 0u32
+
+//# run 0xc0ffee::m::test_u32 --args 1000u32
+
+//# run 0xc0ffee::m::test_u32 --args 5000u32
+
+//# run 0xc0ffee::m::test_u32 --args 10000u32
+
+//# run 0xc0ffee::m::test_u64 --args 0u64
+
+//# run 0xc0ffee::m::test_u64 --args 1000u64
+
+//# run 0xc0ffee::m::test_u64 --args 5000u64
+
+//# run 0xc0ffee::m::test_u64 --args 10000u64
+
+//# run 0xc0ffee::m::test_u128 --args 0u128
+
+//# run 0xc0ffee::m::test_u128 --args 1000u128
+
+//# run 0xc0ffee::m::test_u128 --args 5000u128
+
+//# run 0xc0ffee::m::test_u256 --args 0u256
+
+//# run 0xc0ffee::m::test_u256 --args 1000u256
+
+//# run 0xc0ffee::m::test_u256 --args 5000u256

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/match_extensions/range_basic.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/match_extensions/range_basic.exp
@@ -1,0 +1,40 @@
+processed 20 tasks
+task 0 lines 1-42:  publish [module 0xc0ffee::m {]
+task 1 lines 44-44:  run 0xc0ffee::m::test_exclusive --args 0u64
+return values: 0
+task 2 lines 46-46:  run 0xc0ffee::m::test_exclusive --args 1u64
+return values: 1
+task 3 lines 48-48:  run 0xc0ffee::m::test_exclusive --args 5u64
+return values: 1
+task 4 lines 50-50:  run 0xc0ffee::m::test_exclusive --args 9u64
+return values: 1
+task 5 lines 52-52:  run 0xc0ffee::m::test_exclusive --args 10u64
+return values: 0
+task 6 lines 54-54:  run 0xc0ffee::m::test_inclusive --args 0u64
+return values: 0
+task 7 lines 56-56:  run 0xc0ffee::m::test_inclusive --args 1u64
+return values: 1
+task 8 lines 58-58:  run 0xc0ffee::m::test_inclusive --args 5u64
+return values: 1
+task 9 lines 60-60:  run 0xc0ffee::m::test_inclusive --args 10u64
+return values: 1
+task 10 lines 62-62:  run 0xc0ffee::m::test_inclusive --args 11u64
+return values: 0
+task 11 lines 64-64:  run 0xc0ffee::m::test_open_end --args 4u64
+return values: 0
+task 12 lines 66-66:  run 0xc0ffee::m::test_open_end --args 5u64
+return values: 1
+task 13 lines 68-68:  run 0xc0ffee::m::test_open_end --args 100u64
+return values: 1
+task 14 lines 70-70:  run 0xc0ffee::m::test_open_start --args 0u64
+return values: 1
+task 15 lines 72-72:  run 0xc0ffee::m::test_open_start --args 9u64
+return values: 1
+task 16 lines 74-74:  run 0xc0ffee::m::test_open_start --args 10u64
+return values: 0
+task 17 lines 76-76:  run 0xc0ffee::m::test_open_start_inclusive --args 0u64
+return values: 1
+task 18 lines 78-78:  run 0xc0ffee::m::test_open_start_inclusive --args 10u64
+return values: 1
+task 19 lines 80-80:  run 0xc0ffee::m::test_open_start_inclusive --args 11u64
+return values: 0

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/match_extensions/range_basic.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/match_extensions/range_basic.move
@@ -1,0 +1,80 @@
+//# publish
+module 0xc0ffee::m {
+    // Exclusive range: a..b matches a <= x < b
+    public fun test_exclusive(x: u64): u64 {
+        match (x) {
+            1..10 => 1,
+            _ => 0,
+        }
+    }
+
+    // Inclusive range: a..=b matches a <= x <= b
+    public fun test_inclusive(x: u64): u64 {
+        match (x) {
+            1..=10 => 1,
+            _ => 0,
+        }
+    }
+
+    // Open-end range: a.. matches x >= a
+    public fun test_open_end(x: u64): u64 {
+        match (x) {
+            5.. => 1,
+            _ => 0,
+        }
+    }
+
+    // Open-start exclusive: ..b matches x < b
+    public fun test_open_start(x: u64): u64 {
+        match (x) {
+            ..10 => 1,
+            _ => 0,
+        }
+    }
+
+    // Open-start inclusive: ..=b matches x <= b
+    public fun test_open_start_inclusive(x: u64): u64 {
+        match (x) {
+            ..=10 => 1,
+            _ => 0,
+        }
+    }
+}
+
+//# run 0xc0ffee::m::test_exclusive --args 0u64
+
+//# run 0xc0ffee::m::test_exclusive --args 1u64
+
+//# run 0xc0ffee::m::test_exclusive --args 5u64
+
+//# run 0xc0ffee::m::test_exclusive --args 9u64
+
+//# run 0xc0ffee::m::test_exclusive --args 10u64
+
+//# run 0xc0ffee::m::test_inclusive --args 0u64
+
+//# run 0xc0ffee::m::test_inclusive --args 1u64
+
+//# run 0xc0ffee::m::test_inclusive --args 5u64
+
+//# run 0xc0ffee::m::test_inclusive --args 10u64
+
+//# run 0xc0ffee::m::test_inclusive --args 11u64
+
+//# run 0xc0ffee::m::test_open_end --args 4u64
+
+//# run 0xc0ffee::m::test_open_end --args 5u64
+
+//# run 0xc0ffee::m::test_open_end --args 100u64
+
+//# run 0xc0ffee::m::test_open_start --args 0u64
+
+//# run 0xc0ffee::m::test_open_start --args 9u64
+
+//# run 0xc0ffee::m::test_open_start --args 10u64
+
+//# run 0xc0ffee::m::test_open_start_inclusive --args 0u64
+
+//# run 0xc0ffee::m::test_open_start_inclusive --args 10u64
+
+//# run 0xc0ffee::m::test_open_start_inclusive --args 11u64

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/match_extensions/range_boundaries.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/match_extensions/range_boundaries.exp
@@ -1,0 +1,38 @@
+processed 19 tasks
+task 0 lines 1-49:  publish [module 0xc0ffee::m {]
+task 1 lines 51-51:  run 0xc0ffee::m::test_u8_almost_full --args 0u8
+return values: 1
+task 2 lines 53-53:  run 0xc0ffee::m::test_u8_almost_full --args 128u8
+return values: 1
+task 3 lines 55-55:  run 0xc0ffee::m::test_u8_almost_full --args 254u8
+return values: 1
+task 4 lines 57-57:  run 0xc0ffee::m::test_u8_almost_full --args 255u8
+return values: 2
+task 5 lines 59-59:  run 0xc0ffee::m::test_u8_full_inclusive --args 0u8
+return values: 1
+task 6 lines 61-61:  run 0xc0ffee::m::test_u8_full_inclusive --args 128u8
+return values: 1
+task 7 lines 63-63:  run 0xc0ffee::m::test_u8_full_inclusive --args 255u8
+return values: 1
+task 8 lines 65-65:  run 0xc0ffee::m::test_u8_single_exclusive --args 0u8
+return values: 1
+task 9 lines 67-67:  run 0xc0ffee::m::test_u8_single_exclusive --args 1u8
+return values: 0
+task 10 lines 69-69:  run 0xc0ffee::m::test_u8_single_inclusive --args 4u8
+return values: 0
+task 11 lines 71-71:  run 0xc0ffee::m::test_u8_single_inclusive --args 5u8
+return values: 1
+task 12 lines 73-73:  run 0xc0ffee::m::test_u8_single_inclusive --args 6u8
+return values: 0
+task 13 lines 75-75:  run 0xc0ffee::m::test_u8_open_near_max --args 199u8
+return values: 0
+task 14 lines 77-77:  run 0xc0ffee::m::test_u8_open_near_max --args 200u8
+return values: 1
+task 15 lines 79-79:  run 0xc0ffee::m::test_u8_open_near_max --args 255u8
+return values: 1
+task 16 lines 81-81:  run 0xc0ffee::m::test_u64_max --args 0u64
+return values: 1
+task 17 lines 83-83:  run 0xc0ffee::m::test_u64_max --args 18446744073709551614u64
+return values: 1
+task 18 lines 85-85:  run 0xc0ffee::m::test_u64_max --args 18446744073709551615u64
+return values: 2

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/match_extensions/range_boundaries.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/match_extensions/range_boundaries.move
@@ -1,0 +1,85 @@
+//# publish
+module 0xc0ffee::m {
+    // 0u8..255u8 covers all but 255
+    public fun test_u8_almost_full(x: u8): u64 {
+        match (x) {
+            0..255 => 1,
+            _ => 2,
+        }
+    }
+
+    // 0u8..=255u8 covers all u8 values
+    public fun test_u8_full_inclusive(x: u8): u64 {
+        match (x) {
+            0..=255 => 1,
+        }
+    }
+
+    // Single value exclusive range: 0u8..1u8 matches only 0
+    public fun test_u8_single_exclusive(x: u8): u64 {
+        match (x) {
+            0..1 => 1,
+            _ => 0,
+        }
+    }
+
+    // Single value inclusive range: 5u8..=5u8 matches only 5
+    public fun test_u8_single_inclusive(x: u8): u64 {
+        match (x) {
+            5..=5 => 1,
+            _ => 0,
+        }
+    }
+
+    // Open range near MAX: 200u8.. covers 200-255
+    public fun test_u8_open_near_max(x: u8): u64 {
+        match (x) {
+            200.. => 1,
+            _ => 0,
+        }
+    }
+
+    // u64 MAX boundary
+    public fun test_u64_max(x: u64): u64 {
+        match (x) {
+            0..18446744073709551615 => 1,
+            _ => 2,
+        }
+    }
+}
+
+//# run 0xc0ffee::m::test_u8_almost_full --args 0u8
+
+//# run 0xc0ffee::m::test_u8_almost_full --args 128u8
+
+//# run 0xc0ffee::m::test_u8_almost_full --args 254u8
+
+//# run 0xc0ffee::m::test_u8_almost_full --args 255u8
+
+//# run 0xc0ffee::m::test_u8_full_inclusive --args 0u8
+
+//# run 0xc0ffee::m::test_u8_full_inclusive --args 128u8
+
+//# run 0xc0ffee::m::test_u8_full_inclusive --args 255u8
+
+//# run 0xc0ffee::m::test_u8_single_exclusive --args 0u8
+
+//# run 0xc0ffee::m::test_u8_single_exclusive --args 1u8
+
+//# run 0xc0ffee::m::test_u8_single_inclusive --args 4u8
+
+//# run 0xc0ffee::m::test_u8_single_inclusive --args 5u8
+
+//# run 0xc0ffee::m::test_u8_single_inclusive --args 6u8
+
+//# run 0xc0ffee::m::test_u8_open_near_max --args 199u8
+
+//# run 0xc0ffee::m::test_u8_open_near_max --args 200u8
+
+//# run 0xc0ffee::m::test_u8_open_near_max --args 255u8
+
+//# run 0xc0ffee::m::test_u64_max --args 0u64
+
+//# run 0xc0ffee::m::test_u64_max --args 18446744073709551614u64
+
+//# run 0xc0ffee::m::test_u64_max --args 18446744073709551615u64

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/match_extensions/range_in_enum.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/match_extensions/range_in_enum.exp
@@ -1,0 +1,30 @@
+processed 15 tasks
+task 0 lines 1-97:  publish [module 0xc0ffee::m {]
+task 1 lines 99-99:  run 0xc0ffee::m::test_dark_color
+return values: 1
+task 2 lines 101-101:  run 0xc0ffee::m::test_bright_color
+return values: 2
+task 3 lines 103-103:  run 0xc0ffee::m::test_mixed_color
+return values: 2
+task 4 lines 105-105:  run 0xc0ffee::m::test_named_color
+return values: 3
+task 5 lines 107-107:  run 0xc0ffee::m::test_v1_in_range
+return values: 1
+task 6 lines 109-109:  run 0xc0ffee::m::test_v1_out_range
+return values: 2
+task 7 lines 111-111:  run 0xc0ffee::m::test_v2_both_match
+return values: 3
+task 8 lines 113-113:  run 0xc0ffee::m::test_v2_range_only
+return values: 4
+task 9 lines 115-115:  run 0xc0ffee::m::test_v3
+return values: 5
+task 10 lines 117-117:  run 0xc0ffee::m::test_multi_v1_in
+return values: 1
+task 11 lines 119-119:  run 0xc0ffee::m::test_multi_v1_out
+return values: 2
+task 12 lines 121-121:  run 0xc0ffee::m::test_multi_v2_in
+return values: 3
+task 13 lines 123-123:  run 0xc0ffee::m::test_multi_v2_out
+return values: 4
+task 14 lines 125-125:  run 0xc0ffee::m::test_multi_v3
+return values: 5

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/match_extensions/range_in_enum.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/match_extensions/range_in_enum.move
@@ -1,0 +1,125 @@
+//# publish
+module 0xc0ffee::m {
+    enum Color has drop {
+        RGB(u8, u8, u8),
+        Named(u8),
+    }
+
+    fun classify_color(c: Color): u64 {
+        match (c) {
+            Color::RGB(0..128, 0..128, 0..128) => 1,
+            Color::RGB(_, _, _) => 2,
+            Color::Named(_) => 3,
+        }
+    }
+
+    public fun test_dark_color(): u64 {
+        classify_color(Color::RGB(50, 50, 50))
+    }
+
+    public fun test_bright_color(): u64 {
+        classify_color(Color::RGB(200, 200, 200))
+    }
+
+    public fun test_mixed_color(): u64 {
+        classify_color(Color::RGB(50, 200, 50))
+    }
+
+    public fun test_named_color(): u64 {
+        classify_color(Color::Named(1))
+    }
+
+    enum E has drop {
+        V1(u64),
+        V2(u64, u64),
+        V3,
+    }
+
+    fun mixed_patterns(e: E): u64 {
+        match (e) {
+            E::V1(0..100) => 1,
+            E::V1(_) => 2,
+            E::V2(0..50, 42) => 3,
+            E::V2(_, _) => 4,
+            E::V3 => 5,
+        }
+    }
+
+    public fun test_v1_in_range(): u64 {
+        mixed_patterns(E::V1(50))
+    }
+
+    public fun test_v1_out_range(): u64 {
+        mixed_patterns(E::V1(200))
+    }
+
+    public fun test_v2_both_match(): u64 {
+        mixed_patterns(E::V2(25, 42))
+    }
+
+    public fun test_v2_range_only(): u64 {
+        mixed_patterns(E::V2(25, 99))
+    }
+
+    public fun test_v3(): u64 {
+        mixed_patterns(E::V3)
+    }
+
+    fun multi_variant_range(e: E): u64 {
+        match (e) {
+            E::V1(1..=10) => 1,
+            E::V1(_) => 2,
+            E::V2(0..100, 0..100) => 3,
+            E::V2(_, _) => 4,
+            E::V3 => 5,
+        }
+    }
+
+    public fun test_multi_v1_in(): u64 {
+        multi_variant_range(E::V1(5))
+    }
+
+    public fun test_multi_v1_out(): u64 {
+        multi_variant_range(E::V1(50))
+    }
+
+    public fun test_multi_v2_in(): u64 {
+        multi_variant_range(E::V2(50, 50))
+    }
+
+    public fun test_multi_v2_out(): u64 {
+        multi_variant_range(E::V2(200, 200))
+    }
+
+    public fun test_multi_v3(): u64 {
+        multi_variant_range(E::V3)
+    }
+}
+
+//# run 0xc0ffee::m::test_dark_color
+
+//# run 0xc0ffee::m::test_bright_color
+
+//# run 0xc0ffee::m::test_mixed_color
+
+//# run 0xc0ffee::m::test_named_color
+
+//# run 0xc0ffee::m::test_v1_in_range
+
+//# run 0xc0ffee::m::test_v1_out_range
+
+//# run 0xc0ffee::m::test_v2_both_match
+
+//# run 0xc0ffee::m::test_v2_range_only
+
+//# run 0xc0ffee::m::test_v3
+
+//# run 0xc0ffee::m::test_multi_v1_in
+
+//# run 0xc0ffee::m::test_multi_v1_out
+
+//# run 0xc0ffee::m::test_multi_v2_in
+
+//# run 0xc0ffee::m::test_multi_v2_out
+
+//# run 0xc0ffee::m::test_multi_v3

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/match_extensions/range_in_tuple.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/match_extensions/range_in_tuple.exp
@@ -1,0 +1,18 @@
+processed 9 tasks
+task 0 lines 1-27:  publish [module 0xc0ffee::m {]
+task 1 lines 29-29:  run 0xc0ffee::m::test_tuple_both_ranges --args 3u64 15u64
+return values: 1
+task 2 lines 31-31:  run 0xc0ffee::m::test_tuple_both_ranges --args 3u64 25u64
+return values: 0
+task 3 lines 33-33:  run 0xc0ffee::m::test_tuple_both_ranges --args 0u64 15u64
+return values: 0
+task 4 lines 35-35:  run 0xc0ffee::m::test_tuple_range_and_literal --args 5u64 42u64
+return values: 1
+task 5 lines 37-37:  run 0xc0ffee::m::test_tuple_range_and_literal --args 5u64 99u64
+return values: 2
+task 6 lines 39-39:  run 0xc0ffee::m::test_tuple_range_and_literal --args 50u64 42u64
+return values: 0
+task 7 lines 41-41:  run 0xc0ffee::m::test_tuple_range_and_wildcard --args 50u64 999u64
+return values: 1
+task 8 lines 43-43:  run 0xc0ffee::m::test_tuple_range_and_wildcard --args 200u64 999u64
+return values: 2

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/match_extensions/range_in_tuple.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/match_extensions/range_in_tuple.move
@@ -1,0 +1,43 @@
+//# publish
+module 0xc0ffee::m {
+    // Ranges in both tuple positions
+    public fun test_tuple_both_ranges(x: u64, y: u64): u64 {
+        match ((x, y)) {
+            (1..5, 10..20) => 1,
+            _ => 0,
+        }
+    }
+
+    // Mix of range and literal in tuple
+    public fun test_tuple_range_and_literal(x: u64, y: u64): u64 {
+        match ((x, y)) {
+            (1..10, 42) => 1,
+            (1..10, _) => 2,
+            _ => 0,
+        }
+    }
+
+    // Mix of range and wildcard in tuple
+    public fun test_tuple_range_and_wildcard(x: u64, y: u64): u64 {
+        match ((x, y)) {
+            (0..100, _) => 1,
+            _ => 2,
+        }
+    }
+}
+
+//# run 0xc0ffee::m::test_tuple_both_ranges --args 3u64 15u64
+
+//# run 0xc0ffee::m::test_tuple_both_ranges --args 3u64 25u64
+
+//# run 0xc0ffee::m::test_tuple_both_ranges --args 0u64 15u64
+
+//# run 0xc0ffee::m::test_tuple_range_and_literal --args 5u64 42u64
+
+//# run 0xc0ffee::m::test_tuple_range_and_literal --args 5u64 99u64
+
+//# run 0xc0ffee::m::test_tuple_range_and_literal --args 50u64 42u64
+
+//# run 0xc0ffee::m::test_tuple_range_and_wildcard --args 50u64 999u64
+
+//# run 0xc0ffee::m::test_tuple_range_and_wildcard --args 200u64 999u64

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/match_extensions/range_mixed_tuple_enum.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/match_extensions/range_mixed_tuple_enum.exp
@@ -1,0 +1,18 @@
+processed 9 tasks
+task 0 lines 1-58:  publish [module 0xc0ffee::m {]
+task 1 lines 60-60:  run 0xc0ffee::m::test_rgb_all_match
+return values: 1
+task 2 lines 62-62:  run 0xc0ffee::m::test_rgb_first_out
+return values: 2
+task 3 lines 64-64:  run 0xc0ffee::m::test_rgb_second_mismatch
+return values: 2
+task 4 lines 66-66:  run 0xc0ffee::m::test_rgb_tuple_out
+return values: 2
+task 5 lines 68-68:  run 0xc0ffee::m::test_gray_high_low
+return values: 3
+task 6 lines 70-70:  run 0xc0ffee::m::test_gray_high_tuple_out
+return values: 4
+task 7 lines 72-72:  run 0xc0ffee::m::test_gray_low
+return values: 4
+task 8 lines 74-74:  run 0xc0ffee::m::test_named
+return values: 5

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/match_extensions/range_mixed_tuple_enum.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/match_extensions/range_mixed_tuple_enum.move
@@ -1,0 +1,74 @@
+//# publish
+module 0xc0ffee::m {
+    enum Color has drop {
+        RGB(u8, u8, u8),
+        Grayscale(u8),
+        Named,
+    }
+
+    fun classify(c: Color, x: u64): u64 {
+        match ((c, x)) {
+            (Color::RGB(0..25, 28, 55..66), 88..99) => 1,
+            (Color::RGB(_, _, _), _) => 2,
+            (Color::Grayscale(128..=255), 0..50) => 3,
+            (Color::Grayscale(_), _) => 4,
+            (Color::Named, _) => 5,
+        }
+    }
+
+    // Arm 1: all conditions match
+    public fun test_rgb_all_match(): u64 {
+        classify(Color::RGB(10, 28, 60), 90)
+    }
+
+    // Arm 2: RGB but first field out of range
+    public fun test_rgb_first_out(): u64 {
+        classify(Color::RGB(30, 28, 60), 90)
+    }
+
+    // Arm 2: RGB but second field mismatch
+    public fun test_rgb_second_mismatch(): u64 {
+        classify(Color::RGB(10, 29, 60), 90)
+    }
+
+    // Arm 2: RGB but tuple range mismatch
+    public fun test_rgb_tuple_out(): u64 {
+        classify(Color::RGB(10, 28, 60), 100)
+    }
+
+    // Arm 3: grayscale high + low tuple
+    public fun test_gray_high_low(): u64 {
+        classify(Color::Grayscale(200), 25)
+    }
+
+    // Arm 4: grayscale high but tuple out of range
+    public fun test_gray_high_tuple_out(): u64 {
+        classify(Color::Grayscale(200), 50)
+    }
+
+    // Arm 4: grayscale low value
+    public fun test_gray_low(): u64 {
+        classify(Color::Grayscale(100), 25)
+    }
+
+    // Arm 5: named
+    public fun test_named(): u64 {
+        classify(Color::Named, 0)
+    }
+}
+
+//# run 0xc0ffee::m::test_rgb_all_match
+
+//# run 0xc0ffee::m::test_rgb_first_out
+
+//# run 0xc0ffee::m::test_rgb_second_mismatch
+
+//# run 0xc0ffee::m::test_rgb_tuple_out
+
+//# run 0xc0ffee::m::test_gray_high_low
+
+//# run 0xc0ffee::m::test_gray_high_tuple_out
+
+//# run 0xc0ffee::m::test_gray_low
+
+//# run 0xc0ffee::m::test_named

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/match_extensions/range_mixed_with_literals.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/match_extensions/range_mixed_with_literals.exp
@@ -1,0 +1,22 @@
+processed 11 tasks
+task 0 lines 1-22:  publish [module 0xc0ffee::m {]
+task 1 lines 24-24:  run 0xc0ffee::m::test_mixed --args 0u64
+return values: 1
+task 2 lines 26-26:  run 0xc0ffee::m::test_mixed --args 1u64
+return values: 2
+task 3 lines 28-28:  run 0xc0ffee::m::test_mixed --args 5u64
+return values: 2
+task 4 lines 30-30:  run 0xc0ffee::m::test_mixed --args 9u64
+return values: 2
+task 5 lines 32-32:  run 0xc0ffee::m::test_mixed --args 10u64
+return values: 3
+task 6 lines 34-34:  run 0xc0ffee::m::test_mixed --args 50u64
+return values: 4
+task 7 lines 36-36:  run 0xc0ffee::m::test_mixed --args 100u64
+return values: 5
+task 8 lines 38-38:  run 0xc0ffee::m::test_literal_sandwich --args 0u8
+return values: 1
+task 9 lines 40-40:  run 0xc0ffee::m::test_literal_sandwich --args 128u8
+return values: 2
+task 10 lines 42-42:  run 0xc0ffee::m::test_literal_sandwich --args 255u8
+return values: 3

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/match_extensions/range_mixed_with_literals.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/match_extensions/range_mixed_with_literals.move
@@ -1,0 +1,42 @@
+//# publish
+module 0xc0ffee::m {
+    // Ranges and exact literal patterns in the same match
+    public fun test_mixed(x: u64): u64 {
+        match (x) {
+            0 => 1,
+            1..10 => 2,
+            10 => 3,
+            11..100 => 4,
+            _ => 5,
+        }
+    }
+
+    // Literal before and after range
+    public fun test_literal_sandwich(x: u8): u64 {
+        match (x) {
+            0 => 1,
+            1..=254 => 2,
+            255 => 3,
+        }
+    }
+}
+
+//# run 0xc0ffee::m::test_mixed --args 0u64
+
+//# run 0xc0ffee::m::test_mixed --args 1u64
+
+//# run 0xc0ffee::m::test_mixed --args 5u64
+
+//# run 0xc0ffee::m::test_mixed --args 9u64
+
+//# run 0xc0ffee::m::test_mixed --args 10u64
+
+//# run 0xc0ffee::m::test_mixed --args 50u64
+
+//# run 0xc0ffee::m::test_mixed --args 100u64
+
+//# run 0xc0ffee::m::test_literal_sandwich --args 0u8
+
+//# run 0xc0ffee::m::test_literal_sandwich --args 128u8
+
+//# run 0xc0ffee::m::test_literal_sandwich --args 255u8

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/match_extensions/range_signed_types.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/match_extensions/range_signed_types.exp
@@ -1,0 +1,52 @@
+processed 26 tasks
+task 0 lines 1-58:  publish [module 0xc0ffee::m {]
+task 1 lines 60-60:  run 0xc0ffee::m::test_i8_cross_zero --args -5i8
+return values: 1
+task 2 lines 62-62:  run 0xc0ffee::m::test_i8_cross_zero --args 0i8
+return values: 1
+task 3 lines 64-64:  run 0xc0ffee::m::test_i8_cross_zero --args 4i8
+return values: 1
+task 4 lines 66-66:  run 0xc0ffee::m::test_i8_cross_zero --args 5i8
+return values: 0
+task 5 lines 68-68:  run 0xc0ffee::m::test_i8_negative --args -100i8
+return values: 1
+task 6 lines 70-70:  run 0xc0ffee::m::test_i8_negative --args -75i8
+return values: 1
+task 7 lines 72-72:  run 0xc0ffee::m::test_i8_negative --args -50i8
+return values: 0
+task 8 lines 74-74:  run 0xc0ffee::m::test_i8_negative --args -49i8
+return values: 0
+task 9 lines 76-76:  run 0xc0ffee::m::test_i16 --args -500i16
+return values: 1
+task 10 lines 78-78:  run 0xc0ffee::m::test_i16 --args 0i16
+return values: 2
+task 11 lines 80-80:  run 0xc0ffee::m::test_i16 --args 500i16
+return values: 2
+task 12 lines 82-82:  run 0xc0ffee::m::test_i16 --args 2000i16
+return values: 0
+task 13 lines 84-84:  run 0xc0ffee::m::test_i32 --args -50i32
+return values: 1
+task 14 lines 86-86:  run 0xc0ffee::m::test_i32 --args 0i32
+return values: 2
+task 15 lines 88-88:  run 0xc0ffee::m::test_i32 --args 50i32
+return values: 2
+task 16 lines 90-90:  run 0xc0ffee::m::test_i32 --args 200i32
+return values: 0
+task 17 lines 92-92:  run 0xc0ffee::m::test_i64 --args -50i64
+return values: 1
+task 18 lines 94-94:  run 0xc0ffee::m::test_i64 --args 0i64
+return values: 2
+task 19 lines 96-96:  run 0xc0ffee::m::test_i64 --args 50i64
+return values: 2
+task 20 lines 98-98:  run 0xc0ffee::m::test_i128 --args -50i128
+return values: 1
+task 21 lines 100-100:  run 0xc0ffee::m::test_i128 --args 0i128
+return values: 2
+task 22 lines 102-102:  run 0xc0ffee::m::test_i128 --args 50i128
+return values: 2
+task 23 lines 104-104:  run 0xc0ffee::m::test_i256 --args -50i256
+return values: 1
+task 24 lines 106-106:  run 0xc0ffee::m::test_i256 --args 0i256
+return values: 2
+task 25 lines 108-108:  run 0xc0ffee::m::test_i256 --args 50i256
+return values: 2

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/match_extensions/range_signed_types.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/match_extensions/range_signed_types.move
@@ -1,0 +1,108 @@
+//# publish
+module 0xc0ffee::m {
+    // Ranges crossing zero
+    public fun test_i8_cross_zero(x: i8): u64 {
+        match (x) {
+            -5..5 => 1,
+            _ => 0,
+        }
+    }
+
+    // Negative ranges
+    public fun test_i8_negative(x: i8): u64 {
+        match (x) {
+            -100..-50 => 1,
+            _ => 0,
+        }
+    }
+
+    public fun test_i16(x: i16): u64 {
+        match (x) {
+            -1000..0 => 1,
+            0..=1000 => 2,
+            _ => 0,
+        }
+    }
+
+    public fun test_i32(x: i32): u64 {
+        match (x) {
+            -100..0 => 1,
+            0..=100 => 2,
+            _ => 0,
+        }
+    }
+
+    public fun test_i64(x: i64): u64 {
+        match (x) {
+            -100..0 => 1,
+            0..=100 => 2,
+            _ => 0,
+        }
+    }
+
+    public fun test_i128(x: i128): u64 {
+        match (x) {
+            -100..0 => 1,
+            0..=100 => 2,
+            _ => 0,
+        }
+    }
+
+    public fun test_i256(x: i256): u64 {
+        match (x) {
+            -100..0 => 1,
+            0..=100 => 2,
+            _ => 0,
+        }
+    }
+}
+
+//# run 0xc0ffee::m::test_i8_cross_zero --args -5i8
+
+//# run 0xc0ffee::m::test_i8_cross_zero --args 0i8
+
+//# run 0xc0ffee::m::test_i8_cross_zero --args 4i8
+
+//# run 0xc0ffee::m::test_i8_cross_zero --args 5i8
+
+//# run 0xc0ffee::m::test_i8_negative --args -100i8
+
+//# run 0xc0ffee::m::test_i8_negative --args -75i8
+
+//# run 0xc0ffee::m::test_i8_negative --args -50i8
+
+//# run 0xc0ffee::m::test_i8_negative --args -49i8
+
+//# run 0xc0ffee::m::test_i16 --args -500i16
+
+//# run 0xc0ffee::m::test_i16 --args 0i16
+
+//# run 0xc0ffee::m::test_i16 --args 500i16
+
+//# run 0xc0ffee::m::test_i16 --args 2000i16
+
+//# run 0xc0ffee::m::test_i32 --args -50i32
+
+//# run 0xc0ffee::m::test_i32 --args 0i32
+
+//# run 0xc0ffee::m::test_i32 --args 50i32
+
+//# run 0xc0ffee::m::test_i32 --args 200i32
+
+//# run 0xc0ffee::m::test_i64 --args -50i64
+
+//# run 0xc0ffee::m::test_i64 --args 0i64
+
+//# run 0xc0ffee::m::test_i64 --args 50i64
+
+//# run 0xc0ffee::m::test_i128 --args -50i128
+
+//# run 0xc0ffee::m::test_i128 --args 0i128
+
+//# run 0xc0ffee::m::test_i128 --args 50i128
+
+//# run 0xc0ffee::m::test_i256 --args -50i256
+
+//# run 0xc0ffee::m::test_i256 --args 0i256
+
+//# run 0xc0ffee::m::test_i256 --args 50i256

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/match_extensions/range_with_guards.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/match_extensions/range_with_guards.exp
@@ -1,0 +1,16 @@
+processed 8 tasks
+task 0 lines 1-42:  publish [module 0xc0ffee::m {]
+task 1 lines 44-44:  run 0xc0ffee::m::test_range_with_guard --args 5u64 true
+return values: 1
+task 2 lines 46-46:  run 0xc0ffee::m::test_range_with_guard --args 5u64 false
+return values: 2
+task 3 lines 48-48:  run 0xc0ffee::m::test_range_with_guard --args 50u64 true
+return values: 0
+task 4 lines 50-50:  run 0xc0ffee::m::test_enum_guard_true
+return values: 1
+task 5 lines 52-52:  run 0xc0ffee::m::test_enum_guard_false
+return values: 2
+task 6 lines 54-54:  run 0xc0ffee::m::test_enum_out_of_range
+return values: 3
+task 7 lines 56-56:  run 0xc0ffee::m::test_enum_v2
+return values: 4

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/match_extensions/range_with_guards.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/match_extensions/range_with_guards.move
@@ -1,0 +1,56 @@
+//# publish
+module 0xc0ffee::m {
+    // Range with guard condition
+    public fun test_range_with_guard(x: u64, flag: bool): u64 {
+        match (x) {
+            1..10 if flag => 1,
+            1..10 => 2,
+            _ => 0,
+        }
+    }
+
+    enum E has drop {
+        V1(u64),
+        V2,
+    }
+
+    // Range in enum with guard
+    fun enum_range_guard(e: E, flag: bool): u64 {
+        match (e) {
+            E::V1(0..100) if flag => 1,
+            E::V1(0..100) => 2,
+            E::V1(_) => 3,
+            E::V2 => 4,
+        }
+    }
+
+    public fun test_enum_guard_true(): u64 {
+        enum_range_guard(E::V1(50), true)
+    }
+
+    public fun test_enum_guard_false(): u64 {
+        enum_range_guard(E::V1(50), false)
+    }
+
+    public fun test_enum_out_of_range(): u64 {
+        enum_range_guard(E::V1(200), true)
+    }
+
+    public fun test_enum_v2(): u64 {
+        enum_range_guard(E::V2, true)
+    }
+}
+
+//# run 0xc0ffee::m::test_range_with_guard --args 5u64 true
+
+//# run 0xc0ffee::m::test_range_with_guard --args 5u64 false
+
+//# run 0xc0ffee::m::test_range_with_guard --args 50u64 true
+
+//# run 0xc0ffee::m::test_enum_guard_true
+
+//# run 0xc0ffee::m::test_enum_guard_false
+
+//# run 0xc0ffee::m::test_enum_out_of_range
+
+//# run 0xc0ffee::m::test_enum_v2

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/match_extensions/range_with_ref.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/match_extensions/range_with_ref.exp
@@ -1,0 +1,20 @@
+processed 10 tasks
+task 0 lines 1-48:  publish [module 0xc0ffee::m {]
+task 1 lines 50-50:  run 0xc0ffee::m::test_ref_range --args 0u64
+return values: 0
+task 2 lines 52-52:  run 0xc0ffee::m::test_ref_range --args 5u64
+return values: 1
+task 3 lines 54-54:  run 0xc0ffee::m::test_ref_range --args 10u64
+return values: 0
+task 4 lines 56-56:  run 0xc0ffee::m::test_ref_enum_in_range
+return values: 1
+task 5 lines 58-58:  run 0xc0ffee::m::test_ref_enum_out_range
+return values: 2
+task 6 lines 60-60:  run 0xc0ffee::m::test_ref_enum_v2
+return values: 3
+task 7 lines 62-62:  run 0xc0ffee::m::test_mut_ref_range --args 0u64
+return values: 0
+task 8 lines 64-64:  run 0xc0ffee::m::test_mut_ref_range --args 5u64
+return values: 1
+task 9 lines 66-66:  run 0xc0ffee::m::test_mut_ref_range --args 10u64
+return values: 0

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/match_extensions/range_with_ref.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/match_extensions/range_with_ref.move
@@ -1,0 +1,66 @@
+//# publish
+module 0xc0ffee::m {
+    // Range with immutable reference to primitive
+    public fun test_ref_range(x: u64): u64 {
+        match (&x) {
+            1..10 => 1,
+            _ => 0,
+        }
+    }
+
+    enum E has drop, copy {
+        V1(u64),
+        V2,
+    }
+
+    // Range in enum field via reference
+    fun ref_enum_range(e: &E): u64 {
+        match (e) {
+            E::V1(0..5) => 1,
+            E::V1(_) => 2,
+            E::V2 => 3,
+        }
+    }
+
+    public fun test_ref_enum_in_range(): u64 {
+        let e = E::V1(3);
+        ref_enum_range(&e)
+    }
+
+    public fun test_ref_enum_out_range(): u64 {
+        let e = E::V1(10);
+        ref_enum_range(&e)
+    }
+
+    public fun test_ref_enum_v2(): u64 {
+        let e = E::V2;
+        ref_enum_range(&e)
+    }
+
+    // Mutable reference with range
+    public fun test_mut_ref_range(x: u64): u64 {
+        let mut_x = x;
+        match (&mut mut_x) {
+            1..10 => 1,
+            _ => 0,
+        }
+    }
+}
+
+//# run 0xc0ffee::m::test_ref_range --args 0u64
+
+//# run 0xc0ffee::m::test_ref_range --args 5u64
+
+//# run 0xc0ffee::m::test_ref_range --args 10u64
+
+//# run 0xc0ffee::m::test_ref_enum_in_range
+
+//# run 0xc0ffee::m::test_ref_enum_out_range
+
+//# run 0xc0ffee::m::test_ref_enum_v2
+
+//# run 0xc0ffee::m::test_mut_ref_range --args 0u64
+
+//# run 0xc0ffee::m::test_mut_ref_range --args 5u64
+
+//# run 0xc0ffee::m::test_mut_ref_range --args 10u64

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/match_extensions/round-trip/range_adjacent.decompiled
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/match_extensions/round-trip/range_adjacent.decompiled
@@ -1,0 +1,106 @@
+//**** Cross-compiled for `move` syntax from `tests/no-v1-comparison/match_extensions/range_adjacent.move`
+
+//# publish
+module 0xc0ffee::m {
+    public fun test_adjacent(p0: u64): u64 {
+        let _v0;
+        let _v1;
+        if (p0 >= 0) _v1 = p0 < 5 else _v1 = false;
+        loop {
+            if (!_v1) {
+                let _v2;
+                if (p0 >= 5) _v2 = p0 < 10 else _v2 = false;
+                if (_v2) {
+                    _v0 = 2;
+                    break
+                };
+                _v0 = 3;
+                break
+            };
+            return 1
+        };
+        _v0
+    }
+    public fun test_exact_coverage(p0: u8): u64 {
+        let _v0;
+        if (p0 >= 0u8) _v0 = p0 < 64u8 else _v0 = false;
+        'l1: loop {
+            'l0: loop {
+                loop {
+                    if (!_v0) {
+                        let _v1;
+                        let _v2;
+                        if (p0 >= 64u8) _v1 = p0 < 128u8 else _v1 = false;
+                        if (_v1) break;
+                        if (p0 >= 128u8) _v2 = p0 < 192u8 else _v2 = false;
+                        if (_v2) break 'l0;
+                        if (p0 >= 192u8) break 'l1;
+                        abort 14566554180833181697
+                    };
+                    return 1
+                };
+                return 2
+            };
+            return 3
+        };
+        4
+    }
+    public fun test_overlapping(p0: u64): u64 {
+        let _v0;
+        let _v1;
+        if (p0 >= 0) _v1 = p0 < 10 else _v1 = false;
+        loop {
+            if (!_v1) {
+                let _v2;
+                if (p0 >= 5) _v2 = p0 < 15 else _v2 = false;
+                if (_v2) {
+                    _v0 = 2;
+                    break
+                };
+                _v0 = 3;
+                break
+            };
+            return 1
+        };
+        _v0
+    }
+}
+
+
+//# run 0xc0ffee::m::test_adjacent --args 0u64
+
+//# run 0xc0ffee::m::test_adjacent --args 4u64
+
+//# run 0xc0ffee::m::test_adjacent --args 5u64
+
+//# run 0xc0ffee::m::test_adjacent --args 9u64
+
+//# run 0xc0ffee::m::test_adjacent --args 10u64
+
+//# run 0xc0ffee::m::test_overlapping --args 0u64
+
+//# run 0xc0ffee::m::test_overlapping --args 5u64
+
+//# run 0xc0ffee::m::test_overlapping --args 7u64
+
+//# run 0xc0ffee::m::test_overlapping --args 10u64
+
+//# run 0xc0ffee::m::test_overlapping --args 14u64
+
+//# run 0xc0ffee::m::test_overlapping --args 15u64
+
+//# run 0xc0ffee::m::test_exact_coverage --args 0u8
+
+//# run 0xc0ffee::m::test_exact_coverage --args 63u8
+
+//# run 0xc0ffee::m::test_exact_coverage --args 64u8
+
+//# run 0xc0ffee::m::test_exact_coverage --args 127u8
+
+//# run 0xc0ffee::m::test_exact_coverage --args 128u8
+
+//# run 0xc0ffee::m::test_exact_coverage --args 191u8
+
+//# run 0xc0ffee::m::test_exact_coverage --args 192u8
+
+//# run 0xc0ffee::m::test_exact_coverage --args 255u8

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/match_extensions/round-trip/range_adjacent.decompiled.baseline.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/match_extensions/round-trip/range_adjacent.decompiled.baseline.exp
@@ -1,0 +1,40 @@
+processed 20 tasks
+task 0 lines 3-67:  publish [module 0xc0ffee::m {]
+task 1 lines 70-70:  run 0xc0ffee::m::test_adjacent --args 0u64
+return values: 1
+task 2 lines 72-72:  run 0xc0ffee::m::test_adjacent --args 4u64
+return values: 1
+task 3 lines 74-74:  run 0xc0ffee::m::test_adjacent --args 5u64
+return values: 2
+task 4 lines 76-76:  run 0xc0ffee::m::test_adjacent --args 9u64
+return values: 2
+task 5 lines 78-78:  run 0xc0ffee::m::test_adjacent --args 10u64
+return values: 3
+task 6 lines 80-80:  run 0xc0ffee::m::test_overlapping --args 0u64
+return values: 1
+task 7 lines 82-82:  run 0xc0ffee::m::test_overlapping --args 5u64
+return values: 1
+task 8 lines 84-84:  run 0xc0ffee::m::test_overlapping --args 7u64
+return values: 1
+task 9 lines 86-86:  run 0xc0ffee::m::test_overlapping --args 10u64
+return values: 2
+task 10 lines 88-88:  run 0xc0ffee::m::test_overlapping --args 14u64
+return values: 2
+task 11 lines 90-90:  run 0xc0ffee::m::test_overlapping --args 15u64
+return values: 3
+task 12 lines 92-92:  run 0xc0ffee::m::test_exact_coverage --args 0u8
+return values: 1
+task 13 lines 94-94:  run 0xc0ffee::m::test_exact_coverage --args 63u8
+return values: 1
+task 14 lines 96-96:  run 0xc0ffee::m::test_exact_coverage --args 64u8
+return values: 2
+task 15 lines 98-98:  run 0xc0ffee::m::test_exact_coverage --args 127u8
+return values: 2
+task 16 lines 100-100:  run 0xc0ffee::m::test_exact_coverage --args 128u8
+return values: 3
+task 17 lines 102-102:  run 0xc0ffee::m::test_exact_coverage --args 191u8
+return values: 3
+task 18 lines 104-104:  run 0xc0ffee::m::test_exact_coverage --args 192u8
+return values: 4
+task 19 lines 106-106:  run 0xc0ffee::m::test_exact_coverage --args 255u8
+return values: 4

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/match_extensions/round-trip/range_all_unsigned_types.decompiled
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/match_extensions/round-trip/range_all_unsigned_types.decompiled
@@ -1,0 +1,168 @@
+//**** Cross-compiled for `move` syntax from `tests/no-v1-comparison/match_extensions/range_all_unsigned_types.move`
+
+//# publish
+module 0xc0ffee::m {
+    public fun test_u128(p0: u128): u128 {
+        let _v0;
+        let _v1;
+        if (p0 >= 0u128) _v1 = p0 < 1000u128 else _v1 = false;
+        loop {
+            if (!_v1) {
+                let _v2;
+                if (p0 >= 1000u128) _v2 = p0 <= 5000u128 else _v2 = false;
+                if (_v2) {
+                    _v0 = 2u128;
+                    break
+                };
+                _v0 = 3u128;
+                break
+            };
+            return 1u128
+        };
+        _v0
+    }
+    public fun test_u16(p0: u16): u16 {
+        let _v0;
+        let _v1;
+        if (p0 >= 0u16) _v1 = p0 < 1000u16 else _v1 = false;
+        loop {
+            if (!_v1) {
+                let _v2;
+                if (p0 >= 1000u16) _v2 = p0 <= 5000u16 else _v2 = false;
+                if (_v2) {
+                    _v0 = 2u16;
+                    break
+                };
+                _v0 = 3u16;
+                break
+            };
+            return 1u16
+        };
+        _v0
+    }
+    public fun test_u256(p0: u256): u256 {
+        let _v0;
+        let _v1;
+        if (p0 >= 0u256) _v1 = p0 < 1000u256 else _v1 = false;
+        loop {
+            if (!_v1) {
+                let _v2;
+                if (p0 >= 1000u256) _v2 = p0 <= 5000u256 else _v2 = false;
+                if (_v2) {
+                    _v0 = 2u256;
+                    break
+                };
+                _v0 = 3u256;
+                break
+            };
+            return 1u256
+        };
+        _v0
+    }
+    public fun test_u32(p0: u32): u32 {
+        let _v0;
+        let _v1;
+        if (p0 >= 0u32) _v1 = p0 < 1000u32 else _v1 = false;
+        loop {
+            if (!_v1) {
+                let _v2;
+                if (p0 >= 1000u32) _v2 = p0 <= 5000u32 else _v2 = false;
+                if (_v2) {
+                    _v0 = 2u32;
+                    break
+                };
+                _v0 = 3u32;
+                break
+            };
+            return 1u32
+        };
+        _v0
+    }
+    public fun test_u64(p0: u64): u64 {
+        let _v0;
+        let _v1;
+        if (p0 >= 0) _v1 = p0 < 1000 else _v1 = false;
+        loop {
+            if (!_v1) {
+                let _v2;
+                if (p0 >= 1000) _v2 = p0 <= 5000 else _v2 = false;
+                if (_v2) {
+                    _v0 = 2;
+                    break
+                };
+                _v0 = 3;
+                break
+            };
+            return 1
+        };
+        _v0
+    }
+    public fun test_u8(p0: u8): u8 {
+        let _v0;
+        let _v1;
+        if (p0 >= 0u8) _v1 = p0 < 10u8 else _v1 = false;
+        loop {
+            if (!_v1) {
+                let _v2;
+                if (p0 >= 10u8) _v2 = p0 <= 100u8 else _v2 = false;
+                if (_v2) {
+                    _v0 = 2u8;
+                    break
+                };
+                _v0 = 3u8;
+                break
+            };
+            return 1u8
+        };
+        _v0
+    }
+}
+
+
+//# run 0xc0ffee::m::test_u8 --args 0u8
+
+//# run 0xc0ffee::m::test_u8 --args 5u8
+
+//# run 0xc0ffee::m::test_u8 --args 10u8
+
+//# run 0xc0ffee::m::test_u8 --args 50u8
+
+//# run 0xc0ffee::m::test_u8 --args 200u8
+
+//# run 0xc0ffee::m::test_u16 --args 0u16
+
+//# run 0xc0ffee::m::test_u16 --args 500u16
+
+//# run 0xc0ffee::m::test_u16 --args 1000u16
+
+//# run 0xc0ffee::m::test_u16 --args 3000u16
+
+//# run 0xc0ffee::m::test_u16 --args 10000u16
+
+//# run 0xc0ffee::m::test_u32 --args 0u32
+
+//# run 0xc0ffee::m::test_u32 --args 1000u32
+
+//# run 0xc0ffee::m::test_u32 --args 5000u32
+
+//# run 0xc0ffee::m::test_u32 --args 10000u32
+
+//# run 0xc0ffee::m::test_u64 --args 0u64
+
+//# run 0xc0ffee::m::test_u64 --args 1000u64
+
+//# run 0xc0ffee::m::test_u64 --args 5000u64
+
+//# run 0xc0ffee::m::test_u64 --args 10000u64
+
+//# run 0xc0ffee::m::test_u128 --args 0u128
+
+//# run 0xc0ffee::m::test_u128 --args 1000u128
+
+//# run 0xc0ffee::m::test_u128 --args 5000u128
+
+//# run 0xc0ffee::m::test_u256 --args 0u256
+
+//# run 0xc0ffee::m::test_u256 --args 1000u256
+
+//# run 0xc0ffee::m::test_u256 --args 5000u256

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/match_extensions/round-trip/range_all_unsigned_types.decompiled.baseline.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/match_extensions/round-trip/range_all_unsigned_types.decompiled.baseline.exp
@@ -1,0 +1,50 @@
+processed 25 tasks
+task 0 lines 3-119:  publish [module 0xc0ffee::m {]
+task 1 lines 122-122:  run 0xc0ffee::m::test_u8 --args 0u8
+return values: 1
+task 2 lines 124-124:  run 0xc0ffee::m::test_u8 --args 5u8
+return values: 1
+task 3 lines 126-126:  run 0xc0ffee::m::test_u8 --args 10u8
+return values: 2
+task 4 lines 128-128:  run 0xc0ffee::m::test_u8 --args 50u8
+return values: 2
+task 5 lines 130-130:  run 0xc0ffee::m::test_u8 --args 200u8
+return values: 3
+task 6 lines 132-132:  run 0xc0ffee::m::test_u16 --args 0u16
+return values: 1
+task 7 lines 134-134:  run 0xc0ffee::m::test_u16 --args 500u16
+return values: 1
+task 8 lines 136-136:  run 0xc0ffee::m::test_u16 --args 1000u16
+return values: 2
+task 9 lines 138-138:  run 0xc0ffee::m::test_u16 --args 3000u16
+return values: 2
+task 10 lines 140-140:  run 0xc0ffee::m::test_u16 --args 10000u16
+return values: 3
+task 11 lines 142-142:  run 0xc0ffee::m::test_u32 --args 0u32
+return values: 1
+task 12 lines 144-144:  run 0xc0ffee::m::test_u32 --args 1000u32
+return values: 2
+task 13 lines 146-146:  run 0xc0ffee::m::test_u32 --args 5000u32
+return values: 2
+task 14 lines 148-148:  run 0xc0ffee::m::test_u32 --args 10000u32
+return values: 3
+task 15 lines 150-150:  run 0xc0ffee::m::test_u64 --args 0u64
+return values: 1
+task 16 lines 152-152:  run 0xc0ffee::m::test_u64 --args 1000u64
+return values: 2
+task 17 lines 154-154:  run 0xc0ffee::m::test_u64 --args 5000u64
+return values: 2
+task 18 lines 156-156:  run 0xc0ffee::m::test_u64 --args 10000u64
+return values: 3
+task 19 lines 158-158:  run 0xc0ffee::m::test_u128 --args 0u128
+return values: 1
+task 20 lines 160-160:  run 0xc0ffee::m::test_u128 --args 1000u128
+return values: 2
+task 21 lines 162-162:  run 0xc0ffee::m::test_u128 --args 5000u128
+return values: 2
+task 22 lines 164-164:  run 0xc0ffee::m::test_u256 --args 0u256
+return values: 1
+task 23 lines 166-166:  run 0xc0ffee::m::test_u256 --args 1000u256
+return values: 2
+task 24 lines 168-168:  run 0xc0ffee::m::test_u256 --args 5000u256
+return values: 2

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/match_extensions/round-trip/range_basic.decompiled
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/match_extensions/round-trip/range_basic.decompiled
@@ -1,0 +1,68 @@
+//**** Cross-compiled for `move` syntax from `tests/no-v1-comparison/match_extensions/range_basic.move`
+
+//# publish
+module 0xc0ffee::m {
+    public fun test_exclusive(p0: u64): u64 {
+        let _v0;
+        if (p0 >= 1) _v0 = p0 < 10 else _v0 = false;
+        if (_v0) return 1;
+        0
+    }
+    public fun test_inclusive(p0: u64): u64 {
+        let _v0;
+        if (p0 >= 1) _v0 = p0 <= 10 else _v0 = false;
+        if (_v0) return 1;
+        0
+    }
+    public fun test_open_end(p0: u64): u64 {
+        if (p0 >= 5) return 1;
+        0
+    }
+    public fun test_open_start(p0: u64): u64 {
+        if (p0 < 10) return 1;
+        0
+    }
+    public fun test_open_start_inclusive(p0: u64): u64 {
+        if (p0 <= 10) return 1;
+        0
+    }
+}
+
+
+//# run 0xc0ffee::m::test_exclusive --args 0u64
+
+//# run 0xc0ffee::m::test_exclusive --args 1u64
+
+//# run 0xc0ffee::m::test_exclusive --args 5u64
+
+//# run 0xc0ffee::m::test_exclusive --args 9u64
+
+//# run 0xc0ffee::m::test_exclusive --args 10u64
+
+//# run 0xc0ffee::m::test_inclusive --args 0u64
+
+//# run 0xc0ffee::m::test_inclusive --args 1u64
+
+//# run 0xc0ffee::m::test_inclusive --args 5u64
+
+//# run 0xc0ffee::m::test_inclusive --args 10u64
+
+//# run 0xc0ffee::m::test_inclusive --args 11u64
+
+//# run 0xc0ffee::m::test_open_end --args 4u64
+
+//# run 0xc0ffee::m::test_open_end --args 5u64
+
+//# run 0xc0ffee::m::test_open_end --args 100u64
+
+//# run 0xc0ffee::m::test_open_start --args 0u64
+
+//# run 0xc0ffee::m::test_open_start --args 9u64
+
+//# run 0xc0ffee::m::test_open_start --args 10u64
+
+//# run 0xc0ffee::m::test_open_start_inclusive --args 0u64
+
+//# run 0xc0ffee::m::test_open_start_inclusive --args 10u64
+
+//# run 0xc0ffee::m::test_open_start_inclusive --args 11u64

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/match_extensions/round-trip/range_basic.decompiled.baseline.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/match_extensions/round-trip/range_basic.decompiled.baseline.exp
@@ -1,0 +1,40 @@
+processed 20 tasks
+task 0 lines 3-29:  publish [module 0xc0ffee::m {]
+task 1 lines 32-32:  run 0xc0ffee::m::test_exclusive --args 0u64
+return values: 0
+task 2 lines 34-34:  run 0xc0ffee::m::test_exclusive --args 1u64
+return values: 1
+task 3 lines 36-36:  run 0xc0ffee::m::test_exclusive --args 5u64
+return values: 1
+task 4 lines 38-38:  run 0xc0ffee::m::test_exclusive --args 9u64
+return values: 1
+task 5 lines 40-40:  run 0xc0ffee::m::test_exclusive --args 10u64
+return values: 0
+task 6 lines 42-42:  run 0xc0ffee::m::test_inclusive --args 0u64
+return values: 0
+task 7 lines 44-44:  run 0xc0ffee::m::test_inclusive --args 1u64
+return values: 1
+task 8 lines 46-46:  run 0xc0ffee::m::test_inclusive --args 5u64
+return values: 1
+task 9 lines 48-48:  run 0xc0ffee::m::test_inclusive --args 10u64
+return values: 1
+task 10 lines 50-50:  run 0xc0ffee::m::test_inclusive --args 11u64
+return values: 0
+task 11 lines 52-52:  run 0xc0ffee::m::test_open_end --args 4u64
+return values: 0
+task 12 lines 54-54:  run 0xc0ffee::m::test_open_end --args 5u64
+return values: 1
+task 13 lines 56-56:  run 0xc0ffee::m::test_open_end --args 100u64
+return values: 1
+task 14 lines 58-58:  run 0xc0ffee::m::test_open_start --args 0u64
+return values: 1
+task 15 lines 60-60:  run 0xc0ffee::m::test_open_start --args 9u64
+return values: 1
+task 16 lines 62-62:  run 0xc0ffee::m::test_open_start --args 10u64
+return values: 0
+task 17 lines 64-64:  run 0xc0ffee::m::test_open_start_inclusive --args 0u64
+return values: 1
+task 18 lines 66-66:  run 0xc0ffee::m::test_open_start_inclusive --args 10u64
+return values: 1
+task 19 lines 68-68:  run 0xc0ffee::m::test_open_start_inclusive --args 11u64
+return values: 0

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/match_extensions/round-trip/range_boundaries.decompiled
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/match_extensions/round-trip/range_boundaries.decompiled
@@ -1,0 +1,76 @@
+//**** Cross-compiled for `move` syntax from `tests/no-v1-comparison/match_extensions/range_boundaries.move`
+
+//# publish
+module 0xc0ffee::m {
+    public fun test_u64_max(p0: u64): u64 {
+        let _v0;
+        if (p0 >= 0) _v0 = p0 < MAX_U64 else _v0 = false;
+        if (_v0) return 1;
+        2
+    }
+    public fun test_u8_almost_full(p0: u8): u64 {
+        let _v0;
+        if (p0 >= 0u8) _v0 = p0 < MAX_U8 else _v0 = false;
+        if (_v0) return 1;
+        2
+    }
+    public fun test_u8_full_inclusive(p0: u8): u64 {
+        let _v0;
+        if (p0 >= 0u8) _v0 = p0 <= MAX_U8 else _v0 = false;
+        assert!(_v0, 14566554180833181697);
+        1
+    }
+    public fun test_u8_open_near_max(p0: u8): u64 {
+        if (p0 >= 200u8) return 1;
+        0
+    }
+    public fun test_u8_single_exclusive(p0: u8): u64 {
+        let _v0;
+        if (p0 >= 0u8) _v0 = p0 < 1u8 else _v0 = false;
+        if (_v0) return 1;
+        0
+    }
+    public fun test_u8_single_inclusive(p0: u8): u64 {
+        let _v0;
+        if (p0 >= 5u8) _v0 = p0 <= 5u8 else _v0 = false;
+        if (_v0) return 1;
+        0
+    }
+}
+
+
+//# run 0xc0ffee::m::test_u8_almost_full --args 0u8
+
+//# run 0xc0ffee::m::test_u8_almost_full --args 128u8
+
+//# run 0xc0ffee::m::test_u8_almost_full --args 254u8
+
+//# run 0xc0ffee::m::test_u8_almost_full --args 255u8
+
+//# run 0xc0ffee::m::test_u8_full_inclusive --args 0u8
+
+//# run 0xc0ffee::m::test_u8_full_inclusive --args 128u8
+
+//# run 0xc0ffee::m::test_u8_full_inclusive --args 255u8
+
+//# run 0xc0ffee::m::test_u8_single_exclusive --args 0u8
+
+//# run 0xc0ffee::m::test_u8_single_exclusive --args 1u8
+
+//# run 0xc0ffee::m::test_u8_single_inclusive --args 4u8
+
+//# run 0xc0ffee::m::test_u8_single_inclusive --args 5u8
+
+//# run 0xc0ffee::m::test_u8_single_inclusive --args 6u8
+
+//# run 0xc0ffee::m::test_u8_open_near_max --args 199u8
+
+//# run 0xc0ffee::m::test_u8_open_near_max --args 200u8
+
+//# run 0xc0ffee::m::test_u8_open_near_max --args 255u8
+
+//# run 0xc0ffee::m::test_u64_max --args 0u64
+
+//# run 0xc0ffee::m::test_u64_max --args 18446744073709551614u64
+
+//# run 0xc0ffee::m::test_u64_max --args 18446744073709551615u64

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/match_extensions/round-trip/range_boundaries.decompiled.baseline.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/match_extensions/round-trip/range_boundaries.decompiled.baseline.exp
@@ -1,0 +1,38 @@
+processed 19 tasks
+task 0 lines 3-39:  publish [module 0xc0ffee::m {]
+task 1 lines 42-42:  run 0xc0ffee::m::test_u8_almost_full --args 0u8
+return values: 1
+task 2 lines 44-44:  run 0xc0ffee::m::test_u8_almost_full --args 128u8
+return values: 1
+task 3 lines 46-46:  run 0xc0ffee::m::test_u8_almost_full --args 254u8
+return values: 1
+task 4 lines 48-48:  run 0xc0ffee::m::test_u8_almost_full --args 255u8
+return values: 2
+task 5 lines 50-50:  run 0xc0ffee::m::test_u8_full_inclusive --args 0u8
+return values: 1
+task 6 lines 52-52:  run 0xc0ffee::m::test_u8_full_inclusive --args 128u8
+return values: 1
+task 7 lines 54-54:  run 0xc0ffee::m::test_u8_full_inclusive --args 255u8
+return values: 1
+task 8 lines 56-56:  run 0xc0ffee::m::test_u8_single_exclusive --args 0u8
+return values: 1
+task 9 lines 58-58:  run 0xc0ffee::m::test_u8_single_exclusive --args 1u8
+return values: 0
+task 10 lines 60-60:  run 0xc0ffee::m::test_u8_single_inclusive --args 4u8
+return values: 0
+task 11 lines 62-62:  run 0xc0ffee::m::test_u8_single_inclusive --args 5u8
+return values: 1
+task 12 lines 64-64:  run 0xc0ffee::m::test_u8_single_inclusive --args 6u8
+return values: 0
+task 13 lines 66-66:  run 0xc0ffee::m::test_u8_open_near_max --args 199u8
+return values: 0
+task 14 lines 68-68:  run 0xc0ffee::m::test_u8_open_near_max --args 200u8
+return values: 1
+task 15 lines 70-70:  run 0xc0ffee::m::test_u8_open_near_max --args 255u8
+return values: 1
+task 16 lines 72-72:  run 0xc0ffee::m::test_u64_max --args 0u64
+return values: 1
+task 17 lines 74-74:  run 0xc0ffee::m::test_u64_max --args 18446744073709551614u64
+return values: 1
+task 18 lines 76-76:  run 0xc0ffee::m::test_u64_max --args 18446744073709551615u64
+return values: 2

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/match_extensions/round-trip/range_in_enum.decompiled
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/match_extensions/round-trip/range_in_enum.decompiled
@@ -1,0 +1,207 @@
+//**** Cross-compiled for `move` syntax from `tests/no-v1-comparison/match_extensions/range_in_enum.move`
+
+//# publish
+module 0xc0ffee::m {
+    enum Color has drop {
+        RGB {
+            _0: u8,
+            _1: u8,
+            _2: u8,
+        }
+        Named {
+            _0: u8,
+        }
+    }
+    enum E has drop {
+        V1 {
+            _0: u64,
+        }
+        V2 {
+            _0: u64,
+            _1: u64,
+        }
+        V3,
+    }
+    fun classify_color(p0: Color): u64 {
+        let _v0 = &p0;
+        loop {
+            if (_v0 is RGB) {
+                let _v1;
+                let _v2;
+                let _v3;
+                let _v4 = &_v0._0;
+                let _v5 = &_v0._1;
+                let _v6 = &_v0._2;
+                if (*_v4 >= 0u8) _v3 = *_v4 < 128u8 else _v3 = false;
+                if (_v3) if (*_v5 >= 0u8) _v2 = *_v5 < 128u8 else _v2 = false else _v2 = false;
+                if (_v2) if (*_v6 >= 0u8) _v1 = *_v6 < 128u8 else _v1 = false else _v1 = false;
+                if (_v1) break
+            };
+            loop {
+                if (!(_v0 is RGB)) {
+                    if (_v0 is Named) break;
+                    abort 14566554180833181697
+                };
+                let Color::RGB{_0: _v7, _1: _v8, _2: _v9} = p0;
+                return 2
+            };
+            let Color::Named{_0: _v10} = p0;
+            return 3
+        };
+        let Color::RGB{_0: _v11, _1: _v12, _2: _v13} = p0;
+        1
+    }
+    fun mixed_patterns(p0: E): u64 {
+        let _v0 = &p0;
+        loop {
+            let _v1;
+            let _v2;
+            if (_v0 is V1) {
+                _v2 = &_v0._0;
+                if (*_v2 >= 0) _v1 = *_v2 < 100 else _v1 = false;
+                if (_v1) break
+            };
+            'l0: loop {
+                'l1: loop {
+                    loop {
+                        if (!(_v0 is V1)) {
+                            if (_v0 is V2) {
+                                let _v3;
+                                _v2 = &_v0._0;
+                                let _v4 = &_v0._1;
+                                if (*_v2 >= 0) _v3 = *_v2 < 50 else _v3 = false;
+                                if (_v3) _v1 = *_v4 == 42 else _v1 = false;
+                                if (_v1) break 'l0
+                            };
+                            if (_v0 is V2) break;
+                            if (_v0 is V3) break 'l1;
+                            abort 14566554180833181697
+                        };
+                        let E::V1{_0: _v5} = p0;
+                        return 2
+                    };
+                    let E::V2{_0: _v6, _1: _v7} = p0;
+                    return 4
+                };
+                let E::V3{} = p0;
+                return 5
+            };
+            let E::V2{_0: _v8, _1: _v9} = p0;
+            return 3
+        };
+        let E::V1{_0: _v10} = p0;
+        1
+    }
+    fun multi_variant_range(p0: E): u64 {
+        let _v0 = &p0;
+        loop {
+            let _v1;
+            let _v2;
+            if (_v0 is V1) {
+                _v2 = &_v0._0;
+                if (*_v2 >= 1) _v1 = *_v2 <= 10 else _v1 = false;
+                if (_v1) break
+            };
+            'l0: loop {
+                'l1: loop {
+                    loop {
+                        if (!(_v0 is V1)) {
+                            if (_v0 is V2) {
+                                let _v3;
+                                _v2 = &_v0._0;
+                                let _v4 = &_v0._1;
+                                if (*_v2 >= 0) _v3 = *_v2 < 100 else _v3 = false;
+                                if (_v3) if (*_v4 >= 0) _v1 = *_v4 < 100 else _v1 = false else _v1 = false;
+                                if (_v1) break 'l0
+                            };
+                            if (_v0 is V2) break;
+                            if (_v0 is V3) break 'l1;
+                            abort 14566554180833181697
+                        };
+                        let E::V1{_0: _v5} = p0;
+                        return 2
+                    };
+                    let E::V2{_0: _v6, _1: _v7} = p0;
+                    return 4
+                };
+                let E::V3{} = p0;
+                return 5
+            };
+            let E::V2{_0: _v8, _1: _v9} = p0;
+            return 3
+        };
+        let E::V1{_0: _v10} = p0;
+        1
+    }
+    public fun test_bright_color(): u64 {
+        classify_color(Color::RGB{_0: 200u8, _1: 200u8, _2: 200u8})
+    }
+    public fun test_dark_color(): u64 {
+        classify_color(Color::RGB{_0: 50u8, _1: 50u8, _2: 50u8})
+    }
+    public fun test_mixed_color(): u64 {
+        classify_color(Color::RGB{_0: 50u8, _1: 200u8, _2: 50u8})
+    }
+    public fun test_multi_v1_in(): u64 {
+        multi_variant_range(E::V1{_0: 5})
+    }
+    public fun test_multi_v1_out(): u64 {
+        multi_variant_range(E::V1{_0: 50})
+    }
+    public fun test_multi_v2_in(): u64 {
+        multi_variant_range(E::V2{_0: 50, _1: 50})
+    }
+    public fun test_multi_v2_out(): u64 {
+        multi_variant_range(E::V2{_0: 200, _1: 200})
+    }
+    public fun test_multi_v3(): u64 {
+        multi_variant_range(E::V3{})
+    }
+    public fun test_named_color(): u64 {
+        classify_color(Color::Named{_0: 1u8})
+    }
+    public fun test_v1_in_range(): u64 {
+        mixed_patterns(E::V1{_0: 50})
+    }
+    public fun test_v1_out_range(): u64 {
+        mixed_patterns(E::V1{_0: 200})
+    }
+    public fun test_v2_both_match(): u64 {
+        mixed_patterns(E::V2{_0: 25, _1: 42})
+    }
+    public fun test_v2_range_only(): u64 {
+        mixed_patterns(E::V2{_0: 25, _1: 99})
+    }
+    public fun test_v3(): u64 {
+        mixed_patterns(E::V3{})
+    }
+}
+
+
+//# run 0xc0ffee::m::test_dark_color
+
+//# run 0xc0ffee::m::test_bright_color
+
+//# run 0xc0ffee::m::test_mixed_color
+
+//# run 0xc0ffee::m::test_named_color
+
+//# run 0xc0ffee::m::test_v1_in_range
+
+//# run 0xc0ffee::m::test_v1_out_range
+
+//# run 0xc0ffee::m::test_v2_both_match
+
+//# run 0xc0ffee::m::test_v2_range_only
+
+//# run 0xc0ffee::m::test_v3
+
+//# run 0xc0ffee::m::test_multi_v1_in
+
+//# run 0xc0ffee::m::test_multi_v1_out
+
+//# run 0xc0ffee::m::test_multi_v2_in
+
+//# run 0xc0ffee::m::test_multi_v2_out
+
+//# run 0xc0ffee::m::test_multi_v3

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/match_extensions/round-trip/range_in_enum.decompiled.baseline.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/match_extensions/round-trip/range_in_enum.decompiled.baseline.exp
@@ -1,0 +1,30 @@
+processed 15 tasks
+task 0 lines 3-178:  publish [module 0xc0ffee::m {]
+task 1 lines 181-181:  run 0xc0ffee::m::test_dark_color
+return values: 1
+task 2 lines 183-183:  run 0xc0ffee::m::test_bright_color
+return values: 2
+task 3 lines 185-185:  run 0xc0ffee::m::test_mixed_color
+return values: 2
+task 4 lines 187-187:  run 0xc0ffee::m::test_named_color
+return values: 3
+task 5 lines 189-189:  run 0xc0ffee::m::test_v1_in_range
+return values: 1
+task 6 lines 191-191:  run 0xc0ffee::m::test_v1_out_range
+return values: 2
+task 7 lines 193-193:  run 0xc0ffee::m::test_v2_both_match
+return values: 3
+task 8 lines 195-195:  run 0xc0ffee::m::test_v2_range_only
+return values: 4
+task 9 lines 197-197:  run 0xc0ffee::m::test_v3
+return values: 5
+task 10 lines 199-199:  run 0xc0ffee::m::test_multi_v1_in
+return values: 1
+task 11 lines 201-201:  run 0xc0ffee::m::test_multi_v1_out
+return values: 2
+task 12 lines 203-203:  run 0xc0ffee::m::test_multi_v2_in
+return values: 3
+task 13 lines 205-205:  run 0xc0ffee::m::test_multi_v2_out
+return values: 4
+task 14 lines 207-207:  run 0xc0ffee::m::test_multi_v3
+return values: 5

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/match_extensions/round-trip/range_in_tuple.decompiled
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/match_extensions/round-trip/range_in_tuple.decompiled
@@ -1,0 +1,57 @@
+//**** Cross-compiled for `move` syntax from `tests/no-v1-comparison/match_extensions/range_in_tuple.move`
+
+//# publish
+module 0xc0ffee::m {
+    public fun test_tuple_both_ranges(p0: u64, p1: u64): u64 {
+        let _v0;
+        let _v1;
+        if (p0 >= 1) _v1 = p0 < 5 else _v1 = false;
+        if (_v1) if (p1 >= 10) _v0 = p1 < 20 else _v0 = false else _v0 = false;
+        if (_v0) return 1;
+        0
+    }
+    public fun test_tuple_range_and_literal(p0: u64, p1: u64): u64 {
+        let _v0;
+        let _v1;
+        let _v2;
+        if (p0 >= 1) _v2 = p0 < 10 else _v2 = false;
+        if (_v2) _v1 = p1 == 42 else _v1 = false;
+        loop {
+            if (!_v1) {
+                let _v3;
+                if (p0 >= 1) _v3 = p0 < 10 else _v3 = false;
+                if (_v3) {
+                    _v0 = 2;
+                    break
+                };
+                _v0 = 0;
+                break
+            };
+            return 1
+        };
+        _v0
+    }
+    public fun test_tuple_range_and_wildcard(p0: u64, p1: u64): u64 {
+        let _v0;
+        if (p0 >= 0) _v0 = p0 < 100 else _v0 = false;
+        if (_v0) return 1;
+        2
+    }
+}
+
+
+//# run 0xc0ffee::m::test_tuple_both_ranges --args 3u64 15u64
+
+//# run 0xc0ffee::m::test_tuple_both_ranges --args 3u64 25u64
+
+//# run 0xc0ffee::m::test_tuple_both_ranges --args 0u64 15u64
+
+//# run 0xc0ffee::m::test_tuple_range_and_literal --args 5u64 42u64
+
+//# run 0xc0ffee::m::test_tuple_range_and_literal --args 5u64 99u64
+
+//# run 0xc0ffee::m::test_tuple_range_and_literal --args 50u64 42u64
+
+//# run 0xc0ffee::m::test_tuple_range_and_wildcard --args 50u64 999u64
+
+//# run 0xc0ffee::m::test_tuple_range_and_wildcard --args 200u64 999u64

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/match_extensions/round-trip/range_in_tuple.decompiled.baseline.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/match_extensions/round-trip/range_in_tuple.decompiled.baseline.exp
@@ -1,0 +1,25 @@
+processed 9 tasks
+task 0 lines 3-40:  publish [module 0xc0ffee::m {]
+warning: Unused value of parameter `p1`. Consider removing the parameter, or prefixing with an underscore (e.g., `_p1`), or binding to `_`
+   ┌─ TEMPFILE:34:55
+   │
+34 │     public fun test_tuple_range_and_wildcard(p0: u64, p1: u64): u64 {
+   │                                                       ^^
+
+
+task 1 lines 43-43:  run 0xc0ffee::m::test_tuple_both_ranges --args 3u64 15u64
+return values: 1
+task 2 lines 45-45:  run 0xc0ffee::m::test_tuple_both_ranges --args 3u64 25u64
+return values: 0
+task 3 lines 47-47:  run 0xc0ffee::m::test_tuple_both_ranges --args 0u64 15u64
+return values: 0
+task 4 lines 49-49:  run 0xc0ffee::m::test_tuple_range_and_literal --args 5u64 42u64
+return values: 1
+task 5 lines 51-51:  run 0xc0ffee::m::test_tuple_range_and_literal --args 5u64 99u64
+return values: 2
+task 6 lines 53-53:  run 0xc0ffee::m::test_tuple_range_and_literal --args 50u64 42u64
+return values: 0
+task 7 lines 55-55:  run 0xc0ffee::m::test_tuple_range_and_wildcard --args 50u64 999u64
+return values: 1
+task 8 lines 57-57:  run 0xc0ffee::m::test_tuple_range_and_wildcard --args 200u64 999u64
+return values: 2

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/match_extensions/round-trip/range_mixed_tuple_enum.decompiled
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/match_extensions/round-trip/range_mixed_tuple_enum.decompiled
@@ -1,0 +1,107 @@
+//**** Cross-compiled for `move` syntax from `tests/no-v1-comparison/match_extensions/range_mixed_tuple_enum.move`
+
+//# publish
+module 0xc0ffee::m {
+    enum Color has drop {
+        RGB {
+            _0: u8,
+            _1: u8,
+            _2: u8,
+        }
+        Grayscale {
+            _0: u8,
+        }
+        Named,
+    }
+    fun classify(p0: Color, p1: u64): u64 {
+        let _v0 = p0;
+        let _v1 = &_v0;
+        loop {
+            let _v2;
+            let _v3;
+            let _v4;
+            if (_v1 is RGB) {
+                _v4 = &_v1._0;
+                let _v5 = &_v1._1;
+                let _v6 = &_v1._2;
+                if (p1 >= 88) _v3 = p1 < 99 else _v3 = false;
+                if (_v3) {
+                    let _v7;
+                    let _v8;
+                    if (*_v4 >= 0u8) _v8 = *_v4 < 25u8 else _v8 = false;
+                    if (_v8) _v7 = *_v5 == 28u8 else _v7 = false;
+                    if (_v7) if (*_v6 >= 55u8) _v2 = *_v6 < 66u8 else _v2 = false else _v2 = false
+                } else _v2 = false;
+                if (_v2) break
+            };
+            'l0: loop {
+                'l1: loop {
+                    loop {
+                        if (!(_v1 is RGB)) {
+                            if (_v1 is Grayscale) {
+                                _v4 = &_v1._0;
+                                if (p1 >= 0) _v3 = p1 < 50 else _v3 = false;
+                                if (_v3) if (*_v4 >= 128u8) _v2 = *_v4 <= MAX_U8 else _v2 = false else _v2 = false;
+                                if (_v2) break 'l0
+                            };
+                            if (_v1 is Grayscale) break;
+                            if (_v1 is Named) break 'l1;
+                            abort 14566554180833181697
+                        };
+                        let Color::RGB{_0: _v9, _1: _v10, _2: _v11} = _v0;
+                        return 2
+                    };
+                    let Color::Grayscale{_0: _v12} = _v0;
+                    return 4
+                };
+                let Color::Named{} = _v0;
+                return 5
+            };
+            let Color::Grayscale{_0: _v13} = _v0;
+            return 3
+        };
+        let Color::RGB{_0: _v14, _1: _v15, _2: _v16} = _v0;
+        1
+    }
+    public fun test_gray_high_low(): u64 {
+        classify(Color::Grayscale{_0: 200u8}, 25)
+    }
+    public fun test_gray_high_tuple_out(): u64 {
+        classify(Color::Grayscale{_0: 200u8}, 50)
+    }
+    public fun test_gray_low(): u64 {
+        classify(Color::Grayscale{_0: 100u8}, 25)
+    }
+    public fun test_named(): u64 {
+        classify(Color::Named{}, 0)
+    }
+    public fun test_rgb_all_match(): u64 {
+        classify(Color::RGB{_0: 10u8, _1: 28u8, _2: 60u8}, 90)
+    }
+    public fun test_rgb_first_out(): u64 {
+        classify(Color::RGB{_0: 30u8, _1: 28u8, _2: 60u8}, 90)
+    }
+    public fun test_rgb_second_mismatch(): u64 {
+        classify(Color::RGB{_0: 10u8, _1: 29u8, _2: 60u8}, 90)
+    }
+    public fun test_rgb_tuple_out(): u64 {
+        classify(Color::RGB{_0: 10u8, _1: 28u8, _2: 60u8}, 100)
+    }
+}
+
+
+//# run 0xc0ffee::m::test_rgb_all_match
+
+//# run 0xc0ffee::m::test_rgb_first_out
+
+//# run 0xc0ffee::m::test_rgb_second_mismatch
+
+//# run 0xc0ffee::m::test_rgb_tuple_out
+
+//# run 0xc0ffee::m::test_gray_high_low
+
+//# run 0xc0ffee::m::test_gray_high_tuple_out
+
+//# run 0xc0ffee::m::test_gray_low
+
+//# run 0xc0ffee::m::test_named

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/match_extensions/round-trip/range_mixed_tuple_enum.decompiled.baseline.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/match_extensions/round-trip/range_mixed_tuple_enum.decompiled.baseline.exp
@@ -1,0 +1,18 @@
+processed 9 tasks
+task 0 lines 3-90:  publish [module 0xc0ffee::m {]
+task 1 lines 93-93:  run 0xc0ffee::m::test_rgb_all_match
+return values: 1
+task 2 lines 95-95:  run 0xc0ffee::m::test_rgb_first_out
+return values: 2
+task 3 lines 97-97:  run 0xc0ffee::m::test_rgb_second_mismatch
+return values: 2
+task 4 lines 99-99:  run 0xc0ffee::m::test_rgb_tuple_out
+return values: 2
+task 5 lines 101-101:  run 0xc0ffee::m::test_gray_high_low
+return values: 3
+task 6 lines 103-103:  run 0xc0ffee::m::test_gray_high_tuple_out
+return values: 4
+task 7 lines 105-105:  run 0xc0ffee::m::test_gray_low
+return values: 4
+task 8 lines 107-107:  run 0xc0ffee::m::test_named
+return values: 5

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/match_extensions/round-trip/range_mixed_with_literals.decompiled
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/match_extensions/round-trip/range_mixed_with_literals.decompiled
@@ -1,0 +1,67 @@
+//**** Cross-compiled for `move` syntax from `tests/no-v1-comparison/match_extensions/range_mixed_with_literals.move`
+
+//# publish
+module 0xc0ffee::m {
+    public fun test_literal_sandwich(p0: u8): u64 {
+        'l0: loop {
+            loop {
+                if (!(p0 == 0u8)) {
+                    let _v0;
+                    if (p0 >= 1u8) _v0 = p0 <= 254u8 else _v0 = false;
+                    if (_v0) break;
+                    if (p0 == MAX_U8) break 'l0;
+                    abort 14566554180833181697
+                };
+                return 1
+            };
+            return 2
+        };
+        3
+    }
+    public fun test_mixed(p0: u64): u64 {
+        'l1: loop {
+            'l2: loop {
+                'l0: loop {
+                    loop {
+                        if (!(p0 == 0)) {
+                            let _v0;
+                            let _v1;
+                            if (p0 >= 1) _v0 = p0 < 10 else _v0 = false;
+                            if (_v0) break;
+                            if (p0 == 10) break 'l0;
+                            if (p0 >= 11) _v1 = p0 < 100 else _v1 = false;
+                            if (!_v1) break 'l1;
+                            break 'l2
+                        };
+                        return 1
+                    };
+                    return 2
+                };
+                return 3
+            };
+            return 4
+        };
+        5
+    }
+}
+
+
+//# run 0xc0ffee::m::test_mixed --args 0u64
+
+//# run 0xc0ffee::m::test_mixed --args 1u64
+
+//# run 0xc0ffee::m::test_mixed --args 5u64
+
+//# run 0xc0ffee::m::test_mixed --args 9u64
+
+//# run 0xc0ffee::m::test_mixed --args 10u64
+
+//# run 0xc0ffee::m::test_mixed --args 50u64
+
+//# run 0xc0ffee::m::test_mixed --args 100u64
+
+//# run 0xc0ffee::m::test_literal_sandwich --args 0u8
+
+//# run 0xc0ffee::m::test_literal_sandwich --args 128u8
+
+//# run 0xc0ffee::m::test_literal_sandwich --args 255u8

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/match_extensions/round-trip/range_mixed_with_literals.decompiled.baseline.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/match_extensions/round-trip/range_mixed_with_literals.decompiled.baseline.exp
@@ -1,0 +1,22 @@
+processed 11 tasks
+task 0 lines 3-46:  publish [module 0xc0ffee::m {]
+task 1 lines 49-49:  run 0xc0ffee::m::test_mixed --args 0u64
+return values: 1
+task 2 lines 51-51:  run 0xc0ffee::m::test_mixed --args 1u64
+return values: 2
+task 3 lines 53-53:  run 0xc0ffee::m::test_mixed --args 5u64
+return values: 2
+task 4 lines 55-55:  run 0xc0ffee::m::test_mixed --args 9u64
+return values: 2
+task 5 lines 57-57:  run 0xc0ffee::m::test_mixed --args 10u64
+return values: 3
+task 6 lines 59-59:  run 0xc0ffee::m::test_mixed --args 50u64
+return values: 4
+task 7 lines 61-61:  run 0xc0ffee::m::test_mixed --args 100u64
+return values: 5
+task 8 lines 63-63:  run 0xc0ffee::m::test_literal_sandwich --args 0u8
+return values: 1
+task 9 lines 65-65:  run 0xc0ffee::m::test_literal_sandwich --args 128u8
+return values: 2
+task 10 lines 67-67:  run 0xc0ffee::m::test_literal_sandwich --args 255u8
+return values: 3

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/match_extensions/round-trip/range_signed_types.decompiled
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/match_extensions/round-trip/range_signed_types.decompiled
@@ -1,0 +1,163 @@
+//**** Cross-compiled for `move` syntax from `tests/no-v1-comparison/match_extensions/range_signed_types.move`
+
+//# publish
+module 0xc0ffee::m {
+    public fun test_i128(p0: i128): u64 {
+        let _v0;
+        let _v1;
+        if (p0 >= -100i128) _v1 = p0 < 0i128 else _v1 = false;
+        loop {
+            if (!_v1) {
+                let _v2;
+                if (p0 >= 0i128) _v2 = p0 <= 100i128 else _v2 = false;
+                if (_v2) {
+                    _v0 = 2;
+                    break
+                };
+                _v0 = 0;
+                break
+            };
+            return 1
+        };
+        _v0
+    }
+    public fun test_i16(p0: i16): u64 {
+        let _v0;
+        let _v1;
+        if (p0 >= -1000i16) _v1 = p0 < 0i16 else _v1 = false;
+        loop {
+            if (!_v1) {
+                let _v2;
+                if (p0 >= 0i16) _v2 = p0 <= 1000i16 else _v2 = false;
+                if (_v2) {
+                    _v0 = 2;
+                    break
+                };
+                _v0 = 0;
+                break
+            };
+            return 1
+        };
+        _v0
+    }
+    public fun test_i256(p0: i256): u64 {
+        let _v0;
+        let _v1;
+        if (p0 >= -100i256) _v1 = p0 < 0i256 else _v1 = false;
+        loop {
+            if (!_v1) {
+                let _v2;
+                if (p0 >= 0i256) _v2 = p0 <= 100i256 else _v2 = false;
+                if (_v2) {
+                    _v0 = 2;
+                    break
+                };
+                _v0 = 0;
+                break
+            };
+            return 1
+        };
+        _v0
+    }
+    public fun test_i32(p0: i32): u64 {
+        let _v0;
+        let _v1;
+        if (p0 >= -100i32) _v1 = p0 < 0i32 else _v1 = false;
+        loop {
+            if (!_v1) {
+                let _v2;
+                if (p0 >= 0i32) _v2 = p0 <= 100i32 else _v2 = false;
+                if (_v2) {
+                    _v0 = 2;
+                    break
+                };
+                _v0 = 0;
+                break
+            };
+            return 1
+        };
+        _v0
+    }
+    public fun test_i64(p0: i64): u64 {
+        let _v0;
+        let _v1;
+        if (p0 >= -100i64) _v1 = p0 < 0i64 else _v1 = false;
+        loop {
+            if (!_v1) {
+                let _v2;
+                if (p0 >= 0i64) _v2 = p0 <= 100i64 else _v2 = false;
+                if (_v2) {
+                    _v0 = 2;
+                    break
+                };
+                _v0 = 0;
+                break
+            };
+            return 1
+        };
+        _v0
+    }
+    public fun test_i8_cross_zero(p0: i8): u64 {
+        let _v0;
+        if (p0 >= -5i8) _v0 = p0 < 5i8 else _v0 = false;
+        if (_v0) return 1;
+        0
+    }
+    public fun test_i8_negative(p0: i8): u64 {
+        let _v0;
+        if (p0 >= -100i8) _v0 = p0 < -50i8 else _v0 = false;
+        if (_v0) return 1;
+        0
+    }
+}
+
+
+//# run 0xc0ffee::m::test_i8_cross_zero --args -5i8
+
+//# run 0xc0ffee::m::test_i8_cross_zero --args 0i8
+
+//# run 0xc0ffee::m::test_i8_cross_zero --args 4i8
+
+//# run 0xc0ffee::m::test_i8_cross_zero --args 5i8
+
+//# run 0xc0ffee::m::test_i8_negative --args -100i8
+
+//# run 0xc0ffee::m::test_i8_negative --args -75i8
+
+//# run 0xc0ffee::m::test_i8_negative --args -50i8
+
+//# run 0xc0ffee::m::test_i8_negative --args -49i8
+
+//# run 0xc0ffee::m::test_i16 --args -500i16
+
+//# run 0xc0ffee::m::test_i16 --args 0i16
+
+//# run 0xc0ffee::m::test_i16 --args 500i16
+
+//# run 0xc0ffee::m::test_i16 --args 2000i16
+
+//# run 0xc0ffee::m::test_i32 --args -50i32
+
+//# run 0xc0ffee::m::test_i32 --args 0i32
+
+//# run 0xc0ffee::m::test_i32 --args 50i32
+
+//# run 0xc0ffee::m::test_i32 --args 200i32
+
+//# run 0xc0ffee::m::test_i64 --args -50i64
+
+//# run 0xc0ffee::m::test_i64 --args 0i64
+
+//# run 0xc0ffee::m::test_i64 --args 50i64
+
+//# run 0xc0ffee::m::test_i128 --args -50i128
+
+//# run 0xc0ffee::m::test_i128 --args 0i128
+
+//# run 0xc0ffee::m::test_i128 --args 50i128
+
+//# run 0xc0ffee::m::test_i256 --args -50i256
+
+//# run 0xc0ffee::m::test_i256 --args 0i256
+
+//# run 0xc0ffee::m::test_i256 --args 50i256

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/match_extensions/round-trip/range_signed_types.decompiled.baseline.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/match_extensions/round-trip/range_signed_types.decompiled.baseline.exp
@@ -1,0 +1,52 @@
+processed 26 tasks
+task 0 lines 3-112:  publish [module 0xc0ffee::m {]
+task 1 lines 115-115:  run 0xc0ffee::m::test_i8_cross_zero --args -5i8
+return values: 1
+task 2 lines 117-117:  run 0xc0ffee::m::test_i8_cross_zero --args 0i8
+return values: 1
+task 3 lines 119-119:  run 0xc0ffee::m::test_i8_cross_zero --args 4i8
+return values: 1
+task 4 lines 121-121:  run 0xc0ffee::m::test_i8_cross_zero --args 5i8
+return values: 0
+task 5 lines 123-123:  run 0xc0ffee::m::test_i8_negative --args -100i8
+return values: 1
+task 6 lines 125-125:  run 0xc0ffee::m::test_i8_negative --args -75i8
+return values: 1
+task 7 lines 127-127:  run 0xc0ffee::m::test_i8_negative --args -50i8
+return values: 0
+task 8 lines 129-129:  run 0xc0ffee::m::test_i8_negative --args -49i8
+return values: 0
+task 9 lines 131-131:  run 0xc0ffee::m::test_i16 --args -500i16
+return values: 1
+task 10 lines 133-133:  run 0xc0ffee::m::test_i16 --args 0i16
+return values: 2
+task 11 lines 135-135:  run 0xc0ffee::m::test_i16 --args 500i16
+return values: 2
+task 12 lines 137-137:  run 0xc0ffee::m::test_i16 --args 2000i16
+return values: 0
+task 13 lines 139-139:  run 0xc0ffee::m::test_i32 --args -50i32
+return values: 1
+task 14 lines 141-141:  run 0xc0ffee::m::test_i32 --args 0i32
+return values: 2
+task 15 lines 143-143:  run 0xc0ffee::m::test_i32 --args 50i32
+return values: 2
+task 16 lines 145-145:  run 0xc0ffee::m::test_i32 --args 200i32
+return values: 0
+task 17 lines 147-147:  run 0xc0ffee::m::test_i64 --args -50i64
+return values: 1
+task 18 lines 149-149:  run 0xc0ffee::m::test_i64 --args 0i64
+return values: 2
+task 19 lines 151-151:  run 0xc0ffee::m::test_i64 --args 50i64
+return values: 2
+task 20 lines 153-153:  run 0xc0ffee::m::test_i128 --args -50i128
+return values: 1
+task 21 lines 155-155:  run 0xc0ffee::m::test_i128 --args 0i128
+return values: 2
+task 22 lines 157-157:  run 0xc0ffee::m::test_i128 --args 50i128
+return values: 2
+task 23 lines 159-159:  run 0xc0ffee::m::test_i256 --args -50i256
+return values: 1
+task 24 lines 161-161:  run 0xc0ffee::m::test_i256 --args 0i256
+return values: 2
+task 25 lines 163-163:  run 0xc0ffee::m::test_i256 --args 50i256
+return values: 2

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/match_extensions/round-trip/range_with_guards.decompiled
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/match_extensions/round-trip/range_with_guards.decompiled
@@ -1,0 +1,94 @@
+//**** Cross-compiled for `move` syntax from `tests/no-v1-comparison/match_extensions/range_with_guards.move`
+
+//# publish
+module 0xc0ffee::m {
+    enum E has drop {
+        V1 {
+            _0: u64,
+        }
+        V2,
+    }
+    fun enum_range_guard(p0: E, p1: bool): u64 {
+        let _v0 = &p0;
+        loop {
+            let _v1;
+            let _v2;
+            if (_v0 is V1) {
+                let _v3;
+                _v2 = &_v0._0;
+                if (*_v2 >= 0) _v3 = *_v2 < 100 else _v3 = false;
+                if (_v3) _v1 = p1 else _v1 = false;
+                if (_v1) break
+            };
+            loop {
+                if (_v0 is V1) {
+                    _v2 = &_v0._0;
+                    if (*_v2 >= 0) _v1 = *_v2 < 100 else _v1 = false;
+                    if (_v1) break
+                };
+                loop {
+                    if (!(_v0 is V1)) {
+                        if (_v0 is V2) break;
+                        abort 14566554180833181697
+                    };
+                    let E::V1{_0: _v4} = p0;
+                    return 3
+                };
+                let E::V2{} = p0;
+                return 4
+            };
+            let E::V1{_0: _v5} = p0;
+            return 2
+        };
+        let E::V1{_0: _v6} = p0;
+        1
+    }
+    public fun test_enum_guard_false(): u64 {
+        enum_range_guard(E::V1{_0: 50}, false)
+    }
+    public fun test_enum_guard_true(): u64 {
+        enum_range_guard(E::V1{_0: 50}, true)
+    }
+    public fun test_enum_out_of_range(): u64 {
+        enum_range_guard(E::V1{_0: 200}, true)
+    }
+    public fun test_enum_v2(): u64 {
+        enum_range_guard(E::V2{}, true)
+    }
+    public fun test_range_with_guard(p0: u64, p1: bool): u64 {
+        let _v0;
+        let _v1;
+        let _v2;
+        if (p0 >= 1) _v2 = p0 < 10 else _v2 = false;
+        if (_v2) _v1 = p1 else _v1 = false;
+        loop {
+            if (!_v1) {
+                let _v3;
+                if (p0 >= 1) _v3 = p0 < 10 else _v3 = false;
+                if (_v3) {
+                    _v0 = 2;
+                    break
+                };
+                _v0 = 0;
+                break
+            };
+            return 1
+        };
+        _v0
+    }
+}
+
+
+//# run 0xc0ffee::m::test_range_with_guard --args 5u64 true
+
+//# run 0xc0ffee::m::test_range_with_guard --args 5u64 false
+
+//# run 0xc0ffee::m::test_range_with_guard --args 50u64 true
+
+//# run 0xc0ffee::m::test_enum_guard_true
+
+//# run 0xc0ffee::m::test_enum_guard_false
+
+//# run 0xc0ffee::m::test_enum_out_of_range
+
+//# run 0xc0ffee::m::test_enum_v2

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/match_extensions/round-trip/range_with_guards.decompiled.baseline.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/match_extensions/round-trip/range_with_guards.decompiled.baseline.exp
@@ -1,0 +1,16 @@
+processed 8 tasks
+task 0 lines 3-79:  publish [module 0xc0ffee::m {]
+task 1 lines 82-82:  run 0xc0ffee::m::test_range_with_guard --args 5u64 true
+return values: 1
+task 2 lines 84-84:  run 0xc0ffee::m::test_range_with_guard --args 5u64 false
+return values: 2
+task 3 lines 86-86:  run 0xc0ffee::m::test_range_with_guard --args 50u64 true
+return values: 0
+task 4 lines 88-88:  run 0xc0ffee::m::test_enum_guard_true
+return values: 1
+task 5 lines 90-90:  run 0xc0ffee::m::test_enum_guard_false
+return values: 2
+task 6 lines 92-92:  run 0xc0ffee::m::test_enum_out_of_range
+return values: 3
+task 7 lines 94-94:  run 0xc0ffee::m::test_enum_v2
+return values: 4

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/match_extensions/round-trip/range_with_ref.decompiled
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/match_extensions/round-trip/range_with_ref.decompiled
@@ -1,0 +1,76 @@
+//**** Cross-compiled for `move` syntax from `tests/no-v1-comparison/match_extensions/range_with_ref.move`
+
+//# publish
+module 0xc0ffee::m {
+    enum E has copy, drop {
+        V1 {
+            _0: u64,
+        }
+        V2,
+    }
+    fun ref_enum_range(p0: &E): u64 {
+        loop {
+            if (p0 is V1) {
+                let _v0;
+                let _v1 = &p0._0;
+                if (*_v1 >= 0) _v0 = *_v1 < 5 else _v0 = false;
+                if (_v0) break
+            };
+            loop {
+                if (!(p0 is V1)) {
+                    if (p0 is V2) break;
+                    abort 14566554180833181697
+                };
+                return 2
+            };
+            return 3
+        };
+        1
+    }
+    public fun test_mut_ref_range(p0: u64): u64 {
+        let _v0;
+        let _v1 = p0;
+        let _v2 = &mut _v1;
+        if (*_v2 >= 1) _v0 = *_v2 < 10 else _v0 = false;
+        if (_v0) return 1;
+        0
+    }
+    public fun test_ref_enum_in_range(): u64 {
+        let _v0 = E::V1{_0: 3};
+        ref_enum_range(&_v0)
+    }
+    public fun test_ref_enum_out_range(): u64 {
+        let _v0 = E::V1{_0: 10};
+        ref_enum_range(&_v0)
+    }
+    public fun test_ref_enum_v2(): u64 {
+        let _v0 = E::V2{};
+        ref_enum_range(&_v0)
+    }
+    public fun test_ref_range(p0: u64): u64 {
+        let _v0;
+        let _v1 = &p0;
+        if (*_v1 >= 1) _v0 = *_v1 < 10 else _v0 = false;
+        if (_v0) return 1;
+        0
+    }
+}
+
+
+//# run 0xc0ffee::m::test_ref_range --args 0u64
+
+//# run 0xc0ffee::m::test_ref_range --args 5u64
+
+//# run 0xc0ffee::m::test_ref_range --args 10u64
+
+//# run 0xc0ffee::m::test_ref_enum_in_range
+
+//# run 0xc0ffee::m::test_ref_enum_out_range
+
+//# run 0xc0ffee::m::test_ref_enum_v2
+
+//# run 0xc0ffee::m::test_mut_ref_range --args 0u64
+
+//# run 0xc0ffee::m::test_mut_ref_range --args 5u64
+
+//# run 0xc0ffee::m::test_mut_ref_range --args 10u64

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/match_extensions/round-trip/range_with_ref.decompiled.baseline.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/match_extensions/round-trip/range_with_ref.decompiled.baseline.exp
@@ -1,0 +1,20 @@
+processed 10 tasks
+task 0 lines 3-57:  publish [module 0xc0ffee::m {]
+task 1 lines 60-60:  run 0xc0ffee::m::test_ref_range --args 0u64
+return values: 0
+task 2 lines 62-62:  run 0xc0ffee::m::test_ref_range --args 5u64
+return values: 1
+task 3 lines 64-64:  run 0xc0ffee::m::test_ref_range --args 10u64
+return values: 0
+task 4 lines 66-66:  run 0xc0ffee::m::test_ref_enum_in_range
+return values: 1
+task 5 lines 68-68:  run 0xc0ffee::m::test_ref_enum_out_range
+return values: 2
+task 6 lines 70-70:  run 0xc0ffee::m::test_ref_enum_v2
+return values: 3
+task 7 lines 72-72:  run 0xc0ffee::m::test_mut_ref_range --args 0u64
+return values: 0
+task 8 lines 74-74:  run 0xc0ffee::m::test_mut_ref_range --args 5u64
+return values: 1
+task 9 lines 76-76:  run 0xc0ffee::m::test_mut_ref_range --args 10u64
+return values: 0

--- a/third_party/move/move-model/src/ast.rs
+++ b/third_party/move/move-model/src/ast.rs
@@ -2727,6 +2727,9 @@ pub enum Pattern {
     ),
     /// A literal value pattern (for matching literal constants)
     LiteralValue(NodeId, Value),
+    /// A range pattern: Range(id, lo, hi, inclusive_upper)
+    /// lo..hi, lo..=hi, lo.., ..hi, ..=hi, ..
+    Range(NodeId, Option<Value>, Option<Value>, bool),
     Error(NodeId),
 }
 
@@ -2739,6 +2742,7 @@ impl Pattern {
             | Pattern::Tuple(id, _)
             | Pattern::Struct(id, _, _, _)
             | Pattern::LiteralValue(id, _)
+            | Pattern::Range(id, _, _, _)
             | Pattern::Error(id) => *id,
         }
     }
@@ -2765,6 +2769,9 @@ impl Pattern {
                         .all(|(p1, p2)| p1.structural_eq(p2))
             },
             (Pattern::LiteralValue(_, v1), Pattern::LiteralValue(_, v2)) => v1 == v2,
+            (Pattern::Range(_, lo1, hi1, inc1), Pattern::Range(_, lo2, hi2, inc2)) => {
+                lo1 == lo2 && hi1 == hi2 && inc1 == inc2
+            },
             (Pattern::Error(_), Pattern::Error(_)) => true,
             _ => false,
         }
@@ -2800,7 +2807,7 @@ impl Pattern {
     pub fn has_no_struct(&self) -> bool {
         use Pattern::*;
         match self {
-            Var(..) | Wildcard(..) | LiteralValue(..) | Error(..) => true,
+            Var(..) | Wildcard(..) | LiteralValue(..) | Range(..) | Error(..) => true,
             Tuple(_, pats) => pats.iter().all(|p| p.has_no_struct()),
             Struct(..) => false,
         }
@@ -3027,7 +3034,10 @@ impl Pattern {
                     .map(|pat| pat.remove_vars(vars))
                     .collect(),
             ),
-            Pattern::Error(..) | Pattern::Wildcard(..) | Pattern::LiteralValue(..) => self,
+            Pattern::Error(..)
+            | Pattern::Wildcard(..)
+            | Pattern::LiteralValue(..)
+            | Pattern::Range(..) => self,
         }
     }
 
@@ -3074,7 +3084,10 @@ impl Pattern {
                     None
                 }
             },
-            Pattern::Error(..) | Pattern::Wildcard(..) | Pattern::LiteralValue(..) => None,
+            Pattern::Error(..)
+            | Pattern::Wildcard(..)
+            | Pattern::LiteralValue(..)
+            | Pattern::Range(..) => None,
         }
     }
 
@@ -3088,7 +3101,7 @@ impl Pattern {
         use Pattern::*;
         visitor(false, self);
         match self {
-            Var(..) | Wildcard(..) | LiteralValue(..) | Error(..) => {},
+            Var(..) | Wildcard(..) | LiteralValue(..) | Range(..) | Error(..) => {},
             Tuple(_, patvec) => {
                 for pat in patvec {
                     pat.visit_pre_post(visitor);
@@ -3241,6 +3254,19 @@ impl PatDisplay<'_> {
             LiteralValue(_, val) => {
                 write!(f, "{}", self.env.display(val))?;
             },
+            Range(_, lo, hi, inclusive) => {
+                if let Some(l) = lo {
+                    write!(f, "{}", self.env.display(l))?;
+                }
+                if *inclusive {
+                    write!(f, "..=")?;
+                } else {
+                    write!(f, "..")?;
+                }
+                if let Some(h) = hi {
+                    write!(f, "{}", self.env.display(h))?;
+                }
+            },
             Error(_) => write!(f, "Pattern::Error")?,
         }
         if self.show_type && !showed_type {
@@ -3295,6 +3321,15 @@ pub enum Value {
 }
 
 impl Value {
+    /// If this is a `Number`, return the contained `BigInt`; otherwise `None`.
+    pub fn to_bigint(&self) -> Option<BigInt> {
+        if let Value::Number(n) = self {
+            Some(n.clone())
+        } else {
+            None
+        }
+    }
+
     /// Implement an equality relation on values which identifies representations which
     /// implement the same runtime value, assuming that types match.
     ///

--- a/third_party/move/move-model/src/builder/exp_builder.rs
+++ b/third_party/move/move-model/src/builder/exp_builder.rs
@@ -2935,7 +2935,14 @@ impl ExpTranslator<'_, '_, '_> {
             EA::LValue_::Range(lo_val, hi_val, inclusive) => {
                 // Translate range pattern. Strip reference from expected type.
                 let inner_expected = expected_type.skip_reference();
-                // Range patterns only allowed on integer types.
+                // Range patterns only allowed on concrete integer types.
+                // Reject PrimitiveType::Num (unresolved spec numeric supertype)
+                // because get_min_value/get_max_value return None for it,
+                // which would silently disable range bound validation.
+                if matches!(inner_expected, Type::Primitive(PrimitiveType::Num)) {
+                    self.error(loc, "range patterns require a concrete integer type");
+                    return self.new_error_pat(loc);
+                }
                 if !inner_expected.is_number() {
                     self.error(
                         loc,

--- a/third_party/move/move-model/src/builder/exp_builder.rs
+++ b/third_party/move/move-model/src/builder/exp_builder.rs
@@ -2932,6 +2932,42 @@ impl ExpTranslator<'_, '_, '_> {
                     self.new_error_pat(loc)
                 }
             },
+            EA::LValue_::Range(lo_val, hi_val, inclusive) => {
+                // Translate range pattern. Strip reference from expected type.
+                let inner_expected = expected_type.skip_reference();
+                // Range patterns only allowed on integer types.
+                if !inner_expected.is_number() {
+                    self.error(
+                        loc,
+                        &format!(
+                            "range patterns are only allowed on integer types, found `{}`",
+                            inner_expected.display(&self.type_display_context())
+                        ),
+                    );
+                    return self.new_error_pat(loc);
+                }
+                let lo = lo_val
+                    .as_ref()
+                    .map(|v| self.translate_value(v, inner_expected, context));
+                let hi = hi_val
+                    .as_ref()
+                    .map(|v| self.translate_value(v, inner_expected, context));
+                // Check if any bound translation failed.
+                if lo.as_ref().is_some_and(|r| r.is_none())
+                    || hi.as_ref().is_some_and(|r| r.is_none())
+                {
+                    return self.new_error_pat(loc);
+                }
+                let lo_value = lo.and_then(|r| r.map(|(v, _)| v));
+                let hi_value = hi.and_then(|r| r.map(|(v, _)| v));
+                let pat_ty = if expected_type.is_reference() {
+                    expected_type.clone()
+                } else {
+                    inner_expected.clone()
+                };
+                let id = self.new_node_id_with_type_loc(&pat_ty, loc);
+                Pattern::Range(id, lo_value, hi_value, *inclusive)
+            },
         }
     }
 

--- a/third_party/move/move-model/src/sourcifier.rs
+++ b/third_party/move/move-model/src/sourcifier.rs
@@ -3213,6 +3213,20 @@ impl<'a> ExpSourcifier<'a> {
                 let ty = self.env().get_node_type(*node_id);
                 self.parent.print_value(val, Some(&ty), self.for_spec);
             },
+            Pattern::Range(node_id, lo, hi, inclusive) => {
+                let ty = self.env().get_node_type(*node_id);
+                if let Some(l) = lo {
+                    self.parent.print_value(l, Some(&ty), self.for_spec);
+                }
+                if *inclusive {
+                    emit!(self.wr(), "..=");
+                } else {
+                    emit!(self.wr(), "..");
+                }
+                if let Some(h) = hi {
+                    self.parent.print_value(h, Some(&ty), self.for_spec);
+                }
+            },
             Pattern::Error(_) => emit!(self.wr(), "*error*"),
         }
     }

--- a/third_party/move/move-model/src/sourcifier.rs
+++ b/third_party/move/move-model/src/sourcifier.rs
@@ -3211,12 +3211,14 @@ impl<'a> ExpSourcifier<'a> {
             },
             Pattern::LiteralValue(node_id, val) => {
                 let ty = self.env().get_node_type(*node_id);
-                self.parent.print_value(val, Some(&ty), self.for_spec);
+                let ty = ty.skip_reference();
+                self.parent.print_value(val, Some(ty), self.for_spec);
             },
             Pattern::Range(node_id, lo, hi, inclusive) => {
                 let ty = self.env().get_node_type(*node_id);
+                let ty = ty.skip_reference();
                 if let Some(l) = lo {
-                    self.parent.print_value(l, Some(&ty), self.for_spec);
+                    self.parent.print_value(l, Some(ty), self.for_spec);
                 }
                 if *inclusive {
                     emit!(self.wr(), "..=");
@@ -3224,7 +3226,7 @@ impl<'a> ExpSourcifier<'a> {
                     emit!(self.wr(), "..");
                 }
                 if let Some(h) = hi {
-                    self.parent.print_value(h, Some(&ty), self.for_spec);
+                    self.parent.print_value(h, Some(ty), self.for_spec);
                 }
             },
             Pattern::Error(_) => emit!(self.wr(), "*error*"),


### PR DESCRIPTION
## Description

In this PR, we add integer range pattern support in `match` expressions for Move (2.4+). `match` arms can now use range patterns (`1..10`, `1..=10`, `..10`, `-5..`) wherever literals can be used, including at the top level, inside tuples, and nested within struct/enum patterns. We also validate ranges, performs exhaustiveness and unreachable-arm checking. The ranges are desugared into equivalent comparisons.

An example of what you can do with the new range support:
```move
module 0x42::palette {
    enum Color has drop {
        RGB(u8, u8, u8),
        Yellow,
    }

    fun describe(c: &Color): vector<u8> {
        match (c) { // note that this works even though `c` is a reference
            Color::RGB(200.., 0..=60, 0..=60) => b"strong red",
            Color::RGB(0..=60, 200.., 0..=60) => b"strong green",
            Color::RGB(0..=60, 0..=60, 200..) => b"strong blue",
            Color::RGB(_, _, _) => b"other rgb",
            Color::Yellow => b"yellow",
        }
    }
}
```

## How Has This Been Tested?

Added lots of new tests for range checks, typing, coverage and exhaustiveness, end-to-end.

## Type of Change
- [x] New feature

## Which Components or Systems Does This Change Impact?
- [x] Move Compiler

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Adds a new pattern kind and substantially changes parsing, match desugaring, and exhaustiveness/reachability analysis; bugs here can miscompile matches or produce incorrect diagnostics.
> 
> **Overview**
> Adds a new `Range` pattern across the parser, legacy expansion AST, and Move model AST, including lexer support for the `..=` token and pretty-print/debug output.
> 
> Implements range-pattern semantics in the compiler pipeline: validates bounds and rejects invalid forms, lowers ranges to comparison guards during `match` transforms (including nested struct/enum patterns and reference discriminators), and updates match coverage/unreachable-arm checking to use interval arithmetic (treating literals as `[n, n+1)`), producing improved witness diagnostics. Extensive new unit and transactional tests cover parsing, typing/feature-gating, transforms, and coverage behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ddb680047eb95d1e815e1ff2795b141ba42fa16. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->