### PR TITLE
[tests] Optimize aptos-api test suite

### DIFF
--- a/api/src/tests/event_v2_translation_test.rs
+++ b/api/src/tests/event_v2_translation_test.rs
@@ -85,7 +85,6 @@ fn rotate_authentication_key_payload(
     use_txn_payload_v2_format,
     use_orderless_transactions,
     case(false, false),
-    case(true, false),
     case(true, true)
 )]
 async fn test_event_v2_translation_account_key_rotation_event(
@@ -287,7 +286,6 @@ fn check_for_event_v2_translation_token_objects(
     use_txn_payload_v2_format,
     use_orderless_transactions,
     case(false, false),
-    case(true, false),
     case(true, true)
 )]
 async fn test_event_v2_translation_token_objects(

--- a/api/src/tests/events_test.rs
+++ b/api/src/tests/events_test.rs
@@ -13,19 +13,8 @@ static ACCOUNT_ADDRESS: &str = "0xa550c18";
 static CREATION_NUMBER: &str = "0";
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-#[rstest(
-    use_txn_payload_v2_format,
-    use_orderless_transactions,
-    case(false, false),
-    case(true, false),
-    case(true, true)
-)]
-async fn test_get_events(use_txn_payload_v2_format: bool, use_orderless_transactions: bool) {
-    let mut context = new_test_context_with_orderless_flags(
-        current_function_name!(),
-        use_txn_payload_v2_format,
-        use_orderless_transactions,
-    );
+async fn test_get_events() {
+    let mut context = new_test_context_with_orderless_flags(current_function_name!(), false, false);
 
     let resp = context
         .get(format!("/accounts/{}/events/{}", ACCOUNT_ADDRESS, CREATION_NUMBER).as_str())
@@ -35,22 +24,8 @@ async fn test_get_events(use_txn_payload_v2_format: bool, use_orderless_transact
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-#[rstest(
-    use_txn_payload_v2_format,
-    use_orderless_transactions,
-    case(false, false),
-    case(true, false),
-    case(true, true)
-)]
-async fn test_get_events_filter_by_start_sequence_number(
-    use_txn_payload_v2_format: bool,
-    use_orderless_transactions: bool,
-) {
-    let mut context = new_test_context_with_orderless_flags(
-        current_function_name!(),
-        use_txn_payload_v2_format,
-        use_orderless_transactions,
-    );
+async fn test_get_events_filter_by_start_sequence_number() {
+    let mut context = new_test_context_with_orderless_flags(current_function_name!(), false, false);
 
     let resp = context
         .get(
@@ -64,11 +39,8 @@ async fn test_get_events_filter_by_start_sequence_number(
     context.check_golden_output(resp.clone());
 
     // assert the same resp after db sharding migration with internal indexer turned on
-    let shard_context = new_test_context_with_orderless_flags(
-        current_function_name!(),
-        use_txn_payload_v2_format,
-        use_orderless_transactions,
-    );
+    let shard_context =
+        new_test_context_with_orderless_flags(current_function_name!(), false, false);
     let new_resp = shard_context
         .get(
             format!(
@@ -192,7 +164,6 @@ async fn test_get_events_by_invalid_account_event_handle_field_type() {
     use_txn_payload_v2_format,
     use_orderless_transactions,
     case(false, false),
-    case(true, false),
     case(true, true)
 )]
 async fn test_module_events(use_txn_payload_v2_format: bool, use_orderless_transactions: bool) {

--- a/api/src/tests/function_value_test.rs
+++ b/api/src/tests/function_value_test.rs
@@ -3,24 +3,12 @@
 
 use super::new_test_context_with_orderless_flags;
 use aptos_api_test_context::{current_function_name, TestContext};
-use rstest::rstest;
 use serde_json::json;
 use std::path::PathBuf;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-#[rstest(
-    use_txn_payload_v2_format,
-    use_orderless_transactions,
-    case(false, false),
-    case(true, false),
-    case(true, true)
-)]
-async fn test_function_values(use_txn_payload_v2_format: bool, use_orderless_transactions: bool) {
-    let mut context = new_test_context_with_orderless_flags(
-        current_function_name!(),
-        use_txn_payload_v2_format,
-        use_orderless_transactions,
-    );
+async fn test_function_values() {
+    let mut context = new_test_context_with_orderless_flags(current_function_name!(), false, false);
     let mut account = context.create_account().await;
     let account_addr = account.address();
 
@@ -95,22 +83,8 @@ async fn test_function_values(use_txn_payload_v2_format: bool, use_orderless_tra
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-#[rstest(
-    use_txn_payload_v2_format,
-    use_orderless_transactions,
-    case(false, false),
-    case(true, false),
-    case(true, true)
-)]
-async fn test_function_values_with_references(
-    use_txn_payload_v2_format: bool,
-    use_orderless_transactions: bool,
-) {
-    let mut context = new_test_context_with_orderless_flags(
-        current_function_name!(),
-        use_txn_payload_v2_format,
-        use_orderless_transactions,
-    );
+async fn test_function_values_with_references() {
+    let mut context = new_test_context_with_orderless_flags(current_function_name!(), false, false);
     let mut account = context.create_account().await;
     let addr = account.address();
 
@@ -138,22 +112,8 @@ async fn test_function_values_with_references(
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-#[rstest(
-    use_txn_payload_v2_format,
-    use_orderless_transactions,
-    case(false, false),
-    case(true, false),
-    case(true, true)
-)]
-async fn test_function_values_with_captured_struct(
-    use_txn_payload_v2_format: bool,
-    use_orderless_transactions: bool,
-) {
-    let mut context = new_test_context_with_orderless_flags(
-        current_function_name!(),
-        use_txn_payload_v2_format,
-        use_orderless_transactions,
-    );
+async fn test_function_values_with_captured_struct() {
+    let mut context = new_test_context_with_orderless_flags(current_function_name!(), false, false);
     let mut account = context.create_account().await;
     let addr = account.address();
 

--- a/api/src/tests/invalid_post_request_test.rs
+++ b/api/src/tests/invalid_post_request_test.rs
@@ -3,200 +3,129 @@
 
 use super::new_test_context_with_orderless_flags;
 use aptos_api_test_context::{current_function_name, TestContext};
-use rstest::rstest;
 use serde_json::{json, Value};
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-#[rstest(use_orderless_transactions, case(false), case(true))]
-async fn test_invalid_type_argument_data_type(use_orderless_transactions: bool) {
-    let context = new_test_context_with_orderless_flags(
-        current_function_name!(),
-        true,
-        use_orderless_transactions,
-    );
-    let mut req = signing_message_request(context.use_orderless_transactions);
+async fn test_invalid_type_argument_data_type() {
+    let context = new_test_context_with_orderless_flags(current_function_name!(), false, false);
+    let mut req = signing_message_request(false);
     req["payload"]["type_arguments"] = json!([true]);
 
     response_error_msg(req, context).await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-#[rstest(use_orderless_transactions, case(false), case(true))]
-async fn test_invalid_entry_function_argument_data_type(use_orderless_transactions: bool) {
-    let context = new_test_context_with_orderless_flags(
-        current_function_name!(),
-        true,
-        use_orderless_transactions,
-    );
-    let mut req = signing_message_request(context.use_orderless_transactions);
+async fn test_invalid_entry_function_argument_data_type() {
+    let context = new_test_context_with_orderless_flags(current_function_name!(), false, false);
+    let mut req = signing_message_request(false);
     req["payload"]["arguments"][0] = json!(true);
 
     response_error_msg(req, context).await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-#[rstest(use_orderless_transactions, case(false), case(true))]
-async fn test_invalid_entry_function_argument_u64_string(use_orderless_transactions: bool) {
-    let context = new_test_context_with_orderless_flags(
-        current_function_name!(),
-        true,
-        use_orderless_transactions,
-    );
-    let mut req = signing_message_request(context.use_orderless_transactions);
+async fn test_invalid_entry_function_argument_u64_string() {
+    let context = new_test_context_with_orderless_flags(current_function_name!(), false, false);
+    let mut req = signing_message_request(false);
     req["payload"]["arguments"][0] = json!("invalid");
 
     response_error_msg(req, context).await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-#[rstest(use_orderless_transactions, case(false), case(true))]
-async fn test_invalid_entry_function_argument_address_type(use_orderless_transactions: bool) {
-    let context = new_test_context_with_orderless_flags(
-        current_function_name!(),
-        true,
-        use_orderless_transactions,
-    );
-    let mut req = signing_message_request(context.use_orderless_transactions);
+async fn test_invalid_entry_function_argument_address_type() {
+    let context = new_test_context_with_orderless_flags(current_function_name!(), false, false);
+    let mut req = signing_message_request(false);
     req["payload"]["arguments"][0] = json!(1);
 
     response_error_msg(req, context).await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-#[rstest(use_orderless_transactions, case(false), case(true))]
-async fn test_invalid_entry_function_argument_address_string(use_orderless_transactions: bool) {
-    let context = new_test_context_with_orderless_flags(
-        current_function_name!(),
-        true,
-        use_orderless_transactions,
-    );
-    let mut req = signing_message_request(context.use_orderless_transactions);
+async fn test_invalid_entry_function_argument_address_string() {
+    let context = new_test_context_with_orderless_flags(current_function_name!(), false, false);
+    let mut req = signing_message_request(false);
     req["payload"]["arguments"][0] = json!("invalid");
 
     response_error_msg(req, context).await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-#[rstest(use_orderless_transactions, case(false), case(true))]
-async fn test_missing_entry_function_arguments(use_orderless_transactions: bool) {
-    let context = new_test_context_with_orderless_flags(
-        current_function_name!(),
-        true,
-        use_orderless_transactions,
-    );
-    let mut req = signing_message_request(context.use_orderless_transactions);
+async fn test_missing_entry_function_arguments() {
+    let context = new_test_context_with_orderless_flags(current_function_name!(), false, false);
+    let mut req = signing_message_request(false);
     req["payload"]["arguments"] = json!([]);
 
     response_error_msg(req, context).await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-#[rstest(use_orderless_transactions, case(false), case(true))]
-async fn test_invalid_entry_function_function_name(use_orderless_transactions: bool) {
-    let context = new_test_context_with_orderless_flags(
-        current_function_name!(),
-        true,
-        use_orderless_transactions,
-    );
-    let mut req = signing_message_request(context.use_orderless_transactions);
+async fn test_invalid_entry_function_function_name() {
+    let context = new_test_context_with_orderless_flags(current_function_name!(), false, false);
+    let mut req = signing_message_request(false);
     req["payload"]["function"] = json!("0x1::account::invalid");
 
     response_error_msg(req, context).await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-#[rstest(use_orderless_transactions, case(false), case(true))]
-async fn test_invalid_entry_function_module_name(use_orderless_transactions: bool) {
-    let context = new_test_context_with_orderless_flags(
-        current_function_name!(),
-        true,
-        use_orderless_transactions,
-    );
-    let mut req = signing_message_request(context.use_orderless_transactions);
+async fn test_invalid_entry_function_module_name() {
+    let context = new_test_context_with_orderless_flags(current_function_name!(), false, false);
+    let mut req = signing_message_request(false);
     req["payload"]["function"] = json!("0x1::invalid::invalid");
 
     response_error_msg(req, context).await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-#[rstest(use_orderless_transactions, case(false), case(true))]
-async fn test_invalid_entry_function_module_address(use_orderless_transactions: bool) {
-    let context = new_test_context_with_orderless_flags(
-        current_function_name!(),
-        true,
-        use_orderless_transactions,
-    );
-    let mut req = signing_message_request(context.use_orderless_transactions);
+async fn test_invalid_entry_function_module_address() {
+    let context = new_test_context_with_orderless_flags(current_function_name!(), false, false);
+    let mut req = signing_message_request(false);
     req["payload"]["function"] = json!("0x2342342342::Invalid::invalid");
 
     response_error_msg(req, context).await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-#[rstest(use_orderless_transactions, case(false), case(true))]
-async fn test_invalid_entry_function_function_id(use_orderless_transactions: bool) {
-    let context = new_test_context_with_orderless_flags(
-        current_function_name!(),
-        true,
-        use_orderless_transactions,
-    );
-    let mut req = signing_message_request(context.use_orderless_transactions);
+async fn test_invalid_entry_function_function_id() {
+    let context = new_test_context_with_orderless_flags(current_function_name!(), false, false);
+    let mut req = signing_message_request(false);
     req["payload"]["function"] = json!("invalid");
 
     response_error_msg(req, context).await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-#[rstest(use_orderless_transactions, case(false), case(true))]
-async fn test_invalid_payload_type(use_orderless_transactions: bool) {
-    let context = new_test_context_with_orderless_flags(
-        current_function_name!(),
-        true,
-        use_orderless_transactions,
-    );
-    let mut req = signing_message_request(context.use_orderless_transactions);
+async fn test_invalid_payload_type() {
+    let context = new_test_context_with_orderless_flags(current_function_name!(), false, false);
+    let mut req = signing_message_request(false);
     req["payload"]["type"] = json!("invalid");
 
     response_error_msg(req, context).await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-#[rstest(use_orderless_transactions, case(false), case(true))]
-async fn test_invalid_payload_data_type(use_orderless_transactions: bool) {
-    let context = new_test_context_with_orderless_flags(
-        current_function_name!(),
-        true,
-        use_orderless_transactions,
-    );
-    let mut req = signing_message_request(context.use_orderless_transactions);
+async fn test_invalid_payload_data_type() {
+    let context = new_test_context_with_orderless_flags(current_function_name!(), false, false);
+    let mut req = signing_message_request(false);
     req["payload"] = json!(1234);
 
     response_error_msg(req, context).await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-#[rstest(use_orderless_transactions, case(false), case(true))]
-async fn test_invalid_sender_address(use_orderless_transactions: bool) {
-    let context = new_test_context_with_orderless_flags(
-        current_function_name!(),
-        true,
-        use_orderless_transactions,
-    );
-    let mut req = signing_message_request(context.use_orderless_transactions);
+async fn test_invalid_sender_address() {
+    let context = new_test_context_with_orderless_flags(current_function_name!(), false, false);
+    let mut req = signing_message_request(false);
     req["sender"] = json!("invalid");
 
     response_error_msg(req, context).await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-#[rstest(use_orderless_transactions, case(false), case(true))]
-async fn test_invalid_sequence_number(use_orderless_transactions: bool) {
-    let context = new_test_context_with_orderless_flags(
-        current_function_name!(),
-        true,
-        use_orderless_transactions,
-    );
-    let mut req = signing_message_request(context.use_orderless_transactions);
+async fn test_invalid_sequence_number() {
+    let context = new_test_context_with_orderless_flags(current_function_name!(), false, false);
+    let mut req = signing_message_request(false);
     req["sequence_number"] = json!("invalid");
 
     response_error_msg(req, context).await;

--- a/api/src/tests/modules.rs
+++ b/api/src/tests/modules.rs
@@ -3,23 +3,11 @@
 
 use super::new_test_context_with_orderless_flags;
 use aptos_api_test_context::{current_function_name, TestContext};
-use rstest::rstest;
 use std::path::PathBuf;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-#[rstest(
-    use_txn_payload_v2_format,
-    use_orderless_transactions,
-    case(false, false),
-    case(true, false),
-    case(true, true)
-)]
-async fn test_abi(use_txn_payload_v2_format: bool, use_orderless_transactions: bool) {
-    let mut context = new_test_context_with_orderless_flags(
-        current_function_name!(),
-        use_txn_payload_v2_format,
-        use_orderless_transactions,
-    );
+async fn test_abi() {
+    let mut context = new_test_context_with_orderless_flags(current_function_name!(), false, false);
     let mut account = context.create_account().await;
 
     // Publish packages

--- a/api/src/tests/move/pack_abi/Move.toml
+++ b/api/src/tests/move/pack_abi/Move.toml
@@ -3,7 +3,7 @@ name = "pack_abi"
 version = "0.0.0"
 
 [dependencies]
-AptosFramework = { local = "../../../../../aptos-move/framework/aptos-framework" }
+MoveStdlib = { local = "../../../../../aptos-move/framework/move-stdlib" }
 
 [addresses]
 abi = "_"

--- a/api/src/tests/move/pack_function_values/Move.toml
+++ b/api/src/tests/move/pack_function_values/Move.toml
@@ -3,7 +3,6 @@ name = "pack_function_values"
 version = "0.0.0"
 
 [dependencies]
-AptosFramework = { local = "../../../../../aptos-move/framework/aptos-framework" }
 
 [addresses]
 account = "_"

--- a/api/src/tests/move/pack_function_values_with_struct/Move.toml
+++ b/api/src/tests/move/pack_function_values_with_struct/Move.toml
@@ -3,7 +3,7 @@ name = "pack_function_values"
 version = "0.0.0"
 
 [dependencies]
-AptosFramework = { local = "../../../../../aptos-move/framework/aptos-framework" }
+MoveStdlib = { local = "../../../../../aptos-move/framework/move-stdlib" }
 
 [addresses]
 account = "_"

--- a/api/src/tests/move/public_struct_enum_test/Move.toml
+++ b/api/src/tests/move/public_struct_enum_test/Move.toml
@@ -6,6 +6,4 @@ version = "0.0.0"
 account = "_"
 
 [dependencies]
-AptosFramework = { local = "../../../../../aptos-move/framework/aptos-framework" }
-AptosStdlib = { local = "../../../../../aptos-move/framework/aptos-stdlib" }
 MoveStdlib = { local = "../../../../../aptos-move/framework/move-stdlib" }

--- a/api/src/tests/move/test_option/Move.toml
+++ b/api/src/tests/move/test_option/Move.toml
@@ -3,7 +3,7 @@ name = "test_option"
 version = "0.0.0"
 
 [dependencies]
-AptosFramework = { local = "../../../../../aptos-move/framework/aptos-framework" }
+MoveStdlib = { local = "../../../../../aptos-move/framework/move-stdlib" }
 
 [addresses]
 account = "_"

--- a/api/src/tests/multisig_transactions_test.rs
+++ b/api/src/tests/multisig_transactions_test.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-use super::new_test_context_with_orderless_flags;
+use super::new_test_context;
 use aptos_api_test_context::{current_function_name, TestContext};
 use aptos_types::{
     account_address::AccountAddress,
@@ -12,26 +12,10 @@ use move_core_types::{
     language_storage::{ModuleId, CORE_CODE_ADDRESS},
     value::{serialize_values, MoveValue},
 };
-use proptest::num::usize;
-use rstest::rstest;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-#[rstest(
-    use_txn_payload_v2_format,
-    use_orderless_transactions,
-    case(false, false),
-    case(true, false),
-    case(true, true)
-)]
-async fn test_multisig_transaction_with_payload_succeeds(
-    use_txn_payload_v2_format: bool,
-    use_orderless_transactions: bool,
-) {
-    let mut context = new_test_context_with_orderless_flags(
-        current_function_name!(),
-        use_txn_payload_v2_format,
-        use_orderless_transactions,
-    );
+async fn test_multisig_transaction_with_payload_succeeds() {
+    let mut context = new_test_context(current_function_name!());
     let owner_account_1 = &mut context.create_account().await;
     let owner_account_2 = &mut context.create_account().await;
     let owner_account_3 = &mut context.create_account().await;
@@ -66,22 +50,8 @@ async fn test_multisig_transaction_with_payload_succeeds(
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-#[rstest(
-    use_txn_payload_v2_format,
-    use_orderless_transactions,
-    case(false, false),
-    case(true, false),
-    case(true, true)
-)]
-async fn test_multisig_transaction_with_existing_account(
-    use_txn_payload_v2_format: bool,
-    use_orderless_transactions: bool,
-) {
-    let mut context = new_test_context_with_orderless_flags(
-        current_function_name!(),
-        use_txn_payload_v2_format,
-        use_orderless_transactions,
-    );
+async fn test_multisig_transaction_with_existing_account() {
+    let mut context = new_test_context(current_function_name!());
     let multisig_account = &mut context.create_account().await;
     let owner_account_1 = &mut context.create_account().await;
     let owner_account_2 = &mut context.create_account().await;
@@ -133,22 +103,8 @@ async fn test_multisig_transaction_with_existing_account(
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-#[rstest(
-    use_txn_payload_v2_format,
-    use_orderless_transactions,
-    case(false, false),
-    case(true, false),
-    case(true, true)
-)]
-async fn test_multisig_transaction_to_update_owners(
-    use_txn_payload_v2_format: bool,
-    use_orderless_transactions: bool,
-) {
-    let mut context = new_test_context_with_orderless_flags(
-        current_function_name!(),
-        use_txn_payload_v2_format,
-        use_orderless_transactions,
-    );
+async fn test_multisig_transaction_to_update_owners() {
+    let mut context = new_test_context(current_function_name!());
     let owner_account_1 = &mut context.create_account().await;
     let owner_account_2 = &mut context.create_account().await;
     let owner_account_3 = &mut context.create_account().await;
@@ -233,22 +189,8 @@ async fn test_multisig_transaction_to_update_owners(
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-#[rstest(
-    use_txn_payload_v2_format,
-    use_orderless_transactions,
-    case(false, false),
-    case(true, false),
-    case(true, true)
-)]
-async fn test_multisig_transaction_update_signature_threshold(
-    use_txn_payload_v2_format: bool,
-    use_orderless_transactions: bool,
-) {
-    let mut context = new_test_context_with_orderless_flags(
-        current_function_name!(),
-        use_txn_payload_v2_format,
-        use_orderless_transactions,
-    );
+async fn test_multisig_transaction_update_signature_threshold() {
+    let mut context = new_test_context(current_function_name!());
     let owner_account_1 = &mut context.create_account().await;
     let owner_account_2 = &mut context.create_account().await;
     let multisig_account = context
@@ -289,22 +231,8 @@ async fn test_multisig_transaction_update_signature_threshold(
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-#[rstest(
-    use_txn_payload_v2_format,
-    use_orderless_transactions,
-    case(false, false),
-    case(true, false),
-    case(true, true)
-)]
-async fn test_multisig_transaction_with_insufficient_balance_to_cover_gas(
-    use_txn_payload_v2_format: bool,
-    use_orderless_transactions: bool,
-) {
-    let mut context = new_test_context_with_orderless_flags(
-        current_function_name!(),
-        use_txn_payload_v2_format,
-        use_orderless_transactions,
-    );
+async fn test_multisig_transaction_with_insufficient_balance_to_cover_gas() {
+    let mut context = new_test_context(current_function_name!());
     let owner_account_1 = &mut context.create_account().await;
     // Owner 2 has no APT balance.
     let owner_account_2 = &mut context.gen_account();
@@ -328,22 +256,8 @@ async fn test_multisig_transaction_with_insufficient_balance_to_cover_gas(
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-#[rstest(
-    use_txn_payload_v2_format,
-    use_orderless_transactions,
-    case(false, false),
-    case(true, false),
-    case(true, true)
-)]
-async fn test_multisig_transaction_with_payload_and_failing_execution(
-    use_txn_payload_v2_format: bool,
-    use_orderless_transactions: bool,
-) {
-    let mut context = new_test_context_with_orderless_flags(
-        current_function_name!(),
-        use_txn_payload_v2_format,
-        use_orderless_transactions,
-    );
+async fn test_multisig_transaction_with_payload_and_failing_execution() {
+    let mut context = new_test_context(current_function_name!());
     let owner_account = &mut context.create_account().await;
     let multisig_account = context
         .create_multisig_account(owner_account, vec![], 1, 1000)
@@ -365,22 +279,8 @@ async fn test_multisig_transaction_with_payload_and_failing_execution(
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-#[rstest(
-    use_txn_payload_v2_format,
-    use_orderless_transactions,
-    case(false, false),
-    case(true, false),
-    case(true, true)
-)]
-async fn test_multisig_transaction_with_payload_hash(
-    use_txn_payload_v2_format: bool,
-    use_orderless_transactions: bool,
-) {
-    let mut context = new_test_context_with_orderless_flags(
-        current_function_name!(),
-        use_txn_payload_v2_format,
-        use_orderless_transactions,
-    );
+async fn test_multisig_transaction_with_payload_hash() {
+    let mut context = new_test_context(current_function_name!());
     let owner_account = &mut context.create_account().await;
     let multisig_account = context
         .create_multisig_account(owner_account, vec![], 1, 1000)
@@ -410,22 +310,8 @@ async fn test_multisig_transaction_with_payload_hash(
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-#[rstest(
-    use_txn_payload_v2_format,
-    use_orderless_transactions,
-    case(false, false),
-    case(true, false),
-    case(true, true)
-)]
-async fn test_multisig_transaction_with_payload_hash_and_failing_execution(
-    use_txn_payload_v2_format: bool,
-    use_orderless_transactions: bool,
-) {
-    let mut context = new_test_context_with_orderless_flags(
-        current_function_name!(),
-        use_txn_payload_v2_format,
-        use_orderless_transactions,
-    );
+async fn test_multisig_transaction_with_payload_hash_and_failing_execution() {
+    let mut context = new_test_context(current_function_name!());
     let owner_account = &mut context.create_account().await;
     let multisig_account = context
         .create_multisig_account(owner_account, vec![], 1, 1000)
@@ -458,22 +344,8 @@ async fn test_multisig_transaction_with_payload_hash_and_failing_execution(
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-#[rstest(
-    use_txn_payload_v2_format,
-    use_orderless_transactions,
-    case(false, false),
-    case(true, false),
-    case(true, true)
-)]
-async fn test_multisig_transaction_with_payload_not_matching_hash(
-    use_txn_payload_v2_format: bool,
-    use_orderless_transactions: bool,
-) {
-    let mut context = new_test_context_with_orderless_flags(
-        current_function_name!(),
-        use_txn_payload_v2_format,
-        use_orderless_transactions,
-    );
+async fn test_multisig_transaction_with_payload_not_matching_hash() {
+    let mut context = new_test_context(current_function_name!());
     let owner_account = &mut context.create_account().await;
     let multisig_account = context
         .create_multisig_account(owner_account, vec![], 1, 1000)
@@ -502,23 +374,8 @@ async fn test_multisig_transaction_with_payload_not_matching_hash(
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-#[rstest(
-    use_txn_payload_v2_format,
-    use_orderless_transactions,
-    case(false, false),
-    case(true, false),
-    case(true, true)
-)]
-
-async fn test_multisig_transaction_with_matching_payload(
-    use_txn_payload_v2_format: bool,
-    use_orderless_transactions: bool,
-) {
-    let mut context = new_test_context_with_orderless_flags(
-        current_function_name!(),
-        use_txn_payload_v2_format,
-        use_orderless_transactions,
-    );
+async fn test_multisig_transaction_with_matching_payload() {
+    let mut context = new_test_context(current_function_name!());
     let owner_account = &mut context.create_account().await;
     let multisig_account = context
         .create_multisig_account(owner_account, vec![], 1, 1000)
@@ -544,22 +401,8 @@ async fn test_multisig_transaction_with_matching_payload(
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-#[rstest(
-    use_txn_payload_v2_format,
-    use_orderless_transactions,
-    case(false, false),
-    case(true, false),
-    case(true, true)
-)]
-async fn test_multisig_transaction_with_mismatching_payload(
-    use_txn_payload_v2_format: bool,
-    use_orderless_transactions: bool,
-) {
-    let mut context = new_test_context_with_orderless_flags(
-        current_function_name!(),
-        use_txn_payload_v2_format,
-        use_orderless_transactions,
-    );
+async fn test_multisig_transaction_with_mismatching_payload() {
+    let mut context = new_test_context(current_function_name!());
     let owner_account = &mut context.create_account().await;
     let multisig_account = context
         .create_multisig_account(owner_account, vec![], 1, 1000)
@@ -598,22 +441,8 @@ async fn test_multisig_transaction_with_mismatching_payload(
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-#[rstest(
-    use_txn_payload_v2_format,
-    use_orderless_transactions,
-    case(false, false),
-    case(true, false),
-    case(true, true)
-)]
-async fn test_multisig_transaction_simulation(
-    use_txn_payload_v2_format: bool,
-    use_orderless_transactions: bool,
-) {
-    let mut context = new_test_context_with_orderless_flags(
-        current_function_name!(),
-        use_txn_payload_v2_format,
-        use_orderless_transactions,
-    );
+async fn test_multisig_transaction_simulation() {
+    let mut context = new_test_context(current_function_name!());
     let owner_account_1 = &mut context.create_account().await;
     let owner_account_2 = &mut context.create_account().await;
     let owner_account_3 = &mut context.create_account().await;
@@ -656,22 +485,8 @@ async fn test_multisig_transaction_simulation(
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-#[rstest(
-    use_txn_payload_v2_format,
-    use_orderless_transactions,
-    case(false, false),
-    case(true, false),
-    case(true, true)
-)]
-async fn test_multisig_transaction_simulation_2_of_3(
-    use_txn_payload_v2_format: bool,
-    use_orderless_transactions: bool,
-) {
-    let mut context = new_test_context_with_orderless_flags(
-        current_function_name!(),
-        use_txn_payload_v2_format,
-        use_orderless_transactions,
-    );
+async fn test_multisig_transaction_simulation_2_of_3() {
+    let mut context = new_test_context(current_function_name!());
     let owner_account_1 = &mut context.create_account().await;
     let owner_account_2 = &mut context.create_account().await;
     let owner_account_3 = &mut context.create_account().await;
@@ -718,22 +533,8 @@ async fn test_multisig_transaction_simulation_2_of_3(
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-#[rstest(
-    use_txn_payload_v2_format,
-    use_orderless_transactions,
-    case(false, false),
-    case(true, false),
-    case(true, true)
-)]
-async fn test_multisig_transaction_simulation_fail(
-    use_txn_payload_v2_format: bool,
-    use_orderless_transactions: bool,
-) {
-    let mut context = new_test_context_with_orderless_flags(
-        current_function_name!(),
-        use_txn_payload_v2_format,
-        use_orderless_transactions,
-    );
+async fn test_multisig_transaction_simulation_fail() {
+    let mut context = new_test_context(current_function_name!());
     let owner_account_1 = &mut context.create_account().await;
     let owner_account_2 = &mut context.create_account().await;
     let owner_account_3 = &mut context.create_account().await;
@@ -777,22 +578,8 @@ async fn test_multisig_transaction_simulation_fail(
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-#[rstest(
-    use_txn_payload_v2_format,
-    use_orderless_transactions,
-    case(false, false),
-    case(true, false),
-    case(true, true)
-)]
-async fn test_multisig_transaction_simulation_fail_2_of_3_insufficient_approvals(
-    use_txn_payload_v2_format: bool,
-    use_orderless_transactions: bool,
-) {
-    let mut context = new_test_context_with_orderless_flags(
-        current_function_name!(),
-        use_txn_payload_v2_format,
-        use_orderless_transactions,
-    );
+async fn test_multisig_transaction_simulation_fail_2_of_3_insufficient_approvals() {
+    let mut context = new_test_context(current_function_name!());
     let owner_account_1 = &mut context.create_account().await;
     let owner_account_2 = &mut context.create_account().await;
     let owner_account_3 = &mut context.create_account().await;
@@ -830,22 +617,8 @@ async fn test_multisig_transaction_simulation_fail_2_of_3_insufficient_approvals
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-#[rstest(
-    use_txn_payload_v2_format,
-    use_orderless_transactions,
-    case(false, false),
-    case(true, false),
-    case(true, true)
-)]
-async fn test_simulate_multisig_transaction_should_charge_gas_against_sender(
-    use_txn_payload_v2_format: bool,
-    use_orderless_transactions: bool,
-) {
-    let mut context = new_test_context_with_orderless_flags(
-        current_function_name!(),
-        use_txn_payload_v2_format,
-        use_orderless_transactions,
-    );
+async fn test_simulate_multisig_transaction_should_charge_gas_against_sender() {
+    let mut context = new_test_context(current_function_name!());
     let owner_account = &mut context.create_account().await;
     let multisig_account = context
         .create_multisig_account(

--- a/api/src/tests/objects.rs
+++ b/api/src/tests/objects.rs
@@ -4,7 +4,6 @@
 use super::new_test_context_with_orderless_flags;
 use aptos_api_test_context::{current_function_name, TestContext};
 use aptos_types::account_address::{self, AccountAddress};
-use rstest::rstest;
 use serde_json::{json, Value};
 use std::{collections::BTreeMap, path::PathBuf};
 
@@ -15,19 +14,8 @@ use std::{collections::BTreeMap, path::PathBuf};
 // 4. Transfer to cause transfer event
 // 4. Read emitted event
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-#[rstest(
-    use_txn_payload_v2_format,
-    use_orderless_transactions,
-    case(false, false),
-    case(true, false),
-    case(true, true)
-)]
-async fn test_gen_object(use_txn_payload_v2_format: bool, use_orderless_transactions: bool) {
-    let mut context = new_test_context_with_orderless_flags(
-        current_function_name!(),
-        use_txn_payload_v2_format,
-        use_orderless_transactions,
-    );
+async fn test_gen_object() {
+    let mut context = new_test_context_with_orderless_flags(current_function_name!(), false, false);
 
     // Prepare account
     let mut user = context.create_account().await;

--- a/api/src/tests/option_test.rs
+++ b/api/src/tests/option_test.rs
@@ -3,24 +3,12 @@
 
 use super::new_test_context_with_orderless_flags;
 use aptos_api_test_context::{current_function_name, TestContext};
-use rstest::rstest;
 use serde_json::json;
 use std::path::PathBuf;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-#[rstest(
-    use_txn_payload_v2_format,
-    use_orderless_transactions,
-    case(false, false),
-    case(true, false),
-    case(true, true)
-)]
-async fn run_option(use_txn_payload_v2_format: bool, use_orderless_transactions: bool) {
-    let mut context = new_test_context_with_orderless_flags(
-        current_function_name!(),
-        use_txn_payload_v2_format,
-        use_orderless_transactions,
-    );
+async fn run_option() {
+    let mut context = new_test_context_with_orderless_flags(current_function_name!(), false, false);
     let mut account = context.create_account().await;
     let account_addr = account.address();
 

--- a/api/src/tests/public_struct_enum_negative_test.rs
+++ b/api/src/tests/public_struct_enum_negative_test.rs
@@ -15,23 +15,8 @@ use serde_json::json;
 /// Each case specifies an entry function, a bad argument, and the substring
 /// expected to appear in the 400 error message.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-#[rstest(
-    use_txn_payload_v2_format,
-    use_orderless_transactions,
-    case(false, false),
-    case(true, false),
-    case(true, true)
-)]
-async fn test_invalid_args_rejected(
-    use_txn_payload_v2_format: bool,
-    use_orderless_transactions: bool,
-) {
-    let (context, account) = setup_public_struct_test(
-        current_function_name!(),
-        use_txn_payload_v2_format,
-        use_orderless_transactions,
-    )
-    .await;
+async fn test_invalid_args_rejected() {
+    let (context, account) = setup_public_struct_test(current_function_name!(), false, false).await;
     let account_addr = account.address();
     let seq = account.sequence_number().to_string();
 

--- a/api/src/tests/public_struct_enum_test.rs
+++ b/api/src/tests/public_struct_enum_test.rs
@@ -9,7 +9,6 @@
 use super::setup_public_struct_test;
 use aptos_api_test_context::current_function_name;
 use aptos_types::account_address::AccountAddress;
-use rstest::rstest;
 use serde_json::{json, Value};
 
 /// Fetch the `TestResult` resource for `account_addr` and assert its `value` and `message` fields.
@@ -28,26 +27,12 @@ async fn assert_test_result(
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-#[rstest(
-    use_txn_payload_v2_format,
-    use_orderless_transactions,
-    case(false, false),
-    case(true, false),
-    case(true, true)
-)]
-async fn test_public_struct_point(
-    use_txn_payload_v2_format: bool,
-    use_orderless_transactions: bool,
-) {
-    let (mut context, mut account) = setup_public_struct_test(
-        current_function_name!(),
-        use_txn_payload_v2_format,
-        use_orderless_transactions,
-    )
-    .await;
+async fn test_public_struct_enum_entry_functions() {
+    let (mut context, mut account) =
+        setup_public_struct_test(current_function_name!(), false, false).await;
     let account_addr = account.address();
 
-    // Call entry function with a Point struct: { x: 10, y: 20 }
+    // test_public_struct_point: Point { x: 10, y: 20 }
     context
         .api_execute_entry_function(
             &mut account,
@@ -59,31 +44,9 @@ async fn test_public_struct_point(
             json!([{ "x": "10", "y": "20" }]),
         )
         .await;
-
     assert_test_result(&mut context, &account_addr, "30", "point_received").await;
-}
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-#[rstest(
-    use_txn_payload_v2_format,
-    use_orderless_transactions,
-    case(false, false),
-    case(true, false),
-    case(true, true)
-)]
-async fn test_public_struct_nested(
-    use_txn_payload_v2_format: bool,
-    use_orderless_transactions: bool,
-) {
-    let (mut context, mut account) = setup_public_struct_test(
-        current_function_name!(),
-        use_txn_payload_v2_format,
-        use_orderless_transactions,
-    )
-    .await;
-    let account_addr = account.address();
-
-    // Call entry function with a Rectangle struct with nested Points
+    // test_public_struct_nested: Rectangle with nested Points
     context
         .api_execute_entry_function(
             &mut account,
@@ -98,31 +61,9 @@ async fn test_public_struct_nested(
             }]),
         )
         .await;
-
     assert_test_result(&mut context, &account_addr, "10", "rectangle_received").await;
-}
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-#[rstest(
-    use_txn_payload_v2_format,
-    use_orderless_transactions,
-    case(false, false),
-    case(true, false),
-    case(true, true)
-)]
-async fn test_public_struct_with_string(
-    use_txn_payload_v2_format: bool,
-    use_orderless_transactions: bool,
-) {
-    let (mut context, mut account) = setup_public_struct_test(
-        current_function_name!(),
-        use_txn_payload_v2_format,
-        use_orderless_transactions,
-    )
-    .await;
-    let account_addr = account.address();
-
-    // Call entry function with a Data struct: { values: [5, 10, 15], name: "test_data" }
+    // test_public_struct_with_string: Data { values: [5, 10, 15], name: "test_data" }
     context
         .api_execute_entry_function(
             &mut account,
@@ -134,31 +75,9 @@ async fn test_public_struct_with_string(
             }]),
         )
         .await;
-
     assert_test_result(&mut context, &account_addr, "30", "test_data").await;
-}
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-#[rstest(
-    use_txn_payload_v2_format,
-    use_orderless_transactions,
-    case(false, false),
-    case(true, false),
-    case(true, true)
-)]
-async fn test_public_enum_unit_variant(
-    use_txn_payload_v2_format: bool,
-    use_orderless_transactions: bool,
-) {
-    let (mut context, mut account) = setup_public_struct_test(
-        current_function_name!(),
-        use_txn_payload_v2_format,
-        use_orderless_transactions,
-    )
-    .await;
-    let account_addr = account.address();
-
-    // Call entry function with Color::Red enum variant
+    // test_public_enum_unit_variant: Color::Red
     context
         .api_execute_entry_function(
             &mut account,
@@ -170,31 +89,9 @@ async fn test_public_enum_unit_variant(
             json!([{ "Red": {} }]),
         )
         .await;
-
     assert_test_result(&mut context, &account_addr, "1", "red").await;
-}
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-#[rstest(
-    use_txn_payload_v2_format,
-    use_orderless_transactions,
-    case(false, false),
-    case(true, false),
-    case(true, true)
-)]
-async fn test_public_enum_with_fields(
-    use_txn_payload_v2_format: bool,
-    use_orderless_transactions: bool,
-) {
-    let (mut context, mut account) = setup_public_struct_test(
-        current_function_name!(),
-        use_txn_payload_v2_format,
-        use_orderless_transactions,
-    )
-    .await;
-    let account_addr = account.address();
-
-    // Call entry function with Color::Custom { r: 100, g: 50, b: 25 }
+    // test_public_enum_with_fields: Color::Custom { r: 100, g: 50, b: 25 }
     context
         .api_execute_entry_function(
             &mut account,
@@ -206,31 +103,9 @@ async fn test_public_enum_with_fields(
             json!([{ "Custom": { "r": 100, "g": 50, "b": 25 } }]),
         )
         .await;
-
     assert_test_result(&mut context, &account_addr, "175", "custom").await;
-}
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-#[rstest(
-    use_txn_payload_v2_format,
-    use_orderless_transactions,
-    case(false, false),
-    case(true, false),
-    case(true, true)
-)]
-async fn test_public_enum_with_struct_fields(
-    use_txn_payload_v2_format: bool,
-    use_orderless_transactions: bool,
-) {
-    let (mut context, mut account) = setup_public_struct_test(
-        current_function_name!(),
-        use_txn_payload_v2_format,
-        use_orderless_transactions,
-    )
-    .await;
-    let account_addr = account.address();
-
-    // Call entry function with Shape::Circle { center: Point { x: 5, y: 10 }, radius: 15 }
+    // test_public_enum_with_struct_fields: Shape::Circle { center: Point, radius: 15 }
     context
         .api_execute_entry_function(
             &mut account,
@@ -247,31 +122,9 @@ async fn test_public_enum_with_struct_fields(
             }]),
         )
         .await;
-
     assert_test_result(&mut context, &account_addr, "30", "circle").await;
-}
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-#[rstest(
-    use_txn_payload_v2_format,
-    use_orderless_transactions,
-    case(false, false),
-    case(true, false),
-    case(true, true)
-)]
-async fn test_vector_of_public_structs(
-    use_txn_payload_v2_format: bool,
-    use_orderless_transactions: bool,
-) {
-    let (mut context, mut account) = setup_public_struct_test(
-        current_function_name!(),
-        use_txn_payload_v2_format,
-        use_orderless_transactions,
-    )
-    .await;
-    let account_addr = account.address();
-
-    // Call entry function with a vector of Points
+    // test_vector_of_public_structs: vector of Points
     context
         .api_execute_entry_function(
             &mut account,
@@ -287,31 +140,9 @@ async fn test_vector_of_public_structs(
             ]]),
         )
         .await;
-
     assert_test_result(&mut context, &account_addr, "21", "point_vector_received").await;
-}
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-#[rstest(
-    use_txn_payload_v2_format,
-    use_orderless_transactions,
-    case(false, false),
-    case(true, false),
-    case(true, true)
-)]
-async fn test_whitelisted_string_works(
-    use_txn_payload_v2_format: bool,
-    use_orderless_transactions: bool,
-) {
-    let (mut context, mut account) = setup_public_struct_test(
-        current_function_name!(),
-        use_txn_payload_v2_format,
-        use_orderless_transactions,
-    )
-    .await;
-    let account_addr = account.address();
-
-    // Call entry function with a String value
+    // test_whitelisted_string_works: String value
     context
         .api_execute_entry_function(
             &mut account,
@@ -323,33 +154,9 @@ async fn test_whitelisted_string_works(
             json!(["hello_world"]),
         )
         .await;
-
     assert_test_result(&mut context, &account_addr, "11", "hello_world").await;
-}
 
-/// Test passing Option<Point> with Some value via API
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-#[rstest(
-    use_txn_payload_v2_format,
-    use_orderless_transactions,
-    case(false, false),
-    case(true, false),
-    case(true, true)
-)]
-async fn test_option_some_struct(
-    use_txn_payload_v2_format: bool,
-    use_orderless_transactions: bool,
-) {
-    let (mut context, mut account) = setup_public_struct_test(
-        current_function_name!(),
-        use_txn_payload_v2_format,
-        use_orderless_transactions,
-    )
-    .await;
-    let account_addr = account.address();
-
-    // Call entry function with Option<Point>::Some
-    // Option uses vector-based JSON representation: Some(x) = {"vec": [x]}, None = {"vec": []}
+    // test_option_some_struct: Option<Point>::Some
     context
         .api_execute_entry_function(
             &mut account,
@@ -361,33 +168,9 @@ async fn test_option_some_struct(
             json!([{ "vec": [{ "x": "10", "y": "20" }] }]),
         )
         .await;
-
     assert_test_result(&mut context, &account_addr, "30", "some_point").await;
-}
 
-/// Test passing Option<Point> with None value via API
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-#[rstest(
-    use_txn_payload_v2_format,
-    use_orderless_transactions,
-    case(false, false),
-    case(true, false),
-    case(true, true)
-)]
-async fn test_option_none_struct(
-    use_txn_payload_v2_format: bool,
-    use_orderless_transactions: bool,
-) {
-    let (mut context, mut account) = setup_public_struct_test(
-        current_function_name!(),
-        use_txn_payload_v2_format,
-        use_orderless_transactions,
-    )
-    .await;
-    let account_addr = account.address();
-
-    // Call entry function with Option<Point>::None
-    // Option uses vector-based JSON representation: None = {"vec": []}
+    // test_option_none_struct: Option<Point>::None
     context
         .api_execute_entry_function(
             &mut account,
@@ -399,31 +182,9 @@ async fn test_option_none_struct(
             json!([{ "vec": [] }]),
         )
         .await;
-
     assert_test_result(&mut context, &account_addr, "0", "none_point").await;
-}
 
-/// Test passing Option<Color> with Some(Red) via API
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-#[rstest(
-    use_txn_payload_v2_format,
-    use_orderless_transactions,
-    case(false, false),
-    case(true, false),
-    case(true, true)
-)]
-async fn test_option_some_enum(use_txn_payload_v2_format: bool, use_orderless_transactions: bool) {
-    let (mut context, mut account) = setup_public_struct_test(
-        current_function_name!(),
-        use_txn_payload_v2_format,
-        use_orderless_transactions,
-    )
-    .await;
-    let account_addr = account.address();
-
-    // Call entry function with Option<Color>::Some(Color::Red)
-    // Option uses vector-based JSON representation: Some(x) = {"vec": [x]}, None = {"vec": []}
-    // Option<enum> uses vec format with variant name as key
+    // test_option_some_enum: Option<Color>::Some(Color::Red)
     context
         .api_execute_entry_function(
             &mut account,
@@ -435,30 +196,9 @@ async fn test_option_some_enum(use_txn_payload_v2_format: bool, use_orderless_tr
             json!([{ "vec": [{ "Red": {} }] }]),
         )
         .await;
-
     assert_test_result(&mut context, &account_addr, "1", "some_red").await;
-}
 
-/// Test passing Option<Color> with None via API
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-#[rstest(
-    use_txn_payload_v2_format,
-    use_orderless_transactions,
-    case(false, false),
-    case(true, false),
-    case(true, true)
-)]
-async fn test_option_none_enum(use_txn_payload_v2_format: bool, use_orderless_transactions: bool) {
-    let (mut context, mut account) = setup_public_struct_test(
-        current_function_name!(),
-        use_txn_payload_v2_format,
-        use_orderless_transactions,
-    )
-    .await;
-    let account_addr = account.address();
-
-    // Call entry function with Option<Color>::None
-    // Option uses vector-based JSON representation: None = {"vec": []}
+    // test_option_none_enum: Option<Color>::None
     context
         .api_execute_entry_function(
             &mut account,
@@ -470,79 +210,9 @@ async fn test_option_none_enum(use_txn_payload_v2_format: bool, use_orderless_tr
             json!([{ "vec": [] }]),
         )
         .await;
-
     assert_test_result(&mut context, &account_addr, "0", "none_color").await;
-}
 
-/// Test calling a view function that takes a public struct as argument.
-///
-/// This exercises the `/view` endpoint code path through `convert_view_function` →
-/// `try_into_vm_values` → `try_into_vm_value_struct`, which is a different entry point
-/// from the entry-function submission path and is not covered by e2e move tests.
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_view_with_public_struct() {
-    let (context, account) = setup_public_struct_test(current_function_name!(), false, false).await;
-    let account_addr = account.address();
-
-    let request: Value = json!({
-        "function": format!("0x{}::public_struct_test::check_point", account_addr.to_hex()),
-        "type_arguments": [],
-        "arguments": [{ "x": "3", "y": "7" }],
-    });
-
-    let resp = context.post("/view", request).await;
-
-    // check_point returns p.x + p.y = 3 + 7 = 10
-    assert_eq!(resp, json!(["10"]));
-}
-
-/// Test calling a view function that takes a public enum as argument.
-///
-/// Covers the same `/view` code path as test_view_with_public_struct but with
-/// enum variant parsing (WithVariants layout) rather than plain struct parsing.
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_view_with_public_enum() {
-    let (context, account) = setup_public_struct_test(current_function_name!(), false, false).await;
-    let account_addr = account.address();
-
-    let request: Value = json!({
-        "function": format!("0x{}::public_struct_test::check_color", account_addr.to_hex()),
-        "type_arguments": [],
-        "arguments": [{ "Custom": { "r": 10, "g": 20, "b": 30 } }],
-    });
-
-    let resp = context.post("/view", request).await;
-
-    // check_color returns r + g + b = 10 + 20 + 30 = 60
-    assert_eq!(resp, json!(["60"]));
-}
-
-/// Test passing a Labeled struct (struct with a user-defined enum field) via API (gap 4).
-///
-/// All existing e2e and API tests use flat structs or structs containing other structs.
-/// This test passes a struct whose `color` field is a user-defined enum (Color) as a
-/// top-level entry argument: Labeled { color: Color::Green, value: 10 } → result = 2 + 10 = 12.
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-#[rstest(
-    use_txn_payload_v2_format,
-    use_orderless_transactions,
-    case(false, false),
-    case(true, false),
-    case(true, true)
-)]
-async fn test_struct_with_enum_field(
-    use_txn_payload_v2_format: bool,
-    use_orderless_transactions: bool,
-) {
-    let (mut context, mut account) = setup_public_struct_test(
-        current_function_name!(),
-        use_txn_payload_v2_format,
-        use_orderless_transactions,
-    )
-    .await;
-    let account_addr = account.address();
-
-    // Labeled { color: Color::Green, value: 10 } — tag for Green = 2; result.value = 12
+    // test_struct_with_enum_field: Labeled { color: Color::Green, value: 10 }
     context
         .api_execute_entry_function(
             &mut account,
@@ -554,36 +224,9 @@ async fn test_struct_with_enum_field(
             json!([{ "color": { "Green": {} }, "value": "10" }]),
         )
         .await;
-
     assert_test_result(&mut context, &account_addr, "12", "labeled_received").await;
-}
 
-/// Test vector<vector<Point>> via API (gap 1).
-///
-/// All existing vector tests use `vector<Point>` or `vector<Option<u64>>`.  A
-/// `vector<vector<Point>>` nests the JSON/BCS conversion and pack invocation counter
-/// one level deeper.
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-#[rstest(
-    use_txn_payload_v2_format,
-    use_orderless_transactions,
-    case(false, false),
-    case(true, false),
-    case(true, true)
-)]
-async fn test_nested_vector_of_structs(
-    use_txn_payload_v2_format: bool,
-    use_orderless_transactions: bool,
-) {
-    let (mut context, mut account) = setup_public_struct_test(
-        current_function_name!(),
-        use_txn_payload_v2_format,
-        use_orderless_transactions,
-    )
-    .await;
-    let account_addr = account.address();
-
-    // [[Point{1,2}, Point{3,4}], [Point{5,6}]] — sum = 1+2+3+4+5+6 = 21
+    // test_nested_vector_of_structs: vector<vector<Point>>
     context
         .api_execute_entry_function(
             &mut account,
@@ -598,7 +241,6 @@ async fn test_nested_vector_of_structs(
             ]]),
         )
         .await;
-
     assert_test_result(
         &mut context,
         &account_addr,
@@ -606,54 +248,8 @@ async fn test_nested_vector_of_structs(
         "nested_point_vector_received",
     )
     .await;
-}
 
-/// Test calling a view function with two public struct arguments (gap 3).
-///
-/// All existing view tests (`test_view_with_public_struct`, `test_view_with_public_enum`) use a
-/// single argument.  `check_two_points(p1: Point, p2: Point): u64` exercises the argument
-/// iteration loop for view functions when there are multiple struct args.
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_view_with_multiple_struct_args() {
-    let (context, account) = setup_public_struct_test(current_function_name!(), false, false).await;
-    let account_addr = account.address();
-
-    let request: Value = json!({
-        "function": format!("0x{}::public_struct_test::check_two_points", account_addr.to_hex()),
-        "type_arguments": [],
-        "arguments": [{ "x": "1", "y": "2" }, { "x": "3", "y": "4" }],
-    });
-
-    let resp = context.post("/view", request).await;
-
-    // check_two_points returns p1.x + p1.y + p2.x + p2.y = 1 + 2 + 3 + 4 = 10
-    assert_eq!(resp, json!(["10"]));
-}
-
-/// Test passing Container<Color> (generic struct with enum type argument) via API
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-#[rstest(
-    use_txn_payload_v2_format,
-    use_orderless_transactions,
-    case(false, false),
-    case(true, false),
-    case(true, true)
-)]
-async fn test_generic_container_with_enum(
-    use_txn_payload_v2_format: bool,
-    use_orderless_transactions: bool,
-) {
-    let (mut context, mut account) = setup_public_struct_test(
-        current_function_name!(),
-        use_txn_payload_v2_format,
-        use_orderless_transactions,
-    )
-    .await;
-    let account_addr = account.address();
-
-    // Call entry function with Container<Color> containing Red
-    // Container is a generic struct: struct Container<T> { value: T }
-    // JSON format: { "value": { "Red": {} } }
+    // test_generic_container_with_enum: Container<Color> containing Red
     context
         .api_execute_entry_function(
             &mut account,
@@ -665,6 +261,38 @@ async fn test_generic_container_with_enum(
             json!([{ "value": { "Red": {} } }]),
         )
         .await;
-
     assert_test_result(&mut context, &account_addr, "100", "container_red").await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_public_struct_enum_views() {
+    let (context, account) = setup_public_struct_test(current_function_name!(), false, false).await;
+    let account_addr = account.address();
+
+    // test_view_with_public_struct: check_point(Point{3,7}) = 10
+    let request: Value = json!({
+        "function": format!("0x{}::public_struct_test::check_point", account_addr.to_hex()),
+        "type_arguments": [],
+        "arguments": [{ "x": "3", "y": "7" }],
+    });
+    let resp = context.post("/view", request).await;
+    assert_eq!(resp, json!(["10"]));
+
+    // test_view_with_public_enum: check_color(Custom{10,20,30}) = 60
+    let request: Value = json!({
+        "function": format!("0x{}::public_struct_test::check_color", account_addr.to_hex()),
+        "type_arguments": [],
+        "arguments": [{ "Custom": { "r": 10, "g": 20, "b": 30 } }],
+    });
+    let resp = context.post("/view", request).await;
+    assert_eq!(resp, json!(["60"]));
+
+    // test_view_with_multiple_struct_args: check_two_points(Point{1,2}, Point{3,4}) = 10
+    let request: Value = json!({
+        "function": format!("0x{}::public_struct_test::check_two_points", account_addr.to_hex()),
+        "type_arguments": [],
+        "arguments": [{ "x": "1", "y": "2" }, { "x": "3", "y": "4" }],
+    });
+    let resp = context.post("/view", request).await;
+    assert_eq!(resp, json!(["10"]));
 }

--- a/api/src/tests/resource_groups.rs
+++ b/api/src/tests/resource_groups.rs
@@ -23,7 +23,6 @@ use std::path::PathBuf;
     use_txn_payload_v2_format,
     use_orderless_transactions,
     case(false, false),
-    case(true, false),
     case(true, true)
 )]
 async fn test_gen_resource_group(

--- a/api/src/tests/signed_int_test.rs
+++ b/api/src/tests/signed_int_test.rs
@@ -3,24 +3,12 @@
 
 use super::new_test_context_with_orderless_flags;
 use aptos_api_test_context::{current_function_name, TestContext};
-use rstest::rstest;
 use serde_json::json;
 use std::path::PathBuf;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-#[rstest(
-    use_txn_payload_v2_format,
-    use_orderless_transactions,
-    case(false, false),
-    case(true, false),
-    case(true, true)
-)]
-async fn test_signed_ints(use_txn_payload_v2_format: bool, use_orderless_transactions: bool) {
-    let mut context = new_test_context_with_orderless_flags(
-        current_function_name!(),
-        use_txn_payload_v2_format,
-        use_orderless_transactions,
-    );
+async fn test_signed_ints() {
+    let mut context = new_test_context_with_orderless_flags(current_function_name!(), false, false);
     let mut account = context.create_account().await;
     let account_addr = account.address();
 

--- a/api/src/tests/string_resource_test.rs
+++ b/api/src/tests/string_resource_test.rs
@@ -3,27 +3,12 @@
 
 use super::new_test_context_with_orderless_flags;
 use aptos_api_test_context::{current_function_name, TestContext};
-use rstest::rstest;
 use serde_json::json;
 use std::path::PathBuf;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-#[rstest(
-    use_txn_payload_v2_format,
-    use_orderless_transactions,
-    case(false, false),
-    case(true, false),
-    case(true, true)
-)]
-async fn test_renders_move_acsii_string_into_utf8_string(
-    use_txn_payload_v2_format: bool,
-    use_orderless_transactions: bool,
-) {
-    let mut context = new_test_context_with_orderless_flags(
-        current_function_name!(),
-        use_txn_payload_v2_format,
-        use_orderless_transactions,
-    );
+async fn test_renders_move_acsii_string_into_utf8_string() {
+    let mut context = new_test_context_with_orderless_flags(current_function_name!(), false, false);
     let mut account = context.root_account().await;
     let addr = account.address();
 

--- a/api/src/tests/transactions_test.rs
+++ b/api/src/tests/transactions_test.rs
@@ -2631,22 +2631,8 @@ async fn test_simulation_failure_with_detail_error(
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-#[rstest(
-    use_txn_payload_v2_format,
-    use_orderless_transactions,
-    case(false, false),
-    case(true, false),
-    case(true, true)
-)]
-async fn test_runtime_error_message_in_interpreter(
-    use_txn_payload_v2_format: bool,
-    use_orderless_transactions: bool,
-) {
-    let mut context = new_test_context_with_orderless_flags(
-        current_function_name!(),
-        use_txn_payload_v2_format,
-        use_orderless_transactions,
-    );
+async fn test_runtime_error_message_in_interpreter() {
+    let mut context = new_test_context(current_function_name!());
     let account = context.root_account().await;
 
     let named_addresses = vec![("addr".to_string(), account.address())];

--- a/api/src/tests/view_function.rs
+++ b/api/src/tests/view_function.rs
@@ -30,19 +30,8 @@ fn build_coin_decimals_request() -> Value {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-#[rstest(
-    use_txn_payload_v2_format,
-    use_orderless_transactions,
-    case(false, false),
-    case(true, false),
-    case(true, true)
-)]
-async fn test_simple_view(use_txn_payload_v2_format: bool, use_orderless_transactions: bool) {
-    let mut context = new_test_context_with_orderless_flags(
-        current_function_name!(),
-        use_txn_payload_v2_format,
-        use_orderless_transactions,
-    );
+async fn test_simple_view() {
+    let mut context = new_test_context(current_function_name!());
     let creator = &mut context.gen_account();
     let owner = &mut context.gen_account();
     let txn1 = context.mint_user_account(creator).await;
@@ -58,22 +47,8 @@ async fn test_simple_view(use_txn_payload_v2_format: bool, use_orderless_transac
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-#[rstest(
-    use_txn_payload_v2_format,
-    use_orderless_transactions,
-    case(false, false),
-    case(true, false),
-    case(true, true)
-)]
-async fn test_view_gas_used_header(
-    use_txn_payload_v2_format: bool,
-    use_orderless_transactions: bool,
-) {
-    let mut context = new_test_context_with_orderless_flags(
-        current_function_name!(),
-        use_txn_payload_v2_format,
-        use_orderless_transactions,
-    );
+async fn test_view_gas_used_header() {
+    let mut context = new_test_context(current_function_name!());
     let creator = &mut context.gen_account();
     let owner = &mut context.gen_account();
     let txn1 = context.mint_user_account(creator).await;
@@ -104,14 +79,7 @@ async fn test_view_gas_used_header(
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-#[rstest(
-    use_txn_payload_v2_format,
-    use_orderless_transactions,
-    case(false, false),
-    case(true, false),
-    case(true, true)
-)]
-async fn test_view_allowlist(use_txn_payload_v2_format: bool, use_orderless_transactions: bool) {
+async fn test_view_allowlist() {
     let mut node_config = NodeConfig::default();
 
     // Allowlist only the balance function.
@@ -121,12 +89,8 @@ async fn test_view_allowlist(use_txn_payload_v2_format: bool, use_orderless_tran
         function_name: "balance".to_string(),
     }]);
 
-    let mut context = new_test_context_with_config(
-        current_function_name!(),
-        node_config,
-        use_txn_payload_v2_format,
-        use_orderless_transactions,
-    );
+    let mut context =
+        new_test_context_with_config(current_function_name!(), node_config, false, false);
 
     let creator = &mut context.gen_account();
     let owner = &mut context.gen_account();
@@ -151,14 +115,7 @@ async fn test_view_allowlist(use_txn_payload_v2_format: bool, use_orderless_tran
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-#[rstest(
-    use_txn_payload_v2_format,
-    use_orderless_transactions,
-    case(false, false),
-    case(true, false),
-    case(true, true)
-)]
-async fn test_view_blocklist(use_txn_payload_v2_format: bool, use_orderless_transactions: bool) {
+async fn test_view_blocklist() {
     let mut node_config = NodeConfig::default();
 
     // Blocklist the balance function.
@@ -168,12 +125,8 @@ async fn test_view_blocklist(use_txn_payload_v2_format: bool, use_orderless_tran
         function_name: "balance".to_string(),
     }]);
 
-    let mut context = new_test_context_with_config(
-        current_function_name!(),
-        node_config,
-        use_txn_payload_v2_format,
-        use_orderless_transactions,
-    );
+    let mut context =
+        new_test_context_with_config(current_function_name!(), node_config, false, false);
 
     let creator = &mut context.gen_account();
     let owner = &mut context.gen_account();
@@ -198,22 +151,8 @@ async fn test_view_blocklist(use_txn_payload_v2_format: bool, use_orderless_tran
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-#[rstest(
-    use_txn_payload_v2_format,
-    use_orderless_transactions,
-    case(false, false),
-    case(true, false),
-    case(true, true)
-)]
-async fn test_view_error_move_abort(
-    use_txn_payload_v2_format: bool,
-    use_orderless_transactions: bool,
-) {
-    let mut context = new_test_context_with_orderless_flags(
-        current_function_name!(),
-        use_txn_payload_v2_format,
-        use_orderless_transactions,
-    );
+async fn test_view_error_move_abort() {
+    let mut context = new_test_context(current_function_name!());
     let creator = &mut context.gen_account();
     let owner = &mut context.gen_account();
     let txn1 = context.mint_user_account(creator).await;
@@ -236,22 +175,8 @@ async fn test_view_error_move_abort(
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-#[rstest(
-    use_txn_payload_v2_format,
-    use_orderless_transactions,
-    case(false, false),
-    case(true, false),
-    case(true, true)
-)]
-async fn test_view_error_type_resolution_error(
-    use_txn_payload_v2_format: bool,
-    use_orderless_transactions: bool,
-) {
-    let mut context = new_test_context_with_orderless_flags(
-        current_function_name!(),
-        use_txn_payload_v2_format,
-        use_orderless_transactions,
-    );
+async fn test_view_error_type_resolution_error() {
+    let mut context = new_test_context(current_function_name!());
     let creator = &mut context.gen_account();
     let owner = &mut context.gen_account();
     let txn1 = context.mint_user_account(creator).await;
@@ -299,22 +224,8 @@ async fn test_view_does_not_exist() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-#[rstest(
-    use_txn_payload_v2_format,
-    use_orderless_transactions,
-    case(false, false),
-    case(true, false),
-    case(true, true)
-)]
-async fn test_simple_view_invalid(
-    use_txn_payload_v2_format: bool,
-    use_orderless_transactions: bool,
-) {
-    let mut context = new_test_context_with_orderless_flags(
-        current_function_name!(),
-        use_txn_payload_v2_format,
-        use_orderless_transactions,
-    );
+async fn test_simple_view_invalid() {
+    let mut context = new_test_context(current_function_name!());
     let creator = &mut context.gen_account();
     let owner = &mut context.gen_account();
     let txn1 = context.mint_user_account(creator).await;
@@ -338,22 +249,8 @@ async fn test_simple_view_invalid(
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-#[rstest(
-    use_txn_payload_v2_format,
-    use_orderless_transactions,
-    case(false, false),
-    case(true, false),
-    case(true, true)
-)]
-async fn test_versioned_simple_view(
-    use_txn_payload_v2_format: bool,
-    use_orderless_transactions: bool,
-) {
-    let mut context = new_test_context_with_orderless_flags(
-        current_function_name!(),
-        use_txn_payload_v2_format,
-        use_orderless_transactions,
-    );
+async fn test_versioned_simple_view() {
+    let mut context = new_test_context(current_function_name!());
     let creator = &mut context.gen_account();
     let owner = &mut context.gen_account();
     let initial_ledger_version = u64::from(context.get_latest_ledger_info().ledger_version);
@@ -378,19 +275,8 @@ async fn test_versioned_simple_view(
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-#[rstest(
-    use_txn_payload_v2_format,
-    use_orderless_transactions,
-    case(false, false),
-    case(true, false),
-    case(true, true)
-)]
-async fn test_view_tuple(use_txn_payload_v2_format: bool, use_orderless_transactions: bool) {
-    let mut context = new_test_context_with_orderless_flags(
-        current_function_name!(),
-        use_txn_payload_v2_format,
-        use_orderless_transactions,
-    );
+async fn test_view_tuple() {
+    let mut context = new_test_context(current_function_name!());
     let payload = aptos_stdlib::publish_module_source(
         "test_module",
         r#"
@@ -432,19 +318,8 @@ async fn test_view_tuple(use_txn_payload_v2_format: bool, use_orderless_transact
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-#[rstest(
-    use_txn_payload_v2_format,
-    use_orderless_transactions,
-    case(false, false),
-    case(true, false),
-    case(true, true)
-)]
-async fn test_view_aggregator(use_txn_payload_v2_format: bool, use_orderless_transactions: bool) {
-    let mut context = new_test_context_with_orderless_flags(
-        current_function_name!(),
-        use_txn_payload_v2_format,
-        use_orderless_transactions,
-    );
+async fn test_view_aggregator() {
+    let mut context = new_test_context(current_function_name!());
     let account = context.root_account().await;
 
     let named_addresses = vec![("addr".to_string(), account.address())];
@@ -478,19 +353,8 @@ async fn test_view_aggregator(use_txn_payload_v2_format: bool, use_orderless_tra
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-#[rstest(
-    use_txn_payload_v2_format,
-    use_orderless_transactions,
-    case(false, false),
-    case(true, false),
-    case(true, true)
-)]
-async fn test_view_option(use_txn_payload_v2_format: bool, use_orderless_transactions: bool) {
-    let mut context = new_test_context_with_orderless_flags(
-        current_function_name!(),
-        use_txn_payload_v2_format,
-        use_orderless_transactions,
-    );
+async fn test_view_option() {
+    let mut context = new_test_context(current_function_name!());
     let mut account = context.create_account().await;
     let account_addr = account.address();
 
@@ -568,19 +432,8 @@ async fn test_view_option_some(
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-#[rstest(
-    use_txn_payload_v2_format,
-    use_orderless_transactions,
-    case(false, false),
-    case(true, false),
-    case(true, true)
-)]
-async fn test_view_option_vec(use_txn_payload_v2_format: bool, use_orderless_transactions: bool) {
-    let mut context = new_test_context_with_orderless_flags(
-        current_function_name!(),
-        use_txn_payload_v2_format,
-        use_orderless_transactions,
-    );
+async fn test_view_option_vec() {
+    let mut context = new_test_context(current_function_name!());
     let mut account = context.create_account().await;
     let account_addr = account.address();
 
@@ -609,22 +462,8 @@ async fn test_view_option_vec(use_txn_payload_v2_format: bool, use_orderless_tra
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-#[rstest(
-    use_txn_payload_v2_format,
-    use_orderless_transactions,
-    case(false, false),
-    case(true, false),
-    case(true, true)
-)]
-async fn test_view_option_struct(
-    use_txn_payload_v2_format: bool,
-    use_orderless_transactions: bool,
-) {
-    let mut context = new_test_context_with_orderless_flags(
-        current_function_name!(),
-        use_txn_payload_v2_format,
-        use_orderless_transactions,
-    );
+async fn test_view_option_struct() {
+    let mut context = new_test_context(current_function_name!());
     let mut account = context.create_account().await;
     let account_addr = account.address();
 


### PR DESCRIPTION
## Summary

The `aptos-api` test suite was slow because most tests were parameterized with rstest over `(use_txn_payload_v2_format, use_orderless_transactions)` with 3 cases each. Each invocation bootstraps a full blockchain from genesis with RocksDB (~10-20s), and many also compile + publish a Move package (~5-15s). With nextest running each test in its own process, this meant ~471 total invocations for ~237 test functions.

The problem: for the vast majority of these tests, the parameters only affect how the `TestContext` constructs transactions internally. The test logic itself never branches on them — the assertions are identical regardless of payload format or ordering mode. Running 3x cases added no coverage, just 3x cost.

### What changed

**Removed unnecessary rstest parameterization (~122 invocations eliminated):**
- `multisig_transactions_test.rs`: 16 functions × 3 → 16 × 1 (saves 32)
- `view_function.rs`: 13 functions × 3 → 13 × 1 (saves 26)
- `invalid_post_request_test.rs`: 14 functions × 2 → 14 × 1 (saves 14)
- `public_struct_enum_test.rs`, `option_test.rs`, `function_value_test.rs`, `modules.rs`, `objects.rs`, `string_resource_test.rs`, `signed_int_test.rs`: various (saves ~20)
- `events_test.rs`: 2 functions reduced to 1 case, `test_module_events` reduced from 3→2 (only ordered vs orderless matters)
- `event_v2_translation_test.rs`: 2 functions reduced from 3→2 cases (ordered vs orderless)

**Merged tests sharing expensive setup (~16 genesis bootstraps eliminated):**
- `public_struct_enum_test.rs`: 15 individual entry-function tests + 3 view tests → 2 combined tests. Each previously did a full genesis + Move package compilation independently. Now one setup serves all 15 entry function calls, and another serves all 3 view calls.

**Trimmed Move package dependencies (faster compilation):**
- `public_struct_enum_test/Move.toml`: removed AptosFramework + AptosStdlib (only uses MoveStdlib)
- `test_option/Move.toml`: replaced AptosFramework with MoveStdlib
- `pack_function_values_with_struct/Move.toml`: replaced AptosFramework with MoveStdlib

### What was intentionally kept as-is
- `accounts_test.rs`, `state_test.rs`, `resource_groups.rs` — tests explicitly branch on `use_orderless_transactions` in assertions
- `transactions_test.rs`, `simulation_test.rs` — signature validation is payload-format-sensitive
- `secp256k1_ecdsa.rs`, `webauthn_secp256r1_ecdsa.rs`, `slh_dsa_sha2_128s.rs` — signature-format-dependent
- `account_abstraction_test.rs` — AA payload construction varies by format
- `test_view_option_some` — intentionally has 2 cases with feature flag interaction

## Test plan

- [x] `cargo check -p aptos-api` passes
- [x] `cargo clippy -p aptos-api --tests` — no new warnings in test files
- [x] No orphaned golden output files (golden files are keyed by function name, not rstest case)
- [x] `cargo nextest run -p aptos-api` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to tests and Move test-package manifests, primarily reducing permutations and reusing setup without altering production code paths.
> 
> **Overview**
> Speeds up the `aptos-api` integration test suite by **removing redundant `rstest` parameterization** across many tests (most now run a single `(false,false)` config, while a few keep only the meaningful `case(false,false)` vs `case(true,true)` split).
> 
> Consolidates the public struct/enum API coverage by **merging many per-case tests into two shared-setup tests** (one for entry functions and one for `/view`), reducing repeated genesis + Move package compilation.
> 
> Trims Move test package build time by **dropping `AptosFramework`/`AptosStdlib` dependencies** in several `Move.toml` files in favor of `MoveStdlib`, and updates some tests to use `new_test_context` where flags are no longer needed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 332f6d14f06d026d166c02e23832876fb749a2bd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->