### PR TITLE
Deserialize DigestKey without compression or validation, to improve speed

### DIFF
--- a/crates/aptos-batch-encryption/src/shared/algebra/fk_algorithm.rs
+++ b/crates/aptos-batch-encryption/src/shared/algebra/fk_algorithm.rs
@@ -24,14 +24,20 @@ use std::{fmt, marker::PhantomData, ops::Mul};
 /// subset a "domain".
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CirculantDomain<F: FftField> {
-    #[serde(serialize_with = "ark_se_uncompressed", deserialize_with = "ark_de_uncompressed_no_validate")]
+    #[serde(
+        serialize_with = "ark_se_uncompressed",
+        deserialize_with = "ark_de_uncompressed_no_validate"
+    )]
     fft_domain: Radix2EvaluationDomain<F>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PreparedInput<F: FftField, T: DomainCoeff<F> + CanonicalSerialize + CanonicalDeserialize>
 {
-    #[serde(serialize_with = "ark_se_uncompressed", deserialize_with = "ark_de_uncompressed_no_validate")]
+    #[serde(
+        serialize_with = "ark_se_uncompressed",
+        deserialize_with = "ark_de_uncompressed_no_validate"
+    )]
     pub y: Vec<T>,
     _phantom: PhantomData<F>,
 }

--- a/crates/aptos-batch-encryption/src/shared/digest.rs
+++ b/crates/aptos-batch-encryption/src/shared/digest.rs
@@ -9,7 +9,9 @@ use crate::{
     shared::{algebra::fk_algorithm::FKDomain, ids::UncomputedCoeffs},
 };
 use anyhow::{anyhow, Result};
-use aptos_crypto::arkworks::serialization::{ark_de, ark_se, ark_se_uncompressed, ark_de_uncompressed_no_validate};
+use aptos_crypto::arkworks::serialization::{
+    ark_de, ark_de_uncompressed_no_validate, ark_se, ark_se_uncompressed,
+};
 use ark_ec::{pairing::Pairing, AffineRepr, ScalarMul, VariableBaseMSM};
 use ark_std::{
     rand::{CryptoRng, RngCore},
@@ -25,9 +27,15 @@ use std::{
 /// The digest public parameters.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct DigestKey {
-    #[serde(serialize_with = "ark_se_uncompressed", deserialize_with = "ark_de_uncompressed_no_validate")]
+    #[serde(
+        serialize_with = "ark_se_uncompressed",
+        deserialize_with = "ark_de_uncompressed_no_validate"
+    )]
     pub tau_g2: G2Affine,
-    #[serde(serialize_with = "ark_se_uncompressed", deserialize_with = "ark_de_uncompressed_no_validate")]
+    #[serde(
+        serialize_with = "ark_se_uncompressed",
+        deserialize_with = "ark_de_uncompressed_no_validate"
+    )]
     pub tau_powers_g1: Vec<Vec<G1Affine>>,
     pub fk_domain: FKDomain<Fr, G1Projective>,
 }

--- a/crates/aptos-batch-encryption/src/tests/digest_key_bench.rs
+++ b/crates/aptos-batch-encryption/src/tests/digest_key_bench.rs
@@ -17,7 +17,14 @@ fn bench_digest_key_generate_serialize_deserialize() {
     println!();
     println!(
         "{:<12} {:<12} {:<20} {:<20} {:<15} {:<20} {:<20} {:<15}",
-        "batch_size", "num_rounds", "generate (s)", "serialize (s)", "file_size (MB)", "write_file (s)", "deserialize (s)", "read_file (s)"
+        "batch_size",
+        "num_rounds",
+        "generate (s)",
+        "serialize (s)",
+        "file_size (MB)",
+        "write_file (s)",
+        "deserialize (s)",
+        "read_file (s)"
     );
     println!("{}", "-".repeat(134));
 
@@ -34,10 +41,7 @@ fn bench_digest_key_generate_serialize_deserialize() {
             let bytes = bcs::to_bytes(&dk).expect("BCS serialization should succeed");
             let serialize_elapsed = start.elapsed();
 
-            let file_path = format!(
-                "/tmp/digest_key_b{}_r{}.bcs",
-                batch_size, num_rounds
-            );
+            let file_path = format!("/tmp/digest_key_b{}_r{}.bcs", batch_size, num_rounds);
             let start = Instant::now();
             std::fs::write(&file_path, &bytes).expect("File write should succeed");
             let write_elapsed = start.elapsed();
@@ -89,8 +93,7 @@ fn bench_digest_key_deserialize_from_file() {
     println!("Read time: {:.3} s", read_elapsed.as_secs_f64());
 
     let start = Instant::now();
-    let _dk: DigestKey =
-        bcs::from_bytes(&read_bytes).expect("BCS deserialization should succeed");
+    let _dk: DigestKey = bcs::from_bytes(&read_bytes).expect("BCS deserialization should succeed");
     let deserialize_elapsed = start.elapsed();
 
     println!(

--- a/crates/aptos-batch-encryption/src/tests/mod.rs
+++ b/crates/aptos-batch-encryption/src/tests/mod.rs
@@ -8,6 +8,8 @@ use crate::{
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 
 #[cfg(test)]
+mod digest_key_bench;
+#[cfg(test)]
 pub mod fptx_smoke;
 #[cfg(test)]
 pub mod fptx_succinct_smoke;
@@ -15,8 +17,6 @@ pub mod fptx_succinct_smoke;
 pub mod fptx_weighted_smoke;
 #[cfg(test)]
 pub mod typescript;
-#[cfg(test)]
-mod digest_key_bench;
 
 pub fn prepare_all<T: BatchThresholdEncryption, P: Plaintext>(
     cts: &[T::Ciphertext],

--- a/crates/aptos-crypto/src/arkworks/serialization.rs
+++ b/crates/aptos-crypto/src/arkworks/serialization.rs
@@ -49,7 +49,9 @@ where
 }
 
 /// Serialize without compression or validation
-pub fn ark_de_uncompressed_no_validate<'de, D, A: CanonicalDeserialize>(data: D) -> Result<A, D::Error>
+pub fn ark_de_uncompressed_no_validate<'de, D, A: CanonicalDeserialize>(
+    data: D,
+) -> Result<A, D::Error>
 where
     D: serde::de::Deserializer<'de>,
 {
@@ -57,7 +59,6 @@ where
     let a = A::deserialize_with_mode(s.reader(), Compress::No, Validate::No);
     a.map_err(serde::de::Error::custom)
 }
-
 
 /// TODO: Not sure this is a good idea, will probably remove it in the next PR?
 pub trait BatchSerializable<E: Pairing> {


### PR DESCRIPTION
DigestKey will come from a trusted source, so skipping validation is safe.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes serialization/deserialization modes for cryptographic parameters (now uncompressed and skipping validation), which can affect wire compatibility and removes safety checks if inputs are ever untrusted.
> 
> **Overview**
> Speeds up `DigestKey` (and related FK domain input/domain) persistence by switching serde helpers to **uncompressed** Arkworks encoding and **skipping validation** during deserialization (new `ark_se_uncompressed`/`ark_de_uncompressed_no_validate`, and `ark_de` now disables validation).
> 
> Adds ignored test/bench helpers to generate, serialize to disk, and deserialize `DigestKey` across several batch sizes/round counts for performance and file-size measurement.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e10e021fc897d9e2d2d57c067c59a99468e3bcc4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->