### PR TITLE
[storage] Enable pruning for hot state KV DB

### DIFF
--- a/storage/aptosdb/src/db/aptosdb_internal.rs
+++ b/storage/aptosdb/src/db/aptosdb_internal.rs
@@ -62,10 +62,10 @@ impl AptosDB {
         let state_merkle_db = Arc::new(state_merkle_db);
         let hot_state_kv_db = hot_state_kv_db.map(Arc::new);
         let state_kv_db = Arc::new(state_kv_db);
-        // TODO(HotState): hook up `hot_state_kv_db` with a pruner.
         let state_pruner = StatePruner::new(
             hot_state_merkle_db.clone(),
             Arc::clone(&state_merkle_db),
+            hot_state_kv_db.clone(),
             Arc::clone(&state_kv_db),
             pruner_config,
         );
@@ -169,6 +169,9 @@ impl AptosDB {
                     .state_pruner
                     .state_kv_pruner
                     .maybe_set_pruner_target_db_version(version);
+                if let Some(pruner) = &myself.state_store.state_pruner.hot_state_kv_pruner {
+                    pruner.maybe_set_pruner_target_db_version(version);
+                }
             }
             if let Some(version) = myself.get_latest_state_checkpoint_version()? {
                 myself

--- a/storage/aptosdb/src/db/aptosdb_writer.rs
+++ b/storage/aptosdb/src/db/aptosdb_writer.rs
@@ -633,6 +633,9 @@ impl AptosDB {
                 .state_pruner
                 .state_kv_pruner
                 .maybe_set_pruner_target_db_version(version);
+            if let Some(pruner) = &self.state_store.state_pruner.hot_state_kv_pruner {
+                pruner.maybe_set_pruner_target_db_version(version);
+            }
         }
 
         // Once everything is successfully persisted, update the latest in-memory ledger info.

--- a/storage/aptosdb/src/db_options.rs
+++ b/storage/aptosdb/src/db_options.rs
@@ -115,6 +115,7 @@ pub(super) fn hot_state_kv_db_column_families() -> Vec<ColumnFamilyName> {
         /* empty cf */ DEFAULT_COLUMN_FAMILY_NAME,
         DB_METADATA_CF_NAME,
         HOT_STATE_VALUE_BY_KEY_HASH_CF_NAME,
+        STALE_STATE_VALUE_INDEX_BY_KEY_HASH_CF_NAME,
     ]
 }
 

--- a/storage/aptosdb/src/pruner/state_kv_pruner/mod.rs
+++ b/storage/aptosdb/src/pruner/state_kv_pruner/mod.rs
@@ -28,13 +28,12 @@ use std::{
     sync::{atomic::Ordering, Arc},
 };
 
-pub const STATE_KV_PRUNER_NAME: &str = "state_kv_pruner";
-
 /// Responsible for pruning state kv db.
 pub(crate) struct StateKvPruner {
     /// Keeps track of the target version that the pruner needs to achieve.
     target_version: AtomicVersion,
     progress: AtomicVersion,
+    name: &'static str,
 
     metadata_pruner: StateKvMetadataPruner,
     shard_pruners: Vec<StateKvShardPruner>,
@@ -42,11 +41,11 @@ pub(crate) struct StateKvPruner {
 
 impl DBPruner for StateKvPruner {
     fn name(&self) -> &'static str {
-        STATE_KV_PRUNER_NAME
+        self.name
     }
 
     fn prune(&self, max_versions: usize) -> Result<Version> {
-        let _timer = OTHER_TIMERS_SECONDS.timer_with(&["state_kv_pruner__prune"]);
+        let _timer = OTHER_TIMERS_SECONDS.timer_with(&[&format!("{}__prune", self.name)]);
 
         let mut progress = self.progress();
         let target_version = self.target_version();
@@ -58,6 +57,7 @@ impl DBPruner for StateKvPruner {
             info!(
                 progress = progress,
                 target_version = current_batch_target_version,
+                name = self.name,
                 "Pruning state kv data."
             );
             self.metadata_pruner.prune(current_batch_target_version)?;
@@ -77,7 +77,11 @@ impl DBPruner for StateKvPruner {
 
             progress = current_batch_target_version;
             self.record_progress(progress);
-            info!(progress = progress, "Pruning state kv data is done.");
+            info!(
+                progress = progress,
+                name = self.name,
+                "Pruning state kv data is done."
+            );
         }
 
         Ok(target_version)
@@ -90,7 +94,7 @@ impl DBPruner for StateKvPruner {
     fn set_target_version(&self, target_version: Version) {
         self.target_version.store(target_version, Ordering::SeqCst);
         PRUNER_VERSIONS
-            .with_label_values(&["state_kv_pruner", "target"])
+            .with_label_values(&[self.name, "target"])
             .set(target_version as i64);
     }
 
@@ -101,14 +105,19 @@ impl DBPruner for StateKvPruner {
     fn record_progress(&self, progress: Version) {
         self.progress.store(progress, Ordering::SeqCst);
         PRUNER_VERSIONS
-            .with_label_values(&["state_kv_pruner", "progress"])
+            .with_label_values(&[self.name, "progress"])
             .set(progress as i64);
     }
 }
 
 impl StateKvPruner {
     pub fn new(state_kv_db: Arc<StateKvDb>) -> Result<Self> {
-        info!(name = STATE_KV_PRUNER_NAME, "Initializing...");
+        let name = if state_kv_db.is_hot() {
+            "hot_state_kv_pruner"
+        } else {
+            "state_kv_pruner"
+        };
+        info!(name = name, "Initializing...");
 
         let metadata_pruner = StateKvMetadataPruner::new(Arc::clone(&state_kv_db));
 
@@ -116,6 +125,7 @@ impl StateKvPruner {
 
         info!(
             metadata_progress = metadata_progress,
+            name = name,
             "Created state kv metadata pruner, start catching up all shards."
         );
 
@@ -126,12 +136,14 @@ impl StateKvPruner {
                 shard_id,
                 state_kv_db.db_shard_arc(shard_id),
                 metadata_progress,
+                state_kv_db.is_hot(),
             )?);
         }
 
         let pruner = StateKvPruner {
             target_version: AtomicVersion::new(metadata_progress),
             progress: AtomicVersion::new(metadata_progress),
+            name,
             metadata_pruner,
             shard_pruners,
         };

--- a/storage/aptosdb/src/pruner/state_kv_pruner/state_kv_pruner_manager.rs
+++ b/storage/aptosdb/src/pruner/state_kv_pruner/state_kv_pruner_manager.rs
@@ -17,6 +17,8 @@ use std::sync::{atomic::Ordering, Arc};
 /// The `PrunerManager` for `StateKvPruner`.
 pub(crate) struct StateKvPrunerManager {
     state_kv_db: Arc<StateKvDb>,
+    /// Pruner name for metrics and logging.
+    name: &'static str,
     /// DB version window, which dictates how many version of state values to keep.
     prune_window: Version,
     /// It is None iff the pruner is not enabled.
@@ -59,7 +61,7 @@ impl PrunerManager for StateKvPrunerManager {
             .store(min_readable_version, Ordering::SeqCst);
 
         PRUNER_VERSIONS
-            .with_label_values(&["state_kv_pruner", "min_readable"])
+            .with_label_values(&[self.name, "min_readable"])
             .set(min_readable_version as i64);
 
         self.state_kv_db.write_pruner_progress(min_readable_version)
@@ -83,6 +85,12 @@ impl PrunerManager for StateKvPrunerManager {
 
 impl StateKvPrunerManager {
     pub fn new(state_kv_db: Arc<StateKvDb>, state_kv_pruner_config: LedgerPrunerConfig) -> Self {
+        let name = if state_kv_db.is_hot() {
+            "hot_state_kv_pruner"
+        } else {
+            "state_kv_pruner"
+        };
+
         let pruner_worker = if state_kv_pruner_config.enable {
             Some(Self::init_pruner(
                 Arc::clone(&state_kv_db),
@@ -96,11 +104,12 @@ impl StateKvPrunerManager {
             pruner_utils::get_state_kv_pruner_progress(&state_kv_db).expect("Must succeed.");
 
         PRUNER_VERSIONS
-            .with_label_values(&["state_kv_pruner", "min_readable"])
+            .with_label_values(&[name, "min_readable"])
             .set(min_readable_version as i64);
 
         Self {
             state_kv_db,
+            name,
             prune_window: state_kv_pruner_config.prune_window,
             pruner_worker,
             pruning_batch_size: state_kv_pruner_config.batch_size,
@@ -112,18 +121,20 @@ impl StateKvPrunerManager {
         state_kv_db: Arc<StateKvDb>,
         state_kv_pruner_config: LedgerPrunerConfig,
     ) -> PrunerWorker {
+        let is_hot = state_kv_db.is_hot();
         let pruner =
             Arc::new(StateKvPruner::new(state_kv_db).expect("Failed to create state kv pruner."));
 
         PRUNER_WINDOW
-            .with_label_values(&["state_kv_pruner"])
+            .with_label_values(&[pruner.name])
             .set(state_kv_pruner_config.prune_window as i64);
 
         PRUNER_BATCH_SIZE
-            .with_label_values(&["state_kv_pruner"])
+            .with_label_values(&[pruner.name])
             .set(state_kv_pruner_config.batch_size as i64);
 
-        PrunerWorker::new(pruner, state_kv_pruner_config.batch_size, "state_kv")
+        let worker_name = if is_hot { "hot_state_kv" } else { "state_kv" };
+        PrunerWorker::new(pruner, state_kv_pruner_config.batch_size, worker_name)
     }
 
     fn set_pruner_target_db_version(&self, latest_version: Version) {
@@ -133,7 +144,7 @@ impl StateKvPrunerManager {
             .store(min_readable_version, Ordering::SeqCst);
 
         PRUNER_VERSIONS
-            .with_label_values(&["state_kv_pruner", "min_readable"])
+            .with_label_values(&[self.name, "min_readable"])
             .set(min_readable_version as i64);
 
         self.pruner_worker

--- a/storage/aptosdb/src/pruner/state_kv_pruner/state_kv_shard_pruner.rs
+++ b/storage/aptosdb/src/pruner/state_kv_pruner/state_kv_shard_pruner.rs
@@ -5,6 +5,7 @@ use crate::{
     pruner::pruner_utils::get_or_initialize_subpruner_progress,
     schema::{
         db_metadata::{DbMetadataKey, DbMetadataSchema, DbMetadataValue},
+        hot_state_value_by_key_hash::HotStateValueByKeyHashSchema,
         stale_state_value_index_by_key_hash::StaleStateValueIndexByKeyHashSchema,
         state_value_by_key_hash::StateValueByKeyHashSchema,
     },
@@ -19,6 +20,7 @@ use std::sync::Arc;
 pub(in crate::pruner) struct StateKvShardPruner {
     shard_id: usize,
     db_shard: Arc<DB>,
+    is_hot: bool,
 }
 
 impl StateKvShardPruner {
@@ -26,17 +28,23 @@ impl StateKvShardPruner {
         shard_id: usize,
         db_shard: Arc<DB>,
         metadata_progress: Version,
+        is_hot: bool,
     ) -> Result<Self> {
         let progress = get_or_initialize_subpruner_progress(
             &db_shard,
             &DbMetadataKey::StateKvShardPrunerProgress(shard_id),
             metadata_progress,
         )?;
-        let myself = Self { shard_id, db_shard };
+        let myself = Self {
+            shard_id,
+            db_shard,
+            is_hot,
+        };
 
         info!(
             progress = progress,
             metadata_progress = metadata_progress,
+            is_hot = is_hot,
             "Catching up state kv shard {shard_id}."
         );
         myself.prune(progress, metadata_progress)?;
@@ -64,8 +72,12 @@ impl StateKvShardPruner {
             }
             batch.delete::<StaleStateValueIndexByKeyHashSchema>(&index)?;
             if !index.is_first_write() {
-                batch
-                    .delete::<StateValueByKeyHashSchema>(&(index.state_key_hash, index.version))?;
+                let db_key = (index.state_key_hash, index.version);
+                if self.is_hot {
+                    batch.delete::<HotStateValueByKeyHashSchema>(&db_key)?;
+                } else {
+                    batch.delete::<StateValueByKeyHashSchema>(&db_key)?;
+                }
             }
         }
         batch.put::<DbMetadataSchema>(

--- a/storage/aptosdb/src/state_kv_db.rs
+++ b/storage/aptosdb/src/state_kv_db.rs
@@ -68,6 +68,10 @@ pub struct StateKvDb {
 }
 
 impl StateKvDb {
+    pub(crate) fn is_hot(&self) -> bool {
+        self.is_hot
+    }
+
     fn db_tag(&self) -> &'static str {
         if self.is_hot {
             "hot"

--- a/storage/aptosdb/src/state_store/mod.rs
+++ b/storage/aptosdb/src/state_store/mod.rs
@@ -104,6 +104,7 @@ pub const MAX_COMMIT_PROGRESS_DIFFERENCE: u64 = 1_000_000;
 pub(crate) struct StatePruner {
     pub hot_state_merkle_pruner: Option<StateMerklePrunerManager<StaleNodeIndexSchema>>,
     pub hot_epoch_snapshot_pruner: Option<StateMerklePrunerManager<StaleNodeIndexCrossEpochSchema>>,
+    pub hot_state_kv_pruner: Option<StateKvPrunerManager>,
     pub state_merkle_pruner: StateMerklePrunerManager<StaleNodeIndexSchema>,
     pub epoch_snapshot_pruner: StateMerklePrunerManager<StaleNodeIndexCrossEpochSchema>,
     pub state_kv_pruner: StateKvPrunerManager,
@@ -113,6 +114,7 @@ impl StatePruner {
     pub fn new(
         hot_state_merkle_db: Option<Arc<StateMerkleDb>>,
         state_merkle_db: Arc<StateMerkleDb>,
+        hot_state_kv_db: Option<Arc<StateKvDb>>,
         state_kv_db: Arc<StateKvDb>,
         config: PrunerConfig,
     ) -> Self {
@@ -122,6 +124,8 @@ impl StatePruner {
         let hot_epoch_snapshot_pruner = hot_state_merkle_db.map(|db| {
             StateMerklePrunerManager::new(db, config.epoch_snapshot_pruner_config.into())
         });
+        let hot_state_kv_pruner =
+            hot_state_kv_db.map(|db| StateKvPrunerManager::new(db, config.ledger_pruner_config));
         let state_merkle_pruner = StateMerklePrunerManager::new(
             Arc::clone(&state_merkle_db),
             config.state_merkle_pruner_config,
@@ -140,6 +144,7 @@ impl StatePruner {
         Self {
             hot_state_merkle_pruner,
             hot_epoch_snapshot_pruner,
+            hot_state_kv_pruner,
             state_merkle_pruner,
             epoch_snapshot_pruner,
             state_kv_pruner,
@@ -540,6 +545,7 @@ impl StateStore {
         let state_pruner = StatePruner::new(
             hot_state_merkle_db.clone(),
             Arc::clone(&state_merkle_db),
+            hot_state_kv_db.clone(),
             Arc::clone(&state_kv_db),
             aptos_config::config::NO_OP_STORAGE_PRUNER_CONFIG,
         );
@@ -853,30 +859,60 @@ impl StateStore {
                 .par_iter_mut()
                 .zip_eq(shard_updates.par_iter())
                 .try_for_each(|(batch, shard)| {
-                    for (key_hash, (hot_val, value_version_opt)) in &shard.insertions {
-                        let schema_value = match hot_val.value_opt() {
+                    for (key_hash, op) in &shard.insertions {
+                        let schema_value = match op.value.value_opt() {
                             Some(value) => HotStateEntry::Occupied {
                                 value: value.clone(),
-                                value_version: value_version_opt
+                                value_version: op
+                                    .value_version
                                     .expect("occupied must have value_version"),
                             },
                             None => {
                                 assert!(
-                                    value_version_opt.is_none(),
+                                    op.value_version.is_none(),
                                     "vacant must not have value_version"
                                 );
                                 HotStateEntry::Vacant
                             },
                         };
                         batch.put::<HotStateValueByKeyHashSchema>(
-                            &(*key_hash, hot_val.hot_since_version()),
+                            &(*key_hash, op.value.hot_since_version()),
                             &Some(schema_value),
                         )?;
+                        batch.put::<StaleStateValueIndexByKeyHashSchema>(
+                            &StaleStateValueByKeyHashIndex {
+                                stale_since_version: op.value.hot_since_version(),
+                                version: op
+                                    .superseded_version
+                                    .unwrap_or(StaleStateValueByKeyHashIndex::NO_PREV_VERSION),
+                                state_key_hash: *key_hash,
+                            },
+                            &(),
+                        )?;
                     }
-                    for (key_hash, eviction_version) in &shard.evictions {
+                    for (key_hash, op) in &shard.evictions {
                         batch.put::<HotStateValueByKeyHashSchema>(
-                            &(*key_hash, *eviction_version),
+                            &(*key_hash, op.eviction_version),
                             &None,
+                        )?;
+                        batch.put::<StaleStateValueIndexByKeyHashSchema>(
+                            &StaleStateValueByKeyHashIndex {
+                                stale_since_version: op.eviction_version,
+                                version: op
+                                    .superseded_version
+                                    .unwrap_or(StaleStateValueByKeyHashIndex::NO_PREV_VERSION),
+                                state_key_hash: *key_hash,
+                            },
+                            &(),
+                        )?;
+                        // Self-referential stale entry for the eviction tombstone itself.
+                        batch.put::<StaleStateValueIndexByKeyHashSchema>(
+                            &StaleStateValueByKeyHashIndex {
+                                stale_since_version: op.eviction_version,
+                                version: op.eviction_version,
+                                state_key_hash: *key_hash,
+                            },
+                            &(),
                         )?;
                     }
                     Ok(())

--- a/storage/aptosdb/src/state_store/tests/hot_state_kv.rs
+++ b/storage/aptosdb/src/state_store/tests/hot_state_kv.rs
@@ -3,25 +3,35 @@
 
 use crate::{
     db::AptosDB,
-    schema::hot_state_value_by_key_hash::{HotStateEntry, HotStateValueByKeyHashSchema},
+    pruner::PrunerManager,
+    schema::{
+        hot_state_value_by_key_hash::{HotStateEntry, HotStateValueByKeyHashSchema},
+        stale_state_value_index_by_key_hash::StaleStateValueIndexByKeyHashSchema,
+    },
     state_kv_db::{LoadedHotStateShard, StateKvDb},
 };
 use aptos_config::config::{RocksdbConfig, StorageDirPaths};
 use aptos_crypto::{hash::CryptoHash, HashValue};
 use aptos_schemadb::batch::WriteBatch;
-use aptos_storage_interface::state_store::{HotStateShardUpdates, HotStateUpdates};
+use aptos_storage_interface::state_store::{
+    HotEvictionOp, HotInsertionOp, HotStateShardUpdates, HotStateUpdates,
+};
 use aptos_temppath::TempPath;
 use aptos_types::{
     state_store::{
         hot_state::{HotStateValue, THotStateSlot},
         state_key::StateKey,
         state_slot::StateSlotKind,
-        state_value::StateValue,
+        state_value::{StaleStateValueByKeyHashIndex, StateValue},
         NUM_STATE_SHARDS,
     },
     transaction::Version,
 };
 use std::collections::HashMap;
+
+fn new_empty_shard_updates() -> [HotStateShardUpdates; NUM_STATE_SHARDS] {
+    std::array::from_fn(|_| HotStateShardUpdates::new(HashMap::new(), HashMap::new()))
+}
 
 fn create_hot_state_kv_db(path: &TempPath) -> StateKvDb {
     StateKvDb::new(
@@ -159,71 +169,6 @@ fn test_multiple_versions() {
     let (older_version, older_entry) = db.get_hot_state_entry_by_version(&key, 1).unwrap().unwrap();
     assert_eq!(older_version, 1);
     assert_eq!(older_entry, expected_entry);
-}
-
-#[test]
-fn test_put_hot_state_updates_integration() {
-    let tmp = TempPath::new();
-    let aptos_db = AptosDB::new_for_test(&tmp);
-    let hot_state_kv_db = aptos_db.hot_state_kv_db.as_ref().unwrap();
-
-    let key1 = make_state_key(10);
-    let val1 = make_state_value(10);
-    let key2 = make_state_key(20);
-    let key3 = make_state_key(30);
-
-    let mut shards: [HotStateShardUpdates; NUM_STATE_SHARDS] =
-        std::array::from_fn(|_| HotStateShardUpdates::new(HashMap::new(), HashMap::new()));
-
-    // key1: occupied insertion at hot_since_version=100, value_version=50
-    shards[key1.get_shard_id()].insertions.insert(
-        *key1.crypto_hash_ref(),
-        (HotStateValue::new(Some(val1.clone()), 100), Some(50)),
-    );
-
-    // key2: vacant insertion at hot_since_version=200
-    shards[key2.get_shard_id()].insertions.insert(
-        *key2.crypto_hash_ref(),
-        (HotStateValue::new(None, 200), None),
-    );
-
-    // key3: eviction at version=300
-    shards[key3.get_shard_id()]
-        .evictions
-        .insert(*key3.crypto_hash_ref(), 300);
-
-    let hot_state_updates = HotStateUpdates {
-        for_last_checkpoint: Some(shards),
-        for_latest: None,
-    };
-
-    let mut sharded_batches = hot_state_kv_db.new_sharded_native_batches();
-    aptos_db
-        .state_store
-        .put_hot_state_updates(&hot_state_updates, &mut sharded_batches)
-        .unwrap();
-    hot_state_kv_db.commit(999, None, sharded_batches).unwrap();
-
-    // Verify key1: occupied
-    assert_eq!(
-        get_hot_state_entry(hot_state_kv_db, &key1, 100).unwrap(),
-        HotStateEntry::Occupied {
-            value: val1,
-            value_version: 50,
-        }
-    );
-
-    // Verify key2: vacant
-    assert_eq!(
-        get_hot_state_entry(hot_state_kv_db, &key2, 200).unwrap(),
-        HotStateEntry::Vacant,
-    );
-
-    // Verify key3: eviction (None)
-    assert!(
-        get_hot_state_entry(hot_state_kv_db, &key3, 300).is_none(),
-        "Eviction should be None"
-    );
 }
 
 // ---------------------------------------------------------------------------
@@ -565,20 +510,25 @@ fn test_load_write_then_load_roundtrip() {
     let val1 = make_state_value(10);
     let key2 = make_state_key(20);
 
-    let mut shards: [HotStateShardUpdates; NUM_STATE_SHARDS] =
-        std::array::from_fn(|_| HotStateShardUpdates::new(HashMap::new(), HashMap::new()));
+    let mut shards = new_empty_shard_updates();
 
     // key1: occupied at hot_since_version=100, value_version=50
-    shards[key1.get_shard_id()].insertions.insert(
-        *key1.crypto_hash_ref(),
-        (HotStateValue::new(Some(val1.clone()), 100), Some(50)),
-    );
+    shards[key1.get_shard_id()]
+        .insertions
+        .insert(*key1.crypto_hash_ref(), HotInsertionOp {
+            value: HotStateValue::new(Some(val1.clone()), 100),
+            value_version: Some(50),
+            superseded_version: None,
+        });
 
     // key2: vacant at hot_since_version=200
-    shards[key2.get_shard_id()].insertions.insert(
-        *key2.crypto_hash_ref(),
-        (HotStateValue::new(None, 200), None),
-    );
+    shards[key2.get_shard_id()]
+        .insertions
+        .insert(*key2.crypto_hash_ref(), HotInsertionOp {
+            value: HotStateValue::new(None, 200),
+            value_version: None,
+            superseded_version: None,
+        });
 
     let hot_state_updates = HotStateUpdates {
         for_last_checkpoint: Some(shards),
@@ -625,4 +575,286 @@ fn test_load_write_then_load_roundtrip() {
         other => panic!("Expected HotVacant for key2, got {other:?}"),
     }
     shard2.validate_lru_chain();
+}
+
+// ---------------------------------------------------------------------------
+// Stale index and pruning tests
+// ---------------------------------------------------------------------------
+
+/// Collect all stale index entries from the given shard DB.
+fn collect_stale_indices(db: &StateKvDb, shard_id: usize) -> Vec<StaleStateValueByKeyHashIndex> {
+    let mut iter = db
+        .db_shard(shard_id)
+        .iter::<StaleStateValueIndexByKeyHashSchema>()
+        .unwrap();
+    iter.seek(&0u64).unwrap();
+    iter.map(|item| item.unwrap().0).collect()
+}
+
+#[test]
+fn test_stale_index_direct_write_read() {
+    // Minimal test: verify the stale index CF works on a hot state KV DB.
+    let tmp = TempPath::new();
+    let db = create_hot_state_kv_db(&tmp);
+    let key = make_state_key(1);
+    let shard_id = key.get_shard_id();
+
+    let idx = StaleStateValueByKeyHashIndex {
+        stale_since_version: 100,
+        version: 50,
+        state_key_hash: CryptoHash::hash(&key),
+    };
+
+    let mut batch = db.db_shard(shard_id).new_native_batch();
+    batch
+        .put::<StaleStateValueIndexByKeyHashSchema>(&idx, &())
+        .unwrap();
+    db.db_shard(shard_id).write_schemas(batch).unwrap();
+
+    let entries = collect_stale_indices(&db, shard_id);
+    assert_eq!(
+        entries.len(),
+        1,
+        "should find 1 stale entry, found {}",
+        entries.len()
+    );
+    assert_eq!(entries[0].stale_since_version, 100);
+    assert_eq!(entries[0].version, 50);
+}
+
+#[test]
+fn test_put_hot_state_updates_values_and_stale_indices() {
+    let tmp = TempPath::new();
+    let aptos_db = AptosDB::new_for_test(&tmp);
+    let hot_state_kv_db = aptos_db.hot_state_kv_db.as_ref().unwrap();
+
+    let key1 = make_state_key(10);
+    let val1 = make_state_value(10);
+    let key2 = make_state_key(20);
+    let key3 = make_state_key(30);
+
+    let mut shards = new_empty_shard_updates();
+
+    // key1: first write (no superseded version) at hot_since_version=100
+    shards[key1.get_shard_id()]
+        .insertions
+        .insert(*key1.crypto_hash_ref(), HotInsertionOp {
+            value: HotStateValue::new(Some(val1.clone()), 100),
+            value_version: Some(50),
+            superseded_version: None,
+        });
+
+    // key2: insertion superseding an old entry at hot_since_version=80
+    shards[key2.get_shard_id()]
+        .insertions
+        .insert(*key2.crypto_hash_ref(), HotInsertionOp {
+            value: HotStateValue::new(None, 200),
+            value_version: None,
+            superseded_version: Some(80),
+        });
+
+    // key3: eviction only (key was hot from before at hot_since=150, now evicted at 300).
+    shards[key3.get_shard_id()]
+        .evictions
+        .insert(*key3.crypto_hash_ref(), HotEvictionOp {
+            eviction_version: 300,
+            superseded_version: Some(150),
+        });
+
+    let hot_state_updates = HotStateUpdates {
+        for_last_checkpoint: Some(shards),
+        for_latest: None,
+    };
+
+    let mut sharded_batches = hot_state_kv_db.new_sharded_native_batches();
+    aptos_db
+        .state_store
+        .put_hot_state_updates(&hot_state_updates, &mut sharded_batches)
+        .unwrap();
+    hot_state_kv_db.commit(999, None, sharded_batches).unwrap();
+
+    // -- Verify value entries --
+
+    // key1: occupied
+    assert_eq!(
+        get_hot_state_entry(hot_state_kv_db, &key1, 100).unwrap(),
+        HotStateEntry::Occupied {
+            value: val1,
+            value_version: 50,
+        }
+    );
+    // key2: vacant
+    assert_eq!(
+        get_hot_state_entry(hot_state_kv_db, &key2, 200).unwrap(),
+        HotStateEntry::Vacant,
+    );
+    // key3: eviction (None)
+    assert!(
+        get_hot_state_entry(hot_state_kv_db, &key3, 300).is_none(),
+        "Eviction should be None"
+    );
+
+    // -- Verify stale index entries --
+
+    // Check all shards for any stale entries
+    let total_stale: usize = (0..NUM_STATE_SHARDS)
+        .map(|s| collect_stale_indices(hot_state_kv_db, s).len())
+        .sum();
+    assert!(
+        total_stale > 0,
+        "expected some stale entries across all shards, found 0. key1 shard={}, key2 shard={}, key3 shard={}",
+        key1.get_shard_id(), key2.get_shard_id(), key3.get_shard_id()
+    );
+
+    // key1: should have one stale index entry with NO_PREV_VERSION (first write)
+    let stale1 = collect_stale_indices(hot_state_kv_db, key1.get_shard_id());
+    let key1_entries: Vec<_> = stale1
+        .iter()
+        .filter(|e| e.state_key_hash == CryptoHash::hash(&key1))
+        .collect();
+    assert_eq!(key1_entries.len(), 1);
+    assert_eq!(key1_entries[0].stale_since_version, 100);
+    assert!(key1_entries[0].is_first_write());
+
+    // key2: should have one stale index entry with old version 80
+    let stale2 = collect_stale_indices(hot_state_kv_db, key2.get_shard_id());
+    let key2_entries: Vec<_> = stale2
+        .iter()
+        .filter(|e| e.state_key_hash == CryptoHash::hash(&key2))
+        .collect();
+    assert_eq!(key2_entries.len(), 1);
+    assert_eq!(key2_entries[0].stale_since_version, 200);
+    assert_eq!(key2_entries[0].version, 80);
+
+    // key3: should have two stale index entries from the eviction:
+    //   1. stale_since=300, version=150 (old entry superseded by eviction)
+    //   2. stale_since=300, version=300 (tombstone self-ref)
+    let stale3 = collect_stale_indices(hot_state_kv_db, key3.get_shard_id());
+    let mut key3_entries: Vec<_> = stale3
+        .iter()
+        .filter(|e| e.state_key_hash == CryptoHash::hash(&key3))
+        .cloned()
+        .collect();
+    key3_entries.sort_by_key(|e| (e.stale_since_version, e.version));
+    assert_eq!(
+        key3_entries.len(),
+        2,
+        "key3 stale entries: {key3_entries:#?}"
+    );
+    // Eviction supersedes old entry at 150
+    assert_eq!(key3_entries[0].stale_since_version, 300);
+    assert_eq!(key3_entries[0].version, 150);
+    // Self-referential tombstone
+    assert_eq!(key3_entries[1].stale_since_version, 300);
+    assert_eq!(key3_entries[1].version, 300);
+}
+
+#[test]
+fn test_hot_state_kv_pruner_deletes_old_entries() {
+    use aptos_config::config::{
+        HotStateConfig, PrunerConfig, RocksdbConfigs, StorageDirPaths,
+        DEFAULT_MAX_NUM_NODES_PER_LRU_CACHE_SHARD,
+    };
+
+    let tmp = TempPath::new();
+    // Open with pruner enabled (prune_window=0 so everything is immediately prunable).
+    let mut pruner_config = PrunerConfig::default();
+    pruner_config.ledger_pruner_config.enable = true;
+    pruner_config.ledger_pruner_config.prune_window = 0;
+    pruner_config.ledger_pruner_config.batch_size = 1;
+    let aptos_db = AptosDB::open(
+        StorageDirPaths::from_path(tmp.path()),
+        false,
+        pruner_config,
+        RocksdbConfigs::default(),
+        500_000,
+        DEFAULT_MAX_NUM_NODES_PER_LRU_CACHE_SHARD,
+        None,
+        HotStateConfig::default(),
+    )
+    .unwrap();
+    let hot_state_kv_db = aptos_db.hot_state_kv_db.as_ref().unwrap();
+
+    let key1 = make_state_key(42);
+    let val_old = make_state_value(1);
+    let val_new = make_state_value(2);
+
+    // First batch: write old entry at hot_since=100
+    let mut shards = new_empty_shard_updates();
+    shards[key1.get_shard_id()]
+        .insertions
+        .insert(*key1.crypto_hash_ref(), HotInsertionOp {
+            value: HotStateValue::new(Some(val_old.clone()), 100),
+            value_version: Some(100),
+            superseded_version: None,
+        });
+    let updates1 = HotStateUpdates {
+        for_last_checkpoint: Some(shards),
+        for_latest: None,
+    };
+    let mut batches = hot_state_kv_db.new_sharded_native_batches();
+    aptos_db
+        .state_store
+        .put_hot_state_updates(&updates1, &mut batches)
+        .unwrap();
+    hot_state_kv_db.commit(100, None, batches).unwrap();
+
+    // Second batch: write new entry at hot_since=200 superseding 100
+    let mut shards2 = new_empty_shard_updates();
+    shards2[key1.get_shard_id()]
+        .insertions
+        .insert(*key1.crypto_hash_ref(), HotInsertionOp {
+            value: HotStateValue::new(Some(val_new.clone()), 200),
+            value_version: Some(200),
+            superseded_version: Some(100),
+        });
+    let updates2 = HotStateUpdates {
+        for_last_checkpoint: Some(shards2),
+        for_latest: None,
+    };
+    let mut batches2 = hot_state_kv_db.new_sharded_native_batches();
+    aptos_db
+        .state_store
+        .put_hot_state_updates(&updates2, &mut batches2)
+        .unwrap();
+    hot_state_kv_db.commit(200, None, batches2).unwrap();
+
+    // Both entries exist before pruning
+    assert!(get_hot_state_entry(hot_state_kv_db, &key1, 100).is_some());
+    assert!(get_hot_state_entry(hot_state_kv_db, &key1, 200).is_some());
+
+    // Trigger pruning
+    let pruner = aptos_db
+        .state_store
+        .state_pruner
+        .hot_state_kv_pruner
+        .as_ref()
+        .expect("hot state kv pruner should exist");
+    pruner
+        .wake_and_wait_pruner(200)
+        .expect("pruner should complete");
+
+    // Old entry at version 100 should be pruned
+    let old_entry = hot_state_kv_db
+        .db_shard(key1.get_shard_id())
+        .get::<HotStateValueByKeyHashSchema>(&(CryptoHash::hash(&key1), 100))
+        .unwrap();
+    assert!(
+        old_entry.is_none(),
+        "old entry should have been pruned, got: {old_entry:?}"
+    );
+    // New entry at version 200 should remain
+    assert!(get_hot_state_entry(hot_state_kv_db, &key1, 200).is_some());
+
+    // Stale index entries should be cleaned up
+    let stale = collect_stale_indices(hot_state_kv_db, key1.get_shard_id());
+    let key1_stale: Vec<_> = stale
+        .iter()
+        .filter(|e| e.state_key_hash == CryptoHash::hash(&key1))
+        .filter(|e| e.stale_since_version <= 200)
+        .collect();
+    assert!(
+        key1_stale.is_empty(),
+        "stale entries should be cleaned up, found: {key1_stale:?}"
+    );
 }

--- a/storage/aptosdb/src/state_store/tests/speculative_state_workflow.rs
+++ b/storage/aptosdb/src/state_store/tests/speculative_state_workflow.rs
@@ -14,7 +14,7 @@ use aptos_storage_interface::{
         state_update_refs::StateUpdateRefs,
         state_view::cached_state_view::CachedStateView,
         state_with_summary::{LedgerStateWithSummary, StateWithSummary},
-        HotStateUpdates,
+        HotStateShardUpdates, HotStateUpdates,
     },
     DbReader, Result as DbResult,
 };
@@ -530,6 +530,122 @@ impl DbReader for StateByVersion {
     }
 }
 
+/// Verifies `HotInsertionOp` / `HotEvictionOp` fields against the naive model.
+///
+/// Checks per shard:
+///  - Insertions and evictions have disjoint key sets.
+///  - Insertion / eviction key sets exactly match the naive model's diff between base and result.
+///  - `superseded_version` bijects with the base hot state:
+///    - key hot at base with `hot_since == v`  ⟹  `superseded_version == Some(v)`
+///    - key cold at base                       ⟹  `superseded_version == None`
+///  - `value_version` matches the naive model's result-version hot state slot.
+///  - `value_version.is_some() == value.value_opt().is_some()`.
+///  - `eviction_version` matches the naive model: the key is absent from the naive hot state
+///    at `eviction_version`.
+fn assert_hot_state_ops(
+    state_by_version: &StateByVersion,
+    hot_state_updates: &HotStateUpdates,
+    for_ckpt_base: Option<Version>,
+    for_latest_base: Option<Version>,
+    for_ckpt_result: Option<Version>,
+    for_latest_result: Option<Version>,
+) {
+    if let Some(shards) = &hot_state_updates.for_last_checkpoint {
+        let base = state_by_version.get_state(for_ckpt_base);
+        let result = state_by_version.get_state(for_ckpt_result);
+        assert_hot_state_shard_ops(state_by_version, &base.hot_state, &result.hot_state, shards);
+    }
+    if let Some(shards) = &hot_state_updates.for_latest {
+        let base = state_by_version.get_state(for_latest_base);
+        let result = state_by_version.get_state(for_latest_result);
+        // for_latest is called with no checkpoint versions, so no evictions should occur.
+        assert_hot_state_shard_ops(state_by_version, &base.hot_state, &result.hot_state, shards);
+    }
+}
+
+fn assert_hot_state_shard_ops(
+    state_by_version: &StateByVersion,
+    naive_base_hot: &[LruCache<StateKey, StateSlot>; NUM_STATE_SHARDS],
+    naive_result_hot: &[LruCache<StateKey, StateSlot>; NUM_STATE_SHARDS],
+    shards: &[HotStateShardUpdates; NUM_STATE_SHARDS],
+) {
+    for (shard_id, shard) in shards.iter().enumerate() {
+        // Insertions and evictions must be disjoint — a key is either still hot (insertion) or
+        // removed (eviction), never both.
+        for key_hash in shard.insertions.keys() {
+            assert!(!shard.evictions.contains_key(key_hash));
+        }
+        for key_hash in shard.evictions.keys() {
+            assert!(!shard.insertions.contains_key(key_hash));
+        }
+
+        // Build lookup from the naive model's base-version hot state.
+        let base_hot: HashMap<HashValue, Version> = naive_base_hot[shard_id]
+            .iter()
+            .map(|(k, s)| (*k.crypto_hash_ref(), s.expect_hot_since_version()))
+            .collect();
+
+        // Build lookup from the naive model's result-version hot state.
+        let result_hot: HashMap<HashValue, &StateSlot> = naive_result_hot[shard_id]
+            .iter()
+            .map(|(k, s)| (*k.crypto_hash_ref(), s))
+            .collect();
+
+        // Completeness for insertions: keys in the result hot state whose hot_since_version
+        // differs from base must appear in insertions, and vice versa.
+        let expected_insertions: HashSet<HashValue> = result_hot
+            .iter()
+            .filter(|(kh, slot)| base_hot.get(kh).copied() != Some(slot.expect_hot_since_version()))
+            .map(|(kh, _)| *kh)
+            .collect();
+        let actual_insertions: HashSet<HashValue> = shard.insertions.keys().copied().collect();
+        assert_eq!(actual_insertions, expected_insertions);
+
+        // Completeness for evictions: every key in the base but absent from the result must
+        // be evicted.  The actual set may also contain "transient" evictions — keys that were
+        // inserted and evicted within the same batch (never in the base, never in the result).
+        let expected_evictions: HashSet<HashValue> = base_hot
+            .keys()
+            .filter(|kh| !result_hot.contains_key(kh))
+            .copied()
+            .collect();
+        for kh in &expected_evictions {
+            assert!(shard.evictions.contains_key(kh));
+        }
+        // Every evicted key must truly be absent from the result hot state.
+        for kh in shard.evictions.keys() {
+            assert!(!result_hot.contains_key(kh));
+        }
+
+        for (key_hash, op) in &shard.insertions {
+            // superseded_version must biject with the base hot state.
+            assert_eq!(op.superseded_version, base_hot.get(key_hash).copied());
+            // value_version must be present iff value is occupied.
+            assert_eq!(op.value_version.is_some(), op.value.value_opt().is_some());
+            // value_version must match the naive model's result hot state — an inserted key
+            // must be present in the result.
+            let result_slot = result_hot.get(key_hash).unwrap();
+            assert_eq!(op.value_version, result_slot.value_version_opt());
+        }
+        for (key_hash, op) in &shard.evictions {
+            assert_eq!(op.superseded_version, base_hot.get(key_hash).copied());
+            // Verify eviction_version against the naive model: the key must be absent
+            // from the naive hot state at eviction_version (i.e. it has been evicted at
+            // or before that checkpoint).
+            let hot_at_eviction = &state_by_version
+                .get_state(Some(op.eviction_version))
+                .hot_state[shard_id];
+            assert!(
+                !hot_at_eviction
+                    .iter()
+                    .any(|(k, _)| *k.crypto_hash_ref() == *key_hash),
+                "Evicted key {key_hash} should be absent from naive hot state at eviction_version {}",
+                op.eviction_version,
+            );
+        }
+    }
+}
+
 fn update_state(
     blocks: Vec<Chunk>,
     state_by_version: Arc<StateByVersion>,
@@ -577,6 +693,21 @@ fn update_state(
             .unwrap();
 
         state_by_version.assert_ledger_state(&next_state);
+
+        let for_ckpt_base = parent_state.latest().version();
+        let for_latest_base = if hot_state_updates.for_last_checkpoint.is_some() {
+            next_state.last_checkpoint().version()
+        } else {
+            for_ckpt_base
+        };
+        assert_hot_state_ops(
+            &state_by_version,
+            &hot_state_updates,
+            for_ckpt_base,
+            for_latest_base,
+            next_state.last_checkpoint().version(),
+            next_state.latest().version(),
+        );
 
         parent_state = next_state.clone();
 

--- a/storage/storage-interface/src/state_store/hot_state.rs
+++ b/storage/storage-interface/src/state_store/hot_state.rs
@@ -4,8 +4,9 @@
 use crate::state_store::state_view::hot_state_view::HotStateView;
 use aptos_crypto::HashValue;
 use aptos_experimental_layered_map::LayeredMap;
-use aptos_types::state_store::{
-    hot_state::THotStateSlot, state_key::StateKey, state_slot::StateSlot,
+use aptos_types::{
+    state_store::{hot_state::THotStateSlot, state_key::StateKey, state_slot::StateSlot},
+    transaction::Version,
 };
 use std::{collections::HashMap, num::NonZeroUsize, sync::Arc};
 
@@ -47,7 +48,9 @@ impl<'a> HotStateLRU<'a> {
         }
     }
 
-    pub fn insert(&mut self, key: &StateKey, mut slot: StateSlot) {
+    /// Inserts a hot slot as the most recent entry. Returns the old `hot_since_version` if
+    /// replacing an existing hot entry.
+    pub fn insert(&mut self, key: &StateKey, mut slot: StateSlot) -> Option<Version> {
         assert!(
             slot.is_hot(),
             "Should not insert cold slots into hot state."
@@ -62,10 +65,12 @@ impl<'a> HotStateLRU<'a> {
             slot.set_state_key(key.clone());
         }
         let key_hash = *key.crypto_hash_ref();
-        if self.delete(&key_hash).is_none() {
+        let old_hot_since = self.delete(&key_hash).map(|s| s.expect_hot_since_version());
+        if old_hot_since.is_none() {
             self.num_items += 1;
         }
         self.insert_as_head(key_hash, slot);
+        old_hot_since
     }
 
     fn insert_as_head(&mut self, key_hash: HashValue, mut slot: StateSlot) {

--- a/storage/storage-interface/src/state_store/mod.rs
+++ b/storage/storage-interface/src/state_store/mod.rs
@@ -18,19 +18,34 @@ use aptos_types::{
 use std::collections::HashMap;
 
 #[derive(Debug)]
+pub struct HotInsertionOp {
+    pub value: HotStateValue,
+    /// `Some(version)` for occupied entries and `None` for vacant.
+    pub value_version: Option<Version>,
+    /// The `hot_since_version` of the DB entry being superseded.
+    /// `None` means this is a first write (creation or promotion).
+    pub superseded_version: Option<Version>,
+}
+
+#[derive(Debug)]
+pub struct HotEvictionOp {
+    pub eviction_version: Version,
+    /// The `hot_since_version` of the DB entry being superseded. `None` if the key was never
+    /// persisted to hot DB (e.g. promoted and evicted in the same batch, unlikely though).
+    pub superseded_version: Option<Version>,
+}
+
+#[derive(Debug)]
 pub struct HotStateShardUpdates {
-    /// Each insertion carries the `HotStateValue` and an optional `value_version`.
-    /// `value_version` is `Some(version)` for occupied entries and `None` for vacant.
-    pub insertions: HashMap<HashValue, (HotStateValue, Option<Version>)>,
-    /// Each eviction carries the checkpoint version at which eviction happened.
+    pub insertions: HashMap<HashValue, HotInsertionOp>,
     // TODO(HotState): per-block eviction tracking will be needed for cold-write elimination.
-    pub evictions: HashMap<HashValue, Version>,
+    pub evictions: HashMap<HashValue, HotEvictionOp>,
 }
 
 impl HotStateShardUpdates {
     pub fn new(
-        insertions: HashMap<HashValue, (HotStateValue, Option<Version>)>,
-        evictions: HashMap<HashValue, Version>,
+        insertions: HashMap<HashValue, HotInsertionOp>,
+        evictions: HashMap<HashValue, HotEvictionOp>,
     ) -> Self {
         Self {
             insertions,

--- a/storage/storage-interface/src/state_store/state.rs
+++ b/storage/storage-interface/src/state_store/state.rs
@@ -14,7 +14,7 @@ use crate::{
             hot_state_view::HotStateView,
         },
         versioned_state_value::StateUpdateRef,
-        HotStateShardUpdates, HotStateUpdates,
+        HotEvictionOp, HotInsertionOp, HotStateShardUpdates, HotStateUpdates,
     },
     DbReader,
 };
@@ -220,8 +220,13 @@ impl State {
                             all_updates.take_while_ref(|(_k, u)| u.version <= *ckpt_version)
                         {
                             let key_hash = *key.crypto_hash_ref();
-                            evictions.remove(&key_hash);
-                            if let Some(insertion) = Self::apply_one_update(
+                            // If this key was evicted earlier in the same batch, recover its
+                            // `superseded_version` so the insert→evict→reinsert chain keeps
+                            // pointing at the original DB entry the pruner should clean up.
+                            let evicted_superseded = evictions
+                                .remove(&key_hash)
+                                .and_then(|e: HotEvictionOp| e.superseded_version);
+                            if let Some(op) = Self::apply_one_update(
                                 &mut lru,
                                 overlay,
                                 cache,
@@ -229,20 +234,41 @@ impl State {
                                 update,
                                 self.hot_state_config.refresh_interval_versions,
                             ) {
-                                insertions.insert(key_hash, insertion);
+                                Self::insert_preserving_superseded(
+                                    &mut insertions,
+                                    key_hash,
+                                    op,
+                                    evicted_superseded,
+                                );
                             }
                         }
                         // Only evict at the checkpoints.
                         for (key_hash, slot) in lru.maybe_evict() {
-                            insertions.remove(&key_hash);
                             assert!(slot.is_hot());
-                            evictions.insert(key_hash, *ckpt_version);
+                            assert!(
+                                !evictions.contains_key(&key_hash),
+                                "Key {key_hash} cannot be evicted twice."
+                            );
+                            // Determine the DB version superseded by this hot entry. If the key was
+                            // inserted earlier in this batch, carry forward its superseded_version;
+                            // otherwise the key has been hot since before this batch, so use its
+                            // hot_since_version.
+                            let superseded_version = insertions
+                                .remove(&key_hash)
+                                .map(|prev| prev.superseded_version)
+                                .unwrap_or(Some(slot.expect_hot_since_version()));
+                            evictions.insert(key_hash, HotEvictionOp {
+                                eviction_version: *ckpt_version,
+                                superseded_version,
+                            });
                         }
                     }
                     for (key, update) in all_updates {
                         let key_hash = *key.crypto_hash_ref();
-                        evictions.remove(&key_hash);
-                        if let Some(insertion) = Self::apply_one_update(
+                        let evicted_superseded = evictions
+                            .remove(&key_hash)
+                            .and_then(|e| e.superseded_version);
+                        if let Some(op) = Self::apply_one_update(
                             &mut lru,
                             overlay,
                             cache,
@@ -250,7 +276,12 @@ impl State {
                             update,
                             self.hot_state_config.refresh_interval_versions,
                         ) {
-                            insertions.insert(key_hash, insertion);
+                            Self::insert_preserving_superseded(
+                                &mut insertions,
+                                key_hash,
+                                op,
+                                evicted_superseded,
+                            );
                         }
                     }
 
@@ -292,9 +323,8 @@ impl State {
         ))
     }
 
-    /// Applies the update and returns `(HotStateValue, Option<value_version>)` that will later
-    /// go into the hot state Merkle tree and DB. `None` if the op is `MakeHot` and it's
-    /// determined that refresh is not necessary.
+    /// Applies one update to the LRU. Returns `None` if the op is `MakeHot` and refresh is not
+    /// necessary.
     fn apply_one_update(
         lru: &mut HotStateLRU,
         overlay: &LayeredMap<HashValue, StateSlot>,
@@ -302,15 +332,16 @@ impl State {
         key: &StateKey,
         update: &StateUpdateRef,
         refresh_interval: Version,
-    ) -> Option<(HotStateValue, Option<Version>)> {
+    ) -> Option<HotInsertionOp> {
         let key_hash = *key.crypto_hash_ref();
         if let Some(state_value_opt) = update.state_op.as_state_value_opt() {
-            lru.insert(key, update.to_result_slot((*key).clone()).unwrap());
-            let value_version = state_value_opt.map(|_| update.version);
-            return Some((
-                HotStateValue::new(state_value_opt.cloned(), update.version),
-                value_version,
-            ));
+            let superseded_version =
+                lru.insert(key, update.to_result_slot((*key).clone()).unwrap());
+            return Some(HotInsertionOp {
+                value: HotStateValue::new(state_value_opt.cloned(), update.version),
+                value_version: state_value_opt.map(|_| update.version),
+                superseded_version,
+            });
         }
 
         if let Some(mut slot) = lru.get_slot(&key_hash) {
@@ -327,9 +358,13 @@ impl State {
             };
             if refreshed {
                 let value_version = slot_to_insert.value_version_opt();
-                let ret = HotStateValue::clone_from_slot(&slot_to_insert);
-                lru.insert(key, slot_to_insert);
-                Some((ret, value_version))
+                let value = HotStateValue::clone_from_slot(&slot_to_insert);
+                let superseded_version = lru.insert(key, slot_to_insert);
+                Some(HotInsertionOp {
+                    value,
+                    value_version,
+                    superseded_version,
+                })
             } else {
                 None
             }
@@ -338,10 +373,34 @@ impl State {
             assert!(slot.is_cold());
             let value_version = slot.value_version_opt();
             let slot = slot.to_hot(update.version);
-            let ret = HotStateValue::clone_from_slot(&slot);
-            lru.insert(key, slot);
-            Some((ret, value_version))
+            let value = HotStateValue::clone_from_slot(&slot);
+            let superseded_version = lru.insert(key, slot);
+            Some(HotInsertionOp {
+                value,
+                value_version,
+                superseded_version,
+            })
         }
+    }
+
+    /// Inserts `op` into `insertions`, preserving the original DB-level `superseded_version`
+    /// across insert/evict/reinsert chains within the same batch.
+    fn insert_preserving_superseded(
+        insertions: &mut HashMap<HashValue, HotInsertionOp>,
+        key_hash: HashValue,
+        mut op: HotInsertionOp,
+        evicted_superseded: Option<Version>,
+    ) {
+        if let Some(prev) = insertions.get(&key_hash) {
+            // Key was already inserted earlier in this batch — keep the original
+            // superseded_version so the pruner still targets the right DB entry.
+            op.superseded_version = prev.superseded_version;
+        } else if evicted_superseded.is_some() {
+            // Key was evicted earlier in this batch — carry forward the superseded_version
+            // that was saved at eviction time.
+            op.superseded_version = evicted_superseded;
+        }
+        insertions.insert(key_hash, op);
     }
 
     fn update_usage(&self, usage_delta_per_shard: Vec<(i64, i64)>) -> StateStorageUsage {

--- a/storage/storage-interface/src/state_store/state_summary.rs
+++ b/storage/storage-interface/src/state_store/state_summary.rs
@@ -140,7 +140,7 @@ impl StateSummary {
                 shard
                     .insertions
                     .iter()
-                    .map(|(k, (value, _))| (k, Some(value.hash())))
+                    .map(|(k, op)| (k, Some(op.value.hash())))
                     .chain(shard.evictions.keys().map(|k| (k, None)))
                     .sorted_by_key(|(k, _)| *k)
                     .collect_vec()


### PR DESCRIPTION

Add stale index tracking and background pruning for the hot state KV DB,
following the cold state KV pruner pattern. Without this, the hot state KV DB
grows unbounded as refreshes, promotions, and evictions accumulate old entries.

Key design choices:

- Introduce `HotInsertionOp` and `HotEvictionOp` structs to carry per-operation
  metadata (value, version, superseded version) with named fields, replacing the
  previous unnamed tuples and separate `superseded_versions` map.
- `HotStateLRU::insert()` now returns the old `hot_since_version` of superseded
  entries, which flows directly into `HotInsertionOp::superseded_version`.
- Reuse `StaleStateValueIndexByKeyHashSchema` in the hot state KV DB (separate
  RocksDB instance, no conflict with cold DB). Stale index entries are written
  alongside value entries, including `NO_PREV_VERSION` for first writes
  (truncation support).
- Add `is_hot` dispatch to `StateKvShardPruner` so the same pruner code handles
  both cold (`StateValueByKeyHashSchema`) and hot (`HotStateValueByKeyHashSchema`)
  value deletions. Dynamic metrics labels and worker thread names based on
  `is_hot`.
- New `hot_state_kv_pruner` field in `StatePruner`, triggered from the commit
  path, batch committer, and startup recovery.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new stale-index writes and background pruning for the hot state KV RocksDB, which could delete hot-state history if index generation or pruning targets are incorrect. Changes also affect pruner activation/metrics and the hot-state update pipeline, so regressions could surface as missing hot entries or increased compaction/load.
> 
> **Overview**
> Enables bounded growth for the hot state KV DB by **adding stale-index tracking and wiring a dedicated `hot_state_kv_pruner`** into `StatePruner`, activated on startup recovery and after commits.
> 
> Hot state update payloads are refactored from tuple-based maps to named ops (`HotInsertionOp`, `HotEvictionOp`) and `HotStateLRU::insert()` now returns the superseded `hot_since_version`, allowing `put_hot_state_updates()` to write `StaleStateValueIndexByKeyHashSchema` entries (including eviction tombstone self-references and first-write markers) alongside `HotStateValueByKeyHashSchema` writes.
> 
> The existing state KV pruner is generalized to handle both cold and hot KV DBs via an `is_hot` dispatch in `StateKvShardPruner`, adds hot-specific CF support in `db_options`, and updates metrics/logging/worker names accordingly; tests are expanded to validate stale-index writes and that the hot KV pruner actually deletes superseded hot entries.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 68c6797d11c537afb4d30e3cc2a1354f18578925. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->