### PR TITLE
[deps] bump lz4_flex 0.11.3→0.11.6, quinn-proto 0.11.13→0.11.14

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12351,11 +12351,11 @@ dependencies = [
 
 [[package]]
 name = "lz4_flex"
-version = "0.11.3"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75761162ae2b0e580d7e7c390558127e5f01b4194debd6221fd8c207fc80e3f5"
+checksum = "373f5eceeeab7925e0c1098212f2fbc4d416adec9d35051a6ab251e824c1854a"
 dependencies = [
- "twox-hash",
+ "twox-hash 2.1.2",
 ]
 
 [[package]]
@@ -14558,7 +14558,7 @@ dependencies = [
  "seq-macro",
  "thrift",
  "tokio",
- "twox-hash",
+ "twox-hash 1.6.3",
 ]
 
 [[package]]
@@ -16046,9 +16046,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.13"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
  "bytes",
  "getrandom 0.3.3",
@@ -19775,6 +19775,12 @@ dependencies = [
  "cfg-if",
  "static_assertions",
 ]
+
+[[package]]
+name = "twox-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 
 [[package]]
 name = "typed-arena"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Bumps two transitive Cargo dependencies to address HIGH-severity CVEs detected by Wiz.

| Package | Before | After | CVE | Severity |
|---------|--------|-------|-----|----------|
| `lz4_flex` | 0.11.3 | 0.11.6 | [CVE-2026-32829](https://github.com/advisories/GHSA-vvp9-7p8x-rfvv) | HIGH |
| `quinn-proto` | 0.11.13 | 0.11.14 | [CVE-2026-31812](https://github.com/advisories/GHSA-6xvm-j4wr-6v98) | HIGH |

Both are transitive dependencies with no direct declaration in any workspace `Cargo.toml`. Updated via:

```
cargo update -p lz4_flex
cargo update -p quinn-proto
```

`cargo check -p aptos-node` passes cleanly after the update.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eade6287-eb78-4dd8-ba13-6534ad329829"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eade6287-eb78-4dd8-ba13-6534ad329829"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

