### PR TITLE
[vm] Remove gating for some enabled features

### DIFF
--- a/aptos-move/aptos-vm-environment/src/prod_configs.rs
+++ b/aptos-move/aptos-vm-environment/src/prod_configs.rs
@@ -4,7 +4,7 @@
 pub use aptos_gas_schedule::LATEST_GAS_FEATURE_VERSION;
 use aptos_gas_schedule::{
     gas_feature_versions::{
-        RELEASE_V1_15, RELEASE_V1_30, RELEASE_V1_34, RELEASE_V1_38, RELEASE_V1_41, RELEASE_V1_42,
+        RELEASE_V1_15, RELEASE_V1_30, RELEASE_V1_38, RELEASE_V1_41, RELEASE_V1_42,
     },
     AptosGasParameters,
 };
@@ -151,18 +151,11 @@ pub fn aptos_prod_deserializer_config(features: &Features) -> DeserializerConfig
 
 /// Returns [VerifierConfig] used by the Aptos blockchain in production.
 pub fn aptos_prod_verifier_config(
-    gas_feature_version: u64,
     features: &Features,
     timed_features: &TimedFeatures,
 ) -> VerifierConfig {
-    let sig_checker_v2_fix_script_ty_param_count =
-        features.is_enabled(FeatureFlag::SIGNATURE_CHECKER_V2_SCRIPT_FIX);
-    let sig_checker_v2_fix_function_signatures = gas_feature_version >= RELEASE_V1_34;
-    let enable_enum_types = features.is_enabled(FeatureFlag::ENABLE_ENUM_TYPES);
     let enable_resource_access_control =
         features.is_enabled(FeatureFlag::ENABLE_RESOURCE_ACCESS_CONTROL);
-    let enable_function_values = features.is_enabled(FeatureFlag::ENABLE_FUNCTION_VALUES);
-    // Note: we reuse the `enable_function_values` flag to set various stricter limits on types.
 
     let strict_bounds = timed_features.is_enabled(TimedFeatureFlag::EnableStrictBoundsInProdConfig);
     let revised_bounds = timed_features.is_enabled(TimedFeatureFlag::RevisedBoundsInProdConfig);
@@ -174,11 +167,7 @@ pub fn aptos_prod_verifier_config(
         max_function_parameters: Some(128),
         max_basic_blocks: Some(1024),
         max_value_stack_size: 1024,
-        max_type_nodes: if enable_function_values {
-            Some(128)
-        } else {
-            Some(256)
-        },
+        max_type_nodes: Some(128),
         max_push_size: Some(10000),
         max_struct_definitions: if strict_bounds {
             if revised_bounds {
@@ -198,29 +187,21 @@ pub fn aptos_prod_verifier_config(
         } else {
             None
         },
-        max_fields_in_struct: if strict_bounds { Some(64) } else { None },
-        max_function_definitions: if strict_bounds { Some(1000) } else { None },
+        max_fields_in_struct: Some(64),
+        max_function_definitions: Some(1000),
         max_back_edges_per_function: None,
         max_back_edges_per_module: None,
-        max_basic_blocks_in_script: if strict_bounds { Some(1024) } else { None },
+        max_basic_blocks_in_script: Some(1024),
         max_per_fun_meter_units: Some(1000 * 80000),
         max_per_mod_meter_units: Some(1000 * 80000),
         _use_signature_checker_v2: true,
-        sig_checker_v2_fix_script_ty_param_count,
-        sig_checker_v2_fix_function_signatures,
-        enable_enum_types,
+        _sig_checker_v2_fix_script_ty_param_count: true,
+        _sig_checker_v2_fix_function_signatures: true,
+        enable_enum_types: true,
         enable_resource_access_control,
-        enable_function_values,
-        max_function_return_values: if enable_function_values {
-            Some(128)
-        } else {
-            None
-        },
-        max_type_depth: if enable_function_values {
-            Some(20)
-        } else {
-            None
-        },
+        enable_function_values: true,
+        max_function_return_values: Some(128),
+        max_type_depth: Some(20),
     }
 }
 
@@ -239,7 +220,7 @@ pub fn aptos_prod_vm_config(
     let enable_debugging = get_debugging_enabled();
 
     let deserializer_config = aptos_prod_deserializer_config(features);
-    let verifier_config = aptos_prod_verifier_config(gas_feature_version, features, timed_features);
+    let verifier_config = aptos_prod_verifier_config(features, timed_features);
     let enable_enum_option = features.is_enabled(FeatureFlag::ENABLE_ENUM_OPTION);
     let enable_framework_for_option = features.is_enabled(FeatureFlag::ENABLE_FRAMEWORK_FOR_OPTION);
 
@@ -256,7 +237,6 @@ pub fn aptos_prod_vm_config(
     // shallow while the value can be deeply nested, thanks to captured arguments not visible in a
     // type. Hence, depth checks have been adjusted to operate on values.
     let enable_depth_checks = features.is_enabled(FeatureFlag::ENABLE_FUNCTION_VALUES);
-    let enable_closure_depth_check = timed_features.is_enabled(TimedFeatureFlag::ClosureDepthCheck);
 
     // Some feature gating was missed, so for native dynamic dispatch the feature is always on for
     // testnet after 1.38 release.
@@ -288,11 +268,11 @@ pub fn aptos_prod_vm_config(
         paranoid_ref_checks,
         enable_enum_option,
         enable_layout_caches,
-        propagate_dependency_limit_error: gas_feature_version >= RELEASE_V1_38,
+        propagate_dependency_limit_error: true,
         enable_framework_for_option,
         enable_function_caches_for_native_dynamic_dispatch,
         enable_debugging,
-        enable_closure_depth_check,
+        enable_closure_depth_check: true,
         enable_struct_layout_local_cache: gas_feature_version >= RELEASE_V1_41,
         check_depth_on_type_counts: gas_feature_version >= RELEASE_V1_41,
         enable_public_struct_args: features.is_enabled(FeatureFlag::PUBLIC_STRUCT_ENUM_ARGS),

--- a/aptos-move/aptos-vm/src/move_vm_ext/session/mod.rs
+++ b/aptos-move/aptos-vm/src/move_vm_ext/session/mod.rs
@@ -163,11 +163,6 @@ where
         configs: &ChangeSetConfigs,
         module_storage: &impl ModuleStorage,
     ) -> VMResult<VMChangeSet> {
-        // Note: enabled by 1.38 gas feature version.
-        let is_1_38_release = module_storage
-            .runtime_environment()
-            .vm_config()
-            .propagate_dependency_limit_error;
         let function_extension = module_storage.as_function_value_extension();
 
         let resource_converter = |value: Value,
@@ -192,24 +187,8 @@ where
                     .map(|bytes| (bytes.into(), None))
             };
             serialization_result.ok_or_else(|| {
-                let status_code = if is_1_38_release {
-                    StatusCode::VALUE_SERIALIZATION_ERROR
-                } else {
-                    StatusCode::INTERNAL_TYPE_ERROR
-                };
-                // Note: When enable_closure_depth_check is enabled, do not format
-                // `value` here - deeply nested closures can cause stack overflow
-                // during Display formatting.
-                let enable_closure_depth_check = module_storage
-                    .runtime_environment()
-                    .vm_config()
-                    .enable_closure_depth_check;
-                let message = if enable_closure_depth_check {
-                    "Error when serializing resource.".to_string()
-                } else {
-                    format!("Error when serializing resource {}.", value)
-                };
-                PartialVMError::new(status_code).with_message(message)
+                PartialVMError::new(StatusCode::VALUE_SERIALIZATION_ERROR)
+                    .with_message("Error when serializing resource.".to_string())
             })
         };
 

--- a/storage/backup/backup-cli/src/backup_types/state_snapshot/restore.rs
+++ b/storage/backup/backup-cli/src/backup_types/state_snapshot/restore.rs
@@ -38,7 +38,7 @@ use aptos_types::{
     },
     transaction::Version,
 };
-use aptos_vm_environment::prod_configs::{aptos_prod_verifier_config, LATEST_GAS_FEATURE_VERSION};
+use aptos_vm_environment::prod_configs::aptos_prod_verifier_config;
 use clap::Parser;
 use futures::{stream, TryStreamExt};
 use move_binary_format::CompiledModule;
@@ -235,8 +235,7 @@ impl StateSnapshotRestoreController {
         let features = Features::default();
 
         let timed_features = TimedFeaturesBuilder::enable_all().build();
-        let config =
-            aptos_prod_verifier_config(LATEST_GAS_FEATURE_VERSION, &features, &timed_features);
+        let config = aptos_prod_verifier_config(&features, &timed_features);
         for (key, value) in blob {
             if let StateKeyInner::AccessPath(p) = key.inner() {
                 if let Path::Code(module_id) = p.get_path() {

--- a/testsuite/fuzzer/fuzz/fuzz_targets/move/aptosvm_publish_and_run.rs
+++ b/testsuite/fuzzer/fuzz/fuzz_targets/move/aptosvm_publish_and_run.rs
@@ -15,7 +15,7 @@ use aptos_types::{
     write_set::WriteSet,
 };
 use aptos_vm::AptosVM;
-use aptos_vm_environment::{prod_configs, prod_configs::LATEST_GAS_FEATURE_VERSION};
+use aptos_vm_environment::prod_configs;
 use libfuzzer_sys::{fuzz_target, Corpus};
 use move_binary_format::{
     access::ModuleAccess, deserializer::DeserializerConfig, file_format::SignatureToken,
@@ -87,11 +87,8 @@ fn run_case(mut input: RunnableState) -> Result<(), Corpus> {
     filter_modules(&input)?;
 
     let timed_features = TimedFeaturesBuilder::enable_all().build();
-    let verifier_config = prod_configs::aptos_prod_verifier_config(
-        LATEST_GAS_FEATURE_VERSION,
-        &Features::default(),
-        &timed_features,
-    );
+    let verifier_config =
+        prod_configs::aptos_prod_verifier_config(&Features::default(), &timed_features);
     let deserializer_config = DeserializerConfig::new(BYTECODE_VERSION, 255);
 
     for m in input.dep_modules.iter_mut() {

--- a/testsuite/fuzzer/fuzz/fuzz_targets/move/aptosvm_publish_and_run_transactional.rs
+++ b/testsuite/fuzzer/fuzz/fuzz_targets/move/aptosvm_publish_and_run_transactional.rs
@@ -16,7 +16,7 @@ use aptos_types::{
     write_set::WriteSet,
 };
 use aptos_vm::AptosVM;
-use aptos_vm_environment::{prod_configs, prod_configs::LATEST_GAS_FEATURE_VERSION};
+use aptos_vm_environment::prod_configs;
 use libfuzzer_sys::{fuzz_target, Corpus};
 use move_binary_format::{
     access::ModuleAccess,
@@ -98,11 +98,8 @@ fn run_case(input: RunnableStateWithOperations) -> Result<(), Corpus> {
     filter_modules(&input)?;
 
     let timed_features = TimedFeaturesBuilder::enable_all().build();
-    let verifier_config = prod_configs::aptos_prod_verifier_config(
-        LATEST_GAS_FEATURE_VERSION,
-        &Features::default(),
-        &timed_features,
-    );
+    let verifier_config =
+        prod_configs::aptos_prod_verifier_config(&Features::default(), &timed_features);
     let deserializer_config = DeserializerConfig::new(BYTECODE_VERSION, 255);
 
     let mut dep_modules: Vec<CompiledModule> = vec![];

--- a/testsuite/fuzzer/fuzz/fuzz_targets/move/bytecode_verifier_compiled_modules.rs
+++ b/testsuite/fuzzer/fuzz/fuzz_targets/move/bytecode_verifier_compiled_modules.rs
@@ -4,7 +4,7 @@
 
 #![no_main]
 use aptos_types::on_chain_config::{Features, TimedFeaturesBuilder};
-use aptos_vm_environment::{prod_configs, prod_configs::LATEST_GAS_FEATURE_VERSION};
+use aptos_vm_environment::prod_configs;
 use libfuzzer_sys::{fuzz_target, Corpus};
 use move_binary_format::errors::VMError;
 use move_core_types::vm_status::StatusType;
@@ -24,11 +24,8 @@ fn check_for_invariant_violation_vmerror(e: VMError) {
 
 fuzz_target!(|fuzz_data: RunnableState| -> Corpus {
     let timed_features = TimedFeaturesBuilder::enable_all().build();
-    let verifier_config = prod_configs::aptos_prod_verifier_config(
-        LATEST_GAS_FEATURE_VERSION,
-        &Features::default(),
-        &timed_features,
-    );
+    let verifier_config =
+        prod_configs::aptos_prod_verifier_config(&Features::default(), &timed_features);
 
     for m in fuzz_data.dep_modules.iter() {
         if let Err(e) = move_bytecode_verifier::verify_module_with_config(&verifier_config, m) {

--- a/third_party/move/move-bytecode-verifier/src/signature_v2.rs
+++ b/third_party/move/move-bytecode-verifier/src/signature_v2.rs
@@ -173,18 +173,16 @@ impl<'a, const N: usize> SignatureChecker<'a, N> {
             },
             Function(params, results, abilities) => {
                 assert_abilities(*abilities, required_abilities)?;
-                if self.sig_checker_v2_fix_function_signatures {
-                    for ty in params.iter().chain(results) {
-                        self.check_ty(
-                            ty,
-                            // Immediate params and returns can be references.
-                            true,
-                            // Note we do not need to check abilities of argument or result types,
-                            // they do not matter for the `required_abilities`.
-                            AbilitySet::EMPTY,
-                            param_constraints,
-                        )?
-                    }
+                for ty in params.iter().chain(results) {
+                    self.check_ty(
+                        ty,
+                        // Immediate params and returns can be references.
+                        true,
+                        // Note we do not need to check abilities of argument or result types,
+                        // they do not matter for the `required_abilities`.
+                        AbilitySet::EMPTY,
+                        param_constraints,
+                    )?
                 }
             },
             Struct(sh_idx) => {
@@ -301,8 +299,6 @@ fn check_phantom_params(
 
 struct SignatureChecker<'a, const N: usize> {
     resolver: BinaryIndexedView<'a>,
-    // If enabled, recurses into function signature to check type signatures.
-    sig_checker_v2_fix_function_signatures: bool,
 
     // Here the arena is used as a scoped interner, allowing us to store references in the
     // caches below.
@@ -345,12 +341,10 @@ impl<'a, const N: usize> SignatureChecker<'a, N> {
     fn new(
         constraints: &'a Arena<BitsetTypeParameterConstraints<N>>,
         resolver: BinaryIndexedView<'a>,
-        sig_checker_v2_fix_function_signatures: bool,
     ) -> Self {
         Self {
             resolver,
             constraints,
-            sig_checker_v2_fix_function_signatures,
 
             ty_results: RefCell::new(BTreeMap::new()),
             sig_results: RefCell::new(BTreeMap::new()),
@@ -1146,15 +1140,11 @@ impl<'a, const N: usize> SignatureChecker<'a, N> {
 }
 
 fn verify_module_impl<const N: usize>(
-    config: &VerifierConfig,
+    _config: &VerifierConfig,
     module: &CompiledModule,
 ) -> PartialVMResult<()> {
     let arena = Arena::<BitsetTypeParameterConstraints<N>>::new();
-    let checker = SignatureChecker::new(
-        &arena,
-        BinaryIndexedView::Module(module),
-        config.sig_checker_v2_fix_function_signatures,
-    );
+    let checker = SignatureChecker::new(&arena, BinaryIndexedView::Module(module));
 
     // Check if all signatures & instantiations are well-formed without any specific contexts.
     // This is only needed if we want to keep the binary format super clean.
@@ -1173,15 +1163,11 @@ fn verify_module_impl<const N: usize>(
 }
 
 fn verify_script_impl<const N: usize>(
-    config: &VerifierConfig,
+    _config: &VerifierConfig,
     script: &CompiledScript,
 ) -> PartialVMResult<()> {
     let arena = Arena::<BitsetTypeParameterConstraints<N>>::new();
-    let checker = SignatureChecker::new(
-        &arena,
-        BinaryIndexedView::Script(script),
-        config.sig_checker_v2_fix_function_signatures,
-    );
+    let checker = SignatureChecker::new(&arena, BinaryIndexedView::Script(script));
 
     // Check if all signatures & instantiations are well-formed without any specific contexts.
     // This is only needed if we want to keep the binary format super clean.
@@ -1274,9 +1260,7 @@ pub fn verify_module(config: &VerifierConfig, module: &CompiledModule) -> VMResu
 
 pub fn verify_script(config: &VerifierConfig, script: &CompiledScript) -> VMResult<()> {
     let mut max_num = max_num_of_ty_params_or_args(BinaryIndexedView::Script(script));
-    if config.sig_checker_v2_fix_script_ty_param_count {
-        max_num = max_num.max(script.type_parameters.len());
-    }
+    max_num = max_num.max(script.type_parameters.len());
 
     let res = if max_num <= NUM_PARAMS_PER_WORD {
         verify_script_impl::<1>(config, script)

--- a/third_party/move/move-bytecode-verifier/src/verifier.rs
+++ b/third_party/move/move-bytecode-verifier/src/verifier.rs
@@ -54,7 +54,7 @@ pub struct VerifierConfig {
     pub max_per_mod_meter_units: Option<u128>,
     // signature checker v2 is enabled on mainnet and cannot be disabled
     pub _use_signature_checker_v2: bool,
-    pub sig_checker_v2_fix_script_ty_param_count: bool,
+    pub _sig_checker_v2_fix_script_ty_param_count: bool,
     pub enable_enum_types: bool,
     pub enable_resource_access_control: bool,
     pub enable_function_values: bool,
@@ -62,9 +62,8 @@ pub struct VerifierConfig {
     pub max_function_return_values: Option<usize>,
     /// Maximum depth of a type node.
     pub max_type_depth: Option<usize>,
-    /// If enabled, signature checker V2 also checks parameter and return types in function
-    /// signatures.
-    pub sig_checker_v2_fix_function_signatures: bool,
+    // Always enabled.
+    pub _sig_checker_v2_fix_function_signatures: bool,
 }
 
 /// Scope of verification.
@@ -260,8 +259,8 @@ impl Default for VerifierConfig {
 
             _use_signature_checker_v2: true,
 
-            sig_checker_v2_fix_script_ty_param_count: true,
-            sig_checker_v2_fix_function_signatures: true,
+            _sig_checker_v2_fix_script_ty_param_count: true,
+            _sig_checker_v2_fix_function_signatures: true,
 
             enable_enum_types: true,
             enable_resource_access_control: true,
@@ -309,8 +308,8 @@ impl VerifierConfig {
             max_per_mod_meter_units: Some(1000 * 8000),
 
             _use_signature_checker_v2: true,
-            sig_checker_v2_fix_script_ty_param_count: true,
-            sig_checker_v2_fix_function_signatures: true,
+            _sig_checker_v2_fix_script_ty_param_count: true,
+            _sig_checker_v2_fix_function_signatures: true,
 
             enable_enum_types: true,
             enable_resource_access_control: true,

--- a/third_party/move/move-vm/runtime/src/interpreter.rs
+++ b/third_party/move/move-vm/runtime/src/interpreter.rs
@@ -1647,9 +1647,7 @@ where
         // remap the error.
         if err.status_type() == StatusType::Verification {
             // Make sure we propagate dependency limit errors.
-            if !self.vm_config.propagate_dependency_limit_error
-                || err.major_status() != StatusCode::DEPENDENCY_LIMIT_REACHED
-            {
+            if err.major_status() != StatusCode::DEPENDENCY_LIMIT_REACHED {
                 err.set_major_status(StatusCode::VERIFICATION_ERROR);
             }
         }

--- a/third_party/move/move-vm/runtime/src/storage/ty_depth_checker.rs
+++ b/third_party/move/move-vm/runtime/src/storage/ty_depth_checker.rs
@@ -54,16 +54,9 @@ where
 {
     /// Creates a new depth checker for the specified loader to query struct definitions if needed.
     pub(crate) fn new(struct_definition_loader: &'a T) -> Self {
-        let vm_config = struct_definition_loader.runtime_environment().vm_config();
-        // Gate by other config which will be enabled in 1.38. Will be removed after it is enabled.
-        let maybe_max_depth = if vm_config.propagate_dependency_limit_error {
-            None
-        } else {
-            vm_config.max_value_nest_depth
-        };
         Self {
             struct_definition_loader,
-            maybe_max_depth,
+            maybe_max_depth: None,
             formula_cache: RefCell::new(HashMap::new()),
         }
     }


### PR DESCRIPTION
## Description

Removes enabled features:
- `SIGNATURE_CHECKER_V2_SCRIPT_FIX` gating removed along with `sig_checker_v2_fix_function_signatures`.
- `ENABLE_ENUM_TYPES` and `ENABLE_FUNCTION_VALUES` are set to true now, so multiple config set ups are now simpler.
- `propagate_dependency_limit_error` set to true.

## How Has This Been Tested?

Existing tests.

## Key Areas to Review

This is safe to remove because features were either fixes or feature roll outs.

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [x] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [x] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches VM production configuration and verifier/runtime error handling, which can change module/script acceptance and surfaced status codes across networks. While intended to match already-enabled behavior, misalignment could cause unexpected verification failures or different error remapping.
> 
> **Overview**
> **Simplifies VM production configuration by removing feature/version gating that is now treated as always-on.** `aptos_prod_verifier_config` no longer depends on `gas_feature_version` and now unconditionally enables enum types, function values, signature-checker-v2 fixes, and fixed verifier limits (e.g. `max_type_nodes`, `max_function_definitions`, `max_basic_blocks_in_script`).
> 
> **Makes dependency-limit and closure-depth behaviors unconditional.** `VMConfig.propagate_dependency_limit_error` and `enable_closure_depth_check` are set to `true`, and related runtime paths are simplified: dependency limit errors are always preserved when remapping verification errors, type-depth checking no longer conditionally uses `max_value_nest_depth`, and resource serialization failures always return `VALUE_SERIALIZATION_ERROR` with a non-value-formatting message.
> 
> **Cleans up call sites and verifier internals accordingly.** Backup restore and fuzz targets drop `LATEST_GAS_FEATURE_VERSION` usage, and `VerifierConfig`/signature checker v2 removes now-redundant gating fields (renamed to underscore-prefixed “always enabled” flags) and runs function-signature/type-parameter checks unconditionally.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e918cadea22424352e72eec63501565ea40fb819. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->