### PR TITLE
[trivial] Fix config in verifier

### DIFF
--- a/third_party/move/move-bytecode-verifier/src/meter.rs
+++ b/third_party/move/move-bytecode-verifier/src/meter.rs
@@ -114,7 +114,7 @@ impl BoundMeter {
             mod_bounds: Bounds {
                 name: "<unknown>".to_string(),
                 units: 0,
-                max: config.max_per_fun_meter_units,
+                max: config.max_per_mod_meter_units,
             },
             fun_bounds: Bounds {
                 name: "<unknown>".to_string(),


### PR DESCRIPTION
## Description

Fixing type in config to use **module**, not **function** units. This is safe because we use same for both in prod.

Credit to @zi0Black. 

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, single-line bug fix that only changes which config field caps module-scope metering; could alter rejection thresholds if configs differ between module and function limits.
> 
> **Overview**
> Corrects `BoundMeter::new` to initialize **module-scope** metering (`mod_bounds.max`) from `VerifierConfig::max_per_mod_meter_units` rather than mistakenly using `max_per_fun_meter_units`, ensuring module and function limits are applied to the intended scopes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 915c032496a27e0d13d5b4f535028ce7caa03106. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->