### PR TITLE
[BlockSTM] Replace rayon with lightweight WorkerPool for par_exec threads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2966,7 +2966,6 @@ dependencies = [
  "proptest",
  "proptest-derive",
  "rand 0.7.3",
- "rayon",
  "serde",
 ]
 
@@ -9896,7 +9895,6 @@ dependencies = [
  "move-vm-types",
  "once_cell",
  "primitive-types",
- "rayon",
  "ring 0.16.20",
  "serde",
  "serde_json",

--- a/aptos-move/aptos-vm/src/block_executor/mod.rs
+++ b/aptos-move/aptos-vm/src/block_executor/mod.rs
@@ -18,6 +18,7 @@ use aptos_block_executor::{
     txn_commit_hook::TransactionCommitHook,
     txn_provider::TxnProvider,
     types::InputOutputKey,
+    worker_pool::WorkerPool,
 };
 use aptos_types::{
     block_executor::{
@@ -54,15 +55,7 @@ use std::{
 use triomphe::Arc as TriompheArc;
 use vm_wrapper::AptosExecutorTask;
 
-static RAYON_EXEC_POOL: Lazy<Arc<rayon::ThreadPool>> = Lazy::new(|| {
-    Arc::new(
-        rayon::ThreadPoolBuilder::new()
-            .num_threads(num_cpus::get())
-            .thread_name(|index| format!("par_exec-{}", index))
-            .build()
-            .unwrap(),
-    )
-});
+static WORKER_POOL: Lazy<Arc<WorkerPool>> = Lazy::new(|| Arc::new(WorkerPool::new("par_exec")));
 
 /// Output type wrapper used by block executor. VM output is stored first, then
 /// transformed into TransactionOutput type that is returned.
@@ -517,7 +510,7 @@ impl<
         L: TransactionCommitHook,
         TP: TxnProvider<SignatureVerifiedTransaction, AuxiliaryInfo> + Sync,
     >(
-        executor_thread_pool: Arc<rayon::ThreadPool>,
+        worker_pool: Arc<WorkerPool>,
         signature_verified_block: &TP,
         state_view: &S,
         module_cache_manager: &AptosModuleCacheManager,
@@ -545,7 +538,7 @@ impl<
         let executor =
             BlockExecutor::<SignatureVerifiedTransaction, E, S, L, TP, AuxiliaryInfo>::new(
                 config,
-                executor_thread_pool,
+                worker_pool,
                 transaction_commit_listener,
             );
 
@@ -599,7 +592,7 @@ impl<
         transaction_commit_listener: Option<L>,
     ) -> Result<BlockOutput<SignatureVerifiedTransaction, TransactionOutput>, VMStatus> {
         Self::execute_block_on_thread_pool::<S, L, TP>(
-            Arc::clone(&RAYON_EXEC_POOL),
+            Arc::clone(&WORKER_POOL),
             signature_verified_block,
             state_view,
             module_cache_manager,

--- a/aptos-move/aptos-vm/src/sharded_block_executor/global_executor.rs
+++ b/aptos-move/aptos-vm/src/sharded_block_executor/global_executor.rs
@@ -4,6 +4,7 @@
 use crate::sharded_block_executor::{
     local_executor_shard::GlobalCrossShardClient, sharded_executor_service::ShardedExecutorService,
 };
+use aptos_block_executor::worker_pool::WorkerPool;
 use aptos_logger::trace;
 use aptos_types::{
     block_executor::{
@@ -19,6 +20,7 @@ use std::sync::Arc;
 pub struct GlobalExecutor<S: StateView + Sync + Send + 'static> {
     global_cross_shard_client: Arc<GlobalCrossShardClient>,
     executor_thread_pool: Arc<rayon::ThreadPool>,
+    worker_pool: Arc<WorkerPool>,
     concurrency_level: usize,
     phantom: std::marker::PhantomData<S>,
 }
@@ -33,9 +35,11 @@ impl<S: StateView + Sync + Send + 'static> GlobalExecutor<S> {
                 .build()
                 .unwrap(),
         );
+        let worker_pool = Arc::new(WorkerPool::new("par_exec"));
         Self {
             global_cross_shard_client: cross_shard_client,
             executor_thread_pool,
+            worker_pool,
             phantom: std::marker::PhantomData,
             concurrency_level: num_threads,
         }
@@ -54,6 +58,7 @@ impl<S: StateView + Sync + Send + 'static> GlobalExecutor<S> {
         ShardedExecutorService::execute_transactions_with_dependencies(
             None,
             self.executor_thread_pool.clone(),
+            Arc::clone(&self.worker_pool),
             transactions,
             self.global_cross_shard_client.clone(),
             None,

--- a/aptos-move/aptos-vm/src/sharded_block_executor/sharded_executor_service.rs
+++ b/aptos-move/aptos-vm/src/sharded_block_executor/sharded_executor_service.rs
@@ -18,6 +18,7 @@ use crate::{
 };
 use aptos_block_executor::{
     code_cache_global_manager::AptosModuleCacheManager, txn_provider::default::DefaultTxnProvider,
+    worker_pool::WorkerPool,
 };
 use aptos_logger::{info, trace};
 use aptos_metrics_core::TimerHelper;
@@ -43,6 +44,7 @@ pub struct ShardedExecutorService<S: StateView + Sync + Send + 'static> {
     shard_id: ShardId,
     num_shards: usize,
     executor_thread_pool: Arc<rayon::ThreadPool>,
+    worker_pool: Arc<WorkerPool>,
     coordinator_client: Arc<dyn CoordinatorClient<S>>,
     cross_shard_client: Arc<dyn CrossShardClient>,
 }
@@ -64,10 +66,12 @@ impl<S: StateView + Sync + Send + 'static> ShardedExecutorService<S> {
                 .build()
                 .unwrap(),
         );
+        let worker_pool = Arc::new(WorkerPool::new("par_exec"));
         Self {
             shard_id,
             num_shards,
             executor_thread_pool,
+            worker_pool,
             coordinator_client,
             cross_shard_client,
         }
@@ -91,6 +95,7 @@ impl<S: StateView + Sync + Send + 'static> ShardedExecutorService<S> {
         Self::execute_transactions_with_dependencies(
             Some(self.shard_id),
             self.executor_thread_pool.clone(),
+            Arc::clone(&self.worker_pool),
             sub_block.into_transactions_with_deps(),
             self.cross_shard_client.clone(),
             Some(cross_shard_commit_sender),
@@ -103,6 +108,7 @@ impl<S: StateView + Sync + Send + 'static> ShardedExecutorService<S> {
     pub fn execute_transactions_with_dependencies(
         shard_id: Option<ShardId>, // None means execution on global shard
         executor_thread_pool: Arc<rayon::ThreadPool>,
+        worker_pool: Arc<WorkerPool>,
         transactions: Vec<TransactionWithDependencies<AnalyzedTransaction>>,
         cross_shard_client: Arc<dyn CrossShardClient>,
         cross_shard_commit_sender: Option<CrossShardCommitSender>,
@@ -143,7 +149,7 @@ impl<S: StateView + Sync + Send + 'static> ShardedExecutorService<S> {
                 let txn_provider =
                     DefaultTxnProvider::new_without_info(signature_verified_transactions);
                 let ret = AptosVMBlockExecutorWrapper::execute_block_on_thread_pool(
-                    executor_thread_pool,
+                    worker_pool,
                     &txn_provider,
                     aggr_overridden_state_view.as_ref(),
                     // Since we execute blocks in parallel, we cannot share module caches, so each

--- a/aptos-move/block-executor/Cargo.toml
+++ b/aptos-move/block-executor/Cargo.toml
@@ -48,7 +48,6 @@ parking_lot = { workspace = true }
 proptest = { workspace = true, optional = true }
 proptest-derive = { workspace = true, optional = true }
 rand = { workspace = true }
-rayon = { workspace = true }
 triomphe = { workspace = true }
 
 [dev-dependencies]
@@ -63,6 +62,7 @@ move-vm-types = { workspace = true, features = ["testing"] }
 proptest = { workspace = true }
 proptest-derive = { workspace = true }
 rand = { workspace = true }
+rayon = { workspace = true }
 test-case = { workspace = true }
 
 [features]

--- a/aptos-move/block-executor/src/combinatorial_tests/bencher.rs
+++ b/aptos-move/block-executor/src/combinatorial_tests/bencher.rs
@@ -13,6 +13,7 @@ use crate::{
     executor::BlockExecutor,
     txn_commit_hook::NoOpTransactionCommitHook,
     txn_provider::default::DefaultTxnProvider,
+    worker_pool::WorkerPool,
 };
 use aptos_types::{
     block_executor::{
@@ -126,12 +127,7 @@ where
     pub(crate) fn run(self) {
         let state_view = MockStateView::empty();
 
-        let executor_thread_pool = Arc::new(
-            rayon::ThreadPoolBuilder::new()
-                .num_threads(num_cpus::get())
-                .build()
-                .unwrap(),
-        );
+        let executor_thread_pool = Arc::new(WorkerPool::new("par_exec"));
 
         let config = BlockExecutorConfig::new_no_block_limit(num_cpus::get());
         let mut guard = AptosModuleCacheManagerGuard::none();

--- a/aptos-move/block-executor/src/combinatorial_tests/group_tests.rs
+++ b/aptos-move/block-executor/src/combinatorial_tests/group_tests.rs
@@ -18,6 +18,7 @@ use crate::{
     task::ExecutorTask,
     txn_commit_hook::NoOpTransactionCommitHook,
     txn_provider::default::DefaultTxnProvider,
+    worker_pool::WorkerPool,
 };
 use aptos_types::{
     block_executor::{
@@ -46,7 +47,7 @@ pub(crate) fn create_non_empty_group_data_view(
 
 /// Run both parallel and sequential execution tests for a transaction provider
 pub(crate) fn run_tests_with_groups(
-    executor_thread_pool: Arc<rayon::ThreadPool>,
+    executor_thread_pool: Arc<WorkerPool>,
     gas_limits: Vec<Option<u64>>,
     transactions: Vec<MockTransaction<KeyType<[u8; 32]>, MockEvent>>,
     data_view: &NonEmptyGroupDataView<KeyType<[u8; 32]>>,

--- a/aptos-move/block-executor/src/combinatorial_tests/resource_tests.rs
+++ b/aptos-move/block-executor/src/combinatorial_tests/resource_tests.rs
@@ -12,6 +12,7 @@ use crate::{
     task::ExecutorTask,
     txn_commit_hook::NoOpTransactionCommitHook,
     txn_provider::{default::DefaultTxnProvider, TxnProvider},
+    worker_pool::WorkerPool,
 };
 use aptos_types::{
     block_executor::{
@@ -49,13 +50,8 @@ pub(crate) fn get_gas_limit_variants(
     }
 }
 
-pub(crate) fn create_executor_thread_pool() -> Arc<rayon::ThreadPool> {
-    Arc::new(
-        rayon::ThreadPoolBuilder::new()
-            .num_threads(num_cpus::get())
-            .build()
-            .unwrap(),
-    )
+pub(crate) fn create_executor_thread_pool() -> Arc<WorkerPool> {
+    Arc::new(WorkerPool::new("par_exec"))
 }
 
 /// Populates a module cache manager guard with empty modules for testing.
@@ -98,7 +94,7 @@ pub(crate) fn populate_guard_with_modules(
 }
 
 pub(crate) fn execute_block_parallel<TxnType, ViewType, Provider>(
-    executor_thread_pool: Arc<rayon::ThreadPool>,
+    worker_pool: Arc<WorkerPool>,
     block_gas_limit: Option<u64>,
     txn_provider: &Provider,
     data_view: &ViewType,
@@ -126,7 +122,7 @@ where
         NoOpTransactionCommitHook<usize>,
         Provider,
         AuxiliaryInfo,
-    >::new(config, executor_thread_pool, None);
+    >::new(config, worker_pool, None);
 
     if block_stm_v2 {
         block_executor.execute_transactions_parallel_v2(

--- a/aptos-move/block-executor/src/combinatorial_tests/tests.rs
+++ b/aptos-move/block-executor/src/combinatorial_tests/tests.rs
@@ -32,6 +32,7 @@ use proptest::{
     test_runner::TestRunner,
 };
 use rand::Rng;
+use crate::worker_pool::WorkerPool;
 use std::{cmp::max, fmt::Debug, hash::Hash, marker::PhantomData, sync::Arc};
 use test_case::test_case;
 
@@ -64,12 +65,7 @@ fn run_transactions<K, V, E>(
 
     let state_view = MockStateView::empty();
 
-    let executor_thread_pool = Arc::new(
-        rayon::ThreadPoolBuilder::new()
-            .num_threads(num_cpus::get())
-            .build()
-            .unwrap(),
-    );
+    let executor_thread_pool = Arc::new(WorkerPool::new("par_exec"));
 
     let txn_provider = DefaultTxnProvider::new_without_info(transactions);
     for _ in 0..num_repeat {
@@ -208,13 +204,7 @@ fn deltas_writes_mixed_with_block_gas_limit(num_txns: usize, maybe_block_gas_lim
         phantom: PhantomData,
     };
 
-    let executor_thread_pool = Arc::new(
-        rayon::ThreadPoolBuilder::new()
-            .num_threads(num_cpus::get())
-            .build()
-            .unwrap(),
-    );
-
+    let executor_thread_pool = Arc::new(WorkerPool::new("par_exec"));
     for _ in 0..20 {
         let mut guard = AptosModuleCacheManagerGuard::none();
 
@@ -267,13 +257,7 @@ fn deltas_resolver_with_block_gas_limit(num_txns: usize, maybe_block_gas_limit: 
         .collect();
     let txn_provider = DefaultTxnProvider::new_without_info(transactions);
 
-    let executor_thread_pool = Arc::new(
-        rayon::ThreadPoolBuilder::new()
-            .num_threads(num_cpus::get())
-            .build()
-            .unwrap(),
-    );
-
+    let executor_thread_pool = Arc::new(WorkerPool::new("par_exec"));
     for _ in 0..20 {
         let mut guard = AptosModuleCacheManagerGuard::none();
 
@@ -383,12 +367,7 @@ fn publishing_fixed_params_with_block_gas_limit(
         phantom: PhantomData,
     };
 
-    let executor_thread_pool = Arc::new(
-        rayon::ThreadPoolBuilder::new()
-            .num_threads(num_cpus::get())
-            .build()
-            .unwrap(),
-    );
+    let executor_thread_pool = Arc::new(WorkerPool::new("par_exec"));
 
     let txn_provider = DefaultTxnProvider::new_without_info(transactions.clone());
     // Confirm still no intersection
@@ -432,12 +411,7 @@ fn publishing_fixed_params_with_block_gas_limit(
         },
     };
 
-    let executor_thread_pool = Arc::new(
-        rayon::ThreadPoolBuilder::new()
-            .num_threads(num_cpus::get())
-            .build()
-            .unwrap(),
-    );
+    let executor_thread_pool = Arc::new(WorkerPool::new("par_exec"));
 
     let txn_provider = DefaultTxnProvider::new_without_info(transactions);
     for _ in 0..200 {
@@ -523,13 +497,7 @@ fn non_empty_group(
             .collect(),
     };
 
-    let executor_thread_pool = Arc::new(
-        rayon::ThreadPoolBuilder::new()
-            .num_threads(num_cpus::get())
-            .build()
-            .unwrap(),
-    );
-
+    let executor_thread_pool = Arc::new(WorkerPool::new("par_exec"));
     for _ in 0..num_repeat_parallel {
         let mut guard = AptosModuleCacheManagerGuard::none();
 

--- a/aptos-move/block-executor/src/executor.rs
+++ b/aptos-move/block-executor/src/executor.rs
@@ -27,6 +27,7 @@ use crate::{
     txn_provider::TxnProvider,
     types::ReadWriteSummary,
     view::{LatestView, ParallelState, SequentialState, ViewState},
+    worker_pool::WorkerPool,
 };
 use aptos_aggregator::{
     delayed_change::{ApplyBase, DelayedChange},
@@ -67,7 +68,6 @@ use move_core_types::{language_storage::ModuleId, value::MoveTypeLayout, vm_stat
 use move_vm_runtime::{Module, RuntimeEnvironment, TypeChecker, WithRuntimeEnvironment};
 use move_vm_types::delayed_values::delayed_field_id::DelayedFieldID;
 use num_cpus;
-use rayon::ThreadPool;
 use std::{
     cell::RefCell,
     collections::{BTreeMap, BTreeSet, HashMap, HashSet},
@@ -99,10 +99,10 @@ where
 }
 
 pub struct BlockExecutor<T, E, S, L, TP, A> {
-    // Number of active concurrent tasks, corresponding to the maximum number of rayon
-    // threads that may be concurrently participating in parallel execution.
+    // Number of active concurrent tasks, corresponding to the maximum number of
+    // worker threads that may be concurrently participating in parallel execution.
     config: BlockExecutorConfig,
-    executor_thread_pool: Arc<rayon::ThreadPool>,
+    worker_pool: Arc<WorkerPool>,
     transaction_commit_hook: Option<L>,
     phantom: PhantomData<fn() -> (T, E, S, L, TP, A)>,
 }
@@ -120,7 +120,7 @@ where
     /// be handled by sequential execution) and that concurrency_level <= num_cpus.
     pub fn new(
         config: BlockExecutorConfig,
-        executor_thread_pool: Arc<ThreadPool>,
+        worker_pool: Arc<WorkerPool>,
         transaction_commit_hook: Option<L>,
     ) -> Self {
         let num_cpus = num_cpus::get();
@@ -132,7 +132,7 @@ where
         );
         Self {
             config,
-            executor_thread_pool,
+            worker_pool,
             transaction_commit_hook,
             phantom: PhantomData,
         }
@@ -1852,48 +1852,43 @@ where
         );
 
         let timer = RAYON_EXECUTION_SECONDS.start_timer();
-        let worker_ids: Vec<u32> = (0..num_workers).collect();
         let maybe_executor = ExplicitSyncWrapper::new(None);
-        self.executor_thread_pool.scope(|s| {
-            for worker_id in &worker_ids {
-                s.spawn(|_| {
-                    let environment = module_cache_manager_guard.environment();
-                    let executor = {
-                        let _init_timer = VM_INIT_SECONDS.start_timer();
-                        E::init(
-                            &environment.clone(),
-                            shared_sync_params.base_view,
-                            async_runtime_checks_enabled,
-                        )
-                    };
+        self.worker_pool.run(num_workers as usize, |worker_id| {
+            let environment = module_cache_manager_guard.environment();
+            let executor = {
+                let _init_timer = VM_INIT_SECONDS.start_timer();
+                E::init(
+                    &environment.clone(),
+                    shared_sync_params.base_view,
+                    async_runtime_checks_enabled,
+                )
+            };
 
-                    if let Err(err) = self.worker_loop_v2(
-                        &executor,
-                        signature_verified_block,
-                        environment,
-                        *worker_id,
-                        num_workers,
-                        &scheduler,
-                        &shared_sync_params,
-                    ) {
-                        // If there are multiple errors, they all get logged: FatalVMError is
-                        // logged at construction, below we log CodeInvariantErrors.
-                        if let PanicOr::CodeInvariantError(err_msg) = err {
-                            alert!(
-                                "[BlockSTMv2] worker loop: CodeInvariantError({:?})",
-                                err_msg
-                            );
-                        }
-                        shared_maybe_error.store(true, Ordering::SeqCst);
+            if let Err(err) = self.worker_loop_v2(
+                &executor,
+                signature_verified_block,
+                environment,
+                worker_id,
+                num_workers,
+                &scheduler,
+                &shared_sync_params,
+            ) {
+                // If there are multiple errors, they all get logged: FatalVMError is
+                // logged at construction, below we log CodeInvariantErrors.
+                if let PanicOr::CodeInvariantError(err_msg) = err {
+                    alert!(
+                        "[BlockSTMv2] worker loop: CodeInvariantError({:?})",
+                        err_msg
+                    );
+                }
+                shared_maybe_error.store(true, Ordering::SeqCst);
 
-                        // Make sure to halt the scheduler if it hasn't already been halted.
-                        scheduler.halt();
-                    }
+                // Make sure to halt the scheduler if it hasn't already been halted.
+                scheduler.halt();
+            }
 
-                    if *worker_id == 0 {
-                        maybe_executor.acquire().replace(executor);
-                    }
-                });
+            if worker_id == 0 {
+                maybe_executor.acquire().replace(executor);
             }
         });
         drop(timer);
@@ -2003,7 +1998,6 @@ where
         let scheduler = Scheduler::new(num_txns);
 
         let timer = RAYON_EXECUTION_SECONDS.start_timer();
-        let worker_ids: Vec<u32> = (0..num_workers as u32).collect();
         let maybe_executor = ExplicitSyncWrapper::new(None);
 
         let shared_sync_params: SharedSyncParams<'_, T, E, S> = SharedSyncParams {
@@ -2021,47 +2015,43 @@ where
         let async_runtime_checks_enabled = should_perform_async_runtime_checks_for_block(
             module_cache_manager_guard.environment(),
             num_txns,
-            worker_ids.len() as u32,
+            num_workers as u32,
         );
 
-        self.executor_thread_pool.scope(|s| {
-            for worker_id in &worker_ids {
-                s.spawn(|_| {
-                    let environment = module_cache_manager_guard.environment();
-                    let executor = {
-                        let _init_timer = VM_INIT_SECONDS.start_timer();
-                        E::init(
-                            &environment.clone(),
-                            base_view,
-                            async_runtime_checks_enabled,
-                        )
-                    };
+        self.worker_pool.run(num_workers, |worker_id| {
+            let environment = module_cache_manager_guard.environment();
+            let executor = {
+                let _init_timer = VM_INIT_SECONDS.start_timer();
+                E::init(
+                    &environment.clone(),
+                    base_view,
+                    async_runtime_checks_enabled,
+                )
+            };
 
-                    if let Err(err) = self.worker_loop(
-                        &executor,
-                        environment,
-                        signature_verified_block,
-                        &scheduler,
-                        &skip_module_reads_validation,
-                        &shared_sync_params,
-                        num_workers,
-                    ) {
-                        // If there are multiple errors, they all get logged:
-                        // ModulePathReadWriteError and FatalVMError variant is logged at construction,
-                        // and below we log CodeInvariantErrors.
-                        if let PanicOr::CodeInvariantError(err_msg) = err {
-                            alert!("[BlockSTM] worker loop: CodeInvariantError({:?})", err_msg);
-                        }
-                        shared_maybe_error.store(true, Ordering::SeqCst);
+            if let Err(err) = self.worker_loop(
+                &executor,
+                environment,
+                signature_verified_block,
+                &scheduler,
+                &skip_module_reads_validation,
+                &shared_sync_params,
+                num_workers,
+            ) {
+                // If there are multiple errors, they all get logged:
+                // ModulePathReadWriteError and FatalVMError variant is logged at construction,
+                // and below we log CodeInvariantErrors.
+                if let PanicOr::CodeInvariantError(err_msg) = err {
+                    alert!("[BlockSTM] worker loop: CodeInvariantError({:?})", err_msg);
+                }
+                shared_maybe_error.store(true, Ordering::SeqCst);
 
-                        // Make sure to halt the scheduler if it hasn't already been halted.
-                        scheduler.halt();
-                    }
+                // Make sure to halt the scheduler if it hasn't already been halted.
+                scheduler.halt();
+            }
 
-                    if *worker_id == 0 {
-                        maybe_executor.acquire().replace(executor);
-                    }
-                });
+            if worker_id == 0 {
+                maybe_executor.acquire().replace(executor);
             }
         });
         drop(timer);

--- a/aptos-move/block-executor/src/lib.rs
+++ b/aptos-move/block-executor/src/lib.rs
@@ -161,3 +161,4 @@ pub mod types;
 mod unit_tests;
 mod value_exchange;
 pub mod view;
+pub mod worker_pool;

--- a/aptos-move/block-executor/src/unit_tests/mod.rs
+++ b/aptos-move/block-executor/src/unit_tests/mod.rs
@@ -20,6 +20,7 @@ use crate::{
     },
     txn_commit_hook::NoOpTransactionCommitHook,
     txn_provider::default::DefaultTxnProvider,
+    worker_pool::WorkerPool,
 };
 use aptos_aggregator::{
     bounded_math::SignedU128,
@@ -56,12 +57,7 @@ fn test_block_epilogue_happy_path() {
     let t_1 = MockTransaction::from_behavior(behaivor);
     let transactions = vec![t_0, t_1];
 
-    let executor_thread_pool = Arc::new(
-        rayon::ThreadPoolBuilder::new()
-            .num_threads(num_cpus::get())
-            .build()
-            .unwrap(),
-    );
+    let executor_thread_pool = Arc::new(WorkerPool::new("par_exec"));
     let block_executor = BlockExecutor::<
         MockTransaction<KeyType<u32>, MockEvent>,
         MockTask<KeyType<u32>, MockEvent>,
@@ -127,12 +123,7 @@ fn test_block_epilogue_block_gas_limit_reached() {
     let t_1 = MockTransaction::from_behavior(behaivor);
     let transactions = vec![t_0, t_1];
 
-    let executor_thread_pool = Arc::new(
-        rayon::ThreadPoolBuilder::new()
-            .num_threads(num_cpus::get())
-            .build()
-            .unwrap(),
-    );
+    let executor_thread_pool = Arc::new(WorkerPool::new("par_exec"));
     let block_executor = BlockExecutor::<
         MockTransaction<KeyType<u32>, MockEvent>,
         MockTask<KeyType<u32>, MockEvent>,
@@ -222,12 +213,7 @@ fn test_resource_group_deletion() {
         group_keys: HashSet::new(),
         delayed_field_testing: false,
     };
-    let executor_thread_pool = Arc::new(
-        rayon::ThreadPoolBuilder::new()
-            .num_threads(num_cpus::get())
-            .build()
-            .unwrap(),
-    );
+    let executor_thread_pool = Arc::new(WorkerPool::new("par_exec"));
     let block_executor = BlockExecutor::<
         MockTransaction<KeyType<u32>, MockEvent>,
         MockTask<KeyType<u32>, MockEvent>,
@@ -301,12 +287,7 @@ fn resource_group_bcs_fallback() {
         group_keys: HashSet::new(),
         delayed_field_testing: false,
     };
-    let executor_thread_pool = Arc::new(
-        rayon::ThreadPoolBuilder::new()
-            .num_threads(num_cpus::get())
-            .build()
-            .unwrap(),
-    );
+    let executor_thread_pool = Arc::new(WorkerPool::new("par_exec"));
     let block_executor = BlockExecutor::<
         MockTransaction<KeyType<u32>, MockEvent>,
         MockTask<KeyType<u32>, MockEvent>,
@@ -417,12 +398,7 @@ fn interrupt_requested() {
     let mut guard = AptosModuleCacheManagerGuard::none();
 
     let data_view = MockStateView::empty();
-    let executor_thread_pool = Arc::new(
-        rayon::ThreadPoolBuilder::new()
-            .num_threads(num_cpus::get())
-            .build()
-            .unwrap(),
-    );
+    let executor_thread_pool = Arc::new(WorkerPool::new("par_exec"));
     let block_executor = BlockExecutor::<
         MockTransaction<KeyType<u32>, MockEvent>,
         MockTask<KeyType<u32>, MockEvent>,
@@ -464,12 +440,7 @@ fn block_output_err_precedence() {
     let txn_provider = DefaultTxnProvider::new_without_info(transactions);
 
     let data_view = MockStateView::empty();
-    let executor_thread_pool = Arc::new(
-        rayon::ThreadPoolBuilder::new()
-            .num_threads(num_cpus::get())
-            .build()
-            .unwrap(),
-    );
+    let executor_thread_pool = Arc::new(WorkerPool::new("par_exec"));
     let block_executor = BlockExecutor::<
         MockTransaction<KeyType<u32>, MockEvent>,
         MockTask<KeyType<u32>, MockEvent>,
@@ -508,12 +479,7 @@ fn skip_rest_gas_limit() {
     let txn_provider = DefaultTxnProvider::new_without_info(transactions);
 
     let data_view = MockStateView::empty();
-    let executor_thread_pool = Arc::new(
-        rayon::ThreadPoolBuilder::new()
-            .num_threads(num_cpus::get())
-            .build()
-            .unwrap(),
-    );
+    let executor_thread_pool = Arc::new(WorkerPool::new("par_exec"));
     let block_executor = BlockExecutor::<
         MockTransaction<KeyType<u32>, MockEvent>,
         MockTask<KeyType<u32>, MockEvent>,
@@ -543,12 +509,7 @@ where
     K: PartialOrd + Ord + Send + Sync + Clone + Hash + Eq + ModulePath + Debug + 'static,
     E: Send + Sync + Debug + Clone + TransactionEvent + 'static,
 {
-    let executor_thread_pool = Arc::new(
-        rayon::ThreadPoolBuilder::new()
-            .num_threads(num_cpus::get())
-            .build()
-            .unwrap(),
-    );
+    let executor_thread_pool = Arc::new(WorkerPool::new("par_exec"));
 
     let mut guard = AptosModuleCacheManagerGuard::none();
     let txn_provider = DefaultTxnProvider::new_without_info(transactions);

--- a/aptos-move/block-executor/src/worker_pool.rs
+++ b/aptos-move/block-executor/src/worker_pool.rs
@@ -1,0 +1,218 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! A lightweight persistent thread pool for BlockSTM parallel execution.
+//!
+//! Replaces rayon for `par_exec` workers. Threads are reused across block
+//! executions and idle at zero CPU cost (blocked on channel recv). No
+//! work-stealing overhead.
+
+use std::{
+    panic::{self, AssertUnwindSafe},
+    sync::{
+        mpsc::{self, Sender},
+        Mutex,
+    },
+    thread::{self, JoinHandle},
+};
+
+/// A persistent thread pool that dispatches work via per-worker channels.
+///
+/// Threads are spawned on demand and reused across invocations. Idle threads
+/// block on their channel receiver, consuming zero CPU.
+pub struct WorkerPool {
+    name_prefix: String,
+    state: Mutex<PoolState>,
+}
+
+struct PoolState {
+    threads: Vec<JoinHandle<()>>,
+    job_txs: Vec<Sender<WorkerJob>>,
+}
+
+struct WorkerJob {
+    work: Box<dyn FnOnce() + Send>,
+    done: Sender<thread::Result<()>>,
+}
+
+impl WorkerPool {
+    pub fn new(name_prefix: &str) -> Self {
+        Self {
+            name_prefix: name_prefix.to_owned(),
+            state: Mutex::new(PoolState {
+                threads: Vec::new(),
+                job_txs: Vec::new(),
+            }),
+        }
+    }
+
+    /// Run `f(worker_id)` on `num_workers` persistent threads. Blocks until all
+    /// workers complete.
+    ///
+    /// Threads are created on first use and reused across calls. The pool grows
+    /// as needed but never shrinks.
+    ///
+    /// # Panics
+    ///
+    /// If any worker panics, all workers are still waited on, then the first
+    /// panic is re-raised in the calling thread.
+    pub(crate) fn run<F>(&self, num_workers: usize, f: F)
+    where
+        F: Fn(u32) + Send + Sync,
+    {
+        let n = num_workers;
+        let (done_tx, done_rx) = mpsc::channel();
+
+        {
+            let mut state = self.state.lock().unwrap_or_else(|e| e.into_inner());
+
+            // Grow pool if needed. New threads start blocking on recv immediately.
+            while state.threads.len() < n {
+                let idx = state.threads.len();
+                let (tx, rx) = mpsc::channel::<WorkerJob>();
+                let name = format!("{}-{}", self.name_prefix, idx);
+                let handle = thread::Builder::new()
+                    .name(name)
+                    .spawn(move || {
+                        while let Ok(job) = rx.recv() {
+                            let result = panic::catch_unwind(AssertUnwindSafe(job.work));
+                            let _ = job.done.send(result);
+                        }
+                    })
+                    .expect("Failed to spawn worker thread");
+                state.job_txs.push(tx);
+                state.threads.push(handle);
+            }
+
+            // Dispatch jobs. The closure borrows non-'static data from the
+            // caller's scope. The transmute is safe because we block below until
+            // all workers complete, so borrowed data outlives worker execution.
+            // This is the same safety pattern used by rayon::scope and
+            // std::thread::scope.
+            let f_ref: &(dyn Fn(u32) + Send + Sync) = &f;
+            for i in 0..n {
+                let worker_id = i as u32;
+                let closure: Box<dyn FnOnce() + Send + '_> = Box::new(move || f_ref(worker_id));
+                // SAFETY: We wait for all workers to complete before returning,
+                // so all data borrowed by f outlives worker execution.
+                let closure: Box<dyn FnOnce() + Send + 'static> =
+                    unsafe { std::mem::transmute(closure) };
+                state.job_txs[i]
+                    .send(WorkerJob {
+                        work: closure,
+                        done: done_tx.clone(),
+                    })
+                    .expect("Worker thread terminated unexpectedly");
+            }
+        } // Release state lock before waiting.
+        drop(done_tx);
+
+        // Wait for all workers, collecting the first panic if any.
+        let mut panic_payload = None;
+        for _ in 0..n {
+            match done_rx
+                .recv()
+                .expect("Worker thread terminated unexpectedly")
+            {
+                Ok(()) => {},
+                Err(payload) => {
+                    panic_payload.get_or_insert(payload);
+                },
+            }
+        }
+        if let Some(payload) = panic_payload {
+            panic::resume_unwind(payload);
+        }
+    }
+}
+
+impl Drop for WorkerPool {
+    fn drop(&mut self) {
+        let state = self.state.get_mut().unwrap_or_else(|e| e.into_inner());
+        // Close all job channels, causing workers to exit their recv loop.
+        state.job_txs.clear();
+        for handle in state.threads.drain(..) {
+            let _ = handle.join();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    #[test]
+    fn basic_dispatch() {
+        let pool = WorkerPool::new("test");
+        let counter = AtomicU32::new(0);
+        pool.run(4, |_worker_id| {
+            counter.fetch_add(1, Ordering::Relaxed);
+        });
+        assert_eq!(counter.load(Ordering::Relaxed), 4);
+    }
+
+    #[test]
+    fn correct_worker_ids() {
+        let pool = WorkerPool::new("test");
+        let seen = [
+            AtomicU32::new(0),
+            AtomicU32::new(0),
+            AtomicU32::new(0),
+            AtomicU32::new(0),
+        ];
+        pool.run(4, |worker_id| {
+            seen[worker_id as usize].store(1, Ordering::Relaxed);
+        });
+        for s in &seen {
+            assert_eq!(s.load(Ordering::Relaxed), 1);
+        }
+    }
+
+    #[test]
+    fn variable_worker_count() {
+        let pool = WorkerPool::new("test");
+
+        let counter = AtomicU32::new(0);
+        pool.run(8, |_| {
+            counter.fetch_add(1, Ordering::Relaxed);
+        });
+        assert_eq!(counter.load(Ordering::Relaxed), 8);
+
+        let counter = AtomicU32::new(0);
+        pool.run(3, |_| {
+            counter.fetch_add(1, Ordering::Relaxed);
+        });
+        assert_eq!(counter.load(Ordering::Relaxed), 3);
+
+        let counter = AtomicU32::new(0);
+        pool.run(8, |_| {
+            counter.fetch_add(1, Ordering::Relaxed);
+        });
+        assert_eq!(counter.load(Ordering::Relaxed), 8);
+    }
+
+    #[test]
+    #[should_panic(expected = "worker panic")]
+    fn panic_propagation() {
+        let pool = WorkerPool::new("test");
+        pool.run(4, |worker_id| {
+            if worker_id == 2 {
+                panic!("worker panic");
+            }
+        });
+    }
+
+    #[test]
+    fn scoped_borrows() {
+        let pool = WorkerPool::new("test");
+        let data = vec![0u32; 8];
+        // Each worker writes to its slot — verifies scoped borrowing works.
+        pool.run(8, |worker_id| {
+            // SAFETY: each worker writes to a distinct index.
+            let ptr = data.as_ptr() as *mut u32;
+            unsafe { ptr.add(worker_id as usize).write(worker_id + 1) };
+        });
+        assert_eq!(data, vec![1, 2, 3, 4, 5, 6, 7, 8]);
+    }
+}

--- a/aptos-move/e2e-tests/Cargo.toml
+++ b/aptos-move/e2e-tests/Cargo.toml
@@ -54,7 +54,6 @@ petgraph = "0.5.1"
 proptest = { workspace = true }
 proptest-derive = { workspace = true }
 rand = { workspace = true }
-rayon = { workspace = true }
 serde = { workspace = true }
 
 [features]

--- a/aptos-move/e2e-tests/src/executor.rs
+++ b/aptos-move/e2e-tests/src/executor.rs
@@ -13,7 +13,7 @@ use aptos_bitvec::BitVec;
 use aptos_block_executor::code_cache_global_manager::ModuleHotCacheSnapshot;
 use aptos_block_executor::{
     code_cache_global_manager::AptosModuleCacheManager, txn_commit_hook::NoOpTransactionCommitHook,
-    txn_provider::default::DefaultTxnProvider,
+    txn_provider::default::DefaultTxnProvider, worker_pool::WorkerPool,
 };
 use aptos_crypto::HashValue;
 use aptos_framework::ReleaseBundle;
@@ -162,7 +162,8 @@ struct SharedCacheState {
 pub struct FakeExecutorImpl<O: OutputLogger> {
     state_store: FakeExecutorStateStore,
     event_store: Vec<ContractEvent>,
-    executor_thread_pool: Arc<rayon::ThreadPool>,
+    worker_pool: Arc<WorkerPool>,
+    concurrency_level: usize,
     block_time: u64,
     executed_output: Option<O>,
     trace_dir: Option<PathBuf>,
@@ -232,20 +233,14 @@ pub enum ExecFuncTimerDynamicArgs {
 impl<O: OutputLogger> FakeExecutorImpl<O> {
     /// Creates an executor from a genesis [`WriteSet`].
     pub fn from_genesis(write_set: &WriteSet, chain_id: ChainId) -> Self {
-        let executor_thread_pool = Arc::new(
-            rayon::ThreadPoolBuilder::new()
-                .num_threads(num_cpus::get())
-                .build()
-                .unwrap(),
-        );
-
         let state_store = empty_in_memory_state_store();
         state_store.set_chain_id(chain_id).unwrap();
 
         let mut executor = Self {
             state_store,
             event_store: Vec::new(),
-            executor_thread_pool,
+            worker_pool: Arc::new(WorkerPool::new("par_exec")),
+            concurrency_level: num_cpus::get(),
             block_time: 0,
             executed_output: None,
             trace_dir: None,
@@ -262,7 +257,7 @@ impl<O: OutputLogger> FakeExecutorImpl<O> {
     pub fn from_genesis_with_existing_thread_pool(
         write_set: &WriteSet,
         chain_id: ChainId,
-        executor_thread_pool: Arc<rayon::ThreadPool>,
+        worker_pool: Arc<WorkerPool>,
         module_cache_manager: Option<AptosModuleCacheManager>,
     ) -> Self {
         let state_store = empty_in_memory_state_store();
@@ -271,7 +266,8 @@ impl<O: OutputLogger> FakeExecutorImpl<O> {
         let mut executor = Self {
             state_store,
             event_store: Vec::new(),
-            executor_thread_pool,
+            worker_pool,
+            concurrency_level: num_cpus::get(),
             block_time: 0,
             executed_output: None,
             trace_dir: None,
@@ -313,17 +309,11 @@ impl<O: OutputLogger> FakeExecutorImpl<O> {
             .get_on_chain_config::<CurrentTimeMicroseconds>()
             .expect("failed to get block time from remote");
 
-        let executor_thread_pool = Arc::new(
-            rayon::ThreadPoolBuilder::new()
-                .num_threads(num_cpus::get())
-                .build()
-                .unwrap(),
-        );
-
         Self {
             state_store,
             event_store: Vec::new(),
-            executor_thread_pool,
+            worker_pool: Arc::new(WorkerPool::new("par_exec")),
+            concurrency_level: num_cpus::get(),
             block_time: timestamp.microseconds,
             executed_output: None,
             trace_dir: None,
@@ -507,16 +497,11 @@ impl<O: OutputLogger> FakeExecutorImpl<O> {
 
     /// Creates an executor in which no genesis state has been applied yet.
     pub fn no_genesis() -> Self {
-        let executor_thread_pool = Arc::new(
-            rayon::ThreadPoolBuilder::new()
-                .num_threads(num_cpus::get())
-                .build()
-                .unwrap(),
-        );
         Self {
             state_store: empty_in_memory_state_store(),
             event_store: Vec::new(),
-            executor_thread_pool,
+            worker_pool: Arc::new(WorkerPool::new("par_exec")),
+            concurrency_level: num_cpus::get(),
             block_time: 0,
             executed_output: None,
             trace_dir: None,
@@ -895,7 +880,7 @@ impl<O: OutputLogger> FakeExecutorImpl<O> {
                 NoOpTransactionCommitHook<VMStatus>,
                 _,
             >(
-                self.executor_thread_pool.clone(),
+                Arc::clone(&self.worker_pool),
                 &txn_provider,
                 &state_view,
                 self.module_cache_manager_opt()
@@ -1077,7 +1062,7 @@ impl<O: OutputLogger> FakeExecutorImpl<O> {
 
         let parallel_output = if mode != ExecutorMode::SequentialOnly {
             // use the number of threads specified in the executor thread pool as specified at construction time
-            config.local.concurrency_level = self.executor_thread_pool.current_num_threads();
+            config.local.concurrency_level = self.concurrency_level;
             Some(self.execute_transaction_block_impl_with_state_view(
                 sig_verified_block,
                 state_view,

--- a/execution/executor-benchmark/src/native/native_vm.rs
+++ b/execution/executor-benchmark/src/native/native_vm.rs
@@ -4,7 +4,7 @@
 use crate::{
     db_access::DbAccessUtil,
     native::{
-        native_config::{NativeConfig, NATIVE_EXECUTOR_POOL},
+        native_config::NativeConfig,
         native_transaction::{compute_deltas_for_batch, NativeTransaction},
     },
 };
@@ -18,6 +18,7 @@ use aptos_block_executor::{
     task::{ExecutionStatus, ExecutorTask},
     txn_commit_hook::NoOpTransactionCommitHook,
     txn_provider::default::DefaultTxnProvider,
+    worker_pool::WorkerPool,
 };
 use aptos_logger::error;
 use aptos_mvhashmap::types::TxnIndex;
@@ -63,8 +64,12 @@ use move_core_types::{
     vm_status::VMStatus,
 };
 use move_vm_types::delayed_values::delayed_field_id::DelayedFieldID;
+use once_cell::sync::Lazy;
 use serde::{de::DeserializeOwned, Serialize};
 use std::{collections::BTreeMap, fmt::Debug, sync::Arc};
+
+static NATIVE_WORKER_POOL: Lazy<Arc<WorkerPool>> =
+    Lazy::new(|| Arc::new(WorkerPool::new("native_exe")));
 
 pub struct NativeVMBlockExecutor;
 
@@ -91,7 +96,7 @@ impl VMBlockExecutor for NativeVMBlockExecutor {
             NoOpTransactionCommitHook<VMStatus>,
             _,
         >(
-            Arc::clone(&NATIVE_EXECUTOR_POOL),
+            Arc::clone(&NATIVE_WORKER_POOL),
             txn_provider,
             state_view,
             &AptosModuleCacheManager::new(),

--- a/testsuite/fuzzer/fuzz/Cargo.toml
+++ b/testsuite/fuzzer/fuzz/Cargo.toml
@@ -109,7 +109,6 @@ move-vm-runtime = { workspace = true }
 move-vm-types = { workspace = true, features = ["fuzzing"] }
 once_cell = { workspace = true }
 primitive-types = { workspace = true }
-rayon = { workspace = true }
 ring = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/testsuite/fuzzer/fuzz/fuzz_targets/move/aptosvm_authenticators.rs
+++ b/testsuite/fuzzer/fuzz/fuzz_targets/move/aptosvm_authenticators.rs
@@ -3,6 +3,7 @@
 #![no_main]
 #![allow(unused_imports)]
 
+use aptos_block_executor::worker_pool::WorkerPool;
 use aptos_cached_packages::aptos_stdlib;
 use aptos_crypto::{
     ed25519::{Ed25519PrivateKey, Ed25519PublicKey},
@@ -52,14 +53,7 @@ use utils::{
 static VM: Lazy<WriteSet> = Lazy::new(|| GENESIS_CHANGE_SET_HEAD.write_set().clone());
 
 const FUZZER_CONCURRENCY_LEVEL: usize = 1;
-static TP: Lazy<Arc<rayon::ThreadPool>> = Lazy::new(|| {
-    Arc::new(
-        rayon::ThreadPoolBuilder::new()
-            .num_threads(FUZZER_CONCURRENCY_LEVEL)
-            .build()
-            .unwrap(),
-    )
-});
+static TP: Lazy<Arc<WorkerPool>> = Lazy::new(|| Arc::new(WorkerPool::new("par_exec")));
 
 fn run_case(input: TransactionState) -> Result<(), Corpus> {
     tdbg!(&input);

--- a/testsuite/fuzzer/fuzz/fuzz_targets/move/aptosvm_publish.rs
+++ b/testsuite/fuzzer/fuzz/fuzz_targets/move/aptosvm_publish.rs
@@ -4,6 +4,7 @@
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 mod utils;
+use aptos_block_executor::worker_pool::WorkerPool;
 use aptos_language_e2e_tests::executor::FakeExecutor;
 use aptos_transaction_simulation::GENESIS_CHANGE_SET_HEAD;
 use aptos_types::{chain_id::ChainId, write_set::WriteSet};
@@ -24,14 +25,7 @@ static VM: Lazy<WriteSet> = Lazy::new(|| GENESIS_CHANGE_SET_HEAD.write_set().clo
 
 const TEST_UPGRADE: bool = true;
 const FUZZER_CONCURRENCY_LEVEL: usize = 1;
-static TP: Lazy<Arc<rayon::ThreadPool>> = Lazy::new(|| {
-    Arc::new(
-        rayon::ThreadPoolBuilder::new()
-            .num_threads(FUZZER_CONCURRENCY_LEVEL)
-            .build()
-            .unwrap(),
-    )
-});
+static TP: Lazy<Arc<WorkerPool>> = Lazy::new(|| Arc::new(WorkerPool::new("par_exec")));
 
 fn run_case(mut input: RunnableState) -> Result<(), Corpus> {
     tdbg!(&input);

--- a/testsuite/fuzzer/fuzz/fuzz_targets/move/aptosvm_publish_and_run.rs
+++ b/testsuite/fuzzer/fuzz/fuzz_targets/move/aptosvm_publish_and_run.rs
@@ -3,6 +3,7 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
+use aptos_block_executor::worker_pool::WorkerPool;
 use aptos_language_e2e_tests::{account::Account, executor::FakeExecutor};
 use aptos_transaction_simulation::GENESIS_CHANGE_SET_HEAD;
 use aptos_types::{
@@ -35,14 +36,7 @@ use utils::vm::{
 static VM_WRITE_SET: Lazy<WriteSet> = Lazy::new(|| GENESIS_CHANGE_SET_HEAD.write_set().clone());
 
 const FUZZER_CONCURRENCY_LEVEL: usize = 1;
-static TP: Lazy<Arc<rayon::ThreadPool>> = Lazy::new(|| {
-    Arc::new(
-        rayon::ThreadPoolBuilder::new()
-            .num_threads(FUZZER_CONCURRENCY_LEVEL)
-            .build()
-            .unwrap(),
-    )
-});
+static TP: Lazy<Arc<WorkerPool>> = Lazy::new(|| Arc::new(WorkerPool::new("par_exec")));
 
 const MAX_TYPE_PARAMETER_VALUE: u16 = 64 / 4 * 16; // third_party/move/move-bytecode-verifier/src/signature_v2.rs#L1306-L1312
 

--- a/testsuite/fuzzer/fuzz/fuzz_targets/move/aptosvm_publish_and_run_transactional.rs
+++ b/testsuite/fuzzer/fuzz/fuzz_targets/move/aptosvm_publish_and_run_transactional.rs
@@ -3,7 +3,9 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-use aptos_block_executor::code_cache_global_manager::AptosModuleCacheManager;
+use aptos_block_executor::{
+    code_cache_global_manager::AptosModuleCacheManager, worker_pool::WorkerPool,
+};
 use aptos_language_e2e_tests::{account::Account, executor::FakeExecutor};
 use aptos_transaction_simulation::GENESIS_CHANGE_SET_HEAD;
 use aptos_types::{
@@ -44,14 +46,7 @@ use utils::vm::{
 static VM_WRITE_SET: Lazy<WriteSet> = Lazy::new(|| GENESIS_CHANGE_SET_HEAD.write_set().clone());
 
 const FUZZER_CONCURRENCY_LEVEL: usize = 4;
-static TP: Lazy<Arc<rayon::ThreadPool>> = Lazy::new(|| {
-    Arc::new(
-        rayon::ThreadPoolBuilder::new()
-            .num_threads(FUZZER_CONCURRENCY_LEVEL)
-            .build()
-            .unwrap(),
-    )
-});
+static TP: Lazy<Arc<WorkerPool>> = Lazy::new(|| Arc::new(WorkerPool::new("par_exec")));
 
 const MAX_TYPE_PARAMETER_VALUE: u16 = 64 / 4 * 16; // third_party/move/move-bytecode-verifier/src/signature_v2.rs#L1306-L1312
 


### PR DESCRIPTION

Profiling of the `perpdex-benchmark` benchmark below shows ~8.1% of CPU cycles
spent on rayon's work-stealing overhead (`crossbeam_epoch::try_advance` 4.26%,
`with_handle` 2.90%, `Stealer::steal` 0.91%). The par_exec rayon pool is sized
to the number of cores, but only `concurrency_level` workers are active -- the
remaining idle threads continuously burn cycles on crossbeam epoch GC.

BlockExecutor's rayon usage is trivial: spawn N closures, wait for all to
finish. Workers independently pull tasks from the scheduler -- no work-stealing
between them ever occurs.

Replace with a `WorkerPool` struct using per-worker `mpsc` channels:
- Persistent named threads reused across block executions
- Idle threads block on `recv()` at zero CPU cost
- Per-invocation completion channel for correct concurrent dispatch
- Panic propagation to the calling thread
- Same scoped-borrow safety pattern as `rayon::scope` / `std::thread::scope`

## Benchmark results

Experiments were conducted on a 48-core host (one NUMA node of a larger
machine). In production, most hosts have at least 32 to 48 CPUs and some have up
to 128, so the rayon work-stealing waste scales with core count.

Setup: `perpdex-benchmark run-single-node-benchmark --transaction-type realistic`,
NUMA-bound, 5 runs per configuration, Welch's t-test for significance.

| Concurrency | Parent (rayon) | Commit (WorkerPool) | Delta | p-value |
|-------------|----------------|---------------------|-------|---------|
| c=8         | 1319 ± 35 TPS  | 1335 ± 22 TPS      | +1.2% | 0.42    |
| c=16        | 1301 ± 23 TPS  | 1445 ± 37 TPS      | +11.1% | 0.000168 |

At c=8, the effect is negligible -- the workers are bottlenecked on scheduler
contention rather than CPU, so freeing cycles from idle rayon threads doesn't
translate to throughput.

At c=16, the commit delivers **+11.1% TPS** (p < 0.001, Cohen's d = 4.72). The
gain is primarily from unlocking concurrency scaling: with rayon, going from c=8
to c=16 slightly *hurts* performance (-1.4%) because the idle threads' cache
pollution and crossbeam epoch contention eat the parallelism benefit. With the
WorkerPool, c=8 to c=16 gives +8.2% (p < 0.001) -- the additional workers can
now contribute clean throughput without rayon's overhead tipping the balance
negative.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk because it changes the core parallel execution threading model and introduces new `unsafe` scoped-dispatch logic; failures could manifest as deadlocks, missed panics, or subtle concurrency regressions under load.
> 
> **Overview**
> **Replaces BlockSTM’s `par_exec` execution backend** from a per-block `rayon::ThreadPool`/`scope` model to a new persistent `WorkerPool` that reuses named threads across blocks and propagates worker panics.
> 
> Plumbs `WorkerPool` through `aptos-block-executor`’s `BlockExecutor` API and all call sites (Aptos VM wrapper, sharded executor service/global executor, e2e fake executor, native benchmark executor, fuzz targets, and combinatorial/unit tests), and updates Cargo dependencies to drop `rayon` from main deps where no longer needed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f15b76a367c4f54360895864d3ae24e8a7f01286. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->