### PR TITLE
[BlockSTM] Replace rayon with tokio spawn_blocking for par_exec threads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -750,6 +750,7 @@ dependencies = [
  "rand 0.7.3",
  "rayon",
  "test-case",
+ "tokio",
  "triomphe",
 ]
 
@@ -2966,8 +2967,8 @@ dependencies = [
  "proptest",
  "proptest-derive",
  "rand 0.7.3",
- "rayon",
  "serde",
+ "tokio",
 ]
 
 [[package]]
@@ -5044,6 +5045,7 @@ dependencies = [
  "rayon",
  "serde",
  "test-case",
+ "tokio",
  "triomphe",
 ]
 
@@ -9896,10 +9898,10 @@ dependencies = [
  "move-vm-types",
  "once_cell",
  "primitive-types",
- "rayon",
  "ring 0.16.20",
  "serde",
  "serde_json",
+ "tokio",
 ]
 
 [[package]]

--- a/aptos-move/aptos-vm/Cargo.toml
+++ b/aptos-move/aptos-vm/Cargo.toml
@@ -57,6 +57,7 @@ ouroboros = { workspace = true }
 rand = { workspace = true }
 rayon = { workspace = true }
 serde = { workspace = true }
+tokio = { workspace = true }
 triomphe = { workspace = true }
 
 [dev-dependencies]

--- a/aptos-move/aptos-vm/src/block_executor/mod.rs
+++ b/aptos-move/aptos-vm/src/block_executor/mod.rs
@@ -49,19 +49,22 @@ use once_cell::sync::{Lazy, OnceCell};
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
     marker::PhantomData,
-    sync::Arc,
 };
 use triomphe::Arc as TriompheArc;
 use vm_wrapper::AptosExecutorTask;
 
-static RAYON_EXEC_POOL: Lazy<Arc<rayon::ThreadPool>> = Lazy::new(|| {
-    Arc::new(
-        rayon::ThreadPoolBuilder::new()
-            .num_threads(num_cpus::get())
-            .thread_name(|index| format!("par_exec-{}", index))
-            .build()
-            .unwrap(),
-    )
+static PAR_EXEC_RUNTIME: Lazy<tokio::runtime::Runtime> = Lazy::new(|| {
+    tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(1)
+        .max_blocking_threads(num_cpus::get())
+        .thread_name_fn(|| {
+            use std::sync::atomic::{AtomicUsize, Ordering};
+            static COUNTER: AtomicUsize = AtomicUsize::new(0);
+            let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+            format!("par_exec-{}", id)
+        })
+        .build()
+        .unwrap()
 });
 
 /// Output type wrapper used by block executor. VM output is stored first, then
@@ -517,7 +520,7 @@ impl<
         L: TransactionCommitHook,
         TP: TxnProvider<SignatureVerifiedTransaction, AuxiliaryInfo> + Sync,
     >(
-        executor_thread_pool: Arc<rayon::ThreadPool>,
+        runtime_handle: tokio::runtime::Handle,
         signature_verified_block: &TP,
         state_view: &S,
         module_cache_manager: &AptosModuleCacheManager,
@@ -545,7 +548,7 @@ impl<
         let executor =
             BlockExecutor::<SignatureVerifiedTransaction, E, S, L, TP, AuxiliaryInfo>::new(
                 config,
-                executor_thread_pool,
+                runtime_handle,
                 transaction_commit_listener,
             );
 
@@ -599,7 +602,7 @@ impl<
         transaction_commit_listener: Option<L>,
     ) -> Result<BlockOutput<SignatureVerifiedTransaction, TransactionOutput>, VMStatus> {
         Self::execute_block_on_thread_pool::<S, L, TP>(
-            Arc::clone(&RAYON_EXEC_POOL),
+            PAR_EXEC_RUNTIME.handle().clone(),
             signature_verified_block,
             state_view,
             module_cache_manager,

--- a/aptos-move/aptos-vm/src/sharded_block_executor/global_executor.rs
+++ b/aptos-move/aptos-vm/src/sharded_block_executor/global_executor.rs
@@ -19,6 +19,7 @@ use std::sync::Arc;
 pub struct GlobalExecutor<S: StateView + Sync + Send + 'static> {
     global_cross_shard_client: Arc<GlobalCrossShardClient>,
     executor_thread_pool: Arc<rayon::ThreadPool>,
+    runtime_handle: tokio::runtime::Handle,
     concurrency_level: usize,
     phantom: std::marker::PhantomData<S>,
 }
@@ -33,9 +34,16 @@ impl<S: StateView + Sync + Send + 'static> GlobalExecutor<S> {
                 .build()
                 .unwrap(),
         );
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
+            .max_blocking_threads(num_threads)
+            .thread_name("par_exec")
+            .build()
+            .unwrap();
         Self {
             global_cross_shard_client: cross_shard_client,
             executor_thread_pool,
+            runtime_handle: runtime.handle().clone(),
             phantom: std::marker::PhantomData,
             concurrency_level: num_threads,
         }
@@ -54,6 +62,7 @@ impl<S: StateView + Sync + Send + 'static> GlobalExecutor<S> {
         ShardedExecutorService::execute_transactions_with_dependencies(
             None,
             self.executor_thread_pool.clone(),
+            self.runtime_handle.clone(),
             transactions,
             self.global_cross_shard_client.clone(),
             None,

--- a/aptos-move/aptos-vm/src/sharded_block_executor/sharded_executor_service.rs
+++ b/aptos-move/aptos-vm/src/sharded_block_executor/sharded_executor_service.rs
@@ -43,6 +43,7 @@ pub struct ShardedExecutorService<S: StateView + Sync + Send + 'static> {
     shard_id: ShardId,
     num_shards: usize,
     executor_thread_pool: Arc<rayon::ThreadPool>,
+    runtime_handle: tokio::runtime::Handle,
     coordinator_client: Arc<dyn CoordinatorClient<S>>,
     cross_shard_client: Arc<dyn CrossShardClient>,
 }
@@ -64,10 +65,17 @@ impl<S: StateView + Sync + Send + 'static> ShardedExecutorService<S> {
                 .build()
                 .unwrap(),
         );
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
+            .max_blocking_threads(num_threads)
+            .thread_name("par_exec")
+            .build()
+            .unwrap();
         Self {
             shard_id,
             num_shards,
             executor_thread_pool,
+            runtime_handle: runtime.handle().clone(),
             coordinator_client,
             cross_shard_client,
         }
@@ -91,6 +99,7 @@ impl<S: StateView + Sync + Send + 'static> ShardedExecutorService<S> {
         Self::execute_transactions_with_dependencies(
             Some(self.shard_id),
             self.executor_thread_pool.clone(),
+            self.runtime_handle.clone(),
             sub_block.into_transactions_with_deps(),
             self.cross_shard_client.clone(),
             Some(cross_shard_commit_sender),
@@ -103,6 +112,7 @@ impl<S: StateView + Sync + Send + 'static> ShardedExecutorService<S> {
     pub fn execute_transactions_with_dependencies(
         shard_id: Option<ShardId>, // None means execution on global shard
         executor_thread_pool: Arc<rayon::ThreadPool>,
+        runtime_handle: tokio::runtime::Handle,
         transactions: Vec<TransactionWithDependencies<AnalyzedTransaction>>,
         cross_shard_client: Arc<dyn CrossShardClient>,
         cross_shard_commit_sender: Option<CrossShardCommitSender>,
@@ -143,7 +153,7 @@ impl<S: StateView + Sync + Send + 'static> ShardedExecutorService<S> {
                 let txn_provider =
                     DefaultTxnProvider::new_without_info(signature_verified_transactions);
                 let ret = AptosVMBlockExecutorWrapper::execute_block_on_thread_pool(
-                    executor_thread_pool,
+                    runtime_handle,
                     &txn_provider,
                     aggr_overridden_state_view.as_ref(),
                     // Since we execute blocks in parallel, we cannot share module caches, so each

--- a/aptos-move/block-executor/Cargo.toml
+++ b/aptos-move/block-executor/Cargo.toml
@@ -48,7 +48,7 @@ parking_lot = { workspace = true }
 proptest = { workspace = true, optional = true }
 proptest-derive = { workspace = true, optional = true }
 rand = { workspace = true }
-rayon = { workspace = true }
+tokio = { workspace = true }
 triomphe = { workspace = true }
 
 [dev-dependencies]
@@ -63,6 +63,7 @@ move-vm-types = { workspace = true, features = ["testing"] }
 proptest = { workspace = true }
 proptest-derive = { workspace = true }
 rand = { workspace = true }
+rayon = { workspace = true }
 test-case = { workspace = true }
 
 [features]

--- a/aptos-move/block-executor/src/combinatorial_tests/bencher.rs
+++ b/aptos-move/block-executor/src/combinatorial_tests/bencher.rs
@@ -31,7 +31,7 @@ use proptest::{
     strategy::{Strategy, ValueTree},
     test_runner::TestRunner,
 };
-use std::{fmt::Debug, hash::Hash, marker::PhantomData, sync::Arc};
+use std::{fmt::Debug, hash::Hash, marker::PhantomData};
 
 pub struct Bencher<K, V, E> {
     transaction_size: usize,
@@ -126,12 +126,18 @@ where
     pub(crate) fn run(self) {
         let state_view = MockStateView::empty();
 
-        let executor_thread_pool = Arc::new(
-            rayon::ThreadPoolBuilder::new()
-                .num_threads(num_cpus::get())
-                .build()
-                .unwrap(),
-        );
+        let executor_thread_pool = {
+            static RT: once_cell::sync::Lazy<tokio::runtime::Runtime> =
+                once_cell::sync::Lazy::new(|| {
+                    tokio::runtime::Builder::new_multi_thread()
+                        .worker_threads(1)
+                        .max_blocking_threads(num_cpus::get())
+                        .thread_name("par_exec")
+                        .build()
+                        .unwrap()
+                });
+            RT.handle().clone()
+        };
 
         let config = BlockExecutorConfig::new_no_block_limit(num_cpus::get());
         let mut guard = AptosModuleCacheManagerGuard::none();

--- a/aptos-move/block-executor/src/combinatorial_tests/group_tests.rs
+++ b/aptos-move/block-executor/src/combinatorial_tests/group_tests.rs
@@ -26,7 +26,6 @@ use aptos_types::{
     transaction::AuxiliaryInfo,
 };
 use proptest::{collection::vec, prelude::*, strategy::ValueTree, test_runner::TestRunner};
-use std::sync::Arc;
 use test_case::test_case;
 
 /// Create a data view for testing with non-empty groups
@@ -46,7 +45,7 @@ pub(crate) fn create_non_empty_group_data_view(
 
 /// Run both parallel and sequential execution tests for a transaction provider
 pub(crate) fn run_tests_with_groups(
-    executor_thread_pool: Arc<rayon::ThreadPool>,
+    executor_thread_pool: tokio::runtime::Handle,
     gas_limits: Vec<Option<u64>>,
     transactions: Vec<MockTransaction<KeyType<[u8; 32]>, MockEvent>>,
     data_view: &NonEmptyGroupDataView<KeyType<[u8; 32]>>,

--- a/aptos-move/block-executor/src/combinatorial_tests/resource_tests.rs
+++ b/aptos-move/block-executor/src/combinatorial_tests/resource_tests.rs
@@ -49,13 +49,16 @@ pub(crate) fn get_gas_limit_variants(
     }
 }
 
-pub(crate) fn create_executor_thread_pool() -> Arc<rayon::ThreadPool> {
-    Arc::new(
-        rayon::ThreadPoolBuilder::new()
-            .num_threads(num_cpus::get())
+pub(crate) fn create_executor_thread_pool() -> tokio::runtime::Handle {
+    static RT: once_cell::sync::Lazy<tokio::runtime::Runtime> = once_cell::sync::Lazy::new(|| {
+        tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
+            .max_blocking_threads(num_cpus::get())
+            .thread_name("par_exec")
             .build()
-            .unwrap(),
-    )
+            .unwrap()
+    });
+    RT.handle().clone()
 }
 
 /// Populates a module cache manager guard with empty modules for testing.
@@ -98,7 +101,7 @@ pub(crate) fn populate_guard_with_modules(
 }
 
 pub(crate) fn execute_block_parallel<TxnType, ViewType, Provider>(
-    executor_thread_pool: Arc<rayon::ThreadPool>,
+    executor_thread_pool: tokio::runtime::Handle,
     block_gas_limit: Option<u64>,
     txn_provider: &Provider,
     data_view: &ViewType,

--- a/aptos-move/block-executor/src/combinatorial_tests/tests.rs
+++ b/aptos-move/block-executor/src/combinatorial_tests/tests.rs
@@ -32,8 +32,21 @@ use proptest::{
     test_runner::TestRunner,
 };
 use rand::Rng;
-use std::{cmp::max, fmt::Debug, hash::Hash, marker::PhantomData, sync::Arc};
+use std::{cmp::max, fmt::Debug, hash::Hash, marker::PhantomData};
 use test_case::test_case;
+
+fn create_executor_thread_pool() -> tokio::runtime::Handle {
+    static RT: once_cell::sync::Lazy<tokio::runtime::Runtime> =
+        once_cell::sync::Lazy::new(|| {
+            tokio::runtime::Builder::new_multi_thread()
+                .worker_threads(1)
+                .max_blocking_threads(num_cpus::get())
+                .thread_name("par_exec")
+                .build()
+                .unwrap()
+        });
+    RT.handle().clone()
+}
 
 fn run_transactions<K, V, E>(
     key_universe: &[K],
@@ -64,12 +77,7 @@ fn run_transactions<K, V, E>(
 
     let state_view = MockStateView::empty();
 
-    let executor_thread_pool = Arc::new(
-        rayon::ThreadPoolBuilder::new()
-            .num_threads(num_cpus::get())
-            .build()
-            .unwrap(),
-    );
+    let executor_thread_pool = create_executor_thread_pool();
 
     let txn_provider = DefaultTxnProvider::new_without_info(transactions);
     for _ in 0..num_repeat {
@@ -208,12 +216,7 @@ fn deltas_writes_mixed_with_block_gas_limit(num_txns: usize, maybe_block_gas_lim
         phantom: PhantomData,
     };
 
-    let executor_thread_pool = Arc::new(
-        rayon::ThreadPoolBuilder::new()
-            .num_threads(num_cpus::get())
-            .build()
-            .unwrap(),
-    );
+    let executor_thread_pool = create_executor_thread_pool();
 
     for _ in 0..20 {
         let mut guard = AptosModuleCacheManagerGuard::none();
@@ -267,12 +270,7 @@ fn deltas_resolver_with_block_gas_limit(num_txns: usize, maybe_block_gas_limit: 
         .collect();
     let txn_provider = DefaultTxnProvider::new_without_info(transactions);
 
-    let executor_thread_pool = Arc::new(
-        rayon::ThreadPoolBuilder::new()
-            .num_threads(num_cpus::get())
-            .build()
-            .unwrap(),
-    );
+    let executor_thread_pool = create_executor_thread_pool();
 
     for _ in 0..20 {
         let mut guard = AptosModuleCacheManagerGuard::none();
@@ -383,12 +381,7 @@ fn publishing_fixed_params_with_block_gas_limit(
         phantom: PhantomData,
     };
 
-    let executor_thread_pool = Arc::new(
-        rayon::ThreadPoolBuilder::new()
-            .num_threads(num_cpus::get())
-            .build()
-            .unwrap(),
-    );
+    let executor_thread_pool = create_executor_thread_pool();
 
     let txn_provider = DefaultTxnProvider::new_without_info(transactions.clone());
     // Confirm still no intersection
@@ -432,12 +425,7 @@ fn publishing_fixed_params_with_block_gas_limit(
         },
     };
 
-    let executor_thread_pool = Arc::new(
-        rayon::ThreadPoolBuilder::new()
-            .num_threads(num_cpus::get())
-            .build()
-            .unwrap(),
-    );
+    let executor_thread_pool = create_executor_thread_pool();
 
     let txn_provider = DefaultTxnProvider::new_without_info(transactions);
     for _ in 0..200 {
@@ -523,12 +511,7 @@ fn non_empty_group(
             .collect(),
     };
 
-    let executor_thread_pool = Arc::new(
-        rayon::ThreadPoolBuilder::new()
-            .num_threads(num_cpus::get())
-            .build()
-            .unwrap(),
-    );
+    let executor_thread_pool = create_executor_thread_pool();
 
     for _ in 0..num_repeat_parallel {
         let mut guard = AptosModuleCacheManagerGuard::none();

--- a/aptos-move/block-executor/src/executor.rs
+++ b/aptos-move/block-executor/src/executor.rs
@@ -67,17 +67,49 @@ use move_core_types::{language_storage::ModuleId, value::MoveTypeLayout, vm_stat
 use move_vm_runtime::{Module, RuntimeEnvironment, TypeChecker, WithRuntimeEnvironment};
 use move_vm_types::delayed_values::delayed_field_id::DelayedFieldID;
 use num_cpus;
-use rayon::ThreadPool;
 use std::{
     cell::RefCell,
     collections::{BTreeMap, BTreeSet, HashMap, HashSet},
     marker::{PhantomData, Sync},
-    sync::{
-        atomic::{AtomicBool, AtomicU32, Ordering},
-        Arc,
-    },
+    sync::atomic::{AtomicBool, AtomicU32, Ordering},
 };
 use triomphe::Arc as TriompheArc;
+
+/// Dispatches `f(worker_id)` to `num_workers` tokio blocking tasks and blocks
+/// until all complete. Worker panics are propagated after all tasks finish.
+fn dispatch_workers(
+    handle: &tokio::runtime::Handle,
+    num_workers: usize,
+    f: impl Fn(u32) + Send + Sync,
+) {
+    let f_ref: &(dyn Fn(u32) + Send + Sync) = &f;
+    let join_handles: Vec<_> = (0..num_workers)
+        .map(|i| {
+            let worker_id = i as u32;
+            let task: Box<dyn FnOnce() + Send + '_> = Box::new(move || f_ref(worker_id));
+            // SAFETY: We block on all join handles below before returning, so
+            // all data borrowed by `f` outlives worker execution. This is the
+            // same safety pattern as `rayon::scope` and `std::thread::scope`.
+            let task: Box<dyn FnOnce() + Send + 'static> = unsafe { std::mem::transmute(task) };
+            handle.spawn_blocking(task)
+        })
+        .collect();
+    handle.block_on(async {
+        let mut panic_payload = None;
+        for h in join_handles {
+            match h.await {
+                Ok(()) => {},
+                Err(e) if e.is_panic() => {
+                    panic_payload.get_or_insert(e.into_panic());
+                },
+                Err(e) => panic!("spawn_blocking task cancelled unexpectedly: {e}"),
+            }
+        }
+        if let Some(payload) = panic_payload {
+            std::panic::resume_unwind(payload);
+        }
+    });
+}
 
 struct SharedSyncParams<'a, T, E, S>
 where
@@ -99,10 +131,10 @@ where
 }
 
 pub struct BlockExecutor<T, E, S, L, TP, A> {
-    // Number of active concurrent tasks, corresponding to the maximum number of rayon
-    // threads that may be concurrently participating in parallel execution.
+    // Number of active concurrent tasks, corresponding to the maximum number of
+    // worker threads that may be concurrently participating in parallel execution.
     config: BlockExecutorConfig,
-    executor_thread_pool: Arc<rayon::ThreadPool>,
+    runtime_handle: tokio::runtime::Handle,
     transaction_commit_hook: Option<L>,
     phantom: PhantomData<fn() -> (T, E, S, L, TP, A)>,
 }
@@ -120,7 +152,7 @@ where
     /// be handled by sequential execution) and that concurrency_level <= num_cpus.
     pub fn new(
         config: BlockExecutorConfig,
-        executor_thread_pool: Arc<ThreadPool>,
+        runtime_handle: tokio::runtime::Handle,
         transaction_commit_hook: Option<L>,
     ) -> Self {
         let num_cpus = num_cpus::get();
@@ -132,7 +164,7 @@ where
         );
         Self {
             config,
-            executor_thread_pool,
+            runtime_handle,
             transaction_commit_hook,
             phantom: PhantomData,
         }
@@ -1852,48 +1884,43 @@ where
         );
 
         let timer = RAYON_EXECUTION_SECONDS.start_timer();
-        let worker_ids: Vec<u32> = (0..num_workers).collect();
         let maybe_executor = ExplicitSyncWrapper::new(None);
-        self.executor_thread_pool.scope(|s| {
-            for worker_id in &worker_ids {
-                s.spawn(|_| {
-                    let environment = module_cache_manager_guard.environment();
-                    let executor = {
-                        let _init_timer = VM_INIT_SECONDS.start_timer();
-                        E::init(
-                            &environment.clone(),
-                            shared_sync_params.base_view,
-                            async_runtime_checks_enabled,
-                        )
-                    };
+        dispatch_workers(&self.runtime_handle, num_workers as usize, |worker_id| {
+            let environment = module_cache_manager_guard.environment();
+            let executor = {
+                let _init_timer = VM_INIT_SECONDS.start_timer();
+                E::init(
+                    &environment.clone(),
+                    shared_sync_params.base_view,
+                    async_runtime_checks_enabled,
+                )
+            };
 
-                    if let Err(err) = self.worker_loop_v2(
-                        &executor,
-                        signature_verified_block,
-                        environment,
-                        *worker_id,
-                        num_workers,
-                        &scheduler,
-                        &shared_sync_params,
-                    ) {
-                        // If there are multiple errors, they all get logged: FatalVMError is
-                        // logged at construction, below we log CodeInvariantErrors.
-                        if let PanicOr::CodeInvariantError(err_msg) = err {
-                            alert!(
-                                "[BlockSTMv2] worker loop: CodeInvariantError({:?})",
-                                err_msg
-                            );
-                        }
-                        shared_maybe_error.store(true, Ordering::SeqCst);
+            if let Err(err) = self.worker_loop_v2(
+                &executor,
+                signature_verified_block,
+                environment,
+                worker_id,
+                num_workers,
+                &scheduler,
+                &shared_sync_params,
+            ) {
+                // If there are multiple errors, they all get logged: FatalVMError is logged at
+                // construction, below we log CodeInvariantErrors.
+                if let PanicOr::CodeInvariantError(err_msg) = err {
+                    alert!(
+                        "[BlockSTMv2] worker loop: CodeInvariantError({:?})",
+                        err_msg
+                    );
+                }
+                shared_maybe_error.store(true, Ordering::SeqCst);
 
-                        // Make sure to halt the scheduler if it hasn't already been halted.
-                        scheduler.halt();
-                    }
+                // Make sure to halt the scheduler if it hasn't already been halted.
+                scheduler.halt();
+            }
 
-                    if *worker_id == 0 {
-                        maybe_executor.acquire().replace(executor);
-                    }
-                });
+            if worker_id == 0 {
+                maybe_executor.acquire().replace(executor);
             }
         });
         drop(timer);
@@ -2003,7 +2030,6 @@ where
         let scheduler = Scheduler::new(num_txns);
 
         let timer = RAYON_EXECUTION_SECONDS.start_timer();
-        let worker_ids: Vec<u32> = (0..num_workers as u32).collect();
         let maybe_executor = ExplicitSyncWrapper::new(None);
 
         let shared_sync_params: SharedSyncParams<'_, T, E, S> = SharedSyncParams {
@@ -2021,47 +2047,43 @@ where
         let async_runtime_checks_enabled = should_perform_async_runtime_checks_for_block(
             module_cache_manager_guard.environment(),
             num_txns,
-            worker_ids.len() as u32,
+            num_workers as u32,
         );
 
-        self.executor_thread_pool.scope(|s| {
-            for worker_id in &worker_ids {
-                s.spawn(|_| {
-                    let environment = module_cache_manager_guard.environment();
-                    let executor = {
-                        let _init_timer = VM_INIT_SECONDS.start_timer();
-                        E::init(
-                            &environment.clone(),
-                            base_view,
-                            async_runtime_checks_enabled,
-                        )
-                    };
+        dispatch_workers(&self.runtime_handle, num_workers, |worker_id| {
+            let environment = module_cache_manager_guard.environment();
+            let executor = {
+                let _init_timer = VM_INIT_SECONDS.start_timer();
+                E::init(
+                    &environment.clone(),
+                    base_view,
+                    async_runtime_checks_enabled,
+                )
+            };
 
-                    if let Err(err) = self.worker_loop(
-                        &executor,
-                        environment,
-                        signature_verified_block,
-                        &scheduler,
-                        &skip_module_reads_validation,
-                        &shared_sync_params,
-                        num_workers,
-                    ) {
-                        // If there are multiple errors, they all get logged:
-                        // ModulePathReadWriteError and FatalVMError variant is logged at construction,
-                        // and below we log CodeInvariantErrors.
-                        if let PanicOr::CodeInvariantError(err_msg) = err {
-                            alert!("[BlockSTM] worker loop: CodeInvariantError({:?})", err_msg);
-                        }
-                        shared_maybe_error.store(true, Ordering::SeqCst);
+            if let Err(err) = self.worker_loop(
+                &executor,
+                environment,
+                signature_verified_block,
+                &scheduler,
+                &skip_module_reads_validation,
+                &shared_sync_params,
+                num_workers,
+            ) {
+                // If there are multiple errors, they all get logged:
+                // ModulePathReadWriteError and FatalVMError variant is logged at construction,
+                // and below we log CodeInvariantErrors.
+                if let PanicOr::CodeInvariantError(err_msg) = err {
+                    alert!("[BlockSTM] worker loop: CodeInvariantError({:?})", err_msg);
+                }
+                shared_maybe_error.store(true, Ordering::SeqCst);
 
-                        // Make sure to halt the scheduler if it hasn't already been halted.
-                        scheduler.halt();
-                    }
+                // Make sure to halt the scheduler if it hasn't already been halted.
+                scheduler.halt();
+            }
 
-                    if *worker_id == 0 {
-                        maybe_executor.acquire().replace(executor);
-                    }
-                });
+            if worker_id == 0 {
+                maybe_executor.acquire().replace(executor);
             }
         });
         drop(timer);

--- a/aptos-move/block-executor/src/unit_tests/mod.rs
+++ b/aptos-move/block-executor/src/unit_tests/mod.rs
@@ -46,8 +46,19 @@ use std::{
     fmt::Debug,
     hash::Hash,
     marker::PhantomData,
-    sync::Arc,
 };
+
+fn test_runtime_handle() -> tokio::runtime::Handle {
+    static RT: once_cell::sync::Lazy<tokio::runtime::Runtime> = once_cell::sync::Lazy::new(|| {
+        tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
+            .max_blocking_threads(num_cpus::get())
+            .thread_name("par_exec")
+            .build()
+            .unwrap()
+    });
+    RT.handle().clone()
+}
 
 #[test]
 fn test_block_epilogue_happy_path() {
@@ -56,12 +67,7 @@ fn test_block_epilogue_happy_path() {
     let t_1 = MockTransaction::from_behavior(behaivor);
     let transactions = vec![t_0, t_1];
 
-    let executor_thread_pool = Arc::new(
-        rayon::ThreadPoolBuilder::new()
-            .num_threads(num_cpus::get())
-            .build()
-            .unwrap(),
-    );
+    let executor_thread_pool = test_runtime_handle();
     let block_executor = BlockExecutor::<
         MockTransaction<KeyType<u32>, MockEvent>,
         MockTask<KeyType<u32>, MockEvent>,
@@ -127,12 +133,7 @@ fn test_block_epilogue_block_gas_limit_reached() {
     let t_1 = MockTransaction::from_behavior(behaivor);
     let transactions = vec![t_0, t_1];
 
-    let executor_thread_pool = Arc::new(
-        rayon::ThreadPoolBuilder::new()
-            .num_threads(num_cpus::get())
-            .build()
-            .unwrap(),
-    );
+    let executor_thread_pool = test_runtime_handle();
     let block_executor = BlockExecutor::<
         MockTransaction<KeyType<u32>, MockEvent>,
         MockTask<KeyType<u32>, MockEvent>,
@@ -222,12 +223,7 @@ fn test_resource_group_deletion() {
         group_keys: HashSet::new(),
         delayed_field_testing: false,
     };
-    let executor_thread_pool = Arc::new(
-        rayon::ThreadPoolBuilder::new()
-            .num_threads(num_cpus::get())
-            .build()
-            .unwrap(),
-    );
+    let executor_thread_pool = test_runtime_handle();
     let block_executor = BlockExecutor::<
         MockTransaction<KeyType<u32>, MockEvent>,
         MockTask<KeyType<u32>, MockEvent>,
@@ -301,12 +297,7 @@ fn resource_group_bcs_fallback() {
         group_keys: HashSet::new(),
         delayed_field_testing: false,
     };
-    let executor_thread_pool = Arc::new(
-        rayon::ThreadPoolBuilder::new()
-            .num_threads(num_cpus::get())
-            .build()
-            .unwrap(),
-    );
+    let executor_thread_pool = test_runtime_handle();
     let block_executor = BlockExecutor::<
         MockTransaction<KeyType<u32>, MockEvent>,
         MockTask<KeyType<u32>, MockEvent>,
@@ -417,12 +408,7 @@ fn interrupt_requested() {
     let mut guard = AptosModuleCacheManagerGuard::none();
 
     let data_view = MockStateView::empty();
-    let executor_thread_pool = Arc::new(
-        rayon::ThreadPoolBuilder::new()
-            .num_threads(num_cpus::get())
-            .build()
-            .unwrap(),
-    );
+    let executor_thread_pool = test_runtime_handle();
     let block_executor = BlockExecutor::<
         MockTransaction<KeyType<u32>, MockEvent>,
         MockTask<KeyType<u32>, MockEvent>,
@@ -464,12 +450,7 @@ fn block_output_err_precedence() {
     let txn_provider = DefaultTxnProvider::new_without_info(transactions);
 
     let data_view = MockStateView::empty();
-    let executor_thread_pool = Arc::new(
-        rayon::ThreadPoolBuilder::new()
-            .num_threads(num_cpus::get())
-            .build()
-            .unwrap(),
-    );
+    let executor_thread_pool = test_runtime_handle();
     let block_executor = BlockExecutor::<
         MockTransaction<KeyType<u32>, MockEvent>,
         MockTask<KeyType<u32>, MockEvent>,
@@ -508,12 +489,7 @@ fn skip_rest_gas_limit() {
     let txn_provider = DefaultTxnProvider::new_without_info(transactions);
 
     let data_view = MockStateView::empty();
-    let executor_thread_pool = Arc::new(
-        rayon::ThreadPoolBuilder::new()
-            .num_threads(num_cpus::get())
-            .build()
-            .unwrap(),
-    );
+    let executor_thread_pool = test_runtime_handle();
     let block_executor = BlockExecutor::<
         MockTransaction<KeyType<u32>, MockEvent>,
         MockTask<KeyType<u32>, MockEvent>,
@@ -543,12 +519,7 @@ where
     K: PartialOrd + Ord + Send + Sync + Clone + Hash + Eq + ModulePath + Debug + 'static,
     E: Send + Sync + Debug + Clone + TransactionEvent + 'static,
 {
-    let executor_thread_pool = Arc::new(
-        rayon::ThreadPoolBuilder::new()
-            .num_threads(num_cpus::get())
-            .build()
-            .unwrap(),
-    );
+    let executor_thread_pool = test_runtime_handle();
 
     let mut guard = AptosModuleCacheManagerGuard::none();
     let txn_provider = DefaultTxnProvider::new_without_info(transactions);

--- a/aptos-move/e2e-tests/Cargo.toml
+++ b/aptos-move/e2e-tests/Cargo.toml
@@ -54,8 +54,8 @@ petgraph = "0.5.1"
 proptest = { workspace = true }
 proptest-derive = { workspace = true }
 rand = { workspace = true }
-rayon = { workspace = true }
 serde = { workspace = true }
+tokio = { workspace = true }
 
 [features]
 default = []

--- a/aptos-move/e2e-tests/src/executor.rs
+++ b/aptos-move/e2e-tests/src/executor.rs
@@ -162,7 +162,7 @@ struct SharedCacheState {
 pub struct FakeExecutorImpl<O: OutputLogger> {
     state_store: FakeExecutorStateStore,
     event_store: Vec<ContractEvent>,
-    executor_thread_pool: Arc<rayon::ThreadPool>,
+    runtime_handle: tokio::runtime::Handle,
     block_time: u64,
     executed_output: Option<O>,
     trace_dir: Option<PathBuf>,
@@ -229,23 +229,28 @@ pub enum ExecFuncTimerDynamicArgs {
     DistinctSignersAndFixed(Vec<AccountAddress>),
 }
 
+fn par_exec_runtime_handle() -> tokio::runtime::Handle {
+    static RT: once_cell::sync::Lazy<tokio::runtime::Runtime> = once_cell::sync::Lazy::new(|| {
+        tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
+            .max_blocking_threads(num_cpus::get())
+            .thread_name("par_exec")
+            .build()
+            .unwrap()
+    });
+    RT.handle().clone()
+}
+
 impl<O: OutputLogger> FakeExecutorImpl<O> {
     /// Creates an executor from a genesis [`WriteSet`].
     pub fn from_genesis(write_set: &WriteSet, chain_id: ChainId) -> Self {
-        let executor_thread_pool = Arc::new(
-            rayon::ThreadPoolBuilder::new()
-                .num_threads(num_cpus::get())
-                .build()
-                .unwrap(),
-        );
-
         let state_store = empty_in_memory_state_store();
         state_store.set_chain_id(chain_id).unwrap();
 
         let mut executor = Self {
             state_store,
             event_store: Vec::new(),
-            executor_thread_pool,
+            runtime_handle: par_exec_runtime_handle(),
             block_time: 0,
             executed_output: None,
             trace_dir: None,
@@ -259,10 +264,10 @@ impl<O: OutputLogger> FakeExecutorImpl<O> {
     }
 
     #[cfg(any(test, feature = "fuzzing"))]
-    pub fn from_genesis_with_existing_thread_pool(
+    pub fn from_genesis_with_existing_runtime(
         write_set: &WriteSet,
         chain_id: ChainId,
-        executor_thread_pool: Arc<rayon::ThreadPool>,
+        runtime_handle: tokio::runtime::Handle,
         module_cache_manager: Option<AptosModuleCacheManager>,
     ) -> Self {
         let state_store = empty_in_memory_state_store();
@@ -271,7 +276,7 @@ impl<O: OutputLogger> FakeExecutorImpl<O> {
         let mut executor = Self {
             state_store,
             event_store: Vec::new(),
-            executor_thread_pool,
+            runtime_handle,
             block_time: 0,
             executed_output: None,
             trace_dir: None,
@@ -313,17 +318,10 @@ impl<O: OutputLogger> FakeExecutorImpl<O> {
             .get_on_chain_config::<CurrentTimeMicroseconds>()
             .expect("failed to get block time from remote");
 
-        let executor_thread_pool = Arc::new(
-            rayon::ThreadPoolBuilder::new()
-                .num_threads(num_cpus::get())
-                .build()
-                .unwrap(),
-        );
-
         Self {
             state_store,
             event_store: Vec::new(),
-            executor_thread_pool,
+            runtime_handle: par_exec_runtime_handle(),
             block_time: timestamp.microseconds,
             executed_output: None,
             trace_dir: None,
@@ -507,16 +505,10 @@ impl<O: OutputLogger> FakeExecutorImpl<O> {
 
     /// Creates an executor in which no genesis state has been applied yet.
     pub fn no_genesis() -> Self {
-        let executor_thread_pool = Arc::new(
-            rayon::ThreadPoolBuilder::new()
-                .num_threads(num_cpus::get())
-                .build()
-                .unwrap(),
-        );
         Self {
             state_store: empty_in_memory_state_store(),
             event_store: Vec::new(),
-            executor_thread_pool,
+            runtime_handle: par_exec_runtime_handle(),
             block_time: 0,
             executed_output: None,
             trace_dir: None,
@@ -895,7 +887,7 @@ impl<O: OutputLogger> FakeExecutorImpl<O> {
                 NoOpTransactionCommitHook<VMStatus>,
                 _,
             >(
-                self.executor_thread_pool.clone(),
+                self.runtime_handle.clone(),
                 &txn_provider,
                 &state_view,
                 self.module_cache_manager_opt()
@@ -1076,8 +1068,7 @@ impl<O: OutputLogger> FakeExecutorImpl<O> {
         }
 
         let parallel_output = if mode != ExecutorMode::SequentialOnly {
-            // use the number of threads specified in the executor thread pool as specified at construction time
-            config.local.concurrency_level = self.executor_thread_pool.current_num_threads();
+            config.local.concurrency_level = num_cpus::get();
             Some(self.execute_transaction_block_impl_with_state_view(
                 sig_verified_block,
                 state_view,

--- a/execution/executor-benchmark/src/native/native_config.rs
+++ b/execution/executor-benchmark/src/native/native_config.rs
@@ -2,18 +2,25 @@
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use once_cell::sync::{Lazy, OnceCell};
-use rayon::{ThreadPool, ThreadPoolBuilder};
 use std::sync::Arc;
 
 pub static NATIVE_EXECUTOR_CONCURRENCY_LEVEL: OnceCell<usize> = OnceCell::new();
-pub static NATIVE_EXECUTOR_POOL: Lazy<Arc<ThreadPool>> = Lazy::new(|| {
+pub static NATIVE_EXECUTOR_POOL: Lazy<Arc<rayon::ThreadPool>> = Lazy::new(|| {
     Arc::new(
-        ThreadPoolBuilder::new()
+        rayon::ThreadPoolBuilder::new()
             .num_threads(NativeConfig::get_concurrency_level())
             .thread_name(|index| format!("native_exe_{}", index))
             .build()
             .unwrap(),
     )
+});
+pub static NATIVE_EXECUTOR_RUNTIME: Lazy<tokio::runtime::Runtime> = Lazy::new(|| {
+    tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(1)
+        .max_blocking_threads(NativeConfig::get_concurrency_level())
+        .thread_name("native_exe")
+        .build()
+        .unwrap()
 });
 
 pub struct NativeConfig;

--- a/execution/executor-benchmark/src/native/native_vm.rs
+++ b/execution/executor-benchmark/src/native/native_vm.rs
@@ -4,7 +4,7 @@
 use crate::{
     db_access::DbAccessUtil,
     native::{
-        native_config::{NativeConfig, NATIVE_EXECUTOR_POOL},
+        native_config::{NativeConfig, NATIVE_EXECUTOR_RUNTIME},
         native_transaction::{compute_deltas_for_batch, NativeTransaction},
     },
 };
@@ -64,7 +64,7 @@ use move_core_types::{
 };
 use move_vm_types::delayed_values::delayed_field_id::DelayedFieldID;
 use serde::{de::DeserializeOwned, Serialize};
-use std::{collections::BTreeMap, fmt::Debug, sync::Arc};
+use std::{collections::BTreeMap, fmt::Debug};
 
 pub struct NativeVMBlockExecutor;
 
@@ -91,7 +91,7 @@ impl VMBlockExecutor for NativeVMBlockExecutor {
             NoOpTransactionCommitHook<VMStatus>,
             _,
         >(
-            Arc::clone(&NATIVE_EXECUTOR_POOL),
+            NATIVE_EXECUTOR_RUNTIME.handle().clone(),
             txn_provider,
             state_view,
             &AptosModuleCacheManager::new(),

--- a/testsuite/fuzzer/fuzz/Cargo.toml
+++ b/testsuite/fuzzer/fuzz/Cargo.toml
@@ -109,9 +109,9 @@ move-vm-runtime = { workspace = true }
 move-vm-types = { workspace = true, features = ["fuzzing"] }
 once_cell = { workspace = true }
 primitive-types = { workspace = true }
-rayon = { workspace = true }
 ring = { workspace = true }
 serde = { workspace = true }
+tokio = { workspace = true }
 serde_json = { workspace = true }
 
 [[bin]]

--- a/testsuite/fuzzer/fuzz/fuzz_targets/move/aptosvm_authenticators.rs
+++ b/testsuite/fuzzer/fuzz/fuzz_targets/move/aptosvm_authenticators.rs
@@ -37,7 +37,6 @@ use move_core_types::{
 };
 use once_cell::sync::Lazy;
 use ring::signature;
-use std::sync::Arc;
 mod utils;
 use utils::{
     authenticator::{
@@ -52,23 +51,23 @@ use utils::{
 static VM: Lazy<WriteSet> = Lazy::new(|| GENESIS_CHANGE_SET_HEAD.write_set().clone());
 
 const FUZZER_CONCURRENCY_LEVEL: usize = 1;
-static TP: Lazy<Arc<rayon::ThreadPool>> = Lazy::new(|| {
-    Arc::new(
-        rayon::ThreadPoolBuilder::new()
-            .num_threads(FUZZER_CONCURRENCY_LEVEL)
-            .build()
-            .unwrap(),
-    )
+static RT: Lazy<tokio::runtime::Runtime> = Lazy::new(|| {
+    tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(1)
+        .max_blocking_threads(FUZZER_CONCURRENCY_LEVEL)
+        .thread_name("par_exec")
+        .build()
+        .unwrap()
 });
 
 fn run_case(input: TransactionState) -> Result<(), Corpus> {
     tdbg!(&input);
 
     AptosVM::set_concurrency_level_once(FUZZER_CONCURRENCY_LEVEL);
-    let mut vm = FakeExecutor::from_genesis_with_existing_thread_pool(
+    let mut vm = FakeExecutor::from_genesis_with_existing_runtime(
         &VM,
         ChainId::mainnet(),
-        Arc::clone(&TP),
+        RT.handle().clone(),
         None,
     )
     .set_not_parallel();

--- a/testsuite/fuzzer/fuzz/fuzz_targets/move/aptosvm_publish.rs
+++ b/testsuite/fuzzer/fuzz/fuzz_targets/move/aptosvm_publish.rs
@@ -16,7 +16,7 @@ use move_binary_format::{
     file_format::{CompiledModule, CompiledScript},
 };
 use once_cell::sync::Lazy;
-use std::{collections::HashSet, sync::Arc};
+use std::collections::HashSet;
 use utils::vm::{group_modules_by_address_topo, publish_group};
 
 // genesis write set generated once for each fuzzing session
@@ -24,13 +24,13 @@ static VM: Lazy<WriteSet> = Lazy::new(|| GENESIS_CHANGE_SET_HEAD.write_set().clo
 
 const TEST_UPGRADE: bool = true;
 const FUZZER_CONCURRENCY_LEVEL: usize = 1;
-static TP: Lazy<Arc<rayon::ThreadPool>> = Lazy::new(|| {
-    Arc::new(
-        rayon::ThreadPoolBuilder::new()
-            .num_threads(FUZZER_CONCURRENCY_LEVEL)
-            .build()
-            .unwrap(),
-    )
+static RT: Lazy<tokio::runtime::Runtime> = Lazy::new(|| {
+    tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(1)
+        .max_blocking_threads(FUZZER_CONCURRENCY_LEVEL)
+        .thread_name("par_exec")
+        .build()
+        .unwrap()
 });
 
 fn run_case(mut input: RunnableState) -> Result<(), Corpus> {
@@ -72,10 +72,10 @@ fn run_case(mut input: RunnableState) -> Result<(), Corpus> {
     let packages = group_modules_by_address_topo(input.dep_modules.clone())?;
 
     AptosVM::set_concurrency_level_once(FUZZER_CONCURRENCY_LEVEL);
-    let mut vm = FakeExecutor::from_genesis_with_existing_thread_pool(
+    let mut vm = FakeExecutor::from_genesis_with_existing_runtime(
         &VM,
         ChainId::mainnet(),
-        Arc::clone(&TP),
+        RT.handle().clone(),
         None,
     )
     .set_not_parallel();

--- a/testsuite/fuzzer/fuzz/fuzz_targets/move/aptosvm_publish_and_run.rs
+++ b/testsuite/fuzzer/fuzz/fuzz_targets/move/aptosvm_publish_and_run.rs
@@ -22,7 +22,7 @@ use move_binary_format::{
 };
 use move_core_types::vm_status::{StatusCode, StatusType};
 use once_cell::sync::Lazy;
-use std::{collections::HashSet, sync::Arc, time::Instant};
+use std::{collections::HashSet, time::Instant};
 mod utils;
 use fuzzer::{Authenticator, ExecVariant, RunnableState};
 use move_vm_runtime::RuntimeEnvironment;
@@ -35,13 +35,13 @@ use utils::vm::{
 static VM_WRITE_SET: Lazy<WriteSet> = Lazy::new(|| GENESIS_CHANGE_SET_HEAD.write_set().clone());
 
 const FUZZER_CONCURRENCY_LEVEL: usize = 1;
-static TP: Lazy<Arc<rayon::ThreadPool>> = Lazy::new(|| {
-    Arc::new(
-        rayon::ThreadPoolBuilder::new()
-            .num_threads(FUZZER_CONCURRENCY_LEVEL)
-            .build()
-            .unwrap(),
-    )
+static RT: Lazy<tokio::runtime::Runtime> = Lazy::new(|| {
+    tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(1)
+        .max_blocking_threads(FUZZER_CONCURRENCY_LEVEL)
+        .thread_name("par_exec")
+        .build()
+        .unwrap()
 });
 
 const MAX_TYPE_PARAMETER_VALUE: u16 = 64 / 4 * 16; // third_party/move/move-bytecode-verifier/src/signature_v2.rs#L1306-L1312
@@ -113,10 +113,10 @@ fn run_case(mut input: RunnableState) -> Result<(), Corpus> {
     AptosVM::set_concurrency_level_once(FUZZER_CONCURRENCY_LEVEL);
     // Enable runtime reference-safety checks for the Move VM
     // prod_configs::set_paranoid_ref_checks(true);
-    let mut vm = FakeExecutor::from_genesis_with_existing_thread_pool(
+    let mut vm = FakeExecutor::from_genesis_with_existing_runtime(
         &VM_WRITE_SET,
         ChainId::mainnet(),
-        Arc::clone(&TP),
+        RT.handle().clone(),
         None,
     )
     .set_not_parallel();

--- a/testsuite/fuzzer/fuzz/fuzz_targets/move/aptosvm_publish_and_run_transactional.rs
+++ b/testsuite/fuzzer/fuzz/fuzz_targets/move/aptosvm_publish_and_run_transactional.rs
@@ -29,10 +29,7 @@ use move_core_types::{
 };
 use move_transactional_test_runner::transactional_ops::TransactionalOperation;
 use once_cell::sync::Lazy;
-use std::{
-    collections::{HashMap, HashSet},
-    sync::Arc,
-};
+use std::collections::{HashMap, HashSet};
 mod utils;
 use fuzzer::RunnableStateWithOperations;
 use utils::vm::{
@@ -44,13 +41,13 @@ use utils::vm::{
 static VM_WRITE_SET: Lazy<WriteSet> = Lazy::new(|| GENESIS_CHANGE_SET_HEAD.write_set().clone());
 
 const FUZZER_CONCURRENCY_LEVEL: usize = 4;
-static TP: Lazy<Arc<rayon::ThreadPool>> = Lazy::new(|| {
-    Arc::new(
-        rayon::ThreadPoolBuilder::new()
-            .num_threads(FUZZER_CONCURRENCY_LEVEL)
-            .build()
-            .unwrap(),
-    )
+static RT: Lazy<tokio::runtime::Runtime> = Lazy::new(|| {
+    tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(1)
+        .max_blocking_threads(FUZZER_CONCURRENCY_LEVEL)
+        .thread_name("par_exec")
+        .build()
+        .unwrap()
 });
 
 const MAX_TYPE_PARAMETER_VALUE: u16 = 64 / 4 * 16; // third_party/move/move-bytecode-verifier/src/signature_v2.rs#L1306-L1312
@@ -140,10 +137,10 @@ fn run_case(input: RunnableStateWithOperations) -> Result<(), Corpus> {
 
     let module_cache_manager = AptosModuleCacheManager::new();
     AptosVM::set_concurrency_level_once(FUZZER_CONCURRENCY_LEVEL);
-    let mut vm = FakeExecutor::from_genesis_with_existing_thread_pool(
+    let mut vm = FakeExecutor::from_genesis_with_existing_runtime(
         &VM_WRITE_SET,
         ChainId::mainnet(),
-        Arc::clone(&TP),
+        RT.handle().clone(),
         Some(module_cache_manager),
     )
     .set_parallel();


### PR DESCRIPTION

Profiling of `perpdex-benchmark` shows ~8.1% of CPU cycles spent on rayon's
work-stealing overhead (`crossbeam_epoch::try_advance` 4.26%, `with_handle`
2.90%, `Stealer::steal` 0.91%).

The par_exec rayon pool is sized to `num_cpus`, but only `concurrency_level`
workers are active. The remaining idle threads continuously burn cycles on
crossbeam epoch GC and steal probes. BlockExecutor never uses work-stealing --
workers independently pull tasks from the scheduler, so all of rayon's
coordination machinery is pure waste. Under power-constrained conditions
(e.g. `powersave` governor), these wasted cycles directly eat into throughput
because the CPU has no spare frequency headroom to absorb them.

Replace with tokio's `spawn_blocking` using a dedicated runtime. Idle blocking
threads are parked at zero CPU cost, and threads are reused across block
executions. A `dispatch_workers()` helper (33 lines) wraps spawn + await +
panic propagation -- the only `unsafe` is the scoped-borrow lifetime transmute
(same invariant as `rayon::scope`). An alternative hand-rolled `WorkerPool`
using per-worker `mpsc` channels was prototyped but rejected in favor of
delegating thread management to tokio.

## Benchmark results

`perpdex-benchmark run-single-node-benchmark --transaction-type realistic`,
NUMA-bound, 5 runs per configuration, Welch's t-test.

**`scaling_governor=powersave`**:

| Concurrency | Parent (rayon) | Commit (tokio) | Delta | p-value |
|-------------|----------------|----------------|-------|---------|
| c=8         | 1463 ± 59 TPS  | 1545 ± 72 TPS  | +5.6% | 0.084   |
| c=16        | 1572 ± 46 TPS  | 1756 ± 67 TPS  | +11.8% | 0.001  |

**`scaling_governor=performance`**: no significant difference at either
concurrency level (p > 0.6), confirming the gain comes from eliminating
wasted cycles that matter when CPU frequency headroom is limited.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
