### PR TITLE
[move-prover] Fix bounded existential behavioral-predicate repros

### DIFF
--- a/third_party/move/move-prover/boogie-backend/src/spec_translator.rs
+++ b/third_party/move/move-prover/boogie-backend/src/spec_translator.rs
@@ -43,6 +43,7 @@ use move_prover_bytecode_pipeline::{
     mono_analysis::MonoInfo,
     number_operation::{GlobalNumberOperationState, NumOperation::Bitwise},
 };
+use num::ToPrimitive;
 use std::{
     cell::RefCell,
     collections::{BTreeMap, BTreeSet, HashMap},
@@ -58,6 +59,8 @@ pub struct LabelInfo {
     /// Resource types modified at this label.
     pub modified_types: BTreeSet<QualifiedInstId<StructId>>,
 }
+
+const MAX_UNROLLED_EXISTS_RANGE_SIZE: usize = 8;
 
 #[derive(Clone)]
 pub struct SpecTranslator<'env> {
@@ -244,6 +247,38 @@ impl<'env> SpecTranslator<'env> {
     /// Sets the location of the code writer from node id.
     fn set_writer_location(&self, node_id: NodeId) {
         self.writer.set_location(&self.env.get_node_loc(node_id));
+    }
+
+    fn try_eval_small_vector_len(&self, exp: &Exp) -> Option<usize> {
+        match exp.as_ref() {
+            ExpData::Value(_, Value::Vector(values)) => Some(values.len()),
+            _ => None,
+        }
+    }
+
+    fn try_eval_small_nat(&self, exp: &Exp) -> Option<usize> {
+        match exp.as_ref() {
+            ExpData::Value(_, Value::Number(value)) => value.to_usize(),
+            ExpData::Call(_, Operation::Len, args) if args.len() == 1 => {
+                self.try_eval_small_vector_len(&args[0])
+            },
+            _ => None,
+        }
+    }
+
+    fn try_get_small_unrolled_exists_values(&self, range: &Exp) -> Option<Vec<String>> {
+        match range.as_ref() {
+            ExpData::Call(_, Operation::Range, args) if args.len() == 2 => {
+                let start = self.try_eval_small_nat(&args[0])?;
+                let end = self.try_eval_small_nat(&args[1])?;
+                let len = end.checked_sub(start).unwrap_or(0);
+                if len > MAX_UNROLLED_EXISTS_RANGE_SIZE {
+                    return None;
+                }
+                Some((start..end).map(|value| value.to_string()).collect())
+            },
+            _ => None,
+        }
     }
 
     /// Generates a fresh variable name.
@@ -2915,6 +2950,57 @@ impl SpecTranslator<'_> {
         result
     }
 
+    fn try_translate_unrolled_exists(
+        &self,
+        ranges: &[(Pattern, Exp)],
+        condition: &Option<Exp>,
+        body: &Exp,
+    ) -> bool {
+        if ranges.len() != 1 {
+            return false;
+        }
+
+        let (pat, range) = &ranges[0];
+        if !matches!(
+            self.get_node_type(range.node_id()).skip_reference(),
+            Type::Primitive(PrimitiveType::Range)
+        ) {
+            return false;
+        }
+
+        let values = match self.try_get_small_unrolled_exists_values(range) {
+            Some(values) => values,
+            None => return false,
+        };
+
+        if values.is_empty() {
+            emit!(self.writer, "false");
+            return true;
+        }
+
+        let (_, var_name) = self.require_range_var(pat);
+        let var_name_str = self.env.symbol_pool().string(var_name);
+
+        emit!(self.writer, "(");
+        for (idx, value) in values.iter().enumerate() {
+            if idx > 0 {
+                emit!(self.writer, " || ");
+            }
+            emit!(self.writer, "(var {} := {}; ", var_name_str, value);
+            if let Some(cond) = condition {
+                emit!(self.writer, "(");
+                self.translate_exp(cond);
+                emit!(self.writer, ") && ");
+            }
+            emit!(self.writer, "(");
+            self.translate_exp(body);
+            emit!(self.writer, ")");
+            emit!(self.writer, ")");
+        }
+        emit!(self.writer, ")");
+        true
+    }
+
     fn translate_quant(
         &self,
         _node_id: NodeId,
@@ -2929,6 +3015,10 @@ impl SpecTranslator<'_> {
             .get_extension::<GlobalNumberOperationState>()
             .expect("global number operation state");
         assert!(!kind.is_choice());
+        if kind == QuantKind::Exists && self.try_translate_unrolled_exists(ranges, condition, body)
+        {
+            return;
+        }
         // Translate range expressions. While doing, check for currently unsupported
         // type quantification
         let mut range_tmps = HashMap::new();

--- a/third_party/move/move-prover/boogie-backend/src/spec_translator.rs
+++ b/third_party/move/move-prover/boogie-backend/src/spec_translator.rs
@@ -252,6 +252,7 @@ impl<'env> SpecTranslator<'env> {
     fn try_eval_small_vector_len(&self, exp: &Exp) -> Option<usize> {
         match exp.as_ref() {
             ExpData::Value(_, Value::Vector(values)) => Some(values.len()),
+            ExpData::Call(_, Operation::Vector, values) => Some(values.len()),
             _ => None,
         }
     }

--- a/third_party/move/move-prover/bytecode-pipeline/src/spec_instrumentation.rs
+++ b/third_party/move/move-prover/bytecode-pipeline/src/spec_instrumentation.rs
@@ -29,8 +29,8 @@ use move_stackless_bytecode::{
     livevar_analysis::LiveVarAnalysisProcessor,
     reaching_def_analysis::ReachingDefProcessor,
     stackless_bytecode::{
-        AbortAction, AssignKind, AttrId, BorrowEdge, BorrowNode, Bytecode, HavocKind, Label,
-        Operation, PropKind,
+        AbortAction, AssignKind, AttrId, BorrowEdge, BorrowNode, Bytecode, Constant, HavocKind,
+        Label, Operation, PropKind,
     },
     usage_analysis, COMPILED_MODULE_AVAILABLE,
 };
@@ -334,10 +334,11 @@ impl SpecInstrumentationProcessor {
                 // If guarded, conjunct with the guard: assume guard && base_assume.
                 let assume_exp = if let Some(guard_exp) = guard {
                     let and_node = env.new_node(env.get_node_loc(exp.node_id()), BOOL_TYPE.clone());
-                    ExpData::Call(and_node, ast::Operation::And, vec![
-                        guard_exp.clone(),
-                        base_assume,
-                    ])
+                    ExpData::Call(
+                        and_node,
+                        ast::Operation::And,
+                        vec![guard_exp.clone(), base_assume],
+                    )
                     .into_exp()
                 } else {
                     base_assume
@@ -373,6 +374,8 @@ struct Instrumenter<'a> {
     /// Counter for deterministic label freshening across opaque call sites.
     /// Starts at 0 so that freshened labels are independent of the global counter.
     freshen_counter: usize,
+    /// Best-effort map of locals to concrete pure expressions visible on the current path.
+    known_pure_exps: BTreeMap<TempIndex, Exp>,
 }
 
 // =================================================================================================
@@ -486,6 +489,7 @@ impl<'a> Instrumenter<'a> {
             mem_info: &mem_info,
             split_points: vec![],
             freshen_counter: 0,
+            known_pure_exps: BTreeMap::new(),
         };
         // Always inline spec lets in proof actions, independent of the
         // `inline_spec_lets` option. Proof-action exps are recorded in
@@ -524,6 +528,248 @@ impl<'a> Instrumenter<'a> {
 
     fn is_verified(&self) -> bool {
         self.builder.data.variant.is_verified()
+    }
+
+    fn constant_to_exp(&self, loc: Loc, dest: TempIndex, constant: &Constant) -> Exp {
+        let ty = self.builder.get_local_type(dest).skip_reference().clone();
+        let id = self.builder.global_env().new_node(loc, ty);
+        ExpData::Value(id, constant.to_model_value()).into_exp()
+    }
+
+    fn vector_to_exp(&self, loc: Loc, dest: TempIndex, elements: Vec<Exp>) -> Exp {
+        let ty = self.builder.get_local_type(dest).skip_reference().clone();
+        let id = self.builder.global_env().new_node(loc, ty);
+        ExpData::Call(id, ast::Operation::Vector, elements).into_exp()
+    }
+
+    fn rewrite_known_temp_substitutions(
+        &self,
+        exp: Exp,
+        substitutions: &BTreeMap<TempIndex, Exp>,
+    ) -> Exp {
+        ExpData::rewrite(exp, &mut |e| match e.as_ref() {
+            ExpData::Temporary(_, idx) => {
+                if let Some(replacement) = substitutions.get(idx) {
+                    RewriteResult::Rewritten(replacement.clone())
+                } else {
+                    RewriteResult::Unchanged(e)
+                }
+            },
+            _ => RewriteResult::Unchanged(e),
+        })
+    }
+
+    fn specialize_translated_spec(
+        &self,
+        callee_spec: &mut TranslatedSpec,
+        substitutions: &BTreeMap<TempIndex, Exp>,
+    ) {
+        if substitutions.is_empty() {
+            return;
+        }
+        let rewrite = |exp: Exp| self.rewrite_known_temp_substitutions(exp, substitutions);
+
+        for (_, exp) in &mut callee_spec.pre {
+            *exp = rewrite(exp.clone());
+        }
+        for (_, exp) in &mut callee_spec.post {
+            *exp = rewrite(exp.clone());
+        }
+        for (_, exp, code_opt) in &mut callee_spec.aborts {
+            *exp = rewrite(exp.clone());
+            if let Some(code) = code_opt {
+                *code = rewrite(code.clone());
+            }
+        }
+        for (_, codes) in &mut callee_spec.aborts_with {
+            for code in codes {
+                *code = rewrite(code.clone());
+            }
+        }
+        for (_, msg, handle, cond_opt) in &mut callee_spec.emits {
+            *msg = rewrite(msg.clone());
+            *handle = rewrite(handle.clone());
+            if let Some(cond) = cond_opt {
+                *cond = rewrite(cond.clone());
+            }
+        }
+        for (_, exp) in &mut callee_spec.modifies {
+            *exp = rewrite(exp.clone());
+        }
+        for (_, _, exp) in &mut callee_spec.invariants {
+            *exp = rewrite(exp.clone());
+        }
+        for (_, _, _, exp) in &mut callee_spec.lets {
+            *exp = rewrite(exp.clone());
+        }
+        for (_, lhs, rhs) in &mut callee_spec.updates {
+            *lhs = rewrite(lhs.clone());
+            *rhs = rewrite(rhs.clone());
+        }
+        for (_, _, exp) in &mut callee_spec.debug_traces {
+            *exp = rewrite(exp.clone());
+        }
+    }
+
+    fn specialize_call_spec_with_known_pure_exps(
+        &self,
+        callee_spec: &mut TranslatedSpec,
+        srcs: &[TempIndex],
+    ) {
+        let mut substitutions = srcs
+            .iter()
+            .filter_map(|src| {
+                self.known_pure_exps
+                    .get(src)
+                    .cloned()
+                    .map(|exp| (*src, exp))
+            })
+            .collect::<BTreeMap<_, _>>();
+        for (original_temp, saved_temp) in &callee_spec.saved_params {
+            if let Some(exp) = self.known_pure_exps.get(original_temp).cloned() {
+                substitutions.insert(*saved_temp, exp);
+            }
+        }
+        self.specialize_translated_spec(callee_spec, &substitutions);
+    }
+
+    fn clear_known_pure_exps(&mut self) {
+        self.known_pure_exps.clear();
+    }
+
+    fn can_track_known_pure_exp(&self, idx: TempIndex) -> bool {
+        !self.builder.get_local_type(idx).is_reference()
+    }
+
+    fn should_clear_known_pure_exps_for_call(
+        &self,
+        oper: &Operation,
+        srcs: &[TempIndex],
+        dests: &[TempIndex],
+    ) -> bool {
+        use Operation::*;
+
+        matches!(
+            oper,
+            Function(..)
+                | Invoke
+                | BorrowLoc
+                | BorrowField(..)
+                | BorrowVariantField(..)
+                | BorrowGlobal(..)
+                | WriteRef
+                | WriteBack(..)
+                | UnpackRef
+                | PackRef
+                | UnpackRefDeep
+                | PackRefDeep
+                | MoveTo(..)
+                | MoveFrom(..)
+                | OpaqueCallBegin(..)
+                | OpaqueCallEnd(..)
+                | EmitEvent
+                | EventStoreDiverge
+        ) || srcs
+            .iter()
+            .chain(dests.iter())
+            .any(|idx| self.builder.get_local_type(*idx).is_reference())
+    }
+
+    fn update_known_pure_exps(&mut self, bc: &Bytecode) {
+        use Bytecode::*;
+
+        match bc {
+            Assign(_, dest, src, _) => {
+                if self.can_track_known_pure_exp(*dest)
+                    && self.can_track_known_pure_exp(*src)
+                    && let Some(exp) = self.known_pure_exps.get(src).cloned()
+                {
+                    self.known_pure_exps.insert(*dest, exp);
+                } else {
+                    self.known_pure_exps.remove(dest);
+                }
+            },
+            Load(attr_id, dest, constant) => {
+                if self.can_track_known_pure_exp(*dest) {
+                    let loc = self.builder.get_loc(*attr_id);
+                    let exp = self.constant_to_exp(loc, *dest, constant);
+                    self.known_pure_exps.insert(*dest, exp);
+                } else {
+                    self.known_pure_exps.remove(dest);
+                }
+            },
+            Call(attr_id, dests, Operation::Vector, srcs, _)
+                if dests.len() == 1 && self.can_track_known_pure_exp(dests[0]) =>
+            {
+                let loc = self.builder.get_loc(*attr_id);
+                let elements = srcs
+                    .iter()
+                    .map(|src| self.known_pure_exps.get(src).cloned())
+                    .collect::<Option<Vec<_>>>();
+                for dest in dests {
+                    self.known_pure_exps.remove(dest);
+                }
+                if let Some(elements) = elements {
+                    let exp = self.vector_to_exp(loc, dests[0], elements);
+                    self.known_pure_exps.insert(dests[0], exp);
+                }
+            },
+            Call(_, dests, oper, srcs, _) => {
+                if self.should_clear_known_pure_exps_for_call(oper, srcs, dests) {
+                    self.clear_known_pure_exps();
+                } else {
+                    for dest in dests {
+                        self.known_pure_exps.remove(dest);
+                    }
+                }
+            },
+            Branch(..) | Jump(..) | Label(..) | Ret(..) | Abort(..) => {
+                self.clear_known_pure_exps();
+            },
+            Prop(..) | Nop(..) | SpecBlock(..) | SaveMem(..) | SaveSpecVar(..) => {},
+        }
+    }
+
+    /// Returns whether we should assume a transparent callee's postconditions at the call site.
+    ///
+    /// This is restricted to verification entry points and callees which are themselves part of
+    /// the verification scope. For exclusive debug scopes like `--verify-only foo`, we also allow
+    /// summaries from transparent callees outside the current target set so single-function debug
+    /// runs can still reuse callee contracts.
+    fn should_assume_transparent_postconditions(&self, callee_env: &FunctionEnv<'_>) -> bool {
+        self.is_verified()
+            && !self.options.for_interpretation
+            && !self.options.inference
+            && (callee_env.should_verify(&self.options.verify_scope)
+                || self.options.verify_scope.is_exclusive())
+    }
+
+    /// Emits the state snapshots needed to evaluate a translated spec in post-state.
+    fn emit_saved_state_for_spec(&mut self, spec: &TranslatedSpec) {
+        for (mem, label) in &spec.saved_memory {
+            let mem = mem.clone();
+            self.builder
+                .emit_with(|attr_id| Bytecode::SaveMem(attr_id, *label, mem));
+        }
+        for (spec_var, label) in &spec.saved_spec_vars {
+            let spec_var = spec_var.clone();
+            self.builder
+                .emit_with(|attr_id| Bytecode::SaveSpecVar(attr_id, *label, spec_var));
+        }
+        let saved_params = spec.saved_params.clone();
+        self.emit_save_for_old(&saved_params);
+    }
+
+    /// Assumes the translated postconditions of a callee after a normal return.
+    fn emit_assumed_postconditions(&mut self, spec: &mut TranslatedSpec) {
+        self.emit_lets(spec, true);
+        self.emit_choice_wellformedness(spec, true);
+        let post_conditions = std::mem::take(&mut spec.post);
+        for (_, cond) in post_conditions {
+            self.emit_traces(spec, &cond);
+            self.builder
+                .emit_with(|id| Bytecode::Prop(id, PropKind::Assume, cond));
+        }
     }
 
     fn instrument(
@@ -620,14 +866,16 @@ impl<'a> Instrumenter<'a> {
         let mut pre_proof_emitted = false;
         for bc in old_code.by_ref() {
             if matches!(&bc, Call(_, _, Operation::TraceLocal(_), _, _)) {
-                self.builder.emit(bc);
+                self.builder.emit(bc.clone());
+                self.update_known_pure_exps(&bc);
             } else {
                 // First non-trace instruction: emit pre_proof, then this instruction.
                 if emit_proof {
                     self.emit_proof_actions(&spec.pre_proof, spec);
                 }
                 pre_proof_emitted = true;
-                self.instrument_bytecode(spec, inlined_props, bc);
+                self.instrument_bytecode(spec, inlined_props, bc.clone());
+                self.update_known_pure_exps(&bc);
                 break;
             }
         }
@@ -636,7 +884,8 @@ impl<'a> Instrumenter<'a> {
         }
         // Continue with remaining old_code.
         for bc in old_code {
-            self.instrument_bytecode(spec, inlined_props, bc);
+            self.instrument_bytecode(spec, inlined_props, bc.clone());
+            self.update_known_pure_exps(&bc);
         }
 
         // The return assertion block is emitted in-place at the trailing `Ret`
@@ -760,6 +1009,8 @@ impl<'a> Instrumenter<'a> {
 
         let callee_env = env.get_module(mid).into_function(fid);
         let callee_opaque = callee_env.is_opaque();
+        let assume_transparent_post =
+            !callee_opaque && self.should_assume_transparent_postconditions(&callee_env);
         let mut callee_spec = SpecTranslator::translate_fun_spec(
             self.options.auto_trace_level.functions(),
             true,
@@ -769,6 +1020,7 @@ impl<'a> Instrumenter<'a> {
             Some(&srcs),
             &dests,
         );
+        self.specialize_call_spec_with_known_pure_exps(&mut callee_spec, &srcs);
 
         // Freshen state labels to avoid collisions between different inlining sites.
         // Uses a function-scoped counter for deterministic label IDs.
@@ -832,6 +1084,9 @@ impl<'a> Instrumenter<'a> {
 
         // From here on code differs depending on whether the callee is opaque or not.
         if !callee_env.is_opaque() || self.options.for_interpretation || self.options.inference {
+            if assume_transparent_post {
+                self.emit_saved_state_for_spec(&callee_spec);
+            }
             self.builder.emit(Call(
                 id,
                 dests,
@@ -839,6 +1094,9 @@ impl<'a> Instrumenter<'a> {
                 srcs,
                 Some(AbortAction(self.abort_label, self.abort_local)),
             ));
+            if assume_transparent_post {
+                self.emit_assumed_postconditions(&mut callee_spec);
+            }
             self.can_abort = true;
         } else {
             // Generates OpaqueCallBegin.
@@ -983,11 +1241,11 @@ impl<'a> Instrumenter<'a> {
             // Emit placeholders for assuming well-formedness of return values and mutable ref
             // parameters.
             for idx in mut_srcs.into_iter().chain(dests.iter().cloned()) {
-                let exp = self
-                    .builder
-                    .mk_call(&BOOL_TYPE, ast::Operation::WellFormed, vec![self
-                        .builder
-                        .mk_temporary(idx)]);
+                let exp = self.builder.mk_call(
+                    &BOOL_TYPE,
+                    ast::Operation::WellFormed,
+                    vec![self.builder.mk_temporary(idx)],
+                );
                 self.builder.emit_with(move |id| Prop(id, Assume, exp));
             }
 

--- a/third_party/move/move-prover/bytecode-pipeline/src/spec_instrumentation.rs
+++ b/third_party/move/move-prover/bytecode-pipeline/src/spec_instrumentation.rs
@@ -536,10 +536,62 @@ impl<'a> Instrumenter<'a> {
         ExpData::Value(id, constant.to_model_value()).into_exp()
     }
 
-    fn vector_to_exp(&self, loc: Loc, dest: TempIndex, elements: Vec<Exp>) -> Exp {
+    fn call_to_exp(&self, loc: Loc, dest: TempIndex, oper: ast::Operation, args: Vec<Exp>) -> Exp {
         let ty = self.builder.get_local_type(dest).skip_reference().clone();
         let id = self.builder.global_env().new_node(loc, ty);
-        ExpData::Call(id, ast::Operation::Vector, elements).into_exp()
+        ExpData::Call(id, oper, args).into_exp()
+    }
+
+    fn vector_to_exp(&self, loc: Loc, dest: TempIndex, elements: Vec<Exp>) -> Exp {
+        self.call_to_exp(loc, dest, ast::Operation::Vector, elements)
+    }
+
+    fn tracked_call_to_exp(
+        &self,
+        loc: Loc,
+        dest: TempIndex,
+        oper: &Operation,
+        args: Vec<Exp>,
+    ) -> Option<Exp> {
+        use ast::Operation as AstOp;
+
+        let oper = match oper {
+            Operation::Vector => AstOp::Vector,
+            Operation::CastU8
+            | Operation::CastU16
+            | Operation::CastU32
+            | Operation::CastU64
+            | Operation::CastU128
+            | Operation::CastU256
+            | Operation::CastI8
+            | Operation::CastI16
+            | Operation::CastI32
+            | Operation::CastI64
+            | Operation::CastI128
+            | Operation::CastI256 => AstOp::Cast,
+            Operation::Not => AstOp::Not,
+            Operation::Negate => AstOp::Negate,
+            Operation::Add => AstOp::Add,
+            Operation::Sub => AstOp::Sub,
+            Operation::Mul => AstOp::Mul,
+            Operation::Div => AstOp::Div,
+            Operation::Mod => AstOp::Mod,
+            Operation::BitOr => AstOp::BitOr,
+            Operation::BitAnd => AstOp::BitAnd,
+            Operation::Xor => AstOp::Xor,
+            Operation::Shl => AstOp::Shl,
+            Operation::Shr => AstOp::Shr,
+            Operation::Lt => AstOp::Lt,
+            Operation::Gt => AstOp::Gt,
+            Operation::Le => AstOp::Le,
+            Operation::Ge => AstOp::Ge,
+            Operation::Or => AstOp::Or,
+            Operation::And => AstOp::And,
+            Operation::Eq => AstOp::Eq,
+            Operation::Neq => AstOp::Neq,
+            _ => return None,
+        };
+        Some(self.call_to_exp(loc, dest, oper, args))
     }
 
     fn rewrite_known_temp_substitutions(
@@ -714,12 +766,25 @@ impl<'a> Instrumenter<'a> {
                     self.known_pure_exps.insert(dests[0], exp);
                 }
             },
-            Call(_, dests, oper, srcs, _) => {
+            Call(attr_id, dests, oper, srcs, _) => {
                 if self.should_clear_known_pure_exps_for_call(oper, srcs, dests) {
                     self.clear_known_pure_exps();
                 } else {
+                    let tracked_exp = if dests.len() == 1 && self.can_track_known_pure_exp(dests[0])
+                    {
+                        let loc = self.builder.get_loc(*attr_id);
+                        srcs.iter()
+                            .map(|src| self.known_pure_exps.get(src).cloned())
+                            .collect::<Option<Vec<_>>>()
+                            .and_then(|args| self.tracked_call_to_exp(loc, dests[0], oper, args))
+                    } else {
+                        None
+                    };
                     for dest in dests {
                         self.known_pure_exps.remove(dest);
+                    }
+                    if let Some(exp) = tracked_exp {
+                        self.known_pure_exps.insert(dests[0], exp);
                     }
                 }
             },

--- a/third_party/move/move-prover/tests/sources/functional/closures/behavioral_predicates_examples.exp
+++ b/third_party/move/move-prover/tests/sources/functional/closures/behavioral_predicates_examples.exp
@@ -20,53 +20,6 @@ error: precondition does not hold at this call
     =     at tests/sources/functional/closures/behavioral_predicates_examples.move:123: apply_no_abort_opaque (spec)
 
 error: post-condition does not hold
-    ┌─ tests/sources/functional/closures/behavioral_predicates_examples.move:226:9
-    │
-226 │         ensures result == true;  // TODO(#18560)
-    │         ^^^^^^^^^^^^^^^^^^^^^^^
-    │
-    =     at tests/sources/functional/closures/behavioral_predicates_examples.move:223: contains_test_found
-    =         <redacted> = <redacted>
-    =     at tests/sources/functional/closures/behavioral_predicates_examples.move:192: contains (spec)
-    =     at tests/sources/functional/closures/behavioral_predicates_examples.move:223: contains_test_found
-    =     at tests/sources/functional/closures/behavioral_predicates_examples.move:192: contains (spec)
-    =     at tests/sources/functional/closures/behavioral_predicates_examples.move:176: contains
-    =         v = <redacted>
-    =         pred = <redacted>
-    =     at tests/sources/functional/closures/behavioral_predicates_examples.move:177: contains
-    =         i = <redacted>
-    =     at tests/sources/functional/closures/behavioral_predicates_examples.move:178: contains
-    =         len = <redacted>
-    =     at tests/sources/functional/closures/behavioral_predicates_examples.move:185: contains
-    =     at tests/sources/functional/closures/behavioral_predicates_examples.move:186: contains
-    =     at tests/sources/functional/closures/behavioral_predicates_examples.move:187: contains
-    =     enter loop, variable(s) i havocked and reassigned
-    =         i = <redacted>
-    =     loop invariant holds at current state
-    =     at tests/sources/functional/closures/behavioral_predicates_examples.move:186: contains
-    =     at tests/sources/functional/closures/behavioral_predicates_examples.move:187: contains
-    =     at tests/sources/functional/closures/behavioral_predicates_examples.move:179: contains
-    =     at tests/sources/functional/closures/behavioral_predicates_examples.move:189: contains
-    =     at tests/sources/functional/closures/behavioral_predicates_examples.move:176: contains
-    =         result = <redacted>
-    =     at tests/sources/functional/closures/behavioral_predicates_examples.move:190: contains
-    =         result = <redacted>
-    =     at tests/sources/functional/closures/behavioral_predicates_examples.move:226: contains_test_found (spec)
-
-error: post-condition does not hold
-    ┌─ tests/sources/functional/closures/behavioral_predicates_examples.move:234:9
-    │
-234 │         ensures result == true;  // TODO(#18560)
-    │         ^^^^^^^^^^^^^^^^^^^^^^^
-    │
-    =     at tests/sources/functional/closures/behavioral_predicates_examples.move:231: contains_opaque_test_found
-    =         <redacted> = <redacted>
-    =     at tests/sources/functional/closures/behavioral_predicates_examples.move:216: contains_opaque (spec)
-    =     at tests/sources/functional/closures/behavioral_predicates_examples.move:231: contains_opaque_test_found
-    =         result = <redacted>
-    =     at tests/sources/functional/closures/behavioral_predicates_examples.move:234: contains_opaque_test_found (spec)
-
-error: post-condition does not hold
     ┌─ tests/sources/functional/closures/behavioral_predicates_examples.move:395:9
     │
 395 │         ensures result == 7; // expected failure: result == 8

--- a/third_party/move/move-prover/tests/sources/functional/closures/behavioral_predicates_examples.move
+++ b/third_party/move/move-prover/tests/sources/functional/closures/behavioral_predicates_examples.move
@@ -223,7 +223,7 @@ module 0x42::behavioral_predicates_examples {
         contains(&v, |x| (*x > 2) spec { ensures result == (x > 2); })
     }
     spec contains_test_found {
-        ensures result == true;  // TODO(#18560)
+        ensures result == true;
     }
 
     fun contains_opaque_test_found(): bool {
@@ -231,7 +231,7 @@ module 0x42::behavioral_predicates_examples {
         contains_opaque(&v, |x| (*x > 2) spec { ensures result == (x > 2); })
     }
     spec contains_opaque_test_found {
-        ensures result == true;  // TODO(#18560)
+        ensures result == true;
     }
 
     fun contains_test_not_found(): bool {

--- a/third_party/move/move-prover/tests/sources/functional/closures/behavioral_predicates_examples.move
+++ b/third_party/move/move-prover/tests/sources/functional/closures/behavioral_predicates_examples.move
@@ -234,6 +234,17 @@ module 0x42::behavioral_predicates_examples {
         ensures result == true;
     }
 
+    fun contains_opaque_test_found_from_locals(): bool {
+        let first = 1;
+        let second = first + 3;
+        let third = 2;
+        let v = vector[first, second, third];
+        contains_opaque(&v, |x| (*x > 2) spec { ensures result == (x > 2); })
+    }
+    spec contains_opaque_test_found_from_locals {
+        ensures result == true;
+    }
+
     fun contains_test_not_found(): bool {
         let v = vector[1, 2, 3];
         contains(&v, |x| (*x > 5) spec { ensures result == (x > 5); })

--- a/third_party/move/move-prover/tests/sources/functional/closures/behavioral_predicates_examples.move
+++ b/third_party/move/move-prover/tests/sources/functional/closures/behavioral_predicates_examples.move
@@ -234,6 +234,17 @@ module 0x42::behavioral_predicates_examples {
         ensures result == true;
     }
 
+    fun contains_opaque_test_found_from_constant_locals(): bool {
+        let first = 1;
+        let second = 4;
+        let third = 2;
+        let v = vector[first, second, third];
+        contains_opaque(&v, |x| (*x > 2) spec { ensures result == (x > 2); })
+    }
+    spec contains_opaque_test_found_from_constant_locals {
+        ensures result == true;
+    }
+
     fun contains_opaque_test_found_from_locals(): bool {
         let first = 1;
         let second = first + 3;


### PR DESCRIPTION
## Summary

This revives `#18560` with a narrower, current-main patch for the bounded behavioral-predicate repro.

From first principles, the bug is not "existentials are generally broken". The failing cases are the bounded ones where the proof site already has a tiny witness set, but the pipeline fails to preserve or materialize it:

```text
Failure generators
├─ G1 caller knows a finite witness set
├─ G2 lowering still leaves the solver to invent the witness
└─ G3 transparent call boundaries can hide the caller's concreteness
```

This patch repairs `G2` and `G3` for the narrow bounded-concrete lane.

## What Changed

### 1. Specialize translated callee specs with caller-side concrete pure expressions

- file:
  - `third_party/move/move-prover/bytecode-pipeline/src/spec_instrumentation.rs`
- change:
  - track best-effort concrete pure expressions on the current straight-line path
  - substitute those expressions into translated callee specs before emitting them
  - for verified transparent callees, re-assume the specialized postcondition summary after a normal return
- important review tightening:
  - the tracked map is now cleared conservatively across aliasing / mutation-capable operations so we do not carry stale concrete values across reference boundaries

### 2. Unroll bounded single-range existential quantifiers

- file:
  - `third_party/move/move-prover/boogie-backend/src/spec_translator.rs`
- change:
  - when an `exists` ranges over a single concretely evaluable small natural interval, lower it to a finite disjunction
  - current threshold:
    - `MAX_UNROLLED_EXISTS_RANGE_SIZE = 8`
- example shape:
  - `exists k in 0..3: P(k)` becomes `P(0) || P(1) || P(2)`

### 3. Refresh the existing regression expectation

- files:
  - `third_party/move/move-prover/tests/sources/functional/closures/behavioral_predicates_examples.move`
  - `third_party/move/move-prover/tests/sources/functional/closures/behavioral_predicates_examples.exp`
- change:
  - remove the stale `TODO(#18560)` comments on the two positive bounded repros
  - remove the two corresponding failure blocks from the baseline

## Why This Shape

The opaque and transparent failures turned out to be complementary:

```text
Why each slice is needed
├─ translator-only unrolling was not enough
│  └─ the existential still saw symbolic temps instead of the concrete vector
├─ caller-side specialization alone was not enough
│  └─ the opaque path still asked SMT to synthesize the witness
└─ together they work
   ├─ preserve the concrete vector
   └─ then materialize the finite witness set as ground cases
```

## Validation

Passed locally:

- `rustfmt +stable third_party/move/move-prover/bytecode-pipeline/src/spec_instrumentation.rs third_party/move/move-prover/boogie-backend/src/spec_translator.rs`
- temporary sparse-workspace `cargo +stable check -p move-prover`
- `cargo +stable run -p move-prover -- --language-version 2.4 -d ..\\move-stdlib\\sources -a std=0x1 --verify-only contains_opaque_test_found tests\\sources\\functional\\closures\\behavioral_predicates_examples.move`
- `cargo +stable run -p move-prover -- --language-version 2.4 -d ..\\move-stdlib\\sources -a std=0x1 --verify-only contains_test_found tests\\sources\\functional\\closures\\behavioral_predicates_examples.move`
- `git diff --check -- third_party/move/move-prover/boogie-backend/src/spec_translator.rs third_party/move/move-prover/bytecode-pipeline/src/spec_instrumentation.rs third_party/move/move-prover/tests/sources/functional/closures/behavioral_predicates_examples.move third_party/move/move-prover/tests/sources/functional/closures/behavioral_predicates_examples.exp`

Targeted testsuite note:

- `cargo +stable test --test testsuite -- behavioral_predicates_examples.move` still differs on my Windows Boogie path for unrelated reasons:
  - backslash path formatting
  - `unexpected boogie output: *** MODEL ...`
- so the real semantic signal here is the targeted solver rerun above; upstream Linux CI should be the truth source for the baseline file

## Literature Background

This patch shape also matches the literature on SMT instability around quantified formulas and the Move Prover team's own experience:

- Move Prover extended paper:
  - https://arxiv.org/abs/2110.08362
  - quantifiers are a major source of timeout and unpredictability, so exposing simpler ground formulas matters
- Leino and Pit-Claudel, "Trigger Selection Strategies to Stabilize Program Verifiers", CAV 2016:
  - https://link.springer.com/chapter/10.1007/978-3-319-41528-4_20
  - stabilizing verification often means changing the formula shape instead of hoping trigger heuristics pick the right instantiations
- Reynolds et al., finite quantifier reasoning / finite-model-finding background:
  - https://cvc4.github.io/papers/cade2013-qifmf
  - once a verifier exposes a truly finite domain, witness search becomes dramatically easier

Fixes `#18560`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes spec instrumentation and Boogie quantifier lowering on verification paths; logic is scoped to small ranges and conservative pure-value tracking, but incorrect tracking could weaken or mis-specialize proofs.
> 
> **Overview**
> The prover now handles **bounded behavioral predicates** (small `exists k in 0..n` over known vectors) by combining bytecode specialization with Boogie lowering.
> 
> **Bytecode instrumentation** tracks concrete pure expressions on straight-line paths (loads, assigns, simple ops), substitutes them into translated callee specs at call sites, and for **transparent** verified callees saves state and **assumes** the specialized postconditions after return. The map is cleared on branches and mutation/reference operations so stale values are not carried across.
> 
> **Boogie translation** unrolls single-range `exists` when start/end (or `len` of a constant vector) yield at most **8** witnesses, emitting a finite `||` of ground cases instead of a quantifier.
> 
> **Tests:** `behavioral_predicates_examples` drops `#18560` TODOs and expected post-condition failures for the positive `contains` cases; adds opaque tests built from constant and derived locals.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b91cf6aef92362a5db9bbf69dd548d27c6a6122. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->