### PR TITLE
[lint] Suggest using index syntax for global storage access

### DIFF
--- a/third_party/move/move-model/src/builder/builtins.rs
+++ b/third_party/move/move-model/src/builder/builtins.rs
@@ -17,6 +17,7 @@ use crate::{
     model::{Parameter, TypeParameter, TypeParameterKind},
     options::ModelBuilderOptions,
     ty::{Constraint, PrimitiveType, ReferenceKind, Type},
+    well_known::{BORROW_GLOBAL, BORROW_GLOBAL_MUT},
 };
 use legacy_move_compiler::parser::ast as PA;
 use move_core_types::{
@@ -873,7 +874,7 @@ pub(crate) fn declare_builtins(trans: &mut ModelBuilder) {
         let ref_param_t = Type::Reference(ReferenceKind::Immutable, Box::new(param_t.clone()));
         let mut_ref_param_t = Type::Reference(ReferenceKind::Mutable, Box::new(param_t.clone()));
         trans.define_spec_or_builtin_fun(
-            trans.builtin_qualified_symbol("borrow_global"),
+            trans.builtin_qualified_symbol(BORROW_GLOBAL),
             SpecOrBuiltinFunEntry {
                 loc: loc.clone(),
                 oper: Operation::BorrowGlobal(ReferenceKind::Immutable),
@@ -885,7 +886,7 @@ pub(crate) fn declare_builtins(trans: &mut ModelBuilder) {
             },
         );
         trans.define_spec_or_builtin_fun(
-            trans.builtin_qualified_symbol("borrow_global_mut"),
+            trans.builtin_qualified_symbol(BORROW_GLOBAL_MUT),
             SpecOrBuiltinFunEntry {
                 loc: loc.clone(),
                 oper: Operation::BorrowGlobal(ReferenceKind::Mutable),

--- a/third_party/move/move-model/src/builder/exp_builder.rs
+++ b/third_party/move/move-model/src/builder/exp_builder.rs
@@ -4200,8 +4200,16 @@ impl ExpTranslator<'_, '_, '_> {
                 expected_type,
                 context,
             );
+            // translate_call may wrap the result in a Freeze node when the
+            // expected type is an immutable reference. Set the surface syntax
+            // on the inner node so it is attached to the actual operation.
+            let target_id = if let ExpData::Call(_, Operation::Freeze(_), args) = &result {
+                args[0].node_id()
+            } else {
+                result.node_id()
+            };
             self.env()
-                .set_surface_syntax(result.node_id(), SurfaceSyntax::IndexNotation);
+                .set_surface_syntax(target_id, SurfaceSyntax::IndexNotation);
             result
         } else {
             self.new_error_exp()

--- a/third_party/move/move-model/src/builder/exp_builder.rs
+++ b/third_party/move/move-model/src/builder/exp_builder.rs
@@ -33,7 +33,10 @@ use crate::{
         ReceiverFunctionInstance, ReferenceKind, Substitution, Type, TypeDisplayContext,
         TypeUnificationError, UnificationContext, Variance, WideningOrder, BOOL_TYPE,
     },
-    well_known::{UNSPECIFIED_ABORT_CODE, VECTOR_FUNCS_WITH_BYTECODE_INSTRS, VECTOR_MODULE},
+    well_known::{
+        BORROW_GLOBAL, BORROW_GLOBAL_MUT, UNSPECIFIED_ABORT_CODE,
+        VECTOR_FUNCS_WITH_BYTECODE_INSTRS, VECTOR_MODULE,
+    },
 };
 use codespan_reporting::diagnostic::Severity;
 use itertools::Itertools;
@@ -4185,9 +4188,9 @@ impl ExpTranslator<'_, '_, '_> {
         let type_opt = convert_name_to_type(&resource_ty_exp.loc, resource_ty_exp.clone().value);
         if let Some(ty) = type_opt {
             let name = if mutable {
-                self.symbol_pool().make("borrow_global_mut")
+                self.symbol_pool().make(BORROW_GLOBAL_MUT)
             } else {
-                self.symbol_pool().make("borrow_global")
+                self.symbol_pool().make(BORROW_GLOBAL)
             };
             let result = self.translate_call(
                 loc,

--- a/third_party/move/move-model/src/builder/exp_builder.rs
+++ b/third_party/move/move-model/src/builder/exp_builder.rs
@@ -4189,7 +4189,7 @@ impl ExpTranslator<'_, '_, '_> {
             } else {
                 self.symbol_pool().make("borrow_global")
             };
-            self.translate_call(
+            let result = self.translate_call(
                 loc,
                 &self.to_loc(&resource_ty_exp.loc),
                 CallKind::Regular,
@@ -4199,7 +4199,10 @@ impl ExpTranslator<'_, '_, '_> {
                 &[addr_exp],
                 expected_type,
                 context,
-            )
+            );
+            self.env()
+                .set_surface_syntax(result.node_id(), SurfaceSyntax::IndexNotation);
+            result
         } else {
             self.new_error_exp()
         }

--- a/third_party/move/move-model/src/sourcifier.rs
+++ b/third_party/move/move-model/src/sourcifier.rs
@@ -16,7 +16,7 @@ use crate::{
     },
     symbol::Symbol,
     ty::{PrimitiveType, ReferenceKind, Type, TypeDisplayContext},
-    well_known::UNSPECIFIED_ABORT_CODE,
+    well_known::{BORROW_GLOBAL, BORROW_GLOBAL_MUT, UNSPECIFIED_ABORT_CODE},
 };
 use itertools::Itertools;
 use move_core_types::ability::AbilitySet;
@@ -2451,9 +2451,9 @@ impl<'a> ExpSourcifier<'a> {
             },
             Operation::BorrowGlobal(kind) => self.parenthesize(context_prio, Prio::Postfix, || {
                 if *kind == ReferenceKind::Mutable {
-                    emit!(self.wr(), "borrow_global_mut")
+                    emit!(self.wr(), BORROW_GLOBAL_MUT)
                 } else {
-                    emit!(self.wr(), "borrow_global")
+                    emit!(self.wr(), BORROW_GLOBAL)
                 }
                 self.print_node_inst(id);
                 self.print_exp_list("(", ")", args)

--- a/third_party/move/move-model/src/well_known.rs
+++ b/third_party/move/move-model/src/well_known.rs
@@ -30,6 +30,8 @@ pub const VECTOR_MODULE: &str = "vector";
 pub const SIGNER_MODULE: &str = "signer";
 pub const VECTOR_BORROW: &str = "vector::borrow";
 pub const VECTOR_BORROW_MUT: &str = "vector::borrow_mut";
+pub const BORROW_GLOBAL: &str = "borrow_global";
+pub const BORROW_GLOBAL_MUT: &str = "borrow_global_mut";
 pub const EVENT_EMIT_EVENT: &str = "event::emit_event";
 /// Functions in the std::vector module that are implemented as bytecode instructions.
 pub const VECTOR_FUNCS_WITH_BYTECODE_INSTRS: &[&str] = &[

--- a/third_party/move/tools/move-linter/src/model_ast_lints/use_index_syntax.rs
+++ b/third_party/move/tools/move-linter/src/model_ast_lints/use_index_syntax.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-//! Detects cases where concise vector index notation syntax can be used.
+//! Detects cases where concise index notation syntax can be used for vectors and global storage.
 
 use move_compiler_v2::external_checks::ExpChecker;
 use move_model::{
@@ -14,11 +14,19 @@ use std::collections::BTreeSet;
 const LINT_NAME: &str = "use_index_syntax";
 const VECTOR_INDEX_NOTATION_URL: &str =
     "https://aptos.dev/build/smart-contracts/book/vector#index-notation-for-vectors";
+const GLOBAL_STORAGE_INDEX_NOTATION_URL: &str =
+    "https://aptos.dev/build/smart-contracts/book/global-storage-operators#index-notation-for-storage-operators";
 
 #[derive(Default)]
 pub struct UseIndexSyntax {
     /// NodeIds already reported, to avoid duplicate warnings.
     reported_in_context: BTreeSet<NodeId>,
+}
+
+#[derive(Clone, Copy)]
+enum VerboseBorrowKind {
+    Vector,
+    Global,
 }
 
 /// If the expression is a verbose call to `vector::borrow` or `vector::borrow_mut`
@@ -38,14 +46,36 @@ fn is_verbose_vector_borrow(env: &GlobalEnv, expr: &ExpData) -> Option<NodeId> {
     }
 }
 
-fn report_vector_index_syntax(env: &GlobalEnv, loc: &Loc) {
+/// If the expression is a verbose `borrow_global` or `borrow_global_mut` call
+/// (not from index notation desugaring), returns the call's NodeId.
+fn is_verbose_global_borrow(env: &GlobalEnv, expr: &ExpData) -> Option<NodeId> {
+    let ExpData::Call(id, Operation::BorrowGlobal(_), _) = expr else {
+        return None;
+    };
+    if env.has_surface_syntax(*id, SurfaceSyntax::IndexNotation) {
+        return None;
+    }
+    Some(*id)
+}
+
+/// Checks if an expression is a verbose borrow (vector or global) that could use index syntax.
+fn is_verbose_borrow(env: &GlobalEnv, expr: &ExpData) -> Option<(NodeId, VerboseBorrowKind)> {
+    is_verbose_vector_borrow(env, expr)
+        .map(|id| (id, VerboseBorrowKind::Vector))
+        .or_else(|| is_verbose_global_borrow(env, expr).map(|id| (id, VerboseBorrowKind::Global)))
+}
+
+fn report_index_syntax(env: &GlobalEnv, loc: &Loc, kind: VerboseBorrowKind) {
+    let (description, url) = match kind {
+        VerboseBorrowKind::Vector => ("vector", VECTOR_INDEX_NOTATION_URL),
+        VerboseBorrowKind::Global => ("global storage", GLOBAL_STORAGE_INDEX_NOTATION_URL),
+    };
     env.lint_diag_with_notes(
         loc,
-        "concise vector index notation syntax can be used here instead.",
+        &format!("concise {description} index notation syntax can be used here instead."),
         vec![
             format!(
-                "Concise vector index notation syntax is described here: {}.",
-                VECTOR_INDEX_NOTATION_URL,
+                "Concise {description} index notation syntax is described here: {url}.",
             ),
             format!(
                 "To suppress this warning, annotate the function/module with the attribute `#[lint::skip({})]`.",
@@ -63,43 +93,43 @@ impl ExpChecker for UseIndexSyntax {
     fn visit_expr_pre(&mut self, function: &FunctionEnv, expr: &ExpData) {
         let env = function.env();
 
-        // Pattern 1: Deref(vector::borrow/borrow_mut(...))
+        // Pattern 1: `*vector::borrow(v, i)` or `*borrow_global<T>(addr)`
         if let ExpData::Call(deref_id, Operation::Deref, args) = expr {
             if let Some(inner) = args.first() {
-                if let Some(inner_id) = is_verbose_vector_borrow(env, inner.as_ref()) {
-                    report_vector_index_syntax(env, &env.get_node_loc(*deref_id));
+                if let Some((inner_id, kind)) = is_verbose_borrow(env, inner.as_ref()) {
+                    report_index_syntax(env, &env.get_node_loc(*deref_id), kind);
                     self.reported_in_context.insert(inner_id);
                     return;
                 }
             }
         }
 
-        // Pattern 2: Select(field, vector::borrow/borrow_mut(...))
+        // Pattern 2: `vector::borrow(v, i).field` or `borrow_global<T>(addr).field`
         if let ExpData::Call(select_id, Operation::Select(_, _, _), args) = expr {
             if self.reported_in_context.contains(select_id) {
                 return;
             }
             if let Some(inner) = args.first() {
-                if let Some(inner_id) = is_verbose_vector_borrow(env, inner.as_ref()) {
-                    report_vector_index_syntax(env, &env.get_node_loc(*select_id));
+                if let Some((inner_id, kind)) = is_verbose_borrow(env, inner.as_ref()) {
+                    report_index_syntax(env, &env.get_node_loc(*select_id), kind);
                     self.reported_in_context.insert(inner_id);
                     return;
                 }
             }
         }
 
-        // Pattern 3: Mutate(vector::borrow_mut(...), rhs) or Mutate(Select(..., vector::borrow_mut(...)), rhs)
+        // Pattern 3: `*vector::borrow_mut(v, i) = x` or `borrow_global_mut<T>(addr).field = x`
         if let ExpData::Mutate(mutate_id, lhs, _) = expr {
-            if let Some(inner_id) = is_verbose_vector_borrow(env, lhs.as_ref()) {
-                report_vector_index_syntax(env, &env.get_node_loc(*mutate_id));
+            if let Some((inner_id, kind)) = is_verbose_borrow(env, lhs.as_ref()) {
+                report_index_syntax(env, &env.get_node_loc(*mutate_id), kind);
                 self.reported_in_context.insert(inner_id);
                 return;
             }
             if let ExpData::Call(select_id, Operation::Select(_, _, _), select_args) = lhs.as_ref()
             {
                 if let Some(inner) = select_args.first() {
-                    if let Some(inner_id) = is_verbose_vector_borrow(env, inner.as_ref()) {
-                        report_vector_index_syntax(env, &env.get_node_loc(*mutate_id));
+                    if let Some((inner_id, kind)) = is_verbose_borrow(env, inner.as_ref()) {
+                        report_index_syntax(env, &env.get_node_loc(*mutate_id), kind);
                         self.reported_in_context.insert(*select_id);
                         self.reported_in_context.insert(inner_id);
                         return;
@@ -108,12 +138,12 @@ impl ExpChecker for UseIndexSyntax {
             }
         }
 
-        // Pattern 4: Bare vector::borrow/borrow_mut(...)
-        if let Some(id) = is_verbose_vector_borrow(env, expr) {
+        // Pattern 4: `vector::borrow(v, i)` or `borrow_global<T>(addr)` (bare, not wrapped)
+        if let Some((id, kind)) = is_verbose_borrow(env, expr) {
             if self.reported_in_context.contains(&id) {
                 return;
             }
-            report_vector_index_syntax(env, &env.get_node_loc(id));
+            report_index_syntax(env, &env.get_node_loc(id), kind);
         }
     }
 }

--- a/third_party/move/tools/move-linter/tests/model_ast_lints/aborting_overflow_checks.move
+++ b/third_party/move/tools/move-linter/tests/model_ast_lints/aborting_overflow_checks.move
@@ -84,21 +84,21 @@ module 0xc0ffee::m {
       abort 1
     };
 
-    let c = borrow_global<Counter>(addr).i;
+    let c = Counter[addr].i;
     if (c > c + b) {
       c + b
     } else {
       abort 1
     };
 
-    let nc = borrow_global<NestedCounter>(addr);
+    let nc = &NestedCounter[addr];
     if (nc.n.i > nc.n.i + b) {
       nc.n.i + b
     } else {
       abort 1
     };
 
-    let hnc = borrow_global<HyperNestedCounter>(addr);
+    let hnc = &HyperNestedCounter[addr];
     if (hnc.n.n.i > hnc.n.n.i + b) {
       hnc.n.n.i + b
     } else {

--- a/third_party/move/tools/move-linter/tests/model_ast_lints/deprecated_usage.exp
+++ b/third_party/move/tools/move-linter/tests/model_ast_lints/deprecated_usage.exp
@@ -195,8 +195,8 @@ warning: [lint] use of deprecated struct `0xc0ffee::m::DeprecatedStruct`
 warning: [lint] use of deprecated struct `0xc0ffee::m::DeprecatedStruct`
     ┌─ tests/model_ast_lints/deprecated_usage.move:154:9
     │
-154 │         borrow_global<DeprecatedStruct>(addr).value
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+154 │         DeprecatedStruct[addr].value
+    │         ^^^^^^^^^^^^^^^^^^^^^^
     │
     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(deprecated_usage)]`.
     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#deprecated_usage.
@@ -204,8 +204,8 @@ warning: [lint] use of deprecated struct `0xc0ffee::m::DeprecatedStruct`
 warning: [lint] use of deprecated struct `0xc0ffee::m::DeprecatedStruct`
     ┌─ tests/model_ast_lints/deprecated_usage.move:154:9
     │
-154 │         borrow_global<DeprecatedStruct>(addr).value
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+154 │         DeprecatedStruct[addr].value
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(deprecated_usage)]`.
     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#deprecated_usage.

--- a/third_party/move/tools/move-linter/tests/model_ast_lints/deprecated_usage.move
+++ b/third_party/move/tools/move-linter/tests/model_ast_lints/deprecated_usage.move
@@ -151,7 +151,7 @@ module 0xc0ffee::m {
 
     // borrow_global<DeprecatedStruct> -> warn
     public fun test_borrow_global_deprecated_struct(addr: address): u64 acquires DeprecatedStruct {
-        borrow_global<DeprecatedStruct>(addr).value
+        DeprecatedStruct[addr].value
     }
 
     // move_to with a deprecated struct -> warn

--- a/third_party/move/tools/move-linter/tests/model_ast_lints/exists_bool_equality.exp
+++ b/third_party/move/tools/move-linter/tests/model_ast_lints/exists_bool_equality.exp
@@ -12,8 +12,8 @@ warning: [lint] This boolean expression can be simplified using idempotence (`a 
 warning: [lint] This boolean expression can be simplified using idempotence (`a && a` is equivalent to `a`).
    ┌─ tests/model_ast_lints/exists_bool_equality.move:23:9
    │
-23 │         borrow_global<A>(@0xc0ffee).0 && borrow_global<A>(@0xc0ffee).0
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+23 │         A[@0xc0ffee].0 && A[@0xc0ffee].0
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    │
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(simpler_bool_expression)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#simpler_bool_expression.

--- a/third_party/move/tools/move-linter/tests/model_ast_lints/exists_bool_equality.move
+++ b/third_party/move/tools/move-linter/tests/model_ast_lints/exists_bool_equality.move
@@ -8,7 +8,7 @@ module 0xc0ffee::m {
     }
 
     public fun no_warn_2(): bool {
-        borrow_global<A>(@0xc0ffee).0 && borrow_global<B>(@0xc0ffee).0
+        A[@0xc0ffee].0 && B[@0xc0ffee].0
     }
 
     public fun no_warn_3(): bool {
@@ -20,7 +20,7 @@ module 0xc0ffee::m {
     }
 
     public fun warn_2(): bool {
-        borrow_global<A>(@0xc0ffee).0 && borrow_global<A>(@0xc0ffee).0
+        A[@0xc0ffee].0 && A[@0xc0ffee].0
     }
 
     public fun warn_3(): bool {

--- a/third_party/move/tools/move-linter/tests/model_ast_lints/mutable_view_function.move
+++ b/third_party/move/tools/move-linter/tests/model_ast_lints/mutable_view_function.move
@@ -4,7 +4,7 @@ module 0x42::view_function_safety {
     }
 
     fun modify_state() {
-        let state = borrow_global_mut<State>(@0x42);
+        let state = &mut State[@0x42];
         state.val = state.val + 1;
     }
 
@@ -18,7 +18,7 @@ module 0x42::view_function_safety {
     // Should warn: public view directly using borrow_global_mut
     #[view]
     public fun unsafe_view_direct_borrow(): u64 {
-        let state = borrow_global_mut<State>(@0x42);
+        let state = &mut State[@0x42];
         state.val = state.val + 1;
         1
     }
@@ -59,13 +59,13 @@ module 0x42::view_function_safety {
     // Ok: public view that only reads
     #[view]
     public fun safe_pure_view(): u64 {
-        borrow_global<State>(@0x42).val
+        State[@0x42].val
     }
 
     // Should warn: recursive function that modifies state, called by view
     fun recursive_mutating(n: u64) {
         if (n == 0) {
-            let state = borrow_global_mut<State>(@0x42);
+            let state = &mut State[@0x42];
             state.val = state.val + 1;
         } else {
             recursive_mutating(n - 1);
@@ -95,7 +95,7 @@ module 0x42::view_function_safety {
     // Should warn: mutually recursive functions that modify state, called by view
     fun mutual_a(n: u64) {
         if (n == 0) {
-            let state = borrow_global_mut<State>(@0x42);
+            let state = &mut State[@0x42];
             state.val = state.val + 1;
         } else {
             mutual_b(n - 1);
@@ -113,7 +113,7 @@ module 0x42::view_function_safety {
     }
 
     fun z_mutates() {
-        let state = borrow_global_mut<State>(@0x42);
+        let state = &mut State[@0x42];
         state.val = state.val + 1;
     }
 
@@ -159,7 +159,7 @@ module 0x42::view_function_safety {
 
     // Should warn: deep transitive chain (view -> f -> g -> mutate)
     fun deep_level_3() {
-        let state = borrow_global_mut<State>(@0x42);
+        let state = &mut State[@0x42];
         state.val = state.val + 1;
     }
 
@@ -191,7 +191,7 @@ module 0x42::view_friend_visibility {
     // Should warn: friend view that mutates state
     #[view]
     friend fun unsafe_friend_view_mutates(): u64 {
-        let state = borrow_global_mut<State>(@0x42);
+        let state = &mut State[@0x42];
         state.val = state.val + 1;
         1
     }
@@ -205,7 +205,7 @@ module 0x42::view_package_visibility {
     // Should warn: package view that mutates state
     #[view]
     package fun unsafe_package_view_mutates(): u64 {
-        let state = borrow_global_mut<State>(@0x42);
+        let state = &mut State[@0x42];
         state.val = state.val + 1;
         1
     }

--- a/third_party/move/tools/move-linter/tests/model_ast_lints/needless_deref_ref_warn.exp
+++ b/third_party/move/tools/move-linter/tests/model_ast_lints/needless_deref_ref_warn.exp
@@ -12,8 +12,8 @@ warning: [lint] Needless pair of `*` and `&mut` operators: consider removing the
 warning: [lint] Needless pair of `*` and `&` operators: consider removing them
    ┌─ tests/model_ast_lints/needless_deref_ref_warn.move:30:9
    │
-30 │         *&borrow_global<S>(addr).y
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+30 │         *&S[addr].y
+   │         ^^^^^^^^^^^
    │
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(needless_deref_ref)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#needless_deref_ref.
@@ -21,8 +21,8 @@ warning: [lint] Needless pair of `*` and `&` operators: consider removing them
 warning: [lint] Needless pair of `*` and `&mut` operators: consider removing them
    ┌─ tests/model_ast_lints/needless_deref_ref_warn.move:40:9
    │
-40 │         *&mut borrow_global_mut<S>(addr).y
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+40 │         *&mut (&mut S[addr]).y
+   │         ^^^^^^^^^^^^^^^^^^^^^^
    │
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(needless_deref_ref)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#needless_deref_ref.
@@ -147,8 +147,8 @@ warning: [lint] Needless pair of `*` and `&` operators: consider removing them
 warning: [lint] Needless mutable reference or borrow: consider using immutable reference or borrow instead
    ┌─ tests/model_ast_lints/needless_deref_ref_warn.move:40:15
    │
-40 │         *&mut borrow_global_mut<S>(addr).y
-   │               ^^^^^^^^^^^^^^^^^^^^^^^^^^
+40 │         *&mut (&mut S[addr]).y
+   │               ^^^^^^^^^^^^^^
    │
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(needless_mutable_reference)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#needless_mutable_reference.

--- a/third_party/move/tools/move-linter/tests/model_ast_lints/needless_deref_ref_warn.move
+++ b/third_party/move/tools/move-linter/tests/model_ast_lints/needless_deref_ref_warn.move
@@ -15,29 +15,29 @@ module 0xc0ffee::m {
 
     #[lint::skip(unused_function)]
     fun test1_warn(addr: address) acquires S {
-        let r = borrow_global_mut<S>(addr);
+        let r = &mut S[addr];
         *&mut r.x = 5;
     }
 
     #[lint::skip(unused_function)]
     fun test1_no_warn(addr: address) acquires S {
-        let r = borrow_global_mut<S>(addr);
+        let r = &mut S[addr];
         r.x = 5;
     }
 
     #[lint::skip(unused_function)]
     fun test2_warn(addr: address): U acquires S {
-        *&borrow_global<S>(addr).y
+        *&S[addr].y
     }
 
     #[lint::skip(unused_function)]
     fun test2_no_warn(addr: address): U acquires S {
-        borrow_global<S>(addr).y
+        S[addr].y
     }
 
     #[lint::skip(unused_function)]
     fun test3_warn(addr: address): U acquires S {
-        *&mut borrow_global_mut<S>(addr).y
+        *&mut (&mut S[addr]).y
     }
 
     #[lint::skip(unused_function)]

--- a/third_party/move/tools/move-linter/tests/model_ast_lints/unused/all_used/global_storage_ops.move
+++ b/third_party/move/tools/move-linter/tests/model_ast_lints/unused/all_used/global_storage_ops.move
@@ -7,11 +7,11 @@ module 0x42::m {
     }
 
     public fun test_borrow_global(addr: address): u64 acquires MyResource {
-        borrow_global<MyResource>(addr).value
+        MyResource[addr].value
     }
 
     public fun test_borrow_global_mut(addr: address) acquires MyResource {
-        borrow_global_mut<MyResource>(addr).value = 100;
+        MyResource[addr].value = 100;
     }
 
     public fun test_move_from(addr: address): MyResource acquires MyResource {

--- a/third_party/move/tools/move-linter/tests/model_ast_lints/use_index_syntax.exp
+++ b/third_party/move/tools/move-linter/tests/model_ast_lints/use_index_syntax.exp
@@ -153,6 +153,15 @@ warning: [lint] concise global storage index notation syntax can be used here in
     = Concise global storage index notation syntax is described here: https://aptos.dev/build/smart-contracts/book/global-storage-operators#index-notation-for-storage-operators.
     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(use_index_syntax)]`.
 
+warning: [lint] concise global storage index notation syntax can be used here instead.
+    ┌─ tests/model_ast_lints/use_index_syntax.move:138:29
+    │
+138 │         helper_takes_immref(borrow_global<MyResource>(addr))
+    │                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    = Concise global storage index notation syntax is described here: https://aptos.dev/build/smart-contracts/book/global-storage-operators#index-notation-for-storage-operators.
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(use_index_syntax)]`.
+
 warning: [lint] Needless mutable reference or borrow: consider using immutable reference or borrow instead
     ┌─ tests/model_ast_lints/use_index_syntax.move:128:9
     │

--- a/third_party/move/tools/move-linter/tests/model_ast_lints/use_index_syntax.exp
+++ b/third_party/move/tools/move-linter/tests/model_ast_lints/use_index_syntax.exp
@@ -1,19 +1,10 @@
 
 Diagnostics:
 warning: [lint] concise vector index notation syntax can be used here instead.
-   ┌─ tests/model_ast_lints/use_index_syntax.move:15:9
-   │
-15 │         vector::borrow(v, i)
-   │         ^^^^^^^^^^^^^^^^^^^^
-   │
-   = Concise vector index notation syntax is described here: https://aptos.dev/build/smart-contracts/book/vector#index-notation-for-vectors.
-   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(use_index_syntax)]`.
-
-warning: [lint] concise vector index notation syntax can be used here instead.
    ┌─ tests/model_ast_lints/use_index_syntax.move:20:9
    │
-20 │         vector::borrow_mut(v, i)
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^
+20 │         vector::borrow(v, i)
+   │         ^^^^^^^^^^^^^^^^^^^^
    │
    = Concise vector index notation syntax is described here: https://aptos.dev/build/smart-contracts/book/vector#index-notation-for-vectors.
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(use_index_syntax)]`.
@@ -21,8 +12,8 @@ warning: [lint] concise vector index notation syntax can be used here instead.
 warning: [lint] concise vector index notation syntax can be used here instead.
    ┌─ tests/model_ast_lints/use_index_syntax.move:25:9
    │
-25 │         *vector::borrow(v, i)
-   │         ^^^^^^^^^^^^^^^^^^^^^
+25 │         vector::borrow_mut(v, i)
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^
    │
    = Concise vector index notation syntax is described here: https://aptos.dev/build/smart-contracts/book/vector#index-notation-for-vectors.
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(use_index_syntax)]`.
@@ -30,8 +21,8 @@ warning: [lint] concise vector index notation syntax can be used here instead.
 warning: [lint] concise vector index notation syntax can be used here instead.
    ┌─ tests/model_ast_lints/use_index_syntax.move:30:9
    │
-30 │         *vector::borrow_mut(v, i) = x;
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+30 │         *vector::borrow(v, i)
+   │         ^^^^^^^^^^^^^^^^^^^^^
    │
    = Concise vector index notation syntax is described here: https://aptos.dev/build/smart-contracts/book/vector#index-notation-for-vectors.
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(use_index_syntax)]`.
@@ -39,8 +30,8 @@ warning: [lint] concise vector index notation syntax can be used here instead.
 warning: [lint] concise vector index notation syntax can be used here instead.
    ┌─ tests/model_ast_lints/use_index_syntax.move:35:9
    │
-35 │         vector::borrow(v, i).value
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+35 │         *vector::borrow_mut(v, i) = x;
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    │
    = Concise vector index notation syntax is described here: https://aptos.dev/build/smart-contracts/book/vector#index-notation-for-vectors.
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(use_index_syntax)]`.
@@ -48,8 +39,8 @@ warning: [lint] concise vector index notation syntax can be used here instead.
 warning: [lint] concise vector index notation syntax can be used here instead.
    ┌─ tests/model_ast_lints/use_index_syntax.move:40:9
    │
-40 │         vector::borrow_mut(v, i).value
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+40 │         vector::borrow(v, i).value
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^
    │
    = Concise vector index notation syntax is described here: https://aptos.dev/build/smart-contracts/book/vector#index-notation-for-vectors.
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(use_index_syntax)]`.
@@ -57,17 +48,8 @@ warning: [lint] concise vector index notation syntax can be used here instead.
 warning: [lint] concise vector index notation syntax can be used here instead.
    ┌─ tests/model_ast_lints/use_index_syntax.move:45:9
    │
-45 │         vector::borrow_mut(v, i).value = x;
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   │
-   = Concise vector index notation syntax is described here: https://aptos.dev/build/smart-contracts/book/vector#index-notation-for-vectors.
-   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(use_index_syntax)]`.
-
-warning: [lint] concise vector index notation syntax can be used here instead.
-   ┌─ tests/model_ast_lints/use_index_syntax.move:50:24
-   │
-50 │         vector::borrow(vector::borrow(v, i), j)
-   │                        ^^^^^^^^^^^^^^^^^^^^
+45 │         vector::borrow_mut(v, i).value
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    │
    = Concise vector index notation syntax is described here: https://aptos.dev/build/smart-contracts/book/vector#index-notation-for-vectors.
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(use_index_syntax)]`.
@@ -75,8 +57,17 @@ warning: [lint] concise vector index notation syntax can be used here instead.
 warning: [lint] concise vector index notation syntax can be used here instead.
    ┌─ tests/model_ast_lints/use_index_syntax.move:50:9
    │
-50 │         vector::borrow(vector::borrow(v, i), j)
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+50 │         vector::borrow_mut(v, i).value = x;
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = Concise vector index notation syntax is described here: https://aptos.dev/build/smart-contracts/book/vector#index-notation-for-vectors.
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(use_index_syntax)]`.
+
+warning: [lint] concise vector index notation syntax can be used here instead.
+   ┌─ tests/model_ast_lints/use_index_syntax.move:55:24
+   │
+55 │         vector::borrow(vector::borrow(v, i), j)
+   │                        ^^^^^^^^^^^^^^^^^^^^
    │
    = Concise vector index notation syntax is described here: https://aptos.dev/build/smart-contracts/book/vector#index-notation-for-vectors.
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(use_index_syntax)]`.
@@ -84,8 +75,89 @@ warning: [lint] concise vector index notation syntax can be used here instead.
 warning: [lint] concise vector index notation syntax can be used here instead.
    ┌─ tests/model_ast_lints/use_index_syntax.move:55:9
    │
-55 │         *vector::borrow(v, i) > 0
+55 │         vector::borrow(vector::borrow(v, i), j)
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = Concise vector index notation syntax is described here: https://aptos.dev/build/smart-contracts/book/vector#index-notation-for-vectors.
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(use_index_syntax)]`.
+
+warning: [lint] concise vector index notation syntax can be used here instead.
+   ┌─ tests/model_ast_lints/use_index_syntax.move:60:9
+   │
+60 │         *vector::borrow(v, i) > 0
    │         ^^^^^^^^^^^^^^^^^^^^^
    │
    = Concise vector index notation syntax is described here: https://aptos.dev/build/smart-contracts/book/vector#index-notation-for-vectors.
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(use_index_syntax)]`.
+
+warning: [lint] concise global storage index notation syntax can be used here instead.
+    ┌─ tests/model_ast_lints/use_index_syntax.move:101:18
+    │
+101 │         let _r = borrow_global<MyResource>(addr);
+    │                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    = Concise global storage index notation syntax is described here: https://aptos.dev/build/smart-contracts/book/global-storage-operators#index-notation-for-storage-operators.
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(use_index_syntax)]`.
+
+warning: [lint] concise global storage index notation syntax can be used here instead.
+    ┌─ tests/model_ast_lints/use_index_syntax.move:107:18
+    │
+107 │         let _r = borrow_global_mut<MyResource>(addr);
+    │                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    = Concise global storage index notation syntax is described here: https://aptos.dev/build/smart-contracts/book/global-storage-operators#index-notation-for-storage-operators.
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(use_index_syntax)]`.
+
+warning: [lint] concise global storage index notation syntax can be used here instead.
+    ┌─ tests/model_ast_lints/use_index_syntax.move:113:9
+    │
+113 │         *borrow_global<MyResource>(addr)
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    = Concise global storage index notation syntax is described here: https://aptos.dev/build/smart-contracts/book/global-storage-operators#index-notation-for-storage-operators.
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(use_index_syntax)]`.
+
+warning: [lint] concise global storage index notation syntax can be used here instead.
+    ┌─ tests/model_ast_lints/use_index_syntax.move:118:9
+    │
+118 │         *borrow_global_mut<MyResource>(addr) = x;
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    = Concise global storage index notation syntax is described here: https://aptos.dev/build/smart-contracts/book/global-storage-operators#index-notation-for-storage-operators.
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(use_index_syntax)]`.
+
+warning: [lint] concise global storage index notation syntax can be used here instead.
+    ┌─ tests/model_ast_lints/use_index_syntax.move:123:9
+    │
+123 │         borrow_global<MyResource>(addr).value
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    = Concise global storage index notation syntax is described here: https://aptos.dev/build/smart-contracts/book/global-storage-operators#index-notation-for-storage-operators.
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(use_index_syntax)]`.
+
+warning: [lint] concise global storage index notation syntax can be used here instead.
+    ┌─ tests/model_ast_lints/use_index_syntax.move:128:9
+    │
+128 │         borrow_global_mut<MyResource>(addr).value
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    = Concise global storage index notation syntax is described here: https://aptos.dev/build/smart-contracts/book/global-storage-operators#index-notation-for-storage-operators.
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(use_index_syntax)]`.
+
+warning: [lint] concise global storage index notation syntax can be used here instead.
+    ┌─ tests/model_ast_lints/use_index_syntax.move:133:9
+    │
+133 │         borrow_global_mut<MyResource>(addr).value = x;
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    = Concise global storage index notation syntax is described here: https://aptos.dev/build/smart-contracts/book/global-storage-operators#index-notation-for-storage-operators.
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(use_index_syntax)]`.
+
+warning: [lint] Needless mutable reference or borrow: consider using immutable reference or borrow instead
+    ┌─ tests/model_ast_lints/use_index_syntax.move:128:9
+    │
+128 │         borrow_global_mut<MyResource>(addr).value
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(needless_mutable_reference)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#needless_mutable_reference.

--- a/third_party/move/tools/move-linter/tests/model_ast_lints/use_index_syntax.move
+++ b/third_party/move/tools/move-linter/tests/model_ast_lints/use_index_syntax.move
@@ -1,10 +1,15 @@
 // Tests for the use_index_syntax lint.
-// Detects vector::borrow/borrow_mut calls that can use index syntax v[i].
+// Detects vector::borrow/borrow_mut calls that can use index syntax v[i],
+// and borrow_global/borrow_global_mut calls that can use index syntax T[addr].
 
 module 0xc0ffee::m {
     use std::vector;
 
     struct MyStruct has copy, drop {
+        value: u64,
+    }
+
+    struct MyResource has key, copy, drop {
         value: u64,
     }
 
@@ -55,7 +60,7 @@ module 0xc0ffee::m {
         *vector::borrow(v, i) > 0
     }
 
-    // === Should NOT warn: already using index syntax ===
+    // === Should NOT warn: already using vector index syntax ===
 
     // No warn: index syntax
     public fun test_index_no_warn(v: &vector<u64>, i: u64): u64 {
@@ -89,11 +94,93 @@ module 0xc0ffee::m {
         vector::empty()
     }
 
+    // === Should warn: verbose borrow_global calls ===
+
+    // Warn: borrow_global can be &MyResource[addr]
+    public fun test_borrow_global_warn(addr: address): u64 acquires MyResource {
+        let _r = borrow_global<MyResource>(addr);
+        _r.value
+    }
+
+    // Warn: borrow_global_mut can be &mut MyResource[addr]
+    public fun test_borrow_global_mut_warn(addr: address): u64 acquires MyResource {
+        let _r = borrow_global_mut<MyResource>(addr);
+        _r.value
+    }
+
+    // Warn: *borrow_global can be MyResource[addr]
+    public fun test_deref_borrow_global_warn(addr: address): MyResource acquires MyResource {
+        *borrow_global<MyResource>(addr)
+    }
+
+    // Warn: *borrow_global_mut = x can be MyResource[addr] = x
+    public fun test_deref_borrow_global_mut_assign_warn(addr: address, x: MyResource) acquires MyResource {
+        *borrow_global_mut<MyResource>(addr) = x;
+    }
+
+    // Warn: borrow_global(...).field can be MyResource[addr].field
+    public fun test_borrow_global_field_warn(addr: address): u64 acquires MyResource {
+        borrow_global<MyResource>(addr).value
+    }
+
+    // Warn: borrow_global_mut(...).field read can be MyResource[addr].field
+    public fun test_borrow_global_mut_field_read_warn(addr: address): u64 acquires MyResource {
+        borrow_global_mut<MyResource>(addr).value
+    }
+
+    // Warn: borrow_global_mut(...).field = x can be MyResource[addr].field = x
+    public fun test_borrow_global_mut_field_assign_warn(addr: address, x: u64) acquires MyResource {
+        borrow_global_mut<MyResource>(addr).value = x;
+    }
+
+    // === Should NOT warn: already using global storage index syntax ===
+
+    // No warn: immutable index syntax
+    public fun test_global_index_no_warn(addr: address): u64 acquires MyResource {
+        let _r = &MyResource[addr];
+        _r.value
+    }
+
+    // No warn: mutable index syntax
+    public fun test_global_index_mut_no_warn(addr: address): u64 acquires MyResource {
+        let _r = &mut MyResource[addr];
+        _r.value
+    }
+
+    // No warn: deref index syntax
+    public fun test_global_deref_index_no_warn(addr: address): MyResource acquires MyResource {
+        MyResource[addr]
+    }
+
+    // No warn: index with field access
+    public fun test_global_index_field_no_warn(addr: address): u64 acquires MyResource {
+        MyResource[addr].value
+    }
+
+    // === Should NOT warn: not borrow_global ===
+
+    // No warn: exists is not borrow_global
+    public fun test_exists_no_warn(addr: address): bool {
+        exists<MyResource>(addr)
+    }
+
+    // No warn: move_from is not borrow_global
+    public fun test_move_from_no_warn(addr: address): MyResource acquires MyResource {
+        move_from<MyResource>(addr)
+    }
+
     // === Lint skip ===
 
-    // No warn: lint skip
+    // No warn: lint skip for vector
     #[lint::skip(use_index_syntax)]
     public fun test_skip_no_warn(v: &vector<u64>, i: u64): &u64 {
         vector::borrow(v, i)
+    }
+
+    // No warn: lint skip for global
+    #[lint::skip(use_index_syntax)]
+    public fun test_skip_global_no_warn(addr: address): u64 acquires MyResource {
+        let _r = borrow_global<MyResource>(addr);
+        _r.value
     }
 }

--- a/third_party/move/tools/move-linter/tests/model_ast_lints/use_index_syntax.move
+++ b/third_party/move/tools/move-linter/tests/model_ast_lints/use_index_syntax.move
@@ -157,6 +157,21 @@ module 0xc0ffee::m {
         MyResource[addr].value
     }
 
+    // No warn: mutable index syntax used where immutable ref expected (implicit freeze)
+    fun helper_takes_immref(r: &MyResource): u64 { r.value }
+
+    #[lint::skip(needless_mutable_reference)]
+    public fun test_global_index_mut_freeze_no_warn(addr: address): u64 acquires MyResource {
+        helper_takes_immref(&mut MyResource[addr])
+    }
+
+    // No warn: mutable index syntax assigned to immutable ref binding
+    #[lint::skip(needless_mutable_reference)]
+    public fun test_global_index_mut_to_immref_no_warn(addr: address): u64 acquires MyResource {
+        let _r: &MyResource = &mut MyResource[addr];
+        _r.value
+    }
+
     // === Should NOT warn: not borrow_global ===
 
     // No warn: exists is not borrow_global

--- a/third_party/move/tools/move-linter/tests/model_ast_lints/use_index_syntax.move
+++ b/third_party/move/tools/move-linter/tests/model_ast_lints/use_index_syntax.move
@@ -133,6 +133,11 @@ module 0xc0ffee::m {
         borrow_global_mut<MyResource>(addr).value = x;
     }
 
+    // Warn: borrow_global passed directly as function argument
+    public fun test_borrow_global_as_arg_warn(addr: address): u64 acquires MyResource {
+        helper_takes_immref(borrow_global<MyResource>(addr))
+    }
+
     // === Should NOT warn: already using global storage index syntax ===
 
     // No warn: immutable index syntax

--- a/third_party/move/tools/move-linter/tests/stackless_bytecode_lints/needless_mutable_reference_warn.exp
+++ b/third_party/move/tools/move-linter/tests/stackless_bytecode_lints/needless_mutable_reference_warn.exp
@@ -57,8 +57,8 @@ warning: [lint] Needless mutable reference or borrow: consider using immutable r
 warning: [lint] Needless mutable reference or borrow: consider using immutable reference or borrow instead
     ┌─ tests/stackless_bytecode_lints/needless_mutable_reference_warn.move:118:17
     │
-118 │         let r = borrow_global_mut<R>(addr);
-    │                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
+118 │         let r = &mut R[addr];
+    │                 ^^^^^^^^^^^^
     │
     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(needless_mutable_reference)]`.
     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#needless_mutable_reference.
@@ -66,8 +66,8 @@ warning: [lint] Needless mutable reference or borrow: consider using immutable r
 warning: [lint] Needless mutable reference or borrow: consider using immutable reference or borrow instead
     ┌─ tests/stackless_bytecode_lints/needless_mutable_reference_warn.move:123:17
     │
-123 │         let r = borrow_global_mut<R>(addr);
-    │                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
+123 │         let r = &mut R[addr];
+    │                 ^^^^^^^^^^^^
     │
     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(needless_mutable_reference)]`.
     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#needless_mutable_reference.
@@ -84,8 +84,8 @@ warning: [lint] Needless mutable reference or borrow: consider using immutable r
 warning: [lint] Needless mutable reference or borrow: consider using immutable reference or borrow instead
     ┌─ tests/stackless_bytecode_lints/needless_mutable_reference_warn.move:130:19
     │
-130 │         let ref = borrow_global_mut<S>(addr);
-    │                   ^^^^^^^^^^^^^^^^^^^^^^^^^^
+130 │         let ref = &mut S[addr];
+    │                   ^^^^^^^^^^^^
     │
     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(needless_mutable_reference)]`.
     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#needless_mutable_reference.

--- a/third_party/move/tools/move-linter/tests/stackless_bytecode_lints/needless_mutable_reference_warn.move
+++ b/third_party/move/tools/move-linter/tests/stackless_bytecode_lints/needless_mutable_reference_warn.move
@@ -82,19 +82,19 @@ module 0xc0ffee::n {
     }
 
     public fun test_no_warn_1(addr: address) acquires R {
-        let r = borrow_global_mut<R>(addr);
+        let r = &mut R[addr];
         r.x = 5;
     }
 
     public fun test_no_warn_2(addr: address): u64 acquires R {
-        let r = borrow_global_mut<R>(addr);
+        let r = &mut R[addr];
         let y = &mut r.x;
         *y = 5;
         *y
     }
 
     public fun test_no_warn_3(addr: address) acquires S {
-        let s = borrow_global_mut<S>(addr);
+        let s = &mut S[addr];
         let y = &mut s.r;
         y.x = 5;
     }
@@ -106,7 +106,7 @@ module 0xc0ffee::n {
     fun helper_immut(_r: &R) {}
 
     public fun test_no_warn_4(addr: address, p: bool) acquires R {
-        let r = borrow_global_mut<R>(addr);
+        let r = &mut R[addr];
         if (p) {
             helper_mut(r);
         } else {
@@ -115,19 +115,19 @@ module 0xc0ffee::n {
     }
 
     public fun test_warn_1(addr: address) acquires R {
-        let r = borrow_global_mut<R>(addr);
+        let r = &mut R[addr];
         helper_immut(r);
     }
 
     public fun test_warn_2(addr: address): u64 acquires R {
-        let r = borrow_global_mut<R>(addr);
+        let r = &mut R[addr];
         let y = r.x;
         y
     }
 
     #[lint::skip(unused_function)]
     fun test_warn_3(s: &mut S, p: bool, addr: address): u64 acquires S {
-        let ref = borrow_global_mut<S>(addr);
+        let ref = &mut S[addr];
         if (p) {
             ref = s;
         };
@@ -137,7 +137,7 @@ module 0xc0ffee::n {
     #[lint::skip(unused_function)]
     fun test_no_warn_5(p: bool, a: address, s: &S): u64 acquires S {
         if (p) {
-            s = borrow_global<S>(a);
+            s = &S[a];
         };
         let y = &s.r;
         y.x


### PR DESCRIPTION
## Description

We extend the lint `use_index_syntax` to warn on `borrow_global<T>(addr)` / `borrow_global_mut<T>(addr)` calls that could use the concise `T[addr]` index notation.

| Verbose syntax patterns detected |
|---|
| `borrow_global<T>(addr)` |
| `borrow_global_mut<T>(addr)` |
| `*borrow_global<T>(addr)` |
| `*borrow_global_mut<T>(addr) = x` |
| `borrow_global<T>(addr).field` |
| `borrow_global_mut<T>(addr).field = x` |

This is implemented using the `SurfaceSyntax` mechanism previously introduced.

## How Has This Been Tested?

- added new tests
- modified some existing tests to have the concise syntax, so that we don't spray these warnings in .exp files elsewhere

## Type of Change
- [x] New feature

## Which Components or Systems Does This Change Impact?
- [x] Move linter

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Extends linter behavior and adjusts `ExpBuilder` surface-syntax tagging for `borrow_global` desugaring; incorrect tagging could change or suppress diagnostics across multiple lints/tests.
> 
> **Overview**
> Extends the `use_index_syntax` lint to also warn on verbose global storage access via `borrow_global`/`borrow_global_mut` (including deref, field access, assignments, and bare calls), suggesting the concise `T[addr]` notation and linking to new docs.
> 
> Updates Move model building to centralize `borrow_global` names in `well_known` constants, and fixes `ExpBuilder` to attach `SurfaceSyntax::IndexNotation` to the underlying borrow operation even when an implicit `Freeze` wrapper is introduced.
> 
> Refreshes a broad set of linter and diagnostic golden tests to use the new global-storage index syntax and to cover the new warnings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 221de6d14af49ff1e3cf34afd8e6633d3d2e6dce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->