### PR TITLE
[vm][gas] Optimize type creation gas charging

### DIFF
--- a/aptos-move/aptos-vm-environment/src/prod_configs.rs
+++ b/aptos-move/aptos-vm-environment/src/prod_configs.rs
@@ -5,6 +5,7 @@ pub use aptos_gas_schedule::LATEST_GAS_FEATURE_VERSION;
 use aptos_gas_schedule::{
     gas_feature_versions::{
         RELEASE_V1_15, RELEASE_V1_30, RELEASE_V1_34, RELEASE_V1_38, RELEASE_V1_41, RELEASE_V1_42,
+        RELEASE_V1_45,
     },
     AptosGasParameters,
 };
@@ -296,6 +297,7 @@ pub fn aptos_prod_vm_config(
         enable_struct_layout_local_cache: gas_feature_version >= RELEASE_V1_41,
         check_depth_on_type_counts: gas_feature_version >= RELEASE_V1_41,
         enable_public_struct_args: features.is_enabled(FeatureFlag::PUBLIC_STRUCT_ENUM_ARGS),
+        charge_create_ty_on_cache_hit: gas_feature_version < RELEASE_V1_45,
     };
 
     // Note: if max_value_nest_depth changed, make sure the constant is in-sync. Do not remove this

--- a/third_party/move/mono-move/specializer/src/destack/type_conversion.rs
+++ b/third_party/move/mono-move/specializer/src/destack/type_conversion.rs
@@ -110,8 +110,8 @@ fn convert_impl(
                 .map(|t| convert_impl(view, t, struct_name_table))
                 .collect();
             Type::Function {
-                args,
-                results,
+                args: TriompheArc::new(args),
+                results: TriompheArc::new(results),
                 abilities: *abilities,
             }
         },

--- a/third_party/move/move-vm/runtime/src/config.rs
+++ b/third_party/move/move-vm/runtime/src/config.rs
@@ -76,6 +76,11 @@ pub struct VMConfig {
     /// When enabled, non-private structs and enums with the copy ability can be used as
     /// transaction arguments if they have public pack functions with the Pack attribute.
     pub enable_public_struct_args: bool,
+    /// When true, type creation is charged even if the type was cached for the
+    /// function frame. When false, type creation is only charged on cache miss
+    ///making it much cheaper for use cases like repeated calls to generic
+    /// functions in a loop.
+    pub charge_create_ty_on_cache_hit: bool,
 }
 
 impl Default for VMConfig {
@@ -108,6 +113,7 @@ impl Default for VMConfig {
             enable_struct_layout_local_cache: true,
             check_depth_on_type_counts: true,
             enable_public_struct_args: true,
+            charge_create_ty_on_cache_hit: false,
         }
     }
 }

--- a/third_party/move/move-vm/runtime/src/frame.rs
+++ b/third_party/move/move-vm/runtime/src/frame.rs
@@ -170,12 +170,27 @@ impl Frame {
         stack: &Stack,
     ) -> PartialVMResult<Frame> {
         let ty_args = function.ty_args();
-
         let ty_builder = vm_config.ty_builder.clone();
+        let mut cache_borrow = frame_cache.borrow_mut();
+
         let local_tys = if ty_args.is_empty() {
-            // Function is not generic - avoid cloning types.
-            for ty in function.local_tys() {
-                gas_meter.charge_create_ty(NumTypeNodes::new(ty.num_nodes() as u64))?;
+            // Try cached instantiated locals in frame cache. This way we instantiate only once per
+            // usage of the function.
+            if let Some(local_ty_counts) = cache_borrow.local_ty_counts.as_ref() {
+                // Already cached - charge only for compatibility.
+                if cache_borrow.charge_create_ty_on_cache_hit {
+                    for cnt in local_ty_counts.iter() {
+                        gas_meter.charge_create_ty(*cnt)?;
+                    }
+                }
+            } else {
+                let mut local_ty_counts = Vec::with_capacity(function.local_tys().len());
+                for ty in function.local_tys() {
+                    let cnt = NumTypeNodes::new(ty.num_nodes() as u64);
+                    gas_meter.charge_create_ty(cnt)?;
+                    local_ty_counts.push(cnt);
+                }
+                cache_borrow.local_ty_counts = Some(Rc::from(local_ty_counts));
             }
 
             if RTTCheck::should_perform_checks(&function.function) {
@@ -186,8 +201,7 @@ impl Frame {
         } else {
             // Try cached instantiated locals in frame cache. This way we instantiate only once per
             // usage of the function.
-            let mut cache_borrow = frame_cache.borrow_mut();
-            if let Some(local_ty_counts) = cache_borrow.instantiated_local_ty_counts.as_ref() {
+            if let Some(local_ty_counts) = cache_borrow.local_ty_counts.as_ref() {
                 // Already cached - charge only for compatibility.
                 if cache_borrow.charge_create_ty_on_cache_hit {
                     for cnt in local_ty_counts.iter() {
@@ -211,7 +225,7 @@ impl Frame {
 
                     local_ty_counts.push(cnt);
                 }
-                cache_borrow.instantiated_local_ty_counts = Some(Rc::from(local_ty_counts));
+                cache_borrow.local_ty_counts = Some(Rc::from(local_ty_counts));
             }
 
             if RTTCheck::should_perform_checks(&function.function) {

--- a/third_party/move/move-vm/runtime/src/frame.rs
+++ b/third_party/move/move-vm/runtime/src/frame.rs
@@ -188,8 +188,11 @@ impl Frame {
             // usage of the function.
             let mut cache_borrow = frame_cache.borrow_mut();
             if let Some(local_ty_counts) = cache_borrow.instantiated_local_ty_counts.as_ref() {
-                for cnt in local_ty_counts.iter() {
-                    gas_meter.charge_create_ty(*cnt)?;
+                // Already cached - charge only for compatibility.
+                if cache_borrow.charge_create_ty_on_cache_hit {
+                    for cnt in local_ty_counts.iter() {
+                        gas_meter.charge_create_ty(*cnt)?;
+                    }
                 }
             } else {
                 let local_tys = function.local_tys();

--- a/third_party/move/move-vm/runtime/src/frame_type_cache.rs
+++ b/third_party/move/move-vm/runtime/src/frame_type_cache.rs
@@ -14,7 +14,7 @@ use move_core_types::gas_algebra::NumTypeNodes;
 use move_vm_types::loaded_data::runtime_types::Type;
 use std::{
     cell::RefCell,
-    collections::BTreeMap,
+    collections::{btree_map::Entry, BTreeMap},
     rc::{Rc, Weak},
 };
 
@@ -30,26 +30,144 @@ pub(crate) enum PerInstructionCache {
     CallGeneric(Rc<LoadedFunction>, Weak<RefCell<FrameTypeCache>>),
 }
 
-#[derive(Default)]
+struct CachedFieldTypes {
+    types: Vec<Type>,
+    // TODO: remove individual counts.
+    counts: Vec<NumTypeNodes>,
+    counts_sum: NumTypeNodes,
+}
+
+impl CachedFieldTypes {
+    fn for_struct_fields(idx: StructDefInstantiationIndex, frame: &Frame) -> PartialVMResult<Self> {
+        Ok(Self::new(frame.instantiate_generic_struct_fields(idx)?))
+    }
+
+    fn for_struct_variant_fields(
+        idx: StructVariantInstantiationIndex,
+        frame: &Frame,
+    ) -> PartialVMResult<Self> {
+        Ok(Self::new(
+            frame.instantiate_generic_struct_variant_fields(idx)?,
+        ))
+    }
+
+    fn new(types: Vec<Type>) -> Self {
+        let mut counts = Vec::with_capacity(types.len());
+        let mut counts_sum = NumTypeNodes::new(0);
+        for ty in &types {
+            let count = NumTypeNodes::new(ty.num_nodes() as u64);
+            counts_sum += count;
+            counts.push(count);
+        }
+        Self {
+            types,
+            counts,
+            counts_sum,
+        }
+    }
+}
+
+struct CachedStructType {
+    ty: Type,
+    count: NumTypeNodes,
+}
+
+impl CachedStructType {
+    fn for_struct(idx: StructDefInstantiationIndex, frame: &Frame) -> PartialVMResult<Self> {
+        let ty = frame.get_generic_struct_ty(idx)?;
+        let count = NumTypeNodes::new(ty.num_nodes() as u64);
+        Ok(Self { ty, count })
+    }
+
+    fn for_struct_variant(
+        idx: StructVariantInstantiationIndex,
+        frame: &Frame,
+    ) -> PartialVMResult<Self> {
+        let info = frame.get_struct_variant_instantiation_at(idx);
+        let ty = frame
+            .create_struct_instantiation_ty(&info.definition_struct_type, &info.instantiation)?;
+        let count = NumTypeNodes::new(ty.num_nodes() as u64);
+        Ok(Self { ty, count })
+    }
+}
+
+struct CachedFieldAndStructType {
+    field_ty: Type,
+    struct_ty: Type,
+    // TODO: remove individual counts.
+    field_count: NumTypeNodes,
+    struct_count: NumTypeNodes,
+    counts_sum: NumTypeNodes,
+}
+
+impl CachedFieldAndStructType {
+    fn for_struct(idx: FieldInstantiationIndex, frame: &Frame) -> PartialVMResult<Self> {
+        let struct_ty = frame.field_instantiation_to_struct(idx)?;
+        let field_ty = frame.get_generic_field_ty(idx)?;
+        Ok(Self::new(field_ty, struct_ty))
+    }
+
+    fn for_struct_variant(
+        idx: VariantFieldInstantiationIndex,
+        frame: &Frame,
+    ) -> PartialVMResult<Self> {
+        let info = frame.variant_field_instantiation_info_at(idx);
+        let struct_ty = frame
+            .create_struct_instantiation_ty(&info.definition_struct_type, &info.instantiation)?;
+        let field_ty = frame.instantiate_ty(&info.uninstantiated_field_ty, &info.instantiation)?;
+        Ok(Self::new(field_ty, struct_ty))
+    }
+
+    fn new(field_ty: Type, struct_ty: Type) -> Self {
+        let field_count = NumTypeNodes::new(field_ty.num_nodes() as u64);
+        let struct_count = NumTypeNodes::new(struct_ty.num_nodes() as u64);
+        let counts_sum = field_count + struct_count;
+        Self {
+            field_ty,
+            struct_ty,
+            field_count,
+            struct_count,
+            counts_sum,
+        }
+    }
+}
+
+struct CachedSignatureType {
+    ty: Type,
+    count: NumTypeNodes,
+    depth: usize,
+}
+
+impl CachedSignatureType {
+    fn new(idx: SignatureIndex, frame: &Frame) -> PartialVMResult<Self> {
+        let ty = frame.instantiate_single_type(idx)?;
+        let (num_nodes, depth) = ty.num_nodes_with_max_depth();
+        let count = NumTypeNodes::new(num_nodes as u64);
+        Ok(Self { ty, count, depth })
+    }
+}
+
 pub(crate) struct FrameTypeCache {
-    struct_field_type_instantiation:
-        BTreeMap<StructDefInstantiationIndex, Vec<(Type, NumTypeNodes)>>,
-    struct_variant_field_type_instantiation:
-        BTreeMap<StructVariantInstantiationIndex, Vec<(Type, NumTypeNodes)>>,
-    struct_def_instantiation_type: BTreeMap<StructDefInstantiationIndex, (Type, NumTypeNodes)>,
-    struct_variant_instantiation_type:
-        BTreeMap<StructVariantInstantiationIndex, (Type, NumTypeNodes)>,
-    /// For a given field instantiation, the:
-    ///    ((Type of the field, size of the field type) and (Type of its defining struct,
-    ///    size of its defining struct)
-    field_instantiation:
-        BTreeMap<FieldInstantiationIndex, ((Type, NumTypeNodes), (Type, NumTypeNodes))>,
-    /// Same as above, but for variant field instantiations
-    variant_field_instantiation:
-        BTreeMap<VariantFieldInstantiationIndex, ((Type, NumTypeNodes), (Type, NumTypeNodes))>,
-    /// Maps signature index to a tuple of (Type, NumTypeNodes, depth) for single signature tokens.
-    /// This cache stores instantiated types for signatures with a single type parameter.
-    single_sig_token_type: BTreeMap<SignatureIndex, (Type, NumTypeNodes, usize)>,
+    /// Maps struct definition to runtime type and its size.
+    struct_defs: BTreeMap<StructDefInstantiationIndex, CachedStructType>,
+    /// Maps struct definition to its field runtime types and their sizes.
+    struct_def_fields: BTreeMap<StructDefInstantiationIndex, CachedFieldTypes>,
+    /// Maps field to its type and struct type that defines it. For both, type
+    /// size is also stored.
+    struct_fields: BTreeMap<FieldInstantiationIndex, CachedFieldAndStructType>,
+
+    /// Maps variant definition to runtime type and its size.
+    struct_variant_defs: BTreeMap<StructVariantInstantiationIndex, CachedStructType>,
+    /// Maps variant definition to its field runtime types and their sizes.
+    struct_variant_def_fields: BTreeMap<StructVariantInstantiationIndex, CachedFieldTypes>,
+    /// Maps variant field to its type and struct variant type that defines it.
+    /// For both, type size is also stored.
+    struct_variant_fields: BTreeMap<VariantFieldInstantiationIndex, CachedFieldAndStructType>,
+
+    /// Maps signature (used for vector element types) to runtime type, and its
+    /// derived information: type size and type depth.
+    signatures: BTreeMap<SignatureIndex, CachedSignatureType>,
+
     /// Stores a variant for each individual instruction in the
     /// function's bytecode. We keep the size of the variant to be
     /// small. The caches are indexed by the index of the given
@@ -75,36 +193,73 @@ pub(crate) struct FrameTypeCache {
     pub(crate) instantiated_local_tys: Option<Rc<[Type]>>,
     /// Cached number of type nodes per instantiated local type for gas charging re-use.
     pub(crate) instantiated_local_ty_counts: Option<Rc<[NumTypeNodes]>>,
-}
 
-macro_rules! get_or_insert {
-    ($map:expr, $idx:expr, $ty_func:tt) => {
-        match $map.entry($idx) {
-            std::collections::btree_map::Entry::Occupied(entry) => entry.into_mut(),
-            std::collections::btree_map::Entry::Vacant(entry) => {
-                let v = { $ty_func };
-                entry.insert(v)
-            },
-        }
-    };
+    /// Governs how type sizes are returned from cache APIs for gas metering.
+    /// If true, charging is suboptimal (charge on cache hit, multiple charges
+    /// over a list of type sizes). If false, charging is only on cache miss,
+    /// charges are aggregated when possible.
+    pub(crate) charge_create_ty_on_cache_hit: bool,
 }
 
 impl FrameTypeCache {
+    fn empty(charge_create_ty_on_cache_hit: bool) -> Self {
+        Self {
+            struct_defs: BTreeMap::new(),
+            struct_def_fields: BTreeMap::new(),
+            struct_fields: BTreeMap::new(),
+            struct_variant_defs: BTreeMap::new(),
+            struct_variant_def_fields: BTreeMap::new(),
+            struct_variant_fields: BTreeMap::new(),
+            signatures: BTreeMap::new(),
+            per_instruction_cache: vec![],
+            function_cache: BTreeMap::new(),
+            generic_function_cache: BTreeMap::new(),
+            instantiated_local_tys: None,
+            instantiated_local_ty_counts: None,
+            charge_create_ty_on_cache_hit,
+        }
+    }
+
     // note(inline): do not inline, increases size a lot, might even decrease the performance
     pub(crate) fn get_field_type_and_struct_type(
         &mut self,
         idx: FieldInstantiationIndex,
         frame: &Frame,
-    ) -> PartialVMResult<((&Type, NumTypeNodes), (&Type, NumTypeNodes))> {
-        let ((field_ty, field_ty_count), (struct_ty, struct_ty_count)) =
-            get_or_insert!(&mut self.field_instantiation, idx, {
-                let struct_type = frame.field_instantiation_to_struct(idx)?;
-                let struct_ty_count = NumTypeNodes::new(struct_type.num_nodes() as u64);
-                let field_ty = frame.get_generic_field_ty(idx)?;
-                let field_ty_count = NumTypeNodes::new(field_ty.num_nodes() as u64);
-                ((field_ty, field_ty_count), (struct_type, struct_ty_count))
-            });
-        Ok(((field_ty, *field_ty_count), (struct_ty, *struct_ty_count)))
+    ) -> PartialVMResult<(&Type, &Type)> {
+        Ok(match self.struct_fields.entry(idx) {
+            Entry::Vacant(e) => {
+                let cached = e.insert(CachedFieldAndStructType::for_struct(idx, frame)?);
+                (&cached.field_ty, &cached.struct_ty)
+            },
+            Entry::Occupied(e) => {
+                let cached = e.into_mut();
+                (&cached.field_ty, &cached.struct_ty)
+            },
+        })
+    }
+
+    pub(crate) fn get_field_type_and_struct_type_counts(
+        &mut self,
+        idx: FieldInstantiationIndex,
+        frame: &Frame,
+    ) -> PartialVMResult<(Option<(NumTypeNodes, NumTypeNodes)>, Option<NumTypeNodes>)> {
+        Ok(match self.struct_fields.entry(idx) {
+            Entry::Vacant(e) => {
+                let cached = e.insert(CachedFieldAndStructType::for_struct(idx, frame)?);
+                if self.charge_create_ty_on_cache_hit {
+                    (Some((cached.field_count, cached.struct_count)), None)
+                } else {
+                    (None, Some(cached.counts_sum))
+                }
+            },
+            Entry::Occupied(e) => {
+                let cached = e.get();
+                let legacy_charge = self
+                    .charge_create_ty_on_cache_hit
+                    .then_some((cached.field_count, cached.struct_count));
+                (legacy_charge, None)
+            },
+        })
     }
 
     // note(inline): do not inline, increases size a lot, might even decrease the performance
@@ -112,53 +267,95 @@ impl FrameTypeCache {
         &mut self,
         idx: VariantFieldInstantiationIndex,
         frame: &Frame,
-    ) -> PartialVMResult<((&Type, NumTypeNodes), (&Type, NumTypeNodes))> {
-        let ((field_ty, field_ty_count), (struct_ty, struct_ty_count)) =
-            get_or_insert!(&mut self.variant_field_instantiation, idx, {
-                let info = frame.variant_field_instantiation_info_at(idx);
-                let struct_type = frame.create_struct_instantiation_ty(
-                    &info.definition_struct_type,
-                    &info.instantiation,
-                )?;
-                let struct_ty_count = NumTypeNodes::new(struct_type.num_nodes() as u64);
-                let field_ty =
-                    frame.instantiate_ty(&info.uninstantiated_field_ty, &info.instantiation)?;
-                let field_ty_count = NumTypeNodes::new(field_ty.num_nodes() as u64);
-                ((field_ty, field_ty_count), (struct_type, struct_ty_count))
-            });
-        Ok(((field_ty, *field_ty_count), (struct_ty, *struct_ty_count)))
+    ) -> PartialVMResult<(&Type, &Type)> {
+        Ok(match self.struct_variant_fields.entry(idx) {
+            Entry::Vacant(e) => {
+                let cached = e.insert(CachedFieldAndStructType::for_struct_variant(idx, frame)?);
+                (&cached.field_ty, &cached.struct_ty)
+            },
+            Entry::Occupied(e) => {
+                let cached = e.into_mut();
+                (&cached.field_ty, &cached.struct_ty)
+            },
+        })
+    }
+
+    pub(crate) fn get_variant_field_type_and_struct_type_counts(
+        &mut self,
+        idx: VariantFieldInstantiationIndex,
+        frame: &Frame,
+    ) -> PartialVMResult<(Option<(NumTypeNodes, NumTypeNodes)>, Option<NumTypeNodes>)> {
+        Ok(match self.struct_variant_fields.entry(idx) {
+            Entry::Vacant(e) => {
+                let cached = e.insert(CachedFieldAndStructType::for_struct_variant(idx, frame)?);
+                if self.charge_create_ty_on_cache_hit {
+                    (Some((cached.field_count, cached.struct_count)), None)
+                } else {
+                    (None, Some(cached.counts_sum))
+                }
+            },
+            Entry::Occupied(e) => {
+                let cached = e.get();
+                let legacy_charge = self
+                    .charge_create_ty_on_cache_hit
+                    .then_some((cached.field_count, cached.struct_count));
+                (legacy_charge, None)
+            },
+        })
     }
 
     // note(inline): do not inline, increases size a lot, might even decrease the performance
+    pub(crate) fn get_struct_type_and_count(
+        &mut self,
+        idx: StructDefInstantiationIndex,
+        frame: &Frame,
+    ) -> PartialVMResult<(&Type, Option<NumTypeNodes>)> {
+        let charge_on_hit = self.charge_create_ty_on_cache_hit;
+        Ok(match self.struct_defs.entry(idx) {
+            Entry::Vacant(e) => {
+                let cached = e.insert(CachedStructType::for_struct(idx, frame)?);
+                (&cached.ty, Some(cached.count))
+            },
+            Entry::Occupied(e) => {
+                let cached = e.into_mut();
+                (&cached.ty, charge_on_hit.then_some(cached.count))
+            },
+        })
+    }
+
     pub(crate) fn get_struct_type(
         &mut self,
         idx: StructDefInstantiationIndex,
         frame: &Frame,
-    ) -> PartialVMResult<(&Type, NumTypeNodes)> {
-        let (ty, ty_count) = get_or_insert!(&mut self.struct_def_instantiation_type, idx, {
-            let ty = frame.get_generic_struct_ty(idx)?;
-            let ty_count = NumTypeNodes::new(ty.num_nodes() as u64);
-            (ty, ty_count)
-        });
-        Ok((ty, *ty_count))
+    ) -> PartialVMResult<&Type> {
+        Ok(self.get_struct_type_and_count(idx, frame)?.0)
     }
 
     // note(inline): do not inline, increases size a lot, might even decrease the performance
+    pub(crate) fn get_struct_variant_type_and_count(
+        &mut self,
+        idx: StructVariantInstantiationIndex,
+        frame: &Frame,
+    ) -> PartialVMResult<(&Type, Option<NumTypeNodes>)> {
+        let charge_on_hit = self.charge_create_ty_on_cache_hit;
+        Ok(match self.struct_variant_defs.entry(idx) {
+            Entry::Vacant(e) => {
+                let cached = e.insert(CachedStructType::for_struct_variant(idx, frame)?);
+                (&cached.ty, Some(cached.count))
+            },
+            Entry::Occupied(e) => {
+                let cached = e.into_mut();
+                (&cached.ty, charge_on_hit.then_some(cached.count))
+            },
+        })
+    }
+
     pub(crate) fn get_struct_variant_type(
         &mut self,
         idx: StructVariantInstantiationIndex,
         frame: &Frame,
-    ) -> PartialVMResult<(&Type, NumTypeNodes)> {
-        let (ty, ty_count) = get_or_insert!(&mut self.struct_variant_instantiation_type, idx, {
-            let info = frame.get_struct_variant_instantiation_at(idx);
-            let ty = frame.create_struct_instantiation_ty(
-                &info.definition_struct_type,
-                &info.instantiation,
-            )?;
-            let ty_count = NumTypeNodes::new(ty.num_nodes() as u64);
-            (ty, ty_count)
-        });
-        Ok((ty, *ty_count))
+    ) -> PartialVMResult<&Type> {
+        Ok(self.get_struct_variant_type_and_count(idx, frame)?.0)
     }
 
     // note(inline): do not inline, increases size a lot, might even decrease the performance
@@ -166,21 +363,38 @@ impl FrameTypeCache {
         &mut self,
         idx: StructDefInstantiationIndex,
         frame: &Frame,
-    ) -> PartialVMResult<&[(Type, NumTypeNodes)]> {
-        Ok(get_or_insert!(
-            &mut self.struct_field_type_instantiation,
-            idx,
-            {
-                frame
-                    .instantiate_generic_struct_fields(idx)?
-                    .into_iter()
-                    .map(|ty| {
-                        let num_nodes = NumTypeNodes::new(ty.num_nodes() as u64);
-                        (ty, num_nodes)
-                    })
-                    .collect::<Vec<_>>()
-            }
-        ))
+    ) -> PartialVMResult<&[Type]> {
+        Ok(match self.struct_def_fields.entry(idx) {
+            Entry::Vacant(e) => e
+                .insert(CachedFieldTypes::for_struct_fields(idx, frame)?)
+                .types
+                .as_slice(),
+            Entry::Occupied(e) => e.into_mut().types.as_slice(),
+        })
+    }
+
+    pub(crate) fn get_struct_fields_type_counts_and_sum(
+        &mut self,
+        idx: StructDefInstantiationIndex,
+        frame: &Frame,
+    ) -> PartialVMResult<(&[NumTypeNodes], Option<NumTypeNodes>)> {
+        Ok(match self.struct_def_fields.entry(idx) {
+            Entry::Vacant(e) => {
+                let cached = e.insert(CachedFieldTypes::for_struct_fields(idx, frame)?);
+                if self.charge_create_ty_on_cache_hit {
+                    (cached.counts.as_slice(), None)
+                } else {
+                    (&[], Some(cached.counts_sum))
+                }
+            },
+            Entry::Occupied(e) => {
+                if self.charge_create_ty_on_cache_hit {
+                    (e.into_mut().counts.as_slice(), None)
+                } else {
+                    (&[], None)
+                }
+            },
+        })
     }
 
     // note(inline): do not inline, increases size a lot, might even decrease the performance
@@ -188,47 +402,94 @@ impl FrameTypeCache {
         &mut self,
         idx: StructVariantInstantiationIndex,
         frame: &Frame,
-    ) -> PartialVMResult<&[(Type, NumTypeNodes)]> {
-        Ok(get_or_insert!(
-            &mut self.struct_variant_field_type_instantiation,
-            idx,
-            {
-                frame
-                    .instantiate_generic_struct_variant_fields(idx)?
-                    .into_iter()
-                    .map(|ty| {
-                        let num_nodes = NumTypeNodes::new(ty.num_nodes() as u64);
-                        (ty, num_nodes)
-                    })
-                    .collect::<Vec<_>>()
-            }
-        ))
+    ) -> PartialVMResult<&[Type]> {
+        Ok(match self.struct_variant_def_fields.entry(idx) {
+            Entry::Vacant(e) => e
+                .insert(CachedFieldTypes::for_struct_variant_fields(idx, frame)?)
+                .types
+                .as_slice(),
+            Entry::Occupied(e) => e.into_mut().types.as_slice(),
+        })
+    }
+
+    pub(crate) fn get_struct_variant_fields_type_counts_and_sum(
+        &mut self,
+        idx: StructVariantInstantiationIndex,
+        frame: &Frame,
+    ) -> PartialVMResult<(&[NumTypeNodes], Option<NumTypeNodes>)> {
+        Ok(match self.struct_variant_def_fields.entry(idx) {
+            Entry::Vacant(e) => {
+                let cached = e.insert(CachedFieldTypes::for_struct_variant_fields(idx, frame)?);
+                if self.charge_create_ty_on_cache_hit {
+                    (cached.counts.as_slice(), None)
+                } else {
+                    (&[], Some(cached.counts_sum))
+                }
+            },
+            Entry::Occupied(e) => {
+                if self.charge_create_ty_on_cache_hit {
+                    (e.into_mut().counts.as_slice(), None)
+                } else {
+                    (&[], None)
+                }
+            },
+        })
     }
 
     // note(inline): do not inline, increases size a lot, might even decrease the performance
-    /// Returns a tuple of (Type, NumTypeNodes, depth) for the signature at the given index.
-    /// The Type is the instantiated type, NumTypeNodes is the node count for gas metering,
-    /// and depth is the maximum depth of the type tree.
+    /// Returns a tuple of fully-instantiated runtime type, number of nodes in
+    /// it (for gas metering), a boolean to indicate if this was a cache miss
+    /// (for gas metering), and its depth for the signature at the given index.
+    pub(crate) fn get_signature_index_type_and_count_and_depth(
+        &mut self,
+        idx: SignatureIndex,
+        frame: &Frame,
+    ) -> PartialVMResult<(&Type, NumTypeNodes, bool, usize)> {
+        Ok(match self.signatures.entry(idx) {
+            Entry::Vacant(e) => {
+                let cached = e.insert(CachedSignatureType::new(idx, frame)?);
+                (&cached.ty, cached.count, true, cached.depth)
+            },
+            Entry::Occupied(e) => {
+                let cached = e.into_mut();
+                (&cached.ty, cached.count, false, cached.depth)
+            },
+        })
+    }
+
     pub(crate) fn get_signature_index_type(
         &mut self,
         idx: SignatureIndex,
         frame: &Frame,
-    ) -> PartialVMResult<(&Type, NumTypeNodes, usize)> {
-        let (ty, ty_count, depth) = get_or_insert!(&mut self.single_sig_token_type, idx, {
-            let ty = frame.instantiate_single_type(idx)?;
-            let (ty_count, depth) = ty.num_nodes_with_max_depth();
-            let ty_count = NumTypeNodes::new(ty_count as u64);
-            (ty, ty_count, depth)
-        });
-        Ok((ty, *ty_count, *depth))
+    ) -> PartialVMResult<&Type> {
+        Ok(self
+            .get_signature_index_type_and_count_and_depth(idx, frame)?
+            .0)
     }
 
-    pub(crate) fn make_rc() -> Rc<RefCell<Self>> {
-        Rc::new(RefCell::<Self>::new(Default::default()))
+    pub(crate) fn get_signature_index_type_count(
+        &mut self,
+        idx: SignatureIndex,
+        frame: &Frame,
+    ) -> PartialVMResult<Option<NumTypeNodes>> {
+        let (_, count, is_miss, _) =
+            self.get_signature_index_type_and_count_and_depth(idx, frame)?;
+        Ok((self.charge_create_ty_on_cache_hit || is_miss).then_some(count))
     }
 
-    pub(crate) fn make_rc_for_function(function: &LoadedFunction) -> Rc<RefCell<Self>> {
-        let frame_cache = Rc::new(RefCell::<Self>::new(Default::default()));
+    pub(crate) fn make_rc(charge_create_ty_on_cache_hit: bool) -> Rc<RefCell<Self>> {
+        Rc::new(RefCell::new(FrameTypeCache::empty(
+            charge_create_ty_on_cache_hit,
+        )))
+    }
+
+    pub(crate) fn make_rc_for_function(
+        function: &LoadedFunction,
+        charge_create_ty_on_cache_hit: bool,
+    ) -> Rc<RefCell<Self>> {
+        let frame_cache = Rc::new(RefCell::new(FrameTypeCache::empty(
+            charge_create_ty_on_cache_hit,
+        )));
 
         frame_cache
             .borrow_mut()

--- a/third_party/move/move-vm/runtime/src/frame_type_cache.rs
+++ b/third_party/move/move-vm/runtime/src/frame_type_cache.rs
@@ -191,8 +191,8 @@ pub(crate) struct FrameTypeCache {
 
     /// Cached instantiated local types for generic functions.
     pub(crate) instantiated_local_tys: Option<Rc<[Type]>>,
-    /// Cached number of type nodes per instantiated local type for gas charging re-use.
-    pub(crate) instantiated_local_ty_counts: Option<Rc<[NumTypeNodes]>>,
+    /// Cached number of type nodes per local type for gas charging re-use.
+    pub(crate) local_ty_counts: Option<Rc<[NumTypeNodes]>>,
 
     /// Governs how type sizes are returned from cache APIs for gas metering.
     /// If true, charging is suboptimal (charge on cache hit, multiple charges
@@ -215,7 +215,7 @@ impl FrameTypeCache {
             function_cache: BTreeMap::new(),
             generic_function_cache: BTreeMap::new(),
             instantiated_local_tys: None,
-            instantiated_local_ty_counts: None,
+            local_ty_counts: None,
             charge_create_ty_on_cache_hit,
         }
     }

--- a/third_party/move/move-vm/runtime/src/interpreter.rs
+++ b/third_party/move/move-vm/runtime/src/interpreter.rs
@@ -365,7 +365,7 @@ where
         let frame_cache = if self.vm_config.enable_function_caches {
             function_caches.get_or_create_frame_cache(&function)
         } else {
-            FrameTypeCache::make_rc()
+            FrameTypeCache::make_rc(self.vm_config.charge_create_ty_on_cache_hit)
         };
         let mut current_frame = Frame::make_new_frame::<RTTCheck>(
             gas_meter,
@@ -494,7 +494,8 @@ where
                             &current_frame,
                             fh_idx,
                         )?);
-                        let frame_cache = FrameTypeCache::make_rc();
+                        let frame_cache =
+                            FrameTypeCache::make_rc(self.vm_config.charge_create_ty_on_cache_hit);
                         (function, frame_cache)
                     };
 
@@ -607,7 +608,8 @@ where
                             &current_frame,
                             idx,
                         )?);
-                        let frame_cache = FrameTypeCache::make_rc();
+                        let frame_cache =
+                            FrameTypeCache::make_rc(self.vm_config.charge_create_ty_on_cache_hit);
                         (function, frame_cache)
                     };
 
@@ -800,7 +802,7 @@ where
                         let frame_cache = if self.vm_config.enable_function_caches {
                             function_caches.get_or_create_frame_cache(&callee)
                         } else {
-                            FrameTypeCache::make_rc()
+                            FrameTypeCache::make_rc(self.vm_config.charge_create_ty_on_cache_hit)
                         };
                         self.set_new_call_frame::<RTTCheck, RTRCheck>(
                             &mut current_frame,
@@ -1312,7 +1314,7 @@ where
                 {
                     function_caches.get_or_create_frame_cache(&target_func)
                 } else {
-                    FrameTypeCache::make_rc()
+                    FrameTypeCache::make_rc(self.vm_config.charge_create_ty_on_cache_hit)
                 };
                 self.set_new_call_frame::<RTTCheck, RTRCheck>(
                     current_frame,
@@ -2324,15 +2326,15 @@ impl Frame {
                     },
                     Instruction::ImmBorrowFieldGeneric(fi_idx)
                     | Instruction::MutBorrowFieldGeneric(fi_idx) => {
-                        // TODO: Even though the types are not needed for execution, we still
-                        //       instantiate them for gas metering.
-                        //
-                        //       This is a bit wasteful since the newly created types are
-                        //       dropped immediately.
-                        let ((_, field_ty_count), (_, struct_ty_count)) =
-                            frame_cache.get_field_type_and_struct_type(*fi_idx, self)?;
-                        gas_meter.charge_create_ty(struct_ty_count)?;
-                        gas_meter.charge_create_ty(field_ty_count)?;
+                        let (legacy_counts, sum) =
+                            frame_cache.get_field_type_and_struct_type_counts(*fi_idx, self)?;
+                        if let Some((field_count, struct_count)) = legacy_counts {
+                            gas_meter.charge_create_ty(struct_count)?;
+                            gas_meter.charge_create_ty(field_count)?;
+                        }
+                        if let Some(sum) = sum {
+                            gas_meter.charge_create_ty(sum)?;
+                        }
 
                         let instr = if matches!(instruction, Instruction::MutBorrowFieldGeneric(_))
                         {
@@ -2373,15 +2375,15 @@ impl Frame {
                     },
                     Instruction::ImmBorrowVariantFieldGeneric(fi_idx)
                     | Instruction::MutBorrowVariantFieldGeneric(fi_idx) => {
-                        // TODO: Even though the types are not needed for execution, we still
-                        //       instantiate them for gas metering.
-                        //
-                        //       This is a bit wasteful since the newly created types are
-                        //       dropped immediately.
-                        let ((_, field_ty_count), (_, struct_ty_count)) =
-                            frame_cache.get_variant_field_type_and_struct_type(*fi_idx, self)?;
-                        gas_meter.charge_create_ty(struct_ty_count)?;
-                        gas_meter.charge_create_ty(field_ty_count)?;
+                        let (legacy_counts, sum) = frame_cache
+                            .get_variant_field_type_and_struct_type_counts(*fi_idx, self)?;
+                        if let Some((field_count, struct_count)) = legacy_counts {
+                            gas_meter.charge_create_ty(struct_count)?;
+                            gas_meter.charge_create_ty(field_count)?;
+                        }
+                        if let Some(sum) = sum {
+                            gas_meter.charge_create_ty(sum)?;
+                        }
 
                         let instr = match instruction {
                             Instruction::MutBorrowVariantFieldGeneric(_) => {
@@ -2442,18 +2444,19 @@ impl Frame {
                             .push(Value::struct_(Struct::pack_variant(info.variant, args)))?;
                     },
                     Instruction::PackGeneric(si_idx) => {
-                        // TODO: Even though the types are not needed for execution, we still
-                        //       instantiate them for gas metering.
-                        //
-                        //       This is a bit wasteful since the newly created types are
-                        //       dropped immediately.
-                        let field_tys = frame_cache.get_struct_fields_types(*si_idx, self)?;
-                        for (_, ty_count) in field_tys {
-                            gas_meter.charge_create_ty(*ty_count)?;
+                        let (counts, sum) =
+                            frame_cache.get_struct_fields_type_counts_and_sum(*si_idx, self)?;
+                        for count in counts {
+                            gas_meter.charge_create_ty(*count)?;
+                        }
+                        if let Some(sum) = sum {
+                            gas_meter.charge_create_ty(sum)?;
                         }
 
-                        let (ty, ty_count) = frame_cache.get_struct_type(*si_idx, self)?;
-                        gas_meter.charge_create_ty(ty_count)?;
+                        let (ty, count) = frame_cache.get_struct_type_and_count(*si_idx, self)?;
+                        if let Some(count) = count {
+                            gas_meter.charge_create_ty(count)?;
+                        }
                         interpreter.ty_depth_checker.check_depth_of_type(
                             gas_meter,
                             traversal_context,
@@ -2471,15 +2474,20 @@ impl Frame {
                             .push(Value::struct_(Struct::pack(args)))?;
                     },
                     Instruction::PackVariantGeneric(si_idx) => {
-                        let field_tys =
-                            frame_cache.get_struct_variant_fields_types(*si_idx, self)?;
-
-                        for (_, ty_count) in field_tys {
-                            gas_meter.charge_create_ty(*ty_count)?;
+                        let (counts, sum) = frame_cache
+                            .get_struct_variant_fields_type_counts_and_sum(*si_idx, self)?;
+                        for count in counts {
+                            gas_meter.charge_create_ty(*count)?;
+                        }
+                        if let Some(sum) = sum {
+                            gas_meter.charge_create_ty(sum)?;
                         }
 
-                        let (ty, ty_count) = frame_cache.get_struct_variant_type(*si_idx, self)?;
-                        gas_meter.charge_create_ty(ty_count)?;
+                        let (ty, count) =
+                            frame_cache.get_struct_variant_type_and_count(*si_idx, self)?;
+                        if let Some(count) = count {
+                            gas_meter.charge_create_ty(count)?;
+                        }
                         interpreter.ty_depth_checker.check_depth_of_type(
                             gas_meter,
                             traversal_context,
@@ -2539,20 +2547,19 @@ impl Frame {
                         }
                     },
                     Instruction::UnpackGeneric(si_idx) => {
-                        // TODO: Even though the types are not needed for execution, we still
-                        //       instantiate them for gas metering.
-                        //
-                        //       This is a bit wasteful since the newly created types are
-                        //       dropped immediately.
-                        let ty_and_field_counts =
-                            frame_cache.get_struct_fields_types(*si_idx, self)?;
-                        let num_expected_fields = ty_and_field_counts.len();
-                        for (_, ty_count) in ty_and_field_counts {
-                            gas_meter.charge_create_ty(*ty_count)?;
+                        let (counts, sum) =
+                            frame_cache.get_struct_fields_type_counts_and_sum(*si_idx, self)?;
+                        for count in counts {
+                            gas_meter.charge_create_ty(*count)?;
+                        }
+                        if let Some(sum) = sum {
+                            gas_meter.charge_create_ty(sum)?;
                         }
 
-                        let (_, ty_count) = frame_cache.get_struct_type(*si_idx, self)?;
-                        gas_meter.charge_create_ty(ty_count)?;
+                        let (_, count) = frame_cache.get_struct_type_and_count(*si_idx, self)?;
+                        if let Some(count) = count {
+                            gas_meter.charge_create_ty(count)?;
+                        }
 
                         let struct_ = interpreter.operand_stack.pop_as::<Struct>()?;
                         gas_meter.charge_unpack(true, struct_.field_views())?;
@@ -2561,6 +2568,8 @@ impl Frame {
                         for value in struct_.unpack()? {
                             interpreter.operand_stack.push(value)?;
                         }
+
+                        let num_expected_fields = self.field_instantiation_count(*si_idx) as usize;
                         let num_actual_fields =
                             interpreter.operand_stack.value.len() - operand_stack_size_before;
                         if num_expected_fields != num_actual_fields {
@@ -2571,14 +2580,20 @@ impl Frame {
                         }
                     },
                     Instruction::UnpackVariantGeneric(si_idx) => {
-                        let ty_and_field_counts =
-                            frame_cache.get_struct_variant_fields_types(*si_idx, self)?;
-                        for (_, ty_count) in ty_and_field_counts {
-                            gas_meter.charge_create_ty(*ty_count)?;
+                        let (counts, sum) = frame_cache
+                            .get_struct_variant_fields_type_counts_and_sum(*si_idx, self)?;
+                        for count in counts {
+                            gas_meter.charge_create_ty(*count)?;
+                        }
+                        if let Some(sum) = sum {
+                            gas_meter.charge_create_ty(sum)?;
                         }
 
-                        let (_, ty_count) = frame_cache.get_struct_variant_type(*si_idx, self)?;
-                        gas_meter.charge_create_ty(ty_count)?;
+                        let (_, count) =
+                            frame_cache.get_struct_variant_type_and_count(*si_idx, self)?;
+                        if let Some(count) = count {
+                            gas_meter.charge_create_ty(count)?;
+                        }
 
                         let struct_ = interpreter.operand_stack.pop_as::<Struct>()?;
                         gas_meter.charge_unpack_variant(true, struct_.field_views())?;
@@ -2610,14 +2625,11 @@ impl Frame {
                             .push(reference.test_variant(info.variant)?)?;
                     },
                     Instruction::TestVariantGeneric(sd_idx) => {
-                        // TODO: Even though the types are not needed for execution, we still
-                        //       instantiate them for gas metering.
-                        //
-                        //       This is a bit wasteful since the newly created types are
-                        //       dropped immediately.
-                        let (_, struct_ty_count) =
-                            frame_cache.get_struct_variant_type(*sd_idx, self)?;
-                        gas_meter.charge_create_ty(struct_ty_count)?;
+                        let (_, count) =
+                            frame_cache.get_struct_variant_type_and_count(*sd_idx, self)?;
+                        if let Some(count) = count {
+                            gas_meter.charge_create_ty(count)?;
+                        }
 
                         let reference = interpreter.operand_stack.pop_as::<StructRef>()?;
                         gas_meter.charge_simple_instr(S::TestVariantGeneric)?;
@@ -2995,8 +3007,11 @@ impl Frame {
                     | Instruction::ImmBorrowGlobalGeneric(si_idx) => {
                         let is_mut = matches!(instruction, Instruction::MutBorrowGlobalGeneric(_));
                         let addr = interpreter.operand_stack.pop_as::<AccountAddress>()?;
-                        let (ty, ty_count) = frame_cache.get_struct_type(*si_idx, self)?;
-                        gas_meter.charge_create_ty(ty_count)?;
+                        let (ty, ty_charge) =
+                            frame_cache.get_struct_type_and_count(*si_idx, self)?;
+                        if let Some(count) = ty_charge {
+                            gas_meter.charge_create_ty(count)?;
+                        }
                         interpreter.borrow_global(
                             is_mut,
                             true,
@@ -3021,8 +3036,11 @@ impl Frame {
                     },
                     Instruction::ExistsGeneric(si_idx) => {
                         let addr = interpreter.operand_stack.pop_as::<AccountAddress>()?;
-                        let (ty, ty_count) = frame_cache.get_struct_type(*si_idx, self)?;
-                        gas_meter.charge_create_ty(ty_count)?;
+                        let (ty, ty_charge) =
+                            frame_cache.get_struct_type_and_count(*si_idx, self)?;
+                        if let Some(count) = ty_charge {
+                            gas_meter.charge_create_ty(count)?;
+                        }
                         interpreter.exists(
                             true,
                             data_cache,
@@ -3046,8 +3064,11 @@ impl Frame {
                     },
                     Instruction::MoveFromGeneric(si_idx) => {
                         let addr = interpreter.operand_stack.pop_as::<AccountAddress>()?;
-                        let (ty, ty_count) = frame_cache.get_struct_type(*si_idx, self)?;
-                        gas_meter.charge_create_ty(ty_count)?;
+                        let (ty, ty_charge) =
+                            frame_cache.get_struct_type_and_count(*si_idx, self)?;
+                        if let Some(count) = ty_charge {
+                            gas_meter.charge_create_ty(count)?;
+                        }
                         interpreter.move_from(
                             true,
                             data_cache,
@@ -3084,8 +3105,11 @@ impl Frame {
                             .value_as::<Reference>()?
                             .read_ref()?
                             .value_as::<AccountAddress>()?;
-                        let (ty, ty_count) = frame_cache.get_struct_type(*si_idx, self)?;
-                        gas_meter.charge_create_ty(ty_count)?;
+                        let (ty, ty_charge) =
+                            frame_cache.get_struct_type_and_count(*si_idx, self)?;
+                        if let Some(count) = ty_charge {
+                            gas_meter.charge_create_ty(count)?;
+                        }
                         interpreter.move_to(
                             true,
                             data_cache,
@@ -3110,16 +3134,20 @@ impl Frame {
                         gas_meter.charge_simple_instr(S::Nop)?;
                     },
                     Instruction::VecPack(si, num) => {
-                        let (ty, ty_count, depth) =
-                            frame_cache.get_signature_index_type(*si, self)?;
+                        let charge_create_ty_on_cache_hit =
+                            frame_cache.charge_create_ty_on_cache_hit;
+                        let (ty, count, is_miss, depth) =
+                            frame_cache.get_signature_index_type_and_count_and_depth(*si, self)?;
                         if self.ty_builder.check_depth_on_type_counts_v2 {
                             // Account for new vector node.
                             self.ty_builder.check_final_size_and_depth(
-                                u64::from(ty_count) + 1,
+                                u64::from(count) + 1,
                                 depth as u64 + 1,
                             )?;
                         }
-                        gas_meter.charge_create_ty(ty_count)?;
+                        if charge_create_ty_on_cache_hit || is_miss {
+                            gas_meter.charge_create_ty(count)?;
+                        }
                         interpreter.ty_depth_checker.check_depth_of_type(
                             gas_meter,
                             traversal_context,
@@ -3133,8 +3161,11 @@ impl Frame {
                     },
                     Instruction::VecLen(si) => {
                         let vec_ref = interpreter.operand_stack.pop_as::<VectorRef>()?;
-                        let (_, ty_count, _) = frame_cache.get_signature_index_type(*si, self)?;
-                        gas_meter.charge_create_ty(ty_count)?;
+                        if let Some(count) =
+                            frame_cache.get_signature_index_type_count(*si, self)?
+                        {
+                            gas_meter.charge_create_ty(count)?;
+                        }
                         gas_meter.charge_vec_len()?;
                         let value = vec_ref.len()?;
                         interpreter.operand_stack.push(value)?;
@@ -3142,8 +3173,11 @@ impl Frame {
                     Instruction::VecImmBorrow(si) => {
                         let idx = interpreter.operand_stack.pop_as::<u64>()? as usize;
                         let vec_ref = interpreter.operand_stack.pop_as::<VectorRef>()?;
-                        let (_, ty_count, _) = frame_cache.get_signature_index_type(*si, self)?;
-                        gas_meter.charge_create_ty(ty_count)?;
+                        if let Some(count) =
+                            frame_cache.get_signature_index_type_count(*si, self)?
+                        {
+                            gas_meter.charge_create_ty(count)?;
+                        }
                         gas_meter.charge_vec_borrow(false)?;
                         let elem = vec_ref.borrow_elem(idx)?;
                         interpreter.operand_stack.push(elem)?;
@@ -3151,8 +3185,11 @@ impl Frame {
                     Instruction::VecMutBorrow(si) => {
                         let idx = interpreter.operand_stack.pop_as::<u64>()? as usize;
                         let vec_ref = interpreter.operand_stack.pop_as::<VectorRef>()?;
-                        let (_, ty_count, _) = frame_cache.get_signature_index_type(*si, self)?;
-                        gas_meter.charge_create_ty(ty_count)?;
+                        if let Some(count) =
+                            frame_cache.get_signature_index_type_count(*si, self)?
+                        {
+                            gas_meter.charge_create_ty(count)?;
+                        }
                         gas_meter.charge_vec_borrow(true)?;
                         let elem = vec_ref.borrow_elem(idx)?;
                         interpreter.operand_stack.push(elem)?;
@@ -3160,23 +3197,32 @@ impl Frame {
                     Instruction::VecPushBack(si) => {
                         let elem = interpreter.operand_stack.pop()?;
                         let vec_ref = interpreter.operand_stack.pop_as::<VectorRef>()?;
-                        let (_, ty_count, _) = frame_cache.get_signature_index_type(*si, self)?;
-                        gas_meter.charge_create_ty(ty_count)?;
+                        if let Some(count) =
+                            frame_cache.get_signature_index_type_count(*si, self)?
+                        {
+                            gas_meter.charge_create_ty(count)?;
+                        }
                         gas_meter.charge_vec_push_back(&elem)?;
                         vec_ref.push_back(elem)?;
                     },
                     Instruction::VecPopBack(si) => {
                         let vec_ref = interpreter.operand_stack.pop_as::<VectorRef>()?;
-                        let (_, ty_count, _) = frame_cache.get_signature_index_type(*si, self)?;
-                        gas_meter.charge_create_ty(ty_count)?;
+                        if let Some(count) =
+                            frame_cache.get_signature_index_type_count(*si, self)?
+                        {
+                            gas_meter.charge_create_ty(count)?;
+                        }
                         let res = vec_ref.pop();
                         gas_meter.charge_vec_pop_back(res.as_ref().ok())?;
                         interpreter.operand_stack.push(res?)?;
                     },
                     Instruction::VecUnpack(si, num) => {
                         let vec_val = interpreter.operand_stack.pop_as::<Vector>()?;
-                        let (_, ty_count, _) = frame_cache.get_signature_index_type(*si, self)?;
-                        gas_meter.charge_create_ty(ty_count)?;
+                        if let Some(count) =
+                            frame_cache.get_signature_index_type_count(*si, self)?
+                        {
+                            gas_meter.charge_create_ty(count)?;
+                        }
                         gas_meter.charge_vec_unpack(NumArgs::new(*num), vec_val.elem_views())?;
                         let elements = vec_val.unpack(*num)?;
                         for value in elements {
@@ -3187,8 +3233,11 @@ impl Frame {
                         let idx2 = interpreter.operand_stack.pop_as::<u64>()? as usize;
                         let idx1 = interpreter.operand_stack.pop_as::<u64>()? as usize;
                         let vec_ref = interpreter.operand_stack.pop_as::<VectorRef>()?;
-                        let (_, ty_count, _) = frame_cache.get_signature_index_type(*si, self)?;
-                        gas_meter.charge_create_ty(ty_count)?;
+                        if let Some(count) =
+                            frame_cache.get_signature_index_type_count(*si, self)?
+                        {
+                            gas_meter.charge_create_ty(count)?;
+                        }
                         gas_meter.charge_vec_swap()?;
                         vec_ref.swap(idx1, idx2)?;
                     },

--- a/third_party/move/move-vm/runtime/src/interpreter_caches.rs
+++ b/third_party/move/move-vm/runtime/src/interpreter_caches.rs
@@ -17,13 +17,15 @@ use std::{cell::RefCell, collections::HashMap, rc::Rc};
 pub struct InterpreterFunctionCaches {
     function_instruction_caches: HashMap<FunctionPtr, Rc<RefCell<FrameTypeCache>>>,
     generic_function_instruction_caches: HashMap<GenericFunctionPtr, Rc<RefCell<FrameTypeCache>>>,
+    charge_create_ty_on_cache_hit: bool,
 }
 
 impl InterpreterFunctionCaches {
-    pub fn new() -> Self {
+    pub fn new(charge_create_ty_on_cache_hit: bool) -> Self {
         Self {
             function_instruction_caches: HashMap::new(),
             generic_function_instruction_caches: HashMap::new(),
+            charge_create_ty_on_cache_hit,
         }
     }
 
@@ -48,7 +50,9 @@ impl InterpreterFunctionCaches {
         let ptr = FunctionPtr::from_loaded_function(function);
         self.function_instruction_caches
             .entry(ptr)
-            .or_insert_with(|| FrameTypeCache::make_rc_for_function(function))
+            .or_insert_with(|| {
+                FrameTypeCache::make_rc_for_function(function, self.charge_create_ty_on_cache_hit)
+            })
             .clone()
     }
 
@@ -62,7 +66,9 @@ impl InterpreterFunctionCaches {
         let ptr = GenericFunctionPtr::from_loaded_function(function);
         self.generic_function_instruction_caches
             .entry(ptr)
-            .or_insert_with(|| FrameTypeCache::make_rc_for_function(function))
+            .or_insert_with(|| {
+                FrameTypeCache::make_rc_for_function(function, self.charge_create_ty_on_cache_hit)
+            })
             .clone()
     }
 }

--- a/third_party/move/move-vm/runtime/src/loader/type_loader.rs
+++ b/third_party/move/move-vm/runtime/src/loader/type_loader.rs
@@ -83,8 +83,8 @@ fn convert_tok_to_type_impl(
             let (results, results_fully_instantiated) =
                 convert_toks_to_types_impl(module, results, struct_name_table)?;
             let ty = Type::Function {
-                args,
-                results,
+                args: TriompheArc::new(args),
+                results: TriompheArc::new(results),
                 abilities: *abilities,
             };
             (ty, args_fully_instantiated && results_fully_instantiated)

--- a/third_party/move/move-vm/runtime/src/move_vm.rs
+++ b/third_party/move/move-vm/runtime/src/move_vm.rs
@@ -124,7 +124,7 @@ impl MoveVM {
                 deserialized_args,
                 data_cache,
                 // TODO(caches): async drop
-                &mut InterpreterFunctionCaches::new(),
+                &mut InterpreterFunctionCaches::new(vm_config.charge_create_ty_on_cache_hit),
                 loader,
                 &ty_depth_checker,
                 &layout_converter,

--- a/third_party/move/move-vm/runtime/src/runtime_ref_checks.rs
+++ b/third_party/move/move-vm/runtime/src/runtime_ref_checks.rs
@@ -638,7 +638,7 @@ impl RuntimeRefCheck for FullRuntimeRefCheck {
                 ref_state.borrow_global::<true>(struct_ty)?;
             },
             MutBorrowGlobalGeneric(index) => {
-                let struct_ty = ty_cache.get_struct_type(*index, frame)?.0;
+                let struct_ty = ty_cache.get_struct_type(*index, frame)?;
                 ref_state.borrow_global::<true>(struct_ty.clone())?;
             },
             ImmBorrowGlobal(index) => {
@@ -646,7 +646,7 @@ impl RuntimeRefCheck for FullRuntimeRefCheck {
                 ref_state.borrow_global::<false>(struct_ty)?;
             },
             ImmBorrowGlobalGeneric(index) => {
-                let struct_ty = ty_cache.get_struct_type(*index, frame)?.0;
+                let struct_ty = ty_cache.get_struct_type(*index, frame)?;
                 ref_state.borrow_global::<false>(struct_ty.clone())?;
             },
             Add | Sub | Mul | Mod | Div | BitOr | BitAnd | Xor | Or | And | Lt | Gt | Le | Ge
@@ -676,7 +676,7 @@ impl RuntimeRefCheck for FullRuntimeRefCheck {
                 ref_state.move_from(struct_ty)?;
             },
             MoveFromGeneric(index) => {
-                let struct_ty = ty_cache.get_struct_type(*index, frame)?.0;
+                let struct_ty = ty_cache.get_struct_type(*index, frame)?;
                 ref_state.move_from(struct_ty.clone())?;
             },
             MoveTo(_) => {

--- a/third_party/move/move-vm/runtime/src/runtime_type_checks.rs
+++ b/third_party/move/move-vm/runtime/src/runtime_type_checks.rs
@@ -15,6 +15,7 @@ use move_vm_types::{
     instr::Instruction,
     loaded_data::runtime_types::{Type, TypeBuilder},
 };
+use triomphe::Arc as TriompheArc;
 
 pub(crate) trait RuntimeTypeCheck {
     /// Paranoid type checks to perform before instruction execution.
@@ -169,8 +170,8 @@ pub(crate) fn create_function_type(
         .map(|ret| with_owned_instantiation(ty_builder, func, ret, Ok))
         .collect::<PartialVMResult<Vec<_>>>()?;
     Ok(Type::Function {
-        args,
-        results,
+        args: TriompheArc::new(args),
+        results: TriompheArc::new(results),
         abilities,
     })
 }

--- a/third_party/move/move-vm/runtime/src/runtime_type_checks.rs
+++ b/third_party/move/move-vm/runtime/src/runtime_type_checks.rs
@@ -296,7 +296,7 @@ impl RuntimeTypeCheck for FullRuntimeTypeCheck {
                 // top of the stack. The argument types are checked when the frame
                 // is constructed in the interpreter, using the same code as for regular
                 // calls.
-                let (expected_ty, _, _) = ty_cache.get_signature_index_type(*sig_idx, frame)?;
+                let expected_ty = ty_cache.get_signature_index_type(*sig_idx, frame)?;
                 let given_ty = operand_stack.pop_ty()?;
                 given_ty.paranoid_check_assignable(expected_ty)?;
             },
@@ -554,7 +554,7 @@ impl RuntimeTypeCheck for FullRuntimeTypeCheck {
             },
             Instruction::ImmBorrowFieldGeneric(idx) => {
                 let struct_ty = operand_stack.pop_ty()?;
-                let ((field_ty, _), (expected_struct_ty, _)) =
+                let (field_ty, expected_struct_ty) =
                     ty_cache.get_field_type_and_struct_type(*idx, frame)?;
                 struct_ty.paranoid_check_ref_eq(expected_struct_ty, false)?;
 
@@ -563,7 +563,7 @@ impl RuntimeTypeCheck for FullRuntimeTypeCheck {
             },
             Instruction::MutBorrowFieldGeneric(idx) => {
                 let struct_ty = operand_stack.pop_ty()?;
-                let ((field_ty, _), (expected_struct_ty, _)) =
+                let (field_ty, expected_struct_ty) =
                     ty_cache.get_field_type_and_struct_type(*idx, frame)?;
                 struct_ty.paranoid_check_ref_eq(expected_struct_ty, true)?;
 
@@ -585,7 +585,7 @@ impl RuntimeTypeCheck for FullRuntimeTypeCheck {
             | Instruction::MutBorrowVariantFieldGeneric(idx) => {
                 let is_mut = matches!(instruction, Instruction::MutBorrowVariantFieldGeneric(..));
                 let struct_ty = operand_stack.pop_ty()?;
-                let ((field_ty, _), (expected_struct_ty, _)) =
+                let (field_ty, expected_struct_ty) =
                     ty_cache.get_variant_field_type_and_struct_type(*idx, frame)?;
                 struct_ty.paranoid_check_ref_eq(expected_struct_ty, is_mut)?;
                 let field_ref_ty = ty_builder.create_ref_ty(field_ty, is_mut)?;
@@ -604,7 +604,7 @@ impl RuntimeTypeCheck for FullRuntimeTypeCheck {
             },
             Instruction::PackGeneric(idx) => {
                 let field_count = frame.field_instantiation_count(*idx);
-                let output_ty = ty_cache.get_struct_type(*idx, frame)?.0.clone();
+                let output_ty = ty_cache.get_struct_type(*idx, frame)?.clone();
                 let args_ty = ty_cache.get_struct_fields_types(*idx, frame)?;
 
                 if field_count as usize != args_ty.len() {
@@ -618,12 +618,7 @@ impl RuntimeTypeCheck for FullRuntimeTypeCheck {
                     );
                 }
 
-                verify_pack(
-                    operand_stack,
-                    field_count,
-                    args_ty.iter().map(|(ty, _)| ty),
-                    output_ty,
-                )?;
+                verify_pack(operand_stack, field_count, args_ty.iter(), output_ty)?;
             },
             Instruction::Unpack(idx) => {
                 let struct_ty = operand_stack.pop_ty()?;
@@ -636,10 +631,10 @@ impl RuntimeTypeCheck for FullRuntimeTypeCheck {
             Instruction::UnpackGeneric(idx) => {
                 let struct_ty = operand_stack.pop_ty()?;
 
-                struct_ty.paranoid_check_eq(ty_cache.get_struct_type(*idx, frame)?.0)?;
+                struct_ty.paranoid_check_eq(ty_cache.get_struct_type(*idx, frame)?)?;
 
                 let struct_fields_types = ty_cache.get_struct_fields_types(*idx, frame)?;
-                for (ty, _) in struct_fields_types {
+                for ty in struct_fields_types {
                     operand_stack.push_ty(ty.clone())?;
                 }
             },
@@ -655,14 +650,9 @@ impl RuntimeTypeCheck for FullRuntimeTypeCheck {
             },
             Instruction::PackVariantGeneric(idx) => {
                 let info = frame.get_struct_variant_instantiation_at(*idx);
-                let output_ty = ty_cache.get_struct_variant_type(*idx, frame)?.0.clone();
+                let output_ty = ty_cache.get_struct_variant_type(*idx, frame)?.clone();
                 let args_ty = ty_cache.get_struct_variant_fields_types(*idx, frame)?;
-                verify_pack(
-                    operand_stack,
-                    info.field_count,
-                    args_ty.iter().map(|(ty, _)| ty),
-                    output_ty,
-                )?;
+                verify_pack(operand_stack, info.field_count, args_ty.iter(), output_ty)?;
             },
             Instruction::UnpackVariant(idx) => {
                 let info = frame.get_struct_variant_at(*idx);
@@ -678,11 +668,11 @@ impl RuntimeTypeCheck for FullRuntimeTypeCheck {
                 }
             },
             Instruction::UnpackVariantGeneric(idx) => {
-                let expected_struct_type = ty_cache.get_struct_variant_type(*idx, frame)?.0;
+                let expected_struct_type = ty_cache.get_struct_variant_type(*idx, frame)?;
                 let actual_struct_type = operand_stack.pop_ty()?;
                 actual_struct_type.paranoid_check_eq(expected_struct_type)?;
                 let struct_fields_types = ty_cache.get_struct_variant_fields_types(*idx, frame)?;
-                for (ty, _) in struct_fields_types {
+                for ty in struct_fields_types {
                     operand_stack.push_ty(ty.clone())?;
                 }
             },
@@ -694,7 +684,7 @@ impl RuntimeTypeCheck for FullRuntimeTypeCheck {
                 operand_stack.push_ty(ty_builder.create_bool_ty())?;
             },
             Instruction::TestVariantGeneric(idx) => {
-                let expected_struct_ty = ty_cache.get_struct_variant_type(*idx, frame)?.0;
+                let expected_struct_ty = ty_cache.get_struct_variant_type(*idx, frame)?;
                 let actual_struct_ty = operand_stack.pop_ty()?;
                 actual_struct_ty.paranoid_check_ref_eq(expected_struct_ty, false)?;
                 operand_stack.push_ty(ty_builder.create_bool_ty())?;
@@ -830,7 +820,7 @@ impl RuntimeTypeCheck for FullRuntimeTypeCheck {
             },
             Instruction::MutBorrowGlobalGeneric(idx) => {
                 operand_stack.pop_ty()?.paranoid_check_is_address_ty()?;
-                let struct_ty = ty_cache.get_struct_type(*idx, frame)?.0;
+                let struct_ty = ty_cache.get_struct_type(*idx, frame)?;
                 struct_ty.paranoid_check_has_ability(Ability::Key)?;
 
                 let struct_mut_ref_ty = ty_builder.create_ref_ty(struct_ty, true)?;
@@ -838,7 +828,7 @@ impl RuntimeTypeCheck for FullRuntimeTypeCheck {
             },
             Instruction::ImmBorrowGlobalGeneric(idx) => {
                 operand_stack.pop_ty()?.paranoid_check_is_address_ty()?;
-                let struct_ty = ty_cache.get_struct_type(*idx, frame)?.0;
+                let struct_ty = ty_cache.get_struct_type(*idx, frame)?;
                 struct_ty.paranoid_check_has_ability(Ability::Key)?;
 
                 let struct_ref_ty = ty_builder.create_ref_ty(struct_ty, false)?;
@@ -865,7 +855,7 @@ impl RuntimeTypeCheck for FullRuntimeTypeCheck {
             Instruction::MoveToGeneric(idx) => {
                 let ty = operand_stack.pop_ty()?;
                 operand_stack.pop_ty()?.paranoid_check_is_signer_ref_ty()?;
-                ty.paranoid_check_eq(ty_cache.get_struct_type(*idx, frame)?.0)?;
+                ty.paranoid_check_eq(ty_cache.get_struct_type(*idx, frame)?)?;
                 ty.paranoid_check_has_ability(Ability::Key)?;
             },
             Instruction::MoveFrom(idx) => {
@@ -876,7 +866,7 @@ impl RuntimeTypeCheck for FullRuntimeTypeCheck {
             },
             Instruction::MoveFromGeneric(idx) => {
                 operand_stack.pop_ty()?.paranoid_check_is_address_ty()?;
-                let ty = ty_cache.get_struct_type(*idx, frame)?.0.clone();
+                let ty = ty_cache.get_struct_type(*idx, frame)?.clone();
                 ty.paranoid_check_has_ability(Ability::Key)?;
                 operand_stack.push_ty(ty)?;
             },
@@ -893,7 +883,7 @@ impl RuntimeTypeCheck for FullRuntimeTypeCheck {
                 // operand_stack.push_ty(bool_ty)?;
             },
             Instruction::VecPack(si, num) => {
-                let (ty, _, _) = ty_cache.get_signature_index_type(*si, frame)?;
+                let ty = ty_cache.get_signature_index_type(*si, frame)?;
                 let elem_tys = operand_stack.popn_tys(*num)?;
                 for elem_ty in elem_tys.iter() {
                     // For vector element types, use assignability
@@ -904,7 +894,7 @@ impl RuntimeTypeCheck for FullRuntimeTypeCheck {
                 operand_stack.push_ty(vec_ty)?;
             },
             Instruction::VecLen(si) => {
-                let (ty, _, _) = ty_cache.get_signature_index_type(*si, frame)?;
+                let ty = ty_cache.get_signature_index_type(*si, frame)?;
                 operand_stack
                     .pop_ty()?
                     .paranoid_check_is_vec_ref_ty::<false>(ty)?;
@@ -913,7 +903,7 @@ impl RuntimeTypeCheck for FullRuntimeTypeCheck {
                 operand_stack.push_ty(u64_ty)?;
             },
             Instruction::VecImmBorrow(si) => {
-                let (ty, _, _) = ty_cache.get_signature_index_type(*si, frame)?;
+                let ty = ty_cache.get_signature_index_type(*si, frame)?;
                 operand_stack.pop_ty()?.paranoid_check_is_u64_ty()?;
                 let elem_ref_ty = operand_stack
                     .pop_ty()?
@@ -922,7 +912,7 @@ impl RuntimeTypeCheck for FullRuntimeTypeCheck {
                 operand_stack.push_ty(elem_ref_ty)?;
             },
             Instruction::VecMutBorrow(si) => {
-                let (ty, _, _) = ty_cache.get_signature_index_type(*si, frame)?;
+                let ty = ty_cache.get_signature_index_type(*si, frame)?;
                 operand_stack.pop_ty()?.paranoid_check_is_u64_ty()?;
                 let elem_ref_ty = operand_stack
                     .pop_ty()?
@@ -930,7 +920,7 @@ impl RuntimeTypeCheck for FullRuntimeTypeCheck {
                 operand_stack.push_ty(elem_ref_ty)?;
             },
             Instruction::VecPushBack(si) => {
-                let (ty, _, _) = ty_cache.get_signature_index_type(*si, frame)?;
+                let ty = ty_cache.get_signature_index_type(*si, frame)?;
                 // For pushing an element to a vector, use assignability
                 operand_stack.pop_ty()?.paranoid_check_assignable(ty)?;
                 operand_stack
@@ -938,14 +928,14 @@ impl RuntimeTypeCheck for FullRuntimeTypeCheck {
                     .paranoid_check_is_vec_ref_ty::<true>(ty)?;
             },
             Instruction::VecPopBack(si) => {
-                let (ty, _, _) = ty_cache.get_signature_index_type(*si, frame)?;
+                let ty = ty_cache.get_signature_index_type(*si, frame)?;
                 let elem_ty = operand_stack
                     .pop_ty()?
                     .paranoid_check_and_get_vec_elem_ty::<true>(ty)?;
                 operand_stack.push_ty(elem_ty)?;
             },
             Instruction::VecUnpack(si, num) => {
-                let (expected_elem_ty, _, _) = ty_cache.get_signature_index_type(*si, frame)?;
+                let expected_elem_ty = ty_cache.get_signature_index_type(*si, frame)?;
                 let vec_ty = operand_stack.pop_ty()?;
                 vec_ty.paranoid_check_is_vec_ty(expected_elem_ty)?;
                 for _ in 0..*num {
@@ -953,7 +943,7 @@ impl RuntimeTypeCheck for FullRuntimeTypeCheck {
                 }
             },
             Instruction::VecSwap(si) => {
-                let (ty, _, _) = ty_cache.get_signature_index_type(*si, frame)?;
+                let ty = ty_cache.get_signature_index_type(*si, frame)?;
                 operand_stack.pop_ty()?.paranoid_check_is_u64_ty()?;
                 operand_stack.pop_ty()?.paranoid_check_is_u64_ty()?;
                 operand_stack

--- a/third_party/move/move-vm/runtime/src/runtime_type_checks_async.rs
+++ b/third_party/move/move-vm/runtime/src/runtime_type_checks_async.rs
@@ -108,7 +108,9 @@ where
         Self {
             type_stack: Stack::new(),
             call_stack: CallStack::new(),
-            function_caches: InterpreterFunctionCaches::new(),
+            function_caches: InterpreterFunctionCaches::new(
+                vm_config.charge_create_ty_on_cache_hit,
+            ),
             module_storage,
             ty_pool,
             vm_config,
@@ -202,7 +204,10 @@ where
                         .consume_closure_call()
                         .map_err(|err| err.finish(Location::Undefined))
                         .map(|(f, mask)| (Rc::new(f.clone()), mask))?;
-                    let callee_frame_cache = FrameTypeCache::make_rc_for_function(&callee);
+                    let callee_frame_cache = FrameTypeCache::make_rc_for_function(
+                        &callee,
+                        self.vm_config.charge_create_ty_on_cache_hit,
+                    );
                     self.execute_closure_call::<RTTCheck>(
                         cursor,
                         &mut current_frame,

--- a/third_party/move/move-vm/runtime/src/storage/ty_layout_converter.rs
+++ b/third_party/move/move-vm/runtime/src/storage/ty_layout_converter.rs
@@ -908,8 +908,8 @@ mod tests {
             ),
             (
                 Type::Function {
-                    args: vec![Type::U8],
-                    results: vec![Type::U256],
+                    args: TriompheArc::new(vec![Type::U8]),
+                    results: TriompheArc::new(vec![Type::U256]),
                     abilities: AbilitySet::EMPTY,
                 },
                 MoveTypeLayout::Function,

--- a/third_party/move/move-vm/types/src/loaded_data/runtime_types.rs
+++ b/third_party/move/move-vm/types/src/loaded_data/runtime_types.rs
@@ -313,8 +313,8 @@ pub enum Type {
         ability: AbilityInfo,
     },
     Function {
-        args: Vec<Type>,
-        results: Vec<Type>,
+        args: TriompheArc<Vec<Type>>,
+        results: TriompheArc<Vec<Type>>,
         abilities: AbilitySet,
     },
     Reference(Box<Type>),
@@ -1502,8 +1502,8 @@ impl TypeBuilder {
                     .map(|ty| subs_elem(count, ty))
                     .collect::<PartialVMResult<Vec<_>>>()?;
                 Function {
-                    args,
-                    results,
+                    args: TriompheArc::new(args),
+                    results: TriompheArc::new(results),
                     abilities: *abilities,
                 }
             },
@@ -1596,8 +1596,8 @@ impl TypeBuilder {
                         .collect::<PartialVMResult<Vec<_>>>()
                 };
                 Function {
-                    args: to_list(args)?,
-                    results: to_list(results)?,
+                    args: TriompheArc::new(to_list(args)?),
+                    results: TriompheArc::new(to_list(results)?),
                     abilities: *abilities,
                 }
             },
@@ -1675,10 +1675,12 @@ impl<'a> TypeParamMap<'a> {
                 && args.len() == exp_args.len()
                 && results.len() == exp_results.len() =>
             {
-                args.iter().zip(exp_args).all(|(t, e)| self.match_ty(t, e))
+                args.iter()
+                    .zip(exp_args.iter())
+                    .all(|(t, e)| self.match_ty(t, e))
                     && results
                         .iter()
-                        .zip(exp_results)
+                        .zip(exp_results.iter())
                         .all(|(t, e)| self.match_ty(t, e))
             },
             // Abilities should not contribute to the equality check as they just serve for caching

--- a/third_party/move/move-vm/types/src/ty_interner.rs
+++ b/third_party/move/move-vm/types/src/ty_interner.rs
@@ -451,8 +451,8 @@ mod test {
         let ctx = InternedTypePool::new();
 
         let func_ty = Type::Function {
-            args: vec![Type::U64, Type::Bool],
-            results: vec![Type::U8],
+            args: TriompheArc::new(vec![Type::U64, Type::Bool]),
+            results: TriompheArc::new(vec![Type::U8]),
             abilities: AbilitySet::EMPTY,
         };
 
@@ -462,8 +462,8 @@ mod test {
         assert_eq!(id1, id2);
 
         let func_ty = Type::Function {
-            args: vec![Type::U64],
-            results: vec![Type::U8],
+            args: TriompheArc::new(vec![Type::U64]),
+            results: TriompheArc::new(vec![Type::U8]),
             abilities: AbilitySet::EMPTY,
         };
 
@@ -471,8 +471,8 @@ mod test {
         assert_ne!(id1, id3);
 
         let func_ty = Type::Function {
-            args: vec![Type::U64],
-            results: vec![Type::U8],
+            args: TriompheArc::new(vec![Type::U64]),
+            results: TriompheArc::new(vec![Type::U8]),
             abilities: AbilitySet::ALL,
         };
         let id4 = ctx.instantiate_and_intern(&func_ty, &[]);


### PR DESCRIPTION
## Description

`charge_create_ty` charges gas for type instantiation every time a generic instruction executes. But actual type substitution only happens on the first execution per instruction index within a frame — subsequent executions serve cached results from `FrameTypeCache`. In loops, this overcharges by a factor of N (loop iterations). Similarly, non-generic function frame creation re-charged local type counts on every call despite types never changing.

This PR has three commits:

**1. Charge type creation on cache miss only** — Adds a `charge_create_ty_on_cache_hit` flag to `VMConfig`, gated on gas feature version (< `RELEASE_V1_45`). For older versions, behavior is identical: gas is charged on every execution, per-field. For newer versions, gas is only charged on cache miss and uses aggregated sums instead of per-field loops. Refactors `FrameTypeCache` with struct-of-arrays storage and purpose-specific getters (types-only for runtime checks, counts for gas).

**2. Make function types use arcs** — Wraps `Type::Function` args and results in `TriompheArc<Vec<Type>>` so that `Type::clone()` is O(1) for all variants that can appear as struct fields. Without this, runtime type checks that clone cached types every loop iteration could be exploited for uncharged work with function-typed fields.

**3. Charge non-generic frame local types once** — Non-generic functions were charging `charge_create_ty` for every local on every call, even when the frame cache was reused. Now both generic and non-generic paths cache `local_ty_counts` and skip charging on cache hit (or charge for compatibility on older gas versions).

### Behavior change

- **Old gas version** (`< RELEASE_V1_45`): no change, identical gas semantics
- **New gas version** (`>= RELEASE_V1_45`): generic instructions in loops and repeated function calls pay type creation gas once instead of every iteration/call

## How Has This Been Tested?

- `cargo check -p move-vm-runtime`
- `cargo check -p move-vm-types`
- Replay verification pending

## Key Areas to Review

- `frame_type_cache.rs`: new cache API — `Option`-based returns encode miss/hit for gas, flag controls behavior
- `interpreter.rs`: ~20 call sites updated to use new getters
- `frame.rs`: unified local type charging for generic and non-generic functions
- `prod_configs.rs`: feature gating on `RELEASE_V1_45`

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [x] Performance improvement
- [x] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [x] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation