### PR TITLE
[config] Enable CO v2 message sending by default

### DIFF
--- a/config/src/config/consensus_observer_config.rs
+++ b/config/src/config/consensus_observer_config.rs
@@ -85,7 +85,7 @@ impl Default for ConsensusObserverConfig {
             observer_fallback_startup_period_ms: 60_000, // 60 seconds
             observer_fallback_progress_threshold_ms: 10_000, // 10 seconds
             observer_fallback_sync_lag_threshold_ms: 15_000, // 15 seconds
-            enable_v2_message_sending: false,
+            enable_v2_message_sending: true,
         }
     }
 }


### PR DESCRIPTION
## Summary
- Enable `enable_v2_message_sending` default to `true` in consensus observer config

## Test plan
- [ ] Existing tests pass (this config was already tested with `true` in forge)
- [ ] Verify nodes start correctly with new default

🤖 Generated with [Claude Code](https://claude.com/claude-code)