### PR TITLE
[consensus] Fix SecretShareMsg RPC silently dropped

### DIFF
--- a/consensus/src/network.rs
+++ b/consensus/src/network.rs
@@ -381,6 +381,11 @@ impl NetworkSender {
         self.broadcast_without_self(msg);
     }
 
+    pub fn broadcast_secret_share(&self, msg: ConsensusMsg) {
+        fail_point!("consensus::send::broadcast_secret_share", |_| ());
+        self.broadcast_without_self(msg);
+    }
+
     pub fn broadcast_without_self(&self, msg: ConsensusMsg) {
         fail_point!("consensus::send::any", |_| ());
 
@@ -931,7 +936,15 @@ impl NetworkTask {
                                 warn!(error = ?e, "aptos channel closed");
                             };
                         },
-                        _ => {
+                        // RPC-only and response variants — unexpected as direct sends.
+                        ConsensusMsg::DeprecatedBlockRetrievalRequest(_)
+                        | ConsensusMsg::BlockRetrievalResponse(_)
+                        | ConsensusMsg::BlockRetrievalRequest(_)
+                        | ConsensusMsg::BatchRequestMsg(_)
+                        | ConsensusMsg::BatchResponse(_)
+                        | ConsensusMsg::BatchResponseV2(_)
+                        | ConsensusMsg::DAGMessage(_)
+                        | ConsensusMsg::CommitMessage(_) => {
                             warn!(remote_peer = peer_id, "Unexpected direct send msg");
                             continue;
                         },
@@ -1009,8 +1022,35 @@ impl NetworkTask {
                                 response_sender: callback,
                             })
                         },
-                        _ => {
-                            warn!(remote_peer = peer_id, "Unexpected msg: {:?}", msg);
+                        ConsensusMsg::SecretShareMsg(req) => {
+                            IncomingRpcRequest::SecretShareRequest(IncomingSecretShareRequest {
+                                req,
+                                sender: peer_id,
+                                protocol,
+                                response_sender: callback,
+                            })
+                        },
+                        // Direct-send-only and response variants — unexpected as RPCs.
+                        ConsensusMsg::ProposalMsg(_)
+                        | ConsensusMsg::OptProposalMsg(_)
+                        | ConsensusMsg::VoteMsg(_)
+                        | ConsensusMsg::OrderVoteMsg(_)
+                        | ConsensusMsg::RoundTimeoutMsg(_)
+                        | ConsensusMsg::SyncInfo(_)
+                        | ConsensusMsg::EpochRetrievalRequest(_)
+                        | ConsensusMsg::EpochChangeProof(_)
+                        | ConsensusMsg::CommitVoteMsg(_)
+                        | ConsensusMsg::CommitDecisionMsg(_)
+                        | ConsensusMsg::SignedBatchInfo(_)
+                        | ConsensusMsg::SignedBatchInfoMsgV2(_)
+                        | ConsensusMsg::BatchMsg(_)
+                        | ConsensusMsg::BatchMsgV2(_)
+                        | ConsensusMsg::ProofOfStoreMsg(_)
+                        | ConsensusMsg::ProofOfStoreMsgV2(_)
+                        | ConsensusMsg::BlockRetrievalResponse(_)
+                        | ConsensusMsg::BatchResponse(_)
+                        | ConsensusMsg::BatchResponseV2(_) => {
+                            warn!(remote_peer = peer_id, "Unexpected RPC msg: {:?}", msg);
                             continue;
                         },
                     };

--- a/consensus/src/rand/secret_sharing/secret_share_manager.rs
+++ b/consensus/src/rand/secret_sharing/secret_share_manager.rs
@@ -188,7 +188,7 @@ impl SecretShareManager {
             .author(self.author)
             .round(round));
         self.network_sender
-            .broadcast_without_self(SecretShareMessage::Share(share).into_network_message());
+            .broadcast_secret_share(SecretShareMessage::Share(share).into_network_message());
 
         let guard = self.spawn_share_requester_task(metadata);
         if let Some(item) = self.block_queue.item_mut(round) {

--- a/testsuite/smoke-test/src/decryption/mod.rs
+++ b/testsuite/smoke-test/src/decryption/mod.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
+mod secret_share_rpc_path;
+
 use crate::{
     smoke_test_environment::SwarmBuilder, txn_emitter::generate_traffic,
     utils::create_and_fund_account,

--- a/testsuite/smoke-test/src/decryption/secret_share_rpc_path.rs
+++ b/testsuite/smoke-test/src/decryption/secret_share_rpc_path.rs
@@ -1,0 +1,100 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+use crate::{smoke_test_environment::SwarmBuilder, txn_emitter::generate_traffic};
+use aptos_forge::{EmitJobMode, NodeExt, SwarmExt, TransactionType};
+use aptos_logger::info;
+use aptos_types::on_chain_config::{
+    FeatureFlag, Features, OnChainChunkyDKGConfig, OnChainRandomnessConfig,
+};
+use std::{sync::Arc, time::Duration};
+
+/// Verify that SecretShareMsg works via the RPC path (not just direct send).
+///
+/// This test disables the direct-send broadcast of secret shares via a failpoint,
+/// forcing the system to rely on the RPC path. If the RPC handler for SecretShareMsg
+/// is missing, validators will not be able to exchange secret shares and the chain
+/// will stall.
+#[tokio::test]
+async fn secret_share_rpc_path() {
+    let epoch_duration_secs = 20;
+
+    let mut swarm = SwarmBuilder::new_local(4)
+        .with_aptos()
+        .with_init_config(Arc::new(|_, config, _| {
+            config.api.failpoints_enabled = true;
+            config.api.allow_encrypted_txns_submission = true;
+            config.consensus.quorum_store.enable_batch_v2_tx = true;
+            config.consensus.quorum_store.enable_batch_v2_rx = true;
+            config.consensus.quorum_store.enable_opt_qs_v2_payload_tx = true;
+            config.consensus.quorum_store.enable_opt_qs_v2_payload_rx = true;
+        }))
+        .with_init_genesis_config(Arc::new(move |conf| {
+            conf.epoch_duration_secs = epoch_duration_secs;
+            conf.consensus_config.enable_validator_txns();
+            conf.randomness_config_override = Some(OnChainRandomnessConfig::default_enabled());
+            conf.chunky_dkg_config_override = Some(OnChainChunkyDKGConfig::default_enabled());
+            let mut features = Features::default();
+            features.enable(FeatureFlag::ENCRYPTED_TRANSACTIONS);
+            conf.initial_features_override = Some(features);
+        }))
+        .build()
+        .await;
+
+    let validator_clients: Vec<_> = swarm.validators().map(|v| v.rest_client()).collect();
+
+    // Wait for epoch 2 so DKG + secret sharing are active.
+    info!("Waiting for epoch 2...");
+    swarm
+        .wait_for_all_nodes_to_catchup_to_epoch(2, Duration::from_secs(epoch_duration_secs * 5))
+        .await
+        .expect("Timed out waiting for epoch 2");
+
+    // Disable secret share direct-send on all validators via failpoint.
+    // This forces the system to use only the RPC path for secret share exchange.
+    info!("Injecting failpoint to disable secret share direct-send on all validators...");
+    for client in &validator_clients {
+        client
+            .set_failpoint(
+                "consensus::send::broadcast_secret_share".to_string(),
+                "return".to_string(),
+            )
+            .await
+            .expect("Failed to set failpoint");
+    }
+
+    // Generate encrypted traffic to exercise the decryption / secret share path.
+    info!("Emitting encrypted traffic with direct-send disabled...");
+    let all_validators: Vec<_> = swarm.validators().map(|v| v.peer_id()).collect();
+    let stats = generate_traffic(
+        &mut swarm,
+        &all_validators,
+        Duration::from_secs(20),
+        100,
+        vec![vec![(TransactionType::default(), 1)]],
+        true,
+        Some(EmitJobMode::MaxLoad {
+            mempool_backlog: 20,
+        }),
+    )
+    .await
+    .expect("Failed to generate encrypted traffic");
+    info!(
+        "Emitter stats: submitted={}, committed={}",
+        stats.submitted, stats.committed
+    );
+    assert!(
+        stats.committed > 0,
+        "Expected committed encrypted transactions, got 0"
+    );
+
+    // Wait for the chain to advance to epoch 3. This requires a new DKG round and
+    // secret share exchange, which can now only succeed via the RPC path.
+    info!("Waiting for epoch 3 with secret share direct-send disabled...");
+    swarm
+        .wait_for_all_nodes_to_catchup_to_epoch(3, Duration::from_secs(epoch_duration_secs * 5))
+        .await
+        .expect("Timed out waiting for epoch 3 — SecretShareMsg RPC path may be broken");
+
+    info!("All validators reached epoch 3 using only the RPC path for secret shares.");
+}


### PR DESCRIPTION
## Summary
- The RPC handler in `consensus/src/network.rs` was missing a match arm for `ConsensusMsg::SecretShareMsg`, causing it to silently drop via the wildcard `_ =>`. The system still worked via the direct-send fallback, but with unnecessary retries/timeouts.
- Added `broadcast_secret_share()` on `NetworkSender` with a failpoint to allow disabling the direct-send path in tests.
- Replaced both wildcard `_ =>` arms with exhaustive variant listings so future `ConsensusMsg` variants cause a compile error if not explicitly handled.
- Added a smoke test that disables direct-send via failpoint and verifies the chain advances using only the RPC path.

## Test plan
- [x] `cargo check -p aptos-consensus` compiles clean
- [x] `cargo check -p smoke-test` compiles clean
- [ ] `cargo test -p smoke-test -- secret_share_rpc_path` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)