### PR TITLE
[forge] Latency baseline with 1 slow validator at 4k TPS

### DIFF
--- a/.github/workflows/docker-build-test.yaml
+++ b/.github/workflows/docker-build-test.yaml
@@ -270,7 +270,7 @@ jobs:
       GIT_SHA: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
       FORGE_TEST_SUITE: realistic_env_max_load
       IMAGE_TAG: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
-      FORGE_RUNNER_DURATION_SECS: 480
+      FORGE_RUNNER_DURATION_SECS: 1800
       COMMENT_HEADER: forge-e2e
       # Use the cache ID as the Forge namespace so we can limit Forge test concurrency on k8s, since Forge
       # test lifecycle is separate from that of GHA. This protects us from the case where many Forge tests are triggered

--- a/consensus/src/round_manager.rs
+++ b/consensus/src/round_manager.rs
@@ -488,6 +488,26 @@ impl RoundManager {
                 .expect("Sending to a self loopback unbounded channel cannot fail");
         }
 
+        // HACK: Simulate slow proposer. The last validator (by ordered index)
+        // delays their proposal by 1s 10% of the time (round % 10 == 0).
+        let proposal_delay = {
+            let author = self.proposal_generator.author();
+            let ordered = self.epoch_state.verifier.get_ordered_account_addresses();
+            let n = ordered.len();
+            let idx = ordered.iter().position(|a| *a == author);
+            if matches!(idx, Some(i) if i >= n - 1) && new_round_event.round.is_multiple_of(10) {
+                Some(std::time::Duration::from_millis(1000))
+            } else {
+                None
+            }
+        };
+        if let Some(delay) = proposal_delay {
+            warn!(
+                self.new_log(LogEvent::NewRound),
+                "HACK: delaying proposal for round {} by {:?}", new_round_event.round, delay
+            );
+        }
+
         // If the current proposer is the leading, try to propose a regular block if not opt proposed already
         if is_current_proposer
             && self
@@ -501,6 +521,9 @@ impl RoundManager {
             let safety_rules = self.safety_rules.clone();
             let proposer_election = self.proposer_election.clone();
             tokio::spawn(async move {
+                if let Some(delay) = proposal_delay {
+                    tokio::time::sleep(delay).await;
+                }
                 if let Err(e) = monitor!(
                     "generate_and_send_proposal",
                     Self::generate_and_send_proposal(
@@ -1453,6 +1476,19 @@ impl RoundManager {
 
         let parent = parent_vote.vote_data().proposed().clone();
         let opt_proposal_round = parent.round() + 1;
+        // HACK: Simulate slow opt proposer too.
+        let opt_proposal_delay = {
+            let author = self.proposal_generator.author();
+            let ordered = self.epoch_state.verifier.get_ordered_account_addresses();
+            let n = ordered.len();
+            let idx = ordered.iter().position(|a| *a == author);
+            if matches!(idx, Some(i) if i >= n - 1) && opt_proposal_round.is_multiple_of(10) {
+                Some(std::time::Duration::from_millis(1000))
+            } else {
+                None
+            }
+        };
+
         if self
             .proposer_election
             .is_valid_proposer(self.proposal_generator.author(), opt_proposal_round)
@@ -1474,6 +1510,9 @@ impl RoundManager {
             let proposal_generator = self.proposal_generator.clone();
             let proposer_election = self.proposer_election.clone();
             tokio::spawn(async move {
+                if let Some(delay) = opt_proposal_delay {
+                    tokio::time::sleep(delay).await;
+                }
                 if let Err(e) = monitor!(
                     "generate_and_send_opt_proposal",
                     Self::generate_and_send_opt_proposal(

--- a/testsuite/forge-cli/src/suites/land_blocking.rs
+++ b/testsuite/forge-cli/src/suites/land_blocking.rs
@@ -28,7 +28,8 @@ pub(crate) fn get_land_blocking_test(
 ) -> Option<ForgeConfig> {
     let test = match test_name {
         "land_blocking" | "realistic_env_max_load" => {
-            realistic_env_max_load_test(duration, test_cmd, 7, 0, 3)
+            realistic_env_max_load_test(duration, test_cmd, 7, 0, 0)
+                .with_duration_override(Duration::from_secs(1200))
         },
         "compat" => compat(),
         "framework_upgrade" => framework_upgrade(),

--- a/testsuite/forge-cli/src/suites/realistic_environment.rs
+++ b/testsuite/forge-cli/src/suites/realistic_environment.rs
@@ -440,30 +440,18 @@ pub(crate) fn realistic_env_max_load_test(
     }
 
     // Create the test
-    let mempool_backlog = if ha_proxy { 14000 } else { 19000 };
     ForgeConfig::default()
         .with_initial_validator_count(NonZeroUsize::new(num_validators).unwrap())
         .with_initial_fullnode_count(num_vfns)
         .add_network_test(wrap_with_realistic_env(num_validators, TwoTrafficsTest {
             inner_traffic: EmitJobRequest::default()
-                .mode(EmitJobMode::MaxLoad { mempool_backlog })
+                .mode(EmitJobMode::ConstTps { tps: 4000 })
                 .init_gas_price_multiplier(20),
-            inner_success_criteria: SuccessCriteria::new(
-                if ha_proxy {
-                    7000
-                } else if long_running {
-                    // This is for forge stable
-                    11000
-                } else {
-                    // During land time we want to be less strict, otherwise we flaky fail
-                    10000
-                },
-            ),
+            inner_success_criteria: SuccessCriteria::new(3500),
         }))
         .with_genesis_helm_config_fn(Arc::new(move |helm_values| {
-            // Have single epoch change in land blocking, and a few on long-running
-            helm_values["chain"]["epoch_duration_secs"] =
-                (if long_running { 600 } else { 300 }).into();
+            // No epoch change so measurements are stable.
+            helm_values["chain"]["epoch_duration_secs"] = (24 * 3600).into();
             helm_values["chain"]["on_chain_consensus_config"] =
                 serde_yaml::to_value(OnChainConsensusConfig::default_for_genesis())
                     .expect("must serialize");

--- a/testsuite/forge/src/config.rs
+++ b/testsuite/forge/src/config.rs
@@ -10,7 +10,7 @@ use aptos_config::config::{
     OverrideNodeConfig,
 };
 use aptos_framework::ReleaseBundle;
-use std::{num::NonZeroUsize, sync::Arc};
+use std::{num::NonZeroUsize, sync::Arc, time::Duration};
 
 /// A PFN deployment configuration. Each entry maps to one helm release via the PFN deployer.
 pub struct PfnDeployment {
@@ -77,6 +77,9 @@ pub struct ForgeConfig {
 
     /// URL to download the chunky DKG public parameters blob into the validator init-container
     pub public_parameters_blob_url: Option<String>,
+
+    /// Override the CLI-specified test duration
+    pub duration_override: Option<Duration>,
 }
 
 impl ForgeConfig {
@@ -204,6 +207,11 @@ impl ForgeConfig {
 
     pub fn with_public_parameters_blob_url(mut self, url: impl Into<String>) -> Self {
         self.public_parameters_blob_url = Some(url.into());
+        self
+    }
+
+    pub fn with_duration_override(mut self, duration: Duration) -> Self {
+        self.duration_override = Some(duration);
         self
     }
 
@@ -448,6 +456,7 @@ impl Default for ForgeConfig {
             retain_debug_logs: false,
             digest_key_blob_url: None,
             public_parameters_blob_url: None,
+            duration_override: None,
         }
     }
 }

--- a/testsuite/forge/src/runner.rs
+++ b/testsuite/forge/src/runner.rs
@@ -311,7 +311,7 @@ impl<'cfg, F: Factory> Forge<'cfg, F> {
                 &initial_version,
                 &genesis_version,
                 self.tests.genesis_config.as_ref(),
-                self.global_duration + Duration::from_secs(NAMESPACE_CLEANUP_DURATION_BUFFER_SECS),
+                self.tests.duration_override.unwrap_or(self.global_duration) + Duration::from_secs(NAMESPACE_CLEANUP_DURATION_BUFFER_SECS),
                 self.tests.genesis_helm_config_fn.clone(),
                 self.tests.build_node_helm_config_fn(retain_debug_logs),
                 self.tests.existing_db_tag.clone(),
@@ -343,12 +343,16 @@ impl<'cfg, F: Factory> Forge<'cfg, F> {
 
             let logs_location = swarm.logs_location();
             let swarm = Arc::new(tokio::sync::RwLock::new(swarm));
+            let effective_duration = self
+                .tests
+                .duration_override
+                .unwrap_or(self.global_duration);
             for test in self.filter_tests(&self.tests.network_tests) {
                 let network_ctx = NetworkContext::new(
                     CoreContext::from_rng(&mut rng),
                     swarm.clone(),
                     &mut report,
-                    self.global_duration,
+                    effective_duration,
                     self.tests.emit_job_request.clone(),
                     self.tests.success_criteria.clone(),
                 );


### PR DESCRIPTION
Forge harness for measuring commit-latency baseline against leader-reputation experiments.

## Setup
- 7 validators, 0 fullnodes, ConstTps 4000, 20-minute steady-state window
- 24-hour epoch (no reconfigurations during the test)
- **Faulty validator simulation**: last validator (by ordered index) delays its proposal by 1s on every 10th round (~10% of its rounds), guaranteeing round timeout

## Use
Baseline reference for #19341 (latency-weighted leader-reputation experiment).

⚠ Prototype/experiment code — not for merge to main.