### PR TITLE
[vm] Remove execute_block_on_thread_pool API

### DIFF
--- a/aptos-move/aptos-vm/src/block_executor/mod.rs
+++ b/aptos-move/aptos-vm/src/block_executor/mod.rs
@@ -512,12 +512,11 @@ impl<
         >,
     > AptosBlockExecutorWrapper<E>
 {
-    pub fn execute_block_on_thread_pool<
+    pub fn execute_block<
         S: StateView + Sync,
         L: TransactionCommitHook,
         TP: TxnProvider<SignatureVerifiedTransaction, AuxiliaryInfo> + Sync,
     >(
-        executor_thread_pool: Arc<rayon::ThreadPool>,
         signature_verified_block: &TP,
         state_view: &S,
         module_cache_manager: &AptosModuleCacheManager,
@@ -545,7 +544,7 @@ impl<
         let executor =
             BlockExecutor::<SignatureVerifiedTransaction, E, S, L, TP, AuxiliaryInfo>::new(
                 config,
-                executor_thread_pool,
+                Arc::clone(&RAYON_EXEC_POOL),
                 transaction_commit_listener,
             );
 
@@ -583,30 +582,6 @@ impl<
             }),
             Err(BlockExecutionError::FatalVMError(err)) => Err(err),
         }
-    }
-
-    /// Uses shared thread pool to execute blocks.
-    pub(crate) fn execute_block<
-        S: StateView + Sync,
-        L: TransactionCommitHook,
-        TP: TxnProvider<SignatureVerifiedTransaction, AuxiliaryInfo> + Sync,
-    >(
-        signature_verified_block: &TP,
-        state_view: &S,
-        module_cache_manager: &AptosModuleCacheManager,
-        config: BlockExecutorConfig,
-        transaction_slice_metadata: TransactionSliceMetadata,
-        transaction_commit_listener: Option<L>,
-    ) -> Result<BlockOutput<SignatureVerifiedTransaction, TransactionOutput>, VMStatus> {
-        Self::execute_block_on_thread_pool::<S, L, TP>(
-            Arc::clone(&RAYON_EXEC_POOL),
-            signature_verified_block,
-            state_view,
-            module_cache_manager,
-            config,
-            transaction_slice_metadata,
-            transaction_commit_listener,
-        )
     }
 }
 

--- a/aptos-move/aptos-vm/src/sharded_block_executor/sharded_executor_service.rs
+++ b/aptos-move/aptos-vm/src/sharded_block_executor/sharded_executor_service.rs
@@ -129,9 +129,9 @@ impl<S: StateView + Sync + Send + 'static> ShardedExecutorService<S> {
             .into_iter()
             .map(|txn| txn.into_txn().into_txn())
             .collect();
-        let executor_thread_pool_clone = executor_thread_pool.clone();
+        let async_drop_pool = executor_thread_pool.clone();
 
-        executor_thread_pool.clone().scope(|s| {
+        executor_thread_pool.scope(|s| {
             s.spawn(move |_| {
                 CrossShardCommitReceiver::start(
                     cross_shard_state_view_clone,
@@ -142,8 +142,7 @@ impl<S: StateView + Sync + Send + 'static> ShardedExecutorService<S> {
             s.spawn(move |_| {
                 let txn_provider =
                     DefaultTxnProvider::new_without_info(signature_verified_transactions);
-                let ret = AptosVMBlockExecutorWrapper::execute_block_on_thread_pool(
-                    executor_thread_pool,
+                let ret = AptosVMBlockExecutorWrapper::execute_block(
                     &txn_provider,
                     aggr_overridden_state_view.as_ref(),
                     // Since we execute blocks in parallel, we cannot share module caches, so each
@@ -172,7 +171,7 @@ impl<S: StateView + Sync + Send + 'static> ShardedExecutorService<S> {
                     cross_shard_client_clone.send_global_msg(CrossShardMsg::StopMsg);
                 }
                 callback.send(ret).unwrap();
-                executor_thread_pool_clone.spawn(move || {
+                async_drop_pool.spawn(move || {
                     // Explicit async drop
                     drop(txn_provider);
                 });

--- a/aptos-move/e2e-tests/src/executor.rs
+++ b/aptos-move/e2e-tests/src/executor.rs
@@ -162,7 +162,6 @@ struct SharedCacheState {
 pub struct FakeExecutorImpl<O: OutputLogger> {
     state_store: FakeExecutorStateStore,
     event_store: Vec<ContractEvent>,
-    executor_thread_pool: Arc<rayon::ThreadPool>,
     block_time: u64,
     executed_output: Option<O>,
     trace_dir: Option<PathBuf>,
@@ -232,20 +231,12 @@ pub enum ExecFuncTimerDynamicArgs {
 impl<O: OutputLogger> FakeExecutorImpl<O> {
     /// Creates an executor from a genesis [`WriteSet`].
     pub fn from_genesis(write_set: &WriteSet, chain_id: ChainId) -> Self {
-        let executor_thread_pool = Arc::new(
-            rayon::ThreadPoolBuilder::new()
-                .num_threads(num_cpus::get())
-                .build()
-                .unwrap(),
-        );
-
         let state_store = empty_in_memory_state_store();
         state_store.set_chain_id(chain_id).unwrap();
 
         let mut executor = Self {
             state_store,
             event_store: Vec::new(),
-            executor_thread_pool,
             block_time: 0,
             executed_output: None,
             trace_dir: None,
@@ -259,10 +250,9 @@ impl<O: OutputLogger> FakeExecutorImpl<O> {
     }
 
     #[cfg(any(test, feature = "fuzzing"))]
-    pub fn from_genesis_with_existing_thread_pool(
+    pub fn from_genesis_with_module_cache(
         write_set: &WriteSet,
         chain_id: ChainId,
-        executor_thread_pool: Arc<rayon::ThreadPool>,
         module_cache_manager: Option<AptosModuleCacheManager>,
     ) -> Self {
         let state_store = empty_in_memory_state_store();
@@ -271,7 +261,6 @@ impl<O: OutputLogger> FakeExecutorImpl<O> {
         let mut executor = Self {
             state_store,
             event_store: Vec::new(),
-            executor_thread_pool,
             block_time: 0,
             executed_output: None,
             trace_dir: None,
@@ -313,17 +302,9 @@ impl<O: OutputLogger> FakeExecutorImpl<O> {
             .get_on_chain_config::<CurrentTimeMicroseconds>()
             .expect("failed to get block time from remote");
 
-        let executor_thread_pool = Arc::new(
-            rayon::ThreadPoolBuilder::new()
-                .num_threads(num_cpus::get())
-                .build()
-                .unwrap(),
-        );
-
         Self {
             state_store,
             event_store: Vec::new(),
-            executor_thread_pool,
             block_time: timestamp.microseconds,
             executed_output: None,
             trace_dir: None,
@@ -507,16 +488,9 @@ impl<O: OutputLogger> FakeExecutorImpl<O> {
 
     /// Creates an executor in which no genesis state has been applied yet.
     pub fn no_genesis() -> Self {
-        let executor_thread_pool = Arc::new(
-            rayon::ThreadPoolBuilder::new()
-                .num_threads(num_cpus::get())
-                .build()
-                .unwrap(),
-        );
         Self {
             state_store: empty_in_memory_state_store(),
             event_store: Vec::new(),
-            executor_thread_pool,
             block_time: 0,
             executed_output: None,
             trace_dir: None,
@@ -890,12 +864,7 @@ impl<O: OutputLogger> FakeExecutorImpl<O> {
         let txn_provider = DefaultTxnProvider::new(txn_block, auxiliary_info);
         let metadata = self.get_txn_slice_metadata();
         let result = {
-            AptosVMBlockExecutorWrapper::execute_block_on_thread_pool::<
-                _,
-                NoOpTransactionCommitHook<VMStatus>,
-                _,
-            >(
-                self.executor_thread_pool.clone(),
+            AptosVMBlockExecutorWrapper::execute_block::<_, NoOpTransactionCommitHook<VMStatus>, _>(
                 &txn_provider,
                 &state_view,
                 self.module_cache_manager_opt()
@@ -1077,7 +1046,7 @@ impl<O: OutputLogger> FakeExecutorImpl<O> {
 
         let parallel_output = if mode != ExecutorMode::SequentialOnly {
             // use the number of threads specified in the executor thread pool as specified at construction time
-            config.local.concurrency_level = self.executor_thread_pool.current_num_threads();
+            config.local.concurrency_level = num_cpus::get();
             Some(self.execute_transaction_block_impl_with_state_view(
                 sig_verified_block,
                 state_view,

--- a/execution/executor-benchmark/src/native/native_vm.rs
+++ b/execution/executor-benchmark/src/native/native_vm.rs
@@ -4,7 +4,7 @@
 use crate::{
     db_access::DbAccessUtil,
     native::{
-        native_config::{NativeConfig, NATIVE_EXECUTOR_POOL},
+        native_config::NativeConfig,
         native_transaction::{compute_deltas_for_batch, NativeTransaction},
     },
 };
@@ -64,7 +64,7 @@ use move_core_types::{
 };
 use move_vm_types::delayed_values::delayed_field_id::DelayedFieldID;
 use serde::{de::DeserializeOwned, Serialize};
-use std::{collections::BTreeMap, fmt::Debug, sync::Arc};
+use std::{collections::BTreeMap, fmt::Debug};
 
 pub struct NativeVMBlockExecutor;
 
@@ -86,12 +86,11 @@ impl VMBlockExecutor for NativeVMBlockExecutor {
         onchain_config: BlockExecutorConfigFromOnchain,
         transaction_slice_metadata: TransactionSliceMetadata,
     ) -> Result<BlockOutput<SignatureVerifiedTransaction, TransactionOutput>, VMStatus> {
-        AptosBlockExecutorWrapper::<NativeVMExecutorTask>::execute_block_on_thread_pool::<
+        AptosBlockExecutorWrapper::<NativeVMExecutorTask>::execute_block::<
             _,
             NoOpTransactionCommitHook<VMStatus>,
             _,
         >(
-            Arc::clone(&NATIVE_EXECUTOR_POOL),
             txn_provider,
             state_view,
             &AptosModuleCacheManager::new(),

--- a/testsuite/fuzzer/fuzz/fuzz_targets/move/aptosvm_authenticators.rs
+++ b/testsuite/fuzzer/fuzz/fuzz_targets/move/aptosvm_authenticators.rs
@@ -37,7 +37,7 @@ use move_core_types::{
 };
 use once_cell::sync::Lazy;
 use ring::signature;
-use std::sync::Arc;
+
 mod utils;
 use utils::{
     authenticator::{
@@ -52,26 +52,12 @@ use utils::{
 static VM: Lazy<WriteSet> = Lazy::new(|| GENESIS_CHANGE_SET_HEAD.write_set().clone());
 
 const FUZZER_CONCURRENCY_LEVEL: usize = 1;
-static TP: Lazy<Arc<rayon::ThreadPool>> = Lazy::new(|| {
-    Arc::new(
-        rayon::ThreadPoolBuilder::new()
-            .num_threads(FUZZER_CONCURRENCY_LEVEL)
-            .build()
-            .unwrap(),
-    )
-});
 
 fn run_case(input: TransactionState) -> Result<(), Corpus> {
     tdbg!(&input);
 
     AptosVM::set_concurrency_level_once(FUZZER_CONCURRENCY_LEVEL);
-    let mut vm = FakeExecutor::from_genesis_with_existing_thread_pool(
-        &VM,
-        ChainId::mainnet(),
-        Arc::clone(&TP),
-        None,
-    )
-    .set_not_parallel();
+    let mut vm = FakeExecutor::from_genesis(&VM, ChainId::mainnet()).set_not_parallel();
 
     let sender_acc = if true {
         // create sender pub/priv key. initialize and fund account

--- a/testsuite/fuzzer/fuzz/fuzz_targets/move/aptosvm_publish.rs
+++ b/testsuite/fuzzer/fuzz/fuzz_targets/move/aptosvm_publish.rs
@@ -16,7 +16,7 @@ use move_binary_format::{
     file_format::{CompiledModule, CompiledScript},
 };
 use once_cell::sync::Lazy;
-use std::{collections::HashSet, sync::Arc};
+use std::collections::HashSet;
 use utils::vm::{group_modules_by_address_topo, publish_group};
 
 // genesis write set generated once for each fuzzing session
@@ -24,14 +24,6 @@ static VM: Lazy<WriteSet> = Lazy::new(|| GENESIS_CHANGE_SET_HEAD.write_set().clo
 
 const TEST_UPGRADE: bool = true;
 const FUZZER_CONCURRENCY_LEVEL: usize = 1;
-static TP: Lazy<Arc<rayon::ThreadPool>> = Lazy::new(|| {
-    Arc::new(
-        rayon::ThreadPoolBuilder::new()
-            .num_threads(FUZZER_CONCURRENCY_LEVEL)
-            .build()
-            .unwrap(),
-    )
-});
 
 fn run_case(mut input: RunnableState) -> Result<(), Corpus> {
     tdbg!(&input);
@@ -72,13 +64,7 @@ fn run_case(mut input: RunnableState) -> Result<(), Corpus> {
     let packages = group_modules_by_address_topo(input.dep_modules.clone())?;
 
     AptosVM::set_concurrency_level_once(FUZZER_CONCURRENCY_LEVEL);
-    let mut vm = FakeExecutor::from_genesis_with_existing_thread_pool(
-        &VM,
-        ChainId::mainnet(),
-        Arc::clone(&TP),
-        None,
-    )
-    .set_not_parallel();
+    let mut vm = FakeExecutor::from_genesis(&VM, ChainId::mainnet()).set_not_parallel();
 
     // publish all packages
     for group in packages {

--- a/testsuite/fuzzer/fuzz/fuzz_targets/move/aptosvm_publish_and_run.rs
+++ b/testsuite/fuzzer/fuzz/fuzz_targets/move/aptosvm_publish_and_run.rs
@@ -22,7 +22,7 @@ use move_binary_format::{
 };
 use move_core_types::vm_status::{StatusCode, StatusType};
 use once_cell::sync::Lazy;
-use std::{collections::HashSet, sync::Arc, time::Instant};
+use std::{collections::HashSet, time::Instant};
 mod utils;
 use fuzzer::{Authenticator, ExecVariant, RunnableState};
 use move_vm_runtime::RuntimeEnvironment;
@@ -35,14 +35,6 @@ use utils::vm::{
 static VM_WRITE_SET: Lazy<WriteSet> = Lazy::new(|| GENESIS_CHANGE_SET_HEAD.write_set().clone());
 
 const FUZZER_CONCURRENCY_LEVEL: usize = 1;
-static TP: Lazy<Arc<rayon::ThreadPool>> = Lazy::new(|| {
-    Arc::new(
-        rayon::ThreadPoolBuilder::new()
-            .num_threads(FUZZER_CONCURRENCY_LEVEL)
-            .build()
-            .unwrap(),
-    )
-});
 
 const MAX_TYPE_PARAMETER_VALUE: u16 = 64 / 4 * 16; // third_party/move/move-bytecode-verifier/src/signature_v2.rs#L1306-L1312
 
@@ -113,13 +105,7 @@ fn run_case(mut input: RunnableState) -> Result<(), Corpus> {
     AptosVM::set_concurrency_level_once(FUZZER_CONCURRENCY_LEVEL);
     // Enable runtime reference-safety checks for the Move VM
     // prod_configs::set_paranoid_ref_checks(true);
-    let mut vm = FakeExecutor::from_genesis_with_existing_thread_pool(
-        &VM_WRITE_SET,
-        ChainId::mainnet(),
-        Arc::clone(&TP),
-        None,
-    )
-    .set_not_parallel();
+    let mut vm = FakeExecutor::from_genesis(&VM_WRITE_SET, ChainId::mainnet()).set_not_parallel();
 
     // publish all packages
     for group in packages {

--- a/testsuite/fuzzer/fuzz/fuzz_targets/move/aptosvm_publish_and_run_transactional.rs
+++ b/testsuite/fuzzer/fuzz/fuzz_targets/move/aptosvm_publish_and_run_transactional.rs
@@ -29,10 +29,7 @@ use move_core_types::{
 };
 use move_transactional_test_runner::transactional_ops::TransactionalOperation;
 use once_cell::sync::Lazy;
-use std::{
-    collections::{HashMap, HashSet},
-    sync::Arc,
-};
+use std::collections::{HashMap, HashSet};
 mod utils;
 use fuzzer::RunnableStateWithOperations;
 use utils::vm::{
@@ -44,14 +41,6 @@ use utils::vm::{
 static VM_WRITE_SET: Lazy<WriteSet> = Lazy::new(|| GENESIS_CHANGE_SET_HEAD.write_set().clone());
 
 const FUZZER_CONCURRENCY_LEVEL: usize = 4;
-static TP: Lazy<Arc<rayon::ThreadPool>> = Lazy::new(|| {
-    Arc::new(
-        rayon::ThreadPoolBuilder::new()
-            .num_threads(FUZZER_CONCURRENCY_LEVEL)
-            .build()
-            .unwrap(),
-    )
-});
 
 const MAX_TYPE_PARAMETER_VALUE: u16 = 64 / 4 * 16; // third_party/move/move-bytecode-verifier/src/signature_v2.rs#L1306-L1312
 
@@ -140,10 +129,9 @@ fn run_case(input: RunnableStateWithOperations) -> Result<(), Corpus> {
 
     let module_cache_manager = AptosModuleCacheManager::new();
     AptosVM::set_concurrency_level_once(FUZZER_CONCURRENCY_LEVEL);
-    let mut vm = FakeExecutor::from_genesis_with_existing_thread_pool(
+    let mut vm = FakeExecutor::from_genesis_with_module_cache(
         &VM_WRITE_SET,
         ChainId::mainnet(),
-        Arc::clone(&TP),
         Some(module_cache_manager),
     )
     .set_parallel();


### PR DESCRIPTION

Make `execute_block` the sole public API on `AptosBlockExecutorWrapper`,
always using the global `RAYON_EXEC_POOL` internally. This eliminates the
need for callers to create and pass their own rayon thread pools for block
execution, simplifying the interface ahead of switching to a tokio runtime.

- Merge `execute_block_on_thread_pool` implementation into `execute_block`
- Update sharded executor to call `execute_block` for inner execution
  (per-shard pool retained for the outer scope and async drop)
- Remove `executor_thread_pool` field from `FakeExecutorImpl` and all
  constructors; rename `from_genesis_with_existing_thread_pool` to
  `from_genesis_with_module_cache`
- Update native VM benchmark and fuzzer targets accordingly

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/aptos-labs/aptos-core/pull/19331).
* #19332
* __->__ #19331