### PR TITLE
fix rotate-key crash when no default profile exists

### DIFF
--- a/crates/aptos/src/account/key_rotation.rs
+++ b/crates/aptos/src/account/key_rotation.rs
@@ -124,17 +124,17 @@ impl CliCommand<RotateSummary> for RotateKey {
                 ));
             };
 
-            // Verify that config exists by attempting to load it.
-            let config = CliConfig::load(ConfigSearchMode::CurrentDirAndParents)?;
-
-            // Verify that the new profile name does not already exist in the config.
-            if let Some(profiles) = config.profiles {
-                if profiles.contains_key(new_profile_name) {
-                    return Err(CliError::CommandArgumentError(format!(
-                        "Profile {} already exists",
-                        new_profile_name
-                    )));
-                };
+            // If a config exists, verify that the new profile name does not already exist.
+            if CliConfig::config_exists(ConfigSearchMode::CurrentDirAndParents) {
+                let config = CliConfig::load(ConfigSearchMode::CurrentDirAndParents)?;
+                if let Some(profiles) = config.profiles {
+                    if profiles.contains_key(new_profile_name) {
+                        return Err(CliError::CommandArgumentError(format!(
+                            "Profile {} already exists",
+                            new_profile_name
+                        )));
+                    };
+                }
             }
         };
 
@@ -292,20 +292,28 @@ impl CliCommand<RotateSummary> for RotateKey {
         // specified, then it will have already been error checked above.
         let new_profile_name = self.new_profile_options.save_to_profile.unwrap();
 
-        // If no config exists, then the error should've been caught earlier during the profile
-        // name verification step.
-        let mut config = CliConfig::load(ConfigSearchMode::CurrentDirAndParents)?;
+        // If no config exists, create a default one instead of erroring out.
+        let mut config = if CliConfig::config_exists(ConfigSearchMode::CurrentDirAndParents) {
+            CliConfig::load(ConfigSearchMode::CurrentDirAndParents)?
+        } else {
+            CliConfig::default()
+        };
         if config.profiles.is_none() {
             config.profiles = Some(BTreeMap::new());
         }
 
-        // Create new config.
+        // Create new config. Fall back to default if no existing profile is available.
+        let base_profile = self
+            .txn_options
+            .profile_options
+            .profile()
+            .unwrap_or_default();
         let mut new_profile_config = ProfileConfig {
             public_key: Some(new_public_key),
             account: Some(current_address),
             private_key: new_private_key,
             derivation_path: new_derivation_path,
-            ..self.txn_options.profile_options.profile()?
+            ..base_profile
         };
 
         if let Some(url) = self.txn_options.rest_options.url {


### PR DESCRIPTION
## summary
- fix rotate-key crashing when no default profile exists in config
- check if config exists before loading default profile, create if needed

## test plan
- verified rotate-key no longer panics without a default profile

fixes #9547

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to CLI profile/config handling when saving the rotated key, mainly adding existence checks and fallbacks to defaults.
> 
> **Overview**
> `aptos account rotate-key` no longer crashes when run without an existing CLI config or a default profile.
> 
> The command now checks whether a config file exists before loading it during profile-name validation, creates a default config when saving a new profile if none exists, and builds the new `ProfileConfig` using a default base profile when the current profile can’t be loaded.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60e169fe246cfc6976407cca6add270bfc5b13c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->