### PR TITLE
[consensus] Strict leader reputation with 1 faulty validator at 4k TPS

### DIFF
--- a/aptos-move/aptos-release-builder/data/example-release-with-randomness-framework/release.yaml
+++ b/aptos-move/aptos-release-builder/data/example-release-with-randomness-framework/release.yaml
@@ -34,6 +34,7 @@ proposals:
                         voter_window_num_validators_multiplier: 1
                         weight_by_voting_power: true
                         use_history_from_previous_epoch_max_count: 5
+                        failure_window_num_validators_multiplier: 0
                   max_failed_authors_to_store: 10
                 quorum_store_enabled: true
             vtxn:

--- a/aptos-move/aptos-release-builder/data/example.yaml
+++ b/aptos-move/aptos-release-builder/data/example.yaml
@@ -62,6 +62,7 @@ proposals:
                   voter_window_num_validators_multiplier: 1
                   weight_by_voting_power: true
                   use_history_from_previous_epoch_max_count: 5
+                  failure_window_num_validators_multiplier: 0
             max_failed_authors_to_store: 10
       - Execution:
           V1:

--- a/consensus/src/dag/bootstrap.rs
+++ b/consensus/src/dag/bootstrap.rs
@@ -406,12 +406,21 @@ impl DagBootstrapper {
                 )
             })
             .collect();
+        let failure_window_multiplier = if config.failure_window_num_validators_multiplier > 0 {
+            config.failure_window_num_validators_multiplier
+        } else {
+            config.proposer_window_num_validators_multiplier
+        };
         let metadata_adapter = Arc::new(MetadataBackendAdapter::new(
             num_validators
-                * std::cmp::max(
+                * [
                     config.proposer_window_num_validators_multiplier,
                     config.voter_window_num_validators_multiplier,
-                ),
+                    failure_window_multiplier,
+                ]
+                .into_iter()
+                .max()
+                .unwrap(),
             epoch_to_validator_map,
         ));
         let heuristic: Box<dyn ReputationHeuristic> = Box::new(ProposerAndVoterHeuristic::new(
@@ -422,6 +431,7 @@ impl DagBootstrapper {
             config.failure_threshold_percent,
             num_validators * config.voter_window_num_validators_multiplier,
             num_validators * config.proposer_window_num_validators_multiplier,
+            num_validators * failure_window_multiplier,
             false,
         ));
 

--- a/consensus/src/epoch_manager.rs
+++ b/consensus/src/epoch_manager.rs
@@ -329,6 +329,16 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
                             * proposer_and_voter_config.proposer_window_num_validators_multiplier;
                         let voter_window_size = proposers.len()
                             * proposer_and_voter_config.voter_window_num_validators_multiplier;
+                        // Use separate failure window if configured, otherwise fall back to proposer window
+                        let failure_window_size = if proposer_and_voter_config
+                            .failure_window_num_validators_multiplier
+                            > 0
+                        {
+                            proposers.len()
+                                * proposer_and_voter_config.failure_window_num_validators_multiplier
+                        } else {
+                            proposer_window_size
+                        };
                         let heuristic: Box<dyn ReputationHeuristic> =
                             Box::new(ProposerAndVoterHeuristic::new(
                                 self.author,
@@ -338,11 +348,15 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
                                 proposer_and_voter_config.failure_threshold_percent,
                                 voter_window_size,
                                 proposer_window_size,
+                                failure_window_size,
                                 leader_reputation_type.use_reputation_window_from_stale_end(),
                             ));
                         (
                             heuristic,
-                            std::cmp::max(proposer_window_size, voter_window_size),
+                            [proposer_window_size, voter_window_size, failure_window_size]
+                                .into_iter()
+                                .max()
+                                .unwrap(),
                             proposer_and_voter_config.weight_by_voting_power,
                             proposer_and_voter_config.use_history_from_previous_epoch_max_count,
                         )

--- a/consensus/src/liveness/leader_reputation.rs
+++ b/consensus/src/liveness/leader_reputation.rs
@@ -231,6 +231,9 @@ pub struct NewBlockEventAggregation {
     // dependig on how many failures we have.
     voter_window_size: usize,
     proposer_window_size: usize,
+    // Separate window for counting failed proposals. When larger than proposer_window_size,
+    // failures are remembered for longer, preventing oscillation between failed/inactive/active.
+    failure_window_size: usize,
     reputation_window_from_stale_end: bool,
 }
 
@@ -238,11 +241,13 @@ impl NewBlockEventAggregation {
     pub fn new(
         voter_window_size: usize,
         proposer_window_size: usize,
+        failure_window_size: usize,
         reputation_window_from_stale_end: bool,
     ) -> Self {
         Self {
             voter_window_size,
             proposer_window_size,
+            failure_window_size,
             reputation_window_from_stale_end,
         }
     }
@@ -433,7 +438,7 @@ impl NewBlockEventAggregation {
         Self::history_iter(
             history,
             epoch_to_candidates,
-            self.proposer_window_size,
+            self.failure_window_size,
             self.reputation_window_from_stale_end,
         )
         .fold(HashMap::new(), |mut map, meta| {
@@ -501,6 +506,7 @@ impl ProposerAndVoterHeuristic {
         failure_threshold_percent: u32,
         voter_window_size: usize,
         proposer_window_size: usize,
+        failure_window_size: usize,
         reputation_window_from_stale_end: bool,
     ) -> Self {
         Self {
@@ -512,6 +518,7 @@ impl ProposerAndVoterHeuristic {
             aggregation: NewBlockEventAggregation::new(
                 voter_window_size,
                 proposer_window_size,
+                failure_window_size,
                 reputation_window_from_stale_end,
             ),
         }

--- a/consensus/src/liveness/leader_reputation_test.rs
+++ b/consensus/src/liveness/leader_reputation_test.rs
@@ -145,7 +145,7 @@ fn test_aggregation_counting() {
     let mut example1 = Example1::new(5);
     let validators0 = example1.validators0.clone();
     let epoch_to_validators = HashMap::from([(0u64, validators0.clone())]);
-    let aggregation = NewBlockEventAggregation::new(2, 5, false);
+    let aggregation = NewBlockEventAggregation::new(2, 5, 5, false);
 
     example1.step1();
 
@@ -244,7 +244,7 @@ fn test_proposer_and_voter_heuristic() {
     let validators0 = example1.validators0.clone();
     let epoch_to_validators0 = HashMap::from([(0u64, validators0.clone())]);
     let heuristic =
-        ProposerAndVoterHeuristic::new(example1.validators0[0], 100, 10, 1, 49, 2, 5, false);
+        ProposerAndVoterHeuristic::new(example1.validators0[0], 100, 10, 1, 49, 2, 5, 5, false);
 
     example1.step1();
     assert_eq!(
@@ -332,6 +332,7 @@ fn test_api(use_root_hash: bool) {
                 inactive_weight,
                 0,
                 10,
+                proposers.len(),
                 proposers.len(),
                 proposers.len(),
                 false,

--- a/testsuite/forge-cli/src/suites/realistic_environment.rs
+++ b/testsuite/forge-cli/src/suites/realistic_environment.rs
@@ -19,8 +19,10 @@ use aptos_forge::{
     EmitJobMode, EmitJobRequest, ForgeConfig, NetworkTest, NodeResourceOverride,
 };
 use aptos_sdk::types::on_chain_config::{
-    BlockGasLimitType, FeatureFlag, Features, OnChainChunkyDKGConfig, OnChainConsensusConfig,
-    OnChainExecutionConfig, OnChainRandomnessConfig, TransactionShufflerType,
+    BlockGasLimitType, ConsensusAlgorithmConfig, FeatureFlag, Features, LeaderReputationType,
+    OnChainChunkyDKGConfig, OnChainConsensusConfig, OnChainExecutionConfig,
+    OnChainRandomnessConfig, ProposerAndVoterConfig, ProposerElectionType,
+    TransactionShufflerType,
 };
 use aptos_testcases::{
     load_vs_perf_benchmark::{LoadVsPerfBenchmark, TransactionWorkload, Workloads},
@@ -444,9 +446,30 @@ pub(crate) fn realistic_env_max_load_test(
         .with_genesis_helm_config_fn(Arc::new(move |helm_values| {
             // No epoch change so measurements are stable.
             helm_values["chain"]["epoch_duration_secs"] = (24 * 3600).into();
+            // Set failure_window_num_validators_multiplier to 50 so failed validators
+            // stay penalized even after restart, preventing failed→inactive→active oscillation.
+            let mut consensus_config = OnChainConsensusConfig::default_for_genesis();
+            if let OnChainConsensusConfig::V5 {
+                alg: ConsensusAlgorithmConfig::JolteonV2 { ref mut main, .. },
+                ..
+            } = consensus_config
+            {
+                main.proposer_election_type = ProposerElectionType::LeaderReputation(
+                    LeaderReputationType::ProposerAndVoterV2(ProposerAndVoterConfig {
+                        active_weight: 1000,
+                        inactive_weight: 10,
+                        failed_weight: 1,
+                        failure_threshold_percent: 10,
+                        proposer_window_num_validators_multiplier: 10,
+                        voter_window_num_validators_multiplier: 1,
+                        weight_by_voting_power: true,
+                        use_history_from_previous_epoch_max_count: 5,
+                        failure_window_num_validators_multiplier: 50,
+                    }),
+                );
+            }
             helm_values["chain"]["on_chain_consensus_config"] =
-                serde_yaml::to_value(OnChainConsensusConfig::default_for_genesis())
-                    .expect("must serialize");
+                serde_yaml::to_value(consensus_config).expect("must serialize");
             helm_values["chain"]["on_chain_execution_config"] =
                 serde_yaml::to_value(OnChainExecutionConfig::default_for_genesis())
                     .expect("must serialize");

--- a/types/src/on_chain_config/consensus_config.rs
+++ b/types/src/on_chain_config/consensus_config.rs
@@ -480,6 +480,7 @@ impl Default for ConsensusConfigV1 {
                     voter_window_num_validators_multiplier: 1,
                     weight_by_voting_power: true,
                     use_history_from_previous_epoch_max_count: 5,
+                    failure_window_num_validators_multiplier: 0,
                 }),
             ),
         }
@@ -553,6 +554,12 @@ pub struct ProposerAndVoterConfig {
     // representing a number of historical epochs (beyond the current one)
     // to consider.
     pub use_history_from_previous_epoch_max_count: u32,
+    // Window into history considered for failure statistics, multiplier
+    // on top of number of validators. When 0, falls back to proposer_window_num_validators_multiplier.
+    // A larger failure window keeps failed validators penalized for longer,
+    // preventing oscillation between failed/inactive/active states.
+    #[serde(default)]
+    pub failure_window_num_validators_multiplier: usize,
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -583,6 +590,7 @@ impl Default for DagConsensusConfigV1 {
                     voter_window_num_validators_multiplier: 1,
                     weight_by_voting_power: true,
                     use_history_from_previous_epoch_max_count: 5,
+                    failure_window_num_validators_multiplier: 0,
                 }),
             ),
         }


### PR DESCRIPTION
## Summary
- `daniel/latency-baseline-by-skip` + `daniel/strict-leader` combined
- `realistic_env_max_load` at ConstTps 4k with 1 faulty validator (last by index, skips 50% of proposals)
- Strict leader reputation: `failure_window_num_validators_multiplier` added (default 0, falls back to proposer window)
- Prototype/experiment code — not for merge to main

## Test plan
- [ ] Run forge `land_blocking` and compare latency against `daniel/latency-baseline-by-skip` (PR #19330)

🤖 Generated with [Claude Code](https://claude.com/claude-code)