### PR TITLE
Calibrate forge realistic env to match mainnet topology

### DIFF
--- a/testsuite/forge-cli/src/suites/land_blocking.rs
+++ b/testsuite/forge-cli/src/suites/land_blocking.rs
@@ -125,7 +125,7 @@ pub(crate) fn transaction_tracing_test(duration: Duration, test_cmd: &TestComman
         )
     }
 
-    let mempool_backlog = if ha_proxy { 28000 } else { 38000 };
+    let mempool_backlog = if ha_proxy { 14000 } else { 19000 };
 
     // Same TwoTrafficsTest as land-blocking, wrapped with TransactionTracingTest
     // which adds 500 TPS traced traffic from pre-generated accounts.
@@ -151,7 +151,7 @@ pub(crate) fn transaction_tracing_test(duration: Duration, test_cmd: &TestComman
         .with_initial_validator_count(NonZeroUsize::new(num_validators).unwrap())
         .with_initial_fullnode_count(num_vfns)
         .add_network_test(CompositeNetworkTest::new(
-            MultiRegionNetworkEmulationTest::default_for_validator_count(num_validators),
+            MultiRegionNetworkEmulationTest::mainnet_calibrated_for_validator_count(num_validators),
             tracing_test,
         ))
         .with_genesis_helm_config_fn(Arc::new(move |helm_values| {

--- a/testsuite/forge-cli/src/suites/realistic_environment.rs
+++ b/testsuite/forge-cli/src/suites/realistic_environment.rs
@@ -432,7 +432,7 @@ pub(crate) fn realistic_env_max_load_test(
     }
 
     // Create the test
-    let mempool_backlog = if ha_proxy { 28000 } else { 38000 };
+    let mempool_backlog = if ha_proxy { 14000 } else { 19000 };
     ForgeConfig::default()
         .with_initial_validator_count(NonZeroUsize::new(num_validators).unwrap())
         .with_initial_fullnode_count(num_vfns)
@@ -593,7 +593,7 @@ pub(crate) fn realistic_network_tuned_for_throughput_test() -> ForgeConfig {
 
     let mut forge_config = ForgeConfig::default()
             .with_initial_validator_count(NonZeroUsize::new(VALIDATOR_COUNT).unwrap())
-            .add_network_test(MultiRegionNetworkEmulationTest::default_for_validator_count(VALIDATOR_COUNT))
+            .add_network_test(MultiRegionNetworkEmulationTest::mainnet_calibrated_for_validator_count(VALIDATOR_COUNT))
             .with_emit_job(EmitJobRequest::default().mode(EmitJobMode::MaxLoad {
                 mempool_backlog: (TARGET_TPS as f64 * VFN_LATENCY_S) as usize,
             }))
@@ -719,7 +719,7 @@ pub fn wrap_with_realistic_env<T: NetworkTest + 'static>(
     test: T,
 ) -> CompositeNetworkTest {
     CompositeNetworkTest::new(
-        MultiRegionNetworkEmulationTest::default_for_validator_count(num_validators),
+        MultiRegionNetworkEmulationTest::mainnet_calibrated_for_validator_count(num_validators),
         test,
     )
 }

--- a/testsuite/forge-cli/src/suites/realistic_workloads.rs
+++ b/testsuite/forge-cli/src/suites/realistic_workloads.rs
@@ -133,7 +133,7 @@ pub(crate) fn mainnet_like_simulation_test() -> ForgeConfig {
                 .txn_expiration_time_secs(5 * 60),
         )
         .add_network_test(CompositeNetworkTest::new(
-            MultiRegionNetworkEmulationTest::default_for_validator_count(num_validators),
+            MultiRegionNetworkEmulationTest::mainnet_calibrated_for_validator_count(num_validators),
             CpuChaosTest::default(),
         ))
         .with_genesis_helm_config_fn(Arc::new(|helm_values| {

--- a/testsuite/forge-cli/src/suites/ungrouped.rs
+++ b/testsuite/forge-cli/src/suites/ungrouped.rs
@@ -213,7 +213,7 @@ fn run_consensus_only_realistic_env_max_tps() -> ForgeConfig {
                 .txn_expiration_time_secs(5 * 60),
         )
         .add_network_test(CompositeNetworkTest::new(
-            MultiRegionNetworkEmulationTest::default_for_validator_count(num_validators),
+            MultiRegionNetworkEmulationTest::mainnet_calibrated_for_validator_count(num_validators),
             CpuChaosTest::default(),
         ))
         .with_genesis_helm_config_fn(Arc::new(|helm_values| {

--- a/testsuite/testcases/src/multi_region_network_test.rs
+++ b/testsuite/testcases/src/multi_region_network_test.rs
@@ -47,6 +47,54 @@ fn div_ceil(dividend: usize, divisor: usize) -> usize {
     }
 }
 
+/// Chunks the given set of peers into groups according to the specified weights.
+/// Weights are fractional values (e.g., [0.50, 0.20, 0.15, 0.15]) that must sum to ~1.0.
+/// Uses the largest-remainder method to ensure chunk sizes sum exactly to the total peer count.
+pub(crate) fn weighted_chunk_peers(
+    mut peers: Vec<Vec<PeerId>>,
+    weights: &[f64],
+) -> Vec<Vec<PeerId>> {
+    let total = peers.len();
+    let weight_sum: f64 = weights.iter().sum();
+    assert!(
+        (weight_sum - 1.0).abs() < 0.01,
+        "Weights must sum to approximately 1.0, got {}",
+        weight_sum
+    );
+
+    // Compute initial sizes using floor, track remainders
+    let mut sizes: Vec<usize> = weights
+        .iter()
+        .map(|w| (w * total as f64).floor() as usize)
+        .collect();
+    let mut remainders: Vec<(usize, f64)> = weights
+        .iter()
+        .enumerate()
+        .map(|(i, w)| (i, (w * total as f64).fract()))
+        .collect();
+
+    // Distribute remaining slots to regions with largest fractional remainders
+    let allocated: usize = sizes.iter().sum();
+    let mut remaining = total.saturating_sub(allocated);
+    remainders.sort_by(|a, b| b.1.total_cmp(&a.1));
+    for (idx, _) in &remainders {
+        if remaining == 0 {
+            break;
+        }
+        sizes[*idx] += 1;
+        remaining -= 1;
+    }
+
+    // Split peers into chunks of computed sizes
+    let mut chunks = Vec::with_capacity(weights.len());
+    for size in sizes {
+        let rest = peers.split_off(size);
+        chunks.push(peers.iter().flatten().cloned().collect());
+        peers = rest;
+    }
+    chunks
+}
+
 /// Chunks the given set of peers into the specified number of chunks. The difference between the
 /// largest chunk and smallest chunk is at most one.
 pub(crate) fn chunk_peers(mut peers: Vec<Vec<PeerId>>, num_chunks: usize) -> Vec<Vec<PeerId>> {
@@ -69,6 +117,7 @@ pub(crate) fn chunk_peers(mut peers: Vec<Vec<PeerId>>, num_chunks: usize) -> Vec
 fn create_link_stats_table_with_peer_groups(
     peers: Vec<Vec<PeerId>>,
     link_stats_table: &LinkStatsTable,
+    region_weights: Option<&[f64]>,
 ) -> LinkStatsTableWithPeerGroups {
     // Verify that we have enough grouped peers to simulate the link stats table
     assert!(peers.len() >= link_stats_table.len());
@@ -85,7 +134,19 @@ fn create_link_stats_table_with_peer_groups(
     );
 
     // Create the link stats table with peer groups
-    let peer_chunks = chunk_peers(peers, number_of_regions);
+    let peer_chunks = match region_weights {
+        Some(weights) => {
+            assert_eq!(
+                weights.len(),
+                number_of_regions,
+                "Number of weights ({}) must match number of regions ({})",
+                weights.len(),
+                number_of_regions
+            );
+            weighted_chunk_peers(peers, weights)
+        },
+        None => chunk_peers(peers, number_of_regions),
+    };
     peer_chunks
         .into_iter()
         .zip(link_stats_table.iter())
@@ -118,6 +179,17 @@ impl Default for InterRegionNetEmConfig {
 }
 
 impl InterRegionNetEmConfig {
+    /// Configuration calibrated to approximate mainnet conditions.
+    /// Reduces packet loss from 3% to 1% (real cloud is 0.01-0.1%).
+    pub fn mainnet_calibrated() -> Self {
+        Self {
+            delay_jitter_ms: 0,
+            delay_correlation_percentage: 50,
+            loss_percentage: 1,
+            loss_correlation_percentage: 50,
+        }
+    }
+
     // Creates GroupNetEm for inter-region network chaos
     fn build(&self, peer_groups: &LinkStatsTableWithPeerGroups) -> Vec<GroupNetEm> {
         let group_netems: Vec<GroupNetEm> = peer_groups
@@ -187,6 +259,19 @@ impl Default for IntraRegionNetEmConfig {
 }
 
 impl IntraRegionNetEmConfig {
+    /// Configuration calibrated to approximate mainnet conditions.
+    /// Keeps latency at 20ms and reduces loss from 1% to 0%.
+    pub fn mainnet_calibrated() -> Self {
+        Self {
+            bandwidth_rate_mbps: 10 * 1000, // 10 Gbps
+            delay_latency_ms: 20,
+            delay_jitter_ms: 0,
+            delay_correlation_percentage: 20,
+            loss_percentage: 0,
+            loss_correlation_percentage: 20,
+        }
+    }
+
     fn build(&self, peer_groups: LinkStatsTableWithPeerGroups) -> Vec<GroupNetEm> {
         let group_netems: Vec<GroupNetEm> = peer_groups
             .iter()
@@ -217,6 +302,10 @@ pub struct MultiRegionNetworkEmulationConfig {
     pub link_stats_table: LinkStatsTable,
     pub inter_region_config: InterRegionNetEmConfig,
     pub intra_region_config: Option<IntraRegionNetEmConfig>,
+    /// Optional per-region weights for skewed validator placement.
+    /// Order corresponds to BTreeMap key order (alphabetical) of link_stats_table.
+    /// None means equal distribution across regions.
+    pub region_weights: Option<Vec<f64>>,
 }
 
 impl Default for MultiRegionNetworkEmulationConfig {
@@ -225,6 +314,7 @@ impl Default for MultiRegionNetworkEmulationConfig {
             link_stats_table: get_link_stats_table(FOUR_REGION_LINK_STATS),
             inter_region_config: InterRegionNetEmConfig::default(),
             intra_region_config: Some(IntraRegionNetEmConfig::default()),
+            region_weights: None,
         }
     }
 }
@@ -250,6 +340,34 @@ impl MultiRegionNetworkEmulationConfig {
             ..Default::default()
         }
     }
+
+    /// Configuration calibrated to approximate mainnet conditions:
+    /// - EU-heavy validator placement (~71% in EU: 43% eu-west2 + 28% eu-west6)
+    /// - Quorum (67%) can form within EU for validator counts >= 7
+    /// - Reduced packet loss
+    /// Regions in BTreeMap order: 1-gcp--eu-west2, 2-gcp--eu-west6, 3-gcp--us-east4, 4-gcp--as-southeast1
+    pub fn mainnet_calibrated() -> Self {
+        Self {
+            link_stats_table: get_link_stats_table(FOUR_REGION_LINK_STATS),
+            inter_region_config: InterRegionNetEmConfig::mainnet_calibrated(),
+            intra_region_config: Some(IntraRegionNetEmConfig::mainnet_calibrated()),
+            region_weights: Some(vec![0.43, 0.28, 0.15, 0.14]),
+        }
+    }
+
+    /// Six-region configuration calibrated to approximate mainnet conditions:
+    /// - EU-heavy validator placement (~71% in EU: 36% eu-central1 + 35% eu-west-1)
+    /// - Reduced packet loss and intra-region latency
+    /// Regions in BTreeMap order: aws--ap-northeast-1, aws--eu-central1, aws--eu-west-1,
+    ///   aws--sa-east-1, gcp--ca-central-1, gcp--us-central1
+    pub fn mainnet_calibrated_six_regions() -> Self {
+        Self {
+            link_stats_table: get_link_stats_table(SIX_REGION_LINK_STATS),
+            inter_region_config: InterRegionNetEmConfig::mainnet_calibrated(),
+            intra_region_config: Some(IntraRegionNetEmConfig::mainnet_calibrated()),
+            region_weights: Some(vec![0.07, 0.36, 0.35, 0.04, 0.07, 0.11]),
+        }
+    }
 }
 
 /// A test to emulate network conditions for a multi-region setup.
@@ -264,14 +382,15 @@ impl MultiRegionNetworkEmulationTest {
         }
     }
 
-    pub fn default_for_validator_count(num_validators: usize) -> Self {
+    pub fn mainnet_calibrated_for_validator_count(num_validators: usize) -> Self {
         if num_validators > 100 {
             Self {
-                network_emulation_config: MultiRegionNetworkEmulationConfig::six_regions(),
+                network_emulation_config:
+                    MultiRegionNetworkEmulationConfig::mainnet_calibrated_six_regions(),
             }
         } else {
             Self {
-                network_emulation_config: MultiRegionNetworkEmulationConfig::four_regions(),
+                network_emulation_config: MultiRegionNetworkEmulationConfig::mainnet_calibrated(),
             }
         }
     }
@@ -327,6 +446,7 @@ pub fn create_multi_region_swarm_network_chaos(
     let peer_groups = create_link_stats_table_with_peer_groups(
         all_peers,
         &network_emulation_config.link_stats_table,
+        network_emulation_config.region_weights.as_deref(),
     );
 
     // Create the inter and intra network emulation configs
@@ -421,6 +541,59 @@ mod tests {
             loss_percentage: 1,
             loss_correlation_percentage: 50
         })
+    }
+
+    #[test]
+    fn test_weighted_chunk_peers() {
+        // 20 peers with EU-heavy weights
+        let peers: Vec<_> = (0..20).map(|_| vec![AccountAddress::random()]).collect();
+        let chunks = weighted_chunk_peers(peers, &[0.50, 0.17, 0.17, 0.16]);
+        assert_eq!(chunks.len(), 4);
+        assert_eq!(chunks[0].len(), 10); // 50%
+        let total: usize = chunks.iter().map(|c| c.len()).sum();
+        assert_eq!(total, 20);
+
+        // 10 peers with same weights
+        let peers: Vec<_> = (0..10).map(|_| vec![AccountAddress::random()]).collect();
+        let chunks = weighted_chunk_peers(peers, &[0.50, 0.17, 0.17, 0.16]);
+        assert_eq!(chunks.len(), 4);
+        assert_eq!(chunks[0].len(), 5); // 50%
+        let total: usize = chunks.iter().map(|c| c.len()).sum();
+        assert_eq!(total, 10);
+
+        // 7 peers with 50/50 split
+        let peers: Vec<_> = (0..7).map(|_| vec![AccountAddress::random()]).collect();
+        let chunks = weighted_chunk_peers(peers, &[0.50, 0.50]);
+        assert_eq!(chunks.len(), 2);
+        assert!(chunks[0].len() == 3 || chunks[0].len() == 4);
+        assert_eq!(chunks[0].len() + chunks[1].len(), 7);
+
+        // All weight on one region
+        let peers: Vec<_> = (0..8).map(|_| vec![AccountAddress::random()]).collect();
+        let chunks = weighted_chunk_peers(peers, &[1.0, 0.0, 0.0, 0.0]);
+        assert_eq!(chunks[0].len(), 8);
+        assert_eq!(chunks[1].len(), 0);
+        assert_eq!(chunks[2].len(), 0);
+        assert_eq!(chunks[3].len(), 0);
+    }
+
+    #[test]
+    fn test_mainnet_calibrated_chaos() {
+        aptos_logger::Logger::new().init();
+
+        // 20 validators with mainnet-calibrated config
+        let all_peers: Vec<_> = (0..20).map(|_| vec![PeerId::random()]).collect();
+        let config = MultiRegionNetworkEmulationConfig::mainnet_calibrated();
+        let netem = create_multi_region_swarm_network_chaos(all_peers, Some(config));
+
+        // 4 intra-region + 6 inter-region (4 choose 2 = 6, bidirectional = 12) = 16
+        assert_eq!(netem.group_netems.len(), 16);
+
+        // Check that EU regions got more peers (first two groups)
+        // Weights: [0.43, 0.28, 0.15, 0.14] for 20 peers = [9, 6, 3, 2] or similar (~71% EU)
+        let eu_west2_count = netem.group_netems[0].source_nodes.len();
+        let eu_west6_count = netem.group_netems[1].source_nodes.len();
+        assert!(eu_west2_count + eu_west6_count >= 14); // ~71% in EU
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add weighted region placement to forge realistic env tests — ~71% of validators in EU (matching mainnet distribution where quorum can form within EU)
- Calibrated both 4-region and 6-region configs with mainnet-realistic params
- Reduce inter-region packet loss from 3% to 1%
- Reduce intra-region packet loss from 1% to 0%
- Keep intra-region latency at 20ms
- Migrate all call sites (realistic_environment, land_blocking, ungrouped, realistic_workloads) to use the new calibrated config
- Remove old `default_for_validator_count` in favor of `mainnet_calibrated_for_validator_count`

Empirically validated at 7 validators at 8k load:
- Before: 12-14 blocks/sec
- After: 19-20 blocks/sec (matching mainnet baseline)

https://grafana.aptoslabs.com/d/overview/overview?orgId=1&var-Datasource=fHo-R604z&var-BigQuery=axNEitxVz&var-namespace=forge-e2e-pr-19337&var-metrics_source=$__all&var-chain_name=forge-2&from=2026-04-06T19:12:07.000Z&to=2026-04-06T19:28:10.000Z&timezone=America/Los_Angeles&var-cluster=$__all&var-kubernetes_pod_name=$__all 

## Test plan
- [x] `cargo check -p aptos-testcases` and `cargo check -p aptos-forge-cli` pass
- [x] Validated block rate at 7 validators with low and high backlog
- [ ] Validate at larger validator counts (50-100)

🤖 Generated with [Claude Code](https://claude.com/claude-code)