### PR TITLE
[keyless] Clarify pepper exp validation safety

### DIFF
--- a/keyless/pepper/service/src/dedicated_handlers/pepper_request.rs
+++ b/keyless/pepper/service/src/dedicated_handlers/pepper_request.rs
@@ -387,7 +387,10 @@ async fn verify_jwt_signature(
     // Validate the JWT signature.
     // TODO: can we avoid decoding the JWT twice?
     let mut validation_with_sig_verification = Validation::new(RS256);
-    validation_with_sig_verification.validate_exp = false; // Don't validate the exp time
+    // We intentionally skip JWT `exp` validation here: pepper access
+    // is still time-bounded by EPK expiration checks and nonce binding,
+    // so a leaked JWT alone does not grant indefinite pepper access.
+    validation_with_sig_verification.validate_exp = false;
     jsonwebtoken::decode::<Claims>(jwt, &jwk_decoding_key, &validation_with_sig_verification) // Signature verification happens here
         .map_err(|e| {
             PepperServiceError::BadRequest(format!("JWT signature verification failed: {e}"))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## AI Description
- Clarifies why `validation_with_sig_verification.validate_exp = false` in pepper service is intentional and not an attack vector.
