### PR TITLE
[consensus] Latency-weighted leader reputation heuristic

### DIFF
--- a/config/src/config/consensus_config.rs
+++ b/config/src/config/consensus_config.rs
@@ -116,6 +116,10 @@ pub struct ConsensusConfig {
     /// round-time performance so that validators that commit quorums faster are elected
     /// as leaders proportionally more often.
     pub use_latency_weighted_leader: bool,
+    /// Exponent for latency-weighted leader selection. The weight for an active validator is
+    /// `active_weight * (max_median / median_rt)^multiplier`. Higher values more aggressively
+    /// favor low-latency proposers. Default 1 gives linear scaling.
+    pub latency_weight_multiplier: f64,
 }
 
 /// Deprecated
@@ -410,6 +414,7 @@ impl Default for ConsensusConfig {
             enable_optimistic_proposal_tx: true,
             num_tokio_worker_threads: 0,
             use_latency_weighted_leader: false,
+            latency_weight_multiplier: 1.0,
         }
     }
 }

--- a/config/src/config/consensus_config.rs
+++ b/config/src/config/consensus_config.rs
@@ -112,6 +112,10 @@ pub struct ConsensusConfig {
     // Number of tokio worker theads to use for the Consensus runtime.
     // If set to 0, it will be minimum of num_cpus/2 and DEFAULT_WORKER_THREADS.
     pub num_tokio_worker_threads: u16,
+    /// When true, scale active-validator weights in LeaderReputation by their historical
+    /// round-time performance so that validators that commit quorums faster are elected
+    /// as leaders proportionally more often.
+    pub use_latency_weighted_leader: bool,
 }
 
 /// Deprecated
@@ -405,6 +409,7 @@ impl Default for ConsensusConfig {
             enable_optimistic_proposal_rx: true,
             enable_optimistic_proposal_tx: true,
             num_tokio_worker_threads: 0,
+            use_latency_weighted_leader: false,
         }
     }
 }

--- a/consensus/src/epoch_manager.rs
+++ b/consensus/src/epoch_manager.rs
@@ -344,6 +344,7 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
                                 Box::new(LatencyWeightedHeuristic::new(
                                     inner_heuristic,
                                     proposer_and_voter_config.active_weight,
+                                    self.config.latency_weight_multiplier,
                                 ))
                             } else {
                                 Box::new(inner_heuristic)

--- a/consensus/src/epoch_manager.rs
+++ b/consensus/src/epoch_manager.rs
@@ -14,8 +14,8 @@ use crate::{
     liveness::{
         cached_proposer_election::CachedProposerElection,
         leader_reputation::{
-            extract_epoch_to_proposers, AptosDBBackend, LatencyWeightedHeuristic,
-            LeaderReputation, ProposerAndVoterHeuristic, ReputationHeuristic,
+            extract_epoch_to_proposers, AptosDBBackend, LatencyWeightedHeuristic, LeaderReputation,
+            ProposerAndVoterHeuristic, ReputationHeuristic,
         },
         proposal_generator::{
             ChainHealthBackoffConfig, PipelineBackpressureConfig, ProposalGenerator,

--- a/consensus/src/epoch_manager.rs
+++ b/consensus/src/epoch_manager.rs
@@ -14,8 +14,8 @@ use crate::{
     liveness::{
         cached_proposer_election::CachedProposerElection,
         leader_reputation::{
-            extract_epoch_to_proposers, AptosDBBackend, LeaderReputation,
-            ProposerAndVoterHeuristic, ReputationHeuristic,
+            extract_epoch_to_proposers, AptosDBBackend, LatencyWeightedHeuristic,
+            LeaderReputation, ProposerAndVoterHeuristic, ReputationHeuristic,
         },
         proposal_generator::{
             ChainHealthBackoffConfig, PipelineBackpressureConfig, ProposalGenerator,
@@ -329,17 +329,25 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
                             * proposer_and_voter_config.proposer_window_num_validators_multiplier;
                         let voter_window_size = proposers.len()
                             * proposer_and_voter_config.voter_window_num_validators_multiplier;
+                        let inner_heuristic = ProposerAndVoterHeuristic::new(
+                            self.author,
+                            proposer_and_voter_config.active_weight,
+                            proposer_and_voter_config.inactive_weight,
+                            proposer_and_voter_config.failed_weight,
+                            proposer_and_voter_config.failure_threshold_percent,
+                            voter_window_size,
+                            proposer_window_size,
+                            leader_reputation_type.use_reputation_window_from_stale_end(),
+                        );
                         let heuristic: Box<dyn ReputationHeuristic> =
-                            Box::new(ProposerAndVoterHeuristic::new(
-                                self.author,
-                                proposer_and_voter_config.active_weight,
-                                proposer_and_voter_config.inactive_weight,
-                                proposer_and_voter_config.failed_weight,
-                                proposer_and_voter_config.failure_threshold_percent,
-                                voter_window_size,
-                                proposer_window_size,
-                                leader_reputation_type.use_reputation_window_from_stale_end(),
-                            ));
+                            if self.config.use_latency_weighted_leader {
+                                Box::new(LatencyWeightedHeuristic::new(
+                                    inner_heuristic,
+                                    proposer_and_voter_config.active_weight,
+                                ))
+                            } else {
+                                Box::new(inner_heuristic)
+                            };
                         (
                             heuristic,
                             std::cmp::max(proposer_window_size, voter_window_size),

--- a/consensus/src/liveness/leader_reputation.rs
+++ b/consensus/src/liveness/leader_reputation.rs
@@ -557,18 +557,31 @@ impl ReputationHeuristic for ProposerAndVoterHeuristic {
 /// fast rounds (i.e. collected quorum quickly) get a proportionally higher chance of being
 /// selected as leader, while validators with slow round times get a lower chance.
 ///
-/// Concretely, for every active validator we compute the median interval between consecutive
-/// committed blocks in the history window.  The weight is then:
+/// Concretely, for every active validator we compute the mean interval between consecutive
+/// committed blocks in the history window, splitting each successful pair 50/50 between the
+/// two adjacent proposers and attributing timeout-spanning gaps in full to the failed
+/// proposers (using `failed_proposer_indices`). The weight is then:
 ///
-///   active_weight * (max_median_round_time_us / validator_median_round_time_us)^multiplier
+///   active_weight * (max_mean_round_time_us / validator_mean_round_time_us)^multiplier
 ///
 /// Inactive / failed validators keep their base weights unchanged.
-/// If there is not enough history to compute a median the base active weight is used.
+/// If a validator has fewer than `MIN_OBSERVATIONS` entries the base active weight is used
+/// for that validator. The scaling ratio is clamped at `MAX_LATENCY_RATIO` to prevent one
+/// anomalously-fast validator from monopolizing leader selection.
 pub struct LatencyWeightedHeuristic {
     inner: ProposerAndVoterHeuristic,
     active_weight: u64,
     multiplier: f64,
 }
+
+/// Minimum number of round-time observations needed before a validator is scaled by the
+/// latency-weighted heuristic; below this we fall back to the base active weight.
+const MIN_OBSERVATIONS: usize = 2;
+
+/// Hard ceiling on the per-validator scaling ratio (`max_mean / val_mean`) to bound the
+/// boost a fast validator can receive over the slowest one. Prevents over-concentration
+/// when one validator's mean is anomalously low.
+const MAX_LATENCY_RATIO: f64 = 10.0;
 
 impl LatencyWeightedHeuristic {
     pub fn new(inner: ProposerAndVoterHeuristic, active_weight: u64, multiplier: f64) -> Self {
@@ -579,11 +592,23 @@ impl LatencyWeightedHeuristic {
         }
     }
 
-    /// Compute per-proposer round times from the history.
+    /// Compute per-proposer round-time observations from the history.
     ///
     /// History is ordered newest-first: `history[0]` is the latest block.
-    /// The round time for block `i` is `history[i].proposed_time() - history[i+1].proposed_time()`.
-    fn compute_round_times(history: &[NewBlockEvent]) -> HashMap<Author, Vec<u64>> {
+    /// For each consecutive pair `(newer, older)` within the same epoch we compute
+    /// `interval = newer.proposed_time() - older.proposed_time()` and attribute it as follows:
+    /// * If `newer.failed_proposer_indices()` is empty the pair represents a clean
+    ///   consecutive-round commit: split the interval 50/50 between `newer.proposer()` and
+    ///   `older.proposer()`. Both contributed to closing the round (the older proposed it,
+    ///   the newer aggregated votes and built the next proposal), so each absorbs half.
+    /// * If `newer.failed_proposer_indices()` is non-empty the gap absorbed one or more
+    ///   timeouts: divide the full interval equally among the failed proposers (resolved via
+    ///   `epoch_to_candidates`) and attribute none of it to `newer`/`older`. The healthy
+    ///   adjacent proposers should not be penalized for absorbing someone else's timeout.
+    fn compute_round_times(
+        history: &[NewBlockEvent],
+        epoch_to_candidates: &HashMap<u64, Vec<Author>>,
+    ) -> HashMap<Author, Vec<u64>> {
         let mut round_times: HashMap<Author, Vec<u64>> = HashMap::new();
         for i in 0..history.len().saturating_sub(1) {
             let newer = &history[i];
@@ -593,24 +618,35 @@ impl LatencyWeightedHeuristic {
                 continue;
             }
             let interval = newer.proposed_time().saturating_sub(older.proposed_time());
-            if interval > 0 {
-                round_times.entry(newer.proposer()).or_default().push(interval);
+            if interval == 0 {
+                continue;
+            }
+
+            let failed = newer.failed_proposer_indices();
+            if failed.is_empty() {
+                // Successful pair: 50/50 split between the two adjacent proposers.
+                let half = interval / 2;
+                if half > 0 {
+                    round_times.entry(newer.proposer()).or_default().push(half);
+                    round_times.entry(older.proposer()).or_default().push(half);
+                }
+            } else {
+                // Timeout-spanning pair: attribute the full gap to the failed proposer(s).
+                let candidates = match epoch_to_candidates.get(&newer.epoch()) {
+                    Some(c) => c,
+                    None => continue,
+                };
+                let per_failure = interval / failed.len() as u64;
+                if per_failure > 0 {
+                    for &idx in failed {
+                        if let Some(author) = candidates.get(idx as usize) {
+                            round_times.entry(*author).or_default().push(per_failure);
+                        }
+                    }
+                }
             }
         }
         round_times
-    }
-
-    fn median(values: &mut Vec<u64>) -> u64 {
-        if values.is_empty() {
-            return 0;
-        }
-        values.sort_unstable();
-        let mid = values.len() / 2;
-        if values.len() % 2 == 0 {
-            (values[mid - 1] + values[mid]) / 2
-        } else {
-            values[mid]
-        }
     }
 }
 
@@ -623,35 +659,25 @@ impl ReputationHeuristic for LatencyWeightedHeuristic {
     ) -> Vec<u64> {
         let base_weights = self.inner.get_weights(epoch, epoch_to_candidates, history);
 
-        let mut round_times = Self::compute_round_times(history);
+        let round_times = Self::compute_round_times(history, epoch_to_candidates);
 
-        // Compute per-validator median round time.
-        let mut medians: HashMap<Author, u64> = HashMap::new();
-        for (author, times) in round_times.iter_mut() {
-            let m = Self::median(times);
-            if m > 0 {
-                medians.insert(*author, m);
-            }
-        }
+        // Per-validator mean round time, computed only for validators with enough data.
+        let means: HashMap<Author, u64> = round_times
+            .iter()
+            .filter(|(_, v)| v.len() >= MIN_OBSERVATIONS)
+            .map(|(a, v)| (*a, v.iter().sum::<u64>() / v.len() as u64))
+            .collect();
 
-        // We need at least a handful of data points to trust the medians.
-        // Require each candidate to have at least 2 observations; otherwise fall back to base.
-        let min_observations = 2usize;
-        let candidates = &epoch_to_candidates[&epoch];
-        let enough_data = candidates.iter().all(|author| {
-            round_times
-                .get(author)
-                .map_or(false, |v| v.len() >= min_observations)
-        });
-
-        if !enough_data || medians.is_empty() {
+        // No validator has enough data — fall back to base weights.
+        if means.is_empty() {
             return base_weights;
         }
 
-        // The slowest (highest) median round time is the reference — we scale all others
-        // relative to it so that the fastest proposer keeps `active_weight` and slower
-        // ones get a proportionally smaller share.
-        let max_median = *medians.values().max().expect("medians is non-empty");
+        let max_mean = *means.values().max().expect("means is non-empty");
+        // Degenerate case: every observed mean is zero. Fall back to base weights.
+        if max_mean == 0 {
+            return base_weights;
+        }
 
         epoch_to_candidates[&epoch]
             .iter()
@@ -661,12 +687,15 @@ impl ReputationHeuristic for LatencyWeightedHeuristic {
                 if base != self.active_weight {
                     return base;
                 }
-                match medians.get(author) {
-                    Some(&median_rt) if median_rt > 0 => {
-                        // Scale by (max_median / median_rt)^multiplier.
-                        let ratio = (max_median as f64 / median_rt as f64).powf(self.multiplier);
+                match means.get(author) {
+                    Some(&val_mean) if val_mean > 0 => {
+                        // Scale by (max_mean / val_mean)^multiplier, clamped.
+                        let ratio = (max_mean as f64 / val_mean as f64)
+                            .min(MAX_LATENCY_RATIO)
+                            .powf(self.multiplier);
                         (self.active_weight as f64 * ratio) as u64
                     },
+                    // Per-validator fallback: insufficient observations → keep base weight.
                     _ => base,
                 }
             })

--- a/consensus/src/liveness/leader_reputation.rs
+++ b/consensus/src/liveness/leader_reputation.rs
@@ -577,25 +577,45 @@ impl LatencyWeightedHeuristic {
         }
     }
 
-    /// Compute per-proposer round times from the history.
+    /// Compute per-proposer round times from the history, restricted to the current epoch.
     ///
     /// History is ordered newest-first: `history[0]` is the latest block.
-    /// The round time for block `i` is `history[i].proposed_time() - history[i+1].proposed_time()`.
-    fn compute_round_times(history: &[NewBlockEvent]) -> HashMap<Author, Vec<u64>> {
-        let mut round_times: HashMap<Author, Vec<u64>> = HashMap::new();
+    /// With optimistic proposals the interval `history[i].proposed_time() - history[i+1].proposed_time()`
+    /// is approximately the one-way network latency from `history[i+1].proposer()` (sender) to
+    /// `history[i].proposer()` (receiver).  We track both the per-receiver solo times *and* the
+    /// per-(sender, receiver) pair times so that `get_weights` can condition on who just proposed.
+    ///
+    /// Returns `(receiver_times, pair_times)` where:
+    ///   - `receiver_times[R]`    = all intervals where R was the receiver (solo view)
+    ///   - `pair_times[S][R]`     = intervals where S was the sender and R was the receiver
+    fn compute_round_times(
+        epoch: u64,
+        history: &[NewBlockEvent],
+    ) -> (
+        HashMap<Author, Vec<u64>>,
+        HashMap<Author, HashMap<Author, Vec<u64>>>,
+    ) {
+        let mut receiver_times: HashMap<Author, Vec<u64>> = HashMap::new();
+        let mut pair_times: HashMap<Author, HashMap<Author, Vec<u64>>> = HashMap::new();
         for i in 0..history.len().saturating_sub(1) {
             let newer = &history[i];
             let older = &history[i + 1];
-            // Only compute within the same epoch to avoid epoch-boundary outliers.
-            if newer.epoch() != older.epoch() {
-                continue;
+            // History is newest-first; once older leaves the current epoch we're done.
+            if older.epoch() != epoch {
+                break;
             }
             let interval = newer.proposed_time().saturating_sub(older.proposed_time());
             if interval > 0 {
-                round_times.entry(newer.proposer()).or_default().push(interval);
+                receiver_times.entry(newer.proposer()).or_default().push(interval);
+                pair_times
+                    .entry(older.proposer())
+                    .or_default()
+                    .entry(newer.proposer())
+                    .or_default()
+                    .push(interval);
             }
         }
-        round_times
+        (receiver_times, pair_times)
     }
 
     fn median(values: &mut Vec<u64>) -> u64 {
@@ -621,47 +641,67 @@ impl ReputationHeuristic for LatencyWeightedHeuristic {
     ) -> Vec<u64> {
         let base_weights = self.inner.get_weights(epoch, epoch_to_candidates, history);
 
-        let mut round_times = Self::compute_round_times(history);
+        let (mut receiver_times, pair_times) = Self::compute_round_times(epoch, history);
 
-        // Compute per-validator median round time.
-        let mut medians: HashMap<Author, u64> = HashMap::new();
-        for (author, times) in round_times.iter_mut() {
+        // Compute per-validator solo (receiver) medians.
+        let mut solo_medians: HashMap<Author, u64> = HashMap::new();
+        for (author, times) in receiver_times.iter_mut() {
             let m = Self::median(times);
             if m > 0 {
-                medians.insert(*author, m);
+                solo_medians.insert(*author, m);
             }
         }
 
-        // We need at least a handful of data points to trust the medians.
-        // Require each candidate to have at least 2 observations; otherwise fall back to base.
+        // Require every candidate to have at least 2 solo observations before applying any
+        // weighting, to avoid misfiring at epoch start.
         let min_observations = 2usize;
         let candidates = &epoch_to_candidates[&epoch];
-        let enough_data = candidates.iter().all(|author| {
-            round_times
+        let enough_solo = candidates.iter().all(|author| {
+            receiver_times
                 .get(author)
                 .map_or(false, |v| v.len() >= min_observations)
         });
 
-        if !enough_data || medians.is_empty() {
+        if !enough_solo || solo_medians.is_empty() {
             return base_weights;
         }
 
-        // The slowest (highest) median round time is the reference — we scale all others
-        // relative to it so that the fastest proposer keeps `active_weight` and slower
-        // ones get a proportionally smaller share.
-        let max_median = *medians.values().max().expect("medians is non-empty");
+        // Option 5: condition on the most recently committed proposer.  When we have enough
+        // (sender → receiver) pair observations, use the pair-specific median instead of the
+        // solo average.  This captures within-region topology differences (e.g. cross-EU
+        // 8.5 ms vs intra-region 20 ms) that the solo median averages away.
+        let current_proposer = history.first().map(|b| b.proposer());
+        let cp_pairs = current_proposer.and_then(|cp| pair_times.get(&cp));
+
+        let effective_medians: HashMap<Author, u64> = candidates
+            .iter()
+            .filter_map(|author| {
+                // Prefer a pair-specific median when we have enough data for it.
+                let pair_median = cp_pairs
+                    .and_then(|m| m.get(author))
+                    .filter(|times| times.len() >= min_observations)
+                    .and_then(|times| {
+                        let mut t = times.clone();
+                        let m = Self::median(&mut t);
+                        if m > 0 { Some(m) } else { None }
+                    });
+                let median = pair_median.or_else(|| solo_medians.get(author).copied())?;
+                Some((*author, median))
+            })
+            .collect();
+
+        // The slowest effective median is the reference.
+        let max_median = *effective_medians.values().max().expect("medians is non-empty");
 
         epoch_to_candidates[&epoch]
             .iter()
             .zip(base_weights.iter())
             .map(|(author, &base)| {
-                // Only adjust the weight for validators that received the active weight.
                 if base != self.active_weight {
                     return base;
                 }
-                match medians.get(author) {
+                match effective_medians.get(author) {
                     Some(&median_rt) if median_rt > 0 => {
-                        // Scale proportionally: fastest gets active_weight, others get less.
                         (self.active_weight * max_median) / median_rt
                     },
                     _ => base,

--- a/consensus/src/liveness/leader_reputation.rs
+++ b/consensus/src/liveness/leader_reputation.rs
@@ -552,6 +552,125 @@ impl ReputationHeuristic for ProposerAndVoterHeuristic {
     }
 }
 
+/// A heuristic that wraps `ProposerAndVoterHeuristic` but additionally scales active-validator
+/// weights by their historical round-time performance.  Validators that have been proposing
+/// fast rounds (i.e. collected quorum quickly) get a proportionally higher chance of being
+/// selected as leader, while validators with slow round times get a lower chance.
+///
+/// Concretely, for every active validator we compute the median interval between consecutive
+/// committed blocks in the history window.  The weight is then:
+///
+///   active_weight * max_median_round_time_us / validator_median_round_time_us
+///
+/// Inactive / failed validators keep their base weights unchanged.
+/// If there is not enough history to compute a median the base active weight is used.
+pub struct LatencyWeightedHeuristic {
+    inner: ProposerAndVoterHeuristic,
+    active_weight: u64,
+}
+
+impl LatencyWeightedHeuristic {
+    pub fn new(inner: ProposerAndVoterHeuristic, active_weight: u64) -> Self {
+        Self {
+            inner,
+            active_weight,
+        }
+    }
+
+    /// Compute per-proposer round times from the history.
+    ///
+    /// History is ordered newest-first: `history[0]` is the latest block.
+    /// The round time for block `i` is `history[i].proposed_time() - history[i+1].proposed_time()`.
+    fn compute_round_times(history: &[NewBlockEvent]) -> HashMap<Author, Vec<u64>> {
+        let mut round_times: HashMap<Author, Vec<u64>> = HashMap::new();
+        for i in 0..history.len().saturating_sub(1) {
+            let newer = &history[i];
+            let older = &history[i + 1];
+            // Only compute within the same epoch to avoid epoch-boundary outliers.
+            if newer.epoch() != older.epoch() {
+                continue;
+            }
+            let interval = newer.proposed_time().saturating_sub(older.proposed_time());
+            if interval > 0 {
+                round_times.entry(newer.proposer()).or_default().push(interval);
+            }
+        }
+        round_times
+    }
+
+    fn median(values: &mut Vec<u64>) -> u64 {
+        if values.is_empty() {
+            return 0;
+        }
+        values.sort_unstable();
+        let mid = values.len() / 2;
+        if values.len() % 2 == 0 {
+            (values[mid - 1] + values[mid]) / 2
+        } else {
+            values[mid]
+        }
+    }
+}
+
+impl ReputationHeuristic for LatencyWeightedHeuristic {
+    fn get_weights(
+        &self,
+        epoch: u64,
+        epoch_to_candidates: &HashMap<u64, Vec<Author>>,
+        history: &[NewBlockEvent],
+    ) -> Vec<u64> {
+        let base_weights = self.inner.get_weights(epoch, epoch_to_candidates, history);
+
+        let mut round_times = Self::compute_round_times(history);
+
+        // Compute per-validator median round time.
+        let mut medians: HashMap<Author, u64> = HashMap::new();
+        for (author, times) in round_times.iter_mut() {
+            let m = Self::median(times);
+            if m > 0 {
+                medians.insert(*author, m);
+            }
+        }
+
+        // We need at least a handful of data points to trust the medians.
+        // Require each candidate to have at least 2 observations; otherwise fall back to base.
+        let min_observations = 2usize;
+        let candidates = &epoch_to_candidates[&epoch];
+        let enough_data = candidates.iter().all(|author| {
+            round_times
+                .get(author)
+                .map_or(false, |v| v.len() >= min_observations)
+        });
+
+        if !enough_data || medians.is_empty() {
+            return base_weights;
+        }
+
+        // The slowest (highest) median round time is the reference — we scale all others
+        // relative to it so that the fastest proposer keeps `active_weight` and slower
+        // ones get a proportionally smaller share.
+        let max_median = *medians.values().max().expect("medians is non-empty");
+
+        epoch_to_candidates[&epoch]
+            .iter()
+            .zip(base_weights.iter())
+            .map(|(author, &base)| {
+                // Only adjust the weight for validators that received the active weight.
+                if base != self.active_weight {
+                    return base;
+                }
+                match medians.get(author) {
+                    Some(&median_rt) if median_rt > 0 => {
+                        // Scale proportionally: fastest gets active_weight, others get less.
+                        (self.active_weight * max_median) / median_rt
+                    },
+                    _ => base,
+                }
+            })
+            .collect()
+    }
+}
+
 /// Committed history based proposer election implementation that could help bias towards
 /// successful leaders to help improve performance.
 pub struct LeaderReputation {

--- a/consensus/src/liveness/leader_reputation.rs
+++ b/consensus/src/liveness/leader_reputation.rs
@@ -577,45 +577,25 @@ impl LatencyWeightedHeuristic {
         }
     }
 
-    /// Compute per-proposer round times from the history, restricted to the current epoch.
+    /// Compute per-proposer round times from the history.
     ///
     /// History is ordered newest-first: `history[0]` is the latest block.
-    /// With optimistic proposals the interval `history[i].proposed_time() - history[i+1].proposed_time()`
-    /// is approximately the one-way network latency from `history[i+1].proposer()` (sender) to
-    /// `history[i].proposer()` (receiver).  We track both the per-receiver solo times *and* the
-    /// per-(sender, receiver) pair times so that `get_weights` can condition on who just proposed.
-    ///
-    /// Returns `(receiver_times, pair_times)` where:
-    ///   - `receiver_times[R]`    = all intervals where R was the receiver (solo view)
-    ///   - `pair_times[S][R]`     = intervals where S was the sender and R was the receiver
-    fn compute_round_times(
-        epoch: u64,
-        history: &[NewBlockEvent],
-    ) -> (
-        HashMap<Author, Vec<u64>>,
-        HashMap<Author, HashMap<Author, Vec<u64>>>,
-    ) {
-        let mut receiver_times: HashMap<Author, Vec<u64>> = HashMap::new();
-        let mut pair_times: HashMap<Author, HashMap<Author, Vec<u64>>> = HashMap::new();
+    /// The round time for block `i` is `history[i].proposed_time() - history[i+1].proposed_time()`.
+    fn compute_round_times(history: &[NewBlockEvent]) -> HashMap<Author, Vec<u64>> {
+        let mut round_times: HashMap<Author, Vec<u64>> = HashMap::new();
         for i in 0..history.len().saturating_sub(1) {
             let newer = &history[i];
             let older = &history[i + 1];
-            // History is newest-first; once older leaves the current epoch we're done.
-            if older.epoch() != epoch {
-                break;
+            // Only compute within the same epoch to avoid epoch-boundary outliers.
+            if newer.epoch() != older.epoch() {
+                continue;
             }
             let interval = newer.proposed_time().saturating_sub(older.proposed_time());
             if interval > 0 {
-                receiver_times.entry(newer.proposer()).or_default().push(interval);
-                pair_times
-                    .entry(older.proposer())
-                    .or_default()
-                    .entry(newer.proposer())
-                    .or_default()
-                    .push(interval);
+                round_times.entry(newer.proposer()).or_default().push(interval);
             }
         }
-        (receiver_times, pair_times)
+        round_times
     }
 
     fn median(values: &mut Vec<u64>) -> u64 {
@@ -641,67 +621,47 @@ impl ReputationHeuristic for LatencyWeightedHeuristic {
     ) -> Vec<u64> {
         let base_weights = self.inner.get_weights(epoch, epoch_to_candidates, history);
 
-        let (mut receiver_times, pair_times) = Self::compute_round_times(epoch, history);
+        let mut round_times = Self::compute_round_times(history);
 
-        // Compute per-validator solo (receiver) medians.
-        let mut solo_medians: HashMap<Author, u64> = HashMap::new();
-        for (author, times) in receiver_times.iter_mut() {
+        // Compute per-validator median round time.
+        let mut medians: HashMap<Author, u64> = HashMap::new();
+        for (author, times) in round_times.iter_mut() {
             let m = Self::median(times);
             if m > 0 {
-                solo_medians.insert(*author, m);
+                medians.insert(*author, m);
             }
         }
 
-        // Require every candidate to have at least 2 solo observations before applying any
-        // weighting, to avoid misfiring at epoch start.
+        // We need at least a handful of data points to trust the medians.
+        // Require each candidate to have at least 2 observations; otherwise fall back to base.
         let min_observations = 2usize;
         let candidates = &epoch_to_candidates[&epoch];
-        let enough_solo = candidates.iter().all(|author| {
-            receiver_times
+        let enough_data = candidates.iter().all(|author| {
+            round_times
                 .get(author)
                 .map_or(false, |v| v.len() >= min_observations)
         });
 
-        if !enough_solo || solo_medians.is_empty() {
+        if !enough_data || medians.is_empty() {
             return base_weights;
         }
 
-        // Option 5: condition on the most recently committed proposer.  When we have enough
-        // (sender → receiver) pair observations, use the pair-specific median instead of the
-        // solo average.  This captures within-region topology differences (e.g. cross-EU
-        // 8.5 ms vs intra-region 20 ms) that the solo median averages away.
-        let current_proposer = history.first().map(|b| b.proposer());
-        let cp_pairs = current_proposer.and_then(|cp| pair_times.get(&cp));
-
-        let effective_medians: HashMap<Author, u64> = candidates
-            .iter()
-            .filter_map(|author| {
-                // Prefer a pair-specific median when we have enough data for it.
-                let pair_median = cp_pairs
-                    .and_then(|m| m.get(author))
-                    .filter(|times| times.len() >= min_observations)
-                    .and_then(|times| {
-                        let mut t = times.clone();
-                        let m = Self::median(&mut t);
-                        if m > 0 { Some(m) } else { None }
-                    });
-                let median = pair_median.or_else(|| solo_medians.get(author).copied())?;
-                Some((*author, median))
-            })
-            .collect();
-
-        // The slowest effective median is the reference.
-        let max_median = *effective_medians.values().max().expect("medians is non-empty");
+        // The slowest (highest) median round time is the reference — we scale all others
+        // relative to it so that the fastest proposer keeps `active_weight` and slower
+        // ones get a proportionally smaller share.
+        let max_median = *medians.values().max().expect("medians is non-empty");
 
         epoch_to_candidates[&epoch]
             .iter()
             .zip(base_weights.iter())
             .map(|(author, &base)| {
+                // Only adjust the weight for validators that received the active weight.
                 if base != self.active_weight {
                     return base;
                 }
-                match effective_medians.get(author) {
+                match medians.get(author) {
                     Some(&median_rt) if median_rt > 0 => {
+                        // Scale proportionally: fastest gets active_weight, others get less.
                         (self.active_weight * max_median) / median_rt
                     },
                     _ => base,

--- a/consensus/src/liveness/leader_reputation.rs
+++ b/consensus/src/liveness/leader_reputation.rs
@@ -560,20 +560,22 @@ impl ReputationHeuristic for ProposerAndVoterHeuristic {
 /// Concretely, for every active validator we compute the median interval between consecutive
 /// committed blocks in the history window.  The weight is then:
 ///
-///   active_weight * max_median_round_time_us / validator_median_round_time_us
+///   active_weight * (max_median_round_time_us / validator_median_round_time_us)^multiplier
 ///
 /// Inactive / failed validators keep their base weights unchanged.
 /// If there is not enough history to compute a median the base active weight is used.
 pub struct LatencyWeightedHeuristic {
     inner: ProposerAndVoterHeuristic,
     active_weight: u64,
+    multiplier: f64,
 }
 
 impl LatencyWeightedHeuristic {
-    pub fn new(inner: ProposerAndVoterHeuristic, active_weight: u64) -> Self {
+    pub fn new(inner: ProposerAndVoterHeuristic, active_weight: u64, multiplier: f64) -> Self {
         Self {
             inner,
             active_weight,
+            multiplier: if multiplier > 0.0 { multiplier } else { 1.0 },
         }
     }
 
@@ -661,8 +663,9 @@ impl ReputationHeuristic for LatencyWeightedHeuristic {
                 }
                 match medians.get(author) {
                     Some(&median_rt) if median_rt > 0 => {
-                        // Scale proportionally: fastest gets active_weight, others get less.
-                        (self.active_weight * max_median) / median_rt
+                        // Scale by (max_median / median_rt)^multiplier.
+                        let ratio = (max_median as f64 / median_rt as f64).powf(self.multiplier);
+                        (self.active_weight as f64 * ratio) as u64
                     },
                     _ => base,
                 }

--- a/consensus/src/liveness/leader_reputation_test.rs
+++ b/consensus/src/liveness/leader_reputation_test.rs
@@ -2,7 +2,8 @@
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use super::leader_reputation::{
-    extract_epoch_to_proposers_impl, AptosDBBackend, ProposerAndVoterHeuristic,
+    extract_epoch_to_proposers_impl, AptosDBBackend, LatencyWeightedHeuristic,
+    ProposerAndVoterHeuristic,
 };
 use crate::liveness::{
     leader_reputation::{
@@ -761,4 +762,205 @@ fn test_extract_epoch_to_proposers_impl() {
         )
         .unwrap()
     );
+}
+
+/// #### LatencyWeightedHeuristic tests ####
+
+/// Build a `NewBlockEvent` with the given proposer, timestamp, round, epoch, and failed
+/// proposer indices. Other fields are set to deterministic defaults.
+fn make_block_event(
+    proposer: Author,
+    epoch: u64,
+    round: u64,
+    timestamp_us: u64,
+    failed_proposer_indices: Vec<u64>,
+) -> NewBlockEvent {
+    NewBlockEvent::new(
+        AccountAddress::ZERO,
+        epoch,
+        round,
+        round,
+        BitVec::with_num_bits(1).into(),
+        proposer,
+        failed_proposer_indices,
+        timestamp_us,
+    )
+}
+
+/// Build a `LatencyWeightedHeuristic` wrapping a `ProposerAndVoterHeuristic` configured so
+/// that all candidates with successful proposals receive `active_weight = 1000`.
+fn make_latency_weighted_heuristic(self_author: Author) -> LatencyWeightedHeuristic {
+    // Wide windows + low failure threshold so test fixtures do not accidentally trigger the
+    // failed/inactive branches in the inner heuristic — we want to exercise the latency
+    // scaling on top of `active_weight`.
+    let inner = ProposerAndVoterHeuristic::new(self_author, 1000, 10, 1, 50, 100, 100, false);
+    LatencyWeightedHeuristic::new(inner, 1000, 1.0)
+}
+
+#[test]
+fn test_latency_weighted_50_50_split_equal_intervals() {
+    // With four validators and four successful blocks at uniform 100µs intervals, every
+    // validator's mean is identical, so weights collapse to `active_weight`.
+    let validators: Vec<Author> = (0..4).map(|_| Author::random()).collect();
+    let epoch_to_validators = HashMap::from([(0u64, validators.clone())]);
+
+    // History is newest-first: rounds 4, 3, 2, 1 at timestamps 400, 300, 200, 100.
+    let history = vec![
+        make_block_event(validators[3], 0, 4, 400, vec![]),
+        make_block_event(validators[2], 0, 3, 300, vec![]),
+        make_block_event(validators[1], 0, 2, 200, vec![]),
+        make_block_event(validators[0], 0, 1, 100, vec![]),
+    ];
+
+    let heuristic = make_latency_weighted_heuristic(validators[0]);
+    let weights = heuristic.get_weights(0, &epoch_to_validators, &history);
+
+    // All means equal → ratio is 1 → all weights stay at active_weight = 1000.
+    assert_eq!(weights, vec![1000, 1000, 1000, 1000]);
+}
+
+#[test]
+fn test_latency_weighted_failure_attributed_to_failed_proposer() {
+    // Three validators V0, V1, V2. V1 (index 1) fails round 3; V2 commits round 4 to rescue.
+    // The 600µs gap between V0's commit (round 2) and V2's commit (round 4) absorbs V1's
+    // timeout and must be attributed to V1, not to V2.
+    let validators: Vec<Author> = (0..3).map(|_| Author::random()).collect();
+    let epoch_to_validators = HashMap::from([(0u64, validators.clone())]);
+
+    // Newest-first.
+    let history = vec![
+        make_block_event(validators[2], 0, 6, 1000, vec![]), // round 6
+        make_block_event(validators[1], 0, 5, 900, vec![]),  // round 5 (V1 succeeds here)
+        make_block_event(validators[0], 0, 4, 800, vec![]),  // round 4
+        make_block_event(validators[2], 0, 4, 700, vec![1]), // round 4 rescue, V1 failed round 3
+        make_block_event(validators[0], 0, 2, 100, vec![]),  // round 2
+    ];
+
+    let heuristic = make_latency_weighted_heuristic(validators[0]);
+    let weights = heuristic.get_weights(0, &epoch_to_validators, &history);
+
+    // V1 should have the largest mean (absorbed the 600µs failure entry) and therefore the
+    // smallest weight. V0 and V2 should be boosted relative to V1.
+    assert!(weights[1] < weights[0]);
+    assert!(weights[1] < weights[2]);
+}
+
+#[test]
+fn test_latency_weighted_multiple_failed_proposers_split_gap() {
+    // Two failed proposers in a single gap: the interval is split equally between them.
+    let validators: Vec<Author> = (0..4).map(|_| Author::random()).collect();
+    let epoch_to_validators = HashMap::from([(0u64, validators.clone())]);
+
+    // Round 5 commits with both V1 (idx 1) and V2 (idx 2) listed as failed; gap of 1000µs.
+    let history = vec![
+        make_block_event(validators[3], 0, 6, 1100, vec![]),
+        make_block_event(validators[0], 0, 5, 1000, vec![1, 2]),
+        make_block_event(validators[3], 0, 2, 0, vec![]),
+    ];
+
+    let heuristic = make_latency_weighted_heuristic(validators[0]);
+    let weights = heuristic.get_weights(0, &epoch_to_validators, &history);
+
+    // Both failed proposers should be down-weighted relative to V0/V3.
+    assert!(weights[1] < weights[0]);
+    assert!(weights[2] < weights[0]);
+    assert!(weights[1] < weights[3]);
+    assert!(weights[2] < weights[3]);
+}
+
+#[test]
+fn test_latency_weighted_per_validator_fallback() {
+    // V0 has no observations (it is in the candidate set but never appears in history).
+    // The heuristic must NOT fall back globally just because V0 lacks data — V1 should
+    // still be scaled relative to V2 even though V0 has nothing to compute from.
+    let validators: Vec<Author> = (0..3).map(|_| Author::random()).collect();
+    let epoch_to_validators = HashMap::from([(0u64, validators.clone())]);
+
+    // V1 has fast intervals (~50µs/entry under 50/50), V2 has slow intervals (~500µs/entry).
+    // V0 never appears as proposer.
+    let history = vec![
+        make_block_event(validators[2], 0, 10, 5000, vec![]),
+        make_block_event(validators[2], 0, 8, 4000, vec![]),
+        make_block_event(validators[2], 0, 6, 3000, vec![]),
+        make_block_event(validators[1], 0, 4, 200, vec![]),
+        make_block_event(validators[1], 0, 3, 150, vec![]),
+        make_block_event(validators[1], 0, 2, 100, vec![]),
+    ];
+
+    let heuristic = make_latency_weighted_heuristic(validators[0]);
+    let weights = heuristic.get_weights(0, &epoch_to_validators, &history);
+
+    // V1 is faster than V2, so V1's weight must be strictly larger than V2's.
+    // If the heuristic had fallen back globally because of V0's empty data, V1 == V2.
+    assert!(
+        weights[1] > weights[2],
+        "expected V1 boosted over V2 despite V0 lacking observations; got {:?}",
+        weights,
+    );
+}
+
+#[test]
+fn test_latency_weighted_empty_history_falls_back_to_base() {
+    // No history → no observations → base weights returned unchanged.
+    let validators: Vec<Author> = (0..2).map(|_| Author::random()).collect();
+    let epoch_to_validators = HashMap::from([(0u64, validators.clone())]);
+    let history: Vec<NewBlockEvent> = vec![];
+
+    let heuristic = make_latency_weighted_heuristic(validators[0]);
+    let weights = heuristic.get_weights(0, &epoch_to_validators, &history);
+
+    // Both validators still get base weight (inactive_weight in this case since no proposals).
+    assert_eq!(weights.len(), 2);
+}
+
+#[test]
+fn test_latency_weighted_max_ratio_clamp() {
+    // V0 makes many fast successful proposals (small mean) while V1 is attributed multiple
+    // large failure gaps (huge mean). The raw scaling ratio (max_mean / V0_mean) is ~1000x;
+    // it must be clamped at MAX_LATENCY_RATIO = 10x → V0's weight tops out at 10 * 1000.
+    let validators: Vec<Author> = (0..2).map(|_| Author::random()).collect();
+    let epoch_to_validators = HashMap::from([(0u64, validators.clone())]);
+
+    // History (newest first): V0 successfully proposes a series of fast rounds, then three
+    // huge gaps each attributed to V1 via failed_proposer_indices.
+    let history = vec![
+        make_block_event(validators[0], 0, 10, 30_000, vec![1]), // V1 failure, gap = 10000
+        make_block_event(validators[0], 0, 8, 20_000, vec![1]),  // V1 failure, gap = 10000
+        make_block_event(validators[0], 0, 6, 10_000, vec![1]),  // V1 failure, gap = 9990
+        make_block_event(validators[0], 0, 4, 10, vec![]),
+        make_block_event(validators[0], 0, 3, 5, vec![]),
+    ];
+
+    let heuristic = make_latency_weighted_heuristic(validators[0]);
+    let weights = heuristic.get_weights(0, &epoch_to_validators, &history);
+
+    // V0's raw ratio would be massive (V1_mean ~10000 / V0_mean ~2 = 5000x); clamp pins it
+    // to MAX_LATENCY_RATIO = 10. V0 weight must equal active_weight * 10 = 10_000.
+    assert_eq!(
+        weights[0], 10_000,
+        "expected V0 weight clamped at 10x active_weight; got {:?}",
+        weights,
+    );
+}
+
+#[test]
+fn test_latency_weighted_skips_cross_epoch_pairs() {
+    // A pair spanning an epoch boundary must not contribute to round_times.
+    let validators: Vec<Author> = (0..2).map(|_| Author::random()).collect();
+    let epoch_to_validators =
+        HashMap::from([(0u64, validators.clone()), (1u64, validators.clone())]);
+
+    // Two events: one in epoch 0, one in epoch 1. Cross-epoch pair must be skipped.
+    let history = vec![
+        make_block_event(validators[1], 1, 1, 1_000_000, vec![]), // epoch 1
+        make_block_event(validators[0], 0, 5, 500, vec![]),       // epoch 0
+    ];
+
+    let heuristic = make_latency_weighted_heuristic(validators[0]);
+    let weights = heuristic.get_weights(1, &epoch_to_validators, &history);
+
+    // No same-epoch pairs → empty round_times → fall back to base weights.
+    // Both validators receive whatever base weight the inner heuristic produced; the latency
+    // scaling has no effect.
+    assert_eq!(weights.len(), 2);
 }


### PR DESCRIPTION
## Summary
- Adds latency-weighted leader reputation heuristic that prefers lower-latency validators as proposers
- Configurable exponent (`latency_weight_multiplier`) to control how aggressively latency differences are weighted
- Rebased from PR #19303 onto main, removing `daniel/latency-p90-forge-test` dependency

## Test plan
- [ ] Run forge tests to verify latency-weighted selection works correctly
- [ ] Compare P90 latency against baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)