### PR TITLE
[Network] Add inbound network rate limiter.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3438,6 +3438,7 @@ dependencies = [
  "aptos-proptest-helpers",
  "aptos-short-hex-str",
  "aptos-time-service",
+ "aptos-token-bucket",
  "aptos-types",
  "arc-swap",
  "async-trait",

--- a/config/src/config/network_config.rs
+++ b/config/src/config/network_config.rs
@@ -74,6 +74,16 @@ impl AccessControlPolicy {
     }
 }
 
+/// Rate limiting configuration for inbound network traffic
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct RateLimitConfig {
+    /// Max inbound bytes/sec per peer. None = unlimited.
+    pub inbound_bytes_per_second: Option<u64>,
+    /// Max inbound messages/sec per peer. None = unlimited.
+    pub inbound_messages_per_second: Option<u64>,
+}
+
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct NetworkConfig {
@@ -148,6 +158,9 @@ pub struct NetworkConfig {
     pub access_control_policy: Option<AccessControlPolicy>,
     /// Priority inbound peers that can bypass connection limits
     pub priority_inbound_peers: Vec<PeerId>,
+    /// Rate limiting configuration for inbound network traffic (per peer).
+    /// If None, inbound rate limiting is disabled.
+    pub inbound_rate_limit_config: Option<RateLimitConfig>,
 }
 
 impl Default for NetworkConfig {
@@ -194,6 +207,7 @@ impl NetworkConfig {
             enable_latency_aware_dialing: true,
             access_control_policy: None,
             priority_inbound_peers: Vec::new(),
+            inbound_rate_limit_config: None,
         };
 
         // Configure the number of parallel deserialization tasks

--- a/network/builder/src/builder.rs
+++ b/network/builder/src/builder.rs
@@ -12,9 +12,9 @@
 use aptos_config::{
     config::{
         AccessControlPolicy, BaseConfig, DiscoveryMethod, NetworkConfig, NodeType, Peer, PeerRole,
-        PeerSet, RoleType, CONNECTION_BACKOFF_BASE, CONNECTIVITY_CHECK_INTERVAL_MS,
-        MAX_CONNECTION_DELAY_MS, MAX_FRAME_SIZE, MAX_FULLNODE_OUTBOUND_CONNECTIONS,
-        MAX_INBOUND_CONNECTIONS, NETWORK_CHANNEL_SIZE,
+        PeerSet, RateLimitConfig, RoleType, CONNECTION_BACKOFF_BASE,
+        CONNECTIVITY_CHECK_INTERVAL_MS, MAX_CONNECTION_DELAY_MS, MAX_FRAME_SIZE,
+        MAX_FULLNODE_OUTBOUND_CONNECTIONS, MAX_INBOUND_CONNECTIONS, NETWORK_CHANNEL_SIZE,
     },
     network_id::NetworkContext,
 };
@@ -87,6 +87,7 @@ impl NetworkBuilder {
         tcp_buffer_cfg: TCPBufferCfg,
         access_control_policy: Option<Arc<AccessControlPolicy>>,
         priority_inbound_peers: Vec<PeerId>,
+        inbound_rate_limit_config: Option<RateLimitConfig>,
     ) -> Self {
         // A network cannot exist without a PeerManager
         // TODO:  construct this in create and pass it to new() as a parameter. The complication is manual construction of NetworkBuilder in various tests.
@@ -105,6 +106,7 @@ impl NetworkBuilder {
             tcp_buffer_cfg,
             access_control_policy,
             priority_inbound_peers,
+            inbound_rate_limit_config,
         );
 
         NetworkBuilder {
@@ -146,6 +148,7 @@ impl NetworkBuilder {
             TCPBufferCfg::default(),
             None,       /* access_control_policy */
             Vec::new(), /* priority_inbound_peers */
+            None,       /* inbound_rate_limit_config */
         );
 
         builder.add_connectivity_manager(
@@ -209,6 +212,7 @@ impl NetworkBuilder {
             ),
             access_control_policy.clone(),
             config.priority_inbound_peers.clone(),
+            config.inbound_rate_limit_config.clone(),
         );
 
         network_builder.add_connection_monitoring(

--- a/network/framework/Cargo.toml
+++ b/network/framework/Cargo.toml
@@ -30,6 +30,7 @@ aptos-peer-monitoring-service-types = { workspace = true }
 aptos-proptest-helpers = { workspace = true, optional = true }
 aptos-short-hex-str = { workspace = true }
 aptos-time-service = { workspace = true }
+aptos-token-bucket = { workspace = true }
 aptos-types = { workspace = true }
 arc-swap = { workspace = true }
 async-trait = { workspace = true }

--- a/network/framework/src/counters.rs
+++ b/network/framework/src/counters.rs
@@ -559,6 +559,42 @@ pub static PENDING_PEER_NETWORK_NOTIFICATIONS: Lazy<IntGauge> = Lazy::new(|| {
     .unwrap()
 });
 
+/// Number of inbound messages throttled (delayed) by the per-peer rate limiter
+pub static APTOS_NETWORK_INBOUND_RATE_LIMITER_THROTTLED_COUNT: Lazy<IntCounterVec> =
+    Lazy::new(|| {
+        register_int_counter_vec!(
+            "aptos_network_inbound_rate_limiter_throttled_count",
+            "Number of inbound messages throttled by the rate limiter per bucket type",
+            &["bucket"]
+        )
+        .unwrap()
+    });
+
+/// Increments the throttled-message counter for the given bucket type
+pub fn inc_inbound_rate_limiter_throttled(bucket_label: &str) {
+    APTOS_NETWORK_INBOUND_RATE_LIMITER_THROTTLED_COUNT
+        .with_label_values(&[bucket_label])
+        .inc();
+}
+
+/// Number of inbound messages rejected because they exceed the bucket's maximum capacity
+pub static APTOS_NETWORK_INBOUND_RATE_LIMITER_CAPACITY_EXCEEDED_COUNT: Lazy<IntCounterVec> =
+    Lazy::new(|| {
+        register_int_counter_vec!(
+            "aptos_network_inbound_rate_limiter_capacity_exceeded_count",
+            "Number of inbound messages rejected because they exceed the bucket capacity",
+            &["bucket"]
+        )
+        .unwrap()
+    });
+
+/// Increments the capacity-exceeded counter for the given bucket type
+pub fn inc_inbound_rate_limiter_capacity_exceeded(bucket_label: &str) {
+    APTOS_NETWORK_INBOUND_RATE_LIMITER_CAPACITY_EXCEEDED_COUNT
+        .with_label_values(&[bucket_label])
+        .inc();
+}
+
 pub static NETWORK_RATE_LIMIT_METRICS: Lazy<HistogramVec> = Lazy::new(|| {
     register_histogram_vec!(
         "aptos_network_rate_limit",

--- a/network/framework/src/peer/fuzzing.rs
+++ b/network/framework/src/peer/fuzzing.rs
@@ -107,6 +107,7 @@ pub fn fuzz(data: &[u8]) {
         constants::MAX_CONCURRENT_OUTBOUND_RPCS,
         constants::MAX_FRAME_SIZE,
         constants::MAX_MESSAGE_SIZE,
+        None, /* inbound_rate_limiter */
     );
     executor.spawn(peer.start());
 

--- a/network/framework/src/peer/mod.rs
+++ b/network/framework/src/peer/mod.rs
@@ -20,6 +20,7 @@ use crate::{
         DECLINED_LABEL, FAILED_LABEL, RECEIVED_LABEL, SENT_LABEL, UNKNOWN_LABEL,
     },
     logging::NetworkSchema,
+    peer::rate_limiter::InboundMessageRateLimiter,
     peer_manager::{PeerManagerError, TransportNotification},
     protocols::{
         direct_send::Message,
@@ -60,6 +61,8 @@ mod test;
 
 #[cfg(any(test, feature = "fuzzing"))]
 pub mod fuzzing;
+
+pub(crate) mod rate_limiter;
 
 /// Requests [`Peer`] receives from the [`PeerManager`](crate::peer_manager::PeerManager).
 #[derive(Debug)]
@@ -139,6 +142,8 @@ pub struct Peer<TSocket> {
     max_message_size: usize,
     /// Inbound stream buffer
     inbound_stream: InboundStreamBuffer,
+    /// Optional per-peer inbound rate limiter
+    inbound_rate_limiter: Option<InboundMessageRateLimiter>,
 }
 
 impl<TSocket> Peer<TSocket>
@@ -161,6 +166,7 @@ where
         max_concurrent_outbound_rpcs: u32,
         max_frame_size: usize,
         max_message_size: usize,
+        inbound_rate_limiter: Option<InboundMessageRateLimiter>,
     ) -> Self {
         let Connection {
             metadata: connection_metadata,
@@ -199,6 +205,7 @@ where
             max_frame_size,
             max_message_size,
             inbound_stream: InboundStreamBuffer::new(max_fragments),
+            inbound_rate_limiter,
         }
     }
 
@@ -238,6 +245,10 @@ where
             self.max_message_size,
         );
 
+        // TODO: split up the main event loop into multiple tasks (e.g., one for handling
+        // inbound messages, one for handling outbound requests, etc.). This would allow
+        // us to parallelize the handling of different events and avoid task blocking.
+
         // Start main Peer event loop.
         let reason = loop {
             if let State::ShuttingDown(reason) = self.state {
@@ -259,6 +270,22 @@ where
                 maybe_message = reader.next() => {
                     match maybe_message {
                         Some(message) =>  {
+                            // Apply inbound rate limiting (if required)
+                            if let Some(rate_limiter) = &mut self.inbound_rate_limiter {
+                                if let Err(err) = rate_limiter.throttle(&message).await {
+                                    warn!(
+                                        NetworkSchema::new(&self.network_context)
+                                            .connection_metadata(&self.connection_metadata),
+                                        error = %err,
+                                        "{} Error handling inbound message from peer {} during rate limiting! Dropping message!",
+                                        self.network_context,
+                                        remote_peer_id.short_str(),
+                                    );
+                                    continue;
+                                }
+                            }
+
+                            // Handle the inbound message
                             if let Err(err) = self.handle_inbound_message(message, &mut write_reqs_tx) {
                                 warn!(
                                     NetworkSchema::new(&self.network_context)

--- a/network/framework/src/peer/rate_limiter.rs
+++ b/network/framework/src/peer/rate_limiter.rs
@@ -1,0 +1,415 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+use crate::{
+    counters,
+    peer_manager::PeerManagerError,
+    protocols::{
+        stream::StreamMessage,
+        wire::messaging::v1::{MultiplexMessage, ReadError},
+    },
+};
+use aptos_logger::debug;
+use aptos_time_service::{TimeService, TimeServiceTrait};
+use aptos_token_bucket::TokenBucket;
+
+// Label constants for the two token bucket types
+const MESSAGES_BUCKET_LABEL: &str = "messages";
+const BYTES_BUCKET_LABEL: &str = "bytes";
+
+/// A simple inbound rate limiter backed by token buckets for bytes and messages
+pub struct InboundMessageRateLimiter {
+    bytes_bucket: Option<TokenBucket>,
+    messages_bucket: Option<TokenBucket>,
+    time_service: TimeService,
+}
+
+impl InboundMessageRateLimiter {
+    /// Creates a new rate limiter with the given message and byte limits
+    pub fn new(
+        messages_per_sec: Option<u64>,
+        bytes_per_sec: Option<u64>,
+        time_service: TimeService,
+    ) -> Option<Self> {
+        // If both limits are missing, return none
+        if bytes_per_sec.is_none() && messages_per_sec.is_none() {
+            return None;
+        }
+
+        // Otherwise, create token buckets for the provided limits
+        let messages_bucket = messages_per_sec.map(|messages| {
+            TokenBucket::new(
+                messages, // Initial capacity
+                messages, // Refill rate per second
+                time_service.clone(),
+            )
+        });
+        let bytes_bucket = bytes_per_sec.map(|bytes| {
+            TokenBucket::new(
+                bytes, // Initial capacity
+                bytes, // Refill rate per second
+                time_service.clone(),
+            )
+        });
+
+        Some(Self {
+            bytes_bucket,
+            messages_bucket,
+            time_service,
+        })
+    }
+
+    /// Sleeps until both token buckets can handle the given multiplex message
+    pub async fn throttle(
+        &mut self,
+        message: &Result<MultiplexMessage, ReadError>,
+    ) -> Result<(), PeerManagerError> {
+        // Calculate the message count and bytes for the given message
+        let (message_count, message_bytes) = get_message_count_and_bytes(message);
+
+        // Verify we have enough tokens to process the message
+        if let Some(messages_bucket) = &mut self.messages_bucket {
+            if message_count > 0 {
+                wait_for_tokens(
+                    messages_bucket,
+                    message_count,
+                    &self.time_service,
+                    MESSAGES_BUCKET_LABEL,
+                )
+                .await?;
+            }
+        }
+        if let Some(bytes_bucket) = &mut self.bytes_bucket {
+            if message_bytes > 0 {
+                wait_for_tokens(
+                    bytes_bucket,
+                    message_bytes,
+                    &self.time_service,
+                    BYTES_BUCKET_LABEL,
+                )
+                .await?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Returns the message count and bytes for the given multiplex message
+fn get_message_count_and_bytes(message: &Result<MultiplexMessage, ReadError>) -> (u64, u64) {
+    // Calculate the number of messages (required to handle stream messages)
+    let message_count: u64 = match message {
+        Ok(MultiplexMessage::Message(_)) => 1,
+        Ok(MultiplexMessage::Stream(StreamMessage::Header(_))) => 1,
+        Ok(MultiplexMessage::Stream(StreamMessage::Fragment(_))) => 0,
+        Err(_) => 0,
+    };
+
+    // Calculate the number of bytes in the message
+    let message_bytes: u64 = match message {
+        Ok(MultiplexMessage::Message(msg)) => msg.data_len() as u64,
+        Ok(MultiplexMessage::Stream(StreamMessage::Header(header))) => {
+            header.message.data_len() as u64
+        },
+        Ok(MultiplexMessage::Stream(StreamMessage::Fragment(fragment))) => {
+            fragment.raw_data.len() as u64
+        },
+        Err(_) => 0,
+    };
+
+    (message_count, message_bytes)
+}
+
+/// Loops until the bucket has enough tokens, sleeping between attempts
+async fn wait_for_tokens(
+    bucket: &mut TokenBucket,
+    requested: u64,
+    time_service: &TimeService,
+    bucket_label: &'static str,
+) -> Result<(), PeerManagerError> {
+    loop {
+        // Attempt to acquire the tokens
+        let result = bucket.try_acquire_all(requested);
+
+        // Process the acquisition result
+        match result {
+            Ok(()) => return Ok(()),
+            Err(Some(ready_at_time)) => {
+                debug!(
+                    "Failed to acquire {} tokens from the {} bucket. Throttling until {:?}.",
+                    requested, bucket_label, ready_at_time
+                );
+
+                // Update the metrics to record that this message was throttled
+                counters::inc_inbound_rate_limiter_throttled(bucket_label);
+
+                // Sleep until the tokens will be available
+                time_service.sleep_until(ready_at_time).await
+            },
+            Err(None) => {
+                // The bucket will never have enough tokens
+                counters::inc_inbound_rate_limiter_capacity_exceeded(bucket_label);
+                return Err(PeerManagerError::RateLimitCapacityExceeded);
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        protocols::{
+            stream::{StreamFragment, StreamHeader},
+            wire::messaging::v1::{DirectSendMsg, NetworkMessage},
+        },
+        ProtocolId,
+    };
+    use aptos_time_service::MockTimeService;
+    use std::io;
+
+    #[test]
+    fn test_get_message_count_and_bytes_direct_send() {
+        let msg = create_direct_send_message(42);
+        let (count, bytes) = get_message_count_and_bytes(&msg);
+        assert_eq!(count, 1);
+        assert_eq!(bytes, 42);
+    }
+
+    #[test]
+    fn test_get_message_count_and_bytes_stream_header() {
+        let msg = create_stream_header(20);
+        let (count, bytes) = get_message_count_and_bytes(&msg);
+        assert_eq!(count, 1);
+        assert_eq!(bytes, 20);
+    }
+
+    #[test]
+    fn test_get_message_count_and_bytes_stream_fragment() {
+        let msg = create_stream_fragment(15);
+        let (count, bytes) = get_message_count_and_bytes(&msg);
+        assert_eq!(count, 0);
+        assert_eq!(bytes, 15);
+    }
+
+    #[test]
+    fn test_get_message_count_and_bytes_error_message() {
+        // Error messages should contribute 0 to both counts
+        let io_err = io::Error::other("test error");
+        let (count, bytes) = get_message_count_and_bytes(&Err(ReadError::IoError(io_err)));
+        assert_eq!(count, 0);
+        assert_eq!(bytes, 0);
+    }
+
+    #[test]
+    fn test_new_returns_none_when_no_limits() {
+        let time_service = TimeService::mock();
+        assert!(InboundMessageRateLimiter::new(None, None, time_service).is_none());
+    }
+
+    #[test]
+    fn test_new_returns_some_with_bytes_limit() {
+        let time_service = TimeService::mock();
+        assert!(InboundMessageRateLimiter::new(None, Some(100), time_service).is_some());
+    }
+
+    #[test]
+    fn test_new_returns_some_with_messages_limit() {
+        let time_service = TimeService::mock();
+        assert!(InboundMessageRateLimiter::new(Some(10), None, time_service).is_some());
+    }
+
+    #[tokio::test]
+    async fn test_throttle_passes_immediately_within_limit() {
+        // Create an inbound message rate limiter
+        let messages_per_sec = 10;
+        let bytes_per_sec = 1000;
+        let (mut rate_limiter, _) = create_rate_limiter(messages_per_sec, bytes_per_sec);
+
+        // First message should pass without any waiting
+        let message = create_direct_send_message(100);
+        rate_limiter.throttle(&message).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_throttle_error_exceeds_byte_capacity() {
+        // Create an inbound message rate limiter
+        let messages_per_sec = 50;
+        let bytes_per_sec = 1;
+        let (mut rate_limiter, _) = create_rate_limiter(messages_per_sec, bytes_per_sec);
+
+        // Verify that a message exceeding the byte capacity immediately errors
+        let message = create_direct_send_message(100);
+        let result = rate_limiter.throttle(&message).await;
+        assert!(matches!(
+            result,
+            Err(PeerManagerError::RateLimitCapacityExceeded)
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_throttle_error_exceeds_message_capacity() {
+        // Create an inbound message rate limiter
+        let messages_per_sec = 0; // Don't allow any messages
+        let bytes_per_sec = 1000;
+        let (mut rate_limiter, _) = create_rate_limiter(messages_per_sec, bytes_per_sec);
+
+        // Verify that any message exceeding the message capacity immediately errors
+        let message = create_direct_send_message(100);
+        let result = rate_limiter.throttle(&message).await;
+        assert!(matches!(
+            result,
+            Err(PeerManagerError::RateLimitCapacityExceeded)
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_throttle_waits_and_resumes_after_time_advance() {
+        // Create an inbound message rate limiter
+        let messages_per_sec = 100;
+        let bytes_per_sec = 100;
+        let (mut rate_limiter, mock_time) = create_rate_limiter(messages_per_sec, bytes_per_sec);
+
+        // Drain the byte bucket and then block on the next message
+        let throttle_task = tokio::spawn(async move {
+            rate_limiter
+                .throttle(&create_direct_send_message(100))
+                .await
+                .unwrap();
+            rate_limiter
+                .throttle(&create_direct_send_message(100))
+                .await
+        });
+
+        // Yield so the spawned task runs and blocks on the sleep
+        tokio::task::yield_now().await;
+
+        // Advance mock time by 1 second to trigger the refill
+        mock_time.advance_secs_async(1).await;
+
+        // The throttle should now complete successfully
+        throttle_task.await.unwrap().unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_throttle_waits_for_message_token_refill() {
+        // Create an inbound message rate limiter
+        let messages_per_sec = 1;
+        let bytes_per_sec = 1000;
+        let (mut rate_limiter, mock_time) = create_rate_limiter(messages_per_sec, bytes_per_sec);
+
+        // Consume the message slot and then block on the next message
+        let throttle_task = tokio::spawn(async move {
+            rate_limiter
+                .throttle(&create_direct_send_message(1))
+                .await
+                .unwrap();
+            rate_limiter.throttle(&create_direct_send_message(1)).await
+        });
+
+        // Yield so the spawned task runs and blocks on the sleep
+        tokio::task::yield_now().await;
+
+        // Advance 1 second to refill
+        mock_time.advance_secs_async(1).await;
+
+        // Verify that the message now passes
+        throttle_task.await.unwrap().unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_stream_fragment_does_not_count_as_message() {
+        // Create an inbound message rate limiter
+        let messages_per_sec = 0; // Don't allow any messages
+        let bytes_per_sec = 1000;
+        let (mut rate_limiter, _) = create_rate_limiter(messages_per_sec, bytes_per_sec);
+
+        // Multiple fragments should pass without consuming message tokens
+        for _ in 0..10 {
+            rate_limiter
+                .throttle(&create_stream_fragment(0))
+                .await
+                .unwrap();
+        }
+    }
+
+    #[tokio::test]
+    async fn test_stream_fragment_byte_accounting() {
+        // Create an inbound message rate limiter
+        let messages_per_sec = 1000;
+        let bytes_per_sec = 50;
+        let (mut rate_limiter, mock_time) = create_rate_limiter(messages_per_sec, bytes_per_sec);
+
+        // Drain the byte bucket and then block on the next fragment
+        let throttle_task = tokio::spawn(async move {
+            rate_limiter
+                .throttle(&create_stream_fragment(50))
+                .await
+                .unwrap();
+            rate_limiter.throttle(&create_stream_fragment(50)).await
+        });
+
+        // Yield so the spawned task runs and blocks on the sleep
+        tokio::task::yield_now().await;
+
+        // Advance 1 second to refill
+        mock_time.advance_secs_async(1).await;
+
+        // Verify that the message now passes
+        throttle_task.await.unwrap().unwrap();
+    }
+
+    /// Creates a direct send message with the given payload size
+    fn create_direct_send_message(num_bytes: usize) -> Result<MultiplexMessage, ReadError> {
+        Ok(MultiplexMessage::Message(NetworkMessage::DirectSendMsg(
+            DirectSendMsg {
+                protocol_id: ProtocolId::ConsensusDirectSendJson,
+                priority: 0,
+                raw_msg: vec![0u8; num_bytes],
+            },
+        )))
+    }
+
+    /// Creates a stream header with the given payload size
+    fn create_stream_header(num_bytes: usize) -> Result<MultiplexMessage, ReadError> {
+        let message = NetworkMessage::DirectSendMsg(DirectSendMsg {
+            protocol_id: ProtocolId::ConsensusDirectSendJson,
+            priority: 0,
+            raw_msg: vec![0u8; num_bytes],
+        });
+        Ok(MultiplexMessage::Stream(StreamMessage::Header(
+            StreamHeader {
+                request_id: 0,
+                num_fragments: 1,
+                message,
+            },
+        )))
+    }
+
+    /// Creates a stream fragment with the given payload size
+    fn create_stream_fragment(num_bytes: usize) -> Result<MultiplexMessage, ReadError> {
+        Ok(MultiplexMessage::Stream(StreamMessage::Fragment(
+            StreamFragment {
+                request_id: 0,
+                fragment_id: 0,
+                raw_data: vec![0u8; num_bytes],
+            },
+        )))
+    }
+
+    /// Creates a rate limiter with a mock time service
+    fn create_rate_limiter(
+        messages_per_sec: u64,
+        bytes_per_sec: u64,
+    ) -> (InboundMessageRateLimiter, MockTimeService) {
+        let mock_time_service = MockTimeService::new();
+        let time_service = TimeService::from_mock(mock_time_service.clone());
+        let rate_limiter = InboundMessageRateLimiter::new(
+            Some(messages_per_sec),
+            Some(bytes_per_sec),
+            time_service,
+        )
+        .unwrap();
+        (rate_limiter, mock_time_service)
+    }
+}

--- a/network/framework/src/peer/test.rs
+++ b/network/framework/src/peer/test.rs
@@ -96,6 +96,7 @@ fn build_test_peer(
         MAX_CONCURRENT_OUTBOUND_RPCS,
         MAX_FRAME_SIZE,
         MAX_MESSAGE_SIZE,
+        None, /* inbound_rate_limiter */
     );
     let peer_handle = PeerHandle(peer_reqs_tx);
 

--- a/network/framework/src/peer_manager/builder.rs
+++ b/network/framework/src/peer_manager/builder.rs
@@ -18,7 +18,7 @@ use crate::{
 };
 use aptos_channels::{self, aptos_channel, message_queues::QueueStyle};
 use aptos_config::{
-    config::{AccessControlPolicy, HANDSHAKE_VERSION},
+    config::{AccessControlPolicy, RateLimitConfig, HANDSHAKE_VERSION},
     network_id::NetworkContext,
 };
 use aptos_crypto::x25519;
@@ -82,6 +82,7 @@ struct PeerManagerContext {
     tcp_buffer_cfg: TCPBufferCfg,
     access_control_policy: Option<Arc<AccessControlPolicy>>,
     priority_inbound_peers: Vec<PeerId>,
+    inbound_rate_limit_config: Option<RateLimitConfig>,
 }
 
 impl PeerManagerContext {
@@ -106,6 +107,7 @@ impl PeerManagerContext {
         tcp_buffer_cfg: TCPBufferCfg,
         access_control_policy: Option<Arc<AccessControlPolicy>>,
         priority_inbound_peers: Vec<PeerId>,
+        inbound_rate_limit_config: Option<RateLimitConfig>,
     ) -> Self {
         Self {
             pm_reqs_tx,
@@ -124,6 +126,7 @@ impl PeerManagerContext {
             tcp_buffer_cfg,
             access_control_policy,
             priority_inbound_peers,
+            inbound_rate_limit_config,
         }
     }
 
@@ -183,6 +186,7 @@ impl PeerManagerBuilder {
         tcp_buffer_cfg: TCPBufferCfg,
         access_control_policy: Option<Arc<AccessControlPolicy>>,
         priority_inbound_peers: Vec<PeerId>,
+        inbound_rate_limit_config: Option<RateLimitConfig>,
     ) -> Self {
         // Setup channel to send requests to peer manager.
         let (pm_reqs_tx, pm_reqs_rx) = aptos_channel::new(
@@ -219,6 +223,7 @@ impl PeerManagerBuilder {
                 tcp_buffer_cfg,
                 access_control_policy,
                 priority_inbound_peers,
+                inbound_rate_limit_config,
             )),
             peer_manager: None,
             listen_address,
@@ -354,6 +359,7 @@ impl PeerManagerBuilder {
             pm_context.inbound_connection_limit,
             pm_context.access_control_policy,
             pm_context.priority_inbound_peers,
+            pm_context.inbound_rate_limit_config,
         );
 
         // PeerManager constructor appends a public key to the listen_address.

--- a/network/framework/src/peer_manager/error.rs
+++ b/network/framework/src/peer_manager/error.rs
@@ -42,6 +42,9 @@ pub enum PeerManagerError {
 
     #[error("Error writing to wire: {0}")]
     WireWriteError(#[from] wire::WriteError),
+
+    #[error("Inbound message exceeds rate limiter capacity")]
+    RateLimitCapacityExceeded,
 }
 
 impl PeerManagerError {

--- a/network/framework/src/peer_manager/mod.rs
+++ b/network/framework/src/peer_manager/mod.rs
@@ -14,7 +14,7 @@ use crate::{
     constants,
     counters::{self},
     logging::*,
-    peer::{DisconnectReason, Peer, PeerRequest},
+    peer::{rate_limiter::InboundMessageRateLimiter, DisconnectReason, Peer, PeerRequest},
     transport::{
         Connection, ConnectionId, ConnectionMetadata, TSocket as TransportTSocket,
         TRANSPORT_TIMEOUT,
@@ -23,7 +23,7 @@ use crate::{
 };
 use aptos_channels::{self, aptos_channel, message_queues::QueueStyle};
 use aptos_config::{
-    config::AccessControlPolicy,
+    config::{AccessControlPolicy, RateLimitConfig},
     network_id::{NetworkContext, PeerNetworkId},
 };
 use aptos_logger::prelude::*;
@@ -125,6 +125,8 @@ where
     /// Priority inbound peers that can bypass inbound connection
     /// limits (by evicting lower-priority connections).
     priority_inbound_peers: Vec<PeerId>,
+    /// Rate limiting configuration for inbound network traffic per peer
+    inbound_rate_limit_config: Option<RateLimitConfig>,
 }
 
 impl<TTransport, TSocket> PeerManager<TTransport, TSocket>
@@ -154,6 +156,7 @@ where
         inbound_connection_limit: usize,
         access_control_policy: Option<Arc<AccessControlPolicy>>,
         priority_inbound_peers: Vec<PeerId>,
+        inbound_rate_limit_config: Option<RateLimitConfig>,
     ) -> Self {
         let (transport_notifs_tx, transport_notifs_rx) = aptos_channels::new(
             channel_size,
@@ -197,6 +200,7 @@ where
             inbound_connection_limit,
             access_control_policy,
             priority_inbound_peers,
+            inbound_rate_limit_config,
         }
     }
 
@@ -808,6 +812,15 @@ where
             Some(&counters::PENDING_NETWORK_REQUESTS),
         );
 
+        // Create a per-peer inbound rate limiter (if configured)
+        let inbound_rate_limiter = self.inbound_rate_limit_config.as_ref().and_then(|config| {
+            InboundMessageRateLimiter::new(
+                config.inbound_messages_per_second,
+                config.inbound_bytes_per_second,
+                self.time_service.clone(),
+            )
+        });
+
         // Initialize a new Peer actor for this connection.
         let peer = Peer::new(
             self.network_context,
@@ -822,6 +835,7 @@ where
             constants::MAX_CONCURRENT_OUTBOUND_RPCS,
             self.max_frame_size,
             self.max_message_size,
+            inbound_rate_limiter,
         );
         self.executor.spawn(peer.start());
 

--- a/network/framework/src/peer_manager/tests.rs
+++ b/network/framework/src/peer_manager/tests.rs
@@ -124,6 +124,7 @@ fn build_test_peer_manager(
         MAX_INBOUND_CONNECTIONS,
         None,       /* access_control_policy */
         Vec::new(), /* priority_peers */
+        None,       /* inbound_rate_limit_config */
     );
 
     (
@@ -803,6 +804,7 @@ fn create_peer_manager_with_policy(
         MAX_INBOUND_CONNECTIONS,
         policy.map(std::sync::Arc::new),
         Vec::new(), /* priority_peers */
+        None,       /* inbound_rate_limit_config */
     )
 }
 
@@ -1290,6 +1292,7 @@ fn create_peer_manager_with_priority_peers(
         inbound_connection_limit,
         None, /* access_control_policy */
         priority_inbound_peers,
+        None, /* inbound_rate_limit_config */
     );
 
     (


### PR DESCRIPTION
## Description
This PR adds a simple inbound message rate limiter to the network stack (per peer). The rate limiter supports both message and byte rate limits (per second). When the rate limit is hit, the peer manager stops reading messages off the wire until enough time has elapsed. By default, rate limiting is disabled.

Note: in the next PR, I'll split up the main peer event loop, to parallelize task handling. This will prevent inbound rate limiting from throttling output message sending for the peer.

## Testing Plan
New and existing test infrastructure. Also, a manual run with some limits (you can see throttling [here](https://grafana.aptoslabs.com/d/network/network?from=2026-04-07T18:48:04.000Z&to=2026-04-07T19:04:43.000Z&timezone=America%2FLos_Angeles&var-Datasource=fHo-R604z&var-BigQuery=axNEitxVz&var-metrics_source=$__all&var-chain_name=forge-3&var-cluster=$__all&var-namespace=forge-e2e-pr-19346&var-kubernetes_pod_name=$__all&var-interval=1m&orgId=1&var-role=$__all&var-Filters=&viewPanel=panel-229)).



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core networking read path and introduces async throttling in the `Peer` event loop, which could affect peer throughput/latency or trigger unexpected message drops if misconfigured.
> 
> **Overview**
> Adds an **optional per-peer inbound rate limiter** to the network stack, configurable via `NetworkConfig.inbound_rate_limit_config` with per-second byte and message limits.
> 
> `PeerManager` now constructs an `InboundMessageRateLimiter` for each connection (when configured) and `Peer` applies it before handling each inbound `MultiplexMessage`, sleeping when over limit and erroring when a message exceeds bucket capacity.
> 
> Introduces new `aptos-token-bucket` dependency plus new counters (`aptos_network_inbound_rate_limiter_throttled_count` and `..._capacity_exceeded_count`) and a new `PeerManagerError::RateLimitCapacityExceeded`; updates builders/tests/fuzzing to plumb the new config/parameter through.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b811e1af971a6c198db63d6c781d555e406e40a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->