### PR TITLE
[linter] Add mutable_view_function and unsafe_friend_package_entry lint

### DIFF
--- a/third_party/move/tools/move-linter/src/model_ast_lints.rs
+++ b/third_party/move/tools/move-linter/src/model_ast_lints.rs
@@ -13,6 +13,7 @@ mod deprecated_usage;
 mod empty_if;
 mod equal_operands_in_bin_op;
 mod known_to_abort;
+mod mutable_view_function;
 mod needless_bool;
 mod needless_deref_ref;
 mod needless_ref_deref;
@@ -26,6 +27,7 @@ mod simpler_numeric_expression;
 mod unnecessary_boolean_identity_comparison;
 mod unnecessary_cast;
 mod unnecessary_numerical_extreme_comparison;
+mod unsafe_friend_package_entry;
 pub(crate) mod unused_common;
 mod unused_constant;
 mod unused_function;
@@ -118,8 +120,10 @@ pub fn get_default_function_linter_pipeline(
     config: &BTreeMap<String, String>,
 ) -> Vec<Box<dyn FunctionChecker>> {
     let mut checks: Vec<Box<dyn FunctionChecker>> = vec![
+        Box::new(mutable_view_function::MutableViewFunction::new()),
         Box::<unused_function::UnusedFunction>::default(),
         Box::<needless_visibility::NeedlessVisibility>::default(),
+        Box::<unsafe_friend_package_entry::UnsafeFriendPackageEntry>::default(),
     ];
     let checks_category = config.get("checks").map_or("default", |s| s.as_str());
     if checks_category == "strict" || checks_category == "experimental" {

--- a/third_party/move/tools/move-linter/src/model_ast_lints/mutable_view_function.rs
+++ b/third_party/move/tools/move-linter/src/model_ast_lints/mutable_view_function.rs
@@ -8,35 +8,66 @@
 //! View functions are expected to be read-only. A view that mutates state
 //! could lead to bugs.
 //!
-//! The checker lazily precomputes a set of all functions that transitively
-//! mutate global state using reverse call-graph propagation. Each
-//! `check_function` call then does a simple set lookup.
+//! The checker uses recursive memoized traversal starting from view functions,
+//! so only functions reachable from view functions are ever visited.
 
 use move_compiler_v2::external_checks::FunctionChecker;
 use move_model::{
     ast::{Attribute, ExpData, Operation},
-    model::{FunId, FunctionEnv, GlobalEnv, QualifiedId},
+    model::{FunId, FunctionEnv, QualifiedId},
     ty::ReferenceKind,
 };
-use std::{
-    cell::OnceCell,
-    collections::{BTreeMap, BTreeSet},
-};
+use std::{cell::RefCell, collections::BTreeMap};
 
 const CHECKER_NAME: &str = "mutable_view_function";
 const VIEW_ATTRIBUTE: &str = "view";
 
 pub struct MutableViewFunction {
-    /// Lazily computed set of all functions that (directly or transitively)
-    /// call a state-mutating global operation.
-    mutating_funs: OnceCell<BTreeSet<QualifiedId<FunId>>>,
+    memo: RefCell<BTreeMap<QualifiedId<FunId>, bool>>,
 }
 
 impl MutableViewFunction {
     pub fn new() -> Self {
         Self {
-            mutating_funs: OnceCell::new(),
+            memo: RefCell::new(BTreeMap::new()),
         }
+    }
+
+    fn transitively_mutates(&self, func: &FunctionEnv) -> bool {
+        let fun_id = func.get_qualified_id();
+
+        if let Some(&result) = self.memo.borrow().get(&fun_id) {
+            return result;
+        }
+
+        if func.is_native() {
+            self.memo.borrow_mut().insert(fun_id, false);
+            return false;
+        }
+
+        if mutates_global_state_directly(func) {
+            self.memo.borrow_mut().insert(fun_id, true);
+            return true;
+        }
+
+        // Insert false before recursing to handle cycles.
+        self.memo.borrow_mut().insert(fun_id, false);
+
+        let mut result = false;
+        if let Some(callees) = func.get_called_functions() {
+            let env = &func.module_env.env;
+            for callee_id in callees {
+                if let Some(callee_func) = env.get_function_opt(*callee_id) {
+                    if self.transitively_mutates(&callee_func) {
+                        result = true;
+                        break;
+                    }
+                }
+            }
+        }
+
+        self.memo.borrow_mut().insert(fun_id, result);
+        result
     }
 }
 
@@ -46,13 +77,8 @@ impl FunctionChecker for MutableViewFunction {
     }
 
     fn check_function(&self, func: &FunctionEnv) {
-        let env = &func.module_env.env;
-
-        let mutating_funs = self
-            .mutating_funs
-            .get_or_init(|| compute_mutating_funs(env));
-
-        if has_view_attribute(func) && mutating_funs.contains(&func.get_qualified_id()) {
+        if has_view_attribute(func) && self.transitively_mutates(func) {
+            let env = &func.module_env.env;
             let name = func.get_name_str();
             let msg = format!(
                 "view function `{name}` should not modify state, but this function \
@@ -68,56 +94,6 @@ fn has_view_attribute(func: &FunctionEnv) -> bool {
     let env = &func.module_env.env;
     let view_sym = env.symbol_pool().make(VIEW_ATTRIBUTE);
     func.has_attribute(|attr| matches!(attr, Attribute::Apply(_, name, _) if *name == view_sym))
-}
-
-/// Compute the set of all functions that directly or transitively call a
-/// state-mutating global operation.
-///
-/// Algorithm:
-/// 1. Build a reverse call-graph (callee -> set of callers) using
-///    `get_called_functions()` which is available for all functions.
-/// 2. Seed the worklist with functions that directly mutate global state
-///    by scanning `ExpData` for `BorrowGlobal(Mutable)`, `MoveTo`, `MoveFrom`.
-/// 3. Propagate: any caller of a mutating function is also mutating.
-fn compute_mutating_funs(env: &GlobalEnv) -> BTreeSet<QualifiedId<FunId>> {
-    let mut reverse_callees: BTreeMap<QualifiedId<FunId>, BTreeSet<QualifiedId<FunId>>> =
-        BTreeMap::new();
-    let mut worklist: Vec<QualifiedId<FunId>> = Vec::new();
-
-    for module in env.get_modules() {
-        for func in module.get_functions() {
-            let fun_id = func.get_qualified_id();
-            if func.is_native() {
-                continue;
-            }
-
-            if mutates_global_state_directly(&func) {
-                worklist.push(fun_id);
-            }
-
-            if let Some(callees) = func.get_called_functions() {
-                for callee in callees {
-                    reverse_callees.entry(*callee).or_default().insert(fun_id);
-                }
-            }
-        }
-    }
-
-    let mut mutating_funs = BTreeSet::new();
-    while let Some(current) = worklist.pop() {
-        if !mutating_funs.insert(current) {
-            continue;
-        }
-        if let Some(callers) = reverse_callees.get(&current) {
-            for caller in callers {
-                if !mutating_funs.contains(caller) {
-                    worklist.push(*caller);
-                }
-            }
-        }
-    }
-
-    mutating_funs
 }
 
 /// Check if a function directly mutates global state by scanning its AST.

--- a/third_party/move/tools/move-linter/src/model_ast_lints/mutable_view_function.rs
+++ b/third_party/move/tools/move-linter/src/model_ast_lints/mutable_view_function.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-//! Lint check for `#[view]` public functions that (directly or transitively)
+//! Lint check for `#[view]` functions that (directly or transitively)
 //! call state-mutating global operations (`borrow_global_mut`, `move_to`,
 //! `move_from`).
 //!
@@ -12,7 +12,6 @@
 //! mutate global state using reverse call-graph propagation. Each
 //! `check_function` call then does a simple set lookup.
 
-use move_binary_format::file_format::Bytecode as FileFormatBytecode;
 use move_compiler_v2::external_checks::FunctionChecker;
 use move_model::{
     ast::{Attribute, ExpData, Operation},
@@ -53,10 +52,7 @@ impl FunctionChecker for MutableViewFunction {
             .mutating_funs
             .get_or_init(|| compute_mutating_funs(env));
 
-        if func.visibility().is_public()
-            && has_view_attribute(func)
-            && mutating_funs.contains(&func.get_qualified_id())
-        {
+        if has_view_attribute(func) && mutating_funs.contains(&func.get_qualified_id()) {
             let name = func.get_name_str();
             let msg = format!(
                 "view function `{name}` should not modify state, but this function \
@@ -80,11 +76,8 @@ fn has_view_attribute(func: &FunctionEnv) -> bool {
 /// Algorithm:
 /// 1. Build a reverse call-graph (callee -> set of callers) using
 ///    `get_called_functions()` which is available for all functions.
-/// 2. Seed the worklist with functions that directly mutate global state.
-///    - Primary targets (have AST): scan `ExpData` for
-///      `BorrowGlobal(Mutable)`, `MoveTo`, `MoveFrom`.
-///    - Dependencies (have compiled bytecode): scan `file_format::Bytecode`
-///      for `MutBorrowGlobal*`, `MoveTo*`, `MoveFrom*`.
+/// 2. Seed the worklist with functions that directly mutate global state
+///    by scanning `ExpData` for `BorrowGlobal(Mutable)`, `MoveTo`, `MoveFrom`.
 /// 3. Propagate: any caller of a mutating function is also mutating.
 fn compute_mutating_funs(env: &GlobalEnv) -> BTreeSet<QualifiedId<FunId>> {
     let mut reverse_callees: BTreeMap<QualifiedId<FunId>, BTreeSet<QualifiedId<FunId>>> =
@@ -127,47 +120,20 @@ fn compute_mutating_funs(env: &GlobalEnv) -> BTreeSet<QualifiedId<FunId>> {
     mutating_funs
 }
 
-/// Check if a function directly mutates global state.
-///
-/// Uses AST scanning for primary targets (which have `get_def()`) and
-/// file-format bytecode scanning for dependencies (which have
-/// `get_bytecode()` from their pre-compiled module).
+/// Check if a function directly mutates global state by scanning its AST.
 fn mutates_global_state_directly(func: &FunctionEnv) -> bool {
-    if let Some(def) = func.get_def() {
-        let mut found = false;
-        def.as_ref().visit_pre_order(&mut |exp| {
-            if found {
-                return false;
-            }
-            if let ExpData::Call(_, op, _) = exp
-                && matches!(
-                    op,
+    func.get_def().is_some_and(|def| {
+        def.any(&mut |exp| {
+            matches!(
+                exp,
+                ExpData::Call(
+                    _,
                     Operation::BorrowGlobal(ReferenceKind::Mutable)
                         | Operation::MoveTo
-                        | Operation::MoveFrom
+                        | Operation::MoveFrom,
+                    _
                 )
-            {
-                found = true;
-                return false;
-            }
-            true
-        });
-        return found;
-    }
-
-    if let Some(code) = func.get_bytecode() {
-        return code.iter().any(|bc| {
-            matches!(
-                bc,
-                FileFormatBytecode::MutBorrowGlobal(_)
-                    | FileFormatBytecode::MutBorrowGlobalGeneric(_)
-                    | FileFormatBytecode::MoveTo(_)
-                    | FileFormatBytecode::MoveToGeneric(_)
-                    | FileFormatBytecode::MoveFrom(_)
-                    | FileFormatBytecode::MoveFromGeneric(_)
             )
-        });
-    }
-
-    false
+        })
+    })
 }

--- a/third_party/move/tools/move-linter/src/model_ast_lints/mutable_view_function.rs
+++ b/third_party/move/tools/move-linter/src/model_ast_lints/mutable_view_function.rs
@@ -104,7 +104,7 @@ impl FunctionChecker for MutableViewFunction {
             let name = func.get_name_str();
             let msg = format!(
                 "view function `{name}` should not modify state, but this function \
-                 (or one of its callees) calls a state-mutating operation \
+                 (or one of its callees) calls a global-state mutating operation \
                  (`borrow_global_mut`, `move_to`, or `move_from`).",
             );
             self.report(env, &func.get_id_loc(), &msg);

--- a/third_party/move/tools/move-linter/src/model_ast_lints/mutable_view_function.rs
+++ b/third_party/move/tools/move-linter/src/model_ast_lints/mutable_view_function.rs
@@ -1,0 +1,173 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Lint check for `#[view]` public functions that (directly or transitively)
+//! call state-mutating global operations (`borrow_global_mut`, `move_to`,
+//! `move_from`).
+//!
+//! View functions are expected to be read-only. A view that mutates state
+//! could lead to bugs.
+//!
+//! The checker lazily precomputes a set of all functions that transitively
+//! mutate global state using reverse call-graph propagation. Each
+//! `check_function` call then does a simple set lookup.
+
+use move_binary_format::file_format::Bytecode as FileFormatBytecode;
+use move_compiler_v2::external_checks::FunctionChecker;
+use move_model::{
+    ast::{Attribute, ExpData, Operation},
+    model::{FunId, FunctionEnv, GlobalEnv, QualifiedId},
+    ty::ReferenceKind,
+};
+use std::{
+    cell::OnceCell,
+    collections::{BTreeMap, BTreeSet},
+};
+
+const CHECKER_NAME: &str = "mutable_view_function";
+const VIEW_ATTRIBUTE: &str = "view";
+
+pub struct MutableViewFunction {
+    /// Lazily computed set of all functions that (directly or transitively)
+    /// call a state-mutating global operation.
+    mutating_funs: OnceCell<BTreeSet<QualifiedId<FunId>>>,
+}
+
+impl MutableViewFunction {
+    pub fn new() -> Self {
+        Self {
+            mutating_funs: OnceCell::new(),
+        }
+    }
+}
+
+impl FunctionChecker for MutableViewFunction {
+    fn get_name(&self) -> String {
+        CHECKER_NAME.to_string()
+    }
+
+    fn check_function(&self, func: &FunctionEnv) {
+        let env = &func.module_env.env;
+
+        let mutating_funs = self
+            .mutating_funs
+            .get_or_init(|| compute_mutating_funs(env));
+
+        if func.visibility().is_public()
+            && has_view_attribute(func)
+            && mutating_funs.contains(&func.get_qualified_id())
+        {
+            let name = func.get_name_str();
+            let msg = format!(
+                "view function `{name}` should not modify state, but this function \
+                 (or one of its callees) calls a state-mutating operation \
+                 (`borrow_global_mut`, `move_to`, or `move_from`).",
+            );
+            self.report(env, &func.get_id_loc(), &msg);
+        }
+    }
+}
+
+fn has_view_attribute(func: &FunctionEnv) -> bool {
+    let env = &func.module_env.env;
+    let view_sym = env.symbol_pool().make(VIEW_ATTRIBUTE);
+    func.has_attribute(|attr| matches!(attr, Attribute::Apply(_, name, _) if *name == view_sym))
+}
+
+/// Compute the set of all functions that directly or transitively call a
+/// state-mutating global operation.
+///
+/// Algorithm:
+/// 1. Build a reverse call-graph (callee -> set of callers) using
+///    `get_called_functions()` which is available for all functions.
+/// 2. Seed the worklist with functions that directly mutate global state.
+///    - Primary targets (have AST): scan `ExpData` for
+///      `BorrowGlobal(Mutable)`, `MoveTo`, `MoveFrom`.
+///    - Dependencies (have compiled bytecode): scan `file_format::Bytecode`
+///      for `MutBorrowGlobal*`, `MoveTo*`, `MoveFrom*`.
+/// 3. Propagate: any caller of a mutating function is also mutating.
+fn compute_mutating_funs(env: &GlobalEnv) -> BTreeSet<QualifiedId<FunId>> {
+    let mut reverse_callees: BTreeMap<QualifiedId<FunId>, BTreeSet<QualifiedId<FunId>>> =
+        BTreeMap::new();
+    let mut worklist: Vec<QualifiedId<FunId>> = Vec::new();
+
+    for module in env.get_modules() {
+        for func in module.get_functions() {
+            let fun_id = func.get_qualified_id();
+            if func.is_native() {
+                continue;
+            }
+
+            if mutates_global_state_directly(&func) {
+                worklist.push(fun_id);
+            }
+
+            if let Some(callees) = func.get_called_functions() {
+                for callee in callees {
+                    reverse_callees.entry(*callee).or_default().insert(fun_id);
+                }
+            }
+        }
+    }
+
+    let mut mutating_funs = BTreeSet::new();
+    while let Some(current) = worklist.pop() {
+        if !mutating_funs.insert(current) {
+            continue;
+        }
+        if let Some(callers) = reverse_callees.get(&current) {
+            for caller in callers {
+                if !mutating_funs.contains(caller) {
+                    worklist.push(*caller);
+                }
+            }
+        }
+    }
+
+    mutating_funs
+}
+
+/// Check if a function directly mutates global state.
+///
+/// Uses AST scanning for primary targets (which have `get_def()`) and
+/// file-format bytecode scanning for dependencies (which have
+/// `get_bytecode()` from their pre-compiled module).
+fn mutates_global_state_directly(func: &FunctionEnv) -> bool {
+    if let Some(def) = func.get_def() {
+        let mut found = false;
+        def.as_ref().visit_pre_order(&mut |exp| {
+            if found {
+                return false;
+            }
+            if let ExpData::Call(_, op, _) = exp
+                && matches!(
+                    op,
+                    Operation::BorrowGlobal(ReferenceKind::Mutable)
+                        | Operation::MoveTo
+                        | Operation::MoveFrom
+                )
+            {
+                found = true;
+                return false;
+            }
+            true
+        });
+        return found;
+    }
+
+    if let Some(code) = func.get_bytecode() {
+        return code.iter().any(|bc| {
+            matches!(
+                bc,
+                FileFormatBytecode::MutBorrowGlobal(_)
+                    | FileFormatBytecode::MutBorrowGlobalGeneric(_)
+                    | FileFormatBytecode::MoveTo(_)
+                    | FileFormatBytecode::MoveToGeneric(_)
+                    | FileFormatBytecode::MoveFrom(_)
+                    | FileFormatBytecode::MoveFromGeneric(_)
+            )
+        });
+    }
+
+    false
+}

--- a/third_party/move/tools/move-linter/src/model_ast_lints/mutable_view_function.rs
+++ b/third_party/move/tools/move-linter/src/model_ast_lints/mutable_view_function.rs
@@ -23,7 +23,9 @@ const CHECKER_NAME: &str = "mutable_view_function";
 const VIEW_ATTRIBUTE: &str = "view";
 
 pub struct MutableViewFunction {
-    memo: RefCell<BTreeMap<QualifiedId<FunId>, bool>>,
+    /// `None`  = in-progress or provisional (cycle participant, result uncertain).
+    /// `Some(b)` = finalized result.
+    memo: RefCell<BTreeMap<QualifiedId<FunId>, Option<bool>>>,
 }
 
 impl MutableViewFunction {
@@ -34,31 +36,46 @@ impl MutableViewFunction {
     }
 
     fn transitively_mutates(&self, func: &FunctionEnv) -> bool {
+        self.transitively_mutates_inner(func).0
+    }
+
+    /// Returns `(mutates, hit_cycle)`.
+    ///
+    /// `hit_cycle` is true when the subtree traversed a back-edge to a
+    /// `None` (in-progress) memo entry.  A `false` result with
+    /// `hit_cycle = true` is provisional -- the node stays as `None` in
+    /// the memo so it can be recomputed once its cycle partners are
+    /// resolved.
+    fn transitively_mutates_inner(&self, func: &FunctionEnv) -> (bool, bool) {
         let fun_id = func.get_qualified_id();
 
-        if let Some(&result) = self.memo.borrow().get(&fun_id) {
-            return result;
+        match self.memo.borrow().get(&fun_id).copied() {
+            Some(Some(result)) => return (result, false),
+            Some(None) => return (false, true),
+            None => {},
         }
 
         if func.is_native() {
-            self.memo.borrow_mut().insert(fun_id, false);
-            return false;
+            self.memo.borrow_mut().insert(fun_id, Some(false));
+            return (false, false);
         }
 
         if mutates_global_state_directly(func) {
-            self.memo.borrow_mut().insert(fun_id, true);
-            return true;
+            self.memo.borrow_mut().insert(fun_id, Some(true));
+            return (true, false);
         }
 
-        // Insert false before recursing to handle cycles.
-        self.memo.borrow_mut().insert(fun_id, false);
+        self.memo.borrow_mut().insert(fun_id, None);
 
         let mut result = false;
+        let mut any_cycle = false;
         if let Some(callees) = func.get_called_functions() {
             let env = &func.module_env.env;
             for callee_id in callees {
                 if let Some(callee_func) = env.get_function_opt(*callee_id) {
-                    if self.transitively_mutates(&callee_func) {
+                    let (r, c) = self.transitively_mutates_inner(&callee_func);
+                    any_cycle |= c;
+                    if r {
                         result = true;
                         break;
                     }
@@ -66,8 +83,13 @@ impl MutableViewFunction {
             }
         }
 
-        self.memo.borrow_mut().insert(fun_id, result);
-        result
+        // Only memoize `false` when no cycle back-edge was traversed;
+        // otherwise a cycle partner may later resolve to true.
+        if result || !any_cycle {
+            self.memo.borrow_mut().insert(fun_id, Some(result));
+        }
+
+        (result, any_cycle)
     }
 }
 
@@ -87,6 +109,9 @@ impl FunctionChecker for MutableViewFunction {
             );
             self.report(env, &func.get_id_loc(), &msg);
         }
+        // Discard provisional (None) entries so cycle participants
+        // are recomputed fresh for subsequent view function checks.
+        self.memo.borrow_mut().retain(|_, v| v.is_some());
     }
 }
 
@@ -96,7 +121,6 @@ fn has_view_attribute(func: &FunctionEnv) -> bool {
     func.has_attribute(|attr| matches!(attr, Attribute::Apply(_, name, _) if *name == view_sym))
 }
 
-/// Check if a function directly mutates global state by scanning its AST.
 fn mutates_global_state_directly(func: &FunctionEnv) -> bool {
     func.get_def().is_some_and(|def| {
         def.any(&mut |exp| {

--- a/third_party/move/tools/move-linter/src/model_ast_lints/mutable_view_function.rs
+++ b/third_party/move/tools/move-linter/src/model_ast_lints/mutable_view_function.rs
@@ -67,19 +67,15 @@ impl MutableViewFunction {
 
         self.memo.borrow_mut().insert(fun_id, None);
 
+        let env = &func.module_env.env;
         let mut result = false;
         let mut any_cycle = false;
-        if let Some(callees) = func.get_called_functions() {
-            let env = &func.module_env.env;
-            for callee_id in callees {
-                if let Some(callee_func) = env.get_function_opt(*callee_id) {
-                    let (r, c) = self.transitively_mutates_inner(&callee_func);
-                    any_cycle |= c;
-                    if r {
-                        result = true;
-                        break;
-                    }
-                }
+        for &callee_id in func.get_called_functions().into_iter().flatten() {
+            let (r, c) = self.transitively_mutates_inner(&env.get_function(callee_id));
+            any_cycle |= c;
+            if r {
+                result = true;
+                break;
             }
         }
 
@@ -103,9 +99,11 @@ impl FunctionChecker for MutableViewFunction {
             let env = &func.module_env.env;
             let name = func.get_name_str();
             let msg = format!(
-                "view function `{name}` should not modify state, but this function \
-                 (or one of its callees) calls a global-state mutating operation \
-                 (`borrow_global_mut`, `move_to`, or `move_from`).",
+                "view function `{name}` performs global state mutations (via `borrow_global_mut`, \
+                 `move_to`, or `move_from`), either directly or through a callee. \
+                 These mutations are silently discarded when called via the view API, \
+                 but applied when called from Move code. This inconsistency can lead to \
+                 unexpected behavior, reconsider the implementation.",
             );
             self.report(env, &func.get_id_loc(), &msg);
         }

--- a/third_party/move/tools/move-linter/src/model_ast_lints/unsafe_friend_package_entry.rs
+++ b/third_party/move/tools/move-linter/src/model_ast_lints/unsafe_friend_package_entry.rs
@@ -1,0 +1,45 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Lint check for `public(friend)` or `public(package)` entry functions.
+//!
+//! When a function is marked `entry`, it becomes callable by anyone via a transaction,
+//! regardless of its visibility modifier. A `public(friend) entry` or
+//! `public(package) entry` function therefore does NOT restrict callers to friends
+//! or the same package - the `entry` modifier overrides that restriction.
+
+use move_binary_format::file_format::Visibility;
+use move_compiler_v2::external_checks::FunctionChecker;
+use move_model::model::FunctionEnv;
+
+const CHECKER_NAME: &str = "unsafe_friend_package_entry";
+
+#[derive(Default)]
+pub struct UnsafeFriendPackageEntry;
+
+impl FunctionChecker for UnsafeFriendPackageEntry {
+    fn get_name(&self) -> String {
+        CHECKER_NAME.to_string()
+    }
+
+    fn check_function(&self, func: &FunctionEnv) {
+        if !func.is_entry() || func.visibility() != Visibility::Friend {
+            return;
+        }
+
+        let visibility = if func.has_package_visibility() {
+            "package"
+        } else {
+            "friend"
+        };
+
+        let name = func.get_name_str();
+        let msg = format!(
+            "`{name}` is callable by anyone. \
+             The `entry` modifier allows direct invocation via transactions, \
+             bypassing the {visibility} visibility restriction.",
+        );
+
+        self.report(func.module_env.env, &func.get_id_loc(), &msg);
+    }
+}

--- a/third_party/move/tools/move-linter/src/model_ast_lints/unsafe_friend_package_entry.rs
+++ b/third_party/move/tools/move-linter/src/model_ast_lints/unsafe_friend_package_entry.rs
@@ -37,7 +37,7 @@ impl FunctionChecker for UnsafeFriendPackageEntry {
         let msg = format!(
             "`{name}` is callable by anyone. \
              The `entry` modifier allows direct invocation via transactions, \
-             bypassing the {visibility} visibility restriction.",
+             bypassing the `{visibility}` visibility restriction.",
         );
 
         self.report(func.module_env.env, &func.get_id_loc(), &msg);

--- a/third_party/move/tools/move-linter/src/model_ast_lints/unsafe_friend_package_entry.rs
+++ b/third_party/move/tools/move-linter/src/model_ast_lints/unsafe_friend_package_entry.rs
@@ -5,7 +5,7 @@
 //!
 //! When a function is marked `entry`, it becomes callable by anyone via a transaction,
 //! regardless of its visibility modifier. A `friend entry` or
-//! `public(package) entry` function therefore does NOT restrict callers to friends
+//! `package entry` function therefore does NOT restrict callers to friends
 //! or the same package - the `entry` modifier overrides that restriction.
 
 use move_binary_format::file_format::Visibility;

--- a/third_party/move/tools/move-linter/src/model_ast_lints/unsafe_friend_package_entry.rs
+++ b/third_party/move/tools/move-linter/src/model_ast_lints/unsafe_friend_package_entry.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-//! Lint check for `public(friend)` or `public(package)` entry functions.
+//! Lint check for `friend` or `package` entry functions.
 //!
 //! When a function is marked `entry`, it becomes callable by anyone via a transaction,
 //! regardless of its visibility modifier. A `public(friend) entry` or

--- a/third_party/move/tools/move-linter/src/model_ast_lints/unsafe_friend_package_entry.rs
+++ b/third_party/move/tools/move-linter/src/model_ast_lints/unsafe_friend_package_entry.rs
@@ -4,7 +4,7 @@
 //! Lint check for `friend` or `package` entry functions.
 //!
 //! When a function is marked `entry`, it becomes callable by anyone via a transaction,
-//! regardless of its visibility modifier. A `public(friend) entry` or
+//! regardless of its visibility modifier. A `friend entry` or
 //! `public(package) entry` function therefore does NOT restrict callers to friends
 //! or the same package - the `entry` modifier overrides that restriction.
 

--- a/third_party/move/tools/move-linter/tests/model_ast_lints/mutable_view_function.exp
+++ b/third_party/move/tools/move-linter/tests/model_ast_lints/mutable_view_function.exp
@@ -35,3 +35,57 @@ warning: [lint] view function `unsafe_view_move_from_indirect` should not modify
    │
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(mutable_view_function)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#mutable_view_function.
+
+warning: [lint] view function `private_view_mutates` should not modify state, but this function (or one of its callees) calls a state-mutating operation (`borrow_global_mut`, `move_to`, or `move_from`).
+   ┌─ tests/model_ast_lints/mutable_view_function.move:54:9
+   │
+54 │     fun private_view_mutates(): u64 acquires State {
+   │         ^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(mutable_view_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#mutable_view_function.
+
+warning: [lint] view function `unsafe_view_recursive` should not modify state, but this function (or one of its callees) calls a state-mutating operation (`borrow_global_mut`, `move_to`, or `move_from`).
+   ┌─ tests/model_ast_lints/mutable_view_function.move:76:16
+   │
+76 │     public fun unsafe_view_recursive(): u64 acquires State {
+   │                ^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(mutable_view_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#mutable_view_function.
+
+warning: [lint] view function `unsafe_view_mutual_recursive` should not modify state, but this function (or one of its callees) calls a state-mutating operation (`borrow_global_mut`, `move_to`, or `move_from`).
+    ┌─ tests/model_ast_lints/mutable_view_function.move:110:16
+    │
+110 │     public fun unsafe_view_mutual_recursive(): u64 acquires State {
+    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(mutable_view_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#mutable_view_function.
+
+warning: [lint] view function `unsafe_view_deep_chain` should not modify state, but this function (or one of its callees) calls a state-mutating operation (`borrow_global_mut`, `move_to`, or `move_from`).
+    ┌─ tests/model_ast_lints/mutable_view_function.move:148:16
+    │
+148 │     public fun unsafe_view_deep_chain(): u64 acquires State {
+    │                ^^^^^^^^^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(mutable_view_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#mutable_view_function.
+
+warning: [lint] view function `unsafe_friend_view_mutates` should not modify state, but this function (or one of its callees) calls a state-mutating operation (`borrow_global_mut`, `move_to`, or `move_from`).
+    ┌─ tests/model_ast_lints/mutable_view_function.move:166:24
+    │
+166 │     public(friend) fun unsafe_friend_view_mutates(): u64 acquires State {
+    │                        ^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(mutable_view_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#mutable_view_function.
+
+warning: [lint] view function `unsafe_package_view_mutates` should not modify state, but this function (or one of its callees) calls a state-mutating operation (`borrow_global_mut`, `move_to`, or `move_from`).
+    ┌─ tests/model_ast_lints/mutable_view_function.move:180:25
+    │
+180 │     public(package) fun unsafe_package_view_mutates(): u64 acquires State {
+    │                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(mutable_view_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#mutable_view_function.

--- a/third_party/move/tools/move-linter/tests/model_ast_lints/mutable_view_function.exp
+++ b/third_party/move/tools/move-linter/tests/model_ast_lints/mutable_view_function.exp
@@ -1,109 +1,109 @@
 
 Diagnostics:
-warning: [lint] view function `unsafe_view_indirect` should not modify state, but this function (or one of its callees) calls a state-mutating operation (`borrow_global_mut`, `move_to`, or `move_from`).
+warning: [lint] view function `unsafe_view_indirect` performs global state mutations (via `borrow_global_mut`, `move_to`, or `move_from`), either directly or through a callee. These mutations are silently discarded when called via the view API, but applied when called from Move code. This inconsistency can lead to unexpected behavior, reconsider the implementation.
    ┌─ tests/model_ast_lints/mutable_view_function.move:13:16
    │
-13 │     public fun unsafe_view_indirect(): u64 acquires State {
+13 │     public fun unsafe_view_indirect(): u64 {
    │                ^^^^^^^^^^^^^^^^^^^^
    │
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(mutable_view_function)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#mutable_view_function.
 
-warning: [lint] view function `unsafe_view_direct_borrow` should not modify state, but this function (or one of its callees) calls a state-mutating operation (`borrow_global_mut`, `move_to`, or `move_from`).
+warning: [lint] view function `unsafe_view_direct_borrow` performs global state mutations (via `borrow_global_mut`, `move_to`, or `move_from`), either directly or through a callee. These mutations are silently discarded when called via the view API, but applied when called from Move code. This inconsistency can lead to unexpected behavior, reconsider the implementation.
    ┌─ tests/model_ast_lints/mutable_view_function.move:20:16
    │
-20 │     public fun unsafe_view_direct_borrow(): u64 acquires State {
+20 │     public fun unsafe_view_direct_borrow(): u64 {
    │                ^^^^^^^^^^^^^^^^^^^^^^^^^
    │
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(mutable_view_function)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#mutable_view_function.
 
-warning: [lint] view function `unsafe_view_move_from` should not modify state, but this function (or one of its callees) calls a state-mutating operation (`borrow_global_mut`, `move_to`, or `move_from`).
+warning: [lint] view function `unsafe_view_move_from` performs global state mutations (via `borrow_global_mut`, `move_to`, or `move_from`), either directly or through a callee. These mutations are silently discarded when called via the view API, but applied when called from Move code. This inconsistency can lead to unexpected behavior, reconsider the implementation.
    ┌─ tests/model_ast_lints/mutable_view_function.move:28:16
    │
-28 │     public fun unsafe_view_move_from(): u64 acquires State {
+28 │     public fun unsafe_view_move_from(): u64 {
    │                ^^^^^^^^^^^^^^^^^^^^^
    │
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(mutable_view_function)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#mutable_view_function.
 
-warning: [lint] view function `unsafe_view_move_from_indirect` should not modify state, but this function (or one of its callees) calls a state-mutating operation (`borrow_global_mut`, `move_to`, or `move_from`).
+warning: [lint] view function `unsafe_view_move_from_indirect` performs global state mutations (via `borrow_global_mut`, `move_to`, or `move_from`), either directly or through a callee. These mutations are silently discarded when called via the view API, but applied when called from Move code. This inconsistency can lead to unexpected behavior, reconsider the implementation.
    ┌─ tests/model_ast_lints/mutable_view_function.move:40:16
    │
-40 │     public fun unsafe_view_move_from_indirect(): u64 acquires State {
+40 │     public fun unsafe_view_move_from_indirect(): u64 {
    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    │
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(mutable_view_function)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#mutable_view_function.
 
-warning: [lint] view function `private_view_mutates` should not modify state, but this function (or one of its callees) calls a state-mutating operation (`borrow_global_mut`, `move_to`, or `move_from`).
+warning: [lint] view function `private_view_mutates` performs global state mutations (via `borrow_global_mut`, `move_to`, or `move_from`), either directly or through a callee. These mutations are silently discarded when called via the view API, but applied when called from Move code. This inconsistency can lead to unexpected behavior, reconsider the implementation.
    ┌─ tests/model_ast_lints/mutable_view_function.move:54:9
    │
-54 │     fun private_view_mutates(): u64 acquires State {
+54 │     fun private_view_mutates(): u64 {
    │         ^^^^^^^^^^^^^^^^^^^^
    │
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(mutable_view_function)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#mutable_view_function.
 
-warning: [lint] view function `unsafe_view_recursive` should not modify state, but this function (or one of its callees) calls a state-mutating operation (`borrow_global_mut`, `move_to`, or `move_from`).
+warning: [lint] view function `unsafe_view_recursive` performs global state mutations (via `borrow_global_mut`, `move_to`, or `move_from`), either directly or through a callee. These mutations are silently discarded when called via the view API, but applied when called from Move code. This inconsistency can lead to unexpected behavior, reconsider the implementation.
    ┌─ tests/model_ast_lints/mutable_view_function.move:76:16
    │
-76 │     public fun unsafe_view_recursive(): u64 acquires State {
+76 │     public fun unsafe_view_recursive(): u64 {
    │                ^^^^^^^^^^^^^^^^^^^^^
    │
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(mutable_view_function)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#mutable_view_function.
 
-warning: [lint] view function `unsafe_view_mutual_recursive` should not modify state, but this function (or one of its callees) calls a state-mutating operation (`borrow_global_mut`, `move_to`, or `move_from`).
+warning: [lint] view function `unsafe_view_mutual_recursive` performs global state mutations (via `borrow_global_mut`, `move_to`, or `move_from`), either directly or through a callee. These mutations are silently discarded when called via the view API, but applied when called from Move code. This inconsistency can lead to unexpected behavior, reconsider the implementation.
     ┌─ tests/model_ast_lints/mutable_view_function.move:110:16
     │
-110 │     public fun unsafe_view_mutual_recursive(): u64 acquires State {
+110 │     public fun unsafe_view_mutual_recursive(): u64 {
     │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(mutable_view_function)]`.
     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#mutable_view_function.
 
-warning: [lint] view function `first_view_reaches_x` should not modify state, but this function (or one of its callees) calls a state-mutating operation (`borrow_global_mut`, `move_to`, or `move_from`).
+warning: [lint] view function `first_view_reaches_x` performs global state mutations (via `borrow_global_mut`, `move_to`, or `move_from`), either directly or through a callee. These mutations are silently discarded when called via the view API, but applied when called from Move code. This inconsistency can lead to unexpected behavior, reconsider the implementation.
     ┌─ tests/model_ast_lints/mutable_view_function.move:130:16
     │
-130 │     public fun first_view_reaches_x(): bool acquires State {
+130 │     public fun first_view_reaches_x(): bool {
     │                ^^^^^^^^^^^^^^^^^^^^
     │
     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(mutable_view_function)]`.
     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#mutable_view_function.
 
-warning: [lint] view function `second_view_reaches_y` should not modify state, but this function (or one of its callees) calls a state-mutating operation (`borrow_global_mut`, `move_to`, or `move_from`).
+warning: [lint] view function `second_view_reaches_y` performs global state mutations (via `borrow_global_mut`, `move_to`, or `move_from`), either directly or through a callee. These mutations are silently discarded when called via the view API, but applied when called from Move code. This inconsistency can lead to unexpected behavior, reconsider the implementation.
     ┌─ tests/model_ast_lints/mutable_view_function.move:137:16
     │
-137 │     public fun second_view_reaches_y(): bool acquires State {
+137 │     public fun second_view_reaches_y(): bool {
     │                ^^^^^^^^^^^^^^^^^^^^^
     │
     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(mutable_view_function)]`.
     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#mutable_view_function.
 
-warning: [lint] view function `unsafe_view_deep_chain` should not modify state, but this function (or one of its callees) calls a state-mutating operation (`borrow_global_mut`, `move_to`, or `move_from`).
+warning: [lint] view function `unsafe_view_deep_chain` performs global state mutations (via `borrow_global_mut`, `move_to`, or `move_from`), either directly or through a callee. These mutations are silently discarded when called via the view API, but applied when called from Move code. This inconsistency can lead to unexpected behavior, reconsider the implementation.
     ┌─ tests/model_ast_lints/mutable_view_function.move:175:16
     │
-175 │     public fun unsafe_view_deep_chain(): u64 acquires State {
+175 │     public fun unsafe_view_deep_chain(): u64 {
     │                ^^^^^^^^^^^^^^^^^^^^^^
     │
     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(mutable_view_function)]`.
     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#mutable_view_function.
 
-warning: [lint] view function `unsafe_friend_view_mutates` should not modify state, but this function (or one of its callees) calls a state-mutating operation (`borrow_global_mut`, `move_to`, or `move_from`).
-    ┌─ tests/model_ast_lints/mutable_view_function.move:193:24
+warning: [lint] view function `unsafe_friend_view_mutates` performs global state mutations (via `borrow_global_mut`, `move_to`, or `move_from`), either directly or through a callee. These mutations are silently discarded when called via the view API, but applied when called from Move code. This inconsistency can lead to unexpected behavior, reconsider the implementation.
+    ┌─ tests/model_ast_lints/mutable_view_function.move:193:16
     │
-193 │     public(friend) fun unsafe_friend_view_mutates(): u64 acquires State {
-    │                        ^^^^^^^^^^^^^^^^^^^^^^^^^^
+193 │     friend fun unsafe_friend_view_mutates(): u64 {
+    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(mutable_view_function)]`.
     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#mutable_view_function.
 
-warning: [lint] view function `unsafe_package_view_mutates` should not modify state, but this function (or one of its callees) calls a state-mutating operation (`borrow_global_mut`, `move_to`, or `move_from`).
-    ┌─ tests/model_ast_lints/mutable_view_function.move:207:25
+warning: [lint] view function `unsafe_package_view_mutates` performs global state mutations (via `borrow_global_mut`, `move_to`, or `move_from`), either directly or through a callee. These mutations are silently discarded when called via the view API, but applied when called from Move code. This inconsistency can lead to unexpected behavior, reconsider the implementation.
+    ┌─ tests/model_ast_lints/mutable_view_function.move:207:17
     │
-207 │     public(package) fun unsafe_package_view_mutates(): u64 acquires State {
-    │                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+207 │     package fun unsafe_package_view_mutates(): u64 {
+    │                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(mutable_view_function)]`.
     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#mutable_view_function.

--- a/third_party/move/tools/move-linter/tests/model_ast_lints/mutable_view_function.exp
+++ b/third_party/move/tools/move-linter/tests/model_ast_lints/mutable_view_function.exp
@@ -1,0 +1,37 @@
+
+Diagnostics:
+warning: [lint] view function `unsafe_view_indirect` should not modify state, but this function (or one of its callees) calls a state-mutating operation (`borrow_global_mut`, `move_to`, or `move_from`).
+   ┌─ tests/model_ast_lints/mutable_view_function.move:13:16
+   │
+13 │     public fun unsafe_view_indirect(): u64 acquires State {
+   │                ^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(mutable_view_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#mutable_view_function.
+
+warning: [lint] view function `unsafe_view_direct_borrow` should not modify state, but this function (or one of its callees) calls a state-mutating operation (`borrow_global_mut`, `move_to`, or `move_from`).
+   ┌─ tests/model_ast_lints/mutable_view_function.move:20:16
+   │
+20 │     public fun unsafe_view_direct_borrow(): u64 acquires State {
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(mutable_view_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#mutable_view_function.
+
+warning: [lint] view function `unsafe_view_move_from` should not modify state, but this function (or one of its callees) calls a state-mutating operation (`borrow_global_mut`, `move_to`, or `move_from`).
+   ┌─ tests/model_ast_lints/mutable_view_function.move:28:16
+   │
+28 │     public fun unsafe_view_move_from(): u64 acquires State {
+   │                ^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(mutable_view_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#mutable_view_function.
+
+warning: [lint] view function `unsafe_view_move_from_indirect` should not modify state, but this function (or one of its callees) calls a state-mutating operation (`borrow_global_mut`, `move_to`, or `move_from`).
+   ┌─ tests/model_ast_lints/mutable_view_function.move:40:16
+   │
+40 │     public fun unsafe_view_move_from_indirect(): u64 acquires State {
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(mutable_view_function)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#mutable_view_function.

--- a/third_party/move/tools/move-linter/tests/model_ast_lints/mutable_view_function.exp
+++ b/third_party/move/tools/move-linter/tests/model_ast_lints/mutable_view_function.exp
@@ -63,28 +63,46 @@ warning: [lint] view function `unsafe_view_mutual_recursive` should not modify s
     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(mutable_view_function)]`.
     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#mutable_view_function.
 
-warning: [lint] view function `unsafe_view_deep_chain` should not modify state, but this function (or one of its callees) calls a state-mutating operation (`borrow_global_mut`, `move_to`, or `move_from`).
-    ┌─ tests/model_ast_lints/mutable_view_function.move:148:16
+warning: [lint] view function `first_view_reaches_x` should not modify state, but this function (or one of its callees) calls a state-mutating operation (`borrow_global_mut`, `move_to`, or `move_from`).
+    ┌─ tests/model_ast_lints/mutable_view_function.move:130:16
     │
-148 │     public fun unsafe_view_deep_chain(): u64 acquires State {
+130 │     public fun first_view_reaches_x(): bool acquires State {
+    │                ^^^^^^^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(mutable_view_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#mutable_view_function.
+
+warning: [lint] view function `second_view_reaches_y` should not modify state, but this function (or one of its callees) calls a state-mutating operation (`borrow_global_mut`, `move_to`, or `move_from`).
+    ┌─ tests/model_ast_lints/mutable_view_function.move:137:16
+    │
+137 │     public fun second_view_reaches_y(): bool acquires State {
+    │                ^^^^^^^^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(mutable_view_function)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#mutable_view_function.
+
+warning: [lint] view function `unsafe_view_deep_chain` should not modify state, but this function (or one of its callees) calls a state-mutating operation (`borrow_global_mut`, `move_to`, or `move_from`).
+    ┌─ tests/model_ast_lints/mutable_view_function.move:175:16
+    │
+175 │     public fun unsafe_view_deep_chain(): u64 acquires State {
     │                ^^^^^^^^^^^^^^^^^^^^^^
     │
     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(mutable_view_function)]`.
     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#mutable_view_function.
 
 warning: [lint] view function `unsafe_friend_view_mutates` should not modify state, but this function (or one of its callees) calls a state-mutating operation (`borrow_global_mut`, `move_to`, or `move_from`).
-    ┌─ tests/model_ast_lints/mutable_view_function.move:166:24
+    ┌─ tests/model_ast_lints/mutable_view_function.move:193:24
     │
-166 │     public(friend) fun unsafe_friend_view_mutates(): u64 acquires State {
+193 │     public(friend) fun unsafe_friend_view_mutates(): u64 acquires State {
     │                        ^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(mutable_view_function)]`.
     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#mutable_view_function.
 
 warning: [lint] view function `unsafe_package_view_mutates` should not modify state, but this function (or one of its callees) calls a state-mutating operation (`borrow_global_mut`, `move_to`, or `move_from`).
-    ┌─ tests/model_ast_lints/mutable_view_function.move:180:25
+    ┌─ tests/model_ast_lints/mutable_view_function.move:207:25
     │
-180 │     public(package) fun unsafe_package_view_mutates(): u64 acquires State {
+207 │     public(package) fun unsafe_package_view_mutates(): u64 acquires State {
     │                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(mutable_view_function)]`.

--- a/third_party/move/tools/move-linter/tests/model_ast_lints/mutable_view_function.move
+++ b/third_party/move/tools/move-linter/tests/model_ast_lints/mutable_view_function.move
@@ -1,0 +1,64 @@
+module 0x42::view_function_safety {
+    struct State has key {
+        val: u64
+    }
+
+    fun modify_state() acquires State {
+        let state = borrow_global_mut<State>(@0x42);
+        state.val = state.val + 1;
+    }
+
+    // Should warn: public view calling mutating helper
+    #[view]
+    public fun unsafe_view_indirect(): u64 acquires State {
+        modify_state();
+        1
+    }
+
+    // Should warn: public view directly using borrow_global_mut
+    #[view]
+    public fun unsafe_view_direct_borrow(): u64 acquires State {
+        let state = borrow_global_mut<State>(@0x42);
+        state.val = state.val + 1;
+        1
+    }
+
+    // Should warn: public view using move_from
+    #[view]
+    public fun unsafe_view_move_from(): u64 acquires State {
+        let State { val } = move_from<State>(@0x42);
+        val
+    }
+
+    // Should warn: public view using move_from via helper
+    fun helper_move_from(): u64 acquires State {
+        let State { val } = move_from<State>(@0x42);
+        val
+    }
+
+    #[view]
+    public fun unsafe_view_move_from_indirect(): u64 acquires State {
+        helper_move_from()
+    }
+
+    // Ok: suppressed with lint::skip
+    #[view]
+    #[lint::skip(mutable_view_function)]
+    public fun suppressed_view(): u64 acquires State {
+        modify_state();
+        1
+    }
+
+    // Ok: private view can mutate (unusual but not the check's concern)
+    #[view]
+    fun private_view_mutates(): u64 acquires State {
+        modify_state();
+        1
+    }
+
+    // Ok: public view that only reads
+    #[view]
+    public fun safe_pure_view(): u64 acquires State {
+        borrow_global<State>(@0x42).val
+    }
+}

--- a/third_party/move/tools/move-linter/tests/model_ast_lints/mutable_view_function.move
+++ b/third_party/move/tools/move-linter/tests/model_ast_lints/mutable_view_function.move
@@ -3,21 +3,21 @@ module 0x42::view_function_safety {
         val: u64
     }
 
-    fun modify_state() acquires State {
+    fun modify_state() {
         let state = borrow_global_mut<State>(@0x42);
         state.val = state.val + 1;
     }
 
     // Should warn: public view calling mutating helper
     #[view]
-    public fun unsafe_view_indirect(): u64 acquires State {
+    public fun unsafe_view_indirect(): u64 {
         modify_state();
         1
     }
 
     // Should warn: public view directly using borrow_global_mut
     #[view]
-    public fun unsafe_view_direct_borrow(): u64 acquires State {
+    public fun unsafe_view_direct_borrow(): u64 {
         let state = borrow_global_mut<State>(@0x42);
         state.val = state.val + 1;
         1
@@ -25,45 +25,45 @@ module 0x42::view_function_safety {
 
     // Should warn: public view using move_from
     #[view]
-    public fun unsafe_view_move_from(): u64 acquires State {
+    public fun unsafe_view_move_from(): u64 {
         let State { val } = move_from<State>(@0x42);
         val
     }
 
     // Should warn: public view using move_from via helper
-    fun helper_move_from(): u64 acquires State {
+    fun helper_move_from(): u64 {
         let State { val } = move_from<State>(@0x42);
         val
     }
 
     #[view]
-    public fun unsafe_view_move_from_indirect(): u64 acquires State {
+    public fun unsafe_view_move_from_indirect(): u64 {
         helper_move_from()
     }
 
     // Ok: suppressed with lint::skip
     #[view]
     #[lint::skip(mutable_view_function)]
-    public fun suppressed_view(): u64 acquires State {
+    public fun suppressed_view(): u64 {
         modify_state();
         1
     }
 
     // Should warn: private view that mutates state
     #[view]
-    fun private_view_mutates(): u64 acquires State {
+    fun private_view_mutates(): u64 {
         modify_state();
         1
     }
 
     // Ok: public view that only reads
     #[view]
-    public fun safe_pure_view(): u64 acquires State {
+    public fun safe_pure_view(): u64 {
         borrow_global<State>(@0x42).val
     }
 
     // Should warn: recursive function that modifies state, called by view
-    fun recursive_mutating(n: u64) acquires State {
+    fun recursive_mutating(n: u64) {
         if (n == 0) {
             let state = borrow_global_mut<State>(@0x42);
             state.val = state.val + 1;
@@ -73,7 +73,7 @@ module 0x42::view_function_safety {
     }
 
     #[view]
-    public fun unsafe_view_recursive(): u64 acquires State {
+    public fun unsafe_view_recursive(): u64 {
         recursive_mutating(5);
         1
     }
@@ -93,7 +93,7 @@ module 0x42::view_function_safety {
     }
 
     // Should warn: mutually recursive functions that modify state, called by view
-    fun mutual_a(n: u64) acquires State {
+    fun mutual_a(n: u64) {
         if (n == 0) {
             let state = borrow_global_mut<State>(@0x42);
             state.val = state.val + 1;
@@ -102,39 +102,39 @@ module 0x42::view_function_safety {
         }
     }
 
-    fun mutual_b(n: u64) acquires State {
+    fun mutual_b(n: u64) {
         mutual_a(n);
     }
 
     #[view]
-    public fun unsafe_view_mutual_recursive(): u64 acquires State {
+    public fun unsafe_view_mutual_recursive(): u64 {
         mutual_a(3);
         1
     }
 
-    fun z_mutates() acquires State {
+    fun z_mutates() {
         let state = borrow_global_mut<State>(@0x42);
         state.val = state.val + 1;
     }
 
-    fun cycle_x() acquires State {
+    fun cycle_x() {
         cycle_y();
         z_mutates();
     }
 
-    fun cycle_y() acquires State {
+    fun cycle_y() {
         cycle_x();
     }
 
     #[view]
-    public fun first_view_reaches_x(): bool acquires State {
+    public fun first_view_reaches_x(): bool {
         cycle_x();
         true
     }
 
     // Should warn: y transitively mutates via x -> z_mutates
     #[view]
-    public fun second_view_reaches_y(): bool acquires State {
+    public fun second_view_reaches_y(): bool {
         cycle_y();
         true
     }
@@ -158,21 +158,21 @@ module 0x42::view_function_safety {
     }
 
     // Should warn: deep transitive chain (view -> f -> g -> mutate)
-    fun deep_level_3() acquires State {
+    fun deep_level_3() {
         let state = borrow_global_mut<State>(@0x42);
         state.val = state.val + 1;
     }
 
-    fun deep_level_2() acquires State {
+    fun deep_level_2() {
         deep_level_3();
     }
 
-    fun deep_level_1() acquires State {
+    fun deep_level_1() {
         deep_level_2();
     }
 
     #[view]
-    public fun unsafe_view_deep_chain(): u64 acquires State {
+    public fun unsafe_view_deep_chain(): u64 {
         deep_level_1();
         1
     }
@@ -190,7 +190,7 @@ module 0x42::view_friend_visibility {
 
     // Should warn: friend view that mutates state
     #[view]
-    public(friend) fun unsafe_friend_view_mutates(): u64 acquires State {
+    friend fun unsafe_friend_view_mutates(): u64 {
         let state = borrow_global_mut<State>(@0x42);
         state.val = state.val + 1;
         1
@@ -204,7 +204,7 @@ module 0x42::view_package_visibility {
 
     // Should warn: package view that mutates state
     #[view]
-    public(package) fun unsafe_package_view_mutates(): u64 acquires State {
+    package fun unsafe_package_view_mutates(): u64 {
         let state = borrow_global_mut<State>(@0x42);
         state.val = state.val + 1;
         1

--- a/third_party/move/tools/move-linter/tests/model_ast_lints/mutable_view_function.move
+++ b/third_party/move/tools/move-linter/tests/model_ast_lints/mutable_view_function.move
@@ -49,7 +49,7 @@ module 0x42::view_function_safety {
         1
     }
 
-    // Ok: private view can mutate (unusual but not the check's concern)
+    // Should warn: private view that mutates state
     #[view]
     fun private_view_mutates(): u64 acquires State {
         modify_state();
@@ -60,5 +60,126 @@ module 0x42::view_function_safety {
     #[view]
     public fun safe_pure_view(): u64 acquires State {
         borrow_global<State>(@0x42).val
+    }
+
+    // Should warn: recursive function that modifies state, called by view
+    fun recursive_mutating(n: u64) acquires State {
+        if (n == 0) {
+            let state = borrow_global_mut<State>(@0x42);
+            state.val = state.val + 1;
+        } else {
+            recursive_mutating(n - 1);
+        }
+    }
+
+    #[view]
+    public fun unsafe_view_recursive(): u64 acquires State {
+        recursive_mutating(5);
+        1
+    }
+
+    // Ok: recursive function that does NOT modify state, called by view
+    fun recursive_pure(n: u64): u64 {
+        if (n == 0) {
+            0
+        } else {
+            recursive_pure(n - 1) + 1
+        }
+    }
+
+    #[view]
+    public fun safe_view_recursive(): u64 {
+        recursive_pure(5)
+    }
+
+    // Should warn: mutually recursive functions that modify state, called by view
+    fun mutual_a(n: u64) acquires State {
+        if (n == 0) {
+            let state = borrow_global_mut<State>(@0x42);
+            state.val = state.val + 1;
+        } else {
+            mutual_b(n - 1);
+        }
+    }
+
+    fun mutual_b(n: u64) acquires State {
+        mutual_a(n);
+    }
+
+    #[view]
+    public fun unsafe_view_mutual_recursive(): u64 acquires State {
+        mutual_a(3);
+        1
+    }
+
+    // Ok: mutually recursive functions that do NOT modify state, called by view
+    fun mutual_pure_a(n: u64): u64 {
+        if (n == 0) {
+            0
+        } else {
+            mutual_pure_b(n - 1)
+        }
+    }
+
+    fun mutual_pure_b(n: u64): u64 {
+        mutual_pure_a(n) + 1
+    }
+
+    #[view]
+    public fun safe_view_mutual_recursive(): u64 {
+        mutual_pure_a(3)
+    }
+
+    // Should warn: deep transitive chain (view -> f -> g -> mutate)
+    fun deep_level_3() acquires State {
+        let state = borrow_global_mut<State>(@0x42);
+        state.val = state.val + 1;
+    }
+
+    fun deep_level_2() acquires State {
+        deep_level_3();
+    }
+
+    fun deep_level_1() acquires State {
+        deep_level_2();
+    }
+
+    #[view]
+    public fun unsafe_view_deep_chain(): u64 acquires State {
+        deep_level_1();
+        1
+    }
+
+}
+
+module 0x42::friend_caller {}
+
+module 0x42::view_friend_visibility {
+    friend 0x42::friend_caller;
+
+    struct State has key {
+        val: u64
+    }
+
+    // Should warn: friend view that mutates state
+    #[view]
+    public(friend) fun unsafe_friend_view_mutates(): u64 acquires State {
+        let state = borrow_global_mut<State>(@0x42);
+        state.val = state.val + 1;
+        1
+    }
+}
+
+module 0x42::view_package_visibility {
+    struct State has key {
+        val: u64
+    }
+
+    // Should warn: package view that mutates state
+    #[view]
+    public(package) fun unsafe_package_view_mutates(): u64 acquires State {
+        let state = borrow_global_mut<State>(@0x42);
+        state.val = state.val + 1;
+        1
     }
 }

--- a/third_party/move/tools/move-linter/tests/model_ast_lints/mutable_view_function.move
+++ b/third_party/move/tools/move-linter/tests/model_ast_lints/mutable_view_function.move
@@ -112,6 +112,33 @@ module 0x42::view_function_safety {
         1
     }
 
+    fun z_mutates() acquires State {
+        let state = borrow_global_mut<State>(@0x42);
+        state.val = state.val + 1;
+    }
+
+    fun cycle_x() acquires State {
+        cycle_y();
+        z_mutates();
+    }
+
+    fun cycle_y() acquires State {
+        cycle_x();
+    }
+
+    #[view]
+    public fun first_view_reaches_x(): bool acquires State {
+        cycle_x();
+        true
+    }
+
+    // Should warn: y transitively mutates via x -> z_mutates
+    #[view]
+    public fun second_view_reaches_y(): bool acquires State {
+        cycle_y();
+        true
+    }
+
     // Ok: mutually recursive functions that do NOT modify state, called by view
     fun mutual_pure_a(n: u64): u64 {
         if (n == 0) {

--- a/third_party/move/tools/move-linter/tests/model_ast_lints/unsafe_friend_package_entry.exp
+++ b/third_party/move/tools/move-linter/tests/model_ast_lints/unsafe_friend_package_entry.exp
@@ -1,6 +1,6 @@
 
 Diagnostics:
-warning: [lint] `unsafe_friend_entry` is callable by anyone. The `entry` modifier allows direct invocation via transactions, bypassing the friend visibility restriction.
+warning: [lint] `unsafe_friend_entry` is callable by anyone. The `entry` modifier allows direct invocation via transactions, bypassing the `friend` visibility restriction.
   ┌─ tests/model_ast_lints/unsafe_friend_package_entry.move:8:30
   │
 8 │     public(friend) entry fun unsafe_friend_entry() {}
@@ -9,7 +9,7 @@ warning: [lint] `unsafe_friend_entry` is callable by anyone. The `entry` modifie
   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unsafe_friend_package_entry)]`.
   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#unsafe_friend_package_entry.
 
-warning: [lint] `unsafe_package_entry` is callable by anyone. The `entry` modifier allows direct invocation via transactions, bypassing the package visibility restriction.
+warning: [lint] `unsafe_package_entry` is callable by anyone. The `entry` modifier allows direct invocation via transactions, bypassing the `package` visibility restriction.
    ┌─ tests/model_ast_lints/unsafe_friend_package_entry.move:28:31
    │
 28 │     public(package) entry fun unsafe_package_entry() {}

--- a/third_party/move/tools/move-linter/tests/model_ast_lints/unsafe_friend_package_entry.exp
+++ b/third_party/move/tools/move-linter/tests/model_ast_lints/unsafe_friend_package_entry.exp
@@ -1,19 +1,19 @@
 
 Diagnostics:
 warning: [lint] `unsafe_friend_entry` is callable by anyone. The `entry` modifier allows direct invocation via transactions, bypassing the `friend` visibility restriction.
-  ┌─ tests/model_ast_lints/unsafe_friend_package_entry.move:8:30
+  ┌─ tests/model_ast_lints/unsafe_friend_package_entry.move:8:22
   │
-8 │     public(friend) entry fun unsafe_friend_entry() {}
-  │                              ^^^^^^^^^^^^^^^^^^^
+8 │     friend entry fun unsafe_friend_entry() {}
+  │                      ^^^^^^^^^^^^^^^^^^^
   │
   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unsafe_friend_package_entry)]`.
   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#unsafe_friend_package_entry.
 
 warning: [lint] `unsafe_package_entry` is callable by anyone. The `entry` modifier allows direct invocation via transactions, bypassing the `package` visibility restriction.
-   ┌─ tests/model_ast_lints/unsafe_friend_package_entry.move:28:31
+   ┌─ tests/model_ast_lints/unsafe_friend_package_entry.move:28:23
    │
-28 │     public(package) entry fun unsafe_package_entry() {}
-   │                               ^^^^^^^^^^^^^^^^^^^^
+28 │     package entry fun unsafe_package_entry() {}
+   │                       ^^^^^^^^^^^^^^^^^^^^
    │
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unsafe_friend_package_entry)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#unsafe_friend_package_entry.

--- a/third_party/move/tools/move-linter/tests/model_ast_lints/unsafe_friend_package_entry.exp
+++ b/third_party/move/tools/move-linter/tests/model_ast_lints/unsafe_friend_package_entry.exp
@@ -1,0 +1,19 @@
+
+Diagnostics:
+warning: [lint] `unsafe_friend_entry` is callable by anyone. The `entry` modifier allows direct invocation via transactions, bypassing the friend visibility restriction.
+  ┌─ tests/model_ast_lints/unsafe_friend_package_entry.move:8:30
+  │
+8 │     public(friend) entry fun unsafe_friend_entry() {}
+  │                              ^^^^^^^^^^^^^^^^^^^
+  │
+  = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unsafe_friend_package_entry)]`.
+  = For more information, see https://aptos.dev/en/build/smart-contracts/linter#unsafe_friend_package_entry.
+
+warning: [lint] `unsafe_package_entry` is callable by anyone. The `entry` modifier allows direct invocation via transactions, bypassing the package visibility restriction.
+   ┌─ tests/model_ast_lints/unsafe_friend_package_entry.move:28:31
+   │
+28 │     public(package) entry fun unsafe_package_entry() {}
+   │                               ^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unsafe_friend_package_entry)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#unsafe_friend_package_entry.

--- a/third_party/move/tools/move-linter/tests/model_ast_lints/unsafe_friend_package_entry.move
+++ b/third_party/move/tools/move-linter/tests/model_ast_lints/unsafe_friend_package_entry.move
@@ -1,15 +1,15 @@
 module 0x42::friend_caller {}
 
-// Test public(friend) entry functions
+// Test friend entry functions
 module 0x42::entry_points_friend {
     friend 0x42::friend_caller;
 
-    // Should warn: public(friend) entry is callable by anyone
-    public(friend) entry fun unsafe_friend_entry() {}
+    // Should warn: friend entry is callable by anyone
+    friend entry fun unsafe_friend_entry() {}
 
     // Ok: suppressed with lint::skip
     #[lint::skip(unsafe_friend_package_entry)]
-    public(friend) entry fun suppressed_friend_entry() {}
+    friend entry fun suppressed_friend_entry() {}
 
     // Ok: private entry function
     entry fun private_entry() {}
@@ -19,19 +19,19 @@ module 0x42::entry_points_friend {
 
     // Ok: non-entry friend function (restriction is real)
     #[lint::skip(unused_function)]
-    public(friend) fun friend_non_entry() {}
+    friend fun friend_non_entry() {}
 }
 
-// Test public(package) entry functions
+// Test package entry functions
 module 0x42::entry_points_package {
-    // Should warn: public(package) entry is callable by anyone
-    public(package) entry fun unsafe_package_entry() {}
+    // Should warn: package entry is callable by anyone
+    package entry fun unsafe_package_entry() {}
 
     // Ok: suppressed with lint::skip
     #[lint::skip(unsafe_friend_package_entry)]
-    public(package) entry fun suppressed_package_entry() {}
+    package entry fun suppressed_package_entry() {}
 
     // Ok: non-entry package function (restriction is real)
     #[lint::skip(unused_function)]
-    public(package) fun package_non_entry() {}
+    package fun package_non_entry() {}
 }

--- a/third_party/move/tools/move-linter/tests/model_ast_lints/unsafe_friend_package_entry.move
+++ b/third_party/move/tools/move-linter/tests/model_ast_lints/unsafe_friend_package_entry.move
@@ -1,0 +1,37 @@
+module 0x42::friend_caller {}
+
+// Test public(friend) entry functions
+module 0x42::entry_points_friend {
+    friend 0x42::friend_caller;
+
+    // Should warn: public(friend) entry is callable by anyone
+    public(friend) entry fun unsafe_friend_entry() {}
+
+    // Ok: suppressed with lint::skip
+    #[lint::skip(unsafe_friend_package_entry)]
+    public(friend) entry fun suppressed_friend_entry() {}
+
+    // Ok: private entry function
+    entry fun private_entry() {}
+
+    // Ok: public entry function (fully public, no misleading restriction)
+    public entry fun public_entry() {}
+
+    // Ok: non-entry friend function (restriction is real)
+    #[lint::skip(unused_function)]
+    public(friend) fun friend_non_entry() {}
+}
+
+// Test public(package) entry functions
+module 0x42::entry_points_package {
+    // Should warn: public(package) entry is callable by anyone
+    public(package) entry fun unsafe_package_entry() {}
+
+    // Ok: suppressed with lint::skip
+    #[lint::skip(unsafe_friend_package_entry)]
+    public(package) entry fun suppressed_package_entry() {}
+
+    // Ok: non-entry package function (restriction is real)
+    #[lint::skip(unused_function)]
+    public(package) fun package_non_entry() {}
+}


### PR DESCRIPTION
## Description
New compiler checks now issue a warning in the following cases:
- `public(friend) entry` or `public(package) entry`
- Mutable public view functions

Porting of #18281 into linter checks

## How Has This Been Tested?

## Key Areas to Review
1. aptos-transactional-test-harness
2. aptos-framework
3. local move code 

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [x] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [x] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

## New Linter Stats


| Lint                          | Package           | Warnings |
|-------------------------------|-------------------|----------|
| `unsafe_friend_package_entry` | `aptos-framework` | 1        |
| `mutable_view_function`       | `aptos-framework` | 6        |

All other packages do not generate any warnings.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low runtime risk since this only adds linter warnings, but it may surface new findings and require code changes/suppressions in existing Move packages.
> 
> **Overview**
> Adds two new default function lints to the Move linter pipeline: `mutable_view_function` warns on `#[view]` functions that directly or transitively call global state-mutating ops (`borrow_global_mut`, `move_to`, `move_from`), including through recursion/cycles; `unsafe_friend_package_entry` warns when a `friend`/`package`-scoped function is also marked `entry` (since `entry` makes it transaction-callable by anyone).
> 
> Includes new Move test fixtures and expected diagnostics validating both lints and demonstrating `#[lint::skip(...)]` suppression behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b56139a49a981ab5d32200702d130865124e6889. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->