### PR TITLE
[vm] Size par_exec thread pool to concurrency_level instead of num_cpus

### DIFF
--- a/aptos-move/aptos-vm/src/block_executor/mod.rs
+++ b/aptos-move/aptos-vm/src/block_executor/mod.rs
@@ -19,6 +19,7 @@ use aptos_block_executor::{
     txn_provider::TxnProvider,
     types::InputOutputKey,
 };
+use aptos_logger::info;
 use aptos_types::{
     block_executor::{
         config::BlockExecutorConfig, transaction_slice_metadata::TransactionSliceMetadata,
@@ -45,24 +46,23 @@ use move_core_types::{
 };
 use move_vm_runtime::execution_tracing::Trace;
 use move_vm_types::delayed_values::delayed_field_id::DelayedFieldID;
-use once_cell::sync::{Lazy, OnceCell};
+use once_cell::sync::OnceCell;
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
     marker::PhantomData,
-    sync::Arc,
+    sync::{Arc, Mutex},
 };
 use triomphe::Arc as TriompheArc;
 use vm_wrapper::AptosExecutorTask;
 
-static RAYON_EXEC_POOL: Lazy<Arc<rayon::ThreadPool>> = Lazy::new(|| {
-    Arc::new(
-        rayon::ThreadPoolBuilder::new()
-            .num_threads(num_cpus::get())
-            .thread_name(|index| format!("par_exec-{}", index))
-            .build()
-            .unwrap(),
-    )
-});
+/// Thread pool used by `execute_block` for parallel transaction execution.
+///
+/// Stores `(pool, num_threads)` so we can detect when the requested concurrency level
+/// changes and recreate the pool. In production the concurrency level is set once at
+/// startup, so the pool is created once and the mutex is uncontended thereafter.
+/// Benchmarking and debugging tools may iterate over multiple concurrency levels in the
+/// same process, which requires replacing the pool.
+static RAYON_EXEC_POOL: Mutex<Option<(Arc<rayon::ThreadPool>, usize)>> = Mutex::new(None);
 
 /// Output type wrapper used by block executor. VM output is stored first, then
 /// transformed into TransactionOutput type that is returned.
@@ -598,8 +598,24 @@ impl<
         transaction_slice_metadata: TransactionSliceMetadata,
         transaction_commit_listener: Option<L>,
     ) -> Result<BlockOutput<SignatureVerifiedTransaction, TransactionOutput>, VMStatus> {
+        let num_threads = std::cmp::min(config.local.concurrency_level, num_cpus::get());
+        let pool = match &mut *RAYON_EXEC_POOL.lock().unwrap() {
+            Some((pool, n)) if *n == num_threads => Arc::clone(pool),
+            slot => {
+                info!(num_threads = num_threads, "Creating par_exec thread pool");
+                let pool = Arc::new(
+                    rayon::ThreadPoolBuilder::new()
+                        .num_threads(num_threads)
+                        .thread_name(|index| format!("par_exec-{}", index))
+                        .build()
+                        .unwrap(),
+                );
+                *slot = Some((Arc::clone(&pool), num_threads));
+                pool
+            },
+        };
         Self::execute_block_on_thread_pool::<S, L, TP>(
-            Arc::clone(&RAYON_EXEC_POOL),
+            pool,
             signature_verified_block,
             state_view,
             module_cache_manager,


### PR DESCRIPTION

Profiling from both decibel benchmark and production nodes shows significant CPU
overhead from rayon's work-stealing scheduler on the `par_exec` thread pool.
When the pool is sized to `num_cpus` (48+ on production machines) but only
`concurrency_level` threads (typically 16) are doing real work, the idle threads
spin on work-stealing deque operations, causing cacheline bouncing and cache
pollution across all cores. This contention scales with the number of excess
threads and disproportionately affects tail latency.

The block-STM executor's workload is a poor fit for work-stealing: it spawns N
workers for each block and waits for all of them to finish — there is no
imbalanced work to redistribute. The ideal solution would be replacing rayon
with plain `std::thread::spawn` + join, eliminating the work-stealing
infrastructure entirely. For now, we take the simpler approach of right-sizing
the rayon pool to `concurrency_level` threads, which removes the idle-thread
contention while keeping the code change minimal. We can revisit switching to
bare threads later if warranted.

This commit only addresses the `par_exec` pool (`RAYON_EXEC_POOL`). Other rayon
pools in the codebase may have the same issue and will be handled separately.

The pool is changed from a `Lazy` static (eagerly sized to `num_cpus`) to a
`OnceCell` initialized on first use with `min(concurrency_level, num_cpus)`
threads. This is safe because `concurrency_level` is derived from the
process-global `EXECUTION_CONCURRENCY_LEVEL` `OnceCell`, which is set once at
node startup and never changes.

Decibel benchmark results (on a 48-core machine, 10 runs per config at conc
8/16, 5 runs at conc 32):

**Overall TPS:**

| Concurrency | Baseline TPS | This Commit | Δ%     |
|-------------|-------------|-------------|--------|
| 8           | 1687.7      | 1688.2      | +0.03% |
| 16          | 1682.3      | 1734.9      | +3.1%  |
| 32          | 1190.9      | 1307.3      | +9.8%  |

At conc 16 the improvement is statistically significant (t=5.78, p<0.001) with
notably more stable results (CV 0.4% vs 1.6%).

**P99 block execution latency:**

| Concurrency | Baseline | This Commit | Δ%     |
|-------------|----------|-------------|--------|
| 8           | 120 ms   | 118 ms      | −1.7%  |
| 16          | 166 ms   | 131 ms      | −21.1% |
| 32          | 370 ms   | 214 ms      | −42.3% |

The deeper into the tail, the larger the improvement — consistent with
intermittent cache thrashing from speculative work-stealing. At conc 32, blocks
`>300 ms` drop from 1.4% to 0.3%, and the worst-case block latency drops from
2963ms to 914ms.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: changes global thread-pool initialization/reuse and adds a mutex + dynamic pool recreation, which could affect performance or introduce contention/panics if mis-sized, but does not touch transaction semantics.
> 
> **Overview**
> Sizes the `par_exec` Rayon thread pool used by `execute_block` to `min(concurrency_level, num_cpus)` instead of always `num_cpus`, reducing idle work-stealing overhead.
> 
> Replaces the previous static `Lazy` pool with a mutex-protected cache that *reuses* the pool when the requested thread count is unchanged and *recreates* it when concurrency changes (logging pool creation via `info!`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 831dd08178dfee3f0c23dd2af402e906ac63ec18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->