### PR TITLE
[Smoke Test] Small fixes to prevent sporadic race conditions

### DIFF
--- a/testsuite/smoke-test/src/state_sync_utils.rs
+++ b/testsuite/smoke-test/src/state_sync_utils.rs
@@ -202,6 +202,9 @@ fn verify_first_ledger_info(node: &mut LocalNode) {
     let aptos_db = AptosDB::new_for_test_with_sharding(db_path_buf.as_path(), 1 << 13);
     aptos_db.get_epoch_ending_ledger_info(0).unwrap();
 
+    // Drop the DB handle before restarting the node to release the rocks DB lock file
+    drop(aptos_db);
+
     // Restart the node
     node.start().unwrap();
 }

--- a/testsuite/smoke-test/src/utils.rs
+++ b/testsuite/smoke-test/src/utils.rs
@@ -119,14 +119,12 @@ pub async fn execute_transactions(
     }
 
     // Always ensure that at least one reconfiguration transaction is executed
-    if !execute_epoch_changes {
-        aptos_forge::reconfig(
-            client,
-            &transaction_factory,
-            swarm.chain_info().root_account,
-        )
-        .await;
-    }
+    aptos_forge::reconfig(
+        client,
+        &transaction_factory,
+        swarm.chain_info().root_account,
+    )
+    .await;
 }
 
 /// Executes transactions and waits for all nodes to catch up


### PR DESCRIPTION
## Description
This PR offers two small fixes to the smoke tests to prevent sporadic race conditions.

## Testing Plan
Existing test infrastructure.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes are limited to smoke-test utilities; they mainly adjust test sequencing to avoid RocksDB lock contention and ensure a deterministic reconfiguration transaction occurs.
> 
> **Overview**
> Prevents sporadic smoke-test flakiness by explicitly `drop`ping the `AptosDB` handle before restarting a node in `verify_first_ledger_info`, avoiding RocksDB lockfile contention.
> 
> Makes `execute_transactions` always run an explicit `aptos_forge::reconfig` after transfers (regardless of `execute_epoch_changes`) to ensure a deterministic reconfiguration transaction is always included in test flows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52e6e89faa87eb7cd62ae8ac32fd345e223b75b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->