### PR TITLE
[consensus] Fix rand manager deadlock in multi-block batches

### DIFF
--- a/consensus/consensus-types/src/pipelined_block.rs
+++ b/consensus/consensus-types/src/pipelined_block.rs
@@ -368,8 +368,19 @@ impl PipelinedBlock {
         }
     }
 
+    /// Stores the randomness on the block and eagerly sends it via the pipeline channel
+    /// to unblock the execution phase as early as possible. Without this, later blocks
+    /// in the same ordering batch deadlock: their has_rand_txns_fut waits for earlier
+    /// blocks' execute_fut, which waits for rand_rx. The execution_schedule_phase also
+    /// sends via this channel as a fallback (using take(), so only one send actually occurs).
     pub fn set_randomness(&self, randomness: Randomness) {
-        assert!(self.randomness.set(randomness.clone()).is_ok());
+        assert!(self.randomness.set(randomness).is_ok());
+        if let Some(tx) = self.pipeline_tx().lock().as_mut() {
+            let _ = tx
+                .rand_tx
+                .take()
+                .map(|tx| tx.send(self.randomness().cloned()));
+        }
     }
 
     /// Stores the decryption key on the block and eagerly sends it via the pipeline channel

--- a/consensus/src/rand/rand_gen/block_queue.rs
+++ b/consensus/src/rand/rand_gen/block_queue.rs
@@ -161,8 +161,10 @@ mod tests {
         block_queue::{BlockQueue, QueueItem},
         test_utils::create_ordered_blocks,
     };
+    use aptos_consensus_types::pipelined_block::PipelineInputTx;
     use aptos_types::randomness::Randomness;
     use std::collections::HashSet;
+    use tokio::sync::oneshot;
 
     #[test]
     fn test_queue_item() {
@@ -230,5 +232,53 @@ mod tests {
         assert_eq!(queue.dequeue_rand_ready_prefix().len(), 2);
 
         assert_eq!(queue.queue.len(), 1);
+    }
+
+    /// Test that set_randomness immediately sends rand_tx to unblock the pipeline.
+    /// Without this, multi-block batches deadlock: later blocks' has_rand_txns_fut
+    /// waits for earlier blocks' execute_fut, which waits for rand_rx, which is
+    /// normally only sent after the entire batch is dequeued.
+    #[test]
+    fn test_set_randomness_sends_rand_tx_immediately() {
+        let ordered_blocks = create_ordered_blocks(vec![1, 2]);
+        let mut rand_rxs = vec![];
+
+        // Wire up pipeline_tx with rand_tx/rand_rx for each block
+        for block in &ordered_blocks.ordered_blocks {
+            let (rand_tx, rand_rx) = oneshot::channel();
+            block.set_pipeline_tx(PipelineInputTx {
+                qc_tx: None,
+                rand_tx: Some(rand_tx),
+                order_vote_tx: None,
+                ordered_blocks_and_proof_fut: None,
+                commit_proof_tx: None,
+                secret_shared_key_tx: None,
+            });
+            rand_rxs.push(rand_rx);
+        }
+
+        let mut item = QueueItem::new(ordered_blocks, None);
+
+        // Set randomness on block 1 — rand_rx should fire immediately
+        assert!(item.set_randomness(1, Randomness::default()));
+        let result = rand_rxs[0].try_recv();
+        assert!(
+            result.is_ok(),
+            "rand_tx for block 1 should be sent immediately on set_randomness"
+        );
+
+        // Block 2 rand_rx should NOT have fired yet
+        assert!(
+            rand_rxs[1].try_recv().is_err(),
+            "rand_tx for block 2 should not be sent yet"
+        );
+
+        // Set randomness on block 2
+        assert!(item.set_randomness(2, Randomness::default()));
+        let result = rand_rxs[1].try_recv();
+        assert!(
+            result.is_ok(),
+            "rand_tx for block 2 should be sent immediately on set_randomness"
+        );
     }
 }


### PR DESCRIPTION
## Summary

PR #18699 introduced deferred randomness aggregation where the rand_manager's aggregation/skip decision awaits `has_rand_txns_fut` from the pipeline. This creates a **circular dependency** for multi-block ordering batches:

```
B2's has_rand_txns_fut
  → B1's execute_fut (parent)
    → B1's wait_for_rand → rand_rx[B1]
      → execution_schedule_phase (sends rand_tx)
        → batch dequeued from rand_manager
          → ALL blocks' randomness decided (including B2)
            → B2's has_rand_txns_fut (CYCLE)
```

Later blocks' `has_rand_txns_fut` waits for earlier blocks' `execute_fut`, which waits for `rand_rx`, which is only sent in `execution_schedule_phase` after the **entire batch** is dequeued from the rand_manager — but dequeue requires all blocks' randomness to be decided first.

**Fix:** Send `rand_tx` immediately when randomness is decided per-block in `QueueItem::set_randomness`, rather than waiting for the batch to flow through `execution_schedule_phase`. The schedule phase already handles this idempotently via `.take()` (returns `None` if already consumed).

## Test plan

- [x] `cargo check -p aptos-consensus` — compiles cleanly
- [x] `cargo test -p aptos-consensus -- block_queue` — 8 tests pass
- [x] `cargo test -p aptos-consensus -- rand_store` — 8 tests pass
- [ ] Forge smoke test with randomness enabled and multi-block batches

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches consensus pipeline synchronization by changing when `rand_tx` is fired, which can affect execution scheduling/order and is sensitive to races despite being a small, targeted change.
> 
> **Overview**
> Prevents a deadlock in multi-block ordering batches by making `PipelinedBlock::set_randomness` **immediately** forward the decided randomness via the block’s `pipeline_tx.rand_tx` (using `.take()` for idempotence) instead of waiting for later scheduling.
> 
> Adds a regression test in `rand_gen/block_queue.rs` that wires `rand_tx/rand_rx` for two blocks and asserts `rand_rx` is triggered as soon as each block’s randomness is set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 610dad57084d130530610866b93e385d72252485. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->