### PR TITLE
[compiler-v2] Fixing multiple bugs that were a result of not handling `SelectVariants` in different places in the compiler

### DIFF
--- a/third_party/move/move-compiler-v2/src/env_pipeline/ast_simplifier.rs
+++ b/third_party/move/move-compiler-v2/src/env_pipeline/ast_simplifier.rs
@@ -338,11 +338,11 @@ fn find_possibly_modified_vars(
                             _ => {},
                         }
                     },
-                    Operation::Select(..) => {
-                        // Variable appearing in Select argument may be borrowed if it occurs in
-                        // a Borrow parameter, so leave modifying state alone.  Note that other
-                        // modification contexts (e.g., MoveFrom) cannot have a `Select` in their
-                        // subexpressions.
+                    Operation::Select(..) | Operation::SelectVariants(..) => {
+                        // Variable appearing in Select/SelectVariants argument may be borrowed
+                        // if it occurs in a Borrow parameter, so leave modifying state alone.
+                        // Note that other modification contexts (e.g., MoveFrom) cannot have a
+                        // `Select`/`SelectVariants` in their subexpressions.
                     },
                     _ => {
                         // Other operations don't modify argument variables, so turn off `modifying`
@@ -712,7 +712,7 @@ impl ExpRewriterFunctions for SimplifierRewriter<'_> {
                 match op {
                     Operation::Borrow(ReferenceKind::Mutable) => IsMutableBorrow,
                     // Leave in_mut_borrow alone
-                    Operation::Select(..) => TransparentToBorrow,
+                    Operation::Select(..) | Operation::SelectVariants(..) => TransparentToBorrow,
                     // Other Call operations escape from the borrow
                     _ => NotBorrowable,
                 }
@@ -783,19 +783,8 @@ impl ExpRewriterFunctions for SimplifierRewriter<'_> {
                     // If we turned it into one, then wrap it in a `Sequence` to generate a temp value
                     // to be borrowed.
                     if rexp.is_directly_borrowable() {
-                        use ExpData::*;
-                        match rexp.as_ref() {
-                            LocalVar(id, ..)
-                            | Temporary(id, ..)
-                            | Call(id, Operation::Select(..), _) => {
-                                let cloned_id = self.env().clone_node(*id);
-                                Sequence(cloned_id, vec![rexp]).into_exp()
-                            },
-                            _ => {
-                                // Nothing to do.
-                                rexp
-                            },
-                        }
+                        let cloned_id = self.env().clone_node(rexp.node_id());
+                        ExpData::Sequence(cloned_id, vec![rexp]).into_exp()
                     } else {
                         rexp
                     }

--- a/third_party/move/move-compiler-v2/tests/checking/typing/enum_mut_borrow_through_immutable_ref.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/enum_mut_borrow_through_immutable_ref.exp
@@ -1,0 +1,7 @@
+
+Diagnostics:
+error: cannot mutably borrow from an immutable ref
+  ┌─ tests/checking/typing/enum_mut_borrow_through_immutable_ref.move:9:17
+  │
+9 │         let r = &mut imm.x;
+  │                 ^^^^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/checking/typing/enum_mut_borrow_through_immutable_ref.move
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/enum_mut_borrow_through_immutable_ref.move
@@ -1,0 +1,12 @@
+module 0x42::m {
+    enum Data has drop {
+        V { x: u64 }
+    }
+
+    fun test() {
+        let d = Data::V { x: 1 };
+        let imm = &d;
+        let r = &mut imm.x;
+        *r = 2;
+    }
+}

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/optimization/bug_19322_enum_block_mutation.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/optimization/bug_19322_enum_block_mutation.exp
@@ -1,0 +1,6 @@
+processed 3 tasks
+task 0 lines 1-23:  publish [module 0x42::m {]
+task 1 lines 25-25:  run 0x42::m::test_struct_block_mutation
+return values: 10
+task 2 lines 27-27:  run 0x42::m::test_enum_block_mutation
+return values: 10

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/optimization/bug_19322_enum_block_mutation.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/optimization/bug_19322_enum_block_mutation.move
@@ -1,0 +1,27 @@
+//# publish
+module 0x42::m {
+
+    enum MyEnum has drop, copy {
+        V { x: u64 }
+    }
+
+    struct MyStruct has drop, copy {
+        x: u64,
+    }
+
+    fun test_struct_block_mutation(): u64 {
+        let s = MyStruct { x: 10 };
+        *(&mut ({ s }).x) = 42;
+        s.x
+    }
+
+    fun test_enum_block_mutation(): u64 {
+        let e = MyEnum::V { x: 10 };
+        *(&mut ({ e }).x) = 42;
+        e.x
+    }
+}
+
+//# run 0x42::m::test_struct_block_mutation
+
+//# run 0x42::m::test_enum_block_mutation

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/optimization/bug_19322_enum_block_mutation.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/optimization/bug_19322_enum_block_mutation.move
@@ -17,7 +17,7 @@ module 0x42::m {
 
     fun test_enum_block_mutation(): u64 {
         let e = MyEnum::V { x: 10 };
-        *(&mut ({ e }).x) = 42;
+        *(&mut ({ e }).x) = 42; // modifies a temp value
         e.x
     }
 }

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/optimization/round-trip/bug_19322_enum_block_mutation.decompiled
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/optimization/round-trip/bug_19322_enum_block_mutation.decompiled
@@ -1,0 +1,32 @@
+//**** Cross-compiled for `move` syntax from `tests/optimization/bug_19322_enum_block_mutation.move`
+
+//# publish
+module 0x42::m {
+    enum MyEnum has copy, drop {
+        V {
+            x: u64,
+        }
+    }
+    struct MyStruct has copy, drop {
+        x: u64,
+    }
+    fun test_enum_block_mutation(): u64 {
+        let _v0 = MyEnum::V{x: 10};
+        let _v1 = _v0;
+        let _v2 = &mut (&mut _v1).x;
+        *_v2 = 42;
+        *&(&_v0).x
+    }
+    fun test_struct_block_mutation(): u64 {
+        let _v0 = MyStruct{x: 10};
+        let _v1 = _v0;
+        let _v2 = &mut (&mut _v1).x;
+        *_v2 = 42;
+        *&(&_v0).x
+    }
+}
+
+
+//# run 0x42::m::test_struct_block_mutation
+
+//# run 0x42::m::test_enum_block_mutation

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/optimization/round-trip/bug_19322_enum_block_mutation.decompiled.baseline.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/optimization/round-trip/bug_19322_enum_block_mutation.decompiled.baseline.exp
@@ -1,0 +1,6 @@
+processed 3 tasks
+task 0 lines 3-27:  publish [module 0x42::m {]
+task 1 lines 30-30:  run 0x42::m::test_struct_block_mutation
+return values: 10
+task 2 lines 32-32:  run 0x42::m::test_enum_block_mutation
+return values: 10

--- a/third_party/move/move-model/src/ast.rs
+++ b/third_party/move/move-model/src/ast.rs
@@ -1138,7 +1138,10 @@ impl ExpData {
         use ExpData::*;
         matches!(
             self,
-            LocalVar(..) | Temporary(..) | Call(_, Operation::Select(..), _)
+            LocalVar(..)
+                | Temporary(..)
+                | Call(_, Operation::Select(..), _)
+                | Call(_, Operation::SelectVariants(..), _)
         )
     }
 

--- a/third_party/move/move-model/src/builder/exp_builder.rs
+++ b/third_party/move/move-model/src/builder/exp_builder.rs
@@ -2404,7 +2404,11 @@ impl ExpTranslator<'_, '_, '_> {
         result_exp.visit_pre_order(&mut |e| {
             if let ExpData::Call(id, Operation::Borrow(ReferenceKind::Mutable), args) = &e {
                 debug_assert!(args.len() == 1);
-                if let ExpData::Call(_, Operation::Select(_, _, _), ref_targets) = args[0].as_ref()
+                if let ExpData::Call(
+                    _,
+                    Operation::Select(_, _, _) | Operation::SelectVariants(_, _, _),
+                    ref_targets,
+                ) = args[0].as_ref()
                 {
                     debug_assert!(ref_targets.len() == 1);
                     if self


### PR DESCRIPTION
## Description

Due to not handling `SelectVariants`:
- in AST simplifier, we had a silent mis-compilation bug when optimizations were enabled (reported by move fuzzer).
- in the exp builder, we had a mis-compilation bug that resulted in bytecode verification error (discovered while fixing this bug).

Closes #19360 and #19322.

See these issues or the added test cases for exposition of the bugs.

**note**: it is not the scope of this PR to add exhaustive matches everywhere in compiler v2. It might be worth doing that as a follow up large-scale refactoring.

## How Has This Been Tested?

- added new tests to demonstrate the bugs

## Type of Change
- [x] Bug fix

## Which Components or Systems Does This Change Impact?
- [x] Move Compiler

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core AST simplification and type-checking logic around borrow semantics; changes are targeted but could affect code generation/optimization behavior for enum field access.
> 
> **Overview**
> Fixes compiler-v2 borrow/modification tracking to treat `SelectVariants` like `Select`, including in the AST simplifier’s “possibly modified” analysis and mutable-borrow context handling, preventing enum-field accesses from being rewritten in ways that silently change mutation targets under optimizations.
> 
> Extends borrowability and validation logic to recognize `SelectVariants`, including a post-processing check that now correctly errors on `&mut` borrowing a field through an immutable reference. Adds regression tests covering the new diagnostic and an optimization/round-trip case for enum block mutation (bug #19322).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b3f81c55525c38100a2e90b794908a6dceb899e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->