### PR TITLE
[compiler-v2] Fix missing cases in ability transformer

### DIFF
--- a/third_party/move/move-compiler-v2/src/pipeline/ability_processor.rs
+++ b/third_party/move/move-compiler-v2/src/pipeline/ability_processor.rs
@@ -318,10 +318,7 @@ impl Transformer<'_> {
             },
             Branch(id, if_true, if_false, cond) => {
                 let new_cond = self.copy_arg_if_needed(code_offset, id, cond);
-                self.check_and_emit_bytecode(
-                    code_offset,
-                    Branch(id, if_true, if_false, new_cond),
-                )
+                self.check_and_emit_bytecode(code_offset, Branch(id, if_true, if_false, new_cond))
             },
             Abort(id, code, msg_opt) => {
                 let new_code = self.copy_arg_if_needed(code_offset, id, code);
@@ -330,10 +327,8 @@ impl Transformer<'_> {
             },
             // These variants either have no source temps or are handled by
             // check_and_emit_bytecode without needing copy insertion.
-            Ret(..) | Load(..) | Jump(..) | Label(..) | Nop(..)
-            | SpecBlock(..) | SaveMem(..) | SaveSpecVar(..) | Prop(..) => {
-                self.check_and_emit_bytecode(code_offset, bc.clone())
-            },
+            Ret(..) | Load(..) | Jump(..) | Label(..) | Nop(..) | SpecBlock(..) | SaveMem(..)
+            | SaveSpecVar(..) | Prop(..) => self.check_and_emit_bytecode(code_offset, bc.clone()),
         }
         // Insert/check any drops needed after this program point
         self.check_and_add_implicit_drops(code_offset, &bc, false)

--- a/third_party/move/move-compiler-v2/src/pipeline/ability_processor.rs
+++ b/third_party/move/move-compiler-v2/src/pipeline/ability_processor.rs
@@ -200,7 +200,34 @@ impl TransferFunctions for CopyDropAnalysis<'_> {
                 }
             },
             Ret(_, srcs) => state.moved.extend(srcs.iter().cloned()),
-            _ => {},
+            Branch(_, _, _, cond) => {
+                if temp_needs_copy(cond, instr) {
+                    state.needs_copy.insert(*cond);
+                } else {
+                    state.moved.insert(*cond);
+                }
+            },
+            Abort(_, code, msg_opt) => {
+                if temp_needs_copy(code, instr) {
+                    state.needs_copy.insert(*code);
+                } else {
+                    state.moved.insert(*code);
+                }
+                if let Some(msg) = msg_opt {
+                    if temp_needs_copy(msg, instr) {
+                        state.needs_copy.insert(*msg);
+                    } else {
+                        state.moved.insert(*msg);
+                    }
+                }
+            },
+            // Explicit copies/stores don't need copy inference (the Transformer always
+            // emits AssignKind::Copy for these). The remaining variants have no source
+            // temps, so no copy/move decision is needed.
+            Assign(_, _, _, AssignKind::Copy | AssignKind::Store) => {},
+            Load(..) | Jump(..) | Label(..) | Nop(..) => {},
+            // Spec-only instructions are not executed.
+            SpecBlock(..) | SaveMem(..) | SaveSpecVar(..) | Prop(..) => {},
         }
 
         // Clear information about re-assigned locals
@@ -289,7 +316,24 @@ impl Transformer<'_> {
                 let new_srcs = self.copy_args_if_needed(code_offset, id, srcs);
                 self.check_and_emit_bytecode(code_offset, Call(id, dests, op, new_srcs, ai))
             },
-            _ => self.check_and_emit_bytecode(code_offset, bc.clone()),
+            Branch(id, if_true, if_false, cond) => {
+                let new_cond = self.copy_arg_if_needed(code_offset, id, cond);
+                self.check_and_emit_bytecode(
+                    code_offset,
+                    Branch(id, if_true, if_false, new_cond),
+                )
+            },
+            Abort(id, code, msg_opt) => {
+                let new_code = self.copy_arg_if_needed(code_offset, id, code);
+                let new_msg = msg_opt.map(|m| self.copy_arg_if_needed(code_offset, id, m));
+                self.check_and_emit_bytecode(code_offset, Abort(id, new_code, new_msg))
+            },
+            // These variants either have no source temps or are handled by
+            // check_and_emit_bytecode without needing copy insertion.
+            Ret(..) | Load(..) | Jump(..) | Label(..) | Nop(..)
+            | SpecBlock(..) | SaveMem(..) | SaveSpecVar(..) | Prop(..) => {
+                self.check_and_emit_bytecode(code_offset, bc.clone())
+            },
         }
         // Insert/check any drops needed after this program point
         self.check_and_add_implicit_drops(code_offset, &bc, false)
@@ -349,6 +393,31 @@ impl Transformer<'_> {
         self.check_copy(id, src, || ("explicitly copied here".to_string(), vec![]));
     }
 
+    /// If `src` needs a copy (per the copy-drop analysis), checks copy ability and,
+    /// when the source is also borrowed, emits a physical `Assign(Copy)` to a fresh
+    /// temp — because the file-format generator cannot distinguish borrow-induced
+    /// copies from live-var ones.  Returns the (possibly new) temp to use in place of
+    /// `src`.
+    fn copy_arg_if_needed(
+        &mut self,
+        code_offset: CodeOffset,
+        id: AttrId,
+        src: TempIndex,
+    ) -> TempIndex {
+        use Bytecode::*;
+        let copy_drop_at = self.copy_drop.get(&code_offset).expect("copy drop");
+        if copy_drop_at.needs_copy.contains(&src) {
+            self.check_implicit_copy(code_offset, id, src);
+            if self.lifetime.get_info_at(code_offset).is_borrowed(src) {
+                let ty = self.builder.get_local_type(src);
+                let temp = self.builder.new_temp(ty);
+                self.builder.emit(Assign(id, temp, src, AssignKind::Copy));
+                return temp;
+            }
+        }
+        src
+    }
+
     /// Walks over the argument list and inserts copies if needed.
     fn copy_args_if_needed(
         &mut self,
@@ -356,28 +425,9 @@ impl Transformer<'_> {
         id: AttrId,
         srcs: Vec<TempIndex>,
     ) -> Vec<TempIndex> {
-        use Bytecode::*;
-        let copy_drop_at = self.copy_drop.get(&code_offset).expect("copy drop");
-        let mut new_srcs = vec![];
-        for src in srcs.iter() {
-            if copy_drop_at.needs_copy.contains(src) {
-                self.check_implicit_copy(code_offset, id, *src);
-                // Only need to perform the actual copy if src is borrowed, as this
-                // information cannot be determined from live-var analysis in later
-                // phases.
-                if self.lifetime.get_info_at(code_offset).is_borrowed(*src) {
-                    let ty = self.builder.get_local_type(*src);
-                    let temp = self.builder.new_temp(ty);
-                    self.builder.emit(Assign(id, temp, *src, AssignKind::Copy));
-                    new_srcs.push(temp)
-                } else {
-                    new_srcs.push(*src)
-                }
-            } else {
-                new_srcs.push(*src)
-            }
-        }
-        new_srcs
+        srcs.iter()
+            .map(|src| self.copy_arg_if_needed(code_offset, id, *src))
+            .collect()
     }
 
     /// Checks whether the given temp has copy ability, add diagnostics if not

--- a/third_party/move/move-compiler-v2/src/pipeline/ability_processor.rs
+++ b/third_party/move/move-compiler-v2/src/pipeline/ability_processor.rs
@@ -399,14 +399,14 @@ impl Transformer<'_> {
         id: AttrId,
         src: TempIndex,
     ) -> TempIndex {
-        use Bytecode::*;
         let copy_drop_at = self.copy_drop.get(&code_offset).expect("copy drop");
         if copy_drop_at.needs_copy.contains(&src) {
             self.check_implicit_copy(code_offset, id, src);
             if self.lifetime.get_info_at(code_offset).is_borrowed(src) {
                 let ty = self.builder.get_local_type(src);
                 let temp = self.builder.new_temp(ty);
-                self.builder.emit(Assign(id, temp, src, AssignKind::Copy));
+                self.builder
+                    .emit(Bytecode::Assign(id, temp, src, AssignKind::Copy));
                 return temp;
             }
         }

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/bug_13952_stack_balance.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/bug_13952_stack_balance.exp
@@ -7,30 +7,34 @@ struct Struct0 has copy + drop
 
 // Function definition at index 0
 #[persistent] public fun function5(l0: bool, l1: bool)
-    local l2: &bool
-    local l3: bool
-    local l4: &bool
+    local l2: bool
+    local l3: &bool
+    local l4: bool
+    local l5: &bool
     borrow_loc l0
-    st_loc l2
     copy_loc l0
+    st_loc l2
+    st_loc l3
+    move_loc l2
+    // @5
     br_false l0
     ld_true
-    // @5
-    st_loc l3
+    st_loc l4
     branch l1
 l0: move_loc l1
-    st_loc l3
-l1: borrow_loc l3
     // @10
     st_loc l4
-    move_loc l2
-    move_loc l4
+l1: borrow_loc l4
+    st_loc l5
+    move_loc l3
+    move_loc l5
+    // @15
     neq
     move_loc l0
-    // @15
     pack Struct0
     pop
     pop
+    // @20
     ret
 
 

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/bug_17473.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/bug_17473.exp
@@ -1,0 +1,35 @@
+
+============ disassembled file-format ==================
+// Bytecode version v10
+module 0xcafe::Module0
+// Function definition at index 0
+#[persistent] public fun f1(l0: &bool, l1: bool)
+    move_loc l0
+    pop
+    ret
+
+// Function definition at index 1
+#[persistent] public fun f2(l0: bool)
+    local l1: bool
+    local l2: &bool
+    local l3: bool
+    borrow_loc l0
+    copy_loc l0
+    st_loc l1
+    st_loc l2
+    move_loc l1
+    // @5
+    br_false l0
+    ld_true
+    st_loc l3
+    branch l1
+l0: ld_true
+    // @10
+    st_loc l3
+l1: move_loc l2
+    move_loc l3
+    call f1
+    ret
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/bug_17473.move
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/bug_17473.move
@@ -1,0 +1,10 @@
+module 0xCAFE::Module0 {
+    public fun f1(_x: &bool, _y: bool) { }
+
+    public fun f2(z: bool) {
+        f1(
+            &(z),
+            if (z) true else true
+        );
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/bug_17473.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/bug_17473.opt.exp
@@ -1,0 +1,32 @@
+
+============ disassembled file-format ==================
+// Bytecode version v10
+module 0xcafe::Module0
+// Function definition at index 0
+#[persistent] public fun f1(l0: &bool, l1: bool)
+    move_loc l0
+    pop
+    ret
+
+// Function definition at index 1
+#[persistent] public fun f2(l0: bool)
+    local l1: &bool
+    local l2: bool
+    borrow_loc l0
+    st_loc l1
+    copy_loc l0
+    br_false l0
+    ld_true
+    // @5
+    st_loc l2
+l1: move_loc l1
+    move_loc l2
+    call f1
+    ret
+    // @10
+l0: ld_true
+    st_loc l2
+    branch l1
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/bug_17473_abort.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/bug_17473_abort.exp
@@ -1,0 +1,24 @@
+
+============ disassembled file-format ==================
+// Bytecode version v10
+module 0xcafe::Module0
+// Function definition at index 0
+#[persistent] public fun f(l0: u64, l1: bool): u64
+    local l2: &u64
+    borrow_loc l0
+    st_loc l2
+    move_loc l1
+    br_false l0
+    move_loc l2
+    // @5
+    pop
+    move_loc l0
+    abort
+    branch l0
+l0: move_loc l2
+    // @10
+    read_ref
+    ret
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/bug_17473_abort.move
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/bug_17473_abort.move
@@ -1,0 +1,9 @@
+module 0xCAFE::Module0 {
+    public fun f(x: u64, cond: bool): u64 {
+        let r = &x;
+        if (cond) {
+            abort x
+        };
+        *r
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/bug_17473_abort.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/bug_17473_abort.opt.exp
@@ -1,0 +1,23 @@
+
+============ disassembled file-format ==================
+// Bytecode version v10
+module 0xcafe::Module0
+// Function definition at index 0
+#[persistent] public fun f(l0: u64, l1: bool): u64
+    local l2: &u64
+    borrow_loc l0
+    st_loc l2
+    move_loc l1
+    br_false l0
+    move_loc l2
+    // @5
+    pop
+    move_loc l0
+    abort
+l0: move_loc l2
+    read_ref
+    // @10
+    ret
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/bug_17473_abort_with_message.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/bug_17473_abort_with_message.exp
@@ -1,0 +1,28 @@
+
+============ disassembled file-format ==================
+// Bytecode version v10
+module 0xcafe::Module0
+// Function definition at index 0
+#[persistent] public fun f(l0: vector<u8>, l1: bool): vector<u8>
+    local l2: &vector<u8>
+    local l3: u64
+    borrow_loc l0
+    st_loc l2
+    move_loc l1
+    br_false l0
+    move_loc l2
+    // @5
+    pop
+    ld_u64 14566554180833181696
+    st_loc l3
+    move_loc l3
+    move_loc l0
+    // @10
+    abort_msg
+    branch l0
+l0: move_loc l2
+    read_ref
+    ret
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/bug_17473_abort_with_message.move
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/bug_17473_abort_with_message.move
@@ -1,0 +1,9 @@
+module 0xCAFE::Module0 {
+    public fun f(x: vector<u8>, cond: bool): vector<u8> {
+        let r = &x;
+        if (cond) {
+            abort x
+        };
+        *r
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/bug_17473_abort_with_message.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/bug_17473_abort_with_message.opt.exp
@@ -1,0 +1,25 @@
+
+============ disassembled file-format ==================
+// Bytecode version v10
+module 0xcafe::Module0
+// Function definition at index 0
+#[persistent] public fun f(l0: vector<u8>, l1: bool): vector<u8>
+    local l2: &vector<u8>
+    local l3: u64
+    borrow_loc l0
+    st_loc l2
+    move_loc l1
+    br_false l0
+    move_loc l2
+    // @5
+    pop
+    ld_u64 14566554180833181696
+    move_loc l0
+    abort_msg
+l0: move_loc l2
+    // @10
+    read_ref
+    ret
+
+
+============ bytecode verification succeeded ========


### PR DESCRIPTION
## Description

The compiler's ability processor silently skipped `Branch` and `Abort` instructions in its copy/move analysis (they fell into a `_ => {}` catch-all). When a variable was both borrowed and used as a branch condition — e.g., `f1(&z, if (z) true else true)` — the compiler emitted `MoveLoc` instead of `CopyLoc`, triggering `MOVELOC_EXISTS_BORROW_ERROR` at bytecode verification.

This PR fixes it. Closes #17473

## How Has This Been Tested?

- tests added to showcase the bug and the fix
- updated baseline for one existing test (in the non-optimized path)

## Type of Change
- [x] Bug fix

## Which Components or Systems Does This Change Impact?
- [x] Move Compiler

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes copy/move inference for `Branch`/`Abort` and injects new temporaries when borrowed values also need copies, which can alter generated bytecode and affect verification/runtime behavior. Scope is limited to the compiler’s ability transformation plus new regression baselines.
> 
> **Overview**
> Fixes a compiler-v2 bug where the ability processor skipped copy/move analysis for `Branch` and `Abort`, which could incorrectly emit `MoveLoc` for values that were still borrowed (failing bytecode verification).
> 
> Adds unified `copy_arg_if_needed` logic and applies it to branch conditions and abort operands (including optional abort messages), and updates/adds file-format-generator baselines/regression tests to cover these cases (including optimized output).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 243bee50458eab5fc3c903c96ed2d6fbd7b4d241. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->