### PR TITLE
Validate batch metadata limits during payload verification

### DIFF
--- a/consensus/consensus-types/src/common.rs
+++ b/consensus/consensus-types/src/common.rs
@@ -124,6 +124,27 @@ pub struct RejectedTransactionSummary {
     pub reason: DiscardedVMStatus,
 }
 
+/// Validates that a single batch's num_txns and num_bytes are within receiver-side limits.
+pub fn verify_batch_info_limits<T: TBatchInfo>(
+    batch: &T,
+    max_batch_txns: u64,
+    max_batch_bytes: u64,
+) -> anyhow::Result<()> {
+    ensure!(
+        batch.num_txns() <= max_batch_txns,
+        "Batch txn count {} exceeds limit {}",
+        batch.num_txns(),
+        max_batch_txns,
+    );
+    ensure!(
+        batch.num_bytes() <= max_batch_bytes,
+        "Batch byte count {} exceeds limit {}",
+        batch.num_bytes(),
+        max_batch_bytes,
+    );
+    Ok(())
+}
+
 /// The payload in block.
 #[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq)]
 pub enum Payload {
@@ -281,8 +302,11 @@ impl Payload {
 
     pub fn verify_inline_batches<'a, T: TBatchInfo + 'a>(
         inline_batches: impl Iterator<Item = (&'a T, &'a Vec<SignedTransaction>)>,
+        max_batch_txns: u64,
+        max_batch_bytes: u64,
     ) -> anyhow::Result<()> {
         for (batch, payload) in inline_batches {
+            verify_batch_info_limits(batch, max_batch_txns, max_batch_bytes)?;
             // TODO: Can cloning be avoided here?
             let computed_digest = BatchPayload::new(batch.author(), payload.clone()).hash();
             ensure!(
@@ -299,9 +323,12 @@ impl Payload {
     pub fn verify_opt_batches<T: TBatchInfo>(
         verifier: &ValidatorVerifier,
         opt_batches: &OptBatches<T>,
+        max_batch_txns: u64,
+        max_batch_bytes: u64,
     ) -> anyhow::Result<()> {
         let authors = verifier.address_to_validator_index();
         for batch in &opt_batches.batch_summary {
+            verify_batch_info_limits(batch, max_batch_txns, max_batch_bytes)?;
             ensure!(
                 authors.contains_key(&batch.author()),
                 "Invalid author {} for batch {}",
@@ -318,18 +345,30 @@ impl Payload {
         proof_cache: &ProofCache,
         quorum_store_enabled: bool,
         opt_qs_v2_rx_enabled: bool,
+        max_batch_txns: u64,
+        max_batch_bytes: u64,
     ) -> anyhow::Result<()> {
         match (quorum_store_enabled, self) {
             (false, Payload::DirectMempool(_)) => Ok(()),
             (true, Payload::OptQuorumStore(OptQuorumStorePayload::V1(p))) => {
                 let proof_with_data = p.proof_with_data();
                 Self::verify_with_cache(&proof_with_data.batch_summary, verifier, proof_cache)?;
+                for proof in &proof_with_data.batch_summary {
+                    verify_batch_info_limits(proof.info(), max_batch_txns, max_batch_bytes)?;
+                }
                 Self::verify_inline_batches(
                     p.inline_batches()
                         .iter()
                         .map(|batch| (batch.info(), batch.transactions())),
+                    max_batch_txns,
+                    max_batch_bytes,
                 )?;
-                Self::verify_opt_batches(verifier, p.opt_batches())?;
+                Self::verify_opt_batches(
+                    verifier,
+                    p.opt_batches(),
+                    max_batch_txns,
+                    max_batch_bytes,
+                )?;
                 Ok(())
             },
             (true, Payload::OptQuorumStore(OptQuorumStorePayload::V2(p))) => {
@@ -339,12 +378,22 @@ impl Payload {
                 );
                 let proof_with_data = p.proof_with_data();
                 Self::verify_with_cache(&proof_with_data.batch_summary, verifier, proof_cache)?;
+                for proof in &proof_with_data.batch_summary {
+                    verify_batch_info_limits(proof.info(), max_batch_txns, max_batch_bytes)?;
+                }
                 Self::verify_inline_batches(
                     p.inline_batches()
                         .iter()
                         .map(|batch| (batch.info(), batch.transactions())),
+                    max_batch_txns,
+                    max_batch_bytes,
                 )?;
-                Self::verify_opt_batches(verifier, p.opt_batches())?;
+                Self::verify_opt_batches(
+                    verifier,
+                    p.opt_batches(),
+                    max_batch_txns,
+                    max_batch_bytes,
+                )?;
                 Ok(())
             },
             (_, _) => Err(anyhow::anyhow!(
@@ -538,5 +587,125 @@ impl fmt::Display for PayloadFilter {
                 write!(f, "Empty filter")
             },
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        payload::{BatchPointer, OptBatches},
+        proof_of_store::BatchInfo,
+    };
+    use aptos_crypto::HashValue;
+    use aptos_types::validator_verifier::random_validator_verifier;
+
+    const MAX_BATCH_TXNS: u64 = 100;
+    const MAX_BATCH_BYTES: u64 = 1024 * 1024;
+
+    fn make_batch_info(author: PeerId, num_txns: u64, num_bytes: u64) -> BatchInfo {
+        BatchInfo::new(
+            author,
+            aptos_types::quorum_store::BatchId::new_for_test(1),
+            1, // epoch
+            1000,
+            HashValue::random(),
+            num_txns,
+            num_bytes,
+            0,
+        )
+    }
+
+    #[test]
+    fn test_verify_batch_info_limits_accepts_valid() {
+        let author = PeerId::random();
+        let batch = make_batch_info(author, 50, 500_000);
+        assert!(verify_batch_info_limits(&batch, MAX_BATCH_TXNS, MAX_BATCH_BYTES).is_ok());
+    }
+
+    #[test]
+    fn test_verify_batch_info_limits_rejects_excess_txns() {
+        let author = PeerId::random();
+        let batch = make_batch_info(author, MAX_BATCH_TXNS + 1, 100);
+        assert!(verify_batch_info_limits(&batch, MAX_BATCH_TXNS, MAX_BATCH_BYTES).is_err());
+    }
+
+    #[test]
+    fn test_verify_batch_info_limits_rejects_excess_bytes() {
+        let author = PeerId::random();
+        let batch = make_batch_info(author, 1, MAX_BATCH_BYTES + 1);
+        assert!(verify_batch_info_limits(&batch, MAX_BATCH_TXNS, MAX_BATCH_BYTES).is_err());
+    }
+
+    #[test]
+    fn test_verify_batch_info_limits_rejects_overflow_values() {
+        let author = PeerId::random();
+        let batch = make_batch_info(author, u64::MAX, u64::MAX);
+        assert!(verify_batch_info_limits(&batch, MAX_BATCH_TXNS, MAX_BATCH_BYTES).is_err());
+    }
+
+    #[test]
+    fn test_verify_opt_batches_rejects_oversized_batch() {
+        let (signers, validators) = random_validator_verifier(1, None, false);
+        let author = signers[0].author();
+
+        let bad_batch = make_batch_info(author, 1, u64::MAX);
+        let opt_batches: OptBatches<BatchInfo> = BatchPointer::new(vec![bad_batch]);
+
+        assert!(Payload::verify_opt_batches(
+            &validators,
+            &opt_batches,
+            MAX_BATCH_TXNS,
+            MAX_BATCH_BYTES
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn test_verify_opt_batches_accepts_valid() {
+        let (signers, validators) = random_validator_verifier(1, None, false);
+        let author = signers[0].author();
+
+        let batch = make_batch_info(author, 50, 500_000);
+        let opt_batches: OptBatches<BatchInfo> = BatchPointer::new(vec![batch]);
+
+        assert!(Payload::verify_opt_batches(
+            &validators,
+            &opt_batches,
+            MAX_BATCH_TXNS,
+            MAX_BATCH_BYTES
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn test_verify_opt_batches_rejects_before_checking_author() {
+        let (_signers, validators) = random_validator_verifier(1, None, false);
+        // Use a random author NOT in the validator set, but with oversized batch.
+        // The limit check should fire before the author check.
+        let bad_author = PeerId::random();
+        let bad_batch = make_batch_info(bad_author, MAX_BATCH_TXNS + 1, 100);
+        let opt_batches: OptBatches<BatchInfo> = BatchPointer::new(vec![bad_batch]);
+
+        let err =
+            Payload::verify_opt_batches(&validators, &opt_batches, MAX_BATCH_TXNS, MAX_BATCH_BYTES)
+                .unwrap_err();
+        // Should fail on batch limit, not author
+        assert!(err.to_string().contains("Batch txn count"));
+    }
+
+    #[test]
+    fn test_verify_inline_batches_rejects_oversized_batch() {
+        let author = PeerId::random();
+        let bad_batch = make_batch_info(author, u64::MAX / 2 + 1, u64::MAX / 2 + 1);
+        let empty_txns = vec![];
+        let inline_batches = vec![(&bad_batch, &empty_txns)];
+
+        assert!(Payload::verify_inline_batches(
+            inline_batches.into_iter(),
+            MAX_BATCH_TXNS,
+            MAX_BATCH_BYTES,
+        )
+        .is_err());
     }
 }

--- a/consensus/consensus-types/src/opt_proposal_msg.rs
+++ b/consensus/consensus-types/src/opt_proposal_msg.rs
@@ -100,6 +100,8 @@ impl OptProposalMsg {
         proof_cache: &ProofCache,
         quorum_store_enabled: bool,
         opt_qs_v2_enabled: bool,
+        max_batch_txns: u64,
+        max_batch_bytes: u64,
     ) -> Result<()> {
         ensure!(
             self.proposer() == sender,
@@ -115,6 +117,8 @@ impl OptProposalMsg {
                     proof_cache,
                     quorum_store_enabled,
                     opt_qs_v2_enabled,
+                    max_batch_txns,
+                    max_batch_bytes,
                 )
             },
             || self.block_data().grandparent_qc().verify(validator),
@@ -216,7 +220,15 @@ mod tests {
         let msg = create_opt_proposal_msg(3, 1, signer);
         let proof_cache = ProofCache::new(1024);
         assert!(msg
-            .verify(signer.author(), &validators, &proof_cache, false, false)
+            .verify(
+                signer.author(),
+                &validators,
+                &proof_cache,
+                false,
+                false,
+                100,
+                1024 * 1024
+            )
             .is_ok());
     }
 
@@ -229,7 +241,15 @@ mod tests {
         // Test round too low
         let msg_round_1 = create_opt_proposal_msg(1, 1, signer);
         assert!(msg_round_1
-            .verify(signer.author(), &validators, &proof_cache, false, false)
+            .verify(
+                signer.author(),
+                &validators,
+                &proof_cache,
+                false,
+                false,
+                100,
+                1024 * 1024
+            )
             .is_err());
 
         // Test epoch mismatch
@@ -253,7 +273,15 @@ mod tests {
         );
         let msg_epoch_mismatch = OptProposalMsg::new(epoch_2_block_data, sync_info);
         assert!(msg_epoch_mismatch
-            .verify(signer.author(), &validators, &proof_cache, false, false)
+            .verify(
+                signer.author(),
+                &validators,
+                &proof_cache,
+                false,
+                false,
+                100,
+                1024 * 1024
+            )
             .is_err());
 
         // Test with timeout cert
@@ -270,7 +298,15 @@ mod tests {
         );
         let msg_with_tc = OptProposalMsg::new(block_data, sync_info);
         assert!(msg_with_tc
-            .verify(signer.author(), &validators, &proof_cache, false, false)
+            .verify(
+                signer.author(),
+                &validators,
+                &proof_cache,
+                false,
+                false,
+                100,
+                1024 * 1024
+            )
             .is_err());
     }
 
@@ -284,7 +320,15 @@ mod tests {
         let proof_cache = ProofCache::new(1024);
 
         assert!(msg
-            .verify(signer2.author(), &validators, &proof_cache, false, false)
+            .verify(
+                signer2.author(),
+                &validators,
+                &proof_cache,
+                false,
+                false,
+                100,
+                1024 * 1024
+            )
             .is_err());
     }
 }

--- a/consensus/consensus-types/src/proposal_msg.rs
+++ b/consensus/consensus-types/src/proposal_msg.rs
@@ -86,6 +86,8 @@ impl ProposalMsg {
         proof_cache: &ProofCache,
         quorum_store_enabled: bool,
         opt_qs_v2_rx_enabled: bool,
+        max_batch_txns: u64,
+        max_batch_bytes: u64,
     ) -> Result<()> {
         if let Some(proposal_author) = self.proposal.author() {
             ensure!(
@@ -103,6 +105,8 @@ impl ProposalMsg {
                         proof_cache,
                         quorum_store_enabled,
                         opt_qs_v2_rx_enabled,
+                        max_batch_txns,
+                        max_batch_bytes,
                     )
                 })
             },

--- a/consensus/src/epoch_manager.rs
+++ b/consensus/src/epoch_manager.rs
@@ -1691,6 +1691,8 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
             let max_num_batches = self.config.quorum_store.receiver_max_num_batches;
             let max_batch_expiry_gap_usecs =
                 self.config.quorum_store.batch_expiry_gap_when_init_usecs;
+            let max_batch_txns = self.config.quorum_store.receiver_max_batch_txns as u64;
+            let max_batch_bytes = self.config.quorum_store.receiver_max_batch_bytes as u64;
             let payload_manager = self.payload_manager.clone();
             let pending_blocks = self.pending_blocks.clone();
             self.bounded_executor
@@ -1706,6 +1708,8 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
                             peer_id == my_peer_id,
                             max_num_batches,
                             max_batch_expiry_gap_usecs,
+                            max_batch_txns,
+                            max_batch_bytes,
                         )
                     ) {
                         Ok(verified_event) => {

--- a/consensus/src/quorum_store/batch_coordinator.rs
+++ b/consensus/src/quorum_store/batch_coordinator.rs
@@ -15,7 +15,10 @@ use crate::{
 };
 use anyhow::ensure;
 use aptos_config::config::BatchTransactionFilterConfig;
-use aptos_consensus_types::proof_of_store::{BatchInfoExt, BatchKind, TBatchInfo};
+use aptos_consensus_types::{
+    common::verify_batch_info_limits,
+    proof_of_store::{BatchInfoExt, BatchKind, TBatchInfo},
+};
 use aptos_logger::prelude::*;
 use aptos_short_hex_str::AsShortHexStr;
 use aptos_types::PeerId;
@@ -152,12 +155,11 @@ impl BatchCoordinator {
         let mut total_txns = 0;
         let mut total_bytes = 0;
         for batch in batches.iter() {
-            ensure!(
-                batch.num_txns() <= self.max_batch_txns,
-                "Exceeds batch txn limit {} > {}",
-                batch.num_txns(),
+            verify_batch_info_limits(
+                batch.batch_info(),
                 self.max_batch_txns,
-            );
+                self.max_batch_bytes,
+            )?;
             if batch.batch_info().batch_kind() == Some(BatchKind::Encrypted) {
                 ensure!(
                     batch.num_txns() <= self.max_encrypted_batch_txns,
@@ -166,12 +168,6 @@ impl BatchCoordinator {
                     self.max_encrypted_batch_txns,
                 );
             }
-            ensure!(
-                batch.num_bytes() <= self.max_batch_bytes,
-                "Exceeds batch bytes limit {} > {}",
-                batch.num_bytes(),
-                self.max_batch_bytes,
-            );
 
             total_txns += batch.num_txns();
             total_bytes += batch.num_bytes();

--- a/consensus/src/round_manager.rs
+++ b/consensus/src/round_manager.rs
@@ -111,6 +111,8 @@ impl UnverifiedEvent {
         self_message: bool,
         max_num_batches: usize,
         max_batch_expiry_gap_usecs: u64,
+        max_batch_txns: u64,
+        max_batch_bytes: u64,
     ) -> Result<VerifiedEvent, VerifyError> {
         let start_time = Instant::now();
         Ok(match self {
@@ -122,6 +124,8 @@ impl UnverifiedEvent {
                         proof_cache,
                         quorum_store_enabled,
                         opt_qs_v2_rx_enabled,
+                        max_batch_txns,
+                        max_batch_bytes,
                     )?;
                     counters::VERIFY_MSG
                         .with_label_values(&["proposal"])
@@ -137,6 +141,8 @@ impl UnverifiedEvent {
                         proof_cache,
                         quorum_store_enabled,
                         opt_qs_v2_rx_enabled,
+                        max_batch_txns,
+                        max_batch_bytes,
                     )?;
                     counters::VERIFY_MSG
                         .with_label_values(&["opt_proposal"])


### PR DESCRIPTION
## Summary
- Add per-batch size validation during proposal payload verification
- Consolidate batch limit checks into a shared validation function

## Test plan
- [x] New unit tests for batch limit validation
- [x] Existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)