### PR TITLE
Use async snapshot creation with polling

### DIFF
--- a/testsuite/replay-verify/archive_disk_utils.py
+++ b/testsuite/replay-verify/archive_disk_utils.py
@@ -158,7 +158,7 @@ def create_snapshot_with_gcloud(
             f"Snapshot {e} {target_project} {snapshot_name} does not exist. Creating a new one."
         )
 
-    # Construct the gcloud command to create the snapshot in the target project
+    # Create the snapshot asynchronously, then poll until complete
     source_disk_link = f"https://www.googleapis.com/compute/v1/projects/{source_project}/zones/{source_zone}/disks/{source_volume}"
     command = [
         "gcloud",
@@ -172,19 +172,28 @@ def create_snapshot_with_gcloud(
         target_project,
         "--storage-location",
         get_region_from_zone(source_zone),
+        "--async",
     ]
 
     try:
-        print(
+        logger.info(
             f"Creating snapshot '{snapshot_name}' in project '{target_project}' from disk '{source_disk_link}'..."
         )
         subprocess.run(command, check=True)
-        print(
-            f"Snapshot '{snapshot_name}' created successfully in project '{target_project}'!"
-        )
     except subprocess.CalledProcessError as e:
-        print(f"Error creating snapshot: {e}")
         raise Exception(f"Error creating snapshot: {e}")
+
+    # Poll until the snapshot is READY
+    logger.info(f"Waiting for snapshot '{snapshot_name}' to be ready...")
+    while True:
+        snapshot = snapshot_client.get(project=target_project, snapshot=snapshot_name)
+        if snapshot.status == compute_v1.Snapshot.Status.READY:
+            logger.info(f"Snapshot '{snapshot_name}' created successfully!")
+            break
+        elif snapshot.status == compute_v1.Snapshot.Status.FAILED:
+            raise Exception(f"Snapshot '{snapshot_name}' failed to create.")
+        logger.info(f"Snapshot status: {snapshot.status.name}, waiting...")
+        time.sleep(60)
 
 
 def delete_disk(

--- a/testsuite/replay-verify/archive_disk_utils.py
+++ b/testsuite/replay-verify/archive_disk_utils.py
@@ -198,7 +198,7 @@ def create_snapshot_with_gcloud(
             break
         elif snapshot.status == compute_v1.Snapshot.Status.FAILED:
             raise Exception(f"Snapshot '{snapshot_name}' failed to create.")
-        logger.info(f"Snapshot status: {snapshot.status.name}, waiting...")
+        logger.info(f"Snapshot status: {snapshot.status}, waiting...")
         time.sleep(60)
 
 

--- a/testsuite/replay-verify/archive_disk_utils.py
+++ b/testsuite/replay-verify/archive_disk_utils.py
@@ -192,7 +192,12 @@ def create_snapshot_with_gcloud(
             raise TimeoutError(
                 f"Snapshot '{snapshot_name}' did not become ready after {timeout} seconds"
             )
-        snapshot = snapshot_client.get(project=target_project, snapshot=snapshot_name)
+        try:
+            snapshot = snapshot_client.get(project=target_project, snapshot=snapshot_name)
+        except Exception as e:
+            logger.warning(f"Transient error polling snapshot status: {e}, retrying...")
+            time.sleep(60)
+            continue
         if snapshot.status == "READY":
             logger.info(f"Snapshot '{snapshot_name}' created successfully!")
             break

--- a/testsuite/replay-verify/archive_disk_utils.py
+++ b/testsuite/replay-verify/archive_disk_utils.py
@@ -185,7 +185,13 @@ def create_snapshot_with_gcloud(
 
     # Poll until the snapshot is READY
     logger.info(f"Waiting for snapshot '{snapshot_name}' to be ready...")
+    start_time = time.time()
+    timeout = 3600  # 1 hour timeout
     while True:
+        if time.time() - start_time > timeout:
+            raise TimeoutError(
+                f"Snapshot '{snapshot_name}' did not become ready after {timeout} seconds"
+            )
         snapshot = snapshot_client.get(project=target_project, snapshot=snapshot_name)
         if snapshot.status == compute_v1.Snapshot.Status.READY:
             logger.info(f"Snapshot '{snapshot_name}' created successfully!")

--- a/testsuite/replay-verify/archive_disk_utils.py
+++ b/testsuite/replay-verify/archive_disk_utils.py
@@ -186,7 +186,7 @@ def create_snapshot_with_gcloud(
     # Poll until the snapshot is READY
     logger.info(f"Waiting for snapshot '{snapshot_name}' to be ready...")
     start_time = time.time()
-    timeout = 3600  # 1 hour timeout
+    timeout = 5400  # 1.5 hour timeout
     while True:
         if time.time() - start_time > timeout:
             raise TimeoutError(

--- a/testsuite/replay-verify/archive_disk_utils.py
+++ b/testsuite/replay-verify/archive_disk_utils.py
@@ -193,10 +193,10 @@ def create_snapshot_with_gcloud(
                 f"Snapshot '{snapshot_name}' did not become ready after {timeout} seconds"
             )
         snapshot = snapshot_client.get(project=target_project, snapshot=snapshot_name)
-        if snapshot.status == compute_v1.Snapshot.Status.READY:
+        if snapshot.status == "READY":
             logger.info(f"Snapshot '{snapshot_name}' created successfully!")
             break
-        elif snapshot.status == compute_v1.Snapshot.Status.FAILED:
+        elif snapshot.status == "FAILED":
             raise Exception(f"Snapshot '{snapshot_name}' failed to create.")
         logger.info(f"Snapshot status: {snapshot.status}, waiting...")
         time.sleep(60)


### PR DESCRIPTION
## Summary
- Change snapshot creation in `archive_disk_utils.py` to use `--async` flag so `gcloud` returns immediately
- Poll the snapshot status via the Compute API every 60s until `READY` or `FAILED`
- Replace `print` calls with `logger.info` for consistent logging

## Test plan
- [ ] Verify snapshot creation completes successfully on testnet
- [ ] Verify failed snapshot raises an exception as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the snapshot-creation flow to return immediately and then poll GCP for completion, which could impact timing/timeout behavior and error handling in automation runs.
> 
> **Overview**
> Snapshot creation in `archive_disk_utils.py` now uses `gcloud compute snapshots create --async` and explicitly polls the Compute API until the snapshot reaches `READY` (or errors on `FAILED`/timeout).
> 
> Console `print` output was replaced with structured `logger` calls, and snapshot status polling includes retry handling for transient API errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c1932518fa73767cef17dd43564ac2b79ead0d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->