### PR TITLE
[execution] Replace rayon background pool with tokio runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1810,6 +1810,7 @@ dependencies = [
  "num_cpus",
  "once_cell",
  "rayon",
+ "tokio",
 ]
 
 [[package]]

--- a/execution/executor/src/workflow/do_get_execution_output.rs
+++ b/execution/executor/src/workflow/do_get_execution_output.rs
@@ -89,16 +89,18 @@ impl DoGetExecutionOutput {
         };
 
         let ret = out.clone();
-        THREAD_MANAGER.get_background_pool().spawn(move || {
-            let _timer = OTHER_TIMERS.timer_with(&["async_update_counters__by_execution"]);
-            for x in [&out.to_commit, &out.to_retry, &out.to_discard] {
-                metrics::update_counters_for_processed_chunk(
-                    &x.transactions,
-                    &x.transaction_outputs,
-                    "execution",
-                )
-            }
-        });
+        let _ = THREAD_MANAGER
+            .get_background_pool()
+            .spawn_blocking(move || {
+                let _timer = OTHER_TIMERS.timer_with(&["async_update_counters__by_execution"]);
+                for x in [&out.to_commit, &out.to_retry, &out.to_discard] {
+                    metrics::update_counters_for_processed_chunk(
+                        &x.transactions,
+                        &x.transaction_outputs,
+                        "execution",
+                    )
+                }
+            });
 
         Ok(ret)
     }
@@ -241,14 +243,16 @@ impl DoGetExecutionOutput {
         )?;
 
         let ret = out.clone();
-        THREAD_MANAGER.get_background_pool().spawn(move || {
-            let _timer = OTHER_TIMERS.timer_with(&["async_update_counters__by_output"]);
-            metrics::update_counters_for_processed_chunk(
-                &out.to_commit.transactions,
-                &out.to_commit.transaction_outputs,
-                "output",
-            )
-        });
+        let _ = THREAD_MANAGER
+            .get_background_pool()
+            .spawn_blocking(move || {
+                let _timer = OTHER_TIMERS.timer_with(&["async_update_counters__by_output"]);
+                metrics::update_counters_for_processed_chunk(
+                    &out.to_commit.transactions,
+                    &out.to_commit.transaction_outputs,
+                    "output",
+                )
+            });
 
         Ok(ret)
     }

--- a/experimental/runtimes/Cargo.toml
+++ b/experimental/runtimes/Cargo.toml
@@ -19,3 +19,4 @@ libc = { workspace = true }
 num_cpus = { workspace = true }
 once_cell = { workspace = true }
 rayon = { workspace = true }
+tokio = { workspace = true }

--- a/experimental/runtimes/src/strategies/default.rs
+++ b/experimental/runtimes/src/strategies/default.rs
@@ -5,12 +5,13 @@ use crate::thread_manager::{ThreadManager, MAX_THREAD_POOL_SIZE};
 use aptos_runtimes::spawn_rayon_thread_pool;
 use rayon::ThreadPool;
 use std::cmp::min;
+use tokio::runtime::{Handle, Runtime};
 
 pub struct DefaultThreadManager {
     exe_threads: ThreadPool,
     non_exe_threads: ThreadPool,
     io_threads: ThreadPool,
-    background_threads: ThreadPool,
+    background_runtime: Runtime,
 }
 
 impl DefaultThreadManager {
@@ -26,13 +27,17 @@ impl DefaultThreadManager {
             Some(min(num_cpus::get(), MAX_THREAD_POOL_SIZE)),
         );
         let io_threads = spawn_rayon_thread_pool("io".into(), Some(64));
-        let background_threads =
-            spawn_rayon_thread_pool("background".into(), Some(MAX_THREAD_POOL_SIZE));
+        let background_runtime = tokio::runtime::Builder::new_current_thread()
+            .max_blocking_threads(MAX_THREAD_POOL_SIZE)
+            .thread_name("bg-pool")
+            .enable_all()
+            .build()
+            .expect("Failed to create background tokio runtime");
         Self {
             exe_threads,
             non_exe_threads,
             io_threads,
-            background_threads,
+            background_runtime,
         }
     }
 }
@@ -54,7 +59,7 @@ impl<'a> ThreadManager<'a> for DefaultThreadManager {
         &self.io_threads
     }
 
-    fn get_background_pool(&'a self) -> &'a ThreadPool {
-        &self.background_threads
+    fn get_background_pool(&'a self) -> Handle {
+        self.background_runtime.handle().clone()
     }
 }

--- a/experimental/runtimes/src/strategies/pin_exe_threads_to_cores.rs
+++ b/experimental/runtimes/src/strategies/pin_exe_threads_to_cores.rs
@@ -8,13 +8,14 @@ use crate::{
 use aptos_runtimes::spawn_rayon_thread_pool_with_start_hook;
 use libc::CPU_SET;
 use rayon::ThreadPool;
+use tokio::runtime::{Handle, Runtime};
 
 pub(crate) struct PinExeThreadsToCoresThreadManager {
     exe_threads: ThreadPool,
     non_exe_threads: ThreadPool,
     high_pri_io_threads: ThreadPool,
     io_threads: ThreadPool,
-    background_threads: ThreadPool,
+    background_runtime: Runtime,
 }
 
 impl PinExeThreadsToCoresThreadManager {
@@ -55,18 +56,20 @@ impl PinExeThreadsToCoresThreadManager {
             pin_cpu_set(non_exe_cpu_set),
         );
 
-        let background_threads = spawn_rayon_thread_pool_with_start_hook(
-            "background".into(),
-            Some(32),
-            pin_cpu_set(non_exe_cpu_set),
-        );
+        let background_runtime = tokio::runtime::Builder::new_current_thread()
+            .max_blocking_threads(32)
+            .thread_name("bg-pool")
+            .on_thread_start(pin_cpu_set(non_exe_cpu_set))
+            .enable_all()
+            .build()
+            .expect("Failed to create background tokio runtime");
 
         Self {
             exe_threads,
             non_exe_threads,
             high_pri_io_threads,
             io_threads,
-            background_threads,
+            background_runtime,
         }
     }
 }
@@ -88,7 +91,7 @@ impl<'a> ThreadManager<'a> for PinExeThreadsToCoresThreadManager {
         &self.high_pri_io_threads
     }
 
-    fn get_background_pool(&'a self) -> &'a ThreadPool {
-        &self.background_threads
+    fn get_background_pool(&'a self) -> Handle {
+        self.background_runtime.handle().clone()
     }
 }

--- a/experimental/runtimes/src/strategies/threads_priority.rs
+++ b/experimental/runtimes/src/strategies/threads_priority.rs
@@ -4,13 +4,14 @@
 use crate::{common::set_thread_nice_value, thread_manager::ThreadManager};
 use aptos_runtimes::spawn_rayon_thread_pool_with_start_hook;
 use rayon::ThreadPool;
+use tokio::runtime::{Handle, Runtime};
 
 pub(crate) struct ThreadsPriorityThreadManager {
     exe_threads: ThreadPool,
     non_exe_threads: ThreadPool,
     high_pri_io_threads: ThreadPool,
     io_threads: ThreadPool,
-    background_threads: ThreadPool,
+    background_runtime: Runtime,
 }
 
 impl ThreadsPriorityThreadManager {
@@ -40,18 +41,20 @@ impl ThreadsPriorityThreadManager {
             set_thread_nice_value(1),
         );
 
-        let background_threads = spawn_rayon_thread_pool_with_start_hook(
-            "background".into(),
-            Some(32),
-            set_thread_nice_value(20),
-        );
+        let background_runtime = tokio::runtime::Builder::new_current_thread()
+            .max_blocking_threads(32)
+            .thread_name("bg-pool")
+            .on_thread_start(set_thread_nice_value(20))
+            .enable_all()
+            .build()
+            .expect("Failed to create background tokio runtime");
 
         Self {
             exe_threads,
             non_exe_threads,
             high_pri_io_threads,
             io_threads,
-            background_threads,
+            background_runtime,
         }
     }
 }
@@ -73,7 +76,7 @@ impl<'a> ThreadManager<'a> for ThreadsPriorityThreadManager {
         &self.high_pri_io_threads
     }
 
-    fn get_background_pool(&'a self) -> &'a ThreadPool {
-        &self.background_threads
+    fn get_background_pool(&'a self) -> Handle {
+        self.background_runtime.handle().clone()
     }
 }

--- a/experimental/runtimes/src/thread_manager.rs
+++ b/experimental/runtimes/src/thread_manager.rs
@@ -10,6 +10,7 @@ use crate::strategies::{
 use once_cell::sync::{Lazy, OnceCell};
 use rayon::ThreadPool;
 use std::cmp::max;
+use tokio::runtime::Handle;
 
 pub static MAX_THREAD_POOL_SIZE: usize = 32;
 
@@ -33,7 +34,7 @@ pub trait ThreadManager<'a>: Send + Sync {
     fn get_non_exe_cpu_pool(&'a self) -> &'a ThreadPool;
     fn get_high_pri_io_pool(&'a self) -> &'a ThreadPool;
     fn get_io_pool(&'a self) -> &'a ThreadPool;
-    fn get_background_pool(&'a self) -> &'a ThreadPool;
+    fn get_background_pool(&'a self) -> Handle;
 }
 
 pub struct ThreadManagerBuilder;

--- a/storage/aptosdb/src/pruner/ledger_pruner/mod.rs
+++ b/storage/aptosdb/src/pruner/ledger_pruner/mod.rs
@@ -34,7 +34,6 @@ use aptos_experimental_runtimes::thread_manager::THREAD_MANAGER;
 use aptos_logger::info;
 use aptos_storage_interface::Result;
 use aptos_types::transaction::{AtomicVersion, Version};
-use rayon::prelude::*;
 use std::{
     cmp::min,
     sync::{atomic::Ordering, Arc},
@@ -51,7 +50,7 @@ pub(crate) struct LedgerPruner {
 
     ledger_metadata_pruner: Box<LedgerMetadataPruner>,
 
-    sub_pruners: Vec<Box<dyn DBSubPruner + Send + Sync>>,
+    sub_pruners: Arc<Vec<Box<dyn DBSubPruner + Send + Sync>>>,
 }
 
 impl DBPruner for LedgerPruner {
@@ -75,13 +74,25 @@ impl DBPruner for LedgerPruner {
             self.ledger_metadata_pruner
                 .prune(progress, current_batch_target_version)?;
 
-            THREAD_MANAGER.get_background_pool().install(|| {
-                self.sub_pruners.par_iter().try_for_each(|sub_pruner| {
-                    sub_pruner
-                        .prune(progress, current_batch_target_version)
-                        .map_err(|err| anyhow!("{} failed to prune: {err}", sub_pruner.name()))
-                })
-            })?;
+            {
+                let handle = THREAD_MANAGER.get_background_pool();
+                let sub_pruners = Arc::clone(&self.sub_pruners);
+                let join_handles: Vec<_> = (0..sub_pruners.len())
+                    .map(|i| {
+                        let sub_pruners = Arc::clone(&sub_pruners);
+                        handle.spawn_blocking(move || {
+                            sub_pruners[i]
+                                .prune(progress, current_batch_target_version)
+                                .map_err(|err| {
+                                    anyhow!("{} failed to prune: {err}", sub_pruners[i].name())
+                                })
+                        })
+                    })
+                    .collect();
+                for jh in join_handles {
+                    handle.block_on(jh).expect("background task panicked")?;
+                }
+            }
 
             progress = current_batch_target_version;
             self.record_progress(progress);
@@ -173,7 +184,7 @@ impl LedgerPruner {
             target_version: AtomicVersion::new(metadata_progress),
             progress: AtomicVersion::new(metadata_progress),
             ledger_metadata_pruner,
-            sub_pruners: vec![
+            sub_pruners: Arc::new(vec![
                 event_store_pruner,
                 persisted_auxiliary_info_pruner,
                 transaction_accumulator_pruner,
@@ -181,7 +192,7 @@ impl LedgerPruner {
                 transaction_info_pruner,
                 transaction_pruner,
                 write_set_pruner,
-            ],
+            ]),
         };
 
         info!(

--- a/storage/aptosdb/src/pruner/state_kv_pruner/mod.rs
+++ b/storage/aptosdb/src/pruner/state_kv_pruner/mod.rs
@@ -22,7 +22,6 @@ use aptos_logger::info;
 use aptos_metrics_core::TimerHelper;
 use aptos_storage_interface::Result;
 use aptos_types::transaction::{AtomicVersion, Version};
-use rayon::prelude::*;
 use std::{
     cmp::min,
     sync::{atomic::Ordering, Arc},
@@ -36,7 +35,7 @@ pub(crate) struct StateKvPruner {
     name: &'static str,
 
     metadata_pruner: StateKvMetadataPruner,
-    shard_pruners: Vec<StateKvShardPruner>,
+    shard_pruners: Arc<Vec<StateKvShardPruner>>,
 }
 
 impl DBPruner for StateKvPruner {
@@ -62,18 +61,28 @@ impl DBPruner for StateKvPruner {
             );
             self.metadata_pruner.prune(current_batch_target_version)?;
 
-            THREAD_MANAGER.get_background_pool().install(|| {
-                self.shard_pruners.par_iter().try_for_each(|shard_pruner| {
-                    shard_pruner
-                        .prune(progress, current_batch_target_version)
-                        .map_err(|err| {
-                            anyhow!(
-                                "Failed to prune state kv shard {}: {err}",
-                                shard_pruner.shard_id(),
-                            )
+            {
+                let handle = THREAD_MANAGER.get_background_pool();
+                let shard_pruners = Arc::clone(&self.shard_pruners);
+                let join_handles: Vec<_> = (0..shard_pruners.len())
+                    .map(|i| {
+                        let shard_pruners = Arc::clone(&shard_pruners);
+                        handle.spawn_blocking(move || {
+                            shard_pruners[i]
+                                .prune(progress, current_batch_target_version)
+                                .map_err(|err| {
+                                    anyhow!(
+                                        "Failed to prune state kv shard {}: {err}",
+                                        shard_pruners[i].shard_id(),
+                                    )
+                                })
                         })
-                })
-            })?;
+                    })
+                    .collect();
+                for jh in join_handles {
+                    handle.block_on(jh).expect("background task panicked")?;
+                }
+            }
 
             progress = current_batch_target_version;
             self.record_progress(progress);
@@ -145,7 +154,7 @@ impl StateKvPruner {
             progress: AtomicVersion::new(metadata_progress),
             name,
             metadata_pruner,
-            shard_pruners,
+            shard_pruners: Arc::new(shard_pruners),
         };
 
         info!(

--- a/storage/aptosdb/src/pruner/state_merkle_pruner/mod.rs
+++ b/storage/aptosdb/src/pruner/state_merkle_pruner/mod.rs
@@ -29,7 +29,6 @@ use aptos_metrics_core::TimerHelper;
 use aptos_schemadb::{schema::KeyCodec, ReadOptions, DB};
 use aptos_storage_interface::Result;
 use aptos_types::transaction::{AtomicVersion, Version};
-use rayon::prelude::*;
 use std::{
     marker::PhantomData,
     sync::{atomic::Ordering, Arc},
@@ -44,7 +43,7 @@ pub struct StateMerklePruner<S> {
 
     metadata_pruner: StateMerkleMetadataPruner<S>,
     // Non-empty iff sharding is enabled.
-    shard_pruners: Vec<StateMerkleShardPruner<S>>,
+    shard_pruners: Arc<Vec<StateMerkleShardPruner<S>>>,
 
     _phantom: PhantomData<S>,
 }
@@ -148,7 +147,7 @@ where
             target_version: AtomicVersion::new(metadata_progress),
             progress: AtomicVersion::new(metadata_progress),
             metadata_pruner,
-            shard_pruners,
+            shard_pruners: Arc::new(shard_pruners),
             _phantom: std::marker::PhantomData,
         };
 
@@ -167,21 +166,27 @@ where
         target_version: Version,
         batch_size: usize,
     ) -> Result<()> {
-        THREAD_MANAGER
-            .get_background_pool()
-            .install(|| {
-                self.shard_pruners.par_iter().try_for_each(|shard_pruner| {
-                    shard_pruner
+        let handle = THREAD_MANAGER.get_background_pool();
+        let shard_pruners = Arc::clone(&self.shard_pruners);
+        let join_handles: Vec<_> = (0..shard_pruners.len())
+            .map(|i| {
+                let shard_pruners = Arc::clone(&shard_pruners);
+                handle.spawn_blocking(move || {
+                    shard_pruners[i]
                         .prune(current_progress, target_version, batch_size)
                         .map_err(|err| {
                             anyhow!(
                                 "Failed to prune state merkle shard {}: {err}",
-                                shard_pruner.shard_id(),
+                                shard_pruners[i].shard_id(),
                             )
                         })
                 })
             })
-            .map_err(Into::into)
+            .collect();
+        for jh in join_handles {
+            handle.block_on(jh).expect("background task panicked")?;
+        }
+        Ok(())
     }
 
     pub(in crate::pruner::state_merkle_pruner) fn get_stale_node_indices(


### PR DESCRIPTION

The `ThreadManager::get_background_pool` now returns a
`tokio::runtime::Handle` instead of `&rayon::ThreadPool`. Each strategy
creates a tokio runtime with the same number of blocking threads (32) as
the previous rayon pool, preserving `on_thread_start` hooks for nice
values and CPU pinning where applicable.

Callers are updated accordingly:
- Fire-and-forget sites use `spawn_blocking` (executor metrics).
- Parallel-and-wait sites (`install` + `par_iter` in pruners) use
  `spawn_blocking` per item with `block_on` to collect results; the
  pruner collections are wrapped in `Arc` to satisfy the `'static`
  bound.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/aptos-labs/aptos-core/pull/19384).
* #19386
* __->__ #19384