### PR TITLE
Fix MempoolMessageId ordering and improve error handling

### DIFF
--- a/mempool/src/core_mempool/transaction_store.rs
+++ b/mempool/src/core_mempool/transaction_store.rs
@@ -842,14 +842,10 @@ impl TransactionStore {
         sender_bucket: MempoolSenderBucket,
         start_end_pairs: HashMap<TimelineIndexIdentifier, (u64, u64)>,
     ) -> Vec<(SignedTransaction, u64)> {
-        self.timeline_index
-            .get(&sender_bucket)
-            .unwrap_or_else(|| {
-                panic!(
-                    "Unable to get the timeline index for the sender bucket {}",
-                    sender_bucket
-                )
-            })
+        let Some(index) = self.timeline_index.get(&sender_bucket) else {
+            return Vec::new();
+        };
+        index
             .timeline_range(start_end_pairs)
             .iter()
             .filter_map(|(account, replay_protector)| {

--- a/mempool/src/shared_mempool/types.rs
+++ b/mempool/src/shared_mempool/types.rs
@@ -408,7 +408,8 @@ impl Ord for MempoolMessageId {
                 return ordering;
             }
         }
-        Ordering::Equal
+        // If all compared elements are equal, compare by length for total ordering
+        self.0.len().cmp(&other.0.len())
     }
 }
 
@@ -454,6 +455,19 @@ mod test {
         let left = MempoolMessageId(vec![(sender, 3), (1 | sender, 3), (2, 3)]);
         let right = MempoolMessageId(vec![(2 | sender, 5), (1 | sender, 4), (2, 3)]);
         assert!(right > left);
+
+        // Test different length vectors (total ordering requirement)
+        let left = MempoolMessageId(vec![(0, 0)]);
+        let right = MempoolMessageId(vec![(0, 0), (0, 0)]);
+        assert!(left < right);
+
+        let left = MempoolMessageId(vec![(1, 2), (3, 4)]);
+        let right = MempoolMessageId(vec![(3, 4)]);
+        assert!(left > right);
+
+        let left = MempoolMessageId(vec![]);
+        let right = MempoolMessageId(vec![(0, 0)]);
+        assert!(left < right);
     }
 }
 


### PR DESCRIPTION
## Description

This PR addresses two issues in the mempool module:

1. **MempoolMessageId Ordering**: Fixed the `Ord` implementation to provide total ordering by comparing vector lengths when all elements are equal. Previously, the implementation would return `Ordering::Equal` for vectors with identical elements but different lengths, violating the total ordering requirement for `Ord`. This could cause issues with data structures like `BTreeMap` that rely on consistent ordering.

2. **TransactionStore Error Handling**: Improved error handling in `TransactionStore::get_transactions_by_timeline_range()` by replacing a panic with graceful degradation. Instead of panicking when a timeline index is not found for a sender bucket, the function now returns an empty vector, making the system more resilient to unexpected state.

## How Has This Been Tested?

- Added comprehensive unit tests for `MempoolMessageId` ordering with vectors of different lengths:
  - Test comparing vectors where left is shorter than right
  - Test comparing vectors where left is longer than right
  - Test comparing empty vector with non-empty vector
- Existing tests continue to pass, validating that the ordering change doesn't break existing behavior

## Key Areas to Review

- **MempoolMessageId::cmp()**: The fix ensures that when all compared tuple elements are equal, the vectors are ordered by length. This provides a stable, total ordering required by the `Ord` trait.
- **TransactionStore error handling**: Changed from panic to returning empty results. Reviewers should verify this graceful degradation is the appropriate behavior for missing timeline indices in the context of transaction retrieval.

## Type of Change

- [x] Bug fix
- [x] Refactoring

## Which Components or Systems Does This Change Impact?

- [x] Validator Node
- [x] Full Node (API, Indexer, etc.)

## Checklist

- [x] I have read and followed the CONTRIBUTING doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I tested both happy and unhappy path of the functionality

https://claude.ai/code/session_015icN49e7S8TWrtMRkoe2oP

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes ordering semantics for `MempoolMessageId` used in `BTreeMap`/`BTreeSet` and alters missing-timeline behavior from panic to empty results, which could affect mempool broadcast/ack tracking and transaction fetch behavior in edge cases.
> 
> **Overview**
> Fixes `MempoolMessageId`’s `Ord` implementation to provide a *total ordering* by comparing vector lengths when all compared pairs match, preventing distinct IDs of different lengths from collapsing to `Equal` in `BTreeMap`/`BTreeSet` keys.
> 
> Updates `TransactionStore::timeline_range()` to **gracefully handle** missing `sender_bucket` timeline indexes by returning an empty result instead of panicking, improving resilience to unexpected state. Adds unit tests covering `MempoolMessageId` comparisons for differing vector lengths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2a2a6f53b7a31974f2930e2cee14d3ba440175e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->