### PR TITLE
[storage] Replace rayon kv_reader pool with tokio runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1810,6 +1810,7 @@ dependencies = [
  "num_cpus",
  "once_cell",
  "rayon",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4345,6 +4345,7 @@ dependencies = [
  "rayon",
  "serde",
  "thiserror 1.0.69",
+ "tokio",
 ]
 
 [[package]]

--- a/execution/executor/src/workflow/do_get_execution_output.rs
+++ b/execution/executor/src/workflow/do_get_execution_output.rs
@@ -89,16 +89,18 @@ impl DoGetExecutionOutput {
         };
 
         let ret = out.clone();
-        THREAD_MANAGER.get_background_pool().spawn(move || {
-            let _timer = OTHER_TIMERS.timer_with(&["async_update_counters__by_execution"]);
-            for x in [&out.to_commit, &out.to_retry, &out.to_discard] {
-                metrics::update_counters_for_processed_chunk(
-                    &x.transactions,
-                    &x.transaction_outputs,
-                    "execution",
-                )
-            }
-        });
+        let _ = THREAD_MANAGER
+            .get_background_pool()
+            .spawn_blocking(move || {
+                let _timer = OTHER_TIMERS.timer_with(&["async_update_counters__by_execution"]);
+                for x in [&out.to_commit, &out.to_retry, &out.to_discard] {
+                    metrics::update_counters_for_processed_chunk(
+                        &x.transactions,
+                        &x.transaction_outputs,
+                        "execution",
+                    )
+                }
+            });
 
         Ok(ret)
     }
@@ -241,14 +243,16 @@ impl DoGetExecutionOutput {
         )?;
 
         let ret = out.clone();
-        THREAD_MANAGER.get_background_pool().spawn(move || {
-            let _timer = OTHER_TIMERS.timer_with(&["async_update_counters__by_output"]);
-            metrics::update_counters_for_processed_chunk(
-                &out.to_commit.transactions,
-                &out.to_commit.transaction_outputs,
-                "output",
-            )
-        });
+        let _ = THREAD_MANAGER
+            .get_background_pool()
+            .spawn_blocking(move || {
+                let _timer = OTHER_TIMERS.timer_with(&["async_update_counters__by_output"]);
+                metrics::update_counters_for_processed_chunk(
+                    &out.to_commit.transactions,
+                    &out.to_commit.transaction_outputs,
+                    "output",
+                )
+            });
 
         Ok(ret)
     }

--- a/experimental/runtimes/Cargo.toml
+++ b/experimental/runtimes/Cargo.toml
@@ -19,3 +19,4 @@ libc = { workspace = true }
 num_cpus = { workspace = true }
 once_cell = { workspace = true }
 rayon = { workspace = true }
+tokio = { workspace = true }

--- a/experimental/runtimes/src/strategies/default.rs
+++ b/experimental/runtimes/src/strategies/default.rs
@@ -5,12 +5,13 @@ use crate::thread_manager::{ThreadManager, MAX_THREAD_POOL_SIZE};
 use aptos_runtimes::spawn_rayon_thread_pool;
 use rayon::ThreadPool;
 use std::cmp::min;
+use tokio::runtime::{Handle, Runtime};
 
 pub struct DefaultThreadManager {
     exe_threads: ThreadPool,
     non_exe_threads: ThreadPool,
     io_threads: ThreadPool,
-    background_threads: ThreadPool,
+    background_runtime: Runtime,
 }
 
 impl DefaultThreadManager {
@@ -26,13 +27,17 @@ impl DefaultThreadManager {
             Some(min(num_cpus::get(), MAX_THREAD_POOL_SIZE)),
         );
         let io_threads = spawn_rayon_thread_pool("io".into(), Some(64));
-        let background_threads =
-            spawn_rayon_thread_pool("background".into(), Some(MAX_THREAD_POOL_SIZE));
+        let background_runtime = tokio::runtime::Builder::new_current_thread()
+            .max_blocking_threads(MAX_THREAD_POOL_SIZE)
+            .thread_name("bg-pool")
+            .enable_all()
+            .build()
+            .expect("Failed to create background tokio runtime");
         Self {
             exe_threads,
             non_exe_threads,
             io_threads,
-            background_threads,
+            background_runtime,
         }
     }
 }
@@ -54,7 +59,7 @@ impl<'a> ThreadManager<'a> for DefaultThreadManager {
         &self.io_threads
     }
 
-    fn get_background_pool(&'a self) -> &'a ThreadPool {
-        &self.background_threads
+    fn get_background_pool(&'a self) -> Handle {
+        self.background_runtime.handle().clone()
     }
 }

--- a/experimental/runtimes/src/strategies/pin_exe_threads_to_cores.rs
+++ b/experimental/runtimes/src/strategies/pin_exe_threads_to_cores.rs
@@ -8,13 +8,14 @@ use crate::{
 use aptos_runtimes::spawn_rayon_thread_pool_with_start_hook;
 use libc::CPU_SET;
 use rayon::ThreadPool;
+use tokio::runtime::{Handle, Runtime};
 
 pub(crate) struct PinExeThreadsToCoresThreadManager {
     exe_threads: ThreadPool,
     non_exe_threads: ThreadPool,
     high_pri_io_threads: ThreadPool,
     io_threads: ThreadPool,
-    background_threads: ThreadPool,
+    background_runtime: Runtime,
 }
 
 impl PinExeThreadsToCoresThreadManager {
@@ -55,18 +56,20 @@ impl PinExeThreadsToCoresThreadManager {
             pin_cpu_set(non_exe_cpu_set),
         );
 
-        let background_threads = spawn_rayon_thread_pool_with_start_hook(
-            "background".into(),
-            Some(32),
-            pin_cpu_set(non_exe_cpu_set),
-        );
+        let background_runtime = tokio::runtime::Builder::new_current_thread()
+            .max_blocking_threads(32)
+            .thread_name("bg-pool")
+            .on_thread_start(pin_cpu_set(non_exe_cpu_set))
+            .enable_all()
+            .build()
+            .expect("Failed to create background tokio runtime");
 
         Self {
             exe_threads,
             non_exe_threads,
             high_pri_io_threads,
             io_threads,
-            background_threads,
+            background_runtime,
         }
     }
 }
@@ -88,7 +91,7 @@ impl<'a> ThreadManager<'a> for PinExeThreadsToCoresThreadManager {
         &self.high_pri_io_threads
     }
 
-    fn get_background_pool(&'a self) -> &'a ThreadPool {
-        &self.background_threads
+    fn get_background_pool(&'a self) -> Handle {
+        self.background_runtime.handle().clone()
     }
 }

--- a/experimental/runtimes/src/strategies/threads_priority.rs
+++ b/experimental/runtimes/src/strategies/threads_priority.rs
@@ -4,13 +4,14 @@
 use crate::{common::set_thread_nice_value, thread_manager::ThreadManager};
 use aptos_runtimes::spawn_rayon_thread_pool_with_start_hook;
 use rayon::ThreadPool;
+use tokio::runtime::{Handle, Runtime};
 
 pub(crate) struct ThreadsPriorityThreadManager {
     exe_threads: ThreadPool,
     non_exe_threads: ThreadPool,
     high_pri_io_threads: ThreadPool,
     io_threads: ThreadPool,
-    background_threads: ThreadPool,
+    background_runtime: Runtime,
 }
 
 impl ThreadsPriorityThreadManager {
@@ -40,18 +41,20 @@ impl ThreadsPriorityThreadManager {
             set_thread_nice_value(1),
         );
 
-        let background_threads = spawn_rayon_thread_pool_with_start_hook(
-            "background".into(),
-            Some(32),
-            set_thread_nice_value(20),
-        );
+        let background_runtime = tokio::runtime::Builder::new_current_thread()
+            .max_blocking_threads(32)
+            .thread_name("bg-pool")
+            .on_thread_start(set_thread_nice_value(20))
+            .enable_all()
+            .build()
+            .expect("Failed to create background tokio runtime");
 
         Self {
             exe_threads,
             non_exe_threads,
             high_pri_io_threads,
             io_threads,
-            background_threads,
+            background_runtime,
         }
     }
 }
@@ -73,7 +76,7 @@ impl<'a> ThreadManager<'a> for ThreadsPriorityThreadManager {
         &self.high_pri_io_threads
     }
 
-    fn get_background_pool(&'a self) -> &'a ThreadPool {
-        &self.background_threads
+    fn get_background_pool(&'a self) -> Handle {
+        self.background_runtime.handle().clone()
     }
 }

--- a/experimental/runtimes/src/thread_manager.rs
+++ b/experimental/runtimes/src/thread_manager.rs
@@ -10,6 +10,7 @@ use crate::strategies::{
 use once_cell::sync::{Lazy, OnceCell};
 use rayon::ThreadPool;
 use std::cmp::max;
+use tokio::runtime::Handle;
 
 pub static MAX_THREAD_POOL_SIZE: usize = 32;
 
@@ -33,7 +34,7 @@ pub trait ThreadManager<'a>: Send + Sync {
     fn get_non_exe_cpu_pool(&'a self) -> &'a ThreadPool;
     fn get_high_pri_io_pool(&'a self) -> &'a ThreadPool;
     fn get_io_pool(&'a self) -> &'a ThreadPool;
-    fn get_background_pool(&'a self) -> &'a ThreadPool;
+    fn get_background_pool(&'a self) -> Handle;
 }
 
 pub struct ThreadManagerBuilder;

--- a/storage/aptosdb/src/pruner/ledger_pruner/mod.rs
+++ b/storage/aptosdb/src/pruner/ledger_pruner/mod.rs
@@ -34,7 +34,6 @@ use aptos_experimental_runtimes::thread_manager::THREAD_MANAGER;
 use aptos_logger::info;
 use aptos_storage_interface::Result;
 use aptos_types::transaction::{AtomicVersion, Version};
-use rayon::prelude::*;
 use std::{
     cmp::min,
     sync::{atomic::Ordering, Arc},
@@ -51,7 +50,7 @@ pub(crate) struct LedgerPruner {
 
     ledger_metadata_pruner: Box<LedgerMetadataPruner>,
 
-    sub_pruners: Vec<Box<dyn DBSubPruner + Send + Sync>>,
+    sub_pruners: Arc<Vec<Box<dyn DBSubPruner + Send + Sync>>>,
 }
 
 impl DBPruner for LedgerPruner {
@@ -75,13 +74,25 @@ impl DBPruner for LedgerPruner {
             self.ledger_metadata_pruner
                 .prune(progress, current_batch_target_version)?;
 
-            THREAD_MANAGER.get_background_pool().install(|| {
-                self.sub_pruners.par_iter().try_for_each(|sub_pruner| {
-                    sub_pruner
-                        .prune(progress, current_batch_target_version)
-                        .map_err(|err| anyhow!("{} failed to prune: {err}", sub_pruner.name()))
-                })
-            })?;
+            {
+                let handle = THREAD_MANAGER.get_background_pool();
+                let sub_pruners = Arc::clone(&self.sub_pruners);
+                let join_handles: Vec<_> = (0..sub_pruners.len())
+                    .map(|i| {
+                        let sub_pruners = Arc::clone(&sub_pruners);
+                        handle.spawn_blocking(move || {
+                            sub_pruners[i]
+                                .prune(progress, current_batch_target_version)
+                                .map_err(|err| {
+                                    anyhow!("{} failed to prune: {err}", sub_pruners[i].name())
+                                })
+                        })
+                    })
+                    .collect();
+                for jh in join_handles {
+                    handle.block_on(jh).expect("background task panicked")?;
+                }
+            }
 
             progress = current_batch_target_version;
             self.record_progress(progress);
@@ -173,7 +184,7 @@ impl LedgerPruner {
             target_version: AtomicVersion::new(metadata_progress),
             progress: AtomicVersion::new(metadata_progress),
             ledger_metadata_pruner,
-            sub_pruners: vec![
+            sub_pruners: Arc::new(vec![
                 event_store_pruner,
                 persisted_auxiliary_info_pruner,
                 transaction_accumulator_pruner,
@@ -181,7 +192,7 @@ impl LedgerPruner {
                 transaction_info_pruner,
                 transaction_pruner,
                 write_set_pruner,
-            ],
+            ]),
         };
 
         info!(

--- a/storage/aptosdb/src/pruner/state_kv_pruner/mod.rs
+++ b/storage/aptosdb/src/pruner/state_kv_pruner/mod.rs
@@ -22,7 +22,6 @@ use aptos_logger::info;
 use aptos_metrics_core::TimerHelper;
 use aptos_storage_interface::Result;
 use aptos_types::transaction::{AtomicVersion, Version};
-use rayon::prelude::*;
 use std::{
     cmp::min,
     sync::{atomic::Ordering, Arc},
@@ -36,7 +35,7 @@ pub(crate) struct StateKvPruner {
     name: &'static str,
 
     metadata_pruner: StateKvMetadataPruner,
-    shard_pruners: Vec<StateKvShardPruner>,
+    shard_pruners: Arc<Vec<StateKvShardPruner>>,
 }
 
 impl DBPruner for StateKvPruner {
@@ -62,18 +61,28 @@ impl DBPruner for StateKvPruner {
             );
             self.metadata_pruner.prune(current_batch_target_version)?;
 
-            THREAD_MANAGER.get_background_pool().install(|| {
-                self.shard_pruners.par_iter().try_for_each(|shard_pruner| {
-                    shard_pruner
-                        .prune(progress, current_batch_target_version)
-                        .map_err(|err| {
-                            anyhow!(
-                                "Failed to prune state kv shard {}: {err}",
-                                shard_pruner.shard_id(),
-                            )
+            {
+                let handle = THREAD_MANAGER.get_background_pool();
+                let shard_pruners = Arc::clone(&self.shard_pruners);
+                let join_handles: Vec<_> = (0..shard_pruners.len())
+                    .map(|i| {
+                        let shard_pruners = Arc::clone(&shard_pruners);
+                        handle.spawn_blocking(move || {
+                            shard_pruners[i]
+                                .prune(progress, current_batch_target_version)
+                                .map_err(|err| {
+                                    anyhow!(
+                                        "Failed to prune state kv shard {}: {err}",
+                                        shard_pruners[i].shard_id(),
+                                    )
+                                })
                         })
-                })
-            })?;
+                    })
+                    .collect();
+                for jh in join_handles {
+                    handle.block_on(jh).expect("background task panicked")?;
+                }
+            }
 
             progress = current_batch_target_version;
             self.record_progress(progress);
@@ -145,7 +154,7 @@ impl StateKvPruner {
             progress: AtomicVersion::new(metadata_progress),
             name,
             metadata_pruner,
-            shard_pruners,
+            shard_pruners: Arc::new(shard_pruners),
         };
 
         info!(

--- a/storage/aptosdb/src/pruner/state_merkle_pruner/mod.rs
+++ b/storage/aptosdb/src/pruner/state_merkle_pruner/mod.rs
@@ -29,7 +29,6 @@ use aptos_metrics_core::TimerHelper;
 use aptos_schemadb::{schema::KeyCodec, ReadOptions, DB};
 use aptos_storage_interface::Result;
 use aptos_types::transaction::{AtomicVersion, Version};
-use rayon::prelude::*;
 use std::{
     marker::PhantomData,
     sync::{atomic::Ordering, Arc},
@@ -44,7 +43,7 @@ pub struct StateMerklePruner<S> {
 
     metadata_pruner: StateMerkleMetadataPruner<S>,
     // Non-empty iff sharding is enabled.
-    shard_pruners: Vec<StateMerkleShardPruner<S>>,
+    shard_pruners: Arc<Vec<StateMerkleShardPruner<S>>>,
 
     _phantom: PhantomData<S>,
 }
@@ -148,7 +147,7 @@ where
             target_version: AtomicVersion::new(metadata_progress),
             progress: AtomicVersion::new(metadata_progress),
             metadata_pruner,
-            shard_pruners,
+            shard_pruners: Arc::new(shard_pruners),
             _phantom: std::marker::PhantomData,
         };
 
@@ -167,21 +166,27 @@ where
         target_version: Version,
         batch_size: usize,
     ) -> Result<()> {
-        THREAD_MANAGER
-            .get_background_pool()
-            .install(|| {
-                self.shard_pruners.par_iter().try_for_each(|shard_pruner| {
-                    shard_pruner
+        let handle = THREAD_MANAGER.get_background_pool();
+        let shard_pruners = Arc::clone(&self.shard_pruners);
+        let join_handles: Vec<_> = (0..shard_pruners.len())
+            .map(|i| {
+                let shard_pruners = Arc::clone(&shard_pruners);
+                handle.spawn_blocking(move || {
+                    shard_pruners[i]
                         .prune(current_progress, target_version, batch_size)
                         .map_err(|err| {
                             anyhow!(
                                 "Failed to prune state merkle shard {}: {err}",
-                                shard_pruner.shard_id(),
+                                shard_pruners[i].shard_id(),
                             )
                         })
                 })
             })
-            .map_err(Into::into)
+            .collect();
+        for jh in join_handles {
+            handle.block_on(jh).expect("background task panicked")?;
+        }
+        Ok(())
     }
 
     pub(in crate::pruner::state_merkle_pruner) fn get_stale_node_indices(

--- a/storage/storage-interface/Cargo.toml
+++ b/storage/storage-interface/Cargo.toml
@@ -35,6 +35,7 @@ rand = { workspace = true }
 rayon = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }
+tokio = { workspace = true }
 
 [dev-dependencies]
 aptos-types = { workspace = true, features = ["fuzzing"] }

--- a/storage/storage-interface/src/state_store/state_view/cached_state_view.rs
+++ b/storage/storage-interface/src/state_store/state_view/cached_state_view.rs
@@ -6,7 +6,7 @@ use crate::{
     state_store::{
         state::State,
         state_delta::StateDelta,
-        state_update_refs::{BatchedStateUpdateRefs, StateUpdateRefs},
+        state_update_refs::StateUpdateRefs,
         state_view::{
             db_state_view::DbStateView,
             hot_state_view::{EmptyHotState, HotStateView},
@@ -29,7 +29,6 @@ use core::fmt;
 use dashmap::{mapref::entry::Entry, DashMap};
 use once_cell::sync::Lazy;
 use parking_lot::RwLock;
-use rayon::prelude::*;
 use std::{
     collections::HashMap,
     fmt::{Debug, Formatter},
@@ -38,10 +37,11 @@ use std::{
 
 pub type StateCacheShard = DashMap<StateKey, StateSlot>;
 
-static IO_POOL: Lazy<rayon::ThreadPool> = Lazy::new(|| {
-    rayon::ThreadPoolBuilder::new()
-        .num_threads(32)
-        .thread_name(|index| format!("kv_reader_{}", index))
+static IO_POOL: Lazy<tokio::runtime::Runtime> = Lazy::new(|| {
+    tokio::runtime::Builder::new_current_thread()
+        .max_blocking_threads(32)
+        .thread_name("kv_reader")
+        .enable_all()
         .build()
         .unwrap()
 });
@@ -102,7 +102,7 @@ pub struct CachedStateView {
     id: StateViewId,
 
     /// The in-memory state on top of known persisted state.
-    speculative: StateDelta,
+    speculative: Arc<StateDelta>,
 
     /// Persisted hot state. To be fetched if a key isn't in `speculative`.
     hot: Arc<dyn HotStateView>,
@@ -112,7 +112,7 @@ pub struct CachedStateView {
     cold: Arc<dyn DbReader>,
 
     /// State values (with update versions) read across the lifetime of the state view.
-    memorized: ShardedStateCache,
+    memorized: Arc<ShardedStateCache>,
 }
 
 impl Debug for CachedStateView {
@@ -122,6 +122,10 @@ impl Debug for CachedStateView {
 }
 
 impl CachedStateView {
+    /// Minimum number of keys per blocking task. Shards with more keys are split
+    /// into chunks of this size, similar to rayon's `with_min_len`.
+    const MIN_KEYS_PER_TASK: usize = 16;
+
     /// Constructs a [`CachedStateView`] with persistent state view in the DB and the in-memory
     /// speculative state represented by `speculative_state`. The persistent state view is the
     /// latest one preceding `next_version`
@@ -157,10 +161,10 @@ impl CachedStateView {
 
         Self {
             id,
-            speculative: state.into_delta(persisted_state),
+            speculative: Arc::new(state.into_delta(persisted_state)),
             hot: hot_state,
             cold: reader,
-            memorized: ShardedStateCache::new_empty(version),
+            memorized: Arc::new(ShardedStateCache::new_empty(version)),
         }
     }
 
@@ -177,55 +181,68 @@ impl CachedStateView {
         )
     }
 
+    /// Cheap clone via Arc reference counting, for sharing across blocking tasks.
+    fn cheap_clone(&self) -> Self {
+        Self {
+            id: self.id,
+            speculative: Arc::clone(&self.speculative),
+            hot: Arc::clone(&self.hot),
+            cold: Arc::clone(&self.cold),
+            memorized: Arc::clone(&self.memorized),
+        }
+    }
+
     pub fn prime_cache(&self, updates: &StateUpdateRefs, policy: PrimingPolicy) -> Result<()> {
         let _timer = TIMER.timer_with(&["prime_state_cache"]);
+        let handle = IO_POOL.handle();
+        let mut join_handles = Vec::new();
 
-        IO_POOL.install(|| {
-            if let Some(updates) = updates.for_last_checkpoint_batched() {
-                self.prime_cache_for_batched_updates(updates, policy)?;
+        for batch in [
+            updates.for_last_checkpoint_batched(),
+            updates.for_latest_batched(),
+        ] {
+            if let Some(batch) = batch {
+                for shard in &batch.shards {
+                    let keys: Arc<Vec<StateKey>> = Arc::new(
+                        shard
+                            .iter()
+                            .filter(|(_, u)| {
+                                !matches!(
+                                    policy,
+                                    PrimingPolicy::MakeHotOnly if u.state_op.is_value_write_op()
+                                )
+                            })
+                            .map(|(k, _)| (*k).clone())
+                            .collect(),
+                    );
+                    if keys.is_empty() {
+                        continue;
+                    }
+                    for chunk_start in (0..keys.len()).step_by(Self::MIN_KEYS_PER_TASK) {
+                        let chunk_end = (chunk_start + Self::MIN_KEYS_PER_TASK).min(keys.len());
+                        let keys = Arc::clone(&keys);
+                        let view = self.cheap_clone();
+                        join_handles.push(handle.spawn_blocking(move || {
+                            for key in &keys[chunk_start..chunk_end] {
+                                view.get_state_value(key).expect("Must succeed.");
+                            }
+                        }));
+                    }
+                }
             }
-            if let Some(updates) = updates.for_latest_batched() {
-                self.prime_cache_for_batched_updates(updates, policy)?;
-            }
-            Ok(())
-        })
-    }
+        }
 
-    fn prime_cache_for_batched_updates(
-        &self,
-        updates: &BatchedStateUpdateRefs,
-        policy: PrimingPolicy,
-    ) -> Result<()> {
-        updates.shards.par_iter().try_for_each(|shard| {
-            self.prime_cache_for_keys(
-                shard
-                    .iter()
-                    .filter_map(|(k, u)| match policy {
-                        PrimingPolicy::MakeHotOnly if u.state_op.is_value_write_op() => None,
-                        _ => Some(k),
-                    })
-                    .cloned(),
-            )
-        })
-    }
+        for jh in join_handles {
+            handle.block_on(jh).expect("kv_reader task panicked");
+        }
 
-    fn prime_cache_for_keys<'a, T: IntoIterator<Item = &'a StateKey> + Send>(
-        &self,
-        keys: T,
-    ) -> Result<()> {
-        rayon::scope(|s| {
-            keys.into_iter().for_each(|key| {
-                s.spawn(move |_| {
-                    self.get_state_value(key).expect("Must succeed.");
-                })
-            });
-        });
         Ok(())
     }
 
     /// Consumes `Self` and returns the state and all the memorized state reads.
     pub fn into_memorized_reads(self) -> ShardedStateCache {
-        self.memorized
+        Arc::into_inner(self.memorized)
+            .expect("CachedStateView should be the sole owner of memorized reads")
     }
 
     fn base_version(&self) -> Option<Version> {


### PR DESCRIPTION

Same motivation as the background pool change: rayon's work-stealing
adds unnecessary overhead for I/O-bound cache priming. The static
`IO_POOL` in `cached_state_view.rs` is now a `tokio::runtime::Runtime`
(`new_current_thread` + `max_blocking_threads(32)`), and `prime_cache`
spawns blocking tasks instead of using `par_iter`/`rayon::scope`.

To satisfy `spawn_blocking`'s `'static` requirement, `speculative` and
`memorized` fields are wrapped in `Arc` (cheap clone via refcount, same
pattern as the pruner `shard_pruners` change). Each shard's keys are
chunked with a minimum of 16 keys per task to balance parallelism
against task overhead.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/aptos-labs/aptos-core/pull/19386).
* __->__ #19386
* #19384