### PR TITLE
[consensus] Relax need_sync_for_ledger_info to reduce unnecessary state sync

### DIFF
--- a/consensus/src/block_storage/block_store_test.rs
+++ b/consensus/src/block_storage/block_store_test.rs
@@ -472,15 +472,21 @@ async fn test_need_sync_for_ledger_info() {
     // it's larger and the block doesn't exist in the tree
     let ordered_round_too_far = block_store.ordered_root().round() + 1;
     let ordered_too_far = create_ledger_info(ordered_round_too_far);
-    assert!(block_store.need_sync_for_ledger_info(&ordered_too_far));
+    assert!(block_store
+        .need_sync_for_ledger_info(&ordered_too_far)
+        .is_some());
 
     let committed_round_too_far =
         block_store.commit_root().round() + 30.max(block_store.vote_back_pressure_limit * 2) + 1;
     let committed_too_far = create_ledger_info(committed_round_too_far);
-    assert!(block_store.need_sync_for_ledger_info(&committed_too_far));
+    assert!(block_store
+        .need_sync_for_ledger_info(&committed_too_far)
+        .is_some());
 
     let round_not_too_far =
         block_store.commit_root().round() + block_store.vote_back_pressure_limit + 1;
     let not_too_far = create_ledger_info(round_not_too_far);
-    assert!(!block_store.need_sync_for_ledger_info(&not_too_far));
+    assert!(block_store
+        .need_sync_for_ledger_info(&not_too_far)
+        .is_none());
 }

--- a/consensus/src/block_storage/pending_blocks.rs
+++ b/consensus/src/block_storage/pending_blocks.rs
@@ -119,6 +119,16 @@ impl PendingBlocks {
         }
     }
 
+    /// Check if a block with the given hash exists in the pending buffer.
+    pub fn block_exists_by_id(&self, block_id: &HashValue) -> bool {
+        self.blocks_by_hash.contains_key(block_id)
+    }
+
+    /// Check if any block (regular or opt) is pending at the given round.
+    pub fn has_block_at_round(&self, round: Round) -> bool {
+        self.blocks_by_round.contains_key(&round) || self.opt_blocks_by_round.contains_key(&round)
+    }
+
     pub fn gc(&mut self, round: Round) {
         let mut to_remove = vec![];
         for (r, _) in self.blocks_by_round.range(..=round) {

--- a/consensus/src/block_storage/sync_manager.rs
+++ b/consensus/src/block_storage/sync_manager.rs
@@ -8,7 +8,7 @@ use crate::{
         BlockReader, BlockStore,
     },
     counters::{
-        BLOCKS_FETCHED_FROM_NETWORK_IN_BLOCK_RETRIEVER,
+        self, BLOCKS_FETCHED_FROM_NETWORK_IN_BLOCK_RETRIEVER,
         BLOCKS_FETCHED_FROM_NETWORK_WHILE_FAST_FORWARD_SYNC,
         BLOCKS_FETCHED_FROM_NETWORK_WHILE_INSERTING_QUORUM_CERT, LATE_EXECUTION_WITH_ORDER_VOTE_QC,
         SUCCESSFUL_EXECUTED_WITH_ORDER_VOTE_QC, SUCCESSFUL_EXECUTED_WITH_REGULAR_QC,
@@ -50,6 +50,27 @@ use rand::{prelude::*, Rng};
 use std::{clone::Clone, cmp::min, fmt::Display, sync::Arc, time::Duration};
 use tokio::{time, time::timeout};
 
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+/// Why state sync was triggered in need_sync_for_ledger_info.
+pub enum StateSyncTriggerReason {
+    /// The committed block doesn't exist in the block tree
+    BlockNotExist,
+    /// The commit round gap exceeds the threshold
+    CommitGapTooLarge,
+    /// Both conditions are true
+    BlockNotExistAndCommitGap,
+}
+
+impl StateSyncTriggerReason {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            StateSyncTriggerReason::BlockNotExist => "block_not_exist",
+            StateSyncTriggerReason::CommitGapTooLarge => "commit_gap",
+            StateSyncTriggerReason::BlockNotExistAndCommitGap => "block_not_exist_and_commit_gap",
+        }
+    }
+}
+
 #[derive(Debug, PartialEq, Eq)]
 /// Whether we need to do block retrieval if we want to insert a Quorum Cert.
 pub enum NeedFetchResult {
@@ -61,34 +82,102 @@ pub enum NeedFetchResult {
 
 impl BlockStore {
     /// Check if we're far away from this ledger info and need to sync.
-    /// This ensures that the block referred by the ledger info is not in buffer manager.
-    pub fn need_sync_for_ledger_info(&self, li: &LedgerInfoWithSignatures) -> bool {
+    /// Returns the trigger reason if sync is needed, or None if not.
+    pub fn need_sync_for_ledger_info(
+        &self,
+        li: &LedgerInfoWithSignatures,
+    ) -> Option<StateSyncTriggerReason> {
         const MAX_PRECOMMIT_GAP: u64 = 200;
-        let block_not_exist = self.ordered_root().round() < li.commit_info().round()
-            && !self.block_exists(li.commit_info().id());
+        // Minimum gap between ordered_root and commit_round to trigger state sync
+        // via the block_not_exist path. Below this threshold, the block is likely
+        // in-flight from an optimistic proposal and will arrive shortly.
+        const MIN_ORDERED_ROUND_GAP_FOR_SYNC: u64 = 5;
+
+        let ordered_root_round = self.ordered_root().round();
+        let commit_round = li.commit_info().round();
+        let commit_block_id = li.commit_info().id();
+
+        let block_not_in_tree =
+            ordered_root_round < commit_round && !self.block_exists(commit_block_id);
+
+        // Before concluding the block is missing, check the pending_blocks buffer.
+        // The block may have been received (via opt proposal) but not yet inserted
+        // into the block tree. Also skip sync for very small gaps — the block is
+        // likely in-flight and will arrive within the next few hundred ms.
+        let block_not_exist = if block_not_in_tree {
+            let gap = commit_round.saturating_sub(ordered_root_round);
+            let block_in_pending = {
+                let pending = self.pending_blocks.lock();
+                pending.block_exists_by_id(&commit_block_id)
+                    || pending.has_block_at_round(commit_round)
+            };
+            if block_in_pending {
+                counters::NEED_SYNC_FOR_LEDGER_INFO
+                    .with_label_values(&["skipped_in_pending"])
+                    .inc();
+                false
+            } else if gap <= MIN_ORDERED_ROUND_GAP_FOR_SYNC {
+                counters::NEED_SYNC_FOR_LEDGER_INFO
+                    .with_label_values(&["skipped_small_gap"])
+                    .inc();
+                false
+            } else {
+                counters::NEED_SYNC_FOR_LEDGER_INFO
+                    .with_label_values(&["triggered_block_not_exist"])
+                    .inc();
+                true
+            }
+        } else {
+            false
+        };
         // TODO move min gap to fallback (30) to config, and if configurable make sure the value is
         // larger than buffer manager MAX_BACKLOG (20)
         let max_commit_gap = 30.max(2 * self.vote_back_pressure_limit);
-        let min_commit_round = li.commit_info().round().saturating_sub(max_commit_gap);
+        let min_commit_round = commit_round.saturating_sub(max_commit_gap);
         let current_commit_round = self.commit_root().round();
 
         if let Some(pre_commit_status) = self.pre_commit_status() {
             let mut status_guard = pre_commit_status.lock();
-            if block_not_exist || status_guard.round() < min_commit_round {
+            let commit_gap = status_guard.round() < min_commit_round;
+            if block_not_exist || commit_gap {
+                if !block_not_exist && commit_gap {
+                    counters::NEED_SYNC_FOR_LEDGER_INFO
+                        .with_label_values(&["triggered_commit_gap"])
+                        .inc();
+                }
                 // pause the pre_commit so that pre_commit task doesn't over-commit
                 // it can still commit if it receives the LI previously forwarded,
                 // but it won't exceed the LI here
                 // it'll resume after state sync is done
                 status_guard.pause();
-                true
+                Some(Self::sync_trigger_reason(block_not_exist, commit_gap))
             } else {
                 if current_commit_round + MAX_PRECOMMIT_GAP < status_guard.round() {
                     status_guard.pause();
                 }
-                false
+                None
             }
         } else {
-            block_not_exist || current_commit_round < min_commit_round
+            let commit_gap = current_commit_round < min_commit_round;
+            if !block_not_exist && commit_gap {
+                counters::NEED_SYNC_FOR_LEDGER_INFO
+                    .with_label_values(&["triggered_commit_gap"])
+                    .inc();
+            }
+            if block_not_exist || commit_gap {
+                Some(Self::sync_trigger_reason(block_not_exist, commit_gap))
+            } else {
+                None
+            }
+        }
+    }
+
+    fn sync_trigger_reason(block_not_exist: bool, commit_gap: bool) -> StateSyncTriggerReason {
+        match (block_not_exist, commit_gap) {
+            (true, true) => StateSyncTriggerReason::BlockNotExistAndCommitGap,
+            (true, false) => StateSyncTriggerReason::BlockNotExist,
+            (false, true) => StateSyncTriggerReason::CommitGapTooLarge,
+            (false, false) => unreachable!("called only when block_not_exist || commit_gap"),
         }
     }
 
@@ -117,6 +206,7 @@ impl BlockStore {
         &self,
         sync_info: &SyncInfo,
         mut retriever: BlockRetriever,
+        source: &str,
     ) -> anyhow::Result<()> {
         // When the local ordered round is very old than the received sync_info, this function will
         // (1) resets the block store with highest commit cert = sync_info.highest_quorum_cert()
@@ -128,6 +218,7 @@ impl BlockStore {
             sync_info.highest_quorum_cert().clone(),
             sync_info.highest_commit_cert().clone(),
             &mut retriever,
+            source,
         )
         .await?;
 
@@ -281,10 +372,31 @@ impl BlockStore {
         highest_quorum_cert: QuorumCert,
         highest_commit_cert: WrappedLedgerInfo,
         retriever: &mut BlockRetriever,
+        source: &str,
     ) -> anyhow::Result<()> {
-        if !self.need_sync_for_ledger_info(highest_commit_cert.ledger_info()) {
-            return Ok(());
-        }
+        let reason = match self.need_sync_for_ledger_info(highest_commit_cert.ledger_info()) {
+            Some(reason) => reason,
+            None => return Ok(()),
+        };
+
+        let ordered_root_round = self.ordered_root().round();
+        let commit_round = highest_commit_cert.ledger_info().commit_info().round();
+        let gap = commit_round.saturating_sub(ordered_root_round);
+
+        counters::STATE_SYNC_TRIGGER
+            .with_label_values(&[reason.as_str(), source])
+            .inc();
+        counters::STATE_SYNC_TRIGGER_GAP.observe(gap as f64);
+        info!(
+            LogSchema::new(LogEvent::StateSyncTrigger),
+            reason = reason.as_str(),
+            source = source,
+            ordered_root_round = ordered_root_round,
+            commit_round = commit_round,
+            current_commit_round = self.commit_root().round(),
+            gap = gap,
+            commit_block_id = highest_commit_cert.ledger_info().commit_info().id(),
+        );
 
         if let Some(pre_commit_status) = self.pre_commit_status() {
             defer! {
@@ -306,9 +418,10 @@ impl BlockStore {
         .await?
         .take();
         info!(
-            LogSchema::new(LogEvent::CommitViaSync).round(self.ordered_root().round()),
+            LogSchema::new(LogEvent::CommitViaSync).round(ordered_root_round),
             committed_round = root.commit_root_block.round(),
             block_id = root.commit_root_block.id(),
+            source = source,
         );
         self.rebuild(root, root_metadata, blocks, quorum_certs)
             .await;

--- a/consensus/src/counters.rs
+++ b/consensus/src/counters.rs
@@ -717,6 +717,15 @@ pub static SUCCESSFUL_EXECUTED_WITH_REGULAR_QC: Lazy<IntCounter> = Lazy::new(|| 
     .unwrap()
 });
 
+pub static NEED_SYNC_FOR_LEDGER_INFO: Lazy<IntCounterVec> = Lazy::new(|| {
+    register_int_counter_vec!(
+        "aptos_consensus_need_sync_for_ledger_info",
+        "Count of need_sync_for_ledger_info decisions",
+        &["result"]
+    )
+    .unwrap()
+});
+
 pub static SYNC_TO_HIGHEST_QC: Lazy<IntCounter> = Lazy::new(|| {
     register_int_counter!(
         "aptos_consensus_sync_to_highest_qc",
@@ -806,6 +815,26 @@ pub static BLOCKS_FETCHED_FROM_NETWORK_WHILE_FAST_FORWARD_SYNC: Lazy<IntCounter>
         )
         .unwrap()
     });
+
+/// State sync trigger counter with reason and source labels
+pub static STATE_SYNC_TRIGGER: Lazy<IntCounterVec> = Lazy::new(|| {
+    register_int_counter_vec!(
+        "aptos_consensus_state_sync_trigger",
+        "State sync trigger with reason (block_not_exist, commit_gap) and source (proposal, opt_proposal, vote, sync_info, round_timeout)",
+        &["reason", "source"]
+    )
+    .unwrap()
+});
+
+/// Gap between commit round and ordered root round when state sync triggers
+pub static STATE_SYNC_TRIGGER_GAP: Lazy<Histogram> = Lazy::new(|| {
+    register_histogram!(
+        "aptos_consensus_state_sync_trigger_gap",
+        "Gap between commit round and ordered root round when state sync triggers",
+        vec![1.0, 2.0, 3.0, 5.0, 10.0, 20.0, 50.0, 100.0, 200.0, 500.0, 1000.0]
+    )
+    .unwrap()
+});
 
 //////////////////////
 // RECONFIGURATION COUNTERS

--- a/consensus/src/logging.rs
+++ b/consensus/src/logging.rs
@@ -43,6 +43,7 @@ pub enum LogEvent {
     ReceiveOrderVote,
     RetrieveBlock,
     StateSync,
+    StateSyncTrigger,
     Timeout,
     Vote,
     VoteNIL,

--- a/consensus/src/round_manager.rs
+++ b/consensus/src/round_manager.rs
@@ -747,6 +747,7 @@ impl RoundManager {
                 proposal_msg.proposal().round(),
                 proposal_msg.sync_info(),
                 proposal_msg.proposer(),
+                "proposal",
             )
             .await
             .context("[RoundManager] Process proposal")?;
@@ -812,8 +813,12 @@ impl RoundManager {
             block_parent_hash = proposal_msg.block_data().parent_id(),
         );
 
-        self.sync_up(proposal_msg.sync_info(), proposal_msg.proposer())
-            .await?;
+        self.sync_up(
+            proposal_msg.sync_info(),
+            proposal_msg.proposer(),
+            "opt_proposal",
+        )
+        .await?;
 
         if self.round_state.current_round() == proposal_msg.round() {
             self.opt_proposal_loopback_tx
@@ -877,7 +882,12 @@ impl RoundManager {
     }
 
     /// Sync to the sync info sending from peer if it has newer certificates.
-    async fn sync_up(&mut self, sync_info: &SyncInfo, author: Author) -> anyhow::Result<()> {
+    async fn sync_up(
+        &mut self,
+        sync_info: &SyncInfo,
+        author: Author,
+        source: &str,
+    ) -> anyhow::Result<()> {
         let local_sync_info = self.block_store.sync_info();
         if sync_info.has_newer_certificates(&local_sync_info) {
             debug!(
@@ -899,7 +909,7 @@ impl RoundManager {
             SYNC_INFO_RECEIVED_WITH_NEWER_CERT.inc();
             let result = self
                 .block_store
-                .add_certs(sync_info, self.create_block_retriever(author))
+                .add_certs(sync_info, self.create_block_retriever(author), source)
                 .await;
             self.process_certificates().await?;
             result
@@ -920,11 +930,12 @@ impl RoundManager {
         message_round: Round,
         sync_info: &SyncInfo,
         author: Author,
+        source: &str,
     ) -> anyhow::Result<bool> {
         if message_round < self.round_state.current_round() {
             return Ok(false);
         }
-        self.sync_up(sync_info, author).await?;
+        self.sync_up(sync_info, author, source).await?;
         ensure!(
             message_round == self.round_state.current_round(),
             "After sync, round {} doesn't match local {}. Local Sync Info: {}. Remote Sync Info: {}",
@@ -949,9 +960,14 @@ impl RoundManager {
             self.new_log(LogEvent::ReceiveSyncInfo).remote_peer(peer),
             "{}", sync_info
         );
-        self.ensure_round_and_sync_up(checked!((sync_info.highest_round()) + 1)?, &sync_info, peer)
-            .await
-            .context("[RoundManager] Failed to process sync info msg")?;
+        self.ensure_round_and_sync_up(
+            checked!((sync_info.highest_round()) + 1)?,
+            &sync_info,
+            peer,
+            "sync_info",
+        )
+        .await
+        .context("[RoundManager] Failed to process sync info msg")?;
         Ok(())
     }
 
@@ -1697,6 +1713,7 @@ impl RoundManager {
                 vote_msg.vote().vote_data().proposed().round(),
                 vote_msg.sync_info(),
                 vote_msg.vote().author(),
+                "vote",
             )
             .await
             .context("[RoundManager] Stop processing vote")?
@@ -1858,6 +1875,7 @@ impl RoundManager {
                 round_timeout_msg.round(),
                 round_timeout_msg.sync_info(),
                 round_timeout_msg.author(),
+                "round_timeout",
             )
             .await
             .context("[RoundManager] Stop processing vote")?

--- a/consensus/src/round_manager_tests/consensus_test.rs
+++ b/consensus/src/round_manager_tests/consensus_test.rs
@@ -1243,6 +1243,7 @@ fn sync_on_partial_newer_sync_info() {
                 sync_info.highest_round() + 1,
                 &sync_info,
                 node.signer.author(),
+                "test",
             )
             .await
             .unwrap();


### PR DESCRIPTION
## Summary

Validators with high geographic latency (e.g., aptos-apne1-0 in Tokyo, ~100ms from EU) enter unnecessary state sync **~10K times/day** because `need_sync_for_ledger_info` triggers when a block doesn't exist in the block tree, even though the block is about to arrive via an optimistic proposal or already exists in the `pending_blocks` buffer.

### Root Cause

`need_sync_for_ledger_info` checks `block_exists()` against the block tree only. With optimistic proposals and geographic latency:

1. **Initial trigger**: The round manager processes rounds faster than new opt proposals arrive. When the buffer empties, `biased select` falls to `event_rx`. The event's SyncInfo has a commit cert for a block not yet in the tree → state sync triggered (gap=2).

2. **Cascade**: After sync, processing buffered opt proposals calls `sync_up` (line 815) **before** the block is inserted. The opt proposal's own SyncInfo triggers `need_sync_for_ledger_info` for the block it's about to provide → another sync.

3. **Self-reinforcing**: During sync (~400ms), QCs are not processed. After sync, the QCs needed to convert opt proposals arrive on messages whose commit certs trigger yet another sync.

### Data (3 days mainnet)

| Validator | CommitViaSync count |
|-----------|-------------------|
| **apne1-0 (Tokyo)** | **28,644** |
| euwe2-0 (EU) | 215 |
| euwe4-0 (EU) | 206 |

### Fix

- Check `pending_blocks` buffer before concluding a block is missing
- Skip sync for small gaps (≤5 rounds) where the block is likely in-flight  
- Add structured logging and counter (`aptos_consensus_need_sync_for_ledger_info`) with labels for each decision path

The existing commit_gap sync path is unchanged — if genuinely far behind (>30 rounds), state sync still triggers.

## Test plan

- [x] `cargo check -p aptos-consensus` passes
- [x] `cargo test -p aptos-consensus -- block_store` — all 12 tests pass
- [x] `cargo test -p aptos-consensus -- need_sync` — existing test passes
- [ ] Deploy to apne1-0 and monitor `aptos_consensus_need_sync_for_ledger_info` counter
- [ ] Verify CommitViaSync rate drops from ~10K/day to near zero

🤖 Generated with [Claude Code](https://claude.com/claude-code)