### PR TITLE
Shared data structures and algorithms crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17861,6 +17861,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "shared-dsa"
+version = "0.1.0"
+dependencies = [
+ "rustc-hash 2.1.1",
+]
+
+[[package]]
 name = "shell-words"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -248,6 +248,7 @@ members = [
     "third_party/move/move-vm/test-utils",
     "third_party/move/move-vm/transactional-tests",
     "third_party/move/move-vm/types",
+    "third_party/move/shared-dsa",
     "third_party/move/testing-infra/transactional-test-runner",
     "third_party/move/tools/move-abigen",
     "third_party/move/tools/move-asm",
@@ -783,6 +784,7 @@ rocksdb = { version = "0.24.0", features = ["lz4"] }
 rsa = { version = "0.9.6" }
 rstack-self = { version = "0.3.0", features = ["dw"], default-features = false }
 rstest = "0.15.0"
+rustc-hash = "2"
 rusty-fork = "0.3.0"
 rustversion = "1.0.14"
 scopeguard = "1.2.0"
@@ -931,6 +933,7 @@ move-vm-test-utils = { path = "third_party/move/move-vm/test-utils", features = 
     "table-extension",
 ] }
 move-vm-types = { path = "third_party/move/move-vm/types" }
+shared-dsa = { path = "third_party/move/shared-dsa" }
 
 [profile.release]
 debug = true

--- a/third_party/move/shared-dsa/Cargo.toml
+++ b/third_party/move/shared-dsa/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "shared-dsa"
+version = "0.1.0"
+
+# Workspace inherited keys
+authors = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+repository = { workspace = true }
+rust-version = { workspace = true }
+
+[dependencies]
+rustc-hash = { workspace = true }

--- a/third_party/move/shared-dsa/src/lib.rs
+++ b/third_party/move/shared-dsa/src/lib.rs
@@ -1,0 +1,12 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Collection of data structures and algorithms, for shared use across
+//! various crates.
+
+mod unordered_map;
+mod unordered_set;
+
+pub use std::collections::hash_map::{Entry, OccupiedEntry, VacantEntry};
+pub use unordered_map::UnorderedMap;
+pub use unordered_set::UnorderedSet;

--- a/third_party/move/shared-dsa/src/unordered_map.rs
+++ b/third_party/move/shared-dsa/src/unordered_map.rs
@@ -30,7 +30,7 @@ impl<K, V> UnorderedMap<K, V> {
     #[inline]
     pub fn with_capacity(capacity: usize) -> Self {
         Self {
-            inner: FxHashMap::with_capacity_and_hasher(capacity, FxBuildHasher::default()),
+            inner: FxHashMap::with_capacity_and_hasher(capacity, FxBuildHasher),
         }
     }
 

--- a/third_party/move/shared-dsa/src/unordered_map.rs
+++ b/third_party/move/shared-dsa/src/unordered_map.rs
@@ -1,0 +1,258 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+use rustc_hash::{FxBuildHasher, FxHashMap};
+use std::{borrow::Borrow, collections::hash_map::Entry, fmt, hash::Hash, iter::FromIterator};
+
+/// A fast, non-cryptographic, non-hash-DoS-resistant hash map.
+/// Iteration over keys or key-value pairs are not exposed to avoid any
+/// reliance on non-deterministic ordering.
+#[derive(Clone)]
+pub struct UnorderedMap<K, V> {
+    inner: FxHashMap<K, V>,
+}
+
+// ---------------------------------------------------------------------------
+// Methods that require no bounds on K/V
+// ---------------------------------------------------------------------------
+
+impl<K, V> UnorderedMap<K, V> {
+    #[inline]
+    pub fn new() -> Self {
+        Self {
+            inner: FxHashMap::default(),
+        }
+    }
+
+    /// Creates an empty map pre-allocated to hold at least `capacity` elements
+    /// without reallocation. The load factor is handled internally, so pass the
+    /// number of elements you expect, not an inflated value.
+    #[inline]
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            inner: FxHashMap::with_capacity_and_hasher(capacity, FxBuildHasher::default()),
+        }
+    }
+
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+
+    #[inline]
+    pub fn clear(&mut self) {
+        self.inner.clear();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Methods that require K: Hash + Eq
+// ---------------------------------------------------------------------------
+
+impl<K: Hash + Eq, V> UnorderedMap<K, V> {
+    #[inline]
+    pub fn get<Q>(&self, k: &Q) -> Option<&V>
+    where
+        K: Borrow<Q>,
+        Q: Hash + Eq + ?Sized,
+    {
+        self.inner.get(k)
+    }
+
+    #[inline]
+    pub fn get_mut<Q>(&mut self, k: &Q) -> Option<&mut V>
+    where
+        K: Borrow<Q>,
+        Q: Hash + Eq + ?Sized,
+    {
+        self.inner.get_mut(k)
+    }
+
+    #[inline]
+    pub fn contains_key<Q>(&self, k: &Q) -> bool
+    where
+        K: Borrow<Q>,
+        Q: Hash + Eq + ?Sized,
+    {
+        self.inner.contains_key(k)
+    }
+
+    /// Inserts a key-value pair. Returns the previous value if the key was
+    /// already present, or `None` if it was newly inserted.
+    #[inline]
+    pub fn insert(&mut self, k: K, v: V) -> Option<V> {
+        self.inner.insert(k, v)
+    }
+
+    /// Removes a key, returning its value if the key was present.
+    #[inline]
+    pub fn remove<Q>(&mut self, k: &Q) -> Option<V>
+    where
+        K: Borrow<Q>,
+        Q: Hash + Eq + ?Sized,
+    {
+        self.inner.remove(k)
+    }
+
+    /// Removes a key, returning the key-value pair if the key was present.
+    #[inline]
+    pub fn remove_entry<Q>(&mut self, k: &Q) -> Option<(K, V)>
+    where
+        K: Borrow<Q>,
+        Q: Hash + Eq + ?Sized,
+    {
+        self.inner.remove_entry(k)
+    }
+
+    #[inline]
+    pub fn entry(&mut self, key: K) -> Entry<'_, K, V> {
+        self.inner.entry(key)
+    }
+
+    /// Reserves space for at least `additional` more elements. Pass the number
+    /// of elements you expect to add, not an inflated value — the load factor
+    /// is handled internally.
+    #[inline]
+    pub fn reserve(&mut self, additional: usize) {
+        self.inner.reserve(additional);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Trait implementations
+// ---------------------------------------------------------------------------
+
+impl<K, V> Default for UnorderedMap<K, V> {
+    #[inline]
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<K: fmt::Debug, V: fmt::Debug> fmt::Debug for UnorderedMap<K, V> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.inner.fmt(f)
+    }
+}
+
+impl<K: Hash + Eq, V: PartialEq> PartialEq for UnorderedMap<K, V> {
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        self.inner == other.inner
+    }
+}
+
+impl<K: Hash + Eq, V: Eq> Eq for UnorderedMap<K, V> {}
+
+impl<K: Hash + Eq, V> FromIterator<(K, V)> for UnorderedMap<K, V> {
+    #[inline]
+    fn from_iter<I: IntoIterator<Item = (K, V)>>(iter: I) -> Self {
+        Self {
+            inner: iter.into_iter().collect(),
+        }
+    }
+}
+
+impl<K: Hash + Eq, V> Extend<(K, V)> for UnorderedMap<K, V> {
+    #[inline]
+    fn extend<I: IntoIterator<Item = (K, V)>>(&mut self, iter: I) {
+        self.inner.extend(iter);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_insert_get_remove() {
+        let mut map = UnorderedMap::new();
+        assert!(map.is_empty());
+
+        assert_eq!(map.insert("a", 1), None);
+        assert_eq!(map.insert("b", 2), None);
+        assert_eq!(map.len(), 2);
+
+        assert_eq!(map.get("a"), Some(&1));
+        assert_eq!(map.get("c"), None);
+        assert!(map.contains_key("b"));
+
+        assert_eq!(map.remove("a"), Some(1));
+        assert_eq!(map.len(), 1);
+        assert!(!map.contains_key("a"));
+    }
+
+    #[test]
+    fn test_get_mut() {
+        let mut map = UnorderedMap::new();
+        map.insert("x", 10);
+        *map.get_mut("x").unwrap() = 20;
+        assert_eq!(map.get("x"), Some(&20));
+    }
+
+    #[test]
+    fn test_remove_entry() {
+        let mut map = UnorderedMap::new();
+        map.insert("k", 42);
+        assert_eq!(map.remove_entry("k"), Some(("k", 42)));
+        assert!(map.is_empty());
+    }
+
+    #[test]
+    fn test_entry_api() {
+        let mut map = UnorderedMap::new();
+        map.entry("a").or_insert(1);
+        map.entry("a").and_modify(|v| *v += 10);
+        assert_eq!(map.get("a"), Some(&11));
+    }
+
+    #[test]
+    fn test_clear() {
+        let mut map = UnorderedMap::with_capacity(16);
+        map.insert(1, 1);
+        map.clear();
+        assert!(map.is_empty());
+    }
+
+    #[test]
+    fn test_default() {
+        let map: UnorderedMap<String, i32> = Default::default();
+        assert!(map.is_empty());
+    }
+
+    #[test]
+    fn test_eq() {
+        let a: UnorderedMap<_, _> = [(1, 2), (3, 4)].into_iter().collect();
+        let b: UnorderedMap<_, _> = [(3, 4), (1, 2)].into_iter().collect();
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn test_extend() {
+        let mut map = UnorderedMap::new();
+        map.insert(1, "a");
+        map.extend([(2, "b"), (3, "c")]);
+        assert_eq!(map.len(), 3);
+    }
+
+    #[test]
+    fn test_reserve() {
+        let mut map = UnorderedMap::new();
+        map.insert(1, 1);
+        map.reserve(100);
+    }
+
+    #[test]
+    fn test_debug() {
+        let mut map = UnorderedMap::new();
+        map.insert(1, 2);
+        let s = format!("{:?}", map);
+        assert!(s.contains("1"));
+        assert!(s.contains("2"));
+    }
+}

--- a/third_party/move/shared-dsa/src/unordered_map.rs
+++ b/third_party/move/shared-dsa/src/unordered_map.rs
@@ -134,9 +134,12 @@ impl<K, V> Default for UnorderedMap<K, V> {
     }
 }
 
-impl<K: fmt::Debug, V: fmt::Debug> fmt::Debug for UnorderedMap<K, V> {
+impl<K, V> fmt::Debug for UnorderedMap<K, V> {
+    /// Only shows the length to avoid exposing arbitrary iteration order.
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.inner.fmt(f)
+        f.debug_struct("UnorderedMap")
+            .field("len", &self.inner.len())
+            .finish()
     }
 }
 
@@ -252,7 +255,6 @@ mod tests {
         let mut map = UnorderedMap::new();
         map.insert(1, 2);
         let s = format!("{:?}", map);
-        assert!(s.contains("1"));
-        assert!(s.contains("2"));
+        assert!(s.contains("len: 1"));
     }
 }

--- a/third_party/move/shared-dsa/src/unordered_set.rs
+++ b/third_party/move/shared-dsa/src/unordered_set.rs
@@ -1,0 +1,267 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+use rustc_hash::{FxBuildHasher, FxHashSet};
+use std::{borrow::Borrow, fmt, hash::Hash, iter::FromIterator};
+
+/// A fast, non-cryptographic, non-hash-DoS-resistant hash set.
+/// Iteration over elements is not exposed to avoid any reliance on
+/// non-deterministic ordering.
+#[derive(Clone)]
+pub struct UnorderedSet<K> {
+    inner: FxHashSet<K>,
+}
+
+// ---------------------------------------------------------------------------
+// Methods that require no bounds on K
+// ---------------------------------------------------------------------------
+
+impl<K> UnorderedSet<K> {
+    #[inline]
+    pub fn new() -> Self {
+        Self {
+            inner: FxHashSet::default(),
+        }
+    }
+
+    /// Creates an empty set pre-allocated to hold at least `capacity` elements
+    /// without reallocation. The load factor is handled internally, so pass the
+    /// number of elements you expect, not an inflated value.
+    #[inline]
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            inner: FxHashSet::with_capacity_and_hasher(capacity, FxBuildHasher::default()),
+        }
+    }
+
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+
+    #[inline]
+    pub fn clear(&mut self) {
+        self.inner.clear();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Methods that require K: Hash + Eq
+// ---------------------------------------------------------------------------
+
+impl<K: Hash + Eq> UnorderedSet<K> {
+    #[inline]
+    pub fn contains<Q>(&self, value: &Q) -> bool
+    where
+        K: Borrow<Q>,
+        Q: Hash + Eq + ?Sized,
+    {
+        self.inner.contains(value)
+    }
+
+    #[inline]
+    pub fn get<Q>(&self, value: &Q) -> Option<&K>
+    where
+        K: Borrow<Q>,
+        Q: Hash + Eq + ?Sized,
+    {
+        self.inner.get(value)
+    }
+
+    /// Inserts a value. Returns `true` if the value was newly inserted, or
+    /// `false` if it was already present.
+    #[inline]
+    pub fn insert(&mut self, value: K) -> bool {
+        self.inner.insert(value)
+    }
+
+    #[inline]
+    pub fn replace(&mut self, value: K) -> Option<K> {
+        self.inner.replace(value)
+    }
+
+    /// Removes a value. Returns `true` if the value was present.
+    #[inline]
+    pub fn remove<Q>(&mut self, value: &Q) -> bool
+    where
+        K: Borrow<Q>,
+        Q: Hash + Eq + ?Sized,
+    {
+        self.inner.remove(value)
+    }
+
+    #[inline]
+    pub fn take<Q>(&mut self, value: &Q) -> Option<K>
+    where
+        K: Borrow<Q>,
+        Q: Hash + Eq + ?Sized,
+    {
+        self.inner.take(value)
+    }
+
+    /// Reserves space for at least `additional` more elements. Pass the number
+    /// of elements you expect to add, not an inflated value — the load factor
+    /// is handled internally.
+    #[inline]
+    pub fn reserve(&mut self, additional: usize) {
+        self.inner.reserve(additional);
+    }
+
+    #[inline]
+    pub fn is_subset(&self, other: &UnorderedSet<K>) -> bool {
+        self.inner.is_subset(&other.inner)
+    }
+
+    #[inline]
+    pub fn is_superset(&self, other: &UnorderedSet<K>) -> bool {
+        self.inner.is_superset(&other.inner)
+    }
+
+    #[inline]
+    pub fn is_disjoint(&self, other: &UnorderedSet<K>) -> bool {
+        self.inner.is_disjoint(&other.inner)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Trait implementations
+// ---------------------------------------------------------------------------
+
+impl<K> Default for UnorderedSet<K> {
+    #[inline]
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<K: fmt::Debug> fmt::Debug for UnorderedSet<K> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.inner.fmt(f)
+    }
+}
+
+impl<K: Hash + Eq> PartialEq for UnorderedSet<K> {
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        self.inner == other.inner
+    }
+}
+
+impl<K: Hash + Eq> Eq for UnorderedSet<K> {}
+
+impl<K: Hash + Eq> FromIterator<K> for UnorderedSet<K> {
+    #[inline]
+    fn from_iter<I: IntoIterator<Item = K>>(iter: I) -> Self {
+        Self {
+            inner: iter.into_iter().collect(),
+        }
+    }
+}
+
+impl<K: Hash + Eq> Extend<K> for UnorderedSet<K> {
+    #[inline]
+    fn extend<I: IntoIterator<Item = K>>(&mut self, iter: I) {
+        self.inner.extend(iter);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_insert_contains_remove() {
+        let mut set = UnorderedSet::new();
+        assert!(set.is_empty());
+
+        assert!(set.insert(1));
+        assert!(set.insert(2));
+        assert!(!set.insert(1)); // duplicate
+        assert_eq!(set.len(), 2);
+
+        assert!(set.contains(&1));
+        assert!(!set.contains(&3));
+
+        assert!(set.remove(&1));
+        assert!(!set.remove(&1));
+        assert_eq!(set.len(), 1);
+    }
+
+    #[test]
+    fn test_get_and_take() {
+        let mut set = UnorderedSet::new();
+        set.insert(42);
+        assert_eq!(set.get(&42), Some(&42));
+        assert_eq!(set.take(&42), Some(42));
+        assert!(set.is_empty());
+    }
+
+    #[test]
+    fn test_replace() {
+        let mut set = UnorderedSet::new();
+        assert_eq!(set.replace(1), None);
+        assert_eq!(set.replace(1), Some(1));
+    }
+
+    #[test]
+    fn test_clear() {
+        let mut set = UnorderedSet::with_capacity(16);
+        set.insert(1);
+        set.clear();
+        assert!(set.is_empty());
+    }
+
+    #[test]
+    fn test_set_relations() {
+        let a: UnorderedSet<i32> = [1, 2, 3].into_iter().collect();
+        let b: UnorderedSet<i32> = [1, 2, 3, 4, 5].into_iter().collect();
+        let c: UnorderedSet<i32> = [6, 7].into_iter().collect();
+
+        assert!(a.is_subset(&b));
+        assert!(!b.is_subset(&a));
+        assert!(b.is_superset(&a));
+        assert!(a.is_disjoint(&c));
+        assert!(!a.is_disjoint(&b));
+    }
+
+    #[test]
+    fn test_default() {
+        let set: UnorderedSet<String> = Default::default();
+        assert!(set.is_empty());
+    }
+
+    #[test]
+    fn test_eq() {
+        let a: UnorderedSet<i32> = [1, 2, 3].into_iter().collect();
+        let b: UnorderedSet<i32> = [3, 1, 2].into_iter().collect();
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn test_extend() {
+        let mut set = UnorderedSet::new();
+        set.insert(1);
+        set.extend([2, 3, 4]);
+        assert_eq!(set.len(), 4);
+    }
+
+    #[test]
+    fn test_reserve() {
+        let mut set = UnorderedSet::new();
+        set.insert(1);
+        set.reserve(100);
+    }
+
+    #[test]
+    fn test_debug() {
+        let mut set = UnorderedSet::new();
+        set.insert(42);
+        let s = format!("{:?}", set);
+        assert!(s.contains("42"));
+    }
+}

--- a/third_party/move/shared-dsa/src/unordered_set.rs
+++ b/third_party/move/shared-dsa/src/unordered_set.rs
@@ -139,9 +139,12 @@ impl<K> Default for UnorderedSet<K> {
     }
 }
 
-impl<K: fmt::Debug> fmt::Debug for UnorderedSet<K> {
+impl<K> fmt::Debug for UnorderedSet<K> {
+    /// Only shows the length to avoid exposing arbitrary iteration order.
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.inner.fmt(f)
+        f.debug_struct("UnorderedSet")
+            .field("len", &self.inner.len())
+            .finish()
     }
 }
 
@@ -262,6 +265,6 @@ mod tests {
         let mut set = UnorderedSet::new();
         set.insert(42);
         let s = format!("{:?}", set);
-        assert!(s.contains("42"));
+        assert!(s.contains("len: 1"));
     }
 }

--- a/third_party/move/shared-dsa/src/unordered_set.rs
+++ b/third_party/move/shared-dsa/src/unordered_set.rs
@@ -30,7 +30,7 @@ impl<K> UnorderedSet<K> {
     #[inline]
     pub fn with_capacity(capacity: usize) -> Self {
         Self {
-            inner: FxHashSet::with_capacity_and_hasher(capacity, FxBuildHasher::default()),
+            inner: FxHashSet::with_capacity_and_hasher(capacity, FxBuildHasher),
         }
     }
 


### PR DESCRIPTION
## Description

We implement and expose a fast, non-cryptographic, non-hash-DoS-resistant hashmap and hashset, without exposing the arbitrary iteration over keys/key-value pairs. This is what we want in a number of places in our codebase, but we end up using the slower default hashmap, which is non-deterministic, or various other hashmap implementations.

Currently, this implementation wraps `rustc_hash`'s `FxHash[Map|Set]` , used by the rust compiler.

## How Has This Been Tested?

- added some simple tests

## Type of Change
- [x] New feature


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new collection types backed by non-DoS-resistant hashing; if adopted in code paths that accept untrusted keys, it could create performance-attack risk despite being unused in this PR.
> 
> **Overview**
> Adds a new workspace crate, `third_party/move/shared-dsa`, exposing `UnorderedMap` and `UnorderedSet` wrappers around `rustc_hash`’s `FxHashMap`/`FxHashSet` while *intentionally not exposing iteration APIs* to avoid reliance on non-deterministic ordering.
> 
> Wires the crate into the workspace (`Cargo.toml`) and lockfile, adds a workspace dependency on `rustc-hash`, and includes unit tests covering basic map/set operations and trait behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13019daf01024ad4491ecc300413b5b1193aa032. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->