### PR TITLE
[vm] Fix closure comparison

### DIFF
--- a/aptos-move/aptos-vm-environment/src/prod_configs.rs
+++ b/aptos-move/aptos-vm-environment/src/prod_configs.rs
@@ -5,6 +5,7 @@ pub use aptos_gas_schedule::LATEST_GAS_FEATURE_VERSION;
 use aptos_gas_schedule::{
     gas_feature_versions::{
         RELEASE_V1_15, RELEASE_V1_30, RELEASE_V1_34, RELEASE_V1_38, RELEASE_V1_41, RELEASE_V1_42,
+        RELEASE_V1_45,
     },
     AptosGasParameters,
 };
@@ -296,6 +297,7 @@ pub fn aptos_prod_vm_config(
         enable_struct_layout_local_cache: gas_feature_version >= RELEASE_V1_41,
         check_depth_on_type_counts: gas_feature_version >= RELEASE_V1_41,
         enable_public_struct_args: features.is_enabled(FeatureFlag::PUBLIC_STRUCT_ENUM_ARGS),
+        check_closure_mask_in_eq: gas_feature_version >= RELEASE_V1_45,
     };
 
     // Note: if max_value_nest_depth changed, make sure the constant is in-sync. Do not remove this

--- a/aptos-move/aptos-vm-environment/src/prod_configs.rs
+++ b/aptos-move/aptos-vm-environment/src/prod_configs.rs
@@ -297,7 +297,7 @@ pub fn aptos_prod_vm_config(
         enable_struct_layout_local_cache: gas_feature_version >= RELEASE_V1_41,
         check_depth_on_type_counts: gas_feature_version >= RELEASE_V1_41,
         enable_public_struct_args: features.is_enabled(FeatureFlag::PUBLIC_STRUCT_ENUM_ARGS),
-        check_closure_mask_in_cmp: gas_feature_version >= RELEASE_V1_45,
+        include_closure_mask_in_cmp: gas_feature_version >= RELEASE_V1_45,
     };
 
     // Note: if max_value_nest_depth changed, make sure the constant is in-sync. Do not remove this

--- a/aptos-move/aptos-vm-environment/src/prod_configs.rs
+++ b/aptos-move/aptos-vm-environment/src/prod_configs.rs
@@ -297,7 +297,7 @@ pub fn aptos_prod_vm_config(
         enable_struct_layout_local_cache: gas_feature_version >= RELEASE_V1_41,
         check_depth_on_type_counts: gas_feature_version >= RELEASE_V1_41,
         enable_public_struct_args: features.is_enabled(FeatureFlag::PUBLIC_STRUCT_ENUM_ARGS),
-        check_closure_mask_in_eq: gas_feature_version >= RELEASE_V1_45,
+        check_closure_mask_in_cmp: gas_feature_version >= RELEASE_V1_45,
     };
 
     // Note: if max_value_nest_depth changed, make sure the constant is in-sync. Do not remove this

--- a/aptos-move/framework/move-stdlib/sources/cmp.move
+++ b/aptos-move/framework/move-stdlib/sources/cmp.move
@@ -323,10 +323,10 @@ module std::cmp {
         let closure_a: |u64|u64 has drop = |b| f_two_args(val, b);
         let closure_b: |u64|u64 has drop = |a| f_two_args(a, val);
 
-        // Must NOT be Equal — different masks mean different behavior.
+        // Must not be equal because different masks mean different behavior.
         assert!(compare(&closure_a, &closure_b).is_ne(), 0);
 
-        // Identical closures (same function, same mask, same captured value) must be Equal.
+        // Identical closures (same function, same mask, same captured value) must be equal.
         let closure_c: |u64|u64 has drop = |b| f_two_args(val, b);
         assert!(compare(&closure_a, &closure_c).is_eq(), 1);
     }

--- a/aptos-move/framework/move-stdlib/sources/cmp.move
+++ b/aptos-move/framework/move-stdlib/sources/cmp.move
@@ -310,4 +310,25 @@ module std::cmp {
         };
     }
 
+    #[test_only]
+    fun f_two_args(a: u64, b: u64): u64 {
+        a * 100 + b
+    }
+
+    #[test]
+    fun test_compare_closures() {
+        let val: u64 = 42;
+
+        // Different masks: capture pos 0 vs capture pos 1.
+        let closure_a: |u64|u64 has drop = |b| f_two_args(val, b);
+        let closure_b: |u64|u64 has drop = |a| f_two_args(a, val);
+
+        // Must NOT be Equal — different masks mean different behavior.
+        assert!(compare(&closure_a, &closure_b).is_ne(), 0);
+
+        // Identical closures (same function, same mask, same captured value) must be Equal.
+        let closure_c: |u64|u64 has drop = |b| f_two_args(val, b);
+        assert!(compare(&closure_a, &closure_c).is_eq(), 1);
+    }
+
 }

--- a/aptos-move/framework/move-stdlib/src/natives/cmp.rs
+++ b/aptos-move/framework/move-stdlib/src/natives/cmp.rs
@@ -7,8 +7,9 @@
 
 //! Implementation of native functions for value comparison.
 
-use aptos_gas_schedule::gas_params::natives::move_stdlib::{
-    CMP_COMPARE_BASE, CMP_COMPARE_PER_ABS_VAL_UNIT,
+use aptos_gas_schedule::{
+    gas_feature_versions::RELEASE_V1_45,
+    gas_params::natives::move_stdlib::{CMP_COMPARE_BASE, CMP_COMPARE_PER_ABS_VAL_UNIT},
 };
 use aptos_native_interface::{
     RawSafeNative, SafeNativeBuilder, SafeNativeContext, SafeNativeError, SafeNativeResult,
@@ -18,7 +19,7 @@ use move_vm_runtime::native_functions::NativeFunction;
 use move_vm_types::{
     loaded_data::runtime_types::Type,
     natives::function::PartialVMError,
-    values::{Struct, Value},
+    values::{Struct, Value, DEFAULT_MAX_VM_VALUE_NESTED_DEPTH},
 };
 use smallvec::{smallvec, SmallVec};
 use std::collections::VecDeque;
@@ -51,7 +52,13 @@ fn native_compare(
                 + context.abs_val_size_dereferenced(&args[1])?);
     context.charge(cost)?;
 
-    let ordering = args[0].compare(&args[1])?;
+    let check_mask = context.gas_feature_version() >= RELEASE_V1_45;
+    let ordering = args[0].compare_with_depth(
+        &args[1],
+        1,
+        Some(DEFAULT_MAX_VM_VALUE_NESTED_DEPTH),
+        check_mask,
+    )?;
     let ordering_move_variant = match ordering {
         std::cmp::Ordering::Less => ORDERING_LESS_THAN_VARIANT,
         std::cmp::Ordering::Equal => ORDERING_EQUAL_VARIANT,

--- a/aptos-move/framework/move-stdlib/src/natives/cmp.rs
+++ b/aptos-move/framework/move-stdlib/src/natives/cmp.rs
@@ -55,7 +55,7 @@ fn native_compare(
         .module_storage()
         .runtime_environment()
         .vm_config()
-        .check_closure_mask_in_cmp;
+        .include_closure_mask_in_cmp;
     let ordering = args[0].compare_with_depth(
         &args[1],
         1,

--- a/aptos-move/framework/move-stdlib/src/natives/cmp.rs
+++ b/aptos-move/framework/move-stdlib/src/natives/cmp.rs
@@ -7,9 +7,8 @@
 
 //! Implementation of native functions for value comparison.
 
-use aptos_gas_schedule::{
-    gas_feature_versions::RELEASE_V1_45,
-    gas_params::natives::move_stdlib::{CMP_COMPARE_BASE, CMP_COMPARE_PER_ABS_VAL_UNIT},
+use aptos_gas_schedule::gas_params::natives::move_stdlib::{
+    CMP_COMPARE_BASE, CMP_COMPARE_PER_ABS_VAL_UNIT,
 };
 use aptos_native_interface::{
     RawSafeNative, SafeNativeBuilder, SafeNativeContext, SafeNativeError, SafeNativeResult,
@@ -52,7 +51,11 @@ fn native_compare(
                 + context.abs_val_size_dereferenced(&args[1])?);
     context.charge(cost)?;
 
-    let check_mask = context.gas_feature_version() >= RELEASE_V1_45;
+    let check_mask = context
+        .module_storage()
+        .runtime_environment()
+        .vm_config()
+        .check_closure_mask_in_cmp;
     let ordering = args[0].compare_with_depth(
         &args[1],
         1,

--- a/third_party/move/move-vm/runtime/src/config.rs
+++ b/third_party/move/move-vm/runtime/src/config.rs
@@ -76,6 +76,10 @@ pub struct VMConfig {
     /// When enabled, non-private structs and enums with the copy ability can be used as
     /// transaction arguments if they have public pack functions with the Pack attribute.
     pub enable_public_struct_args: bool,
+    /// When enabled, closure equality and comparison include the closure mask.
+    /// Without this, two closures over the same function with different masks but identical
+    /// captured values are incorrectly treated as equal.
+    pub check_closure_mask_in_eq: bool,
 }
 
 impl Default for VMConfig {
@@ -108,6 +112,7 @@ impl Default for VMConfig {
             enable_struct_layout_local_cache: true,
             check_depth_on_type_counts: true,
             enable_public_struct_args: true,
+            check_closure_mask_in_eq: true,
         }
     }
 }

--- a/third_party/move/move-vm/runtime/src/config.rs
+++ b/third_party/move/move-vm/runtime/src/config.rs
@@ -79,7 +79,7 @@ pub struct VMConfig {
     /// When enabled, closure equality and comparison include the closure mask.
     /// Without this, two closures over the same function with different masks but identical
     /// captured values are incorrectly treated as equal.
-    pub check_closure_mask_in_cmp: bool,
+    pub include_closure_mask_in_cmp: bool,
 }
 
 impl Default for VMConfig {
@@ -112,7 +112,7 @@ impl Default for VMConfig {
             enable_struct_layout_local_cache: true,
             check_depth_on_type_counts: true,
             enable_public_struct_args: true,
-            check_closure_mask_in_cmp: true,
+            include_closure_mask_in_cmp: true,
         }
     }
 }

--- a/third_party/move/move-vm/runtime/src/config.rs
+++ b/third_party/move/move-vm/runtime/src/config.rs
@@ -79,7 +79,7 @@ pub struct VMConfig {
     /// When enabled, closure equality and comparison include the closure mask.
     /// Without this, two closures over the same function with different masks but identical
     /// captured values are incorrectly treated as equal.
-    pub check_closure_mask_in_eq: bool,
+    pub check_closure_mask_in_cmp: bool,
 }
 
 impl Default for VMConfig {
@@ -112,7 +112,7 @@ impl Default for VMConfig {
             enable_struct_layout_local_cache: true,
             check_depth_on_type_counts: true,
             enable_public_struct_args: true,
-            check_closure_mask_in_eq: true,
+            check_closure_mask_in_cmp: true,
         }
     }
 }

--- a/third_party/move/move-vm/runtime/src/interpreter.rs
+++ b/third_party/move/move-vm/runtime/src/interpreter.rs
@@ -2991,7 +2991,7 @@ impl Frame {
                         let lhs = interpreter.operand_stack.pop()?;
                         let rhs = interpreter.operand_stack.pop()?;
                         gas_meter.charge_eq(&lhs, &rhs)?;
-                        let check_mask = interpreter.vm_config.check_closure_mask_in_eq;
+                        let check_mask = interpreter.vm_config.check_closure_mask_in_cmp;
                         interpreter
                             .operand_stack
                             .push(Value::bool(lhs.equals_with_depth(
@@ -3005,7 +3005,7 @@ impl Frame {
                         let lhs = interpreter.operand_stack.pop()?;
                         let rhs = interpreter.operand_stack.pop()?;
                         gas_meter.charge_neq(&lhs, &rhs)?;
-                        let check_mask = interpreter.vm_config.check_closure_mask_in_eq;
+                        let check_mask = interpreter.vm_config.check_closure_mask_in_cmp;
                         interpreter
                             .operand_stack
                             .push(Value::bool(!lhs.equals_with_depth(

--- a/third_party/move/move-vm/runtime/src/interpreter.rs
+++ b/third_party/move/move-vm/runtime/src/interpreter.rs
@@ -2991,7 +2991,7 @@ impl Frame {
                         let lhs = interpreter.operand_stack.pop()?;
                         let rhs = interpreter.operand_stack.pop()?;
                         gas_meter.charge_eq(&lhs, &rhs)?;
-                        let check_mask = interpreter.vm_config.check_closure_mask_in_cmp;
+                        let check_mask = interpreter.vm_config.include_closure_mask_in_cmp;
                         interpreter
                             .operand_stack
                             .push(Value::bool(lhs.equals_with_depth(
@@ -3005,7 +3005,7 @@ impl Frame {
                         let lhs = interpreter.operand_stack.pop()?;
                         let rhs = interpreter.operand_stack.pop()?;
                         gas_meter.charge_neq(&lhs, &rhs)?;
-                        let check_mask = interpreter.vm_config.check_closure_mask_in_cmp;
+                        let check_mask = interpreter.vm_config.include_closure_mask_in_cmp;
                         interpreter
                             .operand_stack
                             .push(Value::bool(!lhs.equals_with_depth(

--- a/third_party/move/move-vm/runtime/src/interpreter.rs
+++ b/third_party/move/move-vm/runtime/src/interpreter.rs
@@ -2991,17 +2991,29 @@ impl Frame {
                         let lhs = interpreter.operand_stack.pop()?;
                         let rhs = interpreter.operand_stack.pop()?;
                         gas_meter.charge_eq(&lhs, &rhs)?;
+                        let check_mask = interpreter.vm_config.check_closure_mask_in_eq;
                         interpreter
                             .operand_stack
-                            .push(Value::bool(lhs.equals(&rhs)?))?;
+                            .push(Value::bool(lhs.equals_with_depth(
+                                &rhs,
+                                1,
+                                interpreter.vm_config.max_value_nest_depth,
+                                check_mask,
+                            )?))?;
                     },
                     Instruction::Neq => {
                         let lhs = interpreter.operand_stack.pop()?;
                         let rhs = interpreter.operand_stack.pop()?;
                         gas_meter.charge_neq(&lhs, &rhs)?;
+                        let check_mask = interpreter.vm_config.check_closure_mask_in_eq;
                         interpreter
                             .operand_stack
-                            .push(Value::bool(!lhs.equals(&rhs)?))?;
+                            .push(Value::bool(!lhs.equals_with_depth(
+                                &rhs,
+                                1,
+                                interpreter.vm_config.max_value_nest_depth,
+                                check_mask,
+                            )?))?;
                     },
                     Instruction::MutBorrowGlobal(sd_idx) | Instruction::ImmBorrowGlobal(sd_idx) => {
                         let is_mut = matches!(instruction, Instruction::MutBorrowGlobal(_));

--- a/third_party/move/move-vm/transactional-tests/tests/instructions/closure_equality.exp
+++ b/third_party/move/move-vm/transactional-tests/tests/instructions/closure_equality.exp
@@ -1,0 +1,4 @@
+processed 3 tasks
+task 0 lines 1-11:  publish [module 0x66::helpers]
+task 1 lines 13-39:  run --verbose [script]
+task 2 lines 41-65:  run --verbose [script]

--- a/third_party/move/move-vm/transactional-tests/tests/instructions/closure_equality.masm
+++ b/third_party/move/move-vm/transactional-tests/tests/instructions/closure_equality.masm
@@ -1,0 +1,65 @@
+//# publish
+module 0x66::helpers
+
+// f(a, b) = a * 100 + b
+#[persistent] public fun f(a: u64, b: u64): u64
+    copy_loc a
+    ld_u64 100
+    mul
+    move_loc b
+    add
+    ret
+
+//# run --verbose
+script
+use 0x66::helpers as h
+
+// Closures with different masks over same function are NOT equal.
+fun test_different_masks_not_equal()
+    local c1: |u64|u64 has drop
+    local c2: |u64|u64 has drop
+
+    // c1 captures 42 at position 0 (mask = 1): c1(x) = f(42, x)
+    ld_u64 42
+    pack_closure h::f, 1
+    st_loc c1
+
+    // c2 captures 42 at position 1 (mask = 2): c2(x) = f(x, 42)
+    ld_u64 42
+    pack_closure h::f, 2
+    st_loc c2
+
+    // They must NOT be equal.
+    move_loc c1
+    move_loc c2
+    eq
+    br_false ok
+    ld_u64 99
+    abort
+ ok: ret
+
+//# run --verbose
+script
+use 0x66::helpers as h
+
+// Closures with same mask and same captured value ARE equal.
+fun test_same_mask_equal()
+    local c1: |u64|u64 has drop
+    local c2: |u64|u64 has drop
+
+    // Both capture 42 at position 0 (mask = 1).
+    ld_u64 42
+    pack_closure h::f, 1
+    st_loc c1
+
+    ld_u64 42
+    pack_closure h::f, 1
+    st_loc c2
+
+    move_loc c1
+    move_loc c2
+    eq
+    br_true ok
+    ld_u64 100
+    abort
+ ok: ret

--- a/third_party/move/move-vm/types/src/values/values_impl.rs
+++ b/third_party/move/move-vm/types/src/values/values_impl.rs
@@ -848,12 +848,12 @@ impl Value {
 impl Value {
     #[cfg_attr(feature = "force-inline", inline(always))]
     pub fn equals(&self, other: &Self) -> PartialVMResult<bool> {
-        self.equals_with_depth(other, 1, Some(DEFAULT_MAX_VM_VALUE_NESTED_DEPTH))
+        self.equals_with_depth(other, 1, Some(DEFAULT_MAX_VM_VALUE_NESTED_DEPTH), true)
     }
 
     #[cfg_attr(feature = "force-inline", inline(always))]
     pub fn compare(&self, other: &Self) -> PartialVMResult<Ordering> {
-        self.compare_with_depth(other, 1, Some(DEFAULT_MAX_VM_VALUE_NESTED_DEPTH))
+        self.compare_with_depth(other, 1, Some(DEFAULT_MAX_VM_VALUE_NESTED_DEPTH), true)
     }
 
     #[cfg_attr(feature = "force-inline", inline(always))]
@@ -862,6 +862,7 @@ impl Value {
         other: &Self,
         depth: u64,
         max_depth: Option<u64>,
+        check_closure_mask: bool,
     ) -> PartialVMResult<bool> {
         use Value::*;
 
@@ -882,11 +883,15 @@ impl Value {
             (Bool(l), Bool(r)) => l == r,
             (Address(l), Address(r)) => l == r,
 
-            (Container(l), Container(r)) => l.equals(r, depth, max_depth)?,
+            (Container(l), Container(r)) => l.equals(r, depth, max_depth, check_closure_mask)?,
 
             // We count references as +1 in nesting, hence increasing the depth.
-            (ContainerRef(l), ContainerRef(r)) => l.equals(r, depth + 1, max_depth)?,
-            (IndexedRef(l), IndexedRef(r)) => l.equals(r, depth + 1, max_depth)?,
+            (ContainerRef(l), ContainerRef(r)) => {
+                l.equals(r, depth + 1, max_depth, check_closure_mask)?
+            },
+            (IndexedRef(l), IndexedRef(r)) => {
+                l.equals(r, depth + 1, max_depth, check_closure_mask)?
+            },
 
             // Disallow equality for delayed values. The rationale behind this
             // semantics is that identifiers might not be deterministic, and
@@ -900,10 +905,11 @@ impl Value {
 
             (ClosureValue(Closure(fun1, captured1)), ClosureValue(Closure(fun2, captured2))) => {
                 if fun1.cmp_dyn(fun2.as_ref())? == Ordering::Equal
+                    && (!check_closure_mask || fun1.closure_mask() == fun2.closure_mask())
                     && captured1.len() == captured2.len()
                 {
                     for (v1, v2) in captured1.iter().zip(captured2.iter()) {
-                        if !v1.equals_with_depth(v2, depth + 1, max_depth)? {
+                        if !v1.equals_with_depth(v2, depth + 1, max_depth, check_closure_mask)? {
                             return Ok(false);
                         }
                     }
@@ -950,6 +956,7 @@ impl Value {
         other: &Self,
         depth: u64,
         max_depth: Option<u64>,
+        check_closure_mask: bool,
     ) -> PartialVMResult<Ordering> {
         use Value::*;
 
@@ -970,11 +977,15 @@ impl Value {
             (Bool(l), Bool(r)) => l.cmp(r),
             (Address(l), Address(r)) => l.cmp(r),
 
-            (Container(l), Container(r)) => l.compare(r, depth, max_depth)?,
+            (Container(l), Container(r)) => l.compare(r, depth, max_depth, check_closure_mask)?,
 
             // We count references as +1 in nesting, hence increasing the depth.
-            (ContainerRef(l), ContainerRef(r)) => l.compare(r, depth + 1, max_depth)?,
-            (IndexedRef(l), IndexedRef(r)) => l.compare(r, depth + 1, max_depth)?,
+            (ContainerRef(l), ContainerRef(r)) => {
+                l.compare(r, depth + 1, max_depth, check_closure_mask)?
+            },
+            (IndexedRef(l), IndexedRef(r)) => {
+                l.compare(r, depth + 1, max_depth, check_closure_mask)?
+            },
 
             // Disallow comparison for delayed values.
             // (see `ValueImpl::equals` above for details on reasoning behind it)
@@ -984,10 +995,14 @@ impl Value {
             },
 
             (ClosureValue(Closure(fun1, captured1)), ClosureValue(Closure(fun2, captured2))) => {
-                let o = fun1.cmp_dyn(fun2.as_ref())?;
+                let mut o = fun1.cmp_dyn(fun2.as_ref())?;
+                if check_closure_mask {
+                    o = o.then_with(|| fun1.closure_mask().cmp(&fun2.closure_mask()));
+                }
                 if o == Ordering::Equal {
                     for (v1, v2) in captured1.iter().zip(captured2.iter()) {
-                        let o = v1.compare_with_depth(v2, depth + 1, max_depth)?;
+                        let o =
+                            v1.compare_with_depth(v2, depth + 1, max_depth, check_closure_mask)?;
                         if o != Ordering::Equal {
                             return Ok(o);
                         }
@@ -1037,7 +1052,7 @@ impl Value {
         other: &Self,
         max_depth: u64,
     ) -> PartialVMResult<bool> {
-        self.equals_with_depth(other, 1, Some(max_depth))
+        self.equals_with_depth(other, 1, Some(max_depth), true)
     }
 
     // Test-only API to test depth checks.
@@ -1047,12 +1062,18 @@ impl Value {
         other: &Self,
         max_depth: u64,
     ) -> PartialVMResult<Ordering> {
-        self.compare_with_depth(other, 1, Some(max_depth))
+        self.compare_with_depth(other, 1, Some(max_depth), true)
     }
 }
 
 impl Container {
-    fn equals(&self, other: &Self, depth: u64, max_depth: Option<u64>) -> PartialVMResult<bool> {
+    fn equals(
+        &self,
+        other: &Self,
+        depth: u64,
+        max_depth: Option<u64>,
+        check_closure_mask: bool,
+    ) -> PartialVMResult<bool> {
         use Container::*;
 
         let res = match (self, other) {
@@ -1064,7 +1085,7 @@ impl Container {
                     return Ok(false);
                 }
                 for (v1, v2) in l.iter().zip(r.iter()) {
-                    if !v1.equals_with_depth(v2, depth + 1, max_depth)? {
+                    if !v1.equals_with_depth(v2, depth + 1, max_depth, check_closure_mask)? {
                         return Ok(false);
                     }
                 }
@@ -1119,6 +1140,7 @@ impl Container {
         other: &Self,
         depth: u64,
         max_depth: Option<u64>,
+        check_closure_mask: bool,
     ) -> PartialVMResult<Ordering> {
         use Container::*;
 
@@ -1128,7 +1150,8 @@ impl Container {
                 let r = &r.borrow();
 
                 for (v1, v2) in l.iter().zip(r.iter()) {
-                    let value_cmp = v1.compare_with_depth(v2, depth + 1, max_depth)?;
+                    let value_cmp =
+                        v1.compare_with_depth(v2, depth + 1, max_depth, check_closure_mask)?;
                     if value_cmp.is_ne() {
                         return Ok(value_cmp);
                     }
@@ -1183,10 +1206,17 @@ impl Container {
 
 impl ContainerRef {
     #[cfg_attr(feature = "force-inline", inline(always))]
-    fn equals(&self, other: &Self, depth: u64, max_depth: Option<u64>) -> PartialVMResult<bool> {
+    fn equals(
+        &self,
+        other: &Self,
+        depth: u64,
+        max_depth: Option<u64>,
+        check_closure_mask: bool,
+    ) -> PartialVMResult<bool> {
         // Note: the depth passed in accounts for the container.
         check_depth(depth, max_depth)?;
-        self.container().equals(other.container(), depth, max_depth)
+        self.container()
+            .equals(other.container(), depth, max_depth, check_closure_mask)
     }
 
     fn compare(
@@ -1194,17 +1224,24 @@ impl ContainerRef {
         other: &Self,
         depth: u64,
         max_depth: Option<u64>,
+        check_closure_mask: bool,
     ) -> PartialVMResult<Ordering> {
         // Note: the depth passed in accounts for the container.
         check_depth(depth, max_depth)?;
         self.container()
-            .compare(other.container(), depth, max_depth)
+            .compare(other.container(), depth, max_depth, check_closure_mask)
     }
 }
 
 impl IndexedRef {
     // note(inline): do not inline, too big
-    fn equals(&self, other: &Self, depth: u64, max_depth: Option<u64>) -> PartialVMResult<bool> {
+    fn equals(
+        &self,
+        other: &Self,
+        depth: u64,
+        max_depth: Option<u64>,
+        check_closure_mask: bool,
+    ) -> PartialVMResult<bool> {
         use Container::*;
 
         self.check_tag()?;
@@ -1229,6 +1266,7 @@ impl IndexedRef {
                 &r2.borrow()[other_index],
                 depth + 1,
                 max_depth,
+                check_closure_mask,
             )?,
 
             (VecU8(r1), VecU8(r2)) => r1.borrow()[self_index] == r2.borrow()[other_index],
@@ -1377,6 +1415,7 @@ impl IndexedRef {
         other: &Self,
         depth: u64,
         max_depth: Option<u64>,
+        check_closure_mask: bool,
     ) -> PartialVMResult<Ordering> {
         use Container::*;
 
@@ -1402,6 +1441,7 @@ impl IndexedRef {
                 &r2.borrow()[other_index],
                 depth + 1,
                 max_depth,
+                check_closure_mask,
             )?,
 
             (VecU8(r1), VecU8(r2)) => r1.borrow()[self_index].cmp(&r2.borrow()[other_index]),

--- a/third_party/move/move-vm/types/src/values/values_impl.rs
+++ b/third_party/move/move-vm/types/src/values/values_impl.rs
@@ -856,13 +856,18 @@ impl Value {
         self.compare_with_depth(other, 1, Some(DEFAULT_MAX_VM_VALUE_NESTED_DEPTH), true)
     }
 
+    /// Returns true if two Move values are equal.
+    ///
+    /// Additional parameters:
+    ///   - Maximum allowed depth of the traversal of value trees.
+    ///   - Whether to include closure mask in closure comparison or not.
     #[cfg_attr(feature = "force-inline", inline(always))]
     pub fn equals_with_depth(
         &self,
         other: &Self,
         depth: u64,
         max_depth: Option<u64>,
-        check_closure_mask: bool,
+        include_closure_mask: bool,
     ) -> PartialVMResult<bool> {
         use Value::*;
 
@@ -883,14 +888,14 @@ impl Value {
             (Bool(l), Bool(r)) => l == r,
             (Address(l), Address(r)) => l == r,
 
-            (Container(l), Container(r)) => l.equals(r, depth, max_depth, check_closure_mask)?,
+            (Container(l), Container(r)) => l.equals(r, depth, max_depth, include_closure_mask)?,
 
             // We count references as +1 in nesting, hence increasing the depth.
             (ContainerRef(l), ContainerRef(r)) => {
-                l.equals(r, depth + 1, max_depth, check_closure_mask)?
+                l.equals(r, depth + 1, max_depth, include_closure_mask)?
             },
             (IndexedRef(l), IndexedRef(r)) => {
-                l.equals(r, depth + 1, max_depth, check_closure_mask)?
+                l.equals(r, depth + 1, max_depth, include_closure_mask)?
             },
 
             // Disallow equality for delayed values. The rationale behind this
@@ -905,11 +910,11 @@ impl Value {
 
             (ClosureValue(Closure(fun1, captured1)), ClosureValue(Closure(fun2, captured2))) => {
                 if fun1.cmp_dyn(fun2.as_ref())? == Ordering::Equal
-                    && (!check_closure_mask || fun1.closure_mask() == fun2.closure_mask())
+                    && (!include_closure_mask || fun1.closure_mask() == fun2.closure_mask())
                     && captured1.len() == captured2.len()
                 {
                     for (v1, v2) in captured1.iter().zip(captured2.iter()) {
-                        if !v1.equals_with_depth(v2, depth + 1, max_depth, check_closure_mask)? {
+                        if !v1.equals_with_depth(v2, depth + 1, max_depth, include_closure_mask)? {
                             return Ok(false);
                         }
                     }
@@ -951,12 +956,17 @@ impl Value {
         Ok(res)
     }
 
+    /// Compares two Move values.
+    ///
+    /// Additional parameters:
+    ///   - Maximum allowed depth of the traversal of value trees.
+    ///   - Whether to include closure mask in closure comparison or not.
     pub fn compare_with_depth(
         &self,
         other: &Self,
         depth: u64,
         max_depth: Option<u64>,
-        check_closure_mask: bool,
+        include_closure_mask: bool,
     ) -> PartialVMResult<Ordering> {
         use Value::*;
 
@@ -977,14 +987,14 @@ impl Value {
             (Bool(l), Bool(r)) => l.cmp(r),
             (Address(l), Address(r)) => l.cmp(r),
 
-            (Container(l), Container(r)) => l.compare(r, depth, max_depth, check_closure_mask)?,
+            (Container(l), Container(r)) => l.compare(r, depth, max_depth, include_closure_mask)?,
 
             // We count references as +1 in nesting, hence increasing the depth.
             (ContainerRef(l), ContainerRef(r)) => {
-                l.compare(r, depth + 1, max_depth, check_closure_mask)?
+                l.compare(r, depth + 1, max_depth, include_closure_mask)?
             },
             (IndexedRef(l), IndexedRef(r)) => {
-                l.compare(r, depth + 1, max_depth, check_closure_mask)?
+                l.compare(r, depth + 1, max_depth, include_closure_mask)?
             },
 
             // Disallow comparison for delayed values.
@@ -996,13 +1006,13 @@ impl Value {
 
             (ClosureValue(Closure(fun1, captured1)), ClosureValue(Closure(fun2, captured2))) => {
                 let mut o = fun1.cmp_dyn(fun2.as_ref())?;
-                if check_closure_mask {
+                if include_closure_mask {
                     o = o.then_with(|| fun1.closure_mask().cmp(&fun2.closure_mask()));
                 }
                 if o == Ordering::Equal {
                     for (v1, v2) in captured1.iter().zip(captured2.iter()) {
                         let o =
-                            v1.compare_with_depth(v2, depth + 1, max_depth, check_closure_mask)?;
+                            v1.compare_with_depth(v2, depth + 1, max_depth, include_closure_mask)?;
                         if o != Ordering::Equal {
                             return Ok(o);
                         }
@@ -1072,7 +1082,7 @@ impl Container {
         other: &Self,
         depth: u64,
         max_depth: Option<u64>,
-        check_closure_mask: bool,
+        include_closure_mask: bool,
     ) -> PartialVMResult<bool> {
         use Container::*;
 
@@ -1085,7 +1095,7 @@ impl Container {
                     return Ok(false);
                 }
                 for (v1, v2) in l.iter().zip(r.iter()) {
-                    if !v1.equals_with_depth(v2, depth + 1, max_depth, check_closure_mask)? {
+                    if !v1.equals_with_depth(v2, depth + 1, max_depth, include_closure_mask)? {
                         return Ok(false);
                     }
                 }
@@ -1140,7 +1150,7 @@ impl Container {
         other: &Self,
         depth: u64,
         max_depth: Option<u64>,
-        check_closure_mask: bool,
+        include_closure_mask: bool,
     ) -> PartialVMResult<Ordering> {
         use Container::*;
 
@@ -1151,7 +1161,7 @@ impl Container {
 
                 for (v1, v2) in l.iter().zip(r.iter()) {
                     let value_cmp =
-                        v1.compare_with_depth(v2, depth + 1, max_depth, check_closure_mask)?;
+                        v1.compare_with_depth(v2, depth + 1, max_depth, include_closure_mask)?;
                     if value_cmp.is_ne() {
                         return Ok(value_cmp);
                     }
@@ -1211,12 +1221,12 @@ impl ContainerRef {
         other: &Self,
         depth: u64,
         max_depth: Option<u64>,
-        check_closure_mask: bool,
+        include_closure_mask: bool,
     ) -> PartialVMResult<bool> {
         // Note: the depth passed in accounts for the container.
         check_depth(depth, max_depth)?;
         self.container()
-            .equals(other.container(), depth, max_depth, check_closure_mask)
+            .equals(other.container(), depth, max_depth, include_closure_mask)
     }
 
     fn compare(
@@ -1224,12 +1234,12 @@ impl ContainerRef {
         other: &Self,
         depth: u64,
         max_depth: Option<u64>,
-        check_closure_mask: bool,
+        include_closure_mask: bool,
     ) -> PartialVMResult<Ordering> {
         // Note: the depth passed in accounts for the container.
         check_depth(depth, max_depth)?;
         self.container()
-            .compare(other.container(), depth, max_depth, check_closure_mask)
+            .compare(other.container(), depth, max_depth, include_closure_mask)
     }
 }
 
@@ -1240,7 +1250,7 @@ impl IndexedRef {
         other: &Self,
         depth: u64,
         max_depth: Option<u64>,
-        check_closure_mask: bool,
+        include_closure_mask: bool,
     ) -> PartialVMResult<bool> {
         use Container::*;
 
@@ -1266,7 +1276,7 @@ impl IndexedRef {
                 &r2.borrow()[other_index],
                 depth + 1,
                 max_depth,
-                check_closure_mask,
+                include_closure_mask,
             )?,
 
             (VecU8(r1), VecU8(r2)) => r1.borrow()[self_index] == r2.borrow()[other_index],
@@ -1415,7 +1425,7 @@ impl IndexedRef {
         other: &Self,
         depth: u64,
         max_depth: Option<u64>,
-        check_closure_mask: bool,
+        include_closure_mask: bool,
     ) -> PartialVMResult<Ordering> {
         use Container::*;
 
@@ -1441,7 +1451,7 @@ impl IndexedRef {
                 &r2.borrow()[other_index],
                 depth + 1,
                 max_depth,
-                check_closure_mask,
+                include_closure_mask,
             )?,
 
             (VecU8(r1), VecU8(r2)) => r1.borrow()[self_index].cmp(&r2.borrow()[other_index]),


### PR DESCRIPTION
## Summary

Closure equality (`==`/`!=`) and ordering (`std::cmp::compare`) did not include the closure mask when comparing two closures. The mask determines which positional arguments of a function are captured vs provided at call time. Without it, two closures over the same function with different masks but identical captured values were treated as equal, even though calling them produces different results.

The fix adds the mask to the comparison chain, gated behind `gas_feature_version >= RELEASE_V1_45` for safe network rollout.

## Changes

- Thread a `check_closure_mask` flag through `equals_with_depth` / `compare_with_depth` and their recursive helpers
- Interpreter `Eq`/`Neq`: read the flag from `VMConfig`
- Native `compare`: read the flag from `gas_feature_version`
- `VMConfig`: new `check_closure_mask_in_eq` field, set from `prod_configs.rs`

## Tests

- Move unit test in `std::cmp` (`test_compare_closures`): verifies closures with different masks compare as not-equal, same masks compare as equal
- Transactional test (`closure_equality.masm`): same coverage at the bytecode level using `pack_closure` with different mask values

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core VM equality/ordering semantics for closures (affecting `==`/`!=` and `std::cmp::compare`), which could alter on-chain behavior; rollout is gated by `RELEASE_V1_45` to reduce compatibility risk.
> 
> **Overview**
> Fixes a bug where closures over the same function could compare equal despite different capture masks by **including the closure mask in closure `equals`/`compare` semantics**.
> 
> Threads a new `include_closure_mask_in_cmp` flag through `Value::{equals_with_depth, compare_with_depth}` and the interpreter’s `Eq`/`Neq` opcodes, and updates the `std::cmp` native to use the depth-aware comparison with this flag. The flag is added to `VMConfig`, default-enabled, and **feature-gated in Aptos prod config** to turn on at `gas_feature_version >= RELEASE_V1_45`, with new Move unit + transactional tests covering closure equality/inequality across masks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a2bee6bf81b7b20698796125767811496b2caae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->