### PR TITLE
[consensus] Relax need_sync_for_ledger_info to reduce unnecessary state sync

### DIFF
--- a/consensus/src/block_storage/sync_manager.rs
+++ b/consensus/src/block_storage/sync_manager.rs
@@ -97,20 +97,18 @@ impl BlockStore {
         li: &LedgerInfoWithSignatures,
     ) -> Option<StateSyncTriggerReason> {
         const MAX_PRECOMMIT_GAP: u64 = 200;
+
         let ordered_root_round = self.ordered_root().round();
         let commit_round = li.commit_info().round();
-        let block_not_exist =
-            ordered_root_round < commit_round && !self.block_exists(li.commit_info().id());
-        // TODO move min gap to fallback (30) to config, and if configurable make sure the value is
-        // larger than buffer manager MAX_BACKLOG (20)
-        let max_commit_gap = 30.max(2 * self.vote_back_pressure_limit);
-        let min_commit_round = commit_round.saturating_sub(max_commit_gap);
-        let current_commit_round = self.commit_root().round();
+        let commit_block_id = li.commit_info().id();
 
-        // Determine the block status by checking the pending_blocks buffer to
-        // distinguish: not received at all vs received as opt block but not yet
-        // converted vs received as regular but not inserted.
-        let block_status = if block_not_exist {
+        let block_not_in_tree =
+            ordered_root_round < commit_round && !self.block_exists(commit_block_id);
+
+        // If block is not in the tree, check the pending_blocks buffer to determine
+        // the block status and whether to skip sync. The block may have been received
+        // (via opt proposal) but not yet inserted into the block tree.
+        let block_status = if block_not_in_tree {
             let pending = self.pending_blocks.lock();
             if pending.has_regular_block_at_round(commit_round) {
                 BlockStatus::RegularBlockPending
@@ -122,6 +120,16 @@ impl BlockStore {
         } else {
             BlockStatus::InTree
         };
+
+        // Skip sync if the block is in the pending buffer — it will be inserted
+        // into the tree normally via insert_quorum_cert.
+        let block_not_exist = matches!(block_status, BlockStatus::NotReceived);
+
+        // TODO move min gap to fallback (30) to config, and if configurable make sure the value is
+        // larger than buffer manager MAX_BACKLOG (20)
+        let max_commit_gap = 30.max(2 * self.vote_back_pressure_limit);
+        let min_commit_round = commit_round.saturating_sub(max_commit_gap);
+        let current_commit_round = self.commit_root().round();
 
         if let Some(pre_commit_status) = self.pre_commit_status() {
             let mut status_guard = pre_commit_status.lock();
@@ -137,6 +145,9 @@ impl BlockStore {
                     commit_gap,
                 })
             } else {
+                if block_not_in_tree && !block_not_exist {
+                    counters::STATE_SYNC_SKIPPED_BY_PENDING_BLOCKS.inc();
+                }
                 if current_commit_round + MAX_PRECOMMIT_GAP < status_guard.round() {
                     status_guard.pause();
                 }
@@ -150,6 +161,9 @@ impl BlockStore {
                     commit_gap,
                 })
             } else {
+                if block_not_in_tree && !block_not_exist {
+                    counters::STATE_SYNC_SKIPPED_BY_PENDING_BLOCKS.inc();
+                }
                 None
             }
         }

--- a/consensus/src/counters.rs
+++ b/consensus/src/counters.rs
@@ -725,6 +725,15 @@ pub static SYNC_TO_HIGHEST_QC: Lazy<IntCounter> = Lazy::new(|| {
     .unwrap()
 });
 
+/// Count of state syncs prevented by finding the block in pending_blocks buffer
+pub static STATE_SYNC_SKIPPED_BY_PENDING_BLOCKS: Lazy<IntCounter> = Lazy::new(|| {
+    register_int_counter!(
+        "aptos_consensus_state_sync_skipped_by_pending_blocks",
+        "Count of state syncs prevented by finding the block in pending_blocks buffer"
+    )
+    .unwrap()
+});
+
 pub static ORDER_VOTE_ADDED: Lazy<IntCounter> = Lazy::new(|| {
     register_int_counter!(
         "aptos_consensus_order_vote_added",


### PR DESCRIPTION
## Summary
Check `pending_blocks` buffer before concluding a block is missing in `need_sync_for_ledger_info` — skip the expensive `fast_forward_sync` + `rebuild` when the block has already been received (via opt proposal) but not yet inserted into the block tree.

## Motivation
apne1-0 (Tokyo, ~100ms to EU) enters unnecessary state sync ~31K times/day. Prometheus metrics from PR #19395 confirmed that **92% of triggers have the block already in the pending buffer** (83% as regular block, 9% as unconverted opt block) — `sync_up` in `process_opt_proposal_msg` calls `need_sync_for_ledger_info` before `insert_quorum_cert` can add it to the tree.

## How it works
When `need_sync_for_ledger_info` finds the block missing from the block tree, it now checks the `pending_blocks` buffer (by block ID and by round). If found, it sets `block_not_exist = false`, skipping the state sync trigger for that reason.

**The skip only applies when `commit_gap` is also false.** If the node is genuinely far behind (>30 rounds), state sync triggers regardless of what's in pending.

When sync is skipped, the block is still fetched normally — `add_certs` continues to `insert_quorum_cert(HQC)` → `fetch_quorum_cert`, which fetches the correct block from the network via the QC parent chain.

## Mainnet results (deployed to apne1-0)

**Before fix**: ~130 state syncs per 10 minutes (~31K/day).

**After fix (10-min sample)**:

| Counter | Count |
|---------|-------|
| `STATE_SYNC_SKIPPED_BY_PENDING_BLOCKS` | **12** |
| `STATE_SYNC_TRIGGER` (actual syncs) | **0** |

**All 12 would-be triggers were caught by the `pending_blocks` check. State syncs dropped from ~130/10min to zero.**

## Test plan
- [x] `cargo check -p aptos-consensus --tests`
- [x] `cargo +nightly fmt -p aptos-consensus -- --check`
- [x] `./scripts/rust_lint.sh`
- [x] Deployed to apne1-0 — state syncs reduced from ~130/10min to 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the conditions that trigger expensive state sync in consensus; incorrect pending-block detection could delay necessary syncs, but the logic is narrowly scoped and still triggers on large commit gaps.
> 
> **Overview**
> Reduces unnecessary consensus state syncs by having `need_sync_for_ledger_info` distinguish **missing commit blocks** from blocks that are already present in `pending_blocks` (regular or opt) but not yet inserted into the block tree; when the block is pending and there is no `commit_gap`, the sync trigger is skipped.
> 
> Adds a new Prometheus counter `aptos_consensus_state_sync_skipped_by_pending_blocks` to track how often a would-be sync is avoided due to the pending-buffer check.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38d7896b72855ed0bba1c180d390218ee7e2ad91. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->