### PR TITLE
[storage] Load hot state from DB on restart when persistence is enabled

### DIFF
--- a/storage/aptosdb/src/state_kv_db.rs
+++ b/storage/aptosdb/src/state_kv_db.rs
@@ -419,16 +419,16 @@ impl StateKvDb {
             .map(|((_, version), entry_opt)| (version, entry_opt)))
     }
 
-    /// Loads all hot state KV entries from the DB, given the most recently committed version.
+    /// Loads hot state KV entries from the DB as of `snapshot_version`.
     ///
-    /// All entries in the DB must have `hot_since_version <= committed_version` (crash recovery
-    /// truncation is assumed to have already run). For each unique key hash, picks the most
-    /// recent entry. Evicted entries are excluded. The returned shards have correctly assembled
+    /// For each unique key hash, picks the most recent entry with
+    /// `hot_since_version <= snapshot_version`. Entries newer than the snapshot version (written
+    /// between the snapshot and the committed version) are skipped — they will be replayed during
+    /// initialisation. Evicted entries are excluded. The returned shards have correctly assembled
     /// LRU doubly-linked list pointers, ordered by `hot_since_version`.
-    #[allow(dead_code)]
     pub(crate) fn load_hot_state_kvs(
         &self,
-        committed_version: Version,
+        snapshot_version: Version,
     ) -> Result<[LoadedHotStateShard; NUM_STATE_SHARDS]> {
         assert!(
             self.is_hot,
@@ -439,7 +439,7 @@ impl StateKvDb {
 
         let shards: [_; NUM_STATE_SHARDS] = (0..NUM_STATE_SHARDS)
             .into_par_iter()
-            .map(|shard_id| self.load_shard(shard_id, committed_version))
+            .map(|shard_id| self.load_shard(shard_id, snapshot_version))
             .collect::<Result<Vec<_>>>()?
             .try_into()
             .expect("Collected exactly NUM_STATE_SHARDS results");
@@ -448,6 +448,7 @@ impl StateKvDb {
         let elapsed = start.elapsed();
         info!(
             total_items = total_items,
+            snapshot_version = snapshot_version,
             duration_ms = elapsed.as_millis() as u64,
             shard_counts = ?shards.iter().map(|s| s.num_items).collect::<Vec<_>>(),
             "Loaded hot state KVs from DB.",
@@ -459,9 +460,9 @@ impl StateKvDb {
     fn load_shard(
         &self,
         shard_id: usize,
-        committed_version: Version,
+        snapshot_version: Version,
     ) -> Result<LoadedHotStateShard> {
-        let entries = self.scan_shard_entries(shard_id, committed_version)?;
+        let entries = self.scan_shard_entries(shard_id, snapshot_version)?;
         let loaded = Self::assemble_lru_chain(entries);
         Ok(loaded)
     }
@@ -469,12 +470,13 @@ impl StateKvDb {
     // TODO(HotState): The current implementation does a full scan per shard. This can be
     // further sped up (e.g. parallel within-shard scan, prefix-seek per key group, or maintaining
     // a separate index), but is left for later since correctness matters more at this stage.
-    /// Scans a single shard DB and returns the most recent hot entry per key_hash.
-    /// Evicted keys are excluded. The returned entries have uninitialized LRU pointers.
+    /// Scans a single shard DB and returns the most recent hot entry per key_hash as of
+    /// `snapshot_version`. Entries newer than the snapshot are skipped. Evicted keys are excluded.
+    /// The returned entries have uninitialized LRU pointers.
     fn scan_shard_entries(
         &self,
         shard_id: usize,
-        committed_version: Version,
+        snapshot_version: Version,
     ) -> Result<Vec<(HashValue, Version, StateSlotKind)>> {
         let mut iter = self
             .db_shard(shard_id)
@@ -488,15 +490,6 @@ impl StateKvDb {
         for item in iter {
             let ((key_hash, hot_since_version), entry_opt) = item?;
 
-            // After crash recovery truncation, no entry should exist beyond the
-            // committed version.
-            assert!(
-                hot_since_version <= committed_version,
-                "Entry {key_hash} has hot_since_version {hot_since_version} > \
-                 committed_version {committed_version}; \
-                 DB should have been truncated during crash recovery.",
-            );
-
             // New key group?
             if current_key_hash != Some(key_hash) {
                 current_key_hash = Some(key_hash);
@@ -507,7 +500,12 @@ impl StateKvDb {
                 continue;
             }
 
-            // This is the most recent entry for this key_hash.
+            // Skip entries newer than the snapshot version — they will be replayed.
+            if hot_since_version > snapshot_version {
+                continue;
+            }
+
+            // This is the most recent entry for this key_hash at the snapshot version.
             found_for_current = true;
 
             let kind = match entry_opt {
@@ -548,6 +546,7 @@ impl StateKvDb {
         // Collect key_hashes for neighbor lookups before consuming entries.
         let key_hashes: Vec<_> = entries.iter().map(|(kh, _, _)| *kh).collect();
 
+        let mut total_value_bytes = 0;
         for (i, (key_hash, _hot_since_version, kind)) in entries.into_iter().enumerate() {
             let prev = if i + 1 < num_items {
                 Some(key_hashes[i + 1])
@@ -557,6 +556,7 @@ impl StateKvDb {
             let next = if i > 0 { Some(key_hashes[i - 1]) } else { None };
             let slot =
                 StateSlot::new_without_state_key(kind.with_lru_info(LRUEntry { prev, next }));
+            total_value_bytes += slot.size();
             map.insert(key_hash, slot);
         }
 
@@ -568,6 +568,7 @@ impl StateKvDb {
             head,
             tail,
             num_items,
+            total_value_bytes,
         };
         loaded.validate_lru_chain();
         loaded
@@ -575,7 +576,6 @@ impl StateKvDb {
 }
 
 /// Per-shard data recovered from the hot state KV DB.
-#[allow(dead_code)]
 #[derive(Debug)]
 pub(crate) struct LoadedHotStateShard {
     /// All hot entries keyed by state key hash.
@@ -586,6 +586,8 @@ pub(crate) struct LoadedHotStateShard {
     pub tail: Option<HashValue>,
     /// Total number of items in this shard.
     pub num_items: usize,
+    /// Sum of `StateSlot::size()` across all entries in this shard.
+    pub total_value_bytes: usize,
 }
 
 impl LoadedHotStateShard {

--- a/storage/aptosdb/src/state_merkle_db.rs
+++ b/storage/aptosdb/src/state_merkle_db.rs
@@ -79,6 +79,10 @@ pub struct StateMerkleDb {
 }
 
 impl StateMerkleDb {
+    pub(crate) fn is_hot(&self) -> bool {
+        self.is_hot
+    }
+
     fn db_tag(&self) -> &'static str {
         if self.is_hot {
             "hot"

--- a/storage/aptosdb/src/state_store/hot_state.rs
+++ b/storage/aptosdb/src/state_store/hot_state.rs
@@ -267,8 +267,7 @@ struct Committer {
     base: Arc<HotStateBase>,
     committed: Arc<Mutex<CommittedSnapshot>>,
     rx: Receiver<CommitMsg>,
-    total_key_bytes: usize,
-    total_value_bytes: usize,
+    total_value_bytes: [usize; NUM_STATE_SHARDS],
     /// Points to the newest entry. `None` if empty.
     heads: [Option<HashValue>; NUM_STATE_SHARDS],
     /// Points to the oldest entry. `None` if empty.
@@ -313,8 +312,7 @@ impl Committer {
             base,
             committed,
             rx,
-            total_key_bytes: 0,
-            total_value_bytes: 0,
+            total_value_bytes: [0; NUM_STATE_SHARDS],
             heads: arr![None; 16],
             tails: arr![None; 16],
             merged_state: initial_state,
@@ -515,21 +513,16 @@ impl Committer {
         for shard_id in 0..NUM_STATE_SHARDS {
             for (key_hash, slot) in delta.shards[shard_id].iter() {
                 if slot.is_hot() {
-                    self.total_key_bytes += HashValue::LENGTH;
-                    self.total_value_bytes += slot.size();
-                    if let Some(old_slot) = self.base.shards[shard_id].insert(key_hash, slot) {
-                        self.total_key_bytes -= HashValue::LENGTH;
-                        self.total_value_bytes -= old_slot.size();
+                    if self.base.shards[shard_id].insert(key_hash, slot).is_some() {
                         n_update += 1;
                     } else {
                         n_insert += 1;
                     }
-                } else if let Some((_, old_slot)) = self.base.shards[shard_id].remove(&key_hash) {
-                    self.total_key_bytes -= HashValue::LENGTH;
-                    self.total_value_bytes -= old_slot.size();
+                } else if self.base.shards[shard_id].remove(&key_hash).is_some() {
                     n_evict += 1;
                 }
             }
+            self.total_value_bytes[shard_id] = target.hot_value_bytes(shard_id);
             self.heads[shard_id] = target.latest_hot_key(shard_id);
             self.tails[shard_id] = target.oldest_hot_key(shard_id);
             assert_eq!(
@@ -540,12 +533,19 @@ impl Committer {
             debug_assert!(self.validate_lru(shard_id).is_ok());
         }
 
+        let total_items = self.base.len();
         COUNTER.inc_with_by(&["hot_state_insert"], n_insert);
         COUNTER.inc_with_by(&["hot_state_update"], n_update);
         COUNTER.inc_with_by(&["hot_state_evict"], n_evict);
-        GAUGE.set_with(&["hot_state_items"], self.base.len() as i64);
-        GAUGE.set_with(&["hot_state_key_bytes"], self.total_key_bytes as i64);
-        GAUGE.set_with(&["hot_state_value_bytes"], self.total_value_bytes as i64);
+        GAUGE.set_with(&["hot_state_items"], total_items as i64);
+        GAUGE.set_with(
+            &["hot_state_key_bytes"],
+            (total_items * HashValue::LENGTH) as i64,
+        );
+        GAUGE.set_with(
+            &["hot_state_value_bytes"],
+            self.total_value_bytes.iter().sum::<usize>() as i64,
+        );
 
         self.report_age_metrics();
     }
@@ -599,27 +599,33 @@ impl Committer {
         {
             let mut num_visited = 0;
             let mut current = *head;
+            let mut total_value_bytes = 0;
             while let Some(key_hash) = current {
                 let entry = shard.get(&key_hash).expect("Must exist.");
                 num_visited += 1;
                 ensure!(num_visited <= shard.len());
                 ensure!(entry.is_hot());
                 current = entry.next().copied();
+                total_value_bytes += entry.size();
             }
             ensure!(num_visited == shard.len());
+            ensure!(total_value_bytes == self.total_value_bytes[shard_id]);
         }
 
         {
             let mut num_visited = 0;
             let mut current = *tail;
+            let mut total_value_bytes = 0;
             while let Some(key_hash) = current {
                 let entry = shard.get(&key_hash).expect("Must exist.");
                 num_visited += 1;
                 ensure!(num_visited <= shard.len());
                 ensure!(entry.is_hot());
                 current = entry.prev().copied();
+                total_value_bytes += entry.size();
             }
             ensure!(num_visited == shard.len());
+            ensure!(total_value_bytes == self.total_value_bytes[shard_id]);
         }
 
         Ok(())

--- a/storage/aptosdb/src/state_store/hot_state.rs
+++ b/storage/aptosdb/src/state_store/hot_state.rs
@@ -17,6 +17,7 @@ use aptos_types::{
     state_store::{hot_state::THotStateSlot, state_slot::StateSlot, NUM_STATE_SHARDS},
     transaction::Version,
 };
+#[cfg(test)]
 use arr_macro::arr;
 use dashmap::{mapref::one::Ref, DashMap};
 #[cfg(test)]
@@ -47,10 +48,15 @@ where
     K: Clone + Eq + std::hash::Hash,
     V: Clone,
 {
+    #[cfg(test)]
     fn new(max_items: usize) -> Self {
         Self {
             inner: DashMap::with_capacity(max_items),
         }
+    }
+
+    fn from_dashmap(map: DashMap<K, V>) -> Self {
+        Self { inner: map }
     }
 
     fn get(&self, key: &K) -> Option<Ref<'_, K, V>> {
@@ -90,9 +96,16 @@ where
     K: Clone + Eq + std::hash::Hash,
     V: Clone,
 {
+    #[cfg(test)]
     fn new_empty(max_items_per_shard: usize) -> Self {
         Self {
             shards: arr![Shard::new(max_items_per_shard); 16],
+        }
+    }
+
+    fn from_loaded(shards: [DashMap<K, V>; NUM_STATE_SHARDS]) -> Self {
+        Self {
+            shards: shards.map(Shard::from_dashmap),
         }
     }
 
@@ -160,7 +173,16 @@ pub struct HotState {
 
 impl HotState {
     pub fn new(state: State, config: HotStateConfig) -> Self {
-        let base = Arc::new(HotStateBase::new_empty(config.max_items_per_shard));
+        let empty_shards =
+            std::array::from_fn(|_| DashMap::with_capacity(config.max_items_per_shard));
+        Self::new_from_loaded(state, empty_shards)
+    }
+
+    pub fn new_from_loaded(
+        state: State,
+        loaded_shards: [DashMap<HashValue, StateSlot>; NUM_STATE_SHARDS],
+    ) -> Self {
+        let base = Arc::new(HotStateBase::from_loaded(loaded_shards));
         let view = Arc::new(LayeredHotStateView {
             delta: None,
             base: Arc::clone(&base),
@@ -308,13 +330,17 @@ impl Committer {
         initial_state: State,
         merged_version: Arc<AtomicU64>,
     ) -> Self {
+        let heads = std::array::from_fn(|i| initial_state.latest_hot_key(i));
+        let tails = std::array::from_fn(|i| initial_state.oldest_hot_key(i));
+        let total_value_bytes = std::array::from_fn(|i| initial_state.hot_value_bytes(i));
+
         Self {
             base,
             committed,
             rx,
-            total_value_bytes: [0; NUM_STATE_SHARDS],
-            heads: arr![None; 16],
-            tails: arr![None; 16],
+            total_value_bytes,
+            heads,
+            tails,
             merged_state: initial_state,
             old_views: Vec::new(),
             merged_version,
@@ -387,7 +413,49 @@ impl Committer {
     /// `HackReset` is a hack used by `hack_reset` and is only sent when no commits are in flight,
     /// so it must be the sole message in the channel. `next_to_commit` asserts this before
     /// calling.
+    ///
+    // TODO(HotState): The DashMaps and the LRU metadata in `State` are loaded together (from
+    // `load_hot_state_kvs`) but arrive here through separate paths — the DashMaps via
+    // `new_from_loaded` at `PersistedState` construction, the `State` via `hack_reset`. The
+    // assertions below guard against the two getting out of sync. Consider passing them
+    // together through a single path to make consistency structural.
     fn handle_reset(&mut self, state: State, ack: Sender<()>) {
+        for i in 0..NUM_STATE_SHARDS {
+            let head = state.latest_hot_key(i);
+            let tail = state.oldest_hot_key(i);
+            assert_eq!(
+                self.base.shards[i].len(),
+                state.num_hot_items(i),
+                "Shard {i}: DashMap/metadata item count mismatch on reset.",
+            );
+            match (head, tail) {
+                (None, None) => assert_eq!(
+                    self.base.shards[i].len(),
+                    0,
+                    "Shard {i}: head and tail are None but DashMap is not empty.",
+                ),
+                (Some(h), Some(t)) => {
+                    let head_entry = self.base.shards[i]
+                        .get(&h)
+                        .unwrap_or_else(|| panic!("Shard {i}: head not in DashMap."));
+                    assert!(
+                        head_entry.prev().is_none(),
+                        "Shard {i}: head has a prev pointer."
+                    );
+                    let tail_entry = self.base.shards[i]
+                        .get(&t)
+                        .unwrap_or_else(|| panic!("Shard {i}: tail not in DashMap."));
+                    assert!(
+                        tail_entry.next().is_none(),
+                        "Shard {i}: tail has a next pointer."
+                    );
+                },
+                _ => panic!("Shard {i}: head and tail must both be None or both be Some."),
+            }
+            self.heads[i] = head;
+            self.tails[i] = tail;
+            self.total_value_bytes[i] = state.hot_value_bytes(i);
+        }
         self.merged_state = state;
         self.merged_version
             .store(self.merged_state.next_version(), Ordering::Release);

--- a/storage/aptosdb/src/state_store/mod.rs
+++ b/storage/aptosdb/src/state_store/mod.rs
@@ -706,22 +706,9 @@ impl StateStore {
         {
             // TODO(HotState): this is needed while starting with an empty hot state during
             // development.
-            let prev_version = snapshot_next_version - 1;
-            let tree_update_batch = TreeUpdateBatch {
-                node_batch: vec![vec![(NodeKey::new_empty_path(prev_version), Node::Null)]],
-                stale_node_index_batch: vec![],
-            };
-            let raw_batch = db.create_jmt_commit_batch_for_shard(
-                prev_version,
-                /* shard_id = */ None,
-                &tree_update_batch,
-                /* previous_epoch_ending_version = */ None,
-            )?;
-            db.commit_top_levels(prev_version, raw_batch)?;
-            info!("Wrote null node for hot state at version {prev_version}");
+            Self::write_hot_state_null_node(db, snapshot_next_version - 1)?;
         }
 
-        // Replaying the committed write sets after the latest snapshot.
         if snapshot_next_version < num_transactions {
             if check_max_versions_after_snapshot {
                 ensure!(
@@ -731,47 +718,13 @@ impl StateStore {
                     num_transactions,
                 );
             }
-            info!("Replaying writesets from {snapshot_next_version} to {num_transactions} to let state Merkle DB catch up.");
-
-            let write_sets = state_db
-                .ledger_db
-                .write_set_db()
-                .get_write_sets(snapshot_next_version, num_transactions)?;
-            let txn_info_iter = state_db
-                .ledger_db
-                .transaction_info_db()
-                .get_transaction_info_iter(snapshot_next_version, write_sets.len())?;
-            let all_checkpoint_indices = txn_info_iter
-                .into_iter()
-                .collect::<Result<Vec<_>>>()?
-                .into_iter()
-                .positions(|txn_info| txn_info.has_state_checkpoint_hash())
-                .collect();
-
-            let state_update_refs = StateUpdateRefs::index_write_sets(
-                state.next_version(),
-                &write_sets,
-                write_sets.len(),
-                all_checkpoint_indices,
-            );
-            let current_state = out_current_state.lock().clone();
-            let (hot_state, state) = out_persisted_state.get_state();
-            let (new_state, _state_reads, hot_state_updates) = current_state
-                .ledger_state()
-                .update_with_db_reader(&state, hot_state, &state_update_refs, state_db.clone())?;
-            let state_summary = out_persisted_state.get_state_summary();
-            let new_state_summary = current_state.ledger_state_summary().update(
-                &ProvableStateSummary::new(state_summary, state_db.as_ref()),
-                &hot_state_updates,
-                &state_update_refs,
-            )?;
-            let updated =
-                LedgerStateWithSummary::from_state_and_summary(new_state, new_state_summary);
-
-            // synchronously commit the snapshot at the last checkpoint here if not committed to disk yet.
-            buffered_state.update(
-                updated, 0,    /* estimated_items, doesn't matter since we sync-commit */
-                true, /* sync_commit */
+            Self::replay_write_sets_after_snapshot(
+                state_db,
+                snapshot_next_version,
+                num_transactions,
+                &mut buffered_state,
+                &out_current_state,
+                &out_persisted_state,
             )?;
         }
 
@@ -787,6 +740,76 @@ impl StateStore {
             "StateStore initialization finished.",
         );
         Ok(buffered_state)
+    }
+
+    /// Writes a null node for the hot state merkle tree at the given version.
+    fn write_hot_state_null_node(db: &StateMerkleDb, version: Version) -> Result<()> {
+        let tree_update_batch = TreeUpdateBatch {
+            node_batch: vec![vec![(NodeKey::new_empty_path(version), Node::Null)]],
+            stale_node_index_batch: vec![],
+        };
+        let raw_batch = db.create_jmt_commit_batch_for_shard(
+            version,
+            /* shard_id = */ None,
+            &tree_update_batch,
+            /* previous_epoch_ending_version = */ None,
+        )?;
+        db.commit_top_levels(version, raw_batch)?;
+        info!("Wrote null node for hot state merkle db at version {version}");
+        Ok(())
+    }
+
+    /// Replays all write sets after the previously committed snapshot until things have caught up.
+    fn replay_write_sets_after_snapshot(
+        state_db: &Arc<StateDb>,
+        snapshot_next_version: Version,
+        num_transactions: u64,
+        buffered_state: &mut BufferedState,
+        out_current_state: &Mutex<LedgerStateWithSummary>,
+        persisted_state: &PersistedState,
+    ) -> Result<()> {
+        info!("Replaying writesets from {snapshot_next_version} to {num_transactions} to let state Merkle DB catch up.");
+
+        let write_sets = state_db
+            .ledger_db
+            .write_set_db()
+            .get_write_sets(snapshot_next_version, num_transactions)?;
+        let txn_info_iter = state_db
+            .ledger_db
+            .transaction_info_db()
+            .get_transaction_info_iter(snapshot_next_version, write_sets.len())?;
+        let all_checkpoint_indices = txn_info_iter
+            .into_iter()
+            .collect::<Result<Vec<_>>>()?
+            .into_iter()
+            .positions(|txn_info| txn_info.has_state_checkpoint_hash())
+            .collect();
+
+        let state_update_refs = StateUpdateRefs::index_write_sets(
+            snapshot_next_version,
+            &write_sets,
+            write_sets.len(),
+            all_checkpoint_indices,
+        );
+        let current_state = out_current_state.lock().clone();
+        let (hot_state, state) = persisted_state.get_state();
+        let (new_state, _state_reads, hot_state_updates) = current_state
+            .ledger_state()
+            .update_with_db_reader(&state, hot_state, &state_update_refs, state_db.clone())?;
+        let state_summary = persisted_state.get_state_summary();
+        let new_state_summary = current_state.ledger_state_summary().update(
+            &ProvableStateSummary::new(state_summary, state_db.as_ref()),
+            &hot_state_updates,
+            &state_update_refs,
+        )?;
+        let updated = LedgerStateWithSummary::from_state_and_summary(new_state, new_state_summary);
+
+        // synchronously commit the snapshot at the last checkpoint here if not committed to disk yet.
+        buffered_state.update(
+            updated, 0,    /* estimated_items, doesn't matter since we sync-commit */
+            true, /* sync_commit */
+        )?;
+        Ok(())
     }
 
     pub fn reset(&self) {

--- a/storage/aptosdb/src/state_store/mod.rs
+++ b/storage/aptosdb/src/state_store/mod.rs
@@ -491,17 +491,9 @@ impl StateStore {
             overall_commit_progress,
             crash_if_difference_is_too_large,
         );
-        Self::sync_state_merkle_commit_progress(
-            ledger_metadata_db,
-            &state_merkle_db,
-            overall_commit_progress,
-            crash_if_difference_is_too_large,
-        );
-
         // When `delete_on_restart` in config is flipped from true to false, the node will have been
         // running for a while, so its hot_state_kv_db is extremely unlikely to not have a progress
-        // marker and `sync_state_kv_commit_progress` should work. Same for hot_state_merkle_db
-        // below.
+        // marker and `sync_state_kv_commit_progress` should work.
         if !delete_hot_state_on_restart && let Some(db) = &hot_state_kv_db {
             Self::sync_state_kv_commit_progress(
                 db,
@@ -509,13 +501,41 @@ impl StateStore {
                 crash_if_difference_is_too_large,
             );
         }
+
+        // Find truncation targets for both state merkle DBs independently.
+        let cold_merkle_target = Self::find_state_merkle_truncation_target(
+            ledger_metadata_db,
+            &state_merkle_db,
+            overall_commit_progress,
+            crash_if_difference_is_too_large,
+        );
+        let hot_merkle_target =
+            if !delete_hot_state_on_restart && let Some(db) = &hot_state_merkle_db {
+                Some(Self::find_state_merkle_truncation_target(
+                    ledger_metadata_db,
+                    db,
+                    overall_commit_progress,
+                    crash_if_difference_is_too_large,
+                ))
+            } else {
+                None
+            };
+
+        // Truncate both merkle DBs to the min of their targets so they end up at the
+        // same snapshot version. After a partial-commit crash one DB may be one snapshot
+        // ahead of the other; using the min guarantees they are consistent on restart.
+        let merkle_target = hot_merkle_target.map_or(cold_merkle_target, |hot| {
+            std::cmp::min(cold_merkle_target, hot)
+        });
+        info!(
+            cold_merkle_target = cold_merkle_target,
+            hot_merkle_target = hot_merkle_target,
+            merkle_target = merkle_target,
+            "State merkle truncation targets.",
+        );
+        Self::truncate_state_merkle_if_needed(&state_merkle_db, merkle_target);
         if !delete_hot_state_on_restart && let Some(db) = &hot_state_merkle_db {
-            Self::sync_state_merkle_commit_progress(
-                ledger_metadata_db,
-                db,
-                overall_commit_progress,
-                crash_if_difference_is_too_large,
-            );
+            Self::truncate_state_merkle_if_needed(db, merkle_target);
         }
     }
 
@@ -553,14 +573,14 @@ impl StateStore {
         .expect("Failed to truncate state K/V db.");
     }
 
-    /// Reads the state merkle max version and truncates the state merkle DB back to
-    /// the tree root at or before `overall_commit_progress`.
-    fn sync_state_merkle_commit_progress(
+    /// Validates the state merkle DB commit progress and returns the tree root version
+    /// at or before `overall_commit_progress`.
+    fn find_state_merkle_truncation_target(
         ledger_metadata_db: &LedgerMetadataDb,
         state_merkle_db: &StateMerkleDb,
         overall_commit_progress: Version,
         crash_if_difference_is_too_large: bool,
-    ) {
+    ) -> Version {
         let state_merkle_max_version = get_max_version_in_state_merkle_db(state_merkle_db)
             .expect("Failed to get state merkle max version.")
             .expect("State merkle max version cannot be None.");
@@ -570,25 +590,29 @@ impl StateStore {
                 assert_le!(difference, MAX_COMMIT_PROGRESS_DIFFERENCE);
             }
         }
-        let state_merkle_target_version = find_tree_root_at_or_before(
-            ledger_metadata_db,
-            state_merkle_db,
-            overall_commit_progress,
-        )
-        .expect("DB read failed.")
-        .unwrap_or_else(|| {
-            panic!(
-                "Could not find a valid root before or at version {}, maybe it was pruned?",
-                overall_commit_progress
-            )
-        });
-        if state_merkle_target_version < state_merkle_max_version {
+        find_tree_root_at_or_before(ledger_metadata_db, state_merkle_db, overall_commit_progress)
+            .expect("DB read failed.")
+            .unwrap_or_else(|| {
+                panic!(
+                    "Could not find a valid root before or at version {}, maybe it was pruned?",
+                    overall_commit_progress
+                )
+            })
+    }
+
+    /// Truncates the state merkle DB back to `target_version` if the DB is ahead.
+    fn truncate_state_merkle_if_needed(state_merkle_db: &StateMerkleDb, target_version: Version) {
+        let state_merkle_max_version = get_max_version_in_state_merkle_db(state_merkle_db)
+            .expect("Failed to get state merkle max version.")
+            .expect("State merkle max version cannot be None.");
+        if target_version < state_merkle_max_version {
             info!(
+                is_hot = state_merkle_db.is_hot(),
                 state_merkle_max_version = state_merkle_max_version,
-                target_version = state_merkle_target_version,
+                target_version = target_version,
                 "Start state merkle truncation..."
             );
-            truncate_state_merkle_db(state_merkle_db, state_merkle_target_version)
+            truncate_state_merkle_db(state_merkle_db, target_version)
                 .expect("Failed to truncate state merkle db.");
         }
     }

--- a/storage/aptosdb/src/state_store/mod.rs
+++ b/storage/aptosdb/src/state_store/mod.rs
@@ -51,7 +51,7 @@ use aptos_scratchpad::SparseMerkleTree;
 use aptos_storage_interface::{
     db_ensure as ensure, db_other_bail as bail,
     state_store::{
-        state::{LedgerState, State},
+        state::{HotStateMetadata, LedgerState, State},
         state_summary::{ProvableStateSummary, StateSummary},
         state_update_refs::{PerVersionStateUpdateRefs, StateUpdateRefs},
         state_view::{
@@ -156,7 +156,7 @@ pub(crate) struct StateDb {
     pub ledger_db: Arc<LedgerDb>,
     pub hot_state_merkle_db: Option<Arc<StateMerkleDb>>,
     pub state_merkle_db: Arc<StateMerkleDb>,
-    pub _hot_state_kv_db: Option<Arc<StateKvDb>>,
+    pub hot_state_kv_db: Option<Arc<StateKvDb>>,
     pub state_kv_db: Arc<StateKvDb>,
     pub state_pruner: StatePruner,
     pub skip_usage: bool,
@@ -399,7 +399,7 @@ impl StateStore {
             ledger_db,
             hot_state_merkle_db,
             state_merkle_db,
-            _hot_state_kv_db: hot_state_kv_db,
+            hot_state_kv_db,
             state_kv_db,
             state_pruner,
             skip_usage,
@@ -408,7 +408,14 @@ impl StateStore {
         let current_state = Arc::new(Mutex::new(LedgerStateWithSummary::new_empty(
             hot_state_config,
         )));
-        let persisted_state = PersistedState::new_empty(hot_state_config);
+        let (persisted_state, hot_state_metadata) = if empty_buffered_state_for_restore {
+            (
+                PersistedState::new_empty(hot_state_config),
+                Default::default(),
+            )
+        } else {
+            Self::load_hot_state_or_empty(&state_db, hot_state_config)
+        };
         let buffered_state = if empty_buffered_state_for_restore {
             BufferedState::new_at_snapshot(
                 &state_db,
@@ -425,6 +432,7 @@ impl StateStore {
                 /*check_max_versions_after_snapshot=*/ true,
                 current_state.clone(),
                 persisted_state.clone(),
+                hot_state_metadata,
                 hot_state_config,
             )
             .expect("buffered state creation failed.")
@@ -636,7 +644,7 @@ impl StateStore {
             ledger_db,
             hot_state_merkle_db,
             state_merkle_db,
-            _hot_state_kv_db: hot_state_kv_db,
+            hot_state_kv_db,
             state_kv_db,
             state_pruner,
             skip_usage: false,
@@ -644,20 +652,26 @@ impl StateStore {
         let current_state = Arc::new(Mutex::new(LedgerStateWithSummary::new_empty(
             HotStateConfig::default(),
         )));
-        let persisted_state = PersistedState::new_empty(HotStateConfig::default());
+        // TODO(HotState): When hot state persistence is needed for this path, load hot state
+        // KV from DB via `load_hot_state_or_empty` and pass the real persisted state and
+        // metadata, instead of empty defaults. This will let both `hot_state_merkle_db` and
+        // `state_merkle_db` catch up correctly during replay.
         let _ = Self::create_buffered_state_from_latest_snapshot(
             &state_db,
             0,
             /*hack_for_tests=*/ false,
             /*check_max_versions_after_snapshot=*/ false,
             current_state.clone(),
-            persisted_state,
+            PersistedState::new_empty(HotStateConfig::default()),
+            Default::default(),
             HotStateConfig::default(),
         )?;
         let base_version = current_state.lock().version();
         Ok(base_version)
     }
 
+    /// Creates a `BufferedState` from the latest state snapshot, replaying write sets
+    /// between the snapshot and the committed version.
     fn create_buffered_state_from_latest_snapshot(
         state_db: &Arc<StateDb>,
         buffered_state_target_items: usize,
@@ -665,6 +679,7 @@ impl StateStore {
         check_max_versions_after_snapshot: bool,
         out_current_state: Arc<Mutex<LedgerStateWithSummary>>,
         out_persisted_state: PersistedState,
+        hot_state_metadata: [HotStateMetadata; NUM_STATE_SHARDS],
         hot_state_config: HotStateConfig,
     ) -> Result<BufferedState> {
         let num_transactions = state_db
@@ -683,7 +698,6 @@ impl StateStore {
             latest_snapshot_version = latest_snapshot_version,
             "Initializing BufferedState."
         );
-        // TODO(HotState): read hot root hash from DB.
         let latest_snapshot_root_hash = if let Some(version) = latest_snapshot_version {
             state_db
                 .state_merkle_db
@@ -692,13 +706,24 @@ impl StateStore {
         } else {
             *SPARSE_MERKLE_PLACEHOLDER_HASH
         };
+        let hot_state_root_hash = if !hot_state_config.delete_on_restart
+            && let Some(version) = latest_snapshot_version
+            && let Some(db) = &state_db.hot_state_merkle_db
+        {
+            db.get_root_hash(version)
+                .expect("Failed to query hot state root hash on initialization.")
+        } else {
+            *SPARSE_MERKLE_PLACEHOLDER_HASH
+        };
         let usage = state_db.get_state_storage_usage(latest_snapshot_version)?;
-        let state = StateWithSummary::new_at_version(
+
+        let state = StateWithSummary::new_at_version_with_hot_state_metadata(
             latest_snapshot_version,
-            *SPARSE_MERKLE_PLACEHOLDER_HASH, // TODO(HotState): for now hot state always starts from empty upon restart.
+            hot_state_root_hash,
             latest_snapshot_root_hash,
             usage,
             hot_state_config,
+            hot_state_metadata,
         );
         let mut buffered_state = BufferedState::new_at_snapshot(
             state_db,
@@ -725,7 +750,8 @@ impl StateStore {
             );
         }
 
-        if snapshot_next_version > 0
+        if hot_state_root_hash == *SPARSE_MERKLE_PLACEHOLDER_HASH
+            && snapshot_next_version > 0
             && let Some(db) = &state_db.hot_state_merkle_db
         {
             // TODO(HotState): this is needed while starting with an empty hot state during
@@ -836,8 +862,74 @@ impl StateStore {
         Ok(())
     }
 
+    /// Tries to load the hot state from DB at the latest snapshot version. Returns an empty
+    /// persisted state when loading is not applicable (disabled, no DB, no snapshot).
+    ///
+    /// Returns:
+    ///   - `PersistedState` — fed into `BufferedState` as the base hot state.
+    ///   - `[HotStateMetadata; NUM_STATE_SHARDS]` — per-shard LRU metadata for seeding
+    ///     the speculative `State` (which diverges from the `PersistedState`'s `State`
+    ///     during replay).
+    fn load_hot_state_or_empty(
+        state_db: &Arc<StateDb>,
+        hot_state_config: HotStateConfig,
+    ) -> (PersistedState, [HotStateMetadata; NUM_STATE_SHARDS]) {
+        let empty = || {
+            (
+                PersistedState::new_empty(hot_state_config),
+                Default::default(),
+            )
+        };
+
+        if hot_state_config.delete_on_restart {
+            return empty();
+        }
+        let hot_kv_db = match &state_db.hot_state_kv_db {
+            Some(db) => db,
+            None => return empty(),
+        };
+        let snapshot_version = match state_db
+            .state_merkle_db
+            .get_state_snapshot_version_before(Version::MAX)
+            .expect("Failed to query latest snapshot on initialization.")
+        {
+            Some(v) => v,
+            None => return empty(),
+        };
+
+        let loaded = hot_kv_db
+            .load_hot_state_kvs(snapshot_version)
+            .expect("Failed to load hot state KVs from DB.");
+        let metadata = std::array::from_fn(|i| {
+            HotStateMetadata::new(
+                loaded[i].head,
+                loaded[i].tail,
+                loaded[i].num_items,
+                loaded[i].total_value_bytes,
+            )
+        });
+        let dashmaps = loaded.map(|s| s.map);
+        let usage = state_db
+            .get_state_storage_usage(Some(snapshot_version))
+            .expect("Failed to query state storage usage on initialization.");
+        let state = State::new_at_version_with_hot_state_metadata(
+            Some(snapshot_version),
+            usage,
+            hot_state_config,
+            metadata.clone(),
+        );
+
+        (
+            PersistedState::new_from_loaded(state, hot_state_config, dashmaps),
+            metadata,
+        )
+    }
+
     pub fn reset(&self) {
         self.buffered_state.lock().quit();
+        // TODO(HotState): restore does not reconstruct the hot state yet, so we pass empty
+        // metadata here. This is safe because callers (restore / state-sync) open the DB with
+        // `empty_buffered_state_for_restore`, so the DashMaps are always empty.
         *self.buffered_state.lock() = Self::create_buffered_state_from_latest_snapshot(
             &self.state_db,
             self.buffered_state_target_items,
@@ -845,6 +937,7 @@ impl StateStore {
             true,
             self.current_state.clone(),
             self.persisted_state.clone(),
+            Default::default(),
             self.hot_state_config,
         )
         .expect("buffered state creation failed.");

--- a/storage/aptosdb/src/state_store/persisted_state.rs
+++ b/storage/aptosdb/src/state_store/persisted_state.rs
@@ -3,6 +3,7 @@
 
 use crate::{metrics::OTHER_TIMERS_SECONDS, state_store::hot_state::HotState};
 use aptos_config::config::HotStateConfig;
+use aptos_crypto::HashValue;
 use aptos_infallible::Mutex;
 use aptos_metrics_core::TimerHelper;
 use aptos_scratchpad::SUBTREE_DROPPER;
@@ -10,6 +11,8 @@ use aptos_storage_interface::state_store::{
     state::State, state_summary::StateSummary, state_view::hot_state_view::HotStateView,
     state_with_summary::StateWithSummary,
 };
+use aptos_types::state_store::{state_slot::StateSlot, NUM_STATE_SHARDS};
+use dashmap::DashMap;
 use std::sync::Arc;
 
 #[derive(Clone)]
@@ -24,6 +27,16 @@ impl PersistedState {
     pub fn new_empty(config: HotStateConfig) -> Self {
         let state = State::new_empty(config);
         let hot_state = Arc::new(HotState::new(state, config));
+        let summary = Arc::new(Mutex::new(StateSummary::new_empty(config)));
+        Self { hot_state, summary }
+    }
+
+    pub fn new_from_loaded(
+        state: State,
+        config: HotStateConfig,
+        loaded_shards: [DashMap<HashValue, StateSlot>; NUM_STATE_SHARDS],
+    ) -> Self {
+        let hot_state = Arc::new(HotState::new_from_loaded(state, loaded_shards));
         let summary = Arc::new(Mutex::new(StateSummary::new_empty(config)));
         Self { hot_state, summary }
     }

--- a/storage/storage-interface/src/state_store/hot_state.rs
+++ b/storage/storage-interface/src/state_store/hot_state.rs
@@ -26,6 +26,8 @@ pub(crate) struct HotStateLRU<'a> {
     tail: Option<HashValue>,
     /// Total number of items.
     num_items: usize,
+    /// Sum of `StateSlot::size()` across all hot entries in this shard.
+    total_value_bytes: usize,
 }
 
 impl<'a> HotStateLRU<'a> {
@@ -36,6 +38,7 @@ impl<'a> HotStateLRU<'a> {
         head: Option<HashValue>,
         tail: Option<HashValue>,
         num_items: usize,
+        total_value_bytes: usize,
     ) -> Self {
         Self {
             capacity,
@@ -45,6 +48,7 @@ impl<'a> HotStateLRU<'a> {
             head,
             tail,
             num_items,
+            total_value_bytes,
         }
     }
 
@@ -65,12 +69,14 @@ impl<'a> HotStateLRU<'a> {
             slot.set_state_key(key.clone());
         }
         let key_hash = *key.crypto_hash_ref();
-        let old_hot_since = self.delete(&key_hash).map(|s| s.expect_hot_since_version());
-        if old_hot_since.is_none() {
-            self.num_items += 1;
+        let old_slot = self.delete(&key_hash);
+        match &old_slot {
+            Some(old) => self.total_value_bytes -= old.size(),
+            None => self.num_items += 1,
         }
+        self.total_value_bytes += slot.size();
         self.insert_as_head(key_hash, slot);
-        old_hot_since
+        old_slot.map(|s| s.expect_hot_since_version())
     }
 
     fn insert_as_head(&mut self, key_hash: HashValue, mut slot: StateSlot) {
@@ -112,6 +118,7 @@ impl<'a> HotStateLRU<'a> {
             let prev_key_hash = *slot
                 .prev()
                 .expect("There must be at least one newer entry (num_items > capacity >= 1).");
+            self.total_value_bytes -= slot.size();
             evicted.push((current, slot.clone()));
             self.pending.insert(current, slot.to_cold());
             current = prev_key_hash;
@@ -184,8 +191,15 @@ impl<'a> HotStateLRU<'a> {
         Option<HashValue>,
         Option<HashValue>,
         usize,
+        usize,
     ) {
-        (self.pending, self.head, self.tail, self.num_items)
+        (
+            self.pending,
+            self.head,
+            self.tail,
+            self.num_items,
+            self.total_value_bytes,
+        )
     }
 
     #[cfg(test)]
@@ -210,12 +224,15 @@ impl<'a> HotStateLRU<'a> {
     ) {
         let mut current = start;
         let mut num_visited = 0;
+        let mut total_value_bytes = 0;
         while let Some(key_hash) = current {
             let slot = self.expect_hot_slot(&key_hash);
             num_visited += 1;
+            total_value_bytes += slot.size();
             current = func(&slot);
         }
         assert_eq!(num_visited, self.num_items);
+        assert_eq!(total_value_bytes, self.total_value_bytes);
     }
 }
 
@@ -385,6 +402,7 @@ mod tests {
             let mut head = None;
             let mut tail = None;
             let mut num_items = 0;
+            let mut total_value_bytes = 0;
             // Use an unbounded cache because it can temporarily exceed the capacity in the middle
             // of the block.
             let mut naive_lru = LruCache::unbounded();
@@ -397,6 +415,7 @@ mod tests {
                     head,
                     tail,
                     num_items,
+                    total_value_bytes,
                 );
                 lru.validate();
 
@@ -421,11 +440,22 @@ mod tests {
                 lru.validate();
                 assert_lru_equal(&lru, &naive_lru);
 
-                let (updates, new_head, new_tail, new_num_items) = lru.into_updates();
+                let (updates, new_head, new_tail, new_num_items, new_total_value_bytes) =
+                    lru.into_updates();
+
+                assert_eq!(new_head, naive_lru.peek_mru().map(|(k, _)| *k));
+                assert_eq!(new_tail, naive_lru.peek_lru().map(|(k, _)| *k));
+                assert_eq!(new_num_items, naive_lru.len());
+                assert_eq!(
+                    new_total_value_bytes,
+                    naive_lru.iter().map(|(_, s)| s.size()).sum::<usize>(),
+                );
+
                 test_obj.commit_updates(updates, new_head, new_tail, new_num_items);
                 head = new_head;
                 tail = new_tail;
                 num_items = new_num_items;
+                total_value_bytes = new_total_value_bytes;
             }
         }
     }

--- a/storage/storage-interface/src/state_store/state.rs
+++ b/storage/storage-interface/src/state_store/state.rs
@@ -42,6 +42,7 @@ pub struct HotStateMetadata {
     latest: Option<HashValue>,
     oldest: Option<HashValue>,
     num_items: usize,
+    total_value_bytes: usize,
 }
 
 impl HotStateMetadata {
@@ -50,6 +51,7 @@ impl HotStateMetadata {
             latest: None,
             oldest: None,
             num_items: 0,
+            total_value_bytes: 0,
         }
     }
 }
@@ -160,6 +162,10 @@ impl State {
         self.hot_state_metadata[shard_id].num_items
     }
 
+    pub fn hot_value_bytes(&self, shard_id: usize) -> usize {
+        self.hot_state_metadata[shard_id].total_value_bytes
+    }
+
     fn update(
         &self,
         persisted_hot_state: Arc<dyn HotStateView>,
@@ -211,6 +217,7 @@ impl State {
                         hot_metadata.latest,
                         hot_metadata.oldest,
                         hot_metadata.num_items,
+                        hot_metadata.total_value_bytes,
                     );
                     let mut all_updates = per_version.iter();
                     let mut insertions = HashMap::new();
@@ -285,7 +292,8 @@ impl State {
                         }
                     }
 
-                    let (new_items, new_head, new_tail, new_num_items) = lru.into_updates();
+                    let (new_items, new_head, new_tail, new_num_items, new_total_value_bytes) =
+                        lru.into_updates();
                     let new_items = new_items.into_iter().collect_vec();
 
                     // TODO(aldenhu): change interface to take iter of ref
@@ -294,6 +302,7 @@ impl State {
                         latest: new_head,
                         oldest: new_tail,
                         num_items: new_num_items,
+                        total_value_bytes: new_total_value_bytes,
                     };
                     let new_usage = Self::usage_delta_for_shard(cache, overlay, batched_updates);
                     (

--- a/storage/storage-interface/src/state_store/state.rs
+++ b/storage/storage-interface/src/state_store/state.rs
@@ -46,12 +46,17 @@ pub struct HotStateMetadata {
 }
 
 impl HotStateMetadata {
-    fn new() -> Self {
+    pub fn new(
+        latest: Option<HashValue>,
+        oldest: Option<HashValue>,
+        num_items: usize,
+        total_value_bytes: usize,
+    ) -> Self {
         Self {
-            latest: None,
-            oldest: None,
-            num_items: 0,
-            total_value_bytes: 0,
+            latest,
+            oldest,
+            num_items,
+            total_value_bytes,
         }
     }
 }
@@ -95,10 +100,24 @@ impl State {
         usage: StateStorageUsage,
         hot_state_config: HotStateConfig,
     ) -> Self {
+        Self::new_at_version_with_hot_state_metadata(
+            version,
+            usage,
+            hot_state_config,
+            arr![HotStateMetadata::default(); 16],
+        )
+    }
+
+    pub fn new_at_version_with_hot_state_metadata(
+        version: Option<Version>,
+        usage: StateStorageUsage,
+        hot_state_config: HotStateConfig,
+        hot_state_metadata: [HotStateMetadata; NUM_STATE_SHARDS],
+    ) -> Self {
         Self::new_with_updates(
             version,
             Arc::new(arr![MapLayer::new_family("state"); 16]),
-            arr![HotStateMetadata::new(); 16],
+            hot_state_metadata,
             usage,
             hot_state_config,
         )

--- a/storage/storage-interface/src/state_store/state_with_summary.rs
+++ b/storage/storage-interface/src/state_store/state_with_summary.rs
@@ -2,13 +2,16 @@
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::state_store::{
-    state::{LedgerState, State},
+    state::{HotStateMetadata, LedgerState, State},
     state_summary::{LedgerStateSummary, StateSummary},
 };
 use aptos_config::config::HotStateConfig;
 use aptos_crypto::HashValue;
 use aptos_scratchpad::SparseMerkleTree;
-use aptos_types::{state_store::state_storage_usage::StateStorageUsage, transaction::Version};
+use aptos_types::{
+    state_store::{state_storage_usage::StateStorageUsage, NUM_STATE_SHARDS},
+    transaction::Version,
+};
 use derive_more::{Deref, DerefMut};
 
 #[derive(Clone, Debug, Deref)]
@@ -38,8 +41,31 @@ impl StateWithSummary {
         usage: StateStorageUsage,
         hot_state_config: HotStateConfig,
     ) -> Self {
+        Self::new_at_version_with_hot_state_metadata(
+            version,
+            hot_state_root_hash,
+            global_state_root_hash,
+            usage,
+            hot_state_config,
+            Default::default(),
+        )
+    }
+
+    pub fn new_at_version_with_hot_state_metadata(
+        version: Option<Version>,
+        hot_state_root_hash: HashValue,
+        global_state_root_hash: HashValue,
+        usage: StateStorageUsage,
+        hot_state_config: HotStateConfig,
+        hot_state_metadata: [HotStateMetadata; NUM_STATE_SHARDS],
+    ) -> Self {
         Self::new(
-            State::new_at_version(version, usage, hot_state_config),
+            State::new_at_version_with_hot_state_metadata(
+                version,
+                usage,
+                hot_state_config,
+                hot_state_metadata,
+            ),
             StateSummary::new_at_version(
                 version,
                 SparseMerkleTree::new(hot_state_root_hash),


### PR DESCRIPTION

The previous commits added hot state KV persistence, LRU metadata tracking,
and crash-safe truncation for the hot state merkle DB. However the
initialization path always started from an empty hot state on restart, meaning
none of the persisted data was actually used. This commit wires everything
together so the node recovers the hot state from DB on startup.

When the hot state KV DB is present and `delete_on_restart` is not set, the
new initialization path recovers the hot state at the latest snapshot version.
`load_hot_state_or_empty` queries the snapshot version, loads KV entries and
the merkle root from their respective DBs, and constructs a `PersistedState`
pre-populated with the recovered data. The caller (`StateStore::new`) passes
the loaded `PersistedState`, root hash, and LRU metadata into
`create_buffered_state_from_latest_snapshot`, which keeps its existing role of
replaying write sets between the snapshot and the committed version. Restore,
reset, and test paths pass placeholder values instead.

A few things worth calling out:

- `load_hot_state_kvs` now takes a `snapshot_version` and skips entries newer
  than that version (they will be replayed). The old assertion that no entry
  can exceed `committed_version` is removed — entries between the snapshot and
  committed version are expected and simply skipped.
- `HotState::new_from_loaded` and `PersistedState::new_from_loaded` accept
  pre-built `DashMap` shards so the loaded data is handed off without
  re-insertion.
- `handle_reset` now validates that the DashMap contents and the LRU metadata
  from `State` are consistent (matching counts, valid head/tail pointers)
  before accepting the reset, since the two arrive through separate paths.
- The null-node write for hot state merkle is now skipped when a real root hash
  was loaded from DB.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches storage initialization, crash-recovery truncation, and hot-state LRU/metrics accounting; regressions could cause incorrect restart state or mismatched snapshot versions, though changes are localized and add consistency assertions.
> 
> **Overview**
> StateStore startup now **recovers hot state from disk** when persistence is enabled (`delete_on_restart=false`): it loads hot KV shards at the latest snapshot, seeds `PersistedState`/`HotState` with the prebuilt `DashMap`s, and passes per-shard `HotStateMetadata` into `create_buffered_state_from_latest_snapshot` so replay between snapshot and committed version rebuilds any newer updates.
> 
> Hot state KV loading (`load_hot_state_kvs`) is changed to be **snapshot-version aware**, skipping entries newer than the snapshot (instead of asserting they don’t exist), and it now returns per-shard `total_value_bytes` used to seed/validate metrics and LRU bookkeeping. `HotStateLRU`, `State`/`StateWithSummary`, and the HotState committer are extended to track/validate `total_value_bytes`, and reset now asserts DashMap contents match `State`’s LRU metadata.
> 
> Crash-recovery syncing is adjusted to compute **independent truncation targets** for hot/cold state merkle DBs and truncate both to the minimum target to guarantee they restart on the same snapshot; hot merkle null-node bootstrapping is skipped when a real hot root hash is present, and replay/write-set catch-up code is refactored into helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abd739ed129b763ddfceed35c4a2fb23819735f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->