### PR TITLE
stop initializing jwk consensus config in genesis

### DIFF
--- a/aptos-move/vm-genesis/src/lib.rs
+++ b/aptos-move/vm-genesis/src/lib.rs
@@ -367,16 +367,6 @@ pub fn encode_genesis_change_set(
     if genesis_config.is_test {
         allow_core_resources_to_set_version(&mut session, &module_storage, &mut traversal_context);
     }
-    let jwk_consensus_config = genesis_config
-        .jwk_consensus_config_override
-        .clone()
-        .unwrap_or_else(OnChainJWKConsensusConfig::default_for_genesis);
-    initialize_jwk_consensus_config(
-        &mut session,
-        &module_storage,
-        &mut traversal_context,
-        &jwk_consensus_config,
-    );
     initialize_jwks_resources(&mut session, &module_storage, &mut traversal_context);
     initialize_keyless_accounts(
         &mut session,


### PR DESCRIPTION
## Description

The current way to initialize JWK (at least for devnet) is to manually update the `SupportedOIDCProviders` in `jwks.move` AFTER genesis.

## How Has This Been Tested?

existing tests

## Key Areas to Review
n/a 

## Type of Change
- [x] Refactoring

## Which Components or Systems Does This Change Impact?
- [x] Other (genesis)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes genesis initialization behavior by no longer writing the on-chain JWK consensus config, which could affect networks expecting this config to exist immediately after genesis.
> 
> **Overview**
> Stops initializing the on-chain JWK consensus configuration during genesis by removing the `jwk_consensus_config_override`/`default_for_genesis` selection and the call to `initialize_jwk_consensus_config` in `aptos-move/vm-genesis/src/lib.rs`.
> 
> Genesis still initializes JWKS/keyless-account resources, but the JWK consensus config must now be set post-genesis if needed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d507b2be97aa73f259552013273de985bc716af3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->