### PR TITLE
Tighten validation checks

### DIFF
--- a/consensus/consensus-types/src/block.rs
+++ b/consensus/consensus-types/src/block.rs
@@ -470,7 +470,10 @@ impl Block {
             // but don't allow anything that shouldn't be there.
             //
             // we validate the full correctness of this field in round_manager.process_proposal()
-            let succ_round = self.round() + u64::from(self.is_nil_block());
+            let succ_round = self
+                .round()
+                .checked_add(u64::from(self.is_nil_block()))
+                .ok_or_else(|| format_err!("Block round overflow"))?;
             let skipped_rounds = succ_round.checked_sub(parent.round() + 1);
             ensure!(
                 skipped_rounds.is_some(),

--- a/consensus/consensus-types/src/block_retrieval.rs
+++ b/consensus/consensus-types/src/block_retrieval.rs
@@ -324,7 +324,10 @@ mod tests {
 
         let err = response.verify(retrieval_request, &verifier).unwrap_err();
         let err_string = err.to_string();
-        assert!(err_string.contains("blocks doesn't form a chain"), "{err_string}");
+        assert!(
+            err_string.contains("blocks doesn't form a chain"),
+            "{err_string}"
+        );
         assert!(!err_string.contains("Block round overflow"), "{err_string}");
     }
 }

--- a/consensus/consensus-types/src/block_retrieval.rs
+++ b/consensus/consensus-types/src/block_retrieval.rs
@@ -305,7 +305,10 @@ impl fmt::Display for BlockRetrievalResponse {
 
 #[cfg(test)]
 mod tests {
-    use super::{BlockRetrievalRequest, BlockRetrievalResponse, BlockRetrievalStatus};
+    use super::{
+        BlockRetrievalRequest, BlockRetrievalRequestV1, BlockRetrievalResponse,
+        BlockRetrievalStatus,
+    };
     use crate::block::{block_test_utils::certificate_for_genesis, Block};
     use aptos_crypto::hash::HashValue;
     use aptos_types::validator_verifier::ValidatorVerifier;
@@ -313,17 +316,15 @@ mod tests {
     #[test]
     fn verify_rejects_chain_mismatch_before_block_validation() {
         let malformed_nil_block = Block::new_nil(u64::MAX, certificate_for_genesis(), vec![]);
-        let retrieval_request = BlockRetrievalRequest::new_with_target_round(
-            HashValue::random(),
-            1,
-            malformed_nil_block.round(),
-        );
+        let retrieval_request =
+            BlockRetrievalRequest::V1(BlockRetrievalRequestV1::new(HashValue::random(), 1));
         let response =
             BlockRetrievalResponse::new(BlockRetrievalStatus::Succeeded, vec![malformed_nil_block]);
         let verifier = ValidatorVerifier::new(vec![]);
 
         let err = response.verify(retrieval_request, &verifier).unwrap_err();
         let err_string = err.to_string();
+        assert!(err_string.contains("blocks doesn't form a chain"), "{err_string}");
         assert!(!err_string.contains("Block round overflow"), "{err_string}");
     }
 }

--- a/consensus/consensus-types/src/block_retrieval.rs
+++ b/consensus/consensus-types/src/block_retrieval.rs
@@ -268,13 +268,13 @@ impl BlockRetrievalResponse {
             .iter()
             .try_fold(retrieval_request.block_id(), |expected_id, block| {
                 block.validate_signature(sig_verifier)?;
-                block.verify_well_formed()?;
                 ensure!(
                     block.id() == expected_id,
                     "blocks doesn't form a chain: expect {}, get {}",
                     expected_id,
                     block.id()
                 );
+                block.verify_well_formed()?;
                 Ok(block.parent_id())
             })
             .map(|_| ())
@@ -300,5 +300,30 @@ impl fmt::Display for BlockRetrievalResponse {
             },
             _ => write!(f, "[BlockRetrievalResponse: status: {:?}]", self.status()),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{BlockRetrievalRequest, BlockRetrievalResponse, BlockRetrievalStatus};
+    use crate::block::{block_test_utils::certificate_for_genesis, Block};
+    use aptos_crypto::hash::HashValue;
+    use aptos_types::validator_verifier::ValidatorVerifier;
+
+    #[test]
+    fn verify_rejects_chain_mismatch_before_block_validation() {
+        let malformed_nil_block = Block::new_nil(u64::MAX, certificate_for_genesis(), vec![]);
+        let retrieval_request = BlockRetrievalRequest::new_with_target_round(
+            HashValue::random(),
+            1,
+            malformed_nil_block.round(),
+        );
+        let response =
+            BlockRetrievalResponse::new(BlockRetrievalStatus::Succeeded, vec![malformed_nil_block]);
+        let verifier = ValidatorVerifier::new(vec![]);
+
+        let err = response.verify(retrieval_request, &verifier).unwrap_err();
+        let err_string = err.to_string();
+        assert!(!err_string.contains("Block round overflow"), "{err_string}");
     }
 }

--- a/consensus/consensus-types/src/block_retrieval.rs
+++ b/consensus/consensus-types/src/block_retrieval.rs
@@ -267,13 +267,13 @@ impl BlockRetrievalResponse {
         self.blocks
             .iter()
             .try_fold(retrieval_request.block_id(), |expected_id, block| {
-                block.validate_signature(sig_verifier)?;
                 ensure!(
                     block.id() == expected_id,
                     "blocks doesn't form a chain: expect {}, get {}",
                     expected_id,
                     block.id()
                 );
+                block.validate_signature(sig_verifier)?;
                 block.verify_well_formed()?;
                 Ok(block.parent_id())
             })

--- a/consensus/consensus-types/src/block_test.rs
+++ b/consensus/consensus-types/src/block_test.rs
@@ -313,3 +313,11 @@ fn test_failed_authors_well_formed() {
         .verify_well_formed()
         .is_err());
 }
+
+#[test]
+fn test_nil_block_overflow_returns_error() {
+    let nil_block = Block::new_nil(u64::MAX, certificate_for_genesis(), vec![]);
+
+    let err = nil_block.verify_well_formed().unwrap_err();
+    assert!(err.to_string().contains("Block round overflow"));
+}


### PR DESCRIPTION
## Summary
- tighten validation around malformed retrieval inputs
- add focused regression coverage

## Testing
- cargo test -p aptos-consensus-types
- cargo check -p aptos-consensus-types