### PR TITLE
[encrypted mempool] Minor smoke test edits

### DIFF
--- a/crates/aptos-batch-encryption/src/tests/smoke/fptx_weighted_smoke.rs
+++ b/crates/aptos-batch-encryption/src/tests/smoke/fptx_weighted_smoke.rs
@@ -18,7 +18,7 @@ use aptos_crypto::{
 };
 use aptos_dkg::{
     pcs::univariate_hiding_kzg,
-    pvss::{chunky::chunked_elgamal::num_chunks_per_scalar, traits::transcript::Aggregatable},
+    pvss::{chunky::{self, chunked_elgamal::num_chunks_per_scalar}, traits::transcript::Aggregatable},
 };
 use ark_ec::AffineRepr as _;
 #[cfg(test)]
@@ -27,6 +27,7 @@ use ark_std::rand::{thread_rng, Rng as _};
 pub fn run_pvss(
     dk: &DigestKey,
 ) -> (
+    chunky::PublicParameters<Pairing>,
     WeightedConfigArkworks<Fr>,
     EncryptionKey,
     Vec<WeightedBIBEVerificationKey>,
@@ -59,6 +60,7 @@ pub fn run_pvss_with_hkzg(
         univariate_hiding_kzg::VerificationKey<Pairing>,
     ),
 ) -> (
+    chunky::PublicParameters<Pairing>,
     WeightedConfigArkworks<Fr>,
     EncryptionKey,
     Vec<WeightedBIBEVerificationKey>,
@@ -132,7 +134,7 @@ pub fn run_pvss_with_hkzg(
         })
         .collect();
 
-    (tc, ek, vks, msk_shares)
+    (pp, tc, ek, vks, msk_shares)
 }
 
 #[test]
@@ -159,7 +161,7 @@ use aptos_dkg::pvss::{
 #[test]
 fn weighted_smoke_with_pvss() {
     let dk = DigestKey::new(&mut thread_rng(), 8, 1).unwrap();
-    let (tc, ek, vks, msk_shares) = run_pvss(&dk);
+    let (_, tc, ek, vks, msk_shares) = run_pvss(&dk);
 
     run_smoke::<FPTXWeighted>(tc, ek, dk, vks, msk_shares);
 }

--- a/crates/aptos-batch-encryption/src/tests/smoke/fptx_weighted_smoke.rs
+++ b/crates/aptos-batch-encryption/src/tests/smoke/fptx_weighted_smoke.rs
@@ -68,7 +68,7 @@ pub fn run_pvss_with_hkzg(
 ) {
     let mut rng_aptos = rand::thread_rng();
 
-    let tc = WeightedConfigArkworks::new(3, vec![1, 2, 5]).unwrap();
+    let tc = WeightedConfigArkworks::new(256, vec![2; 128]).unwrap();
     let pp = <T as TranscriptCore>::PublicParameters::new(
         tc.get_total_weight(),
         aptos_dkg::pvss::chunky::DEFAULT_ELL_FOR_DEPLOYMENT,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk since changes are confined to a smoke test, but the increased `WeightedConfigArkworks` size and new returned public parameters may affect test runtime/flake behavior.
> 
> **Overview**
> Updates the weighted PVSS smoke test to build and return the PVSS `chunky::PublicParameters` alongside the transcript config, and adjusts the call site to ignore this new return value.
> 
> The PVSS-backed test configuration is changed from a tiny (3-player) setup to a larger weighted config (`256` threshold with `128` players of weight `2`), and imports are tweaked to reference `chunky` directly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4d894fc77ac40ab30ef4b5ec2ac13e2760cbb0c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->