### PR TITLE
[vm] Replace variant_name_placeholder mutex with pre-computed static array

### DIFF
--- a/third_party/move/move-core/types/src/value.rs
+++ b/third_party/move/move-core/types/src/value.rs
@@ -24,10 +24,9 @@ use serde::{
     Deserialize, Serialize,
 };
 use std::{
-    collections::{btree_map::Entry, BTreeMap},
     convert::TryInto,
     fmt::{self, Debug},
-    sync::{Arc, Mutex},
+    sync::Arc,
 };
 
 /// The maximal number of enum variants which are supported in values. This must align with
@@ -53,32 +52,19 @@ pub const MOVE_VARIANT_NAME: &str = "variant";
 pub const MOVE_VARIANT_NAME_FIELD: &str = "name";
 
 /// In order to serialize enums with serde, we have to provide `&'static str` names for
-/// variants. This static cache is used to generate those names, and contains
-/// signatures of the form `["0", "1", "2", ..]`. The size of this cache
-/// is bound by `VARIANT_COUNT_MAX * VARIANT_COUNT_MAX / 2` (8064 with max 127)
-static VARIANT_NAME_PLACEHOLDER_CACHE: Lazy<Mutex<BTreeMap<usize, &'static [&'static str]>>> =
-    Lazy::new(|| Mutex::new(Default::default()));
+/// variants. This static is used to generate those names, and contains signatures of
+/// the form `["0", "1", "2", ..]`.
+static VARIANT_NAME_PLACEHOLDERS: Lazy<[&'static str; VARIANT_COUNT_MAX as usize]> =
+    Lazy::new(|| {
+        std::array::from_fn(|i| Box::leak(format!("{i}").into_boxed_str()) as &'static str)
+    });
 
 /// Returns variant name placeholders for providing dummy names in serde serialization.
 pub fn variant_name_placeholder(len: usize) -> Result<&'static [&'static str], anyhow::Error> {
     if len > VARIANT_COUNT_MAX as usize {
         bail!("variant count is restricted to {}", VARIANT_COUNT_MAX);
     }
-    let mutex = &VARIANT_NAME_PLACEHOLDER_CACHE;
-    let mut lock = mutex.lock().expect("acquire index name lock");
-    match lock.entry(len) {
-        Entry::Vacant(e) => {
-            let signature = Box::new(
-                (0..len)
-                    .map(|idx| Box::new(format!("{}", idx)).leak() as &str)
-                    .collect::<Vec<_>>(),
-            )
-            .leak();
-            e.insert(signature);
-            Ok(signature)
-        },
-        Entry::Occupied(e) => Ok(e.get()),
-    }
+    Ok(&VARIANT_NAME_PLACEHOLDERS[..len])
 }
 
 /// enum signer {


### PR DESCRIPTION

`variant_name_placeholder` uses a `Mutex<BTreeMap>` to lazily cache
variant name strings (`"0"`, `"1"`, ...) per requested length. Under
Block-STM v2 with higher parallelism, this mutex shows up as a
contention point since every enum (de)serialization hits it.

Replace with a `Lazy<[&str; 127]>` that pre-computes all 127 names
once on first access. Lookups become a simple slice with zero
synchronization.

Benchmark:
- perpdex benchmark with `--concurrency-level 12`
- block size 400
- 5 runs each

| Config       | before       | after        | Delta  | p-value                 |
|--------------|--------------|--------------|--------|-------------------------|
| Block-STM v1 | 2424.9 txn/s | 2432.5 txn/s | +0.31% | 0.372 (not significant) |
| Block-STM v2 | 3268.3 txn/s | 3305.0 txn/s | +1.12% | 0.018                   |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core Move value (de)serialization by changing how serde enum variant names are generated; while behavior should be equivalent, any mismatch could break serialization/BCS compatibility. Change is small but in a hot, widely used path.
> 
> **Overview**
> Eliminates the `Mutex<BTreeMap>`-based lazy cache used by `variant_name_placeholder` and replaces it with a `Lazy<[&'static str; 127]>` that precomputes all placeholder variant names (`"0".."126"`) once.
> 
> `variant_name_placeholder` now returns a simple slice into this static array, removing per-call locking and map lookups in enum serialization/deserialization paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 192fd46d763316381b26278a7a4b3840a72d528c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->