### PR TITLE
[vm] Replace type interner RwLock with DashMap

### DIFF
--- a/third_party/move/move-core/types/src/value.rs
+++ b/third_party/move/move-core/types/src/value.rs
@@ -24,10 +24,9 @@ use serde::{
     Deserialize, Serialize,
 };
 use std::{
-    collections::{btree_map::Entry, BTreeMap},
     convert::TryInto,
     fmt::{self, Debug},
-    sync::{Arc, Mutex},
+    sync::Arc,
 };
 
 /// The maximal number of enum variants which are supported in values. This must align with
@@ -53,32 +52,19 @@ pub const MOVE_VARIANT_NAME: &str = "variant";
 pub const MOVE_VARIANT_NAME_FIELD: &str = "name";
 
 /// In order to serialize enums with serde, we have to provide `&'static str` names for
-/// variants. This static cache is used to generate those names, and contains
-/// signatures of the form `["0", "1", "2", ..]`. The size of this cache
-/// is bound by `VARIANT_COUNT_MAX * VARIANT_COUNT_MAX / 2` (8064 with max 127)
-static VARIANT_NAME_PLACEHOLDER_CACHE: Lazy<Mutex<BTreeMap<usize, &'static [&'static str]>>> =
-    Lazy::new(|| Mutex::new(Default::default()));
+/// variants. This static is used to generate those names, and contains signatures of
+/// the form `["0", "1", "2", ..]`.
+static VARIANT_NAME_PLACEHOLDERS: Lazy<[&'static str; VARIANT_COUNT_MAX as usize]> =
+    Lazy::new(|| {
+        std::array::from_fn(|i| Box::leak(format!("{i}").into_boxed_str()) as &'static str)
+    });
 
 /// Returns variant name placeholders for providing dummy names in serde serialization.
 pub fn variant_name_placeholder(len: usize) -> Result<&'static [&'static str], anyhow::Error> {
     if len > VARIANT_COUNT_MAX as usize {
         bail!("variant count is restricted to {}", VARIANT_COUNT_MAX);
     }
-    let mutex = &VARIANT_NAME_PLACEHOLDER_CACHE;
-    let mut lock = mutex.lock().expect("acquire index name lock");
-    match lock.entry(len) {
-        Entry::Vacant(e) => {
-            let signature = Box::new(
-                (0..len)
-                    .map(|idx| Box::new(format!("{}", idx)).leak() as &str)
-                    .collect::<Vec<_>>(),
-            )
-            .leak();
-            e.insert(signature);
-            Ok(signature)
-        },
-        Entry::Occupied(e) => Ok(e.get()),
-    }
+    Ok(&VARIANT_NAME_PLACEHOLDERS[..len])
 }
 
 /// enum signer {

--- a/third_party/move/move-vm/types/src/ty_interner.rs
+++ b/third_party/move/move-vm/types/src/ty_interner.rs
@@ -7,9 +7,9 @@
 //! these caches is tied to the code cache, and is managed externally.
 
 use crate::loaded_data::{runtime_types::Type, struct_name_indexing::StructNameIndex};
+use dashmap::DashMap;
 use move_core_types::ability::AbilitySet;
-use parking_lot::RwLock;
-use std::collections::HashMap;
+use std::sync::atomic::{AtomicU32, Ordering};
 use triomphe::Arc;
 
 /// Compactly represents a loaded type.
@@ -56,108 +56,88 @@ enum TypeRepr {
     },
 }
 
-struct InternMap<T, I> {
-    interned: HashMap<T, I>,
-    data: Vec<T>,
-}
-
-impl<T, I> Default for InternMap<T, I> {
-    fn default() -> Self {
-        Self {
-            interned: HashMap::new(),
-            data: Vec::with_capacity(16),
-        }
-    }
-}
-
-impl<T, I> InternMap<T, I> {
-    fn clear(&mut self) {
-        self.interned.clear();
-        self.data.clear();
-    }
-}
-
 /// Interns single types.
 struct TypeInterner {
-    inner: RwLock<InternMap<TypeRepr, TypeId>>,
+    interned: DashMap<TypeRepr, TypeId>,
+    next_id: AtomicU32,
 }
 
 impl Default for TypeInterner {
     fn default() -> Self {
         Self {
-            inner: RwLock::new(InternMap::default()),
+            interned: DashMap::new(),
+            next_id: AtomicU32::new(0),
         }
     }
 }
 
 impl TypeInterner {
     fn intern(&self, repr: TypeRepr) -> TypeId {
-        if let Some(id) = self.inner.read().interned.get(&repr) {
+        if let Some(id) = self.interned.get(&repr) {
             return *id;
         }
 
-        let mut inner = self.inner.write();
-        if let Some(id) = inner.interned.get(&repr) {
-            return *id;
-        }
+        *self
+            .interned
+            .entry(repr)
+            .or_insert_with(|| TypeId(self.next_id.fetch_add(1, Ordering::Relaxed)))
+    }
 
-        let id = TypeId(inner.data.len() as u32);
-        inner.data.push(repr);
-        inner.interned.insert(repr, id);
-        id
+    fn clear(&self) {
+        self.interned.clear();
+        self.next_id.store(0, Ordering::Relaxed);
+    }
+
+    fn len(&self) -> usize {
+        self.next_id.load(Ordering::Relaxed) as usize
     }
 }
 
 /// Interns vector of types (e.g., list of type arguments).
 struct TypeVecInterner {
-    inner: RwLock<InternMap<Arc<[TypeId]>, TypeVecId>>,
+    interned: DashMap<Arc<[TypeId]>, TypeVecId>,
+    next_id: AtomicU32,
 }
 
 impl Default for TypeVecInterner {
     fn default() -> Self {
         Self {
-            inner: RwLock::new(InternMap::default()),
+            interned: DashMap::new(),
+            next_id: AtomicU32::new(0),
         }
     }
 }
 
 impl TypeVecInterner {
     fn intern(&self, tys: &[TypeId]) -> TypeVecId {
-        if let Some(id) = self.inner.read().interned.get(tys) {
+        if let Some(id) = self.interned.get(tys) {
             return *id;
         }
 
-        let tys_arced: Arc<[TypeId]> = Arc::from(tys);
-        let tys_arced_key = tys_arced.clone();
-
-        let mut inner = self.inner.write();
-        if let Some(id) = inner.interned.get(tys) {
-            return *id;
-        }
-
-        let id = TypeVecId(inner.data.len() as u32);
-        inner.data.push(tys_arced);
-        inner.interned.insert(tys_arced_key, id);
-        id
+        *self
+            .interned
+            .entry(Arc::from(tys))
+            .or_insert_with(|| TypeVecId(self.next_id.fetch_add(1, Ordering::Relaxed)))
     }
 
     fn intern_vec(&self, tys: Vec<TypeId>) -> TypeVecId {
-        if let Some(id) = self.inner.read().interned.get(tys.as_slice()) {
+        if let Some(id) = self.interned.get(tys.as_slice()) {
             return *id;
         }
 
-        let tys: Arc<[TypeId]> = tys.into();
-        let tys_key = tys.clone();
+        *self
+            .interned
+            .entry(Arc::from(tys))
+            .or_insert_with(|| TypeVecId(self.next_id.fetch_add(1, Ordering::Relaxed)))
+    }
 
-        let mut inner = self.inner.write();
-        if let Some(id) = inner.interned.get(&tys) {
-            return *id;
-        }
+    fn clear(&self) {
+        self.interned.clear();
+        self.next_id.store(0, Ordering::Relaxed);
+    }
 
-        let id = TypeVecId(inner.data.len() as u32);
-        inner.data.push(tys);
-        inner.interned.insert(tys_key, id);
-        id
+    fn len(&self) -> usize {
+        self.next_id.load(Ordering::Relaxed) as usize
     }
 }
 
@@ -186,12 +166,12 @@ impl InternedTypePool {
 
     /// Returns how many distinct types are instantiated.
     pub fn num_interned_tys(&self) -> usize {
-        self.ty_interner.inner.read().data.len()
+        self.ty_interner.len()
     }
 
     /// Returns how many distinct vectors of types are instantiated.
     pub fn num_interned_ty_vecs(&self) -> usize {
-        self.ty_vec_interner.inner.read().data.len()
+        self.ty_vec_interner.len()
     }
 
     /// Clears all interned data, and then warm-ups the cache for common types. Should be called if
@@ -203,13 +183,8 @@ impl InternedTypePool {
 
     /// Flushes all cached data without warming up the cache.
     fn flush_impl(&self) {
-        let mut ty_interner = self.ty_interner.inner.write();
-        ty_interner.clear();
-        drop(ty_interner);
-
-        let mut ty_vec_interner = self.ty_vec_interner.inner.write();
-        ty_vec_interner.clear();
-        drop(ty_vec_interner);
+        self.ty_interner.clear();
+        self.ty_vec_interner.clear();
     }
 
     /// Interns common type representations.


### PR DESCRIPTION

`TypeInterner` and `TypeVecInterner` use a `RwLock<InternMap>` to cache
interned types. Under Block-STM v2 with higher parallelism, the global
`RwLock` is a contention bottleneck because all reader threads bounce
the same atomic reader-count cache line on every `intern()` call.

Replace with `DashMap` + `AtomicU32`. DashMap shards the map so
concurrent readers on different types touch different per-shard locks,
drastically reducing cross-core contention. This also removes
`InternMap` and its `data: Vec<T>` field, which was never used for
reverse lookups — ID generation is now a simple
`AtomicU32::fetch_add`.

Benchmark:
- perpdex benchmark with `--concurrency-level 12`
- block size 400
- 5 runs each

| Config       | before        | after         | Delta  | p-value |
|--------------|---------------|---------------|--------|---------|
| Block-STM v1 | 2432.5 txn/s | 2483.1 txn/s | +2.08% | <0.0001 |
| Block-STM v2 | 3305.0 txn/s | 3441.8 txn/s | +4.14% | <0.0001 |

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/aptos-labs/aptos-core/pull/19418).
* __->__ #19418
* #19411