### PR TITLE
[Storage] Enable hot state root hash computation on mainnet

### DIFF
--- a/config/src/config/storage_config.rs
+++ b/config/src/config/storage_config.rs
@@ -681,14 +681,6 @@ impl ConfigOptimizer for StorageConfig {
                 config.assert_rlimit_nofile = true;
                 modified_config = true;
             }
-            // TODO(HotState): Hot state root hash computation is off by default in Mainnet unless
-            // explicitly enabled.
-            if chain_id.is_mainnet()
-                && config_yaml["hot_state_config"]["compute_root_hash"].as_bool() != Some(true)
-            {
-                config.hot_state_config.compute_root_hash = false;
-                modified_config = true;
-            }
             // TODO(HotState): Hotness persistence in write sets is disabled on mainnet and testnet
             // unless explicitly enabled.
             if (chain_id.is_mainnet() || chain_id.is_testnet())


### PR DESCRIPTION

Remove temporary feature gates for hot state `compute_root_hash` that were
guarding mainnet rollout. This feature has been running in testnet since the
1.40 release with no issues.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes mainnet runtime defaults by no longer forcing `hot_state_config.compute_root_hash` off, which could impact storage/executor performance or state consistency if issues surface.
> 
> **Overview**
> Removes the mainnet-only optimizer override that forcibly disabled hot state root hash computation when `hot_state_config.compute_root_hash` wasn’t explicitly enabled.
> 
> As a result, mainnet will now honor the config/defaults (with `compute_root_hash` no longer being auto-set to `false` during config optimization), aligning behavior with testnet.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 161ceb2356222677b0693a4cc45a18e748a7cea0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->