### PR TITLE
[storage] Extend crash recovery truncation to hot state DBs

### DIFF
--- a/storage/aptosdb/src/db/aptosdb_internal.rs
+++ b/storage/aptosdb/src/db/aptosdb_internal.rs
@@ -226,6 +226,7 @@ impl AptosDB {
         db_dir: &StorageDirPaths,
         target_version: Version,
     ) -> Result<()> {
+        let delete_hot_state_on_restart = true;
         let (ledger_db, hot_state_merkle_db, state_merkle_db, hot_state_kv_db, state_kv_db) =
             Self::open_dbs(
                 db_dir,
@@ -235,7 +236,7 @@ impl AptosDB {
                 false, // readonly
                 0,     // max_num_nodes_per_lru_cache_shard
                 HotStateConfig {
-                    delete_on_restart: true,
+                    delete_on_restart: delete_hot_state_on_restart,
                     persist_hotness_in_write_set: false,
                     ..HotStateConfig::default()
                 },
@@ -258,7 +259,10 @@ impl AptosDB {
             Arc::clone(&ledger_db),
             Arc::clone(&state_kv_db),
             Arc::clone(&state_merkle_db),
+            hot_state_kv_db.clone(),
+            hot_state_merkle_db.clone(),
             /*crash_if_difference_is_too_large=*/ false,
+            delete_hot_state_on_restart,
         );
 
         if let Some(state_merkle_db_version) =

--- a/storage/aptosdb/src/state_kv_db.rs
+++ b/storage/aptosdb/src/state_kv_db.rs
@@ -172,12 +172,11 @@ impl StateKvDb {
             is_hot,
         };
 
-        // TODO(HotState): Integrate hot state KV DB with pruner and add truncation support
-        // (stale index tracking, etc.) for the hot state DB.
-        if !readonly && !delete_on_restart && !is_hot {
-            if let Some(overall_kv_commit_progress) = get_state_kv_commit_progress(&state_kv_db)? {
-                truncate_state_kv_db_shards(&state_kv_db, overall_kv_commit_progress)?;
-            }
+        if !readonly
+            && !delete_on_restart
+            && let Some(overall_kv_commit_progress) = get_state_kv_commit_progress(&state_kv_db)?
+        {
+            truncate_state_kv_db_shards(&state_kv_db, overall_kv_commit_progress)?;
         }
 
         Ok(state_kv_db)

--- a/storage/aptosdb/src/state_store/mod.rs
+++ b/storage/aptosdb/src/state_store/mod.rs
@@ -389,7 +389,10 @@ impl StateStore {
                 Arc::clone(&ledger_db),
                 Arc::clone(&state_kv_db),
                 Arc::clone(&state_merkle_db),
+                hot_state_kv_db.clone(),
+                hot_state_merkle_db.clone(),
                 /*crash_if_difference_is_too_large=*/ true,
+                hot_state_config.delete_on_restart,
             );
         }
         let state_db = Arc::new(StateDb {
@@ -444,13 +447,19 @@ impl StateStore {
         ledger_db: Arc<LedgerDb>,
         state_kv_db: Arc<StateKvDb>,
         state_merkle_db: Arc<StateMerkleDb>,
+        hot_state_kv_db: Option<Arc<StateKvDb>>,
+        hot_state_merkle_db: Option<Arc<StateMerkleDb>>,
         crash_if_difference_is_too_large: bool,
+        delete_hot_state_on_restart: bool,
     ) {
         let ledger_metadata_db = ledger_db.metadata_db();
         let Some(overall_commit_progress) = ledger_metadata_db
             .get_synced_version()
             .expect("DB read failed.")
         else {
+            // Theoretically someone could bring up a new node and it could crash after saving the
+            // genesis transaction and before writing overall commit progress. Probably not worth
+            // fixing right now.
             info!("No overall commit progress was found!");
             return;
         };
@@ -488,6 +497,26 @@ impl StateStore {
             overall_commit_progress,
             crash_if_difference_is_too_large,
         );
+
+        // When `delete_on_restart` in config is flipped from true to false, the node will have been
+        // running for a while, so its hot_state_kv_db is extremely unlikely to not have a progress
+        // marker and `sync_state_kv_commit_progress` should work. Same for hot_state_merkle_db
+        // below.
+        if !delete_hot_state_on_restart && let Some(db) = &hot_state_kv_db {
+            Self::sync_state_kv_commit_progress(
+                db,
+                overall_commit_progress,
+                crash_if_difference_is_too_large,
+            );
+        }
+        if !delete_hot_state_on_restart && let Some(db) = &hot_state_merkle_db {
+            Self::sync_state_merkle_commit_progress(
+                ledger_metadata_db,
+                db,
+                overall_commit_progress,
+                crash_if_difference_is_too_large,
+            );
+        }
     }
 
     /// Reads the state KV commit progress and truncates the state KV DB back to

--- a/storage/aptosdb/src/utils/truncation_helper.rs
+++ b/storage/aptosdb/src/utils/truncation_helper.rs
@@ -9,6 +9,7 @@ use crate::{
     schema::{
         db_metadata::{DbMetadataKey, DbMetadataSchema, DbMetadataValue},
         epoch_by_version::EpochByVersionSchema,
+        hot_state_value_by_key_hash::HotStateValueByKeyHashSchema,
         jellyfish_merkle_node::JellyfishMerkleNodeSchema,
         ledger_info::LedgerInfoSchema,
         stale_node_index::StaleNodeIndexSchema,
@@ -131,6 +132,7 @@ pub(crate) fn truncate_state_kv_db_single_shard(
         state_kv_db.db_shard(shard_id),
         target_version + 1,
         &mut batch,
+        state_kv_db.is_hot(),
     )?;
     state_kv_db.commit_single_shard(target_version, shard_id, batch)
 }
@@ -549,6 +551,7 @@ fn delete_state_value_and_index(
     state_kv_db_shard: &DB,
     start_version: Version,
     batch: &mut SchemaBatch,
+    is_hot: bool,
 ) -> Result<()> {
     let mut iter = state_kv_db_shard.iter::<StaleStateValueIndexByKeyHashSchema>()?;
     iter.seek(&start_version)?;
@@ -556,10 +559,12 @@ fn delete_state_value_and_index(
     for item in iter {
         let (index, _) = item?;
         batch.delete::<StaleStateValueIndexByKeyHashSchema>(&index)?;
-        batch.delete::<StateValueByKeyHashSchema>(&(
-            index.state_key_hash,
-            index.stale_since_version,
-        ))?;
+        let db_key = (index.state_key_hash, index.stale_since_version);
+        if is_hot {
+            batch.delete::<HotStateValueByKeyHashSchema>(&db_key)?;
+        } else {
+            batch.delete::<StateValueByKeyHashSchema>(&db_key)?;
+        }
     }
 
     Ok(())


### PR DESCRIPTION

On restart, `sync_commit_progress` truncates the cold state KV and merkle DBs
back to the overall commit progress to recover from incomplete writes. The hot
state equivalents were skipped, so a crash with `delete_on_restart: false` could
leave the hot DBs ahead of the commit point, with stale or partially-written
data that never gets cleaned up.

Reuse the existing `sync_state_kv_commit_progress` and
`sync_state_merkle_commit_progress` helpers for the hot DBs as well, gated on
`!delete_on_restart` (under the default `delete_on_restart: true` the hot DBs
are wiped fresh anyway, so this path is only reached when persistence is
enabled). The per-shard self-truncation in `StateKvDb::open_sharded` is also
extended to hot, since the underlying `delete_state_value_and_index` now
branches on `is_hot` to target the correct value schema.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes crash-recovery/truncation behavior for persisted hot-state KV and Merkle DBs, which can affect on-disk state integrity after restart if the gating or schema selection is wrong.
> 
> **Overview**
> Extends crash-recovery `sync_commit_progress` to also truncate *hot state* KV and Merkle DBs back to the overall commit progress when hot-state persistence is enabled (`delete_on_restart: false`).
> 
> Updates state-KV shard self-truncation and truncation helpers to delete the correct value schema for hot vs cold DBs (switching between `HotStateValueByKeyHashSchema` and `StateValueByKeyHashSchema`), and wires the new parameters through callers including the test/debug `truncate_to_version` path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f68a55759be627a0b67b23a4dafcfc85c8b154cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->