### PR TITLE
[CD/CD] Add PR approval checks.

### DIFF
--- a/.github/actions/pr-approval-check/action.yaml
+++ b/.github/actions/pr-approval-check/action.yaml
@@ -1,0 +1,60 @@
+name: PR Approval Check
+description: "Verifies that the pull request has satisfied all path-based approval rules."
+
+inputs:
+  GH_TOKEN:
+    description: "GitHub token with pull-request read access."
+    required: true
+  ORG_TOKEN:
+    description: "GitHub token with read:org scope used to fetch org team membership."
+    required: true
+  PR_NUMBER:
+    description: "Pull-request number"
+    required: true
+  REPO:
+    description: "Repository in owner/repo format (default: github.repository)"
+    required: false
+    default: ""
+  ORG:
+    description: >
+      GitHub organization name used to resolve @team-name references in the
+      approval rules. Defaults to the owner portion of REPO (e.g. 'aptos-labs'
+      from 'aptos-labs/aptos-core').
+    required: false
+    default: ""
+  RULES_FILE:
+    description: "Path to the approval rules YAML file"
+    required: false
+    default: ".github/actions/pr-approval-check/approval-rules.yaml"
+  BASE_BRANCH:
+    description: "Branch to diff against when computing changed files"
+    required: false
+    default: "origin/main"
+
+runs:
+  using: composite
+  steps:
+    - name: Install PyYAML
+      run: pip install --quiet PyYAML
+      shell: bash
+
+    - name: Run unit tests
+      run: python3 .github/actions/pr-approval-check/test_check_pr_approvals.py
+      shell: bash
+
+    - name: Run approval check
+      run: |
+        REPO="${{ inputs.REPO }}"
+        if [ -z "$REPO" ]; then
+          REPO="${GITHUB_REPOSITORY}"
+        fi
+        ORG="${{ inputs.ORG }}"
+        python3 .github/actions/pr-approval-check/check_pr_approvals.py \
+          --rules     "${{ inputs.RULES_FILE }}" \
+          --repo      "$REPO" \
+          --pr        "${{ inputs.PR_NUMBER }}" \
+          --token     "${{ inputs.GH_TOKEN }}" \
+          --org-token "${{ inputs.ORG_TOKEN }}" \
+          --base-branch "${{ inputs.BASE_BRANCH }}" \
+          ${ORG:+--org "$ORG"}
+      shell: bash

--- a/.github/actions/pr-approval-check/approval-rules.yaml
+++ b/.github/actions/pr-approval-check/approval-rules.yaml
@@ -1,0 +1,86 @@
+# PR Approval Rules
+#
+# This file defines approval requirements that are enforced by the
+# "pr-approval-check" CI job on every pull request.
+#
+# Structure:
+#   rules:    List of approval requirements.
+#             @team-name references in rules are resolved automatically from
+#             the GitHub org teams API (e.g., https://github.com/orgs/aptos-labs/teams).
+#
+# Rule fields:
+#   - name (required):
+#       Human-readable name shown in CI output.
+#   - description (required):
+#       Explanation of why this rule exists.
+#   - paths (required):
+#       Glob patterns relative to repo root. The rule fires when ANY changed
+#       file matches at least one pattern.
+#       Patterns follow fnmatch semantics: * matches anything including /,
+#       so "foo/**" matches all files under foo/.
+#   - required_approvers (required):
+#       List of approval clauses evaluated with AND semantics — every clause
+#       must independently be satisfied. Each clause is a dict with:
+#         - approvers (required): list of GitHub usernames or @group references.
+#           Any member's approval satisfies this clause (OR within a clause).
+#         - min_approvals (required): approvals needed from the pool.
+
+rules:
+  # ── Blockchain rules ──────────────────────────────────────
+  - name: "Blockchain Rules"
+    description: Core blockchain code. Requires a single approval from the blockchain team.
+    paths:
+      - "aptos-node/**"
+      - "consensus/**"
+      - "execution/**"
+      - "mempool/**"
+      - "network/**"
+      - "peer-monitoring-service/**"
+      - "secure/**"
+      - "state-sync/**"
+      - "storage/**"
+      - "vm-validator/**"
+    required_approvers:
+      - approvers: ["@blockchain"]
+        min_approvals: 1
+
+  # ── Cryptography rules ────────────────────────────────────────
+  - name: "Cryptography Rules"
+    description: Cryptography-sensitive code. Requires a single approval from the cryptography team.
+    paths:
+      - "aptos-move/aptos-vm/src/keyless_validation.rs"
+      - "aptos-move/framework/aptos-framework/sources/keyless_account.move"
+      - "aptos-move/framework/aptos-stdlib/sources/cryptography/**"
+      - "aptos-move/framework/aptos-stdlib/sources/hash.move"
+      - "aptos-move/framework/src/natives/cryptography/**"
+      - "crates/aptos-crypto/**"
+      - "crates/aptos-crypto-derive/**"
+      - "crates/aptos-dkg/**"
+      - "keyless/**"
+      - "types/src/keyless/**"
+    required_approvers:
+      - approvers: ["@cryptography"]
+        min_approvals: 1
+
+  # ── Move rules ───────────────────────────────────────────────
+  - name: "Move Rules"
+    description: Changes to Move code or tooling require a single approval from the Move team.
+    paths:
+      - "aptos-move/**"
+      - "third_party/move/**"
+    required_approvers:
+      - approvers: ["@move"]
+        min_approvals: 1
+
+  # ── Platform-Infra rules ──────────────────────────────────────
+  - name: "Platform-Infra Rules"
+    description: Infrastructure and platform code. Requires a single approval from the platform-infra team.
+    paths:
+      - ".github/**"
+      - "dashboards/**"
+      - "docker/**"
+      - "scripts/**"
+      - "terraform/**"
+    required_approvers:
+      - approvers: ["@platform-infra"]
+        min_approvals: 1

--- a/.github/actions/pr-approval-check/check_pr_approvals.py
+++ b/.github/actions/pr-approval-check/check_pr_approvals.py
@@ -1,0 +1,417 @@
+#!/usr/bin/env python3
+"""
+check_pr_approvals.py — Enforce path-based PR approval rules.
+
+Usage:
+    python3 check_pr_approvals.py \
+        --rules   .github/actions/pr-approval-check/approval-rules.yaml \
+        --repo    aptos-labs/aptos-core \
+        --pr      <PR number> \
+        --token   <GitHub token>
+
+Exit codes:
+    0  All applicable rules are satisfied.
+    1  One or more rules are violated (or an error occurred).
+"""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import json
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from typing import Any
+
+import yaml
+
+
+# ---------------------------------------------------------------------------
+# Git helpers
+# ---------------------------------------------------------------------------
+
+def get_changed_files(base_branch: str = "origin/main") -> list[str]:
+    """Return the list of files changed relative to the merge-base with *base_branch*."""
+    try:
+        merge_base = subprocess.check_output(
+            ["git", "merge-base", "HEAD", base_branch],
+            text=True,
+        ).strip()
+    except subprocess.CalledProcessError as exc:
+        exit_fatal(f"Could not determine merge-base with '{base_branch}': {exc}")
+
+    try:
+        out = subprocess.check_output(
+            ["git", "diff", "--name-only", merge_base],
+            text=True,
+        ).strip()
+    except subprocess.CalledProcessError as exc:
+        exit_fatal(f"Could not list changed files: {exc}")
+
+    return [line for line in out.splitlines() if line]
+
+
+# ---------------------------------------------------------------------------
+# GitHub API helpers
+# ---------------------------------------------------------------------------
+
+def github_get(url: str, token: str) -> Any:
+    """Make an authenticated GET request to the GitHub API and return parsed JSON."""
+    req = urllib.request.Request(
+        url,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req) as resp:
+            return json.loads(resp.read())
+    except urllib.error.HTTPError as exc:
+        exit_fatal(f"GitHub API error {exc.code} for {url}: {exc.reason}")
+
+
+def get_pr_author(repo: str, pr_number: int, token: str) -> str:
+    """Return the GitHub login of the PR author."""
+    data = github_get(
+        f"https://api.github.com/repos/{repo}/pulls/{pr_number}",
+        token,
+    )
+    return data["user"]["login"]
+
+
+def get_org_team_members(org: str, team_slug: str, token: str) -> list[str]:
+    """Return the list of GitHub logins for all members of an org team."""
+    members: list[str] = []
+    page = 1
+    while True:
+        url = (
+            f"https://api.github.com/orgs/{org}/teams/{team_slug}/members"
+            f"?per_page=100&page={page}"
+        )
+        data = github_get(url, token)
+        if not data:
+            break
+        members.extend(m["login"] for m in data)
+        if len(data) < 100:
+            break
+        page += 1
+    return members
+
+
+def get_pr_reviews(repo: str, pr_number: int, token: str) -> dict[str, str]:
+    """
+    Return a mapping of reviewer login → most-recent review state.
+
+    States emitted by the API: APPROVED, CHANGES_REQUESTED, COMMENTED, DISMISSED.
+    Later reviews overwrite earlier ones for the same user (last review wins).
+    """
+    reviews: dict[str, str] = {}
+    page = 1
+    while True:
+        url = (
+            f"https://api.github.com/repos/{repo}/pulls/{pr_number}/reviews"
+            f"?per_page=100&page={page}"
+        )
+        data = github_get(url, token)
+        if not data:
+            break
+        for review in data:
+            login: str = review["user"]["login"]
+            state: str = review["state"]
+            reviews[login] = state
+        if len(data) < 100:
+            break
+        page += 1
+    return reviews
+
+
+# ---------------------------------------------------------------------------
+# Rule-checking logic
+# ---------------------------------------------------------------------------
+
+def expand_approvers(raw: list[str], groups: dict[str, list[str]]) -> set[str]:
+    """
+    Expand a list that may contain group references (@group-name) into a flat
+    set of GitHub usernames.
+    """
+    result: set[str] = set()
+    for entry in raw:
+        if entry.startswith("@"):
+            group_name = entry[1:]
+            if group_name not in groups:
+                exit_fatal(f"Approval rule references unknown group '@{group_name}'.")
+            else:
+                result.update(groups[group_name])
+        else:
+            result.add(entry)
+    return result
+
+
+def file_matches_any(filepath: str, patterns: list[str]) -> bool:
+    """Return True if *filepath* matches any of the glob *patterns*."""
+    for pattern in patterns:
+        if fnmatch.fnmatch(filepath, pattern):
+            return True
+    return False
+
+
+def check_rules(
+    changed_files: list[str],
+    rules: list[dict],
+    groups: dict[str, list[str]],
+    approvals: dict[str, str],
+    pr_author: str,
+) -> tuple[list[dict], list[dict]]:
+    """
+    Evaluate every rule against *changed_files* and *approvals*.
+
+    Each rule's *required_approvers* is a list of clauses evaluated with AND
+    semantics: every clause must independently be satisfied.  Within a clause,
+    the *approvers* list is an OR pool — any member's approval counts, up to
+    that clause's *min_approvals* (default: 1).
+
+    Returns:
+        (violations, applied_rules)
+        violations    — rules that apply but are not satisfied.
+        applied_rules — all rules that apply (satisfied or not).
+    """
+    # Build the set of users who gave an APPROVED review (excluding the PR
+    # author, who cannot approve their own PR on GitHub).
+    approved_by: set[str] = {
+        login
+        for login, state in approvals.items()
+        if state == "APPROVED" and login != pr_author
+    }
+
+    violations: list[dict] = []
+    applied: list[dict] = []
+
+    for rule in rules:
+        name: str = rule["name"]
+        paths: list[str] = rule.get("paths", [])
+        clauses: list[dict] = rule["required_approvers"]
+
+        # Collect all changed files that are covered by this rule.
+        matching_files = [f for f in changed_files if file_matches_any(f, paths)]
+        if not matching_files:
+            continue  # This rule does not apply to the current PR.
+
+        # AND mode: every clause must be independently satisfied.
+        clause_results = []
+        for clause in clauses:
+            pool = expand_approvers(clause["approvers"], groups)
+            needed: int = clause["min_approvals"]
+            qualifying = approved_by & pool
+            clause_results.append({
+                "pool": sorted(pool),
+                "needed": needed,
+                "qualifying": sorted(qualifying),
+                "satisfied": len(qualifying) >= needed,
+            })
+        unsatisfied_clauses = [c for c in clause_results if not c["satisfied"]]
+        applied_entry = {
+            "rule": name,
+            "description": rule["description"],
+            "matching_files": matching_files,
+            "clause_results": clause_results,
+            "unsatisfied_clauses": unsatisfied_clauses,
+        }
+
+        applied.append(applied_entry)
+        if unsatisfied_clauses:
+            violations.append(applied_entry)
+
+    return violations, applied
+
+
+# ---------------------------------------------------------------------------
+# Output helpers
+# ---------------------------------------------------------------------------
+
+def exit_fatal(msg: str) -> None:
+    print(f"[approval-check] ERROR: {msg}", file=sys.stderr)
+    sys.exit(1)
+
+
+def section(title: str) -> None:
+    print(f"\n{'=' * 60}")
+    print(f"  {title}")
+    print("=" * 60)
+
+
+def validate_rules(rules: list[dict]) -> None:
+    """Validate that every rule has all required fields. Calls exit_fatal on the first problem found."""
+    missing_description = [r.get("name", f"rule[{i}]") for i, r in enumerate(rules) if not r.get("description")]
+    if missing_description:
+        exit_fatal(f"The following rule(s) are missing a required 'description' field: {missing_description}")
+    missing_approvers = [r.get("name", f"rule[{i}]") for i, r in enumerate(rules) if not r.get("required_approvers")]
+    if missing_approvers:
+        exit_fatal(f"The following rule(s) are missing a required 'required_approvers' field: {missing_approvers}")
+    missing_min = [
+        f"{r.get('name', f'rule[{i}]')}.required_approvers[{j}]"
+        for i, r in enumerate(rules)
+        for j, clause in enumerate(r.get("required_approvers", []))
+        if "min_approvals" not in clause or clause["min_approvals"] < 1
+    ]
+    if missing_min:
+        exit_fatal(f"The following clause(s) are missing or have an invalid 'min_approvals' field (must be >= 1): {missing_min}")
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Verify that a PR satisfies path-based approval rules."
+    )
+    parser.add_argument(
+        "--rules",
+        default=".github/actions/pr-approval-check/approval-rules.yaml",
+        help="Path to the YAML approval-rules file (default: .github/actions/pr-approval-check/approval-rules.yaml)",
+    )
+    parser.add_argument(
+        "--repo",
+        required=True,
+        help="GitHub repository in owner/repo format (e.g. aptos-labs/aptos-core)",
+    )
+    parser.add_argument(
+        "--pr",
+        required=True,
+        type=int,
+        help="Pull-request number",
+    )
+    parser.add_argument(
+        "--token",
+        required=True,
+        help="GitHub API token with pull-request read access (secrets.GITHUB_TOKEN is sufficient)",
+    )
+    parser.add_argument(
+        "--org-token",
+        required=True,
+        help="GitHub API token with read:org scope, used to fetch org team membership (must be a PAT or app token)",
+    )
+    parser.add_argument(
+        "--base-branch",
+        default="origin/main",
+        help="Branch to diff against when computing changed files (default: origin/main)",
+    )
+    parser.add_argument(
+        "--org",
+        default="",
+        help=(
+            "GitHub organization name used to resolve @team-name references that are not "
+            "defined in the rules file (default: extracted from --repo, e.g. 'aptos-labs' "
+            "from 'aptos-labs/aptos-core').  The token must have 'read:org' scope."
+        ),
+    )
+    args = parser.parse_args()
+
+    # ── Load rules ───────────────────────────────────────────────────────────
+    try:
+        with open(args.rules) as fh:
+            config = yaml.safe_load(fh)
+    except FileNotFoundError:
+        exit_fatal(f"Rules file not found: {args.rules}")
+    except yaml.YAMLError as exc:
+        exit_fatal(f"Failed to parse rules file: {exc}")
+
+    rules: list[dict] = config.get("rules", [])
+
+    if not rules:
+        print("[approval-check] No rules defined — nothing to check.")
+        return
+
+    # ── Resolve team references from GitHub org ──────────────────────────────
+    # Collect every @team-name referenced in the rules and fetch its members
+    # from the GitHub org teams API.
+    org = args.org if args.org else args.repo.split("/")[0]
+    referenced_groups: set[str] = set()
+    for rule in rules:
+        for clause in rule.get("required_approvers", []):
+            for approver in clause.get("approvers", []):
+                if approver.startswith("@"):
+                    referenced_groups.add(approver[1:])
+
+    groups: dict[str, list[str]] = {}
+    if referenced_groups:
+        print(f"[approval-check] Fetching {len(referenced_groups)} team(s) from GitHub org '{org}'…")
+        for team_slug in sorted(referenced_groups):
+            print(f"  → {org}/{team_slug}")
+            members = get_org_team_members(org, team_slug, args.org_token)
+            if not members:
+                exit_fatal(
+                    f"GitHub team '{org}/{team_slug}' was not found or has no members. "
+                    f"Ensure the token has 'read:org' scope and the team slug is correct."
+                )
+            groups[team_slug] = members
+            print(f"     {len(members)} member(s): {members}")
+
+    # Validate that every rule has all required fields.
+    validate_rules(rules)
+
+    # ── Gather inputs ────────────────────────────────────────────────────────
+    section("Gathering PR information")
+
+    changed_files = get_changed_files(args.base_branch)
+    print(f"Changed files ({len(changed_files)} total):")
+    for f in changed_files:
+        print(f"  {f}")
+
+    pr_author = get_pr_author(args.repo, args.pr, args.token)
+    print(f"\nPR author: {pr_author}")
+
+    reviews = get_pr_reviews(args.repo, args.pr, args.token)
+    approved_reviewers = [u for u, s in reviews.items() if s == "APPROVED" and u != pr_author]
+    print(f"Approvals ({len(approved_reviewers)}): {approved_reviewers or '(none)'}")
+
+    # ── Evaluate rules ───────────────────────────────────────────────────────
+    section("Evaluating approval rules")
+
+    violations, applied = check_rules(changed_files, rules, groups, reviews, pr_author)
+
+    if not applied:
+        print("No approval rules apply to the files changed in this PR.")
+        return
+
+    for entry in applied:
+        status = "PASS" if entry not in violations else "FAIL"
+        print(f"\n[{status}] {entry['rule']}")
+        # Print description as a single line (strip whitespace/newlines from YAML block scalars).
+        print(f"       {' '.join(entry['description'].split())}")
+        # Show the first few matching files for context.
+        shown = entry["matching_files"][:5]
+        ellipsis = f" … (+{len(entry['matching_files']) - 5} more)" if len(entry["matching_files"]) > 5 else ""
+        print(f"       Files: {shown}{ellipsis}")
+        for i, clause in enumerate(entry["clause_results"], 1):
+            clause_status = "ok" if clause["satisfied"] else "MISSING"
+            label = f"Clause {i}" if len(entry["clause_results"]) > 1 else "Requires"
+            print(
+                f"       {label}: {clause['needed']} approval(s) from {clause['pool']}"
+                f"  →  {clause_status} (have: {clause['qualifying'] or 'none'})"
+            )
+
+    # ── Final result ─────────────────────────────────────────────────────────
+    section("Result")
+
+    if violations:
+        print(f"FAILED — {len(violations)} rule(s) not satisfied:\n")
+        for v in violations:
+            print(f"  • {v['rule']}")
+            for clause in v["unsatisfied_clauses"]:
+                print(
+                    f"    Need {clause['needed']} approval(s) from {clause['pool']}"
+                    f", have {clause['qualifying'] or 'none'}"
+                )
+        print()
+        sys.exit(1)
+    else:
+        print(f"PASSED — all {len(applied)} applicable rule(s) satisfied.")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/actions/pr-approval-check/check_pr_approvals.py
+++ b/.github/actions/pr-approval-check/check_pr_approvals.py
@@ -109,7 +109,7 @@ def get_pr_reviews(repo: str, pr_number: int, token: str) -> dict[str, str]:
     States emitted by the API: APPROVED, CHANGES_REQUESTED, COMMENTED, DISMISSED.
     Later reviews overwrite earlier ones for the same user (last review wins).
     """
-    reviews: dict[str, str] = {}
+    all_reviews: list[dict] = []
     page = 1
     while True:
         url = (
@@ -119,13 +119,14 @@ def get_pr_reviews(repo: str, pr_number: int, token: str) -> dict[str, str]:
         data = github_get(url, token)
         if not data:
             break
-        for review in data:
-            login: str = review["user"]["login"]
-            state: str = review["state"]
-            reviews[login] = state
+        all_reviews.extend(data)
         if len(data) < 100:
             break
         page += 1
+
+    reviews: dict[str, str] = {}
+    for review in sorted(all_reviews, key=lambda r: r["id"]):
+        reviews[review["user"]["login"]] = review["state"]
     return reviews
 
 

--- a/.github/actions/pr-approval-check/test_check_pr_approvals.py
+++ b/.github/actions/pr-approval-check/test_check_pr_approvals.py
@@ -1,0 +1,488 @@
+#!/usr/bin/env python3
+"""Unit tests for check_pr_approvals.py."""
+
+import unittest
+from unittest.mock import patch
+
+from check_pr_approvals import (
+    check_rules,
+    expand_approvers,
+    file_matches_any,
+    get_org_team_members,
+    get_pr_reviews,
+    validate_rules,
+)
+
+GROUPS = {
+    "consensus-team": ["alice", "bob"],
+    "crypto-team": ["carol", "dave"],
+}
+
+
+# ---------------------------------------------------------------------------
+# expand_approvers
+# ---------------------------------------------------------------------------
+
+class TestExpandApprovers(unittest.TestCase):
+
+    def test_plain_username(self):
+        self.assertEqual(expand_approvers(["alice"], {}), {"alice"})
+
+    def test_group_reference(self):
+        self.assertEqual(expand_approvers(["@consensus-team"], GROUPS), {"alice", "bob"})
+
+    def test_mixed_users_and_groups(self):
+        result = expand_approvers(["eve", "@consensus-team"], GROUPS)
+        self.assertEqual(result, {"alice", "bob", "eve"})
+
+    def test_multiple_groups_union(self):
+        result = expand_approvers(["@consensus-team", "@crypto-team"], GROUPS)
+        self.assertEqual(result, {"alice", "bob", "carol", "dave"})
+
+    def test_same_user_in_two_groups_deduplicates(self):
+        groups = {"a": ["alice", "bob"], "b": ["alice", "carol"]}
+        result = expand_approvers(["@a", "@b"], groups)
+        self.assertEqual(result, {"alice", "bob", "carol"})
+
+    def test_empty_list(self):
+        self.assertEqual(expand_approvers([], GROUPS), set())
+
+    def test_unknown_group_dies(self):
+        with self.assertRaises(SystemExit):
+            expand_approvers(["@unknown-team"], GROUPS)
+
+
+# ---------------------------------------------------------------------------
+# file_matches_any
+# ---------------------------------------------------------------------------
+
+class TestFileMatchesAny(unittest.TestCase):
+
+    def test_exact_match(self):
+        self.assertTrue(file_matches_any("consensus/foo.rs", ["consensus/foo.rs"]))
+
+    def test_double_star_matches_nested_path(self):
+        self.assertTrue(file_matches_any("consensus/safety-rules/src/lib.rs", ["consensus/**"]))
+
+    def test_double_star_matches_direct_child(self):
+        self.assertTrue(file_matches_any("consensus/lib.rs", ["consensus/**"]))
+
+    def test_similar_prefix_does_not_match(self):
+        # "consensus_other/foo.rs" must not match "consensus/**"
+        self.assertFalse(file_matches_any("consensus_other/foo.rs", ["consensus/**"]))
+
+    def test_no_match_returns_false(self):
+        self.assertFalse(file_matches_any("mempool/foo.rs", ["consensus/**"]))
+
+    def test_empty_patterns_returns_false(self):
+        self.assertFalse(file_matches_any("consensus/foo.rs", []))
+
+    def test_first_of_multiple_patterns_matches(self):
+        self.assertTrue(file_matches_any("consensus/foo.rs", ["consensus/**", "crypto/**"]))
+
+    def test_second_of_multiple_patterns_matches(self):
+        self.assertTrue(file_matches_any("crypto/foo.rs", ["consensus/**", "crypto/**"]))
+
+    def test_star_matches_filename(self):
+        self.assertTrue(file_matches_any("consensus/foo.rs", ["consensus/*.rs"]))
+
+    def test_star_crosses_slash(self):
+        # Python's fnmatch treats * as matching any character including /,
+        # so "consensus/*.rs" matches files at any depth under consensus/.
+        self.assertTrue(file_matches_any("consensus/src/foo.rs", ["consensus/*.rs"]))
+
+
+# ---------------------------------------------------------------------------
+# check_rules helpers
+# ---------------------------------------------------------------------------
+
+def make_rule(name, paths, clauses, description="A rule."):
+    return {
+        "name": name,
+        "description": description,
+        "paths": paths,
+        "required_approvers": clauses,
+    }
+
+
+def make_clause(approvers, min_approvals):
+    return {"approvers": approvers, "min_approvals": min_approvals}
+
+
+# ---------------------------------------------------------------------------
+# check_rules
+# ---------------------------------------------------------------------------
+
+class TestCheckRules(unittest.TestCase):
+
+    # ── Rule applicability ────────────────────────────────────────────────────
+
+    def test_no_changed_files_no_rules_applied(self):
+        rule = make_rule("R", ["consensus/**"], [make_clause(["alice"], 1)])
+        violations, applied = check_rules([], [rule], {}, {}, "author")
+        self.assertEqual(applied, [])
+        self.assertEqual(violations, [])
+
+    def test_changed_file_not_matching_path_skips_rule(self):
+        rule = make_rule("R", ["consensus/**"], [make_clause(["alice"], 1)])
+        violations, applied = check_rules(["mempool/foo.rs"], [rule], {}, {}, "author")
+        self.assertEqual(applied, [])
+
+    def test_changed_file_matching_path_applies_rule(self):
+        rule = make_rule("R", ["consensus/**"], [make_clause(["alice"], 1)])
+        approvals = {"alice": "APPROVED"}
+        _, applied = check_rules(["consensus/foo.rs"], [rule], {}, approvals, "author")
+        self.assertEqual(len(applied), 1)
+        self.assertEqual(applied[0]["rule"], "R")
+
+    # ── Single clause pass / fail ─────────────────────────────────────────────
+
+    def test_single_clause_satisfied(self):
+        rule = make_rule("R", ["consensus/**"], [make_clause(["alice"], 1)])
+        violations, _ = check_rules(
+            ["consensus/foo.rs"], [rule], {}, {"alice": "APPROVED"}, "author"
+        )
+        self.assertEqual(violations, [])
+
+    def test_single_clause_no_approvals_is_violation(self):
+        rule = make_rule("R", ["consensus/**"], [make_clause(["alice"], 1)])
+        violations, _ = check_rules(["consensus/foo.rs"], [rule], {}, {}, "author")
+        self.assertEqual(len(violations), 1)
+
+    def test_min_approvals_2_with_1_approval_is_violation(self):
+        rule = make_rule("R", ["consensus/**"], [make_clause(["alice", "bob"], 2)])
+        violations, _ = check_rules(
+            ["consensus/foo.rs"], [rule], {}, {"alice": "APPROVED"}, "author"
+        )
+        self.assertEqual(len(violations), 1)
+
+    def test_min_approvals_2_with_2_approvals_passes(self):
+        rule = make_rule("R", ["consensus/**"], [make_clause(["alice", "bob"], 2)])
+        approvals = {"alice": "APPROVED", "bob": "APPROVED"}
+        violations, _ = check_rules(["consensus/foo.rs"], [rule], {}, approvals, "author")
+        self.assertEqual(violations, [])
+
+    # ── AND semantics (multiple clauses) ─────────────────────────────────────
+
+    def test_and_both_clauses_satisfied(self):
+        rule = make_rule("R", ["consensus/**"], [
+            make_clause(["alice"], 1),
+            make_clause(["carol"], 1),
+        ])
+        approvals = {"alice": "APPROVED", "carol": "APPROVED"}
+        violations, _ = check_rules(["consensus/foo.rs"], [rule], {}, approvals, "author")
+        self.assertEqual(violations, [])
+
+    def test_and_first_clause_fails(self):
+        rule = make_rule("R", ["consensus/**"], [
+            make_clause(["alice"], 1),
+            make_clause(["carol"], 1),
+        ])
+        violations, _ = check_rules(
+            ["consensus/foo.rs"], [rule], {}, {"carol": "APPROVED"}, "author"
+        )
+        self.assertEqual(len(violations), 1)
+        unsatisfied = violations[0]["unsatisfied_clauses"]
+        self.assertEqual(len(unsatisfied), 1)
+        self.assertIn("alice", unsatisfied[0]["pool"])
+
+    def test_and_second_clause_fails(self):
+        rule = make_rule("R", ["consensus/**"], [
+            make_clause(["alice"], 1),
+            make_clause(["carol"], 1),
+        ])
+        violations, _ = check_rules(
+            ["consensus/foo.rs"], [rule], {}, {"alice": "APPROVED"}, "author"
+        )
+        self.assertEqual(len(violations), 1)
+        unsatisfied = violations[0]["unsatisfied_clauses"]
+        self.assertEqual(len(unsatisfied), 1)
+        self.assertIn("carol", unsatisfied[0]["pool"])
+
+    def test_and_both_clauses_fail_both_in_unsatisfied(self):
+        rule = make_rule("R", ["consensus/**"], [
+            make_clause(["alice"], 1),
+            make_clause(["carol"], 1),
+        ])
+        violations, _ = check_rules(["consensus/foo.rs"], [rule], {}, {}, "author")
+        self.assertEqual(len(violations), 1)
+        self.assertEqual(len(violations[0]["unsatisfied_clauses"]), 2)
+
+    # ── PR author exclusion ───────────────────────────────────────────────────
+
+    def test_pr_author_approval_excluded(self):
+        rule = make_rule("R", ["consensus/**"], [make_clause(["author"], 1)])
+        violations, _ = check_rules(
+            ["consensus/foo.rs"], [rule], {}, {"author": "APPROVED"}, "author"
+        )
+        self.assertEqual(len(violations), 1)
+
+    def test_pr_author_excluded_but_other_reviewer_counts(self):
+        rule = make_rule("R", ["consensus/**"], [make_clause(["author", "alice"], 1)])
+        approvals = {"author": "APPROVED", "alice": "APPROVED"}
+        violations, _ = check_rules(["consensus/foo.rs"], [rule], {}, approvals, "author")
+        self.assertEqual(violations, [])
+
+    # ── Non-APPROVED review states ────────────────────────────────────────────
+
+    def test_changes_requested_does_not_count(self):
+        rule = make_rule("R", ["consensus/**"], [make_clause(["alice"], 1)])
+        violations, _ = check_rules(
+            ["consensus/foo.rs"], [rule], {}, {"alice": "CHANGES_REQUESTED"}, "author"
+        )
+        self.assertEqual(len(violations), 1)
+
+    def test_commented_does_not_count(self):
+        rule = make_rule("R", ["consensus/**"], [make_clause(["alice"], 1)])
+        violations, _ = check_rules(
+            ["consensus/foo.rs"], [rule], {}, {"alice": "COMMENTED"}, "author"
+        )
+        self.assertEqual(len(violations), 1)
+
+    def test_dismissed_does_not_count(self):
+        rule = make_rule("R", ["consensus/**"], [make_clause(["alice"], 1)])
+        violations, _ = check_rules(
+            ["consensus/foo.rs"], [rule], {}, {"alice": "DISMISSED"}, "author"
+        )
+        self.assertEqual(len(violations), 1)
+
+    # ── Last-review-wins ──────────────────────────────────────────────────────
+
+    def test_last_review_wins_approved_then_changes_requested(self):
+        # The approvals dict already reflects last-review-wins (built in get_pr_reviews),
+        # so simulate a user whose final state is CHANGES_REQUESTED.
+        rule = make_rule("R", ["consensus/**"], [make_clause(["alice"], 1)])
+        violations, _ = check_rules(
+            ["consensus/foo.rs"], [rule], {}, {"alice": "CHANGES_REQUESTED"}, "author"
+        )
+        self.assertEqual(len(violations), 1)
+
+    def test_last_review_wins_changes_requested_then_approved(self):
+        rule = make_rule("R", ["consensus/**"], [make_clause(["alice"], 1)])
+        violations, _ = check_rules(
+            ["consensus/foo.rs"], [rule], {}, {"alice": "APPROVED"}, "author"
+        )
+        self.assertEqual(violations, [])
+
+    # ── Group expansion inside check_rules ───────────────────────────────────
+
+    def test_group_reference_in_clause_expands(self):
+        rule = make_rule("R", ["consensus/**"], [make_clause(["@consensus-team"], 1)])
+        approvals = {"bob": "APPROVED"}
+        violations, _ = check_rules(
+            ["consensus/foo.rs"], [rule], GROUPS, approvals, "author"
+        )
+        self.assertEqual(violations, [])
+
+    def test_unknown_group_in_clause_dies(self):
+        rule = make_rule("R", ["consensus/**"], [make_clause(["@nonexistent"], 1)])
+        with self.assertRaises(SystemExit):
+            check_rules(["consensus/foo.rs"], [rule], {}, {}, "author")
+
+    # ── Multiple rules ────────────────────────────────────────────────────────
+
+    def test_multiple_rules_both_pass(self):
+        rules = [
+            make_rule("R1", ["consensus/**"], [make_clause(["alice"], 1)]),
+            make_rule("R2", ["crypto/**"], [make_clause(["carol"], 1)]),
+        ]
+        approvals = {"alice": "APPROVED", "carol": "APPROVED"}
+        violations, applied = check_rules(
+            ["consensus/foo.rs", "crypto/bar.rs"], rules, {}, approvals, "author"
+        )
+        self.assertEqual(len(applied), 2)
+        self.assertEqual(violations, [])
+
+    def test_multiple_rules_one_fails(self):
+        rules = [
+            make_rule("R1", ["consensus/**"], [make_clause(["alice"], 1)]),
+            make_rule("R2", ["crypto/**"], [make_clause(["carol"], 1)]),
+        ]
+        violations, applied = check_rules(
+            ["consensus/foo.rs", "crypto/bar.rs"], rules, {}, {"alice": "APPROVED"}, "author"
+        )
+        self.assertEqual(len(applied), 2)
+        self.assertEqual(len(violations), 1)
+        self.assertEqual(violations[0]["rule"], "R2")
+
+    def test_multiple_rules_only_one_applies(self):
+        rules = [
+            make_rule("R1", ["consensus/**"], [make_clause(["alice"], 1)]),
+            make_rule("R2", ["crypto/**"], [make_clause(["carol"], 1)]),
+        ]
+        violations, applied = check_rules(
+            ["consensus/foo.rs"], rules, {}, {"alice": "APPROVED"}, "author"
+        )
+        self.assertEqual(len(applied), 1)
+        self.assertEqual(applied[0]["rule"], "R1")
+        self.assertEqual(violations, [])
+
+    # ── clause_results structure ──────────────────────────────────────────────
+
+    def test_clause_results_structure(self):
+        rule = make_rule("R", ["consensus/**"], [make_clause(["alice", "bob"], 2)])
+        approvals = {"alice": "APPROVED"}
+        _, applied = check_rules(["consensus/foo.rs"], [rule], {}, approvals, "author")
+        cr = applied[0]["clause_results"][0]
+        self.assertEqual(sorted(cr["pool"]), ["alice", "bob"])
+        self.assertEqual(cr["needed"], 2)
+        self.assertEqual(cr["qualifying"], ["alice"])
+        self.assertFalse(cr["satisfied"])
+
+    def test_matching_files_recorded(self):
+        rule = make_rule("R", ["consensus/**"], [make_clause(["alice"], 1)])
+        files = ["consensus/a.rs", "consensus/b.rs", "mempool/c.rs"]
+        approvals = {"alice": "APPROVED"}
+        _, applied = check_rules(files, [rule], {}, approvals, "author")
+        self.assertEqual(sorted(applied[0]["matching_files"]), ["consensus/a.rs", "consensus/b.rs"])
+
+
+# ---------------------------------------------------------------------------
+# validate_rules
+# ---------------------------------------------------------------------------
+
+class TestValidateRules(unittest.TestCase):
+
+    def _valid_rule(self, name="R"):
+        return {
+            "name": name,
+            "description": "A rule.",
+            "paths": ["foo/**"],
+            "required_approvers": [{"approvers": ["alice"], "min_approvals": 1}],
+        }
+
+    def test_valid_rule_passes(self):
+        validate_rules([self._valid_rule()])  # should not raise
+
+    def test_missing_description_is_fatal(self):
+        rule = self._valid_rule()
+        del rule["description"]
+        with self.assertRaises(SystemExit):
+            validate_rules([rule])
+
+    def test_missing_required_approvers_is_fatal(self):
+        rule = self._valid_rule()
+        del rule["required_approvers"]
+        with self.assertRaises(SystemExit):
+            validate_rules([rule])
+
+    def test_missing_min_approvals_is_fatal(self):
+        rule = self._valid_rule()
+        del rule["required_approvers"][0]["min_approvals"]
+        with self.assertRaises(SystemExit):
+            validate_rules([rule])
+
+    def test_min_approvals_zero_is_fatal(self):
+        rule = self._valid_rule()
+        rule["required_approvers"][0]["min_approvals"] = 0
+        with self.assertRaises(SystemExit):
+            validate_rules([rule])
+
+    def test_min_approvals_negative_is_fatal(self):
+        rule = self._valid_rule()
+        rule["required_approvers"][0]["min_approvals"] = -1
+        with self.assertRaises(SystemExit):
+            validate_rules([rule])
+
+
+# ---------------------------------------------------------------------------
+# get_org_team_members
+# ---------------------------------------------------------------------------
+
+class TestGetOrgTeamMembers(unittest.TestCase):
+
+    def _member(self, login):
+        return {"login": login}
+
+    @patch("check_pr_approvals.github_get")
+    def test_single_page(self, mock_get):
+        mock_get.return_value = [self._member("alice"), self._member("bob")]
+        result = get_org_team_members("my-org", "my-team", "token")
+        self.assertEqual(result, ["alice", "bob"])
+        self.assertEqual(mock_get.call_count, 1)
+        called_url = mock_get.call_args[0][0]
+        self.assertIn("my-org", called_url)
+        self.assertIn("my-team", called_url)
+
+    @patch("check_pr_approvals.github_get")
+    def test_empty_team_returns_empty_list(self, mock_get):
+        mock_get.return_value = []
+        result = get_org_team_members("my-org", "empty-team", "token")
+        self.assertEqual(result, [])
+
+    @patch("check_pr_approvals.github_get")
+    def test_full_page_triggers_second_fetch(self, mock_get):
+        page1 = [self._member(f"user{i}") for i in range(100)]
+        page2 = [self._member("extra")]
+        mock_get.side_effect = [page1, page2]
+        result = get_org_team_members("my-org", "big-team", "token")
+        self.assertEqual(mock_get.call_count, 2)
+        self.assertIn("extra", result)
+        self.assertEqual(len(result), 101)
+
+    @patch("check_pr_approvals.github_get")
+    def test_partial_second_page_stops_pagination(self, mock_get):
+        page1 = [self._member(f"user{i}") for i in range(100)]
+        page2 = [self._member("last1"), self._member("last2")]
+        mock_get.side_effect = [page1, page2]
+        result = get_org_team_members("my-org", "some-team", "token")
+        self.assertEqual(mock_get.call_count, 2)
+        self.assertEqual(len(result), 102)
+
+
+# ---------------------------------------------------------------------------
+# get_pr_reviews
+# ---------------------------------------------------------------------------
+
+class TestGetPrReviews(unittest.TestCase):
+
+    def _review(self, login, state):
+        return {"user": {"login": login}, "state": state}
+
+    @patch("check_pr_approvals.github_get")
+    def test_single_page(self, mock_get):
+        mock_get.return_value = [self._review("alice", "APPROVED")]
+        result = get_pr_reviews("owner/repo", 1, "token")
+        self.assertEqual(result, {"alice": "APPROVED"})
+        self.assertEqual(mock_get.call_count, 1)
+
+    @patch("check_pr_approvals.github_get")
+    def test_empty_first_page_returns_empty(self, mock_get):
+        mock_get.return_value = []
+        result = get_pr_reviews("owner/repo", 1, "token")
+        self.assertEqual(result, {})
+
+    @patch("check_pr_approvals.github_get")
+    def test_full_page_triggers_second_fetch(self, mock_get):
+        page1 = [self._review(f"user{i}", "APPROVED") for i in range(100)]
+        page2 = [self._review("extra", "APPROVED")]
+        mock_get.side_effect = [page1, page2]
+        result = get_pr_reviews("owner/repo", 1, "token")
+        self.assertEqual(mock_get.call_count, 2)
+        self.assertIn("extra", result)
+
+    @patch("check_pr_approvals.github_get")
+    def test_last_review_wins(self, mock_get):
+        # Reviews are returned in chronological order; later entries overwrite earlier.
+        mock_get.return_value = [
+            self._review("alice", "APPROVED"),
+            self._review("alice", "CHANGES_REQUESTED"),
+        ]
+        result = get_pr_reviews("owner/repo", 1, "token")
+        self.assertEqual(result["alice"], "CHANGES_REQUESTED")
+
+    @patch("check_pr_approvals.github_get")
+    def test_multiple_reviewers_tracked_independently(self, mock_get):
+        mock_get.return_value = [
+            self._review("alice", "APPROVED"),
+            self._review("bob", "CHANGES_REQUESTED"),
+            self._review("carol", "COMMENTED"),
+        ]
+        result = get_pr_reviews("owner/repo", 1, "token")
+        self.assertEqual(result["alice"], "APPROVED")
+        self.assertEqual(result["bob"], "CHANGES_REQUESTED")
+        self.assertEqual(result["carol"], "COMMENTED")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/actions/pr-approval-check/test_check_pr_approvals.py
+++ b/.github/actions/pr-approval-check/test_check_pr_approvals.py
@@ -436,8 +436,8 @@ class TestGetOrgTeamMembers(unittest.TestCase):
 
 class TestGetPrReviews(unittest.TestCase):
 
-    def _review(self, login, state):
-        return {"user": {"login": login}, "state": state}
+    def _review(self, login, state, review_id=1):
+        return {"id": review_id, "user": {"login": login}, "state": state}
 
     @patch("check_pr_approvals.github_get")
     def test_single_page(self, mock_get):
@@ -454,8 +454,8 @@ class TestGetPrReviews(unittest.TestCase):
 
     @patch("check_pr_approvals.github_get")
     def test_full_page_triggers_second_fetch(self, mock_get):
-        page1 = [self._review(f"user{i}", "APPROVED") for i in range(100)]
-        page2 = [self._review("extra", "APPROVED")]
+        page1 = [self._review(f"user{i}", "APPROVED", review_id=i) for i in range(100)]
+        page2 = [self._review("extra", "APPROVED", review_id=100)]
         mock_get.side_effect = [page1, page2]
         result = get_pr_reviews("owner/repo", 1, "token")
         self.assertEqual(mock_get.call_count, 2)
@@ -465,8 +465,8 @@ class TestGetPrReviews(unittest.TestCase):
     def test_last_review_wins(self, mock_get):
         # Reviews are returned in chronological order; later entries overwrite earlier.
         mock_get.return_value = [
-            self._review("alice", "APPROVED"),
-            self._review("alice", "CHANGES_REQUESTED"),
+            self._review("alice", "APPROVED", review_id=1),
+            self._review("alice", "CHANGES_REQUESTED", review_id=2),
         ]
         result = get_pr_reviews("owner/repo", 1, "token")
         self.assertEqual(result["alice"], "CHANGES_REQUESTED")

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -2,6 +2,8 @@ name: "Lint+Test"
 on:
   pull_request:
     types: [labeled, opened, synchronize, reopened, auto_merge_enabled]
+  pull_request_review:
+    types: [submitted]
   push:
     branches:
       - main
@@ -21,7 +23,7 @@ env:
 # cancel redundant builds
 concurrency:
   # cancel redundant builds on PRs (only on PR, not on branches)
-  group: ${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.ref) || github.sha }}
+  group: ${{ github.workflow }}-${{ ((github.event_name == 'pull_request' || github.event_name == 'pull_request_review') && github.event.pull_request.number) || github.sha }}
   cancel-in-progress: true
 
 jobs:
@@ -52,6 +54,31 @@ jobs:
           GIT_CREDENTIALS: ${{ secrets.GIT_CREDENTIALS }}
       - run: echo "Skipping general lints! Unrelated changes detected."
         if: needs.file_change_determinator.outputs.only_docs_changed == 'true'
+
+  # Verify that path-based PR approval rules are satisfied. This is a PR required job.
+  pr-approval-check:
+    if: github.event_name == 'pull_request' || github.event_name == 'pull_request_review'
+    runs-on: 2cpu-gh-ubuntu24-x64
+    environment: review-gatekeeper
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # needed to compute the merge-base for changed files
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+      - name: Check PR approvals
+        uses: ./.github/actions/pr-approval-check
+        with:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ORG_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
 
   # Run the crypto hasher domain separation checks
   rust-cryptohasher-domain-separation-check:


### PR DESCRIPTION
## Description
This PR adds a new GitHub workflow for path-based PR approval checking.                                                                                                                                  

It introduces: (i) an `approval-rules.yaml` config mapping file patterns to required approvers; (ii) a Python script (`check_pr_approvals.py`) that evaluates rules against a PR's changed files and current approvals (`@team` references resolved via the GitHub org API; PR author excluded from self-approval); and (iii) a reusable `action.yaml` wrapping the script. 

The `lint-test.yaml` CI pipeline is updated to run this as a required check on every PR.

## Testing Plan
New and existing test infrastructure (as well as manual verification).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new required CI gate that can block merges; correctness depends on GitHub API access (team membership/reviews) and the accuracy of the path-to-team rules, so misconfig or token issues could cause false failures.
> 
> **Overview**
> Adds a new composite action (`.github/actions/pr-approval-check`) that installs PyYAML, runs unit tests, and executes a Python-based approval evaluator against the PR.
> 
> Introduces `approval-rules.yaml` to map changed-path globs to required approver clauses (including `@team` expansion via the GitHub org API, AND semantics across clauses, and excluding self-approval).
> 
> Updates `lint-test.yaml` to run the new **required** `pr-approval-check` job on both `pull_request` and `pull_request_review` events (with updated concurrency grouping) and uses a GitHub App token to read org team membership.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f149adddb25bb2d6c1c3079173959f63486c31a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->