### PR TITLE
Enable bytecode format v10 on testnet

### DIFF
--- a/aptos-move/aptos-release-builder/data/public-args.yaml
+++ b/aptos-move/aptos-release-builder/data/public-args.yaml
@@ -1,0 +1,12 @@
+remote_endpoint: ~
+name: "v1.44-public-struct-enum-args"
+proposals:
+  - name: public_struct_enum_args
+    metadata:
+      title: "Proposal to enable public structs and enums as transaction arguments"
+      description: "public structs and enums (AIP-142, https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-142-public-structs-and-enums.md)."
+    execution_mode: MultiStep
+    update_sequence:
+      - FeatureFlag:
+          enabled:
+            - public_struct_enum_args

--- a/aptos-move/aptos-release-builder/data/vm-binary-format-v10.yaml
+++ b/aptos-move/aptos-release-builder/data/vm-binary-format-v10.yaml
@@ -1,0 +1,12 @@
+remote_endpoint: ~
+name: "v1.44-v-m-binary-format-v10"
+proposals:
+  - name: v_m_binary_format_v10
+    metadata:
+      title: "Proposal to enable bytecode format v10"
+      description: "Enable VM binary format v10, which introduces support for Move abort-with-message (AIP-138, https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-138-move-aborts-with-message.md) and public structs and enums (AIP-142, https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-142-public-structs-and-enums.md)."
+      execution_mode: MultiStep
+    update_sequence:
+      - FeatureFlag:
+          enabled:
+            - v_m_binary_format_v10

--- a/aptos-move/aptos-release-builder/data/vm-binary-format-v10.yaml
+++ b/aptos-move/aptos-release-builder/data/vm-binary-format-v10.yaml
@@ -5,7 +5,7 @@ proposals:
     metadata:
       title: "Proposal to enable bytecode format v10"
       description: "Enable VM binary format v10, which introduces support for Move abort-with-message (AIP-138, https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-138-move-aborts-with-message.md) and public structs and enums (AIP-142, https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-142-public-structs-and-enums.md)."
-      execution_mode: MultiStep
+    execution_mode: MultiStep
     update_sequence:
       - FeatureFlag:
           enabled:


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

Enable bytecode format v10 on testnet.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new on-chain feature-flag proposals that can change VM bytecode compatibility and transaction argument support once executed. Risk is mainly in rollout/misconfiguration rather than code logic since this is configuration-only.
> 
> **Overview**
> Adds two new aptos-release-builder proposal configs (`public-args.yaml` and `vm-binary-format-v10.yaml`) to roll out **feature flags** via `MultiStep` updates.
> 
> The proposals enable `public_struct_enum_args` (public structs/enums as transaction args, AIP-142) and `v_m_binary_format_v10` (bytecode format v10, including abort-with-message AIP-138 and AIP-142 support).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c29578173afdacbb7feac102904cf8ee9825738c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->