### PR TITLE
[mono-vm] Representation and perf refactoring within specializer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18251,6 +18251,8 @@ dependencies = [
  "move-model",
  "move-prover-test-utils",
  "move-vm-types",
+ "shared-dsa",
+ "smallvec",
  "triomphe",
 ]
 

--- a/third_party/move/mono-move/specializer/Cargo.toml
+++ b/third_party/move/mono-move/specializer/Cargo.toml
@@ -13,6 +13,8 @@ move-binary-format = { workspace = true }
 move-bytecode-verifier = { workspace = true }
 move-core-types = { workspace = true }
 move-vm-types = { workspace = true, features = ["testing"] }
+shared-dsa = { workspace = true }
+smallvec = { workspace = true }
 triomphe = { workspace = true }
 
 [dev-dependencies]

--- a/third_party/move/mono-move/specializer/DESIGN.md
+++ b/third_party/move/mono-move/specializer/DESIGN.md
@@ -27,6 +27,10 @@ The lowering pipeline should:
 - convert "named slots" in stackless execution IR into "sized slots" based on
   fully concretized type information
 
+Both pipelines should strive to minimize small allocations all over the place,
+and apply principles of data-oriented design to take advantage of modern CPU
+architectures and memory hierarchies.
+
 ## Destack pipeline
 
 - convert stack-based Move bytecode into a partial SSA form, eliminating the

--- a/third_party/move/mono-move/specializer/src/bin/mseir-compiler.rs
+++ b/third_party/move/mono-move/specializer/src/bin/mseir-compiler.rs
@@ -8,7 +8,7 @@ use anyhow::{Context, Result};
 use clap::Parser;
 use move_binary_format::{access::ModuleAccess, file_format::CompiledModule};
 use move_vm_types::loaded_data::struct_name_indexing::StructNameIndex;
-use specializer::{destack, stackless_exec_ir::Instr};
+use specializer::destack;
 use std::path::PathBuf;
 
 #[derive(Debug, Parser)]
@@ -77,12 +77,8 @@ fn print_stats(module_ir: &specializer::stackless_exec_ir::ModuleIR) {
             None => (0, 0),
         };
 
-        // IR stats: count non-label instructions.
-        let ir_instrs = func_ir
-            .instrs
-            .iter()
-            .filter(|i| !matches!(i, Instr::Label(_)))
-            .count();
+        // IR stats: count instructions.
+        let ir_instrs: usize = func_ir.blocks.iter().map(|b| b.instrs.len()).sum();
 
         let num_temps = func_ir
             .num_home_slots

--- a/third_party/move/mono-move/specializer/src/destack/analysis.rs
+++ b/third_party/move/mono-move/specializer/src/destack/analysis.rs
@@ -10,7 +10,7 @@
 //! This is sound because Move's borrow checker guarantees that a local cannot
 //! be directly read or written while a mutable reference to it is outstanding.
 
-use super::instr_utils::get_defs_uses;
+use super::instr_utils::{for_each_def, for_each_use};
 use crate::stackless_exec_ir::{Instr, Slot};
 use std::collections::BTreeMap;
 
@@ -51,25 +51,24 @@ impl BlockAnalysis {
         let mut local_def_pos: BTreeMap<Slot, Vec<usize>> = BTreeMap::new();
 
         for (i, instr) in instrs.iter().enumerate() {
-            let (defs, uses) = get_defs_uses(instr);
-            for r in &uses {
+            for_each_use(instr, |r| {
                 if r.is_vid() {
-                    last_use.insert(*r, i);
+                    last_use.insert(r, i);
                 }
                 if r.is_home() {
-                    local_touch_pos.entry(*r).or_default().push(i);
+                    local_touch_pos.entry(r).or_default().push(i);
                 }
-            }
-            for r in &defs {
+            });
+            for_each_def(instr, |r| {
                 if r.is_vid() {
-                    last_use.entry(*r).or_insert(i);
-                    def_pos.entry(*r).or_insert(i);
+                    last_use.entry(r).or_insert(i);
+                    def_pos.entry(r).or_insert(i);
                 }
                 if r.is_home() {
-                    local_touch_pos.entry(*r).or_default().push(i);
-                    local_def_pos.entry(*r).or_default().push(i);
+                    local_touch_pos.entry(r).or_default().push(i);
+                    local_def_pos.entry(r).or_default().push(i);
                 }
-            }
+            });
         }
 
         // Call positions — any instruction that clobbers xfer slots.

--- a/third_party/move/mono-move/specializer/src/destack/instr_utils.rs
+++ b/third_party/move/mono-move/specializer/src/destack/instr_utils.rs
@@ -1,15 +1,252 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-//! Instruction utilities for the pipeline.
+//! Instruction utilities.
 //!
-//! Helpers used by `[ssa_conversion]`, `[slot_alloc]`, and `[optimize]`.
+//! Provides read-only slot visitors (`for_each_def`, `for_each_use`,
+//! `for_each_slot`, `collect_defs_uses`), in-place slot rewriters
+//! (`remap_all_slots_with`, `remap_source_slots_with`), and miscellaneous
+//! instruction helpers (`extract_imm_value`, `is_commutative`).
+//!
+//! # Architecture
+//!
+//! All slot traversal is built on two const-generic core functions
+//! (`visit_slots` for reading, `rewrite_instr_slots` for mutation) so that
+//! adding a new `Instr` variant requires updating exactly two match blocks.
+//! Public functions are thin wrappers that select const-generic parameters.
+//!
+//! # Performance
+//!
+//! The design relies on three compile-time optimizations:
+//!
+//! - **Const generics** (`DEFS`, `USES`, `SKIP_BORROW_LOC_SRC`): branches
+//!   guarded by const booleans are eliminated during monomorphization. Each
+//!   wrapper compiles to a specialized match with only the relevant arms.
+//! - **Const folding of `SlotRole`**: the `def`/`used`/`defs`/`uses` emit
+//!   helpers pass a statically known role tag. After inlining, the compiler
+//!   constant-folds role checks in closures that filter or dispatch on role.
+//! - **Inlining**: the emit helpers and `rewrite_slot`/`rewrite_slots` are
+//!   `#[inline]` to ensure they are folded into the core match body. The
+//!   caller-provided closures (`impl FnMut`) are monomorphized and inlined
+//!   at each call site.
 
 use crate::stackless_exec_ir::{BinaryOp, ImmValue, Instr, Slot};
-use std::{collections::BTreeMap, ops::Range};
+use smallvec::SmallVec;
 
-/// Get named slots defined (written) and used (read) by an instruction.
-pub(crate) fn get_defs_uses(instr: &Instr) -> (Vec<Slot>, Vec<Slot>) {
+/// Most instructions have at most 4 defs or uses.
+pub(crate) type SlotList = SmallVec<[Slot; 4]>;
+
+/// Whether a visited slot is a def (written) or a use (read).
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum SlotRole {
+    Def,
+    Use,
+}
+
+// =============================================================================
+// Read-only slot visitors
+// =============================================================================
+
+/// Apply `f` to each slot defined (written) by an instruction.
+pub(crate) fn for_each_def(instr: &Instr, mut f: impl FnMut(Slot)) {
+    visit_slots::<true, false>(instr, |slot, _| f(slot));
+}
+
+/// Apply `f` to each slot used (read) by an instruction.
+pub(crate) fn for_each_use(instr: &Instr, mut f: impl FnMut(Slot)) {
+    visit_slots::<false, true>(instr, |slot, _| f(slot));
+}
+
+/// Apply `f` to every slot (defs and uses) in an instruction.
+pub(crate) fn for_each_slot(instr: &Instr, mut f: impl FnMut(Slot)) {
+    visit_slots::<true, true>(instr, |slot, _| f(slot));
+}
+
+/// Collect defs and uses into separate lists in a single pass.
+pub(crate) fn collect_defs_uses(instr: &Instr) -> (SlotList, SlotList) {
+    let mut defs = SlotList::new();
+    let mut uses = SlotList::new();
+    visit_slots::<true, true>(instr, |slot, role| match role {
+        SlotRole::Def => defs.push(slot),
+        SlotRole::Use => uses.push(slot),
+    });
+    (defs, uses)
+}
+
+// =============================================================================
+// Slot rewriters
+// =============================================================================
+
+/// Rewrite all slot operands of an instruction by applying `f`.
+///
+/// Each slot is rewritten exactly once — `f` is not applied transitively.
+pub(crate) fn remap_all_slots_with(instr: &mut Instr, f: impl FnMut(Slot) -> Slot) {
+    rewrite_instr_slots::<true, true, false>(instr, f);
+}
+
+/// Rewrite source (use) operands of an instruction by applying `f`,
+/// skipping defs and BorrowLoc sources.
+///
+/// Each slot is rewritten exactly once — `f` is not applied transitively.
+pub(crate) fn remap_source_slots_with(instr: &mut Instr, f: impl FnMut(Slot) -> Slot) {
+    rewrite_instr_slots::<false, true, true>(instr, f);
+}
+
+// =============================================================================
+// Other instruction utilities
+// =============================================================================
+
+/// Extract the destination slot and immediate value from a load instruction.
+pub(crate) fn extract_imm_value(instr: &Instr) -> Option<(Slot, ImmValue)> {
+    match instr {
+        Instr::LdTrue(dst) => Some((*dst, ImmValue::Bool(true))),
+        Instr::LdFalse(dst) => Some((*dst, ImmValue::Bool(false))),
+        Instr::LdU8(dst, val) => Some((*dst, ImmValue::U8(*val))),
+        Instr::LdU16(dst, val) => Some((*dst, ImmValue::U16(*val))),
+        Instr::LdU32(dst, val) => Some((*dst, ImmValue::U32(*val))),
+        Instr::LdU64(dst, val) => Some((*dst, ImmValue::U64(*val))),
+        Instr::LdI8(dst, val) => Some((*dst, ImmValue::I8(*val))),
+        Instr::LdI16(dst, val) => Some((*dst, ImmValue::I16(*val))),
+        Instr::LdI32(dst, val) => Some((*dst, ImmValue::I32(*val))),
+        Instr::LdI64(dst, val) => Some((*dst, ImmValue::I64(*val))),
+
+        // Too large or non-numeric — not fusible into BinaryOpImm.
+        Instr::LdU128(_, _)
+        | Instr::LdU256(_, _)
+        | Instr::LdI128(_, _)
+        | Instr::LdI256(_, _)
+        | Instr::LdConst(_, _) => None,
+
+        // Non-load instructions.
+        Instr::Copy(_, _)
+        | Instr::Move(_, _)
+        | Instr::UnaryOp(_, _, _)
+        | Instr::BinaryOp(_, _, _, _)
+        | Instr::BinaryOpImm(_, _, _, _)
+        | Instr::Pack(_, _, _)
+        | Instr::PackGeneric(_, _, _)
+        | Instr::Unpack(_, _, _)
+        | Instr::UnpackGeneric(_, _, _)
+        | Instr::PackVariant(_, _, _)
+        | Instr::PackVariantGeneric(_, _, _)
+        | Instr::UnpackVariant(_, _, _)
+        | Instr::UnpackVariantGeneric(_, _, _)
+        | Instr::TestVariant(_, _, _)
+        | Instr::TestVariantGeneric(_, _, _)
+        | Instr::ImmBorrowLoc(_, _)
+        | Instr::MutBorrowLoc(_, _)
+        | Instr::ImmBorrowField(_, _, _)
+        | Instr::MutBorrowField(_, _, _)
+        | Instr::ImmBorrowFieldGeneric(_, _, _)
+        | Instr::MutBorrowFieldGeneric(_, _, _)
+        | Instr::ImmBorrowVariantField(_, _, _)
+        | Instr::MutBorrowVariantField(_, _, _)
+        | Instr::ImmBorrowVariantFieldGeneric(_, _, _)
+        | Instr::MutBorrowVariantFieldGeneric(_, _, _)
+        | Instr::ReadRef(_, _)
+        | Instr::WriteRef(_, _)
+        | Instr::ReadField(_, _, _)
+        | Instr::ReadFieldGeneric(_, _, _)
+        | Instr::WriteField(_, _, _)
+        | Instr::WriteFieldGeneric(_, _, _)
+        | Instr::ReadVariantField(_, _, _)
+        | Instr::ReadVariantFieldGeneric(_, _, _)
+        | Instr::WriteVariantField(_, _, _)
+        | Instr::WriteVariantFieldGeneric(_, _, _)
+        | Instr::Exists(_, _, _)
+        | Instr::ExistsGeneric(_, _, _)
+        | Instr::MoveFrom(_, _, _)
+        | Instr::MoveFromGeneric(_, _, _)
+        | Instr::MoveTo(_, _, _)
+        | Instr::MoveToGeneric(_, _, _)
+        | Instr::ImmBorrowGlobal(_, _, _)
+        | Instr::ImmBorrowGlobalGeneric(_, _, _)
+        | Instr::MutBorrowGlobal(_, _, _)
+        | Instr::MutBorrowGlobalGeneric(_, _, _)
+        | Instr::Call(_, _, _)
+        | Instr::CallGeneric(_, _, _)
+        | Instr::PackClosure(_, _, _, _)
+        | Instr::PackClosureGeneric(_, _, _, _)
+        | Instr::CallClosure(_, _, _)
+        | Instr::VecPack(_, _, _, _)
+        | Instr::VecLen(_, _, _)
+        | Instr::VecImmBorrow(_, _, _, _)
+        | Instr::VecMutBorrow(_, _, _, _)
+        | Instr::VecPushBack(_, _, _)
+        | Instr::VecPopBack(_, _, _)
+        | Instr::VecUnpack(_, _, _, _)
+        | Instr::VecSwap(_, _, _, _)
+        | Instr::Branch(_)
+        | Instr::BrTrue(_, _)
+        | Instr::BrFalse(_, _)
+        | Instr::Ret(_)
+        | Instr::Abort(_)
+        | Instr::AbortMsg(_, _) => None,
+    }
+}
+
+/// Whether a binary operation is commutative (i.e., operands can be swapped
+/// without changing the result).
+#[inline]
+pub(crate) fn is_commutative(op: &BinaryOp) -> bool {
+    matches!(
+        op,
+        BinaryOp::Add
+            | BinaryOp::Mul
+            | BinaryOp::BitOr
+            | BinaryOp::BitAnd
+            | BinaryOp::Xor
+            | BinaryOp::Eq
+            | BinaryOp::Neq
+            | BinaryOp::Or
+            | BinaryOp::And
+    )
+}
+
+// =============================================================================
+// Internal: read-only slot visitor core
+// =============================================================================
+
+/// Emit a def slot if `ACTIVE` is true.
+#[inline]
+fn def<const ACTIVE: bool>(slot: Slot, f: &mut impl FnMut(Slot, SlotRole)) {
+    if ACTIVE {
+        f(slot, SlotRole::Def);
+    }
+}
+
+/// Emit a use slot if `ACTIVE` is true.
+#[inline]
+fn used<const ACTIVE: bool>(slot: Slot, f: &mut impl FnMut(Slot, SlotRole)) {
+    if ACTIVE {
+        f(slot, SlotRole::Use);
+    }
+}
+
+/// Emit each slot in a slice as defs if `ACTIVE` is true.
+#[inline]
+fn defs<const ACTIVE: bool>(slots: &[Slot], f: &mut impl FnMut(Slot, SlotRole)) {
+    if ACTIVE {
+        slots.iter().for_each(|slot| f(*slot, SlotRole::Def));
+    }
+}
+
+/// Emit each slot in a slice as uses if `ACTIVE` is true.
+#[inline]
+fn uses<const ACTIVE: bool>(slots: &[Slot], f: &mut impl FnMut(Slot, SlotRole)) {
+    if ACTIVE {
+        slots.iter().for_each(|slot| f(*slot, SlotRole::Use));
+    }
+}
+
+/// Visit slots of an instruction, calling `f(slot, role)` for each.
+///
+/// `DEFS`/`USES` select which slots to visit. The `def`/`used`/`defs`/`uses`
+/// helpers pair the role tag with the const generic by convention.
+fn visit_slots<const DEFS: bool, const USES: bool>(
+    instr: &Instr,
+    mut f: impl FnMut(Slot, SlotRole),
+) {
     match instr {
         Instr::LdConst(dst, _)
         | Instr::LdTrue(dst)
@@ -25,32 +262,260 @@ pub(crate) fn get_defs_uses(instr: &Instr) -> (Vec<Slot>, Vec<Slot>) {
         | Instr::LdI32(dst, _)
         | Instr::LdI64(dst, _)
         | Instr::LdI128(dst, _)
-        | Instr::LdI256(dst, _) => (vec![*dst], vec![]),
+        | Instr::LdI256(dst, _) => def::<DEFS>(*dst, &mut f),
 
-        Instr::Copy(dst, src) | Instr::Move(dst, src) => (vec![*dst], vec![*src]),
-
-        Instr::UnaryOp(dst, _, src) => (vec![*dst], vec![*src]),
-        Instr::BinaryOp(dst, _, lhs, rhs) => (vec![*dst], vec![*lhs, *rhs]),
-        Instr::BinaryOpImm(dst, _, lhs, _) => (vec![*dst], vec![*lhs]),
-
-        Instr::Pack(dst, _, fields) | Instr::PackGeneric(dst, _, fields) => {
-            (vec![*dst], fields.to_vec())
+        Instr::Copy(dst, src) | Instr::Move(dst, src) | Instr::UnaryOp(dst, _, src) => {
+            def::<DEFS>(*dst, &mut f);
+            used::<USES>(*src, &mut f);
         },
-        Instr::Unpack(dsts, _, src) | Instr::UnpackGeneric(dsts, _, src) => {
-            (dsts.to_vec(), vec![*src])
+        Instr::BinaryOp(dst, _, lhs, rhs) => {
+            def::<DEFS>(*dst, &mut f);
+            used::<USES>(*lhs, &mut f);
+            used::<USES>(*rhs, &mut f);
+        },
+        Instr::BinaryOpImm(dst, _, lhs, _) => {
+            def::<DEFS>(*dst, &mut f);
+            used::<USES>(*lhs, &mut f);
         },
 
-        Instr::PackVariant(dst, _, fields) | Instr::PackVariantGeneric(dst, _, fields) => {
-            (vec![*dst], fields.to_vec())
+        Instr::Pack(dst, _, fields)
+        | Instr::PackGeneric(dst, _, fields)
+        | Instr::PackVariant(dst, _, fields)
+        | Instr::PackVariantGeneric(dst, _, fields) => {
+            def::<DEFS>(*dst, &mut f);
+            uses::<USES>(fields, &mut f);
         },
-        Instr::UnpackVariant(dsts, _, src) | Instr::UnpackVariantGeneric(dsts, _, src) => {
-            (dsts.to_vec(), vec![*src])
+        Instr::Unpack(dsts, _, src)
+        | Instr::UnpackGeneric(dsts, _, src)
+        | Instr::UnpackVariant(dsts, _, src)
+        | Instr::UnpackVariantGeneric(dsts, _, src) => {
+            defs::<DEFS>(dsts, &mut f);
+            used::<USES>(*src, &mut f);
         },
         Instr::TestVariant(dst, _, src) | Instr::TestVariantGeneric(dst, _, src) => {
-            (vec![*dst], vec![*src])
+            def::<DEFS>(*dst, &mut f);
+            used::<USES>(*src, &mut f);
         },
 
-        Instr::ImmBorrowLoc(dst, src) | Instr::MutBorrowLoc(dst, src) => (vec![*dst], vec![*src]),
+        Instr::ImmBorrowLoc(dst, src)
+        | Instr::MutBorrowLoc(dst, src)
+        | Instr::ImmBorrowField(dst, _, src)
+        | Instr::MutBorrowField(dst, _, src)
+        | Instr::ImmBorrowFieldGeneric(dst, _, src)
+        | Instr::MutBorrowFieldGeneric(dst, _, src)
+        | Instr::ImmBorrowVariantField(dst, _, src)
+        | Instr::MutBorrowVariantField(dst, _, src)
+        | Instr::ImmBorrowVariantFieldGeneric(dst, _, src)
+        | Instr::MutBorrowVariantFieldGeneric(dst, _, src)
+        | Instr::ReadRef(dst, src) => {
+            def::<DEFS>(*dst, &mut f);
+            used::<USES>(*src, &mut f);
+        },
+        Instr::WriteRef(ref_slot, val) => {
+            used::<USES>(*ref_slot, &mut f);
+            used::<USES>(*val, &mut f);
+        },
+
+        Instr::ReadField(dst, _, src)
+        | Instr::ReadFieldGeneric(dst, _, src)
+        | Instr::ReadVariantField(dst, _, src)
+        | Instr::ReadVariantFieldGeneric(dst, _, src) => {
+            def::<DEFS>(*dst, &mut f);
+            used::<USES>(*src, &mut f);
+        },
+        Instr::WriteField(_, ref_slot, val)
+        | Instr::WriteFieldGeneric(_, ref_slot, val)
+        | Instr::WriteVariantField(_, ref_slot, val)
+        | Instr::WriteVariantFieldGeneric(_, ref_slot, val) => {
+            used::<USES>(*ref_slot, &mut f);
+            used::<USES>(*val, &mut f);
+        },
+
+        Instr::Exists(dst, _, addr)
+        | Instr::ExistsGeneric(dst, _, addr)
+        | Instr::MoveFrom(dst, _, addr)
+        | Instr::MoveFromGeneric(dst, _, addr) => {
+            def::<DEFS>(*dst, &mut f);
+            used::<USES>(*addr, &mut f);
+        },
+        Instr::MoveTo(_, signer, val) | Instr::MoveToGeneric(_, signer, val) => {
+            used::<USES>(*signer, &mut f);
+            used::<USES>(*val, &mut f);
+        },
+        Instr::ImmBorrowGlobal(dst, _, addr)
+        | Instr::ImmBorrowGlobalGeneric(dst, _, addr)
+        | Instr::MutBorrowGlobal(dst, _, addr)
+        | Instr::MutBorrowGlobalGeneric(dst, _, addr) => {
+            def::<DEFS>(*dst, &mut f);
+            used::<USES>(*addr, &mut f);
+        },
+
+        Instr::Call(rets, _, args)
+        | Instr::CallGeneric(rets, _, args)
+        | Instr::CallClosure(rets, _, args) => {
+            defs::<DEFS>(rets, &mut f);
+            uses::<USES>(args, &mut f);
+        },
+        Instr::PackClosure(dst, _, _, captured)
+        | Instr::PackClosureGeneric(dst, _, _, captured) => {
+            def::<DEFS>(*dst, &mut f);
+            uses::<USES>(captured, &mut f);
+        },
+
+        Instr::VecPack(dst, _, _, elems) => {
+            def::<DEFS>(*dst, &mut f);
+            uses::<USES>(elems, &mut f);
+        },
+        Instr::VecLen(dst, _, src) | Instr::VecPopBack(dst, _, src) => {
+            def::<DEFS>(*dst, &mut f);
+            used::<USES>(*src, &mut f);
+        },
+        Instr::VecImmBorrow(dst, _, vec_ref, idx) | Instr::VecMutBorrow(dst, _, vec_ref, idx) => {
+            def::<DEFS>(*dst, &mut f);
+            used::<USES>(*vec_ref, &mut f);
+            used::<USES>(*idx, &mut f);
+        },
+        Instr::VecPushBack(_, vec_ref, val) => {
+            used::<USES>(*vec_ref, &mut f);
+            used::<USES>(*val, &mut f);
+        },
+        Instr::VecUnpack(dsts, _, _, src) => {
+            defs::<DEFS>(dsts, &mut f);
+            used::<USES>(*src, &mut f);
+        },
+        Instr::VecSwap(_, vec_ref, idx_a, idx_b) => {
+            used::<USES>(*vec_ref, &mut f);
+            used::<USES>(*idx_a, &mut f);
+            used::<USES>(*idx_b, &mut f);
+        },
+
+        Instr::Branch(_) => {},
+        Instr::BrTrue(_, cond) | Instr::BrFalse(_, cond) => used::<USES>(*cond, &mut f),
+        Instr::Ret(rets) => uses::<USES>(rets, &mut f),
+        Instr::Abort(code) => used::<USES>(*code, &mut f),
+        Instr::AbortMsg(code, msg) => {
+            used::<USES>(*code, &mut f);
+            used::<USES>(*msg, &mut f);
+        },
+    }
+}
+
+// =============================================================================
+// Internal: mutable slot rewriter core
+// =============================================================================
+
+/// Rewrite a slot in-place by applying `f`.
+#[inline]
+fn rewrite_slot(slot: &mut Slot, f: &mut impl FnMut(Slot) -> Slot) {
+    *slot = f(*slot);
+}
+
+/// Rewrite each slot in a slice by applying `f`.
+#[inline]
+fn rewrite_slots(slots: &mut [Slot], f: &mut impl FnMut(Slot) -> Slot) {
+    for slot in slots.iter_mut() {
+        rewrite_slot(slot, f);
+    }
+}
+
+/// Rewrite slot operands of an instruction in-place.
+///
+/// - `DEFS` / `USES`: select which slots to rewrite (compile-time).
+/// - `SKIP_BORROW_LOC_SRC`: when true, BorrowLoc source operands are not
+///   rewritten — needed for copy propagation where substituting BorrowLoc
+///   sources would change which frame slot the reference points to (unsound).
+fn rewrite_instr_slots<const DEFS: bool, const USES: bool, const SKIP_BORROW_LOC_SRC: bool>(
+    instr: &mut Instr,
+    mut f: impl FnMut(Slot) -> Slot,
+) {
+    match instr {
+        Instr::LdConst(dst, _)
+        | Instr::LdTrue(dst)
+        | Instr::LdFalse(dst)
+        | Instr::LdU8(dst, _)
+        | Instr::LdU16(dst, _)
+        | Instr::LdU32(dst, _)
+        | Instr::LdU64(dst, _)
+        | Instr::LdU128(dst, _)
+        | Instr::LdU256(dst, _)
+        | Instr::LdI8(dst, _)
+        | Instr::LdI16(dst, _)
+        | Instr::LdI32(dst, _)
+        | Instr::LdI64(dst, _)
+        | Instr::LdI128(dst, _)
+        | Instr::LdI256(dst, _) => {
+            if DEFS {
+                rewrite_slot(dst, &mut f);
+            }
+        },
+
+        Instr::Copy(dst, src) | Instr::Move(dst, src) | Instr::UnaryOp(dst, _, src) => {
+            if DEFS {
+                rewrite_slot(dst, &mut f);
+            }
+            if USES {
+                rewrite_slot(src, &mut f);
+            }
+        },
+        Instr::BinaryOp(dst, _, lhs, rhs) => {
+            if DEFS {
+                rewrite_slot(dst, &mut f);
+            }
+            if USES {
+                rewrite_slot(lhs, &mut f);
+                rewrite_slot(rhs, &mut f);
+            }
+        },
+        Instr::BinaryOpImm(dst, _, lhs, _) => {
+            if DEFS {
+                rewrite_slot(dst, &mut f);
+            }
+            if USES {
+                rewrite_slot(lhs, &mut f);
+            }
+        },
+
+        Instr::Pack(dst, _, fields)
+        | Instr::PackGeneric(dst, _, fields)
+        | Instr::PackVariant(dst, _, fields)
+        | Instr::PackVariantGeneric(dst, _, fields) => {
+            if DEFS {
+                rewrite_slot(dst, &mut f);
+            }
+            if USES {
+                rewrite_slots(fields, &mut f);
+            }
+        },
+        Instr::Unpack(dsts, _, src)
+        | Instr::UnpackGeneric(dsts, _, src)
+        | Instr::UnpackVariant(dsts, _, src)
+        | Instr::UnpackVariantGeneric(dsts, _, src) => {
+            if DEFS {
+                rewrite_slots(dsts, &mut f);
+            }
+            if USES {
+                rewrite_slot(src, &mut f);
+            }
+        },
+        Instr::TestVariant(dst, _, src) | Instr::TestVariantGeneric(dst, _, src) => {
+            if DEFS {
+                rewrite_slot(dst, &mut f);
+            }
+            if USES {
+                rewrite_slot(src, &mut f);
+            }
+        },
+
+        // BorrowLoc: when SKIP_BORROW_LOC_SRC is true, the source operand is a
+        // storage-location use (identity of the slot matters) and must not be rewritten.
+        Instr::ImmBorrowLoc(dst, src) | Instr::MutBorrowLoc(dst, src) => {
+            if DEFS {
+                rewrite_slot(dst, &mut f);
+            }
+            if USES && !SKIP_BORROW_LOC_SRC {
+                rewrite_slot(src, &mut f);
+            }
+        },
         Instr::ImmBorrowField(dst, _, src)
         | Instr::MutBorrowField(dst, _, src)
         | Instr::ImmBorrowFieldGeneric(dst, _, src)
@@ -58,443 +523,160 @@ pub(crate) fn get_defs_uses(instr: &Instr) -> (Vec<Slot>, Vec<Slot>) {
         | Instr::ImmBorrowVariantField(dst, _, src)
         | Instr::MutBorrowVariantField(dst, _, src)
         | Instr::ImmBorrowVariantFieldGeneric(dst, _, src)
-        | Instr::MutBorrowVariantFieldGeneric(dst, _, src) => (vec![*dst], vec![*src]),
-        Instr::ReadRef(dst, src) => (vec![*dst], vec![*src]),
-        Instr::WriteRef(dst_ref, val) => (vec![], vec![*dst_ref, *val]),
+        | Instr::MutBorrowVariantFieldGeneric(dst, _, src)
+        | Instr::ReadRef(dst, src) => {
+            if DEFS {
+                rewrite_slot(dst, &mut f);
+            }
+            if USES {
+                rewrite_slot(src, &mut f);
+            }
+        },
+        Instr::WriteRef(ref_slot, val) => {
+            if USES {
+                rewrite_slot(ref_slot, &mut f);
+                rewrite_slot(val, &mut f);
+            }
+        },
 
         Instr::ReadField(dst, _, src)
         | Instr::ReadFieldGeneric(dst, _, src)
         | Instr::ReadVariantField(dst, _, src)
-        | Instr::ReadVariantFieldGeneric(dst, _, src) => (vec![*dst], vec![*src]),
-        Instr::WriteField(_, dst_ref, val)
-        | Instr::WriteFieldGeneric(_, dst_ref, val)
-        | Instr::WriteVariantField(_, dst_ref, val)
-        | Instr::WriteVariantFieldGeneric(_, dst_ref, val) => (vec![], vec![*dst_ref, *val]),
+        | Instr::ReadVariantFieldGeneric(dst, _, src) => {
+            if DEFS {
+                rewrite_slot(dst, &mut f);
+            }
+            if USES {
+                rewrite_slot(src, &mut f);
+            }
+        },
+        Instr::WriteField(_, ref_slot, val)
+        | Instr::WriteFieldGeneric(_, ref_slot, val)
+        | Instr::WriteVariantField(_, ref_slot, val)
+        | Instr::WriteVariantFieldGeneric(_, ref_slot, val) => {
+            if USES {
+                rewrite_slot(ref_slot, &mut f);
+                rewrite_slot(val, &mut f);
+            }
+        },
 
         Instr::Exists(dst, _, addr)
         | Instr::ExistsGeneric(dst, _, addr)
         | Instr::MoveFrom(dst, _, addr)
-        | Instr::MoveFromGeneric(dst, _, addr) => (vec![*dst], vec![*addr]),
+        | Instr::MoveFromGeneric(dst, _, addr) => {
+            if DEFS {
+                rewrite_slot(dst, &mut f);
+            }
+            if USES {
+                rewrite_slot(addr, &mut f);
+            }
+        },
         Instr::MoveTo(_, signer, val) | Instr::MoveToGeneric(_, signer, val) => {
-            (vec![], vec![*signer, *val])
+            if USES {
+                rewrite_slot(signer, &mut f);
+                rewrite_slot(val, &mut f);
+            }
         },
         Instr::ImmBorrowGlobal(dst, _, addr)
         | Instr::ImmBorrowGlobalGeneric(dst, _, addr)
         | Instr::MutBorrowGlobal(dst, _, addr)
-        | Instr::MutBorrowGlobalGeneric(dst, _, addr) => (vec![*dst], vec![*addr]),
+        | Instr::MutBorrowGlobalGeneric(dst, _, addr) => {
+            if DEFS {
+                rewrite_slot(dst, &mut f);
+            }
+            if USES {
+                rewrite_slot(addr, &mut f);
+            }
+        },
 
-        Instr::Call(rets, _, args) | Instr::CallGeneric(rets, _, args) => {
-            (rets.to_vec(), args.to_vec())
+        Instr::Call(rets, _, args)
+        | Instr::CallGeneric(rets, _, args)
+        | Instr::CallClosure(rets, _, args) => {
+            if DEFS {
+                rewrite_slots(rets, &mut f);
+            }
+            if USES {
+                rewrite_slots(args, &mut f);
+            }
         },
         Instr::PackClosure(dst, _, _, captured)
-        | Instr::PackClosureGeneric(dst, _, _, captured) => (vec![*dst], captured.to_vec()),
-        Instr::CallClosure(rets, _, args) => (rets.to_vec(), args.to_vec()),
+        | Instr::PackClosureGeneric(dst, _, _, captured) => {
+            if DEFS {
+                rewrite_slot(dst, &mut f);
+            }
+            if USES {
+                rewrite_slots(captured, &mut f);
+            }
+        },
 
-        Instr::VecPack(dst, _, _, elems) => (vec![*dst], elems.to_vec()),
-        Instr::VecLen(dst, _, src) => (vec![*dst], vec![*src]),
+        Instr::VecPack(dst, _, _, elems) => {
+            if DEFS {
+                rewrite_slot(dst, &mut f);
+            }
+            if USES {
+                rewrite_slots(elems, &mut f);
+            }
+        },
+        Instr::VecLen(dst, _, src) | Instr::VecPopBack(dst, _, src) => {
+            if DEFS {
+                rewrite_slot(dst, &mut f);
+            }
+            if USES {
+                rewrite_slot(src, &mut f);
+            }
+        },
         Instr::VecImmBorrow(dst, _, vec_ref, idx) | Instr::VecMutBorrow(dst, _, vec_ref, idx) => {
-            (vec![*dst], vec![*vec_ref, *idx])
-        },
-        Instr::VecPushBack(_, vec_ref, val) => (vec![], vec![*vec_ref, *val]),
-        Instr::VecPopBack(dst, _, src) => (vec![*dst], vec![*src]),
-        Instr::VecUnpack(dsts, _, _, src) => (dsts.to_vec(), vec![*src]),
-        Instr::VecSwap(_, vec_ref, idx_a, idx_b) => (vec![], vec![*vec_ref, *idx_a, *idx_b]),
-
-        Instr::Label(_) | Instr::Branch(_) => (vec![], vec![]),
-        Instr::BrTrue(_, cond) | Instr::BrFalse(_, cond) => (vec![], vec![*cond]),
-        Instr::Ret(rets) => (vec![], rets.to_vec()),
-        Instr::Abort(code) => (vec![], vec![*code]),
-        Instr::AbortMsg(code, msg) => (vec![], vec![*code, *msg]),
-    }
-}
-
-/// Apply named-slot remapping to all operands of an instruction.
-pub(crate) fn remap_instr(instr: &mut Instr, map: &BTreeMap<Slot, Slot>) {
-    fn r(slot: &mut Slot, map: &BTreeMap<Slot, Slot>) {
-        if let Some(&new) = map.get(slot) {
-            *slot = new;
-        }
-    }
-
-    fn r_vec(slots: &mut [Slot], map: &BTreeMap<Slot, Slot>) {
-        for slot in slots.iter_mut() {
-            r(slot, map);
-        }
-    }
-
-    match instr {
-        Instr::LdConst(d, _)
-        | Instr::LdTrue(d)
-        | Instr::LdFalse(d)
-        | Instr::LdU8(d, _)
-        | Instr::LdU16(d, _)
-        | Instr::LdU32(d, _)
-        | Instr::LdU64(d, _)
-        | Instr::LdU128(d, _)
-        | Instr::LdU256(d, _)
-        | Instr::LdI8(d, _)
-        | Instr::LdI16(d, _)
-        | Instr::LdI32(d, _)
-        | Instr::LdI64(d, _)
-        | Instr::LdI128(d, _)
-        | Instr::LdI256(d, _) => r(d, map),
-
-        Instr::Copy(d, s) | Instr::Move(d, s) => {
-            r(d, map);
-            r(s, map);
-        },
-        Instr::UnaryOp(d, _, s) => {
-            r(d, map);
-            r(s, map);
-        },
-        Instr::BinaryOp(d, _, l, rr) => {
-            r(d, map);
-            r(l, map);
-            r(rr, map);
-        },
-        Instr::BinaryOpImm(d, _, l, _) => {
-            r(d, map);
-            r(l, map);
-        },
-
-        Instr::Pack(d, _, fields) | Instr::PackGeneric(d, _, fields) => {
-            r(d, map);
-            r_vec(fields, map);
-        },
-        Instr::Unpack(ds, _, s) | Instr::UnpackGeneric(ds, _, s) => {
-            r_vec(ds, map);
-            r(s, map);
-        },
-        Instr::PackVariant(d, _, fields) | Instr::PackVariantGeneric(d, _, fields) => {
-            r(d, map);
-            r_vec(fields, map);
-        },
-        Instr::UnpackVariant(ds, _, s) | Instr::UnpackVariantGeneric(ds, _, s) => {
-            r_vec(ds, map);
-            r(s, map);
-        },
-        Instr::TestVariant(d, _, s) | Instr::TestVariantGeneric(d, _, s) => {
-            r(d, map);
-            r(s, map);
-        },
-
-        Instr::ImmBorrowLoc(d, s) | Instr::MutBorrowLoc(d, s) => {
-            r(d, map);
-            r(s, map);
-        },
-        Instr::ImmBorrowField(d, _, s)
-        | Instr::MutBorrowField(d, _, s)
-        | Instr::ImmBorrowFieldGeneric(d, _, s)
-        | Instr::MutBorrowFieldGeneric(d, _, s)
-        | Instr::ImmBorrowVariantField(d, _, s)
-        | Instr::MutBorrowVariantField(d, _, s)
-        | Instr::ImmBorrowVariantFieldGeneric(d, _, s)
-        | Instr::MutBorrowVariantFieldGeneric(d, _, s) => {
-            r(d, map);
-            r(s, map);
-        },
-        Instr::ReadRef(d, s) => {
-            r(d, map);
-            r(s, map);
-        },
-        Instr::WriteRef(d, v) => {
-            r(d, map);
-            r(v, map);
-        },
-
-        Instr::ReadField(d, _, s)
-        | Instr::ReadFieldGeneric(d, _, s)
-        | Instr::ReadVariantField(d, _, s)
-        | Instr::ReadVariantFieldGeneric(d, _, s) => {
-            r(d, map);
-            r(s, map);
-        },
-        Instr::WriteField(_, dr, v)
-        | Instr::WriteFieldGeneric(_, dr, v)
-        | Instr::WriteVariantField(_, dr, v)
-        | Instr::WriteVariantFieldGeneric(_, dr, v) => {
-            r(dr, map);
-            r(v, map);
-        },
-
-        Instr::Exists(d, _, a)
-        | Instr::ExistsGeneric(d, _, a)
-        | Instr::MoveFrom(d, _, a)
-        | Instr::MoveFromGeneric(d, _, a) => {
-            r(d, map);
-            r(a, map);
-        },
-        Instr::MoveTo(_, s, v) | Instr::MoveToGeneric(_, s, v) => {
-            r(s, map);
-            r(v, map);
-        },
-        Instr::ImmBorrowGlobal(d, _, a)
-        | Instr::ImmBorrowGlobalGeneric(d, _, a)
-        | Instr::MutBorrowGlobal(d, _, a)
-        | Instr::MutBorrowGlobalGeneric(d, _, a) => {
-            r(d, map);
-            r(a, map);
-        },
-
-        Instr::Call(rets, _, args) | Instr::CallGeneric(rets, _, args) => {
-            r_vec(rets, map);
-            r_vec(args, map);
-        },
-        Instr::PackClosure(d, _, _, captured) | Instr::PackClosureGeneric(d, _, _, captured) => {
-            r(d, map);
-            r_vec(captured, map);
-        },
-        Instr::CallClosure(rets, _, args) => {
-            r_vec(rets, map);
-            r_vec(args, map);
-        },
-
-        Instr::VecPack(d, _, _, elems) => {
-            r(d, map);
-            r_vec(elems, map);
-        },
-        Instr::VecLen(d, _, s) => {
-            r(d, map);
-            r(s, map);
-        },
-        Instr::VecImmBorrow(d, _, v, i) | Instr::VecMutBorrow(d, _, v, i) => {
-            r(d, map);
-            r(v, map);
-            r(i, map);
-        },
-        Instr::VecPushBack(_, v, val) => {
-            r(v, map);
-            r(val, map);
-        },
-        Instr::VecPopBack(d, _, s) => {
-            r(d, map);
-            r(s, map);
-        },
-        Instr::VecUnpack(ds, _, _, s) => {
-            r_vec(ds, map);
-            r(s, map);
-        },
-        Instr::VecSwap(_, v, i, j) => {
-            r(v, map);
-            r(i, map);
-            r(j, map);
-        },
-
-        Instr::Label(_) | Instr::Branch(_) => {},
-        Instr::BrTrue(_, c) | Instr::BrFalse(_, c) => r(c, map),
-        Instr::Ret(rets) => r_vec(rets, map),
-        Instr::Abort(c) => r(c, map),
-        Instr::AbortMsg(c, m) => {
-            r(c, map);
-            r(m, map);
-        },
-    }
-}
-
-/// Apply slot substitution to source operands only (for copy propagation).
-pub(crate) fn apply_subst_to_sources(instr: &mut Instr, subst: &BTreeMap<Slot, Slot>) {
-    fn s(r: &mut Slot, subst: &BTreeMap<Slot, Slot>) {
-        if let Some(&replacement) = subst.get(r) {
-            *r = replacement;
-        }
-    }
-
-    fn s_vec(regs: &mut [Slot], subst: &BTreeMap<Slot, Slot>) {
-        for r in regs.iter_mut() {
-            s(r, subst);
-        }
-    }
-
-    match instr {
-        // For Copy/Move, substitute source only
-        Instr::Copy(_, src) | Instr::Move(_, src) => s(src, subst),
-
-        // Unary: substitute source
-        Instr::UnaryOp(_, _, src) => s(src, subst),
-
-        // Binary: substitute both sources
-        Instr::BinaryOp(_, _, lhs, rhs) => {
-            s(lhs, subst);
-            s(rhs, subst);
-        },
-
-        // Binary immediate: substitute lhs only (immediate has no slot)
-        Instr::BinaryOpImm(_, _, lhs, _) => s(lhs, subst),
-
-        // Struct ops
-        Instr::Pack(_, _, fields) | Instr::PackGeneric(_, _, fields) => s_vec(fields, subst),
-        Instr::Unpack(_, _, src) | Instr::UnpackGeneric(_, _, src) => s(src, subst),
-
-        // Variant ops
-        Instr::PackVariant(_, _, fields) | Instr::PackVariantGeneric(_, _, fields) => {
-            s_vec(fields, subst)
-        },
-        Instr::UnpackVariant(_, _, src) | Instr::UnpackVariantGeneric(_, _, src) => s(src, subst),
-        Instr::TestVariant(_, _, src) | Instr::TestVariantGeneric(_, _, src) => s(src, subst),
-
-        // References — BorrowLoc sources are storage-location uses (identity of the
-        // slot matters), NOT value uses. Substituting them would change which frame
-        // slot the reference points to, which is unsound.
-        Instr::ImmBorrowLoc(_, _) | Instr::MutBorrowLoc(_, _) => {},
-        Instr::ImmBorrowField(_, _, src)
-        | Instr::MutBorrowField(_, _, src)
-        | Instr::ImmBorrowFieldGeneric(_, _, src)
-        | Instr::MutBorrowFieldGeneric(_, _, src)
-        | Instr::ImmBorrowVariantField(_, _, src)
-        | Instr::MutBorrowVariantField(_, _, src)
-        | Instr::ImmBorrowVariantFieldGeneric(_, _, src)
-        | Instr::MutBorrowVariantFieldGeneric(_, _, src) => s(src, subst),
-        Instr::ReadRef(_, src) => s(src, subst),
-        Instr::WriteRef(dst_ref, val) => {
-            s(dst_ref, subst);
-            s(val, subst);
-        },
-
-        // Fused field access
-        Instr::ReadField(_, _, src)
-        | Instr::ReadFieldGeneric(_, _, src)
-        | Instr::ReadVariantField(_, _, src)
-        | Instr::ReadVariantFieldGeneric(_, _, src) => s(src, subst),
-        Instr::WriteField(_, dst_ref, val)
-        | Instr::WriteFieldGeneric(_, dst_ref, val)
-        | Instr::WriteVariantField(_, dst_ref, val)
-        | Instr::WriteVariantFieldGeneric(_, dst_ref, val) => {
-            s(dst_ref, subst);
-            s(val, subst);
-        },
-
-        // Globals
-        Instr::Exists(_, _, addr)
-        | Instr::ExistsGeneric(_, _, addr)
-        | Instr::MoveFrom(_, _, addr)
-        | Instr::MoveFromGeneric(_, _, addr) => s(addr, subst),
-        Instr::MoveTo(_, signer, val) | Instr::MoveToGeneric(_, signer, val) => {
-            s(signer, subst);
-            s(val, subst);
-        },
-        Instr::ImmBorrowGlobal(_, _, addr)
-        | Instr::ImmBorrowGlobalGeneric(_, _, addr)
-        | Instr::MutBorrowGlobal(_, _, addr)
-        | Instr::MutBorrowGlobalGeneric(_, _, addr) => s(addr, subst),
-
-        // Calls
-        Instr::Call(_, _, args) | Instr::CallGeneric(_, _, args) => s_vec(args, subst),
-        Instr::PackClosure(_, _, _, captured) | Instr::PackClosureGeneric(_, _, _, captured) => {
-            s_vec(captured, subst)
-        },
-        Instr::CallClosure(_, _, args) => s_vec(args, subst),
-
-        // Vector
-        Instr::VecPack(_, _, _, elems) => s_vec(elems, subst),
-        Instr::VecLen(_, _, src) => s(src, subst),
-        Instr::VecImmBorrow(_, _, vec_ref, idx) | Instr::VecMutBorrow(_, _, vec_ref, idx) => {
-            s(vec_ref, subst);
-            s(idx, subst);
+            if DEFS {
+                rewrite_slot(dst, &mut f);
+            }
+            if USES {
+                rewrite_slot(vec_ref, &mut f);
+                rewrite_slot(idx, &mut f);
+            }
         },
         Instr::VecPushBack(_, vec_ref, val) => {
-            s(vec_ref, subst);
-            s(val, subst);
+            if USES {
+                rewrite_slot(vec_ref, &mut f);
+                rewrite_slot(val, &mut f);
+            }
         },
-        Instr::VecPopBack(_, _, src) => s(src, subst),
-        Instr::VecUnpack(_, _, _, src) => s(src, subst),
-        Instr::VecSwap(_, vec_ref, i, j) => {
-            s(vec_ref, subst);
-            s(i, subst);
-            s(j, subst);
+        Instr::VecUnpack(dsts, _, _, src) => {
+            if DEFS {
+                rewrite_slots(dsts, &mut f);
+            }
+            if USES {
+                rewrite_slot(src, &mut f);
+            }
+        },
+        Instr::VecSwap(_, vec_ref, idx_a, idx_b) => {
+            if USES {
+                rewrite_slot(vec_ref, &mut f);
+                rewrite_slot(idx_a, &mut f);
+                rewrite_slot(idx_b, &mut f);
+            }
         },
 
-        // Control flow
-        Instr::BrTrue(_, cond) | Instr::BrFalse(_, cond) => s(cond, subst),
-        Instr::Ret(rets) => s_vec(rets, subst),
-        Instr::Abort(code) => s(code, subst),
+        Instr::Branch(_) => {},
+        Instr::BrTrue(_, cond) | Instr::BrFalse(_, cond) => {
+            if USES {
+                rewrite_slot(cond, &mut f);
+            }
+        },
+        Instr::Ret(rets) => {
+            if USES {
+                rewrite_slots(rets, &mut f);
+            }
+        },
+        Instr::Abort(code) => {
+            if USES {
+                rewrite_slot(code, &mut f);
+            }
+        },
         Instr::AbortMsg(code, msg) => {
-            s(code, subst);
-            s(msg, subst);
+            if USES {
+                rewrite_slot(code, &mut f);
+                rewrite_slot(msg, &mut f);
+            }
         },
-
-        // No sources to substitute
-        Instr::Label(_)
-        | Instr::Branch(_)
-        | Instr::LdConst(_, _)
-        | Instr::LdTrue(_)
-        | Instr::LdFalse(_)
-        | Instr::LdU8(_, _)
-        | Instr::LdU16(_, _)
-        | Instr::LdU32(_, _)
-        | Instr::LdU64(_, _)
-        | Instr::LdU128(_, _)
-        | Instr::LdU256(_, _)
-        | Instr::LdI8(_, _)
-        | Instr::LdI16(_, _)
-        | Instr::LdI32(_, _)
-        | Instr::LdI64(_, _)
-        | Instr::LdI128(_, _)
-        | Instr::LdI256(_, _) => {},
     }
-}
-
-/// Split instructions into basic blocks (label to branch/label).
-/// Returns half-open `start..end` ranges.
-pub(crate) fn split_into_blocks(instrs: &[Instr]) -> Vec<Range<usize>> {
-    let mut blocks = Vec::new();
-    let mut start = 0;
-
-    for (i, instr) in instrs.iter().enumerate() {
-        match instr {
-            Instr::Label(_) if i > start => {
-                blocks.push(start..i);
-                start = i;
-            },
-            Instr::Branch(_)
-            | Instr::BrTrue(_, _)
-            | Instr::BrFalse(_, _)
-            | Instr::Ret(_)
-            | Instr::Abort(_)
-            | Instr::AbortMsg(_, _) => {
-                blocks.push(start..i + 1);
-                start = i + 1;
-            },
-            _ => {},
-        }
-    }
-
-    if start < instrs.len() {
-        blocks.push(start..instrs.len());
-    }
-
-    blocks
-}
-
-/// Extract the destination slot and immediate value from a load instruction.
-/// Returns None for LdU128/LdU256/LdI128/LdI256/LdConst (too large or non-numeric).
-pub(crate) fn extract_imm_value(instr: &Instr) -> Option<(Slot, ImmValue)> {
-    match instr {
-        Instr::LdTrue(d) => Some((*d, ImmValue::Bool(true))),
-        Instr::LdFalse(d) => Some((*d, ImmValue::Bool(false))),
-        Instr::LdU8(d, v) => Some((*d, ImmValue::U8(*v))),
-        Instr::LdU16(d, v) => Some((*d, ImmValue::U16(*v))),
-        Instr::LdU32(d, v) => Some((*d, ImmValue::U32(*v))),
-        Instr::LdU64(d, v) => Some((*d, ImmValue::U64(*v))),
-        Instr::LdI8(d, v) => Some((*d, ImmValue::I8(*v))),
-        Instr::LdI16(d, v) => Some((*d, ImmValue::I16(*v))),
-        Instr::LdI32(d, v) => Some((*d, ImmValue::I32(*v))),
-        Instr::LdI64(d, v) => Some((*d, ImmValue::I64(*v))),
-        _ => None,
-    }
-}
-
-/// Whether a binary operation is commutative (operands can be swapped).
-pub(crate) fn is_commutative(op: &BinaryOp) -> bool {
-    matches!(
-        op,
-        BinaryOp::Add
-            | BinaryOp::Mul
-            | BinaryOp::BitOr
-            | BinaryOp::BitAnd
-            | BinaryOp::Xor
-            | BinaryOp::Eq
-            | BinaryOp::Neq
-            | BinaryOp::Or
-            | BinaryOp::And
-    )
 }

--- a/third_party/move/mono-move/specializer/src/destack/instr_utils.rs
+++ b/third_party/move/mono-move/specializer/src/destack/instr_utils.rs
@@ -4,7 +4,7 @@
 //! Instruction utilities.
 //!
 //! Provides read-only slot visitors (`for_each_def`, `for_each_use`,
-//! `for_each_slot`, `collect_defs_uses`), in-place slot rewriters
+//! `for_each_slot`, `collect_defs_and_uses`), in-place slot rewriters
 //! (`remap_all_slots_with`, `remap_source_slots_with`), and miscellaneous
 //! instruction helpers (`extract_imm_value`, `is_commutative`).
 //!
@@ -63,7 +63,7 @@ pub(crate) fn for_each_slot(instr: &Instr, mut f: impl FnMut(Slot)) {
 }
 
 /// Collect defs and uses into separate lists in a single pass.
-pub(crate) fn collect_defs_uses(instr: &Instr) -> (SlotList, SlotList) {
+pub(crate) fn collect_defs_and_uses(instr: &Instr) -> (SlotList, SlotList) {
     let mut defs = SlotList::new();
     let mut uses = SlotList::new();
     visit_slots::<true, true>(instr, |slot, role| match role {

--- a/third_party/move/mono-move/specializer/src/destack/optimize.rs
+++ b/third_party/move/mono-move/specializer/src/destack/optimize.rs
@@ -8,10 +8,11 @@
 //! Pass: Dead instruction elimination
 //! Pass: Slot renumbering
 
-use super::instr_utils::{apply_subst_to_sources, get_defs_uses, remap_instr, split_into_blocks};
+use super::instr_utils::{
+    for_each_def, for_each_slot, for_each_use, remap_all_slots_with, remap_source_slots_with,
+};
 use crate::stackless_exec_ir::{FunctionIR, Instr, ModuleIR, Slot};
-use move_vm_types::loaded_data::runtime_types::Type;
-use std::collections::{BTreeMap, BTreeSet};
+use shared_dsa::{UnorderedMap, UnorderedSet};
 
 /// Optimize all functions in a module IR.
 /// Pre: slot allocation complete — no `Vid`s remain.
@@ -44,7 +45,7 @@ pub fn optimize_module(module_ir: &mut ModuleIR) {
 ///
 /// Copy propagation is sound for value uses (value equality suffices) but
 /// unsound for storage-location uses (identity of the slot matters).
-/// `apply_subst_to_sources` skips BorrowLoc sources to enforce this.
+/// `remap_source_slots` skips BorrowLoc sources to enforce this.
 ///
 /// ## The MutBorrowLoc hidden-write problem
 /// Once a slot is mutably borrowed, it can be silently modified through the
@@ -61,29 +62,29 @@ pub fn optimize_module(module_ir: &mut ModuleIR) {
 /// block as the copy, the kill fires before any hidden write. If it's in a
 /// different block, that block's subst is empty — no stale propagation occurs.
 fn copy_propagation(func: &mut FunctionIR) {
-    let blocks = split_into_blocks(&func.instrs);
+    for block in &mut func.blocks {
+        // [TODO]: `retain` scans all entries to kill by value, making each kill O(|subst|).
+        // For typical small blocks this is fine, but if subst grows large, consider a
+        // reverse index (value → keys) for O(1) value-based kills.
+        let mut subst: UnorderedMap<Slot, Slot> = UnorderedMap::new();
 
-    for block in blocks {
-        let mut subst: BTreeMap<Slot, Slot> = BTreeMap::new();
-
-        for i in block.clone() {
-            apply_subst_to_sources(&mut func.instrs[i], &subst);
+        for instr in &mut block.instrs {
+            remap_source_slots_with(instr, |s| *subst.get(&s).unwrap_or(&s));
 
             // MutBorrowLoc kill: the borrowed slot may be silently written
             // through the resulting reference (WriteRef), which is not tracked
             // as a def. Kill any substitution involving the borrowed slot.
-            if let Instr::MutBorrowLoc(_, src) = &func.instrs[i] {
+            if let Instr::MutBorrowLoc(_, src) = instr {
                 subst.remove(src);
                 subst.retain(|_, v| v != src);
             }
 
-            let (defs, _) = get_defs_uses(&func.instrs[i]);
-            for d in &defs {
-                subst.remove(d);
-                subst.retain(|_, v| v != d);
-            }
+            for_each_def(instr, |d| {
+                subst.remove(&d);
+                subst.retain(|_, v| *v != d);
+            });
 
-            match &func.instrs[i] {
+            match instr {
                 Instr::Copy(dst, src) | Instr::Move(dst, src) => {
                     subst.insert(*dst, *src);
                 },
@@ -95,8 +96,11 @@ fn copy_propagation(func: &mut FunctionIR) {
 
 /// Pass: Remove `Move(r, r)` and `Copy(r, r)` instructions.
 fn eliminate_identity_moves(func: &mut FunctionIR) {
-    func.instrs
-        .retain(|instr| !matches!(instr, Instr::Move(d, s) | Instr::Copy(d, s) if d == s));
+    for block in &mut func.blocks {
+        block
+            .instrs
+            .retain(|instr| !matches!(instr, Instr::Move(d, s) | Instr::Copy(d, s) if d == s));
+    }
 }
 
 /// Pass: Backward dead-code elimination within each basic block.
@@ -107,37 +111,30 @@ fn eliminate_identity_moves(func: &mut FunctionIR) {
 /// Slots that appear in more than one basic block are excluded from
 /// removal — their liveness cannot be determined by block-local analysis.
 fn dead_instruction_elimination(func: &mut FunctionIR) {
-    let blocks = split_into_blocks(&func.instrs);
-
-    // Pre-scan: identify slots that appear in more than one block.
-    let mut slot_block: BTreeMap<Slot, usize> = BTreeMap::new();
-    let mut cross_block_slots: BTreeSet<Slot> = BTreeSet::new();
-    for (block_id, block) in blocks.iter().enumerate() {
-        for i in block.clone() {
-            let (dsts, srcs) = get_defs_uses(&func.instrs[i]);
-            for r in dsts.into_iter().chain(srcs) {
-                match slot_block.get(&r) {
-                    Some(&prev) if prev != block_id => {
-                        cross_block_slots.insert(r);
-                    },
-                    None => {
-                        slot_block.insert(r, block_id);
-                    },
-                    _ => {},
-                }
-            }
+    // Pre-scan: identify Home slots that appear in more than one block.
+    // (Vid and Xfer slots are intra-block and never cross block boundaries.)
+    let mut slot_block: UnorderedMap<Slot, usize> = UnorderedMap::new();
+    let mut cross_block_slots: UnorderedSet<Slot> = UnorderedSet::new();
+    for (block_id, block) in func.blocks.iter().enumerate() {
+        for instr in &block.instrs {
+            for_each_slot(instr, |r| match slot_block.get(&r) {
+                Some(&prev) if prev != block_id => {
+                    cross_block_slots.insert(r);
+                },
+                None => {
+                    slot_block.insert(r, block_id);
+                },
+                _ => {},
+            });
         }
     }
 
-    let mut dead_indices: BTreeSet<usize> = BTreeSet::new();
+    for block in &mut func.blocks {
+        let mut live: UnorderedSet<Slot> = UnorderedSet::new();
+        let mut dead_indices: UnorderedSet<usize> = UnorderedSet::new();
 
-    for block in blocks {
-        let mut live: BTreeSet<Slot> = BTreeSet::new();
-
-        for i in block.rev() {
-            let (dsts, srcs) = get_defs_uses(&func.instrs[i]);
-
-            let is_removable = match &func.instrs[i] {
+        for (i, instr) in block.instrs.iter().enumerate().rev() {
+            let is_removable = match instr {
                 Instr::Copy(dst, _) | Instr::Move(dst, _) if !cross_block_slots.contains(dst) => {
                     !live.contains(dst)
                 },
@@ -147,24 +144,25 @@ fn dead_instruction_elimination(func: &mut FunctionIR) {
             if is_removable {
                 dead_indices.insert(i);
             } else {
-                for d in &dsts {
-                    live.remove(d);
-                }
-                for s in &srcs {
-                    live.insert(*s);
-                }
+                for_each_def(instr, |d| {
+                    live.remove(&d);
+                });
+                for_each_use(instr, |s| {
+                    live.insert(s);
+                });
             }
         }
-    }
 
-    if !dead_indices.is_empty() {
-        let mut new_instrs = Vec::with_capacity(func.instrs.len());
-        for (i, instr) in func.instrs.drain(..).enumerate() {
-            if !dead_indices.contains(&i) {
-                new_instrs.push(instr);
-            }
+        if !dead_indices.is_empty() {
+            // `retain` visits elements in order, so `idx` tracks the original
+            // pre-retain index of each instruction.
+            let mut idx = 0;
+            block.instrs.retain(|_| {
+                let keep = !dead_indices.contains(&idx);
+                idx += 1;
+                keep
+            });
         }
-        func.instrs = new_instrs;
     }
 }
 
@@ -176,27 +174,30 @@ fn dead_instruction_elimination(func: &mut FunctionIR) {
 ///       `num_locals`, `num_home_slots`, and `home_slot_types` are updated.
 fn renumber_slots(func: &mut FunctionIR) {
     let num_params = func.num_params;
+    let old_num_pinned = num_params + func.num_locals;
+    let old_num_home = func.num_home_slots;
 
-    let mut used_home_slots: BTreeSet<u16> = BTreeSet::new();
-    for instr in &func.instrs {
-        let (defs, uses_) = get_defs_uses(instr);
-        for r in defs.into_iter().chain(uses_) {
+    // Pass 1: mark which Home slots are used.
+    let mut used = vec![false; old_num_home as usize];
+    for instr in func.iter_instrs() {
+        for_each_slot(instr, |r| {
             if let Slot::Home(i) = r {
-                used_home_slots.insert(i);
+                used[i as usize] = true;
             }
-        }
+        });
     }
 
-    let mut remap: BTreeMap<Slot, Slot> = BTreeMap::new();
+    // Build remap[old_index] = Some(new_index) or None if unused.
+    // Params keep their ABI indices; non-params are compacted sequentially.
+    let mut remap: Vec<Option<u16>> = vec![None; old_num_home as usize];
     let mut next_slot = num_params;
     let mut num_surviving_locals: u16 = 0;
-    let old_num_pinned = num_params + func.num_locals;
-    for &i in &used_home_slots {
-        if i < num_params {
-            // Params keep their ABI indices.
-            remap.insert(Slot::Home(i), Slot::Home(i));
-        } else {
-            remap.insert(Slot::Home(i), Slot::Home(next_slot));
+    for i in 0..num_params {
+        remap[i as usize] = Some(i);
+    }
+    for i in num_params..old_num_home {
+        if used[i as usize] {
+            remap[i as usize] = Some(next_slot);
             if i < old_num_pinned {
                 num_surviving_locals += 1;
             }
@@ -204,30 +205,26 @@ fn renumber_slots(func: &mut FunctionIR) {
         }
     }
 
-    for instr in &mut func.instrs {
-        remap_instr(instr, &remap);
+    // Pass 2: apply remap to every instruction. O(1) per slot via direct indexing.
+    for instr in func.iter_instrs_mut() {
+        let remap_ref = &remap;
+        remap_all_slots_with(instr, |slot| match slot {
+            Slot::Home(i) => remap_ref[i as usize].map(Slot::Home).unwrap_or(slot),
+            other => other,
+        });
     }
 
-    // Build new home_slot_types. Bool placeholder — every entry is overwritten below:
-    // params are always copied (calling convention requires correct types even if
-    // unused in the body), and non-param slots are copied from the remap.
-    let mut new_slot_types = vec![Type::Bool; next_slot as usize];
-    for i in 0..num_params {
-        if (i as usize) < func.home_slot_types.len() {
-            new_slot_types[i as usize] = func.home_slot_types[i as usize].clone();
+    // Compact home_slot_types in-place. Since new_i <= old_i (compaction only
+    // moves slots down), a forward sweep never overwrites unread entries.
+    for (old_i, mapped) in remap.iter().enumerate().skip(num_params as usize) {
+        if let &Some(new_i) = mapped {
+            let new_i = new_i as usize;
+            if new_i != old_i {
+                func.home_slot_types.swap(new_i, old_i);
+            }
         }
     }
-    // Non-param slots: copy types according to remap. Params are skipped
-    // here — they are already handled by the loop above.
-    for (&old, &new) in &remap {
-        if let (Slot::Home(old_i), Slot::Home(new_i)) = (old, new)
-            && old_i >= num_params
-            && (old_i as usize) < func.home_slot_types.len()
-        {
-            new_slot_types[new_i as usize] = func.home_slot_types[old_i as usize].clone();
-        }
-    }
-    func.home_slot_types = new_slot_types;
+    func.home_slot_types.truncate(next_slot as usize);
 
     func.num_locals = num_surviving_locals;
     func.num_home_slots = next_slot;

--- a/third_party/move/mono-move/specializer/src/destack/optimize.rs
+++ b/third_party/move/mono-move/specializer/src/destack/optimize.rs
@@ -45,7 +45,7 @@ pub fn optimize_module(module_ir: &mut ModuleIR) {
 ///
 /// Copy propagation is sound for value uses (value equality suffices) but
 /// unsound for storage-location uses (identity of the slot matters).
-/// `remap_source_slots` skips BorrowLoc sources to enforce this.
+/// `remap_source_slots_with` skips BorrowLoc sources to enforce this.
 ///
 /// ## The MutBorrowLoc hidden-write problem
 /// Once a slot is mutably borrowed, it can be silently modified through the
@@ -179,7 +179,7 @@ fn renumber_slots(func: &mut FunctionIR) {
 
     // Pass 1: mark which Home slots are used.
     let mut used = vec![false; old_num_home as usize];
-    for instr in func.iter_instrs() {
+    for instr in func.instrs() {
         for_each_slot(instr, |r| {
             if let Slot::Home(i) = r {
                 used[i as usize] = true;
@@ -206,7 +206,7 @@ fn renumber_slots(func: &mut FunctionIR) {
     }
 
     // Pass 2: apply remap to every instruction. O(1) per slot via direct indexing.
-    for instr in func.iter_instrs_mut() {
+    for instr in func.instrs_mut() {
         let remap_ref = &remap;
         remap_all_slots_with(instr, |slot| match slot {
             Slot::Home(i) => remap_ref[i as usize].map(Slot::Home).unwrap_or(slot),

--- a/third_party/move/mono-move/specializer/src/destack/slot_alloc.rs
+++ b/third_party/move/mono-move/specializer/src/destack/slot_alloc.rs
@@ -8,7 +8,7 @@
 
 use super::{
     analysis::BlockAnalysis,
-    instr_utils::{collect_defs_uses, remap_all_slots_with},
+    instr_utils::{collect_defs_and_uses, remap_all_slots_with},
     ssa_function::SSAFunction,
 };
 use crate::stackless_exec_ir::{BasicBlock, Instr, Slot};
@@ -119,7 +119,7 @@ fn allocate_block_in_place(
     let mut next_slot = start_slot;
 
     for (i, instr) in instrs.iter_mut().enumerate() {
-        let (defs, uses) = collect_defs_uses(instr);
+        let (defs, uses) = collect_defs_and_uses(instr);
 
         // Phase 1: Free use-slots whose last use is this instruction.
         // Done BEFORE def allocation so the freed slot can be immediately reused.

--- a/third_party/move/mono-move/specializer/src/destack/slot_alloc.rs
+++ b/third_party/move/mono-move/specializer/src/destack/slot_alloc.rs
@@ -8,17 +8,17 @@
 
 use super::{
     analysis::BlockAnalysis,
-    instr_utils::{get_defs_uses, remap_instr, split_into_blocks},
+    instr_utils::{collect_defs_uses, remap_all_slots_with},
     ssa_function::SSAFunction,
 };
-use crate::stackless_exec_ir::{Instr, Slot};
+use crate::stackless_exec_ir::{BasicBlock, Instr, Slot};
 use anyhow::{bail, Context, Result};
 use move_vm_types::loaded_data::runtime_types::Type;
-use std::collections::BTreeMap;
+use shared_dsa::UnorderedMap;
 
 /// Output of slot allocation for a single function.
 pub(crate) struct AllocatedFunction {
-    pub instrs: Vec<Instr>,
+    pub blocks: Vec<BasicBlock>,
     pub num_home_slots: u16,
     pub num_xfer_slots: u16,
     pub home_slot_types: Vec<Type>,
@@ -26,26 +26,26 @@ pub(crate) struct AllocatedFunction {
 
 /// Map SSA `Vid`s to real slots across all blocks.
 ///
-/// Pre: SSA instruction stream after fusion passes; vid_types maps each `Vid(i)`
+/// Consumes the SSAFunction and remaps instructions in-place.
+///
+/// Pre: SSA blocks after fusion passes; vid_types maps each `Vid(i)`
 ///      to its type at index `i`.
 /// Post: all `Vid`s replaced with real `Home`/`Xfer` slots.
-pub(crate) fn allocate_slots(ssa: &SSAFunction) -> Result<AllocatedFunction> {
+pub(crate) fn allocate_slots(ssa: SSAFunction) -> Result<AllocatedFunction> {
     let num_pinned = ssa.local_types.len() as u16;
-    let blocks = split_into_blocks(&ssa.instrs);
-    let mut result = Vec::with_capacity(ssa.instrs.len());
+    let mut result_blocks = Vec::with_capacity(ssa.blocks.len());
     let mut global_next_slot = num_pinned;
     let mut global_num_xfer_slots: u16 = 0;
-    let mut free_pool: BTreeMap<Type, Vec<Slot>> = BTreeMap::new();
-    let mut real_slot_types: BTreeMap<Slot, Type> = BTreeMap::new();
+    let mut free_pool: UnorderedMap<Type, Vec<Slot>> = UnorderedMap::new();
+    let mut real_slot_types: UnorderedMap<Slot, Type> = UnorderedMap::new();
     for (i, ty) in ssa.local_types.iter().enumerate() {
         real_slot_types.insert(Slot::Home(i as u16), ty.clone());
     }
 
-    for block in blocks {
-        let block_instrs = &ssa.instrs[block.clone()];
-        let analysis = BlockAnalysis::analyze(block_instrs);
-        let (allocated, block_max, block_xfer_slots, returned_pool) = allocate_block(
-            block_instrs,
+    for mut block in ssa.blocks {
+        let analysis = BlockAnalysis::analyze(&block.instrs);
+        let (block_max, block_xfer_slots, returned_pool) = allocate_block_in_place(
+            &mut block.instrs,
             num_pinned,
             global_next_slot,
             free_pool,
@@ -60,7 +60,7 @@ pub(crate) fn allocate_slots(ssa: &SSAFunction) -> Result<AllocatedFunction> {
         if block_xfer_slots > global_num_xfer_slots {
             global_num_xfer_slots = block_xfer_slots;
         }
-        result.extend(allocated);
+        result_blocks.push(block);
     }
 
     let mut home_slot_types = Vec::with_capacity(global_next_slot as usize);
@@ -74,7 +74,7 @@ pub(crate) fn allocate_slots(ssa: &SSAFunction) -> Result<AllocatedFunction> {
     }
 
     Ok(AllocatedFunction {
-        instrs: result,
+        blocks: result_blocks,
         num_home_slots: global_next_slot,
         num_xfer_slots: global_num_xfer_slots,
         home_slot_types,
@@ -91,38 +91,35 @@ fn vid_type(vid: Slot, vid_types: &[Type]) -> Result<Type> {
     }
 }
 
-/// Allocate real slots for a single basic block.
+/// Allocate real slots for a single basic block, remapping instructions in-place.
 ///
 /// For each instruction, in order: free last-use sources, allocate defs, remap, free dead defs.
 /// Allocation priority: xfer_precolor > stloc_targets > coalesce_to_local > type-keyed reuse > fresh.
 ///
-/// Returns (remapped instrs, next available slot index, xfer width, updated free pool).
-fn allocate_block(
-    instrs: &[Instr],
+/// Returns (next available slot index, xfer width, updated free pool).
+fn allocate_block_in_place(
+    instrs: &mut [Instr],
     num_pinned: u16,
     start_slot: u16,
-    carry_pool: BTreeMap<Type, Vec<Slot>>,
+    carry_pool: UnorderedMap<Type, Vec<Slot>>,
     vid_types: &[Type],
-    real_slot_types: &mut BTreeMap<Slot, Type>,
+    real_slot_types: &mut UnorderedMap<Slot, Type>,
     analysis: &BlockAnalysis,
-) -> Result<(Vec<Instr>, u16, u16, BTreeMap<Type, Vec<Slot>>)> {
+) -> Result<(u16, u16, UnorderedMap<Type, Vec<Slot>>)> {
     if instrs.is_empty() {
-        return Ok((Vec::new(), start_slot, 0, carry_pool));
+        return Ok((start_slot, 0, carry_pool));
     }
 
-    // Identity mapping for pinned locals so remap_instr leaves them unchanged.
-    let mut vid_to_real: BTreeMap<Slot, Slot> = BTreeMap::new();
+    // Identity mapping for pinned locals so remap_all_slots leaves them unchanged.
+    let mut vid_to_real: UnorderedMap<Slot, Slot> = UnorderedMap::new();
     for r in 0..num_pinned {
         vid_to_real.insert(Slot::Home(r), Slot::Home(r));
     }
     let mut free_pool = carry_pool;
     let mut next_slot = start_slot;
 
-    let mut output = Vec::with_capacity(instrs.len());
-
-    for (i, instr) in instrs.iter().enumerate() {
-        let mut mapped_instr = instr.clone();
-        let (defs, uses) = get_defs_uses(instr);
+    for (i, instr) in instrs.iter_mut().enumerate() {
+        let (defs, uses) = collect_defs_uses(instr);
 
         // Phase 1: Free use-slots whose last use is this instruction.
         // Done BEFORE def allocation so the freed slot can be immediately reused.
@@ -168,23 +165,22 @@ fn allocate_block(
             }
         }
 
-        // Phase 3: Rewrite the instruction with real slots.
-        remap_instr(&mut mapped_instr, &vid_to_real);
-        output.push(mapped_instr);
+        // Phase 3: Rewrite the instruction with real slots — in-place.
+        remap_all_slots_with(instr, |s| *vid_to_real.get(&s).unwrap_or(&s));
 
         // Phase 4: Free slots for defs that are never used (last_use == def site).
         for d in &defs {
-            if d.is_vid() && analysis.last_use.get(d) == Some(&i) {
-                if !uses.contains(d)
-                    && let Some(&real) = vid_to_real.get(d)
-                    && matches!(real, Slot::Home(i) if i >= num_pinned)
-                {
-                    let ty = real_slot_types.get(&real).cloned().unwrap_or(Type::Bool);
-                    free_pool.entry(ty).or_default().push(real);
-                }
+            if d.is_vid()
+                && analysis.last_use.get(d) == Some(&i)
+                && !uses.contains(d)
+                && let Some(&real) = vid_to_real.get(d)
+                && matches!(real, Slot::Home(i) if i >= num_pinned)
+            {
+                let ty = real_slot_types.get(&real).cloned().unwrap_or(Type::Bool);
+                free_pool.entry(ty).or_default().push(real);
             }
         }
     }
 
-    Ok((output, next_slot, analysis.max_xfer_width, free_pool))
+    Ok((next_slot, analysis.max_xfer_width, free_pool))
 }

--- a/third_party/move/mono-move/specializer/src/destack/ssa_conversion.rs
+++ b/third_party/move/mono-move/specializer/src/destack/ssa_conversion.rs
@@ -11,7 +11,7 @@ use super::{
     ssa_function::SSAFunction,
     type_conversion::{convert_sig_token, convert_sig_tokens},
 };
-use crate::stackless_exec_ir::{BinaryOp, Instr, Label, Slot, UnaryOp};
+use crate::stackless_exec_ir::{BasicBlock, BinaryOp, Instr, Label, Slot, UnaryOp};
 use anyhow::{bail, ensure, Context, Result};
 use move_binary_format::{
     access::ModuleAccess,
@@ -22,7 +22,8 @@ use move_binary_format::{
     CompiledModule,
 };
 use move_vm_types::loaded_data::{runtime_types::Type, struct_name_indexing::StructNameIndex};
-use std::{collections::BTreeMap, ops::Range};
+use shared_dsa::{Entry, UnorderedMap};
+use std::ops::Range;
 
 // ================================================================================================
 // Pass: Bytecode -> Intra-Block SSA
@@ -34,7 +35,7 @@ use std::{collections::BTreeMap, ops::Range};
 /// every terminator (`Branch`, `BrTrue`, `BrFalse`, `Ret`, `Abort`, `AbortMsg`).
 fn split_bytecode_into_blocks(
     code: &[Bytecode],
-    label_map: &BTreeMap<CodeOffset, Label>,
+    label_map: &UnorderedMap<CodeOffset, Label>,
 ) -> Result<Vec<Range<usize>>> {
     let mut blocks = Vec::new();
     let mut start = 0;
@@ -78,10 +79,14 @@ pub(crate) struct SsaConverter<'a> {
     vid_types: Vec<Type>,
     /// Struct name table for type conversion.
     struct_name_table: &'a [StructNameIndex],
-    /// Output instructions
-    instrs: Vec<Instr>,
+    /// Completed basic blocks.
+    blocks: Vec<BasicBlock>,
+    /// Instructions for the current block being built.
+    current_block_instrs: Vec<Instr>,
+    /// Label for the current block being built. `None` before the first block starts.
+    current_block_label: Option<Label>,
     /// Map from bytecode offset to label
-    label_map: BTreeMap<CodeOffset, Label>,
+    label_map: UnorderedMap<CodeOffset, Label>,
     /// Next label index
     next_label: u16,
 }
@@ -94,8 +99,10 @@ impl<'a> SsaConverter<'a> {
             local_types,
             vid_types: Vec::new(),
             struct_name_table,
-            instrs: Vec::new(),
-            label_map: BTreeMap::new(),
+            blocks: Vec::new(),
+            current_block_instrs: Vec::new(),
+            current_block_label: None,
+            label_map: UnorderedMap::new(),
             next_label: 0,
         }
     }
@@ -125,12 +132,14 @@ impl<'a> SsaConverter<'a> {
     }
 
     fn get_or_create_label(&mut self, offset: CodeOffset) -> Label {
-        let next = self.next_label;
-        let label = self.label_map.entry(offset).or_insert_with(|| Label(next));
-        if label.0 == next {
-            self.next_label += 1;
+        match self.label_map.entry(offset) {
+            Entry::Occupied(e) => *e.get(),
+            Entry::Vacant(e) => {
+                let label = Label(self.next_label);
+                self.next_label += 1;
+                *e.insert(label)
+            },
         }
-        *label
     }
 
     fn assign_labels(&mut self, code: &[Bytecode]) {
@@ -242,6 +251,22 @@ impl<'a> SsaConverter<'a> {
     // Function conversion
     // --------------------------------------------------------------------------------------------
 
+    /// Finalize the current block and start a new one with the given label.
+    fn start_new_block(&mut self, label: Label) {
+        self.finalize_current_block();
+        self.current_block_label = Some(label);
+    }
+
+    /// Push the current block onto the completed blocks list.
+    fn finalize_current_block(&mut self) {
+        if let Some(label) = self.current_block_label.take() {
+            self.blocks.push(BasicBlock {
+                label,
+                instrs: std::mem::take(&mut self.current_block_instrs),
+            });
+        }
+    }
+
     /// Converts the function's bytecode into SSA form, consuming the converter.
     pub(crate) fn convert_function(
         mut self,
@@ -258,16 +283,18 @@ impl<'a> SsaConverter<'a> {
                 "stack must be empty at block boundary"
             );
 
-            // Emit label if this block is a branch target.
-            if let Some(&label) = self.label_map.get(&(block.start as CodeOffset)) {
-                self.instrs.push(Instr::Label(label));
-            }
+            // Every block gets a label (assigned on-demand if not already a branch target).
+            let label = self.get_or_create_label(block.start as CodeOffset);
+            self.start_new_block(label);
+
             for bc in &code[block] {
                 self.convert_bytecode(module, bc)?;
             }
         }
+        self.finalize_current_block();
+
         Ok(SSAFunction {
-            instrs: self.instrs,
+            blocks: self.blocks,
             vid_types: self.vid_types,
             local_types: self.local_types,
         })
@@ -287,92 +314,92 @@ impl<'a> SsaConverter<'a> {
             B::LdU8(v) => {
                 let ty = Type::U8;
                 let dst = self.alloc_vid(ty.clone())?;
-                self.instrs.push(Instr::LdU8(dst, *v));
+                self.current_block_instrs.push(Instr::LdU8(dst, *v));
                 self.push_typed_slot(dst, ty);
             },
             B::LdU16(v) => {
                 let ty = Type::U16;
                 let dst = self.alloc_vid(ty.clone())?;
-                self.instrs.push(Instr::LdU16(dst, *v));
+                self.current_block_instrs.push(Instr::LdU16(dst, *v));
                 self.push_typed_slot(dst, ty);
             },
             B::LdU32(v) => {
                 let ty = Type::U32;
                 let dst = self.alloc_vid(ty.clone())?;
-                self.instrs.push(Instr::LdU32(dst, *v));
+                self.current_block_instrs.push(Instr::LdU32(dst, *v));
                 self.push_typed_slot(dst, ty);
             },
             B::LdU64(v) => {
                 let ty = Type::U64;
                 let dst = self.alloc_vid(ty.clone())?;
-                self.instrs.push(Instr::LdU64(dst, *v));
+                self.current_block_instrs.push(Instr::LdU64(dst, *v));
                 self.push_typed_slot(dst, ty);
             },
             B::LdU128(v) => {
                 let ty = Type::U128;
                 let dst = self.alloc_vid(ty.clone())?;
-                self.instrs.push(Instr::LdU128(dst, *v));
+                self.current_block_instrs.push(Instr::LdU128(dst, *v));
                 self.push_typed_slot(dst, ty);
             },
             B::LdU256(v) => {
                 let ty = Type::U256;
                 let dst = self.alloc_vid(ty.clone())?;
-                self.instrs.push(Instr::LdU256(dst, *v));
+                self.current_block_instrs.push(Instr::LdU256(dst, *v));
                 self.push_typed_slot(dst, ty);
             },
             B::LdI8(v) => {
                 let ty = Type::I8;
                 let dst = self.alloc_vid(ty.clone())?;
-                self.instrs.push(Instr::LdI8(dst, *v));
+                self.current_block_instrs.push(Instr::LdI8(dst, *v));
                 self.push_typed_slot(dst, ty);
             },
             B::LdI16(v) => {
                 let ty = Type::I16;
                 let dst = self.alloc_vid(ty.clone())?;
-                self.instrs.push(Instr::LdI16(dst, *v));
+                self.current_block_instrs.push(Instr::LdI16(dst, *v));
                 self.push_typed_slot(dst, ty);
             },
             B::LdI32(v) => {
                 let ty = Type::I32;
                 let dst = self.alloc_vid(ty.clone())?;
-                self.instrs.push(Instr::LdI32(dst, *v));
+                self.current_block_instrs.push(Instr::LdI32(dst, *v));
                 self.push_typed_slot(dst, ty);
             },
             B::LdI64(v) => {
                 let ty = Type::I64;
                 let dst = self.alloc_vid(ty.clone())?;
-                self.instrs.push(Instr::LdI64(dst, *v));
+                self.current_block_instrs.push(Instr::LdI64(dst, *v));
                 self.push_typed_slot(dst, ty);
             },
             B::LdI128(v) => {
                 let ty = Type::I128;
                 let dst = self.alloc_vid(ty.clone())?;
-                self.instrs.push(Instr::LdI128(dst, *v));
+                self.current_block_instrs.push(Instr::LdI128(dst, *v));
                 self.push_typed_slot(dst, ty);
             },
             B::LdI256(v) => {
                 let ty = Type::I256;
                 let dst = self.alloc_vid(ty.clone())?;
-                self.instrs.push(Instr::LdI256(dst, *v));
+                self.current_block_instrs.push(Instr::LdI256(dst, *v));
                 self.push_typed_slot(dst, ty);
             },
             B::LdConst(idx) => {
                 let tok = &module.constant_pool[idx.0 as usize].type_;
                 let ty = convert_sig_token(module, tok, self.struct_name_table);
                 let dst = self.alloc_vid(ty.clone())?;
-                self.instrs.push(Instr::LdConst(dst, *idx));
+                self.current_block_instrs.push(Instr::LdConst(dst, *idx));
                 self.push_typed_slot(dst, ty);
             },
             B::LdTrue => {
                 let ty = Type::Bool;
                 let dst = self.alloc_vid(ty.clone())?;
-                self.instrs.push(Instr::LdTrue(dst));
+                self.current_block_instrs.push(Instr::LdTrue(dst));
                 self.push_typed_slot(dst, ty);
             },
             B::LdFalse => {
                 let ty = Type::Bool;
                 let dst = self.alloc_vid(ty.clone())?;
-                self.instrs.push(Instr::LdFalse(dst));
+                self.current_block_instrs.push(Instr::LdFalse(dst));
                 self.push_typed_slot(dst, ty);
             },
 
@@ -381,20 +408,20 @@ impl<'a> SsaConverter<'a> {
                 let src = Slot::Home(*idx as u16);
                 let ty = self.local_types[*idx as usize].clone();
                 let dst = self.alloc_vid(ty.clone())?;
-                self.instrs.push(Instr::Copy(dst, src));
+                self.current_block_instrs.push(Instr::Copy(dst, src));
                 self.push_typed_slot(dst, ty);
             },
             B::MoveLoc(idx) => {
                 let src = Slot::Home(*idx as u16);
                 let ty = self.local_types[*idx as usize].clone();
                 let dst = self.alloc_vid(ty.clone())?;
-                self.instrs.push(Instr::Move(dst, src));
+                self.current_block_instrs.push(Instr::Move(dst, src));
                 self.push_typed_slot(dst, ty);
             },
             B::StLoc(idx) => {
                 let (src, _ty) = self.pop_typed_slot()?;
                 let dst = Slot::Home(*idx as u16);
-                self.instrs.push(Instr::Move(dst, src));
+                self.current_block_instrs.push(Instr::Move(dst, src));
             },
 
             // --- Pop ---
@@ -448,7 +475,8 @@ impl<'a> SsaConverter<'a> {
                 let fields: Vec<Slot> = fields_typed.iter().map(|(r, _)| *r).collect();
                 let result_ty = self.struct_type(module, *idx);
                 let dst = self.alloc_vid(result_ty.clone())?;
-                self.instrs.push(Instr::Pack(dst, *idx, fields));
+                self.current_block_instrs
+                    .push(Instr::Pack(dst, *idx, fields));
                 self.push_typed_slot(dst, result_ty);
             },
             B::PackGeneric(idx) => {
@@ -458,7 +486,8 @@ impl<'a> SsaConverter<'a> {
                 let fields: Vec<Slot> = fields_typed.iter().map(|(r, _)| *r).collect();
                 let result_ty = self.struct_inst_type(module, *idx);
                 let dst = self.alloc_vid(result_ty.clone())?;
-                self.instrs.push(Instr::PackGeneric(dst, *idx, fields));
+                self.current_block_instrs
+                    .push(Instr::PackGeneric(dst, *idx, fields));
                 self.push_typed_slot(dst, result_ty);
             },
             B::Unpack(idx) => {
@@ -474,7 +503,8 @@ impl<'a> SsaConverter<'a> {
                         .context("field type index out of bounds")?;
                     dsts.push(self.alloc_vid(fty)?);
                 }
-                self.instrs.push(Instr::Unpack(dsts.clone(), *idx, src));
+                self.current_block_instrs
+                    .push(Instr::Unpack(dsts.clone(), *idx, src));
                 for (dst, fty) in dsts.into_iter().zip(ftypes) {
                     self.push_typed_slot(dst, fty);
                 }
@@ -499,7 +529,7 @@ impl<'a> SsaConverter<'a> {
                         .context("field type index out of bounds")?;
                     dsts.push(self.alloc_vid(fty)?);
                 }
-                self.instrs
+                self.current_block_instrs
                     .push(Instr::UnpackGeneric(dsts.clone(), *idx, src));
                 for (dst, fty) in dsts.into_iter().zip(ftypes) {
                     self.push_typed_slot(dst, fty);
@@ -514,7 +544,8 @@ impl<'a> SsaConverter<'a> {
                 let fields: Vec<Slot> = fields_typed.iter().map(|(r, _)| *r).collect();
                 let result_ty = self.struct_type(module, handle.struct_index);
                 let dst = self.alloc_vid(result_ty.clone())?;
-                self.instrs.push(Instr::PackVariant(dst, *idx, fields));
+                self.current_block_instrs
+                    .push(Instr::PackVariant(dst, *idx, fields));
                 self.push_typed_slot(dst, result_ty);
             },
             B::PackVariantGeneric(idx) => {
@@ -528,7 +559,7 @@ impl<'a> SsaConverter<'a> {
                 let tok = SignatureToken::StructInstantiation(def.struct_handle, type_params);
                 let result_ty = convert_sig_token(module, &tok, self.struct_name_table);
                 let dst = self.alloc_vid(result_ty.clone())?;
-                self.instrs
+                self.current_block_instrs
                     .push(Instr::PackVariantGeneric(dst, *idx, fields));
                 self.push_typed_slot(dst, result_ty);
             },
@@ -548,7 +579,7 @@ impl<'a> SsaConverter<'a> {
                         .context("field type index out of bounds")?;
                     dsts.push(self.alloc_vid(fty)?);
                 }
-                self.instrs
+                self.current_block_instrs
                     .push(Instr::UnpackVariant(dsts.clone(), *idx, src));
                 for (dst, fty) in dsts.into_iter().zip(ftypes) {
                     self.push_typed_slot(dst, fty);
@@ -576,8 +607,11 @@ impl<'a> SsaConverter<'a> {
                         .context("field type index out of bounds")?;
                     dsts.push(self.alloc_vid(fty)?);
                 }
-                self.instrs
-                    .push(Instr::UnpackVariantGeneric(dsts.clone(), *idx, src));
+                self.current_block_instrs.push(Instr::UnpackVariantGeneric(
+                    dsts.clone(),
+                    *idx,
+                    src,
+                ));
                 for (dst, fty) in dsts.into_iter().zip(ftypes) {
                     self.push_typed_slot(dst, fty);
                 }
@@ -586,14 +620,16 @@ impl<'a> SsaConverter<'a> {
                 let (src, _src_ty) = self.pop_typed_slot()?;
                 let ty = Type::Bool;
                 let dst = self.alloc_vid(ty.clone())?;
-                self.instrs.push(Instr::TestVariant(dst, *idx, src));
+                self.current_block_instrs
+                    .push(Instr::TestVariant(dst, *idx, src));
                 self.push_typed_slot(dst, ty);
             },
             B::TestVariantGeneric(idx) => {
                 let (src, _src_ty) = self.pop_typed_slot()?;
                 let ty = Type::Bool;
                 let dst = self.alloc_vid(ty.clone())?;
-                self.instrs.push(Instr::TestVariantGeneric(dst, *idx, src));
+                self.current_block_instrs
+                    .push(Instr::TestVariantGeneric(dst, *idx, src));
                 self.push_typed_slot(dst, ty);
             },
 
@@ -603,7 +639,8 @@ impl<'a> SsaConverter<'a> {
                 let inner = self.local_types[*idx as usize].clone();
                 let ty = Type::Reference(Box::new(inner));
                 let dst = self.alloc_vid(ty.clone())?;
-                self.instrs.push(Instr::ImmBorrowLoc(dst, src));
+                self.current_block_instrs
+                    .push(Instr::ImmBorrowLoc(dst, src));
                 self.push_typed_slot(dst, ty);
             },
             B::MutBorrowLoc(idx) => {
@@ -611,7 +648,8 @@ impl<'a> SsaConverter<'a> {
                 let inner = self.local_types[*idx as usize].clone();
                 let ty = Type::MutableReference(Box::new(inner));
                 let dst = self.alloc_vid(ty.clone())?;
-                self.instrs.push(Instr::MutBorrowLoc(dst, src));
+                self.current_block_instrs
+                    .push(Instr::MutBorrowLoc(dst, src));
                 self.push_typed_slot(dst, ty);
             },
             B::ImmBorrowField(idx) => {
@@ -619,7 +657,8 @@ impl<'a> SsaConverter<'a> {
                 let fty = self.field_type(module, *idx)?;
                 let ty = Type::Reference(Box::new(fty));
                 let dst = self.alloc_vid(ty.clone())?;
-                self.instrs.push(Instr::ImmBorrowField(dst, *idx, src));
+                self.current_block_instrs
+                    .push(Instr::ImmBorrowField(dst, *idx, src));
                 self.push_typed_slot(dst, ty);
             },
             B::MutBorrowField(idx) => {
@@ -627,7 +666,8 @@ impl<'a> SsaConverter<'a> {
                 let fty = self.field_type(module, *idx)?;
                 let ty = Type::MutableReference(Box::new(fty));
                 let dst = self.alloc_vid(ty.clone())?;
-                self.instrs.push(Instr::MutBorrowField(dst, *idx, src));
+                self.current_block_instrs
+                    .push(Instr::MutBorrowField(dst, *idx, src));
                 self.push_typed_slot(dst, ty);
             },
             B::ImmBorrowFieldGeneric(idx) => {
@@ -635,7 +675,7 @@ impl<'a> SsaConverter<'a> {
                 let fty = self.field_inst_type(module, *idx)?;
                 let ty = Type::Reference(Box::new(fty));
                 let dst = self.alloc_vid(ty.clone())?;
-                self.instrs
+                self.current_block_instrs
                     .push(Instr::ImmBorrowFieldGeneric(dst, *idx, src));
                 self.push_typed_slot(dst, ty);
             },
@@ -644,7 +684,7 @@ impl<'a> SsaConverter<'a> {
                 let fty = self.field_inst_type(module, *idx)?;
                 let ty = Type::MutableReference(Box::new(fty));
                 let dst = self.alloc_vid(ty.clone())?;
-                self.instrs
+                self.current_block_instrs
                     .push(Instr::MutBorrowFieldGeneric(dst, *idx, src));
                 self.push_typed_slot(dst, ty);
             },
@@ -653,7 +693,7 @@ impl<'a> SsaConverter<'a> {
                 let fty = self.variant_field_handle_type(module, *idx)?;
                 let ty = Type::Reference(Box::new(fty));
                 let dst = self.alloc_vid(ty.clone())?;
-                self.instrs
+                self.current_block_instrs
                     .push(Instr::ImmBorrowVariantField(dst, *idx, src));
                 self.push_typed_slot(dst, ty);
             },
@@ -662,7 +702,7 @@ impl<'a> SsaConverter<'a> {
                 let fty = self.variant_field_handle_type(module, *idx)?;
                 let ty = Type::MutableReference(Box::new(fty));
                 let dst = self.alloc_vid(ty.clone())?;
-                self.instrs
+                self.current_block_instrs
                     .push(Instr::MutBorrowVariantField(dst, *idx, src));
                 self.push_typed_slot(dst, ty);
             },
@@ -671,7 +711,7 @@ impl<'a> SsaConverter<'a> {
                 let fty = self.variant_field_inst_type(module, *idx)?;
                 let ty = Type::Reference(Box::new(fty));
                 let dst = self.alloc_vid(ty.clone())?;
-                self.instrs
+                self.current_block_instrs
                     .push(Instr::ImmBorrowVariantFieldGeneric(dst, *idx, src));
                 self.push_typed_slot(dst, ty);
             },
@@ -680,7 +720,7 @@ impl<'a> SsaConverter<'a> {
                 let fty = self.variant_field_inst_type(module, *idx)?;
                 let ty = Type::MutableReference(Box::new(fty));
                 let dst = self.alloc_vid(ty.clone())?;
-                self.instrs
+                self.current_block_instrs
                     .push(Instr::MutBorrowVariantFieldGeneric(dst, *idx, src));
                 self.push_typed_slot(dst, ty);
             },
@@ -691,13 +731,13 @@ impl<'a> SsaConverter<'a> {
                     other => bail!("ReadRef on non-reference type {:?}", other),
                 };
                 let dst = self.alloc_vid(ty.clone())?;
-                self.instrs.push(Instr::ReadRef(dst, src));
+                self.current_block_instrs.push(Instr::ReadRef(dst, src));
                 self.push_typed_slot(dst, ty);
             },
             B::WriteRef => {
                 let (ref_r, _ref_ty) = self.pop_typed_slot()?;
                 let (val, _val_ty) = self.pop_typed_slot()?;
-                self.instrs.push(Instr::WriteRef(ref_r, val));
+                self.current_block_instrs.push(Instr::WriteRef(ref_r, val));
             },
 
             // --- Globals ---
@@ -705,52 +745,59 @@ impl<'a> SsaConverter<'a> {
                 let (addr, _addr_ty) = self.pop_typed_slot()?;
                 let ty = Type::Bool;
                 let dst = self.alloc_vid(ty.clone())?;
-                self.instrs.push(Instr::Exists(dst, *idx, addr));
+                self.current_block_instrs
+                    .push(Instr::Exists(dst, *idx, addr));
                 self.push_typed_slot(dst, ty);
             },
             B::ExistsGeneric(idx) => {
                 let (addr, _addr_ty) = self.pop_typed_slot()?;
                 let ty = Type::Bool;
                 let dst = self.alloc_vid(ty.clone())?;
-                self.instrs.push(Instr::ExistsGeneric(dst, *idx, addr));
+                self.current_block_instrs
+                    .push(Instr::ExistsGeneric(dst, *idx, addr));
                 self.push_typed_slot(dst, ty);
             },
             B::MoveFrom(idx) => {
                 let (addr, _addr_ty) = self.pop_typed_slot()?;
                 let ty = self.struct_type(module, *idx);
                 let dst = self.alloc_vid(ty.clone())?;
-                self.instrs.push(Instr::MoveFrom(dst, *idx, addr));
+                self.current_block_instrs
+                    .push(Instr::MoveFrom(dst, *idx, addr));
                 self.push_typed_slot(dst, ty);
             },
             B::MoveFromGeneric(idx) => {
                 let (addr, _addr_ty) = self.pop_typed_slot()?;
                 let ty = self.struct_inst_type(module, *idx);
                 let dst = self.alloc_vid(ty.clone())?;
-                self.instrs.push(Instr::MoveFromGeneric(dst, *idx, addr));
+                self.current_block_instrs
+                    .push(Instr::MoveFromGeneric(dst, *idx, addr));
                 self.push_typed_slot(dst, ty);
             },
             B::MoveTo(idx) => {
                 let (val, _val_ty) = self.pop_typed_slot()?;
                 let (signer, _signer_ty) = self.pop_typed_slot()?;
-                self.instrs.push(Instr::MoveTo(*idx, signer, val));
+                self.current_block_instrs
+                    .push(Instr::MoveTo(*idx, signer, val));
             },
             B::MoveToGeneric(idx) => {
                 let (val, _val_ty) = self.pop_typed_slot()?;
                 let (signer, _signer_ty) = self.pop_typed_slot()?;
-                self.instrs.push(Instr::MoveToGeneric(*idx, signer, val));
+                self.current_block_instrs
+                    .push(Instr::MoveToGeneric(*idx, signer, val));
             },
             B::ImmBorrowGlobal(idx) => {
                 let (addr, _addr_ty) = self.pop_typed_slot()?;
                 let ty = Type::Reference(Box::new(self.struct_type(module, *idx)));
                 let dst = self.alloc_vid(ty.clone())?;
-                self.instrs.push(Instr::ImmBorrowGlobal(dst, *idx, addr));
+                self.current_block_instrs
+                    .push(Instr::ImmBorrowGlobal(dst, *idx, addr));
                 self.push_typed_slot(dst, ty);
             },
             B::ImmBorrowGlobalGeneric(idx) => {
                 let (addr, _addr_ty) = self.pop_typed_slot()?;
                 let ty = Type::Reference(Box::new(self.struct_inst_type(module, *idx)));
                 let dst = self.alloc_vid(ty.clone())?;
-                self.instrs
+                self.current_block_instrs
                     .push(Instr::ImmBorrowGlobalGeneric(dst, *idx, addr));
                 self.push_typed_slot(dst, ty);
             },
@@ -758,14 +805,15 @@ impl<'a> SsaConverter<'a> {
                 let (addr, _addr_ty) = self.pop_typed_slot()?;
                 let ty = Type::MutableReference(Box::new(self.struct_type(module, *idx)));
                 let dst = self.alloc_vid(ty.clone())?;
-                self.instrs.push(Instr::MutBorrowGlobal(dst, *idx, addr));
+                self.current_block_instrs
+                    .push(Instr::MutBorrowGlobal(dst, *idx, addr));
                 self.push_typed_slot(dst, ty);
             },
             B::MutBorrowGlobalGeneric(idx) => {
                 let (addr, _addr_ty) = self.pop_typed_slot()?;
                 let ty = Type::MutableReference(Box::new(self.struct_inst_type(module, *idx)));
                 let dst = self.alloc_vid(ty.clone())?;
-                self.instrs
+                self.current_block_instrs
                     .push(Instr::MutBorrowGlobalGeneric(dst, *idx, addr));
                 self.push_typed_slot(dst, ty);
             },
@@ -782,7 +830,8 @@ impl<'a> SsaConverter<'a> {
                 for rty in &ret_types {
                     rets.push(self.alloc_vid(rty.clone())?);
                 }
-                self.instrs.push(Instr::Call(rets.clone(), *idx, args));
+                self.current_block_instrs
+                    .push(Instr::Call(rets.clone(), *idx, args));
                 for (r, rty) in rets.into_iter().zip(ret_types) {
                     self.push_typed_slot(r, rty);
                 }
@@ -804,7 +853,7 @@ impl<'a> SsaConverter<'a> {
                 for rty in &ret_types {
                     rets.push(self.alloc_vid(rty.clone())?);
                 }
-                self.instrs
+                self.current_block_instrs
                     .push(Instr::CallGeneric(rets.clone(), *idx, args));
                 for (r, rty) in rets.into_iter().zip(ret_types) {
                     self.push_typed_slot(r, rty);
@@ -826,7 +875,7 @@ impl<'a> SsaConverter<'a> {
                 );
                 let ty = convert_sig_token(module, &tok, self.struct_name_table);
                 let dst = self.alloc_vid(ty.clone())?;
-                self.instrs
+                self.current_block_instrs
                     .push(Instr::PackClosure(dst, *fhi, *mask, captured));
                 self.push_typed_slot(dst, ty);
             },
@@ -845,7 +894,7 @@ impl<'a> SsaConverter<'a> {
                 );
                 let ty = convert_sig_token(module, &tok, self.struct_name_table);
                 let dst = self.alloc_vid(ty.clone())?;
-                self.instrs
+                self.current_block_instrs
                     .push(Instr::PackClosureGeneric(dst, *fii, *mask, captured));
                 self.push_typed_slot(dst, ty);
             },
@@ -866,8 +915,11 @@ impl<'a> SsaConverter<'a> {
                 for rty in &ret_types {
                     rets.push(self.alloc_vid(rty.clone())?);
                 }
-                self.instrs
-                    .push(Instr::CallClosure(rets.clone(), *sig_idx, all_args));
+                self.current_block_instrs.push(Instr::CallClosure(
+                    rets.clone(),
+                    *sig_idx,
+                    all_args,
+                ));
                 for (r, rty) in rets.into_iter().zip(ret_types) {
                     self.push_typed_slot(r, rty);
                 }
@@ -882,7 +934,7 @@ impl<'a> SsaConverter<'a> {
                 let elem_ty = convert_sig_token(module, elem_tok, self.struct_name_table);
                 let ty = Type::Vector(triomphe::Arc::new(elem_ty));
                 let dst = self.alloc_vid(ty.clone())?;
-                self.instrs
+                self.current_block_instrs
                     .push(Instr::VecPack(dst, *sig_idx, count, elems));
                 self.push_typed_slot(dst, ty);
             },
@@ -890,7 +942,8 @@ impl<'a> SsaConverter<'a> {
                 let (vec_ref, _vec_ty) = self.pop_typed_slot()?;
                 let ty = Type::U64;
                 let dst = self.alloc_vid(ty.clone())?;
-                self.instrs.push(Instr::VecLen(dst, *sig_idx, vec_ref));
+                self.current_block_instrs
+                    .push(Instr::VecLen(dst, *sig_idx, vec_ref));
                 self.push_typed_slot(dst, ty);
             },
             B::VecImmBorrow(sig_idx) => {
@@ -900,7 +953,7 @@ impl<'a> SsaConverter<'a> {
                 let elem_ty = convert_sig_token(module, elem_tok, self.struct_name_table);
                 let ty = Type::Reference(Box::new(elem_ty));
                 let dst = self.alloc_vid(ty.clone())?;
-                self.instrs
+                self.current_block_instrs
                     .push(Instr::VecImmBorrow(dst, *sig_idx, vec_ref, idx_r));
                 self.push_typed_slot(dst, ty);
             },
@@ -911,21 +964,23 @@ impl<'a> SsaConverter<'a> {
                 let elem_ty = convert_sig_token(module, elem_tok, self.struct_name_table);
                 let ty = Type::MutableReference(Box::new(elem_ty));
                 let dst = self.alloc_vid(ty.clone())?;
-                self.instrs
+                self.current_block_instrs
                     .push(Instr::VecMutBorrow(dst, *sig_idx, vec_ref, idx_r));
                 self.push_typed_slot(dst, ty);
             },
             B::VecPushBack(sig_idx) => {
                 let (val, _val_ty) = self.pop_typed_slot()?;
                 let (vec_ref, _vec_ty) = self.pop_typed_slot()?;
-                self.instrs.push(Instr::VecPushBack(*sig_idx, vec_ref, val));
+                self.current_block_instrs
+                    .push(Instr::VecPushBack(*sig_idx, vec_ref, val));
             },
             B::VecPopBack(sig_idx) => {
                 let (vec_ref, _vec_ty) = self.pop_typed_slot()?;
                 let elem_tok = &module.signature_at(*sig_idx).0[0];
                 let ty = convert_sig_token(module, elem_tok, self.struct_name_table);
                 let dst = self.alloc_vid(ty.clone())?;
-                self.instrs.push(Instr::VecPopBack(dst, *sig_idx, vec_ref));
+                self.current_block_instrs
+                    .push(Instr::VecPopBack(dst, *sig_idx, vec_ref));
                 self.push_typed_slot(dst, ty);
             },
             B::VecUnpack(sig_idx, count) => {
@@ -937,8 +992,12 @@ impl<'a> SsaConverter<'a> {
                 for _ in 0..count {
                     dsts.push(self.alloc_vid(elem_ty.clone())?);
                 }
-                self.instrs
-                    .push(Instr::VecUnpack(dsts.clone(), *sig_idx, count, src));
+                self.current_block_instrs.push(Instr::VecUnpack(
+                    dsts.clone(),
+                    *sig_idx,
+                    count,
+                    src,
+                ));
                 for dst in dsts {
                     self.push_typed_slot(dst, elem_ty.clone());
                 }
@@ -947,36 +1006,37 @@ impl<'a> SsaConverter<'a> {
                 let (j, _j_ty) = self.pop_typed_slot()?;
                 let (i, _i_ty) = self.pop_typed_slot()?;
                 let (vec_ref, _vec_ty) = self.pop_typed_slot()?;
-                self.instrs.push(Instr::VecSwap(*sig_idx, vec_ref, i, j));
+                self.current_block_instrs
+                    .push(Instr::VecSwap(*sig_idx, vec_ref, i, j));
             },
 
             // --- Control flow ---
             B::Branch(target) => {
-                let label = self.label_map[target];
-                self.instrs.push(Instr::Branch(label));
+                let label = *self.label_map.get(target).expect("branch target label");
+                self.current_block_instrs.push(Instr::Branch(label));
             },
             B::BrTrue(target) => {
                 let (cond, _cond_ty) = self.pop_typed_slot()?;
-                let label = self.label_map[target];
-                self.instrs.push(Instr::BrTrue(label, cond));
+                let label = *self.label_map.get(target).expect("branch target label");
+                self.current_block_instrs.push(Instr::BrTrue(label, cond));
             },
             B::BrFalse(target) => {
                 let (cond, _cond_ty) = self.pop_typed_slot()?;
-                let label = self.label_map[target];
-                self.instrs.push(Instr::BrFalse(label, cond));
+                let label = *self.label_map.get(target).expect("branch target label");
+                self.current_block_instrs.push(Instr::BrFalse(label, cond));
             },
             B::Ret => {
                 let rets: Vec<Slot> = self.stack.drain(..).map(|(r, _)| r).collect();
-                self.instrs.push(Instr::Ret(rets));
+                self.current_block_instrs.push(Instr::Ret(rets));
             },
             B::Abort => {
                 let (code, _code_ty) = self.pop_typed_slot()?;
-                self.instrs.push(Instr::Abort(code));
+                self.current_block_instrs.push(Instr::Abort(code));
             },
             B::AbortMsg => {
                 let (msg, _msg_ty) = self.pop_typed_slot()?;
                 let (code, _code_ty) = self.pop_typed_slot()?;
-                self.instrs.push(Instr::AbortMsg(code, msg));
+                self.current_block_instrs.push(Instr::AbortMsg(code, msg));
             },
 
             B::Nop => {},
@@ -989,7 +1049,8 @@ impl<'a> SsaConverter<'a> {
         let (lhs, lhs_ty) = self.pop_typed_slot()?;
         let result_ty = if result_is_bool { Type::Bool } else { lhs_ty };
         let dst = self.alloc_vid(result_ty.clone())?;
-        self.instrs.push(Instr::BinaryOp(dst, op, lhs, rhs));
+        self.current_block_instrs
+            .push(Instr::BinaryOp(dst, op, lhs, rhs));
         self.push_typed_slot(dst, result_ty);
         Ok(())
     }
@@ -1007,7 +1068,7 @@ impl<'a> SsaConverter<'a> {
             },
         };
         let dst = self.alloc_vid(result_ty.clone())?;
-        self.instrs.push(Instr::UnaryOp(dst, op, src));
+        self.current_block_instrs.push(Instr::UnaryOp(dst, op, src));
         self.push_typed_slot(dst, result_ty);
         Ok(())
     }

--- a/third_party/move/mono-move/specializer/src/destack/ssa_function.rs
+++ b/third_party/move/mono-move/specializer/src/destack/ssa_function.rs
@@ -2,15 +2,20 @@
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 //! Intermediate SSA representation and pre-allocation fusion passes.
+//!
+//! SSA is intra-block and applies only to value IDs, not to params or locals
+//! (which are mutable across blocks). Because the operand stack is empty at
+//! block boundaries, no phi nodes are needed — each value ID is defined exactly
+//! once within its block and never crosses a block boundary.
 
-use super::instr_utils::{extract_imm_value, get_defs_uses, is_commutative, split_into_blocks};
-use crate::stackless_exec_ir::Instr;
+use super::instr_utils::{extract_imm_value, is_commutative};
+use crate::stackless_exec_ir::{BasicBlock, Instr};
 use move_vm_types::loaded_data::runtime_types::Type;
 
 /// Intermediate SSA representation of a single function, before slot allocation.
 pub(crate) struct SSAFunction {
-    /// Stackless instructions in SSA form.
-    pub instrs: Vec<Instr>,
+    /// Basic blocks in SSA form.
+    pub blocks: Vec<BasicBlock>,
     /// Type of each value ID, indexed directly by the value ID number.
     pub vid_types: Vec<Type>,
     /// Types of all locals (params ++ declared locals).
@@ -18,144 +23,105 @@ pub(crate) struct SSAFunction {
 }
 
 impl SSAFunction {
-    /// Fuse consecutive borrow+deref patterns into combined field access instructions.
-    ///
-    /// Safety: relies on the SSA single-use invariant — each `Vid` produced by a
-    /// borrow instruction is consumed exactly once by the immediately following
-    /// `ReadRef`/`WriteRef`. This holds for verified stack-machine bytecode.
-    pub(crate) fn fuse_field_access_instrs(&mut self) {
-        let instrs = &self.instrs;
-        let mut result = Vec::with_capacity(instrs.len());
-        let mut skip_next = false;
-
-        for w in instrs.windows(2) {
-            if skip_next {
-                skip_next = false;
-                continue;
-            }
-
-            let fused = match (&w[0], &w[1]) {
-                (Instr::ImmBorrowField(ref_r, fld, src), Instr::ReadRef(dst, read_src))
-                    if *ref_r == *read_src =>
-                {
-                    Some(Instr::ReadField(*dst, *fld, *src))
-                },
-                (Instr::ImmBorrowFieldGeneric(ref_r, fld, src), Instr::ReadRef(dst, read_src))
-                    if *ref_r == *read_src =>
-                {
-                    Some(Instr::ReadFieldGeneric(*dst, *fld, *src))
-                },
-                (Instr::MutBorrowField(ref_r, fld, dst_ref), Instr::WriteRef(write_ref, val))
-                    if *ref_r == *write_ref =>
-                {
-                    Some(Instr::WriteField(*fld, *dst_ref, *val))
-                },
-                (
-                    Instr::MutBorrowFieldGeneric(ref_r, fld, dst_ref),
-                    Instr::WriteRef(write_ref, val),
-                ) if *ref_r == *write_ref => Some(Instr::WriteFieldGeneric(*fld, *dst_ref, *val)),
-                (Instr::ImmBorrowVariantField(ref_r, fld, src), Instr::ReadRef(dst, read_src))
-                    if *ref_r == *read_src =>
-                {
-                    Some(Instr::ReadVariantField(*dst, *fld, *src))
-                },
-                (
-                    Instr::ImmBorrowVariantFieldGeneric(ref_r, fld, src),
-                    Instr::ReadRef(dst, read_src),
-                ) if *ref_r == *read_src => Some(Instr::ReadVariantFieldGeneric(*dst, *fld, *src)),
-                (
-                    Instr::MutBorrowVariantField(ref_r, fld, dst_ref),
-                    Instr::WriteRef(write_ref, val),
-                ) if *ref_r == *write_ref => Some(Instr::WriteVariantField(*fld, *dst_ref, *val)),
-                (
-                    Instr::MutBorrowVariantFieldGeneric(ref_r, fld, dst_ref),
-                    Instr::WriteRef(write_ref, val),
-                ) if *ref_r == *write_ref => {
-                    Some(Instr::WriteVariantFieldGeneric(*fld, *dst_ref, *val))
-                },
-                _ => None,
-            };
-
-            if let Some(fused_instr) = fused {
-                result.push(fused_instr);
-                skip_next = true;
-            } else {
-                result.push(w[0].clone());
-            }
+    /// Run all pre-allocation instruction fusion passes.
+    pub(crate) fn with_fusion_passes(mut self) -> Self {
+        // [TODO]: right now, we have each different fusion operation to be a separate pass.
+        // This is easier to reason about, but we could make it more efficient by
+        // combining the passes.
+        for block in &mut self.blocks {
+            fuse_pairs(&mut block.instrs, try_fuse_field_access);
+            fuse_pairs(&mut block.instrs, try_fuse_immediate_binop);
         }
-
-        // The last instruction is only the second element of the final window,
-        // so it's never pushed as w[0]. Emit it unless it was consumed by fusion.
-        if !skip_next {
-            if let Some(last) = instrs.last() {
-                result.push(last.clone());
-            }
-        }
-
-        self.instrs = result;
+        self
     }
+}
 
-    /// Fuse consecutive `Ld*` + `BinaryOp` pairs into `BinaryOpImm` in the SSA IR.
-    pub(crate) fn fuse_immediate_binops(&mut self) {
-        let instrs = &self.instrs;
-        let blocks = split_into_blocks(instrs);
-        let mut result = Vec::with_capacity(instrs.len());
+/// In-place compaction that fuses consecutive instruction pairs.
+///
+/// For each position, calls `try_fuse(&instrs[r], &instrs[r+1])`. If it returns
+/// `Some(fused)`, the pair is replaced by the single fused instruction. Otherwise
+/// the instruction is kept as-is. Uses a write-cursor so no allocation is needed.
+fn fuse_pairs(instrs: &mut Vec<Instr>, try_fuse: fn(&Instr, &Instr) -> Option<Instr>) {
+    let mut write = 0;
+    let mut read = 0;
+    while read < instrs.len() {
+        let fused = instrs
+            .get(read + 1)
+            .and_then(|next| try_fuse(&instrs[read], next));
 
-        let mut block_idx = 0;
-        let mut skip_next = false;
-
-        for i in 0..instrs.len() {
-            if skip_next {
-                skip_next = false;
-                continue;
-            }
-
-            // Advance to the current block.
-            while block_idx < blocks.len() && i >= blocks[block_idx].end {
-                block_idx += 1;
-            }
-
-            // Only fuse within the same basic block.
-            if i + 1 < instrs.len()
-                && block_idx < blocks.len()
-                && i + 1 < blocks[block_idx].end
-                && let Some((tmp, imm)) = extract_imm_value(&instrs[i])
-            {
-                let fused = match &instrs[i + 1] {
-                    Instr::BinaryOp(dst, op, lhs, rhs) if *rhs == tmp => {
-                        Some(Instr::BinaryOpImm(*dst, op.clone(), *lhs, imm.clone()))
-                    },
-                    Instr::BinaryOp(dst, op, lhs, rhs) if *lhs == tmp && is_commutative(op) => {
-                        Some(Instr::BinaryOpImm(*dst, op.clone(), *rhs, imm.clone()))
-                    },
-                    _ => None,
-                };
-                if let Some(fused_instr) = fused {
-                    debug_assert!(
-                        {
-                            let block = &blocks[block_idx];
-                            instrs[block.clone()]
-                                .iter()
-                                .enumerate()
-                                .filter(|&(j, _)| block.start + j != i + 1)
-                                .all(|(_, ins)| {
-                                    let (_, uses) = get_defs_uses(ins);
-                                    !uses.contains(&tmp)
-                                })
-                        },
-                        "BinaryOpImm SSA fusion: VID {:?} has uses outside the \
-                         consecutive Ld+BinaryOp pair — stack machine invariant violated",
-                        tmp,
-                    );
-                    result.push(fused_instr);
-                    skip_next = true;
-                    continue;
+        match fused {
+            Some(fused_instr) => {
+                instrs[write] = fused_instr;
+                read += 2;
+            },
+            None => {
+                if write != read {
+                    instrs.swap(write, read);
                 }
-            }
-
-            result.push(instrs[i].clone());
+                read += 1;
+            },
         }
+        write += 1;
+    }
+    instrs.truncate(write);
+}
 
-        self.instrs = result;
+/// Try to fuse a borrow+deref pair into a combined field access instruction.
+fn try_fuse_field_access(first: &Instr, second: &Instr) -> Option<Instr> {
+    match (first, second) {
+        (Instr::ImmBorrowField(ref_r, fld, src), Instr::ReadRef(dst, read_src))
+            if *ref_r == *read_src =>
+        {
+            Some(Instr::ReadField(*dst, *fld, *src))
+        },
+        (Instr::ImmBorrowFieldGeneric(ref_r, fld, src), Instr::ReadRef(dst, read_src))
+            if *ref_r == *read_src =>
+        {
+            Some(Instr::ReadFieldGeneric(*dst, *fld, *src))
+        },
+        (Instr::MutBorrowField(ref_r, fld, dst_ref), Instr::WriteRef(write_ref, val))
+            if *ref_r == *write_ref =>
+        {
+            Some(Instr::WriteField(*fld, *dst_ref, *val))
+        },
+        (Instr::MutBorrowFieldGeneric(ref_r, fld, dst_ref), Instr::WriteRef(write_ref, val))
+            if *ref_r == *write_ref =>
+        {
+            Some(Instr::WriteFieldGeneric(*fld, *dst_ref, *val))
+        },
+        (Instr::ImmBorrowVariantField(ref_r, fld, src), Instr::ReadRef(dst, read_src))
+            if *ref_r == *read_src =>
+        {
+            Some(Instr::ReadVariantField(*dst, *fld, *src))
+        },
+        (Instr::ImmBorrowVariantFieldGeneric(ref_r, fld, src), Instr::ReadRef(dst, read_src))
+            if *ref_r == *read_src =>
+        {
+            Some(Instr::ReadVariantFieldGeneric(*dst, *fld, *src))
+        },
+        (Instr::MutBorrowVariantField(ref_r, fld, dst_ref), Instr::WriteRef(write_ref, val))
+            if *ref_r == *write_ref =>
+        {
+            Some(Instr::WriteVariantField(*fld, *dst_ref, *val))
+        },
+        (
+            Instr::MutBorrowVariantFieldGeneric(ref_r, fld, dst_ref),
+            Instr::WriteRef(write_ref, val),
+        ) if *ref_r == *write_ref => Some(Instr::WriteVariantFieldGeneric(*fld, *dst_ref, *val)),
+        _ => None,
+    }
+}
+
+/// Try to fuse a `Ld*` + `BinaryOp` pair into a `BinaryOpImm` instruction.
+fn try_fuse_immediate_binop(first: &Instr, second: &Instr) -> Option<Instr> {
+    let (tmp, imm) = extract_imm_value(first)?;
+    match second {
+        Instr::BinaryOp(dst, op, lhs, rhs) if *rhs == tmp => {
+            Some(Instr::BinaryOpImm(*dst, op.clone(), *lhs, imm))
+        },
+        Instr::BinaryOp(dst, op, lhs, rhs) if *lhs == tmp && is_commutative(op) => {
+            Some(Instr::BinaryOpImm(*dst, op.clone(), *rhs, imm))
+        },
+        _ => None,
     }
 }

--- a/third_party/move/mono-move/specializer/src/destack/translate.rs
+++ b/third_party/move/mono-move/specializer/src/destack/translate.rs
@@ -62,20 +62,14 @@ pub fn translate_module(
                 // this will change to use more efficient cached type representations.
                 let local_types = convert_sig_tokens(&module, &all_sig_toks, struct_name_table);
 
-                // Pass: Bytecode -> Intra-Block SSA
+                // Pass: Bytecode -> Intra-Block SSA -> Fusion
                 let converter = SsaConverter::new(local_types, struct_name_table);
-                let mut ssa = converter.convert_function(&module, &code.code)?;
+                let ssa = converter
+                    .convert_function(&module, &code.code)?
+                    .with_fusion_passes();
 
-                // Pass: Pre-allocation instruction fusion
-                // [TODO]: right now, we have each different fusion operation to be a separate pass, each
-                // computing basic block boundaries again in a linear pass. This is easier to reason about
-                // but inefficient, and will be changed in to be more efficient in the future once we
-                // land on a reasonably minimal set of fusion patterns to implement.
-                ssa.fuse_field_access_instrs();
-                ssa.fuse_immediate_binops();
-
-                // Pass: Greedy Slot Allocation
-                let alloc = super::slot_alloc::allocate_slots(&ssa)?;
+                // Pass: Greedy Slot Allocation (consumes SSA, remaps in-place)
+                let alloc = super::slot_alloc::allocate_slots(ssa)?;
 
                 Ok(FunctionIR {
                     name_idx,
@@ -84,7 +78,7 @@ pub fn translate_module(
                     num_locals,
                     num_home_slots: alloc.num_home_slots,
                     num_xfer_slots: alloc.num_xfer_slots,
-                    instrs: alloc.instrs,
+                    blocks: alloc.blocks,
                     home_slot_types: alloc.home_slot_types,
                 })
             })

--- a/third_party/move/mono-move/specializer/src/lower/context.rs
+++ b/third_party/move/mono-move/specializer/src/lower/context.rs
@@ -158,7 +158,7 @@ fn try_build_context_inner(
     let callee_base = frame_data_size + FRAME_METADATA_SIZE as u32;
     let mut call_sites = Vec::new();
 
-    for instr in &func_ir.instrs {
+    for instr in func_ir.iter_instrs() {
         let handle_idx = match instr {
             Instr::Call(_, idx, _) => *idx,
             Instr::CallGeneric(_, idx, _) => {

--- a/third_party/move/mono-move/specializer/src/lower/context.rs
+++ b/third_party/move/mono-move/specializer/src/lower/context.rs
@@ -158,7 +158,7 @@ fn try_build_context_inner(
     let callee_base = frame_data_size + FRAME_METADATA_SIZE as u32;
     let mut call_sites = Vec::new();
 
-    for instr in func_ir.iter_instrs() {
+    for instr in func_ir.instrs() {
         let handle_idx = match instr {
             Instr::Call(_, idx, _) => *idx,
             Instr::CallGeneric(_, idx, _) => {

--- a/third_party/move/mono-move/specializer/src/lower/translate.rs
+++ b/third_party/move/mono-move/specializer/src/lower/translate.rs
@@ -12,7 +12,7 @@ use move_vm_types::loaded_data::runtime_types::Type;
 pub fn lower_function(func_ir: &FunctionIR, ctx: &LoweringContext) -> Result<Vec<MicroOp>> {
     let mut state = LoweringState::new(func_ir, ctx);
     for block in &func_ir.blocks {
-        state.label_map[block.label.0 as usize] = state.ops.len() as u32;
+        state.label_map[block.label.0 as usize] = Some(state.ops.len() as u32);
         let body = &block.instrs;
         let mut i = 0;
         while i < body.len() {
@@ -31,8 +31,8 @@ pub fn lower_function(func_ir: &FunctionIR, ctx: &LoweringContext) -> Result<Vec
 struct LoweringState<'a> {
     ctx: &'a LoweringContext,
     ops: Vec<MicroOp>,
-    /// Label(i) -> micro-op index. Dense: one entry per block, all filled during lowering.
-    label_map: Vec<u32>,
+    /// Label(i) -> micro-op index. Dense: one entry per block; `None` until filled during lowering.
+    label_map: Vec<Option<u32>>,
     /// Indices into ops that need target patching
     branch_fixups: Vec<usize>,
     call_site_cursor: usize,
@@ -59,7 +59,7 @@ impl<'a> LoweringState<'a> {
         LoweringState {
             ctx,
             ops: Vec::new(),
-            label_map: vec![0; func_ir.blocks.len()],
+            label_map: vec![None; func_ir.blocks.len()],
             branch_fixups: Vec::new(),
             call_site_cursor: 0,
             home_slot_types: &func_ir.home_slot_types,
@@ -475,6 +475,7 @@ impl<'a> LoweringState<'a> {
         self.label_map
             .get(label as usize)
             .copied()
+            .flatten()
             .ok_or_else(|| anyhow::anyhow!("unresolved label L{}", label))
     }
 }

--- a/third_party/move/mono-move/specializer/src/lower/translate.rs
+++ b/third_party/move/mono-move/specializer/src/lower/translate.rs
@@ -11,14 +11,17 @@ use move_vm_types::loaded_data::runtime_types::Type;
 
 pub fn lower_function(func_ir: &FunctionIR, ctx: &LoweringContext) -> Result<Vec<MicroOp>> {
     let mut state = LoweringState::new(func_ir, ctx);
-    let instrs = &func_ir.instrs;
-    let mut i = 0;
-    while i < instrs.len() {
-        let fused = state.lower_instr(func_ir, &instrs[i], instrs.get(i + 1))?;
-        if fused {
-            i += 2;
-        } else {
-            i += 1;
+    for block in &func_ir.blocks {
+        state.label_map[block.label.0 as usize] = state.ops.len() as u32;
+        let body = &block.instrs;
+        let mut i = 0;
+        while i < body.len() {
+            let fused = state.lower_instr(func_ir, &body[i], body.get(i + 1))?;
+            if fused {
+                i += 2;
+            } else {
+                i += 1;
+            }
         }
     }
     state.fixup_branches()?;
@@ -28,8 +31,8 @@ pub fn lower_function(func_ir: &FunctionIR, ctx: &LoweringContext) -> Result<Vec
 struct LoweringState<'a> {
     ctx: &'a LoweringContext,
     ops: Vec<MicroOp>,
-    /// Label(i) -> micro-op index
-    label_map: Vec<Option<u32>>,
+    /// Label(i) -> micro-op index. Dense: one entry per block, all filled during lowering.
+    label_map: Vec<u32>,
     /// Indices into ops that need target patching
     branch_fixups: Vec<usize>,
     call_site_cursor: usize,
@@ -42,21 +45,6 @@ struct LoweringState<'a> {
 
 impl<'a> LoweringState<'a> {
     fn new(func_ir: &'a FunctionIR, ctx: &'a LoweringContext) -> Self {
-        // Find max label to size label_map
-        let max_label = func_ir
-            .instrs
-            .iter()
-            .filter_map(|instr| match instr {
-                Instr::Label(Label(l))
-                | Instr::Branch(Label(l))
-                | Instr::BrTrue(Label(l), _)
-                | Instr::BrFalse(Label(l), _) => Some(*l as usize),
-                _ => None,
-            })
-            .max()
-            .map(|m| m + 1)
-            .unwrap_or(0);
-
         // Initialize active_xfer_slots/types from first callsite's arg_write_slots
         let num_xfer_slots = ctx.num_xfer_slots as usize;
         let mut active_xfer_slots = vec![SlotInfo { offset: 0, size: 0 }; num_xfer_slots];
@@ -71,7 +59,7 @@ impl<'a> LoweringState<'a> {
         LoweringState {
             ctx,
             ops: Vec::new(),
-            label_map: vec![None; max_label],
+            label_map: vec![0; func_ir.blocks.len()],
             branch_fixups: Vec::new(),
             call_site_cursor: 0,
             home_slot_types: &func_ir.home_slot_types,
@@ -161,11 +149,6 @@ impl<'a> LoweringState<'a> {
         next: Option<&Instr>,
     ) -> Result<bool> {
         match instr {
-            // --- Labels ---
-            Instr::Label(Label(l)) => {
-                self.label_map[*l as usize] = Some(self.ops.len() as u32);
-            },
-
             // --- Loads ---
             Instr::LdU64(dst, v) => {
                 let d = self.def_slot(*dst);
@@ -492,7 +475,6 @@ impl<'a> LoweringState<'a> {
         self.label_map
             .get(label as usize)
             .copied()
-            .flatten()
             .ok_or_else(|| anyhow::anyhow!("unresolved label L{}", label))
     }
 }

--- a/third_party/move/mono-move/specializer/src/stackless_exec_ir/display.rs
+++ b/third_party/move/mono-move/specializer/src/stackless_exec_ir/display.rs
@@ -95,15 +95,14 @@ fn display_function(
 
     // Instructions
     let mut instr_num = 0;
-    for instr in &func.instrs {
-        if let Instr::Label(label) = instr {
-            writeln!(f, "  L{}:", label.0)?;
-            continue;
+    for block in &func.blocks {
+        writeln!(f, "  L{}:", block.label.0)?;
+        for instr in &block.instrs {
+            write!(f, "    {}: ", instr_num)?;
+            display_instr(f, module, instr)?;
+            writeln!(f)?;
+            instr_num += 1;
         }
-        write!(f, "    {}: ", instr_num)?;
-        display_instr(f, module, instr)?;
-        writeln!(f)?;
-        instr_num += 1;
     }
 
     writeln!(f, "}}")?;
@@ -767,7 +766,6 @@ fn display_instr(
         },
 
         // --- Control flow (no destinations) ---
-        Instr::Label(l) => write!(f, "L{}:", l.0),
         Instr::Branch(l) => write!(f, "branch L{}", l.0),
         Instr::BrTrue(l, c) => write!(f, "br_true L{}, {}", l.0, slot_name(*c)),
         Instr::BrFalse(l, c) => write!(f, "br_false L{}, {}", l.0, slot_name(*c)),

--- a/third_party/move/mono-move/specializer/src/stackless_exec_ir/mod.rs
+++ b/third_party/move/mono-move/specializer/src/stackless_exec_ir/mod.rs
@@ -227,13 +227,23 @@ pub enum Instr {
     VecSwap(SignatureIndex, Slot, Slot, Slot),
 
     // --- Control flow ---
-    Label(Label),
     Branch(Label),
     BrTrue(Label, Slot),
     BrFalse(Label, Slot),
     Ret(Vec<Slot>),
     Abort(Slot),
     AbortMsg(Slot, Slot),
+}
+
+/// A basic block of instructions.
+///
+/// Every block has a label. The last instruction is a terminator.
+/// (`Branch`, `BrTrue`, `BrFalse`, `Ret`, `Abort`, `AbortMsg`).
+pub struct BasicBlock {
+    /// Label identifying this block.
+    pub label: Label,
+    /// Instructions in this block.
+    pub instrs: Vec<Instr>,
 }
 
 /// IR for a single function.
@@ -250,11 +260,23 @@ pub struct FunctionIR {
     pub num_home_slots: u16,
     /// Maximum number of Xfer slots needed across all call sites in this function.
     pub num_xfer_slots: u16,
-    /// The instruction stream.
-    pub instrs: Vec<Instr>,
+    /// Basic blocks of the function.
+    pub blocks: Vec<BasicBlock>,
     /// Type of each Home slot (indexed by Home slot index, 0..num_home_slots-1).
     /// Xfer slots have no entry here — their types are inferred from call signatures.
     pub home_slot_types: Vec<Type>,
+}
+
+impl FunctionIR {
+    /// Iterate over all instructions across all blocks.
+    pub fn iter_instrs(&self) -> impl Iterator<Item = &Instr> {
+        self.blocks.iter().flat_map(|b| b.instrs.iter())
+    }
+
+    /// Iterate mutably over all instructions across all blocks.
+    pub fn iter_instrs_mut(&mut self) -> impl Iterator<Item = &mut Instr> {
+        self.blocks.iter_mut().flat_map(|b| b.instrs.iter_mut())
+    }
 }
 
 /// IR for a module (wraps the original CompiledModule for pool access).

--- a/third_party/move/mono-move/specializer/src/stackless_exec_ir/mod.rs
+++ b/third_party/move/mono-move/specializer/src/stackless_exec_ir/mod.rs
@@ -269,12 +269,12 @@ pub struct FunctionIR {
 
 impl FunctionIR {
     /// Iterate over all instructions across all blocks.
-    pub fn iter_instrs(&self) -> impl Iterator<Item = &Instr> {
+    pub fn instrs(&self) -> impl Iterator<Item = &Instr> {
         self.blocks.iter().flat_map(|b| b.instrs.iter())
     }
 
     /// Iterate mutably over all instructions across all blocks.
-    pub fn iter_instrs_mut(&mut self) -> impl Iterator<Item = &mut Instr> {
+    pub fn instrs_mut(&mut self) -> impl Iterator<Item = &mut Instr> {
         self.blocks.iter_mut().flat_map(|b| b.instrs.iter_mut())
     }
 }

--- a/third_party/move/mono-move/specializer/tests/test_cases/masm/arg_regs.exp
+++ b/third_party/move/mono-move/specializer/tests/test_cases/masm/arg_regs.exp
@@ -4,6 +4,7 @@ fun identity(r0): u64 {
   slots: params(1), locals(0), temps(0)
     r0: u64
   code:
+  L0:
     0: ret [r0]
 }
 
@@ -13,6 +14,7 @@ fun add_two(r0, r1): u64 {
     r1: u64
     r2: u64
   code:
+  L0:
     0: r2 := add r0, r1
     1: ret [r2]
 }
@@ -22,6 +24,7 @@ fun swap(r0, r1): u64 * u64 {
     r0: u64
     r1: u64
   code:
+  L0:
     0: ret [r1, r0]
 }
 
@@ -32,6 +35,7 @@ fun three_args(r0, r1, r2): u64 {
     r2: u64
     r3: u64
   code:
+  L0:
     0: r3 := add r0, r1
     1: r3 := add r3, r2
     2: ret [r3]
@@ -40,6 +44,7 @@ fun three_args(r0, r1, r2): u64 {
 fun simple_promotion(): u64 {
   slots: params(0), locals(0), temps(0), xfer(1)
   code:
+  L0:
     0: x0 := ld_u64 42
     1: [x0] := call identity, [x0]
     2: ret [x0]
@@ -48,6 +53,7 @@ fun simple_promotion(): u64 {
 fun multi_arg(): u64 {
   slots: params(0), locals(0), temps(0), xfer(2)
   code:
+  L0:
     0: x0 := ld_u64 1
     1: x1 := ld_u64 2
     2: [x0] := call add_two, [x0, x1]
@@ -57,6 +63,7 @@ fun multi_arg(): u64 {
 fun nested_fg(): u64 {
   slots: params(0), locals(0), temps(0), xfer(1)
   code:
+  L0:
     0: x0 := ld_u64 7
     1: [x0] := call identity, [x0]
     2: [x0] := call identity, [x0]
@@ -67,6 +74,7 @@ fun two_inner_calls(): u64 {
   slots: params(0), locals(0), temps(1), xfer(2)
     r0: u64
   code:
+  L0:
     0: x0 := ld_u64 10
     1: [r0] := call identity, [x0]
     2: x0 := ld_u64 20
@@ -79,6 +87,7 @@ fun computed_arg(r0): u64 {
   slots: params(1), locals(0), temps(0), xfer(1)
     r0: u64
   code:
+  L0:
     0: x0 := add r0, #1
     1: [x0] := call identity, [x0]
     2: ret [x0]
@@ -88,6 +97,7 @@ fun partial_promotion(r0): u64 {
   slots: params(1), locals(0), temps(0), xfer(2)
     r0: u64
   code:
+  L0:
     0: x1 := add r0, #1
     1: [x0] := call add_two, [r0, x1]
     2: ret [x0]
@@ -97,6 +107,7 @@ fun call_with_param(r0): u64 {
   slots: params(1), locals(0), temps(0), xfer(1)
     r0: u64
   code:
+  L0:
     0: [x0] := call identity, [r0]
     1: ret [x0]
 }
@@ -107,6 +118,7 @@ fun arg_live_after_call(r0): u64 {
     r1: u64
     r2: u64
   code:
+  L0:
     0: [r1] := call identity, [r0]
     1: r2 := add r0, r1
     2: ret [r2]
@@ -117,6 +129,7 @@ fun ret_used_past_next_call(): u64 {
     r0: u64
     r1: u64
   code:
+  L0:
     0: x0 := ld_u64 10
     1: [r0] := call identity, [x0]
     2: x0 := ld_u64 20
@@ -128,6 +141,7 @@ fun ret_used_past_next_call(): u64 {
 fun multi_ret(): u64 {
   slots: params(0), locals(0), temps(0), xfer(2)
   code:
+  L0:
     0: x0 := ld_u64 3
     1: x1 := ld_u64 4
     2: [x0, x1] := call swap, [x0, x1]
@@ -139,6 +153,7 @@ fun width_from_max(): u64 {
   slots: params(0), locals(0), temps(1), xfer(3)
     r0: u64
   code:
+  L0:
     0: x0 := ld_u64 1
     1: [r0] := call identity, [x0]
     2: x0 := ld_u64 10
@@ -155,6 +170,7 @@ fun call_in_loop(r0): u64 {
     r1: u64
     r2: bool
   code:
+  L3:
     0: r1 := ld_u64 0
   L2:
     1: r2 := gt r0, #0
@@ -172,6 +188,7 @@ fun mixed_at_callsite(r0): u64 {
   slots: params(1), locals(0), temps(0), xfer(3)
     r0: u64
   code:
+  L0:
     0: x0 := ld_u64 10
     1: x2 := ld_u64 30
     2: [x0] := call three_args, [x0, r0, x2]
@@ -182,6 +199,7 @@ fun mixed_intervening_call(): u64 {
   slots: params(0), locals(0), temps(1), xfer(3)
     r0: u64
   code:
+  L0:
     0: x0 := ld_u64 10
     1: [r0] := call identity, [x0]
     2: x0 := ld_u64 20
@@ -195,6 +213,7 @@ fun no_calls(): u64 {
   slots: params(0), locals(0), temps(1)
     r0: u64
   code:
+  L0:
     0: r0 := ld_u64 99
     1: ret [r0]
 }

--- a/third_party/move/mono-move/specializer/tests/test_cases/masm/arithmetic.exp
+++ b/third_party/move/mono-move/specializer/tests/test_cases/masm/arithmetic.exp
@@ -6,6 +6,7 @@ fun add_values(r0, r1): u64 {
     r1: u64
     r2: u64
   code:
+  L0:
     0: r2 := add r0, r1
     1: ret [r2]
 }
@@ -16,6 +17,7 @@ fun complex_arith(r0): u64 {
     r1: u64
     r2: u64
   code:
+  L0:
     0: r1 := mul r0, #2
     1: r2 := add r1, #1
     2: ret [r2]

--- a/third_party/move/mono-move/specializer/tests/test_cases/masm/basic_load.exp
+++ b/third_party/move/mono-move/specializer/tests/test_cases/masm/basic_load.exp
@@ -4,6 +4,7 @@ fun load_values(): u64 {
   slots: params(0), locals(0), temps(1)
     r0: u64
   code:
+  L0:
     0: r0 := ld_u64 42
     1: ret [r0]
 }
@@ -12,6 +13,7 @@ fun load_and_store() {
   slots: params(0), locals(1), temps(0)
     r0: u64
   code:
+  L0:
     0: r0 := ld_u64 10
     1: ret []
 }

--- a/third_party/move/mono-move/specializer/tests/test_cases/masm/borrow_soundness.exp
+++ b/third_party/move/mono-move/specializer/tests/test_cases/masm/borrow_soundness.exp
@@ -7,6 +7,7 @@ fun borrow_loc_no_source_subst(r0): u64 {
     r2: &u64
     r3: u64
   code:
+  L0:
     0: r1 := copy r0
     1: r2 := imm_borrow_loc r1
     2: r3 := read_ref r2
@@ -20,6 +21,7 @@ fun imm_borrow_value_prop(r0): u64 {
     r2: &u64
     r3: u64
   code:
+  L0:
     0: r1 := copy r0
     1: r2 := imm_borrow_loc r1
     2: r3 := read_ref r2
@@ -34,6 +36,7 @@ fun mut_borrow_kills_subst(r0): u64 {
     r2: u64
     r3: &mut u64
   code:
+  L0:
     0: r1 := copy r0
     1: r2 := ld_u64 42
     2: r3 := mut_borrow_loc r1
@@ -48,6 +51,7 @@ fun mut_borrow_kills_reverse(r0): u64 {
     r2: u64
     r3: &mut u64
   code:
+  L0:
     0: r1 := copy r0
     1: r2 := ld_u64 99
     2: r3 := mut_borrow_loc r0

--- a/third_party/move/mono-move/specializer/tests/test_cases/masm/calls.exp
+++ b/third_party/move/mono-move/specializer/tests/test_cases/masm/calls.exp
@@ -4,12 +4,14 @@ fun identity(r0): u64 {
   slots: params(1), locals(0), temps(0)
     r0: u64
   code:
+  L0:
     0: ret [r0]
 }
 
 fun caller(): u64 {
   slots: params(0), locals(0), temps(0), xfer(1)
   code:
+  L0:
     0: x0 := ld_u64 10
     1: [x0] := call identity, [x0]
     2: ret [x0]

--- a/third_party/move/mono-move/specializer/tests/test_cases/masm/control_flow.exp
+++ b/third_party/move/mono-move/specializer/tests/test_cases/masm/control_flow.exp
@@ -20,6 +20,7 @@ fun conditional(r0): u64 {
     r0: bool
     r1: u64
   code:
+  L2:
     0: br_true L0, r0
   L1:
     1: r1 := ld_u64 0

--- a/third_party/move/mono-move/specializer/tests/test_cases/masm/field_fusion.exp
+++ b/third_party/move/mono-move/specializer/tests/test_cases/masm/field_fusion.exp
@@ -4,6 +4,7 @@ fun identity(r0): u64 {
   slots: params(1), locals(0), temps(0)
     r0: u64
   code:
+  L0:
     0: ret [r0]
 }
 
@@ -14,6 +15,7 @@ fun add_two_fields(r0): u64 {
     r2: u64
     r3: u64
   code:
+  L0:
     0: r1 := imm_borrow_loc r0
     1: r2 := read_field Pair::_1, r1
     2: r1 := imm_borrow_loc r0
@@ -27,6 +29,7 @@ fun field_to_call(r0): u64 {
     r0: Pair
     r1: &Pair
   code:
+  L0:
     0: r1 := imm_borrow_loc r0
     1: x0 := read_field Pair::_1, r1
     2: [x0] := call identity, [x0]
@@ -41,6 +44,7 @@ fun two_fields_to_call(r0, r1): u64 {
     r3: u64
     r4: u64
   code:
+  L0:
     0: r2 := imm_borrow_loc r0
     1: r3 := read_field Pair::_1, r2
     2: r2 := imm_borrow_loc r1
@@ -56,6 +60,7 @@ fun field_plus_constant(r0): u64 {
     r1: &Pair
     r2: u64
   code:
+  L0:
     0: r1 := imm_borrow_loc r0
     1: r2 := read_field Pair::_1, r1
     2: r2 := add r2, #42
@@ -67,6 +72,7 @@ fun increment_field(r0) {
     r0: &mut Pair
     r1: u64
   code:
+  L0:
     0: r1 := read_field Pair::_1, r0
     1: r1 := add r1, #1
     2: write_field Pair::_1, r0, r1

--- a/third_party/move/mono-move/specializer/tests/test_cases/masm/locals_soundness.exp
+++ b/third_party/move/mono-move/specializer/tests/test_cases/masm/locals_soundness.exp
@@ -7,6 +7,7 @@ fun local_across_blocks(r0, r1): u64 {
     r2: u64
     r3: u64
   code:
+  L2:
     0: r2 := copy r1
     1: br_true L0, r0
   L1:
@@ -23,6 +24,7 @@ fun borrow_written_local(r0): u64 {
     r2: &u64
     r3: u64
   code:
+  L0:
     0: r1 := copy r0
     1: r2 := imm_borrow_loc r1
     2: r3 := read_ref r2

--- a/third_party/move/mono-move/specializer/tests/test_cases/masm/references.exp
+++ b/third_party/move/mono-move/specializer/tests/test_cases/masm/references.exp
@@ -6,6 +6,7 @@ fun read_field_val(r0): u8 {
     r1: &S
     r2: u8
   code:
+  L0:
     0: r1 := imm_borrow_loc r0
     1: r2 := read_field S::_2, r1
     2: ret [r2]
@@ -16,6 +17,7 @@ fun read_and_add(r0): u64 {
     r0: &u64
     r1: u64
   code:
+  L0:
     0: r1 := read_ref r0
     1: r1 := add r1, #1
     2: ret [r1]
@@ -29,6 +31,7 @@ fun read_field_ref_twice(r0): u64 {
     r3: u64
     r4: u64
   code:
+  L0:
     0: r2 := imm_borrow_loc r0
     1: r1 := imm_borrow_field S::_1, r2
     2: r3 := read_ref r1

--- a/third_party/move/mono-move/specializer/tests/test_cases/masm/struct_ops.exp
+++ b/third_party/move/mono-move/specializer/tests/test_cases/masm/struct_ops.exp
@@ -6,6 +6,7 @@ fun pack_and_unpack(): u64 {
     r1: u64
     r2: u8
   code:
+  L0:
     0: r1 := ld_u64 3
     1: r2 := ld_u8 2
     2: r0 := pack S, [r1, r2]

--- a/third_party/move/mono-move/specializer/tests/test_cases/masm/v2_leftovers.exp
+++ b/third_party/move/mono-move/specializer/tests/test_cases/masm/v2_leftovers.exp
@@ -4,6 +4,7 @@ fun identity(r0): u64 {
   slots: params(1), locals(0), temps(0)
     r0: u64
   code:
+  L0:
     0: ret [r0]
 }
 
@@ -13,6 +14,7 @@ fun add_two(r0, r1): u64 {
     r1: u64
     r2: u64
   code:
+  L0:
     0: r2 := add r0, r1
     1: ret [r2]
 }
@@ -21,6 +23,7 @@ fun copy_to_call(r0): u64 {
   slots: params(1), locals(0), temps(0), xfer(1)
     r0: u64
   code:
+  L0:
     0: [x0] := call identity, [r0]
     1: ret [x0]
 }
@@ -29,6 +32,7 @@ fun move_to_call(r0): u64 {
   slots: params(1), locals(0), temps(0), xfer(1)
     r0: u64
   code:
+  L0:
     0: [x0] := call identity, [r0]
     1: ret [x0]
 }
@@ -38,6 +42,7 @@ fun multi_use_local_alias(r0): u64 {
     r0: u64
     r1: u64
   code:
+  L0:
     0: r1 := add r0, #1
     1: r1 := add r1, r0
     2: ret [r1]
@@ -48,6 +53,7 @@ fun copy_call_then_use(r0): u64 {
     r0: u64
     r1: u64
   code:
+  L0:
     0: [x0] := call identity, [r0]
     1: r1 := add x0, r0
     2: ret [r1]
@@ -58,6 +64,7 @@ fun two_copies_to_call(r0, r1): u64 {
     r0: u64
     r1: u64
   code:
+  L0:
     0: [x0] := call add_two, [r0, r1]
     1: ret [x0]
 }

--- a/third_party/move/mono-move/specializer/tests/test_cases/masm/vid_type_reset.exp
+++ b/third_party/move/mono-move/specializer/tests/test_cases/masm/vid_type_reset.exp
@@ -6,6 +6,7 @@ fun vid_type_mismatch(r0): u64 {
     r1: bool
     r2: u64
   code:
+  L2:
     0: r1 := gt r0, #10
     1: br_false L0, r1
   L1:

--- a/third_party/move/mono-move/specializer/tests/test_cases/move/basic.exp
+++ b/third_party/move/mono-move/specializer/tests/test_cases/move/basic.exp
@@ -48,6 +48,7 @@ fun add(r0, r1): u64 {
     r1: u64
     r2: u64
   code:
+  L0:
     0: r2 := add r0, r1
     1: ret [r2]
 }
@@ -57,6 +58,7 @@ fun get_x(r0): u64 {
     r0: &Point
     r1: u64
   code:
+  L0:
     0: r1 := read_field Point::x, r0
     1: ret [r1]
 }
@@ -67,6 +69,7 @@ fun make_point(r0, r1): Point {
     r1: u64
     r2: Point
   code:
+  L0:
     0: r2 := pack Point, [r0, r1]
     1: ret [r2]
 }
@@ -77,6 +80,7 @@ fun max(r0, r1): u64 {
     r1: u64
     r2: bool
   code:
+  L2:
     0: r2 := gt r0, r1
     1: br_false L0, r2
   L1:

--- a/third_party/move/mono-move/specializer/tests/test_cases/move/fibonacci.exp
+++ b/third_party/move/mono-move/specializer/tests/test_cases/move/fibonacci.exp
@@ -33,6 +33,7 @@ fun fib(r0): u64 {
     r1: bool
     r2: u64
   code:
+  L2:
     0: r1 := le r0, #1
     1: br_false L0, r1
   L1:

--- a/third_party/move/shared-dsa/src/unordered_map.rs
+++ b/third_party/move/shared-dsa/src/unordered_map.rs
@@ -114,6 +114,14 @@ impl<K: Hash + Eq, V> UnorderedMap<K, V> {
         self.inner.entry(key)
     }
 
+    /// Retains only the key-value pairs for which the predicate returns `true`.
+    /// The predicate is applied in an arbitrary order — callers must ensure
+    /// that `f` does not depend on the order in which key-value pairs are visited.
+    #[inline]
+    pub fn retain(&mut self, f: impl FnMut(&K, &mut V) -> bool) {
+        self.inner.retain(f);
+    }
+
     /// Reserves space for at least `additional` more elements. Pass the number
     /// of elements you expect to add, not an inflated value — the load factor
     /// is handled internally.

--- a/third_party/move/shared-dsa/src/unordered_set.rs
+++ b/third_party/move/shared-dsa/src/unordered_set.rs
@@ -104,6 +104,14 @@ impl<K: Hash + Eq> UnorderedSet<K> {
         self.inner.take(value)
     }
 
+    /// Retains only the elements for which the predicate returns `true`.
+    /// The predicate is applied in an arbitrary order — callers must ensure
+    /// that `f` does not depend on the order in which elements are visited.
+    #[inline]
+    pub fn retain(&mut self, f: impl FnMut(&K) -> bool) {
+        self.inner.retain(f);
+    }
+
     /// Reserves space for at least `additional` more elements. Pass the number
     /// of elements you expect to add, not an inflated value — the load factor
     /// is handled internally.


### PR DESCRIPTION
## Description

In this PR, we make several updates to the specializer:
- first-class `BasicBlock` representation
- in-place operations where possible
- rewritten abstraction for visiting stackless exec IR
- using faster data structures where possible
and various simplifications as a result.

## How Has This Been Tested?

Existing tests.

## Type of Change
- [x] Performance improvement
- [x] Refactoring

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the specializer’s core IR representation and multiple pipeline stages (SSA conversion, slot allocation, optimizations, lowering), so regressions would affect codegen correctness/perf despite being mostly mechanical and covered by existing tests.
> 
> **Overview**
> **Refactors stackless exec IR to be block-structured.** `Instr::Label` is removed and functions now carry explicit `BasicBlock { label, instrs }` lists, with helper iterators (`instrs()`/`instrs_mut()`) to traverse across blocks.
> 
> **Updates the entire destack/lowering pipeline to operate on blocks and reduce allocations.** SSA conversion now emits labeled blocks directly, fusion runs in-place per block, slot allocation consumes SSA and remaps instructions in-place, and post-allocation passes (copy propagation/DCE/renumbering) run per-block using O(1) remaps.
> 
> **Rewrites instruction slot utilities for performance and maintainability.** Introduces const-generic slot visitors/rewriters (`for_each_def/use/slot`, `remap_*`) backed by `SmallVec`, switches several maps/sets to `shared-dsa` unordered structures (adding `retain` to `UnorderedMap/Set`), and updates lowering/display/tests to match the new block format.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c97f02f5a5445d9640ddb5304416af0f0df0191c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->