### PR TITLE
Improve replay-verify scheduler observability and resilience

### DIFF
--- a/testsuite/replay-verify/main.py
+++ b/testsuite/replay-verify/main.py
@@ -649,9 +649,9 @@ class ReplayScheduler:
                         and self.current_workers[i].is_completed()
                     ):
                         self.process_completed_pod(self.current_workers[i], i)
-                    # Dispatch next task into this slot
+                    # Dispatch next task into this slot (if any remain)
                     if len(self.tasks) == 0:
-                        break
+                        continue
                     task = self.tasks.pop(0)
                     worker_pod = WorkerPod(
                         i,
@@ -682,15 +682,6 @@ class ReplayScheduler:
             if len(self.tasks) == 0 and all_dispatched_time is None:
                 all_dispatched_time = time.time()
                 logger.info("All tasks have been dispatched, waiting for remaining workers")
-
-            # --- Drain completed workers (waiting phase) ---
-            # During dispatching, completed pods are processed when their slot is
-            # reused above. But once there are no more tasks, slots won't be
-            # revisited by the dispatch loop, so we sweep explicitly.
-            if len(self.tasks) == 0:
-                for i in range(len(self.current_workers)):
-                    if self.current_workers[i] is not None and self.current_workers[i].is_completed():
-                        self.process_completed_pod(self.current_workers[i], i)
 
             # --- Periodic status summary ---
             # Every 10 min while dispatching, every 60s while waiting.

--- a/testsuite/replay-verify/main.py
+++ b/testsuite/replay-verify/main.py
@@ -587,14 +587,36 @@ class ReplayScheduler:
                 statuses.append(False)
         return statuses
 
-    def schedule(self, from_scratch: bool = False) -> None:
+    def _has_active_workers(self) -> bool:
+        return any(w is not None for w in self.current_workers)
+
+    def schedule(self, from_scratch: bool = False) -> tuple[list[str], list[str]]:
         if from_scratch:
             self.kill_all_pods()
         self.create_tasks()
 
         schedule_start = time.time()
         last_summary_time = schedule_start
-        while len(self.tasks) > 0:
+        # Track when all tasks have been dispatched so we can apply a
+        # timeout for the remaining workers to finish.
+        all_dispatched_time = None
+        collect_timeout = 20 * 60  # 20 minutes
+
+        while len(self.tasks) > 0 or self._has_active_workers():
+            # Check timeout after all tasks have been dispatched
+            if len(self.tasks) == 0 and all_dispatched_time is not None:
+                elapsed = time.time() - all_dispatched_time
+                if elapsed > collect_timeout:
+                    logger.error(
+                        f"Timed out waiting for remaining workers after {int(elapsed)}s"
+                    )
+                    self._log_worker_summary(schedule_start, log_level=logging.ERROR)
+                    for idx, w in enumerate(self.current_workers):
+                        if w is not None:
+                            self.failed_workpod_logs.append(w.get_humio_log_link())
+                            self.current_workers[idx] = None
+                    break
+
             pvc_bound_status = self.get_pvc_bound_status()
             for i in range(len(self.current_workers)):
                 if (
@@ -633,12 +655,28 @@ class ReplayScheduler:
                     except Exception as e:
                         logger.error(f"Failed to get pod status: {e}")
                         self.reschedule_pod(self.current_workers[i], i)
+
+            # Track when we transition from dispatching to waiting
+            if len(self.tasks) == 0 and all_dispatched_time is None:
+                all_dispatched_time = time.time()
+                logger.info("All tasks have been dispatched, waiting for remaining workers")
+
+            # Process completed workers even when no tasks remain
+            if len(self.tasks) == 0:
+                for i in range(len(self.current_workers)):
+                    if self.current_workers[i] is not None and self.current_workers[i].is_completed():
+                        self.process_completed_pod(self.current_workers[i], i)
+
             now = time.time()
-            if now - last_summary_time >= 600:  # Every 10 minutes
+            # Log more frequently once we're just waiting for remaining workers
+            summary_interval = 60 if len(self.tasks) == 0 else 600
+            if now - last_summary_time >= summary_interval:
                 self._log_worker_summary(schedule_start, tasks_remaining=len(self.tasks))
                 last_summary_time = now
             time.sleep(QUERY_DELAY)
-        logger.info("All tasks have been scheduled")
+
+        logger.info("All tasks completed")
+        return (self.failed_workpod_logs, self.txn_mismatch_logs)
 
     def reschedule_pod(self, worker_pod: WorkerPod, worker_idx: int):
         # clean up the existing pod
@@ -696,44 +734,6 @@ class ReplayScheduler:
             namespace=self.namespace,
             label_selector=f"run={self.get_label()}",
         )
-
-    def collect_all_failed_logs(self) -> tuple[list[str], list[str]]:
-        remaining = sum(1 for w in self.current_workers if w is not None)
-        logger.info(f"Collecting logs from {remaining} remaining pods")
-
-        collect_timeout = 20 * 60  # 20 minutes
-        collect_start = time.time()
-        last_summary_time = collect_start
-
-        all_completed = False
-        while not all_completed:
-            elapsed = time.time() - collect_start
-            if elapsed > collect_timeout:
-                logger.error(
-                    f"collect_all_failed_logs timed out after {int(elapsed)}s"
-                )
-                self._log_worker_summary(collect_start, log_level=logging.ERROR)
-                for idx, w in enumerate(self.current_workers):
-                    if w is not None:
-                        self.failed_workpod_logs.append(w.get_humio_log_link())
-                        self.current_workers[idx] = None
-                break
-
-            all_completed = True
-            for idx, worker in enumerate(self.current_workers):
-                if worker is not None:
-                    if not worker.is_completed():
-                        all_completed = False
-                    else:
-                        self.process_completed_pod(worker, idx)
-
-            now = time.time()
-            if now - last_summary_time >= 60:  # Every 60 seconds
-                self._log_worker_summary(collect_start)
-                last_summary_time = now
-            time.sleep(QUERY_DELAY)
-
-        return (self.failed_workpod_logs, self.txn_mismatch_logs)
 
     def print_stats(self):
         for key, value in self.task_stats.items():
@@ -963,8 +963,7 @@ if __name__ == "__main__":
         scheduler.create_all_required_pvcs()
         try:
             start_time = time.time()
-            scheduler.schedule(from_scratch=True)
-            (failed_logs, txn_mismatch_logs) = scheduler.collect_all_failed_logs()
+            (failed_logs, txn_mismatch_logs) = scheduler.schedule(from_scratch=True)
             scheduler.print_stats()
             print_logs(failed_logs, txn_mismatch_logs)
             if txn_mismatch_logs:

--- a/testsuite/replay-verify/main.py
+++ b/testsuite/replay-verify/main.py
@@ -631,27 +631,21 @@ class ReplayScheduler:
                             self.current_workers[idx] = None
                     break
 
-            # --- Scan worker slots and dispatch tasks ---
-            # For each slot: if the slot is free and there's a task, launch a pod.
-            # The PVC bound check ensures we don't create pods on unbound PVCs
-            # (except for the initial pod per PVC which triggers binding).
+            # --- Scan worker slots ---
             pvc_bound_status = self.get_pvc_bound_status()
             for i in range(len(self.current_workers)):
-                if (
-                    self.current_workers[i] is None
-                    or self.current_workers[i].is_completed()
-                ) and (
-                    pvc_bound_status[i % len(self.pvcs)] or i < len(self.pvcs)
-                ):
-                    # Slot is available — process the completed pod first if any
-                    if (
-                        self.current_workers[i] is not None
-                        and self.current_workers[i].is_completed()
-                    ):
-                        self.process_completed_pod(self.current_workers[i], i)
-                    # Dispatch next task into this slot (if any remain)
-                    if len(self.tasks) == 0:
-                        continue
+                worker = self.current_workers[i]
+
+                # Step 1: Process completed pods to free up the slot
+                if worker is not None and worker.is_completed():
+                    self.process_completed_pod(worker, i)
+                    worker = self.current_workers[i]  # slot may now be None
+
+                # Step 2: If slot is free and there are tasks, dispatch one.
+                # PVC must be bound first, unless this is the initial pod
+                # that triggers binding (i < number of PVCs).
+                pvc_ready = pvc_bound_status[i % len(self.pvcs)] or i < len(self.pvcs)
+                if worker is None and pvc_ready and len(self.tasks) > 0:
                     task = self.tasks.pop(0)
                     worker_pod = WorkerPod(
                         i,
@@ -668,9 +662,9 @@ class ReplayScheduler:
                     worker_pod.start()
                     self.task_stats[worker_pod.name] = TaskStats(worker_pod.name)
 
-                # Probe pod phase to detect failures that need rescheduling
-                # (e.g. pod evictions). If the API call itself fails, reschedule
-                # the pod to be safe.
+                # Step 3: Probe active pods to detect failures that need
+                # rescheduling (e.g. evictions). If the API call itself
+                # fails, reschedule the pod to be safe.
                 if self.current_workers[i] is not None:
                     try:
                         self.current_workers[i].get_phase()

--- a/testsuite/replay-verify/main.py
+++ b/testsuite/replay-verify/main.py
@@ -29,8 +29,9 @@ from archive_disk_utils import (
 
 SHARDING_ENABLED = True
 MAX_RETRIES = 5
-RETRY_DELAY = 20  # seconds
+RETRY_DELAY = 5  # seconds
 QUERY_DELAY = 5  # seconds
+POD_STATUS_CACHE_TTL = 3  # seconds — reuse cached pod status for this long
 
 # Timeout chain — each layer is a backstop for the one before:
 #   scheduler (20m) → binary (30m) → K8s TTL controller (40m)
@@ -56,6 +57,47 @@ class Network(Enum):
             return cls[name.upper()]
         except KeyError:
             raise ValueError(f"{name} is not a valid Network name")
+
+
+class LocalPhase(Enum):
+    """Local state for a WorkerPod.
+
+    State transitions happen only inside WorkerPod.update_status. A pod
+    starts in UNKNOWN and moves through non-terminal states (PENDING,
+    RUNNING) mirroring the K8s phase as seen from successful status
+    fetches. The three terminal states — SUCCEEDED, FAILED, LOST — never
+    transition out: once terminal, the pod stays there.
+
+    Non-terminal states can only move forward (UNKNOWN → PENDING →
+    RUNNING) or directly to any terminal state. The specific terminal
+    state depends on how the pod ended: SUCCEEDED (K8s phase Succeeded),
+    FAILED (K8s phase Failed, including evictions), or LOST (status fetch
+    raised an exception after retries — the pod is presumed gone or the
+    API is unreachable).
+
+    State semantics:
+      UNKNOWN   — no status has been fetched yet
+      PENDING   — K8s phase Pending (scheduling, pulling image, attaching volumes)
+      RUNNING   — K8s phase Running (container is executing)
+      SUCCEEDED — K8s phase Succeeded (container exited 0) — terminal
+      FAILED    — K8s phase Failed (container exited non-zero, or evicted) — terminal
+      LOST      — status fetch raised after retries; pod presumed gone — terminal
+
+    Scheduler treatment of terminal states:
+      SUCCEEDED — task marked succeeded, slot freed
+      FAILED    — if evicted → reschedule task (up to MAX_RETRIES),
+                  else → treat as permanent failure
+      LOST      — reschedule task (up to MAX_RETRIES), else → permanent failure
+    """
+    UNKNOWN = "Unknown"
+    PENDING = "Pending"
+    RUNNING = "Running"
+    SUCCEEDED = "Succeeded"
+    FAILED = "Failed"
+    LOST = "Lost"
+
+    def __str__(self):
+        return self.value
 
 
 logging.basicConfig(level=logging.INFO)
@@ -131,6 +173,8 @@ class WorkerPod:
         self.start_version = start_version
         self.end_version = end_version
         self.status = None
+        self.status_fetched_at = 0.0
+        self.local_phase = LocalPhase.UNKNOWN
         self.log = None
         self.namespace = namespace
         self.network = network
@@ -141,44 +185,71 @@ class WorkerPod:
         self.config = replay_config
 
     def update_status(self) -> None:
-        if self.status is not None and self.status.status.phase in [
-            "Succeeded",
-            "Failed",
-        ]:
+        """Refresh self.local_phase from the K8s API (with caching).
+
+        This is the ONLY method that mutates self.local_phase and self.status.
+        All other getters (is_completed, get_phase, etc.) call this then read
+        the state — they never fetch or transition on their own.
+
+        Caching rules:
+          - Terminal phases (SUCCEEDED/FAILED/LOST) are cached forever.
+          - Non-terminal phases are cached for POD_STATUS_CACHE_TTL seconds.
+          - Any exception during fetch transitions the pod to LOST.
+        """
+        # Terminal phases never change — no need to refetch
+        if self.local_phase in (LocalPhase.SUCCEEDED, LocalPhase.FAILED, LocalPhase.LOST):
             return
-        self.status = self.get_pod_status()
+        # Non-terminal phases — reuse the cached status if it's still fresh
+        if (
+            self.status is not None
+            and time.time() - self.status_fetched_at < POD_STATUS_CACHE_TTL
+        ):
+            return
+        try:
+            self.status = self._get_pod_status_api_call()
+            self.status_fetched_at = time.time()
+            phase_str = self.status.status.phase
+            try:
+                self.local_phase = LocalPhase(phase_str)
+            except ValueError:
+                self.local_phase = LocalPhase.UNKNOWN
+        except Exception as e:
+            # _get_pod_status_api_call already retries 5x internally; if we still get
+            # an exception, consider the pod permanently LOST. Clear the
+            # cached status — the last-known state is no longer trustworthy.
+            logger.error(f"Pod {self.name} marked LOST after status fetch failed: {e}")
+            self.local_phase = LocalPhase.LOST
+            self.status = None
 
     def is_completed(self) -> bool:
-        try:
-            self.update_status()
-            if self.status and self.status.status.phase in ["Succeeded", "Failed"]:
-                return True
-        except Exception as e:
-            logger.error(f"Failed to get pod status: {e}")
-        return False
+        self.update_status()
+        return self.local_phase in (
+            LocalPhase.SUCCEEDED,
+            LocalPhase.FAILED,
+            LocalPhase.LOST,
+        )
 
     def is_failed(self) -> bool:
         self.update_status()
-        if self.status and self.status.status.phase == "Failed":
-            return True
-        return False
+        return self.local_phase in (LocalPhase.FAILED, LocalPhase.LOST)
 
     def should_reschedule(self) -> bool:
-        if self.get_failure_reason() == "Evicted":
+        self.update_status()
+        if self.local_phase == LocalPhase.LOST:
             return True
-        return False
+        return self.get_failure_reason() == "Evicted"
 
     def get_failure_reason(self) -> str | None:
         self.update_status()
-        if self.status and self.status.status.phase == "Failed":
+        if self.local_phase == LocalPhase.LOST:
+            return "Lost"
+        if self.local_phase == LocalPhase.FAILED and self.status:
             return self.status.status.reason
         return None
 
-    def get_phase(self) -> str | None:
+    def get_phase(self) -> LocalPhase:
         self.update_status()
-        if self.status:
-            return self.status.status.phase
-        return None
+        return self.local_phase
 
     def get_container_status(self) -> list[client.V1ContainerStatus] | None:
         self.update_status()
@@ -188,6 +259,9 @@ class WorkerPod:
 
     def get_container_status_summary(self) -> str:
         """Return a one-line summary of the first container's state."""
+        self.update_status()
+        if self.local_phase == LocalPhase.LOST:
+            return "pod-lost"
         container_statuses = self.get_container_status()
         if not container_statuses:
             return "no-container-status"
@@ -206,14 +280,15 @@ class WorkerPod:
         return time.time() - self.start_time
 
     def has_txn_mismatch(self) -> bool:
-        if self.status:
-            container_statuses = self.status.status.container_statuses
-            if (
-                container_statuses
-                and container_statuses[0].state
-                and container_statuses[0].state.terminated
-            ):
-                return container_statuses[0].state.terminated.exit_code == 2
+        if self.local_phase == LocalPhase.LOST or not self.status:
+            return False
+        container_statuses = self.status.status.container_statuses
+        if (
+            container_statuses
+            and container_statuses[0].state
+            and container_statuses[0].state.terminated
+        ):
+            return container_statuses[0].state.terminated.exit_code == 2
         return False
 
     def get_target_db_dir(self) -> str:
@@ -288,6 +363,24 @@ class WorkerPod:
                 )
                 time.sleep(RETRY_DELAY)
 
+    def delete_pod(self) -> None:
+        """Delete the pod. Best-effort — never throws.
+
+        Transitions to LOST only if not already terminal (preserves
+        SUCCEEDED/FAILED in case this is called after the pod finished).
+        """
+        if self.local_phase not in (
+            LocalPhase.SUCCEEDED,
+            LocalPhase.FAILED,
+            LocalPhase.LOST,
+        ):
+            self.local_phase = LocalPhase.LOST
+            self.status = None
+        try:
+            self._delete_pod_api_call()
+        except Exception as e:
+            logger.warning(f"Best-effort delete of pod {self.name} failed: {e}")
+
     @retry(
         stop=stop_after_attempt(MAX_RETRIES),
         wait=wait_fixed(RETRY_DELAY),
@@ -296,28 +389,20 @@ class WorkerPod:
             f"Retry {retry_state.attempt_number}/{MAX_RETRIES} failed: {retry_state.outcome.exception()}"
         ),
     )
-    def delete_pod(self):
+    def _delete_pod_api_call(self):
         try:
-            response = self.client.delete_namespaced_pod(
+            return self.client.delete_namespaced_pod(
                 name=self.name,
                 namespace=self.namespace,
                 body=client.V1DeleteOptions(
                     propagation_policy="Foreground", grace_period_seconds=0
                 ),
             )
-            return response
         except ApiException as e:
             if e.status == 404:  # Pod not found
                 logger.info(f"Pod {self.name} already deleted or doesn't exist")
                 return None  # Consider this a success
             raise  # Re-raise other API exceptions for retry
-
-    def get_pod_exit_code(self):
-        # Check the status of the pod containers
-        for container_status in self.status.status.container_statuses:
-            if container_status.state.terminated:
-                return container_status.state.terminated.exit_code
-        return None
 
     @retry(
         stop=stop_after_attempt(MAX_RETRIES),
@@ -327,7 +412,7 @@ class WorkerPod:
             f"Retry {retry_state.attempt_number}/{MAX_RETRIES} failed: {retry_state.outcome.exception()}"
         ),
     )
-    def get_pod_status(self):
+    def _get_pod_status_api_call(self):
         pod_status = self.client.read_namespaced_pod_status(
             name=self.name, namespace=self.namespace
         )
@@ -343,13 +428,12 @@ class TaskStats:
         self.start_time: float = time.time()
         self.end_time: float | None = None
         self.retry_count: int = 0
-        self.durations: list[float] = []
         self.succeeded: bool = False
 
     def set_end_time(self) -> None:
-        if self.end_time is None:
-            self.end_time = time.time()
-            self.durations.append(self.end_time - self.start_time)
+        # Unconditional update — on retries, the final call wins so the
+        # recorded end_time reflects when the task actually finished.
+        self.end_time = time.time()
 
     def increment_retry_count(self) -> None:
         self.retry_count += 1
@@ -357,8 +441,29 @@ class TaskStats:
     def set_succeeded(self):
         self.succeeded = True
 
+    @property
+    def duration_secs(self) -> float | None:
+        if self.end_time is None:
+            return None
+        return self.end_time - self.start_time
+
+    def _fmt_time(self, t: float | None) -> str:
+        if t is None:
+            return "?"
+        return datetime.datetime.fromtimestamp(t, datetime.timezone.utc).strftime(
+            "%Y-%m-%d %H:%M:%S UTC"
+        )
+
     def __str__(self) -> str:
-        return f"Succeeded: {self.succeeded}, Start time: {self.start_time}, End time: {self.end_time}, Duration: {self.durations}, Retry count: {self.retry_count}"
+        duration = self.duration_secs
+        duration_str = f"{duration:.1f}s" if duration is not None else "?"
+        return (
+            f"Succeeded: {self.succeeded}, "
+            f"Start: {self._fmt_time(self.start_time)}, "
+            f"End: {self._fmt_time(self.end_time)}, "
+            f"Duration: {duration_str}, "
+            f"Retry count: {self.retry_count}"
+        )
 
 
 class ReplayScheduler:
@@ -774,15 +879,17 @@ class ReplayScheduler:
             if worker is None:
                 empty_count += 1
                 continue
-            phase = worker.get_phase() or "Unknown"
+            phase = worker.get_phase()
             phase_counts[phase] += 1
             detail = ""
-            if phase not in ("Succeeded", "Failed", "Running"):
+            if phase not in (LocalPhase.SUCCEEDED, LocalPhase.FAILED, LocalPhase.RUNNING):
                 detail = f", container={worker.get_container_status_summary()}"
             log(
                 f"  Worker {idx}: {worker.name}, phase={phase}, age={int(worker.get_age_secs())}s{detail}"
             )
-        summary = ", ".join(f"{phase}={count}" for phase, count in sorted(phase_counts.items()))
+        summary = ", ".join(
+            f"{phase}={count}" for phase, count in sorted(phase_counts.items(), key=lambda x: x[0].value)
+        )
         log(f"  Summary: {summary}, empty={empty_count}")
         log("=== End worker status ==="  )
         log("")

--- a/testsuite/replay-verify/main.py
+++ b/testsuite/replay-verify/main.py
@@ -183,6 +183,25 @@ class WorkerPod:
             return self.status.status.container_statuses
         return None
 
+    def get_container_status_summary(self) -> str:
+        """Return a one-line summary of the first container's state."""
+        container_statuses = self.get_container_status()
+        if not container_statuses:
+            return "no-container-status"
+        cs = container_statuses[0]
+        if cs.state:
+            if cs.state.waiting:
+                return f"Waiting({cs.state.waiting.reason}: {cs.state.waiting.message})"
+            if cs.state.running:
+                return f"Running(since {cs.state.running.started_at})"
+            if cs.state.terminated:
+                return f"Terminated(reason={cs.state.terminated.reason}, exit={cs.state.terminated.exit_code})"
+        return "unknown-state"
+
+    def get_age_secs(self) -> float:
+        """Return seconds since this WorkerPod was created."""
+        return time.time() - self.start_time
+
     def has_txn_mismatch(self) -> bool:
         if self.status:
             container_statuses = self.status.status.container_statuses
@@ -258,7 +277,7 @@ class WorkerPod:
                 response = self.client.create_namespaced_pod(
                     namespace=self.namespace, body=pod_manifest
                 )
-                logger.info(f"Created pod {self.name}")
+                logger.info(f"Created pod {self.name} (worker={self.worker_id}, pvc={self.get_claim_name()})")
                 return
             except ApiException as e:
                 logger.warning(
@@ -573,6 +592,8 @@ class ReplayScheduler:
             self.kill_all_pods()
         self.create_tasks()
 
+        schedule_start = time.time()
+        last_summary_time = schedule_start
         while len(self.tasks) > 0:
             pvc_bound_status = self.get_pvc_bound_status()
             for i in range(len(self.current_workers)):
@@ -608,13 +629,14 @@ class ReplayScheduler:
 
                 if self.current_workers[i] is not None:
                     try:
-                        phase = self.current_workers[i].get_phase()
-                        # logger.info(
-                        #     f"Checking worker {i}: {self.current_workers[i].name}: {phase}"
-                        # )
+                        self.current_workers[i].get_phase()
                     except Exception as e:
                         logger.error(f"Failed to get pod status: {e}")
                         self.reschedule_pod(self.current_workers[i], i)
+            now = time.time()
+            if now - last_summary_time >= 600:  # Every 10 minutes
+                self._log_worker_summary(schedule_start, tasks_remaining=len(self.tasks))
+                last_summary_time = now
             time.sleep(QUERY_DELAY)
         logger.info("All tasks have been scheduled")
 
@@ -627,21 +649,34 @@ class ReplayScheduler:
         self.current_workers[worker_idx] = None
 
     def process_completed_pod(self, worker_pod, worker_idx):
+        duration = int(worker_pod.get_age_secs())
+
         if worker_pod.has_txn_mismatch():
             logger.info(f"Worker {worker_pod.name} failed with txn mismatch")
             self.txn_mismatch_logs.append(worker_pod.get_humio_log_link())
 
         if worker_pod.is_failed():
+            reason = worker_pod.get_failure_reason()
             if worker_pod.should_reschedule():
                 logger.info(
-                    f"Worker {worker_pod.name} failed with {worker_pod.get_failure_reason()}. Rescheduling"
+                    f"Worker {worker_idx} completed: {worker_pod.name}, "
+                    f"status=Failed({reason}), duration={duration}s, rescheduling"
                 )
                 self.reschedule_pod(worker_pod, worker_idx)
             else:
+                logger.info(
+                    f"Worker {worker_idx} completed: {worker_pod.name}, "
+                    f"status=Failed({reason}), duration={duration}s"
+                )
                 self.failed_workpod_logs.append(worker_pod.get_humio_log_link())
                 self.current_workers[worker_idx] = None
         else:
+            logger.info(
+                f"Worker {worker_idx} completed: {worker_pod.name}, "
+                f"status=Succeeded, duration={duration}s"
+            )
             self.task_stats[worker_pod.name].set_succeeded()
+            self.current_workers[worker_idx] = None
 
         self.task_stats[worker_pod.name].set_end_time()
 
@@ -663,17 +698,39 @@ class ReplayScheduler:
         )
 
     def collect_all_failed_logs(self) -> tuple[list[str], list[str]]:
-        logger.info("Collecting logs from remaining pods")
+        remaining = sum(1 for w in self.current_workers if w is not None)
+        logger.info(f"Collecting logs from {remaining} remaining pods")
+
+        collect_timeout = 20 * 60  # 20 minutes
+        collect_start = time.time()
+        last_summary_time = collect_start
+
         all_completed = False
         while not all_completed:
+            elapsed = time.time() - collect_start
+            if elapsed > collect_timeout:
+                logger.error(
+                    f"collect_all_failed_logs timed out after {int(elapsed)}s"
+                )
+                self._log_worker_summary(collect_start, log_level=logging.ERROR)
+                for idx, w in enumerate(self.current_workers):
+                    if w is not None:
+                        self.failed_workpod_logs.append(w.get_humio_log_link())
+                        self.current_workers[idx] = None
+                break
+
             all_completed = True
             for idx, worker in enumerate(self.current_workers):
                 if worker is not None:
-                    logger.info(f"Checking worker {idx} {worker.name}")
                     if not worker.is_completed():
                         all_completed = False
                     else:
                         self.process_completed_pod(worker, idx)
+
+            now = time.time()
+            if now - last_summary_time >= 60:  # Every 60 seconds
+                self._log_worker_summary(collect_start)
+                last_summary_time = now
             time.sleep(QUERY_DELAY)
 
         return (self.failed_workpod_logs, self.txn_mismatch_logs)
@@ -681,6 +738,36 @@ class ReplayScheduler:
     def print_stats(self):
         for key, value in self.task_stats.items():
             logger.info(f"{key}: {value}")
+
+    def _log_worker_summary(
+        self,
+        phase_start_time: float,
+        tasks_remaining: int | None = None,
+        log_level: int = logging.INFO,
+    ):
+        """Dump status of every worker slot."""
+        from collections import Counter
+        log = lambda msg: logger.log(log_level, msg)
+        phase_counts = Counter()
+        header = f"=== Worker status (elapsed={int(time.time() - phase_start_time)}s"
+        if tasks_remaining is not None:
+            header += f", tasks remaining={tasks_remaining}"
+        header += ") ==="
+        log(header)
+        for idx, worker in enumerate(self.current_workers):
+            if worker is None:
+                phase_counts["(empty)"] += 1
+            else:
+                phase = worker.get_phase() or "Unknown"
+                phase_counts[phase] += 1
+                detail = ""
+                if phase not in ("Succeeded", "Failed", "Running"):
+                    detail = f", container={worker.get_container_status_summary()}"
+                log(
+                    f"  Worker {idx}: {worker.name}, phase={phase}, age={int(worker.get_age_secs())}s{detail}"
+                )
+        summary = ", ".join(f"{phase}={count}" for phase, count in sorted(phase_counts.items()))
+        log(f"  Summary: {summary}")
 
     # read skip ranges from gcp bucket
 

--- a/testsuite/replay-verify/main.py
+++ b/testsuite/replay-verify/main.py
@@ -591,19 +591,33 @@ class ReplayScheduler:
         return any(w is not None for w in self.current_workers)
 
     def schedule(self, from_scratch: bool = False) -> tuple[list[str], list[str]]:
+        """Dispatch all tasks to worker pods and wait for them to complete.
+
+        The loop has two phases that blend together:
+        1. DISPATCHING: Tasks remain in self.tasks. Each iteration scans worker
+           slots — when a slot is free (None or completed), it gets the next task.
+           This continues until the task queue is empty.
+        2. WAITING: No tasks left, but some workers are still running. The loop
+           keeps polling until every worker reaches Succeeded/Failed, or the
+           timeout fires.
+
+        Returns (failed_workpod_logs, txn_mismatch_logs).
+        """
         if from_scratch:
             self.kill_all_pods()
         self.create_tasks()
 
         schedule_start = time.time()
         last_summary_time = schedule_start
-        # Track when all tasks have been dispatched so we can apply a
-        # timeout for the remaining workers to finish.
-        all_dispatched_time = None
-        collect_timeout = 20 * 60  # 20 minutes
+        all_dispatched_time = None  # Set once when task queue empties
+        collect_timeout = 20 * 60  # 20 minutes — max wait after all tasks dispatched
 
+        # Keep running while there are tasks to dispatch OR workers still active.
         while len(self.tasks) > 0 or self._has_active_workers():
-            # Check timeout after all tasks have been dispatched
+
+            # --- Timeout check (waiting phase only) ---
+            # Once all tasks have been dispatched, start a countdown. If workers
+            # don't finish within collect_timeout, log diagnostics and bail out.
             if len(self.tasks) == 0 and all_dispatched_time is not None:
                 elapsed = time.time() - all_dispatched_time
                 if elapsed > collect_timeout:
@@ -617,6 +631,10 @@ class ReplayScheduler:
                             self.current_workers[idx] = None
                     break
 
+            # --- Scan worker slots and dispatch tasks ---
+            # For each slot: if the slot is free and there's a task, launch a pod.
+            # The PVC bound check ensures we don't create pods on unbound PVCs
+            # (except for the initial pod per PVC which triggers binding).
             pvc_bound_status = self.get_pvc_bound_status()
             for i in range(len(self.current_workers)):
                 if (
@@ -624,12 +642,14 @@ class ReplayScheduler:
                     or self.current_workers[i].is_completed()
                 ) and (
                     pvc_bound_status[i % len(self.pvcs)] or i < len(self.pvcs)
-                ):  # we only create a new pod to intialize the pvc before the PVC is bound
+                ):
+                    # Slot is available — process the completed pod first if any
                     if (
                         self.current_workers[i] is not None
                         and self.current_workers[i].is_completed()
                     ):
                         self.process_completed_pod(self.current_workers[i], i)
+                    # Dispatch next task into this slot
                     if len(self.tasks) == 0:
                         break
                     task = self.tasks.pop(0)
@@ -646,9 +666,11 @@ class ReplayScheduler:
                     )
                     self.current_workers[i] = worker_pod
                     worker_pod.start()
-                    # collecting stats
                     self.task_stats[worker_pod.name] = TaskStats(worker_pod.name)
 
+                # Probe pod phase to detect failures that need rescheduling
+                # (e.g. pod evictions). If the API call itself fails, reschedule
+                # the pod to be safe.
                 if self.current_workers[i] is not None:
                     try:
                         self.current_workers[i].get_phase()
@@ -656,23 +678,28 @@ class ReplayScheduler:
                         logger.error(f"Failed to get pod status: {e}")
                         self.reschedule_pod(self.current_workers[i], i)
 
-            # Track when we transition from dispatching to waiting
+            # --- Transition: dispatching → waiting ---
             if len(self.tasks) == 0 and all_dispatched_time is None:
                 all_dispatched_time = time.time()
                 logger.info("All tasks have been dispatched, waiting for remaining workers")
 
-            # Process completed workers even when no tasks remain
+            # --- Drain completed workers (waiting phase) ---
+            # During dispatching, completed pods are processed when their slot is
+            # reused above. But once there are no more tasks, slots won't be
+            # revisited by the dispatch loop, so we sweep explicitly.
             if len(self.tasks) == 0:
                 for i in range(len(self.current_workers)):
                     if self.current_workers[i] is not None and self.current_workers[i].is_completed():
                         self.process_completed_pod(self.current_workers[i], i)
 
+            # --- Periodic status summary ---
+            # Every 10 min while dispatching, every 60s while waiting.
             now = time.time()
-            # Log more frequently once we're just waiting for remaining workers
             summary_interval = 60 if len(self.tasks) == 0 else 600
             if now - last_summary_time >= summary_interval:
                 self._log_worker_summary(schedule_start, tasks_remaining=len(self.tasks))
                 last_summary_time = now
+
             time.sleep(QUERY_DELAY)
 
         logger.info("All tasks completed")

--- a/testsuite/replay-verify/main.py
+++ b/testsuite/replay-verify/main.py
@@ -705,10 +705,12 @@ class ReplayScheduler:
 
         if worker_pod.is_failed():
             reason = worker_pod.get_failure_reason()
-            if worker_pod.should_reschedule():
+            retries = self.task_stats[worker_pod.name].retry_count + 1
+            if worker_pod.should_reschedule() and retries < MAX_RETRIES:
                 logger.info(
                     f"Worker {worker_idx} completed: {worker_pod.name}, "
-                    f"status=Failed({reason}), duration={duration}s, rescheduling"
+                    f"status=Failed({reason}), duration={duration}s, "
+                    f"rescheduling (attempt {retries}/{MAX_RETRIES})"
                 )
                 self.kill_pod_and_reschedule_task(worker_pod, worker_idx)
             else:

--- a/testsuite/replay-verify/main.py
+++ b/testsuite/replay-verify/main.py
@@ -593,13 +593,10 @@ class ReplayScheduler:
     def schedule(self, from_scratch: bool = False) -> tuple[list[str], list[str]]:
         """Dispatch all tasks to worker pods and wait for them to complete.
 
-        The loop has two phases that blend together:
-        1. DISPATCHING: Tasks remain in self.tasks. Each iteration scans worker
-           slots — when a slot is free (None or completed), it gets the next task.
-           This continues until the task queue is empty.
-        2. WAITING: No tasks left, but some workers are still running. The loop
-           keeps polling until every worker reaches Succeeded/Failed, or the
-           timeout fires.
+        The loop scans worker slots each iteration:
+        - Completed or timed-out pods are processed and their slots freed.
+        - Free slots get the next task from the queue (if any).
+        - The loop exits when no tasks remain and all slots are empty.
 
         Returns (failed_workpod_logs, txn_mismatch_logs).
         """
@@ -609,39 +606,47 @@ class ReplayScheduler:
 
         schedule_start = time.time()
         last_summary_time = schedule_start
-        all_dispatched_time = None  # Set once when task queue empties
-        collect_timeout = 20 * 60  # 20 minutes — max wait after all tasks dispatched
+        pod_timeout = 20 * 60  # 20 minutes — max age before a pod is considered stuck
 
         # Keep running while there are tasks to dispatch OR workers still active.
         while len(self.tasks) > 0 or self._has_active_workers():
-
-            # --- Timeout check (waiting phase only) ---
-            # Once all tasks have been dispatched, start a countdown. If workers
-            # don't finish within collect_timeout, log diagnostics and bail out.
-            if len(self.tasks) == 0 and all_dispatched_time is not None:
-                elapsed = time.time() - all_dispatched_time
-                if elapsed > collect_timeout:
-                    logger.error(
-                        f"Timed out waiting for remaining workers after {int(elapsed)}s"
-                    )
-                    self._log_worker_summary(schedule_start, log_level=logging.ERROR)
-                    for idx, w in enumerate(self.current_workers):
-                        if w is not None:
-                            self.failed_workpod_logs.append(w.get_humio_log_link())
-                            self.current_workers[idx] = None
-                    break
 
             # --- Scan worker slots ---
             pvc_bound_status = self.get_pvc_bound_status()
             for i in range(len(self.current_workers)):
                 worker = self.current_workers[i]
 
-                # Step 1: Process completed pods to free up the slot
-                if worker is not None and worker.is_completed():
-                    self.process_completed_pod(worker, i)
-                    worker = self.current_workers[i]  # slot may now be None
+                if worker is not None:
+                    if worker.is_completed():
+                        # Pod finished (Succeeded or Failed) — process and free slot
+                        self.process_completed_pod(worker, i)
+                        worker = self.current_workers[i]
+                    elif worker.get_age_secs() > pod_timeout:
+                        # Pod has been running too long — reschedule if under
+                        # retry limit, otherwise treat as permanent failure.
+                        retries = self.task_stats[worker.name].retry_count
+                        logger.error(
+                            f"Worker {i} timed out: {worker.name}, "
+                            f"phase={worker.get_phase()}, "
+                            f"container={worker.get_container_status_summary()}, "
+                            f"age={int(worker.get_age_secs())}s, "
+                            f"retries={retries}/{MAX_RETRIES}"
+                        )
+                        if retries < MAX_RETRIES:
+                            self.reschedule_pod(worker, i)
+                        else:
+                            logger.error(
+                                f"Worker {i} exceeded max retries, giving up: {worker.name}"
+                            )
+                            self.failed_workpod_logs.append(worker.get_humio_log_link())
+                            self.current_workers[i] = None
+                        # Sync local var with the slot (now None in both branches:
+                        # reschedule_pod clears it, and the else branch above clears
+                        # it explicitly). This allows the dispatch check below to
+                        # immediately fill this slot with a new task.
+                        worker = None
 
-                # Step 2: If slot is free and there are tasks, dispatch one.
+                # If slot is free and there are tasks, dispatch one.
                 # PVC must be bound first, unless this is the initial pod
                 # that triggers binding (i < number of PVCs).
                 pvc_ready = pvc_bound_status[i % len(self.pvcs)] or i < len(self.pvcs)
@@ -661,21 +666,6 @@ class ReplayScheduler:
                     self.current_workers[i] = worker_pod
                     worker_pod.start()
                     self.task_stats[worker_pod.name] = TaskStats(worker_pod.name)
-
-                # Step 3: Probe active pods to detect failures that need
-                # rescheduling (e.g. evictions). If the API call itself
-                # fails, reschedule the pod to be safe.
-                if self.current_workers[i] is not None:
-                    try:
-                        self.current_workers[i].get_phase()
-                    except Exception as e:
-                        logger.error(f"Failed to get pod status: {e}")
-                        self.reschedule_pod(self.current_workers[i], i)
-
-            # --- Transition: dispatching → waiting ---
-            if len(self.tasks) == 0 and all_dispatched_time is None:
-                all_dispatched_time = time.time()
-                logger.info("All tasks have been dispatched, waiting for remaining workers")
 
             # --- Periodic status summary ---
             # Every 10 min while dispatching, every 60s while waiting.
@@ -766,20 +756,21 @@ class ReplayScheduler:
             header += f", tasks remaining={tasks_remaining}"
         header += ") ==="
         log(header)
+        empty_count = 0
         for idx, worker in enumerate(self.current_workers):
             if worker is None:
-                phase_counts["(empty)"] += 1
-            else:
-                phase = worker.get_phase() or "Unknown"
-                phase_counts[phase] += 1
-                detail = ""
-                if phase not in ("Succeeded", "Failed", "Running"):
-                    detail = f", container={worker.get_container_status_summary()}"
-                log(
-                    f"  Worker {idx}: {worker.name}, phase={phase}, age={int(worker.get_age_secs())}s{detail}"
-                )
+                empty_count += 1
+                continue
+            phase = worker.get_phase() or "Unknown"
+            phase_counts[phase] += 1
+            detail = ""
+            if phase not in ("Succeeded", "Failed", "Running"):
+                detail = f", container={worker.get_container_status_summary()}"
+            log(
+                f"  Worker {idx}: {worker.name}, phase={phase}, age={int(worker.get_age_secs())}s{detail}"
+            )
         summary = ", ".join(f"{phase}={count}" for phase, count in sorted(phase_counts.items()))
-        log(f"  Summary: {summary}")
+        log(f"  Summary: {summary}, empty={empty_count}")
 
     # read skip ranges from gcp bucket
 

--- a/testsuite/replay-verify/main.py
+++ b/testsuite/replay-verify/main.py
@@ -31,7 +31,12 @@ SHARDING_ENABLED = True
 MAX_RETRIES = 5
 RETRY_DELAY = 20  # seconds
 QUERY_DELAY = 5  # seconds
-TEARDOWN_DELAY = 30 * 60  # 30 minutes slack to allow for pod setup and teardown
+
+# Timeout chain — each layer is a backstop for the one before:
+#   scheduler (20m) → binary (30m) → K8s TTL controller (40m)
+POD_TIMEOUT = 20 * 60  # scheduler kills stuck pods after 20 min
+BINARY_TIMEOUT = POD_TIMEOUT + 10 * 60  # aptos-debugger self-terminates as backstop
+POD_TTL = BINARY_TIMEOUT + 10 * 60  # K8s TTL controller as last resort
 
 REPLAY_CONCURRENCY_LEVEL = 1
 
@@ -100,13 +105,11 @@ class ReplayConfig:
             self.pvc_number = 35
             self.min_range_size = 10_000
             self.range_size = 5_000_000
-            self.timeout_secs = 9000
         else:
             self.concurrent_replayer = 35
             self.pvc_number = 10
             self.min_range_size = 10_000
             self.range_size = 2_000_000
-            self.timeout_secs = 9000
 
 
 class WorkerPod:
@@ -229,7 +232,7 @@ class WorkerPod:
         pod_manifest["metadata"]["name"] = self.name  # Unique name for each pod
         pod_manifest["metadata"]["labels"]["run"] = self.label
         pod_manifest["spec"]["containers"][0]["image"] = self.image
-        pod_ttl = self.config.timeout_secs + TEARDOWN_DELAY
+        pod_ttl = POD_TTL
         pod_manifest["metadata"]["annotations"][
             "k8s-ttl-controller.twin.sh/ttl"
         ] = f"{pod_ttl}s"
@@ -252,7 +255,7 @@ class WorkerPod:
             "--replay-concurrency-level",
             f"{REPLAY_CONCURRENCY_LEVEL}",
             "--timeout-secs",
-            f"{self.config.timeout_secs}",
+            f"{BINARY_TIMEOUT}",
             "--block-cache-size",
             f"{36 * 1024 * 1024 * 1024}",
         ]
@@ -401,7 +404,9 @@ class ReplayScheduler:
             worker_cnt: {worker_cnt}
             image: {image}
             number_of_pvc: {self.config.pvc_number}
-            timeout_secs: {self.config.timeout_secs}
+            pod_timeout: {POD_TIMEOUT}
+            binary_timeout: {BINARY_TIMEOUT}
+            pod_ttl: {POD_TTL}
             namespace: {self.namespace}"""
 
     def get_label(self):
@@ -607,7 +612,7 @@ class ReplayScheduler:
         schedule_start = time.time()
         last_summary_time = schedule_start
         self.total_tasks = len(self.tasks)
-        pod_timeout = 20 * 60  # 20 minutes — max age before a pod is considered stuck
+        pod_timeout = POD_TIMEOUT
 
         # Keep running while there are tasks to dispatch OR workers still active.
         while len(self.tasks) > 0 or self._has_active_workers():
@@ -634,15 +639,16 @@ class ReplayScheduler:
                             f"attempt {retries}/{MAX_RETRIES}"
                         )
                         if retries < MAX_RETRIES:
-                            self.reschedule_pod(worker, i)
+                            self.kill_pod_and_reschedule_task(worker, i)
                         else:
                             logger.error(
                                 f"Worker {i} exceeded max retries, giving up: {worker.name}"
                             )
+                            worker.delete_pod()
                             self.failed_workpod_logs.append(worker.get_humio_log_link())
                             self.current_workers[i] = None
                         # Sync local var with the slot (now None in both branches:
-                        # reschedule_pod clears it, and the else branch above clears
+                        # kill_pod_and_reschedule_task clears it, and the else branch above clears
                         # it explicitly). This allows the dispatch check below to
                         # immediately fill this slot with a new task.
                         worker = None
@@ -670,7 +676,7 @@ class ReplayScheduler:
                         self.task_stats[worker_pod.name] = TaskStats(worker_pod.name)
 
             # --- Periodic status summary ---
-            # Every 10 min while dispatching, every 60s while waiting.
+            # Every 5 min while dispatching, every 60s while waiting.
             now = time.time()
             summary_interval = 60 if len(self.tasks) == 0 else 300
             if now - last_summary_time >= summary_interval:
@@ -682,7 +688,7 @@ class ReplayScheduler:
         logger.info("All tasks completed")
         return (self.failed_workpod_logs, self.txn_mismatch_logs)
 
-    def reschedule_pod(self, worker_pod: WorkerPod, worker_idx: int):
+    def kill_pod_and_reschedule_task(self, worker_pod: WorkerPod, worker_idx: int):
         # clean up the existing pod
         worker_pod.delete_pod()
         # re-enter the task to the queue
@@ -704,7 +710,7 @@ class ReplayScheduler:
                     f"Worker {worker_idx} completed: {worker_pod.name}, "
                     f"status=Failed({reason}), duration={duration}s, rescheduling"
                 )
-                self.reschedule_pod(worker_pod, worker_idx)
+                self.kill_pod_and_reschedule_task(worker_pod, worker_idx)
             else:
                 logger.info(
                     f"Worker {worker_idx} completed: {worker_pod.name}, "
@@ -755,9 +761,9 @@ class ReplayScheduler:
         phase_counts = Counter()
         header = f"=== Worker status (elapsed={int(time.time() - phase_start_time)}s"
         if tasks_remaining is not None:
-            completed = self.total_tasks - tasks_remaining
-            pct = int(completed / self.total_tasks * 100) if self.total_tasks > 0 else 100
-            header += f", progress={completed}/{self.total_tasks} — {pct}%"
+            dispatched = self.total_tasks - tasks_remaining
+            pct = int(dispatched / self.total_tasks * 100) if self.total_tasks > 0 else 100
+            header += f", dispatched {dispatched}/{self.total_tasks} — {pct}%"
         header += ") ==="
         log("")
         log(header)

--- a/testsuite/replay-verify/main.py
+++ b/testsuite/replay-verify/main.py
@@ -528,7 +528,7 @@ class ReplayScheduler:
         # Wait for the PVC to be bound before creating other PVCs
         logger.info(
             f"Waiting for the PVC {pvc} to be bound. "
-            "This involves cloning a large disk volume from a snapshot and may take several minutes..."
+            "This involves cloning a large disk volume from a snapshot and may take 10+ minutes..."
         )
         bound_status = self.get_pvc_bound_status()
         while not self.get_pvc_bound_status()[0]:
@@ -606,6 +606,7 @@ class ReplayScheduler:
 
         schedule_start = time.time()
         last_summary_time = schedule_start
+        self.total_tasks = len(self.tasks)
         pod_timeout = 20 * 60  # 20 minutes — max age before a pod is considered stuck
 
         # Keep running while there are tasks to dispatch OR workers still active.
@@ -624,13 +625,13 @@ class ReplayScheduler:
                     elif worker.get_age_secs() > pod_timeout:
                         # Pod has been running too long — reschedule if under
                         # retry limit, otherwise treat as permanent failure.
-                        retries = self.task_stats[worker.name].retry_count
+                        retries = self.task_stats[worker.name].retry_count + 1
                         logger.error(
                             f"Worker {i} timed out: {worker.name}, "
                             f"phase={worker.get_phase()}, "
                             f"container={worker.get_container_status_summary()}, "
                             f"age={int(worker.get_age_secs())}s, "
-                            f"retries={retries}/{MAX_RETRIES}"
+                            f"attempt {retries}/{MAX_RETRIES}"
                         )
                         if retries < MAX_RETRIES:
                             self.reschedule_pod(worker, i)
@@ -665,12 +666,13 @@ class ReplayScheduler:
                     )
                     self.current_workers[i] = worker_pod
                     worker_pod.start()
-                    self.task_stats[worker_pod.name] = TaskStats(worker_pod.name)
+                    if worker_pod.name not in self.task_stats:
+                        self.task_stats[worker_pod.name] = TaskStats(worker_pod.name)
 
             # --- Periodic status summary ---
             # Every 10 min while dispatching, every 60s while waiting.
             now = time.time()
-            summary_interval = 60 if len(self.tasks) == 0 else 600
+            summary_interval = 60 if len(self.tasks) == 0 else 300
             if now - last_summary_time >= summary_interval:
                 self._log_worker_summary(schedule_start, tasks_remaining=len(self.tasks))
                 last_summary_time = now
@@ -753,8 +755,11 @@ class ReplayScheduler:
         phase_counts = Counter()
         header = f"=== Worker status (elapsed={int(time.time() - phase_start_time)}s"
         if tasks_remaining is not None:
-            header += f", tasks remaining={tasks_remaining}"
+            completed = self.total_tasks - tasks_remaining
+            pct = int(completed / self.total_tasks * 100) if self.total_tasks > 0 else 100
+            header += f", progress={completed}/{self.total_tasks} — {pct}%"
         header += ") ==="
+        log("")
         log(header)
         empty_count = 0
         for idx, worker in enumerate(self.current_workers):
@@ -771,6 +776,8 @@ class ReplayScheduler:
             )
         summary = ", ".join(f"{phase}={count}" for phase, count in sorted(phase_counts.items()))
         log(f"  Summary: {summary}, empty={empty_count}")
+        log("=== End worker status ==="  )
+        log("")
 
     # read skip ranges from gcp bucket
 

--- a/testsuite/replay-verify/main.py
+++ b/testsuite/replay-verify/main.py
@@ -438,6 +438,16 @@ class TaskStats:
     def increment_retry_count(self) -> None:
         self.retry_count += 1
 
+    def reset_timing(self) -> None:
+        """Reset start_time to now; clear end_time.
+
+        Called when a retried task is re-dispatched, so the reported
+        duration reflects only the final attempt (not queue wait time
+        or earlier failed attempts).
+        """
+        self.start_time = time.time()
+        self.end_time = None
+
     def set_succeeded(self):
         self.succeeded = True
 
@@ -779,6 +789,10 @@ class ReplayScheduler:
                     worker_pod.start()
                     if worker_pod.name not in self.task_stats:
                         self.task_stats[worker_pod.name] = TaskStats(worker_pod.name)
+                    else:
+                        # Retry dispatch: reset timing so duration reflects
+                        # only this attempt, not earlier ones or queue wait.
+                        self.task_stats[worker_pod.name].reset_timing()
 
             # --- Periodic status summary ---
             # Every 5 min while dispatching, every 60s while waiting.
@@ -817,6 +831,7 @@ class ReplayScheduler:
                     f"status=Failed({reason}), duration={duration}s, "
                     f"rescheduling (attempt {retries}/{MAX_RETRIES})"
                 )
+                # Don't set end_time — task will be re-dispatched
                 self.kill_pod_and_reschedule_task(worker_pod, worker_idx)
             else:
                 logger.info(
@@ -825,6 +840,7 @@ class ReplayScheduler:
                 )
                 self.failed_workpod_logs.append(worker_pod.get_humio_log_link())
                 self.current_workers[worker_idx] = None
+                self.task_stats[worker_pod.name].set_end_time()
         else:
             logger.info(
                 f"Worker {worker_idx} completed: {worker_pod.name}, "
@@ -832,8 +848,7 @@ class ReplayScheduler:
             )
             self.task_stats[worker_pod.name].set_succeeded()
             self.current_workers[worker_idx] = None
-
-        self.task_stats[worker_pod.name].set_end_time()
+            self.task_stats[worker_pod.name].set_end_time()
 
     def cleanup(self):
         self.kill_all_pods()


### PR DESCRIPTION
## Summary
- Add periodic worker status dumps during scheduling (every 10 min) and collection (every 60s) phases, showing pod phase, age, and container status detail for stuck pods
- Add 20-minute timeout to `collect_all_failed_logs()` — stuck runs now exit with full diagnostics instead of being silently killed by the GHA 420-min timeout
- Log pod completion events with status (Succeeded/Failed + reason) and duration
- Include worker index and PVC name in pod creation logs for easier cross-referencing with GCP disk attachment errors
- Fix missing worker slot cleanup on success path in `process_completed_pod()`

## Context
Recent replay-verify runs (Apr 2, 6, 9) have been timing out. Investigation suggests pods get stuck in `ContainerCreating` due to GCP disk attachment limits, but the scheduler logs provided no visibility into pod state — just `Checking worker N <pod-name>` repeated 200K+ times with no phase or status information. These changes are observability-focused to help diagnose the root cause in the next run.

## Test plan
- [ ] Verify syntax: `python -c "import py_compile; py_compile.compile('main.py', doraise=True)"`
- [ ] Trigger a manual replay-verify run and confirm new log output appears
- [ ] Verify completed pods show status/duration in logs
- [ ] Verify periodic worker summary dumps appear at expected intervals
- [ ] If pods get stuck, verify the 20-min timeout fires with diagnostic output

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes scheduling and failure-handling logic for Kubernetes worker pods (timeouts, rescheduling, new LOST state), which could alter run completion behavior and retry patterns but is scoped to replay-verify tooling.
> 
> **Overview**
> Improves replay-verify’s scheduler loop to run until *all* worker slots are drained, add a 20-minute per-pod timeout with retry/reschedule behavior, and return failure/mismatch log links directly from `schedule()` (removing the separate `collect_all_failed_logs()` phase).
> 
> Adds a `LocalPhase` state machine with cached pod-status polling and a terminal `LOST` state on repeated API failures, plus best-effort pod deletion and more detailed diagnostics (worker/PVC in creation logs, completion logs with duration/reason, periodic worker status dumps including container state summaries).
> 
> Replaces the previous per-network `timeout_secs` with a coordinated timeout chain (`POD_TIMEOUT`/`BINARY_TIMEOUT`/`POD_TTL`) and updates the `aptos-debugger` `--timeout-secs` and K8s TTL annotation accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e1f26b919c9e2141094c56d2e99fe4a44d9980f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->