### PR TITLE
[mempool] Avoid cloning SignedTransaction for tracing committed hash

### DIFF
--- a/mempool/src/core_mempool/transaction_store.rs
+++ b/mempool/src/core_mempool/transaction_store.rs
@@ -151,6 +151,16 @@ impl TransactionStore {
             .and_then(|txns| txns.get(&replay_protector))
     }
 
+    /// Fetch committed hash without cloning the full transaction.
+    pub(crate) fn get_committed_hash(
+        &self,
+        address: &AccountAddress,
+        replay_protector: ReplayProtector,
+    ) -> Option<HashValue> {
+        self.get_mempool_txn(address, replay_protector)
+            .map(|txn| txn.txn.committed_hash())
+    }
+
     /// Fetch transaction by account address + replay_protector.
     pub(crate) fn get(
         &self,

--- a/mempool/src/shared_mempool/tasks.rs
+++ b/mempool/src/shared_mempool/tasks.rs
@@ -819,11 +819,11 @@ pub(crate) fn process_committed_transactions(
 
     for transaction in transactions {
         if tracing_enabled {
-            if let Some(txn) = pool
+            if let Some(hash) = pool
                 .transactions
-                .get(&transaction.sender, transaction.replay_protector)
+                .get_committed_hash(&transaction.sender, transaction.replay_protector)
             {
-                traced_commit_hashes.push(txn.committed_hash());
+                traced_commit_hashes.push(hash);
             }
         }
         pool.log_commit_transaction(


### PR DESCRIPTION
## Summary
- Add `get_committed_hash()` to `TransactionStore` that fetches the committed hash by reference, avoiding a full `SignedTransaction` clone
- Use it in `process_committed_transactions` instead of `get()` + `committed_hash()`, eliminating unnecessary allocations while holding the mempool mutex

Addresses review feedback from #19436 — the tracing code was cloning the full `SignedTransaction` for every committed transaction just to get the hash, adding allocation + CPU overhead on the critical path.

## Test plan
- [x] `cargo check -p aptos-mempool` passes
- [x] Pre-commit lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, localized perf change: only alters how tracing collects committed transaction hashes and adds a helper accessor, without changing commit/GC semantics.
> 
> **Overview**
> Reduces overhead on the committed-transaction path by adding `TransactionStore::get_committed_hash()` to fetch a txn’s committed hash without cloning the full `SignedTransaction`.
> 
> Updates `process_committed_transactions` tracing to use this helper while holding the mempool lock, avoiding per-transaction allocations during commit processing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b5afbf810099b199f09f2a44b42b775078f121c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->