### PR TITLE
[consensus] Add QsProofOfStore and BlockReceived tracing stages

### DIFF
--- a/consensus/src/quorum_store/proof_coordinator.rs
+++ b/consensus/src/quorum_store/proof_coordinator.rs
@@ -482,6 +482,17 @@ impl ProofCoordinator {
                             }).peekable();
                             if proofs_iter.peek().is_some() {
                                 observe_batch(approx_created_ts_usecs, self_peer_id, BatchStage::POS_FORMED, &info);
+                                // Record QsProofOfStore in transaction trace (uses local clock
+                                // so it's comparable with QsBatchCreated).
+                                {
+                                    let store = aptos_transaction_tracing::store::TransactionTraceStore::global();
+                                    if store.is_enabled() {
+                                        store.record_batch_stage(
+                                            info.digest(),
+                                            aptos_transaction_tracing::types::TransactionStage::QsProofOfStore,
+                                        );
+                                    }
+                                }
                                 if enable_broadcast_proofs {
                                     if proofs_iter.peek().is_some_and(|p| p.info().is_v2()) {
                                         let proofs: Vec<_> = proofs_iter.collect();

--- a/consensus/src/quorum_store/proof_manager.rs
+++ b/consensus/src/quorum_store/proof_manager.rs
@@ -65,8 +65,6 @@ impl ProofManager {
     }
 
     pub(crate) fn receive_proofs(&mut self, proofs: Vec<ProofOfStore<BatchInfoExt>>) {
-        let store = aptos_transaction_tracing::store::TransactionTraceStore::global();
-        let tracing_enabled = store.is_enabled();
         for proof in proofs.into_iter() {
             // Batch tracing (Prometheus histogram) — works on every node,
             // not just the batch author. Measures batch_creation → proof_received.
@@ -94,14 +92,6 @@ impl ProofManager {
                         age.as_millis(),
                     );
                 }
-            }
-            // Txn trace (per-txn log) — only fires on the batch author where the
-            // batch digest is registered. Shows per-txn outliers.
-            if tracing_enabled {
-                store.record_batch_stage(
-                    proof.info().digest(),
-                    aptos_transaction_tracing::types::TransactionStage::QsProofReceived,
-                );
             }
             self.batch_proof_queue.insert_proof(proof);
         }

--- a/consensus/src/quorum_store/proof_manager.rs
+++ b/consensus/src/quorum_store/proof_manager.rs
@@ -4,7 +4,10 @@
 use super::batch_store::BatchStore;
 use crate::{
     monitor,
-    quorum_store::{batch_generator::BackPressure, batch_proof_queue::BatchProofQueue, counters},
+    quorum_store::{
+        batch_generator::BackPressure, batch_proof_queue::BatchProofQueue, counters,
+        tracing::{observe_batch, BatchStage},
+    },
 };
 use aptos_consensus_types::{
     common::{Payload, PayloadFilter, TxnSummaryWithExpiration},
@@ -34,6 +37,7 @@ pub struct ProofManager {
     back_pressure_total_proof_limit: u64,
     remaining_total_proof_num: u64,
     allow_batches_without_pos_in_proposal: bool,
+    batch_expiry_gap_when_init_usecs: u64,
 }
 
 impl ProofManager {
@@ -56,6 +60,7 @@ impl ProofManager {
             back_pressure_total_proof_limit,
             remaining_total_proof_num: 0,
             allow_batches_without_pos_in_proposal,
+            batch_expiry_gap_when_init_usecs,
         }
     }
 
@@ -63,6 +68,20 @@ impl ProofManager {
         let store = aptos_transaction_tracing::store::TransactionTraceStore::global();
         let tracing_enabled = store.is_enabled();
         for proof in proofs.into_iter() {
+            // Batch tracing (Prometheus histogram) — works on every node,
+            // not just the batch author. Measures batch_creation → proof_received.
+            let approx_created_ts_usecs = proof
+                .info()
+                .expiration()
+                .saturating_sub(self.batch_expiry_gap_when_init_usecs);
+            observe_batch(
+                approx_created_ts_usecs,
+                proof.info().author(),
+                BatchStage::PROOF_RECEIVED,
+                proof.info(),
+            );
+            // Txn trace (per-txn log) — only fires on the batch author where the
+            // batch digest is registered. Shows per-txn outliers.
             if tracing_enabled {
                 store.record_batch_stage(
                     proof.info().digest(),

--- a/consensus/src/quorum_store/proof_manager.rs
+++ b/consensus/src/quorum_store/proof_manager.rs
@@ -74,12 +74,27 @@ impl ProofManager {
                 .info()
                 .expiration()
                 .saturating_sub(self.batch_expiry_gap_when_init_usecs);
+            let age = aptos_infallible::duration_since_epoch()
+                .checked_sub(std::time::Duration::from_micros(approx_created_ts_usecs));
             observe_batch(
                 approx_created_ts_usecs,
                 proof.info().author(),
                 BatchStage::PROOF_RECEIVED,
                 proof.info(),
             );
+            // Log on every node when a proof is slow to arrive (> 500ms from
+            // batch creation). Catches outliers that Prometheus histograms miss.
+            if let Some(age) = age {
+                if age.as_millis() > 500 {
+                    info!(
+                        "SlowProofReceipt author={} digest={} num_txns={} age_ms={}",
+                        proof.info().author(),
+                        proof.info().digest(),
+                        proof.info().num_txns(),
+                        age.as_millis(),
+                    );
+                }
+            }
             // Txn trace (per-txn log) — only fires on the batch author where the
             // batch digest is registered. Shows per-txn outliers.
             if tracing_enabled {

--- a/consensus/src/quorum_store/proof_manager.rs
+++ b/consensus/src/quorum_store/proof_manager.rs
@@ -5,7 +5,9 @@ use super::batch_store::BatchStore;
 use crate::{
     monitor,
     quorum_store::{
-        batch_generator::BackPressure, batch_proof_queue::BatchProofQueue, counters,
+        batch_generator::BackPressure,
+        batch_proof_queue::BatchProofQueue,
+        counters,
         tracing::{observe_batch, BatchStage},
     },
 };

--- a/consensus/src/quorum_store/proof_manager.rs
+++ b/consensus/src/quorum_store/proof_manager.rs
@@ -9,7 +9,7 @@ use crate::{
 use aptos_consensus_types::{
     common::{Payload, PayloadFilter, TxnSummaryWithExpiration},
     payload::{OptQuorumStorePayload, PayloadExecutionLimit},
-    proof_of_store::{BatchInfoExt, ProofOfStore, ProofOfStoreMsg},
+    proof_of_store::{BatchInfoExt, ProofOfStore, ProofOfStoreMsg, TBatchInfo},
     request_response::{GetPayloadCommand, GetPayloadResponse},
     utils::PayloadTxnsSize,
 };
@@ -60,7 +60,15 @@ impl ProofManager {
     }
 
     pub(crate) fn receive_proofs(&mut self, proofs: Vec<ProofOfStore<BatchInfoExt>>) {
+        let store = aptos_transaction_tracing::store::TransactionTraceStore::global();
+        let tracing_enabled = store.is_enabled();
         for proof in proofs.into_iter() {
+            if tracing_enabled {
+                store.record_batch_stage(
+                    proof.info().digest(),
+                    aptos_transaction_tracing::types::TransactionStage::QsProofReceived,
+                );
+            }
             self.batch_proof_queue.insert_proof(proof);
         }
         self.update_remaining_txns_and_proofs();

--- a/consensus/src/quorum_store/proof_manager.rs
+++ b/consensus/src/quorum_store/proof_manager.rs
@@ -84,7 +84,7 @@ impl ProofManager {
             // batch creation). Catches outliers that Prometheus histograms miss.
             if let Some(age) = age {
                 if age.as_millis() > 500 {
-                    info!(
+                    warn!(
                         "SlowProofReceipt author={} digest={} num_txns={} age_ms={}",
                         proof.info().author(),
                         proof.info().digest(),

--- a/consensus/src/quorum_store/tracing.rs
+++ b/consensus/src/quorum_store/tracing.rs
@@ -11,6 +11,7 @@ pub struct BatchStage;
 
 impl BatchStage {
     pub const POS_FORMED: &'static str = "pos";
+    pub const PROOF_RECEIVED: &'static str = "proof_received";
     pub const RECEIVED: &'static str = "received";
     pub const SIGNED: &'static str = "signed";
 }

--- a/consensus/src/round_manager.rs
+++ b/consensus/src/round_manager.rs
@@ -1275,11 +1275,18 @@ impl RoundManager {
         if aptos_transaction_tracing::store::TransactionTraceStore::global().is_enabled() {
             if let Some(payload) = proposal.payload() {
                 let batch_digests = extract_batch_digests(payload);
+                let proposal_info = proposal.author().map(|author| {
+                    aptos_transaction_tracing::types::BlockProposalInfo {
+                        proposer: author.short_str().to_string(),
+                        round: proposal.round(),
+                    }
+                });
                 aptos_transaction_tracing::store::TransactionTraceStore::global()
                     .process_proposed_block(
                         proposal.id(),
                         proposal.timestamp_usecs(),
                         &batch_digests,
+                        proposal_info,
                     );
             }
         }

--- a/crates/aptos-transaction-tracing/src/store.rs
+++ b/crates/aptos-transaction-tracing/src/store.rs
@@ -153,6 +153,7 @@ impl TransactionTraceStore {
                     format!("{}({})", stage.as_ref(), inclusion.as_ref())
                 },
                 StageMetadata::BatchPull(_) => stage.as_ref().to_string(),
+                StageMetadata::BlockProposal(_) => stage.as_ref().to_string(),
             };
             observe_stage_latency(trace.insertion_time_usecs, &trace.sender_str, &stage_label);
             trace.record_with_metadata(stage, timestamp_usecs, metadata);
@@ -290,7 +291,9 @@ impl TransactionTraceStore {
         block_id: HashValue,
         block_timestamp_usecs: u64,
         batch_digests: &[(HashValue, crate::types::BatchInclusionType)],
+        proposal_info: Option<crate::types::BlockProposalInfo>,
     ) {
+        let now = now_usecs();
         let mut block_traced_txns: Vec<HashValue> = Vec::new();
         for (digest, inclusion) in batch_digests {
             self.record_batch_stage_with_metadata_at(
@@ -303,7 +306,24 @@ impl TransactionTraceStore {
                 block_traced_txns.extend(txn_hashes.iter());
             }
         }
-        self.register_block(block_id, block_traced_txns);
+        self.register_block(block_id, block_traced_txns.clone());
+
+        // Record BlockReceived at local clock for all traced txns in the block.
+        // Also attach proposal info (proposer + round) for diagnosis.
+        if let Some(info) = proposal_info {
+            for hash in &block_traced_txns {
+                self.record_stage_with_metadata_at(
+                    hash,
+                    TransactionStage::BlockReceived,
+                    StageMetadata::BlockProposal(info.clone()),
+                    now,
+                );
+            }
+        } else {
+            for hash in &block_traced_txns {
+                self.record_stage_at(hash, TransactionStage::BlockReceived, now);
+            }
+        }
     }
 
     /// Record execution results (Keep/Retry/Discard) for traced txns in a block.
@@ -699,6 +719,14 @@ fn log_trace(trace: &TransactionTrace) {
                     info.excluded_txn_count,
                     if info.bp_txn { 1 } else { 0 },
                     if info.bp_proof { 1 } else { 0 },
+                )
+            },
+            Some(StageMetadata::BlockProposal(info)) => {
+                format!(
+                    "{}(r={},by={})",
+                    record.stage.as_ref(),
+                    info.round,
+                    info.proposer,
                 )
             },
             None => record.stage.as_ref().to_string(),

--- a/crates/aptos-transaction-tracing/src/types.rs
+++ b/crates/aptos-transaction-tracing/src/types.rs
@@ -13,6 +13,10 @@ pub enum TransactionStage {
     QsBatchCreated,
     QsProofOfStore,
     BlockProposed,
+    /// Local-clock timestamp when this node received the block proposal.
+    /// Compared with BlockProposed (leader's block_timestamp) to measure
+    /// clock skew + network delay from leader to this node.
+    BlockReceived,
     BlockOrdered,
     ExecutionStart,
     Executed,
@@ -97,6 +101,15 @@ pub struct BatchPullInfo {
     pub recent_batches: std::sync::Arc<Vec<BatchCreationRecord>>,
 }
 
+/// Block proposal context: who proposed and at what round.
+#[derive(Debug, Clone)]
+pub struct BlockProposalInfo {
+    /// Short hex prefix of the proposer's peer ID.
+    pub proposer: String,
+    /// Consensus round number.
+    pub round: u64,
+}
+
 /// Additional metadata for specific stages.
 #[derive(Debug, Clone)]
 pub enum StageMetadata {
@@ -105,6 +118,8 @@ pub enum StageMetadata {
     /// Arc-wrapped to avoid cloning the inner Vecs when the same pull info
     /// is recorded for multiple traced txns in the same pull round.
     BatchPull(Arc<BatchPullInfo>),
+    /// Block proposal context (proposer + round).
+    BlockProposal(BlockProposalInfo),
 }
 
 /// A single recorded stage in a transaction's lifecycle.

--- a/crates/aptos-transaction-tracing/src/types.rs
+++ b/crates/aptos-transaction-tracing/src/types.rs
@@ -12,10 +12,6 @@ pub enum TransactionStage {
     QsBatchPull,
     QsBatchCreated,
     QsProofOfStore,
-    /// Local-clock timestamp when this node's ProofManager received the proof.
-    /// On the batch author: near-instant after QsProofOfStore (validates local path).
-    /// On the leader: shows proof propagation delay from batch author.
-    QsProofReceived,
     BlockProposed,
     /// Local-clock timestamp when this node received the block proposal.
     /// Compared with BlockProposed (leader's block_timestamp) to measure

--- a/crates/aptos-transaction-tracing/src/types.rs
+++ b/crates/aptos-transaction-tracing/src/types.rs
@@ -12,6 +12,10 @@ pub enum TransactionStage {
     QsBatchPull,
     QsBatchCreated,
     QsProofOfStore,
+    /// Local-clock timestamp when this node's ProofManager received the proof.
+    /// On the batch author: near-instant after QsProofOfStore (validates local path).
+    /// On the leader: shows proof propagation delay from batch author.
+    QsProofReceived,
     BlockProposed,
     /// Local-clock timestamp when this node received the block proposal.
     /// Compared with BlockProposed (leader's block_timestamp) to measure


### PR DESCRIPTION
## Summary
Investigating why Asian validator (apne1-0) shows ~900ms gap between `QsBatchCreated` and `BlockProposed(Proof)` in transaction traces, when PoS formation is only ~225ms. This PR adds tracing to break down the blind spot.

### Changes
- **`QsProofOfStore` txn trace stage** — recorded at local clock when PoS forms in proof_coordinator. Splits `QsBatchCreated→BlockProposed` into PoS formation vs proof-to-proposal queueing.
- **`BlockReceived` txn trace stage** — recorded at local clock when proposal is received, with proposer ID and round number. Compared with `BlockProposed` (leader's `block_timestamp`) to measure clock skew + network delay.
- **`batch_tracing{stage="proof_received"}` Prometheus metric** — recorded on every node when ProofManager receives a proof. Measures `batch_creation → proof_receipt` across nodes to reveal proof propagation delay.
- **`SlowProofReceipt` warn log** — fires on every node when a proof arrives >500ms after batch creation. Catches outliers that histograms miss, searchable in Humio by author/digest.

### New trace output (on batch author)
```
stages=[... QsBatchCreated=18ms QsProofOfStore=243ms BlockProposed(Proof)=922ms BlockReceived(r=12345,by=a1b2c3)=1035ms ...]
```

### Diagnosis guide
| Metric | What it reveals |
|---|---|
| `QsProofOfStore - QsBatchCreated` | PoS formation (pure network, ~1 RTT) |
| `BlockReceived - QsProofOfStore` | End-to-end proof-to-receipt on **same local clock** (no clock skew) |
| `BlockReceived - BlockProposed` | `network_delay(leader→self) + clock_skew` |
| `r=ROUND` | Consensus round of the block that included this proof |
| `by=PROPOSER` | Identifies the leader (geographic distance) |

### Grafana queries (after deploy)
```promql
# Proof receipt latency on any node, filtered by Asian batch author
histogram_quantile(0.9, rate(quorum_store_batch_tracing_bucket{stage="proof_received", author="649127a4"}[$__rate_interval]))

# Compare with PoS formation (already on mainnet)
histogram_quantile(0.9, rate(quorum_store_batch_tracing_bucket{stage="pos", author="649127a4"}[$__rate_interval]))
```

## Test plan
- [x] `cargo check -p aptos-consensus -p aptos-transaction-tracing` passes
- [ ] Deploy to Asian validator and verify new stages appear in `TxnTrace` logs
- [ ] Verify `batch_tracing{stage="proof_received"}` appears in Grafana
- [ ] Verify `SlowProofReceipt` warns appear in Humio

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new tracing/metrics/logging on quorum store and proposal-processing hot paths; while mostly observational and gated where possible, it may introduce additional overhead or log volume under load.
> 
> **Overview**
> Adds finer-grained end-to-end observability for Quorum Store and proposal propagation.
> 
> Consensus now records a new `QsProofOfStore` transaction-trace stage when a proof-of-store is formed (local clock), emits a new `batch_tracing{stage="proof_received"}` metric plus a `SlowProofReceipt` warn when proofs arrive late, and extends block tracing to record a local-clock `BlockReceived` stage (optionally annotated with proposer + round) when processing proposals.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e63d84bb9887aaa34b6f58451c221f62ca6109d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->