### PR TITLE
[deps] Remove warnings for soon to be deprecated dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5294,9 +5294,12 @@ dependencies = [
 
 [[package]]
 name = "arc-swap"
-version = "1.6.0"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "ark-bls12-381"
@@ -5398,7 +5401,7 @@ dependencies = [
  "fnv",
  "hashbrown 0.15.3",
  "itertools 0.13.0",
- "num-bigint 0.4.4",
+ "num-bigint 0.4.6",
  "num-integer",
  "num-traits",
  "rayon",
@@ -5418,7 +5421,7 @@ dependencies = [
  "derivative",
  "digest 0.10.7",
  "itertools 0.10.5",
- "num-bigint 0.4.4",
+ "num-bigint 0.4.6",
  "num-traits",
  "paste",
  "rustc_version",
@@ -5438,7 +5441,7 @@ dependencies = [
  "digest 0.10.7",
  "educe",
  "itertools 0.13.0",
- "num-bigint 0.4.4",
+ "num-bigint 0.4.6",
  "num-traits",
  "paste",
  "rayon",
@@ -5470,7 +5473,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
 dependencies = [
- "num-bigint 0.4.4",
+ "num-bigint 0.4.6",
  "num-traits",
  "proc-macro2",
  "quote",
@@ -5482,7 +5485,7 @@ name = "ark-ff-macros"
 version = "0.5.0"
 source = "git+https://github.com/aptos-labs/algebra?branch=fix-fft-parallelism-cutoff#2cacd5efad67bce331aec780b6fcfa4a45f44306"
 dependencies = [
- "num-bigint 0.4.4",
+ "num-bigint 0.4.6",
  "num-traits",
  "proc-macro2",
  "quote",
@@ -5554,7 +5557,7 @@ dependencies = [
  "ark-serialize-derive 0.4.2",
  "ark-std 0.4.0",
  "digest 0.10.7",
- "num-bigint 0.4.4",
+ "num-bigint 0.4.6",
 ]
 
 [[package]]
@@ -5566,7 +5569,7 @@ dependencies = [
  "ark-std 0.5.0",
  "arrayvec 0.7.4",
  "digest 0.10.7",
- "num-bigint 0.4.4",
+ "num-bigint 0.4.6",
  "rayon",
 ]
 
@@ -6349,7 +6352,7 @@ checksum = "4d6867f1565b3aad85681f1015055b087fcfd840d6aeee6eee7f2da317603695"
 dependencies = [
  "autocfg",
  "libm",
- "num-bigint 0.4.4",
+ "num-bigint 0.4.6",
  "num-integer",
  "num-traits",
  "serde",
@@ -8129,22 +8132,21 @@ dependencies = [
 
 [[package]]
 name = "deadpool"
-version = "0.9.5"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "421fe0f90f2ab22016f32a9881be5134fdd71c65298917084b0c7477cbc3856e"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
 dependencies = [
- "async-trait",
  "deadpool-runtime",
+ "lazy_static",
  "num_cpus",
- "retain_mut",
  "tokio",
 ]
 
 [[package]]
 name = "deadpool-redis"
-version = "0.11.1"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b8bde44cbfdf17ae5baa45c9f43073b320f1a19955389315629304a23909ad2"
+checksum = "1ed4f481f6a4770b95e09b91e183ee5ed6e1d4a34c0b09814012b3ee5e585f70"
 dependencies = [
  "deadpool",
  "redis",
@@ -8390,7 +8392,7 @@ dependencies = [
  "diesel_derives",
  "downcast-rs",
  "itoa",
- "num-bigint 0.4.4",
+ "num-bigint 0.3.3",
  "num-integer",
  "num-traits",
  "pq-sys",
@@ -13972,7 +13974,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05180d69e3da0e530ba2a1dae5110317e49e3b7f3d41be227dc5f92e49ee7af"
 dependencies = [
- "num-bigint 0.4.4",
+ "num-bigint 0.4.6",
  "num-complex 0.4.4",
  "num-integer",
  "num-iter",
@@ -14005,22 +14007,20 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.4"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "608e7659b5c3d7cba262d894801b9ec9d00de989e8a82bd4bef91d08da45cdc0"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
- "autocfg",
  "num-integer",
  "num-traits",
 ]
 
 [[package]]
 name = "num-bigint-dig"
-version = "0.8.4"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc84195820f291c7697304f3cbdadd1cb7199c0efc917ff5eafd71225c136151"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
 dependencies = [
- "byteorder",
  "lazy_static",
  "libm",
  "num-integer",
@@ -14078,11 +14078,10 @@ dependencies = [
 
 [[package]]
 name = "num-integer"
-version = "0.1.45"
+version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
- "autocfg",
  "num-traits",
 ]
 
@@ -14116,7 +14115,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
 dependencies = [
  "autocfg",
- "num-bigint 0.4.4",
+ "num-bigint 0.4.6",
  "num-integer",
  "num-traits",
 ]
@@ -14615,7 +14614,7 @@ dependencies = [
  "hashbrown 0.14.3",
  "lz4_flex",
  "num 0.4.1",
- "num-bigint 0.4.4",
+ "num-bigint 0.4.6",
  "paste",
  "seq-macro",
  "thrift",
@@ -16390,9 +16389,9 @@ dependencies = [
 
 [[package]]
 name = "redis"
-version = "0.22.3"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa8455fa3621f6b41c514946de66ea0531f57ca017b2e6c7cc368035ea5b46df"
+checksum = "e902a69d09078829137b4a5d9d082e0490393537badd7c91a3d69d14639e115f"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -16401,20 +16400,23 @@ dependencies = [
  "futures",
  "futures-util",
  "itoa",
+ "num-bigint 0.4.6",
  "percent-encoding",
  "pin-project-lite",
  "ryu",
  "sha1_smol",
+ "socket2 0.5.5",
  "tokio",
+ "tokio-retry",
  "tokio-util 0.7.10",
  "url",
 ]
 
 [[package]]
 name = "redis-test"
-version = "0.1.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e9ceb100979db7292de8a3d4ecdde659cccc85133303ea0741e1618a5bd73df"
+checksum = "85fce0b77b4423c05a7d1525d167830ae5048e5d95b7f41c51c612269ac481fc"
 dependencies = [
  "futures",
  "redis",
@@ -16653,12 +16655,6 @@ dependencies = [
  "tracing",
  "wasm-timer",
 ]
-
-[[package]]
-name = "retain_mut"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4389f1d5789befaf6029ebd9f7dac4af7f7e3d61b69d4f30e2ac02b57e7712b0"
 
 [[package]]
 name = "retry-policies"
@@ -18017,7 +18013,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adc4e5204eb1910f40f9cfa375f6f05b68c3abac4b6fd879c8ff5e7ae8a0a085"
 dependencies = [
- "num-bigint 0.4.4",
+ "num-bigint 0.4.6",
  "num-traits",
  "thiserror 1.0.69",
  "time",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -761,12 +761,12 @@ rand_core = "0.5.1"
 random_word = "0.3.0"
 rapidhash = "1.4.0"
 rayon = "1.5.2"
-redis = { version = "0.22.3", features = [
+redis = { version = "0.26.1", features = [
     "tokio-comp",
     "script",
     "connection-manager",
 ] }
-redis-test = { version = "0.1.1", features = ["aio"] }
+redis-test = { version = "0.5.0", features = ["aio"] }
 ref-cast = "1.0.6"
 regex = "1.9.3"
 reqwest = { version = "0.11.11", features = [

--- a/aptos-move/aptos-gas-profiling/src/report.rs
+++ b/aptos-move/aptos-gas-profiling/src/report.rs
@@ -252,7 +252,7 @@ impl TransactionGasLog {
 
         // Dependencies (execution category - loading modules is CPU work)
         let mut deps = self.exec_io.dependencies.clone();
-        deps.sort_by(|lhs, rhs| rhs.cost.cmp(&lhs.cost));
+        deps.sort_by_key(|dep| std::cmp::Reverse(dep.cost));
         data.insert(
             "deps".to_string(),
             Value::Array(
@@ -394,7 +394,7 @@ impl TransactionGasLog {
 
         // Storage fees & refunds for state changes
         let mut storage_writes = self.storage.write_set_storage.clone();
-        storage_writes.sort_by(|lhs, rhs| rhs.cost.cmp(&lhs.cost));
+        storage_writes.sort_by_key(|write| std::cmp::Reverse(write.cost));
         data.insert(
             "storage-writes".to_string(),
             Value::Array(
@@ -425,7 +425,7 @@ impl TransactionGasLog {
 
         // Storage fees for events
         let mut storage_events = self.storage.events.clone();
-        storage_events.sort_by(|lhs, rhs| rhs.cost.cmp(&lhs.cost));
+        storage_events.sort_by_key(|event| std::cmp::Reverse(event.cost));
         data.insert(
             "storage-events".to_string(),
             Value::Array(

--- a/aptos-move/framework/natives/src/string_utils.rs
+++ b/aptos-move/framework/natives/src/string_utils.rs
@@ -113,7 +113,7 @@ fn format_vector<'a>(
         return Ok(());
     }
     print_space_or_newline(newline, out, depth + 1);
-    for (i, (ty, val)) in fields.zip(values.into_iter()).enumerate() {
+    for (i, (ty, val)) in fields.zip(values).enumerate() {
         if i > 0 {
             out.push(',');
             print_space_or_newline(newline, out, depth + 1);

--- a/crates/aptos-crypto/src/arkworks/msm.rs
+++ b/crates/aptos-crypto/src/arkworks/msm.rs
@@ -20,7 +20,7 @@ use std::{collections::HashMap, fmt::Debug};
 /// An MSM input consists of:
 /// * a list of base elements, and
 /// * a list of scalar elements,
-/// which are coupled pairwise.
+///   which are coupled pairwise.
 ///
 /// Implementations that construct an `MsmInput` should ensure that
 /// `bases.len() == scalars.len()`

--- a/crates/aptos-crypto/src/arkworks/shamir.rs
+++ b/crates/aptos-crypto/src/arkworks/shamir.rs
@@ -295,7 +295,7 @@ impl<F: FftField> ShamirThresholdConfig<F> {
     /// This method creates `n` shares of a secret using
     /// a `(t, n)` Shamir Secret Sharing scheme:
     /// 1. A random polynomial of degree `t-1` is given as input. We are deliberately generating
-    /// it outside of this file so it won't depend on the specific version of the `rand` crate.
+    ///    it outside of this file so it won't depend on the specific version of the `rand` crate.
     /// 2. The polynomial is evaluated over the `domain` using FFT to produce all evaluations,
     ///    which are subsequently trunked.
     pub fn share(&self, coeffs: &[F]) -> Vec<ShamirShare<F>> {

--- a/crates/aptos-crypto/src/multi_ed25519.rs
+++ b/crates/aptos-crypto/src/multi_ed25519.rs
@@ -358,7 +358,7 @@ impl MultiEd25519Signature {
         }
 
         let mut sorted_signatures = signatures;
-        sorted_signatures.sort_by(|a, b| a.1.cmp(&b.1));
+        sorted_signatures.sort_by_key(|a| a.1);
 
         let mut bitmap = [0u8; BITMAP_NUM_OF_BYTES];
 

--- a/crates/aptos-crypto/src/weighted_config.rs
+++ b/crates/aptos-crypto/src/weighted_config.rs
@@ -280,7 +280,7 @@ impl<TC: ThresholdConfig> WeightedConfig<TC> {
             .map(|(i, w)| (self.get_player(i), *w))
             .collect::<Vec<(Player, usize)>>();
 
-        player_and_weights.sort_by(|a, b| a.1.cmp(&b.1));
+        player_and_weights.sort_by_key(|a| a.1);
         player_and_weights
     }
 

--- a/crates/aptos-faucet/core/Cargo.toml
+++ b/crates/aptos-faucet/core/Cargo.toml
@@ -22,7 +22,7 @@ aptos-sdk = { workspace = true }
 async-trait = { workspace = true }
 captcha = { version = "0.0.9" }
 clap = { workspace = true }
-deadpool-redis = { version = "0.11.1", features = ["rt_tokio_1"], default-features = false }
+deadpool-redis = { version = "0.16.0", features = ["rt_tokio_1"], default-features = false }
 enum_dispatch = { workspace = true }
 firebase-token = { workspace = true }
 futures = { workspace = true }

--- a/crates/aptos-faucet/core/src/checkers/redis_ratelimit.rs
+++ b/crates/aptos-faucet/core/src/checkers/redis_ratelimit.rs
@@ -101,6 +101,7 @@ impl RedisRatelimitCheckerConfig {
                 db: self.database_number,
                 username: self.database_user.clone(),
                 password: self.database_password.clone(),
+                protocol: Default::default(),
             },
         }
     }
@@ -288,7 +289,7 @@ impl CheckerTrait for RedisRatelimitChecker {
                         .atomic()
                         .incr(&key, 1)
                         // Expire at the end of the day roughly.
-                        .expire(&key, seconds_until_next_day as usize)
+                        .expire(&key, seconds_until_next_day as i64)
                         // Only set the expiration if one isn't already set.
                         // Only works with Redis 7 sadly.
                         // .arg("NX")

--- a/ecosystem/indexer-grpc/indexer-grpc-cache-worker/src/worker.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-cache-worker/src/worker.rs
@@ -111,7 +111,7 @@ impl Worker {
         loop {
             let conn = self
                 .redis_client
-                .get_tokio_connection_manager()
+                .get_connection_manager()
                 .await
                 .context("Get redis connection failed.")?;
             let mut rpc_client = create_grpc_client(self.fullnode_grpc_address.clone()).await;

--- a/ecosystem/indexer-grpc/indexer-grpc-data-service/src/config.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-data-service/src/config.rs
@@ -164,7 +164,7 @@ impl RunnableConfig for IndexerGrpcDataServiceConfig {
             &self.redis_read_replica_address.0
         );
         let redis_conn = redis::Client::open(self.redis_read_replica_address.0.clone())?
-            .get_tokio_connection_manager()
+            .get_connection_manager()
             .await?;
         println!(">>>> Redis connection established");
         // InMemoryCache.

--- a/ecosystem/indexer-grpc/indexer-grpc-data-service/src/service.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-data-service/src/service.rs
@@ -387,7 +387,7 @@ async fn data_fetcher_task(
     let mut transactions_count = transactions_count;
 
     // Establish redis connection
-    let conn = match redis_client.get_tokio_connection_manager().await {
+    let conn = match redis_client.get_connection_manager().await {
         Ok(conn) => conn,
         Err(e) => {
             ERROR_COUNT

--- a/ecosystem/indexer-grpc/indexer-grpc-file-store/src/processor.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-file-store/src/processor.rs
@@ -48,7 +48,7 @@ impl Processor {
                     redis_main_instance_address.0
                 )
             })?
-            .get_tokio_connection_manager()
+            .get_connection_manager()
             .await
             .with_context(|| {
                 format!(

--- a/ecosystem/indexer-grpc/indexer-grpc-in-memory-cache-benchmark/src/main.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-in-memory-cache-benchmark/src/main.rs
@@ -54,13 +54,13 @@ fn mock_mget_transactions(starting_version: u64, count: usize, txn_size: usize) 
         .collect();
     let values = (0..count)
         .map(|i| {
-            redis::Value::Data(generate_transaction_bytes(
+            redis::Value::BulkString(generate_transaction_bytes(
                 starting_version + i as u64,
                 txn_size,
             ))
         })
         .collect();
-    let redis_resp = redis::Value::Bulk(values);
+    let redis_resp = redis::Value::Array(values);
     MockCmd::new(redis::cmd("MGET").arg(keys), Ok(redis_resp))
 }
 

--- a/ecosystem/indexer-grpc/indexer-grpc-utils/src/cache_operator.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-utils/src/cache_operator.rs
@@ -304,7 +304,7 @@ impl<T: redis::aio::ConnectionLike + Send + Clone> CacheOperator<T> {
         );
 
         let redis_result: RedisResult<()> =
-            redis_pipeline.query_async::<_, _>(&mut self.conn).await;
+            redis_pipeline.query_async::<()>(&mut self.conn).await;
 
         match redis_result {
             Ok(_) => Ok(()),

--- a/ecosystem/indexer-grpc/indexer-grpc-utils/src/in_memory_cache.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-utils/src/in_memory_cache.rs
@@ -400,7 +400,7 @@ mod tests {
         storage_format: StorageFormat,
         size: usize,
     ) -> redis::Value {
-        redis::Value::Bulk(
+        redis::Value::Array(
             (starting_version..starting_version + size as u64)
                 .map(|e| {
                     let txn = Transaction {
@@ -409,7 +409,7 @@ mod tests {
                         ..Default::default()
                     };
                     let cache_entry = CacheEntry::from_transaction(txn, storage_format);
-                    redis::Value::Data(cache_entry.into_inner())
+                    redis::Value::BulkString(cache_entry.into_inner())
                 })
                 .collect(),
         )

--- a/third_party/move/move-binary-format/src/deserializer.rs
+++ b/third_party/move/move-binary-format/src/deserializer.rs
@@ -546,7 +546,7 @@ fn read_table_contents<'a>(
 /// Tables cannot have duplicates, must cover the entire blob and must be disjoint.
 fn check_tables(tables: &mut Vec<Table>, binary_len: usize) -> BinaryLoaderResult<u32> {
     // there is no real reason to pass a mutable reference but we are sorting next line
-    tables.sort_by(|t1, t2| t1.offset.cmp(&t2.offset));
+    tables.sort_by_key(|t1| t1.offset);
 
     let mut current_offset: u32 = 0;
     let mut table_types = HashSet::new();

--- a/third_party/move/move-compiler-v2/legacy-move-compiler/src/parser/mod.rs
+++ b/third_party/move/move-compiler-v2/legacy-move-compiler/src/parser/mod.rs
@@ -61,7 +61,7 @@ pub(crate) fn parse_program(
         }
         // sort the filenames so errors about redefinitions, or other inter-file conflicts, are
         // deterministic
-        res.sort_by(|p1, p2| p1.path.cmp(&p2.path));
+        res.sort_by_key(|p1| p1.path);
         Ok(res)
     }
 

--- a/third_party/move/move-compiler-v2/src/bytecode_generator.rs
+++ b/third_party/move/move-compiler-v2/src/bytecode_generator.rs
@@ -1860,7 +1860,7 @@ impl Generator<'_> {
                         .iter()
                         .map(|exp| self.gen_escape_auto_ref_arg(exp, true))
                         .collect::<Vec<_>>();
-                    for (pat, temp) in pats.iter().zip(temps.into_iter()) {
+                    for (pat, temp) in pats.iter().zip(temps) {
                         self.gen_match_from_temp(
                             id,
                             pat,

--- a/third_party/move/move-compiler-v2/src/env_pipeline/inlining_optimization.rs
+++ b/third_party/move/move-compiler-v2/src/env_pipeline/inlining_optimization.rs
@@ -216,7 +216,7 @@ fn find_cycles_in_call_graph(
     for scc in kosaraju_scc(&graph) {
         if scc.len() > 1 {
             // cycle involving non-self-recursion
-            cycle_nodes.extend(scc.into_iter());
+            cycle_nodes.extend(scc);
         }
     }
     cycle_nodes
@@ -359,7 +359,7 @@ fn pick_from_eligible_and_compute_cost(
             locals_budget_remaining.checked_sub(callee_info.locals_per_site),
             code_size_budget_remaining.checked_sub(callee_info.code_size * sites.len()),
         ) {
-            call_sites_to_inline.extend(sites.into_iter());
+            call_sites_to_inline.extend(sites);
             // Note that we reduce the remaining budget for number of locals once for
             // all the callsites of a callee, because we expect to coalesce the locals at
             // different callsites.

--- a/third_party/move/move-prover/boogie-backend/src/lib.rs
+++ b/third_party/move/move-prover/boogie-backend/src/lib.rs
@@ -283,8 +283,8 @@ pub fn add_prelude(
     context.insert("tuple_instances", &tuple_instances);
     let table_key_instances = mono_info
         .table_inst
-        .iter()
-        .flat_map(|(_, ty_args)| ty_args.iter().map(|(kty, _)| kty))
+        .values()
+        .flat_map(|ty_args| ty_args.iter().map(|(kty, _)| kty))
         .unique()
         .map(|ty| TypeInfo::new(env, options, ty, false))
         .collect_vec();

--- a/third_party/move/move-prover/boogie-backend/src/options.rs
+++ b/third_party/move/move-prover/boogie-backend/src/options.rs
@@ -479,7 +479,7 @@ impl BoogieOptions {
             ));
         }
 
-        for (l, g) in lesser_parts.into_iter().zip(greater_parts.into_iter()) {
+        for (l, g) in lesser_parts.into_iter().zip(greater_parts) {
             let ln = l.parse::<usize>()?;
             let gn = g.parse::<usize>()?;
             if gn < ln {

--- a/third_party/move/move-prover/bytecode-pipeline/src/spec_inference.rs
+++ b/third_party/move/move-prover/bytecode-pipeline/src/spec_inference.rs
@@ -4656,11 +4656,7 @@ impl<'env> SpecInferenceAnalyzer<'env> {
             let mut conditions: Vec<Exp> = vec![];
             let mut block = def_block;
 
-            loop {
-                let Some(idom) = dom.immediate_dominator(block) else {
-                    break; // reached entry
-                };
-
+            while let Some(idom) = dom.immediate_dominator(block) {
                 // Check if the dominator block ends with a Branch
                 let idom_range = fwd_cfg.code_range(idom);
                 if !idom_range.is_empty() {

--- a/third_party/move/move-prover/src/inference.rs
+++ b/third_party/move/move-prover/src/inference.rs
@@ -413,7 +413,7 @@ fn output_to_files(env: &GlobalEnv, inferred_sym: Symbol, options: &Options) -> 
             // multiple new spec blocks all targeting `module_close_insert_pos`),
             // stable sort preserves declaration order — concatenate them into a
             // single insertion so `insert_str` produces the correct order.
-            insertions.sort_by(|a, b| b.0.cmp(&a.0));
+            insertions.sort_by_key(|b| std::cmp::Reverse(b.0));
             let mut merged = source;
             let mut i = 0;
             while i < insertions.len() {
@@ -660,7 +660,7 @@ fn output_unified(env: &GlobalEnv, inferred_sym: Symbol, options: &Options) -> a
 
         // Sort insertions by byte offset in reverse order so earlier offsets
         // aren't invalidated by prior insertions.
-        insertions.sort_by(|a, b| b.0.cmp(&a.0));
+        insertions.sort_by_key(|b| std::cmp::Reverse(b.0));
 
         let mut result = source;
         for (offset, text) in &insertions {

--- a/third_party/move/move-vm/runtime/src/runtime_type_checks.rs
+++ b/third_party/move/move-vm/runtime/src/runtime_type_checks.rs
@@ -192,10 +192,7 @@ pub fn verify_pack_closure(
     let expected_capture_tys = mask.extract(func.param_tys(), true);
 
     let given_capture_tys = operand_stack.popn_tys(expected_capture_tys.len() as u16)?;
-    for (expected, given) in expected_capture_tys
-        .into_iter()
-        .zip(given_capture_tys.into_iter())
-    {
+    for (expected, given) in expected_capture_tys.into_iter().zip(given_capture_tys) {
         expected.paranoid_check_is_no_ref("Captured argument type")?;
         with_instantiation(ty_builder, func, expected, |expected| {
             // Intersect the captured type with the accumulated abilities

--- a/third_party/move/tools/move-asm/src/assembler.rs
+++ b/third_party/move/tools/move-asm/src/assembler.rs
@@ -404,8 +404,8 @@ impl<'a> Assembler<'a> {
                 .require_resolution_context()
                 .local_map
                 .clone()
-                .into_iter()
-                .filter_map(|(_, r)| {
+                .into_values()
+                .filter_map(|r| {
                     if r.0 as usize >= locals_start {
                         Some(r)
                     } else {
@@ -413,7 +413,7 @@ impl<'a> Assembler<'a> {
                     }
                 })
                 .collect();
-            locals.sort_by(|e1, e2| e1.0.cmp(&e2.0));
+            locals.sort_by_key(|e1| e1.0);
             let res = self
                 .builder
                 .signature_index(locals.into_iter().map(|(_, ty)| ty).collect());

--- a/third_party/move/tools/move-coverage/src/coverage_map.rs
+++ b/third_party/move/tools/move-coverage/src/coverage_map.rs
@@ -267,8 +267,8 @@ impl ExecCoverageMap {
             .collect();
 
         let compiled_modules = modules
-            .into_iter()
-            .flat_map(|(_, module_map)| {
+            .into_values()
+            .flat_map(|module_map| {
                 module_map
                     .into_iter()
                     .map(|(_, (module_path, compiled_module))| (module_path, compiled_module))

--- a/third_party/move/tools/move-coverage/src/source_coverage.rs
+++ b/third_party/move/tools/move-coverage/src/source_coverage.rs
@@ -320,13 +320,12 @@ impl<'a> SourceCoverageBuilder<'a> {
                                 minimize_locations(fun_uncov.iter().map(|(loc, _)| *loc).collect());
                             // If any uncovered locations are the same as covered locations,
                             // remove them from uncovered locations.
-                            let uncovered_locations =
-                                BTreeSet::from_iter(uncovered_locations.into_iter())
-                                    .difference(&BTreeSet::from_iter(
-                                        covered_locations.iter().cloned(),
-                                    ))
-                                    .cloned()
-                                    .collect();
+                            let uncovered_locations = BTreeSet::from_iter(uncovered_locations)
+                                .difference(&BTreeSet::from_iter(
+                                    covered_locations.iter().cloned(),
+                                ))
+                                .cloned()
+                                .collect();
                             // Covered locations may be an over-approximation, so uncovered
                             // locations are subtracted from covered locations.
                             let covered_locations = subtract_locations(

--- a/third_party/move/tools/move-package/src/resolution/resolution_graph.rs
+++ b/third_party/move/tools/move-package/src/resolution/resolution_graph.rs
@@ -278,7 +278,7 @@ impl ResolvingGraph {
             .dependencies
             .clone()
             .into_iter()
-            .chain(additional_deps.into_iter())
+            .chain(additional_deps)
         {
             if let Some(std_version) = &override_std {
                 if let Some(std_lib) = StdLib::from_package_name(dep_name) {
@@ -768,8 +768,8 @@ impl ResolvedGraph {
 
     pub fn file_sources(&self) -> BTreeMap<FileHash, (Symbol, String)> {
         self.package_table
-            .iter()
-            .flat_map(|(_, rpkg)| {
+            .values()
+            .flat_map(|rpkg| {
                 rpkg.get_sources(&self.build_options)
                     .unwrap()
                     .iter()

--- a/third_party/move/tools/move-unit-test/src/package_test.rs
+++ b/third_party/move/tools/move-unit-test/src/package_test.rs
@@ -103,8 +103,8 @@ pub fn run_move_unit_tests_with_factory<W: Write + Send, F: UnitTestFactory + Se
     // messages.
     let dep_file_map: HashMap<_, _> = resolution_graph
         .package_table
-        .iter()
-        .flat_map(|(_, rpkg)| {
+        .values()
+        .flat_map(|rpkg| {
             rpkg.get_sources(&resolution_graph.build_options)
                 .unwrap()
                 .iter()

--- a/third_party/move/tools/move-unit-test/src/test_reporter.rs
+++ b/third_party/move/tools/move-unit-test/src/test_reporter.rs
@@ -480,15 +480,15 @@ impl TestStatistics {
     pub fn combine(mut self, other: Self) -> Self {
         for (module_id, test_result) in other.passed {
             let entry = self.passed.entry(module_id).or_default();
-            entry.extend(test_result.into_iter());
+            entry.extend(test_result);
         }
         for (module_id, test_result) in other.failed {
             let entry = self.failed.entry(module_id).or_default();
-            entry.extend(test_result.into_iter());
+            entry.extend(test_result);
         }
         for (module_id, test_output) in other.output {
             let entry = self.output.entry(module_id).or_default();
-            entry.extend(test_output.into_iter());
+            entry.extend(test_output);
         }
         self
     }

--- a/types/src/proptest_types.rs
+++ b/types/src/proptest_types.rs
@@ -219,7 +219,7 @@ impl AccountInfoUniverse {
                 AccountInfo::new(private_key, consensus_private_key)
             })
             .collect();
-        accounts.sort_by(|a, b| a.address.cmp(&b.address));
+        accounts.sort_by_key(|a| a.address);
         let validator_signer = ValidatorSigner::new(
             accounts[0].address,
             Arc::new(accounts[0].consensus_private_key.clone()),


### PR DESCRIPTION
## Description
This fixes the warning saying "redid and num-bigint-dig won't work in a future version of Rust"

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
