### PR TITLE
[consensus] Per-kind pull counters and inline batch cipher verification

### DIFF
--- a/consensus/consensus-types/src/common.rs
+++ b/consensus/consensus-types/src/common.rs
@@ -3,9 +3,9 @@
 
 use crate::{
     payload::{OptBatches, OptQuorumStorePayload, PayloadExecutionLimit, TxnAndGasLimits},
-    proof_of_store::{BatchInfoExt, ProofCache, ProofOfStore, TBatchInfo},
+    proof_of_store::{BatchInfoExt, BatchKind, ProofCache, ProofOfStore, TBatchInfo},
 };
-use anyhow::{bail, ensure};
+use anyhow::{bail, ensure, Context};
 use aptos_crypto::{
     hash::{CryptoHash, CryptoHasher},
     HashValue,
@@ -122,6 +122,51 @@ pub struct RejectedTransactionSummary {
     pub replay_protector: ReplayProtector,
     pub hash: HashValue,
     pub reason: DiscardedVMStatus,
+}
+
+/// Verify that transactions match the expected BatchKind:
+/// - Encrypted: all txns must be encrypted with valid ciphertext
+/// - Normal: no txns may be encrypted
+/// - None (V1): no encrypted txns allowed
+pub fn verify_batch_kind_transactions(
+    kind: Option<BatchKind>,
+    txns: &[SignedTransaction],
+) -> anyhow::Result<()> {
+    match kind {
+        Some(BatchKind::Encrypted) => {
+            txns.par_iter()
+                .with_min_len(24)
+                .try_for_each(|txn| -> anyhow::Result<()> {
+                    ensure!(
+                        txn.is_encrypted_txn(),
+                        "Encrypted batch contains non-encrypted transaction"
+                    );
+                    txn.payload()
+                        .as_encrypted_payload()
+                        .expect("already verified is_encrypted_txn")
+                        .verify(txn.sender())
+                        .context("Encrypted transaction ciphertext verification failed")
+                })?;
+        },
+        Some(BatchKind::Normal) => {
+            for txn in txns {
+                ensure!(
+                    !txn.is_encrypted_txn(),
+                    "Normal batch contains encrypted transaction"
+                );
+            }
+        },
+        None => {
+            // V1 batches do not support encrypted transactions
+            for txn in txns {
+                ensure!(
+                    !txn.is_encrypted_txn(),
+                    "V1 batch contains encrypted transaction"
+                );
+            }
+        },
+    }
+    Ok(())
 }
 
 /// Validates that a single batch's num_txns and num_bytes are within receiver-side limits.
@@ -316,6 +361,7 @@ impl Payload {
                 computed_digest,
                 batch.digest()
             );
+            verify_batch_kind_transactions(batch.batch_kind(), payload)?;
         }
         Ok(())
     }
@@ -594,11 +640,22 @@ impl fmt::Display for PayloadFilter {
 mod tests {
     use super::*;
     use crate::{
-        payload::{BatchPointer, OptBatches},
-        proof_of_store::BatchInfo,
+        payload::{
+            BatchPointer, InlineBatches, OptBatches, OptQuorumStorePayload,
+            PayloadExecutionLimit,
+        },
+        proof_of_store::{BatchInfo, ProofCache},
     };
-    use aptos_crypto::HashValue;
-    use aptos_types::validator_verifier::random_validator_verifier;
+    use aptos_crypto::{ed25519::Ed25519PrivateKey, HashValue, PrivateKey, SigningKey, Uniform};
+    use aptos_types::{
+        chain_id::ChainId,
+        secret_sharing::Ciphertext,
+        transaction::{
+            encrypted_payload::EncryptedPayload, RawTransaction, Script, TransactionExtraConfig,
+            TransactionPayload,
+        },
+        validator_verifier::random_validator_verifier,
+    };
 
     const MAX_BATCH_TXNS: u64 = 100;
     const MAX_BATCH_BYTES: u64 = 1024 * 1024;
@@ -707,5 +764,165 @@ mod tests {
             MAX_BATCH_BYTES,
         )
         .is_err());
+    }
+
+    fn create_normal_signed_transaction() -> SignedTransaction {
+        let private_key = Ed25519PrivateKey::generate_for_testing();
+        let public_key = private_key.public_key();
+        let raw_transaction = RawTransaction::new(
+            AccountAddress::random(),
+            0,
+            TransactionPayload::Script(Script::new(vec![], vec![], vec![])),
+            0,
+            0,
+            0,
+            ChainId::new(10),
+        );
+        let signature = private_key.sign(&raw_transaction).unwrap();
+        SignedTransaction::new(raw_transaction, public_key, signature)
+    }
+
+    fn create_encrypted_signed_transaction() -> SignedTransaction {
+        let private_key = Ed25519PrivateKey::generate_for_testing();
+        let public_key = private_key.public_key();
+        let encrypted_payload = EncryptedPayload::Encrypted {
+            ciphertext: Ciphertext::random(),
+            extra_config: TransactionExtraConfig::V1 {
+                multisig_address: None,
+                replay_protection_nonce: None,
+            },
+            payload_hash: HashValue::random(),
+            claimed_entry_fun: None,
+        };
+        let raw_transaction = RawTransaction::new(
+            AccountAddress::random(),
+            0,
+            TransactionPayload::EncryptedPayload(encrypted_payload),
+            0,
+            0,
+            0,
+            ChainId::new(10),
+        );
+        SignedTransaction::new(
+            raw_transaction,
+            public_key,
+            aptos_crypto::ed25519::Ed25519Signature::dummy_signature(),
+        )
+    }
+
+    fn make_batch_info_ext_v2_with_txns(
+        author: PeerId,
+        txns: &[SignedTransaction],
+        kind: BatchKind,
+    ) -> BatchInfoExt {
+        let batch_payload = BatchPayload::new(author, txns.to_vec());
+        let digest = batch_payload.hash();
+        let num_bytes = batch_payload.num_bytes() as u64;
+        BatchInfoExt::new_v2(
+            author,
+            aptos_types::quorum_store::BatchId::new_for_test(1),
+            1,
+            1000,
+            digest,
+            txns.len() as u64,
+            num_bytes,
+            0,
+            kind,
+        )
+    }
+
+    #[test]
+    fn test_verify_inline_batches_rejects_encrypted_batch_with_normal_txn() {
+        let author = PeerId::random();
+        let txns = vec![create_normal_signed_transaction()];
+        let batch = make_batch_info_ext_v2_with_txns(author, &txns, BatchKind::Encrypted);
+        let inline_batches = vec![(&batch, &txns)];
+
+        let err = Payload::verify_inline_batches(
+            inline_batches.into_iter(),
+            MAX_BATCH_TXNS,
+            MAX_BATCH_BYTES,
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("non-encrypted"),
+            "Expected non-encrypted error, got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_verify_inline_batches_rejects_normal_batch_with_encrypted_txn() {
+        let author = PeerId::random();
+        let txns = vec![create_encrypted_signed_transaction()];
+        let batch = make_batch_info_ext_v2_with_txns(author, &txns, BatchKind::Normal);
+        let inline_batches = vec![(&batch, &txns)];
+
+        let err = Payload::verify_inline_batches(
+            inline_batches.into_iter(),
+            MAX_BATCH_TXNS,
+            MAX_BATCH_BYTES,
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("encrypted transaction"),
+            "Expected encrypted transaction error, got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_verify_inline_batches_rejects_invalid_ciphertext() {
+        let author = PeerId::random();
+        // Ciphertext::random() produces ciphertext that won't verify against the sender
+        let txns = vec![create_encrypted_signed_transaction()];
+        let batch = make_batch_info_ext_v2_with_txns(author, &txns, BatchKind::Encrypted);
+        let inline_batches = vec![(&batch, &txns)];
+
+        let err = Payload::verify_inline_batches(
+            inline_batches.into_iter(),
+            MAX_BATCH_TXNS,
+            MAX_BATCH_BYTES,
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("ciphertext verification failed"),
+            "Expected ciphertext verification error, got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_payload_verify_rejects_encrypted_inline_batch_with_invalid_ciphertext() {
+        let (signers, validators) = random_validator_verifier(1, None, false);
+        let author = signers[0].author();
+        let proof_cache = ProofCache::new(16);
+
+        let txns = vec![create_encrypted_signed_transaction()];
+        let batch_info = make_batch_info_ext_v2_with_txns(author, &txns, BatchKind::Encrypted);
+        let inline_batches: InlineBatches<BatchInfoExt> = vec![(batch_info, txns)].into();
+
+        let payload = Payload::OptQuorumStore(OptQuorumStorePayload::new_v2(
+            inline_batches,
+            BatchPointer::new(vec![]),
+            BatchPointer::new(vec![]),
+            PayloadExecutionLimit::None,
+        ));
+
+        let err = payload
+            .verify(
+                &validators,
+                &proof_cache,
+                true,  // quorum_store_enabled
+                true,  // opt_qs_v2_rx_enabled
+                MAX_BATCH_TXNS,
+                MAX_BATCH_BYTES,
+            )
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("ciphertext verification failed"),
+            "Expected ciphertext verification error through Payload::verify, got: {}",
+            err
+        );
     }
 }

--- a/consensus/consensus-types/src/common.rs
+++ b/consensus/consensus-types/src/common.rs
@@ -641,8 +641,7 @@ mod tests {
     use super::*;
     use crate::{
         payload::{
-            BatchPointer, InlineBatches, OptBatches, OptQuorumStorePayload,
-            PayloadExecutionLimit,
+            BatchPointer, InlineBatches, OptBatches, OptQuorumStorePayload, PayloadExecutionLimit,
         },
         proof_of_store::{BatchInfo, ProofCache},
     };
@@ -668,6 +667,22 @@ mod tests {
             1000,
             HashValue::random(),
             num_txns,
+            num_bytes,
+            0,
+        )
+    }
+
+    fn make_batch_info_with_txns(author: PeerId, txns: &[SignedTransaction]) -> BatchInfo {
+        let batch_payload = BatchPayload::new(author, txns.to_vec());
+        let digest = batch_payload.hash();
+        let num_bytes = batch_payload.num_bytes() as u64;
+        BatchInfo::new(
+            author,
+            aptos_types::quorum_store::BatchId::new_for_test(1),
+            1,
+            1000,
+            digest,
+            txns.len() as u64,
             num_bytes,
             0,
         )
@@ -893,6 +908,27 @@ mod tests {
     }
 
     #[test]
+    fn test_verify_inline_batches_rejects_v1_batch_with_encrypted_txn() {
+        let author = PeerId::random();
+        let txns = vec![create_encrypted_signed_transaction()];
+        let batch = make_batch_info_with_txns(author, &txns);
+        let inline_batches = vec![(&batch, &txns)];
+
+        let err = Payload::verify_inline_batches(
+            inline_batches.into_iter(),
+            MAX_BATCH_TXNS,
+            MAX_BATCH_BYTES,
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("V1 batch contains encrypted transaction"),
+            "Expected V1 encrypted transaction error, got: {}",
+            err
+        );
+    }
+
+    #[test]
     fn test_payload_verify_rejects_encrypted_inline_batch_with_invalid_ciphertext() {
         let (signers, validators) = random_validator_verifier(1, None, false);
         let author = signers[0].author();
@@ -913,8 +949,8 @@ mod tests {
             .verify(
                 &validators,
                 &proof_cache,
-                true,  // quorum_store_enabled
-                true,  // opt_qs_v2_rx_enabled
+                true, // quorum_store_enabled
+                true, // opt_qs_v2_rx_enabled
                 MAX_BATCH_TXNS,
                 MAX_BATCH_BYTES,
             )

--- a/consensus/src/quorum_store/batch_proof_queue.rs
+++ b/consensus/src/quorum_store/batch_proof_queue.rs
@@ -575,6 +575,14 @@ impl BatchProofQueue {
             counters::BLOCK_BYTES_WHEN_PULL.observe(all_txns.size_in_bytes() as f64);
 
             counters::PROOF_SIZE_WHEN_PULL.observe(proof_of_stores.len() as f64);
+            for (kind, count) in &cur_txns_per_kind {
+                let kind_str = match kind {
+                    BatchKind::Normal => "normal",
+                    BatchKind::Encrypted => "encrypted",
+                };
+                counters::CONSENSUS_PULL_NUM_TXNS_PER_KIND
+                    .observe_with(&["proof", kind_str], *count as f64);
+            }
             // Number of proofs remaining in proof queue after the pull
             self.log_remaining_data_after_pull(&proof_of_stores);
         }
@@ -630,6 +638,14 @@ impl BatchProofQueue {
                 .observe_with(&["optbatch"], pulled_txns.count() as f64);
             counters::CONSENSUS_PULL_SIZE_IN_BYTES
                 .observe_with(&["optbatch"], pulled_txns.size_in_bytes() as f64);
+            for (kind, count) in &cur_txns_per_kind {
+                let kind_str = match kind {
+                    BatchKind::Normal => "normal",
+                    BatchKind::Encrypted => "encrypted",
+                };
+                counters::CONSENSUS_PULL_NUM_TXNS_PER_KIND
+                    .observe_with(&["optbatch", kind_str], *count as f64);
+            }
         }
 
         // Add pulled batches to session
@@ -692,7 +708,7 @@ impl BatchProofQueue {
         PayloadTxnsSize,
         u64,
     ) {
-        let (batches, pulled_txns, unique_txns, is_full, _cur_txns_per_kind) = self
+        let (batches, pulled_txns, unique_txns, is_full, cur_txns_per_kind) = self
             .pull_batches_internal(
                 session,
                 &HashSet::new(),
@@ -724,6 +740,14 @@ impl BatchProofQueue {
             counters::CONSENSUS_PULL_NUM_TXNS.observe_with(&["inline"], pulled_txns.count() as f64);
             counters::CONSENSUS_PULL_SIZE_IN_BYTES
                 .observe_with(&["inline"], pulled_txns.size_in_bytes() as f64);
+            for (kind, count) in &cur_txns_per_kind {
+                let kind_str = match kind {
+                    BatchKind::Normal => "normal",
+                    BatchKind::Encrypted => "encrypted",
+                };
+                counters::CONSENSUS_PULL_NUM_TXNS_PER_KIND
+                    .observe_with(&["inline", kind_str], *count as f64);
+            }
         }
         (result, pulled_txns, unique_txns)
     }

--- a/consensus/src/quorum_store/batch_proof_queue.rs
+++ b/consensus/src/quorum_store/batch_proof_queue.rs
@@ -136,6 +136,29 @@ impl<'a> PullSession<'a> {
     }
 }
 
+fn batch_kind_metric_label(kind: Option<BatchKind>) -> &'static str {
+    match kind {
+        Some(BatchKind::Normal) => "normal",
+        Some(BatchKind::Encrypted) => "encrypted",
+        None => "v1",
+    }
+}
+
+fn observe_pulled_txns_per_kind<'a, T: TBatchInfo + 'a>(
+    pull_kind: &str,
+    batches: impl Iterator<Item = &'a T>,
+) {
+    let mut txns_per_kind = HashMap::new();
+    for batch in batches {
+        *txns_per_kind.entry(batch.batch_kind()).or_insert(0) += batch.num_txns();
+    }
+
+    for (kind, count) in txns_per_kind {
+        counters::CONSENSUS_PULL_NUM_TXNS_PER_KIND
+            .observe_with(&[pull_kind, batch_kind_metric_label(kind)], count as f64);
+    }
+}
+
 pub struct BatchProofQueue {
     my_peer_id: PeerId,
     // Queue per peer for batches WITH proofs
@@ -575,14 +598,7 @@ impl BatchProofQueue {
             counters::BLOCK_BYTES_WHEN_PULL.observe(all_txns.size_in_bytes() as f64);
 
             counters::PROOF_SIZE_WHEN_PULL.observe(proof_of_stores.len() as f64);
-            for (kind, count) in &cur_txns_per_kind {
-                let kind_str = match kind {
-                    BatchKind::Normal => "normal",
-                    BatchKind::Encrypted => "encrypted",
-                };
-                counters::CONSENSUS_PULL_NUM_TXNS_PER_KIND
-                    .observe_with(&["proof", kind_str], *count as f64);
-            }
+            observe_pulled_txns_per_kind("proof", proof_of_stores.iter().map(|proof| proof.info()));
             // Number of proofs remaining in proof queue after the pull
             self.log_remaining_data_after_pull(&proof_of_stores);
         }
@@ -638,14 +654,7 @@ impl BatchProofQueue {
                 .observe_with(&["optbatch"], pulled_txns.count() as f64);
             counters::CONSENSUS_PULL_SIZE_IN_BYTES
                 .observe_with(&["optbatch"], pulled_txns.size_in_bytes() as f64);
-            for (kind, count) in &cur_txns_per_kind {
-                let kind_str = match kind {
-                    BatchKind::Normal => "normal",
-                    BatchKind::Encrypted => "encrypted",
-                };
-                counters::CONSENSUS_PULL_NUM_TXNS_PER_KIND
-                    .observe_with(&["optbatch", kind_str], *count as f64);
-            }
+            observe_pulled_txns_per_kind("optbatch", result.iter());
         }
 
         // Add pulled batches to session
@@ -708,7 +717,7 @@ impl BatchProofQueue {
         PayloadTxnsSize,
         u64,
     ) {
-        let (batches, pulled_txns, unique_txns, is_full, cur_txns_per_kind) = self
+        let (batches, pulled_txns, unique_txns, is_full, _cur_txns_per_kind) = self
             .pull_batches_internal(
                 session,
                 &HashSet::new(),
@@ -722,10 +731,10 @@ impl BatchProofQueue {
                 "inline",
             );
         let mut result = Vec::new();
-        for batch in batches.into_iter() {
+        for batch in &batches {
             if let Ok(mut persisted_value) = self.batch_store.get_batch_from_local(batch.digest()) {
                 if let Some(txns) = persisted_value.take_payload() {
-                    result.push((batch, txns));
+                    result.push((batch.clone(), txns));
                 }
             } else {
                 warn!(
@@ -740,14 +749,7 @@ impl BatchProofQueue {
             counters::CONSENSUS_PULL_NUM_TXNS.observe_with(&["inline"], pulled_txns.count() as f64);
             counters::CONSENSUS_PULL_SIZE_IN_BYTES
                 .observe_with(&["inline"], pulled_txns.size_in_bytes() as f64);
-            for (kind, count) in &cur_txns_per_kind {
-                let kind_str = match kind {
-                    BatchKind::Normal => "normal",
-                    BatchKind::Encrypted => "encrypted",
-                };
-                counters::CONSENSUS_PULL_NUM_TXNS_PER_KIND
-                    .observe_with(&["inline", kind_str], *count as f64);
-            }
+            observe_pulled_txns_per_kind("inline", batches.iter());
         }
         (result, pulled_txns, unique_txns)
     }

--- a/consensus/src/quorum_store/counters.rs
+++ b/consensus/src/quorum_store/counters.rs
@@ -341,7 +341,7 @@ pub static CONSENSUS_PULL_NUM_UNIQUE_TXNS: Lazy<HistogramVec> = Lazy::new(|| {
 pub static CONSENSUS_PULL_NUM_TXNS_PER_KIND: Lazy<HistogramVec> = Lazy::new(|| {
     register_histogram_vec!(
         "quorum_store_consensus_pull_num_txns_per_kind",
-        "Number of txns pulled for consensus, by pull kind and batch kind.",
+        "Number of txns pulled for consensus, by pull kind and batch kind (normal, encrypted, or v1).",
         &["pull_kind", "batch_kind"],
         TRANSACTION_COUNT_BUCKETS.clone(),
     )

--- a/consensus/src/quorum_store/counters.rs
+++ b/consensus/src/quorum_store/counters.rs
@@ -338,6 +338,16 @@ pub static CONSENSUS_PULL_NUM_UNIQUE_TXNS: Lazy<HistogramVec> = Lazy::new(|| {
     .unwrap()
 });
 
+pub static CONSENSUS_PULL_NUM_TXNS_PER_KIND: Lazy<HistogramVec> = Lazy::new(|| {
+    register_histogram_vec!(
+        "quorum_store_consensus_pull_num_txns_per_kind",
+        "Number of txns pulled for consensus, by pull kind and batch kind.",
+        &["pull_kind", "batch_kind"],
+        TRANSACTION_COUNT_BUCKETS.clone(),
+    )
+    .unwrap()
+});
+
 pub static CONSENSUS_PULL_SIZE_IN_BYTES: Lazy<HistogramVec> = Lazy::new(|| {
     register_histogram_vec!(
         "quorum_store_consensus_pull_size_in_bytes",

--- a/consensus/src/quorum_store/types.rs
+++ b/consensus/src/quorum_store/types.rs
@@ -1,18 +1,16 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-use anyhow::{ensure, Context};
+use anyhow::ensure;
 use aptos_consensus_types::{
     common::{BatchPayload, TxnSummaryWithExpiration},
     proof_of_store::{BatchInfo, BatchInfoExt, BatchKind, TBatchInfo},
 };
 use aptos_crypto::{hash::CryptoHash, HashValue};
-use aptos_experimental_runtimes::thread_manager::optimal_min_len;
 use aptos_types::{
     ledger_info::LedgerInfoWithSignatures, quorum_store::BatchId, transaction::SignedTransaction,
     validator_verifier::ValidatorVerifier, PeerId,
 };
-use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 use serde_name::{DeserializeNameAdapter, SerializeNameAdapter};
 use std::{
@@ -285,44 +283,10 @@ impl<T: TBatchInfo> Batch<T> {
             );
         }
 
-        // For V2 batches, validate that BatchKind matches the transaction types
-        if let Some(batch_kind) = self.batch_info.batch_kind() {
-            match batch_kind {
-                BatchKind::Encrypted => {
-                    let txns = self.payload.txns();
-                    // Ciphertext verification takes ~40us per txn (ED25519 sig check).
-                    txns.par_iter()
-                        .with_min_len(optimal_min_len(txns.len(), 24))
-                        .try_for_each(|txn| -> anyhow::Result<()> {
-                            ensure!(
-                                txn.is_encrypted_txn(),
-                                "Encrypted batch contains non-encrypted transaction"
-                            );
-                            txn.payload()
-                                .as_encrypted_payload()
-                                .expect("already verified is_encrypted_txn")
-                                .verify(txn.sender())
-                                .context("Encrypted transaction ciphertext verification failed")
-                        })?;
-                },
-                BatchKind::Normal => {
-                    for txn in self.payload.txns() {
-                        ensure!(
-                            !txn.is_encrypted_txn(),
-                            "Normal batch contains encrypted transaction"
-                        );
-                    }
-                },
-            }
-        } else {
-            // V1 batches do not support encrypted transactions
-            for txn in self.payload.txns() {
-                ensure!(
-                    !txn.is_encrypted_txn(),
-                    "V1 batch contains encrypted transaction (only supported in V2)"
-                );
-            }
-        }
+        aptos_consensus_types::common::verify_batch_kind_transactions(
+            self.batch_info.batch_kind(),
+            self.payload.txns(),
+        )?;
 
         Ok(())
     }

--- a/types/src/transaction/encrypted_payload.rs
+++ b/types/src/transaction/encrypted_payload.rs
@@ -6,7 +6,10 @@ use crate::{
     transaction::{TransactionExecutable, TransactionExecutableRef, TransactionExtraConfig},
 };
 use anyhow::{bail, Result};
-use aptos_batch_encryption::traits::{AssociatedData, Plaintext};
+use aptos_batch_encryption::{
+    schemes::fptx_weighted::FPTXWeighted,
+    traits::{AssociatedData, BatchThresholdEncryption, Plaintext},
+};
 use aptos_crypto::HashValue;
 use aptos_crypto_derive::{BCSCryptoHash, CryptoHasher};
 use move_core_types::{
@@ -232,6 +235,6 @@ impl EncryptedPayload {
 
     pub fn verify(&self, sender: AccountAddress) -> anyhow::Result<()> {
         let associated_data = PayloadAssociatedData::new(sender);
-        self.ciphertext().verify(&associated_data)
+        FPTXWeighted::verify_ct(self.ciphertext(), &associated_data)
     }
 }


### PR DESCRIPTION
## Summary
- Add `CONSENSUS_PULL_NUM_TXNS_PER_KIND` histogram with `["pull_kind", "batch_kind"]` labels to track pulled txns by BatchKind (Normal/Encrypted) across all three pull phases (proof, optbatch, inline)
- Fix security gap in `verify_inline_batches`: add ciphertext verification for encrypted inline batches and reject encrypted txns in normal batches, matching the existing `Batch::verify()` behavior

## Test plan
- [x] `cargo test -p aptos-consensus-types` — all 25 tests pass
- [x] `cargo check -p aptos-consensus` — compiles clean
- [x] New tests: `test_verify_inline_batches_rejects_encrypted_batch_with_normal_txn`, `test_verify_inline_batches_rejects_normal_batch_with_encrypted_txn`

🤖 Generated with [Claude Code](https://claude.com/claude-code)