### PR TITLE
[consensus] Add pull loop duration and empty retry metrics

### DIFF
--- a/consensus/src/counters.rs
+++ b/consensus/src/counters.rs
@@ -342,6 +342,26 @@ pub static WAIT_FOR_FULL_BLOCKS_TRIGGERED: Lazy<Histogram> = Lazy::new(|| {
     )
 });
 
+/// Duration of the full pull loop (outer loop with retries) in seconds
+pub static PULL_LOOP_DURATION: Lazy<Histogram> = Lazy::new(|| {
+    register_histogram!(
+        "aptos_consensus_pull_loop_duration_seconds",
+        "Duration of the full payload pull loop including retries",
+    )
+    .unwrap()
+});
+
+/// Number of empty retries in the pull loop before getting a payload
+pub static PULL_LOOP_EMPTY_RETRIES: Lazy<Histogram> = Lazy::new(|| {
+    register_histogram!(
+        "aptos_consensus_pull_loop_empty_retries",
+        "Number of empty retries in the pull loop",
+        // 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 retries (10 × 30ms = 300ms max)
+        vec![0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0],
+    )
+    .unwrap()
+});
+
 /// Counts when pipeline backpressure is triggered
 pub static PIPELINE_BACKPRESSURE_ON_PROPOSAL_TRIGGERED: Lazy<Histogram> = Lazy::new(|| {
     register_avg_counter(

--- a/consensus/src/counters.rs
+++ b/consensus/src/counters.rs
@@ -342,22 +342,32 @@ pub static WAIT_FOR_FULL_BLOCKS_TRIGGERED: Lazy<Histogram> = Lazy::new(|| {
     )
 });
 
-/// Duration of the full pull loop (outer loop with retries) in seconds
+/// Duration of the full pull loop (outer loop with retries) in seconds.
+/// Custom buckets cover 0–1s at 30ms granularity (matching NO_TXN_DELAY)
+/// so the 250–500ms default-bucket gap doesn't hide the 300ms poll ceiling.
 pub static PULL_LOOP_DURATION: Lazy<Histogram> = Lazy::new(|| {
     register_histogram!(
         "aptos_consensus_pull_loop_duration_seconds",
         "Duration of the full payload pull loop including retries",
+        // 30ms steps up to 330ms, then coarser up to 1s for non-default configs
+        vec![
+            0.005, 0.01, 0.03, 0.06, 0.09, 0.12, 0.15, 0.18, 0.21, 0.24, 0.27, 0.30, 0.33,
+            0.5, 0.75, 1.0,
+        ],
     )
     .unwrap()
 });
 
-/// Number of empty retries in the pull loop before getting a payload
+/// Number of empty retries in the pull loop before getting a payload.
+/// Buckets cover up to 34 retries (enough for 1000ms non-default poll time).
 pub static PULL_LOOP_EMPTY_RETRIES: Lazy<Histogram> = Lazy::new(|| {
     register_histogram!(
         "aptos_consensus_pull_loop_empty_retries",
         "Number of empty retries in the pull loop",
-        // 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 retries (10 × 30ms = 300ms max)
-        vec![0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0],
+        vec![
+            0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 15.0, 20.0, 25.0, 30.0,
+            35.0,
+        ],
     )
     .unwrap()
 });

--- a/consensus/src/counters.rs
+++ b/consensus/src/counters.rs
@@ -343,16 +343,17 @@ pub static WAIT_FOR_FULL_BLOCKS_TRIGGERED: Lazy<Histogram> = Lazy::new(|| {
 });
 
 /// Duration of the full pull loop (outer loop with retries) in seconds.
-/// Custom buckets cover 0–1s at 30ms granularity (matching NO_TXN_DELAY)
-/// so the 250–500ms default-bucket gap doesn't hide the 300ms poll ceiling.
+/// Custom buckets cover 0–1s so the 250–500ms default-bucket gap doesn't
+/// hide the 300ms poll ceiling.
 pub static PULL_LOOP_DURATION: Lazy<Histogram> = Lazy::new(|| {
     register_histogram!(
         "aptos_consensus_pull_loop_duration_seconds",
         "Duration of the full payload pull loop including retries",
-        // 30ms steps up to 330ms, then coarser up to 1s for non-default configs
+        // Sub-ms to 10ms for fast path, then 30ms steps (matching NO_TXN_DELAY)
+        // up to 330ms, then coarser up to 1s for non-default configs.
         vec![
-            0.005, 0.01, 0.03, 0.06, 0.09, 0.12, 0.15, 0.18, 0.21, 0.24, 0.27, 0.30, 0.33, 0.5,
-            0.75, 1.0,
+            0.001, 0.002, 0.005, 0.01, 0.03, 0.06, 0.09, 0.12, 0.15, 0.18, 0.21, 0.24, 0.27, 0.30,
+            0.33, 0.5, 0.75, 1.0,
         ],
     )
     .unwrap()

--- a/consensus/src/counters.rs
+++ b/consensus/src/counters.rs
@@ -351,8 +351,8 @@ pub static PULL_LOOP_DURATION: Lazy<Histogram> = Lazy::new(|| {
         "Duration of the full payload pull loop including retries",
         // 30ms steps up to 330ms, then coarser up to 1s for non-default configs
         vec![
-            0.005, 0.01, 0.03, 0.06, 0.09, 0.12, 0.15, 0.18, 0.21, 0.24, 0.27, 0.30, 0.33,
-            0.5, 0.75, 1.0,
+            0.005, 0.01, 0.03, 0.06, 0.09, 0.12, 0.15, 0.18, 0.21, 0.24, 0.27, 0.30, 0.33, 0.5,
+            0.75, 1.0,
         ],
     )
     .unwrap()
@@ -364,10 +364,7 @@ pub static PULL_LOOP_EMPTY_RETRIES: Lazy<Histogram> = Lazy::new(|| {
     register_histogram!(
         "aptos_consensus_pull_loop_empty_retries",
         "Number of empty retries in the pull loop",
-        vec![
-            0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 15.0, 20.0, 25.0, 30.0,
-            35.0,
-        ],
+        vec![0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 15.0, 20.0, 25.0, 30.0, 35.0,],
     )
     .unwrap()
 });

--- a/consensus/src/payload_client/user/quorum_store_client.rs
+++ b/consensus/src/payload_client/user/quorum_store_client.rs
@@ -2,7 +2,9 @@
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
-    counters::WAIT_FOR_FULL_BLOCKS_TRIGGERED, error::QuorumStoreError, monitor,
+    counters::{PULL_LOOP_DURATION, PULL_LOOP_EMPTY_RETRIES, WAIT_FOR_FULL_BLOCKS_TRIGGERED},
+    error::QuorumStoreError,
+    monitor,
     payload_client::user::UserPayloadClient,
 };
 use aptos_consensus_types::{
@@ -105,6 +107,7 @@ impl UserPayloadClient for QuorumStoreClient {
         });
         // keep polling QuorumStore until there's payloads available or there's still pending payloads
         let start_time = Instant::now();
+        let mut empty_retries: u64 = 0;
 
         let payload = loop {
             // Make sure we don't wait more than expected, due to thread scheduling delays/processing time consumed
@@ -122,15 +125,20 @@ impl UserPayloadClient for QuorumStoreClient {
                 )
                 .await?;
             if payload.is_empty() && !return_empty && !done {
+                empty_retries += 1;
                 sleep(Duration::from_millis(NO_TXN_DELAY)).await;
                 continue;
             }
             break payload;
         };
+        let pull_duration = start_time.elapsed();
+        PULL_LOOP_DURATION.observe(pull_duration.as_secs_f64());
+        PULL_LOOP_EMPTY_RETRIES.observe(empty_retries as f64);
         debug!(
             pull_params = ?params,
-            duration_ms = start_time.elapsed().as_millis() as u64,
+            duration_ms = pull_duration.as_millis() as u64,
             payload_len = payload.len(),
+            empty_retries = empty_retries,
             return_empty = return_empty,
             return_non_full = return_non_full,
             "Pull payloads from QuorumStore: proposal"


### PR DESCRIPTION
## Summary
- Add `aptos_consensus_pull_loop_duration_seconds` histogram to measure the full payload pull loop duration (including all 30ms empty retries)
- Add `aptos_consensus_pull_loop_empty_retries` histogram to count how many times the pull loop retried with empty QS responses before getting a payload
- These metrics will help confirm whether the high P99 in `generate_and_send_opt_proposal` (up to 367ms on some validators) is caused by the pull loop sleeping 30ms per retry when QS has no batches ready

## Context
Investigation of mainnet proposal generation latency showed:
- `generate_and_send_opt_proposal` P99 varies from 5ms to 367ms across validators
- Individual `pull_payload` (single QS request) P99 is ~5ms for all validators
- `proposal_delay` (backpressure) is 0 for all validators
- The gap is hypothesized to be the pull loop retry with `NO_TXN_DELAY=30ms` sleeps, but no existing metric directly measures this

## Test plan
- [x] `cargo check -p aptos-consensus` passes
- [x] `./scripts/rust_lint.sh` passes
- [ ] Deploy to mainnet validators and compare `pull_loop_duration` P99 against `generate_and_send_opt_proposal` P99
- [ ] Verify `empty_retries` distribution shows staircase pattern (0, 1, 2, ... retries)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to new Prometheus histograms and lightweight observations around the existing payload pull loop; no consensus logic or data flow behavior is modified.
> 
> **Overview**
> Adds two new consensus Prometheus histograms to instrument QuorumStore payload polling: `aptos_consensus_pull_loop_duration_seconds` (end-to-end loop duration with custom sub-second buckets) and `aptos_consensus_pull_loop_empty_retries` (count of empty QS responses before a payload is returned).
> 
> Updates `QuorumStoreClient::pull` to track empty-retry iterations, emit both metrics after the loop, and include `empty_retries` in the debug log.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f26573eafcd08a03d357e10ff85bd0d0296a695c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->