### PR TITLE
[consensus] Set block timestamp after payload pull

### DIFF
--- a/consensus/src/liveness/proposal_generator.rs
+++ b/consensus/src/liveness/proposal_generator.rs
@@ -593,7 +593,8 @@ impl ProposalGenerator {
         // All proposed blocks in a branch are guaranteed to have increasing timestamps
         // since their predecessor block will not be added to the BlockStore until
         // the local time exceeds it.
-        let timestamp = self.time_service.get_current_timestamp();
+        // Use a pre-pull timestamp for backpressure calculation and batch age filtering.
+        let pre_pull_timestamp = self.time_service.get_current_timestamp();
 
         let voting_power_ratio = proposer_election.get_voting_power_participation_ratio(round);
 
@@ -604,7 +605,7 @@ impl ProposalGenerator {
             block_gas_limit_override,
             proposal_delay,
         ) = self
-            .calculate_max_block_sizes(voting_power_ratio, timestamp, round)
+            .calculate_max_block_sizes(voting_power_ratio, pre_pull_timestamp, round)
             .await;
 
         PROPOSER_MAX_BLOCK_TXNS_AFTER_FILTERING.observe(max_block_txns_after_filtering as f64);
@@ -659,7 +660,7 @@ impl ProposalGenerator {
                     pending_ordering,
                     pending_uncommitted_blocks: pending_blocks.len(),
                     recent_max_fill_fraction: max_fill_fraction,
-                    block_timestamp: timestamp,
+                    block_timestamp: pre_pull_timestamp,
                 },
                 validator_txn_filter,
             )
@@ -677,6 +678,12 @@ impl ProposalGenerator {
         } else if block_gas_limit_override.is_some() {
             payload = payload.transform_to_quorum_store_v2(None, block_gas_limit_override);
         }
+
+        // Set the block timestamp AFTER pulling the payload so it reflects when the
+        // block was actually assembled, not when proposal generation started. This
+        // avoids stale timestamps when the pull loop takes time waiting for batches
+        // (up to quorum_store_poll_time).
+        let timestamp = self.time_service.get_current_timestamp();
         Ok((validator_txns, payload, timestamp.as_micros() as u64))
     }
 


### PR DESCRIPTION
## Summary
- Move the block timestamp from before `pull_payload` to after, so it reflects when the block was actually assembled
- Currently the timestamp is set before the payload pull loop, which can take up to 300ms (retrying every 30ms when QS has no batches). This makes the block timestamp stale by the pull duration

## Motivation
Investigation of mainnet Asian node latency (PR #19438 tracing) revealed that `BlockProposed` timestamps in TxnTrace can be misleadingly early. For example, in one observed round the block timestamp was set 125ms before the proposal was actually broadcast, because the leader spent 125ms in the pull loop waiting for batches to arrive from geographically distant validators.

This distorts cross-node latency analysis: the block timestamp appears close to the mempool insert time (suggesting low latency) when in reality the proposal was broadcast much later.

## Impact
- Block timestamps more accurately reflect when the block was assembled
- TxnTrace `BlockProposed` stage becomes a reliable marker for when the proposal was ready
- No change to consensus safety — the monotonically increasing timestamp invariant is preserved since post-pull time >= pre-pull time >= parent timestamp

## Test plan
- [x] `cargo check -p aptos-consensus` passes
- [x] `./scripts/rust_lint.sh` passes
- [ ] Deploy to testnet and verify block timestamps are slightly later (by pull loop duration) compared to before
- [ ] Verify TxnTrace `BlockProposed` timestamps align with `NetworkReceiveOptProposal` timestamps on nearby validators

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches consensus proposal generation timing; while intended to improve timestamp accuracy, it changes the timestamp included in proposals and could affect time-based logic/metrics if any components assume the pre-pull value.
> 
> **Overview**
> Proposal generation now captures a `pre_pull_timestamp` for backpressure/batch-age filtering and passes that into `calculate_max_block_sizes` and `PayloadPullParameters`.
> 
> The actual block timestamp written into the proposal is now taken *after* `pull_payload` completes, so it reflects when the block was assembled rather than when proposal generation started (avoiding stale timestamps during QuorumStore polling).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a97d2d1988e00683e51d131e66c481e8aed15864. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->