### PR TITLE
[build] Install clang 21 from LLVM apt repo in CI rust-setup action

### DIFF
--- a/.github/actions/rust-setup/action.yaml
+++ b/.github/actions/rust-setup/action.yaml
@@ -18,7 +18,13 @@ runs:
   steps:
     - if: ${{inputs.macos != 'true'}}
       name: Linux - Setup dependencies
-      run: sudo apt-get update && sudo apt-get install build-essential ca-certificates clang curl git libpq-dev libssl-dev pkg-config lsof lld --no-install-recommends --assume-yes
+      run: |
+        sudo apt-get update
+        sudo apt-get install build-essential ca-certificates curl git gnupg libpq-dev libssl-dev lsb-release lsof pkg-config software-properties-common wget --no-install-recommends --assume-yes
+        sudo bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)" llvm.sh 21
+        sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-21 100
+        sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-21 100
+        sudo update-alternatives --install /usr/bin/lld lld /usr/bin/lld-21 100
       shell: bash
 
     - uses: dsherret/rust-toolchain-file@v1

--- a/docker/builder/builder.Dockerfile
+++ b/docker/builder/builder.Dockerfile
@@ -33,13 +33,13 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
         libpq-dev \
         libssl-dev \
         libudev-dev \
-        lld \
         lsb-release \
         pkg-config \
         wget \
     && bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)" llvm.sh ${CLANG_VERSION} \
     && update-alternatives --install /usr/bin/clang clang /usr/bin/clang-${CLANG_VERSION} 100 \
-    && update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-${CLANG_VERSION} 100
+    && update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-${CLANG_VERSION} 100 \
+    && update-alternatives --install /usr/bin/lld lld /usr/bin/lld-${CLANG_VERSION} 100
 
 
 ### Build Rust code ###

--- a/scripts/dev_setup.sh
+++ b/scripts/dev_setup.sh
@@ -121,7 +121,7 @@ function install_build_essentials {
   #fi
 }
 
-function install_clang {
+function install_clang_lld {
   PACKAGE_MANAGER=$1
   VERSION=${2:-21}
 
@@ -138,9 +138,13 @@ function install_clang {
     fi
     "${PRE_COMMAND[@]}" update-alternatives --install /usr/bin/clang clang "/usr/bin/clang-${VERSION}" 100
     "${PRE_COMMAND[@]}" update-alternatives --install /usr/bin/clang++ clang++ "/usr/bin/clang++-${VERSION}" 100
+    "${PRE_COMMAND[@]}" update-alternatives --install /usr/bin/lld lld "/usr/bin/lld-${VERSION}" 100
   else
     install_pkg clang "$PACKAGE_MANAGER"
     install_pkg llvm "$PACKAGE_MANAGER"
+    if [[ "$(uname)" == "Linux" ]]; then
+      install_pkg lld "$PACKAGE_MANAGER"
+    fi
   fi
 }
 
@@ -724,13 +728,6 @@ function install_postgres {
   fi
 }
 
-function install_lld {
-  # Right now, only install lld for linux
-  if [[ "$(uname)" == "Linux" ]]; then
-    install_pkg lld "$PACKAGE_MANAGER"
-  fi
-}
-
 function install_libdw {
   # Right now, only install libdw for linux
   if [[ "$(uname)" == "Linux" && "$PACKAGE_MANAGER" != "pacman" ]]; then
@@ -1003,12 +1000,11 @@ install_pkg wget "$PACKAGE_MANAGER"
 if [[ "$INSTALL_BUILD_TOOLS" == "true" ]]; then
   install_build_essentials "$PACKAGE_MANAGER"
   install_pkg cmake "$PACKAGE_MANAGER"
-  install_clang "$PACKAGE_MANAGER"
+  install_clang_lld "$PACKAGE_MANAGER"
 
   install_openssl_dev "$PACKAGE_MANAGER"
   install_pkg_config "$PACKAGE_MANAGER"
 
-  install_lld
   install_libdw
 
   install_rustup "$BATCH_MODE"


### PR DESCRIPTION

The GitHub Actions `rust-setup` action was using the distro-default `clang`,
which is too old. Switch to installing clang 21 from `apt.llvm.org` via
`llvm.sh`, matching what the Docker builder and `dev_setup.sh` already do.

While here, also install `lld` from the same LLVM version instead of as a
separate system package, so the entire LLVM toolchain stays in sync across
CI, Docker, and local dev setup.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches CI setup and developer tooling installation; the main risk is build failures due to external `apt.llvm.org` availability or version mismatches in the LLVM toolchain.
> 
> **Overview**
> **Standardizes the LLVM toolchain to v21 across CI, Docker, and local setup.** The `rust-setup` GitHub Action now installs `clang`/`clang++`/`lld` 21 via `apt.llvm.org` and wires them through `update-alternatives`, instead of relying on distro packages.
> 
> Local `scripts/dev_setup.sh` is updated to install `lld` alongside `clang` (including `update-alternatives` on apt-based systems), removing the separate `install_lld` step so the linker stays in sync with the selected LLVM version. Docker builder setup is aligned by registering `lld` via `update-alternatives` for the configured `CLANG_VERSION`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ef088e10aa1f84182504efe3e8f1fd8bfa7c73b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->