### PR TITLE
Bind encrypted payload verification to sender auth keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -444,6 +444,7 @@ dependencies = [
  "anyhow",
  "aptos-api-test-context",
  "aptos-api-types",
+ "aptos-batch-encryption",
  "aptos-bcs-utils",
  "aptos-build-info",
  "aptos-cached-packages",

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -51,6 +51,7 @@ tokio = { workspace = true }
 
 [dev-dependencies]
 aptos-api-test-context = { workspace = true }
+aptos-batch-encryption = { workspace = true }
 aptos-cached-packages = { workspace = true, features = ["testing"] }
 aptos-framework = { workspace = true }
 aptos-gas-meter = { workspace = true }

--- a/api/src/tests/transactions_test.rs
+++ b/api/src/tests/transactions_test.rs
@@ -4,10 +4,15 @@
 use super::new_test_context;
 use crate::tests::{new_test_context_with_config, new_test_context_with_orderless_flags};
 use aptos_api_test_context::{assert_json, current_function_name, pretty, TestContext};
+use aptos_api_types::{AsConverter, UserTransactionRequest};
+use aptos_batch_encryption::{
+    schemes::fptx_weighted::FPTXWeighted, traits::BatchThresholdEncryption,
+};
 use aptos_config::config::{GasEstimationStaticOverride, NodeConfig, TransactionFilterConfig};
 use aptos_crypto::{
     ed25519::{Ed25519PrivateKey, Ed25519Signature},
     multi_ed25519::{MultiEd25519PrivateKey, MultiEd25519PublicKey},
+    weighted_config::WeightedConfigArkworks,
     PrivateKey, SigningKey, Uniform,
 };
 use aptos_sdk::types::{AccountKey, LocalAccount};
@@ -31,6 +36,57 @@ use rstest::rstest;
 use serde_json::{json, Value};
 use std::{path::PathBuf, time::Duration};
 use tokio::time::sleep;
+
+fn build_submit_transaction_request(
+    context: &TestContext,
+    txn: &SignedTransaction,
+) -> UserTransactionRequest {
+    let state_view = context.latest_state_view();
+    let converter = state_view.as_converter(context.db.clone(), None);
+    let payload = converter
+        .try_into_transaction_payload(txn.payload().clone())
+        .unwrap();
+    UserTransactionRequest::from((txn, payload))
+}
+
+fn build_json_encrypted_request_with_mismatched_authenticator(context: &mut TestContext) -> Value {
+    let threshold_config = WeightedConfigArkworks::new(1, vec![1]).unwrap();
+    let (encryption_key, _, _, _) =
+        FPTXWeighted::setup_for_testing(context.rng.r#gen(), 8, 1, &threshold_config).unwrap();
+    let encryption_key_bytes = bcs::to_bytes(&encryption_key).unwrap();
+
+    let transaction_factory = context.transaction_factory();
+    transaction_factory
+        .update_encryption_key_state(0, Some(&encryption_key_bytes))
+        .unwrap();
+
+    let sender_key = AccountKey::generate(&mut context.rng);
+    let sender_auth_key = AuthenticationKey::ed25519(sender_key.public_key());
+    let wrong_signer = AccountKey::generate(&mut context.rng);
+
+    let raw_txn = transaction_factory
+        .account_transfer(AccountAddress::ONE, 1)
+        .sender(sender_auth_key.account_address())
+        .auth_key(Some(sender_auth_key))
+        .sequence_number(0)
+        .expiration_timestamp_secs(context.get_expiration_time())
+        .upgrade_payload_with_rng(
+            &mut context.rng,
+            context.use_txn_payload_v2_format,
+            context.use_orderless_transactions,
+        )
+        .build();
+
+    let signed_txn = raw_txn
+        .sign(
+            wrong_signer.private_key(),
+            wrong_signer.public_key().clone(),
+        )
+        .unwrap()
+        .into_inner();
+
+    serde_json::to_value(build_submit_transaction_request(context, &signed_txn)).unwrap()
+}
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_deserialize_genesis_transaction() {
@@ -260,6 +316,39 @@ async fn test_post_invalid_signature_transaction(
     case(true, false),
     case(true, true)
 )]
+async fn test_post_json_encrypted_transaction_rejects_auth_key_mismatch(
+    use_txn_payload_v2_format: bool,
+    use_orderless_transactions: bool,
+) {
+    let mut node_config = NodeConfig::default();
+    node_config.api.allow_encrypted_txns_submission = true;
+    let mut context = new_test_context_with_config(
+        current_function_name!(),
+        node_config,
+        use_txn_payload_v2_format,
+        use_orderless_transactions,
+    );
+
+    let request = build_json_encrypted_request_with_mismatched_authenticator(&mut context);
+    let response = context
+        .expect_status_code(400)
+        .post("/transactions", request)
+        .await;
+
+    assert!(response["message"]
+        .as_str()
+        .unwrap()
+        .contains("Encrypted transaction payload could not be verified"));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[rstest(
+    use_txn_payload_v2_format,
+    use_orderless_transactions,
+    case(false, false),
+    case(true, false),
+    case(true, true)
+)]
 async fn test_post_transaction_rejected_by_mempool(
     use_txn_payload_v2_format: bool,
     use_orderless_transactions: bool,
@@ -380,6 +469,39 @@ async fn test_post_invalid_signature_transaction_batch(
         .post_bcs_txn("/transactions/batch", &body)
         .await;
     context.check_golden_output(resp);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[rstest(
+    use_txn_payload_v2_format,
+    use_orderless_transactions,
+    case(false, false),
+    case(true, false),
+    case(true, true)
+)]
+async fn test_post_json_encrypted_transaction_batch_rejects_auth_key_mismatch(
+    use_txn_payload_v2_format: bool,
+    use_orderless_transactions: bool,
+) {
+    let mut node_config = NodeConfig::default();
+    node_config.api.allow_encrypted_txns_submission = true;
+    let mut context = new_test_context_with_config(
+        current_function_name!(),
+        node_config,
+        use_txn_payload_v2_format,
+        use_orderless_transactions,
+    );
+
+    let request = build_json_encrypted_request_with_mismatched_authenticator(&mut context);
+    let response = context
+        .expect_status_code(400)
+        .post("/transactions/batch", json!([request]))
+        .await;
+
+    assert!(response["message"]
+        .as_str()
+        .unwrap()
+        .contains("Encrypted transaction payload could not be verified"));
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/api/src/transactions.rs
+++ b/api/src/transactions.rs
@@ -1248,6 +1248,10 @@ impl TransactionsApi {
                         AptosErrorCode::InvalidInput,
                         ledger_info,
                     )
+                })
+                .and_then(|signed_transaction| {
+                    self.validate_signed_transaction_payload(ledger_info, &signed_transaction)?;
+                    Ok(signed_transaction)
                 }),
         }
     }
@@ -1340,7 +1344,19 @@ impl TransactionsApi {
                     ));
                 }
 
-                if let Err(e) = payload.verify(signed_transaction.sender()) {
+                let auth_key = signed_transaction
+                    .authenticator()
+                    .sender()
+                    .authentication_key()
+                    .ok_or_else(|| {
+                        SubmitTransactionError::bad_request_with_code(
+                            "Encrypted transactions are not supported with this authenticator type",
+                            AptosErrorCode::InvalidInput,
+                            ledger_info,
+                        )
+                    })?;
+
+                if let Err(e) = payload.verify(signed_transaction.sender(), auth_key) {
                     return Err(SubmitTransactionError::bad_request_with_code(
                         e.context("Encrypted transaction payload could not be verified"),
                         AptosErrorCode::InvalidInput,
@@ -1431,6 +1447,10 @@ impl TransactionsApi {
                                 AptosErrorCode::InvalidInput,
                                 ledger_info,
                             )
+                        })
+                        .and_then(|signed_transaction| {
+                            self.validate_signed_transaction_payload(ledger_info, &signed_transaction)?;
+                            Ok(signed_transaction)
                         })
                 })
                 .collect(),

--- a/api/types/src/transaction.rs
+++ b/api/types/src/transaction.rs
@@ -26,14 +26,12 @@ use aptos_types::{
     function_info::FunctionInfo,
     jwks::{jwk::JWK, ProviderJWKs, QuorumCertifiedUpdate},
     keyless,
-    secret_sharing::Ciphertext,
     transaction::{
         authenticator::{
             AbstractAuthenticator, AccountAuthenticator, AnyPublicKey, AnySignature, MultiKey,
             MultiKeyAuthenticator, SingleKeyAuthenticator, TransactionAuthenticator,
             MAX_NUM_OF_SIGS,
         },
-        encrypted_payload::PayloadAssociatedData,
         webauthn::{PartialAuthenticatorAssertionResponse, MAX_WEBAUTHN_SIGNATURE_BYTES},
         Script, SignedTransaction, TransactionOutput, TransactionWithProof,
     },
@@ -493,20 +491,9 @@ pub struct UserTransactionRequestInner {
 impl VerifyInput for UserTransactionRequestInner {
     fn verify(&self) -> anyhow::Result<()> {
         self.payload.verify()?;
-        // Sender-dependent ciphertext verification for the JSON path.
-        // The BCS path does this in `validate_signed_transaction_payload`.
-        if let TransactionPayload::EncryptedTransactionPayload(
-            EncryptedTransactionPayload::Encrypted(ref p),
-        ) = self.payload
-        {
-            let ciphertext: Ciphertext = bcs::from_bytes(&p.ciphertext.0)
-                .context("Invalid ciphertext: failed to BCS-deserialize")?;
-            let sender = AccountAddress::from(self.sender);
-            let associated_data = PayloadAssociatedData::new(sender);
-            ciphertext
-                .verify(&associated_data)
-                .context("Ciphertext verification failed")?;
-        }
+        // Ciphertext verification for encrypted payloads is done in
+        // `validate_signed_transaction_payload` which has access to the full
+        // SignedTransaction (needed to extract the authenticator's auth_key).
         Ok(())
     }
 }
@@ -1228,9 +1215,9 @@ pub struct DecryptedPayload {
 }
 
 impl VerifyInput for EncryptedTransactionPayload {
-    /// Basic structural checks. Full ciphertext verification with sender happens in
-    /// `UserTransactionRequestInner::verify()` (JSON path) and
-    /// `validate_signed_transaction_payload` (BCS path).
+    /// Basic structural checks. Full ciphertext verification happens in
+    /// `validate_signed_transaction_payload`, after JSON or BCS requests are
+    /// converted into a `SignedTransaction`.
     fn verify(&self) -> anyhow::Result<()> {
         match self {
             EncryptedTransactionPayload::Encrypted(_) => Ok(()),

--- a/consensus/consensus-types/src/common.rs
+++ b/consensus/consensus-types/src/common.rs
@@ -141,10 +141,13 @@ pub fn verify_batch_kind_transactions(
                         txn.is_encrypted_txn(),
                         "Encrypted batch contains non-encrypted transaction"
                     );
+                    let auth_key = txn.authenticator().sender().authentication_key().context(
+                        "Encrypted transactions are not supported with this authenticator type",
+                    )?;
                     txn.payload()
                         .as_encrypted_payload()
                         .expect("already verified is_encrypted_txn")
-                        .verify(txn.sender())
+                        .verify(txn.sender(), auth_key)
                         .context("Encrypted transaction ciphertext verification failed")
                 })?;
         },

--- a/sdk/src/transaction_builder.rs
+++ b/sdk/src/transaction_builder.rs
@@ -42,6 +42,7 @@ pub struct TransactionBuilder {
     expiration_timestamp_secs: u64,
     chain_id: ChainId,
     encryption_key: Arc<RwLock<EncryptionKeyState>>,
+    auth_key: Option<AuthenticationKey>,
 }
 
 impl TransactionBuilder {
@@ -60,6 +61,7 @@ impl TransactionBuilder {
             sender: None,
             sequence_number: None,
             encryption_key: Arc::new(RwLock::new(EncryptionKeyState::default())),
+            auth_key: None,
         }
     }
 
@@ -93,6 +95,11 @@ impl TransactionBuilder {
         self
     }
 
+    pub fn auth_key(mut self, auth_key: Option<AuthenticationKey>) -> Self {
+        self.auth_key = auth_key;
+        self
+    }
+
     pub fn has_nonce(&self) -> bool {
         self.payload.replay_protection_nonce().is_some()
     }
@@ -123,6 +130,8 @@ impl TransactionBuilder {
             let encrypted_payload = TransactionFactory::encrypt_payload(
                 self.payload.clone(),
                 self.sender.expect("sender must have been set"),
+                self.auth_key
+                    .expect("auth_key must be set for encrypted payloads"),
                 encryption_key,
             )
             .expect("Payload must encrypt");
@@ -445,6 +454,7 @@ impl TransactionFactory {
             expiration_timestamp_secs: self.expiration_timestamp(),
             chain_id: self.chain_id,
             encryption_key: self.encryption_key.clone(),
+            auth_key: None,
         }
     }
 
@@ -453,6 +463,7 @@ impl TransactionFactory {
     fn encrypt_payload(
         payload: TransactionPayload,
         sender: AccountAddress,
+        auth_key: AuthenticationKey,
         encryption_key: &EncryptionKey,
     ) -> Result<EncryptedPayload> {
         // Convert payload to executable
@@ -465,8 +476,9 @@ impl TransactionFactory {
         // Create DecryptedPayload for encryption
         let decrypted_payload = DecryptedPayload::new(executable, decryption_nonce);
 
-        // Create associated data
-        let associated_data = PayloadAssociatedData::new(sender);
+        // Create associated data with sender and auth_key to bind the ciphertext
+        // to both the sender address and the authenticator's identity.
+        let associated_data = PayloadAssociatedData::new(sender, auth_key);
 
         // Encrypt the payload
         // Note: FPTXWeighted::encrypt requires CryptoRng from ark_std::rand, so we use StdRng
@@ -512,7 +524,12 @@ impl TransactionFactory {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use aptos_batch_encryption::traits::BatchThresholdEncryption;
+    use aptos_crypto::{
+        ed25519::Ed25519PrivateKey, weighted_config::WeightedConfigArkworks, PrivateKey, Uniform,
+    };
     use aptos_types::transaction::{ReplayProtector, TransactionPayload};
+    use rand::Rng;
 
     fn test_payload() -> TransactionPayload {
         aptos_stdlib::aptos_account_transfer(AccountAddress::ONE, 100)
@@ -562,5 +579,42 @@ mod tests {
             ReplayProtector::SequenceNumber(5)
         );
         assert!(raw_txn.payload_ref().replay_protection_nonce().is_none());
+    }
+
+    #[test]
+    fn test_encrypted_payload_verification_binds_sender_and_auth_key() {
+        let mut rng = rand::thread_rng();
+        let threshold_config = WeightedConfigArkworks::new(1, vec![1]).unwrap();
+        let (encryption_key, _, _, _) =
+            FPTXWeighted::setup_for_testing(rng.r#gen(), 8, 1, &threshold_config).unwrap();
+
+        let sender_private_key = Ed25519PrivateKey::generate_for_testing();
+        let sender_public_key = sender_private_key.public_key();
+        let sender_auth_key = AuthenticationKey::ed25519(&sender_public_key);
+        let sender = sender_auth_key.account_address();
+        let wrong_private_key = Ed25519PrivateKey::generate(&mut rand::thread_rng());
+        let wrong_auth_key = AuthenticationKey::ed25519(&wrong_private_key.public_key());
+        assert_ne!(wrong_auth_key, sender_auth_key);
+        let wrong_sender = if sender == AccountAddress::ONE {
+            AccountAddress::TWO
+        } else {
+            AccountAddress::ONE
+        };
+
+        let encrypted_payload = TransactionFactory::encrypt_payload(
+            test_payload(),
+            sender,
+            sender_auth_key,
+            &encryption_key,
+        )
+        .unwrap();
+
+        encrypted_payload
+            .verify(sender, sender_auth_key)
+            .expect("sender and auth_key used for encryption should verify");
+        assert!(encrypted_payload.verify(sender, wrong_auth_key).is_err());
+        assert!(encrypted_payload
+            .verify(wrong_sender, AuthenticationKey::ed25519(&sender_public_key))
+            .is_err());
     }
 }

--- a/sdk/src/types.rs
+++ b/sdk/src/types.rs
@@ -351,20 +351,22 @@ impl LocalAccount {
         self.auth.sign_transaction(txn)
     }
 
-    pub fn sign_with_transaction_builder(&self, builder: TransactionBuilder) -> SignedTransaction {
-        let raw_txn = if builder.has_nonce() {
+    fn build_raw_transaction(&self, builder: TransactionBuilder) -> RawTransaction {
+        let sequence_number = if builder.has_nonce() {
             // Do not increment sequence number for orderless transactions.
-            builder
-                .sender(self.address())
-                .sequence_number(u64::MAX)
-                .build()
+            u64::MAX
         } else {
-            builder
-                .sender(self.address())
-                .sequence_number(self.increment_sequence_number())
-                .build()
+            self.increment_sequence_number()
         };
-        self.sign_transaction(raw_txn)
+        builder
+            .auth_key(self.optional_authentication_key())
+            .sender(self.address())
+            .sequence_number(sequence_number)
+            .build()
+    }
+
+    pub fn sign_with_transaction_builder(&self, builder: TransactionBuilder) -> SignedTransaction {
+        self.sign_transaction(self.build_raw_transaction(builder))
     }
 
     pub fn sign_multi_agent_with_transaction_builder(
@@ -380,19 +382,7 @@ impl LocalAccount {
             .iter()
             .map(|signer| signer.private_key())
             .collect();
-
-        let raw_txn = if builder.has_nonce() {
-            // Do not increment sequence number for orderless transactions.
-            builder
-                .sender(self.address())
-                .sequence_number(u64::MAX)
-                .build()
-        } else {
-            builder
-                .sender(self.address())
-                .sequence_number(self.increment_sequence_number())
-                .build()
-        };
+        let raw_txn = self.build_raw_transaction(builder);
         raw_txn
             .sign_multi_agent(
                 self.private_key(),
@@ -417,18 +407,7 @@ impl LocalAccount {
             .iter()
             .map(|signer| signer.private_key())
             .collect();
-        let raw_txn = if builder.has_nonce() {
-            // Do not increment sequence number for orderless transactions.
-            builder
-                .sender(self.address())
-                .sequence_number(u64::MAX)
-                .build()
-        } else {
-            builder
-                .sender(self.address())
-                .sequence_number(self.increment_sequence_number())
-                .build()
-        };
+        let raw_txn = self.build_raw_transaction(builder);
         raw_txn
             .sign_fee_payer(
                 self.private_key(),
@@ -452,17 +431,7 @@ impl LocalAccount {
             .map(|signer| signer.address())
             .collect();
         let secondary_signer_auths = secondary_signers.iter().map(|a| a.auth()).collect();
-        let raw_txn = if builder.has_nonce() {
-            builder
-                .sender(self.address())
-                .sequence_number(u64::MAX)
-                .build()
-        } else {
-            builder
-                .sender(self.address())
-                .sequence_number(self.increment_sequence_number())
-                .build()
-        };
+        let raw_txn = self.build_raw_transaction(builder);
         raw_txn
             .sign_aa_transaction(
                 self.auth(),
@@ -509,6 +478,25 @@ impl LocalAccount {
             },
             LocalAccountAuthenticator::Abstraction(..) => todo!(),
             LocalAccountAuthenticator::DerivableAbstraction(..) => todo!(),
+        }
+    }
+
+    fn optional_authentication_key(&self) -> Option<AuthenticationKey> {
+        match &self.auth {
+            LocalAccountAuthenticator::PrivateKey(key) => Some(key.authentication_key()),
+            LocalAccountAuthenticator::Keyless(keyless_account) => {
+                Some(keyless_account.authentication_key())
+            },
+            LocalAccountAuthenticator::FederatedKeyless(federated_keyless_account) => {
+                Some(federated_keyless_account.authentication_key())
+            },
+            LocalAccountAuthenticator::Abstraction(..) => None,
+            LocalAccountAuthenticator::DerivableAbstraction(account) => {
+                Some(AuthenticationKey::domain_abstraction_address(
+                    bcs::to_bytes(&account.function_info).expect("FunctionInfo must serialize"),
+                    &account.account_identity,
+                ))
+            },
         }
     }
 
@@ -634,6 +622,7 @@ impl TransactionSigner for HardwareWalletAccount {
             .sender(self.address())
             .sequence_number(sequence_number)
             .expiration_timestamp_secs(seconds)
+            .auth_key(Some(AuthenticationKey::ed25519(self.public_key())))
             .build();
 
         if !orderless {
@@ -1270,6 +1259,32 @@ mod tests {
 
         // Test invalid private key hex literal.
         assert!(LocalAccount::from_private_key("invalid_private_key", 0).is_err());
+    }
+
+    #[test]
+    fn test_domain_aa_optional_authentication_key_matches_account_address() {
+        let function_info = FunctionInfo::new(
+            AccountAddress::ONE,
+            "test_module".to_owned(),
+            "test_function".to_owned(),
+        );
+        let account_identity = b"domain-aa-identity".to_vec();
+        let expected_auth_key = AuthenticationKey::domain_abstraction_address(
+            bcs::to_bytes(&function_info).unwrap(),
+            &account_identity,
+        );
+        let account = LocalAccount::new_domain_aa(
+            function_info,
+            account_identity,
+            Arc::new(|message| message.to_vec()),
+            0,
+        );
+
+        assert_eq!(
+            account.optional_authentication_key(),
+            Some(expected_auth_key)
+        );
+        assert_eq!(account.address(), expected_auth_key.account_address());
     }
 
     #[ignore]

--- a/types/src/transaction/authenticator.rs
+++ b/types/src/transaction/authenticator.rs
@@ -821,6 +821,36 @@ impl AccountAuthenticator {
         }
     }
 
+    /// Return the authentication key derived from `self`'s public key and scheme id,
+    /// or `None` for authenticator types that don't support stateless key derivation
+    /// (V1 Abstract, NoAccountAuthenticator).
+    pub fn authentication_key(&self) -> Option<AuthenticationKey> {
+        match self {
+            Self::Ed25519 { .. }
+            | Self::MultiEd25519 { .. }
+            | Self::SingleKey { .. }
+            | Self::MultiKey { .. } => Some(AuthenticationKey::from_preimage(
+                self.public_key_bytes(),
+                self.scheme(),
+            )),
+            Self::Abstract { authenticator } => {
+                match authenticator.auth_data().abstract_public_key() {
+                    Some(abstract_public_key) => {
+                        // DerivableV1: derive auth key from function_info + abstract_public_key
+                        let func_info_bytes = bcs::to_bytes(authenticator.function_info())
+                            .expect("FunctionInfo serialization should not fail");
+                        Some(AuthenticationKey::domain_abstraction_address(
+                            func_info_bytes,
+                            abstract_public_key,
+                        ))
+                    },
+                    None => None, // V1 Abstract: no public key available
+                }
+            },
+            Self::NoAccountAuthenticator => None,
+        }
+    }
+
     /// Return an authentication proof derived from `self`'s public key and scheme id
     pub fn authentication_proof(&self) -> AuthenticationProof {
         match self {
@@ -1622,6 +1652,46 @@ mod tests {
     #[test]
     fn test_from_str_should_not_panic_by_given_empty_string() {
         assert!(AuthenticationKey::from_str("").is_err());
+    }
+
+    #[test]
+    fn authentication_key_derivation_matches_supported_authenticators() {
+        let sender = Ed25519PrivateKey::generate_for_testing();
+        let sender_pub = sender.public_key();
+        let ed25519_auth =
+            AccountAuthenticator::ed25519(sender_pub.clone(), Ed25519Signature::dummy_signature());
+        assert_eq!(
+            ed25519_auth.authentication_key(),
+            Some(AuthenticationKey::ed25519(&sender_pub)),
+        );
+
+        let function_info = FunctionInfo::new(
+            AccountAddress::ONE,
+            "test_module".to_owned(),
+            "test_function".to_owned(),
+        );
+        let abstract_public_key = b"derivable-auth-key".to_vec();
+        let derivable_auth = AccountAuthenticator::derivable_abstraction(
+            function_info.clone(),
+            vec![1, 2, 3],
+            vec![4, 5, 6],
+            abstract_public_key.clone(),
+        );
+        assert_eq!(
+            derivable_auth.authentication_key(),
+            Some(AuthenticationKey::domain_abstraction_address(
+                bcs::to_bytes(&function_info).unwrap(),
+                &abstract_public_key,
+            )),
+        );
+
+        let v1_abstract_auth =
+            AccountAuthenticator::abstraction(function_info, vec![7, 8, 9], vec![10, 11, 12]);
+        assert_eq!(v1_abstract_auth.authentication_key(), None);
+        assert_eq!(
+            AccountAuthenticator::NoAccountAuthenticator.authentication_key(),
+            None
+        );
     }
 
     #[test]

--- a/types/src/transaction/encrypted_payload.rs
+++ b/types/src/transaction/encrypted_payload.rs
@@ -3,13 +3,13 @@
 
 use crate::{
     secret_sharing::{Ciphertext, EvalProof},
-    transaction::{TransactionExecutable, TransactionExecutableRef, TransactionExtraConfig},
+    transaction::{
+        authenticator::AuthenticationKey, TransactionExecutable, TransactionExecutableRef,
+        TransactionExtraConfig,
+    },
 };
 use anyhow::{bail, Result};
-use aptos_batch_encryption::{
-    schemes::fptx_weighted::FPTXWeighted,
-    traits::{AssociatedData, BatchThresholdEncryption, Plaintext},
-};
+use aptos_batch_encryption::traits::{AssociatedData, Plaintext};
 use aptos_crypto::HashValue;
 use aptos_crypto_derive::{BCSCryptoHash, CryptoHasher};
 use move_core_types::{
@@ -43,11 +43,12 @@ impl Plaintext for DecryptedPayload {}
 #[derive(Clone, Debug, Hash, Eq, PartialEq, Serialize, Deserialize)]
 pub struct PayloadAssociatedData {
     sender: AccountAddress,
+    auth_key: AuthenticationKey,
 }
 
 impl PayloadAssociatedData {
-    pub fn new(sender: AccountAddress) -> Self {
-        Self { sender }
+    pub fn new(sender: AccountAddress, auth_key: AuthenticationKey) -> Self {
+        Self { sender, auth_key }
     }
 }
 
@@ -233,8 +234,12 @@ impl EncryptedPayload {
         // TODO(ibalajiarun): Avoid the clone
     }
 
-    pub fn verify(&self, sender: AccountAddress) -> anyhow::Result<()> {
-        let associated_data = PayloadAssociatedData::new(sender);
-        FPTXWeighted::verify_ct(self.ciphertext(), &associated_data)
+    pub fn verify(
+        &self,
+        sender: AccountAddress,
+        auth_key: AuthenticationKey,
+    ) -> anyhow::Result<()> {
+        let associated_data = PayloadAssociatedData::new(sender, auth_key);
+        self.ciphertext().verify(&associated_data)
     }
 }


### PR DESCRIPTION
## Summary
- bind encrypted payload associated data to both the sender address and the sender authenticator's derived authentication key
- reject encrypted transactions for authenticator types that cannot derive an auth key statelessly, and wire the auth key through SDK transaction construction
- add focused tests for auth key derivation and sender/auth-key ciphertext binding

## Testing
- cargo test -p aptos-types authentication_key_derivation_matches_supported_authenticators -- --nocapture
- cargo test -p aptos-sdk test_encrypted_payload_verification_binds_sender_and_auth_key -- --nocapture
- ./scripts/rust_lint.sh