### PR TITLE
Harden encrypted transaction decryption handling

### DIFF
--- a/api/doc/spec.json
+++ b/api/doc/spec.json
@@ -17840,6 +17840,7 @@
         "required": [
           "payload_hash",
           "ciphertext",
+          "encryption_epoch",
           "decrypted_payload",
           "decryption_nonce"
         ],
@@ -17856,6 +17857,9 @@
                 "description": "BCS-serialized ciphertext bytes, hex-encoded."
               }
             ]
+          },
+          "encryption_epoch": {
+            "$ref": "#/components/schemas/U64"
           },
           "claimed_entry_fun": {
             "$ref": "#/components/schemas/ClaimedEntryFunction"
@@ -18048,7 +18052,8 @@
         "description": "Payload is still encrypted and cannot be read.",
         "required": [
           "payload_hash",
-          "ciphertext"
+          "ciphertext",
+          "encryption_epoch"
         ],
         "properties": {
           "payload_hash": {
@@ -18063,6 +18068,9 @@
                 "description": "BCS-serialized ciphertext bytes, hex-encoded."
               }
             ]
+          },
+          "encryption_epoch": {
+            "$ref": "#/components/schemas/U64"
           },
           "claimed_entry_fun": {
             "$ref": "#/components/schemas/ClaimedEntryFunction"
@@ -18424,7 +18432,8 @@
         "description": "Decryption was attempted but failed.",
         "required": [
           "payload_hash",
-          "ciphertext"
+          "ciphertext",
+          "encryption_epoch"
         ],
         "properties": {
           "payload_hash": {
@@ -18439,6 +18448,9 @@
                 "description": "BCS-serialized ciphertext bytes, hex-encoded."
               }
             ]
+          },
+          "encryption_epoch": {
+            "$ref": "#/components/schemas/U64"
           },
           "claimed_entry_fun": {
             "$ref": "#/components/schemas/ClaimedEntryFunction"

--- a/api/doc/spec.json
+++ b/api/doc/spec.json
@@ -17864,7 +17864,7 @@
             "$ref": "#/components/schemas/EncryptedTransactionInnerPayload"
           },
           "decryption_nonce": {
-            "$ref": "#/components/schemas/U64"
+            "$ref": "#/components/schemas/HexEncodedBytes"
           }
         }
       },

--- a/api/doc/spec.yaml
+++ b/api/doc/spec.yaml
@@ -13288,6 +13288,7 @@ components:
       required:
       - payload_hash
       - ciphertext
+      - encryption_epoch
       - decrypted_payload
       - decryption_nonce
       properties:
@@ -13297,6 +13298,8 @@ components:
           allOf:
           - $ref: '#/components/schemas/HexEncodedBytes'
           - description: BCS-serialized ciphertext bytes, hex-encoded.
+        encryption_epoch:
+          $ref: '#/components/schemas/U64'
         claimed_entry_fun:
           $ref: '#/components/schemas/ClaimedEntryFunction'
         decrypted_payload:
@@ -13431,6 +13434,7 @@ components:
       required:
       - payload_hash
       - ciphertext
+      - encryption_epoch
       properties:
         payload_hash:
           $ref: '#/components/schemas/HashValue'
@@ -13438,6 +13442,8 @@ components:
           allOf:
           - $ref: '#/components/schemas/HexEncodedBytes'
           - description: BCS-serialized ciphertext bytes, hex-encoded.
+        encryption_epoch:
+          $ref: '#/components/schemas/U64'
         claimed_entry_fun:
           $ref: '#/components/schemas/ClaimedEntryFunction'
     EncryptedTransactionInnerPayload:
@@ -13678,6 +13684,7 @@ components:
       required:
       - payload_hash
       - ciphertext
+      - encryption_epoch
       properties:
         payload_hash:
           $ref: '#/components/schemas/HashValue'
@@ -13685,6 +13692,8 @@ components:
           allOf:
           - $ref: '#/components/schemas/HexEncodedBytes'
           - description: BCS-serialized ciphertext bytes, hex-encoded.
+        encryption_epoch:
+          $ref: '#/components/schemas/U64'
         claimed_entry_fun:
           $ref: '#/components/schemas/ClaimedEntryFunction'
     FederatedKeyless:

--- a/api/doc/spec.yaml
+++ b/api/doc/spec.yaml
@@ -13302,7 +13302,7 @@ components:
         decrypted_payload:
           $ref: '#/components/schemas/EncryptedTransactionInnerPayload'
         decryption_nonce:
-          $ref: '#/components/schemas/U64'
+          $ref: '#/components/schemas/HexEncodedBytes'
     DeleteModule:
       type: object
       description: Delete a module

--- a/api/types/src/convert.rs
+++ b/api/types/src/convert.rs
@@ -16,7 +16,7 @@ use crate::{
     HexEncodedBytes, MoveFunction, MoveModuleBytecode, MoveResource, MoveScriptBytecode, MoveType,
     MoveValue, PendingTransaction, ResourceGroup, ScriptPayload, ScriptWriteSet,
     SubmitTransactionRequest, Transaction, TransactionInfo, TransactionOnChainData,
-    TransactionPayload, U64, VersionedEvent, WriteSet, WriteSetChange, WriteSetPayload,
+    TransactionPayload, VersionedEvent, WriteSet, WriteSetChange, WriteSetPayload, U64,
 };
 use anyhow::{bail, ensure, format_err, Context as AnyhowContext, Result};
 use aptos_crypto::{hash::CryptoHash, HashValue};
@@ -489,41 +489,36 @@ impl<'a, S: StateView> MoveConverter<'a, S> {
                 let ciphertext = HexEncodedBytes::from(bcs::to_bytes(encrypted.ciphertext())?);
 
                 match encrypted {
-                    EP::Encrypted {
-                        payload_hash,
-                        encryption_epoch,
-                        claimed_entry_fun,
-                        ..
-                    } => TransactionPayload::EncryptedTransactionPayload(
+                    EP::Encrypted(inner) => TransactionPayload::EncryptedTransactionPayload(
                         EncryptedTransactionPayload::Encrypted(ApiEncryptedPayload {
-                            payload_hash: crate::HashValue::from(payload_hash),
+                            payload_hash: crate::HashValue::from(inner.payload_hash),
                             ciphertext: ciphertext.clone(),
-                            encryption_epoch: U64::from(encryption_epoch),
-                            claimed_entry_fun: into_api_claimed_entry_function(claimed_entry_fun),
+                            encryption_epoch: U64::from(inner.encryption_epoch),
+                            claimed_entry_fun: into_api_claimed_entry_function(
+                                inner.claimed_entry_fun.clone(),
+                            ),
                         }),
                     ),
-                    EP::FailedDecryption {
-                        payload_hash,
-                        encryption_epoch,
-                        claimed_entry_fun,
-                        ..
-                    } => TransactionPayload::EncryptedTransactionPayload(
-                        EncryptedTransactionPayload::FailedDecryption(ApiFailedDecryptionPayload {
-                            payload_hash: crate::HashValue::from(payload_hash),
-                            ciphertext: ciphertext.clone(),
-                            encryption_epoch: U64::from(encryption_epoch),
-                            claimed_entry_fun: into_api_claimed_entry_function(claimed_entry_fun),
-                        }),
-                    ),
+                    EP::FailedDecryption { original, .. } => {
+                        TransactionPayload::EncryptedTransactionPayload(
+                            EncryptedTransactionPayload::FailedDecryption(
+                                ApiFailedDecryptionPayload {
+                                    payload_hash: crate::HashValue::from(original.payload_hash),
+                                    ciphertext: ciphertext.clone(),
+                                    encryption_epoch: U64::from(original.encryption_epoch),
+                                    claimed_entry_fun: into_api_claimed_entry_function(
+                                        original.claimed_entry_fun.clone(),
+                                    ),
+                                },
+                            ),
+                        )
+                    },
                     EP::Decrypted {
-                        payload_hash,
-                        encryption_epoch,
-                        executable,
-                        decryption_nonce,
-                        claimed_entry_fun,
+                        original,
+                        decrypted,
                         ..
                     } => {
-                        let inner = match executable {
+                        let inner = match decrypted.executable() {
                             aptos_types::transaction::TransactionExecutable::EntryFunction(
                                 entry_function,
                             ) if multisig_address.is_some() => {
@@ -554,13 +549,15 @@ impl<'a, S: StateView> MoveConverter<'a, S> {
                         };
                         TransactionPayload::EncryptedTransactionPayload(
                             EncryptedTransactionPayload::Decrypted(ApiDecryptedPayload {
-                                payload_hash: crate::HashValue::from(payload_hash),
+                                payload_hash: crate::HashValue::from(original.payload_hash),
                                 ciphertext,
-                                encryption_epoch: U64::from(encryption_epoch),
+                                encryption_epoch: U64::from(original.encryption_epoch),
                                 decrypted_payload: inner,
-                                decryption_nonce: HexEncodedBytes::from(decryption_nonce.to_vec()),
+                                decryption_nonce: HexEncodedBytes::from(
+                                    decrypted.decryption_nonce().to_vec(),
+                                ),
                                 claimed_entry_fun: into_api_claimed_entry_function(
-                                    claimed_entry_fun,
+                                    original.claimed_entry_fun.clone(),
                                 ),
                             }),
                         )
@@ -1025,29 +1022,29 @@ impl<'a, S: StateView> MoveConverter<'a, S> {
                 // Only the Encrypted variant can be submitted; VerifyInput enforces this.
                 let (payload_hash, ciphertext_bytes, encryption_epoch, claimed_entry_fun) =
                     match encrypted {
-                    EncryptedTransactionPayload::Encrypted(p) => {
-                        (
+                        EncryptedTransactionPayload::Encrypted(p) => (
                             p.payload_hash,
                             p.ciphertext,
                             p.encryption_epoch,
                             p.claimed_entry_fun,
-                        )
-                    },
-                    _ => bail!("Only encrypted state payloads can be submitted"),
-                };
+                        ),
+                        _ => bail!("Only encrypted state payloads can be submitted"),
+                    };
                 let ciphertext: Ciphertext = bcs::from_bytes(&ciphertext_bytes.0)
                     .context("Failed to BCS-deserialize ciphertext")?;
                 let extra_config = ExtraConfig::V1 {
                     multisig_address: None,
                     replay_protection_nonce: nonce,
                 };
-                Target::EncryptedPayload(EncryptedPayload::Encrypted {
-                    ciphertext,
-                    extra_config,
-                    payload_hash: payload_hash.into(),
-                    encryption_epoch: encryption_epoch.into(),
-                    claimed_entry_fun: into_claimed_entry_fun(claimed_entry_fun),
-                })
+                Target::EncryptedPayload(EncryptedPayload::Encrypted(
+                    aptos_types::transaction::encrypted_payload::EncryptedInner {
+                        ciphertext,
+                        extra_config,
+                        payload_hash: payload_hash.into(),
+                        encryption_epoch: encryption_epoch.into(),
+                        claimed_entry_fun: into_claimed_entry_fun(claimed_entry_fun),
+                    },
+                ))
             },
             // Deprecated.
             TransactionPayload::ModuleBundlePayload(_) => {

--- a/api/types/src/convert.rs
+++ b/api/types/src/convert.rs
@@ -16,7 +16,7 @@ use crate::{
     HexEncodedBytes, MoveFunction, MoveModuleBytecode, MoveResource, MoveScriptBytecode, MoveType,
     MoveValue, PendingTransaction, ResourceGroup, ScriptPayload, ScriptWriteSet,
     SubmitTransactionRequest, Transaction, TransactionInfo, TransactionOnChainData,
-    TransactionPayload, VersionedEvent, WriteSet, WriteSetChange, WriteSetPayload,
+    TransactionPayload, U64, VersionedEvent, WriteSet, WriteSetChange, WriteSetPayload,
 };
 use anyhow::{bail, ensure, format_err, Context as AnyhowContext, Result};
 use aptos_crypto::{hash::CryptoHash, HashValue};
@@ -491,28 +491,33 @@ impl<'a, S: StateView> MoveConverter<'a, S> {
                 match encrypted {
                     EP::Encrypted {
                         payload_hash,
+                        encryption_epoch,
                         claimed_entry_fun,
                         ..
                     } => TransactionPayload::EncryptedTransactionPayload(
                         EncryptedTransactionPayload::Encrypted(ApiEncryptedPayload {
                             payload_hash: crate::HashValue::from(payload_hash),
                             ciphertext: ciphertext.clone(),
+                            encryption_epoch: U64::from(encryption_epoch),
                             claimed_entry_fun: into_api_claimed_entry_function(claimed_entry_fun),
                         }),
                     ),
                     EP::FailedDecryption {
                         payload_hash,
+                        encryption_epoch,
                         claimed_entry_fun,
                         ..
                     } => TransactionPayload::EncryptedTransactionPayload(
                         EncryptedTransactionPayload::FailedDecryption(ApiFailedDecryptionPayload {
                             payload_hash: crate::HashValue::from(payload_hash),
                             ciphertext: ciphertext.clone(),
+                            encryption_epoch: U64::from(encryption_epoch),
                             claimed_entry_fun: into_api_claimed_entry_function(claimed_entry_fun),
                         }),
                     ),
                     EP::Decrypted {
                         payload_hash,
+                        encryption_epoch,
                         executable,
                         decryption_nonce,
                         claimed_entry_fun,
@@ -551,6 +556,7 @@ impl<'a, S: StateView> MoveConverter<'a, S> {
                             EncryptedTransactionPayload::Decrypted(ApiDecryptedPayload {
                                 payload_hash: crate::HashValue::from(payload_hash),
                                 ciphertext,
+                                encryption_epoch: U64::from(encryption_epoch),
                                 decrypted_payload: inner,
                                 decryption_nonce: HexEncodedBytes::from(decryption_nonce.to_vec()),
                                 claimed_entry_fun: into_api_claimed_entry_function(
@@ -1017,9 +1023,15 @@ impl<'a, S: StateView> MoveConverter<'a, S> {
             },
             TransactionPayload::EncryptedTransactionPayload(encrypted) => {
                 // Only the Encrypted variant can be submitted; VerifyInput enforces this.
-                let (payload_hash, ciphertext_bytes, claimed_entry_fun) = match encrypted {
+                let (payload_hash, ciphertext_bytes, encryption_epoch, claimed_entry_fun) =
+                    match encrypted {
                     EncryptedTransactionPayload::Encrypted(p) => {
-                        (p.payload_hash, p.ciphertext, p.claimed_entry_fun)
+                        (
+                            p.payload_hash,
+                            p.ciphertext,
+                            p.encryption_epoch,
+                            p.claimed_entry_fun,
+                        )
                     },
                     _ => bail!("Only encrypted state payloads can be submitted"),
                 };
@@ -1033,6 +1045,7 @@ impl<'a, S: StateView> MoveConverter<'a, S> {
                     ciphertext,
                     extra_config,
                     payload_hash: payload_hash.into(),
+                    encryption_epoch: encryption_epoch.into(),
                     claimed_entry_fun: into_claimed_entry_fun(claimed_entry_fun),
                 })
             },

--- a/api/types/src/convert.rs
+++ b/api/types/src/convert.rs
@@ -16,7 +16,7 @@ use crate::{
     HexEncodedBytes, MoveFunction, MoveModuleBytecode, MoveResource, MoveScriptBytecode, MoveType,
     MoveValue, PendingTransaction, ResourceGroup, ScriptPayload, ScriptWriteSet,
     SubmitTransactionRequest, Transaction, TransactionInfo, TransactionOnChainData,
-    TransactionPayload, VersionedEvent, WriteSet, WriteSetChange, WriteSetPayload, U64,
+    TransactionPayload, VersionedEvent, WriteSet, WriteSetChange, WriteSetPayload,
 };
 use anyhow::{bail, ensure, format_err, Context as AnyhowContext, Result};
 use aptos_crypto::{hash::CryptoHash, HashValue};
@@ -552,7 +552,7 @@ impl<'a, S: StateView> MoveConverter<'a, S> {
                                 payload_hash: crate::HashValue::from(payload_hash),
                                 ciphertext,
                                 decrypted_payload: inner,
-                                decryption_nonce: U64::from(decryption_nonce),
+                                decryption_nonce: HexEncodedBytes::from(decryption_nonce.to_vec()),
                                 claimed_entry_fun: into_api_claimed_entry_function(
                                     claimed_entry_fun,
                                 ),

--- a/api/types/src/transaction.rs
+++ b/api/types/src/transaction.rs
@@ -1191,6 +1191,7 @@ pub struct EncryptedPayload {
     pub payload_hash: HashValue,
     /// BCS-serialized ciphertext bytes, hex-encoded.
     pub ciphertext: HexEncodedBytes,
+    pub encryption_epoch: U64,
     pub claimed_entry_fun: Option<ClaimedEntryFunction>,
 }
 
@@ -1200,6 +1201,7 @@ pub struct FailedDecryptionPayload {
     pub payload_hash: HashValue,
     /// BCS-serialized ciphertext bytes, hex-encoded.
     pub ciphertext: HexEncodedBytes,
+    pub encryption_epoch: U64,
     pub claimed_entry_fun: Option<ClaimedEntryFunction>,
 }
 
@@ -1209,6 +1211,7 @@ pub struct DecryptedPayload {
     pub payload_hash: HashValue,
     /// BCS-serialized ciphertext bytes, hex-encoded.
     pub ciphertext: HexEncodedBytes,
+    pub encryption_epoch: U64,
     pub claimed_entry_fun: Option<ClaimedEntryFunction>,
     pub decrypted_payload: EncryptedTransactionInnerPayload,
     pub decryption_nonce: HexEncodedBytes,

--- a/api/types/src/transaction.rs
+++ b/api/types/src/transaction.rs
@@ -1211,7 +1211,7 @@ pub struct DecryptedPayload {
     pub ciphertext: HexEncodedBytes,
     pub claimed_entry_fun: Option<ClaimedEntryFunction>,
     pub decrypted_payload: EncryptedTransactionInnerPayload,
-    pub decryption_nonce: U64,
+    pub decryption_nonce: HexEncodedBytes,
 }
 
 impl VerifyInput for EncryptedTransactionPayload {

--- a/aptos-move/e2e-move-tests/src/tests/vm.rs
+++ b/aptos-move/e2e-move-tests/src/tests/vm.rs
@@ -9,7 +9,7 @@ use aptos_types::{
     secret_sharing::{Ciphertext, EvalProof},
     state_store::state_key::StateKey,
     transaction::{
-        encrypted_payload::{DecryptionFailureReason, EncryptedPayload},
+        encrypted_payload::{DecryptionFailureReason, EncryptedInner, EncryptedPayload},
         ExecutionStatus, TransactionExtraConfig, TransactionPayload,
     },
     write_set::WriteOp,
@@ -81,26 +81,28 @@ fn failed_encrypted_transaction_increments_sequence_number() {
 
     // Sign the transaction in the Encrypted state (the original state before decryption
     // is attempted). The signature is verified against this state.
-    let encrypted_payload = EncryptedPayload::Encrypted {
+    let encrypted_payload = EncryptedPayload::Encrypted(EncryptedInner {
         ciphertext: ciphertext.clone(),
         extra_config: extra_config.clone(),
         payload_hash,
         encryption_epoch: 1,
         claimed_entry_fun: None,
-    };
+    });
     let payload = TransactionPayload::EncryptedPayload(encrypted_payload);
     let mut txn = h.create_transaction_payload(&sender, payload);
 
     // Mutate the payload to simulate a failed decryption attempt, as the block executor
     // would do after failing to decrypt the ciphertext.
     let failed_payload = EncryptedPayload::FailedDecryption {
-        ciphertext,
-        extra_config,
-        payload_hash,
-        encryption_epoch: 1,
+        original: EncryptedInner {
+            ciphertext,
+            extra_config,
+            payload_hash,
+            encryption_epoch: 1,
+            claimed_entry_fun: None,
+        },
         eval_proof: Some(EvalProof::random()),
         reason: DecryptionFailureReason::CryptoFailure,
-        claimed_entry_fun: None,
     };
     *txn.payload_mut() = TransactionPayload::EncryptedPayload(failed_payload);
 

--- a/aptos-move/e2e-move-tests/src/tests/vm.rs
+++ b/aptos-move/e2e-move-tests/src/tests/vm.rs
@@ -85,6 +85,7 @@ fn failed_encrypted_transaction_increments_sequence_number() {
         ciphertext: ciphertext.clone(),
         extra_config: extra_config.clone(),
         payload_hash,
+        encryption_epoch: 1,
         claimed_entry_fun: None,
     };
     let payload = TransactionPayload::EncryptedPayload(encrypted_payload);
@@ -96,6 +97,7 @@ fn failed_encrypted_transaction_increments_sequence_number() {
         ciphertext,
         extra_config,
         payload_hash,
+        encryption_epoch: 1,
         eval_proof: Some(EvalProof::random()),
         reason: DecryptionFailureReason::CryptoFailure,
         claimed_entry_fun: None,

--- a/consensus/consensus-types/src/common.rs
+++ b/consensus/consensus-types/src/common.rs
@@ -653,8 +653,8 @@ mod tests {
         chain_id::ChainId,
         secret_sharing::Ciphertext,
         transaction::{
-            encrypted_payload::EncryptedPayload, RawTransaction, Script, TransactionExtraConfig,
-            TransactionPayload,
+            encrypted_payload::{EncryptedInner, EncryptedPayload},
+            RawTransaction, Script, TransactionExtraConfig, TransactionPayload,
         },
         validator_verifier::random_validator_verifier,
     };
@@ -803,15 +803,16 @@ mod tests {
     fn create_encrypted_signed_transaction() -> SignedTransaction {
         let private_key = Ed25519PrivateKey::generate_for_testing();
         let public_key = private_key.public_key();
-        let encrypted_payload = EncryptedPayload::Encrypted {
+        let encrypted_payload = EncryptedPayload::Encrypted(EncryptedInner {
             ciphertext: Ciphertext::random(),
             extra_config: TransactionExtraConfig::V1 {
                 multisig_address: None,
                 replay_protection_nonce: None,
             },
             payload_hash: HashValue::random(),
+            encryption_epoch: 0,
             claimed_entry_fun: None,
-        };
+        });
         let raw_transaction = RawTransaction::new(
             AccountAddress::random(),
             0,

--- a/consensus/src/pipeline/decryption_pipeline_builder.rs
+++ b/consensus/src/pipeline/decryption_pipeline_builder.rs
@@ -25,7 +25,7 @@ use aptos_types::{
         SecretSharedKey,
     },
     transaction::{
-        encrypted_payload::{DecryptedPayload, DecryptionFailureReason, EncryptedPayload},
+        encrypted_payload::{DecryptedPlaintext, DecryptionFailureReason, EncryptedPayload},
         SignedTransaction,
     },
 };
@@ -411,37 +411,18 @@ async fn decrypt_validator_path(
                         let encrypted_payload = txn.payload_mut()
                             .as_encrypted_payload_mut()
                             .expect("must happen");
-                        if !encrypted_payload
-                            .verify_payload_hash(&payload)
-                            .expect("must be encrypted")
+                        match encrypted_payload
+                            .try_into_decrypted(eval_proof.clone(), payload)
                         {
-                            warn!(
-                                "transaction with ciphertext id {:?} has mismatching payload hash",
-                                id
-                            );
-                            num_failed_decryptions.fetch_add(1, Ordering::Relaxed);
-                            mark_txn_failed_decryption(
-                                txn,
-                                Some(eval_proof),
-                                DecryptionFailureReason::PayloadHashMismatch,
-                            )
-                        } else if !encrypted_payload.entry_fun_matches(&payload)
-                            .expect("must be encrypted") {
-                            warn!(
-                                "transaction with ciphertext id {:?} has mismatching entry function",
-                                id
-                            );
-                            num_failed_decryptions.fetch_add(1, Ordering::Relaxed);
-                            mark_txn_failed_decryption(
-                                txn,
-                                Some(eval_proof),
-                                DecryptionFailureReason::ClaimedEntryFunctionMismatch,
-                            )
-                        } else {
-                            let (executable, nonce) = payload.unwrap();
-                            encrypted_payload.into_decrypted(eval_proof, executable, nonce)
-                                .expect("must happen");
-                            txn
+                            Ok(()) => txn,
+                            Err(reason) => {
+                                warn!(
+                                    "transaction with ciphertext id {:?} rejected post-decryption: {:?}",
+                                    id, reason
+                                );
+                                num_failed_decryptions.fetch_add(1, Ordering::Relaxed);
+                                mark_txn_failed_decryption(txn, Some(eval_proof), reason)
+                            },
                         }
                     },
                     Err(e) => {
@@ -510,7 +491,7 @@ fn record_decryption_metrics(result: &DecryptionResult) {
                 DecryptionFailureReason::EpochMismatch => epoch_mismatch += 1,
                 DecryptionFailureReason::ClaimedEntryFunctionMismatch => entry_fun_mismatch += 1,
             },
-            EncryptedPayload::Encrypted { .. } => {
+            EncryptedPayload::Encrypted(_) => {
                 // Still in encrypted state — shouldn't happen after decryption pipeline
                 failed_decryption += 1;
             },
@@ -564,6 +545,6 @@ fn mark_txn_failed_decryption(
 fn do_final_decryption(
     decryption_key: &DecryptionKey,
     prepared_ciphertext_or_error: Result<PreparedCiphertext, MissingEvalProofError>,
-) -> anyhow::Result<DecryptedPayload> {
+) -> anyhow::Result<DecryptedPlaintext> {
     FPTXWeighted::decrypt(decryption_key, &prepared_ciphertext_or_error?)
 }

--- a/consensus/src/pipeline/decryption_pipeline_builder.rs
+++ b/consensus/src/pipeline/decryption_pipeline_builder.rs
@@ -385,6 +385,26 @@ async fn decrypt_validator_path(
             .zip(prepared_cts.into_par_iter())
             .map(|(mut txn, (id, prepared_ciphertext_or_error))| {
                 let eval_proof = proofs.get(&id).expect("must exist");
+                let payload_encryption_epoch = txn
+                    .payload()
+                    .as_encrypted_payload()
+                    .expect("must happen")
+                    .encryption_epoch();
+
+                if payload_encryption_epoch != decryption_key.metadata.epoch {
+                    warn!(
+                        "transaction with ciphertext id {:?} has encryption epoch {} but decryption key epoch {}",
+                        id,
+                        payload_encryption_epoch,
+                        decryption_key.metadata.epoch,
+                    );
+                    num_failed_decryptions.fetch_add(1, Ordering::Relaxed);
+                    return mark_txn_failed_decryption(
+                        txn,
+                        Some(eval_proof),
+                        DecryptionFailureReason::EpochMismatch,
+                    );
+                }
 
                 match do_final_decryption(&decryption_key.key, prepared_ciphertext_or_error) {
                     Ok(payload) => {
@@ -472,6 +492,7 @@ fn record_decryption_metrics(result: &DecryptionResult) {
     let mut key_unavailable = 0u64;
     let mut batch_limit_exceeded = 0u64;
     let mut payload_hash_mismatch = 0u64;
+    let mut epoch_mismatch = 0u64;
     let mut entry_fun_mismatch = 0u64;
 
     for txn in &result.decrypted_txns {
@@ -486,6 +507,7 @@ fn record_decryption_metrics(result: &DecryptionResult) {
                 DecryptionFailureReason::ConfigUnavailable => config_unavailable += 1,
                 DecryptionFailureReason::DecryptionKeyUnavailable => key_unavailable += 1,
                 DecryptionFailureReason::PayloadHashMismatch => payload_hash_mismatch += 1,
+                DecryptionFailureReason::EpochMismatch => epoch_mismatch += 1,
                 DecryptionFailureReason::ClaimedEntryFunctionMismatch => entry_fun_mismatch += 1,
             },
             EncryptedPayload::Encrypted { .. } => {
@@ -504,6 +526,7 @@ fn record_decryption_metrics(result: &DecryptionResult) {
         ("key_unavailable", key_unavailable),
         ("batch_limit_exceeded", batch_limit_exceeded),
         ("payload_hash_mismatch", payload_hash_mismatch),
+        ("epoch_mismatch", epoch_mismatch),
         ("entry_fun_mismatch", entry_fun_mismatch),
         ("unencrypted", unencrypted),
     ];

--- a/consensus/src/pipeline/decryption_pipeline_builder.rs
+++ b/consensus/src/pipeline/decryption_pipeline_builder.rs
@@ -391,7 +391,21 @@ async fn decrypt_validator_path(
                         let encrypted_payload = txn.payload_mut()
                             .as_encrypted_payload_mut()
                             .expect("must happen");
-                        if !encrypted_payload.entry_fun_matches(&payload)
+                        if !encrypted_payload
+                            .verify_payload_hash(&payload)
+                            .expect("must be encrypted")
+                        {
+                            warn!(
+                                "transaction with ciphertext id {:?} has mismatching payload hash",
+                                id
+                            );
+                            num_failed_decryptions.fetch_add(1, Ordering::Relaxed);
+                            mark_txn_failed_decryption(
+                                txn,
+                                Some(eval_proof),
+                                DecryptionFailureReason::PayloadHashMismatch,
+                            )
+                        } else if !encrypted_payload.entry_fun_matches(&payload)
                             .expect("must be encrypted") {
                             warn!(
                                 "transaction with ciphertext id {:?} has mismatching entry function",
@@ -457,6 +471,7 @@ fn record_decryption_metrics(result: &DecryptionResult) {
     let mut config_unavailable = 0u64;
     let mut key_unavailable = 0u64;
     let mut batch_limit_exceeded = 0u64;
+    let mut payload_hash_mismatch = 0u64;
     let mut entry_fun_mismatch = 0u64;
 
     for txn in &result.decrypted_txns {
@@ -470,6 +485,7 @@ fn record_decryption_metrics(result: &DecryptionResult) {
                 DecryptionFailureReason::BatchLimitReached => batch_limit_exceeded += 1,
                 DecryptionFailureReason::ConfigUnavailable => config_unavailable += 1,
                 DecryptionFailureReason::DecryptionKeyUnavailable => key_unavailable += 1,
+                DecryptionFailureReason::PayloadHashMismatch => payload_hash_mismatch += 1,
                 DecryptionFailureReason::ClaimedEntryFunctionMismatch => entry_fun_mismatch += 1,
             },
             EncryptedPayload::Encrypted { .. } => {
@@ -487,6 +503,7 @@ fn record_decryption_metrics(result: &DecryptionResult) {
         ("config_unavailable", config_unavailable),
         ("key_unavailable", key_unavailable),
         ("batch_limit_exceeded", batch_limit_exceeded),
+        ("payload_hash_mismatch", payload_hash_mismatch),
         ("entry_fun_mismatch", entry_fun_mismatch),
         ("unencrypted", unencrypted),
     ];

--- a/consensus/src/quorum_store/tests/batch_generator_test.rs
+++ b/consensus/src/quorum_store/tests/batch_generator_test.rs
@@ -25,8 +25,8 @@ use aptos_types::{
     quorum_store::BatchId,
     secret_sharing::Ciphertext,
     transaction::{
-        encrypted_payload::EncryptedPayload, RawTransaction, SignedTransaction,
-        TransactionExtraConfig, TransactionPayload,
+        encrypted_payload::{EncryptedInner, EncryptedPayload},
+        RawTransaction, SignedTransaction, TransactionExtraConfig, TransactionPayload,
     },
 };
 use futures::{
@@ -806,7 +806,7 @@ fn create_encrypted_transaction(gas_unit_price: u64) -> SignedTransaction {
     let private_key = Ed25519PrivateKey::generate_for_testing();
     let public_key = private_key.public_key();
 
-    let encrypted_payload = EncryptedPayload::Encrypted {
+    let encrypted_payload = EncryptedPayload::Encrypted(EncryptedInner {
         ciphertext: Ciphertext::random(),
         extra_config: TransactionExtraConfig::V1 {
             multisig_address: None,
@@ -815,7 +815,7 @@ fn create_encrypted_transaction(gas_unit_price: u64) -> SignedTransaction {
         payload_hash: HashValue::random(),
         encryption_epoch: 1,
         claimed_entry_fun: None,
-    };
+    });
 
     let transaction_payload = TransactionPayload::EncryptedPayload(encrypted_payload);
     let raw_transaction = RawTransaction::new(

--- a/consensus/src/quorum_store/tests/batch_generator_test.rs
+++ b/consensus/src/quorum_store/tests/batch_generator_test.rs
@@ -813,6 +813,7 @@ fn create_encrypted_transaction(gas_unit_price: u64) -> SignedTransaction {
             replay_protection_nonce: None,
         },
         payload_hash: HashValue::random(),
+        encryption_epoch: 1,
         claimed_entry_fun: None,
     };
 

--- a/crates/aptos-transaction-filters/src/tests/utils.rs
+++ b/crates/aptos-transaction-filters/src/tests/utils.rs
@@ -13,7 +13,9 @@ use aptos_types::{
     secret_sharing::{Ciphertext, EvalProof},
     transaction::{
         authenticator::{AccountAuthenticator, AnyPublicKey, TransactionAuthenticator},
-        encrypted_payload::{DecryptionFailureReason, EncryptedPayload},
+        encrypted_payload::{
+            DecryptedPlaintext, DecryptionFailureReason, EncryptedInner, EncryptedPayload,
+        },
         EntryFunction, Multisig, MultisigTransactionPayload, RawTransaction, Script,
         SignedTransaction, TransactionExecutable, TransactionExecutableRef, TransactionExtraConfig,
         TransactionPayload, TransactionPayloadInner,
@@ -53,7 +55,7 @@ pub fn create_encrypted_and_plaintext_transactions() -> Vec<SignedTransaction> {
 /// Creates and returns an encrypted transaction
 #[cfg(test)]
 pub fn create_encrypted_transaction() -> SignedTransaction {
-    let encrypted_payload = EncryptedPayload::Encrypted {
+    let encrypted_payload = EncryptedPayload::Encrypted(EncryptedInner {
         ciphertext: Ciphertext::random(),
         extra_config: TransactionExtraConfig::V1 {
             multisig_address: None,
@@ -62,7 +64,7 @@ pub fn create_encrypted_transaction() -> SignedTransaction {
         payload_hash: HashValue::random(),
         encryption_epoch: 1,
         claimed_entry_fun: None,
-    };
+    });
 
     let transaction_payload = TransactionPayload::EncryptedPayload(encrypted_payload);
     create_signed_transaction(transaction_payload, false)
@@ -72,16 +74,18 @@ pub fn create_encrypted_transaction() -> SignedTransaction {
 #[cfg(test)]
 pub fn create_encrypted_transaction_failed_state() -> SignedTransaction {
     let encrypted_payload = EncryptedPayload::FailedDecryption {
-        ciphertext: Ciphertext::random(),
-        extra_config: TransactionExtraConfig::V1 {
-            multisig_address: None,
-            replay_protection_nonce: None,
+        original: EncryptedInner {
+            ciphertext: Ciphertext::random(),
+            extra_config: TransactionExtraConfig::V1 {
+                multisig_address: None,
+                replay_protection_nonce: None,
+            },
+            payload_hash: HashValue::random(),
+            encryption_epoch: 1,
+            claimed_entry_fun: None,
         },
-        payload_hash: HashValue::random(),
-        encryption_epoch: 1,
         eval_proof: Some(EvalProof::random()),
         reason: DecryptionFailureReason::CryptoFailure,
-        claimed_entry_fun: None,
     };
 
     let transaction_payload = TransactionPayload::EncryptedPayload(encrypted_payload);
@@ -92,17 +96,18 @@ pub fn create_encrypted_transaction_failed_state() -> SignedTransaction {
 #[cfg(test)]
 pub fn create_encrypted_transaction_plaintext_state() -> SignedTransaction {
     let encrypted_payload = EncryptedPayload::Decrypted {
-        ciphertext: Ciphertext::random(),
-        extra_config: TransactionExtraConfig::V1 {
-            multisig_address: None,
-            replay_protection_nonce: None,
+        original: EncryptedInner {
+            ciphertext: Ciphertext::random(),
+            extra_config: TransactionExtraConfig::V1 {
+                multisig_address: None,
+                replay_protection_nonce: None,
+            },
+            payload_hash: HashValue::random(),
+            encryption_epoch: 1,
+            claimed_entry_fun: None,
         },
-        payload_hash: HashValue::random(),
-        encryption_epoch: 1,
         eval_proof: EvalProof::random(),
-        executable: TransactionExecutable::Empty,
-        decryption_nonce: [0; 16],
-        claimed_entry_fun: None,
+        decrypted: DecryptedPlaintext::new(TransactionExecutable::Empty, [0; 16]),
     };
 
     let transaction_payload = TransactionPayload::EncryptedPayload(encrypted_payload);

--- a/crates/aptos-transaction-filters/src/tests/utils.rs
+++ b/crates/aptos-transaction-filters/src/tests/utils.rs
@@ -60,6 +60,7 @@ pub fn create_encrypted_transaction() -> SignedTransaction {
             replay_protection_nonce: None,
         },
         payload_hash: HashValue::random(),
+        encryption_epoch: 1,
         claimed_entry_fun: None,
     };
 
@@ -77,6 +78,7 @@ pub fn create_encrypted_transaction_failed_state() -> SignedTransaction {
             replay_protection_nonce: None,
         },
         payload_hash: HashValue::random(),
+        encryption_epoch: 1,
         eval_proof: Some(EvalProof::random()),
         reason: DecryptionFailureReason::CryptoFailure,
         claimed_entry_fun: None,
@@ -96,6 +98,7 @@ pub fn create_encrypted_transaction_plaintext_state() -> SignedTransaction {
             replay_protection_nonce: None,
         },
         payload_hash: HashValue::random(),
+        encryption_epoch: 1,
         eval_proof: EvalProof::random(),
         executable: TransactionExecutable::Empty,
         decryption_nonce: [0; 16],

--- a/crates/aptos-transaction-filters/src/tests/utils.rs
+++ b/crates/aptos-transaction-filters/src/tests/utils.rs
@@ -98,7 +98,7 @@ pub fn create_encrypted_transaction_plaintext_state() -> SignedTransaction {
         payload_hash: HashValue::random(),
         eval_proof: EvalProof::random(),
         executable: TransactionExecutable::Empty,
-        decryption_nonce: 0,
+        decryption_nonce: [0; 16],
         claimed_entry_fun: None,
     };
 

--- a/sdk/src/transaction_builder.rs
+++ b/sdk/src/transaction_builder.rs
@@ -19,7 +19,9 @@ use aptos_types::{
     function_info::FunctionInfo,
     secret_sharing::EncryptionKey,
     transaction::{
-        encrypted_payload::{DecryptedPayload, EncryptedPayload, PayloadAssociatedData},
+        encrypted_payload::{
+            DecryptedPayload, DecryptionNonce, EncryptedPayload, PayloadAssociatedData,
+        },
         EntryFunction, Script,
     },
 };
@@ -471,7 +473,7 @@ impl TransactionFactory {
         let extra_config = payload.extra_config();
 
         // Generate decryption nonce
-        let decryption_nonce: u64 = rand::random();
+        let decryption_nonce: DecryptionNonce = rand::random();
 
         // Create DecryptedPayload for encryption
         let decrypted_payload = DecryptedPayload::new(executable, decryption_nonce);

--- a/sdk/src/transaction_builder.rs
+++ b/sdk/src/transaction_builder.rs
@@ -126,7 +126,10 @@ impl TransactionBuilder {
     pub fn build(mut self) -> RawTransaction {
         // Read the encryption key at build time (not at builder-creation time)
         // so that epoch-change key rotations are always picked up.
-        let encryption_key = self.encryption_key.read().unwrap().key.clone();
+        let encryption_key_state = self.encryption_key.read().unwrap();
+        let encryption_key = encryption_key_state.key.clone();
+        let encryption_epoch = encryption_key_state.epoch;
+        drop(encryption_key_state);
         if let Some(ref encryption_key) = encryption_key {
             assert!(!self.payload.is_encrypted_variant());
             let encrypted_payload = TransactionFactory::encrypt_payload(
@@ -135,6 +138,7 @@ impl TransactionBuilder {
                 self.auth_key
                     .expect("auth_key must be set for encrypted payloads"),
                 encryption_key,
+                encryption_epoch,
             )
             .expect("Payload must encrypt");
             self.payload = TransactionPayload::EncryptedPayload(encrypted_payload);
@@ -467,6 +471,7 @@ impl TransactionFactory {
         sender: AccountAddress,
         auth_key: AuthenticationKey,
         encryption_key: &EncryptionKey,
+        encryption_epoch: u64,
     ) -> Result<EncryptedPayload> {
         // Convert payload to executable
         let executable = payload.executable()?;
@@ -501,6 +506,7 @@ impl TransactionFactory {
             ciphertext,
             extra_config,
             payload_hash,
+            encryption_epoch,
             claimed_entry_fun: None,
         })
     }
@@ -608,6 +614,7 @@ mod tests {
             sender,
             sender_auth_key,
             &encryption_key,
+            0,
         )
         .unwrap();
 

--- a/sdk/src/transaction_builder.rs
+++ b/sdk/src/transaction_builder.rs
@@ -20,7 +20,8 @@ use aptos_types::{
     secret_sharing::EncryptionKey,
     transaction::{
         encrypted_payload::{
-            DecryptedPayload, DecryptionNonce, EncryptedPayload, PayloadAssociatedData,
+            DecryptedPlaintext, DecryptionNonce, EncryptedInner, EncryptedPayload,
+            PayloadAssociatedData,
         },
         EntryFunction, Script,
     },
@@ -481,7 +482,7 @@ impl TransactionFactory {
         let decryption_nonce: DecryptionNonce = rand::random();
 
         // Create DecryptedPayload for encryption
-        let decrypted_payload = DecryptedPayload::new(executable, decryption_nonce);
+        let decrypted_payload = DecryptedPlaintext::new(executable, decryption_nonce);
 
         // Create associated data with sender and auth_key to bind the ciphertext
         // to both the sender address and the authenticator's identity.
@@ -502,13 +503,13 @@ impl TransactionFactory {
         let payload_hash = CryptoHash::hash(&decrypted_payload);
 
         // Create encrypted payload
-        Ok(EncryptedPayload::Encrypted {
+        Ok(EncryptedPayload::Encrypted(EncryptedInner {
             ciphertext,
             extra_config,
             payload_hash,
             encryption_epoch,
             claimed_entry_fun: None,
-        })
+        }))
     }
 
     fn expiration_timestamp(&self) -> u64 {

--- a/testsuite/generate-format/tests/staged/api.yaml
+++ b/testsuite/generate-format/tests/staged/api.yaml
@@ -338,6 +338,14 @@ DecKeyMetadata:
   STRUCT:
     - epoch: U64
     - round: U64
+DecryptedPlaintext:
+  STRUCT:
+    - executable:
+        TYPENAME: TransactionExecutable
+    - decryption_nonce:
+        TUPLEARRAY:
+          CONTENT: U8
+          SIZE: 16
 DecryptionFailureReason:
   ENUM:
     0:
@@ -364,34 +372,29 @@ Ed25519PublicKey:
   NEWTYPESTRUCT: BYTES
 Ed25519Signature:
   NEWTYPESTRUCT: BYTES
+EncryptedInner:
+  STRUCT:
+    - ciphertext:
+        TYPENAME: Ciphertext
+    - extra_config:
+        TYPENAME: TransactionExtraConfig
+    - payload_hash:
+        TYPENAME: HashValue
+    - encryption_epoch: U64
+    - claimed_entry_fun:
+        OPTION:
+          TYPENAME: ClaimedEntryFunction
 EncryptedPayload:
   ENUM:
     0:
       Encrypted:
-        STRUCT:
-          - ciphertext:
-              TYPENAME: Ciphertext
-          - extra_config:
-              TYPENAME: TransactionExtraConfig
-          - payload_hash:
-              TYPENAME: HashValue
-          - encryption_epoch: U64
-          - claimed_entry_fun:
-              OPTION:
-                TYPENAME: ClaimedEntryFunction
+        NEWTYPE:
+          TYPENAME: EncryptedInner
     1:
       FailedDecryption:
         STRUCT:
-          - ciphertext:
-              TYPENAME: Ciphertext
-          - extra_config:
-              TYPENAME: TransactionExtraConfig
-          - payload_hash:
-              TYPENAME: HashValue
-          - encryption_epoch: U64
-          - claimed_entry_fun:
-              OPTION:
-                TYPENAME: ClaimedEntryFunction
+          - original:
+              TYPENAME: EncryptedInner
           - eval_proof:
               OPTION:
                 TYPENAME: EvalProof
@@ -400,24 +403,12 @@ EncryptedPayload:
     2:
       Decrypted:
         STRUCT:
-          - ciphertext:
-              TYPENAME: Ciphertext
-          - extra_config:
-              TYPENAME: TransactionExtraConfig
-          - payload_hash:
-              TYPENAME: HashValue
-          - encryption_epoch: U64
-          - claimed_entry_fun:
-              OPTION:
-                TYPENAME: ClaimedEntryFunction
+          - original:
+              TYPENAME: EncryptedInner
           - eval_proof:
               TYPENAME: EvalProof
-          - executable:
-              TYPENAME: TransactionExecutable
-          - decryption_nonce:
-              TUPLEARRAY:
-                CONTENT: U8
-                SIZE: 16
+          - decrypted:
+              TYPENAME: DecryptedPlaintext
 EntryFunction:
   STRUCT:
     - module:

--- a/testsuite/generate-format/tests/staged/api.yaml
+++ b/testsuite/generate-format/tests/staged/api.yaml
@@ -350,6 +350,8 @@ DecryptionFailureReason:
       DecryptionKeyUnavailable: UNIT
     4:
       ClaimedEntryFunctionMismatch: UNIT
+    5:
+      PayloadHashMismatch: UNIT
 DepositEvent:
   STRUCT:
     - amount: U64
@@ -407,7 +409,10 @@ EncryptedPayload:
               TYPENAME: EvalProof
           - executable:
               TYPENAME: TransactionExecutable
-          - decryption_nonce: U64
+          - decryption_nonce:
+              TUPLEARRAY:
+                CONTENT: U8
+                SIZE: 16
 EntryFunction:
   STRUCT:
     - module:

--- a/testsuite/generate-format/tests/staged/api.yaml
+++ b/testsuite/generate-format/tests/staged/api.yaml
@@ -352,6 +352,8 @@ DecryptionFailureReason:
       ClaimedEntryFunctionMismatch: UNIT
     5:
       PayloadHashMismatch: UNIT
+    6:
+      EpochMismatch: UNIT
 DepositEvent:
   STRUCT:
     - amount: U64
@@ -373,6 +375,7 @@ EncryptedPayload:
               TYPENAME: TransactionExtraConfig
           - payload_hash:
               TYPENAME: HashValue
+          - encryption_epoch: U64
           - claimed_entry_fun:
               OPTION:
                 TYPENAME: ClaimedEntryFunction
@@ -385,6 +388,7 @@ EncryptedPayload:
               TYPENAME: TransactionExtraConfig
           - payload_hash:
               TYPENAME: HashValue
+          - encryption_epoch: U64
           - claimed_entry_fun:
               OPTION:
                 TYPENAME: ClaimedEntryFunction
@@ -402,6 +406,7 @@ EncryptedPayload:
               TYPENAME: TransactionExtraConfig
           - payload_hash:
               TYPENAME: HashValue
+          - encryption_epoch: U64
           - claimed_entry_fun:
               OPTION:
                 TYPENAME: ClaimedEntryFunction

--- a/testsuite/generate-format/tests/staged/aptos.yaml
+++ b/testsuite/generate-format/tests/staged/aptos.yaml
@@ -330,6 +330,8 @@ DecryptionFailureReason:
       DecryptionKeyUnavailable: UNIT
     4:
       ClaimedEntryFunctionMismatch: UNIT
+    5:
+      PayloadHashMismatch: UNIT
 DeprecatedPayload:
   STRUCT:
     - dummy_value: U64
@@ -384,7 +386,10 @@ EncryptedPayload:
               TYPENAME: EvalProof
           - executable:
               TYPENAME: TransactionExecutable
-          - decryption_nonce: U64
+          - decryption_nonce:
+              TUPLEARRAY:
+                CONTENT: U8
+                SIZE: 16
 EntryFunction:
   STRUCT:
     - module:

--- a/testsuite/generate-format/tests/staged/aptos.yaml
+++ b/testsuite/generate-format/tests/staged/aptos.yaml
@@ -332,6 +332,8 @@ DecryptionFailureReason:
       ClaimedEntryFunctionMismatch: UNIT
     5:
       PayloadHashMismatch: UNIT
+    6:
+      EpochMismatch: UNIT
 DeprecatedPayload:
   STRUCT:
     - dummy_value: U64
@@ -350,6 +352,7 @@ EncryptedPayload:
               TYPENAME: TransactionExtraConfig
           - payload_hash:
               TYPENAME: HashValue
+          - encryption_epoch: U64
           - claimed_entry_fun:
               OPTION:
                 TYPENAME: ClaimedEntryFunction
@@ -362,6 +365,7 @@ EncryptedPayload:
               TYPENAME: TransactionExtraConfig
           - payload_hash:
               TYPENAME: HashValue
+          - encryption_epoch: U64
           - claimed_entry_fun:
               OPTION:
                 TYPENAME: ClaimedEntryFunction
@@ -379,6 +383,7 @@ EncryptedPayload:
               TYPENAME: TransactionExtraConfig
           - payload_hash:
               TYPENAME: HashValue
+          - encryption_epoch: U64
           - claimed_entry_fun:
               OPTION:
                 TYPENAME: ClaimedEntryFunction

--- a/testsuite/generate-format/tests/staged/aptos.yaml
+++ b/testsuite/generate-format/tests/staged/aptos.yaml
@@ -318,6 +318,14 @@ DecKeyMetadata:
   STRUCT:
     - epoch: U64
     - round: U64
+DecryptedPlaintext:
+  STRUCT:
+    - executable:
+        TYPENAME: TransactionExecutable
+    - decryption_nonce:
+        TUPLEARRAY:
+          CONTENT: U8
+          SIZE: 16
 DecryptionFailureReason:
   ENUM:
     0:
@@ -341,34 +349,29 @@ Ed25519PublicKey:
   NEWTYPESTRUCT: BYTES
 Ed25519Signature:
   NEWTYPESTRUCT: BYTES
+EncryptedInner:
+  STRUCT:
+    - ciphertext:
+        TYPENAME: Ciphertext
+    - extra_config:
+        TYPENAME: TransactionExtraConfig
+    - payload_hash:
+        TYPENAME: HashValue
+    - encryption_epoch: U64
+    - claimed_entry_fun:
+        OPTION:
+          TYPENAME: ClaimedEntryFunction
 EncryptedPayload:
   ENUM:
     0:
       Encrypted:
-        STRUCT:
-          - ciphertext:
-              TYPENAME: Ciphertext
-          - extra_config:
-              TYPENAME: TransactionExtraConfig
-          - payload_hash:
-              TYPENAME: HashValue
-          - encryption_epoch: U64
-          - claimed_entry_fun:
-              OPTION:
-                TYPENAME: ClaimedEntryFunction
+        NEWTYPE:
+          TYPENAME: EncryptedInner
     1:
       FailedDecryption:
         STRUCT:
-          - ciphertext:
-              TYPENAME: Ciphertext
-          - extra_config:
-              TYPENAME: TransactionExtraConfig
-          - payload_hash:
-              TYPENAME: HashValue
-          - encryption_epoch: U64
-          - claimed_entry_fun:
-              OPTION:
-                TYPENAME: ClaimedEntryFunction
+          - original:
+              TYPENAME: EncryptedInner
           - eval_proof:
               OPTION:
                 TYPENAME: EvalProof
@@ -377,24 +380,12 @@ EncryptedPayload:
     2:
       Decrypted:
         STRUCT:
-          - ciphertext:
-              TYPENAME: Ciphertext
-          - extra_config:
-              TYPENAME: TransactionExtraConfig
-          - payload_hash:
-              TYPENAME: HashValue
-          - encryption_epoch: U64
-          - claimed_entry_fun:
-              OPTION:
-                TYPENAME: ClaimedEntryFunction
+          - original:
+              TYPENAME: EncryptedInner
           - eval_proof:
               TYPENAME: EvalProof
-          - executable:
-              TYPENAME: TransactionExecutable
-          - decryption_nonce:
-              TUPLEARRAY:
-                CONTENT: U8
-                SIZE: 16
+          - decrypted:
+              TYPENAME: DecryptedPlaintext
 EntryFunction:
   STRUCT:
     - module:

--- a/testsuite/generate-format/tests/staged/consensus.yaml
+++ b/testsuite/generate-format/tests/staged/consensus.yaml
@@ -650,6 +650,8 @@ DecryptionFailureReason:
       DecryptionKeyUnavailable: UNIT
     4:
       ClaimedEntryFunctionMismatch: UNIT
+    5:
+      PayloadHashMismatch: UNIT
 DeprecatedPayload:
   STRUCT:
     - dummy_value: U64
@@ -704,7 +706,10 @@ EncryptedPayload:
               TYPENAME: EvalProof
           - executable:
               TYPENAME: TransactionExecutable
-          - decryption_nonce: U64
+          - decryption_nonce:
+              TUPLEARRAY:
+                CONTENT: U8
+                SIZE: 16
 EntryFunction:
   STRUCT:
     - module:

--- a/testsuite/generate-format/tests/staged/consensus.yaml
+++ b/testsuite/generate-format/tests/staged/consensus.yaml
@@ -638,6 +638,14 @@ DecKeyMetadata:
   STRUCT:
     - epoch: U64
     - round: U64
+DecryptedPlaintext:
+  STRUCT:
+    - executable:
+        TYPENAME: TransactionExecutable
+    - decryption_nonce:
+        TUPLEARRAY:
+          CONTENT: U8
+          SIZE: 16
 DecryptionFailureReason:
   ENUM:
     0:
@@ -661,34 +669,29 @@ Ed25519PublicKey:
   NEWTYPESTRUCT: BYTES
 Ed25519Signature:
   NEWTYPESTRUCT: BYTES
+EncryptedInner:
+  STRUCT:
+    - ciphertext:
+        TYPENAME: Ciphertext
+    - extra_config:
+        TYPENAME: TransactionExtraConfig
+    - payload_hash:
+        TYPENAME: HashValue
+    - encryption_epoch: U64
+    - claimed_entry_fun:
+        OPTION:
+          TYPENAME: ClaimedEntryFunction
 EncryptedPayload:
   ENUM:
     0:
       Encrypted:
-        STRUCT:
-          - ciphertext:
-              TYPENAME: Ciphertext
-          - extra_config:
-              TYPENAME: TransactionExtraConfig
-          - payload_hash:
-              TYPENAME: HashValue
-          - encryption_epoch: U64
-          - claimed_entry_fun:
-              OPTION:
-                TYPENAME: ClaimedEntryFunction
+        NEWTYPE:
+          TYPENAME: EncryptedInner
     1:
       FailedDecryption:
         STRUCT:
-          - ciphertext:
-              TYPENAME: Ciphertext
-          - extra_config:
-              TYPENAME: TransactionExtraConfig
-          - payload_hash:
-              TYPENAME: HashValue
-          - encryption_epoch: U64
-          - claimed_entry_fun:
-              OPTION:
-                TYPENAME: ClaimedEntryFunction
+          - original:
+              TYPENAME: EncryptedInner
           - eval_proof:
               OPTION:
                 TYPENAME: EvalProof
@@ -697,24 +700,12 @@ EncryptedPayload:
     2:
       Decrypted:
         STRUCT:
-          - ciphertext:
-              TYPENAME: Ciphertext
-          - extra_config:
-              TYPENAME: TransactionExtraConfig
-          - payload_hash:
-              TYPENAME: HashValue
-          - encryption_epoch: U64
-          - claimed_entry_fun:
-              OPTION:
-                TYPENAME: ClaimedEntryFunction
+          - original:
+              TYPENAME: EncryptedInner
           - eval_proof:
               TYPENAME: EvalProof
-          - executable:
-              TYPENAME: TransactionExecutable
-          - decryption_nonce:
-              TUPLEARRAY:
-                CONTENT: U8
-                SIZE: 16
+          - decrypted:
+              TYPENAME: DecryptedPlaintext
 EntryFunction:
   STRUCT:
     - module:

--- a/testsuite/generate-format/tests/staged/consensus.yaml
+++ b/testsuite/generate-format/tests/staged/consensus.yaml
@@ -652,6 +652,8 @@ DecryptionFailureReason:
       ClaimedEntryFunctionMismatch: UNIT
     5:
       PayloadHashMismatch: UNIT
+    6:
+      EpochMismatch: UNIT
 DeprecatedPayload:
   STRUCT:
     - dummy_value: U64
@@ -670,6 +672,7 @@ EncryptedPayload:
               TYPENAME: TransactionExtraConfig
           - payload_hash:
               TYPENAME: HashValue
+          - encryption_epoch: U64
           - claimed_entry_fun:
               OPTION:
                 TYPENAME: ClaimedEntryFunction
@@ -682,6 +685,7 @@ EncryptedPayload:
               TYPENAME: TransactionExtraConfig
           - payload_hash:
               TYPENAME: HashValue
+          - encryption_epoch: U64
           - claimed_entry_fun:
               OPTION:
                 TYPENAME: ClaimedEntryFunction
@@ -699,6 +703,7 @@ EncryptedPayload:
               TYPENAME: TransactionExtraConfig
           - payload_hash:
               TYPENAME: HashValue
+          - encryption_epoch: U64
           - claimed_entry_fun:
               OPTION:
                 TYPENAME: ClaimedEntryFunction

--- a/types/src/transaction/authenticator.rs
+++ b/types/src/transaction/authenticator.rs
@@ -2331,6 +2331,7 @@ mod tests {
         Ciphertext,
         TransactionExtraConfig,
         HashValue,
+        u64,
     ) {
         let ciphertext = Ciphertext::random();
         let extra_config = TransactionExtraConfig::V1 {
@@ -2338,13 +2339,15 @@ mod tests {
             replay_protection_nonce: None,
         };
         let payload_hash = HashValue::random();
+        let encryption_epoch = 7;
         let payload = TransactionPayload::EncryptedPayload(EncryptedPayload::Encrypted {
             ciphertext: ciphertext.clone(),
             extra_config: extra_config.clone(),
             payload_hash,
+            encryption_epoch,
             claimed_entry_fun: None,
         });
-        (payload, ciphertext, extra_config, payload_hash)
+        (payload, ciphertext, extra_config, payload_hash, encryption_epoch)
     }
 
     /// Simulate decryption by mutating the signed transaction's payload
@@ -2354,12 +2357,14 @@ mod tests {
         ciphertext: Ciphertext,
         extra_config: TransactionExtraConfig,
         payload_hash: HashValue,
+        encryption_epoch: u64,
     ) {
         *signed_txn.payload_mut() =
             TransactionPayload::EncryptedPayload(EncryptedPayload::Decrypted {
                 ciphertext,
                 extra_config,
                 payload_hash,
+                encryption_epoch,
                 claimed_entry_fun: None,
                 eval_proof: EvalProof::random(),
                 executable: TransactionExecutable::Empty,
@@ -2373,7 +2378,8 @@ mod tests {
         let sender_pub = sender_key.public_key();
         let sender_addr = AuthenticationKey::ed25519(&sender_pub).account_address();
 
-        let (payload, ciphertext, extra_config, payload_hash) = make_encrypted_payload();
+        let (payload, ciphertext, extra_config, payload_hash, encryption_epoch) =
+            make_encrypted_payload();
         let raw_txn = RawTransaction::new(
             sender_addr,
             0,
@@ -2390,7 +2396,13 @@ mod tests {
         signed_txn.verify_signature().unwrap();
 
         // Simulate decryption (Encrypted -> Decrypted).
-        simulate_decryption(&mut signed_txn, ciphertext, extra_config, payload_hash);
+        simulate_decryption(
+            &mut signed_txn,
+            ciphertext,
+            extra_config,
+            payload_hash,
+            encryption_epoch,
+        );
 
         // Signature should still verify because as_encrypted_variant() converts back.
         signed_txn.verify_signature().unwrap();
@@ -2406,7 +2418,8 @@ mod tests {
         let fee_payer_pub = fee_payer_key.public_key();
         let fee_payer_addr = AuthenticationKey::ed25519(&fee_payer_pub).account_address();
 
-        let (payload, ciphertext, extra_config, payload_hash) = make_encrypted_payload();
+        let (payload, ciphertext, extra_config, payload_hash, encryption_epoch) =
+            make_encrypted_payload();
         let raw_txn = RawTransaction::new(
             sender_addr,
             0,
@@ -2439,7 +2452,13 @@ mod tests {
         signed_txn.verify_signature().unwrap();
 
         // Simulate decryption.
-        simulate_decryption(&mut signed_txn, ciphertext, extra_config, payload_hash);
+        simulate_decryption(
+            &mut signed_txn,
+            ciphertext,
+            extra_config,
+            payload_hash,
+            encryption_epoch,
+        );
 
         // Signature should still verify.
         signed_txn.verify_signature().unwrap();
@@ -2455,7 +2474,8 @@ mod tests {
         let secondary_pub = secondary_key.public_key();
         let secondary_addr = AuthenticationKey::ed25519(&secondary_pub).account_address();
 
-        let (payload, ciphertext, extra_config, payload_hash) = make_encrypted_payload();
+        let (payload, ciphertext, extra_config, payload_hash, encryption_epoch) =
+            make_encrypted_payload();
         let raw_txn = RawTransaction::new(
             sender_addr,
             0,
@@ -2481,7 +2501,13 @@ mod tests {
 
         signed_txn.verify_signature().unwrap();
 
-        simulate_decryption(&mut signed_txn, ciphertext, extra_config, payload_hash);
+        simulate_decryption(
+            &mut signed_txn,
+            ciphertext,
+            extra_config,
+            payload_hash,
+            encryption_epoch,
+        );
 
         signed_txn.verify_signature().unwrap();
     }
@@ -2493,7 +2519,8 @@ mod tests {
         let sender_addr =
             AuthenticationKey::any_key(AnyPublicKey::ed25519(sender_pub.clone())).account_address();
 
-        let (payload, ciphertext, extra_config, payload_hash) = make_encrypted_payload();
+        let (payload, ciphertext, extra_config, payload_hash, encryption_epoch) =
+            make_encrypted_payload();
         let raw_txn = RawTransaction::new(
             sender_addr,
             0,
@@ -2514,7 +2541,13 @@ mod tests {
 
         signed_txn.verify_signature().unwrap();
 
-        simulate_decryption(&mut signed_txn, ciphertext, extra_config, payload_hash);
+        simulate_decryption(
+            &mut signed_txn,
+            ciphertext,
+            extra_config,
+            payload_hash,
+            encryption_epoch,
+        );
 
         signed_txn.verify_signature().unwrap();
     }

--- a/types/src/transaction/authenticator.rs
+++ b/types/src/transaction/authenticator.rs
@@ -2363,7 +2363,7 @@ mod tests {
                 claimed_entry_fun: None,
                 eval_proof: EvalProof::random(),
                 executable: TransactionExecutable::Empty,
-                decryption_nonce: 42,
+                decryption_nonce: [42; 16],
             });
     }
 

--- a/types/src/transaction/authenticator.rs
+++ b/types/src/transaction/authenticator.rs
@@ -2340,14 +2340,22 @@ mod tests {
         };
         let payload_hash = HashValue::random();
         let encryption_epoch = 7;
-        let payload = TransactionPayload::EncryptedPayload(EncryptedPayload::Encrypted {
-            ciphertext: ciphertext.clone(),
-            extra_config: extra_config.clone(),
+        let payload = TransactionPayload::EncryptedPayload(EncryptedPayload::Encrypted(
+            crate::transaction::encrypted_payload::EncryptedInner {
+                ciphertext: ciphertext.clone(),
+                extra_config: extra_config.clone(),
+                payload_hash,
+                encryption_epoch,
+                claimed_entry_fun: None,
+            },
+        ));
+        (
+            payload,
+            ciphertext,
+            extra_config,
             payload_hash,
             encryption_epoch,
-            claimed_entry_fun: None,
-        });
-        (payload, ciphertext, extra_config, payload_hash, encryption_epoch)
+        )
     }
 
     /// Simulate decryption by mutating the signed transaction's payload
@@ -2361,14 +2369,18 @@ mod tests {
     ) {
         *signed_txn.payload_mut() =
             TransactionPayload::EncryptedPayload(EncryptedPayload::Decrypted {
-                ciphertext,
-                extra_config,
-                payload_hash,
-                encryption_epoch,
-                claimed_entry_fun: None,
+                original: crate::transaction::encrypted_payload::EncryptedInner {
+                    ciphertext,
+                    extra_config,
+                    payload_hash,
+                    encryption_epoch,
+                    claimed_entry_fun: None,
+                },
                 eval_proof: EvalProof::random(),
-                executable: TransactionExecutable::Empty,
-                decryption_nonce: [42; 16],
+                decrypted: crate::transaction::encrypted_payload::DecryptedPlaintext::new(
+                    TransactionExecutable::Empty,
+                    [42; 16],
+                ),
             });
     }
 

--- a/types/src/transaction/authenticator.rs
+++ b/types/src/transaction/authenticator.rs
@@ -1637,8 +1637,9 @@ mod tests {
         },
         secret_sharing::{Ciphertext, EvalProof},
         transaction::{
-            encrypted_payload::EncryptedPayload, webauthn::AssertionSignature, SignedTransaction,
-            TransactionExecutable, TransactionExtraConfig, TransactionPayload,
+            encrypted_payload::{DecryptedPlaintext, EncryptedInner, EncryptedPayload},
+            webauthn::AssertionSignature,
+            SignedTransaction, TransactionExecutable, TransactionExtraConfig, TransactionPayload,
         },
     };
     use aptos_crypto::{
@@ -2340,15 +2341,14 @@ mod tests {
         };
         let payload_hash = HashValue::random();
         let encryption_epoch = 7;
-        let payload = TransactionPayload::EncryptedPayload(EncryptedPayload::Encrypted(
-            crate::transaction::encrypted_payload::EncryptedInner {
+        let payload =
+            TransactionPayload::EncryptedPayload(EncryptedPayload::Encrypted(EncryptedInner {
                 ciphertext: ciphertext.clone(),
                 extra_config: extra_config.clone(),
                 payload_hash,
                 encryption_epoch,
                 claimed_entry_fun: None,
-            },
-        ));
+            }));
         (
             payload,
             ciphertext,
@@ -2369,7 +2369,7 @@ mod tests {
     ) {
         *signed_txn.payload_mut() =
             TransactionPayload::EncryptedPayload(EncryptedPayload::Decrypted {
-                original: crate::transaction::encrypted_payload::EncryptedInner {
+                original: EncryptedInner {
                     ciphertext,
                     extra_config,
                     payload_hash,
@@ -2377,10 +2377,7 @@ mod tests {
                     claimed_entry_fun: None,
                 },
                 eval_proof: EvalProof::random(),
-                decrypted: crate::transaction::encrypted_payload::DecryptedPlaintext::new(
-                    TransactionExecutable::Empty,
-                    [42; 16],
-                ),
+                decrypted: DecryptedPlaintext::new(TransactionExecutable::Empty, [42; 16]),
             });
     }
 

--- a/types/src/transaction/encrypted_payload.rs
+++ b/types/src/transaction/encrypted_payload.rs
@@ -23,12 +23,12 @@ pub type DecryptionNonce = [u8; DECRYPTION_NONCE_NUM_BYTES];
 #[derive(
     Clone, Debug, Hash, Eq, PartialEq, Serialize, Deserialize, CryptoHasher, BCSCryptoHash,
 )]
-pub struct DecryptedPayload {
+pub struct DecryptedPlaintext {
     executable: TransactionExecutable,
     decryption_nonce: DecryptionNonce,
 }
 
-impl DecryptedPayload {
+impl DecryptedPlaintext {
     pub fn new(executable: TransactionExecutable, decryption_nonce: DecryptionNonce) -> Self {
         Self {
             executable,
@@ -36,12 +36,16 @@ impl DecryptedPayload {
         }
     }
 
-    pub fn unwrap(self) -> (TransactionExecutable, DecryptionNonce) {
-        (self.executable, self.decryption_nonce)
+    pub fn executable(&self) -> &TransactionExecutable {
+        &self.executable
+    }
+
+    pub fn decryption_nonce(&self) -> &DecryptionNonce {
+        &self.decryption_nonce
     }
 }
 
-impl Plaintext for DecryptedPayload {}
+impl Plaintext for DecryptedPlaintext {}
 
 #[derive(Clone, Debug, Hash, Eq, PartialEq, Serialize, Deserialize)]
 pub struct PayloadAssociatedData {
@@ -84,61 +88,62 @@ pub struct ClaimedEntryFunction {
 }
 
 #[derive(Clone, Debug, Hash, Eq, PartialEq, Serialize, Deserialize)]
+pub struct EncryptedInner {
+    pub ciphertext: Ciphertext,
+    pub extra_config: TransactionExtraConfig,
+    pub payload_hash: HashValue,
+    /// Client-supplied label identifying which epoch's encryption key the
+    /// submitter believes the ciphertext was encrypted under. This is a hint
+    /// used for fast-path rejection when it diverges from the available
+    /// decryption key's epoch — it is not a cryptographic commitment.
+    /// Ciphertext integrity is enforced separately via `Ciphertext::verify`.
+    pub encryption_epoch: u64,
+    pub claimed_entry_fun: Option<ClaimedEntryFunction>,
+}
+
+#[derive(Clone, Debug, Hash, Eq, PartialEq, Serialize, Deserialize)]
 pub enum EncryptedPayload {
-    Encrypted {
-        ciphertext: Ciphertext,
-        extra_config: TransactionExtraConfig,
-        payload_hash: HashValue,
-        encryption_epoch: u64,
-        claimed_entry_fun: Option<ClaimedEntryFunction>,
-    },
+    Encrypted(EncryptedInner),
     FailedDecryption {
-        ciphertext: Ciphertext,
-        extra_config: TransactionExtraConfig,
-        payload_hash: HashValue,
-        encryption_epoch: u64,
-        claimed_entry_fun: Option<ClaimedEntryFunction>,
+        original: EncryptedInner,
         eval_proof: Option<EvalProof>,
         reason: DecryptionFailureReason,
     },
     Decrypted {
-        ciphertext: Ciphertext,
-        extra_config: TransactionExtraConfig,
-        payload_hash: HashValue,
-        encryption_epoch: u64,
-        claimed_entry_fun: Option<ClaimedEntryFunction>,
+        original: EncryptedInner,
         eval_proof: EvalProof,
-
-        // decrypted things
-        executable: TransactionExecutable,
-        decryption_nonce: DecryptionNonce,
+        decrypted: DecryptedPlaintext,
     },
 }
 
 impl EncryptedPayload {
-    pub fn ciphertext(&self) -> &Ciphertext {
+    fn original(&self) -> &EncryptedInner {
         match self {
-            Self::Encrypted { ciphertext, .. }
-            | Self::FailedDecryption { ciphertext, .. }
-            | Self::Decrypted { ciphertext, .. } => ciphertext,
+            Self::Encrypted(original)
+            | Self::FailedDecryption { original, .. }
+            | Self::Decrypted { original, .. } => original,
         }
+    }
+
+    pub fn ciphertext(&self) -> &Ciphertext {
+        &self.original().ciphertext
     }
 
     pub fn executable(&self) -> Result<TransactionExecutable> {
         Ok(match self {
-            EncryptedPayload::Encrypted { .. } | EncryptedPayload::FailedDecryption { .. } => {
+            EncryptedPayload::Encrypted(_) | EncryptedPayload::FailedDecryption { .. } => {
                 TransactionExecutable::Encrypted
             },
-            EncryptedPayload::Decrypted { executable, .. } => executable.clone(),
+            EncryptedPayload::Decrypted { decrypted, .. } => decrypted.executable().clone(),
         })
     }
 
     pub fn executable_ref(&self) -> Result<TransactionExecutableRef<'_>> {
         Ok(match self {
-            EncryptedPayload::Encrypted { .. } | EncryptedPayload::FailedDecryption { .. } => {
+            EncryptedPayload::Encrypted(_) | EncryptedPayload::FailedDecryption { .. } => {
                 TransactionExecutableRef::Encrypted
             },
-            EncryptedPayload::Decrypted { executable, .. } => executable.as_ref(),
+            EncryptedPayload::Decrypted { decrypted, .. } => decrypted.executable().as_ref(),
         })
     }
 
@@ -150,95 +155,53 @@ impl EncryptedPayload {
     }
 
     pub fn extra_config(&self) -> &TransactionExtraConfig {
-        match self {
-            EncryptedPayload::Encrypted { extra_config, .. } => extra_config,
-            EncryptedPayload::FailedDecryption { extra_config, .. } => extra_config,
-            EncryptedPayload::Decrypted { extra_config, .. } => extra_config,
-        }
+        &self.original().extra_config
     }
 
     pub fn encryption_epoch(&self) -> u64 {
-        match self {
-            EncryptedPayload::Encrypted {
-                encryption_epoch, ..
-            }
-            | EncryptedPayload::FailedDecryption {
-                encryption_epoch, ..
-            }
-            | EncryptedPayload::Decrypted {
-                encryption_epoch, ..
-            } => *encryption_epoch,
-        }
+        self.original().encryption_epoch
     }
 
     pub fn is_encrypted(&self) -> bool {
-        matches!(self, Self::Encrypted { .. })
+        matches!(self, Self::Encrypted(_))
     }
 
-    pub fn into_decrypted(
+    /// Verify the decrypted plaintext against the stored commitments and, on success,
+    /// transition `self` to `Decrypted`. On mismatch, `self` is left as `Encrypted` and the
+    /// failure reason is returned so the caller can mark the payload failed.
+    pub fn try_into_decrypted(
         &mut self,
         eval_proof: EvalProof,
-        executable: TransactionExecutable,
-        nonce: DecryptionNonce,
-    ) -> anyhow::Result<()> {
-        let Self::Encrypted {
-            ciphertext,
-            extra_config,
-            payload_hash,
-            encryption_epoch,
-            claimed_entry_fun,
-        } = self
-        else {
-            bail!("Payload is not in Encrypted state");
+        plaintext: DecryptedPlaintext,
+    ) -> Result<(), DecryptionFailureReason> {
+        let Self::Encrypted(original) = self else {
+            panic!("try_into_decrypted called on non-Encrypted state");
         };
 
-        *self = Self::Decrypted {
-            ciphertext: ciphertext.clone(),
-            extra_config: extra_config.clone(),
-            payload_hash: *payload_hash,
-            encryption_epoch: *encryption_epoch,
-            eval_proof,
-            executable,
-            decryption_nonce: nonce,
-            claimed_entry_fun: claimed_entry_fun.clone(),
-        };
-        Ok(())
-    }
+        if original.payload_hash != CryptoHash::hash(&plaintext) {
+            return Err(DecryptionFailureReason::PayloadHashMismatch);
+        }
 
-    pub fn verify_payload_hash(&self, decrypted: &DecryptedPayload) -> anyhow::Result<bool> {
-        let Self::Encrypted { payload_hash, .. } = self else {
-            bail!("Payload is not in Encrypted state");
-        };
-
-        Ok(*payload_hash == CryptoHash::hash(decrypted))
-    }
-
-    pub fn entry_fun_matches(&self, decrypted: &DecryptedPayload) -> anyhow::Result<bool> {
-        let Self::Encrypted {
-            claimed_entry_fun, ..
-        } = self
-        else {
-            bail!("Payload is not in Encrypted state");
-        };
-
-        if let Some(claim) = claimed_entry_fun {
-            // If there is a claim about this payload, the payload executable must be an entry
-            // function
-            if let TransactionExecutable::EntryFunction(entry_fun) = &decrypted.executable {
-                if *entry_fun.module() != claim.module {
-                    // module must match
-                    return Ok(false);
-                } else if let Some(claimed_function_id) = &claim.function
-                    && entry_fun.function() != claimed_function_id.as_ident_str()
-                {
-                    // if there is a claimed function name, this must also match
-                    return Ok(false);
-                }
-            } else {
-                return Ok(false);
+        if let Some(claim) = &original.claimed_entry_fun {
+            let TransactionExecutable::EntryFunction(entry_fun) = plaintext.executable() else {
+                return Err(DecryptionFailureReason::ClaimedEntryFunctionMismatch);
+            };
+            if *entry_fun.module() != claim.module {
+                return Err(DecryptionFailureReason::ClaimedEntryFunctionMismatch);
+            }
+            if let Some(claimed_function_id) = &claim.function
+                && entry_fun.function() != claimed_function_id.as_ident_str()
+            {
+                return Err(DecryptionFailureReason::ClaimedEntryFunctionMismatch);
             }
         }
-        Ok(true)
+
+        *self = Self::Decrypted {
+            original: original.clone(),
+            eval_proof,
+            decrypted: plaintext,
+        };
+        Ok(())
     }
 
     pub fn into_failed_decryption_with_reason(
@@ -246,20 +209,9 @@ impl EncryptedPayload {
         eval_proof: Option<EvalProof>,
         reason: DecryptionFailureReason,
     ) -> anyhow::Result<()> {
-        if let Self::Encrypted {
-            ciphertext,
-            extra_config,
-            payload_hash,
-            encryption_epoch,
-            claimed_entry_fun,
-        } = self
-        {
+        if let Self::Encrypted(original) = self {
             *self = Self::FailedDecryption {
-                ciphertext: ciphertext.clone(),
-                extra_config: extra_config.clone(),
-                payload_hash: *payload_hash,
-                encryption_epoch: *encryption_epoch,
-                claimed_entry_fun: claimed_entry_fun.clone(),
+                original: original.clone(),
                 eval_proof,
                 reason,
             };
@@ -285,43 +237,74 @@ mod tests {
     use super::*;
     use crate::transaction::TransactionExtraConfig;
 
-    #[test]
-    fn verify_payload_hash_accepts_matching_hash() {
-        let decrypted = DecryptedPayload::new(TransactionExecutable::Empty, [7; 16]);
-        let encrypted = EncryptedPayload::Encrypted {
+    fn encrypted_with_hash(
+        payload_hash: HashValue,
+        claimed_entry_fun: Option<ClaimedEntryFunction>,
+    ) -> EncryptedPayload {
+        EncryptedPayload::Encrypted(EncryptedInner {
             ciphertext: Ciphertext::random(),
             extra_config: TransactionExtraConfig::V1 {
                 multisig_address: None,
                 replay_protection_nonce: None,
             },
-            payload_hash: CryptoHash::hash(&decrypted),
+            payload_hash,
             encryption_epoch: 7,
-            claimed_entry_fun: None,
-        };
-
-        assert!(encrypted.verify_payload_hash(&decrypted).unwrap());
+            claimed_entry_fun,
+        })
     }
 
     #[test]
-    fn verify_payload_hash_rejects_mismatched_hash() {
-        let decrypted = DecryptedPayload::new(TransactionExecutable::Empty, [7; 16]);
-        let encrypted = EncryptedPayload::Encrypted {
-            ciphertext: Ciphertext::random(),
-            extra_config: TransactionExtraConfig::V1 {
-                multisig_address: None,
-                replay_protection_nonce: None,
-            },
-            payload_hash: HashValue::random(),
-            encryption_epoch: 7,
-            claimed_entry_fun: None,
-        };
+    fn try_into_decrypted_accepts_matching_hash() {
+        let plaintext = DecryptedPlaintext::new(TransactionExecutable::Empty, [7; 16]);
+        let mut encrypted = encrypted_with_hash(CryptoHash::hash(&plaintext), None);
 
-        assert!(!encrypted.verify_payload_hash(&decrypted).unwrap());
+        encrypted
+            .try_into_decrypted(EvalProof::random(), plaintext)
+            .unwrap();
+        assert!(matches!(encrypted, EncryptedPayload::Decrypted { .. }));
+    }
+
+    #[test]
+    fn try_into_decrypted_rejects_mismatched_hash() {
+        let plaintext = DecryptedPlaintext::new(TransactionExecutable::Empty, [7; 16]);
+        let mut encrypted = encrypted_with_hash(HashValue::random(), None);
+
+        assert_eq!(
+            encrypted.try_into_decrypted(EvalProof::random(), plaintext),
+            Err(DecryptionFailureReason::PayloadHashMismatch)
+        );
+        assert!(matches!(encrypted, EncryptedPayload::Encrypted(_)));
+    }
+
+    #[test]
+    fn try_into_decrypted_rejects_mismatched_entry_fun() {
+        use crate::transaction::EntryFunction;
+        use move_core_types::ident_str;
+
+        let entry_fun = EntryFunction::new(
+            ModuleId::new(AccountAddress::ONE, ident_str!("coin").to_owned()),
+            ident_str!("transfer").to_owned(),
+            vec![],
+            vec![],
+        );
+        let plaintext =
+            DecryptedPlaintext::new(TransactionExecutable::EntryFunction(entry_fun), [7; 16]);
+        let claim = ClaimedEntryFunction {
+            module: ModuleId::new(AccountAddress::ONE, ident_str!("other_module").to_owned()),
+            function: None,
+        };
+        let mut encrypted = encrypted_with_hash(CryptoHash::hash(&plaintext), Some(claim));
+
+        assert_eq!(
+            encrypted.try_into_decrypted(EvalProof::random(), plaintext),
+            Err(DecryptionFailureReason::ClaimedEntryFunctionMismatch)
+        );
+        assert!(matches!(encrypted, EncryptedPayload::Encrypted(_)));
     }
 
     #[test]
     fn state_transitions_preserve_encryption_epoch() {
-        let mut encrypted = EncryptedPayload::Encrypted {
+        let mut encrypted = EncryptedPayload::Encrypted(EncryptedInner {
             ciphertext: Ciphertext::random(),
             extra_config: TransactionExtraConfig::V1 {
                 multisig_address: None,
@@ -330,7 +313,7 @@ mod tests {
             payload_hash: HashValue::random(),
             encryption_epoch: 11,
             claimed_entry_fun: None,
-        };
+        });
 
         assert_eq!(encrypted.encryption_epoch(), 11);
 

--- a/types/src/transaction/encrypted_payload.rs
+++ b/types/src/transaction/encrypted_payload.rs
@@ -17,8 +17,7 @@ use move_core_types::{
 };
 use serde::{Deserialize, Serialize};
 
-pub const DECRYPTION_NONCE_NUM_BYTES: usize = 16;
-pub type DecryptionNonce = [u8; DECRYPTION_NONCE_NUM_BYTES];
+pub type DecryptionNonce = [u8; 16];
 
 #[derive(
     Clone, Debug, Hash, Eq, PartialEq, Serialize, Deserialize, CryptoHasher, BCSCryptoHash,

--- a/types/src/transaction/encrypted_payload.rs
+++ b/types/src/transaction/encrypted_payload.rs
@@ -10,30 +10,33 @@ use crate::{
 };
 use anyhow::{bail, Result};
 use aptos_batch_encryption::traits::{AssociatedData, Plaintext};
-use aptos_crypto::HashValue;
+use aptos_crypto::{hash::CryptoHash, HashValue};
 use aptos_crypto_derive::{BCSCryptoHash, CryptoHasher};
 use move_core_types::{
     account_address::AccountAddress, identifier::Identifier, language_storage::ModuleId,
 };
 use serde::{Deserialize, Serialize};
 
+pub const DECRYPTION_NONCE_NUM_BYTES: usize = 16;
+pub type DecryptionNonce = [u8; DECRYPTION_NONCE_NUM_BYTES];
+
 #[derive(
     Clone, Debug, Hash, Eq, PartialEq, Serialize, Deserialize, CryptoHasher, BCSCryptoHash,
 )]
 pub struct DecryptedPayload {
     executable: TransactionExecutable,
-    decryption_nonce: u64,
+    decryption_nonce: DecryptionNonce,
 }
 
 impl DecryptedPayload {
-    pub fn new(executable: TransactionExecutable, decryption_nonce: u64) -> Self {
+    pub fn new(executable: TransactionExecutable, decryption_nonce: DecryptionNonce) -> Self {
         Self {
             executable,
             decryption_nonce,
         }
     }
 
-    pub fn unwrap(self) -> (TransactionExecutable, u64) {
+    pub fn unwrap(self) -> (TransactionExecutable, DecryptionNonce) {
         (self.executable, self.decryption_nonce)
     }
 }
@@ -67,6 +70,8 @@ pub enum DecryptionFailureReason {
     DecryptionKeyUnavailable,
     /// The claimed entry function does not match the one in the decrypted payload
     ClaimedEntryFunctionMismatch,
+    /// The stored payload hash does not match the decrypted payload.
+    PayloadHashMismatch,
 }
 
 // Mirrors EntryFunction in types/src/transaction/script.rs
@@ -101,7 +106,7 @@ pub enum EncryptedPayload {
 
         // decrypted things
         executable: TransactionExecutable,
-        decryption_nonce: u64,
+        decryption_nonce: DecryptionNonce,
     },
 }
 
@@ -155,7 +160,7 @@ impl EncryptedPayload {
         &mut self,
         eval_proof: EvalProof,
         executable: TransactionExecutable,
-        nonce: u64,
+        nonce: DecryptionNonce,
     ) -> anyhow::Result<()> {
         let Self::Encrypted {
             ciphertext,
@@ -177,6 +182,14 @@ impl EncryptedPayload {
             claimed_entry_fun: claimed_entry_fun.clone(),
         };
         Ok(())
+    }
+
+    pub fn verify_payload_hash(&self, decrypted: &DecryptedPayload) -> anyhow::Result<bool> {
+        let Self::Encrypted { payload_hash, .. } = self else {
+            bail!("Payload is not in Encrypted state");
+        };
+
+        Ok(*payload_hash == CryptoHash::hash(decrypted))
     }
 
     pub fn entry_fun_matches(&self, decrypted: &DecryptedPayload) -> anyhow::Result<bool> {
@@ -241,5 +254,43 @@ impl EncryptedPayload {
     ) -> anyhow::Result<()> {
         let associated_data = PayloadAssociatedData::new(sender, auth_key);
         self.ciphertext().verify(&associated_data)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::transaction::TransactionExtraConfig;
+
+    #[test]
+    fn verify_payload_hash_accepts_matching_hash() {
+        let decrypted = DecryptedPayload::new(TransactionExecutable::Empty, [7; 16]);
+        let encrypted = EncryptedPayload::Encrypted {
+            ciphertext: Ciphertext::random(),
+            extra_config: TransactionExtraConfig::V1 {
+                multisig_address: None,
+                replay_protection_nonce: None,
+            },
+            payload_hash: CryptoHash::hash(&decrypted),
+            claimed_entry_fun: None,
+        };
+
+        assert!(encrypted.verify_payload_hash(&decrypted).unwrap());
+    }
+
+    #[test]
+    fn verify_payload_hash_rejects_mismatched_hash() {
+        let decrypted = DecryptedPayload::new(TransactionExecutable::Empty, [7; 16]);
+        let encrypted = EncryptedPayload::Encrypted {
+            ciphertext: Ciphertext::random(),
+            extra_config: TransactionExtraConfig::V1 {
+                multisig_address: None,
+                replay_protection_nonce: None,
+            },
+            payload_hash: HashValue::random(),
+            claimed_entry_fun: None,
+        };
+
+        assert!(!encrypted.verify_payload_hash(&decrypted).unwrap());
     }
 }

--- a/types/src/transaction/encrypted_payload.rs
+++ b/types/src/transaction/encrypted_payload.rs
@@ -72,6 +72,8 @@ pub enum DecryptionFailureReason {
     ClaimedEntryFunctionMismatch,
     /// The stored payload hash does not match the decrypted payload.
     PayloadHashMismatch,
+    /// The payload was encrypted for a different epoch than the available decryption key.
+    EpochMismatch,
 }
 
 // Mirrors EntryFunction in types/src/transaction/script.rs
@@ -87,12 +89,14 @@ pub enum EncryptedPayload {
         ciphertext: Ciphertext,
         extra_config: TransactionExtraConfig,
         payload_hash: HashValue,
+        encryption_epoch: u64,
         claimed_entry_fun: Option<ClaimedEntryFunction>,
     },
     FailedDecryption {
         ciphertext: Ciphertext,
         extra_config: TransactionExtraConfig,
         payload_hash: HashValue,
+        encryption_epoch: u64,
         claimed_entry_fun: Option<ClaimedEntryFunction>,
         eval_proof: Option<EvalProof>,
         reason: DecryptionFailureReason,
@@ -101,6 +105,7 @@ pub enum EncryptedPayload {
         ciphertext: Ciphertext,
         extra_config: TransactionExtraConfig,
         payload_hash: HashValue,
+        encryption_epoch: u64,
         claimed_entry_fun: Option<ClaimedEntryFunction>,
         eval_proof: EvalProof,
 
@@ -152,6 +157,20 @@ impl EncryptedPayload {
         }
     }
 
+    pub fn encryption_epoch(&self) -> u64 {
+        match self {
+            EncryptedPayload::Encrypted {
+                encryption_epoch, ..
+            }
+            | EncryptedPayload::FailedDecryption {
+                encryption_epoch, ..
+            }
+            | EncryptedPayload::Decrypted {
+                encryption_epoch, ..
+            } => *encryption_epoch,
+        }
+    }
+
     pub fn is_encrypted(&self) -> bool {
         matches!(self, Self::Encrypted { .. })
     }
@@ -166,6 +185,7 @@ impl EncryptedPayload {
             ciphertext,
             extra_config,
             payload_hash,
+            encryption_epoch,
             claimed_entry_fun,
         } = self
         else {
@@ -176,6 +196,7 @@ impl EncryptedPayload {
             ciphertext: ciphertext.clone(),
             extra_config: extra_config.clone(),
             payload_hash: *payload_hash,
+            encryption_epoch: *encryption_epoch,
             eval_proof,
             executable,
             decryption_nonce: nonce,
@@ -229,6 +250,7 @@ impl EncryptedPayload {
             ciphertext,
             extra_config,
             payload_hash,
+            encryption_epoch,
             claimed_entry_fun,
         } = self
         {
@@ -236,6 +258,7 @@ impl EncryptedPayload {
                 ciphertext: ciphertext.clone(),
                 extra_config: extra_config.clone(),
                 payload_hash: *payload_hash,
+                encryption_epoch: *encryption_epoch,
                 claimed_entry_fun: claimed_entry_fun.clone(),
                 eval_proof,
                 reason,
@@ -272,6 +295,7 @@ mod tests {
                 replay_protection_nonce: None,
             },
             payload_hash: CryptoHash::hash(&decrypted),
+            encryption_epoch: 7,
             claimed_entry_fun: None,
         };
 
@@ -288,9 +312,31 @@ mod tests {
                 replay_protection_nonce: None,
             },
             payload_hash: HashValue::random(),
+            encryption_epoch: 7,
             claimed_entry_fun: None,
         };
 
         assert!(!encrypted.verify_payload_hash(&decrypted).unwrap());
+    }
+
+    #[test]
+    fn state_transitions_preserve_encryption_epoch() {
+        let mut encrypted = EncryptedPayload::Encrypted {
+            ciphertext: Ciphertext::random(),
+            extra_config: TransactionExtraConfig::V1 {
+                multisig_address: None,
+                replay_protection_nonce: None,
+            },
+            payload_hash: HashValue::random(),
+            encryption_epoch: 11,
+            claimed_entry_fun: None,
+        };
+
+        assert_eq!(encrypted.encryption_epoch(), 11);
+
+        encrypted
+            .into_failed_decryption_with_reason(None, DecryptionFailureReason::EpochMismatch)
+            .unwrap();
+        assert_eq!(encrypted.encryption_epoch(), 11);
     }
 }

--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -697,6 +697,7 @@ impl RawTransaction {
                 ciphertext,
                 extra_config,
                 payload_hash,
+                encryption_epoch,
                 claimed_entry_fun,
                 ..
             })
@@ -704,6 +705,7 @@ impl RawTransaction {
                 ciphertext,
                 extra_config,
                 payload_hash,
+                encryption_epoch,
                 claimed_entry_fun,
                 ..
             }) => Cow::Owned(RawTransaction {
@@ -713,6 +715,7 @@ impl RawTransaction {
                     ciphertext: ciphertext.clone(),
                     extra_config: extra_config.clone(),
                     payload_hash: *payload_hash,
+                    encryption_epoch: *encryption_epoch,
                     claimed_entry_fun: claimed_entry_fun.clone(),
                 }),
                 max_gas_amount: self.max_gas_amount,

--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -694,30 +694,17 @@ impl RawTransaction {
     pub fn as_encrypted_variant(&self) -> Cow<'_, Self> {
         match &self.payload {
             TransactionPayload::EncryptedPayload(EncryptedPayload::Decrypted {
-                ciphertext,
-                extra_config,
-                payload_hash,
-                encryption_epoch,
-                claimed_entry_fun,
-                ..
+                original, ..
             })
             | TransactionPayload::EncryptedPayload(EncryptedPayload::FailedDecryption {
-                ciphertext,
-                extra_config,
-                payload_hash,
-                encryption_epoch,
-                claimed_entry_fun,
+                original,
                 ..
             }) => Cow::Owned(RawTransaction {
                 sender: self.sender,
                 sequence_number: self.sequence_number,
-                payload: TransactionPayload::EncryptedPayload(EncryptedPayload::Encrypted {
-                    ciphertext: ciphertext.clone(),
-                    extra_config: extra_config.clone(),
-                    payload_hash: *payload_hash,
-                    encryption_epoch: *encryption_epoch,
-                    claimed_entry_fun: claimed_entry_fun.clone(),
-                }),
+                payload: TransactionPayload::EncryptedPayload(EncryptedPayload::Encrypted(
+                    original.clone(),
+                )),
                 max_gas_amount: self.max_gas_amount,
                 gas_unit_price: self.gas_unit_price,
                 expiration_timestamp_secs: self.expiration_timestamp_secs,


### PR DESCRIPTION
## Summary
- validate `payload_hash` against the decrypted plaintext before transitioning encrypted transactions to the decrypted state
- stamp encrypted transactions with `encryption_epoch` and fail decryption deterministically with `EpochMismatch` when the decrypting epoch does not match
- widen the decryption nonce to 16 bytes for stronger hiding of `payload_hash`
- restructure `EncryptedPayload` state to preserve the original encrypted submission as `EncryptedInner` across `Encrypted`, `FailedDecryption`, and `Decrypted`

## Commit organization
- `2dcad7a24c` `[types] Validate encrypted payload hashes`
  - correctness/security fix for post-decryption payload validation
- `80fff5fac4` `[types] Stamp encrypted transaction epoch`
  - behavioral fix for next-epoch decryption failures via explicit epoch stamping and `EpochMismatch`
- `a60728aa43` `[types] Extract encrypted payload state`
  - refactors the state model to carry the original encrypted payload explicitly; this also changes the `EncryptedPayload` wire/serde shape and regenerates staged serde-format snapshots

## Testing
- `./scripts/rust_lint.sh`
- `cargo check -p aptos-types -p aptos-sdk -p aptos-api-types -p aptos-consensus -p aptos-transaction-filters -p e2e-move-tests`
- `cargo test -p aptos-types verify_payload_hash_`
- `cargo test -p aptos-types transaction::encrypted_payload::tests`
- `cargo test -p e2e-move-tests failed_encrypted_transaction_increments_sequence_number`
- `cargo run -p generate-format -- --corpus API --record`
- `cargo run -p generate-format -- --corpus Aptos --record`
- `cargo run -p generate-format -- --corpus Consensus --record`
- `cargo test -p generate-format analyze_serde_formats`