### PR TITLE
[test] Fix test_large_total_stake div-by-zero in fee distribution

### DIFF
--- a/testsuite/smoke-test/src/aptos_cli/validator.rs
+++ b/testsuite/smoke-test/src/aptos_cli/validator.rs
@@ -562,6 +562,7 @@ async fn test_large_total_stake() {
             genesis_config.epoch_duration_secs = 4;
             genesis_config.recurring_lockup_duration_secs = 4;
             genesis_config.voting_duration_secs = 3;
+            genesis_config.min_stake = 10_000_000;
             genesis_config.randomness_config_override =
                 Some(OnChainRandomnessConfig::default_disabled());
         }))
@@ -572,7 +573,8 @@ async fn test_large_total_stake() {
     let rest_client = swarm.validators().next().unwrap().rest_client();
 
     let mut keygen = KeyGen::from_os_rng();
-    let (validator_cli_index, keys) = init_validator_account(&mut cli, &mut keygen, None).await;
+    let (validator_cli_index, keys) =
+        init_validator_account(&mut cli, &mut keygen, Some(200_000_000)).await;
     // faucet can make our root LocalAccount sequence number get out of sync.
     swarm
         .chain_info()
@@ -592,6 +594,10 @@ async fn test_large_total_stake() {
     )
     .await
     .unwrap();
+
+    cli.add_stake(validator_cli_index, 100_000_000)
+        .await
+        .unwrap();
 
     cli.join_validator_set(validator_cli_index, None)
         .await


### PR DESCRIPTION
## Summary
- `test_large_total_stake` was failing with a division by zero in `stake::update_stake_pool` during fee distribution
- Root cause: the 5th validator joined the active set with **zero stake** (default `min_stake` was 0), so `stake_active + stake_pending_inactive = 0` triggered `Div` by zero in the fee split calculation
- Set `min_stake = 10_000_000` to a representative value and add `100_000_000` stake for the 5th validator before joining

## Test plan
- [ ] `test_large_total_stake` passes without the division by zero error

🤖 Generated with [Claude Code](https://claude.com/claude-code)