### PR TITLE
[trivial][Move prover] fix benchmark option

### DIFF
--- a/aptos-move/framework/src/prover.rs
+++ b/aptos-move/framework/src/prover.rs
@@ -311,26 +311,32 @@ fn run_prover_benchmark(
     mut options: Options,
 ) -> anyhow::Result<()> {
     info!("starting prover benchmark");
-    // Determine sources and dependencies from the env
-    let mut sources = BTreeSet::new();
+    // Determine sources and dependencies from the env.
+    // We collect parent *directories* (not individual files) for both sources and deps so that
+    // the Move compiler finds all `.move` AND `.spec.move` files in each directory.
+    let mut sources: Vec<String> = vec![];
     let mut deps: Vec<String> = vec![];
     for module in env.get_modules() {
         let file_name = module.get_source_path().to_string_lossy().to_string();
-        if module.is_primary_target() {
-            sources.insert(module.get_source_path().to_string_lossy().to_string());
-        } else if let Some(p) = Path::new(&file_name)
+        let target = if module.is_primary_target() {
+            &mut sources
+        } else {
+            &mut deps
+        };
+        if let Some(p) = Path::new(&file_name)
             .parent()
             .and_then(|p| p.canonicalize().ok())
         {
-            // The prover doesn't like to have `p` and `p/s` as dep paths, filter those out
+            // The prover doesn't like to have `p` and `p/s` as paths, filter those out
             let p = p.to_string_lossy().to_string();
             let mut done = false;
-            for d in &mut deps {
-                if p.starts_with(&*d) {
-                    // p is subsumed
+            for d in target.iter_mut() {
+                // Use Path::starts_with for component-level prefix checks.
+                if Path::new(&p).starts_with(&*d) {
+                    // p is subsumed by d
                     done = true;
                     break;
-                } else if d.starts_with(&p) {
+                } else if Path::new(&*d).starts_with(&p) {
                     // p is more general or equal to d, swap it out
                     *d = p.to_string();
                     done = true;
@@ -338,12 +344,14 @@ fn run_prover_benchmark(
                 }
             }
             if !done {
-                deps.push(p)
+                target.push(p)
             }
         } else {
             bail!("invalid file path `{}`", file_name)
         }
     }
+    // Remove from `deps` any path that is already covered by a `sources` entry so the directory is not compiled twice.
+    deps.retain(|d| !sources.iter().any(|s| Path::new(d).starts_with(s)));
 
     // Enrich the prover options by the aliases in the env
     for (alias, address) in env.get_address_alias_map() {


### PR DESCRIPTION
## Description

Fixes a compilation error that occurred when running `aptos move prove --benchmark` against packages that use spec-native functions defined in `.spec.move` files.

**Root cause**: `run_prover_benchmark` in `aptos-move/framework/src/prover.rs` collected primary-target modules as individual `.move` file paths and passed them as `sources` to the benchmark sub-invocation. When the benchmark tool called `create_move_prover_v2_model` with those individual files, the Move v2 compiler never scanned for adjacent `.spec.move` files, so spec-native functions defined in those files were missing.

**Fix**: Changed source collection to use parent **directories** (with the same prefix-deduplication logic already used for deps) instead of individual `.move` file paths. The Move compiler then finds all `.move` and `.spec.move` files in each directory, resolving the missing spec functions.

## How Has This Been Tested?

Manual test by running `aptos move --benchmark` against aptos-framework and aptos-stdlib.

## Type of Change
- [x] Bug fix

## Which Components or Systems Does This Change Impact?
- [x] Move/Aptos Virtual Machine
- [x] Aptos Framework

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Limited to benchmark-only prover invocation argument construction, mainly affecting which directories are compiled rather than verification semantics.
> 
> **Overview**
> Fixes `aptos move prove --benchmark` by changing `run_prover_benchmark` to pass *directory* paths (not individual `.move` files) for both sources and dependencies so the compiler also picks up adjacent `.spec.move` files.
> 
> It also tightens path de-duplication using `Path::starts_with` and removes any `deps` entries already covered by a `sources` directory to avoid compiling the same directory twice.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed6e1aa3b972b3784d174bd6c7752b4c13cb4df3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->