### PR TITLE
[consensus] Harden SecretShareManager: state preservation, skipped rounds, requester ordering

### DIFF
--- a/consensus/src/rand/secret_sharing/secret_share_manager.rs
+++ b/consensus/src/rand/secret_sharing/secret_share_manager.rs
@@ -268,7 +268,8 @@ impl SecretShareManager {
                         .filter(|author| !existing.contains(author))
                         .collect();
                     if !targets.is_empty() {
-                        let guard = self.spawn_share_requester_for_targets(metadata, targets, 0);
+                        let guard =
+                            self.spawn_share_requester_for_targets(metadata, Some(targets), 0);
                         if let Some(item) = self.block_queue.item_mut(round) {
                             item.push_share_requester_handle(guard);
                         }
@@ -327,30 +328,17 @@ impl SecretShareManager {
     }
 
     fn spawn_share_requester_task(&self, metadata: SecretShareMetadata) -> DropGuard {
-        let secret_share_store = self.secret_share_store.clone();
-        let existing_shares = secret_share_store.lock().get_all_shares_authors(&metadata);
-        let targets: Vec<Author> = match existing_shares {
-            Some(existing) => self
-                .epoch_state
-                .verifier
-                .get_ordered_account_addresses_iter()
-                .filter(|author| !existing.contains(author))
-                .collect(),
-            None => return DropGuard::new(AbortHandle::new_pair().0),
-        };
-        self.spawn_share_requester_for_targets(
-            metadata,
-            targets,
-            self.secret_share_request_delay_ms,
-        )
+        self.spawn_share_requester_for_targets(metadata, None, self.secret_share_request_delay_ms)
     }
 
     fn spawn_share_requester_for_targets(
         &self,
         metadata: SecretShareMetadata,
-        targets: Vec<Author>,
+        targets: Option<Vec<Author>>,
         delay_ms: u64,
     ) -> DropGuard {
+        let secret_share_store = self.secret_share_store.clone();
+        let epoch_state = self.epoch_state.clone();
         let rb = self.reliable_broadcast.clone();
         let aggregate_state = Arc::new(SecretShareAggregateState::new(
             self.secret_share_store.clone(),
@@ -361,6 +349,24 @@ impl SecretShareManager {
         let task = async move {
             if delay_ms > 0 {
                 tokio::time::sleep(Duration::from_millis(delay_ms)).await;
+            }
+            let targets: Vec<Author> = match targets {
+                Some(t) => t,
+                None => {
+                    let existing_shares =
+                        secret_share_store.lock().get_all_shares_authors(&metadata);
+                    match existing_shares {
+                        Some(existing) => epoch_state
+                            .verifier
+                            .get_ordered_account_addresses_iter()
+                            .filter(|author| !existing.contains(author))
+                            .collect(),
+                        None => return,
+                    }
+                },
+            };
+            if targets.is_empty() {
+                return;
             }
             info!(
                 epoch = epoch,

--- a/consensus/src/rand/secret_sharing/secret_share_manager.rs
+++ b/consensus/src/rand/secret_sharing/secret_share_manager.rs
@@ -166,6 +166,7 @@ impl SecretShareManager {
                 if let Some(item) = self.block_queue.item_mut(round) {
                     item.resolve_round_without_key(round);
                 }
+                self.secret_share_store.lock().mark_round_skipped(round);
                 return;
             },
             Err(e) => {

--- a/consensus/src/rand/secret_sharing/secret_share_store.rs
+++ b/consensus/src/rand/secret_sharing/secret_share_store.rs
@@ -318,27 +318,30 @@ impl SecretShareItem {
         share: SecretShare,
         share_weights: &HashMap<Author, u64>,
     ) -> anyhow::Result<()> {
-        let item = std::mem::replace(self, Self::new(Author::ONE));
-        let share_weight = *share_weights
-            .get(share.author())
-            .ok_or_else(|| anyhow::anyhow!("Author {} not found in weights", share.author()))?;
-        let new_item = match item {
-            SecretShareItem::PendingMetadata(mut share_aggregator) => {
+        match self {
+            SecretShareItem::PendingMetadata(_) => {
+                let share_weight = *share_weights.get(share.author()).ok_or_else(|| {
+                    anyhow::anyhow!("Author {} not found in weights", share.author())
+                })?;
+                let SecretShareItem::PendingMetadata(mut share_aggregator) =
+                    std::mem::replace(self, Self::new(Author::ONE))
+                else {
+                    unreachable!("variant gated above")
+                };
                 let metadata = share.metadata.clone();
                 share_aggregator.retain(share.metadata(), share_weights);
                 share_aggregator.add_share(share, share_weight);
-                SecretShareItem::PendingDecision {
+                *self = SecretShareItem::PendingDecision {
                     metadata,
                     share_aggregator,
-                }
+                };
+                Ok(())
             },
             SecretShareItem::PendingDecision { .. } => {
-                bail!("Cannot add self share in PendingDecision state");
+                bail!("Cannot add self share in PendingDecision state")
             },
-            SecretShareItem::Aggregating { .. } | SecretShareItem::Decided { .. } => return Ok(()),
-        };
-        let _ = std::mem::replace(self, new_item);
-        Ok(())
+            SecretShareItem::Aggregating { .. } | SecretShareItem::Decided { .. } => Ok(()),
+        }
     }
 
     fn get_all_shares_authors(&self) -> Option<HashSet<Author>> {
@@ -836,5 +839,104 @@ mod tests {
             .expect("Timed out waiting for decision")
             .expect("Channel closed unexpectedly");
         assert_eq!(unwrap_success(result).metadata, metadata);
+    }
+
+    fn variant_name(item: &SecretShareItem) -> &'static str {
+        match item {
+            SecretShareItem::PendingMetadata(_) => "PendingMetadata",
+            SecretShareItem::PendingDecision { .. } => "PendingDecision",
+            SecretShareItem::Aggregating { .. } => "Aggregating",
+            SecretShareItem::Decided { .. } => "Decided",
+        }
+    }
+
+    #[test]
+    fn test_add_share_with_metadata_on_pending_decision_preserves_state() {
+        let ctx = TestContext::new(vec![1, 1, 1, 1]);
+        let metadata = create_metadata(ctx.epoch, 5);
+        let peer_weights = ctx.secret_share_config.get_peer_weights().clone();
+
+        let mut aggregator = SecretShareAggregator::new(ctx.authors[0]);
+        let peer_share = create_secret_share(&ctx, 1, &metadata);
+        let w1 = ctx
+            .secret_share_config
+            .get_peer_weight(&ctx.authors[1])
+            .unwrap();
+        aggregator.add_share(peer_share, w1);
+
+        let shares_before = aggregator.shares.clone();
+        let total_weight_before = aggregator.total_weight;
+
+        let mut item = SecretShareItem::PendingDecision {
+            metadata: metadata.clone(),
+            share_aggregator: aggregator,
+        };
+
+        let self_share = create_secret_share(&ctx, 0, &metadata);
+        let result = item.add_share_with_metadata(self_share, &peer_weights);
+        assert!(result.is_err());
+
+        match &item {
+            SecretShareItem::PendingDecision {
+                metadata: m,
+                share_aggregator,
+            } => {
+                assert_eq!(m, &metadata);
+                assert_eq!(share_aggregator.shares.len(), shares_before.len());
+                for (author, share) in &shares_before {
+                    let got = share_aggregator
+                        .shares
+                        .get(author)
+                        .expect("share should be preserved");
+                    assert_eq!(got.author, share.author);
+                    assert_eq!(got.metadata, share.metadata);
+                }
+                assert_eq!(share_aggregator.total_weight, total_weight_before);
+            },
+            other => panic!("Expected PendingDecision, got {}", variant_name(other)),
+        }
+    }
+
+    #[test]
+    fn test_add_share_with_metadata_unknown_author_preserves_state() {
+        let ctx = TestContext::new(vec![1, 1, 1, 1]);
+        let metadata = create_metadata(ctx.epoch, 5);
+        let peer_weights = ctx.secret_share_config.get_peer_weights().clone();
+
+        let mut aggregator = SecretShareAggregator::new(ctx.authors[0]);
+        let peer_share = create_secret_share(&ctx, 1, &metadata);
+        let w1 = ctx
+            .secret_share_config
+            .get_peer_weight(&ctx.authors[1])
+            .unwrap();
+        aggregator.add_share(peer_share, w1);
+
+        let shares_before = aggregator.shares.clone();
+        let total_weight_before = aggregator.total_weight;
+
+        let mut item = SecretShareItem::PendingMetadata(aggregator);
+
+        let unknown_author = Author::random();
+        let self_share_template = create_secret_share(&ctx, 0, &metadata);
+        let unknown_share = SecretShare::new(
+            unknown_author,
+            metadata.clone(),
+            self_share_template.share.clone(),
+        );
+        let result = item.add_share_with_metadata(unknown_share, &peer_weights);
+        assert!(result.is_err());
+
+        match &item {
+            SecretShareItem::PendingMetadata(aggr) => {
+                assert_eq!(aggr.shares.len(), shares_before.len());
+                for (author, share) in &shares_before {
+                    let got = aggr.shares.get(author).expect("share should be preserved");
+                    assert_eq!(got.author, share.author);
+                    assert_eq!(got.metadata, share.metadata);
+                }
+                assert_eq!(aggr.total_weight, total_weight_before);
+            },
+            other => panic!("Expected PendingMetadata, got {}", variant_name(other)),
+        }
     }
 }

--- a/consensus/src/rand/secret_sharing/secret_share_store.rs
+++ b/consensus/src/rand/secret_sharing/secret_share_store.rs
@@ -987,6 +987,41 @@ mod tests {
     }
 
     #[test]
+    fn test_get_all_shares_authors_returns_none_for_terminal_and_preaggregation_states() {
+        // The share-requester task relies on `get_all_shares_authors` returning
+        // `None` for any state in which requesting more shares is useless:
+        //   - Aggregating / Decided: we already have (or are finalizing) enough
+        //     shares; retry is driven by `process_aggregation_result` instead.
+        //   - Skipped: round has no encrypted txns.
+        //   - PendingMetadata: self-share not yet derived, we have no metadata
+        //     to request against.
+        // Only `PendingDecision` returns `Some(known_authors)`.
+        let ctx = TestContext::new(vec![1, 1, 1, 1]);
+        let metadata = create_metadata(ctx.epoch, 5);
+
+        // Aggregating
+        let self_share = create_secret_share(&ctx, 0, &metadata);
+        let item = SecretShareItem::Aggregating {
+            metadata: metadata.clone(),
+            self_share: self_share.clone(),
+            pending_shares: HashMap::new(),
+        };
+        assert!(item.get_all_shares_authors().is_none());
+
+        // Decided
+        let item = SecretShareItem::Decided { self_share };
+        assert!(item.get_all_shares_authors().is_none());
+
+        // Skipped
+        let item = SecretShareItem::Skipped;
+        assert!(item.get_all_shares_authors().is_none());
+
+        // PendingMetadata
+        let item = SecretShareItem::PendingMetadata(SecretShareAggregator::new(ctx.authors[0]));
+        assert!(item.get_all_shares_authors().is_none());
+    }
+
+    #[test]
     fn test_mark_round_skipped_rejects_future_shares() {
         let ctx = TestContext::new(vec![1, 1, 1, 1]);
         let (mut store, _rx) = make_store(&ctx);

--- a/consensus/src/rand/secret_sharing/secret_share_store.rs
+++ b/consensus/src/rand/secret_sharing/secret_share_store.rs
@@ -192,6 +192,8 @@ enum SecretShareItem {
     Decided {
         self_share: SecretShare,
     },
+    /// Round had no encrypted txns; key derivation skipped, further shares rejected.
+    Skipped,
 }
 
 impl SecretShareItem {
@@ -238,6 +240,9 @@ impl SecretShareItem {
                 Ok(())
             },
             SecretShareItem::Decided { .. } => Ok(()),
+            SecretShareItem::Skipped => {
+                bail!("Received share for skipped round")
+            },
         }
     }
 
@@ -265,6 +270,10 @@ impl SecretShareItem {
             item @ (SecretShareItem::Decided { .. }
             | SecretShareItem::PendingMetadata(_)
             | SecretShareItem::Aggregating { .. }) => item,
+            SecretShareItem::Skipped => {
+                warn!("try_aggregate called on skipped round — logic bug");
+                SecretShareItem::Skipped
+            },
         };
         let _ = std::mem::replace(self, new_item);
     }
@@ -273,7 +282,13 @@ impl SecretShareItem {
         let item = std::mem::replace(self, Self::new(Author::ONE));
         let new_item = match item {
             SecretShareItem::Aggregating { self_share, .. } => Self::Decided { self_share },
-            other => other,
+            other @ (SecretShareItem::PendingMetadata(_)
+            | SecretShareItem::PendingDecision { .. }
+            | SecretShareItem::Decided { .. }) => other,
+            SecretShareItem::Skipped => {
+                warn!("aggregation_succeeded called on skipped round — logic bug");
+                SecretShareItem::Skipped
+            },
         };
         let _ = std::mem::replace(self, new_item);
     }
@@ -308,7 +323,13 @@ impl SecretShareItem {
                     share_aggregator: aggregator,
                 }
             },
-            other => other,
+            other @ (SecretShareItem::PendingMetadata(_)
+            | SecretShareItem::PendingDecision { .. }
+            | SecretShareItem::Decided { .. }) => other,
+            SecretShareItem::Skipped => {
+                warn!("aggregation_failed called on skipped round — logic bug");
+                SecretShareItem::Skipped
+            },
         };
         let _ = std::mem::replace(self, new_item);
     }
@@ -341,6 +362,9 @@ impl SecretShareItem {
                 bail!("Cannot add self share in PendingDecision state")
             },
             SecretShareItem::Aggregating { .. } | SecretShareItem::Decided { .. } => Ok(()),
+            SecretShareItem::Skipped => {
+                bail!("Cannot add self share for skipped round")
+            },
         }
     }
 
@@ -351,7 +375,8 @@ impl SecretShareItem {
             } => Some(share_aggregator.shares.keys().cloned().collect()),
             SecretShareItem::Aggregating { .. }
             | SecretShareItem::Decided { .. }
-            | SecretShareItem::PendingMetadata(_) => None,
+            | SecretShareItem::PendingMetadata(_)
+            | SecretShareItem::Skipped => None,
         }
     }
 
@@ -363,6 +388,7 @@ impl SecretShareItem {
             } => share_aggregator.get_self_share(),
             SecretShareItem::Aggregating { self_share, .. }
             | SecretShareItem::Decided { self_share, .. } => Some(self_share.clone()),
+            SecretShareItem::Skipped => None,
         }
     }
 }
@@ -450,6 +476,24 @@ impl SecretShareStore {
         item.add_share(share, weight)?;
         item.try_aggregate(&self.verifier, self.decision_tx.clone());
         Ok(item.has_decision())
+    }
+
+    pub fn mark_round_skipped(&mut self, round: Round) {
+        if let Some(existing) = self.secret_share_map.get(&round) {
+            match existing {
+                SecretShareItem::PendingMetadata(_) | SecretShareItem::Skipped => {},
+                SecretShareItem::PendingDecision { .. }
+                | SecretShareItem::Aggregating { .. }
+                | SecretShareItem::Decided { .. } => {
+                    warn!(
+                        round = round,
+                        "mark_round_skipped overwriting active state — logic bug"
+                    );
+                },
+            }
+        }
+        self.secret_share_map
+            .insert(round, SecretShareItem::Skipped);
     }
 
     pub fn handle_aggregation_success(&mut self, round: Round) {
@@ -786,6 +830,7 @@ mod tests {
                 SecretShareItem::PendingMetadata(_) => "PendingMetadata",
                 SecretShareItem::Aggregating { .. } => "Aggregating",
                 SecretShareItem::Decided { .. } => "Decided",
+                SecretShareItem::Skipped => "Skipped",
                 SecretShareItem::PendingDecision { .. } => unreachable!(),
             }),
         }
@@ -847,6 +892,7 @@ mod tests {
             SecretShareItem::PendingDecision { .. } => "PendingDecision",
             SecretShareItem::Aggregating { .. } => "Aggregating",
             SecretShareItem::Decided { .. } => "Decided",
+            SecretShareItem::Skipped => "Skipped",
         }
     }
 
@@ -937,6 +983,90 @@ mod tests {
                 assert_eq!(aggr.total_weight, total_weight_before);
             },
             other => panic!("Expected PendingMetadata, got {}", variant_name(other)),
+        }
+    }
+
+    #[test]
+    fn test_mark_round_skipped_rejects_future_shares() {
+        let ctx = TestContext::new(vec![1, 1, 1, 1]);
+        let (mut store, _rx) = make_store(&ctx);
+        let round = 5;
+        store.update_highest_known_round(round);
+        let metadata = create_metadata(ctx.epoch, round);
+
+        store.mark_round_skipped(round);
+        match store
+            .secret_share_map
+            .get(&round)
+            .expect("entry should exist after mark_round_skipped")
+        {
+            SecretShareItem::Skipped => {},
+            other => panic!("Expected Skipped, got {}", variant_name(other)),
+        }
+
+        let peer_share = create_secret_share(&ctx, 1, &metadata);
+        assert!(store.add_share(peer_share).is_err());
+
+        match store
+            .secret_share_map
+            .get(&round)
+            .expect("entry should still exist")
+        {
+            SecretShareItem::Skipped => {},
+            other => panic!(
+                "Expected Skipped after add_share, got {}",
+                variant_name(other)
+            ),
+        }
+    }
+
+    #[test]
+    fn test_mark_round_skipped_after_pending_metadata() {
+        let ctx = TestContext::new(vec![1, 1, 1, 1]);
+        let (mut store, _rx) = make_store(&ctx);
+        let round = 5;
+        store.update_highest_known_round(round);
+        let metadata = create_metadata(ctx.epoch, round);
+
+        let peer_share = create_secret_share(&ctx, 1, &metadata);
+        store
+            .add_share(peer_share)
+            .expect("add_share should succeed for fresh round");
+
+        match store
+            .secret_share_map
+            .get(&round)
+            .expect("entry should exist after add_share")
+        {
+            SecretShareItem::PendingMetadata(aggr) => {
+                assert_eq!(aggr.shares.len(), 1);
+            },
+            other => panic!("Expected PendingMetadata, got {}", variant_name(other)),
+        }
+
+        store.mark_round_skipped(round);
+        match store
+            .secret_share_map
+            .get(&round)
+            .expect("entry should exist after mark_round_skipped")
+        {
+            SecretShareItem::Skipped => {},
+            other => panic!("Expected Skipped, got {}", variant_name(other)),
+        }
+
+        let peer_share_2 = create_secret_share(&ctx, 2, &metadata);
+        assert!(store.add_share(peer_share_2).is_err());
+
+        match store
+            .secret_share_map
+            .get(&round)
+            .expect("entry should still exist")
+        {
+            SecretShareItem::Skipped => {},
+            other => panic!(
+                "Expected Skipped after subsequent add_share, got {}",
+                variant_name(other)
+            ),
         }
     }
 }


### PR DESCRIPTION
## Summary

Three correctness/robustness fixes for `SecretShareManager`. A companion PR covers a separate DoS / player-validation hardening pass on the same code path.

### Commits

1. **`[consensus] Preserve state in add_share_with_metadata error paths`**
   The variant check and `share_weights` lookup happened *after* `mem::replace`, so any error path left `self` as a freshly-initialized `PendingMetadata` — losing accumulated `PendingDecision` state. Hoisted both fallible checks before the replace; collapsed to a single `match` with a let-else for the post-gate variant extraction.

2. **`[consensus] Mark empty rounds as skipped in secret share store`**
   When a round has no encrypted txns, `process_completed_derive` returned without ever transitioning the store entry past `PendingMetadata`, so late-arriving peer shares accumulated until epoch end. Added a `Skipped` terminal variant; `mark_round_skipped` is called from the `Ok(None)` branch. Subsequent peer shares for skipped rounds now error; aggregation paths warn loudly if reached on a skipped round (logic-bug indicator).

3. **`[consensus] Compute share requester targets after delay`**
   The requester task pre-computed its target list before sleeping for `secret_share_request_delay_ms`, then multicast to that stale list — wasting bandwidth on shares that arrived during the delay. Moved target computation into the task body after the sleep, with early exit if the round became terminal during the delay. `spawn_share_requester_for_targets` now accepts `Option<Vec<Author>>`: `None` triggers post-delay computation; `Some(t)` (failure-retry caller) keeps the existing pre-computed-target behavior.

## Test plan

- [x] `cargo test -p aptos-consensus -- secret_sharing` — 32 passed, 0 failed (5 new tests added across the three commits)
- [x] `cargo +nightly fmt -p aptos-consensus` — clean
- [x] `cargo clippy -p aptos-consensus --all-targets` — no new warnings tied to changed files
- [ ] Smoke test on devnet (gated on companion PR landing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)