### PR TITLE
[consensus] Lower opt_qs_minimum_batch_age_usecs from 50ms to 20ms

### DIFF
--- a/config/src/config/quorum_store_config.rs
+++ b/config/src/config/quorum_store_config.rs
@@ -155,7 +155,7 @@ impl Default for QuorumStoreConfig {
             batch_buckets: DEFAULT_BUCKETS.to_vec(),
             allow_batches_without_pos_in_proposal: true,
             enable_opt_quorum_store: true,
-            opt_qs_minimum_batch_age_usecs: Duration::from_millis(20).as_micros() as u64,
+            opt_qs_minimum_batch_age_usecs: Duration::from_millis(10).as_micros() as u64,
             enable_payload_v2: false,
             enable_batch_v2_tx: false,
             enable_batch_v2_rx: true,

--- a/config/src/config/quorum_store_config.rs
+++ b/config/src/config/quorum_store_config.rs
@@ -155,7 +155,7 @@ impl Default for QuorumStoreConfig {
             batch_buckets: DEFAULT_BUCKETS.to_vec(),
             allow_batches_without_pos_in_proposal: true,
             enable_opt_quorum_store: true,
-            opt_qs_minimum_batch_age_usecs: Duration::from_millis(50).as_micros() as u64,
+            opt_qs_minimum_batch_age_usecs: Duration::from_millis(20).as_micros() as u64,
             enable_payload_v2: false,
             enable_batch_v2_tx: false,
             enable_batch_v2_rx: true,


### PR DESCRIPTION
## Summary
- Lowers `opt_qs_minimum_batch_age_usecs` from 50ms → 20ms
- Phase 2 of experiment (builds on #19479 which adds observation metrics)
- Expected: more batches eligible for opt path, especially EU-authored

## Test plan
- [ ] Deploy on euwe6-1 only (canary)
- [ ] Observe via Phase 1 metrics for 24h:
  - `aptos_consensus_self_opt_proposal_committed / spawned` — opt success rate (should stay ~95%+)
  - `quorum_store_self_proposed_batches_by_type_and_author{type=opt_batch}` — should increase
  - `quorum_store_batch_skipped_too_young` — should drop
  - `aptos_consensus_proposal_payload_availability_count{status=missing}` on recipient validators — monitor for spikes

## Rationale
From euwe6-1 data (1h window, 2026-04-16):
- Inline pulls p50 = 19ms, p90 = 39ms
- Current 50ms threshold excludes most batches <50ms
- EU proof formation ~15-30ms means EU batches are rarely opt-eligible
- 20ms gives safe margin over intra-EU 5ms one-way + jitter

🤖 Generated with [Claude Code](https://claude.com/claude-code)