### PR TITLE
[Config] Update default testnet seeds.

### DIFF
--- a/.github/actions/fullnode-sync/fullnode_sync.py
+++ b/.github/actions/fullnode-sync/fullnode_sync.py
@@ -36,16 +36,6 @@ MAX_TIME_BETWEEN_SYNC_INCREASES_SECS = 1800 # The number of seconds after which 
 NUMBER_OF_HISTORICAL_TRANSACTIONS_TO_SYNC = 2000000 # The number of historical transactions to sync (when syncing from genesis)
 SYNCING_DELTA_VERSIONS = 20000 # The number of versions to sync beyond the highest known at the job start
 
-# Testnet seed peer constants
-TESTNET_SEED_PEERS = {
-  "9D5AF3FFDFF04F7CD51AA9F902253067A40594C7831BF1265503220D585B4D20": {
-    "addresses": [
-      "/dns4/pfn0.euwe4-seed.fullnode.testnet.aptoslabs.com/tcp/6182/noise-ik/9D5AF3FFDFF04F7CD51AA9F902253067A40594C7831BF1265503220D585B4D20/handshake/0"
-    ],
-    "role": "Upstream",
-  },
-}
-
 # Mainnet seed peer constants
 MAINNET_SEED_PEERS = {
   "A118B9BBBB8670D026C59C494317F7B6AA449A8E1B6AE0F9A6D434478AD1CC35": {
@@ -329,12 +319,9 @@ def setup_fullnode_config(network, bootstrapping_mode, continuous_syncing_mode, 
   # Enable storage sharding (AIP-97)
   fullnode_config['storage']['rocksdb_configs'] = {"enable_storage_sharding": True}
 
-  # If we're syncing historical data, we need to add seed peers
-  if syncing_historical_data:
-    if network == MAINNET_STRING:
-      add_seed_peers(fullnode_config, MAINNET_SEED_PEERS)
-    elif network == TESTNET_STRING:
-      add_seed_peers(fullnode_config, TESTNET_SEED_PEERS)
+  # If we're syncing historical data on mainnet, we need to add seed peers
+  if syncing_historical_data and network == MAINNET_STRING:
+    add_seed_peers(fullnode_config, MAINNET_SEED_PEERS)
 
   # Write the config file back to disk
   with open(FULLNODE_CONFIG_NAME, "w") as file:

--- a/config/src/config/config_optimizer.rs
+++ b/config/src/config/config_optimizer.rs
@@ -39,24 +39,24 @@ const MAINNET_SEED_PEERS: [(&str, &str, &str); 1] = [(
 // of (account address, public key, network address).
 const TESTNET_SEED_PEERS: [(&str, &str, &str); 4] = [
     (
-        "31e55012a7d439dcd16fee0509cd5855c1fbdc62057ba7fac3f7c88f5453dd8e",
-        "0x87bb19b02580b7e2a91a8e9342ec77ffd8f3ad967f54e77b22aaf558c5c11755",
-        "/dns/seed0.testnet.aptoslabs.com/tcp/6182/noise-ik/0x87bb19b02580b7e2a91a8e9342ec77ffd8f3ad967f54e77b22aaf558c5c11755/handshake/0",
+        "9d5af3ffdff04f7cd51aa9f902253067a40594c7831bf1265503220d585b4d20",
+        "0x9d5af3ffdff04f7cd51aa9f902253067a40594c7831bf1265503220d585b4d20",
+        "/dns/pfn0.euwe4-seed.fullnode.testnet.aptoslabs.com/tcp/6182/noise-ik/0x9d5af3ffdff04f7cd51aa9f902253067a40594c7831bf1265503220d585b4d20/handshake/0",
     ),
     (
-        "116176e2af223a8b7f8db80dc52f7a423b4d7f8c0553a1747e92ef58849aff4f",
-        "0xc2f24389f31c9c18d2ceb69d153ad9299e0ea7bbd66f457e0a28ef41c77c2b64",
-        "/dns/seed1.testnet.aptoslabs.com/tcp/6182/noise-ik/0xc2f24389f31c9c18d2ceb69d153ad9299e0ea7bbd66f457e0a28ef41c77c2b64/handshake/0",
+        "64d807a57c289fb26aab73bfe1f192cdc0baa25c0ec72f707aefeff97300d434",
+        "0x64d807a57c289fb26aab73bfe1f192cdc0baa25c0ec72f707aefeff97300d434",
+        "/dns/pfn0.usce1.fullnode.testnet.aptoslabs.com/tcp/6182/noise-ik/0x64d807a57c289fb26aab73bfe1f192cdc0baa25c0ec72f707aefeff97300d434/handshake/0",
     ),
     (
-        "12000330d7cd8a748f46c25e6ce5d236a27e13d0b510d4516ac84ecc5fddd002",
-        "0x171c661e5b785283978a74eafc52a906e68c73ae78119737b92f93507c753933",
-        "/dns/seed2.testnet.aptoslabs.com/tcp/6182/noise-ik/0x171c661e5b785283978a74eafc52a906e68c73ae78119737b92f93507c753933/handshake/0",
+        "0058220de6ba1af4c4a803e8727d9ed372104d2e60057cb16d6a99e646512826",
+        "0x0058220de6ba1af4c4a803e8727d9ed372104d2e60057cb16d6a99e646512826",
+        "/dns/pfn0.euwe4.fullnode.testnet.aptoslabs.com/tcp/6182/noise-ik/0x0058220de6ba1af4c4a803e8727d9ed372104d2e60057cb16d6a99e646512826/handshake/0",
     ),
     (
-        "03c04549114877c55f45649aba48ac0a4ff086ab7bdce3b8cc8d3d9947bc0d99",
-        "0xafc38bf177bd825326a1c314748612137d2b35dae6472932806806a32c23174a",
-        "/dns/seed3.testnet.aptoslabs.com/tcp/6182/noise-ik/0xafc38bf177bd825326a1c314748612137d2b35dae6472932806806a32c23174a/handshake/0",
+        "18fe71c4253468e40c540e31e5127d1e341e20494bc0de8b4e4d434c14b54608",
+        "0x18fe71c4253468e40c540e31e5127d1e341e20494bc0de8b4e4d434c14b54608",
+        "/dns/pfn0.apne1.fullnode.testnet.aptoslabs.com/tcp/6182/noise-ik/0x18fe71c4253468e40c540e31e5127d1e341e20494bc0de8b4e4d434c14b54608/handshake/0",
     ),
 ];
 


### PR DESCRIPTION
## Description
This PR updates the default testnet seeds.

## Testing Plan
Manual verification.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default network bootstrap peers for testnet and alters CI fullnode-sync seeding behavior; misconfigured seed addresses could cause nodes or workflows to have connectivity/sync issues.
> 
> **Overview**
> Updates the default testnet seed peer set used by the config optimizer to a new list of PFN-based seeds and corresponding addresses/keys.
> 
> Also simplifies the `fullnode-sync` GitHub Action so seed peers are only injected when doing *historical sync on mainnet*, removing the testnet-specific seed peer constant and branch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f3deaf3f25c285297631ad2db9755a4bb9baa0b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->