### PR TITLE
[config] Rename decryption_setup_blob_path to digest_key_blob_path

### DIFF
--- a/aptos-node/src/lib.rs
+++ b/aptos-node/src/lib.rs
@@ -743,7 +743,7 @@ pub fn setup_environment_and_start_node(
 
     // Initialize the DigestKey and PublicParameters for chunky DKG
     aptos_dkg_runtime::initialize_digest_key_with_counters(
-        node_config.consensus.decryption_setup_blob_path.as_ref(),
+        node_config.consensus.digest_key_blob_path.as_ref(),
         chain_id,
         node_config.base.role.is_validator(),
     );

--- a/config/src/config/consensus_config.rs
+++ b/config/src/config/consensus_config.rs
@@ -104,9 +104,9 @@ pub struct ConsensusConfig {
     pub secret_share_rb_config: ReliableBroadcastConfig,
     /// Delay in ms before broadcasting secret share requests.
     pub secret_share_request_delay_ms: u64,
-    /// Path to the decryption setup blob file (BCS-serialized DigestKey).
+    /// Path to the digest key blob file (BCS-serialized DigestKey).
     /// Required for validators on non-test chains. For test chains, falls back to TEST_DIGEST_KEY.
-    pub decryption_setup_blob_path: Option<PathBuf>,
+    pub digest_key_blob_path: Option<PathBuf>,
     /// Path to the public parameters blob file (BCS-serialized PublicParameters).
     /// Required for validators on non-test chains. For test chains, falls back to TEST_PUBLIC_PARAMETERS.
     pub public_parameters_blob_path: Option<PathBuf>,
@@ -406,7 +406,7 @@ impl Default for ConsensusConfig {
                 rpc_timeout_ms: 10000,
             },
             secret_share_request_delay_ms: 300,
-            decryption_setup_blob_path: None,
+            digest_key_blob_path: None,
             public_parameters_blob_path: None,
             num_bounded_executor_tasks: 16,
             enable_pre_commit: true,

--- a/testsuite/forge-cli/src/suites/realistic_environment.rs
+++ b/testsuite/forge-cli/src/suites/realistic_environment.rs
@@ -564,7 +564,7 @@ pub(crate) fn realistic_env_max_load_encrypted_test(duration: Duration) -> Forge
             config.consensus.quorum_store.enable_opt_qs_v2_payload_tx = true;
             config.consensus.quorum_store.enable_opt_qs_v2_payload_rx = true;
             config.consensus_observer.enable_v2_message_sending = true;
-            config.consensus.decryption_setup_blob_path =
+            config.consensus.digest_key_blob_path =
                 Some("/opt/aptos/genesis/decryption_setup.blob".into());
         }))
         .with_fullnode_override_node_config_fn(Arc::new(|config, _| {
@@ -636,7 +636,7 @@ pub(crate) fn realistic_env_max_load_encrypted_mix_test(duration: Duration) -> F
             config.consensus.quorum_store.enable_opt_qs_v2_payload_tx = true;
             config.consensus.quorum_store.enable_opt_qs_v2_payload_rx = true;
             config.consensus_observer.enable_v2_message_sending = true;
-            config.consensus.decryption_setup_blob_path =
+            config.consensus.digest_key_blob_path =
                 Some("/opt/aptos/genesis/decryption_setup.blob".into());
         }))
         .with_fullnode_override_node_config_fn(Arc::new(|config, _| {

--- a/testsuite/forge-cli/src/suites/realistic_environment.rs
+++ b/testsuite/forge-cli/src/suites/realistic_environment.rs
@@ -556,7 +556,8 @@ pub(crate) fn realistic_env_max_load_encrypted_test(duration: Duration) -> Forge
             helm_values["chain"]["initial_features_override"] =
                 serde_yaml::to_value(features).expect("must serialize");
         }))
-        .with_decryption_setup_blob_url("https://github.com/aptos-labs/aptos-networks/raw/87459ef53acfbb38e0f5b4209d52ad22ac0e8fa4/devnet/decryption_setup.blob")
+        .with_digest_key_blob_url("https://github.com/aptos-labs/aptos-networks/raw/6f69f6b2cd942bcae17efaada3d0f996a4741e85/devnet/digest_key.bin")
+        .with_public_parameters_blob_url("https://github.com/aptos-labs/aptos-networks/raw/6f69f6b2cd942bcae17efaada3d0f996a4741e85/devnet/pp.bin")
         .with_validator_override_node_config_fn(Arc::new(|config, _| {
             config.api.allow_encrypted_txns_submission = true;
             config.consensus.quorum_store.enable_batch_v2_tx = true;
@@ -565,7 +566,9 @@ pub(crate) fn realistic_env_max_load_encrypted_test(duration: Duration) -> Forge
             config.consensus.quorum_store.enable_opt_qs_v2_payload_rx = true;
             config.consensus_observer.enable_v2_message_sending = true;
             config.consensus.digest_key_blob_path =
-                Some("/opt/aptos/genesis/decryption_setup.blob".into());
+                Some("/opt/aptos/genesis/digest_key.bin".into());
+            config.consensus.public_parameters_blob_path =
+                Some("/opt/aptos/genesis/pp.bin".into());
         }))
         .with_fullnode_override_node_config_fn(Arc::new(|config, _| {
             config.api.allow_encrypted_txns_submission = true;
@@ -628,7 +631,8 @@ pub(crate) fn realistic_env_max_load_encrypted_mix_test(duration: Duration) -> F
             helm_values["chain"]["initial_features_override"] =
                 serde_yaml::to_value(features).expect("must serialize");
         }))
-        .with_decryption_setup_blob_url("https://github.com/aptos-labs/aptos-networks/raw/87459ef53acfbb38e0f5b4209d52ad22ac0e8fa4/devnet/decryption_setup.blob")
+        .with_digest_key_blob_url("https://github.com/aptos-labs/aptos-networks/raw/6f69f6b2cd942bcae17efaada3d0f996a4741e85/devnet/digest_key.bin")
+        .with_public_parameters_blob_url("https://github.com/aptos-labs/aptos-networks/raw/6f69f6b2cd942bcae17efaada3d0f996a4741e85/devnet/pp.bin")
         .with_validator_override_node_config_fn(Arc::new(|config, _| {
             config.api.allow_encrypted_txns_submission = true;
             config.consensus.quorum_store.enable_batch_v2_tx = true;
@@ -637,7 +641,9 @@ pub(crate) fn realistic_env_max_load_encrypted_mix_test(duration: Duration) -> F
             config.consensus.quorum_store.enable_opt_qs_v2_payload_rx = true;
             config.consensus_observer.enable_v2_message_sending = true;
             config.consensus.digest_key_blob_path =
-                Some("/opt/aptos/genesis/decryption_setup.blob".into());
+                Some("/opt/aptos/genesis/digest_key.bin".into());
+            config.consensus.public_parameters_blob_path =
+                Some("/opt/aptos/genesis/pp.bin".into());
         }))
         .with_fullnode_override_node_config_fn(Arc::new(|config, _| {
             config.api.allow_encrypted_txns_submission = true;

--- a/testsuite/forge/src/config.rs
+++ b/testsuite/forge/src/config.rs
@@ -72,8 +72,11 @@ pub struct ForgeConfig {
     /// Retain debug logs and above for all nodes instead of just the first 5 nodes
     pub retain_debug_logs: bool,
 
-    /// URL to download the trusted setup blob for chunky DKG into the validator init-container
-    pub decryption_setup_blob_url: Option<String>,
+    /// URL to download the chunky DKG digest key blob into the validator init-container
+    pub digest_key_blob_url: Option<String>,
+
+    /// URL to download the chunky DKG public parameters blob into the validator init-container
+    pub public_parameters_blob_url: Option<String>,
 }
 
 impl ForgeConfig {
@@ -194,8 +197,13 @@ impl ForgeConfig {
             .collect()
     }
 
-    pub fn with_decryption_setup_blob_url(mut self, url: impl Into<String>) -> Self {
-        self.decryption_setup_blob_url = Some(url.into());
+    pub fn with_digest_key_blob_url(mut self, url: impl Into<String>) -> Self {
+        self.digest_key_blob_url = Some(url.into());
+        self
+    }
+
+    pub fn with_public_parameters_blob_url(mut self, url: impl Into<String>) -> Self {
+        self.public_parameters_blob_url = Some(url.into());
         self
     }
 
@@ -243,7 +251,8 @@ impl ForgeConfig {
         let existing_db_tag = self.existing_db_tag.clone();
         let validator_resource_override = self.validator_resource_override;
         let fullnode_resource_override = self.fullnode_resource_override;
-        let decryption_setup_blob_url = self.decryption_setup_blob_url.clone();
+        let digest_key_blob_url = self.digest_key_blob_url.clone();
+        let public_parameters_blob_url = self.public_parameters_blob_url.clone();
 
         // Override specific helm values. See reference: terraform/helm/aptos-node/values.yaml
         Some(Arc::new(move |helm_values: &mut serde_yaml::Value| {
@@ -330,8 +339,11 @@ impl ForgeConfig {
             helm_values["validator"]["config"]["consensus"]["execution_backpressure"]
                 ["gas_limit"] = serde_yaml::to_value(&gas_limit_backpressure).unwrap();
 
-            if let Some(url) = &decryption_setup_blob_url {
-                helm_values["decryption_setup_blob_url"] = url.clone().into();
+            if let Some(url) = &digest_key_blob_url {
+                helm_values["digest_key_blob_url"] = url.clone().into();
+            }
+            if let Some(url) = &public_parameters_blob_url {
+                helm_values["public_parameters_blob_url"] = url.clone().into();
             }
         }))
     }
@@ -434,7 +446,8 @@ impl Default for ForgeConfig {
             validator_resource_override: NodeResourceOverride::default(),
             fullnode_resource_override: NodeResourceOverride::default(),
             retain_debug_logs: false,
-            decryption_setup_blob_url: None,
+            digest_key_blob_url: None,
+            public_parameters_blob_url: None,
         }
     }
 }


### PR DESCRIPTION
## Summary
- Rename the consensus config field `decryption_setup_blob_path` → `digest_key_blob_path` to match the blob's contents (BCS-serialized `DigestKey`).
- Update the two forge-cli call sites and the `aptos-node` runtime initializer.

## Test plan
- [x] `cargo check -p aptos-config -p aptos-node -p aptos-forge-cli`
- [x] `./scripts/rust_lint.sh --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)