### PR TITLE
[execution] Fix missing SnapshotModuleView method

### DIFF
--- a/aptos-move/block-executor/src/captured_reads.rs
+++ b/aptos-move/block-executor/src/captured_reads.rs
@@ -1461,6 +1461,15 @@ impl ModuleStorage for SnapshotModuleView<'_> {
             },
         }
     }
+
+    #[cfg(fuzzing)]
+    fn unmetered_get_module_skip_verification(
+        &self,
+        _address: &AccountAddress,
+        _module_name: &IdentStr,
+    ) -> VMResult<Option<Arc<Module>>> {
+        Ok(None)
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Commit faed5637e ("[vm] Fix async code state replay", 2026-01-29) introduced SnapshotModuleView but omitted the implementation of unmetered_get_module_skip_verification, which is required when the fuzzing feature is enabled.

This leads to E0046 errors in fuzzing pipelines as the method is mandated by the ModuleStorage trait under #[cfg(fuzzing)].

Error Message
```
Step #3 - "compile-libfuzzer-address-x86_64": error[E0046]: not all trait items implemented, missing: `unmetered_get_module_skip_verification`
Step #3 - "compile-libfuzzer-address-x86_64":   --> aptos-move/block-executor/src/captured_reads.rs:1359:1
Step #3 - "compile-libfuzzer-address-x86_64":    |
Step #3 - "compile-libfuzzer-address-x86_64": 1359 | impl ModuleStorage for SnapshotModuleView<'_> {
Step #3 - "compile-libfuzzer-address-x86_64":    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `unmetered_get_module_skip_verification` in implementation
```


This commit resolves the issue by implementing the missing method and guarding it with the appropriate conditional compilation attribute.

Fixes #19495 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> A small, `#[cfg(fuzzing)]`-gated stub method to satisfy a trait; it doesn’t affect production code paths.
> 
> **Overview**
> Fixes fuzzing builds by adding the missing `ModuleStorage` trait method `unmetered_get_module_skip_verification` to `SnapshotModuleView` in `captured_reads.rs`, gated behind `#[cfg(fuzzing)]`.
> 
> The new implementation is a stub that returns `Ok(None)`, ensuring the snapshot module resolver compiles when fuzzing is enabled without changing normal (non-fuzzing) execution behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d31bc9716fd0141d9b1b10518602c55b90383043. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->