### PR TITLE
[storage] Plumb hot state updates to snapshot committer

### DIFF
--- a/storage/aptosdb/src/db/aptosdb_writer.rs
+++ b/storage/aptosdb/src/db/aptosdb_writer.rs
@@ -67,6 +67,7 @@ impl DbWriter for AptosDB {
 
             self.state_store.buffered_state().lock().update(
                 chunk.result_ledger_state_with_summary(),
+                chunk.hot_state_updates.clone(),
                 chunk.estimated_total_state_updates(),
                 sync_commit || chunk.is_reconfig,
             )?;

--- a/storage/aptosdb/src/state_store/buffered_state.rs
+++ b/storage/aptosdb/src/state_store/buffered_state.rs
@@ -12,10 +12,14 @@ use crate::{
 use aptos_infallible::Mutex;
 use aptos_metrics_core::TimerHelper;
 use aptos_storage_interface::{
-    state_store::state_with_summary::{LedgerStateWithSummary, StateWithSummary},
+    state_store::{
+        empty_hot_state_shard_updates,
+        state_with_summary::{LedgerStateWithSummary, StateWithSummary},
+        HotStateShardUpdates, HotStateUpdates,
+    },
     Result,
 };
-use aptos_types::transaction::Version;
+use aptos_types::{state_store::NUM_STATE_SHARDS, transaction::Version};
 use std::{
     sync::{
         mpsc,
@@ -28,6 +32,13 @@ use std::{
 pub(crate) const ASYNC_COMMIT_CHANNEL_BUFFER_SIZE: u64 = 1;
 pub(crate) const TARGET_SNAPSHOT_INTERVAL_IN_VERSION: u64 = 100_000;
 
+/// Payload sent to the state snapshot committer thread: the checkpoint to commit, plus the
+/// aggregated hot state updates accumulated since the previous committed checkpoint.
+pub(crate) struct SnapshotToCommit {
+    pub snapshot: StateWithSummary,
+    pub hot_state_shard_updates: [HotStateShardUpdates; NUM_STATE_SHARDS],
+}
+
 /// BufferedState manages a range of recent state checkpoints and asynchronously commits
 /// the updates in batches.
 #[derive(Debug)]
@@ -37,11 +48,14 @@ pub struct BufferedState {
     /// The most recent checkpoint sent for persistence, not guaranteed to have committed already.
     last_snapshot: StateWithSummary,
     /// channel to send a checkpoint for persistence asynchronously
-    state_commit_sender: SyncSender<CommitMessage<StateWithSummary>>,
+    state_commit_sender: SyncSender<CommitMessage<SnapshotToCommit>>,
     /// Estimated number of items in the buffer.
     estimated_items: usize,
     /// The target number of items in the buffer between commits.
     target_items: usize,
+    /// Hot state updates accumulated across chunks since the last enqueued commit. Flushed to
+    /// the committer thread as part of the next `CommitMessage::Data`.
+    pending_hot_state_shard_updates: [HotStateShardUpdates; NUM_STATE_SHARDS],
     join_handle: Option<JoinHandle<()>>,
 }
 
@@ -88,8 +102,20 @@ impl BufferedState {
             state_commit_sender,
             estimated_items: 0,
             target_items,
+            pending_hot_state_shard_updates: empty_hot_state_shard_updates(),
             // The join handle of the async state commit thread for graceful drop.
             join_handle: Some(join_handle),
+        }
+    }
+
+    /// Merges one shard array of hot state updates into `pending_hot_state_shard_updates`.
+    fn accumulate_hot_state_updates(&mut self, shards: [HotStateShardUpdates; NUM_STATE_SHARDS]) {
+        for (pending, incoming) in self
+            .pending_hot_state_shard_updates
+            .iter_mut()
+            .zip(shards.into_iter())
+        {
+            pending.merge(incoming);
         }
     }
 
@@ -123,8 +149,15 @@ impl BufferedState {
     fn enqueue_commit(&mut self, checkpoint: StateWithSummary) {
         let _timer = OTHER_TIMERS_SECONDS.timer_with(&["buffered_state___enqueue_commit"]);
 
+        let hot_state_shard_updates = std::mem::replace(
+            &mut self.pending_hot_state_shard_updates,
+            empty_hot_state_shard_updates(),
+        );
         self.state_commit_sender
-            .send(CommitMessage::Data(checkpoint.clone()))
+            .send(CommitMessage::Data(SnapshotToCommit {
+                snapshot: checkpoint.clone(),
+                hot_state_shard_updates,
+            }))
             .unwrap();
         // n.b. if the latest state is not a (the latest) checkpoint, the items between them are
         // not counted towards the next commit. If this becomes a concern we can count the items
@@ -156,6 +189,7 @@ impl BufferedState {
     pub fn update(
         &mut self,
         new_state: LedgerStateWithSummary,
+        hot_state_updates: HotStateUpdates,
         estimated_new_items: usize,
         sync_commit: bool,
     ) -> Result<()> {
@@ -173,7 +207,18 @@ impl BufferedState {
         let checkpoint_to_commit_opt =
             (old_state.next_version() < last_checkpoint.next_version()).then_some(last_checkpoint);
         *self.current_state_locked() = new_state;
+
+        // Merge the pre-checkpoint portion of the chunk's hot state updates into `pending`
+        // before potentially flushing — these belong in the committed snapshot.
+        if let Some(shards) = hot_state_updates.for_last_checkpoint {
+            self.accumulate_hot_state_updates(shards);
+        }
         self.maybe_commit(checkpoint_to_commit_opt, sync_commit);
+        // The post-checkpoint portion belongs to the *next* checkpoint's commit, so merge it
+        // after the flush so it carries over.
+        if let Some(shards) = hot_state_updates.for_latest {
+            self.accumulate_hot_state_updates(shards);
+        }
         Self::report_last_checkpoint_version(version);
         Ok(())
     }

--- a/storage/aptosdb/src/state_store/mod.rs
+++ b/storage/aptosdb/src/state_store/mod.rs
@@ -856,7 +856,9 @@ impl StateStore {
 
         // synchronously commit the snapshot at the last checkpoint here if not committed to disk yet.
         buffered_state.update(
-            updated, 0,    /* estimated_items, doesn't matter since we sync-commit */
+            updated,
+            hot_state_updates,
+            0,    /* estimated_items, doesn't matter since we sync-commit */
             true, /* sync_commit */
         )?;
         Ok(())
@@ -1709,6 +1711,7 @@ mod test_only {
                         new_ledger_state,
                         new_state_summary,
                     ),
+                    hot_state_updates,
                     0,    /* estimated_items, doesn't matter since we sync-commit */
                     true, /* sync_commit */
                 )

--- a/storage/aptosdb/src/state_store/state_snapshot_committer.rs
+++ b/storage/aptosdb/src/state_store/state_snapshot_committer.rs
@@ -7,7 +7,7 @@ use crate::{
     metrics::OTHER_TIMERS_SECONDS,
     state_merkle_db::StateMerkleDb,
     state_store::{
-        buffered_state::CommitMessage,
+        buffered_state::{CommitMessage, SnapshotToCommit},
         persisted_state::PersistedState,
         state_merkle_batch_committer::{
             StateMerkleBatch, StateMerkleBatchCommitter, StateMerkleCommit,
@@ -25,7 +25,7 @@ use aptos_storage_interface::{
     jmt_update_refs, state_store::state_with_summary::StateWithSummary, Result,
 };
 use aptos_types::{
-    state_store::{hot_state::HotStateValueRef, state_key::StateKey, NUM_STATE_SHARDS},
+    state_store::{state_key::StateKey, NUM_STATE_SHARDS},
     transaction::Version,
 };
 use rayon::prelude::*;
@@ -42,7 +42,7 @@ pub(crate) struct StateSnapshotCommitter {
     state_db: Arc<StateDb>,
     /// Last snapshot merklized and sent for persistence, not guaranteed to have committed already.
     last_snapshot: StateWithSummary,
-    state_snapshot_commit_receiver: Receiver<CommitMessage<StateWithSummary>>,
+    state_snapshot_commit_receiver: Receiver<CommitMessage<SnapshotToCommit>>,
     state_merkle_batch_commit_sender: SyncSender<CommitMessage<StateMerkleCommit>>,
     join_handle: Option<JoinHandle<()>>,
 }
@@ -52,7 +52,7 @@ impl StateSnapshotCommitter {
 
     pub fn new(
         state_db: Arc<StateDb>,
-        state_snapshot_commit_receiver: Receiver<CommitMessage<StateWithSummary>>,
+        state_snapshot_commit_receiver: Receiver<CommitMessage<SnapshotToCommit>>,
         last_snapshot: StateWithSummary,
         persisted_state: PersistedState,
     ) -> Self {
@@ -87,7 +87,10 @@ impl StateSnapshotCommitter {
     pub fn run(mut self) {
         while let Ok(msg) = self.state_snapshot_commit_receiver.recv() {
             match msg {
-                CommitMessage::Data(snapshot) => {
+                CommitMessage::Data(SnapshotToCommit {
+                    snapshot,
+                    hot_state_shard_updates,
+                }) => {
                     let version = snapshot.version().expect("Cannot be empty");
                     let base_version = self.last_snapshot.version();
                     let previous_epoch_ending_version = self
@@ -99,34 +102,43 @@ impl StateSnapshotCommitter {
                         .map(|(v, _e)| v);
                     let min_version = self.last_snapshot.next_version();
 
-                    // Element format: (key_hash, Option<(value_hash, key)>)
-                    let (hot_updates, all_updates): (Vec<_>, Vec<_>) = snapshot
+                    // Build `all_updates` (cold/global JMT input) from the slot-level delta.
+                    // The hot JMT input is built separately below from the aggregated
+                    // HotStateShardUpdates so it reflects only value-affecting changes,
+                    // not LRU pointer churn on DB-loaded neighbor slots.
+                    let all_updates: Vec<_> = snapshot
                         .make_delta(&self.last_snapshot)
                         .shards
                         .iter()
                         .map(|updates| {
                             let _timer = OTHER_TIMERS_SECONDS.timer_with(&["hash_jmt_updates"]);
-                            let mut hot_updates = Vec::new();
-                            let mut all_updates = Vec::new();
-                            for (key_hash, slot) in updates.iter() {
-                                if slot.is_hot() {
-                                    hot_updates.push((
-                                        key_hash,
-                                        Some((
-                                            HotStateValueRef::from_slot(&slot).hash(),
-                                            slot.expect_state_key().clone(),
-                                        )),
-                                    ));
-                                } else {
-                                    hot_updates.push((key_hash, None));
-                                }
-                                if let Some(value) = slot.maybe_update_jmt(min_version) {
-                                    all_updates.push(value);
-                                }
-                            }
-                            (hot_updates, all_updates)
+                            updates
+                                .iter()
+                                .filter_map(|(_key_hash, slot)| slot.maybe_update_jmt(min_version))
+                                .collect::<Vec<_>>()
                         })
-                        .unzip();
+                        .collect();
+
+                    // Build `hot_updates` (hot JMT input) from the aggregated hot state updates
+                    // accumulated in BufferedState across chunks since the last committed
+                    // checkpoint. Element format: (key_hash, Option<(value_hash, key)>).
+                    let hot_updates: Vec<Vec<(HashValue, Option<(HashValue, StateKey)>)>> =
+                        hot_state_shard_updates
+                            .into_iter()
+                            .map(|shard| {
+                                let mut out: Vec<(HashValue, Option<(HashValue, StateKey)>)> =
+                                    Vec::with_capacity(
+                                        shard.insertions.len() + shard.evictions.len(),
+                                    );
+                                for (key_hash, op) in shard.insertions {
+                                    out.push((key_hash, Some((op.value.hash(), op.state_key))));
+                                }
+                                for (key_hash, _op) in shard.evictions {
+                                    out.push((key_hash, None));
+                                }
+                                out
+                            })
+                            .collect();
 
                     // TODO(HotState): for now we use `is_descendant_of` to determine if hot state
                     // summary is computed at all. When it's not enabled everything is

--- a/storage/aptosdb/src/state_store/tests/hot_state_kv.rs
+++ b/storage/aptosdb/src/state_store/tests/hot_state_kv.rs
@@ -516,6 +516,7 @@ fn test_load_write_then_load_roundtrip() {
     shards[key1.get_shard_id()]
         .insertions
         .insert(*key1.crypto_hash_ref(), HotInsertionOp {
+            state_key: key1.clone(),
             value: HotStateValue::new(Some(val1.clone()), 100),
             value_version: Some(50),
             superseded_version: None,
@@ -525,6 +526,7 @@ fn test_load_write_then_load_roundtrip() {
     shards[key2.get_shard_id()]
         .insertions
         .insert(*key2.crypto_hash_ref(), HotInsertionOp {
+            state_key: key2.clone(),
             value: HotStateValue::new(None, 200),
             value_version: None,
             superseded_version: None,
@@ -639,6 +641,7 @@ fn test_put_hot_state_updates_values_and_stale_indices() {
     shards[key1.get_shard_id()]
         .insertions
         .insert(*key1.crypto_hash_ref(), HotInsertionOp {
+            state_key: key1.clone(),
             value: HotStateValue::new(Some(val1.clone()), 100),
             value_version: Some(50),
             superseded_version: None,
@@ -648,6 +651,7 @@ fn test_put_hot_state_updates_values_and_stale_indices() {
     shards[key2.get_shard_id()]
         .insertions
         .insert(*key2.crypto_hash_ref(), HotInsertionOp {
+            state_key: key2.clone(),
             value: HotStateValue::new(None, 200),
             value_version: None,
             superseded_version: Some(80),
@@ -784,6 +788,7 @@ fn test_hot_state_kv_pruner_deletes_old_entries() {
     shards[key1.get_shard_id()]
         .insertions
         .insert(*key1.crypto_hash_ref(), HotInsertionOp {
+            state_key: key1.clone(),
             value: HotStateValue::new(Some(val_old.clone()), 100),
             value_version: Some(100),
             superseded_version: None,
@@ -804,6 +809,7 @@ fn test_hot_state_kv_pruner_deletes_old_entries() {
     shards2[key1.get_shard_id()]
         .insertions
         .insert(*key1.crypto_hash_ref(), HotInsertionOp {
+            state_key: key1.clone(),
             value: HotStateValue::new(Some(val_new.clone()), 200),
             value_version: Some(200),
             superseded_version: Some(100),

--- a/storage/storage-interface/src/state_store/mod.rs
+++ b/storage/storage-interface/src/state_store/mod.rs
@@ -12,13 +12,16 @@ pub mod versioned_state_value;
 
 use aptos_crypto::HashValue;
 use aptos_types::{
-    state_store::{hot_state::HotStateValue, NUM_STATE_SHARDS},
+    state_store::{hot_state::HotStateValue, state_key::StateKey, NUM_STATE_SHARDS},
     transaction::Version,
 };
 use std::collections::HashMap;
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct HotInsertionOp {
+    /// The key associated with this insertion. Carried alongside the hash so that downstream
+    /// consumers (hot JMT commit, etc.) don't need to look it up from a keyless source.
+    pub state_key: StateKey,
     pub value: HotStateValue,
     /// `Some(version)` for occupied entries and `None` for vacant.
     pub value_version: Option<Version>,
@@ -27,7 +30,7 @@ pub struct HotInsertionOp {
     pub superseded_version: Option<Version>,
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct HotEvictionOp {
     pub eviction_version: Version,
     /// The `hot_since_version` of the DB entry being superseded. `None` if the key was never
@@ -35,7 +38,7 @@ pub struct HotEvictionOp {
     pub superseded_version: Option<Version>,
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct HotStateShardUpdates {
     pub insertions: HashMap<HashValue, HotInsertionOp>,
     // TODO(HotState): per-block eviction tracking will be needed for cold-write elimination.
@@ -52,9 +55,52 @@ impl HotStateShardUpdates {
             evictions,
         }
     }
+
+    /// Merges `other` into `self`, treating `other` as logically later in time.
+    ///
+    /// Semantics mirror the within-batch logic in `LedgerState::update`: when the same key
+    /// appears in both, the earlier DB-level `superseded_version` is preserved so that
+    /// pruner targeting stays correct across insert/evict/reinsert chains.
+    pub fn merge(&mut self, other: HotStateShardUpdates) {
+        for (key_hash, mut op) in other.insertions {
+            if let Some(evicted) = self.evictions.remove(&key_hash) {
+                // Earlier eviction → later insertion: carry forward the eviction's
+                // superseded_version so the insertion still targets the original DB entry.
+                op.superseded_version = evicted.superseded_version;
+                self.insertions.insert(key_hash, op);
+            } else if let Some(prev) = self.insertions.get(&key_hash) {
+                // Earlier insertion → later insertion: keep the first insertion's
+                // superseded_version (the DB-level predecessor).
+                op.superseded_version = prev.superseded_version;
+                self.insertions.insert(key_hash, op);
+            } else {
+                self.insertions.insert(key_hash, op);
+            }
+        }
+        for (key_hash, mut evict) in other.evictions {
+            if let Some(prev) = self.insertions.remove(&key_hash) {
+                // Earlier insertion → later eviction: eviction wins but inherits the
+                // insertion's DB-level superseded_version.
+                evict.superseded_version = prev.superseded_version;
+                self.evictions.insert(key_hash, evict);
+            } else {
+                assert!(
+                    !self.evictions.contains_key(&key_hash),
+                    "Key {key_hash} cannot be evicted twice."
+                );
+                self.evictions.insert(key_hash, evict);
+            }
+        }
+    }
 }
 
-#[derive(Debug)]
+/// Creates an empty `[HotStateShardUpdates; NUM_STATE_SHARDS]`, used as the seed for accumulating
+/// hot state updates across chunks.
+pub fn empty_hot_state_shard_updates() -> [HotStateShardUpdates; NUM_STATE_SHARDS] {
+    std::array::from_fn(|_| HotStateShardUpdates::default())
+}
+
+#[derive(Clone, Debug)]
 pub struct HotStateUpdates {
     pub for_last_checkpoint: Option<[HotStateShardUpdates; NUM_STATE_SHARDS]>,
     pub for_latest: Option<[HotStateShardUpdates; NUM_STATE_SHARDS]>,

--- a/storage/storage-interface/src/state_store/state.rs
+++ b/storage/storage-interface/src/state_store/state.rs
@@ -366,6 +366,7 @@ impl State {
             let superseded_version =
                 lru.insert(key, update.to_result_slot((*key).clone()).unwrap());
             return Some(HotInsertionOp {
+                state_key: (*key).clone(),
                 value: HotStateValue::new(state_value_opt.cloned(), update.version),
                 value_version: state_value_opt.map(|_| update.version),
                 superseded_version,
@@ -389,6 +390,7 @@ impl State {
                 let value = HotStateValue::clone_from_slot(&slot_to_insert);
                 let superseded_version = lru.insert(key, slot_to_insert);
                 Some(HotInsertionOp {
+                    state_key: (*key).clone(),
                     value,
                     value_version,
                     superseded_version,
@@ -404,6 +406,7 @@ impl State {
             let value = HotStateValue::clone_from_slot(&slot);
             let superseded_version = lru.insert(key, slot);
             Some(HotInsertionOp {
+                state_key: (*key).clone(),
                 value,
                 value_version,
                 superseded_version,


### PR DESCRIPTION

The `StateSnapshotCommitter` previously rederived its hot JMT update set
from a slot-level delta (`State::make_delta`). That delta includes LRU
pointer-only mutations on neighbor slots, which is wrong in two ways:

1. The hot JMT only stores `HotStateValue` content, so pointer-only
   changes shouldn't be re-emitted at all.
2. Slots loaded from the hot state KV DB only carry the key hash, not
   the full `StateKey`. When such a slot ended up in the delta because
   its LRU neighbors were touched, the committer's
   `slot.expect_state_key()` call would panic on the first checkpoint
   commit after restart:

       panicked at types/src/state_store/state_slot.rs:104:14:
       StateSlot: state_key is None (loaded from DB without key)

The execution-time path that produces `HotStateUpdates` already excludes
neighbor-only updates by construction. This change plumbs the per-chunk
`HotStateUpdates` from `ExecutionOutput` through `BufferedState` to the
committer, where it replaces the slot-delta-derived hot update set.

## Approach

- Add `state_key: StateKey` to `HotInsertionOp` so the committer can
  build hot JMT leaves directly from insertions.
- Add `HotStateShardUpdates::merge` mirroring the within-batch
  insert/evict/reinsert semantics in `LedgerState::update`.
- Extend `BufferedState::update` to accept `HotStateUpdates` and
  accumulate across chunks. `for_last_checkpoint` is merged before
  `maybe_commit` (lands in the committed snapshot); `for_latest` is
  merged after, to carry over to the next commit.
- Replace the `StateWithSummary` channel payload with `SnapshotToCommit`
  carrying both the snapshot and the aggregated hot updates.
- Rewrite the committer's hot update loop to iterate
  `HotStateShardUpdates.insertions`/`evictions` directly. The
  `all_updates` (cold/global JMT) path still uses `make_delta`.

A merged aggregate is used rather than per-block tracking, since
per-block eviction tracking (a `HotStateShardUpdates` TODO) is not yet
needed.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
