### PR TITLE
[storage] Filter pointer-only hot-state slots from JMT update paths

### DIFF
--- a/storage/aptosdb/src/db/aptosdb_writer.rs
+++ b/storage/aptosdb/src/db/aptosdb_writer.rs
@@ -67,6 +67,7 @@ impl DbWriter for AptosDB {
 
             self.state_store.buffered_state().lock().update(
                 chunk.result_ledger_state_with_summary(),
+                chunk.hot_state_updates.clone(),
                 chunk.estimated_total_state_updates(),
                 sync_commit || chunk.is_reconfig,
             )?;

--- a/storage/aptosdb/src/state_store/buffered_state.rs
+++ b/storage/aptosdb/src/state_store/buffered_state.rs
@@ -6,16 +6,23 @@
 use crate::{
     metrics::{LATEST_CHECKPOINT_VERSION, OTHER_TIMERS_SECONDS},
     state_store::{
-        persisted_state::PersistedState, state_snapshot_committer::StateSnapshotCommitter, StateDb,
+        persisted_state::PersistedState,
+        state_snapshot_committer::{SnapshotToCommit, StateSnapshotCommitter},
+        StateDb,
     },
 };
 use aptos_infallible::Mutex;
 use aptos_metrics_core::TimerHelper;
 use aptos_storage_interface::{
-    state_store::state_with_summary::{LedgerStateWithSummary, StateWithSummary},
+    state_store::{
+        empty_hot_state_updates,
+        state_with_summary::{LedgerStateWithSummary, StateWithSummary},
+        HotStateShardUpdates, HotStateUpdates,
+    },
     Result,
 };
-use aptos_types::transaction::Version;
+use aptos_types::{state_store::NUM_STATE_SHARDS, transaction::Version};
+use itertools::Itertools;
 use std::{
     sync::{
         mpsc,
@@ -37,11 +44,18 @@ pub struct BufferedState {
     /// The most recent checkpoint sent for persistence, not guaranteed to have committed already.
     last_snapshot: StateWithSummary,
     /// channel to send a checkpoint for persistence asynchronously
-    state_commit_sender: SyncSender<CommitMessage<StateWithSummary>>,
+    state_commit_sender: SyncSender<CommitMessage<SnapshotToCommit>>,
     /// Estimated number of items in the buffer.
     estimated_items: usize,
     /// The target number of items in the buffer between commits.
     target_items: usize,
+    /// Hot state updates covering `[last_snapshot, current_state.last_checkpoint()]`.
+    /// Drained into the committer on every snapshot flush.
+    pending_hot_state_updates: [HotStateShardUpdates; NUM_STATE_SHARDS],
+    /// Hot state updates covering `(current_state.last_checkpoint(), current_state.latest()]`.
+    /// Folded into `pending_hot_state_updates` once a later chunk advances the checkpoint past
+    /// them.
+    post_checkpoint_hot_state_updates: [HotStateShardUpdates; NUM_STATE_SHARDS],
     join_handle: Option<JoinHandle<()>>,
 }
 
@@ -88,8 +102,20 @@ impl BufferedState {
             state_commit_sender,
             estimated_items: 0,
             target_items,
+            pending_hot_state_updates: empty_hot_state_updates(),
+            post_checkpoint_hot_state_updates: empty_hot_state_updates(),
             // The join handle of the async state commit thread for graceful drop.
             join_handle: Some(join_handle),
+        }
+    }
+
+    /// Merges `incoming` into `target` per-shard.
+    fn merge_hot_state_updates(
+        target: &mut [HotStateShardUpdates; NUM_STATE_SHARDS],
+        incoming: [HotStateShardUpdates; NUM_STATE_SHARDS],
+    ) {
+        for (t, i) in target.iter_mut().zip_eq(incoming.into_iter()) {
+            t.merge(i);
         }
     }
 
@@ -123,8 +149,15 @@ impl BufferedState {
     fn enqueue_commit(&mut self, checkpoint: StateWithSummary) {
         let _timer = OTHER_TIMERS_SECONDS.timer_with(&["buffered_state___enqueue_commit"]);
 
+        let hot_state_updates = std::mem::replace(
+            &mut self.pending_hot_state_updates,
+            empty_hot_state_updates(),
+        );
         self.state_commit_sender
-            .send(CommitMessage::Data(checkpoint.clone()))
+            .send(CommitMessage::Data(SnapshotToCommit {
+                snapshot: checkpoint.clone(),
+                hot_state_updates,
+            }))
             .unwrap();
         // n.b. if the latest state is not a (the latest) checkpoint, the items between them are
         // not counted towards the next commit. If this becomes a concern we can count the items
@@ -156,6 +189,7 @@ impl BufferedState {
     pub fn update(
         &mut self,
         new_state: LedgerStateWithSummary,
+        hot_state_updates: HotStateUpdates,
         estimated_new_items: usize,
         sync_commit: bool,
     ) -> Result<()> {
@@ -173,7 +207,30 @@ impl BufferedState {
         let checkpoint_to_commit_opt =
             (old_state.next_version() < last_checkpoint.next_version()).then_some(last_checkpoint);
         *self.current_state_locked() = new_state;
+
+        // When a new checkpoint advances past earlier chunks' post-checkpoint updates,
+        // those updates are now pre-(new-)checkpoint and become eligible for the next
+        // snapshot flush. Fold them into `pending_hot_state_updates` first.
+        if checkpoint_to_commit_opt.is_some() {
+            let prev_post_checkpoint = std::mem::replace(
+                &mut self.post_checkpoint_hot_state_updates,
+                empty_hot_state_updates(),
+            );
+            Self::merge_hot_state_updates(
+                &mut self.pending_hot_state_updates,
+                prev_post_checkpoint,
+            );
+        }
+        // Merge this chunk's pre-checkpoint portion before potentially flushing.
+        if let Some(shards) = hot_state_updates.for_last_checkpoint {
+            Self::merge_hot_state_updates(&mut self.pending_hot_state_updates, shards);
+        }
         self.maybe_commit(checkpoint_to_commit_opt, sync_commit);
+        // The post-checkpoint portion of this chunk goes into `post_checkpoint` so it is
+        // NOT flushed at the current checkpoint — its versions are past the snapshot.
+        if let Some(shards) = hot_state_updates.for_latest {
+            Self::merge_hot_state_updates(&mut self.post_checkpoint_hot_state_updates, shards);
+        }
         Self::report_last_checkpoint_version(version);
         Ok(())
     }

--- a/storage/aptosdb/src/state_store/mod.rs
+++ b/storage/aptosdb/src/state_store/mod.rs
@@ -856,7 +856,9 @@ impl StateStore {
 
         // synchronously commit the snapshot at the last checkpoint here if not committed to disk yet.
         buffered_state.update(
-            updated, 0,    /* estimated_items, doesn't matter since we sync-commit */
+            updated,
+            hot_state_updates,
+            0,    /* estimated_items, doesn't matter since we sync-commit */
             true, /* sync_commit */
         )?;
         Ok(())
@@ -1709,6 +1711,7 @@ mod test_only {
                         new_ledger_state,
                         new_state_summary,
                     ),
+                    hot_state_updates,
                     0,    /* estimated_items, doesn't matter since we sync-commit */
                     true, /* sync_commit */
                 )

--- a/storage/aptosdb/src/state_store/state_snapshot_committer.rs
+++ b/storage/aptosdb/src/state_store/state_snapshot_committer.rs
@@ -22,10 +22,12 @@ use aptos_logger::info;
 use aptos_metrics_core::TimerHelper;
 use aptos_scratchpad::SparseMerkleTree;
 use aptos_storage_interface::{
-    jmt_update_refs, state_store::state_with_summary::StateWithSummary, Result,
+    jmt_update_refs,
+    state_store::{state_with_summary::StateWithSummary, HotStateShardUpdates},
+    Result,
 };
 use aptos_types::{
-    state_store::{hot_state::HotStateValueRef, state_key::StateKey, NUM_STATE_SHARDS},
+    state_store::{state_key::StateKey, NUM_STATE_SHARDS},
     transaction::Version,
 };
 use rayon::prelude::*;
@@ -38,11 +40,17 @@ use std::{
     thread::JoinHandle,
 };
 
+/// Payload sent to the state snapshot committer thread.
+pub(crate) struct SnapshotToCommit {
+    pub snapshot: StateWithSummary,
+    pub hot_state_updates: [HotStateShardUpdates; NUM_STATE_SHARDS],
+}
+
 pub(crate) struct StateSnapshotCommitter {
     state_db: Arc<StateDb>,
     /// Last snapshot merklized and sent for persistence, not guaranteed to have committed already.
     last_snapshot: StateWithSummary,
-    state_snapshot_commit_receiver: Receiver<CommitMessage<StateWithSummary>>,
+    state_snapshot_commit_receiver: Receiver<CommitMessage<SnapshotToCommit>>,
     state_merkle_batch_commit_sender: SyncSender<CommitMessage<StateMerkleCommit>>,
     join_handle: Option<JoinHandle<()>>,
 }
@@ -52,7 +60,7 @@ impl StateSnapshotCommitter {
 
     pub fn new(
         state_db: Arc<StateDb>,
-        state_snapshot_commit_receiver: Receiver<CommitMessage<StateWithSummary>>,
+        state_snapshot_commit_receiver: Receiver<CommitMessage<SnapshotToCommit>>,
         last_snapshot: StateWithSummary,
         persisted_state: PersistedState,
     ) -> Self {
@@ -87,7 +95,10 @@ impl StateSnapshotCommitter {
     pub fn run(mut self) {
         while let Ok(msg) = self.state_snapshot_commit_receiver.recv() {
             match msg {
-                CommitMessage::Data(snapshot) => {
+                CommitMessage::Data(SnapshotToCommit {
+                    snapshot,
+                    hot_state_updates,
+                }) => {
                     let version = snapshot.version().expect("Cannot be empty");
                     let base_version = self.last_snapshot.version();
                     let previous_epoch_ending_version = self
@@ -100,33 +111,33 @@ impl StateSnapshotCommitter {
                     let min_version = self.last_snapshot.next_version();
 
                     // Element format: (key_hash, Option<(value_hash, key)>)
-                    let (hot_updates, all_updates): (Vec<_>, Vec<_>) = snapshot
+                    let all_updates: Vec<_> = snapshot
                         .make_delta(&self.last_snapshot)
                         .shards
                         .iter()
                         .map(|updates| {
                             let _timer = OTHER_TIMERS_SECONDS.timer_with(&["hash_jmt_updates"]);
-                            let mut hot_updates = Vec::new();
-                            let mut all_updates = Vec::new();
-                            for (key_hash, slot) in updates.iter() {
-                                if slot.is_hot() {
-                                    hot_updates.push((
-                                        key_hash,
-                                        Some((
-                                            HotStateValueRef::from_slot(&slot).hash(),
-                                            slot.expect_state_key().clone(),
-                                        )),
-                                    ));
-                                } else {
-                                    hot_updates.push((key_hash, None));
-                                }
-                                if let Some(value) = slot.maybe_update_jmt(min_version) {
-                                    all_updates.push(value);
-                                }
-                            }
-                            (hot_updates, all_updates)
+                            updates
+                                .iter()
+                                .filter_map(|(_key_hash, slot)| slot.maybe_update_jmt(min_version))
+                                .collect::<Vec<_>>()
                         })
-                        .unzip();
+                        .collect();
+
+                    let hot_updates: Vec<_> = hot_state_updates
+                        .into_iter()
+                        .map(|shard| {
+                            let _timer = OTHER_TIMERS_SECONDS.timer_with(&["hash_hot_jmt_updates"]);
+                            shard
+                                .insertions
+                                .into_iter()
+                                .map(|(key_hash, op)| {
+                                    (key_hash, Some((op.value.hash(), op.state_key)))
+                                })
+                                .chain(shard.evictions.into_keys().map(|key_hash| (key_hash, None)))
+                                .collect()
+                        })
+                        .collect();
 
                     // TODO(HotState): for now we use `is_descendant_of` to determine if hot state
                     // summary is computed at all. When it's not enabled everything is

--- a/storage/aptosdb/src/state_store/tests/hot_state_kv.rs
+++ b/storage/aptosdb/src/state_store/tests/hot_state_kv.rs
@@ -14,7 +14,7 @@ use aptos_config::config::{RocksdbConfig, StorageDirPaths};
 use aptos_crypto::{hash::CryptoHash, HashValue};
 use aptos_schemadb::batch::WriteBatch;
 use aptos_storage_interface::state_store::{
-    HotEvictionOp, HotInsertionOp, HotStateShardUpdates, HotStateUpdates,
+    empty_hot_state_updates, HotEvictionOp, HotInsertionOp, HotStateUpdates,
 };
 use aptos_temppath::TempPath;
 use aptos_types::{
@@ -27,11 +27,6 @@ use aptos_types::{
     },
     transaction::Version,
 };
-use std::collections::HashMap;
-
-fn new_empty_shard_updates() -> [HotStateShardUpdates; NUM_STATE_SHARDS] {
-    std::array::from_fn(|_| HotStateShardUpdates::new(HashMap::new(), HashMap::new()))
-}
 
 fn create_hot_state_kv_db(path: &TempPath) -> StateKvDb {
     StateKvDb::new(
@@ -510,12 +505,13 @@ fn test_load_write_then_load_roundtrip() {
     let val1 = make_state_value(10);
     let key2 = make_state_key(20);
 
-    let mut shards = new_empty_shard_updates();
+    let mut shards = empty_hot_state_updates();
 
     // key1: occupied at hot_since_version=100, value_version=50
     shards[key1.get_shard_id()]
         .insertions
         .insert(*key1.crypto_hash_ref(), HotInsertionOp {
+            state_key: key1.clone(),
             value: HotStateValue::new(Some(val1.clone()), 100),
             value_version: Some(50),
             superseded_version: None,
@@ -525,6 +521,7 @@ fn test_load_write_then_load_roundtrip() {
     shards[key2.get_shard_id()]
         .insertions
         .insert(*key2.crypto_hash_ref(), HotInsertionOp {
+            state_key: key2.clone(),
             value: HotStateValue::new(None, 200),
             value_version: None,
             superseded_version: None,
@@ -633,12 +630,13 @@ fn test_put_hot_state_updates_values_and_stale_indices() {
     let key2 = make_state_key(20);
     let key3 = make_state_key(30);
 
-    let mut shards = new_empty_shard_updates();
+    let mut shards = empty_hot_state_updates();
 
     // key1: first write (no superseded version) at hot_since_version=100
     shards[key1.get_shard_id()]
         .insertions
         .insert(*key1.crypto_hash_ref(), HotInsertionOp {
+            state_key: key1.clone(),
             value: HotStateValue::new(Some(val1.clone()), 100),
             value_version: Some(50),
             superseded_version: None,
@@ -648,6 +646,7 @@ fn test_put_hot_state_updates_values_and_stale_indices() {
     shards[key2.get_shard_id()]
         .insertions
         .insert(*key2.crypto_hash_ref(), HotInsertionOp {
+            state_key: key2.clone(),
             value: HotStateValue::new(None, 200),
             value_version: None,
             superseded_version: Some(80),
@@ -780,10 +779,11 @@ fn test_hot_state_kv_pruner_deletes_old_entries() {
     let val_new = make_state_value(2);
 
     // First batch: write old entry at hot_since=100
-    let mut shards = new_empty_shard_updates();
+    let mut shards = empty_hot_state_updates();
     shards[key1.get_shard_id()]
         .insertions
         .insert(*key1.crypto_hash_ref(), HotInsertionOp {
+            state_key: key1.clone(),
             value: HotStateValue::new(Some(val_old.clone()), 100),
             value_version: Some(100),
             superseded_version: None,
@@ -800,10 +800,11 @@ fn test_hot_state_kv_pruner_deletes_old_entries() {
     hot_state_kv_db.commit(100, None, batches).unwrap();
 
     // Second batch: write new entry at hot_since=200 superseding 100
-    let mut shards2 = new_empty_shard_updates();
+    let mut shards2 = empty_hot_state_updates();
     shards2[key1.get_shard_id()]
         .insertions
         .insert(*key1.crypto_hash_ref(), HotInsertionOp {
+            state_key: key1.clone(),
             value: HotStateValue::new(Some(val_new.clone()), 200),
             value_version: Some(200),
             superseded_version: Some(100),

--- a/storage/aptosdb/src/state_store/tests/mod.rs
+++ b/storage/aptosdb/src/state_store/tests/mod.rs
@@ -2,6 +2,7 @@
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 mod hot_state_kv;
+mod restart;
 mod speculative_state_workflow;
 
 use super::*;

--- a/storage/aptosdb/src/state_store/tests/restart.rs
+++ b/storage/aptosdb/src/state_store/tests/restart.rs
@@ -1,0 +1,155 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! End-to-end proptest for the node restart flow.
+//!
+//! Commits a proptest-generated block sequence to an `AptosDB`, drops the DB, reopens
+//! it from disk, commits the remainder, and verifies that data and proofs remain
+//! consistent across the restart boundary.
+
+use crate::db::{
+    test_helper::{arb_blocks_to_commit_with_params, verify_committed_transactions},
+    AptosDB,
+};
+use aptos_config::config::{
+    HotStateConfig, RocksdbConfigs, StorageDirPaths, DEFAULT_MAX_NUM_NODES_PER_LRU_CACHE_SHARD,
+    NO_OP_STORAGE_PRUNER_CONFIG,
+};
+use aptos_storage_interface::DbReader;
+use aptos_temppath::TempPath;
+use aptos_types::{
+    ledger_info::LedgerInfoWithSignatures,
+    transaction::{TransactionToCommit, Version},
+};
+use proptest::prelude::*;
+use std::path::Path;
+
+fn open_db<P: AsRef<Path>>(
+    path: P,
+    max_items_per_shard: usize,
+    buffered_state_target_items: usize,
+) -> AptosDB {
+    let hot_state_config = HotStateConfig {
+        max_items_per_shard,
+        refresh_interval_versions: 1_000,
+        delete_on_restart: false,
+        compute_root_hash: true,
+        persist_hotness_in_write_set: true,
+    };
+    AptosDB::open(
+        StorageDirPaths::from_path(path),
+        false, /* readonly */
+        NO_OP_STORAGE_PRUNER_CONFIG,
+        RocksdbConfigs::default(),
+        buffered_state_target_items,
+        DEFAULT_MAX_NUM_NODES_PER_LRU_CACHE_SHARD,
+        None, /* internal_indexer_db */
+        hot_state_config,
+    )
+    .expect("Failed to open AptosDB")
+}
+
+fn commit_batches(
+    db: &AptosDB,
+    batches: &[(Vec<TransactionToCommit>, LedgerInfoWithSignatures, bool)],
+    start_version: Version,
+) -> Version {
+    let mut version = start_version;
+    for (txns, li, sync_commit) in batches {
+        db.save_transactions_for_test(txns, version, Some(li), *sync_commit)
+            .unwrap();
+        verify_committed_transactions(db, txns, version, li, false /* is_latest */);
+        version += txns.len() as Version;
+    }
+    version
+}
+
+fn test_restart_impl(
+    input: Vec<(Vec<TransactionToCommit>, LedgerInfoWithSignatures, bool)>,
+    split_at: usize,
+    max_items_per_shard: usize,
+    buffered_state_target_items: usize,
+) {
+    let (first_half, second_half) = input.split_at(split_at);
+
+    let tmp_dir = TempPath::new();
+    tmp_dir.create_as_dir().unwrap();
+
+    // Phase 1: commit, then drop. Drop flushes `BufferedState` and the snapshot committer.
+    let version = {
+        let db = open_db(
+            tmp_dir.path(),
+            max_items_per_shard,
+            buffered_state_target_items,
+        );
+        commit_batches(&db, first_half, 0)
+    };
+
+    // Phase 2: reopen and commit the rest.
+    let db = open_db(
+        tmp_dir.path(),
+        max_items_per_shard,
+        buffered_state_target_items,
+    );
+    assert_eq!(db.expect_synced_version(), version - 1);
+    let final_version = commit_batches(&db, second_half, version);
+
+    // Re-verify every batch (pre- and post-restart) against the current (post-restart)
+    // ledger info — the per-batch verification inside `commit_batches` only checks against
+    // each batch's own LI.
+    let latest_ledger_info = &input.last().unwrap().1;
+    let last_idx = input.len() - 1;
+    let mut v: Version = 0;
+    for (i, (txns, _, _)) in input.iter().enumerate() {
+        verify_committed_transactions(
+            &db,
+            txns,
+            v, /* first_version */
+            latest_ledger_info,
+            i == last_idx, /* is_latest */
+        );
+        v += txns.len() as Version;
+    }
+
+    let expected_total: u64 = input.iter().map(|(txns, _, _)| txns.len() as u64).sum();
+    assert_eq!(final_version, expected_total);
+    assert_eq!(db.expect_synced_version(), expected_total - 1);
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(20))]
+
+    #[test]
+    fn test_restart(
+        (input, split_at, max_items_per_shard, buffered_state_target_items)
+            in arb_blocks_to_commit_with_params(
+                10, /* num_accounts */
+                2,  /* max_user_txns_per_block */
+                3,  /* min_blocks */
+                8,  /* max_blocks */
+            ).prop_flat_map(|blocks| {
+                let len = blocks.len();
+                (
+                    Just(blocks),
+                    proptest::collection::vec(any::<bool>(), len),
+                    1usize..len,
+                    1usize..10,
+                    1usize..1000,
+                )
+            }).prop_map(|(blocks, sync_flags, split_at, max_items_per_shard, buffered_state_target_items)| {
+                let input = blocks
+                    .into_iter()
+                    .zip(sync_flags)
+                    .map(|((txns, li), sync)| (txns, li, sync))
+                    .collect::<Vec<_>>();
+                (input, split_at, max_items_per_shard, buffered_state_target_items)
+            }),
+    ) {
+        test_restart_impl(
+            input,
+            split_at,
+            max_items_per_shard,
+            buffered_state_target_items,
+        );
+    }
+}

--- a/storage/storage-interface/src/state_store/mod.rs
+++ b/storage/storage-interface/src/state_store/mod.rs
@@ -10,15 +10,17 @@ pub mod state_view;
 pub mod state_with_summary;
 pub mod versioned_state_value;
 
+use anyhow::{bail, Result};
 use aptos_crypto::HashValue;
 use aptos_types::{
-    state_store::{hot_state::HotStateValue, NUM_STATE_SHARDS},
+    state_store::{hot_state::HotStateValue, state_key::StateKey, NUM_STATE_SHARDS},
     transaction::Version,
 };
 use std::collections::HashMap;
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct HotInsertionOp {
+    pub state_key: StateKey,
     pub value: HotStateValue,
     /// `Some(version)` for occupied entries and `None` for vacant.
     pub value_version: Option<Version>,
@@ -27,7 +29,7 @@ pub struct HotInsertionOp {
     pub superseded_version: Option<Version>,
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct HotEvictionOp {
     pub eviction_version: Version,
     /// The `hot_since_version` of the DB entry being superseded. `None` if the key was never
@@ -35,7 +37,7 @@ pub struct HotEvictionOp {
     pub superseded_version: Option<Version>,
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct HotStateShardUpdates {
     pub insertions: HashMap<HashValue, HotInsertionOp>,
     // TODO(HotState): per-block eviction tracking will be needed for cold-write elimination.
@@ -43,18 +45,59 @@ pub struct HotStateShardUpdates {
 }
 
 impl HotStateShardUpdates {
-    pub fn new(
-        insertions: HashMap<HashValue, HotInsertionOp>,
-        evictions: HashMap<HashValue, HotEvictionOp>,
-    ) -> Self {
-        Self {
-            insertions,
-            evictions,
+    /// Inserts `op` at `key_hash`, preserving the original DB-level `superseded_version`
+    /// across insert/evict/reinsert chains: if an earlier eviction or insertion for this
+    /// key already exists, its `superseded_version` is inherited so the pruner still
+    /// targets the original DB entry.
+    pub(crate) fn insert(&mut self, key_hash: HashValue, mut op: HotInsertionOp) {
+        if let Some(evicted) = self.evictions.remove(&key_hash) {
+            op.superseded_version = evicted.superseded_version;
+        } else if let Some(prev) = self.insertions.get(&key_hash) {
+            op.superseded_version = prev.superseded_version;
+        }
+        self.insertions.insert(key_hash, op);
+    }
+
+    /// Records an eviction at `key_hash`. If an earlier insertion for this key exists,
+    /// it is removed and its `superseded_version` is carried onto `evict`. Returns an error
+    /// if the key was already evicted — the caller is expected to never evict the same key
+    /// twice within one `HotStateShardUpdates`.
+    pub(crate) fn evict(&mut self, key_hash: HashValue, mut evict: HotEvictionOp) -> Result<()> {
+        if self.evictions.contains_key(&key_hash) {
+            bail!("Key {key_hash} cannot be evicted twice.");
+        }
+        if let Some(prev) = self.insertions.remove(&key_hash) {
+            evict.superseded_version = prev.superseded_version;
+        }
+        self.evictions.insert(key_hash, evict);
+        Ok(())
+    }
+
+    /// Merges `other` into `self` as the logically later batch. On key collisions, the
+    /// earlier `superseded_version` wins so the pruner still targets the original DB row.
+    pub fn merge(&mut self, other: HotStateShardUpdates) {
+        for (key_hash, op) in other.insertions {
+            self.insert(key_hash, op);
+        }
+        for (key_hash, mut evict) in other.evictions {
+            // Like `self.evict`, but tolerate an existing eviction — re-evicting across
+            // batches is legitimate (key was re-hotted between them).
+            if let Some(existing) = self.evictions.remove(&key_hash) {
+                evict.superseded_version = existing.superseded_version;
+            } else if let Some(prev) = self.insertions.remove(&key_hash) {
+                evict.superseded_version = prev.superseded_version;
+            }
+            self.evictions.insert(key_hash, evict);
         }
     }
 }
 
-#[derive(Debug)]
+/// Creates an empty `[HotStateShardUpdates; NUM_STATE_SHARDS]`.
+pub fn empty_hot_state_updates() -> [HotStateShardUpdates; NUM_STATE_SHARDS] {
+    std::array::from_fn(|_| HotStateShardUpdates::default())
+}
+
+#[derive(Clone, Debug)]
 pub struct HotStateUpdates {
     pub for_last_checkpoint: Option<[HotStateShardUpdates; NUM_STATE_SHARDS]>,
     pub for_latest: Option<[HotStateShardUpdates; NUM_STATE_SHARDS]>,
@@ -66,5 +109,137 @@ impl HotStateUpdates {
             for_last_checkpoint: None,
             for_latest: None,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn hash(n: u8) -> HashValue {
+        HashValue::new([n; HashValue::LENGTH])
+    }
+
+    fn insertion(superseded: Option<Version>, value_version: Option<Version>) -> HotInsertionOp {
+        HotInsertionOp {
+            state_key: StateKey::raw(b"test"),
+            value: HotStateValue::new(None, value_version.unwrap_or(0)),
+            value_version,
+            superseded_version: superseded,
+        }
+    }
+
+    fn eviction(eviction_version: Version, superseded: Option<Version>) -> HotEvictionOp {
+        HotEvictionOp {
+            eviction_version,
+            superseded_version: superseded,
+        }
+    }
+
+    #[test]
+    fn insert_into_empty() {
+        let mut updates = HotStateShardUpdates::default();
+        updates.insert(hash(1), insertion(Some(5), Some(10)));
+        assert!(updates.evictions.is_empty());
+        let op = updates.insertions.get(&hash(1)).unwrap();
+        assert_eq!(op.superseded_version, Some(5));
+        assert_eq!(op.value_version, Some(10));
+    }
+
+    #[test]
+    fn reinsert_preserves_original_superseded() {
+        let mut updates = HotStateShardUpdates::default();
+        updates.insert(hash(1), insertion(Some(5), Some(10)));
+        updates.insert(hash(1), insertion(Some(999), Some(20)));
+        let op = updates.insertions.get(&hash(1)).unwrap();
+        // Superseded carries over from the first insertion; value is taken from the
+        // latest insertion.
+        assert_eq!(op.superseded_version, Some(5));
+        assert_eq!(op.value_version, Some(20));
+    }
+
+    #[test]
+    fn insert_after_eviction_inherits_superseded() {
+        let mut updates = HotStateShardUpdates::default();
+        updates.evict(hash(1), eviction(100, Some(5))).unwrap();
+        updates.insert(hash(1), insertion(Some(999), Some(20)));
+        assert!(updates.evictions.is_empty());
+        let op = updates.insertions.get(&hash(1)).unwrap();
+        assert_eq!(op.superseded_version, Some(5));
+        assert_eq!(op.value_version, Some(20));
+    }
+
+    #[test]
+    fn evict_into_empty() {
+        let mut updates = HotStateShardUpdates::default();
+        updates.evict(hash(1), eviction(100, Some(5))).unwrap();
+        assert!(updates.insertions.is_empty());
+        let ev = updates.evictions.get(&hash(1)).unwrap();
+        assert_eq!(ev.eviction_version, 100);
+        assert_eq!(ev.superseded_version, Some(5));
+    }
+
+    #[test]
+    fn evict_after_insertion_inherits_superseded() {
+        let mut updates = HotStateShardUpdates::default();
+        updates.insert(hash(1), insertion(Some(5), Some(10)));
+        updates.evict(hash(1), eviction(100, Some(999))).unwrap();
+        assert!(updates.insertions.is_empty());
+        let ev = updates.evictions.get(&hash(1)).unwrap();
+        assert_eq!(ev.eviction_version, 100);
+        assert_eq!(ev.superseded_version, Some(5));
+    }
+
+    #[test]
+    fn evict_twice_errors() {
+        let mut updates = HotStateShardUpdates::default();
+        updates.evict(hash(1), eviction(100, Some(5))).unwrap();
+        assert!(updates.evict(hash(1), eviction(200, Some(6))).is_err());
+    }
+
+    #[test]
+    fn merge_preserves_earliest_superseded_across_double_evict() {
+        // `self` already evicted k with the original DB entry at version 5.
+        let mut pending = HotStateShardUpdates::default();
+        pending.evict(hash(1), eviction(100, Some(5))).unwrap();
+
+        // `other` re-hot's k via an insert (with a bogus superseded, since LRU didn't
+        // know about the DB entry) and evicts it again at the next checkpoint. Within
+        // one `HotStateShardUpdates`, insert+evict collapses to just an eviction.
+        let mut chunk = HotStateShardUpdates::default();
+        chunk.insert(hash(1), insertion(None, Some(150)));
+        chunk.evict(hash(1), eviction(200, Some(999))).unwrap();
+        assert!(chunk.insertions.is_empty());
+
+        pending.merge(chunk);
+
+        // A single eviction survives at the later `eviction_version`, but the
+        // original DB-level `superseded_version` (Some(5)) is preserved so the pruner
+        // still targets the right entry.
+        assert!(pending.insertions.is_empty());
+        let ev = pending.evictions.get(&hash(1)).unwrap();
+        assert_eq!(ev.eviction_version, 200);
+        assert_eq!(ev.superseded_version, Some(5));
+    }
+
+    #[test]
+    fn unrelated_keys_are_independent() {
+        let mut updates = HotStateShardUpdates::default();
+        updates.insert(hash(1), insertion(Some(5), Some(10)));
+        updates.evict(hash(2), eviction(100, Some(7))).unwrap();
+        updates.insert(hash(3), insertion(Some(9), Some(30)));
+
+        assert_eq!(
+            updates.insertions.get(&hash(1)).unwrap().superseded_version,
+            Some(5),
+        );
+        assert_eq!(
+            updates.evictions.get(&hash(2)).unwrap().superseded_version,
+            Some(7),
+        );
+        assert_eq!(
+            updates.insertions.get(&hash(3)).unwrap().superseded_version,
+            Some(9),
+        );
     }
 }

--- a/storage/storage-interface/src/state_store/state.rs
+++ b/storage/storage-interface/src/state_store/state.rs
@@ -239,19 +239,12 @@ impl State {
                         hot_metadata.total_value_bytes,
                     );
                     let mut all_updates = per_version.iter();
-                    let mut insertions = HashMap::new();
-                    let mut evictions = HashMap::new();
+                    let mut shard_updates = HotStateShardUpdates::default();
                     for ckpt_version in all_checkpoint_versions {
                         for (key, update) in
                             all_updates.take_while_ref(|(_k, u)| u.version <= *ckpt_version)
                         {
                             let key_hash = *key.crypto_hash_ref();
-                            // If this key was evicted earlier in the same batch, recover its
-                            // `superseded_version` so the insert→evict→reinsert chain keeps
-                            // pointing at the original DB entry the pruner should clean up.
-                            let evicted_superseded = evictions
-                                .remove(&key_hash)
-                                .and_then(|e: HotEvictionOp| e.superseded_version);
                             if let Some(op) = Self::apply_one_update(
                                 &mut lru,
                                 overlay,
@@ -260,40 +253,22 @@ impl State {
                                 update,
                                 self.hot_state_config.refresh_interval_versions,
                             ) {
-                                Self::insert_preserving_superseded(
-                                    &mut insertions,
-                                    key_hash,
-                                    op,
-                                    evicted_superseded,
-                                );
+                                shard_updates.insert(key_hash, op);
                             }
                         }
                         // Only evict at the checkpoints.
                         for (key_hash, slot) in lru.maybe_evict() {
                             assert!(slot.is_hot());
-                            assert!(
-                                !evictions.contains_key(&key_hash),
-                                "Key {key_hash} cannot be evicted twice."
-                            );
-                            // Determine the DB version superseded by this hot entry. If the key was
-                            // inserted earlier in this batch, carry forward its superseded_version;
-                            // otherwise the key has been hot since before this batch, so use its
-                            // hot_since_version.
-                            let superseded_version = insertions
-                                .remove(&key_hash)
-                                .map(|prev| prev.superseded_version)
-                                .unwrap_or(Some(slot.expect_hot_since_version()));
-                            evictions.insert(key_hash, HotEvictionOp {
-                                eviction_version: *ckpt_version,
-                                superseded_version,
-                            });
+                            shard_updates
+                                .evict(key_hash, HotEvictionOp {
+                                    eviction_version: *ckpt_version,
+                                    superseded_version: Some(slot.expect_hot_since_version()),
+                                })
+                                .expect("LRU eviction must succeed.");
                         }
                     }
                     for (key, update) in all_updates {
                         let key_hash = *key.crypto_hash_ref();
-                        let evicted_superseded = evictions
-                            .remove(&key_hash)
-                            .and_then(|e| e.superseded_version);
                         if let Some(op) = Self::apply_one_update(
                             &mut lru,
                             overlay,
@@ -302,12 +277,7 @@ impl State {
                             update,
                             self.hot_state_config.refresh_interval_versions,
                         ) {
-                            Self::insert_preserving_superseded(
-                                &mut insertions,
-                                key_hash,
-                                op,
-                                evicted_superseded,
-                            );
+                            shard_updates.insert(key_hash, op);
                         }
                     }
 
@@ -324,10 +294,7 @@ impl State {
                         total_value_bytes: new_total_value_bytes,
                     };
                     let new_usage = Self::usage_delta_for_shard(cache, overlay, batched_updates);
-                    (
-                        ((new_layer, new_metadata), new_usage),
-                        HotStateShardUpdates::new(insertions, evictions),
-                    )
+                    (((new_layer, new_metadata), new_usage), shard_updates)
                 },
             )
             .unzip();
@@ -366,6 +333,7 @@ impl State {
             let superseded_version =
                 lru.insert(key, update.to_result_slot((*key).clone()).unwrap());
             return Some(HotInsertionOp {
+                state_key: (*key).clone(),
                 value: HotStateValue::new(state_value_opt.cloned(), update.version),
                 value_version: state_value_opt.map(|_| update.version),
                 superseded_version,
@@ -389,6 +357,7 @@ impl State {
                 let value = HotStateValue::clone_from_slot(&slot_to_insert);
                 let superseded_version = lru.insert(key, slot_to_insert);
                 Some(HotInsertionOp {
+                    state_key: (*key).clone(),
                     value,
                     value_version,
                     superseded_version,
@@ -404,31 +373,12 @@ impl State {
             let value = HotStateValue::clone_from_slot(&slot);
             let superseded_version = lru.insert(key, slot);
             Some(HotInsertionOp {
+                state_key: (*key).clone(),
                 value,
                 value_version,
                 superseded_version,
             })
         }
-    }
-
-    /// Inserts `op` into `insertions`, preserving the original DB-level `superseded_version`
-    /// across insert/evict/reinsert chains within the same batch.
-    fn insert_preserving_superseded(
-        insertions: &mut HashMap<HashValue, HotInsertionOp>,
-        key_hash: HashValue,
-        mut op: HotInsertionOp,
-        evicted_superseded: Option<Version>,
-    ) {
-        if let Some(prev) = insertions.get(&key_hash) {
-            // Key was already inserted earlier in this batch — keep the original
-            // superseded_version so the pruner still targets the right DB entry.
-            op.superseded_version = prev.superseded_version;
-        } else if evicted_superseded.is_some() {
-            // Key was evicted earlier in this batch — carry forward the superseded_version
-            // that was saved at eviction time.
-            op.superseded_version = evicted_superseded;
-        }
-        insertions.insert(key_hash, op);
     }
 
     fn update_usage(&self, usage_delta_per_shard: Vec<(i64, i64)>) -> StateStorageUsage {

--- a/types/src/state_store/state_slot.rs
+++ b/types/src/state_store/state_slot.rs
@@ -145,18 +145,19 @@ impl StateSlot {
         }
     }
 
-    /// When committing speculative state to the DB, determine if to make changes to the JMT.
+    /// When committing speculative state to the DB, determine if to make changes to the cold JMT.
     pub fn maybe_update_jmt(
         &self,
         min_version: Version,
     ) -> Option<(HashValue, Option<(HashValue, StateKey)>)> {
+        // Filter out the slots that carry no cold JMT change, including slots that are only changed
+        // because of LRU pointer updates.
+        let value_opt = self.maybe_update_cold_state(min_version)?;
         let state_key = self.expect_state_key();
-        self.maybe_update_cold_state(min_version).map(|value_opt| {
-            (
-                *state_key.crypto_hash_ref(),
-                value_opt.map(|v| (CryptoHash::hash(v), state_key.clone())),
-            )
-        })
+        Some((
+            *state_key.crypto_hash_ref(),
+            value_opt.map(|v| (CryptoHash::hash(v), state_key.clone())),
+        ))
     }
 
     // TODO(HotState): db returns cold slot directly


### PR DESCRIPTION

StateSlot carries an `Option<StateKey>` because `StateKvDb::load_hot_state_kvs`
reconstructs hot-state entries without the key — the hot KV DB only stores the
hash. These DB-loaded slots enter the in-memory hot state at startup. The LRU is
a doubly-linked list threaded through slot pointers, so every insert or eviction
also patches the prev/next fields of neighbor slots and re-queues those
neighbors into `pending`. The design contract is that any slot reaching a JMT
update has `Some(key)`: newly written slots always do, and DB-loaded keyless
slots are expected to reach `StateDelta` only as these pointer-only neighbor
touches, which must be filtered out before JMT update time.

Both JMT paths violated that contract. The panic was first observed on restart
replay — the first execution after startup — but any live block after restart
would trigger it identically:

    panicked at types/src/state_store/state_slot.rs:104:14:
    StateSlot: state_key is None (loaded from DB without key)

- **Hot JMT**: the committer was rederiving hot updates from
  `State::make_delta`, which re-surfaces the pointer-only touches. The
  execution-time `HotStateUpdates` already excludes them by construction. Plumb
  it from `ExecutionOutput` through `BufferedState` (accumulated via
  `HotStateShardUpdates::merge`) into the committer, and build hot JMT leaves
  directly from the aggregated insertions / evictions. `HotInsertionOp` gains a
  `state_key` field; the batch-construction loop in `State::update` moves into
  new `HotStateShardUpdates::{insert, evict}` methods that also own the
  "preserve DB-level `superseded_version` across insert/evict chains" rule.

- **Cold JMT**: `maybe_update_cold_state` already filtered pointer-only slots
  out — their `value_version` / `hot_since_version` are at most the loaded
  snapshot version, strictly below `min_version`, so no cold update is ever
  produced. The filter just wasn't early enough: `maybe_update_jmt` called
  `expect_state_key()` before consulting it, panicking on slots it would have
  discarded a moment later. Resolve the cold-state check first and only demand
  the key once a real update is produced.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches state commit plumbing and hot/cold JMT update generation, which are correctness-critical and could affect snapshot persistence across checkpoints/restarts if the new hot-update accumulation logic is wrong.
> 
> **Overview**
> Fixes restart/live-commit panics by ensuring JMT update generation never touches hot-state slots that only changed due to LRU pointer churn (and may lack a `StateKey`).
> 
> Hot-state JMT updates are no longer re-derived from `StateWithSummary::make_delta`; instead `HotStateUpdates` are plumbed from execution through `AptosDBWriter` -> `BufferedState` (with per-shard merge/flush semantics across checkpoints) into `StateSnapshotCommitter`, which builds hot JMT leaves directly from aggregated hot insertions/evictions. The storage interface refactors `HotStateShardUpdates` to own insert/evict/merge logic (preserving earliest `superseded_version`) and extends `HotInsertionOp` with `state_key`; tests are updated and a new end-to-end restart proptest is added.
> 
> Cold-state JMT updates now call `maybe_update_cold_state()` before requiring a `StateKey`, filtering out pointer-only slots earlier and preventing `expect_state_key()` panics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d82c13726c189309ecd0bf80f20bf88b6a3f73d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->