### PR TITLE
[types] Defer state_key lookup in maybe_update_jmt

### DIFF
--- a/storage/aptosdb/src/db/aptosdb_writer.rs
+++ b/storage/aptosdb/src/db/aptosdb_writer.rs
@@ -67,6 +67,7 @@ impl DbWriter for AptosDB {
 
             self.state_store.buffered_state().lock().update(
                 chunk.result_ledger_state_with_summary(),
+                chunk.hot_state_updates.clone(),
                 chunk.estimated_total_state_updates(),
                 sync_commit || chunk.is_reconfig,
             )?;

--- a/storage/aptosdb/src/state_store/buffered_state.rs
+++ b/storage/aptosdb/src/state_store/buffered_state.rs
@@ -12,10 +12,14 @@ use crate::{
 use aptos_infallible::Mutex;
 use aptos_metrics_core::TimerHelper;
 use aptos_storage_interface::{
-    state_store::state_with_summary::{LedgerStateWithSummary, StateWithSummary},
+    state_store::{
+        empty_hot_state_shard_updates,
+        state_with_summary::{LedgerStateWithSummary, StateWithSummary},
+        HotStateShardUpdates, HotStateUpdates,
+    },
     Result,
 };
-use aptos_types::transaction::Version;
+use aptos_types::{state_store::NUM_STATE_SHARDS, transaction::Version};
 use std::{
     sync::{
         mpsc,
@@ -28,6 +32,13 @@ use std::{
 pub(crate) const ASYNC_COMMIT_CHANNEL_BUFFER_SIZE: u64 = 1;
 pub(crate) const TARGET_SNAPSHOT_INTERVAL_IN_VERSION: u64 = 100_000;
 
+/// Payload sent to the state snapshot committer thread: the checkpoint to commit, plus the
+/// aggregated hot state updates accumulated since the previous committed checkpoint.
+pub(crate) struct SnapshotToCommit {
+    pub snapshot: StateWithSummary,
+    pub hot_state_shard_updates: [HotStateShardUpdates; NUM_STATE_SHARDS],
+}
+
 /// BufferedState manages a range of recent state checkpoints and asynchronously commits
 /// the updates in batches.
 #[derive(Debug)]
@@ -37,11 +48,14 @@ pub struct BufferedState {
     /// The most recent checkpoint sent for persistence, not guaranteed to have committed already.
     last_snapshot: StateWithSummary,
     /// channel to send a checkpoint for persistence asynchronously
-    state_commit_sender: SyncSender<CommitMessage<StateWithSummary>>,
+    state_commit_sender: SyncSender<CommitMessage<SnapshotToCommit>>,
     /// Estimated number of items in the buffer.
     estimated_items: usize,
     /// The target number of items in the buffer between commits.
     target_items: usize,
+    /// Hot state updates accumulated across chunks since the last enqueued commit. Flushed to
+    /// the committer thread as part of the next `CommitMessage::Data`.
+    pending_hot_state_shard_updates: [HotStateShardUpdates; NUM_STATE_SHARDS],
     join_handle: Option<JoinHandle<()>>,
 }
 
@@ -88,9 +102,25 @@ impl BufferedState {
             state_commit_sender,
             estimated_items: 0,
             target_items,
+            pending_hot_state_shard_updates: empty_hot_state_shard_updates(),
             // The join handle of the async state commit thread for graceful drop.
             join_handle: Some(join_handle),
         }
+    }
+
+    /// Merges one shard array of hot state updates into `pending_hot_state_shard_updates`.
+    fn accumulate_hot_state_updates(
+        &mut self,
+        shards: [HotStateShardUpdates; NUM_STATE_SHARDS],
+    ) -> Result<()> {
+        for (pending, incoming) in self
+            .pending_hot_state_shard_updates
+            .iter_mut()
+            .zip(shards.into_iter())
+        {
+            pending.merge(incoming)?;
+        }
+        Ok(())
     }
 
     /// This method checks whether a commit is needed based on the target_items value and the number of items in state_until_checkpoint.
@@ -123,8 +153,15 @@ impl BufferedState {
     fn enqueue_commit(&mut self, checkpoint: StateWithSummary) {
         let _timer = OTHER_TIMERS_SECONDS.timer_with(&["buffered_state___enqueue_commit"]);
 
+        let hot_state_shard_updates = std::mem::replace(
+            &mut self.pending_hot_state_shard_updates,
+            empty_hot_state_shard_updates(),
+        );
         self.state_commit_sender
-            .send(CommitMessage::Data(checkpoint.clone()))
+            .send(CommitMessage::Data(SnapshotToCommit {
+                snapshot: checkpoint.clone(),
+                hot_state_shard_updates,
+            }))
             .unwrap();
         // n.b. if the latest state is not a (the latest) checkpoint, the items between them are
         // not counted towards the next commit. If this becomes a concern we can count the items
@@ -156,6 +193,7 @@ impl BufferedState {
     pub fn update(
         &mut self,
         new_state: LedgerStateWithSummary,
+        hot_state_updates: HotStateUpdates,
         estimated_new_items: usize,
         sync_commit: bool,
     ) -> Result<()> {
@@ -173,7 +211,18 @@ impl BufferedState {
         let checkpoint_to_commit_opt =
             (old_state.next_version() < last_checkpoint.next_version()).then_some(last_checkpoint);
         *self.current_state_locked() = new_state;
+
+        // Merge the pre-checkpoint portion of the chunk's hot state updates into `pending`
+        // before potentially flushing — these belong in the committed snapshot.
+        if let Some(shards) = hot_state_updates.for_last_checkpoint {
+            self.accumulate_hot_state_updates(shards)?;
+        }
         self.maybe_commit(checkpoint_to_commit_opt, sync_commit);
+        // The post-checkpoint portion belongs to the *next* checkpoint's commit, so merge it
+        // after the flush so it carries over.
+        if let Some(shards) = hot_state_updates.for_latest {
+            self.accumulate_hot_state_updates(shards)?;
+        }
         Self::report_last_checkpoint_version(version);
         Ok(())
     }

--- a/storage/aptosdb/src/state_store/mod.rs
+++ b/storage/aptosdb/src/state_store/mod.rs
@@ -856,7 +856,9 @@ impl StateStore {
 
         // synchronously commit the snapshot at the last checkpoint here if not committed to disk yet.
         buffered_state.update(
-            updated, 0,    /* estimated_items, doesn't matter since we sync-commit */
+            updated,
+            hot_state_updates,
+            0,    /* estimated_items, doesn't matter since we sync-commit */
             true, /* sync_commit */
         )?;
         Ok(())
@@ -1709,6 +1711,7 @@ mod test_only {
                         new_ledger_state,
                         new_state_summary,
                     ),
+                    hot_state_updates,
                     0,    /* estimated_items, doesn't matter since we sync-commit */
                     true, /* sync_commit */
                 )

--- a/storage/aptosdb/src/state_store/state_snapshot_committer.rs
+++ b/storage/aptosdb/src/state_store/state_snapshot_committer.rs
@@ -7,7 +7,7 @@ use crate::{
     metrics::OTHER_TIMERS_SECONDS,
     state_merkle_db::StateMerkleDb,
     state_store::{
-        buffered_state::CommitMessage,
+        buffered_state::{CommitMessage, SnapshotToCommit},
         persisted_state::PersistedState,
         state_merkle_batch_committer::{
             StateMerkleBatch, StateMerkleBatchCommitter, StateMerkleCommit,
@@ -25,7 +25,7 @@ use aptos_storage_interface::{
     jmt_update_refs, state_store::state_with_summary::StateWithSummary, Result,
 };
 use aptos_types::{
-    state_store::{hot_state::HotStateValueRef, state_key::StateKey, NUM_STATE_SHARDS},
+    state_store::{state_key::StateKey, NUM_STATE_SHARDS},
     transaction::Version,
 };
 use rayon::prelude::*;
@@ -42,7 +42,7 @@ pub(crate) struct StateSnapshotCommitter {
     state_db: Arc<StateDb>,
     /// Last snapshot merklized and sent for persistence, not guaranteed to have committed already.
     last_snapshot: StateWithSummary,
-    state_snapshot_commit_receiver: Receiver<CommitMessage<StateWithSummary>>,
+    state_snapshot_commit_receiver: Receiver<CommitMessage<SnapshotToCommit>>,
     state_merkle_batch_commit_sender: SyncSender<CommitMessage<StateMerkleCommit>>,
     join_handle: Option<JoinHandle<()>>,
 }
@@ -52,7 +52,7 @@ impl StateSnapshotCommitter {
 
     pub fn new(
         state_db: Arc<StateDb>,
-        state_snapshot_commit_receiver: Receiver<CommitMessage<StateWithSummary>>,
+        state_snapshot_commit_receiver: Receiver<CommitMessage<SnapshotToCommit>>,
         last_snapshot: StateWithSummary,
         persisted_state: PersistedState,
     ) -> Self {
@@ -87,7 +87,10 @@ impl StateSnapshotCommitter {
     pub fn run(mut self) {
         while let Ok(msg) = self.state_snapshot_commit_receiver.recv() {
             match msg {
-                CommitMessage::Data(snapshot) => {
+                CommitMessage::Data(SnapshotToCommit {
+                    snapshot,
+                    hot_state_shard_updates,
+                }) => {
                     let version = snapshot.version().expect("Cannot be empty");
                     let base_version = self.last_snapshot.version();
                     let previous_epoch_ending_version = self
@@ -99,34 +102,43 @@ impl StateSnapshotCommitter {
                         .map(|(v, _e)| v);
                     let min_version = self.last_snapshot.next_version();
 
-                    // Element format: (key_hash, Option<(value_hash, key)>)
-                    let (hot_updates, all_updates): (Vec<_>, Vec<_>) = snapshot
+                    // Build `all_updates` (cold/global JMT input) from the slot-level delta.
+                    // The hot JMT input is built separately below from the aggregated
+                    // HotStateShardUpdates so it reflects only value-affecting changes,
+                    // not LRU pointer churn on DB-loaded neighbor slots.
+                    let all_updates: Vec<_> = snapshot
                         .make_delta(&self.last_snapshot)
                         .shards
                         .iter()
                         .map(|updates| {
                             let _timer = OTHER_TIMERS_SECONDS.timer_with(&["hash_jmt_updates"]);
-                            let mut hot_updates = Vec::new();
-                            let mut all_updates = Vec::new();
-                            for (key_hash, slot) in updates.iter() {
-                                if slot.is_hot() {
-                                    hot_updates.push((
-                                        key_hash,
-                                        Some((
-                                            HotStateValueRef::from_slot(&slot).hash(),
-                                            slot.expect_state_key().clone(),
-                                        )),
-                                    ));
-                                } else {
-                                    hot_updates.push((key_hash, None));
-                                }
-                                if let Some(value) = slot.maybe_update_jmt(min_version) {
-                                    all_updates.push(value);
-                                }
-                            }
-                            (hot_updates, all_updates)
+                            updates
+                                .iter()
+                                .filter_map(|(_key_hash, slot)| slot.maybe_update_jmt(min_version))
+                                .collect::<Vec<_>>()
                         })
-                        .unzip();
+                        .collect();
+
+                    // Build `hot_updates` (hot JMT input) from the aggregated hot state updates
+                    // accumulated in BufferedState across chunks since the last committed
+                    // checkpoint. Element format: (key_hash, Option<(value_hash, key)>).
+                    let hot_updates: Vec<Vec<(HashValue, Option<(HashValue, StateKey)>)>> =
+                        hot_state_shard_updates
+                            .into_iter()
+                            .map(|shard| {
+                                let mut out: Vec<(HashValue, Option<(HashValue, StateKey)>)> =
+                                    Vec::with_capacity(
+                                        shard.insertions.len() + shard.evictions.len(),
+                                    );
+                                for (key_hash, op) in shard.insertions {
+                                    out.push((key_hash, Some((op.value.hash(), op.state_key))));
+                                }
+                                for (key_hash, _op) in shard.evictions {
+                                    out.push((key_hash, None));
+                                }
+                                out
+                            })
+                            .collect();
 
                     // TODO(HotState): for now we use `is_descendant_of` to determine if hot state
                     // summary is computed at all. When it's not enabled everything is

--- a/storage/aptosdb/src/state_store/tests/hot_state_kv.rs
+++ b/storage/aptosdb/src/state_store/tests/hot_state_kv.rs
@@ -516,6 +516,7 @@ fn test_load_write_then_load_roundtrip() {
     shards[key1.get_shard_id()]
         .insertions
         .insert(*key1.crypto_hash_ref(), HotInsertionOp {
+            state_key: key1.clone(),
             value: HotStateValue::new(Some(val1.clone()), 100),
             value_version: Some(50),
             superseded_version: None,
@@ -525,6 +526,7 @@ fn test_load_write_then_load_roundtrip() {
     shards[key2.get_shard_id()]
         .insertions
         .insert(*key2.crypto_hash_ref(), HotInsertionOp {
+            state_key: key2.clone(),
             value: HotStateValue::new(None, 200),
             value_version: None,
             superseded_version: None,
@@ -639,6 +641,7 @@ fn test_put_hot_state_updates_values_and_stale_indices() {
     shards[key1.get_shard_id()]
         .insertions
         .insert(*key1.crypto_hash_ref(), HotInsertionOp {
+            state_key: key1.clone(),
             value: HotStateValue::new(Some(val1.clone()), 100),
             value_version: Some(50),
             superseded_version: None,
@@ -648,6 +651,7 @@ fn test_put_hot_state_updates_values_and_stale_indices() {
     shards[key2.get_shard_id()]
         .insertions
         .insert(*key2.crypto_hash_ref(), HotInsertionOp {
+            state_key: key2.clone(),
             value: HotStateValue::new(None, 200),
             value_version: None,
             superseded_version: Some(80),
@@ -784,6 +788,7 @@ fn test_hot_state_kv_pruner_deletes_old_entries() {
     shards[key1.get_shard_id()]
         .insertions
         .insert(*key1.crypto_hash_ref(), HotInsertionOp {
+            state_key: key1.clone(),
             value: HotStateValue::new(Some(val_old.clone()), 100),
             value_version: Some(100),
             superseded_version: None,
@@ -804,6 +809,7 @@ fn test_hot_state_kv_pruner_deletes_old_entries() {
     shards2[key1.get_shard_id()]
         .insertions
         .insert(*key1.crypto_hash_ref(), HotInsertionOp {
+            state_key: key1.clone(),
             value: HotStateValue::new(Some(val_new.clone()), 200),
             value_version: Some(200),
             superseded_version: Some(100),

--- a/storage/aptosdb/src/state_store/tests/mod.rs
+++ b/storage/aptosdb/src/state_store/tests/mod.rs
@@ -2,6 +2,7 @@
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 mod hot_state_kv;
+mod restart;
 mod speculative_state_workflow;
 
 use super::*;

--- a/storage/aptosdb/src/state_store/tests/restart.rs
+++ b/storage/aptosdb/src/state_store/tests/restart.rs
@@ -1,0 +1,144 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! End-to-end proptest for the node restart flow.
+//!
+//! Commits a proptest-generated block sequence to an `AptosDB`, drops the DB, reopens it
+//! from disk, and commits the remainder. Every commit is `sync_commit = true` so the
+//! snapshot committer runs inline — a panic there (e.g. mishandling of `StateSlot`s
+//! whose `state_key` is `None` after being loaded from the hot state KV DB) surfaces
+//! as a test failure. Post-restart reads of pre-restart data additionally check that
+//! proofs still verify across the boundary.
+//!
+//! Two knobs make the setup relevant to the hot-state path:
+//!   - `delete_on_restart = false`, so the hot KV DB survives reopen and
+//!     `load_hot_state_or_empty` actually populates `StateSlot`s whose `state_key` is
+//!     `None` (the persisted rows only carry the key hash).
+//!   - Small `max_items_per_shard`, so even modest workloads drive LRU insertion and
+//!     eviction — which is what patches those neighbor slots (still without a
+//!     `state_key`) into `pending` and sends them through `make_delta` into the
+//!     committer.
+
+use crate::db::{
+    test_helper::{arb_blocks_to_commit_with_params, verify_committed_transactions},
+    AptosDB,
+};
+use aptos_config::config::{
+    HotStateConfig, RocksdbConfigs, StorageDirPaths, BUFFERED_STATE_TARGET_ITEMS_FOR_TEST,
+    DEFAULT_MAX_NUM_NODES_PER_LRU_CACHE_SHARD, NO_OP_STORAGE_PRUNER_CONFIG,
+};
+use aptos_storage_interface::DbReader;
+use aptos_temppath::TempPath;
+use aptos_types::{
+    ledger_info::LedgerInfoWithSignatures,
+    transaction::{TransactionToCommit, Version},
+};
+use proptest::prelude::*;
+use std::path::Path;
+
+/// Small per-shard capacity forces LRU churn (insertions and evictions) under modest
+/// workloads, so post-restart blocks reliably touch DB-loaded neighbor slots.
+const MAX_HOT_ITEMS_PER_SHARD: usize = 4;
+
+fn open_db<P: AsRef<Path>>(path: P) -> AptosDB {
+    let hot_state_config = HotStateConfig {
+        max_items_per_shard: MAX_HOT_ITEMS_PER_SHARD,
+        refresh_interval_versions: 1_000,
+        // The whole point of this test: persist hotness across restart so reopen loads
+        // `StateSlot`s (with `state_key = None`) via `load_hot_state_kvs`.
+        delete_on_restart: false,
+        compute_root_hash: true,
+        persist_hotness_in_write_set: true,
+    };
+    AptosDB::open(
+        StorageDirPaths::from_path(path),
+        false, /* readonly */
+        NO_OP_STORAGE_PRUNER_CONFIG,
+        RocksdbConfigs::default(),
+        BUFFERED_STATE_TARGET_ITEMS_FOR_TEST,
+        DEFAULT_MAX_NUM_NODES_PER_LRU_CACHE_SHARD,
+        None, /* internal_indexer_db */
+        hot_state_config,
+    )
+    .expect("Failed to open AptosDB")
+}
+
+fn commit_batches(
+    db: &AptosDB,
+    batches: &[(Vec<TransactionToCommit>, LedgerInfoWithSignatures)],
+    start_version: Version,
+) -> Version {
+    let mut version = start_version;
+    for (txns, li) in batches.iter() {
+        db.save_transactions_for_test(txns, version, Some(li), true /* sync_commit */)
+            .unwrap();
+        // `is_latest` is currently unused inside `verify_committed_transactions`; passing
+        // `false` keeps the call site uniform whether we're at the end or not.
+        verify_committed_transactions(db, txns, version, li, false);
+        version += txns.len() as Version;
+    }
+    version
+}
+
+fn test_restart_impl(
+    input: Vec<(Vec<TransactionToCommit>, LedgerInfoWithSignatures)>,
+    split_at: usize,
+) {
+    assert!(
+        split_at >= 1 && split_at < input.len(),
+        "split_at must leave at least one batch on each side"
+    );
+    let (first_half, second_half) = input.split_at(split_at);
+
+    let tmp_dir = TempPath::new();
+    tmp_dir.create_as_dir().unwrap();
+
+    // Phase 1: commit, then drop. Drop flushes `BufferedState` and the snapshot committer
+    // thread, leaving the hot KV DB and state merkle DB on disk.
+    let version = {
+        let db = open_db(tmp_dir.path());
+        commit_batches(&db, first_half, 0)
+    };
+
+    // Phase 2: reopen. `load_hot_state_or_empty` runs here, populating the committed
+    // DashMaps with `StateSlot`s whose `state_key` is `None`. Continuing to commit drives
+    // LRU touches on those slots.
+    let db = open_db(tmp_dir.path());
+    assert_eq!(db.expect_synced_version(), version - 1);
+    let final_version = commit_batches(&db, second_half, version);
+
+    // Re-verify a pre-restart batch against the *current* (post-restart) ledger info. This
+    // confirms that the accumulator / state proofs remain consistent across the boundary.
+    let (first_batch_txns, _) = &input[0];
+    let latest_ledger_info = &input.last().unwrap().1;
+    verify_committed_transactions(
+        &db,
+        first_batch_txns,
+        0, /* first_version */
+        latest_ledger_info,
+        false, /* is_latest */
+    );
+
+    let expected_total: u64 = input.iter().map(|(txns, _)| txns.len() as u64).sum();
+    assert_eq!(final_version, expected_total);
+    assert_eq!(db.expect_synced_version(), expected_total - 1);
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(8))]
+
+    #[test]
+    fn test_restart(
+        (input, split_at) in arb_blocks_to_commit_with_params(
+            10, /* num_accounts — comfortably above 16 shards × MAX_HOT_ITEMS_PER_SHARD */
+            2,  /* max_user_txns_per_block */
+            3,  /* min_blocks — ≥ 2 so any split_at in `1..len` keeps both sides non-empty */
+            8,  /* max_blocks */
+        ).prop_flat_map(|blocks| {
+            let len = blocks.len();
+            (Just(blocks), 1usize..len)
+        }),
+    ) {
+        test_restart_impl(input, split_at);
+    }
+}

--- a/storage/storage-interface/src/state_store/mod.rs
+++ b/storage/storage-interface/src/state_store/mod.rs
@@ -13,13 +13,17 @@ pub mod versioned_state_value;
 use anyhow::{bail, Result};
 use aptos_crypto::HashValue;
 use aptos_types::{
-    state_store::{hot_state::HotStateValue, NUM_STATE_SHARDS},
+    state_store::{hot_state::HotStateValue, state_key::StateKey, NUM_STATE_SHARDS},
     transaction::Version,
 };
 use std::collections::HashMap;
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct HotInsertionOp {
+    /// The key associated with this insertion. Carried alongside the hash so that downstream
+    /// consumers (hot JMT commit, etc.) don't need to recover it from a slot that may lack
+    /// one (e.g. loaded from the hot state KV DB, which stores only the key hash).
+    pub state_key: StateKey,
     pub value: HotStateValue,
     /// `Some(version)` for occupied entries and `None` for vacant.
     pub value_version: Option<Version>,
@@ -28,7 +32,7 @@ pub struct HotInsertionOp {
     pub superseded_version: Option<Version>,
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct HotEvictionOp {
     pub eviction_version: Version,
     /// The `hot_since_version` of the DB entry being superseded. `None` if the key was never
@@ -36,7 +40,7 @@ pub struct HotEvictionOp {
     pub superseded_version: Option<Version>,
 }
 
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct HotStateShardUpdates {
     pub insertions: HashMap<HashValue, HotInsertionOp>,
     // TODO(HotState): per-block eviction tracking will be needed for cold-write elimination.
@@ -81,9 +85,29 @@ impl HotStateShardUpdates {
         self.evictions.insert(key_hash, evict);
         Ok(())
     }
+
+    /// Merges `other` into `self`, treating `other` as logically later in time. When the same
+    /// key appears in both, the earlier DB-level `superseded_version` is preserved so pruner
+    /// targeting stays correct across insert/evict/reinsert chains. Errors if `other` evicts a
+    /// key `self` has already evicted.
+    pub fn merge(&mut self, other: HotStateShardUpdates) -> Result<()> {
+        for (key_hash, op) in other.insertions {
+            self.insert(key_hash, op);
+        }
+        for (key_hash, evict) in other.evictions {
+            self.evict(key_hash, evict)?;
+        }
+        Ok(())
+    }
 }
 
-#[derive(Debug)]
+/// Creates an empty `[HotStateShardUpdates; NUM_STATE_SHARDS]`, used as the seed for accumulating
+/// hot state updates across chunks.
+pub fn empty_hot_state_shard_updates() -> [HotStateShardUpdates; NUM_STATE_SHARDS] {
+    std::array::from_fn(|_| HotStateShardUpdates::default())
+}
+
+#[derive(Clone, Debug)]
 pub struct HotStateUpdates {
     pub for_last_checkpoint: Option<[HotStateShardUpdates; NUM_STATE_SHARDS]>,
     pub for_latest: Option<[HotStateShardUpdates; NUM_STATE_SHARDS]>,
@@ -108,6 +132,7 @@ mod tests {
 
     fn insertion(superseded: Option<Version>, value_version: Option<Version>) -> HotInsertionOp {
         HotInsertionOp {
+            state_key: StateKey::raw(b"test"),
             value: HotStateValue::new(None, value_version.unwrap_or(0)),
             value_version,
             superseded_version: superseded,

--- a/storage/storage-interface/src/state_store/mod.rs
+++ b/storage/storage-interface/src/state_store/mod.rs
@@ -10,6 +10,7 @@ pub mod state_view;
 pub mod state_with_summary;
 pub mod versioned_state_value;
 
+use anyhow::{bail, Result};
 use aptos_crypto::HashValue;
 use aptos_types::{
     state_store::{hot_state::HotStateValue, NUM_STATE_SHARDS},
@@ -35,7 +36,7 @@ pub struct HotEvictionOp {
     pub superseded_version: Option<Version>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct HotStateShardUpdates {
     pub insertions: HashMap<HashValue, HotInsertionOp>,
     // TODO(HotState): per-block eviction tracking will be needed for cold-write elimination.
@@ -52,6 +53,34 @@ impl HotStateShardUpdates {
             evictions,
         }
     }
+
+    /// Inserts `op` at `key_hash`, preserving the original DB-level `superseded_version`
+    /// across insert/evict/reinsert chains: if an earlier eviction or insertion for this
+    /// key already exists, its `superseded_version` is inherited so the pruner still
+    /// targets the original DB entry.
+    pub fn insert(&mut self, key_hash: HashValue, mut op: HotInsertionOp) {
+        if let Some(evicted) = self.evictions.remove(&key_hash) {
+            op.superseded_version = evicted.superseded_version;
+        } else if let Some(prev) = self.insertions.get(&key_hash) {
+            op.superseded_version = prev.superseded_version;
+        }
+        self.insertions.insert(key_hash, op);
+    }
+
+    /// Records an eviction at `key_hash`. If an earlier insertion for this key exists,
+    /// it is removed and its `superseded_version` is carried onto `evict`. Returns an error
+    /// if the key was already evicted — the caller is expected to never evict the same key
+    /// twice within one `HotStateShardUpdates`.
+    pub fn evict(&mut self, key_hash: HashValue, mut evict: HotEvictionOp) -> Result<()> {
+        if self.evictions.contains_key(&key_hash) {
+            bail!("Key {key_hash} cannot be evicted twice.");
+        }
+        if let Some(prev) = self.insertions.remove(&key_hash) {
+            evict.superseded_version = prev.superseded_version;
+        }
+        self.evictions.insert(key_hash, evict);
+        Ok(())
+    }
 }
 
 #[derive(Debug)]
@@ -66,5 +95,111 @@ impl HotStateUpdates {
             for_last_checkpoint: None,
             for_latest: None,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn hash(n: u8) -> HashValue {
+        HashValue::new([n; HashValue::LENGTH])
+    }
+
+    fn insertion(superseded: Option<Version>, value_version: Option<Version>) -> HotInsertionOp {
+        HotInsertionOp {
+            value: HotStateValue::new(None, value_version.unwrap_or(0)),
+            value_version,
+            superseded_version: superseded,
+        }
+    }
+
+    fn eviction(eviction_version: Version, superseded: Option<Version>) -> HotEvictionOp {
+        HotEvictionOp {
+            eviction_version,
+            superseded_version: superseded,
+        }
+    }
+
+    #[test]
+    fn insert_into_empty() {
+        let mut updates = HotStateShardUpdates::default();
+        updates.insert(hash(1), insertion(Some(5), Some(10)));
+        assert!(updates.evictions.is_empty());
+        let op = updates.insertions.get(&hash(1)).unwrap();
+        assert_eq!(op.superseded_version, Some(5));
+        assert_eq!(op.value_version, Some(10));
+    }
+
+    #[test]
+    fn insert_preserves_first_insertions_superseded() {
+        let mut updates = HotStateShardUpdates::default();
+        updates.insert(hash(1), insertion(Some(5), Some(10)));
+        updates.insert(hash(1), insertion(Some(999), Some(20)));
+        let op = updates.insertions.get(&hash(1)).unwrap();
+        // Superseded carries over from the first insertion; value is taken from the
+        // latest insertion.
+        assert_eq!(op.superseded_version, Some(5));
+        assert_eq!(op.value_version, Some(20));
+    }
+
+    #[test]
+    fn insert_after_eviction_inherits_eviction_superseded() {
+        let mut updates = HotStateShardUpdates::default();
+        updates.evict(hash(1), eviction(100, Some(5))).unwrap();
+        updates.insert(hash(1), insertion(Some(999), Some(20)));
+        assert!(updates.evictions.is_empty());
+        let op = updates.insertions.get(&hash(1)).unwrap();
+        assert_eq!(op.superseded_version, Some(5));
+        assert_eq!(op.value_version, Some(20));
+    }
+
+    #[test]
+    fn evict_into_empty() {
+        let mut updates = HotStateShardUpdates::default();
+        updates.evict(hash(1), eviction(100, Some(5))).unwrap();
+        assert!(updates.insertions.is_empty());
+        let ev = updates.evictions.get(&hash(1)).unwrap();
+        assert_eq!(ev.eviction_version, 100);
+        assert_eq!(ev.superseded_version, Some(5));
+    }
+
+    #[test]
+    fn evict_after_insertion_inherits_insertion_superseded() {
+        let mut updates = HotStateShardUpdates::default();
+        updates.insert(hash(1), insertion(Some(5), Some(10)));
+        updates.evict(hash(1), eviction(100, Some(999))).unwrap();
+        assert!(updates.insertions.is_empty());
+        let ev = updates.evictions.get(&hash(1)).unwrap();
+        assert_eq!(ev.eviction_version, 100);
+        assert_eq!(ev.superseded_version, Some(5));
+    }
+
+    #[test]
+    fn evict_twice_errors() {
+        let mut updates = HotStateShardUpdates::default();
+        updates.evict(hash(1), eviction(100, Some(5))).unwrap();
+        assert!(updates.evict(hash(1), eviction(200, Some(6))).is_err());
+    }
+
+    #[test]
+    fn unrelated_keys_are_independent() {
+        let mut updates = HotStateShardUpdates::default();
+        updates.insert(hash(1), insertion(Some(5), Some(10)));
+        updates.evict(hash(2), eviction(100, Some(7))).unwrap();
+        updates.insert(hash(3), insertion(Some(9), Some(30)));
+
+        assert_eq!(
+            updates.insertions.get(&hash(1)).unwrap().superseded_version,
+            Some(5),
+        );
+        assert_eq!(
+            updates.evictions.get(&hash(2)).unwrap().superseded_version,
+            Some(7),
+        );
+        assert_eq!(
+            updates.insertions.get(&hash(3)).unwrap().superseded_version,
+            Some(9),
+        );
     }
 }

--- a/storage/storage-interface/src/state_store/state.rs
+++ b/storage/storage-interface/src/state_store/state.rs
@@ -239,19 +239,12 @@ impl State {
                         hot_metadata.total_value_bytes,
                     );
                     let mut all_updates = per_version.iter();
-                    let mut insertions = HashMap::new();
-                    let mut evictions = HashMap::new();
+                    let mut shard_updates = HotStateShardUpdates::default();
                     for ckpt_version in all_checkpoint_versions {
                         for (key, update) in
                             all_updates.take_while_ref(|(_k, u)| u.version <= *ckpt_version)
                         {
                             let key_hash = *key.crypto_hash_ref();
-                            // If this key was evicted earlier in the same batch, recover its
-                            // `superseded_version` so the insert→evict→reinsert chain keeps
-                            // pointing at the original DB entry the pruner should clean up.
-                            let evicted_superseded = evictions
-                                .remove(&key_hash)
-                                .and_then(|e: HotEvictionOp| e.superseded_version);
                             if let Some(op) = Self::apply_one_update(
                                 &mut lru,
                                 overlay,
@@ -260,40 +253,24 @@ impl State {
                                 update,
                                 self.hot_state_config.refresh_interval_versions,
                             ) {
-                                Self::insert_preserving_superseded(
-                                    &mut insertions,
-                                    key_hash,
-                                    op,
-                                    evicted_superseded,
-                                );
+                                shard_updates.insert(key_hash, op);
                             }
                         }
-                        // Only evict at the checkpoints.
+                        // Only evict at the checkpoints. `hot_since_version` is the default DB
+                        // version this eviction supersedes; if the key was inserted earlier in
+                        // the batch, `shard_updates.evict` will override with that instead.
                         for (key_hash, slot) in lru.maybe_evict() {
                             assert!(slot.is_hot());
-                            assert!(
-                                !evictions.contains_key(&key_hash),
-                                "Key {key_hash} cannot be evicted twice."
-                            );
-                            // Determine the DB version superseded by this hot entry. If the key was
-                            // inserted earlier in this batch, carry forward its superseded_version;
-                            // otherwise the key has been hot since before this batch, so use its
-                            // hot_since_version.
-                            let superseded_version = insertions
-                                .remove(&key_hash)
-                                .map(|prev| prev.superseded_version)
-                                .unwrap_or(Some(slot.expect_hot_since_version()));
-                            evictions.insert(key_hash, HotEvictionOp {
-                                eviction_version: *ckpt_version,
-                                superseded_version,
-                            });
+                            shard_updates
+                                .evict(key_hash, HotEvictionOp {
+                                    eviction_version: *ckpt_version,
+                                    superseded_version: Some(slot.expect_hot_since_version()),
+                                })
+                                .expect("LRU never evicts the same key twice within a batch.");
                         }
                     }
                     for (key, update) in all_updates {
                         let key_hash = *key.crypto_hash_ref();
-                        let evicted_superseded = evictions
-                            .remove(&key_hash)
-                            .and_then(|e| e.superseded_version);
                         if let Some(op) = Self::apply_one_update(
                             &mut lru,
                             overlay,
@@ -302,12 +279,7 @@ impl State {
                             update,
                             self.hot_state_config.refresh_interval_versions,
                         ) {
-                            Self::insert_preserving_superseded(
-                                &mut insertions,
-                                key_hash,
-                                op,
-                                evicted_superseded,
-                            );
+                            shard_updates.insert(key_hash, op);
                         }
                     }
 
@@ -324,10 +296,7 @@ impl State {
                         total_value_bytes: new_total_value_bytes,
                     };
                     let new_usage = Self::usage_delta_for_shard(cache, overlay, batched_updates);
-                    (
-                        ((new_layer, new_metadata), new_usage),
-                        HotStateShardUpdates::new(insertions, evictions),
-                    )
+                    (((new_layer, new_metadata), new_usage), shard_updates)
                 },
             )
             .unzip();
@@ -409,26 +378,6 @@ impl State {
                 superseded_version,
             })
         }
-    }
-
-    /// Inserts `op` into `insertions`, preserving the original DB-level `superseded_version`
-    /// across insert/evict/reinsert chains within the same batch.
-    fn insert_preserving_superseded(
-        insertions: &mut HashMap<HashValue, HotInsertionOp>,
-        key_hash: HashValue,
-        mut op: HotInsertionOp,
-        evicted_superseded: Option<Version>,
-    ) {
-        if let Some(prev) = insertions.get(&key_hash) {
-            // Key was already inserted earlier in this batch — keep the original
-            // superseded_version so the pruner still targets the right DB entry.
-            op.superseded_version = prev.superseded_version;
-        } else if evicted_superseded.is_some() {
-            // Key was evicted earlier in this batch — carry forward the superseded_version
-            // that was saved at eviction time.
-            op.superseded_version = evicted_superseded;
-        }
-        insertions.insert(key_hash, op);
     }
 
     fn update_usage(&self, usage_delta_per_shard: Vec<(i64, i64)>) -> StateStorageUsage {

--- a/storage/storage-interface/src/state_store/state.rs
+++ b/storage/storage-interface/src/state_store/state.rs
@@ -335,6 +335,7 @@ impl State {
             let superseded_version =
                 lru.insert(key, update.to_result_slot((*key).clone()).unwrap());
             return Some(HotInsertionOp {
+                state_key: (*key).clone(),
                 value: HotStateValue::new(state_value_opt.cloned(), update.version),
                 value_version: state_value_opt.map(|_| update.version),
                 superseded_version,
@@ -358,6 +359,7 @@ impl State {
                 let value = HotStateValue::clone_from_slot(&slot_to_insert);
                 let superseded_version = lru.insert(key, slot_to_insert);
                 Some(HotInsertionOp {
+                    state_key: (*key).clone(),
                     value,
                     value_version,
                     superseded_version,
@@ -373,6 +375,7 @@ impl State {
             let value = HotStateValue::clone_from_slot(&slot);
             let superseded_version = lru.insert(key, slot);
             Some(HotInsertionOp {
+                state_key: (*key).clone(),
                 value,
                 value_version,
                 superseded_version,

--- a/types/src/state_store/state_slot.rs
+++ b/types/src/state_store/state_slot.rs
@@ -146,17 +146,20 @@ impl StateSlot {
     }
 
     /// When committing speculative state to the DB, determine if to make changes to the JMT.
+    ///
+    /// Resolves `maybe_update_cold_state` first so slots that carry no cold JMT change —
+    /// notably LRU-churn updates on DB-loaded neighbor slots, which lack a `state_key` — are
+    /// short-circuited before we demand the key.
     pub fn maybe_update_jmt(
         &self,
         min_version: Version,
     ) -> Option<(HashValue, Option<(HashValue, StateKey)>)> {
+        let value_opt = self.maybe_update_cold_state(min_version)?;
         let state_key = self.expect_state_key();
-        self.maybe_update_cold_state(min_version).map(|value_opt| {
-            (
-                *state_key.crypto_hash_ref(),
-                value_opt.map(|v| (CryptoHash::hash(v), state_key.clone())),
-            )
-        })
+        Some((
+            *state_key.crypto_hash_ref(),
+            value_opt.map(|v| (CryptoHash::hash(v), state_key.clone())),
+        ))
     }
 
     // TODO(HotState): db returns cold slot directly


### PR DESCRIPTION

On restart with hot-state persistence, `StateKvDb::load_hot_state_kvs`
creates `StateSlot`s via `new_without_state_key` — the hot KV DB only
stores the key hash. During replay, `HotStateLRU::insert_as_head` and
`delete` update prev/next pointers on neighbor slots pulled from that
DB view and re-insert the patched slots into `pending` with `state_key`
still `None`. Those slots flow through `StateDelta` into the snapshot
committer's cold-JMT iteration, where `maybe_update_jmt` called
`expect_state_key()` unconditionally and panicked:

    StateSlot: state_key is None (loaded from DB without key)
    at types/src/state_store/state_slot.rs:104

These slots never warrant a cold JMT update — their `value_version` /
`hot_since_version` are at most the loaded snapshot version and
therefore strictly below `min_version`, so `maybe_update_cold_state`
already returns `None` for them. Resolve the cold-state check first and
only demand the key when a real update is produced. This mirrors the
filter f142471e9175 already applied on the hot-JMT path via the separate
`HotStateShardUpdates` stream.

Covered by a new end-to-end proptest in
`storage/aptosdb/src/state_store/tests/restart.rs` that commits random
blocks, drops and reopens the `AptosDB` with `delete_on_restart = false`
and a small `max_items_per_shard`, and continues committing. Pre-fix
the `state-committer` thread panics with the above message within
seconds and `drain_commits` hangs; post-fix the test passes and state
proofs verify across the restart boundary.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/aptos-labs/aptos-core/pull/19500).
* __->__ #19500
* #19499
* #19498