### PR TITLE
[prover] Universal state quantification and other bug fixes in dynamic dispatch handling

### DIFF
--- a/aptos-move/flow/scripts/gen-local-for-claude.sh
+++ b/aptos-move/flow/scripts/gen-local-for-claude.sh
@@ -39,4 +39,4 @@ echo "Generating plugin files in $OUTPUT_DIR..."
 move-flow plugin "$OUTPUT_DIR" "${LOG_ARGS[@]}"
 
 echo "Done. Run Claude with:"
-echo "  claude --plugin $OUTPUT_DIR"
+echo "  claude --plugin-dir $OUTPUT_DIR"

--- a/aptos-move/flow/src/mcp/tools/package_spec_infer.rs
+++ b/aptos-move/flow/src/mcp/tools/package_spec_infer.rs
@@ -101,6 +101,7 @@ impl FlowSession {
                     .join("output.bpl")
                     .to_string_lossy()
                     .into_owned();
+                aptos_framework::prover::set_aptos_custom_natives(&mut options);
 
                 // 5. Clear leftover diagnostics from previous runs, then run inference.
                 data.env().clear_diag();

--- a/aptos-move/flow/src/mcp/tools/package_spec_infer.rs
+++ b/aptos-move/flow/src/mcp/tools/package_spec_infer.rs
@@ -101,7 +101,6 @@ impl FlowSession {
                     .join("output.bpl")
                     .to_string_lossy()
                     .into_owned();
-                aptos_framework::prover::set_aptos_custom_natives(&mut options);
 
                 // 5. Clear leftover diagnostics from previous runs, then run inference.
                 data.env().clear_diag();

--- a/aptos-move/flow/src/mcp/tools/package_verify.rs
+++ b/aptos-move/flow/src/mcp/tools/package_verify.rs
@@ -149,7 +149,6 @@ impl FlowSession {
                     .join("output.bpl")
                     .to_string_lossy()
                     .into_owned();
-                aptos_framework::prover::set_aptos_custom_natives(&mut options);
 
                 // 6. Clear leftover diagnostics from previous runs, then run the prover.
                 data.env().clear_diag();

--- a/aptos-move/flow/src/mcp/tools/package_verify.rs
+++ b/aptos-move/flow/src/mcp/tools/package_verify.rs
@@ -26,6 +26,15 @@ struct MovePackageVerifyParams {
     exclude: Option<Vec<String>>,
     /// Solver timeout per verification condition, in seconds. Default: 10. Maximum: 60.
     timeout: Option<usize>,
+    /// If set, generate an independent verification condition for each
+    /// assertion in a function instead of a single combined condition. Can
+    /// help when a function mixes provable-but-hard asserts with asserts
+    /// that produce counterexamples; useful for diagnosing per-function
+    /// timeouts.
+    split_vcs_by_assert: Option<bool>,
+    /// Maximum number of counterexamples reported per verification
+    /// condition.
+    error_limit: Option<usize>,
 }
 
 const DEFAULT_VC_TIMEOUT: usize = 10;
@@ -45,16 +54,21 @@ impl FlowSession {
         Parameters(params): Parameters<MovePackageVerifyParams>,
     ) -> Result<CallToolResult, rmcp::ErrorData> {
         log::info!(
-            "move_package_verify({}, filter={:?}, exclude={:?}, timeout={:?})",
+            "move_package_verify({}, filter={:?}, exclude={:?}, timeout={:?}, \
+             split_vcs_by_assert={:?}, error_limit={:?})",
             params.package_path,
             params.filter,
             params.exclude,
-            params.timeout
+            params.timeout,
+            params.split_vcs_by_assert,
+            params.error_limit
         );
         let (pkg, _) = self.resolve_package(&params.package_path).await?;
         let filter = params.filter.clone();
         let exclude = params.exclude.clone();
         let vc_timeout = params.timeout.unwrap_or(DEFAULT_VC_TIMEOUT);
+        let split_vcs_by_assert = params.split_vcs_by_assert.unwrap_or(false);
+        let error_limit = params.error_limit;
 
         if vc_timeout > MAX_VC_TIMEOUT {
             return Ok(CallToolResult::error(vec![Content::text(
@@ -120,6 +134,10 @@ impl FlowSession {
                 options.prover.verify_scope = verification_scope;
                 options.prover.verify_exclude = verify_exclude;
                 options.backend.vc_timeout = vc_timeout;
+                options.backend.split_vcs_by_assert = split_vcs_by_assert;
+                if let Some(n) = error_limit {
+                    options.backend.error_limit = n;
+                }
                 aptos_framework::prover::configure_aptos_custom_natives(&mut options);
                 #[cfg(test)]
                 {
@@ -131,6 +149,7 @@ impl FlowSession {
                     .join("output.bpl")
                     .to_string_lossy()
                     .into_owned();
+                aptos_framework::prover::set_aptos_custom_natives(&mut options);
 
                 // 6. Clear leftover diagnostics from previous runs, then run the prover.
                 data.env().clear_diag();

--- a/aptos-move/flow/src/tests/list_tools/success.exp
+++ b/aptos-move/flow/src/tests/list_tools/success.exp
@@ -188,6 +188,18 @@
           "format": "uint",
           "minimum": 0,
           "nullable": true
+        },
+        "split_vcs_by_assert": {
+          "description": "If set, generate an independent verification condition for each\nassertion in a function instead of a single combined condition. Can\nhelp when a function mixes provable-but-hard asserts with asserts\nthat produce counterexamples; useful for diagnosing per-function\ntimeouts.",
+          "type": "boolean",
+          "nullable": true
+        },
+        "error_limit": {
+          "description": "Maximum number of counterexamples reported per verification\ncondition.",
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0,
+          "nullable": true
         }
       },
       "required": [

--- a/aptos-move/framework/src/extended_checks.rs
+++ b/aptos-move/framework/src/extended_checks.rs
@@ -292,6 +292,7 @@ impl ExtendedChecker<'_> {
             | Reference(_, _)
             | TypeDomain(_)
             | ResourceDomain(_, _, _)
+            | StateDomain
             | Error
             | Var(_) => false,
         }

--- a/aptos-move/framework/src/prover.rs
+++ b/aptos-move/framework/src/prover.rs
@@ -316,17 +316,6 @@ impl ProverOptions {
     }
 }
 
-/// Configures Aptos-specific native function specifications on the given
-/// prover options. This loads `aptos-natives.bpl` and the module instance
-/// names needed for types like `object` and `aggregator_v2`.
-pub fn set_aptos_custom_natives(options: &mut Options) {
-    options.backend.custom_natives =
-        Some(move_prover_boogie_backend::options::CustomNativeOptions {
-            template_bytes: include_bytes!("aptos-natives.bpl").to_vec(),
-            module_instance_names: move_prover_boogie_backend::options::custom_native_options(),
-        });
-}
-
 fn run_prover_benchmark(
     package_path: &Path,
     env: &mut GlobalEnv,

--- a/aptos-move/framework/src/prover.rs
+++ b/aptos-move/framework/src/prover.rs
@@ -118,6 +118,18 @@ pub struct ProverOptions {
     #[clap(long = "skip-instance-check")]
     pub skip_instance_check: bool,
 
+    /// Generate an independent verification condition for each assertion in a
+    /// function instead of a single combined condition. Can help when a
+    /// function contains both provable-but-hard asserts and asserts that
+    /// produce counterexamples; useful for diagnosing per-function timeouts.
+    #[clap(long)]
+    pub split_vcs_by_assert: bool,
+
+    /// Maximum number of counterexamples reported per verification
+    /// condition.
+    #[clap(long)]
+    pub error_limit: Option<usize>,
+
     /// Internal flag: use a temp dir for boogie output so parallel invocations
     /// don't interfere. Set automatically by test harnesses.
     #[clap(long, hide = true)]
@@ -281,6 +293,9 @@ impl ProverOptions {
                 loop_unroll: self.loop_unroll.or(base_opts.backend.loop_unroll),
                 skip_instance_check: self.skip_instance_check
                     || base_opts.backend.skip_instance_check,
+                split_vcs_by_assert: self.split_vcs_by_assert
+                    || base_opts.backend.split_vcs_by_assert,
+                error_limit: self.error_limit.unwrap_or(base_opts.backend.error_limit),
                 ..base_opts.backend
             },
             ..base_opts
@@ -299,6 +314,17 @@ impl ProverOptions {
             ..Self::default()
         }
     }
+}
+
+/// Configures Aptos-specific native function specifications on the given
+/// prover options. This loads `aptos-natives.bpl` and the module instance
+/// names needed for types like `object` and `aggregator_v2`.
+pub fn set_aptos_custom_natives(options: &mut Options) {
+    options.backend.custom_natives =
+        Some(move_prover_boogie_backend::options::CustomNativeOptions {
+            template_bytes: include_bytes!("aptos-natives.bpl").to_vec(),
+            module_instance_names: move_prover_boogie_backend::options::custom_native_options(),
+        });
 }
 
 fn run_prover_benchmark(

--- a/third_party/move/move-compiler-v2/legacy-move-compiler/src/expansion/translate.rs
+++ b/third_party/move/move-compiler-v2/legacy-move-compiler/src/expansion/translate.rs
@@ -2837,12 +2837,60 @@ fn bind_with_range_list(
     let rs_: Option<Vec<E::LValueWithRange>> = prs_
         .into_iter()
         .map(|sp!(loc, (pb, pr))| -> Option<E::LValueWithRange> {
+            // State-domain ranges (`S in *`) produce a $spec_state_domain call.
+            // The binding variable must be treated as a plain variable, not a
+            // struct pattern, even if uppercase (since state labels conventionally
+            // use uppercase names like `S`).
+            let is_state_domain = is_state_domain_range(&pr);
             let r = exp_(context, pr);
-            let b = bind(context, pb)?;
+            let b = if is_state_domain {
+                bind_as_var(context, pb)
+            } else {
+                bind(context, pb)?
+            };
             Some(sp(loc, (b, r)))
         })
         .collect();
     Some(sp(loc, rs_?))
+}
+
+/// Returns true if the range expression is a `$spec_state_domain()` call.
+fn is_state_domain_range(exp: &P::Exp) -> bool {
+    use crate::parser::ast::{Exp_ as PE, NameAccessChain_ as NA};
+    if let PE::Call(sp!(_, NA::One(name)), _, _, _) = &exp.value {
+        name.value.as_str() == "$spec_state_domain"
+    } else {
+        false
+    }
+}
+
+/// Like `bind`, but always produces a variable binding (never struct destructure).
+/// Used for state-domain quantifier variables, which use uppercase names by convention
+/// (e.g., `S` in `forall S in *:`). Skips the local name validity check since these
+/// are state labels, not regular local variables.
+fn bind_as_var(context: &mut Context, sp!(loc, pb_): P::Bind) -> E::LValue {
+    use E::LValue_ as EL;
+    use P::Bind_ as PB;
+    let b_ = match pb_ {
+        PB::Var(v) => {
+            // Skip check_valid_local_name: state labels use uppercase by convention.
+            EL::Var(sp(loc, E::ModuleAccess_::Name(v.0)), None)
+        },
+        _ => {
+            context.env.add_diag(diag!(
+                Syntax::SpecContextRestricted,
+                (
+                    loc,
+                    "state domain quantifier variable must be a simple variable"
+                )
+            ));
+            EL::Var(
+                sp(loc, E::ModuleAccess_::Name(sp(loc, Symbol::from("_")))),
+                None,
+            )
+        },
+    };
+    sp(loc, b_)
 }
 
 fn bind(context: &mut Context, sp!(loc, pb_): P::Bind) -> Option<E::LValue> {

--- a/third_party/move/move-compiler-v2/legacy-move-compiler/src/parser/syntax.rs
+++ b/third_party/move/move-compiler-v2/legacy-move-compiler/src/parser/syntax.rs
@@ -2907,7 +2907,19 @@ fn parse_quant_binding(context: &mut Context) -> Result<Spanned<(Bind, Exp)>, Bo
     } else {
         // This is a quantifier over a value, like a vector or a range.
         consume_identifier(context.tokens, "in")?;
-        parse_exp(context)?
+        if context.tokens.peek() == Tok::Star {
+            // State domain: `S in *` — quantification over all memory states.
+            let star_start = context.tokens.start_loc();
+            context.tokens.advance()?;
+            let star_loc = make_loc(
+                context.tokens.file_hash(),
+                star_start,
+                context.tokens.previous_end_loc(),
+            );
+            make_builtin_call(star_loc, Symbol::from("$spec_state_domain"), None, vec![])
+        } else {
+            parse_exp(context)?
+        }
     };
     let end_loc = context.tokens.previous_end_loc();
     Ok(spanned(

--- a/third_party/move/move-compiler-v2/src/bytecode_generator.rs
+++ b/third_party/move/move-compiler-v2/src/bytecode_generator.rs
@@ -1013,6 +1013,7 @@ impl Generator<'_> {
             | Operation::TypeValue
             | Operation::TypeDomain
             | Operation::ResourceDomain
+            | Operation::StateDomain
             | Operation::Global(_)
             | Operation::CanModify
             | Operation::Old

--- a/third_party/move/move-compiler-v2/src/env_pipeline/cyclic_instantiation_checker.rs
+++ b/third_party/move/move-compiler-v2/src/env_pipeline/cyclic_instantiation_checker.rs
@@ -242,7 +242,11 @@ fn ty_contains_ty_parameter(ty: &Type) -> Option<u16> {
         },
         Type::Reference(_, ty) => ty_contains_ty_parameter(ty),
         Type::Tuple(ty) => ty.iter().filter_map(ty_contains_ty_parameter).next(),
-        Type::TypeDomain(_) | Type::ResourceDomain(..) | Type::Error | Type::Var(_) => {
+        Type::TypeDomain(_)
+        | Type::ResourceDomain(..)
+        | Type::StateDomain
+        | Type::Error
+        | Type::Var(_) => {
             panic!("ICE: {:?} used as a type parameter", ty)
         },
     }
@@ -259,7 +263,11 @@ fn ty_properly_contains_ty_parameter(ty: &Type) -> Option<u16> {
         },
         Type::Reference(_, ty) => ty_contains_ty_parameter(ty),
         Type::Tuple(ty) => ty.iter().filter_map(ty_contains_ty_parameter).next(),
-        Type::TypeDomain(_) | Type::ResourceDomain(..) | Type::Error | Type::Var(_) => {
+        Type::TypeDomain(_)
+        | Type::ResourceDomain(..)
+        | Type::StateDomain
+        | Type::Error
+        | Type::Var(_) => {
             panic!("ICE: {:?} used as a type parameter", ty)
         },
     }

--- a/third_party/move/move-compiler-v2/src/env_pipeline/function_checker.rs
+++ b/third_party/move/move-compiler-v2/src/env_pipeline/function_checker.rs
@@ -476,6 +476,7 @@ fn collect_struct_op_from_exp(func: &FunctionEnv, exp: &ExpData, ops: &mut Vec<S
             | Operation::TypeValue
             | Operation::TypeDomain
             | Operation::ResourceDomain
+            | Operation::StateDomain
             | Operation::Global(_)
             | Operation::CanModify
             | Operation::Old

--- a/third_party/move/move-compiler-v2/src/env_pipeline/unused_params_checker.rs
+++ b/third_party/move/move-compiler-v2/src/env_pipeline/unused_params_checker.rs
@@ -66,7 +66,11 @@ fn used_type_parameters_in_ty(ty: &Type) -> BTreeSet<u16> {
             .flat_map(|t| used_type_parameters_in_ty(t))
             .collect(),
         Type::Reference(_, t) => used_type_parameters_in_ty(t),
-        Type::TypeDomain(..) | Type::ResourceDomain(..) | Type::Error | Type::Var(..) => {
+        Type::TypeDomain(..)
+        | Type::ResourceDomain(..)
+        | Type::StateDomain
+        | Type::Error
+        | Type::Var(..) => {
             unreachable!("unexpected type")
         },
     }

--- a/third_party/move/move-compiler-v2/src/file_format_generator/module_generator.rs
+++ b/third_party/move/move-compiler-v2/src/file_format_generator/module_generator.rs
@@ -446,7 +446,7 @@ impl ModuleGenerator {
                     *abilities,
                 )
             },
-            TypeDomain(_) | ResourceDomain(_, _, _) | Error | Var(_) => {
+            TypeDomain(_) | ResourceDomain(_, _, _) | StateDomain | Error | Var(_) => {
                 ctx.internal_error(
                     loc,
                     format!(

--- a/third_party/move/move-model/bytecode/src/astifier.rs
+++ b/third_party/move/move-model/bytecode/src/astifier.rs
@@ -2400,7 +2400,8 @@ impl AssignTransformer<'_> {
                 | Operation::SpecPublish(..)
                 | Operation::SpecRemove(..)
                 | Operation::SpecUpdate(..)
-                | Operation::NoOp => false,
+                | Operation::NoOp
+                | Operation::StateDomain => false,
             },
             ExpData::Value(..)
             | ExpData::Temporary(..)

--- a/third_party/move/move-model/src/ast.rs
+++ b/third_party/move/move-model/src/ast.rs
@@ -324,6 +324,14 @@ pub enum BehaviorKind {
     ResultOf,
 }
 
+impl BehaviorKind {
+    /// Returns true if this is a two-state predicate (ensures_of, result_of)
+    /// that requires both pre and post memory states.
+    pub fn is_two_state(&self) -> bool {
+        matches!(self, BehaviorKind::EnsuresOf | BehaviorKind::ResultOf)
+    }
+}
+
 impl fmt::Display for BehaviorKind {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         use BehaviorKind::*;
@@ -2387,8 +2395,8 @@ impl ExpData {
                         | Shr | And | Or | Eq | Neq | Lt | Gt | Le | Ge | Copy | Move | Not
                         | Cast | Negate | Exists(..) | BorrowGlobal(..) | Borrow(..) | Deref
                         | MoveTo | MoveFrom | Freeze(..) | Abort(..) | Vector | Len | TypeValue
-                        | TypeDomain | ResourceDomain | Global(..) | CanModify | Old
-                        | Trace(..) | SpecPublish(..) | SpecRemove(..) | SpecUpdate(..)
+                        | TypeDomain | ResourceDomain | StateDomain | Global(..) | CanModify
+                        | Old | Trace(..) | SpecPublish(..) | SpecRemove(..) | SpecUpdate(..)
                         | EmptyVec | SingleVec | UpdateVec | ConcatVec | IndexOfVec
                         | ContainsVec | InRangeRange | InRangeVec | RangeVec | MaxU8 | MaxU16
                         | MaxU32 | MaxU64 | MaxU128 | MaxU256 | Bv2Int | Int2Bv | AbortFlag
@@ -2628,6 +2636,7 @@ pub enum Operation {
     TypeValue,
     TypeDomain,
     ResourceDomain,
+    StateDomain,
     Global(Option<MemoryLabel>),
     CanModify,
     Old,
@@ -3478,6 +3487,17 @@ impl fmt::Display for EnvDisplay<'_, PropertyBag> {
 /// # Purity of Expressions
 
 impl Operation {
+    /// Returns all `MemoryLabel` values embedded in this operation.
+    pub fn memory_labels(&self) -> Vec<MemoryLabel> {
+        use Operation::*;
+        match self {
+            Global(Some(l)) | Exists(Some(l)) => vec![*l],
+            Behavior(_, range) | SpecFunction(_, _, range) => range.labels().collect(),
+            SpecPublish(range) | SpecRemove(range) | SpecUpdate(range) => range.labels().collect(),
+            _ => vec![],
+        }
+    }
+
     /// Determines whether this operation depends on global memory
     pub fn uses_no_memory<F>(&self, check_pure: &F) -> bool
     where
@@ -3636,6 +3656,7 @@ impl Operation {
             // Operation with no effect
             TestVariants(..) => true, // Cannot abort
             NoOp => true,
+            StateDomain => true, // Spec domain, not runtime
         }
     }
 

--- a/third_party/move/move-model/src/builder/builtins.rs
+++ b/third_party/move/move-model/src/builder/builtins.rs
@@ -971,6 +971,20 @@ pub(crate) fn declare_builtins(trans: &mut ModelBuilder) {
             },
         );
 
+        // State domain (for quantifying over state labels: `forall S in *:`)
+        trans.define_spec_or_builtin_fun(
+            trans.builtin_qualified_symbol("$spec_state_domain"),
+            SpecOrBuiltinFunEntry {
+                loc: loc.clone(),
+                oper: Operation::StateDomain,
+                type_params: vec![],
+                type_param_constraints: BTreeMap::default(),
+                params: vec![],
+                result_type: Type::StateDomain,
+                visibility: Spec,
+            },
+        );
+
         // Old
         trans.define_spec_or_builtin_fun(
             trans.builtin_qualified_symbol("old"),

--- a/third_party/move/move-model/src/builder/exp_builder.rs
+++ b/third_party/move/move-model/src/builder/exp_builder.rs
@@ -5875,6 +5875,7 @@ impl ExpTranslator<'_, '_, '_> {
             let (exp_ty, rdomain_exp) = self.translate_exp_free(domain_exp);
             let elem_ty = self.fresh_type_var();
             let exp_ty = self.subs.specialize(&exp_ty);
+            let is_state_domain = matches!(&exp_ty, Type::StateDomain);
             match &exp_ty {
                 Type::Vector(..) => {
                     self.check_type(
@@ -5900,8 +5901,18 @@ impl ExpTranslator<'_, '_, '_> {
                         &ErrorMessageContext::General,
                     );
                 },
+                Type::StateDomain => {
+                    // State domain: variable is a state label, not a normal local.
+                    // Unify elem_ty with StateDomain so the pattern has a concrete type.
+                    self.check_type(
+                        &loc,
+                        &elem_ty,
+                        &Type::StateDomain,
+                        &ErrorMessageContext::General,
+                    );
+                },
                 _ => {
-                    self.error(&loc, "quantified variables must range over a vector, a type domain, or a number range");
+                    self.error(&loc, "quantified variables must range over a vector, a type domain, a number range, or a state domain");
                     return self.new_error_exp();
                 },
             }
@@ -5913,7 +5924,11 @@ impl ExpTranslator<'_, '_, '_> {
                 false, /*allow_wildcard_for_tuple*/
                 &ErrorMessageContext::Binding,
             );
-            self.define_locals_of_pat(&rpat);
+            if !is_state_domain {
+                // State domain variables are not added to the local scope;
+                // they are resolved as state labels in |~ expressions.
+                self.define_locals_of_pat(&rpat);
+            }
             rranges.push((rpat, rdomain_exp.into_exp()));
         }
         let rtriggers = triggers
@@ -5929,6 +5944,8 @@ impl ExpTranslator<'_, '_, '_> {
         let rcondition = condition
             .as_ref()
             .map(|cond| self.translate_exp(cond, &BOOL_TYPE).into_exp());
+        // Validate that state-domain quantified variables are used as state labels in the body.
+        self.validate_state_domain_usage(&rranges, &rbody);
         self.exit_scope();
         let quant_ty = if rkind.is_choice() {
             self.env().get_node_type(rranges[0].0.node_id())
@@ -5938,6 +5955,56 @@ impl ExpTranslator<'_, '_, '_> {
         self.check_type(loc, &quant_ty, expected_type, context);
         let id = self.new_node_id_with_type_loc(&quant_ty, loc);
         ExpData::Quant(id, rkind, rranges, rtriggers, rcondition, rbody.into_exp())
+    }
+
+    /// Validates that each state-domain quantifier variable is used as a state label
+    /// (`|~`) somewhere in the body of the quantifier.
+    fn validate_state_domain_usage(&self, rranges: &[(Pattern, Exp)], body: &ExpData) {
+        use std::collections::BTreeSet;
+        // Collect symbol names of state-domain quantifier variables
+        let mut state_domain_vars: Vec<(Symbol, Loc)> = Vec::new();
+        for (pat, range) in rranges.iter() {
+            let range_ty = self.env().get_node_type(range.node_id());
+            if matches!(range_ty, Type::StateDomain) {
+                if let Pattern::Var(id, sym) = pat {
+                    let loc = self.env().get_node_loc(*id);
+                    state_domain_vars.push((*sym, loc));
+                }
+            }
+        }
+        if state_domain_vars.is_empty() {
+            return;
+        }
+        // Collect all MemoryLabel values used in the body
+        let mut used_labels = BTreeSet::new();
+        body.visit_pre_order(&mut |e| {
+            if let ExpData::Call(_, op, _) = e {
+                for label in op.memory_labels() {
+                    used_labels.insert(label);
+                }
+            }
+            true
+        });
+        // Map labels back to symbol names
+        let mut used_label_names = BTreeSet::new();
+        for label in &used_labels {
+            if let Some(name) = self.env().get_memory_label_name(*label) {
+                used_label_names.insert(name);
+            }
+        }
+        // Check that each state-domain variable is used as a state label
+        for (sym, loc) in &state_domain_vars {
+            if !used_label_names.contains(sym) {
+                self.error(
+                    loc,
+                    &format!(
+                        "unused quantified state label `{}`; \
+                         state domain variables must be used as state labels (`|~`) in the body",
+                        self.symbol_pool().string(*sym)
+                    ),
+                );
+            }
+        }
     }
 
     /// Translates a behavior predicate expression (requires_of, aborts_of, ensures_of, result_of).

--- a/third_party/move/move-model/src/builder/model_builder.rs
+++ b/third_party/move/move-model/src/builder/model_builder.rs
@@ -50,6 +50,7 @@ impl BuiltinReceiverType {
             Type::Reference(..) => None,
             Type::Fun(..) => None,
             Type::ResourceDomain(..) => None,
+            Type::StateDomain => None,
         }
     }
 

--- a/third_party/move/move-model/src/model.rs
+++ b/third_party/move/move-model/src/model.rs
@@ -861,6 +861,11 @@ impl GlobalEnv {
         self.memory_label_names.borrow().get(&label).copied()
     }
 
+    /// Get a snapshot of all memory label names.
+    pub fn get_memory_label_names(&self) -> BTreeMap<MemoryLabel, Symbol> {
+        self.memory_label_names.borrow().clone()
+    }
+
     /// Returns a reference to the symbol pool owned by this environment.
     pub fn symbol_pool(&self) -> &SymbolPool {
         &self.symbol_pool

--- a/third_party/move/move-model/src/sourcifier.rs
+++ b/third_party/move/move-model/src/sourcifier.rs
@@ -52,11 +52,10 @@ fn is_simple_quant(
     triggers: &[Vec<Exp>],
     where_clause: &Option<Exp>,
 ) -> bool {
-    triggers.is_empty()
-        && where_clause.is_none()
-        && ranges.iter().all(|(_, range)| {
-            matches!(range.as_ref(), ExpData::Call(_, Operation::TypeDomain, args) if args.is_empty())
-        })
+    triggers.is_empty() && where_clause.is_none() && ranges.iter().all(|(_, range)| {
+        matches!(range.as_ref(), ExpData::Call(_, Operation::TypeDomain, args) if args.is_empty())
+            || matches!(range.as_ref(), ExpData::Call(_, Operation::StateDomain, _))
+    })
 }
 
 // NOTE: has_any_state_label was removed — replaced by is_state_neutral which also
@@ -2013,6 +2012,8 @@ impl<'a> ExpSourcifier<'a> {
                     emit!(self.wr(), " in ");
                     self.print_exp(Prio::General, false, range);
                 }
+            } else if matches!(range.as_ref(), ExpData::Call(_, Operation::StateDomain, _)) {
+                emit!(self.wr(), " in *");
             } else {
                 emit!(self.wr(), " in ");
                 self.print_exp(Prio::General, false, range);
@@ -2706,6 +2707,7 @@ impl<'a> ExpSourcifier<'a> {
                 self.print_node_inst(id);
                 emit!(self.wr(), "()")
             }),
+            Operation::StateDomain => emit!(self.wr(), "*"),
             Operation::MaxU8 => emit!(self.wr(), "MAX_U8"),
             Operation::MaxU16 => emit!(self.wr(), "MAX_U16"),
             Operation::MaxU32 => emit!(self.wr(), "MAX_U32"),

--- a/third_party/move/move-model/src/sourcifier.rs
+++ b/third_party/move/move-model/src/sourcifier.rs
@@ -1246,12 +1246,16 @@ impl<'a> Sourcifier<'a> {
         for cond in &spec.conditions {
             self.print_condition(cond, &exp_sourcifier);
         }
-        if let Some(proof) = &spec.proof {
-            self.print_proof(proof, &exp_sourcifier);
-        }
         self.writer.unindent();
 
-        emitln!(self.writer, "}");
+        // The `proof { ... }` clause is a sibling of the `spec { ... }` block in
+        // source syntax, not a member, so emit it after the closing brace.
+        if let Some(proof) = &spec.proof {
+            emit!(self.writer, "} ");
+            self.print_proof(proof, &exp_sourcifier);
+        } else {
+            emitln!(self.writer, "}");
+        }
         emitln!(self.writer);
     }
 
@@ -1331,21 +1335,25 @@ impl<'a> Sourcifier<'a> {
         for cond in &spec.conditions {
             self.print_condition(cond, &exp_sourcifier);
         }
-        if let Some(proof) = &spec.proof {
-            self.print_proof(proof, &exp_sourcifier);
-        }
         self.writer.unindent();
 
-        emitln!(self.writer, "}");
+        // The `proof { ... }` clause is a sibling of the `spec { ... }` block in
+        // source syntax, not a member, so emit it after the closing brace.
+        if let Some(proof) = &spec.proof {
+            emit!(self.writer, "} ");
+            self.print_proof(proof, &exp_sourcifier);
+        } else {
+            emitln!(self.writer, "}");
+        }
         emitln!(self.writer);
     }
 
     fn print_proof(&self, proof: &crate::ast::Proof, exp_sourcifier: &ExpSourcifier) {
-        emitln!(self.writer, "proof {{");
+        emitln!(self.writer, "proof {");
         self.writer.indent();
         self.print_proof_body(proof, exp_sourcifier);
         self.writer.unindent();
-        emitln!(self.writer, "}}");
+        emitln!(self.writer, "}");
     }
 
     fn print_proof_body(&self, proof: &crate::ast::Proof, exp_sourcifier: &ExpSourcifier) {
@@ -1360,17 +1368,17 @@ impl<'a> Sourcifier<'a> {
             Proof::IfElse(_, cond, then_branch, else_branch) => {
                 emit!(self.writer, "if (");
                 exp_sourcifier.print_exp(Prio::General, false, cond);
-                emitln!(self.writer, ") {{");
+                emitln!(self.writer, ") {");
                 self.writer.indent();
                 self.print_proof_body(then_branch, exp_sourcifier);
                 self.writer.unindent();
                 if let Some(eb) = else_branch {
-                    emitln!(self.writer, "}} else {{");
+                    emitln!(self.writer, "} else {");
                     self.writer.indent();
                     self.print_proof_body(eb, exp_sourcifier);
                     self.writer.unindent();
                 }
-                emitln!(self.writer, "}}");
+                emitln!(self.writer, "}");
             },
             Proof::Block(_, stmts) => {
                 for stmt in stmts {

--- a/third_party/move/move-model/src/spec_translator.rs
+++ b/third_party/move/move-model/src/spec_translator.rs
@@ -89,7 +89,7 @@ impl ProofAction {
                 if let Some(e) = opt_exp {
                     *e = freshener.rewrite_exp(e.clone());
                 }
-            },
+            }
         }
     }
 }
@@ -175,7 +175,7 @@ impl TranslatedSpec {
     pub fn pre_conditions<'a, T: ExpGenerator<'a>>(
         &self,
         _builder: &T,
-    ) -> impl Iterator<Item = (Loc, Exp)> + '_ + use<'_, T> {
+    ) -> impl Iterator<Item=(Loc, Exp)> + '_ + use < '_, T > {
         self.pre.iter().cloned()
     }
 
@@ -341,7 +341,7 @@ impl<'a, 'b, T: ExpGenerator<'a>> SpecTranslator<'a, 'b, T> {
     pub fn translate_invariants(
         auto_trace: bool,
         builder: &'b mut T,
-        invariants: impl Iterator<Item = (&'b GlobalInvariant, Vec<Type>)>,
+        invariants: impl Iterator<Item=(&'b GlobalInvariant, Vec<Type>)>,
     ) -> TranslatedSpec {
         let fun_env = builder.function_env().clone();
         let mut translator = SpecTranslator {
@@ -416,7 +416,7 @@ impl<'a, 'b, T: ExpGenerator<'a>> SpecTranslator<'a, 'b, T> {
     pub fn translate_invariants_by_id(
         auto_trace: bool,
         builder: &'b mut T,
-        inv_ids: impl Iterator<Item = (GlobalId, Vec<Type>)>,
+        inv_ids: impl Iterator<Item=(GlobalId, Vec<Type>)>,
     ) -> TranslatedSpec {
         let global_env = builder.global_env();
         SpecTranslator::translate_invariants(
@@ -516,8 +516,8 @@ impl<'a, 'b, T: ExpGenerator<'a>> SpecTranslator<'a, 'b, T> {
         if self.result.aborts.is_empty()
             && self.result.aborts_with.is_empty()
             && self
-                .fun_env
-                .is_pragma_true(ABORTS_IF_IS_STRICT_PRAGMA, || false)
+            .fun_env
+            .is_pragma_true(ABORTS_IF_IS_STRICT_PRAGMA, || false)
         {
             self.result.aborts.push((
                 self.fun_env.get_loc().at_end(),
@@ -541,7 +541,7 @@ impl<'a, 'b, T: ExpGenerator<'a>> SpecTranslator<'a, 'b, T> {
                     ExpData::Call(id, oper, args) if args.len() == 1 => {
                         ExpData::Call(*id, oper.clone(), vec![self.auto_trace(&loc, &args[0])])
                             .into_exp()
-                    },
+                    }
                     _ => target.clone(),
                 };
                 let exp = self.translate_exp(&exp, false);
@@ -625,7 +625,7 @@ impl<'a, 'b, T: ExpGenerator<'a>> SpecTranslator<'a, 'b, T> {
                         op.clone(),
                         args.iter().map(|e| self.auto_trace_sub(e)).collect(),
                     )
-                    .into_exp(),
+                        .into_exp(),
                 ),
                 ExpData::LocalVar(_, sym) => (self.let_locals.contains_key(sym), e),
                 ExpData::Call(id, Operation::Global(None), args) => (
@@ -633,14 +633,14 @@ impl<'a, 'b, T: ExpGenerator<'a>> SpecTranslator<'a, 'b, T> {
                     ExpData::Call(*id, Operation::Global(None), vec![
                         self.auto_trace_sub(&args[0])
                     ])
-                    .into_exp(),
+                        .into_exp(),
                 ),
                 ExpData::Call(id, Operation::Exists(None), args) => (
                     true,
                     ExpData::Call(*id, Operation::Exists(None), vec![
                         self.auto_trace_sub(&args[0])
                     ])
-                    .into_exp(),
+                        .into_exp(),
                 ),
                 _ => (false, e),
             };
@@ -706,7 +706,7 @@ impl<'a, 'b, T: ExpGenerator<'a>> SpecTranslator<'a, 'b, T> {
     /// Save memory for multiple resources using the shared old label.
     fn save_memory_shared<'c>(
         &mut self,
-        used_memory: impl IntoIterator<Item = &'c QualifiedInstId<StructId>>,
+        used_memory: impl IntoIterator<Item=&'c QualifiedInstId<StructId>>,
         inst: &[Type],
     ) -> MemoryLabel {
         let label = self.get_or_create_old_label();
@@ -735,7 +735,7 @@ impl<'a, 'b, T: ExpGenerator<'a>> SpecTranslator<'a, 'b, T> {
                     .lets
                     .push((loc.clone(), self.in_post_state, temp, exp));
                 // No proof action emitted for Let — it's already in result.lets.
-            },
+            }
             Proof::Assert(loc, exp) => {
                 let exp = self.translate_exp(exp, false);
                 let guarded = self.guard_proof_exp(exp, &path_cond);
@@ -743,19 +743,19 @@ impl<'a, 'b, T: ExpGenerator<'a>> SpecTranslator<'a, 'b, T> {
                     loc.clone(),
                     ProofAction::Assert(guarded, "proof assertion not satisfied".to_string()),
                 );
-            },
+            }
             Proof::Assume(loc, exp) => {
                 let exp = self.translate_exp(exp, false);
                 let guarded = self.guard_proof_exp(exp, &path_cond);
                 self.push_proof_action(loc.clone(), ProofAction::Assume(guarded));
-            },
+            }
             Proof::Split(loc, exp) => {
                 let exp = self.translate_exp(exp, false);
                 // Don't wrap with `==>`: for splits the guard is handled separately
                 // by the instrumentation to preserve the split expression's type and
                 // to produce correct case-split semantics.
                 self.push_proof_action(loc.clone(), ProofAction::Split(exp, path_cond.clone()));
-            },
+            }
             Proof::IfElse(_loc, cond, then_p, else_p) => {
                 let cond = self.translate_exp(cond, false);
                 let then_cond = match &path_cond {
@@ -779,24 +779,24 @@ impl<'a, 'b, T: ExpGenerator<'a>> SpecTranslator<'a, 'b, T> {
                     self.translate_proof(eb, Some(else_cond));
                     self.let_locals = saved;
                 }
-            },
+            }
             Proof::Block(_loc, stmts) => {
                 let saved_let_locals = self.let_locals.clone();
                 for stmt in stmts {
                     self.translate_proof(stmt, path_cond.clone());
                 }
                 self.let_locals = saved_let_locals;
-            },
+            }
             Proof::Post(_loc, inner) => {
                 let saved = self.in_post_state;
                 self.in_post_state = true;
                 self.translate_proof(inner, path_cond);
                 self.in_post_state = saved;
-            },
+            }
             Proof::Apply(loc, qid, args) => {
                 let args: Vec<Exp> = args.iter().map(|a| self.translate_exp(a, false)).collect();
                 self.expand_lemma_apply(loc, *qid, &args, &path_cond);
-            },
+            }
             Proof::ForallApply(loc, binds, pats, qid, args) => {
                 let args: Vec<Exp> = args.iter().map(|a| self.translate_exp(a, false)).collect();
                 let pats: Vec<Vec<Exp>> = pats
@@ -809,7 +809,7 @@ impl<'a, 'b, T: ExpGenerator<'a>> SpecTranslator<'a, 'b, T> {
                     })
                     .collect();
                 self.expand_forall_lemma_apply(loc, binds, &pats, *qid, &args, &path_cond);
-            },
+            }
             Proof::Calc(loc, steps) => {
                 let env = self.builder.global_env();
                 for (lhs, op, rhs) in steps {
@@ -823,7 +823,7 @@ impl<'a, 'b, T: ExpGenerator<'a>> SpecTranslator<'a, 'b, T> {
                         ProofAction::Assert(guarded, "calc step not satisfied".to_string()),
                     );
                 }
-            },
+            }
         }
     }
 
@@ -862,7 +862,7 @@ impl<'a, 'b, T: ExpGenerator<'a>> SpecTranslator<'a, 'b, T> {
                         }
                     }
                     None
-                },
+                }
                 RewriteTarget::Temporary(idx) => args.get(idx).cloned(),
             }
         };
@@ -986,7 +986,7 @@ impl<'a, 'b, T: ExpGenerator<'a>> SpecTranslator<'a, 'b, T> {
             None,
             body,
         )
-        .into_exp();
+            .into_exp();
 
         let guarded = self.guard_proof_exp(quant_exp, path_cond);
         self.push_proof_action(loc.clone(), ProofAction::Assume(guarded));
@@ -1045,7 +1045,7 @@ impl<'a, T: ExpGenerator<'a>> ExpRewriterFunctions for SpecTranslator<'a, '_, T>
                         labels,
                     )
                 }
-            },
+            }
             ExpData::Call(id, Operation::Trace(TraceKind::User), args) => {
                 // Generate an error if a TRACE is applied to an expression where it is not
                 // allowed, i.e. if there are free LocalVar terms, excluding locals from lets.
@@ -1061,8 +1061,8 @@ impl<'a, T: ExpGenerator<'a>> ExpRewriterFunctions for SpecTranslator<'a, '_, T>
                              on quantified variables or spec function parameters",
                     )
                 }
-            },
-            _ => {},
+            }
+            _ => {}
         }
         if is_old {
             self.in_old = true;
@@ -1123,7 +1123,7 @@ impl<'a, T: ExpGenerator<'a>> ExpRewriterFunctions for SpecTranslator<'a, '_, T>
                     Global(Some(self.save_memory(self.builder.get_memory_of_node(id)))),
                     args.to_owned(),
                 )
-                .into_exp(),
+                    .into_exp(),
             ),
             Exists(None) if self.in_old => Some(
                 Call(
@@ -1131,7 +1131,7 @@ impl<'a, T: ExpGenerator<'a>> ExpRewriterFunctions for SpecTranslator<'a, '_, T>
                     Exists(Some(self.save_memory(self.builder.get_memory_of_node(id)))),
                     args.to_owned(),
                 )
-                .into_exp(),
+                    .into_exp(),
             ),
             // SpecFunction with labels from state labels: still may need pre-state SaveMem
             SpecFunction(mid, fid, range) if !range.is_default() => {
@@ -1158,7 +1158,7 @@ impl<'a, T: ExpGenerator<'a>> ExpRewriterFunctions for SpecTranslator<'a, '_, T>
                 } else {
                     None
                 }
-            },
+            }
             // SpecFunction in old context: save memory for pre-state
             SpecFunction(mid, fid, range) if self.in_old => {
                 let used_memory = {
@@ -1173,7 +1173,7 @@ impl<'a, T: ExpGenerator<'a>> ExpRewriterFunctions for SpecTranslator<'a, '_, T>
                     post: range.post,
                 };
                 Some(Call(id, SpecFunction(*mid, *fid, new_range), args.to_owned()).into_exp())
-            },
+            }
             // SpecFunction outside old but uses_old: save memory for pre-state
             SpecFunction(mid, fid, range) if !self.in_old => {
                 let (uses_old, has_old_memory, used_memory) = {
@@ -1196,28 +1196,54 @@ impl<'a, T: ExpGenerator<'a>> ExpRewriterFunctions for SpecTranslator<'a, '_, T>
                 } else {
                     None
                 }
-            },
+            }
             // Behavior with labels already set: leave as-is
             Behavior(_, range) if !range.is_default() => None,
             // Behavior that needs pre-state label
             Behavior(kind, range) if needs_pre_label(kind, self.in_old) => {
+                let env = self.builder.global_env();
                 if let Some(ExpData::Call(closure_id, Operation::Closure(mid, fid, _), _)) =
                     args.first().map(|a| a.as_ref())
                 {
-                    let fun_env = self.builder.global_env().get_function(mid.qualified(*fid));
+                    let fun_env = env.get_function(mid.qualified(*fid));
                     let used_memory = fun_env.get_spec_used_memory().clone();
-                    let inst = self
-                        .builder
-                        .global_env()
-                        .get_node_instantiation(*closure_id);
+                    let inst = env.get_node_instantiation(*closure_id);
                     let label = self.save_memory_shared(&used_memory, &inst);
                     let new_range = MemoryRange {
                         pre: Some(label),
                         post: range.post,
                     };
                     Some(Call(id, Behavior(*kind, new_range), args.to_owned()).into_exp())
+                } else if let Some(ExpData::Call(
+                                       _,
+                                       Operation::Select(smid, sid, field_id),
+                                       _,
+                                   )) = args.first().map(|a| a.as_ref())
+                {
+                    // Struct-field function value (e.g. `pool.pricing.0`):
+                    // the closure's memory footprint is declared by the
+                    // struct's field spec (`reads_of<f> …` / `modifies_of<f> …`).
+                    // Using `self.fun_env.get_spec_used_memory()` here would miss
+                    // these resources, leaving the pre-state label unsaved at
+                    // procedure entry.
+                    let struct_env =
+                        env.get_module(*smid).into_struct(*sid);
+                    let field_sym = field_id.symbol();
+                    let memory = collect_field_access_memory(env, &struct_env, field_sym);
+                    let label = self.save_memory_shared(&memory, self.type_args);
+                    let new_range = MemoryRange {
+                        pre: Some(label),
+                        post: range.post,
+                    };
+                    Some(Call(id, Behavior(*kind, new_range), args.to_owned()).into_exp())
                 } else {
-                    // Temporary/LocalVar: use enclosing function's spec_used_memory
+                    // Temporary (function parameter), let-bound local, etc.:
+                    // fall back to the enclosing function's spec_used_memory.
+                    // For function-typed parameters with `modifies_of` /
+                    // `reads_of` declarations, the env_pipeline spec rewriter
+                    // already propagates the parameter's access_of memory into
+                    // the function's spec_used_memory / spec_old_memory, so
+                    // this fallback covers the fun-param case too.
                     let used_memory = self.fun_env.get_spec_used_memory().clone();
                     let label = self.save_memory_shared(&used_memory, self.type_args);
                     let new_range = MemoryRange {
@@ -1226,12 +1252,12 @@ impl<'a, T: ExpGenerator<'a>> ExpRewriterFunctions for SpecTranslator<'a, '_, T>
                     };
                     Some(Call(id, Behavior(*kind, new_range), args.to_owned()).into_exp())
                 }
-            },
+            }
             Old => Some(args[0].to_owned()),
             Result(n) => {
                 self.builder.set_loc_from_node(id);
                 Some(self.builder.mk_temporary(self.ret_locals[*n]))
-            },
+            }
             Trace(kind) => {
                 let exp = args[0].to_owned();
                 let env = self.builder.global_env();
@@ -1241,7 +1267,7 @@ impl<'a, T: ExpGenerator<'a>> ExpRewriterFunctions for SpecTranslator<'a, '_, T>
                     .debug_traces
                     .push((trace_id, *kind, exp.clone()));
                 Some(exp)
-            },
+            }
             _ => None,
         }
     }
@@ -1257,7 +1283,7 @@ impl<'a, T: ExpGenerator<'a>> ExpRewriterFunctions for SpecTranslator<'a, '_, T>
     fn rewrite_enter_scope<'c>(
         &mut self,
         _id: NodeId,
-        decls: impl Iterator<Item = &'c (NodeId, Symbol)>,
+        decls: impl Iterator<Item=&'c (NodeId, Symbol)>,
     ) {
         self.shadowed.push(decls.map(|(_, name)| *name).collect())
     }
@@ -1272,4 +1298,42 @@ impl<'a, T: ExpGenerator<'a>> ExpRewriterFunctions for SpecTranslator<'a, '_, T>
 /// `aborts_of` and `requires_of` only need pre-state if inside `old()`.
 fn needs_pre_label(kind: &BehaviorKind, in_old: bool) -> bool {
     in_old || matches!(kind, BehaviorKind::EnsuresOf | BehaviorKind::ResultOf)
+}
+
+/// Memory accessed by a struct field's function value, as declared by the
+/// struct's `reads_of<f> …` / `modifies_of<f> …` specs. Used to populate
+/// `saved_memory` when a behavioral predicate like `result_of<s.f>(…)` needs
+/// a pre-state label: without this the Boogie evaluator's `old_*` memory
+/// slot would reference an unsaved snapshot variable.
+///
+/// Wildcard (`*`) is approximated by all `key` structs reachable from the
+/// current `GlobalEnv`. Mono-based exact expansion isn't available here
+/// (the spec translator runs before `mono_analysis`), so over-saving is
+/// acceptable: extra saved memory only adds a cheap `SaveMem` at procedure
+/// entry without affecting verification soundness.
+fn collect_field_access_memory(
+    env: &crate::model::GlobalEnv,
+    struct_env: &crate::model::StructEnv,
+    field_sym: Symbol,
+) -> BTreeSet<QualifiedInstId<StructId>> {
+    let mut memory: BTreeSet<QualifiedInstId<StructId>> = BTreeSet::new();
+    for access in struct_env.get_field_access_of() {
+        if access.fun_param != field_sym {
+            continue;
+        }
+        if access.frame_spec.modifies_all || access.frame_spec.reads_all {
+            for module in env.get_modules() {
+                for s in module.get_structs() {
+                    if s.get_abilities().has_key() {
+                        memory.insert(s.get_qualified_id().instantiate(vec![]));
+                    }
+                }
+            }
+        } else {
+            memory.extend(access.used_memory.iter().cloned());
+            memory.extend(access.old_memory.iter().cloned());
+        }
+        break;
+    }
+    memory
 }

--- a/third_party/move/move-model/src/spec_translator.rs
+++ b/third_party/move/move-model/src/spec_translator.rs
@@ -89,7 +89,7 @@ impl ProofAction {
                 if let Some(e) = opt_exp {
                     *e = freshener.rewrite_exp(e.clone());
                 }
-            }
+            },
         }
     }
 }
@@ -175,7 +175,7 @@ impl TranslatedSpec {
     pub fn pre_conditions<'a, T: ExpGenerator<'a>>(
         &self,
         _builder: &T,
-    ) -> impl Iterator<Item=(Loc, Exp)> + '_ + use < '_, T > {
+    ) -> impl Iterator<Item = (Loc, Exp)> + '_ + use<'_, T> {
         self.pre.iter().cloned()
     }
 
@@ -341,7 +341,7 @@ impl<'a, 'b, T: ExpGenerator<'a>> SpecTranslator<'a, 'b, T> {
     pub fn translate_invariants(
         auto_trace: bool,
         builder: &'b mut T,
-        invariants: impl Iterator<Item=(&'b GlobalInvariant, Vec<Type>)>,
+        invariants: impl Iterator<Item = (&'b GlobalInvariant, Vec<Type>)>,
     ) -> TranslatedSpec {
         let fun_env = builder.function_env().clone();
         let mut translator = SpecTranslator {
@@ -416,7 +416,7 @@ impl<'a, 'b, T: ExpGenerator<'a>> SpecTranslator<'a, 'b, T> {
     pub fn translate_invariants_by_id(
         auto_trace: bool,
         builder: &'b mut T,
-        inv_ids: impl Iterator<Item=(GlobalId, Vec<Type>)>,
+        inv_ids: impl Iterator<Item = (GlobalId, Vec<Type>)>,
     ) -> TranslatedSpec {
         let global_env = builder.global_env();
         SpecTranslator::translate_invariants(
@@ -516,8 +516,8 @@ impl<'a, 'b, T: ExpGenerator<'a>> SpecTranslator<'a, 'b, T> {
         if self.result.aborts.is_empty()
             && self.result.aborts_with.is_empty()
             && self
-            .fun_env
-            .is_pragma_true(ABORTS_IF_IS_STRICT_PRAGMA, || false)
+                .fun_env
+                .is_pragma_true(ABORTS_IF_IS_STRICT_PRAGMA, || false)
         {
             self.result.aborts.push((
                 self.fun_env.get_loc().at_end(),
@@ -541,7 +541,7 @@ impl<'a, 'b, T: ExpGenerator<'a>> SpecTranslator<'a, 'b, T> {
                     ExpData::Call(id, oper, args) if args.len() == 1 => {
                         ExpData::Call(*id, oper.clone(), vec![self.auto_trace(&loc, &args[0])])
                             .into_exp()
-                    }
+                    },
                     _ => target.clone(),
                 };
                 let exp = self.translate_exp(&exp, false);
@@ -625,7 +625,7 @@ impl<'a, 'b, T: ExpGenerator<'a>> SpecTranslator<'a, 'b, T> {
                         op.clone(),
                         args.iter().map(|e| self.auto_trace_sub(e)).collect(),
                     )
-                        .into_exp(),
+                    .into_exp(),
                 ),
                 ExpData::LocalVar(_, sym) => (self.let_locals.contains_key(sym), e),
                 ExpData::Call(id, Operation::Global(None), args) => (
@@ -633,14 +633,14 @@ impl<'a, 'b, T: ExpGenerator<'a>> SpecTranslator<'a, 'b, T> {
                     ExpData::Call(*id, Operation::Global(None), vec![
                         self.auto_trace_sub(&args[0])
                     ])
-                        .into_exp(),
+                    .into_exp(),
                 ),
                 ExpData::Call(id, Operation::Exists(None), args) => (
                     true,
                     ExpData::Call(*id, Operation::Exists(None), vec![
                         self.auto_trace_sub(&args[0])
                     ])
-                        .into_exp(),
+                    .into_exp(),
                 ),
                 _ => (false, e),
             };
@@ -706,7 +706,7 @@ impl<'a, 'b, T: ExpGenerator<'a>> SpecTranslator<'a, 'b, T> {
     /// Save memory for multiple resources using the shared old label.
     fn save_memory_shared<'c>(
         &mut self,
-        used_memory: impl IntoIterator<Item=&'c QualifiedInstId<StructId>>,
+        used_memory: impl IntoIterator<Item = &'c QualifiedInstId<StructId>>,
         inst: &[Type],
     ) -> MemoryLabel {
         let label = self.get_or_create_old_label();
@@ -735,7 +735,7 @@ impl<'a, 'b, T: ExpGenerator<'a>> SpecTranslator<'a, 'b, T> {
                     .lets
                     .push((loc.clone(), self.in_post_state, temp, exp));
                 // No proof action emitted for Let — it's already in result.lets.
-            }
+            },
             Proof::Assert(loc, exp) => {
                 let exp = self.translate_exp(exp, false);
                 let guarded = self.guard_proof_exp(exp, &path_cond);
@@ -743,19 +743,19 @@ impl<'a, 'b, T: ExpGenerator<'a>> SpecTranslator<'a, 'b, T> {
                     loc.clone(),
                     ProofAction::Assert(guarded, "proof assertion not satisfied".to_string()),
                 );
-            }
+            },
             Proof::Assume(loc, exp) => {
                 let exp = self.translate_exp(exp, false);
                 let guarded = self.guard_proof_exp(exp, &path_cond);
                 self.push_proof_action(loc.clone(), ProofAction::Assume(guarded));
-            }
+            },
             Proof::Split(loc, exp) => {
                 let exp = self.translate_exp(exp, false);
                 // Don't wrap with `==>`: for splits the guard is handled separately
                 // by the instrumentation to preserve the split expression's type and
                 // to produce correct case-split semantics.
                 self.push_proof_action(loc.clone(), ProofAction::Split(exp, path_cond.clone()));
-            }
+            },
             Proof::IfElse(_loc, cond, then_p, else_p) => {
                 let cond = self.translate_exp(cond, false);
                 let then_cond = match &path_cond {
@@ -779,24 +779,24 @@ impl<'a, 'b, T: ExpGenerator<'a>> SpecTranslator<'a, 'b, T> {
                     self.translate_proof(eb, Some(else_cond));
                     self.let_locals = saved;
                 }
-            }
+            },
             Proof::Block(_loc, stmts) => {
                 let saved_let_locals = self.let_locals.clone();
                 for stmt in stmts {
                     self.translate_proof(stmt, path_cond.clone());
                 }
                 self.let_locals = saved_let_locals;
-            }
+            },
             Proof::Post(_loc, inner) => {
                 let saved = self.in_post_state;
                 self.in_post_state = true;
                 self.translate_proof(inner, path_cond);
                 self.in_post_state = saved;
-            }
+            },
             Proof::Apply(loc, qid, args) => {
                 let args: Vec<Exp> = args.iter().map(|a| self.translate_exp(a, false)).collect();
                 self.expand_lemma_apply(loc, *qid, &args, &path_cond);
-            }
+            },
             Proof::ForallApply(loc, binds, pats, qid, args) => {
                 let args: Vec<Exp> = args.iter().map(|a| self.translate_exp(a, false)).collect();
                 let pats: Vec<Vec<Exp>> = pats
@@ -809,7 +809,7 @@ impl<'a, 'b, T: ExpGenerator<'a>> SpecTranslator<'a, 'b, T> {
                     })
                     .collect();
                 self.expand_forall_lemma_apply(loc, binds, &pats, *qid, &args, &path_cond);
-            }
+            },
             Proof::Calc(loc, steps) => {
                 let env = self.builder.global_env();
                 for (lhs, op, rhs) in steps {
@@ -823,7 +823,7 @@ impl<'a, 'b, T: ExpGenerator<'a>> SpecTranslator<'a, 'b, T> {
                         ProofAction::Assert(guarded, "calc step not satisfied".to_string()),
                     );
                 }
-            }
+            },
         }
     }
 
@@ -862,7 +862,7 @@ impl<'a, 'b, T: ExpGenerator<'a>> SpecTranslator<'a, 'b, T> {
                         }
                     }
                     None
-                }
+                },
                 RewriteTarget::Temporary(idx) => args.get(idx).cloned(),
             }
         };
@@ -986,7 +986,7 @@ impl<'a, 'b, T: ExpGenerator<'a>> SpecTranslator<'a, 'b, T> {
             None,
             body,
         )
-            .into_exp();
+        .into_exp();
 
         let guarded = self.guard_proof_exp(quant_exp, path_cond);
         self.push_proof_action(loc.clone(), ProofAction::Assume(guarded));
@@ -1045,7 +1045,7 @@ impl<'a, T: ExpGenerator<'a>> ExpRewriterFunctions for SpecTranslator<'a, '_, T>
                         labels,
                     )
                 }
-            }
+            },
             ExpData::Call(id, Operation::Trace(TraceKind::User), args) => {
                 // Generate an error if a TRACE is applied to an expression where it is not
                 // allowed, i.e. if there are free LocalVar terms, excluding locals from lets.
@@ -1061,8 +1061,8 @@ impl<'a, T: ExpGenerator<'a>> ExpRewriterFunctions for SpecTranslator<'a, '_, T>
                              on quantified variables or spec function parameters",
                     )
                 }
-            }
-            _ => {}
+            },
+            _ => {},
         }
         if is_old {
             self.in_old = true;
@@ -1123,7 +1123,7 @@ impl<'a, T: ExpGenerator<'a>> ExpRewriterFunctions for SpecTranslator<'a, '_, T>
                     Global(Some(self.save_memory(self.builder.get_memory_of_node(id)))),
                     args.to_owned(),
                 )
-                    .into_exp(),
+                .into_exp(),
             ),
             Exists(None) if self.in_old => Some(
                 Call(
@@ -1131,7 +1131,7 @@ impl<'a, T: ExpGenerator<'a>> ExpRewriterFunctions for SpecTranslator<'a, '_, T>
                     Exists(Some(self.save_memory(self.builder.get_memory_of_node(id)))),
                     args.to_owned(),
                 )
-                    .into_exp(),
+                .into_exp(),
             ),
             // SpecFunction with labels from state labels: still may need pre-state SaveMem
             SpecFunction(mid, fid, range) if !range.is_default() => {
@@ -1158,7 +1158,7 @@ impl<'a, T: ExpGenerator<'a>> ExpRewriterFunctions for SpecTranslator<'a, '_, T>
                 } else {
                     None
                 }
-            }
+            },
             // SpecFunction in old context: save memory for pre-state
             SpecFunction(mid, fid, range) if self.in_old => {
                 let used_memory = {
@@ -1173,7 +1173,7 @@ impl<'a, T: ExpGenerator<'a>> ExpRewriterFunctions for SpecTranslator<'a, '_, T>
                     post: range.post,
                 };
                 Some(Call(id, SpecFunction(*mid, *fid, new_range), args.to_owned()).into_exp())
-            }
+            },
             // SpecFunction outside old but uses_old: save memory for pre-state
             SpecFunction(mid, fid, range) if !self.in_old => {
                 let (uses_old, has_old_memory, used_memory) = {
@@ -1196,7 +1196,7 @@ impl<'a, T: ExpGenerator<'a>> ExpRewriterFunctions for SpecTranslator<'a, '_, T>
                 } else {
                     None
                 }
-            }
+            },
             // Behavior with labels already set: leave as-is
             Behavior(_, range) if !range.is_default() => None,
             // Behavior that needs pre-state label
@@ -1214,11 +1214,8 @@ impl<'a, T: ExpGenerator<'a>> ExpRewriterFunctions for SpecTranslator<'a, '_, T>
                         post: range.post,
                     };
                     Some(Call(id, Behavior(*kind, new_range), args.to_owned()).into_exp())
-                } else if let Some(ExpData::Call(
-                                       _,
-                                       Operation::Select(smid, sid, field_id),
-                                       _,
-                                   )) = args.first().map(|a| a.as_ref())
+                } else if let Some(ExpData::Call(_, Operation::Select(smid, sid, field_id), _)) =
+                    args.first().map(|a| a.as_ref())
                 {
                     // Struct-field function value (e.g. `pool.pricing.0`):
                     // the closure's memory footprint is declared by the
@@ -1226,8 +1223,7 @@ impl<'a, T: ExpGenerator<'a>> ExpRewriterFunctions for SpecTranslator<'a, '_, T>
                     // Using `self.fun_env.get_spec_used_memory()` here would miss
                     // these resources, leaving the pre-state label unsaved at
                     // procedure entry.
-                    let struct_env =
-                        env.get_module(*smid).into_struct(*sid);
+                    let struct_env = env.get_module(*smid).into_struct(*sid);
                     let field_sym = field_id.symbol();
                     let memory = collect_field_access_memory(env, &struct_env, field_sym);
                     let label = self.save_memory_shared(&memory, self.type_args);
@@ -1252,12 +1248,12 @@ impl<'a, T: ExpGenerator<'a>> ExpRewriterFunctions for SpecTranslator<'a, '_, T>
                     };
                     Some(Call(id, Behavior(*kind, new_range), args.to_owned()).into_exp())
                 }
-            }
+            },
             Old => Some(args[0].to_owned()),
             Result(n) => {
                 self.builder.set_loc_from_node(id);
                 Some(self.builder.mk_temporary(self.ret_locals[*n]))
-            }
+            },
             Trace(kind) => {
                 let exp = args[0].to_owned();
                 let env = self.builder.global_env();
@@ -1267,7 +1263,7 @@ impl<'a, T: ExpGenerator<'a>> ExpRewriterFunctions for SpecTranslator<'a, '_, T>
                     .debug_traces
                     .push((trace_id, *kind, exp.clone()));
                 Some(exp)
-            }
+            },
             _ => None,
         }
     }
@@ -1283,7 +1279,7 @@ impl<'a, T: ExpGenerator<'a>> ExpRewriterFunctions for SpecTranslator<'a, '_, T>
     fn rewrite_enter_scope<'c>(
         &mut self,
         _id: NodeId,
-        decls: impl Iterator<Item=&'c (NodeId, Symbol)>,
+        decls: impl Iterator<Item = &'c (NodeId, Symbol)>,
     ) {
         self.shadowed.push(decls.map(|(_, name)| *name).collect())
     }

--- a/third_party/move/move-model/src/ty.rs
+++ b/third_party/move/move-model/src/ty.rs
@@ -52,6 +52,7 @@ pub enum Type {
     // Types only appearing in specifications.
     TypeDomain(Box<Type>),
     ResourceDomain(ModuleId, StructId, Option<Vec<Type>>),
+    StateDomain,
 
     // Temporary types used during type checking
     Error,
@@ -1165,7 +1166,7 @@ impl Type {
         match self {
             Primitive(p) => p.is_spec(),
             Fun(args, result, _) => args.is_spec() || result.is_spec(),
-            TypeDomain(..) | ResourceDomain(..) | Error => true,
+            TypeDomain(..) | ResourceDomain(..) | StateDomain | Error => true,
             Var(..) | TypeParameter(..) => false,
             Tuple(ts) => ts.iter().any(|t| t.is_spec()),
             Struct(_, _, ts) => ts.iter().any(|t| t.is_spec()),
@@ -1255,7 +1256,7 @@ impl Type {
                 types.push(self.clone());
                 types
             },
-            Type::ResourceDomain(_, _, None) => {
+            Type::ResourceDomain(_, _, None) | Type::StateDomain => {
                 vec![self.clone()]
             },
             Type::Var(..) => {
@@ -1378,6 +1379,7 @@ impl Type {
             Type::Fun(..)
             | Type::TypeDomain(..)
             | Type::ResourceDomain(..)
+            | Type::StateDomain
             | Type::Var(..)
             | Type::Error => false,
         }
@@ -1578,7 +1580,7 @@ impl Type {
                 *sid,
                 args_opt.as_ref().map(|args| replace_vec(args, visiting)),
             ),
-            Type::Primitive(..) | Type::Error => self.clone(),
+            Type::Primitive(..) | Type::StateDomain | Type::Error => self.clone(),
         }
     }
 
@@ -1613,7 +1615,7 @@ impl Type {
             Vector(et) => et.is_incomplete(),
             Reference(_, bt) => bt.is_incomplete(),
             TypeDomain(bt) => bt.is_incomplete(),
-            Error | Primitive(..) | TypeParameter(_) | ResourceDomain(..) => false,
+            Error | Primitive(..) | TypeParameter(_) | ResourceDomain(..) | StateDomain => false,
         }
     }
 
@@ -1801,7 +1803,7 @@ impl Type {
             Vector(et) => et.internal_get_vars(vars),
             Reference(_, bt) => bt.internal_get_vars(vars),
             TypeDomain(bt) => bt.internal_get_vars(vars),
-            Error | Primitive(..) | TypeParameter(..) | ResourceDomain(..) => {},
+            Error | Primitive(..) | TypeParameter(..) | ResourceDomain(..) | StateDomain => {},
         }
     }
 
@@ -2544,7 +2546,7 @@ impl Substitution {
             },
             Fun(_, _, abilities) => check(*abilities),
             Reference(_, _) => check(AbilitySet::REFERENCES),
-            TypeDomain(_) | ResourceDomain(_, _, _) => check(AbilitySet::EMPTY),
+            TypeDomain(_) | ResourceDomain(_, _, _) | StateDomain => check(AbilitySet::EMPTY),
             Error => Ok(()),
             Var(idx) => {
                 // Discharge the constraint by adding it to the substitution for
@@ -2894,6 +2896,9 @@ impl Substitution {
                     e1,
                     e2,
                 )?)));
+            },
+            (Type::StateDomain, Type::StateDomain) => {
+                return Ok(Type::StateDomain);
             },
             _ => {},
         }
@@ -3893,6 +3898,7 @@ impl fmt::Display for TypeDisplay<'_> {
                 }
                 f.write_str(">")
             },
+            StateDomain => write!(f, "state_domain"),
             Fun(a, t, abilities) => {
                 f.write_str("|")?;
                 if !a.is_unit() {
@@ -4132,9 +4138,10 @@ pub trait AbilityInference: AbilityContext {
                     .unwrap_or(AbilitySet::PRIMITIVES),
             ),
             Type::Fun(_, _, abilities) => (false, *abilities),
-            Type::TypeDomain(_) | Type::ResourceDomain(_, _, _) | Type::Error => {
-                (false, AbilitySet::EMPTY)
-            },
+            Type::TypeDomain(_)
+            | Type::ResourceDomain(_, _, _)
+            | Type::StateDomain
+            | Type::Error => (false, AbilitySet::EMPTY),
         }
     }
 

--- a/third_party/move/move-prover/boogie-backend/src/boogie_helpers.rs
+++ b/third_party/move/move-prover/boogie-backend/src/boogie_helpers.rs
@@ -370,7 +370,7 @@ pub fn boogie_type(env: &GlobalEnv, ty: &Type, bv_flag: bool) -> String {
         TypeParameter(idx) => boogie_type_param(env, *idx),
         Fun(param, result, abilities) => fun_type(env, param, result, *abilities),
         Tuple(elems) => boogie_tuple_type(ty, elems, |t| boogie_type(env, t, bv_flag)),
-        TypeDomain(..) | ResourceDomain(..) | Error | Var(..) => {
+        TypeDomain(..) | ResourceDomain(..) | StateDomain | Error | Var(..) => {
             format!("<<unsupported: {:?}>>", ty)
         },
     }
@@ -571,7 +571,7 @@ pub fn boogie_type_suffix(env: &GlobalEnv, ty: &Type, bv_flag: bool) -> String {
                 format!("$tup{}'{}'", n, suffixes)
             }
         },
-        TypeDomain(..) | ResourceDomain(..) | Error | Var(..) => {
+        TypeDomain(..) | ResourceDomain(..) | StateDomain | Error | Var(..) => {
             format!("<<unsupported {:?}>>", ty)
         },
     }
@@ -1033,7 +1033,8 @@ fn type_name_to_ident_tokens(
         | Type::Primitive(PrimitiveType::EventStore)
         | Type::Fun(..)
         | Type::TypeDomain(..)
-        | Type::ResourceDomain(..) => {
+        | Type::ResourceDomain(..)
+        | Type::StateDomain => {
             unreachable!("Unexpected spec-only type in type_name call");
         },
         // temporary types
@@ -1131,7 +1132,8 @@ fn type_name_to_info_pack(env: &GlobalEnv, ty: &Type) -> Option<TypeInfoPack> {
         | Type::Primitive(PrimitiveType::EventStore)
         | Type::Fun(..)
         | Type::TypeDomain(..)
-        | Type::ResourceDomain(..) => {
+        | Type::ResourceDomain(..)
+        | Type::StateDomain => {
             unreachable!("Unexpected spec-only type in type_name call");
         },
         // temporary types

--- a/third_party/move/move-prover/boogie-backend/src/boogie_wrapper.rs
+++ b/third_party/move/move-prover/boogie-backend/src/boogie_wrapper.rs
@@ -1471,6 +1471,7 @@ impl ModelValue {
             | Type::Primitive(_)
             | Type::TypeDomain(_)
             | Type::ResourceDomain(_, _, _)
+            | Type::StateDomain
             | Type::Error
             | Type::Var(_) => None,
         }

--- a/third_party/move/move-prover/boogie-backend/src/bytecode_translator.rs
+++ b/third_party/move/move-prover/boogie-backend/src/bytecode_translator.rs
@@ -3603,19 +3603,17 @@ impl<'env> BoogieTranslator<'env> {
 
     /// Recursively collect the input arguments of every `Behavior(kind, _)` call
     /// in the expression (excluding the function expression at index 0). Each
-    /// occurrence is recorded independently.
+    /// occurrence is recorded independently. Traverses all subexpressions
+    /// (calls, quantifiers, blocks, conditionals, lambdas, etc.).
     fn collect_behavior_calls(exp: &Exp, kind: BehaviorKind, out: &mut Vec<Vec<Exp>>) {
-        match exp.as_ref() {
-            ExpData::Call(_, AstOperation::Behavior(k, _), args) if *k == kind => {
-                out.push(args[1..].to_vec());
-            },
-            ExpData::Call(_, _, args) => {
-                for a in args {
-                    Self::collect_behavior_calls(a, kind, out);
+        exp.visit_pre_order(&mut |e| {
+            if let ExpData::Call(_, AstOperation::Behavior(k, _), args) = e {
+                if *k == kind {
+                    out.push(args[1..].to_vec());
                 }
-            },
-            _ => {},
-        }
+            }
+            true
+        });
     }
 
     /// Translate a data invariant body expression to Boogie, mapping quantified

--- a/third_party/move/move-prover/boogie-backend/src/bytecode_translator.rs
+++ b/third_party/move/move-prover/boogie-backend/src/bytecode_translator.rs
@@ -37,7 +37,7 @@ use move_core_types::{ability::AbilitySet, function::ClosureMask};
 use move_model::{
     ast::{
         Attribute, BehaviorKind, ConditionKind, Exp, ExpData, FrameAccessKind, FunParamAccessOf,
-        MemoryLabel, Operation as AstOperation, Pattern, TempIndex, TraceKind, Value,
+        MemoryLabel, Operation as AstOperation, Pattern, QuantKind, TempIndex, TraceKind, Value,
     },
     code_writer::CodeWriter,
     emit, emitln,
@@ -122,6 +122,119 @@ pub struct StructTranslator<'env> {
     parent: &'env BoogieTranslator<'env>,
     struct_env: &'env StructEnv<'env>,
     type_inst: &'env [Type],
+}
+
+/// Context for computing Boogie function names when translating a data-invariant
+/// body. Struct-field and function-parameter axiom variants use different name
+/// helpers; this enum selects the correct one based on the BP kind being emitted,
+/// so a body containing mixed kinds (e.g. `!aborts_of<f>(..) ==> result_of<f>(..) <= y`)
+/// translates to the right bool-returning / int-returning Boogie functions for
+/// each call.
+enum BpAxiomCtx<'a> {
+    StructField {
+        struct_id: &'a QualifiedInstId<StructId>,
+        field_sym: Symbol,
+    },
+    FunParam {
+        fun: &'a QualifiedInstId<FunId>,
+        param_sym: Symbol,
+    },
+}
+
+impl BpAxiomCtx<'_> {
+    fn bp_fun_name(&self, env: &GlobalEnv, kind: BehaviorKind) -> String {
+        match self {
+            BpAxiomCtx::StructField {
+                struct_id,
+                field_sym,
+            } => {
+                if kind == BehaviorKind::ResultOf {
+                    boogie_struct_field_result_fun_name(env, struct_id, *field_sym, &[], false)
+                } else {
+                    boogie_struct_field_spec_fun_name(env, struct_id, *field_sym, kind, &[])
+                }
+            },
+            BpAxiomCtx::FunParam { fun, param_sym } => {
+                if kind == BehaviorKind::ResultOf {
+                    boogie_behavioral_result_fun_name(env, fun, *param_sym, &[], false)
+                } else {
+                    boogie_behavioral_spec_fun_name(env, fun, *param_sym, kind, &[])
+                }
+            },
+        }
+    }
+}
+
+/// One memory type's axiom-side argument slot. `old` is `Some(_)` iff the
+/// memory is modified (the BP function signature then takes the pair
+/// `old_X, X`); `None` means the memory is read-only (single `X`).
+struct MemArgSlot {
+    old: Option<String>,
+    cur: String,
+}
+
+/// Structured memory-arg prefix for BP axiom bodies. Rendered per-BP-kind at
+/// each call site, so `aborts_of`/`requires_of` emit `(old, old)` (they do
+/// not depend on post-state) while `ensures_of`/`result_of` emit `(old, cur)`.
+/// This mirrors `SpecTranslator::emit_evaluator_memory_args` /
+/// `emit_fun_spec_memory_args` on the procedure side — the lifted axiom must
+/// match the ground terms the procedure produces.
+struct BpMemArgs {
+    slots: Vec<MemArgSlot>,
+    /// Struct-field variants use `"n"`; fun-param variants use `None`.
+    instance_id: Option<String>,
+}
+
+impl BpMemArgs {
+    fn empty() -> Self {
+        Self {
+            slots: vec![],
+            instance_id: None,
+        }
+    }
+
+    /// Render the Boogie-arg prefix for a BP call of the given kind.
+    fn render(&self, kind: BehaviorKind) -> String {
+        let mut parts: Vec<String> = Vec::with_capacity(self.slots.len() * 2 + 1);
+        for slot in &self.slots {
+            if let Some(old) = &slot.old {
+                parts.push(old.clone());
+                if kind.is_two_state() {
+                    parts.push(slot.cur.clone());
+                } else {
+                    parts.push(old.clone());
+                }
+            } else {
+                parts.push(slot.cur.clone());
+            }
+        }
+        if let Some(n) = &self.instance_id {
+            parts.push(n.clone());
+        }
+        parts.join(", ")
+    }
+
+    /// Render the Boogie-arg prefix in declaration-shape (always both old and cur
+    /// positions when the slot has an `old`), so that every axiom-bound memory
+    /// variable appears in a pattern. The body may still use kind-aware
+    /// rendering via `render`; the trigger only needs to cover variable
+    /// occurrence — it unifies with any ground term of the same shape,
+    /// including calls where the procedure supplies `(old, old)`.
+    fn render_for_trigger(&self) -> String {
+        let mut parts: Vec<String> = Vec::with_capacity(self.slots.len() * 2 + 1);
+        for slot in &self.slots {
+            if let Some(old) = &slot.old {
+                parts.push(old.clone());
+                parts.push(slot.cur.clone());
+            } else {
+                parts.push(slot.cur.clone());
+            }
+        }
+        if let Some(n) = &self.instance_id {
+            parts.push(n.clone());
+        }
+        parts.join(", ")
+    }
 }
 
 impl<'env> BoogieTranslator<'env> {
@@ -672,7 +785,11 @@ impl<'env> BoogieTranslator<'env> {
         self.generate_behavioral_spec_funs_for_params(fun_type, fun_param_infos);
 
         // Generate uninterpreted spec functions for behavioral predicates on struct field variants.
-        self.generate_behavioral_spec_funs_for_struct_fields(fun_type, struct_field_infos);
+        self.generate_behavioral_spec_funs_for_struct_fields(
+            fun_type,
+            struct_field_infos,
+            fun_param_infos,
+        );
 
         // Generate per-function behavioral spec functions for closure target functions.
         // These inline functions have concrete bodies derived from the function's spec.
@@ -1552,9 +1669,27 @@ impl<'env> BoogieTranslator<'env> {
         emitln!(self.writer, "}");
     }
 
-    /// Generate a behavioral predicate evaluator function for a function type.
-    /// This function dispatches on closure/param variants. Closure branches call
-    /// per-function spec functions. Param branches call per-param spec functions.
+    /// Generate a behavioral predicate evaluator for a function type.
+    ///
+    /// The evaluator is declared as an *uninterpreted* Boogie function and
+    /// constrained by one guarded axiom per closure / param / struct-field
+    /// variant. Each axiom has the shape
+    ///
+    /// ```text
+    /// axiom (forall <all-params> :: {<eval>(<args>)}
+    ///     (f is <variant>) ==> (<eval>(<args>) <==> <per-variant-spec>(<args>)));
+    /// ```
+    ///
+    /// This encoding keeps the per-variant spec terms (`$bp_*`, `$sf_*`)
+    /// out of the VC's term database at call sites whose `f` is known to
+    /// be a different variant: when e-matching instantiates the axiom, the
+    /// guard `(f is V)` simplifies to false via Boogie's datatype theory,
+    /// the implication is trivially true, and the right-hand side terms
+    /// are never introduced. The earlier inline-function encoding exposed
+    /// every variant's `$bp_*` term at every call site and forced Z3 to
+    /// trigger unrelated nonlinear axioms, causing runaway quantifier
+    /// instantiation in functions that invoke the closure through a
+    /// struct field or function parameter.
     fn generate_behavioral_predicate_evaluator(
         &self,
         fun_type: &Type,
@@ -1575,31 +1710,28 @@ impl<'env> BoogieTranslator<'env> {
         let behavioral_outputs = Self::behavioral_output_types(&params, &results);
 
         // Compute union of all variants' memory for the evaluator signature.
-        // This includes both closure and param variants so the evaluator's inline
-        // body can pass memory to per-function spec functions in closure branches.
+        // The evaluator's parameters cover every variant's memory needs so
+        // that any per-variant axiom body can reference the memories it cares
+        // about as a subset of the quantifier's bindings.
         let (union_used_memory, union_old_memory) =
             Self::collect_union_memory(env, closure_infos, fun_param_infos, struct_field_infos);
-        let (eval_mem_decls, _eval_mem_args) =
+        let (eval_mem_decls, eval_mem_args) =
             Self::build_memory_params(env, &union_used_memory, &union_old_memory);
 
-        // Build parameter declarations
-        let mut param_decls: Vec<String> = eval_mem_decls;
+        // Build the evaluator's data portion (input params and, for
+        // ensures_of, result values) separately from memory and `f`. The
+        // general guarded axiom for the struct-field variant uses the
+        // full parameter list, while the specialized closure and
+        // fun_param axioms substitute a concrete constructor term for
+        // `f` and therefore need the memory and data portions independently.
+        let (data_decls, data_args) = Self::data_param_decls_and_args(env, &params, kind, &results);
+        let mut param_decls: Vec<String> = eval_mem_decls.to_vec();
+        let mut arg_names: Vec<String> = eval_mem_args.to_vec();
         param_decls.push(format!("f: {}", fun_ty_boogie_name));
-        let mut param_args = vec![];
-        for (pos, ty) in params.iter().enumerate() {
-            param_decls.push(format!(
-                "p{}: {}",
-                pos,
-                boogie_type(env, ty.skip_reference(), false)
-            ));
-            param_args.push(format!("p{}", pos));
-        }
-        if kind == BehaviorKind::EnsuresOf {
-            for (pos, ty) in behavioral_outputs.iter().enumerate() {
-                param_decls.push(format!("r{}: {}", pos, boogie_type(env, ty, false)));
-                param_args.push(format!("r{}", pos));
-            }
-        }
+        arg_names.push("f".to_string());
+        param_decls.extend(data_decls.iter().cloned());
+        arg_names.extend(data_args.iter().cloned());
+        let _ = behavioral_outputs;
 
         emitln!(
             self.writer,
@@ -1607,151 +1739,309 @@ impl<'env> BoogieTranslator<'env> {
             kind,
             fun_type.display(&env.get_type_display_ctx())
         );
-        emit!(
+        emitln!(
             self.writer,
-            "function {{:inline}} {}({}): bool {{",
+            "function {}({}): bool;",
             eval_fun_name,
             param_decls.join(", ")
         );
-        self.writer.indent();
-        emitln!(self.writer);
 
-        let total_variants = closure_infos.len() + fun_param_infos.len() + struct_field_infos.len();
-        let mut variant_idx = 0;
-
-        // Closure branches: delegate to per-function spec functions
+        // Emit per-variant axioms. Closures and function-parameter variants
+        // use specialized triggers keyed on the constructor term, so Z3 only
+        // fires them when the argument is syntactically that variant — which
+        // is the case at ground call sites like `create_pool(..., f)`. The
+        // struct-field variant uses a guarded axiom with a trigger on the
+        // evaluator itself: field-stored closure values usually appear as
+        // symbolic datatype values (e.g. `pool.pricing`) without a
+        // surrounding constructor, so the guarded form is the only shape
+        // that matches in that case. Pool's `IsValid` pins such values to
+        // the field variant, making the other variants' guards simplify to
+        // false without materializing their right-hand sides.
         for info in closure_infos {
-            let ctor_name = boogie_closure_pack_name(env, &info.fun, info.mask);
-            let is_last = variant_idx == total_variants - 1;
-            if variant_idx == 0 && total_variants == 1 {
-                // Single variant: emit directly
-            } else if variant_idx == 0 {
-                emit!(self.writer, "if (f is {}) then ", ctor_name);
-            } else if is_last {
-                emit!(self.writer, "else /* {} */ ", ctor_name);
-            } else {
-                emit!(self.writer, "else if (f is {}) then ", ctor_name);
-            }
-
-            // Build call to per-function spec function with proper args
-            let bp_name = boogie_behavioral_fun_spec_name(env, &info.fun, kind);
-            let fun_env = env.get_function(info.fun.to_qualified_id());
-            let callee_param_tys = fun_env.get_parameter_types();
-            let num_callee_params = callee_param_tys.len();
-
-            // Build memory args for this function's spec memory (subset of evaluator's union)
-            let fun_mem_args = Self::build_instantiated_memory_args(env, &fun_env, &info.fun.inst);
-
-            // Build args: memory + all callee params (interleaved captured/non-captured)
-            let mut call_args: Vec<String> = fun_mem_args;
-            let mut captured_pos = 0;
-            let mut non_captured_pos = 0;
-            for i in 0..num_callee_params {
-                if info.mask.is_captured(i) {
-                    call_args.push(format!("f->p{}", captured_pos));
-                    captured_pos += 1;
-                } else {
-                    call_args.push(format!("p{}", non_captured_pos));
-                    non_captured_pos += 1;
-                }
-            }
-            // For ensures_of: add result args
-            if kind == BehaviorKind::EnsuresOf {
-                call_args.extend(Self::behavioral_output_args(&params, &results));
-            }
-            emitln!(self.writer, "{}({})", bp_name, call_args.join(", "));
-            variant_idx += 1;
+            self.emit_closure_variant_axiom(
+                &eval_fun_name,
+                &eval_mem_decls,
+                &eval_mem_args,
+                &data_decls,
+                &data_args,
+                info,
+                &params,
+                &results,
+                kind,
+            );
         }
-
-        // Param branches: delegate to per-param uninterpreted functions
         for info in fun_param_infos {
-            let ctor_name = boogie_fun_param_name(env, &info.fun, info.param_sym);
-            let is_last = variant_idx == total_variants - 1;
-            if variant_idx == 0 && total_variants == 1 {
-                // Single variant: emit directly
-            } else if variant_idx == 0 {
-                emit!(self.writer, "if (f is {}) then ", ctor_name);
-            } else if is_last {
-                emit!(self.writer, "else /* {} */ ", ctor_name);
-            } else {
-                emit!(self.writer, "else if (f is {}) then ", ctor_name);
-            }
-
-            let bp_name =
-                boogie_behavioral_spec_fun_name(env, &info.fun, info.param_sym, kind, &[]);
-            let per_param_mem_args: Vec<String> = {
-                let (used, old) = Self::get_param_memory(env, &info.fun, info.param_sym);
-                let (_, args) = Self::build_memory_params(env, &used, &old);
-                args
-            };
-            let args = if kind == BehaviorKind::EnsuresOf {
-                let mut args: Vec<String> = per_param_mem_args;
-                for pos in 0..params.len() {
-                    args.push(format!("p{}", pos));
-                }
-                args.extend(Self::behavioral_output_args(&params, &results));
-                args.join(", ")
-            } else {
-                let mut args = per_param_mem_args;
-                args.extend(param_args.iter().cloned());
-                args.join(", ")
-            };
-            emitln!(self.writer, "{}({})", bp_name, args);
-            variant_idx += 1;
+            self.emit_fun_param_variant_axiom(
+                &eval_fun_name,
+                &eval_mem_decls,
+                &eval_mem_args,
+                &data_decls,
+                &data_args,
+                info,
+                &params,
+                &results,
+                kind,
+            );
         }
-
-        // Struct field branches: delegate to per-struct-field uninterpreted functions.
-        // These have `n: int` (instance id) prepended to args.
         for info in struct_field_infos {
-            let ctor_name = boogie_struct_field_name(env, &info.struct_id, info.field_sym);
-            let is_last = variant_idx == total_variants - 1;
-            if variant_idx == 0 && total_variants == 1 {
-                // Single variant: emit directly
-            } else if variant_idx == 0 {
-                emit!(self.writer, "if (f is {}) then ", ctor_name);
-            } else if is_last {
-                emit!(self.writer, "else /* {} */ ", ctor_name);
-            } else {
-                emit!(self.writer, "else if (f is {}) then ", ctor_name);
-            }
-
-            let bp_name =
-                boogie_struct_field_spec_fun_name(env, &info.struct_id, info.field_sym, kind, &[]);
-            // Build memory args for this struct field (if it has access declarations)
-            let struct_env_for_field = env.get_struct_qid(info.struct_id.to_qualified_id());
-            let field_access = struct_env_for_field.get_field_access_of();
-            let access_decl = field_access.iter().find(|a| a.fun_param == info.field_sym);
-            let mem_args: Vec<String> = if let Some(decl) = access_decl {
-                Self::build_evaluator_memory_args_for_access(
-                    env,
-                    decl,
-                    &union_used_memory,
-                    &union_old_memory,
-                )
-            } else {
-                vec![]
-            };
-            // Args: memory..., n (instance id from datatype field), then data args
-            let args = if kind == BehaviorKind::EnsuresOf {
-                let mut args = mem_args;
-                args.push("f->n".to_string());
-                for pos in 0..params.len() {
-                    args.push(format!("p{}", pos));
-                }
-                args.extend(Self::behavioral_output_args(&params, &results));
-                args.join(", ")
-            } else {
-                let mut args = mem_args;
-                args.push("f->n".to_string());
-                args.extend(param_args.iter().cloned());
-                args.join(", ")
-            };
-            emitln!(self.writer, "{}({})", bp_name, args);
-            variant_idx += 1;
+            self.emit_struct_field_variant_axiom(
+                &eval_fun_name,
+                &param_decls,
+                &arg_names,
+                info,
+                &params,
+                &results,
+                &union_used_memory,
+                &union_old_memory,
+                kind,
+            );
         }
+    }
 
-        self.writer.unindent();
-        emitln!(self.writer, "}");
+    /// Build parameter declarations and names for the "data" portion of the
+    /// evaluator's signature: input parameters `p0..pn` and, for ensures_of,
+    /// result values `r0..rm`. Memory and the function value `f` are handled
+    /// separately because they vary between the general and specialized
+    /// axiom forms.
+    fn data_param_decls_and_args(
+        env: &GlobalEnv,
+        params: &[Type],
+        kind: BehaviorKind,
+        results: &[Type],
+    ) -> (Vec<String>, Vec<String>) {
+        let behavioral_outputs = Self::behavioral_output_types(params, results);
+        let mut decls = Vec::with_capacity(params.len() + behavioral_outputs.len());
+        let mut args = Vec::with_capacity(params.len() + behavioral_outputs.len());
+        for (pos, ty) in params.iter().enumerate() {
+            decls.push(format!(
+                "p{}: {}",
+                pos,
+                boogie_type(env, ty.skip_reference(), false)
+            ));
+            args.push(format!("p{}", pos));
+        }
+        if kind == BehaviorKind::EnsuresOf {
+            for (pos, ty) in behavioral_outputs.iter().enumerate() {
+                decls.push(format!("r{}: {}", pos, boogie_type(env, ty, false)));
+                args.push(format!("r{}", pos));
+            }
+        }
+        (decls, args)
+    }
+
+    /// Emit a specialized evaluator axiom for a closure variant. The
+    /// constructor application (with captured values as free quantifier
+    /// vars) is baked into the trigger so no runtime guard is needed —
+    /// the axiom only fires when Z3 already sees the constructor term.
+    #[allow(clippy::too_many_arguments)]
+    fn emit_closure_variant_axiom(
+        &self,
+        eval_fun_name: &str,
+        mem_decls: &[String],
+        mem_args: &[String],
+        data_decls: &[String],
+        data_args: &[String],
+        info: &ClosureInfo,
+        params: &[Type],
+        results: &[Type],
+        kind: BehaviorKind,
+    ) {
+        let env = self.env;
+        let fun_env = env.get_function(info.fun.to_qualified_id());
+        let callee_param_tys: Vec<Type> = fun_env
+            .get_parameter_types()
+            .into_iter()
+            .map(|ty| ty.instantiate(&info.fun.inst))
+            .collect();
+        let ctor_name = boogie_closure_pack_name(env, &info.fun, info.mask);
+
+        // Captures become quantifier-bound variables `c0..cK`. The
+        // constructor term in the trigger takes them as arguments.
+        let mut capture_decls = Vec::new();
+        let mut capture_args = Vec::new();
+        let mut captured_pos = 0usize;
+        for (i, ty) in callee_param_tys.iter().enumerate() {
+            if info.mask.is_captured(i) {
+                let name = format!("c{}", captured_pos);
+                capture_decls.push(format!(
+                    "{}: {}",
+                    name,
+                    boogie_type(env, ty.skip_reference(), false)
+                ));
+                capture_args.push(name);
+                captured_pos += 1;
+            }
+        }
+        let ctor_term = if capture_args.is_empty() {
+            format!("{}()", ctor_name)
+        } else {
+            format!("{}({})", ctor_name, capture_args.join(", "))
+        };
+
+        // Quantifier bindings: memory, captures, data.
+        let quantifier: Vec<String> = mem_decls
+            .iter()
+            .chain(capture_decls.iter())
+            .chain(data_decls.iter())
+            .cloned()
+            .collect();
+
+        // Build the RHS call to the per-function spec function. Captured
+        // params are taken directly from the bound `cK` variables, not
+        // from `f->pK`, because the trigger commits `f = ctor(c0..cK)`.
+        let bp_name = boogie_behavioral_fun_spec_name(env, &info.fun, kind);
+        let mut rhs_args: Vec<String> =
+            Self::build_instantiated_memory_args(env, &fun_env, &info.fun.inst);
+        let mut captured_pos = 0usize;
+        let mut non_captured_pos = 0usize;
+        for i in 0..callee_param_tys.len() {
+            if info.mask.is_captured(i) {
+                rhs_args.push(format!("c{}", captured_pos));
+                captured_pos += 1;
+            } else {
+                rhs_args.push(format!("p{}", non_captured_pos));
+                non_captured_pos += 1;
+            }
+        }
+        if kind == BehaviorKind::EnsuresOf {
+            rhs_args.extend(Self::behavioral_output_args(params, results));
+        }
+        let rhs = format!("{}({})", bp_name, rhs_args.join(", "));
+
+        // Build the evaluator application used in trigger and body, with
+        // the concrete constructor term substituted for `f`.
+        let eval_call_args: Vec<String> = mem_args
+            .iter()
+            .cloned()
+            .chain(std::iter::once(ctor_term.clone()))
+            .chain(data_args.iter().cloned())
+            .collect();
+        let eval_call = format!("{}({})", eval_fun_name, eval_call_args.join(", "));
+
+        emitln!(
+            self.writer,
+            "axiom (forall {} :: {{{}}} {} <==> {});",
+            quantifier.join(", "),
+            eval_call,
+            eval_call,
+            rhs
+        );
+    }
+
+    /// Emit a specialized evaluator axiom for a function-parameter variant.
+    /// Function-parameter constructors are nullary, so the trigger is the
+    /// evaluator applied to the constructor without any quantifier-bound
+    /// capture vars.
+    #[allow(clippy::too_many_arguments)]
+    fn emit_fun_param_variant_axiom(
+        &self,
+        eval_fun_name: &str,
+        mem_decls: &[String],
+        mem_args: &[String],
+        data_decls: &[String],
+        data_args: &[String],
+        info: &FunParamInfo,
+        params: &[Type],
+        results: &[Type],
+        kind: BehaviorKind,
+    ) {
+        let env = self.env;
+        let ctor_name = boogie_fun_param_name(env, &info.fun, info.param_sym);
+        let ctor_term = format!("{}()", ctor_name);
+
+        let quantifier: Vec<String> = mem_decls.iter().chain(data_decls.iter()).cloned().collect();
+
+        let bp_name = boogie_behavioral_spec_fun_name(env, &info.fun, info.param_sym, kind, &[]);
+        let (used, old) = Self::get_param_memory(env, &info.fun, info.param_sym);
+        let (_, param_mem_args) = Self::build_memory_params(env, &used, &old);
+        let mut rhs_args: Vec<String> = param_mem_args;
+        for pos in 0..params.len() {
+            rhs_args.push(format!("p{}", pos));
+        }
+        if kind == BehaviorKind::EnsuresOf {
+            rhs_args.extend(Self::behavioral_output_args(params, results));
+        }
+        let rhs = format!("{}({})", bp_name, rhs_args.join(", "));
+
+        let eval_call_args: Vec<String> = mem_args
+            .iter()
+            .cloned()
+            .chain(std::iter::once(ctor_term.clone()))
+            .chain(data_args.iter().cloned())
+            .collect();
+        let eval_call = format!("{}({})", eval_fun_name, eval_call_args.join(", "));
+
+        emitln!(
+            self.writer,
+            "axiom (forall {} :: {{{}}} {} <==> {});",
+            quantifier.join(", "),
+            eval_call,
+            eval_call,
+            rhs
+        );
+    }
+
+    /// Emit a guarded evaluator axiom for a struct-field variant. Struct
+    /// field values in caller VCs are usually opaque datatype values
+    /// (e.g. `pool.pricing` read from a resource), not constructor
+    /// applications, so a constructor-keyed trigger would not match. The
+    /// guarded form with a trigger on the evaluator itself fires uniformly,
+    /// and the guard pins the right-hand side to the field-specific spec
+    /// function only when the datatype theory confirms the variant.
+    #[allow(clippy::too_many_arguments)]
+    fn emit_struct_field_variant_axiom(
+        &self,
+        eval_fun_name: &str,
+        param_decls: &[String],
+        arg_names: &[String],
+        info: &StructFieldInfo,
+        params: &[Type],
+        results: &[Type],
+        union_used_memory: &BTreeSet<QualifiedInstId<StructId>>,
+        union_old_memory: &BTreeSet<QualifiedInstId<StructId>>,
+        kind: BehaviorKind,
+    ) {
+        let env = self.env;
+        let ctor_name = boogie_struct_field_name(env, &info.struct_id, info.field_sym);
+        let bp_name =
+            boogie_struct_field_spec_fun_name(env, &info.struct_id, info.field_sym, kind, &[]);
+        let struct_env_for_field = env.get_struct_qid(info.struct_id.to_qualified_id());
+        let field_access = struct_env_for_field.get_field_access_of();
+        let access_decl = field_access.iter().find(|a| a.fun_param == info.field_sym);
+        let mem_args: Vec<String> = if let Some(decl) = access_decl {
+            Self::build_evaluator_memory_args_for_access(
+                env,
+                decl,
+                union_used_memory,
+                union_old_memory,
+            )
+        } else {
+            vec![]
+        };
+        let mut rhs_args = mem_args;
+        rhs_args.push("f->n".to_string());
+        for pos in 0..params.len() {
+            rhs_args.push(format!("p{}", pos));
+        }
+        if kind == BehaviorKind::EnsuresOf {
+            rhs_args.extend(Self::behavioral_output_args(params, results));
+        }
+        let rhs = format!("{}({})", bp_name, rhs_args.join(", "));
+
+        let eval_call = format!("{}({})", eval_fun_name, arg_names.join(", "));
+        emitln!(
+            self.writer,
+            "axiom (forall {} :: {{{}}}",
+            param_decls.join(", "),
+            eval_call
+        );
+        emitln!(
+            self.writer,
+            "    (f is {}) ==> ({} <==> {}));",
+            ctor_name,
+            eval_call,
+            rhs
+        );
     }
 
     /// Generate the uninterpreted `result_of` function and its connecting axiom.
@@ -2944,6 +3234,7 @@ impl<'env> BoogieTranslator<'env> {
         &self,
         fun_type: &Type,
         struct_field_infos: &BTreeSet<StructFieldInfo>,
+        fun_param_infos: &BTreeSet<FunParamInfo>,
     ) {
         let Type::Fun(params, results, _) = fun_type else {
             return;
@@ -2958,9 +3249,12 @@ impl<'env> BoogieTranslator<'env> {
             let access_decl = field_access.iter().find(|a| a.fun_param == info.field_sym);
             let has_memory = access_decl.is_some();
 
-            // Build memory parameter declarations if the field has access declarations
+            // Build memory parameter declarations if the field has access declarations.
+            // `slots` captures the (old, cur) structure per memory type so that the
+            // body translator can render kind-appropriate memory args per BP call.
             let mut mem_param_decls = vec![];
             let mut mem_args = vec![];
+            let mut slots: Vec<MemArgSlot> = vec![];
             if let Some(decl) = access_decl {
                 if decl.frame_spec.modifies_all || decl.frame_spec.reads_all {
                     // Wildcard: include all translated memory types
@@ -2970,13 +3264,20 @@ impl<'env> BoogieTranslator<'env> {
                         let se = self.env.get_struct_qid(qid.to_qualified_id());
                         let mem_type =
                             format!("$Memory {}", boogie_struct_name(&se, &qid.inst, false));
-                        if decl.frame_spec.modifies_all {
+                        let old_opt = if decl.frame_spec.modifies_all {
                             let old_name = format!("old_{}", mem_name);
                             mem_param_decls.push(format!("{}: {}", old_name, mem_type));
-                            mem_args.push(old_name);
-                        }
+                            mem_args.push(old_name.clone());
+                            Some(old_name)
+                        } else {
+                            None
+                        };
                         mem_param_decls.push(format!("{}: {}", mem_name, mem_type));
-                        mem_args.push(mem_name);
+                        mem_args.push(mem_name.clone());
+                        slots.push(MemArgSlot {
+                            old: old_opt,
+                            cur: mem_name,
+                        });
                     }
                 } else {
                     // Specific access declarations
@@ -2987,13 +3288,20 @@ impl<'env> BoogieTranslator<'env> {
                             "$Memory {}",
                             boogie_struct_name(&struct_env, &mem.inst, false)
                         );
-                        if decl.old_memory.contains(mem) {
+                        let old_opt = if decl.old_memory.contains(mem) {
                             let old_name = format!("old_{}", mem_name);
                             mem_param_decls.push(format!("{}: {}", old_name, mem_type));
-                            mem_args.push(old_name);
-                        }
+                            mem_args.push(old_name.clone());
+                            Some(old_name)
+                        } else {
+                            None
+                        };
                         mem_param_decls.push(format!("{}: {}", mem_name, mem_type));
-                        mem_args.push(mem_name);
+                        mem_args.push(mem_name.clone());
+                        slots.push(MemArgSlot {
+                            old: old_opt,
+                            cur: mem_name,
+                        });
                     }
                 }
             }
@@ -3012,6 +3320,17 @@ impl<'env> BoogieTranslator<'env> {
                 input_args.push(format!("arg{}", i));
             }
             let _ = has_memory;
+
+            let input_args_str = input_args.join(", ");
+            let precond = Self::validity_precondition(self.env, &params, "arg");
+            // Structured memory-arg carrier for the axiom body translator.
+            // `render(kind)` dispatches to `(old, old)` for aborts/requires and
+            // `(old, cur)` for ensures/result, matching the procedure-side
+            // emission (see spec_translator.rs:1712,1828).
+            let sf_mem_args = BpMemArgs {
+                slots,
+                instance_id: Some("n".to_string()),
+            };
 
             // For requires_of and aborts_of: generate uninterpreted predicates
             for kind in [BehaviorKind::RequiresOf, BehaviorKind::AbortsOf] {
@@ -3036,9 +3355,6 @@ impl<'env> BoogieTranslator<'env> {
                 .into_iter()
                 .map(|ty| boogie_type(self.env, &ty, false))
                 .collect();
-
-            let input_args_str = input_args.join(", ");
-            let precond = Self::validity_precondition(self.env, &params, "arg");
 
             let ensures_fun_name = boogie_struct_field_spec_fun_name(
                 self.env,
@@ -3075,6 +3391,62 @@ impl<'env> BoogieTranslator<'env> {
                     all_result_type_refs[0],
                     &precond,
                 );
+                // Emit data invariant axioms for all behavioral predicate kinds.
+                // The extractor builds a multi-pattern trigger from the
+                // invariant's own BP-call occurrences, so no single trigger
+                // application is passed in.
+                {
+                    let data_param_decls: Vec<String> = params
+                        .iter()
+                        .enumerate()
+                        .map(|(i, ty)| {
+                            format!(
+                                "arg{}: {}",
+                                i,
+                                boogie_type(self.env, ty.skip_reference(), false)
+                            )
+                        })
+                        .collect();
+                    let sf_ctx = BpAxiomCtx::StructField {
+                        struct_id: &info.struct_id,
+                        field_sym: info.field_sym,
+                    };
+                    let fp_mem_args = BpMemArgs::empty();
+                    for kind in [
+                        BehaviorKind::EnsuresOf,
+                        BehaviorKind::ResultOf,
+                        BehaviorKind::AbortsOf,
+                        BehaviorKind::RequiresOf,
+                    ] {
+                        self.emit_data_invariant_axiom_for_behavior(
+                            info,
+                            kind,
+                            &input_param_decls,
+                            &sf_ctx,
+                            &sf_mem_args,
+                            &params,
+                            &precond,
+                        );
+                        // Also emit for function parameter variants (the
+                        // evaluator dispatch branches on discriminator tag, so
+                        // both variants must be constrained).
+                        for fp_info in fun_param_infos {
+                            let fp_ctx = BpAxiomCtx::FunParam {
+                                fun: &fp_info.fun,
+                                param_sym: fp_info.param_sym,
+                            };
+                            self.emit_data_invariant_axiom_for_behavior(
+                                info,
+                                kind,
+                                &data_param_decls,
+                                &fp_ctx,
+                                &fp_mem_args,
+                                &params,
+                                &precond,
+                            );
+                        }
+                    }
+                }
                 let body = format!("{}({}) == result0", result_fun_name, input_args_str);
                 emitln!(
                     self.writer,
@@ -3108,6 +3480,7 @@ impl<'env> BoogieTranslator<'env> {
                     &tuple_element_types,
                     &precond,
                 );
+                // TODO: emit_data_invariant_axiom_for_field for multi-result case
                 let equality_checks: Vec<String> = (0..all_result_types.len())
                     .map(|i| format!("r->${} == result{}", i, i))
                     .collect();
@@ -3133,6 +3506,584 @@ impl<'env> BoogieTranslator<'env> {
                 );
             }
         }
+    }
+
+    /// Emit a Boogie axiom lifting a struct data invariant containing behavioral
+    /// predicates (`ensures_of`, `result_of`, `aborts_of`, `requires_of`) over
+    /// the stored function field.
+    ///
+    /// The invariant is translated to an axiom over the witness functions
+    /// (`sf_ensures_of_result`, `sf_aborts_of`, …). Multiple occurrences of the
+    /// target kind — anywhere in the expression, including in different arguments
+    /// of a single operator — share a multi-pattern trigger so Z3 fires the
+    /// axiom only once every occurrence is grounded. Monotonicity-style
+    /// invariants (two `result_of` calls at different arguments) rely on this:
+    /// the axiom holds at any memory-state pair, so it survives modifications
+    /// to the enclosing resource between assumption and re-verification.
+    fn emit_data_invariant_axiom_for_behavior(
+        &self,
+        info: &StructFieldInfo,
+        kind: BehaviorKind,
+        input_param_decls: &[String],
+        ctx: &BpAxiomCtx,
+        mem_args: &BpMemArgs,
+        params: &[Type],
+        precond: &str,
+    ) {
+        let env = self.env;
+        let struct_env = env.get_struct_qid(info.struct_id.to_qualified_id());
+
+        for cond in struct_env
+            .get_spec()
+            .filter_kind(ConditionKind::StructInvariant)
+        {
+            let Some(lifted) =
+                self.extract_bp_invariant_body(&cond.exp, kind, params, ctx, mem_args)
+            else {
+                continue;
+            };
+            let Some(body_str) = self.translate_invariant_body_to_boogie(
+                &lifted.body,
+                &lifted.var_map,
+                ctx,
+                mem_args,
+                Some(&lifted.result_sub),
+            ) else {
+                continue;
+            };
+            let mut decls: Vec<String> = input_param_decls.to_vec();
+            decls.extend(lifted.extra_quant_decls.iter().cloned());
+            let precond_full = if lifted.extra_preconds.is_empty() {
+                precond.to_string()
+            } else {
+                format!("{} && {}", precond, lifted.extra_preconds.join(" && "))
+            };
+            let trigger = format!("{{{}}}", lifted.trigger_apps.join(", "));
+            emitln!(
+                self.writer,
+                "axiom (forall {} :: {} {} ==> {});",
+                decls.join(", "),
+                trigger,
+                precond_full,
+                body_str
+            );
+        }
+    }
+
+    /// Render a spec-language constant as a Boogie literal. Mirrors the
+    /// `ExpData::Value` branch of `translate_invariant_body_to_boogie`.
+    fn render_value_literal(val: &Value) -> Option<String> {
+        match val {
+            Value::Number(n) => Some(n.to_string()),
+            Value::Bool(b) => Some(b.to_string()),
+            Value::Address(a) => Some(format!("{:?}", a)),
+            _ => None,
+        }
+    }
+
+    /// Flatten nested implications `A ==> (B ==> C)` into `(premises = [A, B, ...],
+    /// conclusion = C)`. Each premise is itself flattened by `flatten_and` so that
+    /// top-level `&&` chains are split into individual conjuncts. Invariants
+    /// without any outer implication produce an empty premise list with the whole
+    /// body as conclusion.
+    fn flatten_implies(exp: &Exp) -> (Vec<Exp>, Exp) {
+        let mut premises: Vec<Exp> = Vec::new();
+        let mut current = exp.clone();
+        loop {
+            match current.as_ref() {
+                ExpData::Call(_, AstOperation::Implies, args) if args.len() == 2 => {
+                    premises.extend(Self::flatten_and(&args[0]));
+                    current = args[1].clone();
+                },
+                _ => break,
+            }
+        }
+        (premises, current)
+    }
+
+    /// Recursively collect the input arguments of every `Behavior(kind, _)` call
+    /// in the expression (excluding the function expression at index 0). Each
+    /// occurrence is recorded independently.
+    fn collect_behavior_calls(exp: &Exp, kind: BehaviorKind, out: &mut Vec<Vec<Exp>>) {
+        match exp.as_ref() {
+            ExpData::Call(_, AstOperation::Behavior(k, _), args) if *k == kind => {
+                out.push(args[1..].to_vec());
+            },
+            ExpData::Call(_, _, args) => {
+                for a in args {
+                    Self::collect_behavior_calls(a, kind, out);
+                }
+            },
+            _ => {},
+        }
+    }
+
+    /// Translate a data invariant body expression to Boogie, mapping quantified
+    /// variables to their axiom parameter names.
+    ///
+    /// * `var_map` maps quantifier-bound user variables to their `arg{i}` names.
+    /// * `ctx` identifies the axiom variant (struct-field vs function-parameter)
+    ///   and is used to compute the correct Boogie function name for every BP
+    ///   call encountered in the body, per its own `BehaviorKind`.
+    /// * `mem_args` is the structured memory prefix, rendered per-BP-kind at
+    ///   each call site (so aborts/requires use `(old, old)`, ensures/result
+    ///   use `(old, cur)`; mirrors `emit_evaluator_memory_args` on the
+    ///   procedure side).
+    /// * `result_sub` maps each absorbed-`ensures_of` result variable to its
+    ///   precomputed result-fun application string — those vars are
+    ///   existentially eliminated from the axiom quantifier and replaced here.
+    fn translate_invariant_body_to_boogie(
+        &self,
+        exp: &Exp,
+        var_map: &BTreeMap<Symbol, String>,
+        ctx: &BpAxiomCtx,
+        mem_args: &BpMemArgs,
+        result_sub: Option<&BTreeMap<Symbol, String>>,
+    ) -> Option<String> {
+        match exp.as_ref() {
+            ExpData::LocalVar(_, sym) => {
+                if let Some(name) = var_map.get(sym) {
+                    Some(name.clone())
+                } else if let Some(sub) = result_sub {
+                    // Absorbed ensures_of result-var substitution — each ensures_of
+                    // occurrence pre-bound its result vars to result-fun
+                    // applications with that occurrence's input args.
+                    sub.get(sym).cloned()
+                } else {
+                    None
+                }
+            },
+            ExpData::Value(_, val) => match val {
+                Value::Number(n) => Some(n.to_string()),
+                Value::Bool(b) => Some(b.to_string()),
+                Value::Address(a) => Some(format!("{:?}", a)),
+                _ => None,
+            },
+            ExpData::Call(_, oper, args) => self
+                .translate_invariant_call_to_boogie(oper, args, var_map, ctx, mem_args, result_sub),
+            _ => None,
+        }
+    }
+
+    /// Translate a Call expression in a data invariant body to Boogie.
+    fn translate_invariant_call_to_boogie(
+        &self,
+        oper: &AstOperation,
+        args: &[Exp],
+        var_map: &BTreeMap<Symbol, String>,
+        ctx: &BpAxiomCtx,
+        mem_args: &BpMemArgs,
+        result_sub: Option<&BTreeMap<Symbol, String>>,
+    ) -> Option<String> {
+        match oper {
+            AstOperation::Behavior(kind, _) => {
+                // Resolve the Boogie function name for this specific BP kind:
+                // a body may mix kinds (e.g. `!aborts_of<f>(..) ==> result_of<f>(..) <= y`)
+                // and each call must map to its own kind-specific function (bool
+                // vs int return, different arities/args).
+                let fun_name = ctx.bp_fun_name(self.env, *kind);
+                // Recursively translate each predicate argument (args[1..],
+                // skipping the function expression at args[0]).
+                let translated_args: Vec<String> = args[1..]
+                    .iter()
+                    .filter_map(|a| {
+                        self.translate_invariant_body_to_boogie(
+                            a, var_map, ctx, mem_args, result_sub,
+                        )
+                    })
+                    .collect();
+                if translated_args.len() != args.len() - 1 {
+                    return None;
+                }
+                let data_args = translated_args.join(", ");
+                // Kind-aware memory args: aborts/requires render as (old, old),
+                // ensures/result as (old, cur). Read-only memories stay as `X`.
+                let mem_rendered = mem_args.render(*kind);
+                if mem_rendered.is_empty() {
+                    Some(format!("{}({})", fun_name, data_args))
+                } else {
+                    Some(format!("{}({}, {})", fun_name, mem_rendered, data_args))
+                }
+            },
+            AstOperation::Select(mid, sid, fid) => {
+                let arg = self.translate_invariant_body_to_boogie(
+                    &args[0], var_map, ctx, mem_args, result_sub,
+                )?;
+                let struct_env = self.env.get_module(*mid).into_struct(*sid);
+                let field_env = struct_env.get_field(*fid);
+                let field_name = boogie_field_sel(&field_env);
+                Some(format!("{}->{}", arg, field_name))
+            },
+            AstOperation::Ge => {
+                self.translate_binop(">=", args, var_map, ctx, mem_args, result_sub)
+            },
+            AstOperation::Le => {
+                self.translate_binop("<=", args, var_map, ctx, mem_args, result_sub)
+            },
+            AstOperation::Gt => self.translate_binop(">", args, var_map, ctx, mem_args, result_sub),
+            AstOperation::Lt => self.translate_binop("<", args, var_map, ctx, mem_args, result_sub),
+            AstOperation::Eq => {
+                self.translate_binop("==", args, var_map, ctx, mem_args, result_sub)
+            },
+            AstOperation::Neq => {
+                self.translate_binop("!=", args, var_map, ctx, mem_args, result_sub)
+            },
+            AstOperation::Add => {
+                self.translate_binop("+", args, var_map, ctx, mem_args, result_sub)
+            },
+            AstOperation::Sub => {
+                self.translate_binop("-", args, var_map, ctx, mem_args, result_sub)
+            },
+            AstOperation::Mul => {
+                self.translate_binop("*", args, var_map, ctx, mem_args, result_sub)
+            },
+            AstOperation::Div => {
+                self.translate_binop("div", args, var_map, ctx, mem_args, result_sub)
+            },
+            AstOperation::Mod => {
+                self.translate_binop("mod", args, var_map, ctx, mem_args, result_sub)
+            },
+            AstOperation::And => {
+                self.translate_binop("&&", args, var_map, ctx, mem_args, result_sub)
+            },
+            AstOperation::Or => {
+                self.translate_binop("||", args, var_map, ctx, mem_args, result_sub)
+            },
+            AstOperation::Implies => {
+                self.translate_binop("==>", args, var_map, ctx, mem_args, result_sub)
+            },
+            AstOperation::Not => {
+                let a = self.translate_invariant_body_to_boogie(
+                    &args[0], var_map, ctx, mem_args, result_sub,
+                )?;
+                Some(format!("(!{})", a))
+            },
+            _ => None,
+        }
+    }
+
+    /// Helper: translate a binary operation in a data invariant body.
+    fn translate_binop(
+        &self,
+        op: &str,
+        args: &[Exp],
+        var_map: &BTreeMap<Symbol, String>,
+        ctx: &BpAxiomCtx,
+        mem_args: &BpMemArgs,
+        result_sub: Option<&BTreeMap<Symbol, String>>,
+    ) -> Option<String> {
+        if args.len() != 2 {
+            return None;
+        }
+        let a =
+            self.translate_invariant_body_to_boogie(&args[0], var_map, ctx, mem_args, result_sub)?;
+        let b =
+            self.translate_invariant_body_to_boogie(&args[1], var_map, ctx, mem_args, result_sub)?;
+        Some(format!("({} {} {})", a, op, b))
+    }
+}
+
+/// Result of lifting a struct data invariant containing behavioral predicates
+/// (`ensures_of`, `result_of`, `aborts_of`, `requires_of`) into a Boogie axiom.
+/// Built by `BoogieTranslator::extract_bp_invariant_body`.
+struct LiftedBpInvariant {
+    /// Quantified input vars that appear in BP input positions — mapped to
+    /// their `arg{i}` names. Extras (that remain in the axiom quantifier) are
+    /// also inserted here under synthesized names.
+    var_map: BTreeMap<Symbol, String>,
+    /// Extra quantifier parameter declarations (for vars that appear in input
+    /// positions but differ across occurrences — these stay bound in the
+    /// emitted axiom's `forall`).
+    extra_quant_decls: Vec<String>,
+    /// `$IsValid` clauses for `extra_quant_decls` — conjoined with `precond`.
+    extra_preconds: Vec<String>,
+    /// Multi-pattern trigger: one witness-function application per occurrence
+    /// of the lifted kind. Multi-call invariants (e.g. monotonicity) need Z3
+    /// to ground every occurrence before firing.
+    trigger_apps: Vec<String>,
+    /// `sym -> rendered_result_fun_app`: each absorbed `ensures_of` result
+    /// variable is substituted by the corresponding result-fun application
+    /// during body translation, eliminating it from the axiom quantifier.
+    result_sub: BTreeMap<Symbol, String>,
+    /// Body to translate: `residual_premise ==> conclusion` (or just the
+    /// conclusion, if there are no residual conjuncts after absorbing
+    /// `ensures_of` from the premise).
+    body: Exp,
+}
+
+impl BoogieTranslator<'_> {
+    /// Flatten `And`-trees into a vector of conjuncts.
+    fn flatten_and(exp: &Exp) -> Vec<Exp> {
+        match exp.as_ref() {
+            ExpData::Call(_, AstOperation::And, args) if args.len() == 2 => {
+                let mut out = Self::flatten_and(&args[0]);
+                out.extend(Self::flatten_and(&args[1]));
+                out
+            },
+            _ => vec![exp.clone()],
+        }
+    }
+
+    /// Build `a && b && ...` as an `Exp` tree (right-associated). Returns
+    /// `None` if `conjuncts` is empty.
+    fn and_of(conjuncts: &[Exp]) -> Option<Exp> {
+        let mut it = conjuncts.iter().rev();
+        let mut acc = it.next()?.clone();
+        for c in it {
+            let id = acc.node_id();
+            acc = ExpData::Call(id, AstOperation::And, vec![c.clone(), acc]).into_exp();
+        }
+        Some(acc)
+    }
+
+    /// Extract a struct data invariant containing behavioral predicates into a
+    /// form that can be emitted as a Boogie axiom. Handles any mix of
+    /// occurrences and kinds:
+    ///
+    /// * Absorbs `ensures_of<self.field>(inputs, r)` conjuncts in the premise —
+    ///   the result variable `r` is substituted by the deterministic witness
+    ///   `sf_ensures_of_result(mem_args, inputs)`, eliminating `r` from the
+    ///   axiom quantifier.
+    /// * Collects every `Behavior(lifted_kind, _)` occurrence anywhere in the
+    ///   expression (residual premise + conclusion). The multi-pattern trigger
+    ///   covers all of them, so Z3 fires the axiom only when every occurrence
+    ///   has been grounded — the mechanism multi-call invariants (e.g.
+    ///   monotonicity: two `result_of` calls at different arguments) need to
+    ///   hold at any memory-state pair, not just the assumption point.
+    ///
+    /// Returns `None` when no occurrences of the lifted kind are found, or when
+    /// the invariant shape is unsupported (non-`forall`, non-`LocalVar` ensures
+    /// result, multi-result `ensures_of`, or non-variable-non-constant input
+    /// position).
+    fn extract_bp_invariant_body(
+        &self,
+        exp: &Exp,
+        lifted_kind: BehaviorKind,
+        params: &[Type],
+        ctx: &BpAxiomCtx,
+        mem_args: &BpMemArgs,
+    ) -> Option<LiftedBpInvariant> {
+        let env = self.env;
+
+        // Strip the outer Forall.
+        let (ranges, body_exp) = match exp.as_ref() {
+            ExpData::Quant(_, QuantKind::Forall, ranges, _, _, body) => (ranges, body.clone()),
+            _ => return None,
+        };
+
+        // Collect quantifier-bound symbol -> Type from ranges. Only
+        // `Pattern::Var` bindings are supported.
+        let mut quant_types: BTreeMap<Symbol, Type> = BTreeMap::new();
+        for (pat, _range) in ranges {
+            if let Pattern::Var(node_id, sym) = pat {
+                let ty = env.get_node_type(*node_id);
+                quant_types.insert(*sym, ty);
+            }
+        }
+
+        // Flatten nested implications into (premises, conclusion). A body
+        // without an outer implication is treated as an empty premise with
+        // the whole body as conclusion.
+        let (premise_conjuncts, conclusion) = Self::flatten_implies(&body_exp);
+
+        // Partition premise conjuncts: absorb `ensures_of<self.0>(..)` calls
+        // (substituted away by result-fun applications), keep the rest as
+        // residual.
+        let num_inputs = params.len();
+        let mut absorbed_ensures: Vec<(Vec<Exp>, Vec<Symbol>)> = Vec::new();
+        let mut residual: Vec<Exp> = Vec::new();
+        for c in &premise_conjuncts {
+            if let ExpData::Call(_, AstOperation::Behavior(BehaviorKind::EnsuresOf, _), bp_args) =
+                c.as_ref()
+            {
+                if bp_args.len() < num_inputs + 1 {
+                    return None;
+                }
+                let inputs: Vec<Exp> = bp_args[1..=num_inputs].to_vec();
+                let mut results: Vec<Symbol> = Vec::with_capacity(bp_args.len() - 1 - num_inputs);
+                for r in &bp_args[num_inputs + 1..] {
+                    match r.as_ref() {
+                        ExpData::LocalVar(_, sym) => results.push(*sym),
+                        _ => return None,
+                    }
+                }
+                absorbed_ensures.push((inputs, results));
+            } else {
+                residual.push(c.clone());
+            }
+        }
+
+        // Collect occurrences whose inputs drive the multi-pattern trigger.
+        // When lifting EnsuresOf, the absorbed conjuncts ARE the occurrences
+        // (they're removed from the body, but the trigger still references
+        // them). For any other lifted kind, scan the residual + conclusion
+        // (the part of the invariant that remains after absorption).
+        let lifted_occurrences: Vec<Vec<Exp>> = if lifted_kind == BehaviorKind::EnsuresOf {
+            absorbed_ensures
+                .iter()
+                .map(|(inputs, _)| inputs.clone())
+                .collect()
+        } else {
+            let mut out: Vec<Vec<Exp>> = Vec::new();
+            for r in &residual {
+                Self::collect_behavior_calls(r, lifted_kind, &mut out);
+            }
+            Self::collect_behavior_calls(&conclusion, lifted_kind, &mut out);
+            out
+        };
+        if lifted_occurrences.is_empty() {
+            return None;
+        }
+
+        // Gather every input tuple we must render: absorbed_ensures (for
+        // result_sub) plus lifted_occurrences (for trigger_apps). When
+        // `lifted_kind == EnsuresOf` these are the same tuples; don't double-
+        // count them, else arg names could drift.
+        let mut all_tuples: Vec<&Vec<Exp>> = Vec::new();
+        for (inputs, _) in &absorbed_ensures {
+            all_tuples.push(inputs);
+        }
+        if lifted_kind != BehaviorKind::EnsuresOf {
+            for occ in &lifted_occurrences {
+                all_tuples.push(occ);
+            }
+        }
+
+        // First pass: for each input position, claim `arg{i}` for the first
+        // distinct LocalVar seen across all tuples. Symbols in the SAME
+        // position across occurrences share this name; distinct symbols fall
+        // through to the extras pass below.
+        let mut var_map: BTreeMap<Symbol, String> = BTreeMap::new();
+        let mut primary_at_pos: Vec<Option<Symbol>> = vec![None; num_inputs];
+        for inputs in &all_tuples {
+            for (i, arg) in inputs.iter().enumerate().take(num_inputs) {
+                if let ExpData::LocalVar(_, sym) = arg.as_ref() {
+                    if primary_at_pos[i].is_none() {
+                        primary_at_pos[i] = Some(*sym);
+                        var_map.insert(*sym, format!("arg{}", i));
+                    }
+                }
+            }
+        }
+
+        // Second pass: allocate extra quantifier binders for any remaining
+        // quantifier-bound symbols used in input positions, and render each
+        // tuple's input-arg strings.
+        let mut extra_quant_decls: Vec<String> = Vec::new();
+        let mut extra_preconds: Vec<String> = Vec::new();
+        let mut next_extra: usize = num_inputs;
+        let mut tuple_strs: Vec<Vec<String>> = Vec::with_capacity(all_tuples.len());
+        for inputs in &all_tuples {
+            let mut strs: Vec<String> = Vec::with_capacity(num_inputs);
+            for arg in inputs.iter().take(num_inputs) {
+                match arg.as_ref() {
+                    ExpData::LocalVar(_, sym) => {
+                        if !var_map.contains_key(sym) {
+                            let ty = quant_types.get(sym)?;
+                            let name = format!("arg{}", next_extra);
+                            next_extra += 1;
+                            extra_quant_decls.push(format!(
+                                "{}: {}",
+                                name,
+                                boogie_type(env, ty.skip_reference(), false)
+                            ));
+                            extra_preconds.push(boogie_well_formed_expr(
+                                env,
+                                &name,
+                                ty.skip_reference(),
+                                false,
+                            ));
+                            var_map.insert(*sym, name);
+                        }
+                        strs.push(var_map.get(sym)?.clone());
+                    },
+                    ExpData::Value(_, val) => {
+                        strs.push(Self::render_value_literal(val)?);
+                    },
+                    _ => return None,
+                }
+            }
+            tuple_strs.push(strs);
+        }
+
+        // Split tuple_strs back into (absorbed | lifted).
+        let absorbed_strs = &tuple_strs[..absorbed_ensures.len()];
+        let lifted_strs: &[Vec<String>] = if lifted_kind == BehaviorKind::EnsuresOf {
+            absorbed_strs
+        } else {
+            &tuple_strs[absorbed_ensures.len()..]
+        };
+
+        // Build result_sub from absorbed_ensures: each result symbol is
+        // substituted by the deterministic witness `result_fun(mem, inputs)`.
+        let result_fun_name = ctx.bp_fun_name(env, BehaviorKind::ResultOf);
+        let result_mem_rendered = mem_args.render(BehaviorKind::ResultOf);
+        let mut result_sub: BTreeMap<Symbol, String> = BTreeMap::new();
+        for ((_, result_syms), strs) in absorbed_ensures.iter().zip(absorbed_strs.iter()) {
+            if result_syms.len() != 1 {
+                return None;
+            }
+            let data_args = strs.join(", ");
+            let fun_app = if result_mem_rendered.is_empty() {
+                format!("{}({})", result_fun_name, data_args)
+            } else {
+                format!(
+                    "{}({}, {})",
+                    result_fun_name, result_mem_rendered, data_args
+                )
+            };
+            result_sub.insert(result_syms[0], fun_app);
+        }
+
+        // Build trigger_apps for the lifted kind — one witness-function app
+        // per occurrence. The trigger uses declaration-shape memory args so
+        // that every axiom-bound memory variable appears; the body may render
+        // memory kind-aware (e.g. `(old, old)` for AbortsOf). Z3 uses a
+        // multi-pattern `{t1, t2, ...}` trigger, firing only once every
+        // occurrence is grounded.
+        //
+        // For `EnsuresOf`, trigger on the deterministic witness function
+        // `sf_ensures_of_result` — not on the `sf_ensures_of` predicate. The
+        // predicate carries an additional result argument that absorption has
+        // already eliminated (substituted through `result_sub`); the witness
+        // is what the body actually references after absorption.
+        let trigger_kind = if lifted_kind == BehaviorKind::EnsuresOf {
+            BehaviorKind::ResultOf
+        } else {
+            lifted_kind
+        };
+        let trigger_fun_name = ctx.bp_fun_name(env, trigger_kind);
+        let trigger_mem_rendered = mem_args.render_for_trigger();
+        let mut trigger_apps: Vec<String> = Vec::with_capacity(lifted_strs.len());
+        for strs in lifted_strs {
+            let data_args = strs.join(", ");
+            let fun_app = if trigger_mem_rendered.is_empty() {
+                format!("{}({})", trigger_fun_name, data_args)
+            } else {
+                format!(
+                    "{}({}, {})",
+                    trigger_fun_name, trigger_mem_rendered, data_args
+                )
+            };
+            trigger_apps.push(fun_app);
+        }
+
+        // Build body: residual ==> conclusion (or conclusion alone).
+        let body = if let Some(res) = Self::and_of(&residual) {
+            let id = conclusion.node_id();
+            ExpData::Call(id, AstOperation::Implies, vec![res, conclusion]).into_exp()
+        } else {
+            conclusion
+        };
+
+        Some(LiftedBpInvariant {
+            var_map,
+            extra_quant_decls,
+            extra_preconds,
+            trigger_apps,
+            result_sub,
+            body,
+        })
     }
 }
 
@@ -4144,6 +5095,12 @@ impl FunctionTranslator<'_> {
         // Pass label info to the spec translator so it can resolve memory references
         // at labeled states back through the pre-state chain for non-modified types.
         self.parent.spec_translator.set_label_info(label_info);
+        // Pass the set of declared Boogie memory variable names so the spec
+        // translator can detect emissions that would reference an undeclared
+        // variable — a situation which indicates a missing user annotation.
+        self.parent
+            .spec_translator
+            .set_declared_mem_names(declared_mem_names.clone());
 
         // Initialize renamed parameters.
         for (idx, _) in proxied_parameters {
@@ -5541,6 +6498,7 @@ impl FunctionTranslator<'_> {
                             | Type::Fun(..)
                             | Type::TypeDomain(_)
                             | Type::ResourceDomain(_, _, _)
+                            | Type::StateDomain
                             | Type::Error
                             | Type::Var(_) => unreachable!(),
                         };
@@ -5607,6 +6565,7 @@ impl FunctionTranslator<'_> {
                             | Type::Fun(..)
                             | Type::TypeDomain(_)
                             | Type::ResourceDomain(_, _, _)
+                            | Type::StateDomain
                             | Type::Error
                             | Type::Var(_) => unreachable!(),
                         };
@@ -5673,6 +6632,7 @@ impl FunctionTranslator<'_> {
                             | Type::Fun(..)
                             | Type::TypeDomain(_)
                             | Type::ResourceDomain(_, _, _)
+                            | Type::StateDomain
                             | Type::Error
                             | Type::Var(_) => unreachable!(),
                         };
@@ -5710,6 +6670,7 @@ impl FunctionTranslator<'_> {
                                 | Type::Fun(..)
                                 | Type::TypeDomain(_)
                                 | Type::ResourceDomain(_, _, _)
+                                | Type::StateDomain
                                 | Type::Error
                                 | Type::Var(_) => unreachable!(),
                             }
@@ -5750,6 +6711,7 @@ impl FunctionTranslator<'_> {
                                 | Type::Fun(..)
                                 | Type::TypeDomain(_)
                                 | Type::ResourceDomain(_, _, _)
+                                | Type::StateDomain
                                 | Type::Error
                                 | Type::Var(_) => unreachable!(),
                             }
@@ -5790,6 +6752,7 @@ impl FunctionTranslator<'_> {
                             | Type::Fun(..)
                             | Type::TypeDomain(_)
                             | Type::ResourceDomain(_, _, _)
+                            | Type::StateDomain
                             | Type::Error
                             | Type::Var(_) => unreachable!(),
                         };
@@ -5827,6 +6790,7 @@ impl FunctionTranslator<'_> {
                                 | Type::Fun(..)
                                 | Type::TypeDomain(_)
                                 | Type::ResourceDomain(_, _, _)
+                                | Type::StateDomain
                                 | Type::Error
                                 | Type::Var(_) => unreachable!(),
                             };
@@ -5863,6 +6827,7 @@ impl FunctionTranslator<'_> {
                                 | Type::Fun(..)
                                 | Type::TypeDomain(_)
                                 | Type::ResourceDomain(_, _, _)
+                                | Type::StateDomain
                                 | Type::Error
                                 | Type::Var(_) => unreachable!(),
                             };
@@ -5903,6 +6868,7 @@ impl FunctionTranslator<'_> {
                                     | Type::Fun(..)
                                     | Type::TypeDomain(_)
                                     | Type::ResourceDomain(_, _, _)
+                                    | Type::StateDomain
                                     | Type::Error
                                     | Type::Var(_) => unreachable!(),
                                 }
@@ -5997,6 +6963,7 @@ impl FunctionTranslator<'_> {
                                     | Type::Fun(..)
                                     | Type::TypeDomain(_)
                                     | Type::ResourceDomain(_, _, _)
+                                    | Type::StateDomain
                                     | Type::Error
                                     | Type::Var(_) => unreachable!(),
                                 };
@@ -7065,6 +8032,7 @@ pub fn has_native_equality(env: &GlobalEnv, options: &BoogieOptions, ty: &Type) 
         | Type::Fun(..)
         | Type::TypeDomain(_)
         | Type::ResourceDomain(_, _, _)
+        | Type::StateDomain
         | Type::Error
         | Type::Var(_) => true,
     }

--- a/third_party/move/move-prover/boogie-backend/src/options.rs
+++ b/third_party/move/move-prover/boogie-backend/src/options.rs
@@ -202,6 +202,17 @@ pub struct BoogieOptions {
     /// Optional aggregate function names for native methods implementing mutable borrow semantics
     #[arg(skip)]
     pub borrow_aggregates: Vec<BorrowAggregate>,
+    /// Generate an independent verification condition for each assertion in a
+    /// function instead of a single combined condition. Can help the prover
+    /// when a function contains both provable-but-hard asserts and asserts
+    /// that produce counterexamples; useful for diagnosing per-function
+    /// timeouts.
+    #[arg(long)]
+    pub split_vcs_by_assert: bool,
+    /// Maximum number of counterexamples reported per verification
+    /// condition.
+    #[arg(long, default_value_t = 5)]
+    pub error_limit: usize,
 }
 
 impl Default for BoogieOptions {
@@ -238,6 +249,8 @@ impl Default for BoogieOptions {
             loop_unroll: None,
             borrow_aggregates: vec![],
             skip_instance_check: false,
+            split_vcs_by_assert: false,
+            error_limit: 5,
         }
     }
 }
@@ -295,6 +308,10 @@ impl BoogieOptions {
         if let Some(iters) = self.loop_unroll {
             add(&[&format!("-loopUnroll:{}", iters)]);
         }
+        if self.split_vcs_by_assert {
+            add(&["-vcsSplitOnEveryAssert"]);
+        }
+        add(&[&format!("-errorLimit:{}", self.error_limit)]);
         add(&[&format!(
             "-vcsCores:{}",
             if self.stable_test_output {

--- a/third_party/move/move-prover/boogie-backend/src/spec_translator.rs
+++ b/third_party/move/move-prover/boogie-backend/src/spec_translator.rs
@@ -96,6 +96,10 @@ pub struct SpecTranslator<'env> {
     /// Map from state labels to their defining operation info.
     /// Used to resolve memory references at labeled states.
     label_info: RefCell<BTreeMap<MemoryLabel, LabelInfo>>,
+    /// Set of Boogie `var` names that are declared in the enclosing procedure
+    /// (including memory snapshot variables like `$M_$memory#3`). Used to
+    /// verify that BP memory-arg emissions only reference declared variables.
+    declared_mem_names: RefCell<BTreeSet<String>>,
 }
 
 /// A struct which contains information about a lifted choice expression (like `some x:int: p(x)`).
@@ -134,6 +138,7 @@ impl<'env> SpecTranslator<'env> {
             arbitrary_values: Default::default(),
             current_fun_qid: RefCell::new(None),
             label_info: RefCell::new(BTreeMap::new()),
+            declared_mem_names: RefCell::new(BTreeSet::new()),
         }
     }
 
@@ -150,6 +155,11 @@ impl<'env> SpecTranslator<'env> {
     /// Sets the label info map for resolving memory references at labeled states.
     pub fn set_label_info(&self, info: BTreeMap<MemoryLabel, LabelInfo>) {
         *self.label_info.borrow_mut() = info;
+    }
+
+    /// Sets the set of Boogie `var` names declared in the enclosing procedure.
+    pub fn set_declared_mem_names(&self, names: BTreeSet<String>) {
+        *self.declared_mem_names.borrow_mut() = names;
     }
 
     /// Resolve the effective memory label for a resource type at a given state label.
@@ -670,11 +680,17 @@ impl SpecTranslator<'_> {
             // Only truly intermediate labels (those that resolve to themselves via
             // label resolution) need wrapping. Labels resolving to None (pre/post state)
             // are handled by old_aware_memory_name mapping to function parameters.
+            // Labels explicitly quantified by StateDomain ranges are excluded — they are
+            // bound by the user's forall/exists, not by our implicit existential.
             let body = fun.body.as_ref().unwrap();
             let all_labels = self.collect_intermediate_labels_from_exp(body);
+            let quant_bound = self.collect_quant_bound_state_labels(body);
             let intermediate_labels: BTreeSet<_> = all_labels
                 .into_iter()
-                .filter(|(label, mem)| self.resolve_label_for_memory(*label, mem) == Some(*label))
+                .filter(|(label, mem)| {
+                    self.resolve_label_for_memory(*label, mem) == Some(*label)
+                        && !quant_bound.contains(label)
+                })
                 .collect();
 
             // Emit existential prefix if there are intermediate labels
@@ -843,6 +859,7 @@ impl SpecTranslator<'_> {
                 | Type::Fun(..)
                 | Type::TypeDomain(_)
                 | Type::ResourceDomain(_, _, _)
+                | Type::StateDomain
                 | Type::Error
                 | Type::Var(_) => {},
             }
@@ -1425,10 +1442,11 @@ impl SpecTranslator<'_> {
             Operation::CanModify => self.translate_can_modify(node_id, args),
             Operation::Len => self.translate_primitive_call("LenVec", args),
             Operation::TypeValue => self.translate_type_value(node_id),
-            Operation::TypeDomain | Operation::ResourceDomain => self.error(
-                &loc,
-                "domain functions can only be used as the range of a quantifier",
-            ),
+            Operation::TypeDomain | Operation::ResourceDomain | Operation::StateDomain => self
+                .error(
+                    &loc,
+                    "domain functions can only be used as the range of a quantifier",
+                ),
             Operation::UpdateVec => self.translate_primitive_call("UpdateVec", args),
             Operation::ConcatVec => self.translate_primitive_call("ConcatVec", args),
             Operation::EmptyVec => self.translate_primitive_inst_call(node_id, "$EmptyVec", args),
@@ -1664,7 +1682,7 @@ impl SpecTranslator<'_> {
     /// Used for runtime function values (e.g., function-typed parameters after substitution).
     fn translate_behavior_via_evaluator(
         &self,
-        _node_id: NodeId,
+        node_id: NodeId,
         kind: BehaviorKind,
         fun_exp: &Exp,
         pred_args: &[Exp],
@@ -1675,7 +1693,7 @@ impl SpecTranslator<'_> {
         let eval_fun_name = boogie_behavioral_eval_fun_name(self.env, &inst_fun_type, kind);
         emit!(self.writer, "{}(", eval_fun_name);
         let has_mem =
-            self.emit_evaluator_memory_args(&inst_fun_type, kind, &range.pre, &range.post);
+            self.emit_evaluator_memory_args(node_id, &inst_fun_type, kind, &range.pre, &range.post);
         if has_mem {
             emit!(self.writer, ", ");
         }
@@ -1691,6 +1709,7 @@ impl SpecTranslator<'_> {
     /// from all closure and param variants of the given function type.
     fn emit_evaluator_memory_args(
         &self,
+        node_id: NodeId,
         fun_type: &Type,
         kind: BehaviorKind,
         pre: &Option<MemoryLabel>,
@@ -1710,6 +1729,10 @@ impl SpecTranslator<'_> {
         let mut first = true;
         for memory in &union_used_memory {
             if uses_old && union_old_memory.contains(memory) {
+                // Check that the pre-state memory reference will be declared.
+                if !self.check_name_declared(node_id, kind, *pre, memory) {
+                    return !first;
+                }
                 if !first {
                     emit!(self.writer, ", ");
                 }
@@ -1737,7 +1760,7 @@ impl SpecTranslator<'_> {
     #[allow(clippy::too_many_arguments)]
     fn translate_behavior_for_closure(
         &self,
-        _node_id: NodeId,
+        node_id: NodeId,
         kind: BehaviorKind,
         closure_id: NodeId,
         mid: ModuleId,
@@ -1771,7 +1794,7 @@ impl SpecTranslator<'_> {
         emit!(self.writer, "{}(", fun_name);
 
         // Emit memory args, then interleave captured + non-captured params
-        let mut has_args = self.emit_fun_spec_memory_args(&fun_qid, kind, range);
+        let mut has_args = self.emit_fun_spec_memory_args(node_id, &fun_qid, kind, range);
         let mut captured_pos = 0;
         let mut non_captured_pos = 0;
         for i in 0..num_params {
@@ -1802,6 +1825,7 @@ impl SpecTranslator<'_> {
     /// Returns true if any memory args were emitted.
     fn emit_fun_spec_memory_args(
         &self,
+        node_id: NodeId,
         fun_qid: &QualifiedInstId<FunId>,
         kind: BehaviorKind,
         range: &MemoryRange,
@@ -1824,6 +1848,10 @@ impl SpecTranslator<'_> {
         for memory in used_memory {
             let memory = &memory.clone().instantiate(&fun_qid.inst);
             if uses_old && old_memory.contains(memory) {
+                // Check that the pre-state memory reference will be declared.
+                if !self.check_name_declared(node_id, kind, pre, memory) {
+                    return !first;
+                }
                 if !first {
                     emit!(self.writer, ", ");
                 }
@@ -1854,6 +1882,65 @@ impl SpecTranslator<'_> {
             }
         }
         !first // true if we emitted at least one arg
+    }
+
+    /// Verifies that the resolved Boogie memory variable name that would be emitted
+    /// for the pre-state of a dual-state BP arg is actually declared in the
+    /// enclosing procedure. If not, emits a Move-level error pointing the user
+    /// toward `reads_of`/`modifies_of` or state quantification. Returns `false`
+    /// on error so the caller can skip emission.
+    fn check_name_declared(
+        &self,
+        node_id: NodeId,
+        kind: BehaviorKind,
+        pre: Option<MemoryLabel>,
+        memory: &QualifiedInstId<StructId>,
+    ) -> bool {
+        if self.fun_old_memory.is_some() {
+            return true; // spec function body — pre maps to old_ param
+        }
+        let declared = self.declared_mem_names.borrow();
+        if declared.is_empty() {
+            return true; // no declarations tracked (e.g., top-level spec fun translation)
+        }
+        // Resolve the label chain the same way emission will.
+        let resolved = match pre {
+            Some(l) if !self.label_info.borrow().is_empty() => {
+                self.resolve_label_for_memory(l, memory)
+            },
+            other => other,
+        };
+        // If the resolved label is None, emission will use the base memory variable
+        // wrapped in `old(...)` — the base variable is declared globally.
+        let Some(resolved_label) = resolved else {
+            return true;
+        };
+        let name = boogie_resource_memory_name(self.env, memory, &Some(resolved_label));
+        if declared.contains(&name) {
+            return true;
+        }
+        // Mismatch: the Boogie variable we would reference is not declared.
+        let loc = self.env.get_node_loc(node_id);
+        let kind_name = match kind {
+            BehaviorKind::RequiresOf => "requires_of",
+            BehaviorKind::AbortsOf => "aborts_of",
+            BehaviorKind::EnsuresOf => "ensures_of",
+            BehaviorKind::ResultOf => "result_of",
+        };
+        let struct_env = self.env.get_struct_qid(memory.to_qualified_id());
+        let mem_display = struct_env.get_full_name_with_address().to_string();
+        self.env.error(
+            &loc,
+            &format!(
+                "`{}` references resource `{}` used by the target function, but the \
+                 enclosing function does not save a pre-state for it; either declare \
+                 the access via `reads_of`/`modifies_of` on the target, or use state \
+                 quantification, e.g., `forall S in *, ...: S.. |~ {}<f>(...)`",
+                kind_name, mem_display, kind_name
+            ),
+        );
+        emit!(self.writer, "/* undeclared-memory */ ");
+        false
     }
 
     fn translate_event_store_includes(&self, args: &[Exp]) {
@@ -2364,6 +2451,34 @@ impl SpecTranslator<'_> {
         }
     }
 
+    /// Collects all `MemoryLabel`s that are explicitly bound by `StateDomain` quantifier
+    /// ranges within the given expression tree. These labels should NOT be wrapped in
+    /// the implicit existential quantification.
+    pub fn collect_quant_bound_state_labels(&self, exp: &Exp) -> BTreeSet<MemoryLabel> {
+        let env = self.env;
+        let mut result = BTreeSet::new();
+        exp.visit_pre_order(&mut |e| {
+            if let ExpData::Quant(_, _, ranges, _, _, _) = e {
+                let label_names = env.get_memory_label_names();
+                for (pat, range) in ranges {
+                    let range_ty = env.get_node_type(range.node_id());
+                    if matches!(range_ty, Type::StateDomain) {
+                        if let Pattern::Var(_, sym) = pat {
+                            // Find all MemoryLabels with this symbol name
+                            for (label, name) in &label_names {
+                                if name == sym {
+                                    result.insert(*label);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            true
+        });
+        result
+    }
+
     /// Returns the Boogie memory variable name, accounting for old() context in spec funs.
     fn old_aware_memory_name(
         &self,
@@ -2571,6 +2686,7 @@ impl SpecTranslator<'_> {
                 | Type::Fun(..)
                 | Type::TypeDomain(_)
                 | Type::ResourceDomain(_, _, _)
+                | Type::StateDomain
                 | Type::Error
                 | Type::Var(_) => false,
             };
@@ -2580,6 +2696,30 @@ impl SpecTranslator<'_> {
                 self.translate_exp(range);
                 emit!(self.writer, "; ");
                 range_tmps.insert(var_name, range_tmp);
+            }
+        }
+        // Collect state-domain quantifier info: for each state-domain range variable,
+        // find the MemoryLabel and the affected memory types from the body.
+        let all_body_labels = self.collect_intermediate_labels_from_exp(body);
+        let mut state_domain_labels: BTreeMap<
+            Symbol,
+            BTreeSet<(MemoryLabel, QualifiedInstId<StructId>)>,
+        > = BTreeMap::new();
+        for (var, range) in ranges {
+            let quant_ty = self.get_node_type(range.node_id());
+            if matches!(quant_ty.skip_reference(), Type::StateDomain) {
+                let (_, var_name) = self.require_range_var(var);
+                // Find the MemoryLabel for this variable name by reverse lookup
+                let label_names = self.env.get_memory_label_names();
+                let mut affected = BTreeSet::new();
+                for (label, mem) in &all_body_labels {
+                    if let Some(name) = label_names.get(label) {
+                        if *name == var_name {
+                            affected.insert((*label, mem.clone()));
+                        }
+                    }
+                }
+                state_domain_labels.insert(var_name, affected);
             }
         }
         // Translate quantified variables.
@@ -2616,6 +2756,23 @@ impl SpecTranslator<'_> {
                     let addr_quant_var = self.fresh_var_name("a");
                     emit!(self.writer, "{}{}: int", comma, addr_quant_var);
                     resource_vars.insert(var_name, addr_quant_var);
+                },
+                Type::StateDomain => {
+                    // Emit one Boogie memory variable per affected (label, memory_type) pair.
+                    if let Some(affected) = state_domain_labels.get(&var_name) {
+                        for (label, mem) in affected {
+                            let name = boogie_resource_memory_name(self.env, mem, &Some(*label));
+                            let ty = boogie_struct_name(
+                                &self.env.get_struct_qid(mem.to_qualified_id()),
+                                &mem.inst,
+                                false,
+                            );
+                            emit!(self.writer, "{}{}: $Memory {}", comma, name, ty);
+                            comma = ", ";
+                        }
+                    }
+                    // Skip incrementing comma at the end — already done above
+                    continue;
                 },
                 _ => {
                     let quant_var = self.fresh_var_name("i");
@@ -2681,8 +2838,8 @@ impl SpecTranslator<'_> {
                     }
                     emit!(self.writer, "{}{}", separator, type_check);
                 },
-                Type::ResourceDomain(..) => {
-                    // currently does not generate a constraint
+                Type::ResourceDomain(..) | Type::StateDomain => {
+                    // No range constraint needed.
                     continue;
                 },
                 Type::Vector(..) => {

--- a/third_party/move/move-prover/bytecode-pipeline/src/memory_instrumentation.rs
+++ b/third_party/move/move-prover/bytecode-pipeline/src/memory_instrumentation.rs
@@ -216,6 +216,7 @@ impl<'a> Instrumenter<'a> {
             | Fun(..)
             | TypeDomain(_)
             | ResourceDomain(_, _, _)
+            | StateDomain
             | Error
             | Var(_) => false,
         }

--- a/third_party/move/move-prover/bytecode-pipeline/src/mono_analysis.rs
+++ b/third_party/move/move-prover/bytecode-pipeline/src/mono_analysis.rs
@@ -539,6 +539,7 @@ impl Analyzer<'_> {
                     let fun_type =
                         self.normalize_fun_ty(self.instantiate(target.get_local_type(dests[0])));
                     let fun = mid.qualified_inst(*fid, self.instantiate_vec(targs));
+                    self.add_closure_spec_memory(&fun);
                     self.info
                         .fun_infos
                         .entry(fun_type)
@@ -595,6 +596,27 @@ impl Analyzer<'_> {
         }
     }
 
+    /// When a closure value targeting `fun` is recorded, register the resource
+    /// memory accessed by `fun`'s spec. Behavioral predicates (`aborts_of`,
+    /// `ensures_of`, `result_of`) evaluate the target's spec, so its memory
+    /// must be in `structs` for Boogie to emit the `_$memory` declarations —
+    /// even when the closure is never called directly under the current
+    /// verification filter.
+    fn add_closure_spec_memory(&mut self, fun: &QualifiedInstId<FunId>) {
+        let fun_env = self.env.get_function(fun.to_qualified_id());
+        let mems: Vec<_> = fun_env
+            .get_spec_used_memory()
+            .iter()
+            .chain(fun_env.get_spec_old_memory().iter())
+            .cloned()
+            .collect();
+        for mem in mems {
+            let mem = mem.instantiate(&fun.inst);
+            let struct_env = self.env.get_struct_qid(mem.to_qualified_id());
+            self.add_struct(struct_env, &mem.inst);
+        }
+    }
+
     fn instantiate_mem(&self, mem: QualifiedInstId<StructId>) -> QualifiedInstId<StructId> {
         if let Some(inst) = &self.inst_opt {
             mem.instantiate(inst)
@@ -631,6 +653,7 @@ impl Analyzer<'_> {
                 let fun = mid.qualified_inst(*fid, inst);
                 let fun_type =
                     self.normalize_fun_ty(self.instantiate(&self.env.get_node_type(*node_id)));
+                self.add_closure_spec_memory(&fun);
                 self.info
                     .fun_infos
                     .entry(fun_type)

--- a/third_party/move/move-prover/bytecode-pipeline/src/spec_instrumentation.rs
+++ b/third_party/move/move-prover/bytecode-pipeline/src/spec_instrumentation.rs
@@ -92,8 +92,14 @@ impl FunctionTargetProcessor for SpecInstrumentationProcessor {
                 Instrumenter::run(&options, targets, fun_env, verification_data, scc_opt);
             verification_data = instrumented;
 
-            if split_points.is_empty() {
+            if split_points.is_empty() || options.inference {
                 // No splits — insert the single verification variant.
+                // Proof-block split-fork is verification-only; during inference
+                // (`options.inference`) we never fork, so each function has at
+                // most one verified variant for inference to walk. By
+                // construction `Instrumenter::run` should not produce any
+                // `split_points` under inference, but check explicitly so the
+                // gate is local to this site too.
                 targets.insert_target_data(
                     &fun_env.get_qualified_id(),
                     verification_data.variant.clone(),
@@ -475,8 +481,15 @@ impl<'a> Instrumenter<'a> {
         // `split_points` outside the bytecode, so they are not rewritten by
         // the subsequent live-var analysis — inlining here is the only way
         // to ensure they reference only stable Move-level temps.
+        //
+        // Skip during spec inference: proof blocks are a verification-only
+        // construct and must not influence the bytecode the inference walker
+        // sees. `instrument` likewise skips emitting proof actions under
+        // `options.inference`, so this work would be wasted anyway.
         let mut spec = spec;
-        instrumenter.inline_lets_in_proof_actions(&mut spec);
+        if !options.inference {
+            instrumenter.inline_lets_in_proof_actions(&mut spec);
+        }
         if ProverOptions::get(instrumenter.builder.global_env()).inline_spec_lets {
             instrumenter.inline_lets(&mut spec, false);
         }
@@ -586,6 +599,12 @@ impl<'a> Instrumenter<'a> {
         // Instrument and generate new code.
         // Peel leading TraceLocal instructions and emit them before pre_proof
         // so that pre-proof assertion errors can display model values in counter-examples.
+        //
+        // Skip proof-action emission entirely during spec inference: proof
+        // blocks are a verification-only construct, and emitting their props
+        // (or accumulating their split points) would cause the inference
+        // walker to fork per case and produce per-variant inferred specs.
+        let emit_proof = !self.options.inference;
         let mut old_code = old_code.into_iter();
         let mut pre_proof_emitted = false;
         for bc in old_code.by_ref() {
@@ -593,13 +612,15 @@ impl<'a> Instrumenter<'a> {
                 self.builder.emit(bc);
             } else {
                 // First non-trace instruction: emit pre_proof, then this instruction.
-                self.emit_proof_actions(&spec.pre_proof, spec);
+                if emit_proof {
+                    self.emit_proof_actions(&spec.pre_proof, spec);
+                }
                 pre_proof_emitted = true;
                 self.instrument_bytecode(spec, inlined_props, bc);
                 break;
             }
         }
-        if !pre_proof_emitted {
+        if !pre_proof_emitted && emit_proof {
             self.emit_proof_actions(&spec.pre_proof, spec);
         }
         // Continue with remaining old_code.
@@ -1110,7 +1131,17 @@ impl<'a> Instrumenter<'a> {
     /// does not reach them. Substituting here replaces references to
     /// spec-let temps with their defining expressions, which use only
     /// Move-level temps that survive the remap with stable indices.
+    ///
+    /// `LetPre` bindings substituted into post-state proof actions
+    /// (`post_proof`) are annotated with pre-state memory labels and have
+    /// their parameter references remapped to saved versions, mirroring the
+    /// treatment in `inline_lets`. Without this, a `let pre = R[a].f;`
+    /// referenced from a `post { ... }` action would evaluate `R[a].f` at
+    /// post-state instead of the saved entry-state snapshot.
     fn inline_lets_in_proof_actions(&mut self, spec: &mut TranslatedSpec) {
+        if spec.pre_proof.is_empty() && spec.post_proof.is_empty() {
+            return;
+        }
         let env = self.builder.global_env();
         let substitute_exp =
             |env: &GlobalEnv, cond: &mut Exp, temp: TempIndex, replacement: &Exp| {
@@ -1138,24 +1169,63 @@ impl<'a> Instrumenter<'a> {
                     }
                 },
             };
-        // Build a working vector where each let's rhs has all prior lets
-        // already inlined into it — this mirrors the chained substitution in
-        // `inline_lets` so that transitive references between lets resolve
-        // correctly before they are applied to the proof actions.
-        let mut resolved_lets: Vec<(TempIndex, Exp)> = Vec::new();
-        for (_, _, temp, exp) in &spec.lets {
-            let mut rhs = exp.clone();
-            for (prev_temp, prev_exp) in &resolved_lets {
-                substitute_exp(env, &mut rhs, *prev_temp, prev_exp);
+        // Compute the post-state replacement for a `LetPre` lazily — only when
+        // a let temp is actually referenced from a `post_proof` action. This
+        // avoids allocating fresh `saved_memory` labels and `saved_params`
+        // temps for every spec let, which would pollute the pre-state save
+        // sets and bloat downstream Boogie translation even when no proof
+        // action consumes them.
+        let mut resolved_lets: Vec<(TempIndex, bool, Exp)> = Vec::new();
+        for (_, is_post, temp, exp) in spec.lets.clone() {
+            let mut pre_rhs = exp.clone();
+            for (prev_temp, _, prev_pre) in &resolved_lets {
+                substitute_exp(env, &mut pre_rhs, *prev_temp, prev_pre);
             }
-            resolved_lets.push((*temp, rhs));
+            resolved_lets.push((temp, is_post, pre_rhs));
         }
-        for (temp, exp) in &resolved_lets {
+        for (temp, is_post, pre_replacement) in &resolved_lets {
             for (_, action) in &mut spec.pre_proof {
-                substitute_proof_action(env, action, *temp, exp);
+                substitute_proof_action(env, action, *temp, pre_replacement);
             }
+            if spec.post_proof.is_empty() {
+                continue;
+            }
+            // Only compute the (potentially state-allocating) post replacement
+            // if the temp is actually referenced from a post_proof action.
+            let exp_uses_temp = |exp: &Exp, temp: TempIndex| {
+                let mut found = false;
+                exp.visit_pre_order(&mut |e| {
+                    if let ExpData::Temporary(_, idx) = e {
+                        if *idx == temp {
+                            found = true;
+                        }
+                    }
+                    !found
+                });
+                found
+            };
+            let referenced = spec.post_proof.iter().any(|(_, action)| match action {
+                ProofAction::Assert(exp, _) | ProofAction::Assume(exp) => exp_uses_temp(exp, *temp),
+                ProofAction::Split(exp, guard) => {
+                    exp_uses_temp(exp, *temp)
+                        || guard.as_ref().is_some_and(|g| exp_uses_temp(g, *temp))
+                },
+            });
+            if !referenced {
+                continue;
+            }
+            let post_replacement = if !*is_post {
+                let annotated = Self::annotate_pre_state_memory(
+                    env,
+                    pre_replacement.clone(),
+                    &mut spec.saved_memory,
+                );
+                self.remap_params_to_saved(annotated, &mut spec.saved_params)
+            } else {
+                pre_replacement.clone()
+            };
             for (_, action) in &mut spec.post_proof {
-                substitute_proof_action(env, action, *temp, exp);
+                substitute_proof_action(env, action, *temp, &post_replacement);
             }
         }
     }
@@ -1664,7 +1734,10 @@ impl<'a> Instrumenter<'a> {
             }
 
             // Emit return-point proof actions (`post`-prefixed proof statements).
-            self.emit_proof_actions(&spec.post_proof, spec);
+            // Verification-only — see the corresponding gate before pre_proof.
+            if !self.options.inference {
+                self.emit_proof_actions(&spec.post_proof, spec);
+            }
 
             // Emit all post-conditions which must hold.
             // For defining conditions (already assumed), assert the non-defining

--- a/third_party/move/move-prover/bytecode-pipeline/src/spec_instrumentation.rs
+++ b/third_party/move/move-prover/bytecode-pipeline/src/spec_instrumentation.rs
@@ -470,13 +470,17 @@ impl<'a> Instrumenter<'a> {
             split_points: vec![],
             freshen_counter: 0,
         };
+        // Always inline spec lets in proof actions, independent of the
+        // `inline_spec_lets` option. Proof-action exps are recorded in
+        // `split_points` outside the bytecode, so they are not rewritten by
+        // the subsequent live-var analysis — inlining here is the only way
+        // to ensure they reference only stable Move-level temps.
+        let mut spec = spec;
+        instrumenter.inline_lets_in_proof_actions(&mut spec);
         if ProverOptions::get(instrumenter.builder.global_env()).inline_spec_lets {
-            let mut spec = spec;
             instrumenter.inline_lets(&mut spec, false);
-            instrumenter.instrument(&spec, &inlined_props);
-        } else {
-            instrumenter.instrument(&spec, &inlined_props);
         }
+        instrumenter.instrument(&spec, &inlined_props);
 
         // Extract split points before consuming the instrumenter.
         let split_points = std::mem::take(&mut instrumenter.split_points);
@@ -1099,6 +1103,63 @@ impl<'a> Instrumenter<'a> {
         }
     }
 
+    /// Inline spec let bindings into proof-block actions only, leaving
+    /// `spec.lets` and all other conditions untouched. Proof actions are
+    /// recorded out of band (notably `Split` exps in `split_points`), so
+    /// the bytecode-level temp remap performed by later live-var analysis
+    /// does not reach them. Substituting here replaces references to
+    /// spec-let temps with their defining expressions, which use only
+    /// Move-level temps that survive the remap with stable indices.
+    fn inline_lets_in_proof_actions(&mut self, spec: &mut TranslatedSpec) {
+        let env = self.builder.global_env();
+        let substitute_exp =
+            |env: &GlobalEnv, cond: &mut Exp, temp: TempIndex, replacement: &Exp| {
+                let replacement = replacement.clone();
+                let mut replacer =
+                    |_id: move_model::model::NodeId, target: RewriteTarget| -> Option<Exp> {
+                        if let RewriteTarget::Temporary(idx) = target {
+                            if idx == temp {
+                                return Some(replacement.clone());
+                            }
+                        }
+                        None
+                    };
+                *cond = ExpRewriter::new(env, &mut replacer).rewrite_exp(cond.clone());
+            };
+        let substitute_proof_action =
+            |env: &GlobalEnv, action: &mut ProofAction, temp, replacement: &Exp| match action {
+                ProofAction::Assert(exp, _) | ProofAction::Assume(exp) => {
+                    substitute_exp(env, exp, temp, replacement);
+                },
+                ProofAction::Split(exp, guard) => {
+                    substitute_exp(env, exp, temp, replacement);
+                    if let Some(g) = guard {
+                        substitute_exp(env, g, temp, replacement);
+                    }
+                },
+            };
+        // Build a working vector where each let's rhs has all prior lets
+        // already inlined into it — this mirrors the chained substitution in
+        // `inline_lets` so that transitive references between lets resolve
+        // correctly before they are applied to the proof actions.
+        let mut resolved_lets: Vec<(TempIndex, Exp)> = Vec::new();
+        for (_, _, temp, exp) in &spec.lets {
+            let mut rhs = exp.clone();
+            for (prev_temp, prev_exp) in &resolved_lets {
+                substitute_exp(env, &mut rhs, *prev_temp, prev_exp);
+            }
+            resolved_lets.push((*temp, rhs));
+        }
+        for (temp, exp) in &resolved_lets {
+            for (_, action) in &mut spec.pre_proof {
+                substitute_proof_action(env, action, *temp, exp);
+            }
+            for (_, action) in &mut spec.post_proof {
+                substitute_proof_action(env, action, *temp, exp);
+            }
+        }
+    }
+
     /// Inline let bindings by substituting the expression directly into conditions.
     /// For `LetPre` expressions in post-state conditions, annotates memory references
     /// with pre-state labels to preserve pre-state evaluation semantics.
@@ -1375,6 +1436,7 @@ impl<'a> Instrumenter<'a> {
                 | Operation::Exists(_)
                 | Operation::CanModify
                 | Operation::ResourceDomain
+                | Operation::StateDomain
                 | Operation::Behavior(..),
                 _,
             ) = e

--- a/third_party/move/move-prover/bytecode-pipeline/tests/spec_instrumentation/proofs/if_else_let.exp
+++ b/third_party/move/move-prover/bytecode-pipeline/tests/spec_instrumentation/proofs/if_else_let.exp
@@ -110,7 +110,7 @@ fun TestIfElseLet::test_let($t0|x: u64): u64 {
   2: $t3 := +($t0, $t2) on_abort goto 7 with $t4
   3: label L1
      # VC: proof assertion not satisfied at tests/spec_instrumentation/proofs/if_else_let.move:33:14+19
-  4: assert Eq<num>($t1, $t3)
+  4: assert Eq<num>(Add($t0, 1), $t3)
      # VC: post-condition does not hold at tests/spec_instrumentation/proofs/if_else_let.move:30:9+24
   5: assert Eq<u64>($t3, Add($t0, 1))
   6: return $t3

--- a/third_party/move/move-prover/bytecode-pipeline/tests/spec_instrumentation/proofs/post.exp
+++ b/third_party/move/move-prover/bytecode-pipeline/tests/spec_instrumentation/proofs/post.exp
@@ -144,7 +144,7 @@ fun TestPost::scale($t0|x: u64, $t1|factor: u64): u64 {
   2: $t3 := *($t0, $t1) on_abort goto 7 with $t4
   3: label L1
      # VC: proof assertion not satisfied at tests/spec_instrumentation/proofs/post.move:32:14+26
-  4: assert Eq<u64>($t3, $t2)
+  4: assert Eq<u64>($t3, Mul($t0, $t1))
      # VC: post-condition does not hold at tests/spec_instrumentation/proofs/post.move:29:9+29
   5: assert Eq<u64>($t3, Mul($t0, $t1))
   6: return $t3

--- a/third_party/move/move-prover/src/inference.rs
+++ b/third_party/move/move-prover/src/inference.rs
@@ -542,17 +542,39 @@ fn output_unified(env: &GlobalEnv, inferred_sym: Symbol, options: &Options) -> a
                 // just before the line containing the closing `}`.
                 let block_end = spec_info.loc.span().end().to_usize();
                 let block_start = spec_info.loc.span().start().to_usize();
-                // Find the closing `}`, then find the start of its line
-                // so we insert before the line with `}`.
-                let brace_pos = source[..block_end]
-                    .rfind('}')
-                    .expect("spec block should have closing brace");
 
                 // Find the opening `{` to detect single-line blocks like `spec foo {}`.
                 let open_brace_pos = source[block_start..block_end]
                     .find('{')
                     .map(|p| block_start + p)
                     .expect("spec block should have opening brace");
+
+                // Find the spec block's matching closing `}` by scanning forward
+                // from the opening `{` and balancing braces. Without this, when
+                // the spec is followed by a trailing `proof { ... }` block
+                // (which is parsed as part of the same `SpecBlockInfo` loc), an
+                // `rfind('}')` would land on the proof block's closing brace
+                // and inferred conditions would be inserted into the proof
+                // block instead of the spec block.
+                let brace_pos = {
+                    let bytes = source.as_bytes();
+                    let mut depth: i32 = 0;
+                    let scan = bytes[open_brace_pos..block_end]
+                        .iter()
+                        .enumerate()
+                        .find_map(|(offset, b)| match b {
+                            b'{' => {
+                                depth += 1;
+                                None
+                            },
+                            b'}' => {
+                                depth -= 1;
+                                (depth == 0).then_some(open_brace_pos + offset)
+                            },
+                            _ => None,
+                        });
+                    scan.expect("spec block should have matching closing brace")
+                };
                 let is_single_line = !source[open_brace_pos..brace_pos].contains('\n');
 
                 let insert_pos = if is_single_line {
@@ -727,7 +749,10 @@ fn generate_inferred_conditions(
     let sourcifier = Sourcifier::new(env, true);
 
     // Filter to only inferred conditions, properties, and frame_spec; print; then restore.
-    let (original_conditions, original_properties) = {
+    // The user-written `proof { ... }` block is also temporarily cleared so it
+    // is not re-emitted alongside the inferred conditions (it already lives in
+    // the source we are merging into).
+    let (original_conditions, original_properties, original_proof) = {
         let mut spec = fun.get_mut_spec();
         let orig_conds = std::mem::take(&mut spec.conditions);
         spec.conditions = orig_conds
@@ -742,16 +767,18 @@ fn generate_inferred_conditions(
             .filter(|(k, _)| !original_property_keys.contains(k))
             .map(|(k, v)| (*k, v.clone()))
             .collect();
-        (orig_conds, orig_props)
+        let orig_proof = spec.proof.take();
+        (orig_conds, orig_props, orig_proof)
     };
 
     sourcifier.print_fun_spec(fun);
 
-    // Restore original conditions and properties.
+    // Restore original conditions, properties, and proof block.
     {
         let mut spec = fun.get_mut_spec();
         spec.conditions = original_conditions;
         spec.properties = original_properties;
+        spec.proof = original_proof;
     }
 
     let raw = sourcifier.result();

--- a/third_party/move/move-prover/tests/inference/calculator.exp.move
+++ b/third_party/move/move-prover/tests/inference/calculator.exp.move
@@ -117,14 +117,15 @@ module 0x66::calculator {
     entry fun number(s: &signer, x: u64) acquires State {
         process(s, Input::Number(x))
     }
-    spec number(s: &signer, x: u64) {
+    spec number {
         use 0x1::signer;
         pragma opaque = true;
         modifies State[signer::address_of(s)];
         ensures [inferred] ensures_of<process>(s, Input::Number(x));
         aborts_if [inferred] aborts_of<process>(s, Input::Number(x));
+    } proof {
+        split State[address_of(s)];
     }
-
 
     entry fun add(s: &signer) acquires State {
         process(s, Input::Add)

--- a/third_party/move/move-prover/tests/inference/calculator.move
+++ b/third_party/move/move-prover/tests/inference/calculator.move
@@ -52,6 +52,10 @@ module 0x66::calculator {
     entry fun number(s: &signer, x: u64) acquires State {
         process(s, Input::Number(x))
     }
+    spec number {
+    } proof {
+        split State[address_of(s)];
+    }
 
     entry fun add(s: &signer) acquires State {
         process(s, Input::Add)

--- a/third_party/move/move-prover/tests/sources/functional/closures/amm_example.exp
+++ b/third_party/move/move-prover/tests/sources/functional/closures/amm_example.exp
@@ -1,13 +1,10 @@
 Move prover returns: exiting with verification errors
 error: data invariant does not hold
-   ┌─ tests/sources/functional/closures/amm_example.move:36:9
+   ┌─ tests/sources/functional/closures/amm_example.move:28:9
    │
-36 │ ╭         invariant forall S in *, client: address, r_in: u64, r_out: u64,
-37 │ │                         a1: u64, a2: u64:
-38 │ │             S.. |~ a1 <= a2 ==>
-39 │ │                 result_of<self.0>(client, r_in, r_out, a1)
-40 │ │                     <= result_of<self.0>(client, r_in, r_out, a2);
-   │ ╰──────────────────────────────────────────────────────────────────^
+28 │ ╭         invariant forall S in *, client: address, r_in: u64, r_out: u64, amt: u64:
+29 │ │             S |~ !aborts_of<self.0>(client, r_in, r_out, amt);
+   │ ╰──────────────────────────────────────────────────────────────^
    │
    =     at tests/sources/functional/closures/amm_example.move:255: create_noncompliant_fee_pool
    =         account = <redacted>

--- a/third_party/move/move-prover/tests/sources/functional/closures/amm_example.exp
+++ b/third_party/move/move-prover/tests/sources/functional/closures/amm_example.exp
@@ -1,0 +1,47 @@
+Move prover returns: exiting with verification errors
+error: data invariant does not hold
+   ┌─ tests/sources/functional/closures/amm_example.move:36:9
+   │
+36 │ ╭         invariant forall S in *, client: address, r_in: u64, r_out: u64,
+37 │ │                         a1: u64, a2: u64:
+38 │ │             S.. |~ a1 <= a2 ==>
+39 │ │                 result_of<self.0>(client, r_in, r_out, a1)
+40 │ │                     <= result_of<self.0>(client, r_in, r_out, a2);
+   │ ╰──────────────────────────────────────────────────────────────────^
+   │
+   =     at tests/sources/functional/closures/amm_example.move:255: create_noncompliant_fee_pool
+   =         account = <redacted>
+   =     at tests/sources/functional/closures/amm_example.move:257: create_noncompliant_fee_pool
+   =     at tests/sources/functional/closures/amm_example.move:28
+
+error: data invariant does not hold
+   ┌─ tests/sources/functional/closures/amm_example.move:36:9
+   │
+36 │ ╭         invariant forall S in *, client: address, r_in: u64, r_out: u64,
+37 │ │                         a1: u64, a2: u64:
+38 │ │             S.. |~ a1 <= a2 ==>
+39 │ │                 result_of<self.0>(client, r_in, r_out, a1)
+40 │ │                     <= result_of<self.0>(client, r_in, r_out, a2);
+   │ ╰──────────────────────────────────────────────────────────────────^
+   │
+   =     at tests/sources/functional/closures/amm_example.move:255: create_noncompliant_fee_pool
+   =         account = <redacted>
+   =     at tests/sources/functional/closures/amm_example.move:257: create_noncompliant_fee_pool
+   =     at tests/sources/functional/closures/amm_example.move:28
+   =     at tests/sources/functional/closures/amm_example.move:32
+   =     at tests/sources/functional/closures/amm_example.move:36
+
+error: data invariant does not hold
+   ┌─ tests/sources/functional/closures/amm_example.move:43:9
+   │
+43 │ ╭         invariant forall S in *, client: address, r_in: u64, r_out: u64, amt: u64:
+44 │ │             S.. |~ (r_in + amt) * (r_out - result_of<self.0>(client, r_in, r_out, amt)) >= r_in * r_out;
+   │ ╰────────────────────────────────────────────────────────────────────────────────────────────────────────^
+   │
+   =     at tests/sources/functional/closures/amm_example.move:255: create_noncompliant_fee_pool
+   =         account = <redacted>
+   =     at tests/sources/functional/closures/amm_example.move:257: create_noncompliant_fee_pool
+   =     at tests/sources/functional/closures/amm_example.move:28
+   =     at tests/sources/functional/closures/amm_example.move:32
+   =     at tests/sources/functional/closures/amm_example.move:36
+   =     at tests/sources/functional/closures/amm_example.move:43

--- a/third_party/move/move-prover/tests/sources/functional/closures/amm_example.move
+++ b/third_party/move/move-prover/tests/sources/functional/closures/amm_example.move
@@ -1,0 +1,267 @@
+// Copyright © Aptos Foundation
+// AMM (Automated Market Maker) example demonstrating closure invariants
+// carried by a wrapper struct `PricingStrategy`. The invariants are
+// attached to the wrapper, so pack time is the proof obligation point.
+// The Pool simply stores a `PricingStrategy`; creators of a pool only
+// need to supply a valid pricing strategy. The compiler automatically
+// inserts the wrapper when a bare pricing function is passed to
+// `create_pool`, so callers do not need to pack it explicitly.
+//
+// flag: --split-vcs-by-assert
+
+module 0x42::amm {
+
+    // -------------------------------------------------------
+    // Pricing strategy wrapper carrying the pool invariants
+    // -------------------------------------------------------
+
+    /// Wraps a pricing function with the invariants every AMM pool
+    /// expects. Packing a `PricingStrategy` verifies those invariants
+    /// against the concrete pricing function; callers of `create_pool`
+    /// then only need to supply a valid `PricingStrategy`.
+    struct PricingStrategy(|address, u64, u64, u64|u64) has store, copy, drop;
+
+    spec PricingStrategy {
+        modifies_of<self.0> *;
+
+        // No-abort: the pricing function must never abort, for any inputs.
+        invariant forall S in *, client: address, r_in: u64, r_out: u64, amt: u64:
+            S |~ !aborts_of<self.0>(client, r_in, r_out, amt);
+
+        // Safety: output never exceeds the output reserve.
+        invariant forall S in *, client: address, r_in: u64, r_out: u64, amt: u64:
+            S.. |~ result_of<self.0>(client, r_in, r_out, amt) <= r_out;
+
+        // Monotonicity: more input yields at least as much output.
+        invariant forall S in *, client: address, r_in: u64, r_out: u64,
+                        a1: u64, a2: u64:
+            S.. |~ a1 <= a2 ==>
+                result_of<self.0>(client, r_in, r_out, a1)
+                    <= result_of<self.0>(client, r_in, r_out, a2);
+
+        // Constant product preservation: the product of reserves never decreases.
+        invariant forall S in *, client: address, r_in: u64, r_out: u64, amt: u64:
+            S.. |~ (r_in + amt) * (r_out - result_of<self.0>(client, r_in, r_out, amt)) >= r_in * r_out;
+
+    }
+
+    // -------------------------------------------------------
+    // Pool
+    // -------------------------------------------------------
+
+    /// A liquidity pool holding reserves of two tokens and a pricing strategy.
+    struct Pool has key {
+        reserve_x: u64,
+        reserve_y: u64,
+        pricing: PricingStrategy,
+    }
+
+    /// Per-client fee in basis points (e.g. 300 = 3%).
+    struct Fee has key {
+        bps: u64,
+    }
+
+    const E_ZERO_AMOUNT: u64 = 1;
+    const E_INSUFFICIENT_LIQUIDITY: u64 = 2;
+
+    // -------------------------------------------------------
+    // Concrete pricing curves
+    // -------------------------------------------------------
+
+    /// Constant-product pricing (Uniswap v2 style):
+    ///   amount_out = reserve_out * amount_in / (reserve_in + amount_in)
+    /// Guards the degenerate (0, 0) case so the function never aborts,
+    /// satisfying the PricingStrategy no-abort invariant.
+    public fun constant_product(
+        _client: address, reserve_in: u64, reserve_out: u64, amount_in: u64,
+    ): u64 {
+        if (reserve_in == 0 && amount_in == 0) {
+            0
+        } else {
+            let num = (reserve_out as u128) * (amount_in as u128);
+            let den = (reserve_in as u128) + (amount_in as u128);
+            ((num / den) as u64)
+        }
+    }
+    spec constant_product {
+        pragma opaque;
+        // Never aborts.
+        aborts_if false;
+        // Degenerate empty-pool, zero-input case produces no swap.
+        ensures reserve_in == 0 && amount_in == 0 ==> result == 0;
+        // Otherwise result follows the constant-product formula (integer division).
+        ensures !(reserve_in == 0 && amount_in == 0)
+            ==> result == reserve_out * amount_in / (reserve_in + amount_in);
+        // Output never exceeds the output reserve.
+        ensures result <= reserve_out;
+        // Strict sub-reserve: when both reserves and input are positive,
+        // the pool can never be fully drained by a single swap.
+        ensures reserve_in > 0 && reserve_out > 0 && amount_in > 0
+            ==> result < reserve_out;
+    }
+
+
+    /// Default fee (500 bps = 5%) used when the client has no `Fee` resource
+    /// or the stored value is out of range.
+    const DEFAULT_FEE_BPS: u64 = 500;
+
+    /// Constant-product pricing with a per-client fee (compliant variant).
+    /// Uses `Fee[client].bps` when the client has a valid `Fee` resource,
+    /// otherwise falls back to `DEFAULT_FEE_BPS`. Guards the division so
+    /// the function never aborts, satisfying the PricingStrategy invariants.
+    public fun constant_product_with_fee(
+        client: address, reserve_in: u64, reserve_out: u64, amount_in: u64,
+    ): u64 {
+        let fee_bps = if (exists<Fee>(client) && Fee[client].bps <= 10000) {
+            Fee[client].bps
+        } else {
+            DEFAULT_FEE_BPS
+        };
+        let effective_in = (amount_in as u128) * (10000 - fee_bps as u128) / 10000;
+        if (effective_in == 0) {
+            0
+        } else {
+            let num = (reserve_out as u128) * effective_in;
+            let den = (reserve_in as u128) + effective_in;
+            ((num / den) as u64)
+        }
+    }
+    spec constant_product_with_fee {
+        pragma opaque;
+        // Never aborts: the default covers missing/invalid fee configuration,
+        // and the effective-input check avoids division by zero.
+        aborts_if false;
+        let fee_bps = if (exists<Fee>(client) && Fee[client].bps <= 10000) {
+            Fee[client].bps
+        } else {
+            DEFAULT_FEE_BPS
+        };
+        let effective_in = amount_in * (10000 - fee_bps) / 10000;
+        // Zero effective input (small amount fully consumed by the fee)
+        // produces no swap.
+        ensures effective_in == 0
+            ==> result == 0;
+        // Otherwise apply the constant-product formula to the fee-adjusted input.
+        ensures effective_in > 0
+            ==> result == reserve_out * effective_in / (reserve_in + effective_in);
+        // Output never exceeds the output reserve.
+        ensures result <= reserve_out;
+        // Constant-product preservation: the PricingStrategy invariant, stated
+        // directly so callers of `create_pool` do not need to re-derive it from
+        // the fee-adjusted input formula.
+        ensures (reserve_in + amount_in) * (reserve_out - result)
+            >= reserve_in * reserve_out;
+    } proof {
+        // Help the solver discharge the nonlinear ensures above by splitting
+        // on whether the fee has consumed all of amount_in. Each variant
+        // presents a linear obligation to the solver.
+        split effective_in == 0;
+    }
+
+    /// Constant-product pricing with a per-client fee (non-compliant variant).
+    /// Reads `Fee[client].bps` directly and aborts when the client has no
+    /// `Fee` resource — violating the PricingStrategy no-abort invariant.
+    public fun constant_product_with_fee_non_compliant(
+        client: address, reserve_in: u64, reserve_out: u64, amount_in: u64,
+    ): u64 {
+        let fee_bps = Fee[client].bps;
+        let effective_in = (amount_in as u128) * (10000 - fee_bps as u128) / 10000;
+        let num = (reserve_out as u128) * effective_in;
+        let den = (reserve_in as u128) + effective_in;
+        ((num / den) as u64)
+    }
+    spec constant_product_with_fee_non_compliant {
+        pragma opaque;
+        // NON-COMPLIANT: Aborts if client has no fee configuration.
+        aborts_if !exists<Fee>(client);
+        // NON-COMPLIANT: Aborts if fee exceeds 100% (10000 basis points).
+        aborts_if Fee[client].bps > 10000;
+        let fee_bps = Fee[client].bps;
+        let effective_in = amount_in * (10000 - fee_bps) / 10000;
+        // Aborts on division by zero when reserve and effective input are both zero.
+        aborts_if reserve_in + effective_in == 0;
+        // Result follows the constant-product formula applied to the
+        // fee-adjusted input (the fee reduces the effective swap amount).
+        ensures result == reserve_out * effective_in / (reserve_in + effective_in);
+        // Output never exceeds the output reserve.
+        ensures result <= reserve_out;
+    }
+
+    // -------------------------------------------------------
+    // Pool operations
+    // -------------------------------------------------------
+
+    /// Create a pool with a given pricing strategy. Because the
+    /// `PricingStrategy` invariants were already discharged at pack time,
+    /// `create_pool` itself has no further preconditions on `pricing`.
+    public fun create_pool(
+        account: &signer,
+        reserve_x: u64,
+        reserve_y: u64,
+        pricing: PricingStrategy,
+    ) {
+        move_to(account, Pool { reserve_x, reserve_y, pricing });
+    }
+
+    /// Swap `amount_in` of token X for token Y.
+    /// The output is determined by the pool's stored pricing function.
+    public fun swap(pool: &mut Pool, client: address, amount_in: u64): u64 {
+        assert!(amount_in > 0, E_ZERO_AMOUNT);
+        let amount_out = (pool.pricing)(
+            client, pool.reserve_x, pool.reserve_y, amount_in,
+        );
+        assert!(amount_out <= pool.reserve_y, E_INSUFFICIENT_LIQUIDITY);
+        pool.reserve_x = pool.reserve_x + amount_in;
+        pool.reserve_y = pool.reserve_y - amount_out;
+        amount_out
+    }
+    spec swap {
+        // Aborts if the swap amount is zero.
+        aborts_if amount_in == 0;
+        // Aborts on reserve overflow. The pricing function itself cannot abort
+        // because `amount_in > 0` and the PricingStrategy no-abort invariant.
+        aborts_if pool.reserve_x + amount_in > MAX_U64;
+        ensures result == result_of<pool.pricing.0>(client, old(pool).reserve_x, old(pool).reserve_y, amount_in);
+        // Reserve x increases by the input amount.
+        ensures pool.reserve_x == old(pool.reserve_x) + amount_in;
+        // Reserve y decreases by the output amount.
+        ensures pool.reserve_y == old(pool.reserve_y) - result;
+        // Output is bounded by the original y reserve (PricingStrategy safety invariant).
+        ensures result <= old(pool.reserve_y);
+        // Constant-product preservation: the product of reserves never decreases
+        // (PricingStrategy closure invariant applied to the pricing call).
+        ensures pool.reserve_x * pool.reserve_y
+            >= old(pool.reserve_x) * old(pool.reserve_y);
+    }
+
+    // -------------------------------------------------------
+    // Usage examples
+    // -------------------------------------------------------
+    // In each call below the compiler automatically wraps the bare
+    // pricing function as `PricingStrategy(..)`, so the pack-time
+    // invariant check is what succeeds or fails.
+
+    /// Create a pool using the fee-free constant-product curve.
+    /// This satisfies all PricingStrategy invariants: constant_product
+    /// never aborts when amount_in > 0 (since reserve_in + amount_in > 0).
+    fun create_constant_product_pool(account: &signer) {
+        create_pool(account, 1000, 1000, constant_product);
+    }
+
+    /// Create a pool using the non-compliant fee-based pricing curve.
+    /// This should FAIL verification at pack time: the non-compliant
+    /// variant aborts when the client has no Fee resource, violating
+    /// the PricingStrategy no-abort invariant.
+    fun create_noncompliant_fee_pool(account: &signer) {
+        // error: data invariant does not hold
+        create_pool(account, 1000, 1000, constant_product_with_fee_non_compliant);
+    }
+
+    /// Create a pool using the compliant fee-based pricing curve.
+    /// The compliant variant defaults to `DEFAULT_FEE_BPS` when the
+    /// client has no `Fee` resource, so the PricingStrategy no-abort
+    /// invariant is satisfied.
+    fun create_compliant_fee_pool(account: &signer) {
+        create_pool(account, 1000, 1000, constant_product_with_fee);
+    }
+}

--- a/third_party/move/move-prover/tests/sources/functional/closures/amm_example_notes.md
+++ b/third_party/move/move-prover/tests/sources/functional/closures/amm_example_notes.md
@@ -1,0 +1,96 @@
+# AMM example — "pollution" investigation notes
+
+Companion to `amm_example.move`. Records what we tried to explain and
+eliminate the timeout on `create_compliant_fee_pool` when the procedure
+is verified as part of the full module rather than in isolation.
+
+## Symptom
+
+`create_compliant_fee_pool` verifies in ~1.2 s in isolation but times
+out at ~40 s when its VC sits alongside the rest of the AMM module.
+Same solver, same VC — something in the full-module context is slowing
+Z3 down. We labeled this "pollution."
+
+## What we tried
+
+### 1. Encoding BP evaluators as uninterpreted + per-variant axioms (landed)
+
+Replaced the original `function {:inline}` BP evaluator (with
+`if f is V then ... else` dispatch) with uninterpreted
+`$ensures_of'F'` / `$aborts_of'F'` / `$requires_of'F'` plus per-variant
+axioms:
+
+- Closures: trigger `{$ensures_of(…, $closure'V'_mask(c0..ck), …)}`,
+  constructor-keyed, no guard.
+- Fun-param: trigger `{$ensures_of(…, $param'F$p'(), …)}`, nullary
+  ground constructor.
+- Struct-field: guarded form `{$ensures_of(…, f, …)}` with
+  `(f is $struct_field'…') ==>`.
+
+Motivation: stop inlining every variant's spec body at every evaluator
+use-site. **Necessary and kept.** Solved cross-variant term leakage in
+the `swap` VC.
+
+### 2. `--split-vcs-by-assert` flag (landed as opt-in)
+
+Emit one VC per assert instead of one monolithic VC per procedure.
+Cuts full-module time 85 s → 35 s single core. **Symptom mitigation,
+not a root-cause fix.**
+
+### 3. `--error-limit` flag (landed)
+
+Makes diagnostic behavior predictable under split-VCs.
+
+### 4. Hypothesis: fun-param variant axioms leak because they're ground
+
+`$param'F$p'()` is nullary, so Z3 materializes its axiom body even in
+VCs that never use it. Plausible but never cleanly proven — seed
+sweeps confounded the measurement.
+
+### 5. Hypothesis: datatype size matters (5-variant vs 2-variant BPL)
+
+Shrank the fun-type datatype to only variants reachable from the
+procedure under test. **Seed sweep (10 seeds) showed 5/10 timeouts on
+both 2-variant and 5-variant BPLs.** Datatype size is not the dominant
+factor. This invalidated the "nonlinear CP axioms from unrelated
+variants fire and blow up" narrative as stated.
+
+### 6. `smt.random_seed` as confounder — major finding
+
+We had been running manual Boogie invocations without
+`smt.random_seed=1`, the flag the prover actually passes. Timings were
+wildly inconsistent across runs. Many earlier "pollution" claims were
+seed noise. After fixing this, the real picture emerged: same VC, same
+encoding, timeout rate depends heavily on the seed — Z3's nonlinear
+arithmetic solver takes very different search paths per seed.
+
+### 7. Prototype: un-inline closure BPs (reverted)
+
+Closure `$bp_*'F'` functions were still `function {:inline}` with full
+spec body, asymmetric to the fun-param/struct-field uninterpreted +
+axiom form. Hypothesis: inlining forces the nonlinear CP-preservation
+body into the E-graph everywhere, driving NLA search. Converted
+`$bp_requires_of'F'`, `$bp_aborts_of'F'` to uninterpreted + trigger-
+keyed axioms; `$bp_ensures_of'F'` to a thin wrapper over uninterpreted
+`$bp_ensures_of_result'F'` with a result-term-keyed definitional
+axiom. **Seed sweep (10 seeds): new encoding 8/10 timeouts, old 5/10.**
+Made it worse. Reverted.
+
+## Where we stand
+
+- The "pollution = cross-variant constructor dispatch" story was
+  correct early on and fixed by (1).
+- The remaining timeout is **not** obviously explained by inlining,
+  datatype size, or variant-axiom leakage. It's dominated by Z3's
+  nonlinear search cost, whose cost function is seed-sensitive.
+- `--split-vcs-by-assert` reliably masks it at the cost of a flag.
+
+## Open questions
+
+- Is the remaining slowdown really QI/term-database related at all, or
+  is it Z3's nonlinear tactic cost that happens to correlate with
+  module size via unrelated path effects (e.g., more hypotheses in
+  scope)?
+- Would we benefit from QI tracing on the full-module vs isolated VCs
+  to measure actual instantiation counts on suspected culprits, rather
+  than reasoning from encoding shape?

--- a/third_party/move/move-prover/tests/sources/functional/closures/result_of_old_label.move
+++ b/third_party/move/move-prover/tests/sources/functional/closures/result_of_old_label.move
@@ -1,0 +1,44 @@
+// Copyright © Aptos Foundation
+// A two-state behavioral predicate (`result_of<r.f>(addr)`) in an
+// `ensures` on a function that takes a struct-field closure requires
+// the pre-state memory label to be saved at procedure entry, so that
+// the `$result_of` evaluator's `old_*` memory slot refers to the
+// function's entry state.
+//
+// `modifies_of<f> *;` on the struct spec gives the BP evaluator a
+// (old, cur) memory pair — the signature shape that requires this
+// pre-state save. A `reads_of`-only signature has a single memory
+// slot and does not need it.
+
+module 0x42::result_of_old_label {
+    struct Source has key, drop {
+        value: u64,
+    }
+
+    struct Reader has key, drop {
+        f: |address|u64 has copy+store+drop,
+    }
+    spec Reader {
+        modifies_of<f> *;
+        invariant forall a: address: !aborts_of<f>(a);
+    }
+
+    #[persistent]
+    fun safe_read(addr: address): u64 {
+        if (exists<Source>(addr)) { Source[addr].value } else { 0 }
+    }
+    spec safe_read {
+        pragma opaque;
+        aborts_if false;
+        ensures exists<Source>(addr) ==> result == Source[addr].value;
+        ensures !exists<Source>(addr) ==> result == 0;
+    }
+
+    public fun use_reader(r: &Reader, addr: address): u64 {
+        (r.f)(addr)
+    }
+    spec use_reader {
+        aborts_if false;
+        ensures result == result_of<r.f>(addr);
+    }
+}

--- a/third_party/move/move-prover/tests/sources/functional/state_labels/state_domain_quant.exp
+++ b/third_party/move/move-prover/tests/sources/functional/state_labels/state_domain_quant.exp
@@ -1,0 +1,6 @@
+Move prover returns: exiting with compilation errors
+error: unused quantified state label `S`; state domain variables must be used as state labels (`|~`) in the body
+   ┌─ tests/sources/functional/state_labels/state_domain_quant.move:82:25
+   │
+82 │         requires forall S in *, x: u64: x > 0; // error: unused quantified state label
+   │                         ^

--- a/third_party/move/move-prover/tests/sources/functional/state_labels/state_domain_quant.move
+++ b/third_party/move/move-prover/tests/sources/functional/state_labels/state_domain_quant.move
@@ -1,0 +1,84 @@
+// Copyright (c) Aptos Foundation
+// Tests for state-domain quantification: `forall S in *: S |~ P`
+//
+// State-domain quantification allows universally quantifying over all
+// possible memory states, enabling properties like "f never aborts in
+// any state" rather than just "f doesn't abort in the current state".
+
+module 0x42::state_domain_quant {
+
+    struct Counter has key { value: u64 }
+
+    // =========================================================================
+    // Opaque helper functions
+    // =========================================================================
+
+    fun read_counter(addr: address): u64 acquires Counter {
+        Counter[addr].value
+    }
+    spec read_counter {
+        pragma opaque;
+        ensures result == Counter[addr].value;
+        aborts_if !exists<Counter>(addr);
+    }
+
+    fun inc_counter(addr: address) acquires Counter {
+        let c = &mut Counter[addr];
+        c.value = c.value + 1;
+    }
+    spec inc_counter {
+        pragma opaque;
+        modifies Counter[addr];
+        ensures Counter[addr].value == old(Counter[addr].value) + 1;
+        aborts_if !exists<Counter>(addr);
+        aborts_if Counter[addr].value + 1 > MAX_U64;
+    }
+
+    // =========================================================================
+    // Higher-order wrappers with state-domain quantification
+    // =========================================================================
+
+    /// Apply a read-only function. Its spec states that for ANY state,
+    /// the function does not abort when Counter exists with a valid value.
+    fun apply_reader(
+        f: |address| u64,
+        addr: address,
+    ): u64 {
+        f(addr)
+    }
+    spec apply_reader {
+        pragma opaque;
+        reads_of<f> Counter;
+        modifies_of<f> *;
+        // Universal state quantification: f does not abort in ANY state
+        // where Counter exists at addr.
+        ensures ensures_of<f>(addr, result);
+        aborts_if aborts_of<f>(addr);
+    }
+
+    /// Test: call apply_reader with read_counter.
+    fun test_reader(addr: address): u64 acquires Counter {
+        apply_reader(read_counter, addr)
+    }
+    spec test_reader {
+        ensures result == Counter[addr].value;
+        aborts_if !exists<Counter>(addr);
+    }
+
+    // =========================================================================
+    // Error cases: unused state-domain variable
+    // =========================================================================
+
+    fun dummy_pure(x: u64): bool { x > 0 }
+    spec dummy_pure {
+        ensures result == (x > 0);
+    }
+
+    fun test_unused_state_label() {
+        let _ = dummy_pure(1);
+    }
+    spec test_unused_state_label {
+        // Error: S is not used as a state label in the body
+        requires forall S in *, x: u64: x > 0; // error: unused quantified state label
+    }
+}

--- a/third_party/move/tools/move-abigen/src/abigen.rs
+++ b/third_party/move/tools/move-abigen/src/abigen.rs
@@ -335,6 +335,7 @@ impl<'env> Abigen<'env> {
             | Fun(..)
             | TypeDomain(_)
             | ResourceDomain(..)
+            | StateDomain
             | Error
             | Var(_)
             | Reference(_, _) => return Ok(None),

--- a/third_party/move/tools/move-linter/src/model_ast_lints/deprecated_usage.rs
+++ b/third_party/move/tools/move-linter/src/model_ast_lints/deprecated_usage.rs
@@ -131,8 +131,8 @@ fn check_type_for_deprecated(
             check_type_for_deprecated(env, args, loc, report_fn);
             check_type_for_deprecated(env, result, loc, report_fn);
         },
-        // TypeDomain and ResourceDomain only appear in specifications; skip deprecation checks.
-        Type::TypeDomain(..) | Type::ResourceDomain(..) => {},
+        // TypeDomain, ResourceDomain, and StateDomain only appear in specifications; skip deprecation checks.
+        Type::TypeDomain(..) | Type::ResourceDomain(..) | Type::StateDomain => {},
         Type::Primitive(_) | Type::TypeParameter(_) | Type::Error | Type::Var(_) => {},
     }
 }


### PR DESCRIPTION
## Description

This is a collection of fixes coming out of trying to make an automated-market-maker example work, in preparation for the potential FMCAD paper.

The AMM (`amm_example.move`) is a UniSwap-style pool with a dynamic, configurable pricing strategy invoked via dynamic dispatch. A valid strategy is characterized by multiple conditions expressed as data invariants:

```move
struct PricingStrategy(|address, u64, u64, u64|u64) has store, copy, drop;
spec PricingStrategy {
    modifies_of<self.0> *;

    // No-abort: the pricing function must never abort, for any inputs.
    invariant forall S in *, client: address, r_in: u64, r_out: u64, amt: u64:
            S |~ !aborts_of<self.0>(client, r_in, r_out, amt);

    // Safety: output never exceeds the output reserve.
    invariant forall S in *, client: address, r_in: u64, r_out: u64, amt: u64:
            S.. |~ result_of<self.0>(client, r_in, r_out, amt) <= r_out;

    // Monotonicity: more input yields at least as much output.
    invariant forall S in *, client: address, r_in: u64, r_out: u64, a1: u64, a2: u64:
            S.. |~ a1 <= a2 ==>
                result_of<self.0>(client, r_in, r_out, a1)
                    <= result_of<self.0>(client, r_in, r_out, a2);

    // Constant product preservation: the product of reserves never decreases.
    invariant forall S in *, client: address, r_in: u64, r_out: u64, amt: u64:
            S.. |~ (r_in + amt) * (r_out - result_of<self.0>(client, r_in, r_out, amt)) >= r_in * r_out;
}
```

These invariants are (a) injected at usage site, allowing the caller of a stored function to reason about results, and (b) verified at pack or mutation side.

The general approach worked to some extent before, but had multiple issues:

- **Missing state quantification.** We need to express `forall S in *: S |~ !aborts_of<f>(x)`. Without an explicit state label context, the predicate would be evaluated in the current state — but we want to express something about `f` that holds for every state. This motivates a language extension in the frontend supporting quantifiers over state labels. With the current architecture, this has cascading consequences: state labels now need to become typed objects, so a new type `Type::StateDomain` is introduced for those labels.
- **Timeouts.** A number of optimizations are introduced to Boogie/Z3 translation to make verification of the example tractable. Verification of the example still takes long and times out without the newly added flag `--split-vcs-by-assert`. Some notes about the experiments live in `amm_example_notes.md`.

## How Has This Been Tested?

- New functional test `tests/sources/functional/closures/amm_example.move` exercising the end-to-end AMM use case with dynamic dispatch and data invariants over stored function values.
- New functional test `tests/sources/functional/state_labels/state_domain_quant.move` covering the new quantifier-over-state-labels language feature.
- Updates to existing spec-instrumentation baselines (`if_else_let.exp`, `post.exp`).
- Full move-prover test suite.

## Key Changes

- **Frontend extension for state-domain quantification.** Parser/expansion changes in `legacy-move-compiler/src/parser/syntax.rs` and `move-compiler-v2/src/expansion/translate.rs`; the new `Type::StateDomain` in `move-model/src/ty.rs`, along with builder changes in `exp_builder.rs` and `builtins.rs`.
- **Bytecode translator rework.** The bulk of the diff is in `boogie-backend/src/bytecode_translator.rs` (~1.3k lines added). 
- **Spec instrumentation.** Changes in `bytecode-pipeline/src/spec_instrumentation.rs` and the mono-analysis updates for closure/fun-info handling.
- **New `--split-vcs-by-assert` flag** added in `boogie-backend/src/options.rs` and threaded through the translator.

## Type of Change
- [x] New feature
- [x] Bug fix
- [x] Performance improvement

## Which Components or Systems Does This Change Impact?
- [x] Move/Aptos Virtual Machine
- [x] Move Compiler
- [x] Other (specify): Move Prover

---

🤖 Co-authored with [Claude Code](https://claude.com/claude-code) (Claude Opus 4.7, 1M context).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk due to a new spec-language feature (`forall S in *`) plus substantial changes to Move Prover/Boogie translation for behavioral predicates, memory labeling, and instrumentation, which can affect soundness and verification behavior across many packages.
> 
> **Overview**
> Adds **universal state quantification** to Move specs via `forall S in *` by introducing `Type::StateDomain`/`Operation::StateDomain`, parsing `*` as a state-domain range, and updating the model, builder, sourcifier, and assorted compiler/prover passes to type-check and print these quantifiers.
> 
> Reworks Move Prover handling of **behavioral predicates and dynamic dispatch**: the Boogie backend now encodes predicate evaluators as uninterpreted functions constrained by guarded axioms (reducing solver blowups), saves/threads correct pre/post-state memory for `ensures_of`/`result_of`, and adds checks to error when predicate memory arguments would reference undeclared snapshots (with new tracking of declared memory vars and explicit exclusion of user-quantified state labels from implicit existentials).
> 
> Extends prover configuration and tooling by threading new flags `split_vcs_by_assert` and `error_limit` from `move-flow`’s `move_package_verify` tool through prover/Boogie options (emitting `-vcsSplitOnEveryAssert` and `-errorLimit`), adjusts spec instrumentation to avoid proof-block forks during inference and inline spec-lets inside proof actions for stability, fixes inference/sourcifier interactions with `proof { ... }` blocks, and updates/extends test baselines (including a new AMM dynamic-dispatch functional test).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bbed04f4fcdad789d84a5ca0f6f7c202f223ea47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->