### PR TITLE
[vm] Remove MoveVmExt pass-through wrapper

### DIFF
--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -19,7 +19,7 @@ use crate::{
             },
             view_with_change_set::ExecutorViewWithChangeSet,
         },
-        AptosMoveResolver, AsExecutorView, AsResourceGroupView, MoveVmExt, SessionExt, SessionId,
+        AptosMoveResolver, AsExecutorView, AsResourceGroupView, SessionExt, SessionId,
         UserTransactionContext,
     },
     sharded_block_executor::{executor_client::ExecutorClient, ShardedBlockExecutor},
@@ -285,7 +285,7 @@ pub(crate) fn get_or_vm_startup_failure<'a, T>(
 
 pub struct AptosVM {
     is_simulation: bool,
-    move_vm: MoveVmExt,
+    env: AptosEnvironment,
     /// If true, user payloads are allowed not to run extra checks and instead trace execution. If
     /// so, Block-STM replays the trace and performs these checks at post-commit time once. Note
     /// that checks might still be performed in-place based on a heuristic such as payload type.
@@ -299,7 +299,7 @@ impl AptosVM {
     pub fn new(env: &AptosEnvironment) -> Self {
         Self {
             is_simulation: false,
-            move_vm: MoveVmExt::new(env),
+            env: env.clone(),
             // There is no tracing by default because it can only be done if there is access to
             // Block-STM.
             async_runtime_checks_enabled: false,
@@ -322,33 +322,39 @@ impl AptosVM {
         session_id: SessionId,
         user_transaction_context_opt: Option<UserTransactionContext>,
     ) -> SessionExt<'r, R> {
-        self.move_vm
-            .new_session(resolver, session_id, user_transaction_context_opt)
+        SessionExt::new(
+            session_id,
+            self.env.chain_id(),
+            self.env.features(),
+            self.env.vm_config(),
+            user_transaction_context_opt,
+            resolver,
+        )
     }
 
     #[inline(always)]
     pub(crate) fn features(&self) -> &Features {
-        self.move_vm.env.features()
+        self.env.features()
     }
 
     #[inline(always)]
     pub(crate) fn timed_features(&self) -> &TimedFeatures {
-        self.move_vm.env.timed_features()
+        self.env.timed_features()
     }
 
     #[inline(always)]
     fn deserializer_config(&self) -> &DeserializerConfig {
-        &self.move_vm.env.vm_config().deserializer_config
+        &self.env.vm_config().deserializer_config
     }
 
     #[inline(always)]
     fn chain_id(&self) -> ChainId {
-        self.move_vm.env.chain_id()
+        self.env.chain_id()
     }
 
     #[inline(always)]
     pub(crate) fn gas_feature_version(&self) -> u64 {
-        self.move_vm.env.gas_feature_version()
+        self.env.gas_feature_version()
     }
 
     #[inline(always)]
@@ -356,7 +362,7 @@ impl AptosVM {
         &self,
         log_context: &AdapterLogSchema,
     ) -> Result<&AptosGasParameters, VMStatus> {
-        get_or_vm_startup_failure(self.move_vm.env.gas_params(), log_context)
+        get_or_vm_startup_failure(self.env.gas_params(), log_context)
     }
 
     #[inline(always)]
@@ -364,17 +370,17 @@ impl AptosVM {
         &self,
         log_context: &AdapterLogSchema,
     ) -> Result<&StorageGasParameters, VMStatus> {
-        get_or_vm_startup_failure(self.move_vm.env.storage_gas_params(), log_context)
+        get_or_vm_startup_failure(self.env.storage_gas_params(), log_context)
     }
 
     #[inline(always)]
     pub fn runtime_environment(&self) -> &RuntimeEnvironment {
-        self.move_vm.env.runtime_environment()
+        self.env.runtime_environment()
     }
 
     #[inline(always)]
     pub fn environment(&self) -> AptosEnvironment {
-        self.move_vm.env.clone()
+        self.env.clone()
     }
 
     /// Returns true if runtime checks for this transaction should be performed asynchronously,
@@ -3700,7 +3706,7 @@ pub(crate) fn should_create_account_resource(
 
 #[cfg(test)]
 mod tests {
-    use crate::{move_vm_ext::MoveVmExt, AptosVM};
+    use crate::AptosVM;
     use aptos_types::{
         account_address::AccountAddress,
         account_config::{NEW_EPOCH_EVENT_MOVE_TYPE_TAG, NEW_EPOCH_EVENT_V2_MOVE_TYPE_TAG},
@@ -3715,8 +3721,6 @@ mod tests {
 
         assert_send::<AptosVM>();
         assert_sync::<AptosVM>();
-        assert_send::<MoveVmExt>();
-        assert_sync::<MoveVmExt>();
     }
 
     #[test]

--- a/aptos-move/aptos-vm/src/move_vm_ext/mod.rs
+++ b/aptos-move/aptos-vm/src/move_vm_ext/mod.rs
@@ -11,7 +11,7 @@ pub(crate) mod write_op_converter;
 pub use crate::move_vm_ext::{
     resolver::{AptosMoveResolver, AsExecutorView, AsResourceGroupView, ResourceGroupResolver},
     session::{convert_modules_into_write_ops, SessionExt},
-    vm::{GenesisMoveVm, GenesisRuntimeBuilder, MoveVmExt},
+    vm::{GenesisMoveVm, GenesisRuntimeBuilder},
 };
 use aptos_types::state_store::state_key::StateKey;
 pub use aptos_types::transaction::user_transaction_context::UserTransactionContext;

--- a/aptos-move/aptos-vm/src/move_vm_ext/vm.rs
+++ b/aptos-move/aptos-vm/src/move_vm_ext/vm.rs
@@ -8,10 +8,8 @@ use aptos_native_interface::SafeNativeBuilder;
 use aptos_types::{
     chain_id::ChainId,
     on_chain_config::{Features, TimedFeaturesBuilder},
-    transaction::user_transaction_context::UserTransactionContext,
 };
 use aptos_vm_environment::{
-    environment::AptosEnvironment,
     natives::aptos_natives_with_builder,
     prod_configs::{aptos_default_ty_builder, aptos_prod_vm_config},
 };
@@ -110,31 +108,5 @@ impl GenesisMoveVm {
     /// metered, there are no change set (storage) costs.
     pub fn genesis_change_set_configs(&self) -> ChangeSetConfigs {
         ChangeSetConfigs::unlimited_at_gas_feature_version(LATEST_GAS_FEATURE_VERSION)
-    }
-}
-
-pub struct MoveVmExt {
-    pub(crate) env: AptosEnvironment,
-}
-
-impl MoveVmExt {
-    pub fn new(env: &AptosEnvironment) -> Self {
-        Self { env: env.clone() }
-    }
-
-    pub fn new_session<'r, R: AptosMoveResolver>(
-        &self,
-        resolver: &'r R,
-        session_id: SessionId,
-        maybe_user_transaction_context: Option<UserTransactionContext>,
-    ) -> SessionExt<'r, R> {
-        SessionExt::new(
-            session_id,
-            self.env.chain_id(),
-            self.env.features(),
-            self.env.vm_config(),
-            maybe_user_transaction_context,
-            resolver,
-        )
     }
 }

--- a/aptos-move/e2e-move-tests/src/tests/code_publishing.rs
+++ b/aptos-move/e2e-move-tests/src/tests/code_publishing.rs
@@ -215,7 +215,7 @@ fn code_publishing_upgrade_fail_overlapping_module() {
 /// This test verifies that the cache incoherence bug on module upgrade is fixed. This bug
 /// exposes itself by that after module upgrade the old version of the module stays
 /// active until the MoveVM terminates. In order to workaround this until there is a better
-/// fix, we flush the cache in `MoveVmExt::new_session`. One can verify the fix by commenting
+/// fix, we flush the cache in `AptosVM::new_session`. One can verify the fix by commenting
 /// the flush operation out, then this test fails.
 ///
 /// TODO: for some reason this test did not capture a serious bug in `code::check_coexistence`.

--- a/aptos-move/e2e-tests/src/executor.rs
+++ b/aptos-move/e2e-tests/src/executor.rs
@@ -67,7 +67,7 @@ use aptos_vm::{
     block_executor::AptosVMBlockExecutorWrapper,
     data_cache::AsMoveResolver,
     gas::make_prod_gas_meter,
-    move_vm_ext::{AptosMoveResolver, MoveVmExt, SessionExt, SessionId},
+    move_vm_ext::{AptosMoveResolver, SessionExt, SessionId},
     AptosVM, VMValidator,
 };
 use aptos_vm_environment::environment::AptosEnvironment;
@@ -1389,7 +1389,7 @@ impl<O: OutputLogger> FakeExecutorImpl<O> {
 
         let env = AptosEnvironment::new(&self.state_store);
         let resolver = self.state_store.as_move_resolver();
-        let vm = MoveVmExt::new(&env);
+        let vm = AptosVM::new(&env);
         let module_storage = self.state_store.as_aptos_code_storage(&env);
 
         let mut i = 0;
@@ -1528,7 +1528,7 @@ impl<O: OutputLogger> FakeExecutorImpl<O> {
                 }),
             );
             let resolver = self.state_store.as_move_resolver();
-            let vm = MoveVmExt::new(&env);
+            let vm = AptosVM::new(&env);
 
             let module_storage = self.state_store.as_aptos_code_storage(&env);
             let mut session = vm.new_session(&resolver, SessionId::void(), None);
@@ -1591,7 +1591,7 @@ impl<O: OutputLogger> FakeExecutorImpl<O> {
         let (write_set, events) = {
             let env = AptosEnvironment::new(&self.state_store);
             let resolver = self.state_store.as_move_resolver();
-            let vm = MoveVmExt::new(&env);
+            let vm = AptosVM::new(&env);
 
             let module_storage = self.state_store.as_aptos_code_storage(&env);
             let mut session = vm.new_session(&resolver, SessionId::void(), None);
@@ -1637,7 +1637,7 @@ impl<O: OutputLogger> FakeExecutorImpl<O> {
     ) -> Result<(WriteSet, Vec<ContractEvent>), VMStatus> {
         let env = AptosEnvironment::new(&self.state_store);
         let resolver = self.state_store.as_move_resolver();
-        let vm = MoveVmExt::new(&env);
+        let vm = AptosVM::new(&env);
 
         let module_storage = self.state_store.as_aptos_code_storage(&env);
 
@@ -1681,7 +1681,7 @@ impl<O: OutputLogger> FakeExecutorImpl<O> {
     ) -> Result<SerializedReturnValues, VMStatus> {
         let env = AptosEnvironment::new(&self.state_store);
         let resolver = self.state_store.as_move_resolver();
-        let vm = MoveVmExt::new(&env);
+        let vm = AptosVM::new(&env);
 
         let module_storage = self.state_store.as_aptos_code_storage(&env);
 


### PR DESCRIPTION
## Description

`MoveVmExt `wrapped only an `AptosEnvironment` and exposed a single
non-trivial method (`new_session`) that unpacked env fields and called
`SessionExt::new`. It added no behavior and the name was misleading since
nothing about a `MoveVM` was being wrapped. Store `AptosEnvironment`
directly on `AptosVM` and inline the session construction. Call sites in
e2e-tests now use AptosVM::new(&env) which exposes an equivalent
new_session.

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that removes a pass-through wrapper and updates call sites; behavior should be unchanged aside from where `new_session` is constructed.
> 
> **Overview**
> **Removes the `MoveVmExt` pass-through wrapper** and stores `AptosEnvironment` directly on `AptosVM`.
> 
> `AptosVM::new_session` now constructs `SessionExt` directly from the stored environment, and references throughout `AptosVM` are updated to use `self.env` instead of `self.move_vm.env`. Call sites in e2e executor code are updated to create an `AptosVM` instead of `MoveVmExt`, and related exports/tests are cleaned up accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97c44e33cabf260e142689dacae66015d8f1ded6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->