### PR TITLE
Enforce non-zero API limits in config sanitizer to prevent invalid runtime states

### DIFF
--- a/config/src/config/api_config.rs
+++ b/config/src/config/api_config.rs
@@ -192,6 +192,51 @@ impl ConfigSanitizer for ApiConfig {
             ));
         }
 
+        // Validate basic API pagination properties
+        if api_config.max_transactions_page_size == 0 {
+            return Err(Error::ConfigSanitizerFailed(
+                sanitizer_name,
+                "max_transactions_page_size must be greater than 0".into(),
+            ));
+        }
+
+        if api_config.max_block_transactions_page_size == 0 {
+            return Err(Error::ConfigSanitizerFailed(
+                sanitizer_name,
+                "max_block_transactions_page_size must be greater than 0".into(),
+            ));
+        }
+
+        if api_config.max_events_page_size == 0 {
+            return Err(Error::ConfigSanitizerFailed(
+                sanitizer_name,
+                "max_events_page_size must be greater than 0".into(),
+            ));
+        }
+
+        if api_config.max_account_resources_page_size == 0 {
+            return Err(Error::ConfigSanitizerFailed(
+                sanitizer_name,
+                "max_account_resources_page_size must be greater than 0".into(),
+            ));
+        }
+
+        if api_config.max_account_modules_page_size == 0 {
+            return Err(Error::ConfigSanitizerFailed(
+                sanitizer_name,
+                "max_account_modules_page_size must be greater than 0".into(),
+            ));
+        }
+
+        if let Some(limit) = api_config.content_length_limit {
+            if limit == 0 {
+                return Err(Error::ConfigSanitizerFailed(
+                    sanitizer_name,
+                    "content_length_limit must be greater than 0 when set".into(),
+                ));
+            }
+        }
+
         // Sanitize the gas estimation config
         GasEstimationConfig::sanitize(node_config, node_type, chain_id)?;
 
@@ -306,5 +351,131 @@ mod tests {
             ApiConfig::sanitize(&node_config, NodeType::Validator, Some(ChainId::mainnet()))
                 .unwrap_err();
         assert!(matches!(error, Error::ConfigSanitizerFailed(_, _)));
+    }
+
+    #[test]
+    fn test_sanitize_zero_max_transactions_page_size() {
+        let node_config = NodeConfig {
+            api: ApiConfig {
+                enabled: true,
+                max_transactions_page_size: 0,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let error =
+            ApiConfig::sanitize(&node_config, NodeType::Validator, Some(ChainId::mainnet()))
+                .unwrap_err();
+        assert!(matches!(error, Error::ConfigSanitizerFailed(_, _)));
+    }
+
+    #[test]
+    fn test_sanitize_zero_max_block_transactions_page_size() {
+        let node_config = NodeConfig {
+            api: ApiConfig {
+                enabled: true,
+                max_block_transactions_page_size: 0,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let error =
+            ApiConfig::sanitize(&node_config, NodeType::Validator, Some(ChainId::mainnet()))
+                .unwrap_err();
+        assert!(matches!(error, Error::ConfigSanitizerFailed(_, _)));
+    }
+
+    #[test]
+    fn test_sanitize_zero_max_events_page_size() {
+        let node_config = NodeConfig {
+            api: ApiConfig {
+                enabled: true,
+                max_events_page_size: 0,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let error =
+            ApiConfig::sanitize(&node_config, NodeType::Validator, Some(ChainId::mainnet()))
+                .unwrap_err();
+        assert!(matches!(error, Error::ConfigSanitizerFailed(_, _)));
+    }
+
+    #[test]
+    fn test_sanitize_zero_max_account_resources_page_size() {
+        let node_config = NodeConfig {
+            api: ApiConfig {
+                enabled: true,
+                max_account_resources_page_size: 0,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let error =
+            ApiConfig::sanitize(&node_config, NodeType::Validator, Some(ChainId::mainnet()))
+                .unwrap_err();
+        assert!(matches!(error, Error::ConfigSanitizerFailed(_, _)));
+    }
+
+    #[test]
+    fn test_sanitize_zero_max_account_modules_page_size() {
+        let node_config = NodeConfig {
+            api: ApiConfig {
+                enabled: true,
+                max_account_modules_page_size: 0,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let error =
+            ApiConfig::sanitize(&node_config, NodeType::Validator, Some(ChainId::mainnet()))
+                .unwrap_err();
+        assert!(matches!(error, Error::ConfigSanitizerFailed(_, _)));
+    }
+
+    #[test]
+    fn test_sanitize_zero_content_length_limit() {
+        let node_config = NodeConfig {
+            api: ApiConfig {
+                enabled: true,
+                content_length_limit: Some(0),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let error =
+            ApiConfig::sanitize(&node_config, NodeType::Validator, Some(ChainId::mainnet()))
+                .unwrap_err();
+        match error {
+            Error::ConfigSanitizerFailed(_, message) => {
+                assert_eq!(message, "content_length_limit must be greater than 0 when set");
+            },
+            _ => panic!("unexpected error variant"),
+        }
+    }
+
+    #[test]
+    fn test_sanitize_valid_limits() {
+        let node_config = NodeConfig {
+            api: ApiConfig {
+                enabled: true,
+                max_transactions_page_size: 1,
+                max_block_transactions_page_size: 1,
+                max_events_page_size: 1,
+                max_account_resources_page_size: 1,
+                max_account_modules_page_size: 1,
+                content_length_limit: Some(1),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        ApiConfig::sanitize(&node_config, NodeType::Validator, Some(ChainId::mainnet())).unwrap();
     }
 }


### PR DESCRIPTION
## Description

This change enforces a missing configuration invariant in `ApiConfig::sanitize()`:

- All `max_*_page_size` values must be **> 0**
- `content_length_limit`, if set, must be **> 0**

### Motivation

Currently, zero values are accepted in API config and propagate into runtime, causing real failures:

- **Pagination failure**  
  `max_*_page_size = 0` results in computed limit `0`, which leads to invalid storage queries and can trigger internal errors for valid GET requests (e.g. `/v1/transactions`).

- **POST rejection**  
  `content_length_limit = 0` causes middleware to reject all non-empty POST requests (`PayloadTooLarge`), effectively disabling API functionality.

These are not valid operational modes and are not documented behaviors.

### What this change does

- Validates API limits at config load time (sanitizer boundary)
- Rejects invalid zero values early with clear, field-specific errors
- Prevents invalid states from entering runtime

This enforces an already-required invariant (`limit > 0`) rather than introducing new behavior.

---

## How Has This Been Tested?

- Added unit tests covering:
  - Each `max_*_page_size = 0` → fails sanitization
  - `content_length_limit = Some(0)` → fails sanitization with exact error message
  - Valid configurations → pass successfully

- Verified existing tests pass and no current configs rely on zero values

- Covered both:
  - ❌ Invalid configs (failure paths)
  - ✅ Valid configs (success paths)

---

## Key Areas to Review

- **`ApiConfig::sanitize()` changes**
  - Centralized validation for API limits
  - Follows existing sanitizer pattern (`ConfigSanitizerFailed`)

- **Invariant enforcement**
  - Ensures config-derived limits cannot collapse to zero at runtime
  - Prevents cross-module propagation of invalid values

- **Backward compatibility**
  - This is a fail-fast change: invalid configs are rejected at startup instead of causing runtime failures
  - Aligns with existing sanitizer behavior in the codebase

---

## Type of Change
- [ ] New feature
- [x] Bug fix
- [x] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [x] Tests

---

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [x] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

---

## Checklist
- [x] I have read and followed the CONTRIBUTING doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [x] I identified relevant areas for review
- [x] I tested both happy and unhappy paths
- [ ] I have made corresponding changes to documentation (not applicable)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking for any deployment that sets these limits to zero; otherwise low runtime risk since it only adds startup validation on full-node API config.
> 
> **Overview**
> **`ApiConfig::sanitize()`** now rejects invalid API limits when the REST API is enabled, using the existing `ConfigSanitizerFailed` pattern instead of allowing zero values into runtime.
> 
> All **`max_*_page_size`** fields (`max_transactions_page_size`, `max_block_transactions_page_size`, `max_events_page_size`, `max_account_resources_page_size`, `max_account_modules_page_size`) must be **> 0**. **`content_length_limit`**, when explicitly set, must also be **> 0** (unset/`None` is unchanged).
> 
> Unit tests cover each zero-value failure path, an exact message check for `content_length_limit`, and a passing case with minimal valid limits.
> 
> This is a **fail-fast at config load** change: nodes that previously started with zeros and hit broken pagination or POST middleware would now fail sanitization at startup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62091da5ec91016cd0e1f827006cefae03c25f0f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->