### PR TITLE
[compiler-v2] Do not inline callees that emit cross-module events

### DIFF
--- a/aptos-move/framework/src/extended_checks.rs
+++ b/aptos-move/framework/src/extended_checks.rs
@@ -861,7 +861,8 @@ impl ExtendedChecker<'_> {
         callee: QualifiedId<FunId>,
         type_inst: &[Type],
     ) {
-        if !self.is_function(callee, well_known::EVENT_EMIT) {
+        if !self.is_framework_function(callee) || !self.is_function(callee, well_known::EVENT_EMIT)
+        {
             return;
         }
         // We are looking at `0x1::event::emit<T>` and extracting the `T`
@@ -970,7 +971,7 @@ impl<'a> ExtendedChecker<'a> {
 
     fn is_function(&self, id: QualifiedId<FunId>, full_name_str: &str) -> bool {
         let fun = &self.env.get_function(id);
-        fun.get_full_name_with_address() == full_name_str
+        fun.get_full_name_str() == full_name_str
     }
 
     fn is_framework_function(&self, id: QualifiedId<FunId>) -> bool {

--- a/aptos-move/framework/src/extended_checks.rs
+++ b/aptos-move/framework/src/extended_checks.rs
@@ -21,6 +21,7 @@ use move_model::{
     },
     symbol::Symbol,
     ty::{PrimitiveType, ReferenceKind, Type},
+    well_known,
 };
 use move_stackless_bytecode::{
     function_target::{FunctionData, FunctionTarget},
@@ -860,7 +861,7 @@ impl ExtendedChecker<'_> {
         callee: QualifiedId<FunId>,
         type_inst: &[Type],
     ) {
-        if !self.is_function(callee, "0x1::event::emit") {
+        if !self.is_function(callee, well_known::EVENT_EMIT) {
             return;
         }
         // We are looking at `0x1::event::emit<T>` and extracting the `T`

--- a/third_party/move/move-compiler-v2/src/env_pipeline/inlining_optimization.rs
+++ b/third_party/move/move-compiler-v2/src/env_pipeline/inlining_optimization.rs
@@ -594,12 +594,15 @@ fn has_cross_module_event_emit(caller_mid: ModuleId, callee: &FunctionEnv) -> bo
     let Some(body) = callee.get_def() else {
         return false;
     };
+    let stdlib_address = env.get_stdlib_address();
     body.any(&mut |exp: &ExpData| {
         let ExpData::Call(node_id, Operation::MoveFunction(mid, fid), _) = exp else {
             return false;
         };
         let call = env.get_function(mid.qualified(*fid));
-        if call.get_full_name_with_address() != well_known::EVENT_EMIT {
+        if call.module_env.get_name().addr() != &stdlib_address
+            || call.get_full_name_str() != well_known::EVENT_EMIT
+        {
             return false;
         }
 

--- a/third_party/move/move-compiler-v2/src/env_pipeline/inlining_optimization.rs
+++ b/third_party/move/move-compiler-v2/src/env_pipeline/inlining_optimization.rs
@@ -250,6 +250,7 @@ fn compute_call_sites_to_inline_and_new_function_size(
                 || has_privileged_operations(caller_mid, &callee_env)
                 || has_invisible_calls(caller_module, &callee_env, across_package)
                 || has_module_lock_attribute(&callee_env)
+                || has_cross_module_event_emit(caller_mid, &callee_env)
                 || has_access_controls(&callee_env)
             {
                 // won't inline if:
@@ -262,6 +263,8 @@ fn compute_call_sites_to_inline_and_new_function_size(
                 //   perform directly
                 // - callee has calls to functions that are not visible from the caller module
                 // - callee has the `#[module_lock]` attribute
+                // - callee emits an event whose struct is defined in a module other than the
+                //   caller's (0x1::event::emit<T> must be called from T's defining module)
                 // - callee has runtime access control checks
                 // - callee has an abort expression
                 None
@@ -575,6 +578,36 @@ fn has_module_lock_attribute(function: &FunctionEnv) -> bool {
     let env = function.env();
     function.has_attribute(|attr| {
         env.symbol_pool().string(attr.name()).as_str() == well_known::MODULE_LOCK_ATTRIBUTE
+    })
+}
+
+/// Returns true when inlining `callee` would move an `event::emit<T>` call
+/// out of `T`'s module.
+///
+/// `event::emit<T>` is only valid when it runs in `T`'s defining module, and
+/// the extended checker enforces this per call-site. Inlining copies the
+/// callee's bytecode into the caller, so any emit inside the callee lands in
+/// the caller's module. That only works when `T` is a struct defined in the
+/// caller's own module.
+fn has_cross_module_event_emit(caller_mid: ModuleId, callee: &FunctionEnv) -> bool {
+    let env = callee.env();
+    let Some(body) = callee.get_def() else {
+        return false;
+    };
+    body.any(&mut |exp: &ExpData| {
+        let ExpData::Call(node_id, Operation::MoveFunction(mid, fid), _) = exp else {
+            return false;
+        };
+        let call = env.get_function(mid.qualified(*fid));
+        if call.get_full_name_with_address() != well_known::EVENT_EMIT {
+            return false;
+        }
+
+        // We can only inline if struct is in the same module as caller.
+        !matches!(
+            env.get_node_instantiation(*node_id).first(),
+            Some(Type::Struct(struct_mid, _, _)) if *struct_mid == caller_mid
+        )
     })
 }
 

--- a/third_party/move/move-compiler-v2/tests/inlining-optimization/event_emit_cross_module.exp
+++ b/third_party/move/move-compiler-v2/tests/inlining-optimization/event_emit_cross_module.exp
@@ -1,0 +1,94 @@
+// -- Model dump before first bytecode pipeline
+module 0x1::event {
+    public fun emit<T>(_msg: T) {
+        Tuple()
+    }
+} // end 0x1::event
+module 0x1::emitter {
+    struct E {
+        v: u64,
+    }
+    friend fun emit_e(e: E) {
+        event::emit<E>(e)
+    }
+} // end 0x1::emitter
+module 0x1::caller {
+    public fun trigger(e: emitter::E) {
+        emitter::emit_e(e);
+        Tuple()
+    }
+} // end 0x1::caller
+
+// -- Sourcified model before first bytecode pipeline
+module 0x1::event {
+    public fun emit<T: drop + store>(_msg: T) {
+    }
+}
+module 0x1::emitter {
+    friend 0x1::caller;
+    struct E has drop, store {
+        v: u64,
+    }
+    friend fun emit_e(e: E) {
+        0x1::event::emit<E>(e)
+    }
+}
+module 0x1::caller {
+    public fun trigger(e: emitter::E) {
+        0x1::emitter::emit_e(e);
+    }
+}
+
+// -- Model dump before second bytecode pipeline
+module 0x1::event {
+    public fun emit<T>(_msg: T) {
+        Tuple()
+    }
+} // end 0x1::event
+module 0x1::emitter {
+    struct E {
+        v: u64,
+    }
+    friend fun emit_e(e: E) {
+        {
+          let (_msg: E): (E) = Tuple(e);
+          Tuple()
+        }
+    }
+} // end 0x1::emitter
+module 0x1::caller {
+    public fun trigger(e: emitter::E) {
+        emitter::emit_e(e);
+        Tuple()
+    }
+} // end 0x1::caller
+
+
+============ disassembled file-format ==================
+// Bytecode version v10
+module 0x1::event
+// Function definition at index 0
+#[persistent] public fun emit<T0: drop + store>(l0: T0)
+    ret
+
+// Bytecode version v10
+module 0x1::emitter
+friend 0x1::caller
+struct E has drop + store
+  v: u64
+
+// Function definition at index 0
+friend fun emit_e(l0: E)
+    ret
+
+// Bytecode version v10
+module 0x1::caller
+use 0x1::emitter
+// Function definition at index 0
+#[persistent] public fun trigger(l0: emitter::E)
+    move_loc l0
+    call emitter::emit_e
+    ret
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/inlining-optimization/event_emit_cross_module.move
+++ b/third_party/move/move-compiler-v2/tests/inlining-optimization/event_emit_cross_module.move
@@ -1,0 +1,26 @@
+// A callee that calls `0x1::event::emit<T>` must not be inlined into a caller
+// that lives in a different module than `T`. Moving the `event::emit` bytecode
+// across modules would violate the extended-check invariant that requires
+// `event::emit<T>` to be invoked from `T`'s defining module.
+//
+// The callee below does not pack, destructure, or borrow E — so the only
+// reason it is ineligible for inlining is the cross-module `event::emit<E>`.
+module 0x1::event {
+    public fun emit<T: store + drop>(_msg: T) {}
+}
+
+module 0x1::emitter {
+    friend 0x1::caller;
+
+    struct E has drop, store { v: u64 }
+
+    public(friend) fun emit_e(e: E) {
+        0x1::event::emit(e)
+    }
+}
+
+module 0x1::caller {
+    public fun trigger(e: 0x1::emitter::E) {
+        0x1::emitter::emit_e(e);
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/inlining-optimization/event_emit_generic_cross_module.exp
+++ b/third_party/move/move-compiler-v2/tests/inlining-optimization/event_emit_generic_cross_module.exp
@@ -1,0 +1,94 @@
+// -- Model dump before first bytecode pipeline
+module 0x1::event {
+    public fun emit<T>(_msg: T) {
+        Tuple()
+    }
+} // end 0x1::event
+module 0x1::wrapper {
+    friend fun emit_wrapper<T>(e: T) {
+        event::emit<T>(e)
+    }
+} // end 0x1::wrapper
+module 0x1::caller {
+    struct E {
+        v: u64,
+    }
+    public fun trigger(e: E) {
+        wrapper::emit_wrapper<E>(e);
+        Tuple()
+    }
+} // end 0x1::caller
+
+// -- Sourcified model before first bytecode pipeline
+module 0x1::event {
+    public fun emit<T: drop + store>(_msg: T) {
+    }
+}
+module 0x1::wrapper {
+    friend 0x1::caller;
+    friend fun emit_wrapper<T: drop + store>(e: T) {
+        0x1::event::emit<T>(e)
+    }
+}
+module 0x1::caller {
+    struct E has drop, store {
+        v: u64,
+    }
+    public fun trigger(e: E) {
+        0x1::wrapper::emit_wrapper<E>(e);
+    }
+}
+
+// -- Model dump before second bytecode pipeline
+module 0x1::event {
+    public fun emit<T>(_msg: T) {
+        Tuple()
+    }
+} // end 0x1::event
+module 0x1::wrapper {
+    friend fun emit_wrapper<T>(e: T) {
+        {
+          let (_msg: T): (T) = Tuple(e);
+          Tuple()
+        }
+    }
+} // end 0x1::wrapper
+module 0x1::caller {
+    struct E {
+        v: u64,
+    }
+    public fun trigger(e: E) {
+        wrapper::emit_wrapper<E>(e);
+        Tuple()
+    }
+} // end 0x1::caller
+
+
+============ disassembled file-format ==================
+// Bytecode version v10
+module 0x1::event
+// Function definition at index 0
+#[persistent] public fun emit<T0: drop + store>(l0: T0)
+    ret
+
+// Bytecode version v10
+module 0x1::wrapper
+friend 0x1::caller
+// Function definition at index 0
+friend fun emit_wrapper<T0: drop + store>(l0: T0)
+    ret
+
+// Bytecode version v10
+module 0x1::caller
+use 0x1::wrapper
+struct E has drop + store
+  v: u64
+
+// Function definition at index 0
+#[persistent] public fun trigger(l0: E)
+    move_loc l0
+    call wrapper::emit_wrapper<E>
+    ret
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/inlining-optimization/event_emit_generic_cross_module.move
+++ b/third_party/move/move-compiler-v2/tests/inlining-optimization/event_emit_generic_cross_module.move
@@ -1,0 +1,23 @@
+// A generic callee that calls `0x1::event::emit<T>` on its own type parameter
+// must not be inlined across modules. After inlining, the caller's type argument
+// concretizes `T`, potentially into a struct outside the caller's module — which
+// would violate the extended-check invariant on `event::emit<T>`.
+module 0x1::event {
+    public fun emit<T: store + drop>(_msg: T) {}
+}
+
+module 0x1::wrapper {
+    friend 0x1::caller;
+
+    public(friend) fun emit_wrapper<T: store + drop>(e: T) {
+        0x1::event::emit(e)
+    }
+}
+
+module 0x1::caller {
+    struct E has drop, store { v: u64 }
+
+    public fun trigger(e: E) {
+        0x1::wrapper::emit_wrapper(e);
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/inlining-optimization/event_emit_same_module.exp
+++ b/third_party/move/move-compiler-v2/tests/inlining-optimization/event_emit_same_module.exp
@@ -1,0 +1,85 @@
+// -- Model dump before first bytecode pipeline
+module 0x1::event {
+    public fun emit<T>(_msg: T) {
+        Tuple()
+    }
+} // end 0x1::event
+module 0x1::both {
+    struct E {
+        v: u64,
+    }
+    private fun emit_e(e: E) {
+        event::emit<E>(e)
+    }
+    public fun trigger(e: E) {
+        both::emit_e(e)
+    }
+} // end 0x1::both
+
+// -- Sourcified model before first bytecode pipeline
+module 0x1::event {
+    public fun emit<T: drop + store>(_msg: T) {
+    }
+}
+module 0x1::both {
+    struct E has drop, store {
+        v: u64,
+    }
+    fun emit_e(e: E) {
+        0x1::event::emit<E>(e)
+    }
+    public fun trigger(e: E) {
+        emit_e(e)
+    }
+}
+
+// -- Model dump before second bytecode pipeline
+module 0x1::event {
+    public fun emit<T>(_msg: T) {
+        Tuple()
+    }
+} // end 0x1::event
+module 0x1::both {
+    struct E {
+        v: u64,
+    }
+    private fun emit_e(e: E) {
+        {
+          let (_msg: E): (E) = Tuple(e);
+          Tuple()
+        }
+    }
+    public fun trigger(e: E) {
+        {
+          let (e: E): (E) = Tuple(e);
+          {
+            let (_msg: E): (E) = Tuple(e);
+            Tuple()
+          }
+        }
+    }
+} // end 0x1::both
+
+
+============ disassembled file-format ==================
+// Bytecode version v10
+module 0x1::event
+// Function definition at index 0
+#[persistent] public fun emit<T0: drop + store>(l0: T0)
+    ret
+
+// Bytecode version v10
+module 0x1::both
+struct E has drop + store
+  v: u64
+
+// Function definition at index 0
+fun emit_e(l0: E)
+    ret
+
+// Function definition at index 1
+#[persistent] public fun trigger(l0: E)
+    ret
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/inlining-optimization/event_emit_same_module.move
+++ b/third_party/move/move-compiler-v2/tests/inlining-optimization/event_emit_same_module.move
@@ -1,0 +1,18 @@
+// Positive control: when the callee emits an event whose struct is defined in
+// the same module as the caller, inlining is still allowed. The final bytecode
+// for `trigger` should contain the inlined body of `emit_e`, not a call to it.
+module 0x1::event {
+    public fun emit<T: store + drop>(_msg: T) {}
+}
+
+module 0x1::both {
+    struct E has drop, store { v: u64 }
+
+    fun emit_e(e: E) {
+        0x1::event::emit(e)
+    }
+
+    public fun trigger(e: E) {
+        emit_e(e)
+    }
+}

--- a/third_party/move/move-model/src/well_known.rs
+++ b/third_party/move/move-model/src/well_known.rs
@@ -33,6 +33,7 @@ pub const VECTOR_BORROW_MUT: &str = "vector::borrow_mut";
 pub const BORROW_GLOBAL: &str = "borrow_global";
 pub const BORROW_GLOBAL_MUT: &str = "borrow_global_mut";
 pub const EVENT_EMIT_EVENT: &str = "event::emit_event";
+pub const EVENT_EMIT: &str = "0x1::event::emit";
 /// Functions in the std::vector module that are implemented as bytecode instructions.
 pub const VECTOR_FUNCS_WITH_BYTECODE_INSTRS: &[&str] = &[
     "empty",

--- a/third_party/move/move-model/src/well_known.rs
+++ b/third_party/move/move-model/src/well_known.rs
@@ -33,7 +33,7 @@ pub const VECTOR_BORROW_MUT: &str = "vector::borrow_mut";
 pub const BORROW_GLOBAL: &str = "borrow_global";
 pub const BORROW_GLOBAL_MUT: &str = "borrow_global_mut";
 pub const EVENT_EMIT_EVENT: &str = "event::emit_event";
-pub const EVENT_EMIT: &str = "0x1::event::emit";
+pub const EVENT_EMIT: &str = "event::emit";
 /// Functions in the std::vector module that are implemented as bytecode instructions.
 pub const VECTOR_FUNCS_WITH_BYTECODE_INSTRS: &[&str] = &[
     "empty",


### PR DESCRIPTION
## Summary

The Move extended checker at `aptos-move/framework/src/extended_checks.rs:855` requires every `0x1::event::emit<T>` bytecode to reside in `T`'s defining module. The compiler-v2 inliner was happy to inline a small `public(friend)` function whose body contains `event::emit<T>` — relocating the emit bytecode to the caller's module, which then fails the check:

```
0x1::event::emit called with type 0x1::transaction_fee::FeeStatement
which is not a struct type defined in the same module with #[event] attribute
```

This blocked otherwise-valid patterns like `transaction_fee::emit_fee_statement` being called from `transaction_validation`.

This PR adds one more predicate to the inliner's eligibility filter: `has_cross_module_event_emit(caller_mid, callee)` scans the callee body for `0x1::event::emit<T>` calls and returns true when `T`'s module differs from the caller's. When true, the callee is not inlined.

## Test plan

- [x] New baseline test at `tests/inlining-optimization/event_emit_cross_module.move` confirms `emit_e` is not inlined into a caller in a different module (see the `call emitter::emit_e` in the final bytecode dump rather than an inlined body).
- [x] `cargo test -p move-compiler-v2 --test testsuite inlining-optimization` — 10/10 pass.
- [x] `cargo test -p move-compiler-v2 --test testsuite --release` — 2225/2225 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches compiler optimization eligibility logic; incorrect filtering could change inlining behavior and performance or mask/introduce verifier failures around event emission across modules.
> 
> **Overview**
> Prevents compiler-v2’s inliner from inlining callees whose bodies contain `0x1::event::emit<T>` when the emitted struct `T` is not defined in the caller’s module, avoiding generation of bytecode that would later fail the framework’s extended event checks.
> 
> Updates the extended checker to match `event::emit` via the new `well_known::EVENT_EMIT` constant (and compares using `get_full_name_str`), and adds inliner baseline tests covering cross-module, generic cross-module, and same-module `event::emit` cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc65a799a6fcfee443b1b969710f4f2846280e05. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->