### PR TITLE
[mono-move] Initial cross-module call support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12737,6 +12737,7 @@ dependencies = [
  "mono-move-alloc",
  "mono-move-core",
  "mono-move-gas",
+ "move-core-types",
  "rand 0.7.3",
  "thiserror 1.0.69",
 ]
@@ -12748,6 +12749,7 @@ dependencies = [
  "anyhow",
  "legacy-move-compiler",
  "libtest-mimic",
+ "mono-move-core",
  "mono-move-gas",
  "mono-move-global-context",
  "mono-move-runtime",

--- a/third_party/move/mono-move/alloc/src/executable_arena.rs
+++ b/third_party/move/mono-move/alloc/src/executable_arena.rs
@@ -57,6 +57,8 @@ impl<T: ?Sized> Clone for ExecutableArenaPtr<T> {
     }
 }
 
+// TODO: Only needed because MicroOp derives Debug. Remove once MicroOp
+// uses a manual Debug impl or no longer stores ExecutableArenaPtr fields.
 impl<T: ?Sized> fmt::Debug for ExecutableArenaPtr<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "ExecutableArenaPtr({:p})", self.0)

--- a/third_party/move/mono-move/alloc/src/global_arena.rs
+++ b/third_party/move/mono-move/alloc/src/global_arena.rs
@@ -5,6 +5,7 @@ use bumpalo::Bump;
 use crossbeam_utils::CachePadded;
 use parking_lot::{Mutex, MutexGuard};
 use std::{
+    fmt,
     hash::{Hash, Hasher},
     ptr::NonNull,
 };
@@ -70,6 +71,14 @@ impl<T: ?Sized> Copy for GlobalArenaPtr<T> {}
 impl<T: ?Sized> Clone for GlobalArenaPtr<T> {
     fn clone(&self) -> Self {
         *self
+    }
+}
+
+// TODO: Only needed because MicroOp derives Debug. Remove once MicroOp
+// uses a manual Debug impl or no longer stores GlobalArenaPtr fields.
+impl<T: ?Sized> fmt::Debug for GlobalArenaPtr<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "GlobalArenaPtr({:p})", self.0)
     }
 }
 

--- a/third_party/move/mono-move/core/src/function.rs
+++ b/third_party/move/mono-move/core/src/function.rs
@@ -1,7 +1,10 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-use crate::instruction::{CodeOffset, FrameOffset, MicroOp, FRAME_METADATA_SIZE};
+use crate::{
+    instruction::{CodeOffset, FrameOffset, MicroOp, FRAME_METADATA_SIZE},
+    transaction_context::FunctionResolver,
+};
 use mono_move_alloc::{ExecutableArena, ExecutableArenaPtr, GlobalArenaPtr};
 
 /// ---------------------------------------------------------------------------
@@ -223,10 +226,10 @@ impl Function {
     }
 
     /// Replaces every [`MicroOp::CallFunc`] (index-based dispatch) with
-    /// [`MicroOp::CallLocalFunc`] (direct pointer dispatch).
+    /// [`MicroOp::CallDirect`] (direct pointer dispatch).
     ///
-    /// `func_ptrs` is indexed by definition index and may contain `None`
-    /// for functions that were not lowered (e.g. generic functions).
+    /// Only used by hand-built test programs. The executable builder uses
+    /// its own rewrite pass that handles both local and cross-module calls.
     ///
     /// # Safety
     ///
@@ -244,12 +247,132 @@ impl Function {
             let code = unsafe { func.code.as_mut_unchecked() };
             for op in code.iter_mut() {
                 if let MicroOp::CallFunc { func_id } = *op {
-                    *op = MicroOp::CallLocalFunc {
-                        ptr: func_ptrs[func_id as usize]
-                            .expect("CallFunc target must be a lowered function"),
-                    };
+                    if let Some(ptr) = func_ptrs[func_id as usize] {
+                        *op = MicroOp::CallDirect { ptr };
+                    }
                 }
             }
         }
+    }
+
+    /// Replaces every [`MicroOp::CallIndirect`] (name-based dispatch) with
+    /// [`MicroOp::CallDirect`] (direct pointer dispatch) using the
+    /// provided function resolver.
+    ///
+    /// `func_ptrs` yields the functions whose code should be patched.
+    ///
+    /// # Safety
+    ///
+    /// The caller must have exclusive access to the functions and their
+    /// arena-allocated code.
+    pub unsafe fn resolve_module_calls(
+        func_ptrs: impl IntoIterator<Item = ExecutableArenaPtr<Function>>,
+        resolver: &impl FunctionResolver,
+    ) {
+        for mut func_ptr in func_ptrs {
+            // SAFETY: We have exclusive access during build — no concurrent
+            // readers exist yet. The arena is alive because the caller owns it.
+            let func = unsafe { func_ptr.as_mut_unchecked() };
+            let code = unsafe { func.code.as_mut_unchecked() };
+            for op in code.iter_mut() {
+                if let MicroOp::CallIndirect {
+                    executable_id,
+                    func_name,
+                } = *op
+                {
+                    if let Some(ptr) = resolver.resolve_function(executable_id, func_name) {
+                        *op = MicroOp::CallDirect { ptr };
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{transaction_context::FunctionResolver, ExecutableId};
+    use mono_move_alloc::{ExecutableArena, GlobalArenaPool, GlobalArenaShard};
+    use move_core_types::account_address::AccountAddress;
+
+    /// Minimal helper: build a [`Function`] with the given code into `arena`.
+    fn make_function(
+        arena: &ExecutableArena,
+        global: &GlobalArenaShard<'_>,
+        name: &str,
+        code: Vec<MicroOp>,
+    ) -> ExecutableArenaPtr<Function> {
+        let name_ptr = global.alloc_str(name);
+        let code_ptr = arena.alloc_slice_fill_iter(code);
+        let empty_layout = FrameLayoutInfo::new(arena, std::iter::empty::<FrameOffset>());
+        let empty_safe_points =
+            SortedSafePointEntries::new(arena, std::iter::empty::<SafePointEntry>());
+        arena.alloc(Function {
+            name: name_ptr,
+            code: code_ptr,
+            args_size: 0,
+            args_and_locals_size: 8,
+            extended_frame_size: 8 + FRAME_METADATA_SIZE,
+            zero_frame: false,
+            frame_layout: empty_layout,
+            safe_point_layouts: empty_safe_points,
+        })
+    }
+
+    /// A test [`FunctionResolver`] that resolves everything to a fixed target.
+    struct FixedResolver {
+        target: ExecutableArenaPtr<Function>,
+    }
+
+    impl FunctionResolver for FixedResolver {
+        fn resolve_function(
+            &self,
+            _executable_id: GlobalArenaPtr<ExecutableId>,
+            _name: GlobalArenaPtr<str>,
+        ) -> Option<ExecutableArenaPtr<Function>> {
+            Some(self.target)
+        }
+    }
+
+    #[test]
+    fn resolve_module_calls_patches_to_call_local_func() {
+        let arena = ExecutableArena::new();
+        let global_pool = GlobalArenaPool::with_num_arenas(1);
+        let global = global_pool.lock_arena(0);
+
+        // Build the target function (just a Return).
+        let target = make_function(&arena, &global, "target", vec![MicroOp::Return]);
+
+        // Build interned pointers for the cross-module call.
+        let addr = AccountAddress::ONE;
+        let exe_name = global.alloc_str("mod_b");
+        let exe_id_ptr = global.alloc(unsafe { ExecutableId::new(addr, exe_name) });
+        let func_name = global.alloc_str("target");
+
+        // Build the caller with one CallIndirect → Return.
+        let caller = make_function(&arena, &global, "caller", vec![
+            MicroOp::CallIndirect {
+                executable_id: exe_id_ptr,
+                func_name,
+            },
+            MicroOp::Return,
+        ]);
+
+        let func_ptrs = [caller];
+        let resolver = FixedResolver { target };
+
+        unsafe {
+            Function::resolve_module_calls(func_ptrs.iter().copied(), &resolver);
+        }
+
+        // Should now be a CallDirect pointing at target.
+        let resolved_code = unsafe { func_ptrs[0].as_ref_unchecked().code.as_ref_unchecked() };
+        assert!(
+            matches!(resolved_code[0], MicroOp::CallDirect { ptr } if ptr.as_non_null() == target.as_non_null()),
+            "expected CallDirect pointing to target, got {:?}",
+            resolved_code[0]
+        );
+        assert!(matches!(resolved_code[1], MicroOp::Return));
     }
 }

--- a/third_party/move/mono-move/core/src/instruction/gas.rs
+++ b/third_party/move/mono-move/core/src/instruction/gas.rs
@@ -48,7 +48,8 @@ impl HasCfgInfo for MicroOp {
             | MicroOp::ModU64 { .. }
             | MicroOp::Return
             | MicroOp::CallFunc { .. }
-            | MicroOp::CallLocalFunc { .. }
+            | MicroOp::CallIndirect { .. }
+            | MicroOp::CallDirect { .. }
             | MicroOp::VecNew { .. }
             | MicroOp::VecLen { .. }
             | MicroOp::VecPushBack { .. }
@@ -135,7 +136,8 @@ impl RemapTargets for MicroOp {
             | MicroOp::ModU64 { .. }
             | MicroOp::Return
             | MicroOp::CallFunc { .. }
-            | MicroOp::CallLocalFunc { .. }
+            | MicroOp::CallIndirect { .. }
+            | MicroOp::CallDirect { .. }
             | MicroOp::VecNew { .. }
             | MicroOp::VecLen { .. }
             | MicroOp::VecPushBack { .. }
@@ -187,7 +189,9 @@ impl GasSchedule<MicroOp> for MicroOpGasSchedule {
             MicroOp::ModU64 { .. } => 5,
 
             // --- Control flow ---
-            MicroOp::CallFunc { .. } | MicroOp::CallLocalFunc { .. } => 10,
+            MicroOp::CallFunc { .. }
+            | MicroOp::CallIndirect { .. }
+            | MicroOp::CallDirect { .. } => 10,
             MicroOp::Return => 2,
             MicroOp::Jump { .. } => 2,
             MicroOp::JumpNotZeroU64 { .. }

--- a/third_party/move/mono-move/core/src/instruction/mod.rs
+++ b/third_party/move/mono-move/core/src/instruction/mod.rs
@@ -46,7 +46,7 @@
 //!   ```
 //!
 //!   **Call**: the compiler emits explicit micro-ops to place arguments
-//!   into the callee's frame slots. The `CallFunc`/`CallLocalFunc`
+//!   into the callee's frame slots. The `CallFunc`/`CallIndirect`/`CallDirect`
 //!   instruction itself implicitly writes the metadata `(pc, fp,
 //!   func_ptr)` at the end of the caller frame and sets `fp` to the
 //!   callee frame.
@@ -115,8 +115,8 @@
 //!   `elem_ptr_offsets` lists byte offsets *within each element* that hold
 //!   heap pointers.
 
-use crate::Function;
-use mono_move_alloc::ExecutableArenaPtr;
+use crate::{ExecutableId, Function};
+use mono_move_alloc::{ExecutableArenaPtr, GlobalArenaPtr};
 use std::fmt;
 
 // Submodules for instruction.
@@ -284,9 +284,16 @@ pub enum MicroOp {
     /// `current_fp + args_and_locals_size + FRAME_METADATA_SIZE`.
     CallFunc { func_id: u32 },
 
+    /// Call a function by module identity and name. Same calling convention
+    /// as `CallFunc`.
+    CallIndirect {
+        executable_id: GlobalArenaPtr<ExecutableId>,
+        func_name: GlobalArenaPtr<str>,
+    },
+
     /// Call a function via direct pointer. Same calling convention as
     /// `CallFunc`.
-    CallLocalFunc { ptr: ExecutableArenaPtr<Function> },
+    CallDirect { ptr: ExecutableArenaPtr<Function> },
 
     /// Return from the current function call. The compiler has already
     /// emitted micro-ops to write return values at the start of the
@@ -628,8 +635,11 @@ impl fmt::Display for MicroOp {
             MicroOp::CallFunc { func_id } => {
                 write!(f, "CallFunc #{}", func_id)
             },
-            MicroOp::CallLocalFunc { .. } => {
-                write!(f, "CallLocalFunc")
+            MicroOp::CallIndirect { .. } => {
+                write!(f, "CallIndirect")
+            },
+            MicroOp::CallDirect { .. } => {
+                write!(f, "CallDirect")
             },
             MicroOp::Return => {
                 write!(f, "Return")
@@ -981,8 +991,8 @@ mod tests {
 
     #[test]
     fn micro_op_size() {
-        // Current size is 24 bytes due to large variants (e.g.
-        // JumpGreaterEqualU64Imm). We should aim to bring this down to 16.
-        assert_eq!(std::mem::size_of::<MicroOp>(), 24);
+        // Size is 32 bytes due to CallIndirect which carries two
+        // GlobalArenaPtr fields (8 + 16 bytes). TODO: bring this down.
+        assert_eq!(std::mem::size_of::<MicroOp>(), 32);
     }
 }

--- a/third_party/move/mono-move/core/src/lib.rs
+++ b/third_party/move/mono-move/core/src/lib.rs
@@ -12,4 +12,4 @@ pub use instruction::{
     CodeOffset, DescriptorId, FrameOffset, MicroOp, MicroOpGasSchedule, ENUM_DATA_OFFSET,
     ENUM_TAG_OFFSET, FRAME_METADATA_SIZE, OBJECT_HEADER_SIZE, STRUCT_DATA_OFFSET,
 };
-pub use transaction_context::{FunctionResolver, TransactionContext};
+pub use transaction_context::{FunctionResolver, NoopTransactionContext, TransactionContext};

--- a/third_party/move/mono-move/core/src/transaction_context.rs
+++ b/third_party/move/mono-move/core/src/transaction_context.rs
@@ -2,16 +2,16 @@
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{ExecutableId, Function};
-use mono_move_alloc::ExecutableArenaPtr;
+use mono_move_alloc::{ExecutableArenaPtr, GlobalArenaPtr};
 
 /// Handles resolving cross-module functions. Returns [`None`] if executable
 /// or function do not exist.
 pub trait FunctionResolver {
     fn resolve_function(
         &self,
-        executable_id: ExecutableArenaPtr<ExecutableId>,
-        name: ExecutableArenaPtr<str>,
-    ) -> Option<&Function>;
+        executable_id: GlobalArenaPtr<ExecutableId>,
+        name: GlobalArenaPtr<str>,
+    ) -> Option<ExecutableArenaPtr<Function>>;
 }
 
 /// Per-transaction context used by the interpreter. Bundles all state that
@@ -20,3 +20,18 @@ pub trait FunctionResolver {
 ///   - read-set records (to cache reads and for Block-STM tracking),
 ///   - heap / memory management,
 pub trait TransactionContext: FunctionResolver {}
+
+/// A no-op [`TransactionContext`] for testing.
+pub struct NoopTransactionContext;
+
+impl FunctionResolver for NoopTransactionContext {
+    fn resolve_function(
+        &self,
+        _executable_id: GlobalArenaPtr<ExecutableId>,
+        _name: GlobalArenaPtr<str>,
+    ) -> Option<ExecutableArenaPtr<Function>> {
+        None
+    }
+}
+
+impl TransactionContext for NoopTransactionContext {}

--- a/third_party/move/mono-move/global-context/src/context/executable.rs
+++ b/third_party/move/mono-move/global-context/src/context/executable.rs
@@ -13,10 +13,13 @@ use crate::{
 use anyhow::{anyhow, bail};
 use fxhash::FxBuildHasher;
 use mono_move_alloc::{ExecutableArena, ExecutableArenaPtr, GlobalArenaPtr};
-use mono_move_core::{ExecutableId, FrameLayoutInfo, Function, SortedSafePointEntries};
+use mono_move_core::{ExecutableId, FrameLayoutInfo, Function, MicroOp, SortedSafePointEntries};
 use move_binary_format::{
     access::ModuleAccess,
-    file_format::{SignatureToken, StructDefinition, StructFieldInformation, StructHandleIndex},
+    file_format::{
+        FunctionHandleIndex, SignatureToken, StructDefinition, StructFieldInformation,
+        StructHandleIndex,
+    },
     CompiledModule,
 };
 use parking_lot::Mutex;
@@ -158,9 +161,9 @@ impl<'a, 'guard, 'ctx> ExecutableBuilder<'a, 'guard, 'ctx> {
 
         let lowered = specializer::destack_and_lower_module(self.module.clone())?;
 
-        // Indexed by definition index. Generic functions that are not
-        // lowered leave their slot as None.
-        let mut func_ptrs = vec![None; lowered.functions.len()];
+        // Handle-indexed function pointer table. Local definitions get
+        // Some(ptr); cross-module and generic handles remain None.
+        let mut func_ptrs = vec![None; self.module.function_handles.len()];
         for (def_idx, lowered_fn) in lowered.functions.into_iter().enumerate() {
             if let Some(lf) = lowered_fn {
                 let name = self
@@ -180,14 +183,50 @@ impl<'a, 'guard, 'ctx> ExecutableBuilder<'a, 'guard, 'ctx> {
                 };
                 let ptr = self.arena.alloc(func);
                 self.data.functions.insert(name, ptr);
-                func_ptrs[def_idx] = Some(ptr);
+                let handle_idx = self.module.function_defs[def_idx].function.0 as usize;
+                func_ptrs[handle_idx] = Some(ptr);
             }
         }
 
-        // Patch CallFunc to CallLocalFunc using definition-indexed func_ptrs.
-        // SAFETY: We have exclusive access — the executable is being built
-        // and no concurrent readers exist. The arena outlives the executable.
-        unsafe { Function::resolve_calls(&func_ptrs) };
+        // Resolve all CallFunc instructions in a single pass:
+        // - Local calls (entry in func_ptrs) → CallDirect
+        // - Cross-module calls (no entry in func_ptrs) → CallIndirect
+        let self_module_handle_idx = self.module.self_module_handle_idx;
+        for func_ptr in &func_ptrs {
+            let Some(mut func_ptr) = *func_ptr else {
+                continue;
+            };
+            // SAFETY: We have exclusive access — the executable is being built
+            // and no concurrent readers exist. The arena outlives the executable.
+            let func = unsafe { func_ptr.as_mut_unchecked() };
+            let code = unsafe { func.code.as_mut_unchecked() };
+            for op in code.iter_mut() {
+                if let MicroOp::CallFunc { func_id } = *op {
+                    if let Some(ptr) = func_ptrs[func_id as usize] {
+                        *op = MicroOp::CallDirect { ptr };
+                    } else {
+                        let function = self
+                            .module
+                            .function_handle_at(FunctionHandleIndex(func_id as u16));
+                        if function.module == self_module_handle_idx {
+                            bail!("unresolved local function handle {}", func_id);
+                        }
+                        let module = self.module.module_handle_at(function.module);
+                        let executable_id = self.guard.intern_address_name_internal(
+                            *self.module.address_identifier_at(module.address),
+                            self.module.identifier_at(module.name),
+                        );
+                        let func_name = self
+                            .guard
+                            .intern_identifier_internal(self.module.identifier_at(function.name));
+                        *op = MicroOp::CallIndirect {
+                            executable_id,
+                            func_name,
+                        };
+                    }
+                }
+            }
+        }
 
         Ok(Box::new(Executable {
             data: self.data,

--- a/third_party/move/mono-move/global-context/src/transaction_context.rs
+++ b/third_party/move/mono-move/global-context/src/transaction_context.rs
@@ -2,7 +2,7 @@
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::ExecutionGuard;
-use mono_move_alloc::ExecutableArenaPtr;
+use mono_move_alloc::{ExecutableArenaPtr, GlobalArenaPtr};
 use mono_move_core::{ExecutableId, Function, FunctionResolver, TransactionContext};
 
 // TODO:
@@ -24,9 +24,9 @@ impl<'ctx> PlaceholderContext<'ctx> {
 impl FunctionResolver for PlaceholderContext<'_> {
     fn resolve_function(
         &self,
-        _executable_id: ExecutableArenaPtr<ExecutableId>,
-        _name: ExecutableArenaPtr<str>,
-    ) -> Option<&Function> {
+        _executable_id: GlobalArenaPtr<ExecutableId>,
+        _name: GlobalArenaPtr<str>,
+    ) -> Option<ExecutableArenaPtr<Function>> {
         // TODO: implement once specializer support cross-module calls.
         todo!("PlaceholderContext::resolve_function")
     }

--- a/third_party/move/mono-move/global-context/tests/gas_test.rs
+++ b/third_party/move/mono-move/global-context/tests/gas_test.rs
@@ -3,6 +3,7 @@
 
 //! Integration tests for gas metering through the full pipeline.
 
+use mono_move_core::NoopTransactionContext;
 use mono_move_gas::SimpleGasMeter;
 use mono_move_global_context::{ExecutionGuard, GlobalContext};
 use mono_move_runtime::{ExecutionError, InterpreterContext};
@@ -44,8 +45,9 @@ module 0x1::test {
         .and_then(|e| e.get_function(fib_name))
         .expect("fib should exist");
 
+    let txn_ctx = NoopTransactionContext;
     let gas_meter = SimpleGasMeter::new(10);
-    let mut interpreter = InterpreterContext::new(&[], gas_meter, fib);
+    let mut interpreter = InterpreterContext::new(&txn_ctx, &[], gas_meter, fib);
     interpreter.set_root_arg(0, &10u64.to_le_bytes());
     let err = interpreter.run().unwrap_err();
     assert!(matches!(err, ExecutionError::GasExhausted(_)));

--- a/third_party/move/mono-move/programs/benches/bst.rs
+++ b/third_party/move/mono-move/programs/benches/bst.rs
@@ -12,6 +12,7 @@ const KEY_RANGE: u64 = 2500;
 const SEED: u64 = 42;
 
 fn bench_bst(c: &mut Criterion) {
+    use mono_move_core::NoopTransactionContext;
     use mono_move_gas::SimpleGasMeter;
     use mono_move_programs::{
         bst::{generate_ops, micro_op_bst, move_bytecode_bst, move_stdlib_vector, native_run_ops},
@@ -36,12 +37,14 @@ fn bench_bst(c: &mut Criterion) {
         let (functions, descriptors, _arena) = micro_op_bst();
         // SAFETY: Exclusive access during bench setup; arena is alive.
         unsafe { mono_move_core::Function::resolve_calls(&functions) };
+        let txn_ctx = NoopTransactionContext;
         group.bench_function("micro_op", |b| {
             b.iter_batched(
                 || {
-                    let mut ctx = InterpreterContext::new(&descriptors, NoOpGasMeter, unsafe {
-                        functions[6].unwrap().as_ref_unchecked()
-                    });
+                    let mut ctx =
+                        InterpreterContext::new(&txn_ctx, &descriptors, NoOpGasMeter, unsafe {
+                            functions[6].unwrap().as_ref_unchecked()
+                        });
                     let vec_ptr = ctx
                         .alloc_u64_vec(mono_move_core::DescriptorId(0), &ops)
                         .unwrap();
@@ -63,9 +66,10 @@ fn bench_bst(c: &mut Criterion) {
             b.iter_batched(
                 || {
                     let gas_meter = SimpleGasMeter::new(u64::MAX);
-                    let mut ctx = InterpreterContext::new(&descriptors, gas_meter, unsafe {
-                        functions_gas[6].unwrap().as_ref_unchecked()
-                    });
+                    let mut ctx =
+                        InterpreterContext::new(&txn_ctx, &descriptors, gas_meter, unsafe {
+                            functions_gas[6].unwrap().as_ref_unchecked()
+                        });
                     let vec_ptr = ctx
                         .alloc_u64_vec(mono_move_core::DescriptorId(0), &ops)
                         .unwrap();

--- a/third_party/move/mono-move/programs/benches/fib.rs
+++ b/third_party/move/mono-move/programs/benches/fib.rs
@@ -9,6 +9,7 @@ mod helpers;
 const N: u64 = 25;
 
 fn bench_fib(c: &mut Criterion) {
+    use mono_move_core::NoopTransactionContext;
     use mono_move_gas::{NoOpGasMeter, SimpleGasMeter};
     use mono_move_programs::{
         fib::{micro_op_fib, move_bytecode_fib, native_fib},
@@ -31,12 +32,14 @@ fn bench_fib(c: &mut Criterion) {
         let (functions, descriptors, _arena) = micro_op_fib();
         // SAFETY: Exclusive access during bench setup; arena is alive.
         unsafe { mono_move_core::Function::resolve_calls(&functions) };
+        let txn_ctx = NoopTransactionContext;
         group.bench_function("micro_op", |b| {
             b.iter_batched(
                 || {
-                    let mut ctx = InterpreterContext::new(&descriptors, NoOpGasMeter, unsafe {
-                        functions[0].unwrap().as_ref_unchecked()
-                    });
+                    let mut ctx =
+                        InterpreterContext::new(&txn_ctx, &descriptors, NoOpGasMeter, unsafe {
+                            functions[0].unwrap().as_ref_unchecked()
+                        });
                     ctx.set_root_arg(0, &N.to_le_bytes());
                     ctx
                 },
@@ -58,9 +61,10 @@ fn bench_fib(c: &mut Criterion) {
             b.iter_batched(
                 || {
                     let gas_meter = SimpleGasMeter::new(u64::MAX);
-                    let mut ctx = InterpreterContext::new(&descriptors, gas_meter, unsafe {
-                        functions_gas[0].unwrap().as_ref_unchecked()
-                    });
+                    let mut ctx =
+                        InterpreterContext::new(&txn_ctx, &descriptors, gas_meter, unsafe {
+                            functions_gas[0].unwrap().as_ref_unchecked()
+                        });
                     ctx.set_root_arg(0, &N.to_le_bytes());
                     ctx
                 },

--- a/third_party/move/mono-move/programs/benches/match_sum.rs
+++ b/third_party/move/mono-move/programs/benches/match_sum.rs
@@ -9,6 +9,7 @@ mod helpers;
 const N: u64 = 1_000_000;
 
 fn bench_match_sum(c: &mut Criterion) {
+    use mono_move_core::NoopTransactionContext;
     use mono_move_gas::{NoOpGasMeter, SimpleGasMeter};
     use mono_move_programs::{
         match_sum::{micro_op_match_sum, move_bytecode_match_sum, native_match_sum},
@@ -29,12 +30,14 @@ fn bench_match_sum(c: &mut Criterion) {
 
         // plain (no gas instrumentation)
         let (functions, descriptors, _arena) = micro_op_match_sum();
+        let txn_ctx = NoopTransactionContext;
         group.bench_function("micro_op", |b| {
             b.iter_batched(
                 || {
-                    let mut ctx = InterpreterContext::new(&descriptors, NoOpGasMeter, unsafe {
-                        functions[0].as_ref_unchecked()
-                    });
+                    let mut ctx =
+                        InterpreterContext::new(&txn_ctx, &descriptors, NoOpGasMeter, unsafe {
+                            functions[0].as_ref_unchecked()
+                        });
                     ctx.set_root_arg(0, &N.to_le_bytes());
                     ctx
                 },
@@ -55,9 +58,10 @@ fn bench_match_sum(c: &mut Criterion) {
             b.iter_batched(
                 || {
                     let gas_meter = SimpleGasMeter::new(u64::MAX);
-                    let mut ctx = InterpreterContext::new(&descriptors, gas_meter, unsafe {
-                        functions_gas[0].unwrap().as_ref_unchecked()
-                    });
+                    let mut ctx =
+                        InterpreterContext::new(&txn_ctx, &descriptors, gas_meter, unsafe {
+                            functions_gas[0].unwrap().as_ref_unchecked()
+                        });
                     ctx.set_root_arg(0, &N.to_le_bytes());
                     ctx
                 },

--- a/third_party/move/mono-move/programs/benches/merge_sort.rs
+++ b/third_party/move/mono-move/programs/benches/merge_sort.rs
@@ -9,6 +9,7 @@ mod helpers;
 const N: u64 = 1000;
 
 fn bench_merge_sort(c: &mut Criterion) {
+    use mono_move_core::NoopTransactionContext;
     use mono_move_gas::{NoOpGasMeter, SimpleGasMeter};
     use mono_move_programs::{
         merge_sort::{
@@ -42,12 +43,14 @@ fn bench_merge_sort(c: &mut Criterion) {
         let (functions, descriptors, _arena) = micro_op_merge_sort();
         // SAFETY: Exclusive access during bench setup; arena is alive.
         unsafe { mono_move_core::Function::resolve_calls(&functions) };
+        let txn_ctx = NoopTransactionContext;
         group.bench_function("micro_op", |b| {
             b.iter_batched(
                 || {
-                    let mut ctx = InterpreterContext::new(&descriptors, NoOpGasMeter, unsafe {
-                        functions[0].unwrap().as_ref_unchecked()
-                    });
+                    let mut ctx =
+                        InterpreterContext::new(&txn_ctx, &descriptors, NoOpGasMeter, unsafe {
+                            functions[0].unwrap().as_ref_unchecked()
+                        });
                     let vec_ptr = ctx
                         .alloc_u64_vec(mono_move_core::DescriptorId(0), &input)
                         .unwrap();
@@ -69,9 +72,10 @@ fn bench_merge_sort(c: &mut Criterion) {
             b.iter_batched(
                 || {
                     let gas_meter = SimpleGasMeter::new(u64::MAX);
-                    let mut ctx = InterpreterContext::new(&descriptors, gas_meter, unsafe {
-                        functions_gas[0].unwrap().as_ref_unchecked()
-                    });
+                    let mut ctx =
+                        InterpreterContext::new(&txn_ctx, &descriptors, gas_meter, unsafe {
+                            functions_gas[0].unwrap().as_ref_unchecked()
+                        });
                     let vec_ptr = ctx
                         .alloc_u64_vec(mono_move_core::DescriptorId(0), &input)
                         .unwrap();

--- a/third_party/move/mono-move/programs/benches/nested_loop.rs
+++ b/third_party/move/mono-move/programs/benches/nested_loop.rs
@@ -9,6 +9,7 @@ mod helpers;
 const N: u64 = 1000;
 
 fn bench_nested_loop(c: &mut Criterion) {
+    use mono_move_core::NoopTransactionContext;
     use mono_move_gas::{NoOpGasMeter, SimpleGasMeter};
     use mono_move_programs::{
         nested_loop::{micro_op_nested_loop, move_bytecode_nested_loop, native_nested_loop},
@@ -29,12 +30,14 @@ fn bench_nested_loop(c: &mut Criterion) {
 
         // plain (no gas instrumentation)
         let (functions, descriptors, _arena) = micro_op_nested_loop();
+        let txn_ctx = NoopTransactionContext;
         group.bench_function("micro_op", |b| {
             b.iter_batched(
                 || {
-                    let mut ctx = InterpreterContext::new(&descriptors, NoOpGasMeter, unsafe {
-                        functions[0].as_ref_unchecked()
-                    });
+                    let mut ctx =
+                        InterpreterContext::new(&txn_ctx, &descriptors, NoOpGasMeter, unsafe {
+                            functions[0].as_ref_unchecked()
+                        });
                     ctx.set_root_arg(0, &N.to_le_bytes());
                     ctx
                 },
@@ -55,9 +58,10 @@ fn bench_nested_loop(c: &mut Criterion) {
             b.iter_batched(
                 || {
                     let gas_meter = SimpleGasMeter::new(u64::MAX);
-                    let mut ctx = InterpreterContext::new(&descriptors, gas_meter, unsafe {
-                        functions_gas[0].unwrap().as_ref_unchecked()
-                    });
+                    let mut ctx =
+                        InterpreterContext::new(&txn_ctx, &descriptors, gas_meter, unsafe {
+                            functions_gas[0].unwrap().as_ref_unchecked()
+                        });
                     ctx.set_root_arg(0, &N.to_le_bytes());
                     ctx
                 },

--- a/third_party/move/mono-move/programs/tests/bst.rs
+++ b/third_party/move/mono-move/programs/tests/bst.rs
@@ -120,7 +120,7 @@ fn native_insert_remove_sequence() {
 
 #[cfg(feature = "micro-op")]
 mod micro_op {
-    use mono_move_core::Function;
+    use mono_move_core::{Function, NoopTransactionContext};
     use mono_move_gas::{GasMeter, SimpleGasMeter};
     use mono_move_programs::bst::{
         generate_ops, micro_op_bst, native_run_ops_with_results, FN_GET, FN_INSERT, FN_NEW,
@@ -186,8 +186,9 @@ mod micro_op {
         let fn_insert = unsafe { functions[FN_INSERT].unwrap().as_ref_unchecked() };
         let fn_get = unsafe { functions[FN_GET].unwrap().as_ref_unchecked() };
         let fn_remove = unsafe { functions[FN_REMOVE].unwrap().as_ref_unchecked() };
+        let txn_ctx = NoopTransactionContext;
         let gas_meter = SimpleGasMeter::new(u64::MAX);
-        let mut ctx = InterpreterContext::new(&descriptors, gas_meter, fn_new);
+        let mut ctx = InterpreterContext::new(&txn_ctx, &descriptors, gas_meter, fn_new);
         let bst = bst_new(&mut ctx, fn_new);
         let mut results = Vec::new();
         let mut i = 0;

--- a/third_party/move/mono-move/programs/tests/fib.rs
+++ b/third_party/move/mono-move/programs/tests/fib.rs
@@ -12,6 +12,7 @@ fn native() {
 
 #[cfg(feature = "micro-op")]
 mod micro_op {
+    use mono_move_core::NoopTransactionContext;
     use mono_move_gas::SimpleGasMeter;
     use mono_move_programs::fib::{micro_op_fib, FIB_CASES};
     use mono_move_runtime::InterpreterContext;
@@ -20,8 +21,9 @@ mod micro_op {
         let (functions, descriptors, _arena) = micro_op_fib();
         // SAFETY: Exclusive access during test setup; arena is alive.
         unsafe { mono_move_core::Function::resolve_calls(&functions) };
+        let txn_ctx = NoopTransactionContext;
         let gas_meter = SimpleGasMeter::new(u64::MAX);
-        let mut ctx = InterpreterContext::new(&descriptors, gas_meter, unsafe {
+        let mut ctx = InterpreterContext::new(&txn_ctx, &descriptors, gas_meter, unsafe {
             functions[0].unwrap().as_ref_unchecked()
         });
         ctx.set_root_arg(0, &n.to_le_bytes());

--- a/third_party/move/mono-move/programs/tests/match_sum.rs
+++ b/third_party/move/mono-move/programs/tests/match_sum.rs
@@ -12,14 +12,16 @@ fn native() {
 
 #[cfg(feature = "micro-op")]
 mod micro_op {
+    use mono_move_core::NoopTransactionContext;
     use mono_move_gas::SimpleGasMeter;
     use mono_move_programs::match_sum::{micro_op_match_sum, MATCH_SUM_CASES};
     use mono_move_runtime::InterpreterContext;
 
     fn run(n: u64) -> u64 {
         let (functions, descriptors, _arena) = micro_op_match_sum();
+        let txn_ctx = NoopTransactionContext;
         let gas_meter = SimpleGasMeter::new(u64::MAX);
-        let mut ctx = InterpreterContext::new(&descriptors, gas_meter, unsafe {
+        let mut ctx = InterpreterContext::new(&txn_ctx, &descriptors, gas_meter, unsafe {
             functions[0].as_ref_unchecked()
         });
         ctx.set_root_arg(0, &n.to_le_bytes());

--- a/third_party/move/mono-move/programs/tests/merge_sort.rs
+++ b/third_party/move/mono-move/programs/tests/merge_sort.rs
@@ -15,6 +15,7 @@ fn native() {
 
 #[cfg(feature = "micro-op")]
 mod micro_op {
+    use mono_move_core::NoopTransactionContext;
     use mono_move_gas::SimpleGasMeter;
     use mono_move_programs::merge_sort::{micro_op_merge_sort, shuffled_range};
     use mono_move_runtime::{read_u64, InterpreterContext, VEC_DATA_OFFSET};
@@ -24,8 +25,9 @@ mod micro_op {
         let (functions, descriptors, _arena) = micro_op_merge_sort();
         // SAFETY: Exclusive access during test setup; arena is alive.
         unsafe { mono_move_core::Function::resolve_calls(&functions) };
+        let txn_ctx = NoopTransactionContext;
         let gas_meter = SimpleGasMeter::new(u64::MAX);
-        let mut ctx = InterpreterContext::new(&descriptors, gas_meter, unsafe {
+        let mut ctx = InterpreterContext::new(&txn_ctx, &descriptors, gas_meter, unsafe {
             functions[0].unwrap().as_ref_unchecked()
         });
         let vec_ptr = ctx

--- a/third_party/move/mono-move/programs/tests/nested_loop.rs
+++ b/third_party/move/mono-move/programs/tests/nested_loop.rs
@@ -12,14 +12,16 @@ fn native() {
 
 #[cfg(feature = "micro-op")]
 mod micro_op {
+    use mono_move_core::NoopTransactionContext;
     use mono_move_gas::SimpleGasMeter;
     use mono_move_programs::nested_loop::{micro_op_nested_loop, NESTED_LOOP_CASES};
     use mono_move_runtime::InterpreterContext;
 
     fn run(n: u64) -> u64 {
         let (functions, descriptors, _arena) = micro_op_nested_loop();
+        let txn_ctx = NoopTransactionContext;
         let gas_meter = SimpleGasMeter::new(u64::MAX);
-        let mut ctx = InterpreterContext::new(&descriptors, gas_meter, unsafe {
+        let mut ctx = InterpreterContext::new(&txn_ctx, &descriptors, gas_meter, unsafe {
             functions[0].as_ref_unchecked()
         });
         ctx.set_root_arg(0, &n.to_le_bytes());

--- a/third_party/move/mono-move/runtime/Cargo.toml
+++ b/third_party/move/mono-move/runtime/Cargo.toml
@@ -19,3 +19,6 @@ mono-move-core = { workspace = true }
 mono-move-gas = { workspace = true }
 rand = { workspace = true }
 thiserror = { workspace = true }
+
+[dev-dependencies]
+move-core-types = { workspace = true }

--- a/third_party/move/mono-move/runtime/src/heap.rs
+++ b/third_party/move/mono-move/runtime/src/heap.rs
@@ -239,7 +239,7 @@ impl<G: GasMeter> InterpreterContext<'_, G> {
 
         loop {
             // SAFETY: func_ptr is a valid, non-null pointer — set from
-            // `self.functions[]` or from `CallLocalFunc`, and saved/restored
+            // `self.functions[]` or from `CallDirect`, and saved/restored
             // via frame metadata. Arena pointers are valid for the lifetime
             // of the executable. `fp.sub` retrieves saved metadata written
             // by the call protocol.

--- a/third_party/move/mono-move/runtime/src/interpreter.rs
+++ b/third_party/move/mono-move/runtime/src/interpreter.rs
@@ -15,7 +15,7 @@ use crate::{
         VEC_LENGTH_OFFSET,
     },
 };
-use mono_move_core::{DescriptorId, Function, MicroOp, FRAME_METADATA_SIZE};
+use mono_move_core::{DescriptorId, Function, MicroOp, TransactionContext, FRAME_METADATA_SIZE};
 use mono_move_gas::GasMeter;
 use rand::{rngs::StdRng, Rng, SeedableRng};
 use std::ptr::{null, NonNull};
@@ -26,6 +26,8 @@ use std::ptr::{null, NonNull};
 
 /// Interpreter context with a unified call stack and a GC-managed heap.
 pub struct InterpreterContext<'a, G: GasMeter> {
+    /// Per-transaction context (function resolution, gas counters, etc.).
+    pub(crate) txn_ctx: &'a dyn TransactionContext,
     /// Externally-provided object layout descriptors (will be replaced by execution context).
     pub(crate) descriptors: &'a [ObjectDescriptor],
     /// Externally-provided gas meter (will be replaced by execution context).
@@ -44,12 +46,18 @@ pub struct InterpreterContext<'a, G: GasMeter> {
 }
 
 impl<'a, G: GasMeter> InterpreterContext<'a, G> {
-    pub fn new(descriptors: &'a [ObjectDescriptor], gas_meter: G, entry: &Function) -> Self {
-        Self::with_heap_size(descriptors, gas_meter, entry, DEFAULT_HEAP_SIZE)
+    pub fn new(
+        txn_ctx: &'a dyn TransactionContext,
+        descriptors: &'a [ObjectDescriptor],
+        gas_meter: G,
+        entry: &Function,
+    ) -> Self {
+        Self::with_heap_size(txn_ctx, descriptors, gas_meter, entry, DEFAULT_HEAP_SIZE)
     }
 
     /// Create a new context with a custom heap size (for testing GC pressure).
     pub fn with_heap_size(
+        txn_ctx: &'a dyn TransactionContext,
         descriptors: &'a [ObjectDescriptor],
         gas_meter: G,
         entry: &Function,
@@ -77,6 +85,7 @@ impl<'a, G: GasMeter> InterpreterContext<'a, G> {
         }
 
         Self {
+            txn_ctx,
             descriptors,
             gas_meter,
             pc: 0,
@@ -210,10 +219,22 @@ impl<G: GasMeter> InterpreterContext<'_, G> {
             match *instr {
                 // ----- Control flow (set pc explicitly, return early) -----
                 MicroOp::CallFunc { .. } => {
-                    // TODO: Support cross module calls here.
-                    bail!("CallFunc must be resolved to CallLocalFunc before execution");
+                    bail!("CallFunc must be resolved before execution");
                 },
-                MicroOp::CallLocalFunc { ptr } => {
+                MicroOp::CallIndirect {
+                    executable_id,
+                    func_name,
+                } => {
+                    // Cross-module slow path, may trigger lazy module loading here.
+                    let Some(target) = self.txn_ctx.resolve_function(executable_id, func_name)
+                    else {
+                        // TODO: Once loader is in place, this should load the module
+                        // and retry resolution instead of bailing immediately.
+                        bail!("CallIndirect: function not found");
+                    };
+                    return self.call(func, fp, target.as_ref_unchecked());
+                },
+                MicroOp::CallDirect { ptr } => {
                     return self.call(func, fp, ptr.as_ref_unchecked());
                 },
 

--- a/third_party/move/mono-move/runtime/src/verifier.rs
+++ b/third_party/move/mono-move/runtime/src/verifier.rs
@@ -272,11 +272,11 @@ impl FunctionVerifier<'_> {
             MicroOp::Return | MicroOp::ForceGC => {},
 
             MicroOp::CallFunc { .. } => {
-                // TODO: Verify that func_id is a valid function definition
+                // TODO: Verify that func_id is a valid function handle
                 // index. Requires passing the function table (or its length)
                 // into the verifier so we can bounds-check the callee index.
             },
-            MicroOp::CallLocalFunc { .. } => {},
+            MicroOp::CallIndirect { .. } | MicroOp::CallDirect { .. } => {},
 
             // ----- VecNew -----
             MicroOp::VecNew { dst } => {

--- a/third_party/move/mono-move/runtime/tests/cross_module_test.rs
+++ b/third_party/move/mono-move/runtime/tests/cross_module_test.rs
@@ -1,0 +1,137 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-core/blob/main/LICENSE
+
+//! Test for the cross-module call slow path (CallIndirect dispatched at
+//! runtime via TransactionContext).
+//!
+//! TODO: Replace with a transactional test in mono-move/testsuite once the
+//! loader is implemented and cross-module calls work end-to-end.
+
+use mono_move_alloc::{ExecutableArena, ExecutableArenaPtr, GlobalArenaPtr};
+use mono_move_core::{
+    ExecutableId, FrameLayoutInfo, FrameOffset as FO, Function, FunctionResolver, MicroOp,
+    SortedSafePointEntries, TransactionContext, FRAME_METADATA_SIZE,
+};
+use mono_move_gas::SimpleGasMeter;
+use mono_move_runtime::InterpreterContext;
+use move_core_types::account_address::AccountAddress;
+use std::sync::LazyLock;
+
+/// A test TransactionContext that resolves a single cross-module function.
+struct TestTransactionContext {
+    target_executable_id: GlobalArenaPtr<ExecutableId>,
+    target_func_name: GlobalArenaPtr<str>,
+    target_func_ptr: ExecutableArenaPtr<Function>,
+}
+
+impl FunctionResolver for TestTransactionContext {
+    fn resolve_function(
+        &self,
+        executable_id: GlobalArenaPtr<ExecutableId>,
+        name: GlobalArenaPtr<str>,
+    ) -> Option<ExecutableArenaPtr<Function>> {
+        if executable_id == self.target_executable_id && name == self.target_func_name {
+            Some(self.target_func_ptr)
+        } else {
+            None
+        }
+    }
+}
+
+impl TransactionContext for TestTransactionContext {}
+
+/// Verifies that the interpreter's runtime slow path correctly dispatches
+/// cross-module calls through the TransactionContext.
+///
+/// ```move
+/// module 0x1::foo {
+///     public fun add_one(x: u64): u64 { x + 1 }
+/// }
+///
+/// module 0x1::bar {
+///     public fun main(): u64 { 0x1::foo::add_one(41) }
+/// }
+/// ```
+#[test]
+fn call_indirect_runtime_dispatch() {
+    let arena = ExecutableArena::new();
+
+    // module 0x1::foo {
+    //     public fun add_one(x: u64): u64 { x + 1 }
+    // }
+    // Frame: [0..8) arg/return, [8..32) metadata
+    let callee_name = GlobalArenaPtr::from_static("add_one");
+    let callee_code = arena.alloc_slice_fill_iter(vec![
+        MicroOp::AddU64Imm {
+            dst: FO(0),
+            src: FO(0),
+            imm: 1,
+        },
+        MicroOp::Return,
+    ]);
+    let callee = arena.alloc(Function {
+        name: callee_name,
+        code: callee_code,
+        args_size: 8,
+        args_and_locals_size: 8,
+        extended_frame_size: 8 + FRAME_METADATA_SIZE,
+        zero_frame: false,
+        frame_layout: FrameLayoutInfo::empty(&arena),
+        safe_point_layouts: SortedSafePointEntries::empty(&arena),
+    });
+
+    static EXECUTABLE_ID: LazyLock<ExecutableId> = LazyLock::new(|| unsafe {
+        ExecutableId::new(AccountAddress::ONE, GlobalArenaPtr::from_static("foo"))
+    });
+    let executable_id = GlobalArenaPtr::from_static(&*EXECUTABLE_ID);
+
+    // module 0x1::bar {
+    //     public fun main(): u64 { 0x1::foo::add_one(41) }
+    // }
+    // Frame: [0..8) result, [8..32) metadata, [32..40) callee arg slot
+    let caller_name = GlobalArenaPtr::from_static("main");
+    let caller_code = arena.alloc_slice_fill_iter(vec![
+        // Store 41 into callee's arg slot (offset 32 = past metadata).
+        MicroOp::StoreImm8 {
+            dst: FO(8 + FRAME_METADATA_SIZE as u32),
+            imm: 41,
+        },
+        // Cross-module call to foo::add_one.
+        MicroOp::CallIndirect {
+            executable_id,
+            func_name: callee_name,
+        },
+        // Copy return value from callee's frame to our result slot.
+        MicroOp::Move8 {
+            dst: FO(0),
+            src: FO(8 + FRAME_METADATA_SIZE as u32),
+        },
+        MicroOp::Return,
+    ]);
+    let caller = arena.alloc(Function {
+        name: caller_name,
+        code: caller_code,
+        args_size: 0,
+        args_and_locals_size: 8,
+        extended_frame_size: 16 + FRAME_METADATA_SIZE,
+        zero_frame: false,
+        frame_layout: FrameLayoutInfo::empty(&arena),
+        safe_point_layouts: SortedSafePointEntries::empty(&arena),
+    });
+
+    // -- Set up interpreter and run --
+    let txn_ctx = TestTransactionContext {
+        target_executable_id: executable_id,
+        target_func_name: callee_name,
+        target_func_ptr: callee,
+    };
+    let gas_meter = SimpleGasMeter::new(u64::MAX);
+    let caller_ref = unsafe { caller.as_ref_unchecked() };
+    let mut ctx = InterpreterContext::new(&txn_ctx, &[], gas_meter, caller_ref);
+    ctx.run().expect("execution should succeed");
+
+    assert_eq!(ctx.root_result(), 42, "expected foo::add_one(41) = 42");
+}

--- a/third_party/move/mono-move/runtime/tests/enum_test.rs
+++ b/third_party/move/mono-move/runtime/tests/enum_test.rs
@@ -6,7 +6,7 @@
 use mono_move_alloc::{ExecutableArena, GlobalArenaPtr};
 use mono_move_core::{
     CodeOffset as CO, DescriptorId, FrameLayoutInfo, FrameOffset as FO, Function, MicroOp,
-    SortedSafePointEntries, ENUM_DATA_OFFSET, ENUM_TAG_OFFSET,
+    NoopTransactionContext, SortedSafePointEntries, ENUM_DATA_OFFSET, ENUM_TAG_OFFSET,
 };
 use mono_move_gas::SimpleGasMeter;
 use mono_move_runtime::{
@@ -56,8 +56,9 @@ fn enum_basic() {
         size: 24,
         variant_pointer_offsets: vec![vec![], vec![]],
     }];
+    let txn_ctx = NoopTransactionContext;
     let gas_meter = SimpleGasMeter::new(u64::MAX);
-    let mut ctx = InterpreterContext::new(&descriptors, gas_meter, unsafe {
+    let mut ctx = InterpreterContext::new(&txn_ctx, &descriptors, gas_meter, unsafe {
         functions[0].as_ref_unchecked()
     });
     ctx.run().unwrap();
@@ -113,8 +114,9 @@ fn enum_survives_gc() {
         size: 24,
         variant_pointer_offsets: vec![vec![], vec![]],
     }];
+    let txn_ctx = NoopTransactionContext;
     let gas_meter = SimpleGasMeter::new(u64::MAX);
-    let mut ctx = InterpreterContext::new(&descriptors, gas_meter, unsafe {
+    let mut ctx = InterpreterContext::new(&txn_ctx, &descriptors, gas_meter, unsafe {
         functions[0].as_ref_unchecked()
     });
     ctx.run().unwrap();
@@ -180,8 +182,9 @@ fn enum_gc_traces_refs() {
         },
         ObjectDescriptor::Trivial,
     ];
+    let txn_ctx = NoopTransactionContext;
     let gas_meter = SimpleGasMeter::new(u64::MAX);
-    let mut ctx = InterpreterContext::new(&descriptors, gas_meter, unsafe {
+    let mut ctx = InterpreterContext::new(&txn_ctx, &descriptors, gas_meter, unsafe {
         functions[0].as_ref_unchecked()
     });
     ctx.run().unwrap();
@@ -248,8 +251,9 @@ fn enum_pattern_match() {
         size: 24,
         variant_pointer_offsets: vec![vec![], vec![]],
     }];
+    let txn_ctx = NoopTransactionContext;
     let gas_meter = SimpleGasMeter::new(u64::MAX);
-    let mut ctx = InterpreterContext::new(&descriptors, gas_meter, unsafe {
+    let mut ctx = InterpreterContext::new(&txn_ctx, &descriptors, gas_meter, unsafe {
         functions[0].as_ref_unchecked()
     });
     ctx.run().unwrap();
@@ -300,8 +304,9 @@ fn enum_variant_switch() {
         size: 16,
         variant_pointer_offsets: vec![vec![], vec![]],
     }];
+    let txn_ctx = NoopTransactionContext;
     let gas_meter = SimpleGasMeter::new(u64::MAX);
-    let mut ctx = InterpreterContext::new(&descriptors, gas_meter, unsafe {
+    let mut ctx = InterpreterContext::new(&txn_ctx, &descriptors, gas_meter, unsafe {
         functions[0].as_ref_unchecked()
     });
     ctx.run().unwrap();
@@ -354,8 +359,9 @@ fn enum_borrow_field() {
         size: 24,
         variant_pointer_offsets: vec![vec![], vec![]],
     }];
+    let txn_ctx = NoopTransactionContext;
     let gas_meter = SimpleGasMeter::new(u64::MAX);
-    let mut ctx = InterpreterContext::new(&descriptors, gas_meter, unsafe {
+    let mut ctx = InterpreterContext::new(&txn_ctx, &descriptors, gas_meter, unsafe {
         functions[0].as_ref_unchecked()
     });
     ctx.run().unwrap();
@@ -416,8 +422,9 @@ fn enum_gc_variant_switching() {
         },
         ObjectDescriptor::Trivial,
     ];
+    let txn_ctx = NoopTransactionContext;
     let gas_meter = SimpleGasMeter::new(u64::MAX);
-    let mut ctx = InterpreterContext::new(&descriptors, gas_meter, unsafe {
+    let mut ctx = InterpreterContext::new(&txn_ctx, &descriptors, gas_meter, unsafe {
         functions[0].as_ref_unchecked()
     });
     ctx.run().unwrap();
@@ -483,8 +490,9 @@ fn enum_in_struct() {
             variant_pointer_offsets: vec![vec![], vec![]],
         },
     ];
+    let txn_ctx = NoopTransactionContext;
     let gas_meter = SimpleGasMeter::new(u64::MAX);
-    let mut ctx = InterpreterContext::new(&descriptors, gas_meter, unsafe {
+    let mut ctx = InterpreterContext::new(&txn_ctx, &descriptors, gas_meter, unsafe {
         functions[0].as_ref_unchecked()
     });
     ctx.run().unwrap();
@@ -561,8 +569,9 @@ fn enum_in_vector() {
             elem_pointer_offsets: vec![0],
         },
     ];
+    let txn_ctx = NoopTransactionContext;
     let gas_meter = SimpleGasMeter::new(u64::MAX);
-    let mut ctx = InterpreterContext::new(&descriptors, gas_meter, unsafe {
+    let mut ctx = InterpreterContext::new(&txn_ctx, &descriptors, gas_meter, unsafe {
         functions[0].as_ref_unchecked()
     });
     ctx.run().unwrap();

--- a/third_party/move/mono-move/runtime/tests/gc_stress.rs
+++ b/third_party/move/mono-move/runtime/tests/gc_stress.rs
@@ -24,7 +24,7 @@
 use mono_move_alloc::{ExecutableArena, ExecutableArenaPtr, GlobalArenaPtr};
 use mono_move_core::{
     CodeOffset as CO, DescriptorId, FrameLayoutInfo, FrameOffset as FO, Function, MicroOp,
-    SortedSafePointEntries, STRUCT_DATA_OFFSET,
+    NoopTransactionContext, SortedSafePointEntries, STRUCT_DATA_OFFSET,
 };
 use mono_move_gas::SimpleGasMeter;
 use mono_move_runtime::{
@@ -306,8 +306,10 @@ fn gc_stress() {
     let (functions, descriptors) = make_gc_stress_program(&arena, n, max_len);
     // SAFETY: Exclusive access during test setup; arena is alive.
     unsafe { Function::resolve_calls(&functions) };
+    let txn_ctx = NoopTransactionContext;
     let gas_meter = SimpleGasMeter::new(u64::MAX);
     let mut ctx = InterpreterContext::with_heap_size(
+        &txn_ctx,
         &descriptors,
         gas_meter,
         unsafe { functions[0].unwrap().as_ref_unchecked() },

--- a/third_party/move/mono-move/runtime/tests/ref_test.rs
+++ b/third_party/move/mono-move/runtime/tests/ref_test.rs
@@ -6,8 +6,8 @@
 
 use mono_move_alloc::{ExecutableArena, GlobalArenaPtr};
 use mono_move_core::{
-    DescriptorId, FrameLayoutInfo, FrameOffset as FO, Function, MicroOp, SortedSafePointEntries,
-    FRAME_METADATA_SIZE, STRUCT_DATA_OFFSET,
+    DescriptorId, FrameLayoutInfo, FrameOffset as FO, Function, MicroOp, NoopTransactionContext,
+    SortedSafePointEntries, FRAME_METADATA_SIZE, STRUCT_DATA_OFFSET,
 };
 use mono_move_gas::SimpleGasMeter;
 use mono_move_runtime::{
@@ -61,8 +61,9 @@ fn ref_basic() {
         safe_point_layouts: SortedSafePointEntries::empty(&arena),
     })];
     let descriptors = vec![ObjectDescriptor::Trivial];
+    let txn_ctx = NoopTransactionContext;
     let gas_meter = SimpleGasMeter::new(u64::MAX);
-    let mut ctx = InterpreterContext::new(&descriptors, gas_meter, unsafe {
+    let mut ctx = InterpreterContext::new(&txn_ctx, &descriptors, gas_meter, unsafe {
         functions[0].as_ref_unchecked()
     });
     ctx.run().unwrap();
@@ -125,8 +126,9 @@ fn ref_survives_gc() {
         safe_point_layouts: SortedSafePointEntries::empty(&arena),
     })];
     let descriptors = vec![ObjectDescriptor::Trivial];
+    let txn_ctx = NoopTransactionContext;
     let gas_meter = SimpleGasMeter::new(u64::MAX);
-    let mut ctx = InterpreterContext::new(&descriptors, gas_meter, unsafe {
+    let mut ctx = InterpreterContext::new(&txn_ctx, &descriptors, gas_meter, unsafe {
         functions[0].as_ref_unchecked()
     });
     ctx.run().unwrap();
@@ -222,8 +224,9 @@ fn ref_cross_frame() {
     let functions = [Some(main_func), Some(callee_func)];
     // SAFETY: Exclusive access during test setup; arena is alive.
     unsafe { Function::resolve_calls(&functions) };
+    let txn_ctx = NoopTransactionContext;
     let gas_meter = SimpleGasMeter::new(u64::MAX);
-    let mut ctx = InterpreterContext::new(&descriptors, gas_meter, unsafe {
+    let mut ctx = InterpreterContext::new(&txn_ctx, &descriptors, gas_meter, unsafe {
         functions[0].unwrap().as_ref_unchecked()
     });
     ctx.run().unwrap();
@@ -304,8 +307,9 @@ fn ref_multiple_borrows() {
         safe_point_layouts: SortedSafePointEntries::empty(&arena),
     })];
     let descriptors = vec![ObjectDescriptor::Trivial];
+    let txn_ctx = NoopTransactionContext;
     let gas_meter = SimpleGasMeter::new(u64::MAX);
-    let mut ctx = InterpreterContext::new(&descriptors, gas_meter, unsafe {
+    let mut ctx = InterpreterContext::new(&txn_ctx, &descriptors, gas_meter, unsafe {
         functions[0].as_ref_unchecked()
     });
     ctx.run().unwrap();
@@ -371,8 +375,9 @@ fn ref_borrow_local() {
         safe_point_layouts: SortedSafePointEntries::empty(&arena),
     })];
     let descriptors = vec![ObjectDescriptor::Trivial];
+    let txn_ctx = NoopTransactionContext;
     let gas_meter = SimpleGasMeter::new(u64::MAX);
-    let mut ctx = InterpreterContext::new(&descriptors, gas_meter, unsafe {
+    let mut ctx = InterpreterContext::new(&txn_ctx, &descriptors, gas_meter, unsafe {
         functions[0].as_ref_unchecked()
     });
     ctx.run().unwrap();
@@ -461,8 +466,9 @@ fn ref_nested_vectors() {
         elem_size: 8,
         elem_pointer_offsets: vec![0],
     }];
+    let txn_ctx = NoopTransactionContext;
     let gas_meter = SimpleGasMeter::new(u64::MAX);
-    let mut ctx = InterpreterContext::new(&descriptors, gas_meter, unsafe {
+    let mut ctx = InterpreterContext::new(&txn_ctx, &descriptors, gas_meter, unsafe {
         functions[0].as_ref_unchecked()
     });
     ctx.run().unwrap();
@@ -546,8 +552,9 @@ fn ref_survives_double_gc() {
         safe_point_layouts: SortedSafePointEntries::empty(&arena),
     })];
     let descriptors = vec![ObjectDescriptor::Trivial];
+    let txn_ctx = NoopTransactionContext;
     let gas_meter = SimpleGasMeter::new(u64::MAX);
-    let mut ctx = InterpreterContext::new(&descriptors, gas_meter, unsafe {
+    let mut ctx = InterpreterContext::new(&txn_ctx, &descriptors, gas_meter, unsafe {
         functions[0].as_ref_unchecked()
     });
     ctx.run().unwrap();
@@ -610,8 +617,9 @@ fn ref_struct_field_borrow() {
         size: 16,
         pointer_offsets: vec![],
     }];
+    let txn_ctx = NoopTransactionContext;
     let gas_meter = SimpleGasMeter::new(u64::MAX);
-    let mut ctx = InterpreterContext::new(&descriptors, gas_meter, unsafe {
+    let mut ctx = InterpreterContext::new(&txn_ctx, &descriptors, gas_meter, unsafe {
         functions[0].as_ref_unchecked()
     });
     ctx.run().unwrap();
@@ -669,8 +677,9 @@ fn ref_struct_field_survives_gc() {
         size: 16,
         pointer_offsets: vec![],
     }];
+    let txn_ctx = NoopTransactionContext;
     let gas_meter = SimpleGasMeter::new(u64::MAX);
-    let mut ctx = InterpreterContext::new(&descriptors, gas_meter, unsafe {
+    let mut ctx = InterpreterContext::new(&txn_ctx, &descriptors, gas_meter, unsafe {
         functions[0].as_ref_unchecked()
     });
     ctx.run().unwrap();

--- a/third_party/move/mono-move/runtime/tests/struct_test.rs
+++ b/third_party/move/mono-move/runtime/tests/struct_test.rs
@@ -5,8 +5,8 @@
 
 use mono_move_alloc::{ExecutableArena, GlobalArenaPtr};
 use mono_move_core::{
-    DescriptorId, FrameLayoutInfo, FrameOffset as FO, Function, MicroOp, SortedSafePointEntries,
-    STRUCT_DATA_OFFSET,
+    DescriptorId, FrameLayoutInfo, FrameOffset as FO, Function, MicroOp, NoopTransactionContext,
+    SortedSafePointEntries, STRUCT_DATA_OFFSET,
 };
 use mono_move_gas::SimpleGasMeter;
 use mono_move_runtime::{
@@ -45,8 +45,9 @@ fn struct_inline() {
         safe_point_layouts: SortedSafePointEntries::empty(&arena),
     })];
     let descriptors = vec![ObjectDescriptor::Trivial];
+    let txn_ctx = NoopTransactionContext;
     let gas_meter = SimpleGasMeter::new(u64::MAX);
-    let mut ctx = InterpreterContext::new(&descriptors, gas_meter, unsafe {
+    let mut ctx = InterpreterContext::new(&txn_ctx, &descriptors, gas_meter, unsafe {
         functions[0].as_ref_unchecked()
     });
     ctx.run().unwrap();
@@ -91,8 +92,9 @@ fn struct_inline_borrow() {
         safe_point_layouts: SortedSafePointEntries::empty(&arena),
     })];
     let descriptors = vec![ObjectDescriptor::Trivial];
+    let txn_ctx = NoopTransactionContext;
     let gas_meter = SimpleGasMeter::new(u64::MAX);
-    let mut ctx = InterpreterContext::new(&descriptors, gas_meter, unsafe {
+    let mut ctx = InterpreterContext::new(&txn_ctx, &descriptors, gas_meter, unsafe {
         functions[0].as_ref_unchecked()
     });
     ctx.run().unwrap();
@@ -140,8 +142,9 @@ fn struct_heap_basic() {
         size: 16,
         pointer_offsets: vec![],
     }];
+    let txn_ctx = NoopTransactionContext;
     let gas_meter = SimpleGasMeter::new(u64::MAX);
-    let mut ctx = InterpreterContext::new(&descriptors, gas_meter, unsafe {
+    let mut ctx = InterpreterContext::new(&txn_ctx, &descriptors, gas_meter, unsafe {
         functions[0].as_ref_unchecked()
     });
     ctx.run().unwrap();
@@ -190,8 +193,9 @@ fn struct_heap_survives_gc() {
         size: 16,
         pointer_offsets: vec![],
     }];
+    let txn_ctx = NoopTransactionContext;
     let gas_meter = SimpleGasMeter::new(u64::MAX);
-    let mut ctx = InterpreterContext::new(&descriptors, gas_meter, unsafe {
+    let mut ctx = InterpreterContext::new(&txn_ctx, &descriptors, gas_meter, unsafe {
         functions[0].as_ref_unchecked()
     });
     ctx.run().unwrap();
@@ -264,8 +268,9 @@ fn struct_with_vector_field() {
         },
         ObjectDescriptor::Trivial,
     ];
+    let txn_ctx = NoopTransactionContext;
     let gas_meter = SimpleGasMeter::new(u64::MAX);
-    let mut ctx = InterpreterContext::new(&descriptors, gas_meter, unsafe {
+    let mut ctx = InterpreterContext::new(&txn_ctx, &descriptors, gas_meter, unsafe {
         functions[0].as_ref_unchecked()
     });
     ctx.run().unwrap();
@@ -329,8 +334,9 @@ fn struct_borrow_field() {
         size: 16,
         pointer_offsets: vec![],
     }];
+    let txn_ctx = NoopTransactionContext;
     let gas_meter = SimpleGasMeter::new(u64::MAX);
-    let mut ctx = InterpreterContext::new(&descriptors, gas_meter, unsafe {
+    let mut ctx = InterpreterContext::new(&txn_ctx, &descriptors, gas_meter, unsafe {
         functions[0].as_ref_unchecked()
     });
     ctx.run().unwrap();
@@ -385,8 +391,9 @@ fn struct_borrow_survives_gc() {
         size: 16,
         pointer_offsets: vec![],
     }];
+    let txn_ctx = NoopTransactionContext;
     let gas_meter = SimpleGasMeter::new(u64::MAX);
-    let mut ctx = InterpreterContext::new(&descriptors, gas_meter, unsafe {
+    let mut ctx = InterpreterContext::new(&txn_ctx, &descriptors, gas_meter, unsafe {
         functions[0].as_ref_unchecked()
     });
     ctx.run().unwrap();

--- a/third_party/move/mono-move/runtime/tests/vec_sum.rs
+++ b/third_party/move/mono-move/runtime/tests/vec_sum.rs
@@ -4,7 +4,7 @@
 use mono_move_alloc::{ExecutableArena, ExecutableArenaPtr, GlobalArenaPtr};
 use mono_move_core::{
     CodeOffset as CO, DescriptorId, FrameLayoutInfo, FrameOffset as FO, Function, MicroOp,
-    SortedSafePointEntries,
+    NoopTransactionContext, SortedSafePointEntries,
 };
 use mono_move_gas::SimpleGasMeter;
 use mono_move_runtime::{InterpreterContext, ObjectDescriptor};
@@ -68,8 +68,9 @@ fn vec_sum_100() {
     let n: u64 = 100;
     let arena = ExecutableArena::new();
     let (functions, descriptors) = make_vec_sum_program(&arena, n);
+    let txn_ctx = NoopTransactionContext;
     let gas_meter = SimpleGasMeter::new(u64::MAX);
-    let mut ctx = InterpreterContext::new(&descriptors, gas_meter, unsafe {
+    let mut ctx = InterpreterContext::new(&txn_ctx, &descriptors, gas_meter, unsafe {
         functions[0].as_ref_unchecked()
     });
     ctx.run().unwrap();
@@ -81,8 +82,10 @@ fn vec_sum_with_gc_pressure() {
     let n: u64 = 200;
     let arena = ExecutableArena::new();
     let (functions, descriptors) = make_vec_sum_program(&arena, n);
+    let txn_ctx = NoopTransactionContext;
     let gas_meter = SimpleGasMeter::new(u64::MAX);
     let mut ctx = InterpreterContext::with_heap_size(
+        &txn_ctx,
         &descriptors,
         gas_meter,
         unsafe { functions[0].as_ref_unchecked() },

--- a/third_party/move/mono-move/specializer/src/lower/context.rs
+++ b/third_party/move/mono-move/specializer/src/lower/context.rs
@@ -112,11 +112,10 @@ pub struct LoweringContext {
 pub fn try_build_context(
     module: &CompiledModule,
     func_ir: &FunctionIR,
-    func_id_map: &[Option<u32>],
 ) -> Result<Option<LoweringContext>> {
     // Use an inner function that returns Option to keep `?` ergonomic for
     // non-concrete type checks, then wrap the result.
-    let inner = try_build_context_inner(module, func_ir, func_id_map);
+    let inner = try_build_context_inner(module, func_ir);
     match inner {
         Some(result) => result.map(Some),
         None => Ok(None),
@@ -128,7 +127,6 @@ pub fn try_build_context(
 fn try_build_context_inner(
     module: &CompiledModule,
     func_ir: &FunctionIR,
-    func_id_map: &[Option<u32>],
 ) -> Option<Result<LoweringContext>> {
     // 1. Compute home slot layout
     let mut home_slots = Vec::with_capacity(func_ir.num_home_slots as usize);
@@ -169,7 +167,7 @@ fn try_build_context_inner(
         };
 
         let callee_handle = module.function_handle_at(handle_idx);
-        let callee_func_id = func_id_map[handle_idx.0 as usize]?;
+        let callee_func_id = handle_idx.0 as u32;
 
         // Param layout
         let param_sig = &module.signature_at(callee_handle.parameters).0;
@@ -217,21 +215,4 @@ fn try_build_context_inner(
         return_slots,
         num_xfer_slots: func_ir.num_xfer_slots,
     }))
-}
-
-/// Build a func_id_map from the module: FunctionHandleIndex -> Option<u32>.
-/// For same-module definitions, maps to the definition index.
-/// For cross-module handles, maps to None.
-pub fn build_func_id_map(module: &CompiledModule) -> Vec<Option<u32>> {
-    let self_module_handle_idx = module.self_module_handle_idx;
-    let num_handles = module.function_handles.len();
-    let mut map: Vec<Option<u32>> = vec![None; num_handles];
-
-    for (def_idx, func_def) in module.function_defs.iter().enumerate() {
-        let handle = module.function_handle_at(func_def.function);
-        if handle.module == self_module_handle_idx {
-            map[func_def.function.0 as usize] = Some(def_idx as u32);
-        }
-    }
-    map
 }

--- a/third_party/move/mono-move/specializer/src/lower/mod.rs
+++ b/third_party/move/mono-move/specializer/src/lower/mod.rs
@@ -7,7 +7,7 @@ pub mod context;
 pub mod display;
 mod translate;
 
-pub use context::{build_func_id_map, try_build_context, LoweringContext, SlotInfo};
+pub use context::{try_build_context, LoweringContext, SlotInfo};
 pub use display::MicroOpsFunctionDisplay;
 use mono_move_core::MicroOp;
 use move_binary_format::file_format::IdentifierIndex;

--- a/third_party/move/mono-move/specializer/src/pipeline.rs
+++ b/third_party/move/mono-move/specializer/src/pipeline.rs
@@ -5,7 +5,7 @@
 
 use crate::{
     destack,
-    lower::{build_func_id_map, lower_function, try_build_context, LoweredFunction, LoweredModule},
+    lower::{lower_function, try_build_context, LoweredFunction, LoweredModule},
 };
 use anyhow::Result;
 use mono_move_core::{MicroOpGasSchedule, FRAME_METADATA_SIZE};
@@ -21,7 +21,6 @@ pub fn destack_and_lower_module(module: CompiledModule) -> Result<LoweredModule>
         .map(|i| StructNameIndex::new(i as u32))
         .collect();
     let module_ir = destack(module, &struct_name_table)?;
-    let func_id_map = build_func_id_map(&module_ir.module);
 
     let mut functions = Vec::with_capacity(module_ir.functions.len());
     for func_ir in &module_ir.functions {
@@ -29,7 +28,7 @@ pub fn destack_and_lower_module(module: CompiledModule) -> Result<LoweredModule>
             functions.push(None);
             continue;
         };
-        let lowered = match try_build_context(&module_ir.module, func_ir, &func_id_map)? {
+        let lowered = match try_build_context(&module_ir.module, func_ir)? {
             Some(ctx) => {
                 let micro_ops = lower_function(func_ir, &ctx)?;
                 let code = GasInstrumentor::new(MicroOpGasSchedule).run(micro_ops);

--- a/third_party/move/mono-move/specializer/tests/testsuite.rs
+++ b/third_party/move/mono-move/specializer/tests/testsuite.rs
@@ -9,7 +9,7 @@ use move_model::metadata::LanguageVersion;
 use move_vm_types::loaded_data::struct_name_indexing::StructNameIndex;
 use specializer::{
     destack,
-    lower::{build_func_id_map, lower_function, try_build_context, MicroOpsFunctionDisplay},
+    lower::{lower_function, try_build_context, MicroOpsFunctionDisplay},
     stackless_exec_ir::ModuleIR,
 };
 use std::path::Path;
@@ -22,7 +22,6 @@ fn make_struct_name_table(module: &CompiledModule) -> Vec<StructNameIndex> {
 
 fn format_micro_ops(module_ir: &ModuleIR) -> String {
     let module = &module_ir.module;
-    let func_id_map = build_func_id_map(module);
     let self_handle = module.module_handle_at(module.self_module_handle_idx);
     let addr = module.address_identifier_at(self_handle.address);
     let mod_name = module.identifier_at(self_handle.name);
@@ -36,7 +35,7 @@ fn format_micro_ops(module_ir: &ModuleIR) -> String {
 
     for func_ir in module_ir.functions.iter().flatten() {
         let func_name = module.identifier_at(func_ir.name_idx).to_string();
-        match try_build_context(module, func_ir, &func_id_map) {
+        match try_build_context(module, func_ir) {
             Err(e) => {
                 out.push_str(&format!(
                     "\nfun {}(): skipped (context: {})\n",

--- a/third_party/move/mono-move/testsuite/Cargo.toml
+++ b/third_party/move/mono-move/testsuite/Cargo.toml
@@ -15,6 +15,7 @@ rust-version = { workspace = true }
 [dependencies]
 anyhow = { workspace = true }
 legacy-move-compiler = { workspace = true }
+mono-move-core = { workspace = true }
 mono-move-gas = { workspace = true }
 mono-move-global-context = { workspace = true }
 mono-move-runtime = { workspace = true }

--- a/third_party/move/mono-move/testsuite/src/runner.rs
+++ b/third_party/move/mono-move/testsuite/src/runner.rs
@@ -7,6 +7,7 @@
 use crate::{matcher::check_output, parser::Step};
 use anyhow::anyhow;
 use legacy_move_compiler::{compiled_unit::CompiledUnit, shared::known_attributes::KnownAttribute};
+use mono_move_core::NoopTransactionContext;
 use mono_move_gas::SimpleGasMeter;
 use mono_move_global_context::{ExecutionGuard, GlobalContext};
 use mono_move_runtime::InterpreterContext;
@@ -221,9 +222,10 @@ fn execute_function_v2(
         .and_then(|executable| executable.get_function(function_name))
         .unwrap_or_else(|| panic!("Failed to load function or find executable"));
 
+    let txn_ctx = NoopTransactionContext;
     let gas_meter = SimpleGasMeter::new(u64::MAX);
     // TODO: Set object descriptor table when supported.
-    let mut interpreter = InterpreterContext::new(&[], gas_meter, function);
+    let mut interpreter = InterpreterContext::new(&txn_ctx, &[], gas_meter, function);
 
     // TODO: Check function signature to decide how to parse arguments.
     for (i, arg) in args.iter().enumerate() {


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

Adds the initial infrastructure for cross-module function calls in MonoMove. The specializer now emits `CallModuleFunc` instead of bailing when it encounters a call to a function in another module. Before execution, a `FunctionResolver` resolves these to direct-pointer `CallLocalFunc` instructions.

Same-package cross-module calls will be resolved eagerly at load time once the loader (which implements `FunctionResolver`) is implemented. Cross-package calls will need lazy runtime resolution, which is future work blocked on the loader.

- **Instruction set**: new `CallModuleFunc { func_id }` micro-op, resolved to `CallLocalFunc` before execution
- **Specializer**: lowering emits `CallModuleFunc` for cross-module calls
- **Executable builder**: builds a `CrossModuleFuncRef` table mapping function handles to `(ExecutableId, func_name)`
- **Resolution**: `Function::resolve_module_calls` patches `CallModuleFunc` → `CallLocalFunc` via the `FunctionResolver` trait
Same-package cross-module calls will be resolved eagerly at load time once the loader (which implements `FunctionResolver`) is implemented. Cross-package calls will eventually need lazy runtime resolution, 

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new call op variants and changes interpreter call dispatch to resolve cross-module functions at runtime, which touches core execution flow and could affect correctness/performance. Also broad API signature changes (new `TransactionContext` parameter) require updates across tests/benches and increase integration surface.
> 
> **Overview**
> Introduces initial cross-module call support by extending the micro-op ISA with `CallIndirect` (module+function name) and renaming direct calls to `CallDirect`, with corresponding gas metering/display updates.
> 
> Updates executable building to rewrite `CallFunc` into either `CallDirect` for local handles or `CallIndirect` for external module handles, and adds `Function::resolve_module_calls` to optionally patch `CallIndirect` into `CallDirect` via a `FunctionResolver`.
> 
> Plumbs a new per-transaction `TransactionContext` into `InterpreterContext`, implementing runtime slow-path dispatch for `CallIndirect`, and updates all affected tests/benches plus adds a focused runtime test for indirect cross-module dispatch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37214729b3e543845c25970670e462c01e7be33d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->