### PR TITLE
docs(consensus): fix 'QuorurmCertificate' -> 'QuorumCertificate' in block/block_data doc comments

### DIFF
--- a/consensus/consensus-types/src/block.rs
+++ b/consensus/consensus-types/src/block.rs
@@ -44,7 +44,7 @@ pub mod block_test;
 
 #[derive(Serialize, Clone, PartialEq, Eq)]
 /// Block has the core data of a consensus block that should be persistent when necessary.
-/// Each block must know the id of its parent and keep the QuorurmCertificate to that parent.
+/// Each block must know the id of its parent and keep the QuorumCertificate to that parent.
 pub struct Block {
     /// This block's id as a hash value, it is generated at call time
     #[serde(skip)]

--- a/consensus/consensus-types/src/block_data.rs
+++ b/consensus/consensus-types/src/block_data.rs
@@ -71,7 +71,7 @@ pub enum BlockType {
 
 #[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq, CryptoHasher)]
 /// Block has the core data of a consensus block that should be persistent when necessary.
-/// Each block must know the id of its parent and keep the QuorurmCertificate to that parent.
+/// Each block must know the id of its parent and keep the QuorumCertificate to that parent.
 pub struct BlockData {
     /// Epoch number corresponds to the set of validators that are active for this block.
     epoch: u64,


### PR DESCRIPTION
## Description

Two doc comments in \`consensus/consensus-types/src\` referred to \`QuorurmCertificate\` (double 'r'):

- \`block.rs:47\`
- \`block_data.rs:74\`

Every other mention of the type in the consensus tree uses the correct \`QuorumCertificate\`. Doc-comment-only fix — no code behavior changed.

## Test Plan

N/A — doc comments only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: doc-comment-only typo fix with no behavior or data handling changes.
> 
> **Overview**
> Fixes a misspelling in Rust doc comments by renaming `QuorurmCertificate` to `QuorumCertificate` in the documentation for `Block` (`block.rs`) and `BlockData` (`block_data.rs`). No functional code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2cdc91bcd225e6188b24e4c006259491cfb295f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->