### PR TITLE
[smoke-test] Fix aptos-debugger jemalloc HPA hang

### DIFF
--- a/testsuite/smoke-test/src/genesis.rs
+++ b/testsuite/smoke-test/src/genesis.rs
@@ -50,7 +50,7 @@ use std::{
 /// 7. Verify that the VFNs are able to sync with the rest of the network.
 async fn test_fullnode_genesis_transaction_flow() {
     println!("0. Building the Aptos CLI and debugger!");
-    let aptos_debugger = workspace_builder::get_bin("aptos-debugger");
+    workspace_builder::get_bin("aptos-debugger");
     let aptos_cli = workspace_builder::get_bin("aptos");
 
     println!("1. Starting a 4 node validator network with 2 VFNs!");
@@ -96,7 +96,7 @@ async fn test_fullnode_genesis_transaction_flow() {
     println!("6. Applying the genesis transaction to the first validator!");
     let first_validator_config = swarm.validators_mut().next().unwrap().config().clone();
     let first_validator_storage_dir = first_validator_config.storage.dir();
-    let output = Command::new(aptos_debugger.as_path())
+    let output = workspace_builder::get_aptos_debugger_command()
         .current_dir(workspace_root())
         .args(vec![
             "aptos-db",
@@ -195,7 +195,7 @@ async fn test_fullnode_genesis_transaction_flow() {
 /// 7. Verify that a failed validator node is able to db-restore and rejoin the network.
 async fn test_validator_genesis_transaction_and_db_restore_flow() {
     println!("0. Building the Aptos CLI and debugger!");
-    let aptos_debugger = workspace_builder::get_bin("aptos-debugger");
+    workspace_builder::get_bin("aptos-debugger");
     let aptos_cli = workspace_builder::get_bin("aptos");
 
     println!("1. Starting a 5 node validator network!");
@@ -233,7 +233,7 @@ async fn test_validator_genesis_transaction_and_db_restore_flow() {
     println!("7. Applying the genesis transaction to the first validator!");
     let first_validator_config = swarm.validators_mut().next().unwrap().config().clone();
     let first_validator_storage_dir = first_validator_config.storage.dir();
-    let output = Command::new(aptos_debugger.as_path())
+    let output = workspace_builder::get_aptos_debugger_command()
         .current_dir(workspace_root())
         .args(vec![
             "aptos-db",

--- a/testsuite/smoke-test/src/storage.rs
+++ b/testsuite/smoke-test/src/storage.rs
@@ -20,7 +20,6 @@ use itertools::Itertools;
 use std::{
     fs,
     path::Path,
-    process::Command,
     sync::{
         atomic::{AtomicBool, Ordering},
         Arc,
@@ -181,12 +180,11 @@ async fn test_db_restore() {
 fn db_backup_verify(backup_path: &Path, trusted_waypoints: &[Waypoint]) {
     info!("---------- running aptos-debugger aptos-db backup-verify");
     let now = Instant::now();
-    let bin_path = workspace_builder::get_bin("aptos-debugger");
     let metadata_cache_path = TempPath::new();
 
     metadata_cache_path.create_as_dir().unwrap();
 
-    let mut cmd = Command::new(bin_path.as_path());
+    let mut cmd = workspace_builder::get_aptos_debugger_command();
     cmd.args(["aptos-db", "backup", "verify"]);
     trusted_waypoints.iter().for_each(|w| {
         cmd.arg("--trust-waypoint");
@@ -212,13 +210,12 @@ fn db_backup_verify(backup_path: &Path, trusted_waypoints: &[Waypoint]) {
 fn replay_verify(backup_path: &Path, trusted_waypoints: &[Waypoint]) {
     info!("---------- running replay-verify");
     let now = Instant::now();
-    let bin_path = workspace_builder::get_bin("aptos-debugger");
     let metadata_cache_path = TempPath::new();
     let target_db_dir = TempPath::new();
 
     metadata_cache_path.create_as_dir().unwrap();
 
-    let mut cmd = Command::new(bin_path.as_path());
+    let mut cmd = workspace_builder::get_aptos_debugger_command();
     cmd.args(["aptos-db", "replay-verify"]);
     trusted_waypoints.iter().for_each(|w| {
         cmd.arg("--trust-waypoint");
@@ -256,7 +253,6 @@ fn wait_for_backups(
     target_epoch: u64,
     target_version: u64,
     now: Instant,
-    bin_path: &Path,
     metadata_cache_path: &Path,
     backup_path: &Path,
     trusted_waypoints: &[Waypoint],
@@ -266,7 +262,7 @@ fn wait_for_backups(
             "{}th wait for the backup to reach epoch {}, version {}.",
             i, target_epoch, target_version,
         );
-        let state = get_backup_storage_state(bin_path, metadata_cache_path, backup_path)?;
+        let state = get_backup_storage_state(metadata_cache_path, backup_path)?;
         if let Some(epoch_ending) = state.latest_epoch_ending_epoch
             && let Some(txn_version) = state.latest_transaction_version
             && state.latest_state_snapshot_epoch.is_some()
@@ -298,11 +294,10 @@ fn wait_for_backups(
 }
 
 fn get_backup_storage_state(
-    bin_path: &Path,
     metadata_cache_path: &Path,
     backup_path: &Path,
 ) -> Result<BackupStorageState> {
-    let output = Command::new(bin_path)
+    let output = workspace_builder::get_aptos_debugger_command()
         .current_dir(workspace_root())
         .args([
             "aptos-db",
@@ -332,7 +327,6 @@ pub(crate) fn db_backup(
 ) -> (TempPath, Version) {
     info!("---------- running aptos db tool backup");
     let now = Instant::now();
-    let bin_path = workspace_builder::get_bin("aptos-debugger");
     let metadata_cache_path1 = TempPath::new();
     let metadata_cache_path2 = TempPath::new();
     let backup_path = TempPath::new();
@@ -343,10 +337,10 @@ pub(crate) fn db_backup(
 
     // Initialize backup storage, avoid race between the coordinator and wait_for_backups to create
     // the identity file.
-    get_backup_storage_state(&bin_path, metadata_cache_path2.path(), backup_path.path()).unwrap();
+    get_backup_storage_state(metadata_cache_path2.path(), backup_path.path()).unwrap();
 
     // spawn the backup coordinator
-    let mut backup_coordinator = Command::new(bin_path.as_path())
+    let mut backup_coordinator = workspace_builder::get_aptos_debugger_command()
         .current_dir(workspace_root())
         .args([
             "aptos-db",
@@ -373,14 +367,13 @@ pub(crate) fn db_backup(
         target_epoch,
         target_version,
         now,
-        bin_path.as_path(),
         metadata_cache_path2.path(),
         backup_path.path(),
         trusted_waypoints,
     );
 
     // start the backup compaction
-    let compaction = Command::new(bin_path.as_path())
+    let compaction = workspace_builder::get_aptos_debugger_command()
         .current_dir(workspace_root())
         .args([
             "aptos-db",
@@ -419,12 +412,11 @@ pub(crate) fn db_restore(
     target_verion: Option<Version>, /* target version should be same as epoch ending version to start a node */
 ) {
     let now = Instant::now();
-    let bin_path = workspace_builder::get_bin("aptos-debugger");
     let metadata_cache_path = TempPath::new();
 
     metadata_cache_path.create_as_dir().unwrap();
 
-    let mut cmd = Command::new(bin_path.as_path());
+    let mut cmd = workspace_builder::get_aptos_debugger_command();
     cmd.args(["aptos-db", "restore", "bootstrap-db"]);
     trusted_waypoints.iter().for_each(|w| {
         cmd.arg("--trust-waypoint");

--- a/testsuite/smoke-test/src/workspace_builder.rs
+++ b/testsuite/smoke-test/src/workspace_builder.rs
@@ -76,6 +76,17 @@ fn build_dir() -> PathBuf {
         .expect("Can't find the build directory. Cannot continue running tests")
 }
 
+// Returns a `Command` for invoking the `aptos-debugger` binary.
+//
+// Sets `MALLOC_CONF=hpa:false` on the child to work around a jemalloc HPA deadlock that hangs the
+// subprocess on exit under concurrent load. All smoke-test call sites that spawn `aptos-debugger`
+// should use this helper.
+pub fn get_aptos_debugger_command() -> Command {
+    let mut cmd = Command::new(get_bin("aptos-debugger"));
+    cmd.env("MALLOC_CONF", "hpa:false");
+    cmd
+}
+
 // Path to a specified binary
 pub fn get_bin<S: AsRef<str>>(bin_name: S) -> PathBuf {
     assert_ne!(


### PR DESCRIPTION

`test_db_restore` and the genesis-flow tests have been hanging and timing out
after 1800s in CI sporadically. Spent quite some time and tracked this down to a
jemalloc HPA deadlock inside NPTL TSD cleanup when the `aptos-debugger`
subprocess exits, causing commands like `aptos-debugger aptos-db backup verify`
to never terminate:

```
Thread 130 (tokio-rt-worker, RUNNING):
#0  _rjem_je_psset_pick_purge at src/psset.c:338
#1  hpa_try_purge at src/hpa.c:384
#2  hpa_shard_maybe_do_deferred_work at src/hpa.c:542
#3  hpa_dalloc_batch at src/hpa.c:864
...
#13 _rjem_je_tsd_cleanup at src/tsd.c:408
#15 __GI___nptl_deallocate_tsd
#17 start_thread ()
```

HPA targets long-running processes like `aptos-node`, not short-lived CLI
invocations, so disabling it for `aptos-debugger` in smoke tests is fine.
`aptos-debugger` is also used for replay-verify, where HPA is still wanted, so
the workaround is scoped to the smoke-test call sites only: all spawns now go
through a new `workspace_builder::get_aptos_debugger_command()` helper that sets
`MALLOC_CONF=hpa:false` on the child.

We might also undo this after a new jemalloc release, since the bug is likely
fixed in trunk.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are scoped to smoke-test helpers and only affect how the `aptos-debugger` subprocess is spawned (adds an env var) to avoid CI hangs.
> 
> **Overview**
> Adds a smoke-test-only `workspace_builder::get_aptos_debugger_command()` helper that runs `aptos-debugger` with `MALLOC_CONF=hpa:false` to avoid sporadic jemalloc HPA deadlocks/hangs on subprocess exit.
> 
> Updates genesis-flow and storage/backup/restore smoke tests to invoke `aptos-debugger` via this helper (and removes now-unneeded `Command::new`/`bin_path` plumbing), while still prebuilding the binary via `get_bin("aptos-debugger")`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c411996e28a2b381abd08cf6a7608f61e18bd64e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->