### PR TITLE
[storage] Verify hot-state proofs in ProvableStateSummary

### DIFF
--- a/storage/aptosdb/src/db/aptosdb_reader.rs
+++ b/storage/aptosdb/src/db/aptosdb_reader.rs
@@ -32,6 +32,7 @@ use aptos_types::{
     },
     state_proof::StateProof,
     state_store::{
+        hot_state::HotStateValue,
         state_key::StateKey,
         state_storage_usage::StateStorageUsage,
         state_value::{StateValue, StateValueChunkWithProof},
@@ -569,20 +570,31 @@ impl DbReader for AptosDB {
 
     fn get_state_value_with_proof_by_version_ext(
         &self,
-        key_hash: &HashValue,
+        key_hash: HashValue,
         version: Version,
         root_depth: usize,
-        use_hot_state: bool,
     ) -> Result<(Option<StateValue>, SparseMerkleProofExt)> {
         gauged_api("get_state_value_with_proof_by_version_ext", || {
             self.error_if_state_merkle_pruned("State merkle", version)?;
 
-            self.state_store.get_state_value_with_proof_by_version_ext(
-                key_hash,
-                version,
-                root_depth,
-                use_hot_state,
-            )
+            self.state_store
+                .get_state_value_with_proof_by_version_ext(key_hash, version, root_depth)
+        })
+    }
+
+    fn get_hot_state_value_with_proof_by_version_ext(
+        &self,
+        key_hash: HashValue,
+        version: Version,
+        root_depth: usize,
+    ) -> Result<(Option<HotStateValue>, SparseMerkleProofExt)> {
+        gauged_api("get_hot_state_value_with_proof_by_version_ext", || {
+            // TODO(HotState): check `hot_state_kv_pruner` / `hot_state_merkle_pruner` instead.
+            self.error_if_state_kv_pruned("HotStateValue", version)?;
+            self.error_if_state_merkle_pruned("State merkle", version)?;
+
+            self.state_store
+                .get_hot_state_value_with_proof_by_version_ext(key_hash, version, root_depth)
         })
     }
 

--- a/storage/aptosdb/src/db/fake_aptosdb.rs
+++ b/storage/aptosdb/src/db/fake_aptosdb.rs
@@ -799,7 +799,7 @@ impl DbReader for FakeAptosDB {
 
     fn get_state_value_with_proof_by_version_ext(
         &self,
-        key_hash: &HashValue,
+        key_hash: HashValue,
         version: Version,
         root_depth: usize,
     ) -> Result<(Option<StateValue>, SparseMerkleProofExt)> {

--- a/storage/aptosdb/src/state_kv_db.rs
+++ b/storage/aptosdb/src/state_kv_db.rs
@@ -398,21 +398,21 @@ impl StateKvDb {
             .and_then(|((_, version), value_opt)| value_opt.map(|value| (version, value))))
     }
 
-    /// Returns the latest hot state entry for the given key at or before the
-    /// given version. Outer `None` means no entry found; inner `None` means the
-    /// key was evicted at that version.
-    #[cfg(test)]
+    /// Returns the latest hot state entry for the given key hash at or before
+    /// the given version. Outer `None` means no entry found; inner `None` means
+    /// the key was evicted at that version.
     pub(crate) fn get_hot_state_entry_by_version(
         &self,
-        state_key: &StateKey,
+        key_hash: HashValue,
         version: Version,
     ) -> Result<Option<(Version, Option<HotStateEntry>)>> {
         let mut read_opts = ReadOptions::default();
         read_opts.set_prefix_same_as_start(true);
+        let shard_id = usize::from(key_hash.nibble(0));
         let mut iter = self
-            .db_shard(state_key.get_shard_id())
+            .db_shard(shard_id)
             .iter_with_opts::<HotStateValueByKeyHashSchema>(read_opts)?;
-        iter.seek(&(state_key.hash(), version))?;
+        iter.seek(&(key_hash, version))?;
         Ok(iter
             .next()
             .transpose()?

--- a/storage/aptosdb/src/state_store/mod.rs
+++ b/storage/aptosdb/src/state_store/mod.rs
@@ -67,6 +67,7 @@ use aptos_storage_interface::{
 use aptos_types::{
     proof::{definition::LeafCount, SparseMerkleProofExt, SparseMerkleRangeProof},
     state_store::{
+        hot_state::HotStateValue,
         state_key::StateKey,
         state_slot::{StateSlot, StateSlotKind},
         state_storage_usage::StateStorageUsage,
@@ -248,19 +249,13 @@ impl DbReader for StateDb {
     /// Get the state value with proof given the state key and version
     fn get_state_value_with_proof_by_version_ext(
         &self,
-        key_hash: &HashValue,
+        key_hash: HashValue,
         version: Version,
         root_depth: usize,
-        use_hot_state: bool,
     ) -> Result<(Option<StateValue>, SparseMerkleProofExt)> {
-        let db = if use_hot_state {
-            self.hot_state_merkle_db
-                .as_ref()
-                .ok_or(AptosDbError::HotStateError)?
-        } else {
-            &self.state_merkle_db
-        };
-        let (leaf_data, proof) = db.get_with_proof_ext(key_hash, version, root_depth)?;
+        let (leaf_data, proof) = self
+            .state_merkle_db
+            .get_with_proof_ext(&key_hash, version, root_depth)?;
         Ok((
             match leaf_data {
                 Some((_val_hash, (key, ver))) => Some(self.expect_value_by_version(&key, ver)?),
@@ -268,6 +263,27 @@ impl DbReader for StateDb {
             },
             proof,
         ))
+    }
+
+    /// Get the hot state value with proof given the state key (hash) and version
+    fn get_hot_state_value_with_proof_by_version_ext(
+        &self,
+        key_hash: HashValue,
+        version: Version,
+        root_depth: usize,
+    ) -> Result<(Option<HotStateValue>, SparseMerkleProofExt)> {
+        let merkle_db = self
+            .hot_state_merkle_db
+            .as_ref()
+            .ok_or(AptosDbError::HotStateError)?;
+        let (leaf_data, proof) = merkle_db.get_with_proof_ext(&key_hash, version, root_depth)?;
+        let value = match leaf_data {
+            Some((_val_hash, (_key, ver))) => {
+                Some(self.expect_hot_state_value_by_version(key_hash, ver)?)
+            },
+            None => None,
+        };
+        Ok((value, proof))
     }
 
     fn get_state_storage_usage(&self, version: Option<Version>) -> Result<StateStorageUsage> {
@@ -337,17 +353,22 @@ impl DbReader for StateStore {
     /// Get the state value with proof extension given the state key and version
     fn get_state_value_with_proof_by_version_ext(
         &self,
-        key_hash: &HashValue,
+        key_hash: HashValue,
         version: Version,
         root_depth: usize,
-        use_hot_state: bool,
     ) -> Result<(Option<StateValue>, SparseMerkleProofExt)> {
-        self.deref().get_state_value_with_proof_by_version_ext(
-            key_hash,
-            version,
-            root_depth,
-            use_hot_state,
-        )
+        self.deref()
+            .get_state_value_with_proof_by_version_ext(key_hash, version, root_depth)
+    }
+
+    fn get_hot_state_value_with_proof_by_version_ext(
+        &self,
+        key_hash: HashValue,
+        version: Version,
+        root_depth: usize,
+    ) -> Result<(Option<HotStateValue>, SparseMerkleProofExt)> {
+        self.deref()
+            .get_hot_state_value_with_proof_by_version_ext(key_hash, version, root_depth)
     }
 }
 
@@ -363,6 +384,52 @@ impl StateDb {
                     AptosDbError::NotFound(format!(
                         "State Value is missing for key {:?} by version {}",
                         state_key, version
+                    ))
+                })
+            })
+    }
+
+    /// Reads the persisted hot-state KV and assembles the `HotStateValue` for `key_hash` at
+    /// `version`. Returns `None` when no entry exists (key was never hot, or was evicted at/before
+    /// `version`).
+    fn get_hot_state_value_by_version(
+        &self,
+        key_hash: HashValue,
+        version: Version,
+    ) -> Result<Option<HotStateValue>> {
+        let db = self
+            .hot_state_kv_db
+            .as_ref()
+            .ok_or(AptosDbError::HotStateError)?;
+        Ok(
+            match db.get_hot_state_entry_by_version(key_hash, version)? {
+                // No row at or before `version` — key was never hot.
+                None => None,
+                // Eviction tombstone — no hot entry at `version`.
+                Some((_, None)) => None,
+                Some((hot_since_version, Some(HotStateEntry::Occupied { value, .. }))) => {
+                    Some(HotStateValue::new(Some(value), hot_since_version))
+                },
+                Some((hot_since_version, Some(HotStateEntry::Vacant))) => {
+                    Some(HotStateValue::new(None, hot_since_version))
+                },
+            },
+        )
+    }
+
+    /// Asserts a hot-state KV entry exists — used when the caller has already seen a JMT leaf
+    /// at `version`, so the KV must have the matching entry by invariant.
+    fn expect_hot_state_value_by_version(
+        &self,
+        key_hash: HashValue,
+        version: Version,
+    ) -> Result<HotStateValue> {
+        self.get_hot_state_value_by_version(key_hash, version)
+            .and_then(|opt| {
+                opt.ok_or_else(|| {
+                    AptosDbError::NotFound(format!(
+                        "HotStateValue is missing for key hash {} by version {}",
+                        key_hash, version
                     ))
                 })
             })

--- a/storage/aptosdb/src/state_store/tests/hot_state_kv.rs
+++ b/storage/aptosdb/src/state_store/tests/hot_state_kv.rs
@@ -125,7 +125,7 @@ fn test_eviction_write_read() {
 
     // The latest entry should be the eviction.
     let (found_version, found_value) = db
-        .get_hot_state_entry_by_version(&key, Version::MAX)
+        .get_hot_state_entry_by_version(*key.crypto_hash_ref(), Version::MAX)
         .unwrap()
         .unwrap();
     assert_eq!(found_version, 20);
@@ -154,14 +154,17 @@ fn test_multiple_versions() {
 
     // Querying at Version::MAX should return the latest (V2).
     let (latest_version, latest_entry) = db
-        .get_hot_state_entry_by_version(&key, Version::MAX)
+        .get_hot_state_entry_by_version(*key.crypto_hash_ref(), Version::MAX)
         .unwrap()
         .unwrap();
     assert_eq!(latest_version, 2);
     assert_eq!(latest_entry, expected_entry);
 
     // Querying at V1 should return the older entry.
-    let (older_version, older_entry) = db.get_hot_state_entry_by_version(&key, 1).unwrap().unwrap();
+    let (older_version, older_entry) = db
+        .get_hot_state_entry_by_version(*key.crypto_hash_ref(), 1)
+        .unwrap()
+        .unwrap();
     assert_eq!(older_version, 1);
     assert_eq!(older_entry, expected_entry);
 }

--- a/storage/storage-interface/src/lib.rs
+++ b/storage/storage-interface/src/lib.rs
@@ -17,6 +17,7 @@ use aptos_types::{
     },
     state_proof::StateProof,
     state_store::{
+        hot_state::HotStateValue,
         state_key::StateKey,
         state_storage_usage::StateStorageUsage,
         state_value::{StateValue, StateValueChunkWithProof},
@@ -356,11 +357,19 @@ pub trait DbReader: Send + Sync {
         /// This is used by aptos core (executor) internally.
         fn get_state_value_with_proof_by_version_ext(
             &self,
-            key_hash: &HashValue,
+            key_hash: HashValue,
             version: Version,
             root_depth: usize,
-            use_hot_state: bool,
         ) -> Result<(Option<StateValue>, SparseMerkleProofExt)>;
+
+        /// Returns the live `HotStateValue` at `version` together with a proof against the hot
+        /// state root. `None` means the key was never hot, or was evicted at or before `version`.
+        fn get_hot_state_value_with_proof_by_version_ext(
+            &self,
+            key_hash: HashValue,
+            version: Version,
+            root_depth: usize,
+        ) -> Result<(Option<HotStateValue>, SparseMerkleProofExt)>;
 
         /// Gets the latest LedgerView no matter if db has been bootstrapped.
         /// Used by the Db-bootstrapper.
@@ -497,10 +506,9 @@ pub trait DbReader: Send + Sync {
     ) -> Result<(Option<StateValue>, SparseMerkleProof)> {
         // TODO(HotState): check all callers and possibly query hot state first
         self.get_state_value_with_proof_by_version_ext(
-            state_key.crypto_hash_ref(),
+            *state_key.crypto_hash_ref(),
             version,
             /* root_depth = */ 0,
-            /* use_hot_state = */ false,
         )
         .map(|(value, proof_ext)| (value, proof_ext.into()))
     }

--- a/storage/storage-interface/src/state_store/state_summary.rs
+++ b/storage/storage-interface/src/state_store/state_summary.rs
@@ -312,24 +312,30 @@ impl<'db> ProvableStateSummary<'db> {
         root_depth: usize,
         use_hot_state: bool,
     ) -> Result<SparseMerkleProofExt> {
-        // TODO(HotState): we cannot verify proof yet. In order to verify the proof, we need to
-        // fetch and construct the corresponding `HotStateValue` for `key` at `version`, including
-        // `hot_since_version`. However, the current in-memory hot state does not support this
-        // query, and we might need persist hot state KV to db first.
-        if !use_hot_state && rand::random::<usize>().is_multiple_of(10000) {
-            // 1 out of 10000 times, verify the proof.
-            let (val_opt, proof) = self
-                .db
-                // check the full proof
-                .get_state_value_with_proof_by_version_ext(
-                    key, version, /* root_depth = */ 0, /* use_hot_state = */ false,
+        if rand::random::<usize>().is_multiple_of(10000) {
+            // 1 out of 10000 times, verify a full proof from the root.
+            if use_hot_state {
+                let (hot_value_opt, proof) =
+                    self.db.get_hot_state_value_with_proof_by_version_ext(
+                        *key, version, /* root_depth = */ 0,
+                    )?;
+                proof.verify(
+                    self.state_summary.hot_state_summary.root_hash(),
+                    *key,
+                    hot_value_opt.as_ref(),
                 )?;
-            proof.verify(
-                self.state_summary.global_state_summary.root_hash(),
-                *key,
-                val_opt.as_ref(),
-            )?;
-            Ok(proof)
+                Ok(proof)
+            } else {
+                let (val_opt, proof) = self.db.get_state_value_with_proof_by_version_ext(
+                    *key, version, /* root_depth = */ 0,
+                )?;
+                proof.verify(
+                    self.state_summary.global_state_summary.root_hash(),
+                    *key,
+                    val_opt.as_ref(),
+                )?;
+                Ok(proof)
+            }
         } else {
             Ok(self
                 .db


### PR DESCRIPTION

`ProvableStateSummary::get_proof` previously skipped its 1-in-10000
sampled verification on the hot-state path because the code had no way
to recover `hot_since_version` — the hot-state KV was not persisted,
and the in-memory hot state didn't expose that query. Hot-state KV
persistence landed in a73a294a5a50, so the stated blocker is gone.

- Promote `StateKvDb::get_hot_state_entry_by_version` to a production
  helper and switch it to take `HashValue` directly, so callers that
  only have the key hash can use it.
- Add `DbReader::get_hot_state_value_with_proof_by_version_ext`, the
  hot-state counterpart to `get_state_value_with_proof_by_version_ext`.
  It returns `(Option<HotStateValue>, SparseMerkleProofExt)` — the hot
  SMT leaf pre-image (carrying `hot_since_version`) paired with a proof
  against the hot state root. Maps both "never hot" and eviction
  tombstones to `None` so non-existence proofs verify.
- Drop the `use_hot_state` flag from
  `get_state_value_with_proof_by_version_ext`: it always returned
  `StateValue`, but the hot SMT hashes `HotStateValue`, so passing
  `true` would have produced an un-verifiable (value, proof) pair.
  The new hot-state function fills the gap.
- Extend the sampled verification to the `use_hot_state` branch: both
  branches of `get_proof` now make a single call returning
  `(value, proof)` and verify against the relevant root. Drop the TODO.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Extends proof verification into the hot-state path and changes the `DbReader` API surface (signature change + new method), which could impact any downstream callers and proof correctness if invariants between hot-state JMT and KV persistence are violated.
> 
> **Overview**
> `ProvableStateSummary::get_proof` now performs the same 1-in-10000 sampled *full proof verification* for **hot state** as it does for cold state, verifying against the hot-state root using the leaf preimage.
> 
> To support this, the PR adds `DbReader::get_hot_state_value_with_proof_by_version_ext` (and AptosDB/StateStore implementations) to return `(Option<HotStateValue>, SparseMerkleProofExt)` from the hot-state merkle + persisted hot-state KV, and **removes the `use_hot_state` flag** from `get_state_value_with_proof_by_version_ext` (it always queries the cold state merkle). It also promotes `StateKvDb::get_hot_state_entry_by_version` to production use and updates it to accept a `HashValue` key hash directly, with corresponding test and caller updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7bba1a6c8038266b065761320f596881364433f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->