### PR TITLE
[cli] Release Aptos CLI 9.2.0

### DIFF
--- a/.cursor/skills/aptos-cli-release/SKILL.md
+++ b/.cursor/skills/aptos-cli-release/SKILL.md
@@ -24,7 +24,7 @@ Match the requested bump type to the version field and to how you group notes un
 
 1. Under `# Unreleased`, collect bullet notes for changes since the last tagged CLI release (or move existing unreleased bullets).
 2. When releasing, add `## [<new version>]` immediately below `# Unreleased` and move the bullets for this release under it (newest release section stays directly under `Unreleased`).
-3. Leave `# Unreleased` empty or with a placeholder only if there is nothing pending.
+3. If nothing is pending after a release, keep one placeholder bullet under `# Unreleased` (for example `- _No changes yet._`) so the section is clearly intentional, not an oversight.
 
 ## Verification
 

--- a/.cursor/skills/aptos-cli-release/SKILL.md
+++ b/.cursor/skills/aptos-cli-release/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: aptos-cli-release
+description: Use when cutting or preparing a new Aptos CLI release, bumping the `aptos` crate version, or editing `crates/aptos/CHANGELOG.md` for a release
+---
+
+# Aptos CLI release (crate `aptos`)
+
+## Files
+
+| File | Change |
+|------|--------|
+| `crates/aptos/Cargo.toml` | Set `[package] version = ...` to the new semver. |
+| `crates/aptos/CHANGELOG.md` | Follow [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and repo style: `# Unreleased` at top, then `## [X.Y.Z]` sections newest first. |
+
+## Versioning
+
+- **Patch** (9.1.0 → 9.1.1): bugfixes only.
+- **Minor** (9.1.0 → 9.2.0): new features or non-breaking additions.
+- **Major** (9.x → 10.0.0): breaking CLI or documented compatibility breaks.
+
+Match the requested bump type to the version field and to how you group notes under the new `## [version]` heading.
+
+## Changelog workflow
+
+1. Under `# Unreleased`, collect bullet notes for changes since the last tagged CLI release (or move existing unreleased bullets).
+2. When releasing, add `## [<new version>]` immediately below `# Unreleased` and move the bullets for this release under it (newest release section stays directly under `Unreleased`).
+3. Leave `# Unreleased` empty or with a placeholder only if there is nothing pending.
+
+## Verification
+
+After edits, run:
+
+```bash
+cargo check -p aptos
+```
+
+## Common mistakes
+
+- Bumping `Cargo.toml` without adding a matching `## [version]` block (or leaving released notes only under `Unreleased`).
+- Forgetting that the CLI version lives only in `crates/aptos/Cargo.toml` for this workflow (not the workspace root `Cargo.toml`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,8 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+**Aptos CLI releases:** See `.cursor/skills/aptos-cli-release/SKILL.md` for version bumps and `crates/aptos/CHANGELOG.md` updates.
+
 ## Project Overview
 
 Aptos Core is a layer 1 blockchain written primarily in Rust with Move smart contracts. It's a production-grade system with 200+ workspace crates organized into major subsystems: consensus, execution, storage, network, mempool, API, and Move VM.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -295,7 +295,7 @@ dependencies = [
 
 [[package]]
 name = "aptos"
-version = "9.1.0"
+version = "9.2.0"
 dependencies = [
  "anyhow",
  "aptos-api-types",

--- a/crates/aptos/CHANGELOG.md
+++ b/crates/aptos/CHANGELOG.md
@@ -3,6 +3,8 @@
 All notable changes to the Aptos CLI will be captured in this file. This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) and the format set out by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Unreleased
+
+## [9.2.0]
 - Update boogie from 3.5.1 to 3.5.6.
 - Update z3 from 4.11.2 to 4.13.0.
 

--- a/crates/aptos/CHANGELOG.md
+++ b/crates/aptos/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the Aptos CLI will be captured in this file. This project
 
 # Unreleased
 
+- _No changes yet._
+
 ## [9.2.0]
 - Update boogie from 3.5.1 to 3.5.6.
 - Update z3 from 4.11.2 to 4.13.0.

--- a/crates/aptos/Cargo.toml
+++ b/crates/aptos/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aptos"
 description = "Aptos tool for management of nodes and interacting with the blockchain"
-version = "9.1.0"
+version = "9.2.0"
 
 # Workspace inherited keys
 authors = { workspace = true }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Prepare **Aptos CLI 9.2.0** (minor bump from 9.1.0):

- Set `crates/aptos/Cargo.toml` version to **9.2.0** and sync `Cargo.lock`.
- Add a **`## [9.2.0]`** section in `crates/aptos/CHANGELOG.md` with the previously unreleased boogie/z3 notes; keep `# Unreleased` with a placeholder when empty.
- Add **`.cursor/skills/aptos-cli-release/SKILL.md`** so Cursor and Claude can follow a repeatable release checklist, and a one-line pointer in **`CLAUDE.md`**.

## Verification

- `cargo check -p aptos` (completed successfully on the original revision; warnings from dependencies only).

## CI note

If **forge-e2e** (`realistic_env_max_load`) fails with validators stuck **Pending** and PFN deployer **Error**, that indicates cluster capacity/scheduling in the Forge environment rather than this PR’s code paths (docs-only plus version bump). **framework_upgrade** passed on the same head. Re-run Forge if needed.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-681bbefc-fd98-4d77-a8f8-2b83e27fd920"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-681bbefc-fd98-4d77-a8f8-2b83e27fd920"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

