### PR TITLE
Fix cli-release workflow job `if` expression for dry_run

### DIFF
--- a/.github/workflows/cli-release.yaml
+++ b/.github/workflows/cli-release.yaml
@@ -162,7 +162,7 @@ jobs:
     permissions:
       contents: "write"
       pull-requests: "read"
-    if: ${{ inputs.dry_run }} == 'false'
+    if: ${{ !inputs.dry_run }}
     steps:
       - name: Download prebuilt binaries
         uses: actions/download-artifact@v4


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The `release-binaries` job used `if: ${{ inputs.dry_run }} == 'false'`, which leaves ` == 'false'` outside the `${{ }}` expression. GitHub Actions treats that as literal text in the conditional, so the linter warns and the expression does not behave as intended.

## Change

Use `if: ${{ !inputs.dry_run }}` so the entire condition is a single expression. `dry_run` is already a boolean workflow input, so negation matches “run only when not a dry run.”
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-064af64f-e3a2-4dfe-8a23-aa4b0c7a78e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-064af64f-e3a2-4dfe-8a23-aa4b0c7a78e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

