### PR TITLE
Inline package installs in minimal_cli_build.sh

### DIFF
--- a/.github/actions/rust-setup/action.yaml
+++ b/.github/actions/rust-setup/action.yaml
@@ -21,7 +21,10 @@ runs:
       run: |
         sudo apt-get update
         sudo apt-get install build-essential ca-certificates curl git gnupg libpq-dev libssl-dev lsb-release lsof pkg-config software-properties-common wget --no-install-recommends --assume-yes
-        sudo bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)" llvm.sh 21
+        tmp="$(mktemp)"
+        wget --https-only --secure-protocol=TLSv1_2 -qO "$tmp" https://apt.llvm.org/llvm.sh
+        sudo bash "$tmp" 21
+        rm -f "$tmp"
         sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-21 100
         sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-21 100
         sudo update-alternatives --install /usr/bin/lld lld /usr/bin/lld-21 100

--- a/scripts/cli/minimal_cli_build.sh
+++ b/scripts/cli/minimal_cli_build.sh
@@ -3,22 +3,70 @@
 # Parts of the project are originally copyright © Meta Platforms, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
+set -e
+
 has_command() {
   command -v "$1" > /dev/null 2>&1
+}
+
+# Install native packages for the given package manager (self-contained; no external install scripts).
+minimal_install_pkgs() {
+  pm="$1"
+  shift
+  if [ "$#" -eq 0 ]; then
+    return 0
+  fi
+
+  pre_cmd=""
+  if [ "$(id -u)" -ne 0 ]; then
+    pre_cmd="sudo"
+  fi
+
+  echo "Installing packages with $pm: $*"
+  case "$pm" in
+    apt-get)
+      $pre_cmd apt-get install -y --no-install-recommends "$@"
+      ;;
+    dnf)
+      $pre_cmd dnf install -y "$@"
+      ;;
+    yum)
+      $pre_cmd yum install -y "$@"
+      ;;
+    pacman)
+      $pre_cmd pacman -Syu --noconfirm "$@"
+      ;;
+    apk)
+      $pre_cmd apk --update add --no-cache "$@"
+      ;;
+    zypper)
+      $pre_cmd zypper install -y "$@"
+      ;;
+    emerge)
+      $pre_cmd emerge "$@"
+      ;;
+    brew)
+      brew install "$@"
+      ;;
+    port)
+      port install "$@"
+      ;;
+    xbps)
+      $pre_cmd xbps-install -y "$@"
+      ;;
+    pkg)
+      $pre_cmd pkg install -y "$@"
+      ;;
+    *)
+      echo "Unsupported package manager: $pm" 1>&2
+      exit 1
+      ;;
+  esac
 }
 
 # This script is used to set up a minimal environment for building the Aptos CLI and other tools.
 # The `dev_setup.sh` script is way too complex, and too hard to figure out what is actually happening.  This script
 # simplifies the process
-if has_command wget; then
-  wget https://raw.githubusercontent.com/gregnazario/universal-installer/refs/heads/main/scripts/install_pkg.sh
-elif has_command curl; then
-  curl -O https://raw.githubusercontent.com/gregnazario/universal-installer/refs/heads/main/scripts/install_pkg.sh
-else
-  echo "Unable to download install script, no wget or curl. Abort"
-  exit 1
-fi
-
 # TODO: Do we need to add `ca-certificates`, `curl`, `unzip`, `wget`
 # Install rustup
 if ! has_command cargo; then
@@ -31,7 +79,7 @@ case "$OS" in
     if has_command apt-get; then
       # Ubuntu / Debian based APT-GET
       sudo apt-get update
-      sh install_pkg.sh build-essential pkgconf libssl-dev git libudev-dev lld libdw-dev clang llvm cmake
+      minimal_install_pkgs apt-get build-essential pkgconf libssl-dev git libudev-dev lld libdw-dev clang llvm cmake
     elif has_command dnf; then
       # RHEL / CentOS based DNF
       # This depends on the OS!
@@ -41,41 +89,48 @@ case "$OS" in
       # Check if it's Rocky
       if [ "$ID" = "rocky" ]; then
         echo "Rocky Linux detected"
-        sh install_pkg.sh gcc gcc-c++ make pkgconf openssl-devel git systemd-devel lld elfutils-devel clang llvm cmake
+        minimal_install_pkgs dnf gcc gcc-c++ make pkgconf openssl-devel git systemd-devel lld elfutils-devel clang llvm cmake
       else
-        sh install_pkg.sh gcc gcc-c++ make pkgconf openssl-devel git rust-libudev-devel lld elfutils-devel clang llvm cmake
+        minimal_install_pkgs dnf gcc gcc-c++ make pkgconf openssl-devel git rust-libudev-devel lld elfutils-devel clang llvm cmake
       fi
     elif has_command yum; then
       # RHEL / CentOS based YUM
-      sh install_pkg.sh gcc gcc-c++ make pkgconf openssl-devel git rust-libudev-devel lld elfutils-devel clang llvm cmake
+      minimal_install_pkgs yum gcc gcc-c++ make pkgconf openssl-devel git rust-libudev-devel lld elfutils-devel clang llvm cmake
     elif has_command pacman; then
       # Arch based PACMAN
-      sh install_pkg.sh base-devel pkgconf openssl git lld clang llvm cmake
+      minimal_install_pkgs pacman base-devel pkgconf openssl git lld clang llvm cmake
     elif has_command apk; then
       # Alpine based APK
-      sh install_pkg.sh alpine-sdk coreutils pkgconfig openssl-dev git lld elfutils-dev clang llvm cmake libc-dev
+      minimal_install_pkgs apk alpine-sdk coreutils pkgconfig openssl-dev git lld elfutils-dev clang llvm cmake libc-dev
     elif has_command zypper; then
       # OpenSUSE zypper
-      sh install_pkg.sh gcc gcc-c++ make pkg-config libopenssl-devel git libudev-devel lld libdw-devel clang llvm cmake
+      minimal_install_pkgs zypper gcc gcc-c++ make pkg-config libopenssl-devel git libudev-devel lld libdw-devel clang llvm cmake
     elif has_command emerge; then
       # Gentoo Emerge
       sudo emerge --sync
-      sh install_pkg.sh --skip-overrides sys-devel/gcc dev-libs/openssl dev-vcs/git dev-lang/rust llvm-core/clang
+      minimal_install_pkgs emerge sys-devel/gcc dev-libs/openssl dev-vcs/git dev-lang/rust llvm-core/clang
     elif has_command xbps-install; then
       # Void linux xbps
-      sh install_pkg.sh gcc make pkg-config git lld elfutils-devel clang llvm cmake
+      minimal_install_pkgs xbps gcc make pkg-config git lld elfutils-devel clang llvm cmake
     else
       echo "Unable to find supported Linux package manager (apt-get, dnf, yum, zypper, xbps or pacman). Abort"
       exit 1
     fi
   ;;
   Darwin)
-    # macOS
-    sh install_pkg.sh pkgconfig openssl git llvm cmake
+    # macOS (Homebrew or MacPorts)
+    if has_command brew; then
+      minimal_install_pkgs brew pkg-config openssl git llvm cmake
+    elif has_command port; then
+      minimal_install_pkgs port pkgconfig openssl git llvm cmake
+    else
+      echo "Missing package manager Homebrew (https://brew.sh/) or MacPorts (https://www.macports.org/). Abort." 1>&2
+      exit 1
+    fi
   ;;
   FreeBSD)
     # FreeBSD
-    sh install_pkg.sh gcc gmake binutils pkgconf git openssl cmake llvm hidapi
+    minimal_install_pkgs pkg gcc gmake binutils pkgconf git openssl cmake llvm hidapi
   ;;
   *)
     echo "Unknown OS. Abort."

--- a/scripts/cli/minimal_cli_build.sh
+++ b/scripts/cli/minimal_cli_build.sh
@@ -5,6 +5,9 @@
 
 set -e
 
+# Set to 1 after `emerge --sync` in this script (avoids running sync twice on Gentoo).
+EMERGE_SYNC_DONE=0
+
 has_command() {
   command -v "$1" > /dev/null 2>&1
 }
@@ -64,22 +67,91 @@ minimal_install_pkgs() {
   esac
 }
 
+# If HTTPS clients are missing, install curl and wget (and CA bundle) via the OS package manager.
+bootstrap_ssl_and_fetch_clients() {
+  if has_command curl || has_command wget; then
+    return 0
+  fi
+
+  os="$(uname -s)"
+  case "$os" in
+    Linux)
+      if has_command apt-get; then
+        sudo apt-get update
+        minimal_install_pkgs apt-get ca-certificates curl wget unzip
+      elif has_command dnf; then
+        minimal_install_pkgs dnf ca-certificates curl wget unzip
+      elif has_command yum; then
+        minimal_install_pkgs yum ca-certificates curl wget unzip
+      elif has_command pacman; then
+        minimal_install_pkgs pacman ca-certificates curl wget unzip
+      elif has_command apk; then
+        minimal_install_pkgs apk ca-certificates curl wget unzip
+      elif has_command zypper; then
+        minimal_install_pkgs zypper ca-certificates curl wget unzip
+      elif has_command emerge; then
+        sudo emerge --sync
+        EMERGE_SYNC_DONE=1
+        minimal_install_pkgs emerge app-misc/ca-certificates net-misc/curl net-misc/wget app-arch/unzip
+      elif has_command xbps-install; then
+        minimal_install_pkgs xbps ca-certificates curl wget unzip
+      else
+        echo "Neither curl nor wget is installed, and no supported package manager was found to install them. Abort." 1>&2
+        exit 1
+      fi
+      ;;
+    Darwin)
+      if has_command brew; then
+        minimal_install_pkgs brew ca-certificates curl wget unzip
+      elif has_command port; then
+        minimal_install_pkgs port curl wget unzip
+      else
+        echo "Neither curl nor wget is installed, and neither Homebrew nor MacPorts was found to install them. Abort." 1>&2
+        exit 1
+      fi
+      ;;
+    FreeBSD)
+      minimal_install_pkgs pkg ca_root_nss curl wget unzip
+      ;;
+    *)
+      echo "Neither curl nor wget is installed, and automatic install is not implemented for this OS ($os). Abort." 1>&2
+      exit 1
+      ;;
+  esac
+}
+
+# Install rustup when cargo is missing (prefers curl, then wget, then FreeBSD fetch).
+ensure_rustup() {
+  if has_command cargo; then
+    return 0
+  fi
+
+  rustup_url="https://sh.rustup.rs"
+  if has_command curl; then
+    curl --proto '=https' --tlsv1.2 -sSf "$rustup_url" | sh -s -- -y
+  elif has_command wget; then
+    wget -qO- "$rustup_url" | sh -s -- -y
+  elif has_command fetch && [ "$(uname -s)" = "FreeBSD" ]; then
+    fetch -o - "$rustup_url" | sh -s -- -y
+  else
+    echo "Cannot install rustup: need curl or wget (install one with your package manager). Abort." 1>&2
+    exit 1
+  fi
+}
+
 # This script is used to set up a minimal environment for building the Aptos CLI and other tools.
 # The `dev_setup.sh` script is way too complex, and too hard to figure out what is actually happening.  This script
 # simplifies the process
-# TODO: Do we need to add `ca-certificates`, `curl`, `unzip`, `wget`
-# Install rustup
-if ! has_command cargo; then
-  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-fi
 
 OS="$(uname)"
+bootstrap_ssl_and_fetch_clients
+
 case "$OS" in
   Linux)
     if has_command apt-get; then
       # Ubuntu / Debian based APT-GET
       sudo apt-get update
-      minimal_install_pkgs apt-get build-essential pkgconf libssl-dev git libudev-dev lld libdw-dev clang llvm cmake
+      minimal_install_pkgs apt-get ca-certificates curl wget unzip build-essential pkgconf libssl-dev git libudev-dev lld libdw-dev clang llvm cmake
     elif has_command dnf; then
       # RHEL / CentOS based DNF
       # This depends on the OS!
@@ -89,29 +161,31 @@ case "$OS" in
       # Check if it's Rocky
       if [ "$ID" = "rocky" ]; then
         echo "Rocky Linux detected"
-        minimal_install_pkgs dnf gcc gcc-c++ make pkgconf openssl-devel git systemd-devel lld elfutils-devel clang llvm cmake
+        minimal_install_pkgs dnf ca-certificates curl wget unzip gcc gcc-c++ make pkgconf openssl-devel git systemd-devel lld elfutils-devel clang llvm cmake
       else
-        minimal_install_pkgs dnf gcc gcc-c++ make pkgconf openssl-devel git rust-libudev-devel lld elfutils-devel clang llvm cmake
+        minimal_install_pkgs dnf ca-certificates curl wget unzip gcc gcc-c++ make pkgconf openssl-devel git rust-libudev-devel lld elfutils-devel clang llvm cmake
       fi
     elif has_command yum; then
       # RHEL / CentOS based YUM
-      minimal_install_pkgs yum gcc gcc-c++ make pkgconf openssl-devel git rust-libudev-devel lld elfutils-devel clang llvm cmake
+      minimal_install_pkgs yum ca-certificates curl wget unzip gcc gcc-c++ make pkgconf openssl-devel git rust-libudev-devel lld elfutils-devel clang llvm cmake
     elif has_command pacman; then
       # Arch based PACMAN
-      minimal_install_pkgs pacman base-devel pkgconf openssl git lld clang llvm cmake
+      minimal_install_pkgs pacman ca-certificates curl wget unzip base-devel pkgconf openssl git lld clang llvm cmake
     elif has_command apk; then
       # Alpine based APK
-      minimal_install_pkgs apk alpine-sdk coreutils pkgconfig openssl-dev git lld elfutils-dev clang llvm cmake libc-dev
+      minimal_install_pkgs apk ca-certificates curl wget unzip alpine-sdk coreutils pkgconfig openssl-dev git lld elfutils-dev clang llvm cmake libc-dev
     elif has_command zypper; then
       # OpenSUSE zypper
-      minimal_install_pkgs zypper gcc gcc-c++ make pkg-config libopenssl-devel git libudev-devel lld libdw-devel clang llvm cmake
+      minimal_install_pkgs zypper ca-certificates curl wget unzip gcc gcc-c++ make pkg-config libopenssl-devel git libudev-devel lld libdw-devel clang llvm cmake
     elif has_command emerge; then
       # Gentoo Emerge
-      sudo emerge --sync
-      minimal_install_pkgs emerge sys-devel/gcc dev-libs/openssl dev-vcs/git dev-lang/rust llvm-core/clang
+      if [ "$EMERGE_SYNC_DONE" != 1 ]; then
+        sudo emerge --sync
+      fi
+      minimal_install_pkgs emerge app-misc/ca-certificates net-misc/curl net-misc/wget app-arch/unzip sys-devel/gcc dev-libs/openssl dev-vcs/git dev-lang/rust llvm-core/clang
     elif has_command xbps-install; then
       # Void linux xbps
-      minimal_install_pkgs xbps gcc make pkg-config git lld elfutils-devel clang llvm cmake
+      minimal_install_pkgs xbps ca-certificates curl wget unzip gcc make pkg-config git lld elfutils-devel clang llvm cmake
     else
       echo "Unable to find supported Linux package manager (apt-get, dnf, yum, zypper, xbps or pacman). Abort"
       exit 1
@@ -120,9 +194,9 @@ case "$OS" in
   Darwin)
     # macOS (Homebrew or MacPorts)
     if has_command brew; then
-      minimal_install_pkgs brew pkg-config openssl git llvm cmake
+      minimal_install_pkgs brew ca-certificates curl wget unzip pkg-config openssl git llvm cmake
     elif has_command port; then
-      minimal_install_pkgs port pkgconfig openssl git llvm cmake
+      minimal_install_pkgs port curl wget unzip pkgconfig openssl git llvm cmake
     else
       echo "Missing package manager Homebrew (https://brew.sh/) or MacPorts (https://www.macports.org/). Abort." 1>&2
       exit 1
@@ -130,10 +204,12 @@ case "$OS" in
   ;;
   FreeBSD)
     # FreeBSD
-    minimal_install_pkgs pkg gcc gmake binutils pkgconf git openssl cmake llvm hidapi
+    minimal_install_pkgs pkg ca_root_nss curl wget unzip gcc gmake binutils pkgconf git openssl cmake llvm hidapi
   ;;
   *)
     echo "Unknown OS. Abort."
     exit 1
   ;;
 esac
+
+ensure_rustup

--- a/scripts/cli/minimal_cli_build.sh
+++ b/scripts/cli/minimal_cli_build.sh
@@ -12,6 +12,18 @@ has_command() {
   command -v "$1" > /dev/null 2>&1
 }
 
+# Run a command with root privileges when needed (no `sudo` when already root).
+run_as_root() {
+  if [ "$(id -u)" -eq 0 ]; then
+    "$@"
+  elif has_command sudo; then
+    sudo "$@"
+  else
+    echo "Error: root privileges are required for: $*. Rerun as root or install sudo." 1>&2
+    exit 1
+  fi
+}
+
 # Install native packages for the given package manager (self-contained; no external install scripts).
 minimal_install_pkgs() {
   pm="$1"
@@ -22,6 +34,10 @@ minimal_install_pkgs() {
 
   pre_cmd=""
   if [ "$(id -u)" -ne 0 ]; then
+    if ! has_command sudo; then
+      echo "Error: sudo is required to install packages when not running as root. Rerun as root or install sudo." 1>&2
+      exit 1
+    fi
     pre_cmd="sudo"
   fi
 
@@ -37,7 +53,8 @@ minimal_install_pkgs() {
       $pre_cmd yum install -y "$@"
       ;;
     pacman)
-      $pre_cmd pacman -Syu --noconfirm "$@"
+      $pre_cmd pacman -Sy --noconfirm
+      $pre_cmd pacman -S --noconfirm --needed "$@"
       ;;
     apk)
       $pre_cmd apk --update add --no-cache "$@"
@@ -52,7 +69,7 @@ minimal_install_pkgs() {
       brew install "$@"
       ;;
     port)
-      port install "$@"
+      $pre_cmd port install "$@"
       ;;
     xbps)
       $pre_cmd xbps-install -y "$@"
@@ -77,7 +94,7 @@ bootstrap_ssl_and_fetch_clients() {
   case "$os" in
     Linux)
       if has_command apt-get; then
-        sudo apt-get update
+        run_as_root apt-get update
         minimal_install_pkgs apt-get ca-certificates curl wget unzip
       elif has_command dnf; then
         minimal_install_pkgs dnf ca-certificates curl wget unzip
@@ -90,7 +107,7 @@ bootstrap_ssl_and_fetch_clients() {
       elif has_command zypper; then
         minimal_install_pkgs zypper ca-certificates curl wget unzip
       elif has_command emerge; then
-        sudo emerge --sync
+        run_as_root emerge --sync
         EMERGE_SYNC_DONE=1
         minimal_install_pkgs emerge app-misc/ca-certificates net-misc/curl net-misc/wget app-arch/unzip
       elif has_command xbps-install; then
@@ -121,22 +138,30 @@ bootstrap_ssl_and_fetch_clients() {
 }
 
 # Install rustup when cargo is missing (prefers curl, then wget, then FreeBSD fetch).
+# Download to a temp file so downloader failures are not masked by POSIX pipeline exit status.
 ensure_rustup() {
   if has_command cargo; then
     return 0
   fi
 
   rustup_url="https://sh.rustup.rs"
+  tmp="$(mktemp "${TMPDIR:-/tmp}/rustup-init.XXXXXX")"
+  trap 'rm -f "$tmp"' 0
+
   if has_command curl; then
-    curl --proto '=https' --tlsv1.2 -sSf "$rustup_url" | sh -s -- -y
+    curl --proto '=https' --tlsv1.2 -sSf "$rustup_url" -o "$tmp"
   elif has_command wget; then
-    wget -qO- "$rustup_url" | sh -s -- -y
+    wget -qO "$tmp" "$rustup_url"
   elif has_command fetch && [ "$(uname -s)" = "FreeBSD" ]; then
-    fetch -o - "$rustup_url" | sh -s -- -y
+    fetch -o "$tmp" "$rustup_url"
   else
     echo "Cannot install rustup: need curl or wget (install one with your package manager). Abort." 1>&2
     exit 1
   fi
+
+  sh "$tmp" -y
+  rm -f "$tmp"
+  trap - 0
 }
 
 # This script is used to set up a minimal environment for building the Aptos CLI and other tools.
@@ -150,7 +175,7 @@ case "$OS" in
   Linux)
     if has_command apt-get; then
       # Ubuntu / Debian based APT-GET
-      sudo apt-get update
+      run_as_root apt-get update
       minimal_install_pkgs apt-get ca-certificates curl wget unzip build-essential pkgconf libssl-dev git libudev-dev lld libdw-dev clang llvm cmake
     elif has_command dnf; then
       # RHEL / CentOS based DNF
@@ -180,7 +205,7 @@ case "$OS" in
     elif has_command emerge; then
       # Gentoo Emerge
       if [ "$EMERGE_SYNC_DONE" != 1 ]; then
-        sudo emerge --sync
+        run_as_root emerge --sync
       fi
       minimal_install_pkgs emerge app-misc/ca-certificates net-misc/curl net-misc/wget app-arch/unzip sys-devel/gcc dev-libs/openssl dev-vcs/git dev-lang/rust llvm-core/clang
     elif has_command xbps-install; then

--- a/scripts/cli/minimal_cli_build.sh
+++ b/scripts/cli/minimal_cli_build.sh
@@ -5,8 +5,8 @@
 
 set -e
 
-# Set to 1 after `emerge --sync` in this script (avoids running sync twice on Gentoo).
-EMERGE_SYNC_DONE=0
+# Set to true after `emerge --sync` in this script (avoids running sync twice on Gentoo).
+EMERGE_SYNC_DONE=false
 
 has_command() {
   command -v "$1" > /dev/null 2>&1
@@ -53,8 +53,8 @@ minimal_install_pkgs() {
       $pre_cmd yum install -y "$@"
       ;;
     pacman)
-      $pre_cmd pacman -Sy --noconfirm
-      $pre_cmd pacman -S --noconfirm --needed "$@"
+      # One-shot setup: sync and upgrade together so new packages match on-disk libs (Arch wiki).
+      $pre_cmd pacman -Syu --noconfirm --needed "$@"
       ;;
     apk)
       $pre_cmd apk --update add --no-cache "$@"
@@ -108,7 +108,7 @@ bootstrap_ssl_and_fetch_clients() {
         minimal_install_pkgs zypper ca-certificates curl wget unzip
       elif has_command emerge; then
         run_as_root emerge --sync
-        EMERGE_SYNC_DONE=1
+        EMERGE_SYNC_DONE=true
         minimal_install_pkgs emerge app-misc/ca-certificates net-misc/curl net-misc/wget app-arch/unzip
       elif has_command xbps-install; then
         minimal_install_pkgs xbps ca-certificates curl wget unzip
@@ -151,7 +151,12 @@ ensure_rustup() {
   if has_command curl; then
     curl --proto '=https' --tlsv1.2 -sSf "$rustup_url" -o "$tmp"
   elif has_command wget; then
-    wget -qO "$tmp" "$rustup_url"
+    # Prefer HTTPS-only + TLS 1.2 when GNU wget supports it (matches curl hardening above).
+    if wget --help 2>&1 | grep -q -- '--https-only'; then
+      wget --https-only --secure-protocol=TLSv1_2 -qO "$tmp" "$rustup_url"
+    else
+      wget -qO "$tmp" "$rustup_url"
+    fi
   elif has_command fetch && [ "$(uname -s)" = "FreeBSD" ]; then
     fetch -o "$tmp" "$rustup_url"
   else
@@ -204,7 +209,7 @@ case "$OS" in
       minimal_install_pkgs zypper ca-certificates curl wget unzip gcc gcc-c++ make pkg-config libopenssl-devel git libudev-devel lld libdw-devel clang llvm cmake
     elif has_command emerge; then
       # Gentoo Emerge
-      if [ "$EMERGE_SYNC_DONE" != 1 ]; then
+      if [ "$EMERGE_SYNC_DONE" != true ]; then
         run_as_root emerge --sync
       fi
       minimal_install_pkgs emerge app-misc/ca-certificates net-misc/curl net-misc/wget app-arch/unzip sys-devel/gcc dev-libs/openssl dev-vcs/git dev-lang/rust llvm-core/clang

--- a/scripts/dev_setup.sh
+++ b/scripts/dev_setup.sh
@@ -98,6 +98,27 @@ function update_path_and_profile {
   fi
 }
 
+# Download a URL over HTTPS to a temp file (avoids piping remote scripts into a shell).
+function download_https_to_temp {
+  local url="$1"
+  local tmp
+  tmp="$(mktemp)"
+  if command -v curl &>/dev/null; then
+    curl --proto '=https' --tlsv1.2 -sSf "$url" -o "$tmp"
+  elif command -v wget &>/dev/null; then
+    if wget --help 2>&1 | grep -q -- '--https-only'; then
+      wget --https-only --secure-protocol=TLSv1_2 -qO "$tmp" "$url"
+    else
+      wget -qO "$tmp" "$url"
+    fi
+  else
+    rm -f "$tmp"
+    echo "Need curl or wget to download $url" >&2
+    return 1
+  fi
+  echo "$tmp"
+}
+
 function install_build_essentials {
   PACKAGE_MANAGER=$1
   #Differently named packages for pkg-config
@@ -134,7 +155,9 @@ function install_clang_lld {
       echo "clang-${VERSION} already installed, skipping."
     else
       "${PRE_COMMAND[@]}" apt-get install -y gnupg lsb-release software-properties-common wget
-      "${PRE_COMMAND[@]}" bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)" llvm.sh "${VERSION}"
+      llvm_sh="$(download_https_to_temp https://apt.llvm.org/llvm.sh)"
+      "${PRE_COMMAND[@]}" bash "$llvm_sh" "${VERSION}"
+      rm -f "$llvm_sh"
     fi
     "${PRE_COMMAND[@]}" update-alternatives --install /usr/bin/clang clang "/usr/bin/clang-${VERSION}" 100
     "${PRE_COMMAND[@]}" update-alternatives --install /usr/bin/clang++ clang++ "/usr/bin/clang++-${VERSION}" 100
@@ -210,7 +233,9 @@ function install_rustup {
       echo "Rustup is already installed, version: $VERSION"
     fi
   else
-    curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable
+    rustup_init="$(download_https_to_temp https://sh.rustup.rs)"
+    sh "$rustup_init" -s -- -y --default-toolchain stable
+    rm -f "$rustup_init"
     if [[ -n "${CARGO_HOME}" ]]; then
       PATH="${CARGO_HOME}/bin:${PATH}"
     else


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

`scripts/cli/minimal_cli_build.sh` previously downloaded `install_pkg.sh` from an external universal-installer repository. This change removes that network dependency and inlines equivalent install behavior: a small `minimal_install_pkgs` helper runs the same per–package-manager commands the script already branched on. macOS now explicitly requires Homebrew or MacPorts (matching the upstream installer’s behavior).

Follow-up: the script TODO about `ca-certificates`, `curl`, `wget`, and `unzip` is implemented. If neither `curl` nor `wget` is present before package installs, a `bootstrap_ssl_and_fetch_clients` path installs them (plus CA bundle / unzip where applicable). Rustup runs **after** native packages so HTTPS is reliable; `ensure_rustup` prefers `curl`, then `wget`, then FreeBSD `fetch`. Gentoo skips a second `emerge --sync` when bootstrap already synced.

**Review follow-ups (Copilot):** `run_as_root` avoids `sudo` when already root (fixes `apt-get update` / `emerge --sync` in root-only containers). `minimal_install_pkgs` errors clearly if non-root and `sudo` is missing. MacPorts uses the same elevation prefix as other PMs. Rustup installer is downloaded to a temp file then executed so downloader failures are not lost under POSIX pipeline rules.

**Review follow-ups (cursor[bot]):** `wget` rustup fetch uses `--https-only` + `TLSv1_2` when GNU wget supports it. `pacman` uses a single `-Syu --needed` (one-shot setup; keeps DB and installed packages consistent per Arch wiki). `EMERGE_SYNC_DONE` uses `true`/`false` consistently.

**Supply-chain follow-up:** `scripts/dev_setup.sh` and `.github/actions/rust-setup/action.yaml` now download `sh.rustup.rs` / `llvm.sh` to temp files (with the same HTTPS/TLS hardening) instead of piping remote scripts into a shell.

## How Has This Been Tested?

- `sh -n scripts/cli/minimal_cli_build.sh`
- `bash -n scripts/dev_setup.sh`

## Key Areas to Review

- `minimal_install_pkgs` argument handling and `sudo` usage when not root.
- Gentoo: `EMERGE_SYNC_DONE` avoids duplicate `emerge --sync` when bootstrap ran first.
- macOS Homebrew: `ca-certificates` formula vs system trust store (harmless if redundant).
- `pacman -Syu`: intentional for one-shot minimal/CI setup, not repeated dev-machine use.
- `download_https_to_temp` in `dev_setup.sh` shared by rustup and llvm installs.

## Type of Change

- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [x] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?

- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [x] Aptos CLI/SDK
- [x] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist

- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7fd7a584-de7a-47f8-bd08-c68582367444"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7fd7a584-de7a-47f8-bd08-c68582367444"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

