### PR TITLE
[codeowners] Add dedicated owners for third_party/move/mono-move

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -131,6 +131,7 @@
 
 # Owners for third_party/move
 /third_party/move/ @aptos-labs/move
+/third_party/move/mono-move/ @calintat @georgemitenkov @vgao1996 @vineethk
 
 # Owners for the `aptos-dkg` crate.
 /crates/aptos-dkg @alinush @rex1fernando @waamm


### PR DESCRIPTION
## Summary

Adds a dedicated CODEOWNERS entry for `third_party/move/mono-move/` that
routes review requests to a smaller group (@calintat, @georgemitenkov,
@vgao1996, @vineethk) instead of the full `@aptos-labs/move` team.

We want a smaller group here for now to reduce review noise while
mono-move is still early and churning quickly. We can widen ownership
back to the full team once the area stabilizes.

## Test plan

- [ ] CODEOWNERS syntax parses (GitHub will surface errors on PR view)
- [ ] A subsequent PR touching `third_party/move/mono-move/` requests
      reviews from the listed individuals only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk; this only changes GitHub review routing/ownership and does not affect runtime code or behavior.
> 
> **Overview**
> Adds a more specific `CODEOWNERS` rule for `third_party/move/mono-move/`, assigning reviews to `@calintat`, `@georgemitenkov`, `@vgao1996`, and `@vineethk` instead of the broader `@aptos-labs/move` ownership for `third_party/move/`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d993e74ae6f8bc76d82b26df9639d05b9ad705cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->