### PR TITLE
Switch replay-verify to the main PFN deployments in us-central1

### DIFF
--- a/testsuite/replay-verify/archive_disk_utils.py
+++ b/testsuite/replay-verify/archive_disk_utils.py
@@ -743,12 +743,12 @@ if __name__ == "__main__":
 
     if network == "testnet":
         source_cluster_id = "general-usce1-0"
-        source_namespace = "testnet-pfn-usce1-backup"
+        source_namespace = "testnet-pfn-0"
         snapshot_name = TESTNET_SNAPSHOT_NAME
         new_pv_prefix = TESTNET_SNAPSHOT_NAME
     else:
         source_cluster_id = "mainnet-usce1-0"
-        source_namespace = "mainnet-pfn-usce1-backup"
+        source_namespace = "mainnet-pfn-0"
         snapshot_name = MAINNET_SNAPSHOT_NAME
         new_pv_prefix = MAINNET_SNAPSHOT_NAME
     # create OG snapshot


### PR DESCRIPTION
## Description

The dedicated PFN backups are going away.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the Kubernetes namespaces used as the snapshot source for both testnet and mainnet, which could break replay-verify runs or snapshot creation if the new PFN namespaces differ in PVC layout or permissions.
> 
> **Overview**
> Replay-verify snapshot creation now targets the *main PFN deployments* instead of the dedicated `*-backup` namespaces by switching the source namespaces to `testnet-pfn-0` and `mainnet-pfn-0` when creating archive snapshots.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abd65973fb2514a98c80136cc9d71a55b52b54aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->