### PR TITLE
[vm] Avoid panic on simulation output materialization

### DIFF
--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -3599,9 +3599,31 @@ impl AptosSimulationVM {
             &log_context,
             &AuxiliaryInfo::new_timestamp_not_yet_assigned(0),
         );
-        let txn_output = vm_output
-            .try_materialize_into_transaction_output(&resolver)
-            .expect("Materializing aggregator V1 deltas should never fail");
+
+        // Simulation runs outside the normal block-executor finalization pipeline. If the
+        // transaction output contains non-materialized delayed field changes (e.g. delayed fields
+        // / aggregator v2) or v1 delta materialization errors, output conversion can fail.
+        // This must never crash the node: simulation endpoints are attacker-reachable.
+        let gas_used = vm_output.gas_used();
+        let txn_output = match vm_output.try_materialize_into_transaction_output(&resolver) {
+            Ok(out) => out,
+            Err(materialization_status) => {
+                let txn_status = TransactionStatus::from_vm_status(
+                    materialization_status,
+                    vm.features(),
+                    vm.gas_feature_version() >= RELEASE_V1_38,
+                );
+                TransactionOutput::new(
+                    aptos_types::write_set::WriteSetMut::default()
+                        .freeze()
+                        .expect("Freezing an empty WriteSet must succeed"),
+                    vec![],
+                    gas_used,
+                    txn_status,
+                    aptos_types::transaction::TransactionAuxiliaryData::default(),
+                )
+            },
+        };
         (vm_status, txn_output)
     }
 }


### PR DESCRIPTION
Simulation runs outside the block-executor finalization pipeline. If a simulated transaction produces non-materialized delayed-field changes (e.g. delayed fields / aggregator v2) or v1 delta materialization errors, VMOutput->TransactionOutput conversion can return Err(VMStatus).\n\nPreviously AptosSimulationVM::create_vm_and_simulate_signed_transaction() called try_materialize_into_transaction_output(...).expect(...), turning this into an attacker-reachable panic via the public API simulate endpoint.\n\nThis PR replaces the expect with non-panicking error handling: on materialization failure we return an error TransactionOutput with empty writes/events and preserve gas_used.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only the simulation path’s error handling when converting `VMOutput` to `TransactionOutput`, replacing a panic with a safe fallback output.
> 
> **Overview**
> Prevents `AptosSimulationVM::create_vm_and_simulate_signed_transaction()` from panicking when `try_materialize_into_transaction_output()` fails (e.g., non-materialized delayed-field changes or aggregator delta materialization errors).
> 
> On materialization failure, simulation now returns an *error* `TransactionOutput` with empty writes/events while preserving `gas_used`, instead of crashing the node.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b7041472e28842ff67ebd403a1b0779f742b95c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->