### PR TITLE
[storage] Stable hot state order across restarts

### DIFF
--- a/storage/aptosdb/src/state_kv_db.rs
+++ b/storage/aptosdb/src/state_kv_db.rs
@@ -425,7 +425,7 @@ impl StateKvDb {
     /// `hot_since_version <= snapshot_version`. Entries newer than the snapshot version (written
     /// between the snapshot and the committed version) are skipped — they will be replayed during
     /// initialisation. Evicted entries are excluded. The returned shards have correctly assembled
-    /// LRU doubly-linked list pointers, ordered by `hot_since_version`.
+    /// LRU doubly-linked list pointers, ordered by `(hot_since_version, key_hash)`.
     pub(crate) fn load_hot_state_kvs(
         &self,
         snapshot_version: Version,
@@ -531,12 +531,14 @@ impl StateKvDb {
         Ok(entries)
     }
 
-    /// Sorts entries by `(hot_since_version, key_hash)`, assembles LRU doubly-linked list
-    /// pointers, and builds the `DashMap`. Validates the chain before returning.
+    /// Sorts entries by `(hot_since_version, key_hash)` ascending, assembles the LRU
+    /// doubly-linked list, and builds the `DashMap`. Validates the chain before returning.
+    ///
+    /// That tuple is the canonical LRU order for hot state — runtime insertions into
+    /// `HotStateLRU` must follow it, so the chain rebuilt here must match as well.
     fn assemble_lru_chain(
         mut entries: Vec<(HashValue, Version, StateSlotKind)>,
     ) -> LoadedHotStateShard {
-        // Sort by (hot_since_version, key_hash) ascending.
         // Index 0 = oldest (LRU tail), last = newest (MRU head).
         entries.sort_by(|a, b| (a.1, a.0).cmp(&(b.1, b.0)));
 

--- a/storage/aptosdb/src/state_store/tests/speculative_state_workflow.rs
+++ b/storage/aptosdb/src/state_store/tests/speculative_state_workflow.rs
@@ -65,7 +65,7 @@ const TEST_CONFIG: HotStateConfig = HotStateConfig {
     persist_hotness_in_write_set: true,
 };
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 struct UserTxn {
     reads: BTreeSet<StateKey>,
     writes: BTreeMap<StateKey, Option<StateValue>>,
@@ -126,47 +126,46 @@ prop_compose! {
 }
 
 prop_compose! {
+    fn arb_user_txn(
+        keys: Vec<StateKey>,
+        max_read_only_set_size: usize,
+        max_write_set_size: usize,
+    )(
+        reads in vec(any::<Index>(), 0..=max_read_only_set_size),
+        writes in vec(any::<(Index, Option<StateValue>)>(), 1..=max_write_set_size),
+    ) -> UserTxn {
+        let write_set: BTreeMap<_, _> = writes
+            .into_iter()
+            .map(|(idx, value)| (idx.get(&keys).clone(), value))
+            .collect();
+
+        // The read set is a super set of the write set.
+        let read_set: BTreeSet<_> = write_set
+            .keys()
+            .cloned()
+            .chain(reads.iter().map(|idx| idx.get(&keys)).cloned())
+            .collect();
+
+        UserTxn {
+            reads: read_set,
+            writes: write_set,
+        }
+    }
+}
+
+prop_compose! {
     fn arb_user_block(
         keys: Vec<StateKey>,
         max_read_only_set_size: usize,
         max_write_set_size: usize,
         max_block_size: usize,
     )(
-        input in vec(
-            (
-                vec(
-                    any::<Index>(),
-                    0..=max_read_only_set_size,
-                ),
-                vec(
-                    any::<(Index, Option<StateValue>)>(),
-                    1..=max_write_set_size,
-                ),
-            ),
-            1..=max_block_size
+        txns in vec(
+            arb_user_txn(keys, max_read_only_set_size, max_write_set_size),
+            1..=max_block_size,
         ),
     ) -> Vec<UserTxn> {
-        input
-            .into_iter()
-            .map(|(reads, writes)| {
-                let write_set: BTreeMap<_, _> = writes
-                    .into_iter()
-                    .map(|(idx, value)| (idx.get(&keys).clone(), value))
-                    .collect();
-
-                // The read set is a super set of the write set.
-                let read_set: BTreeSet<_> = write_set
-                    .keys()
-                    .cloned()
-                    .chain(reads.iter().map(|idx| idx.get(&keys)).cloned())
-                    .collect();
-
-                UserTxn {
-                    reads: read_set,
-                    writes: write_set,
-                }
-            })
-            .collect_vec()
+        txns
     }
 }
 
@@ -199,6 +198,11 @@ impl VersionState {
         promotions: impl IntoIterator<Item = &'a StateKey>,
         is_checkpoint: bool,
     ) -> Self {
+        enum Op<'a> {
+            Write(Option<&'a StateValue>),
+            Promote,
+        }
+
         assert_eq!(version, self.next_version);
 
         let mut hot_state = self.hot_state.clone();
@@ -206,10 +210,19 @@ impl VersionState {
         let mut hot_smt_updates = vec![];
         let mut smt_updates = vec![];
 
-        for (k, v_opt) in writes {
+        // Sort writes and promotions together by key hash to match `State::update`'s per-shard
+        // `(version, key_hash)` ordering.
+        let mut all_ops: Vec<(&StateKey, Op<'a>)> = writes
+            .into_iter()
+            .map(|(k, v)| (k, Op::Write(v)))
+            .chain(promotions.into_iter().map(|k| (k, Op::Promote)))
+            .collect();
+        all_ops.sort_by_key(|(k, _)| *k.crypto_hash_ref());
+
+        for (k, op) in all_ops {
             let shard_id = k.get_shard_id();
-            match v_opt {
-                None => {
+            match op {
+                Op::Write(None) => {
                     let slot = StateSlot::new(k.clone(), StateSlotKind::HotVacant {
                         hot_since_version: version,
                         lru_info: LRUEntry::uninitialized(),
@@ -220,7 +233,7 @@ impl VersionState {
                     smt_updates.push((k.hash(), None));
                     state.remove(k);
                 },
-                Some(v) => {
+                Op::Write(Some(v)) => {
                     let slot = StateSlot::new(k.clone(), StateSlotKind::HotOccupied {
                         value_version: version,
                         value: v.clone(),
@@ -233,42 +246,40 @@ impl VersionState {
                     smt_updates.push((k.hash(), Some(v.hash())));
                     state.insert(k.clone(), (version, v.clone()));
                 },
-            }
-        }
+                Op::Promote => {
+                    assert!(is_checkpoint, "No promotions unless in checkpoints");
 
-        for k in promotions {
-            assert!(is_checkpoint, "No promotions unless in checkpoints");
-            let shard_id = k.get_shard_id();
-
-            let hot_value_hash;
-            if let Some(slot) = hot_state[shard_id].peek_mut(k) {
-                if slot.expect_hot_since_version() + REFRESH_INTERVAL_VERSIONS <= version {
-                    slot.refresh(version);
-                    hot_value_hash = Some(HotStateValueRef::from_slot(slot).hash());
-                } else {
-                    hot_value_hash = None;
-                }
-            } else {
-                let slot = match state.get(k) {
-                    Some((value_version, value)) => {
-                        StateSlot::new(k.clone(), StateSlotKind::HotOccupied {
-                            value_version: *value_version,
-                            value: value.clone(),
-                            hot_since_version: version,
-                            lru_info: LRUEntry::uninitialized(),
-                        })
-                    },
-                    None => StateSlot::new(k.clone(), StateSlotKind::HotVacant {
-                        hot_since_version: version,
-                        lru_info: LRUEntry::uninitialized(),
-                    }),
-                };
-                hot_value_hash = Some(HotStateValueRef::from_slot(&slot).hash());
-                hot_state[shard_id].put(k.clone(), slot);
-            }
-            if hot_value_hash.is_some() {
-                assert!(hot_state[shard_id].promote(k));
-                hot_smt_updates.push((k.hash(), hot_value_hash));
+                    let hot_value_hash;
+                    if let Some(slot) = hot_state[shard_id].peek_mut(k) {
+                        if slot.expect_hot_since_version() + REFRESH_INTERVAL_VERSIONS <= version {
+                            slot.refresh(version);
+                            hot_value_hash = Some(HotStateValueRef::from_slot(slot).hash());
+                        } else {
+                            hot_value_hash = None;
+                        }
+                    } else {
+                        let slot = match state.get(k) {
+                            Some((value_version, value)) => {
+                                StateSlot::new(k.clone(), StateSlotKind::HotOccupied {
+                                    value_version: *value_version,
+                                    value: value.clone(),
+                                    hot_since_version: version,
+                                    lru_info: LRUEntry::uninitialized(),
+                                })
+                            },
+                            None => StateSlot::new(k.clone(), StateSlotKind::HotVacant {
+                                hot_since_version: version,
+                                lru_info: LRUEntry::uninitialized(),
+                            }),
+                        };
+                        hot_value_hash = Some(HotStateValueRef::from_slot(&slot).hash());
+                        hot_state[shard_id].put(k.clone(), slot);
+                    }
+                    if hot_value_hash.is_some() {
+                        assert!(hot_state[shard_id].promote(k));
+                        hot_smt_updates.push((k.hash(), hot_value_hash));
+                    }
+                },
             }
         }
 
@@ -815,17 +826,17 @@ fn commit_state_buffer(
     }
 }
 
-fn naive_run_blocks(blocks: Vec<(Vec<UserTxn>, bool)>) -> (Vec<Txn>, StateByVersion) {
+fn naive_run_blocks(blocks: Vec<(Vec<UserTxn>, Option<UserTxn>)>) -> (Vec<Txn>, StateByVersion) {
     let mut all_txns = vec![];
     let mut state_by_version = StateByVersion::new_empty();
-    for (block_txns, append_epilogue) in blocks {
+    for (block_txns, epilogue) in blocks {
         let mut op_accu =
             BlockHotStateOpAccumulator::<StateKey>::new_with_config(MAX_PROMOTIONS_PER_BLOCK);
         let num_txns = block_txns.len();
         for (idx, txn) in block_txns.into_iter().enumerate() {
             // No promotions except for block epilogue. Also note that in case of reconfig, there's
             // no epilogue, but we still have a checkpoint and will run eviction on hot state.
-            let is_checkpoint = !append_epilogue && idx + 1 == num_txns;
+            let is_checkpoint = epilogue.is_none() && idx + 1 == num_txns;
             state_by_version.append_version(
                 txn.writes.iter().map(|(k, v)| (k, v.as_ref())),
                 vec![],
@@ -845,16 +856,32 @@ fn naive_run_blocks(blocks: Vec<(Vec<UserTxn>, bool)>) -> (Vec<Txn>, StateByVers
                 is_checkpoint,
             });
         }
-        if append_epilogue {
+        if let Some(epi_txn) = epilogue {
             let to_make_hot = op_accu.get_keys_to_make_hot();
-            let is_checkpoint = true;
-            state_by_version.append_version(vec![], to_make_hot.iter(), is_checkpoint);
 
-            let reads = to_make_hot.clone();
-            let write_set = to_make_hot
-                .into_iter()
-                .map(|k| (k, HotStateOp::make_hot().into_base_op()))
+            state_by_version.append_version(
+                epi_txn.writes.iter().map(|(k, v)| (k, v.as_ref())),
+                to_make_hot
+                    .iter()
+                    .filter(|k| !epi_txn.writes.contains_key(*k)),
+                /* is_checkpoint */ true,
+            );
+
+            let mut reads = to_make_hot.clone();
+            reads.extend(epi_txn.reads.iter().cloned());
+            // On key collision between value writes and `to_make_hot`, the value op wins.
+            // So we insert value ops after.
+            let mut write_set: BTreeMap<StateKey, BaseStateOp> = to_make_hot
+                .iter()
+                .map(|k| (k.clone(), HotStateOp::make_hot().into_base_op()))
                 .collect();
+            for (k, v_opt) in epi_txn.writes {
+                let op = match v_opt {
+                    None => WriteOp::legacy_deletion().into_base_op(),
+                    Some(v) => WriteOp::modification_to_value(v).into_base_op(),
+                };
+                write_set.insert(k, op);
+            }
             all_txns.push(Txn {
                 reads,
                 write_set,
@@ -946,21 +973,25 @@ proptest! {
 
     #[test]
     fn test_speculative_state_workflow(
-        (mut blocks, last_block) in arb_keys(NUM_KEYS)
+        (mut blocks, last_block, last_epilogue) in arb_keys(NUM_KEYS)
             .prop_flat_map(move |keys| {
                 (
                     vec(
                         (
                             arb_user_block(keys.clone(), NUM_KEYS, NUM_KEYS, NUM_KEYS),
-                            prop_oneof![1=>Just(false), 9=>Just(true)]
+                            prop_oneof![
+                                1 => Just(None),
+                                9 => arb_user_txn(keys.clone(), NUM_KEYS, NUM_KEYS).prop_map(Some),
+                            ],
                         ),
                         1..100
                     ),
-                    arb_user_block(keys, NUM_KEYS, NUM_KEYS, NUM_KEYS)
+                    arb_user_block(keys.clone(), NUM_KEYS, NUM_KEYS, NUM_KEYS),
+                    arb_user_txn(keys, NUM_KEYS, NUM_KEYS),
                 )
             })
     ) {
-        blocks.push((last_block, /* is_checkpoint */ true));
+        blocks.push((last_block, Some(last_epilogue)));
 
         let (all_txns, state_by_version) = naive_run_blocks(blocks);
 

--- a/storage/storage-interface/src/state_store/state_update_refs.rs
+++ b/storage/storage-interface/src/state_store/state_update_refs.rs
@@ -64,6 +64,10 @@ impl<'kv> PerVersionStateUpdateRefs<'kv> {
         Self {
             first_version,
             shards: shards.map(|mut shard| {
+                // Things are already sorted by version, but we need to sort by
+                // `(version, key_hash)` for having a canonical order within each
+                // version too. Simply sort the whole thing here.
+                shard.sort_by_key(|(k, u)| (u.version, *k.crypto_hash_ref()));
                 // Release over-allocated memory during construction.
                 shard.shrink_to_fit();
                 shard
@@ -412,5 +416,30 @@ mod tests {
         verify_batching(for_latest, "A", 11, "A1");
         verify_batching(for_latest, "B", 10, "B0");
         verify_batching(for_latest, "C", 12, "C2");
+    }
+
+    /// Each shard's per-version vec must be ordered by `(version, key_hash)`.
+    /// This is the order in which `State::update` inserts keys into
+    /// `HotStateLRU`, and must match `assemble_lru_chain` in
+    /// `storage/aptosdb/src/state_kv_db.rs`, which rebuilds the LRU on restart
+    /// by sorting loaded entries on the same tuple. Otherwise the chain
+    /// produced for same-version keys at runtime would not survive a restart.
+    #[test]
+    fn test_per_version_shards_ordered_by_version_then_hash() {
+        // Use many byte-pattern keys so every shard receives multiple entries
+        // per version. `WriteSet` iterates its `BTreeMap` in `StateKey` byte
+        // order, which is essentially independent of `HashValue` order within
+        // a shard, so this meaningfully exercises the sort.
+        let keys0: Vec<_> = (0..=255u8).map(|b| format!("k0_{b:02x}")).collect();
+        let keys1: Vec<_> = (0..=255u8).map(|b| format!("k1_{b:02x}")).collect();
+        let pairs0: Vec<_> = keys0.iter().map(|k| (k.as_str(), "v0")).collect();
+        let pairs1: Vec<_> = keys1.iter().map(|k| (k.as_str(), "v1")).collect();
+        let ws0 = write_set(&pairs0);
+        let ws1 = write_set(&pairs1);
+        let ret = StateUpdateRefs::index_write_sets(0, vec![&ws0, &ws1], 2, vec![]);
+
+        for shard in &ret.for_latest_per_version().unwrap().shards {
+            assert!(shard.is_sorted_by_key(|(k, u)| (u.version, *k.crypto_hash_ref())));
+        }
     }
 }


### PR DESCRIPTION

Sort each `PerVersionStateUpdateRefs` shard by `(version, key_hash)` so
that `State::update` inserts into `HotStateLRU` in the same order
`assemble_lru_chain` uses when rebuilding the chain from disk on
restart.

Previously the order within a single version was not well defined, so
the LRU chain built at runtime for same-version keys was not
reproducible after a restart.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the canonical ordering of per-shard state updates to be sorted by `(version, key_hash)`, which can affect hot-state LRU insertion/eviction behavior and therefore needs careful validation across execution and restart paths.
> 
> **Overview**
> Ensures hot state LRU ordering is **stable across restarts** by making per-shard `PerVersionStateUpdateRefs` deterministically ordered by `(version, key_hash)` instead of relying on incidental iteration order.
> 
> Aligns documentation and tests with this canonical ordering: `assemble_lru_chain` now explicitly treats `(hot_since_version, key_hash)` as the canonical LRU order, property tests update their naive model to apply writes/promotions in hash order, and a new unit test asserts each shard’s per-version ordering matches `(version, key_hash)`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 203810685d58b31f5ed6ef333ce5384ffe7fe9ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->