### PR TITLE
[natives] Isolate rayon work on a dedicated pool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3393,6 +3393,8 @@ dependencies = [
  "move-core-types",
  "move-vm-runtime",
  "move-vm-types",
+ "once_cell",
+ "rayon",
  "smallvec",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -836,7 +836,11 @@ tiny-keccak = { version = "2.0.2", features = ["keccak", "sha3"] }
 tracing = "0.1.37"
 tracing-log = "0.2.0"
 tracing-opentelemetry = "0.28.0"
-tracing-subscriber = { version = "0.3.17", features = ["json", "env-filter", "registry"] }
+tracing-subscriber = { version = "0.3.17", features = [
+    "json",
+    "env-filter",
+    "registry",
+] }
 triomphe = "0.1.14"
 trybuild = "1.0.80"
 try_match = "0.4.2"

--- a/aptos-move/aptos-native-interface/Cargo.toml
+++ b/aptos-move/aptos-native-interface/Cargo.toml
@@ -19,4 +19,6 @@ move-binary-format = { workspace = true }
 move-core-types = { workspace = true }
 move-vm-runtime = { workspace = true }
 move-vm-types = { workspace = true }
+once_cell = { workspace = true }
+rayon = { workspace = true }
 smallvec = { workspace = true }

--- a/aptos-move/aptos-native-interface/src/lib.rs
+++ b/aptos-move/aptos-native-interface/src/lib.rs
@@ -13,6 +13,7 @@ mod builder;
 mod context;
 mod errors;
 mod native;
+mod rayon_pool;
 
 #[macro_use]
 mod helpers;
@@ -24,3 +25,6 @@ pub use builder::SafeNativeBuilder;
 pub use context::SafeNativeContext;
 pub use errors::{SafeNativeError, SafeNativeResult};
 pub use native::RawSafeNative;
+pub use rayon_pool::{
+    init_native_rayon_pool, with_native_rayon, NativeRayonPoolAlreadyInitialized,
+};

--- a/aptos-move/aptos-native-interface/src/rayon_pool.rs
+++ b/aptos-move/aptos-native-interface/src/rayon_pool.rs
@@ -1,0 +1,115 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Dedicated rayon thread pool for Move native functions that spawn rayon work
+//! (directly or transitively, e.g. via `ark_ec` MSM / pairing or `bulletproofs`).
+//!
+//! Why this exists: block execution runs on the `par_exec` rayon pool. If a
+//! native running on a `par_exec` worker invokes code that calls `par_iter` /
+//! `rayon::scope` without installing its own pool, the sub-tasks land on
+//! `par_exec`'s deques and rayon's `wait_until` work-steals other block-executor
+//! jobs onto the same thread. Combined with writer-preferring RwLocks on
+//! per-txn scheduler state, this can close into a deadlock.
+//!
+//! Natives that reach into rayon-using code must wrap the relevant section in
+//! [`with_native_rayon`] so the work executes on this isolated pool instead.
+
+use once_cell::sync::OnceCell;
+use std::sync::Arc;
+
+static NATIVE_RAYON_POOL: OnceCell<Arc<rayon::ThreadPool>> = OnceCell::new();
+
+/// Returned by [`init_native_rayon_pool`] when the pool has already been built.
+#[derive(Debug)]
+pub struct NativeRayonPoolAlreadyInitialized;
+
+fn build_pool(num_threads: usize) -> Arc<rayon::ThreadPool> {
+    Arc::new(
+        rayon::ThreadPoolBuilder::new()
+            .num_threads(num_threads)
+            .thread_name(|i| format!("native-rayon-{}", i))
+            .build()
+            .expect("failed to build native rayon thread pool"),
+    )
+}
+
+/// Initialize the process-wide native rayon pool with the given thread count.
+///
+/// Intended to be called once at process startup from the same site that reads
+/// the block-executor concurrency level. Returns
+/// [`NativeRayonPoolAlreadyInitialized`] if the pool is already initialized —
+/// it cannot be resized after construction.
+pub fn init_native_rayon_pool(num_threads: usize) -> Result<(), NativeRayonPoolAlreadyInitialized> {
+    let num_threads = std::cmp::max(1, num_threads);
+    NATIVE_RAYON_POOL
+        .set(build_pool(num_threads))
+        .map_err(|_| NativeRayonPoolAlreadyInitialized)
+}
+
+fn pool() -> &'static rayon::ThreadPool {
+    NATIVE_RAYON_POOL.get_or_init(|| build_pool(1))
+}
+
+/// Run `op` on the dedicated native rayon pool.
+///
+/// Use this to wrap any Move native code path that invokes rayon directly or
+/// via a third-party crate (ark_ec, ark_bls12_381, etc.). The call blocks the
+/// current thread until `op` completes.
+pub fn with_native_rayon<F, R>(op: F) -> R
+where
+    F: FnOnce() -> R + Send,
+    R: Send,
+{
+    pool().install(op)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn install_runs_on_native_pool() {
+        let name = with_native_rayon(|| {
+            std::thread::current()
+                .name()
+                .map(|s| s.to_string())
+                .unwrap_or_default()
+        });
+        assert!(
+            name.starts_with("native-rayon-"),
+            "expected native-rayon-* thread, got {:?}",
+            name
+        );
+    }
+
+    #[test]
+    fn nested_par_iter_stays_on_native_pool() {
+        use rayon::prelude::*;
+
+        let outer_pool = rayon::ThreadPoolBuilder::new()
+            .num_threads(2)
+            .thread_name(|i| format!("test-outer-{}", i))
+            .build()
+            .unwrap();
+
+        let names = outer_pool.install(|| {
+            with_native_rayon(|| {
+                (0..64)
+                    .into_par_iter()
+                    .map(|_| {
+                        std::thread::current()
+                            .name()
+                            .map(|s| s.to_string())
+                            .unwrap_or_default()
+                    })
+                    .collect::<Vec<_>>()
+            })
+        });
+
+        assert!(
+            names.iter().all(|n| n.starts_with("native-rayon-")),
+            "found tasks not on native pool: {:?}",
+            names
+        );
+    }
+}

--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -441,6 +441,13 @@ impl AptosVM {
         EXECUTION_CONCURRENCY_LEVEL.set(concurrency_level).ok();
     }
 
+    /// Initialize the dedicated rayon pool used by Move natives that spawn
+    /// rayon work (e.g. multi-scalar-mul, pairings). Only the first call
+    /// succeeds; subsequent calls are ignored.
+    pub fn init_native_rayon_pool_once(num_threads: usize) {
+        aptos_native_interface::init_native_rayon_pool(num_threads).ok();
+    }
+
     /// Get the concurrency level if already set, otherwise return default 1
     /// (sequential execution).
     ///

--- a/aptos-move/framework/natives/src/cryptography/algebra/arithmetics/scalar_mul.rs
+++ b/aptos-move/framework/natives/src/cryptography/algebra/arithmetics/scalar_mul.rs
@@ -17,7 +17,7 @@ use crate::{
 use aptos_gas_algebra::{Arg, GasExpression};
 use aptos_gas_schedule::gas_params::natives::aptos_framework::*;
 use aptos_native_interface::{
-    safely_pop_arg, SafeNativeContext, SafeNativeError, SafeNativeResult,
+    safely_pop_arg, with_native_rayon, SafeNativeContext, SafeNativeError, SafeNativeResult,
 };
 use aptos_types::on_chain_config::FeatureFlag;
 use ark_ec::{CurveGroup, PrimeGroup};
@@ -233,13 +233,15 @@ macro_rules! ark_msm_internal {
             $proj_double_cost,
             num_elements,
         ))?;
-        let new_element: $element_typ =
-            ark_ec::VariableBaseMSM::msm(bases.as_slice(), scalars.as_slice()).map_err(|_e| {
-                SafeNativeError::abort_with_message(
-                    E_SCALAR_MUL_MSM_COMPUTATION_FAILED,
-                    "MSM computation failed",
-                )
-            })?;
+        let new_element: $element_typ = with_native_rayon(|| {
+            ark_ec::VariableBaseMSM::msm(bases.as_slice(), scalars.as_slice())
+        })
+        .map_err(|_e| {
+            SafeNativeError::abort_with_message(
+                E_SCALAR_MUL_MSM_COMPUTATION_FAILED,
+                "MSM computation failed",
+            )
+        })?;
         let new_handle = store_element!($context, new_element)?;
         Ok(smallvec![Value::u64(new_handle as u64)])
     }};

--- a/aptos-move/framework/natives/src/cryptography/algebra/pairing.rs
+++ b/aptos-move/framework/natives/src/cryptography/algebra/pairing.rs
@@ -13,7 +13,7 @@ use crate::{
 use aptos_gas_algebra::{Arg, GasExpression};
 use aptos_gas_schedule::gas_params::natives::aptos_framework::*;
 use aptos_native_interface::{
-    safely_pop_arg, SafeNativeContext, SafeNativeError, SafeNativeResult,
+    safely_pop_arg, with_native_rayon, SafeNativeContext, SafeNativeError, SafeNativeResult,
 };
 use aptos_types::on_chain_config::FeatureFlag;
 use ark_ec::{pairing::Pairing, CurveGroup};
@@ -76,7 +76,8 @@ macro_rules! pairing_internal {
         $context.charge($g2_proj_to_affine_gas_cost)?;
         let g2_element_affine = g2_element.into_affine();
         $context.charge($pairing_gas_cost)?;
-        let new_element = <$pairing>::pairing(g1_element_affine, g2_element_affine).0;
+        let new_element =
+            with_native_rayon(|| <$pairing>::pairing(g1_element_affine, g2_element_affine)).0;
         let new_handle = store_element!($context, new_element)?;
         Ok(smallvec![Value::u64(new_handle as u64)])
     }};
@@ -120,7 +121,9 @@ macro_rules! multi_pairing_internal {
             $multi_pairing_base_gas
                 + $multi_pairing_per_pair_gas * NumArgs::from(num_entries as u64),
         )?;
-        let new_element = <$pairing>::multi_pairing(g1_elements_affine, g2_elements_affine).0;
+        let new_element =
+            with_native_rayon(|| <$pairing>::multi_pairing(g1_elements_affine, g2_elements_affine))
+                .0;
         let new_handle = store_element!($context, new_element)?;
         Ok(smallvec![Value::u64(new_handle as u64)])
     }};

--- a/aptos-node/src/utils.rs
+++ b/aptos-node/src/utils.rs
@@ -2,7 +2,9 @@
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use anyhow::anyhow;
-use aptos_config::config::{NodeConfig, DEFAULT_EXECUTION_CONCURRENCY_LEVEL};
+use aptos_config::config::{
+    NodeConfig, DEFAULT_EXECUTION_CONCURRENCY_LEVEL, DEFAULT_NATIVE_RAYON_CONCURRENCY_LEVEL,
+};
 #[cfg(unix)]
 use aptos_logger::prelude::*;
 use aptos_storage_interface::{
@@ -60,6 +62,14 @@ pub fn set_aptos_vm_configurations(node_config: &NodeConfig) {
         node_config.execution.concurrency_level
     };
     AptosVM::set_concurrency_level_once(effective_concurrency_level as usize);
+
+    let native_rayon_threads = if node_config.execution.native_rayon_concurrency_level == 0 {
+        ((num_cpus::get() / 2) as u16).clamp(1, DEFAULT_NATIVE_RAYON_CONCURRENCY_LEVEL)
+    } else {
+        node_config.execution.native_rayon_concurrency_level
+    };
+    AptosVM::init_native_rayon_pool_once(native_rayon_threads as usize);
+
     AptosVM::set_discard_failed_blocks(node_config.execution.discard_failed_blocks);
     AptosVM::set_num_proof_reading_threads_once(
         node_config.execution.num_proof_reading_threads as usize,

--- a/config/src/config/execution_config.rs
+++ b/config/src/config/execution_config.rs
@@ -19,6 +19,11 @@ use std::{
 // Default execution concurrency level
 pub const DEFAULT_EXECUTION_CONCURRENCY_LEVEL: u16 = 16;
 
+// Default upper bound for the native rayon pool concurrency level. This pool
+// is isolation-oriented rather than performance-oriented, so the default is
+// conservative.
+pub const DEFAULT_NATIVE_RAYON_CONCURRENCY_LEVEL: u16 = 1;
+
 // Genesis constants
 const GENESIS_BLOB_FILENAME: &str = "genesis.blob";
 const GENESIS_VERSION: u64 = 0;
@@ -38,6 +43,12 @@ pub struct ExecutionConfig {
     /// Number of threads to run execution.
     /// If 0, we use min of (num of cores/2, DEFAULT_CONCURRENCY_LEVEL) as default concurrency level
     pub concurrency_level: u16,
+    /// Number of threads in the dedicated rayon pool used by Move native
+    /// functions that spawn rayon work (e.g. multi-scalar-mul, pairings).
+    /// This pool is isolated from the block-executor's `par_exec` pool to
+    /// prevent nested-rayon reentrancy deadlocks.
+    /// If 0, uses `min(num_cpus / 2, DEFAULT_NATIVE_RAYON_CONCURRENCY_LEVEL)`.
+    pub native_rayon_concurrency_level: u16,
     /// Number of threads to read proofs
     pub num_proof_reading_threads: u16,
     /// Enables paranoid mode for types, which adds extra runtime VM checks
@@ -84,6 +95,7 @@ impl Default for ExecutionConfig {
             genesis_file_location: PathBuf::new(),
             // use min of (num of cores/2, DEFAULT_CONCURRENCY_LEVEL) as default concurrency level
             concurrency_level: 0,
+            native_rayon_concurrency_level: 0,
             num_proof_reading_threads: 32,
             paranoid_type_verification: true,
             paranoid_hot_potato_verification: true,


### PR DESCRIPTION
Move natives that spawn rayon work (ark_ec MSM, pairing, multi-pairing) currently run on the block-executor's par_exec pool. When the native calls par_iter/collect, rayon pushes sub-tasks onto par_exec's deques and wait_until work-steals other block-executor scope jobs onto the same thread. Combined with writer-preferring RwLocks on per-txn Scheduler state, this can close into a deadlock (observed in prod thread dump).

Add a dedicated native-rayon pool sized from a new ExecutionConfig field native_rayon_concurrency_level (default max(2, num_cpus/2)), and a with_native_rayon helper that native callers use to hop onto it. Wrap the rayon-calling sections of multi_scalar_mul_internal, pairing_internal, and multi_pairing_internal. bulletproofs 4.0.0 has no rayon dependency and is out of scope.

## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
