### PR TITLE
[dkg] Fix security and DoS issues in ChunkyDKG manager

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1435,6 +1435,7 @@ name = "aptos-dkg-runtime"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "aptos-bitvec",
  "aptos-bounded-executor",
  "aptos-channels",
  "aptos-config",

--- a/aptos-move/aptos-vm/src/validator_txns/chunky_dkg.rs
+++ b/aptos-move/aptos-vm/src/validator_txns/chunky_dkg.rs
@@ -140,6 +140,9 @@ impl AptosVM {
         let trx: AggregatedSubtranscript = bcs::from_bytes(&transcript_bytes).map_err(|_| {
             ExecutionFailure::Expected(ExpectedFailure::TranscriptDeserializationFailed)
         })?;
+        if trx.dealer_epoch != metadata.epoch {
+            return Err(ExecutionFailure::Expected(ExpectedFailure::EpochNotCurrent));
+        }
         verifier
             .verify_multi_signatures(&trx, &signature)
             .map_err(|_| ExecutionFailure::Expected(ExpectedFailure::MultiSigVerificationFailed))?;

--- a/crates/aptos-dkg/src/pvss/chunky/subtranscript.rs
+++ b/crates/aptos-dkg/src/pvss/chunky/subtranscript.rs
@@ -12,6 +12,7 @@ use crate::{
     traits::{transcript::Aggregated, Aggregatable, TranscriptCore},
     Scalar,
 };
+use anyhow::ensure;
 use aptos_crypto::{
     arkworks::{
         random::{unsafe_random_point, unsafe_random_points},
@@ -165,18 +166,48 @@ impl<E: Pairing> Aggregated<Subtranscript<E>> for SubtranscriptProjective<E> {
         sc: &WeightedConfigArkworks<E::ScalarField>,
         other: &Subtranscript<E>,
     ) -> anyhow::Result<()> {
-        debug_assert_eq!(self.Cs_proj.len(), sc.get_total_num_players());
-        debug_assert_eq!(self.Vs_proj.len(), sc.get_total_num_players());
-        debug_assert_eq!(self.Cs_proj.len(), other.Cs.len());
-        debug_assert_eq!(self.Rs_proj.len(), other.Rs.len());
-        debug_assert_eq!(self.Vs_proj.len(), other.Vs.len());
+        ensure!(
+            self.Cs_proj.len() == sc.get_total_num_players(),
+            "Cs_proj length {} != num_players {}",
+            self.Cs_proj.len(),
+            sc.get_total_num_players()
+        );
+        ensure!(
+            self.Vs_proj.len() == sc.get_total_num_players(),
+            "Vs_proj length {} != num_players {}",
+            self.Vs_proj.len(),
+            sc.get_total_num_players()
+        );
+        ensure!(
+            self.Cs_proj.len() == other.Cs.len(),
+            "Cs_proj length {} != other {}",
+            self.Cs_proj.len(),
+            other.Cs.len()
+        );
+        ensure!(
+            self.Rs_proj.len() == other.Rs.len(),
+            "Rs_proj length {} != other {}",
+            self.Rs_proj.len(),
+            other.Rs.len()
+        );
+        ensure!(
+            self.Vs_proj.len() == other.Vs.len(),
+            "Vs_proj length {} != other {}",
+            self.Vs_proj.len(),
+            other.Vs.len()
+        );
 
         // Aggregate the V0s
         self.V0_proj += other.V0;
 
         // Aggregate Vs (nested) element-wise
         for (vs_row, other_row) in self.Vs_proj.iter_mut().zip(&other.Vs) {
-            debug_assert_eq!(vs_row.len(), other_row.len());
+            ensure!(
+                vs_row.len() == other_row.len(),
+                "Vs row length {} != other {}",
+                vs_row.len(),
+                other_row.len()
+            );
             for (v_ij, other_v_ij) in vs_row.iter_mut().zip(other_row) {
                 *v_ij += *other_v_ij;
             }

--- a/dkg/Cargo.toml
+++ b/dkg/Cargo.toml
@@ -14,6 +14,7 @@ rust-version = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }
+aptos-bitvec = { workspace = true }
 aptos-bounded-executor = { workspace = true }
 aptos-channels = { workspace = true }
 aptos-config = { workspace = true }

--- a/dkg/src/chunky/agg_subtrx_producer.rs
+++ b/dkg/src/chunky/agg_subtrx_producer.rs
@@ -294,6 +294,7 @@ impl BroadcastStatus<DKGMessage> for Arc<ChunkyTranscriptAggregationState> {
                         .collect()
                 };
                 let agg_subtrx = AggregatedSubtranscript {
+                    dealer_epoch: self.dkg_config.session_metadata.dealer_epoch,
                     subtranscript: agg_trx,
                     dealers,
                 };

--- a/dkg/src/chunky/agg_subtrx_producer.rs
+++ b/dkg/src/chunky/agg_subtrx_producer.rs
@@ -229,18 +229,14 @@ impl BroadcastStatus<DKGMessage> for Arc<ChunkyTranscriptAggregationState> {
             received_transcripts.insert(metadata.author, transcript);
         }
 
-        // Quorum already reached — transcript is stored for the fetcher but no further
-        // aggregation is needed.
-        if inner_state.agg_subtrx_tx.is_none() {
-            info!(
-                epoch = epoch,
-                peer = sender,
-                "[ChunkyDKG] transcript received after quorum, skipping aggregation"
-            );
-            return Ok(None);
-        }
-
         inner_state.contributors.insert(metadata.author);
+
+        // Quorum already reached — transcript is stored for the fetcher but no
+        // further aggregation is needed.
+        if inner_state.agg_subtrx_tx.is_none() {
+            let all_received = inner_state.contributors.len() >= self.epoch_state.verifier.len();
+            return Ok(all_received.then_some(()));
+        }
         if let Some(agg_subtrx) = inner_state.subtrx.as_mut() {
             agg_subtrx
                 .aggregate_with(&self.dkg_config.threshold_config, &subtranscript)
@@ -267,12 +263,8 @@ impl BroadcastStatus<DKGMessage> for Arc<ChunkyTranscriptAggregationState> {
             let tx = inner_state
                 .agg_subtrx_tx
                 .take()
-                .expect("agg_subtrx_tx must be Some due to above check");
-            let agg_trx = inner_state
-                .subtrx
-                .take()
-                .expect("subtrx must be Some due to above check")
-                .normalize();
+                .expect("agg_subtrx_tx must be Some due to early return above");
+            let agg_trx = inner_state.subtrx.take().unwrap().normalize();
             let num_validators = self.epoch_state.verifier.len();
             let addr_to_index = self.epoch_state.verifier.address_to_validator_index();
             let received = self.received_transcripts.read();
@@ -305,14 +297,14 @@ impl BroadcastStatus<DKGMessage> for Arc<ChunkyTranscriptAggregationState> {
             };
             if let Err(e) = tx.push((), with_hashes) {
                 info!(
-                        epoch = epoch,
-                        "[ChunkyDKG] Failed to send aggregated chunky transcript to ChunkyDKGManager when quorum met: {:?}", e
-                    );
+                    epoch = epoch,
+                    "[ChunkyDKG] Failed to send aggregated chunky transcript to ChunkyDKGManager when quorum met: {:?}", e
+                );
             } else {
                 info!(
-                        epoch = epoch,
-                        "[ChunkyDKG] sent aggregated chunky transcript to ChunkyDKGManager (quorum met)"
-                    );
+                    epoch = epoch,
+                    "[ChunkyDKG] sent aggregated chunky transcript to ChunkyDKGManager (quorum met)"
+                );
             }
         }
 

--- a/dkg/src/chunky/agg_subtrx_producer.rs
+++ b/dkg/src/chunky/agg_subtrx_producer.rs
@@ -14,11 +14,9 @@ use crate::{
 use anyhow::{ensure, Context};
 use aptos_channels::aptos_channel;
 use aptos_consensus_types::common::Author;
+use aptos_bitvec::BitVec;
 use aptos_crypto::HashValue;
-use aptos_dkg::pvss::{
-    traits::transcript::{Aggregatable, Aggregated},
-    Player,
-};
+use aptos_dkg::pvss::traits::transcript::{Aggregatable, Aggregated};
 use aptos_infallible::RwLock;
 use aptos_logger::info;
 use aptos_reliable_broadcast::{BroadcastStatus, ReliableBroadcast};
@@ -261,31 +259,22 @@ impl BroadcastStatus<DKGMessage> for Arc<ChunkyTranscriptAggregationState> {
         if quorum_met {
             if let Some(tx) = inner_state.agg_subtrx_tx.take() {
                 let agg_trx = inner_state.subtrx.take().unwrap().normalize();
-                // Convert AccountAddress contributors to Player by getting their validator indices.
-                // Sort by AccountAddress so dealers order is deterministic (HashSet iteration is
-                // non-deterministic); AggregatedSubtranscript is BCSCryptoHash'd for certification.
-                let mut contributors: Vec<_> = inner_state.contributors.iter().copied().collect();
-                contributors.sort();
-                let dealers: Vec<Player> = contributors
-                    .iter()
-                    .map(|addr| {
-                        self.epoch_state
-                            .verifier
-                            .address_to_validator_index()
-                            .get(addr)
-                            .map(|&index| Player { id: index })
-                            .expect("Request must be sent to validators in current set only")
-                    })
-                    .collect();
-                // Compute per-dealer transcript hashes in the same order as dealers.
-                // These are included in the signature request so the responder can detect
-                // equivocated transcripts (where a dealer sent different transcripts to
-                // different validators), not just missing ones.
+                let num_validators = self.epoch_state.verifier.len();
+                let addr_to_index = self.epoch_state.verifier.address_to_validator_index();
+                let ordered_addrs = self.epoch_state.verifier.get_ordered_account_addresses();
+                // Build dealer bitmask from contributors.
+                let mut dealer_bitmask = BitVec::with_num_bits(num_validators as u16);
+                for addr in inner_state.contributors.iter() {
+                    let index = *addr_to_index.get(addr)
+                        .expect("contributor must be in current validator set");
+                    dealer_bitmask.set(index as u16);
+                }
+                // Per-dealer transcript hashes ordered by set-bit position (ascending validator index).
                 let dealer_transcript_hashes: Vec<HashValue> = {
                     let received = self.received_transcripts.read();
-                    contributors
-                        .iter()
-                        .map(|addr| {
+                    dealer_bitmask.iter_ones()
+                        .map(|idx| {
+                            let addr = &ordered_addrs[idx];
                             let twh = received
                                 .get(addr)
                                 .expect("contributor must have a stored transcript");
@@ -296,7 +285,7 @@ impl BroadcastStatus<DKGMessage> for Arc<ChunkyTranscriptAggregationState> {
                 let agg_subtrx = AggregatedSubtranscript {
                     dealer_epoch: self.dkg_config.session_metadata.dealer_epoch,
                     subtranscript: agg_trx,
-                    dealers,
+                    dealer_bitmask,
                 };
                 let with_hashes = AggregatedSubtranscriptWithHashes {
                     aggregated_subtranscript: agg_subtrx,
@@ -404,8 +393,7 @@ mod tests {
         let agg = rx.select_next_some().now_or_never();
         assert!(agg.is_some());
         let agg_with_hashes = agg.unwrap();
-        // Dealers should be sorted by AccountAddress, then mapped to validator indices.
-        assert_eq!(agg_with_hashes.aggregated_subtranscript.dealers.len(), 3);
+        assert_eq!(agg_with_hashes.aggregated_subtranscript.dealer_bitmask.count_ones(), 3);
         assert_eq!(agg_with_hashes.dealer_transcript_hashes.len(), 3);
 
         // Fourth transcript — all received, returns Some(()).
@@ -481,7 +469,7 @@ mod tests {
         let agg = rx.select_next_some().now_or_never();
         assert!(agg.is_some());
         let agg_with_hashes = agg.unwrap();
-        assert_eq!(agg_with_hashes.aggregated_subtranscript.dealers.len(), 1);
+        assert_eq!(agg_with_hashes.aggregated_subtranscript.dealer_bitmask.count_ones(), 1);
         assert_eq!(agg_with_hashes.dealer_transcript_hashes.len(), 1);
     }
 }

--- a/dkg/src/chunky/agg_subtrx_producer.rs
+++ b/dkg/src/chunky/agg_subtrx_producer.rs
@@ -3,18 +3,18 @@
 
 use crate::{
     chunky::{
+        common::deserialize_chunky_transcript_and_verify,
         types::{
             AggregatedSubtranscriptWithHashes, ChunkyDKGTranscriptRequest, ChunkyTranscriptWithHash,
         },
-        common::deserialize_chunky_transcript_and_verify,
     },
     counters,
     types::DKGMessage,
 };
-use anyhow::{ensure, Context};
+use anyhow::{anyhow, ensure, Context};
+use aptos_bitvec::BitVec;
 use aptos_channels::aptos_channel;
 use aptos_consensus_types::common::Author;
-use aptos_bitvec::BitVec;
 use aptos_crypto::HashValue;
 use aptos_dkg::pvss::traits::transcript::{Aggregatable, Aggregated};
 use aptos_infallible::RwLock;
@@ -154,12 +154,13 @@ impl ChunkyTranscriptAggregationState {
             "[ChunkyDKG] adding peer chunky transcript failed with node author mismatch"
         );
 
-        let peer_power = self.epoch_state.verifier.get_voting_power(&sender);
-        ensure!(
-            peer_power.is_some(),
-            "[ChunkyDKG] adding peer chunky transcript failed with illegal dealer"
-        );
-        let peer_power = peer_power.expect("Peer must be valid");
+        let peer_power = self
+            .epoch_state
+            .verifier
+            .get_voting_power(&sender)
+            .ok_or_else(|| {
+                anyhow!("[ChunkyDKG] adding peer chunky transcript failed with illegal dealer")
+            })?;
 
         // Shared validation: deserialize, verify, check dealer ID.
         let transcript = deserialize_chunky_transcript_and_verify(
@@ -198,7 +199,6 @@ impl BroadcastStatus<DKGMessage> for Arc<ChunkyTranscriptAggregationState> {
             }
         }
 
-        // RwLock allows concurrent validation of multiple transcripts
         let (transcript, peer_power) =
             self.validate_and_deserialize_transcript(sender, metadata, transcript_bytes)?;
 
@@ -229,8 +229,17 @@ impl BroadcastStatus<DKGMessage> for Arc<ChunkyTranscriptAggregationState> {
             received_transcripts.insert(metadata.author, transcript);
         }
 
-        // Aggregate the transcript (projective accumulator; normalize when quorum is met)
-        // TODO(ibalajiarun): Should the transcript be aggregated if quorum is already met?
+        // Quorum already reached — transcript is stored for the fetcher but no further
+        // aggregation is needed.
+        if inner_state.agg_subtrx_tx.is_none() {
+            info!(
+                epoch = epoch,
+                peer = sender,
+                "[ChunkyDKG] transcript received after quorum, skipping aggregation"
+            );
+            return Ok(None);
+        }
+
         inner_state.contributors.insert(metadata.author);
         if let Some(agg_subtrx) = inner_state.subtrx.as_mut() {
             agg_subtrx
@@ -255,51 +264,55 @@ impl BroadcastStatus<DKGMessage> for Arc<ChunkyTranscriptAggregationState> {
 
         // Send to agg_subtrx_tx when quorum is met (only once)
         if quorum_met {
-            if let Some(tx) = inner_state.agg_subtrx_tx.take() {
-                let agg_trx = inner_state.subtrx.take().unwrap().normalize();
-                let num_validators = self.epoch_state.verifier.len();
-                let addr_to_index = self.epoch_state.verifier.address_to_validator_index();
-                let ordered_addrs = self.epoch_state.verifier.get_ordered_account_addresses();
-                // Build dealer bitmask from contributors.
-                let mut dealer_bitmask = BitVec::with_num_bits(num_validators as u16);
-                for addr in inner_state.contributors.iter() {
-                    let index = *addr_to_index.get(addr)
-                        .expect("contributor must be in current validator set");
-                    dealer_bitmask.set(index as u16);
-                }
-                // Per-dealer transcript hashes ordered by set-bit position (ascending validator index).
-                let dealer_transcript_hashes: Vec<HashValue> = {
-                    let received = self.received_transcripts.read();
-                    dealer_bitmask.iter_ones()
-                        .map(|idx| {
-                            let addr = &ordered_addrs[idx];
-                            let twh = received
-                                .get(addr)
-                                .expect("contributor must have a stored transcript");
-                            twh.hash()
-                        })
-                        .collect()
-                };
-                let agg_subtrx = AggregatedSubtranscript {
+            let tx = inner_state
+                .agg_subtrx_tx
+                .take()
+                .expect("agg_subtrx_tx must be Some due to above check");
+            let agg_trx = inner_state
+                .subtrx
+                .take()
+                .expect("subtrx must be Some due to above check")
+                .normalize();
+            let num_validators = self.epoch_state.verifier.len();
+            let addr_to_index = self.epoch_state.verifier.address_to_validator_index();
+            let received = self.received_transcripts.read();
+
+            let mut dealer_bitmask = BitVec::with_num_bits(num_validators as u16);
+            let mut indexed_hashes: Vec<(usize, HashValue)> = Vec::new();
+            for addr in inner_state.contributors.iter() {
+                let index = *addr_to_index
+                    .get(addr)
+                    .ok_or_else(|| anyhow!("contributor {} not in validator set", addr))?;
+                dealer_bitmask.set(index as u16);
+                let hash = received
+                    .get(addr)
+                    .ok_or_else(|| anyhow!("contributor {} missing stored transcript", addr))?
+                    .hash();
+                indexed_hashes.push((index, hash));
+            }
+            indexed_hashes.sort_by_key(|(idx, _)| *idx);
+            let dealer_transcript_hashes: Vec<HashValue> =
+                indexed_hashes.into_iter().map(|(_, h)| h).collect();
+            drop(received);
+
+            let with_hashes = AggregatedSubtranscriptWithHashes {
+                aggregated_subtranscript: AggregatedSubtranscript {
                     dealer_epoch: self.dkg_config.session_metadata.dealer_epoch,
                     subtranscript: agg_trx,
                     dealer_bitmask,
-                };
-                let with_hashes = AggregatedSubtranscriptWithHashes {
-                    aggregated_subtranscript: agg_subtrx,
-                    dealer_transcript_hashes,
-                };
-                if let Err(e) = tx.push((), with_hashes) {
-                    info!(
+                },
+                dealer_transcript_hashes,
+            };
+            if let Err(e) = tx.push((), with_hashes) {
+                info!(
                         epoch = epoch,
                         "[ChunkyDKG] Failed to send aggregated chunky transcript to ChunkyDKGManager when quorum met: {:?}", e
                     );
-                } else {
-                    info!(
+            } else {
+                info!(
                         epoch = epoch,
                         "[ChunkyDKG] sent aggregated chunky transcript to ChunkyDKGManager (quorum met)"
                     );
-                }
             }
         }
 
@@ -391,7 +404,13 @@ mod tests {
         let agg = rx.select_next_some().now_or_never();
         assert!(agg.is_some());
         let agg_with_hashes = agg.unwrap();
-        assert_eq!(agg_with_hashes.aggregated_subtranscript.dealer_bitmask.count_ones(), 3);
+        assert_eq!(
+            agg_with_hashes
+                .aggregated_subtranscript
+                .dealer_bitmask
+                .count_ones(),
+            3
+        );
         assert_eq!(agg_with_hashes.dealer_transcript_hashes.len(), 3);
 
         // Fourth transcript — all received, returns Some(()).
@@ -467,7 +486,13 @@ mod tests {
         let agg = rx.select_next_some().now_or_never();
         assert!(agg.is_some());
         let agg_with_hashes = agg.unwrap();
-        assert_eq!(agg_with_hashes.aggregated_subtranscript.dealer_bitmask.count_ones(), 1);
+        assert_eq!(
+            agg_with_hashes
+                .aggregated_subtranscript
+                .dealer_bitmask
+                .count_ones(),
+            1
+        );
         assert_eq!(agg_with_hashes.dealer_transcript_hashes.len(), 1);
     }
 }

--- a/dkg/src/chunky/agg_subtrx_producer.rs
+++ b/dkg/src/chunky/agg_subtrx_producer.rs
@@ -6,7 +6,7 @@ use crate::{
         types::{
             AggregatedSubtranscriptWithHashes, ChunkyDKGTranscriptRequest, ChunkyTranscriptWithHash,
         },
-        validation::validate_chunky_transcript,
+        common::deserialize_chunky_transcript_and_verify,
     },
     counters,
     types::DKGMessage,
@@ -162,14 +162,12 @@ impl ChunkyTranscriptAggregationState {
         let peer_power = peer_power.expect("Peer must be valid");
 
         // Shared validation: deserialize, verify, check dealer ID.
-        let mut rng = rand::thread_rng();
-        let transcript = validate_chunky_transcript(
+        let transcript = deserialize_chunky_transcript_and_verify(
             sender,
             transcript_bytes,
             &self.dkg_config,
             &self.signing_pubkeys,
             &self.epoch_state,
-            &mut rng,
         )?;
 
         Ok((transcript, peer_power))

--- a/dkg/src/chunky/common.rs
+++ b/dkg/src/chunky/common.rs
@@ -10,21 +10,19 @@ use aptos_types::{
     epoch_state::EpochState,
 };
 use move_core_types::account_address::AccountAddress;
-use rand::{CryptoRng, RngCore};
 
 /// Shared transcript validation pipeline used by both the aggregation producer and the
 /// transcript fetcher. Deserializes, cryptographically verifies, and checks dealer ID.
 ///
-/// The transcript is cryptographically verified via `transcript.verify()` which checks the
-/// dealer's key pair; the dealer-ID check ensures it belongs to the expected dealer; envelope
-/// metadata (epoch, author) is validated by the caller as belt-and-suspenders.
-pub fn validate_chunky_transcript<R: RngCore + CryptoRng>(
+/// `transcript.verify()` checks the PVSS proof and dealer signature against the full session
+/// parameters; the dealer-ID check ensures the transcript belongs to the expected sender;
+/// envelope metadata (epoch, author) is validated by the caller.
+pub fn deserialize_chunky_transcript_and_verify(
     sender: AccountAddress,
     transcript_bytes: &[u8],
     dkg_config: &ChunkyDKGSession,
     signing_pubkeys: &[DealerPublicKey],
     epoch_state: &EpochState,
-    rng: &mut R,
 ) -> anyhow::Result<ChunkyTranscriptWithHash> {
     // Hash the canonical BCS wire bytes once up front to avoid repeated re-serialization.
     // Safe because BCS is strictly canonical: deserialize(serialize(x)) == x byte-for-byte.
@@ -40,6 +38,7 @@ pub fn validate_chunky_transcript<R: RngCore + CryptoRng>(
     let transcript: ChunkyTranscript = bcs::from_bytes(transcript_bytes)
         .map_err(|e| anyhow!("[ChunkyDKG] Unable to deserialize chunky transcript: {e}"))?;
 
+    let mut rng = rand::thread_rng();
     // Verify the transcript cryptographically.
     monitor!(
         "chunky_validate_transcript_verify",
@@ -49,7 +48,7 @@ pub fn validate_chunky_transcript<R: RngCore + CryptoRng>(
             signing_pubkeys,
             &dkg_config.eks,
             &dkg_config.session_metadata,
-            rng,
+            &mut rng,
         )
     )
     .context("chunky transcript verification failed")?;

--- a/dkg/src/chunky/dkg_manager/mod.rs
+++ b/dkg/src/chunky/dkg_manager/mod.rs
@@ -1007,6 +1007,7 @@ impl ChunkyDKGManager {
             ChunkySubtranscript::aggregate(&dkg_config.threshold_config, subtranscripts)
                 .context("failed to aggregate subtranscripts")?;
         let recomputed_aggsubtranscript = AggregatedSubtranscript {
+            dealer_epoch: req.dealer_epoch,
             subtranscript: recomputed_subtranscript,
             dealers: req.aggregated_subtrx_dealers.clone(),
         };

--- a/dkg/src/chunky/dkg_manager/mod.rs
+++ b/dkg/src/chunky/dkg_manager/mod.rs
@@ -19,7 +19,7 @@ use crate::{
 };
 use anyhow::{anyhow, bail, ensure, Context, Result};
 use aptos_channels::{aptos_channel, message_queues::QueueStyle};
-use aptos_crypto::{hash::CryptoHash, HashValue, SigningKey, Uniform};
+use aptos_crypto::{bls12381, hash::CryptoHash, HashValue, SigningKey, Uniform};
 use aptos_dkg::pvss::{traits::transcript::Aggregatable, Player};
 use aptos_infallible::{duration_since_epoch, RwLock};
 use aptos_logger::{debug, error, info, warn};
@@ -86,6 +86,8 @@ enum InnerState {
         vtxn_guard: TxnGuard,
         start_time: Duration,
         my_transcript: Arc<ChunkyDKGTranscript>,
+        aggregated_subtranscript: Arc<AggregatedSubtranscript>,
+        dkg_config: Arc<ChunkyDKGSession>,
         proposed: bool,
     },
 }
@@ -542,6 +544,8 @@ impl ChunkyDKGManager {
         let InnerState::AwaitAggregatedSubtranscriptCertification {
             start_time,
             my_transcript,
+            aggregated_subtranscript: local_agg_subtrx,
+            dkg_config,
             ..
         } = mem::take(&mut self.state)
         else {
@@ -558,12 +562,13 @@ impl ChunkyDKGManager {
         info!("[ChunkyDKG] deriving encryption key");
         // Derive encryption key from subtranscript + DigestKey.
         // Heavy pairing-based crypto — run off the main loop.
+        let agg_subtrx_for_blocking = Arc::clone(&aggregated_subtranscript);
         let (encryption_key_bytes, transcript_bytes) = tokio::task::spawn_blocking(move || {
             let digest_key = DIGEST_KEY
                 .as_ref()
                 .ok_or_else(|| anyhow!("DigestKey not available; cannot derive encryption key"))?;
-            let key = aggregated_subtranscript.derive_encryption_key_bytes(digest_key.tau_g2)?;
-            let bytes = bcs::to_bytes(&aggregated_subtranscript)
+            let key = agg_subtrx_for_blocking.derive_encryption_key_bytes(digest_key.tau_g2)?;
+            let bytes = bcs::to_bytes(agg_subtrx_for_blocking.as_ref())
                 .map_err(|e| anyhow!("transcript serialization error: {e}"))?;
             counters::CHUNKY_DKG_OBJECT_SIZE_BYTES
                 .with_label_values(&["aggregated_subtranscript"])
@@ -604,10 +609,13 @@ impl ChunkyDKGManager {
             my_addr = self.my_addr,
             "[ChunkyDKG] aggregated transcript put into vtxn pool."
         );
+        let _ = local_agg_subtrx;
         self.state = InnerState::Finished {
             vtxn_guard,
             start_time,
             my_transcript,
+            aggregated_subtranscript,
+            dkg_config,
             proposed: false,
         };
         Ok(())
@@ -756,14 +764,16 @@ impl ChunkyDKGManager {
     ) -> Result<()> {
         let (aggregated_transcript, dkg_config) = match &self.state {
             InnerState::AwaitAggregatedSubtranscriptCertification {
-                aggregated_subtranscript: aggregated_transcript,
+                aggregated_subtranscript,
                 dkg_config,
                 ..
-            } => (Arc::clone(aggregated_transcript), Arc::clone(dkg_config)),
+            }
+            | InnerState::Finished {
+                aggregated_subtranscript,
+                dkg_config,
+                ..
+            } => (Arc::clone(aggregated_subtranscript), Arc::clone(dkg_config)),
             _ => {
-                // Send error response instead of dropping response_sender.
-                // Drop = timeout = exponential backoff blowup on the requester side.
-                // Error = quick retry.
                 response_sender.send(Err(anyhow!(
                     "[ChunkyDKG] not ready for signature requests in state {:?}",
                     self.state.variant_name()
@@ -774,13 +784,11 @@ impl ChunkyDKGManager {
 
         let req_subtranscript_hash = req.subtranscript_hash;
 
-        // Skip-if-running: if a handler for this sender with the same subtranscript_hash
-        // is still running, skip spawning a new one. This prevents ReliableBroadcast retries
-        // from aborting a handler that is sleeping (delay+poll) or fetching.
-        // Two-level if: keeps pattern binding separate from boolean guard for readability.
-        #[allow(clippy::collapsible_if)]
-        if let Some((existing_hash, handle)) = self.rpc_handler_guards.get(&sender) {
-            if *existing_hash == req.subtranscript_hash && !handle.is_finished() {
+        // Rate limit: at most one concurrent handler per sender. This prevents
+        // a malicious validator from spawning many expensive handlers by varying
+        // the subtranscript hash. Also deduplicates ReliableBroadcast retries.
+        if let Some((_existing_hash, handle)) = self.rpc_handler_guards.get(&sender) {
+            if !handle.is_finished() {
                 counters::CHUNKY_DKG_SIGNATURE_REQUEST_SKIPPED.inc();
                 response_sender.send(Err(anyhow!(
                     "handler already in-flight for sender {}",
@@ -837,90 +845,63 @@ impl ChunkyDKGManager {
         Ok(())
     }
 
-    /// Detect mismatched or missing dealers by comparing per-dealer hashes against
-    /// the received transcripts map. Uses precomputed transcript hashes.
-    fn detect_mismatches(
-        dealer_addresses: &[AccountAddress],
-        expected_hashes: &[HashValue],
-        received_transcripts: &RwLock<HashMap<AccountAddress, ChunkyTranscriptWithHash>>,
-    ) -> Result<(Vec<ChunkySubtranscript>, Vec<AccountAddress>)> {
-        let map = received_transcripts.read();
-        let mut subtranscripts = Vec::new();
-        let mut mismatched = Vec::new();
-        for (i, addr) in dealer_addresses.iter().enumerate() {
-            match map.get(addr) {
-                Some(twh) => {
-                    if twh.hash() == expected_hashes[i] {
-                        subtranscripts.push(twh.get_subtranscript());
-                    } else {
-                        mismatched.push(*addr);
-                    }
-                },
-                None => mismatched.push(*addr),
-            }
-        }
-        Ok((subtranscripts, mismatched))
-    }
-
-    /// Handle subtranscript validation computation.
-    async fn handle_subtranscript_signature_request(
+    /// Resolve all subtranscripts required by a signature request: validate the bitmask,
+    /// check local storage, poll for late arrivals, and fetch any still-missing transcripts.
+    async fn resolve_subtranscripts(
         sender: AccountAddress,
-        req: ChunkyDKGSubtranscriptSignatureRequest,
-        local_aggregated_transcript: Arc<AggregatedSubtranscript>,
-        dkg_config: Arc<ChunkyDKGSession>,
-        ssk: Arc<DealerPrivateKey>,
-        _my_addr: AccountAddress,
-        received_transcripts: Arc<RwLock<HashMap<AccountAddress, ChunkyTranscriptWithHash>>>,
-        epoch_state: Arc<EpochState>,
+        req: &ChunkyDKGSubtranscriptSignatureRequest,
+        received_transcripts: &Arc<RwLock<HashMap<AccountAddress, ChunkyTranscriptWithHash>>>,
+        epoch_state: &Arc<EpochState>,
+        dkg_config: &Arc<ChunkyDKGSession>,
         network_sender: Arc<NetworkSender>,
-    ) -> Result<DKGMessage> {
-        // In the miniscule chance that the locally aggregated subtranscript is the same as the
-        // remote transcript, we can just sign and return immediately.
-        if local_aggregated_transcript.hash() == req.subtranscript_hash {
-            let signature = ssk
-                .sign(local_aggregated_transcript.as_ref())
-                .map_err(|e| anyhow!("failed to sign subtranscript validation: {:?}", e))?;
-
-            let response = DKGMessage::SubtranscriptSignatureResponse(
-                ChunkyDKGSubtranscriptSignatureResponse::new(
-                    req.dealer_epoch,
-                    req.subtranscript_hash,
-                    signature,
-                ),
-            );
-
-            return Ok(response);
-        }
-
-        // Validate bitmask dimensions.
+    ) -> Result<Vec<ChunkySubtranscript>> {
         let num_validators = epoch_state.verifier.len();
         let ordered_addrs = epoch_state.verifier.get_ordered_account_addresses();
-        ensure!(
-            req.dealer_bitmask.last_set_bit().map_or(true, |b| (b as usize) < num_validators),
-            "dealer_bitmask contains out-of-range bits"
-        );
         let num_dealers = req.dealer_bitmask.count_ones() as usize;
         ensure!(num_dealers > 0, "dealer_bitmask is empty");
+        ensure!(
+            req.dealer_bitmask
+                .last_set_bit()
+                .expect("bitmask cannot be empty")
+                < num_validators as u16,
+            "dealer_bitmask contains out-of-range bits"
+        );
         ensure!(
             req.dealer_transcript_hashes.len() == num_dealers,
             "dealer_transcript_hashes length mismatch with dealer_bitmask popcount"
         );
 
-        // Convert bitmask to dealer addresses (ascending validator index order).
-        let dealer_addresses: Vec<AccountAddress> = req
+        // Safety: last_set_bit check above guarantees all indices are < num_validators.
+        let dealers: Vec<(AccountAddress, HashValue)> = req
             .dealer_bitmask
             .iter_ones()
             .map(|idx| ordered_addrs[idx])
+            .zip(req.dealer_transcript_hashes.iter().copied())
             .collect();
 
-        // First check for mismatches.
-        let (mut subtranscripts, mismatched_dealers) = Self::detect_mismatches(
-            &dealer_addresses,
-            &req.dealer_transcript_hashes,
-            &received_transcripts,
-        )?;
+        epoch_state
+            .verifier
+            .check_voting_power(dealers.iter().map(|(addr, _)| addr), true)
+            .map_err(|e| anyhow!("dealer set does not meet quorum: {:?}", e))?;
 
-        if !mismatched_dealers.is_empty() {
+        let check_local = || {
+            let map = received_transcripts.read();
+            let mut subtranscripts = Vec::new();
+            let mut missing = Vec::new();
+            for &(addr, expected_hash) in &dealers {
+                match map.get(&addr) {
+                    Some(twh) if twh.hash() == expected_hash => {
+                        subtranscripts.push(twh.get_subtranscript())
+                    },
+                    _ => missing.push(addr),
+                }
+            }
+            (subtranscripts, missing)
+        };
+
+        let (mut subtranscripts, missing_dealers) = check_local();
+
+        if !missing_dealers.is_empty() {
             // Poll received_transcripts to let the aggregator resolve mismatches.
             // Most of the time, the aggregator collects all needed transcripts
             // within this window, eliminating the need to fetch entirely.
@@ -934,43 +915,35 @@ impl ChunkyDKGManager {
             );
             let deadline = tokio::time::Instant::now() + MAX_WAIT + jitter;
 
-            let (mut fresh_subtranscripts, mut still_missing) =
-                (subtranscripts.clone(), mismatched_dealers.clone());
+            let mut still_missing = missing_dealers.clone();
             while tokio::time::Instant::now() < deadline {
                 tokio::time::sleep(POLL_INTERVAL).await;
-                let (s, m) = Self::detect_mismatches(
-                    &dealer_addresses,
-                    &req.dealer_transcript_hashes,
-                    &received_transcripts,
-                )?;
-                fresh_subtranscripts = s;
+                let (s, m) = check_local();
+                subtranscripts = s;
                 still_missing = m;
                 if still_missing.is_empty() {
                     break;
                 }
             }
-            subtranscripts = fresh_subtranscripts;
 
-            // Log how many mismatches the delay resolved.
-            let resolved = mismatched_dealers.len().saturating_sub(still_missing.len());
+            let resolved = missing_dealers.len().saturating_sub(still_missing.len());
             info!(
                 sender = sender,
-                initial_mismatches = mismatched_dealers.len(),
+                initial_mismatches = missing_dealers.len(),
                 resolved_by_delay = resolved,
                 still_missing = still_missing.len(),
                 "[ChunkyDKG] Post-delay recheck: {}/{} mismatches resolved by aggregator",
                 resolved,
-                mismatched_dealers.len(),
+                missing_dealers.len(),
             );
 
-            // Fetch only if still needed.
             if !still_missing.is_empty() {
                 let fetcher = TranscriptFetcher::new(
                     sender,
                     req.dealer_epoch,
                     still_missing,
                     Duration::from_secs(10),
-                    Arc::clone(&dkg_config),
+                    Arc::clone(dkg_config),
                     epoch_state.clone(),
                 );
                 let fetched = monitor!(
@@ -1005,37 +978,90 @@ impl ChunkyDKGManager {
             "Not enough subtranscripts"
         );
 
-        // Aggregate subtranscripts in projective form, then normalize (same logic as chunky_agg_trx_producer)
-        let recomputed_subtranscript =
-            ChunkySubtranscript::aggregate(&dkg_config.threshold_config, subtranscripts)
-                .context("failed to aggregate subtranscripts")?;
-        let recomputed_aggsubtranscript = AggregatedSubtranscript {
-            dealer_epoch: req.dealer_epoch,
-            subtranscript: recomputed_subtranscript,
-            dealer_bitmask: req.dealer_bitmask.clone(),
-        };
+        Ok(subtranscripts)
+    }
 
-        // Verify the hash matches
-        ensure!(
-            recomputed_aggsubtranscript.hash() == req.subtranscript_hash,
-            "subtranscript hash mismatch in validation request"
-        );
+    /// Aggregate resolved subtranscripts, verify the hash matches the request, and sign.
+    /// CPU-heavy work runs inside `spawn_blocking`.
+    async fn aggregate_and_sign(
+        subtranscripts: Vec<ChunkySubtranscript>,
+        req: &ChunkyDKGSubtranscriptSignatureRequest,
+        dkg_config: &ChunkyDKGSession,
+        ssk: &Arc<DealerPrivateKey>,
+    ) -> Result<(AggregatedSubtranscript, bls12381::Signature)> {
+        let dealer_epoch = req.dealer_epoch;
+        let dealer_bitmask = req.dealer_bitmask.clone();
+        let subtranscript_hash = req.subtranscript_hash;
+        let threshold_config = dkg_config.threshold_config.clone();
+        let ssk = Arc::clone(ssk);
+        tokio::task::spawn_blocking(move || {
+            let recomputed_subtranscript =
+                ChunkySubtranscript::aggregate(&threshold_config, subtranscripts)
+                    .context("failed to aggregate subtranscripts")?;
+            let recomputed = AggregatedSubtranscript {
+                dealer_epoch,
+                subtranscript: recomputed_subtranscript,
+                dealer_bitmask,
+            };
+            ensure!(
+                recomputed.hash() == subtranscript_hash,
+                "subtranscript hash mismatch in validation request"
+            );
+            let sig = ssk
+                .sign(&recomputed)
+                .map_err(|e| anyhow!("failed to sign subtranscript validation: {:?}", e))?;
+            Ok((recomputed, sig))
+        })
+        .await
+        .map_err(|e| anyhow!("spawn_blocking join error: {e}"))?
+    }
 
-        // Sign over the subtranscript hash
-        let signature = ssk
-            .sign(&recomputed_aggsubtranscript)
-            .map_err(|e| anyhow!("failed to sign subtranscript validation: {:?}", e))?;
+    /// Handle subtranscript validation computation.
+    async fn handle_subtranscript_signature_request(
+        sender: AccountAddress,
+        req: ChunkyDKGSubtranscriptSignatureRequest,
+        local_aggregated_transcript: Arc<AggregatedSubtranscript>,
+        dkg_config: Arc<ChunkyDKGSession>,
+        ssk: Arc<DealerPrivateKey>,
+        _my_addr: AccountAddress,
+        received_transcripts: Arc<RwLock<HashMap<AccountAddress, ChunkyTranscriptWithHash>>>,
+        epoch_state: Arc<EpochState>,
+        network_sender: Arc<NetworkSender>,
+    ) -> Result<DKGMessage> {
+        // Fast path: local aggregated transcript matches — sign and return immediately.
+        if local_aggregated_transcript.hash() == req.subtranscript_hash {
+            let signature = ssk
+                .sign(local_aggregated_transcript.as_ref())
+                .map_err(|e| anyhow!("failed to sign subtranscript validation: {:?}", e))?;
+            return Ok(DKGMessage::SubtranscriptSignatureResponse(
+                ChunkyDKGSubtranscriptSignatureResponse::new(
+                    req.dealer_epoch,
+                    req.subtranscript_hash,
+                    signature,
+                ),
+            ));
+        }
 
-        // Build and send a response message
-        let response = DKGMessage::SubtranscriptSignatureResponse(
+        let subtranscripts = Self::resolve_subtranscripts(
+            sender,
+            &req,
+            &received_transcripts,
+            &epoch_state,
+            &dkg_config,
+            network_sender,
+        )
+        .await?;
+
+        let (_recomputed, signature) =
+            Self::aggregate_and_sign(subtranscripts, &req, &dkg_config, &ssk).await?;
+
+        Ok(DKGMessage::SubtranscriptSignatureResponse(
             ChunkyDKGSubtranscriptSignatureResponse::new(
                 req.dealer_epoch,
                 req.subtranscript_hash,
                 signature,
             ),
-        );
-
-        Ok(response)
+        ))
     }
 
     #[cfg(test)]

--- a/dkg/src/chunky/dkg_manager/mod.rs
+++ b/dkg/src/chunky/dkg_manager/mod.rs
@@ -865,15 +865,15 @@ impl ChunkyDKGManager {
     ) -> Result<Vec<ChunkySubtranscript>> {
         let num_validators = epoch_state.verifier.len();
         let ordered_addrs = epoch_state.verifier.get_ordered_account_addresses();
-        let num_dealers = req.dealer_bitmask.count_ones() as usize;
-        ensure!(num_dealers > 0, "dealer_bitmask is empty");
+        let max_bit = req
+            .dealer_bitmask
+            .last_set_bit()
+            .ok_or_else(|| anyhow!("dealer_bitmask is empty"))?;
         ensure!(
-            req.dealer_bitmask
-                .last_set_bit()
-                .expect("bitmask cannot be empty")
-                < num_validators as u16,
+            (max_bit as usize) < num_validators,
             "dealer_bitmask contains out-of-range bits"
         );
+        let num_dealers = req.dealer_bitmask.count_ones() as usize;
         ensure!(
             req.dealer_transcript_hashes.len() == num_dealers,
             "dealer_transcript_hashes length mismatch with dealer_bitmask popcount"

--- a/dkg/src/chunky/dkg_manager/mod.rs
+++ b/dkg/src/chunky/dkg_manager/mod.rs
@@ -20,7 +20,10 @@ use crate::{
 use anyhow::{anyhow, bail, ensure, Context, Result};
 use aptos_channels::{aptos_channel, message_queues::QueueStyle};
 use aptos_crypto::{bls12381, hash::CryptoHash, HashValue, SigningKey, Uniform};
-use aptos_dkg::pvss::{traits::transcript::Aggregatable, Player};
+use aptos_dkg::pvss::{
+    traits::{transcript::Aggregatable, Transcript},
+    Player,
+};
 use aptos_infallible::{duration_since_epoch, RwLock};
 use aptos_logger::{debug, error, info, warn};
 use aptos_reliable_broadcast::{DropGuard, ReliableBroadcast};
@@ -30,7 +33,7 @@ use aptos_types::{
             AggregatedSubtranscript, CertifiedAggregatedChunkySubtranscript,
             CertifiedChunkyDKGOutput, ChunkyDKGSession, ChunkyDKGSessionMetadata,
             ChunkyDKGSessionState, ChunkyDKGStartEvent, ChunkyDKGTranscript, ChunkyInputSecret,
-            ChunkySubtranscript, DealerPrivateKey, DealerPublicKey,
+            ChunkySubtranscript, ChunkyTranscript, DealerPrivateKey, DealerPublicKey,
         },
         DKGTranscriptMetadata,
     },
@@ -393,27 +396,31 @@ impl ChunkyDKGManager {
             "[ChunkyDKG] Deal transcript started.",
         );
 
-        let dkg_config = ChunkyDKGSession::new(dkg_session_metadata);
-        let dkg_config_clone = dkg_config.clone();
+        let session = ChunkyDKGSession::new(dkg_session_metadata);
+
+        let session_clone = session.clone();
         let ssk_clone = self.ssk.clone();
         let spk_clone = self.spk.clone();
         let my_index = self.my_index;
-        let dkg_session_metadata_clone = dkg_session_metadata.clone();
 
         let trx = tokio::task::spawn_blocking(move || {
             let mut rng = StdRng::from_rng(thread_rng()).unwrap();
             let input_secret = ChunkyInputSecret::generate(&mut rng);
-
             let dealer = Player { id: my_index };
-            let session_id = dkg_session_metadata_clone;
 
-            dkg_config_clone.deal(
-                &ssk_clone,
-                &spk_clone,
-                &input_secret,
-                &session_id,
-                &dealer,
-                &mut rng,
+            monitor!(
+                "chunky_dkg_deal_transcript",
+                ChunkyTranscript::deal(
+                    &session_clone.threshold_config,
+                    &session_clone.public_parameters,
+                    &ssk_clone,
+                    &spk_clone,
+                    &session_clone.eks,
+                    &input_secret,
+                    &session_clone.session_metadata,
+                    &dealer,
+                    &mut rng,
+                )
             )
         })
         .await?;
@@ -423,6 +430,7 @@ impl ChunkyDKGManager {
         counters::CHUNKY_DKG_OBJECT_SIZE_BYTES
             .with_label_values(&["dealer_transcript"])
             .observe(transcript_bytes.len() as f64);
+
         let my_transcript = Arc::new(ChunkyDKGTranscript::new(
             self.epoch_state.epoch,
             self.my_addr,
@@ -451,7 +459,7 @@ impl ChunkyDKGManager {
             self.reliable_broadcast.clone(),
             self.epoch_state.clone(),
             self.my_addr,
-            dkg_config.clone(),
+            session.clone(),
             spks,
             dkg_start_time,
             self.agg_subtrx_tx.as_ref().cloned(),
@@ -463,7 +471,7 @@ impl ChunkyDKGManager {
             start_time: dkg_start_time,
             my_transcript,
             _abort_guard: DropGuard::new(abort_handle),
-            dkg_config,
+            dkg_config: session,
         };
 
         Ok(())

--- a/dkg/src/chunky/dkg_manager/mod.rs
+++ b/dkg/src/chunky/dkg_manager/mod.rs
@@ -892,23 +892,26 @@ impl ChunkyDKGManager {
             return Ok(response);
         }
 
-        // Convert Player dealers to AccountAddress using validator indices
-        let dealer_addresses: Vec<AccountAddress> = req
-            .aggregated_subtrx_dealers
-            .iter()
-            .filter_map(|player| {
-                epoch_state
-                    .verifier
-                    .get_ordered_account_addresses()
-                    .get(player.id)
-                    .copied()
-            })
-            .collect();
-        ensure!(dealer_addresses.len() == req.aggregated_subtrx_dealers.len());
+        // Validate bitmask dimensions.
+        let num_validators = epoch_state.verifier.len();
+        let ordered_addrs = epoch_state.verifier.get_ordered_account_addresses();
         ensure!(
-            req.dealer_transcript_hashes.len() == dealer_addresses.len(),
-            "dealer_transcript_hashes length mismatch with dealers"
+            req.dealer_bitmask.last_set_bit().map_or(true, |b| (b as usize) < num_validators),
+            "dealer_bitmask contains out-of-range bits"
         );
+        let num_dealers = req.dealer_bitmask.count_ones() as usize;
+        ensure!(num_dealers > 0, "dealer_bitmask is empty");
+        ensure!(
+            req.dealer_transcript_hashes.len() == num_dealers,
+            "dealer_transcript_hashes length mismatch with dealer_bitmask popcount"
+        );
+
+        // Convert bitmask to dealer addresses (ascending validator index order).
+        let dealer_addresses: Vec<AccountAddress> = req
+            .dealer_bitmask
+            .iter_ones()
+            .map(|idx| ordered_addrs[idx])
+            .collect();
 
         // First check for mismatches.
         let (mut subtranscripts, mismatched_dealers) = Self::detect_mismatches(
@@ -998,7 +1001,7 @@ impl ChunkyDKGManager {
             "No transcripts found for required dealers"
         );
         ensure!(
-            subtranscripts.len() == dealer_addresses.len(),
+            subtranscripts.len() == num_dealers,
             "Not enough subtranscripts"
         );
 
@@ -1009,7 +1012,7 @@ impl ChunkyDKGManager {
         let recomputed_aggsubtranscript = AggregatedSubtranscript {
             dealer_epoch: req.dealer_epoch,
             subtranscript: recomputed_subtranscript,
-            dealers: req.aggregated_subtrx_dealers.clone(),
+            dealer_bitmask: req.dealer_bitmask.clone(),
         };
 
         // Verify the hash matches

--- a/dkg/src/chunky/dkg_manager/tests.rs
+++ b/dkg/src/chunky/dkg_manager/tests.rs
@@ -5,13 +5,17 @@ use super::ChunkyDKGManager;
 use crate::{
     chunky::{
         test_utils::{ChunkyTestSetup, DummyNetworkSender},
-        types::{CertifiedAggregatedSubtranscript, MissingTranscriptRequest},
+        types::{
+            ChunkyDKGSubtranscriptSignatureRequest, CertifiedAggregatedSubtranscript,
+            MissingTranscriptRequest,
+        },
     },
     network::{DummyRpcResponseSender, IncomingRpcRequest},
     types::DKGMessage,
 };
+use aptos_bitvec::BitVec;
 use aptos_bounded_executor::BoundedExecutor;
-use aptos_crypto::SigningKey;
+use aptos_crypto::{hash::CryptoHash, HashValue, SigningKey};
 use aptos_infallible::RwLock;
 use aptos_network::{
     application::{interface::NetworkClient, storage::PeersAndMetadata},
@@ -289,4 +293,215 @@ async fn test_close_and_notifications() {
         .process_dkg_txn_pulled_notification(dummy_txn)
         .await;
     assert!(result.is_err());
+}
+
+fn new_signature_request_rpc(
+    epoch: u64,
+    sender: AccountAddress,
+    subtranscript_hash: HashValue,
+    dealer_bitmask: BitVec,
+    dealer_transcript_hashes: Vec<HashValue>,
+    response_collector: Arc<RwLock<Vec<anyhow::Result<DKGMessage>>>>,
+) -> IncomingRpcRequest {
+    IncomingRpcRequest {
+        msg: DKGMessage::SubtranscriptSignatureRequest(
+            ChunkyDKGSubtranscriptSignatureRequest::new(
+                epoch,
+                subtranscript_hash,
+                dealer_bitmask,
+                dealer_transcript_hashes,
+            ),
+        ),
+        sender,
+        response_sender: Box::new(DummyRpcResponseSender::new(response_collector)),
+    }
+}
+
+/// Helper: advance a manager through the full DKG lifecycle to Finished.
+async fn advance_to_finished(
+    manager: &mut ChunkyDKGManager,
+    setup: &ChunkyTestSetup,
+) {
+    let event = ChunkyDKGStartEvent {
+        session_metadata: setup.session_metadata.clone(),
+        start_time_us: Duration::from_secs(1700000000).as_micros() as u64,
+    };
+    manager.process_dkg_start_event(event).await.unwrap();
+
+    let agg_with_hashes = setup.aggregate_subtranscripts_with_hashes(&[0, 1, 2]);
+    let agg_subtrx = agg_with_hashes.aggregated_subtranscript.clone();
+    manager
+        .process_aggregated_subtranscript(agg_with_hashes)
+        .await
+        .unwrap();
+
+    let mut sigs = std::collections::BTreeMap::new();
+    for i in 0..3 {
+        let sig = setup.private_keys[i].sign(&agg_subtrx).unwrap();
+        sigs.insert(setup.addrs[i], sig);
+    }
+    let aggregate_signature = setup
+        .epoch_state
+        .verifier
+        .aggregate_signatures(sigs.iter())
+        .unwrap();
+    let certified = CertifiedAggregatedSubtranscript {
+        aggregated_subtranscript: Arc::new(agg_subtrx),
+        aggregate_signature,
+    };
+    manager
+        .process_certified_aggregated_subtranscript(certified)
+        .await
+        .unwrap();
+    assert_eq!(manager.state_name(), "Finished");
+}
+
+#[tokio::test]
+async fn test_signature_request_accepted_in_finished_state() {
+    let setup = ChunkyTestSetup::new_uniform(4);
+    let mut manager = create_test_manager(&setup);
+    advance_to_finished(&mut manager, &setup).await;
+
+    // Build a signature request with a dummy hash — the handler will be spawned
+    // even though the hash won't match locally. The key test is that the request
+    // is accepted (not rejected with "not ready") in Finished state.
+    let rpc_response_collector = Arc::new(RwLock::new(vec![]));
+    let dummy_bitmask = BitVec::with_num_bits(4);
+    let rpc_req = new_signature_request_rpc(
+        999,
+        setup.addrs[1],
+        HashValue::zero(),
+        dummy_bitmask,
+        vec![],
+        rpc_response_collector.clone(),
+    );
+    let result = manager.process_peer_rpc_msg(rpc_req).await;
+    // Should succeed (handler spawned), not return "not ready" error.
+    assert!(result.is_ok());
+    let last_responses = std::mem::take(&mut *rpc_response_collector.write());
+    // Response is sent asynchronously by the spawned handler, so it may not
+    // be available immediately. The important check is that process_peer_rpc_msg
+    // didn't reject the request. The response collector may be empty at this
+    // point (handler still running) — that's fine.
+    // Verify no "not ready" error was sent synchronously.
+    for resp in &last_responses {
+        if let Err(e) = resp {
+            assert!(
+                !e.to_string().contains("not ready"),
+                "Signature request should be accepted in Finished state"
+            );
+        }
+    }
+}
+
+#[tokio::test]
+async fn test_signature_request_rejected_in_init_and_aggregation_states() {
+    let setup = ChunkyTestSetup::new_uniform(4);
+    let mut manager = create_test_manager(&setup);
+
+    let rpc_response_collector = Arc::new(RwLock::new(vec![]));
+    let dummy_bitmask = BitVec::with_num_bits(4);
+
+    // Init state — should be rejected with "not ready".
+    let rpc_req = new_signature_request_rpc(
+        999,
+        setup.addrs[1],
+        HashValue::zero(),
+        dummy_bitmask.clone(),
+        vec![],
+        rpc_response_collector.clone(),
+    );
+    let result = manager.process_peer_rpc_msg(rpc_req).await;
+    assert!(result.is_ok());
+    let last_responses = std::mem::take(&mut *rpc_response_collector.write());
+    assert_eq!(last_responses.len(), 1);
+    assert!(last_responses[0].is_err());
+    assert!(last_responses[0]
+        .as_ref()
+        .unwrap_err()
+        .to_string()
+        .contains("not ready"));
+
+    // AwaitSubtranscriptAggregation state — should also be rejected.
+    let event = ChunkyDKGStartEvent {
+        session_metadata: setup.session_metadata.clone(),
+        start_time_us: Duration::from_secs(1700000000).as_micros() as u64,
+    };
+    manager.process_dkg_start_event(event).await.unwrap();
+    assert_eq!(manager.state_name(), "AwaitSubtranscriptAggregation");
+
+    let rpc_req = new_signature_request_rpc(
+        999,
+        setup.addrs[1],
+        HashValue::zero(),
+        dummy_bitmask,
+        vec![],
+        rpc_response_collector.clone(),
+    );
+    let result = manager.process_peer_rpc_msg(rpc_req).await;
+    assert!(result.is_ok());
+    let last_responses = std::mem::take(&mut *rpc_response_collector.write());
+    assert_eq!(last_responses.len(), 1);
+    assert!(last_responses[0].is_err());
+    assert!(last_responses[0]
+        .as_ref()
+        .unwrap_err()
+        .to_string()
+        .contains("not ready"));
+}
+
+#[tokio::test]
+async fn test_signature_request_rate_limited_per_sender() {
+    let setup = ChunkyTestSetup::new_uniform(4);
+    let mut manager = create_test_manager(&setup);
+    advance_to_finished(&mut manager, &setup).await;
+
+    let rpc_response_collector = Arc::new(RwLock::new(vec![]));
+    let dummy_bitmask = BitVec::with_num_bits(4);
+
+    // First request from sender 1 — should be accepted and spawns a handler.
+    let rpc_req = new_signature_request_rpc(
+        999,
+        setup.addrs[1],
+        HashValue::zero(),
+        dummy_bitmask.clone(),
+        vec![],
+        rpc_response_collector.clone(),
+    );
+    manager.process_peer_rpc_msg(rpc_req).await.unwrap();
+
+    // Second request from the SAME sender with a DIFFERENT hash — should be
+    // rate-limited because the first handler is still running.
+    let rpc_req = new_signature_request_rpc(
+        999,
+        setup.addrs[1],
+        HashValue::from_u64(42),
+        dummy_bitmask.clone(),
+        vec![],
+        rpc_response_collector.clone(),
+    );
+    manager.process_peer_rpc_msg(rpc_req).await.unwrap();
+    let last_responses = std::mem::take(&mut *rpc_response_collector.write());
+    // The rate-limited response is sent synchronously.
+    let has_rate_limited = last_responses.iter().any(|r| {
+        r.as_ref()
+            .err()
+            .map_or(false, |e| e.to_string().contains("already in-flight"))
+    });
+    assert!(
+        has_rate_limited,
+        "Second concurrent request from same sender should be rate-limited"
+    );
+
+    // Request from a DIFFERENT sender should still be accepted.
+    let rpc_req = new_signature_request_rpc(
+        999,
+        setup.addrs[2],
+        HashValue::zero(),
+        dummy_bitmask,
+        vec![],
+        rpc_response_collector.clone(),
+    );
+    let result = manager.process_peer_rpc_msg(rpc_req).await;
+    assert!(result.is_ok());
 }

--- a/dkg/src/chunky/dkg_manager/tests.rs
+++ b/dkg/src/chunky/dkg_manager/tests.rs
@@ -6,7 +6,7 @@ use crate::{
     chunky::{
         test_utils::{ChunkyTestSetup, DummyNetworkSender},
         types::{
-            ChunkyDKGSubtranscriptSignatureRequest, CertifiedAggregatedSubtranscript,
+            CertifiedAggregatedSubtranscript, ChunkyDKGSubtranscriptSignatureRequest,
             MissingTranscriptRequest,
         },
     },
@@ -15,7 +15,7 @@ use crate::{
 };
 use aptos_bitvec::BitVec;
 use aptos_bounded_executor::BoundedExecutor;
-use aptos_crypto::{hash::CryptoHash, HashValue, SigningKey};
+use aptos_crypto::{HashValue, SigningKey};
 use aptos_infallible::RwLock;
 use aptos_network::{
     application::{interface::NetworkClient, storage::PeersAndMetadata},
@@ -318,10 +318,7 @@ fn new_signature_request_rpc(
 }
 
 /// Helper: advance a manager through the full DKG lifecycle to Finished.
-async fn advance_to_finished(
-    manager: &mut ChunkyDKGManager,
-    setup: &ChunkyTestSetup,
-) {
+async fn advance_to_finished(manager: &mut ChunkyDKGManager, setup: &ChunkyTestSetup) {
     let event = ChunkyDKGStartEvent {
         session_metadata: setup.session_metadata.clone(),
         start_time_us: Duration::from_secs(1700000000).as_micros() as u64,
@@ -486,7 +483,7 @@ async fn test_signature_request_rate_limited_per_sender() {
     let has_rate_limited = last_responses.iter().any(|r| {
         r.as_ref()
             .err()
-            .map_or(false, |e| e.to_string().contains("already in-flight"))
+            .is_some_and(|e| e.to_string().contains("already in-flight"))
     });
     assert!(
         has_rate_limited,

--- a/dkg/src/chunky/missing_transcript_fetcher.rs
+++ b/dkg/src/chunky/missing_transcript_fetcher.rs
@@ -3,8 +3,8 @@
 
 use crate::{
     chunky::{
+        common::deserialize_chunky_transcript_and_verify,
         types::{ChunkyTranscriptWithHash, MissingTranscriptRequest},
-        validation::validate_chunky_transcript,
     },
     network::NetworkSender,
     DKGMessage,
@@ -191,14 +191,12 @@ impl TranscriptFetcher {
             ));
         }
 
-        let mut rng = rand::thread_rng();
-        validate_chunky_transcript(
+        deserialize_chunky_transcript_and_verify(
             dealer_addr,
             &transcript_response.transcript_bytes,
             &self.dkg_config,
             signing_pubkeys,
             &self.epoch_state,
-            &mut rng,
         )
     }
 }

--- a/dkg/src/chunky/mod.rs
+++ b/dkg/src/chunky/mod.rs
@@ -4,10 +4,10 @@
 pub use aptos_types::dkg::chunky_dkg::{DIGEST_KEY, PUBLIC_PARAMETERS};
 
 pub mod agg_subtrx_producer;
+pub mod common;
 pub mod dkg_manager;
 pub mod missing_transcript_fetcher;
 pub mod subtrx_cert_producer;
 #[cfg(test)]
 pub(crate) mod test_utils;
 pub mod types;
-pub mod validation;

--- a/dkg/src/chunky/subtrx_cert_producer.rs
+++ b/dkg/src/chunky/subtrx_cert_producer.rs
@@ -351,11 +351,8 @@ mod tests {
         let mut wrong_epoch_agg = setup.aggregate_subtranscripts(&[0, 1, 2]);
         wrong_epoch_agg.dealer_epoch = 998;
         let stale_sig = setup.private_keys[0].sign(&wrong_epoch_agg).unwrap();
-        let stale_resp = ChunkyDKGSubtranscriptSignatureResponse::new(
-            998,
-            wrong_epoch_agg.hash(),
-            stale_sig,
-        );
+        let stale_resp =
+            ChunkyDKGSubtranscriptSignatureResponse::new(998, wrong_epoch_agg.hash(), stale_sig);
         // Epoch mismatch is caught in metadata checks.
         let result = BroadcastStatus::add(&state, setup.addrs[0], stale_resp);
         assert!(result.is_err());

--- a/dkg/src/chunky/subtrx_cert_producer.rs
+++ b/dkg/src/chunky/subtrx_cert_producer.rs
@@ -40,7 +40,7 @@ pub fn start_chunky_subtranscript_certification(
     let req = ChunkyDKGSubtranscriptSignatureRequest::new(
         epoch,
         aggregated_subtranscript.hash(),
-        aggregated_subtranscript.dealers.clone(),
+        aggregated_subtranscript.dealer_bitmask.clone(),
         dealer_transcript_hashes,
     );
     let validation_state = Arc::new(ChunkySubtranscriptCertificationState::new(

--- a/dkg/src/chunky/subtrx_cert_producer.rs
+++ b/dkg/src/chunky/subtrx_cert_producer.rs
@@ -96,6 +96,7 @@ pub struct ChunkySubtranscriptCertificationState {
     sig_aggregator: Mutex<ChunkySubtranscriptSignatureAggregator>,
     epoch_state: Arc<EpochState>,
     aggregated_subtranscript: Arc<AggregatedSubtranscript>,
+    expected_subtranscript_hash: HashValue,
 }
 
 impl ChunkySubtranscriptCertificationState {
@@ -105,12 +106,14 @@ impl ChunkySubtranscriptCertificationState {
         epoch_state: Arc<EpochState>,
         aggregated_subtranscript: Arc<AggregatedSubtranscript>,
     ) -> Self {
+        let expected_subtranscript_hash = aggregated_subtranscript.hash();
         Self {
             start_time,
             my_addr,
             sig_aggregator: Mutex::new(ChunkySubtranscriptSignatureAggregator::default()),
             epoch_state,
             aggregated_subtranscript,
+            expected_subtranscript_hash,
         }
     }
 }
@@ -148,7 +151,7 @@ impl BroadcastStatus<DKGMessage> for Arc<ChunkySubtranscriptCertificationState> 
             self.epoch_state.epoch,
         );
         ensure!(
-            subtranscript_hash == self.aggregated_subtranscript.hash(),
+            subtranscript_hash == self.expected_subtranscript_hash,
             "[ChunkyDKG] signature response hash does not match local aggregated subtranscript hash",
         );
 

--- a/dkg/src/chunky/subtrx_cert_producer.rs
+++ b/dkg/src/chunky/subtrx_cert_producer.rs
@@ -339,6 +339,37 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_certification_rejects_wrong_epoch_signature() {
+        let setup = ChunkyTestSetup::new_uniform(4);
+        let agg_subtrx = setup.aggregate_subtranscripts(&[0, 1, 2]);
+        let state = make_cert_state(&setup, agg_subtrx);
+
+        // Sign a different AggregatedSubtranscript with a wrong epoch.
+        let mut wrong_epoch_agg = setup.aggregate_subtranscripts(&[0, 1, 2]);
+        wrong_epoch_agg.dealer_epoch = 998;
+        let stale_sig = setup.private_keys[0].sign(&wrong_epoch_agg).unwrap();
+        let stale_resp = ChunkyDKGSubtranscriptSignatureResponse::new(
+            998,
+            wrong_epoch_agg.hash(),
+            stale_sig,
+        );
+        // Epoch mismatch is caught in metadata checks.
+        let result = BroadcastStatus::add(&state, setup.addrs[0], stale_resp);
+        assert!(result.is_err());
+
+        // Even if the response claims the right epoch, the signature is over the wrong data
+        // (different epoch in AggregatedSubtranscript changes the hash).
+        let stale_sig2 = setup.private_keys[0].sign(&wrong_epoch_agg).unwrap();
+        let spoofed_resp = ChunkyDKGSubtranscriptSignatureResponse::new(
+            999,
+            state.aggregated_subtranscript().hash(),
+            stale_sig2,
+        );
+        let result = BroadcastStatus::add(&state, setup.addrs[0], spoofed_resp);
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
     async fn test_certification_ignores_duplicate() {
         let setup = ChunkyTestSetup::new_uniform(4);
         let agg_subtrx = setup.aggregate_subtranscripts(&[0, 1, 2]);

--- a/dkg/src/chunky/test_utils.rs
+++ b/dkg/src/chunky/test_utils.rs
@@ -2,6 +2,7 @@
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{chunky::types::AggregatedSubtranscriptWithHashes, types::DKGMessage};
+use aptos_bitvec::BitVec;
 use aptos_crypto::{
     bls12381::{PrivateKey, PublicKey},
     HashValue, Uniform,
@@ -133,30 +134,18 @@ impl ChunkyTestSetup {
         let agg =
             Aggregatable::aggregate(&self.dkg_config.threshold_config, subtranscripts).unwrap();
 
-        let mut sorted_indices: Vec<usize> = indices.to_vec();
-        sorted_indices.sort();
-        // Map indices through address sort order to match production code behavior.
-        // Production code sorts contributors by AccountAddress, then maps to Player indices.
-        // We must do the same.
-        let mut contributor_addrs: Vec<AccountAddress> =
-            indices.iter().map(|&i| self.addrs[i]).collect();
-        contributor_addrs.sort();
-        let addr_to_index = self
-            .epoch_state
-            .verifier
-            .address_to_validator_index()
-            .clone();
-        let dealers: Vec<Player> = contributor_addrs
-            .into_iter()
-            .map(|addr| Player {
-                id: *addr_to_index.get(&addr).unwrap(),
-            })
-            .collect();
+        let addr_to_index = self.epoch_state.verifier.address_to_validator_index();
+        let num_validators = self.epoch_state.verifier.len();
+        let mut dealer_bitmask = BitVec::with_num_bits(num_validators as u16);
+        for &i in indices {
+            let idx = *addr_to_index.get(&self.addrs[i]).unwrap();
+            dealer_bitmask.set(idx as u16);
+        }
 
         AggregatedSubtranscript {
             dealer_epoch: 999,
             subtranscript: agg,
-            dealers,
+            dealer_bitmask,
         }
     }
 
@@ -179,20 +168,14 @@ impl ChunkyTestSetup {
         let agg =
             Aggregatable::aggregate(&self.dkg_config.threshold_config, subtranscripts).unwrap();
 
-        let mut contributor_addrs: Vec<AccountAddress> =
-            indices.iter().map(|&i| self.addrs[i]).collect();
-        contributor_addrs.sort();
-        let addr_to_index = self
-            .epoch_state
-            .verifier
-            .address_to_validator_index()
-            .clone();
-        let dealers: Vec<Player> = contributor_addrs
-            .iter()
-            .map(|addr| Player {
-                id: *addr_to_index.get(addr).unwrap(),
-            })
-            .collect();
+        let addr_to_index = self.epoch_state.verifier.address_to_validator_index();
+        let ordered_addrs = self.epoch_state.verifier.get_ordered_account_addresses();
+        let num_validators = self.epoch_state.verifier.len();
+        let mut dealer_bitmask = BitVec::with_num_bits(num_validators as u16);
+        for &i in indices {
+            let idx = *addr_to_index.get(&self.addrs[i]).unwrap();
+            dealer_bitmask.set(idx as u16);
+        }
 
         // Build a map from addr to transcript for hash lookup
         let addr_to_transcript: HashMap<AccountAddress, &ChunkyTranscript> = indices
@@ -200,9 +183,11 @@ impl ChunkyTestSetup {
             .map(|&i| (self.addrs[i], &transcripts[i]))
             .collect();
 
-        let dealer_transcript_hashes: Vec<HashValue> = contributor_addrs
-            .iter()
-            .map(|addr| {
+        // Per-dealer hashes ordered by set-bit position (ascending validator index).
+        let dealer_transcript_hashes: Vec<HashValue> = dealer_bitmask
+            .iter_ones()
+            .map(|idx| {
+                let addr = &ordered_addrs[idx];
                 let transcript = addr_to_transcript.get(addr).unwrap();
                 let bytes = bcs::to_bytes(*transcript).unwrap();
                 HashValue::sha3_256_of(&bytes)
@@ -213,7 +198,7 @@ impl ChunkyTestSetup {
             aggregated_subtranscript: AggregatedSubtranscript {
                 dealer_epoch: 999,
                 subtranscript: agg,
-                dealers,
+                dealer_bitmask,
             },
             dealer_transcript_hashes,
         }

--- a/dkg/src/chunky/test_utils.rs
+++ b/dkg/src/chunky/test_utils.rs
@@ -7,7 +7,10 @@ use aptos_crypto::{
     bls12381::{PrivateKey, PublicKey},
     HashValue, Uniform,
 };
-use aptos_dkg::pvss::{traits::transcript::HasAggregatableSubtranscript, Player};
+use aptos_dkg::pvss::{
+    traits::{transcript::HasAggregatableSubtranscript, Transcript},
+    Player,
+};
 use aptos_reliable_broadcast::RBNetworkSender;
 use aptos_types::{
     chain_id::ChainId,
@@ -101,9 +104,12 @@ impl ChunkyTestSetup {
             id: validator_index,
         };
 
-        let trx = self.dkg_config.deal(
+        let trx = ChunkyTranscript::deal(
+            &self.dkg_config.threshold_config,
+            &self.dkg_config.public_parameters,
             &self.private_keys[validator_index],
             &self.public_keys[validator_index],
+            &self.dkg_config.eks,
             &input_secret,
             &self.session_metadata,
             &dealer,

--- a/dkg/src/chunky/test_utils.rs
+++ b/dkg/src/chunky/test_utils.rs
@@ -154,6 +154,7 @@ impl ChunkyTestSetup {
             .collect();
 
         AggregatedSubtranscript {
+            dealer_epoch: 999,
             subtranscript: agg,
             dealers,
         }
@@ -210,6 +211,7 @@ impl ChunkyTestSetup {
 
         AggregatedSubtranscriptWithHashes {
             aggregated_subtranscript: AggregatedSubtranscript {
+                dealer_epoch: 999,
                 subtranscript: agg,
                 dealers,
             },

--- a/dkg/src/chunky/types.rs
+++ b/dkg/src/chunky/types.rs
@@ -1,9 +1,10 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
+use aptos_bitvec::BitVec;
 use aptos_crypto::HashValue;
 use aptos_crypto_derive::CryptoHasher;
-use aptos_dkg::pvss::{traits::transcript::HasAggregatableSubtranscript, Player};
+use aptos_dkg::pvss::traits::transcript::HasAggregatableSubtranscript;
 use aptos_types::{
     aggregate_signature::AggregateSignature,
     dkg::{
@@ -52,13 +53,14 @@ impl ChunkyDKGTranscriptRequest {
     }
 }
 
-/// Request to validate an aggregated subtranscript. Contains the hash of the subtranscript and the dealers.
+/// Request to validate an aggregated subtranscript. Contains the hash of the subtranscript
+/// and a bitmask identifying which dealers contributed.
 #[derive(Clone, Serialize, Deserialize, CryptoHasher, Debug, PartialEq)]
 pub struct ChunkyDKGSubtranscriptSignatureRequest {
     pub dealer_epoch: u64,
     pub subtranscript_hash: HashValue,
-    pub aggregated_subtrx_dealers: Vec<Player>,
-    /// Per-dealer transcript hash, same order as `aggregated_subtrx_dealers`.
+    pub dealer_bitmask: BitVec,
+    /// Per-dealer transcript hash, ordered by set-bit position (ascending validator index).
     /// Allows the responder to detect equivocated transcripts (not just missing ones).
     pub dealer_transcript_hashes: Vec<HashValue>,
 }
@@ -67,13 +69,13 @@ impl ChunkyDKGSubtranscriptSignatureRequest {
     pub fn new(
         dealer_epoch: u64,
         subtranscript_hash: HashValue,
-        aggregated_subtrx_dealers: Vec<Player>,
+        dealer_bitmask: BitVec,
         dealer_transcript_hashes: Vec<HashValue>,
     ) -> Self {
         Self {
             dealer_epoch,
             subtranscript_hash,
-            aggregated_subtrx_dealers,
+            dealer_bitmask,
             dealer_transcript_hashes,
         }
     }

--- a/testsuite/smoke-test/src/chunky_dkg/correctness.rs
+++ b/testsuite/smoke-test/src/chunky_dkg/correctness.rs
@@ -33,9 +33,9 @@ async fn chunky_dkg_correctness() {
     // Verify transcript
     let subtranscript_1 = verify_chunky_dkg_transcript(&session_1);
     assert!(
-        subtranscript_1.dealers.len() >= 3,
+        subtranscript_1.dealer_bitmask.count_ones() >= 3,
         "Expected >= 3 dealers (BFT threshold), got {}",
-        subtranscript_1.dealers.len()
+        subtranscript_1.dealer_bitmask.count_ones()
     );
 
     // Verify encryption key
@@ -59,9 +59,9 @@ async fn chunky_dkg_correctness() {
     // Verify second transcript
     let subtranscript_2 = verify_chunky_dkg_transcript(&session_2);
     assert!(
-        subtranscript_2.dealers.len() >= 3,
+        subtranscript_2.dealer_bitmask.count_ones() >= 3,
         "Expected >= 3 dealers for second session, got {}",
-        subtranscript_2.dealers.len()
+        subtranscript_2.dealer_bitmask.count_ones()
     );
 
     // Verify consecutive dealer epochs

--- a/testsuite/smoke-test/src/chunky_dkg/enable_feature.rs
+++ b/testsuite/smoke-test/src/chunky_dkg/enable_feature.rs
@@ -146,7 +146,7 @@ script {
     // Verify the transcript.
     let subtranscript = verify_chunky_dkg_transcript(&session);
     assert!(
-        !subtranscript.dealers.is_empty(),
+        subtranscript.dealer_bitmask.count_ones() > 0,
         "Transcript should have dealers"
     );
 

--- a/testsuite/smoke-test/src/chunky_dkg/mod.rs
+++ b/testsuite/smoke-test/src/chunky_dkg/mod.rs
@@ -65,7 +65,7 @@ fn verify_chunky_dkg_transcript(session: &ChunkyDKGSessionState) -> AggregatedSu
         bcs::from_bytes(&session.transcript).expect("Failed to deserialize transcript bytes");
 
     assert!(
-        !subtranscript.dealers.is_empty(),
+        subtranscript.dealer_bitmask.count_ones() > 0,
         "Transcript should have at least one dealer"
     );
 

--- a/testsuite/smoke-test/src/chunky_dkg/shadow_mode.rs
+++ b/testsuite/smoke-test/src/chunky_dkg/shadow_mode.rs
@@ -193,13 +193,13 @@ async fn chunky_dkg_shadow_mode() {
     // Verify transcript.
     let subtranscript = verify_chunky_dkg_transcript(&session);
     assert!(
-        !subtranscript.dealers.is_empty(),
+        subtranscript.dealer_bitmask.count_ones() > 0,
         "Shadow DKG should produce a transcript with dealers"
     );
     info!(
         "Shadow chunky DKG completed for epoch {} with {} dealers",
         session.target_epoch(),
-        subtranscript.dealers.len()
+        subtranscript.dealer_bitmask.count_ones()
     );
 }
 

--- a/testsuite/smoke-test/src/chunky_dkg/with_validator_down.rs
+++ b/testsuite/smoke-test/src/chunky_dkg/with_validator_down.rs
@@ -47,11 +47,11 @@ async fn chunky_dkg_with_validator_down() {
     // Verify the transcript is valid even with a validator down
     let subtranscript = verify_chunky_dkg_transcript(&session_2);
     assert!(
-        !subtranscript.dealers.is_empty(),
+        subtranscript.dealer_bitmask.count_ones() > 0,
         "Transcript should have dealers even with one validator down"
     );
     info!(
         "Transcript verified successfully with {} dealers",
-        subtranscript.dealers.len()
+        subtranscript.dealer_bitmask.count_ones()
     );
 }

--- a/types/src/dkg/chunky_dkg.rs
+++ b/types/src/dkg/chunky_dkg.rs
@@ -26,8 +26,7 @@ use aptos_dkg::pvss::{
         DecryptPrivKey, EncryptPubKey, InputSecret, PublicParameters, SignedWeightedTranscript,
         WeightedSubtranscript,
     },
-    traits::{transcript::Transcript, TranscriptCore},
-    Player,
+    traits::TranscriptCore,
 };
 use ark_ec::AffineRepr;
 use fixed::types::U64F64;
@@ -36,7 +35,7 @@ use move_core_types::{
     move_resource::MoveStructType,
 };
 use once_cell::sync::Lazy;
-use rand::{rngs::StdRng, CryptoRng, RngCore, SeedableRng};
+use rand::{rngs::StdRng, SeedableRng};
 use serde::{Deserialize, Serialize};
 use std::{
     cmp::max,
@@ -338,28 +337,6 @@ pub struct ChunkyDKGSession {
 }
 
 impl ChunkyDKGSession {
-    pub fn deal<A: Serialize + Clone, R: RngCore + CryptoRng>(
-        &self,
-        ssk: &DealerPrivateKey,
-        spk: &DealerPublicKey,
-        s: &ChunkyInputSecret,
-        sid: &A,
-        dealer: &Player,
-        rng: &mut R,
-    ) -> ChunkyTranscript {
-        ChunkyTranscript::deal(
-            &self.threshold_config,
-            &self.public_parameters,
-            ssk,
-            spk,
-            &self.eks,
-            s,
-            sid,
-            dealer,
-            rng,
-        )
-    }
-
     /// Create a new DKG session from on-chain session metadata.
     pub fn new(dkg_session_metadata: &ChunkyDKGSessionMetadata) -> Arc<ChunkyDKGSession> {
         let onchain_config = dkg_session_metadata

--- a/types/src/dkg/chunky_dkg.rs
+++ b/types/src/dkg/chunky_dkg.rs
@@ -18,6 +18,7 @@ use aptos_batch_encryption::{
     group::{Fr, G2Affine, Pairing},
     shared::{digest::DigestKey, digest_key_file, encryption_key::EncryptionKey},
 };
+use aptos_bitvec::BitVec;
 use aptos_crypto::{bls12381, weighted_config::WeightedConfigArkworks};
 use aptos_crypto_derive::{BCSCryptoHash, CryptoHasher};
 use aptos_dkg::pvss::{
@@ -270,12 +271,15 @@ pub fn initialize_digest_key(chain_id: ChainId, is_validator: bool) -> DigestKey
     }
 }
 
-/// An aggregated transcript with the list of dealers who contributed to it.
+/// An aggregated transcript with the set of dealers who contributed to it.
+///
+/// Dealers are represented as a `BitVec` bitmask over validator indices,
+/// which inherently prevents duplicates and ensures canonical ordering.
 #[derive(Clone, Debug, Serialize, Deserialize, CryptoHasher, BCSCryptoHash)]
 pub struct AggregatedSubtranscript {
     pub dealer_epoch: u64,
     pub subtranscript: ChunkySubtranscript,
-    pub dealers: Vec<Player>,
+    pub dealer_bitmask: BitVec,
 }
 
 impl AggregatedSubtranscript {

--- a/types/src/dkg/chunky_dkg.rs
+++ b/types/src/dkg/chunky_dkg.rs
@@ -273,6 +273,7 @@ pub fn initialize_digest_key(chain_id: ChainId, is_validator: bool) -> DigestKey
 /// An aggregated transcript with the list of dealers who contributed to it.
 #[derive(Clone, Debug, Serialize, Deserialize, CryptoHasher, BCSCryptoHash)]
 pub struct AggregatedSubtranscript {
+    pub dealer_epoch: u64,
     pub subtranscript: ChunkySubtranscript,
     pub dealers: Vec<Player>,
 }


### PR DESCRIPTION
## Summary

Fixes security, DoS, and code quality issues in the ChunkyDKG manager identified during review.

### Commit 1: Bind epoch into AggregatedSubtranscript signature
`AggregatedSubtranscript` did not include the epoch in its signed hash, allowing a valid multi-sig from epoch N to be replayed in epoch N+1. Added `dealer_epoch` field so the BCS hash is epoch-dependent, and added verification in the VM execution path.

### Commit 2: Replace Vec\<Player\> with BitVec for dealer sets
`Vec<Player>` for dealer sets allowed duplicates, reordering, and inflation. Replaced with `BitVec` bitmask over validator indices — matching the existing `AggregateSignature` pattern — which inherently prevents duplicates, enforces canonical order, and bounds size to `num_validators` bits.

### Commit 3: Harden signature request handling
- Accept signature requests in `Finished` state so validators continue helping peers after completing DKG.
- Rate-limit to one concurrent handler per sender (previously only deduplicated same-hash retries).
- Move CPU-heavy subtranscript aggregation into `spawn_blocking`.
- Refactor `handle_subtranscript_signature_request` into focused helpers: `resolve_subtranscripts` (bitmask validation, local check, polling, fetching) and `aggregate_and_sign` (aggregation + hash verification + signing).
- **Add quorum check**: reject signature requests where the dealer set does not meet supermajority voting power.

### Commit 4: Inline ChunkyDKGSession::deal and consolidate validation
- Remove the thin `ChunkyDKGSession::deal` wrapper; callers now invoke `ChunkyTranscript::deal` directly.
- Delete `validation.rs`; merge into `common::deserialize_chunky_transcript_and_verify` with improved doc comment and internalized RNG.

### Commit 5: Harden error handling
- `SubtranscriptProjective::aggregate_with`: replace `debug_assert_eq!` with `ensure!` to prevent silent data corruption in release builds.
- `agg_subtrx_producer`: replace `expect()` with `ok_or_else()` for peer power and contributor lookups.
- Skip aggregation after quorum is met (early return when `agg_subtrx_tx` is taken).
- Single-pass bitmask and hash collection with proper error propagation.

### Commit 6: Pre-compute subtranscript hash in certification state
Cache `expected_subtranscript_hash` at construction time to avoid repeated hashing on every signature response.

## Test plan

- [x] New unit test: signature from wrong epoch is rejected (`test_certification_rejects_wrong_epoch_signature`)
- [x] New unit test: signature requests accepted in Finished state (`test_signature_request_accepted_in_finished_state`)
- [x] New unit test: signature requests rejected in Init/Aggregation states (`test_signature_request_rejected_in_init_and_aggregation_states`)
- [x] New unit test: concurrent requests from same sender rate-limited (`test_signature_request_rate_limited_per_sender`)
- [x] All existing + new unit tests pass (`cargo test -p aptos-dkg-runtime`)
- [x] Zero compiler warnings across `aptos-types`, `aptos-dkg`, `aptos-dkg-runtime`
- [ ] CI passes

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>