### PR TITLE
[block-executor] Promote epilogue's own reads to hot state

### DIFF
--- a/aptos-move/block-executor/src/executor.rs
+++ b/aptos-move/block-executor/src/executor.rs
@@ -25,7 +25,7 @@ use crate::{
     txn_commit_hook::TransactionCommitHook,
     txn_last_input_output::TxnLastInputOutput,
     txn_provider::TxnProvider,
-    types::ReadWriteSummary,
+    types::{InputOutputKey, ReadWriteSummary},
     view::{LatestView, ParallelState, SequentialState, ViewState},
 };
 use aptos_aggregator::{
@@ -1749,6 +1749,13 @@ where
                     runtime_environment,
                     &self.config,
                 )?;
+
+                // Snapshot the epilogue's write summary before materialization
+                // consumes the underlying VMOutput. The matching read set stays in
+                // last_input_output and is grabbed inside the helper.
+                let epilogue_write_summary =
+                    last_input_output.write_summary_pre_materialization(epilogue_txn_idx)?;
+
                 self.materialize_txn_commit(
                     epilogue_txn_idx,
                     scheduler,
@@ -1759,6 +1766,21 @@ where
                     epilogue_txn_idx,
                     num_txns as TxnIndex,
                     shared_sync_params,
+                )?;
+
+                // Fold the epilogue's own reads/writes into the hot-state accumulator,
+                // then re-snapshot and stamp the augmented `to_make_hot` back onto the
+                // in-memory epilogue payload. The payload's `to_make_hot` is non-serialized
+                // (see TBlockEndInfoExt), so this mutation is safe post-execution and only
+                // affects what `do_get_execution_output` later writes into the epilogue's
+                // hotness write set.
+                let mut epilogue_txn = epilogue_txn;
+                Self::fold_epilogue_into_hot_state(
+                    &mut epilogue_txn,
+                    epilogue_txn_idx,
+                    last_input_output,
+                    epilogue_write_summary,
+                    block_limit_processor,
                 )?;
 
                 maybe_block_epilogue_txn = Some(epilogue_txn);
@@ -2105,6 +2127,35 @@ where
             final_results.into_inner(),
             maybe_block_epilogue_txn,
         ))
+    }
+
+    /// After the block epilogue has executed, fold its captured reads/writes into the
+    /// hot-state accumulator and replace the in-memory `to_make_hot` on the epilogue
+    /// payload with the augmented snapshot. See the call site for rationale.
+    fn fold_epilogue_into_hot_state(
+        epilogue_txn: &mut T,
+        epilogue_txn_idx: TxnIndex,
+        last_input_output: &TxnLastInputOutput<T, E::Output>,
+        write_summary: HashSet<InputOutputKey<T::Key, T::Tag>>,
+        block_limit_processor: &ExplicitSyncWrapper<BlockGasLimitProcessor<T>>,
+    ) -> Result<(), PanicError> {
+        let Some((reads, _speculative_failure)) = last_input_output.read_set(epilogue_txn_idx)
+        else {
+            // Nothing to fold in if no read set was captured (e.g. epilogue was skipped).
+            return Ok(());
+        };
+        let read_summary = reads.get_read_summary();
+
+        let rw_summary = ReadWriteSummary::<T>::new(read_summary, write_summary);
+
+        let augmented = {
+            let mut processor = block_limit_processor.acquire();
+            processor.add_epilogue_to_hot_state_accumulator(rw_summary);
+            processor.get_keys_to_make_hot()
+        };
+
+        epilogue_txn.try_set_block_epilogue_keys_to_make_hot(augmented);
+        Ok(())
     }
 
     fn gen_block_epilogue<'a>(
@@ -2629,6 +2680,19 @@ where
                 }
                 idx = num_txns;
             }
+        }
+
+        // Sequential path runs the epilogue through the same loop that feeds
+        // user-txn reads/writes into the accumulator (see accumulate_fee_statement
+        // call above), so the accumulator already reflects user + epilogue. The
+        // payload was, however, constructed before the epilogue executed, with the
+        // user-only snapshot. Re-snapshot now and stamp the augmented set onto the
+        // in-memory epilogue payload (`to_make_hot` is non-serialized — see
+        // TBlockEndInfoExt — so this is safe post-execution).
+        if let Some(epilogue_txn) = block_epilogue_txn.as_mut() {
+            epilogue_txn.try_set_block_epilogue_keys_to_make_hot(
+                block_limit_processor.get_keys_to_make_hot(),
+            );
         }
 
         block_limit_processor.finish_sequential_update_counters_and_log_info(

--- a/aptos-move/block-executor/src/limit_processor.rs
+++ b/aptos-move/block-executor/src/limit_processor.rs
@@ -255,6 +255,31 @@ impl<T: Transaction> BlockGasLimitProcessor<T> {
         self.finish_update_counters_and_log_info(false, num_committed, num_total, 1)
     }
 
+    /// After the block epilogue has executed, fold its own reads/writes into the
+    /// hot-state accumulator so that keys it read but did not write get promoted as
+    /// well. The caller should subsequently re-snapshot via `get_keys_to_make_hot`
+    /// and stamp the result back onto the in-memory epilogue payload.
+    ///
+    /// Mirrors the user-txn aggregation path in `accumulate_fee_statement`: groups
+    /// are collapsed to their parent resource key unless granular conflicts are
+    /// configured.
+    pub(crate) fn add_epilogue_to_hot_state_accumulator(
+        &mut self,
+        rw_summary: ReadWriteSummary<T>,
+    ) {
+        let rw_summary = if self
+            .block_gas_limit_type
+            .use_granular_resource_group_conflicts()
+        {
+            rw_summary
+        } else {
+            rw_summary.collapse_resource_group_conflicts()
+        };
+        if let Some(x) = &mut self.hot_state_op_accumulator {
+            x.add_transaction(rw_summary.keys_written(), rw_summary.keys_read());
+        }
+    }
+
     pub(crate) fn get_block_end_info(&self) -> TBlockEndInfoExt<T::Key> {
         let inner = BlockEndInfo::V0 {
             block_gas_limit_reached: self
@@ -278,7 +303,7 @@ impl<T: Transaction> BlockGasLimitProcessor<T> {
         TBlockEndInfoExt::new(inner, to_make_hot)
     }
 
-    fn get_keys_to_make_hot(&self) -> BTreeSet<T::Key> {
+    pub(crate) fn get_keys_to_make_hot(&self) -> BTreeSet<T::Key> {
         if self.hot_state_op_accumulator.is_none() {
             warn!("BlockHotStateOpAccumulator is not set.");
         }

--- a/aptos-move/block-executor/src/txn_last_input_output.rs
+++ b/aptos-move/block-executor/src/txn_last_input_output.rs
@@ -10,7 +10,7 @@ use crate::{
     scheduler_wrapper::SchedulerWrapper,
     task::{BeforeMaterializationOutput, ExecutionStatus, TransactionOutput},
     txn_commit_hook::TransactionCommitHook,
-    types::ReadWriteSummary,
+    types::{InputOutputKey, ReadWriteSummary},
 };
 use aptos_logger::error;
 use aptos_mvhashmap::{types::TxnIndex, MVHashMap};
@@ -431,6 +431,21 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>> TxnLastInputOutput<T, O> {
         }
 
         Ok(())
+    }
+
+    /// Returns the write summary of the output stored for `txn_idx`, accessed
+    /// pre-materialization. Used by the block-epilogue hot-state hook so it can
+    /// be paired with the captured read set before `materialize_txn_commit`
+    /// consumes the underlying VMOutput.
+    pub(crate) fn write_summary_pre_materialization(
+        &self,
+        txn_idx: TxnIndex,
+    ) -> Result<HashSet<InputOutputKey<T::Key, T::Tag>>, PanicError> {
+        let output_wrapper = self.output_wrappers[txn_idx as usize].lock();
+        match output_wrapper.output.as_ref() {
+            Some(output) => Ok(output.before_materialization()?.get_write_summary()),
+            None => Ok(HashSet::new()),
+        }
     }
 
     pub(crate) fn for_each_resource_key_no_aggregator_v1(

--- a/types/src/transaction/block_epilogue.rs
+++ b/types/src/transaction/block_epilogue.rs
@@ -41,6 +41,15 @@ impl BlockEpiloguePayload {
             Self::V1 { block_end_info, .. } => Some(&block_end_info.to_make_hot),
         }
     }
+
+    /// Replace the in-memory `to_make_hot` set on a V1 payload. No-op for V0.
+    /// `to_make_hot` is not serialized (see Serialize/Deserialize impls below), so this
+    /// can be called after the epilogue has executed without affecting on-wire identity.
+    pub fn try_set_keys_to_make_hot(&mut self, to_make_hot: BTreeSet<StateKey>) {
+        if let Self::V1 { block_end_info, .. } = self {
+            block_end_info.set_keys_to_make_hot(to_make_hot);
+        }
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -127,6 +136,10 @@ impl<Key: Debug + Ord> TBlockEndInfoExt<Key> {
 
     pub fn to_persistent(&self) -> BlockEndInfo {
         self.inner.clone()
+    }
+
+    pub fn set_keys_to_make_hot(&mut self, to_make_hot: BTreeSet<Key>) {
+        self.to_make_hot = to_make_hot;
     }
 }
 

--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -3270,6 +3270,12 @@ impl Transaction {
         })
     }
 
+    pub fn try_set_block_epilogue_keys_to_make_hot(&mut self, to_make_hot: BTreeSet<StateKey>) {
+        if let Transaction::BlockEpilogue(payload) = self {
+            payload.try_set_keys_to_make_hot(to_make_hot);
+        }
+    }
+
     pub fn try_as_signed_user_txn(&self) -> Option<&SignedTransaction> {
         match self {
             Transaction::UserTransaction(txn) => Some(txn),
@@ -3402,6 +3408,9 @@ pub trait BlockExecutableTransaction: Sync + Send + Clone + 'static {
     ) -> Self {
         unimplemented!()
     }
+
+    /// If `self` is a V1 block epilogue, replace its `to_make_hot` set in place. No-op otherwise.
+    fn try_set_block_epilogue_keys_to_make_hot(&mut self, _to_make_hot: BTreeSet<Self::Key>) {}
 
     fn pre_write_values(&self) -> Vec<(Self::Key, Self::Value)> {
         vec![]

--- a/types/src/transaction/signature_verified_transaction.rs
+++ b/types/src/transaction/signature_verified_transaction.rs
@@ -14,7 +14,7 @@ use crate::{
 use aptos_crypto::HashValue;
 use move_core_types::{account_address::AccountAddress, language_storage::StructTag};
 use serde::{Deserialize, Serialize};
-use std::fmt::Debug;
+use std::{collections::BTreeSet, fmt::Debug};
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub enum SignatureVerifiedTransaction {
@@ -124,6 +124,15 @@ impl BlockExecutableTransaction for SignatureVerifiedTransaction {
         fee_distribution: FeeDistribution,
     ) -> Self {
         Transaction::block_epilogue_v1(block_id, block_end_info, fee_distribution).into()
+    }
+
+    fn try_set_block_epilogue_keys_to_make_hot(&mut self, to_make_hot: BTreeSet<Self::Key>) {
+        match self {
+            SignatureVerifiedTransaction::Valid(txn)
+            | SignatureVerifiedTransaction::Invalid(txn) => {
+                txn.try_set_block_epilogue_keys_to_make_hot(to_make_hot);
+            },
+        }
     }
 
     fn pre_write_values(&self) -> Vec<(Self::Key, Self::Value)> {


### PR DESCRIPTION

The block epilogue's `to_make_hot` previously contained only keys read
(but not written) by user transactions: the `BlockHotStateOpAccumulator`
snapshot was sealed in `gen_block_epilogue` *before* the epilogue
executed, and the epilogue's own captured reads were never folded back
in. Any key the epilogue reads-but-doesn't-write therefore wasn't
promoted, and every line added to `block::block_epilogue` was a
potential hot-state miss.

## Approach

Fold the epilogue's reads/writes into the existing accumulator after
execution and re-snapshot.

- **Parallel path** (`generate_block_epilogue_if_needed`): grab the
  epilogue's `write_summary` from `last_input_output` *before*
  `materialize_txn_commit` consumes the `VMOutput`, then after
  `record_finalized_output` call a new helper
  `fold_epilogue_into_hot_state` that pairs it with the captured read
  set, runs `BlockGasLimitProcessor::add_epilogue_to_hot_state_accumulator`
  (which mirrors the user-txn collapse rule), and overwrites the
  in-memory `to_make_hot` on the epilogue payload.
- **Sequential path**: the existing loop already runs
  `accumulate_fee_statement` for the appended epilogue, so the
  accumulator is already augmented. Just re-snapshot via
  `BlockGasLimitProcessor::get_keys_to_make_hot()` after the loop and
  stamp the result onto the payload.

The mutation is safe because `to_make_hot` is non-serialized (see
`Serialize`/`Deserialize` impls on `TBlockEndInfoExt`) — it's an
in-memory side channel from Block-STM to `do_get_execution_output`. As
a side benefit, chunk re-execution (state-sync path 2) also rebuilds
the full set during execution, where today the deserialize-to-empty
behavior dropped user-txn reads as well.

## Mechanics

- `TBlockEndInfoExt::set_keys_to_make_hot` /
  `BlockEpiloguePayload::try_set_keys_to_make_hot` — V0 is a no-op.
- `Transaction::try_set_block_epilogue_keys_to_make_hot` plus a default
  no-op trait method on `BlockExecutableTransaction`, with
  `SignatureVerifiedTransaction` forwarding to the inner txn.
- `BlockGasLimitProcessor::add_epilogue_to_hot_state_accumulator`
  applies the same `use_granular_resource_group_conflicts` collapse as
  `accumulate_fee_statement`. `get_keys_to_make_hot` is now
  `pub(crate)` so the executor can re-snapshot.
- `TxnLastInputOutput::write_summary_pre_materialization` exposes the
  output's write summary while the underlying `VMOutput` is still
  intact.
