### PR TITLE
Fix encrypted transaction validation for multi-signer and unsupported auth types

### DIFF
--- a/api/src/transactions.rs
+++ b/api/src/transactions.rs
@@ -1344,10 +1344,17 @@ impl TransactionsApi {
                     ));
                 }
 
-                let auth_key = signed_transaction
+                if payload.extra_config().is_multisig() {
+                    return Err(SubmitTransactionError::bad_request_with_code(
+                        "Encrypted transactions do not support multisig",
+                        AptosErrorCode::InvalidInput,
+                        ledger_info,
+                    ));
+                }
+
+                let signer_auth_keys = signed_transaction
                     .authenticator()
-                    .sender()
-                    .authentication_key()
+                    .all_signer_auth_keys(signed_transaction.sender())
                     .ok_or_else(|| {
                         SubmitTransactionError::bad_request_with_code(
                             "Encrypted transactions are not supported with this authenticator type",
@@ -1356,7 +1363,7 @@ impl TransactionsApi {
                         )
                     })?;
 
-                if let Err(e) = payload.verify(signed_transaction.sender(), auth_key) {
+                if let Err(e) = payload.verify(signed_transaction.sender(), signer_auth_keys) {
                     return Err(SubmitTransactionError::bad_request_with_code(
                         e.context("Encrypted transaction payload could not be verified"),
                         AptosErrorCode::InvalidInput,

--- a/consensus/consensus-types/src/common.rs
+++ b/consensus/consensus-types/src/common.rs
@@ -146,6 +146,10 @@ pub fn verify_batch_kind_transactions(
                         .as_encrypted_payload()
                         .expect("already verified is_encrypted_txn");
                     ensure!(
+                        encrypted_payload.is_encrypted(),
+                        "Encrypted batch contains transaction not in Encrypted state"
+                    );
+                    ensure!(
                         !encrypted_payload.extra_config().is_multisig(),
                         "Encrypted transactions do not support multisig"
                     );
@@ -153,8 +157,8 @@ pub fn verify_batch_kind_transactions(
                         .authenticator()
                         .all_signer_auth_keys(txn.sender())
                         .context(
-                            "Encrypted transactions are not supported with this authenticator type",
-                        )?;
+                        "Encrypted transactions are not supported with this authenticator type",
+                    )?;
                     encrypted_payload
                         .verify(txn.sender(), signer_auth_keys)
                         .context("Encrypted transaction ciphertext verification failed")
@@ -662,7 +666,7 @@ mod tests {
         chain_id::ChainId,
         secret_sharing::Ciphertext,
         transaction::{
-            encrypted_payload::{EncryptedInner, EncryptedPayload},
+            encrypted_payload::{DecryptionFailureReason, EncryptedInner, EncryptedPayload},
             RawTransaction, Script, TransactionExtraConfig, TransactionPayload,
         },
         validator_verifier::random_validator_verifier,
@@ -971,6 +975,108 @@ mod tests {
         assert!(
             err.to_string().contains("ciphertext verification failed"),
             "Expected ciphertext verification error through Payload::verify, got: {}",
+            err
+        );
+    }
+
+    fn create_failed_decryption_signed_transaction() -> SignedTransaction {
+        let private_key = Ed25519PrivateKey::generate_for_testing();
+        let public_key = private_key.public_key();
+        let encrypted_payload = EncryptedPayload::FailedDecryption {
+            original: EncryptedInner {
+                ciphertext: Ciphertext::random(),
+                extra_config: TransactionExtraConfig::V1 {
+                    multisig_address: None,
+                    replay_protection_nonce: None,
+                },
+                payload_hash: HashValue::random(),
+                encryption_epoch: 0,
+                claimed_entry_fun: None,
+            },
+            eval_proof: None,
+            reason: DecryptionFailureReason::CryptoFailure,
+        };
+        let raw_transaction = RawTransaction::new(
+            AccountAddress::random(),
+            0,
+            TransactionPayload::EncryptedPayload(encrypted_payload),
+            0,
+            0,
+            0,
+            ChainId::new(10),
+        );
+        SignedTransaction::new(
+            raw_transaction,
+            public_key,
+            aptos_crypto::ed25519::Ed25519Signature::dummy_signature(),
+        )
+    }
+
+    fn create_encrypted_multisig_signed_transaction() -> SignedTransaction {
+        let private_key = Ed25519PrivateKey::generate_for_testing();
+        let public_key = private_key.public_key();
+        let encrypted_payload = EncryptedPayload::Encrypted(EncryptedInner {
+            ciphertext: Ciphertext::random(),
+            extra_config: TransactionExtraConfig::V1 {
+                multisig_address: Some(AccountAddress::random()),
+                replay_protection_nonce: None,
+            },
+            payload_hash: HashValue::random(),
+            encryption_epoch: 0,
+            claimed_entry_fun: None,
+        });
+        let raw_transaction = RawTransaction::new(
+            AccountAddress::random(),
+            0,
+            TransactionPayload::EncryptedPayload(encrypted_payload),
+            0,
+            0,
+            0,
+            ChainId::new(10),
+        );
+        SignedTransaction::new(
+            raw_transaction,
+            public_key,
+            aptos_crypto::ed25519::Ed25519Signature::dummy_signature(),
+        )
+    }
+
+    #[test]
+    fn test_verify_inline_batches_rejects_non_encrypted_state_payload() {
+        let author = PeerId::random();
+        let txns = vec![create_failed_decryption_signed_transaction()];
+        let batch = make_batch_info_ext_v2_with_txns(author, &txns, BatchKind::Encrypted);
+        let inline_batches = vec![(&batch, &txns)];
+
+        let err = Payload::verify_inline_batches(
+            inline_batches.into_iter(),
+            MAX_BATCH_TXNS,
+            MAX_BATCH_BYTES,
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("not in Encrypted state"),
+            "Expected non-Encrypted state error, got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_verify_inline_batches_rejects_encrypted_multisig() {
+        let author = PeerId::random();
+        let txns = vec![create_encrypted_multisig_signed_transaction()];
+        let batch = make_batch_info_ext_v2_with_txns(author, &txns, BatchKind::Encrypted);
+        let inline_batches = vec![(&batch, &txns)];
+
+        let err = Payload::verify_inline_batches(
+            inline_batches.into_iter(),
+            MAX_BATCH_TXNS,
+            MAX_BATCH_BYTES,
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("do not support multisig"),
+            "Expected multisig rejection error, got: {}",
             err
         );
     }

--- a/consensus/consensus-types/src/common.rs
+++ b/consensus/consensus-types/src/common.rs
@@ -141,13 +141,22 @@ pub fn verify_batch_kind_transactions(
                         txn.is_encrypted_txn(),
                         "Encrypted batch contains non-encrypted transaction"
                     );
-                    let auth_key = txn.authenticator().sender().authentication_key().context(
-                        "Encrypted transactions are not supported with this authenticator type",
-                    )?;
-                    txn.payload()
+                    let encrypted_payload = txn
+                        .payload()
                         .as_encrypted_payload()
-                        .expect("already verified is_encrypted_txn")
-                        .verify(txn.sender(), auth_key)
+                        .expect("already verified is_encrypted_txn");
+                    ensure!(
+                        !encrypted_payload.extra_config().is_multisig(),
+                        "Encrypted transactions do not support multisig"
+                    );
+                    let signer_auth_keys = txn
+                        .authenticator()
+                        .all_signer_auth_keys(txn.sender())
+                        .context(
+                            "Encrypted transactions are not supported with this authenticator type",
+                        )?;
+                    encrypted_payload
+                        .verify(txn.sender(), signer_auth_keys)
                         .context("Encrypted transaction ciphertext verification failed")
                 })?;
         },

--- a/sdk/src/transaction_builder.rs
+++ b/sdk/src/transaction_builder.rs
@@ -46,6 +46,7 @@ pub struct TransactionBuilder {
     chain_id: ChainId,
     encryption_key: Arc<RwLock<EncryptionKeyState>>,
     auth_key: Option<AuthenticationKey>,
+    additional_signer_auth_keys: Vec<(AccountAddress, AuthenticationKey)>,
 }
 
 impl TransactionBuilder {
@@ -65,6 +66,7 @@ impl TransactionBuilder {
             sequence_number: None,
             encryption_key: Arc::new(RwLock::new(EncryptionKeyState::default())),
             auth_key: None,
+            additional_signer_auth_keys: Vec::new(),
         }
     }
 
@@ -103,6 +105,14 @@ impl TransactionBuilder {
         self
     }
 
+    pub fn additional_signer_auth_keys(
+        mut self,
+        keys: Vec<(AccountAddress, AuthenticationKey)>,
+    ) -> Self {
+        self.additional_signer_auth_keys = keys;
+        self
+    }
+
     pub fn has_nonce(&self) -> bool {
         self.payload.replay_protection_nonce().is_some()
     }
@@ -133,11 +143,16 @@ impl TransactionBuilder {
         drop(encryption_key_state);
         if let Some(ref encryption_key) = encryption_key {
             assert!(!self.payload.is_encrypted_variant());
+            let sender = self.sender.expect("sender must have been set");
+            let auth_key = self
+                .auth_key
+                .expect("auth_key must be set for encrypted payloads");
+            let mut signer_auth_keys = vec![(sender, auth_key)];
+            signer_auth_keys.extend(std::mem::take(&mut self.additional_signer_auth_keys));
             let encrypted_payload = TransactionFactory::encrypt_payload(
                 self.payload.clone(),
-                self.sender.expect("sender must have been set"),
-                self.auth_key
-                    .expect("auth_key must be set for encrypted payloads"),
+                sender,
+                signer_auth_keys,
                 encryption_key,
                 encryption_epoch,
             )
@@ -462,6 +477,7 @@ impl TransactionFactory {
             chain_id: self.chain_id,
             encryption_key: self.encryption_key.clone(),
             auth_key: None,
+            additional_signer_auth_keys: Vec::new(),
         }
     }
 
@@ -470,7 +486,7 @@ impl TransactionFactory {
     fn encrypt_payload(
         payload: TransactionPayload,
         sender: AccountAddress,
-        auth_key: AuthenticationKey,
+        signer_auth_keys: Vec<(AccountAddress, AuthenticationKey)>,
         encryption_key: &EncryptionKey,
         encryption_epoch: u64,
     ) -> Result<EncryptedPayload> {
@@ -484,9 +500,7 @@ impl TransactionFactory {
         // Create DecryptedPayload for encryption
         let decrypted_payload = DecryptedPlaintext::new(executable, decryption_nonce);
 
-        // Create associated data with sender and auth_key to bind the ciphertext
-        // to both the sender address and the authenticator's identity.
-        let associated_data = PayloadAssociatedData::new(sender, auth_key);
+        let associated_data = PayloadAssociatedData::new(sender, signer_auth_keys);
 
         // Encrypt the payload
         // Note: FPTXWeighted::encrypt requires CryptoRng from ark_std::rand, so we use StdRng
@@ -613,18 +627,23 @@ mod tests {
         let encrypted_payload = TransactionFactory::encrypt_payload(
             test_payload(),
             sender,
-            sender_auth_key,
+            vec![(sender, sender_auth_key)],
             &encryption_key,
             0,
         )
         .unwrap();
 
         encrypted_payload
-            .verify(sender, sender_auth_key)
+            .verify(sender, vec![(sender, sender_auth_key)])
             .expect("sender and auth_key used for encryption should verify");
-        assert!(encrypted_payload.verify(sender, wrong_auth_key).is_err());
         assert!(encrypted_payload
-            .verify(wrong_sender, AuthenticationKey::ed25519(&sender_public_key))
+            .verify(sender, vec![(sender, wrong_auth_key)])
+            .is_err());
+        assert!(encrypted_payload
+            .verify(wrong_sender, vec![(
+                wrong_sender,
+                AuthenticationKey::ed25519(&sender_public_key)
+            )])
             .is_err());
     }
 }

--- a/sdk/src/types.rs
+++ b/sdk/src/types.rs
@@ -374,7 +374,7 @@ impl LocalAccount {
         secondary_signers: Vec<&Self>,
         builder: TransactionBuilder,
     ) -> SignedTransaction {
-        let secondary_signer_addresses = secondary_signers
+        let secondary_signer_addresses: Vec<_> = secondary_signers
             .iter()
             .map(|signer| signer.address())
             .collect();
@@ -382,7 +382,15 @@ impl LocalAccount {
             .iter()
             .map(|signer| signer.private_key())
             .collect();
-        let raw_txn = self.build_raw_transaction(builder);
+        let additional_auth_keys = secondary_signers
+            .iter()
+            .filter_map(|s| {
+                s.optional_authentication_key()
+                    .map(|key| (s.address(), key))
+            })
+            .collect();
+        let raw_txn =
+            self.build_raw_transaction(builder.additional_signer_auth_keys(additional_auth_keys));
         raw_txn
             .sign_multi_agent(
                 self.private_key(),
@@ -399,7 +407,7 @@ impl LocalAccount {
         fee_payer_signer: &Self,
         builder: TransactionBuilder,
     ) -> SignedTransaction {
-        let secondary_signer_addresses = secondary_signers
+        let secondary_signer_addresses: Vec<_> = secondary_signers
             .iter()
             .map(|signer| signer.address())
             .collect();
@@ -407,7 +415,18 @@ impl LocalAccount {
             .iter()
             .map(|signer| signer.private_key())
             .collect();
-        let raw_txn = self.build_raw_transaction(builder);
+        let mut additional_auth_keys: Vec<_> = secondary_signers
+            .iter()
+            .filter_map(|s| {
+                s.optional_authentication_key()
+                    .map(|key| (s.address(), key))
+            })
+            .collect();
+        if let Some(key) = fee_payer_signer.optional_authentication_key() {
+            additional_auth_keys.push((fee_payer_signer.address(), key));
+        }
+        let raw_txn =
+            self.build_raw_transaction(builder.additional_signer_auth_keys(additional_auth_keys));
         raw_txn
             .sign_fee_payer(
                 self.private_key(),

--- a/types/src/transaction/authenticator.rs
+++ b/types/src/transaction/authenticator.rs
@@ -348,6 +348,9 @@ impl TransactionAuthenticator {
 
         let secondary_addresses = self.secondary_signer_addresses();
         let secondary_auths = self.secondary_signers();
+        if secondary_addresses.len() != secondary_auths.len() {
+            return None;
+        }
         for (addr, auth) in secondary_addresses.into_iter().zip(secondary_auths.iter()) {
             if !auth.supports_encrypted_txn() {
                 return None;
@@ -1273,7 +1276,9 @@ impl MultiKey {
     }
 
     pub fn supports_encrypted_txn(&self) -> bool {
-        self.public_keys.iter().all(|pk| pk.supports_encrypted_txn())
+        self.public_keys
+            .iter()
+            .all(|pk| pk.supports_encrypted_txn())
     }
 
     pub fn signatures_required(&self) -> u8 {
@@ -1493,7 +1498,13 @@ impl AnyPublicKey {
     }
 
     pub fn supports_encrypted_txn(&self) -> bool {
-        !matches!(self, Self::Keyless { .. } | Self::FederatedKeyless { .. })
+        match self {
+            Self::Ed25519 { .. }
+            | Self::Secp256k1Ecdsa { .. }
+            | Self::Secp256r1Ecdsa { .. }
+            | Self::SlhDsa_Sha2_128s { .. } => true,
+            Self::Keyless { .. } | Self::FederatedKeyless { .. } => false,
+        }
     }
 
     pub fn to_bytes(&self) -> Vec<u8> {

--- a/types/src/transaction/authenticator.rs
+++ b/types/src/transaction/authenticator.rs
@@ -330,6 +330,43 @@ impl TransactionAuthenticator {
         }
     }
 
+    /// Collect `(address, auth_key)` pairs for every signer in the transaction,
+    /// in deterministic order: sender, then secondary signers, then fee payer.
+    /// Returns `None` if any signer uses an authenticator incompatible with
+    /// encrypted transactions (keyless, abstract auth, etc.).
+    pub fn all_signer_auth_keys(
+        &self,
+        sender_address: AccountAddress,
+    ) -> Option<Vec<(AccountAddress, AuthenticationKey)>> {
+        let mut result = Vec::new();
+
+        let sender_auth = self.sender();
+        if !sender_auth.supports_encrypted_txn() {
+            return None;
+        }
+        result.push((sender_address, sender_auth.authentication_key()?));
+
+        let secondary_addresses = self.secondary_signer_addresses();
+        let secondary_auths = self.secondary_signers();
+        for (addr, auth) in secondary_addresses.into_iter().zip(secondary_auths.iter()) {
+            if !auth.supports_encrypted_txn() {
+                return None;
+            }
+            result.push((addr, auth.authentication_key()?));
+        }
+
+        if let (Some(fee_payer_addr), Some(fee_payer_auth)) =
+            (self.fee_payer_address(), self.fee_payer_signer())
+        {
+            if !fee_payer_auth.supports_encrypted_txn() {
+                return None;
+            }
+            result.push((fee_payer_addr, fee_payer_auth.authentication_key()?));
+        }
+
+        Some(result)
+    }
+
     pub fn all_signers(&self) -> Vec<AccountAuthenticator> {
         match self {
             // This is to ensure that any new TransactionAuthenticator variant must update this function.
@@ -763,6 +800,19 @@ impl AccountAuthenticator {
 
     pub fn is_abstracted(&self) -> bool {
         matches!(self, Self::Abstract { .. })
+    }
+
+    pub fn supports_encrypted_txn(&self) -> bool {
+        match self {
+            Self::Ed25519 { .. } | Self::MultiEd25519 { .. } => true,
+            Self::SingleKey { authenticator } => {
+                authenticator.public_key().supports_encrypted_txn()
+            },
+            Self::MultiKey { authenticator } => {
+                authenticator.public_keys().supports_encrypted_txn()
+            },
+            Self::Abstract { .. } | Self::NoAccountAuthenticator => false,
+        }
     }
 
     /// Return Ok if the authenticator's public key matches its signature, Err otherwise
@@ -1222,6 +1272,10 @@ impl MultiKey {
         &self.public_keys
     }
 
+    pub fn supports_encrypted_txn(&self) -> bool {
+        self.public_keys.iter().all(|pk| pk.supports_encrypted_txn())
+    }
+
     pub fn signatures_required(&self) -> u8 {
         self.signatures_required
     }
@@ -1436,6 +1490,10 @@ impl AnyPublicKey {
 
     pub fn federated_keyless(public_key: FederatedKeylessPublicKey) -> Self {
         Self::FederatedKeyless { public_key }
+    }
+
+    pub fn supports_encrypted_txn(&self) -> bool {
+        !matches!(self, Self::Keyless { .. } | Self::FederatedKeyless { .. })
     }
 
     pub fn to_bytes(&self) -> Vec<u8> {

--- a/types/src/transaction/encrypted_payload.rs
+++ b/types/src/transaction/encrypted_payload.rs
@@ -47,14 +47,22 @@ impl DecryptedPlaintext {
 impl Plaintext for DecryptedPlaintext {}
 
 #[derive(Clone, Debug, Hash, Eq, PartialEq, Serialize, Deserialize)]
-pub struct PayloadAssociatedData {
-    sender: AccountAddress,
-    auth_key: AuthenticationKey,
+pub enum PayloadAssociatedData {
+    V1 {
+        sender: AccountAddress,
+        signer_auth_keys: Vec<(AccountAddress, AuthenticationKey)>,
+    },
 }
 
 impl PayloadAssociatedData {
-    pub fn new(sender: AccountAddress, auth_key: AuthenticationKey) -> Self {
-        Self { sender, auth_key }
+    pub fn new(
+        sender: AccountAddress,
+        signer_auth_keys: Vec<(AccountAddress, AuthenticationKey)>,
+    ) -> Self {
+        Self::V1 {
+            sender,
+            signer_auth_keys,
+        }
     }
 }
 
@@ -224,9 +232,9 @@ impl EncryptedPayload {
     pub fn verify(
         &self,
         sender: AccountAddress,
-        auth_key: AuthenticationKey,
+        signer_auth_keys: Vec<(AccountAddress, AuthenticationKey)>,
     ) -> anyhow::Result<()> {
-        let associated_data = PayloadAssociatedData::new(sender, auth_key);
+        let associated_data = PayloadAssociatedData::new(sender, signer_auth_keys);
         self.ciphertext().verify(&associated_data)
     }
 }


### PR DESCRIPTION
## Summary

- **Bind all signers' auth keys in encrypted payload verification.** Previously only the sender's `AuthenticationKey` was included in `PayloadAssociatedData`. For multi-agent and fee-payer transactions, secondary signers and the fee payer were not bound to the ciphertext — allowing them to be swapped without invalidating the encrypted payload.
- **Version `PayloadAssociatedData` as an enum** (`V1 { sender, signer_auth_keys }`) for future-proofing. The sender address is an explicit named field; all signers' `(address, auth_key)` pairs are included.
- **Reject keyless, federated keyless, and abstract auth** for encrypted transactions. Their signature mutability means the auth key binding doesn't provide the same guarantee — a signature can be mutated to pass ciphertext verification but fail VM verification.
- **Reject multisig** (`multisig_address` set in `TransactionExtraConfig`) for encrypted transactions.
- **Reject non-Encrypted state payloads** in consensus batch verification. Without this, a malicious peer could submit batches containing `FailedDecryption` or `Decrypted` variants, which should only be produced by the decryption pipeline.
- All checks applied consistently in both the API submission path and the consensus batch verification path.

## Test plan
- [x] `cargo check` on aptos-types, aptos-api, aptos-consensus-types, aptos-sdk
- [x] All existing encrypted payload tests pass (8 in aptos-types)
- [x] All authenticator tests pass including multi-agent and fee-payer encrypted variants (16 tests)
- [x] SDK encrypted payload verification test updated and passes
- [x] Consensus batch verification tests pass (17 tests)
- [ ] Manual review of keyless/abstract auth rejection logic
- [ ] E2E test with multi-agent encrypted transaction (future)

🤖 Generated with [Claude Code](https://claude.com/claude-code)