### PR TITLE
[storage] Persist hot-state promotions in epilogue

### DIFF
--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -162,6 +162,7 @@ static NUM_PROOF_READING_THREADS: OnceCell<usize> = OnceCell::new();
 static DISCARD_FAILED_BLOCKS: OnceCell<bool> = OnceCell::new();
 static PROCESSED_TRANSACTIONS_DETAILED_COUNTERS: OnceCell<bool> = OnceCell::new();
 static ENABLE_PRE_WRITE: OnceCell<bool> = OnceCell::new();
+static PERSIST_HOTNESS_IN_EPILOGUE: OnceCell<bool> = OnceCell::new();
 
 macro_rules! deprecated_module_bundle {
     () => {
@@ -470,6 +471,19 @@ impl AptosVM {
         match ENABLE_PRE_WRITE.get() {
             Some(enable_pre_write) => *enable_pre_write,
             None => true,
+        }
+    }
+
+    /// Sets persist_hotness_in_epilogue flag when invoked the first time.
+    pub fn set_persist_hotness_in_epilogue_once(persist: bool) {
+        let _ = PERSIST_HOTNESS_IN_EPILOGUE.set(persist);
+    }
+
+    /// Get the persist_hotness_in_epilogue flag if already set, otherwise return default (false)
+    pub fn get_persist_hotness_in_epilogue() -> bool {
+        match PERSIST_HOTNESS_IN_EPILOGUE.get() {
+            Some(persist) => *persist,
+            None => false,
         }
     }
 
@@ -2698,6 +2712,11 @@ impl AptosVM {
                 block_id,
                 fee_distribution,
                 ..
+            }
+            | BlockEpiloguePayload::V2 {
+                block_id,
+                fee_distribution,
+                ..
             } => (block_id, fee_distribution),
         };
 
@@ -3334,6 +3353,7 @@ impl VMBlockExecutor for AptosVMBlockExecutor {
                 discard_failed_blocks: AptosVM::get_discard_failed_blocks(),
                 module_cache_config: BlockExecutorModuleCacheLocalConfig::default(),
                 enable_pre_write: AptosVM::get_enable_pre_write(),
+                persist_hotness_in_epilogue: AptosVM::get_persist_hotness_in_epilogue(),
             },
             onchain: onchain_config,
         };

--- a/aptos-move/block-executor/src/executor.rs
+++ b/aptos-move/block-executor/src/executor.rs
@@ -2181,11 +2181,22 @@ where
                 }
             }
         }
-        Ok(T::block_epilogue_v1(
-            block_id,
-            block_end_info,
-            FeeDistribution::new(amount),
-        ))
+        let fee_distribution = FeeDistribution::new(amount);
+        if self.config.local.persist_hotness_in_epilogue {
+            let (inner, to_make_hot) = block_end_info.into_parts();
+            Ok(T::block_epilogue_v2(
+                block_id,
+                inner,
+                fee_distribution,
+                to_make_hot,
+            ))
+        } else {
+            Ok(T::block_epilogue_v1(
+                block_id,
+                block_end_info,
+                fee_distribution,
+            ))
+        }
     }
 
     fn apply_output_sequential(

--- a/aptos-move/e2e-tests/src/executor.rs
+++ b/aptos-move/e2e-tests/src/executor.rs
@@ -1034,6 +1034,7 @@ impl<O: OutputLogger> FakeExecutorImpl<O> {
                 discard_failed_blocks: false,
                 module_cache_config: BlockExecutorModuleCacheLocalConfig::default(),
                 enable_pre_write: true,
+                persist_hotness_in_epilogue: false,
             },
             onchain: onchain_config.clone(),
         };

--- a/aptos-move/replay-benchmark/src/execution.rs
+++ b/aptos-move/replay-benchmark/src/execution.rs
@@ -28,6 +28,7 @@ pub(crate) fn execute_workload(
             discard_failed_blocks: false,
             module_cache_config: BlockExecutorModuleCacheLocalConfig::default(),
             enable_pre_write: true,
+            persist_hotness_in_epilogue: false,
         },
         // For replay, there is no block limit.
         onchain: BlockExecutorConfigFromOnchain::on_but_large_for_test(),

--- a/aptos-node/src/utils.rs
+++ b/aptos-node/src/utils.rs
@@ -76,6 +76,12 @@ pub fn set_aptos_vm_configurations(node_config: &NodeConfig) {
     );
     AptosVM::set_blockstm_v2_enabled_once(node_config.execution.blockstm_v2_enabled);
     AptosVM::set_enable_pre_write_once(node_config.execution.enable_pre_write);
+    AptosVM::set_persist_hotness_in_epilogue_once(
+        node_config
+            .storage
+            .hot_state_config
+            .persist_hotness_in_epilogue,
+    );
 
     if node_config
         .execution

--- a/config/src/config/storage_config.rs
+++ b/config/src/config/storage_config.rs
@@ -253,6 +253,8 @@ pub struct HotStateConfig {
     pub compute_root_hash: bool,
     /// Whether to persist hotness data alongside write sets in write set DB.
     pub persist_hotness_in_write_set: bool,
+    /// Whether to embed the per-block hot-state promotions into the epilogue transactions.
+    pub persist_hotness_in_epilogue: bool,
 }
 
 impl Default for HotStateConfig {
@@ -263,6 +265,7 @@ impl Default for HotStateConfig {
             delete_on_restart: true,
             compute_root_hash: true,
             persist_hotness_in_write_set: true,
+            persist_hotness_in_epilogue: false,
         }
     }
 }

--- a/storage/aptosdb/src/state_store/hot_state.rs
+++ b/storage/aptosdb/src/state_store/hot_state.rs
@@ -720,6 +720,7 @@ mod tests {
         delete_on_restart: false,
         compute_root_hash: true,
         persist_hotness_in_write_set: true,
+        persist_hotness_in_epilogue: false,
     };
 
     fn make_hot_slot(key: &StateKey, version: Version, value: &[u8]) -> StateSlot {

--- a/storage/aptosdb/src/state_store/tests/restart.rs
+++ b/storage/aptosdb/src/state_store/tests/restart.rs
@@ -35,6 +35,7 @@ fn open_db<P: AsRef<Path>>(
         delete_on_restart: false,
         compute_root_hash: true,
         persist_hotness_in_write_set: true,
+        persist_hotness_in_epilogue: false,
     };
     AptosDB::open(
         StorageDirPaths::from_path(path),

--- a/storage/aptosdb/src/state_store/tests/speculative_state_workflow.rs
+++ b/storage/aptosdb/src/state_store/tests/speculative_state_workflow.rs
@@ -63,6 +63,7 @@ const TEST_CONFIG: HotStateConfig = HotStateConfig {
     delete_on_restart: false,
     compute_root_hash: true,
     persist_hotness_in_write_set: true,
+    persist_hotness_in_epilogue: false,
 };
 
 #[derive(Clone, Debug)]

--- a/testsuite/generate-format/tests/staged/api.yaml
+++ b/testsuite/generate-format/tests/staged/api.yaml
@@ -191,6 +191,18 @@ BlockEpiloguePayload:
               TYPENAME: BlockEndInfo
           - fee_distribution:
               TYPENAME: FeeDistribution
+    2:
+      V2:
+        STRUCT:
+          - block_id:
+              TYPENAME: HashValue
+          - block_end_info:
+              TYPENAME: BlockEndInfo
+          - fee_distribution:
+              TYPENAME: FeeDistribution
+          - to_make_hot:
+              SEQ:
+                TYPENAME: StateKey
 BlockMetadata:
   STRUCT:
     - id:

--- a/testsuite/generate-format/tests/staged/aptos.yaml
+++ b/testsuite/generate-format/tests/staged/aptos.yaml
@@ -179,6 +179,18 @@ BlockEpiloguePayload:
               TYPENAME: BlockEndInfo
           - fee_distribution:
               TYPENAME: FeeDistribution
+    2:
+      V2:
+        STRUCT:
+          - block_id:
+              TYPENAME: HashValue
+          - block_end_info:
+              TYPENAME: BlockEndInfo
+          - fee_distribution:
+              TYPENAME: FeeDistribution
+          - to_make_hot:
+              SEQ:
+                TYPENAME: StateKey
 BlockMetadata:
   STRUCT:
     - id:

--- a/testsuite/generate-format/tests/staged/consensus.yaml
+++ b/testsuite/generate-format/tests/staged/consensus.yaml
@@ -276,6 +276,18 @@ BlockEpiloguePayload:
               TYPENAME: BlockEndInfo
           - fee_distribution:
               TYPENAME: FeeDistribution
+    2:
+      V2:
+        STRUCT:
+          - block_id:
+              TYPENAME: HashValue
+          - block_end_info:
+              TYPENAME: BlockEndInfo
+          - fee_distribution:
+              TYPENAME: FeeDistribution
+          - to_make_hot:
+              SEQ:
+                TYPENAME: StateKey
 BlockInfo:
   STRUCT:
     - epoch: U64

--- a/types/src/block_executor/config.rs
+++ b/types/src/block_executor/config.rs
@@ -62,6 +62,9 @@ pub struct BlockExecutorLocalConfig {
     pub discard_failed_blocks: bool,
     pub module_cache_config: BlockExecutorModuleCacheLocalConfig,
     pub enable_pre_write: bool,
+    /// If true, the per-block hot-state promotion set is embedded into the block epilogue
+    /// transaction (BlockEpiloguePayload::V2).
+    pub persist_hotness_in_epilogue: bool,
 }
 
 impl BlockExecutorLocalConfig {
@@ -77,6 +80,7 @@ impl BlockExecutorLocalConfig {
             discard_failed_blocks: false,
             module_cache_config: BlockExecutorModuleCacheLocalConfig::default(),
             enable_pre_write: true,
+            persist_hotness_in_epilogue: false,
         }
     }
 }

--- a/types/src/transaction/block_epilogue.rs
+++ b/types/src/transaction/block_epilogue.rs
@@ -25,6 +25,12 @@ pub enum BlockEpiloguePayload {
         block_end_info: BlockEndInfoExt,
         fee_distribution: FeeDistribution,
     },
+    V2 {
+        block_id: HashValue,
+        block_end_info: BlockEndInfo,
+        fee_distribution: FeeDistribution,
+        to_make_hot: BTreeSet<StateKey>,
+    },
 }
 
 impl BlockEpiloguePayload {
@@ -32,6 +38,7 @@ impl BlockEpiloguePayload {
         match self {
             BlockEpiloguePayload::V0 { block_end_info, .. } => Some(block_end_info),
             BlockEpiloguePayload::V1 { block_end_info, .. } => Some(&block_end_info.inner),
+            BlockEpiloguePayload::V2 { block_end_info, .. } => Some(block_end_info),
         }
     }
 
@@ -39,6 +46,7 @@ impl BlockEpiloguePayload {
         match self {
             Self::V0 { .. } => None,
             Self::V1 { block_end_info, .. } => Some(&block_end_info.to_make_hot),
+            Self::V2 { to_make_hot, .. } => Some(to_make_hot),
         }
     }
 }
@@ -127,6 +135,10 @@ impl<Key: Debug + Ord> TBlockEndInfoExt<Key> {
 
     pub fn to_persistent(&self) -> BlockEndInfo {
         self.inner.clone()
+    }
+
+    pub fn into_parts(self) -> (BlockEndInfo, BTreeSet<Key>) {
+        (self.inner, self.to_make_hot)
     }
 }
 

--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -3270,6 +3270,20 @@ impl Transaction {
         })
     }
 
+    pub fn block_epilogue_v2(
+        block_id: HashValue,
+        block_end_info: BlockEndInfo,
+        fee_distribution: FeeDistribution,
+        to_make_hot: BTreeSet<StateKey>,
+    ) -> Self {
+        Self::BlockEpilogue(BlockEpiloguePayload::V2 {
+            block_id,
+            block_end_info,
+            fee_distribution,
+            to_make_hot,
+        })
+    }
+
     pub fn try_as_signed_user_txn(&self) -> Option<&SignedTransaction> {
         match self {
             Transaction::UserTransaction(txn) => Some(txn),
@@ -3399,6 +3413,15 @@ pub trait BlockExecutableTransaction: Sync + Send + Clone + 'static {
         _block_id: HashValue,
         _block_end_info: TBlockEndInfoExt<Self::Key>,
         _fee_distribution: FeeDistribution,
+    ) -> Self {
+        unimplemented!()
+    }
+
+    fn block_epilogue_v2(
+        _block_id: HashValue,
+        _block_end_info: BlockEndInfo,
+        _fee_distribution: FeeDistribution,
+        _to_make_hot: BTreeSet<Self::Key>,
     ) -> Self {
         unimplemented!()
     }

--- a/types/src/transaction/signature_verified_transaction.rs
+++ b/types/src/transaction/signature_verified_transaction.rs
@@ -14,7 +14,7 @@ use crate::{
 use aptos_crypto::HashValue;
 use move_core_types::{account_address::AccountAddress, language_storage::StructTag};
 use serde::{Deserialize, Serialize};
-use std::fmt::Debug;
+use std::{collections::BTreeSet, fmt::Debug};
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub enum SignatureVerifiedTransaction {
@@ -124,6 +124,16 @@ impl BlockExecutableTransaction for SignatureVerifiedTransaction {
         fee_distribution: FeeDistribution,
     ) -> Self {
         Transaction::block_epilogue_v1(block_id, block_end_info, fee_distribution).into()
+    }
+
+    fn block_epilogue_v2(
+        block_id: HashValue,
+        block_end_info: BlockEndInfo,
+        fee_distribution: FeeDistribution,
+        to_make_hot: BTreeSet<Self::Key>,
+    ) -> Self {
+        Transaction::block_epilogue_v2(block_id, block_end_info, fee_distribution, to_make_hot)
+            .into()
     }
 
     fn pre_write_values(&self) -> Vec<(Self::Key, Self::Value)> {


### PR DESCRIPTION

Add `BlockEpiloguePayload::V2`, which carries the per-block `to_make_hot`
set as a normally-serialized sibling field. V0 and V1 are untouched. With
V2, hot-state promotions survive BCS round-trip and are reproducible across
both re-execute and apply-output state sync paths.

V2 production is gated on `HotStateConfig::persist_hotness_in_epilogue`,
defaulted to `false` everywhere for now. We'll enable it manually for devnet.
The gating should eventually be done via onchain configs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches consensus-critical transaction serialization by adding a new `BlockEpiloguePayload` variant, but behavior is gated and defaults to off. Risk centers on compatibility/round-trip correctness when the flag is enabled.
> 
> **Overview**
> Adds a new `BlockEpiloguePayload::V2` that serializes the per-block hot-state promotion set (`to_make_hot`) alongside `block_end_info` and `fee_distribution`, and wires it through `Transaction` constructors and `SignatureVerifiedTransaction`.
> 
> Plumbs a new `persist_hotness_in_epilogue` flag from `HotStateConfig`/node config into `BlockExecutorLocalConfig`, and updates the block executor to emit `block_epilogue_v2` when enabled (otherwise keep emitting V1), while teaching `AptosVM::process_block_epilogue` to accept V2.
> 
> Updates generated format fixtures to include the new V2 variant and sets default/test configs to keep the feature disabled (`false`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0656bc54410fdebff25dde534cd50632a16a3540. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->