### PR TITLE
[storage] Re-write hot state KV in restart replay

### DIFF
--- a/storage/aptosdb/src/db/aptosdb_writer.rs
+++ b/storage/aptosdb/src/db/aptosdb_writer.rs
@@ -18,6 +18,7 @@ use crate::{
         db_metadata::{DbMetadataKey, DbMetadataSchema, DbMetadataValue},
         transaction_accumulator_root_hash::TransactionAccumulatorRootHashSchema,
     },
+    state_store::StateStore,
 };
 use aptos_crypto::HashValue;
 use aptos_experimental_runtimes::thread_manager::THREAD_MANAGER;
@@ -333,8 +334,10 @@ impl AptosDB {
             .as_ref()
             .expect("hot_state_kv_db must exist on the write path");
         let mut sharded_hot_state_kv_batches = hot_state_kv_db.new_sharded_native_batches();
-        self.state_store
-            .put_hot_state_updates(chunk.hot_state_updates, &mut sharded_hot_state_kv_batches)?;
+        StateStore::put_hot_state_updates(
+            chunk.hot_state_updates,
+            &mut sharded_hot_state_kv_batches,
+        )?;
 
         // Write block index.
         for (i, txn_out) in chunk.transaction_outputs.iter().enumerate() {

--- a/storage/aptosdb/src/state_store/mod.rs
+++ b/storage/aptosdb/src/state_store/mod.rs
@@ -842,6 +842,7 @@ impl StateStore {
                 &mut buffered_state,
                 &out_current_state,
                 &out_persisted_state,
+                hot_state_config.delete_on_restart,
             )?;
         }
 
@@ -884,6 +885,7 @@ impl StateStore {
         buffered_state: &mut BufferedState,
         out_current_state: &Mutex<LedgerStateWithSummary>,
         persisted_state: &PersistedState,
+        delete_hot_state_on_restart: bool,
     ) -> Result<()> {
         info!("Replaying writesets from {snapshot_next_version} to {num_transactions} to let state Merkle DB catch up.");
 
@@ -920,6 +922,14 @@ impl StateStore {
             &state_update_refs,
         )?;
         let updated = LedgerStateWithSummary::from_state_and_summary(new_state, new_state_summary);
+
+        // `delete_on_restart` wiped the hot state KV for this range; re-write it so it
+        // matches the JMT we're about to commit.
+        if delete_hot_state_on_restart && let Some(db) = state_db.hot_state_kv_db.as_ref() {
+            let mut sharded_batches = db.new_sharded_native_batches();
+            Self::put_hot_state_updates(&hot_state_updates, &mut sharded_batches)?;
+            db.commit(num_transactions - 1, None, sharded_batches)?;
+        }
 
         // synchronously commit the snapshot at the last checkpoint here if not committed to disk yet.
         buffered_state.update(
@@ -1113,7 +1123,6 @@ impl StateStore {
     // TODO(HotState): multiple writes to the same key are batched (within `for_last_checkpoint`
     // and `for_latest`) and only the last one is persisted. Revisit later if necessary.
     pub fn put_hot_state_updates(
-        &self,
         hot_state_updates: &HotStateUpdates,
         sharded_hot_state_kv_batches: &mut ShardedStateKvSchemaBatch,
     ) -> Result<()> {

--- a/storage/aptosdb/src/state_store/tests/hot_state_kv.rs
+++ b/storage/aptosdb/src/state_store/tests/hot_state_kv.rs
@@ -9,6 +9,7 @@ use crate::{
         stale_state_value_index_by_key_hash::StaleStateValueIndexByKeyHashSchema,
     },
     state_kv_db::{LoadedHotStateShard, StateKvDb},
+    state_store::StateStore,
 };
 use aptos_config::config::{RocksdbConfig, StorageDirPaths};
 use aptos_crypto::{hash::CryptoHash, HashValue};
@@ -536,10 +537,7 @@ fn test_load_write_then_load_roundtrip() {
     };
 
     let mut sharded_batches = hot_state_kv_db.new_sharded_native_batches();
-    aptos_db
-        .state_store
-        .put_hot_state_updates(&hot_state_updates, &mut sharded_batches)
-        .unwrap();
+    StateStore::put_hot_state_updates(&hot_state_updates, &mut sharded_batches).unwrap();
     hot_state_kv_db.commit(999, None, sharded_batches).unwrap();
 
     // Load back.
@@ -669,10 +667,7 @@ fn test_put_hot_state_updates_values_and_stale_indices() {
     };
 
     let mut sharded_batches = hot_state_kv_db.new_sharded_native_batches();
-    aptos_db
-        .state_store
-        .put_hot_state_updates(&hot_state_updates, &mut sharded_batches)
-        .unwrap();
+    StateStore::put_hot_state_updates(&hot_state_updates, &mut sharded_batches).unwrap();
     hot_state_kv_db.commit(999, None, sharded_batches).unwrap();
 
     // -- Verify value entries --
@@ -796,10 +791,7 @@ fn test_hot_state_kv_pruner_deletes_old_entries() {
         for_latest: None,
     };
     let mut batches = hot_state_kv_db.new_sharded_native_batches();
-    aptos_db
-        .state_store
-        .put_hot_state_updates(&updates1, &mut batches)
-        .unwrap();
+    StateStore::put_hot_state_updates(&updates1, &mut batches).unwrap();
     hot_state_kv_db.commit(100, None, batches).unwrap();
 
     // Second batch: write new entry at hot_since=200 superseding 100
@@ -817,10 +809,7 @@ fn test_hot_state_kv_pruner_deletes_old_entries() {
         for_latest: None,
     };
     let mut batches2 = hot_state_kv_db.new_sharded_native_batches();
-    aptos_db
-        .state_store
-        .put_hot_state_updates(&updates2, &mut batches2)
-        .unwrap();
+    StateStore::put_hot_state_updates(&updates2, &mut batches2).unwrap();
     hot_state_kv_db.commit(200, None, batches2).unwrap();
 
     // Both entries exist before pruning


### PR DESCRIPTION

After a restart with `delete_on_restart=true`, the hot state KV is wiped
but the cold state still needs the chunks between its last snapshot and
the synced version to be re-applied. `replay_write_sets_after_snapshot`
was feeding the resulting hot state updates to the JMT committer (via
`buffered_state.update`) but skipping the KV write that the steady-state
chunk-commit path normally does. The replay finished with hot JMT leaves
stamped at the new snapshot version that had no matching KV entries.

This was latent until 8a8d269 added the 1-in-10000 hot-state proof
verification, which reads the KV via `expect_hot_state_value_by_version`
and panics on the mismatch.

Fix: in the replay path, when `delete_on_restart` is true, mirror the
chunk-commit hot-KV write — allocate sharded batches on
`hot_state_kv_db`, fill via `StateStore::put_hot_state_updates`, and
commit at `num_transactions - 1`.

`put_hot_state_updates` had an unused \`&self\`; dropped so the static
init-time replay can call it without a `StateStore` instance (not yet
constructed at that point). The chunk-commit caller and tests now go
through `StateStore::put_hot_state_updates(...)` directly.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches state-store restart replay and hot-state KV commit behavior; mistakes could leave hot-state proofs inconsistent or cause incorrect DB versions to be committed after restarts.
> 
> **Overview**
> Fixes a restart edge case where `delete_on_restart=true` wipes the hot-state KV but replaying write sets only advanced the hot JMT, leaving missing KV rows for the replayed range.
> 
> During `replay_write_sets_after_snapshot`, the hot-state KV is now re-written from the computed `hot_state_updates` and committed at `num_transactions - 1` when `delete_on_restart` is enabled.
> 
> Refactors `put_hot_state_updates` to be callable as `StateStore::put_hot_state_updates(...)` (drops unused `&self`), updates the steady-state chunk commit path and hot-state KV tests to use the static call.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2fd5d1736f0da75a90fa15951977e96e2306903. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->