### PR TITLE
[mono-move] LoadedModule with ModuleIR to be used in code cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12709,6 +12709,7 @@ dependencies = [
  "move-binary-format",
  "move-core-types",
  "parking_lot 0.12.5",
+ "specializer",
 ]
 
 [[package]]

--- a/third_party/move/mono-move/core/src/executable.rs
+++ b/third_party/move/mono-move/core/src/executable.rs
@@ -5,13 +5,10 @@ use crate::{
     types::{InternedType, Type},
     Function,
 };
-use mono_move_alloc::{
-    ExecutableArena, ExecutableArenaPtr, GlobalArenaPtr, LeakedBoxPtr, VersionedLeakedBoxPtr,
-};
+use mono_move_alloc::{ExecutableArena, ExecutableArenaPtr, GlobalArenaPtr};
 use move_core_types::account_address::AccountAddress;
 use parking_lot::Mutex;
 use shared_dsa::UnorderedMap;
-use std::sync::Arc;
 
 /// Identifies an executable (module or script) by its address and name.
 ///   - For modules, constructed from module address and name.
@@ -43,38 +40,6 @@ impl ExecutableId {
     /// Returns the arena pointer to the name.
     pub fn name(&self) -> GlobalArenaPtr<str> {
         self.name
-    }
-}
-
-// ================================================================================================
-// Executable cache slot and mandatory dependencies
-// ================================================================================================
-
-/// Stable slot pointer for an executable in the cache. May be empty if the
-/// executable has not yet been cached.
-pub type ExecutableSlot = LeakedBoxPtr<VersionedLeakedBoxPtr<Executable>>;
-
-/// What a loaded executable says about its mandatory dependencies, keyed by
-/// the loading policy that built it. Always excludes self.
-#[derive(Clone)]
-pub struct MandatoryDependencies {
-    inner: Option<Arc<[ExecutableSlot]>>,
-}
-
-impl MandatoryDependencies {
-    /// Slots of the modules this executable loaded together with.
-    pub fn slots(&self) -> &[ExecutableSlot] {
-        self.inner.as_ref().map(|r| r.as_ref()).unwrap_or(&[])
-    }
-
-    pub fn empty() -> MandatoryDependencies {
-        MandatoryDependencies { inner: None }
-    }
-
-    pub fn package(package_slots: Vec<ExecutableSlot>) -> MandatoryDependencies {
-        MandatoryDependencies {
-            inner: Some(Arc::from(package_slots)),
-        }
     }
 }
 
@@ -153,10 +118,6 @@ struct ExecutableData {
     id: GlobalArenaPtr<ExecutableId>,
     /// Deterministic load cost for this executable.
     cost: u64,
-    /// Slots of every other module in this executable's mandatory-dependency
-    /// set. Slots are aliases of the leaked-box slots owned by the cache;
-    /// dropping these aliases does not free any slot.
-    mandatory_dependencies: MandatoryDependencies,
     /// Non-generic struct definitions.
     structs: UnorderedMap<GlobalArenaPtr<str>, StructType>,
     /// Non-generic enum definitions.
@@ -178,23 +139,21 @@ impl Executable {
     pub fn new(
         id: GlobalArenaPtr<ExecutableId>,
         cost: u64,
-        mandatory_dependencies: MandatoryDependencies,
         structs: UnorderedMap<GlobalArenaPtr<str>, StructType>,
         enums: UnorderedMap<GlobalArenaPtr<str>, EnumType>,
         functions: UnorderedMap<GlobalArenaPtr<str>, ExecutableArenaPtr<Function>>,
         arena: ExecutableArena,
-    ) -> Box<Self> {
-        Box::new(Self {
+    ) -> Self {
+        Self {
             data: ExecutableData {
                 id,
                 cost,
-                mandatory_dependencies,
                 structs,
                 enums,
                 functions,
             },
             arena: Mutex::new(arena),
-        })
+        }
     }
 
     /// Returns a non-generic function from this executable. Returns [`None`]
@@ -224,11 +183,5 @@ impl Executable {
     /// Returns the deterministic load cost for this executable.
     pub fn cost(&self) -> u64 {
         self.data.cost
-    }
-
-    /// Returns the slots of every other module in this executable's
-    /// mandatory dependencies.
-    pub fn mandatory_dependencies(&self) -> &MandatoryDependencies {
-        &self.data.mandatory_dependencies
     }
 }

--- a/third_party/move/mono-move/core/src/lib.rs
+++ b/third_party/move/mono-move/core/src/lib.rs
@@ -8,10 +8,7 @@ pub mod interner;
 mod transaction_context;
 pub mod types;
 
-pub use executable::{
-    EnumType, Executable, ExecutableId, ExecutableSlot, MandatoryDependencies, StructType,
-    VariantFields,
-};
+pub use executable::{EnumType, Executable, ExecutableId, StructType, VariantFields};
 pub use function::{FrameLayoutInfo, Function, SafePointEntry, SortedSafePointEntries};
 pub use instruction::{
     CodeOffset, DescriptorId, FrameOffset, MicroOp, MicroOpGasSchedule, ENUM_DATA_OFFSET,

--- a/third_party/move/mono-move/global-context/Cargo.toml
+++ b/third_party/move/mono-move/global-context/Cargo.toml
@@ -21,3 +21,4 @@ mono-move-core = { workspace = true }
 move-binary-format = { workspace = true }
 move-core-types = { workspace = true }
 parking_lot = { workspace = true }
+specializer = { workspace = true }

--- a/third_party/move/mono-move/global-context/src/context.rs
+++ b/third_party/move/mono-move/global-context/src/context.rs
@@ -36,7 +36,7 @@ use crate::maintenance_config::MaintenanceConfig;
 use anyhow::Result;
 use dashmap::DashMap;
 use mono_move_alloc::{GlobalArenaPool, GlobalArenaPtr, GlobalArenaShard};
-use mono_move_core::{types::StructLayout, ExecutableId, ExecutableSlot, Interner};
+use mono_move_core::{types::StructLayout, ExecutableId, Interner};
 use move_binary_format::{file_format::SignatureToken, CompiledModule};
 use parking_lot::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 use std::{
@@ -50,6 +50,8 @@ use identifiers::IdentifierInternerKey;
 mod executable_ids;
 use executable_ids::ExecutableIdInternerKey;
 pub use mono_move_core::Executable;
+mod loaded_module;
+pub use loaded_module::{LoadedModule, LoadedModuleSlot, MandatoryDependencies};
 mod executable_cache;
 use executable_cache::ExecutableCache;
 mod types;
@@ -286,30 +288,28 @@ impl<'ctx> MaintenanceGuard<'ctx> {
 }
 
 impl<'ctx> ExecutionGuard<'ctx> {
-    /// Inserts a loaded executable into the cache, keyed by its interned ID.
+    /// Inserts a loaded module into the cache, keyed by its interned ID.
     ///
     /// Returns an error only if the cache detects an invariant violation
     /// during install. Under normal operation this method always returns
     /// `Ok`.
-    pub fn insert_executable(&self, executable: Box<Executable>) -> Result<&Executable> {
-        let ptr = self
-            .ctx
-            .executable_cache
-            .insert(executable.id(), executable)?;
+    pub fn insert_loaded_module(&self, loaded: Box<LoadedModule>) -> Result<&LoadedModule> {
+        let ptr = self.ctx.executable_cache.insert(loaded.id(), loaded)?;
 
         // SAFETY: The pointer is valid since it was created by leaking a box,
         // and can only be freed during the maintenance phase, while we are in
-        // the execution phase (guard is alive). If the executable was already
-        // in the cache, it is also alive (maintenance has not reset caches).
+        // the execution phase (guard is alive). If the loaded module was
+        // already in the cache, it is also alive (maintenance has not reset
+        // caches).
         Ok(unsafe { ptr.as_ref_unchecked() })
     }
 
-    /// Looks up a cached executable by its interned ID and returns a reference
-    /// tied to the guard's lifetime, if found.
-    pub fn get_executable<'guard>(
+    /// Looks up a cached loaded module by its interned ID and returns a
+    /// reference tied to the guard's lifetime, if found.
+    pub fn get_loaded_module<'guard>(
         &'guard self,
         key: ArenaRef<'guard, ExecutableId>,
-    ) -> Option<&'guard Executable> {
+    ) -> Option<&'guard LoadedModule> {
         let ptr = self.ctx.executable_cache.get(key.into_global_arena_ptr())?;
 
         // SAFETY: The pointer is valid since it was created by leaking a box,
@@ -324,7 +324,7 @@ impl<'ctx> ExecutionGuard<'ctx> {
     pub fn get_or_create_slot<'guard>(
         &'guard self,
         key: ArenaRef<'guard, ExecutableId>,
-    ) -> ExecutableSlot {
+    ) -> LoadedModuleSlot {
         self.ctx
             .executable_cache
             .get_or_create_slot(key.into_global_arena_ptr())

--- a/third_party/move/mono-move/global-context/src/context/executable_cache.rs
+++ b/third_party/move/mono-move/global-context/src/context/executable_cache.rs
@@ -1,27 +1,28 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-//! Cache of loaded executables, keyed by executable IDs.
+//! Cache of loaded modules, keyed by executable IDs.
 //!
 //! Each entry is a stable pointer to a slot which stores multiple versions
-//! of executables. A slot can be:
+//! of loaded modules. A slot can be:
 //!   1. Empty (e.g., cleared by eviction). Readers treat this as a cache
 //!      miss and repopulate the slot.
-//!   2. Non-empty. Readers select correct version of executable they need.
+//!   2. Non-empty. Readers select correct version of loaded module they need.
 //!
-//! Because of upgrades, slot can contain more than 1 version of executable at
-//! a time.
+//! Because of upgrades, slot can contain more than 1 version of loaded module
+//! at a time.
 //!
-//! Other executables may point to their dependency slots. Hence, it is crucial
-//! that the eviction from the cache never removes the slots themselves, unless
-//! the whole cache is cleared.
+//! Other loaded modules may point to their dependency slots. Hence, it is
+//! crucial that the eviction from the cache never removes the slots
+//! themselves, unless the whole cache is cleared.
 
+use crate::context::loaded_module::{LoadedModule, LoadedModuleSlot};
 use anyhow::{anyhow, Result};
 use dashmap::DashMap;
 use mono_move_alloc::{GlobalArenaPtr, LeakedBoxPtr, VersionedLeakedBoxPtr};
-use mono_move_core::{Executable, ExecutableId, ExecutableSlot};
+use mono_move_core::ExecutableId;
 
-/// Concurrent long-living executable cache.
+/// Concurrent long-living loaded module cache.
 ///
 // TODO:
 //   1. Support speculative writes for Zaptos optimistic pipeline.
@@ -29,11 +30,11 @@ use mono_move_core::{Executable, ExecutableId, ExecutableSlot};
 pub(super) struct ExecutableCache {
     // Uses fxhash because the keys are already well-distributed arena
     // pointers, so a simple, fast hash is sufficient.
-    inner: DashMap<GlobalArenaPtr<ExecutableId>, ExecutableSlot, fxhash::FxBuildHasher>,
+    inner: DashMap<GlobalArenaPtr<ExecutableId>, LoadedModuleSlot, fxhash::FxBuildHasher>,
 }
 
 impl ExecutableCache {
-    /// Creates an empty executable cache.
+    /// Creates an empty cache.
     pub(super) fn new() -> Self {
         Self {
             inner: DashMap::with_hasher(fxhash::FxBuildHasher::default()),
@@ -44,20 +45,20 @@ impl ExecutableCache {
     ///
     /// The returned pointer is stable for the lifetime of the cache.
     /// Takes a shard write lock on the create path.
-    pub(super) fn get_or_create_slot(&self, key: GlobalArenaPtr<ExecutableId>) -> ExecutableSlot {
+    pub(super) fn get_or_create_slot(&self, key: GlobalArenaPtr<ExecutableId>) -> LoadedModuleSlot {
         *self
             .inner
             .entry(key)
             .or_insert_with(|| LeakedBoxPtr::from_box(Box::new(VersionedLeakedBoxPtr::new())))
     }
 
-    /// Inserts `executable` into the slot for `key`, creating the slot if
+    /// Inserts `loaded` into the slot for `key`, creating the slot if
     /// needed. On race, frees the caller's box and returns the winner.
     pub(super) fn insert(
         &self,
         key: GlobalArenaPtr<ExecutableId>,
-        executable: Box<Executable>,
-    ) -> Result<LeakedBoxPtr<Executable>> {
+        loaded: Box<LoadedModule>,
+    ) -> Result<LeakedBoxPtr<LoadedModule>> {
         if let Some(existing) = self.get(key) {
             return Ok(existing);
         }
@@ -67,7 +68,7 @@ impl ExecutableCache {
         // execution guard.
         let slot = unsafe { slot_ptr.as_ref_unchecked() };
 
-        let leaked = LeakedBoxPtr::from_box(executable);
+        let leaked = LeakedBoxPtr::from_box(loaded);
         match slot.init(leaked) {
             Ok(()) => Ok(leaked),
             Err(loser) => {
@@ -83,24 +84,24 @@ impl ExecutableCache {
     pub(super) fn get(
         &self,
         key: GlobalArenaPtr<ExecutableId>,
-    ) -> Option<LeakedBoxPtr<Executable>> {
+    ) -> Option<LeakedBoxPtr<LoadedModule>> {
         let slot_ptr = self.inner.get(&key).map(|e| *e.value())?;
         // SAFETY: slots are stable for the cache's lifetime.
         let slot = unsafe { slot_ptr.as_ref_unchecked() };
         slot.load()
     }
 
-    /// Frees all executable content stored in slots, frees the slots
+    /// Frees all loaded module content stored in slots, frees the slots
     /// themselves, and clears the map.
     ///
     /// # Safety
     ///
     /// 1. The caller must have exclusive access to the cache.
-    /// 2. The caller must ensure no live references to cached executables or
-    ///    slots exist.
+    /// 2. The caller must ensure no live references to cached loaded modules
+    ///    or slots exist.
     pub(super) unsafe fn clear(&self) {
         for entry in self.inner.iter() {
-            let slot_ptr: ExecutableSlot = *entry.value();
+            let slot_ptr: LoadedModuleSlot = *entry.value();
 
             // SAFETY: caller guarantees no outstanding references.
             let content = unsafe { slot_ptr.as_ref_unchecked() }.clear();

--- a/third_party/move/mono-move/global-context/src/context/loaded_module.rs
+++ b/third_party/move/mono-move/global-context/src/context/loaded_module.rs
@@ -1,0 +1,96 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Loaded module — what the executable cache stores.
+//!
+//! `LoadedModule` wraps the polymorphic `ModuleIR` (specializer) with the
+//! monomorphic `Executable` (core) and the mandatory-dependency descriptor
+//! recorded by the loader.
+//!
+//! TODO (placement): the natural home for this type is `mono-move-orchestrator`
+//! (where the builder is) or even `mono-move-loader`. It lives here because IR
+//! is in `specializer` and the cache is in this crate; putting `LoadedModule` in
+//! orchestrator would require `global-context` to depend on something that
+//! already depends on `global-context`. Resolve by moving `ModuleIR` out of
+//! `specializer` (e.g. into `mono-move-core` or a new `ir` crate) so this
+//! crate no longer needs the `specializer` dep — then `LoadedModule` can move.
+
+use mono_move_alloc::{LeakedBoxPtr, VersionedLeakedBoxPtr};
+use mono_move_core::{Executable, ExecutableId};
+use specializer::ModuleIR;
+use std::sync::Arc;
+
+/// Stable slot pointer for a loaded module in the cache. May be empty if the
+/// module has not yet been cached.
+pub type LoadedModuleSlot = LeakedBoxPtr<VersionedLeakedBoxPtr<LoadedModule>>;
+
+/// What a loaded module says about its mandatory dependencies, keyed by the
+/// loading policy that built it. Always excludes self.
+#[derive(Clone)]
+pub struct MandatoryDependencies {
+    inner: Option<Arc<[LoadedModuleSlot]>>,
+}
+
+impl MandatoryDependencies {
+    /// Slots of the modules this module loaded together with.
+    pub fn slots(&self) -> &[LoadedModuleSlot] {
+        self.inner.as_ref().map(|r| r.as_ref()).unwrap_or(&[])
+    }
+
+    pub fn empty() -> MandatoryDependencies {
+        MandatoryDependencies { inner: None }
+    }
+
+    pub fn package(package_slots: Vec<LoadedModuleSlot>) -> MandatoryDependencies {
+        MandatoryDependencies {
+            inner: Some(Arc::from(package_slots)),
+        }
+    }
+}
+
+/// A loaded module: polymorphic IR + the monomorphic executable view + the
+/// dependency descriptor produced at load time.
+pub struct LoadedModule {
+    ir: ModuleIR,
+    executable: Executable,
+    mandatory_dependencies: MandatoryDependencies,
+}
+
+impl LoadedModule {
+    pub fn new(
+        ir: ModuleIR,
+        executable: Executable,
+        mandatory_dependencies: MandatoryDependencies,
+    ) -> Box<Self> {
+        Box::new(Self {
+            ir,
+            executable,
+            mandatory_dependencies,
+        })
+    }
+
+    /// Returns the polymorphic stackless IR.
+    pub fn ir(&self) -> &ModuleIR {
+        &self.ir
+    }
+
+    /// Returns the monomorphic executable view.
+    pub fn executable(&self) -> &Executable {
+        &self.executable
+    }
+
+    /// Returns the mandatory-dependency descriptor.
+    pub fn mandatory_dependencies(&self) -> &MandatoryDependencies {
+        &self.mandatory_dependencies
+    }
+
+    /// Convenience: the executable's ID. Same as `self.executable().id()`.
+    pub fn id(&self) -> mono_move_alloc::GlobalArenaPtr<ExecutableId> {
+        self.executable.id()
+    }
+
+    /// Convenience: the executable's deterministic load cost.
+    pub fn cost(&self) -> u64 {
+        self.executable.cost()
+    }
+}

--- a/third_party/move/mono-move/global-context/src/context/loaded_module.rs
+++ b/third_party/move/mono-move/global-context/src/context/loaded_module.rs
@@ -3,19 +3,10 @@
 
 //! Loaded module — what the executable cache stores.
 //!
-//! `LoadedModule` wraps the polymorphic `ModuleIR` (specializer) with the
-//! monomorphic `Executable` (core) and the mandatory-dependency descriptor
-//! recorded by the loader.
-//!
-//! TODO (placement): the natural home for this type is `mono-move-orchestrator`
-//! (where the builder is) or even `mono-move-loader`. It lives here because IR
-//! is in `specializer` and the cache is in this crate; putting `LoadedModule` in
-//! orchestrator would require `global-context` to depend on something that
-//! already depends on `global-context`. Resolve by moving `ModuleIR` out of
-//! `specializer` (e.g. into `mono-move-core` or a new `ir` crate) so this
-//! crate no longer needs the `specializer` dep — then `LoadedModule` can move.
+//! [`LoadedModule`] wraps the polymorphic [`ModuleIR`] with the monomorphic
+//! [`Executable`] and a [`MandatoryDependencies`] descriptor.
 
-use mono_move_alloc::{LeakedBoxPtr, VersionedLeakedBoxPtr};
+use mono_move_alloc::{GlobalArenaPtr, LeakedBoxPtr, VersionedLeakedBoxPtr};
 use mono_move_core::{Executable, ExecutableId};
 use specializer::ModuleIR;
 use std::sync::Arc;
@@ -25,7 +16,8 @@ use std::sync::Arc;
 pub type LoadedModuleSlot = LeakedBoxPtr<VersionedLeakedBoxPtr<LoadedModule>>;
 
 /// What a loaded module says about its mandatory dependencies, keyed by the
-/// loading policy that built it. Always excludes self.
+/// loading policy that built it. Covers every package member including self
+/// for package loads, and is empty for lazy loads.
 #[derive(Clone)]
 pub struct MandatoryDependencies {
     inner: Option<Arc<[LoadedModuleSlot]>>,
@@ -85,7 +77,7 @@ impl LoadedModule {
     }
 
     /// Convenience: the executable's ID. Same as `self.executable().id()`.
-    pub fn id(&self) -> mono_move_alloc::GlobalArenaPtr<ExecutableId> {
+    pub fn id(&self) -> GlobalArenaPtr<ExecutableId> {
         self.executable.id()
     }
 

--- a/third_party/move/mono-move/global-context/src/lib.rs
+++ b/third_party/move/mono-move/global-context/src/lib.rs
@@ -7,7 +7,7 @@ mod transaction_context;
 pub use context::{
     struct_info_at, try_as_primitive_type, view_name, view_type, view_type_list, ArenaRef,
     Executable, ExecutionGuard, FieldLayout, GlobalContext, InternedType, InternedTypeList,
-    MaintenanceGuard, Type,
+    LoadedModule, LoadedModuleSlot, MaintenanceGuard, MandatoryDependencies, Type,
 };
 pub mod maintenance_config;
 pub use transaction_context::PlaceholderContext;

--- a/third_party/move/mono-move/loader/src/loader.rs
+++ b/third_party/move/mono-move/loader/src/loader.rs
@@ -10,9 +10,11 @@ use crate::{
 };
 use anyhow::{anyhow, bail};
 use fxhash::FxHashMap;
-use mono_move_core::{Executable, ExecutableId, ExecutableSlot, MandatoryDependencies};
+use mono_move_core::ExecutableId;
 use mono_move_gas::GasMeter;
-use mono_move_global_context::{ArenaRef, ExecutionGuard};
+use mono_move_global_context::{
+    ArenaRef, ExecutionGuard, LoadedModule, LoadedModuleSlot, MandatoryDependencies,
+};
 use mono_move_orchestrator::ExecutableBuilder;
 use move_binary_format::{access::ModuleAccess, CompiledModule};
 
@@ -98,7 +100,7 @@ impl<'guard, 'ctx> Loader<'guard, 'ctx> {
         read_set: &mut ExecutableReadSet<'guard>,
         gas_meter: &mut impl GasMeter,
         id: ArenaRef<'guard, ExecutableId>,
-    ) -> anyhow::Result<&'guard Executable> {
+    ) -> anyhow::Result<&'guard LoadedModule> {
         match &self.policy {
             LoadingPolicy::Lazy(lowering) => {
                 use LoweringPolicy::*;
@@ -124,16 +126,16 @@ impl<'guard, 'ctx> Loader<'guard, 'ctx> {
         read_set: &mut ExecutableReadSet<'guard>,
         gas_meter: &mut impl GasMeter,
         id: ArenaRef<'guard, ExecutableId>,
-    ) -> anyhow::Result<&'guard Executable> {
-        if let Some(executable) = self.guard.get_executable(id) {
-            self.record_loaded_and_charge(read_set, gas_meter, executable)?;
-            return Ok(executable);
+    ) -> anyhow::Result<&'guard LoadedModule> {
+        if let Some(loaded) = self.guard.get_loaded_module(id) {
+            self.record_loaded_and_charge(read_set, gas_meter, loaded)?;
+            return Ok(loaded);
         }
 
         let (module, cost) = self.get_verified_module_from_storage(id)?;
-        let executable = self.build_and_insert(&module, cost, MandatoryDependencies::empty())?;
-        self.record_loaded_and_charge(read_set, gas_meter, executable)?;
-        Ok(executable)
+        let loaded = self.build_and_insert(&module, cost, MandatoryDependencies::empty())?;
+        self.record_loaded_and_charge(read_set, gas_meter, loaded)?;
+        Ok(loaded)
     }
 
     /// Loads the code corresponding to the specified ID and all other
@@ -144,16 +146,16 @@ impl<'guard, 'ctx> Loader<'guard, 'ctx> {
         read_set: &mut ExecutableReadSet<'guard>,
         gas_meter: &mut impl GasMeter,
         id: ArenaRef<'guard, ExecutableId>,
-    ) -> anyhow::Result<&'guard Executable> {
-        if let Some(executable) = self.guard.get_executable(id) {
+    ) -> anyhow::Result<&'guard LoadedModule> {
+        if let Some(loaded) = self.guard.get_loaded_module(id) {
             // `slots` covers all package members, including self. Probe
             // every slot before touching the read-set: a concurrent
             // miss-path worker may have populated `id`'s slot but not yet
             // all sibling slots. In that window we fall through to the
             // miss path, which re-verifies and re-inserts.
-            // `insert_executable` returns the canonical winner on CAS
+            // `insert_loaded_module` returns the canonical winner on CAS
             // loss, so already-cached members are not duplicated.
-            let slots = executable.mandatory_dependencies().slots();
+            let slots = loaded.mandatory_dependencies().slots();
             let mut members = Vec::with_capacity(slots.len());
             let mut all_present = true;
             for slot in slots {
@@ -174,7 +176,7 @@ impl<'guard, 'ctx> Loader<'guard, 'ctx> {
                     read_set.record(member_id, ExecutableRead::Loaded(member))?;
                 }
                 gas_meter.charge(total)?;
-                return Ok(executable);
+                return Ok(loaded);
             }
             // Fall through to the miss path.
         }
@@ -199,17 +201,17 @@ impl<'guard, 'ctx> Loader<'guard, 'ctx> {
 
         let mut total = 0u64;
         for (_, module, cost) in &pending {
-            let executable = self.build_and_insert(module, *cost, mandatory_deps.clone())?;
-            let id = self.guard.arena_ref_for_executable_id(executable.id());
-            read_set.record(id, ExecutableRead::Loaded(executable))?;
-            total = total.saturating_add(executable.cost());
+            let loaded = self.build_and_insert(module, *cost, mandatory_deps.clone())?;
+            let id = self.guard.arena_ref_for_executable_id(loaded.id());
+            read_set.record(id, ExecutableRead::Loaded(loaded))?;
+            total = total.saturating_add(loaded.cost());
         }
 
         gas_meter.charge(total)?;
 
         Ok(read_set
             .get(id)
-            .expect("Every executable was recorded in read-set"))
+            .expect("Every loaded module was recorded in read-set"))
     }
 
     /// Orders modules leaves-first by inter-member import dependencies,
@@ -223,8 +225,8 @@ impl<'guard, 'ctx> Loader<'guard, 'ctx> {
     // TODO: double-check that publish rejects packages with cycles.
     fn topological_ordering(
         &self,
-        modules: Vec<(ExecutableSlot, CompiledModule, u64)>,
-    ) -> Vec<(ExecutableSlot, CompiledModule, u64)> {
+        modules: Vec<(LoadedModuleSlot, CompiledModule, u64)>,
+    ) -> Vec<(LoadedModuleSlot, CompiledModule, u64)> {
         let id_to_idx = modules
             .iter()
             .enumerate()
@@ -281,19 +283,19 @@ impl<'guard, 'ctx> Loader<'guard, 'ctx> {
             .collect()
     }
 
-    /// Builds an executable for the compiled module and inserts it into the
-    /// cache, returning the canonical pointer.
+    /// Builds a loaded module from the compiled module and inserts it into
+    /// the cache, returning the canonical pointer.
     fn build_and_insert(
         &self,
         module: &CompiledModule,
         cost: u64,
         deps: MandatoryDependencies,
-    ) -> anyhow::Result<&'guard Executable> {
-        let executable = ExecutableBuilder::new(self.guard, module)
+    ) -> anyhow::Result<&'guard LoadedModule> {
+        let loaded = ExecutableBuilder::new(self.guard, module)
             .with_cost(cost)
             .with_mandatory_dependencies(deps)
             .build()?;
-        self.guard.insert_executable(executable)
+        self.guard.insert_loaded_module(loaded)
     }
 
     /// Fetches, deserializes, and verifies the module from storage, returning
@@ -314,29 +316,29 @@ impl<'guard, 'ctx> Loader<'guard, 'ctx> {
         Ok((compiled, cost))
     }
 
-    /// Records a single executable in the read-set and charges its cost.
+    /// Records a single loaded module in the read-set and charges its cost.
     fn record_loaded_and_charge(
         &self,
         read_set: &mut ExecutableReadSet<'guard>,
         gas_meter: &mut impl GasMeter,
-        executable: &'guard Executable,
+        loaded: &'guard LoadedModule,
     ) -> anyhow::Result<()> {
-        let id = self.guard.arena_ref_for_executable_id(executable.id());
+        let id = self.guard.arena_ref_for_executable_id(loaded.id());
         // Always record the read before charging, so that if charging fails,
         // the read is part of the set for later Block-STM validation.
-        read_set.record(id, ExecutableRead::Loaded(executable))?;
-        gas_meter.charge(executable.cost())?;
+        read_set.record(id, ExecutableRead::Loaded(loaded))?;
+        gas_meter.charge(loaded.cost())?;
         Ok(())
     }
 }
 
-/// Loads the current executable content behind `slot`, or `None` if the
-/// slot is empty. Safe while an execution guard is held: slot and content
-/// are freed only under maintenance, which execution excludes. The guard
-/// reference anchors `'guard` so the returned reference cannot outlive it.
+/// Loads the current loaded module behind `slot`, or `None` if the slot is
+/// empty. Safe while an execution guard is held: slot and content are freed
+/// only under maintenance, which execution excludes. The guard reference
+/// anchors `'guard` so the returned reference cannot outlive it.
 fn load_content<'guard, 'ctx>(
     _guard: &'guard ExecutionGuard<'ctx>,
-    slot: ExecutableSlot,
-) -> Option<&'guard Executable> {
+    slot: LoadedModuleSlot,
+) -> Option<&'guard LoadedModule> {
     unsafe { slot.as_ref_unchecked().load().map(|p| p.as_ref_unchecked()) }
 }

--- a/third_party/move/mono-move/loader/src/read_set.rs
+++ b/third_party/move/mono-move/loader/src/read_set.rs
@@ -6,14 +6,14 @@
 
 use anyhow::{bail, Result};
 use mono_move_core::ExecutableId;
-use mono_move_global_context::{ArenaRef, Executable};
+use mono_move_global_context::{ArenaRef, LoadedModule};
 use shared_dsa::UnorderedMap;
 use std::collections::hash_map::Entry;
 
-/// Tracks how this read depends on a particular executable.
+/// Tracks how this read depends on a particular loaded module.
 #[derive(Copy, Clone)]
 pub enum ExecutableRead<'guard> {
-    Loaded(&'guard Executable),
+    Loaded(&'guard LoadedModule),
 }
 
 /// Maps from executable ID to the version the transaction is using for the
@@ -31,10 +31,10 @@ impl<'guard> ExecutableReadSet<'guard> {
         }
     }
 
-    /// Returns the recorded executable or [`None`] otherwise.
-    pub fn get(&self, key: ArenaRef<'guard, ExecutableId>) -> Option<&'guard Executable> {
+    /// Returns the recorded loaded module or [`None`] otherwise.
+    pub fn get(&self, key: ArenaRef<'guard, ExecutableId>) -> Option<&'guard LoadedModule> {
         match self.inner.get(&key)? {
-            ExecutableRead::Loaded(executable) => Some(*executable),
+            ExecutableRead::Loaded(loaded) => Some(*loaded),
         }
     }
 

--- a/third_party/move/mono-move/orchestrator/src/builder.rs
+++ b/third_party/move/mono-move/orchestrator/src/builder.rs
@@ -1,25 +1,27 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-//! Builds an [`Executable`] from a [`CompiledModule`] by resolving its
-//! struct/enum types and accumulating lowered functions.
+//! Builds a [`LoadedModule`] from a [`CompiledModule`] by resolving its
+//! struct/enum types, running the specializer, and packaging the result
+//! alongside the polymorphic IR.
 //!
 //! The abstract interning interface (`Interner`, `StructResolver`,
 //! `walk_sig_token`) lives in `mono-move-core`; the concrete implementation
 //! that owns the global tables is provided by `ExecutionGuard` in
 //! `mono-move-global-context`. This module drives the module-level walk
 //! (struct defs, enum defs, layout computation), delegates leaf type
-//! interning to the guard, and assembles the final `Executable`.
+//! interning to the guard, and assembles the final `LoadedModule`.
 
 use anyhow::{anyhow, bail};
 use mono_move_alloc::{ExecutableArena, ExecutableArenaPtr, GlobalArenaPtr};
 use mono_move_core::{
     types::{align_up, EMPTY_TYPE_LIST},
-    walk_sig_token, EnumType, Executable, ExecutableId, FrameLayoutInfo, Function,
-    MandatoryDependencies, MicroOp, SortedSafePointEntries, StructResolver, StructType,
-    VariantFields,
+    walk_sig_token, EnumType, Executable, ExecutableId, FrameLayoutInfo, Function, MicroOp,
+    SortedSafePointEntries, StructResolver, StructType, VariantFields,
 };
-use mono_move_global_context::{struct_info_at, ExecutionGuard, FieldLayout, InternedType};
+use mono_move_global_context::{
+    struct_info_at, ExecutionGuard, FieldLayout, InternedType, LoadedModule, MandatoryDependencies,
+};
 use move_binary_format::{
     access::ModuleAccess,
     file_format::{
@@ -29,7 +31,7 @@ use move_binary_format::{
     CompiledModule,
 };
 use shared_dsa::UnorderedMap;
-use specializer::LoweredFunction;
+use specializer::{lower_module, LoweredFunction, ModuleIR};
 
 // TODO: this is likely to change. Placeholder.
 // TODO: refactor to own CompiledModule instead of borrowing it (needed for ModuleIR cache).
@@ -174,33 +176,39 @@ impl<'a, 'guard, 'ctx> ExecutableBuilder<'a, 'guard, 'ctx> {
         self.func_ptrs[lowered.handle_idx.0 as usize] = Some(ptr);
     }
 
-    /// Runs the full build pipeline (resolve types → run specializer → add
-    /// every lowered function → finish). Use this when callers don't need to
+    /// Runs the full build pipeline (resolve types → destack → lower every
+    /// function → add it → finish). Use this when callers don't need to
     /// interleave additional work between stages.
-    pub fn build(mut self) -> anyhow::Result<Box<Executable>> {
+    pub fn build(mut self) -> anyhow::Result<Box<LoadedModule>> {
         self.resolve_types()?;
         let struct_types = self.struct_type_table();
-        let lowered =
-            specializer::destack_and_lower_module(self.module.clone(), self.guard, &struct_types)?;
+        let module_ir = specializer::destack(self.module.clone(), self.guard, &struct_types)?;
+        let lowered = lower_module(&module_ir)?;
         for lowered_fn in lowered.functions {
             self.add_function(lowered_fn);
         }
-        self.finish()
+        self.finish(module_ir)
     }
 
-    /// Finishes building the executable. Call after every function definition
-    /// has been recorded via `add_function`.
-    pub fn finish(self) -> anyhow::Result<Box<Executable>> {
+    /// Finishes building the loaded module. Call after every function
+    /// definition has been recorded via `add_function`. `module_ir` is the
+    /// polymorphic IR produced earlier in the pipeline; it is preserved on
+    /// the resulting `LoadedModule`.
+    pub fn finish(self, module_ir: ModuleIR) -> anyhow::Result<Box<LoadedModule>> {
         self.resolve_all_calls()?;
 
-        Ok(Executable::new(
+        let executable = Executable::new(
             self.id,
             self.cost,
-            self.mandatory_dependencies,
             self.structs,
             self.enums,
             self.functions,
             self.arena,
+        );
+        Ok(LoadedModule::new(
+            module_ir,
+            executable,
+            self.mandatory_dependencies,
         ))
     }
 

--- a/third_party/move/mono-move/orchestrator/src/lib.rs
+++ b/third_party/move/mono-move/orchestrator/src/lib.rs
@@ -8,19 +8,18 @@ mod builder;
 
 use anyhow::Result;
 pub use builder::ExecutableBuilder;
-use mono_move_core::Executable;
-use mono_move_global_context::ExecutionGuard;
+use mono_move_global_context::{ExecutionGuard, LoadedModule};
 use move_binary_format::CompiledModule;
 
-/// Build an executable from a compiled module.
+/// Build a loaded module from a compiled module.
 ///
 /// Orchestrates the full pipeline:
 /// 1. Resolve struct/enum types via the execution guard's interner
 /// 2. Run the specializer (destack → lower → gas instrument)
-/// 3. Assemble the executable from lowered output
+/// 3. Assemble the loaded module (IR + executable + dependencies)
 pub fn build_executable(
     guard: &ExecutionGuard<'_>,
     module: &CompiledModule,
-) -> Result<Box<Executable>> {
+) -> Result<Box<LoadedModule>> {
     ExecutableBuilder::new(guard, module).build()
 }

--- a/third_party/move/mono-move/specializer/src/lib.rs
+++ b/third_party/move/mono-move/specializer/src/lib.rs
@@ -9,4 +9,5 @@ pub mod pipeline;
 
 pub use destack::destack;
 pub use lower::{LoweredFunction, LoweredModule};
-pub use pipeline::destack_and_lower_module;
+pub use pipeline::{destack_and_lower_module, lower_module};
+pub use stackless_exec_ir::ModuleIR;

--- a/third_party/move/mono-move/specializer/src/lib.rs
+++ b/third_party/move/mono-move/specializer/src/lib.rs
@@ -9,5 +9,5 @@ pub mod pipeline;
 
 pub use destack::destack;
 pub use lower::{LoweredFunction, LoweredModule};
-pub use pipeline::{destack_and_lower_module, lower_module};
+pub use pipeline::lower_module;
 pub use stackless_exec_ir::ModuleIR;

--- a/third_party/move/mono-move/specializer/src/pipeline.rs
+++ b/third_party/move/mono-move/specializer/src/pipeline.rs
@@ -6,27 +6,27 @@
 use crate::{
     destack,
     lower::{lower_function, try_build_context, LoweredFunction, LoweredModule},
+    stackless_exec_ir::ModuleIR,
 };
 use anyhow::Result;
 use mono_move_core::{types::InternedType, Interner, MicroOpGasSchedule, FRAME_METADATA_SIZE};
 use mono_move_gas::GasInstrumentor;
 use move_binary_format::CompiledModule;
 
-/// Run the full specializer pipeline: destack → lower → gas instrument → frame layout.
+/// Lower an already-destacked [`ModuleIR`] into a [`LoweredModule`].
+///
+/// Callers that need to keep the [`ModuleIR`] alive (e.g. the executable
+/// builder, which stores it on the `LoadedModule`) should call [`destack`] and
+/// this function separately. Callers that don't can use the
+/// [`destack_and_lower_module`] wrapper.
 // TODO: extend with additional passes (e.g., monomorphization, GC safe-point layout).
-pub fn destack_and_lower_module(
-    module: CompiledModule,
-    interner: &impl Interner,
-    struct_types: &[Option<InternedType>],
-) -> Result<LoweredModule> {
-    let module_ir = destack(module, interner, struct_types)?;
-
+pub fn lower_module(module_ir: &ModuleIR) -> Result<LoweredModule> {
     let mut functions = Vec::with_capacity(module_ir.functions.len());
     for func_ir in &module_ir.functions {
         let Some(func_ir) = func_ir else {
             continue;
         };
-        let Some(ctx) = try_build_context(&module_ir, func_ir)? else {
+        let Some(ctx) = try_build_context(module_ir, func_ir)? else {
             continue;
         };
         let micro_ops = lower_function(func_ir, &ctx)?;
@@ -59,4 +59,17 @@ pub fn destack_and_lower_module(
     }
 
     Ok(LoweredModule { functions })
+}
+
+/// Run the full specializer pipeline: destack → lower → gas instrument → frame layout.
+///
+/// Drops the intermediate [`ModuleIR`]. Callers that need to keep it should
+/// call [`destack`] and [`lower_module`] directly.
+pub fn destack_and_lower_module(
+    module: CompiledModule,
+    interner: &impl Interner,
+    struct_types: &[Option<InternedType>],
+) -> Result<LoweredModule> {
+    let module_ir = destack(module, interner, struct_types)?;
+    lower_module(&module_ir)
 }

--- a/third_party/move/mono-move/specializer/src/pipeline.rs
+++ b/third_party/move/mono-move/specializer/src/pipeline.rs
@@ -4,21 +4,14 @@
 //! High-level pipeline: destack → lower → gas instrument → frame layout.
 
 use crate::{
-    destack,
     lower::{lower_function, try_build_context, LoweredFunction, LoweredModule},
     stackless_exec_ir::ModuleIR,
 };
 use anyhow::Result;
-use mono_move_core::{types::InternedType, Interner, MicroOpGasSchedule, FRAME_METADATA_SIZE};
+use mono_move_core::{MicroOpGasSchedule, FRAME_METADATA_SIZE};
 use mono_move_gas::GasInstrumentor;
-use move_binary_format::CompiledModule;
 
 /// Lower an already-destacked [`ModuleIR`] into a [`LoweredModule`].
-///
-/// Callers that need to keep the [`ModuleIR`] alive (e.g. the executable
-/// builder, which stores it on the `LoadedModule`) should call [`destack`] and
-/// this function separately. Callers that don't can use the
-/// [`destack_and_lower_module`] wrapper.
 // TODO: extend with additional passes (e.g., monomorphization, GC safe-point layout).
 pub fn lower_module(module_ir: &ModuleIR) -> Result<LoweredModule> {
     let mut functions = Vec::with_capacity(module_ir.functions.len());
@@ -59,17 +52,4 @@ pub fn lower_module(module_ir: &ModuleIR) -> Result<LoweredModule> {
     }
 
     Ok(LoweredModule { functions })
-}
-
-/// Run the full specializer pipeline: destack → lower → gas instrument → frame layout.
-///
-/// Drops the intermediate [`ModuleIR`]. Callers that need to keep it should
-/// call [`destack`] and [`lower_module`] directly.
-pub fn destack_and_lower_module(
-    module: CompiledModule,
-    interner: &impl Interner,
-    struct_types: &[Option<InternedType>],
-) -> Result<LoweredModule> {
-    let module_ir = destack(module, interner, struct_types)?;
-    lower_module(&module_ir)
 }

--- a/third_party/move/mono-move/testsuite/src/runner.rs
+++ b/third_party/move/mono-move/testsuite/src/runner.rs
@@ -58,11 +58,11 @@ pub fn run_test(steps: Vec<Step>, kind: SourceKind) -> anyhow::Result<()> {
                     storage.add_module_bytes(module.self_addr(), module.self_name(), blob.into());
 
                     // V2 path.
-                    let executable = mono_move_orchestrator::build_executable(&guard, module)
-                        .map_err(|err| anyhow!("Failed to build executable: {}", err))?;
+                    let loaded = mono_move_orchestrator::build_executable(&guard, module)
+                        .map_err(|err| anyhow!("Failed to build loaded module: {}", err))?;
                     guard
-                        .insert_executable(executable)
-                        .map_err(|err| anyhow!("Failed to insert executable: {}", err))?;
+                        .insert_loaded_module(loaded)
+                        .map_err(|err| anyhow!("Failed to insert loaded module: {}", err))?;
                 }
             },
             Step::Execute {
@@ -184,9 +184,13 @@ fn execute_function_v2(
     let id = guard.intern_address_name(address, module_name);
     let function_name = guard.intern_identifier(function_name);
     let function = guard
-        .get_executable(id)
-        .and_then(|executable| executable.get_function(function_name.into_global_arena_ptr()))
-        .unwrap_or_else(|| panic!("Failed to load function or find executable"));
+        .get_loaded_module(id)
+        .and_then(|loaded| {
+            loaded
+                .executable()
+                .get_function(function_name.into_global_arena_ptr())
+        })
+        .unwrap_or_else(|| panic!("Failed to load function or find loaded module"));
 
     let txn_ctx = NoopTransactionContext;
     let gas_meter = SimpleGasMeter::new(u64::MAX);

--- a/third_party/move/mono-move/testsuite/tests/gas_test.rs
+++ b/third_party/move/mono-move/testsuite/tests/gas_test.rs
@@ -9,14 +9,14 @@ use mono_move_global_context::{ExecutionGuard, GlobalContext};
 use mono_move_runtime::{ExecutionError, InterpreterContext};
 use move_core_types::{account_address::AccountAddress, ident_str};
 
-/// Compiles a Move module and adds it to the executable cache.
+/// Compiles a Move module and adds it to the cache.
 fn add_executable(guard: &ExecutionGuard<'_>, source: &str) {
     let modules = mono_move_testsuite::compile_move_source(source).expect("compilation failed");
     for module in &modules {
-        let executable = mono_move_orchestrator::build_executable(guard, module)
-            .expect("Building an executable should always succeed");
+        let loaded = mono_move_orchestrator::build_executable(guard, module)
+            .expect("Building a loaded module should always succeed");
         guard
-            .insert_executable(executable)
+            .insert_loaded_module(loaded)
             .expect("insert should succeed");
     }
 }
@@ -40,8 +40,12 @@ module 0x1::test {
     let id = guard.intern_address_name(&AccountAddress::ONE, ident_str!("test"));
     let fib_name = guard.intern_identifier(ident_str!("fib"));
     let fib = guard
-        .get_executable(id)
-        .and_then(|e| e.get_function(fib_name.into_global_arena_ptr()))
+        .get_loaded_module(id)
+        .and_then(|loaded| {
+            loaded
+                .executable()
+                .get_function(fib_name.into_global_arena_ptr())
+        })
         .expect("fib should exist");
 
     let txn_ctx = NoopTransactionContext;

--- a/third_party/move/mono-move/testsuite/tests/types_tests.rs
+++ b/third_party/move/mono-move/testsuite/tests/types_tests.rs
@@ -7,7 +7,8 @@ use mono_move_global_context::{Executable, ExecutionGuard, GlobalContext};
 use move_asm::assembler;
 use move_core_types::ident_str;
 
-/// Assembles a compiled module and adds it to the executable cache.
+/// Assembles a compiled module and adds it to the cache, returning the
+/// monomorphic executable view.
 fn add_executable<'guard>(guard: &'guard ExecutionGuard<'_>, source: &str) -> &'guard Executable {
     let options = assembler::Options::default();
     let module = assembler::assemble(&options, source, std::iter::empty())
@@ -15,12 +16,13 @@ fn add_executable<'guard>(guard: &'guard ExecutionGuard<'_>, source: &str) -> &'
         .left()
         .expect("Only modules are expected");
 
-    let executable = mono_move_orchestrator::build_executable(guard, &module)
-        .expect("Building an executable should always succeed");
+    let loaded = mono_move_orchestrator::build_executable(guard, &module)
+        .expect("Building a loaded module should always succeed");
 
     guard
-        .insert_executable(executable)
+        .insert_loaded_module(loaded)
         .expect("insert should succeed")
+        .executable()
 }
 
 #[test]


### PR DESCRIPTION
## Description

This PR introduces `LoadedModule` which stores both `ModuleIR` and executable functions with micro-ops. For now, it stores `Executable` but it will ultimately go away. 

Note that `LoadedModule` lives in `global-context` crate right now because `ModuleIR` is in specializer. @vineethk - any thoughts on moving this out to `core`? then `LoadedModule` can be in core and used in orchestrator or loader without external deps.

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core code-loading and caching APIs (types and lifetimes), so integration breakages or subtle cache/read-set issues are possible despite largely being a data-structure refactor.
> 
> **Overview**
> Introduces `LoadedModule` as the cache unit, bundling the polymorphic `ModuleIR` with the monomorphic `Executable` and its `MandatoryDependencies`, and updates the global executable cache/guard APIs to store and return `LoadedModule` instead of `Executable`.
> 
> Refactors module build/load flow accordingly: the orchestrator now runs `specializer::destack` to produce `ModuleIR`, lowers via the new `lower_module(&ModuleIR)` pipeline, and returns a `LoadedModule`; the loader/read-set and tests are updated to operate on `LoadedModule` and access functions via `loaded.executable()`.
> 
> Moves `MandatoryDependencies`/slot types out of `mono-move-core` (removing them from `Executable`) into `mono-move-global-context`, adds a `specializer` dependency there, and adjusts `Executable::new` to no longer take deps (and return `Self` rather than `Box<Self>`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1696c8cc3c2a3257f9b68fc5671722679b88210e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->