### PR TITLE
[mono-move] Lazy layout population

### DIFF
--- a/third_party/move/mono-move/core/src/types.rs
+++ b/third_party/move/mono-move/core/src/types.rs
@@ -56,6 +56,7 @@
 use crate::{ExecutableId, Interner};
 use mono_move_alloc::GlobalArenaPtr;
 use move_core_types::ability::AbilitySet;
+use std::sync::OnceLock;
 
 // ================================================================================================
 // Layout types
@@ -243,14 +244,21 @@ pub enum Type {
     Vector {
         elem: InternedType,
     },
-    /// Named struct with its layout. Layout is only set for fully-instantiated
-    /// structs.
+    /// Named struct with its layout. The layout slot is empty for generic
+    /// structs and for cross-module references whose layout has not yet been
+    /// populated by the loader; it is filled once via [`OnceLock::set`] when
+    /// all constituent layouts become available.
+    ///
+    /// The slot is `OnceLock`-gated so layout can be filled after interning.
+    /// Drop on arena reset is skipped (bumpalo bulk-rewinds without calling
+    /// `Drop`), which is harmless only as long as `StructLayout` owns no
+    /// non-arena memory - keep it that way.
     Struct {
         // TODO: Make this a pointer to struct type struct which holds these pointers.
         executable_id: GlobalArenaPtr<ExecutableId>,
         name: GlobalArenaPtr<str>,
         ty_args: InternedTypeList,
-        layout: Option<StructLayout>,
+        layout: OnceLock<StructLayout>,
     },
     /// Named enum. Does not store any layout information as it may change (new
     /// variant can be added during module upgrade). Enum layouts are always
@@ -289,8 +297,9 @@ impl Type {
     /// Returns the size and alignment of this type. Returns [`None`] if the
     /// size or alignment cannot be computed:
     ///   - If the type is a generic struct.
+    ///   - If the type is a struct whose layout has not yet been populated
+    ///     (e.g., a cross-module reference awaiting its loader pass).
     ///   - If the type is an unresolved type parameter.
-    /// In both cases, type substitution must run first.
     pub fn size_and_align(&self) -> Option<(Size, Alignment)> {
         Some(match self {
             // Primitives.
@@ -314,16 +323,11 @@ impl Type {
             // Function values - TODO: for now use heap pointer values.
             Type::Function { .. } => (8, 8),
 
-            // Structs: the layout must be pre-computed for all fields inline.
-            Type::Struct { layout, .. } => {
-                match layout {
-                    Some(layout) => (layout.size, layout.align),
-                    None => {
-                        // INVARIANT: If layout is unset, this struct contains
-                        // generic type arguments.
-                        return None;
-                    },
-                }
+            // Structs: the layout slot may be empty for generic structs or
+            // for cross-module references awaiting layout population.
+            Type::Struct { layout, .. } => match layout.get() {
+                Some(layout) => (layout.size, layout.align),
+                None => return None,
             },
 
             // Need type substitution to calculate the size and alignment.
@@ -334,10 +338,10 @@ impl Type {
     }
 
     /// Returns layout for a struct type, or [`None`] for non-struct types or
-    /// generic structs without a computed layout.
+    /// structs whose layout slot has not yet been populated.
     pub fn struct_layout(&self) -> Option<&StructLayout> {
         match self {
-            Type::Struct { layout, .. } => layout.as_ref(),
+            Type::Struct { layout, .. } => layout.get(),
             Type::Bool
             | Type::U8
             | Type::U16

--- a/third_party/move/mono-move/core/src/types.rs
+++ b/third_party/move/mono-move/core/src/types.rs
@@ -207,6 +207,12 @@ impl StructLayout {
     }
 }
 
+// Arena reset bulk-rewinds without running `Drop`. Layout is allowed to skip
+// drop only as long as it owns no non-arena memory. If a future field
+// introduces a heap owner (`Vec`, `String`, `Box`, etc.), this assertion turns
+// the silent leak / double-free into a compile error.
+const _: () = assert!(!std::mem::needs_drop::<StructLayout>());
+
 // ================================================================================================
 // Type enum
 // ================================================================================================

--- a/third_party/move/mono-move/global-context/src/context.rs
+++ b/third_party/move/mono-move/global-context/src/context.rs
@@ -33,7 +33,7 @@
 //!   - Trade-off: minor memory waste for lower lock contention.
 
 use crate::maintenance_config::MaintenanceConfig;
-use anyhow::Result;
+use anyhow::{bail, Result};
 use dashmap::DashMap;
 use mono_move_alloc::{GlobalArenaPool, GlobalArenaPtr, GlobalArenaShard};
 use mono_move_core::{types::StructLayout, ExecutableId, Interner};
@@ -42,6 +42,7 @@ use parking_lot::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 use std::{
     hash::{Hash, Hasher},
     marker::PhantomData,
+    sync::OnceLock,
 };
 
 // Submodules: to split implementation into smaller pieces.
@@ -358,26 +359,77 @@ impl<'ctx> ExecutionGuard<'ctx> {
         unsafe { ptr.as_ref_unchecked() }
     }
 
-    /// Interns a struct type with its layout. The field-layout slice is
-    /// allocated in the global arena.
-    pub fn intern_struct_type(
+    /// Interns a struct identity without populating its layout. The returned
+    /// pointer can be used immediately in IR, but [`Type::size_and_align`] and
+    /// [`Type::struct_layout`] will return [`None`] until [`Self::set_struct_layout`]
+    /// is called for this type. Callers using this in cross-module contexts
+    /// must tolerate the missing layout until a layout-population pass runs.
+    pub fn intern_struct_identity(
         &self,
         executable_id: GlobalArenaPtr<ExecutableId>,
         name: GlobalArenaPtr<str>,
         ty_args: InternedTypeList,
-        size: u32,
-        align: u32,
-        fields: &[FieldLayout],
     ) -> InternedType {
-        let fields_ptr = self.global_arena.alloc_slice_copy(fields);
-        let layout = StructLayout::new(size, align, fields_ptr);
         let ty = self.global_arena.alloc(Type::Struct {
             executable_id,
             name,
             ty_args,
-            layout: Some(layout),
+            layout: OnceLock::new(),
         });
         self.insert_allocated_type_pointer_internal(ty)
+    }
+
+    /// Allocates the field-layout slice in the arena, builds a [`StructLayout`]
+    /// and installs it into struct type's layout slot. Returns an error if the
+    /// type was not a struct type.
+    ///
+    /// Setting layouts concurrently is safe. Layout already stores canonical
+    /// field type pointers so is structurally identical for both threads.
+    pub fn set_struct_layout(
+        &self,
+        ty: InternedType,
+        size: u32,
+        align: u32,
+        fields: &[FieldLayout],
+    ) -> Result<()> {
+        let fields_ptr = self.global_arena.alloc_slice_copy(fields);
+        let layout = StructLayout::new(size, align, fields_ptr);
+        let result = match view_type(ty) {
+            Type::Struct { layout: slot, .. } => slot.set(layout),
+            Type::Bool
+            | Type::U8
+            | Type::U16
+            | Type::U32
+            | Type::U64
+            | Type::U128
+            | Type::U256
+            | Type::I8
+            | Type::I16
+            | Type::I32
+            | Type::I64
+            | Type::I128
+            | Type::I256
+            | Type::Address
+            | Type::Signer
+            | Type::ImmutRef { .. }
+            | Type::MutRef { .. }
+            | Type::Vector { .. }
+            | Type::Enum { .. }
+            | Type::Function { .. }
+            | Type::TypeParam { .. } => bail!("set_struct_layout called on a non-struct type"),
+        };
+        if let Err(other_layout) = result {
+            let layout = view_type(ty)
+                .struct_layout()
+                .expect("Layout was just installed");
+            debug_assert_eq!(layout.size, other_layout.size);
+            debug_assert_eq!(layout.align, other_layout.align);
+            debug_assert_eq!(
+                layout.field_layouts().len(),
+                other_layout.field_layouts().len()
+            );
+        }
+        Ok(())
     }
 
     /// Interns an enum type. Enum size/align is fixed metadata, so no

--- a/third_party/move/mono-move/global-context/src/context.rs
+++ b/third_party/move/mono-move/global-context/src/context.rs
@@ -392,10 +392,8 @@ impl<'ctx> ExecutionGuard<'ctx> {
         align: u32,
         fields: &[FieldLayout],
     ) -> Result<()> {
-        let fields_ptr = self.global_arena.alloc_slice_copy(fields);
-        let layout = StructLayout::new(size, align, fields_ptr);
-        let result = match view_type(ty) {
-            Type::Struct { layout: slot, .. } => slot.set(layout),
+        let slot = match view_type(ty) {
+            Type::Struct { layout: slot, .. } => slot,
             Type::Bool
             | Type::U8
             | Type::U16
@@ -418,16 +416,34 @@ impl<'ctx> ExecutionGuard<'ctx> {
             | Type::Function { .. }
             | Type::TypeParam { .. } => bail!("set_struct_layout called on a non-struct type"),
         };
-        if let Err(other_layout) = result {
-            let layout = view_type(ty)
-                .struct_layout()
-                .expect("Layout was just installed");
-            debug_assert_eq!(layout.size, other_layout.size);
-            debug_assert_eq!(layout.align, other_layout.align);
+
+        // Fast path: if the layout is already installed, skip the field-slice
+        // allocation entirely. A race can still leak one allocation between
+        // this check and `slot.set` below, but that is bounded and consistent
+        // with the documented arena race trade-off.
+        if slot.get().is_some() {
+            return Ok(());
+        }
+
+        let fields_ptr = self.global_arena.alloc_slice_copy(fields);
+        let layout = StructLayout::new(size, align, fields_ptr);
+        if let Err(other_layout) = slot.set(layout) {
+            let installed_layout = slot.get().expect("Layout was just installed");
+            debug_assert_eq!(installed_layout.size, other_layout.size);
+            debug_assert_eq!(installed_layout.align, other_layout.align);
             debug_assert_eq!(
-                layout.field_layouts().len(),
+                installed_layout.field_layouts().len(),
                 other_layout.field_layouts().len()
             );
+            // Layout computation is deterministic given the struct identity,
+            // so per-field offsets must match too.
+            for (installed, other) in installed_layout
+                .field_layouts()
+                .iter()
+                .zip(other_layout.field_layouts().iter())
+            {
+                debug_assert_eq!(installed.offset, other.offset);
+            }
         }
         Ok(())
     }
@@ -451,6 +467,12 @@ impl<'ctx> ExecutionGuard<'ctx> {
     /// Looks up a type previously interned from a signature token of `module`.
     /// Returns `None` if the token has not yet been interned in this module's
     /// context.
+    ///
+    /// For struct types, the returned pointer carries identity but its layout
+    /// slot may still be empty — `set_struct_layout` runs in a separate pass
+    /// after all field types are interned. Callers consuming this in cross-
+    /// module contexts must tolerate `None` from [`Type::size_and_align`] and
+    /// [`Type::struct_layout`] until the layout-population pass completes.
     pub fn try_intern_for_module(
         &self,
         token: &SignatureToken,

--- a/third_party/move/mono-move/orchestrator/src/builder.rs
+++ b/third_party/move/mono-move/orchestrator/src/builder.rs
@@ -335,14 +335,10 @@ impl<'a, 'guard, 'ctx> ExecutableBuilder<'a, 'guard, 'ctx> {
                 }
 
                 let size = align_up(offset, align);
-                let ptr = self.guard.intern_struct_type(
-                    self.id,
-                    name,
-                    EMPTY_TYPE_LIST,
-                    size,
-                    align,
-                    &fields,
-                );
+                let ptr = self
+                    .guard
+                    .intern_struct_identity(self.id, name, EMPTY_TYPE_LIST);
+                self.guard.set_struct_layout(ptr, size, align, &fields)?;
 
                 self.structs.insert(name, StructType::new(ptr));
                 Ok(ptr)


### PR DESCRIPTION
## Description

Changing struct layout field to `OnceLock` so we can set it during resolution. In theory, we can move this out of type completely and have a separate layout map, but avoiding indirection is nice as most of these will be populated eventually for all on-generics.

This set's up infra for lazy layout loading.

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core runtime type/layout metadata and introduces deferred initialization, so any missing `set_struct_layout` call or unexpected `None` handling could surface as layout/size computation failures at runtime.
> 
> **Overview**
> Enables **lazy, post-interning population of struct layouts** by replacing `Type::Struct.layout: Option<StructLayout>` with `OnceLock<StructLayout>`, so struct identity can be interned before all field layouts are available (e.g., cross-module references).
> 
> `ExecutionGuard` now exposes `intern_struct_identity` plus a new `set_struct_layout` API to allocate the field-layout slice and install the computed `StructLayout` exactly once (with race-tolerant behavior and erroring on non-struct types). Call sites in the orchestrator builder were updated to intern the identity first and then set the layout, and `Type::size_and_align`/`struct_layout` now return `None` until the slot is populated; a compile-time assertion was added to ensure `StructLayout` remains `Drop`-free under arena rewinds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33778b55ab0edb62d52afb5a0b054c25563c51dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->