### PR TITLE
[consensus] Add encrypted-txn-aware transaction shuffler

### DIFF
--- a/consensus/src/pipeline/pipeline_builder.rs
+++ b/consensus/src/pipeline/pipeline_builder.rs
@@ -742,7 +742,6 @@ impl PipelineBuilder {
             block_gas_limit,
             decryption_key,
         } = decryption_fut.await?;
-        // TODO(ibalajiarun): make sure decrypted_txns are in front of regular_txns
         let input_txns = [decrypted_txns, regular_txns].concat();
 
         tracker.start_working();

--- a/consensus/src/transaction_shuffler/mod.rs
+++ b/consensus/src/transaction_shuffler/mod.rs
@@ -97,5 +97,25 @@ pub fn create_transaction_shuffler(
             );
             Arc::new(use_case_aware::UseCaseAwareShuffler { config })
         },
+        UseCaseAndEncryptedTxnsAware {
+            sender_spread_factor,
+            platform_use_case_spread_factor,
+            user_use_case_spread_factor,
+        } => {
+            let config = use_case_aware::Config {
+                sender_spread_factor,
+                platform_use_case_spread_factor,
+                user_use_case_spread_factor,
+            };
+            info!(
+                config = ?config,
+                "Using use case and encrypted txns aware transaction shuffling."
+            );
+            Arc::new(
+                use_case_aware::encrypted_txns_aware::UseCaseAndEncryptedTxnsAwareShuffler {
+                    config,
+                },
+            )
+        },
     }
 }

--- a/consensus/src/transaction_shuffler/use_case_aware/encrypted_txns_aware.rs
+++ b/consensus/src/transaction_shuffler/use_case_aware/encrypted_txns_aware.rs
@@ -1,0 +1,313 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+use super::iterator::ShuffledTransactionIterator;
+use crate::transaction_shuffler::{use_case_aware::Config, TransactionShuffler};
+use aptos_types::transaction::{
+    signature_verified_transaction::SignatureVerifiedTransaction,
+    use_case::UseCaseAwareTransaction, BlockExecutableTransaction, SignedTransaction,
+};
+use std::fmt::Debug;
+
+pub struct UseCaseAndEncryptedTxnsAwareShuffler {
+    pub config: Config,
+}
+
+impl TransactionShuffler for UseCaseAndEncryptedTxnsAwareShuffler {
+    fn shuffle(&self, txns: Vec<SignedTransaction>) -> Vec<SignedTransaction> {
+        self.signed_transaction_iterator(txns).collect()
+    }
+
+    fn signed_transaction_iterator(
+        &self,
+        txns: Vec<SignedTransaction>,
+    ) -> Box<dyn Iterator<Item = SignedTransaction> + 'static> {
+        let (encrypted, regular): (Vec<_>, Vec<_>) = txns
+            .into_iter()
+            .partition(|t| t.payload().is_encrypted_variant());
+
+        let iter = ShuffledTransactionIterator::new(self.config.clone()).extended_with(encrypted);
+        Box::new(TwoPhaseIterator {
+            inner: iter,
+            pending_regular: regular,
+        })
+    }
+
+    fn signature_verified_transaction_iterator(
+        &self,
+        txns: Vec<SignatureVerifiedTransaction>,
+    ) -> Box<dyn Iterator<Item = SignatureVerifiedTransaction> + 'static> {
+        let (encrypted, regular): (Vec<_>, Vec<_>) = txns.into_iter().partition(|t| {
+            t.try_as_signed_user_txn()
+                .is_some_and(|txn| txn.payload().is_encrypted_variant())
+        });
+
+        let iter = ShuffledTransactionIterator::new(self.config.clone()).extended_with(encrypted);
+        Box::new(TwoPhaseIterator {
+            inner: iter,
+            pending_regular: regular,
+        })
+    }
+}
+
+struct TwoPhaseIterator<Txn> {
+    inner: ShuffledTransactionIterator<Txn>,
+    pending_regular: Vec<Txn>,
+}
+
+impl<Txn: UseCaseAwareTransaction + Debug> Iterator for TwoPhaseIterator<Txn> {
+    type Item = Txn;
+
+    fn next(&mut self) -> Option<Txn> {
+        if let Some(txn) = self.inner.next() {
+            return Some(txn);
+        }
+        if !self.pending_regular.is_empty() {
+            self.inner
+                .extend_with(std::mem::take(&mut self.pending_regular));
+            self.inner.next()
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::transaction_shuffler::use_case_aware::iterator::ShuffledTransactionIterator;
+    use aptos_types::transaction::use_case::UseCaseKey;
+    use move_core_types::account_address::AccountAddress;
+
+    #[derive(Clone, Copy)]
+    struct Account(u8);
+
+    impl Account {
+        fn as_account_address(self) -> AccountAddress {
+            let mut addr = [0u8; 32];
+            addr[31] = self.0;
+            AccountAddress::new(addr)
+        }
+    }
+
+    #[derive(Clone, Copy)]
+    enum Contract {
+        Platform,
+        User(u8),
+    }
+
+    struct TestTxn {
+        contract: Contract,
+        sender: Account,
+        encrypted: bool,
+        original_idx: usize,
+    }
+
+    impl Debug for TestTxn {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(
+                f,
+                "t{}:{}a{}",
+                self.original_idx,
+                if self.encrypted { "E" } else { "" },
+                self.sender.0
+            )
+        }
+    }
+
+    impl UseCaseAwareTransaction for TestTxn {
+        fn parse_sender(&self) -> AccountAddress {
+            self.sender.as_account_address()
+        }
+
+        fn parse_use_case(&self) -> UseCaseKey {
+            match self.contract {
+                Contract::Platform => UseCaseKey::Platform,
+                Contract::User(c) => UseCaseKey::ContractAddress(Account(c).as_account_address()),
+            }
+        }
+    }
+
+    const A1: Account = Account(1);
+    const A2: Account = Account(2);
+    const A3: Account = Account(3);
+
+    const C1: Contract = Contract::User(0xF1);
+    const C2: Contract = Contract::User(0xF2);
+    const PP: Contract = Contract::Platform;
+
+    fn make_txns(specs: &[(Contract, Account, bool)]) -> Vec<TestTxn> {
+        specs
+            .iter()
+            .enumerate()
+            .map(|(i, &(contract, sender, encrypted))| TestTxn {
+                contract,
+                sender,
+                encrypted,
+                original_idx: i,
+            })
+            .collect()
+    }
+
+    fn two_phase_shuffle(config: Config, txns: Vec<TestTxn>) -> Vec<usize> {
+        let (encrypted, regular): (Vec<_>, Vec<_>) = txns.into_iter().partition(|t| t.encrypted);
+
+        let iter = ShuffledTransactionIterator::new(config).extended_with(encrypted);
+        let mut two_phase = TwoPhaseIterator {
+            inner: iter,
+            pending_regular: regular,
+        };
+
+        std::iter::from_fn(move || two_phase.next())
+            .map(|t| t.original_idx)
+            .collect()
+    }
+
+    fn plain_shuffle(config: Config, txns: Vec<TestTxn>) -> Vec<usize> {
+        ShuffledTransactionIterator::new(config)
+            .extended_with(txns)
+            .map(|t| t.original_idx)
+            .collect()
+    }
+
+    #[test]
+    fn test_encrypted_before_regular() {
+        let config = Config {
+            sender_spread_factor: 0,
+            platform_use_case_spread_factor: 0,
+            user_use_case_spread_factor: 0,
+        };
+        let txns = make_txns(&[
+            (C1, A1, true),
+            (C2, A2, false),
+            (C1, A3, true),
+            (C2, A1, false),
+        ]);
+
+        let order = two_phase_shuffle(config, txns);
+        assert_eq!(order, vec![0, 2, 1, 3]);
+    }
+
+    #[test]
+    fn test_cross_boundary_sender_spread() {
+        let config = Config {
+            sender_spread_factor: 2,
+            platform_use_case_spread_factor: 0,
+            user_use_case_spread_factor: 0,
+        };
+        let txns = make_txns(&[
+            (C1, A1, true),  // 0: encrypted, A1
+            (C2, A2, false), // 1: regular, A2
+            (C1, A3, false), // 2: regular, A3
+            (C2, A1, false), // 3: regular, A1
+        ]);
+
+        let order = two_phase_shuffle(config.clone(), txns);
+        // Encrypted phase: [0] (A1 at output pos 0, try_delay_till = 0+1+2 = 3)
+        // Regular phase starts at output pos 1.
+        // A2(1) at pos 1: ok. A3(2) at pos 2: ok. A1(3) at pos 3: try_delay_till=3, ok.
+        assert_eq!(order, vec![0, 1, 2, 3]);
+
+        let txns = make_txns(&[
+            (C1, A1, true),  // 0: encrypted, A1
+            (C1, A1, false), // 1: regular, A1
+            (C2, A2, false), // 2: regular, A2
+        ]);
+
+        let order = two_phase_shuffle(config, txns);
+        // Encrypted: [0] (A1 at pos 0, try_delay_till=3)
+        // Regular: A1(1) blocked until pos 3, A2(2) at pos 1. A1(1) force-popped at pos 2.
+        assert_eq!(order, vec![0, 2, 1]);
+    }
+
+    #[test]
+    fn test_use_case_spread_within_groups() {
+        let config = Config {
+            sender_spread_factor: 0,
+            platform_use_case_spread_factor: 0,
+            user_use_case_spread_factor: 1,
+        };
+        let txns = make_txns(&[
+            (C1, A1, true), // 0
+            (C1, A2, true), // 1
+            (C2, A3, true), // 2
+        ]);
+
+        let order = two_phase_shuffle(config, txns);
+        assert_eq!(order, vec![0, 2, 1]);
+    }
+
+    #[test]
+    fn test_empty_encrypted() {
+        let config = Config {
+            sender_spread_factor: 1,
+            platform_use_case_spread_factor: 0,
+            user_use_case_spread_factor: 0,
+        };
+
+        let order = two_phase_shuffle(
+            config.clone(),
+            make_txns(&[(C1, A1, false), (C2, A1, false), (C1, A2, false)]),
+        );
+        let expected = plain_shuffle(
+            config,
+            make_txns(&[(C1, A1, false), (C2, A1, false), (C1, A2, false)]),
+        );
+        assert_eq!(order, expected);
+    }
+
+    #[test]
+    fn test_all_encrypted() {
+        let config = Config {
+            sender_spread_factor: 1,
+            platform_use_case_spread_factor: 0,
+            user_use_case_spread_factor: 0,
+        };
+
+        let order = two_phase_shuffle(
+            config.clone(),
+            make_txns(&[(C1, A1, true), (C2, A1, true), (C1, A2, true)]),
+        );
+        let expected = plain_shuffle(
+            config,
+            make_txns(&[(C1, A1, true), (C2, A1, true), (C1, A2, true)]),
+        );
+        assert_eq!(order, expected);
+    }
+
+    #[test]
+    fn test_output_is_permutation_and_encrypted_first() {
+        let config = Config {
+            sender_spread_factor: 2,
+            platform_use_case_spread_factor: 1,
+            user_use_case_spread_factor: 1,
+        };
+        let encrypted_original_indices = [0usize, 1, 5];
+        let regular_original_indices = [2usize, 3, 4];
+        let txns = make_txns(&[
+            (PP, A1, true),  // 0
+            (C1, A2, true),  // 1
+            (C2, A3, false), // 2
+            (PP, A1, false), // 3
+            (C1, A2, false), // 4
+            (C2, A3, true),  // 5
+        ]);
+
+        let order = two_phase_shuffle(config, txns);
+
+        let mut sorted = order.clone();
+        sorted.sort();
+        assert_eq!(sorted, vec![0, 1, 2, 3, 4, 5]);
+
+        let max_encrypted_pos = order
+            .iter()
+            .position(|idx| regular_original_indices.contains(idx))
+            .unwrap();
+        for idx in &order[..max_encrypted_pos] {
+            assert!(
+                encrypted_original_indices.contains(idx),
+                "Non-encrypted txn {idx} found in encrypted prefix"
+            );
+        }
+    }
+}

--- a/consensus/src/transaction_shuffler/use_case_aware/iterator.rs
+++ b/consensus/src/transaction_shuffler/use_case_aware/iterator.rs
@@ -35,6 +35,10 @@ where
         self
     }
 
+    pub(super) fn extend_with(&mut self, txns: impl IntoIterator<Item = Txn>) {
+        self.input_queue.extend(txns);
+    }
+
     pub(super) fn select_next_txn(&mut self) -> Option<Txn> {
         let ret = self.select_next_txn_inner();
         if ret.is_some() {

--- a/consensus/src/transaction_shuffler/use_case_aware/mod.rs
+++ b/consensus/src/transaction_shuffler/use_case_aware/mod.rs
@@ -14,6 +14,7 @@ pub(crate) mod types;
 pub(crate) mod utils;
 
 pub(crate) mod delayed_queue;
+pub(crate) mod encrypted_txns_aware;
 #[cfg(test)]
 mod tests;
 

--- a/types/src/on_chain_config/execution_config.rs
+++ b/types/src/on_chain_config/execution_config.rs
@@ -230,6 +230,11 @@ pub enum TransactionShufflerType {
         platform_use_case_spread_factor: usize,
         user_use_case_spread_factor: usize,
     },
+    UseCaseAndEncryptedTxnsAware {
+        sender_spread_factor: usize,
+        platform_use_case_spread_factor: usize,
+        user_use_case_spread_factor: usize,
+    },
 }
 
 impl TransactionShufflerType {
@@ -248,6 +253,10 @@ impl TransactionShufflerType {
             | Self::SenderAwareV2(_)
             | Self::DeprecatedFairness => None,
             Self::UseCaseAware {
+                user_use_case_spread_factor,
+                ..
+            }
+            | Self::UseCaseAndEncryptedTxnsAware {
                 user_use_case_spread_factor,
                 ..
             } => Some(*user_use_case_spread_factor),


### PR DESCRIPTION
## Summary
- Adds `UseCaseAndEncryptedTxnsAwareShuffler`, a new `TransactionShuffler` implementation that ensures decrypted (encrypted) transactions stay at the front of the block while preserving use-case and sender spread factors.
- Uses a two-phase approach with a single `ShuffledTransactionIterator`: encrypted txns shuffled first, then regular txns fed into the same iterator so spread state (sender/use-case delay) carries across the boundary.
- Adds `UseCaseAndEncryptedTxnsAware` variant to `TransactionShufflerType` on-chain config enum, selectable via governance.

## Test plan
- [x] 6 new unit tests covering: encrypted-first ordering, cross-boundary sender spread, use-case spread within groups, empty encrypted, all encrypted, permutation correctness
- [x] All 10 existing `use_case_aware` shuffler tests pass unchanged
- [x] `cargo clippy` clean
- [x] Smoke test with encrypted transactions enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)