### PR TITLE
[forge][experiment] Tighter binary classifier: threshold=5%, failed_weight=0, window=100×

### DIFF
--- a/.github/workflows/docker-build-test.yaml
+++ b/.github/workflows/docker-build-test.yaml
@@ -270,7 +270,7 @@ jobs:
       GIT_SHA: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
       FORGE_TEST_SUITE: realistic_env_max_load
       IMAGE_TAG: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
-      FORGE_RUNNER_DURATION_SECS: 480
+      FORGE_RUNNER_DURATION_SECS: 1800
       COMMENT_HEADER: forge-e2e
       # Use the cache ID as the Forge namespace so we can limit Forge test concurrency on k8s, since Forge
       # test lifecycle is separate from that of GHA. This protects us from the case where many Forge tests are triggered

--- a/consensus/src/round_manager.rs
+++ b/consensus/src/round_manager.rs
@@ -488,6 +488,26 @@ impl RoundManager {
                 .expect("Sending to a self loopback unbounded channel cannot fail");
         }
 
+        // HACK: Simulate slow proposer. The last validator (by ordered index)
+        // delays their proposal by 1s 10% of the time (round % 10 == 0).
+        let proposal_delay = {
+            let author = self.proposal_generator.author();
+            let ordered = self.epoch_state.verifier.get_ordered_account_addresses();
+            let n = ordered.len();
+            let idx = ordered.iter().position(|a| *a == author);
+            if matches!(idx, Some(i) if i >= n - 1) && new_round_event.round.is_multiple_of(10) {
+                Some(std::time::Duration::from_millis(1000))
+            } else {
+                None
+            }
+        };
+        if let Some(delay) = proposal_delay {
+            warn!(
+                self.new_log(LogEvent::NewRound),
+                "HACK: delaying proposal for round {} by {:?}", new_round_event.round, delay
+            );
+        }
+
         // If the current proposer is the leading, try to propose a regular block if not opt proposed already
         if is_current_proposer
             && self
@@ -501,6 +521,9 @@ impl RoundManager {
             let safety_rules = self.safety_rules.clone();
             let proposer_election = self.proposer_election.clone();
             tokio::spawn(async move {
+                if let Some(delay) = proposal_delay {
+                    tokio::time::sleep(delay).await;
+                }
                 if let Err(e) = monitor!(
                     "generate_and_send_proposal",
                     Self::generate_and_send_proposal(
@@ -1453,6 +1476,19 @@ impl RoundManager {
 
         let parent = parent_vote.vote_data().proposed().clone();
         let opt_proposal_round = parent.round() + 1;
+        // HACK: Simulate slow opt proposer too.
+        let opt_proposal_delay = {
+            let author = self.proposal_generator.author();
+            let ordered = self.epoch_state.verifier.get_ordered_account_addresses();
+            let n = ordered.len();
+            let idx = ordered.iter().position(|a| *a == author);
+            if matches!(idx, Some(i) if i >= n - 1) && opt_proposal_round.is_multiple_of(10) {
+                Some(std::time::Duration::from_millis(1000))
+            } else {
+                None
+            }
+        };
+
         if self
             .proposer_election
             .is_valid_proposer(self.proposal_generator.author(), opt_proposal_round)
@@ -1474,6 +1510,9 @@ impl RoundManager {
             let proposal_generator = self.proposal_generator.clone();
             let proposer_election = self.proposer_election.clone();
             tokio::spawn(async move {
+                if let Some(delay) = opt_proposal_delay {
+                    tokio::time::sleep(delay).await;
+                }
                 if let Err(e) = monitor!(
                     "generate_and_send_opt_proposal",
                     Self::generate_and_send_opt_proposal(

--- a/testsuite/forge-cli/src/suites/land_blocking.rs
+++ b/testsuite/forge-cli/src/suites/land_blocking.rs
@@ -29,7 +29,7 @@ pub(crate) fn get_land_blocking_test(
     let test = match test_name {
         "land_blocking" | "realistic_env_max_load" => {
             realistic_env_max_load_test(duration, test_cmd, 7, 0, 0)
-                .with_duration_override(Duration::from_secs(1200))
+                .with_duration_override(Duration::from_secs(900))
         },
         "compat" => compat(),
         "framework_upgrade" => framework_upgrade(),

--- a/testsuite/forge-cli/src/suites/land_blocking.rs
+++ b/testsuite/forge-cli/src/suites/land_blocking.rs
@@ -28,7 +28,8 @@ pub(crate) fn get_land_blocking_test(
 ) -> Option<ForgeConfig> {
     let test = match test_name {
         "land_blocking" | "realistic_env_max_load" => {
-            realistic_env_max_load_test(duration, test_cmd, 7, 0, 3)
+            realistic_env_max_load_test(duration, test_cmd, 7, 0, 0)
+                .with_duration_override(Duration::from_secs(1200))
         },
         "compat" => compat(),
         "framework_upgrade" => framework_upgrade(),

--- a/testsuite/forge-cli/src/suites/realistic_environment.rs
+++ b/testsuite/forge-cli/src/suites/realistic_environment.rs
@@ -440,30 +440,18 @@ pub(crate) fn realistic_env_max_load_test(
     }
 
     // Create the test
-    let mempool_backlog = if ha_proxy { 14000 } else { 19000 };
     ForgeConfig::default()
         .with_initial_validator_count(NonZeroUsize::new(num_validators).unwrap())
         .with_initial_fullnode_count(num_vfns)
         .add_network_test(wrap_with_realistic_env(num_validators, TwoTrafficsTest {
             inner_traffic: EmitJobRequest::default()
-                .mode(EmitJobMode::MaxLoad { mempool_backlog })
+                .mode(EmitJobMode::ConstTps { tps: 4000 })
                 .init_gas_price_multiplier(20),
-            inner_success_criteria: SuccessCriteria::new(
-                if ha_proxy {
-                    7000
-                } else if long_running {
-                    // This is for forge stable
-                    11000
-                } else {
-                    // During land time we want to be less strict, otherwise we flaky fail
-                    10000
-                },
-            ),
+            inner_success_criteria: SuccessCriteria::new(3500),
         }))
         .with_genesis_helm_config_fn(Arc::new(move |helm_values| {
-            // Have single epoch change in land blocking, and a few on long-running
-            helm_values["chain"]["epoch_duration_secs"] =
-                (if long_running { 600 } else { 300 }).into();
+            // No epoch change so measurements are stable.
+            helm_values["chain"]["epoch_duration_secs"] = (24 * 3600).into();
             helm_values["chain"]["on_chain_consensus_config"] =
                 serde_yaml::to_value(OnChainConsensusConfig::default_for_genesis())
                     .expect("must serialize");

--- a/testsuite/forge-cli/src/suites/realistic_environment.rs
+++ b/testsuite/forge-cli/src/suites/realistic_environment.rs
@@ -460,7 +460,7 @@ pub(crate) fn realistic_env_max_load_test(
             //   sampling noise).
             // - failed_weight: 1 -> 0 so a validator classified failed is excluded
             //   entirely from leader selection instead of leaking 1/N share.
-            // - proposer_window_num_validators_multiplier: 10 -> 50 so the larger
+            // - proposer_window_num_validators_multiplier: 10 -> 100 so the larger
             //   observation window stabilizes the failure-rate estimate.
             let mut consensus_config = OnChainConsensusConfig::default_for_genesis();
             if let OnChainConsensusConfig::V5 {
@@ -474,7 +474,7 @@ pub(crate) fn realistic_env_max_load_test(
                         inactive_weight: 10,
                         failed_weight: 0,           // bumped from 1: classified-failed -> banned
                         failure_threshold_percent: 5, // bumped from 10: clear of V6's true 10%
-                        proposer_window_num_validators_multiplier: 50, // bumped from 10
+                        proposer_window_num_validators_multiplier: 100, // bumped from 10
                         voter_window_num_validators_multiplier: 1,
                         weight_by_voting_power: true,
                         use_history_from_previous_epoch_max_count: 5,

--- a/testsuite/forge-cli/src/suites/realistic_environment.rs
+++ b/testsuite/forge-cli/src/suites/realistic_environment.rs
@@ -20,8 +20,9 @@ use aptos_forge::{
     TransactionType,
 };
 use aptos_sdk::types::on_chain_config::{
-    BlockGasLimitType, FeatureFlag, Features, OnChainChunkyDKGConfig, OnChainConsensusConfig,
-    OnChainExecutionConfig, OnChainRandomnessConfig, TransactionShufflerType,
+    BlockGasLimitType, ConsensusAlgorithmConfig, FeatureFlag, Features, LeaderReputationType,
+    OnChainChunkyDKGConfig, OnChainConsensusConfig, OnChainExecutionConfig, OnChainRandomnessConfig,
+    ProposerAndVoterConfig, ProposerElectionType, TransactionShufflerType,
 };
 use aptos_testcases::{
     load_vs_perf_benchmark::{LoadVsPerfBenchmark, TransactionWorkload, Workloads},
@@ -452,9 +453,36 @@ pub(crate) fn realistic_env_max_load_test(
         .with_genesis_helm_config_fn(Arc::new(move |helm_values| {
             // No epoch change so measurements are stable.
             helm_values["chain"]["epoch_duration_secs"] = (24 * 3600).into();
+            // Tighter binary classifier for slow leaders:
+            // - failure_threshold_percent: 10 -> 5 so a validator with a true 10%
+            //   failure rate clearly exceeds the threshold (instead of sitting on
+            //   the boundary, which causes oscillation between active/failed under
+            //   sampling noise).
+            // - failed_weight: 1 -> 0 so a validator classified failed is excluded
+            //   entirely from leader selection instead of leaking 1/N share.
+            // - proposer_window_num_validators_multiplier: 10 -> 50 so the larger
+            //   observation window stabilizes the failure-rate estimate.
+            let mut consensus_config = OnChainConsensusConfig::default_for_genesis();
+            if let OnChainConsensusConfig::V5 {
+                alg: ConsensusAlgorithmConfig::JolteonV2 { ref mut main, .. },
+                ..
+            } = consensus_config
+            {
+                main.proposer_election_type = ProposerElectionType::LeaderReputation(
+                    LeaderReputationType::ProposerAndVoterV2(ProposerAndVoterConfig {
+                        active_weight: 1000,
+                        inactive_weight: 10,
+                        failed_weight: 0,           // bumped from 1: classified-failed -> banned
+                        failure_threshold_percent: 5, // bumped from 10: clear of V6's true 10%
+                        proposer_window_num_validators_multiplier: 50, // bumped from 10
+                        voter_window_num_validators_multiplier: 1,
+                        weight_by_voting_power: true,
+                        use_history_from_previous_epoch_max_count: 5,
+                    }),
+                );
+            }
             helm_values["chain"]["on_chain_consensus_config"] =
-                serde_yaml::to_value(OnChainConsensusConfig::default_for_genesis())
-                    .expect("must serialize");
+                serde_yaml::to_value(consensus_config).expect("must serialize");
             helm_values["chain"]["on_chain_execution_config"] =
                 serde_yaml::to_value(OnChainExecutionConfig::default_for_genesis())
                     .expect("must serialize");

--- a/testsuite/forge/src/config.rs
+++ b/testsuite/forge/src/config.rs
@@ -10,7 +10,7 @@ use aptos_config::config::{
     OverrideNodeConfig,
 };
 use aptos_framework::ReleaseBundle;
-use std::{num::NonZeroUsize, sync::Arc};
+use std::{num::NonZeroUsize, sync::Arc, time::Duration};
 
 /// A PFN deployment configuration. Each entry maps to one helm release via the PFN deployer.
 pub struct PfnDeployment {
@@ -77,6 +77,9 @@ pub struct ForgeConfig {
 
     /// URL to download the chunky DKG public parameters blob into the validator init-container
     pub public_parameters_blob_url: Option<String>,
+
+    /// Override the CLI-specified test duration
+    pub duration_override: Option<Duration>,
 }
 
 impl ForgeConfig {
@@ -204,6 +207,11 @@ impl ForgeConfig {
 
     pub fn with_public_parameters_blob_url(mut self, url: impl Into<String>) -> Self {
         self.public_parameters_blob_url = Some(url.into());
+        self
+    }
+
+    pub fn with_duration_override(mut self, duration: Duration) -> Self {
+        self.duration_override = Some(duration);
         self
     }
 
@@ -448,6 +456,7 @@ impl Default for ForgeConfig {
             retain_debug_logs: false,
             digest_key_blob_url: None,
             public_parameters_blob_url: None,
+            duration_override: None,
         }
     }
 }

--- a/testsuite/forge/src/runner.rs
+++ b/testsuite/forge/src/runner.rs
@@ -311,7 +311,7 @@ impl<'cfg, F: Factory> Forge<'cfg, F> {
                 &initial_version,
                 &genesis_version,
                 self.tests.genesis_config.as_ref(),
-                self.global_duration + Duration::from_secs(NAMESPACE_CLEANUP_DURATION_BUFFER_SECS),
+                self.tests.duration_override.unwrap_or(self.global_duration) + Duration::from_secs(NAMESPACE_CLEANUP_DURATION_BUFFER_SECS),
                 self.tests.genesis_helm_config_fn.clone(),
                 self.tests.build_node_helm_config_fn(retain_debug_logs),
                 self.tests.existing_db_tag.clone(),
@@ -343,12 +343,16 @@ impl<'cfg, F: Factory> Forge<'cfg, F> {
 
             let logs_location = swarm.logs_location();
             let swarm = Arc::new(tokio::sync::RwLock::new(swarm));
+            let effective_duration = self
+                .tests
+                .duration_override
+                .unwrap_or(self.global_duration);
             for test in self.filter_tests(&self.tests.network_tests) {
                 let network_ctx = NetworkContext::new(
                     CoreContext::from_rng(&mut rng),
                     swarm.clone(),
                     &mut report,
-                    self.global_duration,
+                    effective_duration,
                     self.tests.emit_job_request.clone(),
                     self.tests.success_criteria.clone(),
                 );


### PR DESCRIPTION
## Summary

A/B experiment branch. Stacks on baseline #19330. Tunes the existing ProposerAndVoter binary classifier so it reliably bans a slow validator. **No heuristic changes** — pure config tuning.

## Changes (all in genesis OnChainConsensusConfig)

- **`failure_threshold_percent: 10 → 5`** — V6's injected real failure rate is 10%, exactly equal to the default threshold. Sampling noise made V6 cross >10% in only ~26-38% of windows; the rest of the time V6 sat at boundary, classified active. Lowering to 5% makes V6's 10% clearly exceed under any window size.
- **`failed_weight: 1 → 0`** — when a validator IS classified failed, default weight 1 still leaks ~1/(N·active_weight + 1) share. Setting to 0 fully excludes.
- **`proposer_window_num_validators_multiplier: 10 → 100`** — larger window for statistical stability (100 proposals per validator gives reliable failure-rate estimates).

## Background

The original window-only experiment showed +19% p90 regression because V6's true failure rate sits exactly at the default threshold — the larger window stabilized V6 *near* threshold rather than above it. Lowering the threshold and zeroing the failed-weight is the principled fix.

The companion window-only PR (#19574) confirms this: with default `threshold=10%, failed_weight=1`, bumping window 10×→100× gives essentially zero improvement.

## Pairs with

- #19330 — baseline
- #19574 — window-only control (~no effect)
- #19567 — heuristic-only (latency-weighted, default classifier)
- #19341 — combined (classifier + heuristic) ← **best result**

## Forge results (run 2026-04-28 21:14-21:28 UTC, 14 min, 4k TPS, 1 slow validator)

Commit-accepted latency vs baseline #19330:

| | p50 | p75 | p90 | p99 |
|---|---|---|---|---|
| #19330 baseline | 0.209 | 0.298 | 0.658 | 1.268 |
| **this PR** | 0.191 | 0.255 | **0.337** | 1.207 |
| Δ vs baseline | −8.5% | −14% | **−49%** | −5% |

The strict classifier roughly halves p90 (0.658 → 0.337) by reliably excluding V6 from leader selection. p99 only drops 5% — the tail still has occasional timeouts during boundary detection / brief misclassification windows.

## Test plan

- [x] Run forge `land_blocking`, compare commit p50/p75/p90/p99 against baseline #19330
- [ ] Verify V6 selection share drops to near-zero (target: ≤0.1% of total proposals)

⚠ Draft / experiment — not for merge to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)