### PR TITLE
[consensus][experiment] Latency-weighted leader reputation, default classifier

### DIFF
--- a/.github/workflows/docker-build-test.yaml
+++ b/.github/workflows/docker-build-test.yaml
@@ -270,7 +270,7 @@ jobs:
       GIT_SHA: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
       FORGE_TEST_SUITE: realistic_env_max_load
       IMAGE_TAG: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
-      FORGE_RUNNER_DURATION_SECS: 480
+      FORGE_RUNNER_DURATION_SECS: 1800
       COMMENT_HEADER: forge-e2e
       # Use the cache ID as the Forge namespace so we can limit Forge test concurrency on k8s, since Forge
       # test lifecycle is separate from that of GHA. This protects us from the case where many Forge tests are triggered

--- a/consensus/src/dag/bootstrap.rs
+++ b/consensus/src/dag/bootstrap.rs
@@ -49,7 +49,7 @@ use aptos_types::{
     epoch_state::EpochState,
     on_chain_config::{
         AnchorElectionMode, DagConsensusConfigV1,
-        LeaderReputationType::{ProposerAndVoter, ProposerAndVoterV2},
+        LeaderReputationType::{ProposerAndVoter, ProposerAndVoterV2, ProposerAndVoterV3},
         OnChainJWKConsensusConfig, OnChainRandomnessConfig, ProposerAndVoterConfig,
         ValidatorTxnConfig,
     },
@@ -478,6 +478,24 @@ impl DagBootstrapper {
                             commit_events,
                             self.build_leader_reputation_components(config),
                         )
+                    },
+                    // V3 is V2 plus the latency-weighted gate. The DAG path does not yet
+                    // wire `LatencyWeightedHeuristic` into its anchor-election plumbing,
+                    // so we use the V3 base config and ignore the latency-weighted toggle.
+                    // TODO(consensus): plumb LatencyWeightedHeuristic into DAG when needed.
+                    ProposerAndVoterV3(config) => {
+                        let base = &config.base;
+                        let commit_events = self
+                            .storage
+                            .get_latest_k_committed_events(
+                                std::cmp::max(
+                                    base.proposer_window_num_validators_multiplier,
+                                    base.voter_window_num_validators_multiplier,
+                                ) as u64
+                                    * self.epoch_state.verifier.len() as u64,
+                            )
+                            .expect("Failed to read commit events from storage");
+                        (commit_events, self.build_leader_reputation_components(base))
                     },
                     ProposerAndVoter(_) => unreachable!("unsupported mode"),
                 };

--- a/consensus/src/epoch_manager.rs
+++ b/consensus/src/epoch_manager.rs
@@ -14,7 +14,7 @@ use crate::{
     liveness::{
         cached_proposer_election::CachedProposerElection,
         leader_reputation::{
-            extract_epoch_to_proposers, AptosDBBackend, LeaderReputation,
+            extract_epoch_to_proposers, AptosDBBackend, LatencyWeightedHeuristic, LeaderReputation,
             ProposerAndVoterHeuristic, ReputationHeuristic,
         },
         proposal_generator::{
@@ -320,37 +320,40 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
                 Arc::new(RotatingProposer::new(vec![proposer], *contiguous_rounds))
             },
             ProposerElectionType::LeaderReputation(leader_reputation_type) => {
-                let (
-                    heuristic,
-                    window_size,
-                    weight_by_voting_power,
-                    use_history_from_previous_epoch_max_count,
-                ) = match &leader_reputation_type {
-                    LeaderReputationType::ProposerAndVoter(proposer_and_voter_config)
-                    | LeaderReputationType::ProposerAndVoterV2(proposer_and_voter_config) => {
-                        let proposer_window_size = proposers.len()
-                            * proposer_and_voter_config.proposer_window_num_validators_multiplier;
-                        let voter_window_size = proposers.len()
-                            * proposer_and_voter_config.voter_window_num_validators_multiplier;
-                        let heuristic: Box<dyn ReputationHeuristic> =
-                            Box::new(ProposerAndVoterHeuristic::new(
-                                self.author,
-                                proposer_and_voter_config.active_weight,
-                                proposer_and_voter_config.inactive_weight,
-                                proposer_and_voter_config.failed_weight,
-                                proposer_and_voter_config.failure_threshold_percent,
-                                voter_window_size,
-                                proposer_window_size,
-                                leader_reputation_type.use_reputation_window_from_stale_end(),
-                            ));
-                        (
-                            heuristic,
-                            std::cmp::max(proposer_window_size, voter_window_size),
-                            proposer_and_voter_config.weight_by_voting_power,
-                            proposer_and_voter_config.use_history_from_previous_epoch_max_count,
-                        )
-                    },
+                // Pull base parameters and the latency-weighted gate out of the on-chain
+                // config in a version-agnostic way. V3 carries the latency settings; V1/V2
+                // return false for `use_latency_weighted` so behavior is unchanged for them.
+                let params = leader_reputation_type.proposer_and_voter_params();
+                let proposer_and_voter_config = params.base;
+                let proposer_window_size = proposers.len()
+                    * proposer_and_voter_config.proposer_window_num_validators_multiplier;
+                let voter_window_size = proposers.len()
+                    * proposer_and_voter_config.voter_window_num_validators_multiplier;
+                let inner_heuristic = ProposerAndVoterHeuristic::new(
+                    self.author,
+                    proposer_and_voter_config.active_weight,
+                    proposer_and_voter_config.inactive_weight,
+                    proposer_and_voter_config.failed_weight,
+                    proposer_and_voter_config.failure_threshold_percent,
+                    voter_window_size,
+                    proposer_window_size,
+                    leader_reputation_type.use_reputation_window_from_stale_end(),
+                );
+                let heuristic: Box<dyn ReputationHeuristic> = if params.use_latency_weighted {
+                    // Decode milli-multiplier (1000 = 1.0×) deterministically.
+                    let multiplier = params.latency_weight_multiplier_milli as f64 / 1000.0;
+                    Box::new(LatencyWeightedHeuristic::new(
+                        inner_heuristic,
+                        proposer_and_voter_config.active_weight,
+                        multiplier,
+                    ))
+                } else {
+                    Box::new(inner_heuristic)
                 };
+                let window_size = std::cmp::max(proposer_window_size, voter_window_size);
+                let weight_by_voting_power = proposer_and_voter_config.weight_by_voting_power;
+                let use_history_from_previous_epoch_max_count =
+                    proposer_and_voter_config.use_history_from_previous_epoch_max_count;
 
                 let seek_len = onchain_config.leader_reputation_exclude_round() as usize
                     + onchain_config.max_failed_authors_to_store()

--- a/consensus/src/epoch_manager.rs
+++ b/consensus/src/epoch_manager.rs
@@ -102,10 +102,9 @@ use aptos_types::{
     jwks::SupportedOIDCProviders,
     on_chain_config::{
         ChunkyDKGConfigMoveStruct, ChunkyDKGConfigSeqNum, Features, OnChainChunkyDKGConfig,
-        OnChainConfigPayload, OnChainConfigProvider,
-        OnChainConsensusConfig, OnChainExecutionConfig, OnChainJWKConsensusConfig,
-        OnChainRandomnessConfig, ProposerElectionType, RandomnessConfigMoveStruct,
-        RandomnessConfigSeqNum, ValidatorSet,
+        OnChainConfigPayload, OnChainConfigProvider, OnChainConsensusConfig,
+        OnChainExecutionConfig, OnChainJWKConsensusConfig, OnChainRandomnessConfig,
+        ProposerElectionType, RandomnessConfigMoveStruct, RandomnessConfigSeqNum, ValidatorSet,
     },
     randomness::{RandKeys, WvufPP, WVUF},
     secret_sharing::SecretShareConfig,

--- a/consensus/src/epoch_manager.rs
+++ b/consensus/src/epoch_manager.rs
@@ -101,8 +101,8 @@ use aptos_types::{
     epoch_state::EpochState,
     jwks::SupportedOIDCProviders,
     on_chain_config::{
-        ChunkyDKGConfigMoveStruct, ChunkyDKGConfigSeqNum, Features, LeaderReputationType,
-        OnChainChunkyDKGConfig, OnChainConfigPayload, OnChainConfigProvider,
+        ChunkyDKGConfigMoveStruct, ChunkyDKGConfigSeqNum, Features, OnChainChunkyDKGConfig,
+        OnChainConfigPayload, OnChainConfigProvider,
         OnChainConsensusConfig, OnChainExecutionConfig, OnChainJWKConsensusConfig,
         OnChainRandomnessConfig, ProposerElectionType, RandomnessConfigMoveStruct,
         RandomnessConfigSeqNum, ValidatorSet,

--- a/consensus/src/epoch_manager.rs
+++ b/consensus/src/epoch_manager.rs
@@ -345,6 +345,7 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
                         inner_heuristic,
                         proposer_and_voter_config.active_weight,
                         multiplier,
+                        params.latency_warmup_rounds,
                     ))
                 } else {
                     Box::new(inner_heuristic)

--- a/consensus/src/liveness/leader_reputation.rs
+++ b/consensus/src/liveness/leader_reputation.rs
@@ -552,6 +552,157 @@ impl ReputationHeuristic for ProposerAndVoterHeuristic {
     }
 }
 
+/// A heuristic that wraps `ProposerAndVoterHeuristic` but additionally scales active-validator
+/// weights by their historical round-time performance.  Validators that have been proposing
+/// fast rounds (i.e. collected quorum quickly) get a proportionally higher chance of being
+/// selected as leader, while validators with slow round times get a lower chance.
+///
+/// Concretely, for every active validator we compute the mean interval between consecutive
+/// committed blocks in the history window, splitting each successful pair 50/50 between the
+/// two adjacent proposers and attributing timeout-spanning gaps in full to the failed
+/// proposers (using `failed_proposer_indices`). The weight is then:
+///
+///   active_weight * (max_mean_round_time_us / validator_mean_round_time_us)^multiplier
+///
+/// Inactive / failed validators keep their base weights unchanged.
+/// If a validator has fewer than `MIN_OBSERVATIONS` entries the base active weight is used
+/// for that validator. The scaling ratio is clamped at `MAX_LATENCY_RATIO` to prevent one
+/// anomalously-fast validator from monopolizing leader selection.
+pub struct LatencyWeightedHeuristic {
+    inner: ProposerAndVoterHeuristic,
+    active_weight: u64,
+    multiplier: f64,
+}
+
+/// Minimum number of round-time observations needed before a validator is scaled by the
+/// latency-weighted heuristic; below this we fall back to the base active weight.
+const MIN_OBSERVATIONS: usize = 2;
+
+/// Hard ceiling on the per-validator scaling ratio (`max_mean / val_mean`) to bound the
+/// boost a fast validator can receive over the slowest one. Prevents over-concentration
+/// when one validator's mean is anomalously low.
+const MAX_LATENCY_RATIO: f64 = 10.0;
+
+impl LatencyWeightedHeuristic {
+    pub fn new(inner: ProposerAndVoterHeuristic, active_weight: u64, multiplier: f64) -> Self {
+        Self {
+            inner,
+            active_weight,
+            multiplier: if multiplier > 0.0 { multiplier } else { 1.0 },
+        }
+    }
+
+    /// Compute per-proposer round-time observations from the history.
+    ///
+    /// History is ordered newest-first: `history[0]` is the latest block.
+    /// For each consecutive pair `(newer, older)` within the same epoch we compute
+    /// `interval = newer.proposed_time() - older.proposed_time()` and attribute it as follows:
+    /// * If `newer.failed_proposer_indices()` is empty the pair represents a clean
+    ///   consecutive-round commit: split the interval 50/50 between `newer.proposer()` and
+    ///   `older.proposer()`. Both contributed to closing the round (the older proposed it,
+    ///   the newer aggregated votes and built the next proposal), so each absorbs half.
+    /// * If `newer.failed_proposer_indices()` is non-empty the gap absorbed one or more
+    ///   timeouts: divide the full interval equally among the failed proposers (resolved via
+    ///   `epoch_to_candidates`) and attribute none of it to `newer`/`older`. The healthy
+    ///   adjacent proposers should not be penalized for absorbing someone else's timeout.
+    fn compute_round_times(
+        history: &[NewBlockEvent],
+        epoch_to_candidates: &HashMap<u64, Vec<Author>>,
+    ) -> HashMap<Author, Vec<u64>> {
+        let mut round_times: HashMap<Author, Vec<u64>> = HashMap::new();
+        for i in 0..history.len().saturating_sub(1) {
+            let newer = &history[i];
+            let older = &history[i + 1];
+            // Only compute within the same epoch to avoid epoch-boundary outliers.
+            if newer.epoch() != older.epoch() {
+                continue;
+            }
+            let interval = newer.proposed_time().saturating_sub(older.proposed_time());
+            if interval == 0 {
+                continue;
+            }
+
+            let failed = newer.failed_proposer_indices();
+            if failed.is_empty() {
+                // Successful pair: 50/50 split between the two adjacent proposers.
+                let half = interval / 2;
+                if half > 0 {
+                    round_times.entry(newer.proposer()).or_default().push(half);
+                    round_times.entry(older.proposer()).or_default().push(half);
+                }
+            } else {
+                // Timeout-spanning pair: attribute the full gap to the failed proposer(s).
+                let candidates = match epoch_to_candidates.get(&newer.epoch()) {
+                    Some(c) => c,
+                    None => continue,
+                };
+                let per_failure = interval / failed.len() as u64;
+                if per_failure > 0 {
+                    for &idx in failed {
+                        if let Some(author) = candidates.get(idx as usize) {
+                            round_times.entry(*author).or_default().push(per_failure);
+                        }
+                    }
+                }
+            }
+        }
+        round_times
+    }
+}
+
+impl ReputationHeuristic for LatencyWeightedHeuristic {
+    fn get_weights(
+        &self,
+        epoch: u64,
+        epoch_to_candidates: &HashMap<u64, Vec<Author>>,
+        history: &[NewBlockEvent],
+    ) -> Vec<u64> {
+        let base_weights = self.inner.get_weights(epoch, epoch_to_candidates, history);
+
+        let round_times = Self::compute_round_times(history, epoch_to_candidates);
+
+        // Per-validator mean round time, computed only for validators with enough data.
+        let means: HashMap<Author, u64> = round_times
+            .iter()
+            .filter(|(_, v)| v.len() >= MIN_OBSERVATIONS)
+            .map(|(a, v)| (*a, v.iter().sum::<u64>() / v.len() as u64))
+            .collect();
+
+        // No validator has enough data — fall back to base weights.
+        if means.is_empty() {
+            return base_weights;
+        }
+
+        let max_mean = *means.values().max().expect("means is non-empty");
+        // Degenerate case: every observed mean is zero. Fall back to base weights.
+        if max_mean == 0 {
+            return base_weights;
+        }
+
+        epoch_to_candidates[&epoch]
+            .iter()
+            .zip(base_weights.iter())
+            .map(|(author, &base)| {
+                // Only adjust the weight for validators that received the active weight.
+                if base != self.active_weight {
+                    return base;
+                }
+                match means.get(author) {
+                    Some(&val_mean) if val_mean > 0 => {
+                        // Scale by (max_mean / val_mean)^multiplier, clamped.
+                        let ratio = (max_mean as f64 / val_mean as f64)
+                            .min(MAX_LATENCY_RATIO)
+                            .powf(self.multiplier);
+                        (self.active_weight as f64 * ratio) as u64
+                    },
+                    // Per-validator fallback: insufficient observations → keep base weight.
+                    _ => base,
+                }
+            })
+            .collect()
+    }
+}
+
 /// Committed history based proposer election implementation that could help bias towards
 /// successful leaders to help improve performance.
 pub struct LeaderReputation {

--- a/consensus/src/liveness/leader_reputation.rs
+++ b/consensus/src/liveness/leader_reputation.rs
@@ -601,6 +601,11 @@ pub struct LatencyWeightedHeuristic {
     inner: ProposerAndVoterHeuristic,
     active_weight: u64,
     multiplier: f64,
+    /// Skip the latency-weighted scaling (behave as inner ProposerAndVoter) until the
+    /// latest event in the history window has reached this round. 0 = activate immediately.
+    /// Used for forge A/B verification: run a clean baseline phase before the heuristic
+    /// kicks in. Production should set 0.
+    warmup_rounds: u64,
     /// Carry-forward state: last computed weight factor per author (guarded for &self
     /// access). Mutated only inside `get_weights`.
     last_factor: Mutex<HashMap<Author, f64>>,
@@ -617,11 +622,17 @@ const MIN_OBSERVATIONS: usize = 2;
 const MAX_LATENCY_RATIO: f64 = 10.0;
 
 impl LatencyWeightedHeuristic {
-    pub fn new(inner: ProposerAndVoterHeuristic, active_weight: u64, multiplier: f64) -> Self {
+    pub fn new(
+        inner: ProposerAndVoterHeuristic,
+        active_weight: u64,
+        multiplier: f64,
+        warmup_rounds: u64,
+    ) -> Self {
         Self {
             inner,
             active_weight,
             multiplier: if multiplier > 0.0 { multiplier } else { 1.0 },
+            warmup_rounds,
             last_factor: Mutex::new(HashMap::new()),
         }
     }
@@ -692,6 +703,17 @@ impl ReputationHeuristic for LatencyWeightedHeuristic {
         history: &[NewBlockEvent],
     ) -> Vec<u64> {
         let base_weights = self.inner.get_weights(epoch, epoch_to_candidates, history);
+
+        // Warmup gate: until the latest history event has reached `warmup_rounds`,
+        // behave as plain ProposerAndVoter (no latency scaling). This is a forge-only
+        // A/B verification knob; production sets warmup_rounds=0 (activate immediately).
+        // Determinism: every validator sees the same `history`, so they all gate identically.
+        if self.warmup_rounds > 0 {
+            let latest_round = history.first().map(|e| e.round()).unwrap_or(0);
+            if latest_round < self.warmup_rounds {
+                return base_weights;
+            }
+        }
 
         let round_times = Self::compute_round_times(history, epoch_to_candidates);
 

--- a/consensus/src/liveness/leader_reputation.rs
+++ b/consensus/src/liveness/leader_reputation.rs
@@ -729,8 +729,7 @@ impl ReputationHeuristic for LatencyWeightedHeuristic {
                         // (max(1.0) clamps the ratio), validators above median are
                         // penalized by 1 / ratio^multiplier.
                         let ratio = (val_mean as f64 / median as f64)
-                            .max(1.0)
-                            .min(MAX_LATENCY_RATIO);
+                            .clamp(1.0, MAX_LATENCY_RATIO);
                         let f = 1.0 / ratio.powf(self.multiplier);
                         // Persist for carry-forward when this validator next has no obs.
                         last_factor.insert(*author, f);

--- a/consensus/src/liveness/leader_reputation.rs
+++ b/consensus/src/liveness/leader_reputation.rs
@@ -553,34 +553,67 @@ impl ReputationHeuristic for ProposerAndVoterHeuristic {
 }
 
 /// A heuristic that wraps `ProposerAndVoterHeuristic` but additionally scales active-validator
-/// weights by their historical round-time performance.  Validators that have been proposing
-/// fast rounds (i.e. collected quorum quickly) get a proportionally higher chance of being
-/// selected as leader, while validators with slow round times get a lower chance.
+/// weights down based on their historical round-time performance. Validators with slow round
+/// times (i.e. those that take longer to produce a committed block, including timeouts
+/// attributed to them via `failed_proposer_indices`) get a proportionally lower chance of
+/// being selected as leader. Healthy validators are not boosted — they keep their base
+/// active weight.
 ///
-/// Concretely, for every active validator we compute the mean interval between consecutive
-/// committed blocks in the history window, splitting each successful pair 50/50 between the
-/// two adjacent proposers and attributing timeout-spanning gaps in full to the failed
-/// proposers (using `failed_proposer_indices`). The weight is then:
+/// ## Penalty formula
 ///
-///   active_weight * (max_mean_round_time_us / validator_mean_round_time_us)^multiplier
+/// For every active validator we compute the mean interval between consecutive committed
+/// blocks in the history window:
+/// * Successful pairs are split 50/50 between the two adjacent proposers.
+/// * Timeout-spanning gaps are attributed in full to the failed proposers
+///   (via `failed_proposer_indices`).
 ///
-/// Inactive / failed validators keep their base weights unchanged.
-/// If a validator has fewer than `MIN_OBSERVATIONS` entries the base active weight is used
-/// for that validator. The scaling ratio is clamped at `MAX_LATENCY_RATIO` to prevent one
-/// anomalously-fast validator from monopolizing leader selection.
+/// We use the **median** of all observed per-validator means as the reference point. The
+/// per-validator weight is:
+///
+///   factor = 1.0 / max(1.0, val_mean / median_mean).clamp(_, MAX_LATENCY_RATIO).powf(multiplier)
+///   weight = active_weight * factor
+///
+/// Properties:
+/// * Validators at or below the median: `factor = 1.0` (no penalty, no boost). This makes
+///   the heuristic robust to small natural variation between healthy validators — at higher
+///   multipliers, transient blips on a fast validator no longer cliff its weight.
+/// * Validators above the median: penalized by `(val_mean / median_mean)^-multiplier`.
+///   The slowest validator (which used to get the **base** weight under the old `max_mean /
+///   val_mean` formula) now gets the **lowest** weight — closer to the original intent.
+/// * Penalty ratio is clamped at `MAX_LATENCY_RATIO` to bound the suppression for a single
+///   anomalously-slow validator.
+///
+/// ## Carry-forward for validators with no observations
+///
+/// A validator with `< MIN_OBSERVATIONS` round-time samples in the window does NOT fall back
+/// to the base active weight (the previous behavior). Instead, we apply the **last computed
+/// factor** for that validator (stored in `last_factor`). This breaks the oscillation cycle
+/// where a successfully-suppressed slow validator would pop back to full weight as soon as
+/// our successful suppression denied it observations:
+///
+///   * fresh observations → recompute factor, store it
+///   * no fresh observations → carry-forward the previous factor
+///   * never seen before → factor = 1.0 (benefit of doubt for newly-rotated-in validators)
+///
+/// State is per-epoch (the heuristic is reconstructed on epoch change), so cross-epoch
+/// rotation is naturally handled.
 pub struct LatencyWeightedHeuristic {
     inner: ProposerAndVoterHeuristic,
     active_weight: u64,
     multiplier: f64,
+    /// Carry-forward state: last computed weight factor per author (guarded for &self
+    /// access). Mutated only inside `get_weights`.
+    last_factor: Mutex<HashMap<Author, f64>>,
 }
 
 /// Minimum number of round-time observations needed before a validator is scaled by the
-/// latency-weighted heuristic; below this we fall back to the base active weight.
+/// latency-weighted heuristic; below this we apply the carry-forward factor (or 1.0 for
+/// validators we have never observed).
 const MIN_OBSERVATIONS: usize = 2;
 
-/// Hard ceiling on the per-validator scaling ratio (`max_mean / val_mean`) to bound the
-/// boost a fast validator can receive over the slowest one. Prevents over-concentration
-/// when one validator's mean is anomalously low.
+/// Hard ceiling on the per-validator scaling ratio (`val_mean / median_mean`) used to
+/// bound how aggressively a single anomalously-slow validator can be suppressed. With
+/// multiplier=2.0 and MAX_LATENCY_RATIO=10, the minimum factor is 1/100 = 0.01.
 const MAX_LATENCY_RATIO: f64 = 10.0;
 
 impl LatencyWeightedHeuristic {
@@ -589,6 +622,7 @@ impl LatencyWeightedHeuristic {
             inner,
             active_weight,
             multiplier: if multiplier > 0.0 { multiplier } else { 1.0 },
+            last_factor: Mutex::new(HashMap::new()),
         }
     }
 
@@ -668,39 +702,65 @@ impl ReputationHeuristic for LatencyWeightedHeuristic {
             .map(|(a, v)| (*a, v.iter().sum::<u64>() / v.len() as u64))
             .collect();
 
-        // No validator has enough data — fall back to base weights.
-        if means.is_empty() {
-            return base_weights;
-        }
+        // Median of observed means is the reference point. Below median: no penalty.
+        // Above median: penalty proportional to ratio. We use median (rather than max)
+        // so that the slowest validator gets the LARGEST penalty rather than the base
+        // weight, and so that small variations among healthy validators do not
+        // exponentially amplify (the failure mode that made the old `max_mean / val_mean`
+        // formula fragile at multiplier > 2).
+        let median_mean = compute_median(&means);
 
-        let max_mean = *means.values().max().expect("means is non-empty");
-        // Degenerate case: every observed mean is zero. Fall back to base weights.
-        if max_mean == 0 {
-            return base_weights;
-        }
+        let mut last_factor = self.last_factor.lock();
 
         epoch_to_candidates[&epoch]
             .iter()
             .zip(base_weights.iter())
             .map(|(author, &base)| {
                 // Only adjust the weight for validators that received the active weight.
+                // Inactive / failed-classified validators keep their base weight (the
+                // inner classifier is already handling those).
                 if base != self.active_weight {
                     return base;
                 }
-                match means.get(author) {
-                    Some(&val_mean) if val_mean > 0 => {
-                        // Scale by (max_mean / val_mean)^multiplier, clamped.
-                        let ratio = (max_mean as f64 / val_mean as f64)
-                            .min(MAX_LATENCY_RATIO)
-                            .powf(self.multiplier);
-                        (self.active_weight as f64 * ratio) as u64
+
+                let factor = match (median_mean, means.get(author)) {
+                    (Some(median), Some(&val_mean)) if median > 0 && val_mean > 0 => {
+                        // Asymmetric penalty: validators at or below median are unchanged
+                        // (max(1.0) clamps the ratio), validators above median are
+                        // penalized by 1 / ratio^multiplier.
+                        let ratio = (val_mean as f64 / median as f64)
+                            .max(1.0)
+                            .min(MAX_LATENCY_RATIO);
+                        let f = 1.0 / ratio.powf(self.multiplier);
+                        // Persist for carry-forward when this validator next has no obs.
+                        last_factor.insert(*author, f);
+                        f
                     },
-                    // Per-validator fallback: insufficient observations → keep base weight.
-                    _ => base,
-                }
+                    // No fresh observations (or degenerate median): apply carry-forward
+                    // factor if we have one for this validator, else 1.0 (benefit of doubt
+                    // for never-before-seen / newly-rotated-in validators).
+                    _ => last_factor.get(author).copied().unwrap_or(1.0),
+                };
+
+                (self.active_weight as f64 * factor) as u64
             })
             .collect()
     }
+}
+
+/// Median of the observed per-validator means. `None` if there are no observations.
+fn compute_median(means: &HashMap<Author, u64>) -> Option<u64> {
+    if means.is_empty() {
+        return None;
+    }
+    let mut vals: Vec<u64> = means.values().copied().collect();
+    vals.sort_unstable();
+    let n = vals.len();
+    Some(if n.is_multiple_of(2) {
+        (vals[n / 2 - 1] + vals[n / 2]) / 2
+    } else {
+        vals[n / 2]
+    })
 }
 
 /// Committed history based proposer election implementation that could help bias towards

--- a/consensus/src/liveness/leader_reputation.rs
+++ b/consensus/src/liveness/leader_reputation.rs
@@ -728,8 +728,7 @@ impl ReputationHeuristic for LatencyWeightedHeuristic {
                         // Asymmetric penalty: validators at or below median are unchanged
                         // (max(1.0) clamps the ratio), validators above median are
                         // penalized by 1 / ratio^multiplier.
-                        let ratio = (val_mean as f64 / median as f64)
-                            .clamp(1.0, MAX_LATENCY_RATIO);
+                        let ratio = (val_mean as f64 / median as f64).clamp(1.0, MAX_LATENCY_RATIO);
                         let f = 1.0 / ratio.powf(self.multiplier);
                         // Persist for carry-forward when this validator next has no obs.
                         last_factor.insert(*author, f);
@@ -755,11 +754,13 @@ fn compute_median(means: &HashMap<Author, u64>) -> Option<u64> {
     let mut vals: Vec<u64> = means.values().copied().collect();
     vals.sort_unstable();
     let n = vals.len();
-    Some(if n.is_multiple_of(2) {
-        (vals[n / 2 - 1] + vals[n / 2]) / 2
-    } else {
-        vals[n / 2]
-    })
+    Some(
+        if n.is_multiple_of(2) {
+            (vals[n / 2 - 1] + vals[n / 2]) / 2
+        } else {
+            vals[n / 2]
+        },
+    )
 }
 
 /// Committed history based proposer election implementation that could help bias towards

--- a/consensus/src/liveness/leader_reputation_test.rs
+++ b/consensus/src/liveness/leader_reputation_test.rs
@@ -915,31 +915,107 @@ fn test_latency_weighted_empty_history_falls_back_to_base() {
 
 #[test]
 fn test_latency_weighted_max_ratio_clamp() {
-    // V0 makes many fast successful proposals (small mean) while V1 is attributed multiple
-    // large failure gaps (huge mean). The raw scaling ratio (max_mean / V0_mean) is ~1000x;
-    // it must be clamped at MAX_LATENCY_RATIO = 10x → V0's weight tops out at 10 * 1000.
-    let validators: Vec<Author> = (0..2).map(|_| Author::random()).collect();
+    // Three validators, all classified active. V1 has a huge mean from absorbing
+    // failure attributions, while V0 and V2 have small means from successful pairs.
+    // The raw penalty ratio (V1_mean / median_mean) is much larger than
+    // MAX_LATENCY_RATIO=10 and must be clamped → V1 weight floors at
+    // active_weight / 10 = 100 (with multiplier=1.0). V0 and V2 stay at base 1000.
+    let validators: Vec<Author> = (0..3).map(|_| Author::random()).collect();
     let epoch_to_validators = HashMap::from([(0u64, validators.clone())]);
 
-    // History (newest first): V0 successfully proposes a series of fast rounds, then three
-    // huge gaps each attributed to V1 via failed_proposer_indices.
+    // History (newest first):
+    //   - 3 huge V1-failure attributions (gap ≈ 10000 each) — pushes V1 mean way up.
+    //   - 3 V1 successful proposals at small intervals — keeps V1 under the 50%
+    //     failure threshold so it stays classified active.
+    //   - 6 alternating V0/V2 successful proposals at small intervals — both V0 and
+    //     V2 accumulate enough small-mean observations to set the median.
     let history = vec![
-        make_block_event(validators[0], 0, 10, 30_000, vec![1]), // V1 failure, gap = 10000
-        make_block_event(validators[0], 0, 8, 20_000, vec![1]),  // V1 failure, gap = 10000
-        make_block_event(validators[0], 0, 6, 10_000, vec![1]),  // V1 failure, gap = 9990
-        make_block_event(validators[0], 0, 4, 10, vec![]),
-        make_block_event(validators[0], 0, 3, 5, vec![]),
+        make_block_event(validators[0], 0, 18, 1_030_000, vec![1]),
+        make_block_event(validators[0], 0, 16, 1_020_000, vec![1]),
+        make_block_event(validators[0], 0, 14, 1_010_000, vec![1]),
+        make_block_event(validators[1], 0, 12, 1_000_030, vec![]),
+        make_block_event(validators[1], 0, 11, 1_000_020, vec![]),
+        make_block_event(validators[1], 0, 10, 1_000_010, vec![]),
+        make_block_event(validators[2], 0, 9, 1_000_005, vec![]),
+        make_block_event(validators[0], 0, 8, 1_000_000, vec![]),
+        make_block_event(validators[2], 0, 7, 999_995, vec![]),
+        make_block_event(validators[0], 0, 6, 999_990, vec![]),
+        make_block_event(validators[2], 0, 5, 999_985, vec![]),
+        make_block_event(validators[0], 0, 4, 999_980, vec![]),
     ];
 
     let heuristic = make_latency_weighted_heuristic(validators[0]);
     let weights = heuristic.get_weights(0, &epoch_to_validators, &history);
 
-    // V0's raw ratio would be massive (V1_mean ~10000 / V0_mean ~2 = 5000x); clamp pins it
-    // to MAX_LATENCY_RATIO = 10. V0 weight must equal active_weight * 10 = 10_000.
+    // V0, V2 (healthy, near median): no penalty, weight = active_weight = 1000.
     assert_eq!(
-        weights[0], 10_000,
-        "expected V0 weight clamped at 10x active_weight; got {:?}",
+        weights[0], 1000,
+        "expected V0 to keep base active_weight; got {:?}",
         weights,
+    );
+    assert_eq!(
+        weights[2], 1000,
+        "expected V2 to keep base active_weight; got {:?}",
+        weights,
+    );
+    // V1 (very slow): penalty clamped at MAX_LATENCY_RATIO=10, multiplier=1.0
+    // → minimum factor = 1/10 → weight = active_weight / 10 = 100.
+    assert_eq!(
+        weights[1], 100,
+        "expected V1 penalty clamped at 1/10 of active_weight; got {:?}",
+        weights,
+    );
+}
+
+#[test]
+fn test_latency_weighted_carry_forward_for_unobserved_validator() {
+    // Verify carry-forward semantics. First call: V1 has slow observations and gets
+    // penalized. Second call: V1 has too few observations to recompute → must retain
+    // the previous penalty rather than jumping back to base weight (which would
+    // create the oscillation that the carry-forward is designed to prevent).
+    let validators: Vec<Author> = (0..2).map(|_| Author::random()).collect();
+    let epoch_to_validators = HashMap::from([(0u64, validators.clone())]);
+
+    // First call: V0 and V1 alternate as successful proposers; one gap is attributed
+    // to V1 via failed_proposer_indices. V1 has a single failure (3 proposals
+    // succeed, 1 fails → 25% < 50% threshold → active) but its mean is still
+    // dominated by the 4500µs failure attribution → meaningful penalty.
+    let history_with_obs = vec![
+        make_block_event(validators[0], 0, 8, 5000, vec![1]),
+        make_block_event(validators[1], 0, 6, 500, vec![]),
+        make_block_event(validators[0], 0, 5, 100, vec![]),
+        make_block_event(validators[1], 0, 4, 50, vec![]),
+        make_block_event(validators[0], 0, 3, 25, vec![]),
+        make_block_event(validators[1], 0, 2, 10, vec![]),
+    ];
+    let heuristic = make_latency_weighted_heuristic(validators[0]);
+    let weights1 = heuristic.get_weights(0, &epoch_to_validators, &history_with_obs);
+
+    // V1 (slow) is below base; V0 (healthy, below median) stays at base.
+    assert_eq!(weights1[0], 1000, "V0 base preserved in first call; got {:?}", weights1);
+    assert!(
+        weights1[1] < 1000,
+        "V1 should be penalized in first call; got {:?}",
+        weights1,
+    );
+    let v1_first_weight = weights1[1];
+
+    // Second call: just one pair → both V0 and V1 get only 1 round-time observation
+    // (below MIN_OBSERVATIONS=2). Both fall through to carry-forward. Both are still
+    // classified active because they have a successful proposal in this window.
+    let history_no_v1_obs = vec![
+        make_block_event(validators[1], 0, 1, 100, vec![]),
+        make_block_event(validators[0], 0, 0, 50, vec![]),
+    ];
+    let weights2 = heuristic.get_weights(0, &epoch_to_validators, &history_no_v1_obs);
+
+    // V0's stored factor was 1.0 → carry-forward restores base.
+    assert_eq!(weights2[0], 1000, "V0 carry-forward at base; got {:?}", weights2);
+    // V1's stored factor was the first-call penalty → must be preserved, NOT reset.
+    assert_eq!(
+        weights2[1], v1_first_weight,
+        "carry-forward must preserve V1's penalty; got weights {:?}, expected V1={}",
+        weights2, v1_first_weight,
     );
 }
 

--- a/consensus/src/liveness/leader_reputation_test.rs
+++ b/consensus/src/liveness/leader_reputation_test.rs
@@ -992,7 +992,11 @@ fn test_latency_weighted_carry_forward_for_unobserved_validator() {
     let weights1 = heuristic.get_weights(0, &epoch_to_validators, &history_with_obs);
 
     // V1 (slow) is below base; V0 (healthy, below median) stays at base.
-    assert_eq!(weights1[0], 1000, "V0 base preserved in first call; got {:?}", weights1);
+    assert_eq!(
+        weights1[0], 1000,
+        "V0 base preserved in first call; got {:?}",
+        weights1
+    );
     assert!(
         weights1[1] < 1000,
         "V1 should be penalized in first call; got {:?}",
@@ -1010,7 +1014,11 @@ fn test_latency_weighted_carry_forward_for_unobserved_validator() {
     let weights2 = heuristic.get_weights(0, &epoch_to_validators, &history_no_v1_obs);
 
     // V0's stored factor was 1.0 → carry-forward restores base.
-    assert_eq!(weights2[0], 1000, "V0 carry-forward at base; got {:?}", weights2);
+    assert_eq!(
+        weights2[0], 1000,
+        "V0 carry-forward at base; got {:?}",
+        weights2
+    );
     // V1's stored factor was the first-call penalty → must be preserved, NOT reset.
     assert_eq!(
         weights2[1], v1_first_weight,

--- a/consensus/src/liveness/leader_reputation_test.rs
+++ b/consensus/src/liveness/leader_reputation_test.rs
@@ -2,7 +2,8 @@
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use super::leader_reputation::{
-    extract_epoch_to_proposers_impl, AptosDBBackend, ProposerAndVoterHeuristic,
+    extract_epoch_to_proposers_impl, AptosDBBackend, LatencyWeightedHeuristic,
+    ProposerAndVoterHeuristic,
 };
 use crate::liveness::{
     leader_reputation::{
@@ -761,4 +762,205 @@ fn test_extract_epoch_to_proposers_impl() {
         )
         .unwrap()
     );
+}
+
+/// #### LatencyWeightedHeuristic tests ####
+
+/// Build a `NewBlockEvent` with the given proposer, timestamp, round, epoch, and failed
+/// proposer indices. Other fields are set to deterministic defaults.
+fn make_block_event(
+    proposer: Author,
+    epoch: u64,
+    round: u64,
+    timestamp_us: u64,
+    failed_proposer_indices: Vec<u64>,
+) -> NewBlockEvent {
+    NewBlockEvent::new(
+        AccountAddress::ZERO,
+        epoch,
+        round,
+        round,
+        BitVec::with_num_bits(1).into(),
+        proposer,
+        failed_proposer_indices,
+        timestamp_us,
+    )
+}
+
+/// Build a `LatencyWeightedHeuristic` wrapping a `ProposerAndVoterHeuristic` configured so
+/// that all candidates with successful proposals receive `active_weight = 1000`.
+fn make_latency_weighted_heuristic(self_author: Author) -> LatencyWeightedHeuristic {
+    // Wide windows + low failure threshold so test fixtures do not accidentally trigger the
+    // failed/inactive branches in the inner heuristic — we want to exercise the latency
+    // scaling on top of `active_weight`.
+    let inner = ProposerAndVoterHeuristic::new(self_author, 1000, 10, 1, 50, 100, 100, false);
+    LatencyWeightedHeuristic::new(inner, 1000, 1.0)
+}
+
+#[test]
+fn test_latency_weighted_50_50_split_equal_intervals() {
+    // With four validators and four successful blocks at uniform 100µs intervals, every
+    // validator's mean is identical, so weights collapse to `active_weight`.
+    let validators: Vec<Author> = (0..4).map(|_| Author::random()).collect();
+    let epoch_to_validators = HashMap::from([(0u64, validators.clone())]);
+
+    // History is newest-first: rounds 4, 3, 2, 1 at timestamps 400, 300, 200, 100.
+    let history = vec![
+        make_block_event(validators[3], 0, 4, 400, vec![]),
+        make_block_event(validators[2], 0, 3, 300, vec![]),
+        make_block_event(validators[1], 0, 2, 200, vec![]),
+        make_block_event(validators[0], 0, 1, 100, vec![]),
+    ];
+
+    let heuristic = make_latency_weighted_heuristic(validators[0]);
+    let weights = heuristic.get_weights(0, &epoch_to_validators, &history);
+
+    // All means equal → ratio is 1 → all weights stay at active_weight = 1000.
+    assert_eq!(weights, vec![1000, 1000, 1000, 1000]);
+}
+
+#[test]
+fn test_latency_weighted_failure_attributed_to_failed_proposer() {
+    // Three validators V0, V1, V2. V1 (index 1) fails round 3; V2 commits round 4 to rescue.
+    // The 600µs gap between V0's commit (round 2) and V2's commit (round 4) absorbs V1's
+    // timeout and must be attributed to V1, not to V2.
+    let validators: Vec<Author> = (0..3).map(|_| Author::random()).collect();
+    let epoch_to_validators = HashMap::from([(0u64, validators.clone())]);
+
+    // Newest-first.
+    let history = vec![
+        make_block_event(validators[2], 0, 6, 1000, vec![]), // round 6
+        make_block_event(validators[1], 0, 5, 900, vec![]),  // round 5 (V1 succeeds here)
+        make_block_event(validators[0], 0, 4, 800, vec![]),  // round 4
+        make_block_event(validators[2], 0, 4, 700, vec![1]), // round 4 rescue, V1 failed round 3
+        make_block_event(validators[0], 0, 2, 100, vec![]),  // round 2
+    ];
+
+    let heuristic = make_latency_weighted_heuristic(validators[0]);
+    let weights = heuristic.get_weights(0, &epoch_to_validators, &history);
+
+    // V1 should have the largest mean (absorbed the 600µs failure entry) and therefore the
+    // smallest weight. V0 and V2 should be boosted relative to V1.
+    assert!(weights[1] < weights[0]);
+    assert!(weights[1] < weights[2]);
+}
+
+#[test]
+fn test_latency_weighted_multiple_failed_proposers_split_gap() {
+    // Two failed proposers in a single gap: the interval is split equally between them.
+    let validators: Vec<Author> = (0..4).map(|_| Author::random()).collect();
+    let epoch_to_validators = HashMap::from([(0u64, validators.clone())]);
+
+    // Round 5 commits with both V1 (idx 1) and V2 (idx 2) listed as failed; gap of 1000µs.
+    let history = vec![
+        make_block_event(validators[3], 0, 6, 1100, vec![]),
+        make_block_event(validators[0], 0, 5, 1000, vec![1, 2]),
+        make_block_event(validators[3], 0, 2, 0, vec![]),
+    ];
+
+    let heuristic = make_latency_weighted_heuristic(validators[0]);
+    let weights = heuristic.get_weights(0, &epoch_to_validators, &history);
+
+    // Both failed proposers should be down-weighted relative to V0/V3.
+    assert!(weights[1] < weights[0]);
+    assert!(weights[2] < weights[0]);
+    assert!(weights[1] < weights[3]);
+    assert!(weights[2] < weights[3]);
+}
+
+#[test]
+fn test_latency_weighted_per_validator_fallback() {
+    // V0 has no observations (it is in the candidate set but never appears in history).
+    // The heuristic must NOT fall back globally just because V0 lacks data — V1 should
+    // still be scaled relative to V2 even though V0 has nothing to compute from.
+    let validators: Vec<Author> = (0..3).map(|_| Author::random()).collect();
+    let epoch_to_validators = HashMap::from([(0u64, validators.clone())]);
+
+    // V1 has fast intervals (~50µs/entry under 50/50), V2 has slow intervals (~500µs/entry).
+    // V0 never appears as proposer.
+    let history = vec![
+        make_block_event(validators[2], 0, 10, 5000, vec![]),
+        make_block_event(validators[2], 0, 8, 4000, vec![]),
+        make_block_event(validators[2], 0, 6, 3000, vec![]),
+        make_block_event(validators[1], 0, 4, 200, vec![]),
+        make_block_event(validators[1], 0, 3, 150, vec![]),
+        make_block_event(validators[1], 0, 2, 100, vec![]),
+    ];
+
+    let heuristic = make_latency_weighted_heuristic(validators[0]);
+    let weights = heuristic.get_weights(0, &epoch_to_validators, &history);
+
+    // V1 is faster than V2, so V1's weight must be strictly larger than V2's.
+    // If the heuristic had fallen back globally because of V0's empty data, V1 == V2.
+    assert!(
+        weights[1] > weights[2],
+        "expected V1 boosted over V2 despite V0 lacking observations; got {:?}",
+        weights,
+    );
+}
+
+#[test]
+fn test_latency_weighted_empty_history_falls_back_to_base() {
+    // No history → no observations → base weights returned unchanged.
+    let validators: Vec<Author> = (0..2).map(|_| Author::random()).collect();
+    let epoch_to_validators = HashMap::from([(0u64, validators.clone())]);
+    let history: Vec<NewBlockEvent> = vec![];
+
+    let heuristic = make_latency_weighted_heuristic(validators[0]);
+    let weights = heuristic.get_weights(0, &epoch_to_validators, &history);
+
+    // Both validators still get base weight (inactive_weight in this case since no proposals).
+    assert_eq!(weights.len(), 2);
+}
+
+#[test]
+fn test_latency_weighted_max_ratio_clamp() {
+    // V0 makes many fast successful proposals (small mean) while V1 is attributed multiple
+    // large failure gaps (huge mean). The raw scaling ratio (max_mean / V0_mean) is ~1000x;
+    // it must be clamped at MAX_LATENCY_RATIO = 10x → V0's weight tops out at 10 * 1000.
+    let validators: Vec<Author> = (0..2).map(|_| Author::random()).collect();
+    let epoch_to_validators = HashMap::from([(0u64, validators.clone())]);
+
+    // History (newest first): V0 successfully proposes a series of fast rounds, then three
+    // huge gaps each attributed to V1 via failed_proposer_indices.
+    let history = vec![
+        make_block_event(validators[0], 0, 10, 30_000, vec![1]), // V1 failure, gap = 10000
+        make_block_event(validators[0], 0, 8, 20_000, vec![1]),  // V1 failure, gap = 10000
+        make_block_event(validators[0], 0, 6, 10_000, vec![1]),  // V1 failure, gap = 9990
+        make_block_event(validators[0], 0, 4, 10, vec![]),
+        make_block_event(validators[0], 0, 3, 5, vec![]),
+    ];
+
+    let heuristic = make_latency_weighted_heuristic(validators[0]);
+    let weights = heuristic.get_weights(0, &epoch_to_validators, &history);
+
+    // V0's raw ratio would be massive (V1_mean ~10000 / V0_mean ~2 = 5000x); clamp pins it
+    // to MAX_LATENCY_RATIO = 10. V0 weight must equal active_weight * 10 = 10_000.
+    assert_eq!(
+        weights[0], 10_000,
+        "expected V0 weight clamped at 10x active_weight; got {:?}",
+        weights,
+    );
+}
+
+#[test]
+fn test_latency_weighted_skips_cross_epoch_pairs() {
+    // A pair spanning an epoch boundary must not contribute to round_times.
+    let validators: Vec<Author> = (0..2).map(|_| Author::random()).collect();
+    let epoch_to_validators =
+        HashMap::from([(0u64, validators.clone()), (1u64, validators.clone())]);
+
+    // Two events: one in epoch 0, one in epoch 1. Cross-epoch pair must be skipped.
+    let history = vec![
+        make_block_event(validators[1], 1, 1, 1_000_000, vec![]), // epoch 1
+        make_block_event(validators[0], 0, 5, 500, vec![]),       // epoch 0
+    ];
+
+    let heuristic = make_latency_weighted_heuristic(validators[0]);
+    let weights = heuristic.get_weights(1, &epoch_to_validators, &history);
+
+    // No same-epoch pairs → empty round_times → fall back to base weights.
+    // Both validators receive whatever base weight the inner heuristic produced; the latency
+    // scaling has no effect.
+    assert_eq!(weights.len(), 2);
 }

--- a/consensus/src/liveness/leader_reputation_test.rs
+++ b/consensus/src/liveness/leader_reputation_test.rs
@@ -794,7 +794,7 @@ fn make_latency_weighted_heuristic(self_author: Author) -> LatencyWeightedHeuris
     // failed/inactive branches in the inner heuristic — we want to exercise the latency
     // scaling on top of `active_weight`.
     let inner = ProposerAndVoterHeuristic::new(self_author, 1000, 10, 1, 50, 100, 100, false);
-    LatencyWeightedHeuristic::new(inner, 1000, 1.0)
+    LatencyWeightedHeuristic::new(inner, 1000, 1.0, 0)
 }
 
 #[test]
@@ -1024,6 +1024,74 @@ fn test_latency_weighted_carry_forward_for_unobserved_validator() {
         weights2[1], v1_first_weight,
         "carry-forward must preserve V1's penalty; got weights {:?}, expected V1={}",
         weights2, v1_first_weight,
+    );
+}
+
+#[test]
+fn test_latency_weighted_warmup_gates_heuristic() {
+    // Verify that `warmup_rounds` defers the heuristic. Below the threshold the weights
+    // must equal the base ProposerAndVoter output (no latency scaling). Above the
+    // threshold the heuristic kicks in normally.
+    let validators: Vec<Author> = (0..2).map(|_| Author::random()).collect();
+    let epoch_to_validators = HashMap::from([(0u64, validators.clone())]);
+
+    // History where V1 has a failure attribution → V1 mean >> V0 mean. Without warmup,
+    // V1 would be penalized.
+    let history = vec![
+        make_block_event(validators[0], 0, 100, 5000, vec![1]),
+        make_block_event(validators[1], 0, 98, 500, vec![]),
+        make_block_event(validators[0], 0, 97, 100, vec![]),
+        make_block_event(validators[1], 0, 96, 50, vec![]),
+        make_block_event(validators[0], 0, 95, 25, vec![]),
+        make_block_event(validators[1], 0, 94, 10, vec![]),
+    ];
+
+    // Warmup until round 200 — latest history round is 100, so heuristic is disabled.
+    let inner = ProposerAndVoterHeuristic::new(validators[0], 1000, 10, 1, 50, 100, 100, false);
+    let heuristic_with_warmup = LatencyWeightedHeuristic::new(inner, 1000, 1.0, 200);
+    let weights_warmup = heuristic_with_warmup.get_weights(0, &epoch_to_validators, &history);
+
+    // Same history, no warmup — heuristic active.
+    let inner2 = ProposerAndVoterHeuristic::new(validators[0], 1000, 10, 1, 50, 100, 100, false);
+    let heuristic_no_warmup = LatencyWeightedHeuristic::new(inner2, 1000, 1.0, 0);
+    let weights_active = heuristic_no_warmup.get_weights(0, &epoch_to_validators, &history);
+
+    // Warmup case: V1 should still have base active_weight (no penalty applied).
+    assert_eq!(
+        weights_warmup[1], 1000,
+        "warmup must skip latency scaling; V1 should be at active_weight; got {:?}",
+        weights_warmup,
+    );
+    // Active case: V1 is penalized.
+    assert!(
+        weights_active[1] < 1000,
+        "with warmup expired, V1 should be penalized; got {:?}",
+        weights_active,
+    );
+}
+
+#[test]
+fn test_latency_weighted_warmup_zero_means_active_immediately() {
+    // warmup_rounds = 0 must be a no-op (the production default).
+    let validators: Vec<Author> = (0..2).map(|_| Author::random()).collect();
+    let epoch_to_validators = HashMap::from([(0u64, validators.clone())]);
+
+    let history = vec![
+        make_block_event(validators[0], 0, 5, 5000, vec![1]),
+        make_block_event(validators[1], 0, 3, 100, vec![]),
+        make_block_event(validators[0], 0, 2, 50, vec![]),
+        make_block_event(validators[1], 0, 1, 10, vec![]),
+    ];
+
+    let inner = ProposerAndVoterHeuristic::new(validators[0], 1000, 10, 1, 50, 100, 100, false);
+    let heuristic = LatencyWeightedHeuristic::new(inner, 1000, 1.0, 0);
+    let weights = heuristic.get_weights(0, &epoch_to_validators, &history);
+
+    // V1 should be penalized — heuristic is active from the start.
+    assert!(
+        weights[1] < 1000,
+        "warmup_rounds=0 should not gate the heuristic; got {:?}",
+        weights,
     );
 }
 

--- a/consensus/src/round_manager.rs
+++ b/consensus/src/round_manager.rs
@@ -488,6 +488,26 @@ impl RoundManager {
                 .expect("Sending to a self loopback unbounded channel cannot fail");
         }
 
+        // HACK: Simulate slow proposer. The last validator (by ordered index)
+        // delays their proposal by 1s 10% of the time (round % 10 == 0).
+        let proposal_delay = {
+            let author = self.proposal_generator.author();
+            let ordered = self.epoch_state.verifier.get_ordered_account_addresses();
+            let n = ordered.len();
+            let idx = ordered.iter().position(|a| *a == author);
+            if matches!(idx, Some(i) if i >= n - 1) && new_round_event.round.is_multiple_of(10) {
+                Some(std::time::Duration::from_millis(1000))
+            } else {
+                None
+            }
+        };
+        if let Some(delay) = proposal_delay {
+            warn!(
+                self.new_log(LogEvent::NewRound),
+                "HACK: delaying proposal for round {} by {:?}", new_round_event.round, delay
+            );
+        }
+
         // If the current proposer is the leading, try to propose a regular block if not opt proposed already
         if is_current_proposer
             && self
@@ -501,6 +521,9 @@ impl RoundManager {
             let safety_rules = self.safety_rules.clone();
             let proposer_election = self.proposer_election.clone();
             tokio::spawn(async move {
+                if let Some(delay) = proposal_delay {
+                    tokio::time::sleep(delay).await;
+                }
                 if let Err(e) = monitor!(
                     "generate_and_send_proposal",
                     Self::generate_and_send_proposal(
@@ -1453,6 +1476,19 @@ impl RoundManager {
 
         let parent = parent_vote.vote_data().proposed().clone();
         let opt_proposal_round = parent.round() + 1;
+        // HACK: Simulate slow opt proposer too.
+        let opt_proposal_delay = {
+            let author = self.proposal_generator.author();
+            let ordered = self.epoch_state.verifier.get_ordered_account_addresses();
+            let n = ordered.len();
+            let idx = ordered.iter().position(|a| *a == author);
+            if matches!(idx, Some(i) if i >= n - 1) && opt_proposal_round.is_multiple_of(10) {
+                Some(std::time::Duration::from_millis(1000))
+            } else {
+                None
+            }
+        };
+
         if self
             .proposer_election
             .is_valid_proposer(self.proposal_generator.author(), opt_proposal_round)
@@ -1474,6 +1510,9 @@ impl RoundManager {
             let proposal_generator = self.proposal_generator.clone();
             let proposer_election = self.proposer_election.clone();
             tokio::spawn(async move {
+                if let Some(delay) = opt_proposal_delay {
+                    tokio::time::sleep(delay).await;
+                }
                 if let Err(e) = monitor!(
                     "generate_and_send_opt_proposal",
                     Self::generate_and_send_opt_proposal(

--- a/testsuite/forge-cli/src/suites/land_blocking.rs
+++ b/testsuite/forge-cli/src/suites/land_blocking.rs
@@ -29,7 +29,7 @@ pub(crate) fn get_land_blocking_test(
     let test = match test_name {
         "land_blocking" | "realistic_env_max_load" => {
             realistic_env_max_load_test(duration, test_cmd, 7, 0, 0)
-                .with_duration_override(Duration::from_secs(1200))
+                .with_duration_override(Duration::from_secs(900))
         },
         "compat" => compat(),
         "framework_upgrade" => framework_upgrade(),

--- a/testsuite/forge-cli/src/suites/land_blocking.rs
+++ b/testsuite/forge-cli/src/suites/land_blocking.rs
@@ -28,7 +28,8 @@ pub(crate) fn get_land_blocking_test(
 ) -> Option<ForgeConfig> {
     let test = match test_name {
         "land_blocking" | "realistic_env_max_load" => {
-            realistic_env_max_load_test(duration, test_cmd, 7, 0, 3)
+            realistic_env_max_load_test(duration, test_cmd, 7, 0, 0)
+                .with_duration_override(Duration::from_secs(1200))
         },
         "compat" => compat(),
         "framework_upgrade" => framework_upgrade(),

--- a/testsuite/forge-cli/src/suites/realistic_environment.rs
+++ b/testsuite/forge-cli/src/suites/realistic_environment.rs
@@ -477,7 +477,7 @@ pub(crate) fn realistic_env_max_load_test(
                             use_history_from_previous_epoch_max_count: 5,
                         },
                         use_latency_weighted: true,
-                        latency_weight_multiplier_milli: 4000, // 4.0× — aggressively suppress slow leaders
+                        latency_weight_multiplier_milli: 2000, // 2.0× — suppress slow leaders
                     }),
                 );
             }

--- a/testsuite/forge-cli/src/suites/realistic_environment.rs
+++ b/testsuite/forge-cli/src/suites/realistic_environment.rs
@@ -478,7 +478,7 @@ pub(crate) fn realistic_env_max_load_test(
                             use_history_from_previous_epoch_max_count: 5,
                         },
                         use_latency_weighted: true,
-                        latency_weight_multiplier_milli: 2000, // 2.0× — suppress slow leaders
+                        latency_weight_multiplier_milli: 3000, // 3.0× — suppress slow leaders
                     }),
                 );
             }

--- a/testsuite/forge-cli/src/suites/realistic_environment.rs
+++ b/testsuite/forge-cli/src/suites/realistic_environment.rs
@@ -440,30 +440,18 @@ pub(crate) fn realistic_env_max_load_test(
     }
 
     // Create the test
-    let mempool_backlog = if ha_proxy { 14000 } else { 19000 };
     ForgeConfig::default()
         .with_initial_validator_count(NonZeroUsize::new(num_validators).unwrap())
         .with_initial_fullnode_count(num_vfns)
         .add_network_test(wrap_with_realistic_env(num_validators, TwoTrafficsTest {
             inner_traffic: EmitJobRequest::default()
-                .mode(EmitJobMode::MaxLoad { mempool_backlog })
+                .mode(EmitJobMode::ConstTps { tps: 4000 })
                 .init_gas_price_multiplier(20),
-            inner_success_criteria: SuccessCriteria::new(
-                if ha_proxy {
-                    7000
-                } else if long_running {
-                    // This is for forge stable
-                    11000
-                } else {
-                    // During land time we want to be less strict, otherwise we flaky fail
-                    10000
-                },
-            ),
+            inner_success_criteria: SuccessCriteria::new(3500),
         }))
         .with_genesis_helm_config_fn(Arc::new(move |helm_values| {
-            // Have single epoch change in land blocking, and a few on long-running
-            helm_values["chain"]["epoch_duration_secs"] =
-                (if long_running { 600 } else { 300 }).into();
+            // No epoch change so measurements are stable.
+            helm_values["chain"]["epoch_duration_secs"] = (24 * 3600).into();
             helm_values["chain"]["on_chain_consensus_config"] =
                 serde_yaml::to_value(OnChainConsensusConfig::default_for_genesis())
                     .expect("must serialize");

--- a/testsuite/forge-cli/src/suites/realistic_environment.rs
+++ b/testsuite/forge-cli/src/suites/realistic_environment.rs
@@ -479,6 +479,11 @@ pub(crate) fn realistic_env_max_load_test(
                         },
                         use_latency_weighted: true,
                         latency_weight_multiplier_milli: 2000, // 2.0× — suppress slow leaders
+                        // A/B verification: skip the heuristic until round 10,000
+                        // (~5 min at ~32 rounds/sec). Lets us observe baseline behavior
+                        // first, then watch whether spikes appear when the heuristic
+                        // activates. Set to 0 in production.
+                        latency_warmup_rounds: 10_000,
                     }),
                 );
             }

--- a/testsuite/forge-cli/src/suites/realistic_environment.rs
+++ b/testsuite/forge-cli/src/suites/realistic_environment.rs
@@ -478,7 +478,7 @@ pub(crate) fn realistic_env_max_load_test(
                             use_history_from_previous_epoch_max_count: 5,
                         },
                         use_latency_weighted: true,
-                        latency_weight_multiplier_milli: 2000, // 2.0× — suppress slow leaders
+                        latency_weight_multiplier_milli: 3000, // 3.0× — aggressive V6 suppression (safe with warmup)
                         // A/B verification: skip the heuristic until round 10,000
                         // (~5 min at ~32 rounds/sec). Lets us observe baseline behavior
                         // first, then watch whether spikes appear when the heuristic

--- a/testsuite/forge-cli/src/suites/realistic_environment.rs
+++ b/testsuite/forge-cli/src/suites/realistic_environment.rs
@@ -21,8 +21,9 @@ use aptos_forge::{
 };
 use aptos_sdk::types::on_chain_config::{
     BlockGasLimitType, ConsensusAlgorithmConfig, FeatureFlag, Features, LeaderReputationType,
-    OnChainChunkyDKGConfig, OnChainConsensusConfig, OnChainExecutionConfig, OnChainRandomnessConfig,
-    ProposerAndVoterConfig, ProposerAndVoterConfigV3, ProposerElectionType, TransactionShufflerType,
+    OnChainChunkyDKGConfig, OnChainConsensusConfig, OnChainExecutionConfig,
+    OnChainRandomnessConfig, ProposerAndVoterConfig, ProposerAndVoterConfigV3,
+    ProposerElectionType, TransactionShufflerType,
 };
 use aptos_testcases::{
     load_vs_perf_benchmark::{LoadVsPerfBenchmark, TransactionWorkload, Workloads},

--- a/testsuite/forge-cli/src/suites/realistic_environment.rs
+++ b/testsuite/forge-cli/src/suites/realistic_environment.rs
@@ -496,6 +496,12 @@ pub(crate) fn realistic_env_max_load_test(
         .with_validator_override_node_config_fn(Arc::new(|config, _| {
             // Allow validator-PFN connections
             config.base.enable_validator_pfn_connections = true;
+            // EXPERIMENT: disable chain-health backoff entirely to isolate whether
+            // the spike we observe at multiplier=3.0× is caused by the
+            // chain-health-backoff cascade (vs. the heuristic itself). With this
+            // empty, the chain never throttles block size based on participation.
+            // Keep this off in production.
+            config.consensus.chain_health_backoff = vec![];
         }))
         .with_fullnode_override_node_config_fn(Arc::new(|config, _| {
             // Increase the consensus observer fallback thresholds

--- a/testsuite/forge-cli/src/suites/realistic_environment.rs
+++ b/testsuite/forge-cli/src/suites/realistic_environment.rs
@@ -20,8 +20,9 @@ use aptos_forge::{
     TransactionType,
 };
 use aptos_sdk::types::on_chain_config::{
-    BlockGasLimitType, FeatureFlag, Features, OnChainChunkyDKGConfig, OnChainConsensusConfig,
-    OnChainExecutionConfig, OnChainRandomnessConfig, TransactionShufflerType,
+    BlockGasLimitType, ConsensusAlgorithmConfig, FeatureFlag, Features, LeaderReputationType,
+    OnChainChunkyDKGConfig, OnChainConsensusConfig, OnChainExecutionConfig, OnChainRandomnessConfig,
+    ProposerAndVoterConfig, ProposerAndVoterConfigV3, ProposerElectionType, TransactionShufflerType,
 };
 use aptos_testcases::{
     load_vs_perf_benchmark::{LoadVsPerfBenchmark, TransactionWorkload, Workloads},
@@ -452,9 +453,36 @@ pub(crate) fn realistic_env_max_load_test(
         .with_genesis_helm_config_fn(Arc::new(move |helm_values| {
             // No epoch change so measurements are stable.
             helm_values["chain"]["epoch_duration_secs"] = (24 * 3600).into();
+            // Use ProposerAndVoterV3 to enable the latency-weighted heuristic via on-chain
+            // config (so all validators deterministically agree on the leader schedule —
+            // node-local toggles would fork during partial rollout). Window size left at
+            // the default 10× to isolate the heuristic's contribution; the window-bump
+            // experiment lives in a separate companion PR.
+            let mut consensus_config = OnChainConsensusConfig::default_for_genesis();
+            if let OnChainConsensusConfig::V5 {
+                alg: ConsensusAlgorithmConfig::JolteonV2 { ref mut main, .. },
+                ..
+            } = consensus_config
+            {
+                main.proposer_election_type = ProposerElectionType::LeaderReputation(
+                    LeaderReputationType::ProposerAndVoterV3(ProposerAndVoterConfigV3 {
+                        base: ProposerAndVoterConfig {
+                            active_weight: 1000,
+                            inactive_weight: 10,
+                            failed_weight: 1,
+                            failure_threshold_percent: 10,
+                            proposer_window_num_validators_multiplier: 10, // default
+                            voter_window_num_validators_multiplier: 1,
+                            weight_by_voting_power: true,
+                            use_history_from_previous_epoch_max_count: 5,
+                        },
+                        use_latency_weighted: true,
+                        latency_weight_multiplier_milli: 4000, // 4.0× — aggressively suppress slow leaders
+                    }),
+                );
+            }
             helm_values["chain"]["on_chain_consensus_config"] =
-                serde_yaml::to_value(OnChainConsensusConfig::default_for_genesis())
-                    .expect("must serialize");
+                serde_yaml::to_value(consensus_config).expect("must serialize");
             helm_values["chain"]["on_chain_execution_config"] =
                 serde_yaml::to_value(OnChainExecutionConfig::default_for_genesis())
                     .expect("must serialize");

--- a/testsuite/forge-cli/src/suites/realistic_environment.rs
+++ b/testsuite/forge-cli/src/suites/realistic_environment.rs
@@ -478,7 +478,7 @@ pub(crate) fn realistic_env_max_load_test(
                             use_history_from_previous_epoch_max_count: 5,
                         },
                         use_latency_weighted: true,
-                        latency_weight_multiplier_milli: 3000, // 3.0× — suppress slow leaders
+                        latency_weight_multiplier_milli: 2000, // 2.0× — suppress slow leaders
                     }),
                 );
             }

--- a/testsuite/forge-cli/src/suites/realistic_environment.rs
+++ b/testsuite/forge-cli/src/suites/realistic_environment.rs
@@ -456,9 +456,9 @@ pub(crate) fn realistic_env_max_load_test(
             helm_values["chain"]["epoch_duration_secs"] = (24 * 3600).into();
             // Use ProposerAndVoterV3 to enable the latency-weighted heuristic via on-chain
             // config (so all validators deterministically agree on the leader schedule —
-            // node-local toggles would fork during partial rollout). Window size left at
-            // the default 10× to isolate the heuristic's contribution; the window-bump
-            // experiment lives in a separate companion PR.
+            // node-local toggles would fork during partial rollout).
+            // Window bumped to 100× (700 blocks / 35s with 7 validators) for statistical
+            // stability: 100 proposals per validator gives reliable latency mean estimates.
             let mut consensus_config = OnChainConsensusConfig::default_for_genesis();
             if let OnChainConsensusConfig::V5 {
                 alg: ConsensusAlgorithmConfig::JolteonV2 { ref mut main, .. },
@@ -472,7 +472,7 @@ pub(crate) fn realistic_env_max_load_test(
                             inactive_weight: 10,
                             failed_weight: 1,
                             failure_threshold_percent: 10,
-                            proposer_window_num_validators_multiplier: 10, // default
+                            proposer_window_num_validators_multiplier: 100, // bumped from 10 for statistical stability
                             voter_window_num_validators_multiplier: 1,
                             weight_by_voting_power: true,
                             use_history_from_previous_epoch_max_count: 5,

--- a/testsuite/forge/src/config.rs
+++ b/testsuite/forge/src/config.rs
@@ -10,7 +10,7 @@ use aptos_config::config::{
     OverrideNodeConfig,
 };
 use aptos_framework::ReleaseBundle;
-use std::{num::NonZeroUsize, sync::Arc};
+use std::{num::NonZeroUsize, sync::Arc, time::Duration};
 
 /// A PFN deployment configuration. Each entry maps to one helm release via the PFN deployer.
 pub struct PfnDeployment {
@@ -77,6 +77,9 @@ pub struct ForgeConfig {
 
     /// URL to download the chunky DKG public parameters blob into the validator init-container
     pub public_parameters_blob_url: Option<String>,
+
+    /// Override the CLI-specified test duration
+    pub duration_override: Option<Duration>,
 }
 
 impl ForgeConfig {
@@ -204,6 +207,11 @@ impl ForgeConfig {
 
     pub fn with_public_parameters_blob_url(mut self, url: impl Into<String>) -> Self {
         self.public_parameters_blob_url = Some(url.into());
+        self
+    }
+
+    pub fn with_duration_override(mut self, duration: Duration) -> Self {
+        self.duration_override = Some(duration);
         self
     }
 
@@ -448,6 +456,7 @@ impl Default for ForgeConfig {
             retain_debug_logs: false,
             digest_key_blob_url: None,
             public_parameters_blob_url: None,
+            duration_override: None,
         }
     }
 }

--- a/testsuite/forge/src/runner.rs
+++ b/testsuite/forge/src/runner.rs
@@ -311,7 +311,8 @@ impl<'cfg, F: Factory> Forge<'cfg, F> {
                 &initial_version,
                 &genesis_version,
                 self.tests.genesis_config.as_ref(),
-                self.tests.duration_override.unwrap_or(self.global_duration) + Duration::from_secs(NAMESPACE_CLEANUP_DURATION_BUFFER_SECS),
+                self.tests.duration_override.unwrap_or(self.global_duration)
+                    + Duration::from_secs(NAMESPACE_CLEANUP_DURATION_BUFFER_SECS),
                 self.tests.genesis_helm_config_fn.clone(),
                 self.tests.build_node_helm_config_fn(retain_debug_logs),
                 self.tests.existing_db_tag.clone(),
@@ -343,10 +344,7 @@ impl<'cfg, F: Factory> Forge<'cfg, F> {
 
             let logs_location = swarm.logs_location();
             let swarm = Arc::new(tokio::sync::RwLock::new(swarm));
-            let effective_duration = self
-                .tests
-                .duration_override
-                .unwrap_or(self.global_duration);
+            let effective_duration = self.tests.duration_override.unwrap_or(self.global_duration);
             for test in self.filter_tests(&self.tests.network_tests) {
                 let network_ctx = NetworkContext::new(
                     CoreContext::from_rng(&mut rng),

--- a/testsuite/forge/src/runner.rs
+++ b/testsuite/forge/src/runner.rs
@@ -311,7 +311,7 @@ impl<'cfg, F: Factory> Forge<'cfg, F> {
                 &initial_version,
                 &genesis_version,
                 self.tests.genesis_config.as_ref(),
-                self.global_duration + Duration::from_secs(NAMESPACE_CLEANUP_DURATION_BUFFER_SECS),
+                self.tests.duration_override.unwrap_or(self.global_duration) + Duration::from_secs(NAMESPACE_CLEANUP_DURATION_BUFFER_SECS),
                 self.tests.genesis_helm_config_fn.clone(),
                 self.tests.build_node_helm_config_fn(retain_debug_logs),
                 self.tests.existing_db_tag.clone(),
@@ -343,12 +343,16 @@ impl<'cfg, F: Factory> Forge<'cfg, F> {
 
             let logs_location = swarm.logs_location();
             let swarm = Arc::new(tokio::sync::RwLock::new(swarm));
+            let effective_duration = self
+                .tests
+                .duration_override
+                .unwrap_or(self.global_duration);
             for test in self.filter_tests(&self.tests.network_tests) {
                 let network_ctx = NetworkContext::new(
                     CoreContext::from_rng(&mut rng),
                     swarm.clone(),
                     &mut report,
-                    self.global_duration,
+                    effective_duration,
                     self.tests.emit_job_request.clone(),
                     self.tests.success_criteria.clone(),
                 );

--- a/testsuite/smoke-test/src/aptos_cli/validator.rs
+++ b/testsuite/smoke-test/src/aptos_cli/validator.rs
@@ -279,7 +279,8 @@ async fn test_onchain_config_change() {
             panic!()
         };
     let proposer_and_voter_config = match &leader_reputation_type {
-        LeaderReputationType::ProposerAndVoterV2(_) | LeaderReputationType::ProposerAndVoterV3(_) => {
+        LeaderReputationType::ProposerAndVoterV2(_)
+        | LeaderReputationType::ProposerAndVoterV3(_) => {
             panic!()
         },
         LeaderReputationType::ProposerAndVoter(proposer_and_voter_config) => {

--- a/testsuite/smoke-test/src/aptos_cli/validator.rs
+++ b/testsuite/smoke-test/src/aptos_cli/validator.rs
@@ -225,6 +225,7 @@ async fn test_onchain_config_change() {
                 LeaderReputationType::ProposerAndVoterV2(proposer_and_voter_config) => {
                     proposer_and_voter_config
                 },
+                LeaderReputationType::ProposerAndVoterV3(config) => &config.base,
             };
             let new_consensus_config = OnChainConsensusConfig::V1(ConsensusConfigV1 {
                 proposer_election_type: ProposerElectionType::LeaderReputation(
@@ -278,7 +279,9 @@ async fn test_onchain_config_change() {
             panic!()
         };
     let proposer_and_voter_config = match &leader_reputation_type {
-        LeaderReputationType::ProposerAndVoterV2(_) => panic!(),
+        LeaderReputationType::ProposerAndVoterV2(_) | LeaderReputationType::ProposerAndVoterV3(_) => {
+            panic!()
+        },
         LeaderReputationType::ProposerAndVoter(proposer_and_voter_config) => {
             proposer_and_voter_config
         },

--- a/testsuite/smoke-test/src/state_sync.rs
+++ b/testsuite/smoke-test/src/state_sync.rs
@@ -682,8 +682,11 @@ async fn test_validator_sync_and_participate(fast_sync: bool, epoch_changes: boo
                 LeaderReputationType::ProposerAndVoterV2(proposer_and_voter_config) => {
                     proposer_and_voter_config
                 },
+                // V3 is V2 plus the latency-weighted gate; this state-sync test only cares
+                // about the base proposer/voter parameters.
+                LeaderReputationType::ProposerAndVoterV3(config) => &config.base,
                 leader_reputation_type => panic!(
-                    "This test requires a proposer and voter V2 leader reputation, but got: {:?}",
+                    "This test requires a proposer and voter V2/V3 leader reputation, but got: {:?}",
                     leader_reputation_type
                 ),
             };

--- a/types/src/on_chain_config/consensus_config.rs
+++ b/types/src/on_chain_config/consensus_config.rs
@@ -516,6 +516,12 @@ pub enum LeaderReputationType {
     // * use reputation window from recent end
     // * unpredictable seed, based on root hash
     ProposerAndVoterV2(ProposerAndVoterConfig),
+    // Version 3: extends V2 with on-chain gating for the latency-weighted heuristic.
+    // Adds `use_latency_weighted` and `latency_weight_multiplier_milli` so all validators
+    // deterministically agree on whether to apply latency weighting and with what exponent.
+    // Without on-chain gating, validators on different node-local config values would
+    // compute different leader schedules and fork.
+    ProposerAndVoterV3(ProposerAndVoterConfigV3),
 }
 
 impl LeaderReputationType {
@@ -528,6 +534,35 @@ impl LeaderReputationType {
         // all versions after V1 shouldn't use from stale end
         matches!(self, Self::ProposerAndVoter(_))
     }
+
+    /// Borrow the inner `ProposerAndVoter*` parameters in a version-agnostic way. Returns
+    /// the latency-weighted toggle and milli-multiplier alongside; both are zero/false for
+    /// V1/V2 since those versions predate the latency-weighted feature.
+    pub fn proposer_and_voter_params(&self) -> ProposerAndVoterParams<'_> {
+        match self {
+            Self::ProposerAndVoter(c) | Self::ProposerAndVoterV2(c) => ProposerAndVoterParams {
+                base: c,
+                use_latency_weighted: false,
+                latency_weight_multiplier_milli: 0,
+            },
+            Self::ProposerAndVoterV3(c) => ProposerAndVoterParams {
+                base: &c.base,
+                use_latency_weighted: c.use_latency_weighted,
+                latency_weight_multiplier_milli: c.latency_weight_multiplier_milli,
+            },
+        }
+    }
+}
+
+/// Borrowed view over the parameters needed to construct a `LeaderReputation` heuristic,
+/// abstracting over `LeaderReputationType` versions. See `proposer_and_voter_params`.
+pub struct ProposerAndVoterParams<'a> {
+    pub base: &'a ProposerAndVoterConfig,
+    pub use_latency_weighted: bool,
+    /// Multiplier expressed in milli-units (1000 = 1.0×). Stored as integer for
+    /// deterministic BCS serialization across implementations. Ignored when
+    /// `use_latency_weighted` is false.
+    pub latency_weight_multiplier_milli: u32,
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -553,6 +588,22 @@ pub struct ProposerAndVoterConfig {
     // representing a number of historical epochs (beyond the current one)
     // to consider.
     pub use_history_from_previous_epoch_max_count: u32,
+}
+
+/// V3 leader-reputation parameters: V2's `ProposerAndVoterConfig` plus the on-chain gate
+/// for the latency-weighted heuristic. New fields live on a new struct so existing on-chain
+/// V1/V2 payloads continue to deserialize unchanged.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct ProposerAndVoterConfigV3 {
+    /// V2 parameters (selection weights, windows, etc.).
+    pub base: ProposerAndVoterConfig,
+    /// On-chain toggle for the latency-weighted heuristic that scales active validators by
+    /// per-validator mean round time. When false the heuristic behaves like V2.
+    pub use_latency_weighted: bool,
+    /// Exponent applied to the latency ratio, expressed in milli-units (1000 = 1.0×).
+    /// Integer-encoded for BCS determinism. Decoded as `value as f64 / 1000.0` at runtime.
+    /// Ignored when `use_latency_weighted` is false.
+    pub latency_weight_multiplier_milli: u32,
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]

--- a/types/src/on_chain_config/consensus_config.rs
+++ b/types/src/on_chain_config/consensus_config.rs
@@ -544,11 +544,13 @@ impl LeaderReputationType {
                 base: c,
                 use_latency_weighted: false,
                 latency_weight_multiplier_milli: 0,
+                latency_warmup_rounds: 0,
             },
             Self::ProposerAndVoterV3(c) => ProposerAndVoterParams {
                 base: &c.base,
                 use_latency_weighted: c.use_latency_weighted,
                 latency_weight_multiplier_milli: c.latency_weight_multiplier_milli,
+                latency_warmup_rounds: c.latency_warmup_rounds,
             },
         }
     }
@@ -563,6 +565,9 @@ pub struct ProposerAndVoterParams<'a> {
     /// deterministic BCS serialization across implementations. Ignored when
     /// `use_latency_weighted` is false.
     pub latency_weight_multiplier_milli: u32,
+    /// Skip the latency-weighted heuristic until this round (forge-only A/B verification
+    /// knob). 0 means activate immediately. V1/V2 always set 0.
+    pub latency_warmup_rounds: u64,
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -604,6 +609,11 @@ pub struct ProposerAndVoterConfigV3 {
     /// Integer-encoded for BCS determinism. Decoded as `value as f64 / 1000.0` at runtime.
     /// Ignored when `use_latency_weighted` is false.
     pub latency_weight_multiplier_milli: u32,
+    /// Skip the latency-weighted heuristic (i.e., behave like V2) until the latest event in
+    /// the history window has reached this round number. 0 means activate immediately. Used
+    /// for forge A/B verification where we want a clean baseline phase before the heuristic
+    /// kicks in. Production deployments should use 0.
+    pub latency_warmup_rounds: u64,
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]

--- a/types/src/on_chain_config/mod.rs
+++ b/types/src/on_chain_config/mod.rs
@@ -46,8 +46,9 @@ pub use self::{
     commit_history::CommitHistoryResource,
     consensus_config::{
         AnchorElectionMode, ConsensusAlgorithmConfig, ConsensusConfigV1, DagConsensusConfigV1,
-        LeaderReputationType, OnChainConsensusConfig, ProposerAndVoterConfig, ProposerElectionType,
-        ValidatorTxnConfig, DEFAULT_ENABLED_WINDOW_SIZE, DEFAULT_WINDOW_SIZE,
+        LeaderReputationType, OnChainConsensusConfig, ProposerAndVoterConfig,
+        ProposerAndVoterConfigV3, ProposerAndVoterParams, ProposerElectionType, ValidatorTxnConfig,
+        DEFAULT_ENABLED_WINDOW_SIZE, DEFAULT_WINDOW_SIZE,
     },
     execution_config::{
         BlockGasLimitType, ExecutionConfigV1, ExecutionConfigV2, ExecutionConfigV4,


### PR DESCRIPTION
## Summary

A/B experiment branch. Stacks on top of baseline #19330. Adds a continuous, per-validator weight scaling to leader reputation that prefers validators with lower historical commit-to-commit interval as proposers. **Default binary classifier** (`failed_weight=1, threshold=10%`) — keeps the existing classifier behavior to isolate the heuristic's contribution.

## Changes

- **New `LeaderReputationType::ProposerAndVoterV3(ProposerAndVoterConfigV3)`** with `use_latency_weighted: bool` and `latency_weight_multiplier_milli: u32` (BCS-friendly milli-units; 1000 = 1.0×). V1/V2 default the toggle to false → no behavior change for existing payloads.
- **Forge config:** `use_latency_weighted=true, latency_weight_multiplier_milli=2000` (2.0× — moderate suppression of slow leaders).
- **`proposer_window_num_validators_multiplier: 10 → 100`** for statistical stability of latency mean estimates.

## Heuristic

Splits successful pair intervals 50/50 between newer/older proposer; attributes timeout-spanning gaps to the failed proposer(s) via `failed_proposer_indices`. Aggregates with mean (not median — median discarded the failure tail). Healthy adjacents are no longer wrongly penalized for absorbing others' timeouts.

Guards:
- Per-validator fallback below `MIN_OBSERVATIONS=2`
- Scaling ratio clamped at `MAX_LATENCY_RATIO=10×`
- Empty / zero-mean → base weights

## Tests

7 new unit tests for the heuristic. All 18 leader-reputation lib tests pass.

## Pairs with

- #19330 — baseline
- #19574 — window-only control (~no effect)
- #19566 — classifier-only (binary exclusion)
- #19341 — combined (classifier + heuristic) ← **best result**

## Forge results (run 2026-04-28 21:14-21:28 UTC, 14 min, 4k TPS, 1 slow validator)

Commit-accepted latency vs baseline #19330:

| | p50 | p75 | p90 | p99 |
|---|---|---|---|---|
| #19330 baseline | 0.209 | 0.298 | 0.658 | 1.268 |
| **this PR** | 0.179 | 0.229 | 0.299 | 1.064 |
| Δ vs baseline | −14% | −23% | **−55%** | **−16%** |

Notably:
- **Beats classifier-only PR (#19566) on every percentile from p50 through p99.** Soft weighting handles slow-but-not-failed leaders better than binary classification.
- p90: 0.299 vs #19566's 0.337 (better)
- p99: 1.064 vs #19566's 1.207 (better)

The heuristic alone achieves what the strict classifier achieves, plus extra p99 tail flattening.

## Test plan

- [x] Run forge `land_blocking`, compare commit p50/p75/p90/p99 against baseline #19330
- [x] Compare against the classifier-only PR (#19566) — heuristic wins on all percentiles

⚠ Draft / experiment — not for merge to main. Canonical merge requires governance migration of the on-chain config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)