### PR TITLE
[mono-move] Combine enum and struct types

### DIFF
--- a/third_party/move/mono-move/core/src/executable.rs
+++ b/third_party/move/mono-move/core/src/executable.rs
@@ -49,8 +49,10 @@ impl ExecutableId {
 
 /// Struct type metadata in an executable.
 pub struct StructType {
-    /// Struct type signature. Invariant: stored type is always
-    /// [`Type::StructOrEnum`].
+    /// Struct type signature. Invariants:
+    ///   - Stored type is always [`Type::Nominal`].
+    ///   - When the layout slot is populated, `layout.fields == Some(_)`
+    ///     (structs cache per-field offsets).
     ty: InternedType,
 }
 
@@ -68,8 +70,11 @@ impl StructType {
 
 /// Enum type metadata in an executable.
 pub struct EnumType {
-    /// Enum type signature. Invariant: stored type is always
-    /// [`Type::StructOrEnum`].
+    /// Enum type signature. Invariants:
+    ///   - Stored type is always [`Type::Nominal`].
+    ///   - When the layout slot is populated, `layout.fields == None`
+    ///     (enums do not cache per-field offsets at the type level, since
+    ///     new variants may be added on module upgrade).
     ty: InternedType,
     /// Per-variant field types, indexed by variant tag.
     #[allow(dead_code)]

--- a/third_party/move/mono-move/core/src/executable.rs
+++ b/third_party/move/mono-move/core/src/executable.rs
@@ -50,7 +50,7 @@ impl ExecutableId {
 /// Struct type metadata in an executable.
 pub struct StructType {
     /// Struct type signature. Invariant: stored type is always
-    /// [`Type::Struct`].
+    /// [`Type::StructOrEnum`].
     ty: InternedType,
 }
 
@@ -69,7 +69,7 @@ impl StructType {
 /// Enum type metadata in an executable.
 pub struct EnumType {
     /// Enum type signature. Invariant: stored type is always
-    /// [`Type::Enum`].
+    /// [`Type::StructOrEnum`].
     ty: InternedType,
     /// Per-variant field types, indexed by variant tag.
     #[allow(dead_code)]

--- a/third_party/move/mono-move/core/src/types.rs
+++ b/third_party/move/mono-move/core/src/types.rs
@@ -35,19 +35,15 @@
 //!
 //! Size of references is 16 bytes (fat pointers). Alignment is also 16 bytes.
 //!
-//! ## Fully-instantiated structs
+//! ## Fully-instantiated structs and enums
 //!
-//! Struct types are arena-allocated, and store executable ID, name and type
-//! arguments that uniquely identify the type. Additionally, fully-instantiated
-//! structs cache their layout information (size, alignment and field offsets).
-//!
-//! ## Enums
-//!
-//! Enums are simply pointers to arena-allocated executable IDs, identifiers
-//! and type arguments that uniquely identify the type. Enum layouts are not
-//! cached in the type graph because enum definitions can change on module
-//! upgrade (new variants added). Instead, variant field layouts are stored
-//! per-executable and resolved at runtime.
+//! Struct and enum types are arena-allocated, and store executable ID, name
+//! and type arguments that uniquely identify the type. Both can carry an
+//! optional layout slot. The slot stores size and alignment of this type. For
+//! structs, per-field offsets in flat memory are also recorded. Note that enum
+//! field offsets are not cached in the type graph because enum definitions
+//! can change on module upgrade (new variants added); per-variant field
+//! layouts are stored per-executable and resolved at runtime.
 //!
 //! ## Generic structs
 //!
@@ -181,29 +177,39 @@ impl FieldLayout {
     }
 }
 
-/// Struct layout information: total size, alignment and information about the
-/// field layouts.
-pub struct StructLayout {
+/// Layout information shared by structs and enums: total size, alignment,
+/// and an optional pointer to per-field offsets (unset for enums).
+pub struct StructOrEnumLayout {
     /// Total size of the struct. Includes necessary padding based on the
     /// alignment requirements.
     pub size: Size,
     pub align: Alignment,
-    fields: GlobalArenaPtr<[FieldLayout]>,
+    fields: Option<GlobalArenaPtr<[FieldLayout]>>,
 }
 
-impl StructLayout {
-    /// Creates a new struct layout entry.
-    pub fn new(size: Size, align: Alignment, fields: GlobalArenaPtr<[FieldLayout]>) -> Self {
+impl StructOrEnumLayout {
+    /// Creates a struct layout entry with per-field offsets.
+    pub fn new_struct(size: Size, align: Alignment, fields: GlobalArenaPtr<[FieldLayout]>) -> Self {
         Self {
             size,
             align,
-            fields,
+            fields: Some(fields),
+        }
+    }
+
+    /// Creates an enum layout entry. Enums do not store per-field offsets
+    /// at the type level.
+    pub fn new_enum(size: Size, align: Alignment) -> Self {
+        Self {
+            size,
+            align,
+            fields: None,
         }
     }
 
     // TODO: This API is test-only for now, will change, so ignore safety.
-    pub fn field_layouts(&self) -> &[FieldLayout] {
-        unsafe { self.fields.as_ref_unchecked() }
+    pub fn field_layouts(&self) -> Option<&[FieldLayout]> {
+        self.fields.map(|p| unsafe { p.as_ref_unchecked() })
     }
 }
 
@@ -211,7 +217,7 @@ impl StructLayout {
 // drop only as long as it owns no non-arena memory. If a future field
 // introduces a heap owner (`Vec`, `String`, `Box`, etc.), this assertion turns
 // the silent leak / double-free into a compile error.
-const _: () = assert!(!std::mem::needs_drop::<StructLayout>());
+const _: () = assert!(!std::mem::needs_drop::<StructOrEnumLayout>());
 
 // ================================================================================================
 // Type enum
@@ -250,31 +256,23 @@ pub enum Type {
     Vector {
         elem: InternedType,
     },
-    /// Named struct with its layout. The layout slot is empty for generic
+    /// Named struct or enum with its layout. The layout slot is empty for generic
     /// structs and for cross-module references whose layout has not yet been
     /// populated by the loader; it is filled once via [`OnceLock::set`] when
-    /// all constituent layouts become available.
+    /// all constituent layouts become available. For structs, layout stores field
+    /// offsets as well. This is not the case for enums. Enums are always pointer-sized
+    /// today, because new variants may be added on module upgrade.
     ///
     /// The slot is `OnceLock`-gated so layout can be filled after interning.
     /// Drop on arena reset is skipped (bumpalo bulk-rewinds without calling
-    /// `Drop`), which is harmless only as long as `StructLayout` owns no
-    /// non-arena memory - keep it that way.
-    Struct {
-        // TODO: Make this a pointer to struct type struct which holds these pointers.
+    /// `Drop`), which is harmless only as long as layout owns no non-arena
+    /// memory - keep it that way.
+    StructOrEnum {
+        // TODO: Make this a pointer to a named-type struct holding these pointers.
         executable_id: GlobalArenaPtr<ExecutableId>,
         name: GlobalArenaPtr<str>,
         ty_args: InternedTypeList,
-        layout: OnceLock<StructLayout>,
-    },
-    /// Named enum. Does not store any layout information as it may change (new
-    /// variant can be added during module upgrade). Enum layouts are always
-    /// resolved through the executable where they are defined.
-    Enum {
-        // TODO: Make this a pointer to enum type struct which holds these pointers.
-        executable_id: GlobalArenaPtr<ExecutableId>,
-        name: GlobalArenaPtr<str>,
-        ty_args: InternedTypeList,
-        // TODO: Optional layout for enums with fixed size (frozen).
+        layout: OnceLock<StructOrEnumLayout>,
     },
     /// Function type with argument types, result types and abilities.
     Function {
@@ -303,8 +301,9 @@ impl Type {
     /// Returns the size and alignment of this type. Returns [`None`] if the
     /// size or alignment cannot be computed:
     ///   - If the type is a generic struct.
-    ///   - If the type is a struct whose layout has not yet been populated
-    ///     (e.g., a cross-module reference awaiting its loader pass).
+    ///   - If the type is a struct or enum whose layout has not yet been
+    ///     populated (e.g., a cross-module reference awaiting its loader
+    ///     pass).
     ///   - If the type is an unresolved type parameter.
     pub fn size_and_align(&self) -> Option<(Size, Alignment)> {
         Some(match self {
@@ -323,15 +322,13 @@ impl Type {
             // References are 16-byte fat pointers.
             Type::ImmutRef { .. } | Type::MutRef { .. } => (16, 16),
 
-            // Enums: always heap pointers because of upgradability.
-            Type::Enum { .. } => (8, 8),
-
             // Function values - TODO: for now use heap pointer values.
             Type::Function { .. } => (8, 8),
 
-            // Structs: the layout slot may be empty for generic structs or
-            // for cross-module references awaiting layout population.
-            Type::Struct { layout, .. } => match layout.get() {
+            // Structs and enums: the layout slot may be empty for generic
+            // types or for cross-module references awaiting layout
+            // population.
+            Type::StructOrEnum { layout, .. } => match layout.get() {
                 Some(layout) => (layout.size, layout.align),
                 None => return None,
             },
@@ -343,11 +340,12 @@ impl Type {
         })
     }
 
-    /// Returns layout for a struct type, or [`None`] for non-struct types or
-    /// structs whose layout slot has not yet been populated.
-    pub fn struct_layout(&self) -> Option<&StructLayout> {
+    /// Returns layout for a struct or enum type, or [`None`] for other
+    /// types or for struct/enum types whose layout slot has not yet been
+    /// populated.
+    pub fn layout(&self) -> Option<&StructOrEnumLayout> {
         match self {
-            Type::Struct { layout, .. } => layout.get(),
+            Type::StructOrEnum { layout, .. } => layout.get(),
             Type::Bool
             | Type::U8
             | Type::U16
@@ -366,7 +364,6 @@ impl Type {
             | Type::ImmutRef { .. }
             | Type::MutRef { .. }
             | Type::Vector { .. }
-            | Type::Enum { .. }
             | Type::Function { .. }
             | Type::TypeParam { .. } => None,
         }

--- a/third_party/move/mono-move/core/src/types.rs
+++ b/third_party/move/mono-move/core/src/types.rs
@@ -177,17 +177,25 @@ impl FieldLayout {
     }
 }
 
-/// Layout information shared by structs and enums: total size, alignment,
-/// and an optional pointer to per-field offsets (unset for enums).
-pub struct StructOrEnumLayout {
-    /// Total size of the struct. Includes necessary padding based on the
+/// Layout information for a [`Type::Nominal`]: total size, alignment, and an
+/// optional pointer to per-field offsets.
+///
+/// `fields` is `Some(_)` when per-field offsets are cached (today: structs)
+/// and `None` when they are not (today: enums, whose layout can change on
+/// module upgrade). `Some(_)` is therefore not a "this is a struct" marker —
+/// once `#[frozen]` enums land, frozen enums will also carry `Some(_)` since
+/// their variants cannot change. TODO: replace this side-channel with a
+/// more explicit shape (e.g., a dedicated enum) once frozen enums are wired
+/// in.
+pub struct NominalLayout {
+    /// Total size of the type. Includes necessary padding based on the
     /// alignment requirements.
     pub size: Size,
     pub align: Alignment,
     fields: Option<GlobalArenaPtr<[FieldLayout]>>,
 }
 
-impl StructOrEnumLayout {
+impl NominalLayout {
     /// Creates a struct layout entry with per-field offsets.
     pub fn new_struct(size: Size, align: Alignment, fields: GlobalArenaPtr<[FieldLayout]>) -> Self {
         Self {
@@ -217,7 +225,7 @@ impl StructOrEnumLayout {
 // drop only as long as it owns no non-arena memory. If a future field
 // introduces a heap owner (`Vec`, `String`, `Box`, etc.), this assertion turns
 // the silent leak / double-free into a compile error.
-const _: () = assert!(!std::mem::needs_drop::<StructOrEnumLayout>());
+const _: () = assert!(!std::mem::needs_drop::<NominalLayout>());
 
 // ================================================================================================
 // Type enum
@@ -256,23 +264,29 @@ pub enum Type {
     Vector {
         elem: InternedType,
     },
-    /// Named struct or enum with its layout. The layout slot is empty for generic
-    /// structs and for cross-module references whose layout has not yet been
-    /// populated by the loader; it is filled once via [`OnceLock::set`] when
-    /// all constituent layouts become available. For structs, layout stores field
-    /// offsets as well. This is not the case for enums. Enums are always pointer-sized
-    /// today, because new variants may be added on module upgrade.
+    /// Nominal type — a struct or enum identified by name. The layout slot is
+    /// empty for generic instances and for cross-module references whose
+    /// layout has not yet been populated by the loader; it is filled once via
+    /// [`OnceLock::set`] when all constituent layouts become available. For
+    /// structs, layout stores field offsets as well. This is not the case for
+    /// enums. Enums are always pointer-sized today, because new variants may
+    /// be added on module upgrade.
+    ///
+    /// TODO: `#[frozen]` enums (e.g., `Option`) cannot gain new variants on
+    /// upgrade, so they should cache per-variant field offsets in the layout
+    /// slot rather than indirecting through a pointer. This will need to be
+    /// wired in once the frozen-enum attribute is supported end-to-end.
     ///
     /// The slot is `OnceLock`-gated so layout can be filled after interning.
     /// Drop on arena reset is skipped (bumpalo bulk-rewinds without calling
     /// `Drop`), which is harmless only as long as layout owns no non-arena
     /// memory - keep it that way.
-    StructOrEnum {
+    Nominal {
         // TODO: Make this a pointer to a named-type struct holding these pointers.
         executable_id: GlobalArenaPtr<ExecutableId>,
         name: GlobalArenaPtr<str>,
         ty_args: InternedTypeList,
-        layout: OnceLock<StructOrEnumLayout>,
+        layout: OnceLock<NominalLayout>,
     },
     /// Function type with argument types, result types and abilities.
     Function {
@@ -325,10 +339,10 @@ impl Type {
             // Function values - TODO: for now use heap pointer values.
             Type::Function { .. } => (8, 8),
 
-            // Structs and enums: the layout slot may be empty for generic
-            // types or for cross-module references awaiting layout
-            // population.
-            Type::StructOrEnum { layout, .. } => match layout.get() {
+            // Nominal types (struct/enum): the layout slot may be empty for
+            // generic instances or for cross-module references awaiting
+            // layout population.
+            Type::Nominal { layout, .. } => match layout.get() {
                 Some(layout) => (layout.size, layout.align),
                 None => return None,
             },
@@ -340,12 +354,12 @@ impl Type {
         })
     }
 
-    /// Returns layout for a struct or enum type, or [`None`] for other
-    /// types or for struct/enum types whose layout slot has not yet been
+    /// Returns layout for a nominal (struct or enum) type, or [`None`] for
+    /// other types or for nominal types whose layout slot has not yet been
     /// populated.
-    pub fn layout(&self) -> Option<&StructOrEnumLayout> {
+    pub fn layout(&self) -> Option<&NominalLayout> {
         match self {
-            Type::StructOrEnum { layout, .. } => layout.get(),
+            Type::Nominal { layout, .. } => layout.get(),
             Type::Bool
             | Type::U8
             | Type::U16

--- a/third_party/move/mono-move/global-context/src/context.rs
+++ b/third_party/move/mono-move/global-context/src/context.rs
@@ -36,7 +36,7 @@ use crate::maintenance_config::MaintenanceConfig;
 use anyhow::{bail, Result};
 use dashmap::DashMap;
 use mono_move_alloc::{GlobalArenaPool, GlobalArenaPtr, GlobalArenaShard};
-use mono_move_core::{types::StructLayout, ExecutableId, Interner};
+use mono_move_core::{types::StructOrEnumLayout, ExecutableId, Interner};
 use move_binary_format::{file_format::SignatureToken, CompiledModule};
 use parking_lot::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 use std::{
@@ -359,18 +359,19 @@ impl<'ctx> ExecutionGuard<'ctx> {
         unsafe { ptr.as_ref_unchecked() }
     }
 
-    /// Interns a struct identity without populating its layout. The returned
-    /// pointer can be used immediately in IR, but [`Type::size_and_align`] and
-    /// [`Type::struct_layout`] will return [`None`] until [`Self::set_struct_layout`]
-    /// is called for this type. Callers using this in cross-module contexts
-    /// must tolerate the missing layout until a layout-population pass runs.
-    pub fn intern_struct_identity(
+    /// Interns a struct or enum identity without populating its layout. The
+    /// returned pointer can be used immediately in IR, but
+    /// [`Type::size_and_align`] and [`Type::layout`] will return [`None`]
+    /// until [`Self::set_struct_or_enum_layout`] is called for this type.
+    /// Callers using this in cross-module contexts must tolerate the
+    /// missing layout until a layout-population pass runs.
+    pub fn intern_struct_or_enum(
         &self,
         executable_id: GlobalArenaPtr<ExecutableId>,
         name: GlobalArenaPtr<str>,
         ty_args: InternedTypeList,
     ) -> InternedType {
-        let ty = self.global_arena.alloc(Type::Struct {
+        let ty = self.global_arena.alloc(Type::StructOrEnum {
             executable_id,
             name,
             ty_args,
@@ -379,21 +380,22 @@ impl<'ctx> ExecutionGuard<'ctx> {
         self.insert_allocated_type_pointer_internal(ty)
     }
 
-    /// Allocates the field-layout slice in the arena, builds a [`StructLayout`]
-    /// and installs it into struct type's layout slot. Returns an error if the
-    /// type was not a struct type.
+    /// Allocates the field-layout slice in the arena (when `fields` is
+    /// `Some`), builds a [`StructOrEnumLayout`] and installs it into the
+    /// type's layout slot. Pass `Some(&fields)` for structs and `None` for
+    /// enums. Returns an error if `ty` is not a struct or enum type.
     ///
-    /// Setting layouts concurrently is safe. Layout already stores canonical
-    /// field type pointers so is structurally identical for both threads.
-    pub fn set_struct_layout(
+    /// Setting layouts concurrently is safe: the layout stores canonical
+    /// field type pointers and so is structurally identical across threads.
+    pub fn set_struct_or_enum_layout(
         &self,
         ty: InternedType,
         size: u32,
         align: u32,
-        fields: &[FieldLayout],
+        fields: Option<&[FieldLayout]>,
     ) -> Result<()> {
         let slot = match view_type(ty) {
-            Type::Struct { layout: slot, .. } => slot,
+            Type::StructOrEnum { layout: slot, .. } => slot,
             Type::Bool
             | Type::U8
             | Type::U16
@@ -412,9 +414,10 @@ impl<'ctx> ExecutionGuard<'ctx> {
             | Type::ImmutRef { .. }
             | Type::MutRef { .. }
             | Type::Vector { .. }
-            | Type::Enum { .. }
             | Type::Function { .. }
-            | Type::TypeParam { .. } => bail!("set_struct_layout called on a non-struct type"),
+            | Type::TypeParam { .. } => {
+                bail!("set_struct_or_enum_layout called on a non-struct/enum type")
+            },
         };
 
         // Fast path: if the layout is already installed, skip the field-slice
@@ -425,54 +428,46 @@ impl<'ctx> ExecutionGuard<'ctx> {
             return Ok(());
         }
 
-        let fields_ptr = self.global_arena.alloc_slice_copy(fields);
-        let layout = StructLayout::new(size, align, fields_ptr);
+        let layout = match fields {
+            Some(fields) => {
+                let fields_ptr = self.global_arena.alloc_slice_copy(fields);
+                StructOrEnumLayout::new_struct(size, align, fields_ptr)
+            },
+            None => StructOrEnumLayout::new_enum(size, align),
+        };
         if let Err(other_layout) = slot.set(layout) {
             let installed_layout = slot.get().expect("Layout was just installed");
             debug_assert_eq!(installed_layout.size, other_layout.size);
             debug_assert_eq!(installed_layout.align, other_layout.align);
             debug_assert_eq!(
-                installed_layout.field_layouts().len(),
-                other_layout.field_layouts().len()
+                installed_layout.field_layouts().is_some(),
+                other_layout.field_layouts().is_some()
             );
-            // Layout computation is deterministic given the struct identity,
+            // Layout computation is deterministic given the type identity,
             // so per-field offsets must match too.
-            for (installed, other) in installed_layout
-                .field_layouts()
-                .iter()
-                .zip(other_layout.field_layouts().iter())
-            {
-                debug_assert_eq!(installed.offset, other.offset);
+            if let (Some(installed), Some(other)) = (
+                installed_layout.field_layouts(),
+                other_layout.field_layouts(),
+            ) {
+                debug_assert_eq!(installed.len(), other.len());
+                for (installed, other) in installed.iter().zip(other.iter()) {
+                    debug_assert_eq!(installed.offset, other.offset);
+                }
             }
         }
         Ok(())
-    }
-
-    /// Interns an enum type. Enum size/align is fixed metadata, so no
-    /// field-layout slice is carried on the type.
-    pub fn intern_enum_type(
-        &self,
-        executable_id: GlobalArenaPtr<ExecutableId>,
-        name: GlobalArenaPtr<str>,
-        ty_args: InternedTypeList,
-    ) -> InternedType {
-        let ty = self.global_arena.alloc(Type::Enum {
-            executable_id,
-            name,
-            ty_args,
-        });
-        self.insert_allocated_type_pointer_internal(ty)
     }
 
     /// Looks up a type previously interned from a signature token of `module`.
     /// Returns `None` if the token has not yet been interned in this module's
     /// context.
     ///
-    /// For struct types, the returned pointer carries identity but its layout
-    /// slot may still be empty — `set_struct_layout` runs in a separate pass
-    /// after all field types are interned. Callers consuming this in cross-
-    /// module contexts must tolerate `None` from [`Type::size_and_align`] and
-    /// [`Type::struct_layout`] until the layout-population pass completes.
+    /// For struct/enum types, the returned pointer carries identity but its
+    /// layout slot may still be empty — `set_struct_or_enum_layout` runs in
+    /// a separate pass after all field types are interned. Callers
+    /// consuming this in cross-module contexts must tolerate `None` from
+    /// [`Type::size_and_align`] and [`Type::layout`] until the layout-
+    /// population pass completes.
     pub fn try_intern_for_module(
         &self,
         token: &SignatureToken,

--- a/third_party/move/mono-move/global-context/src/context.rs
+++ b/third_party/move/mono-move/global-context/src/context.rs
@@ -36,7 +36,7 @@ use crate::maintenance_config::MaintenanceConfig;
 use anyhow::{bail, Result};
 use dashmap::DashMap;
 use mono_move_alloc::{GlobalArenaPool, GlobalArenaPtr, GlobalArenaShard};
-use mono_move_core::{types::StructOrEnumLayout, ExecutableId, Interner};
+use mono_move_core::{types::NominalLayout, ExecutableId, Interner};
 use move_binary_format::{file_format::SignatureToken, CompiledModule};
 use parking_lot::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 use std::{
@@ -359,19 +359,19 @@ impl<'ctx> ExecutionGuard<'ctx> {
         unsafe { ptr.as_ref_unchecked() }
     }
 
-    /// Interns a struct or enum identity without populating its layout. The
-    /// returned pointer can be used immediately in IR, but
+    /// Interns a nominal (struct or enum) identity without populating its
+    /// layout. The returned pointer can be used immediately in IR, but
     /// [`Type::size_and_align`] and [`Type::layout`] will return [`None`]
-    /// until [`Self::set_struct_or_enum_layout`] is called for this type.
-    /// Callers using this in cross-module contexts must tolerate the
-    /// missing layout until a layout-population pass runs.
-    pub fn intern_struct_or_enum(
+    /// until [`Self::set_nominal_layout`] is called for this type. Callers
+    /// using this in cross-module contexts must tolerate the missing layout
+    /// until a layout-population pass runs.
+    pub fn intern_nominal(
         &self,
         executable_id: GlobalArenaPtr<ExecutableId>,
         name: GlobalArenaPtr<str>,
         ty_args: InternedTypeList,
     ) -> InternedType {
-        let ty = self.global_arena.alloc(Type::StructOrEnum {
+        let ty = self.global_arena.alloc(Type::Nominal {
             executable_id,
             name,
             ty_args,
@@ -381,13 +381,13 @@ impl<'ctx> ExecutionGuard<'ctx> {
     }
 
     /// Allocates the field-layout slice in the arena (when `fields` is
-    /// `Some`), builds a [`StructOrEnumLayout`] and installs it into the
-    /// type's layout slot. Pass `Some(&fields)` for structs and `None` for
-    /// enums. Returns an error if `ty` is not a struct or enum type.
+    /// `Some`), builds a [`NominalLayout`] and installs it into the type's
+    /// layout slot. Pass `Some(&fields)` for structs and `None` for enums.
+    /// Returns an error if `ty` is not a nominal type.
     ///
     /// Setting layouts concurrently is safe: the layout stores canonical
     /// field type pointers and so is structurally identical across threads.
-    pub fn set_struct_or_enum_layout(
+    pub fn set_nominal_layout(
         &self,
         ty: InternedType,
         size: u32,
@@ -395,7 +395,7 @@ impl<'ctx> ExecutionGuard<'ctx> {
         fields: Option<&[FieldLayout]>,
     ) -> Result<()> {
         let slot = match view_type(ty) {
-            Type::StructOrEnum { layout: slot, .. } => slot,
+            Type::Nominal { layout: slot, .. } => slot,
             Type::Bool
             | Type::U8
             | Type::U16
@@ -416,7 +416,7 @@ impl<'ctx> ExecutionGuard<'ctx> {
             | Type::Vector { .. }
             | Type::Function { .. }
             | Type::TypeParam { .. } => {
-                bail!("set_struct_or_enum_layout called on a non-struct/enum type")
+                bail!("set_nominal_layout called on a non-nominal type")
             },
         };
 
@@ -431,9 +431,9 @@ impl<'ctx> ExecutionGuard<'ctx> {
         let layout = match fields {
             Some(fields) => {
                 let fields_ptr = self.global_arena.alloc_slice_copy(fields);
-                StructOrEnumLayout::new_struct(size, align, fields_ptr)
+                NominalLayout::new_struct(size, align, fields_ptr)
             },
-            None => StructOrEnumLayout::new_enum(size, align),
+            None => NominalLayout::new_enum(size, align),
         };
         if let Err(other_layout) = slot.set(layout) {
             let installed_layout = slot.get().expect("Layout was just installed");
@@ -462,10 +462,10 @@ impl<'ctx> ExecutionGuard<'ctx> {
     /// Returns `None` if the token has not yet been interned in this module's
     /// context.
     ///
-    /// For struct/enum types, the returned pointer carries identity but its
-    /// layout slot may still be empty — `set_struct_or_enum_layout` runs in
-    /// a separate pass after all field types are interned. Callers
-    /// consuming this in cross-module contexts must tolerate `None` from
+    /// For nominal types, the returned pointer carries identity but its
+    /// layout slot may still be empty — `set_nominal_layout` runs in a
+    /// separate pass after all field types are interned. Callers consuming
+    /// this in cross-module contexts must tolerate `None` from
     /// [`Type::size_and_align`] and [`Type::layout`] until the layout-
     /// population pass completes.
     pub fn try_intern_for_module(

--- a/third_party/move/mono-move/global-context/src/context/types.rs
+++ b/third_party/move/mono-move/global-context/src/context/types.rs
@@ -3,7 +3,7 @@
 
 //! Type interning infrastructure.
 //!
-//! The pure type model ([`Type`], [`FieldLayout`], [`StructOrEnumLayout`], etc.)
+//! The pure type model ([`Type`], [`FieldLayout`], [`NominalLayout`], etc.)
 //! lives in `mono_move_core::types`. This module provides the interning
 //! machinery that deduplicates types in the global arena, plus cross-format
 //! hashing/equality between [`SignatureToken`]s and interned [`Type`]s.
@@ -134,7 +134,7 @@ mod type_discriminant {
     pub(super) const REFERENCE: u8 = 15;
     pub(super) const REFERENCE_MUT: u8 = 16;
     pub(super) const VECTOR: u8 = 17;
-    pub(super) const STRUCT: u8 = 18;
+    pub(super) const NOMINAL: u8 = 18;
     pub(super) const FUNCTION: u8 = 19;
     pub(super) const TYPE_PARAM: u8 = 20;
 }
@@ -214,7 +214,7 @@ impl Hash for TypeInternerKey {
                 type_discriminant::VECTOR.hash(state);
                 Self(*elem).hash(state);
             },
-            StructOrEnum {
+            Nominal {
                 executable_id,
                 name,
                 ty_args,
@@ -232,7 +232,7 @@ impl Hash for TypeInternerKey {
                 // hash of lookup key (e.g., signature token). Type identity
                 // is based on address, executable name, name and type
                 // arguments.
-                type_discriminant::STRUCT.hash(state);
+                type_discriminant::NOMINAL.hash(state);
                 executable_id.address().hash(state);
                 executable_name.hash(state);
                 name.hash(state);
@@ -324,13 +324,13 @@ impl PartialEq for TypeInternerKey {
                     false
                 }
             },
-            StructOrEnum {
+            Nominal {
                 executable_id,
                 name,
                 ty_args,
                 ..
             } => {
-                if let StructOrEnum {
+                if let Nominal {
                     executable_id: other_executable_id,
                     name: other_name,
                     ty_args: other_ty_args,
@@ -474,7 +474,7 @@ fn hash_struct_signature_token<H: Hasher>(
     ty_args: &[SignatureToken],
     module: &CompiledModule,
 ) {
-    type_discriminant::STRUCT.hash(state);
+    type_discriminant::NOMINAL.hash(state);
     let (address, module_name, struct_name) = struct_info_at(module, idx);
     address.hash(state);
     module_name.as_str().hash(state);
@@ -485,20 +485,20 @@ fn hash_struct_signature_token<H: Hasher>(
     }
 }
 
-/// Returns true if [`Type`] is equivalent to a [`SignatureToken`] struct or
-/// an enum (identified by handle index and type arguments).
+/// Returns true if [`Type`] is equivalent to a [`SignatureToken`] nominal
+/// type (struct or enum, identified by handle index and type arguments).
 ///
 /// # Safety
 ///
 /// All pointers inside the interned type must be safe to dereference.
-fn equivalent_struct_types(
+fn equivalent_nominal_types(
     ty: &Type,
     idx: StructHandleIndex,
     ty_args: &[SignatureToken],
     module: &CompiledModule,
 ) -> bool {
     let (other_executable_id, other_name, other_ty_args) = match ty {
-        Type::StructOrEnum {
+        Type::Nominal {
             executable_id,
             name,
             ty_args,
@@ -595,8 +595,10 @@ impl Equivalent<TypeInternerKey> for SignatureTokenKey<'_> {
                     false
                 }
             },
-            Struct(idx) => equivalent_struct_types(ty, *idx, &[], self.1),
-            StructInstantiation(idx, ty_args) => equivalent_struct_types(ty, *idx, ty_args, self.1),
+            Struct(idx) => equivalent_nominal_types(ty, *idx, &[], self.1),
+            StructInstantiation(idx, ty_args) => {
+                equivalent_nominal_types(ty, *idx, ty_args, self.1)
+            },
             Function(args, results, abilities) => {
                 if let Type::Function {
                     args: other_args,

--- a/third_party/move/mono-move/global-context/src/context/types.rs
+++ b/third_party/move/mono-move/global-context/src/context/types.rs
@@ -3,7 +3,7 @@
 
 //! Type interning infrastructure.
 //!
-//! The pure type model ([`Type`], [`FieldLayout`], [`StructLayout`], etc.)
+//! The pure type model ([`Type`], [`FieldLayout`], [`StructOrEnumLayout`], etc.)
 //! lives in `mono_move_core::types`. This module provides the interning
 //! machinery that deduplicates types in the global arena, plus cross-format
 //! hashing/equality between [`SignatureToken`]s and interned [`Type`]s.
@@ -214,16 +214,11 @@ impl Hash for TypeInternerKey {
                 type_discriminant::VECTOR.hash(state);
                 Self(*elem).hash(state);
             },
-            Struct {
+            StructOrEnum {
                 executable_id,
                 name,
                 ty_args,
                 layout: _,
-            }
-            | Enum {
-                executable_id,
-                name,
-                ty_args,
             } => {
                 // SAFETY: It is safe to dereference pointers because the
                 // caller ensures they remain valid during the lifetime of
@@ -234,9 +229,9 @@ impl Hash for TypeInternerKey {
                 let ty_args = unsafe { ty_args.as_ref_unchecked() };
 
                 // Must use structural hash because it is compared against the
-                // hash of lookup key (e.g., signature token). Enums reuse the
-                // same discriminant as structs because type identity is based
-                // on address, executable name, name and type arguments.
+                // hash of lookup key (e.g., signature token). Type identity
+                // is based on address, executable name, name and type
+                // arguments.
                 type_discriminant::STRUCT.hash(state);
                 executable_id.address().hash(state);
                 executable_name.hash(state);
@@ -329,35 +324,17 @@ impl PartialEq for TypeInternerKey {
                     false
                 }
             },
-            Struct {
+            StructOrEnum {
                 executable_id,
                 name,
                 ty_args,
                 ..
             } => {
-                if let Struct {
+                if let StructOrEnum {
                     executable_id: other_executable_id,
                     name: other_name,
                     ty_args: other_ty_args,
                     ..
-                } = other
-                {
-                    executable_id == other_executable_id
-                        && name == other_name
-                        && ty_args == other_ty_args
-                } else {
-                    false
-                }
-            },
-            Enum {
-                executable_id,
-                name,
-                ty_args,
-            } => {
-                if let Enum {
-                    executable_id: other_executable_id,
-                    name: other_name,
-                    ty_args: other_ty_args,
                 } = other
                 {
                     executable_id == other_executable_id
@@ -521,16 +498,11 @@ fn equivalent_struct_types(
     module: &CompiledModule,
 ) -> bool {
     let (other_executable_id, other_name, other_ty_args) = match ty {
-        Type::Struct {
+        Type::StructOrEnum {
             executable_id,
             name,
             ty_args,
             ..
-        }
-        | Type::Enum {
-            executable_id,
-            name,
-            ty_args,
         } => (executable_id, name, ty_args),
         Type::Bool
         | Type::U8

--- a/third_party/move/mono-move/orchestrator/src/builder.rs
+++ b/third_party/move/mono-move/orchestrator/src/builder.rs
@@ -335,11 +335,9 @@ impl<'a, 'guard, 'ctx> ExecutableBuilder<'a, 'guard, 'ctx> {
                 }
 
                 let size = align_up(offset, align);
-                let ptr = self
-                    .guard
-                    .intern_struct_or_enum(self.id, name, EMPTY_TYPE_LIST);
+                let ptr = self.guard.intern_nominal(self.id, name, EMPTY_TYPE_LIST);
                 self.guard
-                    .set_struct_or_enum_layout(ptr, size, align, Some(&fields))?;
+                    .set_nominal_layout(ptr, size, align, Some(&fields))?;
 
                 self.structs.insert(name, StructType::new(ptr));
                 Ok(ptr)
@@ -355,13 +353,10 @@ impl<'a, 'guard, 'ctx> ExecutableBuilder<'a, 'guard, 'ctx> {
                 let ty = self
                     .guard
                     .try_intern_for_module(&tok, self.module)
-                    .unwrap_or_else(|| {
-                        self.guard
-                            .intern_struct_or_enum(self.id, name, EMPTY_TYPE_LIST)
-                    });
+                    .unwrap_or_else(|| self.guard.intern_nominal(self.id, name, EMPTY_TYPE_LIST));
                 // Enum size/align is fixed today (heap pointer); the layout
                 // slot stores no per-field offsets.
-                self.guard.set_struct_or_enum_layout(ty, 8, 8, None)?;
+                self.guard.set_nominal_layout(ty, 8, 8, None)?;
 
                 let mut variants = Vec::with_capacity(variant_defs.len());
                 for variant_def in variant_defs {

--- a/third_party/move/mono-move/orchestrator/src/builder.rs
+++ b/third_party/move/mono-move/orchestrator/src/builder.rs
@@ -337,8 +337,9 @@ impl<'a, 'guard, 'ctx> ExecutableBuilder<'a, 'guard, 'ctx> {
                 let size = align_up(offset, align);
                 let ptr = self
                     .guard
-                    .intern_struct_identity(self.id, name, EMPTY_TYPE_LIST);
-                self.guard.set_struct_layout(ptr, size, align, &fields)?;
+                    .intern_struct_or_enum(self.id, name, EMPTY_TYPE_LIST);
+                self.guard
+                    .set_struct_or_enum_layout(ptr, size, align, Some(&fields))?;
 
                 self.structs.insert(name, StructType::new(ptr));
                 Ok(ptr)
@@ -354,7 +355,13 @@ impl<'a, 'guard, 'ctx> ExecutableBuilder<'a, 'guard, 'ctx> {
                 let ty = self
                     .guard
                     .try_intern_for_module(&tok, self.module)
-                    .unwrap_or_else(|| self.guard.intern_enum_type(self.id, name, EMPTY_TYPE_LIST));
+                    .unwrap_or_else(|| {
+                        self.guard
+                            .intern_struct_or_enum(self.id, name, EMPTY_TYPE_LIST)
+                    });
+                // Enum size/align is fixed today (heap pointer); the layout
+                // slot stores no per-field offsets.
+                self.guard.set_struct_or_enum_layout(ty, 8, 8, None)?;
 
                 let mut variants = Vec::with_capacity(variant_defs.len());
                 for variant_def in variant_defs {

--- a/third_party/move/mono-move/specializer/src/stackless_exec_ir/display.rs
+++ b/third_party/move/mono-move/specializer/src/stackless_exec_ir/display.rs
@@ -825,7 +825,7 @@ fn display_type(f: &mut fmt::Formatter<'_>, ty: InternedType) -> fmt::Result {
             write!(f, "&mut ")?;
             display_type(f, *inner)
         },
-        Type::Struct { name, .. } | Type::Enum { name, .. } => {
+        Type::StructOrEnum { name, .. } => {
             write!(f, "{}", view_name(*name))
         },
         Type::Function { args, results, .. } => {

--- a/third_party/move/mono-move/specializer/src/stackless_exec_ir/display.rs
+++ b/third_party/move/mono-move/specializer/src/stackless_exec_ir/display.rs
@@ -825,7 +825,7 @@ fn display_type(f: &mut fmt::Formatter<'_>, ty: InternedType) -> fmt::Result {
             write!(f, "&mut ")?;
             display_type(f, *inner)
         },
-        Type::StructOrEnum { name, .. } => {
+        Type::Nominal { name, .. } => {
             write!(f, "{}", view_name(*name))
         },
         Type::Function { args, results, .. } => {

--- a/third_party/move/mono-move/testsuite/tests/types_tests.rs
+++ b/third_party/move/mono-move/testsuite/tests/types_tests.rs
@@ -67,12 +67,13 @@ struct D
     let layout = executable
         .get_struct(name.into_global_arena_ptr())
         .unwrap()
-        .struct_layout()
+        .layout()
         .unwrap();
     assert_eq!(layout.size, 96);
     assert_eq!(layout.align, 32);
     let offsets = layout
         .field_layouts()
+        .expect("Struct layout carries per-field offsets")
         .iter()
         .map(|f| f.offset)
         .collect::<Vec<_>>();
@@ -82,12 +83,13 @@ struct D
     let layout = executable
         .get_struct(name.into_global_arena_ptr())
         .unwrap()
-        .struct_layout()
+        .layout()
         .unwrap();
     assert_eq!(layout.size, 192);
     assert_eq!(layout.align, 32);
     let offsets = layout
         .field_layouts()
+        .expect("Struct layout carries per-field offsets")
         .iter()
         .map(|f| f.offset)
         .collect::<Vec<_>>();


### PR DESCRIPTION
## Why

Imported struct/enum references go through a `StructHandleIndex` that doesn't tell us whether the target is a struct or an enum. Keeping `Type::Struct` and `Type::Enum` as separate variants forced the loader to commit to "struct vs. enum" at the moment we intern an identity for a cross-module reference, which blocks lazy cross-module layout population.

## What

Fold `Type::Struct` and `Type::Enum` into a single `Type::StructOrEnum` carrying an `OnceLock<StructOrEnumLayout>`. The layout struct has `size`, `align`, and an optional `fields` pointer — `Some` for structs (per-field offsets), `None` for enums.

Interning is now shape-agnostic:

- `intern_struct_or_enum` allocates the identity with an empty layout slot, no struct/enum commitment.
- `set_struct_or_enum_layout(ty, size, align, fields)` fills the slot later — pass `Some(&fields)` for structs, `None` for enums.
- The dedicated `intern_enum_type` is gone. Three `Struct {..} | Enum {..}` paired match arms (hash, eq, equivalence) collapse to one.

## Test plan

- [x] `cargo check -p mono-move-core -p mono-move-global-context -p mono-move-orchestrator -p specializer -p mono-move-testsuite`
- [x] `cargo test -p mono-move-testsuite` (unit, differential, snapshot, types_tests)
- [x] CI clippy / fmt

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors core type representations and layout population APIs across the interner/loader path, which can affect type identity hashing/equality and runtime layout resolution. Behavior should remain equivalent but mistakes could cause subtle mismatches or missing layouts at runtime.
> 
> **Overview**
> Combines `Type::Struct` and `Type::Enum` into a single `Type::Nominal` variant with a unified `OnceLock<NominalLayout>` layout slot, where per-field offsets are optional (`Some` for structs, `None` for enums).
> 
> Updates the global-context interning APIs to be shape-agnostic (`intern_nominal`, `set_nominal_layout`) and removes the dedicated enum interning path, adjusting hashing/equality and signature-token equivalence to use a single nominal discriminant.
> 
> Adjusts the orchestrator, IR display, and tests to use the new nominal layout accessors (`Type::layout`, `NominalLayout::field_layouts()` returning `Option`) and to explicitly set enum size/align without caching field offsets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01b1606529ab9ab0a235001063b1f400980b8a4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->