### PR TITLE
[consensus] Enable sending Batch V2 and OptQS V2 proposals

### DIFF
--- a/config/src/config/quorum_store_config.rs
+++ b/config/src/config/quorum_store_config.rs
@@ -160,9 +160,9 @@ impl Default for QuorumStoreConfig {
             enable_opt_quorum_store: true,
             opt_qs_minimum_batch_age_usecs: Duration::from_millis(50).as_micros() as u64,
             enable_payload_v2: false,
-            enable_batch_v2_tx: false,
+            enable_batch_v2_tx: true,
             enable_batch_v2_rx: true,
-            enable_opt_qs_v2_payload_tx: false,
+            enable_opt_qs_v2_payload_tx: true,
             enable_opt_qs_v2_payload_rx: true,
         }
     }


### PR DESCRIPTION
## Summary
- Flip `enable_batch_v2_tx` and `enable_opt_qs_v2_payload_tx` defaults to `true` in `QuorumStoreConfig`
- Receive flags (`enable_batch_v2_rx`, `enable_opt_qs_v2_payload_rx`) were already `true`, so this completes the rollout by enabling the send side

## Test plan
- [x] CI green
- [x] Smoke / forge tests pass with senders emitting V2 batches and OptQS V2 proposals

🤖 Generated with [Claude Code](https://claude.com/claude-code)