### PR TITLE
[cli] Add aptos-node --commit flag

### DIFF
--- a/aptos-node/src/lib.rs
+++ b/aptos-node/src/lib.rs
@@ -22,7 +22,7 @@ use crate::utils::ensure_max_open_files_limit;
 use anyhow::{anyhow, Context};
 use aptos_admin_service::AdminService;
 use aptos_api::bootstrap as bootstrap_api;
-use aptos_build_info::build_information;
+use aptos_build_info::{build_information, get_git_hash};
 use aptos_config::config::{merge_node_config, NodeConfig, PersistableConfig};
 use aptos_framework::ReleaseBundle;
 use aptos_genesis::builder::GenesisConfiguration;
@@ -60,9 +60,12 @@ pub struct AptosNodeArgs {
         short = 'f',
         long,
         value_parser,
-        required_unless_present_any = ["test", "info"],
+        required_unless_present_any = ["test", "info", "commit"],
     )]
-    #[cfg_attr(target_os = "linux", clap(required_unless_present_any = ["stacktrace"]))]
+    #[cfg_attr(
+        target_os = "linux",
+        clap(required_unless_present_any = ["stacktrace", "test", "info", "commit"])
+    )]
     config: Option<PathBuf>,
 
     /// Directory to run the test mode in.
@@ -106,6 +109,10 @@ pub struct AptosNodeArgs {
     #[clap(long)]
     info: bool,
 
+    /// Display the git commit hash for this node binary
+    #[clap(long)]
+    commit: bool,
+
     #[cfg(target_os = "linux")]
     /// Start as a child process to collect thread dump.
     /// See rstack-self crate for more details.
@@ -133,6 +140,11 @@ impl AptosNodeArgs {
                 serde_json::to_string_pretty(&build_information)
                     .expect("Failed to print build information")
             );
+            return;
+        }
+
+        if self.commit {
+            println!("{}", binary_commit_hash());
             return;
         }
 
@@ -194,6 +206,10 @@ impl AptosNodeArgs {
 pub fn load_seed(input: &str) -> Result<[u8; 32], FromHexError> {
     let trimmed_input = input.trim();
     FromHex::from_hex(trimmed_input)
+}
+
+fn binary_commit_hash() -> String {
+    get_git_hash()
 }
 
 /// Runtime handle to ensure that all inner runtimes stay in scope
@@ -917,4 +933,30 @@ pub fn setup_environment_and_start_node(
 fn verify_tool() {
     use clap::CommandFactory;
     AptosNodeArgs::command().debug_assert()
+}
+
+#[test]
+fn test_commit_flag_parses_without_config() {
+    let args = AptosNodeArgs::try_parse_from(["aptos-node", "--commit"])
+        .expect("--commit should parse without requiring a config");
+
+    assert!(args.commit);
+    assert!(!args.info);
+    assert!(args.config.is_none());
+}
+
+#[test]
+fn test_binary_commit_hash_matches_build_info() {
+    let build_information = build_information!();
+    let commit_hash = build_information
+        .get(aptos_build_info::BUILD_COMMIT_HASH)
+        .expect("build information should include a commit hash");
+
+    assert_eq!(binary_commit_hash(), *commit_hash);
+}
+
+#[test]
+fn test_info_flag_parses_without_config() {
+    AptosNodeArgs::try_parse_from(["aptos-node", "--info"])
+        .expect("--info should parse without requiring a config");
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description
- add a top-level `--commit` flag to `aptos-node`
- print the embedded git commit hash used by the binary, matching the build metadata source exposed by the REST API index endpoint
- allow `aptos-node --commit` to run without requiring a node config path, similar to other informational flags

## How Has This Been Tested?
- `cargo check -p aptos-node`
- `cargo test -p aptos-node --lib -- --nocapture`
- `cargo run -p aptos-node -- --commit`

## Key Areas to Review
- `aptos-node/src/lib.rs` clap wiring for top-level flags that bypass config loading
- `binary_commit_hash()` helper and its use of `aptos_build_info::get_git_hash()`
- parser/unit tests covering standalone `--commit` and build-info consistency

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [x] Tests

## Which Components or Systems Does This Change Impact?
- [x] Validator Node
- [x] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://aptos-org.slack.com/archives/C045G5Q0V8W/p1777415023581659?thread_ts=1777415023.581659&cid=C045G5Q0V8W)

<div><a href="https://cursor.com/agents/bc-e08edc70-717b-5fb1-bf30-13537246f8ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e08edc70-717b-5fb1-bf30-13537246f8ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

