### PR TITLE
[gha] do not publish docker on hotfix suffix

### DIFF
--- a/.github/workflows/copy-images-to-dockerhub-release.yaml
+++ b/.github/workflows/copy-images-to-dockerhub-release.yaml
@@ -23,6 +23,8 @@ permissions:
 
 jobs:
   copy-images-to-docker-hub:
+    # Skip hotfix branches/tags; same substring rule as before, without shell interpolation.
+    if: ${{ !contains(github.ref_name, 'hotfix') }}
     uses: ./.github/workflows/copy-images-to-dockerhub.yaml
     with:
       image_tag_prefix: ${{ github.ref_name }}


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

Do not retag docker images on releases with `hotfix` in the tag.

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only changes a GitHub Actions workflow condition to prevent publishing/retagging images when the ref name includes `hotfix`. Main risk is accidentally skipping (or not skipping) publishes due to the simple substring match.
> 
> **Overview**
> Adds a `verify-ref-name` job to detect whether the pushed tag/branch name contains `hotfix`, and gates the `copy-images-to-docker-hub` reusable workflow to run only when `is_hotfix` is `false`.
> 
> This prevents DockerHub image copying/retagging on hotfix-suffixed releases, with additional debug logging to aid troubleshooting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd5b801378f4f6fd8d8242e8f4c869e25a4d2ac9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->