### PR TITLE
[mono-vm] Combining differential and snapshot testing

### DIFF
--- a/third_party/move/mono-move/specializer/src/stackless_exec_ir/display.rs
+++ b/third_party/move/mono-move/specializer/src/stackless_exec_ir/display.rs
@@ -24,12 +24,7 @@ impl fmt::Display for ModuleIR {
         let self_handle = module.module_handle_at(module.self_module_handle_idx);
         let addr = module.address_identifier_at(self_handle.address);
         let name = module.identifier_at(self_handle.name);
-        writeln!(
-            f,
-            "=== Module 0x{}::{} ===",
-            addr.short_str_lossless(),
-            name
-        )?;
+        writeln!(f, "// module 0x{}::{}", addr.short_str_lossless(), name)?;
 
         for func_ir in self.functions.iter().flatten() {
             writeln!(f)?;

--- a/third_party/move/mono-move/testsuite/Cargo.toml
+++ b/third_party/move/mono-move/testsuite/Cargo.toml
@@ -28,17 +28,17 @@ move-binary-format = { workspace = true }
 move-compiler-v2 = { workspace = true }
 move-core-types = { workspace = true }
 move-model = { workspace = true }
+move-prover-test-utils = { workspace = true }
 move-stdlib = { path = "../../move-stdlib" }
 move-vm-runtime = { workspace = true }
 move-vm-test-utils = { workspace = true }
 move-vm-types = { workspace = true }
+specializer = { workspace = true }
 tempfile = { workspace = true }
 
 [dev-dependencies]
 datatest-stable = { workspace = true }
 libtest-mimic = { workspace = true }
-move-prover-test-utils = { workspace = true }
-specializer = { workspace = true }
 walkdir = { workspace = true }
 
 [[test]]

--- a/third_party/move/mono-move/testsuite/src/lib.rs
+++ b/third_party/move/mono-move/testsuite/src/lib.rs
@@ -7,6 +7,7 @@ pub mod compile;
 pub mod matcher;
 pub mod module_provider;
 pub mod parser;
+pub mod print_sections;
 pub mod runner;
 
 pub use compile::{

--- a/third_party/move/mono-move/testsuite/src/parser.rs
+++ b/third_party/move/mono-move/testsuite/src/parser.rs
@@ -9,12 +9,24 @@
 //! A test file is a sequence of **publish** and **execute** steps processed
 //! in order. Each step may have **check** directives attached.
 //!
-//! ## `// RUN: publish`
+//! ## `// RUN: publish [--print(<sections>)]`
 //!
 //! All non-directive lines following this marker (until the next `// RUN:`
 //! directive or EOF) are collected verbatim as Move source text, compiled
 //! into one or more modules, and published into the test storage for both
 //! VMs. Multiple publish blocks accumulate modules across the test.
+//!
+//! The optional `--print(<csv>)` modifier requests that an `.exp` snapshot
+//! be produced alongside the test file. Recognized sections:
+//!
+//! - `bytecode`  — Move bytecode disassembly (rejected for `.masm` inputs,
+//!                 since the bytecode *is* the input).
+//! - `stackless` — stackless execution IR.
+//! - `micro-ops` — lowered micro-ops.
+//!
+//! Sections are emitted in the order above regardless of the order written
+//! in `--print(...)`. Unknown tokens or an empty section list cause the
+//! test to fail at parse time.
 //!
 //! ## `// RUN: execute <addr>::<module>::<func> [--args <v1>, <v2>, ...]`
 //!
@@ -55,11 +67,20 @@ pub enum Check {
     V2(String),
 }
 
+/// A snapshot section requested via `// RUN: publish --print(...)`.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum PrintSection {
+    Bytecode,
+    Stackless,
+    MicroOps,
+}
+
 /// A single step in a differential test.
 #[derive(Debug)]
 pub enum Step {
     Publish {
         sources: String,
+        print: Vec<PrintSection>,
     },
     Execute {
         address: AccountAddress,
@@ -74,7 +95,7 @@ pub enum Step {
 pub fn parse(content: &str) -> anyhow::Result<Vec<Step>> {
     let mut steps = vec![];
     let mut sources = vec![];
-    let mut in_publish = false;
+    let mut publish_print: Option<Vec<PrintSection>> = None;
 
     for raw_line in content.lines() {
         let line = raw_line.trim();
@@ -82,16 +103,16 @@ pub fn parse(content: &str) -> anyhow::Result<Vec<Step>> {
         if let Some(directive) = line.strip_prefix("// RUN:") {
             let directive = directive.trim();
 
-            if in_publish {
+            if let Some(print) = publish_print.take() {
                 steps.push(Step::Publish {
                     sources: sources.join("\n"),
+                    print,
                 });
                 sources.clear();
-                in_publish = false;
             }
 
-            if directive == "publish" {
-                in_publish = true;
+            if let Some(rest) = directive.strip_prefix("publish") {
+                publish_print = Some(parse_publish_modifiers(rest.trim())?);
             } else if let Some(rest) = directive.strip_prefix("execute") {
                 let rest = rest.trim();
                 let step = parse_execute_step(rest)
@@ -108,18 +129,49 @@ pub fn parse(content: &str) -> anyhow::Result<Vec<Step>> {
             let pattern = pattern.trim().to_string();
             attach_check(&mut steps, Check::V1(pattern.clone()))?;
             attach_check(&mut steps, Check::V2(pattern))?;
-        } else if in_publish {
+        } else if publish_print.is_some() {
             sources.push(raw_line);
         }
     }
 
-    if in_publish {
+    if let Some(print) = publish_print.take() {
         steps.push(Step::Publish {
             sources: sources.join("\n"),
+            print,
         });
     }
 
     Ok(steps)
+}
+
+/// Parse the modifiers after the `publish` keyword. Currently only
+/// `--print(<sections>)` is supported.
+fn parse_publish_modifiers(rest: &str) -> anyhow::Result<Vec<PrintSection>> {
+    if rest.is_empty() {
+        return Ok(vec![]);
+    }
+    let inner = rest
+        .strip_prefix("--print(")
+        .and_then(|s| s.strip_suffix(')'))
+        .ok_or_else(|| anyhow!("Unrecognized publish modifier: {}", rest))?;
+    let mut sections = vec![];
+    for raw in inner.split(',') {
+        let token = raw.trim();
+        let section = match token {
+            "bytecode" => PrintSection::Bytecode,
+            "stackless" => PrintSection::Stackless,
+            "micro-ops" => PrintSection::MicroOps,
+            _ => bail!("Unknown print section: {:?}", token),
+        };
+        if sections.contains(&section) {
+            bail!("Duplicate print section: {:?}", token);
+        }
+        sections.push(section);
+    }
+    if sections.is_empty() {
+        bail!("`--print()` requires at least one section");
+    }
+    Ok(sections)
 }
 
 /// Parses execution step.

--- a/third_party/move/mono-move/testsuite/src/parser.rs
+++ b/third_party/move/mono-move/testsuite/src/parser.rs
@@ -154,6 +154,9 @@ fn parse_publish_modifiers(rest: &str) -> anyhow::Result<Vec<PrintSection>> {
         .strip_prefix("--print(")
         .and_then(|s| s.strip_suffix(')'))
         .ok_or_else(|| anyhow!("Unrecognized publish modifier: {}", rest))?;
+    if inner.trim().is_empty() {
+        bail!("`--print()` requires at least one section");
+    }
     let mut sections = vec![];
     for raw in inner.split(',') {
         let token = raw.trim();
@@ -167,9 +170,6 @@ fn parse_publish_modifiers(rest: &str) -> anyhow::Result<Vec<PrintSection>> {
             bail!("Duplicate print section: {:?}", token);
         }
         sections.push(section);
-    }
-    if sections.is_empty() {
-        bail!("`--print()` requires at least one section");
     }
     Ok(sections)
 }

--- a/third_party/move/mono-move/testsuite/src/print_sections.rs
+++ b/third_party/move/mono-move/testsuite/src/print_sections.rs
@@ -1,0 +1,138 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Render print sections (bytecode, stackless IR, micro-ops) for the
+//! differential and snapshot test harnesses.
+//!
+//! Given a list of [`PrintSection`]s requested via `// RUN: publish
+//! --print(...)`, [`render`] produces a string containing a
+//! `=== <section> ===` block per requested section per compiled module.
+//! Sections are emitted in a fixed order (`bytecode` → `stackless` →
+//! `micro-ops`) regardless of the order in the directive.
+
+use crate::parser::PrintSection;
+use anyhow::{anyhow, Result};
+use mono_move_core::types::InternedType;
+use mono_move_global_context::ExecutionGuard;
+use mono_move_orchestrator::ExecutableBuilder;
+use move_binary_format::{access::ModuleAccess, CompiledModule};
+use specializer::{
+    destack,
+    lower::{lower_function, try_build_context, MicroOpsFunctionDisplay},
+    stackless_exec_ir::ModuleIR,
+};
+
+/// Render the requested sections for all modules into a single string.
+pub fn render(
+    guard: &ExecutionGuard<'_>,
+    modules: &[CompiledModule],
+    sections: &[PrintSection],
+) -> Result<String> {
+    let want_bytecode = sections.contains(&PrintSection::Bytecode);
+    let want_stackless = sections.contains(&PrintSection::Stackless);
+    let want_micro_ops = sections.contains(&PrintSection::MicroOps);
+
+    let mut out = String::new();
+    for module in modules {
+        if want_bytecode {
+            push_section(&mut out, "=== bytecode ===\n", &format_bytecode(module)?);
+        }
+        if want_stackless || want_micro_ops {
+            let struct_types = resolve_struct_types(guard, module)?;
+            let module_ir = destack(module.clone(), guard, &struct_types)
+                .map_err(|e| anyhow!("destack failed: {:#}", e))?;
+            if want_stackless {
+                push_section(&mut out, "=== stackless ===\n", &module_ir.to_string());
+            }
+            if want_micro_ops {
+                push_section(
+                    &mut out,
+                    "=== micro-ops ===\n",
+                    &format_micro_ops(&module_ir),
+                );
+            }
+        }
+    }
+    Ok(out)
+}
+
+fn push_section(out: &mut String, header: &str, content: &str) {
+    out.push_str(header);
+    out.push_str(content);
+    if !content.ends_with('\n') {
+        out.push('\n');
+    }
+}
+
+fn format_bytecode(module: &CompiledModule) -> Result<String> {
+    move_asm::disassembler::disassemble_module(String::new(), module)
+        .map_err(|e| anyhow!("bytecode disassembly failed: {:#}", e))
+}
+
+/// Resolve struct types via the orchestrator's builder and return the
+/// `struct_type_table` that the specializer expects.
+pub fn resolve_struct_types(
+    guard: &ExecutionGuard<'_>,
+    module: &CompiledModule,
+) -> Result<Vec<Option<InternedType>>> {
+    let mut builder = ExecutableBuilder::new(guard, module);
+    builder
+        .resolve_types()
+        .map_err(|e| anyhow!("type resolution failed: {:#}", e))?;
+    Ok(builder.struct_type_table())
+}
+
+/// Format the micro-ops for every function in `module_ir`, with a
+/// `// module ...` banner and a stanza per function (or a
+/// `skipped (...)` line when lowering is not yet supported).
+pub fn format_micro_ops(module_ir: &ModuleIR) -> String {
+    let module = &module_ir.module;
+    let self_handle = module.module_handle_at(module.self_module_handle_idx);
+    let addr = module.address_identifier_at(self_handle.address);
+    let mod_name = module.identifier_at(self_handle.name);
+
+    let mut out = String::new();
+    out.push_str(&format!(
+        "// module 0x{}::{}\n",
+        addr.short_str_lossless(),
+        mod_name
+    ));
+
+    for func_ir in module_ir.functions.iter().flatten() {
+        let func_name = module.identifier_at(func_ir.name_idx).to_string();
+        match try_build_context(module_ir, func_ir) {
+            Err(e) => {
+                out.push_str(&format!(
+                    "\nfun {}(): skipped (context: {})\n",
+                    func_name, e
+                ));
+            },
+            Ok(None) => {
+                out.push_str(&format!(
+                    "\nfun {}(): skipped (not all types are concrete)\n",
+                    func_name
+                ));
+            },
+            Ok(Some(ctx)) => match lower_function(func_ir, &ctx) {
+                Ok(ops) => {
+                    out.push('\n');
+                    out.push_str(
+                        &MicroOpsFunctionDisplay {
+                            func_name: &func_name,
+                            ctx: &ctx,
+                            ops: &ops,
+                        }
+                        .to_string(),
+                    );
+                },
+                Err(e) => {
+                    out.push_str(&format!(
+                        "\nfun {}(): skipped (lowering: {})\n",
+                        func_name, e
+                    ));
+                },
+            },
+        }
+    }
+    out
+}

--- a/third_party/move/mono-move/testsuite/src/runner.rs
+++ b/third_party/move/mono-move/testsuite/src/runner.rs
@@ -7,9 +7,10 @@
 use crate::{
     compile::{compile, SourceKind},
     matcher::check_output,
-    parser::Step,
+    parser::{PrintSection, Step},
+    print_sections,
 };
-use anyhow::anyhow;
+use anyhow::{anyhow, bail};
 use mono_move_core::NoopTransactionContext;
 use mono_move_gas::SimpleGasMeter;
 use mono_move_global_context::{ExecutionGuard, GlobalContext};
@@ -27,6 +28,7 @@ use move_vm_runtime::{
 };
 use move_vm_test_utils::InMemoryStorage;
 use move_vm_types::{gas::UnmeteredGasMeter, loaded_data::runtime_types::Type};
+use std::path::Path;
 
 /// Execution output from a VM, carrying both the display string and the
 /// number of return values so that mono-move can avoid reparsing.
@@ -35,16 +37,20 @@ struct Output {
     num_returns: usize,
 }
 
-/// Run all steps in a differential test, checking both VMs produce matching output.
-pub fn run_test(steps: Vec<Step>, kind: SourceKind) -> anyhow::Result<()> {
+/// Run all steps in a differential test, checking both VMs produce matching
+/// output. If any `Publish` step requested `--print(...)` sections, the
+/// rendered snapshot is verified against (or written to with `UPBL=1`) a
+/// `.exp` baseline alongside `test_path`.
+pub fn run_test(steps: Vec<Step>, kind: SourceKind, test_path: &Path) -> anyhow::Result<()> {
     let ctx = GlobalContext::with_num_execution_workers(1);
     let guard = ctx.try_execution_context(0).unwrap();
 
     let mut storage = InMemoryStorage::new();
+    let mut snapshot = String::new();
 
     for step in steps {
         match step {
-            Step::Publish { sources } => {
+            Step::Publish { sources, print } => {
                 let modules = compile(&sources, kind)?;
                 for module in &modules {
                     // V1 path.
@@ -63,6 +69,16 @@ pub fn run_test(steps: Vec<Step>, kind: SourceKind) -> anyhow::Result<()> {
                     guard
                         .insert_loaded_module(loaded)
                         .map_err(|err| anyhow!("Failed to insert loaded module: {}", err))?;
+                }
+
+                if !print.is_empty() {
+                    if matches!(kind, SourceKind::Masm) && print.contains(&PrintSection::Bytecode) {
+                        bail!(
+                            "`bytecode` is not a valid print section for .masm inputs — \
+                             the bytecode is the input"
+                        );
+                    }
+                    snapshot.push_str(&print_sections::render(&guard, &modules, &print)?);
                 }
             },
             Step::Execute {
@@ -85,6 +101,11 @@ pub fn run_test(steps: Vec<Step>, kind: SourceKind) -> anyhow::Result<()> {
                 check_output(&checks, &v1_output.display, &v2_output.display)?;
             },
         }
+    }
+
+    if !snapshot.is_empty() {
+        let baseline = test_path.with_extension("exp");
+        move_prover_test_utils::baseline_test::verify_or_update_baseline(&baseline, &snapshot)?;
     }
 
     Ok(())

--- a/third_party/move/mono-move/testsuite/tests/differential.rs
+++ b/third_party/move/mono-move/testsuite/tests/differential.rs
@@ -35,7 +35,7 @@ fn main() {
                 let content = std::fs::read_to_string(&path).map_err(|e| format!("{:?}", e))?;
                 let steps =
                     mono_move_testsuite::parser::parse(&content).map_err(|e| format!("{:?}", e))?;
-                mono_move_testsuite::runner::run_test(steps, kind)
+                mono_move_testsuite::runner::run_test(steps, kind, &path)
                     .map_err(|e| format!("{:?}", e).into())
             })
         })

--- a/third_party/move/mono-move/testsuite/tests/snapshot.rs
+++ b/third_party/move/mono-move/testsuite/tests/snapshot.rs
@@ -10,77 +10,13 @@
 //! Struct references render with real names via the orchestrator's
 //! [`ExecutableBuilder`] rather than a placeholder table.
 
-use mono_move_core::types::InternedType;
-use mono_move_global_context::{ExecutionGuard, GlobalContext};
-use mono_move_orchestrator::ExecutableBuilder;
-use mono_move_testsuite::{assemble_masm_source, compile_move_path};
-use move_binary_format::{access::ModuleAccess, CompiledModule};
-use specializer::{
-    destack,
-    lower::{lower_function, try_build_context, MicroOpsFunctionDisplay},
-    stackless_exec_ir::ModuleIR,
+use mono_move_global_context::GlobalContext;
+use mono_move_testsuite::{
+    assemble_masm_source, compile_move_path,
+    print_sections::{format_micro_ops, resolve_struct_types},
 };
+use specializer::destack;
 use std::path::Path;
-
-fn format_micro_ops(module_ir: &ModuleIR) -> String {
-    let module = &module_ir.module;
-    let self_handle = module.module_handle_at(module.self_module_handle_idx);
-    let addr = module.address_identifier_at(self_handle.address);
-    let mod_name = module.identifier_at(self_handle.name);
-
-    let mut out = String::new();
-    out.push_str(&format!(
-        "=== Module 0x{}::{} ===\n",
-        addr.short_str_lossless(),
-        mod_name
-    ));
-
-    for func_ir in module_ir.functions.iter().flatten() {
-        let func_name = module.identifier_at(func_ir.name_idx).to_string();
-        match try_build_context(module_ir, func_ir) {
-            Err(e) => {
-                out.push_str(&format!(
-                    "\nfun {}(): skipped (context: {})\n",
-                    func_name, e
-                ));
-            },
-            Ok(None) => {
-                out.push_str(&format!(
-                    "\nfun {}(): skipped (not all types are concrete)\n",
-                    func_name
-                ));
-            },
-            Ok(Some(ctx)) => match lower_function(func_ir, &ctx) {
-                Ok(ops) => {
-                    out.push('\n');
-                    out.push_str(&format!("{}", MicroOpsFunctionDisplay {
-                        func_name: &func_name,
-                        ctx: &ctx,
-                        ops: &ops,
-                    }));
-                },
-                Err(e) => {
-                    out.push_str(&format!(
-                        "\nfun {}(): skipped (lowering: {})\n",
-                        func_name, e
-                    ));
-                },
-            },
-        }
-    }
-    out
-}
-
-/// Resolve types via the orchestrator's builder and return the
-/// struct_type_table that the specializer expects.
-fn resolve_struct_types(
-    guard: &ExecutionGuard<'_>,
-    module: &CompiledModule,
-) -> Result<Vec<Option<InternedType>>, String> {
-    let mut builder = ExecutableBuilder::new(guard, module);
-    builder.resolve_types().map_err(|e| format!("{:#}", e))?;
-    Ok(builder.struct_type_table())
-}
 
 const EXP_EXT: &str = "exp";
 
@@ -99,10 +35,10 @@ fn masm_runner(path: &Path) -> datatest_stable::Result<()> {
 
     let ctx = GlobalContext::with_num_execution_workers(1);
     let guard = ctx.try_execution_context(0).unwrap();
-    let struct_types = resolve_struct_types(&guard, &module)?;
+    let struct_types = resolve_struct_types(&guard, &module).map_err(|e| format!("{:#}", e))?;
 
     let ir = destack(module, &guard, &struct_types).map_err(|e| format!("{:#}", e))?;
-    let mut output = format!("{}", ir);
+    let mut output = ir.to_string();
     output.push_str("\n=== micro-ops ===\n");
     output.push_str(&format_micro_ops(&ir));
 
@@ -122,16 +58,15 @@ fn move_runner(path: &Path) -> datatest_stable::Result<()> {
 
     let mut output = String::new();
     for module in &modules {
-        let struct_types = resolve_struct_types(&guard, module)?;
+        let struct_types = resolve_struct_types(&guard, module).map_err(|e| format!("{:#}", e))?;
         let masm_output = move_asm::disassembler::disassemble_module(String::new(), module)
             .map_err(|e| format!("disassembly failed: {:#}", e))?;
         let module_ir =
             destack(module.clone(), &guard, &struct_types).map_err(|e| format!("{:#}", e))?;
-        let ir_output = format!("{}", module_ir);
         output.push_str("=== masm ===\n");
         output.push_str(&masm_output);
         output.push_str("\n=== specializer ===\n");
-        output.push_str(&ir_output);
+        output.push_str(&module_ir.to_string());
         output.push_str("\n=== micro-ops ===\n");
         output.push_str(&format_micro_ops(&module_ir));
     }

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/add_three.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/add_three.exp
@@ -1,0 +1,39 @@
+=== bytecode ===
+// Bytecode version v10
+module 0x1::test
+// Function definition at index 0
+fun add_three(l0: u64, l1: u64, l2: u64): u64
+    move_loc l0
+    move_loc l1
+    add
+    move_loc l2
+    add
+    // @5
+    ret
+
+=== stackless ===
+// module 0x1::test
+
+fun add_three(r0, r1, r2): u64 {
+  slots: params(3), locals(0), temps(1)
+    r0: u64
+    r1: u64
+    r2: u64
+    r3: u64
+  code:
+  L0:
+    0: r3 := add r0, r1
+    1: r3 := add r3, r2
+    2: ret [r3]
+}
+=== micro-ops ===
+// module 0x1::test
+
+fun add_three() {
+  frame_data_size: 32
+  code:
+    0: AddU64 [24] <- [0] + [8]
+    1: AddU64 [24] <- [24] + [16]
+    2: Move8 [0] <- [24]
+    3: Return
+}

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/add_three.move
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/add_three.move
@@ -1,7 +1,7 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-// RUN: publish
+// RUN: publish --print(bytecode,stackless,micro-ops)
 module 0x1::test {
     fun add_three(a: u64, b: u64, c: u64): u64 {
         a + b + c

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/add_values.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/add_values.exp
@@ -1,3 +1,4 @@
+=== stackless ===
 // module 0x66::test
 
 fun add_values(r0, r1): u64 {
@@ -10,19 +11,6 @@ fun add_values(r0, r1): u64 {
     0: r2 := add r0, r1
     1: ret [r2]
 }
-
-fun complex_arith(r0): u64 {
-  slots: params(1), locals(1), temps(1)
-    r0: u64
-    r1: u64
-    r2: u64
-  code:
-  L0:
-    0: r1 := mul r0, #2
-    1: r2 := add r1, #1
-    2: ret [r2]
-}
-
 === micro-ops ===
 // module 0x66::test
 
@@ -33,5 +21,3 @@ fun add_values() {
     1: Move8 [0] <- [16]
     2: Return
 }
-
-fun complex_arith(): skipped (lowering: BinaryOpImm Mul for u64-sized type not yet lowered)

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/add_values.masm
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/add_values.masm
@@ -1,7 +1,7 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-// RUN: publish
+// RUN: publish --print(stackless,micro-ops)
 module 0x66::test
 
 fun add_values(a: u64, b: u64): u64

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/basic_arithmetic.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/basic_arithmetic.exp
@@ -1,0 +1,33 @@
+=== bytecode ===
+// Bytecode version v10
+module 0x1::test
+// Function definition at index 0
+fun add(l0: u64, l1: u64): u64
+    move_loc l0
+    move_loc l1
+    add
+    ret
+
+=== stackless ===
+// module 0x1::test
+
+fun add(r0, r1): u64 {
+  slots: params(2), locals(0), temps(1)
+    r0: u64
+    r1: u64
+    r2: u64
+  code:
+  L0:
+    0: r2 := add r0, r1
+    1: ret [r2]
+}
+=== micro-ops ===
+// module 0x1::test
+
+fun add() {
+  frame_data_size: 24
+  code:
+    0: AddU64 [16] <- [0] + [8]
+    1: Move8 [0] <- [16]
+    2: Return
+}

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/basic_arithmetic.move
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/basic_arithmetic.move
@@ -1,7 +1,7 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-// RUN: publish
+// RUN: publish --print(bytecode,stackless,micro-ops)
 module 0x1::test {
     fun add(a: u64, b: u64): u64 {
         a + b

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/branch.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/branch.exp
@@ -1,0 +1,43 @@
+=== bytecode ===
+// Bytecode version v10
+module 0x1::test
+// Function definition at index 0
+fun clamp(l0: u64): u64
+    copy_loc l0
+    ld_u64 10
+    le
+    br_false l0
+    move_loc l0
+    // @5
+    ret
+l0: ld_u64 10
+    ret
+
+=== stackless ===
+// module 0x1::test
+
+fun clamp(r0): u64 {
+  slots: params(1), locals(0), temps(1)
+    r0: u64
+    r1: u64
+  code:
+  L2:
+    0: br_gt L0, r0, #10
+  L1:
+    1: ret [r0]
+  L0:
+    2: r1 := ld_u64 10
+    3: ret [r1]
+}
+=== micro-ops ===
+// module 0x1::test
+
+fun clamp() {
+  frame_data_size: 16
+  code:
+    0: JumpGreaterU64Imm @2 [0] > #10
+    1: Return
+    2: StoreImm8 [8] <- #10
+    3: Move8 [0] <- [8]
+    4: Return
+}

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/branch.move
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/branch.move
@@ -1,7 +1,7 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-// RUN: publish
+// RUN: publish --print(bytecode,stackless,micro-ops)
 module 0x1::test {
     fun clamp(n: u64): u64 {
         if (n <= 10) {

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/fibonacci.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/fibonacci.exp
@@ -1,6 +1,6 @@
-=== masm ===
+=== bytecode ===
 // Bytecode version v10
-module 0x42::fibonacci
+module 0x1::test
 // Function definition at index 0
 fun fib(l0: u64): u64
     copy_loc l0
@@ -23,9 +23,8 @@ l0: copy_loc l0
     // @15
     ret
 
-
-=== specializer ===
-// module 0x42::fibonacci
+=== stackless ===
+// module 0x1::test
 
 fun fib(r0): u64 {
   slots: params(1), locals(0), temps(1), xfer(1)
@@ -44,9 +43,8 @@ fun fib(r0): u64 {
     6: r1 := add r1, x0
     7: ret [r1]
 }
-
 === micro-ops ===
-// module 0x42::fibonacci
+// module 0x1::test
 
 fun fib() {
   frame_data_size: 16

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/fibonacci.move
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/fibonacci.move
@@ -1,7 +1,7 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-// RUN: publish
+// RUN: publish --print(bytecode,stackless,micro-ops)
 module 0x1::test {
     fun fib(n: u64): u64 {
         if (n <= 1) { n } else { fib(n - 1) + fib(n - 2) }

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/multi_func.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/multi_func.exp
@@ -1,0 +1,59 @@
+=== bytecode ===
+// Bytecode version v10
+module 0x1::test
+// Function definition at index 0
+fun double(l0: u64): u64
+    copy_loc l0
+    move_loc l0
+    add
+    ret
+
+// Function definition at index 1
+fun quad(l0: u64): u64
+    move_loc l0
+    call double
+    call double
+    ret
+
+=== stackless ===
+// module 0x1::test
+
+fun double(r0): u64 {
+  slots: params(1), locals(0), temps(1)
+    r0: u64
+    r1: u64
+  code:
+  L0:
+    0: r1 := add r0, r0
+    1: ret [r1]
+}
+
+fun quad(r0): u64 {
+  slots: params(1), locals(0), temps(0), xfer(1)
+    r0: u64
+  code:
+  L0:
+    0: [x0] := call double, [r0]
+    1: [x0] := call double, [x0]
+    2: ret [x0]
+}
+=== micro-ops ===
+// module 0x1::test
+
+fun double() {
+  frame_data_size: 16
+  code:
+    0: AddU64 [8] <- [0] + [0]
+    1: Move8 [0] <- [8]
+    2: Return
+}
+
+fun quad() {
+  frame_data_size: 8
+  code:
+    0: Move8 [32] <- [0]
+    1: CallFunc #0
+    2: CallFunc #0
+    3: Move8 [0] <- [32]
+    4: Return
+}

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/multi_func.move
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/multi_func.move
@@ -1,7 +1,7 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-// RUN: publish
+// RUN: publish --print(bytecode,stackless,micro-ops)
 module 0x1::test {
     fun double(x: u64): u64 {
         x + x

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/multi_module.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/multi_module.exp
@@ -1,0 +1,69 @@
+=== bytecode ===
+// Bytecode version v10
+module 0x1::math
+// Function definition at index 0
+#[persistent] public fun double(l0: u64): u64
+    copy_loc l0
+    move_loc l0
+    add
+    ret
+
+=== stackless ===
+// module 0x1::math
+
+fun double(r0): u64 {
+  slots: params(1), locals(0), temps(1)
+    r0: u64
+    r1: u64
+  code:
+  L0:
+    0: r1 := add r0, r0
+    1: ret [r1]
+}
+=== micro-ops ===
+// module 0x1::math
+
+fun double() {
+  frame_data_size: 16
+  code:
+    0: AddU64 [8] <- [0] + [0]
+    1: Move8 [0] <- [8]
+    2: Return
+}
+=== bytecode ===
+// Bytecode version v10
+module 0x1::utils
+// Function definition at index 0
+#[persistent] public fun triple(l0: u64): u64
+    copy_loc l0
+    copy_loc l0
+    add
+    move_loc l0
+    add
+    // @5
+    ret
+
+=== stackless ===
+// module 0x1::utils
+
+fun triple(r0): u64 {
+  slots: params(1), locals(0), temps(1)
+    r0: u64
+    r1: u64
+  code:
+  L0:
+    0: r1 := add r0, r0
+    1: r1 := add r1, r0
+    2: ret [r1]
+}
+=== micro-ops ===
+// module 0x1::utils
+
+fun triple() {
+  frame_data_size: 16
+  code:
+    0: AddU64 [8] <- [0] + [0]
+    1: AddU64 [8] <- [8] + [0]
+    2: Move8 [0] <- [8]
+    3: Return
+}

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/multi_module.move
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/multi_module.move
@@ -1,7 +1,7 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-// RUN: publish
+// RUN: publish --print(bytecode,stackless,micro-ops)
 module 0x1::math {
     public fun double(x: u64): u64 {
         x + x

--- a/third_party/move/mono-move/testsuite/tests/test_cases/snapshot/masm/arg_regs.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/snapshot/masm/arg_regs.exp
@@ -1,4 +1,4 @@
-=== Module 0x66::arg_regs ===
+// module 0x66::arg_regs
 
 fun identity(r0): u64 {
   slots: params(1), locals(0), temps(0)
@@ -217,7 +217,7 @@ fun no_calls(): u64 {
 }
 
 === micro-ops ===
-=== Module 0x66::arg_regs ===
+// module 0x66::arg_regs
 
 fun identity() {
   frame_data_size: 8

--- a/third_party/move/mono-move/testsuite/tests/test_cases/snapshot/masm/basic_load.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/snapshot/masm/basic_load.exp
@@ -1,4 +1,4 @@
-=== Module 0x66::test ===
+// module 0x66::test
 
 fun load_values(): u64 {
   slots: params(0), locals(0), temps(1)
@@ -19,7 +19,7 @@ fun load_and_store() {
 }
 
 === micro-ops ===
-=== Module 0x66::test ===
+// module 0x66::test
 
 fun load_values() {
   frame_data_size: 8

--- a/third_party/move/mono-move/testsuite/tests/test_cases/snapshot/masm/borrow_soundness.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/snapshot/masm/borrow_soundness.exp
@@ -1,4 +1,4 @@
-=== Module 0x66::borrow_soundness ===
+// module 0x66::borrow_soundness
 
 fun borrow_loc_no_source_subst(r0): u64 {
   slots: params(1), locals(1), temps(2)
@@ -60,7 +60,7 @@ fun mut_borrow_kills_reverse(r0): u64 {
 }
 
 === micro-ops ===
-=== Module 0x66::borrow_soundness ===
+// module 0x66::borrow_soundness
 
 fun borrow_loc_no_source_subst(): skipped (lowering: instruction ImmBorrowLoc not yet lowered)
 

--- a/third_party/move/mono-move/testsuite/tests/test_cases/snapshot/masm/calls.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/snapshot/masm/calls.exp
@@ -1,4 +1,4 @@
-=== Module 0x66::test ===
+// module 0x66::test
 
 fun identity(r0): u64 {
   slots: params(1), locals(0), temps(0)
@@ -18,7 +18,7 @@ fun caller(): u64 {
 }
 
 === micro-ops ===
-=== Module 0x66::test ===
+// module 0x66::test
 
 fun identity() {
   frame_data_size: 8

--- a/third_party/move/mono-move/testsuite/tests/test_cases/snapshot/masm/control_flow.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/snapshot/masm/control_flow.exp
@@ -1,4 +1,4 @@
-=== Module 0x66::test ===
+// module 0x66::test
 
 fun loop_down(r0) {
   slots: params(1), locals(0), temps(0)
@@ -29,7 +29,7 @@ fun conditional(r0): u64 {
 }
 
 === micro-ops ===
-=== Module 0x66::test ===
+// module 0x66::test
 
 fun loop_down() {
   frame_data_size: 8

--- a/third_party/move/mono-move/testsuite/tests/test_cases/snapshot/masm/field_fusion.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/snapshot/masm/field_fusion.exp
@@ -1,4 +1,4 @@
-=== Module 0x66::field_fusion ===
+// module 0x66::field_fusion
 
 fun identity(r0): u64 {
   slots: params(1), locals(0), temps(0)
@@ -80,7 +80,7 @@ fun increment_field(r0) {
 }
 
 === micro-ops ===
-=== Module 0x66::field_fusion ===
+// module 0x66::field_fusion
 
 fun identity() {
   frame_data_size: 8

--- a/third_party/move/mono-move/testsuite/tests/test_cases/snapshot/masm/locals_soundness.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/snapshot/masm/locals_soundness.exp
@@ -1,4 +1,4 @@
-=== Module 0x66::locals_soundness ===
+// module 0x66::locals_soundness
 
 fun local_across_blocks(r0, r1): u64 {
   slots: params(2), locals(1), temps(1)
@@ -32,7 +32,7 @@ fun borrow_written_local(r0): u64 {
 }
 
 === micro-ops ===
-=== Module 0x66::locals_soundness ===
+// module 0x66::locals_soundness
 
 fun local_across_blocks() {
   frame_data_size: 32

--- a/third_party/move/mono-move/testsuite/tests/test_cases/snapshot/masm/references.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/snapshot/masm/references.exp
@@ -1,4 +1,4 @@
-=== Module 0x66::test ===
+// module 0x66::test
 
 fun read_field_val(r0): u8 {
   slots: params(1), locals(0), temps(2)
@@ -41,7 +41,7 @@ fun read_field_ref_twice(r0): u64 {
 }
 
 === micro-ops ===
-=== Module 0x66::test ===
+// module 0x66::test
 
 fun read_field_val(): skipped (lowering: instruction ImmBorrowLoc not yet lowered)
 

--- a/third_party/move/mono-move/testsuite/tests/test_cases/snapshot/masm/struct_ops.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/snapshot/masm/struct_ops.exp
@@ -1,4 +1,4 @@
-=== Module 0x66::test ===
+// module 0x66::test
 
 fun pack_and_unpack(): u64 {
   slots: params(0), locals(1), temps(2)
@@ -15,6 +15,6 @@ fun pack_and_unpack(): u64 {
 }
 
 === micro-ops ===
-=== Module 0x66::test ===
+// module 0x66::test
 
 fun pack_and_unpack(): skipped (lowering: instruction Pack not yet lowered)

--- a/third_party/move/mono-move/testsuite/tests/test_cases/snapshot/masm/v2_leftovers.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/snapshot/masm/v2_leftovers.exp
@@ -1,4 +1,4 @@
-=== Module 0x66::v2_leftovers ===
+// module 0x66::v2_leftovers
 
 fun identity(r0): u64 {
   slots: params(1), locals(0), temps(0)
@@ -70,7 +70,7 @@ fun two_copies_to_call(r0, r1): u64 {
 }
 
 === micro-ops ===
-=== Module 0x66::v2_leftovers ===
+// module 0x66::v2_leftovers
 
 fun identity() {
   frame_data_size: 8

--- a/third_party/move/mono-move/testsuite/tests/test_cases/snapshot/masm/vid_type_reset.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/snapshot/masm/vid_type_reset.exp
@@ -1,4 +1,4 @@
-=== Module 0x66::test ===
+// module 0x66::test
 
 fun vid_type_mismatch(r0): u64 {
   slots: params(1), locals(0), temps(1)
@@ -15,7 +15,7 @@ fun vid_type_mismatch(r0): u64 {
 }
 
 === micro-ops ===
-=== Module 0x66::test ===
+// module 0x66::test
 
 fun vid_type_mismatch() {
   frame_data_size: 16

--- a/third_party/move/mono-move/testsuite/tests/test_cases/snapshot/move/basic.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/snapshot/move/basic.exp
@@ -40,7 +40,7 @@ l0: move_loc l1
 
 
 === specializer ===
-=== Module 0x42::basic ===
+// module 0x42::basic
 
 fun add(r0, r1): u64 {
   slots: params(2), locals(0), temps(1)
@@ -88,7 +88,7 @@ fun max(r0, r1): u64 {
 }
 
 === micro-ops ===
-=== Module 0x42::basic ===
+// module 0x42::basic
 
 fun add() {
   frame_data_size: 24


### PR DESCRIPTION
## Description

We currently have at least two kinds of tests: differential (compare vms v1 vs. v2) and snapshot (display stackless execution ir, micro-ops etc). For now, we want to have both kinds, because the implementations are incomplete.

But as we implement more features, we usually want to both display snapshots and perform end-to-end runs and check semantics vs. v1, else we need to replicate tests in both styles.

In this PR, we add an opt-in --print(...) modifier on the run directive in differential testing:
```
// RUN: publish --print(bytecode,stackless,micro-ops)
```
When present, the harness renders the requested sections — bytecode disassembly, stackless IR, lowered micro-ops — into a .exp snapshot file alongside the test source, verified or refreshed via the standard UPBL=1 baseline mechanism. Sections are emitted in a fixed order regardless of how they're listed. Differential CHECK semantics are unchanged: a single test file can now both run V1/V2 against each other and lock down compile-time output.
  
Validation rules: unknown print tokens, duplicates, and empty --print() fail at parse time; requesting bytecode on a .masm input is rejected (the bytecode is the input).

All existing differential fixtures opted in to the new modifier; their generated .exp files are committed.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to test harnesses and snapshot formatting; main risk is churn/flake potential from baseline output changes and stricter directive parsing.
> 
> **Overview**
> Differential test `publish` steps now accept an opt-in `--print(...)` modifier that records requested compilation/lowering artifacts (bytecode disassembly, stackless IR, and/or micro-ops) into a `.exp` baseline file alongside the test, using the standard `UPBL=1` update flow.
> 
> This adds parsing/validation for print sections (unknown/duplicate/empty rejected; `bytecode` disallowed for `.masm`), introduces a shared `print_sections` renderer reused by snapshot tests, tweaks IR display banners to a `// module ...` style, and updates existing differential fixtures to opt in with newly committed `.exp` outputs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d825ca45717ed1175f176d19b436a49fbee7d4bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->