### PR TITLE
[encrypted mempool] Fix PVSS sigma proof shape check

### DIFF
--- a/crates/aptos-dkg/src/pvss/chunky/weighted_transcript.rs
+++ b/crates/aptos-dkg/src/pvss/chunky/weighted_transcript.rs
@@ -305,6 +305,35 @@ impl<const N: usize, P: FpConfig<N>, E: Pairing<ScalarField = Fp<P, N>>>
             sid,
             <Self as traits::Transcript>::dst(),
         )?;
+
+        // Check SoK shape
+        if self.sharing_proof.SoK.z.len() != sc.get_total_num_players() {
+            bail!(
+                "Sharing proof has incorrect shape: z.len() = {}, when it should be {}",
+                self.sharing_proof.SoK.z.len(),
+                sc.get_total_num_players(),
+            );
+        }
+        for (i,chunked_plaintexts) in self.sharing_proof.SoK.z.chunked_plaintexts.enumerate() {
+            if chunked_plaintexts.len() != sc.get_player_weight(&sc.get_player(i)) {
+                bail!("Sharing proof has incorrect shape: chunked plaintext vec lengths do not correspond to player weights");
+            }
+            for chunked_plaintext in chunked_plaintexts {
+                if chunked_plaintext.len() != num_chunks_per_scalar::<E::ScalarField>(pp.ell) {
+                    bail!("Sharing proof has incorrect shape: chunked plaintext has incorrect number of chunks");
+                }
+            }
+        }
+        if self.sharing_proof.SoK.z.elgamal_randomness.len() != sc.get_max_weight() {
+            bail!("Sharing proof has incorrect shape: elgamal_randomness.len() should equal sc.get_max_weight()");
+        }
+        for randomness in self.sharing_proof.SoK.z.elgamal_randomness {
+            if randomness.len() != num_chunks_per_scalar::<E::ScalarField>(pp.ell) {
+                bail!("Sharing proof has incorrect shape: elgamal_randomness element has incorrect number of chunks");
+            }
+        }
+
+
         let Vs_flat = self.subtrs.all_Vs_flat(); // Also has the public key V[0]
 
         // Step 1: Do the SCRAPE LDT (G_2)

--- a/crates/aptos-dkg/src/pvss/chunky/weighted_transcript.rs
+++ b/crates/aptos-dkg/src/pvss/chunky/weighted_transcript.rs
@@ -310,7 +310,14 @@ impl<const N: usize, P: FpConfig<N>, E: Pairing<ScalarField = Fp<P, N>>>
         if self.sharing_proof.SoK.z.chunked_plaintexts.len() != sc.get_total_num_players() {
             bail!("Sharing proof has incorrect shape: z.len() != sc.get_total_num_players()");
         }
-        for (i,chunked_plaintexts) in self.sharing_proof.SoK.z.chunked_plaintexts.iter().enumerate() {
+        for (i, chunked_plaintexts) in self
+            .sharing_proof
+            .SoK
+            .z
+            .chunked_plaintexts
+            .iter()
+            .enumerate()
+        {
             if chunked_plaintexts.len() != sc.get_player_weight(&sc.get_player(i))
                 .expect("Should never fail to get player, b/c of z.len() == sc.get_total_num_players() check above")
             {
@@ -330,7 +337,6 @@ impl<const N: usize, P: FpConfig<N>, E: Pairing<ScalarField = Fp<P, N>>>
                 bail!("Sharing proof has incorrect shape: elgamal_randomness element has incorrect number of chunks");
             }
         }
-
 
         let Vs_flat = self.subtrs.all_Vs_flat(); // Also has the public key V[0]
 

--- a/crates/aptos-dkg/src/pvss/chunky/weighted_transcript.rs
+++ b/crates/aptos-dkg/src/pvss/chunky/weighted_transcript.rs
@@ -307,15 +307,13 @@ impl<const N: usize, P: FpConfig<N>, E: Pairing<ScalarField = Fp<P, N>>>
         )?;
 
         // Check SoK shape
-        if self.sharing_proof.SoK.z.len() != sc.get_total_num_players() {
-            bail!(
-                "Sharing proof has incorrect shape: z.len() = {}, when it should be {}",
-                self.sharing_proof.SoK.z.len(),
-                sc.get_total_num_players(),
-            );
+        if self.sharing_proof.SoK.z.chunked_plaintexts.len() != sc.get_total_num_players() {
+            bail!("Sharing proof has incorrect shape: z.len() != sc.get_total_num_players()");
         }
-        for (i,chunked_plaintexts) in self.sharing_proof.SoK.z.chunked_plaintexts.enumerate() {
-            if chunked_plaintexts.len() != sc.get_player_weight(&sc.get_player(i)) {
+        for (i,chunked_plaintexts) in self.sharing_proof.SoK.z.chunked_plaintexts.iter().enumerate() {
+            if chunked_plaintexts.len() != sc.get_player_weight(&sc.get_player(i))
+                .expect("Should never fail to get player, b/c of z.len() == sc.get_total_num_players() check above")
+            {
                 bail!("Sharing proof has incorrect shape: chunked plaintext vec lengths do not correspond to player weights");
             }
             for chunked_plaintext in chunked_plaintexts {
@@ -327,7 +325,7 @@ impl<const N: usize, P: FpConfig<N>, E: Pairing<ScalarField = Fp<P, N>>>
         if self.sharing_proof.SoK.z.elgamal_randomness.len() != sc.get_max_weight() {
             bail!("Sharing proof has incorrect shape: elgamal_randomness.len() should equal sc.get_max_weight()");
         }
-        for randomness in self.sharing_proof.SoK.z.elgamal_randomness {
+        for randomness in &self.sharing_proof.SoK.z.elgamal_randomness {
             if randomness.len() != num_chunks_per_scalar::<E::ScalarField>(pp.ell) {
                 bail!("Sharing proof has incorrect shape: elgamal_randomness element has incorrect number of chunks");
             }

--- a/crates/aptos-dkg/src/sigma_protocol/traits.rs
+++ b/crates/aptos-dkg/src/sigma_protocol/traits.rs
@@ -276,7 +276,6 @@ pub trait CurveGroupTrait:
             None => bail!("proof must contain commitment for Fiat–Shamir"),
         };
 
-
         let c = self.fiat_shamir_challenge_for_sigma_protocol(
             cntxt,
             public_statement,

--- a/crates/aptos-dkg/src/sigma_protocol/traits.rs
+++ b/crates/aptos-dkg/src/sigma_protocol/traits.rs
@@ -275,6 +275,8 @@ pub trait CurveGroupTrait:
             Some(m) => m,
             None => bail!("proof must contain commitment for Fiat–Shamir"),
         };
+
+
         let c = self.fiat_shamir_challenge_for_sigma_protocol(
             cntxt,
             public_statement,


### PR DESCRIPTION
Auditors noticed the shape of the sigma protocol wasn't being checked, which could lead to malicious shapes that cause skipped verification. This PR adds the necessary shape checks to prevent this.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches cryptographic verification paths: while the change is additive validation, incorrect assumptions about expected dimensions could cause valid transcripts to be rejected or mask deeper shape mismatches.
> 
> **Overview**
> Tightens `chunky` weighted PVSS transcript verification by **explicitly validating the shape of the sigma proof response `z`** (per-player plaintext vectors, per-weight chunk counts, and `elgamal_randomness` dimensions) before proceeding with the rest of verification.
> 
> This prevents malformed or adversarially-shaped proofs from causing skipped/partial verification; no functional protocol changes beyond these new precondition checks (plus a trivial formatting change in `sigma_protocol::traits`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ac1c0f6827d6a8e4b2d293687f18d693ee78ad8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->