### PR TITLE
[forge] Probe txn-readiness before emitting + per-client failover in minter

### DIFF
--- a/crates/transaction-emitter-lib/src/emitter/account_minter.rs
+++ b/crates/transaction-emitter-lib/src/emitter/account_minter.rs
@@ -19,13 +19,51 @@ use aptos_transaction_generator_lib::{
 use aptos_types::account_address::AccountAddress;
 use core::result::Result::{Err, Ok};
 use futures::{future::try_join_all, StreamExt};
-use log::{error, info};
+use log::{error, info, warn};
 use rand::{rngs::StdRng, Rng, SeedableRng};
 use std::{
     path::Path,
     sync::Arc,
     time::{Duration, Instant},
 };
+
+/// Number of attempts per batch before propagating the failure. The first attempt may route
+/// to a client that's permanently broken (e.g. a validator just restarted by a compat upgrade);
+/// the executor's per-client unhealthy bit gets set during that attempt, so a second attempt
+/// has a real chance of routing to a healthy client.
+const MINTER_BATCH_ATTEMPTS: usize = 2;
+
+/// Submit a batch of transactions, retrying once on failure. We re-submit the same
+/// `SignedTransaction`s — any that landed on the first attempt will hit
+/// `SEQUENCE_NUMBER_TOO_OLD` and fall through to the on-chain check inside
+/// `submit_check_and_retry`, while genuine retries get a fresh client pick informed by the
+/// per-client health state that the first attempt populated.
+async fn execute_batch_with_failover(
+    txn_executor: &dyn ReliableTransactionSubmitter,
+    requests: &[SignedTransaction],
+    counters: &CounterState,
+    label: &str,
+) -> Result<()> {
+    let mut last_err: Option<anyhow::Error> = None;
+    for attempt in 0..MINTER_BATCH_ATTEMPTS {
+        match txn_executor
+            .execute_transactions_with_counter(requests, counters)
+            .await
+        {
+            Ok(()) => return Ok(()),
+            Err(err) => {
+                if attempt + 1 < MINTER_BATCH_ATTEMPTS {
+                    warn!(
+                        "{} attempt {} failed, will retry: {:?}",
+                        label, attempt, err
+                    );
+                }
+                last_err = Some(err);
+            },
+        }
+    }
+    Err(last_err.unwrap_or_else(|| anyhow!("{} exhausted attempts", label)))
+}
 
 pub struct SourceAccountManager<'t> {
     pub source_account: Arc<LocalAccount>,
@@ -385,9 +423,13 @@ impl<'t> AccountMinter<'t> {
                     )
                 })
                 .collect();
-            txn_executor
-                .execute_transactions_with_counter(&create_requests, counters)
-                .await?;
+            execute_batch_with_failover(
+                txn_executor,
+                &create_requests,
+                counters,
+                "create_and_fund_seed_accounts",
+            )
+            .await?;
         }
 
         Ok(())
@@ -495,15 +537,19 @@ async fn create_and_fund_new_accounts(
             })
             .collect();
 
-        txn_executor
-            .execute_transactions_with_counter(&creation_requests, counters)
-            .await
-            .with_context(|| {
-                format!(
-                    "Account {} couldn't mint batch {}",
-                    source_address, batch_index
-                )
-            })?;
+        execute_batch_with_failover(
+            txn_executor,
+            &creation_requests,
+            counters,
+            &format!("create_and_fund_new_accounts batch {}", batch_index),
+        )
+        .await
+        .with_context(|| {
+            format!(
+                "Account {} couldn't mint batch {}",
+                source_address, batch_index
+            )
+        })?;
     }
     Ok(())
 }

--- a/crates/transaction-emitter-lib/src/emitter/transaction_executor.rs
+++ b/crates/transaction-emitter-lib/src/emitter/transaction_executor.rs
@@ -18,11 +18,20 @@ use std::{
     time::{Duration, Instant},
 };
 
+/// Number of consecutive submit/wait failures against a client at which we treat it as
+/// unhealthy and skip it in subsequent client selection. A successful submission resets
+/// the counter back to zero. Picked small enough that a permanently-broken client (e.g.
+/// a validator just restarted by an upgrade) is excluded after a few txns rather than
+/// after the full `max_retries` worth of attempts that the seeded retry would otherwise
+/// consume on a single doomed client.
+const UNHEALTHY_CONSECUTIVE_FAILURES: usize = 3;
+
 // Reliable/retrying transaction executor, used for initializing
 pub struct RestApiReliableTransactionSubmitter {
     rest_clients: Vec<RestClient>,
     max_retries: usize,
     retry_after: Duration,
+    consecutive_failures: Vec<AtomicUsize>,
 }
 
 impl RestApiReliableTransactionSubmitter {
@@ -32,23 +41,67 @@ impl RestApiReliableTransactionSubmitter {
             max_retries,
             retry_after.as_secs_f32()
         );
+        let consecutive_failures = (0..rest_clients.len())
+            .map(|_| AtomicUsize::new(0))
+            .collect();
         Self {
             rest_clients,
             max_retries,
             retry_after,
+            consecutive_failures,
         }
+    }
+
+    fn client_index(&self, client: &RestClient) -> Option<usize> {
+        let key = client.path_prefix_string();
+        self.rest_clients
+            .iter()
+            .position(|c| c.path_prefix_string() == key)
+    }
+
+    fn note_success(&self, client: &RestClient) {
+        if let Some(idx) = self.client_index(client) {
+            self.consecutive_failures[idx].store(0, std::sync::atomic::Ordering::Relaxed);
+        }
+    }
+
+    fn note_failure(&self, client: &RestClient) {
+        if let Some(idx) = self.client_index(client) {
+            self.consecutive_failures[idx].fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        }
+    }
+
+    fn healthy_client_indices(&self) -> Vec<usize> {
+        (0..self.rest_clients.len())
+            .filter(|i| {
+                self.consecutive_failures[*i].load(std::sync::atomic::Ordering::Relaxed)
+                    < UNHEALTHY_CONSECUTIVE_FAILURES
+            })
+            .collect()
     }
 
     fn random_rest_client(&self) -> &RestClient {
         let mut rng = thread_rng();
-        self.rest_clients.choose(&mut rng).unwrap()
+        self.random_rest_client_from_rng(&mut rng)
     }
 
+    /// Pick a client, preferring those whose recent submissions succeeded. If every client
+    /// is currently flagged as unhealthy we fall back to the full pool — a deadlock here
+    /// would be worse than retrying against a known-bad client.
     fn random_rest_client_from_rng<R>(&self, rng: &mut R) -> &RestClient
     where
         R: Rng + ?Sized,
     {
-        self.rest_clients.choose(rng).unwrap()
+        let healthy = self.healthy_client_indices();
+        let idx = if healthy.is_empty() {
+            *(0..self.rest_clients.len())
+                .collect::<Vec<_>>()
+                .choose(rng)
+                .unwrap()
+        } else {
+            *healthy.choose(rng).unwrap()
+        };
+        &self.rest_clients[idx]
     }
 
     async fn submit_check_and_retry(
@@ -116,6 +169,7 @@ impl RestApiReliableTransactionSubmitter {
 
             match result {
                 Ok(()) => {
+                    self.note_success(rest_client);
                     counters
                         .successes
                         .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
@@ -130,6 +184,9 @@ impl RestApiReliableTransactionSubmitter {
                     return Ok(());
                 },
                 Err(err) => {
+                    if failed_submit || failed_wait {
+                        self.note_failure(rest_client);
+                    }
                     // TODO: we should have a better way to decide if a failure is retryable
                     if format!("{}", err).contains("SEQUENCE_NUMBER_TOO_OLD") {
                         break;

--- a/testsuite/forge/src/interface/swarm.rs
+++ b/testsuite/forge/src/interface/swarm.rs
@@ -517,3 +517,101 @@ pub async fn get_highest_synced_version_and_epoch(
     }
     Ok(latest_version_and_epoch)
 }
+
+/// Wait until each of `clients` is ready to land transactions.
+///
+/// "Ready" means: REST endpoint replies, ledger version is within `max_lag_versions` of the
+/// highest version among the set, and ledger timestamp is within `max_timestamp_lag` of wall
+/// clock now. This is a transactional readiness probe — a client that just restarted or hasn't
+/// finished state-syncing yet will report a stale ledger timestamp and we wait for it to catch
+/// up before letting the emitter target it. Without this, the emitter sends txns that expire
+/// before the node's mempool sees them ("Transaction expired, without being seen in mempool")
+/// or that hit the 60s `DEFAULT_MAX_SERVER_LAG_WAIT_DURATION` ceiling in the rest client.
+pub async fn wait_for_clients_to_be_txn_ready(
+    clients: &[RestClient],
+    max_lag_versions: u64,
+    max_timestamp_lag: Duration,
+    timeout: Duration,
+) -> Result<()> {
+    if clients.is_empty() {
+        return Ok(());
+    }
+    let start = Instant::now();
+    loop {
+        let infos = join_all(clients.iter().map(|c| c.get_ledger_information())).await;
+        let mut last_status: Vec<(String, String)> = Vec::with_capacity(clients.len());
+        let mut max_version: u64 = 0;
+        let mut all_ok = true;
+        let now_usecs = aptos_infallible::duration_since_epoch().as_micros() as u64;
+        let max_ts_lag_usecs = max_timestamp_lag.as_micros() as u64;
+        for (client, info) in clients.iter().zip(infos.iter()) {
+            match info {
+                Ok(resp) => {
+                    let inner = resp.inner();
+                    max_version = max_version.max(inner.version);
+                    let ts_lag_usecs = now_usecs.saturating_sub(inner.timestamp_usecs);
+                    if ts_lag_usecs > max_ts_lag_usecs {
+                        all_ok = false;
+                        last_status.push((
+                            client.path_prefix_string(),
+                            format!(
+                                "ledger timestamp lags wall clock by {}s (limit {}s), version {}",
+                                ts_lag_usecs / 1_000_000,
+                                max_timestamp_lag.as_secs(),
+                                inner.version,
+                            ),
+                        ));
+                    } else {
+                        last_status.push((
+                            client.path_prefix_string(),
+                            format!("ok at version {}", inner.version),
+                        ));
+                    }
+                },
+                Err(err) => {
+                    all_ok = false;
+                    last_status.push((client.path_prefix_string(), format!("error: {}", err)));
+                },
+            }
+        }
+        if all_ok {
+            // Re-check version skew now that we know max_version.
+            let mut version_ok = true;
+            for (client, info) in clients.iter().zip(infos.iter()) {
+                if let Ok(resp) = info {
+                    let v = resp.inner().version;
+                    if max_version.saturating_sub(v) > max_lag_versions {
+                        version_ok = false;
+                        last_status.push((
+                            client.path_prefix_string(),
+                            format!(
+                                "version {} is {} behind max {} (limit {})",
+                                v,
+                                max_version - v,
+                                max_version,
+                                max_lag_versions,
+                            ),
+                        ));
+                    }
+                }
+            }
+            if version_ok {
+                info!(
+                    "All {} clients are txn-ready in {}s",
+                    clients.len(),
+                    start.elapsed().as_secs()
+                );
+                return Ok(());
+            }
+        }
+
+        if start.elapsed() > timeout {
+            return Err(anyhow!(
+                "wait_for_clients_to_be_txn_ready timed out after {}s; status: {:?}",
+                start.elapsed().as_secs(),
+                last_status,
+            ));
+        }
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+}

--- a/testsuite/testcases/src/lib.rs
+++ b/testsuite/testcases/src/lib.rs
@@ -29,8 +29,9 @@ pub mod validator_reboot_stress_test;
 use anyhow::Context;
 use aptos_forge::{
     prometheus_metrics::{fetch_latency_breakdown, LatencyBreakdown},
-    EmitJob, EmitJobRequest, NetworkContext, NetworkContextSynchronizer, NetworkTest, NodeExt,
-    Result, Swarm, SwarmExt, Test, TestReport, TxnEmitter, TxnStats, Version,
+    wait_for_clients_to_be_txn_ready, EmitJob, EmitJobRequest, NetworkContext,
+    NetworkContextSynchronizer, NetworkTest, NodeExt, Result, Swarm, SwarmExt, Test, TestReport,
+    TxnEmitter, TxnStats, Version,
 };
 use aptos_logger::warn;
 use aptos_rest_client::Client as RestClient;
@@ -51,6 +52,14 @@ use tokio::runtime::{Handle, Runtime};
 const DEFAULT_REST_CLIENT_TIMEOUT_SECS: u64 = 30;
 pub const WARMUP_DURATION_FRACTION: f32 = 0.07;
 pub const COOLDOWN_DURATION_FRACTION: f32 = 0.04;
+
+/// Bounds for the txn-ready probe used before emitting load against a chosen client set.
+/// The timestamp bound is the load-bearing check (catches PFNs that haven't peered or
+/// validators that just restarted); the version bound is a sanity check that the chosen
+/// clients agree with each other. The overall timeout caps how long we'll wait.
+const TXN_READY_MAX_LAG_VERSIONS: u64 = 1_000;
+const TXN_READY_MAX_TIMESTAMP_LAG: Duration = Duration::from_secs(30);
+const TXN_READY_TIMEOUT: Duration = Duration::from_secs(120);
 
 async fn batch_update(
     ctx: &mut NetworkContext<'_>,
@@ -172,6 +181,14 @@ pub async fn generate_traffic(
         .read()
         .await
         .get_clients_for_peers(nodes, Duration::from_secs(DEFAULT_REST_CLIENT_TIMEOUT_SECS));
+    wait_for_clients_to_be_txn_ready(
+        &clients,
+        TXN_READY_MAX_LAG_VERSIONS,
+        TXN_READY_MAX_TIMESTAMP_LAG,
+        TXN_READY_TIMEOUT,
+    )
+    .await
+    .context("wait for traffic clients to be txn-ready")?;
     let (emitter, emit_job_request) =
         create_emitter_and_request(ctx.swarm.clone(), emit_job_request, clients, rng).await?;
 
@@ -390,6 +407,14 @@ pub async fn create_buffered_load(
 ) -> Result<Vec<LoadTestPhaseStats>> {
     // Generate some traffic
     let clients = clients_to_send_load_to.clone();
+    wait_for_clients_to_be_txn_ready(
+        &clients,
+        TXN_READY_MAX_LAG_VERSIONS,
+        TXN_READY_MAX_TIMESTAMP_LAG,
+        TXN_READY_TIMEOUT,
+    )
+    .await
+    .context("wait for load clients to be txn-ready")?;
     let (mut emitter, emit_job_request) = create_emitter_and_request(
         swarm.clone(),
         emit_job_request,


### PR DESCRIPTION
## Description

Fixes the two recurring `InfraFailure` patterns surfaced (most recently) by the forge run [`25121261232`](https://github.com/aptos-labs/aptos-core/actions/runs/25121261232?pr=19584). That run was on a docs-only PR (#19584), so the failures were flakes — but they reflect real brittleness in the harness that's worth fixing rather than papering over with reruns.

### What broke (analysis)

Both failures bottom out in `aptos_transaction_emitter_lib::emitter::account_minter` during the *initial account-creation* phase:

**`forge-e2e` / `CompositeNetworkTest`** (`realistic_env_max_load`):
```
Error: start emitter job
Caused by:
    0: Tried executing 10 txns, request counters: "success 0,
       failed submit [10×18], failed wait [10×18],
       by client: [(0,60,60): pfn-0-lb] [(0,60,60): pfn-2-lb] [(0,60,60): pfn-1-lb]"
    1: Unknown error Transaction expired, without being seen in mempool.
```
Every seed-account txn against every PFN expired before any mempool saw it — the PFNs were process-alive but not yet forwarding to a validator. The job died on the first batch after 18 retries.

**`forge-compat` / `simple-validator-upgrade`**:
```
Error: Failed to create accounts: Account 0x611b... couldn't mint batch 0
Caused by:
    0: ... by client: [(578,42,60):  node-2]
                     [(0,  345,480): node-1]   ← all submissions died here
                     [(581,43,88):  node-3]
                     [(671,23,48):  node-0]
    1: Unknown error Ledger on endpoint (.../node-1...) is more than 60s
       behind current time, timing out waiting for the transaction.
```
3 of 4 validators were healthy; node-1 (just upgraded by `batch_update_gradually`) was `>60 s` behind chain time. The single batch routed to node-1 died and a single batch failure aborts the whole mint via `?`.

### Root causes

1. **Readiness check is too shallow.** `wait_until_healthy` only loops on REST liveness, not "this mempool can land a txn". No PFN-sync gate; no post-upgrade catch-up gate. (The pre-existing `realistic_env_max_load_test` comment "*First start higher gas-fee traffic, to not cause issues with TxnEmitter setup*" is already evidence the team has hit this.)
2. **`AccountMinter` has no client failover.** `create_and_fund_seed_accounts` / `create_and_fund_new_accounts` use sequential `for batch { await? }`; one bad client = whole job dies. `submit_check_and_retry`'s seeded-RNG retry can keep re-picking the same broken client because there's no per-client unhealthy bit.

(Out of scope: the hardcoded 60 s `DEFAULT_MAX_SERVER_LAG_WAIT_DURATION` in `aptos-rest-client/src/lib.rs:63` is fine for steady state — bumping it would just paper over the readiness gap.)

## Changes

### Fix A — close the readiness gap

- **`testsuite/forge/src/interface/swarm.rs`** — new free fn `wait_for_clients_to_be_txn_ready(clients, max_lag_versions, max_timestamp_lag, timeout)`. Polls each client's `get_ledger_information()` and waits until **(a)** each replies Ok, **(b)** every ledger timestamp is within `max_timestamp_lag` of wall-clock, **(c)** every version is within `max_lag_versions` of the highest in the set. Errors out with a per-client status diagnostic on timeout. Re-exported automatically through `pub use swarm::*`.
- **`testsuite/testcases/src/lib.rs`** — call the probe before the emitter starts at both entry points: `generate_traffic` (used by compat after `batch_update_gradually`) and `create_buffered_load` (used by `TwoTrafficsTest` / `CompositeNetworkTest` for `realistic_env_max_load`). Bounds defined as named consts: `1_000` versions, `30 s` timestamp lag, `120 s` overall timeout.

### Fix B — emitter resilience

- **`crates/transaction-emitter-lib/src/emitter/transaction_executor.rs`** — `RestApiReliableTransactionSubmitter` now owns a per-client `consecutive_failures: Vec<AtomicUsize>`. `note_success` resets to 0; `note_failure` increments. `random_rest_client_from_rng` filters clients above `UNHEALTHY_CONSECUTIVE_FAILURES = 3`, falling back to the full pool if all are flagged (avoids deadlock). Same-sender determinism within a retry attempt (the parking-lot invariant) is preserved — the seeded RNG is identical across same-sender txns at the same `i` and they observe the same health snapshot.
- **`crates/transaction-emitter-lib/src/emitter/account_minter.rs`** — new helper `execute_batch_with_failover` retries each batch up to `MINTER_BATCH_ATTEMPTS = 2`. The first attempt populates the unhealthy bit; the second attempt routes around the broken client. Already-committed txns from the first attempt resolve via the existing `SEQUENCE_NUMBER_TOO_OLD` short-circuit + `wait_for_signed_transaction_bcs` fallback. Both `create_and_fund_seed_accounts` and `create_and_fund_new_accounts` now go through the helper.

## How Has This Been Tested?

- `cargo check` on `aptos-transaction-emitter-lib`, `aptos-forge`, `aptos-testcases`, `aptos-forge-cli` — clean.
- `cargo clippy` on the three changed crates with the project's flag set — clean (`dead_code` errors that surface in `aptos-language-e2e-tests` and `aptos-consensus` are pre-existing on `main`).
- `cargo +nightly fmt`, `cargo machete`, `cargo sort --grouped --workspace --check` — clean.
- `cargo test -p aptos-transaction-emitter-lib --lib` (10/10) and `cargo test -p aptos-forge --lib` (26/26) pass. The single failure in `aptos-testcases::multi_region_network_test` reproduces on baseline `main` and is unrelated.
- End-to-end forge runs: covered by the existing `forge-e2e-test` and `forge-compat-test` jobs once this PR is rebased; the changes touch their hot path.

## Key Areas to Review

1. **Probe placement in `lib.rs`** — calling it inside `generate_traffic` and at the top of `create_buffered_load` covers both call sites without changing test orchestration. Confirm there isn't a third emitter entry point I missed.
2. **`random_rest_client_from_rng` filtering vs. parking-lot invariant** — the original comment requires same-sender txns at the same retry index to land on the same client. With a global health snapshot read inside the function, the determinism still holds *within* a single iteration; double-check this reasoning before approving.
3. **`MINTER_BATCH_ATTEMPTS = 2` re-submitting the same `SignedTransaction`s** — relies on the executor's existing `SEQUENCE_NUMBER_TOO_OLD` short-circuit + on-chain re-check to no-op already-landed txns. Confirm this assumption.
4. **Constants** (`UNHEALTHY_CONSECUTIVE_FAILURES = 3`, `TXN_READY_MAX_TIMESTAMP_LAG = 30 s`, `TXN_READY_TIMEOUT = 120 s`, `TXN_READY_MAX_LAG_VERSIONS = 1_000`) — picked to be conservative; happy to tune based on observed behavior in CI.

## Type of Change

- [x] Bug fix

## Which Components or Systems Does This Change Impact?

- [x] Developer Infrastructure

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes transaction submission/client selection and adds new pre-emission gating logic; mistakes could cause false timeouts or skew load generation in CI.
> 
> **Overview**
> Improves forge/emitter resilience to flaky or recently-restarted nodes by **waiting for REST clients to be transaction-ready** (ledger timestamp close to wall clock and versions not too skewed) before starting traffic/load.
> 
> Adds **per-client failover** in the transaction emitter: `RestApiReliableTransactionSubmitter` now tracks consecutive submit/wait failures and temporarily avoids unhealthy clients, and `AccountMinter` retries each minting batch once to route around a bad endpoint instead of aborting the whole job.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e98a075004840de864906cdc944d2fc9b59f83f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->