### PR TITLE
[mono-move] Encapsulate ObjectDescriptor and ObjectDescriptorTable

### DIFF
--- a/third_party/move/mono-move/core/src/instruction/mod.rs
+++ b/third_party/move/mono-move/core/src/instruction/mod.rs
@@ -214,10 +214,13 @@ pub struct PackClosureOp {
     pub func_ref: ClosureFuncRef,
     /// Bitmask of which function parameters are captured vs provided.
     pub mask: u64,
-    /// Descriptor for the allocated closure object.
-    pub closure_descriptor_id: DescriptorId,
-    /// Descriptor for the allocated `ClosureCapturedData` (Materialized) object.
-    pub captured_data_descriptor_id: DescriptorId,
+    /// Descriptor for the allocated `ClosureCapturedData` (Materialized)
+    /// object. `Some` iff this closure captures at least one value;
+    /// otherwise `None` and no captured-data object is allocated.
+    ///
+    /// The closure object's own descriptor is implicit: it is always the
+    /// reserved `CLOSURE_DESCRIPTOR_ID` slot in the descriptor table.
+    pub captured_data_descriptor_id: Option<DescriptorId>,
     /// Sources (in caller's frame) of the captured values, in the order that
     /// `mask.is_captured(i)` is true — i.e. ascending `i` through the
     /// function's parameter list.
@@ -921,9 +924,14 @@ impl fmt::Display for MicroOp {
             MicroOp::PackClosure(op) => {
                 write!(
                     f,
-                    "PackClosure [{}] <- func_ref={:?}, mask={:b}, closure_desc={}, captured_desc={}, captured=[",
-                    op.dst.0, op.func_ref, op.mask, op.closure_descriptor_id, op.captured_data_descriptor_id
+                    "PackClosure [{}] <- func_ref={:?}, mask={:b}, captured_desc=",
+                    op.dst.0, op.func_ref, op.mask
                 )?;
+                match op.captured_data_descriptor_id {
+                    Some(id) => write!(f, "{}", id)?,
+                    None => write!(f, "<none>")?,
+                }
+                write!(f, ", captured=[")?;
                 for (i, slot) in op.captured.iter().enumerate() {
                     if i > 0 {
                         write!(f, ", ")?;

--- a/third_party/move/mono-move/programs/src/bst.rs
+++ b/third_party/move/mono-move/programs/src/bst.rs
@@ -270,14 +270,10 @@ mod micro_op {
         CodeOffset as CO, DescriptorId, FrameLayoutInfo, FrameOffset as FO, Function,
         MicroOp as Op, MicroOp::*, SortedSafePointEntries, FRAME_METADATA_SIZE,
     };
-    use mono_move_runtime::ObjectDescriptor;
+    use mono_move_runtime::{ObjectDescriptor, ObjectDescriptorTable};
 
     const NULL: u64 = u64::MAX;
     const NODE_SIZE: u32 = 32;
-    /// Descriptor index for trivial (no-pointer) vector elements.
-    const DESC_TRIVIAL: DescriptorId = DescriptorId(0);
-    /// Descriptor index for the BstMap heap struct.
-    const DESC_BST_MAP: DescriptorId = DescriptorId(1);
 
     /// BstMap struct field offsets (within the struct payload).
     const BST_NODES: u32 = 0;
@@ -292,27 +288,27 @@ mod micro_op {
 
     pub fn program() -> (
         Vec<Option<ExecutableArenaPtr<Function>>>,
-        Vec<ObjectDescriptor>,
+        ObjectDescriptorTable,
         ExecutableArena,
     ) {
         let arena = ExecutableArena::new();
-        let descriptors = vec![
-            ObjectDescriptor::Trivial, // 0: node elements, free_list elements
-            ObjectDescriptor::Struct {
-                // 1: BstMap { nodes, free_list, root }
-                size: 24,
-                pointer_offsets: vec![0, 8], // nodes and free_list are heap pointers
-            },
-        ];
+        let mut descriptors = ObjectDescriptorTable::new();
+        // BstMap { nodes, free_list, root }: nodes and free_list are heap pointers.
+        let desc_bst_map = descriptors.push(ObjectDescriptor::new_struct(24, vec![0, 8]).unwrap());
+        // Nodes vector: 32-byte trivial node elements.
+        let desc_nodes_vec =
+            descriptors.push(ObjectDescriptor::new_vector(NODE_SIZE, vec![]).unwrap());
+        // Free-list vector: 8-byte trivial elements.
+        let desc_free_list_vec = descriptors.push(ObjectDescriptor::new_vector(8, vec![]).unwrap());
         (
             vec![
-                Some(make_new(&arena)),         // 0
-                Some(make_insert(&arena, 3)),   // 1, calls alloc_node at 3
-                Some(make_get(&arena)),         // 2
-                Some(make_alloc_node(&arena)),  // 3
-                Some(make_remove(&arena, 5)),   // 4, calls remove_node at 5
-                Some(make_remove_node(&arena)), // 5
-                Some(make_run_ops(&arena)),     // 6
+                Some(make_new(&arena, desc_bst_map)),               // 0
+                Some(make_insert(&arena, 3)),                       // 1, calls alloc_node at 3
+                Some(make_get(&arena)),                             // 2
+                Some(make_alloc_node(&arena, desc_nodes_vec)),      // 3
+                Some(make_remove(&arena, 5)),                       // 4, calls remove_node at 5
+                Some(make_remove_node(&arena, desc_free_list_vec)), // 5
+                Some(make_run_ops(&arena)),                         // 6
             ],
             descriptors,
             arena,
@@ -328,7 +324,10 @@ mod micro_op {
     // Frame layout:
     //   [0] result: bst_ref   [8] nodes (temp)   [16] free_list (temp)
     // =================================================================
-    fn make_new(arena: &ExecutableArena) -> ExecutableArenaPtr<Function> {
+    fn make_new(
+        arena: &ExecutableArena,
+        desc_bst_map: DescriptorId,
+    ) -> ExecutableArenaPtr<Function> {
         let bst = 0u32;
         let nodes = 8u32;
         let free_list = 16u32;
@@ -337,7 +336,7 @@ mod micro_op {
         let code = [
             VecNew { dst: FO(nodes) },                                             // 0
             VecNew { dst: FO(free_list) },                                         // 1
-            HeapNew { dst: FO(bst), descriptor_id: DESC_BST_MAP },                 // 2
+            HeapNew { dst: FO(bst), descriptor_id: desc_bst_map },                       // 2
             Op::struct_store8(FO(bst), BST_NODES, FO(nodes)),                 // 3
             Op::struct_store8(FO(bst), BST_FREE_LIST, FO(free_list)),         // 4
             HeapMoveToImm8 { heap_ptr: FO(bst),
@@ -554,7 +553,10 @@ mod micro_op {
     //   [72] idx   [80] fl_len
     //   [88] new_node (32B: key[88] val[96] left[104] right[112])
     // =================================================================
-    fn make_alloc_node(arena: &ExecutableArena) -> ExecutableArenaPtr<Function> {
+    fn make_alloc_node(
+        arena: &ExecutableArena,
+        desc_nodes_vec: DescriptorId,
+    ) -> ExecutableArenaPtr<Function> {
         let bst = 0u32;
         let key = 8u32;
         let value = 16u32;
@@ -587,7 +589,7 @@ mod micro_op {
             // PUSH path: idx = nodes.len(); nodes.push(new_node)
             VecLen { dst: FO(idx), vec_ref: FO(nodes_ref) },                       // 9
             VecPushBack { vec_ref: FO(nodes_ref), elem: FO(new_node),
-                          elem_size: NODE_SIZE, descriptor_id: DESC_TRIVIAL },     // 10
+                          elem_size: NODE_SIZE, descriptor_id: desc_nodes_vec },         // 10
             Jump { target: CO(14) },                                               // 11: → DONE
             // POP path (12): idx = free_list.pop(); nodes[idx] = new_node
             VecPopBack { dst: FO(idx), vec_ref: FO(free_list_ref),
@@ -734,7 +736,10 @@ mod micro_op {
     //   [80] parent   [88] cur   [96] cur_right
     //   [104] scratch (32B: key[104] val[112] left[120] right[128])
     // =================================================================
-    fn make_remove_node(arena: &ExecutableArena) -> ExecutableArenaPtr<Function> {
+    fn make_remove_node(
+        arena: &ExecutableArena,
+        desc_free_list_vec: DescriptorId,
+    ) -> ExecutableArenaPtr<Function> {
         let bst = 0u32;
         let idx = 8u32;
         let bst_ref = 16u32;
@@ -808,7 +813,7 @@ mod micro_op {
             Move8 { dst: FO(result), src: FO(cur) },                              // 32
             // -- FREE_RETURN (33): free_list.push(idx); return --
             VecPushBack { vec_ref: FO(free_list_ref), elem: FO(idx),
-                          elem_size: 8, descriptor_id: DESC_TRIVIAL },             // 33
+                          elem_size: 8, descriptor_id: desc_free_list_vec },             // 33
             Return,                                                                // 34
         ];
 

--- a/third_party/move/mono-move/programs/src/fib.rs
+++ b/third_party/move/mono-move/programs/src/fib.rs
@@ -44,11 +44,11 @@ mod micro_op {
         CodeOffset as CO, FrameLayoutInfo, FrameOffset as FO, Function, MicroOp::*,
         SortedSafePointEntries, FRAME_METADATA_SIZE,
     };
-    use mono_move_runtime::ObjectDescriptor;
+    use mono_move_runtime::ObjectDescriptorTable;
 
     pub fn program() -> (
         Vec<Option<ExecutableArenaPtr<Function>>>,
-        Vec<ObjectDescriptor>,
+        ObjectDescriptorTable,
         ExecutableArena,
     ) {
         let arena = ExecutableArena::new();
@@ -95,7 +95,7 @@ mod micro_op {
             safe_point_layouts: SortedSafePointEntries::empty(),
         });
 
-        (vec![Some(func)], vec![ObjectDescriptor::Trivial], arena)
+        (vec![Some(func)], ObjectDescriptorTable::new(), arena)
     }
 }
 

--- a/third_party/move/mono-move/programs/src/match_sum.rs
+++ b/third_party/move/mono-move/programs/src/match_sum.rs
@@ -85,11 +85,11 @@ mod micro_op {
         CodeOffset as CO, FrameLayoutInfo, FrameOffset as FO, Function, MicroOp::*,
         SortedSafePointEntries,
     };
-    use mono_move_runtime::ObjectDescriptor;
+    use mono_move_runtime::ObjectDescriptorTable;
 
     pub fn program() -> (
         Vec<ExecutableArenaPtr<Function>>,
-        Vec<ObjectDescriptor>,
+        ObjectDescriptorTable,
         ExecutableArena,
     ) {
         let arena = ExecutableArena::new();
@@ -155,7 +155,7 @@ mod micro_op {
             safe_point_layouts: SortedSafePointEntries::empty(),
         });
 
-        (vec![func], vec![ObjectDescriptor::Trivial], arena)
+        (vec![func], ObjectDescriptorTable::new(), arena)
     }
 }
 

--- a/third_party/move/mono-move/programs/src/merge_sort.rs
+++ b/third_party/move/mono-move/programs/src/merge_sort.rs
@@ -63,18 +63,21 @@ pub fn native_merge_sort(v: &mut [u64]) {
 mod micro_op {
     use mono_move_alloc::{ExecutableArena, ExecutableArenaPtr, GlobalArenaPtr};
     use mono_move_core::{
-        CodeOffset as CO, DescriptorId, FrameLayoutInfo, FrameOffset as FO, Function, MicroOp::*,
+        CodeOffset as CO, FrameLayoutInfo, FrameOffset as FO, Function, MicroOp::*,
         SortedSafePointEntries, FRAME_METADATA_SIZE,
     };
-    use mono_move_runtime::ObjectDescriptor;
+    use mono_move_runtime::{ObjectDescriptor, ObjectDescriptorTable};
 
     pub fn program() -> (
         Vec<Option<ExecutableArenaPtr<Function>>>,
-        Vec<ObjectDescriptor>,
+        ObjectDescriptorTable,
         ExecutableArena,
     ) {
         let arena = ExecutableArena::new();
         let meta = FRAME_METADATA_SIZE as u32;
+
+        let mut descriptors = ObjectDescriptorTable::new();
+        let desc_vec_u64 = descriptors.push(ObjectDescriptor::new_vector(8, vec![]).unwrap());
 
         // =================================================================
         // Function 0 — merge_sort(vec)
@@ -247,12 +250,12 @@ mod micro_op {
                               idx: FO(j), elem_size: 8 },                       // 11
                 JumpLessU64 { target: CO(16), lhs: FO(elem_a), rhs: FO(elem_b) }, // 12
                 // a >= b: push b
-                VecPushBack { vec_ref: FO(tmp_ref), elem: FO(elem_b), elem_size: 8, descriptor_id: DescriptorId(0) }, // 13
+                VecPushBack { vec_ref: FO(tmp_ref), elem: FO(elem_b), elem_size: 8, descriptor_id: desc_vec_u64 }, // 13
                 AddU64Imm { dst: FO(j), src: FO(j), imm: 1 },                  // 14
                 Jump { target: CO(5) },                                          // 15
 
                 // PUSH_LEFT (16): a < b, push a
-                VecPushBack { vec_ref: FO(tmp_ref), elem: FO(elem_a), elem_size: 8, descriptor_id: DescriptorId(0) }, // 16
+                VecPushBack { vec_ref: FO(tmp_ref), elem: FO(elem_a), elem_size: 8, descriptor_id: desc_vec_u64 }, // 16
                 AddU64Imm { dst: FO(i), src: FO(i), imm: 1 },                  // 17
                 Jump { target: CO(5) },                                          // 18
 
@@ -261,7 +264,7 @@ mod micro_op {
                 Jump { target: CO(31) },                                         // 20
                 VecLoadElem { dst: FO(elem_a), vec_ref: FO(vec_ref),
                               idx: FO(i), elem_size: 8 },                       // 21
-                VecPushBack { vec_ref: FO(tmp_ref), elem: FO(elem_a), elem_size: 8, descriptor_id: DescriptorId(0) }, // 22
+                VecPushBack { vec_ref: FO(tmp_ref), elem: FO(elem_a), elem_size: 8, descriptor_id: desc_vec_u64 }, // 22
                 AddU64Imm { dst: FO(i), src: FO(i), imm: 1 },                  // 23
                 Jump { target: CO(19) },                                         // 24
 
@@ -270,7 +273,7 @@ mod micro_op {
                 Jump { target: CO(31) },                                         // 26
                 VecLoadElem { dst: FO(elem_b), vec_ref: FO(vec_ref),
                               idx: FO(j), elem_size: 8 },                       // 27
-                VecPushBack { vec_ref: FO(tmp_ref), elem: FO(elem_b), elem_size: 8, descriptor_id: DescriptorId(0) }, // 28
+                VecPushBack { vec_ref: FO(tmp_ref), elem: FO(elem_b), elem_size: 8, descriptor_id: desc_vec_u64 }, // 28
                 AddU64Imm { dst: FO(j), src: FO(j), imm: 1 },                  // 29
                 Jump { target: CO(25) },                                         // 30
 
@@ -308,7 +311,6 @@ mod micro_op {
             })
         };
 
-        let descriptors = vec![ObjectDescriptor::Trivial];
         (
             vec![
                 Some(func_merge_sort),

--- a/third_party/move/mono-move/programs/src/nested_loop.rs
+++ b/third_party/move/mono-move/programs/src/nested_loop.rs
@@ -64,11 +64,11 @@ mod micro_op {
         CodeOffset as CO, FrameLayoutInfo, FrameOffset as FO, Function, MicroOp::*,
         SortedSafePointEntries,
     };
-    use mono_move_runtime::ObjectDescriptor;
+    use mono_move_runtime::ObjectDescriptorTable;
 
     pub fn program() -> (
         Vec<ExecutableArenaPtr<Function>>,
-        Vec<ObjectDescriptor>,
+        ObjectDescriptorTable,
         ExecutableArena,
     ) {
         let arena = ExecutableArena::new();
@@ -120,7 +120,7 @@ mod micro_op {
             safe_point_layouts: SortedSafePointEntries::empty(),
         });
 
-        (vec![func], vec![ObjectDescriptor::Trivial], arena)
+        (vec![func], ObjectDescriptorTable::new(), arena)
     }
 }
 

--- a/third_party/move/mono-move/runtime/src/heap/mod.rs
+++ b/third_party/move/mono-move/runtime/src/heap/mod.rs
@@ -9,16 +9,18 @@
 //! into [`PinnedRoots`]) while still invoking allocation paths that mutate
 //! only the heap.
 
+pub(crate) mod object_descriptor;
 pub(crate) mod pinned_roots;
 
 use crate::{
     bail,
     error::ExecutionResult,
+    heap::object_descriptor::{ObjectDescriptor, ObjectDescriptorInner},
     memory::{read_ptr, read_u32, read_u64, write_ptr, write_u32, write_u64, MemoryRegion},
     types::{
-        ObjectDescriptor, DEFAULT_HEAP_SIZE, FORWARDED_MARKER, HEADER_DESCRIPTOR_OFFSET,
-        HEADER_SIZE_OFFSET, META_SAVED_FP_OFFSET, META_SAVED_FUNC_PTR_OFFSET, META_SAVED_PC_OFFSET,
-        VEC_DATA_OFFSET, VEC_LENGTH_OFFSET,
+        DEFAULT_HEAP_SIZE, FORWARDED_MARKER, HEADER_DESCRIPTOR_OFFSET, HEADER_SIZE_OFFSET,
+        META_SAVED_FP_OFFSET, META_SAVED_FUNC_PTR_OFFSET, META_SAVED_PC_OFFSET, VEC_DATA_OFFSET,
+        VEC_LENGTH_OFFSET,
     },
 };
 use mono_move_core::{
@@ -283,15 +285,15 @@ pub(crate) fn alloc_obj(
     pc: usize,
     descriptor_id: DescriptorId,
 ) -> ExecutionResult<*mut u8> {
-    let payload_size = match &descriptors[descriptor_id.as_usize()] {
-        ObjectDescriptor::Struct { size, .. } => *size as usize,
-        ObjectDescriptor::Enum { size, .. } => *size as usize,
-        ObjectDescriptor::Closure => CLOSURE_OBJECT_SIZE - OBJECT_HEADER_SIZE,
-        ObjectDescriptor::CapturedData { size, .. } => {
+    let payload_size = match descriptors[descriptor_id.as_usize()].inner() {
+        ObjectDescriptorInner::Struct { size, .. } => *size as usize,
+        ObjectDescriptorInner::Enum { size, .. } => *size as usize,
+        ObjectDescriptorInner::Closure => CLOSURE_OBJECT_SIZE - OBJECT_HEADER_SIZE,
+        ObjectDescriptorInner::CapturedData { size, .. } => {
             // Add the 8-byte tag+padding prefix to the values-region size.
             (CAPTURED_DATA_VALUES_OFFSET - OBJECT_HEADER_SIZE) + *size as usize
         },
-        ObjectDescriptor::Trivial | ObjectDescriptor::Vector { .. } => bail!(
+        ObjectDescriptorInner::Trivial | ObjectDescriptorInner::Vector { .. } => bail!(
             "alloc_obj called with non-allocatable descriptor {}",
             descriptor_id
         ),
@@ -622,9 +624,9 @@ fn gc_scan_object(
         return;
     };
 
-    match desc {
-        ObjectDescriptor::Trivial => {},
-        ObjectDescriptor::Vector {
+    match desc.inner() {
+        ObjectDescriptorInner::Trivial => {},
+        ObjectDescriptorInner::Vector {
             elem_size,
             elem_pointer_offsets,
         } => {
@@ -648,7 +650,7 @@ fn gc_scan_object(
                 }
             }
         },
-        ObjectDescriptor::Struct {
+        ObjectDescriptorInner::Struct {
             pointer_offsets, ..
         } => {
             if pointer_offsets.is_empty() {
@@ -664,7 +666,7 @@ fn gc_scan_object(
                 }
             }
         },
-        ObjectDescriptor::Enum {
+        ObjectDescriptorInner::Enum {
             variant_pointer_offsets,
             ..
         } => unsafe {
@@ -684,7 +686,7 @@ fn gc_scan_object(
                 }
             }
         },
-        ObjectDescriptor::Closure => unsafe {
+        ObjectDescriptorInner::Closure => unsafe {
             // The closure's only heap pointer is `captured_data_ptr` at a
             // fixed payload offset.
             let off = CLOSURE_CAPTURED_DATA_PTR_OFFSET;
@@ -694,7 +696,7 @@ fn gc_scan_object(
                 write_ptr(obj_ptr, off, new_ptr);
             }
         },
-        ObjectDescriptor::CapturedData {
+        ObjectDescriptorInner::CapturedData {
             pointer_offsets, ..
         } => {
             if pointer_offsets.is_empty() {

--- a/third_party/move/mono-move/runtime/src/heap/object_descriptor.rs
+++ b/third_party/move/mono-move/runtime/src/heap/object_descriptor.rs
@@ -1,0 +1,421 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Object descriptors and the program-wide [`ObjectDescriptorTable`].
+//!
+//! An [`ObjectDescriptor`] tells the GC how to trace internal pointers
+//! within a single heap object. The descriptor table is a program-wide
+//! `Vec<ObjectDescriptor>` indexed by [`DescriptorId`], with two reserved
+//! entries (`Trivial` at 0, `Closure` at 1) that are populated implicitly
+//! by [`ObjectDescriptorTable::new`].
+
+use mono_move_core::DescriptorId;
+
+// ---------------------------------------------------------------------------
+// Object descriptors (for GC tracing)
+// ---------------------------------------------------------------------------
+
+/// Describes the reference layout of a heap object so the GC knows how to
+/// trace internal pointers. Only one level of indirection is described;
+/// pointed-to objects are self-describing via their own headers.
+///
+/// `ObjectDescriptor` is opaque to external callers — the wrapped
+/// [`ObjectDescriptorInner`] enum is crate-private. External code creates
+/// descriptors only through the validating constructors
+/// ([`Self::new_vector`], [`Self::new_struct`], [`Self::new_enum`],
+/// [`Self::new_captured_data`]) which return `anyhow::Result`; `Trivial`
+/// and `Closure` are placed by [`ObjectDescriptorTable::new`] at their
+/// reserved indices and cannot be constructed externally. Any
+/// `&ObjectDescriptor` flowing through the runtime is therefore
+/// self-sound by construction (nonzero size, in-bounds 8-byte-aligned
+/// strictly-sorted pointer offsets).
+#[derive(Debug)]
+pub struct ObjectDescriptor(ObjectDescriptorInner);
+
+/// Crate-private representation of an [`ObjectDescriptor`]. The runtime's
+/// GC and verifier match on this directly via [`ObjectDescriptor::inner`].
+#[derive(Debug)]
+pub(crate) enum ObjectDescriptorInner {
+    /// No internal heap references. GC copies the blob and moves on.
+    Trivial,
+
+    /// Closure object — fixed runtime layout shared by every closure.
+    ///
+    /// Payload layout (`size = CLOSURE_OBJECT_SIZE - OBJECT_HEADER_SIZE = 32`):
+    /// `[func_ref(16)] [mask(8)] [captured_data_ptr(8)]`. The single heap
+    /// pointer is `captured_data_ptr` at payload offset
+    /// `CLOSURE_CAPTURED_DATA_PTR_OFFSET - OBJECT_HEADER_SIZE = 24`. Both
+    /// the size and the pointer offset are constants of the runtime
+    /// layout — there is nothing per-instance to store here.
+    Closure,
+
+    /// Vector whose elements may contain heap pointers at known offsets.
+    Vector {
+        /// Size of each element in bytes.
+        /// The address of element `i` is `data_start + i * elem_size`.
+        elem_size: u32,
+        /// Byte offsets within each element that are heap pointers.
+        elem_pointer_offsets: Vec<u32>,
+    },
+
+    /// Fixed-size struct allocated on the heap.
+    Struct {
+        /// Total payload size in bytes (excluding the object header).
+        size: u32,
+        /// Byte offsets within the payload that hold owned heap pointers.
+        /// Move forbids references inside structs, so these are always
+        /// 8-byte pointers to other heap objects (vectors, structs, etc.).
+        pointer_offsets: Vec<u32>,
+    },
+
+    /// Enum (tagged union) allocated on the heap.
+    /// Layout: [header(8)] [tag: u64(8)] [fields padded to max variant size]
+    Enum {
+        /// Total payload size in bytes (tag + max variant fields, excluding header).
+        size: u32,
+        /// Per-variant pointer layouts. `variant_pointer_offsets[tag]` gives
+        /// byte offsets (relative to `ENUM_DATA_OFFSET`) that hold heap
+        /// pointers for that variant.
+        variant_pointer_offsets: Vec<Vec<u32>>,
+    },
+
+    /// `ClosureCapturedData` (Materialized) object.
+    ///
+    /// Object layout: `[header(8)] [tag(1) + padding(7)] [values...]`.
+    /// `size` and `pointer_offsets` are interpreted relative to the
+    /// values region (i.e., excluding both the header and the
+    /// tag+padding prefix), so an offset of `0` names the first byte of
+    /// the first captured value. The 8-byte tag prefix is added
+    /// internally by the GC.
+    CapturedData {
+        /// Byte size of the values region (sum of captured value sizes).
+        size: u32,
+        /// Byte offsets within the values region that hold heap pointers.
+        pointer_offsets: Vec<u32>,
+    },
+}
+
+impl ObjectDescriptor {
+    /// Construct a [`Vector`](ObjectDescriptorInner::Vector) descriptor.
+    ///
+    /// Returns `Err` if `elem_size == 0` or any offset in
+    /// `elem_pointer_offsets` is not 8-byte aligned, runs past
+    /// `elem_size`, or breaks strict ordering.
+    pub fn new_vector(elem_size: u32, elem_pointer_offsets: Vec<u32>) -> anyhow::Result<Self> {
+        anyhow::ensure!(elem_size > 0, "Vector: elem_size must be > 0");
+        check_pointer_offsets(
+            "Vector::elem_pointer_offsets",
+            &elem_pointer_offsets,
+            elem_size,
+        )?;
+        Ok(Self(ObjectDescriptorInner::Vector {
+            elem_size,
+            elem_pointer_offsets,
+        }))
+    }
+
+    /// Construct a [`Struct`](ObjectDescriptorInner::Struct) descriptor.
+    ///
+    /// Returns `Err` if `size == 0` or any offset in `pointer_offsets`
+    /// is not 8-byte aligned, runs past `size`, or breaks strict
+    /// ordering.
+    pub fn new_struct(size: u32, pointer_offsets: Vec<u32>) -> anyhow::Result<Self> {
+        anyhow::ensure!(size > 0, "Struct: size must be > 0");
+        check_pointer_offsets("Struct::pointer_offsets", &pointer_offsets, size)?;
+        Ok(Self(ObjectDescriptorInner::Struct {
+            size,
+            pointer_offsets,
+        }))
+    }
+
+    /// Construct an [`Enum`](ObjectDescriptorInner::Enum) descriptor.
+    ///
+    /// Returns `Err` if `size == 0`, `size < 8` (cannot hold the 8-byte
+    /// tag), or any per-variant offset is not 8-byte aligned, runs past
+    /// `size - 8` (the variant region after the tag), or breaks strict
+    /// ordering within its variant.
+    pub fn new_enum(size: u32, variant_pointer_offsets: Vec<Vec<u32>>) -> anyhow::Result<Self> {
+        anyhow::ensure!(size > 0, "Enum: size must be > 0");
+        // The 8-byte tag word lives at the start of the payload; variant
+        // pointer offsets are relative to the data region after the tag,
+        // so they must fit in `size - 8`.
+        let variant_region = size.checked_sub(8).ok_or_else(|| {
+            anyhow::anyhow!("Enum: size {} too small to hold the 8-byte tag", size)
+        })?;
+        for (variant, offsets) in variant_pointer_offsets.iter().enumerate() {
+            let label = format!("Enum::variant_pointer_offsets[{}]", variant);
+            check_pointer_offsets(&label, offsets, variant_region)?;
+        }
+        Ok(Self(ObjectDescriptorInner::Enum {
+            size,
+            variant_pointer_offsets,
+        }))
+    }
+
+    /// Construct a [`CapturedData`](ObjectDescriptorInner::CapturedData)
+    /// descriptor.
+    ///
+    /// Returns `Err` if `size == 0` or any offset in `pointer_offsets`
+    /// is not 8-byte aligned, runs past `size`, or breaks strict
+    /// ordering.
+    pub fn new_captured_data(size: u32, pointer_offsets: Vec<u32>) -> anyhow::Result<Self> {
+        anyhow::ensure!(size > 0, "CapturedData: size must be > 0");
+        check_pointer_offsets("CapturedData::pointer_offsets", &pointer_offsets, size)?;
+        Ok(Self(ObjectDescriptorInner::CapturedData {
+            size,
+            pointer_offsets,
+        }))
+    }
+
+    /// Crate-internal access to the inner enum for pattern matching by
+    /// the GC and verifier.
+    pub(crate) fn inner(&self) -> &ObjectDescriptorInner {
+        &self.0
+    }
+}
+
+/// Reserved descriptor table index for [`ObjectDescriptorInner::Trivial`].
+/// Every program's descriptor table has `Trivial` at this index.
+pub const TRIVIAL_DESCRIPTOR_ID: DescriptorId = DescriptorId(0);
+
+/// Reserved descriptor table index for [`ObjectDescriptorInner::Closure`].
+/// Every program's descriptor table has `Closure` at this index. The
+/// `PackClosure` micro-op uses this implicitly — it does not carry a
+/// closure descriptor id of its own.
+pub const CLOSURE_DESCRIPTOR_ID: DescriptorId = DescriptorId(1);
+
+// ---------------------------------------------------------------------------
+// Object descriptor table
+// ---------------------------------------------------------------------------
+
+/// Program-wide table of [`ObjectDescriptor`] entries, indexed by
+/// [`DescriptorId`].
+///
+/// The table starts with two reserved entries:
+///   - index `0` is [`ObjectDescriptorInner::Trivial`]
+///   - index `1` is [`ObjectDescriptorInner::Closure`]
+///
+/// User descriptors are appended starting at index `2` via [`Self::push`].
+/// `Trivial` and `Closure` aren't externally constructable; they only
+/// live at their reserved indices.
+///
+/// Each user descriptor is validated by its constructor before reaching
+/// the table (nonzero size, in-bounds 8-byte-aligned strictly-sorted
+/// pointer offsets, `Enum` size large enough for the 8-byte tag). Any
+/// `&ObjectDescriptorTable` is therefore structurally well-formed by
+/// construction; no separate verification pass is needed.
+///
+/// Implements `Deref<Target = [ObjectDescriptor]>`, so it can be passed
+/// anywhere a `&[ObjectDescriptor]` is expected.
+#[derive(Debug)]
+pub struct ObjectDescriptorTable {
+    descriptors: Vec<ObjectDescriptor>,
+}
+
+// `len_without_is_empty`: the table always has the two reserved entries,
+// so `is_empty()` would be a tautological `false` — not worth providing.
+#[allow(clippy::len_without_is_empty)]
+impl ObjectDescriptorTable {
+    /// Fresh table containing only the two reserved entries.
+    pub fn new() -> Self {
+        Self {
+            descriptors: vec![
+                ObjectDescriptor(ObjectDescriptorInner::Trivial),
+                ObjectDescriptor(ObjectDescriptorInner::Closure),
+            ],
+        }
+    }
+
+    /// Append a user descriptor and return its assigned [`DescriptorId`].
+    /// Callers must capture the returned id and use it in micro-ops; the
+    /// descriptor's index in the underlying storage is not part of the
+    /// public API.
+    ///
+    /// `desc` is sound by construction (the public constructors on
+    /// [`ObjectDescriptor`] validate inline), so this method does no
+    /// further validation; it just appends.
+    pub fn push(&mut self, desc: ObjectDescriptor) -> DescriptorId {
+        let id = DescriptorId(
+            u32::try_from(self.descriptors.len())
+                .expect("descriptor table length exceeds u32::MAX"),
+        );
+        self.descriptors.push(desc);
+        id
+    }
+
+    /// View the table as a slice indexed by [`DescriptorId`].
+    pub fn as_slice(&self) -> &[ObjectDescriptor] {
+        &self.descriptors
+    }
+
+    /// Number of entries (always at least 2).
+    pub fn len(&self) -> usize {
+        self.descriptors.len()
+    }
+}
+
+impl Default for ObjectDescriptorTable {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl std::ops::Deref for ObjectDescriptorTable {
+    type Target = [ObjectDescriptor];
+
+    fn deref(&self) -> &[ObjectDescriptor] {
+        self.as_slice()
+    }
+}
+
+/// Check that each offset in `offsets` names an 8-byte pointer in-bounds of
+/// a region of `region_size` bytes (`off + 8 <= region_size`), is 8-byte
+/// aligned, and that the list is strictly sorted (non-overlap follows).
+fn check_pointer_offsets(label: &str, offsets: &[u32], region_size: u32) -> anyhow::Result<()> {
+    for &off in offsets {
+        anyhow::ensure!(
+            off % 8 == 0,
+            "{}: offset {} is not 8-byte aligned",
+            label,
+            off
+        );
+        let end = off
+            .checked_add(8)
+            .ok_or_else(|| anyhow::anyhow!("{}: offset {} + 8 overflows", label, off))?;
+        anyhow::ensure!(
+            end <= region_size,
+            "{}: pointer at offset {} (end {}) exceeds region size {}",
+            label,
+            off,
+            end,
+            region_size
+        );
+    }
+    for w in offsets.windows(2) {
+        anyhow::ensure!(
+            w[0] < w[1],
+            "{}: offsets not strictly sorted ({} >= {})",
+            label,
+            w[0],
+            w[1]
+        );
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_has_reserved_entries() {
+        let t = ObjectDescriptorTable::new();
+        assert_eq!(t.len(), 2);
+        assert!(matches!(t[0].inner(), ObjectDescriptorInner::Trivial));
+        assert!(matches!(t[1].inner(), ObjectDescriptorInner::Closure));
+    }
+
+    #[test]
+    fn push_returns_increasing_ids() {
+        let mut t = ObjectDescriptorTable::new();
+        let a = t.push(ObjectDescriptor::new_vector(8, vec![]).unwrap());
+        let b = t.push(ObjectDescriptor::new_struct(16, vec![]).unwrap());
+        assert_eq!(a, DescriptorId(2));
+        assert_eq!(b, DescriptorId(3));
+        assert_eq!(t.len(), 4);
+    }
+
+    fn err_msg<T>(r: anyhow::Result<T>) -> String {
+        r.err().expect("expected Err").to_string()
+    }
+
+    // ----- Zero size -----
+
+    #[test]
+    fn vector_zero_elem_size_errors() {
+        assert!(err_msg(ObjectDescriptor::new_vector(0, vec![])).contains("elem_size"));
+    }
+
+    #[test]
+    fn struct_zero_size_errors() {
+        assert!(err_msg(ObjectDescriptor::new_struct(0, vec![])).contains("Struct: size"));
+    }
+
+    #[test]
+    fn enum_zero_size_errors() {
+        assert!(err_msg(ObjectDescriptor::new_enum(0, vec![vec![]])).contains("Enum: size"));
+    }
+
+    #[test]
+    fn captured_data_zero_size_errors() {
+        assert!(
+            err_msg(ObjectDescriptor::new_captured_data(0, vec![])).contains("CapturedData: size")
+        );
+    }
+
+    // ----- Pointer offsets -----
+
+    #[test]
+    fn struct_pointer_out_of_bounds_errors() {
+        // 16 + 8 = 24 > 16
+        assert!(err_msg(ObjectDescriptor::new_struct(16, vec![16])).contains("exceeds region size"));
+    }
+
+    #[test]
+    fn struct_pointer_partially_out_of_bounds_errors() {
+        // size 20 (allowed; runtime rounds up). Pointer at aligned offset
+        // 16 starts in-bounds but `16 + 8 = 24 > 20`.
+        assert!(err_msg(ObjectDescriptor::new_struct(20, vec![16])).contains("exceeds region size"));
+    }
+
+    #[test]
+    fn misaligned_pointer_offset_errors() {
+        assert!(err_msg(ObjectDescriptor::new_struct(24, vec![3])).contains("8-byte aligned"));
+    }
+
+    #[test]
+    fn unsorted_pointer_offsets_errors() {
+        assert!(
+            err_msg(ObjectDescriptor::new_struct(32, vec![16, 8])).contains("not strictly sorted")
+        );
+    }
+
+    #[test]
+    fn vector_pointer_out_of_bounds_errors() {
+        // 8 + 8 = 16 > 8
+        assert!(err_msg(ObjectDescriptor::new_vector(8, vec![8])).contains("exceeds region size"));
+    }
+
+    // ----- Enum tag accounting -----
+
+    #[test]
+    fn enum_size_smaller_than_tag_errors() {
+        assert!(err_msg(ObjectDescriptor::new_enum(4, vec![vec![]])).contains("8-byte tag"));
+    }
+
+    #[test]
+    fn enum_variant_pointer_out_of_bounds_errors() {
+        // size 16 = tag(8) + variant region(8). Pointer at variant offset 8
+        // means 8 + 8 = 16 > 8 (variant region).
+        assert!(
+            err_msg(ObjectDescriptor::new_enum(16, vec![vec![], vec![8]]))
+                .contains("exceeds region size")
+        );
+    }
+
+    #[test]
+    fn captured_data_pointer_out_of_bounds_errors() {
+        // 8 + 8 = 16 > 8
+        assert!(err_msg(ObjectDescriptor::new_captured_data(8, vec![8]))
+            .contains("exceeds region size"));
+    }
+
+    // ----- Deref to slice -----
+
+    #[test]
+    fn deref_to_slice_works() {
+        let t = ObjectDescriptorTable::new();
+        let s: &[ObjectDescriptor] = &t;
+        assert_eq!(s.len(), 2);
+    }
+}

--- a/third_party/move/mono-move/runtime/src/interpreter.rs
+++ b/third_party/move/mono-move/runtime/src/interpreter.rs
@@ -9,12 +9,13 @@ use crate::{
     error::ExecutionResult,
     heap::{
         macros::{alloc_obj, alloc_vec, gc_collect, grow_vec_ref},
+        object_descriptor::{ObjectDescriptor, CLOSURE_DESCRIPTOR_ID},
         pinned_roots::PinnedRoots,
         Heap,
     },
     memory::{read_ptr, read_u32, read_u64, vec_elem_ptr, write_ptr, write_u64, MemoryRegion},
     types::{
-        ObjectDescriptor, StepResult, DEFAULT_HEAP_SIZE, DEFAULT_STACK_SIZE, HEADER_SIZE_OFFSET,
+        StepResult, DEFAULT_HEAP_SIZE, DEFAULT_STACK_SIZE, HEADER_SIZE_OFFSET,
         META_SAVED_FP_OFFSET, META_SAVED_FUNC_PTR_OFFSET, META_SAVED_PC_OFFSET, VEC_DATA_OFFSET,
         VEC_LENGTH_OFFSET,
     },
@@ -727,7 +728,7 @@ impl<T: ExecutionContext> InterpreterContext<'_, T> {
             // and leave `captured_data_ptr` as the zeroed/null value written
             // by `alloc_obj`. No pinning needed — only one allocation.
             if op.captured.is_empty() {
-                let closure = alloc_obj!(self, fp, op.closure_descriptor_id)?;
+                let closure = alloc_obj!(self, fp, CLOSURE_DESCRIPTOR_ID)?;
                 self.write_closure_func_ref_and_mask(closure, op);
                 write_ptr(fp, op.dst, closure);
                 return Ok(());
@@ -741,12 +742,17 @@ impl<T: ExecutionContext> InterpreterContext<'_, T> {
             // skipped). Pinning keeps the closure live across the second
             // allocation and lets GC update the pinned slot in-place if
             // the object is relocated.
-            let closure_ptr = alloc_obj!(self, fp, op.closure_descriptor_id)?;
+            let closure_ptr = alloc_obj!(self, fp, CLOSURE_DESCRIPTOR_ID)?;
             let pin = self.pinned_roots.pin(NonNull::new_unchecked(closure_ptr));
 
             self.write_closure_func_ref_and_mask(pin.get().as_ptr(), op);
 
-            let captured_data = alloc_obj!(self, fp, op.captured_data_descriptor_id)?;
+            // SAFETY: the verifier guarantees `captured_data_descriptor_id`
+            // is `Some(CapturedData)` whenever `captured` is non-empty.
+            let captured_desc_id = op
+                .captured_data_descriptor_id
+                .expect("verifier ensures Some when captured is non-empty");
+            let captured_data = alloc_obj!(self, fp, captured_desc_id)?;
             *captured_data.add(CAPTURED_DATA_TAG_OFFSET) = CAPTURED_DATA_TAG_MATERIALIZED;
 
             let mut captured_offset = CAPTURED_DATA_VALUES_OFFSET;

--- a/third_party/move/mono-move/runtime/src/lib.rs
+++ b/third_party/move/mono-move/runtime/src/lib.rs
@@ -11,10 +11,15 @@ mod types;
 mod verifier;
 
 pub use error::{ExecutionError, ExecutionResult};
-pub use heap::pinned_roots::{PinGuard, PinnedRoots};
+pub use heap::{
+    object_descriptor::{
+        ObjectDescriptor, ObjectDescriptorTable, CLOSURE_DESCRIPTOR_ID, TRIVIAL_DESCRIPTOR_ID,
+    },
+    pinned_roots::{PinGuard, PinnedRoots},
+};
 pub use interpreter::InterpreterContext;
 pub use memory::{
     read_ptr, read_u32, read_u64, vec_elem_ptr, write_ptr, write_u32, write_u64, MemoryRegion,
 };
-pub use types::{ObjectDescriptor, StepResult, VEC_DATA_OFFSET, VEC_LENGTH_OFFSET};
-pub use verifier::{verify_function, VerificationError};
+pub use types::{StepResult, VEC_DATA_OFFSET, VEC_LENGTH_OFFSET};
+pub use verifier::{verify_function, verify_program, VerificationError};

--- a/third_party/move/mono-move/runtime/src/types.rs
+++ b/third_party/move/mono-move/runtime/src/types.rs
@@ -1,77 +1,11 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-//! Core types and constants for the interpreter runtime.
+//! Misc runtime types and layout constants.
+//!
+//! Object descriptors live in [`crate::heap::object_descriptor`].
 
 pub(crate) use mono_move_core::OBJECT_HEADER_SIZE;
-
-// ---------------------------------------------------------------------------
-// Object descriptors (for GC tracing)
-// ---------------------------------------------------------------------------
-
-/// Describes the reference layout of a heap object so the GC knows how to
-/// trace internal pointers. Only one level of indirection is described;
-/// pointed-to objects are self-describing via their own headers.
-#[derive(Debug)]
-pub enum ObjectDescriptor {
-    /// No internal heap references. GC copies the blob and moves on.
-    Trivial,
-
-    /// Vector whose elements may contain heap pointers at known offsets.
-    Vector {
-        /// Size of each element in bytes.
-        /// The address of element `i` is `data_start + i * elem_size`.
-        elem_size: u32,
-        /// Byte offsets within each element that are heap pointers.
-        elem_pointer_offsets: Vec<u32>,
-    },
-
-    /// Fixed-size struct allocated on the heap.
-    Struct {
-        /// Total payload size in bytes (excluding the object header).
-        size: u32,
-        /// Byte offsets within the payload that hold owned heap pointers.
-        /// Move forbids references inside structs, so these are always
-        /// 8-byte pointers to other heap objects (vectors, structs, etc.).
-        pointer_offsets: Vec<u32>,
-    },
-
-    /// Enum (tagged union) allocated on the heap.
-    /// Layout: [header(8)] [tag: u64(8)] [fields padded to max variant size]
-    Enum {
-        /// Total payload size in bytes (tag + max variant fields, excluding header).
-        size: u32,
-        /// Per-variant pointer layouts. `variant_pointer_offsets[tag]` gives
-        /// byte offsets (relative to `ENUM_DATA_OFFSET`) that hold heap
-        /// pointers for that variant.
-        variant_pointer_offsets: Vec<Vec<u32>>,
-    },
-
-    /// Closure object — fixed runtime layout shared by every closure.
-    ///
-    /// Payload layout (`size = CLOSURE_OBJECT_SIZE - OBJECT_HEADER_SIZE = 32`):
-    /// `[func_ref(16)] [mask(8)] [captured_data_ptr(8)]`. The single heap
-    /// pointer is `captured_data_ptr` at payload offset
-    /// `CLOSURE_CAPTURED_DATA_PTR_OFFSET - OBJECT_HEADER_SIZE = 24`. Both
-    /// the size and the pointer offset are constants of the runtime
-    /// layout — there is nothing per-instance to store here.
-    Closure,
-
-    /// `ClosureCapturedData` (Materialized) object.
-    ///
-    /// Object layout: `[header(8)] [tag(1) + padding(7)] [values...]`.
-    /// `size` and `pointer_offsets` are interpreted relative to the
-    /// values region (i.e., excluding both the header and the
-    /// tag+padding prefix), so an offset of `0` names the first byte of
-    /// the first captured value. The 8-byte tag prefix is added
-    /// internally by the GC.
-    CapturedData {
-        /// Byte size of the values region (sum of captured value sizes).
-        size: u32,
-        /// Byte offsets within the values region that hold heap pointers.
-        pointer_offsets: Vec<u32>,
-    },
-}
 
 // ---------------------------------------------------------------------------
 // Step result

--- a/third_party/move/mono-move/runtime/src/verifier.rs
+++ b/third_party/move/mono-move/runtime/src/verifier.rs
@@ -3,9 +3,18 @@
 
 //! Static verifier for `Function` bodies. Checks well-formedness properties
 //! that would otherwise cause undefined behavior at runtime: frame bounds,
-//! pointer slot validity, invalid jump targets, etc.
+//! pointer slot validity, invalid jump targets, op/descriptor variant
+//! mismatch, etc.
+//!
+//! The descriptor table itself is not verified here — its self-soundness
+//! (reserved entries, nonzero sizes, in-bounds pointer offsets) is enforced
+//! by [`crate::types::ObjectDescriptorTable`] at construction time. The
+//! per-function checks below trust that any descriptor they look up by id
+//! is internally well-formed.
 
-use crate::types::ObjectDescriptor;
+use crate::heap::object_descriptor::{
+    ObjectDescriptor, ObjectDescriptorInner, CLOSURE_DESCRIPTOR_ID,
+};
 use mono_move_core::{
     CallClosureOp, ClosureFuncRef, CodeOffset, DescriptorId, FrameOffset, Function, MicroOp,
     PackClosureOp, FRAME_METADATA_SIZE,
@@ -36,14 +45,8 @@ impl fmt::Display for VerificationError {
 // Public API
 // ---------------------------------------------------------------------------
 
-/// Validate a single function and its pointer slots against the descriptor table.
-/// Returns an empty `Vec` on success.
-///
-// TODO: add a separate descriptor-self-soundness pass (run once over the
-// descriptor table, not per function) that checks each entry's
-// `pointer_offsets` are in-bounds, 8-byte aligned, sorted, and
-// non-overlapping. Per-op consistency checks below assume that pass has
-// run.
+/// Validate a single function and its pointer slots against the descriptor
+/// table. Returns an empty `Vec` on success.
 pub fn verify_function(
     func: &Function,
     descriptors: &[ObjectDescriptor],
@@ -55,6 +58,19 @@ pub fn verify_function(
         errors: &mut errors,
     };
     fv.verify();
+    errors
+}
+
+/// Validate every function in a program against a shared descriptor table.
+/// Errors from each function are concatenated.
+pub fn verify_program(
+    funcs: &[&Function],
+    descriptors: &[ObjectDescriptor],
+) -> Vec<VerificationError> {
+    let mut errors = Vec::new();
+    for func in funcs {
+        errors.extend(verify_function(func, descriptors));
+    }
     errors
 }
 
@@ -316,6 +332,20 @@ impl FunctionVerifier<'_> {
                 self.check_nonzero_size(pc, elem_size);
                 self.check_frame_access(Some(pc), elem, elem_size);
                 self.check_descriptor(pc, descriptor_id);
+                if descriptor_id.as_usize() < self.descriptors.len()
+                    && !matches!(
+                        self.descriptors[descriptor_id.as_usize()].inner(),
+                        ObjectDescriptorInner::Vector { .. }
+                    )
+                {
+                    self.err(
+                        Some(pc),
+                        format!(
+                            "VecPushBack: descriptor_id {} is not a Vector",
+                            descriptor_id
+                        ),
+                    );
+                }
             },
 
             MicroOp::VecPopBack {
@@ -394,8 +424,8 @@ impl FunctionVerifier<'_> {
                 self.check_descriptor(pc, descriptor_id);
                 if descriptor_id.as_usize() < self.descriptors.len()
                     && !matches!(
-                        self.descriptors[descriptor_id.as_usize()],
-                        ObjectDescriptor::Struct { .. } | ObjectDescriptor::Enum { .. }
+                        self.descriptors[descriptor_id.as_usize()].inner(),
+                        ObjectDescriptorInner::Struct { .. } | ObjectDescriptorInner::Enum { .. }
                     )
                 {
                     self.err(
@@ -442,43 +472,64 @@ impl FunctionVerifier<'_> {
     fn verify_pack_closure(&mut self, pc: usize, op: &PackClosureOp) {
         // Destination: 8-byte heap pointer slot for the closure heap object.
         self.check_frame_access_8(pc, op.dst);
-        // Allocator descriptors must be valid.
-        self.check_descriptor(pc, op.closure_descriptor_id);
-        self.check_descriptor(pc, op.captured_data_descriptor_id);
-        // The closure descriptor must be the special `Closure` variant —
-        // size and the single heap-pointer offset are baked in.
-        let closure_desc_idx = op.closure_descriptor_id.as_usize();
-        if closure_desc_idx < self.descriptors.len()
-            && !matches!(
-                self.descriptors[closure_desc_idx],
-                ObjectDescriptor::Closure
-            )
-        {
-            self.err(
-                Some(pc),
-                format!(
-                    "PackClosure: closure_descriptor_id {} is not a Closure",
-                    op.closure_descriptor_id
-                ),
-            );
-        }
-        // The captured-data descriptor must be the `CapturedData` variant
-        // (not Struct) — its `size` and `pointer_offsets` are interpreted
-        // relative to the values region, not the full payload.
-        let captured_data_desc_idx = op.captured_data_descriptor_id.as_usize();
-        if captured_data_desc_idx < self.descriptors.len()
-            && !matches!(
-                self.descriptors[captured_data_desc_idx],
-                ObjectDescriptor::CapturedData { .. }
-            )
-        {
-            self.err(
-                Some(pc),
-                format!(
-                    "PackClosure: captured_data_descriptor_id {} is not a CapturedData",
-                    op.captured_data_descriptor_id
-                ),
-            );
+        // The closure object itself uses the implicit reserved
+        // `CLOSURE_DESCRIPTOR_ID` — no per-op field for it. The descriptor
+        // table is constructed via `ObjectDescriptorTable::new`, which
+        // unconditionally places `Closure` at this index (and therefore
+        // also guarantees `len() > CLOSURE_DESCRIPTOR_ID`). The asserts
+        // below are sanity checks against future internal regressions.
+        debug_assert!(
+            CLOSURE_DESCRIPTOR_ID.as_usize() < self.descriptors.len(),
+            "ObjectDescriptorTable invariant: descriptor table must have entry at {}",
+            CLOSURE_DESCRIPTOR_ID
+        );
+        debug_assert!(
+            matches!(
+                self.descriptors[CLOSURE_DESCRIPTOR_ID.as_usize()].inner(),
+                ObjectDescriptorInner::Closure
+            ),
+            "ObjectDescriptorTable invariant: descriptor[{}] must be Closure",
+            CLOSURE_DESCRIPTOR_ID
+        );
+        // captured_data_descriptor_id and `captured` must agree on emptiness:
+        // a captured-data object is allocated iff at least one value is
+        // captured.
+        match (op.captured_data_descriptor_id, op.captured.is_empty()) {
+            (None, true) => {},
+            (Some(id), false) => {
+                self.check_descriptor(pc, id);
+                let idx = id.as_usize();
+                if idx < self.descriptors.len()
+                    && !matches!(
+                        self.descriptors[idx].inner(),
+                        ObjectDescriptorInner::CapturedData { .. }
+                    )
+                {
+                    self.err(
+                        Some(pc),
+                        format!(
+                            "PackClosure: captured_data_descriptor_id {} is not a CapturedData",
+                            id
+                        ),
+                    );
+                }
+            },
+            (Some(id), true) => {
+                self.err(
+                    Some(pc),
+                    format!(
+                        "PackClosure: captured_data_descriptor_id {} provided but no captures",
+                        id
+                    ),
+                );
+            },
+            (None, false) => {
+                self.err(
+                    Some(pc),
+                    "PackClosure: captured non-empty but captured_data_descriptor_id is None"
+                        .to_string(),
+                );
+            },
         }
         // Captured sources: verify each (offset, size) is in-bounds.
         for slot in &op.captured {
@@ -547,21 +598,25 @@ impl FunctionVerifier<'_> {
         }
         // The captured-data descriptor's values region must be exactly
         // the materialized captured values — no padding, no extras.
-        // Together with the descriptor self-soundness check (see TODO on
-        // `verify_function`), this is sufficient to ensure the runtime's
-        // fixed-offset writes stay in bounds.
-        let expected_values_size: u32 = op.captured.iter().map(|s| s.size).sum();
-        let idx = op.captured_data_descriptor_id.as_usize();
-        if idx < self.descriptors.len() {
-            if let ObjectDescriptor::CapturedData { size: actual, .. } = &self.descriptors[idx] {
-                if *actual != expected_values_size {
-                    self.err(
-                        Some(pc),
-                        format!(
-                            "PackClosure: captured_data values size {} != expected {}",
-                            actual, expected_values_size
-                        ),
-                    );
+        // Together with the descriptor self-soundness pass, this is
+        // sufficient to ensure the runtime's fixed-offset writes stay in
+        // bounds.
+        if let Some(id) = op.captured_data_descriptor_id {
+            let expected_values_size: u32 = op.captured.iter().map(|s| s.size).sum();
+            let idx = id.as_usize();
+            if idx < self.descriptors.len() {
+                if let ObjectDescriptorInner::CapturedData { size: actual, .. } =
+                    self.descriptors[idx].inner()
+                {
+                    if *actual != expected_values_size {
+                        self.err(
+                            Some(pc),
+                            format!(
+                                "PackClosure: captured_data values size {} != expected {}",
+                                actual, expected_values_size
+                            ),
+                        );
+                    }
                 }
             }
         }

--- a/third_party/move/mono-move/runtime/tests/closures.rs
+++ b/third_party/move/mono-move/runtime/tests/closures.rs
@@ -17,7 +17,7 @@ use mono_move_core::{
     FrameOffset as FO, Function, LocalExecutionContext, MicroOp, PackClosureOp, SizedSlot,
     SortedSafePointEntries, FRAME_METADATA_SIZE,
 };
-use mono_move_runtime::{InterpreterContext, ObjectDescriptor};
+use mono_move_runtime::{InterpreterContext, ObjectDescriptor, ObjectDescriptorTable};
 
 // ---------------------------------------------------------------------------
 // Descriptors (shared — these describe object *shapes*, not test state)
@@ -32,33 +32,31 @@ use mono_move_runtime::{InterpreterContext, ObjectDescriptor};
 //     [header(8)] [tag(1)] [padding(7)] [captured values packed]
 //   Payload = 8 + sum(captured sizes). No pointer offsets for these
 //   tests (captures are u64 scalars).
+//
+// Descriptor 0 is reserved for `Trivial`; descriptor 1 is reserved for
+// `Closure` and is used implicitly by `PackClosure` (no per-op id field).
 
-const CLOSURE_DESC: DescriptorId = DescriptorId(0);
-const CAPTURED_0: DescriptorId = DescriptorId(1);
-const CAPTURED_1_U64: DescriptorId = DescriptorId(2);
-const CAPTURED_2_U64: DescriptorId = DescriptorId(3);
-const VEC_U64_DESC: DescriptorId = DescriptorId(4);
+/// Bundle of the descriptor table and the named ids it returns. Each test
+/// calls [`test_descriptors`] once at the top and threads the captured ids
+/// into its `PackClosure` / `VecPushBack` micro-ops.
+struct TestDescriptors {
+    table: ObjectDescriptorTable,
+    desc_captured_1_u64: DescriptorId,
+    desc_captured_2_u64: DescriptorId,
+    desc_vec_u64: DescriptorId,
+}
 
-fn test_descriptors() -> Vec<ObjectDescriptor> {
-    vec![
-        ObjectDescriptor::Closure,
-        ObjectDescriptor::CapturedData {
-            size: 0, // no captured values
-            pointer_offsets: vec![],
-        },
-        ObjectDescriptor::CapturedData {
-            size: 8, // 1 * u64
-            pointer_offsets: vec![],
-        },
-        ObjectDescriptor::CapturedData {
-            size: 16, // 2 * u64
-            pointer_offsets: vec![],
-        },
-        ObjectDescriptor::Vector {
-            elem_size: 8,
-            elem_pointer_offsets: vec![],
-        },
-    ]
+fn test_descriptors() -> TestDescriptors {
+    let mut table = ObjectDescriptorTable::new();
+    let desc_captured_1_u64 = table.push(ObjectDescriptor::new_captured_data(8, vec![]).unwrap());
+    let desc_captured_2_u64 = table.push(ObjectDescriptor::new_captured_data(16, vec![]).unwrap());
+    let desc_vec_u64 = table.push(ObjectDescriptor::new_vector(8, vec![]).unwrap());
+    TestDescriptors {
+        table,
+        desc_captured_1_u64,
+        desc_captured_2_u64,
+        desc_vec_u64,
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -239,6 +237,7 @@ fn identity_no_captures() {
     let args_and_locals: usize = 24;
     let callee_arg0 = FO((args_and_locals + FRAME_METADATA_SIZE) as u32);
 
+    let descs = test_descriptors();
     let arena = ExecutableArena::new();
     let identity = make_identity(&arena);
 
@@ -253,8 +252,7 @@ fn identity_no_captures() {
                 dst: closure,
                 func_ref: ClosureFuncRef::Resolved(identity),
                 mask: 0,
-                closure_descriptor_id: CLOSURE_DESC,
-                captured_data_descriptor_id: CAPTURED_0,
+                captured_data_descriptor_id: None,
                 captured: vec![],
             })),
             MicroOp::CallClosure(Box::new(CallClosureOp {
@@ -279,8 +277,7 @@ fn identity_no_captures() {
         safe_point_layouts: SortedSafePointEntries::empty(),
     });
 
-    let result =
-        run_main_and_get_u64_result(unsafe { main.as_ref_unchecked() }, &test_descriptors());
+    let result = run_main_and_get_u64_result(unsafe { main.as_ref_unchecked() }, &descs.table);
     assert_eq!(result, 42);
 }
 
@@ -310,6 +307,7 @@ fn add_captured_a_provided_b() {
     let args_and_locals: usize = 32;
     let callee_arg0 = FO((args_and_locals + FRAME_METADATA_SIZE) as u32);
 
+    let descs = test_descriptors();
     let arena = ExecutableArena::new();
     let add = make_add_u64(&arena);
 
@@ -322,8 +320,7 @@ fn add_captured_a_provided_b() {
                 dst: closure,
                 func_ref: ClosureFuncRef::Resolved(add),
                 mask: 0b01, // capture position 0
-                closure_descriptor_id: CLOSURE_DESC,
-                captured_data_descriptor_id: CAPTURED_1_U64,
+                captured_data_descriptor_id: Some(descs.desc_captured_1_u64),
                 captured: vec![SizedSlot { offset: a, size: 8 }],
             })),
             MicroOp::CallClosure(Box::new(CallClosureOp {
@@ -345,8 +342,7 @@ fn add_captured_a_provided_b() {
         safe_point_layouts: SortedSafePointEntries::empty(),
     });
 
-    let result =
-        run_main_and_get_u64_result(unsafe { main.as_ref_unchecked() }, &test_descriptors());
+    let result = run_main_and_get_u64_result(unsafe { main.as_ref_unchecked() }, &descs.table);
     assert_eq!(result, 42);
 }
 
@@ -369,6 +365,7 @@ fn add_provided_a_captured_b() {
     let args_and_locals: usize = 32;
     let callee_arg0 = FO((args_and_locals + FRAME_METADATA_SIZE) as u32);
 
+    let descs = test_descriptors();
     let arena = ExecutableArena::new();
     let add = make_add_u64(&arena);
 
@@ -381,8 +378,7 @@ fn add_provided_a_captured_b() {
                 dst: closure,
                 func_ref: ClosureFuncRef::Resolved(add),
                 mask: 0b10, // capture position 1
-                closure_descriptor_id: CLOSURE_DESC,
-                captured_data_descriptor_id: CAPTURED_1_U64,
+                captured_data_descriptor_id: Some(descs.desc_captured_1_u64),
                 captured: vec![SizedSlot { offset: b, size: 8 }],
             })),
             MicroOp::CallClosure(Box::new(CallClosureOp {
@@ -404,8 +400,7 @@ fn add_provided_a_captured_b() {
         safe_point_layouts: SortedSafePointEntries::empty(),
     });
 
-    let result =
-        run_main_and_get_u64_result(unsafe { main.as_ref_unchecked() }, &test_descriptors());
+    let result = run_main_and_get_u64_result(unsafe { main.as_ref_unchecked() }, &descs.table);
     assert_eq!(result, 42);
 }
 
@@ -428,6 +423,7 @@ fn add_all_captured() {
     let args_and_locals: usize = 32;
     let callee_arg0 = FO((args_and_locals + FRAME_METADATA_SIZE) as u32);
 
+    let descs = test_descriptors();
     let arena = ExecutableArena::new();
     let add = make_add_u64(&arena);
 
@@ -440,8 +436,7 @@ fn add_all_captured() {
                 dst: closure,
                 func_ref: ClosureFuncRef::Resolved(add),
                 mask: 0b11,
-                closure_descriptor_id: CLOSURE_DESC,
-                captured_data_descriptor_id: CAPTURED_2_U64,
+                captured_data_descriptor_id: Some(descs.desc_captured_2_u64),
                 captured: vec![SizedSlot { offset: a, size: 8 }, SizedSlot {
                     offset: b,
                     size: 8,
@@ -466,8 +461,7 @@ fn add_all_captured() {
         safe_point_layouts: SortedSafePointEntries::empty(),
     });
 
-    let result =
-        run_main_and_get_u64_result(unsafe { main.as_ref_unchecked() }, &test_descriptors());
+    let result = run_main_and_get_u64_result(unsafe { main.as_ref_unchecked() }, &descs.table);
     assert_eq!(result, 42);
 }
 
@@ -516,6 +510,7 @@ fn vector_map_add_captured() {
     let n: u64 = 3;
     let y_val: u64 = 10;
 
+    let descs = test_descriptors();
     let arena = ExecutableArena::new();
     let add = make_add_u64(&arena);
     let vector_map = make_vector_map(&arena);
@@ -537,21 +532,21 @@ fn vector_map_add_captured() {
                 vec_ref,
                 elem: tmp,
                 elem_size: 8,
-                descriptor_id: VEC_U64_DESC,
+                descriptor_id: descs.desc_vec_u64,
             },
             StoreImm8 { dst: tmp, imm: 3 },
             VecPushBack {
                 vec_ref,
                 elem: tmp,
                 elem_size: 8,
-                descriptor_id: VEC_U64_DESC,
+                descriptor_id: descs.desc_vec_u64,
             },
             StoreImm8 { dst: tmp, imm: 4 },
             VecPushBack {
                 vec_ref,
                 elem: tmp,
                 elem_size: 8,
-                descriptor_id: VEC_U64_DESC,
+                descriptor_id: descs.desc_vec_u64,
             },
             // === Pack closure: `|x| x + y`, wrapping add_u64 with `b` captured ===
             // pc 8: y = 10
@@ -561,8 +556,7 @@ fn vector_map_add_captured() {
                 dst: closure,
                 func_ref: ClosureFuncRef::Resolved(add),
                 mask: 0b10,
-                closure_descriptor_id: CLOSURE_DESC,
-                captured_data_descriptor_id: CAPTURED_1_U64,
+                captured_data_descriptor_id: Some(descs.desc_captured_1_u64),
                 captured: vec![SizedSlot { offset: y, size: 8 }],
             })),
             // === Call vector_map(vec, closure, n) ===
@@ -630,7 +624,6 @@ fn vector_map_add_captured() {
         safe_point_layouts: SortedSafePointEntries::empty(),
     });
 
-    let result =
-        run_main_and_get_u64_result(unsafe { main.as_ref_unchecked() }, &test_descriptors());
+    let result = run_main_and_get_u64_result(unsafe { main.as_ref_unchecked() }, &descs.table);
     assert_eq!(result, (2 + y_val) + (3 + y_val) + (4 + y_val));
 }

--- a/third_party/move/mono-move/runtime/tests/enum_test.rs
+++ b/third_party/move/mono-move/runtime/tests/enum_test.rs
@@ -5,11 +5,12 @@
 
 use mono_move_alloc::{ExecutableArena, ExecutableArenaPtr, GlobalArenaPtr};
 use mono_move_core::{
-    CodeOffset as CO, DescriptorId, FrameLayoutInfo, FrameOffset as FO, Function,
-    LocalExecutionContext, MicroOp, SortedSafePointEntries, ENUM_DATA_OFFSET, ENUM_TAG_OFFSET,
+    CodeOffset as CO, FrameLayoutInfo, FrameOffset as FO, Function, LocalExecutionContext, MicroOp,
+    SortedSafePointEntries, ENUM_DATA_OFFSET, ENUM_TAG_OFFSET,
 };
 use mono_move_runtime::{
-    read_ptr, read_u64, InterpreterContext, ObjectDescriptor, VEC_DATA_OFFSET, VEC_LENGTH_OFFSET,
+    read_ptr, read_u64, InterpreterContext, ObjectDescriptor, ObjectDescriptorTable,
+    VEC_DATA_OFFSET, VEC_LENGTH_OFFSET,
 };
 
 // ---------------------------------------------------------------------------
@@ -26,9 +27,13 @@ fn enum_basic() {
 
     let arena = ExecutableArena::new();
 
+    let mut descriptors = ObjectDescriptorTable::new();
+    let desc_shape_enum =
+        descriptors.push(ObjectDescriptor::new_enum(24, vec![vec![], vec![]]).unwrap());
+
     #[rustfmt::skip]
     let code = arena.alloc_slice_fill_iter([
-        HeapNew { dst: FO(shape), descriptor_id: DescriptorId(0) },
+        HeapNew { dst: FO(shape), descriptor_id: desc_shape_enum },
         MicroOp::enum_set_tag(FO(shape), 1),
         StoreImm8 { dst: FO(tmp), imm: 3 },
         MicroOp::enum_store8(FO(shape), 0, FO(tmp)),
@@ -52,10 +57,7 @@ fn enum_basic() {
         frame_layout: FrameLayoutInfo::new(&arena, [FO(shape)]),
         safe_point_layouts: SortedSafePointEntries::empty(),
     })];
-    let descriptors = [ObjectDescriptor::Enum {
-        size: 24,
-        variant_pointer_offsets: vec![vec![], vec![]],
-    }];
+
     let mut exec_ctx = LocalExecutionContext::with_max_budget();
     let mut ctx = InterpreterContext::new(&mut exec_ctx, &descriptors, unsafe {
         functions[0].as_ref_unchecked()
@@ -87,9 +89,13 @@ fn enum_survives_gc() {
 
     let arena = ExecutableArena::new();
 
+    let mut descriptors = ObjectDescriptorTable::new();
+    let desc_shape_enum =
+        descriptors.push(ObjectDescriptor::new_enum(24, vec![vec![], vec![]]).unwrap());
+
     #[rustfmt::skip]
     let code = arena.alloc_slice_fill_iter([
-        HeapNew { dst: FO(shape), descriptor_id: DescriptorId(0) },
+        HeapNew { dst: FO(shape), descriptor_id: desc_shape_enum },
         MicroOp::enum_set_tag(FO(shape), 0),
         StoreImm8 { dst: FO(tmp), imm: 42 },
         MicroOp::enum_store8(FO(shape), 0, FO(tmp)),
@@ -110,10 +116,7 @@ fn enum_survives_gc() {
         frame_layout: FrameLayoutInfo::new(&arena, [FO(shape)]),
         safe_point_layouts: SortedSafePointEntries::empty(),
     })];
-    let descriptors = [ObjectDescriptor::Enum {
-        size: 24,
-        variant_pointer_offsets: vec![vec![], vec![]],
-    }];
+
     let mut exec_ctx = LocalExecutionContext::with_max_budget();
     let mut ctx = InterpreterContext::new(&mut exec_ctx, &descriptors, unsafe {
         functions[0].as_ref_unchecked()
@@ -144,17 +147,22 @@ fn enum_gc_traces_refs() {
 
     let arena = ExecutableArena::new();
 
+    let mut descriptors = ObjectDescriptorTable::new();
+    let desc_val_enum =
+        descriptors.push(ObjectDescriptor::new_enum(16, vec![vec![], vec![0]]).unwrap());
+    let desc_vec_u64 = descriptors.push(ObjectDescriptor::new_vector(8, vec![]).unwrap());
+
     #[rustfmt::skip]
     let code = arena.alloc_slice_fill_iter([
         VecNew { dst: FO(vec) },
         SlotBorrow { dst: FO(vec_ref), local: FO(vec) },
         StoreImm8 { dst: FO(tmp), imm: 10 },
-        VecPushBack { vec_ref: FO(vec_ref), elem: FO(tmp), elem_size: 8, descriptor_id: DescriptorId(1) },
+        VecPushBack { vec_ref: FO(vec_ref), elem: FO(tmp), elem_size: 8, descriptor_id: desc_vec_u64 },
         StoreImm8 { dst: FO(tmp), imm: 20 },
-        VecPushBack { vec_ref: FO(vec_ref), elem: FO(tmp), elem_size: 8, descriptor_id: DescriptorId(1) },
+        VecPushBack { vec_ref: FO(vec_ref), elem: FO(tmp), elem_size: 8, descriptor_id: desc_vec_u64 },
         StoreImm8 { dst: FO(tmp), imm: 30 },
-        VecPushBack { vec_ref: FO(vec_ref), elem: FO(tmp), elem_size: 8, descriptor_id: DescriptorId(1) },
-        HeapNew { dst: FO(val), descriptor_id: DescriptorId(0) },
+        VecPushBack { vec_ref: FO(vec_ref), elem: FO(tmp), elem_size: 8, descriptor_id: desc_vec_u64 },
+        HeapNew { dst: FO(val), descriptor_id: desc_val_enum },
         MicroOp::enum_set_tag(FO(val), 1),
         MicroOp::enum_store8(FO(val), 0, FO(vec)),
         ForceGC,
@@ -175,13 +183,7 @@ fn enum_gc_traces_refs() {
         frame_layout: FrameLayoutInfo::new(&arena, [FO(val), FO(vec), FO(vec_ref)]),
         safe_point_layouts: SortedSafePointEntries::empty(),
     })];
-    let descriptors = [
-        ObjectDescriptor::Enum {
-            size: 16,
-            variant_pointer_offsets: vec![vec![], vec![0]],
-        },
-        ObjectDescriptor::Trivial,
-    ];
+
     let mut exec_ctx = LocalExecutionContext::with_max_budget();
     let mut ctx = InterpreterContext::new(&mut exec_ctx, &descriptors, unsafe {
         functions[0].as_ref_unchecked()
@@ -219,9 +221,13 @@ fn enum_pattern_match() {
 
     let arena = ExecutableArena::new();
 
+    let mut descriptors = ObjectDescriptorTable::new();
+    let desc_op_enum =
+        descriptors.push(ObjectDescriptor::new_enum(24, vec![vec![], vec![]]).unwrap());
+
     #[rustfmt::skip]
     let code = arena.alloc_slice_fill_iter([
-        HeapNew { dst: FO(op), descriptor_id: DescriptorId(0) },
+        HeapNew { dst: FO(op), descriptor_id: desc_op_enum },
         MicroOp::enum_set_tag(FO(op), 0),
         StoreImm8 { dst: FO(tmp), imm: 10 },
         MicroOp::enum_store8(FO(op), 0, FO(tmp)),
@@ -247,10 +253,7 @@ fn enum_pattern_match() {
         frame_layout: FrameLayoutInfo::new(&arena, [FO(op)]),
         safe_point_layouts: SortedSafePointEntries::empty(),
     })];
-    let descriptors = [ObjectDescriptor::Enum {
-        size: 24,
-        variant_pointer_offsets: vec![vec![], vec![]],
-    }];
+
     let mut exec_ctx = LocalExecutionContext::with_max_budget();
     let mut ctx = InterpreterContext::new(&mut exec_ctx, &descriptors, unsafe {
         functions[0].as_ref_unchecked()
@@ -274,9 +277,13 @@ fn enum_variant_switch() {
 
     let arena = ExecutableArena::new();
 
+    let mut descriptors = ObjectDescriptorTable::new();
+    let desc_e_enum =
+        descriptors.push(ObjectDescriptor::new_enum(16, vec![vec![], vec![]]).unwrap());
+
     #[rustfmt::skip]
     let code = arena.alloc_slice_fill_iter([
-        HeapNew { dst: FO(e), descriptor_id: DescriptorId(0) },
+        HeapNew { dst: FO(e), descriptor_id: desc_e_enum },
         MicroOp::enum_set_tag(FO(e), 0),
         StoreImm8 { dst: FO(tmp), imm: 111 },
         MicroOp::enum_store8(FO(e), 0, FO(tmp)),
@@ -300,10 +307,7 @@ fn enum_variant_switch() {
         frame_layout: FrameLayoutInfo::new(&arena, [FO(e)]),
         safe_point_layouts: SortedSafePointEntries::empty(),
     })];
-    let descriptors = [ObjectDescriptor::Enum {
-        size: 16,
-        variant_pointer_offsets: vec![vec![], vec![]],
-    }];
+
     let mut exec_ctx = LocalExecutionContext::with_max_budget();
     let mut ctx = InterpreterContext::new(&mut exec_ctx, &descriptors, unsafe {
         functions[0].as_ref_unchecked()
@@ -328,9 +332,13 @@ fn enum_borrow_field() {
 
     let arena = ExecutableArena::new();
 
+    let mut descriptors = ObjectDescriptorTable::new();
+    let desc_e_enum =
+        descriptors.push(ObjectDescriptor::new_enum(24, vec![vec![], vec![]]).unwrap());
+
     #[rustfmt::skip]
     let code = arena.alloc_slice_fill_iter([
-        HeapNew { dst: FO(e), descriptor_id: DescriptorId(0) },
+        HeapNew { dst: FO(e), descriptor_id: desc_e_enum },
         MicroOp::enum_set_tag(FO(e), 0),
         StoreImm8 { dst: FO(result), imm: 10 },
         MicroOp::enum_store8(FO(e), 0, FO(result)),
@@ -355,10 +363,7 @@ fn enum_borrow_field() {
         frame_layout: FrameLayoutInfo::new(&arena, [FO(e), FO(r#ref), FO(e_ref)]),
         safe_point_layouts: SortedSafePointEntries::empty(),
     })];
-    let descriptors = [ObjectDescriptor::Enum {
-        size: 24,
-        variant_pointer_offsets: vec![vec![], vec![]],
-    }];
+
     let mut exec_ctx = LocalExecutionContext::with_max_budget();
     let mut ctx = InterpreterContext::new(&mut exec_ctx, &descriptors, unsafe {
         functions[0].as_ref_unchecked()
@@ -384,13 +389,18 @@ fn enum_gc_variant_switching() {
 
     let arena = ExecutableArena::new();
 
+    let mut descriptors = ObjectDescriptorTable::new();
+    let desc_ctr_enum =
+        descriptors.push(ObjectDescriptor::new_enum(16, vec![vec![], vec![0]]).unwrap());
+    let desc_vec_u64 = descriptors.push(ObjectDescriptor::new_vector(8, vec![]).unwrap());
+
     #[rustfmt::skip]
     let code = arena.alloc_slice_fill_iter([
         VecNew { dst: FO(vec) },
         SlotBorrow { dst: FO(vec_ref), local: FO(vec) },
         StoreImm8 { dst: FO(tmp), imm: 100 },
-        VecPushBack { vec_ref: FO(vec_ref), elem: FO(tmp), elem_size: 8, descriptor_id: DescriptorId(1) },
-        HeapNew { dst: FO(ctr), descriptor_id: DescriptorId(0) },
+        VecPushBack { vec_ref: FO(vec_ref), elem: FO(tmp), elem_size: 8, descriptor_id: desc_vec_u64 },
+        HeapNew { dst: FO(ctr), descriptor_id: desc_ctr_enum },
         MicroOp::enum_set_tag(FO(ctr), 1),
         MicroOp::enum_store8(FO(ctr), 0, FO(vec)),
         ForceGC,
@@ -415,13 +425,7 @@ fn enum_gc_variant_switching() {
         frame_layout: FrameLayoutInfo::new(&arena, [FO(ctr), FO(vec), FO(vec_ref)]),
         safe_point_layouts: SortedSafePointEntries::empty(),
     })];
-    let descriptors = [
-        ObjectDescriptor::Enum {
-            size: 16,
-            variant_pointer_offsets: vec![vec![], vec![0]],
-        },
-        ObjectDescriptor::Trivial,
-    ];
+
     let mut exec_ctx = LocalExecutionContext::with_max_budget();
     let mut ctx = InterpreterContext::new(&mut exec_ctx, &descriptors, unsafe {
         functions[0].as_ref_unchecked()
@@ -451,13 +455,18 @@ fn enum_in_struct() {
 
     let arena = ExecutableArena::new();
 
+    let mut descriptors = ObjectDescriptorTable::new();
+    let desc_wrapper_struct = descriptors.push(ObjectDescriptor::new_struct(16, vec![8]).unwrap());
+    let desc_payload_enum =
+        descriptors.push(ObjectDescriptor::new_enum(16, vec![vec![], vec![]]).unwrap());
+
     #[rustfmt::skip]
     let code = arena.alloc_slice_fill_iter([
-        HeapNew { dst: FO(payload), descriptor_id: DescriptorId(1) },
+        HeapNew { dst: FO(payload), descriptor_id: desc_payload_enum },
         MicroOp::enum_set_tag(FO(payload), 1),
         StoreImm8 { dst: FO(tmp), imm: 42 },
         MicroOp::enum_store8(FO(payload), 0, FO(tmp)),
-        HeapNew { dst: FO(wrapper), descriptor_id: DescriptorId(0) },
+        HeapNew { dst: FO(wrapper), descriptor_id: desc_wrapper_struct },
         StoreImm8 { dst: FO(tmp), imm: 7 },
         MicroOp::struct_store8(FO(wrapper), 0, FO(tmp)),
         MicroOp::struct_store8(FO(wrapper), 8, FO(payload)),
@@ -480,16 +489,7 @@ fn enum_in_struct() {
         frame_layout: FrameLayoutInfo::new(&arena, [FO(wrapper), FO(payload)]),
         safe_point_layouts: SortedSafePointEntries::empty(),
     })];
-    let descriptors = [
-        ObjectDescriptor::Struct {
-            size: 16,
-            pointer_offsets: vec![8],
-        },
-        ObjectDescriptor::Enum {
-            size: 16,
-            variant_pointer_offsets: vec![vec![], vec![]],
-        },
-    ];
+
     let mut exec_ctx = LocalExecutionContext::with_max_budget();
     let mut ctx = InterpreterContext::new(&mut exec_ctx, &descriptors, unsafe {
         functions[0].as_ref_unchecked()
@@ -520,22 +520,27 @@ fn enum_in_vector() {
 
     let arena = ExecutableArena::new();
 
+    let mut descriptors = ObjectDescriptorTable::new();
+    let desc_e_enum =
+        descriptors.push(ObjectDescriptor::new_enum(24, vec![vec![], vec![]]).unwrap());
+    let desc_vec_enum_ptrs = descriptors.push(ObjectDescriptor::new_vector(8, vec![0]).unwrap());
+
     #[rustfmt::skip]
     let code = arena.alloc_slice_fill_iter([
         VecNew { dst: FO(vec) },
         SlotBorrow { dst: FO(vec_ref), local: FO(vec) },
-        HeapNew { dst: FO(e), descriptor_id: DescriptorId(0) },
+        HeapNew { dst: FO(e), descriptor_id: desc_e_enum },
         MicroOp::enum_set_tag(FO(e), 0),
         StoreImm8 { dst: FO(tmp), imm: 10 },
         MicroOp::enum_store8(FO(e), 0, FO(tmp)),
-        VecPushBack { vec_ref: FO(vec_ref), elem: FO(e), elem_size: 8, descriptor_id: DescriptorId(1) },
-        HeapNew { dst: FO(e), descriptor_id: DescriptorId(0) },
+        VecPushBack { vec_ref: FO(vec_ref), elem: FO(e), elem_size: 8, descriptor_id: desc_vec_enum_ptrs },
+        HeapNew { dst: FO(e), descriptor_id: desc_e_enum },
         MicroOp::enum_set_tag(FO(e), 1),
         StoreImm8 { dst: FO(tmp), imm: 30 },
         MicroOp::enum_store8(FO(e), 0, FO(tmp)),
         StoreImm8 { dst: FO(tmp), imm: 40 },
         MicroOp::enum_store8(FO(e), 8, FO(tmp)),
-        VecPushBack { vec_ref: FO(vec_ref), elem: FO(e), elem_size: 8, descriptor_id: DescriptorId(1) },
+        VecPushBack { vec_ref: FO(vec_ref), elem: FO(e), elem_size: 8, descriptor_id: desc_vec_enum_ptrs },
         ForceGC,
         StoreImm8 { dst: FO(tmp), imm: 0 },
         VecLoadElem { dst: FO(e), vec_ref: FO(vec_ref), idx: FO(tmp), elem_size: 8 },
@@ -559,16 +564,7 @@ fn enum_in_vector() {
         frame_layout: FrameLayoutInfo::new(&arena, [FO(vec), FO(e), FO(vec_ref)]),
         safe_point_layouts: SortedSafePointEntries::empty(),
     })];
-    let descriptors = [
-        ObjectDescriptor::Enum {
-            size: 24,
-            variant_pointer_offsets: vec![vec![], vec![]],
-        },
-        ObjectDescriptor::Vector {
-            elem_size: 8,
-            elem_pointer_offsets: vec![0],
-        },
-    ];
+
     let mut exec_ctx = LocalExecutionContext::with_max_budget();
     let mut ctx = InterpreterContext::new(&mut exec_ctx, &descriptors, unsafe {
         functions[0].as_ref_unchecked()

--- a/third_party/move/mono-move/runtime/tests/gc_stress.rs
+++ b/third_party/move/mono-move/runtime/tests/gc_stress.rs
@@ -23,11 +23,12 @@
 
 use mono_move_alloc::{ExecutableArena, ExecutableArenaPtr, GlobalArenaPtr};
 use mono_move_core::{
-    CodeOffset as CO, DescriptorId, FrameLayoutInfo, FrameOffset as FO, Function,
-    LocalExecutionContext, MicroOp, SortedSafePointEntries, STRUCT_DATA_OFFSET,
+    CodeOffset as CO, FrameLayoutInfo, FrameOffset as FO, Function, LocalExecutionContext, MicroOp,
+    SortedSafePointEntries, STRUCT_DATA_OFFSET,
 };
 use mono_move_runtime::{
-    read_ptr, read_u64, InterpreterContext, ObjectDescriptor, VEC_DATA_OFFSET, VEC_LENGTH_OFFSET,
+    read_ptr, read_u64, InterpreterContext, ObjectDescriptor, ObjectDescriptorTable,
+    VEC_DATA_OFFSET, VEC_LENGTH_OFFSET,
 };
 use rand::{rngs::StdRng, Rng, SeedableRng};
 
@@ -98,9 +99,14 @@ fn make_gc_stress_program(
     max_len: u64,
 ) -> (
     Vec<Option<ExecutableArenaPtr<Function>>>,
-    Vec<ObjectDescriptor>,
+    ObjectDescriptorTable,
 ) {
     use MicroOp::*;
+
+    let mut descriptors = ObjectDescriptorTable::new();
+    let desc_entry_struct = descriptors.push(ObjectDescriptor::new_struct(16, vec![8]).unwrap());
+    let desc_outer_vec = descriptors.push(ObjectDescriptor::new_vector(8, vec![0]).unwrap());
+    let desc_inner_vec = descriptors.push(ObjectDescriptor::new_vector(8, vec![]).unwrap());
 
     // -- Function 1: make_entry(val) -> entry_ptr --
     let callee_val: u32 = 0;
@@ -110,14 +116,10 @@ fn make_gc_stress_program(
 
     #[rustfmt::skip]
     let make_entry_code = arena.alloc_slice_fill_iter([
-        // PC 0: vec = VecNew(descriptor=0, elem_size=8)
         VecNew { dst: FO(callee_vec) },
-        // PC 1: vec_ref = SlotBorrow(vec)
         SlotBorrow { dst: FO(callee_vec_ref), local: FO(callee_vec) },
-        // PC 2: VecPushBack(vec_ref, val)
-        VecPushBack { vec_ref: FO(callee_vec_ref), elem: FO(callee_val), elem_size: 8, descriptor_id: DescriptorId(0) },
-        // PC 3: entry = HeapNew(descriptor=1)
-        HeapNew { dst: FO(callee_entry), descriptor_id: DescriptorId(1) },
+        VecPushBack { vec_ref: FO(callee_vec_ref), elem: FO(callee_val), elem_size: 8, descriptor_id: desc_inner_vec },
+        HeapNew { dst: FO(callee_entry), descriptor_id: desc_entry_struct },
         // PC 4: entry.key = val
         MicroOp::struct_store8(FO(callee_entry), 0, FO(callee_val)),
         // PC 5: entry.values = vec
@@ -189,7 +191,7 @@ fn make_gc_stress_program(
         // PC 13: if len >= max_len: goto REPLACE (PC 16)
         JumpGreaterEqualU64Imm { target: CO(16), src: FO(len), imm: max_len },
         // ---- PUSH (PC 14) ----
-        VecPushBack { vec_ref: FO(outer_vec_ref), elem: FO(entry_ptr), elem_size: 8, descriptor_id: DescriptorId(2) },
+        VecPushBack { vec_ref: FO(outer_vec_ref), elem: FO(entry_ptr), elem_size: 8, descriptor_id: desc_outer_vec },
         // PC 15: goto NEXT (PC 28)
         Jump { target: CO(28) },
 
@@ -248,21 +250,6 @@ fn make_gc_stress_program(
         safe_point_layouts: SortedSafePointEntries::empty(),
     });
 
-    let descriptors = vec![
-        // Descriptor 0: trivial — inner vectors hold plain u64 values
-        ObjectDescriptor::Trivial,
-        // Descriptor 1: Entry struct { key: u64, values: *vec }
-        ObjectDescriptor::Struct {
-            size: 16,
-            pointer_offsets: vec![8],
-        },
-        // Descriptor 2: outer vector whose 8-byte elements are heap pointers (to Entry structs)
-        ObjectDescriptor::Vector {
-            elem_size: 8,
-            elem_pointer_offsets: vec![0],
-        },
-    ];
-
     (vec![Some(main_func), Some(callee_func)], descriptors)
 }
 
@@ -307,6 +294,7 @@ fn gc_stress() {
     let (functions, descriptors) = make_gc_stress_program(&arena, n, max_len);
     // SAFETY: Exclusive access during test setup; arena is alive.
     unsafe { Function::resolve_calls(&functions) };
+
     let mut exec_ctx = LocalExecutionContext::with_max_budget();
     let mut ctx = InterpreterContext::with_heap_size(
         &mut exec_ctx,

--- a/third_party/move/mono-move/runtime/tests/ref_test.rs
+++ b/third_party/move/mono-move/runtime/tests/ref_test.rs
@@ -6,11 +6,12 @@
 
 use mono_move_alloc::{ExecutableArena, ExecutableArenaPtr, GlobalArenaPtr};
 use mono_move_core::{
-    DescriptorId, FrameLayoutInfo, FrameOffset as FO, Function, LocalExecutionContext, MicroOp,
+    FrameLayoutInfo, FrameOffset as FO, Function, LocalExecutionContext, MicroOp,
     SortedSafePointEntries, FRAME_METADATA_SIZE, STRUCT_DATA_OFFSET,
 };
 use mono_move_runtime::{
-    read_ptr, read_u64, InterpreterContext, ObjectDescriptor, VEC_DATA_OFFSET,
+    read_ptr, read_u64, InterpreterContext, ObjectDescriptor, ObjectDescriptorTable,
+    VEC_DATA_OFFSET,
 };
 
 // ---------------------------------------------------------------------------
@@ -31,16 +32,19 @@ fn ref_basic() {
 
     let arena = ExecutableArena::new();
 
+    let mut descriptors = ObjectDescriptorTable::new();
+    let desc_vec_u64 = descriptors.push(ObjectDescriptor::new_vector(8, vec![]).unwrap());
+
     #[rustfmt::skip]
     let code = arena.alloc_slice_fill_iter([
         VecNew { dst: FO(vec) },
         SlotBorrow { dst: FO(vec_ref), local: FO(vec) },
         StoreImm8 { dst: FO(tmp), imm: 10 },
-        VecPushBack { vec_ref: FO(vec_ref), elem: FO(tmp), elem_size: 8, descriptor_id: DescriptorId(0) },
+        VecPushBack { vec_ref: FO(vec_ref), elem: FO(tmp), elem_size: 8, descriptor_id: desc_vec_u64 },
         StoreImm8 { dst: FO(tmp), imm: 20 },
-        VecPushBack { vec_ref: FO(vec_ref), elem: FO(tmp), elem_size: 8, descriptor_id: DescriptorId(0) },
+        VecPushBack { vec_ref: FO(vec_ref), elem: FO(tmp), elem_size: 8, descriptor_id: desc_vec_u64 },
         StoreImm8 { dst: FO(tmp), imm: 30 },
-        VecPushBack { vec_ref: FO(vec_ref), elem: FO(tmp), elem_size: 8, descriptor_id: DescriptorId(0) },
+        VecPushBack { vec_ref: FO(vec_ref), elem: FO(tmp), elem_size: 8, descriptor_id: desc_vec_u64 },
         StoreImm8 { dst: FO(idx), imm: 1 },
         VecBorrow { dst: FO(r#ref), vec_ref: FO(vec_ref), idx: FO(idx), elem_size: 8 },
         ReadRef { dst: FO(result), ref_ptr: FO(r#ref), size: 8 },
@@ -60,7 +64,7 @@ fn ref_basic() {
         frame_layout: FrameLayoutInfo::new(&arena, [FO(vec), FO(r#ref), FO(vec_ref)]),
         safe_point_layouts: SortedSafePointEntries::empty(),
     })];
-    let descriptors = [ObjectDescriptor::Trivial];
+
     let mut exec_ctx = LocalExecutionContext::with_max_budget();
     let mut ctx = InterpreterContext::new(&mut exec_ctx, &descriptors, unsafe {
         functions[0].as_ref_unchecked()
@@ -95,16 +99,19 @@ fn ref_survives_gc() {
 
     let arena = ExecutableArena::new();
 
+    let mut descriptors = ObjectDescriptorTable::new();
+    let desc_vec_u64 = descriptors.push(ObjectDescriptor::new_vector(8, vec![]).unwrap());
+
     #[rustfmt::skip]
     let code = arena.alloc_slice_fill_iter([
         VecNew { dst: FO(vec) },
         SlotBorrow { dst: FO(vec_ref), local: FO(vec) },
         StoreImm8 { dst: FO(tmp), imm: 100 },
-        VecPushBack { vec_ref: FO(vec_ref), elem: FO(tmp), elem_size: 8, descriptor_id: DescriptorId(0) },
+        VecPushBack { vec_ref: FO(vec_ref), elem: FO(tmp), elem_size: 8, descriptor_id: desc_vec_u64 },
         StoreImm8 { dst: FO(tmp), imm: 200 },
-        VecPushBack { vec_ref: FO(vec_ref), elem: FO(tmp), elem_size: 8, descriptor_id: DescriptorId(0) },
+        VecPushBack { vec_ref: FO(vec_ref), elem: FO(tmp), elem_size: 8, descriptor_id: desc_vec_u64 },
         StoreImm8 { dst: FO(tmp), imm: 300 },
-        VecPushBack { vec_ref: FO(vec_ref), elem: FO(tmp), elem_size: 8, descriptor_id: DescriptorId(0) },
+        VecPushBack { vec_ref: FO(vec_ref), elem: FO(tmp), elem_size: 8, descriptor_id: desc_vec_u64 },
         StoreImm8 { dst: FO(idx), imm: 2 },
         VecBorrow { dst: FO(r#ref), vec_ref: FO(vec_ref), idx: FO(idx), elem_size: 8 },
         ForceGC,
@@ -125,7 +132,7 @@ fn ref_survives_gc() {
         frame_layout: FrameLayoutInfo::new(&arena, [FO(vec), FO(ref_base), FO(vec_ref)]),
         safe_point_layouts: SortedSafePointEntries::empty(),
     })];
-    let descriptors = [ObjectDescriptor::Trivial];
+
     let mut exec_ctx = LocalExecutionContext::with_max_budget();
     let mut ctx = InterpreterContext::new(&mut exec_ctx, &descriptors, unsafe {
         functions[0].as_ref_unchecked()
@@ -161,6 +168,9 @@ fn ref_cross_frame() {
 
     let arena = ExecutableArena::new();
 
+    let mut descriptors = ObjectDescriptorTable::new();
+    let desc_vec_u64 = descriptors.push(ObjectDescriptor::new_vector(8, vec![]).unwrap());
+
     #[rustfmt::skip]
     let callee_code = arena.alloc_slice_fill_iter([
         ForceGC,
@@ -194,11 +204,11 @@ fn ref_cross_frame() {
         VecNew { dst: FO(m_vec) },
         SlotBorrow { dst: FO(m_vec_ref), local: FO(m_vec) },
         StoreImm8 { dst: FO(m_tmp), imm: 10 },
-        VecPushBack { vec_ref: FO(m_vec_ref), elem: FO(m_tmp), elem_size: 8, descriptor_id: DescriptorId(0) },
+        VecPushBack { vec_ref: FO(m_vec_ref), elem: FO(m_tmp), elem_size: 8, descriptor_id: desc_vec_u64 },
         StoreImm8 { dst: FO(m_tmp), imm: 20 },
-        VecPushBack { vec_ref: FO(m_vec_ref), elem: FO(m_tmp), elem_size: 8, descriptor_id: DescriptorId(0) },
+        VecPushBack { vec_ref: FO(m_vec_ref), elem: FO(m_tmp), elem_size: 8, descriptor_id: desc_vec_u64 },
         StoreImm8 { dst: FO(m_tmp), imm: 30 },
-        VecPushBack { vec_ref: FO(m_vec_ref), elem: FO(m_tmp), elem_size: 8, descriptor_id: DescriptorId(0) },
+        VecPushBack { vec_ref: FO(m_vec_ref), elem: FO(m_tmp), elem_size: 8, descriptor_id: desc_vec_u64 },
         StoreImm8 { dst: FO(m_idx), imm: 1 },
         VecBorrow { dst: FO(m_callee_ref), vec_ref: FO(m_vec_ref), idx: FO(m_idx), elem_size: 8 },
         CallFunc { func_id: 1 },
@@ -217,10 +227,10 @@ fn ref_cross_frame() {
         safe_point_layouts: SortedSafePointEntries::empty(),
     });
 
-    let descriptors = [ObjectDescriptor::Trivial];
     let functions = [Some(main_func), Some(callee_func)];
     // SAFETY: Exclusive access during test setup; arena is alive.
     unsafe { Function::resolve_calls(&functions) };
+
     let mut exec_ctx = LocalExecutionContext::with_max_budget();
     let mut ctx = InterpreterContext::new(&mut exec_ctx, &descriptors, unsafe {
         functions[0].unwrap().as_ref_unchecked()
@@ -263,18 +273,21 @@ fn ref_multiple_borrows() {
 
     let arena = ExecutableArena::new();
 
+    let mut descriptors = ObjectDescriptorTable::new();
+    let desc_vec_u64 = descriptors.push(ObjectDescriptor::new_vector(8, vec![]).unwrap());
+
     #[rustfmt::skip]
     let code = arena.alloc_slice_fill_iter([
         VecNew { dst: FO(vec) },
         SlotBorrow { dst: FO(vec_ref), local: FO(vec) },
         StoreImm8 { dst: FO(tmp), imm: 10 },
-        VecPushBack { vec_ref: FO(vec_ref), elem: FO(tmp), elem_size: 8, descriptor_id: DescriptorId(0) },
+        VecPushBack { vec_ref: FO(vec_ref), elem: FO(tmp), elem_size: 8, descriptor_id: desc_vec_u64 },
         StoreImm8 { dst: FO(tmp), imm: 20 },
-        VecPushBack { vec_ref: FO(vec_ref), elem: FO(tmp), elem_size: 8, descriptor_id: DescriptorId(0) },
+        VecPushBack { vec_ref: FO(vec_ref), elem: FO(tmp), elem_size: 8, descriptor_id: desc_vec_u64 },
         StoreImm8 { dst: FO(tmp), imm: 30 },
-        VecPushBack { vec_ref: FO(vec_ref), elem: FO(tmp), elem_size: 8, descriptor_id: DescriptorId(0) },
+        VecPushBack { vec_ref: FO(vec_ref), elem: FO(tmp), elem_size: 8, descriptor_id: desc_vec_u64 },
         StoreImm8 { dst: FO(tmp), imm: 40 },
-        VecPushBack { vec_ref: FO(vec_ref), elem: FO(tmp), elem_size: 8, descriptor_id: DescriptorId(0) },
+        VecPushBack { vec_ref: FO(vec_ref), elem: FO(tmp), elem_size: 8, descriptor_id: desc_vec_u64 },
         StoreImm8 { dst: FO(idx), imm: 1 },
         VecBorrow { dst: FO(ref_a), vec_ref: FO(vec_ref), idx: FO(idx), elem_size: 8 },
         StoreImm8 { dst: FO(idx), imm: 3 },
@@ -303,7 +316,7 @@ fn ref_multiple_borrows() {
         ]),
         safe_point_layouts: SortedSafePointEntries::empty(),
     })];
-    let descriptors = [ObjectDescriptor::Trivial];
+
     let mut exec_ctx = LocalExecutionContext::with_max_budget();
     let mut ctx = InterpreterContext::new(&mut exec_ctx, &descriptors, unsafe {
         functions[0].as_ref_unchecked()
@@ -345,6 +358,9 @@ fn ref_borrow_local() {
 
     let arena = ExecutableArena::new();
 
+    // No user descriptors used; the table just provides the reserved entries.
+    let descriptors = ObjectDescriptorTable::new();
+
     #[rustfmt::skip]
     let code = arena.alloc_slice_fill_iter([
         StoreImm8 { dst: FO(local_val), imm: 42 },
@@ -371,7 +387,7 @@ fn ref_borrow_local() {
         frame_layout: FrameLayoutInfo::new(&arena, [FO(ref_base), FO(vec), FO(vec_ref)]),
         safe_point_layouts: SortedSafePointEntries::empty(),
     })];
-    let descriptors = [ObjectDescriptor::Trivial];
+
     let mut exec_ctx = LocalExecutionContext::with_max_budget();
     let mut ctx = InterpreterContext::new(&mut exec_ctx, &descriptors, unsafe {
         functions[0].as_ref_unchecked()
@@ -407,29 +423,33 @@ fn ref_nested_vectors() {
 
     let arena = ExecutableArena::new();
 
+    let mut descriptors = ObjectDescriptorTable::new();
+    let desc_vec_outer = descriptors.push(ObjectDescriptor::new_vector(8, vec![0]).unwrap());
+    let desc_vec_inner = descriptors.push(ObjectDescriptor::new_vector(8, vec![]).unwrap());
+
     #[rustfmt::skip]
     let code = arena.alloc_slice_fill_iter([
         // -- Build inner0 = [100, 200] --
         VecNew { dst: FO(inner_ptr) },
         SlotBorrow { dst: FO(inner_ref), local: FO(inner_ptr) },
         StoreImm8 { dst: FO(tmp), imm: 100 },
-        VecPushBack { vec_ref: FO(inner_ref), elem: FO(tmp), elem_size: 8, descriptor_id: DescriptorId(0) },
+        VecPushBack { vec_ref: FO(inner_ref), elem: FO(tmp), elem_size: 8, descriptor_id: desc_vec_inner },
         StoreImm8 { dst: FO(tmp), imm: 200 },
-        VecPushBack { vec_ref: FO(inner_ref), elem: FO(tmp), elem_size: 8, descriptor_id: DescriptorId(0) },
+        VecPushBack { vec_ref: FO(inner_ref), elem: FO(tmp), elem_size: 8, descriptor_id: desc_vec_inner },
         // -- Build outer --
         VecNew { dst: FO(outer) },
         SlotBorrow { dst: FO(outer_ref), local: FO(outer) },
-        VecPushBack { vec_ref: FO(outer_ref), elem: FO(inner_ptr), elem_size: 8, descriptor_id: DescriptorId(1) },
+        VecPushBack { vec_ref: FO(outer_ref), elem: FO(inner_ptr), elem_size: 8, descriptor_id: desc_vec_outer },
         // -- Build inner1 = [300, 400, 500] --
         VecNew { dst: FO(inner_ptr) },
         SlotBorrow { dst: FO(inner_ref), local: FO(inner_ptr) },
         StoreImm8 { dst: FO(tmp), imm: 300 },
-        VecPushBack { vec_ref: FO(inner_ref), elem: FO(tmp), elem_size: 8, descriptor_id: DescriptorId(0) },
+        VecPushBack { vec_ref: FO(inner_ref), elem: FO(tmp), elem_size: 8, descriptor_id: desc_vec_inner },
         StoreImm8 { dst: FO(tmp), imm: 400 },
-        VecPushBack { vec_ref: FO(inner_ref), elem: FO(tmp), elem_size: 8, descriptor_id: DescriptorId(0) },
+        VecPushBack { vec_ref: FO(inner_ref), elem: FO(tmp), elem_size: 8, descriptor_id: desc_vec_inner },
         StoreImm8 { dst: FO(tmp), imm: 500 },
-        VecPushBack { vec_ref: FO(inner_ref), elem: FO(tmp), elem_size: 8, descriptor_id: DescriptorId(0) },
-        VecPushBack { vec_ref: FO(outer_ref), elem: FO(inner_ptr), elem_size: 8, descriptor_id: DescriptorId(1) },
+        VecPushBack { vec_ref: FO(inner_ref), elem: FO(tmp), elem_size: 8, descriptor_id: desc_vec_inner },
+        VecPushBack { vec_ref: FO(outer_ref), elem: FO(inner_ptr), elem_size: 8, descriptor_id: desc_vec_outer },
         // -- Load outer[1] → inner1 ptr, borrow inner1[2] --
         StoreImm8 { dst: FO(idx), imm: 1 },
         VecLoadElem { dst: FO(inner_ptr), vec_ref: FO(outer_ref), idx: FO(idx), elem_size: 8 },
@@ -459,10 +479,7 @@ fn ref_nested_vectors() {
         ]),
         safe_point_layouts: SortedSafePointEntries::empty(),
     })];
-    let descriptors = [ObjectDescriptor::Trivial, ObjectDescriptor::Vector {
-        elem_size: 8,
-        elem_pointer_offsets: vec![0],
-    }];
+
     let mut exec_ctx = LocalExecutionContext::with_max_budget();
     let mut ctx = InterpreterContext::new(&mut exec_ctx, &descriptors, unsafe {
         functions[0].as_ref_unchecked()
@@ -518,16 +535,19 @@ fn ref_survives_double_gc() {
 
     let arena = ExecutableArena::new();
 
+    let mut descriptors = ObjectDescriptorTable::new();
+    let desc_vec_u64 = descriptors.push(ObjectDescriptor::new_vector(8, vec![]).unwrap());
+
     #[rustfmt::skip]
     let code = arena.alloc_slice_fill_iter([
         VecNew { dst: FO(vec) },
         SlotBorrow { dst: FO(vec_ref), local: FO(vec) },
         StoreImm8 { dst: FO(tmp), imm: 10 },
-        VecPushBack { vec_ref: FO(vec_ref), elem: FO(tmp), elem_size: 8, descriptor_id: DescriptorId(0) },
+        VecPushBack { vec_ref: FO(vec_ref), elem: FO(tmp), elem_size: 8, descriptor_id: desc_vec_u64 },
         StoreImm8 { dst: FO(tmp), imm: 20 },
-        VecPushBack { vec_ref: FO(vec_ref), elem: FO(tmp), elem_size: 8, descriptor_id: DescriptorId(0) },
+        VecPushBack { vec_ref: FO(vec_ref), elem: FO(tmp), elem_size: 8, descriptor_id: desc_vec_u64 },
         StoreImm8 { dst: FO(tmp), imm: 30 },
-        VecPushBack { vec_ref: FO(vec_ref), elem: FO(tmp), elem_size: 8, descriptor_id: DescriptorId(0) },
+        VecPushBack { vec_ref: FO(vec_ref), elem: FO(tmp), elem_size: 8, descriptor_id: desc_vec_u64 },
         StoreImm8 { dst: FO(idx), imm: 1 },
         VecBorrow { dst: FO(r#ref), vec_ref: FO(vec_ref), idx: FO(idx), elem_size: 8 },
         ForceGC,
@@ -548,7 +568,7 @@ fn ref_survives_double_gc() {
         frame_layout: FrameLayoutInfo::new(&arena, [FO(vec), FO(ref_base), FO(vec_ref)]),
         safe_point_layouts: SortedSafePointEntries::empty(),
     })];
-    let descriptors = [ObjectDescriptor::Trivial];
+
     let mut exec_ctx = LocalExecutionContext::with_max_budget();
     let mut ctx = InterpreterContext::new(&mut exec_ctx, &descriptors, unsafe {
         functions[0].as_ref_unchecked()
@@ -584,9 +604,12 @@ fn ref_struct_field_borrow() {
 
     let arena = ExecutableArena::new();
 
+    let mut descriptors = ObjectDescriptorTable::new();
+    let desc_entry_struct = descriptors.push(ObjectDescriptor::new_struct(16, vec![]).unwrap());
+
     #[rustfmt::skip]
     let code = arena.alloc_slice_fill_iter([
-        HeapNew { dst: FO(entry), descriptor_id: DescriptorId(0) },
+        HeapNew { dst: FO(entry), descriptor_id: desc_entry_struct },
         StoreImm8 { dst: FO(result), imm: 42 },
         MicroOp::struct_store8(FO(entry), 0, FO(result)),
         StoreImm8 { dst: FO(result), imm: 100 },
@@ -610,10 +633,7 @@ fn ref_struct_field_borrow() {
         frame_layout: FrameLayoutInfo::new(&arena, [FO(entry), FO(r#ref), FO(entry_ref)]),
         safe_point_layouts: SortedSafePointEntries::empty(),
     })];
-    let descriptors = [ObjectDescriptor::Struct {
-        size: 16,
-        pointer_offsets: vec![],
-    }];
+
     let mut exec_ctx = LocalExecutionContext::with_max_budget();
     let mut ctx = InterpreterContext::new(&mut exec_ctx, &descriptors, unsafe {
         functions[0].as_ref_unchecked()
@@ -646,9 +666,12 @@ fn ref_struct_field_survives_gc() {
 
     let arena = ExecutableArena::new();
 
+    let mut descriptors = ObjectDescriptorTable::new();
+    let desc_entry_struct = descriptors.push(ObjectDescriptor::new_struct(16, vec![]).unwrap());
+
     #[rustfmt::skip]
     let code = arena.alloc_slice_fill_iter([
-        HeapNew { dst: FO(entry), descriptor_id: DescriptorId(0) },
+        HeapNew { dst: FO(entry), descriptor_id: desc_entry_struct },
         StoreImm8 { dst: FO(result), imm: 7 },
         MicroOp::struct_store8(FO(entry), 0, FO(result)),
         StoreImm8 { dst: FO(result), imm: 13 },
@@ -670,10 +693,7 @@ fn ref_struct_field_survives_gc() {
         frame_layout: FrameLayoutInfo::new(&arena, [FO(entry), FO(ref_base), FO(entry_ref)]),
         safe_point_layouts: SortedSafePointEntries::empty(),
     })];
-    let descriptors = [ObjectDescriptor::Struct {
-        size: 16,
-        pointer_offsets: vec![],
-    }];
+
     let mut exec_ctx = LocalExecutionContext::with_max_budget();
     let mut ctx = InterpreterContext::new(&mut exec_ctx, &descriptors, unsafe {
         functions[0].as_ref_unchecked()

--- a/third_party/move/mono-move/runtime/tests/struct_test.rs
+++ b/third_party/move/mono-move/runtime/tests/struct_test.rs
@@ -5,11 +5,12 @@
 
 use mono_move_alloc::{ExecutableArena, ExecutableArenaPtr, GlobalArenaPtr};
 use mono_move_core::{
-    DescriptorId, FrameLayoutInfo, FrameOffset as FO, Function, LocalExecutionContext, MicroOp,
+    FrameLayoutInfo, FrameOffset as FO, Function, LocalExecutionContext, MicroOp,
     SortedSafePointEntries, STRUCT_DATA_OFFSET,
 };
 use mono_move_runtime::{
-    read_ptr, read_u64, InterpreterContext, ObjectDescriptor, VEC_DATA_OFFSET, VEC_LENGTH_OFFSET,
+    read_ptr, read_u64, InterpreterContext, ObjectDescriptor, ObjectDescriptorTable,
+    VEC_DATA_OFFSET, VEC_LENGTH_OFFSET,
 };
 
 // ---------------------------------------------------------------------------
@@ -44,7 +45,8 @@ fn struct_inline() {
         frame_layout: FrameLayoutInfo::empty(),
         safe_point_layouts: SortedSafePointEntries::empty(),
     })];
-    let descriptors = [ObjectDescriptor::Trivial];
+    let descriptors = ObjectDescriptorTable::new();
+
     let mut exec_ctx = LocalExecutionContext::with_max_budget();
     let mut ctx = InterpreterContext::new(&mut exec_ctx, &descriptors, unsafe {
         functions[0].as_ref_unchecked()
@@ -91,7 +93,8 @@ fn struct_inline_borrow() {
         frame_layout: FrameLayoutInfo::new(&arena, [FO(r#ref)]),
         safe_point_layouts: SortedSafePointEntries::empty(),
     })];
-    let descriptors = [ObjectDescriptor::Trivial];
+    let descriptors = ObjectDescriptorTable::new();
+
     let mut exec_ctx = LocalExecutionContext::with_max_budget();
     let mut ctx = InterpreterContext::new(&mut exec_ctx, &descriptors, unsafe {
         functions[0].as_ref_unchecked()
@@ -115,9 +118,12 @@ fn struct_heap_basic() {
 
     let arena = ExecutableArena::new();
 
+    let mut descriptors = ObjectDescriptorTable::new();
+    let desc_entry_struct = descriptors.push(ObjectDescriptor::new_struct(16, vec![]).unwrap());
+
     #[rustfmt::skip]
     let code = arena.alloc_slice_fill_iter([
-        HeapNew { dst: FO(entry), descriptor_id: DescriptorId(0) },
+        HeapNew { dst: FO(entry), descriptor_id: desc_entry_struct },
         StoreImm8 { dst: FO(tmp), imm: 42 },
         MicroOp::struct_store8(FO(entry), 0, FO(tmp)),
         StoreImm8 { dst: FO(tmp), imm: 100 },
@@ -138,10 +144,7 @@ fn struct_heap_basic() {
         frame_layout: FrameLayoutInfo::new(&arena, [FO(entry)]),
         safe_point_layouts: SortedSafePointEntries::empty(),
     })];
-    let descriptors = [ObjectDescriptor::Struct {
-        size: 16,
-        pointer_offsets: vec![],
-    }];
+
     let mut exec_ctx = LocalExecutionContext::with_max_budget();
     let mut ctx = InterpreterContext::new(&mut exec_ctx, &descriptors, unsafe {
         functions[0].as_ref_unchecked()
@@ -165,9 +168,12 @@ fn struct_heap_survives_gc() {
 
     let arena = ExecutableArena::new();
 
+    let mut descriptors = ObjectDescriptorTable::new();
+    let desc_entry_struct = descriptors.push(ObjectDescriptor::new_struct(16, vec![]).unwrap());
+
     #[rustfmt::skip]
     let code = arena.alloc_slice_fill_iter([
-        HeapNew { dst: FO(entry), descriptor_id: DescriptorId(0) },
+        HeapNew { dst: FO(entry), descriptor_id: desc_entry_struct },
         StoreImm8 { dst: FO(tmp), imm: 7 },
         MicroOp::struct_store8(FO(entry), 0, FO(tmp)),
         StoreImm8 { dst: FO(tmp), imm: 13 },
@@ -189,10 +195,7 @@ fn struct_heap_survives_gc() {
         frame_layout: FrameLayoutInfo::new(&arena, [FO(entry)]),
         safe_point_layouts: SortedSafePointEntries::empty(),
     })];
-    let descriptors = [ObjectDescriptor::Struct {
-        size: 16,
-        pointer_offsets: vec![],
-    }];
+
     let mut exec_ctx = LocalExecutionContext::with_max_budget();
     let mut ctx = InterpreterContext::new(&mut exec_ctx, &descriptors, unsafe {
         functions[0].as_ref_unchecked()
@@ -224,19 +227,23 @@ fn struct_with_vector_field() {
 
     let arena = ExecutableArena::new();
 
+    let mut descriptors = ObjectDescriptorTable::new();
+    let desc_ctr_struct = descriptors.push(ObjectDescriptor::new_struct(16, vec![8]).unwrap());
+    let desc_vec_u64 = descriptors.push(ObjectDescriptor::new_vector(8, vec![]).unwrap());
+
     #[rustfmt::skip]
     let code = arena.alloc_slice_fill_iter([
-        HeapNew { dst: FO(ctr), descriptor_id: DescriptorId(0) },
+        HeapNew { dst: FO(ctr), descriptor_id: desc_ctr_struct },
         StoreImm8 { dst: FO(tmp), imm: 999 },
         MicroOp::struct_store8(FO(ctr), 0, FO(tmp)),
         VecNew { dst: FO(items) },
         SlotBorrow { dst: FO(vec_ref), local: FO(items) },
         StoreImm8 { dst: FO(tmp), imm: 10 },
-        VecPushBack { vec_ref: FO(vec_ref), elem: FO(tmp), elem_size: 8, descriptor_id: DescriptorId(1) },
+        VecPushBack { vec_ref: FO(vec_ref), elem: FO(tmp), elem_size: 8, descriptor_id: desc_vec_u64 },
         StoreImm8 { dst: FO(tmp), imm: 20 },
-        VecPushBack { vec_ref: FO(vec_ref), elem: FO(tmp), elem_size: 8, descriptor_id: DescriptorId(1) },
+        VecPushBack { vec_ref: FO(vec_ref), elem: FO(tmp), elem_size: 8, descriptor_id: desc_vec_u64 },
         StoreImm8 { dst: FO(tmp), imm: 30 },
-        VecPushBack { vec_ref: FO(vec_ref), elem: FO(tmp), elem_size: 8, descriptor_id: DescriptorId(1) },
+        VecPushBack { vec_ref: FO(vec_ref), elem: FO(tmp), elem_size: 8, descriptor_id: desc_vec_u64 },
         MicroOp::struct_store8(FO(ctr), 8, FO(items)),
         ForceGC,
         SlotBorrow { dst: FO(ctr_ref), local: FO(ctr) },
@@ -256,13 +263,7 @@ fn struct_with_vector_field() {
         frame_layout: FrameLayoutInfo::new(&arena, [FO(ctr), FO(items), FO(vec_ref), FO(ctr_ref)]),
         safe_point_layouts: SortedSafePointEntries::empty(),
     })];
-    let descriptors = [
-        ObjectDescriptor::Struct {
-            size: 16,
-            pointer_offsets: vec![8],
-        },
-        ObjectDescriptor::Trivial,
-    ];
+
     let mut exec_ctx = LocalExecutionContext::with_max_budget();
     let mut ctx = InterpreterContext::new(&mut exec_ctx, &descriptors, unsafe {
         functions[0].as_ref_unchecked()
@@ -299,9 +300,12 @@ fn struct_borrow_field() {
 
     let arena = ExecutableArena::new();
 
+    let mut descriptors = ObjectDescriptorTable::new();
+    let desc_entry_struct = descriptors.push(ObjectDescriptor::new_struct(16, vec![]).unwrap());
+
     #[rustfmt::skip]
     let code = arena.alloc_slice_fill_iter([
-        HeapNew { dst: FO(entry), descriptor_id: DescriptorId(0) },
+        HeapNew { dst: FO(entry), descriptor_id: desc_entry_struct },
         StoreImm8 { dst: FO(result), imm: 5 },
         MicroOp::struct_store8(FO(entry), 0, FO(result)),
         StoreImm8 { dst: FO(result), imm: 10 },
@@ -325,10 +329,7 @@ fn struct_borrow_field() {
         frame_layout: FrameLayoutInfo::new(&arena, [FO(entry), FO(r#ref), FO(entry_ref)]),
         safe_point_layouts: SortedSafePointEntries::empty(),
     })];
-    let descriptors = [ObjectDescriptor::Struct {
-        size: 16,
-        pointer_offsets: vec![],
-    }];
+
     let mut exec_ctx = LocalExecutionContext::with_max_budget();
     let mut ctx = InterpreterContext::new(&mut exec_ctx, &descriptors, unsafe {
         functions[0].as_ref_unchecked()
@@ -358,9 +359,12 @@ fn struct_borrow_survives_gc() {
 
     let arena = ExecutableArena::new();
 
+    let mut descriptors = ObjectDescriptorTable::new();
+    let desc_entry_struct = descriptors.push(ObjectDescriptor::new_struct(16, vec![]).unwrap());
+
     #[rustfmt::skip]
     let code = arena.alloc_slice_fill_iter([
-        HeapNew { dst: FO(entry), descriptor_id: DescriptorId(0) },
+        HeapNew { dst: FO(entry), descriptor_id: desc_entry_struct },
         StoreImm8 { dst: FO(result), imm: 100 },
         MicroOp::struct_store8(FO(entry), 0, FO(result)),
         StoreImm8 { dst: FO(result), imm: 200 },
@@ -382,10 +386,7 @@ fn struct_borrow_survives_gc() {
         frame_layout: FrameLayoutInfo::new(&arena, [FO(entry), FO(ref_base), FO(entry_ref)]),
         safe_point_layouts: SortedSafePointEntries::empty(),
     })];
-    let descriptors = [ObjectDescriptor::Struct {
-        size: 16,
-        pointer_offsets: vec![],
-    }];
+
     let mut exec_ctx = LocalExecutionContext::with_max_budget();
     let mut ctx = InterpreterContext::new(&mut exec_ctx, &descriptors, unsafe {
         functions[0].as_ref_unchecked()

--- a/third_party/move/mono-move/runtime/tests/vec_sum.rs
+++ b/third_party/move/mono-move/runtime/tests/vec_sum.rs
@@ -3,10 +3,10 @@
 
 use mono_move_alloc::{ExecutableArena, ExecutableArenaPtr, GlobalArenaPtr};
 use mono_move_core::{
-    CodeOffset as CO, DescriptorId, FrameLayoutInfo, FrameOffset as FO, Function,
-    LocalExecutionContext, MicroOp, SortedSafePointEntries,
+    CodeOffset as CO, FrameLayoutInfo, FrameOffset as FO, Function, LocalExecutionContext, MicroOp,
+    SortedSafePointEntries,
 };
-use mono_move_runtime::{InterpreterContext, ObjectDescriptor};
+use mono_move_runtime::{InterpreterContext, ObjectDescriptor, ObjectDescriptorTable};
 
 /// Data segment (48 bytes):
 ///   [fp + 0 ] : result (output) / scratch
@@ -17,7 +17,7 @@ use mono_move_runtime::{InterpreterContext, ObjectDescriptor};
 fn make_vec_sum_program(
     arena: &ExecutableArena,
     n: u64,
-) -> (Vec<ExecutableArenaPtr<Function>>, Vec<ObjectDescriptor>) {
+) -> (Vec<ExecutableArenaPtr<Function>>, ObjectDescriptorTable) {
     use MicroOp::*;
 
     let slot_result: u32 = 0;
@@ -26,13 +26,16 @@ fn make_vec_sum_program(
     let slot_tmp: u32 = 24;
     let slot_vec_ref: u32 = 32;
 
+    let mut descriptors = ObjectDescriptorTable::new();
+    let desc_vec_u64 = descriptors.push(ObjectDescriptor::new_vector(8, vec![]).unwrap());
+
     #[rustfmt::skip]
     let code = arena.alloc_slice_fill_iter([
         VecNew { dst: FO(slot_vec) },
         SlotBorrow { dst: FO(slot_vec_ref), local: FO(slot_vec) },
         StoreImm8 { dst: FO(slot_i), imm: 0 },
         JumpGreaterEqualU64Imm { target: CO(9), src: FO(slot_i), imm: n },
-        VecPushBack { vec_ref: FO(slot_vec_ref), elem: FO(slot_i), elem_size: 8, descriptor_id: DescriptorId(0) },
+        VecPushBack { vec_ref: FO(slot_vec_ref), elem: FO(slot_i), elem_size: 8, descriptor_id: desc_vec_u64 },
         StoreImm8 { dst: FO(slot_tmp), imm: 1 },
         AddU64 { dst: FO(slot_i), lhs: FO(slot_i), rhs: FO(slot_tmp) },
         JumpGreaterEqualU64Imm { target: CO(9), src: FO(slot_i), imm: n },
@@ -59,7 +62,6 @@ fn make_vec_sum_program(
         safe_point_layouts: SortedSafePointEntries::empty(),
     });
 
-    let descriptors = vec![ObjectDescriptor::Trivial];
     (vec![func], descriptors)
 }
 

--- a/third_party/move/mono-move/runtime/tests/verifier_test.rs
+++ b/third_party/move/mono-move/runtime/tests/verifier_test.rs
@@ -1,17 +1,19 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-//! Tests for the static verifier (`verify_function`).
+//! Tests for the static verifier (`verify_function`, `verify_descriptors`).
 
 use mono_move_alloc::{ExecutableArena, ExecutableArenaPtr, GlobalArenaPtr};
 use mono_move_core::{
     CodeOffset as CO, DescriptorId, FrameLayoutInfo, FrameOffset as FO, Function, MicroOp,
     SortedSafePointEntries,
 };
-use mono_move_runtime::{verify_function, ObjectDescriptor};
+use mono_move_runtime::{verify_function, ObjectDescriptor, ObjectDescriptorTable};
 
-fn trivial_descriptors() -> Vec<ObjectDescriptor> {
-    vec![ObjectDescriptor::Trivial]
+fn trivial_descriptors() -> ObjectDescriptorTable {
+    let mut t = ObjectDescriptorTable::new();
+    t.push(ObjectDescriptor::new_vector(8, vec![]).unwrap());
+    t
 }
 
 /// A minimal well-formed function: one `Return`, param_and_local_sizes_sum 8.
@@ -90,7 +92,7 @@ fn valid_with_vec_and_pointer_slots() {
         VecNew { dst: FO(0) },
         SlotBorrow { dst: FO(16), local: FO(0) },
         StoreImm8 { dst: FO(8), imm: 42 },
-        VecPushBack { vec_ref: FO(16), elem: FO(8), elem_size: 8, descriptor_id: DescriptorId(0) },
+        VecPushBack { vec_ref: FO(16), elem: FO(8), elem_size: 8, descriptor_id: DescriptorId(2) },
         Return,
     ]);
     // SAFETY: Arena is alive for the duration of the test.
@@ -630,4 +632,85 @@ fn multiple_errors_collected() {
         "expected at least 2 errors, got {}",
         errors.len()
     );
+}
+
+// ---------------------------------------------------------------------------
+// Op/variant tightening
+//
+// Descriptor table self-soundness (reserved indices, nonzero sizes,
+// in-bounds pointer offsets, etc.) is now enforced structurally by
+// `ObjectDescriptorTable`; see its unit tests in `runtime/src/types.rs`.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn vec_pushback_must_target_vector_descriptor() {
+    use MicroOp::*;
+    let arena = ExecutableArena::new();
+    // SAFETY: arena outlives the test.
+    let func = unsafe {
+        arena
+            .alloc(Function {
+                name: GlobalArenaPtr::from_static("test"),
+                code: arena.alloc_slice_fill_iter([
+                    VecNew { dst: FO(0) },
+                    SlotBorrow {
+                        dst: FO(16),
+                        local: FO(0),
+                    },
+                    StoreImm8 { dst: FO(8), imm: 1 },
+                    VecPushBack {
+                        vec_ref: FO(16),
+                        elem: FO(8),
+                        elem_size: 8,
+                        descriptor_id: DescriptorId(0), // Trivial — wrong variant
+                    },
+                    Return,
+                ]),
+                param_sizes: ExecutableArenaPtr::empty_slice(),
+                param_sizes_sum: 0,
+                param_and_local_sizes_sum: 32,
+                extended_frame_size: 56,
+                zero_frame: true,
+                frame_layout: FrameLayoutInfo::new(&arena, [FO(0)]),
+                safe_point_layouts: SortedSafePointEntries::empty(),
+            })
+            .as_ref_unchecked()
+    };
+    let errors = verify_function(func, &trivial_descriptors());
+    assert!(errors
+        .iter()
+        .any(|e| e.message.contains("VecPushBack") && e.message.contains("not a Vector")));
+}
+
+#[test]
+fn heap_new_rejects_vector_descriptor() {
+    use MicroOp::*;
+    let arena = ExecutableArena::new();
+    // trivial_descriptors() has Vector at index 2.
+    // SAFETY: arena outlives the test.
+    let func = unsafe {
+        arena
+            .alloc(Function {
+                name: GlobalArenaPtr::from_static("test"),
+                code: arena.alloc_slice_fill_iter([
+                    HeapNew {
+                        dst: FO(0),
+                        descriptor_id: DescriptorId(2),
+                    },
+                    Return,
+                ]),
+                param_sizes: ExecutableArenaPtr::empty_slice(),
+                param_sizes_sum: 0,
+                param_and_local_sizes_sum: 8,
+                extended_frame_size: 32,
+                zero_frame: true,
+                frame_layout: FrameLayoutInfo::new(&arena, [FO(0)]),
+                safe_point_layouts: SortedSafePointEntries::empty(),
+            })
+            .as_ref_unchecked()
+    };
+    let errors = verify_function(func, &trivial_descriptors());
+    assert!(errors
+        .iter()
+        .any(|e| e.message.contains("not a Struct or Enum")));
 }


### PR DESCRIPTION
## Summary

Refactors the mono-move runtime's object descriptor system around two encapsulating types so descriptors are sound by construction and the table's reserved entries are managed centrally.

- **Reserved descriptor indices.** `DescriptorId(0) = Trivial`, `DescriptorId(1) = Closure`. The `PackClosure` micro-op no longer carries a closure descriptor id; `captured_data_descriptor_id` is now `Option<DescriptorId>` (`Some` iff the closure captures any value).
- **`ObjectDescriptorTable` newtype.** Construction goes `ObjectDescriptorTable::new()` (auto-populates the reserved entries) + `push(desc) -> DescriptorId`. Callers must capture the returned id; the underlying storage index is no longer part of the public API. `Deref<Target = [ObjectDescriptor]>` keeps every existing slice-based caller working.
- **`ObjectDescriptor` is opaque.** The variants are wrapped in a crate-private inner enum (`ObjectDescriptorInner`). External code constructs descriptors only via the validating factories `ObjectDescriptor::new_vector` / `new_struct` / `new_enum` / `new_captured_data`, which panic on malformed input (zero size, out-of-bounds / misaligned / unsorted pointer offsets, `Enum` size < 8). `Trivial` and `Closure` are not externally constructable.
- **Verifier simplification.** With construction-time validation in place, the descriptor self-soundness pass is redundant: `verify_descriptors` is removed entirely, and `verify_program` collapses to a `verify_function` loop. Op↔descriptor variant cross-checks (`HeapNew → Struct|Enum`, `VecPushBack → Vector`, `PackClosure.captured_data → CapturedData`) stay in `verify_function`.
- **Verifier tightening.** `VecPushBack.descriptor_id` must be a `Vector` variant (was bounds-checked only). Combined with the existing `HeapNew → Struct|Enum` rule, `Closure` and `CapturedData` are now structurally unreachable from any non-closure op.
- **Test/program migration.** Every descriptor table in `runtime/tests/` and `programs/src/` switches to the new construction path. Magic `DescriptorId(N)` literals are replaced with bindings returned from `push`. Bindings carry a `desc_` prefix for visual consistency. Several latent bugs surfaced where `Trivial` was being used as a vector descriptor stand-in — those tables now carry proper `Vector` descriptors.

## Commits

1. `78248d950e` — reserve descriptor indices, add the (now-deleted) self-soundness pass and op-variant tightening.
2. `06ac52a2d8` — introduce `ObjectDescriptorTable`, drop `verify_descriptors`.
3. `024a1492ef` — encapsulate `ObjectDescriptor`; require ids via `push` (drop `from_user_descriptors`).
4. `4616eb4c5a` — prefix descriptor-id bindings with `desc_`.

## Test plan

- [x] \`cargo test -p mono-move-runtime\` — all suites pass (incl. 21 new \`ObjectDescriptorTable\` unit tests).
- [x] \`cargo test -p mono-move-programs\` — fib / match_sum / merge_sort / nested_loop / bst all pass after migration.
- [x] \`cargo +nightly fmt --check -p mono-move-runtime -p mono-move-core -p mono-move-programs\` — clean.
- [x] \`cargo check -p mono-move-core -p specializer -p mono-move-orchestrator -p mono-move-loader -p mono-move-testsuite\` — clean.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches GC tracing, closure allocation, and bytecode verification by changing how descriptor IDs are constructed and validated, so mistakes could surface as runtime memory/GC errors despite being largely a refactor with added checks.
> 
> **Overview**
> Refactors the runtime’s GC descriptor plumbing to use a new `ObjectDescriptorTable` with **reserved IDs** (`Trivial` at `0`, `Closure` at `1`) and an opaque, constructor-validated `ObjectDescriptor`, replacing ad-hoc `Vec<ObjectDescriptor>` tables and magic `DescriptorId(N)` literals across programs and tests.
> 
> Updates closure packing to make the closure descriptor **implicit** and to allocate captured-data only when needed (`PackClosureOp.captured_data_descriptor_id: Option<DescriptorId>`), with corresponding interpreter and verifier changes plus improved debug formatting.
> 
> Tightens verification by checking op↔descriptor variant consistency (notably `VecPushBack` must reference a `Vector` descriptor), adds `verify_program`, and migrates/adjusts benchmarks and runtime tests to build and thread descriptor IDs via `ObjectDescriptorTable::push` (fixing prior cases that used `Trivial` as a stand-in for vector descriptors).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d40429897a9e70da26c5ec3e0596cf8a0ddf34d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->