### PR TITLE
[mono-move] flesh out u64 arithmetic / bitwise / shift micro-ops

### DIFF
--- a/third_party/move/mono-move/core/src/instruction/gas.rs
+++ b/third_party/move/mono-move/core/src/instruction/gas.rs
@@ -41,11 +41,22 @@ impl HasCfgInfo for MicroOp {
             | MicroOp::Move { .. }
             | MicroOp::AddU64 { .. }
             | MicroOp::AddU64Imm { .. }
+            | MicroOp::SubU64 { .. }
             | MicroOp::SubU64Imm { .. }
             | MicroOp::RSubU64Imm { .. }
-            | MicroOp::XorU64 { .. }
-            | MicroOp::ShrU64Imm { .. }
+            | MicroOp::MulU64 { .. }
+            | MicroOp::MulU64Imm { .. }
+            | MicroOp::DivU64 { .. }
+            | MicroOp::DivU64Imm { .. }
             | MicroOp::ModU64 { .. }
+            | MicroOp::ModU64Imm { .. }
+            | MicroOp::BitAndU64 { .. }
+            | MicroOp::BitOrU64 { .. }
+            | MicroOp::BitXorU64 { .. }
+            | MicroOp::ShlU64 { .. }
+            | MicroOp::ShlU64Imm { .. }
+            | MicroOp::ShrU64 { .. }
+            | MicroOp::ShrU64Imm { .. }
             | MicroOp::Return
             | MicroOp::CallFunc { .. }
             | MicroOp::CallIndirect { .. }
@@ -131,11 +142,22 @@ impl RemapTargets for MicroOp {
             | MicroOp::Move { .. }
             | MicroOp::AddU64 { .. }
             | MicroOp::AddU64Imm { .. }
+            | MicroOp::SubU64 { .. }
             | MicroOp::SubU64Imm { .. }
             | MicroOp::RSubU64Imm { .. }
-            | MicroOp::XorU64 { .. }
-            | MicroOp::ShrU64Imm { .. }
+            | MicroOp::MulU64 { .. }
+            | MicroOp::MulU64Imm { .. }
+            | MicroOp::DivU64 { .. }
+            | MicroOp::DivU64Imm { .. }
             | MicroOp::ModU64 { .. }
+            | MicroOp::ModU64Imm { .. }
+            | MicroOp::BitAndU64 { .. }
+            | MicroOp::BitOrU64 { .. }
+            | MicroOp::BitXorU64 { .. }
+            | MicroOp::ShlU64 { .. }
+            | MicroOp::ShlU64Imm { .. }
+            | MicroOp::ShrU64 { .. }
+            | MicroOp::ShrU64Imm { .. }
             | MicroOp::Return
             | MicroOp::CallFunc { .. }
             | MicroOp::CallIndirect { .. }
@@ -186,11 +208,21 @@ impl GasSchedule<MicroOp> for MicroOpGasSchedule {
             // --- Arithmetic ---
             MicroOp::AddU64 { .. }
             | MicroOp::AddU64Imm { .. }
+            | MicroOp::SubU64 { .. }
             | MicroOp::SubU64Imm { .. }
             | MicroOp::RSubU64Imm { .. }
-            | MicroOp::XorU64 { .. }
+            | MicroOp::BitAndU64 { .. }
+            | MicroOp::BitOrU64 { .. }
+            | MicroOp::BitXorU64 { .. }
+            | MicroOp::ShlU64 { .. }
+            | MicroOp::ShlU64Imm { .. }
+            | MicroOp::ShrU64 { .. }
             | MicroOp::ShrU64Imm { .. } => 3,
-            MicroOp::ModU64 { .. } => 5,
+            MicroOp::MulU64 { .. } | MicroOp::MulU64Imm { .. } => 4,
+            MicroOp::DivU64 { .. }
+            | MicroOp::DivU64Imm { .. }
+            | MicroOp::ModU64 { .. }
+            | MicroOp::ModU64Imm { .. } => 5,
 
             // --- Control flow ---
             MicroOp::CallFunc { .. }

--- a/third_party/move/mono-move/core/src/instruction/mod.rs
+++ b/third_party/move/mono-move/core/src/instruction/mod.rs
@@ -265,13 +265,21 @@ pub enum MicroOp {
     // Arithmetic & bitwise
     //======================================================================
     // Currently u64-only. Each op has a reg-reg form and/or an immediate
-    // form; we add variants as the compiler needs them.
+    // form; we add variants as the compiler needs them. All arithmetic is
+    // checked: overflow / underflow / division by zero / oversize shift
+    // all abort.
+    //
+    // Bitwise ops carry the `Bit` prefix to disambiguate from the boolean
+    // logical Or/And/Not (which will not have it).
     //
     // May want:
-    // - Mul, Div, Sub (reg-reg), Negate, bitwise And/Or/Xor/Not, Shl,
+    // - Logical Or/And/Not (Phase 3), Negate (signed), bitwise Not,
+    // - Reverse-imm forms: RDiv, RMod, RShl, RShr (mirroring RSubU64Imm),
     // - u8, u16, u32 variants (mask on u64?), u128/u256 (multi-word),
     // - signed integer support.
     //======================================================================
+
+    // --- Add ---
     /// `dst = lhs + rhs` (u64, checked).
     AddU64 {
         dst: FrameOffset,
@@ -284,6 +292,14 @@ pub enum MicroOp {
         dst: FrameOffset,
         src: FrameOffset,
         imm: u64,
+    },
+
+    // --- Sub ---
+    /// `dst = lhs - rhs` (u64, checked).
+    SubU64 {
+        dst: FrameOffset,
+        lhs: FrameOffset,
+        rhs: FrameOffset,
     },
 
     /// `dst = src - imm` (u64, checked).
@@ -300,25 +316,107 @@ pub enum MicroOp {
         imm: u64,
     },
 
-    /// `dst = lhs ^ rhs` (u64, bitwise XOR).
-    XorU64 {
+    // --- Mul ---
+    /// `dst = lhs * rhs` (u64, checked).
+    MulU64 {
         dst: FrameOffset,
         lhs: FrameOffset,
         rhs: FrameOffset,
     },
 
-    /// `dst = src >> imm` (u64, logical right shift).
-    ShrU64Imm {
+    /// `dst = src * imm` (u64, checked).
+    MulU64Imm {
         dst: FrameOffset,
         src: FrameOffset,
         imm: u64,
     },
 
-    /// `dst = lhs % rhs` (u64 modulo). Panics on division by zero.
+    // --- Div ---
+    /// `dst = lhs / rhs` (u64). Aborts on division by zero.
+    DivU64 {
+        dst: FrameOffset,
+        lhs: FrameOffset,
+        rhs: FrameOffset,
+    },
+
+    /// `dst = src / imm` (u64). Aborts if `imm == 0`.
+    DivU64Imm {
+        dst: FrameOffset,
+        src: FrameOffset,
+        imm: u64,
+    },
+
+    // --- Mod ---
+    /// `dst = lhs % rhs` (u64). Aborts on division by zero.
     ModU64 {
         dst: FrameOffset,
         lhs: FrameOffset,
         rhs: FrameOffset,
+    },
+
+    /// `dst = src % imm` (u64). Aborts if `imm == 0`.
+    ModU64Imm {
+        dst: FrameOffset,
+        src: FrameOffset,
+        imm: u64,
+    },
+
+    // --- Bitwise ---
+    /// `dst = lhs & rhs` (u64, bitwise AND).
+    BitAndU64 {
+        dst: FrameOffset,
+        lhs: FrameOffset,
+        rhs: FrameOffset,
+    },
+
+    /// `dst = lhs | rhs` (u64, bitwise OR).
+    BitOrU64 {
+        dst: FrameOffset,
+        lhs: FrameOffset,
+        rhs: FrameOffset,
+    },
+
+    /// `dst = lhs ^ rhs` (u64, bitwise XOR).
+    BitXorU64 {
+        dst: FrameOffset,
+        lhs: FrameOffset,
+        rhs: FrameOffset,
+    },
+
+    // --- Shifts ---
+    //
+    // TODO: in old Move bytecode the shift amount is a u8, not a u64. We
+    // currently model `rhs` as a full 8-byte slot to match the rest of
+    // the slot ABI; the value living there is zero-extended from a u8 by
+    // the lowerer. Reconsider whether `rhs` (and the imm field of the
+    // imm-form ops) should be narrower once the slot-alignment story is
+    // sorted out — affects destack, lowering, and slot allocation.
+    /// `dst = lhs << rhs` (u64). Aborts if `rhs >= 64`.
+    ShlU64 {
+        dst: FrameOffset,
+        lhs: FrameOffset,
+        rhs: FrameOffset,
+    },
+
+    /// `dst = src << imm` (u64). Aborts if `imm >= 64`.
+    ShlU64Imm {
+        dst: FrameOffset,
+        src: FrameOffset,
+        imm: u64,
+    },
+
+    /// `dst = lhs >> rhs` (u64, logical right shift). Aborts if `rhs >= 64`.
+    ShrU64 {
+        dst: FrameOffset,
+        lhs: FrameOffset,
+        rhs: FrameOffset,
+    },
+
+    /// `dst = src >> imm` (u64, logical right shift). Aborts if `imm >= 64`.
+    ShrU64Imm {
+        dst: FrameOffset,
+        src: FrameOffset,
+        imm: u64,
     },
 
     //======================================================================
@@ -702,17 +800,53 @@ impl fmt::Display for MicroOp {
             MicroOp::AddU64Imm { dst, src, imm } => {
                 write!(f, "AddU64Imm [{}] <- [{}] + #{}", dst.0, src.0, imm)
             },
+            MicroOp::SubU64 { dst, lhs, rhs } => {
+                write!(f, "SubU64 [{}] <- [{}] - [{}]", dst.0, lhs.0, rhs.0)
+            },
             MicroOp::SubU64Imm { dst, src, imm } => {
                 write!(f, "SubU64Imm [{}] <- [{}] - #{}", dst.0, src.0, imm)
             },
             MicroOp::RSubU64Imm { dst, src, imm } => {
                 write!(f, "RSubU64Imm [{}] <- #{} - [{}]", dst.0, imm, src.0)
             },
-            MicroOp::ShrU64Imm { dst, src, imm } => {
-                write!(f, "ShrU64Imm [{}] <- [{}] >> #{}", dst.0, src.0, imm)
+            MicroOp::MulU64 { dst, lhs, rhs } => {
+                write!(f, "MulU64 [{}] <- [{}] * [{}]", dst.0, lhs.0, rhs.0)
+            },
+            MicroOp::MulU64Imm { dst, src, imm } => {
+                write!(f, "MulU64Imm [{}] <- [{}] * #{}", dst.0, src.0, imm)
+            },
+            MicroOp::DivU64 { dst, lhs, rhs } => {
+                write!(f, "DivU64 [{}] <- [{}] / [{}]", dst.0, lhs.0, rhs.0)
+            },
+            MicroOp::DivU64Imm { dst, src, imm } => {
+                write!(f, "DivU64Imm [{}] <- [{}] / #{}", dst.0, src.0, imm)
             },
             MicroOp::ModU64 { dst, lhs, rhs } => {
                 write!(f, "ModU64 [{}] <- [{}] % [{}]", dst.0, lhs.0, rhs.0)
+            },
+            MicroOp::ModU64Imm { dst, src, imm } => {
+                write!(f, "ModU64Imm [{}] <- [{}] % #{}", dst.0, src.0, imm)
+            },
+            MicroOp::BitAndU64 { dst, lhs, rhs } => {
+                write!(f, "BitAndU64 [{}] <- [{}] & [{}]", dst.0, lhs.0, rhs.0)
+            },
+            MicroOp::BitOrU64 { dst, lhs, rhs } => {
+                write!(f, "BitOrU64 [{}] <- [{}] | [{}]", dst.0, lhs.0, rhs.0)
+            },
+            MicroOp::BitXorU64 { dst, lhs, rhs } => {
+                write!(f, "BitXorU64 [{}] <- [{}] ^ [{}]", dst.0, lhs.0, rhs.0)
+            },
+            MicroOp::ShlU64 { dst, lhs, rhs } => {
+                write!(f, "ShlU64 [{}] <- [{}] << [{}]", dst.0, lhs.0, rhs.0)
+            },
+            MicroOp::ShlU64Imm { dst, src, imm } => {
+                write!(f, "ShlU64Imm [{}] <- [{}] << #{}", dst.0, src.0, imm)
+            },
+            MicroOp::ShrU64 { dst, lhs, rhs } => {
+                write!(f, "ShrU64 [{}] <- [{}] >> [{}]", dst.0, lhs.0, rhs.0)
+            },
+            MicroOp::ShrU64Imm { dst, src, imm } => {
+                write!(f, "ShrU64Imm [{}] <- [{}] >> #{}", dst.0, src.0, imm)
             },
             MicroOp::CallFunc { func_id } => {
                 write!(f, "CallFunc #{}", func_id)
@@ -891,9 +1025,6 @@ impl fmt::Display for MicroOp {
             },
             MicroOp::StoreRandomU64 { dst } => {
                 write!(f, "StoreRandomU64 [{}]", dst.0)
-            },
-            MicroOp::XorU64 { dst, lhs, rhs } => {
-                write!(f, "XorU64 [{}] <- [{}] ^ [{}]", dst.0, lhs.0, rhs.0)
             },
             MicroOp::JumpLessU64Imm { target, src, imm } => {
                 write!(f, "JumpLessU64Imm @{} [{}] < #{}", target.0, src.0, imm)

--- a/third_party/move/mono-move/programs/src/nested_loop.rs
+++ b/third_party/move/mono-move/programs/src/nested_loop.rs
@@ -93,7 +93,7 @@ mod micro_op {
             JumpLessU64 { target: CO(7), lhs: FO(j), rhs: FO(n) }, // 5
             Jump { target: CO(11) },                                // 6: goto INNER_END
             // INNER_BODY: sum += i ^ j; j += 1
-            XorU64 { dst: FO(tmp), lhs: FO(i), rhs: FO(j) },      // 7
+            BitXorU64 { dst: FO(tmp), lhs: FO(i), rhs: FO(j) },   // 7
             AddU64 { dst: FO(sum), lhs: FO(sum), rhs: FO(tmp) },   // 8
             AddU64Imm { dst: FO(j), src: FO(j), imm: 1 },          // 9
             Jump { target: CO(5) },                                 // 10: goto INNER_LOOP

--- a/third_party/move/mono-move/runtime/src/interpreter.rs
+++ b/third_party/move/mono-move/runtime/src/interpreter.rs
@@ -20,7 +20,7 @@ use crate::{
     },
 };
 use mono_move_core::{
-    CallClosureOp, ClosureFuncRef, DescriptorId, ExecutionContext, Function, MicroOp,
+    CallClosureOp, ClosureFuncRef, DescriptorId, ExecutionContext, FrameOffset, Function, MicroOp,
     PackClosureOp, SizedSlot, CAPTURED_DATA_TAG_MATERIALIZED, CAPTURED_DATA_TAG_OFFSET,
     CAPTURED_DATA_VALUES_OFFSET, CLOSURE_CAPTURED_DATA_PTR_OFFSET, CLOSURE_FUNC_REF_OFFSET,
     CLOSURE_MASK_OFFSET, FRAME_METADATA_SIZE, FUNC_REF_PAYLOAD_OFFSET, FUNC_REF_TAG_OFFSET,
@@ -193,6 +193,131 @@ impl<'a, T: ExecutionContext> InterpreterContext<'a, T> {
 }
 
 // ---------------------------------------------------------------------------
+// Arithmetic helpers
+// ---------------------------------------------------------------------------
+//
+// All arithmetic micro-ops follow one of a few shapes — read 1 or 2 u64
+// frame slots, apply a (possibly fallible) computation, write the result
+// to a destination slot. The helpers below capture each shape so the
+// `step()` arms stay one line each and the read/write boilerplate lives
+// in one place.
+//
+// `#[inline(always)]` ensures the closures and the helper itself are
+// folded into the caller in release builds. Inlining verified by
+// inspecting the release-build x64 asm for `step::<SimpleGasMeter>` on
+// 2026-04-30: zero standalone definitions for any helper or closure,
+// zero call/jmp instructions targeting them, and individual arms
+// compile to a handful of direct memory ops (e.g. AddU64 is 4 movs +
+// addq + jae + jmp).
+//
+// TODO: re-verify inlining after non-trivial changes to the helpers,
+// the call sites, or the rustc/LLVM versions the workspace pins to.
+
+/// `dst <- op(lhs_slot, rhs_slot)` (infallible).
+#[inline(always)]
+unsafe fn binop_u64<F: FnOnce(u64, u64) -> u64>(
+    fp: *mut u8,
+    dst: FrameOffset,
+    lhs: FrameOffset,
+    rhs: FrameOffset,
+    op: F,
+) {
+    // SAFETY: `fp` is the current frame pointer and `lhs`/`rhs`/`dst` are
+    // in-bounds 8-byte slots within that frame (enforced by the verifier).
+    unsafe {
+        let a = read_u64(fp, lhs);
+        let b = read_u64(fp, rhs);
+        write_u64(fp, dst, op(a, b));
+    }
+}
+
+/// `dst <- op(lhs_slot, rhs_slot)`. Bail with `err` on `None`.
+#[inline(always)]
+unsafe fn checked_binop_u64<F: FnOnce(u64, u64) -> Option<u64>>(
+    fp: *mut u8,
+    dst: FrameOffset,
+    lhs: FrameOffset,
+    rhs: FrameOffset,
+    op: F,
+    err: &'static str,
+) -> ExecutionResult<()> {
+    // SAFETY: `fp` is the current frame pointer and `lhs`/`rhs`/`dst` are
+    // in-bounds 8-byte slots within that frame (enforced by the verifier).
+    unsafe {
+        let a = read_u64(fp, lhs);
+        let b = read_u64(fp, rhs);
+        match op(a, b) {
+            Some(v) => write_u64(fp, dst, v),
+            None => bail!(err),
+        }
+        Ok(())
+    }
+}
+
+/// `dst <- op(src_slot, imm)` (infallible).
+#[inline(always)]
+unsafe fn imm_op_u64<F: FnOnce(u64, u64) -> u64>(
+    fp: *mut u8,
+    dst: FrameOffset,
+    src: FrameOffset,
+    imm: u64,
+    op: F,
+) {
+    // SAFETY: `fp` is the current frame pointer and `src`/`dst` are
+    // in-bounds 8-byte slots within that frame (enforced by the verifier).
+    unsafe {
+        let a = read_u64(fp, src);
+        write_u64(fp, dst, op(a, imm));
+    }
+}
+
+/// `dst <- op(src_slot, imm)`. Bail with `err` on `None`.
+#[inline(always)]
+unsafe fn checked_imm_op_u64<F: FnOnce(u64, u64) -> Option<u64>>(
+    fp: *mut u8,
+    dst: FrameOffset,
+    src: FrameOffset,
+    imm: u64,
+    op: F,
+    err: &'static str,
+) -> ExecutionResult<()> {
+    // SAFETY: `fp` is the current frame pointer and `src`/`dst` are
+    // in-bounds 8-byte slots within that frame (enforced by the verifier).
+    unsafe {
+        let a = read_u64(fp, src);
+        match op(a, imm) {
+            Some(v) => write_u64(fp, dst, v),
+            None => bail!(err),
+        }
+        Ok(())
+    }
+}
+
+/// `dst <- op(lhs_slot, rhs_slot_as_shift)`. Bail if shift `>= 64`.
+/// `op_name` is used to format the error message.
+#[inline(always)]
+unsafe fn shift_u64<F: FnOnce(u64, u64) -> u64>(
+    fp: *mut u8,
+    dst: FrameOffset,
+    lhs: FrameOffset,
+    rhs: FrameOffset,
+    op: F,
+    op_name: &'static str,
+) -> ExecutionResult<()> {
+    // SAFETY: `fp` is the current frame pointer and `lhs`/`rhs`/`dst` are
+    // in-bounds 8-byte slots within that frame (enforced by the verifier).
+    unsafe {
+        let shift = read_u64(fp, rhs);
+        if shift >= 64 {
+            bail!("{}: shift amount {} exceeds 63", op_name, shift);
+        }
+        let v = read_u64(fp, lhs);
+        write_u64(fp, dst, op(v, shift));
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Interpreter loop
 // ---------------------------------------------------------------------------
 
@@ -339,68 +464,104 @@ impl<T: ExecutionContext> InterpreterContext<'_, T> {
                 },
 
                 // ----- Arithmetic -----
-                MicroOp::StoreImm8 { dst, imm } => {
-                    write_u64(fp, dst, imm);
-                },
+                MicroOp::StoreImm8 { dst, imm } => write_u64(fp, dst, imm),
 
-                MicroOp::SubU64Imm { dst, src, imm } => {
-                    let v = read_u64(fp, src);
-                    let result = match v.checked_sub(imm) {
-                        Some(v) => v,
-                        None => bail!("arithmetic underflow"),
-                    };
-                    write_u64(fp, dst, result);
-                },
-
+                // Add
                 MicroOp::AddU64 { dst, lhs, rhs } => {
-                    let v1 = read_u64(fp, lhs);
-                    let v2 = read_u64(fp, rhs);
-                    let result = match v1.checked_add(v2) {
-                        Some(v) => v,
-                        None => bail!("arithmetic overflow"),
-                    };
-                    write_u64(fp, dst, result);
+                    checked_binop_u64(fp, dst, lhs, rhs, u64::checked_add, "AddU64: overflow")?
                 },
-
                 MicroOp::AddU64Imm { dst, src, imm } => {
-                    let v = read_u64(fp, src);
-                    let result = match v.checked_add(imm) {
-                        Some(v) => v,
-                        None => bail!("arithmetic overflow"),
-                    };
-                    write_u64(fp, dst, result);
+                    checked_imm_op_u64(fp, dst, src, imm, u64::checked_add, "AddU64Imm: overflow")?
                 },
 
-                MicroOp::RSubU64Imm { dst, src, imm } => {
-                    let v = read_u64(fp, src);
-                    let result = match imm.checked_sub(v) {
-                        Some(v) => v,
-                        None => bail!("arithmetic underflow"),
-                    };
-                    write_u64(fp, dst, result);
+                // Sub
+                MicroOp::SubU64 { dst, lhs, rhs } => {
+                    checked_binop_u64(fp, dst, lhs, rhs, u64::checked_sub, "SubU64: underflow")?
+                },
+                MicroOp::SubU64Imm { dst, src, imm } => {
+                    checked_imm_op_u64(fp, dst, src, imm, u64::checked_sub, "SubU64Imm: underflow")?
+                },
+                // dst = imm - src, so flip the operand order.
+                MicroOp::RSubU64Imm { dst, src, imm } => checked_imm_op_u64(
+                    fp,
+                    dst,
+                    src,
+                    imm,
+                    |s, i| u64::checked_sub(i, s),
+                    "RSubU64Imm: underflow",
+                )?,
+
+                // Mul
+                MicroOp::MulU64 { dst, lhs, rhs } => {
+                    checked_binop_u64(fp, dst, lhs, rhs, u64::checked_mul, "MulU64: overflow")?
+                },
+                MicroOp::MulU64Imm { dst, src, imm } => {
+                    checked_imm_op_u64(fp, dst, src, imm, u64::checked_mul, "MulU64Imm: overflow")?
                 },
 
-                MicroOp::XorU64 { dst, lhs, rhs } => {
-                    let lhs_val = read_u64(fp, lhs);
-                    let rhs_val = read_u64(fp, rhs);
-                    write_u64(fp, dst, lhs_val ^ rhs_val);
+                // Div / Mod
+                MicroOp::DivU64 { dst, lhs, rhs } => checked_binop_u64(
+                    fp,
+                    dst,
+                    lhs,
+                    rhs,
+                    u64::checked_div,
+                    "DivU64: division by zero",
+                )?,
+                // INVARIANT: the verifier rejects `imm == 0`, so plain `s / imm`
+                // cannot trigger Rust's div-by-zero panic. Asserted below in
+                // debug builds as a defensive check.
+                MicroOp::DivU64Imm { dst, src, imm } => {
+                    debug_assert!(
+                        imm != 0,
+                        "DivU64Imm: imm must be non-zero (verifier invariant)"
+                    );
+                    imm_op_u64(fp, dst, src, imm, |s, i| s / i)
+                },
+                MicroOp::ModU64 { dst, lhs, rhs } => checked_binop_u64(
+                    fp,
+                    dst,
+                    lhs,
+                    rhs,
+                    u64::checked_rem,
+                    "ModU64: division by zero",
+                )?,
+                // INVARIANT: the verifier rejects `imm == 0`, so plain `s % imm`
+                // cannot trigger Rust's div-by-zero panic. Asserted below in
+                // debug builds as a defensive check.
+                MicroOp::ModU64Imm { dst, src, imm } => {
+                    debug_assert!(
+                        imm != 0,
+                        "ModU64Imm: imm must be non-zero (verifier invariant)"
+                    );
+                    imm_op_u64(fp, dst, src, imm, |s, i| s % i)
                 },
 
+                // Bitwise (infallible)
+                MicroOp::BitAndU64 { dst, lhs, rhs } => binop_u64(fp, dst, lhs, rhs, |a, b| a & b),
+                MicroOp::BitOrU64 { dst, lhs, rhs } => binop_u64(fp, dst, lhs, rhs, |a, b| a | b),
+                MicroOp::BitXorU64 { dst, lhs, rhs } => binop_u64(fp, dst, lhs, rhs, |a, b| a ^ b),
+
+                // Shifts
+                MicroOp::ShlU64 { dst, lhs, rhs } => {
+                    shift_u64(fp, dst, lhs, rhs, |v, s| v << s, "ShlU64")?
+                },
+                // INVARIANT: the verifier rejects `imm >= 64`, so plain `s << imm`
+                // cannot wrap or trigger UB. Asserted below in debug builds as a
+                // defensive check.
+                MicroOp::ShlU64Imm { dst, src, imm } => {
+                    debug_assert!(imm < 64, "ShlU64Imm: imm must be < 64 (verifier invariant)");
+                    imm_op_u64(fp, dst, src, imm, |s, i| s << i)
+                },
+                MicroOp::ShrU64 { dst, lhs, rhs } => {
+                    shift_u64(fp, dst, lhs, rhs, |v, s| v >> s, "ShrU64")?
+                },
+                // INVARIANT: the verifier rejects `imm >= 64`, so plain `s >> imm`
+                // cannot wrap or trigger UB. Asserted below in debug builds as a
+                // defensive check.
                 MicroOp::ShrU64Imm { dst, src, imm } => {
-                    if imm > 63 {
-                        bail!("ShrU64Imm: shift amount {} exceeds 63", imm);
-                    }
-                    let v = read_u64(fp, src);
-                    write_u64(fp, dst, v >> imm);
-                },
-
-                MicroOp::ModU64 { dst, lhs, rhs } => {
-                    let lhs_val = read_u64(fp, lhs);
-                    let rhs_val = read_u64(fp, rhs);
-                    if rhs_val == 0 {
-                        bail!("ModU64: division by zero");
-                    }
-                    write_u64(fp, dst, lhs_val % rhs_val);
+                    debug_assert!(imm < 64, "ShrU64Imm: imm must be < 64 (verifier invariant)");
+                    imm_op_u64(fp, dst, src, imm, |s, i| s >> i)
                 },
 
                 MicroOp::StoreRandomU64 { dst } => {

--- a/third_party/move/mono-move/runtime/src/verifier.rs
+++ b/third_party/move/mono-move/runtime/src/verifier.rs
@@ -196,12 +196,43 @@ impl FunctionVerifier<'_> {
                 self.check_frame_access_8(pc, dst);
             },
 
-            MicroOp::SubU64Imm { dst, src, imm: _ }
+            MicroOp::AddU64Imm { dst, src, imm: _ }
+            | MicroOp::SubU64Imm { dst, src, imm: _ }
             | MicroOp::RSubU64Imm { dst, src, imm: _ }
-            | MicroOp::AddU64Imm { dst, src, imm: _ }
-            | MicroOp::ShrU64Imm { dst, src, imm: _ } => {
+            | MicroOp::MulU64Imm { dst, src, imm: _ } => {
                 self.check_frame_access_8(pc, src);
                 self.check_frame_access_8(pc, dst);
+            },
+
+            // Div / Mod imm: reject `imm == 0` statically — at runtime it
+            // would always abort, so this is dead-code-with-a-bomb.
+            //
+            // TODO: this changes the surface vs the old VM, which aborted
+            // at runtime with a `DIV_BY_ZERO` status code. The cleanest
+            // fix is probably for the specializer to detect `imm == 0` and
+            // emit an explicit `Abort(DIV_BY_ZERO)` instead of `*U64Imm`,
+            // so the verifier never sees the bad op. Open question: can
+            // the specializer report any error post-bytecode-verification,
+            // and if so should it fail the whole module or only the
+            // function (or only the basic block)? The branch containing
+            // `imm == 0` may not even be reachable at runtime. Revisit
+            // once the abort/error story is settled.
+            MicroOp::DivU64Imm { dst, src, imm } | MicroOp::ModU64Imm { dst, src, imm } => {
+                self.check_frame_access_8(pc, src);
+                self.check_frame_access_8(pc, dst);
+                if imm == 0 {
+                    self.err(Some(pc), "division by zero (imm)");
+                }
+            },
+
+            // Shift imm: reject `imm >= 64` statically — same reason as
+            // div by zero (the runtime would always abort).
+            MicroOp::ShlU64Imm { dst, src, imm } | MicroOp::ShrU64Imm { dst, src, imm } => {
+                self.check_frame_access_8(pc, src);
+                self.check_frame_access_8(pc, dst);
+                if imm >= 64 {
+                    self.err(Some(pc), format!("shift amount {} exceeds 63 (imm)", imm));
+                }
             },
 
             MicroOp::Move8 { dst, src } => {
@@ -210,8 +241,15 @@ impl FunctionVerifier<'_> {
             },
 
             MicroOp::AddU64 { dst, lhs, rhs }
-            | MicroOp::XorU64 { dst, lhs, rhs }
-            | MicroOp::ModU64 { dst, lhs, rhs } => {
+            | MicroOp::SubU64 { dst, lhs, rhs }
+            | MicroOp::MulU64 { dst, lhs, rhs }
+            | MicroOp::DivU64 { dst, lhs, rhs }
+            | MicroOp::ModU64 { dst, lhs, rhs }
+            | MicroOp::BitAndU64 { dst, lhs, rhs }
+            | MicroOp::BitOrU64 { dst, lhs, rhs }
+            | MicroOp::BitXorU64 { dst, lhs, rhs }
+            | MicroOp::ShlU64 { dst, lhs, rhs }
+            | MicroOp::ShrU64 { dst, lhs, rhs } => {
                 self.check_frame_access_8(pc, lhs);
                 self.check_frame_access_8(pc, rhs);
                 self.check_frame_access_8(pc, dst);

--- a/third_party/move/mono-move/runtime/tests/arithmetic_ops.rs
+++ b/third_party/move/mono-move/runtime/tests/arithmetic_ops.rs
@@ -1,0 +1,273 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! End-to-end tests for u64 arithmetic / bitwise / shift micro-ops.
+//!
+//! Each test builds a one-instruction "function" (op + Return), seeds the
+//! input slots via `set_root_arg`, runs to completion, and checks the
+//! result. Abort-path tests assert that `run()` returns an error.
+//!
+//! TODO: revisit which of these belong here vs. in the differential-test
+//! harness (`mono-move-testsuite/.../snapshot/masm/arithmetic.masm`),
+//! once we have a clearer story on running the same `.masm` programs
+//! against the old VM for cross-validation. Some of these are "micro-op
+//! unit tests" that don't need the specializer pipeline and probably
+//! belong here regardless; others (the happy-path arithmetic checks)
+//! could move. Check with @vineethk before migrating.
+
+use mono_move_alloc::{ExecutableArena, ExecutableArenaPtr, GlobalArenaPtr};
+use mono_move_core::{
+    FrameLayoutInfo, FrameOffset as FO, Function, LocalExecutionContext, MicroOp,
+    SortedSafePointEntries, FRAME_METADATA_SIZE,
+};
+use mono_move_runtime::{InterpreterContext, ObjectDescriptor};
+
+// ---------------------------------------------------------------------------
+// Frame layout used by every test in this file
+// ---------------------------------------------------------------------------
+//   [SLOT_DST] = result (output)
+//   [SLOT_LHS] = first input (lhs for binary ops; src for imm/unary ops)
+//   [SLOT_RHS] = second input (rhs for binary ops; unused for unary)
+
+const SLOT_DST: u32 = 0;
+const SLOT_LHS: u32 = 8;
+const SLOT_RHS: u32 = 16;
+/// Imm ops read their input from the same slot as a binary op's lhs.
+const SLOT_SRC: u32 = SLOT_LHS;
+const FRAME_SIZE: u32 = 24;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn make_func(arena: &ExecutableArena, op: MicroOp) -> ExecutableArenaPtr<Function> {
+    arena.alloc(Function {
+        name: GlobalArenaPtr::from_static("op"),
+        code: arena.alloc_slice_fill_iter([op, MicroOp::Return]),
+        param_sizes: ExecutableArenaPtr::empty_slice(),
+        param_sizes_sum: 0,
+        param_and_local_sizes_sum: FRAME_SIZE as usize,
+        extended_frame_size: FRAME_SIZE as usize + FRAME_METADATA_SIZE,
+        zero_frame: false,
+        frame_layout: FrameLayoutInfo::empty(),
+        safe_point_layouts: SortedSafePointEntries::empty(),
+    })
+}
+
+/// Run a reg-reg binary u64 op: writes `lhs` and `rhs` into the input
+/// slots, runs the op + Return, returns the value at `SLOT_DST` (or err).
+fn run_binary_u64_op(op: MicroOp, lhs: u64, rhs: u64) -> Result<u64, anyhow::Error> {
+    let arena = ExecutableArena::new();
+    let func = make_func(&arena, op);
+    let descriptors: Vec<ObjectDescriptor> = vec![];
+    let mut exec_ctx = LocalExecutionContext::with_max_budget();
+    let mut ctx = InterpreterContext::new(&mut exec_ctx, &descriptors, unsafe {
+        func.as_ref_unchecked()
+    });
+    ctx.set_root_arg(SLOT_LHS, &lhs.to_ne_bytes());
+    ctx.set_root_arg(SLOT_RHS, &rhs.to_ne_bytes());
+    ctx.run()?;
+    Ok(ctx.root_result())
+}
+
+/// Run an immediate-form u64 op (one runtime input + a baked-in imm):
+/// writes `src` into `SLOT_SRC`, runs the op + Return, returns the value
+/// at `SLOT_DST` (or err).
+fn run_unary_u64_op(op: MicroOp, src: u64) -> Result<u64, anyhow::Error> {
+    let arena = ExecutableArena::new();
+    let func = make_func(&arena, op);
+    let descriptors: Vec<ObjectDescriptor> = vec![];
+    let mut exec_ctx = LocalExecutionContext::with_max_budget();
+    let mut ctx = InterpreterContext::new(&mut exec_ctx, &descriptors, unsafe {
+        func.as_ref_unchecked()
+    });
+    ctx.set_root_arg(SLOT_SRC, &src.to_ne_bytes());
+    ctx.run()?;
+    Ok(ctx.root_result())
+}
+
+// ---------------------------------------------------------------------------
+// Macros
+// ---------------------------------------------------------------------------
+//
+// `binop!` / `imm_op!` build a `MicroOp` value with dst/lhs/rhs/src wired
+// to the shared frame slots. `binary_ok!`/`binary_err!` and `imm_ok!`/
+// `imm_err!` build the op, run it, and assert.
+//
+// Argument order is positional: variant first, then operands left-to-right
+// in the same order they appear in the op's struct fields.
+
+/// Build a reg-reg binary u64 op (dst/lhs/rhs ← shared frame slots).
+macro_rules! binop {
+    ($variant:ident) => {
+        MicroOp::$variant {
+            dst: FO(SLOT_DST),
+            lhs: FO(SLOT_LHS),
+            rhs: FO(SLOT_RHS),
+        }
+    };
+}
+
+/// Build an immediate-form u64 op (dst/src ← shared frame slots).
+macro_rules! imm_op {
+    ($variant:ident, $imm:expr) => {
+        MicroOp::$variant {
+            dst: FO(SLOT_DST),
+            src: FO(SLOT_SRC),
+            imm: $imm,
+        }
+    };
+}
+
+/// `binary_ok!(AddU64, 7, 35 => 42)` → `(7 + 35) == 42`.
+macro_rules! binary_ok {
+    ($variant:ident, $lhs:expr, $rhs:expr => $expected:expr) => {
+        assert_eq!(
+            run_binary_u64_op(binop!($variant), $lhs, $rhs).unwrap(),
+            $expected,
+        );
+    };
+}
+
+/// `binary_err!(AddU64, u64::MAX, 1)` → expects abort.
+macro_rules! binary_err {
+    ($variant:ident, $lhs:expr, $rhs:expr) => {
+        assert!(run_binary_u64_op(binop!($variant), $lhs, $rhs).is_err());
+    };
+}
+
+/// `imm_ok!(SubU64Imm, 8, 50 => 42)` → `(50 - 8) == 42`. Args are
+/// `variant, imm, src => expected`.
+macro_rules! imm_ok {
+    ($variant:ident, $imm:expr, $src:expr => $expected:expr) => {
+        assert_eq!(
+            run_unary_u64_op(imm_op!($variant, $imm), $src).unwrap(),
+            $expected,
+        );
+    };
+}
+
+/// `imm_err!(SubU64Imm, 8, 0)` → expects abort. Args are
+/// `variant, imm, src`.
+macro_rules! imm_err {
+    ($variant:ident, $imm:expr, $src:expr) => {
+        assert!(run_unary_u64_op(imm_op!($variant, $imm), $src).is_err());
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+// --- Add / Sub ---
+
+#[test]
+fn add_u64() {
+    binary_ok!(AddU64, 7, 35 => 42);
+    binary_err!(AddU64, u64::MAX, 1); // overflow
+}
+
+#[test]
+fn sub_u64() {
+    binary_ok!(SubU64, 50, 8 => 42);
+    binary_err!(SubU64, 0, 1); // underflow
+}
+
+#[test]
+fn sub_u64_imm() {
+    imm_ok!(SubU64Imm, 8, 50 => 42);
+    imm_err!(SubU64Imm, 8, 0); // underflow
+}
+
+#[test]
+fn rsub_u64_imm() {
+    imm_ok!(RSubU64Imm, 50, 8 => 42); // 50 - 8
+    imm_err!(RSubU64Imm, 50, 51); // underflow
+}
+
+// --- Mul / Div / Mod ---
+
+#[test]
+fn mul_u64() {
+    binary_ok!(MulU64, 6, 7 => 42);
+    binary_err!(MulU64, u64::MAX, 2); // overflow
+}
+
+#[test]
+fn mul_u64_imm() {
+    imm_ok!(MulU64Imm, 7, 6 => 42);
+    imm_err!(MulU64Imm, 2, u64::MAX); // overflow
+}
+
+#[test]
+fn div_u64() {
+    binary_ok!(DivU64, 84, 2 => 42);
+    binary_err!(DivU64, 1, 0); // div by zero
+}
+
+#[test]
+fn div_u64_imm() {
+    imm_ok!(DivU64Imm, 2, 84 => 42);
+    // Note: imm == 0 is rejected statically by the verifier; see
+    // verifier_test::div_u64_imm_zero.
+}
+
+#[test]
+fn mod_u64() {
+    binary_ok!(ModU64, 100, 7 => 2);
+    binary_err!(ModU64, 1, 0); // div by zero
+}
+
+#[test]
+fn mod_u64_imm() {
+    imm_ok!(ModU64Imm, 7, 100 => 2);
+    // Note: imm == 0 is rejected statically by the verifier; see
+    // verifier_test::mod_u64_imm_zero.
+}
+
+// --- Bitwise ---
+
+#[test]
+fn bit_and_u64() {
+    binary_ok!(BitAndU64, 0xFF00, 0x0FF0 => 0x0F00);
+}
+
+#[test]
+fn bit_or_u64() {
+    binary_ok!(BitOrU64, 0xFF00, 0x0FF0 => 0xFFF0);
+}
+
+#[test]
+fn bit_xor_u64() {
+    binary_ok!(BitXorU64, 0xFF00, 0x0FF0 => 0xF0F0);
+}
+
+// --- Shifts ---
+
+#[test]
+fn shl_u64() {
+    binary_ok!(ShlU64, 1, 4 => 16);
+    binary_ok!(ShlU64, 1, 63 => 1u64 << 63);
+    binary_err!(ShlU64, 1, 64); // shift >= 64
+}
+
+#[test]
+fn shl_u64_imm() {
+    imm_ok!(ShlU64Imm, 4, 1 => 16);
+    // Note: imm >= 64 is rejected statically by the verifier; see
+    // verifier_test::shl_u64_imm_oversize.
+}
+
+#[test]
+fn shr_u64() {
+    binary_ok!(ShrU64, 256, 4 => 16);
+    binary_ok!(ShrU64, u64::MAX, 63 => 1);
+    binary_err!(ShrU64, 1, 64); // shift >= 64
+}
+
+#[test]
+fn shr_u64_imm() {
+    imm_ok!(ShrU64Imm, 4, 256 => 16);
+    // Note: imm >= 64 is rejected statically by the verifier; see
+    // verifier_test::shr_u64_imm_oversize.
+}

--- a/third_party/move/mono-move/runtime/tests/verifier_test.rs
+++ b/third_party/move/mono-move/runtime/tests/verifier_test.rs
@@ -594,6 +594,125 @@ fn zero_frame_size() {
 }
 
 // ---------------------------------------------------------------------------
+// Static arithmetic constraints (imm-form ops)
+// ---------------------------------------------------------------------------
+//
+// Some imm-form ops would always abort at runtime for a particular imm
+// value (`Div`/`Mod` with `0`, shifts with `>= 64`). The verifier rejects
+// these statically.
+
+fn func_with_single_op(arena: &ExecutableArena, op: MicroOp) -> &Function {
+    // SAFETY: Arena is alive for the duration of the test.
+    unsafe {
+        arena
+            .alloc(Function {
+                name: GlobalArenaPtr::from_static("test"),
+                code: arena.alloc_slice_fill_iter([op, MicroOp::Return]),
+                param_sizes: ExecutableArenaPtr::empty_slice(),
+                param_sizes_sum: 0,
+                param_and_local_sizes_sum: 24,
+                extended_frame_size: 48,
+                zero_frame: false,
+                frame_layout: FrameLayoutInfo::empty(),
+                safe_point_layouts: SortedSafePointEntries::empty(),
+            })
+            .as_ref_unchecked()
+    }
+}
+
+#[test]
+fn div_u64_imm_zero() {
+    let arena = ExecutableArena::new();
+    let func = func_with_single_op(&arena, MicroOp::DivU64Imm {
+        dst: FO(0),
+        src: FO(8),
+        imm: 0,
+    });
+    let errors = verify_function(func, &trivial_descriptors());
+    assert!(
+        errors
+            .iter()
+            .any(|e| e.message.contains("division by zero")),
+        "expected division-by-zero error, got: {:?}",
+        errors
+    );
+}
+
+#[test]
+fn mod_u64_imm_zero() {
+    let arena = ExecutableArena::new();
+    let func = func_with_single_op(&arena, MicroOp::ModU64Imm {
+        dst: FO(0),
+        src: FO(8),
+        imm: 0,
+    });
+    let errors = verify_function(func, &trivial_descriptors());
+    assert!(
+        errors
+            .iter()
+            .any(|e| e.message.contains("division by zero")),
+        "expected division-by-zero error, got: {:?}",
+        errors
+    );
+}
+
+#[test]
+fn div_u64_imm_nonzero_ok() {
+    let arena = ExecutableArena::new();
+    let func = func_with_single_op(&arena, MicroOp::DivU64Imm {
+        dst: FO(0),
+        src: FO(8),
+        imm: 1,
+    });
+    let errors = verify_function(func, &trivial_descriptors());
+    assert!(errors.is_empty(), "errors: {:?}", errors);
+}
+
+#[test]
+fn shl_u64_imm_oversize() {
+    let arena = ExecutableArena::new();
+    let func = func_with_single_op(&arena, MicroOp::ShlU64Imm {
+        dst: FO(0),
+        src: FO(8),
+        imm: 64,
+    });
+    let errors = verify_function(func, &trivial_descriptors());
+    assert!(
+        errors.iter().any(|e| e.message.contains("shift amount")),
+        "expected oversize-shift error, got: {:?}",
+        errors
+    );
+}
+
+#[test]
+fn shr_u64_imm_oversize() {
+    let arena = ExecutableArena::new();
+    let func = func_with_single_op(&arena, MicroOp::ShrU64Imm {
+        dst: FO(0),
+        src: FO(8),
+        imm: 100,
+    });
+    let errors = verify_function(func, &trivial_descriptors());
+    assert!(
+        errors.iter().any(|e| e.message.contains("shift amount")),
+        "expected oversize-shift error, got: {:?}",
+        errors
+    );
+}
+
+#[test]
+fn shl_u64_imm_in_range_ok() {
+    let arena = ExecutableArena::new();
+    let func = func_with_single_op(&arena, MicroOp::ShlU64Imm {
+        dst: FO(0),
+        src: FO(8),
+        imm: 63,
+    });
+    let errors = verify_function(func, &trivial_descriptors());
+    assert!(errors.is_empty(), "errors: {:?}", errors);
+}
+
+// ---------------------------------------------------------------------------
 // Multiple errors collected
 // ---------------------------------------------------------------------------
 

--- a/third_party/move/mono-move/specializer/src/lower/translate.rs
+++ b/third_party/move/mono-move/specializer/src/lower/translate.rs
@@ -230,13 +230,24 @@ impl<'a> LoweringState<'a> {
                     let l = self.slot(*lhs);
                     let r = self.slot(*rhs);
                     let d = self.def_slot(*dst);
+                    let dst = FrameOffset(d.offset);
+                    let lhs = FrameOffset(l.offset);
+                    let rhs = FrameOffset(r.offset);
                     match op {
-                        BinaryOp::Add => self.emit(MicroOp::AddU64 {
-                            dst: FrameOffset(d.offset),
-                            lhs: FrameOffset(l.offset),
-                            rhs: FrameOffset(r.offset),
-                        }),
-                        _ => bail!("BinaryOp {:?} for u64-sized type not yet lowered", op),
+                        BinaryOp::Add => self.emit(MicroOp::AddU64 { dst, lhs, rhs }),
+                        BinaryOp::Sub => self.emit(MicroOp::SubU64 { dst, lhs, rhs }),
+                        BinaryOp::Mul => self.emit(MicroOp::MulU64 { dst, lhs, rhs }),
+                        BinaryOp::Div => self.emit(MicroOp::DivU64 { dst, lhs, rhs }),
+                        BinaryOp::Mod => self.emit(MicroOp::ModU64 { dst, lhs, rhs }),
+                        BinaryOp::BitAnd => self.emit(MicroOp::BitAndU64 { dst, lhs, rhs }),
+                        BinaryOp::BitOr => self.emit(MicroOp::BitOrU64 { dst, lhs, rhs }),
+                        BinaryOp::Xor => self.emit(MicroOp::BitXorU64 { dst, lhs, rhs }),
+                        BinaryOp::Shl => self.emit(MicroOp::ShlU64 { dst, lhs, rhs }),
+                        BinaryOp::Shr => self.emit(MicroOp::ShrU64 { dst, lhs, rhs }),
+                        // Phase 2/3: comparison-to-register and logical and/or.
+                        BinaryOp::Cmp(_) | BinaryOp::Or | BinaryOp::And => {
+                            bail!("BinaryOp {:?} for u64-sized type not yet lowered", op)
+                        },
                     }
                 } else {
                     bail!("BinaryOp for non-u64 type not yet lowered");
@@ -250,18 +261,26 @@ impl<'a> LoweringState<'a> {
                     let s = self.slot(*src);
                     let d = self.def_slot(*dst);
                     let v = imm_to_u64(imm);
+                    let dst = FrameOffset(d.offset);
+                    let src = FrameOffset(s.offset);
                     match op {
-                        BinaryOp::Sub => self.emit(MicroOp::SubU64Imm {
-                            dst: FrameOffset(d.offset),
-                            src: FrameOffset(s.offset),
-                            imm: v,
-                        }),
-                        BinaryOp::Add => self.emit(MicroOp::AddU64Imm {
-                            dst: FrameOffset(d.offset),
-                            src: FrameOffset(s.offset),
-                            imm: v,
-                        }),
-                        _ => bail!("BinaryOpImm {:?} for u64-sized type not yet lowered", op),
+                        BinaryOp::Add => self.emit(MicroOp::AddU64Imm { dst, src, imm: v }),
+                        BinaryOp::Sub => self.emit(MicroOp::SubU64Imm { dst, src, imm: v }),
+                        BinaryOp::Mul => self.emit(MicroOp::MulU64Imm { dst, src, imm: v }),
+                        BinaryOp::Div => self.emit(MicroOp::DivU64Imm { dst, src, imm: v }),
+                        BinaryOp::Mod => self.emit(MicroOp::ModU64Imm { dst, src, imm: v }),
+                        BinaryOp::Shl => self.emit(MicroOp::ShlU64Imm { dst, src, imm: v }),
+                        BinaryOp::Shr => self.emit(MicroOp::ShrU64Imm { dst, src, imm: v }),
+                        // No immediate forms today: BitAnd/BitOr/Xor and the
+                        // Phase 2/3 Cmp/Or/And ops.
+                        BinaryOp::BitAnd
+                        | BinaryOp::BitOr
+                        | BinaryOp::Xor
+                        | BinaryOp::Cmp(_)
+                        | BinaryOp::Or
+                        | BinaryOp::And => {
+                            bail!("BinaryOpImm {:?} for u64-sized type not yet lowered", op)
+                        },
                     }
                 } else {
                     bail!("BinaryOpImm for non-u64 type not yet lowered");

--- a/third_party/move/mono-move/testsuite/tests/test_cases/snapshot/masm/arithmetic.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/snapshot/masm/arithmetic.exp
@@ -23,6 +23,154 @@ fun complex_arith(r0): u64 {
     2: ret [r2]
 }
 
+fun sub_values(r0, r1): u64 {
+  slots: params(2), locals(0), temps(1)
+    r0: u64
+    r1: u64
+    r2: u64
+  code:
+  L0:
+    0: r2 := sub r0, r1
+    1: ret [r2]
+}
+
+fun sub_imm(r0): u64 {
+  slots: params(1), locals(0), temps(1)
+    r0: u64
+    r1: u64
+  code:
+  L0:
+    0: r1 := sub r0, #5
+    1: ret [r1]
+}
+
+fun div_values(r0, r1): u64 {
+  slots: params(2), locals(0), temps(1)
+    r0: u64
+    r1: u64
+    r2: u64
+  code:
+  L0:
+    0: r2 := div r0, r1
+    1: ret [r2]
+}
+
+fun mod_values(r0, r1): u64 {
+  slots: params(2), locals(0), temps(1)
+    r0: u64
+    r1: u64
+    r2: u64
+  code:
+  L0:
+    0: r2 := mod r0, r1
+    1: ret [r2]
+}
+
+fun bit_and(r0, r1): u64 {
+  slots: params(2), locals(0), temps(1)
+    r0: u64
+    r1: u64
+    r2: u64
+  code:
+  L0:
+    0: r2 := bit_and r0, r1
+    1: ret [r2]
+}
+
+fun bit_or(r0, r1): u64 {
+  slots: params(2), locals(0), temps(1)
+    r0: u64
+    r1: u64
+    r2: u64
+  code:
+  L0:
+    0: r2 := bit_or r0, r1
+    1: ret [r2]
+}
+
+fun bit_xor(r0, r1): u64 {
+  slots: params(2), locals(0), temps(1)
+    r0: u64
+    r1: u64
+    r2: u64
+  code:
+  L0:
+    0: r2 := xor r0, r1
+    1: ret [r2]
+}
+
+fun shl_values(r0, r1): u64 {
+  slots: params(2), locals(0), temps(1)
+    r0: u64
+    r1: u8
+    r2: u64
+  code:
+  L0:
+    0: r2 := shl r0, r1
+    1: ret [r2]
+}
+
+fun shr_values(r0, r1): u64 {
+  slots: params(2), locals(0), temps(1)
+    r0: u64
+    r1: u8
+    r2: u64
+  code:
+  L0:
+    0: r2 := shr r0, r1
+    1: ret [r2]
+}
+
+fun mul_imm(r0): u64 {
+  slots: params(1), locals(0), temps(1)
+    r0: u64
+    r1: u64
+  code:
+  L0:
+    0: r1 := mul r0, #7
+    1: ret [r1]
+}
+
+fun div_imm(r0): u64 {
+  slots: params(1), locals(0), temps(1)
+    r0: u64
+    r1: u64
+  code:
+  L0:
+    0: r1 := div r0, #3
+    1: ret [r1]
+}
+
+fun mod_imm(r0): u64 {
+  slots: params(1), locals(0), temps(1)
+    r0: u64
+    r1: u64
+  code:
+  L0:
+    0: r1 := mod r0, #10
+    1: ret [r1]
+}
+
+fun shl_imm(r0): u64 {
+  slots: params(1), locals(0), temps(1)
+    r0: u64
+    r1: u64
+  code:
+  L0:
+    0: r1 := shl r0, #4u8
+    1: ret [r1]
+}
+
+fun shr_imm(r0): u64 {
+  slots: params(1), locals(0), temps(1)
+    r0: u64
+    r1: u64
+  code:
+  L0:
+    0: r1 := shr r0, #2u8
+    1: ret [r1]
+}
+
 === micro-ops ===
 // module 0x66::test
 
@@ -34,4 +182,123 @@ fun add_values() {
     2: Return
 }
 
-fun complex_arith(): skipped (lowering: BinaryOpImm Mul for u64-sized type not yet lowered)
+fun complex_arith() {
+  frame_data_size: 24
+  code:
+    0: MulU64Imm [8] <- [0] * #2
+    1: AddU64Imm [16] <- [8] + #1
+    2: Move8 [0] <- [16]
+    3: Return
+}
+
+fun sub_values() {
+  frame_data_size: 24
+  code:
+    0: SubU64 [16] <- [0] - [8]
+    1: Move8 [0] <- [16]
+    2: Return
+}
+
+fun sub_imm() {
+  frame_data_size: 16
+  code:
+    0: SubU64Imm [8] <- [0] - #5
+    1: Move8 [0] <- [8]
+    2: Return
+}
+
+fun div_values() {
+  frame_data_size: 24
+  code:
+    0: DivU64 [16] <- [0] / [8]
+    1: Move8 [0] <- [16]
+    2: Return
+}
+
+fun mod_values() {
+  frame_data_size: 24
+  code:
+    0: ModU64 [16] <- [0] % [8]
+    1: Move8 [0] <- [16]
+    2: Return
+}
+
+fun bit_and() {
+  frame_data_size: 24
+  code:
+    0: BitAndU64 [16] <- [0] & [8]
+    1: Move8 [0] <- [16]
+    2: Return
+}
+
+fun bit_or() {
+  frame_data_size: 24
+  code:
+    0: BitOrU64 [16] <- [0] | [8]
+    1: Move8 [0] <- [16]
+    2: Return
+}
+
+fun bit_xor() {
+  frame_data_size: 24
+  code:
+    0: BitXorU64 [16] <- [0] ^ [8]
+    1: Move8 [0] <- [16]
+    2: Return
+}
+
+fun shl_values() {
+  frame_data_size: 24
+  code:
+    0: ShlU64 [16] <- [0] << [8]
+    1: Move8 [0] <- [16]
+    2: Return
+}
+
+fun shr_values() {
+  frame_data_size: 24
+  code:
+    0: ShrU64 [16] <- [0] >> [8]
+    1: Move8 [0] <- [16]
+    2: Return
+}
+
+fun mul_imm() {
+  frame_data_size: 16
+  code:
+    0: MulU64Imm [8] <- [0] * #7
+    1: Move8 [0] <- [8]
+    2: Return
+}
+
+fun div_imm() {
+  frame_data_size: 16
+  code:
+    0: DivU64Imm [8] <- [0] / #3
+    1: Move8 [0] <- [8]
+    2: Return
+}
+
+fun mod_imm() {
+  frame_data_size: 16
+  code:
+    0: ModU64Imm [8] <- [0] % #10
+    1: Move8 [0] <- [8]
+    2: Return
+}
+
+fun shl_imm() {
+  frame_data_size: 16
+  code:
+    0: ShlU64Imm [8] <- [0] << #4
+    1: Move8 [0] <- [8]
+    2: Return
+}
+
+fun shr_imm() {
+  frame_data_size: 16
+  code:
+    0: ShrU64Imm [8] <- [0] >> #2
+    1: Move8 [0] <- [8]
+    2: Return
+}

--- a/third_party/move/mono-move/testsuite/tests/test_cases/snapshot/masm/arithmetic.masm
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/snapshot/masm/arithmetic.masm
@@ -16,3 +16,87 @@ fun complex_arith(x: u64): u64
     ld_u64 1
     add
     ret
+
+fun sub_values(a: u64, b: u64): u64
+    copy_loc a
+    copy_loc b
+    sub
+    ret
+
+fun sub_imm(x: u64): u64
+    copy_loc x
+    ld_u64 5
+    sub
+    ret
+
+fun div_values(a: u64, b: u64): u64
+    copy_loc a
+    copy_loc b
+    div
+    ret
+
+fun mod_values(a: u64, b: u64): u64
+    copy_loc a
+    copy_loc b
+    mod
+    ret
+
+fun bit_and(a: u64, b: u64): u64
+    copy_loc a
+    copy_loc b
+    bit_and
+    ret
+
+fun bit_or(a: u64, b: u64): u64
+    copy_loc a
+    copy_loc b
+    bit_or
+    ret
+
+fun bit_xor(a: u64, b: u64): u64
+    copy_loc a
+    copy_loc b
+    xor
+    ret
+
+fun shl_values(a: u64, b: u8): u64
+    copy_loc a
+    copy_loc b
+    shl
+    ret
+
+fun shr_values(a: u64, b: u8): u64
+    copy_loc a
+    copy_loc b
+    shr
+    ret
+
+fun mul_imm(x: u64): u64
+    copy_loc x
+    ld_u64 7
+    mul
+    ret
+
+fun div_imm(x: u64): u64
+    copy_loc x
+    ld_u64 3
+    div
+    ret
+
+fun mod_imm(x: u64): u64
+    copy_loc x
+    ld_u64 10
+    mod
+    ret
+
+fun shl_imm(x: u64): u64
+    copy_loc x
+    ld_u8 4
+    shl
+    ret
+
+fun shr_imm(x: u64): u64
+    copy_loc x
+    ld_u8 2
+    shr
+    ret


### PR DESCRIPTION
## Summary

Phase 1 of arithmetic / boolean op support in mono-move. Adds the missing reg-reg and reg-imm forms so the lowerer can stop bail!ing on common Move arithmetic.

**New micro-ops:**
- reg-reg: \`SubU64\`, \`MulU64\`, \`DivU64\`, \`BitAndU64\`, \`BitOrU64\`, \`ShlU64\`, \`ShrU64\`
- imm:     \`MulU64Imm\`, \`DivU64Imm\`, \`ModU64Imm\`, \`ShlU64Imm\`

All checked: overflow / underflow / div-by-zero / shift>=64 abort.

**Rename:** \`XorU64\` → \`BitXorU64\` for naming consistency with the new \`BitAnd\`/\`BitOr\` (and to disambiguate from forthcoming logical \`Or\`/\`And\`/\`Not\`).

**Wired through every layer:**
- core: enum variant + \`Display\`, gas \`HasCfgInfo\` / \`RemapTargets\` / cost
- runtime: verifier arms + interpreter \`step()\` arms with checked arithmetic
- specializer: \`lower/translate.rs\` \`BinaryOp\` / \`BinaryOpImm\` arms

**Static checks added to the verifier:**
- \`DivU64Imm\` / \`ModU64Imm\` with \`imm == 0\` is rejected statically (always-abort).
- \`ShlU64Imm\` / \`ShrU64Imm\` with \`imm >= 64\` is rejected statically (always-abort).

**Out of scope (deferred):**
- Reverse-imm forms for non-commutative ops other than Sub. Will add if destacker output shows we need them.
- Boolean \`Or\` / \`And\` / \`Not\` (Phase 3).
- Comparison-to-register \`EqU64\` / \`LtU64\` / etc (Phase 2).
- \`Negate\` (signed-int territory, separate work item).

## Test plan

- [x] \`cargo test -p mono-move-runtime\` — full suite passes including 17 new arithmetic_ops tests + 6 new verifier tests.
- [x] \`cargo test -p mono-move-testsuite --test snapshot\` — baselines regenerated with broader op coverage; new ops emit the expected micro-ops.
- [x] \`cargo +nightly fmt -- --check\` clean on touched files.
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it expands the VM instruction set and touches interpreter execution, verifier validation, gas costing, and lowering logic; mistakes could cause incorrect execution or unexpected abort behavior.
> 
> **Overview**
> Adds new checked u64 micro-ops for `Sub` (reg-reg), `Mul`, `Div`, `ModImm`, bitwise (`BitAnd`/`BitOr`/`BitXor`), and shifts (`Shl`/`Shr`, reg-reg and imm), and renames `XorU64` to `BitXorU64` for naming consistency.
> 
> Wires these ops through core (`MicroOp` enum + `Display`, gas CFG/target remapping, and updated gas costs), the runtime interpreter (new execution paths via shared arithmetic helpers with checked overflow/underflow/div-by-zero/shift bounds), and the specializer lowering so common Move arithmetic no longer `bail!()`s.
> 
> Tightens runtime verification by statically rejecting always-aborting imm ops (`DivU64Imm`/`ModU64Imm` with `imm == 0`, shifts with `imm >= 64`), updates example micro-op programs, and adds new end-to-end arithmetic/shift tests plus verifier unit tests; snapshot baselines are regenerated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b36b7b2cdd39496c28f9efde2fe7ef4fc6ab02ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->