### PR TITLE
[docker] release tags always with the git sha (#19463)

### DIFF
--- a/docker/release-images.mjs
+++ b/docker/release-images.mjs
@@ -131,15 +131,22 @@ async function main() {
             profilePrefix,
             featureSuffix,
           )}`;
+          // Second ref: same image, tag with git SHA appended (joinTagSegments adds "_" before the sha segment).
+          const imageTargetWithSha = joinTagSegments(imageTarget, parsedArgs.GIT_SHA);
           await waitForImageToBecomeAvailable(imageSource, parsedArgs.WAIT_FOR_IMAGE_SECONDS);
           if (parsedArgs.DRY_RUN) {
-            console.info(chalk.yellow(`INFO: skipping copy of ${imageSource} to ${imageTarget} due to dry run`));
+            console.info(
+              chalk.yellow(
+                `INFO: skipping copy of ${imageSource} to ${imageTarget} and ${imageTargetWithSha} due to dry run`,
+              ),
+            );
             continue;
           } else {
             console.info(chalk.green(`INFO: copying ${imageSource} to ${imageTarget}`));
+            console.info(chalk.green(`INFO: copying ${imageSource} to ${imageTargetWithSha}`));
           }
           await $`${crane} copy ${imageSource} ${imageTarget}`;
-          await $`${crane} copy ${imageSource} ${joinTagSegments(imageTarget, parsedArgs.GIT_SHA)}`;
+          await $`${crane} copy ${imageSource} ${imageTargetWithSha}`;
         }
       }
     }


### PR DESCRIPTION
## Description
This cherry-picks a missing commit (1a365d3f7b7b6e4aa599ae93fc642ab9ca8bead2)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small change to the image release script’s tagging/copy behavior and log output, with impact limited to CI publishing of Docker image tags.
> 
> **Overview**
> Ensures `docker/release-images.mjs` always publishes **two tags per released image**: the release tag (from `IMAGE_TAG_PREFIX`/profile/feature) and a second tag with the same release tag **plus the `GIT_SHA` suffix**.
> 
> Updates dry-run and copy logging to reflect both destinations, and reuses a computed `imageTargetWithSha` when invoking `crane copy`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 536946227de05a3c05e030b9c38e569ba7933151. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->