### PR TITLE
[docker] build and release all performance images (#19347)

### DIFF
--- a/docker/IMAGE_TAGGING.md
+++ b/docker/IMAGE_TAGGING.md
@@ -1,0 +1,130 @@
+# Docker Image Tagging
+
+## Overview
+
+Images are built into GCP Artifact Registry (internal), then copied to GCP and Docker Hub (public) during release. The tag format encodes the build profile, feature flags, and git ref as `_`-delimited segments — empty segments are dropped.
+
+## Tag Anatomy
+
+```
+{IMAGE_TAG_PREFIX}[_{profile}][_{feature}][_{git_sha}]
+```
+
+| Segment | Value | When present |
+|---|---|---|
+| `IMAGE_TAG_PREFIX` | e.g. `aptos-node-v1.2.3`, `devnet`, `nightly` | Always |
+| `profile` | `performance` | Only for non-`release` profiles |
+| `feature` | e.g. `failpoints` | Only for non-`default` features |
+| `git_sha` | full commit SHA | Always appended as a second immutable tag |
+
+### Build profiles
+
+| Profile | Tag segment |
+|---|---|
+| `release` (default) | _(omitted)_ |
+| `performance` | `performance` |
+
+### Build features
+
+| Feature | Tag segment |
+|---|---|
+| `default` | _(omitted)_ |
+| `failpoints` | `failpoints` |
+
+Source: profile/feature prefix logic is implemented in [`docker/builder/docker-bake-rust-all.sh`](builder/docker-bake-rust-all.sh) and the `joinTagSegments` helper in [`docker/image-helpers.js`](image-helpers.js).
+
+## Examples
+
+| Scenario | Tag |
+|---|---|
+| release profile, default feature | `aptos-node-v1.2.3` |
+| performance profile, default feature | `aptos-node-v1.2.3_performance` |
+| release profile, failpoints feature | `aptos-node-v1.2.3_failpoints` |
+| performance + failpoints | `aptos-node-v1.2.3_performance_failpoints` |
+
+Each tag is also copied with the git SHA appended:
+```
+aptos-node-v1.2.3_performance → aptos-node-v1.2.3_performance_{git_sha}
+```
+
+## Source tags (GCP, pre-release)
+
+Images are staged in GCP Artifact Registry during CI builds, tagged by profile/feature + git SHA:
+
+```
+{GCP_REPO}/{image}:[{profile}_][{feature}_]{git_sha}
+```
+
+Also tagged with the normalized branch/PR name for layer cache reuse:
+```
+{GCP_REPO}/{image}:[{profile}_][{feature}_]{branch_or_pr}
+```
+
+Examples:
+- `validator:abc123`  ← release profile, default feature
+- `validator:performance_abc123`  ← performance profile
+- `validator:failpoints_abc123`  ← release + failpoints
+
+Source: [`docker/builder/docker-bake-rust-all.hcl`](builder/docker-bake-rust-all.hcl) — the `generate_tags` function produces these tags for every image target.
+
+## CI build workflows
+
+Images are built by [`workflow-run-docker-rust-build.yaml`](../.github/workflows/workflow-run-docker-rust-build.yaml), which accepts `PROFILE` and `FEATURES` inputs and invokes `docker/builder/docker-bake-rust-all.sh`. It is called from [`docker-build-test.yaml`](../.github/workflows/docker-build-test.yaml) as three parallel jobs:
+
+| Job | Profile | Features | Label to trigger on PRs |
+|---|---|---|---|
+| `rust-images` | `release` | — | always required |
+| `rust-images-performance` | `performance` | — | `CICD:build-performance-images` |
+| `rust-images-failpoints` | `release` | `failpoints` | `CICD:build-failpoints-images` |
+
+`docker-build-test.yaml` also sets `PROFILE_RELEASE`, `PROFILE_PERF`, and `FEATURE_FAILPOINTS` flags that are forwarded to the wait-images step.
+
+## Waiting for images
+
+[`docker/wait-images-ci.mjs`](wait-images-ci.mjs) polls GCP for staged images before dependent CI jobs run. It is wrapped by the [`wait-images-ci` composite action](../.github/actions/wait-images-ci/action.yaml) which accepts the same three boolean flags (`PROFILE_RELEASE`, `PROFILE_PERF`, `FEATURE_FAILPOINTS`) to know which variant tags to wait for. The set of image+profile combinations it checks is defined by `getImagesToWaitFor` in [`docker/image-helpers.js`](image-helpers.js).
+
+## Release workflows
+
+### Versioned releases (`aptos-node-vX.Y.Z`, `aptos-indexer-grpc-vX.Y.Z`)
+
+Triggered by pushing a tag or one of the named network branches (`devnet`, `testnet`, `mainnet`, etc.) via [`copy-images-to-dockerhub-release.yaml`](../.github/workflows/copy-images-to-dockerhub-release.yaml). The git ref name (`github.ref_name`) becomes `IMAGE_TAG_PREFIX`.
+
+For `aptos-node-vX.Y.Z` tags, [`docker/image-helpers.js`](image-helpers.js) (`assertTagMatchesSourceVersion`) validates that the version in the tag matches `aptos-node/Cargo.toml` before copying. The release PR that bumps that version is created by [`aptos-node-release.yaml`](../.github/workflows/aptos-node-release.yaml).
+
+### Nightly
+
+[`copy-images-to-dockerhub-nightly.yaml`](../.github/workflows/copy-images-to-dockerhub-nightly.yaml) runs on dispatch with `IMAGE_TAG_PREFIX=nightly`.
+
+### Core copy logic
+
+Both release paths call [`copy-images-to-dockerhub.yaml`](../.github/workflows/copy-images-to-dockerhub.yaml), which runs [`docker/release-images.mjs`](release-images.mjs). That script:
+1. Determines the release group from `IMAGE_TAG_PREFIX` (`getImageReleaseGroupByImageTagPrefix` in [`release-images.mjs`](release-images.mjs))
+2. Iterates over the per-image release matrix (see below)
+3. Copies `{GCP_REPO}/{image}:{profile}_{git_sha}` → `{registry}/{image}:{prefix}_{profile}` and also tags it with `_{git_sha}`
+
+## Release groups
+
+`IMAGE_TAG_PREFIX` selects which images are released together (defined in `IMAGES_TO_RELEASE_BY_RELEASE_GROUP` in [`docker/release-images.mjs`](release-images.mjs)):
+
+| Prefix contains | Release group | Images |
+|---|---|---|
+| `aptos-node` (default) | `aptos-node` | `validator`, `validator-testing`, `faucet`, `tools` |
+| `aptos-indexer-grpc` | `aptos-indexer-grpc` | `indexer-grpc` |
+
+`validator-testing` is released to GCP only — never to Docker Hub (controlled by `IMAGE_NAMES_TO_RELEASE_ONLY_INTERNAL` in [`docker/release-images.mjs`](release-images.mjs)).
+
+## Per-image release matrix
+
+Each image declares which (profile, feature) combinations are released. Defined in `IMAGES_TO_RELEASE` in [`docker/release-images.mjs`](release-images.mjs):
+
+| Image | Profiles |
+|---|---|
+| `validator` | `release`, `performance` |
+| `validator-testing` | `release`, `performance` |
+| `faucet` | `release`, `performance` |
+| `tools` | `release`, `performance` |
+| `indexer-grpc` | `release`, `performance` |
+
+## Release validation
+
+For `aptos-node-vX.Y.Z` prefixes, the script validates that `X.Y.Z` matches the version in `aptos-node/Cargo.toml` before copying. Non-release prefixes (e.g. `devnet`, `nightly`) skip this check. See `assertTagMatchesSourceVersion` and `isReleaseImage` in [`docker/image-helpers.js`](image-helpers.js).

--- a/docker/image-helpers.js
+++ b/docker/image-helpers.js
@@ -123,8 +123,8 @@ export const CargoBuildProfiles = {
 }
 
 export function getImagesToWaitFor(args) {
-  const perfImages = ["validator", "validator-testing"];
-  const images = ["forge", "tools", "indexer-grpc"];
+  const perfImages = ["validator", "validator-testing", "faucet", "tools", "indexer-grpc"];
+  const images = ["forge"];
   const imagesToWaitFor = {};
   for (const image of [...perfImages, ...images]) {
     const imageConfig = {};

--- a/docker/release-images.mjs
+++ b/docker/release-images.mjs
@@ -61,12 +61,15 @@ const IMAGES_TO_RELEASE = {
     [CargoBuildProfiles.Release]: [CargoBuildFeatures.Default],
   },
   faucet: {
+    [CargoBuildProfiles.Performance]: [CargoBuildFeatures.Default],
     [CargoBuildProfiles.Release]: [CargoBuildFeatures.Default],
   },
   tools: {
+    [CargoBuildProfiles.Performance]: [CargoBuildFeatures.Default],
     [CargoBuildProfiles.Release]: [CargoBuildFeatures.Default],
   },
   "indexer-grpc": {
+    [CargoBuildProfiles.Performance]: [CargoBuildFeatures.Default],
     [CargoBuildProfiles.Release]: [CargoBuildFeatures.Default],
   },
 };


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

Cherrypick missing commit, to publish performance variants of all our images. This is in 1.45 and main

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI/release image matrices and wait logic to publish additional `performance` tags; risk is moderate because mistakes can break image availability or release workflows but scope is limited to Docker automation.
> 
> **Overview**
> Adds documentation (`docker/IMAGE_TAGGING.md`) describing Docker image tag structure, CI build variants, and release/copy behavior.
> 
> Updates Docker automation to treat more images as having `performance` variants: `getImagesToWaitFor` now waits on performance builds for `faucet`, `tools`, and `indexer-grpc`, and `release-images.mjs` expands the release matrix to also copy/publish `performance` tags for those images.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 992dd24db4513391125b31b98a2ee76344fcc06f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->