### PR TITLE
[gas] Fold V1_46 changes into V1_45

### DIFF
--- a/aptos-move/aptos-gas-meter/src/meter.rs
+++ b/aptos-move/aptos-gas-meter/src/meter.rs
@@ -635,7 +635,7 @@ where
     }
 
     fn charge_encrypted_txn_decryption(&mut self) -> VMResult<()> {
-        if self.feature_version() < RELEASE_V1_46 {
+        if self.feature_version() < RELEASE_V1_45 {
             return Ok(());
         }
 

--- a/aptos-move/aptos-gas-schedule/src/gas_schedule/aptos_framework.rs
+++ b/aptos-move/aptos-gas-schedule/src/gas_schedule/aptos_framework.rs
@@ -8,7 +8,7 @@ use crate::{
     gas_schedule::NativeGasParameters,
     ver::gas_feature_versions::{
         RELEASE_V1_12, RELEASE_V1_13, RELEASE_V1_23, RELEASE_V1_26, RELEASE_V1_28, RELEASE_V1_36,
-        RELEASE_V1_39, RELEASE_V1_46,
+        RELEASE_V1_39, RELEASE_V1_45,
     },
 };
 use aptos_gas_algebra::{
@@ -316,7 +316,7 @@ crate::gas_schedule::macros::define_gas_parameters!(
         [transaction_context_entry_function_payload_per_byte_in_str: InternalGasPerByte, {RELEASE_V1_12.. => "transaction_context.entry_function_payload.per_abstract_memory_unit"}, 180],
         [transaction_context_multisig_payload_base: InternalGas, {RELEASE_V1_12.. => "transaction_context.multisig_payload.base"}, 7350],
         [transaction_context_multisig_payload_per_byte_in_str: InternalGasPerByte, {RELEASE_V1_12.. => "transaction_context.multisig_payload.per_abstract_memory_unit"}, 180],
-        [transaction_context_is_encrypted_txn_base: InternalGas, {RELEASE_V1_46.. => "transaction_context.is_encrypted_txn.base"}, 7350],
+        [transaction_context_is_encrypted_txn_base: InternalGas, {RELEASE_V1_45.. => "transaction_context.is_encrypted_txn.base"}, 7350],
 
         [code_request_publish_base: InternalGas, "code.request_publish.base", 18380],
         [code_request_publish_per_byte: InternalGasPerByte, "code.request_publish.per_byte", 70],

--- a/aptos-move/aptos-gas-schedule/src/gas_schedule/transaction.rs
+++ b/aptos-move/aptos-gas-schedule/src/gas_schedule/transaction.rs
@@ -8,7 +8,7 @@ use crate::{
     gas_schedule::VMGasParameters,
     ver::gas_feature_versions::{
         RELEASE_V1_10, RELEASE_V1_11, RELEASE_V1_12, RELEASE_V1_13, RELEASE_V1_15, RELEASE_V1_26,
-        RELEASE_V1_41, RELEASE_V1_46,
+        RELEASE_V1_41, RELEASE_V1_45,
     },
 };
 use aptos_gas_algebra::{
@@ -63,7 +63,7 @@ crate::gas_schedule::macros::define_gas_parameters!(
         ],
         [
             high_limit_txn_min_price_per_gas_unit: FeePerGasUnit,
-            { RELEASE_V1_46.. => "high_limit_txn_min_price_per_gas_unit" },
+            { RELEASE_V1_45.. => "high_limit_txn_min_price_per_gas_unit" },
             // 10x of the min_price_per_gas_unit (100).
             1000
         ],
@@ -288,14 +288,14 @@ crate::gas_schedule::macros::define_gas_parameters!(
         ],
         [
             encrypted_txn_decryption_base_cost: InternalGas,
-            { RELEASE_V1_46.. => "encrypted_txn_decryption.base" },
+            { RELEASE_V1_45.. => "encrypted_txn_decryption.base" },
             // 120ms e2e decryption latency amortized over 32 txns * 100M internal gas/ms.
             // The per-block max is 64 encrypted txns, so we assume a half-full block.
             375_000_000,
         ],
         [
             encrypted_txn_min_price_per_gas_unit: FeePerGasUnit,
-            { RELEASE_V1_46.. => "encrypted_txn_min_price_per_gas_unit" },
+            { RELEASE_V1_45.. => "encrypted_txn_min_price_per_gas_unit" },
             200,  // 2x the current min_price_per_gas_unit (100)
         ],
     ]

--- a/aptos-move/aptos-gas-schedule/src/ver.rs
+++ b/aptos-move/aptos-gas-schedule/src/ver.rs
@@ -8,7 +8,7 @@
 ///   - Changing how gas is calculated in any way
 ///
 /// Change log:
-/// - V46:
+/// - V45:
 ///    - New minimum price per gas unit parameter for higher-limit transactions
 ///    - Gas charging for encrypted transaction decryption
 ///    - Minimum gas unit price for encrypted transactions
@@ -77,7 +77,7 @@
 ///       global operations.
 /// - V1
 ///   - TBA
-pub const LATEST_GAS_FEATURE_VERSION: u64 = gas_feature_versions::RELEASE_V1_46;
+pub const LATEST_GAS_FEATURE_VERSION: u64 = gas_feature_versions::RELEASE_V1_45;
 
 pub mod gas_feature_versions {
     pub const RELEASE_V1_8: u64 = 11;
@@ -117,5 +117,4 @@ pub mod gas_feature_versions {
     pub const RELEASE_V1_43: u64 = 47;
     pub const RELEASE_V1_44: u64 = 48;
     pub const RELEASE_V1_45: u64 = 49;
-    pub const RELEASE_V1_46: u64 = 50;
 }

--- a/aptos-move/aptos-vm/src/gas.rs
+++ b/aptos-move/aptos-vm/src/gas.rs
@@ -5,7 +5,7 @@ use crate::{move_vm_ext::AptosMoveResolver, transaction_metadata::TransactionMet
 use aptos_gas_algebra::{Gas, GasExpression, InternalGas};
 use aptos_gas_meter::{StandardGasAlgebra, StandardGasMeter};
 use aptos_gas_schedule::{
-    gas_feature_versions::{RELEASE_V1_13, RELEASE_V1_46},
+    gas_feature_versions::{RELEASE_V1_13, RELEASE_V1_45},
     gas_params::txn::{
         ENCRYPTED_TXN_DECRYPTION_BASE_COST, KEYLESS_BASE_COST, SLH_DSA_SHA2_128S_BASE_COST,
     },
@@ -152,7 +152,7 @@ pub(crate) fn check_gas(
         InternalGas::zero()
     };
     let encrypted_txn_cost =
-        if txn_metadata.is_encrypted_txn() && gas_feature_version >= RELEASE_V1_46 {
+        if txn_metadata.is_encrypted_txn() && gas_feature_version >= RELEASE_V1_45 {
             // Encrypted txns must meet a higher minimum gas unit price (priority pricing).
             // Uses max() so encrypted floor never goes below base minimum.
             let encrypted_min = std::cmp::max(


### PR DESCRIPTION
## Summary

The 1.45 release branch was re-cut to include #19109 and #19453, both of which gated their new gas params on `RELEASE_V1_46`. This folds those changes into V1_45:

- Drop the `RELEASE_V1_46 = 50` constant
- Point `LATEST_GAS_FEATURE_VERSION` back at `RELEASE_V1_45`
- Rename the V46 changelog header to V45
- Update 5 `RELEASE_V1_46` call sites across `aptos-gas-schedule`, `aptos-gas-meter`, and `aptos-vm`

## Test plan

- [x] `cargo check -p aptos-gas-schedule -p aptos-gas-meter -p aptos-vm`
- [x] `cargo test -p aptos-gas-schedule encrypted_min_price_is_at_least_2x_base_min_price`
- [x] `cargo +nightly fmt --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the gas feature version boundary for encrypted-txn pricing/decryption and high-limit txn minimum pricing, which can affect on-chain gas schedule compatibility across releases. While largely a constant/gating adjustment, an off-by-one version error could change fees or validation behavior at runtime.
> 
> **Overview**
> Folds previously V1_46-gated transaction gas changes into **V1_45** by removing the V1_46 feature version and setting `LATEST_GAS_FEATURE_VERSION` back to `RELEASE_V1_45`.
> 
> Updates all gating checks/mappings so encrypted transaction decryption charging and minimum gas-price enforcement (plus the high-limit txn min price param and `transaction_context.is_encrypted_txn` gas param) activate starting at `RELEASE_V1_45` in `aptos-gas-schedule`, `aptos-gas-meter`, and `aptos-vm`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8052f8047afaa84026eda39f9b51b5b20b6174b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->