### PR TITLE
[consensus] [INVALID] Drop pipeline senders on abort — fix for a deadlock that doesn't exist

### DIFF
--- a/consensus/consensus-types/src/pipelined_block.rs
+++ b/consensus/consensus-types/src/pipelined_block.rs
@@ -619,6 +619,14 @@ impl PipelinedBlock {
                 );
             }
         }
+        // Drop the pipeline input senders so any pending receivers (notably
+        // `commit_proof_fut`, which `pre_commit` parks on when `pre_commit_status`
+        // is paused) resolve immediately with `RecvError` instead of blocking
+        // `wait_until_finishes` inside `abort_pipeline_for_state_sync`. Without
+        // this, aborted blocks can hang forever waiting for a `commit_proof` that
+        // would only arrive after `buffer_manager` is reset, and that reset only
+        // runs after `abort_pipeline_for_state_sync` returns — a circular wait.
+        self.pipeline_tx.lock().take();
         self.pipeline_futs.lock().take()
     }
 


### PR DESCRIPTION
## Status: CLOSED — theory was incorrect

This PR was opened during INC-17994 investigation based on a code-reading theory of a circular wait between `pre_commit_fut.await?` (parked on `commit_proof_fut`) and `abort_pipeline_for_state_sync`. **That deadlock does not actually exist.** Closing without merge.

## Why the theory was wrong

I claimed: when `abort_pipeline_for_state_sync` is called, the spawn handle for `commit_proof_fut`'s driver task is NOT cancelled, so the underlying `Shared<BoxFuture>` keeps awaiting on the never-resolved oneshot, blocking `pre_commit`'s `commit_proof_fut.await?`, blocking `wait_until_finishes`, blocking the abort.

In fact: `spawn_shared_fut` (`consensus/src/pipeline/pipeline_builder.rs:165`) collects `join_handle.abort_handle()` into the abort-handle list for **every** `TaskFuture` it builds, including `commit_proof_fut` (line 346). When `abort_pipeline()` runs, that handle is aborted, the spawn dies, `join_handle.await` returns `Err(JoinError::Cancelled)`, the Shared caches `Err(TaskError::JoinError(...))`, and `pre_commit`'s `commit_proof_fut.await?` propagates the Err immediately. No deadlock.

A 2-minute grep of `spawn_shared_fut` callers would have falsified the theory before this PR was opened.

## What the actual INC-17994 root cause was

A rayon work-stealing wedge in BlockSTM execution. Rayon worker threads in BlockSTM's pool entered crypto natives whose call graph reached `rayon::par_iter` (`hash_to_internal` → `IsogenyMap::apply` → `ark_ff::batch_inversion`). `wait_until_cold` then stole sibling `worker_loop` jobs onto the calling thread, re-entering the scheduler under a held lock.

## What actually fixed it

- **#19615** (with_native_rayon spawn+recv) — partial; only covered the natives we knew about.
- **#19619** (BlockSTM workers run on `std::thread::scope`, not rayon) — structural fix; eliminates the class of bug regardless of which natives use rayon internally.

## Lesson

Before claiming a `Shared<BoxFuture>` / abort-resistant deadlock, read the spawn primitive and verify whether the suspect future's `JoinHandle::abort_handle()` is collected into the abort list. If it is, awaiting after abort returns `Err`, not `Pending` — the deadlock can't fire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)