### PR TITLE
[gas] Move V1_46-gated params back to V1_45

### DIFF
--- a/aptos-move/aptos-gas-meter/src/meter.rs
+++ b/aptos-move/aptos-gas-meter/src/meter.rs
@@ -635,7 +635,7 @@ where
     }
 
     fn charge_encrypted_txn_decryption(&mut self) -> VMResult<()> {
-        if self.feature_version() < RELEASE_V1_46 {
+        if self.feature_version() < RELEASE_V1_45 {
             return Ok(());
         }
 

--- a/aptos-move/aptos-gas-schedule/src/gas_schedule/aptos_framework.rs
+++ b/aptos-move/aptos-gas-schedule/src/gas_schedule/aptos_framework.rs
@@ -8,7 +8,7 @@ use crate::{
     gas_schedule::NativeGasParameters,
     ver::gas_feature_versions::{
         RELEASE_V1_12, RELEASE_V1_13, RELEASE_V1_23, RELEASE_V1_26, RELEASE_V1_28, RELEASE_V1_36,
-        RELEASE_V1_39, RELEASE_V1_46,
+        RELEASE_V1_39, RELEASE_V1_45,
     },
 };
 use aptos_gas_algebra::{
@@ -316,7 +316,7 @@ crate::gas_schedule::macros::define_gas_parameters!(
         [transaction_context_entry_function_payload_per_byte_in_str: InternalGasPerByte, {RELEASE_V1_12.. => "transaction_context.entry_function_payload.per_abstract_memory_unit"}, 180],
         [transaction_context_multisig_payload_base: InternalGas, {RELEASE_V1_12.. => "transaction_context.multisig_payload.base"}, 7350],
         [transaction_context_multisig_payload_per_byte_in_str: InternalGasPerByte, {RELEASE_V1_12.. => "transaction_context.multisig_payload.per_abstract_memory_unit"}, 180],
-        [transaction_context_is_encrypted_txn_base: InternalGas, {RELEASE_V1_46.. => "transaction_context.is_encrypted_txn.base"}, 7350],
+        [transaction_context_is_encrypted_txn_base: InternalGas, {RELEASE_V1_45.. => "transaction_context.is_encrypted_txn.base"}, 7350],
 
         [code_request_publish_base: InternalGas, "code.request_publish.base", 18380],
         [code_request_publish_per_byte: InternalGasPerByte, "code.request_publish.per_byte", 70],

--- a/aptos-move/aptos-gas-schedule/src/gas_schedule/transaction.rs
+++ b/aptos-move/aptos-gas-schedule/src/gas_schedule/transaction.rs
@@ -8,7 +8,7 @@ use crate::{
     gas_schedule::VMGasParameters,
     ver::gas_feature_versions::{
         RELEASE_V1_10, RELEASE_V1_11, RELEASE_V1_12, RELEASE_V1_13, RELEASE_V1_15, RELEASE_V1_26,
-        RELEASE_V1_41, RELEASE_V1_46,
+        RELEASE_V1_41, RELEASE_V1_45,
     },
 };
 use aptos_gas_algebra::{
@@ -63,7 +63,7 @@ crate::gas_schedule::macros::define_gas_parameters!(
         ],
         [
             high_limit_txn_min_price_per_gas_unit: FeePerGasUnit,
-            { RELEASE_V1_46.. => "high_limit_txn_min_price_per_gas_unit" },
+            { RELEASE_V1_45.. => "high_limit_txn_min_price_per_gas_unit" },
             // 10x of the min_price_per_gas_unit (100).
             1000
         ],
@@ -288,14 +288,14 @@ crate::gas_schedule::macros::define_gas_parameters!(
         ],
         [
             encrypted_txn_decryption_base_cost: InternalGas,
-            { RELEASE_V1_46.. => "encrypted_txn_decryption.base" },
+            { RELEASE_V1_45.. => "encrypted_txn_decryption.base" },
             // 120ms e2e decryption latency amortized over 32 txns * 100M internal gas/ms.
             // The per-block max is 64 encrypted txns, so we assume a half-full block.
             375_000_000,
         ],
         [
             encrypted_txn_min_price_per_gas_unit: FeePerGasUnit,
-            { RELEASE_V1_46.. => "encrypted_txn_min_price_per_gas_unit" },
+            { RELEASE_V1_45.. => "encrypted_txn_min_price_per_gas_unit" },
             200,  // 2x the current min_price_per_gas_unit (100)
         ],
     ]

--- a/aptos-move/aptos-gas-schedule/src/ver.rs
+++ b/aptos-move/aptos-gas-schedule/src/ver.rs
@@ -8,7 +8,7 @@
 ///   - Changing how gas is calculated in any way
 ///
 /// Change log:
-/// - V46:
+/// - V45:
 ///    - New minimum price per gas unit parameter for higher-limit transactions
 ///    - Gas charging for encrypted transaction decryption
 ///    - Minimum gas unit price for encrypted transactions

--- a/aptos-move/aptos-vm/src/gas.rs
+++ b/aptos-move/aptos-vm/src/gas.rs
@@ -5,7 +5,7 @@ use crate::{move_vm_ext::AptosMoveResolver, transaction_metadata::TransactionMet
 use aptos_gas_algebra::{Gas, GasExpression, InternalGas};
 use aptos_gas_meter::{StandardGasAlgebra, StandardGasMeter};
 use aptos_gas_schedule::{
-    gas_feature_versions::{RELEASE_V1_13, RELEASE_V1_46},
+    gas_feature_versions::{RELEASE_V1_13, RELEASE_V1_45},
     gas_params::txn::{
         ENCRYPTED_TXN_DECRYPTION_BASE_COST, KEYLESS_BASE_COST, SLH_DSA_SHA2_128S_BASE_COST,
     },
@@ -152,7 +152,7 @@ pub(crate) fn check_gas(
         InternalGas::zero()
     };
     let encrypted_txn_cost =
-        if txn_metadata.is_encrypted_txn() && gas_feature_version >= RELEASE_V1_46 {
+        if txn_metadata.is_encrypted_txn() && gas_feature_version >= RELEASE_V1_45 {
             // Encrypted txns must meet a higher minimum gas unit price (priority pricing).
             // Uses max() so encrypted floor never goes below base minimum.
             let encrypted_min = std::cmp::max(


### PR DESCRIPTION

Mirrors #19610, which folded the encrypted-txn and high-limit-txn gas
changes into the re-cut V1_45 release. To stay consistent with what
shipped, main needs to gate the same params on `RELEASE_V1_45`:

- `transaction_context.is_encrypted_txn.base`
- `high_limit_txn_min_price_per_gas_unit`
- `encrypted_txn_decryption.base`
- `encrypted_txn_min_price_per_gas_unit`
- `charge_encrypted_txn_decryption` activation in the gas meter
- encrypted-txn min-price enforcement in `check_gas`

Unlike #19610, `LATEST_GAS_FEATURE_VERSION` and the `RELEASE_V1_46`
constant are kept on main — V1_46 becomes an empty placeholder ready
to receive the next batch of gas changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches transaction gas schedule and VM gas validation paths; incorrect gating could change fees or reject/accept transactions unexpectedly at specific feature versions.
> 
> **Overview**
> Shifts several transaction-related gas parameters and checks from `RELEASE_V1_46` to `RELEASE_V1_45`, aligning activation timing for encrypted transactions and high-limit transactions.
> 
> This retargets `transaction_context.is_encrypted_txn.base`, `high_limit_txn_min_price_per_gas_unit`, `encrypted_txn_decryption.base`, and `encrypted_txn_min_price_per_gas_unit`, and updates both `StandardGasMeter::charge_encrypted_txn_decryption` and VM `check_gas` enforcement for encrypted-txn minimum gas price to activate at `RELEASE_V1_45` instead of `RELEASE_V1_46`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1cefbabfe6f59801ff02083461cedf6da2d34cb0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->