### PR TITLE
[vm] Fix par_exec deadlock in with_native_rayon

### DIFF
--- a/aptos-move/aptos-native-interface/src/rayon_pool.rs
+++ b/aptos-move/aptos-native-interface/src/rayon_pool.rs
@@ -18,12 +18,22 @@
 //!
 //! Natives that reach into rayon-using code must wrap the relevant section in
 //! [`with_native_rayon`] so the work executes on this isolated pool instead.
+//!
+//! The helper blocks the caller via a channel `recv` (a real OS park) rather
+//! than `ThreadPool::install`. That matters: `install` would leave the caller
+//! eligible for rayon work-stealing from its home pool while the native work
+//! runs, which in `par_exec` can close into a deadlock through writer-
+//! preferring per-txn locks.
 
+use crate::{SafeNativeError, SafeNativeResult};
 use anyhow::{anyhow, Result};
+use move_binary_format::errors::PartialVMError;
+use move_core_types::vm_status::StatusCode;
 use std::{
     cell::OnceCell,
     sync::{
         atomic::{AtomicUsize, Ordering},
+        mpsc::sync_channel,
         Arc, OnceLock,
     },
 };
@@ -74,15 +84,37 @@ pub fn init_native_rayon_pool(threads_per_pool: usize) -> Result<()> {
 ///
 /// Use this to wrap any Move native code path that invokes rayon directly or
 /// via a third-party crate (ark_ec, ark_bls12_381, etc.). The call blocks the
-/// current thread until `op` completes.
-pub fn with_native_rayon<F, R>(op: F) -> R
+/// current thread on a channel `recv` until `op` completes on the native pool.
+///
+/// We deliberately do not use `ThreadPool::install` here. `install`'s
+/// `wait_until` loop is cooperative: if the caller is a `par_exec` rayon
+/// worker, rayon will steal other `par_exec` jobs onto it while the native
+/// work runs. Those stolen jobs can then block on state the caller already
+/// holds (e.g. a writer-preferring per-txn `RwLock` that a sibling worker is
+/// waiting to upgrade), forming a cycle through the caller and deadlocking
+/// block execution. A plain channel `recv` is an OS-level park, so the caller
+/// leaves rayon's steal set entirely until `op` finishes.
+///
+/// Returns [`SafeNativeError::InvariantViolation`] if the native-pool worker
+/// disappears before sending a result (pool dropped, or the spawned closure
+/// panicked). This is not expected in healthy builds.
+pub fn with_native_rayon<F, R>(op: F) -> SafeNativeResult<R>
 where
-    F: FnOnce() -> R + Send,
-    R: Send,
+    F: FnOnce() -> R + Send + 'static,
+    R: Send + 'static,
 {
     PER_CALLER_POOL.with(|cell| {
         let pool = cell.get_or_init(build_pool).clone();
-        pool.install(op)
+        let (tx, rx) = sync_channel(1);
+        pool.spawn(move || {
+            let _ = tx.send(op());
+        });
+        rx.recv().map_err(|_| {
+            SafeNativeError::InvariantViolation(
+                PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
+                    .with_message("native rayon pool worker disappeared".to_string()),
+            )
+        })
     })
 }
 
@@ -90,14 +122,23 @@ where
 mod tests {
     use super::*;
 
+    fn unwrap_ok<T>(r: SafeNativeResult<T>) -> T {
+        match r {
+            Ok(v) => v,
+            Err(_) => panic!("native rayon pool returned error"),
+        }
+    }
+
+    fn current_thread_name() -> String {
+        std::thread::current()
+            .name()
+            .map(|s| s.to_string())
+            .unwrap_or_default()
+    }
+
     #[test]
-    fn install_runs_on_native_pool() {
-        let name = with_native_rayon(|| {
-            std::thread::current()
-                .name()
-                .map(|s| s.to_string())
-                .unwrap_or_default()
-        });
+    fn runs_on_native_pool() {
+        let name = unwrap_ok(with_native_rayon(current_thread_name));
         assert!(
             name.starts_with("native-rayon-"),
             "expected native-rayon-* thread, got {:?}",
@@ -116,17 +157,12 @@ mod tests {
             .unwrap();
 
         let names = outer_pool.install(|| {
-            with_native_rayon(|| {
+            unwrap_ok(with_native_rayon(|| {
                 (0..64)
                     .into_par_iter()
-                    .map(|_| {
-                        std::thread::current()
-                            .name()
-                            .map(|s| s.to_string())
-                            .unwrap_or_default()
-                    })
+                    .map(|_| current_thread_name())
                     .collect::<Vec<_>>()
-            })
+            }))
         });
 
         assert!(
@@ -140,22 +176,8 @@ mod tests {
     fn distinct_caller_threads_get_distinct_pools() {
         // Two threads concurrently entering with_native_rayon must end up on
         // different per-caller pools (different `native-rayon-{id}-*` prefix).
-        let join_a = std::thread::spawn(|| {
-            with_native_rayon(|| {
-                std::thread::current()
-                    .name()
-                    .map(|s| s.to_string())
-                    .unwrap_or_default()
-            })
-        });
-        let join_b = std::thread::spawn(|| {
-            with_native_rayon(|| {
-                std::thread::current()
-                    .name()
-                    .map(|s| s.to_string())
-                    .unwrap_or_default()
-            })
-        });
+        let join_a = std::thread::spawn(|| unwrap_ok(with_native_rayon(current_thread_name)));
+        let join_b = std::thread::spawn(|| unwrap_ok(with_native_rayon(current_thread_name)));
         let name_a = join_a.join().unwrap();
         let name_b = join_b.join().unwrap();
         assert!(name_a.starts_with("native-rayon-"));
@@ -168,5 +190,40 @@ mod tests {
             "expected distinct pool prefixes, got {} vs {}",
             prefix_a, prefix_b
         );
+    }
+
+    /// Regression test for the `install`-based deadlock: while the native work
+    /// runs, a caller that already holds a lock must not work-steal a sibling
+    /// task that would contend for that lock.
+    #[test]
+    fn caller_does_not_work_steal_while_native_runs() {
+        use std::{
+            sync::{Arc, Mutex},
+            time::Duration,
+        };
+
+        let outer = rayon::ThreadPoolBuilder::new()
+            .num_threads(2)
+            .build()
+            .unwrap();
+        let lock = Arc::new(Mutex::new(()));
+
+        outer.install(|| {
+            let guard = lock.lock().unwrap();
+
+            // Sibling job on the outer pool that also wants the lock. With
+            // `install`, the caller would steal this task onto itself while
+            // blocked on the native pool, deadlocking on `guard`.
+            let l = lock.clone();
+            rayon::spawn(move || {
+                let _g = l.lock().unwrap();
+            });
+
+            unwrap_ok(with_native_rayon(|| {
+                std::thread::sleep(Duration::from_millis(50))
+            }));
+
+            drop(guard);
+        });
     }
 }

--- a/aptos-move/framework/natives/src/cryptography/algebra/arithmetics/scalar_mul.rs
+++ b/aptos-move/framework/natives/src/cryptography/algebra/arithmetics/scalar_mul.rs
@@ -233,9 +233,9 @@ macro_rules! ark_msm_internal {
             $proj_double_cost,
             num_elements,
         ))?;
-        let new_element: $element_typ = with_native_rayon(|| {
+        let new_element: $element_typ = with_native_rayon(move || {
             ark_ec::VariableBaseMSM::msm(bases.as_slice(), scalars.as_slice())
-        })
+        })?
         .map_err(|_e| {
             SafeNativeError::abort_with_message(
                 E_SCALAR_MUL_MSM_COMPUTATION_FAILED,

--- a/aptos-move/framework/natives/src/cryptography/algebra/pairing.rs
+++ b/aptos-move/framework/natives/src/cryptography/algebra/pairing.rs
@@ -77,7 +77,7 @@ macro_rules! pairing_internal {
         let g2_element_affine = g2_element.into_affine();
         $context.charge($pairing_gas_cost)?;
         let new_element =
-            with_native_rayon(|| <$pairing>::pairing(g1_element_affine, g2_element_affine)).0;
+            with_native_rayon(move || <$pairing>::pairing(g1_element_affine, g2_element_affine))?.0;
         let new_handle = store_element!($context, new_element)?;
         Ok(smallvec![Value::u64(new_handle as u64)])
     }};
@@ -121,9 +121,10 @@ macro_rules! multi_pairing_internal {
             $multi_pairing_base_gas
                 + $multi_pairing_per_pair_gas * NumArgs::from(num_entries as u64),
         )?;
-        let new_element =
-            with_native_rayon(|| <$pairing>::multi_pairing(g1_elements_affine, g2_elements_affine))
-                .0;
+        let new_element = with_native_rayon(move || {
+            <$pairing>::multi_pairing(g1_elements_affine, g2_elements_affine)
+        })?
+        .0;
         let new_handle = store_element!($context, new_element)?;
         Ok(smallvec![Value::u64(new_handle as u64)])
     }};


### PR DESCRIPTION
## Summary

`with_native_rayon` previously used `ThreadPool::install` to run MSM / pairing work on the per-caller native pool. That's unsafe when the caller is a `par_exec` rayon worker: `install`'s `wait_until` is **cooperative** — while blocked on the native-pool latch, rayon keeps the caller busy by stealing other jobs from its home pool onto it. A stolen job that then blocks on state the caller itself holds (e.g. a writer-preferring per-txn `RwLock` a sibling worker is waiting to upgrade) forms a cycle through the caller and deadlocks block execution.

**Fix:** replace `pool.install(op)` with `pool.spawn(op) + rx.recv()`. A channel `recv` is a real OS park, so the caller leaves rayon's steal set entirely while the native work runs.

- Tightened bounds to `F: ... + 'static`, `R: ... + 'static`. Satisfied at all call sites by adding `move` — they capture owned locals (`Vec<_>`, affine points) that aren't used after the call.
- Return type changed to `SafeNativeResult<R>`. The (unreachable) case of the native worker disappearing surfaces as `InvariantViolation` instead of a panic, matching the rest of `aptos-native-interface`'s conventions.
- Added a regression test that reproduces the old deadlock: the caller holds a `Mutex`, spawns a sibling job that wants it, then enters `with_native_rayon`. Under the old `install`-based implementation this test would hang; it now passes.

### Call sites updated
- `aptos-move/framework/natives/src/cryptography/algebra/arithmetics/scalar_mul.rs` (MSM)
- `aptos-move/framework/natives/src/cryptography/algebra/pairing.rs` (pairing, multi-pairing)

### Tradeoff
The caller is no longer available to help `par_exec` while the native call runs. That's the whole point — the caller being idle is what makes the scheduler state it holds safe to hold across the call. `THREADS_PER_POOL` can be raised if MSM latency is a concern.

## Test plan

- [x] `cargo test -p aptos-native-interface --lib` — all 4 tests pass, including the new `caller_does_not_work_steal_while_native_runs` regression test
- [x] `cargo build -p aptos-native-interface -p aptos-framework-natives`
- [x] `cargo +nightly fmt -p aptos-native-interface -p aptos-framework-natives`
- [ ] CI clippy / full test suite
- [ ] Forge / replay-verify smoke on a pre-existing workload that exercises MSM and pairing natives (BLS12-381 group ops)

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk because it changes core VM/native execution concurrency behavior and modifies on-chain `confidential_asset` logic (governance pause, transfer semantics, proof validation) that can affect transaction validity and safety.
> 
> **Overview**
> Prevents `par_exec` deadlocks by introducing a per-caller-thread rayon pool in `aptos-native-interface` and running rayon-using native work via `spawn` + blocking channel (instead of `ThreadPool::install`), with new VM/node wiring (`ExecutionConfig.native_rayon_thread_per_exec_thread`) to size these pools.
> 
> Updates cryptography natives (MSM/pairing and confidential range proof batch verification registration) to execute inside `with_native_rayon`, and adds regression tests including a stack-overflow/maximum-value-depth PoC test.
> 
> Extends the Move `confidential_asset` framework with **emergency pause** (GlobalConfig V2 + event + governance setter + view), memo length limits, stricter EK identity checks, and adjusts proof/range-proof APIs to use compressed points and streamlined statement return values; updates associated specs/docs/tests.
> 
> Also bumps `aptos-node` version, tweaks QuorumStore defaults, fixes pipeline randomness sending to avoid ordering/execution deadlock, updates release-builder YAML for testnet, and adjusts CI rust setup to install LLVM/clang-21 explicitly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 723a82bcb79b0c5512634c56aab3dc68e3824162. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->