### PR TITLE
[types] Carry hotness inline via WriteSetV1

### DIFF
--- a/execution/executor/src/workflow/do_get_execution_output.rs
+++ b/execution/executor/src/workflow/do_get_execution_output.rs
@@ -156,6 +156,7 @@ impl DoGetExecutionOutput {
         //
         // TODO(HotState): it might be better to do this in AptosVM::execute_single_transaction,
         // but we need to figure out how to properly construct `VMOutput` from block end info.
+        let persist_hotness_in_write_set = parent_state.persist_hotness_in_write_set();
         for (transaction, output) in transactions.iter().zip_eq(transaction_outputs.iter_mut()) {
             if let Transaction::BlockEpilogue(payload) = transaction {
                 assert!(output.status().is_kept(), "Block epilogue must be kept");
@@ -167,6 +168,7 @@ impl DoGetExecutionOutput {
                         .into_iter()
                         .map(|key| (key, HotStateOp::make_hot()))
                         .collect(),
+                    persist_hotness_in_write_set,
                 );
             }
         }

--- a/storage/aptosdb/src/backup/restore_utils.rs
+++ b/storage/aptosdb/src/backup/restore_utils.rs
@@ -261,7 +261,6 @@ pub(crate) fn save_transactions_impl(
             first_version + idx as Version,
             ws,
             &mut ledger_db_batch.write_set_db_batches,
-            /*persist_hotness=*/ false, // TODO(HotState): revisit.
         )?;
     }
 

--- a/storage/aptosdb/src/db/mod.rs
+++ b/storage/aptosdb/src/db/mod.rs
@@ -119,7 +119,6 @@ impl AptosDB {
             env,
             block_cache,
             readonly,
-            hot_state_config.persist_hotness_in_write_set,
         )?;
         let hot_state_kv_db = if !readonly {
             Some(StateKvDb::new(

--- a/storage/aptosdb/src/db_debugger/common/mod.rs
+++ b/storage/aptosdb/src/db_debugger/common/mod.rs
@@ -56,7 +56,6 @@ impl DbDir {
             env,
             block_cache,
             /*readonly=*/ true,
-            /*persist_write_set_hotness=*/ false,
         )
     }
 }

--- a/storage/aptosdb/src/ledger_db/mod.rs
+++ b/storage/aptosdb/src/ledger_db/mod.rs
@@ -115,7 +115,6 @@ impl LedgerDb {
         env: Option<&Env>,
         block_cache: Option<&Cache>,
         readonly: bool,
-        persist_write_set_hotness: bool,
     ) -> Result<Self> {
         let ledger_metadata_db_path = Self::metadata_db_path(db_root_path.as_ref());
         let ledger_metadata_db = Arc::new(Self::open_rocksdb(
@@ -225,20 +224,17 @@ impl LedgerDb {
                 )));
             });
             s.spawn(|_| {
-                write_set_db = Some(WriteSetDb::new(
-                    Arc::new(
-                        Self::open_rocksdb(
-                            ledger_db_folder.join(WRITE_SET_DB_NAME),
-                            WRITE_SET_DB_NAME,
-                            &ledger_db_config,
-                            env,
-                            block_cache,
-                            readonly,
-                        )
-                        .unwrap(),
-                    ),
-                    persist_write_set_hotness,
-                ));
+                write_set_db = Some(WriteSetDb::new(Arc::new(
+                    Self::open_rocksdb(
+                        ledger_db_folder.join(WRITE_SET_DB_NAME),
+                        WRITE_SET_DB_NAME,
+                        &ledger_db_config,
+                        env,
+                        block_cache,
+                        readonly,
+                    )
+                    .unwrap(),
+                )));
             });
         });
 
@@ -266,7 +262,6 @@ impl LedgerDb {
             None,
             None,
             /*readonly=*/ false,
-            /*persist_write_set_hotness=*/ false,
         )?;
         let cp_ledger_db_folder = cp_root_path.as_ref().join(LEDGER_DB_FOLDER_NAME);
 

--- a/storage/aptosdb/src/ledger_db/write_set_db.rs
+++ b/storage/aptosdb/src/ledger_db/write_set_db.rs
@@ -5,15 +5,13 @@ use crate::{
     metrics::OTHER_TIMERS_SECONDS,
     schema::{
         db_metadata::{DbMetadataKey, DbMetadataSchema, DbMetadataValue},
-        write_set::{encode_write_set, WriteSetSchema},
-        WRITE_SET_CF_NAME,
+        write_set::WriteSetSchema,
     },
     utils::iterators::ExpectContinuousVersions,
 };
 use aptos_metrics_core::TimerHelper;
 use aptos_schemadb::{
     batch::{SchemaBatch, WriteBatch},
-    schema::KeyCodec,
     ReadOptions, DB,
 };
 use aptos_storage_interface::{db_ensure as ensure, AptosDbError, Result};
@@ -27,15 +25,11 @@ use std::{path::Path, sync::Arc};
 #[derive(Debug)]
 pub(crate) struct WriteSetDb {
     db: Arc<DB>,
-    persist_hotness: bool,
 }
 
 impl WriteSetDb {
-    pub(super) fn new(db: Arc<DB>, persist_hotness: bool) -> Self {
-        Self {
-            db,
-            persist_hotness,
-        }
+    pub(super) fn new(db: Arc<DB>) -> Self {
+        Self { db }
     }
 
     pub(super) fn create_checkpoint(&self, path: impl AsRef<Path>) -> Result<()> {
@@ -133,7 +127,6 @@ impl WriteSetDb {
     ) -> Result<()> {
         let _timer = OTHER_TIMERS_SECONDS.timer_with(&["commit_write_sets"]);
 
-        let persist_hotness = self.persist_hotness;
         let chunk_size = transaction_outputs.len() / 4 + 1;
         let batches = transaction_outputs
             .par_chunks(chunk_size)
@@ -147,7 +140,6 @@ impl WriteSetDb {
                         chunk_first_version + i as Version,
                         txn_out.write_set(),
                         &mut batch,
-                        persist_hotness,
                     )
                 })?;
                 Ok(batch)
@@ -168,20 +160,8 @@ impl WriteSetDb {
         version: Version,
         write_set: &WriteSet,
         batch: &mut impl WriteBatch,
-        persist_hotness: bool,
     ) -> Result<()> {
-        if persist_hotness {
-            // Bypass `ValueCodec::encode_value` (whose signature doesn't allow passing the
-            // flag) and encode via `encode_write_set` + `raw_put` instead.
-            let key_bytes = <Version as KeyCodec<WriteSetSchema>>::encode_key(&version)?;
-            let value_bytes = encode_write_set(write_set, /*persist_hotness=*/ true)?;
-            batch
-                .stats()
-                .put(WRITE_SET_CF_NAME, key_bytes.len() + value_bytes.len());
-            batch.raw_put(WRITE_SET_CF_NAME, key_bytes, value_bytes)
-        } else {
-            batch.put::<WriteSetSchema>(&version, write_set)
-        }
+        batch.put::<WriteSetSchema>(&version, write_set)
     }
 
     /// Deletes the write sets between a range of version in [begin, end).

--- a/storage/aptosdb/src/schema/write_set/mod.rs
+++ b/storage/aptosdb/src/schema/write_set/mod.rs
@@ -19,14 +19,9 @@ use aptos_schemadb::{
     define_schema,
     schema::{KeyCodec, ValueCodec},
 };
-use aptos_types::{
-    state_store::state_key::StateKey,
-    transaction::Version,
-    write_set::{HotStateOp, ValueWriteSet, WriteSet, WriteSetV0},
-};
+use aptos_types::{transaction::Version, write_set::WriteSet};
 use byteorder::{BigEndian, ReadBytesExt};
-use serde::{Deserialize, Serialize};
-use std::{collections::BTreeSet, mem::size_of};
+use std::mem::size_of;
 
 define_schema!(WriteSetSchema, Version, WriteSet, WRITE_SET_CF_NAME);
 
@@ -41,60 +36,13 @@ impl KeyCodec<WriteSetSchema> for Version {
     }
 }
 
-/// Storage-only serialization format for `WriteSet`. Separate from `ValueWriteSet` so that the
-/// `BCSCryptoHash` (which goes through `WriteSet::Serialize` → `ValueWriteSet`) is not affected
-/// for now.
-#[derive(Serialize, Deserialize)]
-enum PersistedWriteSet {
-    /// Legacy format: identical BCS layout to `ValueWriteSet::V0`.
-    V0(WriteSetV0),
-    /// Extended format that also persists the set of hot state keys.
-    V1 {
-        value: WriteSetV0,
-        hotness: BTreeSet<StateKey>,
-    },
-}
-
-/// Encode a `WriteSet` for storage. When `persist_hotness` is true, produces the V1 format
-/// (which includes the set of hot state keys); otherwise produces the legacy V0 format
-/// (byte-identical to `bcs::to_bytes(write_set)`).
-pub(crate) fn encode_write_set(
-    write_set: &WriteSet,
-    persist_hotness: bool,
-) -> bcs::Result<Vec<u8>> {
-    if persist_hotness {
-        let persisted = PersistedWriteSet::V1 {
-            value: write_set.as_v0().clone(),
-            hotness: write_set.hotness_keys().cloned().collect(),
-        };
-        bcs::to_bytes(&persisted)
-    } else {
-        // Delegates to WriteSet::Serialize → ValueWriteSet → V0 layout.
-        bcs::to_bytes(write_set)
-    }
-}
-
-/// Decode a `WriteSet` from storage, handling both V0 (legacy) and V1 (with hotness) formats.
-fn decode_write_set(data: &[u8]) -> bcs::Result<WriteSet> {
-    match bcs::from_bytes(data)? {
-        PersistedWriteSet::V0(ws_v0) => Ok(WriteSet::new_from_value(ValueWriteSet::V0(ws_v0))),
-        PersistedWriteSet::V1 { value, hotness } => Ok(WriteSet::new_from_value_with_hotness(
-            ValueWriteSet::V0(value),
-            hotness
-                .into_iter()
-                .map(|key| (key, HotStateOp::make_hot()))
-                .collect(),
-        )),
-    }
-}
-
 impl ValueCodec<WriteSetSchema> for WriteSet {
     fn encode_value(&self) -> Result<Vec<u8>> {
         bcs::to_bytes(self).map_err(Into::into)
     }
 
     fn decode_value(data: &[u8]) -> Result<Self> {
-        decode_write_set(data).map_err(Into::into)
+        bcs::from_bytes(data).map_err(Into::into)
     }
 }
 

--- a/storage/aptosdb/src/schema/write_set/test.rs
+++ b/storage/aptosdb/src/schema/write_set/test.rs
@@ -3,9 +3,7 @@
 
 use super::*;
 use aptos_schemadb::{schema::fuzzing::assert_encode_decode, test_no_panic_decoding};
-use aptos_types::write_set::WriteOp;
 use proptest::prelude::*;
-use std::collections::BTreeMap;
 
 proptest! {
     #[test]
@@ -18,74 +16,3 @@ proptest! {
 }
 
 test_no_panic_decoding!(WriteSetSchema);
-
-/// Data serialized with the old format (`bcs::to_bytes` via the custom `WriteSet::Serialize`,
-/// which only serializes the `value` field) must decode correctly through `decode_write_set`.
-#[test]
-fn test_decode_legacy_format() {
-    let ws = WriteSet::new(vec![
-        (
-            StateKey::raw(b"key1"),
-            WriteOp::legacy_creation(b"val1".to_vec().into()),
-        ),
-        (
-            StateKey::raw(b"key2"),
-            WriteOp::legacy_modification(b"val2".to_vec().into()),
-        ),
-    ])
-    .unwrap();
-
-    // Old encode path: WriteSet::Serialize → ValueWriteSet::V0
-    let old_bytes = bcs::to_bytes(&ws).unwrap();
-    let decoded = decode_write_set(&old_bytes).unwrap();
-
-    assert_eq!(decoded.as_v0(), ws.as_v0());
-    assert_eq!(decoded.hotness_keys().count(), 0);
-}
-
-/// Roundtrip: a `WriteSet` with hotness, encoded via `encode_write_set(..., true)` and decoded
-/// via `decode_write_set`, must preserve both the value write ops and the set of hot keys.
-#[test]
-fn test_roundtrip_with_hotness() {
-    let mut ws = WriteSet::new(vec![(
-        StateKey::raw(b"a"),
-        WriteOp::legacy_creation(b"v".to_vec().into()),
-    )])
-    .unwrap();
-
-    let hot_keys: BTreeMap<StateKey, HotStateOp> = [
-        (StateKey::raw(b"hot1"), HotStateOp::make_hot()),
-        (StateKey::raw(b"hot2"), HotStateOp::make_hot()),
-    ]
-    .into_iter()
-    .collect();
-    ws.add_hotness(hot_keys);
-
-    let encoded = encode_write_set(&ws, true).unwrap();
-    let decoded = decode_write_set(&encoded).unwrap();
-
-    assert_eq!(decoded.as_v0(), ws.as_v0());
-    assert_eq!(
-        decoded.hotness_keys().collect::<BTreeSet<_>>(),
-        ws.hotness_keys().collect::<BTreeSet<_>>(),
-    );
-}
-
-/// `encode_write_set(ws, false)` must produce byte-identical output to the old
-/// `bcs::to_bytes(&ws)` path. This guarantees `PersistedWriteSet::V0` has the same BCS layout
-/// as `ValueWriteSet::V0`.
-#[test]
-fn test_v0_byte_identity() {
-    let ws = WriteSet::new(vec![
-        (
-            StateKey::raw(b"x"),
-            WriteOp::legacy_creation(b"y".to_vec().into()),
-        ),
-        (StateKey::raw(b"z"), WriteOp::legacy_deletion()),
-    ])
-    .unwrap();
-
-    let old_bytes = bcs::to_bytes(&ws).unwrap();
-    let new_bytes = encode_write_set(&ws, false).unwrap();
-    assert_eq!(old_bytes, new_bytes);
-}

--- a/storage/storage-interface/src/state_store/state.rs
+++ b/storage/storage-interface/src/state_store/state.rs
@@ -139,6 +139,10 @@ impl State {
         self.usage
     }
 
+    pub fn persist_hotness_in_write_set(&self) -> bool {
+        self.hot_state_config.persist_hotness_in_write_set
+    }
+
     pub fn shards(&self) -> &[MapLayer<HashValue, StateSlot>; NUM_STATE_SHARDS] {
         &self.shards
     }

--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -2199,8 +2199,12 @@ impl TransactionOutput {
         self.write_set.state_update_refs()
     }
 
-    pub fn add_hotness(&mut self, hotness: BTreeMap<StateKey, HotStateOp>) {
-        self.write_set.add_hotness(hotness);
+    pub fn add_hotness(
+        &mut self,
+        hotness: BTreeMap<StateKey, HotStateOp>,
+        persist_in_write_set: bool,
+    ) {
+        self.write_set.add_hotness(hotness, persist_in_write_set);
     }
 }
 

--- a/types/src/unit_tests/write_set_test.rs
+++ b/types/src/unit_tests/write_set_test.rs
@@ -1,13 +1,50 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-use crate::write_set::WriteSet;
+use crate::{
+    state_store::state_key::StateKey,
+    write_set::{HotStateOp, WriteOp, WriteSet},
+};
 use bcs::test_helpers::assert_canonical_encode_decode;
 use proptest::prelude::*;
+use std::collections::BTreeMap;
 
 proptest! {
     #[test]
     fn write_set_roundtrip_canonical_serialization(write_set in any::<WriteSet>()) {
         assert_canonical_encode_decode(write_set);
     }
+}
+
+/// V1 (hotness inline) survives standard serde, while V0 with side-channel hotness drops it
+/// — both are intentional and exercised here.
+#[test]
+fn write_set_v1_carries_hotness_through_serde() {
+    let hot_keys: BTreeMap<StateKey, HotStateOp> = [
+        (StateKey::raw(b"hot1"), HotStateOp::make_hot()),
+        (StateKey::raw(b"hot2"), HotStateOp::make_hot()),
+    ]
+    .into_iter()
+    .collect();
+
+    // V1: hotness inline → preserved by serde.
+    let mut ws_v1 = WriteSet::new(vec![(
+        StateKey::raw(b"a"),
+        WriteOp::legacy_creation(b"v".to_vec().into()),
+    )])
+    .unwrap();
+    ws_v1.add_hotness(hot_keys.clone(), /*persist_in_write_set=*/ true);
+    let decoded: WriteSet = bcs::from_bytes(&bcs::to_bytes(&ws_v1).unwrap()).unwrap();
+    assert_eq!(decoded.hotness_keys().count(), 2);
+    assert_eq!(decoded, ws_v1);
+
+    // V0 + side-channel hotness: dropped by serde (current behavior on testnet/mainnet).
+    let mut ws_v0 = WriteSet::new(vec![(
+        StateKey::raw(b"a"),
+        WriteOp::legacy_creation(b"v".to_vec().into()),
+    )])
+    .unwrap();
+    ws_v0.add_hotness(hot_keys, /*persist_in_write_set=*/ false);
+    let decoded: WriteSet = bcs::from_bytes(&bcs::to_bytes(&ws_v0).unwrap()).unwrap();
+    assert_eq!(decoded.hotness_keys().count(), 0);
 }

--- a/types/src/write_set.rs
+++ b/types/src/write_set.rs
@@ -505,6 +505,10 @@ impl Debug for WriteOp {
 #[serde(rename = "WriteSet")]
 pub enum ValueWriteSet {
     V0(WriteSetV0),
+    /// V1 carries hotness inline, so it travels via standard serde and reaches
+    /// nodes catching up via apply-outputs state-sync. Produced when
+    /// `HotStateConfig::persist_hotness_in_write_set` is enabled.
+    V1(WriteSetV1),
 }
 
 impl Default for ValueWriteSet {
@@ -513,8 +517,38 @@ impl Default for ValueWriteSet {
     }
 }
 
+impl ValueWriteSet {
+    fn write_ops(&self) -> &BTreeMap<StateKey, WriteOp> {
+        match self {
+            ValueWriteSet::V0(v0) => &v0.0.write_set,
+            ValueWriteSet::V1(v1) => &v1.write_set,
+        }
+    }
+
+    fn write_ops_mut(&mut self) -> &mut BTreeMap<StateKey, WriteOp> {
+        match self {
+            ValueWriteSet::V0(v0) => &mut v0.0.write_set,
+            ValueWriteSet::V1(v1) => &mut v1.write_set,
+        }
+    }
+
+    fn into_write_ops(self) -> BTreeMap<StateKey, WriteOp> {
+        match self {
+            ValueWriteSet::V0(v0) => v0.0.write_set,
+            ValueWriteSet::V1(v1) => v1.write_set,
+        }
+    }
+
+    fn inline_hotness(&self) -> Option<&BTreeMap<StateKey, HotStateOp>> {
+        match self {
+            ValueWriteSet::V0(_) => None,
+            ValueWriteSet::V1(v1) => Some(&v1.hotness),
+        }
+    }
+}
+
 // TODO(HotState): revisit when the hot state is deterministic.
-/// Represents a hotness only change, not persisted for now.
+/// Represents a hotness only change.
 #[derive(Clone, Eq, PartialEq)]
 pub struct HotStateOp(BaseStateOp);
 
@@ -541,6 +575,37 @@ impl Debug for HotStateOp {
             Creation(_) | Modification(_) | Deletion(_) => {
                 unreachable!("malformed hot state op")
             },
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename = "HotStateOp")]
+enum PersistedHotStateOp {
+    MakeHot,
+}
+
+impl Serialize for HotStateOp {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match &self.0 {
+            BaseStateOp::MakeHot => PersistedHotStateOp::MakeHot.serialize(serializer),
+            BaseStateOp::Creation(_) | BaseStateOp::Modification(_) | BaseStateOp::Deletion(_) => {
+                unreachable!("malformed hot state op")
+            },
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for HotStateOp {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        match PersistedHotStateOp::deserialize(deserializer)? {
+            PersistedHotStateOp::MakeHot => Ok(Self(BaseStateOp::MakeHot)),
         }
     }
 }
@@ -576,26 +641,22 @@ impl<'de> Deserialize<'de> for WriteSet {
 }
 
 impl WriteSet {
-    fn into_v0(self) -> WriteSetV0 {
-        match self.value {
-            ValueWriteSet::V0(ws) => ws,
-        }
-    }
-
+    /// Returns the V0 inner. Panics if the WriteSet is V1.
     pub fn as_v0(&self) -> &WriteSetV0 {
         match &self.value {
             ValueWriteSet::V0(ws) => ws,
-        }
-    }
-
-    fn as_v0_mut(&mut self) -> &mut WriteSetV0 {
-        match &mut self.value {
-            ValueWriteSet::V0(ws) => ws,
+            ValueWriteSet::V1(_) => unreachable!("as_v0 called on V1 write set"),
         }
     }
 
     pub fn into_mut(self) -> WriteSetMut {
-        self.into_v0().0
+        WriteSetMut {
+            write_set: self.value.into_write_ops(),
+        }
+    }
+
+    fn hotness_map(&self) -> &BTreeMap<StateKey, HotStateOp> {
+        self.value.inline_hotness().unwrap_or(&self.hotness)
     }
 
     pub fn new_from_value(value: ValueWriteSet) -> Self {
@@ -629,7 +690,8 @@ impl WriteSet {
     }
 
     pub fn state_update_refs(&self) -> impl Iterator<Item = (&StateKey, Option<&StateValue>)> + '_ {
-        self.as_v0()
+        self.value
+            .write_ops()
             .iter()
             .map(|(key, op)| (key, op.as_state_value_opt()))
     }
@@ -642,43 +704,58 @@ impl WriteSet {
     }
 
     pub fn update_total_supply(&mut self, value: u128) {
-        self.as_v0_mut().update_total_supply(value);
+        let write_set = self.value.write_ops_mut();
+        assert!(write_set
+            .insert(
+                TOTAL_SUPPLY_STATE_KEY.clone(),
+                WriteOp::legacy_modification(bcs::to_bytes(&value).unwrap().into())
+            )
+            .is_some());
     }
 
     pub fn get_write_op(&self, state_key: &StateKey) -> Option<&WriteOp> {
-        self.as_v0().get(state_key)
+        self.value.write_ops().get(state_key)
     }
 
     pub fn get_total_supply(&self) -> Option<u128> {
-        self.as_v0().get_total_supply()
+        let value = self
+            .value
+            .write_ops()
+            .get(&TOTAL_SUPPLY_STATE_KEY)
+            .and_then(|op| op.bytes())
+            .map(|bytes| bcs::from_bytes::<u128>(bytes));
+        value.transpose().map_err(anyhow::Error::msg).unwrap()
     }
 
     pub fn is_empty(&self) -> bool {
-        self.as_v0().is_empty() && self.hotness.is_empty()
+        self.value.write_ops().is_empty() && self.hotness_map().is_empty()
     }
 
     pub fn expect_into_write_op_iter(self) -> impl IntoIterator<Item = (StateKey, WriteOp)> {
-        self.into_v0().0.write_set
+        self.value.into_write_ops()
     }
 
     pub fn expect_write_op_iter(&self) -> impl Iterator<Item = (&StateKey, &WriteOp)> {
-        self.as_v0().0.write_set.iter()
+        self.value.write_ops().iter()
     }
 
     pub fn write_op_iter(&self) -> impl Iterator<Item = (&StateKey, &WriteOp)> {
-        self.as_v0().iter()
+        self.value.write_ops().iter()
     }
 
     pub fn into_write_op_iter(self) -> impl Iterator<Item = (StateKey, WriteOp)> {
-        self.into_v0().into_write_op_iter()
+        self.value.into_write_ops().into_iter()
     }
 
     pub fn base_op_iter(&self) -> impl Iterator<Item = (&StateKey, &BaseStateOp)> {
-        self.as_v0()
+        self.value
+            .write_ops()
             .iter()
             .map(|(key, op)| (key, op.as_base_op()))
             .merge_join_by(
-                self.hotness.iter().map(|(key, op)| (key, op.as_base_op())),
+                self.hotness_map()
+                    .iter()
+                    .map(|(key, op)| (key, op.as_base_op())),
                 |a, b| a.0.cmp(b.0),
             )
             .map(|entry| {
@@ -693,15 +770,29 @@ impl WriteSet {
     }
 
     pub fn hotness_keys(&self) -> impl Iterator<Item = &StateKey> {
-        self.hotness.keys()
+        self.hotness_map().keys()
     }
 
-    pub fn add_hotness(&mut self, hotness: BTreeMap<StateKey, HotStateOp>) {
+    /// When `persist_in_write_set` is true, promote the value to V1 with hotness inline so that
+    /// state-sync (apply-outputs) carries hotness through standard serde. Otherwise hotness is
+    /// stored in the side field, which is not serialized.
+    pub fn add_hotness(
+        &mut self,
+        hotness: BTreeMap<StateKey, HotStateOp>,
+        persist_in_write_set: bool,
+    ) {
         assert!(
-            self.hotness.is_empty(),
+            self.hotness.is_empty() && self.value.inline_hotness().is_none(),
             "hotness should only be initialized once."
         );
-        self.hotness = hotness;
+        if persist_in_write_set {
+            // Take ownership of the existing value so we can move its write_ops into V1.
+            let prev = std::mem::take(&mut self.value);
+            let write_set = prev.into_write_ops();
+            self.value = ValueWriteSet::V1(WriteSetV1 { write_set, hotness });
+        } else {
+            self.hotness = hotness;
+        }
     }
 }
 
@@ -715,11 +806,6 @@ pub struct WriteSetV0(WriteSetMut);
 
 impl WriteSetV0 {
     #[inline]
-    fn is_empty(&self) -> bool {
-        self.0.is_empty()
-    }
-
-    #[inline]
     pub fn iter(&self) -> btree_map::Iter<'_, StateKey, WriteOp> {
         self.0.write_set.iter()
     }
@@ -732,30 +818,16 @@ impl WriteSetV0 {
     pub fn get(&self, key: &StateKey) -> Option<&WriteOp> {
         self.0.get(key)
     }
+}
 
-    fn get_total_supply(&self) -> Option<u128> {
-        let value = self
-            .0
-            .get(&TOTAL_SUPPLY_STATE_KEY)
-            .and_then(|op| op.bytes())
-            .map(|bytes| bcs::from_bytes::<u128>(bytes));
-        value.transpose().map_err(anyhow::Error::msg).unwrap()
-    }
-
-    // This is a temporary method to update the total supply in the write set.
-    // TODO: get rid of this func() and use WriteSetMut instead; for that we need to change
-    //       VM execution such that to 'TransactionOutput' is materialized after updating
-    //       total_supply.
-    fn update_total_supply(&mut self, value: u128) {
-        assert!(self
-            .0
-            .write_set
-            .insert(
-                TOTAL_SUPPLY_STATE_KEY.clone(),
-                WriteOp::legacy_modification(bcs::to_bytes(&value).unwrap().into())
-            )
-            .is_some());
-    }
+/// V1 of the on-wire write set: like V0, but also carries the hot state promotions inline so
+/// they survive standard serde and reach catching-up nodes via state-sync.
+#[derive(
+    BCSCryptoHash, Clone, CryptoHasher, Debug, Default, Eq, PartialEq, Serialize, Deserialize,
+)]
+pub struct WriteSetV1 {
+    write_set: BTreeMap<StateKey, WriteOp>,
+    hotness: BTreeMap<StateKey, HotStateOp>,
 }
 
 /// A mutable version of `WriteSet`.


### PR DESCRIPTION

`WriteSet::Serialize` only emits the value field, so hotness
promotions added by block epilogues never reach a node catching
up via apply-outputs state-sync. Today this is masked because
the side `hotness` field is not folded into `TransactionInfo`,
but it blocks running hot state end-to-end on devnet, and the
side-field workaround stops working once the epilogue produces
its own hotness (which cannot live in the epilogue payload due
to a circular dependency).

Introduce `ValueWriteSet::V1(WriteSetV1)` carrying the hotness
map alongside the write ops. When
`HotStateConfig::persist_hotness_in_write_set` is on,
`add_hotness` promotes the value to V1 so hotness travels via
standard serde; when off, hotness still goes to the side field
and behavior is unchanged.

V0 BCS layout is byte-identical, so testnet/mainnet
`TransactionInfo` hashes are unaffected. Note that the flag is
now consensus-relevant — V1 changes the hash, so all validators
on the same chain must agree on it. Devnet flips it on
uniformly; testnet/mainnet stay off.

The custom storage-side encoding in \`write_set_db\` is no longer
needed and is removed; \`WriteSetSchema\` goes back to plain bcs
serde.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
