### PR TITLE
[block-executor] Run workers on std::thread::scope, not rayon

### DIFF
--- a/aptos-move/block-executor/src/executor.rs
+++ b/aptos-move/block-executor/src/executor.rs
@@ -102,6 +102,11 @@ pub struct BlockExecutor<T, E, S, L, TP, A> {
     // Number of active concurrent tasks, corresponding to the maximum number of rayon
     // threads that may be concurrently participating in parallel execution.
     config: BlockExecutorConfig,
+    // Retained for API compatibility with callers (aptos-vm, sharded exec, tests)
+    // that construct and pass it. Block-STM itself no longer dispatches work
+    // onto this pool; workers run on `std::thread::scope` — see the deadlock
+    // note on the scope sites below.
+    #[allow(dead_code)]
     executor_thread_pool: Arc<rayon::ThreadPool>,
     transaction_commit_hook: Option<L>,
     phantom: PhantomData<fn() -> (T, E, S, L, TP, A)>,
@@ -1848,9 +1853,17 @@ where
         let timer = RAYON_EXECUTION_SECONDS.start_timer();
         let worker_ids: Vec<u32> = (0..num_workers).collect();
         let maybe_executor = ExplicitSyncWrapper::new(None);
-        self.executor_thread_pool.scope(|s| {
+        // Block-STM workers run as plain OS threads, not rayon workers. This
+        // is deliberate: a rayon worker that enters a native calling
+        // `par_iter` / `rayon::scope` (transitively via ark-ec / ark-ff etc.)
+        // will have rayon work-steal sibling `worker_loop` tasks onto it via
+        // `WorkerThread::wait_until_cold`. Combined with writer-preferring
+        // per-txn RwLocks, that closes into a deadlock. Plain `std::thread`
+        // workers are not part of any rayon registry, so rayon cannot steal
+        // block-executor jobs onto them.
+        std::thread::scope(|s| {
             for worker_id in &worker_ids {
-                s.spawn(|_| {
+                s.spawn(|| {
                     let environment = module_cache_manager_guard.environment();
                     let executor = {
                         let _init_timer = VM_INIT_SECONDS.start_timer();
@@ -2018,9 +2031,11 @@ where
             worker_ids.len() as u32,
         );
 
-        self.executor_thread_pool.scope(|s| {
+        // See BlockSTMv2 site above for why we use `std::thread::scope` here
+        // rather than the rayon pool.
+        std::thread::scope(|s| {
             for worker_id in &worker_ids {
-                s.spawn(|_| {
+                s.spawn(|| {
                     let environment = module_cache_manager_guard.environment();
                     let executor = {
                         let _init_timer = VM_INIT_SECONDS.start_timer();


### PR DESCRIPTION
## Summary

Cherry-pick of the main-branch structural fix for the rayon deadlock observed in `par_exec`, targeted at `aptos-release-v1.44`. Complements PR #19615 (`with_native_rayon` hotfix) which only wraps the natives we know about.

Block-STM worker loops previously ran under `rayon::ThreadPool::scope`. When a worker entered a native that transitively called `par_iter` / `rayon::scope` (e.g. `ark_ff::batch_inversion` inside `algebra::hash_to_structure::hash_to_internal`, which is **not** wrapped by `with_native_rayon`), rayon would work-steal sibling `worker_loop` tasks onto that thread. Combined with writer-preferring per-txn `RwLock`s in the scheduler, that closed into a deadlock (stack rooted at `Scheduler::never_executed -> RawRwLock::lock_shared` under `rayon_core::WorkerThread::wait_until_cold`).

Switching the two scope sites in `executor.rs` to `std::thread::scope` takes Block-STM workers out of any rayon registry, so no rayon job can be stolen onto a block-executor thread. This fixes the class of deadlock structurally, independent of which natives internally use rayon — including natives not covered by `with_native_rayon`.

- 1 file changed, 19 insertions(+), 4 deletions(-)
- `Arc<rayon::ThreadPool>` field retained on `BlockExecutor` for API compatibility with `aptos-vm` / sharded executor / tests, marked `#[allow(dead_code)]`.
- `std::thread::scope` propagates panics and enforces borrow scoping identically to `rayon::scope`.

## Test plan

- [x] `cargo check -p aptos-block-executor` (against v1.44 base)
- [x] `cargo test -p aptos-block-executor --lib` — 252 passed (verified on main-based branch; same code)
- [ ] Forge smoke / load run on the release build
- [ ] Reproducer for the `hash_to_structure` deadlock no longer hangs

## Notes

Companion to #19615. With this change, the `with_native_rayon` wrapper is no longer strictly required for correctness (no caller of a rayon-using native is itself a rayon worker), but we should keep it in v1.44 as belt-and-suspenders.


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the threading model for Block-STM worker execution to avoid a rayon work-stealing deadlock; while scoped threads should be behaviorally similar, concurrency changes here can surface new scheduling/performance issues or edge-case panics.
> 
> **Overview**
> Switches Block-STM (v1 and v2) worker spawning from `rayon::ThreadPool::scope` to `std::thread::scope` so worker threads are not part of rayon’s registry, preventing rayon work-stealing from pulling sibling `worker_loop` jobs onto threads that enter rayon-using natives (a deadlock scenario).
> 
> Keeps the `executor_thread_pool: Arc<rayon::ThreadPool>` field on `BlockExecutor` for API compatibility, marking it `#[allow(dead_code)]`, and adds inline documentation explaining the deadlock rationale at both scope sites.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4ecc748d806344c358649449dfcae8351153c10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->