### PR TITLE
[time] use std helpers in MockTimeService

### DIFF
--- a/crates/aptos-time-service/src/mock.rs
+++ b/crates/aptos-time-service/src/mock.rs
@@ -14,13 +14,6 @@ use std::{
     time::{Duration, Instant},
 };
 
-/// TODO(philiphayes): Use `Duration::MAX` once it stabilizes.
-#[inline]
-#[allow(clippy::arithmetic_side_effects)]
-fn duration_max() -> Duration {
-    Duration::new(u64::MAX, 1_000_000_000 - 1)
-}
-
 /// Each waiter in the pending queue has a unique index to distinguish waiters
 /// with the same deadline.
 type SleepIndex = usize;
@@ -100,7 +93,7 @@ impl MockTimeService {
 
     /// Create a new `MockTimeService` that will auto advance forever.
     pub fn new_auto_advance() -> Self {
-        Self::new_auto_advance_for(duration_max())
+        Self::new_auto_advance_for(Duration::MAX)
     }
 
     /// Create a new `MockTimeService` that will auto advance until the simulation
@@ -312,11 +305,7 @@ impl Inner {
 
     // Unregister and return the next waiter with the earliest deadline.
     fn unregister_min_sleep(&mut self) -> Option<((Duration, SleepIndex), Option<Waker>)> {
-        // TODO(philiphayes): use `BTreeMap::pop_first()` when that stabilizes.
-        let (deadline, index) = self.pending.keys().next()?;
-        let deadline = *deadline;
-        let index = *index;
-        self.pending.remove_entry(&(deadline, index))
+        self.pending.pop_first()
     }
 
     // Wake up the next waiter with the earliest deadline and return the wake


### PR DESCRIPTION
Replace older compatibility helpers with Duration::MAX and BTreeMap::pop_first().

This keeps behavior unchanged and simplifies the implementation.

## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that swaps custom compatibility helpers for standard-library APIs; behavioral changes are unlikely but depend on Rust/MSRV support for `Duration::MAX` and `BTreeMap::pop_first()`.
> 
> **Overview**
> Simplifies `MockTimeService` by removing a custom "max duration" helper and using `Duration::MAX` for `new_auto_advance()`.
> 
> Replaces the manual "find min key then remove" logic in `unregister_min_sleep()` with `BTreeMap::pop_first()`, keeping the pending-sleep wake ordering the same while reducing boilerplate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8778aafeb3398015c6a7fe17514341e80754fc34. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->