### PR TITLE
[storage] Gate KV restore on JMT checks

### DIFF
--- a/storage/aptosdb/src/state_restore/mod.rs
+++ b/storage/aptosdb/src/state_restore/mod.rs
@@ -230,22 +230,56 @@ impl<K: Key + CryptoHash + Hash + Eq, V: Value> StateSnapshotReceiver<K, V>
                 .add_chunk(chunk.clone())
         };
 
-        let tree_fn = || {
-            let _timer = OTHER_TIMERS_SECONDS.timer_with(&["jmt_add_chunk"]);
-            self.tree_restore
-                .lock()
-                .as_mut()
-                .unwrap()
-                .add_chunk_impl(chunk.iter().map(|(k, v)| (k, v.hash())).collect(), proof)
-        };
         match self.restore_mode {
             StateSnapshotRestoreMode::KvOnly => kv_fn()?,
-            StateSnapshotRestoreMode::TreeOnly => tree_fn()?,
+            StateSnapshotRestoreMode::TreeOnly => {
+                let _timer = OTHER_TIMERS_SECONDS.timer_with(&["jmt_add_chunk"]);
+                let mut tree = self.tree_restore.lock();
+                let tree = tree.as_mut().unwrap();
+                // No dependent KV; pass JMT's own progress so the prefix walk is a no-op.
+                let kv_progress = tree.previous_key_hash();
+                if tree.prepare_chunk(
+                    chunk.iter().map(|(k, v)| (k, v.hash())).collect(),
+                    proof,
+                    kv_progress,
+                )? {
+                    tree.commit_prepared()?;
+                }
+            },
             StateSnapshotRestoreMode::Default => {
-                // We run kv_fn with TreeOnly to restore the usage of DB
-                let (r1, r2) = IO_POOL.join(kv_fn, tree_fn);
-                r1?;
-                r2?;
+                // `prepare_chunk` verifies the entire chunk against the expected root and
+                // the JMT-stored leaves (catching wrong values and missing keys when the
+                // JMT is ahead of the KV after a partial crash), so run it before any DB
+                // write.
+                let kv_progress = self
+                    .kv_restore
+                    .lock()
+                    .as_ref()
+                    .unwrap()
+                    .previous_key_hash()?;
+                let needs_commit = {
+                    let _timer = OTHER_TIMERS_SECONDS.timer_with(&["jmt_prepare_chunk"]);
+                    self.tree_restore.lock().as_mut().unwrap().prepare_chunk(
+                        chunk.iter().map(|(k, v)| (k, v.hash())).collect(),
+                        proof,
+                        kv_progress,
+                    )?
+                };
+                if needs_commit {
+                    let tree_commit_fn = || {
+                        let _timer = OTHER_TIMERS_SECONDS.timer_with(&["jmt_commit_chunk"]);
+                        self.tree_restore.lock().as_mut().unwrap().commit_prepared()
+                    };
+                    let (r1, r2) = IO_POOL.join(kv_fn, tree_commit_fn);
+                    r1?;
+                    r2?;
+                } else {
+                    // The chunk added nothing new to the JMT — it was already covered by
+                    // the rightmost stored leaf, e.g. KV catch-up after a partial crash.
+                    // The prefix walk above already verified the chunk's contents match,
+                    // so the KV writes are safe.
+                    kv_fn()?;
+                }
             },
         }
 

--- a/storage/aptosdb/src/state_restore/mod.rs
+++ b/storage/aptosdb/src/state_restore/mod.rs
@@ -230,22 +230,47 @@ impl<K: Key + CryptoHash + Hash + Eq, V: Value> StateSnapshotReceiver<K, V>
                 .add_chunk(chunk.clone())
         };
 
-        let tree_fn = || {
-            let _timer = OTHER_TIMERS_SECONDS.timer_with(&["jmt_add_chunk"]);
-            self.tree_restore
-                .lock()
-                .as_mut()
-                .unwrap()
-                .add_chunk_impl(chunk.iter().map(|(k, v)| (k, v.hash())).collect(), proof)
-        };
         match self.restore_mode {
             StateSnapshotRestoreMode::KvOnly => kv_fn()?,
-            StateSnapshotRestoreMode::TreeOnly => tree_fn()?,
+            StateSnapshotRestoreMode::TreeOnly => {
+                let _timer = OTHER_TIMERS_SECONDS.timer_with(&["jmt_add_chunk"]);
+                let mut tree = self.tree_restore.lock();
+                let tree = tree.as_mut().unwrap();
+                if tree.prepare_chunk(chunk.iter().map(|(k, v)| (k, v.hash())).collect(), proof)? {
+                    tree.commit_prepared()?;
+                }
+            },
             StateSnapshotRestoreMode::Default => {
-                // We run kv_fn with TreeOnly to restore the usage of DB
-                let (r1, r2) = IO_POOL.join(kv_fn, tree_fn);
-                r1?;
-                r2?;
+                // Verify the JMT proof before letting kv_fn touch state_kv_db: kv_fn does
+                // not verify, so writing it concurrently with an unverified tree could
+                // persist bad data. Once prepare_chunk returns Ok, the chunk is proven and
+                // it is safe to overlap kv_fn with the tree's storage commit.
+                let needs_commit = {
+                    let _timer = OTHER_TIMERS_SECONDS.timer_with(&["jmt_prepare_chunk"]);
+                    self.tree_restore
+                        .lock()
+                        .as_mut()
+                        .unwrap()
+                        .prepare_chunk(chunk.iter().map(|(k, v)| (k, v.hash())).collect(), proof)?
+                };
+                if needs_commit {
+                    let tree_commit_fn = || {
+                        let _timer = OTHER_TIMERS_SECONDS.timer_with(&["jmt_commit_chunk"]);
+                        self.tree_restore.lock().as_mut().unwrap().commit_prepared()
+                    };
+                    let (r1, r2) = IO_POOL.join(kv_fn, tree_commit_fn);
+                    r1?;
+                    r2?;
+                } else {
+                    self.tree_restore
+                        .lock()
+                        .as_mut()
+                        .unwrap()
+                        .verify_chunk_against_storage(
+                            chunk.iter().map(|(k, v)| (k, v.hash())).collect(),
+                        )?;
+                    kv_fn()?;
+                }
             },
         }
 

--- a/storage/aptosdb/src/state_restore/restore_test.rs
+++ b/storage/aptosdb/src/state_restore/restore_test.rs
@@ -228,6 +228,92 @@ proptest! {
     }
 }
 
+#[test]
+fn test_tree_skipped_chunk_is_checked_before_kv_catchup() {
+    let source_kvs: BTreeMap<_, _> = [
+        (ValueBlob::from(vec![1]), ValueBlob::from(vec![10])),
+        (ValueBlob::from(vec![2]), ValueBlob::from(vec![20])),
+        (ValueBlob::from(vec![3]), ValueBlob::from(vec![30])),
+    ]
+    .into_iter()
+    .collect();
+    let all: BTreeMap<_, _> = source_kvs
+        .iter()
+        .map(|(k, v)| (CryptoHash::hash(k), (k.clone(), v.clone())))
+        .collect();
+    let (source_db, version) = init_mock_store(&source_kvs);
+    let source_tree = JellyfishMerkleTree::new(&source_db);
+    let expected_root_hash = source_tree.get_root_hash(version).unwrap();
+
+    let first_two_with_hashes: Vec<_> = all.iter().take(2).collect();
+    let first_two: Vec<_> = first_two_with_hashes
+        .iter()
+        .map(|(_, (k, v))| ((*k).clone(), (*v).clone()))
+        .collect();
+    let first_two_proof = source_tree
+        .get_range_proof(*first_two_with_hashes.last().unwrap().0, version)
+        .unwrap();
+    let third_with_hash = all.iter().nth(2).unwrap();
+    let (third_key, third_value) = third_with_hash.1;
+    let third = (third_key.clone(), third_value.clone());
+    let third_proof = source_tree
+        .get_range_proof(*third_with_hash.0, version)
+        .unwrap();
+
+    let restore_db = Arc::new(MockSnapshotStore::default());
+    {
+        let mut restore = StateSnapshotRestore::new(
+            &restore_db,
+            &restore_db,
+            version,
+            expected_root_hash,
+            false, /* async_commit */
+            StateSnapshotRestoreMode::Default,
+        )
+        .unwrap();
+        restore
+            .add_chunk(first_two.clone(), first_two_proof.clone())
+            .unwrap();
+        restore.add_chunk(vec![third], third_proof).unwrap();
+    }
+
+    // Simulate KV progress falling behind after the tree already restored these leaves.
+    restore_db.kv_store.write().clear();
+    restore_db.progress_store.write().clear();
+
+    let mut restore = StateSnapshotRestore::new(
+        &restore_db,
+        &restore_db,
+        version,
+        expected_root_hash,
+        false, /* async_commit */
+        StateSnapshotRestoreMode::Default,
+    )
+    .unwrap();
+    let mut corrupted_first_two = first_two.clone();
+    corrupted_first_two[0].1 = ValueBlob::from(vec![99]);
+    let err = restore
+        .add_chunk(corrupted_first_two, first_two_proof.clone())
+        .unwrap_err();
+    assert!(
+        err.to_string().contains("Restored JMT value hash mismatch"),
+        "{}",
+        err,
+    );
+    assert!(restore_db.kv_store.read().is_empty());
+    assert!(restore_db.progress_store.read().get(&version).is_none());
+
+    restore
+        .add_chunk(first_two.clone(), first_two_proof)
+        .unwrap();
+    for (key, value) in first_two {
+        assert_eq!(
+            restore_db.get_value_at_version(&(key, version)),
+            Some(value),
+        );
+    }
+}
+
 fn assert_success<V>(
     db: &MockSnapshotStore<V, V>,
     expected_root_hash: HashValue,

--- a/storage/aptosdb/src/state_restore/restore_test.rs
+++ b/storage/aptosdb/src/state_restore/restore_test.rs
@@ -228,6 +228,241 @@ proptest! {
     }
 }
 
+#[test]
+fn test_tree_skipped_chunk_is_checked_before_kv_catchup() {
+    let source_kvs: BTreeMap<_, _> = [
+        (ValueBlob::from(vec![1]), ValueBlob::from(vec![10])),
+        (ValueBlob::from(vec![2]), ValueBlob::from(vec![20])),
+        (ValueBlob::from(vec![3]), ValueBlob::from(vec![30])),
+    ]
+    .into_iter()
+    .collect();
+    let all: BTreeMap<_, _> = source_kvs
+        .iter()
+        .map(|(k, v)| (CryptoHash::hash(k), (k.clone(), v.clone())))
+        .collect();
+    let (source_db, version) = init_mock_store(&source_kvs);
+    let source_tree = JellyfishMerkleTree::new(&source_db);
+    let expected_root_hash = source_tree.get_root_hash(version).unwrap();
+
+    let first_two_with_hashes: Vec<_> = all.iter().take(2).collect();
+    let first_two: Vec<_> = first_two_with_hashes
+        .iter()
+        .map(|(_, (k, v))| ((*k).clone(), (*v).clone()))
+        .collect();
+    let first_two_proof = source_tree
+        .get_range_proof(*first_two_with_hashes.last().unwrap().0, version)
+        .unwrap();
+    let third_with_hash = all.iter().nth(2).unwrap();
+    let (third_key, third_value) = third_with_hash.1;
+    let third = (third_key.clone(), third_value.clone());
+    let third_proof = source_tree
+        .get_range_proof(*third_with_hash.0, version)
+        .unwrap();
+
+    let restore_db = Arc::new(MockSnapshotStore::default());
+    {
+        let mut restore = StateSnapshotRestore::new(
+            &restore_db,
+            &restore_db,
+            version,
+            expected_root_hash,
+            false, /* async_commit */
+            StateSnapshotRestoreMode::Default,
+        )
+        .unwrap();
+        restore
+            .add_chunk(first_two.clone(), first_two_proof.clone())
+            .unwrap();
+        restore.add_chunk(vec![third], third_proof).unwrap();
+    }
+
+    // Simulate KV progress falling behind after the tree already restored these leaves.
+    restore_db.kv_store.write().clear();
+    restore_db.progress_store.write().clear();
+
+    let mut restore = StateSnapshotRestore::new(
+        &restore_db,
+        &restore_db,
+        version,
+        expected_root_hash,
+        false, /* async_commit */
+        StateSnapshotRestoreMode::Default,
+    )
+    .unwrap();
+    let mut corrupted_first_two = first_two.clone();
+    corrupted_first_two[0].1 = ValueBlob::from(vec![99]);
+    let err = restore
+        .add_chunk(corrupted_first_two, first_two_proof.clone())
+        .unwrap_err();
+    assert!(
+        err.to_string().contains("Restored JMT value hash mismatch"),
+        "{}",
+        err,
+    );
+    assert!(restore_db.kv_store.read().is_empty());
+    assert!(restore_db.progress_store.read().get(&version).is_none());
+
+    restore
+        .add_chunk(first_two.clone(), first_two_proof)
+        .unwrap();
+    for (key, value) in first_two {
+        assert_eq!(
+            restore_db.get_value_at_version(&(key, version)),
+            Some(value),
+        );
+    }
+}
+
+/// After a partial-crash recovery where the JMT got ahead of the KV, the next chunk straddles
+/// the JMT progress: a prefix of the chunk is already in JMT, plus a suffix of new keys. The
+/// proof for the chunk is valid (it covers the suffix correctly), but a malicious source can
+/// substitute a wrong value in the prefix — those entries used to be silently dropped. The new
+/// `prepare_chunk` walks the JMT-stored leaves alongside the prefix and rejects the mismatch
+/// before any KV writes can land.
+#[test]
+fn test_partial_overlap_chunk_with_corrupt_prefix_value_is_rejected() {
+    let source_kvs: BTreeMap<_, _> = (1u8..=4)
+        .map(|i| (ValueBlob::from(vec![i]), ValueBlob::from(vec![i * 10])))
+        .collect();
+    let all: BTreeMap<_, _> = source_kvs
+        .iter()
+        .map(|(k, v)| (CryptoHash::hash(k), (k.clone(), v.clone())))
+        .collect();
+    let (source_db, version) = init_mock_store(&source_kvs);
+    let source_tree = JellyfishMerkleTree::new(&source_db);
+    let expected_root_hash = source_tree.get_root_hash(version).unwrap();
+
+    // First session restores three leaves and is dropped without `finish` — only the first
+    // two are frozen into JMT storage; the third was rightmost in memory and is lost.
+    let three_with_hashes: Vec<_> = all.iter().take(3).collect();
+    let three: Vec<_> = three_with_hashes
+        .iter()
+        .map(|(_, (k, v))| ((*k).clone(), (*v).clone()))
+        .collect();
+    let three_proof = source_tree
+        .get_range_proof(*three_with_hashes.last().unwrap().0, version)
+        .unwrap();
+    let restore_db = Arc::new(MockSnapshotStore::default());
+    {
+        let mut restore = StateSnapshotRestore::new(
+            &restore_db,
+            &restore_db,
+            version,
+            expected_root_hash,
+            false, /* async_commit */
+            StateSnapshotRestoreMode::Default,
+        )
+        .unwrap();
+        restore.add_chunk(three, three_proof).unwrap();
+    }
+
+    // Simulate KV falling behind the JMT.
+    restore_db.kv_store.write().clear();
+    restore_db.progress_store.write().clear();
+
+    // The replay chunk straddles the JMT progress: the first two entries (prefix) are
+    // already in JMT, the last two (suffix) are new. Corrupt the second entry's value.
+    let mut restore = StateSnapshotRestore::new(
+        &restore_db,
+        &restore_db,
+        version,
+        expected_root_hash,
+        false, /* async_commit */
+        StateSnapshotRestoreMode::Default,
+    )
+    .unwrap();
+    let four_with_hashes: Vec<_> = all.iter().take(4).collect();
+    let mut chunk: Vec<_> = four_with_hashes
+        .iter()
+        .map(|(_, (k, v))| ((*k).clone(), (*v).clone()))
+        .collect();
+    chunk[1].1 = ValueBlob::from(vec![0xFF]);
+    let proof = source_tree
+        .get_range_proof(*four_with_hashes.last().unwrap().0, version)
+        .unwrap();
+
+    let err = restore.add_chunk(chunk, proof).unwrap_err();
+    assert!(
+        err.to_string().contains("Restored JMT value hash mismatch"),
+        "expected value hash mismatch error, got: {}",
+        err,
+    );
+    assert!(restore_db.kv_store.read().is_empty());
+    assert!(restore_db.progress_store.read().get(&version).is_none());
+}
+
+/// A malicious source can otherwise leave a permanent hole in the KV by sending a chunk whose
+/// first key is past KV's progress (skipping JMT-stored leaves the KV still needs to fill).
+/// The proof — which only commits to right siblings — would still verify. The new walk yields
+/// the missing JMT leaf first and rejects the chunk before any KV writes happen.
+#[test]
+fn test_chunk_with_left_gap_after_kv_catchup_is_rejected() {
+    let source_kvs: BTreeMap<_, _> = (1u8..=4)
+        .map(|i| (ValueBlob::from(vec![i]), ValueBlob::from(vec![i * 10])))
+        .collect();
+    let all: BTreeMap<_, _> = source_kvs
+        .iter()
+        .map(|(k, v)| (CryptoHash::hash(k), (k.clone(), v.clone())))
+        .collect();
+    let (source_db, version) = init_mock_store(&source_kvs);
+    let source_tree = JellyfishMerkleTree::new(&source_db);
+    let expected_root_hash = source_tree.get_root_hash(version).unwrap();
+
+    let three_with_hashes: Vec<_> = all.iter().take(3).collect();
+    let three: Vec<_> = three_with_hashes
+        .iter()
+        .map(|(_, (k, v))| ((*k).clone(), (*v).clone()))
+        .collect();
+    let three_proof = source_tree
+        .get_range_proof(*three_with_hashes.last().unwrap().0, version)
+        .unwrap();
+    let restore_db = Arc::new(MockSnapshotStore::default());
+    {
+        let mut restore = StateSnapshotRestore::new(
+            &restore_db,
+            &restore_db,
+            version,
+            expected_root_hash,
+            false, /* async_commit */
+            StateSnapshotRestoreMode::Default,
+        )
+        .unwrap();
+        restore.add_chunk(three, three_proof).unwrap();
+    }
+    restore_db.kv_store.write().clear();
+    restore_db.progress_store.write().clear();
+
+    // Skip the leftmost leaf (`all[0]`): the chunk pretends KV is already caught up past it.
+    let mut restore = StateSnapshotRestore::new(
+        &restore_db,
+        &restore_db,
+        version,
+        expected_root_hash,
+        false, /* async_commit */
+        StateSnapshotRestoreMode::Default,
+    )
+    .unwrap();
+    let skipped_first_with_hashes: Vec<_> = all.iter().skip(1).take(3).collect();
+    let chunk: Vec<_> = skipped_first_with_hashes
+        .iter()
+        .map(|(_, (k, v))| ((*k).clone(), (*v).clone()))
+        .collect();
+    let proof = source_tree
+        .get_range_proof(*skipped_first_with_hashes.last().unwrap().0, version)
+        .unwrap();
+
+    let err = restore.add_chunk(chunk, proof).unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("does not match next restored JMT leaf") || msg.contains("missing key"),
+        "expected gap-detection error, got: {}",
+        err,
+    );
+    assert!(restore_db.kv_store.read().is_empty());
+    assert!(restore_db.progress_store.read().get(&version).is_none());
+}
+
 fn assert_success<V>(
     db: &MockSnapshotStore<V, V>,
     expected_root_hash: HashValue,

--- a/storage/jellyfish-merkle/src/restore/mod.rs
+++ b/storage/jellyfish-merkle/src/restore/mod.rs
@@ -25,7 +25,6 @@ use aptos_types::{
     proof::{SparseMerkleInternalNode, SparseMerkleLeafNode, SparseMerkleRangeProof},
     transaction::Version,
 };
-use itertools::Itertools;
 use once_cell::sync::Lazy;
 use std::{
     cmp::Eq,
@@ -126,6 +125,7 @@ where
 pub struct JellyfishMerkleRestore<K> {
     /// The underlying storage.
     store: Arc<dyn TreeWriter<K>>,
+    reader: Option<Arc<dyn TreeReader<K> + Send + Sync>>,
 
     /// The version of the tree we are restoring.
     version: Version,
@@ -192,7 +192,8 @@ where
         expected_root_hash: HashValue,
         async_commit: bool,
     ) -> Result<Self> {
-        let tree_reader = Arc::clone(&store);
+        let tree_reader: Arc<dyn TreeReader<K> + Send + Sync> = store.clone();
+        let tree_writer: Arc<dyn TreeWriter<K>> = store;
         let (finished, partial_nodes, previous_leaf) = if let Some(root_node) =
             tree_reader.get_node_option(&NodeKey::new_empty_path(version), "restore")?
         {
@@ -221,7 +222,8 @@ where
         };
 
         Ok(Self {
-            store,
+            store: tree_writer,
+            reader: Some(tree_reader),
             version,
             partial_nodes,
             frozen_nodes: HashMap::new(),
@@ -241,6 +243,7 @@ where
     ) -> Result<Self> {
         Ok(Self {
             store,
+            reader: None,
             version,
             partial_nodes: vec![InternalInfo::new_empty(NodeKey::new_empty_path(version))],
             frozen_nodes: HashMap::new(),
@@ -333,50 +336,77 @@ where
         Ok(partial_nodes)
     }
 
-    /// Restores a chunk of states. This function will verify that the given chunk is correct
-    /// using the proof and root hash, then write things to storage. If the chunk is invalid, an
-    /// error will be returned and nothing will be written to storage.
-    pub fn add_chunk_impl(
+    /// Builds the partial tree in memory from `chunk` and verifies the entire chunk against
+    /// the expected root and the JMT-stored leaves. Does not touch storage.
+    ///
+    /// `kv_progress` is the caller's last-written key hash for the dependent KV side (or
+    /// `None` if nothing is written yet). When the JMT restore is ahead of the KV — typically
+    /// after a partial-crash recovery where the previous chunk's tree commit landed but the
+    /// KV write didn't — `kv_progress < previous_leaf.account_key()`, and the chunk arrives
+    /// with a prefix of leaves that the JMT already stores. This function then walks the JMT
+    /// in `(kv_progress, previous_leaf]` and pairs each stored leaf with the chunk's prefix,
+    /// catching wrong values *and* missing keys (left-edge or internal gaps) before any KV
+    /// write is allowed to land. To opt out (e.g., `TreeOnly` mode where there is no
+    /// dependent KV), pass `kv_progress` equal to `previous_leaf.account_key()` — the walk
+    /// then has an empty range and is skipped.
+    ///
+    /// Returns `Ok(true)` when there are frozen nodes pending — the caller must follow up
+    /// with [`Self::commit_prepared`]. Returns `Ok(false)` when the chunk added nothing new
+    /// (already finished, empty, or fully covered by `previous_leaf`); no commit is needed.
+    pub fn prepare_chunk(
         &mut self,
         mut chunk: Vec<(&K, HashValue)>,
         proof: SparseMerkleRangeProof,
-    ) -> Result<()> {
+        kv_progress: Option<HashValue>,
+    ) -> Result<bool> {
         if self.finished {
             info!("State snapshot restore already finished, ignoring entire chunk.");
-            return Ok(());
+            return Ok(false);
         }
-
-        if let Some(prev_leaf) = &self.previous_leaf {
-            let skip_until = chunk
-                .iter()
-                .find_position(|(key, _hash)| key.hash() > *prev_leaf.account_key());
-            chunk = match skip_until {
-                None => {
-                    info!("Skipping entire chunk.");
-                    return Ok(());
-                },
-                Some((0, _)) => chunk,
-                Some((num_to_skip, next_leaf)) => {
-                    info!(
-                        num_to_skip = num_to_skip,
-                        next_leaf = next_leaf,
-                        "Skipping leaves."
-                    );
-                    chunk.split_off(num_to_skip)
-                },
-            }
-        };
         if chunk.is_empty() {
-            return Ok(());
+            return Ok(false);
         }
 
-        for (key, value_hash) in chunk {
+        let jmt_progress = self.previous_leaf.as_ref().map(|l| *l.account_key());
+        let prefix_len = match jmt_progress {
+            Some(jmt) => chunk.iter().take_while(|(k, _)| k.hash() <= jmt).count(),
+            None => 0,
+        };
+
+        // When the dependent KV is behind the JMT, the chunk's prefix must exactly match the
+        // JMT's leaves in `(kv_progress, walk_upper]`, where `walk_upper` is the highest key
+        // the chunk claims to cover that the JMT also has stored — i.e.,
+        // `min(chunk.last_key, jmt_progress)`. The merge-walk catches both wrong values
+        // (Bug 1) and missing keys at the left edge or between prefix entries (Bug 2).
+        let need_prefix_check = match (kv_progress, jmt_progress) {
+            (_, None) => false,
+            (None, Some(_)) => true,
+            (Some(kv), Some(jmt)) => kv < jmt,
+        };
+        if need_prefix_check {
+            let jmt = jmt_progress.expect("jmt_progress is Some when need_prefix_check is true");
+            let chunk_last = chunk
+                .last()
+                .expect("chunk is non-empty (early return above)")
+                .0
+                .hash();
+            let walk_upper = std::cmp::min(chunk_last, jmt);
+            self.wait_for_async_commit()?;
+            self.verify_prefix_against_storage(&chunk[..prefix_len], kv_progress, walk_upper)?;
+        }
+
+        let suffix = chunk.split_off(prefix_len);
+        if suffix.is_empty() {
+            return Ok(false);
+        }
+
+        for (key, value_hash) in suffix {
             let hashed_key = key.hash();
             if let Some(ref prev_leaf) = self.previous_leaf {
                 ensure!(
                     &hashed_key > prev_leaf.account_key(),
                     "State keys must come in increasing order.",
-                )
+                );
             }
             self.previous_leaf.replace(LeafNode::new(
                 hashed_key,
@@ -387,10 +417,209 @@ where
             self.num_keys_received += 1;
         }
 
-        // Verify what we have added so far is all correct.
+        // After this returns Ok, the chunk is proven against the expected root hash and it
+        // is safe for the caller to commit dependent state (e.g. KV writes) in parallel with
+        // `commit_prepared`.
         self.verify(proof)?;
 
-        // Write the frozen nodes to storage.
+        Ok(true)
+    }
+
+    /// Walks the JMT leaves in `(exclusive_lower, inclusive_upper]` in increasing key order
+    /// and pairs them 1-to-1 with `prefix`. Errors on any divergence: a JMT leaf with no
+    /// matching chunk entry (chunk skipped a key — gap), a chunk entry that doesn't match
+    /// the next JMT leaf (out of order, extra entry, or missing key in JMT), a value-hash
+    /// mismatch, or a leftover chunk entry past the upper bound.
+    fn verify_prefix_against_storage(
+        &self,
+        prefix: &[(&K, HashValue)],
+        exclusive_lower: Option<HashValue>,
+        inclusive_upper: HashValue,
+    ) -> Result<()> {
+        let reader = self.reader.as_ref().ok_or_else(|| {
+            AptosDbError::Other("Cannot verify chunk prefix without a tree reader.".into())
+        })?;
+
+        let mut prefix_iter = prefix.iter();
+        self.walk_leaves(
+            reader.as_ref(),
+            exclusive_lower,
+            inclusive_upper,
+            |leaf: LeafNode<K>| match prefix_iter.next() {
+                None => Err(AptosDbError::Other(format!(
+                    "Chunk is missing key {} that exists in restored JMT.",
+                    leaf.account_key(),
+                ))),
+                Some((key, value_hash)) => {
+                    ensure!(
+                        key.hash() == *leaf.account_key(),
+                        "Chunk key {} does not match next restored JMT leaf {}.",
+                        key.hash(),
+                        leaf.account_key(),
+                    );
+                    ensure!(
+                        *value_hash == leaf.value_hash(),
+                        "Restored JMT value hash mismatch for key {}: chunk has {}, JMT has {}.",
+                        leaf.account_key(),
+                        value_hash,
+                        leaf.value_hash(),
+                    );
+                    Ok(())
+                },
+            },
+        )?;
+
+        if let Some((extra_key, _)) = prefix_iter.next() {
+            return Err(AptosDbError::Other(format!(
+                "Chunk has prefix entry {} not found in restored JMT.",
+                extra_key.hash(),
+            )));
+        }
+
+        Ok(())
+    }
+
+    /// Walks the leaves of the in-progress tree whose keys fall in
+    /// `(exclusive_lower, inclusive_upper]`, in increasing key order, invoking `visit` for
+    /// each. The traversal uses `self.partial_nodes` for the rightmost in-memory path
+    /// (whose root may not be in storage yet) and descends into storage only for frozen
+    /// subtrees on the left. Subtrees fully outside the query range are pruned by nibble
+    /// path so the cost is `O(yielded_leaves + log n)` storage reads.
+    fn walk_leaves<F>(
+        &self,
+        reader: &(dyn TreeReader<K> + Send + Sync),
+        exclusive_lower: Option<HashValue>,
+        inclusive_upper: HashValue,
+        mut visit: F,
+    ) -> Result<()>
+    where
+        F: FnMut(LeafNode<K>) -> Result<()>,
+    {
+        self.walk_partial(reader, 0, exclusive_lower, inclusive_upper, &mut visit)
+    }
+
+    fn walk_partial<F>(
+        &self,
+        reader: &(dyn TreeReader<K> + Send + Sync),
+        depth: usize,
+        exclusive_lower: Option<HashValue>,
+        inclusive_upper: HashValue,
+        visit: &mut F,
+    ) -> Result<()>
+    where
+        F: FnMut(LeafNode<K>) -> Result<()>,
+    {
+        let info = &self.partial_nodes[depth];
+        for (child_index, child_opt) in info.children.iter().enumerate() {
+            let child = match child_opt {
+                Some(c) => c,
+                None => continue,
+            };
+            let child_nibble: Nibble = (child_index as u8).into();
+            let child_node_key = info.node_key.gen_child_node_key(self.version, child_nibble);
+            let (sub_min, sub_max) = Self::subtree_key_range(child_node_key.nibble_path());
+            let above_lower = exclusive_lower.map_or(true, |l| sub_max > l);
+            let below_upper = sub_min <= inclusive_upper;
+            if !(above_lower && below_upper) {
+                continue;
+            }
+            match child {
+                ChildInfo::Leaf(leaf) => {
+                    let key = *leaf.account_key();
+                    let above_lower_leaf = exclusive_lower.map_or(true, |l| key > l);
+                    if above_lower_leaf && key <= inclusive_upper {
+                        visit(leaf.clone())?;
+                    }
+                },
+                ChildInfo::Internal { hash: Some(_), .. } => {
+                    // Frozen — fully in storage; descend from this child's node key.
+                    Self::walk_subtree(
+                        reader,
+                        self.version,
+                        child_node_key,
+                        exclusive_lower,
+                        inclusive_upper,
+                        visit,
+                    )?;
+                },
+                ChildInfo::Internal { hash: None, .. } => {
+                    // Partial — points to the next level of `partial_nodes`.
+                    self.walk_partial(reader, depth + 1, exclusive_lower, inclusive_upper, visit)?;
+                },
+            }
+        }
+        Ok(())
+    }
+
+    fn walk_subtree<F>(
+        reader: &(dyn TreeReader<K> + Send + Sync),
+        version: Version,
+        node_key: NodeKey,
+        exclusive_lower: Option<HashValue>,
+        inclusive_upper: HashValue,
+        visit: &mut F,
+    ) -> Result<()>
+    where
+        F: FnMut(LeafNode<K>) -> Result<()>,
+    {
+        let node = match reader.get_node_option(&node_key, "walk_leaves")? {
+            Some(n) => n,
+            None => return Ok(()),
+        };
+        match node {
+            Node::Null => Ok(()),
+            Node::Leaf(leaf) => {
+                let key = *leaf.account_key();
+                let above_lower = exclusive_lower.map_or(true, |l| key > l);
+                if above_lower && key <= inclusive_upper {
+                    visit(leaf)?;
+                }
+                Ok(())
+            },
+            Node::Internal(internal) => {
+                for (nibble, _) in internal.children_sorted() {
+                    let child_key = node_key.gen_child_node_key(version, *nibble);
+                    let (sub_min, sub_max) = Self::subtree_key_range(child_key.nibble_path());
+                    let above_lower = exclusive_lower.map_or(true, |l| sub_max > l);
+                    let below_upper = sub_min <= inclusive_upper;
+                    if above_lower && below_upper {
+                        Self::walk_subtree(
+                            reader,
+                            version,
+                            child_key,
+                            exclusive_lower,
+                            inclusive_upper,
+                            visit,
+                        )?;
+                    }
+                }
+                Ok(())
+            },
+        }
+    }
+
+    /// Returns the smallest and largest possible leaf keys in the subtree rooted at
+    /// `nibble_path` — i.e., the path padded with all-zero / all-`F` suffix bytes.
+    fn subtree_key_range(nibble_path: &NibblePath) -> (HashValue, HashValue) {
+        let mut min_bytes = [0u8; HashValue::LENGTH];
+        let mut max_bytes = [0xFFu8; HashValue::LENGTH];
+        for (i, nibble) in nibble_path.nibbles().enumerate() {
+            let byte_idx = i / 2;
+            let n = u8::from(nibble);
+            if i % 2 == 0 {
+                min_bytes[byte_idx] = n << 4;
+                max_bytes[byte_idx] = (n << 4) | 0x0F;
+            } else {
+                min_bytes[byte_idx] = (min_bytes[byte_idx] & 0xF0) | n;
+                max_bytes[byte_idx] = (max_bytes[byte_idx] & 0xF0) | n;
+            }
+        }
+        (HashValue::new(min_bytes), HashValue::new(max_bytes))
+    }
+
+    /// Writes the frozen nodes accumulated by [`Self::prepare_chunk`] to storage. With
+    /// `async_commit`, the write is dispatched to `IO_POOL` and drained on the next call.
+    pub fn commit_prepared(&mut self) -> Result<()> {
         if self.async_commit {
             self.wait_for_async_commit()?;
             let (tx, rx) = channel();

--- a/storage/jellyfish-merkle/src/restore/mod.rs
+++ b/storage/jellyfish-merkle/src/restore/mod.rs
@@ -126,6 +126,7 @@ where
 pub struct JellyfishMerkleRestore<K> {
     /// The underlying storage.
     store: Arc<dyn TreeWriter<K>>,
+    reader: Option<Arc<dyn TreeReader<K> + Send + Sync>>,
 
     /// The version of the tree we are restoring.
     version: Version,
@@ -192,7 +193,8 @@ where
         expected_root_hash: HashValue,
         async_commit: bool,
     ) -> Result<Self> {
-        let tree_reader = Arc::clone(&store);
+        let tree_reader: Arc<dyn TreeReader<K> + Send + Sync> = store.clone();
+        let tree_writer: Arc<dyn TreeWriter<K>> = store;
         let (finished, partial_nodes, previous_leaf) = if let Some(root_node) =
             tree_reader.get_node_option(&NodeKey::new_empty_path(version), "restore")?
         {
@@ -221,7 +223,8 @@ where
         };
 
         Ok(Self {
-            store,
+            store: tree_writer,
+            reader: Some(tree_reader),
             version,
             partial_nodes,
             frozen_nodes: HashMap::new(),
@@ -241,6 +244,7 @@ where
     ) -> Result<Self> {
         Ok(Self {
             store,
+            reader: None,
             version,
             partial_nodes: vec![InternalInfo::new_empty(NodeKey::new_empty_path(version))],
             frozen_nodes: HashMap::new(),
@@ -333,17 +337,18 @@ where
         Ok(partial_nodes)
     }
 
-    /// Restores a chunk of states. This function will verify that the given chunk is correct
-    /// using the proof and root hash, then write things to storage. If the chunk is invalid, an
-    /// error will be returned and nothing will be written to storage.
-    pub fn add_chunk_impl(
+    /// Builds the partial tree in memory from `chunk` and verifies the supplied proof. Does
+    /// not touch storage. Returns `Ok(true)` when there are frozen nodes pending — the caller
+    /// must follow up with [`Self::commit_prepared`]. Returns `Ok(false)` when the chunk was
+    /// skipped (already finished or fully behind `previous_leaf`); no commit is needed.
+    pub fn prepare_chunk(
         &mut self,
         mut chunk: Vec<(&K, HashValue)>,
         proof: SparseMerkleRangeProof,
-    ) -> Result<()> {
+    ) -> Result<bool> {
         if self.finished {
             info!("State snapshot restore already finished, ignoring entire chunk.");
-            return Ok(());
+            return Ok(false);
         }
 
         if let Some(prev_leaf) = &self.previous_leaf {
@@ -353,7 +358,7 @@ where
             chunk = match skip_until {
                 None => {
                     info!("Skipping entire chunk.");
-                    return Ok(());
+                    return Ok(false);
                 },
                 Some((0, _)) => chunk,
                 Some((num_to_skip, next_leaf)) => {
@@ -367,7 +372,7 @@ where
             }
         };
         if chunk.is_empty() {
-            return Ok(());
+            return Ok(false);
         }
 
         for (key, value_hash) in chunk {
@@ -387,10 +392,106 @@ where
             self.num_keys_received += 1;
         }
 
-        // Verify what we have added so far is all correct.
+        // Verify what we have added so far is all correct. After this returns Ok, the chunk
+        // is proven against the expected root hash and it is safe for the caller to commit
+        // dependent state (e.g. KV writes) in parallel with `commit_prepared`.
         self.verify(proof)?;
 
-        // Write the frozen nodes to storage.
+        Ok(true)
+    }
+
+    /// Verifies a chunk that has already been restored by the tree side. This is used when
+    /// `prepare_chunk` skipped the chunk because the JMT restore progress is ahead of the KV
+    /// restore progress. The range proof was checked when these leaves were originally prepared;
+    /// here we make sure the retried KV values match those already-restored leaves before KV
+    /// writes are allowed to catch up.
+    pub fn verify_chunk_against_storage(&mut self, chunk: Vec<(&K, HashValue)>) -> Result<()> {
+        if chunk.is_empty() {
+            return Ok(());
+        }
+
+        self.wait_for_async_commit()?;
+        let reader = self.reader.as_ref().ok_or_else(|| {
+            AptosDbError::Other("Cannot verify skipped restore chunk without a tree reader.".into())
+        })?;
+
+        let mut previous_key = None;
+        for (key, value_hash) in chunk {
+            let hashed_key = key.hash();
+            if let Some(previous_key) = previous_key {
+                ensure!(
+                    hashed_key > previous_key,
+                    "State keys must come in increasing order.",
+                );
+            }
+            previous_key = Some(hashed_key);
+
+            if let Some(prev_leaf) = &self.previous_leaf {
+                ensure!(
+                    &hashed_key <= prev_leaf.account_key(),
+                    "Skipped restore chunk contains key {} beyond restored tree progress {}.",
+                    hashed_key,
+                    prev_leaf.account_key(),
+                );
+            }
+
+            let leaf = Self::find_leaf_in_storage(reader.as_ref(), self.version, hashed_key)?
+                .ok_or_else(|| {
+                    AptosDbError::Other(format!(
+                        "Restored JMT is missing skipped restore key {}.",
+                        hashed_key,
+                    ))
+                })?;
+            ensure!(
+                leaf.value_hash() == value_hash,
+                "Restored JMT value hash mismatch for skipped restore key {}. \
+                 Expected {}, got {}.",
+                hashed_key,
+                leaf.value_hash(),
+                value_hash,
+            );
+        }
+
+        Ok(())
+    }
+
+    fn find_leaf_in_storage(
+        reader: &(dyn TreeReader<K> + Send + Sync),
+        version: Version,
+        hashed_key: HashValue,
+    ) -> Result<Option<LeafNode<K>>> {
+        if let Some(node) =
+            reader.get_node_option(&NodeKey::new_empty_path(version), "restore_verify")?
+        {
+            match node {
+                Node::Leaf(leaf) if *leaf.account_key() == hashed_key => return Ok(Some(leaf)),
+                Node::Leaf(_) | Node::Null => return Ok(None),
+                Node::Internal(_) => (),
+            }
+        }
+
+        let mut node_path = NibblePath::new_even(vec![]);
+        let full_path = NibblePath::new_even(hashed_key.to_vec());
+        for nibble in full_path.nibbles() {
+            node_path.push(nibble);
+            let node_key = NodeKey::new(version, node_path.clone());
+            if let Some(node) = reader.get_node_option(&node_key, "restore_verify")? {
+                match node {
+                    Node::Leaf(leaf) if *leaf.account_key() == hashed_key => {
+                        return Ok(Some(leaf));
+                    },
+                    Node::Leaf(_) | Node::Null => return Ok(None),
+                    Node::Internal(_) => (),
+                }
+            }
+        }
+
+        Ok(None)
+    }
+
+    /// Writes the frozen nodes accumulated by [`Self::prepare_chunk`] to storage. With
+    /// `async_commit`, the write is dispatched to `IO_POOL` and drained on the next call.
+    pub fn commit_prepared(&mut self) -> Result<()> {
         if self.async_commit {
             self.wait_for_async_commit()?;
             let (tx, rx) = channel();


### PR DESCRIPTION

Split JMT chunk handling into prepare and commit so Default restore verifies
proofs before KV writes while still overlapping KV writes with tree commits.

When the tree is already ahead on resume, validate skipped chunks against stored
JMT leaves before allowing KV catch-up.
