### PR TITLE
[storage] sequence kv before tree in snapshot restore

### DIFF
--- a/storage/aptosdb/src/state_restore/mod.rs
+++ b/storage/aptosdb/src/state_restore/mod.rs
@@ -13,21 +13,11 @@ use aptos_types::{
     proof::SparseMerkleRangeProof, state_store::state_storage_usage::StateStorageUsage,
     transaction::Version,
 };
-use once_cell::sync::Lazy;
-use rayon::{ThreadPool, ThreadPoolBuilder};
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, hash::Hash, str::FromStr, sync::Arc};
 
 #[cfg(test)]
 mod restore_test;
-
-pub static IO_POOL: Lazy<ThreadPool> = Lazy::new(|| {
-    ThreadPoolBuilder::new()
-        .num_threads(32)
-        .thread_name(|index| format!("jmt-io-{}", index))
-        .build()
-        .unwrap()
-});
 
 /// Key-Value batch that will be written into db atomically with other batches.
 pub type StateValueBatch<K, V> = HashMap<(K, Version), V>;
@@ -221,31 +211,41 @@ impl<K: Key + CryptoHash + Hash + Eq, V: Value> StateSnapshotReceiver<K, V>
     for StateSnapshotRestore<K, V>
 {
     fn add_chunk(&mut self, chunk: Vec<(K, V)>, proof: SparseMerkleRangeProof) -> Result<()> {
-        let kv_fn = || {
-            let _timer = OTHER_TIMERS_SECONDS.timer_with(&["state_value_add_chunk"]);
-            self.kv_restore
-                .lock()
-                .as_mut()
-                .unwrap()
-                .add_chunk(chunk.clone())
-        };
-
-        let tree_fn = || {
-            let _timer = OTHER_TIMERS_SECONDS.timer_with(&["jmt_add_chunk"]);
-            self.tree_restore
-                .lock()
-                .as_mut()
-                .unwrap()
-                .add_chunk_impl(chunk.iter().map(|(k, v)| (k, v.hash())).collect(), proof)
-        };
         match self.restore_mode {
-            StateSnapshotRestoreMode::KvOnly => kv_fn()?,
-            StateSnapshotRestoreMode::TreeOnly => tree_fn()?,
+            StateSnapshotRestoreMode::KvOnly => {
+                let _timer = OTHER_TIMERS_SECONDS.timer_with(&["state_value_add_chunk"]);
+                self.kv_restore.lock().as_mut().unwrap().add_chunk(chunk)?;
+            },
+            StateSnapshotRestoreMode::TreeOnly => {
+                let _timer = OTHER_TIMERS_SECONDS.timer_with(&["jmt_add_chunk"]);
+                self.tree_restore
+                    .lock()
+                    .as_mut()
+                    .unwrap()
+                    .add_chunk_impl(chunk.iter().map(|(k, v)| (k, v.hash())).collect(), proof)?;
+            },
             StateSnapshotRestoreMode::Default => {
-                // We run kv_fn with TreeOnly to restore the usage of DB
-                let (r1, r2) = IO_POOL.join(kv_fn, tree_fn);
-                r1?;
-                r2?;
+                // Sequence: verify proof -> write state_kv_db -> write state_merkle_db.
+                // This keeps state_kv_db at or ahead of state_merkle_db on disk at every
+                // crash point. Were merkle ever ahead, the resume path (which feeds chunks
+                // from min(kv_progress, tree_progress)) would land bytes in (kv_progress,
+                // tree_progress] that the tree side skips and therefore does not re-verify.
+                {
+                    let _timer = OTHER_TIMERS_SECONDS.timer_with(&["jmt_verify_chunk"]);
+                    self.tree_restore
+                        .lock()
+                        .as_mut()
+                        .unwrap()
+                        .verify_chunk(chunk.iter().map(|(k, v)| (k, v.hash())).collect(), proof)?;
+                }
+                {
+                    let _timer = OTHER_TIMERS_SECONDS.timer_with(&["state_value_add_chunk"]);
+                    self.kv_restore.lock().as_mut().unwrap().add_chunk(chunk)?;
+                }
+                {
+                    let _timer = OTHER_TIMERS_SECONDS.timer_with(&["jmt_commit_chunk"]);
+                    self.tree_restore.lock().as_mut().unwrap().commit_chunk()?;
+                }
             },
         }
 

--- a/storage/jellyfish-merkle/src/restore/mod.rs
+++ b/storage/jellyfish-merkle/src/restore/mod.rs
@@ -338,6 +338,18 @@ where
     /// error will be returned and nothing will be written to storage.
     pub fn add_chunk_impl(
         &mut self,
+        chunk: Vec<(&K, HashValue)>,
+        proof: SparseMerkleRangeProof,
+    ) -> Result<()> {
+        self.verify_chunk(chunk, proof)?;
+        self.commit_chunk()
+    }
+
+    /// Verifies a chunk and stages frozen nodes in memory; call [`Self::commit_chunk`] to
+    /// flush. On error, in-memory state is partially updated — abort the restore rather
+    /// than calling again.
+    pub fn verify_chunk(
+        &mut self,
         mut chunk: Vec<(&K, HashValue)>,
         proof: SparseMerkleRangeProof,
     ) -> Result<()> {
@@ -389,8 +401,16 @@ where
 
         // Verify what we have added so far is all correct.
         self.verify(proof)?;
+        Ok(())
+    }
 
-        // Write the frozen nodes to storage.
+    /// Flushes frozen nodes staged by [`Self::verify_chunk`]. With async commit, awaits the
+    /// previous write before spawning the new one.
+    pub fn commit_chunk(&mut self) -> Result<()> {
+        if self.finished || self.frozen_nodes.is_empty() {
+            return Ok(());
+        }
+
         if self.async_commit {
             self.wait_for_async_commit()?;
             let (tx, rx) = channel();


### PR DESCRIPTION

The `Default` mode used to write state_kv_db and state_merkle_db
concurrently via `IO_POOL.join`. Only the tree side verifies the
proof, so bad input could land in kv before the tree returned an
error. Worse, on resume after a crash where merkle ended up ahead
of kv, the chunk-skip logic (kv skips by kv_progress, tree skips
by tree_progress) would let kv write bytes in the range
`(kv_progress, tree_progress]` that the tree side skips and
therefore doesn't re-verify.

Split `JellyfishMerkleRestore::add_chunk_impl` into `verify_chunk`
(in-memory only) and `commit_chunk` (flush frozen nodes), then
sequence Default mode as:

1. `tree.verify_chunk` — applies and verifies in memory
2. `kv.add_chunk` — commits to state_kv_db
3. `tree.commit_chunk` — commits to state_merkle_db

This keeps state_kv_db at or ahead of state_merkle_db on disk at
every crash point. The cost is per-chunk concurrency between kv
and tree writes and can be recovered in a follow-up via `async_commit`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes snapshot restore ordering and splits JMT restore into verify/commit phases, affecting crash-resume and consistency behavior; mistakes could corrupt restore progress or leave DBs out of sync.
> 
> **Overview**
> Ensures `StateSnapshotRestore` in *Default* mode no longer writes KV and merkle tree data concurrently; it now **verifies the chunk proof in-memory first**, then writes `state_kv_db`, then commits the staged JMT nodes to `state_merkle_db` to keep KV at-or-ahead of merkle on disk across crashes.
> 
> Refactors `JellyfishMerkleRestore` by splitting `add_chunk_impl` into `verify_chunk` (stage + verify, no I/O) and `commit_chunk` (flush staged frozen nodes, honoring `async_commit`), and updates metrics timers accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16bec8ecbce93305be319f90ce7a0c9eb5957e67. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->