### PR TITLE
[vm] Use errors for invariant violations

### DIFF
--- a/third_party/move/move-vm/types/src/values/values_impl.rs
+++ b/third_party/move/move-vm/types/src/values/values_impl.rs
@@ -3937,7 +3937,15 @@ impl VectorRef {
             Container::VecBool(r) => r.borrow().len(),
             Container::VecAddress(r) => r.borrow().len(),
             Container::Vec(r) => r.borrow().len(),
-            Container::Locals(_) | Container::Struct(_) => unreachable!(),
+            Container::Locals(_) | Container::Struct(_) => {
+                return Err(
+                    PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
+                        .with_message(
+                            "length_as_usize called on non-vector container (Locals or Struct)"
+                                .to_string(),
+                        ),
+                );
+            },
         };
         Ok(len)
     }
@@ -3967,7 +3975,15 @@ impl VectorRef {
             Container::VecBool(r) => r.borrow_mut().push(e.value_as()?),
             Container::VecAddress(r) => r.borrow_mut().push(e.value_as()?),
             Container::Vec(r) => r.borrow_mut().push(e),
-            Container::Locals(_) | Container::Struct(_) => unreachable!(),
+            Container::Locals(_) | Container::Struct(_) => {
+                return Err(
+                    PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
+                        .with_message(
+                            "push_back called on non-vector container (Locals or Struct)"
+                                .to_string(),
+                        ),
+                );
+            },
         }
 
         self.0.mark_dirty();
@@ -4067,7 +4083,14 @@ impl VectorRef {
                 Some(x) => x,
                 None => err_pop_empty_vec!(),
             },
-            Container::Locals(_) | Container::Struct(_) => unreachable!(),
+            Container::Locals(_) | Container::Struct(_) => {
+                return Err(
+                    PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
+                        .with_message(
+                            "pop called on non-vector container (Locals or Struct)".to_string(),
+                        ),
+                );
+            },
         };
 
         self.0.mark_dirty();
@@ -4104,7 +4127,14 @@ impl VectorRef {
             Container::VecBool(r) => swap!(r),
             Container::VecAddress(r) => swap!(r),
             Container::Vec(r) => swap!(r),
-            Container::Locals(_) | Container::Struct(_) => unreachable!(),
+            Container::Locals(_) | Container::Struct(_) => {
+                return Err(
+                    PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
+                        .with_message(
+                            "swap called on non-vector container (Locals or Struct)".to_string(),
+                        ),
+                );
+            },
         }
 
         self.0.mark_dirty();
@@ -4181,7 +4211,15 @@ impl VectorRef {
                 move_range!(from_r, to_r)
             },
             (Container::Vec(from_r), Container::Vec(to_r)) => move_range!(from_r, to_r),
-            (_, _) => unreachable!(),
+            (_, _) => {
+                return Err(
+                    PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
+                        .with_message(
+                            "move_range called with mismatched or non-vector container types"
+                                .to_string(),
+                        ),
+                );
+            },
         }
 
         from_self.0.mark_dirty();
@@ -4496,13 +4534,17 @@ impl GlobalValueImpl {
             Self::None | Self::Deleted => {
                 return Err(PartialVMError::new(StatusCode::MISSING_DATA))
             },
-            Self::Fresh { .. } => match mem::replace(self, Self::None) {
-                Self::Fresh { value } => value,
-                _ => unreachable!(),
+            Self::Fresh { .. } => {
+                let Self::Fresh { value } = mem::replace(self, Self::None) else {
+                    unreachable!("Value has been checked to be fresh")
+                };
+                value
             },
-            Self::Cached { .. } => match mem::replace(self, Self::Deleted) {
-                Self::Cached { value, .. } => value,
-                _ => unreachable!(),
+            Self::Cached { .. } => {
+                let Self::Cached { value, .. } = mem::replace(self, Self::Deleted) else {
+                    unreachable!("Value has been checked to be cached")
+                };
+                value
             },
         };
         let fields = Self::expect_struct_fields(&value);


### PR DESCRIPTION
Replaces `unreachable!()` panics with `UNKNOWN_INVARIANT_VIOLATION_ERROR` returns in `Vector::{length_as_usize, push_back, pop, swap, move_range}`, which already return `PartialVMResult`. These arms are statically excluded by the bytecode verifier, but returning an error instead of panicking surfaces unexpected inputs as a clean VM status rather than aborting the worker.

Also rewrites the two truly-unreachable arms in `GlobalValueImpl::move_from` as `let ... else` with descriptive messages — no behavior change, the outer match already pins the variant.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core Move VM value/container operations by replacing `unreachable!()` panics with propagated `PartialVMError`s; behavior should only differ on unexpected invalid container states but could change failure modes in edge cases.
> 
> **Overview**
> Replaces several `unreachable!()` panics in `VectorRef` vector operations (`length_as_usize`, `push_back`, `pop`, `swap`) with `PartialVMError` returns using `StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR`, so invariant breaks surface as VM errors instead of aborting the process.
> 
> Updates `VectorRef::move_range` to return the same invariant-violation error when called with mismatched or non-vector container types, and refactors `GlobalValueImpl::move_from` to use `let ... else` with clearer `unreachable!` messages (no intended behavior change).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f976767dc73f3ad6ba6d8a9429d0d70863cf3381. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->