### PR TITLE
[vm] Optimize Drop for values

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13650,6 +13650,7 @@ dependencies = [
  "better_any",
  "bytes",
  "claims",
+ "criterion",
  "crossbeam",
  "dashmap 7.0.0-rc2",
  "derivative",

--- a/third_party/move/move-vm/types/Cargo.toml
+++ b/third_party/move/move-vm/types/Cargo.toml
@@ -31,11 +31,16 @@ triomphe = { workspace = true }
 
 [dev-dependencies]
 claims = { workspace = true }
+criterion = { workspace = true }
 mockall = { workspace = true }
 move-binary-format = { workspace = true, features = ["fuzzing"] }
 once_cell = { workspace = true }
 proptest = { workspace = true }
 rand = { workspace = true }
+
+[[bench]]
+name = "drop_bench"
+harness = false
 
 [features]
 default = [

--- a/third_party/move/move-vm/types/benches/drop_bench.rs
+++ b/third_party/move/move-vm/types/benches/drop_bench.rs
@@ -1,0 +1,108 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+// Microbenchmarks for `Drop` on Move `Value`s. The interesting variants are
+// `Container::{Vec, Struct, Locals}` which the iterative-Drop work-stack walks.
+//
+// All builders use the public `Value` / `Struct` API, which routes through
+// `NestedValues::new(...)` internally, so each value is uniquely owned and
+// Drop walks the unique-Rc path (the one we want to measure).
+
+use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
+use move_vm_types::values::{Struct, Value};
+
+/// `vector<Color>` of length `len` where `Color = { r: u8, g: u8, b: u8 }`.
+/// Mirrors the shape of `vector_picture`'s `Palette.vec`.
+fn make_color_vec(len: usize) -> Value {
+    Value::vector_unchecked((0..len).map(|i| {
+        let b = (i & 0xFF) as u8;
+        Value::struct_(Struct::pack([Value::u8(b), Value::u8(b), Value::u8(b)]))
+    }))
+    .unwrap()
+}
+
+/// `Palette { vec: vector<Color> }` — one wrapper struct around the color vec.
+fn make_palette(len: usize) -> Value {
+    Value::struct_(Struct::pack([make_color_vec(len)]))
+}
+
+/// `vector<vector<u64>>` — outer fanout × inner fanout. Both levels go through
+/// `Container::Vec(NestedValues)` (the inner `vector<u64>` is `VecU64`, which
+/// is the specialized primitive variant — so depth=1 from the Drop walker's POV).
+fn make_vec_of_vec_u64(outer: usize, inner: usize) -> Value {
+    Value::vector_unchecked((0..outer).map(|_| Value::vector_u64((0..inner).map(|j| j as u64))))
+        .unwrap()
+}
+
+/// `vector<vector<S>>` where `S = { u8 }`. Both nesting levels are
+/// `NestedValues`, so every element pushes onto the iterative-Drop work stack.
+/// This is the shape that maximally exercises the BFS stack growth.
+fn make_vec_of_vec_struct(outer: usize, inner: usize) -> Value {
+    Value::vector_unchecked((0..outer).map(|_| {
+        Value::vector_unchecked(
+            (0..inner).map(|i| Value::struct_(Struct::pack([Value::u8((i & 0xFF) as u8)]))),
+        )
+        .unwrap()
+    }))
+    .unwrap()
+}
+
+/// Right-deep nesting: `S { S { S { ... { u8 } } } }` of depth `depth`.
+/// Each level is one `Container::Struct(NestedValues)` holding one child.
+/// Useful as a regression check that DFS doesn't lose its depth handling.
+fn make_deep_nested(depth: usize) -> Value {
+    let mut v = Value::u8(0);
+    for _ in 0..depth {
+        v = Value::struct_(Struct::pack([v]));
+    }
+    v
+}
+
+fn bench_drop(c: &mut Criterion) {
+    let mut group = c.benchmark_group("drop");
+    group
+        .warm_up_time(std::time::Duration::from_secs(1))
+        .measurement_time(std::time::Duration::from_secs(3));
+
+    // VectorPicture30K shape: 30,720 Colors, each a 3-u8 struct.
+    group.bench_function("palette/30k", |b| {
+        b.iter_batched(|| make_palette(30 * 1024), drop, BatchSize::PerIteration);
+    });
+
+    group.bench_function("color_vec/30k", |b| {
+        b.iter_batched(|| make_color_vec(30 * 1024), drop, BatchSize::PerIteration);
+    });
+
+    group.bench_function("color_vec/1k", |b| {
+        b.iter_batched(|| make_color_vec(1024), drop, BatchSize::SmallInput);
+    });
+
+    // Outer-wide × inner-narrow with primitive inner. Outer push goes through
+    // NestedValues (BFS-stack territory); inner is `VecU64` (compiler drop).
+    group.bench_function("vec_of_vec_u64/1000x100", |b| {
+        b.iter_batched(
+            || make_vec_of_vec_u64(1000, 100),
+            drop,
+            BatchSize::PerIteration,
+        );
+    });
+
+    // Both levels are NestedValues. Maximally stresses the work stack.
+    group.bench_function("vec_of_vec_struct/1000x30", |b| {
+        b.iter_batched(
+            || make_vec_of_vec_struct(1000, 30),
+            drop,
+            BatchSize::PerIteration,
+        );
+    });
+
+    // Deep right-nested: depth bound matters, fanout = 1.
+    group.bench_function("deep_nested/depth_1000", |b| {
+        b.iter_batched(|| make_deep_nested(1000), drop, BatchSize::SmallInput);
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_drop);
+criterion_main!(benches);

--- a/third_party/move/move-vm/types/src/values/values_impl.rs
+++ b/third_party/move/move-vm/types/src/values/values_impl.rs
@@ -193,10 +193,10 @@ impl std::ops::Deref for NestedValues {
 /// heap work-stack rather than the Rust call stack. Only uniquely-owned Rcs are decomposed;
 /// shared containers (refcount > 1) fall through to the default Rc drop (refcount decrement).
 ///
-/// We drain the inner `Vec<Value>` in place via `Rc::get_mut` — no replacement `Rc`/`RefCell`
-/// is ever allocated. The work stack holds owned `Vec<Value>`s rather than `Rc<...>`s, so the
-/// only possible heap allocation is the stack itself, which stays at `Vec::new()` capacity 0
-/// until the first push.
+/// For nested children we use `into_rc` + `Rc::try_unwrap` to claim the inner `Vec<Value>`
+/// without re-entering this `Drop` on the consumed `NestedValues`. The work stack holds
+/// owned `Vec<Value>`s rather than `Rc<...>`s, so the only possible heap allocation is the
+/// stack itself, which stays at `Vec::new()` capacity 0 until the first push.
 impl Drop for NestedValues {
     fn drop(&mut self) {
         // Drain the root level in place: if we hold the sole reference, take the inner
@@ -215,22 +215,21 @@ impl Drop for NestedValues {
         // values never push, so this stays at capacity 0.
         let mut stack: Vec<Vec<Value>> = vec![];
         loop {
+            stack.reserve(cur_vec.len());
             for v in cur_vec {
                 match v {
                     Value::Container(c) => match c {
-                        Container::Locals(mut nv)
-                        | Container::Vec(mut nv)
-                        | Container::Struct(mut nv) => {
-                            // Drain `nv`'s inner Vec iff uniquely owned. `nv` then drops
-                            // normally — its own `Drop` re-enters this function, sees an
-                            // empty drained vec, pushes nothing, and exits.
-                            if let Some(inner_cell) = Rc::get_mut(&mut nv.0) {
-                                let inner = std::mem::take(inner_cell.get_mut());
+                        Container::Locals(nv) | Container::Vec(nv) | Container::Struct(nv) => {
+                            // Claim sole ownership of the inner `RefCell<Vec<Value>>`
+                            // if unique. On the unique path we extract the `Vec` directly.
+                            // On the shared path the returned `Rc` drops normally — just a
+                            // refcount decrement.
+                            if let Ok(inner_cell) = Rc::try_unwrap(nv.into_rc()) {
+                                let inner = inner_cell.into_inner();
                                 if !inner.is_empty() {
                                     stack.push(inner);
                                 }
                             }
-                            // Shared Rc (refcount > 1): fall through, nv drops normally.
                         },
                         // Primitive-vec variants cannot hold further `Value`s — their
                         // default drop is non-recursive and bounded.


### PR DESCRIPTION
## Why

The iterative Drop change at d0d10695 introduced a ~25% regression on Drop of wide-flat values (e.g. `vector<S>` of 30K) — surfaced as the `vector_picture30k` regression. This PR recovers most of it.

## Changes

In `NestedValues::drop`:

1. `Rc::try_unwrap(nv.into_rc())` for nested children, instead of `Rc::get_mut + mem::take`. The old code drained the inner Vec but left an empty Vec in the cell, then `nv` fell out of scope and re-entered `NestedValues::drop` to do trivial cleanup. 30K of those re-entries per palette/30k drop accounted for most of the regression.
2. `stack.reserve(cur_vec.len())` once per level. Avoids ~15 doubling reallocations of the work-stack on wide containers. No-op when the stack already has spare capacity, so deep-narrow values are unaffected.

Plus a criterion bench at `third_party/move/move-vm/types/benches/drop_bench.rs` covering both the regressing shapes and a deep-nested guard so the iterative Drop's safety property keeps being exercised.

## Numbers

Median walltime, 100 criterion samples each, on the same machine:

| Bench                          | Pre-iterative-Drop | Iterative Drop | This PR  |
|--------------------------------|--------------------|----------------|----------|
| drop/palette/30k               | 1.086 ms           | 1.387 ms       | 1.220 ms |
| drop/color_vec/30k             | 1.086 ms           | 1.365 ms       | 1.220 ms |
| drop/color_vec/1k              | 37.1 µs            | 45.3 µs        | 41.2 µs  |
| drop/vec_of_vec_struct/1000x30 | 1.055 ms           | 1.262 ms       | 1.133 ms |
| drop/vec_of_vec_u64/1000x100   | 38.9 µs            | 42.5 µs        | 40.4 µs  |
| drop/deep_nested/depth_1000    | 42.0 µs            | 36.0 µs        | 33.3 µs  |

palette/30k: ~50% of the regression closed. deep_nested stays faster than pre-iterative-Drop, so the case the iterative Drop was added for is preserved.

## Tried, didn't work

- DFS work-stack (`Vec<vec::IntoIter<Value>>` instead of `Vec<Vec<Value>>`). Per-element overhead from `stack.last_mut() + top.next() + Some/None branch` exceeded the BFS-stack savings. Slower on every bench, including deep_nested where the choice of data structure should be neutral.
- Flat single-level `match v` covering Container variants and scalars together, instead of the nested `match v { Container(c) => match c { ... } }`. LLVM produces tighter code for the nested form.

## Residual gap

~4–5 ns per outer element, width-independent. Per-element cost of the explicit match + `try_unwrap` + `push` body of `NestedValues::drop`, vs the compiler-generated `drop_in_place` recursion that the pre-iterative-Drop code used. Closing it further likely needs structural changes (e.g. tagging at construction whether a container's children contain recursive variants), which is out of scope here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches `Drop` behavior for `NestedValues` (core VM value lifecycle) and changes Rc unwrapping logic; mistakes could cause leaks or unexpected drop semantics, though changes are localized and benchmark-backed.
> 
> **Overview**
> Improves the iterative `Drop` path for Move `Value` containers by switching nested-child handling to `into_rc` + `Rc::try_unwrap` (avoiding trivial re-entry into `NestedValues::drop`) and by reserving work-stack capacity per level to reduce reallocations on wide values.
> 
> Adds a Criterion benchmark suite (`drop_bench`) and wires it into `move-vm-types` via `criterion` dev-dependency and a `[[bench]]` target to cover wide, nested, and deep-nesting drop shapes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c65e93647dc740c05492f0aef1346779114e166a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->