### PR TITLE
fix: add short-circuit for sqrt(0)

### DIFF
--- a/aptos-move/framework/aptos-stdlib/sources/math_fixed64.move
+++ b/aptos-move/framework/aptos-stdlib/sources/math_fixed64.move
@@ -14,9 +14,13 @@ module aptos_std::math_fixed64 {
     /// Square root of fixed point number
     public fun sqrt(x: FixedPoint64): FixedPoint64 {
         let y = x.get_raw_value();
-        let z = (math128::sqrt(y) << 32 as u256);
-        z = (z + ((y as u256) << 64) / z) >> 1;
-        fixed_point64::create_from_raw_value((z as u128))
+        if (y == 0) {
+            fixed_point64::create_from_raw_value(0)
+        } else {
+            let z = (math128::sqrt(y) << 32 as u256);
+            z = (z + ((y as u256) << 64) / z) >> 1;
+            fixed_point64::create_from_raw_value((z as u128))
+        }
     }
 
     /// Exponent function with a precission of 9 digits.
@@ -100,6 +104,9 @@ module aptos_std::math_fixed64 {
         let fixed_base = 1 << 64;
         let result = sqrt(fixed_point64::create_from_u128(1));
         assert!(result.get_raw_value() == fixed_base, 0);
+
+        let result = sqrt(fixed_point64::create_from_u128(0));
+        assert!(result.get_raw_value() == 0, 1);
 
         let result = sqrt(fixed_point64::create_from_u128(2));
         assert_approx_the_same((result.get_raw_value() as u256), 26087635650665564424, 16);

--- a/aptos-move/framework/aptos-stdlib/sources/math_fixed64.spec.move
+++ b/aptos-move/framework/aptos-stdlib/sources/math_fixed64.spec.move
@@ -1,9 +1,6 @@
 spec aptos_std::math_fixed64 {
-
-    /// `sqrt` aborts when the input is zero (math128::sqrt(0)==0 causes division by zero in the Newton step).
-    /// No loop in the body (single Newton refinement step), so callers can inline without havocing.
     spec sqrt(x: FixedPoint64): FixedPoint64 {
-        aborts_if x.get_raw_value() == 0;
+        aborts_if [abstract] false;
     }
 
     /// `mul_div` aborts when z is zero or when x * y / z overflows u128.


### PR DESCRIPTION
## Description
minor fix for `sqrt(0)`

## How Has This Been Tested?

## Key Areas to Review


## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [x] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk bug fix in `math_fixed64::sqrt` to avoid a division-by-zero on zero input, plus a small spec/test adjustment to match the new behavior.
> 
> **Overview**
> Updates `aptos_std::math_fixed64::sqrt` to **short-circuit zero input**, returning `0` instead of hitting a division-by-zero during the Newton refinement step.
> 
> Adds a regression test for `sqrt(0)` and relaxes the Move spec for `sqrt` to no longer state it aborts on zero.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d224065895f29bc3d55ab28a8e25e7968b6ed3ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->