### PR TITLE
[consensus] Skip decryption when block has DKG-result vtxn

### DIFF
--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -2153,21 +2153,30 @@ impl AptosVM {
             Err(_) => return unwrap_or_discard!(Err(deprecated_module_bundle!())),
         };
 
-        // If the encrypted transaction exceeded the batch limit, return Retry
-        // so it is re-queued without charging gas or incrementing sequence number.
-        if txn.payload().decryption_failure_reason()
-            == Some(&DecryptionFailureReason::BatchLimitReached)
-        {
-            return (
-                VMStatus::Error {
-                    status_code: StatusCode::UNKNOWN_STATUS,
-                    sub_status: None,
-                    message: Some(
-                        "Encrypted transaction exceeded batch limit; retrying".to_string(),
-                    ),
+        // Re-queue without charging gas or bumping the sequence number when the
+        // decryption pipeline marked this txn for retry: either the per-block
+        // batch limit was reached, or the block carried an epoch-ending vtxn so
+        // decryption was skipped to avoid leaking sender intent.
+        if let Some(reason) = txn.payload().decryption_failure_reason() {
+            let message = match reason {
+                DecryptionFailureReason::BatchLimitReached => {
+                    Some("Encrypted transaction exceeded batch limit; retrying")
                 },
-                VMOutput::empty_with_status(TransactionStatus::Retry),
-            );
+                DecryptionFailureReason::EpochEndRetry => {
+                    Some("Block contained an epoch-ending vtxn; retrying encrypted txn next epoch")
+                },
+                _ => None,
+            };
+            if let Some(message) = message {
+                return (
+                    VMStatus::Error {
+                        status_code: StatusCode::UNKNOWN_STATUS,
+                        sub_status: None,
+                        message: Some(message.to_string()),
+                    },
+                    VMOutput::empty_with_status(TransactionStatus::Retry),
+                );
+            }
         }
 
         let multisig_address = txn.multisig_address();

--- a/consensus/src/pipeline/decryption_pipeline_builder.rs
+++ b/consensus/src/pipeline/decryption_pipeline_builder.rs
@@ -28,6 +28,7 @@ use aptos_types::{
         encrypted_payload::{DecryptedPlaintext, DecryptionFailureReason, EncryptedPayload},
         SignedTransaction,
     },
+    validator_txn::ValidatorTransaction,
 };
 use rayon::iter::{IndexedParallelIterator, IntoParallelIterator, ParallelIterator};
 use std::sync::{
@@ -190,6 +191,17 @@ async fn decrypt_observer_path(
     })
 }
 
+fn block_has_epoch_end_vtxn(block: &Block) -> bool {
+    block.validator_txns().is_some_and(|vtxns| {
+        vtxns.iter().any(|v| {
+            matches!(
+                v,
+                ValidatorTransaction::DKGResult(_) | ValidatorTransaction::ChunkyDKGResult(_)
+            )
+        })
+    })
+}
+
 /// Validator path: derive key share, prepare ciphertexts, await the shared
 /// decryption key, and decrypt all encrypted transactions.
 async fn decrypt_validator_path(
@@ -208,6 +220,27 @@ async fn decrypt_validator_path(
         let _ = derived_self_key_share_tx.send(None);
         return Ok(DecryptionResult {
             decrypted_txns: Vec::new(),
+            regular_txns,
+            max_txns_from_block_to_execute,
+            block_gas_limit,
+            decryption_key: Some(None),
+        });
+    }
+
+    // Decrypting txns that the VM will skip after a NewEpochEvent leaks sender
+    // intent. If the block carries an epoch-ending vtxn, mark every encrypted
+    // txn as retry without performing any crypto work.
+    if block_has_epoch_end_vtxn(block) {
+        info!(
+            "Block {} has epoch-ending vtxn; marking {} encrypted txns as EpochEndRetry",
+            block.round(),
+            encrypted_txns.len()
+        );
+        let _ = derived_self_key_share_tx.send(None);
+        let failed_txns =
+            mark_txns_failed_decryption(encrypted_txns, DecryptionFailureReason::EpochEndRetry);
+        return Ok(DecryptionResult {
+            decrypted_txns: failed_txns,
             regular_txns,
             max_txns_from_block_to_execute,
             block_gas_limit,
@@ -474,6 +507,7 @@ fn record_decryption_metrics(result: &DecryptionResult) {
     let mut batch_limit_exceeded = 0u64;
     let mut payload_hash_mismatch = 0u64;
     let mut epoch_mismatch = 0u64;
+    let mut epoch_end_retry = 0u64;
     let mut entry_fun_mismatch = 0u64;
 
     for txn in &result.decrypted_txns {
@@ -489,6 +523,7 @@ fn record_decryption_metrics(result: &DecryptionResult) {
                 DecryptionFailureReason::DecryptionKeyUnavailable => key_unavailable += 1,
                 DecryptionFailureReason::PayloadHashMismatch => payload_hash_mismatch += 1,
                 DecryptionFailureReason::EpochMismatch => epoch_mismatch += 1,
+                DecryptionFailureReason::EpochEndRetry => epoch_end_retry += 1,
                 DecryptionFailureReason::ClaimedEntryFunctionMismatch => entry_fun_mismatch += 1,
             },
             EncryptedPayload::Encrypted(_) => {
@@ -508,6 +543,7 @@ fn record_decryption_metrics(result: &DecryptionResult) {
         ("batch_limit_exceeded", batch_limit_exceeded),
         ("payload_hash_mismatch", payload_hash_mismatch),
         ("epoch_mismatch", epoch_mismatch),
+        ("epoch_end_retry", epoch_end_retry),
         ("entry_fun_mismatch", entry_fun_mismatch),
         ("unencrypted", unencrypted),
     ];

--- a/consensus/src/pipeline/decryption_pipeline_builder.rs
+++ b/consensus/src/pipeline/decryption_pipeline_builder.rs
@@ -584,3 +584,637 @@ fn do_final_decryption(
 ) -> anyhow::Result<DecryptedPlaintext> {
     FPTXWeighted::decrypt(decryption_key, &prepared_ciphertext_or_error?)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::rand::secret_sharing::test_utils::TestContext;
+    use aptos_consensus_types::{
+        block::block_test_utils::certificate_for_genesis, block_data::BlockData, common::Payload,
+        pipelined_block::TaskError,
+    };
+    use aptos_crypto::{
+        ed25519::Ed25519PrivateKey,
+        hash::{CryptoHash, HashValue},
+        PrivateKey, SigningKey, Uniform,
+    };
+    use aptos_types::{
+        aggregate_signature::AggregateSignature,
+        chain_id::ChainId,
+        dkg::{
+            chunky_dkg::{CertifiedAggregatedChunkySubtranscript, CertifiedChunkyDKGOutput},
+            DKGTranscriptMetadata,
+        },
+        jwks::QuorumCertifiedUpdate,
+        secret_sharing::{Ciphertext, EvalProof},
+        transaction::{
+            encrypted_payload::EncryptedInner, EntryFunction, RawTransaction, Script,
+            TransactionExecutable, TransactionExtraConfig, TransactionPayload,
+        },
+        validator_txn::ValidatorTransaction,
+    };
+    use futures::FutureExt;
+    use move_core_types::{account_address::AccountAddress, ident_str, language_storage::ModuleId};
+    use rand::thread_rng;
+
+    // ---------- Test helpers ----------
+
+    fn sign_payload(payload: TransactionPayload) -> SignedTransaction {
+        let raw = RawTransaction::new(
+            AccountAddress::random(),
+            0,
+            payload,
+            0,
+            0,
+            0,
+            ChainId::new(10),
+        );
+        let private_key = Ed25519PrivateKey::generate(&mut thread_rng());
+        let public_key = private_key.public_key();
+        SignedTransaction::new(raw.clone(), public_key, private_key.sign(&raw).unwrap())
+    }
+
+    fn encrypted_inner() -> EncryptedInner {
+        EncryptedInner {
+            ciphertext: Ciphertext::random(),
+            extra_config: TransactionExtraConfig::V1 {
+                multisig_address: None,
+                replay_protection_nonce: None,
+            },
+            payload_hash: HashValue::random(),
+            encryption_epoch: 1,
+            claimed_entry_fun: None,
+        }
+    }
+
+    fn make_encrypted_txn() -> SignedTransaction {
+        sign_payload(TransactionPayload::EncryptedPayload(
+            EncryptedPayload::Encrypted(encrypted_inner()),
+        ))
+    }
+
+    fn make_failed_decryption_txn(reason: DecryptionFailureReason) -> SignedTransaction {
+        sign_payload(TransactionPayload::EncryptedPayload(
+            EncryptedPayload::FailedDecryption {
+                original: encrypted_inner(),
+                eval_proof: Some(EvalProof::random()),
+                reason,
+            },
+        ))
+    }
+
+    fn make_decrypted_txn() -> SignedTransaction {
+        let executable = TransactionExecutable::EntryFunction(EntryFunction::new(
+            ModuleId::new(AccountAddress::ONE, ident_str!("coin").to_owned()),
+            ident_str!("transfer").to_owned(),
+            vec![],
+            vec![],
+        ));
+        let plaintext = DecryptedPlaintext::new(executable, [0; 16]);
+        let mut original = encrypted_inner();
+        original.payload_hash = CryptoHash::hash(&plaintext);
+        sign_payload(TransactionPayload::EncryptedPayload(
+            EncryptedPayload::Decrypted {
+                original,
+                eval_proof: EvalProof::random(),
+                decrypted: plaintext,
+            },
+        ))
+    }
+
+    fn make_regular_txn() -> SignedTransaction {
+        sign_payload(TransactionPayload::Script(Script::new(
+            vec![],
+            vec![],
+            vec![],
+        )))
+    }
+
+    fn make_block(vtxns: Option<Vec<ValidatorTransaction>>) -> Arc<Block> {
+        let qc = certificate_for_genesis();
+        let block_data = match vtxns {
+            Some(vtxns) => BlockData::new_proposal_ext(
+                vtxns,
+                Payload::empty(false),
+                AccountAddress::random(),
+                Vec::new(),
+                1,
+                1,
+                qc,
+            ),
+            None => BlockData::new_proposal(
+                Payload::empty(false),
+                AccountAddress::random(),
+                Vec::new(),
+                1,
+                1,
+                qc,
+            ),
+        };
+        let id = block_data.hash();
+        Arc::new(Block::new_for_testing(id, block_data, None))
+    }
+
+    fn dkg_vtxn() -> ValidatorTransaction {
+        ValidatorTransaction::dummy(b"dkg".to_vec())
+    }
+
+    fn chunky_dkg_vtxn() -> ValidatorTransaction {
+        ValidatorTransaction::ChunkyDKGResult(CertifiedChunkyDKGOutput {
+            certified_transcript: CertifiedAggregatedChunkySubtranscript {
+                metadata: DKGTranscriptMetadata {
+                    epoch: 0,
+                    author: AccountAddress::ZERO,
+                },
+                transcript_bytes: vec![],
+                signature: AggregateSignature::empty(),
+            },
+            encryption_key: vec![],
+        })
+    }
+
+    fn jwk_vtxn() -> ValidatorTransaction {
+        ValidatorTransaction::ObservedJWKUpdate(QuorumCertifiedUpdate::dummy())
+    }
+
+    fn materialize_ok(txns: Vec<SignedTransaction>) -> TaskFuture<MaterializeResult> {
+        async move { Ok((txns, None, None)) }.boxed().shared()
+    }
+
+    fn materialize_err() -> TaskFuture<MaterializeResult> {
+        async {
+            Err(TaskError::InternalError(Arc::new(anyhow!(
+                "materialize failed"
+            ))))
+        }
+        .boxed()
+        .shared()
+    }
+
+    fn assert_failed_with(txn: &SignedTransaction, expected: &DecryptionFailureReason) {
+        match txn
+            .payload()
+            .as_encrypted_payload()
+            .expect("must be encrypted payload")
+        {
+            EncryptedPayload::FailedDecryption { reason, .. } => assert_eq!(reason, expected),
+            other => panic!("expected FailedDecryption, got {:?}", other),
+        }
+    }
+
+    // ---------- Helper functions and metrics ----------
+
+    #[test]
+    fn block_has_epoch_end_vtxn_returns_true_for_dkg_result() {
+        let block = make_block(Some(vec![dkg_vtxn()]));
+        assert!(block_has_epoch_end_vtxn(&block));
+    }
+
+    #[test]
+    fn block_has_epoch_end_vtxn_returns_true_for_chunky_dkg_result() {
+        let block = make_block(Some(vec![chunky_dkg_vtxn()]));
+        assert!(block_has_epoch_end_vtxn(&block));
+    }
+
+    #[test]
+    fn block_has_epoch_end_vtxn_returns_false_for_jwk_update_only() {
+        let block = make_block(Some(vec![jwk_vtxn()]));
+        assert!(!block_has_epoch_end_vtxn(&block));
+    }
+
+    #[test]
+    fn block_has_epoch_end_vtxn_returns_false_for_no_vtxns() {
+        let block = make_block(None);
+        assert!(!block_has_epoch_end_vtxn(&block));
+    }
+
+    #[test]
+    fn block_has_epoch_end_vtxn_returns_false_for_empty_vtxns() {
+        let block = make_block(Some(vec![]));
+        assert!(!block_has_epoch_end_vtxn(&block));
+    }
+
+    #[test]
+    fn block_has_epoch_end_vtxn_returns_true_for_mixed() {
+        let block = make_block(Some(vec![jwk_vtxn(), dkg_vtxn()]));
+        assert!(block_has_epoch_end_vtxn(&block));
+    }
+
+    #[test]
+    fn mark_txn_failed_decryption_transitions_state() {
+        let txn = make_encrypted_txn();
+        let proof = EvalProof::random();
+        let marked = mark_txn_failed_decryption(
+            txn,
+            Some(proof.clone()),
+            DecryptionFailureReason::CryptoFailure,
+        );
+        match marked
+            .payload()
+            .as_encrypted_payload()
+            .expect("must be encrypted")
+        {
+            EncryptedPayload::FailedDecryption {
+                eval_proof, reason, ..
+            } => {
+                assert_eq!(*reason, DecryptionFailureReason::CryptoFailure);
+                assert_eq!(eval_proof.as_ref(), Some(&proof));
+            },
+            other => panic!("expected FailedDecryption, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn mark_txns_failed_decryption_marks_all() {
+        let txns: Vec<_> = (0..3).map(|_| make_encrypted_txn()).collect();
+        let marked = mark_txns_failed_decryption(txns, DecryptionFailureReason::EpochEndRetry);
+        assert_eq!(marked.len(), 3);
+        for txn in &marked {
+            assert_failed_with(txn, &DecryptionFailureReason::EpochEndRetry);
+            // No eval_proof when bulk-marking before crypto.
+            match txn.payload().as_encrypted_payload().unwrap() {
+                EncryptedPayload::FailedDecryption { eval_proof, .. } => {
+                    assert!(eval_proof.is_none());
+                },
+                _ => unreachable!(),
+            }
+        }
+    }
+
+    #[test]
+    fn record_decryption_metrics_counts_every_variant_exhaustively() {
+        // Snapshot every label so we can assert deltas (the counter is global).
+        let labels = [
+            "decrypted",
+            "failed_decryption",
+            "config_unavailable",
+            "key_unavailable",
+            "batch_limit_exceeded",
+            "payload_hash_mismatch",
+            "epoch_mismatch",
+            "epoch_end_retry",
+            "entry_fun_mismatch",
+            "unencrypted",
+        ];
+        let before: Vec<u64> = labels
+            .iter()
+            .map(|l| {
+                counters::DECRYPTION_PIPELINE_TXNS_COUNT
+                    .with_label_values(&[l])
+                    .get()
+            })
+            .collect();
+
+        // One txn per FailedDecryption variant + one Decrypted + two regular.
+        let result = DecryptionResult {
+            decrypted_txns: vec![
+                make_decrypted_txn(),
+                make_failed_decryption_txn(DecryptionFailureReason::CryptoFailure),
+                make_failed_decryption_txn(DecryptionFailureReason::BatchLimitReached),
+                make_failed_decryption_txn(DecryptionFailureReason::ConfigUnavailable),
+                make_failed_decryption_txn(DecryptionFailureReason::DecryptionKeyUnavailable),
+                make_failed_decryption_txn(DecryptionFailureReason::PayloadHashMismatch),
+                make_failed_decryption_txn(DecryptionFailureReason::EpochMismatch),
+                make_failed_decryption_txn(DecryptionFailureReason::EpochEndRetry),
+                make_failed_decryption_txn(DecryptionFailureReason::ClaimedEntryFunctionMismatch),
+            ],
+            regular_txns: vec![make_regular_txn(), make_regular_txn()],
+            max_txns_from_block_to_execute: None,
+            block_gas_limit: None,
+            decryption_key: Some(None),
+        };
+        record_decryption_metrics(&result);
+
+        let after: Vec<u64> = labels
+            .iter()
+            .map(|l| {
+                counters::DECRYPTION_PIPELINE_TXNS_COUNT
+                    .with_label_values(&[l])
+                    .get()
+            })
+            .collect();
+        let deltas: Vec<u64> = before
+            .iter()
+            .zip(after.iter())
+            .map(|(b, a)| a - b)
+            .collect();
+        let expected = [1, 1, 1, 1, 1, 1, 1, 1, 1, 2];
+        assert_eq!(deltas, expected, "labels: {:?}", labels);
+    }
+
+    // ---------- decrypt_encrypted_txns_inner routing ----------
+
+    #[tokio::test]
+    async fn routing_disabled_marks_config_unavailable() {
+        let encrypted = vec![make_encrypted_txn(), make_encrypted_txn()];
+        let regular = vec![make_regular_txn()];
+        let mut input = encrypted.clone();
+        input.extend(regular.clone());
+
+        let (key_share_tx, key_share_rx) = oneshot::channel();
+        let (_skey_tx, skey_rx) = oneshot::channel();
+
+        let result = PipelineBuilder::decrypt_encrypted_txns_inner(
+            materialize_ok(input),
+            make_block(None),
+            AccountAddress::random(),
+            false, // is_decryption_enabled
+            None,
+            key_share_tx,
+            skey_rx,
+            false,
+            None,
+        )
+        .await
+        .expect("should succeed");
+
+        assert_eq!(result.decrypted_txns.len(), 2);
+        for txn in &result.decrypted_txns {
+            assert_failed_with(txn, &DecryptionFailureReason::ConfigUnavailable);
+        }
+        assert_eq!(result.regular_txns.len(), 1);
+        assert_eq!(result.decryption_key, None);
+        assert!(key_share_rx.await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn routing_no_config_no_observer_marks_config_unavailable() {
+        let encrypted = vec![make_encrypted_txn()];
+        let regular = vec![make_regular_txn()];
+        let mut input = encrypted.clone();
+        input.extend(regular.clone());
+
+        let (key_share_tx, key_share_rx) = oneshot::channel();
+        let (_skey_tx, skey_rx) = oneshot::channel();
+
+        let result = PipelineBuilder::decrypt_encrypted_txns_inner(
+            materialize_ok(input),
+            make_block(None),
+            AccountAddress::random(),
+            true,
+            None, // maybe_secret_share_config
+            key_share_tx,
+            skey_rx,
+            false, // observer_enabled
+            None,
+        )
+        .await
+        .expect("should succeed");
+
+        assert_eq!(result.decrypted_txns.len(), 1);
+        assert_failed_with(
+            &result.decrypted_txns[0],
+            &DecryptionFailureReason::ConfigUnavailable,
+        );
+        assert_eq!(result.regular_txns.len(), 1);
+        assert_eq!(result.decryption_key, Some(None));
+        assert!(key_share_rx.await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn routing_no_config_with_observer_uses_observer_path() {
+        // Observer path: encrypted txns are NOT marked here (the observer
+        // consumes pre-decrypted txns provided by the validator).
+        let encrypted = vec![make_encrypted_txn()];
+        let observer_decrypted = vec![make_decrypted_txn()];
+        let mut input = encrypted.clone();
+        input.push(make_regular_txn());
+
+        let (key_share_tx, _key_share_rx) = oneshot::channel();
+        let (skey_tx, skey_rx) = oneshot::channel();
+        skey_tx.send(None).unwrap();
+
+        let result = PipelineBuilder::decrypt_encrypted_txns_inner(
+            materialize_ok(input),
+            make_block(None),
+            AccountAddress::random(),
+            true,
+            None,
+            key_share_tx,
+            skey_rx,
+            true, // observer_enabled
+            Some(observer_decrypted.clone()),
+        )
+        .await
+        .expect("should succeed");
+
+        // Observer-path output: decrypted_txns mirror the provided observer txns
+        // (Decrypted state, not FailedDecryption).
+        assert_eq!(result.decrypted_txns.len(), 1);
+        assert!(matches!(
+            result.decrypted_txns[0]
+                .payload()
+                .as_encrypted_payload()
+                .unwrap(),
+            EncryptedPayload::Decrypted { .. }
+        ));
+        assert_eq!(result.decryption_key, Some(None));
+    }
+
+    #[tokio::test]
+    async fn routing_propagates_materialize_fut_error() {
+        let (key_share_tx, _key_share_rx) = oneshot::channel();
+        let (_skey_tx, skey_rx) = oneshot::channel();
+
+        let err = PipelineBuilder::decrypt_encrypted_txns_inner(
+            materialize_err(),
+            make_block(None),
+            AccountAddress::random(),
+            true,
+            None,
+            key_share_tx,
+            skey_rx,
+            false,
+            None,
+        )
+        .await
+        .expect_err("should propagate error");
+
+        assert!(format!("{}", err).contains("materialize failed"));
+    }
+
+    // ---------- decrypt_observer_path ----------
+
+    #[tokio::test]
+    async fn observer_with_key_and_decrypted_txns_passes_through() {
+        let ctx = TestContext::new(vec![100]);
+        let metadata = crate::rand::secret_sharing::test_utils::create_metadata(1, 1);
+        let key =
+            crate::rand::secret_sharing::test_utils::create_secret_shared_key(&ctx, &metadata);
+
+        let regular = vec![make_regular_txn()];
+        let observer_decrypted = vec![make_decrypted_txn(), make_decrypted_txn()];
+
+        let (skey_tx, skey_rx) = oneshot::channel();
+        skey_tx.send(Some(key)).unwrap();
+
+        let result = decrypt_observer_path(
+            vec![],
+            regular.clone(),
+            skey_rx,
+            Some(observer_decrypted.clone()),
+            None,
+            None,
+        )
+        .await
+        .expect("should succeed");
+
+        assert_eq!(result.decrypted_txns.len(), 2);
+        assert!(matches!(result.decryption_key, Some(Some(_))));
+        assert_eq!(result.regular_txns.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn observer_with_no_key_but_decrypted_txns_returns_some_none() {
+        let observer_decrypted = vec![make_decrypted_txn()];
+        let (skey_tx, skey_rx) = oneshot::channel();
+        skey_tx.send(None).unwrap();
+
+        let result = decrypt_observer_path(
+            vec![],
+            vec![],
+            skey_rx,
+            Some(observer_decrypted.clone()),
+            None,
+            None,
+        )
+        .await
+        .expect("should succeed");
+
+        assert_eq!(result.decrypted_txns.len(), 1);
+        assert_eq!(result.decryption_key, Some(None));
+    }
+
+    #[tokio::test]
+    async fn observer_with_no_key_no_txns_returns_empty() {
+        let (skey_tx, skey_rx) = oneshot::channel();
+        skey_tx.send(None).unwrap();
+
+        let result = decrypt_observer_path(vec![], vec![], skey_rx, None, None, None)
+            .await
+            .expect("should succeed");
+
+        assert!(result.decrypted_txns.is_empty());
+        assert_eq!(result.decryption_key, Some(None));
+    }
+
+    #[tokio::test]
+    async fn observer_with_dropped_rx_returns_error() {
+        let (skey_tx, skey_rx) = oneshot::channel::<Option<SecretSharedKey>>();
+        drop(skey_tx);
+
+        let err = decrypt_observer_path(vec![], vec![], skey_rx, None, None, None)
+            .await
+            .expect_err("should error");
+        assert!(format!("{}", err).contains("secret_shared_key_rx dropped"));
+    }
+
+    #[tokio::test]
+    async fn observer_preserves_regular_txns() {
+        let regular = vec![make_regular_txn(), make_regular_txn(), make_regular_txn()];
+        let (skey_tx, skey_rx) = oneshot::channel();
+        skey_tx.send(None).unwrap();
+
+        let result = decrypt_observer_path(vec![], regular.clone(), skey_rx, None, None, None)
+            .await
+            .expect("should succeed");
+
+        assert_eq!(result.regular_txns.len(), regular.len());
+    }
+
+    // ---------- decrypt_validator_path (pre-crypto branches) ----------
+
+    #[tokio::test]
+    async fn validator_path_empty_encrypted_txns_short_circuits() {
+        let ctx = TestContext::new(vec![100]);
+        let block = make_block(None);
+        let regular = vec![make_regular_txn()];
+
+        let (key_share_tx, key_share_rx) = oneshot::channel();
+        let (_skey_tx, skey_rx) = oneshot::channel();
+
+        let result = decrypt_validator_path(
+            vec![], // empty encrypted_txns
+            regular.clone(),
+            &block,
+            ctx.authors[0],
+            &ctx.secret_share_config,
+            key_share_tx,
+            skey_rx,
+            None,
+            None,
+        )
+        .await
+        .expect("should succeed");
+
+        assert!(result.decrypted_txns.is_empty());
+        assert_eq!(result.regular_txns.len(), 1);
+        assert_eq!(result.decryption_key, Some(None));
+        assert!(key_share_rx.await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn validator_path_dkg_result_vtxn_marks_all_epoch_end_retry() {
+        let ctx = TestContext::new(vec![100]);
+        let block = make_block(Some(vec![dkg_vtxn()]));
+        let encrypted = vec![make_encrypted_txn(), make_encrypted_txn()];
+        let regular = vec![make_regular_txn()];
+
+        let (key_share_tx, key_share_rx) = oneshot::channel();
+        let (_skey_tx, skey_rx) = oneshot::channel();
+
+        let result = decrypt_validator_path(
+            encrypted.clone(),
+            regular.clone(),
+            &block,
+            ctx.authors[0],
+            &ctx.secret_share_config,
+            key_share_tx,
+            skey_rx,
+            None,
+            None,
+        )
+        .await
+        .expect("should succeed");
+
+        assert_eq!(result.decrypted_txns.len(), 2);
+        for txn in &result.decrypted_txns {
+            assert_failed_with(txn, &DecryptionFailureReason::EpochEndRetry);
+        }
+        assert_eq!(result.regular_txns.len(), 1);
+        assert_eq!(result.decryption_key, Some(None));
+        assert!(key_share_rx.await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn validator_path_chunky_dkg_result_vtxn_marks_all_epoch_end_retry() {
+        let ctx = TestContext::new(vec![100]);
+        let block = make_block(Some(vec![chunky_dkg_vtxn()]));
+        let encrypted = vec![make_encrypted_txn()];
+
+        let (key_share_tx, key_share_rx) = oneshot::channel();
+        let (_skey_tx, skey_rx) = oneshot::channel();
+
+        let result = decrypt_validator_path(
+            encrypted,
+            vec![],
+            &block,
+            ctx.authors[0],
+            &ctx.secret_share_config,
+            key_share_tx,
+            skey_rx,
+            None,
+            None,
+        )
+        .await
+        .expect("should succeed");
+
+        assert_eq!(result.decrypted_txns.len(), 1);
+        assert_failed_with(
+            &result.decrypted_txns[0],
+            &DecryptionFailureReason::EpochEndRetry,
+        );
+        assert_eq!(result.decryption_key, Some(None));
+        assert!(key_share_rx.await.unwrap().is_none());
+    }
+}

--- a/consensus/src/rand/secret_sharing/mod.rs
+++ b/consensus/src/rand/secret_sharing/mod.rs
@@ -7,6 +7,6 @@ pub mod reliable_broadcast_state;
 pub mod secret_share_manager;
 pub mod secret_share_store;
 #[cfg(test)]
-mod test_utils;
+pub(crate) mod test_utils;
 pub mod types;
 pub mod verifier;

--- a/testsuite/generate-format/tests/staged/api.yaml
+++ b/testsuite/generate-format/tests/staged/api.yaml
@@ -374,6 +374,8 @@ DecryptionFailureReason:
       PayloadHashMismatch: UNIT
     6:
       EpochMismatch: UNIT
+    7:
+      EpochEndRetry: UNIT
 DepositEvent:
   STRUCT:
     - amount: U64

--- a/testsuite/generate-format/tests/staged/aptos.yaml
+++ b/testsuite/generate-format/tests/staged/aptos.yaml
@@ -354,6 +354,8 @@ DecryptionFailureReason:
       PayloadHashMismatch: UNIT
     6:
       EpochMismatch: UNIT
+    7:
+      EpochEndRetry: UNIT
 DeprecatedPayload:
   STRUCT:
     - dummy_value: U64

--- a/testsuite/generate-format/tests/staged/consensus.yaml
+++ b/testsuite/generate-format/tests/staged/consensus.yaml
@@ -674,6 +674,8 @@ DecryptionFailureReason:
       PayloadHashMismatch: UNIT
     6:
       EpochMismatch: UNIT
+    7:
+      EpochEndRetry: UNIT
 DeprecatedPayload:
   STRUCT:
     - dummy_value: U64

--- a/types/src/transaction/encrypted_payload.rs
+++ b/types/src/transaction/encrypted_payload.rs
@@ -85,6 +85,11 @@ pub enum DecryptionFailureReason {
     PayloadHashMismatch,
     /// The payload was encrypted for a different epoch than the available decryption key.
     EpochMismatch,
+    /// The block contains an epoch-ending validator transaction (DKGResult /
+    /// ChunkyDKGResult). Decrypting txns that the VM will skip post-NewEpochEvent
+    /// would leak sender intent, so the txn is failed with retry semantics and
+    /// the user resubmits in the next epoch with the rotated key.
+    EpochEndRetry,
 }
 
 // Mirrors EntryFunction in types/src/transaction/script.rs


### PR DESCRIPTION
## Summary

- Fixes an intent-disclosure leak at epoch boundaries: encrypted txns landing behind a `DKGResult` / `ChunkyDKGResult` vtxn were being decrypted by the consensus pipeline even though the VM skips them post-`NewEpochEvent`. The plaintext was visible to validators / observers without the sender's consent. A malicious proposer could deliberately position a target txn after the vtxn to force the leak.
- New `DecryptionFailureReason::EpochEndRetry` (mirrors `BatchLimitReached`'s VM retry semantics — `TransactionStatus::Retry`, no gas charge, no sequence-number bump).
- `decrypt_validator_path` short-circuits when the block carries an epoch-ending vtxn: marks every encrypted txn as `EpochEndRetry` without performing any crypto work. Sender resubmits in the next epoch with the rotated key. Helper `block_has_epoch_end_vtxn` excludes `ObservedJWKUpdate` since it does not reconfigure.
- Audit context: this addresses a component of the encrypted mempool security audit.

## Test plan

- [x] `cargo check -p aptos-consensus -p aptos-types -p aptos-vm` (clean)
- [x] `cargo +nightly fmt -p aptos-consensus -p aptos-types -p aptos-vm --check` (clean)
- [x] `cargo clippy -p aptos-consensus -p aptos-types -p aptos-vm --all-targets` (no new warnings on touched files)
- [x] `cargo test -p generate-format` (serde format YAML changes match the new enum variant)
- [x] `cargo test -p aptos-types --lib transaction::encrypted_payload` (4/4)
- [x] `cargo test -p aptos-consensus --lib pipeline::decryption_pipeline_builder::tests` (21/21 in 1.5s)
- [ ] Manual smoke on a chunky-DKG test net: trigger a DKG-result block while encrypted txns are pending; confirm those txns are not visible decrypted in logs/metrics, that `epoch_end_retry` counter increments, and that the sender's resubmission in the next epoch executes successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)