### PR TITLE
[block-executor] replace rayon BlockSTM pool with plain std-thread pool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2974,7 +2974,6 @@ dependencies = [
  "proptest",
  "proptest-derive",
  "rand 0.7.3",
- "rayon",
  "serde",
 ]
 
@@ -9932,7 +9931,6 @@ dependencies = [
  "move-vm-types",
  "once_cell",
  "primitive-types",
- "rayon",
  "ring 0.16.20",
  "serde",
  "serde_json",

--- a/aptos-move/aptos-vm/src/block_executor/mod.rs
+++ b/aptos-move/aptos-vm/src/block_executor/mod.rs
@@ -19,7 +19,6 @@ use aptos_block_executor::{
     txn_provider::TxnProvider,
     types::InputOutputKey,
 };
-use aptos_logger::info;
 use aptos_types::{
     block_executor::{
         config::BlockExecutorConfig, transaction_slice_metadata::TransactionSliceMetadata,
@@ -50,19 +49,9 @@ use once_cell::sync::OnceCell;
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
     marker::PhantomData,
-    sync::{Arc, Mutex},
 };
 use triomphe::Arc as TriompheArc;
 use vm_wrapper::AptosExecutorTask;
-
-/// Thread pool used by `execute_block` for parallel transaction execution.
-///
-/// Stores `(pool, num_threads)` so we can detect when the requested concurrency level
-/// changes and recreate the pool. In production the concurrency level is set once at
-/// startup, so the pool is created once and the mutex is uncontended thereafter.
-/// Benchmarking and debugging tools may iterate over multiple concurrency levels in the
-/// same process, which requires replacing the pool.
-static RAYON_EXEC_POOL: Mutex<Option<(Arc<rayon::ThreadPool>, usize)>> = Mutex::new(None);
 
 /// Output type wrapper used by block executor. VM output is stored first, then
 /// transformed into TransactionOutput type that is returned.
@@ -512,12 +501,11 @@ impl<
         >,
     > AptosBlockExecutorWrapper<E>
 {
-    pub fn execute_block_on_thread_pool<
+    pub fn execute_block<
         S: StateView + Sync,
         L: TransactionCommitHook,
         TP: TxnProvider<SignatureVerifiedTransaction, AuxiliaryInfo> + Sync,
     >(
-        executor_thread_pool: Arc<rayon::ThreadPool>,
         signature_verified_block: &TP,
         state_view: &S,
         module_cache_manager: &AptosModuleCacheManager,
@@ -545,7 +533,6 @@ impl<
         let executor =
             BlockExecutor::<SignatureVerifiedTransaction, E, S, L, TP, AuxiliaryInfo>::new(
                 config,
-                executor_thread_pool,
                 transaction_commit_listener,
             );
 
@@ -583,46 +570,6 @@ impl<
             }),
             Err(BlockExecutionError::FatalVMError(err)) => Err(err),
         }
-    }
-
-    /// Uses shared thread pool to execute blocks.
-    pub(crate) fn execute_block<
-        S: StateView + Sync,
-        L: TransactionCommitHook,
-        TP: TxnProvider<SignatureVerifiedTransaction, AuxiliaryInfo> + Sync,
-    >(
-        signature_verified_block: &TP,
-        state_view: &S,
-        module_cache_manager: &AptosModuleCacheManager,
-        config: BlockExecutorConfig,
-        transaction_slice_metadata: TransactionSliceMetadata,
-        transaction_commit_listener: Option<L>,
-    ) -> Result<BlockOutput<SignatureVerifiedTransaction, TransactionOutput>, VMStatus> {
-        let num_threads = std::cmp::min(config.local.concurrency_level, num_cpus::get());
-        let pool = match &mut *RAYON_EXEC_POOL.lock().unwrap() {
-            Some((pool, n)) if *n == num_threads => Arc::clone(pool),
-            slot => {
-                info!(num_threads = num_threads, "Creating par_exec thread pool");
-                let pool = Arc::new(
-                    rayon::ThreadPoolBuilder::new()
-                        .num_threads(num_threads)
-                        .thread_name(|index| format!("par_exec-{}", index))
-                        .build()
-                        .unwrap(),
-                );
-                *slot = Some((Arc::clone(&pool), num_threads));
-                pool
-            },
-        };
-        Self::execute_block_on_thread_pool::<S, L, TP>(
-            pool,
-            signature_verified_block,
-            state_view,
-            module_cache_manager,
-            config,
-            transaction_slice_metadata,
-            transaction_commit_listener,
-        )
     }
 }
 

--- a/aptos-move/aptos-vm/src/sharded_block_executor/sharded_executor_service.rs
+++ b/aptos-move/aptos-vm/src/sharded_block_executor/sharded_executor_service.rs
@@ -142,8 +142,7 @@ impl<S: StateView + Sync + Send + 'static> ShardedExecutorService<S> {
             s.spawn(move |_| {
                 let txn_provider =
                     DefaultTxnProvider::new_without_info(signature_verified_transactions);
-                let ret = AptosVMBlockExecutorWrapper::execute_block_on_thread_pool(
-                    executor_thread_pool,
+                let ret = AptosVMBlockExecutorWrapper::execute_block(
                     &txn_provider,
                     aggr_overridden_state_view.as_ref(),
                     // Since we execute blocks in parallel, we cannot share module caches, so each

--- a/aptos-move/block-executor/src/combinatorial_tests/bencher.rs
+++ b/aptos-move/block-executor/src/combinatorial_tests/bencher.rs
@@ -31,7 +31,7 @@ use proptest::{
     strategy::{Strategy, ValueTree},
     test_runner::TestRunner,
 };
-use std::{fmt::Debug, hash::Hash, marker::PhantomData, sync::Arc};
+use std::{fmt::Debug, hash::Hash, marker::PhantomData};
 
 pub struct Bencher<K, V, E> {
     transaction_size: usize,
@@ -126,13 +126,6 @@ where
     pub(crate) fn run(self) {
         let state_view = MockStateView::empty();
 
-        let executor_thread_pool = Arc::new(
-            rayon::ThreadPoolBuilder::new()
-                .num_threads(num_cpus::get())
-                .build()
-                .unwrap(),
-        );
-
         let config = BlockExecutorConfig::new_no_block_limit(num_cpus::get());
         let mut guard = AptosModuleCacheManagerGuard::none();
 
@@ -143,7 +136,7 @@ where
             NoOpTransactionCommitHook<usize>,
             DefaultTxnProvider<MockTransaction<KeyType<K>, E>, AuxiliaryInfo>,
             AuxiliaryInfo,
-        >::new(config, executor_thread_pool, None)
+        >::new(config, None)
         .execute_transactions_parallel(
             &self.txns_provider,
             &state_view,

--- a/aptos-move/block-executor/src/combinatorial_tests/delayed_field_tests.rs
+++ b/aptos-move/block-executor/src/combinatorial_tests/delayed_field_tests.rs
@@ -5,7 +5,7 @@ use crate::{
     combinatorial_tests::{
         group_tests::{create_non_empty_group_data_view, run_tests_with_groups},
         mock_executor::{MockEvent, MockTask},
-        resource_tests::{create_executor_thread_pool, get_gas_limit_variants},
+        resource_tests::get_gas_limit_variants,
         types::{KeyType, MockTransaction, TransactionGen, TransactionGenParams},
     },
     task::ExecutorTask,
@@ -65,12 +65,9 @@ fn delayed_field_transaction_tests(
 
     let data_view = create_non_empty_group_data_view(&key_universe, universe_size, true);
 
-    let executor_thread_pool = create_executor_thread_pool();
-
     let gas_limits = get_gas_limit_variants(use_gas_limit, transaction_count);
 
     run_tests_with_groups(
-        executor_thread_pool,
         gas_limits,
         transactions,
         &data_view,

--- a/aptos-move/block-executor/src/combinatorial_tests/delta_tests.rs
+++ b/aptos-move/block-executor/src/combinatorial_tests/delta_tests.rs
@@ -6,8 +6,7 @@ use crate::{
         baseline::BaselineOutput,
         mock_executor::{MockEvent, MockTask},
         resource_tests::{
-            create_executor_thread_pool, execute_block_parallel,
-            generate_universe_and_transactions, get_gas_limit_variants,
+            execute_block_parallel, generate_universe_and_transactions, get_gas_limit_variants,
         },
         types::{DeltaDataView, KeyType, MockTransaction},
     },
@@ -27,8 +26,6 @@ fn run_transactions_deltas(
     num_executions: usize,
     num_random_generations: usize,
 ) {
-    let executor_thread_pool = create_executor_thread_pool();
-
     // The delta threshold controls how many keys / paths are guaranteed r/w resources even
     // in the presence of deltas.
     let delta_threshold = std::cmp::min(15, universe_size / 2);
@@ -66,7 +63,6 @@ fn run_transactions_deltas(
                         AuxiliaryInfo,
                     >,
                 >(
-                    executor_thread_pool.clone(),
                     maybe_block_gas_limit,
                     &txn_provider,
                     &data_view,

--- a/aptos-move/block-executor/src/combinatorial_tests/group_tests.rs
+++ b/aptos-move/block-executor/src/combinatorial_tests/group_tests.rs
@@ -6,9 +6,7 @@ use crate::{
     combinatorial_tests::{
         baseline::BaselineOutput,
         mock_executor::{MockEvent, MockTask},
-        resource_tests::{
-            create_executor_thread_pool, execute_block_parallel, get_gas_limit_variants,
-        },
+        resource_tests::{execute_block_parallel, get_gas_limit_variants},
         types::{
             KeyType, MockTransaction, NonEmptyGroupDataView, TransactionGen, TransactionGenParams,
         },
@@ -26,7 +24,6 @@ use aptos_types::{
     transaction::AuxiliaryInfo,
 };
 use proptest::{collection::vec, prelude::*, strategy::ValueTree, test_runner::TestRunner};
-use std::sync::Arc;
 use test_case::test_case;
 
 /// Create a data view for testing with non-empty groups
@@ -46,7 +43,6 @@ pub(crate) fn create_non_empty_group_data_view(
 
 /// Run both parallel and sequential execution tests for a transaction provider
 pub(crate) fn run_tests_with_groups(
-    executor_thread_pool: Arc<rayon::ThreadPool>,
     gas_limits: Vec<Option<u64>>,
     transactions: Vec<MockTransaction<KeyType<[u8; 32]>, MockEvent>>,
     data_view: &NonEmptyGroupDataView<KeyType<[u8; 32]>>,
@@ -71,7 +67,6 @@ pub(crate) fn run_tests_with_groups(
                         AuxiliaryInfo,
                     >,
                 >(
-                    executor_thread_pool.clone(),
                     *maybe_block_gas_limit,
                     &txn_provider,
                     data_view,
@@ -98,7 +93,6 @@ pub(crate) fn run_tests_with_groups(
             AuxiliaryInfo,
         >::new(
             BlockExecutorConfig::new_no_block_limit(num_cpus::get()),
-            executor_thread_pool.clone(),
             None,
         )
         .execute_transactions_sequential(
@@ -169,11 +163,9 @@ fn non_empty_group_transaction_tests(
         .collect();
 
     let data_view = create_non_empty_group_data_view(&key_universe, universe_size, false);
-    let executor_thread_pool = create_executor_thread_pool();
     let gas_limits = get_gas_limit_variants(use_gas_limit, transaction_count);
 
     run_tests_with_groups(
-        executor_thread_pool,
         gas_limits,
         transactions,
         &data_view,

--- a/aptos-move/block-executor/src/combinatorial_tests/module_tests.rs
+++ b/aptos-move/block-executor/src/combinatorial_tests/module_tests.rs
@@ -5,9 +5,7 @@ use crate::{
     combinatorial_tests::{
         baseline::BaselineOutput,
         mock_executor::{MockEvent, MockTask},
-        resource_tests::{
-            create_executor_thread_pool, execute_block_parallel, get_gas_limit_variants,
-        },
+        resource_tests::{execute_block_parallel, get_gas_limit_variants},
         types::{
             key_to_mock_module_id, KeyType, MockTransaction, TransactionGen, TransactionGenParams,
         },
@@ -48,7 +46,6 @@ fn execute_module_tests(
     assert!(fail::has_failpoints());
     fail::cfg("module_test", "return").unwrap();
 
-    let executor_thread_pool = create_executor_thread_pool();
     let mut runner = TestRunner::default();
 
     let module_id_pool = InternedModuleIdPool::new();
@@ -124,7 +121,6 @@ fn execute_module_tests(
                         AuxiliaryInfo,
                     >,
                 >(
-                    executor_thread_pool.clone(),
                     *maybe_block_gas_limit,
                     &txn_provider,
                     &state_view,

--- a/aptos-move/block-executor/src/combinatorial_tests/pre_write_tests.rs
+++ b/aptos-move/block-executor/src/combinatorial_tests/pre_write_tests.rs
@@ -15,7 +15,6 @@ use crate::{
     code_cache_global_manager::AptosModuleCacheManagerGuard,
     combinatorial_tests::{
         mock_executor::{MockEvent, MockOutput, MockTask},
-        resource_tests::create_executor_thread_pool,
         types::{KeyType, MockIncarnation, MockTransaction, ValueType},
     },
     executor::BlockExecutor,
@@ -44,7 +43,6 @@ fn execute_block_with_pre_write_config<Provider>(
 where
     Provider: TxnProvider<TestTransaction, AuxiliaryInfo> + Sync + 'static,
 {
-    let executor_thread_pool = create_executor_thread_pool();
     let mut guard = AptosModuleCacheManagerGuard::none();
 
     let config = BlockExecutorConfig::new_maybe_block_limit(num_cpus::get(), None);
@@ -55,7 +53,7 @@ where
         NoOpTransactionCommitHook<usize>,
         Provider,
         AuxiliaryInfo,
-    >::new(config, executor_thread_pool, None);
+    >::new(config, None);
 
     if block_stm_v2 {
         block_executor.execute_transactions_parallel_v2(

--- a/aptos-move/block-executor/src/combinatorial_tests/resource_tests.rs
+++ b/aptos-move/block-executor/src/combinatorial_tests/resource_tests.rs
@@ -49,15 +49,6 @@ pub(crate) fn get_gas_limit_variants(
     }
 }
 
-pub(crate) fn create_executor_thread_pool() -> Arc<rayon::ThreadPool> {
-    Arc::new(
-        rayon::ThreadPoolBuilder::new()
-            .num_threads(num_cpus::get())
-            .build()
-            .unwrap(),
-    )
-}
-
 /// Populates a module cache manager guard with empty modules for testing.
 /// This function creates empty modules for each ModuleId in the provided list and adds them to the guard's module cache.
 ///
@@ -98,7 +89,6 @@ pub(crate) fn populate_guard_with_modules(
 }
 
 pub(crate) fn execute_block_parallel<TxnType, ViewType, Provider>(
-    executor_thread_pool: Arc<rayon::ThreadPool>,
     block_gas_limit: Option<u64>,
     txn_provider: &Provider,
     data_view: &ViewType,
@@ -126,7 +116,7 @@ where
         NoOpTransactionCommitHook<usize>,
         Provider,
         AuxiliaryInfo,
-    >::new(config, executor_thread_pool, None);
+    >::new(config, None);
 
     if block_stm_v2 {
         block_executor.execute_transactions_parallel_v2(
@@ -183,7 +173,6 @@ pub(crate) fn run_transactions_resources(
     num_executions: usize,
     num_random_generations: usize,
 ) {
-    let executor_thread_pool = create_executor_thread_pool();
     let mut runner = TestRunner::default();
 
     let gas_limits = get_gas_limit_variants(use_gas_limit, transaction_count);
@@ -246,7 +235,6 @@ pub(crate) fn run_transactions_resources(
                             AuxiliaryInfo,
                         >,
                     >(
-                        executor_thread_pool.clone(),
                         *maybe_block_gas_limit,
                         &txn_provider,
                         &state_view,

--- a/aptos-move/block-executor/src/counters.rs
+++ b/aptos-move/block-executor/src/counters.rs
@@ -361,6 +361,14 @@ pub static BLOCKSTM_VERSION_NUMBER: Lazy<IntGauge> = Lazy::new(|| {
     .unwrap()
 });
 
+pub static PAR_EXEC_POOL_SIZE: Lazy<IntGauge> = Lazy::new(|| {
+    register_int_gauge!(
+        "par_exec_pool_size",
+        "Number of worker threads currently spawned in the BlockSTM worker pool"
+    )
+    .unwrap()
+});
+
 pub static GLOBAL_MODULE_CACHE_SIZE_IN_BYTES: Lazy<IntGauge> = Lazy::new(|| {
     register_int_gauge!(
         "global_module_cache_size_in_bytes",

--- a/aptos-move/block-executor/src/executor.rs
+++ b/aptos-move/block-executor/src/executor.rs
@@ -27,6 +27,7 @@ use crate::{
     txn_provider::TxnProvider,
     types::ReadWriteSummary,
     view::{LatestView, ParallelState, SequentialState, ViewState},
+    worker_pool::WorkerPool,
 };
 use aptos_aggregator::{
     delayed_change::{ApplyBase, DelayedChange},
@@ -67,15 +68,12 @@ use move_core_types::{language_storage::ModuleId, value::MoveTypeLayout, vm_stat
 use move_vm_runtime::{Module, RuntimeEnvironment, TypeChecker, WithRuntimeEnvironment};
 use move_vm_types::delayed_values::delayed_field_id::DelayedFieldID;
 use num_cpus;
-use rayon::ThreadPool;
+use once_cell::sync::Lazy;
 use std::{
     cell::RefCell,
     collections::{BTreeMap, BTreeSet, HashMap, HashSet},
     marker::{PhantomData, Sync},
-    sync::{
-        atomic::{AtomicBool, AtomicU32, Ordering},
-        Arc,
-    },
+    sync::atomic::{AtomicBool, AtomicU32, Ordering},
 };
 use triomphe::Arc as TriompheArc;
 
@@ -98,11 +96,11 @@ where
     maybe_block_epilogue_txn_idx: &'a ExplicitSyncWrapper<Option<TxnIndex>>,
 }
 
+/// BlockSTM worker pool.
+static WORKER_POOL: Lazy<WorkerPool> = Lazy::new(WorkerPool::new);
+
 pub struct BlockExecutor<T, E, S, L, TP, A> {
-    // Number of active concurrent tasks, corresponding to the maximum number of rayon
-    // threads that may be concurrently participating in parallel execution.
     config: BlockExecutorConfig,
-    executor_thread_pool: Arc<rayon::ThreadPool>,
     transaction_commit_hook: Option<L>,
     phantom: PhantomData<fn() -> (T, E, S, L, TP, A)>,
 }
@@ -118,11 +116,7 @@ where
 {
     /// The caller needs to ensure that concurrency_level > 1 (0 is illegal and 1 should
     /// be handled by sequential execution) and that concurrency_level <= num_cpus.
-    pub fn new(
-        config: BlockExecutorConfig,
-        executor_thread_pool: Arc<ThreadPool>,
-        transaction_commit_hook: Option<L>,
-    ) -> Self {
+    pub fn new(config: BlockExecutorConfig, transaction_commit_hook: Option<L>) -> Self {
         let num_cpus = num_cpus::get();
         assert!(
             config.local.concurrency_level > 0 && config.local.concurrency_level <= num_cpus,
@@ -132,7 +126,6 @@ where
         );
         Self {
             config,
-            executor_thread_pool,
             transaction_commit_hook,
             phantom: PhantomData,
         }
@@ -1852,48 +1845,44 @@ where
         );
 
         let timer = RAYON_EXECUTION_SECONDS.start_timer();
-        let worker_ids: Vec<u32> = (0..num_workers).collect();
         let maybe_executor = ExplicitSyncWrapper::new(None);
-        self.executor_thread_pool.scope(|s| {
-            for worker_id in &worker_ids {
-                s.spawn(|_| {
-                    let environment = module_cache_manager_guard.environment();
-                    let executor = {
-                        let _init_timer = VM_INIT_SECONDS.start_timer();
-                        E::init(
-                            &environment.clone(),
-                            shared_sync_params.base_view,
-                            async_runtime_checks_enabled,
-                        )
-                    };
+        WORKER_POOL.scope(num_workers as usize, |worker_id| {
+            let worker_id = worker_id as u32;
+            let environment = module_cache_manager_guard.environment();
+            let executor = {
+                let _init_timer = VM_INIT_SECONDS.start_timer();
+                E::init(
+                    &environment.clone(),
+                    shared_sync_params.base_view,
+                    async_runtime_checks_enabled,
+                )
+            };
 
-                    if let Err(err) = self.worker_loop_v2(
-                        &executor,
-                        signature_verified_block,
-                        environment,
-                        *worker_id,
-                        num_workers,
-                        &scheduler,
-                        &shared_sync_params,
-                    ) {
-                        // If there are multiple errors, they all get logged: FatalVMError is
-                        // logged at construction, below we log CodeInvariantErrors.
-                        if let PanicOr::CodeInvariantError(err_msg) = err {
-                            alert!(
-                                "[BlockSTMv2] worker loop: CodeInvariantError({:?})",
-                                err_msg
-                            );
-                        }
-                        shared_maybe_error.store(true, Ordering::SeqCst);
+            if let Err(err) = self.worker_loop_v2(
+                &executor,
+                signature_verified_block,
+                environment,
+                worker_id,
+                num_workers,
+                &scheduler,
+                &shared_sync_params,
+            ) {
+                // If there are multiple errors, they all get logged: FatalVMError is
+                // logged at construction, below we log CodeInvariantErrors.
+                if let PanicOr::CodeInvariantError(err_msg) = err {
+                    alert!(
+                        "[BlockSTMv2] worker loop: CodeInvariantError({:?})",
+                        err_msg
+                    );
+                }
+                shared_maybe_error.store(true, Ordering::SeqCst);
 
-                        // Make sure to halt the scheduler if it hasn't already been halted.
-                        scheduler.halt();
-                    }
+                // Make sure to halt the scheduler if it hasn't already been halted.
+                scheduler.halt();
+            }
 
-                    if *worker_id == 0 {
-                        maybe_executor.acquire().replace(executor);
-                    }
-                });
+            if worker_id == 0 {
+                maybe_executor.acquire().replace(executor);
             }
         });
         drop(timer);
@@ -2003,7 +1992,6 @@ where
         let scheduler = Scheduler::new(num_txns);
 
         let timer = RAYON_EXECUTION_SECONDS.start_timer();
-        let worker_ids: Vec<u32> = (0..num_workers as u32).collect();
         let maybe_executor = ExplicitSyncWrapper::new(None);
 
         let shared_sync_params: SharedSyncParams<'_, T, E, S> = SharedSyncParams {
@@ -2021,47 +2009,44 @@ where
         let async_runtime_checks_enabled = should_perform_async_runtime_checks_for_block(
             module_cache_manager_guard.environment(),
             num_txns,
-            worker_ids.len() as u32,
+            num_workers as u32,
         );
 
-        self.executor_thread_pool.scope(|s| {
-            for worker_id in &worker_ids {
-                s.spawn(|_| {
-                    let environment = module_cache_manager_guard.environment();
-                    let executor = {
-                        let _init_timer = VM_INIT_SECONDS.start_timer();
-                        E::init(
-                            &environment.clone(),
-                            base_view,
-                            async_runtime_checks_enabled,
-                        )
-                    };
+        WORKER_POOL.scope(num_workers, |worker_id| {
+            let worker_id = worker_id as u32;
+            let environment = module_cache_manager_guard.environment();
+            let executor = {
+                let _init_timer = VM_INIT_SECONDS.start_timer();
+                E::init(
+                    &environment.clone(),
+                    base_view,
+                    async_runtime_checks_enabled,
+                )
+            };
 
-                    if let Err(err) = self.worker_loop(
-                        &executor,
-                        environment,
-                        signature_verified_block,
-                        &scheduler,
-                        &skip_module_reads_validation,
-                        &shared_sync_params,
-                        num_workers,
-                    ) {
-                        // If there are multiple errors, they all get logged:
-                        // ModulePathReadWriteError and FatalVMError variant is logged at construction,
-                        // and below we log CodeInvariantErrors.
-                        if let PanicOr::CodeInvariantError(err_msg) = err {
-                            alert!("[BlockSTM] worker loop: CodeInvariantError({:?})", err_msg);
-                        }
-                        shared_maybe_error.store(true, Ordering::SeqCst);
+            if let Err(err) = self.worker_loop(
+                &executor,
+                environment,
+                signature_verified_block,
+                &scheduler,
+                &skip_module_reads_validation,
+                &shared_sync_params,
+                num_workers,
+            ) {
+                // If there are multiple errors, they all get logged:
+                // ModulePathReadWriteError and FatalVMError variant is logged at construction,
+                // and below we log CodeInvariantErrors.
+                if let PanicOr::CodeInvariantError(err_msg) = err {
+                    alert!("[BlockSTM] worker loop: CodeInvariantError({:?})", err_msg);
+                }
+                shared_maybe_error.store(true, Ordering::SeqCst);
 
-                        // Make sure to halt the scheduler if it hasn't already been halted.
-                        scheduler.halt();
-                    }
+                // Make sure to halt the scheduler if it hasn't already been halted.
+                scheduler.halt();
+            }
 
-                    if *worker_id == 0 {
-                        maybe_executor.acquire().replace(executor);
-                    }
-                });
+            if worker_id == 0 {
+                maybe_executor.acquire().replace(executor);
             }
         });
         drop(timer);

--- a/aptos-move/block-executor/src/lib.rs
+++ b/aptos-move/block-executor/src/lib.rs
@@ -161,3 +161,4 @@ pub mod types;
 mod unit_tests;
 mod value_exchange;
 pub mod view;
+mod worker_pool;

--- a/aptos-move/block-executor/src/unit_tests/mod.rs
+++ b/aptos-move/block-executor/src/unit_tests/mod.rs
@@ -46,7 +46,6 @@ use std::{
     fmt::Debug,
     hash::Hash,
     marker::PhantomData,
-    sync::Arc,
 };
 
 #[test]
@@ -56,12 +55,6 @@ fn test_block_epilogue_happy_path() {
     let t_1 = MockTransaction::from_behavior(behaivor);
     let transactions = vec![t_0, t_1];
 
-    let executor_thread_pool = Arc::new(
-        rayon::ThreadPoolBuilder::new()
-            .num_threads(num_cpus::get())
-            .build()
-            .unwrap(),
-    );
     let block_executor = BlockExecutor::<
         MockTransaction<KeyType<u32>, MockEvent>,
         MockTask<KeyType<u32>, MockEvent>,
@@ -71,7 +64,6 @@ fn test_block_epilogue_happy_path() {
         AuxiliaryInfo,
     >::new(
         BlockExecutorConfig::new_no_block_limit(num_cpus::get()),
-        executor_thread_pool,
         None,
     );
     let data_view = MockStateView::empty();
@@ -127,12 +119,6 @@ fn test_block_epilogue_block_gas_limit_reached() {
     let t_1 = MockTransaction::from_behavior(behaivor);
     let transactions = vec![t_0, t_1];
 
-    let executor_thread_pool = Arc::new(
-        rayon::ThreadPoolBuilder::new()
-            .num_threads(num_cpus::get())
-            .build()
-            .unwrap(),
-    );
     let block_executor = BlockExecutor::<
         MockTransaction<KeyType<u32>, MockEvent>,
         MockTask<KeyType<u32>, MockEvent>,
@@ -142,7 +128,6 @@ fn test_block_epilogue_block_gas_limit_reached() {
         AuxiliaryInfo,
     >::new(
         BlockExecutorConfig::new_maybe_block_limit(num_cpus::get(), Some(1)),
-        executor_thread_pool,
         None,
     );
     let data_view = MockStateView::empty();
@@ -222,12 +207,6 @@ fn test_resource_group_deletion() {
         group_keys: HashSet::new(),
         delayed_field_testing: false,
     };
-    let executor_thread_pool = Arc::new(
-        rayon::ThreadPoolBuilder::new()
-            .num_threads(num_cpus::get())
-            .build()
-            .unwrap(),
-    );
     let block_executor = BlockExecutor::<
         MockTransaction<KeyType<u32>, MockEvent>,
         MockTask<KeyType<u32>, MockEvent>,
@@ -237,7 +216,6 @@ fn test_resource_group_deletion() {
         AuxiliaryInfo,
     >::new(
         BlockExecutorConfig::new_no_block_limit(num_cpus::get()),
-        executor_thread_pool,
         None,
     );
 
@@ -301,12 +279,6 @@ fn resource_group_bcs_fallback() {
         group_keys: HashSet::new(),
         delayed_field_testing: false,
     };
-    let executor_thread_pool = Arc::new(
-        rayon::ThreadPoolBuilder::new()
-            .num_threads(num_cpus::get())
-            .build()
-            .unwrap(),
-    );
     let block_executor = BlockExecutor::<
         MockTransaction<KeyType<u32>, MockEvent>,
         MockTask<KeyType<u32>, MockEvent>,
@@ -316,7 +288,6 @@ fn resource_group_bcs_fallback() {
         AuxiliaryInfo,
     >::new(
         BlockExecutorConfig::new_no_block_limit(num_cpus::get()),
-        executor_thread_pool,
         None,
     );
 
@@ -417,12 +388,6 @@ fn interrupt_requested() {
     let mut guard = AptosModuleCacheManagerGuard::none();
 
     let data_view = MockStateView::empty();
-    let executor_thread_pool = Arc::new(
-        rayon::ThreadPoolBuilder::new()
-            .num_threads(num_cpus::get())
-            .build()
-            .unwrap(),
-    );
     let block_executor = BlockExecutor::<
         MockTransaction<KeyType<u32>, MockEvent>,
         MockTask<KeyType<u32>, MockEvent>,
@@ -432,7 +397,6 @@ fn interrupt_requested() {
         AuxiliaryInfo,
     >::new(
         BlockExecutorConfig::new_no_block_limit(num_cpus::get()),
-        executor_thread_pool,
         None,
     );
 
@@ -464,12 +428,6 @@ fn block_output_err_precedence() {
     let txn_provider = DefaultTxnProvider::new_without_info(transactions);
 
     let data_view = MockStateView::empty();
-    let executor_thread_pool = Arc::new(
-        rayon::ThreadPoolBuilder::new()
-            .num_threads(num_cpus::get())
-            .build()
-            .unwrap(),
-    );
     let block_executor = BlockExecutor::<
         MockTransaction<KeyType<u32>, MockEvent>,
         MockTask<KeyType<u32>, MockEvent>,
@@ -479,7 +437,6 @@ fn block_output_err_precedence() {
         AuxiliaryInfo,
     >::new(
         BlockExecutorConfig::new_no_block_limit(num_cpus::get()),
-        executor_thread_pool,
         None,
     );
 
@@ -508,12 +465,6 @@ fn skip_rest_gas_limit() {
     let txn_provider = DefaultTxnProvider::new_without_info(transactions);
 
     let data_view = MockStateView::empty();
-    let executor_thread_pool = Arc::new(
-        rayon::ThreadPoolBuilder::new()
-            .num_threads(num_cpus::get())
-            .build()
-            .unwrap(),
-    );
     let block_executor = BlockExecutor::<
         MockTransaction<KeyType<u32>, MockEvent>,
         MockTask<KeyType<u32>, MockEvent>,
@@ -523,7 +474,6 @@ fn skip_rest_gas_limit() {
         AuxiliaryInfo,
     >::new(
         BlockExecutorConfig::new_maybe_block_limit(num_cpus::get(), Some(5)),
-        executor_thread_pool,
         None,
     );
 
@@ -543,13 +493,6 @@ where
     K: PartialOrd + Ord + Send + Sync + Clone + Hash + Eq + ModulePath + Debug + 'static,
     E: Send + Sync + Debug + Clone + TransactionEvent + 'static,
 {
-    let executor_thread_pool = Arc::new(
-        rayon::ThreadPoolBuilder::new()
-            .num_threads(num_cpus::get())
-            .build()
-            .unwrap(),
-    );
-
     let mut guard = AptosModuleCacheManagerGuard::none();
     let txn_provider = DefaultTxnProvider::new_without_info(transactions);
 
@@ -567,7 +510,6 @@ where
             AuxiliaryInfo,
         >::new(
             BlockExecutorConfig::new_no_block_limit(num_cpus::get()),
-            executor_thread_pool,
             None,
         )
         .execute_transactions_parallel(
@@ -587,7 +529,6 @@ where
             AuxiliaryInfo,
         >::new(
             BlockExecutorConfig::new_no_block_limit(num_cpus::get()),
-            executor_thread_pool,
             None,
         )
         .execute_transactions_parallel(

--- a/aptos-move/block-executor/src/worker_pool.rs
+++ b/aptos-move/block-executor/src/worker_pool.rs
@@ -1,0 +1,423 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Worker thread pool that runs BlockSTM workers on plain `std::thread`s.
+//!
+//! Unlike a rayon thread pool, threads here do not participate in cross-scope work stealing.
+//! BlockSTM workers can park on a `Condvar` while waiting for a transaction dependency. If the
+//! workers ran on a rayon pool, a worker waiting inside a nested `par_iter()` would actively
+//! work-steal and could pick up an inner task spawned by another worker; that inner task could then
+//! park on the v1 dependency `Condvar` waiting on the very transaction the work-stealing thread is
+//! supposed to be executing, deadlocking. Plain `std` threads are not registered with rayon, so any
+//! nested `par_iter()` runs on rayon's global pool while the worker simply blocks via OS
+//! primitives.
+
+use crate::counters::PAR_EXEC_POOL_SIZE;
+use aptos_logger::info;
+use parking_lot::Mutex;
+use std::sync::{Arc, Barrier};
+
+type Task = Box<dyn FnOnce() + Send + 'static>;
+
+struct State {
+    // Sum of `num_tasks` across all in-flight `scope` calls.
+    in_flight: usize,
+    // Number of worker threads we have created.
+    spawned: usize,
+}
+
+pub(crate) struct WorkerPool {
+    sender: crossbeam::channel::Sender<Task>,
+    receiver: crossbeam::channel::Receiver<Task>,
+    state: Mutex<State>,
+}
+
+impl WorkerPool {
+    pub fn new() -> Self {
+        let (sender, receiver) = crossbeam::channel::unbounded();
+        Self {
+            sender,
+            receiver,
+            state: Mutex::new(State {
+                in_flight: 0,
+                spawned: 0,
+            }),
+        }
+    }
+
+    /// Run `num_tasks` invocations of `work`, each receiving its index in `0..num_tasks`. Blocks
+    /// until every invocation has either returned or panicked. If any task panics, the first
+    /// captured panic is resumed in the calling thread after every task has completed.
+    pub fn scope<F>(&self, num_tasks: usize, work: F)
+    where
+        F: Fn(usize) + Sync,
+    {
+        if num_tasks == 0 {
+            return;
+        }
+
+        let _decrement = self.grow_and_bump_in_flight(num_tasks);
+
+        // SAFETY: we manually extend the lifetime of `work_ref` to `'static`, in order to send it
+        // to be executed by threads. This is safe because this function blocks until every worker
+        // has finished and stopped dereferencing it, and `work` is only dropped afterwards.
+        let work_static: &'static (dyn Fn(usize) + Sync) = unsafe {
+            let work_ref: &(dyn Fn(usize) + Sync) = &work;
+            std::mem::transmute(work_ref)
+        };
+
+        let barrier = Arc::new(Barrier::new(num_tasks + 1));
+        let panic_slot = Arc::new(Mutex::new(None));
+
+        // Build every task before sending any. If `Box::new` panics mid-loop (e.g. allocator OOM),
+        // the partial `Vec` drops without anything being sent.
+        let mut tasks = Vec::with_capacity(num_tasks);
+        for i in 0..num_tasks {
+            let barrier = Arc::clone(&barrier);
+            let panic_slot = Arc::clone(&panic_slot);
+            tasks.push(Box::new(move || {
+                let result =
+                    std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| work_static(i)));
+                // The path from here to `barrier.wait()` must be panic-free: a worker that skips
+                // the barrier would let the caller drop `work` while we still hold `work_static`.
+                if let Err(p) = result {
+                    let mut slot = panic_slot.lock();
+                    if slot.is_none() {
+                        *slot = Some(p);
+                    }
+                }
+                barrier.wait();
+            }));
+        }
+
+        // Infallible: `self.receiver` is held by `WorkerPool` for the lifetime of `&self`, so the
+        // channel cannot disconnect.
+        for task in tasks {
+            self.sender
+                .send(task)
+                .expect("WorkerPool channel disconnected (unreachable)");
+        }
+
+        // Wait until EVERY worker has reached its own `barrier.wait()`, even if some of them panic,
+        // so no worker still dereferences `work_static`.
+        barrier.wait();
+
+        if let Some(p) = panic_slot.lock().take() {
+            std::panic::resume_unwind(p);
+        }
+    }
+
+    /// Grows the pool to cover the new demand (rare) and reserves `num_tasks` worker slots.
+    /// Returns a RAII guard that rolls back the reservation on drop.
+    fn grow_and_bump_in_flight(&self, num_tasks: usize) -> InFlightDecrement<'_> {
+        let mut state = self.state.lock();
+        let target = state.in_flight + num_tasks;
+        if state.spawned < target {
+            info!(
+                "Growing par_exec worker pool from {} to {} thread(s)",
+                state.spawned, target
+            );
+            while state.spawned < target {
+                let receiver = self.receiver.clone();
+                let id = state.spawned;
+                std::thread::Builder::new()
+                    .name(format!("par_exec-{}", id))
+                    .spawn(move || {
+                        while let Ok(task) = receiver.recv() {
+                            task();
+                        }
+                        info!("par_exec worker {} exiting (channel disconnected)", id);
+                    })
+                    .expect("Failed to spawn par_exec worker thread");
+                state.spawned += 1;
+            }
+            PAR_EXEC_POOL_SIZE.set(state.spawned as i64);
+        }
+        state.in_flight += num_tasks;
+        InFlightDecrement {
+            state: &self.state,
+            n: num_tasks,
+        }
+    }
+}
+
+struct InFlightDecrement<'a> {
+    state: &'a Mutex<State>,
+    n: usize,
+}
+
+impl Drop for InFlightDecrement<'_> {
+    fn drop(&mut self) {
+        self.state.lock().in_flight -= self.n;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{
+        panic::AssertUnwindSafe,
+        sync::atomic::{AtomicBool, AtomicUsize, Ordering},
+        time::Duration,
+    };
+
+    fn snapshot(pool: &WorkerPool) -> (usize, usize) {
+        let s = pool.state.lock();
+        (s.spawned, s.in_flight)
+    }
+
+    #[test]
+    fn scope_zero_tasks_is_noop() {
+        let pool = WorkerPool::new();
+        let called = AtomicUsize::new(0);
+        pool.scope(0, |_| {
+            called.fetch_add(1, Ordering::Relaxed);
+        });
+        assert_eq!(called.load(Ordering::Relaxed), 0);
+        // No worker threads spawned and in_flight stays at zero.
+        assert_eq!(snapshot(&pool), (0, 0));
+    }
+
+    #[test]
+    fn scope_single_task_runs_once_with_index_zero() {
+        let pool = WorkerPool::new();
+        let seen = Mutex::new(Vec::new());
+        pool.scope(1, |i| seen.lock().push(i));
+        assert_eq!(*seen.lock(), vec![0]);
+    }
+
+    #[test]
+    fn scope_calls_work_with_each_index_exactly_once() {
+        let pool = WorkerPool::new();
+        const N: usize = 8;
+        let counts: Vec<AtomicUsize> = (0..N).map(|_| AtomicUsize::new(0)).collect();
+        pool.scope(N, |i| {
+            counts[i].fetch_add(1, Ordering::Relaxed);
+        });
+        for c in &counts {
+            assert_eq!(c.load(Ordering::Relaxed), 1);
+        }
+    }
+
+    #[test]
+    fn scope_blocks_until_slowest_task_completes() {
+        let pool = WorkerPool::new();
+        let done = AtomicBool::new(false);
+        pool.scope(4, |i| {
+            if i == 3 {
+                std::thread::sleep(Duration::from_millis(50));
+                done.store(true, Ordering::Release);
+            }
+        });
+        // The slowest task must have set `done` by the time scope returns.
+        assert!(done.load(Ordering::Acquire));
+    }
+
+    #[test]
+    fn pool_grows_to_match_demand() {
+        let pool = WorkerPool::new();
+        assert_eq!(snapshot(&pool), (0, 0));
+        pool.scope(4, |_| {});
+        let (spawned, in_flight) = snapshot(&pool);
+        assert_eq!(spawned, 4);
+        assert_eq!(in_flight, 0);
+    }
+
+    #[test]
+    fn pool_reuses_threads_for_smaller_or_equal_scope() {
+        let pool = WorkerPool::new();
+        pool.scope(6, |_| {});
+        assert_eq!(snapshot(&pool).0, 6);
+        // Smaller and equal scopes must not spawn more threads.
+        pool.scope(3, |_| {});
+        pool.scope(6, |_| {});
+        assert_eq!(snapshot(&pool).0, 6);
+    }
+
+    #[test]
+    fn pool_grows_further_for_larger_scope() {
+        let pool = WorkerPool::new();
+        pool.scope(2, |_| {});
+        assert_eq!(snapshot(&pool).0, 2);
+        pool.scope(5, |_| {});
+        assert_eq!(snapshot(&pool).0, 5);
+    }
+
+    #[test]
+    fn in_flight_returns_to_zero_after_scope() {
+        let pool = WorkerPool::new();
+        pool.scope(4, |_| {});
+        assert_eq!(snapshot(&pool).1, 0);
+        pool.scope(8, |_| {});
+        assert_eq!(snapshot(&pool).1, 0);
+    }
+
+    #[test]
+    fn panic_in_task_propagates_to_caller() {
+        let pool = WorkerPool::new();
+        let result = std::panic::catch_unwind(AssertUnwindSafe(|| {
+            pool.scope(4, |i| {
+                if i == 2 {
+                    panic!("boom from task {}", i);
+                }
+            });
+        }));
+        let err = result.expect_err("scope should have panicked");
+        let msg = err
+            .downcast_ref::<String>()
+            .map(String::as_str)
+            .or_else(|| err.downcast_ref::<&'static str>().copied())
+            .unwrap_or("");
+        assert!(msg.contains("boom"), "unexpected panic payload: {msg:?}");
+    }
+
+    #[test]
+    fn panic_does_not_skip_other_tasks() {
+        // Every non-panicking task must still observe its index — proving the barrier waits for
+        // them even when one task aborts.
+        let pool = WorkerPool::new();
+        const N: usize = 6;
+        let observed: Vec<AtomicBool> = (0..N).map(|_| AtomicBool::new(false)).collect();
+        let _ = std::panic::catch_unwind(AssertUnwindSafe(|| {
+            pool.scope(N, |i| {
+                observed[i].store(true, Ordering::Release);
+                if i == 0 {
+                    panic!("only task 0 panics");
+                }
+            });
+        }));
+        for (i, flag) in observed.iter().enumerate() {
+            assert!(
+                flag.load(Ordering::Acquire),
+                "task {i} did not get a chance to run"
+            );
+        }
+    }
+
+    #[test]
+    fn pool_is_usable_after_a_panicking_scope() {
+        let pool = WorkerPool::new();
+        let _ = std::panic::catch_unwind(AssertUnwindSafe(|| {
+            pool.scope(3, |_| panic!("everyone panics"));
+        }));
+        // After unwinding, in_flight must be back to zero and the next scope must succeed.
+        assert_eq!(snapshot(&pool).1, 0);
+        let counter = AtomicUsize::new(0);
+        pool.scope(5, |_| {
+            counter.fetch_add(1, Ordering::Relaxed);
+        });
+        assert_eq!(counter.load(Ordering::Relaxed), 5);
+    }
+
+    #[test]
+    fn concurrent_scopes_share_a_pool() {
+        // Two threads call `scope` simultaneously; together they need 2*M workers in flight, so
+        // the pool must grow to satisfy the combined demand.
+        let pool = Arc::new(WorkerPool::new());
+        const M: usize = 4;
+        let start = Arc::new(Barrier::new(2));
+        let entered = Arc::new(AtomicUsize::new(0));
+        let release = Arc::new(Barrier::new(2 * M));
+
+        let handles: Vec<_> = (0..2)
+            .map(|_| {
+                let pool = Arc::clone(&pool);
+                let start = Arc::clone(&start);
+                let entered = Arc::clone(&entered);
+                let release = Arc::clone(&release);
+                std::thread::Builder::new()
+                    .name("test-driver".into())
+                    .spawn(move || {
+                        start.wait();
+                        pool.scope(M, |_| {
+                            entered.fetch_add(1, Ordering::Relaxed);
+                            // Hold every worker until all 2*M are running concurrently. Will hang
+                            // if the pool fails to grow past M.
+                            release.wait();
+                        });
+                    })
+                    .unwrap()
+            })
+            .collect();
+
+        for h in handles {
+            h.join().unwrap();
+        }
+
+        assert_eq!(entered.load(Ordering::Relaxed), 2 * M);
+        let (spawned, in_flight) = snapshot(&pool);
+        assert!(
+            spawned >= 2 * M,
+            "pool must grow to support concurrent demand, spawned={spawned}"
+        );
+        assert_eq!(in_flight, 0);
+    }
+
+    #[test]
+    fn tasks_run_in_parallel() {
+        // A `Barrier::new(N)` deadlocks unless all N tasks run concurrently.
+        let pool = WorkerPool::new();
+        const N: usize = 4;
+        let rendezvous = Arc::new(Barrier::new(N));
+        pool.scope(N, |_| {
+            rendezvous.wait();
+        });
+    }
+
+    #[test]
+    fn worker_threads_carry_par_exec_name() {
+        let pool = WorkerPool::new();
+        let names = Mutex::new(Vec::new());
+        pool.scope(3, |_| {
+            let name = std::thread::current().name().unwrap_or_default().to_owned();
+            names.lock().push(name);
+        });
+        let names = names.into_inner();
+        assert_eq!(names.len(), 3);
+        for n in &names {
+            assert!(
+                n.starts_with("par_exec-"),
+                "worker thread name should start with 'par_exec-', got {n:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn many_tasks_complete_correctly() {
+        let pool = WorkerPool::new();
+        const N: usize = 64;
+        let sum = AtomicUsize::new(0);
+        pool.scope(N, |i| {
+            sum.fetch_add(i, Ordering::Relaxed);
+        });
+        assert_eq!(sum.load(Ordering::Relaxed), (0..N).sum::<usize>());
+    }
+
+    #[test]
+    fn scope_passes_borrowed_state_through_unsafe_lifetime_extension() {
+        // The closure borrows a stack-local `Vec`. If `scope` returned before workers stopped
+        // touching it, this would be a use-after-free; running cleanly under Miri/ASAN is the
+        // real check, but the assertion verifies the data round-trips.
+        let pool = WorkerPool::new();
+        let inputs: Vec<usize> = (0..10).map(|i| i * 7).collect();
+        let outputs: Vec<AtomicUsize> = (0..inputs.len()).map(|_| AtomicUsize::new(0)).collect();
+        pool.scope(inputs.len(), |i| {
+            outputs[i].store(inputs[i] + 1, Ordering::Relaxed);
+        });
+        for (i, out) in outputs.iter().enumerate() {
+            assert_eq!(out.load(Ordering::Relaxed), inputs[i] + 1);
+        }
+    }
+
+    #[test]
+    fn back_to_back_scopes_share_the_same_workers() {
+        // Spawn count must be monotonic and stable when each scope's demand fits.
+        let pool = WorkerPool::new();
+        pool.scope(3, |_| {});
+        let after_first = snapshot(&pool).0;
+        for _ in 0..5 {
+            pool.scope(3, |_| {});
+        }
+        assert_eq!(snapshot(&pool).0, after_first);
+    }
+}

--- a/aptos-move/e2e-tests/Cargo.toml
+++ b/aptos-move/e2e-tests/Cargo.toml
@@ -54,7 +54,6 @@ petgraph = "0.5.1"
 proptest = { workspace = true }
 proptest-derive = { workspace = true }
 rand = { workspace = true }
-rayon = { workspace = true }
 serde = { workspace = true }
 
 [features]

--- a/aptos-move/e2e-tests/src/executor.rs
+++ b/aptos-move/e2e-tests/src/executor.rs
@@ -162,7 +162,7 @@ struct SharedCacheState {
 pub struct FakeExecutorImpl<O: OutputLogger> {
     state_store: FakeExecutorStateStore,
     event_store: Vec<ContractEvent>,
-    executor_thread_pool: Arc<rayon::ThreadPool>,
+    concurrency_level: usize,
     block_time: u64,
     executed_output: Option<O>,
     trace_dir: Option<PathBuf>,
@@ -232,20 +232,13 @@ pub enum ExecFuncTimerDynamicArgs {
 impl<O: OutputLogger> FakeExecutorImpl<O> {
     /// Creates an executor from a genesis [`WriteSet`].
     pub fn from_genesis(write_set: &WriteSet, chain_id: ChainId) -> Self {
-        let executor_thread_pool = Arc::new(
-            rayon::ThreadPoolBuilder::new()
-                .num_threads(num_cpus::get())
-                .build()
-                .unwrap(),
-        );
-
         let state_store = empty_in_memory_state_store();
         state_store.set_chain_id(chain_id).unwrap();
 
         let mut executor = Self {
             state_store,
             event_store: Vec::new(),
-            executor_thread_pool,
+            concurrency_level: num_cpus::get(),
             block_time: 0,
             executed_output: None,
             trace_dir: None,
@@ -259,10 +252,10 @@ impl<O: OutputLogger> FakeExecutorImpl<O> {
     }
 
     #[cfg(any(test, feature = "fuzzing"))]
-    pub fn from_genesis_with_existing_thread_pool(
+    pub fn from_genesis_with_module_cache_manager(
         write_set: &WriteSet,
         chain_id: ChainId,
-        executor_thread_pool: Arc<rayon::ThreadPool>,
+        concurrency_level: usize,
         module_cache_manager: Option<AptosModuleCacheManager>,
     ) -> Self {
         let state_store = empty_in_memory_state_store();
@@ -271,14 +264,14 @@ impl<O: OutputLogger> FakeExecutorImpl<O> {
         let mut executor = Self {
             state_store,
             event_store: Vec::new(),
-            executor_thread_pool,
+            concurrency_level,
             block_time: 0,
             executed_output: None,
             trace_dir: None,
             rng: KeyGen::from_seed(RNG_SEED),
             executor_mode: None,
             allow_block_executor_fallback: true,
-            // Enable a shared module cache for fuzzing/test usage with external thread pool.
+            // Enable a shared module cache for fuzzing/test usage.
             block_state: match module_cache_manager {
                 Some(manager) => BlockState::Fuzzing(SharedCacheState {
                     manager,
@@ -313,17 +306,10 @@ impl<O: OutputLogger> FakeExecutorImpl<O> {
             .get_on_chain_config::<CurrentTimeMicroseconds>()
             .expect("failed to get block time from remote");
 
-        let executor_thread_pool = Arc::new(
-            rayon::ThreadPoolBuilder::new()
-                .num_threads(num_cpus::get())
-                .build()
-                .unwrap(),
-        );
-
         Self {
             state_store,
             event_store: Vec::new(),
-            executor_thread_pool,
+            concurrency_level: num_cpus::get(),
             block_time: timestamp.microseconds,
             executed_output: None,
             trace_dir: None,
@@ -507,16 +493,10 @@ impl<O: OutputLogger> FakeExecutorImpl<O> {
 
     /// Creates an executor in which no genesis state has been applied yet.
     pub fn no_genesis() -> Self {
-        let executor_thread_pool = Arc::new(
-            rayon::ThreadPoolBuilder::new()
-                .num_threads(num_cpus::get())
-                .build()
-                .unwrap(),
-        );
         Self {
             state_store: empty_in_memory_state_store(),
             event_store: Vec::new(),
-            executor_thread_pool,
+            concurrency_level: num_cpus::get(),
             block_time: 0,
             executed_output: None,
             trace_dir: None,
@@ -890,12 +870,7 @@ impl<O: OutputLogger> FakeExecutorImpl<O> {
         let txn_provider = DefaultTxnProvider::new(txn_block, auxiliary_info);
         let metadata = self.get_txn_slice_metadata();
         let result = {
-            AptosVMBlockExecutorWrapper::execute_block_on_thread_pool::<
-                _,
-                NoOpTransactionCommitHook<VMStatus>,
-                _,
-            >(
-                self.executor_thread_pool.clone(),
+            AptosVMBlockExecutorWrapper::execute_block::<_, NoOpTransactionCommitHook<VMStatus>, _>(
                 &txn_provider,
                 &state_view,
                 self.module_cache_manager_opt()
@@ -1077,8 +1052,7 @@ impl<O: OutputLogger> FakeExecutorImpl<O> {
         }
 
         let parallel_output = if mode != ExecutorMode::SequentialOnly {
-            // use the number of threads specified in the executor thread pool as specified at construction time
-            config.local.concurrency_level = self.executor_thread_pool.current_num_threads();
+            config.local.concurrency_level = self.concurrency_level;
             Some(self.execute_transaction_block_impl_with_state_view(
                 sig_verified_block,
                 state_view,

--- a/execution/executor-benchmark/src/native/native_vm.rs
+++ b/execution/executor-benchmark/src/native/native_vm.rs
@@ -4,7 +4,7 @@
 use crate::{
     db_access::DbAccessUtil,
     native::{
-        native_config::{NativeConfig, NATIVE_EXECUTOR_POOL},
+        native_config::NativeConfig,
         native_transaction::{compute_deltas_for_batch, NativeTransaction},
     },
 };
@@ -64,7 +64,7 @@ use move_core_types::{
 };
 use move_vm_types::delayed_values::delayed_field_id::DelayedFieldID;
 use serde::{de::DeserializeOwned, Serialize};
-use std::{collections::BTreeMap, fmt::Debug, sync::Arc};
+use std::{collections::BTreeMap, fmt::Debug};
 
 pub struct NativeVMBlockExecutor;
 
@@ -86,12 +86,11 @@ impl VMBlockExecutor for NativeVMBlockExecutor {
         onchain_config: BlockExecutorConfigFromOnchain,
         transaction_slice_metadata: TransactionSliceMetadata,
     ) -> Result<BlockOutput<SignatureVerifiedTransaction, TransactionOutput>, VMStatus> {
-        AptosBlockExecutorWrapper::<NativeVMExecutorTask>::execute_block_on_thread_pool::<
+        AptosBlockExecutorWrapper::<NativeVMExecutorTask>::execute_block::<
             _,
             NoOpTransactionCommitHook<VMStatus>,
             _,
         >(
-            Arc::clone(&NATIVE_EXECUTOR_POOL),
             txn_provider,
             state_view,
             &AptosModuleCacheManager::new(),

--- a/testsuite/fuzzer/fuzz/Cargo.toml
+++ b/testsuite/fuzzer/fuzz/Cargo.toml
@@ -109,7 +109,6 @@ move-vm-runtime = { workspace = true }
 move-vm-types = { workspace = true, features = ["fuzzing"] }
 once_cell = { workspace = true }
 primitive-types = { workspace = true }
-rayon = { workspace = true }
 ring = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/testsuite/fuzzer/fuzz/fuzz_targets/move/aptosvm_authenticators.rs
+++ b/testsuite/fuzzer/fuzz/fuzz_targets/move/aptosvm_authenticators.rs
@@ -52,23 +52,15 @@ use utils::{
 static VM: Lazy<WriteSet> = Lazy::new(|| GENESIS_CHANGE_SET_HEAD.write_set().clone());
 
 const FUZZER_CONCURRENCY_LEVEL: usize = 1;
-static TP: Lazy<Arc<rayon::ThreadPool>> = Lazy::new(|| {
-    Arc::new(
-        rayon::ThreadPoolBuilder::new()
-            .num_threads(FUZZER_CONCURRENCY_LEVEL)
-            .build()
-            .unwrap(),
-    )
-});
 
 fn run_case(input: TransactionState) -> Result<(), Corpus> {
     tdbg!(&input);
 
     AptosVM::set_concurrency_level_once(FUZZER_CONCURRENCY_LEVEL);
-    let mut vm = FakeExecutor::from_genesis_with_existing_thread_pool(
+    let mut vm = FakeExecutor::from_genesis_with_module_cache_manager(
         &VM,
         ChainId::mainnet(),
-        Arc::clone(&TP),
+        FUZZER_CONCURRENCY_LEVEL,
         None,
     )
     .set_not_parallel();

--- a/testsuite/fuzzer/fuzz/fuzz_targets/move/aptosvm_publish.rs
+++ b/testsuite/fuzzer/fuzz/fuzz_targets/move/aptosvm_publish.rs
@@ -16,7 +16,7 @@ use move_binary_format::{
     file_format::{CompiledModule, CompiledScript},
 };
 use once_cell::sync::Lazy;
-use std::{collections::HashSet, sync::Arc};
+use std::collections::HashSet;
 use utils::vm::{group_modules_by_address_topo, publish_group};
 
 // genesis write set generated once for each fuzzing session
@@ -24,14 +24,6 @@ static VM: Lazy<WriteSet> = Lazy::new(|| GENESIS_CHANGE_SET_HEAD.write_set().clo
 
 const TEST_UPGRADE: bool = true;
 const FUZZER_CONCURRENCY_LEVEL: usize = 1;
-static TP: Lazy<Arc<rayon::ThreadPool>> = Lazy::new(|| {
-    Arc::new(
-        rayon::ThreadPoolBuilder::new()
-            .num_threads(FUZZER_CONCURRENCY_LEVEL)
-            .build()
-            .unwrap(),
-    )
-});
 
 fn run_case(mut input: RunnableState) -> Result<(), Corpus> {
     tdbg!(&input);
@@ -72,10 +64,10 @@ fn run_case(mut input: RunnableState) -> Result<(), Corpus> {
     let packages = group_modules_by_address_topo(input.dep_modules.clone())?;
 
     AptosVM::set_concurrency_level_once(FUZZER_CONCURRENCY_LEVEL);
-    let mut vm = FakeExecutor::from_genesis_with_existing_thread_pool(
+    let mut vm = FakeExecutor::from_genesis_with_module_cache_manager(
         &VM,
         ChainId::mainnet(),
-        Arc::clone(&TP),
+        FUZZER_CONCURRENCY_LEVEL,
         None,
     )
     .set_not_parallel();

--- a/testsuite/fuzzer/fuzz/fuzz_targets/move/aptosvm_publish_and_run.rs
+++ b/testsuite/fuzzer/fuzz/fuzz_targets/move/aptosvm_publish_and_run.rs
@@ -22,7 +22,7 @@ use move_binary_format::{
 };
 use move_core_types::vm_status::{StatusCode, StatusType};
 use once_cell::sync::Lazy;
-use std::{collections::HashSet, sync::Arc, time::Instant};
+use std::{collections::HashSet, time::Instant};
 mod utils;
 use fuzzer::{Authenticator, ExecVariant, RunnableState};
 use move_vm_runtime::RuntimeEnvironment;
@@ -35,14 +35,6 @@ use utils::vm::{
 static VM_WRITE_SET: Lazy<WriteSet> = Lazy::new(|| GENESIS_CHANGE_SET_HEAD.write_set().clone());
 
 const FUZZER_CONCURRENCY_LEVEL: usize = 1;
-static TP: Lazy<Arc<rayon::ThreadPool>> = Lazy::new(|| {
-    Arc::new(
-        rayon::ThreadPoolBuilder::new()
-            .num_threads(FUZZER_CONCURRENCY_LEVEL)
-            .build()
-            .unwrap(),
-    )
-});
 
 const MAX_TYPE_PARAMETER_VALUE: u16 = 64 / 4 * 16; // third_party/move/move-bytecode-verifier/src/signature_v2.rs#L1306-L1312
 
@@ -113,10 +105,10 @@ fn run_case(mut input: RunnableState) -> Result<(), Corpus> {
     AptosVM::set_concurrency_level_once(FUZZER_CONCURRENCY_LEVEL);
     // Enable runtime reference-safety checks for the Move VM
     // prod_configs::set_paranoid_ref_checks(true);
-    let mut vm = FakeExecutor::from_genesis_with_existing_thread_pool(
+    let mut vm = FakeExecutor::from_genesis_with_module_cache_manager(
         &VM_WRITE_SET,
         ChainId::mainnet(),
-        Arc::clone(&TP),
+        FUZZER_CONCURRENCY_LEVEL,
         None,
     )
     .set_not_parallel();

--- a/testsuite/fuzzer/fuzz/fuzz_targets/move/aptosvm_publish_and_run_transactional.rs
+++ b/testsuite/fuzzer/fuzz/fuzz_targets/move/aptosvm_publish_and_run_transactional.rs
@@ -29,10 +29,7 @@ use move_core_types::{
 };
 use move_transactional_test_runner::transactional_ops::TransactionalOperation;
 use once_cell::sync::Lazy;
-use std::{
-    collections::{HashMap, HashSet},
-    sync::Arc,
-};
+use std::collections::{HashMap, HashSet};
 mod utils;
 use fuzzer::RunnableStateWithOperations;
 use utils::vm::{
@@ -44,14 +41,6 @@ use utils::vm::{
 static VM_WRITE_SET: Lazy<WriteSet> = Lazy::new(|| GENESIS_CHANGE_SET_HEAD.write_set().clone());
 
 const FUZZER_CONCURRENCY_LEVEL: usize = 4;
-static TP: Lazy<Arc<rayon::ThreadPool>> = Lazy::new(|| {
-    Arc::new(
-        rayon::ThreadPoolBuilder::new()
-            .num_threads(FUZZER_CONCURRENCY_LEVEL)
-            .build()
-            .unwrap(),
-    )
-});
 
 const MAX_TYPE_PARAMETER_VALUE: u16 = 64 / 4 * 16; // third_party/move/move-bytecode-verifier/src/signature_v2.rs#L1306-L1312
 
@@ -140,10 +129,10 @@ fn run_case(input: RunnableStateWithOperations) -> Result<(), Corpus> {
 
     let module_cache_manager = AptosModuleCacheManager::new();
     AptosVM::set_concurrency_level_once(FUZZER_CONCURRENCY_LEVEL);
-    let mut vm = FakeExecutor::from_genesis_with_existing_thread_pool(
+    let mut vm = FakeExecutor::from_genesis_with_module_cache_manager(
         &VM_WRITE_SET,
         ChainId::mainnet(),
-        Arc::clone(&TP),
+        FUZZER_CONCURRENCY_LEVEL,
         Some(module_cache_manager),
     )
     .set_parallel();


### PR DESCRIPTION

BlockSTM v1 can deadlock when a transaction enters a Rayon parallel
section on the same pool that runs the BlockSTM workers.

One failing sequence is:
1. A BlockSTM worker starts executing txn N, then enters a nested
   `par_iter()` and waits for its Rayon subtasks to finish.
2. While waiting, Rayon lets that worker steal work from the same pool.
   It can steal an inner Rayon task spawned by another BlockSTM worker.
3. The stolen task can hit a BlockSTM read dependency and park on the v1
   dependency `Condvar`, waiting for txn N to finish.
4. Txn N cannot finish because its original worker is now parked inside
   the stolen task, but the BlockSTM scheduler still marks txn N as
   `Executing`.

At that point the usual BlockSTM liveness argument no longer applies:
the lowest blocked transaction is waiting on a Rayon worker that has
stopped running it, so execution can stall forever.

Move BlockSTM workers to a plain `std::thread` pool. These threads are
not registered with Rayon, so nested `par_iter()` work runs on the Rayon
global pool instead of making BlockSTM workers steal across nested
parallel scopes. The worker can block in OS primitives without creating
this dependency cycle.

`BlockExecutor::new` no longer takes an `Arc<rayon::ThreadPool>`, and
`execute_block_on_thread_pool` is removed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk because it changes the concurrency/runtime behavior of BlockSTM parallel execution and removes the injectable `rayon::ThreadPool` API, which can affect performance and liveness across VM execution, benchmarks, and fuzzing.
> 
> **Overview**
> Replaces BlockSTM’s rayon-based worker execution with a custom `WorkerPool` backed by plain `std::thread`s to avoid deadlocks caused by rayon work-stealing in nested parallel sections.
> 
> This removes the per-call/shared rayon pool plumbing (`execute_block_on_thread_pool`, `BlockExecutor::new(..., Arc<ThreadPool>, ...)`) and updates all call sites (VM wrapper, sharded executor, benchmarks/tests, e2e `FakeExecutor`, and native executor benchmark) to use the new API and a stored `concurrency_level` instead of a thread-pool handle.
> 
> Adds the `par_exec_pool_size` metric to track spawned worker threads and drops `rayon` dependencies from several crates that no longer construct their own pools.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46bb30d6be66a319300c5dc8a33a872aef8a9074. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->