### PR TITLE
[consensus] Cap encrypted decryption by block-execute limit and trusted-setup capacity

### DIFF
--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -2168,6 +2168,13 @@ impl AptosVM {
                 DecryptionFailureReason::EpochEndRetry => {
                     Some("Block contained an epoch-ending vtxn; retrying encrypted txn next epoch")
                 },
+                // TODO(ibalajiarun): TrustedSetupExhausted is an operational
+                // condition (the epoch outlived the trusted setup's num_rounds);
+                // falling through here charges the user gas + bumps their seq#
+                // for a system issue. Alert on the
+                // `aptos_consensus_decryption_pipeline_txns_count{category="trusted_setup_exhausted"}`
+                // counter so ops can extend the setup before users are affected.
+                // Revisit to use a Discard path that does not charge.
                 DecryptionFailureReason::CryptoFailure
                 | DecryptionFailureReason::ConfigUnavailable
                 | DecryptionFailureReason::DecryptionKeyUnavailable

--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -2162,10 +2162,19 @@ impl AptosVM {
                 DecryptionFailureReason::BatchLimitReached => {
                     Some("Encrypted transaction exceeded batch limit; retrying")
                 },
+                DecryptionFailureReason::ExecuteBlockLimitReached => {
+                    Some("Encrypted transaction exceeded execute-block limit; retrying")
+                },
                 DecryptionFailureReason::EpochEndRetry => {
                     Some("Block contained an epoch-ending vtxn; retrying encrypted txn next epoch")
                 },
-                _ => None,
+                DecryptionFailureReason::CryptoFailure
+                | DecryptionFailureReason::ConfigUnavailable
+                | DecryptionFailureReason::DecryptionKeyUnavailable
+                | DecryptionFailureReason::ClaimedEntryFunctionMismatch
+                | DecryptionFailureReason::PayloadHashMismatch
+                | DecryptionFailureReason::EpochMismatch
+                | DecryptionFailureReason::TrustedSetupExhausted => None,
             };
             if let Some(message) = message {
                 return (

--- a/consensus/src/pipeline/decryption_pipeline_builder.rs
+++ b/consensus/src/pipeline/decryption_pipeline_builder.rs
@@ -227,6 +227,31 @@ async fn decrypt_validator_path(
         });
     }
 
+    // Trusted setup capacity is fixed for the epoch. Once block.round() reaches
+    // num_rounds, no further encrypted txns can be decrypted in this epoch —
+    // mark them all as TrustedSetupExhausted (non-retryable in-epoch).
+    let num_rounds = secret_share_config.digest_key().num_rounds();
+    if block.round() >= num_rounds as u64 {
+        error!(
+            "Block round {} >= trusted setup num_rounds {}; marking {} encrypted txns as TrustedSetupExhausted",
+            block.round(),
+            num_rounds,
+            encrypted_txns.len()
+        );
+        let _ = derived_self_key_share_tx.send(None);
+        let failed_txns = mark_txns_failed_decryption(
+            encrypted_txns,
+            DecryptionFailureReason::TrustedSetupExhausted,
+        );
+        return Ok(DecryptionResult {
+            decrypted_txns: failed_txns,
+            regular_txns,
+            max_txns_from_block_to_execute,
+            block_gas_limit,
+            decryption_key: Some(None),
+        });
+    }
+
     // Decrypting txns that the VM will skip after a NewEpochEvent leaks sender
     // intent. If the block carries an epoch-ending vtxn, mark every encrypted
     // txn as retry without performing any crypto work.
@@ -258,16 +283,47 @@ async fn decrypt_validator_path(
         );
         let mut all = encrypted_txns;
         let exceeded = all.split_off(max_encrypted_txns);
+        let exceeded =
+            mark_txns_failed_decryption(exceeded, DecryptionFailureReason::BatchLimitReached);
         (all, exceeded)
     } else {
         (encrypted_txns, Vec::new())
     };
 
-    // Mark batch-limit-exceeded txns as failed decryption with retry reason.
-    let batch_limit_exceeded_txns = mark_txns_failed_decryption(
-        batch_limit_exceeded_txns,
-        DecryptionFailureReason::BatchLimitReached,
-    );
+    // Cap encrypted txns at max_txns_from_block_to_execute. Anything past the
+    // cap will be truncated by prepare_block anyway, so skip the crypto.
+    let (encrypted_txns, execute_limit_exceeded_txns) = match max_txns_from_block_to_execute {
+        Some(max) if (encrypted_txns.len() as u64) > max => {
+            let max = max as usize;
+            warn!(
+                "Block {} has {} encrypted txns exceeding execute-block limit {}; marking excess as ExecuteBlockLimitReached",
+                block.round(),
+                encrypted_txns.len(),
+                max,
+            );
+            let mut all = encrypted_txns;
+            let exceeded = all.split_off(max);
+            let exceeded = mark_txns_failed_decryption(
+                exceeded,
+                DecryptionFailureReason::ExecuteBlockLimitReached,
+            );
+            (all, exceeded)
+        },
+        _ => (encrypted_txns, Vec::new()),
+    };
+
+    // If the cap left no encrypted txns to decrypt, short-circuit before crypto.
+    if encrypted_txns.is_empty() {
+        let _ = derived_self_key_share_tx.send(None);
+        let decrypted_txns = [batch_limit_exceeded_txns, execute_limit_exceeded_txns].concat();
+        return Ok(DecryptionResult {
+            decrypted_txns,
+            regular_txns,
+            max_txns_from_block_to_execute,
+            block_gas_limit,
+            decryption_key: Some(None),
+        });
+    }
 
     let txn_ciphertexts: Vec<Ciphertext> = encrypted_txns
         .iter()
@@ -282,9 +338,8 @@ async fn decrypt_validator_path(
         .collect();
 
     // TODO(ibalajiarun): Consider using commit block height to reduce trusted setup size
-    // TODO(ibalajiarun): Fix this wrapping
-    let num_rounds = secret_share_config.digest_key().num_rounds() as u64;
-    let encryption_round = block.round() % num_rounds;
+    // Safe: TrustedSetupExhausted check above guarantees block.round() < num_rounds.
+    let encryption_round = block.round();
     let digest_key = secret_share_config.digest_key_arc();
     let (txn_ciphertexts, digest, proofs_promise) = tokio::task::spawn_blocking(move || {
         monitor!(
@@ -393,7 +448,12 @@ async fn decrypt_validator_path(
                 )
             })
             .collect();
-        let decrypted_txns = [failed_txns, batch_limit_exceeded_txns].concat();
+        let decrypted_txns = [
+            failed_txns,
+            batch_limit_exceeded_txns,
+            execute_limit_exceeded_txns,
+        ]
+        .concat();
         return Ok(DecryptionResult {
             decrypted_txns,
             regular_txns,
@@ -478,14 +538,20 @@ async fn decrypt_validator_path(
     let num_failed = num_failed_decryptions.into_inner();
     let num_decrypted = decrypted_txns.len() - num_failed;
     info!(
-        "Decryption complete for block {}: {} decrypted, {} failed, {} batch_limit_exceeded, {} unencrypted",
+        "Decryption complete for block {}: {} decrypted, {} failed, {} batch_limit_exceeded, {} execute_limit_exceeded, {} unencrypted",
         block.round(),
         num_decrypted,
         num_failed,
         batch_limit_exceeded_txns.len(),
+        execute_limit_exceeded_txns.len(),
         regular_txns.len(),
     );
-    let decrypted_txns = [decrypted_txns, batch_limit_exceeded_txns].concat();
+    let decrypted_txns = [
+        decrypted_txns,
+        batch_limit_exceeded_txns,
+        execute_limit_exceeded_txns,
+    ]
+    .concat();
 
     let block_txn_dec_key = BlockTxnDecryptionKey::from_secret_shared_key(&decryption_key)
         .context("Decryption key serialization failed")?;
@@ -505,9 +571,11 @@ fn record_decryption_metrics(result: &DecryptionResult) {
     let mut config_unavailable = 0u64;
     let mut key_unavailable = 0u64;
     let mut batch_limit_exceeded = 0u64;
+    let mut execute_block_limit_exceeded = 0u64;
     let mut payload_hash_mismatch = 0u64;
     let mut epoch_mismatch = 0u64;
     let mut epoch_end_retry = 0u64;
+    let mut trusted_setup_exhausted = 0u64;
     let mut entry_fun_mismatch = 0u64;
 
     for txn in &result.decrypted_txns {
@@ -519,11 +587,15 @@ fn record_decryption_metrics(result: &DecryptionResult) {
             EncryptedPayload::FailedDecryption { reason, .. } => match reason {
                 DecryptionFailureReason::CryptoFailure => failed_decryption += 1,
                 DecryptionFailureReason::BatchLimitReached => batch_limit_exceeded += 1,
+                DecryptionFailureReason::ExecuteBlockLimitReached => {
+                    execute_block_limit_exceeded += 1
+                },
                 DecryptionFailureReason::ConfigUnavailable => config_unavailable += 1,
                 DecryptionFailureReason::DecryptionKeyUnavailable => key_unavailable += 1,
                 DecryptionFailureReason::PayloadHashMismatch => payload_hash_mismatch += 1,
                 DecryptionFailureReason::EpochMismatch => epoch_mismatch += 1,
                 DecryptionFailureReason::EpochEndRetry => epoch_end_retry += 1,
+                DecryptionFailureReason::TrustedSetupExhausted => trusted_setup_exhausted += 1,
                 DecryptionFailureReason::ClaimedEntryFunctionMismatch => entry_fun_mismatch += 1,
             },
             EncryptedPayload::Encrypted(_) => {
@@ -541,9 +613,11 @@ fn record_decryption_metrics(result: &DecryptionResult) {
         ("config_unavailable", config_unavailable),
         ("key_unavailable", key_unavailable),
         ("batch_limit_exceeded", batch_limit_exceeded),
+        ("execute_block_limit_exceeded", execute_block_limit_exceeded),
         ("payload_hash_mismatch", payload_hash_mismatch),
         ("epoch_mismatch", epoch_mismatch),
         ("epoch_end_retry", epoch_end_retry),
+        ("trusted_setup_exhausted", trusted_setup_exhausted),
         ("entry_fun_mismatch", entry_fun_mismatch),
         ("unencrypted", unencrypted),
     ];
@@ -850,9 +924,11 @@ mod tests {
             "config_unavailable",
             "key_unavailable",
             "batch_limit_exceeded",
+            "execute_block_limit_exceeded",
             "payload_hash_mismatch",
             "epoch_mismatch",
             "epoch_end_retry",
+            "trusted_setup_exhausted",
             "entry_fun_mismatch",
             "unencrypted",
         ];
@@ -877,6 +953,8 @@ mod tests {
                 make_failed_decryption_txn(DecryptionFailureReason::EpochMismatch),
                 make_failed_decryption_txn(DecryptionFailureReason::EpochEndRetry),
                 make_failed_decryption_txn(DecryptionFailureReason::ClaimedEntryFunctionMismatch),
+                make_failed_decryption_txn(DecryptionFailureReason::ExecuteBlockLimitReached),
+                make_failed_decryption_txn(DecryptionFailureReason::TrustedSetupExhausted),
             ],
             regular_txns: vec![make_regular_txn(), make_regular_txn()],
             max_txns_from_block_to_execute: None,
@@ -898,7 +976,7 @@ mod tests {
             .zip(after.iter())
             .map(|(b, a)| a - b)
             .collect();
-        let expected = [1, 1, 1, 1, 1, 1, 1, 1, 1, 2];
+        let expected = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2];
         assert_eq!(deltas, expected, "labels: {:?}", labels);
     }
 
@@ -1155,7 +1233,8 @@ mod tests {
 
     #[tokio::test]
     async fn validator_path_dkg_result_vtxn_marks_all_epoch_end_retry() {
-        let ctx = TestContext::new(vec![100]);
+        // num_rounds=2 so block.round()=1 doesn't trigger TrustedSetupExhausted.
+        let ctx = TestContext::new_with_capacity(vec![100], 1, 2);
         let block = make_block(Some(vec![dkg_vtxn()]));
         let encrypted = vec![make_encrypted_txn(), make_encrypted_txn()];
         let regular = vec![make_regular_txn()];
@@ -1188,7 +1267,8 @@ mod tests {
 
     #[tokio::test]
     async fn validator_path_chunky_dkg_result_vtxn_marks_all_epoch_end_retry() {
-        let ctx = TestContext::new(vec![100]);
+        // num_rounds=2 so block.round()=1 doesn't trigger TrustedSetupExhausted.
+        let ctx = TestContext::new_with_capacity(vec![100], 1, 2);
         let block = make_block(Some(vec![chunky_dkg_vtxn()]));
         let encrypted = vec![make_encrypted_txn()];
 
@@ -1214,6 +1294,86 @@ mod tests {
             &result.decrypted_txns[0],
             &DecryptionFailureReason::EpochEndRetry,
         );
+        assert_eq!(result.decryption_key, Some(None));
+        assert!(key_share_rx.await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn validator_path_round_exceeds_num_rounds_marks_trusted_setup_exhausted() {
+        // TestContext::new uses num_rounds=1; make_block uses round=1, so the
+        // round check fires. Setting max_txns_from_block_to_execute=Some(0)
+        // also verifies that TrustedSetupExhausted takes precedence over
+        // ExecuteBlockLimitReached.
+        let ctx = TestContext::new(vec![100]);
+        let block = make_block(None);
+        assert!(block.round() >= ctx.secret_share_config.digest_key().num_rounds() as u64);
+        let encrypted = vec![make_encrypted_txn(), make_encrypted_txn()];
+        let regular = vec![make_regular_txn()];
+
+        let (key_share_tx, key_share_rx) = oneshot::channel();
+        let (_skey_tx, skey_rx) = oneshot::channel();
+
+        let result = decrypt_validator_path(
+            encrypted,
+            regular,
+            &block,
+            ctx.authors[0],
+            &ctx.secret_share_config,
+            key_share_tx,
+            skey_rx,
+            Some(0),
+            None,
+        )
+        .await
+        .expect("should succeed");
+
+        assert_eq!(result.decrypted_txns.len(), 2);
+        for txn in &result.decrypted_txns {
+            assert_failed_with(txn, &DecryptionFailureReason::TrustedSetupExhausted);
+        }
+        assert_eq!(result.regular_txns.len(), 1);
+        assert_eq!(result.decryption_key, Some(None));
+        assert!(key_share_rx.await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn validator_path_execute_block_limit_caps_encrypted_txns() {
+        // num_rounds=2 so block.round()=1 passes the trusted-setup check.
+        // max_batch_size=8 (must be a power of 2) so batch limit doesn't fire.
+        let ctx = TestContext::new_with_capacity(vec![100], 8, 2);
+        let block = make_block(None);
+        assert!(block.round() < ctx.secret_share_config.digest_key().num_rounds() as u64);
+        let encrypted = vec![
+            make_encrypted_txn(),
+            make_encrypted_txn(),
+            make_encrypted_txn(),
+        ];
+        let regular = vec![make_regular_txn()];
+
+        let (key_share_tx, key_share_rx) = oneshot::channel();
+        let (_skey_tx, skey_rx) = oneshot::channel();
+
+        // max=0 forces all encrypted txns past the cap and triggers the
+        // post-cap empty short-circuit (no crypto work).
+        let result = decrypt_validator_path(
+            encrypted,
+            regular,
+            &block,
+            ctx.authors[0],
+            &ctx.secret_share_config,
+            key_share_tx,
+            skey_rx,
+            Some(0),
+            None,
+        )
+        .await
+        .expect("should succeed");
+
+        assert_eq!(result.decrypted_txns.len(), 3);
+        for txn in &result.decrypted_txns {
+            assert_failed_with(txn, &DecryptionFailureReason::ExecuteBlockLimitReached);
+        }
+        assert_eq!(result.regular_txns.len(), 1);
         assert_eq!(result.decryption_key, Some(None));
         assert!(key_share_rx.await.unwrap().is_none());
     }

--- a/consensus/src/pipeline/decryption_pipeline_builder.rs
+++ b/consensus/src/pipeline/decryption_pipeline_builder.rs
@@ -290,8 +290,11 @@ async fn decrypt_validator_path(
         (encrypted_txns, Vec::new())
     };
 
-    // Cap encrypted txns at max_txns_from_block_to_execute. Anything past the
-    // cap will be truncated by prepare_block anyway, so skip the crypto.
+    // Cap the encrypted partition at max_txns_from_block_to_execute. The cap is
+    // applied pre-shuffle here; prepare_block later concats [decrypted, regular]
+    // and truncates at the same limit, so this is a conservative optimization:
+    // it may over-mark txns that would have survived shuffle, but it never
+    // under-decrypts, since ExecuteBlockLimitReached is a Retry status.
     let (encrypted_txns, execute_limit_exceeded_txns) = match max_txns_from_block_to_execute {
         Some(max) if (encrypted_txns.len() as u64) > max => {
             let max = max as usize;
@@ -1303,7 +1306,8 @@ mod tests {
         // TestContext::new uses num_rounds=1; make_block uses round=1, so the
         // round check fires. Setting max_txns_from_block_to_execute=Some(0)
         // also verifies that TrustedSetupExhausted takes precedence over
-        // ExecuteBlockLimitReached.
+        // ExecuteBlockLimitReached. (See the dkg-vtxn precedence test below
+        // for precedence over EpochEndRetry.)
         let ctx = TestContext::new(vec![100]);
         let block = make_block(None);
         assert!(block.round() >= ctx.secret_share_config.digest_key().num_rounds() as u64);
@@ -1332,6 +1336,40 @@ mod tests {
             assert_failed_with(txn, &DecryptionFailureReason::TrustedSetupExhausted);
         }
         assert_eq!(result.regular_txns.len(), 1);
+        assert_eq!(result.decryption_key, Some(None));
+        assert!(key_share_rx.await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn validator_path_trusted_setup_exhausted_wins_over_epoch_end_retry() {
+        // Both `block.round() >= num_rounds` and a DKG vtxn are present;
+        // TrustedSetupExhausted should win since it's checked first.
+        let ctx = TestContext::new(vec![100]);
+        let block = make_block(Some(vec![dkg_vtxn()]));
+        assert!(block.round() >= ctx.secret_share_config.digest_key().num_rounds() as u64);
+        let encrypted = vec![make_encrypted_txn(), make_encrypted_txn()];
+
+        let (key_share_tx, key_share_rx) = oneshot::channel();
+        let (_skey_tx, skey_rx) = oneshot::channel();
+
+        let result = decrypt_validator_path(
+            encrypted,
+            vec![],
+            &block,
+            ctx.authors[0],
+            &ctx.secret_share_config,
+            key_share_tx,
+            skey_rx,
+            None,
+            None,
+        )
+        .await
+        .expect("should succeed");
+
+        assert_eq!(result.decrypted_txns.len(), 2);
+        for txn in &result.decrypted_txns {
+            assert_failed_with(txn, &DecryptionFailureReason::TrustedSetupExhausted);
+        }
         assert_eq!(result.decryption_key, Some(None));
         assert!(key_share_rx.await.unwrap().is_none());
     }

--- a/consensus/src/rand/secret_sharing/test_utils.rs
+++ b/consensus/src/rand/secret_sharing/test_utils.rs
@@ -24,6 +24,10 @@ pub struct TestContext {
 
 impl TestContext {
     pub fn new(weights: Vec<u64>) -> Self {
+        Self::new_with_capacity(weights, 1, 1)
+    }
+
+    pub fn new_with_capacity(weights: Vec<u64>, max_batch_size: usize, num_rounds: usize) -> Self {
         let num_validators = weights.len();
         let (signers, validator_verifier) =
             random_validator_verifier_with_voting_power(num_validators, None, false, &weights);
@@ -39,7 +43,8 @@ impl TestContext {
         .expect("Failed to create weighted config");
 
         let (ek, dk, vks, msk_shares) =
-            FPTXWeighted::setup_for_testing(8, 1, 1, &tc).expect("Failed to setup crypto");
+            FPTXWeighted::setup_for_testing(8, max_batch_size, num_rounds, &tc)
+                .expect("Failed to setup crypto");
 
         let secret_share_config = SecretShareConfig::new(
             Arc::new(validator_verifier),

--- a/testsuite/generate-format/tests/staged/api.yaml
+++ b/testsuite/generate-format/tests/staged/api.yaml
@@ -376,6 +376,10 @@ DecryptionFailureReason:
       EpochMismatch: UNIT
     7:
       EpochEndRetry: UNIT
+    8:
+      TrustedSetupExhausted: UNIT
+    9:
+      ExecuteBlockLimitReached: UNIT
 DepositEvent:
   STRUCT:
     - amount: U64

--- a/testsuite/generate-format/tests/staged/aptos.yaml
+++ b/testsuite/generate-format/tests/staged/aptos.yaml
@@ -356,6 +356,10 @@ DecryptionFailureReason:
       EpochMismatch: UNIT
     7:
       EpochEndRetry: UNIT
+    8:
+      TrustedSetupExhausted: UNIT
+    9:
+      ExecuteBlockLimitReached: UNIT
 DeprecatedPayload:
   STRUCT:
     - dummy_value: U64

--- a/testsuite/generate-format/tests/staged/consensus.yaml
+++ b/testsuite/generate-format/tests/staged/consensus.yaml
@@ -676,6 +676,10 @@ DecryptionFailureReason:
       EpochMismatch: UNIT
     7:
       EpochEndRetry: UNIT
+    8:
+      TrustedSetupExhausted: UNIT
+    9:
+      ExecuteBlockLimitReached: UNIT
 DeprecatedPayload:
   STRUCT:
     - dummy_value: U64

--- a/types/src/transaction/encrypted_payload.rs
+++ b/types/src/transaction/encrypted_payload.rs
@@ -90,6 +90,12 @@ pub enum DecryptionFailureReason {
     /// would leak sender intent, so the txn is failed with retry semantics and
     /// the user resubmits in the next epoch with the rotated key.
     EpochEndRetry,
+    /// The block's round exceeds the trusted-setup capacity (`num_rounds`).
+    /// The txn cannot be decrypted in this epoch; not retryable until next epoch.
+    TrustedSetupExhausted,
+    /// The encrypted txn was skipped because the block already reached
+    /// `max_txns_from_block_to_execute`. Should be retried in a subsequent block.
+    ExecuteBlockLimitReached,
 }
 
 // Mirrors EntryFunction in types/src/transaction/script.rs


### PR DESCRIPTION
## Summary

Two fixes to `decryption_pipeline_builder.rs`:

1. **Respect `max_txns_from_block_to_execute` during decryption.** The materialize step returns this cap and we used to pass it through unused, decrypting txns that downstream `prepare_block` would then truncate. Now we cap encrypted-txn decryption at this limit and mark the excess as a new `ExecuteBlockLimitReached` failure (retried in a subsequent block).
2. **Replace silent modulo wrap on `block.round() % num_rounds`.** Once `block.round() >= num_rounds`, the trusted setup is exhausted; the modulo would alias new rounds onto old ones. Now we reject the entire encrypted batch with a new `TrustedSetupExhausted` failure (non-retryable within the epoch — clears next epoch with the rotated key). The `as u64` cast and modulo are removed.

The `TrustedSetupExhausted` check runs above the epoch-end-vtxn check since it's an environmental condition that invalidates all encrypted txns regardless of block content.

`aptos_vm.rs` retry-classification match is now exhaustive (no more `_ => None`); `ExecuteBlockLimitReached` retries, `TrustedSetupExhausted` falls through to discard.

Serde format corpus (`api.yaml`, `aptos.yaml`, `consensus.yaml`) updated for the new variants.

## Test plan

- [x] `cargo test -p aptos-consensus --lib pipeline::decryption_pipeline_builder` — 23/23 pass, including two new tests:
  - `validator_path_round_exceeds_num_rounds_marks_trusted_setup_exhausted` (also verifies precedence over `ExecuteBlockLimitReached`)
  - `validator_path_execute_block_limit_caps_encrypted_txns`
- [x] `cargo test -p aptos-types --lib transaction::encrypted_payload`
- [x] `cargo test -p generate-format` (corpus diff check)
- [x] `cargo test -p aptos-vm --lib`
- [x] `./scripts/rust_lint.sh --check` (clippy, fmt, sort, machete) clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)