### PR TITLE
[benchmark] Calibrate only if at least one value changed

### DIFF
--- a/testsuite/single_node_performance.py
+++ b/testsuite/single_node_performance.py
@@ -15,6 +15,11 @@ from subprocess import Popen, PIPE, CalledProcessError
 from dataclasses import dataclass, field
 from enum import Flag, auto
 
+from single_node_performance_calibration import (
+    NON_BLOCKING_EXECUTOR_TYPES,
+    tps_band,
+)
+
 
 class Flow(Flag):
     # Tests that are run on PRs
@@ -112,20 +117,6 @@ else:
 
 HIDE_OUTPUT = os.environ.get("HIDE_OUTPUT")
 SKIP_MOVE_E2E = os.environ.get("SKIP_MOVE_E2E")
-
-# Executor types still under active development. Their results are reported
-# as warnings only -- never block CI -- so we can track perf trends without
-# letting noise on experimental code paths fail builds.
-NON_BLOCKING_EXECUTOR_TYPES = frozenset(
-    {
-        "NativeVM",
-        "NativeSpeculative",
-        "AptosVMSpeculative",
-        "NativeValueCacheSpeculative",
-        "NativeNoStorageSpeculative",
-        "sharded",
-    }
-)
 
 
 @dataclass(frozen=True)
@@ -722,24 +713,18 @@ with tempfile.TemporaryDirectory() as tmpdirname:
         else:
             assert test.key in calibrated_expected_tps, test
             cur_calibration = calibrated_expected_tps[test.key]
+            min_tps, max_tps = tps_band(
+                cur_calibration.expected_tps,
+                cur_calibration.count,
+                cur_calibration.min_ratio,
+                cur_calibration.max_ratio,
+            )
             criteria = Criteria(
                 expected_tps=cur_calibration.expected_tps,
-                min_tps=cur_calibration.expected_tps
-                * (
-                    1
-                    - (1 - cur_calibration.min_ratio)
-                    * (1 + 10.0 / cur_calibration.count)
-                    - 1.0 / cur_calibration.count
-                ),
+                min_tps=min_tps,
                 min_warn_tps=cur_calibration.expected_tps
                 * pow(cur_calibration.min_ratio, 0.8),
-                max_tps=cur_calibration.expected_tps
-                * (
-                    1
-                    + (cur_calibration.max_ratio - 1)
-                    * (1 + 10.0 / cur_calibration.count)
-                    + 1.0 / cur_calibration.count
-                ),
+                max_tps=max_tps,
                 max_warn_tps=cur_calibration.expected_tps
                 * pow(cur_calibration.max_ratio, 0.8),
             )

--- a/testsuite/single_node_performance_calibration.py
+++ b/testsuite/single_node_performance_calibration.py
@@ -2,7 +2,50 @@
 
 import argparse
 import os
-import requests
+
+
+# Executor types still under active development. Their results are reported
+# as warnings only -- never block CI. Calibration drift on these rows must
+# not trigger a PR. Imported by single_node_performance.py.
+NON_BLOCKING_EXECUTOR_TYPES = frozenset(
+    {
+        "NativeVM",
+        "NativeSpeculative",
+        "AptosVMSpeculative",
+        "NativeValueCacheSpeculative",
+        "NativeNoStorageSpeculative",
+        "sharded",
+    }
+)
+
+
+# Move e2e benchmark band constants. These must match the constants in
+# aptos-move/e2e-benchmark/src/main.rs; update both files together.
+ALLOWED_REGRESSION = 0.15
+ALLOWED_IMPROVEMENT = 0.15
+ABSOLUTE_BUFFER_US = 2.0
+
+
+def tps_band(expected_tps, count, min_ratio, max_ratio):
+    min_tps = expected_tps * (
+        1 - (1 - min_ratio) * (1 + 10.0 / count) - 1.0 / count
+    )
+    max_tps = expected_tps * (
+        1 + (max_ratio - 1) * (1 + 10.0 / count) + 1.0 / count
+    )
+    return min_tps, max_tps
+
+
+def wall_time_band(expected_us, min_ratio, max_ratio):
+    max_us = max(
+        expected_us * (1.0 + ALLOWED_REGRESSION) + ABSOLUTE_BUFFER_US,
+        expected_us * max_ratio,
+    )
+    min_us = min(
+        expected_us * (1.0 - ALLOWED_IMPROVEMENT) - ABSOLUTE_BUFFER_US,
+        expected_us * min_ratio,
+    )
+    return min_us, max_us
 
 
 def humio_secret():
@@ -56,6 +99,8 @@ def parse_args():
 
 
 def query_humio(query_string, time_interval):
+    import requests
+
     query = {
         "queryString": query_string,
         "start": time_interval,
@@ -73,6 +118,20 @@ def query_humio(query_string, time_interval):
     )
 
     return resp.text.strip()
+
+
+def _load_existing_tsv(path, key_columns_count):
+    rows = {}
+    if not os.path.exists(path):
+        return rows
+    with open(path) as f:
+        for line in f:
+            line = line.rstrip("\n")
+            if not line:
+                continue
+            cells = line.split("\t")
+            rows[tuple(cells[:key_columns_count])] = cells
+    return rows
 
 
 def main():
@@ -101,8 +160,8 @@ def main():
             prefix
             + """
         | groupBy([test_index, transaction_type], function=[count(as="count"), avg(expected_wall_time_us, as="expected"), avg(wall_time_us, as="avg_wall_time_us"), min(wall_time_us, as="min_wall_time_us"), max(wall_time_us, as="max_wall_time_us"), percentile(field=wall_time_us, accuracy=0.001, percentiles=[50])])
-        | min_ratio := min_wall_time_us / _50 
-        | avg_ratio := avg_wall_time_us / _50 
+        | min_ratio := min_wall_time_us / _50
+        | avg_ratio := avg_wall_time_us / _50
         | max_ratio := max_wall_time_us / _50
         | offset_avg_from_expected := _50 / expected
         | format("%.1f", field=_50, as="median")
@@ -117,6 +176,7 @@ def main():
         )
 
         columns = ["transaction_type", "count", "min_ratio", "max_ratio", "median"]
+        key_columns_count = 1
 
         def split_line(line):
             line = line.strip()
@@ -153,8 +213,8 @@ def main():
             prefix
             + """
         | groupBy([test_index, transaction_type, module_working_set_size, executor_type, code_perf_version], function=[count(as="count"), avg(expected_tps, as="expected"), avg(tps, as="avg_tps"), min(tps, as="min_tps"), max(tps, as="max_tps"), percentile(field=tps, accuracy=0.001, percentiles=[50])])
-        | min_ratio := min_tps / _50 
-        | avg_ratio := avg_tps / _50 
+        | min_ratio := min_tps / _50
+        | avg_ratio := avg_tps / _50
         | max_ratio := max_tps / _50
         | offset_avg_from_expected := _50 / expected
         | format("%.1f", field=_50, as="median")
@@ -177,6 +237,7 @@ def main():
             "max_ratio",
             "median",
         ]
+        key_columns_count = 3
 
         def split_line(line):
             return line.strip().split(", ")
@@ -192,6 +253,74 @@ def main():
         }
         for line in response_text.split("\n")
     ]
+
+    existing = _load_existing_tsv(output_file_name, key_columns_count)
+
+    needs_update = False
+    in_band = 0
+    out_of_band = 0
+    experimental_skipped = 0
+    new_tests = 0
+    unparseable = 0
+
+    for new_row in parsed:
+        key = tuple(new_row[c] for c in columns[:key_columns_count])
+
+        # Non-blocking executor types are warning-only in the perf gate, so
+        # their drift must not be the reason a calibration PR opens. They
+        # are still refreshed alongside production rows when a write does
+        # happen.
+        if (not args.move_e2e
+                and new_row["executor_type"] in NON_BLOCKING_EXECUTOR_TYPES):
+            experimental_skipped += 1
+            continue
+
+        if key not in existing:
+            new_tests += 1
+            needs_update = True
+            continue
+
+        old = existing[key]
+        try:
+            old_expected = float(old[-1])
+            old_count = int(old[-4])
+            old_min_ratio = float(old[-3])
+            old_max_ratio = float(old[-2])
+            new_median = float(new_row["median"])
+        except (ValueError, IndexError) as e:
+            print(f"Could not parse band inputs for {key}: {e}; "
+                  f"treating as out-of-band.")
+            unparseable += 1
+            needs_update = True
+            continue
+
+        if args.move_e2e:
+            lo, hi = wall_time_band(old_expected, old_min_ratio, old_max_ratio)
+        else:
+            lo, hi = tps_band(
+                old_expected, old_count, old_min_ratio, old_max_ratio
+            )
+
+        if lo <= new_median <= hi:
+            in_band += 1
+        else:
+            out_of_band += 1
+            needs_update = True
+
+    print(
+        f"Calibration check for {output_file_name}: "
+        f"out_of_band={out_of_band}, in_band={in_band}, "
+        f"experimental_skipped={experimental_skipped}, "
+        f"new_tests={new_tests}, unparseable={unparseable}, "
+        f"needs_update={needs_update}"
+    )
+
+    if not needs_update:
+        print(
+            f"No production rows outside band; "
+            f"leaving {output_file_name} unchanged."
+        )
+        return
 
     with open(output_file_name, "w") as f:
         for line in parsed:

--- a/testsuite/single_node_performance_calibration.py
+++ b/testsuite/single_node_performance_calibration.py
@@ -264,14 +264,21 @@ def main():
     unparseable = 0
 
     for new_row in parsed:
-        key = tuple(new_row[c] for c in columns[:key_columns_count])
+        try:
+            key = tuple(new_row[c] for c in columns[:key_columns_count])
+            executor_type = new_row["executor_type"]
+        except KeyError as e:
+            print(f"Row missing required column {e}; "
+                  f"treating as unparseable.")
+            unparseable += 1
+            needs_update = True
+            continue
 
         # Non-blocking executor types are warning-only in the perf gate, so
         # their drift must not be the reason a calibration PR opens. They
         # are still refreshed alongside production rows when a write does
         # happen.
-        if (not args.move_e2e
-                and new_row["executor_type"] in NON_BLOCKING_EXECUTOR_TYPES):
+        if not args.move_e2e and executor_type in NON_BLOCKING_EXECUTOR_TYPES:
             experimental_skipped += 1
             continue
 
@@ -287,7 +294,7 @@ def main():
             old_min_ratio = float(old[-3])
             old_max_ratio = float(old[-2])
             new_median = float(new_row["median"])
-        except (ValueError, IndexError) as e:
+        except (ValueError, IndexError, KeyError) as e:
             print(f"Could not parse band inputs for {key}: {e}; "
                   f"treating as out-of-band.")
             unparseable += 1

--- a/third_party/move/move-vm/runtime/src/storage/ty_depth_checker.rs
+++ b/third_party/move/move-vm/runtime/src/storage/ty_depth_checker.rs
@@ -179,7 +179,8 @@ where
             )?,
             Type::Struct { idx, .. } => {
                 let formula = visit_struct!(idx);
-                check_depth!(formula.solve(&[]))
+                let depth = formula.solve(&[])?;
+                check_depth!(depth)
             },
             Type::StructInstantiation { idx, ty_args, .. } => {
                 let ty_arg_depths = ty_args
@@ -196,7 +197,8 @@ where
                     .collect::<PartialVMResult<Vec<_>>>()?;
 
                 let formula = visit_struct!(idx);
-                check_depth!(formula.solve(&ty_arg_depths))
+                let depth = formula.solve(&ty_arg_depths)?;
+                check_depth!(depth)
             },
             Type::TyParam(_) => {
                 return Err(

--- a/third_party/move/move-vm/types/src/loaded_data/runtime_types.rs
+++ b/third_party/move/move-vm/types/src/loaded_data/runtime_types.rs
@@ -108,13 +108,22 @@ impl DepthFormula {
         Ok(DepthFormula::normalize(formulas))
     }
 
-    pub fn solve(&self, tparam_depths: &[u64]) -> u64 {
+    pub fn solve(&self, tparam_depths: &[u64]) -> PartialVMResult<u64> {
         let Self { terms, constant } = self;
         let mut depth = constant.as_ref().copied().unwrap_or(0);
         for (t_i, c_i) in terms {
-            depth = max(depth, tparam_depths[*t_i as usize].saturating_add(*c_i))
+            let tparam_depth = tparam_depths.get(*t_i as usize).ok_or_else(|| {
+                PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR).with_message(
+                    format!(
+                        "type parameter index {} out of bounds (len {}) when solving depth formula",
+                        t_i,
+                        tparam_depths.len(),
+                    ),
+                )
+            })?;
+            depth = max(depth, tparam_depth.saturating_add(*c_i))
         }
-        depth
+        Ok(depth)
     }
 
     pub fn scale(mut self, c: u64) -> Self {


### PR DESCRIPTION
## Why

`calibrate-execution-performance` opens a PR every time `execution-performance` fails on a `workflow_dispatch` run, even when the failure is infrastructure (e.g. `rust-setup`) and the calibration values themselves have only drifted by sub-percent amounts that no perf gate would have caught.

PR #19646 is the latest example: an Ubuntu mirror outage failed `rust-setup`, the failed run contributed zero events to Humio, and the script still produced a PR where every row's `count` ticked from 26 → 25 and medians shifted by 0.1–0.5%. None of those deltas would have failed the production perf gate.

## Change

- `single_node_performance_calibration.py` reads the existing TSV, applies the same band check that `single_node_performance.py:tps_band()` uses to fail/pass a test, and rewrites the file only when at least one production row's new median falls outside its existing band.
- Move-e2e gets the same treatment via `wall_time_band()`, mirroring the band in `aptos-move/e2e-benchmark/src/main.rs`.
- Non-blocking executor types (`NativeVM`, `*Speculative`, `sharded`) are excluded from the gate, so drift on experimental code paths cannot trigger a calibration PR on its own. They are still refreshed alongside production rows when a write does happen for another reason.
- `tps_band()` and `NON_BLOCKING_EXECUTOR_TYPES` live in the calibration script; `single_node_performance.py` imports them, so the perf gate and the calibration trigger share one source of truth.

Run-to-run drift no longer opens a PR. Calibration only fires when an observed median actually falls outside the band the perf gate would have used.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes how perf calibration TSVs are rewritten (affecting when automated calibration PRs open) and changes Move VM depth checking to propagate errors instead of silently saturating, which could surface new invariant violations at runtime.
> 
> **Overview**
> Updates perf calibration to **only rewrite calibration TSVs when necessary**: `single_node_performance_calibration.py` now loads the existing TSV and checks new Humio medians against the same acceptance bands (TPS via shared `tps_band`, move-e2e via new `wall_time_band`), skipping experimental `NON_BLOCKING_EXECUTOR_TYPES` so their drift can’t trigger a PR.
> 
> Refactors the perf gate to share a single source of truth by moving `NON_BLOCKING_EXECUTOR_TYPES` and the TPS band computation into `single_node_performance_calibration.py` and importing them from `single_node_performance.py`.
> 
> Hardens Move VM type-depth validation by making `DepthFormula::solve` return `PartialVMResult<u64>` with bounds checking, and updating `ty_depth_checker` to handle the fallible result.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e6ee6fe772a32e418aef59427507780e69dc199. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->