### PR TITLE
[compiler-v2] Type inference: allow more orthogonal constraints

### DIFF
--- a/third_party/move/move-compiler-v2/tests/checking/receiver/ref_field_unsatisfiable.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/receiver/ref_field_unsatisfiable.exp
@@ -1,0 +1,25 @@
+
+Diagnostics:
+error: unable to infer instantiation of type `struct{duration,is_isolated} + &_` (consider providing type arguments or annotating the type)
+   ┌─ tests/checking/receiver/ref_field_unsatisfiable.move:20:16
+   │
+20 │         apply(|x| {
+   │                ^
+
+error: unable to infer instantiation of type `_` (consider providing type arguments or annotating the type)
+   ┌─ tests/checking/receiver/ref_field_unsatisfiable.move:21:21
+   │
+21 │             let _ = *x;
+   │                     ^^
+
+error: unable to infer instantiation of type `_` (consider providing type arguments or annotating the type)
+   ┌─ tests/checking/receiver/ref_field_unsatisfiable.move:22:21
+   │
+22 │             let _ = x.is_isolated;
+   │                     ^^^^^^^^^^^^^
+
+error: unable to infer instantiation of type `_` (consider providing type arguments or annotating the type)
+   ┌─ tests/checking/receiver/ref_field_unsatisfiable.move:23:21
+   │
+23 │             let _ = x.duration;
+   │                     ^^^^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/checking/receiver/ref_field_unsatisfiable.move
+++ b/third_party/move/move-compiler-v2/tests/checking/receiver/ref_field_unsatisfiable.move
@@ -1,0 +1,27 @@
+module 0x42::m {
+
+    struct Position { is_isolated: bool }
+    struct Bond { duration: u64 }
+
+    inline fun apply<T>(f: |T|u64): u64 {
+        abort 0
+    }
+
+    // The lambda parameter `x` starts as a fresh type variable T:
+    //   *x            adds SomeReference
+    //   x.is_isolated adds SomeStruct{is_isolated}
+    //   x.duration    adds SomeStruct{duration} (merged with the above)
+    // SomeReference coexists with the merged SomeStruct{is_isolated, duration}
+    // constraint. No struct in scope has both fields, so the compiler should
+    // produce a clean "unable to infer" diagnostic rather than the bogus
+    // "constraint `&_` incompatible with
+    // `struct{...}`".
+    fun test(): u64 {
+        apply(|x| {
+            let _ = *x;
+            let _ = x.is_isolated;
+            let _ = x.duration;
+            0
+        })
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/checking/receiver/ref_receiver_unsatisfiable.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/receiver/ref_receiver_unsatisfiable.exp
@@ -1,0 +1,19 @@
+
+Diagnostics:
+error: unable to infer instantiation of type `fun self.get_nav(..):_ + &_ + fun self.get_size(..):u64` (consider providing type arguments or annotating the type)
+   ┌─ tests/checking/receiver/ref_receiver_unsatisfiable.move:23:16
+   │
+23 │         apply(|x| {
+   │                ^
+
+error: unable to infer instantiation of type `_` (consider providing type arguments or annotating the type)
+   ┌─ tests/checking/receiver/ref_receiver_unsatisfiable.move:24:21
+   │
+24 │             let _ = *x;
+   │                     ^^
+
+error: unable to infer instantiation of type `_` (consider providing type arguments or annotating the type)
+   ┌─ tests/checking/receiver/ref_receiver_unsatisfiable.move:25:21
+   │
+25 │             let _ = x.get_nav();
+   │                     ^^^^^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/checking/receiver/ref_receiver_unsatisfiable.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/receiver/ref_receiver_unsatisfiable.exp
@@ -1,19 +1,19 @@
 
 Diagnostics:
 error: unable to infer instantiation of type `fun self.get_nav(..):_ + &_ + fun self.get_size(..):u64` (consider providing type arguments or annotating the type)
-   ┌─ tests/checking/receiver/ref_receiver_unsatisfiable.move:23:16
+   ┌─ tests/checking/receiver/ref_receiver_unsatisfiable.move:22:16
    │
-23 │         apply(|x| {
+22 │         apply(|x| {
    │                ^
+
+error: unable to infer instantiation of type `_` (consider providing type arguments or annotating the type)
+   ┌─ tests/checking/receiver/ref_receiver_unsatisfiable.move:23:21
+   │
+23 │             let _ = *x;
+   │                     ^^
 
 error: unable to infer instantiation of type `_` (consider providing type arguments or annotating the type)
    ┌─ tests/checking/receiver/ref_receiver_unsatisfiable.move:24:21
    │
-24 │             let _ = *x;
-   │                     ^^
-
-error: unable to infer instantiation of type `_` (consider providing type arguments or annotating the type)
-   ┌─ tests/checking/receiver/ref_receiver_unsatisfiable.move:25:21
-   │
-25 │             let _ = x.get_nav();
+24 │             let _ = x.get_nav();
    │                     ^^^^^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/checking/receiver/ref_receiver_unsatisfiable.move
+++ b/third_party/move/move-compiler-v2/tests/checking/receiver/ref_receiver_unsatisfiable.move
@@ -1,0 +1,29 @@
+module 0x42::m {
+
+    struct Market { nav: u64 }
+    struct Item { size: u64 }
+
+    fun get_nav(self: &Market): u64 { self.nav }
+    fun get_size(self: &Item): u64 { self.size }
+
+    inline fun apply<T>(f: |T|u64): u64 {
+        abort 0
+    }
+
+    // The lambda parameter `x` starts as a fresh type variable T:
+    //   *x           adds SomeReference
+    //   x.get_nav()  adds SomeReceiverFunction(get_nav)
+    //   x.get_size() adds SomeReceiverFunction(get_size) (different name, coexists)
+    // After the orthogonality fix, SomeReference coexists with the
+    // SomeReceiverFunction constraints. No type has both `get_nav` and
+    // `get_size` methods, so the compiler should produce a clean "unable to
+    // infer" diagnostic rather than the bogus "constraint `&_` incompatible
+    // with `fun self.get_nav(...)`".
+    fun test(): u64 {
+        apply(|x| {
+            let _ = *x;
+            let _ = x.get_nav();
+            x.get_size()
+        })
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/checking/receiver/ref_receiver_unsatisfiable.move
+++ b/third_party/move/move-compiler-v2/tests/checking/receiver/ref_receiver_unsatisfiable.move
@@ -14,11 +14,10 @@ module 0x42::m {
     //   *x           adds SomeReference
     //   x.get_nav()  adds SomeReceiverFunction(get_nav)
     //   x.get_size() adds SomeReceiverFunction(get_size) (different name, coexists)
-    // After the orthogonality fix, SomeReference coexists with the
-    // SomeReceiverFunction constraints. No type has both `get_nav` and
-    // `get_size` methods, so the compiler should produce a clean "unable to
-    // infer" diagnostic rather than the bogus "constraint `&_` incompatible
-    // with `fun self.get_nav(...)`".
+    // SomeReference coexists with the SomeReceiverFunction constraints.
+    // No type has both `get_nav` and `get_size` methods, so the compiler should
+    // produce a clean "unable to infer" diagnostic rather than the bogus
+    // "constraint `&_` incompatible with `fun self.get_nav(...)`".
     fun test(): u64 {
         apply(|x| {
             let _ = *x;

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/ref_constraint_resolution.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/ref_constraint_resolution.exp
@@ -1,0 +1,4 @@
+processed 3 tasks
+task 0 lines 1-58:  publish [module 0x42::ref_constraint_test {]
+task 1 lines 60-60:  run --verbose -- 0x42::ref_constraint_test::test_receiver
+task 2 lines 62-62:  run --verbose -- 0x42::ref_constraint_test::test_field

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/ref_constraint_resolution.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/ref_constraint_resolution.move
@@ -1,0 +1,62 @@
+//# publish
+module 0x42::ref_constraint_test {
+    struct Container<V> has store, drop {
+        v: V
+    }
+
+    struct Item has store, copy, drop {
+        size: u64
+    }
+
+    fun set_size(self: &mut Item, new_size: u64) {
+        self.size = new_size;
+    }
+
+    inline fun modify_and_return<V: store, R>(self: &mut Container<V>, f: |&mut V|R): R {
+        f(&mut self.v)
+    }
+
+    // Exercises SomeReference + SomeReceiverFunction coexistence: in the
+    // lambda body, `*item` adds a SomeReference constraint while
+    // `item.set_size(size)` adds a SomeReceiverFunction constraint on the
+    // same fresh type variable. Compilation requires the two to be treated
+    // as orthogonal.
+    fun call_receiver(c: &mut Container<Item>, size: u64): Item {
+        c.modify_and_return(
+            |item| {
+                item.set_size(size);
+                *item
+            }
+        )
+    }
+
+    // Exercises SomeReference + SomeStruct coexistence: `*item` adds a
+    // SomeReference constraint while `item.size = ...` adds a SomeStruct
+    // constraint on the same fresh type variable.
+    fun call_field(c: &mut Container<Item>, new_size: u64): Item {
+        c.modify_and_return(
+            |item| {
+                item.size = new_size;
+                *item
+            }
+        )
+    }
+
+    fun test_receiver() {
+        let c = Container { v: Item { size: 1 } };
+        let result = call_receiver(&mut c, 42);
+        assert!(result.size == 42, 0);
+        assert!(c.v.size == 42, 1);
+    }
+
+    fun test_field() {
+        let c = Container { v: Item { size: 1 } };
+        let result = call_field(&mut c, 7);
+        assert!(result.size == 7, 0);
+        assert!(c.v.size == 7, 1);
+    }
+}
+
+//# run --verbose -- 0x42::ref_constraint_test::test_receiver
+
+//# run --verbose -- 0x42::ref_constraint_test::test_field

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/round-trip/ref_constraint_resolution.decompiled
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/round-trip/ref_constraint_resolution.decompiled
@@ -1,0 +1,43 @@
+//**** Cross-compiled for `move` syntax from `tests/no-v1-comparison/ref_constraint_resolution.move`
+
+//# publish
+module 0x42::ref_constraint_test {
+    struct Container<T0> has drop, store {
+        v: T0,
+    }
+    struct Item has copy, drop, store {
+        size: u64,
+    }
+    fun call_field(p0: &mut Container<Item>, p1: u64): Item {
+        let _v0 = &mut p0.v;
+        let _v1 = &mut _v0.size;
+        *_v1 = p1;
+        *_v0
+    }
+    fun call_receiver(p0: &mut Container<Item>, p1: u64): Item {
+        let _v0 = &mut p0.v;
+        set_size(_v0, p1);
+        *_v0
+    }
+    fun set_size(p0: &mut Item, p1: u64) {
+        let _v0 = &mut p0.size;
+        *_v0 = p1;
+    }
+    fun test_field() {
+        let _v0 = Container<Item>{v: Item{size: 1}};
+        let _v1 = call_field(&mut _v0, 7);
+        assert!(*&(&_v1).size == 7, 0);
+        assert!(*&(&(&_v0).v).size == 7, 1);
+    }
+    fun test_receiver() {
+        let _v0 = Container<Item>{v: Item{size: 1}};
+        let _v1 = call_receiver(&mut _v0, 42);
+        assert!(*&(&_v1).size == 42, 0);
+        assert!(*&(&(&_v0).v).size == 42, 1);
+    }
+}
+
+
+//# run --verbose -- 0x42::ref_constraint_test::test_receiver
+
+//# run --verbose -- 0x42::ref_constraint_test::test_field

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/round-trip/ref_constraint_resolution.decompiled.baseline.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/round-trip/ref_constraint_resolution.decompiled.baseline.exp
@@ -1,0 +1,4 @@
+processed 3 tasks
+task 0 lines 3-38:  publish [module 0x42::ref_constraint_test {]
+task 1 lines 41-41:  run --verbose -- 0x42::ref_constraint_test::test_receiver
+task 2 lines 43-43:  run --verbose -- 0x42::ref_constraint_test::test_field

--- a/third_party/move/move-model/src/ty.rs
+++ b/third_party/move/move-model/src/ty.rs
@@ -682,6 +682,15 @@ impl Constraint {
             // (field existence vs receiver function existence), so they can coexist.
             (Constraint::SomeStruct(..), Constraint::SomeReceiverFunction(..))
             | (Constraint::SomeReceiverFunction(..), Constraint::SomeStruct(..)) => Ok(false),
+            // SomeReference is orthogonal to constraints that propagate over references
+            // (SomeStruct, SomeReceiverFunction — see `propagate_over_reference`): the
+            // reference shape applies to the outer type while the field/method
+            // requirement is satisfied by the referent. E.g. `&mut S` is a reference and
+            // `S` has the field/method.
+            (Constraint::SomeReference(..), Constraint::SomeStruct(..))
+            | (Constraint::SomeStruct(..), Constraint::SomeReference(..))
+            | (Constraint::SomeReference(..), Constraint::SomeReceiverFunction(..))
+            | (Constraint::SomeReceiverFunction(..), Constraint::SomeReference(..)) => Ok(false),
             // After the above checks, if one of the constraints is
             // accumulating, indicate its compatible but cannot be joined.
             (c1, c2) if c1.accumulating() || c2.accumulating() => Ok(false),


### PR DESCRIPTION
## Description

We had some false "constraint incompatible" errors emitted by the compiler, eg., when `SomeReference` constraint was paired with `SomeReceiverFunction` or `SomeStruct`. We now allow these constraint-pairs to coexist, thus admitting more programs than before.

## How Has This Been Tested?

- added new +ve and -ve tests
- existing tests pass

## Type of Change
- [x] Bug fix

## Which Components or Systems Does This Change Impact?
- [x] Move Compiler

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the Move compiler’s core type unification/constraint-joining logic, which can subtly change inference results and diagnostics across many programs. Added tests mitigate risk, but widened compatibility may expose new edge cases in constraint propagation and error reporting.
> 
> **Overview**
> Fixes a type-inference bug where combining `SomeReference` with propagated-over-reference constraints (`SomeStruct` field constraints or `SomeReceiverFunction` method constraints) could incorrectly be treated as *incompatible*, producing misleading “constraint incompatible” errors.
> 
> Updates constraint joining in `move-model` (`ty.rs`) to allow these constraint pairs to coexist (treating reference shape vs referent field/method requirements as orthogonal), and adds new negative and transactional tests to lock in the improved “unable to infer” diagnostics and successful compilation for valid patterns.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 540c4c98737aa2222221637d3f2355e2c6441864. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->