### PR TITLE
[replay-verify] Rework PVC pipeline; tune timeouts and concurrency

### DIFF
--- a/testsuite/replay-verify/main.py
+++ b/testsuite/replay-verify/main.py
@@ -1,4 +1,6 @@
 import argparse
+from collections import Counter
+from dataclasses import dataclass
 import datetime
 import dateparser
 from enum import Enum
@@ -11,6 +13,7 @@ import os
 import sys
 from tenacity import retry, stop_after_attempt, wait_fixed, retry_if_exception_type
 import time
+from typing import Optional
 import urllib.error
 import urllib.parse
 import yaml
@@ -22,8 +25,9 @@ from testsuite import forge
 from archive_disk_utils import (
     TESTNET_SNAPSHOT_NAME,
     MAINNET_SNAPSHOT_NAME,
-    create_replay_verify_pvcs_from_existing,
+    create_one_pvc_from_existing,
     create_replay_verify_pvcs_from_snapshot,
+    generate_disk_name,
     get_kubectl_credentials,
 )
 
@@ -33,11 +37,30 @@ RETRY_DELAY = 5  # seconds
 QUERY_DELAY = 5  # seconds
 POD_STATUS_CACHE_TTL = 3  # seconds — reuse cached pod status for this long
 
-# Timeout chain — each layer is a backstop for the one before:
-#   scheduler (20m) → binary (30m) → K8s TTL controller (40m)
-POD_TIMEOUT = 20 * 60  # scheduler kills stuck pods after 20 min
-BINARY_TIMEOUT = POD_TIMEOUT + 10 * 60  # aptos-debugger self-terminates as backstop
-POD_TTL = BINARY_TIMEOUT + 10 * 60  # K8s TTL controller as last resort
+# Cap on in-flight PVC creations (Pending → Bound). Lower numbers reduce
+# concurrent load on GCE PD's snapshot-clone path, which appears to be where
+# tail-latency throttling happens.
+MAX_CONCURRENT_PVC_CREATIONS = 5
+PVC_TTL_SECS = 8 * 60 * 60
+
+# Hard ceiling on workers attached to a single PVC at once. Empirically
+# observed: GCE Persistent Disk allows roughly 10 concurrent active readers
+# per disk before additional workers stop making progress (they get queued
+# at the CSI/attach layer or starve at the IO layer). Setting
+# workers_per_pvc higher than this in ReplayConfig produces no throughput
+# gain — it just adds Pending pods that brush against the per-pod timeout.
+MAX_WORKERS_PER_PVC = 10
+
+# Per-pod timeout for Pending phase. A pod that hasn't reached Running
+# after this long is almost certainly stuck (image-pull failure, node
+# unhealthy, etc.) — kill and reschedule rather than waste a Running-budget
+# retry slot. Same for both networks; depends on image-pull worst-case
+# rather than workload.
+PENDING_TIMEOUT = 10 * 60
+
+# Per-pod timeouts for the Running phase live in ReplayConfig (running_timeout)
+# because they vary by network. Binary self-timeout and K8s pod TTL are
+# derived from running_timeout — see ReplayConfig.
 
 REPLAY_CONCURRENCY_LEVEL = 1
 
@@ -57,6 +80,36 @@ class Network(Enum):
             return cls[name.upper()]
         except KeyError:
             raise ValueError(f"{name} is not a valid Network name")
+
+
+@dataclass
+class PVCInfo:
+    """Tracks the lifecycle of one PVC managed by the scheduler.
+
+    Source PVC is cloned from the snapshot directly. Clone PVCs are cloned
+    from the source PVC (which must be Bound first, since `dataSource` needs
+    a real GCE disk). After they bind, source and clones are interchangeable
+    from the worker's perspective.
+    """
+
+    name: str
+    is_source: bool
+    created_at: float
+    bound_at: Optional[float] = None
+
+    @property
+    def is_bound(self) -> bool:
+        return self.bound_at is not None
+
+    @property
+    def age_secs(self) -> float:
+        return time.time() - self.created_at
+
+    @property
+    def bind_duration_secs(self) -> Optional[float]:
+        if self.bound_at is None:
+            return None
+        return self.bound_at - self.created_at
 
 
 class LocalPhase(Enum):
@@ -144,14 +197,30 @@ class ReplayConfig:
     def __init__(self, network: Network) -> None:
         if network == Network.TESTNET:
             self.concurrent_replayer = 35
-            self.pvc_number = 35
+            self.pvc_number = 10
+            self.workers_per_pvc = 10
             self.min_range_size = 10_000
             self.range_size = 5_000_000
+            # Testnet has the 6.7B-6.8B heavy zone; some 1M chunks take ~33m.
+            self.running_timeout = 40 * 60
         else:
             self.concurrent_replayer = 35
             self.pvc_number = 10
+            self.workers_per_pvc = 10
             self.min_range_size = 10_000
             self.range_size = 2_000_000
+            self.running_timeout = 30 * 60
+        # Timeout chain for the Running phase — each layer is a backstop:
+        #   scheduler (running_timeout) -> binary (+10m) -> K8s TTL (+10m).
+        self.binary_timeout = self.running_timeout + 10 * 60
+        self.pod_ttl = self.binary_timeout + 10 * 60
+        # See MAX_WORKERS_PER_PVC for the rationale. This catches accidental
+        # bumps in either branch above.
+        assert self.workers_per_pvc <= MAX_WORKERS_PER_PVC, (
+            f"workers_per_pvc={self.workers_per_pvc} exceeds GCE PD's per-disk "
+            f"concurrent-reader ceiling ({MAX_WORKERS_PER_PVC}). Going higher "
+            f"adds no throughput — extras queue or starve."
+        )
 
 
 class WorkerPod:
@@ -162,7 +231,7 @@ class WorkerPod:
         end_version: int,
         label: str,
         image: str,
-        pvcs: list[str],
+        pvc_name: str,
         replay_config: ReplayConfig,
         network: Network = Network.TESTNET,
         namespace: str = "default",
@@ -180,21 +249,31 @@ class WorkerPod:
         self.network = network
         self.label = label
         self.start_time = time.time()
+        # First time we observed this pod in Running phase. Used to apply
+        # running_timeout from the moment the binary actually started, so
+        # slow Pending (image pull, attach) doesn't eat the Running budget.
+        self.running_first_seen_at: Optional[float] = None
         self.image = image
-        self.pvcs = pvcs
+        self.pvc_name = pvc_name
         self.config = replay_config
 
     def update_status(self) -> None:
         """Refresh self.local_phase from the K8s API (with caching).
 
-        This is the ONLY method that mutates self.local_phase and self.status.
-        All other getters (is_completed, get_phase, etc.) call this then read
-        the state — they never fetch or transition on their own.
+        This is the ONLY method that mutates self.local_phase, self.status,
+        and self.running_first_seen_at. All other getters (is_completed,
+        get_phase, get_running_age_secs, etc.) call this then read the
+        state — they never fetch or transition on their own.
 
         Caching rules:
           - Terminal phases (SUCCEEDED/FAILED/LOST) are cached forever.
           - Non-terminal phases are cached for POD_STATUS_CACHE_TTL seconds.
           - Any exception during fetch transitions the pod to LOST.
+
+        running_first_seen_at is captured exactly once, the first time a
+        successful fetch observes phase=RUNNING. Cache-fresh returns,
+        terminal-phase returns, and exception paths all skip the capture,
+        which is correct because no transition occurs in those paths.
         """
         # Terminal phases never change — no need to refetch
         if self.local_phase in (LocalPhase.SUCCEEDED, LocalPhase.FAILED, LocalPhase.LOST):
@@ -213,6 +292,13 @@ class WorkerPod:
                 self.local_phase = LocalPhase(phase_str)
             except ValueError:
                 self.local_phase = LocalPhase.UNKNOWN
+            # Capture the first time we observe Running so the scheduler
+            # can apply running_timeout from there (not from pod creation).
+            if (
+                self.local_phase == LocalPhase.RUNNING
+                and self.running_first_seen_at is None
+            ):
+                self.running_first_seen_at = time.time()
         except Exception as e:
             # _get_pod_status_api_call already retries 5x internally; if we still get
             # an exception, consider the pod permanently LOST. Clear the
@@ -279,6 +365,17 @@ class WorkerPod:
         """Return seconds since this WorkerPod was created."""
         return time.time() - self.start_time
 
+    def get_running_age_secs(self) -> Optional[float]:
+        """Seconds since the pod first transitioned to Running, or None.
+
+        None if the pod hasn't been observed in Running phase yet — caller
+        should fall back to Pending-phase semantics in that case.
+        """
+        self.update_status()
+        if self.running_first_seen_at is None:
+            return None
+        return time.time() - self.running_first_seen_at
+
     def has_txn_mismatch(self) -> bool:
         if self.local_phase == LocalPhase.LOST or not self.status:
             return False
@@ -295,8 +392,7 @@ class WorkerPod:
         return "/mnt/archive/db"
 
     def get_claim_name(self) -> str:
-        idx = self.worker_id % len(self.pvcs)
-        return self.pvcs[idx]
+        return self.pvc_name
 
     def start(self) -> None:
         # Load the worker YAML from the file
@@ -307,10 +403,9 @@ class WorkerPod:
         pod_manifest["metadata"]["name"] = self.name  # Unique name for each pod
         pod_manifest["metadata"]["labels"]["run"] = self.label
         pod_manifest["spec"]["containers"][0]["image"] = self.image
-        pod_ttl = POD_TTL
         pod_manifest["metadata"]["annotations"][
             "k8s-ttl-controller.twin.sh/ttl"
-        ] = f"{pod_ttl}s"
+        ] = f"{self.config.pod_ttl}s"
         pod_manifest["spec"]["volumes"][0]["persistentVolumeClaim"][
             "claimName"
         ] = self.get_claim_name()
@@ -330,7 +425,7 @@ class WorkerPod:
             "--replay-concurrency-level",
             f"{REPLAY_CONCURRENCY_LEVEL}",
             "--timeout-secs",
-            f"{BINARY_TIMEOUT}",
+            f"{self.config.binary_timeout}",
             "--block-cache-size",
             f"{36 * 1024 * 1024 * 1024}",
         ]
@@ -507,7 +602,8 @@ class ReplayScheduler:
         # record
         self.task_stats = {}
         self.image = image
-        self.pvcs = []
+        self.pvcs: list[PVCInfo] = []
+        self._snapshot_name: Optional[str] = None
         self.config = replay_config
 
     def __str__(self):
@@ -516,12 +612,13 @@ class ReplayScheduler:
             start_version: {self.start_version}
             end_version: {self.end_version}
             range_size: {self.range_size}
-            worker_cnt: {worker_cnt}
-            image: {image}
+            worker_cnt: {len(self.current_workers)}
+            image: {self.image}
             number_of_pvc: {self.config.pvc_number}
-            pod_timeout: {POD_TIMEOUT}
-            binary_timeout: {BINARY_TIMEOUT}
-            pod_ttl: {POD_TTL}
+            pending_timeout: {PENDING_TIMEOUT}
+            running_timeout: {self.config.running_timeout}
+            binary_timeout: {self.config.binary_timeout}
+            pod_ttl: {self.config.pod_ttl}
             namespace: {self.namespace}"""
 
     def get_label(self):
@@ -616,96 +713,128 @@ class ReplayScheduler:
 
         logger.info(f"Task ranges: {self.tasks}")
 
-    def create_pvc_from_snapshot(self):
+    def start_pvc_creation_pipeline(self) -> None:
+        """Kick off PVC creation. Non-blocking: only the source PVC is requested
+        here; clones spawn progressively as the schedule loop runs (see
+        :meth:`_maintain_pvc_pipeline`). Workers can dispatch to any PVC the
+        moment it becomes Bound, including the source.
+        """
         snapshot_name = (
             TESTNET_SNAPSHOT_NAME
             if self.network == Network.TESTNET
             else MAINNET_SNAPSHOT_NAME
         )
-        # Because PVCs can be shared among multiple replay-verify runs, a more correct TTL
-        # would be computed from the number of shards and the expected run time of the replay-verify
-        # run. However, for simplicity, we set the TTL to 9 hours.
-        pvc_ttl = 9 * 60 * 60  # 9 hours
-        pvcs = create_replay_verify_pvcs_from_snapshot(
-            self.id,
-            snapshot_name,
-            self.namespace,
-            self.config.pvc_number,
-            self.get_label(),
-            pvc_ttl,
-        )
-        assert len(pvcs) == self.config.pvc_number, "failed to create all pvcs"
-        self.pvcs = pvcs
-
-    def create_all_required_pvcs(self) -> None:
-        snapshot_name = (
-            TESTNET_SNAPSHOT_NAME
-            if self.network == Network.TESTNET
-            else MAINNET_SNAPSHOT_NAME
-        )
-        pvc = self.create_one_pvc_from_snapshot(snapshot_name)
-        self.pvcs = [pvc]
-        # Wait for the PVC to be bound before creating other PVCs
+        self._snapshot_name = snapshot_name
+        source_name = self._create_source_pvc(snapshot_name)
+        self.pvcs = [
+            PVCInfo(name=source_name, is_source=True, created_at=time.time())
+        ]
         logger.info(
-            f"Waiting for the PVC {pvc} to be bound. "
-            "This involves cloning a large disk volume from a snapshot and may take 10+ minutes..."
+            f"Started creating source PVC {source_name} "
+            f"(target: {self.config.pvc_number} PVCs total, "
+            f"max {MAX_CONCURRENT_PVC_CREATIONS} concurrent creates)"
         )
-        bound_status = self.get_pvc_bound_status()
-        while not self.get_pvc_bound_status()[0]:
-            time.sleep(QUERY_DELAY)
-        logger.info(f"PVC {pvc} is now bound. Proceeding to clone additional PVCs...")
-        self.create_pvc_from_existing(snapshot_name, pvc)
 
-    def create_one_pvc_from_snapshot(self, snapshot_name: str) -> str:
-        # Because PVCs can be shared among multiple replay-verify runs, a more correct TTL
-        # would be computed from the number of shards and the expected run time of the replay-verify
-        # run. However, for simplicity, we set the TTL to 3 hours.
-        pvc_ttl = 8 * 60 * 60  # 8 hours
+    def _create_source_pvc(self, snapshot_name: str) -> str:
         pvcs = create_replay_verify_pvcs_from_snapshot(
             self.id,
             snapshot_name,
             self.namespace,
             1,  # only create one PVC
             self.get_label(),
-            pvc_ttl,
+            PVC_TTL_SECS,
         )
-        assert len(pvcs) == 1, "failed to create the PVC"
+        assert len(pvcs) == 1, "failed to create the source PVC"
         return pvcs[0]
 
-    # Creates a pvc by cloning an existing pvc
-    def create_pvc_from_existing(self, original_snapshot_name: str, existing_pvc: str):
-        pvc_ttl = 8 * 60 * 60
-        pvcs = create_replay_verify_pvcs_from_existing(
-            self.id,
-            original_snapshot_name,
-            existing_pvc,
-            self.config.pvc_number,
-            self.namespace,
-            self.get_label(),
-            pvc_ttl,
-        )
-        assert len(pvcs) == self.config.pvc_number, "failed to create all pvcs"
-        self.pvcs = pvcs
-
-    @retry(
-        stop=stop_after_attempt(MAX_RETRIES),
-        wait=wait_fixed(RETRY_DELAY),
-        retry=retry_if_exception_type(ApiException),
-        before_sleep=lambda retry_state: logger.warning(
-            f"Retry {retry_state.attempt_number}/{MAX_RETRIES} failed: {retry_state.outcome.exception()}"
-        ),
-    )
-    def get_pvc_bound_status(self) -> list[bool]:
-        statuses = []
-        for pvc in self.pvcs:
+    def _is_pvc_bound(self, name: str) -> bool:
+        try:
             pvc_status = self.client.read_namespaced_persistent_volume_claim_status(
-                name=pvc, namespace=self.namespace
+                name=name, namespace=self.namespace
             )
-            if pvc_status.status.phase == "Bound":
-                statuses.append(True)
-            else:
-                statuses.append(False)
-        return statuses
+            return pvc_status.status.phase == "Bound"
+        except Exception as e:
+            logger.warning(f"Failed to check PVC {name} status: {e}")
+            return False
+
+    def _maintain_pvc_pipeline(self) -> None:
+        """Refresh bound status of in-flight PVCs and request new clones up to
+        the concurrency cap.
+
+        Run every iteration of the schedule loop. Cheap when nothing is in
+        flight (no API calls if all PVCs are already bound).
+        """
+        # 1. Refresh bound status for any not-yet-bound PVC.
+        for pvc in self.pvcs:
+            if not pvc.is_bound and self._is_pvc_bound(pvc.name):
+                pvc.bound_at = time.time()
+                logger.info(
+                    f"PVC {pvc.name} is now bound after "
+                    f"{int(pvc.bind_duration_secs)}s "
+                    f"({'source' if pvc.is_source else 'clone'})"
+                )
+
+        # 2. If we still need more clones, and the source is bound, request
+        #    more up to the concurrency cap.
+        target = self.config.pvc_number
+        if len(self.pvcs) >= target:
+            return  # all requested
+
+        source = self.pvcs[0]
+        if not source.is_bound:
+            return  # clones use source as dataSource; must wait for it
+
+        in_flight = sum(1 for p in self.pvcs if not p.is_bound)
+        headroom = MAX_CONCURRENT_PVC_CREATIONS - in_flight
+        if headroom <= 0:
+            return
+        to_spawn = min(headroom, target - len(self.pvcs))
+        for _ in range(to_spawn):
+            # Unified naming: source is index 0 (created elsewhere with the
+            # same snapshot prefix), clones are indices 1, 2, 3, ... All
+            # PVCs share the format: {snapshot}-{run_id}-{idx}.
+            pvc_idx = len(self.pvcs)
+            clone_name = generate_disk_name(
+                self.id, self._snapshot_name, pvc_idx
+            )
+            try:
+                create_one_pvc_from_existing(
+                    clone_name,
+                    source.name,
+                    self.namespace,
+                    self.get_label(),
+                    PVC_TTL_SECS,
+                )
+            except Exception as e:
+                logger.error(
+                    f"Failed to start creating clone PVC {clone_name}: {e}"
+                )
+                # Don't append; we'll retry on a subsequent iteration.
+                return
+            self.pvcs.append(
+                PVCInfo(name=clone_name, is_source=False, created_at=time.time())
+            )
+            logger.info(
+                f"Started creating clone PVC {clone_name} "
+                f"(requested {len(self.pvcs)}/{target}, "
+                f"in-flight {in_flight + 1}/{MAX_CONCURRENT_PVC_CREATIONS})"
+            )
+            in_flight += 1
+
+    def _pick_pvc_for_dispatch(
+        self, active_per_pvc: "Counter[str]"
+    ) -> Optional[str]:
+        """Return the least-loaded bound PVC with capacity, or None if none available."""
+        cap = self.config.workers_per_pvc
+        candidates = [
+            (active_per_pvc.get(p.name, 0), p.name)
+            for p in self.pvcs
+            if p.is_bound and active_per_pvc.get(p.name, 0) < cap
+        ]
+        if not candidates:
+            return None
+        candidates.sort()  # ascending by active count → least-loaded first
+        return candidates[0][1]
 
     def _has_active_workers(self) -> bool:
         return any(w is not None for w in self.current_workers)
@@ -727,52 +856,86 @@ class ReplayScheduler:
         schedule_start = time.time()
         last_summary_time = schedule_start
         self.total_tasks = len(self.tasks)
-        pod_timeout = POD_TIMEOUT
 
         # Keep running while there are tasks to dispatch OR workers still active.
         while len(self.tasks) > 0 or self._has_active_workers():
 
+            # --- Maintain PVC pipeline (poll bound status, spawn more clones) ---
+            self._maintain_pvc_pipeline()
+
+            # Track active workers per PVC so we can enforce per-PVC concurrency
+            # caps when picking where to dispatch. Computed once per iteration;
+            # incremented as we dispatch within this iteration.
+            active_per_pvc: "Counter[str]" = Counter()
+            for w in self.current_workers:
+                if w is not None:
+                    active_per_pvc[w.pvc_name] += 1
+
             # --- Scan worker slots ---
-            pvc_bound_status = self.get_pvc_bound_status()
             for i in range(len(self.current_workers)):
                 worker = self.current_workers[i]
 
                 if worker is not None:
                     if worker.is_completed():
-                        # Pod finished (Succeeded or Failed) — process and free slot
+                        # Pod finished (Succeeded or Failed) — process and free
+                        # slot. process_completed_pod always clears the slot
+                        # (every branch sets current_workers[i] = None), so
+                        # the slot is guaranteed empty after this call.
                         self.process_completed_pod(worker, i)
-                        worker = self.current_workers[i]
-                    elif worker.get_age_secs() > pod_timeout:
-                        # Pod has been running too long — reschedule if under
-                        # retry limit, otherwise treat as permanent failure.
-                        retries = self.task_stats[worker.name].retry_count + 1
-                        logger.error(
-                            f"Worker {i} timed out: {worker.name}, "
-                            f"phase={worker.get_phase()}, "
-                            f"container={worker.get_container_status_summary()}, "
-                            f"age={int(worker.get_age_secs())}s, "
-                            f"attempt {retries}/{MAX_RETRIES}"
-                        )
-                        if retries < MAX_RETRIES:
-                            self.kill_pod_and_reschedule_task(worker, i)
-                        else:
-                            logger.error(
-                                f"Worker {i} exceeded max retries, giving up: {worker.name}"
-                            )
-                            worker.delete_pod()
-                            self.failed_workpod_logs.append(worker.get_humio_log_link())
-                            self.current_workers[i] = None
-                        # Sync local var with the slot (now None in both branches:
-                        # kill_pod_and_reschedule_task clears it, and the else branch above clears
-                        # it explicitly). This allows the dispatch check below to
-                        # immediately fill this slot with a new task.
+                        active_per_pvc[worker.pvc_name] -= 1
                         worker = None
+                    else:
+                        # Phase-aware timeout: a pod that hasn't reached
+                        # Running uses PENDING_TIMEOUT (10m); a pod in
+                        # Running phase gets running_timeout from the moment
+                        # it first transitioned to Running, so a slow Pending
+                        # doesn't eat into the binary's budget.
+                        running_age = worker.get_running_age_secs()
+                        if running_age is not None:
+                            timeout_age = running_age
+                            timeout_threshold = self.config.running_timeout
+                            timeout_kind = "running"
+                        else:
+                            timeout_age = worker.get_age_secs()
+                            timeout_threshold = PENDING_TIMEOUT
+                            timeout_kind = "pending"
 
-                # If slot is free and there are tasks, dispatch one.
-                # PVC must be bound first, unless this is the initial pod
-                # that triggers binding (i < number of PVCs).
-                pvc_ready = pvc_bound_status[i % len(self.pvcs)] or i < len(self.pvcs)
-                if worker is None and pvc_ready and len(self.tasks) > 0:
+                        if timeout_age > timeout_threshold:
+                            retries = self.task_stats[worker.name].retry_count + 1
+                            logger.error(
+                                f"Worker {i} {timeout_kind}-timeout: {worker.name}, "
+                                f"phase={worker.get_phase()}, "
+                                f"container={worker.get_container_status_summary()}, "
+                                f"age={int(timeout_age)}s > {timeout_threshold}s, "
+                                f"attempt {retries}/{MAX_RETRIES}"
+                            )
+                            if retries < MAX_RETRIES:
+                                self.kill_pod_and_reschedule_task(worker, i)
+                            else:
+                                logger.error(
+                                    f"Worker {i} exceeded max retries, giving up: {worker.name}"
+                                )
+                                worker.delete_pod()
+                                self.failed_workpod_logs.append(worker.get_humio_log_link())
+                                self.current_workers[i] = None
+                                # Mark terminal so this task counts as
+                                # failed in the aggregate stats and
+                                # "completed" header. Missing this was
+                                # making timeout-exhausted tasks invisible
+                                # to both. (Mirrors process_completed_pod's
+                                # permanent-fail path.)
+                                self.task_stats[worker.name].set_end_time()
+                            # Slot now empty in both branches; reflect that in the
+                            # active counter so the dispatch step below can refill.
+                            active_per_pvc[worker.pvc_name] -= 1
+                            worker = None
+
+                # If slot is free and there are tasks AND there's a bound PVC
+                # with available capacity, dispatch one.
+                if worker is None and len(self.tasks) > 0:
+                    pvc_name = self._pick_pvc_for_dispatch(active_per_pvc)
+                    if pvc_name is None:
+                        continue  # no bound PVC with capacity; try later
                     task = self.tasks.pop(0)
                     worker_pod = WorkerPod(
                         i,
@@ -780,13 +943,14 @@ class ReplayScheduler:
                         task[1],
                         self.get_label(),
                         self.image,
-                        self.pvcs,
+                        pvc_name,
                         self.config,
                         self.network,
                         self.namespace,
                     )
                     self.current_workers[i] = worker_pod
                     worker_pod.start()
+                    active_per_pvc[pvc_name] += 1
                     if worker_pod.name not in self.task_stats:
                         self.task_stats[worker_pod.name] = TaskStats(worker_pod.name)
                     else:
@@ -870,6 +1034,61 @@ class ReplayScheduler:
     def print_stats(self):
         for key, value in self.task_stats.items():
             logger.info(f"{key}: {value}")
+        self._print_aggregate_stats()
+
+    def _print_aggregate_stats(self):
+        """End-of-run aggregate: counts, retry distribution, duration percentiles.
+
+        Durations reflect each task's *final attempt* (reset_timing() clears
+        start_time on each redispatch), so percentiles are not contaminated
+        by retried-then-succeeded tasks.
+        """
+        if not self.task_stats:
+            logger.info("No tasks were dispatched")
+            return
+
+        log = lambda msg: logger.info(msg)
+
+        succeeded = [ts for ts in self.task_stats.values() if ts.succeeded]
+        failed = [
+            ts for ts in self.task_stats.values()
+            if not ts.succeeded and ts.end_time is not None
+        ]
+
+        log("")
+        log("=== Run statistics ===")
+        log(
+            f"  Total tasks: {len(self.task_stats)} "
+            f"(succeeded={len(succeeded)}, failed={len(failed)})"
+        )
+
+        retry_counts = Counter(ts.retry_count for ts in self.task_stats.values())
+        breakdown = ", ".join(f"{r}->{c}" for r, c in sorted(retry_counts.items()))
+        log(f"  Retry counts: {breakdown}")
+
+        def _emit(label: str, items: list) -> None:
+            durations = sorted(
+                ts.duration_secs for ts in items if ts.duration_secs is not None
+            )
+            n = len(durations)
+            if n == 0:
+                log(f"  {label} task durations: (none)")
+                return
+            # Percentile pick: floor(n*p), clamped to last index.
+            def pct(p: float) -> int:
+                return int(durations[min(int(n * p), n - 1)])
+            log(
+                f"  {label} task durations ({n}): "
+                f"min={int(durations[0])}s, "
+                f"p50={pct(0.5)}s, p90={pct(0.9)}s, p99={pct(0.99)}s, "
+                f"max={int(durations[-1])}s, "
+                f"mean={int(sum(durations) / n)}s"
+            )
+
+        _emit("Succeeded", succeeded)
+        if failed:
+            _emit("Failed", failed)
+        log("=== End run statistics ===")
 
     def _log_worker_summary(
         self,
@@ -877,36 +1096,80 @@ class ReplayScheduler:
         tasks_remaining: int | None = None,
         log_level: int = logging.INFO,
     ):
-        """Dump status of every worker slot."""
-        from collections import Counter
+        """Dump scheduler status: PVC pipeline (always shown) plus per-worker state."""
         log = lambda msg: logger.log(log_level, msg)
-        phase_counts = Counter()
-        header = f"=== Worker status (elapsed={int(time.time() - phase_start_time)}s"
+        header = f"=== Scheduler status (elapsed={int(time.time() - phase_start_time)}s"
         if tasks_remaining is not None:
-            dispatched = self.total_tasks - tasks_remaining
-            pct = int(dispatched / self.total_tasks * 100) if self.total_tasks > 0 else 100
-            header += f", dispatched {dispatched}/{self.total_tasks} — {pct}%"
+            # "Completed" = task reached a terminal state (succeeded OR
+            # permanently failed). Tasks still in retry-cycle have end_time
+            # cleared by reset_timing(), so they don't count yet.
+            completed = sum(
+                1 for ts in self.task_stats.values()
+                if ts.succeeded or ts.end_time is not None
+            )
+            pct = int(completed / self.total_tasks * 100) if self.total_tasks > 0 else 100
+            header += f", completed {completed}/{self.total_tasks} — {pct}%"
         header += ") ==="
         log("")
         log(header)
+
+        # --- One pass over workers: phase counts, per-PVC load, detail lines ---
+        phase_counts: "Counter[LocalPhase]" = Counter()
+        active_per_pvc: "Counter[str]" = Counter()
         empty_count = 0
+        worker_lines = []
         for idx, worker in enumerate(self.current_workers):
             if worker is None:
                 empty_count += 1
                 continue
             phase = worker.get_phase()
             phase_counts[phase] += 1
+            active_per_pvc[worker.pvc_name] += 1
             detail = ""
             if phase not in (LocalPhase.SUCCEEDED, LocalPhase.FAILED, LocalPhase.RUNNING):
                 detail = f", container={worker.get_container_status_summary()}"
-            log(
-                f"  Worker {idx}: {worker.name}, phase={phase}, age={int(worker.get_age_secs())}s{detail}"
+            worker_lines.append(
+                f"    Worker {idx}: {worker.name}, phase={phase}, "
+                f"pvc={worker.pvc_name}, age={int(worker.get_age_secs())}s{detail}"
             )
-        summary = ", ".join(
-            f"{phase}={count}" for phase, count in sorted(phase_counts.items(), key=lambda x: x[0].value)
+
+        # --- PVCs section: summary line + every PVC's status. Bound PVCs
+        # show their bind time and current worker load; creating PVCs show
+        # how long they've been pending. ---
+        target = self.config.pvc_number
+        bound_count = sum(1 for p in self.pvcs if p.is_bound)
+        creating_count = len(self.pvcs) - bound_count
+        not_yet_started = target - len(self.pvcs)
+        cap = self.config.workers_per_pvc
+        log(
+            f"  PVCs: {bound_count}/{target} bound, "
+            f"{creating_count} creating, {not_yet_started} not yet requested"
         )
-        log(f"  Summary: {summary}, empty={empty_count}")
-        log("=== End worker status ==="  )
+        for p in self.pvcs:
+            kind = "source" if p.is_source else "clone"
+            if p.is_bound:
+                load = active_per_pvc.get(p.name, 0)
+                log(
+                    f"    {p.name}: {kind}, bound "
+                    f"(took {int(p.bind_duration_secs)}s), {load}/{cap} workers"
+                )
+            else:
+                log(f"    {p.name}: {kind}, creating, age={int(p.age_secs)}s")
+
+        # --- Workers section. Header is always present; per-worker detail
+        # lines follow only for non-empty slots. ---
+        active = sum(phase_counts.values())
+        if active > 0:
+            breakdown = ", ".join(
+                f"{phase}={count}"
+                for phase, count in sorted(phase_counts.items(), key=lambda x: x[0].value)
+            )
+            log(f"  Workers: {active} active ({breakdown}), {empty_count} empty")
+        else:
+            log(f"  Workers: 0 active, {empty_count} empty")
+        for line in worker_lines:
+            log(line)
+        log("=== End scheduler status ===")
         log("")
 
     # read skip ranges from gcp bucket
@@ -1060,7 +1323,11 @@ if __name__ == "__main__":
     run_id = f"{datetime.datetime.now().strftime('%Y%m%d-%H%M%S')}-{image[-5:]}"
     network = Network.from_string(args.network)
     config = ReplayConfig(network)
-    worker_cnt = args.worker_cnt if args.worker_cnt else config.pvc_number * 10
+    worker_cnt = (
+        args.worker_cnt
+        if args.worker_cnt
+        else config.pvc_number * config.workers_per_pvc
+    )
     range_size = args.range_size if args.range_size else config.range_size
 
     # Resolve time-based args to versions
@@ -1100,7 +1367,7 @@ if __name__ == "__main__":
         scheduler.cleanup()
         exit(0)
     else:
-        scheduler.create_all_required_pvcs()
+        scheduler.start_pvc_creation_pipeline()
         try:
             start_time = time.time()
             (failed_logs, txn_mismatch_logs) = scheduler.schedule(from_scratch=True)


### PR DESCRIPTION
## Summary

Addresses a class of failures where worker pods sat Pending waiting for their PVC to bind, burning the per-pod retry budget on storage delays unrelated to replay correctness. Restructures how PVCs are managed and tightens the per-pod / per-PVC limits to match GCE's actual constraints.

This addresses the root cause that resulted in our scheduled runs to constantly timeout since the beginning of the year.

## Architecture

- **PVC creation is now a non-blocking pipeline** that runs concurrently with the worker scheduler. `start_pvc_creation_pipeline()` requests only the source PVC and returns immediately; clones spawn progressively from `_maintain_pvc_pipeline()` each scheduler iteration. No more 15+ minute idle gap at startup before any worker can run.
- **Workers can dispatch to any PVC the moment it becomes Bound**, including the source. Workers start running on the source ~3–5 minutes before any clone has bound, instead of the old "wait for source → wait for clones → start workers" sequence.
- **Slot-to-PVC mapping is dynamic.** `_pick_pvc_for_dispatch` picks the least-loaded bound PVC under the per-PVC cap. Slots stay empty when no bound PVC has capacity, so they don't burn retry budget on storage that isn't ready.
- **`MAX_CONCURRENT_PVC_CREATIONS = 5`** in-flight PVC creations at a time. Empirically matches GCE's per-source clone-concurrency limit observed on both mainnet and testnet runs (the "first 5 clones bind in 30s, 6th waits 5 min" cliff).

## Per-pod timeouts (split by phase)

- **`PENDING_TIMEOUT = 10m`** for any pod that hasn't reached Running. With the architectural fix, Pending now only covers image pull + volume attach + container start, so a long Pending reliably indicates a stuck pod — kill fast and retry rather than waste a Running-budget retry slot.
- **`running_timeout`** per-network: 30m mainnet, 40m testnet. Testnet needs the extra 10m for the 6.7B–6.8B heavy zone, where 1M chunks empirically take ~33m. Measured from the moment the pod first transitioned to Running (not pod creation), so a slow Pending doesn't eat the binary's budget.
- **`binary_timeout = running_timeout + 10m`**, **`pod_ttl = binary_timeout + 10m`**. Each layer a backstop for the previous, all per-network.

## Worker concurrency

- **`MAX_WORKERS_PER_PVC = 10`** hard ceiling, with assertion in `ReplayConfig`. GCE PD allows roughly 10 concurrent active readers per disk; going higher just queues or starves at the CSI/IO layer. Earlier testnet tuning at 20 workers/PVC nearly doubled p99 task duration vs. 15 (979s → 1177s p90, 1192s → 2351s p99) without any aggregate throughput gain.
- Testnet config: **10 PVCs × 10 workers/PVC = 100 workers** (was 35×10=350). Mainnet unchanged at 10×10.

## Logging

- Periodic status dump renamed **"Scheduler status"** and now includes a PVCs section (counts plus per-PVC detail with bind durations and current worker load) followed by a Workers section with phase breakdown.
- Header reports **"completed N/M"** (terminal-state count) instead of "dispatched N/M" (which included in-flight tasks).
- Phase-aware timeout error messages distinguish **`pending-timeout`** from **`running-timeout`** and report the threshold inline.
- **End-of-run aggregate statistics**: total/succeeded/failed counts, retry distribution, and duration percentiles (min/p50/p90/p99/max/mean) for succeeded and failed tasks separately. Failed durations cluster at the timeout ceiling, so reporting them combined would distort percentiles.
- `Started creating clone PVC X (requested K/N, in-flight M/5)` and `PVC X is now bound after Ts (source/clone)` log lines surface pipeline progress.

## Naming

Source and clone PVCs now share a single name format: `{snapshot}-{run_id}-{idx}`. Source is index 0, clones are 1..N. No more `-clone-` infix.

## Bug fixes

- **`set_end_time` was missing** in the timeout-driven max-retry path, making those failures invisible in aggregate stats and the completion header (counts wouldn't add up). Now consistent with `process_completed_pod`'s permanent-fail path.
- **`ReplayScheduler.__str__`** was referencing `worker_cnt` and `image` as bare names, relying on script-as-`__main__` globals. Fixed to use `self` attributes.

## Test plan

- [ ] Trigger `replay-verify-on-archive` on testnet with this branch
- [ ] Confirm source PVC binds, then clones spawn in waves of ≤5 with progressive logging
- [ ] Verify workers start dispatching to source the moment it binds (not waiting for all clones)
- [ ] Verify status dump shows the new PVC + Workers sections clearly
- [ ] Verify no `phase=Pending, container=no-container-status` worker timeouts (the original failure mode)
- [ ] Verify end-of-run aggregate stats appear and percentile counts add up to total
- [ ] Run mainnet to confirm 10×10 + 30m running_timeout still passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it refactors core replay-verify scheduling/PVC provisioning logic and timeout handling, which could change throughput or failure behavior under real cluster/storage conditions.
> 
> **Overview**
> Replay-verify now provisions storage via a **non-blocking PVC pipeline**: it creates a single source PVC from the snapshot, then progressively spawns clone PVCs (capped by `MAX_CONCURRENT_PVC_CREATIONS`) while the scheduler runs, and dispatches workers to any *bound* PVC based on per-PVC load.
> 
> Worker scheduling is updated to enforce a **per-PVC worker cap** (`workers_per_pvc`, asserted against `MAX_WORKERS_PER_PVC`) and to apply **phase-aware timeouts** (separate `PENDING_TIMEOUT` vs per-network `running_timeout`, measured from first observed Running) with derived `binary_timeout`/`pod_ttl`.
> 
> Logging/stats are expanded with PVC bind progress, per-PVC load, a corrected “completed” counter, end-of-run aggregate duration percentiles, and a bug fix to mark timeout-exhausted tasks terminal; `ReplayScheduler.__str__` also stops relying on globals.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc26caf0900e4eb96bb9b5771bc4ee6c47af7a26. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->