### PR TITLE
[prover] Add e2e-tests crate + baseline-aware framework prover helper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2015,12 +2015,14 @@ dependencies = [
  "move-prover-boogie-backend",
  "move-prover-bytecode-pipeline",
  "move-prover-lab",
+ "move-prover-test-utils",
  "move-stackless-bytecode",
  "move-unit-test",
  "move-vm-runtime",
  "move-vm-types",
  "num-traits",
  "once_cell",
+ "regex",
  "serde",
  "tempfile",
  "toml 0.7.8",
@@ -13330,6 +13332,21 @@ dependencies = [
  "shell-words",
  "tempfile",
  "walkdir",
+]
+
+[[package]]
+name = "move-prover-e2e-tests"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "codespan-reporting",
+ "move-core-types",
+ "move-model",
+ "move-package",
+ "move-prover",
+ "move-prover-test-utils",
+ "regex",
+ "tempfile",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -240,6 +240,7 @@ members = [
     "third_party/move/move-prover",
     "third_party/move/move-prover/boogie-backend",
     "third_party/move/move-prover/bytecode-pipeline",
+    "third_party/move/move-prover/e2e-tests",
     "third_party/move/move-prover/lab",
     "third_party/move/move-prover/test-utils",
     "third_party/move/move-symbol-pool",

--- a/aptos-move/framework/Cargo.toml
+++ b/aptos-move/framework/Cargo.toml
@@ -54,8 +54,10 @@ aptos-gas-meter = { workspace = true }
 aptos-vm = { workspace = true, features = ["testing"] }
 claims = { workspace = true }
 move-prover = { workspace = true }
+move-prover-test-utils = { workspace = true }
 move-unit-test = { workspace = true }
 move-vm-types = { workspace = true, features = ["testing"] }
+regex = { workspace = true }
 
 [features]
 default = []

--- a/aptos-move/framework/tests/move_prover_tests.rs
+++ b/aptos-move/framework/tests/move_prover_tests.rs
@@ -3,8 +3,14 @@
 
 use aptos_framework::{extended_checks, prover::ProverOptions};
 use move_binary_format::file_format_common::VERSION_DEFAULT;
+use move_core_types::diag_writer::DiagWriter;
 use move_model::metadata::{CompilerVersion, LanguageVersion};
-use std::{collections::BTreeMap, path::PathBuf};
+use move_prover_test_utils::baseline_test::verify_or_update_baseline;
+use regex::Regex;
+use std::{
+    collections::BTreeMap,
+    path::{Path, PathBuf},
+};
 
 const ENV_TEST_INCONSISTENCY: &str = "MVP_TEST_INCONSISTENCY";
 const ENV_TEST_UNCONDITIONAL_ABORT_AS_INCONSISTENCY: &str =
@@ -29,13 +35,27 @@ pub fn read_env_var(v: &str) -> String {
     std::env::var(v).unwrap_or_else(|_| String::new())
 }
 
-pub fn run_prover_for_pkg(
-    path_to_pkg: impl Into<String>,
-    shards: usize,
-    only_shard: Option<usize>,
-) {
-    let pkg_path = path_in_crate(path_to_pkg);
+/// Build the test-mode `ProverOptions` shared by both the panic-on-error
+/// and baseline-driven entry points.
+fn build_test_options(shards: usize, only_shard: Option<usize>) -> ProverOptions {
     let mut options = ProverOptions::default_for_test();
+    options.shards = Some(shards);
+    options.only_shard = only_shard;
+    options.check_inconsistency = read_env_var(ENV_TEST_INCONSISTENCY) == "1";
+    options.unconditional_abort_as_inconsistency =
+        read_env_var(ENV_TEST_UNCONDITIONAL_ABORT_AS_INCONSISTENCY) == "1";
+    options.disallow_global_timeout_to_be_overwritten =
+        read_env_var(ENV_TEST_DISALLOW_TIMEOUT_OVERWRITE) == "1";
+    options.vc_timeout = read_env_var(ENV_TEST_VC_TIMEOUT)
+        .parse::<usize>()
+        .ok()
+        .or(options.vc_timeout);
+    options
+}
+
+/// Panics with a helpful message if the prover's external tools (Boogie / Z3
+/// or CVC5) are not configured in the environment.
+fn assert_prover_tools_available(options: &ProverOptions) {
     let no_tools = read_env_var("BOOGIE_EXE").is_empty()
         || !options.cvc5 && read_env_var("Z3_EXE").is_empty()
         || options.cvc5 && read_env_var("CVC5_EXE").is_empty();
@@ -46,35 +66,113 @@ pub fn run_prover_for_pkg(
         for instructions, or \
         use \"-- --skip prover\" to filter out the prover tests"
         );
-    } else {
-        let inconsistency_flag = read_env_var(ENV_TEST_INCONSISTENCY) == "1";
-        let unconditional_abort_inconsistency_flag =
-            read_env_var(ENV_TEST_UNCONDITIONAL_ABORT_AS_INCONSISTENCY) == "1";
-        let disallow_timeout_overwrite = read_env_var(ENV_TEST_DISALLOW_TIMEOUT_OVERWRITE) == "1";
-        options.shards = Some(shards);
-        options.only_shard = only_shard;
-        options.check_inconsistency = inconsistency_flag;
-        options.unconditional_abort_as_inconsistency = unconditional_abort_inconsistency_flag;
-        options.disallow_global_timeout_to_be_overwritten = disallow_timeout_overwrite;
-        options.vc_timeout = read_env_var(ENV_TEST_VC_TIMEOUT)
-            .parse::<usize>()
-            .ok()
-            .or(options.vc_timeout);
-        let skip_attribute_checks = false;
-        options
-            .prove(
-                false,
-                pkg_path.as_path(),
-                BTreeMap::default(),
-                Some(VERSION_DEFAULT),
-                Some(CompilerVersion::latest_stable()),
-                Some(LanguageVersion::latest_stable()),
-                skip_attribute_checks,
-                extended_checks::get_all_attribute_names(),
-                &[],
-            )
-            .unwrap()
     }
+}
+
+pub fn run_prover_for_pkg(
+    path_to_pkg: impl Into<String>,
+    shards: usize,
+    only_shard: Option<usize>,
+) {
+    let pkg_path = path_in_crate(path_to_pkg);
+    let options = build_test_options(shards, only_shard);
+    assert_prover_tools_available(&options);
+    options
+        .prove(
+            false,
+            pkg_path.as_path(),
+            BTreeMap::default(),
+            Some(VERSION_DEFAULT),
+            Some(CompilerVersion::latest_stable()),
+            Some(LanguageVersion::latest_stable()),
+            false, // skip_attribute_checks
+            extended_checks::get_all_attribute_names(),
+            &[],
+        )
+        .unwrap()
+}
+
+/// Run the prover on `path_to_pkg` and compare the captured diagnostic output
+/// against a `.exp` baseline file (path derived from `test_file`, which should
+/// be `file!()` at the call site).
+///
+/// Unlike [`run_prover_for_pkg`], a prover error does **not** fail the test.
+/// The error is captured into the baseline output, so subsequent runs verify
+/// the captured text against the stored baseline. Set `UB=1` (or `UPBL=1` /
+/// `UPDATE_BASELINE=1`) to (re)create the baseline from the current output.
+pub fn run_prover_for_pkg_with_baseline(
+    test_file: &str,
+    path_to_pkg: impl Into<String>,
+    shards: usize,
+    only_shard: Option<usize>,
+) {
+    let pkg_path = path_in_crate(path_to_pkg);
+    let mut options = build_test_options(shards, only_shard);
+    // Redact non-deterministic values (signer addresses, fresh temp ids, …)
+    // in the prover's diagnostic output so the captured baseline is stable
+    // across runs — same mechanism as `move-prover/tests/testsuite.rs`.
+    options.stable_test_output = true;
+    assert_prover_tools_available(&options);
+
+    let (mut writer, buf) = DiagWriter::new_buffer();
+    let result = options.prove_to(
+        &mut writer,
+        false,
+        pkg_path.as_path(),
+        BTreeMap::default(),
+        Some(VERSION_DEFAULT),
+        Some(CompilerVersion::latest_stable()),
+        Some(LanguageVersion::latest_stable()),
+        false, // skip_attribute_checks
+        extended_checks::get_all_attribute_names(),
+        &[],
+    );
+
+    // Mirror the format produced by `move-prover/tests/testsuite.rs`: error
+    // message (if any) first, then the captured diagnostic buffer. An empty
+    // baseline means clean verification.
+    let mut diags = match &result {
+        Ok(()) => String::new(),
+        Err(err) => format!("Move prover returns: {err}\n"),
+    };
+    diags += &String::from_utf8_lossy(buf.lock().unwrap().as_slice());
+
+    check_baseline(test_file, &diags);
+}
+
+/// Compute the `.exp` baseline path for a test source file. Pass `file!()`
+/// from the test module.
+fn exp_path(test_file: &str) -> PathBuf {
+    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("workspace root must exist");
+    workspace_root.join(test_file).with_extension("exp")
+}
+
+/// Strip filesystem-dependent paths from the captured prover output so the
+/// baseline is stable across machines and runs.
+fn sanitize_output(s: &str) -> String {
+    // Replace temp-dir-style paths: /tmp/..., /var/..., /private/var/...
+    let re_tmp = Regex::new(r#"(/private)?(/var|/tmp)(/[^\s,\]"`]+)*/"#).expect("regex");
+    let s = re_tmp.replace_all(s, "<TEMPDIR>/");
+    let re_tmp_bare = Regex::new(r"<TEMPDIR>/\.tmp[a-zA-Z0-9]+").expect("regex");
+    let s = re_tmp_bare.replace_all(&s, "<TEMPDIR>");
+
+    // Replace CARGO_MANIFEST_DIR (the framework crate root).
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    let s = s.replace(manifest_dir, "<FRAMEWORK_DIR>");
+
+    s.to_string()
+}
+
+/// Compare `output` against the `.exp` baseline next to the given test source.
+/// When `UB` (or `UPBL` / `UPDATE_BASELINE`) is set, updates the baseline.
+fn check_baseline(test_file: &str, output: &str) {
+    let baseline = exp_path(test_file);
+    let sanitized = sanitize_output(output);
+    verify_or_update_baseline(&baseline, &sanitized)
+        .unwrap_or_else(|e| panic!("baseline mismatch for {}: {}", test_file, e));
 }
 
 #[test]

--- a/third_party/move/move-prover/doc/higher-order-paper-26/examples/prover.exp
+++ b/third_party/move/move-prover/doc/higher-order-paper-26/examples/prover.exp
@@ -1,0 +1,77 @@
+Move prover returns: exiting with verification errors
+warning: Unused value of parameter `caller`. Consider removing the parameter, or prefixing with an underscore (e.g., `_caller`), or binding to `_`
+   ┌─ <PKG>/sources/vault.move:48:24
+   │
+48 │     public fun harvest(caller: &signer, vault_addr: address) {
+   │                        ^^^^^^
+
+error: data invariant does not hold
+   ┌─ <PKG>/sources/amm_example.move:30:9
+   │
+30 │ ╭         invariant forall S in *, r_in: u64, r_out: u64, amt: u64:
+31 │ │             S |~ !aborts_of<self.pricing>(r_in, r_out, amt);
+   │ ╰────────────────────────────────────────────────────────────^
+   │
+   =     at <PKG>/sources/amm_example.move:241: create_noncompliant_fee_pool
+   =         account = <redacted>
+   =     at <PKG>/sources/amm_example.move:242: create_noncompliant_fee_pool
+   =     at <PKG>/../../../../move-stdlib/sources/signer.move:26: address_of
+   =         s = <redacted>
+   =     at <PKG>/../../../../move-stdlib/sources/signer.move:27: address_of
+   =         result = <redacted>
+   =         owner = <redacted>
+   =     at <PKG>/sources/amm_example.move:245: create_noncompliant_fee_pool
+   =     at <PKG>/sources/amm_example.move:246: create_noncompliant_fee_pool
+   =     at <PKG>/sources/amm_example.move:247: create_noncompliant_fee_pool
+   =     at <PKG>/sources/amm_example.move:244: create_noncompliant_fee_pool
+   =     at <PKG>/sources/amm_example.move:30
+
+error: data invariant does not hold
+   ┌─ <PKG>/sources/amm_example.move:38:9
+   │
+38 │ ╭         invariant forall S in *, r_in: u64, r_out: u64,
+39 │ │                         a1: u64, a2: u64:
+40 │ │             S.. |~ a1 <= a2 ==>
+41 │ │                 result_of<self.pricing>(r_in, r_out, a1)
+42 │ │                     <= result_of<self.pricing>(r_in, r_out, a2);
+   │ ╰────────────────────────────────────────────────────────────────^
+   │
+   =     at <PKG>/sources/amm_example.move:241: create_noncompliant_fee_pool
+   =         account = <redacted>
+   =     at <PKG>/sources/amm_example.move:242: create_noncompliant_fee_pool
+   =     at <PKG>/../../../../move-stdlib/sources/signer.move:26: address_of
+   =         s = <redacted>
+   =     at <PKG>/../../../../move-stdlib/sources/signer.move:27: address_of
+   =         result = <redacted>
+   =         owner = <redacted>
+   =     at <PKG>/sources/amm_example.move:245: create_noncompliant_fee_pool
+   =     at <PKG>/sources/amm_example.move:246: create_noncompliant_fee_pool
+   =     at <PKG>/sources/amm_example.move:247: create_noncompliant_fee_pool
+   =     at <PKG>/sources/amm_example.move:244: create_noncompliant_fee_pool
+   =     at <PKG>/sources/amm_example.move:30
+   =     at <PKG>/sources/amm_example.move:34
+   =     at <PKG>/sources/amm_example.move:38
+
+error: data invariant does not hold
+   ┌─ <PKG>/sources/amm_example.move:45:9
+   │
+45 │ ╭         invariant forall S in *, r_in: u64, r_out: u64, amt: u64:
+46 │ │             S.. |~ (r_in + amt) * (r_out - result_of<self.pricing>(r_in, r_out, amt)) >= r_in * r_out;
+   │ ╰──────────────────────────────────────────────────────────────────────────────────────────────────────^
+   │
+   =     at <PKG>/sources/amm_example.move:241: create_noncompliant_fee_pool
+   =         account = <redacted>
+   =     at <PKG>/sources/amm_example.move:242: create_noncompliant_fee_pool
+   =     at <PKG>/../../../../move-stdlib/sources/signer.move:26: address_of
+   =         s = <redacted>
+   =     at <PKG>/../../../../move-stdlib/sources/signer.move:27: address_of
+   =         result = <redacted>
+   =         owner = <redacted>
+   =     at <PKG>/sources/amm_example.move:245: create_noncompliant_fee_pool
+   =     at <PKG>/sources/amm_example.move:246: create_noncompliant_fee_pool
+   =     at <PKG>/sources/amm_example.move:247: create_noncompliant_fee_pool
+   =     at <PKG>/sources/amm_example.move:244: create_noncompliant_fee_pool
+   =     at <PKG>/sources/amm_example.move:30
+   =     at <PKG>/sources/amm_example.move:34
+   =     at <PKG>/sources/amm_example.move:38
+   =     at <PKG>/sources/amm_example.move:45

--- a/third_party/move/move-prover/e2e-tests/Cargo.toml
+++ b/third_party/move/move-prover/e2e-tests/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "move-prover-e2e-tests"
+description = "End-to-end Move Prover regression tests run as Rust unit tests, with `prover.exp` baselines stored next to each Move package's `Move.toml`."
+version = "0.1.0"
+
+# Workspace inherited keys
+authors = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+repository = { workspace = true }
+rust-version = { workspace = true }
+
+[dependencies]
+anyhow = { workspace = true }
+codespan-reporting = { workspace = true }
+move-core-types = { workspace = true }
+move-model = { workspace = true }
+move-package = { workspace = true }
+move-prover = { workspace = true }
+move-prover-test-utils = { workspace = true }
+regex = { workspace = true }
+tempfile = { workspace = true }
+
+[lib]
+doctest = false

--- a/third_party/move/move-prover/e2e-tests/src/lib.rs
+++ b/third_party/move/move-prover/e2e-tests/src/lib.rs
@@ -1,0 +1,135 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Test utilities for running the Move Prover on the example packages
+//! shipped alongside the prover papers in `move-prover/doc/`.
+//!
+//! Each package is verified end-to-end and its captured diagnostic output
+//! is compared against a `prover.exp` baseline stored next to the package's
+//! `Move.toml`. A prover error does **not** fail the test directly; the
+//! error is captured into the baseline and the test only fails on baseline
+//! mismatch (set `UB=1` to update).
+
+use codespan_reporting::diagnostic::Severity;
+use move_core_types::diag_writer::DiagWriter;
+use move_model::metadata::{CompilerVersion, LanguageVersion};
+use move_package::{source_package::layout::SourcePackageLayout, BuildConfig, ModelConfig};
+use move_prover_test_utils::baseline_test::verify_or_update_baseline;
+use regex::Regex;
+use std::{path::Path, time::Instant};
+use tempfile::TempDir;
+
+/// Filename of the prover-output baseline, stored next to the package's
+/// `Move.toml`.
+pub const BASELINE_FILE: &str = "prover.exp";
+
+/// Run the Move Prover on the package at `pkg_path` and compare the
+/// captured diagnostic output against `prover.exp` next to its `Move.toml`.
+///
+/// Honors `UB=1` (`UPBL=1`, `UPDATE_BASELINE=1`) to (re)create the baseline.
+pub fn run_paper_with_baseline(pkg_path: impl AsRef<Path>) {
+    let pkg_path = pkg_path.as_ref();
+    let pkg_path = pkg_path
+        .canonicalize()
+        .unwrap_or_else(|e| panic!("cannot canonicalize {}: {}", pkg_path.display(), e));
+    let baseline = pkg_path.join(BASELINE_FILE);
+
+    let captured = run_prover_capturing(&pkg_path);
+    let sanitized = sanitize_output(&pkg_path, &captured);
+
+    verify_or_update_baseline(&baseline, &sanitized)
+        .unwrap_or_else(|e| panic!("baseline mismatch for {}: {}", pkg_path.display(), e));
+}
+
+/// Build the package model and run the prover, capturing all diagnostics
+/// into an in-memory buffer. Always returns a string; on prover failure a
+/// trailing `Prover returned error: …` line is appended.
+fn run_prover_capturing(pkg_path: &Path) -> String {
+    // The Move package system (via `move_model_for_package`) currently
+    // mutates the process-wide current directory. Save and restore it so
+    // unrelated tests in the same binary aren't affected.
+    let saved_cd = std::env::current_dir().expect("current directory");
+
+    let rerooted =
+        SourcePackageLayout::try_find_root(pkg_path).unwrap_or_else(|_| pkg_path.to_path_buf());
+
+    let mut args = vec!["package".to_string()];
+    let prover_toml = rerooted.join("Prover.toml");
+    if prover_toml.exists() {
+        args.push(format!("--config={}", prover_toml.to_string_lossy()));
+    }
+    let mut options =
+        move_prover::cli::Options::create_from_args(&args).expect("prover CLI options");
+    options.set_quiet();
+    // Redact non-deterministic values (signer addresses, fresh temp ids, …)
+    // in the prover's diagnostic output so the captured baseline is stable
+    // across runs — same mechanism as `move-prover/tests/testsuite.rs`.
+    options.prover.stable_test_output = true;
+    options.backend.stable_test_output = true;
+
+    // Use a fresh temp dir for `output.bpl` so concurrent test invocations
+    // don't collide on the same path.
+    let temp_dir = TempDir::new().expect("temp dir");
+    options.output_path = temp_dir
+        .path()
+        .join("output.bpl")
+        .to_string_lossy()
+        .to_string();
+
+    let mut config = BuildConfig {
+        dev_mode: true,
+        verify_mode: true,
+        test_mode: false,
+        ..BuildConfig::default()
+    };
+    // Paper example packages use experimental BP / state-label syntax —
+    // verify against the latest (possibly unstable) language version.
+    config.compiler_config.language_version = Some(LanguageVersion::latest());
+    config.compiler_config.compiler_version = Some(CompilerVersion::latest());
+    let compiler_version = config.compiler_config.compiler_version.unwrap();
+    let language_version = config.compiler_config.language_version.unwrap();
+
+    let (mut writer, buf) = DiagWriter::new_buffer();
+    let result = (|| -> anyhow::Result<()> {
+        let mut model = config.move_model_for_package(&rerooted, ModelConfig {
+            all_files_as_targets: false,
+            target_filter: None,
+            compiler_version,
+            language_version,
+            with_bytecode: true,
+        })?;
+        // `check_diag` renders the env's accumulated diagnostics into the
+        // writer (so compilation errors land in our captured baseline) and
+        // bails out with the given suffix when `has_errors()`.
+        model.check_diag(&mut writer, Severity::Warning, "in compilation")?;
+        move_prover::run_move_prover_with_model_v2(
+            &mut model,
+            &mut writer,
+            options,
+            Instant::now(),
+        )?;
+        Ok(())
+    })();
+
+    std::env::set_current_dir(saved_cd).expect("restore current directory");
+
+    // Mirror the format produced by `move-prover/tests/testsuite.rs`: error
+    // message (if any) first, then the captured diagnostic buffer. An empty
+    // baseline means clean verification.
+    let mut diags = match &result {
+        Ok(()) => String::new(),
+        Err(err) => format!("Move prover returns: {err}\n"),
+    };
+    diags += &String::from_utf8_lossy(buf.lock().unwrap().as_slice());
+    diags
+}
+
+/// Strip filesystem-dependent paths from the captured output so the
+/// baseline is stable across machines and runs.
+fn sanitize_output(pkg_path: &Path, s: &str) -> String {
+    let s = s.replace(&pkg_path.display().to_string(), "<PKG>");
+    let re_tmp = Regex::new(r#"(/private)?(/var|/tmp)(/[^\s,\]"`]+)*/"#).expect("regex");
+    let s = re_tmp.replace_all(&s, "<TEMPDIR>/").to_string();
+    let re_tmp_bare = Regex::new(r"<TEMPDIR>/\.tmp[a-zA-Z0-9]+").expect("regex");
+    re_tmp_bare.replace_all(&s, "<TEMPDIR>").to_string()
+}

--- a/third_party/move/move-prover/e2e-tests/tests/papers.rs
+++ b/third_party/move/move-prover/e2e-tests/tests/papers.rs
@@ -1,0 +1,16 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+use std::path::PathBuf;
+
+/// Resolve a path relative to this crate's root (the `e2e-tests` dir).
+fn paper_pkg(rel: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(rel)
+}
+
+#[test]
+fn higher_order_paper_examples() {
+    move_prover_e2e_tests::run_paper_with_baseline(paper_pkg(
+        "../doc/higher-order-paper-26/examples",
+    ));
+}


### PR DESCRIPTION
New crate `move-prover-e2e-tests` at `third_party/move/move-prover/e2e-tests/`
runs the Move Prover end-to-end on Move packages as Rust unit tests, capturing
diagnostic output into a `prover.exp` baseline stored next to each package's
`Move.toml`. First test exercises the higher-order paper's example package
(`doc/higher-order-paper-26/examples`). Output follows the
`move-prover/tests/testsuite.rs` convention (`Move prover returns:` prefix on
error, `<redacted>` via `stable_test_output`).

Adds `run_prover_for_pkg_with_baseline` to `aptos-move/framework/tests/move_prover_tests.rs`
as a sibling of `run_prover_for_pkg` for tests that should compare prover
output against a baseline rather than fail on prover error.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to test infrastructure (new e2e test crate and baseline comparison helpers) and do not affect production runtime behavior, aside from adding a few dev/test dependencies.
> 
> **Overview**
> Adds a new workspace crate, `move-prover-e2e-tests`, that runs the Move Prover end-to-end on bundled paper example Move packages and verifies captured diagnostics against a `prover.exp` baseline (with path/temp-dir redaction and `stable_test_output` enabled).
> 
> Refactors `aptos-framework` prover tests to share option/tool-availability setup and introduces `run_prover_for_pkg_with_baseline`, which captures prover diagnostics via `DiagWriter`, sanitizes nondeterministic paths, and compares/updates `.exp` baselines using `move-prover-test-utils`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec3696cc951b64b40d21a8b1c48c1a479e794dce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->