### PR TITLE
[forge] Enable BlockSTM v2 on validators for all forge runs

### DIFF
--- a/testsuite/forge/src/backend/local/swarm.rs
+++ b/testsuite/forge/src/backend/local/swarm.rs
@@ -155,6 +155,9 @@ impl LocalSwarm {
             .with_init_config(Some(Arc::new(move |index, config, base| {
                 config.execution.concurrency_level = concurrency_level;
 
+                // Enable BlockSTM v2 for all forge runs.
+                config.execution.blockstm_v2_enabled = true;
+
                 // Single node orders blocks too fast which would trigger backpressure and stall for 1 sec
                 // which cause flakiness in tests.
                 if number_of_validators.get() == 1 {

--- a/testsuite/forge/src/config.rs
+++ b/testsuite/forge/src/config.rs
@@ -322,6 +322,9 @@ impl ForgeConfig {
             helm_values["validator"]["config"]["indexer_db_config"]["enable_event"] = true.into();
             helm_values["fullnode"]["config"]["indexer_db_config"]["enable_event"] = true.into();
 
+            // Enable BlockSTM v2 on validators for all forge runs.
+            helm_values["validator"]["config"]["execution"]["blockstm_v2_enabled"] = true.into();
+
             // override consensus observer refresh latency
             helm_values["fullnode"]["config"]["consensus_observer"]
                 ["subscription_peer_change_interval_ms"] = 5_000.into();


### PR DESCRIPTION
## Summary
- Force-enable `execution.blockstm_v2_enabled` on validators in the k8s forge path (`ForgeConfig::build_node_helm_config_fn`).
- Set the same flag on validators in the local forge path via the genesis builder `init_config` closure (which only fires for validators, not fullnodes).
- Net effect: every forge run exercises BlockSTMv2 on validators; fullnodes are left on the default.

## Test plan
- [ ] Run a smoke test locally (`cargo test -p smoke-test`) to confirm validators come up with BlockSTMv2 enabled.
- [ ] Run a forge land-blocking suite and verify validator config in the rendered helm values has `execution.blockstm_v2_enabled: true`.
- [ ] Confirm fullnodes still default to BlockSTMv1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Forces a different execution engine on all forge validators (local and k8s), which may change performance/behavior and impact test stability or uncover new bugs. Scope is limited to the test harness configuration, not production runtime defaults.
> 
> **Overview**
> Forge now **force-enables `execution.blockstm_v2_enabled` for validators** in both local swarms (via the genesis builder `init_config` closure) and k8s deployments (via rendered validator helm values).
> 
> Fullnodes are left unchanged (continue using their defaults), so forge runs will consistently exercise BlockSTM v2 on validator nodes only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43d2482cea91af00355501efaa6c3d4927e736fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->