### PR TITLE
[cli] Allow aptos move replay to handle system transactions

### DIFF
--- a/aptos-move/aptos-debugger/src/aptos_debugger.rs
+++ b/aptos-move/aptos-debugger/src/aptos_debugger.rs
@@ -505,6 +505,27 @@ impl MoveDebugger for AptosDebugger {
         self.execute_transaction_at_version_with_gas_profiler(version, txn, auxiliary_info)
     }
 
+    fn execute_transaction_at_version(
+        &self,
+        version: u64,
+        transaction: Transaction,
+        auxiliary_info: PersistedAuxiliaryInfo,
+    ) -> anyhow::Result<TransactionOutput> {
+        // Route through the block-executor path so all Transaction variants
+        // (user + system) are handled uniformly. Single-element batch.
+        let outputs = self.execute_transactions_at_version(
+            version,
+            vec![transaction],
+            vec![auxiliary_info],
+            1,
+            &[1],
+        )?;
+        outputs
+            .into_iter()
+            .next()
+            .ok_or_else(|| anyhow::anyhow!("execute_transactions_at_version returned no outputs"))
+    }
+
     async fn get_committed_transaction_at_version(
         &self,
         version: u64,

--- a/aptos-move/cli/src/commands.rs
+++ b/aptos-move/cli/src/commands.rs
@@ -2560,11 +2560,63 @@ impl CliCommand<TransactionSummary> for Replay {
 
         let txn = match txn {
             Transaction::UserTransaction(txn) => txn,
-            _ => {
-                return Err(CliError::UnexpectedError(
-                    "Unsupported transaction type. Only user transactions are supported."
-                        .to_string(),
-                ))
+            other => {
+                // System transactions (BlockMetadata, BlockEpilogue,
+                // StateCheckpoint, ValidatorTransaction, etc.) take the
+                // block-executor path. None of the user-txn-specific options
+                // (gas profiling, benchmarking, local package overrides)
+                // apply, so reject those upfront with a clear message.
+                if self.profile_gas {
+                    return Err(CliError::UnexpectedError(
+                        "Gas profiling is only supported for user transactions.".to_string(),
+                    ));
+                }
+                if self.benchmark {
+                    return Err(CliError::UnexpectedError(
+                        "Benchmarking is only supported for user transactions.".to_string(),
+                    ));
+                }
+                if !self.use_local_package.is_empty() {
+                    return Err(CliError::UnexpectedError(
+                        "Local package overrides are only supported for user transactions."
+                            .to_string(),
+                    ));
+                }
+
+                println!("Replaying system transaction at version {}...", self.txn_id);
+                let txn_output = debugger
+                    .execute_transaction_at_version(self.txn_id, other, aux_info)
+                    .map_err(|e| {
+                        CliError::UnexpectedError(format!(
+                            "Failed to execute system transaction: {}",
+                            e
+                        ))
+                    })?;
+
+                if !self.skip_comparison {
+                    txn_output
+                        .ensure_match_transaction_info(self.txn_id, &txn_info, None, None)
+                        .map_err(|msg| CliError::UnexpectedError(msg.to_string()))?;
+                }
+
+                let success = match txn_output.status() {
+                    TransactionStatus::Keep(exec_status) => Some(exec_status.is_success()),
+                    TransactionStatus::Discard(_) | TransactionStatus::Retry => None,
+                };
+                return Ok(TransactionSummary {
+                    transaction_hash: txn_info.transaction_hash().into(),
+                    gas_used: Some(txn_output.gas_used()),
+                    gas_unit_price: None,
+                    pending: None,
+                    sender: None,
+                    sequence_number: None,
+                    replay_protector: None,
+                    success,
+                    timestamp_us: None,
+                    version: Some(self.txn_id),
+                    vm_status: Some(format!("{:?}", txn_output.status())),
+                    deployed_object_address: None,
+                });
             },
         };
 

--- a/aptos-move/cli/src/lib.rs
+++ b/aptos-move/cli/src/lib.rs
@@ -42,7 +42,7 @@ use aptos_types::{
     },
     transaction::{
         AuxiliaryInfo, PersistedAuxiliaryInfo, SignedTransaction, Transaction, TransactionInfo,
-        TransactionPayload, Version,
+        TransactionOutput, TransactionPayload, Version,
     },
 };
 use aptos_vm_types::output::VMOutput;
@@ -252,6 +252,21 @@ pub trait MoveDebugger: Send + Sync + 'static {
         txn: SignedTransaction,
         auxiliary_info: AuxiliaryInfo,
     ) -> anyhow::Result<(VMStatus, VMOutput, TransactionGasLog)>;
+
+    /// Execute any committed transaction at a given version through the
+    /// block-executor path, returning its materialized output.
+    ///
+    /// Unlike `execute_transaction_at_version_with_gas_profiler` (which only
+    /// accepts `SignedTransaction`, i.e. user transactions), this method
+    /// takes the full `Transaction` enum and supports system transactions —
+    /// `BlockMetadata`, `BlockMetadataExt`, `BlockEpilogue`, `StateCheckpoint`,
+    /// `ValidatorTransaction`, etc.
+    fn execute_transaction_at_version(
+        &self,
+        version: u64,
+        transaction: Transaction,
+        auxiliary_info: PersistedAuxiliaryInfo,
+    ) -> anyhow::Result<TransactionOutput>;
 
     /// Fetch a committed transaction at a specific version from the chain.
     async fn get_committed_transaction_at_version(


### PR DESCRIPTION
## Summary

The `aptos move replay` CLI currently rejects anything that isn't a `UserTransaction`:

```rust
let txn = match txn {
    Transaction::UserTransaction(txn) => txn,
    _ => return Err(...Unsupported transaction type...),
};
```

This makes the tool unusable for investigating replay-mismatch bugs that affect **system transactions** specifically — `BlockMetadata`, `BlockMetadataExt`, `BlockEpilogue`, `StateCheckpoint`, `ValidatorTransaction`, etc. We're currently chasing one such bug (state-storage-usage zeroing on system txns; suspected to be hot-state-persistence stack `b50e6c9b…`/`e65a8d11…`), and want a single-txn replay tool to confirm it.

## What changes

- New `MoveDebugger::execute_transaction_at_version` trait method that takes the full `Transaction` enum (not just `SignedTransaction`) and returns `TransactionOutput`.
- `AptosDebugger` implements it by delegating to its existing `execute_transactions_at_version` with a single-element batch — so all variants flow through the same block-executor path that the bulk replay-verify already uses.
- `Replay::execute` special-cases non-`UserTransaction`: calls the new method, compares the output against the archived `TransactionInfo` via the same `ensure_match_transaction_info` the user-txn path uses, and produces a `TransactionSummary` with user-only fields (`sender`, `gas_unit_price`, `replay_protector`) left as `None`.
- Gas profiling, benchmarking, and `--use-local-package` remain user-txn-only — rejected upfront with clear error messages when combined with a system-txn version.

## Test plan

- [ ] `aptos move replay --network testnet --txn-id <user-txn-version>` still works (regression check)
- [ ] `aptos move replay --network testnet --txn-id <BlockMetadata-version>` reproduces the StateStorageUsage mismatch we see in replay-verify
- [ ] `aptos move replay --network testnet --txn-id <system-txn> --skip-comparison` runs to completion
- [ ] `aptos move replay --network testnet --txn-id <system-txn> --profile-gas` errors with a clear message

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Expands the `MoveDebugger` trait and changes `aptos move replay` control flow to execute non-user (system) transactions via the block executor; this may affect downstream debugger implementations and replay output comparison behavior.
> 
> **Overview**
> `aptos move replay` now supports replaying *system* transactions (e.g., block metadata/epilogue/checkpoints/validator txns) instead of rejecting anything that isn’t a `UserTransaction`.
> 
> This introduces a new `MoveDebugger::execute_transaction_at_version` API that accepts the full `Transaction` enum and returns a `TransactionOutput`, implemented in `AptosDebugger` by delegating to `execute_transactions_at_version` with a single-item batch. The CLI routes non-user transactions through this path, blocks user-only flags (`--profile-gas`, `--benchmark`, `--use-local-package`) with clear errors, optionally compares outputs against on-chain `TransactionInfo`, and returns a `TransactionSummary` with user-specific fields left unset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d099bd68c6d55846c202fb6aeee39c38b1c9b752. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->