### PR TITLE
[consensus] tighten BatchProofQueue ingress checks

### DIFF
--- a/consensus/src/quorum_store/batch_proof_queue.rs
+++ b/consensus/src/quorum_store/batch_proof_queue.rs
@@ -276,13 +276,25 @@ impl BatchProofQueue {
             return;
         }
         let batch_key = BatchKey::from_info(proof.info());
-        if self
-            .items
-            .get(&batch_key)
-            .is_some_and(|item| item.proof.is_some() || item.is_committed())
-        {
-            counters::inc_rejected_pos_count(counters::POS_DUPLICATE_LABEL);
-            return;
+        if let Some(existing) = self.items.get(&batch_key) {
+            if existing.info != *proof.info() {
+                // Same (author, batch_id) but different full BatchInfo (e.g. different
+                // digest, expiration, or num_txns). Accepting this proof would corrupt
+                // the queue's invariants because items[batch_key].info would no longer
+                // match the proof attached to it.
+                warn!(
+                    author = proof.author().short_str().as_str(),
+                    "Rejecting ProofOfStore: BatchKey collision between {:?} (queue) and {:?} (proof)",
+                    existing.info,
+                    proof.info(),
+                );
+                counters::inc_rejected_pos_count(counters::POS_COLLISION_LABEL);
+                return;
+            }
+            if existing.proof.is_some() || existing.is_committed() {
+                counters::inc_rejected_pos_count(counters::POS_DUPLICATE_LABEL);
+                return;
+            }
         }
 
         let author = proof.author();
@@ -410,14 +422,26 @@ impl BatchProofQueue {
             let batch_sort_key = BatchSortKey::from_info(&batch_info);
             let batch_key = BatchKey::from_info(&batch_info);
 
-            // If the batch is either committed or the txn summary already exists, skip
-            // inserting this batch.
-            if self
-                .items
-                .get(&batch_key)
-                .is_some_and(|item| item.is_committed() || item.txn_summaries.is_some())
-            {
-                continue;
+            if let Some(existing) = self.items.get(&batch_key) {
+                if existing.info != batch_info {
+                    // Same (author, batch_id) but different full BatchInfo. Drop this
+                    // summary; the queue is keyed on (author, batch_id) and accepting it
+                    // would split the bookkeeping (e.g. distinct sort keys for the same
+                    // queue item) and lead to underflow on expiration.
+                    warn!(
+                        author = batch_info.author().short_str().as_str(),
+                        "Rejecting batch summary: BatchKey collision between {:?} (queue) and {:?} (incoming)",
+                        existing.info,
+                        batch_info,
+                    );
+                    counters::inc_rejected_batch_count(counters::BATCH_COLLISION_LABEL);
+                    continue;
+                }
+                // If the batch is either committed or the txn summary already exists, skip
+                // inserting this batch.
+                if existing.is_committed() || existing.txn_summaries.is_some() {
+                    continue;
+                }
             }
 
             // Determine if existing item already has a proof

--- a/consensus/src/quorum_store/batch_proof_queue.rs
+++ b/consensus/src/quorum_store/batch_proof_queue.rs
@@ -1152,12 +1152,16 @@ impl BatchProofQueue {
                 let is_committed = item.is_committed();
                 let gas_bucket = item.proof.as_ref().map(|p| p.gas_bucket_start());
                 let insertion_elapsed = item.proof_insertion_time.map(|t| t.elapsed());
+                let stored_num_txns = item.info.num_txns();
+                let stored_sort_key = BatchSortKey::from_info(&item.info);
                 (
                     had_proof,
                     had_summaries,
                     is_committed,
                     gas_bucket,
                     insertion_elapsed,
+                    stored_num_txns,
+                    stored_sort_key,
                 )
             });
 
@@ -1168,12 +1172,14 @@ impl BatchProofQueue {
                     is_already_committed,
                     gas_bucket,
                     insertion_elapsed,
+                    stored_num_txns,
+                    stored_sort_key,
                 )) => {
                     if had_proof {
                         if let (Some(bucket), Some(elapsed)) = (gas_bucket, insertion_elapsed) {
                             counters::pos_to_commit(bucket, elapsed.as_secs_f64());
                         }
-                        self.dec_remaining_proofs(&batch.author(), batch.num_txns());
+                        self.dec_remaining_proofs(&batch.author(), stored_num_txns);
                         counters::GARBAGE_COLLECTED_IN_PROOF_QUEUE_COUNTER
                             .with_label_values(&["committed_proof"])
                             .inc();
@@ -1207,15 +1213,14 @@ impl BatchProofQueue {
                     item.mark_committed();
 
                     // Remove from whichever author map it's in (committed items no longer in author maps)
-                    let batch_sort_key = BatchSortKey::from_info(&batch);
                     if let Some(q) = self.author_to_proof_batches.get_mut(&batch.author()) {
-                        q.remove(&batch_sort_key);
+                        q.remove(&stored_sort_key);
                         if q.is_empty() {
                             self.author_to_proof_batches.remove(&batch.author());
                         }
                     }
                     if let Some(q) = self.author_to_non_proof_batches.get_mut(&batch.author()) {
-                        q.remove(&batch_sort_key);
+                        q.remove(&stored_sort_key);
                         if q.is_empty() {
                             self.author_to_non_proof_batches.remove(&batch.author());
                         }
@@ -1227,7 +1232,7 @@ impl BatchProofQueue {
                             self.num_proofs_with_summary_count -= 1;
                         } else if had_proof {
                             self.num_proofs_without_summary_count -= 1;
-                            self.remaining_proof_txns_without_summary -= batch.num_txns();
+                            self.remaining_proof_txns_without_summary -= stored_num_txns;
                         } else {
                             self.num_batches_without_proof_count -= 1;
                         }

--- a/consensus/src/quorum_store/counters.rs
+++ b/consensus/src/quorum_store/counters.rs
@@ -26,6 +26,13 @@ pub const CALLBACK_SUCCESS_LABEL: &str = "callback_success";
 
 pub const POS_EXPIRED_LABEL: &str = "expired";
 pub const POS_DUPLICATE_LABEL: &str = "duplicate";
+pub const POS_COLLISION_LABEL: &str = "collision";
+
+pub const BATCH_COLLISION_LABEL: &str = "collision";
+
+pub fn inc_rejected_batch_count(reason: &str) {
+    REJECTED_BATCH_COUNT.with_label_values(&[reason]).inc();
+}
 
 static TRANSACTION_COUNT_BUCKETS: Lazy<Vec<f64>> = Lazy::new(|| {
     exponential_buckets(
@@ -765,6 +772,15 @@ static REJECTED_POS_COUNT: Lazy<IntCounterVec> = Lazy::new(|| {
 pub fn inc_rejected_pos_count(reason: &str) {
     REJECTED_POS_COUNT.with_label_values(&[reason]).inc();
 }
+
+static REJECTED_BATCH_COUNT: Lazy<IntCounterVec> = Lazy::new(|| {
+    register_int_counter_vec!(
+        "quorum_store_rejected_batch_count",
+        "Count of batches rejected by the proof queue, grouped by reason.",
+        &["reason"]
+    )
+    .unwrap()
+});
 
 /// Count of the received batches since last restart.
 pub static RECEIVED_REMOTE_BATCH_COUNT: Lazy<IntCounter> = Lazy::new(|| {

--- a/consensus/src/quorum_store/tests/batch_proof_queue_test.rs
+++ b/consensus/src/quorum_store/tests/batch_proof_queue_test.rs
@@ -1014,6 +1014,65 @@ async fn test_proof_queue_rejects_batch_key_collision_proof_first() {
     assert!(proof_queue.is_empty());
 }
 
+/// `mark_committed` is driven by the *committed block*'s PoS, which can disagree
+/// with what the local queue holds for the same (author, batch_id) if a colliding
+/// BatchInfo gathered 2f+1 signatures over the network. Accounting must come from
+/// the queue's stored info, not the incoming committed BatchInfo, otherwise
+/// remaining_txns_with_duplicates underflows.
+#[tokio::test]
+async fn test_mark_committed_with_colliding_info_uses_stored_num_txns() {
+    let my_peer_id = PeerId::random();
+    let batch_store = batch_store_for_test(5 * 1024 * 1024);
+    let mut proof_queue = BatchProofQueue::new(my_peer_id, batch_store, 1);
+    let now_in_usecs = aptos_infallible::duration_since_epoch().as_micros() as u64;
+
+    let attacker = PeerId::random();
+    let batch_id = BatchId::new_for_test(11);
+    let expiration = now_in_usecs + 100_000;
+
+    // Local queue has a proof for A with num_txns=1.
+    let proof_a: ProofOfStore<BatchInfoExt> = ProofOfStore::new(
+        BatchInfo::new(
+            attacker,
+            batch_id,
+            0,
+            expiration,
+            HashValue::random(),
+            1,
+            1,
+            0,
+        )
+        .into(),
+        AggregateSignature::empty(),
+    );
+    proof_queue.insert_proof(proof_a);
+    assert_eq!(proof_queue.remaining_txns_and_proofs(), (1, 1));
+
+    // Network commits a colliding PoS_B with num_txns=5 (different digest, gas
+    // bucket, and tx count). With the old code, dec_remaining_proofs would use
+    // batch.num_txns()=5 here, underflowing the counter that was only incremented
+    // by 1 at insert_proof time.
+    let info_b: BatchInfoExt = BatchInfo::new(
+        attacker,
+        batch_id,
+        0,
+        expiration,
+        HashValue::random(),
+        5,
+        5,
+        1,
+    )
+    .into();
+    proof_queue.mark_committed(vec![info_b]);
+
+    // No underflow. Accounting reflects the stored info_A, not info_B.
+    assert_eq!(proof_queue.remaining_txns_and_proofs(), (0, 0));
+
+    // Expiration cleans up cleanly.
+    proof_queue.handle_updated_block_timestamp(expiration);
+    assert!(proof_queue.is_empty());
+}
+
 /// A re-send of the exact same BatchInfo (same digest + metadata) must still be
 /// accepted as an idempotent retransmit, both for proof and summary paths.
 #[tokio::test]

--- a/consensus/src/quorum_store/tests/batch_proof_queue_test.rs
+++ b/consensus/src/quorum_store/tests/batch_proof_queue_test.rs
@@ -883,3 +883,171 @@ async fn test_proof_queue_pull_full_utilization() {
     proof_queue.handle_updated_block_timestamp(10);
     assert!(proof_queue.is_empty());
 }
+
+/// Regression test for a BatchKey-collision crash. An attacker that controls one
+/// active validator can send two well-formed batches with the same (author, batch_id)
+/// but different digests/metadata, then aggregate a quorum-valid ProofOfStore for
+/// the second one. Previously the proof queue would attach the colliding proof to
+/// the existing item and underflow `remaining_txns_with_duplicates` when the shared
+/// expiration fired. The queue must instead reject the colliding insert at ingress.
+#[tokio::test]
+async fn test_proof_queue_rejects_batch_key_collision() {
+    let my_peer_id = PeerId::random();
+    let batch_store = batch_store_for_test(5 * 1024 * 1024);
+    let mut proof_queue = BatchProofQueue::new(my_peer_id, batch_store, 1);
+    let now_in_secs = aptos_infallible::duration_since_epoch().as_secs();
+    let now_in_usecs = aptos_infallible::duration_since_epoch().as_micros() as u64;
+
+    let attacker = PeerId::random();
+    let batch_id = BatchId::new_for_test(42);
+    let expiration = now_in_usecs + 100_000;
+
+    // Two batches that collide on (author, batch_id) but differ everywhere else.
+    let info_a: BatchInfoExt = BatchInfo::new(
+        attacker,
+        batch_id,
+        0,
+        expiration,
+        HashValue::random(),
+        1,
+        1,
+        0,
+    )
+    .into();
+    let proof_b: ProofOfStore<BatchInfoExt> = ProofOfStore::new(
+        BatchInfo::new(
+            attacker,
+            batch_id,
+            0,
+            expiration,
+            HashValue::random(),
+            0,
+            0,
+            1,
+        )
+        .into(),
+        AggregateSignature::empty(),
+    );
+    assert_ne!(info_a.digest(), proof_b.info().digest());
+
+    let txn = TxnSummaryWithExpiration::new(
+        PeerId::ONE,
+        ReplayProtector::SequenceNumber(0),
+        now_in_secs + 1,
+        HashValue::zero(),
+    );
+
+    // Summary for A lands first.
+    proof_queue.insert_batches(vec![(info_a.clone(), vec![txn])]);
+    assert_eq!(proof_queue.batch_summaries_len(), 1);
+    assert_eq!(proof_queue.remaining_txns_and_proofs(), (0, 0));
+
+    // Colliding proof for B must be rejected — no crash, no state mutation.
+    proof_queue.insert_proof(proof_b.clone());
+    assert_eq!(proof_queue.batch_summaries_len(), 1);
+    assert_eq!(proof_queue.remaining_txns_and_proofs(), (0, 0));
+
+    // Driving expiration past T must not panic (previously underflowed
+    // remaining_txns_with_duplicates because the proof was incremented with
+    // num_txns_B=0 but A's num_txns_A=1 was used at decrement time).
+    proof_queue.handle_updated_block_timestamp(expiration);
+    assert!(proof_queue.is_empty());
+}
+
+/// Reverse ordering of the same collision: proof for B arrives first, then a
+/// summary for the colliding info A. The second insert must be rejected.
+#[tokio::test]
+async fn test_proof_queue_rejects_batch_key_collision_proof_first() {
+    let my_peer_id = PeerId::random();
+    let batch_store = batch_store_for_test(5 * 1024 * 1024);
+    let mut proof_queue = BatchProofQueue::new(my_peer_id, batch_store, 1);
+    let now_in_secs = aptos_infallible::duration_since_epoch().as_secs();
+    let now_in_usecs = aptos_infallible::duration_since_epoch().as_micros() as u64;
+
+    let attacker = PeerId::random();
+    let batch_id = BatchId::new_for_test(7);
+    let expiration = now_in_usecs + 100_000;
+
+    let proof_b: ProofOfStore<BatchInfoExt> = ProofOfStore::new(
+        BatchInfo::new(
+            attacker,
+            batch_id,
+            0,
+            expiration,
+            HashValue::random(),
+            0,
+            0,
+            1,
+        )
+        .into(),
+        AggregateSignature::empty(),
+    );
+    let info_a: BatchInfoExt = BatchInfo::new(
+        attacker,
+        batch_id,
+        0,
+        expiration,
+        HashValue::random(),
+        1,
+        1,
+        0,
+    )
+    .into();
+    assert_ne!(info_a.digest(), proof_b.info().digest());
+
+    let txn = TxnSummaryWithExpiration::new(
+        PeerId::ONE,
+        ReplayProtector::SequenceNumber(0),
+        now_in_secs + 1,
+        HashValue::zero(),
+    );
+
+    proof_queue.insert_proof(proof_b.clone());
+    assert_eq!(proof_queue.remaining_txns_and_proofs(), (0, 1));
+
+    // Colliding summary for A is dropped; no second sort key, no extra summary.
+    proof_queue.insert_batches(vec![(info_a, vec![txn])]);
+    assert_eq!(proof_queue.batch_summaries_len(), 0);
+    assert_eq!(proof_queue.remaining_txns_and_proofs(), (0, 1));
+
+    proof_queue.handle_updated_block_timestamp(expiration);
+    assert!(proof_queue.is_empty());
+}
+
+/// A re-send of the exact same BatchInfo (same digest + metadata) must still be
+/// accepted as an idempotent retransmit, both for proof and summary paths.
+#[tokio::test]
+async fn test_proof_queue_accepts_identical_resend() {
+    let my_peer_id = PeerId::random();
+    let batch_store = batch_store_for_test(5 * 1024 * 1024);
+    let mut proof_queue = BatchProofQueue::new(my_peer_id, batch_store, 1);
+    let now_in_secs = aptos_infallible::duration_since_epoch().as_secs();
+    let now_in_usecs = aptos_infallible::duration_since_epoch().as_micros() as u64;
+
+    let author = PeerId::random();
+    let batch_id = BatchId::new_for_test(99);
+    let expiration = now_in_usecs + 100_000;
+    let digest = HashValue::random();
+
+    let info: BatchInfoExt =
+        BatchInfo::new(author, batch_id, 0, expiration, digest, 1, 1, 0).into();
+    let proof = ProofOfStore::new(info.clone(), AggregateSignature::empty());
+
+    let txn = TxnSummaryWithExpiration::new(
+        PeerId::ONE,
+        ReplayProtector::SequenceNumber(0),
+        now_in_secs + 1,
+        HashValue::zero(),
+    );
+
+    proof_queue.insert_batches(vec![(info.clone(), vec![txn])]);
+    proof_queue.insert_batches(vec![(info.clone(), vec![txn])]); // dup summary
+    proof_queue.insert_proof(proof.clone());
+    proof_queue.insert_proof(proof); // dup proof
+
+    assert_eq!(proof_queue.batch_summaries_len(), 1);
+    assert_eq!(proof_queue.remaining_txns_and_proofs(), (1, 1));
+
+    proof_queue.handle_updated_block_timestamp(expiration);
+    assert!(proof_queue.is_empty());
+}


### PR DESCRIPTION
## Summary

- Add invariant checks at the ingress points of `BatchProofQueue` to keep its per-author state internally consistent.
- Includes regression tests.

## Test plan

- [x] `cargo test -p aptos-consensus --lib quorum_store::`
- [x] `./scripts/rust_lint.sh --check`