### PR TITLE
[consensus] Enforce V2-only entries on V2 quorum store wire messages

### DIFF
--- a/consensus/consensus-types/src/proof_of_store.rs
+++ b/consensus/consensus-types/src/proof_of_store.rs
@@ -418,6 +418,29 @@ where
     }
 }
 
+impl SignedBatchInfoMsg<BatchInfoExt> {
+    pub fn verify_v2(
+        &self,
+        sender: PeerId,
+        max_num_batches: usize,
+        max_batch_expiry_gap_usecs: u64,
+        validator: &ValidatorVerifier,
+    ) -> anyhow::Result<()> {
+        for signed_info in &self.signed_infos {
+            ensure!(
+                signed_info.batch_info().is_v2(),
+                "Non-V2 entry in SignedBatchInfoMsgV2"
+            );
+        }
+        self.verify(
+            sender,
+            max_num_batches,
+            max_batch_expiry_gap_usecs,
+            validator,
+        )
+    }
+}
+
 impl From<SignedBatchInfoMsg<BatchInfo>> for SignedBatchInfoMsg<BatchInfoExt> {
     fn from(info: SignedBatchInfoMsg<BatchInfo>) -> Self {
         Self {
@@ -623,6 +646,20 @@ where
 
     pub fn take(self) -> Vec<ProofOfStore<T>> {
         self.proofs
+    }
+}
+
+impl ProofOfStoreMsg<BatchInfoExt> {
+    pub fn verify_v2(
+        &self,
+        max_num_proofs: usize,
+        validator: &ValidatorVerifier,
+        cache: &ProofCache,
+    ) -> anyhow::Result<()> {
+        for proof in &self.proofs {
+            ensure!(proof.info().is_v2(), "Non-V2 entry in ProofOfStoreMsgV2");
+        }
+        self.verify(max_num_proofs, validator, cache)
     }
 }
 

--- a/consensus/consensus-types/src/proof_of_store.rs
+++ b/consensus/consensus-types/src/proof_of_store.rs
@@ -770,3 +770,68 @@ impl From<ProofOfStore<BatchInfo>> for ProofOfStore<BatchInfoExt> {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn v1_info() -> BatchInfoExt {
+        BatchInfoExt::new_v1(
+            PeerId::random(),
+            BatchId::new_for_test(1),
+            1,
+            1,
+            HashValue::random(),
+            0,
+            0,
+            0,
+        )
+    }
+
+    fn v2_info() -> BatchInfoExt {
+        BatchInfoExt::new_v2(
+            PeerId::random(),
+            BatchId::new_for_test(2),
+            1,
+            u64::MAX,
+            HashValue::random(),
+            0,
+            0,
+            0,
+            BatchKind::Normal,
+        )
+    }
+
+    #[test]
+    fn signed_batch_info_msg_verify_v2_rejects_v1_entry() {
+        let author = PeerId::random();
+        let msg = SignedBatchInfoMsg::new(vec![
+            SignedBatchInfo::dummy(v1_info(), author),
+            SignedBatchInfo::dummy(v2_info(), author),
+        ]);
+        let err = msg
+            .verify_v2(author, 10, u64::MAX, &ValidatorVerifier::new(vec![]))
+            .expect_err("must reject V1 entry in SignedBatchInfoMsgV2");
+        assert!(
+            err.to_string()
+                .contains("Non-V2 entry in SignedBatchInfoMsgV2"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn proof_of_store_msg_verify_v2_rejects_v1_entry() {
+        let msg = ProofOfStoreMsg::new(vec![
+            ProofOfStore::new(v1_info(), AggregateSignature::empty()),
+            ProofOfStore::new(v2_info(), AggregateSignature::empty()),
+        ]);
+        let err = msg
+            .verify_v2(10, &ValidatorVerifier::new(vec![]), &ProofCache::new(1))
+            .expect_err("must reject V1 entry in ProofOfStoreMsgV2");
+        assert!(
+            err.to_string()
+                .contains("Non-V2 entry in ProofOfStoreMsgV2"),
+            "unexpected error: {err}"
+        );
+    }
+}

--- a/consensus/consensus-types/src/proof_of_store.rs
+++ b/consensus/consensus-types/src/proof_of_store.rs
@@ -373,7 +373,9 @@ where
         Self { signed_infos }
     }
 
-    pub fn verify(
+    /// Per-entry verification shared by V1 (`verify`) and V2 (`verify_v2`).
+    /// Variant-specific gating is layered on by the concrete impls.
+    fn verify_inner(
         &self,
         sender: PeerId,
         max_num_batches: usize,
@@ -418,6 +420,23 @@ where
     }
 }
 
+impl SignedBatchInfoMsg<BatchInfo> {
+    pub fn verify(
+        &self,
+        sender: PeerId,
+        max_num_batches: usize,
+        max_batch_expiry_gap_usecs: u64,
+        validator: &ValidatorVerifier,
+    ) -> anyhow::Result<()> {
+        self.verify_inner(
+            sender,
+            max_num_batches,
+            max_batch_expiry_gap_usecs,
+            validator,
+        )
+    }
+}
+
 impl SignedBatchInfoMsg<BatchInfoExt> {
     pub fn verify_v2(
         &self,
@@ -432,7 +451,7 @@ impl SignedBatchInfoMsg<BatchInfoExt> {
                 "Non-V2 entry in SignedBatchInfoMsgV2"
             );
         }
-        self.verify(
+        self.verify_inner(
             sender,
             max_num_batches,
             max_batch_expiry_gap_usecs,
@@ -605,7 +624,9 @@ where
         Self { proofs }
     }
 
-    pub fn verify(
+    /// Per-proof verification shared by V1 (`verify`) and V2 (`verify_v2`).
+    /// Variant-specific gating is layered on by the concrete impls.
+    fn verify_inner(
         &self,
         max_num_proofs: usize,
         validator: &ValidatorVerifier,
@@ -649,6 +670,17 @@ where
     }
 }
 
+impl ProofOfStoreMsg<BatchInfo> {
+    pub fn verify(
+        &self,
+        max_num_proofs: usize,
+        validator: &ValidatorVerifier,
+        cache: &ProofCache,
+    ) -> anyhow::Result<()> {
+        self.verify_inner(max_num_proofs, validator, cache)
+    }
+}
+
 impl ProofOfStoreMsg<BatchInfoExt> {
     pub fn verify_v2(
         &self,
@@ -659,7 +691,7 @@ impl ProofOfStoreMsg<BatchInfoExt> {
         for proof in &self.proofs {
             ensure!(proof.info().is_v2(), "Non-V2 entry in ProofOfStoreMsgV2");
         }
-        self.verify(max_num_proofs, validator, cache)
+        self.verify_inner(max_num_proofs, validator, cache)
     }
 }
 

--- a/consensus/src/quorum_store/types.rs
+++ b/consensus/src/quorum_store/types.rs
@@ -460,7 +460,9 @@ impl<T: TBatchInfo> BatchMsg<T> {
         Self { batches }
     }
 
-    pub fn verify(
+    /// Per-batch verification shared by V1 (`verify`) and V2 (`verify_v2`).
+    /// Variant-specific gating is layered on by the concrete impls.
+    fn verify_inner(
         &self,
         peer_id: PeerId,
         max_num_batches: usize,
@@ -519,6 +521,17 @@ impl<T: TBatchInfo> BatchMsg<T> {
     }
 }
 
+impl BatchMsg<BatchInfo> {
+    pub fn verify(
+        &self,
+        peer_id: PeerId,
+        max_num_batches: usize,
+        verifier: &ValidatorVerifier,
+    ) -> anyhow::Result<()> {
+        self.verify_inner(peer_id, max_num_batches, verifier)
+    }
+}
+
 impl BatchMsg<BatchInfoExt> {
     pub fn verify_v2(
         &self,
@@ -529,7 +542,7 @@ impl BatchMsg<BatchInfoExt> {
         for batch in self.batches.iter() {
             ensure!(batch.batch_info().is_v2(), "Non-V2 batch in BatchMsgV2");
         }
-        self.verify(peer_id, max_num_batches, verifier)
+        self.verify_inner(peer_id, max_num_batches, verifier)
     }
 }
 

--- a/consensus/src/quorum_store/types.rs
+++ b/consensus/src/quorum_store/types.rs
@@ -491,6 +491,20 @@ impl<T: TBatchInfo> BatchMsg<T> {
     }
 }
 
+impl BatchMsg<BatchInfoExt> {
+    pub fn verify_v2(
+        &self,
+        peer_id: PeerId,
+        max_num_batches: usize,
+        verifier: &ValidatorVerifier,
+    ) -> anyhow::Result<()> {
+        for batch in self.batches.iter() {
+            ensure!(batch.batch_info().is_v2(), "Non-V2 batch in BatchMsgV2");
+        }
+        self.verify(peer_id, max_num_batches, verifier)
+    }
+}
+
 impl From<BatchMsg<BatchInfo>> for BatchMsg<BatchInfoExt> {
     fn from(msg: BatchMsg<BatchInfo>) -> Self {
         Self {

--- a/consensus/src/quorum_store/types.rs
+++ b/consensus/src/quorum_store/types.rs
@@ -140,6 +140,34 @@ mod tests {
             config::BATCH_PADDING_BYTES
         );
     }
+
+    #[test]
+    fn verify_v2_rejects_v1_batch_in_batch_msg_v2() {
+        use super::*;
+        use aptos_consensus_types::proof_of_store::BatchKind;
+        use aptos_types::quorum_store::BatchId;
+
+        let author = PeerId::random();
+        let v1 = Batch::<BatchInfoExt>::new_v1(BatchId::new_for_test(1), vec![], 1, 1, author, 0);
+        let v2 = Batch::<BatchInfoExt>::new_v2(
+            BatchId::new_for_test(2),
+            vec![],
+            1,
+            u64::MAX,
+            author,
+            0,
+            BatchKind::Normal,
+        );
+        // Mirrors the disclosed crafted message: V1 first, V2 second.
+        let msg = BatchMsg::new(vec![v1, v2]);
+        let err = msg
+            .verify_v2(author, 10, &ValidatorVerifier::new(vec![]))
+            .expect_err("must reject V1 entry in BatchMsgV2");
+        assert!(
+            err.to_string().contains("Non-V2 batch in BatchMsgV2"),
+            "unexpected error: {err}"
+        );
+    }
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/consensus/src/round_manager.rs
+++ b/consensus/src/round_manager.rs
@@ -196,7 +196,7 @@ impl UnverifiedEvent {
             },
             UnverifiedEvent::BatchMsgV2(b) => {
                 if !self_message {
-                    b.verify(peer_id, max_num_batches, validator)?;
+                    b.verify_v2(peer_id, max_num_batches, validator)?;
                     counters::VERIFY_MSG
                         .with_label_values(&["batch_v2"])
                         .observe(start_time.elapsed().as_secs_f64());
@@ -219,7 +219,7 @@ impl UnverifiedEvent {
             },
             UnverifiedEvent::SignedBatchInfoMsgV2(sd) => {
                 if !self_message {
-                    sd.verify(
+                    sd.verify_v2(
                         peer_id,
                         max_num_batches,
                         max_batch_expiry_gap_usecs,
@@ -242,7 +242,7 @@ impl UnverifiedEvent {
             },
             UnverifiedEvent::ProofOfStoreMsgV2(p) => {
                 if !self_message {
-                    p.verify(max_num_batches, validator, proof_cache)?;
+                    p.verify_v2(max_num_batches, validator, proof_cache)?;
                     counters::VERIFY_MSG
                         .with_label_values(&["proof_of_store_v2"])
                         .observe(start_time.elapsed().as_secs_f64());

--- a/consensus/src/round_manager.rs
+++ b/consensus/src/round_manager.rs
@@ -2381,4 +2381,54 @@ mod reject_encrypted_tests {
             UnverifiedEvent::SignedBatchInfoMsgV2(Box::new(make_encrypted_signed_batch_info_v2()));
         assert!(event.reject_encrypted().is_err());
     }
+
+    /// Exercises the disclosed crafted `BatchMsgV2` (V1 entry with expiration=1
+    /// followed by V2 entry with expiration=u64::MAX) through
+    /// `UnverifiedEvent::verify`, ensuring `round_manager` routes V2 wire
+    /// messages through `verify_v2` and that the variant check rejects the
+    /// message before any panic-prone downstream consumer runs.
+    #[test]
+    fn test_unverified_event_rejects_v1_in_batch_msg_v2() {
+        use aptos_consensus_types::proof_of_store::ProofCache;
+        use aptos_types::validator_verifier::ValidatorVerifier;
+
+        let author = AccountAddress::random();
+        let v1 = crate::quorum_store::types::Batch::<BatchInfoExt>::new_v1(
+            BatchId::new_for_test(1),
+            vec![],
+            1,
+            1,
+            author,
+            0,
+        );
+        let v2 = crate::quorum_store::types::Batch::<BatchInfoExt>::new_v2(
+            BatchId::new_for_test(2),
+            vec![],
+            1,
+            u64::MAX,
+            author,
+            0,
+            BatchKind::Normal,
+        );
+        let event = UnverifiedEvent::BatchMsgV2(Box::new(BatchMsg::new(vec![v1, v2])));
+        let err = event
+            .verify(
+                author,
+                &ValidatorVerifier::new(vec![]),
+                &ProofCache::new(1),
+                true,     // quorum_store_enabled
+                true,     // opt_qs_v2_rx_enabled
+                false,    // self_message
+                100,      // max_num_batches
+                u64::MAX, // max_batch_expiry_gap_usecs
+                1_000_000,
+                1_000_000,
+                true, // encrypted_enabled
+            )
+            .expect_err("must reject mixed-variant BatchMsgV2");
+        assert!(
+            err.to_string().contains("Non-V2 batch in BatchMsgV2"),
+            "unexpected error: {err}"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Receivers of `BatchMsgV2`, `SignedBatchInfoMsgV2`, and `ProofOfStoreMsgV2` admit any mix of `BatchInfoExt::V1` and `V2` entries because `verify` is generic over `TBatchInfo` and never checks the variant. Downstream code (`persist_and_send_digests`, `try_into` for V1 send paths) assumes homogeneity, which lets a single crafted message panic the process via a violated `assert!`/`expect(...)`.

This PR adds concrete `verify_v2` wrappers on the three V2 wire messages that reject any non-V2 entry before running the generic per-element verify, and routes the V2 paths in `round_manager` through them.

- `BatchMsg<BatchInfoExt>::verify_v2` (`consensus/src/quorum_store/types.rs`)
- `SignedBatchInfoMsg<BatchInfoExt>::verify_v2` (`consensus/consensus-types/src/proof_of_store.rs`)
- `ProofOfStoreMsg<BatchInfoExt>::verify_v2` (`consensus/consensus-types/src/proof_of_store.rs`)
- V2 wire path call sites in `round_manager.rs` updated.

The variant check runs first so a malformed message is rejected before per-entry signature/digest verification.

## Test plan

- [ ] `cargo check -p aptos-consensus -p aptos-consensus-types`
- [ ] `cargo test -p aptos-consensus`
- [ ] Add unit test: mixed-variant `BatchMsgV2` is rejected by `verify_v2`
- [ ] Add unit test: mixed-variant `SignedBatchInfoMsgV2` is rejected
- [ ] Add unit test: mixed-variant `ProofOfStoreMsgV2` is rejected
- [ ] Smoke test in mainnet-shadow

🤖 Generated with [Claude Code](https://claude.com/claude-code)