### PR TITLE
jwk consensus clean-up

### DIFF
--- a/crates/aptos-jwk-consensus/src/jwk_manager/mod.rs
+++ b/crates/aptos-jwk-consensus/src/jwk_manager/mod.rs
@@ -299,11 +299,16 @@ impl IssuerLevelConsensusManager {
         } = rpc_req;
         match msg {
             JWKConsensusMsg::ObservationRequest(request) => {
-                let state = self.states_by_issuer.entry(request.issuer).or_default();
-                let response: Result<JWKConsensusMsg> = match &state.consensus_state {
-                    ConsensusState::NotStarted => Err(anyhow!("observed update unavailable")),
-                    ConsensusState::InProgress { my_proposal, .. }
-                    | ConsensusState::Finished { my_proposal, .. } => Ok(
+                let response: Result<JWKConsensusMsg> = match self
+                    .states_by_issuer
+                    .get(&request.issuer)
+                    .map(|s| &s.consensus_state)
+                {
+                    None | Some(ConsensusState::NotStarted) => {
+                        Err(anyhow!("observed update unavailable"))
+                    },
+                    Some(ConsensusState::InProgress { my_proposal, .. })
+                    | Some(ConsensusState::Finished { my_proposal, .. }) => Ok(
                         JWKConsensusMsg::ObservationResponse(ObservedUpdateResponse {
                             epoch: self.epoch_state.epoch,
                             update: my_proposal.clone(),

--- a/crates/aptos-jwk-consensus/src/jwk_manager/tests.rs
+++ b/crates/aptos-jwk-consensus/src/jwk_manager/tests.rs
@@ -145,9 +145,9 @@ async fn test_jwk_manager_state_transition() {
     assert!(last_invocations.len() == 1 && last_invocations[0].is_err());
     assert_eq!(expected_states, jwk_manager.states_by_issuer);
 
-    // When JWK consensus is `NotStarted` for issuer Carl, JWKConsensusManager should:
-    // reply an error to any observation request and keep the state unchanged;
-    // also create an entry in the state table on the fly.
+    // When an observation request arrives for an issuer with no local state
+    // (Carl), JWKConsensusManager should reply an error and leave
+    // `states_by_issuer` unchanged.
     let carl_ob_req = new_rpc_observation_request(
         999,
         issuer_carl.clone(),
@@ -157,7 +157,6 @@ async fn test_jwk_manager_state_transition() {
     assert!(jwk_manager.process_peer_request(carl_ob_req).is_ok());
     let last_invocations = std::mem::take(&mut *rpc_response_collector.write());
     assert!(last_invocations.len() == 1 && last_invocations[0].is_err());
-    expected_states.insert(issuer_carl.clone(), PerProviderState::default());
     assert_eq!(expected_states, jwk_manager.states_by_issuer);
 
     // When JWK consensus is `NotStarted` for issuer Bob, JWKConsensusManager should:
@@ -207,6 +206,7 @@ async fn test_jwk_manager_state_transition() {
     assert!(jwk_manager
         .process_new_observation(issuer_carl.clone(), carl_jwks_new.clone())
         .is_ok());
+    expected_states.insert(issuer_carl.clone(), PerProviderState::default());
     {
         let expected_carl_state = expected_states.get_mut(&issuer_carl).unwrap();
         expected_carl_state.observed = Some(carl_jwks_new.clone());

--- a/crates/aptos-jwk-consensus/src/jwk_manager_per_key.rs
+++ b/crates/aptos-jwk-consensus/src/jwk_manager_per_key.rs
@@ -271,12 +271,11 @@ impl KeyLevelConsensusManager {
         match msg {
             JWKConsensusMsg::KeyLevelObservationRequest(request) => {
                 let ObservedKeyLevelUpdateRequest { issuer, kid, .. } = request;
-                let consensus_state = self
+                let response: Result<JWKConsensusMsg> = match self
                     .states_by_key
-                    .entry((issuer.clone(), kid.clone()))
-                    .or_default();
-                let response: Result<JWKConsensusMsg> = match &consensus_state {
-                    ConsensusState::NotStarted => {
+                    .get(&(issuer.clone(), kid.clone()))
+                {
+                    None | Some(ConsensusState::NotStarted) => {
                         debug!(
                             issuer = String::from_utf8(issuer.clone()).ok(),
                             kid = String::from_utf8(kid.clone()).ok(),
@@ -284,8 +283,8 @@ impl KeyLevelConsensusManager {
                         );
                         return Ok(());
                     },
-                    ConsensusState::InProgress { my_proposal, .. }
-                    | ConsensusState::Finished { my_proposal, .. } => Ok(
+                    Some(ConsensusState::InProgress { my_proposal, .. })
+                    | Some(ConsensusState::Finished { my_proposal, .. }) => Ok(
                         JWKConsensusMsg::ObservationResponse(ObservedUpdateResponse {
                             epoch: self.epoch_state.epoch,
                             update: ObservedUpdate {


### PR DESCRIPTION
## Summary

Switch `process_peer_request` in both `jwk_manager` and `jwk_manager_per_key` from `entry(...).or_default()` to `get(...)`. Peer observation requests no longer create default `ConsensusState` entries on lookup; the manager relies on entries populated by `process_new_observation` and `reset_with_on_chain_state` for issuers configured in `SupportedOIDCProviders`.

Behavior preserved: per-issuer manager still replies "observed update unavailable" for unknown / NotStarted; per-key manager still drops silently for unknown / NotStarted.

## Test plan

- [x] `test_jwk_manager_state_transition` updated to assert that an unknown-issuer observation request leaves `states_by_issuer` unchanged.
- [x] Existing per-key and per-issuer unit tests pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how incoming observation RPCs interact with in-memory consensus state, which can affect session lifecycle and peer responses. Scope is small but touches consensus/network request handling paths.
> 
> **Overview**
> Stops `process_peer_request` from implicitly creating default consensus entries when handling observation RPCs in both issuer-level and key-level JWK managers (switches `entry(...).or_default()` lookups to `get(...)`). Unknown issuers/keys now **do not mutate** the local state maps: the issuer-level manager still responds with an error, while the key-level manager continues to silently drop the request.
> 
> Updates `test_jwk_manager_state_transition` to assert that an unknown-issuer observation request leaves `states_by_issuer` unchanged, and adjusts expectations so state for a new issuer is only created when `process_new_observation` runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 777d695ba70c6693d19f82306295a906738db384. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->