### PR TITLE
[jwk-consensus] Document epoch-replay residual risk in signed payload

### DIFF
--- a/aptos-move/aptos-vm/src/validator_txns/jwk.rs
+++ b/aptos-move/aptos-vm/src/validator_txns/jwk.rs
@@ -137,6 +137,24 @@ impl AptosVM {
             .map_err(|_| Expected(NotEnoughVotingPower))?;
 
         // Verify multi-sig.
+        //
+        // NOTE: `observed` (a `ProviderJWKs`) is signed without the producing
+        // epoch, so this verifier accepts any aggregate whose signer set still
+        // maps to current consensus pubkeys — including aggregates whose
+        // partials were formed in a prior epoch. Combined with the strict
+        // `on_chain.version + 1 == observed.version` gate above, the chain can
+        // never be rolled back to a historical snapshot, but a stale snapshot
+        // from a prior epoch can occupy a still-unfilled `current + 1` slot.
+        // Honest validators overwrite within seconds via a `current + 2`
+        // update; the residual harm window is bounded by that landing latency,
+        // and the only attack surface is kids that were present in the stale
+        // snapshot but revoked upstream since then (briefly honored by keyless
+        // auth). The precondition — a quorum-certified update formed but never
+        // landed, with no other update for the same issuer landing since — is
+        // narrow under healthy operation.
+        // TODO: bind the producing epoch into the signed payload (sign and
+        // verify `(epoch, ProviderJWKs)` with `epoch == current_epoch`) so
+        // cached partials cryptographically expire at epoch boundaries.
         verifier
             .verify_multi_signatures(&observed, &multi_sig)
             .map_err(|_| Expected(MultiSigVerificationFailed))?;

--- a/crates/aptos-jwk-consensus/src/jwk_manager/mod.rs
+++ b/crates/aptos-jwk-consensus/src/jwk_manager/mod.rs
@@ -199,6 +199,13 @@ impl IssuerLevelConsensusManager {
                 version: state.on_chain_version() + 1,
                 jwks,
             };
+            // NOTE: signing `&observed` does not bind `self.epoch_state.epoch`,
+            // so partials collected here remain verifiable in any later epoch
+            // whose validator set still maps the signer addresses to the same
+            // consensus pubkeys. See the residual-risk note in
+            // `validator_txns::jwk::process_jwk_update_inner`.
+            // TODO: sign `(self.epoch_state.epoch, observed)` once the
+            // verification path is updated to match.
             let signature = self
                 .consensus_key
                 .sign(&observed)

--- a/crates/aptos-jwk-consensus/src/jwk_manager_per_key.rs
+++ b/crates/aptos-jwk-consensus/src/jwk_manager_per_key.rs
@@ -196,6 +196,15 @@ impl KeyLevelConsensusManager {
         let issuer_level_repr = update
             .try_as_issuer_level_repr()
             .context("initiate_key_level_consensus failed at repr conversion")?;
+        // NOTE: signing `&issuer_level_repr` does not bind
+        // `self.epoch_state.epoch`, so partials collected here remain
+        // verifiable in any later epoch whose validator set still maps the
+        // signer addresses to the same consensus pubkeys. See the
+        // residual-risk note in
+        // `validator_txns::jwk::process_jwk_update_inner` (the shared VM
+        // verification path for both per-issuer and per-key modes).
+        // TODO: sign `(self.epoch_state.epoch, issuer_level_repr)` once the
+        // verification path is updated to match.
         let signature = self
             .consensus_key
             .sign(&issuer_level_repr)


### PR DESCRIPTION
## Summary

The signed payload for a JWK observation update — `ProviderJWKs { issuer, version, jwks }` in `types/src/jwks/mod.rs` — does not include the producing epoch. The on-chain verifier in `validator_txns/jwk.rs` therefore accepts any `QuorumCertifiedUpdate` whose multisig still verifies against the *current* `ValidatorSet`, including aggregates whose partial signatures were collected in a prior epoch.

Combined with the strict `on_chain.version + 1 == observed.version` gate, this means:
- **Historical rollback is impossible.** Once a `(version = V, ...)` update has landed, no QC with `version ≤ V` can be re-applied.
- **A stale snapshot from a prior epoch can occupy a still-unfilled `current + 1` slot.** Honest validators overwrite within seconds via a `current + 2` update; the bounded harm window only matters for kids that were present in the stale snapshot but revoked upstream since then (briefly honored by keyless auth).

The precondition — a QC formed but never landed, with no other QC for the same issuer landing since, and validator-set/consensus-pubkeys unchanged across the gap — is narrow under healthy operation. The clean fix is to bind the producing epoch into the signed bytes (sign and verify `(epoch, ProviderJWKs)`), making cached partials cryptographically expire at epoch boundaries.

This PR is documentation only. No behavior change. A `TODO` comment marks the proper fix at both the verification site (most informative single location) and the signing site (as a pointer).

## Test plan
- [x] `cargo check -p aptos-jwk-consensus -p aptos-vm` passes — pure comment additions.
- [ ] No runtime tests needed; no behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only change documenting a subtle epoch-replay residual risk in JWK multisig verification/signing; no runtime behavior or data handling is modified.
> 
> **Overview**
> Documents a *residual epoch-replay risk* in JWK consensus where the signed `ProviderJWKs` payload is not bound to the producing epoch, meaning cached partial signatures can remain valid across epochs if validator consensus keys are unchanged.
> 
> Adds matching notes and `TODO`s at the VM verification site (`validator_txns/jwk.rs`) and the signing sites in both per-issuer and per-key managers, pointing to the intended fix of signing/verifying `(epoch, payload)`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8d939d4cc3cb5bd3a97fc64866660c21018c1f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->