### PR TITLE
[storage] Skip drop-log for gen=0 SMTs

### DIFF
--- a/storage/scratchpad/src/sparse_merkle/mod.rs
+++ b/storage/scratchpad/src/sparse_merkle/mod.rs
@@ -130,7 +130,11 @@ impl Drop for Inner {
                 stack.extend(descendant.drain_children_for_drop());
             }
         }
-        self.log_generation("drop");
+
+        // Avoid logging for dummy / empty trees.
+        if self.generation > 0 {
+            self.log_generation("drop");
+        }
     }
 }
 


### PR DESCRIPTION

`Inner::drop` logs `aptos_scratchpad_smt_generation{name="drop"}` to
record the latest generation of an SMT that's been freed. Every
`StateComputeResult::new_dummy()` (used widely in consensus: DAG
ordering, block-store recovery, `PipelinedBlock` deserialization,
consensus observer message handling) builds a
`LedgerStateSummary::new_empty(...)` containing two fresh gen=0 SMTs.
When those dummies later drop, they clobber the gauge to 0 and race
against the meaningful drops on the executor side, making the metric
less accurate under real load.

Skip the log when `generation == 0`. Only `Inner::new` produces gen=0
(`spawn` always increments); the only real gen=0 trees come from
boot/recovery and only drop at teardown or epoch flip, by which point
the gauge has long since been advanced by descendant drops.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only changes a debug/observability metric update on `Drop` and does not affect SMT structure, hashing, or persistence behavior.
> 
> **Overview**
> Prevents gen=0 (dummy/empty) Sparse Merkle Trees from updating the `aptos_scratchpad_smt_generation{name="drop"}` gauge when they are dropped.
> 
> `Inner::drop` now conditionally calls `log_generation("drop")` only when `generation > 0`, avoiding metric clobbering from short-lived placeholder trees.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba8c66aae5053737f16efd106df687f35dfca357. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->