### PR TITLE
[consensus] Avoid PipelinedBlock Arc cycle

### DIFF
--- a/consensus/consensus-types/src/pipelined_block.rs
+++ b/consensus/consensus-types/src/pipelined_block.rs
@@ -151,8 +151,8 @@ pub struct PipelineInputTx {
     pub qc_tx: Option<oneshot::Sender<Arc<QuorumCert>>>,
     pub rand_tx: Option<oneshot::Sender<Option<Randomness>>>,
     pub order_vote_tx: Option<oneshot::Sender<()>>,
-    pub ordered_blocks_and_proof_fut:
-        Option<oneshot::Sender<(Vec<Arc<PipelinedBlock>>, WrappedLedgerInfo)>>,
+    pub order_proof_tx: Option<oneshot::Sender<WrappedLedgerInfo>>,
+    pub ordered_blocks_for_observer_tx: Option<oneshot::Sender<OrderedBlocksForObserver>>,
     pub commit_proof_tx: Option<oneshot::Sender<LedgerInfoWithSignatures>>,
     pub secret_shared_key_tx: Option<oneshot::Sender<Option<SecretSharedKey>>>,
 }
@@ -161,9 +161,82 @@ pub struct PipelineInputRx {
     pub qc_rx: oneshot::Receiver<Arc<QuorumCert>>,
     pub rand_rx: oneshot::Receiver<Option<Randomness>>,
     pub order_vote_rx: oneshot::Receiver<()>,
-    pub ordered_blocks_and_proof_fut: TaskFuture<(Vec<Arc<PipelinedBlock>>, WrappedLedgerInfo)>,
+    pub order_proof_fut: TaskFuture<WrappedLedgerInfo>,
+    pub ordered_blocks_for_observer_fut: TaskFuture<OrderedBlocksForObserver>,
     pub commit_proof_fut: TaskFuture<LedgerInfoWithSignatures>,
     pub secret_shared_key_rx: oneshot::Receiver<Option<SecretSharedKey>>,
+}
+
+#[derive(Clone)]
+pub struct OrderedBlocksForObserver {
+    /// `block_id` (HashValue) helps with logging if a block is dropped before observer publishing.
+    blocks: Vec<(HashValue, Weak<PipelinedBlock>)>,
+}
+
+impl OrderedBlocksForObserver {
+    pub fn new(blocks: &[Arc<PipelinedBlock>]) -> Self {
+        Self {
+            blocks: blocks
+                .iter()
+                .map(|block| (block.id(), Arc::downgrade(block)))
+                .collect(),
+        }
+    }
+
+    pub fn pipelined_blocks(&self) -> Result<Vec<Arc<PipelinedBlock>>, HashValue> {
+        self.blocks
+            .iter()
+            .map(|(block_id, block)| block.upgrade().ok_or(*block_id))
+            .collect()
+    }
+
+    pub fn pipelined_block(
+        &self,
+        target_block_id: HashValue,
+    ) -> Result<Option<Arc<PipelinedBlock>>, HashValue> {
+        for (block_id, block) in &self.blocks {
+            if *block_id == target_block_id {
+                return block.upgrade().map(Some).ok_or(*block_id);
+            }
+        }
+        Ok(None)
+    }
+
+    pub fn last_block_id(&self) -> Option<HashValue> {
+        self.blocks.last().map(|(block_id, _)| *block_id)
+    }
+
+    pub fn block_ids(&self) -> Vec<HashValue> {
+        self.blocks.iter().map(|(block_id, _)| *block_id).collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ordered_blocks_for_observer_does_not_keep_blocks_alive() {
+        let block = Arc::new(PipelinedBlock::new_ordered(
+            Block::make_genesis_block(),
+            OrderedBlockWindow::empty(),
+        ));
+        let block_id = block.id();
+
+        let ordered_blocks = OrderedBlocksForObserver::new(std::slice::from_ref(&block));
+        assert_eq!(Arc::strong_count(&block), 1);
+
+        {
+            let upgraded_blocks = ordered_blocks.pipelined_blocks().unwrap();
+            assert_eq!(upgraded_blocks.len(), 1);
+            assert_eq!(upgraded_blocks[0].id(), block_id);
+        }
+
+        assert_eq!(Arc::strong_count(&block), 1);
+
+        drop(block);
+        assert_eq!(ordered_blocks.pipelined_blocks().unwrap_err(), block_id);
+    }
 }
 
 /// A window of blocks that are needed for execution with the execution pool, EXCLUDING the current block

--- a/consensus/src/pipeline/execution_client.rs
+++ b/consensus/src/pipeline/execution_client.rs
@@ -36,7 +36,7 @@ use aptos_channels::{aptos_channel, message_queues::QueueStyle};
 use aptos_config::config::{ConsensusConfig, ConsensusObserverConfig};
 use aptos_consensus_types::{
     common::{Author, Round},
-    pipelined_block::PipelinedBlock,
+    pipelined_block::{OrderedBlocksForObserver, PipelinedBlock},
     wrapped_ledger_info::WrappedLedgerInfo,
 };
 use aptos_crypto::{bls12381::PrivateKey, HashValue};
@@ -614,12 +614,16 @@ impl TExecutionClient for ExecutionProxyClient {
             },
         };
 
+        let ordered_blocks_for_observer = OrderedBlocksForObserver::new(&blocks);
         for block in &blocks {
             block.set_insertion_time();
             if let Some(tx) = block.pipeline_tx().lock().as_mut() {
-                tx.ordered_blocks_and_proof_fut
+                tx.order_proof_tx
                     .take()
-                    .map(|tx| tx.send((blocks.clone(), ordered_proof.clone())));
+                    .map(|tx| tx.send(ordered_proof.clone()));
+                tx.ordered_blocks_for_observer_tx
+                    .take()
+                    .map(|tx| tx.send(ordered_blocks_for_observer.clone()));
             }
         }
 

--- a/consensus/src/pipeline/pipeline_builder.rs
+++ b/consensus/src/pipeline/pipeline_builder.rs
@@ -23,9 +23,9 @@ use aptos_consensus_types::{
     pipeline::commit_vote::CommitVote,
     pipelined_block::{
         CommitLedgerResult, CommitVoteResult, DecryptionResult, ExecuteResult, LedgerUpdateResult,
-        MaterializeResult, NotifyStateSyncResult, PipelineFutures, PipelineInputRx,
-        PipelineInputTx, PipelinedBlock, PostCommitResult, PostLedgerUpdateResult, PreCommitResult,
-        PrepareResult, RandResult, TaskError, TaskFuture, TaskResult,
+        MaterializeResult, NotifyStateSyncResult, OrderedBlocksForObserver, PipelineFutures,
+        PipelineInputRx, PipelineInputTx, PipelinedBlock, PostCommitResult, PostLedgerUpdateResult,
+        PreCommitResult, PrepareResult, RandResult, TaskError, TaskFuture, TaskResult,
     },
     quorum_cert::QuorumCert,
     wrapped_ledger_info::WrappedLedgerInfo,
@@ -329,6 +329,7 @@ impl PipelineBuilder {
         let (order_vote_tx, order_vote_rx) = oneshot::channel();
         let (order_proof_tx, order_proof_fut) = oneshot::channel();
         let (commit_proof_tx, commit_proof_fut) = oneshot::channel();
+        let (ordered_blocks_for_observer_tx, ordered_blocks_for_observer_fut) = oneshot::channel();
         let order_proof_fut = spawn_shared_fut(
             async move {
                 order_proof_fut
@@ -345,13 +346,22 @@ impl PipelineBuilder {
             },
             Some(abort_handles),
         );
+        let ordered_blocks_for_observer_fut = spawn_shared_fut(
+            async move {
+                ordered_blocks_for_observer_fut.await.map_err(|_| {
+                    TaskError::from(anyhow!("ordered blocks for observer tx cancelled"))
+                })
+            },
+            Some(abort_handles),
+        );
         let (secret_shared_key_tx, secret_shared_key_rx) = oneshot::channel();
         (
             PipelineInputTx {
                 qc_tx: Some(qc_tx),
                 rand_tx: Some(rand_tx),
                 order_vote_tx: Some(order_vote_tx),
-                ordered_blocks_and_proof_fut: Some(order_proof_tx),
+                order_proof_tx: Some(order_proof_tx),
+                ordered_blocks_for_observer_tx: Some(ordered_blocks_for_observer_tx),
                 commit_proof_tx: Some(commit_proof_tx),
                 secret_shared_key_tx: Some(secret_shared_key_tx),
             },
@@ -359,7 +369,8 @@ impl PipelineBuilder {
                 qc_rx,
                 rand_rx,
                 order_vote_rx,
-                ordered_blocks_and_proof_fut: order_proof_fut,
+                order_proof_fut,
+                ordered_blocks_for_observer_fut,
                 commit_proof_fut,
                 secret_shared_key_rx,
             },
@@ -482,12 +493,14 @@ impl PipelineBuilder {
         pipelined_block: &PipelinedBlock,
     ) -> (PipelineFutures, PipelineInputTx, Vec<AbortHandle>) {
         let mut abort_handles = vec![];
+        let enable_observer_publish = self.consensus_publisher.is_some();
         let (tx, rx) = Self::channel(&mut abort_handles);
         let PipelineInputRx {
             qc_rx,
             rand_rx,
             order_vote_rx,
-            ordered_blocks_and_proof_fut: order_proof_fut,
+            order_proof_fut,
+            ordered_blocks_for_observer_fut,
             commit_proof_fut,
             secret_shared_key_rx,
         } = rx;
@@ -561,12 +574,13 @@ impl PipelineBuilder {
             ),
             None,
         );
-        let observer_publish_fut = if self.consensus_publisher.is_some() {
+        let observer_publish_fut = if enable_observer_publish {
             spawn_shared_fut(
                 Self::observer_publish(
                     parent.observer_publish_fut.clone(),
                     decryption_fut.clone(),
                     order_proof_fut.clone(),
+                    ordered_blocks_for_observer_fut,
                     rand_check_fut.clone(),
                     block.clone(),
                     observer_enabled,
@@ -980,7 +994,8 @@ impl PipelineBuilder {
     async fn observer_publish(
         parent_observer_publish_fut: TaskFuture<()>,
         decryption_fut: TaskFuture<DecryptionResult>,
-        order_proof_fut: TaskFuture<(Vec<Arc<PipelinedBlock>>, WrappedLedgerInfo)>,
+        order_proof_fut: TaskFuture<WrappedLedgerInfo>,
+        ordered_blocks_for_observer_fut: TaskFuture<OrderedBlocksForObserver>,
         rand_check: TaskFuture<RandResult>,
         block: Arc<Block>,
         observer_enabled: bool,
@@ -990,34 +1005,47 @@ impl PipelineBuilder {
         let mut tracker = Tracker::start_waiting("observer_publish", &block);
         parent_observer_publish_fut.await?;
         let DecryptionResult { decrypted_txns, .. } = decryption_fut.await?;
-        let (ordered_blocks, order_proof) = order_proof_fut.await?;
+        let order_proof = order_proof_fut.await?;
+        let ordered_blocks_for_observer = ordered_blocks_for_observer_fut.await?;
         rand_check.await?;
 
         tracker.start_working();
-
-        if ordered_blocks
-            .iter()
-            .find(|ordered_block| ordered_block.id() == block.id())
-            .map(|block| {
-                if !observer_enabled {
-                    block.set_decrypted_txns(decrypted_txns);
-                }
-            })
-            .is_none()
-        {
+        let ordered_block = ordered_blocks_for_observer
+            .pipelined_block(block.id())
+            .map_err(|missing_block_id| {
+                TaskError::InternalError(Arc::new(anyhow!(
+                    "Ordered block {} dropped before observer publishing block {}, ordered blocks: {:?}",
+                    missing_block_id,
+                    block.id(),
+                    ordered_blocks_for_observer.block_ids(),
+                )))
+            })?;
+        if let Some(ordered_block) = ordered_block {
+            // Consensus publishers cache decrypted txns for serialization; observers receive them already set.
+            if !observer_enabled {
+                ordered_block.set_decrypted_txns(decrypted_txns);
+            }
+        } else {
             return Err(TaskError::InternalError(Arc::new(anyhow!(
                 "Could not find the block {} in the ordered blocks, {:?}",
                 block.id(),
-                ordered_blocks
-                    .iter()
-                    .map(|block| block.id())
-                    .collect::<Vec<_>>()
+                ordered_blocks_for_observer.block_ids(),
             ))));
         }
         if let Some(publisher) = publisher
-            && let Some(last_block) = ordered_blocks.last()
-            && last_block.id() == block.id()
+            && ordered_blocks_for_observer.last_block_id() == Some(block.id())
         {
+            let ordered_blocks =
+                ordered_blocks_for_observer
+                    .pipelined_blocks()
+                    .map_err(|missing_block_id| {
+                        TaskError::InternalError(Arc::new(anyhow!(
+                            "Ordered block {} dropped before observer publishing block {}, ordered blocks: {:?}",
+                            missing_block_id,
+                            block.id(),
+                            ordered_blocks_for_observer.block_ids(),
+                        )))
+                    })?;
             // Only send if this block is the last block in the blocks
             let message = ConsensusObserverMessage::new_ordered_block_message(
                 ordered_blocks,
@@ -1139,7 +1167,7 @@ impl PipelineBuilder {
     async fn sign_and_broadcast_commit_vote(
         ledger_update_fut: TaskFuture<LedgerUpdateResult>,
         order_vote_rx: oneshot::Receiver<()>,
-        order_proof_fut: TaskFuture<(Vec<Arc<PipelinedBlock>>, WrappedLedgerInfo)>,
+        order_proof_fut: TaskFuture<WrappedLedgerInfo>,
         commit_proof_fut: TaskFuture<LedgerInfoWithSignatures>,
         signer: Arc<ValidatorSigner>,
         block: Arc<Block>,
@@ -1152,7 +1180,7 @@ impl PipelineBuilder {
             Ok(_) = order_vote_rx => {
                 HashValue::zero()
             }
-            Ok((_, li)) = order_proof_fut => {
+            Ok(li) = order_proof_fut => {
                 li.ledger_info().ledger_info().consensus_data_hash()
             }
             Ok(li) = commit_proof_fut => {
@@ -1196,7 +1224,7 @@ impl PipelineBuilder {
     async fn pre_commit(
         ledger_update_fut: TaskFuture<LedgerUpdateResult>,
         parent_block_pre_commit_fut: TaskFuture<PreCommitResult>,
-        order_proof_fut: TaskFuture<(Vec<Arc<PipelinedBlock>>, WrappedLedgerInfo)>,
+        order_proof_fut: TaskFuture<WrappedLedgerInfo>,
         commit_proof_fut: TaskFuture<LedgerInfoWithSignatures>,
         executor: Arc<dyn BlockExecutorTrait>,
         block: Arc<Block>,
@@ -1292,7 +1320,7 @@ impl PipelineBuilder {
     /// What it does: Update counters for the block, and notify block tree about the commit
     async fn post_commit_ledger(
         pre_commit_fut: TaskFuture<PreCommitResult>,
-        order_proof_fut: TaskFuture<(Vec<Arc<PipelinedBlock>>, WrappedLedgerInfo)>,
+        order_proof_fut: TaskFuture<WrappedLedgerInfo>,
         commit_ledger_fut: TaskFuture<CommitLedgerResult>,
         notify_state_sync_fut: TaskFuture<NotifyStateSyncResult>,
         parent_post_commit: TaskFuture<PostCommitResult>,
@@ -1318,7 +1346,7 @@ impl PipelineBuilder {
         payload_manager.notify_commit(timestamp, payload_vec);
 
         if let Some(ledger_info_with_sigs) = maybe_ledger_info_with_sigs {
-            let (_, order_proof) = order_proof_fut.await?;
+            let order_proof = order_proof_fut.await?;
             block_store_callback(order_proof, ledger_info_with_sigs);
         }
         Ok(())

--- a/consensus/src/rand/rand_gen/block_queue.rs
+++ b/consensus/src/rand/rand_gen/block_queue.rs
@@ -250,7 +250,8 @@ mod tests {
                 qc_tx: None,
                 rand_tx: Some(rand_tx),
                 order_vote_tx: None,
-                ordered_blocks_and_proof_fut: None,
+                order_proof_tx: None,
+                ordered_blocks_for_observer_tx: None,
                 commit_proof_tx: None,
                 secret_shared_key_tx: None,
             });


### PR DESCRIPTION
## Summary

Avoid a potential Arc cycle in PipelinedBlock pipeline futures by splitting the order proof future from observer ordered-block data.

The order proof channel now carries only WrappedLedgerInfo. Observer publishing receives a separate OrderedBlocksForObserver wrapper that stores Weak<PipelinedBlock> refs, upgrades the current block only when setting decrypted transactions, and upgrades the full ordered list only when publishing the observer message.

## Test Plan

- cargo check -p aptos-consensus
- cargo test -p aptos-consensus-types ordered_blocks_for_observer_does_not_keep_blocks_alive
- cargo test -p aptos-consensus test_set_randomness_sends_rand_tx_immediately