### PR TITLE
[vm] Relax upgrade compatibility to allow changing friend/package entry to private entry

### DIFF
--- a/aptos-move/aptos-release-builder/src/components/feature_flags.rs
+++ b/aptos-move/aptos-release-builder/src/components/feature_flags.rs
@@ -165,6 +165,7 @@ pub enum FeatureFlag {
     TransactionLimits,
     VersionedTransactionValidation,
     StorageSlotNatives,
+    FriendEntryToPrivateEntry,
 }
 
 fn generate_features_blob(writer: &CodeWriter, data: &[u64]) {
@@ -431,6 +432,9 @@ impl From<FeatureFlag> for AptosFeatureFlag {
                 AptosFeatureFlag::VERSIONED_TRANSACTION_VALIDATION
             },
             FeatureFlag::StorageSlotNatives => AptosFeatureFlag::STORAGE_SLOT_NATIVES,
+            FeatureFlag::FriendEntryToPrivateEntry => {
+                AptosFeatureFlag::FRIEND_ENTRY_TO_PRIVATE_ENTRY
+            },
         }
     }
 }
@@ -624,6 +628,9 @@ impl From<AptosFeatureFlag> for FeatureFlag {
                 FeatureFlag::VersionedTransactionValidation
             },
             AptosFeatureFlag::STORAGE_SLOT_NATIVES => FeatureFlag::StorageSlotNatives,
+            AptosFeatureFlag::FRIEND_ENTRY_TO_PRIVATE_ENTRY => {
+                FeatureFlag::FriendEntryToPrivateEntry
+            },
         }
     }
 }

--- a/aptos-move/aptos-release-builder/src/components/feature_flags.rs
+++ b/aptos-move/aptos-release-builder/src/components/feature_flags.rs
@@ -165,7 +165,7 @@ pub enum FeatureFlag {
     TransactionLimits,
     VersionedTransactionValidation,
     StorageSlotNatives,
-    FriendEntryToPrivateEntry,
+    AllowFriendEntryVisibilityDowngrade,
 }
 
 fn generate_features_blob(writer: &CodeWriter, data: &[u64]) {
@@ -432,8 +432,8 @@ impl From<FeatureFlag> for AptosFeatureFlag {
                 AptosFeatureFlag::VERSIONED_TRANSACTION_VALIDATION
             },
             FeatureFlag::StorageSlotNatives => AptosFeatureFlag::STORAGE_SLOT_NATIVES,
-            FeatureFlag::FriendEntryToPrivateEntry => {
-                AptosFeatureFlag::FRIEND_ENTRY_TO_PRIVATE_ENTRY
+            FeatureFlag::AllowFriendEntryVisibilityDowngrade => {
+                AptosFeatureFlag::ALLOW_FRIEND_ENTRY_VISIBILITY_DOWNGRADE
             },
         }
     }
@@ -628,8 +628,8 @@ impl From<AptosFeatureFlag> for FeatureFlag {
                 FeatureFlag::VersionedTransactionValidation
             },
             AptosFeatureFlag::STORAGE_SLOT_NATIVES => FeatureFlag::StorageSlotNatives,
-            AptosFeatureFlag::FRIEND_ENTRY_TO_PRIVATE_ENTRY => {
-                FeatureFlag::FriendEntryToPrivateEntry
+            AptosFeatureFlag::ALLOW_FRIEND_ENTRY_VISIBILITY_DOWNGRADE => {
+                FeatureFlag::AllowFriendEntryVisibilityDowngrade
             },
         }
     }

--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -1658,12 +1658,17 @@ impl AptosVM {
             .is_enabled(FeatureFlag::TREAT_FRIEND_AS_PRIVATE);
         // TODO(#17171): remove this once 1.34 is in production.
         let function_compat_bug = self.gas_feature_version() < gas_feature_versions::RELEASE_V1_34;
+        // allow `friend/package entry` -> private `entry` upgrades.
+        let allow_friend_entry_to_private_entry = self
+            .features()
+            .is_enabled(FeatureFlag::FRIEND_ENTRY_TO_PRIVATE_ENTRY);
         let compatibility_checks = Compatibility::new(
             check_struct_layout,
             check_friend_linking,
             self.timed_features()
                 .is_enabled(TimedFeatureFlag::EntryCompatibility),
             function_compat_bug,
+            allow_friend_entry_to_private_entry,
         );
 
         session.finish_with_module_publishing_and_initialization(

--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -1658,17 +1658,18 @@ impl AptosVM {
             .is_enabled(FeatureFlag::TREAT_FRIEND_AS_PRIVATE);
         // TODO(#17171): remove this once 1.34 is in production.
         let function_compat_bug = self.gas_feature_version() < gas_feature_versions::RELEASE_V1_34;
-        // allow `friend/package entry` -> private `entry` upgrades.
-        let allow_friend_entry_to_private_entry = self
+        // Allow downgrading the visibility of an `entry` function from
+        // `friend/package` to private during an upgrade.
+        let allow_friend_entry_visibility_downgrade = self
             .features()
-            .is_enabled(FeatureFlag::FRIEND_ENTRY_TO_PRIVATE_ENTRY);
+            .is_enabled(FeatureFlag::ALLOW_FRIEND_ENTRY_VISIBILITY_DOWNGRADE);
         let compatibility_checks = Compatibility::new(
             check_struct_layout,
             check_friend_linking,
             self.timed_features()
                 .is_enabled(TimedFeatureFlag::EntryCompatibility),
             function_compat_bug,
-            allow_friend_entry_to_private_entry,
+            allow_friend_entry_visibility_downgrade,
         );
 
         session.finish_with_module_publishing_and_initialization(

--- a/aptos-move/e2e-move-tests/src/tests/upgrade_compatibility.rs
+++ b/aptos-move/e2e-move-tests/src/tests/upgrade_compatibility.rs
@@ -70,6 +70,35 @@ fn friend_add_entry() {
 }
 
 #[test]
+fn friend_non_entry_to_private() {
+    // friend visibility demoted to private on a non-entry function. Allowed in
+    // production via the early-skip path (TREAT_FRIEND_AS_PRIVATE on =>
+    // check_friend_linking off => non-entry friend functions skip every check).
+    // Pinning it down here so future refactors of the skip logic can't silently
+    // regress it.
+    let result = check_upgrade("public(friend) fun f(){}", "fun f(){}");
+    assert_success!(result);
+}
+
+#[test]
+fn friend_entry_to_private_entry() {
+    // `public(friend) entry fun f()` -> `entry fun f()` must succeed.
+    // Entry is preserved; friend visibility is independently demoted to private.
+    let result = check_upgrade("public(friend) entry fun f(){}", "entry fun f(){}");
+    assert_success!(result);
+
+    let result = check_upgrade_latest_move("package entry fun f(){}", "entry fun f(){}");
+    assert_success!(result);
+}
+
+#[test]
+fn public_entry_to_private_entry_rejected() {
+    // Public must remain public.
+    let result = check_upgrade("public entry fun f(){}", "entry fun f(){}");
+    assert_vm_status!(result, StatusCode::BACKWARD_INCOMPATIBLE_MODULE_UPDATE);
+}
+
+#[test]
 fn friend_upgrade_failures() {
     let result = check_upgrade("public(friend) entry fun f(){}", "public(friend) fun f(){}");
     assert_vm_status!(result, StatusCode::BACKWARD_INCOMPATIBLE_MODULE_UPDATE);

--- a/third_party/move/move-binary-format/src/compatibility.rs
+++ b/third_party/move/move-binary-format/src/compatibility.rs
@@ -37,11 +37,11 @@ pub struct Compatibility {
     /// A temporary flag to preserve compatibility.
     /// TODO(#17171): remove this once 1.34 rolled out
     function_type_compat_bug: bool,
-    /// If true, allow a `friend entry` (thus also `package entry`) function to be converted
-    /// to a private `entry` function during a module upgrade. Has no effect when
-    /// `check_friend_linking` is true, since friend linking is then a contract that must
-    /// be preserved.
-    pub(crate) allow_friend_entry_to_private_entry: bool,
+    /// If true, allow an `entry` function's visibility to be downgraded from `friend`
+    /// (a.k.a. `package`) to private during a module upgrade, while keeping `entry`.
+    /// Has no effect when `check_friend_linking` is true, since friend linking is then
+    /// a contract that must be preserved.
+    pub(crate) allow_friend_entry_visibility_downgrade: bool,
 }
 
 impl Default for Compatibility {
@@ -52,7 +52,7 @@ impl Default for Compatibility {
             check_friend_linking: true,
             treat_entry_as_public: true,
             function_type_compat_bug: false,
-            allow_friend_entry_to_private_entry: true,
+            allow_friend_entry_visibility_downgrade: true,
         }
     }
 }
@@ -69,7 +69,7 @@ impl Compatibility {
             check_friend_linking: false,
             treat_entry_as_public: false,
             function_type_compat_bug: false,
-            allow_friend_entry_to_private_entry: false,
+            allow_friend_entry_visibility_downgrade: false,
         }
     }
 
@@ -79,7 +79,7 @@ impl Compatibility {
         treat_entry_as_public: bool,
         // TODO: remove this once 1.34 is released
         function_type_compat_bug: bool,
-        allow_friend_entry_to_private_entry: bool,
+        allow_friend_entry_visibility_downgrade: bool,
     ) -> Self {
         Self {
             check_struct_and_pub_function_linking: true,
@@ -87,7 +87,7 @@ impl Compatibility {
             check_friend_linking,
             treat_entry_as_public,
             function_type_compat_bug,
-            allow_friend_entry_to_private_entry,
+            allow_friend_entry_visibility_downgrade,
         }
     }
 
@@ -228,7 +228,7 @@ impl Compatibility {
                 // independently allowed when friend linking is not a contract and the flag
                 // is set.
                 (Visibility::Friend, Visibility::Private) => {
-                    !self.check_friend_linking && self.allow_friend_entry_to_private_entry
+                    !self.check_friend_linking && self.allow_friend_entry_visibility_downgrade
                 },
                 // private can become public or friend, or stay private
                 (Visibility::Private, _) => true,

--- a/third_party/move/move-binary-format/src/compatibility.rs
+++ b/third_party/move/move-binary-format/src/compatibility.rs
@@ -37,6 +37,11 @@ pub struct Compatibility {
     /// A temporary flag to preserve compatibility.
     /// TODO(#17171): remove this once 1.34 rolled out
     function_type_compat_bug: bool,
+    /// If true, allow a `friend entry` (thus also `package entry`) function to be converted
+    /// to a private `entry` function during a module upgrade. Has no effect when
+    /// `check_friend_linking` is true, since friend linking is then a contract that must
+    /// be preserved.
+    pub(crate) allow_friend_entry_to_private_entry: bool,
 }
 
 impl Default for Compatibility {
@@ -47,6 +52,7 @@ impl Default for Compatibility {
             check_friend_linking: true,
             treat_entry_as_public: true,
             function_type_compat_bug: false,
+            allow_friend_entry_to_private_entry: true,
         }
     }
 }
@@ -63,6 +69,7 @@ impl Compatibility {
             check_friend_linking: false,
             treat_entry_as_public: false,
             function_type_compat_bug: false,
+            allow_friend_entry_to_private_entry: false,
         }
     }
 
@@ -72,6 +79,7 @@ impl Compatibility {
         treat_entry_as_public: bool,
         // TODO: remove this once 1.34 is released
         function_type_compat_bug: bool,
+        allow_friend_entry_to_private_entry: bool,
     ) -> Self {
         Self {
             check_struct_and_pub_function_linking: true,
@@ -79,6 +87,7 @@ impl Compatibility {
             check_friend_linking,
             treat_entry_as_public,
             function_type_compat_bug,
+            allow_friend_entry_to_private_entry,
         }
     }
 
@@ -212,7 +221,15 @@ impl Compatibility {
                 // friend can become public or remain friend
                 (Visibility::Friend, Visibility::Public)
                 | (Visibility::Friend, Visibility::Friend) => true,
-                (Visibility::Friend, _) => false,
+                // friend → private: only the entry-function form reaches here (non-entry
+                // friend functions are already short-circuited above when
+                // `check_friend_linking` is false). The entry surface is enforced by
+                // `is_entry_compatible` below; converting friend-entry to private-entry is
+                // independently allowed when friend linking is not a contract and the flag
+                // is set.
+                (Visibility::Friend, Visibility::Private) => {
+                    !self.check_friend_linking && self.allow_friend_entry_to_private_entry
+                },
                 // private can become public or friend, or stay private
                 (Visibility::Private, _) => true,
             };

--- a/third_party/move/move-binary-format/src/unit_tests/compatibility_tests.rs
+++ b/third_party/move/move-binary-format/src/unit_tests/compatibility_tests.rs
@@ -143,7 +143,7 @@ fn friend_entry_to_private_entry() {
         false, // check_friend_linking (TREAT_FRIEND_AS_PRIVATE on)
         true,  // treat_entry_as_public
         false, // function_type_compat_bug
-        true,  // allow_friend_entry_to_private_entry
+        true,  // allow_friend_entry_visibility_downgrade
     );
     assert!(allow.check(&friend_entry, &private_entry).is_ok());
 

--- a/third_party/move/move-binary-format/src/unit_tests/compatibility_tests.rs
+++ b/third_party/move/move-binary-format/src/unit_tests/compatibility_tests.rs
@@ -14,8 +14,12 @@ fn mk_module(vis: u8) -> CompiledModule {
     } else {
         (Visibility::try_from(vis).unwrap(), false)
     };
+    mk_module_with_entry(visibility, is_entry, crate::file_format_common::VERSION_4)
+}
+
+fn mk_module_with_entry(visibility: Visibility, is_entry: bool, version: u32) -> CompiledModule {
     CompiledModule {
-        version: crate::file_format_common::VERSION_4,
+        version,
         module_handles: vec![
             // only self module
             ModuleHandle {
@@ -121,4 +125,60 @@ fn deprecated_add_script_visibility() {
     assert!(Compatibility::full_check()
         .check(&friend_module, &script_module)
         .is_err());
+}
+
+#[test]
+fn friend_entry_to_private_entry() {
+    // `public(friend) entry fun f()` -> `entry fun f()`.
+    // The transaction-callable surface is preserved by `entry`; friend visibility is
+    // independently demoted to private. This must be allowed when `check_friend_linking`
+    // is off (i.e. friend is treated as private) AND the flag is on.
+    let version = crate::file_format_common::VERSION_7;
+    let friend_entry = mk_module_with_entry(Visibility::Friend, true, version);
+    let private_entry = mk_module_with_entry(Visibility::Private, true, version);
+
+    // Flag on, friend linking off (production post-rollout state): allowed.
+    let allow = Compatibility::new(
+        true,  // check_struct_layout
+        false, // check_friend_linking (TREAT_FRIEND_AS_PRIVATE on)
+        true,  // treat_entry_as_public
+        false, // function_type_compat_bug
+        true,  // allow_friend_entry_to_private_entry
+    );
+    assert!(allow.check(&friend_entry, &private_entry).is_ok());
+
+    // Flag off, friend linking off (production pre-rollout state): rejected — pins down
+    // that the gate matters and the legacy behavior is preserved before activation.
+    let pre_rollout = Compatibility::new(true, false, true, false, false);
+    assert!(pre_rollout.check(&friend_entry, &private_entry).is_err());
+
+    // Strict mode (check_friend_linking=true): rejected even with the flag on.
+    // Friend linking is a contract; we don't relax it here.
+    let strict = Compatibility::new(true, true, true, false, true);
+    assert!(strict.check(&friend_entry, &private_entry).is_err());
+}
+
+#[test]
+fn friend_entry_to_non_entry_still_rejected() {
+    // `public(friend) entry fun f()` -> `fun f()` (entry removed): always rejected,
+    // because `is_entry_compatible` requires entry to remain entry. Confirms that the
+    // visibility relaxation does not bypass the entry check.
+    let version = crate::file_format_common::VERSION_7;
+    let friend_entry = mk_module_with_entry(Visibility::Friend, true, version);
+    let private_non_entry = mk_module_with_entry(Visibility::Private, false, version);
+
+    let allow = Compatibility::new(true, false, true, false, true);
+    assert!(allow.check(&friend_entry, &private_non_entry).is_err());
+}
+
+#[test]
+fn public_entry_to_private_entry_still_rejected() {
+    // `public entry fun f()` -> `entry fun f()`: always rejected because public must
+    // remain public — pins down that we did not over-relax the `Public` arm.
+    let version = crate::file_format_common::VERSION_7;
+    let public_entry = mk_module_with_entry(Visibility::Public, true, version);
+    let private_entry = mk_module_with_entry(Visibility::Private, true, version);
+
+    let allow = Compatibility::new(true, false, true, false, true);
+    assert!(allow.check(&public_entry, &private_entry).is_err());
 }

--- a/third_party/move/testing-infra/transactional-test-runner/src/vm_test_harness.rs
+++ b/third_party/move/testing-infra/transactional-test-runner/src/vm_test_harness.rs
@@ -252,8 +252,9 @@ impl<'a> MoveTestAdapter<'a> for SimpleVMTestAdapter<'a> {
             Compatibility::new(
                 !extra_args.skip_check_struct_layout,
                 !extra_args.skip_check_friend_linking,
+                true,
                 false,
-                false,
+                true,
             )
         };
         let staging_module_storage = StagingModuleStorage::create_with_compat_config(

--- a/types/src/on_chain_config/aptos_features.rs
+++ b/types/src/on_chain_config/aptos_features.rs
@@ -177,9 +177,10 @@ pub enum FeatureFlag {
     VERSIONED_TRANSACTION_VALIDATION = 112,
     /// Whether storage_slot move natives are enabled.
     STORAGE_SLOT_NATIVES = 113,
-    /// If enabled, a module upgrade may convert a `friend/package entry`
-    /// function into a private `entry` function.
-    FRIEND_ENTRY_TO_PRIVATE_ENTRY = 114,
+    /// If enabled, a module upgrade may downgrade the visibility of an `entry` function
+    /// from `friend/package` to private, while keeping the `entry` modifier. The `entry`
+    /// modifier itself still cannot be removed. See issue #19650.
+    ALLOW_FRIEND_ENTRY_VISIBILITY_DOWNGRADE = 114,
 }
 
 impl FeatureFlag {
@@ -293,7 +294,7 @@ impl FeatureFlag {
             Self::TRANSACTION_LIMITS,
             Self::VERSIONED_TRANSACTION_VALIDATION,
             Self::STORAGE_SLOT_NATIVES,
-            Self::FRIEND_ENTRY_TO_PRIVATE_ENTRY,
+            Self::ALLOW_FRIEND_ENTRY_VISIBILITY_DOWNGRADE,
         ]
     }
 }

--- a/types/src/on_chain_config/aptos_features.rs
+++ b/types/src/on_chain_config/aptos_features.rs
@@ -177,6 +177,9 @@ pub enum FeatureFlag {
     VERSIONED_TRANSACTION_VALIDATION = 112,
     /// Whether storage_slot move natives are enabled.
     STORAGE_SLOT_NATIVES = 113,
+    /// If enabled, a module upgrade may convert a `friend/package entry`
+    /// function into a private `entry` function.
+    FRIEND_ENTRY_TO_PRIVATE_ENTRY = 114,
 }
 
 impl FeatureFlag {
@@ -290,6 +293,7 @@ impl FeatureFlag {
             Self::TRANSACTION_LIMITS,
             Self::VERSIONED_TRANSACTION_VALIDATION,
             Self::STORAGE_SLOT_NATIVES,
+            Self::FRIEND_ENTRY_TO_PRIVATE_ENTRY,
         ]
     }
 }


### PR DESCRIPTION
## Description

Allow demoting `friend`/`package` `entry` functions to private `entry` during module upgrades, behind a new on-chain feature flag. This fixes a spurious `BACKWARD_INCOMPATIBLE_MODULE_UPDATE` rejection.

closes #19650.

## How Has This Been Tested?

Added new upgrade compatibility tests.

## Type of Change
- [x] Bug fix

## Which Components or Systems Does This Change Impact?
- [x] Move/Aptos Virtual Machine

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Move module upgrade compatibility rules in the VM/bytecode verifier; although gated behind a new on-chain feature flag, incorrect logic could allow unintended API surface changes during upgrades.
> 
> **Overview**
> Adds a new on-chain feature flag `ALLOW_FRIEND_ENTRY_VISIBILITY_DOWNGRADE` and wires it through the release builder and default feature set.
> 
> When enabled (and when `friend` linking is not treated as a strict contract), module upgrade compatibility now permits `public(friend)/package entry fun` to be downgraded to `private entry fun` while still rejecting removal of `entry` or downgrades from `public`.
> 
> Extends e2e and Move binary-format compatibility unit tests to lock in the new allowed/rejected upgrade cases, and updates the transactional test harness to use the new `Compatibility::new` signature.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 221bccb314ef922e84c888ba36310400a1bced98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->