### PR TITLE
[paper] add calculator and e2e test for inference paper

### DIFF
--- a/third_party/move/move-prover/doc/higher-order-paper-26/examples/sources/calculator.move
+++ b/third_party/move/move-prover/doc/higher-order-paper-26/examples/sources/calculator.move
@@ -1,0 +1,149 @@
+module 0x42::calculator {
+    use 0x1::signer::address_of;
+
+    const EINVALID_INPUT: u64 = 1;
+
+    enum Input {
+        Number(u64),
+        Add,
+        Sub,
+    }
+
+    /// State of the calculator
+    enum State has key, copy, drop {
+        Empty,
+        Value(u64),
+        Continuation(|u64|u64)
+    }
+
+    /// Process input in the current state.
+    fun process(s: &signer, input: Input) acquires State {
+        let addr = address_of(s);
+        match ((move_from<State>(addr), input)) {
+            (Empty, Number(x)) => move_to(s, State::Value(x)),
+            (Value(_), Number(x)) => move_to(s, State::Value(x)),
+            (Value(x), Add) => move_to(s, State::Continuation(|y| storable_add(x, y))),
+            (Value(x), Sub) => move_to(s, State::Continuation(|y| storable_sub(x, y))),
+            (Continuation(f), Number(x)) => move_to(s, State::Value(f(x))),
+            (_, _) => abort EINVALID_INPUT
+        }
+    }
+    spec process(s: &signer, input: Input) {
+        use 0x1::signer;
+        pragma opaque = true;
+        modifies State[signer::address_of(s)];
+        let address_of_0 = signer::address_of(s);
+        ensures [inferred] ..S1 |~ remove<State>(address_of_0);
+        ensures [inferred] (old(State[address_of_0]) is Continuation) ==> {
+            let a = State::Value(S1..S6 |~ result_of<old(State[address_of_0]).Continuation.0>(input.0));
+            S6.. |~ publish<State>(address_of_0, a)
+        };
+        ensures [inferred] (old(State[address_of_0]) is Value) && (input is Number) ==> (S1.. |~ publish<State>(address_of_0, State::Value(input.0)));
+        ensures [inferred] (old(State[address_of_0]) is Value) && (input is Add) ==>
+            (S1.. |~ publish<State>(address_of_0, State::Continuation({
+                let b = old(State[address_of_0]).Value.0;
+                |x| storable_add(b, x)
+            })));
+        ensures [inferred] (old(State[address_of_0]) is Value) && (input is Sub) ==>
+            (S1.. |~ publish<State>(address_of_0, State::Continuation({
+                let b = old(State[address_of_0]).Value.0;
+                |x| storable_sub(b, x)
+            })));
+        ensures [inferred] (old(State[address_of_0]) is Empty) && (input is Number) ==> (S1.. |~ publish<State>(address_of_0, State::Value(input.0)));
+        ensures [inferred] (old(State[address_of_0]) is Empty) && (input is Add | Sub) ==> {
+            let a = State::Value(S1..S6 |~ result_of<old(State[address_of_0]).Continuation.0>(input.0));
+            S6.. |~ publish<State>(address_of_0, a)
+        };
+        aborts_if [inferred] !exists<State>(address_of_0);
+        aborts_if [inferred] (State[address_of_0] is Continuation) && (S1 |~ aborts_of<State[address_of_0].Continuation.0>(input.0));
+        aborts_if [inferred] (State[address_of_0] is Continuation) && (input is Add | Sub);
+        aborts_if [inferred] (State[address_of_0] is Continuation) && (S6 |~ exists<State>(address_of_0));
+        aborts_if [inferred] (State[address_of_0] is Value) && (S1 |~ (input is Number) && exists<State>(address_of_0));
+        aborts_if [inferred] (State[address_of_0] is Value) && (S1 |~ (input is Add) && exists<State>(address_of_0));
+        aborts_if [inferred] (State[address_of_0] is Value) && (S1 |~ (input is Sub) && exists<State>(address_of_0));
+        aborts_if [inferred] (State[address_of_0] is Empty) && (S1 |~ (input is Number) && exists<State>(address_of_0));
+        aborts_if [inferred] (State[address_of_0] is Empty) && (input is Add | Sub);
+    }
+
+    fun init_module(s: &signer) {
+        move_to(s, State::Empty)
+    }
+    spec init_module(s: &signer) {
+        use 0x1::signer;
+        pragma opaque = true;
+        modifies State[signer::address_of(s)];
+        ensures [inferred] publish<State>(signer::address_of(s), State::Empty{});
+        aborts_if [inferred] exists<State>(signer::address_of(s));
+    }
+
+    #[persistent]
+    fun storable_add(x: u64, y: u64): u64 {
+        x + y
+    }
+    spec storable_add(x: u64, y: u64): u64 {
+        pragma opaque = true;
+        ensures [inferred] result == x + y;
+        aborts_if [inferred] x + y > MAX_U64;
+    }
+
+    #[persistent]
+    fun storable_sub(x: u64, y: u64): u64 {
+        x - y
+    }
+    spec storable_sub(x: u64, y: u64): u64 {
+        pragma opaque = true;
+        ensures [inferred] result == x - y;
+        aborts_if [inferred] x < y;
+    }
+
+    entry fun number(s: &signer, x: u64) acquires State {
+        process(s, Input::Number(x))
+    }
+    spec number {
+        use 0x1::signer;
+        pragma opaque = true;
+        modifies State[signer::address_of(s)];
+        ensures [inferred] ensures_of<process>(s, Input::Number(x));
+        aborts_if [inferred] aborts_of<process>(s, Input::Number(x));
+    } proof {
+        split State[address_of(s)];
+    }
+
+    entry fun add(s: &signer) acquires State {
+        process(s, Input::Add)
+    }
+    spec add(s: &signer) {
+        use 0x1::signer;
+        pragma opaque = true;
+        modifies State[signer::address_of(s)];
+        ensures [inferred] ensures_of<process>(s, Input::Add{});
+        aborts_if [inferred] aborts_of<process>(s, Input::Add{});
+    }
+
+    entry fun sub(s: &signer) acquires State {
+        process(s, Input::Sub)
+    }
+    spec sub(s: &signer) {
+        use 0x1::signer;
+        pragma opaque = true;
+        modifies State[signer::address_of(s)];
+        ensures [inferred] ensures_of<process>(s, Input::Sub{});
+        aborts_if [inferred] aborts_of<process>(s, Input::Sub{});
+    }
+
+    fun view(s: &signer): u64 acquires State {
+        match (&State[address_of(s)]) {
+            Value(x) => *x,
+            _ => abort EINVALID_INPUT
+        }
+    }
+    spec view(s: &signer): u64 {
+        use 0x1::signer;
+        pragma opaque = true;
+        let address_of_0 = signer::address_of(s);
+        ensures [inferred] result == State[address_of_0].Value.0;
+        aborts_if [inferred] State[address_of_0] is Empty | Continuation;
+        aborts_if [inferred] !exists<State>(address_of_0);
+    }
+
+}

--- a/third_party/move/move-prover/doc/inference-paper-26/examples/calculator.orig.move
+++ b/third_party/move/move-prover/doc/inference-paper-26/examples/calculator.orig.move
@@ -1,0 +1,72 @@
+module 0x42::calculator {
+    use 0x1::signer::address_of;
+
+    const EINVALID_INPUT: u64 = 1;
+
+    /// Input provided
+    enum Input {
+        Number(u64),
+        Add,
+        Sub,
+    }
+
+    /// State of the calculator
+    enum State has key, copy, drop {
+        Empty,
+        Value(u64),
+        Continuation(|u64|u64)
+    }
+
+    /// Process input in the current state.
+    fun process(s: &signer, input: Input) acquires State {
+        let addr = address_of(s);
+        match ((move_from<State>(addr), input)) {
+            (Empty, Number(x)) => move_to(s, State::Value(x)),
+            (Value(_), Number(x)) => move_to(s, State::Value(x)),
+            (Value(x), Add) => move_to(s, State::Continuation(|y| storable_add(x, y))),
+            (Value(x), Sub) => move_to(s, State::Continuation(|y| storable_sub(x, y))),
+            (Continuation(f), Number(x)) => move_to(s, State::Value(f(x))),
+            (_, _) => abort EINVALID_INPUT
+        }
+    }
+
+
+    fun init_module(s: &signer) {
+        move_to(s, State::Empty)
+    }
+
+
+    #[persistent]
+    fun storable_add(x: u64, y: u64): u64 {
+        x + y
+    }
+
+    #[persistent]
+    fun storable_sub(x: u64, y: u64): u64 {
+        x - y
+    }
+
+    /// Entry point functions
+    entry fun number(s: &signer, x: u64) acquires State {
+        process(s, Input::Number(x))
+    }
+    spec number {
+    } proof {
+        split State[address_of(s)];
+    }
+
+    entry fun add(s: &signer) acquires State {
+        process(s, Input::Add)
+    }
+
+    entry fun sub(s: &signer) acquires State {
+        process(s, Input::Sub)
+    }
+
+    fun view(s: &signer): u64 acquires State {
+        match (&State[address_of(s)]) {
+            Value(x) => *x,
+            _ => abort EINVALID_INPUT
+        }
+    }
+}

--- a/third_party/move/move-prover/doc/inference-paper-26/examples/sources/calculator.move
+++ b/third_party/move/move-prover/doc/inference-paper-26/examples/sources/calculator.move
@@ -1,0 +1,149 @@
+module 0x42::calculator {
+    use 0x1::signer::address_of;
+
+    const EINVALID_INPUT: u64 = 1;
+
+    enum Input {
+        Number(u64),
+        Add,
+        Sub,
+    }
+
+    /// State of the calculator
+    enum State has key, copy, drop {
+        Empty,
+        Value(u64),
+        Continuation(|u64|u64)
+    }
+
+    /// Process input in the current state.
+    fun process(s: &signer, input: Input) acquires State {
+        let addr = address_of(s);
+        match ((move_from<State>(addr), input)) {
+            (Empty, Number(x)) => move_to(s, State::Value(x)),
+            (Value(_), Number(x)) => move_to(s, State::Value(x)),
+            (Value(x), Add) => move_to(s, State::Continuation(|y| storable_add(x, y))),
+            (Value(x), Sub) => move_to(s, State::Continuation(|y| storable_sub(x, y))),
+            (Continuation(f), Number(x)) => move_to(s, State::Value(f(x))),
+            (_, _) => abort EINVALID_INPUT
+        }
+    }
+    spec process(s: &signer, input: Input) {
+        use 0x1::signer;
+        pragma opaque = true;
+        modifies State[signer::address_of(s)];
+        let address_of_0 = signer::address_of(s);
+        ensures [inferred] ..S1 |~ remove<State>(address_of_0);
+        ensures [inferred] (old(State[address_of_0]) is Continuation) ==> {
+            let a = State::Value(S1..S6 |~ result_of<old(State[address_of_0]).Continuation.0>(input.0));
+            S6.. |~ publish<State>(address_of_0, a)
+        };
+        ensures [inferred] (old(State[address_of_0]) is Value) && (input is Number) ==> (S1.. |~ publish<State>(address_of_0, State::Value(input.0)));
+        ensures [inferred] (old(State[address_of_0]) is Value) && (input is Add) ==>
+            (S1.. |~ publish<State>(address_of_0, State::Continuation({
+                let b = old(State[address_of_0]).Value.0;
+                |x| storable_add(b, x)
+            })));
+        ensures [inferred] (old(State[address_of_0]) is Value) && (input is Sub) ==>
+            (S1.. |~ publish<State>(address_of_0, State::Continuation({
+                let b = old(State[address_of_0]).Value.0;
+                |x| storable_sub(b, x)
+            })));
+        ensures [inferred] (old(State[address_of_0]) is Empty) && (input is Number) ==> (S1.. |~ publish<State>(address_of_0, State::Value(input.0)));
+        ensures [inferred] (old(State[address_of_0]) is Empty) && (input is Add | Sub) ==> {
+            let a = State::Value(S1..S6 |~ result_of<old(State[address_of_0]).Continuation.0>(input.0));
+            S6.. |~ publish<State>(address_of_0, a)
+        };
+        aborts_if [inferred] !exists<State>(address_of_0);
+        aborts_if [inferred] (State[address_of_0] is Continuation) && (S1 |~ aborts_of<State[address_of_0].Continuation.0>(input.0));
+        aborts_if [inferred] (State[address_of_0] is Continuation) && (input is Add | Sub);
+        aborts_if [inferred] (State[address_of_0] is Continuation) && (S6 |~ exists<State>(address_of_0));
+        aborts_if [inferred] (State[address_of_0] is Value) && (S1 |~ (input is Number) && exists<State>(address_of_0));
+        aborts_if [inferred] (State[address_of_0] is Value) && (S1 |~ (input is Add) && exists<State>(address_of_0));
+        aborts_if [inferred] (State[address_of_0] is Value) && (S1 |~ (input is Sub) && exists<State>(address_of_0));
+        aborts_if [inferred] (State[address_of_0] is Empty) && (S1 |~ (input is Number) && exists<State>(address_of_0));
+        aborts_if [inferred] (State[address_of_0] is Empty) && (input is Add | Sub);
+    }
+
+    fun init_module(s: &signer) {
+        move_to(s, State::Empty)
+    }
+    spec init_module(s: &signer) {
+        use 0x1::signer;
+        pragma opaque = true;
+        modifies State[signer::address_of(s)];
+        ensures [inferred] publish<State>(signer::address_of(s), State::Empty{});
+        aborts_if [inferred] exists<State>(signer::address_of(s));
+    }
+
+    #[persistent]
+    fun storable_add(x: u64, y: u64): u64 {
+        x + y
+    }
+    spec storable_add(x: u64, y: u64): u64 {
+        pragma opaque = true;
+        ensures [inferred] result == x + y;
+        aborts_if [inferred] x + y > MAX_U64;
+    }
+
+    #[persistent]
+    fun storable_sub(x: u64, y: u64): u64 {
+        x - y
+    }
+    spec storable_sub(x: u64, y: u64): u64 {
+        pragma opaque = true;
+        ensures [inferred] result == x - y;
+        aborts_if [inferred] x < y;
+    }
+
+    entry fun number(s: &signer, x: u64) acquires State {
+        process(s, Input::Number(x))
+    }
+    spec number {
+        use 0x1::signer;
+        pragma opaque = true;
+        modifies State[signer::address_of(s)];
+        ensures [inferred] ensures_of<process>(s, Input::Number(x));
+        aborts_if [inferred] aborts_of<process>(s, Input::Number(x));
+    } proof {
+        split State[address_of(s)];
+    }
+
+    entry fun add(s: &signer) acquires State {
+        process(s, Input::Add)
+    }
+    spec add(s: &signer) {
+        use 0x1::signer;
+        pragma opaque = true;
+        modifies State[signer::address_of(s)];
+        ensures [inferred] ensures_of<process>(s, Input::Add{});
+        aborts_if [inferred] aborts_of<process>(s, Input::Add{});
+    }
+
+    entry fun sub(s: &signer) acquires State {
+        process(s, Input::Sub)
+    }
+    spec sub(s: &signer) {
+        use 0x1::signer;
+        pragma opaque = true;
+        modifies State[signer::address_of(s)];
+        ensures [inferred] ensures_of<process>(s, Input::Sub{});
+        aborts_if [inferred] aborts_of<process>(s, Input::Sub{});
+    }
+
+    fun view(s: &signer): u64 acquires State {
+        match (&State[address_of(s)]) {
+            Value(x) => *x,
+            _ => abort EINVALID_INPUT
+        }
+    }
+    spec view(s: &signer): u64 {
+        use 0x1::signer;
+        pragma opaque = true;
+        let address_of_0 = signer::address_of(s);
+        ensures [inferred] result == State[address_of_0].Value.0;
+        aborts_if [inferred] State[address_of_0] is Empty | Continuation;
+        aborts_if [inferred] !exists<State>(address_of_0);
+    }
+
+}

--- a/third_party/move/move-prover/e2e-tests/tests/papers.rs
+++ b/third_party/move/move-prover/e2e-tests/tests/papers.rs
@@ -14,3 +14,8 @@ fn higher_order_paper_examples() {
         "../doc/higher-order-paper-26/examples",
     ));
 }
+
+#[test]
+fn inference_paper_examples() {
+    move_prover_e2e_tests::run_paper_with_baseline(paper_pkg("../doc/inference-paper-26/examples"));
+}


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

1) Add the calculator example to the example of two papers;
2) Add prover e2e test for inference paper.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only add new Move Prover paper example sources/specs and a new e2e test entry, with no impact on production logic.
> 
> **Overview**
> Adds a new `calculator` example module to the Move Prover paper examples, including a fully specified version under `sources/` (for both the higher-order and inference papers) plus an unspecced `calculator.orig.move` for the inference paper.
> 
> Extends `e2e-tests/tests/papers.rs` with an `inference_paper_examples` test so the inference paper example package is exercised against baselines in CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 621f4f68b4226dad9082e17c3401e127ad720293. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->