### PR TITLE
[prover] User-form behavioral predicates for &mut T parameters

### DIFF
--- a/third_party/move/move-compiler-v2/src/env_pipeline/spec_rewriter.rs
+++ b/third_party/move/move-compiler-v2/src/env_pipeline/spec_rewriter.rs
@@ -1077,6 +1077,11 @@ struct SpecConverter<'a> {
     contains_imperative_expression: bool,
     /// Set to true when rewriting spec during inlining phase
     for_inline: bool,
+    /// Depth tracker for behavioral-predicate argument context. When > 0,
+    /// the rewriter is descending into args of an `ensures_of` / `result_of`
+    /// (etc.) call; in this context, `Borrow(Mut, ...)` selector borrows
+    /// must be preserved so the model spec rewriter can normalize them.
+    bp_arg_depth: usize,
 }
 
 impl<'a> SpecConverter<'a> {
@@ -1093,6 +1098,7 @@ impl<'a> SpecConverter<'a> {
             reference_strip_exempted: Default::default(),
             contains_imperative_expression: false,
             for_inline: false,
+            bp_arg_depth: 0,
         }
     }
 
@@ -1109,6 +1115,7 @@ impl<'a> SpecConverter<'a> {
             reference_strip_exempted: Default::default(),
             contains_imperative_expression: false,
             for_inline: true,
+            bp_arg_depth: 0,
         }
     }
 
@@ -1180,7 +1187,18 @@ impl ExpRewriterFunctions for SpecConverter<'_> {
                 _ => exp,
             };
 
+            // Track behavioral-predicate argument depth across descent so
+            // `Borrow(Mut, ...)` selectors inside `ensures_of(&mut x.foo, ...)`
+            // are preserved (their stripping is done later by the model spec
+            // rewriter only after augmenting the call to its canonical form).
+            let is_behavior = matches!(exp.as_ref(), Call(_, Behavior(_, _), _));
+            if is_behavior {
+                self.bp_arg_depth += 1;
+            }
             let exp = self.rewrite_exp_descent(exp);
+            if is_behavior {
+                self.bp_arg_depth -= 1;
+            }
 
             // Simplification after descent
             match exp.as_ref() {
@@ -1196,6 +1214,13 @@ impl ExpRewriterFunctions for SpecConverter<'_> {
                 Call(id, BorrowGlobal(ReferenceKind::Immutable), args) => {
                     // Map borrow_global to specification global
                     Call(*id, Global(None), args.clone()).into_exp()
+                },
+                Call(_, Borrow(ReferenceKind::Mutable), _) if self.bp_arg_depth > 0 => {
+                    // Inside a behavioral-predicate argument: preserve the
+                    // `Borrow(Mut, ...)` so the model spec rewriter can
+                    // augment the call (extracting pre-state via
+                    // `old(...)` and appending post-state clones).
+                    exp.clone()
                 },
                 Call(_, Borrow(_), args) | Call(_, Deref, args) => {
                     // Skip local borrow

--- a/third_party/move/move-model/src/builder/exp_builder.rs
+++ b/third_party/move/move-model/src/builder/exp_builder.rs
@@ -121,6 +121,12 @@ pub(crate) struct ExpTranslator<'env, 'translator, 'module_translator> {
     /// Map from state label names to their GlobalId, ensuring the same label name
     /// always resolves to the same MemoryLabel across behavior predicates.
     pub state_label_map: BTreeMap<Symbol, MemoryLabel>,
+    /// True while translating an argument expression of a behavioral predicate
+    /// (`ensures_of` / `result_of` / etc.). In this context, `&mut x.foo`
+    /// selector borrows are accepted in spec mode (the spec rewriter and
+    /// Boogie translator interpret them as field-path expressions over the
+    /// underlying mut-ref param).
+    pub in_behavior_pred_arg: bool,
 }
 
 #[derive(Debug)]
@@ -194,6 +200,7 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
             insert_freeze: true,
             loop_stack: vec![],
             state_label_map: BTreeMap::new(),
+            in_behavior_pred_arg: false,
         }
     }
 
@@ -1966,7 +1973,12 @@ impl ExpTranslator<'_, '_, '_> {
                 ExpData::Call(id, Operation::Deref, vec![target_exp.into_exp()])
             },
             EA::Exp_::Borrow(mutable, exp) => {
-                self.require_impl_language(&loc);
+                // Behavioral predicate arguments accept `&mut x.foo` selector
+                // borrows even in spec mode — the model spec rewriter / Boogie
+                // translator interpret them as field-path expressions.
+                if !self.in_behavior_pred_arg {
+                    self.require_impl_language(&loc);
+                }
                 let ref_kind = ReferenceKind::from_is_mut(*mutable);
                 let target_ty = self.fresh_type_var();
                 let ty = Type::Reference(ref_kind, Box::new(target_ty.clone()));
@@ -6056,15 +6068,20 @@ impl ExpTranslator<'_, '_, '_> {
             return self.new_error_exp();
         };
 
-        // Compute expected argument types based on behavior kind and function signature
-        let expected_arg_types = self.compute_behavior_arg_types(&arg_ty, &result_ty, &model_kind);
-
-        // Translate arguments and check types
+        // Translate arguments and check types. Both the user-facing minimum
+        // arity (inputs + explicit results for `EnsuresOf`) and the canonical
+        // augmented arity (with post-state slots for `&mut` params) are
+        // accepted; `augment_behavior_call` in the spec rewriter normalizes
+        // the minimum form to the canonical form automatically.
         let translated_args =
-            self.translate_and_check_behavior_args(loc, args, &expected_arg_types, &model_kind);
+            self.translate_and_check_behavior_args(loc, args, &arg_ty, &result_ty, &model_kind);
 
         // Determine the result type based on the behavior kind
-        let fun_type = Type::Fun(Box::new(arg_ty), Box::new(result_ty), AbilitySet::EMPTY);
+        let fun_type = Type::Fun(
+            Box::new(arg_ty.clone()),
+            Box::new(result_ty),
+            AbilitySet::EMPTY,
+        );
         let Some(computed_result_ty) =
             self.compute_behavior_result_type(loc, &model_kind, &fun_type)
         else {
@@ -6096,7 +6113,9 @@ impl ExpTranslator<'_, '_, '_> {
             return self.new_error_exp();
         }
 
-        // Build args with function expression as first argument
+        // Build args with function expression as first argument. The
+        // user-facing 2-arg form is canonicalized to the internal 3-arg form
+        // by `SpecTranslator::augment_behavior_call` during spec rewriting.
         let mut all_args = vec![fun_exp];
         all_args.extend(translated_args);
 
@@ -6296,45 +6315,51 @@ impl ExpTranslator<'_, '_, '_> {
     }
 
     /// Computes the expected argument types for a behavior predicate based on kind.
-    fn compute_behavior_arg_types(
+    ///
+    /// Input parameter types are stripped of all references — spec language
+    /// treats references transparently. For `EnsuresOf`, explicit result types
+    /// are appended after inputs (the user-facing "minimum" form). When the
+    /// caller writes the canonical form (with explicit post-state slots for
+    /// each `&mut` parameter), `compute_behavior_arg_types_canonical` returns
+    /// the extended type list. `translate_and_check_behavior_args` accepts
+    /// either arity.
+    fn compute_behavior_arg_types_minimum(
         &self,
         arg_ty: &Type,
         result_ty: &Type,
         kind: &BehaviorKind,
     ) -> Vec<Type> {
-        match kind {
-            BehaviorKind::RequiresOf | BehaviorKind::AbortsOf | BehaviorKind::ResultOf => {
-                // requires_of, aborts_of, and result_of take the VALUES of input parameters.
-                // In spec language, references are transparent: a caller writing
-                // `result_of<f>(self.shares, shareholder)` passes value-typed expressions
-                // regardless of whether `f` declares `&T` or `&mut T` params. Strip all
-                // reference wrappers so the expected type for each arg slot is the value type T.
-                arg_ty
-                    .clone()
-                    .flatten()
-                    .into_iter()
-                    .map(|ty| ty.skip_reference().clone())
-                    .collect()
-            },
-            BehaviorKind::EnsuresOf => {
-                // ensures_of takes the VALUES of input parameters + result + modified mut ref values.
-                // Input param expected types: strip all references (same rationale as above).
-                let mut types: Vec<Type> = arg_ty
-                    .clone()
-                    .flatten()
-                    .into_iter()
-                    .map(|ty| ty.skip_reference().clone())
-                    .collect();
-                types.extend(result_ty.clone().flatten());
-                // Add mutable reference parameters as outputs (their post-state values).
-                for ty in arg_ty.clone().flatten() {
-                    if ty.is_mutable_reference() {
-                        types.push(ty.skip_reference().clone());
-                    }
-                }
-                types
-            },
+        let mut types: Vec<Type> = arg_ty
+            .clone()
+            .flatten()
+            .into_iter()
+            .map(|ty| ty.skip_reference().clone())
+            .collect();
+        if matches!(kind, BehaviorKind::EnsuresOf) {
+            types.extend(result_ty.clone().flatten());
         }
+        types
+    }
+
+    /// The canonical (augmented) expected argument types for a behavior
+    /// predicate. For `EnsuresOf`, the inputs and explicit results are
+    /// followed by the post-state value type for each `&mut T` parameter.
+    /// For other kinds, this matches the minimum form.
+    fn compute_behavior_arg_types_canonical(
+        &self,
+        arg_ty: &Type,
+        result_ty: &Type,
+        kind: &BehaviorKind,
+    ) -> Vec<Type> {
+        let mut types = self.compute_behavior_arg_types_minimum(arg_ty, result_ty, kind);
+        if matches!(kind, BehaviorKind::EnsuresOf) {
+            for ty in arg_ty.clone().flatten() {
+                if ty.is_mutable_reference() {
+                    types.push(ty.skip_reference().clone());
+                }
+            }
+        }
+        types
     }
 
     /// Computes the result type for a behavior predicate based on the kind.
@@ -6384,37 +6409,65 @@ impl ExpTranslator<'_, '_, '_> {
         Some(Type::tuple(result_types))
     }
 
-    /// Translates and type-checks behavior predicate arguments.
+    /// Translates and type-checks behavior predicate arguments. Accepts
+    /// either the user-facing minimum arity or the canonical augmented arity
+    /// (which includes post-state slots for `&mut T` parameters in
+    /// `EnsuresOf`). The model spec rewriter normalizes the minimum form to
+    /// the canonical form via `augment_behavior_call`.
     fn translate_and_check_behavior_args(
         &mut self,
         loc: &Loc,
         args: &[EA::Exp],
-        expected_types: &[Type],
+        arg_ty: &Type,
+        result_ty: &Type,
         kind: &BehaviorKind,
     ) -> Vec<Exp> {
-        // Check arity for behavior kinds
+        let minimum = self.compute_behavior_arg_types_minimum(arg_ty, result_ty, kind);
+        let canonical = self.compute_behavior_arg_types_canonical(arg_ty, result_ty, kind);
+        let expected_types: &[Type] =
+            if args.len() == canonical.len() && canonical.len() != minimum.len() {
+                &canonical
+            } else {
+                &minimum
+            };
+
         if args.len() != expected_types.len() {
-            self.error(
-                loc,
-                &format!(
+            // Report against the minimum-arity (the user-facing default);
+            // also mention the canonical arity if it differs.
+            let msg = if minimum.len() == canonical.len() {
+                format!(
                     "expected {} argument(s) for {} but {} were provided",
-                    expected_types.len(),
+                    minimum.len(),
                     kind,
                     args.len()
-                ),
-            );
-            // Still translate arguments to provide better error messages
-            return args
+                )
+            } else {
+                format!(
+                    "expected {} argument(s) for {} (or {} for the canonical form including post-state slots), but {} were provided",
+                    minimum.len(),
+                    kind,
+                    canonical.len(),
+                    args.len()
+                )
+            };
+            self.error(loc, &msg);
+            let prev = std::mem::replace(&mut self.in_behavior_pred_arg, true);
+            let translated = args
                 .iter()
                 .map(|arg| self.translate_exp_free(arg).1.into_exp())
                 .collect();
+            self.in_behavior_pred_arg = prev;
+            return translated;
         }
 
-        // Translate each argument with expected type
-        args.iter()
+        let prev = std::mem::replace(&mut self.in_behavior_pred_arg, true);
+        let translated = args
+            .iter()
             .zip(expected_types.iter())
             .map(|(arg, expected_ty)| self.translate_exp(arg, expected_ty).into_exp())
-            .collect()
+            .collect();
+        self.in_behavior_pred_arg = prev;
+        translated
     }
 
     /// Unify types with order `LeftToRight` and shallow variance

--- a/third_party/move/move-model/src/pureness_checker.rs
+++ b/third_party/move/move-model/src/pureness_checker.rs
@@ -79,9 +79,25 @@ where
     pub fn check_exp(&mut self, env: &GlobalEnv, exp: &Exp) -> bool {
         // Reset before start of traversal
         self.is_impure = false;
-        exp.visit_post_order(&mut |e| {
+        // Track behavioral-predicate argument depth: while > 0, we are inside
+        // an `ensures_of` / `result_of` / etc. argument expression, where
+        // `&mut x.foo` selector borrows are accepted (the spec rewriter and
+        // Boogie translator interpret them as field-path expressions).
+        let mut bp_arg_depth: usize = 0;
+        exp.visit_pre_post(&mut |post, e| {
             use ExpData::*;
             use Operation::*;
+            // Maintain bp_arg_depth around Behavior nodes' descendants.
+            if !post {
+                if matches!(e, Call(_, Behavior(_, _), _)) {
+                    bp_arg_depth += 1;
+                }
+                return !self.is_impure;
+            }
+            // post-visit (children fully visited)
+            if matches!(e, Call(_, Behavior(_, _), _)) {
+                bp_arg_depth = bp_arg_depth.saturating_sub(1);
+            }
             match e {
                 Assign(id, ..) if self.mode == FunctionPurenessCheckerMode::Specification => {
                     (self.impure_action)(*id, "assigns variable", &self.visiting);
@@ -107,7 +123,7 @@ where
                         &self.visiting,
                     );
                 },
-                Call(id, Borrow(ReferenceKind::Mutable), ..) => {
+                Call(id, Borrow(ReferenceKind::Mutable), ..) if bp_arg_depth == 0 => {
                     (self.impure_action)(*id, "mutably borrows value", &self.visiting);
                     self.is_impure = true;
                 },

--- a/third_party/move/move-model/src/spec_translator.rs
+++ b/third_party/move/move-model/src/spec_translator.rs
@@ -23,7 +23,7 @@ use crate::{
         CONDITION_EXPORT_PROP, CONDITION_INJECTED_PROP,
     },
     symbol::Symbol,
-    ty::{PrimitiveType, Type, BOOL_TYPE},
+    ty::{PrimitiveType, ReferenceKind, Type, BOOL_TYPE},
 };
 use codespan_reporting::diagnostic::Severity;
 use itertools::Itertools;
@@ -1003,10 +1003,187 @@ impl<'a, 'b, T: ExpGenerator<'a>> SpecTranslator<'a, 'b, T> {
             saved
         }
     }
+
+    /// Bridge the user-facing behavioral-predicate syntax to the canonical
+    /// 3-arg form expected downstream:
+    ///   - Reference-typed input args at `&mut T` parameter positions are
+    ///     wrapped in `old(...)` so the inner `Temporary` triggers
+    ///     `save_param` during the rest of the rewrite. Value-typed args at
+    ///     such positions are left untouched — their value is timeless and
+    ///     no pre-state extraction is needed.
+    ///   - For `EnsuresOf`, a post-state clone is appended for each
+    ///     reference-typed `&mut T` input that we wrapped. The clone is the
+    ///     un-`old`-wrapped form, which the rewriter leaves alone, so the
+    ///     Boogie translator emits `$Dereference($t<idx>)` (live, post-call
+    ///     value) at the wrapper's exit.
+    /// When all `&mut T` slots are filled with value-typed args, no
+    /// augmentation runs — the caller is expected to have already supplied
+    /// the canonical form (typically via the inference engine's
+    /// `result_of`-projection idiom for chained calls).
+    /// Idempotent: re-augmenting is a no-op when every reference-typed
+    /// `&mut T` input is already `old`-wrapped.
+    /// True if `arg` syntactically denotes a stateful mutable reference:
+    /// a reference-typed expression, a `Borrow(Mut, ...)` selector chain,
+    /// a `Temporary` referring to a `&mut`-typed local in the enclosing
+    /// function, or an `Old(...)` wrapping any of the above. Used to decide
+    /// whether a `&mut T` parameter slot of a behavioral predicate needs
+    /// the `old(...)` / post-state-clone augmentation.
+    fn is_stateful_mut_ref(&self, arg: &Exp) -> bool {
+        let env = self.builder.global_env();
+        if env.get_node_type(arg.node_id()).is_reference() {
+            return true;
+        }
+        match arg.as_ref() {
+            ExpData::Call(_, Operation::Borrow(ReferenceKind::Mutable), _) => true,
+            ExpData::Call(_, Operation::Old, inner) if inner.len() == 1 => {
+                self.is_stateful_mut_ref(&inner[0])
+            },
+            ExpData::Temporary(_, idx) => self
+                .fun_env
+                .get_local_type(*idx)
+                .as_ref()
+                .is_some_and(Type::is_reference),
+            _ => false,
+        }
+    }
+
+    fn augment_behavior_call(&self, exp: &Exp) -> Exp {
+        use crate::ast::BehaviorKind;
+        let env = self.builder.global_env();
+        let ExpData::Call(node_id, Operation::Behavior(kind, range), args) = exp.as_ref() else {
+            return exp.clone();
+        };
+        let Some(fun_exp) = args.first() else {
+            return exp.clone();
+        };
+        let fun_type = env.get_node_type(fun_exp.node_id());
+        let Type::Fun(arg_ty_box, result_ty_box, _) = fun_type else {
+            return exp.clone();
+        };
+        let arg_types: Vec<Type> = (*arg_ty_box).flatten();
+        let num_inputs = arg_types.len();
+        let num_explicit_results = (*result_ty_box).flatten().len();
+        if args.len() < 1 + num_inputs {
+            return exp.clone();
+        }
+
+        // Identify input slots that need wrapping: a `&mut T` parameter
+        // whose corresponding argument expression is a stateful reference
+        // (Temporary of a `&mut` param, a `Borrow(Mut, ...)` selector, or
+        // an `Old(...)` wrapping such an expression). Value-typed arguments
+        // at `&mut T` positions (e.g., a let-bound `update_field(...)`
+        // result) are timeless — their value is already the pre-state and
+        // they need no `old(...)` wrapping.
+        //
+        // The check is both type- and shape-based: type unification may
+        // have widened a stateful arg's type to its value form, so we
+        // also accept syntactic `Borrow(Mut, ...)`, `Temporary(idx)` where
+        // `idx` references a `&mut`-typed local, and `Old(...)` of either
+        // (which is what a user writes when they manually pre-wrap).
+        let wrap_mask: Vec<bool> = (0..num_inputs)
+            .map(|k| {
+                if !arg_types[k].is_mutable_reference() {
+                    return false;
+                }
+                let Some(arg) = args.get(k + 1) else {
+                    return false;
+                };
+                self.is_stateful_mut_ref(arg)
+            })
+            .collect();
+        let post_state_slot_count = wrap_mask.iter().filter(|b| **b).count();
+        if post_state_slot_count == 0 {
+            // No reference-typed `&mut T` slots — nothing to do.
+            return exp.clone();
+        }
+
+        // Compute the canonical augmented arity. For non-`EnsuresOf` kinds
+        // there are no post-state slots, so it equals the input arity.
+        let augmented_arity = 1
+            + num_inputs
+            + if matches!(kind, BehaviorKind::EnsuresOf) {
+                num_explicit_results + post_state_slot_count
+            } else {
+                0
+            };
+        let needs_post_state =
+            matches!(kind, BehaviorKind::EnsuresOf) && args.len() < augmented_arity;
+
+        // Determine if `Old`-wrapping is already in place for every
+        // wrap_mask position. If so, and we don't need to append post-state
+        // clones, we can short-circuit.
+        let all_wrapped = wrap_mask.iter().enumerate().all(|(k, needs_wrap)| {
+            if !needs_wrap {
+                return true;
+            }
+            matches!(
+                args.get(k + 1).map(|a| a.as_ref()),
+                Some(ExpData::Call(_, Operation::Old, _))
+            )
+        });
+        if all_wrapped && !needs_post_state {
+            return exp.clone();
+        }
+
+        let mut new_args: Vec<Exp> = Vec::with_capacity(augmented_arity);
+        new_args.push(fun_exp.clone());
+        let mut post_state_clones: Vec<Exp> = Vec::new();
+        for k in 0..num_inputs {
+            let arg = args[k + 1].clone();
+            if wrap_mask[k] {
+                let raw = match arg.as_ref() {
+                    ExpData::Call(_, Operation::Old, inner_args) if inner_args.len() == 1 => {
+                        inner_args[0].clone()
+                    },
+                    _ => arg.clone(),
+                };
+                if needs_post_state {
+                    post_state_clones.push(raw.clone());
+                }
+                if matches!(arg.as_ref(), ExpData::Call(_, Operation::Old, _)) {
+                    new_args.push(arg);
+                } else {
+                    let inner_ty = env.get_node_type(raw.node_id());
+                    let inner_id = env.new_node(env.get_node_loc(raw.node_id()), inner_ty);
+                    new_args.push(ExpData::Call(inner_id, Operation::Old, vec![raw]).into_exp());
+                }
+            } else {
+                new_args.push(arg);
+            }
+        }
+        if matches!(kind, BehaviorKind::EnsuresOf) {
+            for arg in args.iter().skip(1 + num_inputs) {
+                new_args.push(arg.clone());
+            }
+            new_args.extend(post_state_clones);
+        }
+        ExpData::Call(
+            *node_id,
+            Operation::Behavior(*kind, range.clone()),
+            new_args,
+        )
+        .into_exp()
+    }
 }
 
 impl<'a, T: ExpGenerator<'a>> ExpRewriterFunctions for SpecTranslator<'a, '_, T> {
     fn rewrite_exp(&mut self, exp: Exp) -> Exp {
+        // Bridge user-facing behavioral-predicate syntax to the canonical
+        // 3-arg form before descent, so that:
+        //   - mut-ref input args become `old(arg)` (triggering `save_param`
+        //     on the inner Temporary during descent), and
+        //   - `ensures_of`'s post-state slots (one per mut-ref input) are
+        //     present, populated by clones of the un-wrapped input args
+        //     (left untouched by save_param so they refer to the live,
+        //     post-call value of the reference at the wrapper's exit).
+        // Idempotent: skips wrapping for inputs already wrapped in `old`,
+        // and skips appending post-state clones if they're already present.
+        let exp = if let ExpData::Call(_, Operation::Behavior(_, _), _) = exp.as_ref() {
+            self.augment_behavior_call(&exp)
+        } else {
+            exp
+        };
+
         // Do some pre-processing of the expression before actual rewrite, reporting
         // errors.
         let env = self.builder.global_env();

--- a/third_party/move/move-prover/boogie-backend/src/spec_translator.rs
+++ b/third_party/move/move-prover/boogie-backend/src/spec_translator.rs
@@ -36,7 +36,7 @@ use move_model::{
     },
     pragmas::INTRINSIC_TYPE_MAP,
     symbol::Symbol,
-    ty::{PrimitiveType, Type},
+    ty::{PrimitiveType, ReferenceKind, Type},
     well_known::{TYPE_INFO_SPEC, TYPE_NAME_GET_SPEC, TYPE_NAME_SPEC, TYPE_SPEC_IS_STRUCT},
 };
 use move_prover_bytecode_pipeline::{
@@ -104,6 +104,12 @@ pub struct SpecTranslator<'env> {
     /// uses `..S |~` / `S.. |~` with `|&mut T|` closure parameters rather than
     /// global memory. Maps `MemoryLabel → (boogie_var_name, T)`.
     value_state_vars: RefCell<BTreeMap<MemoryLabel, (String, Type)>>,
+    /// True while translating the argument of a behavioral predicate
+    /// (`ensures_of` / `result_of` / etc.). In this context, a `&mut x.foo`
+    /// borrow expression is treated as a value-yielding selector rather than
+    /// a runtime borrow operation: the inner field path is translated and the
+    /// surrounding `in_old_context` flag selects pre- vs post-state.
+    in_behavior_pred_arg: RefCell<bool>,
 }
 
 /// A struct which contains information about a lifted choice expression (like `some x:int: p(x)`).
@@ -144,6 +150,7 @@ impl<'env> SpecTranslator<'env> {
             label_info: RefCell::new(BTreeMap::new()),
             declared_mem_names: RefCell::new(BTreeSet::new()),
             value_state_vars: RefCell::new(BTreeMap::new()),
+            in_behavior_pred_arg: RefCell::new(false),
         }
     }
 
@@ -1667,6 +1674,13 @@ impl SpecTranslator<'_> {
                     ),
                 );
             },
+            Operation::Borrow(ReferenceKind::Mutable) if *self.in_behavior_pred_arg.borrow() => {
+                // `&mut x.foo` (and similar selector chains) inside a behavioral
+                // predicate argument: drop the borrow wrapper and translate the
+                // inner expression. The enclosing `in_old_context` flag chooses
+                // pre- vs post-state of the selected field.
+                self.translate_exp(&args[0]);
+            },
             Operation::BorrowGlobal(_)
             | Operation::Borrow(..)
             | Operation::Deref
@@ -1683,8 +1697,23 @@ impl SpecTranslator<'_> {
         }
     }
 
+    /// Translate a behavioral-predicate argument expression. The
+    /// `in_behavior_pred_arg` flag enables special-case handling of
+    /// `&mut x.foo` selector borrows in the inner expression.
+    fn translate_behavior_arg(&self, arg: &Exp) {
+        let prev = self.in_behavior_pred_arg.replace(true);
+        self.translate_exp(arg);
+        self.in_behavior_pred_arg.replace(prev);
+    }
+
     /// Translate a behavioral predicate using the per-type evaluator dispatch function.
     /// Used for runtime function values (e.g., function-typed parameters after substitution).
+    ///
+    /// `pred_args` arrive in canonical 3-arg shape (input slots followed by
+    /// explicit-result + post-state slots for `EnsuresOf`). State-label
+    /// substitutions (`..S |~` and `S.. |~`) replace the post-state of the
+    /// *last* mut-ref param and the pre-state of the *first* mut-ref param,
+    /// respectively, matching the prior semantics for single-mut-ref closures.
     fn translate_behavior_via_evaluator(
         &self,
         node_id: NodeId,
@@ -1703,6 +1732,7 @@ impl SpecTranslator<'_> {
             emit!(self.writer, ", ");
         }
         self.translate_exp(fun_exp);
+
         // For value-typed state labels (|&mut T| closures with no global memory):
         // substitute the state variable S_val into the appropriate pred_arg position.
         //   ..S |~ ensures_of<f>(old_x, x)  →  ensures_of<f>(old_x, S_val)   [post label: replace last]
@@ -1741,9 +1771,24 @@ impl SpecTranslator<'_> {
                     continue;
                 }
             }
-            self.translate_exp(arg);
+            self.translate_behavior_arg(arg);
         }
         emit!(self.writer, ")");
+    }
+
+    /// Position of the first `&mut T` parameter in a function type — used by
+    /// the `S.. |~` state-label substitution path in
+    /// `translate_behavior_via_evaluator`.
+    fn find_mut_ref_input_position(fun_type: &Type) -> Option<usize> {
+        if let Type::Fun(arg_ty, _, _) = fun_type {
+            arg_ty
+                .clone()
+                .flatten()
+                .iter()
+                .position(|ty| ty.is_mutable_reference())
+        } else {
+            None
+        }
     }
 
     /// Emit memory arguments for an evaluator call by computing the memory union
@@ -1796,8 +1841,13 @@ impl SpecTranslator<'_> {
     }
 
     /// Translate a behavioral predicate for a closure expression.
-    /// Calls the per-function behavioral spec function directly, mapping
-    /// captured and non-captured args to the callee's parameter positions.
+    ///
+    /// Calls the per-function behavioral spec function (or `result_of` function)
+    /// directly. The `pred_args` arrive already augmented with the canonical
+    /// 3-arg shape produced by `translate_behavior_predicate` (and the
+    /// inference engine): input args wrapped in `old(...)` for `&mut`
+    /// parameters, then for `EnsuresOf`, the explicit-result args followed by
+    /// the (un-wrapped) post-state clones of each `&mut` input.
     #[allow(clippy::too_many_arguments)]
     fn translate_behavior_for_closure(
         &self,
@@ -1819,7 +1869,6 @@ impl SpecTranslator<'_> {
         let fun_env = self.env.get_function(fun_qid.to_qualified_id());
         let num_params = fun_env.get_parameter_count();
 
-        // Choose the function name based on kind
         let fun_name = if kind == BehaviorKind::ResultOf {
             let multi_result = fun_env.get_return_count()
                 + fun_env
@@ -1844,19 +1893,20 @@ impl SpecTranslator<'_> {
             }
             has_args = true;
             if mask.is_captured(i) {
-                self.translate_exp(&closure_args[captured_pos]);
+                self.translate_behavior_arg(&closure_args[captured_pos]);
                 captured_pos += 1;
             } else {
-                self.translate_exp(&pred_args[non_captured_pos]);
+                self.translate_behavior_arg(&pred_args[non_captured_pos]);
                 non_captured_pos += 1;
             }
         }
 
-        // For ensures_of: emit result args from remaining pred_args
+        // For `EnsuresOf`: emit result args + post-state slots from remaining
+        // pred_args (already in canonical order: explicit_results, post_states).
         if kind == BehaviorKind::EnsuresOf {
             for arg in &pred_args[non_captured_pos..] {
                 emit!(self.writer, ", ");
-                self.translate_exp(arg);
+                self.translate_behavior_arg(arg);
             }
         }
         emit!(self.writer, ")");
@@ -2739,21 +2789,6 @@ impl SpecTranslator<'_> {
             true
         });
         result
-    }
-
-    /// Returns the pred_arg index corresponding to the "old value" input of the first
-    /// `&mut T` parameter in a function type, for use in `S.. |~` substitution.
-    /// For `|&mut T|` this is 0; for `|A, &mut T|` this is 1; etc.
-    fn find_mut_ref_input_position(fun_type: &Type) -> Option<usize> {
-        if let Type::Fun(arg_ty, _, _) = fun_type {
-            arg_ty
-                .clone()
-                .flatten()
-                .iter()
-                .position(|ty| ty.is_mutable_reference())
-        } else {
-            None
-        }
     }
 
     fn translate_quant(

--- a/third_party/move/move-prover/bytecode-pipeline/src/spec_inference.rs
+++ b/third_party/move/move-prover/bytecode-pipeline/src/spec_inference.rs
@@ -3449,7 +3449,11 @@ impl<'env> SpecInferenceAnalyzer<'env> {
             state.add_ensures(ensures_of);
         } else if !any_dest_referenced {
             {
-                // Result discarded: emit ensures_of<f>(args, result_of<f>(args)...)
+                // Result discarded: emit `ensures_of<f>(args, result_of<f>(args)...)`.
+                // The trailing slots cover both explicit results and post-states of
+                // any `&mut` inputs — together they form the canonical ensures-of
+                // shape. The model-level rewriter (`augment_behavior_call`) leaves
+                // this canonical form unchanged.
                 let mut ensures_args = args.clone();
                 for i in 0..num_all_outputs {
                     ensures_args.push(self.mk_result_of_at_with_state(
@@ -3678,9 +3682,15 @@ impl<'env> SpecInferenceAnalyzer<'env> {
     }
 
     /// Build behavioral predicate arguments for a call site.
-    /// Direct `&mut` parameters must contribute their pre-state value because
-    /// inferred postconditions interpret the bare parameter name as the
-    /// post-state pointee value.
+    ///
+    /// `&mut` source temps are wrapped in `old(...)` so the inferred
+    /// expression captures the *pre-call* value. The wrapping is essential for
+    /// the WP substitution machinery: without it, substituting a `&mut` temp
+    /// during state propagation would replace its occurrences inside its own
+    /// `result_of` post-state expression, producing nested-loop garbage like
+    /// `result_of<f>(result_of<f>(...))`. With `old(...)`, the substitution
+    /// only fires for bare temps in the state (post-state references), while
+    /// pre-state references are preserved by `substitute_old_param_in_state`.
     fn mk_behavioral_call_args(&self, _state: &WPState, srcs: &[TempIndex]) -> Vec<Exp> {
         srcs.iter()
             .map(|&idx| {

--- a/third_party/move/move-prover/tests/inference/function_calls.exp.move
+++ b/third_party/move/move-prover/tests/inference/function_calls.exp.move
@@ -92,6 +92,7 @@ module 0x42::function_calls {
         }
     }
     spec factorial {
+        pragma verify = false; // timeout, but still can be inferred
         pragma opaque;
         ensures [inferred] n == 0 ==> result == 1;
         ensures [inferred] n != 0 ==> result == n * factorial(n - 1);

--- a/third_party/move/move-prover/tests/inference/function_calls.move
+++ b/third_party/move/move-prover/tests/inference/function_calls.move
@@ -58,6 +58,7 @@ module 0x42::function_calls {
         }
     }
     spec factorial {
+        pragma verify = false; // timeout, but still can be inferred
         pragma opaque;
     }
 

--- a/third_party/move/move-prover/tests/sources/functional/closures/behavioral_results.move
+++ b/third_party/move/move-prover/tests/sources/functional/closures/behavioral_results.move
@@ -43,60 +43,72 @@ module 0x42::behavioral_results {
     }
 
     // ===== Tests for mutable reference parameters =====
+    //
+    // The user passes `&mut T` arguments directly (no manual `old(...)`
+    // wrapping or explicit post-state args). The model-level rewriter wraps
+    // mut-ref inputs in `old(...)` and (for `ensures_of`) appends post-state
+    // clones automatically; the Boogie translator emits the canonical
+    // pre-state / explicit-result / post-state slots.
+    //
+    // `result_of<f>` keeps its full return shape: explicit results followed
+    // by post-state values of any `&mut` parameters.
 
     // Test 6: result_of with void function that has mutable ref param
     // f returns () but modifies x, so result_of returns just the modified value (not a tuple)
     fun apply_void_mut(f: |&mut u64|, x: &mut u64) { f(x) }
     spec apply_void_mut {
-        // result_of returns just the modified value (not a tuple since only one output)
-        ensures x == result_of<f>(old(x));
+        ensures x == result_of<f>(x);
     }
 
     // Test 7: ensures_of with mutable reference parameter
     fun test_ensures_mut(f: |&mut u64| u64, x: &mut u64): u64 { f(x) }
     spec test_ensures_mut {
-        // ensures_of takes (input_x, explicit_result, modified_x)
-        ensures ensures_of<f>(old(x), result, x);
+        ensures ensures_of<f>(x, result);
+    }
+
+    // Test 7b: same as Test 7 but with an explicit `old(...)` on the
+    // `&mut` arg. The augmenter must still add the post-state slot so
+    // the canonical form reaches Boogie with arity 4.
+    fun test_ensures_mut_old(f: |&mut u64| u64, x: &mut u64): u64 { f(x) }
+    spec test_ensures_mut_old {
+        ensures ensures_of<f>(old(x), result);
     }
 
     // Test 8: result_of with mut ref returning a value - using ensures_of to verify
-    // f returns a value AND modifies x, so result_of returns (explicit_result, modified_x) tuple
     fun apply_mut(f: |&mut u64| u64, x: &mut u64): u64 { f(x) }
     spec apply_mut {
-        // result_of returns (explicit_result, modified_x) tuple
-        // ensures_of takes (input_x, explicit_result, modified_x)
-        ensures ensures_of<f>(old(x), result, x);
+        ensures ensures_of<f>(x, result);
     }
 
     // Test 9: result_of with function returning value AND modifying &mut param
     // result_of returns (explicit_result, modified_x) tuple, compared via tuple equality
     fun apply_mut_result(f: |&mut u64| u64, x: &mut u64): u64 { f(x) }
     spec apply_mut_result {
-        ensures (result, x) == result_of<f>(old(x));
+        ensures (result, x) == result_of<f>(x);
     }
 
     // Test 10: result_of tuple with component extraction via let expression
     fun apply_mut_extract(f: |&mut u64| u64, x: &mut u64): u64 { f(x) }
     spec apply_mut_extract {
-        // Extract explicit return from the result tuple using expression-level let
-        ensures result == {let (r, p) = result_of<f>(old(x)); r};
-        // Extract &mut post-value from the result tuple
-        ensures x == {let (r, p) = result_of<f>(old(x)); p};
+        ensures result == {let (r, _p) = result_of<f>(x); r};
+        ensures x == {let (_r, p) = result_of<f>(x); p};
     }
 
     // Test 11: result_of with mixed return + &mut, using let to extract and use in expression
     fun apply_mut_arith(f: |&mut u64| u64, x: &mut u64): u64 { f(x) }
     spec apply_mut_arith {
-        // Use let expression to extract components and combine in arithmetic
-        ensures result + x == {let (r, p) = result_of<f>(old(x)); r + p};
+        ensures result + x == {let (r, p) = result_of<f>(x); r + p};
     }
 
-    // Test 12: result_of &mut value used in chained expression
-    // Closure f: |&mut u64| with void return, result_of returns single value
+    // Test 12: chained calls to a |&mut u64| closure expressed via state-label
+    // composition. `..S |~ ensures_of<f>(x)` says f transforms `old(x)` into
+    // the value at S; `S.. |~ ensures_of<f>(x)` says f transforms that value
+    // into the final `x`. The intermediate state S is bound by `exists S in *`.
     fun apply_twice(f: |&mut u64| has copy, x: &mut u64) { f(x); f(x) }
     spec apply_twice {
-        // Second call uses result of first as input
-        ensures x == result_of<f>(result_of<f>(old(x)));
+        ensures exists S in *:
+            (..S |~ ensures_of<f>(x)) &&
+            (S.. |~ ensures_of<f>(x));
     }
 
 }

--- a/third_party/move/move-prover/tests/sources/functional/closures/bp_mut_ref_selector.move
+++ b/third_party/move/move-prover/tests/sources/functional/closures/bp_mut_ref_selector.move
@@ -1,0 +1,30 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+// Tests `&mut x.foo` selector arguments for behavioral predicates.
+// The Boogie translator's spec rewriter peels the outer `Borrow(Mutable)`
+// when the expression appears in a behavioral-predicate argument position,
+// so the selector resolves to the field's pre/post value as needed.
+
+module 0x42::bp_mut_ref_selector {
+    struct Point has copy, drop {
+        x: u64,
+        y: u64,
+    }
+
+    // Apply `f` to a field of `p` via a `&mut` field borrow.
+    fun apply_to_x(f: |&mut u64|, p: &mut Point) { f(&mut p.x) }
+    spec apply_to_x {
+        // The post-state of `p.x` equals f's post-state of its &mut argument
+        // applied to the pre-state of `p.x`.
+        ensures p.x == result_of<f>(&mut p.x);
+        // p.y is unchanged by the call.
+        ensures p.y == old(p).y;
+    }
+
+    // Combined with explicit returns.
+    fun apply_to_x_returning(f: |&mut u64| u64, p: &mut Point): u64 { f(&mut p.x) }
+    spec apply_to_x_returning {
+        ensures ensures_of<f>(&mut p.x, result);
+    }
+}

--- a/third_party/move/move-prover/tests/sources/functional/state_labels/followed_by_mut_ref.move
+++ b/third_party/move/move-prover/tests/sources/functional/state_labels/followed_by_mut_ref.move
@@ -30,7 +30,7 @@ module 0x42::followed_by_mut_ref {
     }
     spec followed_by {
         ensures exists S in *:
-            (..S |~ ensures_of<f>(old(x), x)) &&
-            (S.. |~ ensures_of<g>(old(x), x));
+            (..S |~ ensures_of<f>(x)) &&
+            (S.. |~ ensures_of<g>(x));
     }
 }

--- a/third_party/move/move-stdlib/docs/ascii.md
+++ b/third_party/move/move-stdlib/docs/ascii.md
@@ -1,7 +1,4 @@
-
-<a id="0x1_ascii"></a>
-
-# Module `0x1::ascii`
+# Module `0x1::ascii` <a id="0x1_ascii"></a>
 
 The <code>ASCII</code> module defines basic string and char newtypes in Move that verify
 that characters are valid ASCII, and that strings consist of only valid ASCII characters.
@@ -28,10 +25,7 @@ that characters are valid ASCII, and that strings consist of only valid ASCII ch
 </code></pre>
 
 
-
-<a id="0x1_ascii_String"></a>
-
-## Struct `String`
+## Struct `String` <a id="0x1_ascii_String"></a>
 
 The <code><a href="ascii.md#0x1_ascii_String">String</a></code> struct holds a vector of bytes that all represent
 valid ASCII characters. Note that these ASCII characters may not all
@@ -61,6 +55,7 @@ defined in this module.
 
 </details>
 
+
 <details>
 <summary>Specification</summary>
 
@@ -73,9 +68,7 @@ defined in this module.
 
 </details>
 
-<a id="0x1_ascii_Char"></a>
-
-## Struct `Char`
+## Struct `Char` <a id="0x1_ascii_Char"></a>
 
 An ASCII character.
 
@@ -101,6 +94,7 @@ An ASCII character.
 
 </details>
 
+
 <details>
 <summary>Specification</summary>
 
@@ -113,9 +107,7 @@ An ASCII character.
 
 </details>
 
-<a id="@Constants_0"></a>
-
-## Constants
+## Constants <a id="@Constants_0"></a>
 
 
 <a id="0x1_ascii_EINVALID_ASCII_CHARACTER"></a>
@@ -127,10 +119,7 @@ An invalid ASCII character was encountered when creating an ASCII string.
 </code></pre>
 
 
-
-<a id="0x1_ascii_char"></a>
-
-## Function `char`
+## Function `char` <a id="0x1_ascii_char"></a>
 
 Convert a <code>byte</code> into a <code><a href="ascii.md#0x1_ascii_Char">Char</a></code> that is checked to make sure it is valid ASCII.
 
@@ -154,6 +143,7 @@ Convert a <code>byte</code> into a <code><a href="ascii.md#0x1_ascii_Char">Char<
 
 </details>
 
+
 <details>
 <summary>Specification</summary>
 
@@ -166,9 +156,7 @@ Convert a <code>byte</code> into a <code><a href="ascii.md#0x1_ascii_Char">Char<
 
 </details>
 
-<a id="0x1_ascii_string"></a>
-
-## Function `string`
+## Function `string` <a id="0x1_ascii_string"></a>
 
 Convert a vector of bytes <code>bytes</code> into an <code><a href="ascii.md#0x1_ascii_String">String</a></code>. Aborts if
 <code>bytes</code> contains non-ASCII characters.
@@ -197,6 +185,7 @@ Convert a vector of bytes <code>bytes</code> into an <code><a href="ascii.md#0x1
 
 </details>
 
+
 <details>
 <summary>Specification</summary>
 
@@ -209,9 +198,7 @@ Convert a vector of bytes <code>bytes</code> into an <code><a href="ascii.md#0x1
 
 </details>
 
-<a id="0x1_ascii_try_string"></a>
-
-## Function `try_string`
+## Function `try_string` <a id="0x1_ascii_try_string"></a>
 
 Convert a vector of bytes <code>bytes</code> into an <code><a href="ascii.md#0x1_ascii_String">String</a></code>. Returns
 <code>Some(&lt;ascii_string&gt;)</code> if the <code>bytes</code> contains all valid ASCII
@@ -253,9 +240,7 @@ characters. Otherwise returns <code>None</code>.
 
 </details>
 
-<a id="0x1_ascii_all_characters_printable"></a>
-
-## Function `all_characters_printable`
+## Function `all_characters_printable` <a id="0x1_ascii_all_characters_printable"></a>
 
 Returns <code><b>true</b></code> if all characters in <code><a href="string.md#0x1_string">string</a></code> are printable characters
 Returns <code><b>false</b></code> otherwise. Not all <code><a href="ascii.md#0x1_ascii_String">String</a></code>s are printable strings.
@@ -296,6 +281,7 @@ Returns <code><b>false</b></code> otherwise. Not all <code><a href="ascii.md#0x1
 
 </details>
 
+
 <details>
 <summary>Specification</summary>
 
@@ -308,9 +294,7 @@ Returns <code><b>false</b></code> otherwise. Not all <code><a href="ascii.md#0x1
 
 </details>
 
-<a id="0x1_ascii_push_char"></a>
-
-## Function `push_char`
+## Function `push_char` <a id="0x1_ascii_push_char"></a>
 
 
 
@@ -332,6 +316,7 @@ Returns <code><b>false</b></code> otherwise. Not all <code><a href="ascii.md#0x1
 
 </details>
 
+
 <details>
 <summary>Specification</summary>
 
@@ -344,9 +329,7 @@ Returns <code><b>false</b></code> otherwise. Not all <code><a href="ascii.md#0x1
 
 </details>
 
-<a id="0x1_ascii_pop_char"></a>
-
-## Function `pop_char`
+## Function `pop_char` <a id="0x1_ascii_pop_char"></a>
 
 
 
@@ -368,6 +351,7 @@ Returns <code><b>false</b></code> otherwise. Not all <code><a href="ascii.md#0x1
 
 </details>
 
+
 <details>
 <summary>Specification</summary>
 
@@ -380,9 +364,7 @@ Returns <code><b>false</b></code> otherwise. Not all <code><a href="ascii.md#0x1
 
 </details>
 
-<a id="0x1_ascii_length"></a>
-
-## Function `length`
+## Function `length` <a id="0x1_ascii_length"></a>
 
 
 
@@ -404,9 +386,7 @@ Returns <code><b>false</b></code> otherwise. Not all <code><a href="ascii.md#0x1
 
 </details>
 
-<a id="0x1_ascii_as_bytes"></a>
-
-## Function `as_bytes`
+## Function `as_bytes` <a id="0x1_ascii_as_bytes"></a>
 
 Get the inner bytes of the <code><a href="string.md#0x1_string">string</a></code> as a reference
 
@@ -429,9 +409,7 @@ Get the inner bytes of the <code><a href="string.md#0x1_string">string</a></code
 
 </details>
 
-<a id="0x1_ascii_into_bytes"></a>
-
-## Function `into_bytes`
+## Function `into_bytes` <a id="0x1_ascii_into_bytes"></a>
 
 Unpack the <code><a href="string.md#0x1_string">string</a></code> to get its backing bytes
 
@@ -455,9 +433,7 @@ Unpack the <code><a href="string.md#0x1_string">string</a></code> to get its bac
 
 </details>
 
-<a id="0x1_ascii_byte"></a>
-
-## Function `byte`
+## Function `byte` <a id="0x1_ascii_byte"></a>
 
 Unpack the <code>char</code> into its underlying byte.
 
@@ -481,9 +457,7 @@ Unpack the <code>char</code> into its underlying byte.
 
 </details>
 
-<a id="0x1_ascii_is_valid_char"></a>
-
-## Function `is_valid_char`
+## Function `is_valid_char` <a id="0x1_ascii_is_valid_char"></a>
 
 Returns <code><b>true</b></code> if <code>b</code> is a valid ASCII character. Returns <code><b>false</b></code> otherwise.
 
@@ -506,9 +480,7 @@ Returns <code><b>true</b></code> if <code>b</code> is a valid ASCII character. R
 
 </details>
 
-<a id="0x1_ascii_is_printable_char"></a>
-
-## Function `is_printable_char`
+## Function `is_printable_char` <a id="0x1_ascii_is_printable_char"></a>
 
 Returns <code><b>true</b></code> if <code>byte</code> is an printable ASCII character. Returns <code><b>false</b></code> otherwise.
 

--- a/third_party/move/move-stdlib/docs/bcs.md
+++ b/third_party/move/move-stdlib/docs/bcs.md
@@ -1,7 +1,4 @@
-
-<a id="0x1_bcs"></a>
-
-# Module `0x1::bcs`
+# Module `0x1::bcs` <a id="0x1_bcs"></a>
 
 Utility for converting a Move value to its binary representation in BCS (Binary Canonical
 Serialization). BCS is the binary encoding for Move resources and other non-module values
@@ -16,10 +13,7 @@ details on BCS.
 <pre><code></code></pre>
 
 
-
-<a id="0x1_bcs_to_bytes"></a>
-
-## Function `to_bytes`
+## Function `to_bytes` <a id="0x1_bcs_to_bytes"></a>
 
 Return the binary representation of <code>v</code> in BCS (Binary Canonical Serialization) format
 
@@ -40,9 +34,7 @@ Return the binary representation of <code>v</code> in BCS (Binary Canonical Seri
 
 </details>
 
-<a id="@Module_Specification_0"></a>
-
-## Module Specification
+## Module Specification <a id="@Module_Specification_0"></a>
 
 
 

--- a/third_party/move/move-stdlib/docs/bit_vector.md
+++ b/third_party/move/move-stdlib/docs/bit_vector.md
@@ -1,7 +1,4 @@
-
-<a id="0x1_bit_vector"></a>
-
-# Module `0x1::bit_vector`
+# Module `0x1::bit_vector` <a id="0x1_bit_vector"></a>
 
 
 
@@ -19,10 +16,7 @@
 <pre><code></code></pre>
 
 
-
-<a id="0x1_bit_vector_BitVector"></a>
-
-## Struct `BitVector`
+## Struct `BitVector` <a id="0x1_bit_vector_BitVector"></a>
 
 
 
@@ -53,9 +47,7 @@
 
 </details>
 
-<a id="@Constants_0"></a>
-
-## Constants
+## Constants <a id="@Constants_0"></a>
 
 
 <a id="0x1_bit_vector_EINDEX"></a>
@@ -96,10 +88,7 @@ The maximum allowed bitvector size
 </code></pre>
 
 
-
-<a id="0x1_bit_vector_new"></a>
-
-## Function `new`
+## Function `new` <a id="0x1_bit_vector_new"></a>
 
 
 
@@ -141,6 +130,7 @@ The maximum allowed bitvector size
 
 </details>
 
+
 <details>
 <summary>Specification</summary>
 
@@ -168,9 +158,7 @@ The maximum allowed bitvector size
 
 </details>
 
-<a id="0x1_bit_vector_set"></a>
-
-## Function `set`
+## Function `set` <a id="0x1_bit_vector_set"></a>
 
 Set the bit at <code>bit_index</code> in the <code>bitvector</code> regardless of its previous state.
 
@@ -194,6 +182,7 @@ Set the bit at <code>bit_index</code> in the <code>bitvector</code> regardless o
 
 
 </details>
+
 
 <details>
 <summary>Specification</summary>
@@ -221,9 +210,7 @@ Set the bit at <code>bit_index</code> in the <code>bitvector</code> regardless o
 
 </details>
 
-<a id="0x1_bit_vector_unset"></a>
-
-## Function `unset`
+## Function `unset` <a id="0x1_bit_vector_unset"></a>
 
 Unset the bit at <code>bit_index</code> in the <code>bitvector</code> regardless of its previous state.
 
@@ -247,6 +234,7 @@ Unset the bit at <code>bit_index</code> in the <code>bitvector</code> regardless
 
 
 </details>
+
 
 <details>
 <summary>Specification</summary>
@@ -274,9 +262,7 @@ Unset the bit at <code>bit_index</code> in the <code>bitvector</code> regardless
 
 </details>
 
-<a id="0x1_bit_vector_shift_left"></a>
-
-## Function `shift_left`
+## Function `shift_left` <a id="0x1_bit_vector_shift_left"></a>
 
 Shift the <code>bitvector</code> left by <code>amount</code>. If <code>amount</code> is greater than the
 bitvector's length the bitvector will be zeroed out.
@@ -323,9 +309,7 @@ bitvector's length the bitvector will be zeroed out.
 
 </details>
 
-<a id="0x1_bit_vector_is_index_set"></a>
-
-## Function `is_index_set`
+## Function `is_index_set` <a id="0x1_bit_vector_is_index_set"></a>
 
 Return the value of the bit at <code>bit_index</code> in the <code>bitvector</code>. <code><b>true</b></code>
 represents "1" and <code><b>false</b></code> represents a 0
@@ -349,6 +333,7 @@ represents "1" and <code><b>false</b></code> represents a 0
 
 
 </details>
+
 
 <details>
 <summary>Specification</summary>
@@ -391,9 +376,7 @@ represents "1" and <code><b>false</b></code> represents a 0
 
 </details>
 
-<a id="0x1_bit_vector_length"></a>
-
-## Function `length`
+## Function `length` <a id="0x1_bit_vector_length"></a>
 
 Return the length (number of usable bits) of this bitvector
 
@@ -416,9 +399,7 @@ Return the length (number of usable bits) of this bitvector
 
 </details>
 
-<a id="0x1_bit_vector_longest_set_sequence_starting_at"></a>
-
-## Function `longest_set_sequence_starting_at`
+## Function `longest_set_sequence_starting_at` <a id="0x1_bit_vector_longest_set_sequence_starting_at"></a>
 
 Returns the length of the longest sequence of set bits starting at (and
 including) <code>start_index</code> in the <code>bitvector</code>. If there is no such

--- a/third_party/move/move-stdlib/docs/error.md
+++ b/third_party/move/move-stdlib/docs/error.md
@@ -1,7 +1,4 @@
-
-<a id="0x1_error"></a>
-
-# Module `0x1::error`
+# Module `0x1::error` <a id="0x1_error"></a>
 
 This module defines a set of canonical error codes which are optional to use by applications for the
 <code><b>abort</b></code> and <code><b>assert</b>!</code> features.
@@ -45,10 +42,7 @@ error codes here are a bit richer than HTTP codes.
 <pre><code></code></pre>
 
 
-
-<a id="@Constants_0"></a>
-
-## Constants
+## Constants <a id="@Constants_0"></a>
 
 
 <a id="0x1_error_ABORTED"></a>
@@ -180,10 +174,7 @@ The service is currently unavailable. Indicates that a retry could solve the iss
 </code></pre>
 
 
-
-<a id="0x1_error_canonical"></a>
-
-## Function `canonical`
+## Function `canonical` <a id="0x1_error_canonical"></a>
 
 Construct a canonical error code from a category and a reason.
 
@@ -206,9 +197,7 @@ Construct a canonical error code from a category and a reason.
 
 </details>
 
-<a id="0x1_error_invalid_argument"></a>
-
-## Function `invalid_argument`
+## Function `invalid_argument` <a id="0x1_error_invalid_argument"></a>
 
 Functions to construct a canonical error code of the given category.
 
@@ -229,9 +218,7 @@ Functions to construct a canonical error code of the given category.
 
 </details>
 
-<a id="0x1_error_out_of_range"></a>
-
-## Function `out_of_range`
+## Function `out_of_range` <a id="0x1_error_out_of_range"></a>
 
 
 
@@ -251,9 +238,7 @@ Functions to construct a canonical error code of the given category.
 
 </details>
 
-<a id="0x1_error_invalid_state"></a>
-
-## Function `invalid_state`
+## Function `invalid_state` <a id="0x1_error_invalid_state"></a>
 
 
 
@@ -273,9 +258,7 @@ Functions to construct a canonical error code of the given category.
 
 </details>
 
-<a id="0x1_error_unauthenticated"></a>
-
-## Function `unauthenticated`
+## Function `unauthenticated` <a id="0x1_error_unauthenticated"></a>
 
 
 
@@ -295,9 +278,7 @@ Functions to construct a canonical error code of the given category.
 
 </details>
 
-<a id="0x1_error_permission_denied"></a>
-
-## Function `permission_denied`
+## Function `permission_denied` <a id="0x1_error_permission_denied"></a>
 
 
 
@@ -317,9 +298,7 @@ Functions to construct a canonical error code of the given category.
 
 </details>
 
-<a id="0x1_error_not_found"></a>
-
-## Function `not_found`
+## Function `not_found` <a id="0x1_error_not_found"></a>
 
 
 
@@ -339,9 +318,7 @@ Functions to construct a canonical error code of the given category.
 
 </details>
 
-<a id="0x1_error_aborted"></a>
-
-## Function `aborted`
+## Function `aborted` <a id="0x1_error_aborted"></a>
 
 
 
@@ -361,9 +338,7 @@ Functions to construct a canonical error code of the given category.
 
 </details>
 
-<a id="0x1_error_already_exists"></a>
-
-## Function `already_exists`
+## Function `already_exists` <a id="0x1_error_already_exists"></a>
 
 
 
@@ -383,9 +358,7 @@ Functions to construct a canonical error code of the given category.
 
 </details>
 
-<a id="0x1_error_resource_exhausted"></a>
-
-## Function `resource_exhausted`
+## Function `resource_exhausted` <a id="0x1_error_resource_exhausted"></a>
 
 
 
@@ -405,9 +378,7 @@ Functions to construct a canonical error code of the given category.
 
 </details>
 
-<a id="0x1_error_internal"></a>
-
-## Function `internal`
+## Function `internal` <a id="0x1_error_internal"></a>
 
 
 
@@ -427,9 +398,7 @@ Functions to construct a canonical error code of the given category.
 
 </details>
 
-<a id="0x1_error_not_implemented"></a>
-
-## Function `not_implemented`
+## Function `not_implemented` <a id="0x1_error_not_implemented"></a>
 
 
 
@@ -449,9 +418,7 @@ Functions to construct a canonical error code of the given category.
 
 </details>
 
-<a id="0x1_error_unavailable"></a>
-
-## Function `unavailable`
+## Function `unavailable` <a id="0x1_error_unavailable"></a>
 
 
 

--- a/third_party/move/move-stdlib/docs/fixed_point32.md
+++ b/third_party/move/move-stdlib/docs/fixed_point32.md
@@ -1,7 +1,4 @@
-
-<a id="0x1_fixed_point32"></a>
-
-# Module `0x1::fixed_point32`
+# Module `0x1::fixed_point32` <a id="0x1_fixed_point32"></a>
 
 Defines a fixed-point numeric type with a 32-bit integer part and
 a 32-bit fractional part.
@@ -27,10 +24,7 @@ a 32-bit fractional part.
 <pre><code></code></pre>
 
 
-
-<a id="0x1_fixed_point32_FixedPoint32"></a>
-
-## Struct `FixedPoint32`
+## Struct `FixedPoint32` <a id="0x1_fixed_point32_FixedPoint32"></a>
 
 Define a fixed-point numeric type with 32 fractional bits.
 This is just a u64 integer but it is wrapped in a struct to
@@ -64,9 +58,7 @@ decimal.
 
 </details>
 
-<a id="@Constants_0"></a>
-
-## Constants
+## Constants <a id="@Constants_0"></a>
 
 
 <a id="0x1_fixed_point32_MAX_U64"></a>
@@ -128,10 +120,7 @@ The computed ratio when converting to a <code><a href="fixed_point32.md#0x1_fixe
 </code></pre>
 
 
-
-<a id="0x1_fixed_point32_multiply_u64"></a>
-
-## Function `multiply_u64`
+## Function `multiply_u64` <a id="0x1_fixed_point32_multiply_u64"></a>
 
 Multiply a u64 integer by a fixed-point number, truncating any
 fractional part of the product. This will abort if the product
@@ -164,6 +153,7 @@ overflows.
 
 
 </details>
+
 
 <details>
 <summary>Specification</summary>
@@ -203,9 +193,7 @@ overflows.
 
 </details>
 
-<a id="0x1_fixed_point32_divide_u64"></a>
-
-## Function `divide_u64`
+## Function `divide_u64` <a id="0x1_fixed_point32_divide_u64"></a>
 
 Divide a u64 integer by a fixed-point number, truncating any
 fractional part of the quotient. This will abort if the divisor
@@ -239,6 +227,7 @@ is zero or if the quotient overflows.
 
 
 </details>
+
 
 <details>
 <summary>Specification</summary>
@@ -279,9 +268,7 @@ is zero or if the quotient overflows.
 
 </details>
 
-<a id="0x1_fixed_point32_create_from_rational"></a>
-
-## Function `create_from_rational`
+## Function `create_from_rational` <a id="0x1_fixed_point32_create_from_rational"></a>
 
 Create a fixed-point value from a rational number specified by its
 numerator and denominator. Calling this function should be preferred
@@ -324,6 +311,7 @@ rounding, e.g., 0.0125 will round down to 0.012 instead of up to 0.013.
 
 
 </details>
+
 
 <details>
 <summary>Specification</summary>
@@ -369,9 +357,7 @@ rounding, e.g., 0.0125 will round down to 0.012 instead of up to 0.013.
 
 </details>
 
-<a id="0x1_fixed_point32_create_from_raw_value"></a>
-
-## Function `create_from_raw_value`
+## Function `create_from_raw_value` <a id="0x1_fixed_point32_create_from_raw_value"></a>
 
 Create a fixedpoint value from a raw value.
 
@@ -394,6 +380,7 @@ Create a fixedpoint value from a raw value.
 
 </details>
 
+
 <details>
 <summary>Specification</summary>
 
@@ -408,9 +395,7 @@ Create a fixedpoint value from a raw value.
 
 </details>
 
-<a id="0x1_fixed_point32_get_raw_value"></a>
-
-## Function `get_raw_value`
+## Function `get_raw_value` <a id="0x1_fixed_point32_get_raw_value"></a>
 
 Accessor for the raw u64 value. Other less common operations, such as
 adding or subtracting FixedPoint32 values, can be done using the raw
@@ -435,9 +420,7 @@ values directly.
 
 </details>
 
-<a id="0x1_fixed_point32_is_zero"></a>
-
-## Function `is_zero`
+## Function `is_zero` <a id="0x1_fixed_point32_is_zero"></a>
 
 Returns true if the ratio is zero.
 
@@ -460,9 +443,7 @@ Returns true if the ratio is zero.
 
 </details>
 
-<a id="0x1_fixed_point32_min"></a>
-
-## Function `min`
+## Function `min` <a id="0x1_fixed_point32_min"></a>
 
 Returns the smaller of the two FixedPoint32 numbers.
 
@@ -488,6 +469,7 @@ Returns the smaller of the two FixedPoint32 numbers.
 
 
 </details>
+
 
 <details>
 <summary>Specification</summary>
@@ -518,9 +500,7 @@ Returns the smaller of the two FixedPoint32 numbers.
 
 </details>
 
-<a id="0x1_fixed_point32_max"></a>
-
-## Function `max`
+## Function `max` <a id="0x1_fixed_point32_max"></a>
 
 Returns the larger of the two FixedPoint32 numbers.
 
@@ -546,6 +526,7 @@ Returns the larger of the two FixedPoint32 numbers.
 
 
 </details>
+
 
 <details>
 <summary>Specification</summary>
@@ -576,9 +557,7 @@ Returns the larger of the two FixedPoint32 numbers.
 
 </details>
 
-<a id="0x1_fixed_point32_create_from_u64"></a>
-
-## Function `create_from_u64`
+## Function `create_from_u64` <a id="0x1_fixed_point32_create_from_u64"></a>
 
 Create a fixedpoint value from a u64 value.
 
@@ -602,6 +581,7 @@ Create a fixedpoint value from a u64 value.
 
 
 </details>
+
 
 <details>
 <summary>Specification</summary>
@@ -641,9 +621,7 @@ Create a fixedpoint value from a u64 value.
 
 </details>
 
-<a id="0x1_fixed_point32_floor"></a>
-
-## Function `floor`
+## Function `floor` <a id="0x1_fixed_point32_floor"></a>
 
 Returns the largest integer less than or equal to a given number.
 
@@ -665,6 +643,7 @@ Returns the largest integer less than or equal to a given number.
 
 
 </details>
+
 
 <details>
 <summary>Specification</summary>
@@ -696,9 +675,7 @@ Returns the largest integer less than or equal to a given number.
 
 </details>
 
-<a id="0x1_fixed_point32_ceil"></a>
-
-## Function `ceil`
+## Function `ceil` <a id="0x1_fixed_point32_ceil"></a>
 
 Rounds up the given FixedPoint32 to the next largest integer.
 
@@ -725,6 +702,7 @@ Rounds up the given FixedPoint32 to the next largest integer.
 
 
 </details>
+
 
 <details>
 <summary>Specification</summary>
@@ -758,9 +736,7 @@ Rounds up the given FixedPoint32 to the next largest integer.
 
 </details>
 
-<a id="0x1_fixed_point32_round"></a>
-
-## Function `round`
+## Function `round` <a id="0x1_fixed_point32_round"></a>
 
 Returns the value of a FixedPoint32 to the nearest integer.
 
@@ -788,6 +764,7 @@ Returns the value of a FixedPoint32 to the nearest integer.
 
 
 </details>
+
 
 <details>
 <summary>Specification</summary>
@@ -822,9 +799,7 @@ Returns the value of a FixedPoint32 to the nearest integer.
 
 </details>
 
-<a id="@Module_Specification_1"></a>
-
-## Module Specification
+## Module Specification <a id="@Module_Specification_1"></a>
 
 
 

--- a/third_party/move/move-stdlib/docs/hash.md
+++ b/third_party/move/move-stdlib/docs/hash.md
@@ -1,7 +1,4 @@
-
-<a id="0x1_hash"></a>
-
-# Module `0x1::hash`
+# Module `0x1::hash` <a id="0x1_hash"></a>
 
 Module which defines SHA hashes for byte vectors.
 
@@ -16,10 +13,7 @@ as in the Move prover's prelude.
 <pre><code></code></pre>
 
 
-
-<a id="0x1_hash_sha2_256"></a>
-
-## Function `sha2_256`
+## Function `sha2_256` <a id="0x1_hash_sha2_256"></a>
 
 
 
@@ -39,9 +33,7 @@ as in the Move prover's prelude.
 
 </details>
 
-<a id="0x1_hash_sha3_256"></a>
-
-## Function `sha3_256`
+## Function `sha3_256` <a id="0x1_hash_sha3_256"></a>
 
 
 
@@ -60,6 +52,7 @@ as in the Move prover's prelude.
 
 
 </details>
+
 
 <details>
 <summary>Specification</summary>

--- a/third_party/move/move-stdlib/docs/option.md
+++ b/third_party/move/move-stdlib/docs/option.md
@@ -1,7 +1,4 @@
-
-<a id="0x1_option"></a>
-
-# Module `0x1::option`
+# Module `0x1::option` <a id="0x1_option"></a>
 
 This module defines the Option type and its methods to represent and handle an optional value.
 
@@ -39,10 +36,7 @@ This module defines the Option type and its methods to represent and handle an o
 </code></pre>
 
 
-
-<a id="0x1_option_Option"></a>
-
-## Struct `Option`
+## Struct `Option` <a id="0x1_option_Option"></a>
 
 Abstraction of a value that may or may not be present. Implemented with a vector of size
 zero or one because Move bytecode does not have ADTs.
@@ -69,6 +63,7 @@ zero or one because Move bytecode does not have ADTs.
 
 </details>
 
+
 <details>
 <summary>Specification</summary>
 
@@ -84,9 +79,7 @@ because it's 0 for "none" or 1 for "some".
 
 </details>
 
-<a id="@Constants_0"></a>
-
-## Constants
+## Constants <a id="@Constants_0"></a>
 
 
 <a id="0x1_option_EOPTION_IS_SET"></a>
@@ -110,10 +103,7 @@ The <code><a href="option.md#0x1_option_Option">Option</a></code> is <code>None<
 </code></pre>
 
 
-
-<a id="0x1_option_none"></a>
-
-## Function `none`
+## Function `none` <a id="0x1_option_none"></a>
 
 Return an empty <code><a href="option.md#0x1_option_Option">Option</a></code>
 
@@ -135,6 +125,7 @@ Return an empty <code><a href="option.md#0x1_option_Option">Option</a></code>
 
 
 </details>
+
 
 <details>
 <summary>Specification</summary>
@@ -161,9 +152,7 @@ Return an empty <code><a href="option.md#0x1_option_Option">Option</a></code>
 
 </details>
 
-<a id="0x1_option_some"></a>
-
-## Function `some`
+## Function `some` <a id="0x1_option_some"></a>
 
 Return an <code><a href="option.md#0x1_option_Option">Option</a></code> containing <code>e</code>
 
@@ -185,6 +174,7 @@ Return an <code><a href="option.md#0x1_option_Option">Option</a></code> containi
 
 
 </details>
+
 
 <details>
 <summary>Specification</summary>
@@ -211,9 +201,7 @@ Return an <code><a href="option.md#0x1_option_Option">Option</a></code> containi
 
 </details>
 
-<a id="0x1_option_is_none"></a>
-
-## Function `is_none`
+## Function `is_none` <a id="0x1_option_is_none"></a>
 
 Return true if <code>t</code> does not hold a value
 
@@ -236,6 +224,7 @@ Return true if <code>t</code> does not hold a value
 
 </details>
 
+
 <details>
 <summary>Specification</summary>
 
@@ -250,9 +239,7 @@ Return true if <code>t</code> does not hold a value
 
 </details>
 
-<a id="0x1_option_is_some"></a>
-
-## Function `is_some`
+## Function `is_some` <a id="0x1_option_is_some"></a>
 
 Return true if <code>t</code> holds a value
 
@@ -275,6 +262,7 @@ Return true if <code>t</code> holds a value
 
 </details>
 
+
 <details>
 <summary>Specification</summary>
 
@@ -289,9 +277,7 @@ Return true if <code>t</code> holds a value
 
 </details>
 
-<a id="0x1_option_contains"></a>
-
-## Function `contains`
+## Function `contains` <a id="0x1_option_contains"></a>
 
 Return true if the value in <code>t</code> is equal to <code>e_ref</code>
 Always returns <code><b>false</b></code> if <code>t</code> does not hold a value
@@ -314,6 +300,7 @@ Always returns <code><b>false</b></code> if <code>t</code> does not hold a value
 
 
 </details>
+
 
 <details>
 <summary>Specification</summary>
@@ -340,9 +327,7 @@ Always returns <code><b>false</b></code> if <code>t</code> does not hold a value
 
 </details>
 
-<a id="0x1_option_borrow"></a>
-
-## Function `borrow`
+## Function `borrow` <a id="0x1_option_borrow"></a>
 
 Return an immutable reference to the value inside <code>t</code>
 Aborts if <code>t</code> does not hold a value
@@ -367,6 +352,7 @@ Aborts if <code>t</code> does not hold a value
 
 </details>
 
+
 <details>
 <summary>Specification</summary>
 
@@ -381,9 +367,7 @@ Aborts if <code>t</code> does not hold a value
 
 </details>
 
-<a id="0x1_option_borrow_with_default"></a>
-
-## Function `borrow_with_default`
+## Function `borrow_with_default` <a id="0x1_option_borrow_with_default"></a>
 
 Return a reference to the value inside <code>t</code> if it holds one
 Return <code>default_ref</code> if <code>t</code> does not hold a value
@@ -409,6 +393,7 @@ Return <code>default_ref</code> if <code>t</code> does not hold a value
 
 </details>
 
+
 <details>
 <summary>Specification</summary>
 
@@ -423,9 +408,7 @@ Return <code>default_ref</code> if <code>t</code> does not hold a value
 
 </details>
 
-<a id="0x1_option_get_with_default"></a>
-
-## Function `get_with_default`
+## Function `get_with_default` <a id="0x1_option_get_with_default"></a>
 
 Return the value inside <code>t</code> if it holds one
 Return <code>default</code> if <code>t</code> does not hold a value
@@ -454,6 +437,7 @@ Return <code>default</code> if <code>t</code> does not hold a value
 
 </details>
 
+
 <details>
 <summary>Specification</summary>
 
@@ -468,9 +452,7 @@ Return <code>default</code> if <code>t</code> does not hold a value
 
 </details>
 
-<a id="0x1_option_fill"></a>
-
-## Function `fill`
+## Function `fill` <a id="0x1_option_fill"></a>
 
 Convert the none option <code>t</code> to a some option by adding <code>e</code>.
 Aborts if <code>t</code> already holds a value
@@ -496,6 +478,7 @@ Aborts if <code>t</code> already holds a value
 
 </details>
 
+
 <details>
 <summary>Specification</summary>
 
@@ -511,9 +494,7 @@ Aborts if <code>t</code> already holds a value
 
 </details>
 
-<a id="0x1_option_extract"></a>
-
-## Function `extract`
+## Function `extract` <a id="0x1_option_extract"></a>
 
 Convert a <code>some</code> option to a <code>none</code> by removing and returning the value stored inside <code>t</code>
 Aborts if <code>t</code> does not hold a value
@@ -538,6 +519,7 @@ Aborts if <code>t</code> does not hold a value
 
 </details>
 
+
 <details>
 <summary>Specification</summary>
 
@@ -553,9 +535,7 @@ Aborts if <code>t</code> does not hold a value
 
 </details>
 
-<a id="0x1_option_borrow_mut"></a>
-
-## Function `borrow_mut`
+## Function `borrow_mut` <a id="0x1_option_borrow_mut"></a>
 
 Return a mutable reference to the value inside <code>t</code>
 Aborts if <code>t</code> does not hold a value
@@ -580,6 +560,7 @@ Aborts if <code>t</code> does not hold a value
 
 </details>
 
+
 <details>
 <summary>Specification</summary>
 
@@ -595,9 +576,7 @@ Aborts if <code>t</code> does not hold a value
 
 </details>
 
-<a id="0x1_option_swap"></a>
-
-## Function `swap`
+## Function `swap` <a id="0x1_option_swap"></a>
 
 Swap the old value inside <code>t</code> with <code>e</code> and return the old value
 Aborts if <code>t</code> does not hold a value
@@ -625,6 +604,7 @@ Aborts if <code>t</code> does not hold a value
 
 </details>
 
+
 <details>
 <summary>Specification</summary>
 
@@ -641,9 +621,7 @@ Aborts if <code>t</code> does not hold a value
 
 </details>
 
-<a id="0x1_option_swap_or_fill"></a>
-
-## Function `swap_or_fill`
+## Function `swap_or_fill` <a id="0x1_option_swap_or_fill"></a>
 
 Swap the old value inside <code>t</code> with <code>e</code> and return the old value;
 or if there is no old value, fill it with <code>e</code>.
@@ -672,6 +650,7 @@ Different from swap(), swap_or_fill() allows for <code>t</code> not holding a va
 
 </details>
 
+
 <details>
 <summary>Specification</summary>
 
@@ -686,9 +665,7 @@ Different from swap(), swap_or_fill() allows for <code>t</code> not holding a va
 
 </details>
 
-<a id="0x1_option_destroy_with_default"></a>
-
-## Function `destroy_with_default`
+## Function `destroy_with_default` <a id="0x1_option_destroy_with_default"></a>
 
 Destroys <code>t.</code> If <code>t</code> holds a value, return it. Returns <code>default</code> otherwise
 
@@ -713,6 +690,7 @@ Destroys <code>t.</code> If <code>t</code> holds a value, return it. Returns <co
 
 </details>
 
+
 <details>
 <summary>Specification</summary>
 
@@ -727,9 +705,7 @@ Destroys <code>t.</code> If <code>t</code> holds a value, return it. Returns <co
 
 </details>
 
-<a id="0x1_option_destroy_some"></a>
-
-## Function `destroy_some`
+## Function `destroy_some` <a id="0x1_option_destroy_some"></a>
 
 Unpack <code>t</code> and return its contents
 Aborts if <code>t</code> does not hold a value
@@ -757,6 +733,7 @@ Aborts if <code>t</code> does not hold a value
 
 </details>
 
+
 <details>
 <summary>Specification</summary>
 
@@ -771,9 +748,7 @@ Aborts if <code>t</code> does not hold a value
 
 </details>
 
-<a id="0x1_option_destroy_none"></a>
-
-## Function `destroy_none`
+## Function `destroy_none` <a id="0x1_option_destroy_none"></a>
 
 Unpack <code>t</code>
 Aborts if <code>t</code> holds a value
@@ -799,6 +774,7 @@ Aborts if <code>t</code> holds a value
 
 </details>
 
+
 <details>
 <summary>Specification</summary>
 
@@ -812,9 +788,7 @@ Aborts if <code>t</code> holds a value
 
 </details>
 
-<a id="0x1_option_to_vec"></a>
-
-## Function `to_vec`
+## Function `to_vec` <a id="0x1_option_to_vec"></a>
 
 Convert <code>t</code> into a vector of length 1 if it is <code>Some</code>,
 and an empty vector otherwise
@@ -839,6 +813,7 @@ and an empty vector otherwise
 
 </details>
 
+
 <details>
 <summary>Specification</summary>
 
@@ -853,9 +828,7 @@ and an empty vector otherwise
 
 </details>
 
-<a id="0x1_option_for_each"></a>
-
-## Function `for_each`
+## Function `for_each` <a id="0x1_option_for_each"></a>
 
 Apply the function to the optional element, consuming it.
 
@@ -882,9 +855,7 @@ Apply the function to the optional element, consuming it.
 
 </details>
 
-<a id="0x1_option_for_each_ref"></a>
-
-## Function `for_each_ref`
+## Function `for_each_ref` <a id="0x1_option_for_each_ref"></a>
 
 Apply the function to the optional element reference.
 
@@ -909,9 +880,7 @@ Apply the function to the optional element reference.
 
 </details>
 
-<a id="0x1_option_for_each_mut"></a>
-
-## Function `for_each_mut`
+## Function `for_each_mut` <a id="0x1_option_for_each_mut"></a>
 
 Apply the function to the optional element reference.
 
@@ -936,9 +905,7 @@ Apply the function to the optional element reference.
 
 </details>
 
-<a id="0x1_option_fold"></a>
-
-## Function `fold`
+## Function `fold` <a id="0x1_option_fold"></a>
 
 Folds the function over the optional element.
 
@@ -970,9 +937,7 @@ Folds the function over the optional element.
 
 </details>
 
-<a id="0x1_option_map"></a>
-
-## Function `map`
+## Function `map` <a id="0x1_option_map"></a>
 
 Maps the content of an option
 
@@ -1000,9 +965,7 @@ Maps the content of an option
 
 </details>
 
-<a id="0x1_option_filter"></a>
-
-## Function `filter`
+## Function `filter` <a id="0x1_option_filter"></a>
 
 Filters the content of an option
 
@@ -1029,9 +992,7 @@ Filters the content of an option
 
 </details>
 
-<a id="@Module_Specification_1"></a>
-
-## Module Specification
+## Module Specification <a id="@Module_Specification_1"></a>
 
 
 
@@ -1040,10 +1001,7 @@ Filters the content of an option
 </code></pre>
 
 
-
-<a id="@Helper_Schema_2"></a>
-
-### Helper Schema
+### Helper Schema <a id="@Helper_Schema_2"></a>
 
 
 

--- a/third_party/move/move-stdlib/docs/overview.md
+++ b/third_party/move/move-stdlib/docs/overview.md
@@ -1,15 +1,9 @@
-
-<a id="@Move_Stdlib_Modules_0"></a>
-
-# Move Stdlib Modules
+# Move Stdlib Modules <a id="@Move_Stdlib_Modules_0"></a>
 
 
 This is the root document for the Move stdlib module documentation. The Move stdlib provides modules that can be used to access or interact with core language features.
 
-
-<a id="@Index_1"></a>
-
-## Index
+## Index <a id="@Index_1"></a>
 
 
 -  [`0x1::ascii`](ascii.md#0x1_ascii)

--- a/third_party/move/move-stdlib/docs/signer.md
+++ b/third_party/move/move-stdlib/docs/signer.md
@@ -1,7 +1,4 @@
-
-<a id="0x1_signer"></a>
-
-# Module `0x1::signer`
+# Module `0x1::signer` <a id="0x1_signer"></a>
 
 
 
@@ -13,10 +10,7 @@
 <pre><code></code></pre>
 
 
-
-<a id="0x1_signer_borrow_address"></a>
-
-## Function `borrow_address`
+## Function `borrow_address` <a id="0x1_signer_borrow_address"></a>
 
 signer is a builtin move type that represents an address that has been verfied by the VM.
 
@@ -57,9 +51,7 @@ semantics.
 
 </details>
 
-<a id="0x1_signer_address_of"></a>
-
-## Function `address_of`
+## Function `address_of` <a id="0x1_signer_address_of"></a>
 
 
 
@@ -81,9 +73,7 @@ semantics.
 
 </details>
 
-<a id="@Module_Specification_0"></a>
-
-## Module Specification
+## Module Specification <a id="@Module_Specification_0"></a>
 
 Return true only if <code>s</code> is a transaction signer. This is a spec function only available in spec.
 

--- a/third_party/move/move-stdlib/docs/string.md
+++ b/third_party/move/move-stdlib/docs/string.md
@@ -1,7 +1,4 @@
-
-<a id="0x1_string"></a>
-
-# Module `0x1::string`
+# Module `0x1::string` <a id="0x1_string"></a>
 
 The <code><a href="string.md#0x1_string">string</a></code> module defines the <code><a href="string.md#0x1_string_String">String</a></code> type which represents UTF8 encoded strings.
 
@@ -30,10 +27,7 @@ The <code><a href="string.md#0x1_string">string</a></code> module defines the <c
 </code></pre>
 
 
-
-<a id="0x1_string_String"></a>
-
-## Struct `String`
+## Struct `String` <a id="0x1_string_String"></a>
 
 A <code><a href="string.md#0x1_string_String">String</a></code> holds a sequence of bytes which is guaranteed to be in utf8 format.
 
@@ -59,9 +53,7 @@ A <code><a href="string.md#0x1_string_String">String</a></code> holds a sequence
 
 </details>
 
-<a id="@Constants_0"></a>
-
-## Constants
+## Constants <a id="@Constants_0"></a>
 
 
 <a id="0x1_string_EINVALID_INDEX"></a>
@@ -83,10 +75,7 @@ An invalid UTF8 encoding.
 </code></pre>
 
 
-
-<a id="0x1_string_utf8"></a>
-
-## Function `utf8`
+## Function `utf8` <a id="0x1_string_utf8"></a>
 
 Creates a new string from a sequence of bytes. Aborts if the bytes do not represent valid utf8.
 
@@ -110,9 +99,7 @@ Creates a new string from a sequence of bytes. Aborts if the bytes do not repres
 
 </details>
 
-<a id="0x1_string_try_utf8"></a>
-
-## Function `try_utf8`
+## Function `try_utf8` <a id="0x1_string_try_utf8"></a>
 
 Tries to create a new string from a sequence of bytes.
 
@@ -139,9 +126,7 @@ Tries to create a new string from a sequence of bytes.
 
 </details>
 
-<a id="0x1_string_bytes"></a>
-
-## Function `bytes`
+## Function `bytes` <a id="0x1_string_bytes"></a>
 
 Returns a reference to the underlying byte vector.
 
@@ -164,9 +149,7 @@ Returns a reference to the underlying byte vector.
 
 </details>
 
-<a id="0x1_string_into_bytes"></a>
-
-## Function `into_bytes`
+## Function `into_bytes` <a id="0x1_string_into_bytes"></a>
 
 Returns the underlying byte vector.
 
@@ -190,9 +173,7 @@ Returns the underlying byte vector.
 
 </details>
 
-<a id="0x1_string_is_empty"></a>
-
-## Function `is_empty`
+## Function `is_empty` <a id="0x1_string_is_empty"></a>
 
 Checks whether this string is empty.
 
@@ -215,9 +196,7 @@ Checks whether this string is empty.
 
 </details>
 
-<a id="0x1_string_length"></a>
-
-## Function `length`
+## Function `length` <a id="0x1_string_length"></a>
 
 Returns the length of this string, in bytes.
 
@@ -240,9 +219,7 @@ Returns the length of this string, in bytes.
 
 </details>
 
-<a id="0x1_string_append"></a>
-
-## Function `append`
+## Function `append` <a id="0x1_string_append"></a>
 
 Appends a string.
 
@@ -265,9 +242,7 @@ Appends a string.
 
 </details>
 
-<a id="0x1_string_append_utf8"></a>
-
-## Function `append_utf8`
+## Function `append_utf8` <a id="0x1_string_append_utf8"></a>
 
 Appends bytes which must be in valid utf8 format.
 
@@ -290,9 +265,7 @@ Appends bytes which must be in valid utf8 format.
 
 </details>
 
-<a id="0x1_string_insert"></a>
-
-## Function `insert`
+## Function `insert` <a id="0x1_string_insert"></a>
 
 Insert the other string at the byte index in given string. The index must be at a valid utf8 char
 boundary.
@@ -323,9 +296,7 @@ boundary.
 
 </details>
 
-<a id="0x1_string_sub_string"></a>
-
-## Function `sub_string`
+## Function `sub_string` <a id="0x1_string_sub_string"></a>
 
 Returns a sub-string using the given byte indices, where <code>i</code> is the first byte position and <code>j</code> is the start
 of the first byte not included (or the length of the string). The indices must be at valid utf8 char boundaries,
@@ -356,9 +327,7 @@ guaranteeing that the result is valid utf8.
 
 </details>
 
-<a id="0x1_string_index_of"></a>
-
-## Function `index_of`
+## Function `index_of` <a id="0x1_string_index_of"></a>
 
 Computes the index of the first occurrence of a string. Returns <code><a href="string.md#0x1_string_length">length</a>(s)</code> if no occurrence found.
 
@@ -381,9 +350,7 @@ Computes the index of the first occurrence of a string. Returns <code><a href="s
 
 </details>
 
-<a id="0x1_string_internal_check_utf8"></a>
-
-## Function `internal_check_utf8`
+## Function `internal_check_utf8` <a id="0x1_string_internal_check_utf8"></a>
 
 
 
@@ -403,9 +370,7 @@ Computes the index of the first occurrence of a string. Returns <code><a href="s
 
 </details>
 
-<a id="0x1_string_internal_is_char_boundary"></a>
-
-## Function `internal_is_char_boundary`
+## Function `internal_is_char_boundary` <a id="0x1_string_internal_is_char_boundary"></a>
 
 
 
@@ -425,9 +390,7 @@ Computes the index of the first occurrence of a string. Returns <code><a href="s
 
 </details>
 
-<a id="0x1_string_internal_sub_string"></a>
-
-## Function `internal_sub_string`
+## Function `internal_sub_string` <a id="0x1_string_internal_sub_string"></a>
 
 
 
@@ -447,9 +410,7 @@ Computes the index of the first occurrence of a string. Returns <code><a href="s
 
 </details>
 
-<a id="0x1_string_internal_index_of"></a>
-
-## Function `internal_index_of`
+## Function `internal_index_of` <a id="0x1_string_internal_index_of"></a>
 
 
 

--- a/third_party/move/move-stdlib/docs/type_name.md
+++ b/third_party/move/move-stdlib/docs/type_name.md
@@ -1,7 +1,4 @@
-
-<a id="0x1_type_name"></a>
-
-# Module `0x1::type_name`
+# Module `0x1::type_name` <a id="0x1_type_name"></a>
 
 Functionality for converting Move types into values. Use with care!
 
@@ -16,10 +13,7 @@ Functionality for converting Move types into values. Use with care!
 </code></pre>
 
 
-
-<a id="0x1_type_name_TypeName"></a>
-
-## Struct `TypeName`
+## Struct `TypeName` <a id="0x1_type_name_TypeName"></a>
 
 
 
@@ -50,9 +44,7 @@ Functionality for converting Move types into values. Use with care!
 
 </details>
 
-<a id="0x1_type_name_get"></a>
-
-## Function `get`
+## Function `get` <a id="0x1_type_name_get"></a>
 
 Return a value representation of the type <code>T</code>.
 
@@ -73,9 +65,7 @@ Return a value representation of the type <code>T</code>.
 
 </details>
 
-<a id="0x1_type_name_borrow_string"></a>
-
-## Function `borrow_string`
+## Function `borrow_string` <a id="0x1_type_name_borrow_string"></a>
 
 Get the String representation of <code>self</code>
 
@@ -98,9 +88,7 @@ Get the String representation of <code>self</code>
 
 </details>
 
-<a id="0x1_type_name_into_string"></a>
-
-## Function `into_string`
+## Function `into_string` <a id="0x1_type_name_into_string"></a>
 
 Convert <code>self</code> into its inner String
 

--- a/third_party/move/move-stdlib/docs/vector.md
+++ b/third_party/move/move-stdlib/docs/vector.md
@@ -1,7 +1,4 @@
-
-<a id="0x1_vector"></a>
-
-# Module `0x1::vector`
+# Module `0x1::vector` <a id="0x1_vector"></a>
 
 A variable-sized container that can hold any type. Indexing is 0-based, and
 vectors are growable. This module has many native functions.
@@ -46,10 +43,7 @@ the return on investment didn't seem worth it for these simple functions.
 <pre><code></code></pre>
 
 
-
-<a id="@Constants_0"></a>
-
-## Constants
+## Constants <a id="@Constants_0"></a>
 
 
 <a id="0x1_vector_EINDEX_OUT_OF_BOUNDS"></a>
@@ -61,10 +55,7 @@ The index into the vector is out of bounds
 </code></pre>
 
 
-
-<a id="0x1_vector_empty"></a>
-
-## Function `empty`
+## Function `empty` <a id="0x1_vector_empty"></a>
 
 Create an empty vector.
 
@@ -86,9 +77,7 @@ Create an empty vector.
 
 </details>
 
-<a id="0x1_vector_length"></a>
-
-## Function `length`
+## Function `length` <a id="0x1_vector_length"></a>
 
 Return the length of the vector.
 
@@ -110,9 +99,7 @@ Return the length of the vector.
 
 </details>
 
-<a id="0x1_vector_borrow"></a>
-
-## Function `borrow`
+## Function `borrow` <a id="0x1_vector_borrow"></a>
 
 Acquire an immutable reference to the <code>i</code>th element of the vector <code>v</code>.
 Aborts if <code>i</code> is out of bounds.
@@ -135,9 +122,7 @@ Aborts if <code>i</code> is out of bounds.
 
 </details>
 
-<a id="0x1_vector_push_back"></a>
-
-## Function `push_back`
+## Function `push_back` <a id="0x1_vector_push_back"></a>
 
 Add element <code>e</code> to the end of the vector <code>v</code>.
 
@@ -159,9 +144,7 @@ Add element <code>e</code> to the end of the vector <code>v</code>.
 
 </details>
 
-<a id="0x1_vector_borrow_mut"></a>
-
-## Function `borrow_mut`
+## Function `borrow_mut` <a id="0x1_vector_borrow_mut"></a>
 
 Return a mutable reference to the <code>i</code>th element in the vector <code>v</code>.
 Aborts if <code>i</code> is out of bounds.
@@ -184,9 +167,7 @@ Aborts if <code>i</code> is out of bounds.
 
 </details>
 
-<a id="0x1_vector_pop_back"></a>
-
-## Function `pop_back`
+## Function `pop_back` <a id="0x1_vector_pop_back"></a>
 
 Pop an element from the end of vector <code>v</code>.
 Aborts if <code>v</code> is empty.
@@ -209,9 +190,7 @@ Aborts if <code>v</code> is empty.
 
 </details>
 
-<a id="0x1_vector_destroy_empty"></a>
-
-## Function `destroy_empty`
+## Function `destroy_empty` <a id="0x1_vector_destroy_empty"></a>
 
 Destroy the vector <code>v</code>.
 Aborts if <code>v</code> is not empty.
@@ -234,9 +213,7 @@ Aborts if <code>v</code> is not empty.
 
 </details>
 
-<a id="0x1_vector_swap"></a>
-
-## Function `swap`
+## Function `swap` <a id="0x1_vector_swap"></a>
 
 Swaps the elements at the <code>i</code>th and <code>j</code>th indices in the vector <code>v</code>.
 Aborts if <code>i</code> or <code>j</code> is out of bounds.
@@ -259,9 +236,7 @@ Aborts if <code>i</code> or <code>j</code> is out of bounds.
 
 </details>
 
-<a id="0x1_vector_singleton"></a>
-
-## Function `singleton`
+## Function `singleton` <a id="0x1_vector_singleton"></a>
 
 Return an vector of size one containing element <code>e</code>.
 
@@ -286,6 +261,7 @@ Return an vector of size one containing element <code>e</code>.
 
 </details>
 
+
 <details>
 <summary>Specification</summary>
 
@@ -299,9 +275,7 @@ Return an vector of size one containing element <code>e</code>.
 
 </details>
 
-<a id="0x1_vector_reverse"></a>
-
-## Function `reverse`
+## Function `reverse` <a id="0x1_vector_reverse"></a>
 
 Reverses the order of the elements in the vector <code>v</code> in place.
 
@@ -333,6 +307,7 @@ Reverses the order of the elements in the vector <code>v</code> in place.
 
 </details>
 
+
 <details>
 <summary>Specification</summary>
 
@@ -345,9 +320,7 @@ Reverses the order of the elements in the vector <code>v</code> in place.
 
 </details>
 
-<a id="0x1_vector_find"></a>
-
-## Function `find`
+## Function `find` <a id="0x1_vector_find"></a>
 
 
 
@@ -392,9 +365,7 @@ Reverses the order of the elements in the vector <code>v</code> in place.
 
 </details>
 
-<a id="0x1_vector_append"></a>
-
-## Function `append`
+## Function `append` <a id="0x1_vector_append"></a>
 
 Pushes all of the elements of the <code>other</code> vector into the <code>lhs</code> vector.
 
@@ -419,6 +390,7 @@ Pushes all of the elements of the <code>other</code> vector into the <code>lhs</
 
 </details>
 
+
 <details>
 <summary>Specification</summary>
 
@@ -431,9 +403,7 @@ Pushes all of the elements of the <code>other</code> vector into the <code>lhs</
 
 </details>
 
-<a id="0x1_vector_is_empty"></a>
-
-## Function `is_empty`
+## Function `is_empty` <a id="0x1_vector_is_empty"></a>
 
 Return <code><b>true</b></code> if the vector <code>v</code> has no elements and <code><b>false</b></code> otherwise.
 
@@ -456,6 +426,7 @@ Return <code><b>true</b></code> if the vector <code>v</code> has no elements and
 
 </details>
 
+
 <details>
 <summary>Specification</summary>
 
@@ -468,9 +439,7 @@ Return <code><b>true</b></code> if the vector <code>v</code> has no elements and
 
 </details>
 
-<a id="0x1_vector_contains"></a>
-
-## Function `contains`
+## Function `contains` <a id="0x1_vector_contains"></a>
 
 Return true if <code>e</code> is in the vector <code>v</code>.
 Otherwise, returns false.
@@ -500,6 +469,7 @@ Otherwise, returns false.
 
 </details>
 
+
 <details>
 <summary>Specification</summary>
 
@@ -512,9 +482,7 @@ Otherwise, returns false.
 
 </details>
 
-<a id="0x1_vector_index_of"></a>
-
-## Function `index_of`
+## Function `index_of` <a id="0x1_vector_index_of"></a>
 
 Return <code>(<b>true</b>, i)</code> if <code>e</code> is in the vector <code>v</code> at index <code>i</code>.
 Otherwise, returns <code>(<b>false</b>, 0)</code>.
@@ -544,6 +512,7 @@ Otherwise, returns <code>(<b>false</b>, 0)</code>.
 
 </details>
 
+
 <details>
 <summary>Specification</summary>
 
@@ -556,9 +525,7 @@ Otherwise, returns <code>(<b>false</b>, 0)</code>.
 
 </details>
 
-<a id="0x1_vector_remove"></a>
-
-## Function `remove`
+## Function `remove` <a id="0x1_vector_remove"></a>
 
 Remove the <code>i</code>th element of the vector <code>v</code>, shifting all subsequent elements.
 This is O(n) and preserves ordering of elements in the vector.
@@ -589,6 +556,7 @@ Aborts if <code>i</code> is out of bounds.
 
 </details>
 
+
 <details>
 <summary>Specification</summary>
 
@@ -601,9 +569,7 @@ Aborts if <code>i</code> is out of bounds.
 
 </details>
 
-<a id="0x1_vector_swap_remove"></a>
-
-## Function `swap_remove`
+## Function `swap_remove` <a id="0x1_vector_swap_remove"></a>
 
 Swap the <code>i</code>th element of the vector <code>v</code> with the last element and then pop the element.
 This is O(1), but does not preserve ordering of elements in the vector.
@@ -631,6 +597,7 @@ Aborts if <code>i</code> is out of bounds.
 
 </details>
 
+
 <details>
 <summary>Specification</summary>
 
@@ -643,9 +610,7 @@ Aborts if <code>i</code> is out of bounds.
 
 </details>
 
-<a id="0x1_vector_for_each"></a>
-
-## Function `for_each`
+## Function `for_each` <a id="0x1_vector_for_each"></a>
 
 Apply the function to each element in the vector, consuming it.
 
@@ -672,9 +637,7 @@ Apply the function to each element in the vector, consuming it.
 
 </details>
 
-<a id="0x1_vector_for_each_ref"></a>
-
-## Function `for_each_ref`
+## Function `for_each_ref` <a id="0x1_vector_for_each_ref"></a>
 
 Apply the function to a reference of each element in the vector.
 
@@ -701,9 +664,7 @@ Apply the function to a reference of each element in the vector.
 
 </details>
 
-<a id="0x1_vector_for_each_mut"></a>
-
-## Function `for_each_mut`
+## Function `for_each_mut` <a id="0x1_vector_for_each_mut"></a>
 
 Apply the function to a mutable reference to each element in the vector.
 
@@ -730,9 +691,7 @@ Apply the function to a mutable reference to each element in the vector.
 
 </details>
 
-<a id="0x1_vector_fold"></a>
-
-## Function `fold`
+## Function `fold` <a id="0x1_vector_fold"></a>
 
 Fold the function over the elements. For example, <code><a href="vector.md#0x1_vector_fold">fold</a>(<a href="vector.md#0x1_vector">vector</a>[1,2,3], 0, f)</code> will execute
 <code>f(f(f(0, 1), 2), 3)</code>
@@ -762,9 +721,7 @@ Fold the function over the elements. For example, <code><a href="vector.md#0x1_v
 
 </details>
 
-<a id="0x1_vector_map"></a>
-
-## Function `map`
+## Function `map` <a id="0x1_vector_map"></a>
 
 Map the function over the elements of the vector, producing a new vector.
 
@@ -792,9 +749,7 @@ Map the function over the elements of the vector, producing a new vector.
 
 </details>
 
-<a id="0x1_vector_filter"></a>
-
-## Function `filter`
+## Function `filter` <a id="0x1_vector_filter"></a>
 
 Filter the vector using the boolean function, removing all elements for which <code>p(e)</code> is not true.
 
@@ -824,15 +779,10 @@ Filter the vector using the boolean function, removing all elements for which <c
 
 </details>
 
-<a id="@Module_Specification_1"></a>
-
-## Module Specification
+## Module Specification <a id="@Module_Specification_1"></a>
 
 
-
-<a id="@Helper_Functions_2"></a>
-
-### Helper Functions
+### Helper Functions <a id="@Helper_Functions_2"></a>
 
 
 Check if <code>v1</code> is equal to the result of adding <code>e</code> at the end of <code>v2</code>


### PR DESCRIPTION
## Description

Users no longer have to wrap `&mut T` arguments in `old(...)` or duplicate them as post-state slots when calling behavioral predicates. The rewriter inserts the canonical pre/post split automatically.

Before:

```move
spec followed_by {
    ensures exists S in *:
        (..S |~ ensures_of<f>(old(x), x)) &&
        (S.. |~ ensures_of<g>(old(x), x));
}
```

After:

```move
spec followed_by {
    ensures exists S in *:
        (..S |~ ensures_of<f>(x)) &&
        (S.. |~ ensures_of<g>(x));
}
```

This applies to `ensures_of`, `requires_of`, and `aborts_of`. `&mut x.foo` selector borrows are also accepted as BP arguments, e.g. `ensures_of<f>(&mut x.foo)`. For `result_of<f>` on a function with `&mut T`, users get the canonical tuple `(U_explicit..., mut_post...)` and can compare via tuple equality (`(result, x) == result_of<f>(x)`) or destructure with `let`.

## How Has This Been Tested?

- Functional tests (`cargo test -p move-prover --test testsuite`) — 230/230 pass. The closure BP tests are simplified to the new form: see `behavioral_results.move`, `bp_mut_ref_selector.move` (new), and `state_labels/followed_by_mut_ref.move`.
- Inference suite (`cargo test -p move-prover --test inference_testsuite`) — 24/24 pass.
- Full Move test suite (`UB=1 bash third_party/move/scripts/move_pr.sh -t`) — 6394 passed, 1 skipped.
- Lints clean: `cargo clippy`, `cargo +nightly fmt`, `cargo sort --grouped --workspace`, `cargo machete`.

## Key Areas to Review

- The user-form → canonical-form rewrite (`augment_behavior_call` in `move-model/src/spec_translator.rs`): wraps `&mut T` input args in `old(...)` and appends post-state clones.
- `bp_arg_depth` tracking in `move-compiler-v2/src/env_pipeline/spec_rewriter.rs` and `move-model/src/pureness_checker.rs`: keeps `Borrow(Mut, ...)` selectors alive across descent so the model rewriter can see them.
- Dual-arity acceptance in `move-model/src/builder/exp_builder.rs` (`compute_behavior_arg_types_minimum` vs `_canonical`): the type-checker accepts either the user form or the canonical form.

## Type of Change
- [x] New feature

## Which Components or Systems Does This Change Impact?
- [x] Move Compiler

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes spec rewriting/typechecking/translation for behavioral predicates, which can subtly affect verification semantics for `&mut` parameters and state-label handling. Scope spans compiler/model/prover layers but is covered by updated and new functional tests.
> 
> **Overview**
> **Behavioral predicates now accept a simplified user-facing call shape for `&mut T` parameters.** The model spec rewriter (`augment_behavior_call`) automatically wraps stateful `&mut` inputs in `old(...)` and, for `ensures_of`, appends the necessary post-state argument slots, making the rewrite idempotent and preserving existing canonical callers.
> 
> The type checker/AST builder now accepts both the minimum arity and canonical augmented arity for behavioral predicates and relaxes spec-mode borrowing rules specifically within BP argument expressions. Downstream, the compiler/model/prover pipeline tracks “BP-argument context” to *preserve* `Borrow(Mut, ...)` selector borrows (e.g. `&mut p.x`) through rewriting/pureness checks and translates them as field-path selectors rather than runtime borrows.
> 
> Tests are updated to use the new syntax, a new test covers `&mut x.foo` selector arguments, and various stdlib docs are reformatted (anchor placement/heading layout) without semantic changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae44faa4ff52704ce2aa7a8a6bbcb8b3aa97f99b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->