### PR TITLE
[jwk-consensus] Clean up state lookup in process_peer_request

### DIFF
--- a/crates/aptos-jwk-consensus/src/jwk_manager/mod.rs
+++ b/crates/aptos-jwk-consensus/src/jwk_manager/mod.rs
@@ -299,11 +299,16 @@ impl IssuerLevelConsensusManager {
         } = rpc_req;
         match msg {
             JWKConsensusMsg::ObservationRequest(request) => {
-                let state = self.states_by_issuer.entry(request.issuer).or_default();
-                let response: Result<JWKConsensusMsg> = match &state.consensus_state {
-                    ConsensusState::NotStarted => Err(anyhow!("observed update unavailable")),
-                    ConsensusState::InProgress { my_proposal, .. }
-                    | ConsensusState::Finished { my_proposal, .. } => Ok(
+                let response: Result<JWKConsensusMsg> = match self
+                    .states_by_issuer
+                    .get(&request.issuer)
+                    .map(|s| &s.consensus_state)
+                {
+                    None | Some(ConsensusState::NotStarted) => {
+                        Err(anyhow!("observed update unavailable"))
+                    },
+                    Some(ConsensusState::InProgress { my_proposal, .. })
+                    | Some(ConsensusState::Finished { my_proposal, .. }) => Ok(
                         JWKConsensusMsg::ObservationResponse(ObservedUpdateResponse {
                             epoch: self.epoch_state.epoch,
                             update: my_proposal.clone(),

--- a/crates/aptos-jwk-consensus/src/jwk_manager/tests.rs
+++ b/crates/aptos-jwk-consensus/src/jwk_manager/tests.rs
@@ -145,9 +145,9 @@ async fn test_jwk_manager_state_transition() {
     assert!(last_invocations.len() == 1 && last_invocations[0].is_err());
     assert_eq!(expected_states, jwk_manager.states_by_issuer);
 
-    // When JWK consensus is `NotStarted` for issuer Carl, JWKConsensusManager should:
-    // reply an error to any observation request and keep the state unchanged;
-    // also create an entry in the state table on the fly.
+    // When an observation request arrives for an issuer with no local state
+    // (Carl), JWKConsensusManager should reply an error and leave
+    // `states_by_issuer` unchanged.
     let carl_ob_req = new_rpc_observation_request(
         999,
         issuer_carl.clone(),
@@ -157,7 +157,6 @@ async fn test_jwk_manager_state_transition() {
     assert!(jwk_manager.process_peer_request(carl_ob_req).is_ok());
     let last_invocations = std::mem::take(&mut *rpc_response_collector.write());
     assert!(last_invocations.len() == 1 && last_invocations[0].is_err());
-    expected_states.insert(issuer_carl.clone(), PerProviderState::default());
     assert_eq!(expected_states, jwk_manager.states_by_issuer);
 
     // When JWK consensus is `NotStarted` for issuer Bob, JWKConsensusManager should:
@@ -207,6 +206,7 @@ async fn test_jwk_manager_state_transition() {
     assert!(jwk_manager
         .process_new_observation(issuer_carl.clone(), carl_jwks_new.clone())
         .is_ok());
+    expected_states.insert(issuer_carl.clone(), PerProviderState::default());
     {
         let expected_carl_state = expected_states.get_mut(&issuer_carl).unwrap();
         expected_carl_state.observed = Some(carl_jwks_new.clone());

--- a/crates/aptos-jwk-consensus/src/jwk_manager_per_key.rs
+++ b/crates/aptos-jwk-consensus/src/jwk_manager_per_key.rs
@@ -271,12 +271,11 @@ impl KeyLevelConsensusManager {
         match msg {
             JWKConsensusMsg::KeyLevelObservationRequest(request) => {
                 let ObservedKeyLevelUpdateRequest { issuer, kid, .. } = request;
-                let consensus_state = self
+                let response: Result<JWKConsensusMsg> = match self
                     .states_by_key
-                    .entry((issuer.clone(), kid.clone()))
-                    .or_default();
-                let response: Result<JWKConsensusMsg> = match &consensus_state {
-                    ConsensusState::NotStarted => {
+                    .get(&(issuer.clone(), kid.clone()))
+                {
+                    None | Some(ConsensusState::NotStarted) => {
                         debug!(
                             issuer = String::from_utf8(issuer.clone()).ok(),
                             kid = String::from_utf8(kid.clone()).ok(),
@@ -284,8 +283,8 @@ impl KeyLevelConsensusManager {
                         );
                         return Ok(());
                     },
-                    ConsensusState::InProgress { my_proposal, .. }
-                    | ConsensusState::Finished { my_proposal, .. } => Ok(
+                    Some(ConsensusState::InProgress { my_proposal, .. })
+                    | Some(ConsensusState::Finished { my_proposal, .. }) => Ok(
                         JWKConsensusMsg::ObservationResponse(ObservedUpdateResponse {
                             epoch: self.epoch_state.epoch,
                             update: ObservedUpdate {


### PR DESCRIPTION
## Summary
- Replace `entry(...).or_default()` with `get()` in `process_peer_request` for both the per-issuer and per-key JWK consensus managers, so that peer observation requests no longer default-insert empty state entries. Honest entries are populated by `process_new_observation` / `reset_with_on_chain_state` for issuers in the on-chain `SupportedOIDCProviders` list.
- Behavior preserved: per-issuer manager still replies `"observed update unavailable"` for unknown / `NotStarted`; per-key manager still drops silently for unknown / `NotStarted`.
- Updated `test_jwk_manager_state_transition` to confirm an unknown-issuer observation request leaves `states_by_issuer` unchanged.

## Test plan
- [ ] `cargo test -p aptos-jwk-consensus`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor to RPC request handling that prevents creating empty consensus state entries for unknown issuers/keys; behavior changes are narrow and covered by an updated unit test.
> 
> **Overview**
> Stops `process_peer_request` in both issuer-level and key-level JWK consensus managers from default-inserting empty state via `entry(...).or_default()` when a peer requests an observation for an unknown `(issuer[, kid])`, using `get()` lookups instead.
> 
> Updates `test_jwk_manager_state_transition` to assert that an observation request for an unknown issuer returns an error **without mutating** `states_by_issuer` (state is only created later when a real observation is processed).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db8d3401f2d4070621a99c1c444e6795e50e5215. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->