### PR TITLE
[mono-move] Move heap object headers to negative offsets

### DIFF
--- a/third_party/move/mono-move/core/src/align.rs
+++ b/third_party/move/mono-move/core/src/align.rs
@@ -1,0 +1,84 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Alignment constants and helpers.
+
+// ---------------------------------------------------------------------------
+// MAX_ALIGN
+// ---------------------------------------------------------------------------
+
+/// Maximum alignment used by any value or VM-internal layout. Bounds the
+/// alignment of region bases, the frame pointer, the bump pointer, and
+/// the padding rounded into per-object `size` fields and frame segments.
+///
+/// Must be a power of two, at least 8 (the heap object header is 8 bytes,
+/// and the 24-byte frame metadata block needs 8-byte granularity), and a
+/// multiple of every alignment used by any value or VM-internal layout
+/// (the third constraint is implied by the first two as long as every
+/// such alignment is a power of two ≤ [`MAX_ALIGN`]).
+pub const MAX_ALIGN: usize = 8;
+
+const _: () = {
+    assert!(MAX_ALIGN.is_power_of_two());
+    assert!(MAX_ALIGN >= 8);
+};
+
+// ---------------------------------------------------------------------------
+// Parametric rounding (usize)
+// ---------------------------------------------------------------------------
+
+/// Round `size` up to the next multiple of `align`. Wraps if
+/// `size + (align - 1)` overflows `usize`; use [`checked_align_up`] when
+/// the input may be attacker-controlled or otherwise unbounded.
+///
+/// **Pre-condition:** `align` is non-zero and is a power of two.
+#[inline(always)]
+pub const fn align_up(size: usize, align: usize) -> usize {
+    debug_assert!(align > 0 && align.is_power_of_two());
+    (size + (align - 1)) & !(align - 1)
+}
+
+/// Overflow-checked variant of [`align_up`]. Returns `None` if rounding
+/// up would overflow `usize`.
+///
+/// **Pre-condition:** `align` is non-zero and is a power of two.
+#[inline(always)]
+pub const fn checked_align_up(size: usize, align: usize) -> Option<usize> {
+    debug_assert!(align > 0 && align.is_power_of_two());
+    match size.checked_add(align - 1) {
+        Some(v) => Some(v & !(align - 1)),
+        None => None,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Specializations to MAX_ALIGN
+// ---------------------------------------------------------------------------
+
+/// Round `size` up to the next multiple of [`MAX_ALIGN`]. Wraps if `size`
+/// exceeds `usize::MAX - (MAX_ALIGN - 1)`; use [`checked_align_max`] when
+/// the input may be attacker-controlled or otherwise unbounded.
+#[inline(always)]
+pub const fn align_max(size: usize) -> usize {
+    align_up(size, MAX_ALIGN)
+}
+
+/// Overflow-checked variant of [`align_max`]. Returns `None` if rounding
+/// up would overflow `usize`.
+#[inline(always)]
+pub const fn checked_align_max(size: usize) -> Option<usize> {
+    checked_align_up(size, MAX_ALIGN)
+}
+
+// ---------------------------------------------------------------------------
+// u32 variant (specializer layout)
+// ---------------------------------------------------------------------------
+
+/// `u32` variant of [`align_up`].
+///
+/// **Pre-condition:** `align` is non-zero and is a power of two.
+#[inline(always)]
+pub fn align_up_u32(offset: u32, align: u32) -> u32 {
+    debug_assert!(align > 0 && align.is_power_of_two());
+    (offset + align - 1) & !(align - 1)
+}

--- a/third_party/move/mono-move/core/src/instruction/mod.rs
+++ b/third_party/move/mono-move/core/src/instruction/mod.rs
@@ -115,7 +115,7 @@
 //!   `elem_ptr_offsets` lists byte offsets *within each element* that hold
 //!   heap pointers.
 
-use crate::{ExecutableId, Function};
+use crate::{align::MAX_ALIGN, ExecutableId, Function};
 use mono_move_alloc::{ExecutableArenaPtr, GlobalArenaPtr};
 use std::fmt;
 
@@ -1091,50 +1091,48 @@ impl fmt::Display for MicroOp {
 // Constructor helpers for the re-compiler
 // ---------------------------------------------------------------------------
 
-/// Maximum alignment used by any value or VM-internal layout. Bounds the
-/// alignment of region bases, the frame pointer, the bump pointer, and
-/// the padding rounded into per-object `size` fields and frame segments.
-///
-/// Must be a power of two, at least 8 (the heap object header is 8 bytes,
-/// and the 24-byte frame metadata block needs 8-byte granularity), and a
-/// multiple of every alignment used by any value or VM-internal layout
-/// (the third constraint is implied by the first two as long as every
-/// such alignment is a power of two ≤ [`MAX_ALIGN`]).
-pub const MAX_ALIGN: usize = 8;
-
-const _: () = {
-    assert!(MAX_ALIGN.is_power_of_two());
-    assert!(MAX_ALIGN >= 8);
-};
-
-/// Round `size` up to the next multiple of [`MAX_ALIGN`].
-#[inline(always)]
-pub const fn align_max(size: usize) -> usize {
-    (size + (MAX_ALIGN - 1)) & !(MAX_ALIGN - 1)
-}
-
 /// Size of the per-frame metadata section: `(saved_pc, saved_fp, func_id)`.
 pub const FRAME_METADATA_SIZE: usize = 24;
 
-/// Size of the object header: [descriptor_id: u32 | size_in_bytes: u32].
-pub const OBJECT_HEADER_SIZE: usize = 8;
+/// Allocation overhead per heap object — the number of bytes the bump
+/// allocator reserves *before* the data region for the
+/// `[descriptor_id: u32 | size_in_bytes: u32]` header. The header pair
+/// always sits in the last 8 bytes of this reservation (at `obj_ptr - 8`
+/// and `obj_ptr - 4`); any additional bytes are padding so the data start
+/// remains [`MAX_ALIGN`]-aligned.
+///
+/// Tying `OBJECT_HEADER_SIZE` to [`MAX_ALIGN`] is what keeps both
+/// invariants (header-aligned, data-aligned) automatic as [`MAX_ALIGN`]
+/// grows: a future bump to 16 expands the reservation without changing
+/// any per-type layout constant below.
+pub const OBJECT_HEADER_SIZE: usize = MAX_ALIGN;
 
-/// Offset where struct field data begins (same as OBJECT_HEADER_SIZE).
-pub const STRUCT_DATA_OFFSET: usize = OBJECT_HEADER_SIZE; // 8
+const _: () = {
+    // The header pair (`desc_id: u32 + size: u32`) needs the last 8 bytes
+    // of the reservation. Cannot be less.
+    assert!(OBJECT_HEADER_SIZE >= 8);
+    // Data start = header start + OBJECT_HEADER_SIZE; needs to land on a
+    // `MAX_ALIGN` boundary.
+    assert!(OBJECT_HEADER_SIZE.is_multiple_of(MAX_ALIGN));
+};
 
 /// Offset of the variant tag (u64) within an enum object.
-pub const ENUM_TAG_OFFSET: usize = OBJECT_HEADER_SIZE; // 8
+pub const ENUM_TAG_OFFSET: usize = 0;
 
-/// Offset where enum variant field data begins (after header + tag).
-pub const ENUM_DATA_OFFSET: usize = OBJECT_HEADER_SIZE + 8; // 16
+/// Offset where enum variant field data begins (after the tag).
+pub const ENUM_DATA_OFFSET: usize = 8;
 
 // ---------------------------------------------------------------------------
 // Closure object layout
 // ---------------------------------------------------------------------------
 //
-// Closure object (heap-allocated, fixed size):
+// Closure object (heap-allocated, fixed data-region size):
 //
-//   [header(8)] [func_ref(16)] [mask(8)] [captured_data_ptr(8)]  = 40 bytes
+//   [func_ref(16)] [mask(8)] [captured_data_ptr(8)]  = 32 bytes
+//
+// Offsets below are relative to the data start (the object pointer). The
+// 8-byte header lives at `obj_ptr - 8`; allocator bookkeeping is hidden
+// from per-type layouts.
 //
 // `func_ref` is an inline `ClosureFuncRef` enum. Reserved as 16 bytes to
 // leave room for a future `Unresolved` variant; v0 uses only `Resolved`:
@@ -1149,18 +1147,18 @@ pub const ENUM_DATA_OFFSET: usize = OBJECT_HEADER_SIZE + 8; // 16
 /// changes.
 pub const CLOSURE_FUNC_REF_SIZE: usize = 16;
 
-/// Offset of the `func_ref` field within a closure heap object (after header).
-pub const CLOSURE_FUNC_REF_OFFSET: usize = OBJECT_HEADER_SIZE; // 8
+/// Offset of the `func_ref` field within a closure heap object's data region.
+pub const CLOSURE_FUNC_REF_OFFSET: usize = 0;
 
 /// Offset of the `mask` field within a closure heap object.
-pub const CLOSURE_MASK_OFFSET: usize = CLOSURE_FUNC_REF_OFFSET + CLOSURE_FUNC_REF_SIZE; // 24
+pub const CLOSURE_MASK_OFFSET: usize = CLOSURE_FUNC_REF_OFFSET + CLOSURE_FUNC_REF_SIZE; // 16
 
 /// Offset of the `captured_data_ptr` field within a closure heap object.
 /// The GC traces this slot (heap pointer to the `ClosureCapturedData` object).
-pub const CLOSURE_CAPTURED_DATA_PTR_OFFSET: usize = CLOSURE_MASK_OFFSET + 8; // 32
+pub const CLOSURE_CAPTURED_DATA_PTR_OFFSET: usize = CLOSURE_MASK_OFFSET + 8; // 24
 
-/// Total size of a closure heap object (header + payload).
-pub const CLOSURE_OBJECT_SIZE: usize = CLOSURE_CAPTURED_DATA_PTR_OFFSET + 8; // 40
+/// Size of a closure heap object's data region (the header is separate).
+pub const CLOSURE_DATA_SIZE: usize = CLOSURE_CAPTURED_DATA_PTR_OFFSET + 8; // 32
 
 // Offsets within the `func_ref` region.
 /// Byte offset of the tag within `func_ref`.
@@ -1176,7 +1174,10 @@ pub const FUNC_REF_TAG_RESOLVED: u8 = 0;
 // ClosureCapturedData object layout (Materialized)
 // ---------------------------------------------------------------------------
 //
-//   [header(8)] [tag(1)] [padding(7)] [captured values packed in param order]
+//   Data region: [tag(1)] [padding(7)] [captured values packed in param order]
+//
+// Offsets below are relative to the data start (the object pointer). The
+// 8-byte header lives at `obj_ptr - 8`.
 //
 // Captured values are packed tightly, in the order of their parameter
 // positions (i.e. ascending `i` where `mask.is_captured(i)` is true).
@@ -1184,23 +1185,28 @@ pub const FUNC_REF_TAG_RESOLVED: u8 = 0;
 // read from the target function's `param_sizes` at call time.
 
 /// Byte offset of the tag (u8) within a `ClosureCapturedData` heap object.
-pub const CAPTURED_DATA_TAG_OFFSET: usize = OBJECT_HEADER_SIZE; // 8
+pub const CAPTURED_DATA_TAG_OFFSET: usize = 0;
 
-/// Byte offset where captured values begin (after header + tag + padding).
-pub const CAPTURED_DATA_VALUES_OFFSET: usize = OBJECT_HEADER_SIZE + 8; // 16
+/// Byte offset where captured values begin (after tag + padding).
+pub const CAPTURED_DATA_VALUES_OFFSET: usize = 8;
 
 /// `ClosureCapturedData::Materialized` tag value.
 pub const CAPTURED_DATA_TAG_MATERIALIZED: u8 = 0;
 // Future: `CAPTURED_DATA_TAG_RAW: u8 = 1`
 
 impl MicroOp {
-    // ----- Struct helpers (offsets relative to STRUCT_DATA_OFFSET) -----
+    // ----- Struct helpers -----
+    //
+    // Field offsets are byte offsets within the struct's data region, which
+    // is exactly what each Heap* op's `offset` field already names — the
+    // header lives at a negative offset and is invisible to per-type
+    // layouts.
 
     pub fn struct_load8(heap_ptr: FrameOffset, field_offset: u32, dst: FrameOffset) -> Self {
         MicroOp::HeapMoveFrom8 {
             dst,
             heap_ptr,
-            offset: STRUCT_DATA_OFFSET as u32 + field_offset,
+            offset: field_offset,
         }
     }
 
@@ -1213,7 +1219,7 @@ impl MicroOp {
         MicroOp::HeapMoveFrom {
             dst,
             heap_ptr,
-            offset: STRUCT_DATA_OFFSET as u32 + field_offset,
+            offset: field_offset,
             size,
         }
     }
@@ -1221,7 +1227,7 @@ impl MicroOp {
     pub fn struct_store8(heap_ptr: FrameOffset, field_offset: u32, src: FrameOffset) -> Self {
         MicroOp::HeapMoveTo8 {
             heap_ptr,
-            offset: STRUCT_DATA_OFFSET as u32 + field_offset,
+            offset: field_offset,
             src,
         }
     }
@@ -1234,7 +1240,7 @@ impl MicroOp {
     ) -> Self {
         MicroOp::HeapMoveTo {
             heap_ptr,
-            offset: STRUCT_DATA_OFFSET as u32 + field_offset,
+            offset: field_offset,
             src,
             size,
         }
@@ -1244,11 +1250,11 @@ impl MicroOp {
         MicroOp::HeapBorrow {
             dst,
             obj_ref,
-            offset: STRUCT_DATA_OFFSET as u32 + field_offset,
+            offset: field_offset,
         }
     }
 
-    // ----- Enum helpers (offsets relative to ENUM_DATA_OFFSET) -----
+    // ----- Enum helpers (variant fields live after the 8-byte tag) -----
 
     pub fn enum_get_tag(heap_ptr: FrameOffset, dst: FrameOffset) -> Self {
         MicroOp::HeapMoveFrom8 {

--- a/third_party/move/mono-move/core/src/lib.rs
+++ b/third_party/move/mono-move/core/src/lib.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
+pub mod align;
 mod executable;
 mod execution_context;
 mod function;
@@ -9,16 +10,19 @@ pub mod interner;
 mod prepared_module;
 pub mod types;
 
+pub use align::{
+    align_max, align_up, align_up_u32, checked_align_max, checked_align_up, MAX_ALIGN,
+};
 pub use executable::{EnumType, Executable, ExecutableId, StructType, VariantFields};
 pub use execution_context::{ExecutionContext, FunctionResolver, LocalExecutionContext};
 pub use function::{FrameLayoutInfo, Function, SafePointEntry, SortedSafePointEntries};
 pub use instruction::{
-    align_max, CallClosureOp, ClosureFuncRef, CodeOffset, DescriptorId, FrameOffset, MicroOp,
+    CallClosureOp, ClosureFuncRef, CodeOffset, DescriptorId, FrameOffset, MicroOp,
     MicroOpGasSchedule, PackClosureOp, SizedSlot, CAPTURED_DATA_TAG_MATERIALIZED,
     CAPTURED_DATA_TAG_OFFSET, CAPTURED_DATA_VALUES_OFFSET, CLOSURE_CAPTURED_DATA_PTR_OFFSET,
-    CLOSURE_FUNC_REF_OFFSET, CLOSURE_FUNC_REF_SIZE, CLOSURE_MASK_OFFSET, CLOSURE_OBJECT_SIZE,
+    CLOSURE_DATA_SIZE, CLOSURE_FUNC_REF_OFFSET, CLOSURE_FUNC_REF_SIZE, CLOSURE_MASK_OFFSET,
     ENUM_DATA_OFFSET, ENUM_TAG_OFFSET, FRAME_METADATA_SIZE, FUNC_REF_PAYLOAD_OFFSET,
-    FUNC_REF_TAG_OFFSET, FUNC_REF_TAG_RESOLVED, MAX_ALIGN, OBJECT_HEADER_SIZE, STRUCT_DATA_OFFSET,
+    FUNC_REF_TAG_OFFSET, FUNC_REF_TAG_RESOLVED, OBJECT_HEADER_SIZE,
 };
 pub use interner::Interner;
 pub use prepared_module::PreparedModule;

--- a/third_party/move/mono-move/core/src/types.rs
+++ b/third_party/move/mono-move/core/src/types.rs
@@ -432,15 +432,3 @@ pub const ADDRESS_TY: InternedType = GlobalArenaPtr::from_static(&ADDRESS);
 pub const SIGNER_TY: InternedType = GlobalArenaPtr::from_static(&SIGNER);
 
 pub const EMPTY_TYPE_LIST: InternedTypeList = GlobalArenaPtr::from_static(&EMPTY_LIST);
-
-// ================================================================================================
-// Alignment utility
-// ================================================================================================
-
-/// Rounds a byte offset up to the next multiple of `align`.
-///
-/// **Pre-condition:** `align` is non-zero and is a power of two.
-pub fn align_up(offset: u32, align: u32) -> u32 {
-    debug_assert!(align > 0 && align.is_power_of_two());
-    (offset + align - 1) & !(align - 1)
-}

--- a/third_party/move/mono-move/docs/heap_and_gc.md
+++ b/third_party/move/mono-move/docs/heap_and_gc.md
@@ -138,7 +138,7 @@ All pointers must be updated after memory moves during GC. Missing a pointer lea
 
 1. **Frame metadata integrity** — saved `fp`/`pc`/`func_ptr` are written only by call/return, never by user micro-ops.
 2. **Pointer-slot accuracy** — `Function::frame_layout` (and, at safe points, the matching `safe_point_layouts` entry) together exactly match slots that hold live heap pointers.
-3. **Object header integrity** — `descriptor_id` and `size` are set by the allocator and never overwritten by user code.
+3. **Object header integrity** — `descriptor_id` and `size` live at fixed negative offsets (`obj_ptr - 8` and `obj_ptr - 4`) and are set by the allocator; user-emitted micro-ops only access offsets within the data region (≥ 0) so they cannot reach the header.
 
 ### Auxiliary GC Roots: `PinnedRoots`
 

--- a/third_party/move/mono-move/docs/memory_alignment.md
+++ b/third_party/move/mono-move/docs/memory_alignment.md
@@ -28,11 +28,11 @@ It governs the alignment of the stack and heap regions, of `fp` and the bump poi
 - It must be at least **8**, because the heap object header (8 bytes) and the `params + locals + metadata` region (which contains the 24-byte metadata block) both need 8-byte granularity at minimum.
 - It must be a multiple of every alignment used by any value or VM-internal layout. With current alignments (1, 2, 4, 8) this is satisfied by any multiple of 8.
 
-**Raising `MAX_ALIGN` does not automatically resize headers.** If a future change introduces values requiring more than 8-byte alignment, the specializer and runtime have to insert extra padding *inside* containers to make the post-header offsets land at the new alignment — `MAX_ALIGN` only guarantees that *object base addresses* are sufficiently aligned. Concretely:
+**Raising `MAX_ALIGN` resizes the heap header reservation automatically.** Per [§5.1](#51-heap-object-header), `OBJECT_HEADER_SIZE = MAX_ALIGN` — the allocator reserves at least `MAX_ALIGN` bytes before each data region so that the object pointer (and therefore field 0) lands on a `MAX_ALIGN` boundary. The descriptor/size pair always lives in the *last* 8 bytes of that reservation (at `obj_ptr - 8` / `obj_ptr - 4`), independent of `MAX_ALIGN`. Per-type layouts (struct field offsets, enum data offset, vector data offset, closure fields, captured-data values) are all expressed relative to the data start, so none of them shift when `MAX_ALIGN` grows. Costs to keep in mind:
 
-- **Heap objects.** The header is fixed at 8 bytes. To put a 16-aligned field at the start of the body, the specializer must emit 8 bytes of padding between the header and the field. To put a 32-aligned field, 24 bytes of padding. The header could be redesigned to consume more space when stronger alignment is needed, but doing so is a layout change that must be planned explicitly.
+- **Per-object padding when `MAX_ALIGN > 8`.** A 16-byte `MAX_ALIGN` adds 8 bytes of header padding (header reservation goes from 8 → 16 bytes); a 32-byte `MAX_ALIGN` adds 24. The padding pays for "data start is always `MAX_ALIGN`-aligned" without needing per-container layout changes.
 - **Frame metadata.** The 24-byte metadata block is not `MAX_ALIGN`-aligned in size when `MAX_ALIGN > 8`. The frame layout pass must pad the metadata up to `MAX_ALIGN` so the next callee's `fp` lands on an aligned offset.
-- **Vector data offset.** Element 0 currently starts at offset 16 (header + length). For elements requiring more than 16-byte alignment, the data offset would need to grow per vector — but the current vector micro-ops have no mechanism to express this. See [§8.3](#83-vector-data-offset-under-stronger-element-alignment).
+- **Vector data offset.** Element 0 starts at `VEC_DATA_OFFSET = 8` within the data region (after the length field). For elements requiring more than 8-byte alignment, the data offset would need to grow per vector — but the current vector micro-ops have no mechanism to express this. See [§8.3](#83-vector-data-offset-under-stronger-element-alignment).
 
 **Natives inherit `MAX_ALIGN`.** Native functions follow the same calling convention and read parameters from the frame at the same offsets. Any pointer they receive into the stack or heap inherits the `MAX_ALIGN` (and below) alignment guarantees. If a native ever needs stronger alignment than `MAX_ALIGN` for a Rust-side type, it must allocate its own scratch space — the VM frame won't satisfy it.
 
@@ -105,13 +105,11 @@ Stored as a heap pointer in the owner region. 8 bytes, 8-byte aligned.
 
 ### 5.1 Heap Object Header
 
-Every heap object starts with the 8-byte header `[desc_id: u32 | size: u32]`. The header itself is 8-byte aligned and sits at offset 0 of every heap object. Because the heap allocator always places objects at `MAX_ALIGN`-aligned addresses ([§3.1](#31-the-heap)), the header is automatically aligned without any work from the body layout.
+Every heap object has an 8-byte header `[desc_id: u32 | size: u32]` that sits at a *negative* offset relative to the object pointer that callers hold (`desc_id` at `obj_ptr - 8`, `size` at `obj_ptr - 4`). The allocator reserves `OBJECT_HEADER_SIZE = MAX_ALIGN` bytes before each data region, so the header is `MAX_ALIGN`-aligned for free (the bump pointer is `MAX_ALIGN`-aligned per [§3.1](#31-the-heap)) and the descriptor+size pair stays adjacent to the data — good for cache locality. When `MAX_ALIGN > 8`, the lower bytes of the reservation are unused padding; the negative offsets `-8` / `-4` don't shift.
 
 ### 5.2 Heap Object Body
 
-The body starts at offset 8 (immediately after the header). Body fields are placed at offsets that satisfy each field's natural alignment relative to the start of the heap object. Today the body offset equals `MAX_ALIGN`, so the first field can sit at offset 8 regardless of its alignment (which is ≤ `MAX_ALIGN` by construction); if `MAX_ALIGN` is ever raised above the header size, padding between header and body is needed (see [§2](#2-the-max_align-constant)).
-
-> TODO: a future refactor will move the header to a *negative* offset relative to the body (the way `malloc` does). Once that lands, the body always starts at offset 0 and the header-vs-body alignment discussion above goes away.
+The body starts at the object pointer (offset 0 of the data region). Body fields are placed at offsets that satisfy each field's natural alignment relative to `obj_ptr`. Because the allocator guarantees `obj_ptr` is `MAX_ALIGN`-aligned, the first field can sit at offset 0 regardless of its alignment (which is ≤ `MAX_ALIGN` by construction); raising `MAX_ALIGN` does not require any per-type layout changes.
 
 ### 5.3 Inline Structs
 
@@ -121,7 +119,7 @@ The struct's alignment is the max of its fields' alignments. The owner is respon
 
 ### 5.4 Heap Structs
 
-Heap structs follow [§5.1](#51-heap-object-header)–[§5.2](#52-heap-object-body). Field offsets *within the body* are computed relative to the body start (offset 8), using the same natural-alignment rule as inline structs. The compiler-provided `pointer_offsets` for the GC are body-relative offsets.
+Heap structs follow [§5.1](#51-heap-object-header)–[§5.2](#52-heap-object-body). Field offsets *within the body* are computed relative to `obj_ptr` (offset 0), using the same natural-alignment rule as inline structs. The compiler-provided `pointer_offsets` for the GC are body-relative offsets.
 
 ### 5.5 Inline Enums
 
@@ -142,15 +140,20 @@ Same as [§5.4](#54-heap-structs), with the body laid out as `[tag | pad | varia
 ### 5.7 Vectors
 
 ```
-offset 0    4    8         16        16 + i*elem_size
-      ┌────┬────┬──────────┬──────────────────────┐
-      │desc│size│ length   │  elem_0  elem_1 ...  │
-      └────┴────┴──────────┴──────────────────────┘
+          obj_ptr    obj_ptr + VEC_DATA_OFFSET
+          │          │
+          ▼          ▼
+┌────┬────┬──────────┬──────────────────────┐
+│desc│size│ length   │  elem_0  elem_1 ...  │
+└────┴────┴──────────┴──────────────────────┘
+ ▲    ▲    ╰──────── data region ──────────╯
+ │    └ size, at obj_ptr - 4
+ └ desc, at obj_ptr - 8
 ```
 
-The header is at offsets 0–7 ([§5.1](#51-heap-object-header)). The vector also stores a `length` field as a `u64` immediately after the header at offset 8 (8-byte aligned). Element 0 starts at offset 16, which is 8-byte aligned — sufficient for any primitive under [§4](#4-primitive-types)'s 8-byte cap. Element `i` is at offset `16 + i * elem_size`, where `elem_size` is rounded up to the element's alignment (so successive elements remain aligned). Within an element, fields are at their natural alignment.
+The header is at `obj_ptr - 8` / `obj_ptr - 4` ([§5.1](#51-heap-object-header)). `obj_ptr` itself points at the start of the data region, where the vector stores a `length` field (`u64`, at `VEC_LENGTH_OFFSET = 0`). Element 0 starts at `VEC_DATA_OFFSET = 8` from `obj_ptr`, which is 8-byte aligned — sufficient for any primitive under [§4](#4-primitive-types)'s 8-byte cap. Element `i` is at offset `VEC_DATA_OFFSET + i * elem_size`, where `elem_size` is rounded up to the element's alignment (so successive elements remain aligned). Within an element, fields are at their natural alignment.
 
-This layout assumes element alignment is ≤ 16, which holds today and would still hold under any `MAX_ALIGN` ≤ 16. Stronger element alignment would require a per-vector data offset that the current micro-ops cannot express; see [§8.3](#83-vector-data-offset-under-stronger-element-alignment).
+This layout assumes element alignment is ≤ 8, which holds today. Stronger element alignment would require a per-vector data offset that the current micro-ops cannot express; see [§8.3](#83-vector-data-offset-under-stronger-element-alignment).
 
 ### 5.8 Closures
 
@@ -179,16 +182,18 @@ Struct size = 16, alignment = 8.
 
 **Example 2 — same struct, heap.**
 
+Offsets below are relative to `obj_ptr` (the data start). The 8-byte header `[desc_id | size]` lives at `obj_ptr - 8` and adds 8 bytes of allocator-owned reservation per object.
+
 | Offset | Content |
 |---|---|
-| 0–7 | header |
-| 8 | `a` (1 byte) |
-| 9–11 | pad |
-| 12 | `b` (4 bytes) |
-| 16 | `c` (8 bytes) |
-| 24 | end |
+| -8 .. 0 | header (allocator-owned) |
+| 0 | `a` (1 byte) |
+| 1–3 | pad |
+| 4 | `b` (4 bytes) |
+| 8 | `c` (8 bytes) |
+| 16 | end |
 
-Total object size = 24 (already a multiple of `MAX_ALIGN = 8`).
+Data-region size = 16. Total object size (header + data) = 24 — a multiple of `MAX_ALIGN = 8`.
 
 **Example 3 — nested struct, heap.**
 
@@ -206,19 +211,19 @@ Inner inline:
 
 Inner has alignment 4 and size 8: `x` occupies offsets 0–3 and `y` offset 4, with 3 bytes of trailing padding so that successive Inners (e.g., in a vector) keep `x` 4-aligned.
 
-Outer on the heap:
+Outer on the heap (offsets relative to `obj_ptr`; the header lives at `obj_ptr - 8`):
 
 | Offset | Content |
 |---|---|
-| 0–7 | header |
-| 8 | Outer.`a` (1B) |
-| 9–11 | pad (align Inner to 4) |
-| 12 | Inner.`x` (4B) |
-| 16 | Inner.`y` (1B) |
-| 17–19 | Inner trailing pad |
-| 20–23 | Outer trailing pad to `MAX_ALIGN` |
+| -8 .. 0 | header (allocator-owned) |
+| 0 | Outer.`a` (1B) |
+| 1–3 | pad (align Inner to 4) |
+| 4 | Inner.`x` (4B) |
+| 8 | Inner.`y` (1B) |
+| 9–11 | Inner trailing pad |
+| 12–15 | Outer trailing pad to `MAX_ALIGN` |
 
-Total object size = 24. Outer's body is 12 bytes (`a` + pad + Inner = 1 + 3 + 8); body alignment = 4.
+Data-region size = 16. Total object size = 24. Outer's body is 12 bytes (`a` + pad + Inner = 1 + 3 + 8); body alignment = 4.
 
 **Example 4 — enum, heap.**
 
@@ -231,15 +236,17 @@ enum Result {
 
 Variant region: max size = 8 (Ok's u64), max alignment = 8.
 
+Offsets relative to `obj_ptr`; header at `obj_ptr - 8`.
+
 | Offset | Content |
 |---|---|
-| 0–7 | header |
-| 8 | tag (1 byte conceptually; 8 bytes as currently stored) |
-| 9–15 | pad |
-| 16 | variant payload (8 bytes; `u64` for Ok, `u32` + 4B padding for Err) |
-| 24 | end |
+| -8 .. 0 | header (allocator-owned) |
+| 0 | tag (1 byte conceptually; 8 bytes as currently stored) |
+| 1–7 | pad |
+| 8 | variant payload (8 bytes; `u64` for Ok, `u32` + 4B padding for Err) |
+| 16 | end |
 
-Total object size = 24, body size = 16.
+Total object size = 24, data-region size = 16.
 
 **Example 5 — vector of struct.**
 
@@ -248,16 +255,18 @@ struct Point { x: u32, y: u32 }   // size 8, align 4
 let v: vector<Point>;             // 3 elements
 ```
 
+Offsets relative to `obj_ptr`; header at `obj_ptr - 8`.
+
 | Offset | Content |
 |---|---|
-| 0–7 | header |
-| 8–15 | length (u64) |
-| 16 | element 0: `x`@16, `y`@20 |
-| 24 | element 1: `x`@24, `y`@28 |
-| 32 | element 2: `x`@32, `y`@36 |
-| 40 | end |
+| -8 .. 0 | header (allocator-owned) |
+| 0–7 | length (u64) |
+| 8 | element 0: `x`@8, `y`@12 |
+| 16 | element 1: `x`@16, `y`@20 |
+| 24 | element 2: `x`@24, `y`@28 |
+| 32 | end |
 
-Total object size = 40 (already a multiple of `MAX_ALIGN`).
+Data-region size = 32. Total object size = 40 — a multiple of `MAX_ALIGN`.
 
 ## 6. Enforcement
 
@@ -316,9 +325,9 @@ We capped alignment at 8 for these types in [§4](#4-primitive-types). The argum
 
 The arguments against (and why we picked 8):
 
-- **Padding cost.** Raising any of these to 16 or 32 forces padding before the field in any container that doesn't start on a sufficiently aligned boundary — heap object bodies (which start at offset 8 after the header), inline structs at odd offsets, etc. That overhead applies to every object containing such a field, not just SIMD-hot ones.
+- **Padding cost.** Raising any of these to 16 or 32 forces padding before the field in any container that doesn't start on a sufficiently aligned boundary — inline structs at odd offsets, etc. That overhead applies to every object containing such a field, not just SIMD-hot ones.
 - **No SIMD use case today.** The hot path doesn't have wide-vector loads; the cost of higher alignment would be paid up front for unrealized future benefit.
-- **Container starts limited.** With a fixed 8-byte heap header, the body never naturally lands at a 16- or 32-aligned offset, so adopting stronger alignment would either require redesigning the header or paying header-side padding everywhere.
+- **Per-object header padding.** With `OBJECT_HEADER_SIZE = MAX_ALIGN`, raising `MAX_ALIGN` from 8 to 16 adds 8 bytes of unused header padding per heap object; 32 adds 24 bytes. Heap object bodies still start at `obj_ptr`, which the allocator guarantees is `MAX_ALIGN`-aligned — so no per-container layout change is needed when `MAX_ALIGN` grows. The cost is the padding, not the layout churn.
 
 The recommendation is to revisit if profiling shows arithmetic on `u128` / `u256` is hot, or if SIMD-based crypto natives become a measurable win. The constants are centralized, so the change is mostly mechanical (with the caveats from [§2](#2-the-max_align-constant)).
 
@@ -326,9 +335,9 @@ The recommendation is to revisit if profiling shows arithmetic on `u128` / `u256
 
 ### 8.3 Vector data offset under stronger element alignment
 
-Vector micro-ops compute the address of element `i` as `vec_ptr + VEC_DATA_OFFSET + i * elem_size`, where `VEC_DATA_OFFSET = OBJECT_HEADER_SIZE + 8 = 16` is a global constant. This works as long as every element alignment is ≤ 16, which is satisfied today (max is 8 per [§4](#4-primitive-types)) and would still be satisfied under any `MAX_ALIGN` ≤ 16.
+Vector micro-ops compute the address of element `i` as `vec_ptr + VEC_DATA_OFFSET + i * elem_size`, where `VEC_DATA_OFFSET = 8` is a global constant (the offset past the length field within the data region). This works as long as every element alignment is ≤ 8, which is satisfied today (max is 8 per [§4](#4-primitive-types)).
 
-If a future change introduces a vector element with alignment > 16 — most plausibly via [§8.2](#82-stronger-alignment-for-u128--u256--address--signer)'s stronger-alignment proposal for `address` / `u256` — the correct data offset becomes `align_up(OBJECT_HEADER_SIZE + 8, elem_align)`, which varies per vector. Unlike struct or enum field offsets — which are baked into each access op at specialization time — vector access uses an indexed pattern (`base + data_offset + i * elem_size`), so the data offset must be expressible as a single value the runtime can use across every elem load, store, push, pop, and growth on a given vector.
+If a future change introduces a vector element with alignment > 8 — most plausibly via [§8.2](#82-stronger-alignment-for-u128--u256--address--signer)'s stronger-alignment proposal for `address` / `u256` — the correct data offset becomes `align_up(8, elem_align)`, which varies per vector. Unlike struct or enum field offsets — which are baked into each access op at specialization time — vector access uses an indexed pattern (`base + data_offset + i * elem_size`), so the data offset must be expressible as a single value the runtime can use across every elem load, store, push, pop, and growth on a given vector.
 
 The current micro-op design has no channel for this: `VecLoadElem`, `VecStoreElem`, `VecPushBack`, `VecPopBack`, `AllocVec`, and `GrowVec` all rely on a hardcoded `VEC_DATA_OFFSET`. Bridging the gap would require adding per-vector or per-instruction data-offset metadata, or globally raising `VEC_DATA_OFFSET`, each with its own cost profile.
 

--- a/third_party/move/mono-move/docs/value_representation.md
+++ b/third_party/move/mono-move/docs/value_representation.md
@@ -16,16 +16,24 @@ For the alignment story (per-primitive alignments, references, and how it flows 
 
 ## Heap Object Header
 
-All heap objects (structs, enums, vectors, and any future heap types) share a universal 8-byte header:
+All heap objects (structs, enums, vectors, and any future heap types) share a universal 8-byte header `[desc_id: u32 | size: u32]`. The header lives at a *negative* offset relative to the object pointer that callers hold — `obj_ptr` points at the start of the data region, and the header sits in the bytes immediately before it:
 
 ```
-┌──────────────────────────┐
-│ desc_id(4) | size(4)     │  8 bytes
-└──────────────────────────┘
+                     obj_ptr
+                        │
+                        ▼
+┌──────────────────────┬──────────────────────────┐
+│ desc_id(4) | size(4) │  data region             │
+└──────────────────────┴──────────────────────────┘
+   header (-8..-4..0)
 ```
 
-- `desc_id` (`u32`): indexes into the descriptor table, telling the GC how to trace internal pointers.
-- `size` (`u32`): total object size in bytes (header + data, 8-byte aligned), so the GC can skip over objects during linear heap scanning (Cheney's algorithm).
+- `desc_id` (`u32`, at `obj_ptr - 8`): indexes into the descriptor table, telling the GC how to trace internal pointers.
+- `size` (`u32`, at `obj_ptr - 4`): total object size in bytes (header + data, `MAX_ALIGN`-aligned), so the GC can skip over objects during linear heap scanning (Cheney's algorithm).
+
+The allocator reserves `OBJECT_HEADER_SIZE = MAX_ALIGN` bytes before each data region so that `obj_ptr` is itself `MAX_ALIGN`-aligned. When `MAX_ALIGN > 8`, the unused bytes precede `desc_id` (which stays adjacent to the data at offset `-8`); the negative-offset constants don't shift.
+
+Treating the header as allocator-only bookkeeping means per-type layouts (struct fields, enum tag/variants, vector length/data, closures, captured data) describe their data region exclusively — field 0 of a heap struct is at offset 0, the vector length is at offset 0, etc.
 
 ## Structs
 
@@ -45,17 +53,16 @@ Inline structs may not be explicitly reflected in runtime code, as they are alre
 
 ### Heap structs
 
-An 8-byte pointer in the enclosing memory region points to a heap object with the standard header followed by fields.
+An 8-byte pointer in the enclosing memory region points to the data region of a heap object. The header sits in the bytes immediately preceding the pointer's target.
 
 ```
 Owner region                       Heap
 ┌────────┐                  ┌──────────────────────────┐
-│   ●────┼─────────────────►│ desc_id(4) | size(4)     │  header
-│        │                  ├──────────────────────────┤
-└────────┘                  │ field_0                  │
-  8 bytes                   │ field_1                  │
-                            │ ...                      │
-                            └──────────────────────────┘
+│        │                  │ desc_id(4) | size(4)     │  header (-8..0)
+│   ●────┼─────────────────►│ field_0                  │  obj_ptr
+│        │                  │ field_1                  │
+└────────┘                  │ ...                      │
+  8 bytes                   └──────────────────────────┘
 ```
 
 The `desc_id` indexes into the descriptor table so the GC knows which field offsets hold heap pointers (`ObjectDescriptor::Struct`).
@@ -77,12 +84,11 @@ The current runtime implements only heap enums:
 ```
 Owner region                       Heap
 ┌────────┐                  ┌──────────────────────────┐
-│   ●────┼─────────────────►│ desc_id(4) | size(4)     │  header
+│        │                  │ desc_id(4) | size(4)     │  header (-8..0)
+│   ●────┼─────────────────►│ tag                      │  obj_ptr
 │        │                  ├──────────────────────────┤
-└────────┘                  │ tag                      │
-  8 bytes                   ├──────────────────────────┤
-                            │ variant fields           │
-                            └──────────────────────────┘
+└────────┘                  │ variant fields           │
+  8 bytes                   └──────────────────────────┘
 ```
 
 The GC traces enums via `ObjectDescriptor::Enum`, which provides per-variant pointer offset lists indexed by the tag.
@@ -100,17 +106,16 @@ An 8-byte pointer in the enclosing memory region points to a heap object (or nul
 ```
 Owner region                  Heap
 ┌────────┐             ┌──────────────────────────┐
-│   ●────┼────────────►│ desc_id(4) | size(4)     │  header
+│        │             │ desc_id(4) | size(4)     │  header (-8..0)
+│   ●────┼────────────►│ length (u64)             │  obj_ptr (offset 0)
 │        │             ├──────────────────────────┤
-└────────┘             │ length (u64)             │
-  8 bytes              ├──────────────────────────┤
-  (or null             │ elem_0                   │
-   if empty)           │ elem_1                   │
-                       │ ...                      │
-                       └──────────────────────────┘
+└────────┘             │ elem_0                   │
+  8 bytes              │ elem_1                   │
+  (or null             │ ...                      │
+   if empty)           └──────────────────────────┘
 ```
 
-The vector's metadata (length) lives on the heap alongside the element data. The GC needs the length to know how many elements to trace for inner pointers. Capacity is not stored explicitly — it is derived from the header: `cap = (size - VEC_DATA_OFFSET) / elem_size`.
+The vector's metadata (length) lives on the heap alongside the element data. The GC needs the length to know how many elements to trace for inner pointers. Capacity is not stored explicitly — it is derived from the header: `cap = (size - OBJECT_HEADER_SIZE - VEC_DATA_OFFSET) / elem_size`.
 
 A null pointer represents an empty vector with no heap allocation. `VecNew` writes null; the first `VecPushBack` allocates lazily.
 
@@ -123,27 +128,25 @@ For element alignment within vectors, see [`memory_alignment.md`](memory_alignme
 ### Heap struct containing a vector field
 
 ```
-Owner region         Heap (struct)                  Heap (vector)
-┌────────┐    ┌──────────────────────┐       ┌──────────────────────┐
-│   ●────┼───►│ desc_id(4) | size(4) │       │ desc_id(4) | size(4) │
-└────────┘    ├──────────────────────┤       ├──────────────────────┤
-              │ some_field           │       │ length (u64)         │
-              │ vec_ptr  ●───────────┼──────►│ elem_0               │
-              └──────────────────────┘       │ elem_1               │
-                                             │ ...                  │
-                                             └──────────────────────┘
+Owner region         Heap (struct)                Heap (vector)
+┌────────┐    ┌──────────────────────┐     ┌──────────────────────┐
+│        │    │ desc_id(4) | size(4) │     │ desc_id(4) | size(4) │
+│   ●────┼───►│ some_field           │     │ length (u64)         │
+└────────┘    │ vec_ptr  ●───────────┼────►│ elem_0               │
+              └──────────────────────┘     │ elem_1               │
+                                           │ ...                  │
+                                           └──────────────────────┘
 ```
 
 ### Heap struct containing another heap struct
 
 ```
-Owner region         Heap (outer)                    Heap (inner)
-┌────────┐    ┌──────────────────────┐        ┌──────────────────────┐
-│   ●────┼───►│ desc_id(4) | size(4) │        │ desc_id(4) | size(4) │
-└────────┘    ├──────────────────────┤        ├──────────────────────┤
-              │ inner_ptr ●──────────┼───────►│ field_0              │
-              │ other_field          │        │ field_1              │
-              └──────────────────────┘        └──────────────────────┘
+Owner region         Heap (outer)               Heap (inner)
+┌────────┐    ┌──────────────────────┐    ┌──────────────────────┐
+│        │    │ desc_id(4) | size(4) │    │ desc_id(4) | size(4) │
+│   ●────┼───►│ inner_ptr ●──────────┼───►│ field_0              │
+└────────┘    │ other_field          │    │ field_1              │
+              └──────────────────────┘    └──────────────────────┘
 ```
 
 ## References (Fat Pointers)
@@ -172,10 +175,10 @@ The base pointer points directly to the local's slot. The offset is always 0. Si
 ### Reference to a heap struct field
 
 ```
-  ref = (heap_ptr, STRUCT_DATA_OFFSET + field_offset)
+  ref = (heap_ptr, field_offset)
 ```
 
-Base points to the heap object. The GC can relocate the struct and update the base pointer; the field offset stays the same.
+Base points to the heap object's data region. The field offset is the byte offset of the field within the data region (the header is at a negative offset and is invisible to references). The GC can relocate the struct and update the base pointer; the field offset stays the same.
 
 ### Reference to a vector element
 
@@ -183,7 +186,7 @@ Base points to the heap object. The GC can relocate the struct and update the ba
   ref = (vec_heap_ptr, VEC_DATA_OFFSET + idx * elem_size)
 ```
 
-Base points to the vector's heap object. Safe as long as no growth occurs while the borrow is live (enforced by Move's borrow checker).
+Base points to the vector's heap object. `VEC_DATA_OFFSET` (= 8) skips the length field at the start of the data region. Safe as long as no growth occurs while the borrow is live (enforced by Move's borrow checker).
 
 ### Alternative: raw pointer references
 

--- a/third_party/move/mono-move/orchestrator/src/builder.rs
+++ b/third_party/move/mono-move/orchestrator/src/builder.rs
@@ -15,7 +15,8 @@
 use anyhow::{anyhow, bail, Result};
 use mono_move_alloc::{ExecutableArena, ExecutableArenaPtr, GlobalArenaPtr};
 use mono_move_core::{
-    types::{align_up, view_type, Type},
+    align_up_u32,
+    types::{view_type, Type},
     EnumType, Executable, ExecutableId, FrameLayoutInfo, Function, MicroOp, PreparedModule,
     SortedSafePointEntries, StructType, VariantFields,
 };
@@ -276,12 +277,12 @@ impl<'guard, 'ctx> ExecutableBuilder<'guard, 'ctx> {
                     let (sz, al) = view_type(fty).size_and_align().ok_or_else(|| {
                         anyhow!("Size and alignment is set for non-generic types")
                     })?;
-                    offset = align_up(offset, al);
+                    offset = align_up_u32(offset, al);
                     align = align.max(al);
                     fields.push(FieldLayout::new(offset, fty));
                     offset += sz;
                 }
-                let size = align_up(offset, align);
+                let size = align_up_u32(offset, align);
                 self.guard
                     .set_nominal_layout(bare_ty, size, align, Some(&fields))?;
                 self.structs.insert(name, StructType::new(bare_ty));

--- a/third_party/move/mono-move/programs/src/bst.rs
+++ b/third_party/move/mono-move/programs/src/bst.rs
@@ -340,7 +340,7 @@ mod micro_op {
             Op::struct_store8(FO(bst), BST_NODES, FO(nodes)),                 // 3
             Op::struct_store8(FO(bst), BST_FREE_LIST, FO(free_list)),         // 4
             HeapMoveToImm8 { heap_ptr: FO(bst),
-                             offset: 8 + BST_ROOT, imm: NULL },                   // 5: STRUCT_DATA_OFFSET=8
+                             offset: BST_ROOT, imm: NULL },                       // 5
             Return,                                                                // 6
         ];
 

--- a/third_party/move/mono-move/runtime/AGENTS.md
+++ b/third_party/move/mono-move/runtime/AGENTS.md
@@ -27,7 +27,7 @@ The runtime is at proof-of-concept stage. See `TODO.md` for the backlog of missi
 
 **Bump-allocated heap with copying GC.** Heap objects (vectors, structs, enums) are bump-allocated. When the bump pointer hits the end, Cheney's copying GC runs: it walks the call stack using per-function `frame_layout` (and per-safe-point `safe_point_layouts`) to find roots, then does a breadth-first copy of all reachable objects into a fresh to-space. Forwarding pointers handle cycles and double-scans.
 
-**Object layout.** Every heap object starts with an 8-byte header: `[descriptor_id: u32, size_in_bytes: u32]`. The descriptor tells the GC how to trace internal pointers. Vectors additionally store a `length` field after the header (capacity is derived from `size_in_bytes`).
+**Object layout.** Every heap object has an 8-byte header `[descriptor_id: u32, size_in_bytes: u32]` at *negative* offsets relative to the object pointer (descriptor at `obj_ptr - 8`, size at `obj_ptr - 4`). The allocator reserves `OBJECT_HEADER_SIZE = MAX_ALIGN` bytes before each data region; when `MAX_ALIGN > 8` the leading bytes are unused header padding, keeping the data start `MAX_ALIGN`-aligned. Per-type layouts (struct fields, enum tag/variants, vector length/data, closure fields, captured-data values) are expressed relative to the data start, so the shared header is invisible to them. Vectors store a `length` field at offset 0 of the data region (capacity is derived from `size_in_bytes`). The descriptor tells the GC how to trace internal pointers.
 
 **Fat pointers.** References are 16-byte `(base_ptr, byte_offset)` pairs. This lets borrows point into the interior of heap objects (e.g., a struct field or vector element) without a separate indirection.
 
@@ -39,7 +39,7 @@ The interpreter uses raw pointer arithmetic extensively (`unsafe`). Correctness 
 
 1. **Frame metadata integrity** — saved `fp`/`pc`/`func_ptr` are written only by call/return, never by user micro-ops
 2. **Pointer-slot accuracy** — `Function::frame_layout` (and matching `safe_point_layouts` entries) together exactly match slots that hold live heap pointers
-3. **Object header integrity** — `descriptor_id` and `size` are set by the allocator and never overwritten by user code
+3. **Object header integrity** — `descriptor_id` and `size` live at fixed negative offsets (`obj_ptr - 8` / `obj_ptr - 4`) set by the allocator; user micro-ops only access offsets within the data region (≥ 0) so they cannot reach the header
 
 The verifier checks what it can statically; the rest is the compiler's responsibility.
 

--- a/third_party/move/mono-move/runtime/src/heap/mod.rs
+++ b/third_party/move/mono-move/runtime/src/heap/mod.rs
@@ -16,17 +16,19 @@ use crate::{
     bail,
     error::ExecutionResult,
     heap::object_descriptor::{ObjectDescriptor, ObjectDescriptorInner},
-    memory::{read_ptr, read_u32, read_u64, write_ptr, write_u32, write_u64, MemoryRegion},
+    memory::{
+        read_descriptor, read_forwarding, read_obj_size, read_ptr, read_u64, write_descriptor,
+        write_forwarding, write_obj_size, write_ptr, write_u64, MemoryRegion,
+    },
     types::{
-        DEFAULT_HEAP_SIZE, FORWARDED_MARKER, HEADER_DESCRIPTOR_OFFSET, HEADER_SIZE_OFFSET,
-        META_SAVED_FP_OFFSET, META_SAVED_FUNC_PTR_OFFSET, META_SAVED_PC_OFFSET, VEC_DATA_OFFSET,
-        VEC_LENGTH_OFFSET,
+        DEFAULT_HEAP_SIZE, FORWARDED_MARKER, META_SAVED_FP_OFFSET, META_SAVED_FUNC_PTR_OFFSET,
+        META_SAVED_PC_OFFSET, VEC_DATA_OFFSET, VEC_LENGTH_OFFSET,
     },
 };
 use mono_move_core::{
-    align_max, DescriptorId, FrameOffset, Function, CAPTURED_DATA_VALUES_OFFSET,
-    CLOSURE_CAPTURED_DATA_PTR_OFFSET, CLOSURE_OBJECT_SIZE, ENUM_DATA_OFFSET, ENUM_TAG_OFFSET,
-    FRAME_METADATA_SIZE, OBJECT_HEADER_SIZE, STRUCT_DATA_OFFSET,
+    align_max, checked_align_max, DescriptorId, FrameOffset, Function, CAPTURED_DATA_VALUES_OFFSET,
+    CLOSURE_CAPTURED_DATA_PTR_OFFSET, CLOSURE_DATA_SIZE, ENUM_DATA_OFFSET, ENUM_TAG_OFFSET,
+    FRAME_METADATA_SIZE, OBJECT_HEADER_SIZE,
 };
 use pinned_roots::PinnedRoots;
 use std::ptr::NonNull;
@@ -78,9 +80,15 @@ pub(crate) mod macros {
     pub(crate) use alloc_obj;
 
     /// Forwards to [`super::alloc_vec`]. Arguments: (`$ctx`, `$fp`,
-    /// `$descriptor_id`, `$elem_size`, `$capacity`).
+    /// `$descriptor_id`, `$elem_size`, `$capacity_in_elems`).
     macro_rules! alloc_vec {
-        ($ctx:ident, $fp:expr, $descriptor_id:expr, $elem_size:expr, $capacity:expr $(,)?) => {
+        (
+            $ctx:ident,
+            $fp:expr,
+            $descriptor_id:expr,
+            $elem_size:expr,
+            $capacity_in_elems:expr $(,)?
+        ) => {
             $crate::heap::alloc_vec(
                 &mut $ctx.heap,
                 $ctx.descriptors,
@@ -90,16 +98,22 @@ pub(crate) mod macros {
                 $ctx.pc,
                 $descriptor_id,
                 $elem_size,
-                $capacity,
+                $capacity_in_elems,
             )
         };
     }
     pub(crate) use alloc_vec;
 
     /// Forwards to [`super::grow_vec_ref`]. Arguments: (`$ctx`, `$fp`,
-    /// `$vec_ref_offset`, `$elem_size`, `$required_cap`).
+    /// `$vec_ref_offset`, `$elem_size`, `$required_cap_in_elems`).
     macro_rules! grow_vec_ref {
-        ($ctx:ident, $fp:expr, $vec_ref_offset:expr, $elem_size:expr, $required_cap:expr $(,)?) => {
+        (
+            $ctx:ident,
+            $fp:expr,
+            $vec_ref_offset:expr,
+            $elem_size:expr,
+            $required_cap_in_elems:expr $(,)?
+        ) => {
             $crate::heap::grow_vec_ref(
                 &mut $ctx.heap,
                 $ctx.descriptors,
@@ -109,7 +123,7 @@ pub(crate) mod macros {
                 $fp,
                 $vec_ref_offset,
                 $elem_size,
-                $required_cap,
+                $required_cap_in_elems,
             )
         };
     }
@@ -161,8 +175,11 @@ pub struct Heap {
     /// Backing memory. Swapped with a fresh `MemoryRegion` on every GC
     /// (`to_space` becomes the new `buffer`).
     pub(crate) buffer: MemoryRegion,
-    /// Next free byte in `buffer`. Invariant: always within
-    /// `[buffer.as_ptr(), buffer.as_ptr() + buffer.len()]`.
+    /// Next free byte in `buffer` — i.e., the start of the next header
+    /// reservation. Object pointers returned to callers are
+    /// `bump_ptr + OBJECT_HEADER_SIZE` (data-region start). Invariant:
+    /// always within `[buffer.as_ptr(), buffer.as_ptr() + buffer.len()]`
+    /// and `MAX_ALIGN`-aligned.
     pub(crate) bump_ptr: *mut u8,
     /// Number of times the GC has run. Exposed for tests / diagnostics.
     pub(crate) gc_count: usize,
@@ -183,53 +200,76 @@ impl Heap {
 // Allocation
 // ---------------------------------------------------------------------------
 
-/// Allocate `size` bytes (8-byte aligned) on the heap.
+/// Allocate `total_size` bytes on the heap and initialize the header.
+/// `total_size` covers header + payload; the function rounds it up to
+/// `MAX_ALIGN`, allocates, and writes both header fields (`descriptor_id`
+/// and the aligned size) before returning the **object pointer** — the
+/// data-region start at `header_start + OBJECT_HEADER_SIZE`. Callers
+/// only need to populate the data region (e.g. vector length, captured
+/// values).
+///
 /// Triggers GC if the bump allocator is full; fails on OOM after GC.
 ///
 /// `fp`, `current_func`, `pc` describe the top of the call stack so that GC
 /// (if triggered) can walk frames to find roots. `pinned_roots` is the
 /// auxiliary root set.
-pub(crate) fn heap_alloc(
+fn heap_alloc(
     heap: &mut Heap,
     descriptors: &[ObjectDescriptor],
     pinned_roots: &PinnedRoots,
     fp: *mut u8,
     current_func: NonNull<Function>,
     pc: usize,
-    size: usize,
+    total_size: usize,
+    descriptor_id: DescriptorId,
 ) -> ExecutionResult<*mut u8> {
-    if size == 0 {
-        bail!("heap_alloc: size must not be zero");
-    }
-    if size > MAX_SINGLE_ALLOCATION_SIZE {
+    // Round up to MAX_ALIGN with overflow protection; the
+    // `MAX_SINGLE_ALLOCATION_SIZE` check below then applies to the
+    // *aligned* size so the rounding can't smuggle an oversize allocation
+    // past the bound.
+    let aligned_size = checked_align_max(total_size).ok_or_else(|| {
+        anyhow::anyhow!("heap_alloc: size {} overflows after alignment", total_size)
+    })?;
+    debug_assert!(aligned_size >= OBJECT_HEADER_SIZE);
+    if aligned_size > MAX_SINGLE_ALLOCATION_SIZE {
         bail!(
             "heap_alloc: size {} exceeds maximum single allocation size",
-            size
+            aligned_size
         );
     }
-    let aligned = align_max(size);
 
     // Bound check uses integer arithmetic on addresses rather than
-    // `bump_ptr.add(aligned)` against `buffer.as_ptr().add(buffer.len())`:
+    // `bump_ptr.add(aligned_size)` against `buffer.as_ptr().add(buffer.len())`:
     // pointer arithmetic that produces a result more than one byte past
     // the end of the buffer is UB, so we cannot legally form the
     // out-of-bounds pointer just to compare it.
-    if !fits_in_buffer(heap, aligned) {
+    if !fits_in_buffer(heap, aligned_size) {
         gc_collect(heap, descriptors, pinned_roots, fp, current_func, pc)?;
-        if !fits_in_buffer(heap, aligned) {
-            bail!("out of heap memory after GC (requested {} bytes)", size);
+        if !fits_in_buffer(heap, aligned_size) {
+            bail!(
+                "out of heap memory after GC (requested {} bytes)",
+                aligned_size
+            );
         }
     }
 
     unsafe {
-        let ptr = heap.bump_ptr;
-        heap.bump_ptr = ptr.add(aligned);
-        std::ptr::write_bytes(ptr, 0, aligned);
-        Ok(ptr)
+        let header_start = heap.bump_ptr;
+        heap.bump_ptr = header_start.add(aligned_size);
+        std::ptr::write_bytes(header_start, 0, aligned_size);
+        let obj_ptr = header_start.add(OBJECT_HEADER_SIZE);
+        write_descriptor(obj_ptr, descriptor_id.as_u32());
+        write_obj_size(obj_ptr, aligned_size as u32);
+        Ok(obj_ptr)
     }
 }
 
-/// Allocate a new vector object on the heap with the given parameters.
+/// Allocate a new vector object on the heap.
+///
+/// `capacity_in_elems` is the number of elements the vector can hold
+/// before needing to grow — *not* a byte size. Total bytes allocated
+/// are roughly `capacity_in_elems * elem_size + OBJECT_HEADER_SIZE +
+/// VEC_DATA_OFFSET`, rounded up to `MAX_ALIGN`.
 pub(crate) fn alloc_vec(
     heap: &mut Heap,
     descriptors: &[ObjectDescriptor],
@@ -239,14 +279,13 @@ pub(crate) fn alloc_vec(
     pc: usize,
     descriptor_id: DescriptorId,
     elem_size: u32,
-    capacity: u64,
+    capacity_in_elems: u64,
 ) -> ExecutionResult<*mut u8> {
-    let total_size = (capacity as usize)
+    let total_size = (capacity_in_elems as usize)
         .checked_mul(elem_size as usize)
-        .and_then(|v| v.checked_add(VEC_DATA_OFFSET))
+        .and_then(|v| v.checked_add(OBJECT_HEADER_SIZE + VEC_DATA_OFFSET))
         .ok_or_else(|| anyhow::anyhow!("alloc_vec: size overflow"))?;
-    let aligned_size = align_max(total_size);
-    let ptr = heap_alloc(
+    heap_alloc(
         heap,
         descriptors,
         pinned_roots,
@@ -254,13 +293,9 @@ pub(crate) fn alloc_vec(
         current_func,
         pc,
         total_size,
-    )?;
-    unsafe {
-        write_u32(ptr, HEADER_DESCRIPTOR_OFFSET, descriptor_id.as_u32());
-        write_u32(ptr, HEADER_SIZE_OFFSET, aligned_size as u32);
-        write_u64(ptr, VEC_LENGTH_OFFSET, 0);
-    }
-    Ok(ptr)
+        descriptor_id,
+    )
+    // `length` defaults to 0 via heap_alloc's zero-init.
 }
 
 /// Allocate a new zeroed heap object (struct or enum). Size comes from the
@@ -277,37 +312,32 @@ pub(crate) fn alloc_obj(
     let payload_size = match descriptors[descriptor_id.as_usize()].inner() {
         ObjectDescriptorInner::Struct { size, .. } => *size as usize,
         ObjectDescriptorInner::Enum { size, .. } => *size as usize,
-        ObjectDescriptorInner::Closure => CLOSURE_OBJECT_SIZE - OBJECT_HEADER_SIZE,
+        ObjectDescriptorInner::Closure => CLOSURE_DATA_SIZE,
         ObjectDescriptorInner::CapturedData { size, .. } => {
             // Add the 8-byte tag+padding prefix to the values-region size.
-            (CAPTURED_DATA_VALUES_OFFSET - OBJECT_HEADER_SIZE) + *size as usize
+            CAPTURED_DATA_VALUES_OFFSET + *size as usize
         },
         ObjectDescriptorInner::Trivial | ObjectDescriptorInner::Vector { .. } => bail!(
             "alloc_obj called with non-allocatable descriptor {}",
             descriptor_id
         ),
     };
-    let total_size = OBJECT_HEADER_SIZE + payload_size;
-    let aligned_size = align_max(total_size);
-    let ptr = heap_alloc(
+    heap_alloc(
         heap,
         descriptors,
         pinned_roots,
         fp,
         current_func,
         pc,
-        total_size,
-    )?;
-    unsafe {
-        write_u32(ptr, HEADER_DESCRIPTOR_OFFSET, descriptor_id.as_u32());
-        write_u32(ptr, HEADER_SIZE_OFFSET, aligned_size as u32);
-    }
-    Ok(ptr)
+        OBJECT_HEADER_SIZE + payload_size,
+        descriptor_id,
+    )
 }
 
-/// Grow a vector to at least `required_cap` elements, accessed through
-/// a fat pointer reference at `fp + vec_ref_offset`. The vector pointer
-/// is written back through the reference; returns the new object pointer.
+/// Grow a vector to at least `required_cap_in_elems` elements, accessed
+/// through a fat pointer reference at `fp + vec_ref_offset`. The vector
+/// pointer is written back through the reference; returns the new object
+/// pointer.
 ///
 /// # Safety
 ///
@@ -326,7 +356,7 @@ pub(crate) fn grow_vec_ref(
     fp: *mut u8,
     vec_ref_offset: usize,
     elem_size: u32,
-    required_cap: u64,
+    required_cap_in_elems: u64,
 ) -> ExecutionResult<*mut u8> {
     unsafe {
         let base = read_ptr(fp, vec_ref_offset);
@@ -334,13 +364,18 @@ pub(crate) fn grow_vec_ref(
         let old_ptr = read_ptr(base, off);
 
         let old_len = read_u64(old_ptr, VEC_LENGTH_OFFSET);
-        let old_size = read_u32(old_ptr, HEADER_SIZE_OFFSET) as usize;
-        let old_cap = ((old_size - VEC_DATA_OFFSET) / elem_size as usize) as u64;
-        let descriptor_id = DescriptorId(read_u32(old_ptr, HEADER_DESCRIPTOR_OFFSET));
+        let old_total = read_obj_size(old_ptr) as usize;
+        let old_cap_in_elems =
+            ((old_total - OBJECT_HEADER_SIZE - VEC_DATA_OFFSET) / elem_size as usize) as u64;
+        let descriptor_id = DescriptorId(read_descriptor(old_ptr));
 
-        let mut new_cap = if old_cap == 0 { 4 } else { old_cap * 2 };
-        if new_cap < required_cap {
-            new_cap = required_cap;
+        let mut new_cap_in_elems = if old_cap_in_elems == 0 {
+            4
+        } else {
+            old_cap_in_elems * 2
+        };
+        if new_cap_in_elems < required_cap_in_elems {
+            new_cap_in_elems = required_cap_in_elems;
         }
 
         // alloc_vec may trigger GC. Re-read through the fat pointer afterward.
@@ -353,7 +388,7 @@ pub(crate) fn grow_vec_ref(
             pc,
             descriptor_id,
             elem_size,
-            new_cap,
+            new_cap_in_elems,
         )?;
         let base = read_ptr(fp, vec_ref_offset);
         let off = read_u64(fp, vec_ref_offset + 8) as usize;
@@ -412,6 +447,13 @@ pub(crate) fn gc_collect(
     heap.gc_count += 1;
 
     let to_space = MemoryRegion::new(heap.buffer.len());
+    // `free_ptr` is a raw bump cursor — it points at the start of the
+    // next *header* reservation, advancing by each object's total size.
+    // Treating it as a raw cursor (rather than as an "object pointer"
+    // biased by OBJECT_HEADER_SIZE) keeps its maximum value at
+    // `to_space.end()`, which is the one-past-end address that pointer
+    // arithmetic permits. A `+ H` bias would let it overshoot when all
+    // of from-space survives, producing UB on `.add` / `.sub`.
     let mut free_ptr = to_space.as_ptr();
 
     // Phase 1: scan roots from the call stack.
@@ -477,6 +519,8 @@ pub(crate) fn gc_collect(
     }
 
     // Phase 2: Cheney-style breadth-first scan of copied objects.
+    // `scan_ptr` is a raw cursor — header start of the next object to
+    // scan. Object pointers (data starts) are `scan_ptr + H`.
     let mut scan_ptr = to_space.as_ptr();
     while (scan_ptr as usize) < (free_ptr as usize) {
         // SAFETY: scan_ptr advances through to-space by each object's
@@ -484,8 +528,9 @@ pub(crate) fn gc_collect(
         // gc_copy_object, so descriptor_id and size are valid as long
         // as the object-header-integrity invariant holds (see above).
         unsafe {
-            let descriptor_id = read_u32(scan_ptr, HEADER_DESCRIPTOR_OFFSET);
-            let obj_size = read_u32(scan_ptr, HEADER_SIZE_OFFSET) as usize;
+            let obj_ptr = scan_ptr.add(OBJECT_HEADER_SIZE);
+            let descriptor_id = read_descriptor(obj_ptr);
+            let obj_size = read_obj_size(obj_ptr) as usize;
 
             if obj_size == 0 || obj_size != align_max(obj_size) {
                 bail!(
@@ -497,13 +542,15 @@ pub(crate) fn gc_collect(
             if descriptor_id == FORWARDED_MARKER {
                 bail!("GC found forwarding marker in to-space (invariant violation)");
             }
-            gc_scan_object(descriptors, heap, scan_ptr, descriptor_id, &mut free_ptr);
+            gc_scan_object(descriptors, heap, obj_ptr, descriptor_id, &mut free_ptr);
 
             scan_ptr = scan_ptr.add(obj_size);
         }
     }
 
-    // Phase 3: swap — drop old heap, adopt new one.
+    // Phase 3: swap — drop old heap, adopt new one. The bump cursor
+    // semantics match `free_ptr` directly (both are raw header-start
+    // cursors).
     heap.buffer = to_space;
     heap.bump_ptr = free_ptr;
     Ok(())
@@ -543,41 +590,54 @@ unsafe fn gc_scan_frame_roots(
     }
 }
 
-/// Copy a single object from the old heap into to-space (at `*free_ptr`),
+/// Copy a single object from the old heap into to-space at `*free_ptr`,
 /// writing a forwarding pointer in the old location. If the object is
 /// already forwarded, just return the forwarding address.
 ///
+/// `old_ptr` and the returned pointer are *object pointers* (data-region
+/// starts); the header lives at `obj_ptr - OBJECT_HEADER_SIZE`. The
+/// forwarding pointer is parked at offset 0 of the data region (over the
+/// old object's first 8 payload bytes), and the descriptor field at
+/// `obj_ptr - 8` is overwritten with `FORWARDED_MARKER`.
+///
+/// `*free_ptr` is a raw bump cursor in to-space (header start of the
+/// next slot); after this call it advances by `obj_size`.
+///
 /// # Safety
 ///
-/// - `old_ptr` must point to the header of a live object in from-space.
-///   Its `descriptor_id` and `size` header fields must be valid (see
-///   object-header-integrity invariant on [`gc_collect`]).
-/// - `free_ptr` must point into to-space with at least `obj_size` bytes
-///   remaining (already 8-byte aligned).
+/// - `old_ptr` must point to the data region of a live object in
+///   from-space. Its `descriptor_id` and `size` header fields must be
+///   valid (see object-header-integrity invariant on [`gc_collect`]).
+/// - `*free_ptr` must point into to-space with at least `obj_size` bytes
+///   (header + payload) of room ahead.
 /// - The from-space object must not have been partially overwritten
 ///   except by a prior call to this function (which installs a
 ///   forwarding marker).
 fn gc_copy_object(old_ptr: *mut u8, free_ptr: &mut *mut u8) -> *mut u8 {
     unsafe {
-        let descriptor_id = read_u32(old_ptr, HEADER_DESCRIPTOR_OFFSET);
+        let descriptor_id = read_descriptor(old_ptr);
 
         if descriptor_id == FORWARDED_MARKER {
-            return read_ptr(old_ptr, OBJECT_HEADER_SIZE);
+            return read_forwarding(old_ptr);
         }
 
-        let obj_size = read_u32(old_ptr, HEADER_SIZE_OFFSET) as usize;
+        let obj_size = read_obj_size(old_ptr) as usize;
         debug_assert!(
-            obj_size > 0 && obj_size == align_max(obj_size),
+            obj_size >= OBJECT_HEADER_SIZE && obj_size == align_max(obj_size),
             "gc_copy_object: invalid object size {}",
             obj_size
         );
-        let new_ptr = *free_ptr;
 
-        std::ptr::copy_nonoverlapping(old_ptr, new_ptr, obj_size);
-        *free_ptr = new_ptr.add(obj_size);
+        // Move the `[header | payload]` block from from-space to
+        // to-space, then advance the raw bump cursor by `obj_size`. The
+        // returned obj_ptr is `new_header_start + H`.
+        let new_header_start = *free_ptr;
+        std::ptr::copy_nonoverlapping(old_ptr.sub(OBJECT_HEADER_SIZE), new_header_start, obj_size);
+        *free_ptr = new_header_start.add(obj_size);
+        let new_ptr = new_header_start.add(OBJECT_HEADER_SIZE);
 
-        write_u32(old_ptr, HEADER_DESCRIPTOR_OFFSET, FORWARDED_MARKER);
-        write_ptr(old_ptr, OBJECT_HEADER_SIZE, new_ptr);
+        write_descriptor(old_ptr, FORWARDED_MARKER);
+        write_forwarding(old_ptr, new_ptr);
 
         new_ptr
     }
@@ -613,6 +673,11 @@ fn gc_scan_object(
         return;
     };
 
+    // All offsets below are relative to `obj_ptr` (the data-region
+    // start). Struct field offsets are used directly as obj_ptr-relative
+    // byte offsets; `ENUM_DATA_OFFSET` / `VEC_DATA_OFFSET` /
+    // `CAPTURED_DATA_VALUES_OFFSET` are the small fixed prefixes for the
+    // tag / length / tag+padding.
     match desc.inner() {
         ObjectDescriptorInner::Trivial => {},
         ObjectDescriptorInner::Vector {
@@ -647,10 +712,10 @@ fn gc_scan_object(
             }
             unsafe {
                 for &off in pointer_offsets {
-                    let old_ptr = read_ptr(obj_ptr, STRUCT_DATA_OFFSET + off as usize);
+                    let old_ptr = read_ptr(obj_ptr, off as usize);
                     if !old_ptr.is_null() && is_heap_ptr(heap, old_ptr) {
                         let new_ptr = gc_copy_object(old_ptr, free_ptr);
-                        write_ptr(obj_ptr, STRUCT_DATA_OFFSET + off as usize, new_ptr);
+                        write_ptr(obj_ptr, off as usize, new_ptr);
                     }
                 }
             }
@@ -677,7 +742,7 @@ fn gc_scan_object(
         },
         ObjectDescriptorInner::Closure => unsafe {
             // The closure's only heap pointer is `captured_data_ptr` at a
-            // fixed payload offset.
+            // fixed data-region offset.
             let off = CLOSURE_CAPTURED_DATA_PTR_OFFSET;
             let old_ptr = read_ptr(obj_ptr, off);
             if !old_ptr.is_null() && is_heap_ptr(heap, old_ptr) {

--- a/third_party/move/mono-move/runtime/src/heap/mod.rs
+++ b/third_party/move/mono-move/runtime/src/heap/mod.rs
@@ -556,12 +556,25 @@ pub(crate) fn gc_collect(
     Ok(())
 }
 
-/// Returns true if `ptr` falls within the (from-space) heap buffer.
+/// Returns true if `ptr` is a valid object pointer (data-region start)
+/// in the from-space heap buffer.
+///
+/// Valid obj_ptrs lie in `[start + OBJECT_HEADER_SIZE, end]`:
+/// - The header at `obj_ptr - OBJECT_HEADER_SIZE` must be in-bounds
+///   (lower bound).
+/// - The data region `[obj_ptr, obj_ptr + payload)` must be in-bounds;
+///   `obj_ptr == end` is permitted for a zero-payload object whose
+///   header occupies the very last bytes of the buffer (upper bound).
+///
+/// Current descriptor validation enforces `payload_size > 0`, so
+/// `obj_ptr == end` is unreachable in practice. The bound is written
+/// to match the semantic invariant so it stays correct under future
+/// changes.
 fn is_heap_ptr(heap: &Heap, ptr: *const u8) -> bool {
     let start = heap.buffer.as_ptr() as usize;
     let end = start + heap.buffer.len();
     let p = ptr as usize;
-    p >= start && p < end
+    p >= start + OBJECT_HEADER_SIZE && p <= end
 }
 
 /// Scan a set of pointer offsets in a frame, copying any heap objects

--- a/third_party/move/mono-move/runtime/src/heap/object_descriptor.rs
+++ b/third_party/move/mono-move/runtime/src/heap/object_descriptor.rs
@@ -41,12 +41,12 @@ pub(crate) enum ObjectDescriptorInner {
 
     /// Closure object — fixed runtime layout shared by every closure.
     ///
-    /// Payload layout (`size = CLOSURE_OBJECT_SIZE - OBJECT_HEADER_SIZE = 32`):
+    /// Data-region layout (`size = CLOSURE_DATA_SIZE = 32`):
     /// `[func_ref(16)] [mask(8)] [captured_data_ptr(8)]`. The single heap
-    /// pointer is `captured_data_ptr` at payload offset
-    /// `CLOSURE_CAPTURED_DATA_PTR_OFFSET - OBJECT_HEADER_SIZE = 24`. Both
-    /// the size and the pointer offset are constants of the runtime
-    /// layout — there is nothing per-instance to store here.
+    /// pointer is `captured_data_ptr` at offset
+    /// `CLOSURE_CAPTURED_DATA_PTR_OFFSET = 24`. Both the size and the
+    /// pointer offset are constants of the runtime layout — there is
+    /// nothing per-instance to store here.
     Closure,
 
     /// Vector whose elements may contain heap pointers at known offsets.
@@ -69,7 +69,7 @@ pub(crate) enum ObjectDescriptorInner {
     },
 
     /// Enum (tagged union) allocated on the heap.
-    /// Layout: [header(8)] [tag: u64(8)] [fields padded to max variant size]
+    /// Data-region layout: [tag: u64(8)] [fields padded to max variant size]
     Enum {
         /// Total payload size in bytes (tag + max variant fields, excluding header).
         size: u32,
@@ -81,12 +81,11 @@ pub(crate) enum ObjectDescriptorInner {
 
     /// `ClosureCapturedData` (Materialized) object.
     ///
-    /// Object layout: `[header(8)] [tag(1) + padding(7)] [values...]`.
+    /// Data-region layout: `[tag(1) + padding(7)] [values...]`.
     /// `size` and `pointer_offsets` are interpreted relative to the
-    /// values region (i.e., excluding both the header and the
-    /// tag+padding prefix), so an offset of `0` names the first byte of
-    /// the first captured value. The 8-byte tag prefix is added
-    /// internally by the GC.
+    /// values region (i.e., excluding the tag+padding prefix), so an
+    /// offset of `0` names the first byte of the first captured value.
+    /// The 8-byte tag prefix is added internally by the GC.
     CapturedData {
         /// Byte size of the values region (sum of captured value sizes).
         size: u32,

--- a/third_party/move/mono-move/runtime/src/interpreter.rs
+++ b/third_party/move/mono-move/runtime/src/interpreter.rs
@@ -14,12 +14,12 @@ use crate::{
         Heap,
     },
     memory::{
-        read_ptr, read_u32, read_u64, read_u8, vec_elem_ptr, write_ptr, write_u64, MemoryRegion,
+        read_obj_size, read_ptr, read_u64, read_u8, vec_elem_ptr, write_ptr, write_u64,
+        MemoryRegion,
     },
     types::{
-        StepResult, DEFAULT_HEAP_SIZE, DEFAULT_STACK_SIZE, HEADER_SIZE_OFFSET,
-        META_SAVED_FP_OFFSET, META_SAVED_FUNC_PTR_OFFSET, META_SAVED_PC_OFFSET, VEC_DATA_OFFSET,
-        VEC_LENGTH_OFFSET,
+        StepResult, DEFAULT_HEAP_SIZE, DEFAULT_STACK_SIZE, META_SAVED_FP_OFFSET,
+        META_SAVED_FUNC_PTR_OFFSET, META_SAVED_PC_OFFSET, VEC_DATA_OFFSET, VEC_LENGTH_OFFSET,
     },
 };
 use mono_move_core::{
@@ -27,7 +27,7 @@ use mono_move_core::{
     PackClosureOp, SizedSlot, CAPTURED_DATA_TAG_MATERIALIZED, CAPTURED_DATA_TAG_OFFSET,
     CAPTURED_DATA_VALUES_OFFSET, CLOSURE_CAPTURED_DATA_PTR_OFFSET, CLOSURE_FUNC_REF_OFFSET,
     CLOSURE_MASK_OFFSET, FRAME_METADATA_SIZE, FUNC_REF_PAYLOAD_OFFSET, FUNC_REF_TAG_OFFSET,
-    FUNC_REF_TAG_RESOLVED,
+    FUNC_REF_TAG_RESOLVED, OBJECT_HEADER_SIZE,
 };
 use mono_move_gas::GasMeter;
 use rand::{rngs::StdRng, Rng, SeedableRng};
@@ -623,10 +623,11 @@ impl<T: ExecutionContext> InterpreterContext<'_, T> {
                     }
 
                     let len = read_u64(vec_ptr, VEC_LENGTH_OFFSET);
-                    let size = read_u32(vec_ptr, HEADER_SIZE_OFFSET) as usize;
-                    let cap = ((size - VEC_DATA_OFFSET) / elem_size as usize) as u64;
+                    let total = read_obj_size(vec_ptr) as usize;
+                    let cap_in_elems = ((total - OBJECT_HEADER_SIZE - VEC_DATA_OFFSET)
+                        / elem_size as usize) as u64;
 
-                    if len >= cap {
+                    if len >= cap_in_elems {
                         vec_ptr = grow_vec_ref!(self, fp, vec_ref.into(), elem_size, len + 1)?;
                     }
 

--- a/third_party/move/mono-move/runtime/src/memory.rs
+++ b/third_party/move/mono-move/runtime/src/memory.rs
@@ -123,3 +123,91 @@ pub unsafe fn vec_elem_ptr(vec_ptr: *const u8, idx: u64, elem_size: u32) -> *con
     // SAFETY: caller must uphold the documented pointer requirements.
     unsafe { vec_ptr.add(VEC_DATA_OFFSET + idx as usize * elem_size as usize) }
 }
+
+// ---------------------------------------------------------------------------
+// Heap object header access (negative offsets)
+// ---------------------------------------------------------------------------
+//
+// A heap object pointer (`obj_ptr`) points at the first byte of the object's
+// data region. The 8-byte `[desc_id: u32 | size: u32]` header sits in the
+// 8 bytes immediately preceding `obj_ptr` (i.e., at offsets -8 and -4). When
+// `MAX_ALIGN > 8`, the allocator reserves `OBJECT_HEADER_SIZE = MAX_ALIGN`
+// bytes before each data region so that the data start stays MAX_ALIGN-aligned;
+// the descriptor+size pair always lives at the last 8 bytes of that reservation
+// (i.e., adjacent to the data — good for cache locality, and the negative
+// offsets stay invariant across MAX_ALIGN values).
+
+/// Byte offset of `descriptor_id` (u32) from `obj_ptr`. Always `-8`.
+const HEADER_DESCRIPTOR_NEG_OFFSET: isize = -8;
+/// Byte offset of `size_in_bytes` (u32) from `obj_ptr`. Always `-4`.
+const HEADER_SIZE_NEG_OFFSET: isize = -4;
+
+/// Read the descriptor id from an object's header.
+///
+/// # Safety
+/// `obj_ptr` must point to the data region of a valid heap object whose
+/// header lies at `obj_ptr - 8`.
+#[inline(always)]
+pub(crate) unsafe fn read_descriptor(obj_ptr: *const u8) -> u32 {
+    // SAFETY: caller must uphold the documented pointer requirements.
+    unsafe { (obj_ptr.offset(HEADER_DESCRIPTOR_NEG_OFFSET) as *const u32).read() }
+}
+
+/// Write the descriptor id into an object's header.
+///
+/// # Safety
+/// `obj_ptr` must point to the data region of a writable heap object whose
+/// header lies at `obj_ptr - 8`.
+#[inline(always)]
+pub(crate) unsafe fn write_descriptor(obj_ptr: *mut u8, descriptor_id: u32) {
+    // SAFETY: caller must uphold the documented pointer requirements.
+    unsafe { (obj_ptr.offset(HEADER_DESCRIPTOR_NEG_OFFSET) as *mut u32).write(descriptor_id) }
+}
+
+/// Read the total object size (header + aligned payload) from the header.
+///
+/// # Safety
+/// `obj_ptr` must point to the data region of a valid heap object whose
+/// header lies at `obj_ptr - 8`.
+#[inline(always)]
+pub(crate) unsafe fn read_obj_size(obj_ptr: *const u8) -> u32 {
+    // SAFETY: caller must uphold the documented pointer requirements.
+    unsafe { (obj_ptr.offset(HEADER_SIZE_NEG_OFFSET) as *const u32).read() }
+}
+
+/// Write the total object size (header + aligned payload) into the header.
+///
+/// # Safety
+/// `obj_ptr` must point to the data region of a writable heap object whose
+/// header lies at `obj_ptr - 8`.
+#[inline(always)]
+pub(crate) unsafe fn write_obj_size(obj_ptr: *mut u8, size: u32) {
+    // SAFETY: caller must uphold the documented pointer requirements.
+    unsafe { (obj_ptr.offset(HEADER_SIZE_NEG_OFFSET) as *mut u32).write(size) }
+}
+
+/// Read the forwarding pointer that the GC writes into a forwarded-from-space
+/// object's first 8 data bytes.
+///
+/// # Safety
+/// `obj_ptr` must point to the data region of a forwarded heap object (i.e.,
+/// `read_descriptor(obj_ptr) == FORWARDED_MARKER`), with at least 8 bytes of
+/// data region.
+#[inline(always)]
+pub(crate) unsafe fn read_forwarding(obj_ptr: *const u8) -> *mut u8 {
+    // SAFETY: caller must uphold the documented pointer requirements.
+    unsafe { (obj_ptr as *const *mut u8).read() }
+}
+
+/// Write a forwarding pointer into a from-space object's first 8 data bytes.
+/// Used together with `write_descriptor(obj_ptr, FORWARDED_MARKER)` to mark
+/// an object as forwarded during GC.
+///
+/// # Safety
+/// `obj_ptr` must point to the data region of a writable heap object with
+/// at least 8 bytes of data region.
+#[inline(always)]
+pub(crate) unsafe fn write_forwarding(obj_ptr: *mut u8, new_ptr: *mut u8) {
+    // SAFETY: caller must uphold the documented pointer requirements.
+    unsafe { (obj_ptr as *mut *mut u8).write(new_ptr) }
+}

--- a/third_party/move/mono-move/runtime/src/types.rs
+++ b/third_party/move/mono-move/runtime/src/types.rs
@@ -5,7 +5,7 @@
 //!
 //! Object descriptors live in [`crate::heap::object_descriptor`].
 
-pub(crate) use mono_move_core::{MAX_ALIGN, OBJECT_HEADER_SIZE};
+pub(crate) use mono_move_core::MAX_ALIGN;
 
 // ---------------------------------------------------------------------------
 // Step result
@@ -27,11 +27,6 @@ pub(crate) const DEFAULT_STACK_SIZE: usize = 1024 * 1024; // 1 MiB
 
 pub(crate) const DEFAULT_HEAP_SIZE: usize = 10 * 1024 * 1024; // 10 MiB
 
-/// Byte offset of the `descriptor_id` (u32) within any heap object header.
-pub(crate) const HEADER_DESCRIPTOR_OFFSET: usize = 0;
-/// Byte offset of `size_in_bytes` (u32) within any heap object header.
-pub(crate) const HEADER_SIZE_OFFSET: usize = 4;
-
 /// Byte offset of `saved_pc` within frame metadata.
 pub(crate) const META_SAVED_PC_OFFSET: usize = 0;
 /// Byte offset of `saved_fp` within frame metadata.
@@ -39,18 +34,21 @@ pub(crate) const META_SAVED_FP_OFFSET: usize = 8;
 /// Byte offset of `saved_func_ptr` within frame metadata.
 pub(crate) const META_SAVED_FUNC_PTR_OFFSET: usize = 16;
 
-/// Offset of the `length` field within a vector object (after the header).
-pub const VEC_LENGTH_OFFSET: usize = OBJECT_HEADER_SIZE; // 8
-/// Offset where vector element data begins (after header + length).
+/// Offset of the `length` field within a vector object's data region.
+/// Vectors put the length at the very start of the data region; element 0
+/// begins at [`VEC_DATA_OFFSET`].
+pub const VEC_LENGTH_OFFSET: usize = 0;
+/// Offset where vector element data begins (after the `length` field).
 /// Capacity is not stored; it is derived from the header's `size_in_bytes`
-/// field: `capacity = (size_in_bytes - VEC_DATA_OFFSET) / elem_size`.
-pub const VEC_DATA_OFFSET: usize = OBJECT_HEADER_SIZE + 8; // 16
+/// field: `capacity = (size_in_bytes - OBJECT_HEADER_SIZE - VEC_DATA_OFFSET) / elem_size`.
+pub const VEC_DATA_OFFSET: usize = 8;
 
 // Element 0 must land on a `MAX_ALIGN`-aligned offset so that any element
-// type (whose alignment is ≤ `MAX_ALIGN`) is naturally aligned. If a future
-// change adds another field before the element data (e.g., capacity) and
-// pushes `VEC_DATA_OFFSET` to a non-`MAX_ALIGN` boundary, this assertion
-// catches it. See `docs/memory_alignment.md` (§8.3).
+// type (whose alignment is ≤ `MAX_ALIGN`) is naturally aligned. Object
+// pointers are `MAX_ALIGN`-aligned by the allocator ([§3.1] of
+// `docs/memory_alignment.md`), so this assertion guards that
+// `VEC_DATA_OFFSET` itself is also a `MAX_ALIGN` multiple. See
+// `docs/memory_alignment.md` (§8.3).
 const _: () = assert!(VEC_DATA_OFFSET.is_multiple_of(MAX_ALIGN));
 
 /// Marker written into the `descriptor_id` field of a forwarded object during GC.

--- a/third_party/move/mono-move/runtime/tests/gc_stress.rs
+++ b/third_party/move/mono-move/runtime/tests/gc_stress.rs
@@ -24,7 +24,7 @@
 use mono_move_alloc::{ExecutableArena, ExecutableArenaPtr, GlobalArenaPtr};
 use mono_move_core::{
     CodeOffset as CO, FrameLayoutInfo, FrameOffset as FO, Function, LocalExecutionContext, MicroOp,
-    SortedSafePointEntries, STRUCT_DATA_OFFSET,
+    SortedSafePointEntries,
 };
 use mono_move_runtime::{
     read_ptr, read_u64, InterpreterContext, ObjectDescriptor, ObjectDescriptorTable,
@@ -264,8 +264,8 @@ unsafe fn read_vm_outer_vec(outer_ptr: *const u8) -> Vec<(u64, Vec<u64>)> {
 
         for i in 0..outer_len {
             let entry_ptr = read_ptr(outer_ptr, VEC_DATA_OFFSET + i * 8);
-            let key = read_u64(entry_ptr, STRUCT_DATA_OFFSET);
-            let values_ptr = read_ptr(entry_ptr, STRUCT_DATA_OFFSET + 8);
+            let key = read_u64(entry_ptr, 0usize);
+            let values_ptr = read_ptr(entry_ptr, 8usize);
             let values_len = read_u64(values_ptr, VEC_LENGTH_OFFSET) as usize;
             let mut values = Vec::with_capacity(values_len);
             for j in 0..values_len {

--- a/third_party/move/mono-move/runtime/tests/ref_test.rs
+++ b/third_party/move/mono-move/runtime/tests/ref_test.rs
@@ -7,7 +7,7 @@
 use mono_move_alloc::{ExecutableArena, ExecutableArenaPtr, GlobalArenaPtr};
 use mono_move_core::{
     FrameLayoutInfo, FrameOffset as FO, Function, LocalExecutionContext, MicroOp,
-    SortedSafePointEntries, FRAME_METADATA_SIZE, STRUCT_DATA_OFFSET,
+    SortedSafePointEntries, FRAME_METADATA_SIZE,
 };
 use mono_move_runtime::{
     read_ptr, read_u64, InterpreterContext, ObjectDescriptor, ObjectDescriptorTable,
@@ -646,7 +646,7 @@ fn ref_struct_field_borrow() {
         "entry.value should be 55 after WriteRef through StructBorrow"
     );
     let entry_ptr = ctx.root_heap_ptr(8);
-    let key = unsafe { read_u64(entry_ptr, STRUCT_DATA_OFFSET) };
+    let key = unsafe { read_u64(entry_ptr, 0usize) };
     assert_eq!(key, 42, "entry.key should be untouched");
 }
 
@@ -704,6 +704,6 @@ fn ref_struct_field_survives_gc() {
     assert_eq!(ctx.gc_count(), 1);
 
     let entry_ptr = ctx.root_heap_ptr(8);
-    let key = unsafe { read_u64(entry_ptr, STRUCT_DATA_OFFSET) };
+    let key = unsafe { read_u64(entry_ptr, 0usize) };
     assert_eq!(key, 7, "entry.key should survive GC");
 }

--- a/third_party/move/mono-move/runtime/tests/struct_test.rs
+++ b/third_party/move/mono-move/runtime/tests/struct_test.rs
@@ -6,7 +6,7 @@
 use mono_move_alloc::{ExecutableArena, ExecutableArenaPtr, GlobalArenaPtr};
 use mono_move_core::{
     FrameLayoutInfo, FrameOffset as FO, Function, LocalExecutionContext, MicroOp,
-    SortedSafePointEntries, STRUCT_DATA_OFFSET,
+    SortedSafePointEntries,
 };
 use mono_move_runtime::{
     read_ptr, read_u64, InterpreterContext, ObjectDescriptor, ObjectDescriptorTable,
@@ -273,7 +273,7 @@ fn struct_with_vector_field() {
     assert_eq!(ctx.root_result(), 999, "ctr.tag should be 999 after GC");
 
     let ctr_ptr = ctx.root_heap_ptr(8);
-    let items_ptr = unsafe { read_ptr(ctr_ptr, STRUCT_DATA_OFFSET + 8) };
+    let items_ptr = unsafe { read_ptr(ctr_ptr, 8usize) };
     let len = unsafe { read_u64(items_ptr, VEC_LENGTH_OFFSET) };
     assert_eq!(len, 3, "items vector should have 3 elements");
     let e0 = unsafe { read_u64(items_ptr, VEC_DATA_OFFSET) };
@@ -397,6 +397,6 @@ fn struct_borrow_survives_gc() {
     assert_eq!(ctx.gc_count(), 1);
 
     let entry_ptr = ctx.root_heap_ptr(8);
-    let key = unsafe { read_u64(entry_ptr, STRUCT_DATA_OFFSET) };
+    let key = unsafe { read_u64(entry_ptr, 0usize) };
     assert_eq!(key, 100, "entry.key should be 100 after GC");
 }

--- a/third_party/move/mono-move/specializer/src/lower/context.rs
+++ b/third_party/move/mono-move/specializer/src/lower/context.rs
@@ -9,7 +9,8 @@
 use crate::stackless_exec_ir::{FunctionIR, Instr, ModuleIR};
 use anyhow::Result;
 use mono_move_core::{
-    types::{align_up, view_type, Alignment, InternedType, Size},
+    align_up_u32,
+    types::{view_type, Alignment, InternedType, Size},
     FRAME_METADATA_SIZE,
 };
 use move_binary_format::access::ModuleAccess;
@@ -132,7 +133,7 @@ fn layout_slots(base: u32, types: &[InternedType]) -> Option<Vec<SlotInfo>> {
     let mut offset = base;
     for ty in types {
         let (size, alignment) = type_size_and_align(*ty)?;
-        offset = align_up(offset, alignment);
+        offset = align_up_u32(offset, alignment);
         slots.push(SlotInfo {
             offset,
             size,


### PR DESCRIPTION
## Summary

Heap object pointers now point at the start of the data region. The 8-byte `[desc_id | size]` header lives at fixed negative offsets (`obj_ptr - 8` and `obj_ptr - 4`), accessed only through helpers in `runtime::memory`. The allocator reserves `OBJECT_HEADER_SIZE = MAX_ALIGN` bytes before each data region so the object pointer (and therefore field 0) is always `MAX_ALIGN`-aligned.

```
                     obj_ptr
                        │
                        ▼
┌──────────────────────┬──────────────────────────┐
│ desc_id(4) | size(4) │  data region             │
└──────────────────────┴──────────────────────────┘
   header (-8..-4..0)
```

## Why

**1. Per-type layouts no longer carry shared-header arithmetic.** Struct field offsets, the enum tag, vector length, closure fields, and captured-data values are all expressed relative to the data start (`STRUCT_DATA_OFFSET = 0`, `VEC_LENGTH_OFFSET = 0`, `CLOSURE_FUNC_REF_OFFSET = 0`, etc.). The shared header becomes purely allocator/GC bookkeeping — invisible to the IR and to anything reading or writing object fields.

**2. Readiness for `MAX_ALIGN > 8`.** Tying the header reservation to `MAX_ALIGN` means a future bump (e.g., for SIMD or `u128`/`u256` natural alignment) grows the per-object header padding without rippling through every layout constant or micro-op constructor. The descriptor/size pair always sits in the last 8 bytes of the reservation (adjacent to the data — same cache line for small objects); the negative offsets stay invariant.

## What changed

- **`runtime/src/memory.rs`** — new header-access helpers (`read_descriptor`, `write_descriptor`, `read_obj_size`, `write_obj_size`, `read_forwarding`, `write_forwarding`) encapsulate the negative-offset arithmetic. Only these touch `obj_ptr - 8` / `obj_ptr - 4`.
- **`core/src/instruction/mod.rs`** — `OBJECT_HEADER_SIZE = MAX_ALIGN` with static asserts (`>= 8`, `is_multiple_of(MAX_ALIGN)`). Layout offsets flipped: `STRUCT_DATA_OFFSET = 0`, `ENUM_TAG_OFFSET = 0`, `ENUM_DATA_OFFSET = 8`, `VEC_LENGTH_OFFSET = 0`, `VEC_DATA_OFFSET = 8`, `CLOSURE_*` shifted down by 8, `CLOSURE_OBJECT_SIZE = 32` (data-region size, not total). `MicroOp::struct_*` constructors drop the `+ STRUCT_DATA_OFFSET` adjustment.
- **`runtime/src/heap/mod.rs`** — `heap_alloc` returns `bump_ptr + OBJECT_HEADER_SIZE`; `alloc_obj`/`alloc_vec` write the header via helpers. `gc_copy_object` memcpys `[header|payload]` from `old_ptr - H` to `new_ptr - H`. Cheney scan walks object pointers (init `scan_ptr = to_space + H`, advance by `obj_size`); the bump cursor is restored as `free_ptr - H` after the swap.
- **`runtime/src/interpreter.rs`** — vector ops use `read_obj_size` instead of reading the size field directly.
- **`programs/src/bst.rs`** — one hardcoded `8 + BST_ROOT` site dropped to `BST_ROOT`.
- **Docs** — `docs/value_representation.md`, `docs/memory_alignment.md`, `docs/heap_and_gc.md`, `runtime/AGENTS.md` updated to reflect the negative-offset header and `OBJECT_HEADER_SIZE = MAX_ALIGN` convention. Worked examples in `memory_alignment.md` §5.9 redrawn.

## Test plan

- [x] `cargo check -p mono-move-core -p mono-move-runtime -p mono-move-programs --tests` — clean
- [x] `cargo test -p mono-move-core -p mono-move-runtime -p mono-move-programs` — all 124+ tests pass (including `gc_stress`, which exercises the forwarding-pointer write path)
- [x] `cargo +nightly fmt -- --check` — clean
- [x] `cargo clippy` — no new warnings (pre-existing warnings in `core/src/function.rs` and `runtime/src/verifier.rs` unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk because it changes core heap object layout, allocation, and Cheney GC pointer/size handling; any mismatch can cause memory corruption or GC mis-tracing.
> 
> **Overview**
> **Reworks heap object layout so heap pointers now reference the start of the data region**, with the `[descriptor_id|size]` header stored at fixed negative offsets (`obj_ptr - 8` / `obj_ptr - 4`). This removes shared-header offset arithmetic from per-type layouts and micro-op helpers (e.g., struct field offsets are now data-relative).
> 
> **Updates allocator + GC to operate on a `OBJECT_HEADER_SIZE = MAX_ALIGN` header reservation**: allocation writes headers via new `runtime::memory` helpers, copying GC now memcpys `[header|payload]` blocks using raw header-start cursors, and vector capacity/size computations are adjusted accordingly. Alignment utilities are centralized in a new `core::align` module and call sites (specializer/orchestrator) are switched to the shared `align_up_u32`.
> 
> Documentation and tests are updated to reflect the new header semantics, data-relative offsets, and revised vector/closure/captured-data layout constants.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e26c0ba321856372fcee792dfca47a58f23568af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->