### PR TITLE
[mono-move] Use u8 for shift amount; rename Xor → BitXor

### DIFF
--- a/third_party/move/mono-move/core/src/instruction/mod.rs
+++ b/third_party/move/mono-move/core/src/instruction/mod.rs
@@ -388,13 +388,10 @@ pub enum MicroOp {
 
     // --- Shifts ---
     //
-    // TODO: in old Move bytecode the shift amount is a u8, not a u64. We
-    // currently model `rhs` as a full 8-byte slot to match the rest of
-    // the slot ABI; the value living there is zero-extended from a u8 by
-    // the lowerer. Reconsider whether `rhs` (and the imm field of the
-    // imm-form ops) should be narrower once the slot-alignment story is
-    // sorted out — affects destack, lowering, and slot allocation.
-    /// `dst = lhs << rhs` (u64). Aborts if `rhs >= 64`.
+    // The shift amount is a u8 (matching Move bytecode, where the rhs of
+    // `Shl`/`Shr` is always u8). For the reg-reg forms, `rhs` is the offset
+    // of a 1-byte slot; the interpreter reads exactly one byte from it.
+    /// `dst = lhs << rhs` (u64). `rhs` is a 1-byte slot. Aborts if `rhs >= 64`.
     ShlU64 {
         dst: FrameOffset,
         lhs: FrameOffset,
@@ -405,10 +402,11 @@ pub enum MicroOp {
     ShlU64Imm {
         dst: FrameOffset,
         src: FrameOffset,
-        imm: u64,
+        imm: u8,
     },
 
-    /// `dst = lhs >> rhs` (u64, logical right shift). Aborts if `rhs >= 64`.
+    /// `dst = lhs >> rhs` (u64, logical right shift). `rhs` is a 1-byte slot.
+    /// Aborts if `rhs >= 64`.
     ShrU64 {
         dst: FrameOffset,
         lhs: FrameOffset,
@@ -419,7 +417,7 @@ pub enum MicroOp {
     ShrU64Imm {
         dst: FrameOffset,
         src: FrameOffset,
-        imm: u64,
+        imm: u8,
     },
 
     //======================================================================

--- a/third_party/move/mono-move/runtime/src/interpreter.rs
+++ b/third_party/move/mono-move/runtime/src/interpreter.rs
@@ -13,7 +13,9 @@ use crate::{
         pinned_roots::PinnedRoots,
         Heap,
     },
-    memory::{read_ptr, read_u32, read_u64, vec_elem_ptr, write_ptr, write_u64, MemoryRegion},
+    memory::{
+        read_ptr, read_u32, read_u64, read_u8, vec_elem_ptr, write_ptr, write_u64, MemoryRegion,
+    },
     types::{
         StepResult, DEFAULT_HEAP_SIZE, DEFAULT_STACK_SIZE, HEADER_SIZE_OFFSET,
         META_SAVED_FP_OFFSET, META_SAVED_FUNC_PTR_OFFSET, META_SAVED_PC_OFFSET, VEC_DATA_OFFSET,
@@ -295,7 +297,8 @@ unsafe fn checked_imm_op_u64<F: FnOnce(u64, u64) -> Option<u64>>(
 }
 
 /// `dst <- op(lhs_slot, rhs_slot_as_shift)`. Bail if shift `>= 64`.
-/// `op_name` is used to format the error message.
+/// `op_name` is used to format the error message. The shift amount lives in
+/// a 1-byte slot (Move bytecode invariant); only that byte is read.
 #[inline(always)]
 unsafe fn shift_u64<F: FnOnce(u64, u64) -> u64>(
     fp: *mut u8,
@@ -305,10 +308,11 @@ unsafe fn shift_u64<F: FnOnce(u64, u64) -> u64>(
     op: F,
     op_name: &'static str,
 ) -> ExecutionResult<()> {
-    // SAFETY: `fp` is the current frame pointer and `lhs`/`rhs`/`dst` are
-    // in-bounds 8-byte slots within that frame (enforced by the verifier).
+    // SAFETY: `fp` is the current frame pointer; `lhs`/`dst` are in-bounds
+    // 8-byte slots and `rhs` is an in-bounds 1-byte slot within that frame
+    // (enforced by the verifier).
     unsafe {
-        let shift = read_u64(fp, rhs);
+        let shift = read_u8(fp, rhs) as u64;
         if shift >= 64 {
             bail!("{}: shift amount {} exceeds 63", op_name, shift);
         }
@@ -552,7 +556,7 @@ impl<T: ExecutionContext> InterpreterContext<'_, T> {
                 // defensive check.
                 MicroOp::ShlU64Imm { dst, src, imm } => {
                     debug_assert!(imm < 64, "ShlU64Imm: imm must be < 64 (verifier invariant)");
-                    imm_op_u64(fp, dst, src, imm, |s, i| s << i)
+                    imm_op_u64(fp, dst, src, imm as u64, |s, i| s << i)
                 },
                 MicroOp::ShrU64 { dst, lhs, rhs } => {
                     shift_u64(fp, dst, lhs, rhs, |v, s| v >> s, "ShrU64")?
@@ -562,7 +566,7 @@ impl<T: ExecutionContext> InterpreterContext<'_, T> {
                 // defensive check.
                 MicroOp::ShrU64Imm { dst, src, imm } => {
                     debug_assert!(imm < 64, "ShrU64Imm: imm must be < 64 (verifier invariant)");
-                    imm_op_u64(fp, dst, src, imm, |s, i| s >> i)
+                    imm_op_u64(fp, dst, src, imm as u64, |s, i| s >> i)
                 },
 
                 MicroOp::StoreRandomU64 { dst } => {

--- a/third_party/move/mono-move/runtime/src/memory.rs
+++ b/third_party/move/mono-move/runtime/src/memory.rs
@@ -59,6 +59,14 @@ impl Drop for MemoryRegion {
 // ---------------------------------------------------------------------------
 
 /// # Safety
+/// `base.add(byte_offset)` must be valid and point to an initialized `u8`.
+#[inline(always)]
+pub unsafe fn read_u8(base: *const u8, byte_offset: impl Into<usize>) -> u8 {
+    // SAFETY: caller must uphold the documented pointer requirements.
+    unsafe { base.add(byte_offset.into()).read() }
+}
+
+/// # Safety
 /// `base.add(byte_offset)` must be valid, aligned, and point to an initialized `u64`.
 #[inline(always)]
 pub unsafe fn read_u64(base: *const u8, byte_offset: impl Into<usize>) -> u64 {

--- a/third_party/move/mono-move/runtime/src/verifier.rs
+++ b/third_party/move/mono-move/runtime/src/verifier.rs
@@ -263,11 +263,16 @@ impl FunctionVerifier<'_> {
             | MicroOp::ModU64 { dst, lhs, rhs }
             | MicroOp::BitAndU64 { dst, lhs, rhs }
             | MicroOp::BitOrU64 { dst, lhs, rhs }
-            | MicroOp::BitXorU64 { dst, lhs, rhs }
-            | MicroOp::ShlU64 { dst, lhs, rhs }
-            | MicroOp::ShrU64 { dst, lhs, rhs } => {
+            | MicroOp::BitXorU64 { dst, lhs, rhs } => {
                 self.check_frame_access_8(pc, lhs);
                 self.check_frame_access_8(pc, rhs);
+                self.check_frame_access_8(pc, dst);
+            },
+
+            // Shifts: `rhs` is a 1-byte slot (the Move shift amount is u8).
+            MicroOp::ShlU64 { dst, lhs, rhs } | MicroOp::ShrU64 { dst, lhs, rhs } => {
+                self.check_frame_access_8(pc, lhs);
+                self.check_frame_access_1(pc, rhs);
                 self.check_frame_access_8(pc, dst);
             },
 
@@ -721,6 +726,10 @@ impl FunctionVerifier<'_> {
 
     fn check_frame_access_8(&mut self, pc: usize, offset: FrameOffset) {
         self.check_frame_access(Some(pc), offset, 8);
+    }
+
+    fn check_frame_access_1(&mut self, pc: usize, offset: FrameOffset) {
+        self.check_frame_access(Some(pc), offset, 1);
     }
 
     fn check_descriptor(&mut self, pc: usize, descriptor_id: DescriptorId) {

--- a/third_party/move/mono-move/specializer/src/destack/instr_utils.rs
+++ b/third_party/move/mono-move/specializer/src/destack/instr_utils.rs
@@ -198,7 +198,7 @@ pub(crate) fn is_commutative(op: &BinaryOp) -> bool {
             | BinaryOp::Mul
             | BinaryOp::BitOr
             | BinaryOp::BitAnd
-            | BinaryOp::Xor
+            | BinaryOp::BitXor
             | BinaryOp::Cmp(CmpOp::Eq)
             | BinaryOp::Cmp(CmpOp::Neq)
             | BinaryOp::Or

--- a/third_party/move/mono-move/specializer/src/destack/ssa_conversion.rs
+++ b/third_party/move/mono-move/specializer/src/destack/ssa_conversion.rs
@@ -417,7 +417,7 @@ impl<'a, I: Interner> SsaConverter<'a, I> {
             B::Mod => self.convert_binop(BinaryOp::Mod, false)?,
             B::BitOr => self.convert_binop(BinaryOp::BitOr, false)?,
             B::BitAnd => self.convert_binop(BinaryOp::BitAnd, false)?,
-            B::Xor => self.convert_binop(BinaryOp::Xor, false)?,
+            B::Xor => self.convert_binop(BinaryOp::BitXor, false)?,
             B::Shl => self.convert_binop(BinaryOp::Shl, false)?,
             B::Shr => self.convert_binop(BinaryOp::Shr, false)?,
             // --- Comparisons / logical (result type = bool) ---

--- a/third_party/move/mono-move/specializer/src/lower/translate.rs
+++ b/third_party/move/mono-move/specializer/src/lower/translate.rs
@@ -241,7 +241,7 @@ impl<'a> LoweringState<'a> {
                         BinaryOp::Mod => self.emit(MicroOp::ModU64 { dst, lhs, rhs }),
                         BinaryOp::BitAnd => self.emit(MicroOp::BitAndU64 { dst, lhs, rhs }),
                         BinaryOp::BitOr => self.emit(MicroOp::BitOrU64 { dst, lhs, rhs }),
-                        BinaryOp::Xor => self.emit(MicroOp::BitXorU64 { dst, lhs, rhs }),
+                        BinaryOp::BitXor => self.emit(MicroOp::BitXorU64 { dst, lhs, rhs }),
                         BinaryOp::Shl => self.emit(MicroOp::ShlU64 { dst, lhs, rhs }),
                         BinaryOp::Shr => self.emit(MicroOp::ShrU64 { dst, lhs, rhs }),
                         // Phase 2/3: comparison-to-register and logical and/or.
@@ -260,22 +260,49 @@ impl<'a> LoweringState<'a> {
                 if Self::fits_in_u64(src_ty) {
                     let s = self.slot(*src);
                     let d = self.def_slot(*dst);
-                    let v = imm_to_u64(imm);
                     let dst = FrameOffset(d.offset);
                     let src = FrameOffset(s.offset);
                     match op {
-                        BinaryOp::Add => self.emit(MicroOp::AddU64Imm { dst, src, imm: v }),
-                        BinaryOp::Sub => self.emit(MicroOp::SubU64Imm { dst, src, imm: v }),
-                        BinaryOp::Mul => self.emit(MicroOp::MulU64Imm { dst, src, imm: v }),
-                        BinaryOp::Div => self.emit(MicroOp::DivU64Imm { dst, src, imm: v }),
-                        BinaryOp::Mod => self.emit(MicroOp::ModU64Imm { dst, src, imm: v }),
-                        BinaryOp::Shl => self.emit(MicroOp::ShlU64Imm { dst, src, imm: v }),
-                        BinaryOp::Shr => self.emit(MicroOp::ShrU64Imm { dst, src, imm: v }),
-                        // No immediate forms today: BitAnd/BitOr/Xor and the
+                        BinaryOp::Add => self.emit(MicroOp::AddU64Imm {
+                            dst,
+                            src,
+                            imm: imm_to_u64(imm),
+                        }),
+                        BinaryOp::Sub => self.emit(MicroOp::SubU64Imm {
+                            dst,
+                            src,
+                            imm: imm_to_u64(imm),
+                        }),
+                        BinaryOp::Mul => self.emit(MicroOp::MulU64Imm {
+                            dst,
+                            src,
+                            imm: imm_to_u64(imm),
+                        }),
+                        BinaryOp::Div => self.emit(MicroOp::DivU64Imm {
+                            dst,
+                            src,
+                            imm: imm_to_u64(imm),
+                        }),
+                        BinaryOp::Mod => self.emit(MicroOp::ModU64Imm {
+                            dst,
+                            src,
+                            imm: imm_to_u64(imm),
+                        }),
+                        BinaryOp::Shl => self.emit(MicroOp::ShlU64Imm {
+                            dst,
+                            src,
+                            imm: shift_imm_u8(imm)?,
+                        }),
+                        BinaryOp::Shr => self.emit(MicroOp::ShrU64Imm {
+                            dst,
+                            src,
+                            imm: shift_imm_u8(imm)?,
+                        }),
+                        // No immediate forms today: BitAnd/BitOr/BitXor and the
                         // Phase 2/3 Cmp/Or/And ops.
                         BinaryOp::BitAnd
                         | BinaryOp::BitOr
-                        | BinaryOp::Xor
+                        | BinaryOp::BitXor
                         | BinaryOp::Cmp(_)
                         | BinaryOp::Or
                         | BinaryOp::And => {
@@ -542,5 +569,14 @@ fn imm_to_u64(imm: &ImmValue) -> u64 {
         ImmValue::I16(v) => *v as u64,
         ImmValue::I32(v) => *v as u64,
         ImmValue::I64(v) => *v as u64,
+    }
+}
+
+/// Extract a u8 shift amount. The rhs of a Move `Shl`/`Shr` is always u8
+/// by language spec; anything else is an upstream invariant violation.
+fn shift_imm_u8(imm: &ImmValue) -> Result<u8> {
+    match imm {
+        ImmValue::U8(v) => Ok(*v),
+        other => bail!("shift immediate must be u8, got {:?}", other),
     }
 }

--- a/third_party/move/mono-move/specializer/src/stackless_exec_ir/display.rs
+++ b/third_party/move/mono-move/specializer/src/stackless_exec_ir/display.rs
@@ -740,7 +740,7 @@ fn binary_op_name(op: &BinaryOp) -> &'static str {
         BinaryOp::Mod => "mod",
         BinaryOp::BitOr => "bit_or",
         BinaryOp::BitAnd => "bit_and",
-        BinaryOp::Xor => "xor",
+        BinaryOp::BitXor => "bit_xor",
         BinaryOp::Shl => "shl",
         BinaryOp::Shr => "shr",
         BinaryOp::Cmp(cmp) => cmp_op_name(cmp),

--- a/third_party/move/mono-move/specializer/src/stackless_exec_ir/mod.rs
+++ b/third_party/move/mono-move/specializer/src/stackless_exec_ir/mod.rs
@@ -116,7 +116,7 @@ pub enum BinaryOp {
     Mod,
     BitOr,
     BitAnd,
-    Xor,
+    BitXor,
     Shl,
     Shr,
     Cmp(CmpOp),

--- a/third_party/move/mono-move/testsuite/tests/test_cases/snapshot/masm/arithmetic.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/snapshot/masm/arithmetic.exp
@@ -95,7 +95,7 @@ fun bit_xor(r0, r1): u64 {
     r2: u64
   code:
   L0:
-    0: r2 := xor r0, r1
+    0: r2 := bit_xor r0, r1
     1: ret [r2]
 }
 


### PR DESCRIPTION
## Summary

The shift micro-ops now take the shift amount as a u8, matching the Move bytecode (where the rhs of `Shl`/`Shr` is always u8).

- **Imm forms** (`ShlU64Imm`, `ShrU64Imm`): `imm: u64 → u8`.
- **Reg-reg forms** (`ShlU64`, `ShrU64`): the interpreter now reads exactly one byte from the `rhs` slot. This fixes a latent read-past-the-slot bug — the slot is laid out as 1 byte (the u8 shift amount), but the interpreter was reading 8 bytes from it, picking up 7 bytes of whatever happened to follow in the frame. The verifier now uses a new `check_frame_access_1` for the 1-byte access.
- **Rename:** `BinaryOp::Xor → BinaryOp::BitXor` in the stackless exec IR (variant + display string `"xor" → "bit_xor"`), for consistency with `BitAnd`/`BitOr` and the micro-op `BitXorU64`.

## Test plan

- [x] `cargo test -p mono-move-runtime` — shift unit tests + verifier tests pass.
- [x] `cargo test -p mono-move-testsuite --test snapshot` — `arithmetic.exp` baseline updated only for the `xor → bit_xor` display rename.
- [x] `cargo test -p mono-move-loader` / `-p mono-move-programs` — green.
- [x] `cargo check -p specializer` / `-p mono-move-testsuite` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core execution semantics for shift ops (slot sizing and verifier enforcement), which could affect bytecode compatibility and runtime behavior if any producer still assumes 8-byte rhs slots. Renaming `Xor` to `BitXor` is low risk but requires consistent updates across the specializer/IR and tests.
> 
> **Overview**
> Updates shift micro-ops to match Move bytecode’s u8 shift invariant: `ShlU64Imm`/`ShrU64Imm` now store `imm` as `u8`, and reg-reg shift ops read the shift amount via a new `read_u8` helper instead of `read_u64`.
> 
> Tightens safety checks by having the verifier validate shift `rhs` accesses as 1-byte slots (via `check_frame_access_1`), preventing accidental over-reads in the interpreter.
> 
> Renames stackless IR `BinaryOp::Xor` to `BinaryOp::BitXor` (including display name), updates lowering to emit `BitXorU64`, and refreshes the snapshot test output accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e7902f5bc9a392b328182e6cc30774786d5d452. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->