### PR TITLE
fix gas schedule v64 comment

### DIFF
--- a/aptos-move/aptos-gas-schedule/src/ver.rs
+++ b/aptos-move/aptos-gas-schedule/src/ver.rs
@@ -9,9 +9,8 @@
 ///
 /// Change log:
 /// - V46:
-///    - Fix BN254 `Fr::one()` native to charge `algebra.ark_bn254_fr_one` instead of
-///      `algebra.ark_bls12_381_fr_one`. Schedule key renamed to `..._fr_one_v2` so the
-///      old (zero-valued) key remains in effect for pre-V46 versions.
+///    - Correct gas parameter for `algebra.ark_bn254_fr_one`.
+///    - Fix BN254 `Fr::one()` native to charge `algebra.ark_bn254_fr_one`.
 /// - V45:
 ///    - New minimum price per gas unit parameter for higher-limit transactions
 ///    - Gas charging for encrypted transaction decryption

--- a/aptos-move/aptos-gas-schedule/src/ver.rs
+++ b/aptos-move/aptos-gas-schedule/src/ver.rs
@@ -9,7 +9,7 @@
 ///
 /// Change log:
 /// - V46:
-///    - Correct gas parameter for `algebra.ark_bn254_fr_one`.
+///    - Correct value for gas param `algebra.ark_bn254_fr_one`.
 ///    - Fix BN254 `Fr::one()` native to charge `algebra.ark_bn254_fr_one`.
 /// - V45:
 ///    - New minimum price per gas unit parameter for higher-limit transactions


### PR DESCRIPTION
## Description

Fix gas scheudle V64 comments.

## How Has This Been Tested?
n/a

## Key Areas to Review
n/a

## Type of Change
- [x] Documentation update

## Which Components or Systems Does This Change Impact?
n/a

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only update in `aptos-gas-schedule` clarifying the V46 changelog; no functional or runtime behavior changes.
> 
> **Overview**
> Updates the V46 entry in `aptos-move/aptos-gas-schedule/src/ver.rs` to correct/clarify the changelog text around the `algebra.ark_bn254_fr_one` gas parameter and the BN254 `Fr::one()` native charging key, removing the outdated note about a renamed schedule key.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5f08951e6a417cfec27e8e323502a4b6c39bc67. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->