### PR TITLE
[storage] Seed hot state KV pruner progress on wipe

### DIFF
--- a/storage/aptosdb/src/db/aptosdb_internal.rs
+++ b/storage/aptosdb/src/db/aptosdb_internal.rs
@@ -145,6 +145,16 @@ impl AptosDB {
                 hot_state_config,
             )?;
 
+        // Seed pruner progress after `delete_on_restart` wipes the hot_state_kv_db, before
+        // initializing the pruner, so the pruner doesn't catch up from 0 over an empty DB.
+        if !readonly
+            && hot_state_config.delete_on_restart
+            && let Some(db) = hot_state_kv_db.as_ref()
+            && let Some(synced_version) = ledger_db.metadata_db().get_synced_version()?
+        {
+            db.write_pruner_progress(synced_version)?;
+        }
+
         let myself = Self::new_with_dbs(
             ledger_db,
             hot_state_merkle_db,


### PR DESCRIPTION

When delete_on_restart wipes the hot state KV DB, the pruner reads
progress=0 from the freshly wiped metadata DB and grinds through a
no-op catch-up loop from 0 to (latest - prune_window) in 5K-version
batches, causing hours of log spam right after each restart.

Seed `StateKvPrunerProgress` with the synced version after the wipe.

(Hot state merkle db does not have the same problem because its pruner
works a bit differently.)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches storage pruning metadata on startup; if the seeded version is wrong or missing it could delay or skip hot-state KV pruning, affecting disk usage or retention behavior.
> 
> **Overview**
> When `HotStateConfig.delete_on_restart` wipes the hot state KV DB, `open_internal` now seeds `StateKvPrunerProgress` to the ledger DB’s `synced_version` before pruners are initialized.
> 
> This avoids the hot-state KV pruner doing a long no-op catch-up from version 0 after restarts on an empty/wiped hot-state KV DB.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa353cb29f778f22401c413c10e67b740acbcc75. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->