### PR TITLE
[trading-native][schema] Add native-position storage schemas (hash-keyed)

### DIFF
--- a/storage/aptosdb/src/schema/mod.rs
+++ b/storage/aptosdb/src/schema/mod.rs
@@ -16,8 +16,10 @@ pub(crate) mod hot_state_value_by_key_hash;
 pub(crate) mod jellyfish_merkle_node;
 pub(crate) mod ledger_info;
 pub(crate) mod persisted_auxiliary_info;
+pub(crate) mod position_value;
 pub(crate) mod stale_node_index;
 pub(crate) mod stale_node_index_cross_epoch;
+pub(crate) mod stale_position_value_index;
 pub(crate) mod stale_state_value_index_by_key_hash;
 pub(crate) mod state_value_by_key_hash;
 pub(crate) mod transaction;
@@ -45,7 +47,9 @@ pub const HOT_STATE_VALUE_BY_KEY_HASH_CF_NAME: ColumnFamilyName = "hot_state_val
 pub const JELLYFISH_MERKLE_NODE_CF_NAME: ColumnFamilyName = "jellyfish_merkle_node";
 pub const LEDGER_INFO_CF_NAME: ColumnFamilyName = "ledger_info";
 pub const PERSISTED_AUXILIARY_INFO_CF_NAME: ColumnFamilyName = "persisted_auxiliary_info";
+pub const POSITION_VALUE_CF_NAME: ColumnFamilyName = "position_value";
 pub const STALE_NODE_INDEX_CF_NAME: ColumnFamilyName = "stale_node_index";
+pub const STALE_POSITION_VALUE_INDEX_CF_NAME: ColumnFamilyName = "stale_position_value_index";
 pub const STALE_NODE_INDEX_CROSS_EPOCH_CF_NAME: ColumnFamilyName = "stale_node_index_cross_epoch";
 pub const STALE_STATE_VALUE_INDEX_BY_KEY_HASH_CF_NAME: ColumnFamilyName =
     "stale_state_value_index_by_key_hash";
@@ -104,9 +108,13 @@ pub mod fuzzing {
             assert_no_panic_decoding::<super::persisted_auxiliary_info::PersistedAuxiliaryInfoSchema>(
                 data,
             );
+            assert_no_panic_decoding::<super::position_value::PositionValueSchema>(data);
             assert_no_panic_decoding::<super::stale_node_index::StaleNodeIndexSchema>(data);
             assert_no_panic_decoding::<
                 super::stale_node_index_cross_epoch::StaleNodeIndexCrossEpochSchema,
+            >(data);
+            assert_no_panic_decoding::<
+                super::stale_position_value_index::StalePositionValueIndexSchema,
             >(data);
             assert_no_panic_decoding::<
                 super::stale_state_value_index_by_key_hash::StaleStateValueIndexByKeyHashSchema,

--- a/storage/aptosdb/src/schema/position_value/mod.rs
+++ b/storage/aptosdb/src/schema/position_value/mod.rs
@@ -1,0 +1,70 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Physical storage schema for the native-position `position_value` CF.
+//!
+//! Hash-keyed, mirroring `state_value_by_key_hash` from the main-state
+//! tier. The row key is the 32-byte `StateKey::hash()` (the same hash
+//! the JMT uses as `account_key`) plus the bit-inverted version for
+//! newest-first ordering.
+//!
+//! ```text
+//! |<------------ key ------------>|<---- value ---->|
+//! | state_key_hash (32B) | !version (8B BE) | Option<StateValue>
+//! ```
+//!
+//! Reverse lookup (hash → StateKey) goes through `position_merkle_db`,
+//! whose JMT leaves carry the original [`StateKey`] (see
+//! [`crate::position_merkle_db`]). Cold-load + backup walk the JMT
+//! iterator at the snapshot version to enumerate live positions, then
+//! query this CF by hash to fetch values.
+
+use crate::schema::{ensure_slice_len_eq, POSITION_VALUE_CF_NAME};
+use anyhow::Result;
+use aptos_crypto::HashValue;
+use aptos_schemadb::{
+    define_schema,
+    schema::{KeyCodec, ValueCodec},
+};
+use aptos_types::{state_store::state_value::StateValue, transaction::Version};
+use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
+use std::{io::Write, mem::size_of};
+
+pub type Key = (HashValue, Version);
+
+define_schema!(
+    PositionValueSchema,
+    Key,
+    Option<StateValue>,
+    POSITION_VALUE_CF_NAME
+);
+
+impl KeyCodec<PositionValueSchema> for Key {
+    fn encode_key(&self) -> Result<Vec<u8>> {
+        let mut out = Vec::with_capacity(HashValue::LENGTH + size_of::<Version>());
+        out.write_all(self.0.as_ref())?;
+        out.write_u64::<BigEndian>(!self.1)?;
+        Ok(out)
+    }
+
+    fn decode_key(data: &[u8]) -> Result<Self> {
+        const VERSION_SIZE: usize = size_of::<Version>();
+        ensure_slice_len_eq(data, HashValue::LENGTH + VERSION_SIZE)?;
+        let state_key_hash = HashValue::from_slice(&data[..HashValue::LENGTH])?;
+        let version = !(&data[HashValue::LENGTH..]).read_u64::<BigEndian>()?;
+        Ok((state_key_hash, version))
+    }
+}
+
+impl ValueCodec<PositionValueSchema> for Option<StateValue> {
+    fn encode_value(&self) -> Result<Vec<u8>> {
+        bcs::to_bytes(self).map_err(Into::into)
+    }
+
+    fn decode_value(data: &[u8]) -> Result<Self> {
+        bcs::from_bytes(data).map_err(Into::into)
+    }
+}
+
+#[cfg(test)]
+mod test;

--- a/storage/aptosdb/src/schema/position_value/test.rs
+++ b/storage/aptosdb/src/schema/position_value/test.rs
@@ -1,0 +1,20 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+use super::*;
+use aptos_crypto::HashValue;
+use aptos_schemadb::{schema::fuzzing::assert_encode_decode, test_no_panic_decoding};
+use proptest::prelude::*;
+
+proptest! {
+    #[test]
+    fn test_encode_decode(
+        state_key_hash in any::<HashValue>(),
+        version in any::<Version>(),
+        v in any::<Option<StateValue>>(),
+    ) {
+        assert_encode_decode::<PositionValueSchema>(&(state_key_hash, version), &v);
+    }
+}
+
+test_no_panic_decoding!(PositionValueSchema);

--- a/storage/aptosdb/src/schema/stale_position_value_index/mod.rs
+++ b/storage/aptosdb/src/schema/stale_position_value_index/mod.rs
@@ -1,0 +1,100 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Physical storage schema for the native-position
+//! `stale_position_value_index` CF. Hash-keyed, mirroring
+//! `stale_state_value_index_by_key_hash` from the main-state tier —
+//! same `(stale_since_version, version, state_key_hash)` shape, so
+//! the position pruner reuses
+//! [`aptos_types::state_store::state_value::StaleStateValueByKeyHashIndex`]
+//! directly under the local alias [`StalePositionValueIndex`]. Only
+//! the CF and the schema type differ; the byte format is shared and
+//! the [`KeyCodec`] impl below is byte-identical to the main-state
+//! schema's.
+//!
+//! Drives the position-value pruner. When a new Position write
+//! supersedes an older row at version `version`, this index emits an
+//! entry with `stale_since_version` = the new-write version,
+//! `version` = the superseded-row version, and the 32-byte
+//! `state_key_hash`.
+//!
+//! ```text
+//! |<--------- key ----------------------------->|<-value->|
+//! | stale_since_version | version | key_hash    |   ()    |
+//! ```
+//!
+//! `stale_since_version` is big-endian so RocksDB orders records
+//! numerically; the pruner seeks up to a horizon via the
+//! [`SeekKeyCodec<Version>`] impl below.
+
+use crate::schema::STALE_POSITION_VALUE_INDEX_CF_NAME;
+use anyhow::{ensure, Result};
+use aptos_crypto::HashValue;
+use aptos_schemadb::{
+    define_schema,
+    schema::{KeyCodec, SeekKeyCodec, ValueCodec},
+};
+pub use aptos_types::state_store::state_value::StaleStateValueByKeyHashIndex as StalePositionValueIndex;
+use aptos_types::transaction::Version;
+use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
+use std::{io::Write, mem::size_of};
+
+define_schema!(
+    StalePositionValueIndexSchema,
+    StalePositionValueIndex,
+    (),
+    STALE_POSITION_VALUE_INDEX_CF_NAME
+);
+
+impl KeyCodec<StalePositionValueIndexSchema> for StalePositionValueIndex {
+    fn encode_key(&self) -> Result<Vec<u8>> {
+        let mut out = Vec::with_capacity(2 * size_of::<Version>() + HashValue::LENGTH);
+        out.write_u64::<BigEndian>(self.stale_since_version)?;
+        out.write_u64::<BigEndian>(self.version)?;
+        out.write_all(self.state_key_hash.as_ref())?;
+        Ok(out)
+    }
+
+    fn decode_key(data: &[u8]) -> Result<Self> {
+        const VERSION_SIZE: usize = size_of::<Version>();
+        ensure!(
+            data.len() == 2 * VERSION_SIZE + HashValue::LENGTH,
+            "stale_position_value_index key: unexpected length {}",
+            data.len(),
+        );
+        let stale_since_version = (&data[..VERSION_SIZE]).read_u64::<BigEndian>()?;
+        let version = (&data[VERSION_SIZE..2 * VERSION_SIZE]).read_u64::<BigEndian>()?;
+        let state_key_hash = HashValue::from_slice(&data[2 * VERSION_SIZE..])?;
+        Ok(Self {
+            stale_since_version,
+            version,
+            state_key_hash,
+        })
+    }
+}
+
+impl ValueCodec<StalePositionValueIndexSchema> for () {
+    fn encode_value(&self) -> Result<Vec<u8>> {
+        Ok(Vec::new())
+    }
+
+    fn decode_value(data: &[u8]) -> Result<Self> {
+        ensure!(
+            data.is_empty(),
+            "stale_position_value_index value: expected empty"
+        );
+        Ok(())
+    }
+}
+
+/// Pruner-side seek key: encodes just the `stale_since_version` so
+/// the pruner can seek to "first row with stale_since_version >= X"
+/// without constructing the full composite key.
+impl SeekKeyCodec<StalePositionValueIndexSchema> for Version {
+    fn encode_seek_key(&self) -> Result<Vec<u8>> {
+        Ok(self.to_be_bytes().to_vec())
+    }
+}
+
+#[cfg(test)]
+mod test;

--- a/storage/aptosdb/src/schema/stale_position_value_index/test.rs
+++ b/storage/aptosdb/src/schema/stale_position_value_index/test.rs
@@ -1,0 +1,17 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+use super::*;
+use aptos_schemadb::{schema::fuzzing::assert_encode_decode, test_no_panic_decoding};
+use proptest::prelude::*;
+
+proptest! {
+    #[test]
+    fn test_encode_decode(
+        stale_position_value_index in any::<StalePositionValueIndex>(),
+    ) {
+        assert_encode_decode::<StalePositionValueIndexSchema>(&stale_position_value_index, &());
+    }
+}
+
+test_no_panic_decoding!(StalePositionValueIndexSchema);


### PR DESCRIPTION
Two new RocksDB column families for the upcoming native-position storage subsystem. Hash-keyed, mirroring the main-state convention from `state_value_by_key_hash" /
`stale_state_value_index_by_key_hash":

- `position_value" CF: `(state_key_hash: 32B, !version: 8B BE)" → `Option<StateValue>". The 32-byte key is `StateKey::hash()"; reverse lookup (hash → StateKey) is the JMT's job in the downstream storage commit.
- `stale_position_value_index" CF: `(stale_since_version, version, state_key_hash)" → `()". Drives the pruner. Includes `SeekKeyCodec<Version>" for horizon-based seeks (matches main state).
- `DbMetadataKey::PositionPrunerProgress" variant appended for the pruner's progress tracking.
- CF name constants registered in `schema/mod.rs".

Test coverage:

- Per-schema `test.rs" with proptest round-trip + no-panic-decoding.
- Both schemas registered in `schema::fuzzing::fuzz_decode" for external fuzz target coverage, alongside main-state hash-keyed schemas.

The schemas are self-contained — they depend only on `aptos_crypto::HashValue", `aptos_types::StateValue", and `aptos_types::Version", all already on main. The CFs are not yet opened anywhere; that wiring lands in a follow-up storage commit along with PositionDb / PositionMerkleDb / NativeStateCommitter.

4/4 new schema tests pass.

## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [x] Validator Node
- [x] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new RocksDB column family schemas and encodings, which affects on-disk data layout and future pruning behavior, but the change is additive and not yet wired into read/write paths.
> 
> **Overview**
> Adds two new AptosDB RocksDB schemas to support upcoming native-position storage: `position_value` (hash + inverted version → `Option<StateValue>`) and `stale_position_value_index` (stale-since/version/hash → `()`, with `SeekKeyCodec<Version>` for pruner scans).
> 
> Registers the new column family name constants and includes both schemas in the fuzzing decode harness, with proptest round-trip and no-panic decoding tests for each.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6933da7fab47412239200ddcc5ad5b7d6437b70. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->