### PR TITLE
[v1.44] admin-service: return symbolized pprof from /malloc/dump_profile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -413,6 +413,7 @@ dependencies = [
  "futures-channel",
  "http 0.2.11",
  "hyper 0.14.28",
+ "jemalloc_pprof",
  "sha256",
  "tikv-jemalloc-ctl",
  "tikv-jemalloc-sys",
@@ -5764,7 +5765,7 @@ dependencies = [
  "futures-lite 2.2.0",
  "parking",
  "polling 3.3.1",
- "rustix 0.38.28",
+ "rustix 0.38.34",
  "slab",
  "tracing",
  "windows-sys 0.52.0",
@@ -5821,7 +5822,7 @@ dependencies = [
  "cfg-if",
  "event-listener 3.1.0",
  "futures-lite 1.13.0",
- "rustix 0.38.28",
+ "rustix 0.38.34",
  "windows-sys 0.48.0",
 ]
 
@@ -5848,7 +5849,7 @@ dependencies = [
  "cfg-if",
  "futures-core",
  "futures-io",
- "rustix 0.38.28",
+ "rustix 0.38.34",
  "signal-hook-registry",
  "slab",
  "windows-sys 0.48.0",
@@ -11500,7 +11501,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bad00257d07be169d870ab665980b06cdb366d792ad690bf2e76876dc503455"
 dependencies = [
  "hermit-abi 0.3.9",
- "rustix 0.38.28",
+ "rustix 0.38.34",
  "windows-sys 0.52.0",
 ]
 
@@ -11594,6 +11595,23 @@ name = "itoa"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
+
+[[package]]
+name = "jemalloc_pprof"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a0d44c349cfe2654897fadcb9de4f0bfbf48288ec344f700b2bd59f152dd209"
+dependencies = [
+ "anyhow",
+ "libc",
+ "mappings",
+ "once_cell",
+ "pprof_util",
+ "tempfile",
+ "tikv-jemalloc-ctl",
+ "tokio",
+ "tracing",
+]
 
 [[package]]
 name = "jobserver"
@@ -12348,6 +12366,19 @@ name = "maplit"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
+
+[[package]]
+name = "mappings"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bab1e61a4b76757edb59cd81fcaa7f3ba9018d43b527d9abfad877b4c6c60f2"
+dependencies = [
+ "anyhow",
+ "libc",
+ "once_cell",
+ "pprof_util",
+ "tracing",
+]
 
 [[package]]
 name = "match_cfg"
@@ -15265,7 +15296,7 @@ dependencies = [
  "cfg-if",
  "concurrent-queue",
  "pin-project-lite",
- "rustix 0.38.28",
+ "rustix 0.38.34",
  "tracing",
  "windows-sys 0.52.0",
 ]
@@ -15385,6 +15416,20 @@ dependencies = [
  "symbolic-demangle",
  "tempfile",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "pprof_util"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eea0cc524de808a6d98d192a3d99fe95617031ad4a52ec0a0f987ef4432e8fe1"
+dependencies = [
+ "anyhow",
+ "backtrace",
+ "flate2",
+ "num 0.4.1",
+ "paste",
+ "prost 0.14.3",
 ]
 
 [[package]]
@@ -15803,6 +15848,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
+dependencies = [
+ "bytes",
+ "prost-derive 0.14.3",
+]
+
+[[package]]
 name = "prost-derive"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15833,6 +15888,19 @@ name = "prost-derive"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "157c5a9d7ea5c2ed2d9fb8f495b64759f7816c7eaea54ba3978f0d63000162e3"
+dependencies = [
+ "anyhow",
+ "itertools 0.13.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
  "itertools 0.13.0",
@@ -16913,9 +16981,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.28"
+version = "0.38.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72e572a5e8ca657d7366229cdde4bd14c4eb5499a9573d4d366fe1b599daa316"
+checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
 dependencies = [
  "bitflags 2.11.0",
  "errno",
@@ -18720,15 +18788,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.9.0"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01ce4141aa927a6d1bd34a041795abd0db1cccba5d5f24b009f694bdf3a1f3fa"
+checksum = "04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64"
 dependencies = [
  "cfg-if",
  "fastrand 2.3.0",
- "redox_syscall 0.4.1",
- "rustix 0.38.28",
- "windows-sys 0.52.0",
+ "once_cell",
+ "rustix 0.38.34",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -18779,7 +18847,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f599bd7ca042cfdf8f4512b277c02ba102247820f9d9d4a9f521f496751a6ef"
 dependencies = [
- "rustix 0.38.28",
+ "rustix 0.38.34",
  "windows-sys 0.59.0",
 ]
 
@@ -20141,7 +20209,7 @@ dependencies = [
  "errno",
  "js-sys",
  "libc",
- "rustix 0.38.28",
+ "rustix 0.38.34",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "wasm-bindgen",
  "winapi 0.3.9",
@@ -20539,7 +20607,7 @@ dependencies = [
  "either",
  "home",
  "once_cell",
- "rustix 0.38.28",
+ "rustix 0.38.34",
 ]
 
 [[package]]
@@ -21040,7 +21108,7 @@ checksum = "914566e6413e7fa959cc394fb30e563ba80f3541fbd40816d4c05a0fc3f2a0f1"
 dependencies = [
  "libc",
  "linux-raw-sys 0.4.12",
- "rustix 0.38.28",
+ "rustix 0.38.34",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -676,6 +676,7 @@ jemallocator = { package = "tikv-jemallocator", version = "0.6.1", features = [
 ] }
 jemalloc-ctl = { package = "tikv-jemalloc-ctl", version = "0.6.1" }
 jemalloc-sys = { package = "tikv-jemalloc-sys", version = "0.6.1" }
+jemalloc_pprof = { version = "0.8", features = ["symbolize"] }
 json-patch = "0.2.6"
 jsonwebtoken = "8.1"
 jwt = "0.16.0"

--- a/crates/aptos-admin-service/Cargo.toml
+++ b/crates/aptos-admin-service/Cargo.toml
@@ -35,3 +35,6 @@ url = { workspace = true }
 [target.'cfg(unix)'.dependencies]
 jemalloc-ctl = { workspace = true }
 jemalloc-sys = { workspace = true }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+jemalloc_pprof = { workspace = true }

--- a/crates/aptos-admin-service/src/server/malloc.rs
+++ b/crates/aptos-admin-service/src/server/malloc.rs
@@ -3,6 +3,8 @@
 
 use aptos_logger::info;
 use aptos_system_utils::utils::{reply_with, reply_with_status};
+#[cfg(target_os = "linux")]
+use hyper::header::{HeaderValue, CONTENT_ENCODING, CONTENT_TYPE};
 use hyper::{Body, Request, Response, StatusCode};
 use std::{
     collections::HashMap,
@@ -88,9 +90,17 @@ fn validate_output_path(path: &str) -> Result<(), String> {
     Ok(())
 }
 
-pub fn handle_dump_profile_request(req: Request<Body>) -> hyper::Result<Response<Body>> {
+pub async fn handle_dump_profile_request(req: Request<Body>) -> hyper::Result<Response<Body>> {
     let query = req.uri().query().unwrap_or("");
     let query_pairs: HashMap<_, _> = url::form_urlencoded::parse(query.as_bytes()).collect();
+
+    // ?format=path keeps the legacy behavior: write the raw .heap file to disk and
+    // return its path as text. Default returns a symbolized, gzipped pprof body.
+    let want_path_only = query_pairs
+        .get("format")
+        .map(|f| f.as_ref() == "path")
+        .unwrap_or(false);
+
     let output_path = query_pairs
         .get("output")
         .map(|p| p.to_string())
@@ -102,20 +112,73 @@ pub fn handle_dump_profile_request(req: Request<Body>) -> hyper::Result<Response
         return Ok(reply_with_status(StatusCode::BAD_REQUEST, msg));
     }
 
+    if want_path_only || output_path.is_some() {
+        return Ok(legacy_dump_to_path(output_path));
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        match dump_pprof_symbolized().await {
+            Ok(pprof) => {
+                info!("Returning symbolized pprof ({} bytes).", pprof.len());
+                let mut resp = Response::new(Body::from(pprof));
+                resp.headers_mut().insert(
+                    CONTENT_TYPE,
+                    HeaderValue::from_static("application/octet-stream"),
+                );
+                resp.headers_mut()
+                    .insert(CONTENT_ENCODING, HeaderValue::from_static("gzip"));
+                Ok(resp)
+            },
+            Err(e) => {
+                info!("Failed to produce pprof: {e:?}");
+                Ok(reply_with_status(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    format!("Failed to produce pprof: {e}"),
+                ))
+            },
+        }
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        Ok(legacy_dump_to_path(output_path))
+    }
+}
+
+fn legacy_dump_to_path(output_path: Option<String>) -> Response<Body> {
     match dump_heap_profile(output_path) {
         Ok(path) => {
             info!("Finished dumping heap profile to {path}.");
-            Ok(reply_with(
+            reply_with(
                 Vec::new(),
                 Body::from(format!("Successfully dumped heap profile to {path}")),
-            ))
+            )
         },
         Err(e) => {
             info!("Failed to dump heap profile: {e:?}");
-            Ok(reply_with_status(
+            reply_with_status(
                 StatusCode::INTERNAL_SERVER_ERROR,
                 format!("Failed to dump heap profile: {e}"),
-            ))
+            )
         },
     }
+}
+
+#[cfg(target_os = "linux")]
+async fn dump_pprof_symbolized() -> anyhow::Result<Vec<u8>> {
+    let prof_ctl_lock = jemalloc_pprof::PROF_CTL
+        .as_ref()
+        .ok_or_else(|| anyhow::anyhow!("jemalloc profiling controller unavailable"))?;
+    // Take an owned guard so it can move into the blocking task below.
+    let mut prof_ctl = prof_ctl_lock.clone().lock_owned().await;
+    if !prof_ctl.activated() {
+        anyhow::bail!(
+            "jemalloc profiling is not activated; start aptos-node with MALLOC_CONF=prof:true"
+        );
+    }
+    // Symbolization reads /proc/self/maps and parses ELF; it can take seconds.
+    // Offload to the blocking pool so other admin-service requests aren't stalled.
+    tokio::task::spawn_blocking(move || prof_ctl.dump_pprof())
+        .await
+        .map_err(|e| anyhow::anyhow!("dump_pprof task join error: {e}"))?
 }

--- a/crates/aptos-admin-service/src/server/mod.rs
+++ b/crates/aptos-admin-service/src/server/mod.rs
@@ -191,7 +191,7 @@ impl AdminService {
             },
             #[cfg(unix)]
             (hyper::Method::GET, "/malloc/dump_profile") => {
-                malloc::handle_dump_profile_request(req)
+                malloc::handle_dump_profile_request(req).await
             },
             (hyper::Method::GET, "/debug/consensus/consensusdb") => {
                 let consensus_db = context.consensus_db.read().clone();


### PR DESCRIPTION
Backport of #19730 to `aptos-release-v1.44`.

## Summary
- Default `GET /malloc/dump_profile` now returns gzipped, symbolized pprof bytes via `jemalloc_pprof` (Linux only). Pyroscope / Alloy's `pyroscope.scrape` can ingest this directly — no more PID-namespace tricks to run `jeprof` from a sidecar.
- Legacy file-dump behavior preserved via `?format=path` or `?output=<path>` so existing operator workflows are unaffected.
- Symbolization reads `/proc/self/maps` and parses ELF (can take seconds); offloaded to `tokio::task::spawn_blocking` so other admin-service requests aren't stalled.
- Returns 500 with a clear message when `MALLOC_CONF=prof:true` is not set.
- Non-Linux unix targets (macOS) fall back to the legacy file-dump path; `jemalloc_pprof` is cfg-gated to `target_os = "linux"`.

## Test plan
- [ ] CI build green on the v1.44 branch
- [ ] Manual: deploy validator with `MALLOC_CONF=prof:true,prof_active:true` on Linux, `curl http://<admin>/malloc/dump_profile -o profile.pb.gz`, run `pprof profile.pb.gz` and confirm symbolized stacks
- [ ] Manual: `curl 'http://<admin>/malloc/dump_profile?format=path'` returns legacy text response with file path
- [ ] Manual: `curl 'http://<admin>/malloc/dump_profile?output=/tmp/foo.heap'` writes file and returns path
- [ ] Manual: without `MALLOC_CONF=prof:true`, default request returns 500 with the activation message

🤖 Generated with [Claude Code](https://claude.com/claude-code)