### PR TITLE
[trading-native][types] Add native-position StateKey variant + per-block NativeTransactionWrites

### DIFF
--- a/api/types/src/convert.rs
+++ b/api/types/src/convert.rs
@@ -615,6 +615,10 @@ impl<'a, S: StateView> MoveConverter<'a, S> {
                 "Can't convert account raw key {:?} to WriteSetChange",
                 state_key
             )),
+            StateKeyInner::TradingNative(_) => Err(format_err!(
+                "Can't convert trading-native key {:?} to WriteSetChange",
+                state_key
+            )),
         }
     }
 

--- a/aptos-move/aptos-gas-profiling/src/aggregate.rs
+++ b/aptos-move/aptos-gas-profiling/src/aggregate.rs
@@ -117,6 +117,7 @@ impl ExecutionAndIOCosts {
                     format!("table_item<{},{}>", Render(handle), TableKey { bytes: key },)
                 },
                 Raw(..) => panic!("not supported"),
+                TradingNative(..) => panic!("not supported"),
             };
 
             insert_or_add(&mut storage_writes, key, write.cost);

--- a/aptos-move/aptos-gas-profiling/src/render.rs
+++ b/aptos-move/aptos-gas-profiling/src/render.rs
@@ -118,6 +118,7 @@ impl Display for Render<'_, StateKey> {
                 },)
             },
             Raw(..) => panic!("not supported"),
+            TradingNative(..) => panic!("not supported"),
         }
     }
 }

--- a/aptos-move/aptos-transaction-simulation-session/src/state_store.rs
+++ b/aptos-move/aptos-transaction-simulation-session/src/state_store.rs
@@ -84,6 +84,7 @@ impl std::fmt::Display for HumanReadable<&StateKey> {
                 write!(f, "table_item::{}::{}", handle.0, hex::encode(key))
             },
             StateKeyInner::Raw(bytes) => write!(f, "raw::{}", hex::encode(bytes)),
+            StateKeyInner::TradingNative(key) => write!(f, "trading_native::{:?}", key),
         }
     }
 }

--- a/aptos-move/e2e-tests/goldens/language_e2e_testsuite__tests__create_account__create_account.exp
+++ b/aptos-move/e2e-tests/goldens/language_e2e_testsuite__tests__create_account__create_account.exp
@@ -15,6 +15,7 @@ Ok(
                     ),
                 ),
                 hotness: {},
+                native_positions: {},
             },
             events: [
                 ModuleEvent { type: Struct(StructTag { address: 0000000000000000000000000000000000000000000000000000000000000001, module: Identifier("fungible_asset"), name: Identifier("Withdraw"), type_args: [] }), event_data: "b26af11b4f332a7794398554b6313a38c6a102c74c5ba9a12629ae3a492acb2f0100000000000000" },

--- a/aptos-move/e2e-tests/goldens/language_e2e_testsuite__tests__scripts__script_bad_sig_function_dep.exp
+++ b/aptos-move/e2e-tests/goldens/language_e2e_testsuite__tests__scripts__script_bad_sig_function_dep.exp
@@ -14,6 +14,7 @@ Ok(
                     ),
                 ),
                 hotness: {},
+                native_positions: {},
             },
             events: [
                 ModuleEvent { type: Struct(StructTag { address: 0000000000000000000000000000000000000000000000000000000000000001, module: Identifier("transaction_fee"), name: Identifier("FeeStatement"), type_args: [] }), event_data: "1c000000000000001c00000000000000000000000000000000000000000000000000000000000000" },

--- a/aptos-move/e2e-tests/goldens/language_e2e_testsuite__tests__scripts__script_code_unverifiable.exp
+++ b/aptos-move/e2e-tests/goldens/language_e2e_testsuite__tests__scripts__script_code_unverifiable.exp
@@ -14,6 +14,7 @@ Ok(
                     ),
                 ),
                 hotness: {},
+                native_positions: {},
             },
             events: [
                 ModuleEvent { type: Struct(StructTag { address: 0000000000000000000000000000000000000000000000000000000000000001, module: Identifier("transaction_fee"), name: Identifier("FeeStatement"), type_args: [] }), event_data: "1c000000000000001c00000000000000000000000000000000000000000000000000000000000000" },

--- a/aptos-move/e2e-tests/goldens/language_e2e_testsuite__tests__scripts__script_nested_type_argument_module_does_not_exist.exp
+++ b/aptos-move/e2e-tests/goldens/language_e2e_testsuite__tests__scripts__script_nested_type_argument_module_does_not_exist.exp
@@ -14,6 +14,7 @@ Ok(
                     ),
                 ),
                 hotness: {},
+                native_positions: {},
             },
             events: [
                 ModuleEvent { type: Struct(StructTag { address: 0000000000000000000000000000000000000000000000000000000000000001, module: Identifier("transaction_fee"), name: Identifier("FeeStatement"), type_args: [] }), event_data: "1c000000000000001c00000000000000000000000000000000000000000000000000000000000000" },

--- a/aptos-move/e2e-tests/goldens/language_e2e_testsuite__tests__scripts__script_non_existing_function_dep.exp
+++ b/aptos-move/e2e-tests/goldens/language_e2e_testsuite__tests__scripts__script_non_existing_function_dep.exp
@@ -14,6 +14,7 @@ Ok(
                     ),
                 ),
                 hotness: {},
+                native_positions: {},
             },
             events: [
                 ModuleEvent { type: Struct(StructTag { address: 0000000000000000000000000000000000000000000000000000000000000001, module: Identifier("transaction_fee"), name: Identifier("FeeStatement"), type_args: [] }), event_data: "1c000000000000001c00000000000000000000000000000000000000000000000000000000000000" },

--- a/aptos-move/e2e-tests/goldens/language_e2e_testsuite__tests__scripts__script_none_existing_module_dep.exp
+++ b/aptos-move/e2e-tests/goldens/language_e2e_testsuite__tests__scripts__script_none_existing_module_dep.exp
@@ -14,6 +14,7 @@ Ok(
                     ),
                 ),
                 hotness: {},
+                native_positions: {},
             },
             events: [
                 ModuleEvent { type: Struct(StructTag { address: 0000000000000000000000000000000000000000000000000000000000000001, module: Identifier("transaction_fee"), name: Identifier("FeeStatement"), type_args: [] }), event_data: "1c000000000000001c00000000000000000000000000000000000000000000000000000000000000" },

--- a/aptos-move/e2e-tests/goldens/language_e2e_testsuite__tests__scripts__script_type_argument_module_does_not_exist.exp
+++ b/aptos-move/e2e-tests/goldens/language_e2e_testsuite__tests__scripts__script_type_argument_module_does_not_exist.exp
@@ -14,6 +14,7 @@ Ok(
                     ),
                 ),
                 hotness: {},
+                native_positions: {},
             },
             events: [
                 ModuleEvent { type: Struct(StructTag { address: 0000000000000000000000000000000000000000000000000000000000000001, module: Identifier("transaction_fee"), name: Identifier("FeeStatement"), type_args: [] }), event_data: "1c000000000000001c00000000000000000000000000000000000000000000000000000000000000" },

--- a/aptos-move/e2e-tests/goldens/language_e2e_testsuite__tests__state_store__borrow_after_move.exp
+++ b/aptos-move/e2e-tests/goldens/language_e2e_testsuite__tests__state_store__borrow_after_move.exp
@@ -12,6 +12,7 @@ Ok(
                     ),
                 ),
                 hotness: {},
+                native_positions: {},
             },
             events: [
                 ModuleEvent { type: Struct(StructTag { address: 0000000000000000000000000000000000000000000000000000000000000001, module: Identifier("transaction_fee"), name: Identifier("FeeStatement"), type_args: [] }), event_data: "20000000000000001d00000000000000040000000000000000000000000000000000000000000000" },
@@ -43,6 +44,7 @@ Ok(
                     ),
                 ),
                 hotness: {},
+                native_positions: {},
             },
             events: [
                 ModuleEvent { type: Struct(StructTag { address: 0000000000000000000000000000000000000000000000000000000000000001, module: Identifier("transaction_fee"), name: Identifier("FeeStatement"), type_args: [] }), event_data: "21000000000000001d00000000000000050000000000000000000000000000000000000000000000" },
@@ -69,6 +71,7 @@ Ok(
                     ),
                 ),
                 hotness: {},
+                native_positions: {},
             },
             events: [
                 ModuleEvent { type: Struct(StructTag { address: 0000000000000000000000000000000000000000000000000000000000000001, module: Identifier("transaction_fee"), name: Identifier("FeeStatement"), type_args: [] }), event_data: "27000000000000001d000000000000000a0000000000000000000000000000000000000000000000" },
@@ -96,6 +99,7 @@ Ok(
                     ),
                 ),
                 hotness: {},
+                native_positions: {},
             },
             events: [
                 ModuleEvent { type: Struct(StructTag { address: 0000000000000000000000000000000000000000000000000000000000000001, module: Identifier("transaction_fee"), name: Identifier("FeeStatement"), type_args: [] }), event_data: "28000000000000001d000000000000000b0000000000000000000000000000000000000000000000" },
@@ -118,6 +122,7 @@ Ok(
                     ),
                 ),
                 hotness: {},
+                native_positions: {},
             },
             events: [
                 ModuleEvent { type: Struct(StructTag { address: 0000000000000000000000000000000000000000000000000000000000000001, module: Identifier("transaction_fee"), name: Identifier("FeeStatement"), type_args: [] }), event_data: "20000000000000001d00000000000000040000000000000000000000000000000000000000000000" },

--- a/aptos-move/e2e-tests/goldens/language_e2e_testsuite__tests__state_store__change_after_move.exp
+++ b/aptos-move/e2e-tests/goldens/language_e2e_testsuite__tests__state_store__change_after_move.exp
@@ -12,6 +12,7 @@ Ok(
                     ),
                 ),
                 hotness: {},
+                native_positions: {},
             },
             events: [
                 ModuleEvent { type: Struct(StructTag { address: 0000000000000000000000000000000000000000000000000000000000000001, module: Identifier("transaction_fee"), name: Identifier("FeeStatement"), type_args: [] }), event_data: "20000000000000001d00000000000000040000000000000000000000000000000000000000000000" },
@@ -43,6 +44,7 @@ Ok(
                     ),
                 ),
                 hotness: {},
+                native_positions: {},
             },
             events: [
                 ModuleEvent { type: Struct(StructTag { address: 0000000000000000000000000000000000000000000000000000000000000001, module: Identifier("transaction_fee"), name: Identifier("FeeStatement"), type_args: [] }), event_data: "21000000000000001d00000000000000050000000000000000000000000000000000000000000000" },
@@ -69,6 +71,7 @@ Ok(
                     ),
                 ),
                 hotness: {},
+                native_positions: {},
             },
             events: [
                 ModuleEvent { type: Struct(StructTag { address: 0000000000000000000000000000000000000000000000000000000000000001, module: Identifier("transaction_fee"), name: Identifier("FeeStatement"), type_args: [] }), event_data: "27000000000000001d000000000000000a0000000000000000000000000000000000000000000000" },
@@ -96,6 +99,7 @@ Ok(
                     ),
                 ),
                 hotness: {},
+                native_positions: {},
             },
             events: [
                 ModuleEvent { type: Struct(StructTag { address: 0000000000000000000000000000000000000000000000000000000000000001, module: Identifier("transaction_fee"), name: Identifier("FeeStatement"), type_args: [] }), event_data: "28000000000000001d000000000000000b0000000000000000000000000000000000000000000000" },
@@ -118,6 +122,7 @@ Ok(
                     ),
                 ),
                 hotness: {},
+                native_positions: {},
             },
             events: [
                 ModuleEvent { type: Struct(StructTag { address: 0000000000000000000000000000000000000000000000000000000000000001, module: Identifier("transaction_fee"), name: Identifier("FeeStatement"), type_args: [] }), event_data: "20000000000000001d00000000000000040000000000000000000000000000000000000000000000" },
@@ -148,6 +153,7 @@ Ok(
                     ),
                 ),
                 hotness: {},
+                native_positions: {},
             },
             events: [
                 ModuleEvent { type: Struct(StructTag { address: 0000000000000000000000000000000000000000000000000000000000000001, module: Identifier("transaction_fee"), name: Identifier("FeeStatement"), type_args: [] }), event_data: "20000000000000001d00000000000000040000000000000000000000000000000000000000000000" },

--- a/aptos-move/e2e-tests/goldens/language_e2e_testsuite__tests__state_store__move_from_across_blocks.exp
+++ b/aptos-move/e2e-tests/goldens/language_e2e_testsuite__tests__state_store__move_from_across_blocks.exp
@@ -12,6 +12,7 @@ Ok(
                     ),
                 ),
                 hotness: {},
+                native_positions: {},
             },
             events: [
                 ModuleEvent { type: Struct(StructTag { address: 0000000000000000000000000000000000000000000000000000000000000001, module: Identifier("transaction_fee"), name: Identifier("FeeStatement"), type_args: [] }), event_data: "20000000000000001d00000000000000040000000000000000000000000000000000000000000000" },
@@ -43,6 +44,7 @@ Ok(
                     ),
                 ),
                 hotness: {},
+                native_positions: {},
             },
             events: [
                 ModuleEvent { type: Struct(StructTag { address: 0000000000000000000000000000000000000000000000000000000000000001, module: Identifier("transaction_fee"), name: Identifier("FeeStatement"), type_args: [] }), event_data: "21000000000000001d00000000000000050000000000000000000000000000000000000000000000" },
@@ -69,6 +71,7 @@ Ok(
                     ),
                 ),
                 hotness: {},
+                native_positions: {},
             },
             events: [
                 ModuleEvent { type: Struct(StructTag { address: 0000000000000000000000000000000000000000000000000000000000000001, module: Identifier("transaction_fee"), name: Identifier("FeeStatement"), type_args: [] }), event_data: "27000000000000001d000000000000000a0000000000000000000000000000000000000000000000" },
@@ -96,6 +99,7 @@ Ok(
                     ),
                 ),
                 hotness: {},
+                native_positions: {},
             },
             events: [
                 ModuleEvent { type: Struct(StructTag { address: 0000000000000000000000000000000000000000000000000000000000000001, module: Identifier("transaction_fee"), name: Identifier("FeeStatement"), type_args: [] }), event_data: "28000000000000001d000000000000000b0000000000000000000000000000000000000000000000" },
@@ -122,6 +126,7 @@ Ok(
                     ),
                 ),
                 hotness: {},
+                native_positions: {},
             },
             events: [
                 ModuleEvent { type: Struct(StructTag { address: 0000000000000000000000000000000000000000000000000000000000000001, module: Identifier("transaction_fee"), name: Identifier("FeeStatement"), type_args: [] }), event_data: "20000000000000001d00000000000000040000000000000000000000000000000000000000000000" },
@@ -152,6 +157,7 @@ Ok(
                     ),
                 ),
                 hotness: {},
+                native_positions: {},
             },
             events: [
                 ModuleEvent { type: Struct(StructTag { address: 0000000000000000000000000000000000000000000000000000000000000001, module: Identifier("transaction_fee"), name: Identifier("FeeStatement"), type_args: [] }), event_data: "20000000000000001d00000000000000040000000000000000000000000000000000000000000000" },
@@ -183,6 +189,7 @@ Ok(
                     ),
                 ),
                 hotness: {},
+                native_positions: {},
             },
             events: [
                 ModuleEvent { type: Struct(StructTag { address: 0000000000000000000000000000000000000000000000000000000000000001, module: Identifier("transaction_fee"), name: Identifier("FeeStatement"), type_args: [] }), event_data: "21000000000000001d00000000000000050000000000000000000000000000000000000000000000" },
@@ -210,6 +217,7 @@ Ok(
                     ),
                 ),
                 hotness: {},
+                native_positions: {},
             },
             events: [
                 ModuleEvent { type: Struct(StructTag { address: 0000000000000000000000000000000000000000000000000000000000000001, module: Identifier("transaction_fee"), name: Identifier("FeeStatement"), type_args: [] }), event_data: "28000000000000001d000000000000000b0000000000000000000000000000000000000000000000" },
@@ -232,6 +240,7 @@ Ok(
                     ),
                 ),
                 hotness: {},
+                native_positions: {},
             },
             events: [
                 ModuleEvent { type: Struct(StructTag { address: 0000000000000000000000000000000000000000000000000000000000000001, module: Identifier("transaction_fee"), name: Identifier("FeeStatement"), type_args: [] }), event_data: "20000000000000001d00000000000000040000000000000000000000000000000000000000000000" },

--- a/aptos-move/e2e-tests/goldens/language_e2e_testsuite__tests__verify_txn__test_arbitrary_script_execution.exp
+++ b/aptos-move/e2e-tests/goldens/language_e2e_testsuite__tests__verify_txn__test_arbitrary_script_execution.exp
@@ -14,6 +14,7 @@ Ok(
                     ),
                 ),
                 hotness: {},
+                native_positions: {},
             },
             events: [
                 ModuleEvent { type: Struct(StructTag { address: 0000000000000000000000000000000000000000000000000000000000000001, module: Identifier("transaction_fee"), name: Identifier("FeeStatement"), type_args: [] }), event_data: "1c000000000000001c00000000000000000000000000000000000000000000000000000000000000" },

--- a/aptos-move/e2e-tests/goldens/language_e2e_testsuite__tests__verify_txn__test_script_dependency_fails_verification.exp
+++ b/aptos-move/e2e-tests/goldens/language_e2e_testsuite__tests__verify_txn__test_script_dependency_fails_verification.exp
@@ -14,6 +14,7 @@ Ok(
                     ),
                 ),
                 hotness: {},
+                native_positions: {},
             },
             events: [
                 ModuleEvent { type: Struct(StructTag { address: 0000000000000000000000000000000000000000000000000000000000000001, module: Identifier("transaction_fee"), name: Identifier("FeeStatement"), type_args: [] }), event_data: "03000000000000000300000000000000000000000000000000000000000000000000000000000000" },

--- a/aptos-move/e2e-tests/goldens/language_e2e_testsuite__tests__verify_txn__test_script_transitive_dependency_fails_verification.exp
+++ b/aptos-move/e2e-tests/goldens/language_e2e_testsuite__tests__verify_txn__test_script_transitive_dependency_fails_verification.exp
@@ -14,6 +14,7 @@ Ok(
                     ),
                 ),
                 hotness: {},
+                native_positions: {},
             },
             events: [
                 ModuleEvent { type: Struct(StructTag { address: 0000000000000000000000000000000000000000000000000000000000000001, module: Identifier("transaction_fee"), name: Identifier("FeeStatement"), type_args: [] }), event_data: "03000000000000000300000000000000000000000000000000000000000000000000000000000000" },

--- a/aptos-move/e2e-tests/goldens/language_e2e_testsuite__tests__verify_txn__test_type_tag_dependency_fails_verification.exp
+++ b/aptos-move/e2e-tests/goldens/language_e2e_testsuite__tests__verify_txn__test_type_tag_dependency_fails_verification.exp
@@ -14,6 +14,7 @@ Ok(
                     ),
                 ),
                 hotness: {},
+                native_positions: {},
             },
             events: [
                 ModuleEvent { type: Struct(StructTag { address: 0000000000000000000000000000000000000000000000000000000000000001, module: Identifier("transaction_fee"), name: Identifier("FeeStatement"), type_args: [] }), event_data: "03000000000000000300000000000000000000000000000000000000000000000000000000000000" },

--- a/aptos-move/e2e-tests/goldens/language_e2e_testsuite__tests__verify_txn__test_type_tag_transitive_dependency_fails_verification.exp
+++ b/aptos-move/e2e-tests/goldens/language_e2e_testsuite__tests__verify_txn__test_type_tag_transitive_dependency_fails_verification.exp
@@ -14,6 +14,7 @@ Ok(
                     ),
                 ),
                 hotness: {},
+                native_positions: {},
             },
             events: [
                 ModuleEvent { type: Struct(StructTag { address: 0000000000000000000000000000000000000000000000000000000000000001, module: Identifier("transaction_fee"), name: Identifier("FeeStatement"), type_args: [] }), event_data: "03000000000000000300000000000000000000000000000000000000000000000000000000000000" },

--- a/aptos-move/e2e-tests/goldens/language_e2e_testsuite__tests__verify_txn__verify_multi_agent_duplicate_secondary_signer.exp
+++ b/aptos-move/e2e-tests/goldens/language_e2e_testsuite__tests__verify_txn__verify_multi_agent_duplicate_secondary_signer.exp
@@ -10,6 +10,7 @@ Ok(
                     ),
                 ),
                 hotness: {},
+                native_positions: {},
             },
             events: [],
             gas_used: 0,

--- a/aptos-move/e2e-tests/goldens/language_e2e_testsuite__tests__verify_txn__verify_multi_agent_invalid_secondary_signature.exp
+++ b/aptos-move/e2e-tests/goldens/language_e2e_testsuite__tests__verify_txn__verify_multi_agent_invalid_secondary_signature.exp
@@ -10,6 +10,7 @@ Ok(
                     ),
                 ),
                 hotness: {},
+                native_positions: {},
             },
             events: [],
             gas_used: 0,

--- a/aptos-move/e2e-tests/goldens/language_e2e_testsuite__tests__verify_txn__verify_multi_agent_invalid_sender_signature.exp
+++ b/aptos-move/e2e-tests/goldens/language_e2e_testsuite__tests__verify_txn__verify_multi_agent_invalid_sender_signature.exp
@@ -10,6 +10,7 @@ Ok(
                     ),
                 ),
                 hotness: {},
+                native_positions: {},
             },
             events: [],
             gas_used: 0,

--- a/storage/indexer/src/db_v2.rs
+++ b/storage/indexer/src/db_v2.rs
@@ -250,6 +250,7 @@ impl<'a, R: StateView> TableInfoParser<'a, R> {
                     self.collect_table_info_from_table_item(*handle, bytes)?
                 },
                 StateKeyInner::Raw(_) => (),
+                StateKeyInner::TradingNative(_) => (),
             }
         }
         Ok(())

--- a/testsuite/generate-format/tests/staged/api.yaml
+++ b/testsuite/generate-format/tests/staged/api.yaml
@@ -783,6 +783,10 @@ StateKey:
     2:
       Raw:
         NEWTYPE: BYTES
+    3:
+      TradingNative:
+        NEWTYPE:
+          TYPENAME: TradingNativeKey
 StateValueMetadata:
   ENUM:
     0:
@@ -817,6 +821,17 @@ SymmetricCiphertext:
 TableHandle:
   NEWTYPESTRUCT:
     TYPENAME: AccountAddress
+TradingNativeKey:
+  ENUM:
+    0:
+      Position:
+        STRUCT:
+          - exchange:
+              TYPENAME: AccountAddress
+          - account:
+              TYPENAME: AccountAddress
+          - market:
+              TYPENAME: AccountAddress
 Transaction:
   ENUM:
     0:

--- a/testsuite/generate-format/tests/staged/aptos.yaml
+++ b/testsuite/generate-format/tests/staged/aptos.yaml
@@ -715,6 +715,10 @@ StateKey:
     2:
       Raw:
         NEWTYPE: BYTES
+    3:
+      TradingNative:
+        NEWTYPE:
+          TYPENAME: TradingNativeKey
 StateValueMetadata:
   ENUM:
     0:
@@ -749,6 +753,17 @@ SymmetricCiphertext:
 TableHandle:
   NEWTYPESTRUCT:
     TYPENAME: AccountAddress
+TradingNativeKey:
+  ENUM:
+    0:
+      Position:
+        STRUCT:
+          - exchange:
+              TYPENAME: AccountAddress
+          - account:
+              TYPENAME: AccountAddress
+          - market:
+              TYPENAME: AccountAddress
 Transaction:
   ENUM:
     0:

--- a/testsuite/generate-format/tests/staged/consensus.yaml
+++ b/testsuite/generate-format/tests/staged/consensus.yaml
@@ -1268,6 +1268,10 @@ StateKey:
     2:
       Raw:
         NEWTYPE: BYTES
+    3:
+      TradingNative:
+        NEWTYPE:
+          TYPENAME: TradingNativeKey
 StateValueMetadata:
   ENUM:
     0:
@@ -1314,6 +1318,17 @@ SyncInfo:
 TableHandle:
   NEWTYPESTRUCT:
     TYPENAME: AccountAddress
+TradingNativeKey:
+  ENUM:
+    0:
+      Position:
+        STRUCT:
+          - exchange:
+              TYPENAME: AccountAddress
+          - account:
+              TYPENAME: AccountAddress
+          - market:
+              TYPENAME: AccountAddress
 Transaction:
   ENUM:
     0:

--- a/types/src/state_store/state_key/inner.rs
+++ b/types/src/state_store/state_key/inner.rs
@@ -4,6 +4,7 @@
 use crate::{access_path::AccessPath, state_store::table::TableHandle};
 use aptos_crypto_derive::CryptoHasher;
 use bytes::{BufMut, Bytes, BytesMut};
+use move_core_types::account_address::AccountAddress;
 use num_derive::{FromPrimitive, ToPrimitive};
 use serde::{Deserialize, Serialize};
 use std::{
@@ -18,7 +19,24 @@ use thiserror::Error;
 pub enum StateKeyTag {
     AccessPath,
     TableItem,
+    /// Umbrella for the trading-native subsystem. Sub-entities
+    /// (Position, future Collateral / Order / ...) are distinguished
+    /// by [`TradingNativeKeyTag`] inside the payload, not by a
+    /// top-level tag. This keeps the top-level tag space focused on
+    /// subsystem-level categories.
+    TradingNative = 2,
     Raw = 255,
+}
+
+/// Sub-tag distinguishing entities inside the
+/// [`StateKeyInner::TradingNative`] umbrella. Encoded as the first
+/// byte of the payload after the top-level [`StateKeyTag::TradingNative`]
+/// byte. Variant ordinals are part of the on-disk byte format —
+/// **do not reorder or insert before existing entries**.
+#[repr(u8)]
+#[derive(Clone, Debug, FromPrimitive, ToPrimitive)]
+pub enum TradingNativeKeyTag {
+    Position = 0,
 }
 
 /// Error thrown when a [`StateKey`] fails to be deserialized out of a byte sequence stored in physical
@@ -35,6 +53,10 @@ pub enum StateKeyDecodeErr {
 
     #[error("Not enough bytes: tag: {}, num bytes: {}", tag, num_bytes)]
     NotEnoughBytes { tag: u8, num_bytes: usize },
+
+    /// The sub-tag inside a `TradingNative` payload is unrecognized.
+    #[error("unknown TradingNative sub-tag: {}", unknown_sub_tag)]
+    UnknownTradingNativeSubTag { unknown_sub_tag: u8 },
 
     #[error(transparent)]
     BcsError(#[from] bcs::Error),
@@ -56,6 +78,25 @@ pub enum StateKeyInner {
     // Only used for testing
     #[serde(with = "serde_bytes")]
     Raw(Vec<u8>),
+    /// Umbrella variant for the trading-native subsystem. Specific
+    /// entities are distinguished by the inner [`TradingNativeKey`].
+    TradingNative(TradingNativeKey),
+}
+
+/// Sub-shape of a `StateKeyInner::TradingNative` key. Each variant
+/// owns a fixed-width encoding; the [`TradingNativeKeyTag`] sub-tag
+/// is written/read once per encode/decode.
+#[derive(
+    Clone, Debug, CryptoHasher, Eq, PartialEq, Serialize, Deserialize, Ord, PartialOrd, Hash,
+)]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(proptest_derive::Arbitrary))]
+pub enum TradingNativeKey {
+    /// Native-position persisted entry: per-(exchange, account, market) position.
+    Position {
+        exchange: AccountAddress,
+        account: AccountAddress,
+        market: AccountAddress,
+    },
 }
 
 impl StateKeyInner {
@@ -76,6 +117,21 @@ impl StateKeyInner {
             StateKeyInner::Raw(raw_bytes) => {
                 writer.write_all(&[StateKeyTag::Raw as u8])?;
                 writer.write_all(raw_bytes)?;
+            },
+            StateKeyInner::TradingNative(key) => {
+                writer.write_all(&[StateKeyTag::TradingNative as u8])?;
+                match key {
+                    TradingNativeKey::Position {
+                        exchange,
+                        account,
+                        market,
+                    } => {
+                        writer.write_all(&[TradingNativeKeyTag::Position as u8])?;
+                        writer.write_all(exchange.as_ref())?;
+                        writer.write_all(account.as_ref())?;
+                        writer.write_all(market.as_ref())?;
+                    },
+                }
             },
         };
 
@@ -99,6 +155,17 @@ impl Debug for StateKeyInner {
             },
             StateKeyInner::Raw(bytes) => {
                 write!(f, "StateKey::Raw({})", hex::encode(bytes),)
+            },
+            StateKeyInner::TradingNative(key) => match key {
+                TradingNativeKey::Position {
+                    exchange,
+                    account,
+                    market,
+                } => write!(
+                    f,
+                    "StateKey::TradingNative::Position {{ exchange: {}, account: {}, market: {} }}",
+                    exchange, account, market,
+                ),
             },
         }
     }

--- a/types/src/state_store/state_key/mod.rs
+++ b/types/src/state_store/state_key/mod.rs
@@ -15,7 +15,7 @@ use crate::{
     on_chain_config::OnChainConfig,
     state_store::{
         state_key::{
-            inner::{StateKeyDecodeErr, StateKeyTag},
+            inner::{StateKeyDecodeErr, StateKeyTag, TradingNativeKey, TradingNativeKeyTag},
             registry::{Entry, REGISTRY},
         },
         table::TableHandle,
@@ -90,6 +90,41 @@ impl StateKey {
                 Self::table_item(&handle, &val[1 + HANDLE_SIZE..])
             },
             StateKeyTag::Raw => Self::raw(&val[1..]),
+            StateKeyTag::TradingNative => {
+                // Expected: [tag:1][sub_tag:1][...payload]
+                if val.len() < 2 {
+                    return Err(StateKeyDecodeErr::NotEnoughBytes {
+                        tag,
+                        num_bytes: val.len(),
+                    });
+                }
+                let sub_tag = val[1];
+                let sub = TradingNativeKeyTag::from_u8(sub_tag).ok_or(
+                    StateKeyDecodeErr::UnknownTradingNativeSubTag {
+                        unknown_sub_tag: sub_tag,
+                    },
+                )?;
+                match sub {
+                    TradingNativeKeyTag::Position => {
+                        // [tag:1][sub_tag:1][exchange:32][account:32][market:32]
+                        const ADDR: usize = AccountAddress::LENGTH;
+                        const POS_LEN: usize = 2 + ADDR * 3;
+                        if val.len() != POS_LEN {
+                            return Err(StateKeyDecodeErr::NotEnoughBytes {
+                                tag,
+                                num_bytes: val.len(),
+                            });
+                        }
+                        let exchange = AccountAddress::from_bytes(&val[2..2 + ADDR])
+                            .map_err(|e| StateKeyDecodeErr::AnyHow(e.into()))?;
+                        let account = AccountAddress::from_bytes(&val[2 + ADDR..2 + ADDR * 2])
+                            .map_err(|e| StateKeyDecodeErr::AnyHow(e.into()))?;
+                        let market = AccountAddress::from_bytes(&val[2 + ADDR * 2..POS_LEN])
+                            .map_err(|e| StateKeyDecodeErr::AnyHow(e.into()))?;
+                        Self::position(exchange, account, market)
+                    },
+                }
+            },
         };
         Ok(myself)
     }
@@ -103,6 +138,16 @@ impl StateKey {
             StateKeyInner::AccessPath(access_path) => access_path.size(),
             StateKeyInner::TableItem { handle, key } => handle.size() + key.len(),
             StateKeyInner::Raw(bytes) => bytes.len(),
+            StateKeyInner::TradingNative(key) => match key {
+                TradingNativeKey::Position { .. } => {
+                    // sub_tag (1) + exchange (32) + account (32) + market (32).
+                    // Umbrella tag byte is uniform across all StateKey variants
+                    // and excluded by convention (see AccessPath/TableItem/Raw
+                    // size() impls); the sub-tag is payload-specific to
+                    // TradingNative variants and counted here.
+                    1 + AccountAddress::LENGTH * 3
+                },
+            },
         }
     }
 
@@ -131,9 +176,36 @@ impl StateKey {
             },
             StateKeyInner::TableItem { handle, key } => Self::table_item(&handle, &key),
             StateKeyInner::Raw(bytes) => Self::raw(&bytes),
+            StateKeyInner::TradingNative(key) => match key {
+                TradingNativeKey::Position {
+                    exchange,
+                    account,
+                    market,
+                } => Self::position(exchange, account, market),
+            },
         };
 
         Ok(myself)
+    }
+
+    /// Construct a persisted Position state key.
+    pub fn position(
+        exchange: AccountAddress,
+        account: AccountAddress,
+        market: AccountAddress,
+    ) -> Self {
+        Self(
+            REGISTRY
+                .position((exchange, account), &market)
+                .get_or_add(&(exchange, account), &market, || {
+                    Ok(StateKeyInner::TradingNative(TradingNativeKey::Position {
+                        exchange,
+                        account,
+                        market,
+                    }))
+                })
+                .expect("Position StateKey encode is infallible"),
+        )
     }
 
     pub fn resource(address: &AccountAddress, struct_tag: &StructTag) -> Result<Self> {

--- a/types/src/state_store/state_key/registry.rs
+++ b/types/src/state_store/state_key/registry.rs
@@ -4,7 +4,7 @@
 use crate::{
     access_path::AccessPath,
     state_store::{
-        state_key::inner::{StateKeyInner, StateKeyInnerHasher},
+        state_key::inner::{StateKeyInner, StateKeyInnerHasher, TradingNativeKey},
         table::TableHandle,
     },
 };
@@ -64,6 +64,15 @@ impl Drop for Entry {
                 REGISTRY.table_item(handle, key).maybe_remove(handle, key)
             },
             StateKeyInner::Raw(bytes) => REGISTRY.raw(bytes).maybe_remove(bytes, &()),
+            StateKeyInner::TradingNative(key) => match key {
+                TradingNativeKey::Position {
+                    exchange,
+                    account,
+                    market,
+                } => REGISTRY
+                    .position((*exchange, *account), market)
+                    .maybe_remove(&(*exchange, *account), market),
+            },
         }
     }
 }
@@ -198,6 +207,7 @@ const NUM_RESOURCE_GROUP_SHARDS: usize = 8;
 const NUM_MODULE_SHARDS: usize = 8;
 const NUM_TABLE_ITEM_SHARDS: usize = 8;
 const NUM_RAW_SHARDS: usize = 4;
+const NUM_POSITION_SHARDS: usize = 8;
 
 #[derive(Default)]
 pub struct StateKeyRegistry {
@@ -206,6 +216,10 @@ pub struct StateKeyRegistry {
     module_shards: [TwoKeyRegistry<AccountAddress, Identifier>; NUM_MODULE_SHARDS],
     table_item_shards: [TwoKeyRegistry<TableHandle, Vec<u8>>; NUM_TABLE_ITEM_SHARDS],
     raw_shards: [TwoKeyRegistry<Vec<u8>, ()>; NUM_RAW_SHARDS], // for tests only
+    /// (exchange, account) -> market -> Entry. Positions are bounded by a
+    /// single exchange's universe so the shard count is modest.
+    position_shards:
+        [TwoKeyRegistry<(AccountAddress, AccountAddress), AccountAddress>; NUM_POSITION_SHARDS],
 }
 
 impl StateKeyRegistry {
@@ -258,5 +272,18 @@ impl StateKeyRegistry {
 
     pub(crate) fn raw(&self, bytes: &[u8]) -> &TwoKeyRegistry<Vec<u8>, ()> {
         &self.raw_shards[Self::hash_address_and_name(&AccountAddress::ONE, bytes) % NUM_RAW_SHARDS]
+    }
+
+    pub(crate) fn position(
+        &self,
+        key1: (AccountAddress, AccountAddress),
+        market: &AccountAddress,
+    ) -> &TwoKeyRegistry<(AccountAddress, AccountAddress), AccountAddress> {
+        let (exchange, account) = key1;
+        let mut hasher = fxhash::FxHasher::default();
+        hasher.write_u8(exchange.as_ref()[AccountAddress::LENGTH - 1]);
+        hasher.write_u8(account.as_ref()[AccountAddress::LENGTH - 1]);
+        hasher.write_u8(market.as_ref()[AccountAddress::LENGTH - 1]);
+        &self.position_shards[hasher.finish() as usize % NUM_POSITION_SHARDS]
     }
 }

--- a/types/src/write_set.rs
+++ b/types/src/write_set.rs
@@ -545,12 +545,49 @@ impl Debug for HotStateOp {
     }
 }
 
+/// Native-position write produced by a transaction. Type-distinct
+/// from [`WriteOp`] so the compiler refuses to mix native-position
+/// entries into the main-state bucket (`ValueWriteSet`). Wraps the
+/// same `BaseStateOp` payload variants as `WriteOp` (Creation /
+/// Modification / Deletion) — `MakeHot` is rejected at construction.
+///
+/// Carried by [`WriteSet::native_positions`]; skipped from the
+/// WriteSet's serde representation, so `TransactionInfo` hashes and
+/// on-disk WriteSet bytes are unaffected. The storage commit applier
+/// (in `aptos-db`) consumes it via [`WriteSet::native_position_iter`].
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct NativePositionOp(BaseStateOp);
+
+impl NativePositionOp {
+    pub fn from_write_op(op: WriteOp) -> Self {
+        Self(op.into_base_op())
+    }
+
+    pub fn as_base_op(&self) -> &BaseStateOp {
+        &self.0
+    }
+
+    /// Borrow as a `WriteOp`. Always succeeds because the only
+    /// constructor takes a `WriteOp`.
+    pub fn as_write_op(&self) -> &WriteOp {
+        self.0
+            .as_write_op_opt()
+            .expect("NativePositionOp must wrap a WriteOp variant")
+    }
+}
+
 #[derive(BCSCryptoHash, Clone, CryptoHasher, Debug, Default, Eq, PartialEq)]
 pub struct WriteSet {
     value: ValueWriteSet,
     /// Hot state promotions, non-empty only in block epilogues.
     /// TODO(HotState): not hashed into `TransactionInfo` for now.
     hotness: BTreeMap<StateKey, HotStateOp>,
+    /// Native-position writes staged by the transaction. Routed
+    /// to the dedicated `position_db` + in-memory `NativeStateStore`
+    /// by the storage commit applier; never enters main state.
+    /// Skipped from serde so `TransactionInfo` hashes and the
+    /// on-disk WriteSet format are unaffected.
+    native_positions: BTreeMap<StateKey, NativePositionOp>,
 }
 
 impl Serialize for WriteSet {
@@ -571,6 +608,7 @@ impl<'de> Deserialize<'de> for WriteSet {
         Ok(Self {
             value,
             hotness: BTreeMap::new(),
+            native_positions: BTreeMap::new(),
         })
     }
 }
@@ -602,6 +640,7 @@ impl WriteSet {
         Self {
             value,
             hotness: BTreeMap::new(),
+            native_positions: BTreeMap::new(),
         }
     }
 
@@ -609,7 +648,11 @@ impl WriteSet {
         value: ValueWriteSet,
         hotness: BTreeMap<StateKey, HotStateOp>,
     ) -> Self {
-        Self { value, hotness }
+        Self {
+            value,
+            hotness,
+            native_positions: BTreeMap::new(),
+        }
     }
 
     pub fn new(write_ops: impl IntoIterator<Item = (StateKey, WriteOp)>) -> Result<Self> {
@@ -654,7 +697,7 @@ impl WriteSet {
     }
 
     pub fn is_empty(&self) -> bool {
-        self.as_v0().is_empty() && self.hotness.is_empty()
+        self.as_v0().is_empty() && self.hotness.is_empty() && self.native_positions.is_empty()
     }
 
     pub fn expect_into_write_op_iter(self) -> impl IntoIterator<Item = (StateKey, WriteOp)> {
@@ -702,6 +745,31 @@ impl WriteSet {
             "hotness should only be initialized once."
         );
         self.hotness = hotness;
+    }
+
+    /// Iterate the native-position bucket. Used by the storage
+    /// commit applier; main-state consumers never see these entries.
+    pub fn native_position_iter(&self) -> impl Iterator<Item = (&StateKey, &NativePositionOp)> {
+        self.native_positions.iter()
+    }
+
+    pub fn native_position_keys(&self) -> impl Iterator<Item = &StateKey> {
+        self.native_positions.keys()
+    }
+
+    pub fn has_native_positions(&self) -> bool {
+        !self.native_positions.is_empty()
+    }
+
+    /// Install the native-position bucket. Mirrors [`add_hotness`]:
+    /// expected to be called once per WriteSet, at VM-output
+    /// materialization time.
+    pub fn add_native_positions(&mut self, native_positions: BTreeMap<StateKey, NativePositionOp>) {
+        assert!(
+            self.native_positions.is_empty(),
+            "native_positions should only be initialized once."
+        );
+        self.native_positions = native_positions;
     }
 }
 
@@ -804,6 +872,7 @@ impl WriteSetMut {
         Ok(WriteSet {
             value: ValueWriteSet::V0(WriteSetV0(self)),
             hotness: BTreeMap::new(),
+            native_positions: BTreeMap::new(),
         })
     }
 


### PR DESCRIPTION
Foundational types for the native-position storage subsystem.

Adds:
- `StateKeyInner::TradingNative(TradingNativeKey)` umbrella variant (top-level tag 2). The inner `TradingNativeKey::Position { exchange, account, market }` sub-variant is distinguished by a `TradingNativeKeyTag` byte written immediately after the umbrella tag — the encoded layout is 98 bytes (`[2][0][exchange:32B][account:32B][market:32B]`). Future sub-entities (Collateral / Order / ...) extend `TradingNativeKey` rather than the top-level tag space.
- `StateKey::position(exchange, account, market)` constructor via the interning REGISTRY (8 shards keyed by (exchange, account) -> market).
- `NativeTransactionWrites { position_writes: BTreeMap<StateKey, WriteOp> }` as a transient side-channel on `TransactionOutput`. Skipped from serde — used only as an in-process hand-off from VMOutput materialization to the storage commit applier.

Downstream wiring (match arms in api/types/convert, indexer/db_v2, gas-profiling, transaction-simulation) lands in this commit too so the workspace stays buildable; the follow-up storage/VM commits land separately on their respective branches.

## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [x] Validator Node
- [x] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new on-disk `StateKey` encoding and extends `WriteSet` with a new non-serialized write bucket, which can affect storage key decoding and downstream tooling if any consumer misses the new variant.
> 
> **Overview**
> Adds a new `StateKeyInner::TradingNative(TradingNativeKey)` variant with a fixed binary encoding (top-level tag `2` plus a `TradingNativeKeyTag` sub-tag) and a `StateKey::position(exchange, account, market)` constructor backed by new interning registry shards.
> 
> Extends `WriteSet` with a separate `native_positions` bucket (typed via `NativePositionOp`) that is **not** included in serde/`TransactionInfo` hashing, plus accessors/initializers; updates e2e goldens to show the new empty field.
> 
> Updates downstream match arms and format definitions to recognize the new `StateKey` variant (API conversion rejects it, gas-profiling panics on it, transaction simulation prints it, indexer ignores it) and stages `TradingNativeKey` in generated YAML formats.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 767a7e8af673bd37823e92bf46f653f3aab6dea1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->