### PR TITLE
[Mempool] Add fee payer transaction limits.

### DIFF
--- a/config/src/config/mempool_config.rs
+++ b/config/src/config/mempool_config.rs
@@ -106,6 +106,8 @@ pub struct MempoolConfig {
     /// Maximum rate of inbound transactions (TPS) per peer (note: client
     /// submission is not affected). If None, no rate limit is applied.
     pub inbound_rate_limit_tps_per_peer: Option<u64>,
+    /// Maximum number of sponsored (fee payer) transactions in mempool, per fee payer account
+    pub fee_payer_txn_capacity: usize,
 }
 
 impl Default for MempoolConfig {
@@ -173,6 +175,7 @@ impl Default for MempoolConfig {
             enable_max_load_balancing_at_any_load: false,
             orderless_txn_capacity_per_user: 5000,
             inbound_rate_limit_tps_per_peer: None,
+            fee_payer_txn_capacity: 5000,
         }
     }
 }

--- a/mempool/src/core_mempool/transaction_store.rs
+++ b/mempool/src/core_mempool/transaction_store.rs
@@ -37,7 +37,8 @@ use std::{
 pub const TXN_INDEX_ESTIMATED_BYTES: usize = size_of::<crate::core_mempool::index::OrderedQueueKey>() // priority_index
     + size_of::<crate::core_mempool::index::TTLOrderingKey>() * 2 // expiration_time_index + system_ttl_index
     + (size_of::<u64>() * 3 + size_of::<AccountAddress>()) // timeline_index
-    + (size_of::<HashValue>() + size_of::<u64>() + size_of::<AccountAddress>()); // hash_index
+    + (size_of::<HashValue>() + size_of::<u64>() + size_of::<AccountAddress>()) // hash_index
+    + (size_of::<AccountAddress>() + size_of::<usize>()); // fee_payer_txn_counts (worst case: one map entry per txn)
 
 pub fn sender_bucket(
     address: &AccountAddress,
@@ -93,7 +94,12 @@ pub struct TransactionStore {
     capacity_per_user: usize,
     // Maximum number of orderless transactions allowed in the Mempool per user
     orderless_txn_capacity_per_user: usize,
+    // Maximum number of sponsored (fee payer) transactions allowed per fee payer account
+    fee_payer_txn_capacity: usize,
     max_batch_bytes: u64,
+
+    // Counts of pending sponsored transactions keyed by fee payer address
+    fee_payer_txn_counts: HashMap<AccountAddress, usize>,
 
     // eager expiration
     eager_expire_threshold: Option<Duration>,
@@ -132,7 +138,10 @@ impl TransactionStore {
             capacity_bytes: config.capacity_bytes,
             capacity_per_user: config.capacity_per_user,
             orderless_txn_capacity_per_user: config.orderless_txn_capacity_per_user,
+            fee_payer_txn_capacity: config.fee_payer_txn_capacity,
             max_batch_bytes: config.shared_mempool_max_batch_bytes,
+
+            fee_payer_txn_counts: HashMap::new(),
 
             // eager expiration
             eager_expire_threshold: config.eager_expire_threshold_ms.map(Duration::from_millis),
@@ -250,6 +259,7 @@ impl TransactionStore {
     ) -> MempoolStatus {
         let address = txn.get_sender();
         let txn_replay_protector = txn.get_replay_protector();
+        let fee_payer_address = txn.txn.authenticator_ref().fee_payer_address();
 
         let account_sequence_number = account_sequence_number.map(|seq_num| {
             max(
@@ -326,6 +336,25 @@ impl TransactionStore {
             ));
         }
 
+        // Fee payer capacity check for sponsored transactions
+        if let Some(fee_payer) = fee_payer_address {
+            let count = self
+                .fee_payer_txn_counts
+                .get(&fee_payer)
+                .copied()
+                .unwrap_or(0);
+            if count >= self.fee_payer_txn_capacity {
+                return MempoolStatus::new(MempoolStatusCode::TooManyTransactions).with_message(
+                    format!(
+                        "Mempool over capacity for fee payer: {}. Number of sponsored transactions from fee payer: {} Capacity per fee payer: {}",
+                        fee_payer.to_standard_string(),
+                        count,
+                        self.fee_payer_txn_capacity,
+                    ),
+                );
+            }
+        }
+
         self.transactions.entry(address).or_default();
         if let Some(txns) = self.transactions.get_mut(&address) {
             // capacity check
@@ -363,6 +392,9 @@ impl TransactionStore {
             }
             self.size_bytes += txn.get_estimated_bytes();
             txns.insert(txn);
+            if let Some(fee_payer) = fee_payer_address {
+                *self.fee_payer_txn_counts.entry(fee_payer).or_insert(0) += 1;
+            }
             self.track_indices();
         }
 
@@ -753,6 +785,18 @@ impl TransactionStore {
     /// Removes transaction from all indexes. Only call after removing from main transactions DS.
     fn index_remove(&mut self, txn: &MempoolTransaction) {
         counters::CORE_MEMPOOL_REMOVED_TXNS.inc();
+        // Decrement the per-fee-payer count for sponsored transactions.
+        if let Some(fee_payer) = txn.txn.authenticator_ref().fee_payer_address() {
+            match self.fee_payer_txn_counts.get_mut(&fee_payer) {
+                Some(count) if *count <= 1 => {
+                    self.fee_payer_txn_counts.remove(&fee_payer);
+                },
+                Some(count) => {
+                    *count = count.saturating_sub(1);
+                },
+                None => {},
+            }
+        }
         self.system_ttl_index.remove(txn);
         self.expiration_time_index.remove(txn);
         self.priority_index.remove(txn);

--- a/mempool/src/tests/core_mempool_test.rs
+++ b/mempool/src/tests/core_mempool_test.rs
@@ -11,15 +11,19 @@ use crate::{
 };
 use aptos_config::config::{MempoolConfig, NodeConfig};
 use aptos_consensus_types::common::{TransactionInProgress, TransactionSummary};
-use aptos_crypto::HashValue;
+use aptos_crypto::{ed25519::Ed25519PrivateKey, HashValue, PrivateKey, Uniform as _};
 use aptos_types::{
-    account_address::AccountAddress,
+    account_address::{self, AccountAddress},
+    chain_id::ChainId,
     mempool_status::MempoolStatusCode,
-    transaction::{ReplayProtector, SignedTransaction},
+    transaction::{
+        RawTransaction, ReplayProtector, Script, SignedTransaction, TransactionExecutable,
+    },
     vm_status::DiscardedVMStatus,
 };
 use itertools::Itertools;
 use maplit::btreemap;
+use rand::{rngs::StdRng, SeedableRng};
 use std::time::{Duration, Instant, SystemTime};
 
 #[test]
@@ -1757,4 +1761,413 @@ fn test_include_gas_upgraded() {
         high_gas_txn => TransactionInProgress::new(high_gas_price)
     });
     assert_eq!(batch.len(), 0);
+}
+
+#[test]
+fn test_fee_payer_cap_rejects_when_full() {
+    // Create a mempool with the specified fee payer capacity
+    let fee_payer_txn_capacity = 3;
+    let mut mempool = create_mempool_with_fee_payer_capacity(fee_payer_txn_capacity);
+
+    // Create a fee payer account
+    let fee_payer_key = generate_private_key_from_seed(0);
+    let fee_payer_addr = account_address::from_public_key(&fee_payer_key.public_key());
+
+    // Add exactly `fee_payer_txn_capacity` sponsored transactions from distinct senders (all should be accepted)
+    for i in 0..fee_payer_txn_capacity {
+        let sender_key = generate_private_key_from_seed(1 + i as u64);
+        let txn = make_fee_payer_txn(
+            &sender_key,
+            ReplayProtector::SequenceNumber(0),
+            (i + 1) as u64,
+            fee_payer_addr,
+            &fee_payer_key,
+        );
+        assert_eq!(
+            add_fee_payer_txn(&mut mempool, txn),
+            MempoolStatusCode::Accepted,
+        );
+    }
+
+    // One more sponsored txn for the same fee payer should be rejected
+    let sender_key = generate_private_key_from_seed(1 + fee_payer_txn_capacity as u64);
+    let txn = make_fee_payer_txn(
+        &sender_key,
+        ReplayProtector::SequenceNumber(0),
+        1,
+        fee_payer_addr,
+        &fee_payer_key,
+    );
+    assert_eq!(
+        add_fee_payer_txn(&mut mempool, txn),
+        MempoolStatusCode::TooManyTransactions,
+    );
+}
+
+#[test]
+fn test_fee_payer_cap_independent_per_fee_payer() {
+    // Create a mempool with the specified fee payer capacity
+    let fee_payer_txn_capacity = 3;
+    let mut mempool = create_mempool_with_fee_payer_capacity(fee_payer_txn_capacity);
+
+    // Create two fee payer accounts
+    let fee_payer_key_a = generate_private_key_from_seed(0);
+    let fee_payer_address_a = account_address::from_public_key(&fee_payer_key_a.public_key());
+    let fee_payer_key_b = generate_private_key_from_seed(1);
+    let fee_payer_address_b = account_address::from_public_key(&fee_payer_key_b.public_key());
+
+    // Fill fee payer A to capacity
+    for i in 0..fee_payer_txn_capacity {
+        let sender_key = generate_private_key_from_seed(10 + i as u64);
+        let txn = make_fee_payer_txn(
+            &sender_key,
+            ReplayProtector::SequenceNumber(0),
+            (i + 1) as u64,
+            fee_payer_address_a,
+            &fee_payer_key_a,
+        );
+        assert_eq!(
+            add_fee_payer_txn(&mut mempool, txn),
+            MempoolStatusCode::Accepted
+        );
+    }
+
+    // Fee payer B should still have room
+    let sender_key = generate_private_key_from_seed(20);
+    let txn_b = make_fee_payer_txn(
+        &sender_key,
+        ReplayProtector::SequenceNumber(0),
+        1,
+        fee_payer_address_b,
+        &fee_payer_key_b,
+    );
+    assert_eq!(
+        add_fee_payer_txn(&mut mempool, txn_b),
+        MempoolStatusCode::Accepted,
+    );
+}
+
+#[test]
+fn test_non_sponsored_txn_unaffected_by_fee_payer_cap() {
+    // Create a mempool with the specified fee payer capacity
+    let fee_payer_txn_capacity = 0;
+    let mut mempool = create_mempool_with_fee_payer_capacity(fee_payer_txn_capacity);
+
+    // A normal (non-fee-payer) transaction should be admitted regardless
+    let txn = TestTransaction::new(0, ReplayProtector::SequenceNumber(0), 1);
+    assert!(add_txn(&mut mempool, txn).is_ok(),);
+}
+
+#[test]
+fn test_fee_payer_cap_slot_released_on_reject() {
+    // Create a mempool with the specified fee payer capacity
+    let fee_payer_txn_capacity = 1;
+    let mut mempool = create_mempool_with_fee_payer_capacity(fee_payer_txn_capacity);
+
+    // Create a fee payer account
+    let fee_payer_key = generate_private_key_from_seed(0);
+    let fee_payer_addr = account_address::from_public_key(&fee_payer_key.public_key());
+
+    // Insert one sponsored txn to fill the capacity
+    let sender_key = generate_private_key_from_seed(1);
+    let txn = make_fee_payer_txn(
+        &sender_key,
+        ReplayProtector::SequenceNumber(0),
+        1,
+        fee_payer_addr,
+        &fee_payer_key,
+    );
+    assert_eq!(
+        add_fee_payer_txn(&mut mempool, txn.clone()),
+        MempoolStatusCode::Accepted
+    );
+
+    // Reject the transaction (this should release the fee payer slot)
+    mempool.reject_transaction(
+        &txn.sender(),
+        txn.replay_protector(),
+        &txn.committed_hash(),
+        &DiscardedVMStatus::MALFORMED,
+    );
+
+    // Now a new sponsored txn for the same fee payer should be allowed
+    let sender_key2 = generate_private_key_from_seed(2);
+    let txn2 = make_fee_payer_txn(
+        &sender_key2,
+        ReplayProtector::SequenceNumber(0),
+        1,
+        fee_payer_addr,
+        &fee_payer_key,
+    );
+    assert_eq!(
+        add_fee_payer_txn(&mut mempool, txn2),
+        MempoolStatusCode::Accepted,
+    );
+}
+
+#[test]
+fn test_fee_payer_cap_slot_released_on_gc() {
+    // Create a mempool with the specified fee payer capacity, and a short TTL
+    // to ensure that GC will evict the transaction and release the fee payer slot.
+    let fee_payer_txn_capacity = 1;
+    let mut node_config = NodeConfig::generate_random_config();
+    node_config.mempool.fee_payer_txn_capacity = fee_payer_txn_capacity;
+    node_config.mempool.system_transaction_timeout_secs = 0; // Set TTL to 0 seconds for immediate expiration
+    let mut mempool = CoreMempool::new(&node_config);
+
+    // Create a fee payer account
+    let fee_payer_key = generate_private_key_from_seed(0);
+    let fee_payer_addr = account_address::from_public_key(&fee_payer_key.public_key());
+
+    // Insert one sponsored txn to fill the capacity
+    let sender_key = generate_private_key_from_seed(1);
+    let txn = make_fee_payer_txn(
+        &sender_key,
+        ReplayProtector::SequenceNumber(0),
+        1,
+        fee_payer_addr,
+        &fee_payer_key,
+    );
+    assert_eq!(
+        add_fee_payer_txn(&mut mempool, txn),
+        MempoolStatusCode::Accepted
+    );
+
+    // Verify that the fee payer slot is currently occupied (capacity should be 1)
+    let sender_key = generate_private_key_from_seed(2);
+    let txn = make_fee_payer_txn(
+        &sender_key,
+        ReplayProtector::SequenceNumber(0),
+        1,
+        fee_payer_addr,
+        &fee_payer_key,
+    );
+    assert_eq!(
+        add_fee_payer_txn(&mut mempool, txn),
+        MempoolStatusCode::TooManyTransactions,
+    );
+
+    // GC should evict the expired txn and release its fee payer slot
+    mempool.gc();
+
+    // Now a new sponsored txn for the same fee payer should be allowed
+    let sender_key = generate_private_key_from_seed(3);
+    let txn = make_fee_payer_txn(
+        &sender_key,
+        ReplayProtector::SequenceNumber(0),
+        1,
+        fee_payer_addr,
+        &fee_payer_key,
+    );
+    assert_eq!(
+        add_fee_payer_txn(&mut mempool, txn),
+        MempoolStatusCode::Accepted,
+    );
+}
+
+#[test]
+fn test_fee_payer_cap_gas_upgrade_does_not_double_count() {
+    // Create a mempool with the specified fee payer capacity
+    let fee_payer_txn_capacity = 1;
+    let mut mempool = create_mempool_with_fee_payer_capacity(fee_payer_txn_capacity);
+
+    // Create a fee payer account
+    let fee_payer_key = generate_private_key_from_seed(0);
+    let fee_payer_addr = account_address::from_public_key(&fee_payer_key.public_key());
+
+    // Insert the initial sponsored txn (gas price 1)
+    let sender_key = generate_private_key_from_seed(1);
+    let txn_low = make_fee_payer_txn(
+        &sender_key,
+        ReplayProtector::SequenceNumber(0),
+        1,
+        fee_payer_addr,
+        &fee_payer_key,
+    );
+    assert_eq!(
+        add_fee_payer_txn(&mut mempool, txn_low),
+        MempoolStatusCode::Accepted
+    );
+
+    // Re-submit the same txn with a higher gas price (the update should succeed)
+    let txn_high = make_fee_payer_txn(
+        &sender_key,
+        ReplayProtector::SequenceNumber(0),
+        10,
+        fee_payer_addr,
+        &fee_payer_key,
+    );
+    assert_eq!(
+        add_fee_payer_txn(&mut mempool, txn_high),
+        MempoolStatusCode::Accepted,
+    );
+
+    // A new sponsored txn from a different sender should now be rejected
+    let other_sender_key = generate_private_key_from_seed(2);
+    let other_txn = make_fee_payer_txn(
+        &other_sender_key,
+        ReplayProtector::SequenceNumber(0),
+        1,
+        fee_payer_addr,
+        &fee_payer_key,
+    );
+    assert_eq!(
+        add_fee_payer_txn(&mut mempool, other_txn),
+        MempoolStatusCode::TooManyTransactions,
+    );
+}
+
+#[test]
+fn test_fee_payer_cap_slot_released_on_commit() {
+    // Create a mempool with the specified fee payer capacity
+    let fee_payer_txn_capacity = 1;
+    let mut mempool = create_mempool_with_fee_payer_capacity(fee_payer_txn_capacity);
+
+    // Create a fee payer account
+    let fee_payer_key = generate_private_key_from_seed(0);
+    let fee_payer_addr = account_address::from_public_key(&fee_payer_key.public_key());
+
+    // Insert one sponsored txn to fill the capacity
+    let sender_key = generate_private_key_from_seed(1);
+    let txn = make_fee_payer_txn(
+        &sender_key,
+        ReplayProtector::SequenceNumber(0),
+        1,
+        fee_payer_addr,
+        &fee_payer_key,
+    );
+    assert_eq!(
+        add_fee_payer_txn(&mut mempool, txn.clone()),
+        MempoolStatusCode::Accepted
+    );
+
+    // Verify that the fee payer slot is currently occupied (capacity should be 1)
+    let sender_key_2 = generate_private_key_from_seed(2);
+    let txn_2 = make_fee_payer_txn(
+        &sender_key_2,
+        ReplayProtector::SequenceNumber(0),
+        1,
+        fee_payer_addr,
+        &fee_payer_key,
+    );
+    assert_eq!(
+        add_fee_payer_txn(&mut mempool, txn_2),
+        MempoolStatusCode::TooManyTransactions,
+    );
+
+    // Commit the transaction (this should release the fee payer slot)
+    mempool.commit_transaction(&txn.sender(), ReplayProtector::SequenceNumber(0));
+
+    // A new sponsored txn for the same fee payer should now be accepted
+    let sender_key2 = generate_private_key_from_seed(3);
+    let txn2 = make_fee_payer_txn(
+        &sender_key2,
+        ReplayProtector::SequenceNumber(0),
+        1,
+        fee_payer_addr,
+        &fee_payer_key,
+    );
+    assert_eq!(
+        add_fee_payer_txn(&mut mempool, txn2),
+        MempoolStatusCode::Accepted,
+    );
+}
+
+#[test]
+fn test_fee_payer_cap_idempotent_resubmission_does_not_consume_extra_slot() {
+    // Create a mempool with the specified fee payer capacity
+    let fee_payer_txn_capacity = 1;
+    let mut mempool = create_mempool_with_fee_payer_capacity(fee_payer_txn_capacity);
+
+    // Create a fee payer account
+    let fee_payer_key = generate_private_key_from_seed(0);
+    let fee_payer_addr = account_address::from_public_key(&fee_payer_key.public_key());
+
+    // Insert one sponsored txn to fill the capacity
+    let sender_key = generate_private_key_from_seed(1);
+    let txn = make_fee_payer_txn(
+        &sender_key,
+        ReplayProtector::SequenceNumber(0),
+        1,
+        fee_payer_addr,
+        &fee_payer_key,
+    );
+    assert_eq!(
+        add_fee_payer_txn(&mut mempool, txn.clone()),
+        MempoolStatusCode::Accepted
+    );
+
+    // Re-submit the same txn, and verify that it is accepted
+    assert_eq!(
+        add_fee_payer_txn(&mut mempool, txn),
+        MempoolStatusCode::Accepted,
+    );
+
+    // Verify that the fee payer slot is still occupied by trying to add another txn (should be rejected)
+    let other_sender_key = generate_private_key_from_seed(2);
+    let other_txn = make_fee_payer_txn(
+        &other_sender_key,
+        ReplayProtector::SequenceNumber(0),
+        1,
+        fee_payer_addr,
+        &fee_payer_key,
+    );
+    assert_eq!(
+        add_fee_payer_txn(&mut mempool, other_txn),
+        MempoolStatusCode::TooManyTransactions,
+    );
+}
+
+/// Adds a sponsored (fee-payer) transaction to mempool
+fn add_fee_payer_txn(pool: &mut CoreMempool, txn: SignedTransaction) -> MempoolStatusCode {
+    pool.add_txn(
+        txn,
+        1,
+        Some(0), // Fresh sender (on-chain seq num is 0)
+        TimelineState::NotReady,
+        false,
+        None,
+        Some(BroadcastPeerPriority::Primary),
+    )
+    .code
+}
+
+/// Creates a mempool with the specified fee payer capacity
+fn create_mempool_with_fee_payer_capacity(fee_payer_txn_capacity: usize) -> CoreMempool {
+    let mut config = NodeConfig::generate_random_config();
+    config.mempool.fee_payer_txn_capacity = fee_payer_txn_capacity;
+    CoreMempool::new(&config)
+}
+
+/// Generates a unique Ed25519 private key from a u64 seed
+fn generate_private_key_from_seed(seed_value: u64) -> Ed25519PrivateKey {
+    let mut seed = [0u8; 32];
+    seed[..8].copy_from_slice(&seed_value.to_le_bytes());
+    let mut rng = StdRng::from_seed(seed);
+    Ed25519PrivateKey::generate(&mut rng)
+}
+
+/// Creates a sponsored (fee-payer) transaction
+fn make_fee_payer_txn(
+    sender_key: &Ed25519PrivateKey,
+    replay_protector: ReplayProtector,
+    gas_price: u64,
+    fee_payer_addr: AccountAddress,
+    fee_payer_key: &Ed25519PrivateKey,
+) -> SignedTransaction {
+    let sender_addr = account_address::from_public_key(&sender_key.public_key());
+    let raw_txn = RawTransaction::new_txn(
+        sender_addr,
+        replay_protector,
+        TransactionExecutable::Script(Script::new(vec![], vec![], vec![])),
+        None,
+        100,
+        gas_price,
+        u64::MAX,
+        ChainId::test(),
+    );
+    raw_txn
+        .sign_fee_payer(sender_key, vec![], vec![], fee_payer_addr, fee_payer_key)
+        .unwrap()
+        .into_inner()
 }


### PR DESCRIPTION
## Description
This PR adds a per-fee-payer transaction count cap to mempool (`fee_payer_txn_capacity`, default `5000`), including unit tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes mempool admission for fee-payer transactions on a hot path; misconfiguration or counter bugs could reject valid sponsored traffic, though behavior is covered by new unit tests.
> 
> **Overview**
> Adds a **per-fee-payer cap** on sponsored transactions in mempool via new config `fee_payer_txn_capacity` (default **5000**), mirroring existing per-sender limits.
> 
> `TransactionStore` tracks pending sponsored txns per fee payer address, rejects new ones with `TooManyTransactions` when at capacity, and **releases slots** on remove paths (reject, commit, GC, gas upgrade / idempotent resubmit without double-counting). Non-sponsored submissions are unchanged.
> 
> Includes broad unit tests for cap enforcement, per-payer isolation, and slot lifecycle.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ab29addae59b9fc00275891655daa9c3dccf83a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->