### PR TITLE
[storage] Split KV-only replay chunks at epoch boundaries

### DIFF
--- a/storage/backup/backup-cli/src/backup_types/transaction/restore.rs
+++ b/storage/backup/backup-cli/src/backup_types/transaction/restore.rs
@@ -260,6 +260,47 @@ pub struct TransactionRestoreBatchController {
     first_version: Option<Version>,
 }
 
+/// Save a chunk of transactions and replay their KV writes, splitting the
+/// chunk at the epoch-ending versions in `epoch_end_versions` (sorted, empty
+/// when `--skip-epoch-endings` is set).
+fn save_kv_split_at_epoch_ends(
+    handler: &RestoreHandler,
+    epoch_end_versions: &[Version],
+    base_version: Version,
+    txns: &[Transaction],
+    persisted_aux_info: &[PersistedAuxiliaryInfo],
+    txn_infos: &[TransactionInfo],
+    events: &[Vec<ContractEvent>],
+    mut write_sets: Vec<WriteSet>,
+) -> Result<()> {
+    let len = txns.len();
+    let last_version = base_version + len as u64 - 1;
+    let lo = epoch_end_versions.partition_point(|&v| v < base_version);
+    let hi = epoch_end_versions.partition_point(|&v| v <= last_version);
+    let mut sub_ends: Vec<_> = epoch_end_versions[lo..hi]
+        .iter()
+        .map(|&v| (v - base_version + 1) as usize)
+        .collect();
+    if sub_ends.last().copied() != Some(len) {
+        sub_ends.push(len);
+    }
+
+    let mut start = 0usize;
+    for sub_end in sub_ends {
+        let n = sub_end - start;
+        handler.save_transactions_and_replay_kv(
+            base_version + start as u64,
+            &txns[start..sub_end],
+            &persisted_aux_info[start..sub_end],
+            &txn_infos[start..sub_end],
+            &events[start..sub_end],
+            write_sets.drain(..n).collect(),
+        )?;
+        start = sub_end;
+    }
+    Ok(())
+}
+
 impl TransactionRestoreBatchController {
     pub fn new(
         global_opt: GlobalRestoreOptions,
@@ -567,6 +608,14 @@ impl TransactionRestoreBatchController {
         let (first_version, _) = self.replay_from_version.unwrap();
         restore_handler.force_state_version_for_kv_restore(first_version.checked_sub(1))?;
 
+        // Sorted ascending; empty when `--skip-epoch-endings` is set.
+        let epoch_end_versions: Arc<Vec<Version>> = Arc::new(
+            self.epoch_history
+                .as_ref()
+                .map(|h| h.epoch_endings.iter().map(|li| li.version()).collect())
+                .unwrap_or_default(),
+        );
+
         let mut base_version = first_version;
         let mut offset = 0u64;
         let replay_start = Instant::now();
@@ -584,13 +633,15 @@ impl TransactionRestoreBatchController {
                     Vec<_>,
                 ) = chunk.into_iter().multiunzip();
                 let handler = arc_restore_handler.clone();
+                let epoch_end_versions = Arc::clone(&epoch_end_versions);
                 base_version += offset;
                 offset = txns.len() as u64;
                 async move {
                     let _timer = OTHER_TIMERS_SECONDS.timer_with(&["replay_txn_chunk_kv_only"]);
                     tokio::task::spawn_blocking(move || {
-                        // we directly save transaction and kvs to DB without involving chunk executor
-                        handler.save_transactions_and_replay_kv(
+                        save_kv_split_at_epoch_ends(
+                            &handler,
+                            &epoch_end_versions,
                             base_version,
                             &txns,
                             &persisted_aux_info,

--- a/storage/backup/backup-cli/src/backup_types/transaction/tests.rs
+++ b/storage/backup/backup-cli/src/backup_types/transaction/tests.rs
@@ -2,25 +2,36 @@
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
-    backup_types::transaction::{
-        backup::{TransactionBackupController, TransactionBackupOpt},
-        restore::TransactionRestoreBatchController,
+    backup_types::{
+        epoch_ending::restore::EpochHistory,
+        state_snapshot::{
+            backup::{StateSnapshotBackupController, StateSnapshotBackupOpt},
+            restore::{StateSnapshotRestoreController, StateSnapshotRestoreOpt},
+        },
+        transaction::{
+            backup::{TransactionBackupController, TransactionBackupOpt},
+            restore::TransactionRestoreBatchController,
+        },
     },
     storage::{local_fs::LocalFs, BackupStorage},
     utils::{
         backup_service_client::BackupServiceClient,
-        test_utils::{start_local_backup_service, tmp_db_with_random_content},
-        ConcurrentDownloadsOpt, GlobalBackupOpt, GlobalRestoreOpt, ReplayConcurrencyLevelOpt,
-        RocksdbOpt, TrustedWaypointOpt,
+        test_utils::{start_local_backup_service, tmp_db_empty, tmp_db_with_random_content},
+        ConcurrentDownloadsOpt, GlobalBackupOpt, GlobalRestoreOpt, GlobalRestoreOptions,
+        ReplayConcurrencyLevelOpt, RocksdbOpt, TrustedWaypointOpt,
     },
 };
-use aptos_db::AptosDB;
+use aptos_db::{
+    db::test_helper::arb_blocks_to_commit_with_block_nums, state_restore::StateSnapshotRestoreMode,
+    AptosDB,
+};
 use aptos_executor_types::VerifyExecutionMode;
+use aptos_proptest_helpers::ValueGenerator;
 use aptos_storage_interface::DbReader;
 use aptos_temppath::TempPath;
 use aptos_types::transaction::Version;
 use itertools::zip_eq;
-use std::{convert::TryInto, mem::size_of, sync::Arc};
+use std::{collections::HashMap, convert::TryInto, mem::size_of, sync::Arc};
 use tokio::time::Duration;
 
 #[test]
@@ -175,6 +186,169 @@ fn end_to_end() {
             .take(target_version as usize)
             .collect::<Vec<_>>()
     );
+
+    rt.shutdown_timeout(Duration::from_secs(1));
+}
+
+// Exercise the KV-only replay path across multiple epoch boundaries and
+// assert that VersionData is written at every epoch-ending version inside the
+// replay range. Without `save_kv_split_at_epoch_ends`, batches straddling an
+// epoch end would drop the VersionData row at that version.
+#[test]
+fn kv_only_replay_writes_version_data_at_epoch_ends() {
+    // Build a source DB with enough blocks that at proptest's ~25% per-block
+    // epoch-ending rate we always get >= 2 epoch endings. `deterministic()`
+    // keeps both the data and the chunk/epoch alignment stable across runs.
+    let (_src_db_dir, src_db) = tmp_db_empty();
+    let blocks =
+        ValueGenerator::deterministic().generate(arb_blocks_to_commit_with_block_nums(40, 40));
+    let mut cur_ver: Version = 0;
+    for (txns, li) in &blocks {
+        src_db
+            .save_transactions_for_test(txns, cur_ver, Some(li), true /* sync_commit */)
+            .unwrap();
+        cur_ver += txns.len() as u64;
+    }
+    let target_version = cur_ver - 1;
+
+    let epoch_endings: Vec<(u64, Version)> = blocks
+        .iter()
+        .filter_map(|(_, li)| {
+            let li = li.ledger_info();
+            li.ends_epoch().then(|| (li.epoch(), li.version()))
+        })
+        .collect();
+    assert!(
+        epoch_endings.len() >= 2,
+        "test data needs >= 2 epoch endings, got {}",
+        epoch_endings.len(),
+    );
+    let (snapshot_epoch, snapshot_version) = epoch_endings[0];
+
+    let tgt_db_dir = TempPath::new();
+    tgt_db_dir.create_as_dir().unwrap();
+    let backup_dir = TempPath::new();
+    backup_dir.create_as_dir().unwrap();
+    let store: Arc<dyn BackupStorage> = Arc::new(LocalFs::new(backup_dir.path().to_path_buf()));
+
+    let (rt, port) = start_local_backup_service(Arc::clone(&src_db));
+    let client = Arc::new(BackupServiceClient::new(format!(
+        "http://localhost:{}",
+        port
+    )));
+
+    let global_backup_opt = GlobalBackupOpt {
+        max_chunk_size: 2048,
+        concurrent_data_requests: 2,
+    };
+
+    // Snapshot at the first epoch ending; restoring it provides the baseline
+    // VersionData that the KV-only path needs at `first_version - 1`.
+    let state_snapshot_manifest = rt
+        .block_on(
+            StateSnapshotBackupController::new(
+                StateSnapshotBackupOpt {
+                    epoch: snapshot_epoch,
+                },
+                global_backup_opt.clone(),
+                Arc::clone(&client),
+                Arc::clone(&store),
+            )
+            .run(),
+        )
+        .unwrap();
+
+    let txn_manifest = rt
+        .block_on(
+            TransactionBackupController::new(
+                TransactionBackupOpt {
+                    start_version: 0,
+                    num_transactions: cur_ver as usize,
+                },
+                global_backup_opt,
+                Arc::clone(&client),
+                Arc::clone(&store),
+            )
+            .run(),
+        )
+        .unwrap();
+
+    let global_restore_opt: GlobalRestoreOptions = GlobalRestoreOpt {
+        dry_run: false,
+        db_dir: Some(tgt_db_dir.path().to_path_buf()),
+        target_version: Some(target_version),
+        trusted_waypoints: TrustedWaypointOpt::default(),
+        rocksdb_opt: RocksdbOpt::default(),
+        concurrent_downloads: ConcurrentDownloadsOpt::default(),
+        replay_concurrency_level: ReplayConcurrencyLevelOpt::default(),
+        enable_state_indices: false,
+    }
+    .try_into()
+    .unwrap();
+
+    rt.block_on(
+        StateSnapshotRestoreController::new(
+            StateSnapshotRestoreOpt {
+                manifest_handle: state_snapshot_manifest,
+                version: snapshot_version,
+                validate_modules: false,
+                restore_mode: StateSnapshotRestoreMode::Default,
+            },
+            global_restore_opt.clone(),
+            Arc::clone(&store),
+            None, /* epoch_history */
+        )
+        .run(),
+    )
+    .unwrap();
+
+    // Build EpochHistory inline from `blocks` instead of going through
+    // EpochEndingRestoreController; this is what feeds the new splitting
+    // logic inside `save_kv_split_at_epoch_ends`.
+    let epoch_history = Arc::new(EpochHistory {
+        epoch_endings: blocks
+            .iter()
+            .filter_map(|(_, li)| {
+                let li = li.ledger_info();
+                li.ends_epoch().then(|| li.clone())
+            })
+            .collect(),
+        trusted_waypoints: Arc::new(HashMap::new()),
+    });
+
+    rt.block_on(
+        TransactionRestoreBatchController::new(
+            global_restore_opt,
+            Arc::clone(&store),
+            vec![txn_manifest],
+            Some(0), // skip frozen-subtree confirmation (snapshot phase already done)
+            Some((snapshot_version + 1, true)), // KV-only replay from snapshot_version + 1
+            Some(Arc::clone(&epoch_history)),
+            VerifyExecutionMode::verify_all(),
+            None,
+        )
+        .run(),
+    )
+    .unwrap();
+
+    // AptosDB opens with `skip_usage = true`, so `get_state_storage_usage`
+    // returns `Untracked` rather than `Err` when the VersionData row is
+    // missing — `is_untracked()` is the actual "missing" signal.
+    let tgt_db = AptosDB::new_readonly_for_test(&tgt_db_dir);
+    let assert_tracked = |v: Version| {
+        let usage = tgt_db.get_state_storage_usage(Some(v)).unwrap();
+        assert!(!usage.is_untracked(), "VersionData missing at version {v}");
+    };
+
+    assert_tracked(snapshot_version);
+    let mut covered = 0;
+    for &(_, v) in &epoch_endings {
+        if v > snapshot_version && v <= target_version {
+            assert_tracked(v);
+            covered += 1;
+        }
+    }
+    assert!(covered > 0, "no epoch endings fall inside the replay range");
 
     rt.shutdown_timeout(Duration::from_secs(1));
 }


### PR DESCRIPTION

Phase 1 of `aptos-db restore bootstrap-db` applies recorded write sets
in batches, bypassing the chunk executor. Each batch writes
`VersionData` only at its last version, so a batch straddling an epoch
end silently dropped the `VersionData` row at that version — breaking
replay-verify on archive.

Split each batch at every epoch-ending version before applying.
Boundaries come from the already-loaded `EpochHistory` (sorted
versions, binary-searched per batch); the lower-level save path is
unchanged.

When `--skip-epoch-endings` is set (debug only) the boundary list is
empty and batches are not split, preserving the previous behavior on
that path.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
