### PR TITLE
[prover] Align `result_of` and `ensures_of` for `&mut` parameters

### DIFF
--- a/third_party/move/documentation/book/src/spec-compositional.md
+++ b/third_party/move/documentation/book/src/spec-compositional.md
@@ -151,6 +151,8 @@ spec test_known {
 
 The existence of `result_of<f>(args)` implies that `f` is deterministic — it denotes the unique value `y` satisfying `ensures_of<f>(args, y)`. This is why `result_of` also establishes functional behavior: if `ensures_of<f>(x, y1)` and `ensures_of<f>(x, y2)` both hold, then `y1 == y2 == result_of<f>(x)`.
 
+`result_of<f>(args)` has the return type of `f`. For void callees, `result_of` is invalid; use `ensures_of` instead. For closures with `&mut` parameters, see [Mutable Reference Parameters](#mutable-reference-parameters).
+
 ### Inline Closure Specifications
 
 When a closure is passed to an opaque higher-order function, the prover needs to know the closure's specification to reason about it. Closures can carry inline specifications using the `spec { ... }` syntax:
@@ -200,37 +202,36 @@ This approach enables modular verification: the implementation of `apply_opaque`
 
 ### Mutable Reference Parameters
 
-Behavioral predicates extend to closures with mutable reference parameters. When a function takes `&mut T`, it effectively has two outputs: the explicit return value and the modified reference. The predicates account for both:
+Behavioral predicates extend to closures with mutable reference parameters. A `&mut T` argument appears **once** in a behavioral-predicate call — the prover supplies both the pre-state and post-state of the argument to the underlying predicate automatically:
+
+```move
+fun apply_mut(f: |&mut u64| u64, x: &mut u64): u64 { f(x) }
+spec apply_mut {
+    ensures result == result_of<f>(x);
+}
+```
+
+`result_of<f>(x_mut)` has the same type as the procedure's `result`, so `result == result_of<f>(x_mut)` type-checks directly. The `&mut` post-state of `x` is constrained deterministically: when `f` is functional in its inputs, `x`'s post-state is uniquely determined by its pre-state.
+
+`ensures_of<f>(x_mut, r)` is the relational form. It is equivalent to `r == result_of<f>(x_mut)` for non-void deterministic callees, and is the only choice for void callees:
 
 ```move
 fun apply_void_mut(f: |&mut u64|, x: &mut u64) { f(x) }
 spec apply_void_mut {
-    // For void return with &mut param, result_of returns the modified value
-    ensures x == result_of<f>(old(x));
-}
-
-fun apply_mut(f: |&mut u64| u64, x: &mut u64): u64 { f(x) }
-spec apply_mut {
-    // For non-void return with &mut, ensures_of takes (input, result, modified_param)
-    ensures ensures_of<f>(old(x), result, x);
+    // Void `f` has no return — `result_of` is rejected. `ensures_of`
+    // relates pre- and post-state of `x`.
+    ensures ensures_of<f>(x);
 }
 ```
 
-When a closure both returns a value and modifies a `&mut` parameter, `result_of` returns a tuple `(explicit_result, modified_value)`:
+For multi-return closures with `&mut` parameters, `result_of<f>` returns the declared return tuple. The `&mut` post-state is still pinned automatically:
 
 ```move
-fun apply_mut_result(f: |&mut u64| u64, x: &mut u64): u64 { f(x) }
-spec apply_mut_result {
-    ensures (result, x) == result_of<f>(old(x));
+fun apply_two_results(f: |&mut u64| (u64, u64), x: &mut u64): (u64, u64) {
+    f(x)
 }
-```
-
-Tuple components can be extracted with let expressions:
-
-```move
-spec apply_mut_extract {
-    ensures result == {let (r, _p) = result_of<f>(old(x)); r};
-    ensures x == {let (_r, p) = result_of<f>(old(x)); p};
+spec apply_two_results {
+    ensures (result_1, result_2) == result_of<f>(x);
 }
 ```
 

--- a/third_party/move/documentation/book/src/spec-lang.md
+++ b/third_party/move/documentation/book/src/spec-lang.md
@@ -209,36 +209,36 @@ they will be of `bv` types in all instances of the function or the struct when t
 ## Built-in functions
 
 MSL supports a number of built-in constants and functions. Most of them are not available in the Move
-language:
+language. The two-state mutation predicates (`publish`, `remove`, `update`) are only meaningful in
+contexts that compare pre- and post-state, such as `ensures` clauses.
 
-- `MAX_U8: num`, `MAX_U64: num`, `MAX_U128: num` return the maximum value of the corresponding
-  type.
-- `exists<T>(address): bool` returns true if the resource `T` exists at the address.
-- `global<T>(address): T` returns the resource value at the address.
-- `len<T>(vector<T>): num` returns the length of the vector.
-- `update<T>(vector<T>, num, T): vector<T>` returns a new vector with the element replaced at the
-  given index.
-- `vec<T>(): vector<T>` returns an empty vector.
-- `vec<T>(x): vector<T>` returns a singleton vector.
-- `concat<T>(vector<T>, vector<T>): vector<T>` returns the concatenation of the parameters.
-- `contains<T>(vector<T>, T): bool` returns true if the element is in the vector.
-- `index_of<T>(vector<T>, T): num` returns the index of the element in the vector, or the length of
-  the vector if it does not contain it.
-- `range<T>(vector<T>): range` returns the index range of the vector.
-- `in_range<T>(vector<T>, num): bool` returns true if the number is in the index range of the
-  vector.
-- `in_range<T>(range, num): bool` returns true if the number is in the range.
-- `update_field(S, F, T): S` updates a field in a struct, preserving the values of other fields,
-  where `S` is some struct, `F` the name of a field in `S`, and `T` a value for this field.
-- `old(T): T` delivers the value of the passed argument at point of entry into a Move function. This
-  is allowed in
-  `ensures` post-conditions,
-  inline spec blocks (with additional restrictions), and
-  certain forms of invariants, as discussed later.
-- `TRACE(T): T` is semantically the identity function and causes visualization of the argument's
-  value in error messages created by the prover.
-- `int2bv(v)` explicitly converts an integer `v` into its `bv` representation.
-- `bv2int(b)` explicitly converts a `bv` integer `b` into the `num` representation. However, its use is not encouraged due to efficiency issues.
+<div class="signature-table">
+
+| Signature | Description |
+| --- | --- |
+| `bv2int(b)` | Explicitly converts a `bv` integer `b` into the `num` representation. Use is discouraged due to efficiency. |
+| `concat<T>(vector<T>, vector<T>): vector<T>` | Concatenation of the two vectors. |
+| `contains<T>(vector<T>, T): bool` | True if the element is in the vector. |
+| `exists<T>(address): bool` | True if the resource `T` exists at the address. |
+| `global<T>(address): T` | The resource value at the address. |
+| `index_of<T>(vector<T>, T): num` | Index of the element in the vector, or the length of the vector if absent. |
+| `in_range<T>(range, num): bool` | True if the number is in the range. |
+| `in_range<T>(vector<T>, num): bool` | True if the number is a valid index of the vector. |
+| `int2bv(v)` | Explicitly converts an integer `v` into its `bv` representation. |
+| `len<T>(vector<T>): num` | Length of the vector. |
+| `MAX_U8`, `MAX_U16`, `MAX_U32`, `MAX_U64`, `MAX_U128`, `MAX_U256: num` | Maximum value of the corresponding integer type. |
+| `old(T): T` | Value of the argument at the point of entry into the Move function. Allowed in `ensures` post-conditions, inline spec blocks (with restrictions), and certain forms of invariants. |
+| `publish<T: key>(address, T): bool` | Two-state: true iff resource `T` did not exist at the address in the pre-state and exists with the given value in the post-state. |
+| `range<T>(vector<T>): range` | Index range of the vector. |
+| `remove<T: key>(address): bool` | Two-state: true iff resource `T` existed at the address in the pre-state and does not exist in the post-state. |
+| `TRACE(T): T` | Identity function that causes visualization of the argument's value in prover error messages. |
+| `update<T: key>(address, T): bool` | Two-state: true iff resource `T` existed at the address in the pre-state and has the given value in the post-state. |
+| `update<T>(vector<T>, num, T): vector<T>` | New vector with the element replaced at the given index. |
+| `update_field(S, F, T): S` | Updates a field in a struct, preserving the values of other fields. `S` is some struct, `F` the name of a field in `S`, and `T` a value for the field. |
+| `vec<T>(): vector<T>` | Empty vector. |
+| `vec<T>(x): vector<T>` | Singleton vector containing `x`. |
+
+</div>
 
 Built-in functions live in an unnamed outer scope of a module. If the module defines a function `len`,
 then this definition will shadow that of the according built-in function. To access the built-in

--- a/third_party/move/documentation/book/theme/content-width.css
+++ b/third_party/move/documentation/book/theme/content-width.css
@@ -10,3 +10,14 @@
 .content main {
     max-width: 100ch;
 }
+
+/* Tables tagged with `signature-table` give more room to the first
+ * column, which typically holds long function signatures. */
+.signature-table table {
+    table-layout: fixed;
+    width: 100%;
+}
+.signature-table th:first-child,
+.signature-table td:first-child {
+    width: 40%;
+}

--- a/third_party/move/move-compiler-v2/src/env_pipeline/spec_rewriter.rs
+++ b/third_party/move/move-compiler-v2/src/env_pipeline/spec_rewriter.rs
@@ -1077,10 +1077,9 @@ struct SpecConverter<'a> {
     contains_imperative_expression: bool,
     /// Set to true when rewriting spec during inlining phase
     for_inline: bool,
-    /// Depth tracker for behavioral-predicate argument context. When > 0,
-    /// the rewriter is descending into args of an `ensures_of` / `result_of`
-    /// (etc.) call; in this context, `Borrow(Mut, ...)` selector borrows
-    /// must be preserved so the model spec rewriter can normalize them.
+    /// > 0 while descending into args of a behavioral-predicate call;
+    /// preserves `Borrow(Mut, ...)` selectors so the model rewriter can
+    /// detect them and route pre-state through `save_param`.
     bp_arg_depth: usize,
 }
 
@@ -1187,10 +1186,8 @@ impl ExpRewriterFunctions for SpecConverter<'_> {
                 _ => exp,
             };
 
-            // Track behavioral-predicate argument depth across descent so
-            // `Borrow(Mut, ...)` selectors inside `ensures_of(&mut x.foo, ...)`
-            // are preserved (their stripping is done later by the model spec
-            // rewriter only after augmenting the call to its canonical form).
+            // Track BP-arg depth so `Borrow(Mut, ...)` selectors survive
+            // for the model rewriter.
             let is_behavior = matches!(exp.as_ref(), Call(_, Behavior(_, _), _));
             if is_behavior {
                 self.bp_arg_depth += 1;
@@ -1216,10 +1213,8 @@ impl ExpRewriterFunctions for SpecConverter<'_> {
                     Call(*id, Global(None), args.clone()).into_exp()
                 },
                 Call(_, Borrow(ReferenceKind::Mutable), _) if self.bp_arg_depth > 0 => {
-                    // Inside a behavioral-predicate argument: preserve the
-                    // `Borrow(Mut, ...)` so the model spec rewriter can
-                    // augment the call (extracting pre-state via
-                    // `old(...)` and appending post-state clones).
+                    // Preserve in BP args so the model rewriter sees the
+                    // stateful mut-ref shape.
                     exp.clone()
                 },
                 Call(_, Borrow(_), args) | Call(_, Deref, args) => {

--- a/third_party/move/move-model/src/ast.rs
+++ b/third_party/move/move-model/src/ast.rs
@@ -319,16 +319,22 @@ pub enum BehaviorKind {
     AbortsOf,
     /// `ensures_of<f>(args)` - the postcondition of function `f`
     EnsuresOf,
-    /// `result_of<f>(args)` - deterministic result selector based on `ensures_of`
-    /// Semantics: `result_of<f>(x) == choose y where ensures_of<f>(x, y)`
+    /// `result_of<f>(args)` — `choose r where ensures_of<f>(args, r, ...)`.
     ResultOf,
+    /// `write_of<f, j>(args)` — WP-internal selector for the post-state of
+    /// the j-th `&mut` parameter (counted among `&mut` parameters). Not
+    /// surface syntax; emitted by spec inference and translated by the
+    /// Boogie backend to a Skolem axiomatized against `ensures_of`.
+    WriteOf(usize),
 }
 
 impl BehaviorKind {
-    /// Returns true if this is a two-state predicate (ensures_of, result_of)
-    /// that requires both pre and post memory states.
+    /// True for predicates whose semantics span pre- and post-memory.
     pub fn is_two_state(&self) -> bool {
-        matches!(self, BehaviorKind::EnsuresOf | BehaviorKind::ResultOf)
+        matches!(
+            self,
+            BehaviorKind::EnsuresOf | BehaviorKind::ResultOf | BehaviorKind::WriteOf(_)
+        )
     }
 }
 
@@ -340,6 +346,7 @@ impl fmt::Display for BehaviorKind {
             AbortsOf => write!(f, "aborts_of"),
             EnsuresOf => write!(f, "ensures_of"),
             ResultOf => write!(f, "result_of"),
+            WriteOf(j) => write!(f, "write_of_{}", j),
         }
     }
 }

--- a/third_party/move/move-model/src/builder/exp_builder.rs
+++ b/third_party/move/move-model/src/builder/exp_builder.rs
@@ -6086,7 +6086,8 @@ impl ExpTranslator<'_, '_, '_> {
         expected_type: &Type,
         context: &ErrorMessageContext,
     ) -> ExpData {
-        // Convert parser BehaviorKind to model BehaviorKind
+        // Model has a `WriteOf` variant too, but it's internal to spec
+        // inference and never produced by the parser.
         let model_kind = match kind {
             PA::BehaviorKind::RequiresOf => BehaviorKind::RequiresOf,
             PA::BehaviorKind::AbortsOf => BehaviorKind::AbortsOf,
@@ -6118,11 +6119,6 @@ impl ExpTranslator<'_, '_, '_> {
             return self.new_error_exp();
         };
 
-        // Translate arguments and check types. Both the user-facing minimum
-        // arity (inputs + explicit results for `EnsuresOf`) and the canonical
-        // augmented arity (with post-state slots for `&mut` params) are
-        // accepted; `augment_behavior_call` in the spec rewriter normalizes
-        // the minimum form to the canonical form automatically.
         let translated_args =
             self.translate_and_check_behavior_args(loc, args, &arg_ty, &result_ty, &model_kind);
 
@@ -6163,9 +6159,6 @@ impl ExpTranslator<'_, '_, '_> {
             return self.new_error_exp();
         }
 
-        // Build args with function expression as first argument. The
-        // user-facing 2-arg form is canonicalized to the internal 3-arg form
-        // by `SpecTranslator::augment_behavior_call` during spec rewriting.
         let mut all_args = vec![fun_exp];
         all_args.extend(translated_args);
 
@@ -6364,16 +6357,9 @@ impl ExpTranslator<'_, '_, '_> {
         result
     }
 
-    /// Computes the expected argument types for a behavior predicate based on kind.
-    ///
-    /// Input parameter types are stripped of all references — spec language
-    /// treats references transparently. For `EnsuresOf`, explicit result types
-    /// are appended after inputs (the user-facing "minimum" form). When the
-    /// caller writes the canonical form (with explicit post-state slots for
-    /// each `&mut` parameter), `compute_behavior_arg_types_canonical` returns
-    /// the extended type list. `translate_and_check_behavior_args` accepts
-    /// either arity.
-    fn compute_behavior_arg_types_minimum(
+    /// Minimum-form expected argument types: input types (references
+    /// stripped), and for `EnsuresOf` a slot per return value.
+    fn compute_behavior_arg_types(
         &self,
         arg_ty: &Type,
         result_ty: &Type,
@@ -6391,17 +6377,18 @@ impl ExpTranslator<'_, '_, '_> {
         types
     }
 
-    /// The canonical (augmented) expected argument types for a behavior
-    /// predicate. For `EnsuresOf`, the inputs and explicit results are
-    /// followed by the post-state value type for each `&mut T` parameter.
-    /// For other kinds, this matches the minimum form.
+    /// Canonical form for `EnsuresOf`: minimum form plus an explicit
+    /// post-state slot for each `&mut` parameter. `ResultOf`'s `&mut`
+    /// post-state slots are appended later by `wrap_mut_ref_bp_inputs` in
+    /// the model-rewrite pass; at parse time `result_of` accepts only the
+    /// minimum form so the user-facing signature matches `f`'s arity.
     fn compute_behavior_arg_types_canonical(
         &self,
         arg_ty: &Type,
         result_ty: &Type,
         kind: &BehaviorKind,
     ) -> Vec<Type> {
-        let mut types = self.compute_behavior_arg_types_minimum(arg_ty, result_ty, kind);
+        let mut types = self.compute_behavior_arg_types(arg_ty, result_ty, kind);
         if matches!(kind, BehaviorKind::EnsuresOf) {
             for ty in arg_ty.clone().flatten() {
                 if ty.is_mutable_reference() {
@@ -6412,10 +6399,9 @@ impl ExpTranslator<'_, '_, '_> {
         types
     }
 
-    /// Computes the result type for a behavior predicate based on the kind.
-    /// - `ResultOf` returns the function's result type (including modified mut ref values)
-    /// - All other behavior predicates return bool
-    /// Returns `None` if the result type cannot be computed (e.g., result_of on void function).
+    /// Result type for a behavior predicate. `ResultOf` returns the
+    /// function's return type and is rejected for void callees; others
+    /// return `bool`. Returns `None` on rejection.
     fn compute_behavior_result_type(
         &mut self,
         loc: &Loc,
@@ -6426,44 +6412,24 @@ impl ExpTranslator<'_, '_, '_> {
             return Some(BOOL_TYPE);
         }
 
-        // For ResultOf, compute result type from function type
-        let Type::Fun(params, result, _abilities) = fun_type else {
-            // Should not happen if resolve_behavior_target succeeded
+        let Type::Fun(_, result, _abilities) = fun_type else {
             return Some(Type::Error);
         };
 
-        // Compute result types: explicit results + modified mut ref values
-        let result_types: Vec<_> = result
-            .clone()
-            .flatten()
-            .into_iter()
-            .chain(
-                params
-                    .clone()
-                    .flatten()
-                    .into_iter()
-                    .filter(|ty| ty.is_mutable_reference())
-                    .map(|ty| ty.skip_reference().clone()),
-            )
-            .collect();
-
-        // Error only if there are NO outputs at all
-        if result_types.is_empty() {
+        if result.clone().flatten().is_empty() {
             self.error(
                 loc,
-                "`result_of` cannot be used with functions that have no outputs",
+                "`result_of` cannot be used with functions that have no return value; \
+                 use `ensures_of` to constrain the post-state of `&mut` arguments instead",
             );
             return None;
         }
 
-        Some(Type::tuple(result_types))
+        Some((**result).clone())
     }
 
-    /// Translates and type-checks behavior predicate arguments. Accepts
-    /// either the user-facing minimum arity or the canonical augmented arity
-    /// (which includes post-state slots for `&mut T` parameters in
-    /// `EnsuresOf`). The model spec rewriter normalizes the minimum form to
-    /// the canonical form via `augment_behavior_call`.
+    /// Translates and type-checks behavior predicate arguments against the
+    /// expected types computed by `compute_behavior_arg_types`.
     fn translate_and_check_behavior_args(
         &mut self,
         loc: &Loc,
@@ -6472,7 +6438,7 @@ impl ExpTranslator<'_, '_, '_> {
         result_ty: &Type,
         kind: &BehaviorKind,
     ) -> Vec<Exp> {
-        let minimum = self.compute_behavior_arg_types_minimum(arg_ty, result_ty, kind);
+        let minimum = self.compute_behavior_arg_types(arg_ty, result_ty, kind);
         let canonical = self.compute_behavior_arg_types_canonical(arg_ty, result_ty, kind);
         let expected_types: &[Type] =
             if args.len() == canonical.len() && canonical.len() != minimum.len() {
@@ -6482,8 +6448,6 @@ impl ExpTranslator<'_, '_, '_> {
             };
 
         if args.len() != expected_types.len() {
-            // Report against the minimum-arity (the user-facing default);
-            // also mention the canonical arity if it differs.
             let msg = if minimum.len() == canonical.len() {
                 format!(
                     "expected {} argument(s) for {} but {} were provided",
@@ -6493,7 +6457,7 @@ impl ExpTranslator<'_, '_, '_> {
                 )
             } else {
                 format!(
-                    "expected {} argument(s) for {} (or {} for the canonical form including post-state slots), but {} were provided",
+                    "expected {} argument(s) for {} (or {} for the canonical form including post-state slots) but {} were provided",
                     minimum.len(),
                     kind,
                     canonical.len(),

--- a/third_party/move/move-model/src/exp_generator.rs
+++ b/third_party/move/move-model/src/exp_generator.rs
@@ -1133,6 +1133,28 @@ pub trait ExpGenerator<'env> {
             all_args,
         )
     }
+
+    /// Build `write_of<f, j>(args)` with pre/post state labels.
+    /// `mut_ref_idx` indexes the targeted `&mut` parameter among the
+    /// callee's `&mut` parameters only.
+    fn mk_write_of_with_state(
+        &self,
+        fun_exp: Exp,
+        args: Vec<Exp>,
+        mut_ref_value_type: &Type,
+        mut_ref_idx: usize,
+        pre: Option<MemoryLabel>,
+        post: Option<MemoryLabel>,
+    ) -> Exp {
+        let mut all_args = vec![fun_exp];
+        all_args.extend(args);
+        let range = MemoryRange { pre, post };
+        self.mk_call(
+            mut_ref_value_type,
+            Operation::Behavior(BehaviorKind::WriteOf(mut_ref_idx), range),
+            all_args,
+        )
+    }
 }
 
 // =================================================================================================

--- a/third_party/move/move-model/src/exp_rewriter.rs
+++ b/third_party/move/move-model/src/exp_rewriter.rs
@@ -994,3 +994,19 @@ impl ExpRewriterFunctions for MemoryLabelFreshener {
         new_oper.map(|op| ExpData::Call(id, op, args.to_vec()).into_exp())
     }
 }
+
+/// Strip every `Operation::Old` wrapper at any nesting level: `old(p).x`
+/// becomes `p.x`, `old(old(x))` becomes `x`, etc.
+pub fn strip_all_olds(exp: &Exp) -> Exp {
+    struct OldStripper;
+    impl ExpRewriterFunctions for OldStripper {
+        fn rewrite_call(&mut self, _id: NodeId, oper: &Operation, args: &[Exp]) -> Option<Exp> {
+            if matches!(oper, Operation::Old) && args.len() == 1 {
+                Some(self.rewrite_exp(args[0].clone()))
+            } else {
+                None
+            }
+        }
+    }
+    OldStripper.rewrite_exp(exp.clone())
+}

--- a/third_party/move/move-model/src/sourcifier.rs
+++ b/third_party/move/move-model/src/sourcifier.rs
@@ -4,8 +4,8 @@
 use crate::{
     ast::{
         AbortKind, AccessSpecifierKind, AddressSpecifier, Condition, ConditionKind, Exp, ExpData,
-        FrameSpec, LambdaCaptureKind, Operation, Pattern, PropertyBag, PropertyValue, QuantKind,
-        ResourceSpecifier, Spec, SpecVarDecl, TempIndex, Value,
+        FrameSpec, LambdaCaptureKind, MemoryRange, Operation, Pattern, PropertyBag, PropertyValue,
+        QuantKind, ResourceSpecifier, Spec, SpecVarDecl, TempIndex, Value,
     },
     code_writer::CodeWriter,
     emit, emitln,
@@ -132,6 +132,138 @@ fn prints_without_label_prefix(exp: &Exp) -> bool {
     })
 }
 
+/// True if `e` itself carries a state label (labeled Behavior/SpecFunction/
+/// SpecPublish/SpecRemove/SpecUpdate call or labeled Global/Exists).
+fn has_label_at_top(e: &ExpData) -> bool {
+    match e {
+        ExpData::Call(_, Operation::Global(Some(_)), _)
+        | ExpData::Call(_, Operation::Exists(Some(_)), _) => true,
+        ExpData::Call(
+            _,
+            Operation::Behavior(_, range)
+            | Operation::SpecFunction(_, _, range)
+            | Operation::SpecPublish(range)
+            | Operation::SpecRemove(range)
+            | Operation::SpecUpdate(range),
+            _,
+        ) => range.pre.is_some() || range.post.is_some(),
+        _ => false,
+    }
+}
+
+/// True if any direct child of `e` is labeled at top; guards the clause-
+/// level CSE — a directly labeled child is already handled by the
+/// label-prefix hoist or `hoist_nested_labels`.
+fn has_labeled_direct_child(e: &ExpData) -> bool {
+    let mut found = false;
+    let mut check = |child: &ExpData| {
+        if has_label_at_top(child) {
+            found = true;
+        }
+    };
+    match e {
+        ExpData::Call(_, _, args) => {
+            for a in args {
+                check(a.as_ref());
+            }
+        },
+        ExpData::Block(_, _, binding, body) => {
+            if let Some(b) = binding {
+                check(b.as_ref());
+            }
+            check(body.as_ref());
+        },
+        ExpData::IfElse(_, cond, on_true, on_false) => {
+            check(cond.as_ref());
+            check(on_true.as_ref());
+            check(on_false.as_ref());
+        },
+        ExpData::Sequence(_, exps) => {
+            for x in exps {
+                check(x.as_ref());
+            }
+        },
+        ExpData::Quant(_, _, _, _, _, body) => check(body.as_ref()),
+        _ => {},
+    }
+    found
+}
+
+/// Collect unique labeled subexpressions (dedup by structural equality).
+/// Stops at each labeled top — nested labels within get hoisted when the
+/// let-binding RHS is later printed. Skips quantifier bodies so bindings
+/// referencing the bound variable don't escape scope.
+fn collect_labeled_subexprs(e: &ExpData, out: &mut Vec<Exp>) {
+    if has_label_at_top(e) {
+        let e_exp = ExpData::into_exp(e.clone());
+        if !out.iter().any(|x| x.as_ref().structural_eq(&e_exp)) {
+            out.push(e_exp);
+        }
+        return;
+    }
+    match e {
+        ExpData::Call(_, _, args) => {
+            for a in args {
+                collect_labeled_subexprs(a.as_ref(), out);
+            }
+        },
+        ExpData::Block(_, _, binding, body) => {
+            if let Some(b) = binding {
+                collect_labeled_subexprs(b.as_ref(), out);
+            }
+            collect_labeled_subexprs(body.as_ref(), out);
+        },
+        ExpData::IfElse(_, cond, on_true, on_false) => {
+            collect_labeled_subexprs(cond.as_ref(), out);
+            collect_labeled_subexprs(on_true.as_ref(), out);
+            collect_labeled_subexprs(on_false.as_ref(), out);
+        },
+        ExpData::Sequence(_, exps) => {
+            for x in exps {
+                collect_labeled_subexprs(x.as_ref(), out);
+            }
+        },
+        // Quantifier bodies may reference the bound variable; hoisting
+        // out would leak scope.
+        ExpData::Quant(..) => {},
+        _ => {},
+    }
+}
+
+/// AST node count. Used to sort labeled subexprs smallest-first so outer
+/// ones reference inner let-binding names.
+fn node_count(exp: &ExpData) -> usize {
+    let mut count = 0;
+    exp.visit_pre_order(&mut |_| {
+        count += 1;
+        true
+    });
+    count
+}
+
+/// Replace every subexpression of `exp` structurally equal to `target`
+/// with `replacement`.
+fn substitute_structural(exp: &Exp, target: &Exp, replacement: &Exp) -> Exp {
+    use crate::exp_rewriter::ExpRewriterFunctions;
+    struct Sub<'a> {
+        target: &'a Exp,
+        replacement: &'a Exp,
+    }
+    impl ExpRewriterFunctions for Sub<'_> {
+        fn rewrite_exp(&mut self, exp: Exp) -> Exp {
+            if exp.as_ref().structural_eq(self.target) {
+                return self.replacement.clone();
+            }
+            self.rewrite_exp_descent(exp)
+        }
+    }
+    Sub {
+        target,
+        replacement,
+    }
+    .rewrite_exp(exp.clone())
+}
+
 /// Returns the priority and operator string for binary ops that support label hoisting.
 fn hoistable_bin_op_info(op: &Operation) -> Option<(Priority, &'static str)> {
     match op {
@@ -148,8 +280,6 @@ fn hoistable_bin_op_info(op: &Operation) -> Option<(Priority, &'static str)> {
         _ => None,
     }
 }
-
-// has_any_state_label removed — replaced by is_state_neutral (see above)
 
 impl<'a> Sourcifier<'a> {
     /// Creates a new sourcifier.
@@ -2861,42 +2991,21 @@ impl<'a> ExpSourcifier<'a> {
                 emit!(self.wr(), ")")
             }),
             Operation::Behavior(kind, range) => {
-                let kind_str = match kind {
-                    crate::ast::BehaviorKind::AbortsOf => "aborts_of",
-                    crate::ast::BehaviorKind::EnsuresOf => "ensures_of",
-                    crate::ast::BehaviorKind::RequiresOf => "requires_of",
-                    crate::ast::BehaviorKind::ResultOf => "result_of",
-                };
+                // `WriteOf(j)` is WP-internal and is expected to be eliminated
+                // before sourcification; if it leaks here we still render via
+                // its `Display` (`write_of_{j}`) rather than panicking, so the
+                // baseline shows the offending shape for diagnosis.
+                let kind_str = kind.to_string();
                 let has_labels = range.pre.is_some() || range.post.is_some();
 
-                // When the operation has a state label range, hoist any
-                // argument that contains a labeled subexpression into a let
-                // binding so the outer label can't visually appear to scope
-                // over it. `args[0]` is the function target (closure/
-                // MoveFunction), not a value — never hoist it. Mirrors the
-                // SpecPublish/Remove/Update path above, but uses a targeted
-                // neutrality check that doesn't over-hoist `old(...)` or
-                // unlabeled `self.field` reads (which never print with a
-                // `|~` prefix and so can't create nested labels).
+                // If args carry their own labels, hoist them out into
+                // `let` bindings to avoid visually nested labels.
+                // `args[0]` is the function target and never hoisted.
                 let needs_let =
                     has_labels && args.iter().skip(1).any(|a| !prints_without_label_prefix(a));
                 if needs_let {
-                    let mut let_bindings = vec![];
-                    let new_args: Vec<Exp> = args
-                        .iter()
-                        .enumerate()
-                        .map(|(i, arg)| {
-                            if i == 0 || prints_without_label_prefix(arg) {
-                                arg.clone()
-                            } else {
-                                let (pat, var_exp) = self.let_bind_exp(arg, args);
-                                let_bindings.push((pat, arg.clone()));
-                                var_exp
-                            }
-                        })
-                        .collect();
-                    let new_call = ExpData::Call(id, oper.clone(), new_args).into_exp();
-                    let wrapped = self.wrap_in_lets(let_bindings, new_call);
+                    let wrapped =
+                        self.hoist_nested_labels(id, oper, args, /*keep_outer_label=*/ true);
                     self.print_exp(context_prio, true, &wrapped);
                     return;
                 }
@@ -2912,7 +3021,7 @@ impl<'a> ExpSourcifier<'a> {
                 };
                 if has_labels {
                     // aborts_of/requires_of only take a pre-state (single state form),
-                    // ensures_of/result_of can have pre..post ranges.
+                    // ensures_of/result_of/write_of can have pre..post ranges.
                     let is_single_state = matches!(
                         kind,
                         crate::ast::BehaviorKind::AbortsOf | crate::ast::BehaviorKind::RequiresOf
@@ -3043,12 +3152,52 @@ impl<'a> ExpSourcifier<'a> {
     /// Hoisting produces `S |~ global<R>(a) == x`, where the label provides context
     /// for the entire relation — a more natural reading for humans.
     fn print_exp_hoisting_label(&self, exp: &Exp) {
+        let preprocessed = self.hoist_clause_level_labels(exp);
+        let exp = &preprocessed;
         if has_hoistable_label(exp) {
             self.print_hoisted_label_prefix(exp);
             self.print_exp_without_label(Prio::General, exp);
         } else {
             self.print_exp(Prio::General, false, exp);
         }
+    }
+
+    /// Lift labeled subexpressions buried in non-hoistable positions (e.g.
+    /// inside arithmetic) into a clause-level `let` chain. Returns `exp`
+    /// unchanged when the label-prefix hoist or `hoist_nested_labels`
+    /// already handles all labels.
+    fn hoist_clause_level_labels(&self, exp: &Exp) -> Exp {
+        if has_label_at_top(exp.as_ref()) || has_labeled_direct_child(exp.as_ref()) {
+            return exp.clone();
+        }
+
+        let mut labeled: Vec<Exp> = Vec::new();
+        collect_labeled_subexprs(exp.as_ref(), &mut labeled);
+        if labeled.is_empty() {
+            return exp.clone();
+        }
+
+        labeled.sort_by_key(|e| node_count(e.as_ref()));
+
+        // Pass the clause as scope so generated names don't shadow free
+        // vars or temp display names in scope.
+        let scope = std::slice::from_ref(exp);
+        let mut let_bindings: Vec<(Pattern, Exp)> = Vec::new();
+        let mut substitutions: Vec<(Exp, Exp)> = Vec::new();
+        for sub in &labeled {
+            let mut sub_substituted = sub.clone();
+            for (target, repl) in &substitutions {
+                sub_substituted = substitute_structural(&sub_substituted, target, repl);
+            }
+            let (pat, var_exp) = self.let_bind_exp(&sub_substituted, scope);
+            let_bindings.push((pat, sub_substituted));
+            substitutions.push((sub.clone(), var_exp));
+        }
+        let mut new_exp = exp.clone();
+        for (target, repl) in &substitutions {
+            new_exp = substitute_structural(&new_exp, target, repl);
+        }
+        self.wrap_in_lets(let_bindings, new_exp)
     }
 
     /// Print a binary operator, hoisting a state label out if possible.
@@ -3176,13 +3325,19 @@ impl<'a> ExpSourcifier<'a> {
                     self.parent.enclosing_state_label.set(prev);
                 })
             },
-            ExpData::Call(_id, Operation::Behavior(kind, _range), args) => {
-                let kind_str = match kind {
-                    crate::ast::BehaviorKind::AbortsOf => "aborts_of",
-                    crate::ast::BehaviorKind::EnsuresOf => "ensures_of",
-                    crate::ast::BehaviorKind::RequiresOf => "requires_of",
-                    crate::ast::BehaviorKind::ResultOf => "result_of",
-                };
+            ExpData::Call(id, oper @ Operation::Behavior(kind, _range), args) => {
+                // See note above on `WriteOf` rendering.
+                let kind_str = kind.to_string();
+                // Caller already emitted the outer label, but args may
+                // still carry labels: hoist them so labels don't visually
+                // nest.
+                let nested_label = args.iter().skip(1).any(|a| !prints_without_label_prefix(a));
+                if nested_label {
+                    let wrapped =
+                        self.hoist_nested_labels(*id, oper, args, /*keep_outer_label=*/ false);
+                    self.print_exp(prio, false, &wrapped);
+                    return;
+                }
                 self.parenthesize(prio, Prio::Postfix, || {
                     emit!(self.wr(), "{}", kind_str);
                     emit!(self.wr(), "<");
@@ -3472,6 +3627,73 @@ impl<'a> ExpSourcifier<'a> {
                 );
                 ExpData::Block(block_id, pat, Some(binding), acc).into_exp()
             })
+    }
+
+    /// Lift labeled subexpressions in `args[1..]` into a `let` chain wrapping
+    /// the call. Smaller subexprs are bound first so outer ones can reference
+    /// inner names. `keep_outer_label = false` strips the call's range when
+    /// the caller already emitted the prefix (i.e. via
+    /// `print_exp_without_label`).
+    fn hoist_nested_labels(
+        &self,
+        id: NodeId,
+        oper: &Operation,
+        args: &[Exp],
+        keep_outer_label: bool,
+    ) -> Exp {
+        let mut labeled: Vec<Exp> = Vec::new();
+        for arg in args.iter().skip(1) {
+            arg.as_ref().visit_pre_order(&mut |e: &ExpData| {
+                if has_label_at_top(e) {
+                    let e_exp = ExpData::into_exp(e.clone());
+                    if !labeled.iter().any(|x| x.as_ref().structural_eq(&e_exp)) {
+                        labeled.push(e_exp);
+                    }
+                    false
+                } else {
+                    true
+                }
+            });
+        }
+        labeled.sort_by_key(|e| node_count(e.as_ref()));
+
+        let mut let_bindings: Vec<(Pattern, Exp)> = Vec::new();
+        let mut substitutions: Vec<(Exp, Exp)> = Vec::new();
+        for sub in &labeled {
+            let mut sub_substituted = sub.clone();
+            for (target, repl) in &substitutions {
+                sub_substituted = substitute_structural(&sub_substituted, target, repl);
+            }
+            let (pat, var_exp) = self.let_bind_exp(&sub_substituted, args);
+            let_bindings.push((pat, sub_substituted));
+            substitutions.push((sub.clone(), var_exp));
+        }
+
+        let new_args: Vec<Exp> = args
+            .iter()
+            .enumerate()
+            .map(|(i, arg)| {
+                if i == 0 {
+                    arg.clone()
+                } else {
+                    let mut current = arg.clone();
+                    for (target, repl) in &substitutions {
+                        current = substitute_structural(&current, target, repl);
+                    }
+                    current
+                }
+            })
+            .collect();
+
+        let inner_oper = if keep_outer_label {
+            oper.clone()
+        } else if let Operation::Behavior(kind, _) = oper {
+            Operation::Behavior(*kind, MemoryRange::default())
+        } else {
+            oper.clone()
+        };
+        let new_call = ExpData::Call(id, inner_oper, new_args).into_exp();
+        self.wrap_in_lets(let_bindings, new_call)
     }
 
     fn is_unspecified_abort_code(exp: &Exp) -> bool {

--- a/third_party/move/move-model/src/spec_translator.rs
+++ b/third_party/move/move-model/src/spec_translator.rs
@@ -13,7 +13,9 @@ use crate::{
         TraceKind,
     },
     exp_generator::ExpGenerator,
-    exp_rewriter::{ExpRewriter, ExpRewriterFunctions, MemoryLabelFreshener, RewriteTarget},
+    exp_rewriter::{
+        strip_all_olds, ExpRewriter, ExpRewriterFunctions, MemoryLabelFreshener, RewriteTarget,
+    },
     model::{
         FunctionEnv, GlobalEnv, GlobalId, Loc, NodeId, Parameter, QualifiedId, QualifiedInstId,
         SpecVarId, StructId,
@@ -23,7 +25,7 @@ use crate::{
         CONDITION_EXPORT_PROP, CONDITION_INJECTED_PROP,
     },
     symbol::Symbol,
-    ty::{PrimitiveType, ReferenceKind, Type, BOOL_TYPE},
+    ty::{PrimitiveType, Type, BOOL_TYPE},
 };
 use codespan_reporting::diagnostic::Severity;
 use itertools::Itertools;
@@ -1005,50 +1007,12 @@ impl<'a, 'b, T: ExpGenerator<'a>> SpecTranslator<'a, 'b, T> {
     }
 
     /// Bridge the user-facing behavioral-predicate syntax to the canonical
-    /// 3-arg form expected downstream:
-    ///   - Reference-typed input args at `&mut T` parameter positions are
-    ///     wrapped in `old(...)` so the inner `Temporary` triggers
-    ///     `save_param` during the rest of the rewrite. Value-typed args at
-    ///     such positions are left untouched — their value is timeless and
-    ///     no pre-state extraction is needed.
-    ///   - For `EnsuresOf`, a post-state clone is appended for each
-    ///     reference-typed `&mut T` input that we wrapped. The clone is the
-    ///     un-`old`-wrapped form, which the rewriter leaves alone, so the
-    ///     Boogie translator emits `$Dereference($t<idx>)` (live, post-call
-    ///     value) at the wrapper's exit.
-    /// When all `&mut T` slots are filled with value-typed args, no
-    /// augmentation runs — the caller is expected to have already supplied
-    /// the canonical form (typically via the inference engine's
-    /// `result_of`-projection idiom for chained calls).
-    /// Idempotent: re-augmenting is a no-op when every reference-typed
-    /// `&mut T` input is already `old`-wrapped.
-    /// True if `arg` syntactically denotes a stateful mutable reference:
-    /// a reference-typed expression, a `Borrow(Mut, ...)` selector chain,
-    /// a `Temporary` referring to a `&mut`-typed local in the enclosing
-    /// function, or an `Old(...)` wrapping any of the above. Used to decide
-    /// whether a `&mut T` parameter slot of a behavioral predicate needs
-    /// the `old(...)` / post-state-clone augmentation.
-    fn is_stateful_mut_ref(&self, arg: &Exp) -> bool {
-        let env = self.builder.global_env();
-        if env.get_node_type(arg.node_id()).is_reference() {
-            return true;
-        }
-        match arg.as_ref() {
-            ExpData::Call(_, Operation::Borrow(ReferenceKind::Mutable), _) => true,
-            ExpData::Call(_, Operation::Old, inner) if inner.len() == 1 => {
-                self.is_stateful_mut_ref(&inner[0])
-            },
-            ExpData::Temporary(_, idx) => self
-                .fun_env
-                .get_local_type(*idx)
-                .as_ref()
-                .is_some_and(Type::is_reference),
-            _ => false,
-        }
-    }
-
-    fn augment_behavior_call(&self, exp: &Exp) -> Exp {
-        use crate::ast::BehaviorKind;
+    /// form the Boogie backend consumes. Each stateful `&mut T` input gets
+    /// `Old(...)`-wrapped (triggering `save_param` for the captured pre-state
+    /// temp). For `EnsuresOf` and `ResultOf`, a live post-state clone of each
+    /// wrapped `&mut T` arg is appended after the existing user-provided
+    /// trailing args (the result slot, if any). Idempotent.
+    fn wrap_mut_ref_bp_inputs(&self, exp: &Exp) -> Exp {
         let env = self.builder.global_env();
         let ExpData::Call(node_id, Operation::Behavior(kind, range), args) = exp.as_ref() else {
             return exp.clone();
@@ -1067,19 +1031,8 @@ impl<'a, 'b, T: ExpGenerator<'a>> SpecTranslator<'a, 'b, T> {
             return exp.clone();
         }
 
-        // Identify input slots that need wrapping: a `&mut T` parameter
-        // whose corresponding argument expression is a stateful reference
-        // (Temporary of a `&mut` param, a `Borrow(Mut, ...)` selector, or
-        // an `Old(...)` wrapping such an expression). Value-typed arguments
-        // at `&mut T` positions (e.g., a let-bound `update_field(...)`
-        // result) are timeless — their value is already the pre-state and
-        // they need no `old(...)` wrapping.
-        //
-        // The check is both type- and shape-based: type unification may
-        // have widened a stateful arg's type to its value form, so we
-        // also accept syntactic `Borrow(Mut, ...)`, `Temporary(idx)` where
-        // `idx` references a `&mut`-typed local, and `Old(...)` of either
-        // (which is what a user writes when they manually pre-wrap).
+        // Wrap `&mut` slots whose arg is stateful (ref-typed, `Borrow(Mut,
+        // ...)`, `Old(...)`, or a `Temporary` of a `&mut`-typed local).
         let wrap_mask: Vec<bool> = (0..num_inputs)
             .map(|k| {
                 if !arg_types[k].is_mutable_reference() {
@@ -1093,25 +1046,27 @@ impl<'a, 'b, T: ExpGenerator<'a>> SpecTranslator<'a, 'b, T> {
             .collect();
         let post_state_slot_count = wrap_mask.iter().filter(|b| **b).count();
         if post_state_slot_count == 0 {
-            // No reference-typed `&mut T` slots — nothing to do.
             return exp.clone();
         }
 
-        // Compute the canonical augmented arity. For non-`EnsuresOf` kinds
-        // there are no post-state slots, so it equals the input arity.
+        // `EnsuresOf` and `ResultOf` carry trailing post-state clones.
+        // `EnsuresOf` also has explicit result slots between inputs and post.
+        let has_post_slots = matches!(kind, BehaviorKind::EnsuresOf | BehaviorKind::ResultOf);
+        let result_slots = if matches!(kind, BehaviorKind::EnsuresOf) {
+            num_explicit_results
+        } else {
+            0
+        };
         let augmented_arity = 1
             + num_inputs
-            + if matches!(kind, BehaviorKind::EnsuresOf) {
-                num_explicit_results + post_state_slot_count
+            + if has_post_slots {
+                result_slots + post_state_slot_count
             } else {
                 0
             };
-        let needs_post_state =
-            matches!(kind, BehaviorKind::EnsuresOf) && args.len() < augmented_arity;
+        let needs_post_state = has_post_slots && args.len() < augmented_arity;
 
-        // Determine if `Old`-wrapping is already in place for every
-        // wrap_mask position. If so, and we don't need to append post-state
-        // clones, we can short-circuit.
+        // Idempotent short-circuit when canonical form is already present.
         let all_wrapped = wrap_mask.iter().enumerate().all(|(k, needs_wrap)| {
             if !needs_wrap {
                 return true;
@@ -1131,27 +1086,27 @@ impl<'a, 'b, T: ExpGenerator<'a>> SpecTranslator<'a, 'b, T> {
         for k in 0..num_inputs {
             let arg = args[k + 1].clone();
             if wrap_mask[k] {
-                let raw = match arg.as_ref() {
-                    ExpData::Call(_, Operation::Old, inner_args) if inner_args.len() == 1 => {
-                        inner_args[0].clone()
-                    },
-                    _ => arg.clone(),
-                };
+                // Live form (all `Old` wrappers stripped at every level):
+                // `old(p).x → p.x`, `old(Select(p, x)) → p.x`, …
+                let live = strip_all_olds(&arg);
                 if needs_post_state {
-                    post_state_clones.push(raw.clone());
+                    post_state_clones.push(live.clone());
                 }
                 if matches!(arg.as_ref(), ExpData::Call(_, Operation::Old, _)) {
                     new_args.push(arg);
                 } else {
-                    let inner_ty = env.get_node_type(raw.node_id());
-                    let inner_id = env.new_node(env.get_node_loc(raw.node_id()), inner_ty);
-                    new_args.push(ExpData::Call(inner_id, Operation::Old, vec![raw]).into_exp());
+                    // `in_old` propagates through `Select`/`SelectVariants`
+                    // so the inner `Temporary`'s `save_param` still fires.
+                    let arg_ty = env.get_node_type(arg.node_id());
+                    let arg_loc = env.get_node_loc(arg.node_id());
+                    let new_id = env.new_node(arg_loc, arg_ty);
+                    new_args.push(ExpData::Call(new_id, Operation::Old, vec![arg]).into_exp());
                 }
             } else {
                 new_args.push(arg);
             }
         }
-        if matches!(kind, BehaviorKind::EnsuresOf) {
+        if has_post_slots {
             for arg in args.iter().skip(1 + num_inputs) {
                 new_args.push(arg.clone());
             }
@@ -1164,22 +1119,43 @@ impl<'a, 'b, T: ExpGenerator<'a>> SpecTranslator<'a, 'b, T> {
         )
         .into_exp()
     }
+
+    /// True if `arg` is a stateful `&mut`-source shape: a ref-typed
+    /// expression, `Borrow(Mut, ...)`, `Old(...)` of a stateful inner,
+    /// a `Select`/`SelectVariants` rooted in a stateful inner, or a
+    /// `Temporary` of a `&mut`-typed local.
+    fn is_stateful_mut_ref(&self, arg: &Exp) -> bool {
+        let env = self.builder.global_env();
+        if env.get_node_type(arg.node_id()).is_reference() {
+            return true;
+        }
+        match arg.as_ref() {
+            ExpData::Call(_, Operation::Borrow(crate::ty::ReferenceKind::Mutable), _) => true,
+            ExpData::Call(_, Operation::Old, inner) if inner.len() == 1 => {
+                self.is_stateful_mut_ref(&inner[0])
+            },
+            ExpData::Call(_, Operation::Select(..), inner) if inner.len() == 1 => {
+                self.is_stateful_mut_ref(&inner[0])
+            },
+            ExpData::Call(_, Operation::SelectVariants(..), inner) if inner.len() == 1 => {
+                self.is_stateful_mut_ref(&inner[0])
+            },
+            ExpData::Temporary(_, idx) => self
+                .fun_env
+                .get_local_type(*idx)
+                .as_ref()
+                .is_some_and(Type::is_reference),
+            _ => false,
+        }
+    }
 }
 
 impl<'a, T: ExpGenerator<'a>> ExpRewriterFunctions for SpecTranslator<'a, '_, T> {
     fn rewrite_exp(&mut self, exp: Exp) -> Exp {
-        // Bridge user-facing behavioral-predicate syntax to the canonical
-        // 3-arg form before descent, so that:
-        //   - mut-ref input args become `old(arg)` (triggering `save_param`
-        //     on the inner Temporary during descent), and
-        //   - `ensures_of`'s post-state slots (one per mut-ref input) are
-        //     present, populated by clones of the un-wrapped input args
-        //     (left untouched by save_param so they refer to the live,
-        //     post-call value of the reference at the wrapper's exit).
-        // Idempotent: skips wrapping for inputs already wrapped in `old`,
-        // and skips appending post-state clones if they're already present.
+        // `Old`-wrap stateful `&mut` BP args so `save_param` routes their
+        // pre-state through captured temps.
         let exp = if let ExpData::Call(_, Operation::Behavior(_, _), _) = exp.as_ref() {
-            self.augment_behavior_call(&exp)
+            self.wrap_mut_ref_bp_inputs(&exp)
         } else {
             exp
         };
@@ -1467,10 +1443,10 @@ impl<'a, T: ExpGenerator<'a>> ExpRewriterFunctions for SpecTranslator<'a, '_, T>
 }
 
 /// Returns true if a behavioral predicate of given kind needs a pre-state memory label.
-/// `ensures_of` and `result_of` always need pre-state (they compare pre vs post).
+/// `ensures_of`, `result_of`, and `write_of` always need pre-state (they compare pre vs post).
 /// `aborts_of` and `requires_of` only need pre-state if inside `old()`.
 fn needs_pre_label(kind: &BehaviorKind, in_old: bool) -> bool {
-    in_old || matches!(kind, BehaviorKind::EnsuresOf | BehaviorKind::ResultOf)
+    in_old || kind.is_two_state()
 }
 
 /// Memory accessed by a struct field's function value, as declared by the

--- a/third_party/move/move-prover/boogie-backend/src/bytecode_translator.rs
+++ b/third_party/move/move-prover/boogie-backend/src/bytecode_translator.rs
@@ -2052,6 +2052,15 @@ impl<'env> BoogieTranslator<'env> {
     }
 
     /// Generate the uninterpreted `result_of` function and its connecting axiom.
+    ///
+    /// The Skolem takes `(memory, fun, params, &mut post-state slots)` as
+    /// inputs and returns the declared return type only. The axiom ties it
+    /// to `ensures_of` by splatting the Skolem output into the result slots:
+    ///
+    /// ```text
+    /// axiom forall mem, f, p_*, q_* ::
+    ///     ensures_of(mem, f, p_*, result_of(mem, f, p_*, q_*), q_*)
+    /// ```
     fn generate_result_of_function_and_axiom(
         &self,
         fun_type: &Type,
@@ -2065,16 +2074,19 @@ impl<'env> BoogieTranslator<'env> {
         };
         let params_flat = params.clone().flatten();
         let results_flat = results.clone().flatten();
-        let all_outputs = Self::behavioral_output_types(&params_flat, &results_flat);
+        let declared_results: Vec<Type> = results_flat
+            .iter()
+            .map(|ty| ty.skip_reference().clone())
+            .collect();
+        let post_state_types = Self::behavioral_post_state_types(&params_flat);
 
-        if all_outputs.is_empty() {
+        if declared_results.is_empty() {
             return;
         }
 
         let fun_ty_boogie_name = boogie_type(env, fun_type, false);
 
-        // Compute union of all variants' memory for the result_of function.
-        // Must match the evaluator's memory since the axiom references ensures_of.
+        // Memory must match `ensures_of` since the axiom references it.
         let (union_used_memory, union_old_memory) =
             Self::collect_union_memory(env, closure_infos, fun_param_infos, struct_field_infos);
         let (eval_mem_decls, eval_mem_args) =
@@ -2084,24 +2096,34 @@ impl<'env> BoogieTranslator<'env> {
         let ensures_of_name =
             boogie_behavioral_eval_fun_name(env, fun_type, BehaviorKind::EnsuresOf);
 
-        // Parameters: (memory..., fun, params...)
+        // Inputs: memory, fun, p0..pN, q0..qK (post-state slots).
         let mut param_decls: Vec<String> = eval_mem_decls;
         param_decls.push(format!("f: {}", fun_ty_boogie_name));
-        let mut param_args: Vec<String> = eval_mem_args;
-        param_args.push("f".to_string());
+        let mut input_args: Vec<String> = eval_mem_args;
+        input_args.push("f".to_string());
         for (pos, ty) in params_flat.iter().enumerate() {
             param_decls.push(format!(
                 "p{}: {}",
                 pos,
                 boogie_type(env, ty.skip_reference(), false)
             ));
-            param_args.push(format!("p{}", pos));
+            input_args.push(format!("p{}", pos));
         }
+        let mut post_args: Vec<String> = Vec::with_capacity(post_state_types.len());
+        for (pos, ty) in post_state_types.iter().enumerate() {
+            param_decls.push(format!("q{}: {}", pos, boogie_type(env, ty, false)));
+            post_args.push(format!("q{}", pos));
+        }
+        let all_call_args = {
+            let mut v = input_args.clone();
+            v.extend(post_args.iter().cloned());
+            v
+        };
 
-        let result_type = if all_outputs.len() == 1 {
-            boogie_type(env, &all_outputs[0], false)
+        let result_type = if declared_results.len() == 1 {
+            boogie_type(env, &declared_results[0], false)
         } else {
-            boogie_type(env, &Type::Tuple(all_outputs.clone()), false)
+            boogie_type(env, &Type::Tuple(declared_results.clone()), false)
         };
 
         emitln!(
@@ -2112,35 +2134,96 @@ impl<'env> BoogieTranslator<'env> {
             result_type
         );
 
-        let result_of_call = format!("{}({})", result_of_name, param_args.join(", "));
+        let result_of_call = format!("{}({})", result_of_name, all_call_args.join(", "));
 
-        let axiom_body = if all_outputs.len() == 1 {
-            format!(
-                "{}({}, {})",
-                ensures_of_name,
-                param_args.join(", "),
-                result_of_call
-            )
+        // ensures_of takes: input_args, then result slots (declared + post-state).
+        let mut ensures_args = input_args.clone();
+        if declared_results.len() == 1 {
+            ensures_args.push(result_of_call.clone());
+            ensures_args.extend(post_args.iter().cloned());
+            let body = format!("{}({})", ensures_of_name, ensures_args.join(", "));
+            emitln!(
+                self.writer,
+                "axiom (forall {} :: {{{}}} {});",
+                param_decls.join(", "),
+                result_of_call,
+                body
+            );
         } else {
-            let tuple_projections: Vec<String> = (0..all_outputs.len())
+            let tuple_projections: Vec<String> = (0..declared_results.len())
                 .map(|i| format!("_r->${}", i))
                 .collect();
-            format!(
-                "(var _r := {}; {}({}, {}))",
+            ensures_args.extend(tuple_projections);
+            ensures_args.extend(post_args.iter().cloned());
+            let body = format!(
+                "(var _r := {}; {}({}))",
                 result_of_call,
                 ensures_of_name,
-                param_args.join(", "),
-                tuple_projections.join(", ")
-            )
-        };
+                ensures_args.join(", ")
+            );
+            emitln!(
+                self.writer,
+                "axiom (forall {} :: {{{}}} {});",
+                param_decls.join(", "),
+                result_of_call,
+                body
+            );
+        }
 
-        emitln!(
-            self.writer,
-            "axiom (forall {} :: {{{}}} {});",
-            param_decls.join(", "),
-            result_of_call,
-            axiom_body
-        );
+        // Per-`&mut`-parameter functionality projections. `write_of_<j>`
+        // takes only the input slots (no post-state) and returns the j-th
+        // `&mut` post-state. The functionality axiom says: whenever
+        // `ensures_of(..., q_*)` holds, `q_j == write_of_<j>(inputs)`.
+        // Together with the `result_of` axiom this lets the verifier derive
+        // that all outputs of a deterministic `f` are functions of inputs.
+        let input_decls: Vec<String> = param_decls
+            .iter()
+            .take(param_decls.len() - post_state_types.len())
+            .cloned()
+            .collect();
+        for (j, ty) in post_state_types.iter().enumerate() {
+            let write_of_name =
+                boogie_behavioral_eval_fun_name(env, fun_type, BehaviorKind::WriteOf(j));
+            let write_of_call = format!("{}({})", write_of_name, input_args.join(", "));
+            emitln!(
+                self.writer,
+                "function {}({}): {};",
+                write_of_name,
+                input_decls.join(", "),
+                boogie_type(env, ty, false)
+            );
+            // Quantifier vars: inputs + remaining q's (for ensures_of's tail).
+            let q_decls: Vec<String> = post_state_types
+                .iter()
+                .enumerate()
+                .map(|(i, ty)| format!("q{}: {}", i, boogie_type(env, ty, false)))
+                .collect();
+            let r_decls: Vec<String> = declared_results
+                .iter()
+                .enumerate()
+                .map(|(i, ty)| format!("r{}: {}", i, boogie_type(env, ty, false)))
+                .collect();
+            let r_args: Vec<String> = (0..declared_results.len())
+                .map(|i| format!("r{}", i))
+                .collect();
+            let mut all_quant = input_decls.clone();
+            all_quant.extend(r_decls);
+            all_quant.extend(q_decls);
+            let mut ensures_call_args = input_args.clone();
+            ensures_call_args.extend(r_args);
+            ensures_call_args.extend(post_args.iter().cloned());
+            let ensures_call = format!("{}({})", ensures_of_name, ensures_call_args.join(", "));
+            emitln!(
+                self.writer,
+                "axiom (forall {} :: {{{}, {}}} {} ==> q{} == {});",
+                all_quant.join(", "),
+                ensures_call,
+                write_of_call,
+                ensures_call,
+                j,
+                write_of_call
+            );
+        }
     }
 
     /// Generate per-function behavioral spec functions for closure target functions.
@@ -2231,7 +2314,12 @@ impl<'env> BoogieTranslator<'env> {
                 );
             }
 
-            // Generate ensures_of with result functions.
+            // The per-variant ensures_of/result_of Skolems keep the old
+            // shape (multi-output Skolem returning declared + post-state).
+            // The procedure-side dispatcher reads `&mut` post-states from
+            // this Skolem's extended tuple. User-facing `result_of` symmetry
+            // is enforced at the per-type evaluator level — see
+            // `generate_result_of_function_and_axiom`.
             let all_result_type_refs =
                 Self::behavioral_output_type_refs(&fun_param_tys, &results_flat);
             let all_result_types: Vec<String> =
@@ -2251,13 +2339,11 @@ impl<'env> BoogieTranslator<'env> {
             let ensures_fun_name =
                 boogie_behavioral_fun_spec_name(self.env, &info.fun, BehaviorKind::EnsuresOf);
 
-            // Build full parameter list including results
             let mut full_param_decls = input_param_decls.clone();
             for (i, result_type) in all_result_types.iter().enumerate() {
                 full_param_decls.push(format!("r{}: {}", i, result_type));
             }
 
-            // Memory + input args combined (for connecting axioms)
             let all_input_arg_names: Vec<String> = {
                 let mut args = mem_args.clone();
                 args.extend(input_args.iter().cloned());
@@ -2265,7 +2351,6 @@ impl<'env> BoogieTranslator<'env> {
             };
 
             if all_result_types.len() == 1 {
-                // Single result: generate result function and define ensures_of
                 let result_fun_name = boogie_behavioral_fun_result_name(self.env, &info.fun, false);
                 emitln!(
                     self.writer,
@@ -2275,7 +2360,6 @@ impl<'env> BoogieTranslator<'env> {
                     all_result_types[0]
                 );
 
-                // Validity axiom
                 let result_fun_app = format!("{}({})", result_fun_name, input_args_str);
                 self.emit_result_validity_axiom(
                     &input_param_decls,
@@ -2284,7 +2368,6 @@ impl<'env> BoogieTranslator<'env> {
                     &precond,
                 );
 
-                // Connecting axiom: result satisfies ensures_of
                 let ensures_body = self.translate_fun_spec_conditions(
                     &fun_env,
                     &closure_spec,
@@ -2292,7 +2375,6 @@ impl<'env> BoogieTranslator<'env> {
                     &info.fun.inst,
                     &inst_old,
                 );
-                // Define ensures_of as inline function using the translated body
                 emitln!(
                     self.writer,
                     "function {{:inline}} {}({}): bool {{ {} }}",
@@ -2301,7 +2383,6 @@ impl<'env> BoogieTranslator<'env> {
                     ensures_body
                 );
 
-                // Connecting axiom: result_fun satisfies ensures_of
                 let ensures_of_with_result = {
                     let mut call_args = all_input_arg_names.clone();
                     call_args.push(format!("{}({})", result_fun_name, input_args_str));
@@ -2319,7 +2400,6 @@ impl<'env> BoogieTranslator<'env> {
                     );
                 }
             } else if all_result_types.len() >= 2 {
-                // Multiple results: generate tuple-returning result function
                 let result_fun_name = boogie_behavioral_fun_result_name(self.env, &info.fun, true);
 
                 let tuple_element_types = Self::deref_output_types(&all_result_type_refs);
@@ -2333,7 +2413,6 @@ impl<'env> BoogieTranslator<'env> {
                     tuple_type
                 );
 
-                // Validity axiom
                 let result_fun_app = format!("{}({})", result_fun_name, input_args_str);
                 self.emit_tuple_result_validity_axiom(
                     &input_param_decls,
@@ -2342,7 +2421,6 @@ impl<'env> BoogieTranslator<'env> {
                     &precond,
                 );
 
-                // Define ensures_of with translated body
                 let ensures_body = self.translate_fun_spec_conditions(
                     &fun_env,
                     &closure_spec,
@@ -2358,7 +2436,6 @@ impl<'env> BoogieTranslator<'env> {
                     ensures_body
                 );
 
-                // Connecting axiom
                 let tuple_projections: Vec<String> = (0..all_result_types.len())
                     .map(|i| format!("_r->${}", i))
                     .collect();
@@ -2385,7 +2462,6 @@ impl<'env> BoogieTranslator<'env> {
                     );
                 }
             } else {
-                // No return values: still translate ensures body for state-change conditions
                 let ensures_body = self.translate_fun_spec_conditions(
                     &fun_env,
                     &closure_spec,
@@ -2421,7 +2497,9 @@ impl<'env> BoogieTranslator<'env> {
                 BehaviorKind::RequiresOf => matches!(c.kind, ConditionKind::Requires),
                 BehaviorKind::AbortsOf => matches!(c.kind, ConditionKind::AbortsIf),
                 BehaviorKind::EnsuresOf => matches!(c.kind, ConditionKind::Ensures),
-                BehaviorKind::ResultOf => false,
+                // ResultOf/WriteOf are uninterpreted Skolems; the axiom in
+                // `generate_result_of_function_and_axiom` ties them to `ensures_of`.
+                BehaviorKind::ResultOf | BehaviorKind::WriteOf(_) => false,
             })
             .collect();
 
@@ -2429,7 +2507,7 @@ impl<'env> BoogieTranslator<'env> {
             return match kind {
                 BehaviorKind::RequiresOf | BehaviorKind::EnsuresOf => "true".to_string(),
                 BehaviorKind::AbortsOf => "false".to_string(),
-                BehaviorKind::ResultOf => "true".to_string(),
+                BehaviorKind::ResultOf | BehaviorKind::WriteOf(_) => "true".to_string(),
             };
         }
 
@@ -2490,7 +2568,8 @@ impl<'env> BoogieTranslator<'env> {
                         BehaviorKind::RequiresOf | BehaviorKind::AbortsOf => {
                             format!("p{}", param_idx)
                         },
-                        BehaviorKind::ResultOf => unreachable!(),
+                        // ResultOf/WriteOf are uninterpreted — no body translated.
+                        BehaviorKind::ResultOf | BehaviorKind::WriteOf(_) => unreachable!(),
                     };
                     result =
                         result.replace(&format!("$Dereference($t{})", param_idx), &current_value);
@@ -2526,7 +2605,7 @@ impl<'env> BoogieTranslator<'env> {
                     format!("({})", translated.join(" || "))
                 }
             },
-            BehaviorKind::ResultOf => return "true".to_string(),
+            BehaviorKind::ResultOf | BehaviorKind::WriteOf(_) => return "true".to_string(),
         };
 
         // Collect intermediate labels from conditions that need existential wrapping.
@@ -2561,7 +2640,7 @@ impl<'env> BoogieTranslator<'env> {
                         BehaviorKind::RequiresOf => matches!(c.kind, ConditionKind::Requires),
                         BehaviorKind::AbortsOf => matches!(c.kind, ConditionKind::AbortsIf),
                         BehaviorKind::EnsuresOf => matches!(c.kind, ConditionKind::Ensures),
-                        BehaviorKind::ResultOf => false,
+                        BehaviorKind::ResultOf | BehaviorKind::WriteOf(_) => false,
                     };
                     if dominated {
                         return false;
@@ -2954,24 +3033,26 @@ impl<'env> BoogieTranslator<'env> {
         args
     }
 
-    /// Behavioral predicates reason over plain values, even when the underlying
-    /// function result is a reference or a `&mut` parameter post-state. Both
-    /// `&T` and `&mut T` are stripped to `T` here so that `result_of<f>(...)`
-    /// has the same Boogie value type as the surrounding spec context's
-    /// auto-derefed `result`.
+    /// Result slot types in the `ensures_of` signature: declared returns
+    /// followed by one slot per `&mut` parameter post-state. References are
+    /// stripped — spec predicates work on values.
     fn behavioral_output_types(params: &[Type], results: &[Type]) -> Vec<Type> {
         let mut outputs = results
             .iter()
-            // Strip ALL references from results — spec predicates work on values, not refs.
             .map(|ty| ty.skip_reference().clone())
             .collect::<Vec<_>>();
-        outputs.extend(
-            params
-                .iter()
-                .filter(|ty| ty.is_mutable_reference())
-                .map(|ty| ty.skip_reference().clone()),
-        );
+        outputs.extend(Self::behavioral_post_state_types(params));
         outputs
+    }
+
+    /// `&mut` parameter post-state slot types (input slots on `result_of`,
+    /// trailing result slots on `ensures_of`).
+    fn behavioral_post_state_types(params: &[Type]) -> Vec<Type> {
+        params
+            .iter()
+            .filter(|ty| ty.is_mutable_reference())
+            .map(|ty| ty.skip_reference().clone())
+            .collect()
     }
 
     fn behavioral_output_type_refs<'a>(params: &'a [Type], results: &'a [Type]) -> Vec<&'a Type> {
@@ -3131,22 +3212,19 @@ impl<'env> BoogieTranslator<'env> {
                 );
             }
 
-            // For ensures_of: generate result functions and define ensures_of in terms of them.
+            // Multi-output Skolem (declared returns + `&mut` post-states).
+            // The procedure dispatcher reads `&mut` post-states from this
+            // Skolem's output tuple. User-facing `result_of` symmetry is
+            // enforced at the per-type evaluator level.
             let all_result_type_refs = Self::behavioral_output_type_refs(&params, &results);
             let all_result_types: Vec<String> = Self::behavioral_output_types(&params, &results)
                 .into_iter()
                 .map(|ty| boogie_type(self.env, &ty, false))
                 .collect();
 
-            // Generate uninterpreted result functions and validity axioms.
-            // For single result: generates `ensures_of_result0(args) : result_type`
-            // For multiple results: generates `ensures_of_results(args) : $Tuple{n} ...`
-            // This is needed to establish witnesses for choice expressions like `choose y where ensures_of<f>(x, y)`.
             let input_args_str = input_args.join(", ");
-
             let precond = Self::validity_precondition(self.env, &params, "arg");
 
-            // Get the ensures_of function name (used in both branches)
             let ensures_fun_name = boogie_behavioral_spec_fun_name(
                 self.env,
                 &info.fun,
@@ -3155,15 +3233,12 @@ impl<'env> BoogieTranslator<'env> {
                 &[],
             );
 
-            // Build full parameter list including results
             let mut full_param_decls = input_param_decls.clone();
             for (i, result_type) in all_result_types.iter().enumerate() {
                 full_param_decls.push(format!("result{}: {}", i, result_type));
             }
 
             if all_result_types.len() == 1 {
-                // Single result: generate simple function ensures_of_result(args) : result_type
-                // all_result_types already has dereferenced types.
                 let result_fun_name = boogie_behavioral_result_fun_name(
                     self.env,
                     &info.fun,
@@ -3179,7 +3254,6 @@ impl<'env> BoogieTranslator<'env> {
                     all_result_types[0]
                 );
 
-                // Validity axiom
                 let result_fun_app = format!("{}({})", result_fun_name, input_args_str);
                 self.emit_result_validity_axiom(
                     &input_param_decls,
@@ -3188,7 +3262,6 @@ impl<'env> BoogieTranslator<'env> {
                     &precond,
                 );
 
-                // Define ensures_of as simple equality
                 let body = format!("{}({}) == result0", result_fun_name, input_args_str);
                 emitln!(
                     self.writer,
@@ -3198,7 +3271,6 @@ impl<'env> BoogieTranslator<'env> {
                     body
                 );
             } else if all_result_types.len() >= 2 {
-                // Multiple results: generate tuple-returning function ensures_of_results(args) : $Tuple{n} ...
                 let result_fun_name = boogie_behavioral_result_fun_name(
                     self.env,
                     &info.fun,
@@ -3218,7 +3290,6 @@ impl<'env> BoogieTranslator<'env> {
                     tuple_type
                 );
 
-                // Validity axiom
                 let result_fun_app = format!("{}({})", result_fun_name, input_args_str);
                 self.emit_tuple_result_validity_axiom(
                     &input_param_decls,
@@ -3227,8 +3298,6 @@ impl<'env> BoogieTranslator<'env> {
                     &precond,
                 );
 
-                // Define ensures_of by unpacking tuple:
-                // (var r := result_fun(args); r->$0 == result0 && r->$1 == result1 && ...)
                 let equality_checks: Vec<String> = (0..all_result_types.len())
                     .map(|i| format!("r->${} == result{}", i, i))
                     .collect();
@@ -3246,9 +3315,6 @@ impl<'env> BoogieTranslator<'env> {
                     body
                 );
             } else {
-                // No return values: generate the real ensures body for state-change conditions.
-                // This is the parameter variant evaluator — it dispatches to the concrete
-                // closure's ensures body which now correctly handles void functions.
                 emitln!(
                     self.writer,
                     "function {{:inline}} {}({}): bool {{ true }}",
@@ -3353,7 +3419,6 @@ impl<'env> BoogieTranslator<'env> {
             }
             let _ = has_memory;
 
-            let input_args_str = input_args.join(", ");
             let precond = Self::validity_precondition(self.env, &params, "arg");
             // Structured memory-arg carrier for the axiom body translator.
             // `render(kind)` dispatches to `(old, old)` for aborts/requires and
@@ -3381,13 +3446,15 @@ impl<'env> BoogieTranslator<'env> {
                 );
             }
 
-            // For ensures_of: generate result functions and define ensures_of in terms of them.
+            // Multi-output Skolem (declared returns + `&mut` post-states).
+            // User-facing symmetry is at the per-type evaluator level.
             let all_result_type_refs = Self::behavioral_output_type_refs(&params, &results);
             let all_result_types: Vec<String> = Self::behavioral_output_types(&params, &results)
                 .into_iter()
                 .map(|ty| boogie_type(self.env, &ty, false))
                 .collect();
 
+            let input_args_str = input_args.join(", ");
             let ensures_fun_name = boogie_struct_field_spec_fun_name(
                 self.env,
                 &info.struct_id,
@@ -3512,7 +3579,6 @@ impl<'env> BoogieTranslator<'env> {
                     &tuple_element_types,
                     &precond,
                 );
-                // TODO: emit_data_invariant_axiom_for_field for multi-result case
                 let equality_checks: Vec<String> = (0..all_result_types.len())
                     .map(|i| format!("r->${} == result{}", i, i))
                     .collect();

--- a/third_party/move/move-prover/boogie-backend/src/spec_translator.rs
+++ b/third_party/move/move-prover/boogie-backend/src/spec_translator.rs
@@ -128,6 +128,17 @@ struct LiftedChoiceInfo {
     condition: Exp,
 }
 
+/// Projection of an extended-tuple Skolem output, used by
+/// `translate_behavior_for_closure` for the closure-direct path where the
+/// per-function Skolem still returns `(declared..., post_state...)`.
+#[derive(Clone, Copy)]
+enum ProjKind {
+    /// `(SKOLEM_CALL)->$idx`.
+    Single(usize),
+    /// `(var _r := SKOLEM_CALL; $TupleN(_r->$0, ..., _r->$(n-1)))`.
+    Truncate(usize),
+}
+
 impl<'env> SpecTranslator<'env> {
     /// Creates a translator.
     pub fn new(
@@ -1706,14 +1717,8 @@ impl SpecTranslator<'_> {
         self.in_behavior_pred_arg.replace(prev);
     }
 
-    /// Translate a behavioral predicate using the per-type evaluator dispatch function.
-    /// Used for runtime function values (e.g., function-typed parameters after substitution).
-    ///
-    /// `pred_args` arrive in canonical 3-arg shape (input slots followed by
-    /// explicit-result + post-state slots for `EnsuresOf`). State-label
-    /// substitutions (`..S |~` and `S.. |~`) replace the post-state of the
-    /// *last* mut-ref param and the pre-state of the *first* mut-ref param,
-    /// respectively, matching the prior semantics for single-mut-ref closures.
+    /// Translate a behavioral predicate via the per-type evaluator dispatch
+    /// function (used for runtime function values).
     fn translate_behavior_via_evaluator(
         &self,
         node_id: NodeId,
@@ -1724,7 +1729,9 @@ impl SpecTranslator<'_> {
     ) {
         let fun_type = self.env.get_node_type(fun_exp.node_id());
         let inst_fun_type = fun_type.instantiate(&self.type_inst);
+
         let eval_fun_name = boogie_behavioral_eval_fun_name(self.env, &inst_fun_type, kind);
+
         emit!(self.writer, "{}(", eval_fun_name);
         let has_mem =
             self.emit_evaluator_memory_args(node_id, &inst_fun_type, kind, &range.pre, &range.post);
@@ -1733,10 +1740,8 @@ impl SpecTranslator<'_> {
         }
         self.translate_exp(fun_exp);
 
-        // For value-typed state labels (|&mut T| closures with no global memory):
-        // substitute the state variable S_val into the appropriate pred_arg position.
-        //   ..S |~ ensures_of<f>(old_x, x)  →  ensures_of<f>(old_x, S_val)   [post label: replace last]
-        //   S.. |~ ensures_of<g>(old_x, x)  →  ensures_of<g>(S_val, x)       [pre label: replace first &mut input]
+        // Value-typed state-label substitutions: replace specific arg slots
+        // with the bound state variable when present.
         let post_sub = range.post.and_then(|label| {
             self.value_state_vars
                 .borrow()
@@ -1810,7 +1815,7 @@ impl SpecTranslator<'_> {
         let uses_old = !union_old_memory.is_empty();
         let current = match kind {
             BehaviorKind::RequiresOf | BehaviorKind::AbortsOf => pre,
-            BehaviorKind::EnsuresOf | BehaviorKind::ResultOf => post,
+            BehaviorKind::EnsuresOf | BehaviorKind::ResultOf | BehaviorKind::WriteOf(_) => post,
         };
         let mut first = true;
         for memory in &union_used_memory {
@@ -1841,13 +1846,9 @@ impl SpecTranslator<'_> {
     }
 
     /// Translate a behavioral predicate for a closure expression.
-    ///
-    /// Calls the per-function behavioral spec function (or `result_of` function)
-    /// directly. The `pred_args` arrive already augmented with the canonical
-    /// 3-arg shape produced by `translate_behavior_predicate` (and the
-    /// inference engine): input args wrapped in `old(...)` for `&mut`
-    /// parameters, then for `EnsuresOf`, the explicit-result args followed by
-    /// the (un-wrapped) post-state clones of each `&mut` input.
+    /// `pred_args` is in canonical form: `&mut T` input slots are
+    /// `Old(...)`-wrapped (so they reference the captured pre-state temp),
+    /// and `EnsuresOf` carries trailing post-state clones for each `&mut`.
     #[allow(clippy::too_many_arguments)]
     fn translate_behavior_for_closure(
         &self,
@@ -1868,22 +1869,56 @@ impl SpecTranslator<'_> {
         let fun_qid = mid.qualified_inst(fid, inst);
         let fun_env = self.env.get_function(fun_qid.to_qualified_id());
         let num_params = fun_env.get_parameter_count();
+        let num_explicit_results = fun_env.get_return_count();
+        let num_mut_refs = fun_env
+            .get_parameter_types()
+            .iter()
+            .filter(|ty| ty.is_mutable_reference())
+            .count();
+        let total_outputs = num_explicit_results + num_mut_refs;
 
-        let fun_name = if kind == BehaviorKind::ResultOf {
-            let multi_result = fun_env.get_return_count()
-                + fun_env
-                    .get_parameter_types()
-                    .iter()
-                    .filter(|ty| ty.is_mutable_reference())
-                    .count()
-                != 1;
-            boogie_behavioral_fun_result_name(self.env, &fun_qid, multi_result)
-        } else {
-            boogie_behavioral_fun_spec_name(self.env, &fun_qid, kind)
+        // The Skolem shape depends on `total_outputs = num_explicit_results
+        // + num_mut_refs`: with `total_outputs == 1` we call the scalar
+        // Skolem (no projection); with `total_outputs > 1` we call the
+        // multi-result Skolem returning `(declared..., post...)` and project
+        // out the requested slice. Both `ResultOf` and `WriteOf` agree with
+        // the procedure-side dispatcher's choice of Skolem
+        // (`multi_in_boogie == total_outputs > 1`).
+        let multi_in_boogie = total_outputs > 1;
+        let projection = match kind {
+            // ResultOf: take the declared-result slice. Only needed when
+            // post-state slots are appended past it.
+            BehaviorKind::ResultOf if multi_in_boogie && total_outputs > num_explicit_results => {
+                if num_explicit_results == 1 {
+                    Some(ProjKind::Single(0))
+                } else {
+                    Some(ProjKind::Truncate(num_explicit_results))
+                }
+            },
+            // WriteOf(j): take the j-th `&mut` post-state slot. Only needed
+            // when the multi Skolem is in play; with `total_outputs == 1`
+            // the scalar Skolem already returns that slot directly.
+            BehaviorKind::WriteOf(j) if multi_in_boogie => {
+                Some(ProjKind::Single(num_explicit_results + j))
+            },
+            _ => None,
         };
+
+        let fun_name = match kind {
+            BehaviorKind::ResultOf | BehaviorKind::WriteOf(_) => {
+                boogie_behavioral_fun_result_name(self.env, &fun_qid, multi_in_boogie)
+            },
+            _ => boogie_behavioral_fun_spec_name(self.env, &fun_qid, kind),
+        };
+
+        match projection {
+            Some(ProjKind::Single(_)) => emit!(self.writer, "("),
+            Some(ProjKind::Truncate(_)) => emit!(self.writer, "(var _r := "),
+            None => {},
+        }
         emit!(self.writer, "{}(", fun_name);
 
-        // Emit memory args, then interleave captured + non-captured params
+        // Memory args, then interleave captured + non-captured input args.
         let mut has_args = self.emit_fun_spec_memory_args(node_id, &fun_qid, kind, range);
         let mut captured_pos = 0;
         let mut non_captured_pos = 0;
@@ -1901,15 +1936,31 @@ impl SpecTranslator<'_> {
             }
         }
 
-        // For `EnsuresOf`: emit result args + post-state slots from remaining
-        // pred_args (already in canonical order: explicit_results, post_states).
+        // `EnsuresOf` carries trailing post-state clones after the input
+        // slots — emit them. `ResultOf` also carries them in `pred_args`, but
+        // the per-function Skolem doesn't take them (post-state is in its
+        // output tuple instead); skip them here.
         if kind == BehaviorKind::EnsuresOf {
             for arg in &pred_args[non_captured_pos..] {
                 emit!(self.writer, ", ");
                 self.translate_behavior_arg(arg);
             }
         }
+
         emit!(self.writer, ")");
+        match projection {
+            Some(ProjKind::Single(idx)) => emit!(self.writer, ")->${}", idx),
+            Some(ProjKind::Truncate(n)) => {
+                emit!(self.writer, "; $Tuple{}(", n);
+                let mut sep = "";
+                for i in 0..n {
+                    emit!(self.writer, "{}_r->${}", sep, i);
+                    sep = ", ";
+                }
+                emit!(self.writer, "))");
+            },
+            None => {},
+        }
     }
 
     /// Emit memory arguments for a function's spec memory in proper state order.
@@ -1933,7 +1984,7 @@ impl SpecTranslator<'_> {
         let uses_old = !old_memory.is_empty();
         let current = match kind {
             BehaviorKind::RequiresOf | BehaviorKind::AbortsOf => pre,
-            BehaviorKind::EnsuresOf | BehaviorKind::ResultOf => post,
+            BehaviorKind::EnsuresOf | BehaviorKind::ResultOf | BehaviorKind::WriteOf(_) => post,
         };
         let mut first = true;
         for memory in used_memory {
@@ -2017,6 +2068,7 @@ impl SpecTranslator<'_> {
             BehaviorKind::AbortsOf => "aborts_of",
             BehaviorKind::EnsuresOf => "ensures_of",
             BehaviorKind::ResultOf => "result_of",
+            BehaviorKind::WriteOf(_) => "write_of",
         };
         let struct_env = self.env.get_struct_qid(memory.to_qualified_id());
         let mem_display = struct_env.get_full_name_with_address().to_string();

--- a/third_party/move/move-prover/bytecode-pipeline/src/spec_inference.rs
+++ b/third_party/move/move-prover/bytecode-pipeline/src/spec_inference.rs
@@ -103,7 +103,7 @@ use move_model::{
         Pattern, PropertyValue, QuantKind, RewriteResult, TempIndex, Value,
     },
     exp_generator::{ExpGenerator, RangeCheckKind},
-    exp_rewriter::{ExpRewriter, ExpRewriterFunctions, RewriteTarget},
+    exp_rewriter::{strip_all_olds, ExpRewriter, ExpRewriterFunctions, RewriteTarget},
     exp_simplifier::{flatten_conjunction_owned, ExpSimplifier},
     memory_labels::MemoryLabelInfo,
     model::{
@@ -688,6 +688,10 @@ impl FunctionTargetProcessor for SpecInferenceProcessor {
                         .collect();
                 }
 
+                // Eliminate WP-internal `WriteOf` carriers before simplification
+                // so any tautologies it produces are folded away.
+                analyzer.eliminate_write_of(&mut state);
+
                 // Simplify conditions: constant folding, arithmetic/boolean
                 // identities, and assumption-based redundancy elimination.
                 // Multiple passes allow multi-step simplification chains to complete
@@ -1061,7 +1065,7 @@ fn is_cse_candidate(exp: &ExpData) -> bool {
 }
 
 /// Generates a readable name for a CSE binding based on expression structure.
-fn cse_name_for(env: &GlobalEnv, exp: &ExpData, index: usize) -> String {
+fn cse_name_for(env: &GlobalEnv, exp: &ExpData) -> String {
     let name = match exp {
         ExpData::Call(_, AstOp::MoveFunction(mid, fid), _)
         | ExpData::Call(_, AstOp::Closure(mid, fid, _), _) => {
@@ -1076,12 +1080,14 @@ fn cse_name_for(env: &GlobalEnv, exp: &ExpData, index: usize) -> String {
         ExpData::Call(_, AstOp::Select(_, _, field_id), _) => {
             field_id.symbol().display(env.symbol_pool()).to_string()
         },
-        _ => format!("cse_{}", index),
+        _ => "cse".to_string(),
     };
-    // Strip internal `$` prefix used for auto-generated spec function names
+    // Strip internal `$` prefix used for auto-generated spec function names.
     let name = name.strip_prefix('$').unwrap_or(&name);
-    // Append index to avoid collision with imported function names
-    format!("{}_{}", name, index)
+    // Always append a trailing underscore to avoid collision with the
+    // imported function/field name; further collisions are resolved by
+    // appending more underscores at the call site.
+    format!("{}_", name)
 }
 
 /// Performs common sub-expression elimination on inferred spec conditions.
@@ -1181,19 +1187,12 @@ fn cse_inferred_conditions(fun_env: &FunctionEnv) {
     }
 
     // Process each candidate: create a let binding and rewrite all conditions
-    for (cse_idx, (candidate_exp, _count)) in candidates.iter().enumerate() {
-        // Generate a unique name
-        let mut name = cse_name_for(env, candidate_exp.as_ref(), cse_idx);
-        if used_names.contains(&name) {
-            let base = name.clone();
-            let mut suffix = 1;
-            loop {
-                name = format!("{}_{}", base, suffix);
-                if !used_names.contains(&name) {
-                    break;
-                }
-                suffix += 1;
-            }
+    for (candidate_exp, _count) in candidates.iter() {
+        // Generate a unique name. The base name ends with `_`; resolve
+        // collisions by appending additional underscores.
+        let mut name = cse_name_for(env, candidate_exp.as_ref());
+        while used_names.contains(&name) {
+            name.push('_');
         }
         used_names.insert(name.clone());
         let name_sym = pool.make(&name);
@@ -1445,6 +1444,213 @@ fn entities_match(a: &DeterminedEntity, b: &DeterminedEntity) -> bool {
 /// Check if an expression is a trivial boolean `false` literal
 fn is_trivial_false(exp: &Exp) -> bool {
     matches!(exp.as_ref(), ExpData::Value(_, Value::Bool(false)))
+}
+
+/// Match `lhs == result_of<f>(args)` (single-return) or the multi-return
+/// destructure `lhs == { let (..._t_i...) = result_of<f>(args); _t_i }`.
+/// Returns `(lhs, output_idx, fun_exp, args, range)`.
+fn extract_result_of_clause(exp: &Exp) -> Option<(Exp, usize, Exp, Vec<Exp>, MemoryRange)> {
+    use move_model::ast::BehaviorKind;
+    let ExpData::Call(_, AstOp::Eq, eq_args) = exp.as_ref() else {
+        return None;
+    };
+    if eq_args.len() != 2 {
+        return None;
+    }
+    let lhs = eq_args[0].clone();
+    let rhs = &eq_args[1];
+
+    if let ExpData::Call(_, AstOp::Behavior(BehaviorKind::ResultOf, range), bp_args) = rhs.as_ref()
+    {
+        if bp_args.is_empty() {
+            return None;
+        }
+        let fun_exp = bp_args[0].clone();
+        let args = bp_args[1..].to_vec();
+        return Some((lhs, 0, fun_exp, args, range.clone()));
+    }
+
+    if let ExpData::Block(_, pat, Some(binding), body) = rhs.as_ref() {
+        let Pattern::Tuple(_, pat_elems) = pat else {
+            return None;
+        };
+        let ExpData::Call(_, AstOp::Behavior(BehaviorKind::ResultOf, range), bp_args) =
+            binding.as_ref()
+        else {
+            return None;
+        };
+        let ExpData::LocalVar(_, body_sym) = body.as_ref() else {
+            return None;
+        };
+        let body_sym = *body_sym;
+        for (i, pe) in pat_elems.iter().enumerate() {
+            if let Pattern::Var(_, sym) = pe {
+                if *sym == body_sym {
+                    if bp_args.is_empty() {
+                        return None;
+                    }
+                    let fun_exp = bp_args[0].clone();
+                    let args = bp_args[1..].to_vec();
+                    return Some((lhs, i, fun_exp, args, range.clone()));
+                }
+            }
+        }
+    }
+
+    None
+}
+
+/// Match `ensures_of<f>(args, …)` at the clause top; return `(fun_exp, args_after_fun, range)`.
+fn extract_top_ensures_of_clause(exp: &Exp) -> Option<(Exp, Vec<Exp>, MemoryRange)> {
+    use move_model::ast::BehaviorKind;
+    let ExpData::Call(_, AstOp::Behavior(BehaviorKind::EnsuresOf, range), bp_args) = exp.as_ref()
+    else {
+        return None;
+    };
+    if bp_args.is_empty() {
+        return None;
+    }
+    let fun_exp = bp_args[0].clone();
+    let args = bp_args[1..].to_vec();
+    Some((fun_exp, args, range.clone()))
+}
+
+/// Structural equality of the (function, args) pair identifying a call site.
+fn calls_match(fun1: &Exp, args1: &[Exp], fun2: &Exp, args2: &[Exp]) -> bool {
+    if !fun1.structural_eq(fun2) {
+        return false;
+    }
+    if args1.len() != args2.len() {
+        return false;
+    }
+    args1
+        .iter()
+        .zip(args2.iter())
+        .all(|(a, b)| a.structural_eq(b))
+}
+
+/// Collect `(write_of_call, L_path)` from each `Eq(L, R)` where `R` is
+/// `write_of(...)` or `update_field(B, f, write_of(...))` (possibly nested).
+/// Each `update_field` layer extends `L_path` with a `Select` step, so the
+/// path names the procedure-level `&mut` post-state even when WP
+/// propagated the body-borrow source through `let` bindings (e.g.
+/// `Eq(result, update_field(p, x, write_of(...)))` → `write_of ↦ result.x`).
+fn collect_write_of_bindings(env: &GlobalEnv, exps: &[Exp]) -> Vec<(Exp, Exp)> {
+    let mut result: Vec<(Exp, Exp)> = Vec::new();
+    for exp in exps {
+        exp.visit_pre_order(&mut |sub| {
+            if let ExpData::Call(_, AstOp::Eq, args) = sub {
+                if args.len() == 2 && is_procedure_level_path(&args[0]) {
+                    decompose_write_of_binding(env, &args[0], &args[1], &mut result);
+                }
+            }
+            true
+        });
+    }
+    result
+}
+
+/// True if `exp` is a `Temporary`, the procedure result, or a `Select` /
+/// `SelectVariants` chain rooted at one. Guards binding collection: a
+/// quantifier-bound `LocalVar` LHS would leak out of scope after
+/// substitution.
+fn is_procedure_level_path(exp: &Exp) -> bool {
+    match exp.as_ref() {
+        ExpData::Temporary(..) => true,
+        ExpData::Call(_, AstOp::Result(..), _) => true,
+        ExpData::Call(_, AstOp::Select(..), args) if args.len() == 1 => {
+            is_procedure_level_path(&args[0])
+        },
+        ExpData::Call(_, AstOp::SelectVariants(..), args) if args.len() == 1 => {
+            is_procedure_level_path(&args[0])
+        },
+        _ => false,
+    }
+}
+
+/// Peel `update_field` wrappers off `rhs`, extending `l` by a `Select`
+/// step per layer; on reaching `write_of`, record `(write_of, l)`.
+/// Both the *value* arm (this update's RHS) and the *base* arm (the
+/// remaining struct, which may itself be a nested `update_field` chain
+/// for sibling fields) are searched.
+fn decompose_write_of_binding(env: &GlobalEnv, l: &Exp, rhs: &Exp, out: &mut Vec<(Exp, Exp)>) {
+    use move_model::ast::BehaviorKind;
+    match rhs.as_ref() {
+        ExpData::Call(_, AstOp::Behavior(BehaviorKind::WriteOf(_), _), _) => {
+            out.push((rhs.clone(), l.clone()));
+        },
+        ExpData::Call(_, AstOp::UpdateField(mid, sid, fid), uf_args) if uf_args.len() == 2 => {
+            let base = &uf_args[0];
+            let value = &uf_args[1];
+            let value_ty = env.get_node_type(value.node_id());
+            let l_loc = env.get_node_loc(l.node_id());
+            let new_l_id = env.new_node(l_loc, value_ty);
+            let new_l = ExpData::Call(new_l_id, AstOp::Select(*mid, *sid, *fid), vec![l.clone()])
+                .into_exp();
+            decompose_write_of_binding(env, &new_l, value, out);
+            // Sibling-field updates live in the base arm.
+            decompose_write_of_binding(env, l, base, out);
+        },
+        _ => {},
+    }
+}
+
+/// Replace each `write_of<f, j>(args)` with the bound `lhs` from `bindings`;
+/// when no binding matches (body-borrow case), fall back to
+/// `strip_all_olds(args[mut_param_pos(j)])`.
+fn substitute_write_of_with_natural(env: &GlobalEnv, exp: &Exp, bindings: &[(Exp, Exp)]) -> Exp {
+    use move_model::ast::BehaviorKind;
+    struct Sub<'a> {
+        env: &'a GlobalEnv,
+        bindings: &'a [(Exp, Exp)],
+    }
+    impl ExpRewriterFunctions for Sub<'_> {
+        fn rewrite_call(&mut self, id: NodeId, oper: &AstOp, args: &[Exp]) -> Option<Exp> {
+            let AstOp::Behavior(BehaviorKind::WriteOf(j), _) = oper else {
+                return None;
+            };
+            // Match against the original (pre-recursion) form: bindings come from the same clause-set.
+            let original = ExpData::Call(id, oper.clone(), args.to_vec()).into_exp();
+            for (wo, lhs) in self.bindings {
+                if wo.as_ref().structural_eq(&original) {
+                    return Some(lhs.clone());
+                }
+            }
+            let new_args: Vec<Exp> = args.iter().map(|a| self.rewrite_exp(a.clone())).collect();
+            if new_args.is_empty() {
+                return None;
+            }
+            let fun_exp = &new_args[0];
+            let fun_type = self.env.get_node_type(fun_exp.node_id());
+            let Type::Fun(arg_ty, _, _) = fun_type else {
+                return None;
+            };
+            let flat = arg_ty.flatten();
+            let mut_pos = flat
+                .iter()
+                .enumerate()
+                .filter(|(_, t)| t.is_mutable_reference())
+                .nth(*j)
+                .map(|(pos, _)| pos)?;
+            let mut_arg = new_args.get(1 + mut_pos)?;
+            Some(strip_all_olds(mut_arg))
+        }
+    }
+    Sub { env, bindings }.rewrite_exp(exp.clone())
+}
+
+/// True for `true`, `Eq(x, x)`, `Implies(_, true_body)`, conjunctions of
+/// these, and `Forall x. true_body`. Used to drop tautologies left behind
+/// by `write_of → lhs` substitution.
+fn is_trivially_true(exp: &Exp) -> bool {
+    match exp.as_ref() {
+        ExpData::Value(_, Value::Bool(true)) => true,
+        ExpData::Call(_, AstOp::Eq, args) if args.len() == 2 => args[0].structural_eq(&args[1]),
+        ExpData::Call(_, AstOp::Implies, args) if args.len() == 2 => is_trivially_true(&args[1]),
+        ExpData::Call(_, AstOp::And, args) => args.iter().all(is_trivially_true),
+        ExpData::Quant(_, QuantKind::Forall, _, _, _, body) => is_trivially_true(body),
+        _ => false,
+    }
 }
 
 /// Strip all memory labels from Global, Exists, Behavior, and SpecFunction operations.
@@ -3281,11 +3487,10 @@ impl<'env> SpecInferenceAnalyzer<'env> {
     }
 
     /// Shared WP logic for function calls (direct) and closure invocations.
-    ///
-    /// Handles: pre-label creation, intermediate labels for captured globals,
-    /// behavioral state setup, extended result type computation, simultaneous
-    /// substitution of dests and &mut post-values, captured_mut_params tracking,
-    /// ensures_of for void calls, aborts_of emission, and post-state update.
+    /// Substitutes `dest_i ↦ result_of<f>(args)[i]` and
+    /// `&mut src_j ↦ write_of<f, j>(args)`. For caller-`&mut`-param
+    /// chaining, `write_of` flows through `substitute_old_param_in_state`.
+    /// For void callees, emits an `ensures_of<f>(args)` state-chain anchor.
     fn wp_function_call(
         &self,
         state: &mut WPState,
@@ -3296,87 +3501,61 @@ impl<'env> SpecInferenceAnalyzer<'env> {
         dests: &[TempIndex],
         mut_ref_srcs: &[(usize, TempIndex)],
     ) {
-        // Pre-label from forward analysis; post from backward WP state.
         let pre_label = self.forward_label_at(offset);
         let call_post = state.post;
 
-        // Create state labels for the behavioral predicates:
-        // - result_of uses pre_label as pre-state and call_post as post-state
-        // - aborts_of uses only pre_label (no post-state: aborts don't produce state)
+        // `aborts_of` has no post-state — aborts don't produce state.
         let behavior_pre = Some(pre_label);
         let behavior_post = Some(call_post);
         let aborts_pre = Some(pre_label);
         let aborts_post: Option<MemoryLabel> = None;
 
-        // Compute extended result type: explicit results + &mut post-values
-        let extended_result_type = if mut_ref_srcs.is_empty() {
-            result_type.clone()
-        } else {
-            let mut all_outputs: Vec<Type> = result_type.clone().flatten();
-            for (_, idx) in mut_ref_srcs {
-                all_outputs.push(self.get_local_type(*idx).skip_reference().clone());
-            }
-            if all_outputs.len() == 1 {
-                all_outputs.into_iter().next().unwrap()
-            } else {
-                Type::Tuple(all_outputs)
-            }
-        };
-        let num_all_outputs = extended_result_type.clone().flatten().len();
+        let num_declared_results = result_type.clone().flatten().len();
 
-        // Collect ALL substitutions (explicit dests + &mut post-values)
-        // and apply them simultaneously to avoid double-nesting of result_of
-        // expressions. Sequential substitution would replace &mut src temps
-        // inside already-substituted result_of args, producing incorrect
-        // nested result_of expressions.
-        let num_explicit = dests.len();
+        let mk_write_of_for = |me: &Self, j: usize| -> Exp {
+            let mut_ref_value_type = me
+                .get_local_type(mut_ref_srcs[j].1)
+                .skip_reference()
+                .clone();
+            me.mk_write_of_with_state(
+                fun_exp.clone(),
+                args.clone(),
+                &mut_ref_value_type,
+                j,
+                behavior_pre,
+                behavior_post,
+            )
+        };
+
+        // Collect all substitutions and apply simultaneously: sequential
+        // substitution would re-substitute inside already-substituted args.
         let mut all_subs: Vec<(TempIndex, Exp)> = Vec::new();
 
-        // Explicit dests: dest_i ↦ result_of<f>(args)[i]
         for (i, &dest) in dests.iter().enumerate() {
             let result_exp = self.mk_result_of_at_with_state(
                 fun_exp.clone(),
                 args.clone(),
-                &extended_result_type,
+                result_type,
                 i,
-                num_all_outputs,
+                num_declared_results,
                 behavior_pre,
                 behavior_post,
             );
             all_subs.push((dest, result_exp));
         }
 
-        // &mut src post-values: src_j ↦ result_of<f>(args)[num_explicit + j]
-        //
-        // For &mut params that are ALREADY in captured_mut_params, do NOT add them
-        // to all_subs. Their old(param) pattern will be replaced by
-        // substitute_old_param_in_state below. Adding them here would cause
-        // substitute_multiple_temps_in_state to also replace `param` inside
-        // `old(param)` in the state (turning it into `old(result_of<...>)`),
-        // and then substitute_old_param_in_state would find another `old(param)`
-        // inside the substitution value and replace it again, producing a
-        // doubly-applied result_of — e.g. result_of<f>(result_of<f>(c, a), a)
-        // instead of the correct result_of<f>(c, a).
-        for (j, (_, idx)) in mut_ref_srcs.iter().enumerate() {
-            if self.is_mut_ref_param(*idx) && state.captured_mut_params.contains(idx) {
-                // Already captured: handled exclusively by substitute_old_param_in_state.
+        // Skip already-captured caller-`&mut`-params: their `old(param)`
+        // gets handled by `substitute_old_param_in_state` below; adding a
+        // direct substitution here would cause double-application.
+        for (j, &(_, idx)) in mut_ref_srcs.iter().enumerate() {
+            if self.is_mut_ref_param(idx) && state.captured_mut_params.contains(&idx) {
                 continue;
             }
-            let result_exp = self.mk_result_of_at_with_state(
-                fun_exp.clone(),
-                args.clone(),
-                &extended_result_type,
-                num_explicit + j,
-                num_all_outputs,
-                behavior_pre,
-                behavior_post,
-            );
-            all_subs.push((*idx, result_exp));
+            all_subs.push((idx, mk_write_of_for(self, j)));
         }
 
-        // Check if any dest temp is referenced in the state before substitution.
-        // If not, result_of will vanish (return value discarded) and we'll need
-        // ensures_of as a fallback to preserve the post-label for state chaining.
+        // If no dest is referenced downstream, the result is discarded —
+        // emit `ensures_of` as a state-chain anchor instead.
         let any_dest_referenced = dests.iter().any(|&d| {
             state.ensures.iter().chain(state.aborts.iter()).any(|e| {
                 let mut found = false;
@@ -3392,54 +3571,32 @@ impl<'env> SpecInferenceAnalyzer<'env> {
             })
         });
 
-        // Apply all substitutions simultaneously
         *state = self.substitute_multiple_temps_in_state(state, &all_subs);
 
-        // For &mut srcs that are params of the current function:
-        // add ensures and mark as captured, mirroring WriteRef handling.
-        for (j, (_, idx)) in mut_ref_srcs.iter().enumerate() {
-            if self.is_mut_ref_param(*idx) {
-                if !state.captured_mut_params.contains(idx) {
-                    // First capture (last write in execution order):
-                    // add ensures param == result_of<f>(args)[num_explicit + j]
+        // For caller-`&mut`-params: on first encounter, add the binding
+        // `Eq(param, write_of(...))` and mark captured. On subsequent
+        // calls, substitute `old(param)` with the chained write_of.
+        for (j, &(_, idx)) in mut_ref_srcs.iter().enumerate() {
+            if self.is_mut_ref_param(idx) {
+                if !state.captured_mut_params.contains(&idx) {
                     if state.is_normal_return {
-                        let param_exp = self.mk_temporary(*idx);
-                        let result_exp = self.mk_result_of_at_with_state(
-                            fun_exp.clone(),
-                            args.clone(),
-                            &extended_result_type,
-                            num_explicit + j,
-                            num_all_outputs,
-                            behavior_pre,
-                            behavior_post,
-                        );
-                        state.add_ensures(self.mk_eq(param_exp, result_exp));
+                        let param_exp = self.mk_temporary(idx);
+                        let write_exp = mk_write_of_for(self, j);
+                        state.add_ensures(self.mk_eq(param_exp, write_exp));
                     }
-                    state.captured_mut_params.insert(*idx);
+                    state.captured_mut_params.insert(idx);
                 } else {
-                    // Already captured: substitute old(param) with the
-                    // call's post-value (chains through earlier writes).
-                    let result_exp = self.mk_result_of_at_with_state(
-                        fun_exp.clone(),
-                        args.clone(),
-                        &extended_result_type,
-                        num_explicit + j,
-                        num_all_outputs,
-                        behavior_pre,
-                        behavior_post,
-                    );
-                    *state = self.substitute_old_param_in_state(state, *idx, &result_exp);
+                    let write_exp = mk_write_of_for(self, j);
+                    *state = self.substitute_old_param_in_state(state, idx, &write_exp);
                 }
             }
         }
 
-        // Emit ensures_of for state chaining in two cases:
-        // 1. Void calls (no dests, no &mut): ensures_of is the only postcondition
-        // 2. Non-void calls where result_of vanished (return value discarded):
-        //    ensures_of<f>(args, result_of<f>(args)) preserves the post-label
-        //    so downstream behavioral predicates can reference the intermediate state.
-        if dests.is_empty() && mut_ref_srcs.is_empty() {
-            // Void call: ensures_of<f>(args)
+        // For void callees: `ensures_of<f>(args)` is the only postcondition.
+        // For non-void with discarded result: anchor with `ensures_of<f>(args,
+        // result_of<f>(args)...)` so downstream predicates can reference
+        // the intermediate state.
+        if num_declared_results == 0 {
             let ensures_of = self.mk_ensures_of_with_state(
                 fun_exp.clone(),
                 args.clone(),
@@ -3448,32 +3605,25 @@ impl<'env> SpecInferenceAnalyzer<'env> {
             );
             state.add_ensures(ensures_of);
         } else if !any_dest_referenced {
-            {
-                // Result discarded: emit `ensures_of<f>(args, result_of<f>(args)...)`.
-                // The trailing slots cover both explicit results and post-states of
-                // any `&mut` inputs — together they form the canonical ensures-of
-                // shape. The model-level rewriter (`augment_behavior_call`) leaves
-                // this canonical form unchanged.
-                let mut ensures_args = args.clone();
-                for i in 0..num_all_outputs {
-                    ensures_args.push(self.mk_result_of_at_with_state(
-                        fun_exp.clone(),
-                        args.clone(),
-                        &extended_result_type,
-                        i,
-                        num_all_outputs,
-                        behavior_pre,
-                        behavior_post,
-                    ));
-                }
-                let ensures_of = self.mk_ensures_of_with_state(
+            let mut ensures_args = args.clone();
+            for i in 0..num_declared_results {
+                ensures_args.push(self.mk_result_of_at_with_state(
                     fun_exp.clone(),
-                    ensures_args,
+                    args.clone(),
+                    result_type,
+                    i,
+                    num_declared_results,
                     behavior_pre,
                     behavior_post,
-                );
-                state.add_ensures(ensures_of);
+                ));
             }
+            let ensures_of = self.mk_ensures_of_with_state(
+                fun_exp.clone(),
+                ensures_args,
+                behavior_pre,
+                behavior_post,
+            );
+            state.add_ensures(ensures_of);
         }
 
         let aborts = self.mk_aborts_of_with_state(fun_exp, args, aborts_pre, aborts_post);
@@ -3865,6 +4015,200 @@ impl<'env> SpecInferenceAnalyzer<'env> {
 
             StripOldLabels.rewrite_exp(e.clone())
         })
+    }
+
+    /// Rewrite the WP-internal `WriteOf(j)` carrier into user-facing
+    /// behavioral predicates. WP emits two shapes:
+    ///   (a) `Eq(lhs, write_of(...))` (possibly wrapped in
+    ///       `Implies(WellFormed, ...)`) for each caller-`&mut` captured on
+    ///       a normal return — `lhs` is the procedure-level post-state name.
+    ///   (b) `write_of(...)` nested inside other expressions (body-borrow
+    ///       `&mut` sources).
+    ///
+    /// Phases:
+    ///   1. Collect `(write_of, lhs_path)` bindings (sees through
+    ///      `update_field` layers).
+    ///   2. For each call site with a binding for every `&mut` slot, emit
+    ///      `ensures_of<f>(args, ..dests, ..post_state_slots)` in canonical
+    ///      form. Sites missing a binding are skipped (the substitution
+    ///      below is still sound but loses the `&mut` post-state binding).
+    ///   3. Substitute remaining `write_of`s with the bound `lhs` (or
+    ///      `strip_olds(args[mut_pos(j)])` as a fallback) and drop
+    ///      tautologies.
+    fn eliminate_write_of(&self, state: &mut WPState) {
+        let env = self.global_env();
+
+        let bindings = collect_write_of_bindings(env, &state.ensures);
+
+        let mut sites: Vec<(Exp, Vec<Exp>, MemoryRange)> = Vec::new();
+        for (write_of_call, _lhs) in &bindings {
+            let ExpData::Call(_, AstOp::Behavior(_, range), bp_args) = write_of_call.as_ref()
+            else {
+                continue;
+            };
+            if bp_args.is_empty() {
+                continue;
+            }
+            let fun_exp = bp_args[0].clone();
+            let args = &bp_args[1..];
+            let args_natural: Vec<Exp> = args.iter().map(strip_all_olds).collect();
+            if !sites
+                .iter()
+                .any(|(f, a, _)| calls_match(f, a, &fun_exp, &args_natural))
+            {
+                sites.push((fun_exp, args_natural, range.clone()));
+            }
+        }
+
+        let mut to_remove: BTreeSet<usize> = BTreeSet::new();
+        let mut to_add: Vec<Exp> = Vec::new();
+
+        for (fun_exp, args_natural, range) in &sites {
+            let num_inputs = args_natural.len();
+            let fun_type = env.get_node_type(fun_exp.node_id());
+            let Type::Fun(arg_ty_box, result_ty, _) = fun_type else {
+                continue;
+            };
+            let arg_types: Vec<Type> = arg_ty_box.flatten();
+            let result_type: Type = (*result_ty).clone();
+            let declared_result_types: Vec<Type> = result_type.clone().flatten();
+            let num_declared_results = declared_result_types.len();
+            let is_void = num_declared_results == 0;
+
+            // One binding-LHS per `&mut` slot — otherwise we can't fill
+            // the canonical's post-state slots.
+            let mut post_state_slots: Vec<Option<Exp>> = Vec::new();
+            for (k, t) in arg_types.iter().enumerate() {
+                if !t.is_mutable_reference() {
+                    continue;
+                }
+                let mut_ref_idx = arg_types[..k]
+                    .iter()
+                    .filter(|ty| ty.is_mutable_reference())
+                    .count();
+                let lhs = bindings.iter().find_map(|(wo_call, lhs)| {
+                    use move_model::ast::BehaviorKind;
+                    let ExpData::Call(_, AstOp::Behavior(BehaviorKind::WriteOf(j), _), bp_args) =
+                        wo_call.as_ref()
+                    else {
+                        return None;
+                    };
+                    if *j != mut_ref_idx {
+                        return None;
+                    }
+                    if bp_args.is_empty() {
+                        return None;
+                    }
+                    let wo_fun = &bp_args[0];
+                    let wo_args_natural: Vec<Exp> =
+                        bp_args[1..].iter().map(strip_all_olds).collect();
+                    if !calls_match(fun_exp, args_natural, wo_fun, &wo_args_natural) {
+                        return None;
+                    }
+                    Some(lhs.clone())
+                });
+                post_state_slots.push(lhs);
+            }
+            if post_state_slots.iter().any(Option::is_none) {
+                continue;
+            }
+            let post_state_slots: Vec<Exp> =
+                post_state_slots.into_iter().map(Option::unwrap).collect();
+
+            // Walk clauses once, collecting both (a) explicit `dest`s from
+            // sibling `result_of` clauses and (b) any void state-anchor
+            // candidates for this site. Removal is committed only below,
+            // *after* we have decided to build a replacement canonical —
+            // never leave an anchor removed without a replacement.
+            let mut dests_by_idx: BTreeMap<usize, Exp> = BTreeMap::new();
+            let mut anchors_for_site: Vec<usize> = Vec::new();
+            for (idx, clause) in state.ensures.iter().enumerate() {
+                if let Some((dest, output_idx, fun2, args2, _)) = extract_result_of_clause(clause) {
+                    let args2_natural: Vec<Exp> = args2.iter().map(strip_all_olds).collect();
+                    if calls_match(fun_exp, args_natural, &fun2, &args2_natural) {
+                        dests_by_idx.insert(output_idx, dest);
+                    }
+                } else if let Some((fun2, args2, _)) = extract_top_ensures_of_clause(clause) {
+                    let args2_natural: Vec<Exp> = args2.iter().map(strip_all_olds).collect();
+                    if calls_match(fun_exp, args_natural, &fun2, &args2_natural)
+                        && args2.len() == num_inputs
+                    {
+                        anchors_for_site.push(idx);
+                    }
+                }
+            }
+
+            // Non-void calls need at least one captured `dest` to anchor
+            // on; otherwise leave any discarded-result anchor in place.
+            let has_result_of = !dests_by_idx.is_empty();
+            if !is_void && !has_result_of {
+                continue;
+            }
+
+            // Fill every declared result slot — uncaptured ones become
+            // synthesized `result_of<f>(...)` projections so the canonical
+            // keeps the full declared-result arity.
+            let mut dests: Vec<Exp> = Vec::with_capacity(num_declared_results);
+            for i in 0..num_declared_results {
+                if let Some(d) = dests_by_idx.remove(&i) {
+                    dests.push(d);
+                } else {
+                    dests.push(self.mk_result_of_at_with_state(
+                        fun_exp.clone(),
+                        args_natural.clone(),
+                        &result_type,
+                        i,
+                        num_declared_results,
+                        range.pre,
+                        range.post,
+                    ));
+                }
+            }
+
+            let mut canonical_args: Vec<Exp> =
+                Vec::with_capacity(1 + args_natural.len() + dests.len() + post_state_slots.len());
+            canonical_args.push(fun_exp.clone());
+            canonical_args.extend(args_natural.iter().cloned());
+            canonical_args.extend(dests);
+            canonical_args.extend(post_state_slots);
+            let bool_ty = Type::Primitive(PrimitiveType::Bool);
+            let new_id = self.new_node(bool_ty, None);
+            let canonical = ExpData::Call(
+                new_id,
+                AstOp::Behavior(move_model::ast::BehaviorKind::EnsuresOf, range.clone()),
+                canonical_args,
+            )
+            .into_exp();
+            to_add.push(canonical);
+            to_remove.extend(anchors_for_site);
+        }
+
+        let mut new_ensures: Vec<Exp> = Vec::new();
+        for (idx, clause) in std::mem::take(&mut state.ensures).into_iter().enumerate() {
+            if !to_remove.contains(&idx) {
+                new_ensures.push(clause);
+            }
+        }
+        new_ensures.extend(to_add);
+        state.ensures = new_ensures;
+
+        state.ensures = state
+            .ensures
+            .iter()
+            .map(|e| substitute_write_of_with_natural(env, e, &bindings))
+            .collect();
+        state.aborts = state
+            .aborts
+            .iter()
+            .map(|e| substitute_write_of_with_natural(env, e, &bindings))
+            .collect();
+        state.direct_modifies = state
+            .direct_modifies
+            .iter()
+            .map(|e| substitute_write_of_with_natural(env, e, &bindings))
+            .collect();
+
+        state.ensures.retain(|e| !is_trivially_true(e));
     }
 
     /// Substitute memory labels in an expression.

--- a/third_party/move/move-prover/doc/higher-order-paper-26/examples/sources/followed_by.move
+++ b/third_party/move/move-prover/doc/higher-order-paper-26/examples/sources/followed_by.move
@@ -33,8 +33,11 @@ module 0x42::followed_by {
     spec followed_by {
         // f can abort on the input.
         aborts_if aborts_of<f>(x);
-        // g can abort on the intermediate value produced by f.
-        aborts_if aborts_of<g>(result_of<f>(x));
+        // g can abort on the intermediate value produced by f. Express
+        // this as: there exists an intermediate value `v` reachable from
+        // `x` via `f`, on which `g` aborts.
+        aborts_if exists v: Acc:
+            ensures_of<f>(x, v) && aborts_of<g>(v);
         ensures exists S in *:
             (..S |~ ensures_of<f>(old(x), x)) &&
             (S.. |~ ensures_of<g>(old(x), x));

--- a/third_party/move/move-prover/tests/inference/calculator.exp.move
+++ b/third_party/move/move-prover/tests/inference/calculator.exp.move
@@ -35,44 +35,62 @@ module 0x66::calculator {
         use 0x1::signer;
         pragma opaque = true;
         modifies State[signer::address_of(s)];
-        let address_of_0 = signer::address_of(s);
-        ensures [inferred] (old(State[address_of_0]) is Continuation) ==> {
-            let a = State::Value(S1..S6 |~ result_of<old(State[address_of_0]).Continuation.0>(input.0));
-            S6.. |~ publish<State>(address_of_0, a)
+        let address_of_ = signer::address_of(s);
+        ensures [inferred] (old(State[address_of_]) is Continuation) ==> {
+            let a = State::Value(S1..S6 |~ result_of<old(State[address_of_]).Continuation.0>(input.0));
+            S6.. |~ publish<State>(address_of_, a)
         };
-        ensures [inferred] (old(State[address_of_0]) is Value) && (input is Number) ==> (S1.. |~ publish<State>(address_of_0, State::Value(input.0)));
-        ensures [inferred] (old(State[address_of_0]) is Value) && (input is Add) ==> {
+        ensures [inferred] (old(State[address_of_]) is Value) && (input is Number) ==> (S1.. |~ publish<State>(address_of_, State::Value(input.0)));
+        ensures [inferred] (old(State[address_of_]) is Value) && (input is Add) ==> {
             let a = State::Continuation({
-                let b = old(State[address_of_0]).Value.0;
+                let b = old(State[address_of_]).Value.0;
                 |x| storable_add(b, x)
             });
-            S1.. |~ publish<State>(address_of_0, a)
+            S1.. |~ publish<State>(address_of_, a)
         };
-        ensures [inferred] (old(State[address_of_0]) is Value) && (input is Sub) ==> {
+        ensures [inferred] (old(State[address_of_]) is Value) && (input is Sub) ==> {
             let a = State::Continuation({
-                let b = old(State[address_of_0]).Value.0;
+                let b = old(State[address_of_]).Value.0;
                 |x| storable_sub(b, x)
             });
-            S1.. |~ publish<State>(address_of_0, a)
+            S1.. |~ publish<State>(address_of_, a)
         };
-        ensures [inferred] (old(State[address_of_0]) is Empty) && (input is Number) ==> (S1.. |~ publish<State>(address_of_0, State::Value(input.0)));
-        ensures [inferred] (old(State[address_of_0]) is Empty) && (input is Add | Sub) ==> {
-            let a = State::Value(S1..S6 |~ result_of<old(State[address_of_0]).Continuation.0>(input.0));
-            S6.. |~ publish<State>(address_of_0, a)
+        ensures [inferred] (old(State[address_of_]) is Empty) && (input is Number) ==> (S1.. |~ publish<State>(address_of_, State::Value(input.0)));
+        ensures [inferred] (old(State[address_of_]) is Empty) && (input is Add | Sub) ==> {
+            let a = State::Value(S1..S6 |~ result_of<old(State[address_of_]).Continuation.0>(input.0));
+            S6.. |~ publish<State>(address_of_, a)
         };
-        ensures [inferred] ..S1 |~ remove<State>(address_of_0);
-        aborts_if [inferred] (State[address_of_0] is Continuation) && (S6 |~ exists<State>(address_of_0));
-        aborts_if [inferred] (State[address_of_0] is Continuation) && (S1 |~ aborts_of<State[address_of_0].Continuation.0>(input.0));
-        aborts_if [inferred] (State[address_of_0] is Continuation) && (input is Add | Sub);
-        aborts_if [inferred] (State[address_of_0] is Value) && (S1 |~ (input is Number) && exists<State>(address_of_0));
-        aborts_if [inferred] (State[address_of_0] is Value) && (S1 |~ (input is Add) && exists<State>(address_of_0));
-        aborts_if [inferred] (State[address_of_0] is Value) && (S1 |~ (input is Sub) && exists<State>(address_of_0));
-        aborts_if [inferred] (State[address_of_0] is Empty) && (S1 |~ (input is Number) && exists<State>(address_of_0));
-        aborts_if [inferred] (input is Add | Sub) && ((State[address_of_0] is Empty) && (S6 |~ exists<State>(address_of_0)));
-        aborts_if [inferred] (input is Add | Sub) && ((State[address_of_0] is Empty) && (S1 |~ aborts_of<State[address_of_0].Continuation.0>(input.0)));
-        aborts_if [inferred] (State[address_of_0] is Empty) && (input is Add | Sub);
-        aborts_if [inferred] (input is Add | Sub) && (State[address_of_0] is Empty);
-        aborts_if [inferred] !exists<State>(address_of_0);
+        ensures [inferred] ..S1 |~ remove<State>(address_of_);
+        aborts_if [inferred] (State[address_of_] is Continuation) && (S6 |~ exists<State>(address_of_));
+        aborts_if [inferred] (State[address_of_] is Continuation) && (S1 |~ aborts_of<State[address_of_].Continuation.0>(input.0));
+        aborts_if [inferred] (State[address_of_] is Continuation) && (input is Add | Sub);
+        aborts_if [inferred] {
+            let a = S1 |~ exists<State>(address_of_);
+            (State[address_of_] is Value) && ((input is Number) && a)
+        };
+        aborts_if [inferred] {
+            let a = S1 |~ exists<State>(address_of_);
+            (State[address_of_] is Value) && ((input is Add) && a)
+        };
+        aborts_if [inferred] {
+            let a = S1 |~ exists<State>(address_of_);
+            (State[address_of_] is Value) && ((input is Sub) && a)
+        };
+        aborts_if [inferred] {
+            let a = S1 |~ exists<State>(address_of_);
+            (State[address_of_] is Empty) && ((input is Number) && a)
+        };
+        aborts_if [inferred] {
+            let a = S6 |~ exists<State>(address_of_);
+            (input is Add | Sub) && ((State[address_of_] is Empty) && a)
+        };
+        aborts_if [inferred] {
+            let a = S1 |~ aborts_of<State[address_of_].Continuation.0>(input.0);
+            (input is Add | Sub) && ((State[address_of_] is Empty) && a)
+        };
+        aborts_if [inferred] (State[address_of_] is Empty) && (input is Add | Sub);
+        aborts_if [inferred] (input is Add | Sub) && (State[address_of_] is Empty);
+        aborts_if [inferred] !exists<State>(address_of_);
         aborts_if [inferred] aborts_of<signer::address_of>(s);
     }
 
@@ -160,10 +178,10 @@ module 0x66::calculator {
     spec view(s: &signer): u64 {
         use 0x1::signer;
         pragma opaque = true;
-        let address_of_0 = signer::address_of(s);
-        ensures [inferred] result == State[address_of_0].Value.0;
-        aborts_if [inferred] State[address_of_0] is Empty | Continuation;
-        aborts_if [inferred] !exists<State>(address_of_0);
+        let address_of_ = signer::address_of(s);
+        ensures [inferred] result == State[address_of_].Value.0;
+        aborts_if [inferred] State[address_of_] is Empty | Continuation;
+        aborts_if [inferred] !exists<State>(address_of_);
         aborts_if [inferred] aborts_of<signer::address_of>(s);
     }
 

--- a/third_party/move/move-prover/tests/inference/chain_mut_ref.exp.move
+++ b/third_party/move/move-prover/tests/inference/chain_mut_ref.exp.move
@@ -85,23 +85,17 @@ module 0x42::chain_mut_ref {
     spec chain(self: &mut Pool, x: u64): u64 {
         pragma opaque = true;
         ensures [inferred] result == {
-            let (_t0,_t1) = {
-                let a = update_field(old(self), total, old(self).total + (..S1 |~ result_of<compute>(old(self), x)));
-                let b = ..S1 |~ result_of<compute>(old(self), x);
-                S1.. |~ result_of<update>(a, b)
-            };
-            _t0
+            let a = ..S1 |~ result_of<compute>(old(self), x);
+            S1.. |~ result_of<update>(update_field(old(self), total, old(self).total + a), a)
         };
-        ensures [inferred] self == {
-            let (_t0,_t1) = {
-                let a = update_field(old(self), total, old(self).total + (..S1 |~ result_of<compute>(old(self), x)));
-                let b = ..S1 |~ result_of<compute>(old(self), x);
-                S1.. |~ result_of<update>(a, b)
-            };
-            _t1
+        aborts_if [inferred] S1 |~ {
+            let a = ..S1 |~ result_of<compute>(self, x);
+            aborts_of<update>(update_field(self, total, self.total + a), a)
         };
-        aborts_if [inferred] S1 |~ aborts_of<update>(update_field(self, total, self.total + (..S1 |~ result_of<compute>(self, x))), ..S1 |~ result_of<compute>(self, x));
-        aborts_if [inferred] self.total + (..S1 |~ result_of<compute>(self, x)) > MAX_U64;
+        aborts_if [inferred] {
+            let a = ..S1 |~ result_of<compute>(self, x);
+            self.total + a > MAX_U64
+        };
         aborts_if [inferred] aborts_of<compute>(self, x);
     }
 

--- a/third_party/move/move-prover/tests/inference/chained_opaque.exp.move
+++ b/third_party/move/move-prover/tests/inference/chained_opaque.exp.move
@@ -64,7 +64,10 @@ module 0x42::chained_opaque {
             let a = ..S1 |~ result_of<f1>(self, x);
             S1.. |~ result_of<f2>(self, a)
         };
-        aborts_if [inferred] S1 |~ aborts_of<f2>(self, ..S1 |~ result_of<f1>(self, x));
+        aborts_if [inferred] S1 |~ {
+            let a = ..S1 |~ result_of<f1>(self, x);
+            aborts_of<f2>(self, a)
+        };
         aborts_if [inferred] aborts_of<f1>(self, x);
     }
 

--- a/third_party/move/move-prover/tests/inference/loops.exp.move
+++ b/third_party/move/move-prover/tests/inference/loops.exp.move
@@ -193,12 +193,30 @@ module 0x42::loops {
             let a = update_field(old(Counter[addr]), value, old(Counter[addr]).value + 1);
             ..S1 |~ update<Counter>(addr, a)
         };
-        aborts_if [inferred] 3 < n && (S3 |~ global<Counter>(addr)).value == MAX_U64;
-        aborts_if [inferred] S3 |~ 3 < n && !exists<Counter>(addr);
-        aborts_if [inferred] 2 < n && (S2 |~ global<Counter>(addr)).value == MAX_U64;
-        aborts_if [inferred] S2 |~ 2 < n && !exists<Counter>(addr);
-        aborts_if [inferred] 1 < n && (S1 |~ global<Counter>(addr)).value == MAX_U64;
-        aborts_if [inferred] S1 |~ 1 < n && !exists<Counter>(addr);
+        aborts_if [inferred] {
+            let a = S3 |~ global<Counter>(addr);
+            3 < n && a.value == MAX_U64
+        };
+        aborts_if [inferred] {
+            let a = S3 |~ exists<Counter>(addr);
+            3 < n && !a
+        };
+        aborts_if [inferred] {
+            let a = S2 |~ global<Counter>(addr);
+            2 < n && a.value == MAX_U64
+        };
+        aborts_if [inferred] {
+            let a = S2 |~ exists<Counter>(addr);
+            2 < n && !a
+        };
+        aborts_if [inferred] {
+            let a = S1 |~ global<Counter>(addr);
+            1 < n && a.value == MAX_U64
+        };
+        aborts_if [inferred] {
+            let a = S1 |~ exists<Counter>(addr);
+            1 < n && !a
+        };
         aborts_if [inferred] 0 < n && Counter[addr].value == MAX_U64;
         aborts_if [inferred] 0 < n && !exists<Counter>(addr);
     }

--- a/third_party/move/move-prover/tests/inference/mut_ref_invariant.exp.move
+++ b/third_party/move/move-prover/tests/inference/mut_ref_invariant.exp.move
@@ -46,14 +46,7 @@ module 0x42::mut_ref_invariant {
     }
     spec caller(self: &mut Pool, x: u64): u64 {
         pragma opaque = true;
-        ensures [inferred] result == {
-            let (_t0,_t1) = result_of<f>(old(self), x);
-            _t0
-        };
-        ensures [inferred] self == {
-            let (_t0,_t1) = result_of<f>(old(self), x);
-            _t1
-        };
+        ensures [inferred] result == result_of<f>(old(self), x);
         aborts_if [inferred] aborts_of<f>(self, x);
     }
 

--- a/third_party/move/move-prover/tests/inference/mutations.exp.move
+++ b/third_party/move/move-prover/tests/inference/mutations.exp.move
@@ -342,8 +342,8 @@ module 0x42::mutations {
     }
     spec pass_ref_to_fn(p: &mut Point, val: u64) {
         pragma opaque = true;
-        ensures [inferred] p == update_field(old(p), x, result_of<write_to_ref>(old(p).x, val));
-        ensures [inferred] ensures_of<write_to_ref>(old(p).x, val, result_of<write_to_ref>(old(p).x, val));
+        ensures [inferred] p == update_field(old(p), x, p.x);
+        ensures [inferred] ensures_of<write_to_ref>(p.x, val, p.x);
         aborts_if [inferred] aborts_of<write_to_ref>(p.x, val);
     }
 
@@ -357,8 +357,8 @@ module 0x42::mutations {
     }
     spec create_pass_continue(p: Point, val: u64): Point {
         pragma opaque = true;
-        ensures [inferred] result == update_field(p, x, result_of<write_to_ref>(p.x, val));
-        ensures [inferred] ensures_of<write_to_ref>(p.x, val, result_of<write_to_ref>(p.x, val));
+        ensures [inferred] result == update_field(p, x, result.x);
+        ensures [inferred] ensures_of<write_to_ref>(p.x, val, result.x);
         aborts_if [inferred] aborts_of<write_to_ref>(p.x, val);
     }
 
@@ -385,14 +385,8 @@ module 0x42::mutations {
     }
     spec call_replace(r: &mut u64): u64 {
         pragma opaque = true;
-        ensures [inferred] result == {
-            let (_t0,_t1) = result_of<replace_ref>(old(r), 99);
-            _t0
-        };
-        ensures [inferred] r == {
-            let (_t0,_t1) = result_of<replace_ref>(old(r), 99);
-            _t1
-        };
+        ensures [inferred] result == result_of<replace_ref>(old(r), 99);
+        ensures [inferred] ensures_of<replace_ref>(r, 99, result, r);
         aborts_if [inferred] aborts_of<replace_ref>(r, 99);
     }
 
@@ -556,7 +550,10 @@ module 0x42::mutations {
             let a = update_field(old(Counter[addr]), value, old(Counter[addr]).value + 1);
             ..S1 |~ update<Counter>(addr, a)
         };
-        aborts_if [inferred] (S1 |~ global<Counter>(addr)).value == MAX_U64;
+        aborts_if [inferred] {
+            let a = S1 |~ global<Counter>(addr);
+            a.value == MAX_U64
+        };
         aborts_if [inferred] S1 |~ !exists<Counter>(addr);
         aborts_if [inferred] Counter[addr].value == MAX_U64;
         aborts_if [inferred] !exists<Counter>(addr);
@@ -653,8 +650,14 @@ module 0x42::mutations {
             let a = update_field(old(Counter[a2]), value, v1);
             ..S1 |~ update<Counter>(a2, a)
         };
-        aborts_if [inferred] S1 |~ cond && !exists<Counter>(a2);
-        aborts_if [inferred] S1 |~ !cond && !exists<Counter>(a1);
+        aborts_if [inferred] {
+            let a = S1 |~ exists<Counter>(a2);
+            cond && !a
+        };
+        aborts_if [inferred] {
+            let a = S1 |~ exists<Counter>(a1);
+            !cond && !a
+        };
         aborts_if [inferred] cond && !exists<Counter>(a1);
         aborts_if [inferred] !cond && !exists<Counter>(a2);
     }
@@ -689,10 +692,22 @@ module 0x42::mutations {
             let a = update_field(old(Counter[a2]), value, old(Counter[a2]).value + v1);
             ..S1 |~ update<Counter>(a2, a)
         };
-        aborts_if [inferred] cond && (S1 |~ global<Counter>(a2)).value + v2 > MAX_U64;
-        aborts_if [inferred] S1 |~ cond && !exists<Counter>(a2);
-        aborts_if [inferred] !cond && (S1 |~ global<Counter>(a1)).value + v2 > MAX_U64;
-        aborts_if [inferred] S1 |~ !cond && !exists<Counter>(a1);
+        aborts_if [inferred] {
+            let a = S1 |~ global<Counter>(a2);
+            cond && a.value + v2 > MAX_U64
+        };
+        aborts_if [inferred] {
+            let a = S1 |~ exists<Counter>(a2);
+            cond && !a
+        };
+        aborts_if [inferred] {
+            let a = S1 |~ global<Counter>(a1);
+            !cond && a.value + v2 > MAX_U64
+        };
+        aborts_if [inferred] {
+            let a = S1 |~ exists<Counter>(a1);
+            !cond && !a
+        };
         aborts_if [inferred] cond && Counter[a1].value + v1 > MAX_U64;
         aborts_if [inferred] cond && !exists<Counter>(a1);
         aborts_if [inferred] !cond && Counter[a2].value + v1 > MAX_U64;

--- a/third_party/move/move-prover/tests/inference/ref_result_pred.exp.move
+++ b/third_party/move/move-prover/tests/inference/ref_result_pred.exp.move
@@ -31,14 +31,8 @@ module 0x42::ref_result_pred {
     }
     spec caller(self: &mut Data): u64 {
         pragma opaque = true;
-        ensures [inferred] result == {
-            let (_t0,_t1) = result_of<peek>(old(self));
-            _t0
-        };
-        ensures [inferred] self == {
-            let (_t0,_t1) = result_of<peek>(old(self));
-            _t1
-        };
+        ensures [inferred] result == result_of<peek>(old(self));
+        ensures [inferred] ensures_of<peek>(self, result, self);
         aborts_if [inferred] aborts_of<peek>(self);
     }
 

--- a/third_party/move/move-prover/tests/inference/sequential_mutation.exp.move
+++ b/third_party/move/move-prover/tests/inference/sequential_mutation.exp.move
@@ -43,13 +43,9 @@ module 0x42::sequential_mutation {
     }
     spec add_twice(c: &mut Counter, a: u64, b: u64) {
         pragma opaque = true;
-        ensures [inferred] S1.. |~ c == result_of<add_amount>(..S1 |~ result_of<add_amount>(old(c), a), b);
-        ensures [inferred] S1.. |~ ensures_of<add_amount>(..S1 |~ result_of<add_amount>(old(c), a), b, {
-            let a_1 = ..S1 |~ result_of<add_amount>(old(c), a);
-            S1.. |~ result_of<add_amount>(a_1, b)
-        });
-        ensures [inferred] ..S1 |~ ensures_of<add_amount>(old(c), a, ..S1 |~ result_of<add_amount>(old(c), a));
-        aborts_if [inferred] S1 |~ aborts_of<add_amount>(..S1 |~ result_of<add_amount>(c, a), b);
+        ensures [inferred] ..S1 |~ ensures_of<add_amount>(old(c), a);
+        ensures [inferred] S1.. |~ ensures_of<add_amount>(c, b, c);
+        aborts_if [inferred] S1 |~ aborts_of<add_amount>(c, b);
         aborts_if [inferred] aborts_of<add_amount>(c, a);
     }
 

--- a/third_party/move/move-prover/tests/inference/shadowed_behavior_pred.exp.move
+++ b/third_party/move/move-prover/tests/inference/shadowed_behavior_pred.exp.move
@@ -40,8 +40,7 @@ module 0x42::shadowed_behavior_pred {
         pragma verify = false;
         let set_value = 0u64; // shadows the function 'set_value'
         pragma opaque = true;
-        ensures [inferred] s == result_of<0x42::shadowed_behavior_pred::set_value>(old(s), v);
-        ensures [inferred] ensures_of<0x42::shadowed_behavior_pred::set_value>(old(s), v, result_of<0x42::shadowed_behavior_pred::set_value>(old(s), v));
+        ensures [inferred] ensures_of<0x42::shadowed_behavior_pred::set_value>(s, v, s);
         aborts_if [inferred] aborts_of<0x42::shadowed_behavior_pred::set_value>(s, v);
     }
 }

--- a/third_party/move/move-prover/tests/inference/spec_companion.exp.move
+++ b/third_party/move/move-prover/tests/inference/spec_companion.exp.move
@@ -30,9 +30,8 @@ module 0x42::spec_companion {
     }
     spec caller(self: &mut Counter): u64 {
         pragma opaque = true;
-        ensures [inferred] result == result_of<increment>(old(self)).value;
-        ensures [inferred] self == result_of<increment>(old(self));
-        ensures [inferred] ensures_of<increment>(old(self), result_of<increment>(old(self)));
+        ensures [inferred] result == self.value;
+        ensures [inferred] ensures_of<increment>(self, self);
         aborts_if [inferred] aborts_of<increment>(self);
     }
 

--- a/third_party/move/move-prover/tests/inference/state_labels.exp.move
+++ b/third_party/move/move-prover/tests/inference/state_labels.exp.move
@@ -312,7 +312,10 @@ module 0x42::state_labels {
         pragma opaque = true;
         modifies Resource[addr1];
         ensures [inferred] result == (S1.. |~ result_of<read_resource>(addr2));
-        ensures [inferred] ..S1 |~ ensures_of<remove_resource>(addr1, ..S1 |~ result_of<remove_resource>(addr1));
+        ensures [inferred] ..S1 |~ {
+            let a = ..S1 |~ result_of<remove_resource>(addr1);
+            ensures_of<remove_resource>(addr1, a)
+        };
         aborts_if [inferred] S1 |~ aborts_of<read_resource>(addr2);
         aborts_if [inferred] aborts_of<remove_resource>(addr1);
     }
@@ -402,11 +405,17 @@ module 0x42::state_labels {
             };
             S2.. |~ result_of<swap_value>(a3, a)
         };
-        aborts_if [inferred] S2 |~ aborts_of<swap_value>(a3, {
+        aborts_if [inferred] S2 |~ {
+            let a = {
+                let b = ..S1 |~ result_of<swap_value>(a1, 0);
+                S1..S2 |~ result_of<swap_value>(a2, b)
+            };
+            aborts_of<swap_value>(a3, a)
+        };
+        aborts_if [inferred] S1 |~ {
             let a = ..S1 |~ result_of<swap_value>(a1, 0);
-            S1..S2 |~ result_of<swap_value>(a2, a)
-        });
-        aborts_if [inferred] S1 |~ aborts_of<swap_value>(a2, ..S1 |~ result_of<swap_value>(a1, 0));
+            aborts_of<swap_value>(a2, a)
+        };
         aborts_if [inferred] aborts_of<swap_value>(a1, 0);
     }
 

--- a/third_party/move/move-prover/tests/inference/vault.exp.move
+++ b/third_party/move/move-prover/tests/inference/vault.exp.move
@@ -35,28 +35,40 @@ module 0x42::vault {
     spec harvest {
         let store_addr = object::object_address(Vault[vault_obj.object_address()].store);
         ensures FungibleStore[store_addr].balance >= old(FungibleStore[store_addr].balance);
-        let object_address_0 = object::object_address(vault_obj);
-        ensures [inferred] S3.. |~ ensures_of<fungible_asset::deposit<fungible_asset::FungibleStore>>(Vault[object_address_0].store, {
+        let object_address_ = object::object_address(vault_obj);
+        ensures [inferred] S3.. |~ {
             let a = {
-                let b = ..S1 |~ result_of<fungible_asset::balance<fungible_asset::FungibleStore>>(Vault[object_address_0].store);
-                S1..S2 |~ result_of<fungible_asset::withdraw<fungible_asset::FungibleStore>>(caller, Vault[object_address_0].store, b)
+                let b = {
+                    let c = ..S1 |~ result_of<fungible_asset::balance<fungible_asset::FungibleStore>>(Vault[object_address_].store);
+                    S1..S2 |~ result_of<fungible_asset::withdraw<fungible_asset::FungibleStore>>(caller, Vault[object_address_].store, c)
+                };
+                S2..S3 |~ result_of<Vault[object_address_].strategy.0>(b)
             };
-            S2..S3 |~ result_of<Vault[object_address_0].strategy.0>(a)
-        });
-        aborts_if [inferred] S3 |~ aborts_of<fungible_asset::deposit<fungible_asset::FungibleStore>>(Vault[object_address_0].store, {
+            ensures_of<fungible_asset::deposit<fungible_asset::FungibleStore>>(Vault[object_address_].store, a)
+        };
+        aborts_if [inferred] S3 |~ {
             let a = {
-                let b = ..S1 |~ result_of<fungible_asset::balance<fungible_asset::FungibleStore>>(Vault[object_address_0].store);
-                S1..S2 |~ result_of<fungible_asset::withdraw<fungible_asset::FungibleStore>>(caller, Vault[object_address_0].store, b)
+                let b = {
+                    let c = ..S1 |~ result_of<fungible_asset::balance<fungible_asset::FungibleStore>>(Vault[object_address_].store);
+                    S1..S2 |~ result_of<fungible_asset::withdraw<fungible_asset::FungibleStore>>(caller, Vault[object_address_].store, c)
+                };
+                S2..S3 |~ result_of<Vault[object_address_].strategy.0>(b)
             };
-            S2..S3 |~ result_of<Vault[object_address_0].strategy.0>(a)
-        });
-        aborts_if [inferred] S2 |~ aborts_of<Vault[object_address_0].strategy.0>({
-            let a = ..S1 |~ result_of<fungible_asset::balance<fungible_asset::FungibleStore>>(Vault[object_address_0].store);
-            S1..S2 |~ result_of<fungible_asset::withdraw<fungible_asset::FungibleStore>>(caller, Vault[object_address_0].store, a)
-        });
-        aborts_if [inferred] S1 |~ aborts_of<fungible_asset::withdraw<fungible_asset::FungibleStore>>(caller, Vault[object_address_0].store, ..S1 |~ result_of<fungible_asset::balance<fungible_asset::FungibleStore>>(Vault[object_address_0].store));
-        aborts_if [inferred] aborts_of<fungible_asset::balance<fungible_asset::FungibleStore>>(Vault[object_address_0].store);
-        aborts_if [inferred] !exists<Vault>(object_address_0);
+            aborts_of<fungible_asset::deposit<fungible_asset::FungibleStore>>(Vault[object_address_].store, a)
+        };
+        aborts_if [inferred] S2 |~ {
+            let a = {
+                let b = ..S1 |~ result_of<fungible_asset::balance<fungible_asset::FungibleStore>>(Vault[object_address_].store);
+                S1..S2 |~ result_of<fungible_asset::withdraw<fungible_asset::FungibleStore>>(caller, Vault[object_address_].store, b)
+            };
+            aborts_of<Vault[object_address_].strategy.0>(a)
+        };
+        aborts_if [inferred] S1 |~ {
+            let a = ..S1 |~ result_of<fungible_asset::balance<fungible_asset::FungibleStore>>(Vault[object_address_].store);
+            aborts_of<fungible_asset::withdraw<fungible_asset::FungibleStore>>(caller, Vault[object_address_].store, a)
+        };
+        aborts_if [inferred] aborts_of<fungible_asset::balance<fungible_asset::FungibleStore>>(Vault[object_address_].store);
+        aborts_if [inferred] !exists<Vault>(object_address_);
         aborts_if [inferred] aborts_of<object::object_address<Vault>>(vault_obj);
     }
 }

--- a/third_party/move/move-prover/tests/sources/functional/closures/behavioral_results.move
+++ b/third_party/move/move-prover/tests/sources/functional/closures/behavioral_results.move
@@ -44,20 +44,18 @@ module 0x42::behavioral_results {
 
     // ===== Tests for mutable reference parameters =====
     //
-    // The user passes `&mut T` arguments directly (no manual `old(...)`
-    // wrapping or explicit post-state args). The model-level rewriter wraps
-    // mut-ref inputs in `old(...)` and (for `ensures_of`) appends post-state
-    // clones automatically; the Boogie translator emits the canonical
-    // pre-state / explicit-result / post-state slots.
-    //
-    // `result_of<f>` keeps its full return shape: explicit results followed
-    // by post-state values of any `&mut` parameters.
+    // `&mut T` arguments appear exactly once in a behavioral-predicate call;
+    // the Boogie backend handles the in/out split by emitting pre-state into
+    // the input slot and the live (post-state) form into the matching
+    // `ensures_of` post slot. `result_of<f>` returns only `f`'s declared
+    // return type and is only valid on non-void callees; for the post-state
+    // of a `&mut` argument, use `ensures_of<f>(x, result)` as a relation.
 
-    // Test 6: result_of with void function that has mutable ref param
-    // f returns () but modifies x, so result_of returns just the modified value (not a tuple)
+    // Test 6: void callee with `&mut` param — `result_of` is invalid here,
+    // so use `ensures_of` directly to relate pre-/post-state.
     fun apply_void_mut(f: |&mut u64|, x: &mut u64) { f(x) }
     spec apply_void_mut {
-        ensures x == result_of<f>(x);
+        ensures ensures_of<f>(x);
     }
 
     // Test 7: ensures_of with mutable reference parameter
@@ -66,49 +64,79 @@ module 0x42::behavioral_results {
         ensures ensures_of<f>(x, result);
     }
 
-    // Test 7b: same as Test 7 but with an explicit `old(...)` on the
-    // `&mut` arg. The augmenter must still add the post-state slot so
-    // the canonical form reaches Boogie with arity 4.
-    fun test_ensures_mut_old(f: |&mut u64| u64, x: &mut u64): u64 { f(x) }
-    spec test_ensures_mut_old {
-        ensures ensures_of<f>(old(x), result);
-    }
-
-    // Test 8: result_of with mut ref returning a value - using ensures_of to verify
+    // Test 8: result_of returning the declared scalar return of a `|&mut T| R`
+    // closure — `x` appears only once on the right-hand side, as the
+    // pre-state input.
     fun apply_mut(f: |&mut u64| u64, x: &mut u64): u64 { f(x) }
     spec apply_mut {
+        ensures result == result_of<f>(x);
         ensures ensures_of<f>(x, result);
     }
 
-    // Test 9: result_of with function returning value AND modifying &mut param
-    // result_of returns (explicit_result, modified_x) tuple, compared via tuple equality
-    fun apply_mut_result(f: |&mut u64| u64, x: &mut u64): u64 { f(x) }
-    spec apply_mut_result {
-        ensures (result, x) == result_of<f>(x);
+    // Test 9: symmetric form combining a scalar `result_of` postcondition
+    // with `ensures_of` for the `&mut` post-state constraint.
+    fun apply_mut_sym(f: |&mut u64| u64, x: &mut u64): u64 { f(x) }
+    spec apply_mut_sym {
+        ensures result == result_of<f>(x);
+        ensures ensures_of<f>(x, result);
     }
 
-    // Test 10: result_of tuple with component extraction via let expression
-    fun apply_mut_extract(f: |&mut u64| u64, x: &mut u64): u64 { f(x) }
-    spec apply_mut_extract {
-        ensures result == {let (r, _p) = result_of<f>(x); r};
-        ensures x == {let (_r, p) = result_of<f>(x); p};
-    }
-
-    // Test 11: result_of with mixed return + &mut, using let to extract and use in expression
-    fun apply_mut_arith(f: |&mut u64| u64, x: &mut u64): u64 { f(x) }
-    spec apply_mut_arith {
-        ensures result + x == {let (r, p) = result_of<f>(x); r + p};
-    }
-
-    // Test 12: chained calls to a |&mut u64| closure expressed via state-label
-    // composition. `..S |~ ensures_of<f>(x)` says f transforms `old(x)` into
-    // the value at S; `S.. |~ ensures_of<f>(x)` says f transforms that value
-    // into the final `x`. The intermediate state S is bound by `exists S in *`.
+    // Test 10: chained calls to a `|&mut u64|` closure expressed via
+    // state-label composition. `..S |~ ensures_of<f>(x)` says `f` transforms
+    // `old(x)` into the value at `S`; `S.. |~ ensures_of<f>(x)` says `f`
+    // transforms that value into the final `x`. The intermediate state `S`
+    // is bound by `exists S in *`.
     fun apply_twice(f: |&mut u64| has copy, x: &mut u64) { f(x); f(x) }
     spec apply_twice {
         ensures exists S in *:
             (..S |~ ensures_of<f>(x)) &&
             (S.. |~ ensures_of<f>(x));
+    }
+
+    // Test 11: canonical-form `ensures_of` with an explicit post-state slot.
+    // Equivalent to Test 9 — both express the same pre/post relation; the
+    // parser accepts either the minimum form `ensures_of<f>(x, r)` (Test 9)
+    // or the canonical form `ensures_of<f>(x_pre, r, x_post)` (this test).
+    fun apply_mut_canonical(f: |&mut u64| u64, x: &mut u64): u64 { f(x) }
+    spec apply_mut_canonical {
+        ensures result == result_of<f>(x);
+        // Three args after `f`: pre-state of `x`, the result, post-state of `x`.
+        ensures ensures_of<f>(old(x), result, x);
+    }
+
+    // Test 12: two `&mut` parameters. `result_of<f>(p, q)` returns the
+    // declared `u64` return; `ensures_of<f>(p, q, result)` constrains the
+    // pre/post relation for both `&mut` slots simultaneously.
+    fun apply_two_mut(f: |&mut u64, &mut u64| u64, p: &mut u64, q: &mut u64): u64 {
+        f(p, q)
+    }
+    spec apply_two_mut {
+        ensures result == result_of<f>(p, q);
+        ensures ensures_of<f>(p, q, result);
+    }
+
+    // Test 13: multi-return closure plus `&mut`. `result_of<f>(x)` returns
+    // the declared 2-tuple `(u64, u64)`; the Boogie backend extracts the
+    // declared-results sub-tuple from the extended Skolem (which also
+    // carries the `&mut` post-state). The spec compares the procedure's
+    // two return values to the projected components.
+    fun apply_mut_multi(f: |&mut u64| (u64, u64), x: &mut u64): (u64, u64) { f(x) }
+    spec apply_mut_multi {
+        ensures (result_1, result_2) == result_of<f>(x);
+    }
+
+    // Test 14: labeled subexpression inside a quantifier body that
+    // references the bound variable. Clause-level CSE must not hoist
+    // `..S |~ result_of<g>(i)` outside the quantifier — `i` would no
+    // longer be in scope at the let-binding site.
+    fun query_at(g: |u64| u64, n: u64): bool {
+        let _ = g(0);
+        n > 0
+    }
+    spec query_at {
+        ensures result == (n > 0);
+        ensures forall i: u64 where i < n:
+            result_of<g>(i) >= 0;
     }
 
 }

--- a/third_party/move/move-prover/tests/sources/functional/closures/bp_bytecode_natives.exp
+++ b/third_party/move/move-prover/tests/sources/functional/closures/bp_bytecode_natives.exp
@@ -42,55 +42,55 @@ error: behavioral predicates are not supported on `std::vector::push_back` — u
    │                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: behavioral predicates are not supported on `std::vector::push_back` — use the spec language directly (e.g. write `len(v)` instead of `result_of<vector::length>(v)`, `v[i]` instead of `result_of<vector::borrow>(v, i)`, `!in_range(v, i)` instead of `aborts_of<vector::borrow>(v, i)`)
-   ┌─ tests/sources/functional/closures/bp_bytecode_natives.move:90:17
+   ┌─ tests/sources/functional/closures/bp_bytecode_natives.move:91:17
    │
-90 │         ensures ensures_of<vector::push_back<T>>(old(v), e, v);
-   │                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+91 │         ensures ensures_of<vector::push_back<T>>(v, e);
+   │                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: behavioral predicates are not supported on `std::vector::pop_back` — use the spec language directly (e.g. write `len(v)` instead of `result_of<vector::length>(v)`, `v[i]` instead of `result_of<vector::borrow>(v, i)`, `!in_range(v, i)` instead of `aborts_of<vector::borrow>(v, i)`)
-    ┌─ tests/sources/functional/closures/bp_bytecode_natives.move:101:19
+    ┌─ tests/sources/functional/closures/bp_bytecode_natives.move:102:19
     │
-101 │         aborts_if aborts_of<vector::pop_back<T>>(v);
+102 │         aborts_if aborts_of<vector::pop_back<T>>(v);
     │                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: behavioral predicates are not supported on `std::vector::pop_back` — use the spec language directly (e.g. write `len(v)` instead of `result_of<vector::length>(v)`, `v[i]` instead of `result_of<vector::borrow>(v, i)`, `!in_range(v, i)` instead of `aborts_of<vector::borrow>(v, i)`)
-    ┌─ tests/sources/functional/closures/bp_bytecode_natives.move:108:19
+    ┌─ tests/sources/functional/closures/bp_bytecode_natives.move:109:19
     │
-108 │         requires !aborts_of<vector::pop_back<T>>(v);
+109 │         requires !aborts_of<vector::pop_back<T>>(v);
     │                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: behavioral predicates are not supported on `std::vector::destroy_empty` — use the spec language directly (e.g. write `len(v)` instead of `result_of<vector::length>(v)`, `v[i]` instead of `result_of<vector::borrow>(v, i)`, `!in_range(v, i)` instead of `aborts_of<vector::borrow>(v, i)`)
-    ┌─ tests/sources/functional/closures/bp_bytecode_natives.move:120:19
+    ┌─ tests/sources/functional/closures/bp_bytecode_natives.move:121:19
     │
-120 │         aborts_if aborts_of<vector::destroy_empty<T>>(v);
+121 │         aborts_if aborts_of<vector::destroy_empty<T>>(v);
     │                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: behavioral predicates are not supported on `std::vector::swap` — use the spec language directly (e.g. write `len(v)` instead of `result_of<vector::length>(v)`, `v[i]` instead of `result_of<vector::borrow>(v, i)`, `!in_range(v, i)` instead of `aborts_of<vector::borrow>(v, i)`)
-    ┌─ tests/sources/functional/closures/bp_bytecode_natives.move:131:19
+    ┌─ tests/sources/functional/closures/bp_bytecode_natives.move:132:19
     │
-131 │         aborts_if aborts_of<vector::swap<T>>(v, i, j);
+132 │         aborts_if aborts_of<vector::swap<T>>(v, i, j);
     │                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: behavioral predicates are not supported on `std::vector::singleton` — use the spec language directly (e.g. write `len(v)` instead of `result_of<vector::length>(v)`, `v[i]` instead of `result_of<vector::borrow>(v, i)`, `!in_range(v, i)` instead of `aborts_of<vector::borrow>(v, i)`)
-    ┌─ tests/sources/functional/closures/bp_bytecode_natives.move:142:19
+    ┌─ tests/sources/functional/closures/bp_bytecode_natives.move:143:19
     │
-142 │         aborts_if aborts_of<vector::singleton<T>>(e);
+143 │         aborts_if aborts_of<vector::singleton<T>>(e);
     │                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: behavioral predicates are not supported on `std::vector::singleton` — use the spec language directly (e.g. write `len(v)` instead of `result_of<vector::length>(v)`, `v[i]` instead of `result_of<vector::borrow>(v, i)`, `!in_range(v, i)` instead of `aborts_of<vector::borrow>(v, i)`)
-    ┌─ tests/sources/functional/closures/bp_bytecode_natives.move:143:27
+    ┌─ tests/sources/functional/closures/bp_bytecode_natives.move:144:27
     │
-143 │         ensures result == result_of<vector::singleton<T>>(e);
+144 │         ensures result == result_of<vector::singleton<T>>(e);
     │                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: behavioral predicates are not supported on `std::vector::contains` — use the spec language directly (e.g. write `len(v)` instead of `result_of<vector::length>(v)`, `v[i]` instead of `result_of<vector::borrow>(v, i)`, `!in_range(v, i)` instead of `aborts_of<vector::borrow>(v, i)`)
-    ┌─ tests/sources/functional/closures/bp_bytecode_natives.move:154:19
+    ┌─ tests/sources/functional/closures/bp_bytecode_natives.move:155:19
     │
-154 │         aborts_if aborts_of<vector::contains<T>>(v, e);
+155 │         aborts_if aborts_of<vector::contains<T>>(v, e);
     │                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: behavioral predicates are not supported on `std::vector::contains` — use the spec language directly (e.g. write `len(v)` instead of `result_of<vector::length>(v)`, `v[i]` instead of `result_of<vector::borrow>(v, i)`, `!in_range(v, i)` instead of `aborts_of<vector::borrow>(v, i)`)
-    ┌─ tests/sources/functional/closures/bp_bytecode_natives.move:155:27
+    ┌─ tests/sources/functional/closures/bp_bytecode_natives.move:156:27
     │
-155 │         ensures result == result_of<vector::contains<T>>(v, e);
+156 │         ensures result == result_of<vector::contains<T>>(v, e);
     │                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/third_party/move/move-prover/tests/sources/functional/closures/bp_bytecode_natives.move
+++ b/third_party/move/move-prover/tests/sources/functional/closures/bp_bytecode_natives.move
@@ -79,15 +79,16 @@ module 0x42::bp_bytecode_natives {
         aborts_if aborts_of<vector::push_back<T>>(v, e);
     }
 
-    /// `ensures_of` over push_back captures the post-state via the
-    /// in/out-param convention: `ensures_of<push_back>(v, e, v_post)`
-    /// rewrites to `v_post == concat(v, vec(e))`.
+    /// `ensures_of` over push_back relates the pre/post state of the
+    /// `&mut` argument: the user writes the call with `v` appearing once;
+    /// the model rewriter and Boogie backend together produce the canonical
+    /// `(pre_v, e, post_v)` form.
     fun push_back_ensures<T: drop>(v: &mut vector<T>, e: T) {
         vector::push_back(v, e)
     }
     spec push_back_ensures {
         aborts_if false;
-        ensures ensures_of<vector::push_back<T>>(old(v), e, v);
+        ensures ensures_of<vector::push_back<T>>(v, e);
     }
 
     // ====================================================================

--- a/third_party/move/move-prover/tests/sources/functional/closures/bp_mut_ref_selector.move
+++ b/third_party/move/move-prover/tests/sources/functional/closures/bp_mut_ref_selector.move
@@ -15,9 +15,11 @@ module 0x42::bp_mut_ref_selector {
     // Apply `f` to a field of `p` via a `&mut` field borrow.
     fun apply_to_x(f: |&mut u64|, p: &mut Point) { f(&mut p.x) }
     spec apply_to_x {
-        // The post-state of `p.x` equals f's post-state of its &mut argument
-        // applied to the pre-state of `p.x`.
-        ensures p.x == result_of<f>(&mut p.x);
+        // `f` is void; the only output is the `&mut` post-state. Use
+        // `ensures_of` (relational) to constrain it — `result_of` is
+        // invalid on void callees. The selector `&mut p.x` carries pre-
+        // and post-state of the field through the BP call.
+        ensures ensures_of<f>(&mut p.x);
         // p.y is unchanged by the call.
         ensures p.y == old(p).y;
     }

--- a/third_party/move/move-prover/tests/sources/functional/closures/result_of_void_invalid.exp
+++ b/third_party/move/move-prover/tests/sources/functional/closures/result_of_void_invalid.exp
@@ -1,0 +1,18 @@
+Move prover returns: exiting with compilation errors
+error: `result_of` cannot be used with functions that have no return value; use `ensures_of` to constrain the post-state of `&mut` arguments instead
+   ┌─ tests/sources/functional/closures/result_of_void_invalid.move:14:17
+   │
+14 │         ensures result_of<f>(x) == 0;
+   │                 ^^^^^^^^^^^^^^^
+
+error: `result_of` cannot be used with functions that have no return value; use `ensures_of` to constrain the post-state of `&mut` arguments instead
+   ┌─ tests/sources/functional/closures/result_of_void_invalid.move:21:17
+   │
+21 │         ensures result_of<f>(x) == 0;
+   │                 ^^^^^^^^^^^^^^^
+
+error: expected 1 argument(s) for result_of but 2 were provided
+   ┌─ tests/sources/functional/closures/result_of_void_invalid.move:28:27
+   │
+28 │         ensures result == result_of<f>(old(x), x);
+   │                           ^^^^^^^^^^^^^^^^^^^^^^^

--- a/third_party/move/move-prover/tests/sources/functional/closures/result_of_void_invalid.move
+++ b/third_party/move/move-prover/tests/sources/functional/closures/result_of_void_invalid.move
@@ -1,0 +1,30 @@
+// `result_of<f>` is rejected for `f` returning no values. For the
+// post-state of a `&mut` argument, the user must write `ensures_of<f>(...)`
+// instead.
+//
+// `result_of<f>` is also rejected when the user supplies an explicit
+// `&mut` post-state slot: the `&mut` parameter appears once and the prover
+// supplies the pre/post split automatically.
+module 0x42::result_of_void_invalid {
+
+    fun apply_void(f: |u64|, x: u64) { f(x) }
+    spec apply_void {
+        // error: `result_of` cannot be used with functions that have no
+        // return value.
+        ensures result_of<f>(x) == 0;
+    }
+
+    fun apply_void_mut(f: |&mut u64|, x: &mut u64) { f(x) }
+    spec apply_void_mut {
+        // error: `result_of` cannot be used with functions that have no
+        // return value.
+        ensures result_of<f>(x) == 0;
+    }
+
+    fun apply_mut(f: |&mut u64| u64, x: &mut u64): u64 { f(x) }
+    spec apply_mut {
+        // error: `result_of<f>` takes only `f`'s input parameters; the `&mut`
+        // post-state slot is not user-facing.
+        ensures result == result_of<f>(old(x), x);
+    }
+}


### PR DESCRIPTION
For a function value `f: |&mut T| R`, behavioral predicates over `&mut`
arguments are now fully symmetric: the `&mut` parameter appears once and
the procedure-level pre/post split is handled by the prover. Users can
write the deterministic-result form

    r == result_of<f>(x_mut)

alongside the relational form

    ensures_of<f>(x_mut, r)

with the same `x_mut` slot in each. Previously, `result_of<f>` was typed
to return the extended tuple `(R, T)`, forcing callers into the
asymmetric `(r, x_mut) == result_of<f>(old(x_mut))`. `result_of<f>`
now returns only `f`'s declared return type and is rejected on void
callees; the post-state of a `&mut` argument is expressed exclusively
through `ensures_of<f>(x_mut, r)`.

Example: a closure that mutates `&mut u64` and returns `u64`:

    fun apply_mut(f: |&mut u64| u64, x: &mut u64): u64 { f(x) }
    spec apply_mut {
        ensures result == result_of<f>(x);
        ensures ensures_of<f>(x, result);
    }

The sourcifier additionally hoists nested labeled subexpressions (e.g.
`..S |~ result_of<g>(...)` inside arithmetic or struct-field
construction) into `let` bindings at the clause level, so inferred
specs render with each labeled subexpression named once and referenced
uniformly across siblings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches core spec translation and Boogie axiom generation for behavioral predicates, so regressions could change verification results or soundness around `&mut` state handling and inference.
> 
> **Overview**
> Aligns behavioral predicates for `&mut` parameters so the mutable argument appears **once**: `result_of<f>(x_mut)` now returns only `f`’s declared return type and is rejected for void callees, while `ensures_of<f>(x_mut, r)` (or canonical `ensures_of<f>(old(x), r, x)`) constrains both return values and `&mut` post-state.
> 
> Implements this by adding internal `BehaviorKind::WriteOf(j)` and wiring new Boogie Skolems/axioms so `&mut` post-states are functionally determined from inputs; the WP/inference pipeline emits and then eliminates `write_of` back into canonical `ensures_of` clauses.
> 
> Improves readability/robustness of inferred specs and error output: the sourcifier hoists nested labeled subexpressions into clause-level `let` bindings, CSE naming avoids collisions, and documentation/tests are updated (including new negative tests for `result_of` on void functions and for extra `&mut` slots).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef760511e22d7c43fbce775b39dfa98d1fe5c0c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->