### PR TITLE
[forge] Add configurable gas-price multiplier for encrypted txn emitter traffic

### DIFF
--- a/crates/transaction-emitter-lib/src/args.rs
+++ b/crates/transaction-emitter-lib/src/args.rs
@@ -191,6 +191,9 @@ pub struct EmitArgs {
 
     #[clap(long, default_value = "false", hide = true)]
     pub encrypt_transactions: bool,
+
+    #[clap(long)]
+    pub encrypted_gas_price_multiplier: Option<u64>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Parser, Serialize)]

--- a/crates/transaction-emitter-lib/src/emitter/mod.rs
+++ b/crates/transaction-emitter-lib/src/emitter/mod.rs
@@ -175,6 +175,7 @@ pub struct EmitJobRequest {
 
     gas_price: u64,
     init_gas_price_multiplier: u64,
+    encrypted_gas_price_multiplier: u64,
 
     mint_to_root: bool,
     skip_funding_accounts: bool,
@@ -220,6 +221,7 @@ impl Default for EmitJobRequest {
             gas_price: aptos_global_constants::GAS_UNIT_PRICE,
             init_max_gas_per_txn: None,
             init_gas_price_multiplier: 2,
+            encrypted_gas_price_multiplier: 2,
             mint_to_root: false,
             skip_funding_accounts: false,
             txn_expiration_time_secs: 60,
@@ -278,6 +280,11 @@ impl EmitJobRequest {
 
     pub fn init_gas_price_multiplier(mut self, init_gas_price_multiplier: u64) -> Self {
         self.init_gas_price_multiplier = init_gas_price_multiplier;
+        self
+    }
+
+    pub fn encrypted_gas_price_multiplier(mut self, encrypted_gas_price_multiplier: u64) -> Self {
+        self.encrypted_gas_price_multiplier = encrypted_gas_price_multiplier;
         self
     }
 
@@ -429,6 +436,23 @@ impl EmitJobRequest {
 
     pub fn get_init_gas_price(&self) -> u64 {
         self.gas_price * self.init_gas_price_multiplier
+    }
+
+    pub fn needs_encryption(&self) -> bool {
+        self.encrypt_transactions
+            || self.transaction_mix_per_phase.iter().any(|phase| {
+                phase
+                    .iter()
+                    .any(|(tt, _)| matches!(tt, TransactionType::Encrypted { .. }))
+            })
+    }
+
+    pub fn get_effective_gas_price(&self) -> u64 {
+        if self.needs_encryption() {
+            self.gas_price * self.encrypted_gas_price_multiplier
+        } else {
+            self.gas_price
+        }
     }
 
     pub fn calculate_mode_params(&self) -> EmitModeParams {
@@ -781,22 +805,25 @@ impl TxnEmitter {
             .with_gas_unit_price(req.get_init_gas_price())
             .with_transaction_expiration_time(init_expiration_time);
 
+        let needs_encryption = req.needs_encryption();
+        let traffic_gas_price = req.get_effective_gas_price();
+        if needs_encryption {
+            info!(
+                "Encrypted transactions enabled – boosting gas price from {} to {} ({}x multiplier)",
+                req.gas_price, traffic_gas_price, req.encrypted_gas_price_multiplier,
+            );
+        }
+
         // Build traffic factory (may encrypt)
         let txn_factory = self
             .txn_factory
             .clone()
             .with_transaction_expiration_time(mode_params.txn_expiration_time_secs)
-            .with_gas_unit_price(req.gas_price)
+            .with_gas_unit_price(traffic_gas_price)
             .with_max_gas_amount(req.max_gas_per_txn);
 
         // Set the encryption key on the traffic factory upfront.
         // init_txn_factory has its own independent Arc so it won't be affected.
-        let has_per_workload_encryption = req.transaction_mix_per_phase.iter().any(|phase| {
-            phase
-                .iter()
-                .any(|(tt, _)| matches!(tt, TransactionType::Encrypted { .. }))
-        });
-        let needs_encryption = req.encrypt_transactions || has_per_workload_encryption;
         if needs_encryption {
             let state = self.rest_cli.get_ledger_information().await?.into_inner();
             txn_factory
@@ -1420,12 +1447,13 @@ pub fn get_needed_balance_per_account_from_req(req: &EmitJobRequest, num_account
         );
         val
     } else {
+        let effective_gas_price = req.get_effective_gas_price();
         get_needed_balance_per_account(
             req.expected_max_txns,
             req.get_expected_gas_per_txn(),
             SEND_AMOUNT,
             num_accounts,
-            req.gas_price,
+            effective_gas_price,
             req.max_gas_per_txn,
         )
     }

--- a/crates/transaction-emitter-lib/src/wrappers.rs
+++ b/crates/transaction-emitter-lib/src/wrappers.rs
@@ -195,6 +195,11 @@ pub async fn emit_transactions_with_cluster(
         emit_job_request = emit_job_request.encrypt_transactions(true);
     }
 
+    if let Some(encrypted_gas_price_multiplier) = args.encrypted_gas_price_multiplier {
+        emit_job_request =
+            emit_job_request.encrypted_gas_price_multiplier(encrypted_gas_price_multiplier);
+    }
+
     let coin_source_account = std::sync::Arc::new(coin_source_account);
     let stats = emitter
         .emit_txn_for_with_stats(


### PR DESCRIPTION
## Description
Encrypted transactions consume more gas than regular ones, so the emitter
can underprice them and fall behind under load. This adds a knob to scale
the traffic gas price when encryption is in use.

- New CLI flag `--encrypted-gas-price-multiplier <N>` on `EmitArgs`
  (defaults to 2x to match the existing init-funding multiplier).
- Detect "encryption is active" from either `--encrypt-transactions` or
  any `TransactionType::Encrypted { .. }` in the workload mix.
- When active, boost the traffic factory's gas unit price by the
  multiplier and log the before/after price.
- Size per-account funding (`get_needed_balance_per_account_from_req`)
  against the effective gas price so accounts don't run dry.

No effect when encryption is not used.

## How Has This Been Tested?
Manual emitter runs with and without `--encrypt-transactions`; verified
log line reports the boosted price and that funding is sized accordingly.

## Key Areas to Review
- `EmitJobRequest::get_effective_gas_price` (encryption-active detection
  duplicated with the inline check in `start_job` — kept separate so the
  emitter can log and still reuse `needs_encryption` downstream for
  encryption-key setup).
- Default multiplier of 2x — applied automatically whenever encryption
  is active, even without the new flag.

## Type of Change
- [x] New feature

## Which Components or Systems Does This Change Impact?
- [x] Developer Infrastructure