### PR TITLE
[consensus-observer] Preserve decrypted_txns when secret_shared_key is absent

### DIFF
--- a/consensus/src/consensus_observer/network/observer_message.rs
+++ b/consensus/src/consensus_observer/network/observer_message.rs
@@ -382,9 +382,14 @@ impl PipelinedBlockV2Owned {
         }
         if let Some(key) = self.secret_shared_key {
             block.set_decryption_key(key);
-            // Note: Decryption key must be Some if decrypted transactions are available.
-            block.set_decrypted_txns(self.decrypted_txns);
         }
+        // decrypted_txns is independent of secret_shared_key: the validator
+        // pipeline emits FailedDecryption variants (TrustedSetupExhausted,
+        // EpochEndRetry, BatchLimitReached, DecryptionKeyUnavailable, etc.)
+        // without ever setting a decryption key. Dropping them here would
+        // cause the observer's prepare input to diverge from the validator's,
+        // changing executed-txn count and block_approx_output_size.
+        block.set_decrypted_txns(self.decrypted_txns);
         Arc::new(block)
     }
 }
@@ -1955,6 +1960,47 @@ mod test {
             .verify_payload_signatures(&epoch_state)
             .unwrap_err();
         assert_matches!(error, Error::InvalidMessageError(_));
+    }
+
+    #[test]
+    fn test_ordered_block_v2_preserves_decrypted_txns_when_secret_shared_key_is_none() {
+        // Regression test: the validator's decryption pipeline emits non-empty
+        // decrypted_txns (FailedDecryption variants like TrustedSetupExhausted,
+        // EpochEndRetry, BatchLimitReached, DecryptionKeyUnavailable) without
+        // ever setting a secret_shared_key on the block. The observer-side
+        // deserializer must not gate `set_decrypted_txns` on the key being
+        // present, otherwise the observer's prepare input drops those txns and
+        // diverges from the validator (different executed-txn count, different
+        // block_approx_output_size).
+        let block_info = create_block_info(0, HashValue::random());
+        let pipelined_block = create_pipelined_block(block_info.clone());
+
+        // Populate decrypted_txns; leave secret_shared_key unset.
+        let decrypted_txns = create_signed_transactions(3);
+        pipelined_block.set_decrypted_txns(decrypted_txns.clone());
+        assert!(pipelined_block.secret_shared_key().is_none());
+
+        let ordered_proof = LedgerInfoWithSignatures::new(
+            LedgerInfo::new(block_info, HashValue::random()),
+            AggregateSignature::empty(),
+        );
+        let ordered_block_v2 = OrderedBlockV2::new(vec![pipelined_block], ordered_proof);
+
+        // Round-trip through bcs (the wire format used by the consensus observer).
+        let bytes = bcs::to_bytes(&ordered_block_v2).unwrap();
+        let decoded: OrderedBlockV2 = bcs::from_bytes(&bytes).unwrap();
+
+        let blocks = decoded.into_ordered_block().blocks().clone();
+        assert_eq!(blocks.len(), 1);
+        assert!(
+            blocks[0].secret_shared_key().is_none(),
+            "secret_shared_key should remain unset after round-trip"
+        );
+        assert_eq!(
+            blocks[0].decrypted_txns(),
+            Some(decrypted_txns),
+            "decrypted_txns must survive deserialization even when secret_shared_key is None"
+        );
     }
 
     /// Creates and returns a new batch info with random data


### PR DESCRIPTION
## Summary

- Fixes a validator/observer divergence where `block_approx_output_size` mismatches between the validator and consensus observer paths.
- Root cause: `PipelinedBlockV2Owned::into_pipelined_block` gated `set_decrypted_txns` on `secret_shared_key.is_some()`. The validator pipeline emits non-empty `decrypted_txns` of `FailedDecryption` variants (`TrustedSetupExhausted`, `EpochEndRetry`, `BatchLimitReached`, `DecryptionKeyUnavailable`, `ConfigUnavailable`) without ever setting a key, so the observer was silently dropping them. The observer's prepare input became `[regular_txns]` while the validator's was `[N failed-decryption txns, regular_txns]`, leading to a different executed transaction set and divergent `block_approx_output_size` in `BlockGasLimitProcessor`.
- Fix: always call `set_decrypted_txns` during V2 deserialization; `set_decryption_key` remains gated on the key being present (the two fields are already serialized independently on the wire).

## Test plan

- [x] Added `test_ordered_block_v2_preserves_decrypted_txns_when_secret_shared_key_is_none` — round-trips an `OrderedBlockV2` through bcs with non-empty `decrypted_txns` and `secret_shared_key = None`, asserts the txns survive.
- [x] Verified the test fails against the un-fixed code (`decrypted_txns()` returns `None` instead of `Some([3 txns])`) and passes after the fix.
- [x] All 13 tests in `consensus_observer::network::observer_message::test` pass.
- [x] `./scripts/rust_lint.sh --check` (clippy, fmt, sort, machete) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)