### PR TITLE
[consensus] Dump StateComputeResult on commit_info mismatch panic

### DIFF
--- a/consensus/src/pipeline/buffer_item.rs
+++ b/consensus/src/pipeline/buffer_item.rs
@@ -22,6 +22,62 @@ use itertools::zip_eq;
 use std::{collections::HashMap, sync::Arc};
 use tokio::time::Instant;
 
+fn log_execution_state_for_mismatch(
+    label: &str,
+    executed_blocks: &[Arc<PipelinedBlock>],
+    local: &BlockInfo,
+    incoming: &BlockInfo,
+) {
+    error!(
+        label = label,
+        local_commit_info = %local,
+        incoming_commit_info = %incoming,
+        num_executed_blocks = executed_blocks.len(),
+        "commit_info mismatch detected — about to panic; dumping StateComputeResult per executed block"
+    );
+
+    for b in executed_blocks {
+        let cr = b.compute_result();
+        let lu = &cr.ledger_update_output;
+        let parent_version = lu.parent_accumulator.num_leaves;
+        let next_version = lu.transaction_accumulator.num_leaves;
+
+        error!(
+            label = label,
+            block_id = %b.id(),
+            parent_id = %b.parent_id(),
+            epoch = b.epoch(),
+            round = b.round(),
+            executed_state_id = ?cr.root_hash(),
+            parent_state_id = ?lu.parent_accumulator.root_hash,
+            version_start = parent_version,
+            version_end = next_version,
+            num_input_txns = cr.num_input_transactions(),
+            num_to_commit = cr.num_transactions_to_commit(),
+            has_reconfiguration = cr.has_reconfiguration(),
+            next_epoch = cr.epoch_state().as_ref().map(|e| e.epoch),
+            block_end_info = ?cr.execution_output.block_end_info,
+            "commit_info mismatch — dumping executed block state before panic"
+        );
+
+        for (i, (info, info_hash)) in lu
+            .transaction_infos
+            .iter()
+            .zip(lu.transaction_info_hashes.iter())
+            .enumerate()
+        {
+            error!(
+                label = label,
+                block_id = %b.id(),
+                version = parent_version + i as u64,
+                info_hash = ?info_hash,
+                info = ?info,
+                "commit_info mismatch — dumping txn info before panic"
+            );
+        }
+    }
+}
+
 fn generate_commit_ledger_info(
     commit_info: &BlockInfo,
     ordered_proof: &LedgerInfoWithSignatures,
@@ -146,6 +202,14 @@ impl BufferItem {
                 if let Some(commit_proof) = commit_proof {
                     // We have already received the commit proof in fast forward sync path,
                     // we can just use that proof and proceed to aggregated
+                    if *commit_proof.commit_info() != commit_info {
+                        log_execution_state_for_mismatch(
+                            "ordered→aggregated",
+                            &executed_blocks,
+                            &commit_info,
+                            commit_proof.commit_info(),
+                        );
+                    }
                     assert_eq!(commit_proof.commit_info().clone(), commit_info);
                     debug!(
                         "{} advance to aggregated from ordered",
@@ -240,6 +304,14 @@ impl BufferItem {
                     partial_commit_proof: local_commit_proof,
                     ..
                 } = *signed_item;
+                if local_commit_proof.data().commit_info() != commit_proof.commit_info() {
+                    log_execution_state_for_mismatch(
+                        "signed→aggregated",
+                        &executed_blocks,
+                        local_commit_proof.data().commit_info(),
+                        commit_proof.commit_info(),
+                    );
+                }
                 assert_eq!(
                     local_commit_proof.data().commit_info(),
                     commit_proof.commit_info()
@@ -259,6 +331,14 @@ impl BufferItem {
                     commit_info,
                     ..
                 } = *executed_item;
+                if commit_info != *commit_proof.commit_info() {
+                    log_execution_state_for_mismatch(
+                        "executed→aggregated",
+                        &executed_blocks,
+                        &commit_info,
+                        commit_proof.commit_info(),
+                    );
+                }
                 assert_eq!(commit_info, *commit_proof.commit_info());
                 debug!(
                     "{} advance to aggregated with commit decision",


### PR DESCRIPTION
## Summary
- At each of the three production `assert_eq!` sites in `consensus/src/pipeline/buffer_item.rs` that fire on execution-state-id divergence (lines 149/243/262), add an `if local != incoming` check just before the assert that emits structured `error!` logs of the per-block `StateComputeResult`. The original `assert_eq!` is retained and remains the panic source.
- The new helper `log_execution_state_for_mismatch` emits, per buffer item: one header line, one summary line per block (block_id, parent_id, epoch, round, executed_state_id, parent_state_id, version range, counts, `block_end_info`, etc.), and one line per `TransactionInfo` (version, info_hash, full info debug). Per-txn lines are split into separate `error!` calls to avoid `aptos-logger`'s 10 KiB per-field truncation on real-sized blocks.
- Each panic site carries a label (`ordered→aggregated`, `signed→aggregated`, `executed→aggregated`) so logs are filterable by which arm fired.

## Motivation
When consensus panics on a `commit_info` mismatch, the existing `assert_eq!` only prints the two `BlockInfo`s. The underlying divergence is in `StateComputeResult` — specifically the per-transaction `TransactionInfo`s and accumulator roots — but none of that lands in the log. This adds enough forensic detail just before the panic to pinpoint the divergent transaction by diffing logs across nodes.

## Test plan
- [x] `cargo check -p aptos-consensus`
- [x] `cargo test -p aptos-consensus --lib pipeline::buffer_item::` — existing tests still pass
- [x] `./scripts/rust_lint.sh --check` — clippy / fmt / sort / machete clean
- [ ] Manual validation: trigger the panic path on a divergence and confirm logs are emitted in expected order (header → per-block summary → per-txn lines → assert panic stack)

🤖 Generated with [Claude Code](https://claude.com/claude-code)