### PR TITLE
[move docs] Document book and framework-book publish URLs

### DIFF
--- a/third_party/move/documentation/book/README.md
+++ b/third_party/move/documentation/book/README.md
@@ -1,38 +1,11 @@
----
-id: move-book
-title: Move Book
-custom_edit_url: https://github.com/move-language/move/edit/main/language/documentation/book/README.md
----
+# Move Book
 
-In order to update the Move book and preview changes to it you'll need to
-install
-[`mdbook`](https://rust-lang.github.io/mdBook/guide/installation.html). You
-can do this via `cargo install mdbook`.
+mdbook source for the Move language reference documentation. Published at
+<https://aptos-labs.github.io/move-book/>. Sibling project to
+[`../framework-book/`](../framework-book/), which covers the Aptos Framework.
 
-After installing mdbook, you can preview changes via either `mdbook serve`,
-or if you want the output to change as you make changes to the book you can
-use `mdbook watch`. More information on options can be found at the [mdbook
-website](https://rust-lang.github.io/mdBook/).
-
-Once you are happy with your changes to the Move book, you can create a PR to
-update the Move book website. This is the process that has been used in
-the past and is known to work, but there may be a better way:
-
-1. Run `mdbook build` in this directory. This will create a directory
-called `book`. Copy this to some location `L` outside of the Move git tree.
-
-2. Make sure your upstream is up-to-date and checkout to `upstream/gh-pages`.
-
-3. Once you have checked out to `upstream/gh-pages`, make sure you are at the
-root of the repo. You should see a number of `.html` files. You can now
-move all contents in `L` to this location: `mv L/* .`
-
-4. Once this is done inspect things to make sure the book looks the way you
-want. If everything looks good submit a PR to the **`gh-pages`** branch of the
-main Move repo.
-
-After this the normal PR process is followed. Once the PR has been accepted and
-lands the updated Move book should be visible immediately.
-
-**NB:** When adding a new (sub)section to the book you _must_ include the new
-file in the `SUMMARY.md` file otherwise it will not appear in the updated book.
+```
+mdbook build       # render to ./html
+mdbook serve       # live preview at http://localhost:3000
+./deploy.sh        # publish to https://aptos-labs.github.io/move-book/
+```

--- a/third_party/move/documentation/framework-book/README.md
+++ b/third_party/move/documentation/framework-book/README.md
@@ -1,9 +1,11 @@
 # Aptos Framework Book
 
-mdbook source for the Aptos Framework reference documentation. Sibling
-project to [`../book/`](../book/), which covers the Move language itself.
+mdbook source for the Aptos Framework reference documentation. Published at
+<https://aptos-labs.github.io/framework-book/>. Sibling project to
+[`../book/`](../book/), which covers the Move language itself.
 
 ```
-mdbook build       # render to ./html
+./build.sh         # generate per-package module docs and render to ./html
 mdbook serve       # live preview at http://localhost:3000
+./deploy.sh        # publish to https://aptos-labs.github.io/framework-book/
 ```


### PR DESCRIPTION
## Description

Update the two READMEs under `third_party/move/documentation/` so they document where each book is actually published:

- `book/README.md` — replace the stale `gh-pages` deploy workflow with a short pointer to <https://aptos-labs.github.io/move-book/> and the current `deploy.sh` helper.
- `framework-book/README.md` — add the matching publish URL <https://aptos-labs.github.io/framework-book/> and the missing `./build.sh` / `./deploy.sh` lines (the directory already ships both scripts).

No code or build changes.

## How Has This Been Tested?

Docs-only change; verified the referenced helper scripts (`build.sh`, `deploy.sh`) exist in both directories and their headers describe the publish targets used in the READMEs.

## Key Areas to Review

Just confirm the published URLs are the ones we want surfaced to readers.

## Type of Change

- [x] Documentation update

## Which Components or Systems Does This Change Impact?

- [x] Move Compiler
- [x] Other (specify): Move language book and Aptos Framework book

Co-authored-by: Claude <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only updates to two READMEs; no runtime or build logic changes, so risk is limited to potential confusion if URLs/scripts are incorrect.
> 
> **Overview**
> Updates `third_party/move/documentation/book/README.md` to remove the stale `gh-pages` publishing instructions and instead document the live URL and `./deploy.sh` workflow.
> 
> Updates `third_party/move/documentation/framework-book/README.md` to add the published URL and include the missing `./build.sh` and `./deploy.sh` commands alongside `mdbook serve`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86a9dc0ab914056e4514d57ad7858a772d14a33c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->