### PR TITLE
[dkg] Publish blake3 hash of digest key and public params

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -336,6 +336,7 @@ dependencies = [
  "backoff",
  "base64 0.13.1",
  "bcs 0.1.4",
+ "blake3",
  "bollard",
  "chrono",
  "clap 4.5.60",
@@ -362,7 +363,6 @@ dependencies = [
  "serde_json",
  "serde_yaml 0.8.26",
  "set_env",
- "sha2 0.9.9",
  "shadow-rs",
  "tempfile",
  "thiserror 1.0.69",
@@ -6522,6 +6522,7 @@ dependencies = [
  "constant_time_eq 0.4.2",
  "cpufeatures 0.3.0",
  "memmap2 0.9.9",
+ "rayon-core",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,7 +66,7 @@ checksum = "ac1f845298e95f983ff1944b728ae08b8cebab80d684f0a832ed0fc74dfa27e2"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.12",
 ]
 
 [[package]]
@@ -1463,6 +1463,7 @@ dependencies = [
  "ark-std 0.5.0",
  "async-trait",
  "bcs 0.1.4",
+ "blake3",
  "bytes",
  "fail",
  "futures",
@@ -6509,6 +6510,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "blake3"
+version = "1.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce"
+dependencies = [
+ "arrayref",
+ "arrayvec 0.7.4",
+ "cc",
+ "cfg-if",
+ "constant_time_eq 0.4.2",
+ "cpufeatures 0.3.0",
+ "memmap2 0.9.9",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7428,7 +7444,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b0485bab839b018a8f1723fc5391819fea5f8f0f32288ef8a735fd096b6160c"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.12",
  "hex",
  "proptest",
  "serde",
@@ -7509,6 +7525,12 @@ name = "constant_time_eq"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
+
+[[package]]
+name = "constant_time_eq"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
 name = "convert_case"
@@ -7632,6 +7654,15 @@ name = "cpufeatures"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -7925,7 +7956,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a677b8922c94e01bdbb12126b0bc852f00447528dee1782229af9c720c3f348"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.12",
  "curve25519-dalek-derive",
  "digest 0.10.7",
  "fiat-crypto",
@@ -11814,7 +11845,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f6d5ed8676d904364de097082f4e7d240b571b67989ced0240f08b7f966f940"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.12",
 ]
 
 [[package]]
@@ -11823,7 +11854,7 @@ version = "0.2.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a412fe37705d515cba9dbf1448291a717e187e2351df908cfc0137cbec3d480"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.12",
 ]
 
 [[package]]
@@ -15403,7 +15434,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d52cff9d1d4dee5fe6d03729099f4a310a41179e0a10dbf542039873f2e826fb"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.12",
  "opaque-debug",
  "universal-hash",
 ]
@@ -17891,7 +17922,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.12",
  "digest 0.10.7",
 ]
 
@@ -17909,7 +17940,7 @@ checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
 dependencies = [
  "block-buffer 0.9.0",
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.12",
  "digest 0.9.0",
  "opaque-debug",
 ]
@@ -17921,7 +17952,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.12",
  "digest 0.10.7",
 ]
 
@@ -17932,7 +17963,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c5f3b1e2dc8aad28310d8410bd4d7e180eca65fca176c52ab00d364475d0024"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.12",
  "digest 0.11.0",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -544,7 +544,7 @@ bigdecimal = { version = "0.4.0", features = ["serde"] }
 version-compare = "0.1.1"
 bitvec = "1.0.1"
 blake2 = "0.10.4"
-blake3 = { version = "1.5.4", features = ["mmap"] }
+blake3 = { version = "1.5.4", features = ["mmap", "rayon"] }
 blake2-rfc = "0.2.18"
 bls12_381 = "0.8.0"
 blst = "0.3.15"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -544,6 +544,7 @@ bigdecimal = { version = "0.4.0", features = ["serde"] }
 version-compare = "0.1.1"
 bitvec = "1.0.1"
 blake2 = "0.10.4"
+blake3 = { version = "1.5.4", features = ["mmap"] }
 blake2-rfc = "0.2.18"
 bls12_381 = "0.8.0"
 blst = "0.3.15"

--- a/crates/aptos/CHANGELOG.md
+++ b/crates/aptos/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the Aptos CLI will be captured in this file. This project
 
 # Unreleased
 
-- _No changes yet._
+- Replaced `aptos node verify-digest-key` with two commands: `aptos node validate-digest-key` and `aptos node validate-public-parameters`. Both compute and report a blake3 checksum (instead of SHA-256) along with the file size, and verify that the blob deserializes to the corresponding type. The JSON output field is renamed from `sha256` to `blake3`.
 
 ## [9.2.0]
 - Update boogie from 3.5.1 to 3.5.6.

--- a/crates/aptos/Cargo.toml
+++ b/crates/aptos/Cargo.toml
@@ -52,6 +52,7 @@ async-trait = { workspace = true }
 backoff = { workspace = true }
 base64 = { workspace = true }
 bcs = { workspace = true }
+blake3 = { workspace = true }
 bollard = { workspace = true }
 chrono = { workspace = true }
 clap = { workspace = true, features = ["env", "unstable-styles", "wrap_help"] }
@@ -81,7 +82,6 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
 set_env = { workspace = true }
-sha2 = { workspace = true }
 tempfile = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }

--- a/crates/aptos/src/node/mod.rs
+++ b/crates/aptos/src/node/mod.rs
@@ -81,7 +81,8 @@ pub enum NodeTool {
     RunLocalnet(RunLocalnet),
     UpdateConsensusKey(UpdateConsensusKey),
     UpdateValidatorNetworkAddresses(UpdateValidatorNetworkAddresses),
-    VerifyDigestKey(VerifyDigestKey),
+    ValidateDigestKey(ValidateDigestKey),
+    ValidatePublicParameters(ValidatePublicParameters),
 }
 
 impl NodeTool {
@@ -109,7 +110,8 @@ impl NodeTool {
                 .map(|_| "".to_string()),
             UpdateConsensusKey(tool) => tool.execute_serialized().await,
             UpdateValidatorNetworkAddresses(tool) => tool.execute_serialized().await,
-            VerifyDigestKey(tool) => tool.execute_serialized().await,
+            ValidateDigestKey(tool) => tool.execute_serialized().await,
+            ValidatePublicParameters(tool) => tool.execute_serialized().await,
         }
     }
 }
@@ -1492,49 +1494,55 @@ impl Time {
     }
 }
 
-/// Verify a BCS-serialized DigestKey blob file
+#[derive(Serialize)]
+pub struct BlobValidationResult {
+    pub file_size_bytes: u64,
+    pub blake3: String,
+}
+
+fn file_size_and_blake3(file: &PathBuf) -> CliTypedResult<(u64, String)> {
+    use std::time::Instant;
+
+    println!("Reading file {}...", file.display());
+    let file_size_bytes = std::fs::metadata(file)
+        .map_err(|e| CliError::IO(format!("Failed to stat {}: {}", file.display(), e), e))?
+        .len();
+
+    println!("Computing blake3...");
+    let t = Instant::now();
+    let mut hasher = blake3::Hasher::new();
+    hasher
+        .update_mmap_rayon(file)
+        .map_err(|e| CliError::IO(format!("Failed to read {}: {}", file.display(), e), e))?;
+    let blake3 = hasher.finalize().to_hex().to_string();
+    println!("blake3: {} in {:.2?}", blake3, t.elapsed());
+
+    Ok((file_size_bytes, blake3))
+}
+
+/// Validate a BCS-serialized DigestKey blob file
 ///
-/// Reads the file, attempts BCS deserialization, and prints the file size
-/// and SHA-256 checksum.
+/// Reads the file, computes the file size and blake3 checksum, and verifies
+/// that the contents are a valid BCS-serialized DigestKey.
 #[derive(Parser)]
-pub struct VerifyDigestKey {
+pub struct ValidateDigestKey {
     /// Path to the BCS-serialized DigestKey blob file
     #[clap(value_parser)]
     pub file: PathBuf,
 }
 
-#[derive(Serialize)]
-pub struct VerifyDigestKeyResult {
-    pub file_size_bytes: u64,
-    pub sha256: String,
-}
-
 #[async_trait]
-impl CliCommand<VerifyDigestKeyResult> for VerifyDigestKey {
+impl CliCommand<BlobValidationResult> for ValidateDigestKey {
     fn command_name(&self) -> &'static str {
-        "VerifyDigestKey"
+        "ValidateDigestKey"
     }
 
-    async fn execute(self) -> CliTypedResult<VerifyDigestKeyResult> {
+    async fn execute(self) -> CliTypedResult<BlobValidationResult> {
         use aptos_batch_encryption::shared::digest_key_file;
         use aptos_types::secret_sharing::DigestKey;
-        use sha2::{Digest, Sha256};
         use std::time::Instant;
 
-        println!("Reading file {}...", self.file.display());
-        let t = Instant::now();
-        let bytes = std::fs::read(&self.file).map_err(|e| {
-            CliError::IO(format!("Failed to read {}: {}", self.file.display(), e), e)
-        })?;
-        let file_size_bytes = bytes.len() as u64;
-        println!("Read {} bytes in {:.2?}", file_size_bytes, t.elapsed());
-
-        println!("Computing SHA-256...");
-        let t = Instant::now();
-        let sha256 = hex::encode(Sha256::digest(&bytes));
-        println!("SHA-256: {} in {:.2?}", sha256, t.elapsed());
-
-        drop(bytes);
+        let (file_size_bytes, blake3) = file_size_and_blake3(&self.file)?;
 
         println!("Deserializing DigestKey...");
         let t = Instant::now();
@@ -1546,9 +1554,55 @@ impl CliCommand<VerifyDigestKeyResult> for VerifyDigestKey {
         })?;
         println!("DigestKey is valid. Deserialized in {:.2?}", t.elapsed());
 
-        Ok(VerifyDigestKeyResult {
+        Ok(BlobValidationResult {
             file_size_bytes,
-            sha256,
+            blake3,
+        })
+    }
+}
+
+/// Validate a BCS-serialized PublicParameters blob file
+///
+/// Reads the file, computes the file size and blake3 checksum, and verifies
+/// that the contents are a valid BCS-serialized PublicParameters.
+#[derive(Parser)]
+pub struct ValidatePublicParameters {
+    /// Path to the BCS-serialized PublicParameters blob file
+    #[clap(value_parser)]
+    pub file: PathBuf,
+}
+
+#[async_trait]
+impl CliCommand<BlobValidationResult> for ValidatePublicParameters {
+    fn command_name(&self) -> &'static str {
+        "ValidatePublicParameters"
+    }
+
+    async fn execute(self) -> CliTypedResult<BlobValidationResult> {
+        use aptos_types::dkg::chunky_dkg::ChunkyDKGPublicParameters;
+        use std::time::Instant;
+
+        let (file_size_bytes, blake3) = file_size_and_blake3(&self.file)?;
+
+        println!("Deserializing PublicParameters...");
+        let t = Instant::now();
+        let bytes = std::fs::read(&self.file).map_err(|e| {
+            CliError::IO(format!("Failed to read {}: {}", self.file.display(), e), e)
+        })?;
+        let _pp: ChunkyDKGPublicParameters = bcs::from_bytes(&bytes).map_err(|e| {
+            CliError::UnexpectedError(format!(
+                "Failed to deserialize PublicParameters ({} bytes): {}",
+                file_size_bytes, e
+            ))
+        })?;
+        println!(
+            "PublicParameters is valid. Deserialized in {:.2?}",
+            t.elapsed()
+        );
+
+        Ok(BlobValidationResult {
+            file_size_bytes,
+            blake3,
         })
     }
 }

--- a/dkg/Cargo.toml
+++ b/dkg/Cargo.toml
@@ -38,6 +38,7 @@ aptos-validator-transaction-pool = { workspace = true }
 ark-std = { workspace = true }
 async-trait = { workspace = true }
 bcs = { workspace = true }
+blake3 = { workspace = true }
 bytes = { workspace = true }
 fail = { workspace = true }
 futures = { workspace = true }

--- a/dkg/src/counters.rs
+++ b/dkg/src/counters.rs
@@ -114,6 +114,24 @@ pub static PUBLIC_PARAMS_FILE_SIZE_BYTES: Lazy<IntGauge> = Lazy::new(|| {
     .unwrap()
 });
 
+pub static DIGEST_KEY_BLAKE3: Lazy<IntGaugeVec> = Lazy::new(|| {
+    register_int_gauge_vec!(
+        "aptos_dkg_digest_key_blake3",
+        "blake3 hash (hex) of the DigestKey blob file loaded at startup",
+        &["blake3"]
+    )
+    .unwrap()
+});
+
+pub static PUBLIC_PARAMS_BLAKE3: Lazy<IntGaugeVec> = Lazy::new(|| {
+    register_int_gauge_vec!(
+        "aptos_dkg_public_params_blake3",
+        "blake3 hash (hex) of the PublicParameters blob file loaded at startup",
+        &["blake3"]
+    )
+    .unwrap()
+});
+
 pub static CHUNKY_DKG_CONFIG_MODE: Lazy<IntGauge> = Lazy::new(|| {
     register_int_gauge!(
         "aptos_chunky_dkg_config_mode",

--- a/dkg/src/lib.rs
+++ b/dkg/src/lib.rs
@@ -18,7 +18,8 @@ use aptos_config::config::{ReliableBroadcastConfig, SafetyRulesConfig};
 use aptos_event_notifications::{
     DbBackedOnChainConfig, EventNotificationListener, ReconfigNotificationListener,
 };
-use aptos_metrics_core::IntGauge;
+use aptos_logger::{info, warn};
+use aptos_metrics_core::{IntGauge, IntGaugeVec};
 use aptos_network::application::interface::{NetworkClient, NetworkServiceEvents};
 use aptos_types::{
     chain_id::ChainId,
@@ -30,7 +31,11 @@ use aptos_types::{
 };
 use aptos_validator_transaction_pool::VTxnPoolState;
 use move_core_types::account_address::AccountAddress;
-use std::{path::PathBuf, time::Instant};
+use std::{
+    io,
+    path::{Path, PathBuf},
+    time::Instant,
+};
 use tokio::runtime::Runtime;
 pub use types::DKGMessage;
 
@@ -79,17 +84,18 @@ pub fn initialize_digest_key_with_counters(
         set_digest_key_path(path.clone());
     }
     let source = initialize_digest_key(chain_id, is_validator);
-    match &source {
-        DigestKeySource::WillLoadFromFile { file_size } => {
-            counters::DIGEST_KEY_FILE_SIZE_BYTES.set(*file_size as i64);
+    match source {
+        DigestKeySource::WillLoadFromFile { path, file_size } => {
+            counters::DIGEST_KEY_FILE_SIZE_BYTES.set(file_size as i64);
             counters::DIGEST_KEY_SOURCE
                 .with_label_values(&["file"])
                 .set(1);
             // Eagerly load the key in a background thread so the metric is available on all nodes.
-            std::thread::spawn(|| {
+            std::thread::spawn(move || {
                 let start = Instant::now();
                 let _ = &*DIGEST_KEY;
                 counters::DIGEST_KEY_LOAD_DURATION_SECONDS.observe(start.elapsed().as_secs_f64());
+                publish_blake3(&path, &counters::DIGEST_KEY_BLAKE3, "DigestKey");
             });
         },
         DigestKeySource::TestKeyFallback => {
@@ -112,17 +118,18 @@ pub fn initialize_public_parameters_with_counters(blob_path: Option<&PathBuf>, c
         set_public_parameters_path(path.clone());
     }
     let source = initialize_public_parameters(chain_id);
-    match &source {
-        PublicParametersSource::WillLoadFromFile { file_size } => {
-            counters::PUBLIC_PARAMS_FILE_SIZE_BYTES.set(*file_size as i64);
+    match source {
+        PublicParametersSource::WillLoadFromFile { path, file_size } => {
+            counters::PUBLIC_PARAMS_FILE_SIZE_BYTES.set(file_size as i64);
             counters::PUBLIC_PARAMS_SOURCE
                 .with_label_values(&["file"])
                 .set(1);
-            std::thread::spawn(|| {
+            std::thread::spawn(move || {
                 let start = Instant::now();
                 let _ = &*PUBLIC_PARAMETERS;
                 counters::PUBLIC_PARAMS_LOAD_DURATION_SECONDS
                     .observe(start.elapsed().as_secs_f64());
+                publish_blake3(&path, &counters::PUBLIC_PARAMS_BLAKE3, "PublicParameters");
             });
         },
         PublicParametersSource::TestKeyFallback => {
@@ -134,6 +141,35 @@ pub fn initialize_public_parameters_with_counters(blob_path: Option<&PathBuf>, c
             counters::PUBLIC_PARAMS_SOURCE
                 .with_label_values(&["none"])
                 .set(1);
+        },
+    }
+}
+
+fn hash_file_blake3(path: &Path) -> io::Result<blake3::Hash> {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update_mmap(path)?;
+    Ok(hasher.finalize())
+}
+
+fn publish_blake3(path: &Path, gauge: &IntGaugeVec, kind: &str) {
+    match hash_file_blake3(path) {
+        Ok(hash) => {
+            let hex = hash.to_hex();
+            gauge.with_label_values(&[hex.as_str()]).set(1);
+            info!(
+                "{} blake3 hash for {}: {}",
+                kind,
+                path.display(),
+                hex.as_str()
+            );
+        },
+        Err(e) => {
+            warn!(
+                "Failed to compute {} blake3 hash for {}: {}",
+                kind,
+                path.display(),
+                e
+            );
         },
     }
 }

--- a/types/src/dkg/chunky_dkg.rs
+++ b/types/src/dkg/chunky_dkg.rs
@@ -152,7 +152,7 @@ pub fn set_public_parameters(pp: Arc<ChunkyDKGPublicParameters>) {
 #[derive(Debug)]
 pub enum PublicParametersSource {
     /// A blob file exists and will be lazily read on first access.
-    WillLoadFromFile { file_size: u64 },
+    WillLoadFromFile { path: PathBuf, file_size: u64 },
     /// Will fall back to the built-in test parameters on first access.
     TestKeyFallback,
     /// No PublicParameters available (no path configured, not a test chain).
@@ -167,6 +167,7 @@ pub fn initialize_public_parameters(chain_id: ChainId) -> PublicParametersSource
     if let Some(path) = PUBLIC_PARAMETERS_PATH.get() {
         match std::fs::metadata(path) {
             Ok(meta) => PublicParametersSource::WillLoadFromFile {
+                path: path.clone(),
                 file_size: meta.len(),
             },
             Err(_) => PublicParametersSource::NotAvailable,
@@ -243,7 +244,7 @@ pub fn set_digest_key(key: Arc<DigestKey>) {
 #[derive(Debug)]
 pub enum DigestKeySource {
     /// A blob file exists and will be lazily read on first access.
-    WillLoadFromFile { file_size: u64 },
+    WillLoadFromFile { path: PathBuf, file_size: u64 },
     /// Fell back to the built-in test key.
     TestKeyFallback,
     /// No DigestKey is available (no path configured, not a test chain).
@@ -258,6 +259,7 @@ pub fn initialize_digest_key(chain_id: ChainId, is_validator: bool) -> DigestKey
     if let Some(path) = DIGEST_KEY_PATH.get() {
         match std::fs::metadata(path) {
             Ok(meta) => DigestKeySource::WillLoadFromFile {
+                path: path.clone(),
                 file_size: meta.len(),
             },
             Err(_) => DigestKeySource::NotAvailable,


### PR DESCRIPTION
## Summary

**Runtime (`[dkg]`)**
- Computes the blake3 hash of the DigestKey and PublicParameters blob files during the existing eager-load background thread and exposes each as an `IntGaugeVec` labelled with the hex hash (value `1`). Lets operators confirm the entire validator fleet loaded the same blob from disk by grouping on the `blake3` label in Grafana.
- Adds `blake3` (with `mmap` feature) as a workspace dependency and wires it into `aptos-dkg-runtime`.
- Plumbs the source path through `DigestKeySource::WillLoadFromFile` / `PublicParametersSource::WillLoadFromFile` so callers don't need a separate copy of the path.

New metrics:
- `aptos_dkg_digest_key_blake3{blake3="<hex>"}` = 1
- `aptos_dkg_public_params_blake3{blake3="<hex>"}` = 1

**CLI (`[cli]`)**
- Replaces `aptos node verify-digest-key` with two type-specific commands:
  - `aptos node validate-digest-key`
  - `aptos node validate-public-parameters`
- Each computes the file size + blake3 checksum (was SHA-256) and verifies that the blob BCS-deserializes to the corresponding type (`DigestKey` or `ChunkyDKGPublicParameters`).
- JSON output field renamed from `sha256` to `blake3`; shape shared via `BlobValidationResult`.
- Drops the `sha2` dep from the CLI; adds `blake3` (with `mmap`).
- CHANGELOG entry under `# Unreleased`.

## Test plan
- [ ] `cargo check -p aptos-dkg-runtime -p aptos-node -p aptos`
- [ ] Start a node with real DigestKey/PublicParameters blob files and confirm the new metrics appear with the expected hashes
- [ ] Verify on a test chain (no blob files) that the metrics simply don't appear (TestKeyFallback path is unaffected)
- [ ] Run \`aptos node validate-digest-key --file <path>\` and \`aptos node validate-public-parameters --file <path>\`; confirm the printed blake3 matches the values reported by the runtime metrics

🤖 Generated with [Claude Code](https://claude.com/claude-code)