### PR TITLE
[ci] Publish rustdoc for all crates to gh-pages

### DIFF
--- a/.github/rust-docs/build-index.sh
+++ b/.github/rust-docs/build-index.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+#
+# Generate a top-level index.html for the rustdoc output produced by
+# `cargo doc --workspace --no-deps`.
+#
+# Cargo writes per-crate HTML directories under target/doc/ but doesn't write
+# its own root index.html on stable (the `--enable-index-page` rustdoc flag is
+# nightly-only). This script enumerates the crate directories that actually
+# contain a rendered `index.html` and emits a simple landing page that links
+# to each one. It also stamps the page with the build SHA and timestamp passed
+# in via the environment so the deployed site advertises its provenance.
+#
+# Inputs (env):
+#   DOC_DIR     directory containing rustdoc output (default: target/doc)
+#   BUILD_SHA   full git sha of the source commit (default: from `git`)
+#   BUILD_TIME  human-readable build timestamp (default: now in UTC)
+#   REPO_URL    https URL of the source repo, used to deep-link the SHA
+#               (default: https://github.com/aptos-labs/aptos-core)
+#
+# Output:
+#   $DOC_DIR/index.html
+
+set -euo pipefail
+
+DOC_DIR="${DOC_DIR:-target/doc}"
+BUILD_SHA="${BUILD_SHA:-$(git rev-parse HEAD 2>/dev/null || echo unknown)}"
+BUILD_SHORT="$(printf '%s' "$BUILD_SHA" | cut -c1-12)"
+BUILD_TIME="${BUILD_TIME:-$(date -u +'%Y-%m-%d %H:%M UTC')}"
+REPO_URL="${REPO_URL:-https://github.com/aptos-labs/aptos-core}"
+
+if [ ! -d "$DOC_DIR" ]; then
+  echo "error: doc directory '$DOC_DIR' does not exist" >&2
+  exit 1
+fi
+
+# Enumerate every immediate subdirectory of $DOC_DIR that has its own
+# rustdoc-generated index.html. Cargo creates one such directory per crate
+# (using the crate's library name with hyphens converted to underscores), so
+# this set is exactly the list of crates whose docs we successfully built.
+mapfile -t CRATES < <(
+  find "$DOC_DIR" -mindepth 2 -maxdepth 2 -name index.html -printf '%h\n' \
+    | xargs -r -n1 basename \
+    | LC_ALL=C sort -u
+)
+
+if [ "${#CRATES[@]}" -eq 0 ]; then
+  echo "error: no crate documentation found under $DOC_DIR" >&2
+  exit 1
+fi
+
+echo "==> Generating index.html for ${#CRATES[@]} crates"
+
+INDEX="$DOC_DIR/index.html"
+
+{
+  cat <<HTML_HEAD
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>aptos-core Rust API documentation</title>
+  <style>
+    :root {
+      color-scheme: light dark;
+      --fg: #1f2328;
+      --muted: #57606a;
+      --bg: #ffffff;
+      --accent: #0969da;
+      --border: #d0d7de;
+    }
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --fg: #e6edf3;
+        --muted: #8b949e;
+        --bg: #0d1117;
+        --accent: #58a6ff;
+        --border: #30363d;
+      }
+    }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+      color: var(--fg);
+      background: var(--bg);
+      margin: 0;
+      padding: 2rem 1.5rem 4rem;
+    }
+    main { max-width: 64rem; margin: 0 auto; }
+    h1 { margin: 0 0 0.5rem; font-size: 2rem; }
+    p { color: var(--muted); margin: 0.25rem 0 1rem; }
+    .meta {
+      font-size: 0.9rem;
+      color: var(--muted);
+      border-bottom: 1px solid var(--border);
+      padding-bottom: 1rem;
+      margin-bottom: 1.5rem;
+    }
+    .meta a { color: var(--accent); text-decoration: none; }
+    .meta a:hover { text-decoration: underline; }
+    .filter {
+      width: 100%;
+      box-sizing: border-box;
+      padding: 0.5rem 0.75rem;
+      font-size: 1rem;
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      background: var(--bg);
+      color: var(--fg);
+      margin-bottom: 1rem;
+    }
+    ul.crates {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(18rem, 1fr));
+      gap: 0.25rem 1rem;
+    }
+    ul.crates li { padding: 0.2rem 0; }
+    ul.crates a { color: var(--accent); text-decoration: none; font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+    ul.crates a:hover { text-decoration: underline; }
+    footer { margin-top: 3rem; font-size: 0.8rem; color: var(--muted); }
+  </style>
+</head>
+<body>
+<main>
+  <h1>aptos-core Rust API documentation</h1>
+  <p>Auto-generated <code>cargo doc</code> output for every crate in the
+     <a href="${REPO_URL}">aptos-core</a> workspace.</p>
+  <div class="meta">
+    Built from
+    <a href="${REPO_URL}/commit/${BUILD_SHA}"><code>${BUILD_SHORT}</code></a>
+    at ${BUILD_TIME}.
+    Other documentation:
+    <a href="https://aptos.dev">aptos.dev</a> ·
+    <a href="https://aptos-labs.github.io/move-book/">Move book</a> ·
+    <a href="https://aptos-labs.github.io/framework-book/">Aptos framework book</a>.
+  </div>
+  <input class="filter" type="search" placeholder="Filter crates&hellip;" oninput="filterCrates(this.value)" autofocus>
+  <ul class="crates" id="crates">
+HTML_HEAD
+
+  for crate in "${CRATES[@]}"; do
+    # Each crate dir always contains an index.html; link straight to it.
+    printf '    <li><a href="%s/index.html">%s</a></li>\n' "$crate" "$crate"
+  done
+
+  cat <<HTML_TAIL
+  </ul>
+  <footer>
+    aptos-core ${BUILD_SHORT} · ${#CRATES[@]} crates · built ${BUILD_TIME}
+  </footer>
+</main>
+<script>
+  // Trivial client-side filter so users can find a crate without scrolling.
+  function filterCrates(needle) {
+    const q = needle.trim().toLowerCase();
+    for (const li of document.querySelectorAll('#crates li')) {
+      const name = li.textContent.toLowerCase();
+      li.style.display = !q || name.includes(q) ? '' : 'none';
+    }
+  }
+</script>
+</body>
+</html>
+HTML_TAIL
+} > "$INDEX"
+
+echo "==> Wrote $INDEX"

--- a/.github/rust-docs/publish.sh
+++ b/.github/rust-docs/publish.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+#
+# Publish a freshly built rustdoc tree to the gh-pages branch.
+#
+# The deploy is implemented as a single orphan commit so the gh-pages branch
+# stays small even though the rustdoc payload is large (the workspace has
+# hundreds of crates). Anything in $PRESERVE_PATHS is carried over from the
+# previous gh-pages tip; everything else from the old tree is dropped — that
+# is how the leftover Diem-era rustdoc gets cleaned up.
+#
+# Inputs (env):
+#   DOC_DIR          rustdoc tree to publish (default: target/doc)
+#   GITHUB_REPOSITORY  owner/repo (default: aptos-labs/aptos-core)
+#   GH_PAGES_BRANCH  destination branch (default: gh-pages)
+#   PRESERVE_PATHS   space-separated list of paths under gh-pages root to
+#                    carry over from the previous tip (default: "move-book")
+#   COMMIT_USER_NAME, COMMIT_USER_EMAIL
+#                    git author/committer identity for the deploy commit
+#   GITHUB_TOKEN     token with write access to the repo (required unless
+#                    DRY_RUN=1 is set)
+#   GITHUB_SHA       sha of the source commit being deployed (default: HEAD)
+#   DRY_RUN          if non-empty, build the commit but skip the push
+#
+# Usage:
+#   GITHUB_TOKEN=... bash .github/rust-docs/publish.sh
+#   DRY_RUN=1 bash .github/rust-docs/publish.sh
+
+set -euo pipefail
+
+DOC_DIR="${DOC_DIR:-target/doc}"
+GITHUB_REPOSITORY="${GITHUB_REPOSITORY:-aptos-labs/aptos-core}"
+GH_PAGES_BRANCH="${GH_PAGES_BRANCH:-gh-pages}"
+PRESERVE_PATHS="${PRESERVE_PATHS:-move-book}"
+COMMIT_USER_NAME="${COMMIT_USER_NAME:-github-actions[bot]}"
+COMMIT_USER_EMAIL="${COMMIT_USER_EMAIL:-41898282+github-actions[bot]@users.noreply.github.com}"
+GITHUB_SHA="${GITHUB_SHA:-$(git rev-parse HEAD 2>/dev/null || echo unknown)}"
+GITHUB_SHA_SHORT="$(printf '%s' "$GITHUB_SHA" | cut -c1-12)"
+BUILD_TIME="$(date -u +'%Y-%m-%d %H:%M UTC')"
+
+if [ ! -d "$DOC_DIR" ]; then
+  echo "error: doc directory '$DOC_DIR' does not exist" >&2
+  exit 1
+fi
+
+if [ -z "${GITHUB_TOKEN:-}" ] && [ -z "${DRY_RUN:-}" ]; then
+  echo "error: GITHUB_TOKEN must be set (or pass DRY_RUN=1)" >&2
+  exit 1
+fi
+
+DOC_DIR_ABS="$(cd "$DOC_DIR" && pwd)"
+WORK_DIR="$(mktemp -d -t rustdoc-deploy.XXXXXX)"
+PRESERVE_DIR="$(mktemp -d -t rustdoc-preserve.XXXXXX)"
+
+cleanup() {
+  rm -rf "$WORK_DIR" "$PRESERVE_DIR"
+}
+trap cleanup EXIT
+
+if [ -n "${GITHUB_TOKEN:-}" ]; then
+  CLONE_URL="https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+else
+  CLONE_URL="https://github.com/${GITHUB_REPOSITORY}.git"
+fi
+
+echo "==> Fetching $GH_PAGES_BRANCH from $GITHUB_REPOSITORY to harvest preserved paths"
+# Shallow clone is enough; we only need the current tip of gh-pages so we can
+# copy out the directories we want to keep. If the branch doesn't exist yet
+# (fresh-pages repo) we still create the destination from scratch.
+if git clone --depth=1 --branch "$GH_PAGES_BRANCH" "$CLONE_URL" "$WORK_DIR" 2>/dev/null; then
+  echo "==> Harvesting preserved paths: ${PRESERVE_PATHS}"
+  for path in $PRESERVE_PATHS; do
+    if [ -e "$WORK_DIR/$path" ]; then
+      mkdir -p "$PRESERVE_DIR/$(dirname "$path")"
+      cp -a "$WORK_DIR/$path" "$PRESERVE_DIR/$path"
+      echo "    kept $path"
+    else
+      echo "    (not present on $GH_PAGES_BRANCH) $path"
+    fi
+  done
+  rm -rf "$WORK_DIR"
+else
+  echo "==> $GH_PAGES_BRANCH does not exist yet; will create it"
+fi
+
+# Build the new tree as an orphan checkout. Using a fresh `git init` rather
+# than reusing the cloned working tree means the deploy commit has no parent,
+# which keeps the branch small even though we ship hundreds of MB of HTML.
+echo "==> Staging new gh-pages tree"
+mkdir -p "$WORK_DIR"
+cd "$WORK_DIR"
+git init --quiet --initial-branch="$GH_PAGES_BRANCH"
+git config user.name "$COMMIT_USER_NAME"
+git config user.email "$COMMIT_USER_EMAIL"
+git remote add origin "$CLONE_URL"
+
+# Copy the rustdoc output into the worktree root.
+cp -a "$DOC_DIR_ABS/." .
+
+# Restore preserved paths on top of the rustdoc tree. We restore *after* the
+# copy so a preserved path always wins over any same-named rustdoc artifact;
+# in practice rustdoc never produces e.g. a top-level `move-book/` directory,
+# so there is no real collision risk, but be explicit anyway.
+if [ -d "$PRESERVE_DIR" ]; then
+  cp -a "$PRESERVE_DIR/." . 2>/dev/null || true
+fi
+
+# `.nojekyll` tells GitHub Pages to skip Jekyll processing — required because
+# rustdoc emits files and directories whose names start with an underscore
+# (e.g. `_static/`), which Jekyll would otherwise hide.
+touch .nojekyll
+
+echo "==> Committing and pushing"
+git add -A
+if git diff --cached --quiet; then
+  echo "==> No changes to deploy."
+  exit 0
+fi
+git commit --quiet -m "publish rustdoc from aptos-core ${GITHUB_SHA_SHORT} (${BUILD_TIME})"
+
+if [ -n "${DRY_RUN:-}" ]; then
+  echo "==> DRY_RUN set; skipping push."
+  echo "    Staged commit lives in $WORK_DIR (cleaned on exit)."
+  exit 0
+fi
+
+# Force-push: each deploy is a single orphan commit, so the branch's history
+# is intentionally rewritten on every run.
+git push --force origin "HEAD:${GH_PAGES_BRANCH}"
+
+echo "==> Done."
+echo "    https://${GITHUB_REPOSITORY%/*}.github.io/${GITHUB_REPOSITORY#*/}/"

--- a/.github/workflows/rust-docs.yaml
+++ b/.github/workflows/rust-docs.yaml
@@ -1,0 +1,92 @@
+name: "Publish Rust Docs"
+
+# Build `cargo doc` for every workspace crate and publish the HTML to the
+# `gh-pages` branch, which GitHub Pages serves at
+# https://aptos-labs.github.io/aptos-core/. The deploy is a single orphan
+# commit per run (see .github/rust-docs/publish.sh) so the branch stays small
+# even though the rustdoc payload is large. Anything outside the rustdoc
+# payload that lives at the gh-pages root (currently just `move-book/`) is
+# carried over from the previous tip.
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      # Re-publish whenever Rust source, the workspace manifest, the toolchain
+      # pin, or the deploy plumbing itself changes. Avoid re-running on pure
+      # Move/docs/markdown churn that wouldn't change rustdoc output.
+      - "**/*.rs"
+      - "**/Cargo.toml"
+      - "Cargo.lock"
+      - "rust-toolchain.toml"
+      - ".github/workflows/rust-docs.yaml"
+      - ".github/rust-docs/**"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Build the docs but skip the push to gh-pages"
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+
+# Only one publish at a time — concurrent runs would race on the gh-pages
+# branch (we force-push). Don't cancel an in-flight publish; let it finish.
+concurrency:
+  group: rust-docs-publish
+  cancel-in-progress: false
+
+jobs:
+  build-and-publish:
+    # Forks won't have permission to push to gh-pages; skip there entirely.
+    if: github.repository == 'aptos-labs/aptos-core'
+    runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
+    timeout-minutes: 240
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Set up Rust toolchain and system deps
+        uses: ./.github/actions/rust-setup
+        with:
+          GIT_CREDENTIALS: ${{ secrets.GIT_CREDENTIALS }}
+          # Distinct cache key — rustdoc artifacts in target/doc are not
+          # produced by the regular check/test pipelines, so reusing those
+          # caches would mostly miss anyway. Keep them separate.
+          ADDITIONAL_KEY: rust-docs
+
+      - name: Build rustdoc for the entire workspace
+        run: |
+          set -euo pipefail
+          # `--no-deps` keeps us from rendering docs for every dependency on
+          # crates.io (which would balloon to many GB and add hours).
+          # `--keep-going` lets the build skip a crate that fails to render
+          # rather than aborting the whole workspace — partial docs are
+          # better than no docs.
+          cargo doc \
+            --workspace \
+            --no-deps \
+            --locked \
+            --keep-going
+
+      - name: Generate landing page
+        env:
+          BUILD_SHA: ${{ github.sha }}
+        run: bash .github/rust-docs/build-index.sh
+
+      - name: Report build size
+        run: |
+          du -sh target/doc
+          echo "Crates rendered:"
+          find target/doc -mindepth 2 -maxdepth 2 -name index.html | wc -l
+
+      - name: Publish to gh-pages
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_SHA: ${{ github.sha }}
+          DRY_RUN: ${{ (github.event_name == 'workflow_dispatch' && inputs.dry_run) && '1' || '' }}
+        run: bash .github/rust-docs/publish.sh

--- a/.github/workflows/rust-docs.yaml
+++ b/.github/workflows/rust-docs.yaml
@@ -45,7 +45,7 @@ jobs:
     runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     timeout-minutes: 240
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # pin@v4.3.1
         with:
           fetch-depth: 1
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

The repo's GitHub Pages site at <https://aptos-labs.github.io/aptos-core/> is currently serving the **Diem-era rustdoc from February 2022** — every directory at the root of the `gh-pages` branch is a `diem_*` crate (`diem_api`, `diem_crypto`, `diem_mempool`, `diem_node`, …). This PR replaces it with auto-generated rustdoc for the current aptos-core workspace.

It adds a new GitHub Actions workflow (`.github/workflows/rust-docs.yaml`) that:

1. Runs `cargo doc --workspace --no-deps --locked --keep-going` on the same beefy `runs-on` runner the existing rust workflows use.
2. Generates a top-level `index.html` landing page (`.github/rust-docs/build-index.sh`) listing every crate that successfully rendered, with a client-side filter and a stamp for the source SHA + build time.
3. Publishes the result to `gh-pages` (`.github/rust-docs/publish.sh`) as a **single orphan commit per run** so the branch stays small even though the rendered HTML is many GB. The previous tip's `move-book/` subdirectory is harvested and restored on top of the new tree so existing `…/aptos-core/move-book/` links keep working.
4. Triggers on push to `main` (filtered to changes that could affect rustdoc — `**/*.rs`, `Cargo.toml`/`Cargo.lock`, the toolchain pin, and the deploy plumbing itself) and via `workflow_dispatch` with an optional `dry_run` input.

After this lands, a single push to `main` (or a manual `Run workflow`) will wipe the Diem leftovers and replace them with current docs. No GitHub Pages settings need to change — Pages is already configured to serve from `gh-pages` root (`build_type: legacy`, verified via the GitHub API).

The only third-party action the workflow invokes (`actions/checkout`) is pinned to an immutable commit SHA (`@34e114876b0b11c390a56381ad16ebd13914f8d5 # pin@v4.3.1`), matching the repo convention used for `Swatinem/rust-cache`, `codecov/codecov-action`, etc. The local `./.github/actions/rust-setup` composite is the same one the rest of CI consumes.

## How Has This Been Tested?

Locally on the cloud agent VM, against the real `gh-pages` branch:

- `actionlint` and `yamllint` clean on the workflow.
- `shellcheck` clean on both helper scripts.
- `build-index.sh` exercised against a fake `target/doc` with a handful of crate dirs — produces well-formed HTML, links resolve, footer is stamped.
- `publish.sh` exercised end-to-end with `DRY_RUN=1` against the live `gh-pages` branch:
  - The clone-and-harvest step finds and copies out the existing `move-book/` directory.
  - The orphan commit contains the new rustdoc tree at root, `move-book/` restored, plus `.nojekyll`.
  - No Diem-era directories carry over.
  - Author/committer set to `github-actions[bot]`; commit message stamps the source SHA and build time.

The workflow is gated on `if: github.repository == 'aptos-labs/aptos-core'` so forks don't try (and fail) to push to gh-pages. A workspace-wide `cargo doc` build was not exercised on the agent VM (would have needed the full dev_setup + many GB of build cache); the workflow uses the existing `./.github/actions/rust-setup` composite that the rest of CI relies on for `cargo doc` and other builds.

## Key Areas to Review

- **Replacement vs. preservation policy.** `publish.sh` only carries `move-book/` over from the previous tip (`PRESERVE_PATHS="move-book"`). Everything else at the gh-pages root — including the Diem rustdoc — is dropped on the first run. Confirm this is the intended cleanup; if any other top-level path on `gh-pages` is being maintained out-of-band, add it to `PRESERVE_PATHS`.
- **Orphan commit / force-push.** Each deploy is a fresh orphan commit, force-pushed. This intentionally rewrites `gh-pages` history every run to keep the branch from ballooning. If you want to retain history (e.g. to roll back), switch to a non-orphan commit and accept that the branch will grow without bound.
- **Trigger filters.** The `paths:` list re-runs on Rust source / manifest / toolchain changes. Expand if you want pure docs/Move PRs to also refresh the published site (or remove the filter entirely to publish on every `main` push).
- **Runner choice and timeout.** Reuses the standard 64-CPU `c7` runner; `timeout-minutes: 240` is generous to avoid spurious failures on a cold cache. Tune if needed once we see real timings.
- **Action pinning.** `actions/checkout` is pinned to an immutable SHA (`@34e114876b0b11c390a56381ad16ebd13914f8d5 # pin@v4.3.1`).

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [x] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [x] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6e0c6756-4429-4de1-8ade-de3a220c724e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6e0c6756-4429-4de1-8ade-de3a220c724e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

