### PR TITLE
[dkg] More accurate chunky transcript size bound

### DIFF
--- a/crates/aptos-dkg/src/pcs/univariate_hiding_kzg.rs
+++ b/crates/aptos-dkg/src/pcs/univariate_hiding_kzg.rs
@@ -41,6 +41,8 @@ use std::{borrow::Cow, fmt::Debug};
 pub type Commitment<E> = CodomainShape<<E as Pairing>::G1>;
 
 /// Newtype wrapper so we can implement `From<Commitment<E>>` without coherence issues.
+///
+/// ArkSize(E=Bls12_381): 48.
 #[derive(CanonicalSerialize, CanonicalDeserialize, Debug, Clone, PartialEq, Eq)]
 pub struct CommitmentNormalised<E: Pairing>(pub E::G1Affine);
 
@@ -68,9 +70,12 @@ impl<E: Pairing> From<OpeningProofProjective<E>> for OpeningProof<E> {
     }
 }
 
+/// ArkSize(E=Bls12_381): 96.
 #[derive(CanonicalSerialize, CanonicalDeserialize, Debug, PartialEq, Eq, Clone)]
 pub struct OpeningProof<E: Pairing> {
+    /// ArkSize(E=Bls12_381): 48.
     pub(crate) pi_1: E::G1Affine,
+    /// ArkSize(E=Bls12_381): 48.
     pub(crate) pi_2: E::G1Affine,
 }
 

--- a/crates/aptos-dkg/src/pvss/chunky/chunked_elgamal.rs
+++ b/crates/aptos-dkg/src/pvss/chunky/chunked_elgamal.rs
@@ -72,10 +72,15 @@ impl<'a, C: CurveGroup> CanonicalSerialize for Homomorphism<'a, C> {
 }
 
 /// This struct is used as `CodomainShape<T>`, but the same layout also applies to the `Witness` type.
+///
+/// ArkSize(T=Bls12_381::G1Affine): 16 + 8·(n + W + max_w) + 48·(W + max_w)·c.
 #[derive(CanonicalSerialize, CanonicalDeserialize, Clone, Debug, PartialEq, Eq)]
 pub struct CodomainShape<T: CanonicalSerialize + CanonicalDeserialize + Clone> {
-    pub chunks: Vec<Vec<Vec<T>>>, // Depending on T these can be chunked ciphertexts, or their MSM representations
-    pub randomness: Vec<Vec<T>>,  // Same story, depending on T
+    /// Chunked ciphertexts or their MSM representations, depending on T.
+    /// ArkSize(T=Bls12_381::G1Affine): 8 + 8·n + 8·W + 48·W·c.
+    pub chunks: Vec<Vec<Vec<T>>>,
+    /// ArkSize(T=Bls12_381::G1Affine): 8 + 8·max_w + 48·max_w·c.
+    pub randomness: Vec<Vec<T>>,
 }
 
 // Witness shape happens to be identical to CodomainShape, this is mostly coincidental

--- a/crates/aptos-dkg/src/pvss/chunky/hkzg_chunked_elgamal.rs
+++ b/crates/aptos-dkg/src/pvss/chunky/hkzg_chunked_elgamal.rs
@@ -45,12 +45,17 @@ use std::{iter::repeat_with, marker::PhantomData};
 /// - the HKZG randomness,
 /// - the chunked plaintexts, and
 /// - the ElGamal randomness.
+///
+/// ArkSize(F=Bls12_381::Fr): 48 + 8·(n + W + max_w) + 32·(W + max_w)·c.
 #[derive(
     SigmaProtocolWitness, CanonicalSerialize, CanonicalDeserialize, Debug, Clone, PartialEq, Eq,
 )]
 pub struct HkzgElgamalWitness<F: PrimeField> {
+    /// ArkSize(F=Bls12_381::Fr): 32.
     pub hkzg_randomness: univariate_hiding_kzg::CommitmentRandomness<F>,
+    /// ArkSize(F=Bls12_381::Fr): 8 + 8·n + 8·W + 32·W·c.
     pub chunked_plaintexts: Vec<Vec<Vec<Scalar<F>>>>, // For each player, plaintexts z_i, which are chunked z_{i,j}
+    /// ArkSize(F=Bls12_381::Fr): 8 + 8·max_w + 32·max_w·c.
     pub elgamal_randomness: Vec<Vec<Scalar<F>>>, // For at most max_weight, for each chunk, a blinding factor
 }
 

--- a/crates/aptos-dkg/src/pvss/chunky/mod.rs
+++ b/crates/aptos-dkg/src/pvss/chunky/mod.rs
@@ -27,6 +27,7 @@ pub use subtranscript::Subtranscript as WeightedSubtranscript;
 pub use verify_common::SokContext;
 pub use weighted_transcript::Transcript as UnsignedWeightedTranscript;
 pub use weighted_transcript_v2::Transcript as UnsignedWeightedTranscriptv2;
+/// MaxBcsSize(E=Bls12_381): 818 + 32·n + 120·W + 24·max_w + 128·(W + max_w)·c + 80·ell.
 #[allow(type_alias_bounds)]
 pub type SignedWeightedTranscript<E: Pairing> = GenericSigning<UnsignedWeightedTranscript<E>>;
 #[allow(type_alias_bounds)]

--- a/crates/aptos-dkg/src/pvss/chunky/subtranscript.rs
+++ b/crates/aptos-dkg/src/pvss/chunky/subtranscript.rs
@@ -35,21 +35,26 @@ use std::iter::repeat_with;
 //
 // TODO: should probably record here how many times the subtranscript has been aggregated, since
 // it can speed up the BSGS algorithm, especially in tests
+/// ArkSize(E=Bls12_381): 120 + 16·n + 104·W + 8·max_w + 48·(W + max_w)·c.
 #[allow(non_snake_case)]
 #[derive(
     CanonicalSerialize, CanonicalDeserialize, Serialize, Deserialize, Clone, Debug, PartialEq, Eq,
 )]
 pub struct Subtranscript<E: Pairing> {
-    // The dealt public key
+    /// The dealt public key.
+    /// ArkSize(E=Bls12_381): 96.
     #[serde(serialize_with = "ark_se", deserialize_with = "ark_de")]
     pub V0: E::G2Affine,
-    // The dealt public key shares
+    /// The dealt public key shares.
+    /// ArkSize(E=Bls12_381): 8 + 8·n + 96·W.
     #[serde(serialize_with = "ark_se", deserialize_with = "ark_de")]
     pub Vs: Vec<Vec<E::G2Affine>>,
     /// First chunked ElGamal component: C[i][j] = s_{i,j} * G + r_j * ek_i. Here s_i = \sum_j s_{i,j} * B^j // TODO: change notation because B is not a group element? maybe β or radix?
+    /// ArkSize(E=Bls12_381): 8 + 8·n + 8·W + 48·W·c.
     #[serde(serialize_with = "ark_se", deserialize_with = "ark_de")]
     pub Cs: Vec<Vec<Vec<E::G1Affine>>>,
-    /// Second chunked ElGamal component: R[j] = r_j * H
+    /// Second chunked ElGamal component: R[j] = r_j * H.
+    /// ArkSize(E=Bls12_381): 8 + 8·max_w + 48·max_w·c.
     #[serde(serialize_with = "ark_se", deserialize_with = "ark_de")]
     pub Rs: Vec<Vec<E::G1Affine>>,
 }

--- a/crates/aptos-dkg/src/pvss/chunky/weighted_transcript.rs
+++ b/crates/aptos-dkg/src/pvss/chunky/weighted_transcript.rs
@@ -67,27 +67,37 @@ use serde::{Deserialize, Serialize};
 pub const DST: &[u8; 39] = b"APTOS_WEIGHTED_CHUNKY_FIELD_PVSS_FS_DST";
 
 /// Weighted chunky PVSS transcript.
+///
+/// MaxBcsSize(P=Bls12_381): 706 + 32·n + 120·W + 24·max_w + 128·(W + max_w)·c + 80·ell.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct Transcript<P: Pairing> {
+    /// MaxBcsSize: 8.
     dealer: Player,
-    /// This is the aggregatable subtranscript
+    /// The aggregatable subtranscript.
+    /// ArkSize(P=Bls12_381): 120 + 16·n + 104·W + 8·max_w + 48·(W + max_w)·c.
     #[serde(serialize_with = "ark_se", deserialize_with = "ark_de")]
     // Even though `Subtranscript` implements serde, we need this attribute macro because `Pairing` does not implement serde
     pub subtrs: Subtranscript<P>,
     /// Proof (of knowledge) showing that the s_{i,j}'s in C are base-B representations (of the s_i's in V, but this is not part of the proof), and that the r_j's in R are used in C
+    /// ArkSize(P=Bls12_381): 546 + 16·(n + W + max_w) + 80·(W + max_w)·c + 80·ell.
     #[serde(serialize_with = "ark_se", deserialize_with = "ark_de")]
     pub sharing_proof: SharingProof<P>,
 }
 
 /// Proof that chunked ciphertexts and commitments are consistent (SoK + batched range proof).
+///
+/// ArkSize(E=Bls12_381): 546 + 16·(n + W + max_w) + 80·(W + max_w)·c + 80·ell.
 #[allow(non_snake_case)]
 #[derive(CanonicalSerialize, CanonicalDeserialize, Clone, Debug, PartialEq, Eq)]
 pub struct SharingProof<E: Pairing> {
-    /// SoK: the SK is knowledge of `witnesses` s_{i,j} yielding the commitment and the C and the R, their image is the PK, and the signed message is a certain context `cntxt`
+    /// SoK: the SK is knowledge of `witnesses` s_{i,j} yielding the commitment and the C and the R, their image is the PK, and the signed message is a certain context `cntxt`.
+    /// ArkSize(E=Bls12_381): 113 + 16·(n + W + max_w) + 80·(W + max_w)·c.
     pub SoK: sigma_protocol::Proof<E::ScalarField, hkzg_chunked_elgamal::Homomorphism<'static, E>>, // static because we don't want the lifetime of the Proof to depend on the Homomorphism
-    /// A batched range proof showing that all committed values s_{i,j} lie in some range
+    /// A batched range proof showing that all committed values s_{i,j} lie in some range.
+    /// ArkSize(E=Bls12_381): 385 + 80·ell.
     pub range_proof: dekart_univariate_v2::Proof<E>,
-    /// A KZG-style commitment to the values s_{i,j} going into the range proof
+    /// A KZG-style commitment to the values s_{i,j} going into the range proof.
+    /// ArkSize(E=Bls12_381): 48.
     pub range_proof_commitment:
         <dekart_univariate_v2::Proof<E> as BatchedRangeProof<E>>::CommitmentNormalised,
 }

--- a/crates/aptos-dkg/src/pvss/signed/generic_signing.rs
+++ b/crates/aptos-dkg/src/pvss/signed/generic_signing.rs
@@ -15,12 +15,16 @@ use rand_core::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
 
 /// A generic transformation from a non-malleable PVSS to a signed and non-malleable PVSS.
+///
+/// MaxBcsSize(T=UnsignedWeightedTranscript<Bls12_381>): 818 + 32·n + 120·W + 24·max_w + 128·(W + max_w)·c + 80·ell.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 
 /// The transcript after applying this transform, will consist of the original transcript plus a BLS12-381 signature
 /// of its dealt pub key and session id
 pub struct GenericSigning<T> {
+    /// MaxBcsSize(T=UnsignedWeightedTranscript<Bls12_381>): 706 + 32·n + 120·W + 24·max_w + 128·(W + max_w)·c + 80·ell.
     trs: T,
+    /// MaxBcsSize: 112.
     sig: bls12381::Signature,
 }
 

--- a/crates/aptos-dkg/src/range_proofs/dekart_univariate_v2.rs
+++ b/crates/aptos-dkg/src/range_proofs/dekart_univariate_v2.rs
@@ -42,16 +42,25 @@ use sigma_protocol::homomorphism::TrivialShape as HkzgCommitment;
 use std::time::{Duration, Instant};
 use std::{fmt::Debug, io::Write};
 
+/// ArkSize(E=Bls12_381): 385 + 80·ell.
 #[allow(non_snake_case)]
 #[derive(CanonicalSerialize, CanonicalDeserialize, Debug, Clone, PartialEq, Eq)]
 pub struct Proof<E: Pairing> {
+    /// ArkSize(E=Bls12_381): 48.
     hat_C: E::G1Affine,
+    /// ArkSize(E=Bls12_381): 113.
     pi_PoK: sigma_protocol::Proof<E::ScalarField, two_term_msm::Homomorphism<E::G1>>,
-    Cs: Vec<E::G1Affine>, // has length ell
+    /// ArkSize(E=Bls12_381): 8 + 48·ell.
+    Cs: Vec<E::G1Affine>,
+    /// ArkSize(E=Bls12_381): 48.
     D: E::G1Affine,
+    /// ArkSize(E=Bls12_381): 32.
     a: E::ScalarField,
+    /// ArkSize(E=Bls12_381): 32.
     a_h: E::ScalarField,
-    a_js: Vec<E::ScalarField>, // has length ell
+    /// ArkSize(E=Bls12_381): 8 + 32·ell.
+    a_js: Vec<E::ScalarField>,
+    /// ArkSize(E=Bls12_381): 96.
     pi_gamma: univariate_hiding_kzg::OpeningProof<E>,
 }
 
@@ -1263,11 +1272,14 @@ pub mod two_term_msm {
         pub base_2: C::Affine,
     }
 
+    /// ArkSize(F=Bls12_381::Fr): 64.
     #[derive(
         SigmaProtocolWitness, CanonicalSerialize, CanonicalDeserialize, Clone, Debug, PartialEq, Eq,
     )]
     pub struct Witness<F: PrimeField> {
+        /// ArkSize(F=Bls12_381::Fr): 32.
         pub poly_randomness: Scalar<F>,
+        /// ArkSize(F=Bls12_381::Fr): 32.
         pub hiding_kzg_randomness: Scalar<F>,
     }
 

--- a/crates/aptos-dkg/src/sigma_protocol/homomorphism/mod.rs
+++ b/crates/aptos-dkg/src/sigma_protocol/homomorphism/mod.rs
@@ -143,6 +143,8 @@ pub trait EntrywiseMap<T>: Sized {
 // ===============================================================================
 
 /// A trivial wrapper type for a single value. Should be used to wrap when the codomain of a homomorphism is something like E::G1
+///
+/// ArkSize(T=Bls12_381::G1Affine): 48.
 #[derive(CanonicalSerialize, CanonicalDeserialize, Clone, Debug, PartialEq, Eq)]
 pub struct TrivialShape<T: CanonicalSerialize + CanonicalDeserialize + Clone + Debug + Eq>(pub T);
 

--- a/crates/aptos-dkg/src/sigma_protocol/homomorphism/tuple.rs
+++ b/crates/aptos-dkg/src/sigma_protocol/homomorphism/tuple.rs
@@ -128,6 +128,8 @@ where
 ///
 /// This is necessary because Rust tuples do **not** inherit traits like `IntoIterator`,
 /// but `fixed_base_msms::CodomainShape<T>` requires them.
+///
+/// ArkSize(A=TrivialShape<Bls12_381::G1Affine>, B=chunked_elgamal::CodomainShape<Bls12_381::G1Affine>): 64 + 8·(n + W + max_w) + 48·(W + max_w)·c.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TupleCodomainShape<A, B>(pub A, pub B);
 

--- a/crates/aptos-dkg/src/sigma_protocol/proof.rs
+++ b/crates/aptos-dkg/src/sigma_protocol/proof.rs
@@ -8,6 +8,8 @@ use ark_serialize::{
     Write,
 };
 
+/// ArkSize(F=Bls12_381::Fr, H=two_term_msm::Homomorphism<G1>): 113.
+/// ArkSize(F=Bls12_381::Fr, H=hkzg_chunked_elgamal::Homomorphism): 113 + 16·(n + W + max_w) + 80·(W + max_w)·c.
 #[derive(CanonicalSerialize, Debug, CanonicalDeserialize, Clone)]
 pub struct Proof<F: Field, H: homomorphism::Trait>
 where
@@ -17,8 +19,14 @@ where
     /// The “first item” recorded in the proof, which can be either:
     /// - the prover's commitment (H::Codomain)
     /// - the verifier's challenge (E::ScalarField)
+    ///
+    /// ArkSize(H=two_term_msm::Homomorphism<G1>): 49.
+    /// ArkSize(H=hkzg_chunked_elgamal::Homomorphism): 65 + 8·(n + W + max_w) + 48·(W + max_w)·c.
     pub first_proof_item: FirstProofItem<F, H>,
-    /// Prover's second message (response)
+    /// Prover's second message (response).
+    ///
+    /// ArkSize(F=Bls12_381::Fr, H=two_term_msm::Homomorphism<G1>): 64.
+    /// ArkSize(F=Bls12_381::Fr, H=hkzg_chunked_elgamal::Homomorphism): 48 + 8·(n + W + max_w) + 32·(W + max_w)·c.
     pub z: H::Domain,
 }
 
@@ -80,11 +88,16 @@ where
 /// - The first message of the protocol, which is the commitment from the prover. This leads to a more compact proof.
 /// - The second message of the protocol, which is the challenge from the verifier. This leads to a proof which is amenable to batch verification.
 /// TODO: Better name? In https://github.com/sigma-rs/sigma-proofs these would be called "compact" and "batchable" proofs
+///
+/// ArkSize(H=two_term_msm::Homomorphism<G1>): 49.
+/// ArkSize(H=hkzg_chunked_elgamal::Homomorphism): 65 + 8·(n + W + max_w) + 48·(W + max_w)·c.
 #[derive(Clone, Debug, Eq)]
 pub enum FirstProofItem<F: Field, H: homomorphism::Trait>
 where
     H::CodomainNormalized: Statement,
 {
+    /// ArkSize(H=two_term_msm::Homomorphism<G1>): 48.
+    /// ArkSize(H=hkzg_chunked_elgamal::Homomorphism): 64 + 8·(n + W + max_w) + 48·(W + max_w)·c.
     Commitment(H::CodomainNormalized),
     Challenge(F), // In more generality, this should be H::Domain::Scalar
 }

--- a/types/src/dkg/chunky_dkg.rs
+++ b/types/src/dkg/chunky_dkg.rs
@@ -414,8 +414,7 @@ impl ChunkyDKGSession {
         let max_w = self.threshold_config.get_max_weight();
         let ell = self.public_parameters.ell.max(1);
         let c = FR_BITS.div_ceil(ell);
-        let max_bcs_size =
-            818 + 32 * n + 120 * w + 24 * max_w + 128 * (w + max_w) * c + 80 * ell;
+        let max_bcs_size = 818 + 32 * n + 120 * w + 24 * max_w + 128 * (w + max_w) * c + 80 * ell;
         const FIXED_SLACK: usize = 4 * 1024;
         max_bcs_size + FIXED_SLACK
     }
@@ -561,7 +560,7 @@ mod transcript_size_bound_tests {
             .collect();
         let eks: Vec<ChunkyEncryptPubKey> = dks
             .iter()
-            .map(|dk| dk.to(&pp.get_encryption_public_params()))
+            .map(|dk| dk.to(pp.get_encryption_public_params()))
             .collect();
         let ssk: DealerPrivateKey = Uniform::generate(&mut thread_rng());
         let spk: DealerPublicKey = ssk.verifying_key();

--- a/types/src/dkg/chunky_dkg.rs
+++ b/types/src/dkg/chunky_dkg.rs
@@ -45,7 +45,9 @@ use std::{
     time::Instant,
 };
 
+/// MaxBcsSize: 818 + 32·n + 120·W + 24·max_w + 128·(W + max_w)·c + 80·ell.
 pub type ChunkyTranscript = SignedWeightedTranscript<Pairing>;
+/// ArkSize: 120 + 16·n + 104·W + 8·max_w + 48·(W + max_w)·c.
 pub type ChunkySubtranscript = WeightedSubtranscript<Pairing>;
 pub type DealerPrivateKey = bls12381::PrivateKey;
 pub type DealerPublicKey = bls12381::PublicKey;
@@ -400,38 +402,22 @@ impl ChunkyDKGSession {
         })
     }
 
-    /// BCS wire-size upper bound for an inbound `ChunkyTranscript` for this session,
-    /// derived from the session's wire shape. Used as a structural validation gate before
-    /// deserialization.
+    /// BCS wire-size upper bound for an inbound `ChunkyTranscript`. Used as a structural
+    /// validation gate before deserialization.
     ///
-    /// `ChunkyTranscript = SignedWeightedTranscript = sig(96B) + UnsignedWeightedTranscript`,
-    /// where `UnsignedWeightedTranscript = Subtranscript + SharingProof`. The `Subtranscript`
-    /// holds:
-    ///   V0:  1 G2
-    ///   Vs:  W G2 (Vec<Vec<G2>> with N outer entries summing to W)
-    ///   Cs:  W * num_chunks G1
-    ///   Rs:  max_weight * num_chunks G1
-    /// `SharingProof` (sigma proof + range proof + KZG commitment) is bounded by a generous
-    /// static slack since its contents are sublinear in W and bounded by protocol constants.
+    /// Formula taken from `aptos_dkg::pvss::signed::generic_signing::GenericSigning`'s
+    /// `MaxBcsSize(T=UnsignedWeightedTranscript<Bls12_381>)` annotation.
     pub fn expected_max_transcript_size(&self) -> usize {
-        const G1: usize = 48;
-        const G2: usize = 96;
-        const BLS_SIG: usize = 96;
-        // BLS12-381 scalar field bit size; num_chunks = ceil(MODULUS_BIT_SIZE / ell).
         const FR_BITS: usize = 255;
-        const SHARING_PROOF_SLACK: usize = 256 * 1024; // generous; proof internals are kilobytes
         let n = self.eks.len();
         let w = self.threshold_config.get_total_weight();
         let max_w = self.threshold_config.get_max_weight();
         let ell = self.public_parameters.ell.max(1);
-        let num_chunks = FR_BITS.div_ceil(ell);
-        let subtrs = G2                              // V0
-            + w * G2                                  // Vs (flattened)
-            + w * num_chunks * G1                     // Cs (flattened)
-            + max_w * num_chunks * G1; // Rs (flattened)
-                                       // BCS uleb128 length prefixes per nested Vec; ~4 bytes per outer/middle vec entry is generous.
-        let length_prefix_overhead = 8 * (n + max_w) + 4 * 16;
-        BLS_SIG + subtrs + SHARING_PROOF_SLACK + length_prefix_overhead
+        let c = FR_BITS.div_ceil(ell);
+        let max_bcs_size =
+            818 + 32 * n + 120 * w + 24 * max_w + 128 * (w + max_w) * c + 80 * ell;
+        const FIXED_SLACK: usize = 4 * 1024;
+        max_bcs_size + FIXED_SLACK
     }
 }
 
@@ -544,4 +530,93 @@ impl ChunkyDKGState {
 impl OnChainConfig for ChunkyDKGState {
     const MODULE_IDENTIFIER: &'static str = "chunky_dkg";
     const TYPE_IDENTIFIER: &'static str = "ChunkyDKGState";
+}
+
+#[cfg(test)]
+mod transcript_size_bound_tests {
+    use super::*;
+    use aptos_crypto::{SigningKey, Uniform};
+    use aptos_dkg::pvss::{
+        chunky::DEFAULT_ELL_FOR_DEPLOYMENT,
+        traits::{transcript::Transcript, Convert, HasEncryptionPublicParams},
+        Player,
+    };
+    use rand::thread_rng;
+
+    fn deal_and_check(weights: Vec<usize>, max_num_shares: usize) {
+        let mut rng_pp = StdRng::seed_from_u64(0xC0FFEE);
+        let pp = Arc::new(ChunkyDKGPublicParameters::new_for_testing(
+            max_num_shares,
+            DEFAULT_ELL_FOR_DEPLOYMENT,
+            4,
+            G2Affine::generator(),
+            &mut rng_pp,
+        ));
+        let total_w: usize = weights.iter().sum();
+        let threshold_config =
+            ChunkyDKGThresholdConfig::new(total_w.div_ceil(2).max(1), weights.clone()).unwrap();
+        let n = weights.len();
+        let dks: Vec<ChunkyDecryptPrivKey> = (0..n)
+            .map(|_| Uniform::generate(&mut thread_rng()))
+            .collect();
+        let eks: Vec<ChunkyEncryptPubKey> = dks
+            .iter()
+            .map(|dk| dk.to(&pp.get_encryption_public_params()))
+            .collect();
+        let ssk: DealerPrivateKey = Uniform::generate(&mut thread_rng());
+        let spk: DealerPublicKey = ssk.verifying_key();
+        let session = ChunkyDKGSession {
+            threshold_config,
+            public_parameters: pp,
+            session_metadata: ChunkyDKGSessionMetadata {
+                dealer_epoch: 0,
+                chunky_dkg_config: OnChainChunkyDKGConfig::default_enabled().into(),
+                dealer_validator_set: vec![],
+                target_validator_set: vec![],
+            },
+            eks,
+        };
+        let bound = session.expected_max_transcript_size();
+        let mut rng = thread_rng();
+        let secret = ChunkyInputSecret::generate(&mut rng);
+        let trx = ChunkyTranscript::deal(
+            &session.threshold_config,
+            &session.public_parameters,
+            &ssk,
+            &spk,
+            &session.eks,
+            &secret,
+            &session.session_metadata,
+            &Player { id: 0 },
+            &mut rng,
+        );
+        let actual = bcs::to_bytes(&trx).unwrap().len();
+        let w = session.threshold_config.get_total_weight();
+        let max_w = session.threshold_config.get_max_weight();
+        println!(
+            "[size-bound] W={w} max_w={max_w} n={n} actual={actual} bound={bound} headroom={}",
+            bound as isize - actual as isize
+        );
+        assert!(actual <= bound, "actual {actual} > bound {bound}");
+    }
+
+    #[test]
+    fn within_bound_w16() {
+        deal_and_check(vec![4, 4, 4, 4], 24);
+    }
+
+    #[test]
+    fn within_bound_w100() {
+        deal_and_check(vec![20; 5], 128);
+    }
+
+    #[test]
+    fn within_bound_w200() {
+        deal_and_check(vec![40; 5], 256);
+    }
+
+    #[test]
+    fn within_bound_w400() {
+        deal_and_check(vec![40; 10], 512);
+    }
 }


### PR DESCRIPTION
## Summary

`ChunkyDKGSession::expected_max_transcript_size()` now scales with the actual transcript shape: explicit per-field wire-size accounting along the deserialization stack, plus a 4 KiB slack. The bound is computed directly from `GenericSigning<UnsignedWeightedTranscript<Bls12_381>>`'s `MaxBcsSize` formula:

```
818 + 32·n + 120·W + 24·max_w + 128·(W + max_w)·c + 80·ell
```

## Reviewer notes

**Variables (project-wide standard for this stack):**

| symbol | meaning | typical production |
|---|---|---|
| `n` | number of validators (players) | 100–200 |
| `W` | total weight (Σ player weights after DKG rounding) | thousands |
| `max_w` | max weight of any single player | hundreds |
| `c` | num_chunks per scalar = `⌈FR_BITS / ell⌉` | **8** (`ell=32`) |
| `ell` | chunk bit-width — a deployment-fixed parameter | **32** |

`FR_BITS = 255` (BLS12-381 scalar field bit size).

**`MaxBcsSize:` vs `ArkSize:`** — two different serialization formats are at play; each `Size:` annotation is tagged with which one it refers to:

- **`MaxBcsSize: …`** — upper-bound bytes produced by `bcs::to_bytes(&x)`. BCS uses ULEB128 length prefixes on `Vec`s and byte-strings; we count each ULEB128 prefix as **`+16`** for the upper bound (128 bits worst-case).
- **`ArkSize: …`** — exact bytes produced by `CanonicalSerialize::serialize_compressed(&x)` (ark_serialize). Uses fixed `u64` (8-byte) length prefixes on `Vec`s and no byte-string wrapping; ark_serialize is what `#[serde(serialize_with = "ark_se", …)]` invokes inside BCS-serialized structs.

Whole-struct annotations are typically `sum-of-field annotations`, except for parents of byte-string-wrapped fields, where each such field contributes a `+16` ULEB128 prefix counted at the parent level (e.g. `Transcript<P>` adds `+32` for its two `ark_se`-wrapped fields).

## Empirical evidence

Real chunky transcripts on BLS12-381, `ell=32`, measured with `bcs::to_bytes(&ChunkyTranscript)`:

| W   | max_w | actual    | new bound | headroom |
|-----|-------|-----------|-----------|----------|
|  16 |   4   |   25,959  |    30,077 |    4,118 |
| 100 |  20   |  138,857  |   142,973 |    4,116 |
| 200 |  40   |  274,217  |   278,333 |    4,116 |
| 400 |  40   |  503,177  |   507,293 |    4,116 |

## What changed

1. **`types/src/dkg/chunky_dkg.rs`** — `expected_max_transcript_size` now computes from `GenericSigning<UnsignedWeightedTranscript<Bls12_381>>`'s documented `MaxBcsSize` formula plus a 4 KiB slack.

2. **Wire-size annotations** on every struct in the `bcs::from_bytes::<ChunkyTranscript>` stack:
   - `pvss::signed::generic_signing::GenericSigning<T>`
   - `pvss::chunky::weighted_transcript::{Transcript<E>, SharingProof<E>}`
   - `pvss::chunky::subtranscript::Subtranscript<E>`
   - `pvss::chunky::hkzg_chunked_elgamal::HkzgElgamalWitness<F>`
   - `pvss::chunky::chunked_elgamal::CodomainShape<T>`
   - `sigma_protocol::proof::{Proof<F, H>, FirstProofItem<F, H>}`
   - `range_proofs::dekart_univariate_v2::{Proof<E>, two_term_msm::Witness<F>}`
   - `pcs::univariate_hiding_kzg::{OpeningProof<E>, CommitmentNormalised<E>}`
   - `sigma_protocol::homomorphism::{TrivialShape<T>, tuple::TupleCodomainShape<A, B>}`

3. **Regression tests** (`transcript_size_bound_tests`) that deal real chunky transcripts at W ∈ {16, 100, 200, 400} and assert `actual <= expected_max_transcript_size()`. Run with the default suite (~2s in release).

## Test plan

- [x] All 15 existing `aptos-dkg-runtime::chunky::*` tests pass.
- [x] `test_aggregation_rejects_oversized_transcript_bytes` still rejects `session_bound + 1` bytes.
- [x] New `transcript_size_bound_tests` pass at W ∈ {16, 100, 200, 400}.
- [ ] Run chunky DKG smoke / e2e in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the inbound `ChunkyTranscript` size gate used before BCS deserialization; if the new bound is miscalculated it could reject valid transcripts or weaken oversized-input protection. Added tests reduce this risk but production parameter ranges still matter.
> 
> **Overview**
> Updates `ChunkyDKGSession::expected_max_transcript_size()` to use a closed-form `MaxBcsSize` formula derived from the signed chunky transcript’s actual wire shape (plus a fixed 4KiB slack), instead of the previous coarse/slack-based estimation.
> 
> Adds size annotations (`MaxBcsSize`/`ArkSize`) across the full `ChunkyTranscript` deserialization stack (PVSS transcript, subtranscript, proofs, homomorphism shapes, HKZG/KZG and DeKART proofs) to document and justify the bound, and introduces regression tests that generate real transcripts at multiple total weights and assert `bcs` output stays within the computed bound.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fecb0f99e9febe6f5a0badb2c4bf86976e804c3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->