### PR TITLE
[state-sync] Carry write-set hotness in v2 output responses

### DIFF
--- a/config/src/config/state_sync_config.rs
+++ b/config/src/config/state_sync_config.rs
@@ -176,6 +176,8 @@ pub struct StorageServiceConfig {
     pub enable_size_and_time_aware_chunking: bool,
     /// Whether transaction data v2 is enabled
     pub enable_transaction_data_v2: bool,
+    /// Whether to carry per-output hot state keys alongside v2 output responses
+    pub enable_hotness_in_state_sync: bool,
     /// Maximum number of epoch ending ledger infos per chunk
     pub max_epoch_chunk_size: u64,
     /// Maximum number of invalid requests per peer
@@ -219,6 +221,7 @@ impl Default for StorageServiceConfig {
         Self {
             enable_size_and_time_aware_chunking: true,
             enable_transaction_data_v2: true,
+            enable_hotness_in_state_sync: true,
             max_epoch_chunk_size: MAX_EPOCH_CHUNK_SIZE,
             max_invalid_requests_per_peer: 500,
             max_requests_per_second_per_peer: None,
@@ -561,7 +564,13 @@ impl ConfigOptimizer for StateSyncConfig {
             chain_id,
         )?;
 
-        Ok(modified_driver_config || modified_data_streaming_config)
+        // Optimize the storage service
+        let modified_storage_service_config =
+            StorageServiceConfig::optimize(node_config, local_config_yaml, node_type, chain_id)?;
+
+        Ok(modified_driver_config
+            || modified_data_streaming_config
+            || modified_storage_service_config)
     }
 }
 
@@ -585,6 +594,33 @@ impl ConfigOptimizer for StateSyncDriverConfig {
             {
                 state_sync_driver_config.bootstrapping_mode =
                     BootstrappingMode::DownloadLatestStates;
+                modified_config = true;
+            }
+        }
+
+        Ok(modified_config)
+    }
+}
+
+impl ConfigOptimizer for StorageServiceConfig {
+    fn optimize(
+        node_config: &mut NodeConfig,
+        local_config_yaml: &Value,
+        _node_type: NodeType,
+        chain_id: Option<ChainId>,
+    ) -> Result<bool, Error> {
+        let storage_service_config = &mut node_config.state_sync.storage_service;
+        let local_storage_service_config_yaml = &local_config_yaml["state_sync"]["storage_service"];
+
+        let mut modified_config = false;
+        if let Some(chain_id) = chain_id {
+            // TODO(HotState): Hotness in state sync is disabled on mainnet and testnet
+            // unless explicitly enabled.
+            if (chain_id.is_mainnet() || chain_id.is_testnet())
+                && local_storage_service_config_yaml["enable_hotness_in_state_sync"].as_bool()
+                    != Some(true)
+            {
+                storage_service_config.enable_hotness_in_state_sync = false;
                 modified_config = true;
             }
         }

--- a/state-sync/storage-service/server/src/storage.rs
+++ b/state-sync/storage-service/server/src/storage.rs
@@ -27,13 +27,19 @@ use aptos_types::{
     transaction::{
         PersistedAuxiliaryInfo, Transaction, TransactionAuxiliaryData, TransactionInfo,
         TransactionListWithAuxiliaryInfos, TransactionListWithProof, TransactionListWithProofV2,
-        TransactionOutput, TransactionOutputListWithAuxiliaryInfos, TransactionOutputListWithProof,
+        TransactionOutput, TransactionOutputExtension, TransactionOutputListWithAuxiliaryInfos,
+        TransactionOutputListWithExtensions, TransactionOutputListWithProof,
         TransactionOutputListWithProofV2, Version,
     },
     write_set::WriteSet,
 };
 use serde::Serialize;
-use std::{cmp::min, sync::Arc, time::Instant};
+use std::{
+    cmp::min,
+    collections::{BTreeMap, BTreeSet},
+    sync::Arc,
+    time::Instant,
+};
 
 /// The interface into local storage (e.g., the Aptos DB) used by the storage
 /// server to handle client requests and responses.
@@ -656,12 +662,21 @@ impl StorageReader {
                         get_num_serialized_bytes(&persisted_auxiliary_info).map_err(|error| {
                             Error::UnexpectedErrorEncountered(error.to_string())
                         })?;
+                    // `WriteSet::Serialize` strips in-place hotness, so it isn't counted by
+                    // `get_num_serialized_bytes(&output)`. Reserve room for the extension
+                    // that `get_transaction_data_with_proof` will attach.
+                    let num_hotness_extension_bytes = if self.config.enable_hotness_in_state_sync {
+                        hotness_extension_size_for_output(&output)?
+                    } else {
+                        0
+                    };
 
                     // Add the data items to the lists
                     let total_serialized_bytes = num_transaction_bytes
                         + num_info_bytes
                         + num_output_bytes
-                        + num_auxiliary_info_bytes;
+                        + num_auxiliary_info_bytes
+                        + num_hotness_extension_bytes;
                     if response_progress_tracker.data_items_fits_in_response(
                         !is_transaction_or_output_request,
                         total_serialized_bytes,
@@ -719,7 +734,9 @@ impl StorageReader {
             DataResponse::get_transaction_outputs_with_proof_v2_label(),
         );
 
-        // Create the transaction data with proof response
+        // Create the transaction data with proof response. The hotness extension is
+        // attached later, in `get_transaction_data_with_proof` only. Legacy request
+        // variants strip the wrapper and cannot carry hotness.
         let output_list_with_proof_v2 =
             TransactionOutputListWithProofV2::new(TransactionOutputListWithAuxiliaryInfos::new(
                 transaction_output_list_with_proof,
@@ -1030,6 +1047,36 @@ impl StorageReader {
             version, start_index, end_index
         )))
     }
+
+    /// Rewraps into the extension-carrying V2 variant when enabled and there's any hotness to carry.
+    fn attach_hotness_extension_if_enabled(
+        &self,
+        output_list: TransactionOutputListWithProofV2,
+    ) -> TransactionOutputListWithProofV2 {
+        if !self.config.enable_hotness_in_state_sync {
+            return output_list;
+        }
+        let inner = match output_list {
+            TransactionOutputListWithProofV2::TransactionOutputListWithAuxiliaryInfos(inner) => {
+                inner
+            },
+            already @ TransactionOutputListWithProofV2::TransactionOutputListWithExtensions(_) => {
+                return already;
+            },
+        };
+        let hotness = extract_per_output_hotness(&inner.transaction_output_list_with_proof);
+        if hotness.is_empty() {
+            TransactionOutputListWithProofV2::new(inner)
+        } else {
+            TransactionOutputListWithProofV2::new_with_extensions(
+                TransactionOutputListWithExtensions::new(
+                    inner.transaction_output_list_with_proof,
+                    inner.persisted_auxiliary_infos,
+                    vec![TransactionOutputExtension::Hotness(hotness)],
+                ),
+            )
+        }
+    }
 }
 
 impl StorageReaderInterface for StorageReader {
@@ -1153,7 +1200,7 @@ impl StorageReaderInterface for StorageReader {
         );
 
         // Fetch the transaction data based on the request type
-        match transaction_data_with_proof_request.transaction_data_request_type {
+        let mut response = match transaction_data_with_proof_request.transaction_data_request_type {
             TransactionDataRequestType::TransactionData(request) => {
                 // Get the transaction list with proof
                 self.get_transactions_with_proof_by_size(
@@ -1163,7 +1210,7 @@ impl StorageReaderInterface for StorageReader {
                     request.include_events,
                     max_response_bytes,
                     self.config.enable_size_and_time_aware_chunking,
-                )
+                )?
             },
             TransactionDataRequestType::TransactionOutputData => {
                 // Get the transaction output list with proof
@@ -1174,7 +1221,7 @@ impl StorageReaderInterface for StorageReader {
                     max_response_bytes,
                     false,
                     self.config.enable_size_and_time_aware_chunking,
-                )
+                )?
             },
             TransactionDataRequestType::TransactionOrOutputData(request) => {
                 // Get the transaction or output list with proof
@@ -1186,9 +1233,20 @@ impl StorageReaderInterface for StorageReader {
                     0, // Fetch all outputs, or return transactions
                     max_response_bytes,
                     self.config.enable_size_and_time_aware_chunking,
-                )
+                )?
             },
+        };
+
+        // Attach the hotness extension for transaction data v2 responses. The legacy paths
+        // (`get_transaction_outputs_with_proof` and `get_transactions_or_outputs_with_proof`)
+        // strip the wrapper before returning, so attaching there is both wasted and unsafe —
+        // `consume_output_list_with_proof` would re-splice into WriteSets that already carry
+        // in-place hotness from storage and trip `WriteSet::add_hotness`'s assertion.
+        if let Some(output_list) = response.transaction_output_list_with_proof {
+            response.transaction_output_list_with_proof =
+                Some(self.attach_hotness_extension_if_enabled(output_list));
         }
+        Ok(response)
     }
 
     fn get_number_of_states(
@@ -1514,4 +1572,35 @@ fn get_num_serialized_bytes<T: ?Sized + Serialize>(
     let num_serialized_bytes = bcs::serialized_size(data)
         .map_err(|error| Error::UnexpectedErrorEncountered(error.to_string()))?;
     Ok(num_serialized_bytes as u64)
+}
+
+/// Collects per-output hot state keys; sparse — outputs with no hotness are omitted.
+fn extract_per_output_hotness(
+    output_list: &TransactionOutputListWithProof,
+) -> BTreeMap<u32, BTreeSet<StateKey>> {
+    let mut hotness = BTreeMap::new();
+    for (idx, (_, output)) in output_list.transactions_and_outputs.iter().enumerate() {
+        let keys: BTreeSet<_> = output.write_set().hotness_keys().cloned().collect();
+        if !keys.is_empty() {
+            hotness.insert(idx as u32, keys);
+        }
+    }
+    hotness
+}
+
+/// Conservatively estimates the bytes this output contributes to the hotness extension.
+/// Returns 0 when the output has no hotness.
+fn hotness_extension_size_for_output(
+    output: &TransactionOutput,
+) -> aptos_storage_service_types::Result<u64, Error> {
+    let keys: BTreeSet<_> = output.write_set().hotness_keys().cloned().collect();
+    if keys.is_empty() {
+        return Ok(0);
+    }
+    let mut hotness = BTreeMap::new();
+    hotness.insert(0, keys);
+    let extensions = vec![TransactionOutputExtension::Hotness(hotness)];
+    let extension_bytes = bcs::serialized_size(&extensions)
+        .map_err(|error| Error::UnexpectedErrorEncountered(error.to_string()))?;
+    Ok(extension_bytes as u64)
 }

--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -2913,6 +2913,7 @@ fn verify_events_against_root_hash(
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 pub enum TransactionOutputListWithProofV2 {
     TransactionOutputListWithAuxiliaryInfos(TransactionOutputListWithAuxiliaryInfos),
+    TransactionOutputListWithExtensions(TransactionOutputListWithExtensions),
 }
 
 impl TransactionOutputListWithProofV2 {
@@ -2920,6 +2921,10 @@ impl TransactionOutputListWithProofV2 {
         transaction_output_list_with_auxiliary_infos: TransactionOutputListWithAuxiliaryInfos,
     ) -> Self {
         Self::TransactionOutputListWithAuxiliaryInfos(transaction_output_list_with_auxiliary_infos)
+    }
+
+    pub fn new_with_extensions(inner: TransactionOutputListWithExtensions) -> Self {
+        Self::TransactionOutputListWithExtensions(inner)
     }
 
     /// A convenience function to create an empty proof. Mostly used for tests.
@@ -2944,29 +2949,21 @@ impl TransactionOutputListWithProofV2 {
             Self::TransactionOutputListWithAuxiliaryInfos(output_list_with_auxiliary_infos) => {
                 output_list_with_auxiliary_infos.transaction_output_list_with_proof
             },
+            Self::TransactionOutputListWithExtensions(inner) => {
+                let (output_list, _) = inner.into_parts();
+                output_list
+            },
         }
     }
 
     /// Returns the first version in the transaction output list
     pub fn get_first_output_version(&self) -> Option<Version> {
-        match self {
-            Self::TransactionOutputListWithAuxiliaryInfos(output_list_with_auxiliary_infos) => {
-                output_list_with_auxiliary_infos
-                    .transaction_output_list_with_proof
-                    .get_first_output_version()
-            },
-        }
+        self.get_output_list_with_proof().get_first_output_version()
     }
 
     /// Returns the number of outputs in the transaction output list
     pub fn get_num_outputs(&self) -> usize {
-        match self {
-            Self::TransactionOutputListWithAuxiliaryInfos(output_list_with_auxiliary_infos) => {
-                output_list_with_auxiliary_infos
-                    .transaction_output_list_with_proof
-                    .get_num_outputs()
-            },
-        }
+        self.get_output_list_with_proof().get_num_outputs()
     }
 
     /// Returns a reference to the inner transaction output list with proof
@@ -2974,6 +2971,9 @@ impl TransactionOutputListWithProofV2 {
         match self {
             Self::TransactionOutputListWithAuxiliaryInfos(output_list_with_auxiliary_infos) => {
                 &output_list_with_auxiliary_infos.transaction_output_list_with_proof
+            },
+            Self::TransactionOutputListWithExtensions(inner) => {
+                &inner.transaction_output_list_with_proof
             },
         }
     }
@@ -2984,6 +2984,7 @@ impl TransactionOutputListWithProofV2 {
             Self::TransactionOutputListWithAuxiliaryInfos(output_list_with_auxiliary_infos) => {
                 &output_list_with_auxiliary_infos.persisted_auxiliary_infos
             },
+            Self::TransactionOutputListWithExtensions(inner) => &inner.persisted_auxiliary_infos,
         }
     }
 
@@ -2994,10 +2995,12 @@ impl TransactionOutputListWithProofV2 {
                 output_list_with_auxiliary_infos.transaction_output_list_with_proof,
                 output_list_with_auxiliary_infos.persisted_auxiliary_infos,
             ),
+            Self::TransactionOutputListWithExtensions(inner) => inner.into_parts(),
         }
     }
 
-    /// Verifies the transaction output list with proof v2 against the given ledger info
+    /// Verifies the transaction output list with proof v2 against the given ledger info.
+    /// Extension payloads are not verified, but duplicate extension variants are rejected.
     pub fn verify(
         &self,
         ledger_info: &LedgerInfo,
@@ -3005,6 +3008,9 @@ impl TransactionOutputListWithProofV2 {
     ) -> Result<()> {
         match self {
             Self::TransactionOutputListWithAuxiliaryInfos(inner) => {
+                inner.verify(ledger_info, first_transaction_output_version)
+            },
+            Self::TransactionOutputListWithExtensions(inner) => {
                 inner.verify(ledger_info, first_transaction_output_version)
             },
         }
@@ -3061,6 +3067,113 @@ impl TransactionOutputListWithAuxiliaryInfos {
             .verify(ledger_info, first_transaction_output_version)?;
 
         // Verify the auxiliary infos against the transaction infos
+        verify_auxiliary_infos_against_transaction_infos(
+            &self.persisted_auxiliary_infos,
+            &self
+                .transaction_output_list_with_proof
+                .proof
+                .transaction_infos,
+        )
+    }
+}
+
+/// Extensions carried alongside a transaction output list.
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+pub enum TransactionOutputExtension {
+    /// Carries per-output hot state keys as a sidecar; `WriteSet::Serialize` would
+    /// otherwise drop them.
+    Hotness(BTreeMap<u32, BTreeSet<StateKey>>),
+}
+
+/// Like `TransactionOutputListWithAuxiliaryInfos`, plus optional extension payloads
+/// carried as sidecars.
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+pub struct TransactionOutputListWithExtensions {
+    pub transaction_output_list_with_proof: TransactionOutputListWithProof,
+    pub persisted_auxiliary_infos: Vec<PersistedAuxiliaryInfo>,
+    pub extensions: Vec<TransactionOutputExtension>,
+}
+
+impl TransactionOutputListWithExtensions {
+    pub fn new(
+        transaction_output_list_with_proof: TransactionOutputListWithProof,
+        persisted_auxiliary_infos: Vec<PersistedAuxiliaryInfo>,
+        extensions: Vec<TransactionOutputExtension>,
+    ) -> Self {
+        Self {
+            transaction_output_list_with_proof,
+            persisted_auxiliary_infos,
+            extensions,
+        }
+    }
+
+    /// Splits the transaction output list and auxiliary infos, applying any extensions first.
+    pub fn into_parts(self) -> (TransactionOutputListWithProof, Vec<PersistedAuxiliaryInfo>) {
+        let Self {
+            mut transaction_output_list_with_proof,
+            persisted_auxiliary_infos,
+            extensions,
+        } = self;
+
+        for extension in extensions {
+            match extension {
+                TransactionOutputExtension::Hotness(hotness) => {
+                    Self::apply_hotness_extension(&mut transaction_output_list_with_proof, hotness);
+                },
+            }
+        }
+
+        (
+            transaction_output_list_with_proof,
+            persisted_auxiliary_infos,
+        )
+    }
+
+    fn apply_hotness_extension(
+        transaction_output_list_with_proof: &mut TransactionOutputListWithProof,
+        hotness: BTreeMap<u32, BTreeSet<StateKey>>,
+    ) {
+        for (idx, keys) in hotness {
+            if let Some((_, output)) = transaction_output_list_with_proof
+                .transactions_and_outputs
+                .get_mut(idx as usize)
+            {
+                output.add_hotness(
+                    keys.into_iter()
+                        .map(|key| (key, HotStateOp::make_hot()))
+                        .collect(),
+                );
+            }
+        }
+    }
+
+    fn verify_extension_variants_are_unique(&self) -> Result<()> {
+        let mut seen_hotness = false;
+        for extension in &self.extensions {
+            match extension {
+                TransactionOutputExtension::Hotness(_) => {
+                    ensure!(
+                        !seen_hotness,
+                        "Found duplicate transaction output extension: Hotness"
+                    );
+                    seen_hotness = true;
+                },
+            }
+        }
+        Ok(())
+    }
+
+    /// Verifies the inner output list + aux infos. Extension payloads are not
+    /// verified, but duplicate extension variants are rejected.
+    pub fn verify(
+        &self,
+        ledger_info: &LedgerInfo,
+        first_transaction_output_version: Option<Version>,
+    ) -> Result<()> {
+        self.verify_extension_variants_are_unique()?;
+        self.transaction_output_list_with_proof
+            .verify(ledger_info, first_transaction_output_version)?;
+
         verify_auxiliary_infos_against_transaction_infos(
             &self.persisted_auxiliary_infos,
             &self

--- a/types/src/unit_tests/transaction_test.rs
+++ b/types/src/unit_tests/transaction_test.rs
@@ -4,19 +4,28 @@
 use crate::{
     account_address::AccountAddress,
     chain_id::ChainId,
+    proof::TransactionInfoListWithProof,
+    state_store::state_key::StateKey,
     transaction::{
-        AccountOrderedTransactionsWithProof, RawTransaction, Script, SignedTransaction,
-        Transaction, TransactionInfo, TransactionListWithProof, TransactionPayload,
+        AccountOrderedTransactionsWithProof, PersistedAuxiliaryInfo, RawTransaction, Script,
+        SignedTransaction, Transaction, TransactionInfo, TransactionListWithProof,
+        TransactionOutput, TransactionOutputExtension, TransactionOutputListWithExtensions,
+        TransactionOutputListWithProof, TransactionOutputListWithProofV2, TransactionPayload,
         TransactionWithProof,
     },
+    write_set::WriteSet,
 };
 use aptos_crypto::{
     ed25519::{self, Ed25519PrivateKey, Ed25519Signature},
+    hash::HashValue,
     PrivateKey, Uniform,
 };
 use bcs::test_helpers::assert_canonical_encode_decode;
 use proptest::prelude::*;
-use std::convert::TryFrom;
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    convert::TryFrom,
+};
 
 #[test]
 fn test_invalid_signature() {
@@ -90,4 +99,48 @@ proptest! {
     fn acct_txns_with_proof_bcs_roundtrip(acct_txns_with_proof in any::<AccountOrderedTransactionsWithProof>()) {
         assert_canonical_encode_decode(acct_txns_with_proof);
     }
+}
+
+#[test]
+fn transaction_output_list_v2_hotness_roundtrip() {
+    // Only the trailing output carries hotness, mirroring the typical chunk where
+    // hotness lives in the block epilogue.
+    let txn0 = Transaction::StateCheckpoint(HashValue::zero());
+    let output0 = TransactionOutput::new_success_with_write_set(WriteSet::default());
+
+    let txn1 = Transaction::StateCheckpoint(HashValue::random());
+    let output1 = TransactionOutput::new_success_with_write_set(WriteSet::default());
+
+    let output_list = TransactionOutputListWithProof::new(
+        vec![(txn0, output0), (txn1, output1)],
+        Some(0),
+        TransactionInfoListWithProof::new_empty(),
+    );
+
+    let hot_keys: BTreeSet<_> = vec![StateKey::raw(b"hot_key_a"), StateKey::raw(b"hot_key_b")]
+        .into_iter()
+        .collect();
+    let mut hotness = BTreeMap::new();
+    hotness.insert(1u32, hot_keys.clone());
+
+    let v2 = TransactionOutputListWithProofV2::new_with_extensions(
+        TransactionOutputListWithExtensions::new(
+            output_list,
+            vec![PersistedAuxiliaryInfo::None, PersistedAuxiliaryInfo::None],
+            vec![TransactionOutputExtension::Hotness(hotness)],
+        ),
+    );
+
+    // Round-trip through BCS. `WriteSet::Serialize` drops in-WriteSet hotness, so the
+    // extension is the only carrier across the wire.
+    let encoded = bcs::to_bytes(&v2).expect("v2 BCS encode");
+    let decoded: TransactionOutputListWithProofV2 =
+        bcs::from_bytes(&encoded).expect("v2 BCS decode");
+
+    let (output_list, _aux) = decoded.into_parts();
+    let outputs = &output_list.transactions_and_outputs;
+    assert_eq!(outputs.len(), 2);
+    assert_eq!(outputs[0].1.write_set().hotness_keys().count(), 0);
+    let restored: BTreeSet<_> = outputs[1].1.write_set().hotness_keys().cloned().collect();
+    assert_eq!(restored, hot_keys);
 }


### PR DESCRIPTION

WriteSet's BCS encoding strips in-place hotness, so state sync chunks
arrive with hotness erased. Add a Hotness extension variant to
TransactionOutputListWithProofV2 that ferries sparse per-output hot
StateKeys and re-splices them on consumption.

Gated by storage_service.enable_hotness_in_state_sync; the optimizer
flips it off on mainnet/testnet unless explicitly enabled. Chunk sizing
accounts for sidecar bytes when the flag is on.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes state sync’s v2 transaction output wire format by adding an extension sidecar and new config gating, which could affect compatibility and chunk sizing if mishandled.
> 
> **Overview**
> State sync v2 transaction output responses can now optionally carry write-set *hotness* by adding a `Hotness` sidecar extension to `TransactionOutputListWithProofV2`, and re-applying that data when the response is consumed.
> 
> The storage service attaches this extension only for v2 `get_transaction_data_with_proof` output responses (not legacy variants) and updates chunk sizing to account for the extra serialized bytes. A new `storage_service.enable_hotness_in_state_sync` flag controls the behavior, with config optimization disabling it on mainnet/testnet unless explicitly enabled, and a unit test covering BCS round-tripping/restoration of hotness.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22babcc50c55c8251e4da4d045fc94afb88bc135. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->