### PR TITLE
[docker] document trusted setup files in validator compose

### DIFF
--- a/docker/compose/aptos-node/docker-compose.yaml
+++ b/docker/compose/aptos-node/docker-compose.yaml
@@ -55,6 +55,23 @@ services:
       - type: bind
         source: ./keys/validator-identity.yaml
         target: /opt/aptos/genesis/validator-identity.yaml
+      # ----------------------------------------------------------------------
+      # Trusted setup files for chunky DKG / batch encryption.
+      # Required for validators on non-test chains.
+      #
+      # To enable:
+      #   1. Place `digest_key.bin` and `pp.bin` in this directory (next to
+      #      `genesis.blob` and `waypoint.txt`).
+      #   2. Uncomment the two `- type: bind` blocks immediately below.
+      #   3. Uncomment the `digest_key_blob_path` and `public_parameters_blob_path`
+      #      entries under `consensus:` in validator.yaml.
+      # ----------------------------------------------------------------------
+      # - type: bind
+      #   source: ./digest_key.bin
+      #   target: /opt/aptos/genesis/digest_key.bin
+      # - type: bind
+      #   source: ./pp.bin
+      #   target: /opt/aptos/genesis/pp.bin
     command: ["/usr/local/bin/aptos-node", "-f", "/opt/aptos/etc/validator.yaml"]
     restart: unless-stopped
     expose:

--- a/docker/compose/aptos-node/validator.yaml
+++ b/docker/compose/aptos-node/validator.yaml
@@ -5,6 +5,17 @@ base:
     from_file: "/opt/aptos/genesis/waypoint.txt"
 
 consensus:
+  # ----------------------------------------------------------------------
+  # Trusted setup files for chunky DKG / batch encryption.
+  # Required for validators on non-test chains.
+  #
+  # To enable:
+  #   1. Mount `digest_key.bin` and `pp.bin` into the validator container
+  #      (uncomment the matching bind mounts in docker-compose.yaml).
+  #   2. Uncomment the two lines immediately below.
+  # ----------------------------------------------------------------------
+  # digest_key_blob_path: /opt/aptos/genesis/digest_key.bin
+  # public_parameters_blob_path: /opt/aptos/genesis/pp.bin
   safety_rules:
     service:
       type: "local"


### PR DESCRIPTION
## Summary
- Add commented-out bind mounts for `digest_key.bin` and `pp.bin` in `docker/compose/aptos-node/docker-compose.yaml`.
- Add commented-out `digest_key_blob_path` / `public_parameters_blob_path` entries under `consensus:` in `docker/compose/aptos-node/validator.yaml`.
- Each block carries step-by-step instructions cross-referencing the other file, so an operator can enable the trusted setup files once they are available.

No behavior change — the files stay commented out so existing deployments keep working. Operators on non-test chains will uncomment both blocks after placing the binaries next to `genesis.blob` / `waypoint.txt`.

Helm/terraform changes are intentionally out of scope for this PR.

## Test plan
- [ ] `docker compose -f docker/compose/aptos-node/docker-compose.yaml config` still parses (commented mounts are inert).
- [ ] After uncommenting both blocks and providing the two files, validator container mounts them at `/opt/aptos/genesis/{digest_key.bin,pp.bin}` and `aptos-node` picks them up via the consensus config paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)