### PR TITLE
[mempool] add pull_count label and prev-block latency metric

### DIFF
--- a/mempool/src/core_mempool/mempool.rs
+++ b/mempool/src/core_mempool/mempool.rs
@@ -170,7 +170,9 @@ impl Mempool {
                 bucket,
                 time_delta,
                 priority,
-                insertion_info.consensus_pulled_counter.load(Ordering::Relaxed),
+                insertion_info
+                    .consensus_pulled_counter
+                    .load(Ordering::Relaxed),
             );
         }
     }
@@ -219,7 +221,9 @@ impl Mempool {
         priority: &str,
         tracked_use_case: Option<(UseCaseKey, &String)>,
     ) {
-        let pull_count = insertion_info.consensus_pulled_counter.load(Ordering::Relaxed);
+        let pull_count = insertion_info
+            .consensus_pulled_counter
+            .load(Ordering::Relaxed);
         let parked_duration = if let Some(park_time) = insertion_info.park_time {
             let parked_duration = insertion_info
                 .ready_time
@@ -297,28 +301,31 @@ impl Mempool {
 
             let insertion_timestamp =
                 aptos_infallible::duration_since_epoch_at(&insertion_info.insertion_time);
-            let pull_count = insertion_info.consensus_pulled_counter.load(Ordering::Relaxed);
-            if let Some(insertion_to_block) = block_timestamp.checked_sub(insertion_timestamp) {
-                counters::core_mempool_txn_commit_latency(
+            let pull_count = insertion_info
+                .consensus_pulled_counter
+                .load(Ordering::Relaxed);
+            let submitted_by = insertion_info.submitted_by_label();
+            let priority_str = priority.to_string();
+            for (stage, latency) in [
+                (
                     counters::COMMIT_ACCEPTED_BLOCK_LABEL,
-                    insertion_info.submitted_by_label(),
-                    bucket.as_str(),
-                    insertion_to_block,
-                    priority.to_string().as_str(),
-                    pull_count,
-                );
-            }
-            if let Some(insertion_to_prev_block) = prev_block_timestamp
-                .and_then(|prev| prev.checked_sub(insertion_timestamp))
-            {
-                counters::core_mempool_txn_commit_latency(
+                    block_timestamp.checked_sub(insertion_timestamp),
+                ),
+                (
                     counters::COMMIT_ACCEPTED_PREV_BLOCK_LABEL,
-                    insertion_info.submitted_by_label(),
-                    bucket.as_str(),
-                    insertion_to_prev_block,
-                    priority.to_string().as_str(),
-                    pull_count,
-                );
+                    prev_block_timestamp.and_then(|prev| prev.checked_sub(insertion_timestamp)),
+                ),
+            ] {
+                if let Some(latency) = latency {
+                    counters::core_mempool_txn_commit_latency(
+                        stage,
+                        submitted_by,
+                        bucket.as_str(),
+                        latency,
+                        priority_str.as_str(),
+                        pull_count,
+                    );
+                }
             }
         }
     }

--- a/mempool/src/core_mempool/mempool.rs
+++ b/mempool/src/core_mempool/mempool.rs
@@ -37,6 +37,10 @@ pub struct Mempool {
     pub(crate) transactions: TransactionStore,
 
     pub system_transaction_timeout: Duration,
+
+    // Timestamp of the most recently committed block we've observed, used to
+    // compute the `commit_accepted_prev_block` latency for the next commit.
+    prev_commit_block_timestamp: Option<Duration>,
 }
 
 impl Mempool {
@@ -46,6 +50,20 @@ impl Mempool {
             system_transaction_timeout: Duration::from_secs(
                 config.mempool.system_transaction_timeout_secs,
             ),
+            prev_commit_block_timestamp: None,
+        }
+    }
+
+    pub(crate) fn prev_commit_block_timestamp(&self) -> Option<Duration> {
+        self.prev_commit_block_timestamp
+    }
+
+    pub(crate) fn set_prev_commit_block_timestamp(&mut self, block_timestamp: Duration) {
+        if self
+            .prev_commit_block_timestamp
+            .is_none_or(|prev| block_timestamp > prev)
+        {
+            self.prev_commit_block_timestamp = Some(block_timestamp);
         }
     }
 
@@ -65,12 +83,19 @@ impl Mempool {
         replay_protector: ReplayProtector,
         tracked_use_case: Option<(UseCaseKey, &String)>,
         block_timestamp: Duration,
+        prev_block_timestamp: Option<Duration>,
     ) {
         trace!(
             LogSchema::new(LogEntry::RemoveTxn).txns(TxnsLog::new_txn(*sender, replay_protector)),
             is_rejected = false
         );
-        self.log_commit_latency(*sender, replay_protector, tracked_use_case, block_timestamp);
+        self.log_commit_latency(
+            *sender,
+            replay_protector,
+            tracked_use_case,
+            block_timestamp,
+            prev_block_timestamp,
+        );
         if let Some(ranking_score) = self
             .transactions
             .get_ranking_score(sender, replay_protector)
@@ -145,6 +170,7 @@ impl Mempool {
                 bucket,
                 time_delta,
                 priority,
+                insertion_info.consensus_pulled_counter.load(Ordering::Relaxed),
             );
         }
     }
@@ -193,6 +219,7 @@ impl Mempool {
         priority: &str,
         tracked_use_case: Option<(UseCaseKey, &String)>,
     ) {
+        let pull_count = insertion_info.consensus_pulled_counter.load(Ordering::Relaxed);
         let parked_duration = if let Some(park_time) = insertion_info.park_time {
             let parked_duration = insertion_info
                 .ready_time
@@ -204,6 +231,7 @@ impl Mempool {
                 bucket,
                 parked_duration,
                 priority,
+                pull_count,
             );
             parked_duration
         } else {
@@ -221,6 +249,7 @@ impl Mempool {
                 bucket,
                 commit_minus_parked,
                 priority,
+                pull_count,
             );
 
             if insertion_info.park_time.is_none() {
@@ -247,6 +276,7 @@ impl Mempool {
         replay_protector: ReplayProtector,
         tracked_use_case: Option<(UseCaseKey, &String)>,
         block_timestamp: Duration,
+        prev_block_timestamp: Option<Duration>,
     ) {
         if let Some((insertion_info, bucket, priority)) = self
             .transactions
@@ -267,6 +297,7 @@ impl Mempool {
 
             let insertion_timestamp =
                 aptos_infallible::duration_since_epoch_at(&insertion_info.insertion_time);
+            let pull_count = insertion_info.consensus_pulled_counter.load(Ordering::Relaxed);
             if let Some(insertion_to_block) = block_timestamp.checked_sub(insertion_timestamp) {
                 counters::core_mempool_txn_commit_latency(
                     counters::COMMIT_ACCEPTED_BLOCK_LABEL,
@@ -274,6 +305,19 @@ impl Mempool {
                     bucket.as_str(),
                     insertion_to_block,
                     priority.to_string().as_str(),
+                    pull_count,
+                );
+            }
+            if let Some(insertion_to_prev_block) = prev_block_timestamp
+                .and_then(|prev| prev.checked_sub(insertion_timestamp))
+            {
+                counters::core_mempool_txn_commit_latency(
+                    counters::COMMIT_ACCEPTED_PREV_BLOCK_LABEL,
+                    insertion_info.submitted_by_label(),
+                    bucket.as_str(),
+                    insertion_to_prev_block,
+                    priority.to_string().as_str(),
+                    pull_count,
                 );
             }
         }
@@ -372,6 +416,7 @@ impl Mempool {
                     priority
                         .map_or_else(|| "Unknown".to_string(), |priority| priority.to_string())
                         .as_str(),
+                    0,
                 );
             }
         }

--- a/mempool/src/core_mempool/transaction_store.rs
+++ b/mempool/src/core_mempool/transaction_store.rs
@@ -519,12 +519,16 @@ impl TransactionStore {
         insertion_info.ready_time = SystemTime::now();
         if let Ok(time_delta) = SystemTime::now().duration_since(insertion_info.insertion_time) {
             let submitted_by = insertion_info.submitted_by_label();
+            let pull_count = insertion_info
+                .consensus_pulled_counter
+                .load(std::sync::atomic::Ordering::Relaxed);
             counters::core_mempool_txn_commit_latency(
                 CONSENSUS_READY_LABEL,
                 submitted_by,
                 bucket,
                 time_delta,
                 priority,
+                pull_count,
             );
 
             if ready_for_mempool_broadcast {
@@ -534,6 +538,7 @@ impl TransactionStore {
                     bucket,
                     time_delta,
                     priority,
+                    pull_count,
                 );
             }
         }

--- a/mempool/src/counters.rs
+++ b/mempool/src/counters.rs
@@ -25,6 +25,7 @@ pub const SIZE_BYTES_LABEL: &str = "size_bytes";
 pub const BROADCAST_RECEIVED_LABEL: &str = "broadcast_received";
 pub const COMMIT_ACCEPTED_LABEL: &str = "commit_accepted";
 pub const COMMIT_ACCEPTED_BLOCK_LABEL: &str = "commit_accepted_block";
+pub const COMMIT_ACCEPTED_PREV_BLOCK_LABEL: &str = "commit_accepted_prev_block";
 pub const COMMIT_REJECTED_LABEL: &str = "commit_rejected";
 pub const COMMIT_REJECTED_DUPLICATE_LABEL: &str = "commit_rejected_duplicate";
 pub const COMMIT_IGNORED_LABEL: &str = "commit_ignored";
@@ -215,14 +216,29 @@ pub fn core_mempool_txn_commit_latency(
     bucket: &str,
     latency: Duration,
     priority: &str,
+    pull_count: usize,
 ) {
+    let pull_count = pull_count_label(pull_count);
     CORE_MEMPOOL_TXN_COMMIT_LATENCY
-        .with_label_values(&[stage, submitted_by, bucket])
+        .with_label_values(&[stage, submitted_by, bucket, pull_count])
         .observe(latency.as_secs_f64());
 
     CORE_MEMPOOL_TXN_LATENCIES
-        .with_label_values(&[stage, submitted_by, bucket, priority])
+        .with_label_values(&[stage, submitted_by, bucket, priority, pull_count])
         .observe(latency.as_secs_f64());
+}
+
+/// Bucket a raw consensus pull count into a low-cardinality label.
+pub fn pull_count_label(pull_count: usize) -> &'static str {
+    match pull_count {
+        0 => "0",
+        1 => "1",
+        2 => "2",
+        3 => "3",
+        4..=5 => "4-5",
+        6..=10 => "6-10",
+        _ => "11+",
+    }
 }
 
 /// Counter tracking latency of txns reaching various stages in committing
@@ -231,7 +247,7 @@ static CORE_MEMPOOL_TXN_COMMIT_LATENCY: Lazy<HistogramVec> = Lazy::new(|| {
     register_histogram_vec!(
         "aptos_core_mempool_txn_commit_latency",
         "Latency of txn reaching various stages in core mempool after insertion",
-        &["stage", "submitted_by", "bucket"],
+        &["stage", "submitted_by", "bucket", "pull_count"],
         MEMPOOL_LATENCY_BUCKETS.to_vec()
     )
     .unwrap()
@@ -243,7 +259,7 @@ static CORE_MEMPOOL_TXN_LATENCIES: Lazy<HistogramVec> = Lazy::new(|| {
     register_histogram_vec!(
         "aptos_core_mempool_txn_latencies",
         "Latency of txn reaching various stages in mempool",
-        &["stage", "submitted_by", "bucket", "priority"],
+        &["stage", "submitted_by", "bucket", "priority", "pull_count"],
         MEMPOOL_LATENCY_BUCKETS.to_vec()
     )
     .unwrap()

--- a/mempool/src/shared_mempool/tasks.rs
+++ b/mempool/src/shared_mempool/tasks.rs
@@ -805,6 +805,7 @@ pub(crate) fn process_committed_transactions(
 ) {
     let mut pool = mempool.lock();
     let block_timestamp = Duration::from_micros(block_timestamp_usecs);
+    let prev_block_timestamp = pool.prev_commit_block_timestamp();
 
     let tracking_usecases = {
         let mut history = use_case_history.lock();
@@ -833,12 +834,14 @@ pub(crate) fn process_committed_transactions(
                 .get(&transaction.use_case)
                 .map(|name| (transaction.use_case.clone(), name)),
             block_timestamp,
+            prev_block_timestamp,
         );
         pool.commit_transaction(&transaction.sender, transaction.replay_protector);
     }
 
     if block_timestamp_usecs > 0 {
         pool.gc_by_expiration_time(block_timestamp);
+        pool.set_prev_commit_block_timestamp(block_timestamp);
     }
 
     // Release mempool lock, then finalize traces (which may trigger GC).


### PR DESCRIPTION
## Summary
- Adds a low-cardinality `pull_count` label to `aptos_core_mempool_txn_commit_latency` and `aptos_core_mempool_txn_latencies`, derived from `InsertionInfo::consensus_pulled_counter` and bucketed via `pull_count_label` (`0`, `1`, `2`, `3`, `4-5`, `6-10`, `11+`). Existing call sites in `mempool.rs` and `transaction_store.rs` thread this through; the `broadcast_received` site (txn just inserted) passes `0`.
- Introduces a new stage label `commit_accepted_prev_block` recorded from `log_commit_latency`. The metric tracks `prev_block_timestamp - insertion_timestamp` and is only emitted when that subtraction is non-negative (i.e., the txn was already in mempool when the prior block was committed).
- Tracks the prior block timestamp on `Mempool` as `prev_commit_block_timestamp: Option<Duration>`. `process_committed_transactions` snapshots it before the loop, threads it down, and updates it after GC. `set_prev_commit_block_timestamp` only overwrites when the new value is strictly greater than the stored one, so out-of-order commit notifications do not roll it back.

## Test plan
- [ ] `cargo check -p aptos-mempool` (passes locally)
- [ ] `cargo test -p aptos-mempool`
- [ ] Verify in a forge run that new series appear with `stage="commit_accepted_prev_block"` and that `pull_count` is populated across stages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the label set for core mempool latency histograms and adds new latency series, which can break existing dashboards/alerts and increase metric cardinality if misused, but does not change transaction selection or validation logic.
> 
> **Overview**
> Adds a new low-cardinality `pull_count` dimension to core mempool latency histograms (derived from each txn’s consensus pull counter and bucketed via `pull_count_label`) and threads this through all `core_mempool_txn_commit_latency` call sites.
> 
> Introduces a new `commit_accepted_prev_block` latency stage, backed by tracking the last observed committed block timestamp in `Mempool` and passing it through `process_committed_transactions` so commits can emit both *insertion→current block* and *insertion→previous block* latencies when applicable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46358813c2ab17d430d6f400648648e5c7143b0c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->