### PR TITLE
Backport latest fixes to the Forge deployer

### DIFF
--- a/testsuite/forge/src/backend/k8s_deployer/constants.rs
+++ b/testsuite/forge/src/backend/k8s_deployer/constants.rs
@@ -13,7 +13,7 @@ pub const INDEXER_GRPC_DOCKER_IMAGE_REPO: &str =
 
 /// The version of the forge deployer image to use.
 pub const DEFAULT_FORGE_DEPLOYER_IMAGE_TAG: &str =
-    "release_08d94a461f8b08c3f5a47b45303d5ea6ffcd6bc6"; // latest stable build (2026-03-23)
+    "release_5af9feed8f04b4caa5edaeece71998ade1865d58"; // latest stable build (2026-05-15)
 
 /// This is the service account name that the deployer will use to deploy the forge components. It may require extra permissions and additonal setup
 pub const FORGE_DEPLOYER_SERVICE_ACCOUNT_NAME: &str = "forge";


### PR DESCRIPTION
Use the latest Forge deployer that fixes a K8s crashloop bug.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates the default Forge K8s deployer image tag, which changes the binary used during deployments and could affect cluster behavior if the new image has regressions. Code changes are minimal and isolated to a constant.
> 
> **Overview**
> Bumps `DEFAULT_FORGE_DEPLOYER_IMAGE_TAG` in `testsuite/forge` to a newer `release_...` tag (dated 2026-05-15), so Forge K8s deployer jobs (when no explicit tag is provided) run the updated deployer image.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 001357e7cc5002cc5b69775552e8ff4c176dfe69. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->