### PR TITLE
Backport latest fixes to Forge deployer

### DIFF
--- a/testsuite/forge/src/backend/k8s_deployer/constants.rs
+++ b/testsuite/forge/src/backend/k8s_deployer/constants.rs
@@ -13,7 +13,7 @@ pub const INDEXER_GRPC_DOCKER_IMAGE_REPO: &str =
 
 /// The version of the forge deployer image to use.
 pub const DEFAULT_FORGE_DEPLOYER_IMAGE_TAG: &str =
-    "release_a5ad1dc3548e99def34645a3845168f2fa3fa436"; // latest stable build (2026-04-27)
+    "release_5af9feed8f04b4caa5edaeece71998ade1865d58"; // latest stable build (2026-05-15)
 
 /// This is the service account name that the deployer will use to deploy the forge components. It may require extra permissions and additonal setup
 pub const FORGE_DEPLOYER_SERVICE_ACCOUNT_NAME: &str = "forge";


### PR DESCRIPTION
Use the latest Forge deployer that fixes a K8s crashloop bug.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates the default Forge deployer Docker image tag used by the k8s deployer, with no code/logic changes. Risk is limited to runtime behavior changes introduced by the newer deployer image itself.
> 
> **Overview**
> Updates `DEFAULT_FORGE_DEPLOYER_IMAGE_TAG` in `testsuite/forge` to point to a newer stable Forge deployer image (`release_5af9feed…`, dated 2026-05-15), changing which deployer version runs by default when creating k8s deployer jobs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40778db714c45e923fa56b39f085de867cfa5ead. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->