### PR TITLE
Backport latest fixes to Forge deployer

### DIFF
--- a/testsuite/forge/src/backend/k8s_deployer/constants.rs
+++ b/testsuite/forge/src/backend/k8s_deployer/constants.rs
@@ -13,7 +13,7 @@ pub const INDEXER_GRPC_DOCKER_IMAGE_REPO: &str =
 
 /// The version of the forge deployer image to use.
 pub const DEFAULT_FORGE_DEPLOYER_IMAGE_TAG: &str =
-    "release_a5ad1dc3548e99def34645a3845168f2fa3fa436"; // latest stable build (2026-04-27)
+    "release_5af9feed8f04b4caa5edaeece71998ade1865d58"; // latest stable build (2026-05-15)
 
 /// This is the service account name that the deployer will use to deploy the forge components. It may require extra permissions and additonal setup
 pub const FORGE_DEPLOYER_SERVICE_ACCOUNT_NAME: &str = "forge";


### PR DESCRIPTION
Use the latest Forge deployer that fixes a K8s crashloop bug.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Small code change but it updates the default Forge deployer Docker image used for k8s jobs, which can alter deployment behavior and potentially affect testnet/forge reliability if the new image has regressions.
> 
> **Overview**
> Updates `DEFAULT_FORGE_DEPLOYER_IMAGE_TAG` in `k8s_deployer/constants.rs` to point to a newer stable Forge deployer image (`release_5af9feed...`, dated 2026-05-15), so k8s Forge deployments default to the updated deployer build.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4048fea84c9ed77a130a90d9e35e391a0c53f321. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->