### PR TITLE
[consensus] Dump input Transaction on commit_info mismatch

### DIFF
--- a/consensus/src/pipeline/buffer_item.rs
+++ b/consensus/src/pipeline/buffer_item.rs
@@ -60,6 +60,7 @@ fn log_execution_state_for_mismatch(
             "commit_info mismatch — dumping executed block state before panic"
         );
 
+        let txns = cr.transactions_to_commit();
         for (i, (info, info_hash)) in lu
             .transaction_infos
             .iter()
@@ -72,6 +73,7 @@ fn log_execution_state_for_mismatch(
                 version = parent_version + i as u64,
                 info_hash = ?info_hash,
                 info = ?info,
+                txn = ?txns.get(i),
                 "commit_info mismatch — dumping txn info before panic"
             );
         }


### PR DESCRIPTION
## Summary
- Add `txn = ?txns.get(i)` to the per-txn dump line in `log_execution_state_for_mismatch` so the actual input `Transaction` (e.g. `BlockMetadataExt::V1` vs `::V2` with `decryption_key`) is visible in the panic log.
- Uses `cr.transactions_to_commit()` aligned with the existing `transaction_infos` / `transaction_info_hashes` zip; `.get(i)` so a length mismatch never panics from the dump path itself.

## Motivation
When validator and PFN (via consensus observer) diverge on `executed_state_id` for the same block, the existing dump shows `TransactionInfo` fields but not the input bytes. Identical `state_change_hash` / `event_root_hash` / `gas_used` / `status` with a divergent `info_hash` typically means the input txn variant differs (e.g. V1 BlockMetadataExt on PFN vs V2 with `decryption_key: None` on validator due to `is_decryption_enabled` flag mismatch). Logging the input Transaction lets operators confirm the variant directly from logs.

## Test plan
- [ ] Build passes (`cargo check -p aptos-consensus`)
- [ ] On a deliberate state-id mismatch, the log line includes `txn = Some(BlockMetadataExt(V1 { ... }))` / `Some(BlockMetadataExt(V2 { ... }))`

🤖 Generated with [Claude Code](https://claude.com/claude-code)