### PR TITLE
[move] use bytecode_version v9 for future framework releases

### DIFF
--- a/aptos-move/aptos-release-builder/data/release.yaml
+++ b/aptos-move/aptos-release-builder/data/release.yaml
@@ -16,5 +16,5 @@ proposals:
           # old: https://raw.githubusercontent.com/aptos-labs/aptos-networks/main/gas/vX.WW.Z.json
           # new: https://raw.githubusercontent.com/aptos-labs/aptos-networks/main/gas/vX.YY.Z.json
       - Framework:
-          bytecode_version: 8
+          bytecode_version: 9
           git_hash: ~


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Updates the release-builder configuration to target a new Move bytecode version, which can affect generated framework upgrade artifacts and compatibility testing expectations.
> 
> **Overview**
> Switches the framework upgrade template in `aptos-move/aptos-release-builder/data/release.yaml` to use `bytecode_version: 9` instead of `8` for future multi-step mainnet framework release proposals.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81ae13d8c8563cc29be58998d3ddd16422598773. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->