### PR TITLE
[vm] Type formula to use checked access

### DIFF
--- a/third_party/move/move-vm/runtime/src/storage/ty_depth_checker.rs
+++ b/third_party/move/move-vm/runtime/src/storage/ty_depth_checker.rs
@@ -197,7 +197,8 @@ where
                     .collect::<PartialVMResult<Vec<_>>>()?;
 
                 let formula = visit_struct!(idx);
-                check_depth!(formula.solve(&ty_arg_depths)?)
+                let depth = formula.solve(&ty_arg_depths)?;
+                check_depth!(depth)
             },
             Type::TyParam(_) => {
                 return Err(

--- a/third_party/move/move-vm/runtime/src/storage/ty_depth_checker.rs
+++ b/third_party/move/move-vm/runtime/src/storage/ty_depth_checker.rs
@@ -179,7 +179,8 @@ where
             )?,
             Type::Struct { idx, .. } => {
                 let formula = visit_struct!(idx);
-                check_depth!(formula.solve(&[])?)
+                let depth = formula.solve(&[])?;
+                check_depth!(depth)
             },
             Type::StructInstantiation { idx, ty_args, .. } => {
                 let ty_arg_depths = ty_args

--- a/third_party/move/move-vm/runtime/src/storage/ty_depth_checker.rs
+++ b/third_party/move/move-vm/runtime/src/storage/ty_depth_checker.rs
@@ -179,7 +179,7 @@ where
             )?,
             Type::Struct { idx, .. } => {
                 let formula = visit_struct!(idx);
-                check_depth!(formula.solve(&[]))
+                check_depth!(formula.solve(&[])?)
             },
             Type::StructInstantiation { idx, ty_args, .. } => {
                 let ty_arg_depths = ty_args
@@ -196,7 +196,7 @@ where
                     .collect::<PartialVMResult<Vec<_>>>()?;
 
                 let formula = visit_struct!(idx);
-                check_depth!(formula.solve(&ty_arg_depths))
+                check_depth!(formula.solve(&ty_arg_depths)?)
             },
             Type::TyParam(_) => {
                 return Err(

--- a/third_party/move/move-vm/types/src/loaded_data/runtime_types.rs
+++ b/third_party/move/move-vm/types/src/loaded_data/runtime_types.rs
@@ -108,13 +108,22 @@ impl DepthFormula {
         Ok(DepthFormula::normalize(formulas))
     }
 
-    pub fn solve(&self, tparam_depths: &[u64]) -> u64 {
+    pub fn solve(&self, tparam_depths: &[u64]) -> PartialVMResult<u64> {
         let Self { terms, constant } = self;
         let mut depth = constant.as_ref().copied().unwrap_or(0);
         for (t_i, c_i) in terms {
-            depth = max(depth, tparam_depths[*t_i as usize].saturating_add(*c_i))
+            let tparam_depth = tparam_depths.get(*t_i as usize).ok_or_else(|| {
+                PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR).with_message(
+                    format!(
+                        "type parameter index {} out of bounds (len {}) when solving depth formula",
+                        t_i,
+                        tparam_depths.len(),
+                    ),
+                )
+            })?;
+            depth = max(depth, tparam_depth.saturating_add(*c_i))
         }
-        depth
+        Ok(depth)
     }
 
     pub fn scale(mut self, c: u64) -> Self {


### PR DESCRIPTION
Replace unchecked indexing in `DepthFormula::solve` with a bounds check that returns an invariant violation error instead of panicking on a stale type parameter index.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, localized change that replaces a potential panic with a handled invariant-violation error during type depth computation.
> 
> **Overview**
> Prevents panics in `DepthFormula::solve` by replacing unchecked indexing into `tparam_depths` with a bounds check that returns `UNKNOWN_INVARIANT_VIOLATION_ERROR` when a stale/out-of-range type parameter index is encountered.
> 
> Updates `TypeDepthChecker` to handle the new `PartialVMResult<u64>` return type from `solve` when computing struct and struct-instantiation depths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d95de498b58f809b428f8fac26352bdeb2d59c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->