### PR TITLE
[ci] Fix e2e benchmark calibration

### DIFF
--- a/testsuite/single_node_performance_calibration.py
+++ b/testsuite/single_node_performance_calibration.py
@@ -266,7 +266,11 @@ def main():
     for new_row in parsed:
         try:
             key = tuple(new_row[c] for c in columns[:key_columns_count])
-            executor_type = new_row["executor_type"]
+            # Move-e2e rows do not carry an executor_type column; the gate
+            # below only applies to the non-move-e2e path.
+            executor_type = (
+                None if args.move_e2e else new_row["executor_type"]
+            )
         except KeyError as e:
             print(f"Row missing required column {e}; "
                   f"treating as unparseable.")


### PR DESCRIPTION
## Summary

PR #19649 added a band check to skip rewriting the calibration TSV when no production row moved outside its band. The check works for `single_node_performance_values.tsv` but is bypassed for `aptos-move/e2e-benchmark/data/calibration_values.tsv`.

The move-e2e Humio query (`testsuite/single_node_performance_calibration.py:174`) emits rows with columns `transaction_type, count, min_ratio, max_ratio, median, expected` — no `executor_type`. The loop on line 269 unconditionally read `new_row[\"executor_type\"]`, so every move-e2e row raised `KeyError`, was counted as unparseable, and set `needs_update = True`. The `wall_time_band` gate on lines 304-315 never ran, and every calibration job rewrote the TSV — the exact behavior #19649 set out to prevent.

## Fix

Skip the `executor_type` read when `args.move_e2e` is set. Non-move-e2e rows still require the column and treat its absence as unparseable.

## Test plan

- [ ] Run `python testsuite/single_node_performance_calibration.py --move-e2e` against a known-stable window and confirm the script reports `out_of_band=0` and exits without rewriting the TSV
- [ ] Run without `--move-e2e` and confirm existing behavior (executor_type gate, NON_BLOCKING_EXECUTOR_TYPES skip) is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, localized change to CI calibration parsing that only relaxes `executor_type` handling for the `--move-e2e` path while leaving the non-move-e2e gating intact.
> 
> **Overview**
> Fixes the `--move-e2e` calibration path in `single_node_performance_calibration.py` by no longer requiring an `executor_type` field for move-e2e Humio rows.
> 
> This prevents move-e2e rows from being marked *unparseable* (and forcing `needs_update=true`), so the existing band-check can correctly skip rewriting `aptos-move/e2e-benchmark/data/calibration_values.tsv` when results stay in-band.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f1bca9e1a5c324d97118bf7ca83aed9bf1c6bd9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->