### PR TITLE
[Network] Improve peer dialing: reduce backoff time and add min-dials-before-backoff

### DIFF
--- a/config/src/config/network_config.rs
+++ b/config/src/config/network_config.rs
@@ -161,6 +161,8 @@ pub struct NetworkConfig {
     /// Rate limiting configuration for inbound network traffic (per peer).
     /// If None, inbound rate limiting is disabled.
     pub inbound_rate_limit_config: Option<RateLimitConfig>,
+    /// The minimum number of dial attempts before a peer is put into backoff mode
+    pub num_dials_before_backoff: usize,
 }
 
 impl Default for NetworkConfig {
@@ -208,6 +210,7 @@ impl NetworkConfig {
             access_control_policy: None,
             priority_inbound_peers: Vec::new(),
             inbound_rate_limit_config: None,
+            num_dials_before_backoff: 2, // Attempt at least 2 dials before backing off
         };
 
         // Configure the number of parallel deserialization tasks

--- a/network/builder/src/builder.rs
+++ b/network/builder/src/builder.rs
@@ -162,6 +162,7 @@ impl NetworkBuilder {
             mutual_authentication,
             true, /* enable_latency_aware_dialing */
             None, /* access_control_policy */
+            2,    /* num_dials_before_backoff */
         );
 
         builder
@@ -237,6 +238,7 @@ impl NetworkBuilder {
             config.mutual_authentication,
             config.enable_latency_aware_dialing,
             access_control_policy,
+            config.num_dials_before_backoff,
         );
 
         network_builder.discovery_listeners = Some(Vec::new());
@@ -344,6 +346,7 @@ impl NetworkBuilder {
         mutual_authentication: bool,
         enable_latency_aware_dialing: bool,
         access_control_policy: Option<Arc<AccessControlPolicy>>,
+        num_dials_before_backoff: usize,
     ) -> &mut Self {
         let pm_conn_mgr_notifs_rx = self.peer_manager_builder.add_connection_event_listener();
         let outbound_connection_limit = if !self.network_context.network_id().is_validator_network()
@@ -368,6 +371,7 @@ impl NetworkBuilder {
             mutual_authentication,
             enable_latency_aware_dialing,
             access_control_policy,
+            num_dials_before_backoff,
         ));
         self
     }

--- a/network/framework/src/connectivity_manager/builder.rs
+++ b/network/framework/src/connectivity_manager/builder.rs
@@ -24,6 +24,7 @@ pub struct ConnectivityManagerBuilder {
 }
 
 impl ConnectivityManagerBuilder {
+    #[allow(clippy::too_many_arguments)]
     pub fn create(
         network_context: NetworkContext,
         time_service: TimeService,
@@ -39,6 +40,7 @@ impl ConnectivityManagerBuilder {
         mutual_authentication: bool,
         enable_latency_aware_dialing: bool,
         access_control_policy: Option<Arc<AccessControlPolicy>>,
+        num_dials_before_backoff: usize,
     ) -> Self {
         let (conn_mgr_reqs_tx, conn_mgr_reqs_rx) = aptos_channels::new(
             channel_size,
@@ -62,6 +64,7 @@ impl ConnectivityManagerBuilder {
                 mutual_authentication,
                 enable_latency_aware_dialing,
                 access_control_policy,
+                num_dials_before_backoff,
             )),
         }
     }

--- a/network/framework/src/connectivity_manager/mod.rs
+++ b/network/framework/src/connectivity_manager/mod.rs
@@ -132,6 +132,8 @@ pub struct ConnectivityManager<TBackoff> {
     enable_latency_aware_dialing: bool,
     /// Access control policy for peer connections
     access_control_policy: Option<Arc<AccessControlPolicy>>,
+    /// The minimum number of dial attempts before a peer is put into backoff mode
+    num_dials_before_backoff: usize,
 }
 
 /// Different sources for peer addresses, ordered by priority (Onchain=highest,
@@ -238,6 +240,8 @@ struct DiscoveredPeer {
     keys: PublicKeys,
     /// The last time the node was dialed
     last_dial_time: SystemTime,
+    /// The number of times we have dialed this peer
+    dial_count: usize,
     /// The calculated peer ping latency (secs)
     ping_latency_secs: Option<f64>,
 }
@@ -249,6 +253,7 @@ impl DiscoveredPeer {
             addrs: Addresses::default(),
             keys: PublicKeys::default(),
             last_dial_time: SystemTime::UNIX_EPOCH,
+            dial_count: 0,
             ping_latency_secs: None,
         }
     }
@@ -268,9 +273,10 @@ impl DiscoveredPeer {
         self.addrs.is_empty() && self.keys.is_empty()
     }
 
-    /// Updates the last time we tried to connect to this node
+    /// Updates the last time we tried to connect to this node and increments the dial count
     pub fn update_last_dial_time(&mut self) {
         self.last_dial_time = SystemTime::now();
+        self.dial_count = self.dial_count.saturating_add(1);
     }
 
     /// Updates the ping latency for this peer
@@ -278,8 +284,13 @@ impl DiscoveredPeer {
         self.ping_latency_secs = Some(latency_secs);
     }
 
-    /// Based on input, backoff on amount of time to dial a peer again
-    pub fn has_dialed_recently(&self) -> bool {
+    /// Returns true iff this peer should be considered "recently dialed" for backoff purposes.
+    /// A peer is only put into backoff mode after it has been dialed at least
+    /// `num_dials_before_backoff` times, ensuring we try all addresses before backing off.
+    pub fn has_dialed_recently(&self, num_dials_before_backoff: usize) -> bool {
+        if self.dial_count < num_dials_before_backoff {
+            return false;
+        }
         if let Ok(duration_since_last_dial) = self.last_dial_time.elapsed() {
             duration_since_last_dial < TRY_DIAL_BACKOFF_TIME
         } else {
@@ -288,10 +299,16 @@ impl DiscoveredPeer {
     }
 }
 
-impl PartialOrd for DiscoveredPeer {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        let self_dialed_recently = self.has_dialed_recently();
-        let other_dialed_recently = other.has_dialed_recently();
+impl DiscoveredPeer {
+    /// Compares this peer to another for dial prioritization. Peers that
+    /// haven't been dialed recently are prioritized (i.e., ordered as Less).
+    pub fn compare_dial_priority(
+        &self,
+        other: &Self,
+        num_dials_before_backoff: usize,
+    ) -> Option<Ordering> {
+        let self_dialed_recently = self.has_dialed_recently(num_dials_before_backoff);
+        let other_dialed_recently = other.has_dialed_recently(num_dials_before_backoff);
 
         // Less recently dialed is prioritized over recently dialed
         if !self_dialed_recently && other_dialed_recently {
@@ -347,6 +364,7 @@ where
     TBackoff: Iterator<Item = Duration> + Clone,
 {
     /// Creates a new instance of the [`ConnectivityManager`] actor.
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         network_context: NetworkContext,
         time_service: TimeService,
@@ -362,6 +380,7 @@ where
         mutual_authentication: bool,
         enable_latency_aware_dialing: bool,
         access_control_policy: Option<Arc<AccessControlPolicy>>,
+        num_dials_before_backoff: usize,
     ) -> Self {
         // Verify that the trusted peers set exists and that it is empty
         let trusted_peers = peers_and_metadata
@@ -399,6 +418,7 @@ where
             mutual_authentication,
             enable_latency_aware_dialing,
             access_control_policy,
+            num_dials_before_backoff,
         };
 
         // Set the initial seed config addresses and public keys
@@ -657,10 +677,15 @@ where
                 eligible_peers,
                 num_peers_to_dial,
                 self.discovered_peers.clone(),
+                self.num_dials_before_backoff,
             )
         } else {
             // Choose the peers randomly
-            selection::choose_peers_to_dial_randomly(eligible_peers, num_peers_to_dial)
+            selection::choose_peers_to_dial_randomly(
+                eligible_peers,
+                num_peers_to_dial,
+                self.num_dials_before_backoff,
+            )
         }
     }
 

--- a/network/framework/src/connectivity_manager/mod.rs
+++ b/network/framework/src/connectivity_manager/mod.rs
@@ -89,8 +89,8 @@ const MAX_SOCKET_ADDRESSES_TO_PING: usize = 2;
 
 /// The amount of time to try other peers until dialing this peer again.
 ///
-/// It's currently set to 5 minutes to ensure rotation through all (or most) peers
-const TRY_DIAL_BACKOFF_TIME: Duration = Duration::from_secs(300);
+/// It's currently set to 3 minutes to ensure rotation through all (or most) peers
+const TRY_DIAL_BACKOFF_TIME: Duration = Duration::from_secs(180);
 
 /// The ConnectivityManager actor.
 pub struct ConnectivityManager<TBackoff> {

--- a/network/framework/src/connectivity_manager/mod.rs
+++ b/network/framework/src/connectivity_manager/mod.rs
@@ -286,7 +286,7 @@ impl DiscoveredPeer {
 
     /// Returns true iff this peer should be considered "recently dialed" for backoff purposes.
     /// A peer is only put into backoff mode after it has been dialed at least
-    /// `num_dials_before_backoff` times, ensuring we try all addresses before backing off.
+    /// `num_dials_before_backoff` times, ensuring we try a few addresses before backing off.
     pub fn has_dialed_recently(&self, num_dials_before_backoff: usize) -> bool {
         if self.dial_count < num_dials_before_backoff {
             return false;
@@ -1425,5 +1425,97 @@ where
         let jitter = jitter(MAX_CONNECTION_DELAY_JITTER);
 
         min(max_delay, self.backoff.next().unwrap_or(max_delay)) + jitter
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aptos_config::config::PeerRole;
+
+    #[test]
+    fn test_has_dialed_recently_below_threshold() {
+        // A peer dialed once with num_dials_before_backoff=2 should not be in backoff
+        let peer = create_peer_dialed_n_times(1);
+        assert!(!peer.has_dialed_recently(2));
+    }
+
+    #[test]
+    fn test_has_dialed_recently_at_threshold() {
+        // A peer dialed exactly num_dials_before_backoff times should be in backoff
+        let peer = create_peer_dialed_n_times(2);
+        assert!(peer.has_dialed_recently(2));
+    }
+
+    #[test]
+    fn test_has_dialed_recently_above_threshold() {
+        // A peer dialed more than num_dials_before_backoff times should still be in backoff
+        let peer = create_peer_dialed_n_times(5);
+        assert!(peer.has_dialed_recently(2));
+    }
+
+    #[test]
+    fn test_has_dialed_recently_zero_dials() {
+        // A peer that has never been dialed should never be in backoff
+        let peer = DiscoveredPeer::new(PeerRole::ValidatorFullNode);
+        assert!(!peer.has_dialed_recently(1));
+        assert!(!peer.has_dialed_recently(2));
+    }
+
+    #[test]
+    fn test_has_dialed_recently_threshold_one() {
+        // With num_dials_before_backoff=1, a single dial should trigger backoff
+        let peer = create_peer_dialed_n_times(1);
+        assert!(peer.has_dialed_recently(1));
+    }
+
+    #[test]
+    fn test_compare_dial_priority_below_threshold_not_deprioritized() {
+        // A peer dialed once (below threshold=2) should not be deprioritized vs a fresh peer
+        let dialed_once_peer = create_peer_dialed_n_times(1);
+        let fresh_peer = DiscoveredPeer::new(PeerRole::ValidatorFullNode);
+
+        // Neither is in backoff, so ordering falls back to role comparison (equal here)
+        assert_eq!(
+            dialed_once_peer.compare_dial_priority(&fresh_peer, 2),
+            Some(Ordering::Equal)
+        );
+    }
+
+    #[test]
+    fn test_compare_dial_priority_at_threshold_is_deprioritized() {
+        // A peer that has hit the threshold should be ordered Greater (lower priority) than a fresh peer
+        let dialed_twice_peer = create_peer_dialed_n_times(2);
+        let fresh_peer = DiscoveredPeer::new(PeerRole::ValidatorFullNode);
+
+        assert_eq!(
+            dialed_twice_peer.compare_dial_priority(&fresh_peer, 2),
+            Some(Ordering::Greater)
+        );
+        assert_eq!(
+            fresh_peer.compare_dial_priority(&dialed_twice_peer, 2),
+            Some(Ordering::Less)
+        );
+    }
+
+    #[test]
+    fn test_dial_count_increments_on_update() {
+        let mut peer = DiscoveredPeer::new(PeerRole::ValidatorFullNode);
+        assert_eq!(peer.dial_count, 0);
+
+        peer.update_last_dial_time();
+        assert_eq!(peer.dial_count, 1);
+
+        peer.update_last_dial_time();
+        assert_eq!(peer.dial_count, 2);
+    }
+
+    /// Creates a `DiscoveredPeer` that has been dialed `n` times (with a recent dial time)
+    fn create_peer_dialed_n_times(n: usize) -> DiscoveredPeer {
+        let mut peer = DiscoveredPeer::new(PeerRole::ValidatorFullNode);
+        for _ in 0..n {
+            peer.update_last_dial_time();
+        }
+        peer
     }
 }

--- a/network/framework/src/connectivity_manager/selection.rs
+++ b/network/framework/src/connectivity_manager/selection.rs
@@ -653,6 +653,136 @@ mod test {
         ));
     }
 
+    /// Verifies that peers dialed fewer than `num_dials_before_backoff` times are
+    /// not treated as recently dialed and are therefore selected before fresh peers
+    /// (i.e., no deprioritization below the threshold).
+    #[test]
+    fn test_backoff_not_applied_below_threshold() {
+        let num_dials_before_backoff = 2;
+
+        // Build eligible peers: some dialed once (below threshold), some never dialed
+        let mut eligible_peers = vec![];
+        let mut below_threshold_peers = hashset![];
+        let mut never_dialed_peers = hashset![];
+
+        for _ in 0..10 {
+            let peer_id = AccountAddress::random();
+            let mut peer = DiscoveredPeer::new(PeerRole::ValidatorFullNode);
+            peer.update_last_dial_time(); // dial_count = 1, below threshold of 2
+            below_threshold_peers.insert(peer_id);
+            eligible_peers.push((peer_id, peer));
+        }
+
+        for _ in 0..10 {
+            let peer_id = AccountAddress::random();
+            never_dialed_peers.insert(peer_id);
+            eligible_peers.push((peer_id, DiscoveredPeer::new(PeerRole::ValidatorFullNode)));
+        }
+
+        // Choose all peers — both groups should appear since neither is in backoff
+        let selected =
+            choose_peers_to_dial_randomly(eligible_peers.clone(), 20, num_dials_before_backoff);
+        assert_eq!(selected.len(), 20);
+
+        // Choose only 10 peers — could come from either group since neither is deprioritized
+        // (both have the same role, so ordering is equal within each group after shuffle)
+        let selected = choose_peers_to_dial_randomly(eligible_peers, 10, num_dials_before_backoff);
+        assert_eq!(selected.len(), 10);
+    }
+
+    /// Verifies that peers dialed at least `num_dials_before_backoff` times are
+    /// deprioritized in favor of peers that have not yet hit the threshold.
+    #[test]
+    fn test_backoff_applied_at_threshold() {
+        let num_dials_before_backoff = 2;
+
+        let mut eligible_peers = vec![];
+
+        // 20 peers at or above the threshold (in backoff)
+        let at_threshold_peers = insert_dialed_peers(20, &mut eligible_peers);
+
+        // 10 peers below the threshold (not in backoff) — dialed once
+        let mut below_threshold_peers = hashset![];
+        for _ in 0..10 {
+            let peer_id = AccountAddress::random();
+            let mut peer = DiscoveredPeer::new(PeerRole::ValidatorFullNode);
+            peer.update_last_dial_time(); // dial_count = 1
+            below_threshold_peers.insert(peer_id);
+            eligible_peers.push((peer_id, peer));
+        }
+
+        // Selecting up to 10 peers should prefer the below-threshold peers
+        for num_to_select in 1..=10 {
+            let selected = choose_peers_to_dial_randomly(
+                eligible_peers.clone(),
+                num_to_select,
+                num_dials_before_backoff,
+            );
+            assert_eq!(selected.len(), num_to_select);
+            for (peer_id, _) in &selected {
+                assert!(
+                    below_threshold_peers.contains(peer_id),
+                    "Expected below-threshold peer to be selected, got {:?}",
+                    peer_id
+                );
+                assert!(!at_threshold_peers.contains(peer_id));
+            }
+        }
+    }
+
+    /// Verifies that a peer dialed once (below threshold=2) is not in backoff,
+    /// and that after a second dial it enters backoff.
+    #[test]
+    fn test_backoff_transition_at_threshold() {
+        let num_dials_before_backoff = 2;
+
+        let mut peer = DiscoveredPeer::new(PeerRole::ValidatorFullNode);
+
+        // Before any dials: not in backoff
+        assert!(!peer.has_dialed_recently(num_dials_before_backoff));
+
+        // After one dial: still not in backoff (below threshold)
+        peer.update_last_dial_time();
+        assert!(!peer.has_dialed_recently(num_dials_before_backoff));
+
+        // After second dial: now in backoff (at threshold)
+        peer.update_last_dial_time();
+        assert!(peer.has_dialed_recently(num_dials_before_backoff));
+    }
+
+    /// Verifies that with threshold=1 the old single-dial backoff behavior is preserved.
+    #[test]
+    fn test_backoff_threshold_one_matches_old_behavior() {
+        let num_dials_before_backoff = 1;
+
+        let mut eligible_peers = vec![];
+        let non_dialed_peers = insert_non_dialed_peers(10, &mut eligible_peers);
+
+        // Peers dialed once (threshold=1 means they are in backoff after 1 dial)
+        let mut single_dialed = hashset![];
+        for _ in 0..10 {
+            let peer_id = AccountAddress::random();
+            let mut peer = DiscoveredPeer::new(PeerRole::ValidatorFullNode);
+            peer.update_last_dial_time();
+            single_dialed.insert(peer_id);
+            eligible_peers.push((peer_id, peer));
+        }
+
+        // Should prefer the non-dialed peers
+        for num_to_select in 1..=10 {
+            let selected = choose_peers_to_dial_randomly(
+                eligible_peers.clone(),
+                num_to_select,
+                num_dials_before_backoff,
+            );
+            assert_eq!(selected.len(), num_to_select);
+            for (peer_id, _) in &selected {
+                assert!(non_dialed_peers.contains(peer_id));
+                assert!(!single_dialed.contains(peer_id));
+            }
+        }
+    }
+
     /// Creates a set of discovered peers from the given eligible
     /// peers. If `set_ping_latencies` is true, random ping latencies
     /// are set for each peer.

--- a/network/framework/src/connectivity_manager/selection.rs
+++ b/network/framework/src/connectivity_manager/selection.rs
@@ -20,13 +20,16 @@ use std::{cmp::Ordering, collections::HashSet, sync::Arc};
 pub fn choose_peers_to_dial_randomly(
     mut eligible_peers: Vec<(PeerId, DiscoveredPeer)>,
     num_peers_to_dial: usize,
+    num_dials_before_backoff: usize,
 ) -> Vec<(PeerId, DiscoveredPeer)> {
     // Shuffle the peers (so that we don't always dial the same ones first)
     eligible_peers.shuffle(&mut ::rand_latest::thread_rng());
 
     // Sort the peers by priority (this takes into account last dial times)
-    eligible_peers
-        .sort_by(|(_, peer), (_, other)| peer.partial_cmp(other).unwrap_or(Ordering::Equal));
+    eligible_peers.sort_by(|(_, peer), (_, other)| {
+        peer.compare_dial_priority(other, num_dials_before_backoff)
+            .unwrap_or(Ordering::Equal)
+    });
 
     // Select the peers to dial
     eligible_peers.into_iter().take(num_peers_to_dial).collect()
@@ -38,6 +41,7 @@ pub fn choose_random_peers_by_ping_latency(
     eligible_peers: Vec<(PeerId, DiscoveredPeer)>,
     num_peers_to_choose: usize,
     discovered_peers: Arc<RwLock<DiscoveredPeerSet>>,
+    num_dials_before_backoff: usize,
 ) -> Vec<(PeerId, DiscoveredPeer)> {
     // Get all eligible peer IDs
     let eligible_peer_ids = eligible_peers
@@ -48,7 +52,7 @@ pub fn choose_random_peers_by_ping_latency(
     // Identify the peer IDs that haven't been dialed recently
     let non_recently_dialed_peer_ids = eligible_peers
         .iter()
-        .filter(|(_, peer)| !peer.has_dialed_recently())
+        .filter(|(_, peer)| !peer.has_dialed_recently(num_dials_before_backoff))
         .map(|(peer_id, _)| *peer_id)
         .collect::<HashSet<_>>();
 
@@ -237,7 +241,7 @@ mod test {
         let eligible_peers = vec![];
 
         // Choose several peers randomly and verify none are selected
-        let selected_peers = choose_peers_to_dial_randomly(eligible_peers, 5);
+        let selected_peers = choose_peers_to_dial_randomly(eligible_peers, 5, 2);
         assert!(selected_peers.is_empty());
 
         // Create a large set of eligible peers
@@ -245,7 +249,7 @@ mod test {
 
         // Choose several peers randomly and verify the number of selected peers
         let num_peers_to_dial = 5;
-        let selected_peers = choose_peers_to_dial_randomly(eligible_peers, num_peers_to_dial);
+        let selected_peers = choose_peers_to_dial_randomly(eligible_peers, num_peers_to_dial, 2);
         assert_eq!(selected_peers.len(), num_peers_to_dial);
 
         // Create a small set of eligible peers
@@ -253,7 +257,7 @@ mod test {
         let eligible_peers = create_eligible_peers(num_eligible_peers);
 
         // Choose many peers randomly and verify the number of selected peers
-        let selected_peers = choose_peers_to_dial_randomly(eligible_peers, 20);
+        let selected_peers = choose_peers_to_dial_randomly(eligible_peers, 20, 2);
         assert_eq!(selected_peers.len(), num_eligible_peers);
     }
 
@@ -265,11 +269,11 @@ mod test {
 
         // Choose all the peers randomly and verify the number of selected peers
         let selected_peers_1 =
-            choose_peers_to_dial_randomly(eligible_peers.clone(), num_eligible_peers);
+            choose_peers_to_dial_randomly(eligible_peers.clone(), num_eligible_peers, 2);
         assert_eq!(selected_peers_1.len(), num_eligible_peers);
 
         // Choose all the peers randomly again and verify the number of selected peers
-        let selected_peers_2 = choose_peers_to_dial_randomly(eligible_peers, num_eligible_peers);
+        let selected_peers_2 = choose_peers_to_dial_randomly(eligible_peers, num_eligible_peers, 2);
         assert_eq!(selected_peers_2.len(), num_eligible_peers);
 
         // Verify the selected peer sets are identical
@@ -298,7 +302,7 @@ mod test {
         for num_peers_to_dial in 1..=num_non_dialed_peers {
             // Choose peers randomly and verify the number of selected peers
             let selected_peers =
-                choose_peers_to_dial_randomly(eligible_peers.clone(), num_peers_to_dial);
+                choose_peers_to_dial_randomly(eligible_peers.clone(), num_peers_to_dial, 2);
             assert_eq!(selected_peers.len(), num_peers_to_dial);
 
             // Verify that all of the selected peers were not dialed recently
@@ -315,7 +319,7 @@ mod test {
         for num_peers_to_dial in num_non_dialed_peers + 1..=total_num_peers {
             // Choose peers randomly and verify the number of selected peers
             let selected_peers =
-                choose_peers_to_dial_randomly(eligible_peers.clone(), num_peers_to_dial);
+                choose_peers_to_dial_randomly(eligible_peers.clone(), num_peers_to_dial, 2);
             assert_eq!(selected_peers.len(), num_peers_to_dial);
 
             // Update the selected peer flags
@@ -358,6 +362,7 @@ mod test {
                 eligible_peers.clone(),
                 num_peers_to_dial,
                 discovered_peers.clone(),
+                2,
             );
             assert_eq!(selected_peers.len(), num_peers_to_dial);
 
@@ -377,6 +382,7 @@ mod test {
                 eligible_peers.clone(),
                 num_peers_to_dial,
                 discovered_peers.clone(),
+                2,
             );
             assert_eq!(selected_peers.len(), num_peers_to_dial);
 
@@ -413,6 +419,7 @@ mod test {
             eligible_peers.clone(),
             5,
             discovered_peers.clone(),
+            2,
         );
         assert!(selected_peers.is_empty());
 
@@ -430,6 +437,7 @@ mod test {
             eligible_peers.clone(),
             num_peers_to_choose,
             discovered_peers.clone(),
+            2,
         );
         assert_eq!(selected_peers.len(), num_peers_to_choose);
 
@@ -439,6 +447,7 @@ mod test {
             eligible_peers.clone(),
             num_non_dialed_peers,
             discovered_peers.clone(),
+            2,
         );
         assert_eq!(selected_peers.len(), num_non_dialed_peers);
 
@@ -448,6 +457,7 @@ mod test {
             eligible_peers.clone(),
             num_non_dialed_peers + 1,
             discovered_peers.clone(),
+            2,
         );
         assert_eq!(selected_peers.len(), num_non_dialed_peers);
 
@@ -465,6 +475,7 @@ mod test {
             eligible_peers.clone(),
             num_peers_to_choose,
             discovered_peers.clone(),
+            2,
         );
         assert_eq!(selected_peers.len(), num_peers_to_choose);
 
@@ -475,6 +486,7 @@ mod test {
             eligible_peers.clone(),
             num_peers_to_choose,
             discovered_peers.clone(),
+            2,
         );
         assert_eq!(selected_peers.len(), num_peers_to_choose);
 
@@ -485,6 +497,7 @@ mod test {
             eligible_peers.clone(),
             num_total_peers + 10,
             discovered_peers.clone(),
+            2,
         );
         assert_eq!(selected_peers.len(), num_total_peers);
     }
@@ -515,6 +528,7 @@ mod test {
                 eligible_peers.clone(),
                 num_peers_to_dial,
                 discovered_peers.clone(),
+                2,
             );
             assert_eq!(selected_peers.len(), num_peers_to_dial);
 
@@ -560,6 +574,7 @@ mod test {
                 eligible_peers.clone(),
                 num_peers_to_dial,
                 discovered_peers.clone(),
+                2,
             );
             assert_eq!(selected_peers.len(), num_peers_to_dial);
 
@@ -688,7 +703,8 @@ mod test {
             let mut peer = DiscoveredPeer::new(PeerRole::PreferredUpstream);
             dialed_peers.insert(peer_id);
 
-            // Set the last dial time to be recent
+            // Set the last dial time to be recent (dial twice to meet num_dials_before_backoff = 2)
+            peer.update_last_dial_time();
             peer.update_last_dial_time();
 
             // Add the peer to the eligible peers

--- a/network/framework/src/connectivity_manager/test.rs
+++ b/network/framework/src/connectivity_manager/test.rs
@@ -106,6 +106,7 @@ impl TestHarness {
             true, /* mutual_authentication */
             true, /* enable_latency_aware_dialing */
             None, /* access_control_policy */
+            2,    /* num_dials_before_backoff */
         );
         let mock = Self {
             network_context,
@@ -1027,6 +1028,7 @@ fn create_connectivity_manager_with_policy(
         true, /* mutual_authentication */
         true, /* enable_latency_aware_dialing */
         access_control_policy,
+        2, /* num_dials_before_backoff */
     )
 }
 


### PR DESCRIPTION
## Description
This PR makes two improvements to how the connectivity manager dials peers:                                                                                                                                                                                                                                             
   
  1. Reduces `TRY_DIAL_BACKOFF_TIME` from 5 minutes to 3 minutes. This speeds up peer rotation and reconnection after a failed dial cycle.                                                                                                                                                                                  
  2. Adds `num_dials_before_backoff` config (default: 2). Previously, a single dial attempt would immediately start the full backoff timer, meaning a peer with multiple addresses (e.g., a validator with both a PFN port, and a VFN) could get stuck behind the backoff after only trying one address. Now, a peer won't enter backoff mode until it has been dialed at least `num_dials_before_backoff` times.
  
Note: this is useful for supporting VFN removal as a part of AIP 139: https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-139-deprecating-validator-full-nodes-vfns.md

## Testing Plan
New and existing test infrastructure, as well as manual verification.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes peer dialing/backoff behavior in the `ConnectivityManager`, which can affect network connectivity and peer rotation under failure scenarios. Risk is mitigated by defaulting the new setting and adding targeted unit tests, but it still touches core networking logic.
> 
> **Overview**
> Reduces peer redial backoff (`TRY_DIAL_BACKOFF_TIME`) from **5 minutes to 3 minutes** to speed up peer rotation after failed dial cycles.
> 
> Introduces a new `NetworkConfig` knob, `num_dials_before_backoff` (default **2**), and threads it through the network builder into the `ConnectivityManager`. Dial deprioritization/backoff now only triggers after a peer has been dialed at least this many times (tracked via a new per-peer `dial_count`), updating both random and latency-aware peer selection and expanding tests accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17164f536e0670d4af08bff3989ae6a744561029. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->