### PR TITLE
[Release] release.yaml for v1.45.0-rc testnet framework

### DIFF
--- a/aptos-move/aptos-release-builder/data/release.yaml
+++ b/aptos-move/aptos-release-builder/data/release.yaml
@@ -1,20 +1,18 @@
 ---
-remote_endpoint: https://fullnode.mainnet.aptoslabs.com
+remote_endpoint: https://fullnode.testnet.aptoslabs.com
 # replace with below for actual release, compat test needs concrete URL above:
 # remote_endpoint: ~
-name: "vX.YY.Z"
+name: "v1.45.0-rc"
 proposals:
   - name: proposal_1_upgrade_framework
     metadata:
-      title: "Multi-step proposal to upgrade mainnet framework, version vX.YY.Z"
-      description: "This includes changes in https://github.com/aptos-labs/aptos-core/releases/tag/aptos-node-vX.YY.Z"
+      title: "Multi-step proposal to upgrade testnet framework, version v1.45.0-rc"
+      description: "This includes changes in https://github.com/aptos-labs/aptos-core/releases/tag/aptos-framework-v1.45.0-rc"
     execution_mode: MultiStep
     update_sequence:
       - Gas:
-          new: current
-          # replace with below for actual release, above "current" is needed for compat tests:
-          # old: https://raw.githubusercontent.com/aptos-labs/aptos-networks/main/gas/vX.WW.Z.json
-          # new: https://raw.githubusercontent.com/aptos-labs/aptos-networks/main/gas/vX.YY.Z.json
+          old: https://raw.githubusercontent.com/aptos-labs/aptos-networks/main/gas/v1.44.0.json
+          new: https://raw.githubusercontent.com/aptos-labs/aptos-networks/main/gas/v1.45.1.json
       - Framework:
-          bytecode_version: 8
+          bytecode_version: 9
           git_hash: ~


### PR DESCRIPTION
## Summary

Prepares the framework upgrade proposal for the v1.45.0-rc testnet release.

- Endpoint and proposal metadata switched to testnet and the `aptos-framework-v1.45.0-rc` release tag.
- Gas schedule: `v1.44.0` -> `v1.45.1`. Note: no `v1.45.0.json` was published on aptos-networks, so the new gas file jumps to `v1.45.1` (matches the branch version bumped in fb229eacc5).
- `bytecode_version` bumped to 9, consistent with d604b7830e on main.

## Test plan

- [ ] Confirm gas URLs resolve: `gas/v1.44.0.json` and `gas/v1.45.1.json`
- [ ] Confirm the `aptos-framework-v1.45.0-rc` release tag exists on GitHub
- [ ] Run release builder compat tests against testnet endpoint
- [ ] Dry-run the multi-step governance proposal on testnet before submitting on-chain

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates release-builder configuration used to generate a testnet governance upgrade proposal, including gas schedule URLs and bytecode version, so mistakes could lead to an incorrect or failing on-chain upgrade.
> 
> **Overview**
> Switches `release.yaml` from the placeholder mainnet config to a concrete **testnet** framework upgrade proposal for `v1.45.0-rc`.
> 
> Updates proposal metadata to point at the `aptos-framework-v1.45.0-rc` release tag, sets the gas schedule change to `v1.44.0.json` -> `v1.45.1.json`, and bumps `Framework.bytecode_version` from `8` to `9`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05f659bdaa37b4a26fb60e7b749ec1e5d9be2959. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->