### PR TITLE
[db-tool] log txn version + info for 0x1::confidential_asset events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1373,6 +1373,7 @@ dependencies = [
  "bcs 0.1.4",
  "clap 4.5.60",
  "itertools 0.13.0",
+ "move-core-types",
  "rayon",
  "serde_json",
  "tokio",

--- a/storage/db-tool/Cargo.toml
+++ b/storage/db-tool/Cargo.toml
@@ -29,6 +29,7 @@ aptos-vm-environment = { workspace = true }
 bcs = { workspace = true }
 clap = { workspace = true }
 itertools = { workspace = true }
+move-core-types = { workspace = true }
 rayon = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }

--- a/storage/db-tool/src/replay_on_archive.rs
+++ b/storage/db-tool/src/replay_on_archive.rs
@@ -30,6 +30,7 @@ use aptos_vm_environment::prod_configs::{
     set_async_runtime_checks, set_layout_caches, set_paranoid_type_checks,
 };
 use clap::Parser;
+use move_core_types::language_storage::{TypeTag, CORE_CODE_ADDRESS};
 use rayon::{iter::ParallelIterator, prelude::IntoParallelIterator};
 use std::{
     panic,
@@ -252,6 +253,7 @@ impl Verifier {
         let mut expected_txn_infos = Vec::with_capacity(limit as usize);
         let mut chunk_start_version = start;
         let executor = AptosVMBlockExecutor::new();
+        let mut next_version = start;
         for item in txn_iter {
             // timeout check
             if let Some(duration) = self.timeout_secs {
@@ -273,6 +275,27 @@ impl Verifier {
                 expected_writeset,
             ) = item?;
             let is_epoch_ending = expected_event.iter().any(ContractEvent::is_new_epoch_event);
+            let txn_version = next_version;
+            next_version += 1;
+            let confidential_asset_event_names: Vec<&str> = expected_event
+                .iter()
+                .filter_map(|event| {
+                    if let TypeTag::Struct(struct_tag) = event.type_tag() {
+                        if struct_tag.address == CORE_CODE_ADDRESS
+                            && struct_tag.module.as_str() == "confidential_asset"
+                        {
+                            return Some(struct_tag.name.as_str());
+                        }
+                    }
+                    None
+                })
+                .collect();
+            if !confidential_asset_event_names.is_empty() {
+                info!(
+                    "Txn version {} has events from 0x1::confidential_asset: {:?}. {}",
+                    txn_version, confidential_asset_event_names, expected_txn_info,
+                );
+            }
             cur_txns.push(input_txn);
             cur_persisted_aux_info.push(persisted_aux_info);
             expected_txn_infos.push(expected_txn_info);


### PR DESCRIPTION
## Summary
- During `replay_on_archive`, emit an `info!` log whenever a replayed transaction emits an event whose struct tag lives in `0x1::confidential_asset`.
- The log line includes the txn version, the matching event struct names, and the full `TransactionInfo` (txn hash, state change hash, event root hash, state checkpoint hash, gas used, status) via its `Display` impl.
- Adds `move-core-types` as a dependency of `aptos-db-tool` for `TypeTag` / `CORE_CODE_ADDRESS`.

Intended as a low-overhead way to enumerate confidential-asset activity offline by tailing `replay_on_archive` logs.

## Test plan
- [ ] `cargo check -p aptos-db-tool` (passes locally)
- [ ] Run `replay_on_archive` over a known range that includes `0x1::confidential_asset` events and confirm the log lines appear with the expected version + hash fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)