### PR TITLE
[execution] Clamp per-block gas limit override to on-chain cap

### DIFF
--- a/aptos-move/block-executor/src/limit_processor.rs
+++ b/aptos-move/block-executor/src/limit_processor.rs
@@ -125,9 +125,7 @@ impl<T: Transaction> BlockGasLimitProcessor<T> {
             self.block_gas_limit_override,
             self.block_gas_limit_type.block_gas_limit(),
         ) {
-            (Some(override_limit), Some(onchain_limit)) => {
-                Some(override_limit.min(onchain_limit))
-            },
+            (Some(override_limit), Some(onchain_limit)) => Some(override_limit.min(onchain_limit)),
             (Some(override_limit), None) => Some(override_limit),
             (None, onchain_limit) => onchain_limit,
         }

--- a/aptos-move/block-executor/src/limit_processor.rs
+++ b/aptos-move/block-executor/src/limit_processor.rs
@@ -117,10 +117,19 @@ impl<T: Transaction> BlockGasLimitProcessor<T> {
     }
 
     fn block_gas_limit(&self) -> Option<u64> {
-        if self.block_gas_limit_override.is_some() {
-            self.block_gas_limit_override
-        } else {
-            self.block_gas_limit_type.block_gas_limit()
+        // The override is proposer-supplied (via the payload's TxnAndGasLimits) and
+        // is not validated against the on-chain cap during consensus payload
+        // verification. Clamp it to the on-chain limit so a Byzantine proposer
+        // cannot raise the per-block gas cap; the override may only lower it.
+        match (
+            self.block_gas_limit_override,
+            self.block_gas_limit_type.block_gas_limit(),
+        ) {
+            (Some(override_limit), Some(onchain_limit)) => {
+                Some(override_limit.min(onchain_limit))
+            },
+            (Some(override_limit), None) => Some(override_limit),
+            (None, onchain_limit) => onchain_limit,
         }
     }
 
@@ -350,6 +359,66 @@ mod test {
         processor.accumulate_fee_statement(execution_fee(10), None, None);
         assert!(!processor.should_end_block_parallel());
         processor.accumulate_fee_statement(execution_fee(50), None, None);
+        assert!(!processor.should_end_block_parallel());
+        processor.accumulate_fee_statement(execution_fee(40), None, None);
+        assert!(processor.should_end_block_parallel());
+    }
+
+    #[test]
+    fn test_override_cannot_exceed_onchain_limit() {
+        // Onchain effective cap is 100. A (potentially Byzantine) proposer-supplied
+        // override of u64::MAX must be clamped to 100, not honored as-is.
+        let block_gas_limit = BlockGasLimitType::ComplexLimitV1 {
+            effective_block_gas_limit: 100,
+            execution_gas_effective_multiplier: 1,
+            io_gas_effective_multiplier: 1,
+            conflict_penalty_window: 1,
+            use_module_publishing_block_conflict: false,
+            block_output_limit: None,
+            include_user_txn_size_in_block_output: true,
+            add_block_limit_outcome_onchain: false,
+            use_granular_resource_group_conflicts: false,
+        };
+
+        let mut processor = TestProcessor::new(block_gas_limit, Some(u64::MAX), 10);
+
+        processor.accumulate_fee_statement(execution_fee(60), None, None);
+        assert!(!processor.should_end_block_parallel());
+        // After 110 raw gas, the clamped (=100) onchain cap must trigger early halt.
+        processor.accumulate_fee_statement(execution_fee(50), None, None);
+        assert!(processor.should_end_block_parallel());
+    }
+
+    #[test]
+    fn test_override_can_lower_onchain_limit() {
+        // Override may still lower the effective cap below the onchain value.
+        let block_gas_limit = BlockGasLimitType::ComplexLimitV1 {
+            effective_block_gas_limit: 1_000_000,
+            execution_gas_effective_multiplier: 1,
+            io_gas_effective_multiplier: 1,
+            conflict_penalty_window: 1,
+            use_module_publishing_block_conflict: false,
+            block_output_limit: None,
+            include_user_txn_size_in_block_output: true,
+            add_block_limit_outcome_onchain: false,
+            use_granular_resource_group_conflicts: false,
+        };
+
+        let mut processor = TestProcessor::new(block_gas_limit, Some(50), 10);
+
+        processor.accumulate_fee_statement(execution_fee(20), None, None);
+        assert!(!processor.should_end_block_parallel());
+        processor.accumulate_fee_statement(execution_fee(40), None, None);
+        assert!(processor.should_end_block_parallel());
+    }
+
+    #[test]
+    fn test_override_when_onchain_is_no_limit() {
+        // When the onchain config has no cap, the override applies as given:
+        // there is no protocol cap to enforce, and Byzantine-amplification is moot.
+        let mut processor = TestProcessor::new(BlockGasLimitType::NoLimit, Some(50), 10);
+
+        processor.accumulate_fee_statement(execution_fee(20), None, None);
         assert!(!processor.should_end_block_parallel());
         processor.accumulate_fee_statement(execution_fee(40), None, None);
         assert!(processor.should_end_block_parallel());


### PR DESCRIPTION
## Summary

- `BlockGasLimitProcessor::block_gas_limit()` previously preferred the proposer-supplied `block_gas_limit_override` (carried in the OptQuorumStore payload's `TxnAndGasLimits`) over the on-chain `effective_block_gas_limit` whenever it was present, with no clamp. Consensus payload verification bounds only transaction count and bytes, not gas — so once `enable_per_block_gas_limit` is on, a Byzantine proposer could set `gas_limit = Some(u64::MAX)` (or any value above the configured cap) and force honest validators to execute far more gas per block than the protocol intends.
- This change clamps the override with `min(override, on-chain limit)` in `aptos-move/block-executor/src/limit_processor.rs`. The override may now only **lower** the per-block cap, never raise it. Enforcement lives at the executor — the on-chain config is in hand there, and this gives defense-in-depth regardless of what consensus payload verification does.
- Three semantics:
  - Both override and on-chain set → `min(override, on-chain)` (the fix)
  - Only override set (on-chain `NoLimit`) → honor override (no protocol cap to bypass)
  - No override → on-chain limit (unchanged)

## Test plan

- [x] `cargo test -p aptos-block-executor --lib limit_processor` — all 8 tests pass, including 3 new ones:
  - `test_override_cannot_exceed_onchain_limit` — `u64::MAX` override is clamped to the on-chain cap
  - `test_override_can_lower_onchain_limit` — override may still lower the effective cap
  - `test_override_when_onchain_is_no_limit` — when on-chain has no cap, override applies as-is

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches block execution limiting logic; an incorrect clamp could cause premature halts or allow oversized blocks, affecting throughput and safety under adversarial proposals.
> 
> **Overview**
> **Clamps proposer-supplied per-block gas limit overrides to the on-chain configured cap** in `BlockGasLimitProcessor::block_gas_limit()`, so overrides can only reduce the effective limit (or apply as-is when on-chain is `NoLimit`).
> 
> Adds unit tests covering the three cases: override higher than on-chain (clamped), override lower than on-chain (honored), and override with no on-chain limit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13b70c548151ff9aed65157dcc32280e7bb87f18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->