### PR TITLE
fix(rust-sdk): prevent integer overflow in expiration_timestamp_secs

### DIFF
--- a/crates/aptos-rest-client/src/lib.rs
+++ b/crates/aptos-rest-client/src/lib.rs
@@ -826,7 +826,7 @@ impl Client {
 
             if let Some(max_server_lag_wait_duration) = max_server_lag_wait {
                 if aptos_infallible::duration_since_epoch().as_secs()
-                    > expiration_timestamp_secs + max_server_lag_wait_duration.as_secs()
+                    > expiration_timestamp_secs.saturating_add(max_server_lag_wait_duration.as_secs())
                 {
                     return Err(anyhow!(
                         "Ledger on endpoint ({}) is more than {}s behind current time, timing out waiting for the transaction. Warning, transaction ({}) might still succeed.",


### PR DESCRIPTION
This is an independent contribution made after reviewing the issue and source code. Not affiliated with any organization or competition.

## Summary

Prevents a panic in `wait_for_transaction_by_hash_inner` when a transaction is submitted with `expiration_timestamp_secs` set to `u64::MAX`. The panic occurs due to an unchecked addition that overflows.

## Root Cause

In `crates/aptos-rest-client/src/lib.rs`, the expression `expiration_timestamp_secs + max_server_lag_wait_duration.as_secs()` uses the `+` operator, which panics on overflow in debug builds and wraps in release builds. When `expiration_timestamp_secs` is `u64::MAX`, adding any positive value triggers the overflow.

## Fix

Replaced the `+` operator with `saturating_add()`, which caps at `u64::MAX` instead of overflowing:

```rust
// Before:
> expiration_timestamp_secs + max_server_lag_wait_duration.as_secs()

// After:
> expiration_timestamp_secs.saturating_add(max_server_lag_wait_duration.as_secs())
```

This is semantically correct because `u64::MAX` already represents an effectively infinite expiration, so saturating at `u64::MAX` preserves the intended behavior without panicking.

## Testing

- The code compiles successfully with `cargo check -p aptos-rest-client`
- Existing semantics are preserved for all non-extreme values
- For `u64::MAX`, the comparison evaluates to `u64::MAX > current_time`, which is true and triggers the timeout path as expected

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, single-line change in timeout comparison logic; behavior is unchanged for normal values and only affects the extreme overflow edge case.
> 
> **Overview**
> Prevents integer overflow in `wait_for_transaction_by_hash_inner` when computing the server-lag timeout threshold by switching from `expiration_timestamp_secs + max_server_lag_wait_duration.as_secs()` to `expiration_timestamp_secs.saturating_add(...)`.
> 
> This avoids debug-build panics (and release wraparound) for extreme `expiration_timestamp_secs` values while preserving existing timeout behavior for typical inputs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 656d9442252d36e5be2e8182b65336aabdb70335. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->