### PR TITLE
[mono-move] Support aborts in the runtime

### DIFF
--- a/third_party/move/mono-move/core/src/instruction/gas.rs
+++ b/third_party/move/mono-move/core/src/instruction/gas.rs
@@ -69,6 +69,8 @@ impl HasCfgInfo for MicroOp {
             | MicroOp::IntShr(_)
             | MicroOp::IntNegate(_)
             | MicroOp::Return
+            | MicroOp::Abort { .. }
+            | MicroOp::AbortMsg { .. }
             | MicroOp::CallIndirect { .. }
             | MicroOp::CallDirect { .. }
             | MicroOp::VecNew { .. }
@@ -180,6 +182,8 @@ impl RemapTargets for MicroOp {
             | MicroOp::IntShr(_)
             | MicroOp::IntNegate(_)
             | MicroOp::Return
+            | MicroOp::Abort { .. }
+            | MicroOp::AbortMsg { .. }
             | MicroOp::CallIndirect { .. }
             | MicroOp::CallDirect { .. }
             | MicroOp::VecNew { .. }
@@ -262,6 +266,8 @@ impl GasSchedule<MicroOp> for MicroOpGasSchedule {
             // --- Control flow ---
             MicroOp::CallIndirect { .. } | MicroOp::CallDirect { .. } => 10,
             MicroOp::Return => 2,
+            MicroOp::Abort { .. } => 2,
+            MicroOp::AbortMsg { .. } => 5,
             MicroOp::Jump { .. } => 2,
             MicroOp::JumpNotZeroU64 { .. }
             | MicroOp::JumpGreaterEqualU64Imm { .. }

--- a/third_party/move/mono-move/core/src/instruction/mod.rs
+++ b/third_party/move/mono-move/core/src/instruction/mod.rs
@@ -471,7 +471,6 @@ pub enum MicroOp {
     // handle "dirty" bools (values other than 0 or 1).
     //
     // May want:
-    // - Abort,
     // - more conditions: ==, !=, >, <=, and const variants,
     // - something for enum dispatch (jump table)?
     //======================================================================
@@ -559,6 +558,21 @@ pub enum MicroOp {
         target: CodeOffset,
         lhs: FrameOffset,
         rhs: FrameOffset,
+    },
+
+    /// Abort the current execution with a u64 abort code, read from
+    /// `code`.
+    Abort {
+        code: FrameOffset,
+    },
+
+    /// Abort the current execution with a u64 abort code and a
+    /// `vector<u8>` message read from `message`. The interpreter
+    /// copies the bytes out, validates them as UTF-8, and enforces
+    /// the abort-message size limit.
+    AbortMsg {
+        code: FrameOffset,
+        message: FrameOffset,
     },
 
     //======================================================================
@@ -967,6 +981,12 @@ impl fmt::Display for MicroOp {
             MicroOp::Return => {
                 write!(f, "Return")
             },
+            MicroOp::Abort { code } => {
+                write!(f, "Abort [{}]", code.0)
+            },
+            MicroOp::AbortMsg { code, message } => {
+                write!(f, "AbortMsg code=[{}] msg=[{}]", code.0, message.0)
+            },
             MicroOp::Jump { target } => {
                 write!(f, "Jump @{}", target.0)
             },
@@ -1344,6 +1364,8 @@ impl MicroOp {
             | MicroOp::JumpLessU64 { .. }
             | MicroOp::JumpGreaterEqualU64 { .. }
             | MicroOp::JumpNotEqualU64 { .. }
+            | MicroOp::Abort { .. }
+            | MicroOp::AbortMsg { .. }
             | MicroOp::VecNew { .. }
             | MicroOp::VecLen { .. }
             | MicroOp::VecPopBack { .. }

--- a/third_party/move/mono-move/runtime/src/error.rs
+++ b/third_party/move/mono-move/runtime/src/error.rs
@@ -64,6 +64,12 @@ pub enum RuntimeError {
     #[error("alloc_vec: size overflow")]
     VecAllocSizeOverflow,
 
+    #[error("AbortMsg: message is not valid UTF-8")]
+    InvalidAbortMessage,
+
+    #[error("AbortMsg: message size {len} exceeds maximum {max}")]
+    AbortMessageTooLong { len: usize, max: usize },
+
     #[error("invariant violation: {0}")]
     InvariantViolation(#[from] RuntimeInvariantViolation),
 }
@@ -85,12 +91,14 @@ impl IntoExecutionError for RuntimeError {
             | DivisionByZeroOrOverflow { .. }
             | NegateMinOverflow { .. }
             | PopFromEmptyVector
-            | VectorIndexOutOfBounds { .. } => ExecutionErrorKind::InvalidOperation,
+            | VectorIndexOutOfBounds { .. }
+            | InvalidAbortMessage => ExecutionErrorKind::InvalidOperation,
 
             StackOverflow
             | OutOfHeapMemory { .. }
             | AllocationTooLarge { .. }
-            | VecAllocSizeOverflow => ExecutionErrorKind::RuntimeLimitExceeded,
+            | VecAllocSizeOverflow
+            | AbortMessageTooLong { .. } => ExecutionErrorKind::RuntimeLimitExceeded,
 
             InvariantViolation(_) => ExecutionErrorKind::InvariantViolation,
         }
@@ -216,6 +224,17 @@ pub enum RuntimeInvariantViolation {
         "CallClosure: {provided} provided_args but only {consumed} non-captured params consumed"
     )]
     ClosureArgsCountMismatch { provided: usize, consumed: usize },
+}
+
+/// Successful terminal outcomes from `Interpreter::run`. Runtime
+/// failures flow through the `Err` channel as [`RuntimeError`] — abort
+/// and failure are structurally separate.
+#[derive(Debug)]
+pub enum RuntimeStatus {
+    Success,
+    // TODO: carry the abort's `Location` (which module raised it) once
+    // we have a `Location` type defined.
+    Aborted { code: u64, message: Option<String> },
 }
 
 /// Returns from the enclosing function with an [`RuntimeError::InvariantViolation`]

--- a/third_party/move/mono-move/runtime/src/interpreter.rs
+++ b/third_party/move/mono-move/runtime/src/interpreter.rs
@@ -5,7 +5,7 @@
 //! and a bump-allocated heap with copying GC.
 
 use crate::{
-    error::{ArithOp, RuntimeError, RuntimeResult, Signedness, VecOp},
+    error::{ArithOp, RuntimeError, RuntimeResult, RuntimeStatus, Signedness, VecOp},
     heap::{
         macros::{alloc_obj, alloc_vec, gc_collect, grow_vec_ref},
         object_descriptor::{ObjectDescriptor, CLOSURE_DESCRIPTOR_ID},
@@ -18,8 +18,9 @@ use crate::{
         MemoryRegion,
     },
     types::{
-        StepResult, DEFAULT_HEAP_SIZE, DEFAULT_STACK_SIZE, META_SAVED_FP_OFFSET,
-        META_SAVED_FUNC_PTR_OFFSET, META_SAVED_PC_OFFSET, VEC_DATA_OFFSET, VEC_LENGTH_OFFSET,
+        StepResult, ABORT_MESSAGE_SIZE_LIMIT, DEFAULT_HEAP_SIZE, DEFAULT_STACK_SIZE,
+        META_SAVED_FP_OFFSET, META_SAVED_FUNC_PTR_OFFSET, META_SAVED_PC_OFFSET, VEC_DATA_OFFSET,
+        VEC_LENGTH_OFFSET,
     },
 };
 use mono_move_core::{
@@ -786,6 +787,41 @@ impl<T: ExecutionContext> InterpreterContext<'_, T> {
                     self.pc = read_u64(meta, META_SAVED_PC_OFFSET) as usize;
                     self.frame_ptr = read_ptr(meta, META_SAVED_FP_OFFSET);
                     return Ok(StepResult::Continue);
+                },
+
+                MicroOp::Abort { code } => {
+                    let code = read_u64(fp, code);
+                    return Ok(StepResult::Aborted {
+                        code,
+                        message: None,
+                    });
+                },
+
+                MicroOp::AbortMsg { code, message } => {
+                    let code = read_u64(fp, code);
+                    let vec_ptr = read_ptr(fp, message);
+                    let message = if vec_ptr.is_null() {
+                        String::new()
+                    } else {
+                        // TODO: charge gas for abort message bytes.
+                        let len = read_u64(vec_ptr, VEC_LENGTH_OFFSET) as usize;
+                        if len > ABORT_MESSAGE_SIZE_LIMIT {
+                            return Err(RuntimeError::AbortMessageTooLong {
+                                len,
+                                max: ABORT_MESSAGE_SIZE_LIMIT,
+                            });
+                        }
+                        // SAFETY: `vec_ptr` is non-null (checked above) and
+                        // points at a heap vector with `len` initialized
+                        // bytes at `VEC_DATA_OFFSET`.
+                        let data = vec_ptr.add(VEC_DATA_OFFSET);
+                        String::from_utf8(std::slice::from_raw_parts(data, len).to_vec())
+                            .map_err(|_| RuntimeError::InvalidAbortMessage)?
+                    };
+                    return Ok(StepResult::Aborted {
+                        code,
+                        message: Some(message),
+                    });
                 },
 
                 // ----- Arithmetic -----
@@ -1581,11 +1617,14 @@ impl<T: ExecutionContext> InterpreterContext<'_, T> {
     // iteration. LLVM can't keep them in registers because heap operations
     // (VecPushBack, etc.) take &mut self, which may alias these fields.
     // Write back only on CallFunc/Return.
-    pub fn run(&mut self) -> RuntimeResult<()> {
+    pub fn run(&mut self) -> RuntimeResult<RuntimeStatus> {
         loop {
             match self.step()? {
                 StepResult::Continue => {},
-                StepResult::Done => return Ok(()),
+                StepResult::Done => return Ok(RuntimeStatus::Success),
+                StepResult::Aborted { code, message } => {
+                    return Ok(RuntimeStatus::Aborted { code, message })
+                },
             }
         }
     }

--- a/third_party/move/mono-move/runtime/src/lib.rs
+++ b/third_party/move/mono-move/runtime/src/lib.rs
@@ -10,7 +10,7 @@ pub(crate) mod memory;
 mod types;
 mod verifier;
 
-pub use error::RuntimeError;
+pub use error::{RuntimeError, RuntimeStatus};
 pub use heap::{
     object_descriptor::{
         ObjectDescriptor, ObjectDescriptorTable, CLOSURE_DESCRIPTOR_ID, TRIVIAL_DESCRIPTOR_ID,

--- a/third_party/move/mono-move/runtime/src/types.rs
+++ b/third_party/move/mono-move/runtime/src/types.rs
@@ -17,6 +17,9 @@ pub enum StepResult {
     Continue,
     /// The outermost function has returned — execution is complete.
     Done,
+    /// Execution hit an `Abort` / `AbortMsg` micro-op. The code is the
+    /// u64 abort code; the message is populated when `AbortMsg` ran.
+    Aborted { code: u64, message: Option<String> },
 }
 
 // ---------------------------------------------------------------------------
@@ -26,6 +29,10 @@ pub enum StepResult {
 pub(crate) const DEFAULT_STACK_SIZE: usize = 1024 * 1024; // 1 MiB
 
 pub(crate) const DEFAULT_HEAP_SIZE: usize = 10 * 1024 * 1024; // 10 MiB
+
+/// Maximum size of an `AbortMsg` message, in bytes.
+/// TODO: make this configurable in some VM config.
+pub(crate) const ABORT_MESSAGE_SIZE_LIMIT: usize = 1024;
 
 /// Byte offset of `saved_pc` within frame metadata.
 pub(crate) const META_SAVED_PC_OFFSET: usize = 0;

--- a/third_party/move/mono-move/runtime/src/verifier.rs
+++ b/third_party/move/mono-move/runtime/src/verifier.rs
@@ -429,6 +429,15 @@ impl FunctionVerifier<'_> {
 
             MicroOp::Return | MicroOp::ForceGC => {},
 
+            MicroOp::Abort { code } => {
+                self.check_frame_access_8(pc, code);
+            },
+
+            MicroOp::AbortMsg { code, message } => {
+                self.check_frame_access_8(pc, code);
+                self.check_frame_access_8(pc, message);
+            },
+
             MicroOp::CallIndirect { .. } | MicroOp::CallDirect { .. } => {},
 
             // ----- VecNew -----

--- a/third_party/move/mono-move/specializer/src/lower/translate.rs
+++ b/third_party/move/mono-move/specializer/src/lower/translate.rs
@@ -691,6 +691,20 @@ impl<'a> LoweringState<'a> {
                 self.emit(MicroOp::Return);
             },
 
+            // --- Abort ---
+            Instr::Abort(code) => {
+                let code = self.slot(*code)?;
+                self.emit(MicroOp::Abort { code: code.offset });
+            },
+            Instr::AbortMsg(code, message) => {
+                let code = self.slot(*code)?;
+                let message = self.slot(*message)?;
+                self.emit(MicroOp::AbortMsg {
+                    code: code.offset,
+                    message: message.offset,
+                });
+            },
+
             _ => bail!("instruction {} not yet lowered", instr.opcode_name()),
         }
         Ok(())

--- a/third_party/move/mono-move/testsuite/src/runner.rs
+++ b/third_party/move/mono-move/testsuite/src/runner.rs
@@ -16,13 +16,14 @@ use mono_move_core::{types::EMPTY_TYPE_LIST, ExecutionContext};
 use mono_move_gas::SimpleGasMeter;
 use mono_move_global_context::{ExecutionGuard, GlobalContext};
 use mono_move_loader::{Loader, LoadingPolicy, LoweringPolicy, TransactionContext};
-use mono_move_runtime::InterpreterContext;
+use mono_move_runtime::{InterpreterContext, RuntimeStatus};
 use move_core_types::{
     account_address::AccountAddress,
     identifier::IdentStr,
     int256::{I256, U256},
     language_storage::ModuleId,
     value::MoveValue,
+    vm_status::StatusCode,
 };
 use move_vm_runtime::{
     data_cache::{MoveVmDataCacheAdapter, TransactionDataCache},
@@ -194,6 +195,14 @@ fn execute_function_v1(
                 display: format!("results: {}", vals.join(", ")),
             }
         },
+        Err(err) if err.major_status() == StatusCode::ABORTED => {
+            let code = err.sub_status().unwrap();
+            let display = match err.message() {
+                Some(m) => format!("aborted: code {} ({})", code, m),
+                None => format!("aborted: code {}", code),
+            };
+            Output { display }
+        },
         Err(err) => Output {
             display: format!("error: {}", err),
         },
@@ -260,7 +269,14 @@ fn execute_function_v2(
         Err(err) => Output {
             display: format!("error: {}", err),
         },
-        Ok(()) => {
+        Ok(RuntimeStatus::Aborted { code, message }) => {
+            let display = match message {
+                Some(m) => format!("aborted: code {} ({})", code, m),
+                None => format!("aborted: code {}", code),
+            };
+            Output { display }
+        },
+        Ok(RuntimeStatus::Success) => {
             let mut ret_off: u32 = 0;
             let mut vals = Vec::with_capacity(return_kinds.len());
             for kind in return_kinds {

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/abort.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/abort.exp
@@ -1,0 +1,26 @@
+=== bytecode ===
+// Bytecode version v10
+module 0x1::test
+// Function definition at index 0
+fun do_abort(l0: u64)
+    move_loc l0
+    abort
+
+=== stackless ===
+// module 0x1::test
+
+fun do_abort(r0) {
+  slots: params(1), locals(0), temps(0)
+    r0: u64
+  code:
+  L0:
+    0: abort r0
+}
+=== micro-ops ===
+// module 0x1::test
+
+fun do_abort() {
+  frame_data_size: 8
+  code:
+    0: Abort [0]
+}

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/abort.move
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/abort.move
@@ -1,0 +1,12 @@
+// RUN: publish --print(bytecode,stackless,micro-ops)
+module 0x1::test {
+    fun do_abort(code: u64) {
+        abort code
+    }
+}
+
+// RUN: execute 0x1::test::do_abort --args 42
+// CHECK: aborted: code 42
+
+// RUN: execute 0x1::test::do_abort --args 0
+// CHECK: aborted: code 0


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

Implement Move's `abort` in the VM. Adds the two abort micro-ops (with and without a message), threads the abort outcome through the interpreter as a separate channel from VM failures, and adds differential tests covering all three abort shapes (code only, message only, code + message).

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new control-flow termination paths (`Abort`/`AbortMsg`) and changes the interpreter `run()` API to return a new `RuntimeStatus`, which can affect callers and execution outcomes. Also introduces message parsing/validation with a size limit, which could surface new runtime errors for invalid inputs.
> 
> **Overview**
> Adds first-class support for Move `abort` in MonoMove by introducing new micro-ops `MicroOp::Abort` and `MicroOp::AbortMsg` (including display formatting, verifier checks, and gas schedule entries) and lowering `Instr::Abort`/`Instr::AbortMsg` to these ops.
> 
> Updates the interpreter to treat aborts as a *successful terminal outcome* separate from runtime failures: `step()` can now return `StepResult::Aborted`, `run()` returns a new `RuntimeStatus` (`Success` vs `Aborted { code, message }`), and the runtime exports this status. `AbortMsg` copies a `vector<u8>` message, enforces `ABORT_MESSAGE_SIZE_LIMIT`, and validates UTF-8, adding new `RuntimeError`s for invalid/oversized messages.
> 
> Extends the differential test runner to print abort outcomes and adds a new differential test case for basic `abort` code emission and execution output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77200128c79e51f3d60a57a1f925ceb3cf99575a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->