### PR TITLE
[mono-vm] Implement gc safe points based on xfer liveness analysis

### DIFF
--- a/third_party/move/mono-move/gas/src/instrument.rs
+++ b/third_party/move/mono-move/gas/src/instrument.rs
@@ -26,6 +26,15 @@
 //! rewritten to account for all inserted charge ops. The [`RemapTargets`]
 //! trait lets each instruction type perform this rewrite without the gas
 //! crate knowing instruction internals.
+//!
+//! ## Op-position remapping
+//!
+//! TODO: this goes away once we move gas instrumentation to the stackless exec
+//! IR level. Distinct from branch-target remapping: a branch target lands on
+//! the inserted `Charge` at the new block start, but consumers like safe-point
+//! tables need the original op's *own* new position (not the Charge before it).
+//! [`GasInstrumentor::run_with_pc_map`] returns the per-original-op new-PC map
+//! for that purpose. The map is monotone increasing.
 
 use crate::{compute_basic_blocks, GasSchedule, HasCfgInfo, InstrCost};
 
@@ -84,8 +93,24 @@ impl<S> GasInstrumentor<S> {
         I: HasCfgInfo + RemapTargets + GasMeteredInstruction,
         S: GasSchedule<I>,
     {
+        self.run_with_pc_map(ops).0
+    }
+
+    /// Like [`Self::run`], but also returns a per-original-op new-PC
+    /// map: `pc_map[i]` is where `ops[i]` lives in the instrumented
+    /// sequence. Use this to remap PC-keyed sidecars (e.g.,
+    /// safe-point tables). Distinct from the branch-target remap,
+    /// which lands on inserted `Charge` ops at block entries rather
+    /// than on the original ops themselves.
+    ///
+    /// Monotone strictly-increasing, so PC-sorted inputs stay sorted.
+    pub fn run_with_pc_map<I>(&self, ops: Vec<I>) -> (Vec<I>, Vec<u32>)
+    where
+        I: HasCfgInfo + RemapTargets + GasMeteredInstruction,
+        S: GasSchedule<I>,
+    {
         if ops.is_empty() {
-            return vec![];
+            return (vec![], vec![]);
         }
 
         let blocks = compute_basic_blocks(&ops);
@@ -114,19 +139,23 @@ impl<S> GasInstrumentor<S> {
         let remap = |t: usize| t + block_starts.partition_point(|&s| s < t) + d_before[t];
 
         let mut result = Vec::with_capacity(ops.len() + blocks.len() + n_dynamic);
+        let mut pc_map: Vec<u32> = Vec::with_capacity(ops.len());
         let mut bi = 0usize;
         for (i, (op, cost)) in ops.into_iter().zip(costs).enumerate() {
             if bi < block_starts.len() && block_starts[bi] == i {
                 result.push(I::charge(block_costs[bi]));
                 bi += 1;
             }
+            // `op`'s own new position, not the `Charge` that `remap(i)`
+            // targets.
+            pc_map.push(result.len() as u32);
             result.push(op.remap_targets(remap));
             if let Some(dynamic) = cost.dynamic {
                 result.push(dynamic);
             }
         }
 
-        result
+        (result, pc_map)
     }
 }
 

--- a/third_party/move/mono-move/gas/src/instrument.rs
+++ b/third_party/move/mono-move/gas/src/instrument.rs
@@ -139,7 +139,7 @@ impl<S> GasInstrumentor<S> {
         let remap = |t: usize| t + block_starts.partition_point(|&s| s < t) + d_before[t];
 
         let mut result = Vec::with_capacity(ops.len() + blocks.len() + n_dynamic);
-        let mut pc_map: Vec<u32> = Vec::with_capacity(ops.len());
+        let mut pc_map = Vec::with_capacity(ops.len());
         let mut bi = 0usize;
         for (i, (op, cost)) in ops.into_iter().zip(costs).enumerate() {
             if bi < block_starts.len() && block_starts[bi] == i {

--- a/third_party/move/mono-move/specializer/src/destack/analysis.rs
+++ b/third_party/move/mono-move/specializer/src/destack/analysis.rs
@@ -76,8 +76,10 @@
 //! upstream `MutBorrowLoc`. (Field-level coalescing, if ever added,
 //! would need to revisit this.)
 
-use super::instr_utils::{for_each_def, for_each_use};
-use crate::stackless_exec_ir::{Instr, Slot};
+use crate::stackless_exec_ir::{
+    instr_utils::{clobbers_xfer, for_each_def, for_each_use},
+    Instr, Slot,
+};
 use shared_dsa::{UnorderedMap, UnorderedSet};
 use smallbitvec::SmallBitVec;
 #[cfg(debug_assertions)]
@@ -487,6 +489,70 @@ fn next_arg_lifetime_overlaps(
     !(a_lu <= b_def || b_lu <= a_def)
 }
 
+/// Check the per-call structural Xfer invariants:
+///
+/// - **Arg positionality** (invariant 2): if `args[j]` resolves to
+///   `Xfer(i)`, then `i == j`.
+/// - **Return Xfer prefix** (invariant 5): the rets list is a
+///   (possibly empty) Xfer-resolved prefix followed by a non-Xfer
+///   suffix.
+/// - **Return monotonicity** (invariant 3): within the Xfer prefix,
+///   resolved Xfer indices strictly increase.
+#[cfg(debug_assertions)]
+fn check_call_structural_invariants<F>(
+    args: &[Slot],
+    rets: &[Slot],
+    xfer_pos: F,
+) -> anyhow::Result<()>
+where
+    F: Fn(&Slot) -> Option<u16>,
+{
+    use anyhow::bail;
+
+    for (j, slot) in args.iter().enumerate() {
+        if let Some(i) = xfer_pos(slot)
+            && i as usize != j
+        {
+            bail!(
+                "arg positionality: args[{}] resolves to Xfer({}), expected Xfer({})",
+                j,
+                i,
+                j,
+            );
+        }
+    }
+
+    let mut seen_non_xfer = false;
+    let mut last_xfer: Option<u16> = None;
+    for (k, slot) in rets.iter().enumerate() {
+        match xfer_pos(slot) {
+            Some(i) => {
+                if seen_non_xfer {
+                    bail!(
+                        "return Xfer prefix: rets[{}] resolves to Xfer({}) after a non-Xfer ret",
+                        k,
+                        i,
+                    );
+                }
+                if let Some(prev) = last_xfer
+                    && i <= prev
+                {
+                    bail!(
+                        "return monotonicity: rets[{}] = Xfer({}) ≤ prev Xfer({})",
+                        k,
+                        i,
+                        prev,
+                    );
+                }
+                last_xfer = Some(i);
+            },
+            None => seen_non_xfer = true,
+        }
+    }
+
+    Ok(())
+}
+
 /// Verifies the seven Xfer invariants from the file header on the
 /// just-built `xfer_precolor` map. Per-call invariants (arg
 /// positionality, return monotonicity, pass-through contiguity, return
@@ -526,44 +592,18 @@ fn assert_xfer_invariants(
             .copied()
             .unwrap_or(instrs.len());
 
-        // Arg positionality: args[j] precolored to Xfer must be Xfer(j).
-        for (j, vid) in args.iter().enumerate() {
-            if let Some(&Slot::Xfer(i)) = xfer_precolor.get(vid) {
-                assert_eq!(
-                    i, j as u16,
-                    "[arg positionality] args[{}] precolored to Xfer({})",
-                    j, i
-                );
+        // Structural invariants (arg positionality, return Xfer prefix, return
+        // monotonicity).
+        check_call_structural_invariants(args, rets, |slot| {
+            if !slot.is_vid() {
+                return None;
             }
-        }
-
-        // Return Xfer prefix: rets are an Xfer prefix followed by a Home
-        // suffix. Return monotonicity: within the prefix, Xfer indices
-        // strictly increase with k.
-        let mut seen_home = false;
-        let mut last_xfer: Option<u16> = None;
-        for (k, vid) in rets.iter().enumerate() {
-            match xfer_precolor.get(vid) {
-                Some(&Slot::Xfer(i)) if vid.is_vid() => {
-                    assert!(
-                        !seen_home,
-                        "[return Xfer prefix] rets[{}] precolored to Xfer follows a Home ret",
-                        k
-                    );
-                    if let Some(prev) = last_xfer {
-                        assert!(
-                            i > prev,
-                            "[return monotonicity] rets[{}] = Xfer({}) ≤ prev Xfer({})",
-                            k,
-                            i,
-                            prev
-                        );
-                    }
-                    last_xfer = Some(i);
-                },
-                _ => seen_home = true,
+            match xfer_precolor.get(slot) {
+                Some(&Slot::Xfer(i)) => Some(i),
+                _ => None,
             }
-        }
+        })
+        .unwrap_or_else(|e| panic!("[xfer structural invariant] {e}"));
 
         // Pass-through contiguity: among args of `call_pos` defined at the
         // immediately-preceding call and bound to Xfer, the positions form
@@ -704,16 +744,6 @@ fn assert_xfer_invariants(
     }
 }
 
-/// Call-like instructions (`Call`, `CallGeneric`, `CallClosure`) that
-/// clobber Xfer slots and act as call boundaries for liveness analysis.
-#[inline]
-fn clobbers_xfer(instr: &Instr) -> bool {
-    matches!(
-        instr,
-        Instr::Call(..) | Instr::CallGeneric(..) | Instr::CallClosure(..)
-    )
-}
-
 /// Returns `(rets, args)` for `Call` / `CallGeneric`. `CallClosure` is
 /// intentionally excluded: Xfer precoloring leaves closure calls alone
 /// (they still count as call boundaries via `clobbers_xfer`, just not
@@ -735,6 +765,145 @@ fn has_any_in_range(sorted: &[usize], lo: usize, hi: usize) -> bool {
     // Find the first element >= lo.
     let idx = sorted.partition_point(|&x| x < lo);
     idx < sorted.len() && sorted[idx] < hi
+}
+
+/// Verify that the post-optimize, slot-allocated IR satisfies the
+/// Xfer-slot invariants the lowering depends on.
+///
+/// The seven invariants at the top of this file are established by
+/// `BlockAnalysis::analyze` on pre-allocation Vid IR but are not
+/// re-checked through `optimize_module`. This walk re-checks the
+/// subset that survives slot allocation:
+///
+/// 1. Every use of `Xfer(j)` is preceded by a def in the same block.
+/// 2. At a call boundary, every bound Xfer slot is consumed by the
+///    call's args (orphans signal an upstream regression).
+/// 3. Calls clobber every Xfer slot; ret defs re-bind on the same
+///    instruction.
+/// 4. No Xfer binding leaks across a block boundary.
+/// 5. Per-call structural invariants — arg positionality, return
+///    Xfer prefix, return monotonicity — via
+///    `check_call_structural_invariants`, the same helper
+///    `assert_xfer_invariants` uses on the Vid-level maps.
+///
+/// Pass-through contiguity (invariant 4 in the header) is not
+/// checked here: it requires distinguishing bound positions that
+/// came from the previous call's rets from positions defined by
+/// intermediate non-call instrs, which this walk doesn't track.
+#[cfg(debug_assertions)]
+pub(crate) fn assert_xfer_invariants_on_final_ir(
+    func: &crate::stackless_exec_ir::FunctionIR,
+) -> anyhow::Result<()> {
+    use anyhow::bail;
+
+    let num_xfer = func.num_xfer_positions as usize;
+    let mut bound: Vec<bool> = vec![false; num_xfer];
+    for (b_idx, block) in func.blocks.iter().enumerate() {
+        // Block-local lifetime: a fresh state at every block.
+        bound.iter_mut().for_each(|b| *b = false);
+        for (i, instr) in block.instrs.iter().enumerate() {
+            // (1) every Xfer use must be live.
+            let mut unbound: Option<u16> = None;
+            for_each_use(instr, |s| {
+                if let Slot::Xfer(j) = s
+                    && !bound[j as usize]
+                    && unbound.is_none()
+                {
+                    unbound = Some(j);
+                }
+            });
+            if let Some(j) = unbound {
+                bail!(
+                    "post-optimize Xfer verifier: block {}, instr {}: use of Xfer({}) \
+                     with no live def earlier in this block — copy_propagation may have \
+                     rewritten a Home use to an Xfer use across a clobbering call",
+                    b_idx,
+                    i,
+                    j,
+                );
+            }
+
+            // (2) at a call boundary, every bound Xfer slot must
+            // be consumed by this call's args as args[j] = Xfer(j)
+            // (arg positionality).
+            if clobbers_xfer(instr) {
+                let (rets, args): (&[Slot], &[Slot]) = match instr {
+                    Instr::Call(rets, _, args)
+                    | Instr::CallGeneric(rets, _, args)
+                    | Instr::CallClosure(rets, _, args) => (rets, args),
+                    _ => unreachable!("clobbers_xfer matches only Call variants"),
+                };
+                // Structural invariants (arg positionality, return Xfer prefix,
+                // return monotonicity).
+                check_call_structural_invariants(args, rets, |s| match s {
+                    Slot::Xfer(i) => Some(*i),
+                    _ => None,
+                })
+                .map_err(|e| {
+                    anyhow::anyhow!(
+                        "post-optimize Xfer verifier: block {}, instr {}: {}",
+                        b_idx,
+                        i,
+                        e,
+                    )
+                })?;
+                // Orphan check: every bound slot must be consumed
+                // by this call's args. A bound position not in args
+                // signals a dead Xfer def from earlier in the block.
+                for (j, &b) in bound.iter().enumerate() {
+                    if b {
+                        let consumed_here = j < args.len() && args[j] == Slot::Xfer(j as u16);
+                        if !consumed_here {
+                            bail!(
+                                "post-optimize Xfer verifier: block {}, instr {}: \
+                                 Xfer({}) bound at call boundary but not consumed \
+                                 as args[{}] of this call — a dead Xfer def \
+                                 leaked from earlier in the block (likely an \
+                                 upstream destack precoloring regression)",
+                                b_idx,
+                                i,
+                                j,
+                                j,
+                            );
+                        }
+                    }
+                }
+                // Clobber: a call reuses the entire callee region;
+                // the ret defs below re-bind whatever positions
+                // this call returns to.
+                bound.iter_mut().for_each(|b| *b = false);
+            } else {
+                // Non-call: consumed uses release their bindings
+                // (single-use). Matches the lowering's end-of-instr
+                // clear.
+                for_each_use(instr, |s| {
+                    if let Slot::Xfer(j) = s {
+                        bound[j as usize] = false;
+                    }
+                });
+            }
+            // Defs bind: ret-Xfers for calls, Move/Copy dst (etc.)
+            // for non-calls.
+            for_each_def(instr, |s| {
+                if let Slot::Xfer(j) = s {
+                    bound[j as usize] = true;
+                }
+            });
+        }
+
+        // (3) no Xfer binding may survive past the end of a block.
+        for (j, &b) in bound.iter().enumerate() {
+            if b {
+                bail!(
+                    "post-optimize Xfer verifier: block {}: Xfer({}) bound at block end \
+                     (Xfer lifetimes must be block-local)",
+                    b_idx,
+                    j,
+                );
+            }
+        }
+    }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/third_party/move/mono-move/specializer/src/destack/mod.rs
+++ b/third_party/move/mono-move/specializer/src/destack/mod.rs
@@ -4,7 +4,6 @@
 //! Destack pipeline: converts Move bytecode into stackless execution IR.
 
 mod analysis;
-mod instr_utils;
 pub mod optimize;
 mod slot_alloc;
 mod ssa_conversion;
@@ -25,5 +24,10 @@ pub fn destack(module: CompiledModule, interner: &impl Interner) -> Result<Modul
     let module = PreparedModule::build(module, interner)?;
     let mut module_ir = translate::translate_module(module, interner)?;
     optimize::optimize_module(&mut module_ir);
+    // Debug-mode failsafe: verify xfer invariants hold after optimization.
+    #[cfg(debug_assertions)]
+    for func in module_ir.functions.iter().flatten() {
+        analysis::assert_xfer_invariants_on_final_ir(func)?;
+    }
     Ok(module_ir)
 }

--- a/third_party/move/mono-move/specializer/src/destack/optimize.rs
+++ b/third_party/move/mono-move/specializer/src/destack/optimize.rs
@@ -8,10 +8,12 @@
 //! Pass: Dead instruction elimination
 //! Pass: Slot renumbering
 
-use super::instr_utils::{
-    for_each_def, for_each_slot, for_each_use, remap_all_slots_with, remap_source_slots_with,
+use crate::stackless_exec_ir::{
+    instr_utils::{
+        for_each_def, for_each_slot, for_each_use, remap_all_slots_with, remap_source_slots_with,
+    },
+    FunctionIR, Instr, ModuleIR, Slot,
 };
-use crate::stackless_exec_ir::{FunctionIR, Instr, ModuleIR, Slot};
 use shared_dsa::{UnorderedMap, UnorderedSet};
 
 /// Optimize all functions in a module IR.
@@ -86,7 +88,11 @@ fn copy_propagation(func: &mut FunctionIR) {
 
             match instr {
                 Instr::Copy(dst, src) | Instr::Move(dst, src) => {
-                    subst.insert(*dst, *src);
+                    // Xfer slot values don't survive a call boundary,
+                    // so don't copy propagate from them.
+                    if !matches!(src, Slot::Xfer(_)) {
+                        subst.insert(*dst, *src);
+                    }
                 },
                 _ => {},
             }

--- a/third_party/move/mono-move/specializer/src/destack/slot_alloc.rs
+++ b/third_party/move/mono-move/specializer/src/destack/slot_alloc.rs
@@ -6,12 +6,11 @@
 //! Consumes `BlockAnalysis` from `analysis` and maps SSA temp `Vid`s to
 //! real `Home`/`Xfer` slots using liveness-driven type-keyed reuse.
 
-use super::{
-    analysis::BlockAnalysis,
+use super::{analysis::BlockAnalysis, ssa_function::SSAFunction};
+use crate::stackless_exec_ir::{
     instr_utils::{collect_defs_and_uses, remap_all_slots_with},
-    ssa_function::SSAFunction,
+    BasicBlock, Instr, Slot,
 };
-use crate::stackless_exec_ir::{BasicBlock, Instr, Slot};
 use anyhow::{bail, Context, Result};
 use mono_move_core::types::InternedType;
 use shared_dsa::UnorderedMap;

--- a/third_party/move/mono-move/specializer/src/destack/ssa_function.rs
+++ b/third_party/move/mono-move/specializer/src/destack/ssa_function.rs
@@ -8,8 +8,10 @@
 //! block boundaries, no phi nodes are needed — each value ID is defined exactly
 //! once within its block and never crosses a block boundary.
 
-use super::instr_utils::{extract_imm_value, is_commutative};
-use crate::stackless_exec_ir::{BasicBlock, BinaryOp, Instr};
+use crate::stackless_exec_ir::{
+    instr_utils::{extract_imm_value, is_commutative},
+    BasicBlock, BinaryOp, Instr,
+};
 use mono_move_core::types::InternedType;
 
 /// Intermediate SSA representation of a single function, before slot allocation.

--- a/third_party/move/mono-move/specializer/src/lower/context.rs
+++ b/third_party/move/mono-move/specializer/src/lower/context.rs
@@ -21,8 +21,8 @@ use mono_move_core::{
         view_type, view_type_list, Alignment, FieldLayout, InternedType, InternedTypeList, Size,
         Type, EMPTY_TYPE_LIST,
     },
-    Code, DescriptorId, FieldTypes, FrameLayoutInfo, FrameOffset, Function, Interner,
-    MicroOpGasSchedule, SortedSafePointEntries, FRAME_METADATA_SIZE,
+    Code, CodeOffset, DescriptorId, FieldTypes, FrameLayoutInfo, FrameOffset, Function, Interner,
+    MicroOpGasSchedule, SafePointEntry, SortedSafePointEntries, FRAME_METADATA_SIZE,
 };
 use mono_move_gas::GasInstrumentor;
 use move_binary_format::access::ModuleAccess;
@@ -456,15 +456,22 @@ pub fn try_lower_function(
     };
 
     let name = module_ir.module.interned_identifier_at(func_ir.name_idx);
-    let code = lower_function(func_ir, &ctx)?;
-    let code = GasInstrumentor::new(MicroOpGasSchedule).run(code);
-
-    // TODO: derive per-PC `safe_point_layouts` so that allocating
-    // ops (`MicroOp::is_allocating`) can keep callee-region pointers
-    // alive across the GC they may trigger. Until this lands,
-    // executing such an op while callee-region pointer slots are live
-    // will silently miss those pointers — GC may collect or move
-    // objects that the frame still references.
+    let (code, raw_safe_points) = lower_function(func_ir, &ctx)?;
+    // TODO: this remapping of safe-point PCs to the allocating op's own new position
+    // will go away once we move gas instrumentation to the stackless exec IR level.
+    let (code, pc_map) = GasInstrumentor::new(MicroOpGasSchedule).run_with_pc_map(code);
+    let mut safe_points: Vec<SafePointEntry> = raw_safe_points
+        .into_iter()
+        .map(|entry| SafePointEntry {
+            code_offset: CodeOffset(pc_map[entry.code_offset.0 as usize]),
+            layout: entry.layout,
+        })
+        .collect();
+    // TODO: drop this sort if we can guarantee the input is already
+    // sorted. `pc_map` is monotone and `emit` pushes in code-offset
+    // order, so it's structurally a no-op today — kept as a safety
+    // net for now.
+    safe_points.sort_by_key(|e| e.code_offset.0);
 
     let param_sizes = ctx.home_slots[..func_ir.num_params as usize]
         .iter()
@@ -483,9 +490,6 @@ pub fn try_lower_function(
     // Derive `frame_layout` and `zero_frame` from home-slot types.
     // Substitute `ty_args` so generic instantiations see concrete
     // types — `gc_layout` rejects raw `TypeParam`s.
-    //
-    // TODO: derive callee-region safe-point entries and feed them
-    // into `Function::safe_point_layouts`. Today they stay empty.
     let home_list = interner.type_list_of(&func_ir.home_slot_types);
     let home_list = interner.subst_type_list(home_list, ty_args)?;
     let derived = derive_frame_layout(&ctx, func_ir, view_type_list(home_list))?;
@@ -499,7 +503,7 @@ pub fn try_lower_function(
         extended_frame_size,
         zero_frame: derived.zero_frame,
         frame_layout: FrameLayoutInfo::new(derived.heap_ptr_offsets),
-        safe_point_layouts: SortedSafePointEntries::empty(),
+        safe_point_layouts: SortedSafePointEntries::new(safe_points),
     }))
 }
 

--- a/third_party/move/mono-move/specializer/src/lower/context.rs
+++ b/third_party/move/mono-move/specializer/src/lower/context.rs
@@ -460,13 +460,13 @@ pub fn try_lower_function(
     // TODO: this remapping of safe-point PCs to the allocating op's own new position
     // will go away once we move gas instrumentation to the stackless exec IR level.
     let (code, pc_map) = GasInstrumentor::new(MicroOpGasSchedule).run_with_pc_map(code);
-    let mut safe_points: Vec<SafePointEntry> = raw_safe_points
+    let mut safe_points = raw_safe_points
         .into_iter()
         .map(|entry| SafePointEntry {
             code_offset: CodeOffset(pc_map[entry.code_offset.0 as usize]),
             layout: entry.layout,
         })
-        .collect();
+        .collect::<Vec<_>>();
     // TODO: drop this sort if we can guarantee the input is already
     // sorted. `pc_map` is monotone and `emit` pushes in code-offset
     // order, so it's structurally a no-op today — kept as a safety

--- a/third_party/move/mono-move/specializer/src/lower/display.rs
+++ b/third_party/move/mono-move/specializer/src/lower/display.rs
@@ -7,6 +7,10 @@ use super::context::LoweringContext;
 use mono_move_core::{MicroOp, SafePointEntry};
 use std::fmt;
 
+// TODO: replace this test-only display struct with a `Display` impl on
+// `mono_move_core::Function`, and have the snapshot pipeline build a
+// `Function` (via `try_lower_function`) instead of calling the
+// lower-level `lower_function` and piecing fields together here.
 pub struct MicroOpsFunctionDisplay<'a> {
     pub func_name: &'a str,
     pub ctx: &'a LoweringContext,

--- a/third_party/move/mono-move/specializer/src/lower/display.rs
+++ b/third_party/move/mono-move/specializer/src/lower/display.rs
@@ -4,13 +4,16 @@
 //! Display for lowered micro-ops in test baselines.
 
 use super::context::LoweringContext;
-use mono_move_core::MicroOp;
+use mono_move_core::{MicroOp, SafePointEntry};
 use std::fmt;
 
 pub struct MicroOpsFunctionDisplay<'a> {
     pub func_name: &'a str,
     pub ctx: &'a LoweringContext,
     pub ops: &'a [MicroOp],
+    /// Safe-point entries; each `code_offset` indexes into `ops`.
+    /// An empty slice omits the `safe_point_layouts:` section.
+    pub safe_points: &'a [SafePointEntry],
 }
 
 impl fmt::Display for MicroOpsFunctionDisplay<'_> {
@@ -21,6 +24,18 @@ impl fmt::Display for MicroOpsFunctionDisplay<'_> {
         for (i, op) in self.ops.iter().enumerate() {
             write!(f, "    {}: {}", i, op)?;
             writeln!(f)?;
+        }
+        if !self.safe_points.is_empty() {
+            writeln!(f, "  safe_point_layouts:")?;
+            for entry in self.safe_points {
+                let offsets: Vec<String> = entry
+                    .layout
+                    .heap_ptr_offsets
+                    .iter()
+                    .map(|o| o.0.to_string())
+                    .collect();
+                writeln!(f, "    {}: [{}]", entry.code_offset.0, offsets.join(", "))?;
+            }
         }
         writeln!(f, "}}")
     }

--- a/third_party/move/mono-move/specializer/src/lower/translate.rs
+++ b/third_party/move/mono-move/specializer/src/lower/translate.rs
@@ -46,6 +46,7 @@ pub fn lower_function(
         state.label_map[block.label.0 as usize] = Some(state.out_buf.len() as u32);
         for instr in &block.instrs {
             state.lower_instr(func_ir, instr)?;
+            state.commit_xfer_bindings_after(instr);
         }
     }
     state.fixup_branches()?;
@@ -144,8 +145,7 @@ impl<'a> LoweringState<'a> {
     fn emit(&mut self, op: MicroOp) -> Result<()> {
         if op.is_allocating() {
             let code_offset = CodeOffset(self.out_buf.len() as u32);
-            let mut heap_ptr_offsets: Vec<FrameOffset> =
-                Vec::with_capacity(self.xfer_bindings.len());
+            let mut heap_ptr_offsets = Vec::with_capacity(self.xfer_bindings.len());
             for ts in self.xfer_bindings.iter().flatten() {
                 let rels = type_pointer_offsets(ts.ty).with_context(|| {
                     format!(
@@ -827,6 +827,11 @@ impl<'a> LoweringState<'a> {
             _ => bail!("instruction {} not yet lowered", instr.opcode_name()),
         }
 
+        Ok(())
+    }
+
+    /// Advance the Xfer state machine after `instr` has been lowered.
+    fn commit_xfer_bindings_after(&mut self, instr: &Instr) {
         // Calls manage their own Xfer state in `lower_call`.
         if !clobbers_xfer(instr) {
             // Release Xfer bindings consumed by this instr's uses.
@@ -846,8 +851,6 @@ impl<'a> LoweringState<'a> {
                 "calls must not leave a pending Xfer def bind",
             );
         }
-
-        Ok(())
     }
 
     /// Lower one call. Args are written by reverse iteration over the

--- a/third_party/move/mono-move/specializer/src/lower/translate.rs
+++ b/third_party/move/mono-move/specializer/src/lower/translate.rs
@@ -752,7 +752,7 @@ impl<'a> LoweringState<'a> {
             // --- Abort ---
             Instr::Abort(code) => {
                 let code = self.slot(*code)?;
-                self.emit(MicroOp::Abort { code: code.offset });
+                self.emit(MicroOp::Abort { code: code.offset })?;
             },
             Instr::AbortMsg(code, message) => {
                 let code = self.slot(*code)?;
@@ -760,7 +760,7 @@ impl<'a> LoweringState<'a> {
                 self.emit(MicroOp::AbortMsg {
                     code: code.offset,
                     message: message.offset,
-                });
+                })?;
             },
 
             // --- Vector ---

--- a/third_party/move/mono-move/specializer/src/lower/translate.rs
+++ b/third_party/move/mono-move/specializer/src/lower/translate.rs
@@ -5,26 +5,43 @@
 
 use super::{
     context::{concrete_type_size, LoweringContext, SlotInfo, TypedSlot},
+    gc_layout::type_pointer_offsets,
     parallel_copy,
 };
 use crate::stackless_exec_ir::{
+    instr_utils::{clobbers_xfer, for_each_use},
     BinaryOp, CmpOp, FunctionIR, ImmValue, Instr, Label, Slot, UnaryOp,
 };
 use anyhow::{bail, Context, Result};
 use mono_move_core::{
     types::{strip_ref, view_type, InternedType, Type},
-    CodeOffset, FrameOffset, IntBinaryOp, IntNegateOp, IntOperand, IntShiftOp, IntTy, MicroOp,
-    ShiftOperand,
+    CodeOffset, FrameLayoutInfo, FrameOffset, IntBinaryOp, IntNegateOp, IntOperand, IntShiftOp,
+    IntTy, MicroOp, SafePointEntry, ShiftOperand,
 };
 
-pub fn lower_function(func_ir: &FunctionIR, ctx: &LoweringContext) -> Result<Vec<MicroOp>> {
+/// Lower a slot-allocated function to its micro-op form.
+///
+/// Returns `(ops, safe_points)`:
+/// - `ops` — pre-instrumentation micro-ops in emission order.
+/// - `safe_points` — one entry **per allocating micro-op only**,
+///   in code-offset order. Non-allocating PCs are not represented;
+///   the vector is sparse. Each entry's `code_offset` indexes
+///   directly into `ops`.
+pub fn lower_function(
+    func_ir: &FunctionIR,
+    ctx: &LoweringContext,
+) -> Result<(Vec<MicroOp>, Vec<SafePointEntry>)> {
     let mut state = LoweringState::new(func_ir, ctx);
     for block in &func_ir.blocks {
-        // Reset Xfer bindings: Vids are block-local in the post-allocation
-        // IR, so a binding from a previous block can never be a legitimate
-        // read in this one. Wiping makes any accidental cross-block read
-        // surface as an error from `slot()` (via `xfer_binding`) instead
-        // of silently using a stale binding.
+        // Xfer slots are block-local.
+        debug_assert!(
+            state.xfer_bindings.iter().all(Option::is_none),
+            "xfer_bindings not fully cleared at block boundary",
+        );
+        debug_assert!(
+            state.pending_def_bind.is_none(),
+            "pending_def_bind not committed at block boundary",
+        );
         state.xfer_bindings.fill(None);
         state.label_map[block.label.0 as usize] = Some(state.out_buf.len() as u32);
         for instr in &block.instrs {
@@ -32,7 +49,7 @@ pub fn lower_function(func_ir: &FunctionIR, ctx: &LoweringContext) -> Result<Vec
         }
     }
     state.fixup_branches()?;
-    Ok(state.out_buf)
+    Ok((state.out_buf, state.pending_safe_points))
 }
 
 struct LoweringState<'a> {
@@ -57,14 +74,17 @@ struct LoweringState<'a> {
     /// Types of the function IR's home (frame-resident) slots, indexed
     /// by Home slot id.
     home_slot_types: &'a [InternedType],
-    /// Where `Slot::Xfer(j)` currently lives in the caller's frame
-    /// (an arg slot before a call; a ret slot after). `None` means no
-    /// value lives at `j` right now. Length is fixed at
-    /// `ctx.num_xfer_positions`. Each `j` is rebound many times within
-    /// a block as successive calls reuse it; every binding is wiped to
-    /// `None` at block boundaries by `lower_function`, so stale
-    /// cross-block reads error out via `xfer_binding`.
+    /// `Some(TypedSlot)` while `Slot::Xfer(j)` holds a fully-written
+    /// live value visible to the GC; `None` otherwise. Length
+    /// `ctx.num_xfer_positions`.
     xfer_bindings: Vec<Option<TypedSlot>>,
+    /// Holds at most one pending Xfer binding. `Some((j, ts))`
+    /// means `Xfer(j)` is to be bound to typed slot `ts`; `None`
+    /// means no binding is pending.
+    pending_def_bind: Option<(u16, TypedSlot)>,
+    /// Safe-point entries in code-offset order. Populated by `emit`
+    /// when `op.is_allocating()`.
+    pending_safe_points: Vec<SafePointEntry>,
 }
 
 impl<'a> LoweringState<'a> {
@@ -78,6 +98,8 @@ impl<'a> LoweringState<'a> {
             call_site_cursor: 0,
             home_slot_types: &func_ir.home_slot_types,
             xfer_bindings: vec![None; num_xfer_positions],
+            pending_def_bind: None,
+            pending_safe_points: Vec::new(),
         }
     }
 
@@ -94,23 +116,56 @@ impl<'a> LoweringState<'a> {
         })
     }
 
-    /// Resolve slot info for a destination slot. For Xfer slots, binds
-    /// the position to the upcoming call's `arg_slots[j]`.
+    /// Returns layout info for a destination slot. For
+    /// `Slot::Xfer(j)`, stages a pending binding from `Xfer(j)` to
+    /// the typed slot at arg position `j` of the upcoming call.
+    /// Errors if a binding is already staged or for `Slot::Vid`.
     fn def_slot(&mut self, slot: Slot) -> Result<SlotInfo> {
         Ok(match slot {
             Slot::Home(i) => self.ctx.home_slots[i as usize],
             Slot::Xfer(j) => {
-                let cs = &self.ctx.call_sites[self.call_site_cursor];
-                let ts = cs.arg_slots[j as usize];
-                self.xfer_bindings[j as usize] = Some(ts);
-                ts.slot
+                let call_site = &self.ctx.call_sites[self.call_site_cursor];
+                let typed_slot = call_site.arg_slots[j as usize];
+                debug_assert!(
+                    self.pending_def_bind.is_none(),
+                    "second Xfer def_slot in one IR instr",
+                );
+                self.pending_def_bind = Some((j, typed_slot));
+                typed_slot.slot
             },
             Slot::Vid(i) => bail!("Vid({}) in post-allocation IR", i),
         })
     }
 
-    fn emit(&mut self, op: MicroOp) {
+    /// Append `op` to the output buffer. For allocating `op`s,
+    /// also emit a paired `SafePointEntry` whose `code_offset` is
+    /// `op`'s index in the buffer and whose `heap_ptr_offsets`
+    /// are derived from the current `xfer_bindings`.
+    fn emit(&mut self, op: MicroOp) -> Result<()> {
+        if op.is_allocating() {
+            let code_offset = CodeOffset(self.out_buf.len() as u32);
+            let mut heap_ptr_offsets: Vec<FrameOffset> =
+                Vec::with_capacity(self.xfer_bindings.len());
+            for ts in self.xfer_bindings.iter().flatten() {
+                let rels = type_pointer_offsets(ts.ty).with_context(|| {
+                    format!(
+                        "deriving safe-point heap pointer offsets at code_offset {}",
+                        code_offset.0
+                    )
+                })?;
+                heap_ptr_offsets
+                    .extend(rels.into_iter().map(|r| FrameOffset(ts.slot.offset.0 + r)));
+            }
+            // TODO: revisit the need to sort and dedup.
+            heap_ptr_offsets.sort_by_key(|o| o.0);
+            heap_ptr_offsets.dedup();
+            self.pending_safe_points.push(SafePointEntry {
+                code_offset,
+                layout: FrameLayoutInfo::new(heap_ptr_offsets),
+            });
+        }
         self.out_buf.push(op);
+        Ok(())
     }
 
     /// Interned-type corresponding to `slot`.
@@ -124,7 +179,7 @@ impl<'a> LoweringState<'a> {
 
     /// Canonical [`Type`] variant of `slot`. Use [`Self::slot_interned_type`]
     /// when an interned pointer is needed instead.
-    fn slot_type(&self, slot: Slot) -> Result<&Type> {
+    fn slot_type(&self, slot: Slot) -> Result<&'static Type> {
         Ok(view_type(self.slot_interned_type(slot)?))
     }
 
@@ -147,22 +202,23 @@ impl<'a> LoweringState<'a> {
     /// Emit one byte-copy from `src` to `dst_offset`. Caller is
     /// responsible for ensuring no other concurrent move clobbers the
     /// source bytes.
-    fn emit_single_move(&mut self, dst_offset: FrameOffset, src: SlotInfo) {
+    fn emit_single_move(&mut self, dst_offset: FrameOffset, src: SlotInfo) -> Result<()> {
         if dst_offset == src.offset {
-            return;
+            return Ok(());
         }
         if src.size == 8 {
             self.emit(MicroOp::Move8 {
                 dst: dst_offset,
                 src: src.offset,
-            });
+            })?;
         } else {
             self.emit(MicroOp::Move {
                 dst: dst_offset,
                 src: src.offset,
                 size: src.size,
-            });
+            })?;
         }
+        Ok(())
     }
 
     /// Lower one IR instruction.
@@ -174,77 +230,77 @@ impl<'a> LoweringState<'a> {
                 self.emit(MicroOp::StoreImm8 {
                     dst: dst_info.offset,
                     imm: *v,
-                });
+                })?;
             },
             Instr::LdTrue(dst) => {
                 let dst_info = self.def_slot(*dst)?;
                 self.emit(MicroOp::StoreImm8 {
                     dst: dst_info.offset,
                     imm: 1,
-                });
+                })?;
             },
             Instr::LdFalse(dst) => {
                 let dst_info = self.def_slot(*dst)?;
                 self.emit(MicroOp::StoreImm8 {
                     dst: dst_info.offset,
                     imm: 0,
-                });
+                })?;
             },
             Instr::LdU8(dst, v) => {
                 let dst_info = self.def_slot(*dst)?;
                 self.emit(MicroOp::StoreImm8 {
                     dst: dst_info.offset,
                     imm: *v as u64,
-                });
+                })?;
             },
             Instr::LdU16(dst, v) => {
                 let dst_info = self.def_slot(*dst)?;
                 self.emit(MicroOp::StoreImm8 {
                     dst: dst_info.offset,
                     imm: *v as u64,
-                });
+                })?;
             },
             Instr::LdU32(dst, v) => {
                 let dst_info = self.def_slot(*dst)?;
                 self.emit(MicroOp::StoreImm8 {
                     dst: dst_info.offset,
                     imm: *v as u64,
-                });
+                })?;
             },
             Instr::LdI8(dst, v) => {
                 let dst_info = self.def_slot(*dst)?;
                 self.emit(MicroOp::StoreImm8 {
                     dst: dst_info.offset,
                     imm: *v as u64,
-                });
+                })?;
             },
             Instr::LdI16(dst, v) => {
                 let dst_info = self.def_slot(*dst)?;
                 self.emit(MicroOp::StoreImm8 {
                     dst: dst_info.offset,
                     imm: *v as u64,
-                });
+                })?;
             },
             Instr::LdI32(dst, v) => {
                 let dst_info = self.def_slot(*dst)?;
                 self.emit(MicroOp::StoreImm8 {
                     dst: dst_info.offset,
                     imm: *v as u64,
-                });
+                })?;
             },
             Instr::LdI64(dst, v) => {
                 let dst_info = self.def_slot(*dst)?;
                 self.emit(MicroOp::StoreImm8 {
                     dst: dst_info.offset,
                     imm: *v as u64,
-                });
+                })?;
             },
 
             // --- Copy/Move ---
             Instr::Copy(dst, src) | Instr::Move(dst, src) => {
                 let src_info = self.slot(*src)?;
                 let dst_info = self.def_slot(*dst)?;
-                self.emit_single_move(dst_info.offset, src_info);
+                self.emit_single_move(dst_info.offset, src_info)?;
             },
 
             // --- Binary ops ---
@@ -263,6 +319,7 @@ impl<'a> LoweringState<'a> {
                 // Fast path: emit a specialized u64 variant when one exists.
                 // u64 `Cmp(_)` / `Or` / `And` have no specialized variant
                 // and fall through to the unspecialized path.
+                let mut handled = false;
                 if lhs_ty.is_u64() {
                     let emitted = match op {
                         BinaryOp::Add => Some(MicroOp::AddU64 { dst, lhs, rhs }),
@@ -278,81 +335,83 @@ impl<'a> LoweringState<'a> {
                         BinaryOp::Cmp(_) | BinaryOp::Or | BinaryOp::And => None,
                     };
                     if let Some(micro) = emitted {
-                        self.emit(micro);
-                        return Ok(());
+                        self.emit(micro)?;
+                        handled = true;
                     }
                 }
 
-                match op {
-                    BinaryOp::Add
-                    | BinaryOp::Sub
-                    | BinaryOp::Mul
-                    | BinaryOp::Div
-                    | BinaryOp::Mod
-                    | BinaryOp::BitAnd
-                    | BinaryOp::BitOr
-                    | BinaryOp::BitXor => {
-                        let rhs = int_operand_from_slot(lhs_ty, rhs)?;
-                        if matches!(op, BinaryOp::BitAnd | BinaryOp::BitOr | BinaryOp::BitXor)
-                            && rhs.is_signed()
-                        {
-                            bail!("BinaryOp {:?}: bitwise on a signed value is invalid", op);
-                        }
-                        let binop = IntBinaryOp { dst, lhs, rhs };
-                        self.emit(match op {
-                            BinaryOp::Add => MicroOp::IntAdd(binop),
-                            BinaryOp::Sub => MicroOp::IntSub(binop),
-                            BinaryOp::Mul => MicroOp::IntMul(binop),
-                            BinaryOp::Div => MicroOp::IntDiv(binop),
-                            BinaryOp::Mod => MicroOp::IntMod(binop),
-                            BinaryOp::BitAnd => MicroOp::IntBitAnd(binop),
-                            BinaryOp::BitOr => MicroOp::IntBitOr(binop),
-                            BinaryOp::BitXor => MicroOp::IntBitXor(binop),
-                            BinaryOp::Shl
-                            | BinaryOp::Shr
-                            | BinaryOp::Cmp(_)
-                            | BinaryOp::Or
-                            | BinaryOp::And => {
-                                bail!("internal: unexpected op in arith/bitwise arm")
-                            },
-                        });
-                    },
-                    BinaryOp::Shl | BinaryOp::Shr => {
-                        let ty = IntTy::from_type(lhs_ty)
-                            .filter(|t| !t.is_signed())
-                            .ok_or_else(|| {
-                                anyhow::anyhow!(
-                                    "BinaryOp {:?}: requires an unsigned non-u64 integer type",
-                                    op
-                                )
+                if !handled {
+                    match op {
+                        BinaryOp::Add
+                        | BinaryOp::Sub
+                        | BinaryOp::Mul
+                        | BinaryOp::Div
+                        | BinaryOp::Mod
+                        | BinaryOp::BitAnd
+                        | BinaryOp::BitOr
+                        | BinaryOp::BitXor => {
+                            let rhs = int_operand_from_slot(lhs_ty, rhs)?;
+                            if matches!(op, BinaryOp::BitAnd | BinaryOp::BitOr | BinaryOp::BitXor)
+                                && rhs.is_signed()
+                            {
+                                bail!("BinaryOp {:?}: bitwise on a signed value is invalid", op);
+                            }
+                            let binop = IntBinaryOp { dst, lhs, rhs };
+                            self.emit(match op {
+                                BinaryOp::Add => MicroOp::IntAdd(binop),
+                                BinaryOp::Sub => MicroOp::IntSub(binop),
+                                BinaryOp::Mul => MicroOp::IntMul(binop),
+                                BinaryOp::Div => MicroOp::IntDiv(binop),
+                                BinaryOp::Mod => MicroOp::IntMod(binop),
+                                BinaryOp::BitAnd => MicroOp::IntBitAnd(binop),
+                                BinaryOp::BitOr => MicroOp::IntBitOr(binop),
+                                BinaryOp::BitXor => MicroOp::IntBitXor(binop),
+                                BinaryOp::Shl
+                                | BinaryOp::Shr
+                                | BinaryOp::Cmp(_)
+                                | BinaryOp::Or
+                                | BinaryOp::And => {
+                                    bail!("internal: unexpected op in arith/bitwise arm")
+                                },
                             })?;
-                        let shift_op = IntShiftOp {
-                            ty,
-                            dst,
-                            lhs,
-                            rhs: ShiftOperand::SlotU8(rhs),
-                        };
-                        self.emit(match op {
-                            BinaryOp::Shl => MicroOp::IntShl(shift_op),
-                            BinaryOp::Shr => MicroOp::IntShr(shift_op),
-                            BinaryOp::Add
-                            | BinaryOp::Sub
-                            | BinaryOp::Mul
-                            | BinaryOp::Div
-                            | BinaryOp::Mod
-                            | BinaryOp::BitAnd
-                            | BinaryOp::BitOr
-                            | BinaryOp::BitXor
-                            | BinaryOp::Cmp(_)
-                            | BinaryOp::Or
-                            | BinaryOp::And => bail!("internal: unexpected op in shift arm"),
-                        });
-                    },
-                    // Comparison-to-register and logical and/or are not
-                    // yet lowered for any integer width.
-                    BinaryOp::Cmp(_) | BinaryOp::Or | BinaryOp::And => {
-                        bail!("BinaryOp {:?} not yet lowered", op)
-                    },
+                        },
+                        BinaryOp::Shl | BinaryOp::Shr => {
+                            let ty = IntTy::from_type(lhs_ty)
+                                .filter(|t| !t.is_signed())
+                                .ok_or_else(|| {
+                                    anyhow::anyhow!(
+                                        "BinaryOp {:?}: requires an unsigned non-u64 integer type",
+                                        op
+                                    )
+                                })?;
+                            let shift_op = IntShiftOp {
+                                ty,
+                                dst,
+                                lhs,
+                                rhs: ShiftOperand::SlotU8(rhs),
+                            };
+                            self.emit(match op {
+                                BinaryOp::Shl => MicroOp::IntShl(shift_op),
+                                BinaryOp::Shr => MicroOp::IntShr(shift_op),
+                                BinaryOp::Add
+                                | BinaryOp::Sub
+                                | BinaryOp::Mul
+                                | BinaryOp::Div
+                                | BinaryOp::Mod
+                                | BinaryOp::BitAnd
+                                | BinaryOp::BitOr
+                                | BinaryOp::BitXor
+                                | BinaryOp::Cmp(_)
+                                | BinaryOp::Or
+                                | BinaryOp::And => bail!("internal: unexpected op in shift arm"),
+                            })?;
+                        },
+                        // Comparison-to-register and logical and/or are not
+                        // yet lowered for any integer width.
+                        BinaryOp::Cmp(_) | BinaryOp::Or | BinaryOp::And => {
+                            bail!("BinaryOp {:?} not yet lowered", op)
+                        },
+                    }
                 }
             },
 
@@ -369,6 +428,7 @@ impl<'a> LoweringState<'a> {
                 // Fast path: u64 specialized imm variants where they exist.
                 // u64 BitAnd/BitOr/BitXor/Cmp/Or/And imm have no specialized
                 // variant and fall through to the unspecialized path below.
+                let mut handled = false;
                 if src_ty.is_u64() {
                     let emitted = match op {
                         BinaryOp::Add => Some(MicroOp::AddU64Imm {
@@ -414,79 +474,81 @@ impl<'a> LoweringState<'a> {
                         | BinaryOp::And => None,
                     };
                     if let Some(micro) = emitted {
-                        self.emit(micro);
-                        return Ok(());
+                        self.emit(micro)?;
+                        handled = true;
                     }
                 }
 
-                match op {
-                    BinaryOp::Add
-                    | BinaryOp::Sub
-                    | BinaryOp::Mul
-                    | BinaryOp::Div
-                    | BinaryOp::Mod
-                    | BinaryOp::BitAnd
-                    | BinaryOp::BitOr
-                    | BinaryOp::BitXor => {
-                        let rhs = int_operand_from_imm(imm)?;
-                        if matches!(op, BinaryOp::BitAnd | BinaryOp::BitOr | BinaryOp::BitXor)
-                            && rhs.is_signed()
-                        {
-                            bail!("BinaryOpImm {:?}: bitwise on a signed value is invalid", op,);
-                        }
-                        let binop = IntBinaryOp { dst, lhs, rhs };
-                        self.emit(match op {
-                            BinaryOp::Add => MicroOp::IntAdd(binop),
-                            BinaryOp::Sub => MicroOp::IntSub(binop),
-                            BinaryOp::Mul => MicroOp::IntMul(binop),
-                            BinaryOp::Div => MicroOp::IntDiv(binop),
-                            BinaryOp::Mod => MicroOp::IntMod(binop),
-                            BinaryOp::BitAnd => MicroOp::IntBitAnd(binop),
-                            BinaryOp::BitOr => MicroOp::IntBitOr(binop),
-                            BinaryOp::BitXor => MicroOp::IntBitXor(binop),
-                            BinaryOp::Shl
-                            | BinaryOp::Shr
-                            | BinaryOp::Cmp(_)
-                            | BinaryOp::Or
-                            | BinaryOp::And => {
-                                bail!("internal: unexpected op in arith/bitwise arm")
-                            },
-                        });
-                    },
-                    BinaryOp::Shl | BinaryOp::Shr => {
-                        let ty = IntTy::from_type(src_ty)
-                            .filter(|t| !t.is_signed())
-                            .ok_or_else(|| {
-                                anyhow::anyhow!(
+                if !handled {
+                    match op {
+                        BinaryOp::Add
+                        | BinaryOp::Sub
+                        | BinaryOp::Mul
+                        | BinaryOp::Div
+                        | BinaryOp::Mod
+                        | BinaryOp::BitAnd
+                        | BinaryOp::BitOr
+                        | BinaryOp::BitXor => {
+                            let rhs = int_operand_from_imm(imm)?;
+                            if matches!(op, BinaryOp::BitAnd | BinaryOp::BitOr | BinaryOp::BitXor)
+                                && rhs.is_signed()
+                            {
+                                bail!("BinaryOpImm {:?}: bitwise on a signed value is invalid", op,);
+                            }
+                            let binop = IntBinaryOp { dst, lhs, rhs };
+                            self.emit(match op {
+                                BinaryOp::Add => MicroOp::IntAdd(binop),
+                                BinaryOp::Sub => MicroOp::IntSub(binop),
+                                BinaryOp::Mul => MicroOp::IntMul(binop),
+                                BinaryOp::Div => MicroOp::IntDiv(binop),
+                                BinaryOp::Mod => MicroOp::IntMod(binop),
+                                BinaryOp::BitAnd => MicroOp::IntBitAnd(binop),
+                                BinaryOp::BitOr => MicroOp::IntBitOr(binop),
+                                BinaryOp::BitXor => MicroOp::IntBitXor(binop),
+                                BinaryOp::Shl
+                                | BinaryOp::Shr
+                                | BinaryOp::Cmp(_)
+                                | BinaryOp::Or
+                                | BinaryOp::And => {
+                                    bail!("internal: unexpected op in arith/bitwise arm")
+                                },
+                            })?;
+                        },
+                        BinaryOp::Shl | BinaryOp::Shr => {
+                            let ty = IntTy::from_type(src_ty)
+                                .filter(|t| !t.is_signed())
+                                .ok_or_else(|| {
+                                    anyhow::anyhow!(
                                     "BinaryOpImm {:?}: requires an unsigned non-u64 integer type",
                                     op
                                 )
+                                })?;
+                            let shift_op = IntShiftOp {
+                                ty,
+                                dst,
+                                lhs,
+                                rhs: ShiftOperand::ImmU8(shift_imm_u8(imm)?),
+                            };
+                            self.emit(match op {
+                                BinaryOp::Shl => MicroOp::IntShl(shift_op),
+                                BinaryOp::Shr => MicroOp::IntShr(shift_op),
+                                BinaryOp::Add
+                                | BinaryOp::Sub
+                                | BinaryOp::Mul
+                                | BinaryOp::Div
+                                | BinaryOp::Mod
+                                | BinaryOp::BitAnd
+                                | BinaryOp::BitOr
+                                | BinaryOp::BitXor
+                                | BinaryOp::Cmp(_)
+                                | BinaryOp::Or
+                                | BinaryOp::And => bail!("internal: unexpected op in shift arm"),
                             })?;
-                        let shift_op = IntShiftOp {
-                            ty,
-                            dst,
-                            lhs,
-                            rhs: ShiftOperand::ImmU8(shift_imm_u8(imm)?),
-                        };
-                        self.emit(match op {
-                            BinaryOp::Shl => MicroOp::IntShl(shift_op),
-                            BinaryOp::Shr => MicroOp::IntShr(shift_op),
-                            BinaryOp::Add
-                            | BinaryOp::Sub
-                            | BinaryOp::Mul
-                            | BinaryOp::Div
-                            | BinaryOp::Mod
-                            | BinaryOp::BitAnd
-                            | BinaryOp::BitOr
-                            | BinaryOp::BitXor
-                            | BinaryOp::Cmp(_)
-                            | BinaryOp::Or
-                            | BinaryOp::And => bail!("internal: unexpected op in shift arm"),
-                        });
-                    },
-                    BinaryOp::Cmp(_) | BinaryOp::Or | BinaryOp::And => {
-                        bail!("BinaryOpImm {:?} not yet lowered", op)
-                    },
+                        },
+                        BinaryOp::Cmp(_) | BinaryOp::Or | BinaryOp::And => {
+                            bail!("BinaryOpImm {:?} not yet lowered", op)
+                        },
+                    }
                 }
             },
 
@@ -504,7 +566,7 @@ impl<'a> LoweringState<'a> {
                     ty: signed_ty,
                     dst: dst_info.offset,
                     src: src_info.offset,
-                }));
+                }))?;
             },
 
             // --- References ---
@@ -514,7 +576,7 @@ impl<'a> LoweringState<'a> {
                 self.emit(MicroOp::SlotBorrow {
                     dst: dst_info.offset,
                     local: src_info.offset,
-                });
+                })?;
             },
             Instr::ReadRef(dst, ref_src) => {
                 // TODO: `size` could equivalently come from `dst_info.size`
@@ -528,7 +590,7 @@ impl<'a> LoweringState<'a> {
                     dst: dst_info.offset,
                     ref_ptr: ref_info.offset,
                     size,
-                });
+                })?;
             },
             Instr::WriteRef(ref_dst, src) => {
                 // TODO: `size` could equivalently come from `src_info.size`
@@ -542,7 +604,7 @@ impl<'a> LoweringState<'a> {
                     ref_ptr: ref_info.offset,
                     src: src_info.offset,
                     size,
-                });
+                })?;
             },
 
             // --- Control flow ---
@@ -551,7 +613,7 @@ impl<'a> LoweringState<'a> {
                 self.branch_fixups.push(idx);
                 self.emit(MicroOp::Jump {
                     target: CodeOffset(encode_label(*l)),
-                });
+                })?;
             },
             Instr::BrTrue(Label(l), cond) => {
                 let cond_info = self.slot(*cond)?;
@@ -562,7 +624,7 @@ impl<'a> LoweringState<'a> {
                 self.emit(MicroOp::JumpNotZeroU64 {
                     target: CodeOffset(encode_label(*l)),
                     src: cond_info.offset,
-                });
+                })?;
             },
             Instr::BrFalse(Label(l), cond) => {
                 let cond_info = self.slot(*cond)?;
@@ -574,7 +636,7 @@ impl<'a> LoweringState<'a> {
                     target: CodeOffset(encode_label(*l)),
                     src: cond_info.offset,
                     imm: 1,
-                });
+                })?;
             },
 
             // --- Fused compare+branch ---
@@ -590,29 +652,29 @@ impl<'a> LoweringState<'a> {
                             target: CodeOffset(encode_label(*l)),
                             lhs: lhs_info.offset,
                             rhs: rhs_info.offset,
-                        }),
+                        })?,
                         CmpOp::Ge => self.emit(MicroOp::JumpGreaterEqualU64 {
                             target: CodeOffset(encode_label(*l)),
                             lhs: lhs_info.offset,
                             rhs: rhs_info.offset,
-                        }),
+                        })?,
                         // x > y ↔ y < x
                         CmpOp::Gt => self.emit(MicroOp::JumpLessU64 {
                             target: CodeOffset(encode_label(*l)),
                             lhs: rhs_info.offset,
                             rhs: lhs_info.offset,
-                        }),
+                        })?,
                         // x <= y ↔ y >= x
                         CmpOp::Le => self.emit(MicroOp::JumpGreaterEqualU64 {
                             target: CodeOffset(encode_label(*l)),
                             lhs: rhs_info.offset,
                             rhs: lhs_info.offset,
-                        }),
+                        })?,
                         CmpOp::Neq => self.emit(MicroOp::JumpNotEqualU64 {
                             target: CodeOffset(encode_label(*l)),
                             lhs: lhs_info.offset,
                             rhs: rhs_info.offset,
-                        }),
+                        })?,
                         CmpOp::Eq => {
                             bail!("BrCmp Eq for u64-sized type not yet lowered")
                         },
@@ -633,22 +695,22 @@ impl<'a> LoweringState<'a> {
                             target: CodeOffset(encode_label(*l)),
                             src: src_info.offset,
                             imm: v,
-                        }),
+                        })?,
                         CmpOp::Lt => self.emit(MicroOp::JumpLessU64Imm {
                             target: CodeOffset(encode_label(*l)),
                             src: src_info.offset,
                             imm: v,
-                        }),
+                        })?,
                         CmpOp::Gt => self.emit(MicroOp::JumpGreaterU64Imm {
                             target: CodeOffset(encode_label(*l)),
                             src: src_info.offset,
                             imm: v,
-                        }),
+                        })?,
                         CmpOp::Le => self.emit(MicroOp::JumpLessEqualU64Imm {
                             target: CodeOffset(encode_label(*l)),
                             src: src_info.offset,
                             imm: v,
-                        }),
+                        })?,
                         CmpOp::Eq | CmpOp::Neq => {
                             bail!("BrCmpImm {:?} for u64-sized type not yet lowered", op)
                         },
@@ -684,7 +746,7 @@ impl<'a> LoweringState<'a> {
                     });
                 }
                 parallel_copy::emit_parallel_copy(&mut self.out_buf, &copies, self.ctx.scratch)?;
-                self.emit(MicroOp::Return);
+                self.emit(MicroOp::Return)?;
             },
 
             // --- Abort ---
@@ -708,7 +770,7 @@ impl<'a> LoweringState<'a> {
                 self.emit(MicroOp::VecLen {
                     dst: dst_info.offset,
                     vec_ref: vec_ref_info.offset,
-                });
+                })?;
             },
             Instr::VecImmBorrow(dst, elem_ty, vec_ref, idx)
             | Instr::VecMutBorrow(dst, elem_ty, vec_ref, idx) => {
@@ -722,7 +784,7 @@ impl<'a> LoweringState<'a> {
                     vec_ref: vec_ref_info.offset,
                     idx: idx_info.offset,
                     elem_size,
-                });
+                })?;
             },
             Instr::VecPopBack(dst, elem_ty, vec_ref) => {
                 let elem_size = concrete_type_size(*elem_ty, "vector elem type")?;
@@ -732,7 +794,7 @@ impl<'a> LoweringState<'a> {
                     dst: dst_info.offset,
                     vec_ref: vec_ref_info.offset,
                     elem_size,
-                });
+                })?;
             },
             Instr::VecPack(dst, _elem_ty, _count, elems) => {
                 if !elems.is_empty() {
@@ -741,7 +803,7 @@ impl<'a> LoweringState<'a> {
                 let dst_info = self.def_slot(*dst)?;
                 self.emit(MicroOp::VecNew {
                     dst: dst_info.offset,
-                });
+                })?;
             },
             Instr::VecPushBack(elem_ty, vec_ref, val) => {
                 let elem_size = concrete_type_size(*elem_ty, "vector elem type")?;
@@ -759,11 +821,32 @@ impl<'a> LoweringState<'a> {
                     elem: val_info.offset,
                     elem_size,
                     descriptor_id,
-                });
+                })?;
             },
 
             _ => bail!("instruction {} not yet lowered", instr.opcode_name()),
         }
+
+        // Calls manage their own Xfer state in `lower_call`.
+        if !clobbers_xfer(instr) {
+            // Release Xfer bindings consumed by this instr's uses.
+            for_each_use(instr, |s| {
+                if let Slot::Xfer(j) = s {
+                    self.xfer_bindings[j as usize] = None;
+                }
+            });
+            // Clear-then-commit so an instr that uses and re-defs
+            // the same `Xfer(j)` ends with the new value visible.
+            if let Some((j, ts)) = self.pending_def_bind.take() {
+                self.xfer_bindings[j as usize] = Some(ts);
+            }
+        } else {
+            debug_assert!(
+                self.pending_def_bind.is_none(),
+                "calls must not leave a pending Xfer def bind",
+            );
+        }
+
         Ok(())
     }
 
@@ -828,13 +911,13 @@ impl<'a> LoweringState<'a> {
                 self.emit(MicroOp::Move8 {
                     dst: dst_off,
                     src: arg_info.offset,
-                });
+                })?;
             } else {
                 self.emit(MicroOp::Move {
                     dst: dst_off,
                     src: arg_info.offset,
                     size: arg_info.size,
-                });
+                })?;
             }
         }
 
@@ -842,13 +925,17 @@ impl<'a> LoweringState<'a> {
             module_id: cs.callee_module_id,
             func_name: cs.callee_func_name,
             ty_args: cs.ty_args,
-        });
+        })?;
         self.call_site_cursor += 1;
 
-        // Place each ret. Xfer rets just bind the slot info — the next
-        // consumer reads from `ret_slots[k]` directly. Home rets copy
-        // out of the ret region into their Home slot (disjoint regions,
-        // never conflict with future arg setup).
+        // Clear all Xfer bindings (calls clobber the entire callee
+        // region). The ret loop below re-binds the positions this
+        // call returns to.
+        self.xfer_bindings.fill(None);
+
+        // Place each ret. Xfer rets are recorded in `xfer_bindings`
+        // immediately — `CallIndirect` has already written the
+        // values.
         for (k, ret_slot) in rets.iter().enumerate() {
             match *ret_slot {
                 Slot::Xfer(j) => {
@@ -857,7 +944,7 @@ impl<'a> LoweringState<'a> {
                 Slot::Home(i) => {
                     let src = cs.ret_slots[k].slot;
                     let dst = self.ctx.home_slots[i as usize];
-                    self.emit_single_move(dst.offset, src);
+                    self.emit_single_move(dst.offset, src)?;
                 },
                 Slot::Vid(_) => bail!("Vid slot in post-allocation IR"),
             }

--- a/third_party/move/mono-move/specializer/src/stackless_exec_ir/instr_utils.rs
+++ b/third_party/move/mono-move/specializer/src/stackless_exec_ir/instr_utils.rs
@@ -30,7 +30,7 @@
 //!   caller-provided closures (`impl FnMut`) are monomorphized and inlined
 //!   at each call site.
 
-use crate::stackless_exec_ir::{BinaryOp, ImmValue, Instr, Slot};
+use super::{BinaryOp, ImmValue, Instr, Slot};
 use smallvec::SmallVec;
 
 /// Most instructions have at most 4 defs or uses.
@@ -95,6 +95,16 @@ pub(crate) fn remap_source_slots_with(instr: &mut Instr, f: impl FnMut(Slot) -> 
 // =============================================================================
 // Other instruction utilities
 // =============================================================================
+
+/// Call-like instructions (`Call`, `CallGeneric`, `CallClosure`) that clobber
+/// Xfer slots.
+#[inline]
+pub(crate) fn clobbers_xfer(instr: &Instr) -> bool {
+    matches!(
+        instr,
+        Instr::Call(..) | Instr::CallGeneric(..) | Instr::CallClosure(..)
+    )
+}
 
 /// Extract the destination slot and immediate value from a load instruction.
 // TODO: the wide arms (`LdU128`/`LdU256`/`LdI128`/`LdI256`) each allocate

--- a/third_party/move/mono-move/specializer/src/stackless_exec_ir/mod.rs
+++ b/third_party/move/mono-move/specializer/src/stackless_exec_ir/mod.rs
@@ -7,6 +7,7 @@
 //! eliminating the operand stack and allowing direct named-slot operands on each instruction.
 
 mod display;
+pub(crate) mod instr_utils;
 
 use mono_move_core::{
     types::{InternedType, InternedTypeList},

--- a/third_party/move/mono-move/testsuite/src/print_sections.rs
+++ b/third_party/move/mono-move/testsuite/src/print_sections.rs
@@ -141,13 +141,14 @@ pub fn format_micro_ops(guard: &ExecutionGuard<'_>, module_ir: &ModuleIR) -> Str
                 out.push_str(&format!("\nfun {}(): skipped ({})\n", func_name, reason));
             },
             Ok(BuildContextOutcome::Built(ctx)) => match lower_function(func_ir, &ctx) {
-                Ok(ops) => {
+                Ok((ops, safe_points)) => {
                     out.push('\n');
                     out.push_str(
                         &MicroOpsFunctionDisplay {
                             func_name: &func_name,
                             ctx: &ctx,
                             ops: &ops,
+                            safe_points: &safe_points,
                         }
                         .to_string(),
                     );

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/cross_module_vec_sum.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/cross_module_vec_sum.exp
@@ -110,6 +110,8 @@ fun push_and_sum() {
     14: SubU64Imm [16] <- [16] - #1
     15: Jump @10
     16: Return
+  safe_point_layouts:
+    4: []
 }
 === frame-layout ===
 // module 0xc0ffee::foo

--- a/third_party/move/mono-move/testsuite/tests/test_cases/snapshot/masm/xfer_propagation_safety.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/snapshot/masm/xfer_propagation_safety.exp
@@ -1,0 +1,55 @@
+// module 0x66::test
+
+fun helper(): u64 {
+  slots: params(0), locals(0), temps(1)
+    r0: u64
+  code:
+  L0:
+    0: r0 := ld_u64 7
+    1: ret [r0]
+}
+
+fun void_no_arg() {
+  slots: params(0), locals(0), temps(0)
+  code:
+  L0:
+    0: ret []
+}
+
+fun trigger(): u64 {
+  slots: params(0), locals(1), temps(0), xfer(1)
+    r0: u64
+  code:
+  L0:
+    0: [x0] := call helper, []
+    1: r0 := ld_u64 0
+    2: r0 := move x0
+    3: [] := call void_no_arg, []
+    4: ret [r0]
+}
+
+=== micro-ops ===
+// module 0x66::test
+
+fun helper() {
+  frame_data_size: 8
+  code:
+    0: StoreImm8 [0] <- #7
+    1: Return
+}
+
+fun void_no_arg() {
+  frame_data_size: 0
+  code:
+    0: Return
+}
+
+fun trigger() {
+  frame_data_size: 8
+  code:
+    0: CallIndirect 0x66::test::helper
+    1: StoreImm8 [0] <- #0
+    2: Move8 [0] <- [32]
+    3: CallIndirect 0x66::test::void_no_arg
+    4: Return
+}

--- a/third_party/move/mono-move/testsuite/tests/test_cases/snapshot/masm/xfer_propagation_safety.masm
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/snapshot/masm/xfer_propagation_safety.masm
@@ -1,0 +1,18 @@
+module 0x66::test
+
+fun helper(): u64
+    ld_u64 7
+    ret
+
+fun void_no_arg()
+    ret
+
+fun trigger(): u64
+    local k: u64
+    call helper
+    ld_u64 0
+    st_loc k
+    st_loc k
+    call void_no_arg
+    move_loc k
+    ret

--- a/third_party/move/mono-move/testsuite/tests/test_cases/snapshot/move/vec_pushback_safe_point.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/snapshot/move/vec_pushback_safe_point.exp
@@ -1,0 +1,91 @@
+=== masm ===
+// Bytecode version v10
+module 0x66::vec_pushback_safe_point
+// Function definition at index 0
+#[persistent] public fun caller()
+    local l0: vector<u64>
+    call fresh
+    vec_pack <u64>, 0
+    st_loc l0
+    mut_borrow_loc l0
+    ld_u64 42
+    // @5
+    vec_push_back <u64>
+    call take
+    ret
+
+// Function definition at index 1
+fun fresh(): vector<u8>
+    vec_pack <u8>, 0
+    ret
+
+// Function definition at index 2
+fun take(l0: vector<u8>)
+    ret
+
+
+=== specializer ===
+// module 0x66::vec_pushback_safe_point
+
+fun caller() {
+  slots: params(0), locals(1), temps(2), xfer(1)
+    r0: vector<u64>
+    r1: &mut vector<u64>
+    r2: u64
+  code:
+  L0:
+    0: [x0] := call fresh, []
+    1: r0 := vec_pack u64, 0, []
+    2: r1 := mut_borrow_loc r0
+    3: r2 := ld_u64 42
+    4: vec_push_back u64, r1, r2
+    5: [] := call take, [x0]
+    6: ret []
+}
+
+fun fresh(): vector<u8> {
+  slots: params(0), locals(0), temps(1)
+    r0: vector<u8>
+  code:
+  L0:
+    0: r0 := vec_pack u8, 0, []
+    1: ret [r0]
+}
+
+fun take(r0) {
+  slots: params(1), locals(0), temps(0)
+    r0: vector<u8>
+  code:
+  L0:
+    0: ret []
+}
+
+=== micro-ops ===
+// module 0x66::vec_pushback_safe_point
+
+fun caller() {
+  frame_data_size: 32
+  code:
+    0: CallIndirect 0x66::vec_pushback_safe_point::fresh
+    1: VecNew [0]
+    2: SlotBorrow [8] <- &[0]
+    3: StoreImm8 [24] <- #42
+    4: VecPushBack [8].push([24], size=8, desc=2)
+    5: CallIndirect 0x66::vec_pushback_safe_point::take
+    6: Return
+  safe_point_layouts:
+    4: [56]
+}
+
+fun fresh() {
+  frame_data_size: 8
+  code:
+    0: VecNew [0]
+    1: Return
+}
+
+fun take() {
+  frame_data_size: 8
+  code:
+    0: Return
+}

--- a/third_party/move/mono-move/testsuite/tests/test_cases/snapshot/move/vec_pushback_safe_point.move
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/snapshot/move/vec_pushback_safe_point.move
@@ -1,0 +1,16 @@
+module 0x66::vec_pushback_safe_point {
+    use std::vector;
+
+    fun fresh(): vector<u8> {
+        vector::empty<u8>()
+    }
+
+    fun take(_v: vector<u8>) {}
+
+    public fun caller() {
+        let saved = fresh();
+        let v = vector::empty<u64>();
+        vector::push_back(&mut v, 42);
+        take(saved);
+    }
+}


### PR DESCRIPTION
## Description

In this PR, we add per-PC GC safe-point layouts: lowering now derives a `SafePointEntry` for every allocating micro-op, capturing the byte offsets of currently-live heap pointers in the callee region.
  
To do this, we do liveness analysis on xfer slots during lowering by tightening an existing mechanism: `xfer_bindings` is now strictly "holds an actual live value", with consumed uses cleared at end-of-instr, destination binds deferred via a pending_def_bind until the value is actually written, and calls clearing the full callee region to match the clobber semantics.

There is also an optimizer soundness fix: closed a latent bug in copy_propagation where substitutions sourced from Xfer slots could survive a call that clobbers the callee region, letting downstream reads land on overwritten bytes (triggering required hand-crafted masm). We also add debug-only post-optimize verification that xfer invariants still hold.

Note that the code pertaining to remapping safe-point layouts will be gone soon when we move the gas instrumentation to stackless execution IR, so this part does not need deep review.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Adds per-PC GC safe-point metadata and changes lowering/optimization around `Xfer` slot liveness, which can affect GC correctness and call-frame safety. Also introduces new instrumentation PC remapping and debug verifiers that may surface latent IR/optimizer bugs.
> 
> **Overview**
> Implements per-PC GC safe points for lowered micro-ops by emitting `SafePointEntry` records for allocating ops based on live `Xfer` bindings during lowering, and wiring these through to `Function.safe_point_layouts` (with test output updates to display them).
> 
> To keep safe-point PCs correct after gas instrumentation inserts `Charge` ops, `GasInstrumentor` now exposes `run_with_pc_map` and lowering remaps safe-point `CodeOffset`s using the returned monotone PC map.
> 
> Hardens `Xfer` correctness: copy propagation no longer substitutes from `Slot::Xfer(_)` sources across call boundaries, `xfer_bindings` tracking is tightened (deferred bind + end-of-instr release + call clobber), and debug-only post-optimization verification is added to ensure `Xfer` invariants still hold.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 682527aa38141bad209a5c472976faf4e96afd1f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->