### PR TITLE
[qs] fix pos verification for batch v2

### DIFF
--- a/consensus/consensus-types/src/proof_of_store.rs
+++ b/consensus/consensus-types/src/proof_of_store.rs
@@ -815,6 +815,12 @@ impl From<ProofOfStore<BatchInfo>> for ProofOfStore<BatchInfoExt> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use aptos_bitvec::BitVec;
+    use aptos_crypto::HashValue;
+    use aptos_types::{
+        aggregate_signature::PartialSignatures, quorum_store::BatchId,
+        validator_verifier::random_validator_verifier,
+    };
 
     fn v1_info() -> BatchInfoExt {
         BatchInfoExt::new_v1(
@@ -841,6 +847,35 @@ mod tests {
             0,
             BatchKind::Normal,
         )
+    }
+
+    fn make_batch_info(author: PeerId) -> BatchInfo {
+        BatchInfo::new(
+            author,
+            BatchId::new_for_test(1),
+            /* epoch */ 1,
+            /* expiration */ u64::MAX,
+            HashValue::random(),
+            /* num_txns */ 1,
+            /* num_bytes */ 1,
+            /* gas_bucket_start */ 0,
+        )
+    }
+
+    fn aggregate<T: CryptoHash + Serialize>(
+        signers: &[ValidatorSigner],
+        verifier: &ValidatorVerifier,
+        msg: &T,
+    ) -> AggregateSignature {
+        let partial = PartialSignatures::new(
+            signers
+                .iter()
+                .map(|s| (s.author(), s.sign(msg).unwrap()))
+                .collect(),
+        );
+        verifier
+            .aggregate_signatures(partial.signatures_iter())
+            .unwrap()
     }
 
     #[test]
@@ -874,5 +909,82 @@ mod tests {
                 .contains("Non-V2 entry in ProofOfStoreMsgV2"),
             "unexpected error: {err}"
         );
+    }
+
+    #[test]
+    fn verify_v1_proof_wrapped_as_batch_info_ext() {
+        // V1 batches are signed over `BatchInfo` (see batch_store::persist_inner),
+        // but a V2 OptQuorumStorePayload carries V1 batch proofs wrapped as
+        // `BatchInfoExt::V1`. Verification must hash against the raw
+        // `BatchInfo`, not the V1 enum variant.
+        let (signers, verifier) = random_validator_verifier(4, None, false);
+        let info = make_batch_info(signers[0].author());
+
+        let multi_sig = aggregate(&signers, &verifier, &info);
+
+        let proof_v1 = ProofOfStore::new(info.clone(), multi_sig);
+        let proof_ext: ProofOfStore<BatchInfoExt> = proof_v1.into();
+
+        let cache = ProofCache::new(128);
+        proof_ext.verify(&verifier, &cache).unwrap();
+    }
+
+    #[test]
+    fn verify_v2_proof() {
+        // V2 batches are signed over `BatchInfoExt` directly.
+        let (signers, verifier) = random_validator_verifier(4, None, false);
+        let info = make_batch_info(signers[0].author());
+        let ext = BatchInfoExt::V2 {
+            info,
+            extra: ExtraBatchInfo {
+                batch_kind: BatchKind::Normal,
+            },
+        };
+
+        let multi_sig = aggregate(&signers, &verifier, &ext);
+
+        let proof = ProofOfStore::new(ext, multi_sig);
+        let cache = ProofCache::new(128);
+        proof.verify(&verifier, &cache).unwrap();
+    }
+
+    #[test]
+    fn verify_v1_proof_signed_over_wrong_type_fails() {
+        // Regression guard: if a future change ever signs a V1 batch as
+        // `BatchInfoExt::V1` instead of `BatchInfo`, verify must reject it.
+        let (signers, verifier) = random_validator_verifier(4, None, false);
+        let info = make_batch_info(signers[0].author());
+        let ext_v1 = BatchInfoExt::V1 { info: info.clone() };
+
+        let bad_sig = aggregate(&signers, &verifier, &ext_v1);
+
+        let proof = ProofOfStore::new(ext_v1, bad_sig);
+        let cache = ProofCache::new(128);
+        assert!(proof.verify(&verifier, &cache).is_err());
+    }
+
+    #[test]
+    fn verify_rejects_insufficient_voting_power() {
+        // Sanity: a single signature out of 4 validators is below quorum.
+        let (signers, verifier) = random_validator_verifier(4, None, false);
+        let info = make_batch_info(signers[0].author());
+
+        let one_signer = &signers[..1];
+        let partial = PartialSignatures::new(
+            one_signer
+                .iter()
+                .map(|s| (s.author(), s.sign(&info).unwrap()))
+                .collect(),
+        );
+        let agg = verifier
+            .aggregate_signatures(partial.signatures_iter())
+            .unwrap();
+        // Sanity-check the bitmask actually reflects a single signer.
+        let bits: BitVec = agg.get_signers_bitvec().clone();
+        assert_eq!(bits.iter_ones().count(), 1);
+
+        let proof: ProofOfStore<BatchInfoExt> = ProofOfStore::new(info, agg).into();
+        let cache = ProofCache::new(128);
+        assert!(proof.verify(&verifier, &cache).is_err());
     }
 }

--- a/consensus/consensus-types/src/proof_of_store.rs
+++ b/consensus/consensus-types/src/proof_of_store.rs
@@ -733,12 +733,21 @@ where
                 return Ok(());
             }
         }
-        let result = validator
-            .verify_multi_signatures(&self.info, &self.multi_signature)
-            .context(format!(
-                "Failed to verify ProofOfStore for batch: {:?}",
-                self.info
-            ));
+        let result = if batch_info_ext.is_v2() {
+            validator
+                .verify_multi_signatures(&batch_info_ext, &self.multi_signature)
+                .context(format!(
+                    "Failed to verify ProofOfStore for batch: {:?}",
+                    self.info
+                ))
+        } else {
+            validator
+                .verify_multi_signatures(self.info.as_batch_info(), &self.multi_signature)
+                .context(format!(
+                    "Failed to verify ProofOfStore for batch: {:?}",
+                    self.info
+                ))
+        };
         if result.is_ok() {
             cache.insert(batch_info_ext, self.multi_signature.clone());
         }


### PR DESCRIPTION
## Summary

Fix how V1 batch proofs are verified when they are carried inside a `OptQuorumStorePayload::V2`.

`OptQuorumStorePayload::V2` is `OptQuorumStorePayloadV1<BatchInfoExt>` — its proofs are `ProofOfStore<BatchInfoExt>`, and a V1 batch sits inside as `BatchInfoExt::V1 { info }`. Signers originally signed over the raw `BatchInfo`, so on verification we must hash against `BatchInfo`, not the `BatchInfoExt::V1` enum variant (which BCS-encodes with a variant tag and produces a different hash).

`ProofOfStore<BatchInfoExt>::verify` now branches on `is_v2()`:
- V2 → `verify_multi_signatures(&batch_info_ext, …)` (matches V2 signing in `batch_store::persist_inner`).
- V1 → `verify_multi_signatures(self.info.as_batch_info(), …)` (matches V1 signing).

Companion to #19828 on `aptos-release-v1.45` (without the `enable_batch_v2_tx`/`enable_opt_qs_v2_payload_tx` release-only kill-switch flip).

Includes 4 unit tests covering the V1-in-V2 regression, the V2 happy path, an inverse-signing guard, and a quorum sanity check.

## Test plan

- [x] `cargo test -p aptos-consensus-types --lib proof_of_store::tests` — 6 passed (2 existing on main + 4 new)
- [x] Verified the regression tests fail when the fix is reverted, pass with it applied
- [x] `./scripts/rust_lint.sh` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)