### PR TITLE
Release Aptos CLI v9.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -295,7 +295,7 @@ dependencies = [
 
 [[package]]
 name = "aptos"
-version = "9.2.0"
+version = "9.3.0"
 dependencies = [
  "anyhow",
  "aptos-api-types",

--- a/crates/aptos/CHANGELOG.md
+++ b/crates/aptos/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to the Aptos CLI will be captured in this file. This project
 
 # Unreleased
 
+- _No changes yet._
+
+## [9.3.0]
 - Replaced `aptos node verify-digest-key` with two commands: `aptos node validate-digest-key` and `aptos node validate-public-parameters`. Both compute and report a blake3 checksum (instead of SHA-256) along with the file size, and verify that the blob deserializes to the corresponding type. The JSON output field is renamed from `sha256` to `blake3`.
 
 ## [9.2.0]

--- a/crates/aptos/Cargo.toml
+++ b/crates/aptos/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aptos"
 description = "Aptos tool for management of nodes and interacting with the blockchain"
-version = "9.2.0"
+version = "9.3.0"
 
 # Workspace inherited keys
 authors = { workspace = true }


### PR DESCRIPTION
## Description

This PR releases Aptos CLI version 9.3.0. The version bump reflects the recent changes to the node verification commands that were introduced in the previous commit.

**Changes:**
- Bumped version from 9.2.0 to 9.3.0 in `Cargo.toml`
- Updated `CHANGELOG.md` to document the 9.3.0 release with the command replacements:
  - Replaced `aptos node verify-digest-key` with `aptos node validate-digest-key` and `aptos node validate-public-parameters`
  - Changed checksum algorithm from SHA-256 to blake3
  - Updated JSON output field from `sha256` to `blake3`

## How Has This Been Tested?

The changes in this PR are version/documentation updates only. The underlying functionality was tested as part of the previous commit that introduced the command changes.

## Type of Change

- [x] Documentation update

## Which Components or Systems Does This Change Impact?

- [x] Aptos CLI/SDK

## Checklist

- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have made corresponding changes to the documentation (CHANGELOG.md)

https://claude.ai/code/session_01BBfneLAYRza39qFy8hRMLF