### PR TITLE
[encrypted mempool] Refactor `aptos-batch-encryption` smoke tests to test all digest key rounds

### DIFF
--- a/crates/aptos-batch-encryption/src/schemes/fptx.rs
+++ b/crates/aptos-batch-encryption/src/schemes/fptx.rs
@@ -91,6 +91,18 @@ impl BatchThresholdEncryption for FPTX {
         Ok((ek, digest_key, vks, msk_shares))
     }
 
+    fn max_batch_size(
+            dk: &Self::DigestKey
+        ) -> usize {
+        dk.max_batch_size()
+    }
+
+    fn num_rounds(
+            dk: &Self::DigestKey
+        ) -> usize {
+        dk.num_rounds()
+    }
+
     fn encrypt<R: CryptoRng + RngCore>(
         ek: &Self::EncryptionKey,
         rng: &mut R,

--- a/crates/aptos-batch-encryption/src/schemes/fptx.rs
+++ b/crates/aptos-batch-encryption/src/schemes/fptx.rs
@@ -91,15 +91,11 @@ impl BatchThresholdEncryption for FPTX {
         Ok((ek, digest_key, vks, msk_shares))
     }
 
-    fn max_batch_size(
-            dk: &Self::DigestKey
-        ) -> usize {
+    fn max_batch_size(dk: &Self::DigestKey) -> usize {
         dk.max_batch_size()
     }
 
-    fn num_rounds(
-            dk: &Self::DigestKey
-        ) -> usize {
+    fn num_rounds(dk: &Self::DigestKey) -> usize {
         dk.num_rounds()
     }
 

--- a/crates/aptos-batch-encryption/src/schemes/fptx_succinct.rs
+++ b/crates/aptos-batch-encryption/src/schemes/fptx_succinct.rs
@@ -95,15 +95,11 @@ impl BatchThresholdEncryption for FPTXSuccinct {
         Ok((ek, digest_key, vks, msk_shares))
     }
 
-    fn max_batch_size(
-            dk: &Self::DigestKey
-        ) -> usize {
+    fn max_batch_size(dk: &Self::DigestKey) -> usize {
         dk.max_batch_size()
     }
 
-    fn num_rounds(
-            dk: &Self::DigestKey
-        ) -> usize {
+    fn num_rounds(dk: &Self::DigestKey) -> usize {
         dk.num_rounds()
     }
 

--- a/crates/aptos-batch-encryption/src/schemes/fptx_succinct.rs
+++ b/crates/aptos-batch-encryption/src/schemes/fptx_succinct.rs
@@ -95,6 +95,18 @@ impl BatchThresholdEncryption for FPTXSuccinct {
         Ok((ek, digest_key, vks, msk_shares))
     }
 
+    fn max_batch_size(
+            dk: &Self::DigestKey
+        ) -> usize {
+        dk.max_batch_size()
+    }
+
+    fn num_rounds(
+            dk: &Self::DigestKey
+        ) -> usize {
+        dk.num_rounds()
+    }
+
     fn encrypt<R: CryptoRng + RngCore>(
         ek: &Self::EncryptionKey,
         rng: &mut R,

--- a/crates/aptos-batch-encryption/src/schemes/fptx_weighted.rs
+++ b/crates/aptos-batch-encryption/src/schemes/fptx_weighted.rs
@@ -325,15 +325,11 @@ impl BatchThresholdEncryption for FPTXWeighted {
         Ok((ek, digest_key, vks, msk_shares))
     }
 
-    fn max_batch_size(
-            dk: &Self::DigestKey
-        ) -> usize {
+    fn max_batch_size(dk: &Self::DigestKey) -> usize {
         dk.max_batch_size()
     }
 
-    fn num_rounds(
-            dk: &Self::DigestKey
-        ) -> usize {
+    fn num_rounds(dk: &Self::DigestKey) -> usize {
         dk.num_rounds()
     }
 

--- a/crates/aptos-batch-encryption/src/schemes/fptx_weighted.rs
+++ b/crates/aptos-batch-encryption/src/schemes/fptx_weighted.rs
@@ -325,6 +325,18 @@ impl BatchThresholdEncryption for FPTXWeighted {
         Ok((ek, digest_key, vks, msk_shares))
     }
 
+    fn max_batch_size(
+            dk: &Self::DigestKey
+        ) -> usize {
+        dk.max_batch_size()
+    }
+
+    fn num_rounds(
+            dk: &Self::DigestKey
+        ) -> usize {
+        dk.num_rounds()
+    }
+
     fn encrypt<R: CryptoRng + RngCore>(
         ek: &Self::EncryptionKey,
         rng: &mut R,

--- a/crates/aptos-batch-encryption/src/tests/smoke/fptx_smoke.rs
+++ b/crates/aptos-batch-encryption/src/tests/smoke/fptx_smoke.rs
@@ -16,6 +16,6 @@ fn smoke_with_setup_for_testing() {
     let (ek, dk, vks, msk_shares) = FPTX::setup_for_testing(rng.r#gen(), 8, 1, &tc).unwrap();
     run_smoke_single_round::<FPTX>(tc, ek, dk, vks, msk_shares);
 
-    let (ek, dk, vks, msk_shares) = FPTX::setup_for_testing(rng.r#gen(), 8, 1, &tc).unwrap();
+    let (ek, dk, vks, msk_shares) = FPTX::setup_for_testing(rng.r#gen(), 8, 2, &tc).unwrap();
     run_smoke_all_rounds::<FPTX>(tc, ek, dk, vks, msk_shares);
 }

--- a/crates/aptos-batch-encryption/src/tests/smoke/fptx_smoke.rs
+++ b/crates/aptos-batch-encryption/src/tests/smoke/fptx_smoke.rs
@@ -1,6 +1,6 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
-use crate::{schemes::fptx::FPTX, tests::smoke::run_smoke, traits::BatchThresholdEncryption};
+use crate::{schemes::fptx::FPTX, tests::smoke::{run_smoke_all_rounds, run_smoke_single_round}, traits::BatchThresholdEncryption};
 use aptos_crypto::arkworks::shamir::ShamirThresholdConfig;
 use ark_std::rand::{thread_rng, Rng as _};
 
@@ -10,6 +10,8 @@ fn smoke_with_setup_for_testing() {
     let tc = ShamirThresholdConfig::new(3, 8);
 
     let (ek, dk, vks, msk_shares) = FPTX::setup_for_testing(rng.r#gen(), 8, 1, &tc).unwrap();
+    run_smoke_single_round::<FPTX>(tc, ek, dk, vks, msk_shares);
 
-    run_smoke::<FPTX>(tc, ek, dk, vks, msk_shares);
+    let (ek, dk, vks, msk_shares) = FPTX::setup_for_testing(rng.r#gen(), 8, 1, &tc).unwrap();
+    run_smoke_all_rounds::<FPTX>(tc, ek, dk, vks, msk_shares);
 }

--- a/crates/aptos-batch-encryption/src/tests/smoke/fptx_smoke.rs
+++ b/crates/aptos-batch-encryption/src/tests/smoke/fptx_smoke.rs
@@ -1,6 +1,10 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
-use crate::{schemes::fptx::FPTX, tests::smoke::{run_smoke_all_rounds, run_smoke_single_round}, traits::BatchThresholdEncryption};
+use crate::{
+    schemes::fptx::FPTX,
+    tests::smoke::{run_smoke_all_rounds, run_smoke_single_round},
+    traits::BatchThresholdEncryption,
+};
 use aptos_crypto::arkworks::shamir::ShamirThresholdConfig;
 use ark_std::rand::{thread_rng, Rng as _};
 

--- a/crates/aptos-batch-encryption/src/tests/smoke/fptx_succinct_smoke.rs
+++ b/crates/aptos-batch-encryption/src/tests/smoke/fptx_succinct_smoke.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 use crate::{
-    schemes::fptx_succinct::FPTXSuccinct, tests::smoke::run_smoke, traits::BatchThresholdEncryption,
+    schemes::fptx_succinct::FPTXSuccinct, tests::smoke::run_smoke_single_round, traits::BatchThresholdEncryption,
 };
 use aptos_crypto::arkworks::shamir::ShamirThresholdConfig;
 use ark_std::rand::{thread_rng, Rng as _};
@@ -14,5 +14,5 @@ fn smoke_with_setup_for_testing() {
     let (ek, dk, vks, msk_shares) =
         FPTXSuccinct::setup_for_testing(rng.r#gen(), 8, 1, &tc).unwrap();
 
-    run_smoke::<FPTXSuccinct>(tc, ek, dk, vks, msk_shares);
+    run_smoke_single_round::<FPTXSuccinct>(tc, ek, dk, vks, msk_shares);
 }

--- a/crates/aptos-batch-encryption/src/tests/smoke/fptx_succinct_smoke.rs
+++ b/crates/aptos-batch-encryption/src/tests/smoke/fptx_succinct_smoke.rs
@@ -1,7 +1,8 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 use crate::{
-    schemes::fptx_succinct::FPTXSuccinct, tests::smoke::run_smoke_single_round, traits::BatchThresholdEncryption,
+    schemes::fptx_succinct::FPTXSuccinct, tests::smoke::run_smoke_single_round,
+    traits::BatchThresholdEncryption,
 };
 use aptos_crypto::arkworks::shamir::ShamirThresholdConfig;
 use ark_std::rand::{thread_rng, Rng as _};

--- a/crates/aptos-batch-encryption/src/tests/smoke/fptx_weighted_smoke.rs
+++ b/crates/aptos-batch-encryption/src/tests/smoke/fptx_weighted_smoke.rs
@@ -2,11 +2,14 @@
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 #[cfg(test)]
-use crate::tests::smoke::{run_smoke_single_round, run_smoke_all_rounds};
+use crate::tests::smoke::{run_smoke_all_rounds, run_smoke_single_round};
 use crate::{
-    group::{Fr, G1Affine, G2Affine, Pairing}, schemes::fptx_weighted::{
+    group::{Fr, G1Affine, G2Affine, Pairing},
+    schemes::fptx_weighted::{
         FPTXWeighted, WeightedBIBEMasterSecretKeyShare, WeightedBIBEVerificationKey,
-    }, shared::{digest::DigestKey, encryption_key::EncryptionKey}, traits::BatchThresholdEncryption
+    },
+    shared::{digest::DigestKey, encryption_key::EncryptionKey},
+    traits::BatchThresholdEncryption,
 };
 use aptos_crypto::{
     arkworks::{srs::SrsType, GroupGenerators},

--- a/crates/aptos-batch-encryption/src/tests/smoke/fptx_weighted_smoke.rs
+++ b/crates/aptos-batch-encryption/src/tests/smoke/fptx_weighted_smoke.rs
@@ -2,14 +2,11 @@
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 #[cfg(test)]
-use crate::tests::smoke::run_smoke;
+use crate::tests::smoke::{run_smoke_single_round, run_smoke_all_rounds};
 use crate::{
-    group::{Fr, G1Affine, G2Affine, Pairing},
-    schemes::fptx_weighted::{
+    group::{Fr, G1Affine, G2Affine, Pairing}, schemes::fptx_weighted::{
         FPTXWeighted, WeightedBIBEMasterSecretKeyShare, WeightedBIBEVerificationKey,
-    },
-    shared::{digest::DigestKey, encryption_key::EncryptionKey},
-    traits::BatchThresholdEncryption,
+    }, shared::{digest::DigestKey, encryption_key::EncryptionKey}, traits::BatchThresholdEncryption
 };
 use aptos_crypto::{
     arkworks::{srs::SrsType, GroupGenerators},
@@ -150,7 +147,7 @@ fn weighted_smoke_with_setup_for_testing() {
     let (ek, dk, vks, msk_shares) =
         FPTXWeighted::setup_for_testing(rng.r#gen(), 8, 1, &tc).unwrap();
 
-    run_smoke::<FPTXWeighted>(tc, ek, dk, vks, msk_shares);
+    run_smoke_single_round::<FPTXWeighted>(tc, ek, dk, vks, msk_shares);
 }
 
 type T = aptos_dkg::pvss::chunky::SignedWeightedTranscript<crate::group::Pairing>;
@@ -168,5 +165,10 @@ fn weighted_smoke_with_pvss() {
     let dk = DigestKey::new(&mut thread_rng(), 8, 1).unwrap();
     let (_, tc, ek, vks, msk_shares) = run_pvss(&dk);
 
-    run_smoke::<FPTXWeighted>(tc, ek, dk, vks, msk_shares);
+    run_smoke_single_round::<FPTXWeighted>(tc, ek, dk, vks, msk_shares);
+
+    let dk = DigestKey::new(&mut thread_rng(), 8, 2).unwrap();
+    let (_, tc, ek, vks, msk_shares) = run_pvss(&dk);
+
+    run_smoke_all_rounds::<FPTXWeighted>(tc, ek, dk, vks, msk_shares);
 }

--- a/crates/aptos-batch-encryption/src/tests/smoke/mod.rs
+++ b/crates/aptos-batch-encryption/src/tests/smoke/mod.rs
@@ -86,12 +86,12 @@ fn do_decryption<Scheme: BatchThresholdEncryption, P: Plaintext>(
     let mut rng_aptos = rand::thread_rng();
 
     let (d, pfs_promise) = Scheme::digest(dk, cts, round).unwrap();
-    let pfs = Scheme::eval_proofs_compute_all(&pfs_promise, &dk);
+    let pfs = Scheme::eval_proofs_compute_all(&pfs_promise, dk);
 
     let dk_shares: Vec<<Scheme as BatchThresholdEncryption>::DecryptionKeyShare> = msk_shares
-        .into_iter()
+        .iter()
         .map(|msk_share| {
-            <Scheme as BatchThresholdEncryption>::derive_decryption_key_share(&msk_share, &d)
+            <Scheme as BatchThresholdEncryption>::derive_decryption_key_share(msk_share, &d)
                 .unwrap()
         })
         .collect();
@@ -115,9 +115,9 @@ fn do_decryption<Scheme: BatchThresholdEncryption, P: Plaintext>(
         })
         .collect();
 
-    let dk = Scheme::reconstruct_decryption_key(&eligible_share_subset, &tc).unwrap();
+    let dk = Scheme::reconstruct_decryption_key(&eligible_share_subset, tc).unwrap();
 
-    <Scheme as BatchThresholdEncryption>::verify_decryption_key(&ek, &d, &dk).unwrap();
+    <Scheme as BatchThresholdEncryption>::verify_decryption_key(ek, &d, &dk).unwrap();
 
     let prepared_cts = cts.into_par_iter()
         .map(|ct| <Scheme as BatchThresholdEncryption>::prepare_ct(ct, &d, &pfs))

--- a/crates/aptos-batch-encryption/src/tests/smoke/mod.rs
+++ b/crates/aptos-batch-encryption/src/tests/smoke/mod.rs
@@ -1,9 +1,10 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-use crate::traits::{BatchThresholdEncryption, DecryptionKeyShare};
+use crate::{errors::MissingEvalProofError, traits::{BatchThresholdEncryption, DecryptionKeyShare, Plaintext}};
 use anyhow::Result;
 use aptos_crypto::TSecretSharingConfig;
+use rayon::iter::{IntoParallelIterator, ParallelIterator};
 
 #[cfg(test)]
 pub mod fptx_smoke;
@@ -11,7 +12,8 @@ pub mod fptx_smoke;
 pub mod fptx_succinct_smoke;
 pub mod fptx_weighted_smoke;
 
-pub fn run_smoke<Scheme: BatchThresholdEncryption>(
+
+pub fn run_smoke_all_rounds<Scheme: BatchThresholdEncryption>(
     tc: <Scheme as BatchThresholdEncryption>::ThresholdConfig,
     ek: <Scheme as BatchThresholdEncryption>::EncryptionKey,
     dk: <Scheme as BatchThresholdEncryption>::DigestKey,
@@ -19,7 +21,41 @@ pub fn run_smoke<Scheme: BatchThresholdEncryption>(
     msk_shares: Vec<<Scheme as BatchThresholdEncryption>::MasterSecretKeyShare>,
 ) {
     let mut rng_arkworks = ark_std::rand::thread_rng();
-    let mut rng_aptos = rand::thread_rng();
+
+    let plaintext: String = String::from("hi");
+    let associated_data: String = String::from("hi");
+
+    for round in 0..Scheme::num_rounds(&dk) {
+        // Test a decryption round w/ 1 CT
+        let ct = Scheme::encrypt(&ek, &mut rng_arkworks, &plaintext, &associated_data).unwrap();
+        Scheme::verify_ct(&ct, &associated_data).unwrap();
+        let (_, _, _, decrypted_plaintexts) = do_decryption::<Scheme, String>(&tc, &ek, &dk, &vks, &msk_shares, std::slice::from_ref(&ct), round as u64);
+        assert_eq!(decrypted_plaintexts[0], plaintext);
+
+        // Test a decryption round w/ B CTs
+        let cts = (0..Scheme::max_batch_size(&dk))
+            .map(|_| Scheme::encrypt(&ek, &mut rng_arkworks, &plaintext, &associated_data).unwrap())
+            .collect::<Vec<Scheme::Ciphertext>>();
+
+        let (_, _, _, decrypted_plaintexts) = do_decryption::<Scheme, String>(&tc, &ek, &dk, &vks, &msk_shares, &cts, round as u64);
+
+        for i in 0..cts.len() {
+            Scheme::verify_ct(&cts[i], &associated_data).unwrap();
+            assert_eq!(decrypted_plaintexts[i], plaintext);
+        }
+    }
+
+    // note: skips individual decryption verification so that the test runs faster
+}
+
+pub fn run_smoke_single_round<Scheme: BatchThresholdEncryption>(
+    tc: <Scheme as BatchThresholdEncryption>::ThresholdConfig,
+    ek: <Scheme as BatchThresholdEncryption>::EncryptionKey,
+    dk: <Scheme as BatchThresholdEncryption>::DigestKey,
+    vks: Vec<<Scheme as BatchThresholdEncryption>::VerificationKey>,
+    msk_shares: Vec<<Scheme as BatchThresholdEncryption>::MasterSecretKeyShare>,
+) {
+    let mut rng_arkworks = ark_std::rand::thread_rng();
 
     let plaintext: String = String::from("hi");
     let associated_data: String = String::from("hi");
@@ -27,7 +63,29 @@ pub fn run_smoke<Scheme: BatchThresholdEncryption>(
     let ct = Scheme::encrypt(&ek, &mut rng_arkworks, &plaintext, &associated_data).unwrap();
     Scheme::verify_ct(&ct, &associated_data).unwrap();
 
-    let (d, pfs_promise) = Scheme::digest(&dk, std::slice::from_ref(&ct), 0).unwrap();
+    let (dk, d, pfs, decrypted_plaintexts) = do_decryption::<Scheme, String>(&tc, &ek, &dk, &vks, &msk_shares, std::slice::from_ref(&ct), 0);
+
+    assert_eq!(decrypted_plaintexts[0], plaintext);
+
+    // Test decryption verification
+    let eval_proof = Scheme::eval_proof_for_ct(&pfs, &ct).unwrap();
+    let individual_decrypted_plaintext: String =
+        Scheme::decrypt_slow(&dk, &ct, &d, &eval_proof).unwrap();
+    assert_eq!(individual_decrypted_plaintext, plaintext);
+}
+
+fn do_decryption<Scheme: BatchThresholdEncryption, P: Plaintext>(
+    tc: &<Scheme as BatchThresholdEncryption>::ThresholdConfig,
+    ek: &<Scheme as BatchThresholdEncryption>::EncryptionKey,
+    dk: &<Scheme as BatchThresholdEncryption>::DigestKey,
+    vks: &Vec<<Scheme as BatchThresholdEncryption>::VerificationKey>,
+    msk_shares: &Vec<<Scheme as BatchThresholdEncryption>::MasterSecretKeyShare>,
+    cts: &[Scheme::Ciphertext],
+    round: u64,
+) -> (Scheme::DecryptionKey, Scheme::Digest, Scheme::EvalProofs, Vec<P>) {
+    let mut rng_aptos = rand::thread_rng();
+
+    let (d, pfs_promise) = Scheme::digest(dk, cts, round).unwrap();
     let pfs = Scheme::eval_proofs_compute_all(&pfs_promise, &dk);
 
     let dk_shares: Vec<<Scheme as BatchThresholdEncryption>::DecryptionKeyShare> = msk_shares
@@ -40,7 +98,7 @@ pub fn run_smoke<Scheme: BatchThresholdEncryption>(
 
     dk_shares
         .iter()
-        .zip(&vks)
+        .zip(vks)
         .map(|(dk_share, vk)| Scheme::verify_decryption_key_share(vk, &d, dk_share))
         .collect::<Result<Vec<()>>>()
         .unwrap();
@@ -61,17 +119,21 @@ pub fn run_smoke<Scheme: BatchThresholdEncryption>(
 
     <Scheme as BatchThresholdEncryption>::verify_decryption_key(&ek, &d, &dk).unwrap();
 
-    let decrypted_plaintext: String = Scheme::decrypt(
-        &dk,
-        &<Scheme as BatchThresholdEncryption>::prepare_ct(&ct, &d, &pfs).unwrap(),
+    let prepared_cts = cts.into_par_iter()
+        .map(|ct| <Scheme as BatchThresholdEncryption>::prepare_ct(ct, &d, &pfs))
+        .collect::<Result<Vec<Scheme::PreparedCiphertext>, MissingEvalProofError>>()
+        .unwrap();
+
+    let plaintexts =
+        prepared_cts.into_par_iter()
+            .map(|prepared_ct| Scheme::decrypt(&dk, &prepared_ct))
+            .collect::<Result<Vec<P>>>()
+            .unwrap();
+
+    (
+        dk,
+        d,
+        pfs,
+        plaintexts
     )
-    .unwrap();
-
-    assert_eq!(decrypted_plaintext, plaintext);
-
-    // Test decryption verification
-    let eval_proof = Scheme::eval_proof_for_ct(&pfs, &ct).unwrap();
-    let individual_decrypted_plaintext: String =
-        Scheme::decrypt_slow(&dk, &ct, &d, &eval_proof).unwrap();
-    assert_eq!(individual_decrypted_plaintext, plaintext);
 }

--- a/crates/aptos-batch-encryption/src/tests/smoke/mod.rs
+++ b/crates/aptos-batch-encryption/src/tests/smoke/mod.rs
@@ -1,7 +1,10 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-use crate::{errors::MissingEvalProofError, traits::{BatchThresholdEncryption, DecryptionKeyShare, Plaintext}};
+use crate::{
+    errors::MissingEvalProofError,
+    traits::{BatchThresholdEncryption, DecryptionKeyShare, Plaintext},
+};
 use anyhow::Result;
 use aptos_crypto::TSecretSharingConfig;
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
@@ -11,7 +14,6 @@ pub mod fptx_smoke;
 #[cfg(test)]
 pub mod fptx_succinct_smoke;
 pub mod fptx_weighted_smoke;
-
 
 pub fn run_smoke_all_rounds<Scheme: BatchThresholdEncryption>(
     tc: <Scheme as BatchThresholdEncryption>::ThresholdConfig,
@@ -29,7 +31,15 @@ pub fn run_smoke_all_rounds<Scheme: BatchThresholdEncryption>(
         // Test a decryption round w/ 1 CT
         let ct = Scheme::encrypt(&ek, &mut rng_arkworks, &plaintext, &associated_data).unwrap();
         Scheme::verify_ct(&ct, &associated_data).unwrap();
-        let (_, _, _, decrypted_plaintexts) = do_decryption::<Scheme, String>(&tc, &ek, &dk, &vks, &msk_shares, std::slice::from_ref(&ct), round as u64);
+        let (_, _, _, decrypted_plaintexts) = do_decryption::<Scheme, String>(
+            &tc,
+            &ek,
+            &dk,
+            &vks,
+            &msk_shares,
+            std::slice::from_ref(&ct),
+            round as u64,
+        );
         assert_eq!(decrypted_plaintexts[0], plaintext);
 
         // Test a decryption round w/ B CTs
@@ -37,7 +47,8 @@ pub fn run_smoke_all_rounds<Scheme: BatchThresholdEncryption>(
             .map(|_| Scheme::encrypt(&ek, &mut rng_arkworks, &plaintext, &associated_data).unwrap())
             .collect::<Vec<Scheme::Ciphertext>>();
 
-        let (_, _, _, decrypted_plaintexts) = do_decryption::<Scheme, String>(&tc, &ek, &dk, &vks, &msk_shares, &cts, round as u64);
+        let (_, _, _, decrypted_plaintexts) =
+            do_decryption::<Scheme, String>(&tc, &ek, &dk, &vks, &msk_shares, &cts, round as u64);
 
         for i in 0..cts.len() {
             Scheme::verify_ct(&cts[i], &associated_data).unwrap();
@@ -63,7 +74,15 @@ pub fn run_smoke_single_round<Scheme: BatchThresholdEncryption>(
     let ct = Scheme::encrypt(&ek, &mut rng_arkworks, &plaintext, &associated_data).unwrap();
     Scheme::verify_ct(&ct, &associated_data).unwrap();
 
-    let (dk, d, pfs, decrypted_plaintexts) = do_decryption::<Scheme, String>(&tc, &ek, &dk, &vks, &msk_shares, std::slice::from_ref(&ct), 0);
+    let (dk, d, pfs, decrypted_plaintexts) = do_decryption::<Scheme, String>(
+        &tc,
+        &ek,
+        &dk,
+        &vks,
+        &msk_shares,
+        std::slice::from_ref(&ct),
+        0,
+    );
 
     assert_eq!(decrypted_plaintexts[0], plaintext);
 
@@ -78,11 +97,16 @@ fn do_decryption<Scheme: BatchThresholdEncryption, P: Plaintext>(
     tc: &<Scheme as BatchThresholdEncryption>::ThresholdConfig,
     ek: &<Scheme as BatchThresholdEncryption>::EncryptionKey,
     dk: &<Scheme as BatchThresholdEncryption>::DigestKey,
-    vks: &Vec<<Scheme as BatchThresholdEncryption>::VerificationKey>,
-    msk_shares: &Vec<<Scheme as BatchThresholdEncryption>::MasterSecretKeyShare>,
+    vks: &[<Scheme as BatchThresholdEncryption>::VerificationKey],
+    msk_shares: &[<Scheme as BatchThresholdEncryption>::MasterSecretKeyShare],
     cts: &[Scheme::Ciphertext],
     round: u64,
-) -> (Scheme::DecryptionKey, Scheme::Digest, Scheme::EvalProofs, Vec<P>) {
+) -> (
+    Scheme::DecryptionKey,
+    Scheme::Digest,
+    Scheme::EvalProofs,
+    Vec<P>,
+) {
     let mut rng_aptos = rand::thread_rng();
 
     let (d, pfs_promise) = Scheme::digest(dk, cts, round).unwrap();
@@ -119,21 +143,17 @@ fn do_decryption<Scheme: BatchThresholdEncryption, P: Plaintext>(
 
     <Scheme as BatchThresholdEncryption>::verify_decryption_key(ek, &d, &dk).unwrap();
 
-    let prepared_cts = cts.into_par_iter()
+    let prepared_cts = cts
+        .into_par_iter()
         .map(|ct| <Scheme as BatchThresholdEncryption>::prepare_ct(ct, &d, &pfs))
         .collect::<Result<Vec<Scheme::PreparedCiphertext>, MissingEvalProofError>>()
         .unwrap();
 
-    let plaintexts =
-        prepared_cts.into_par_iter()
-            .map(|prepared_ct| Scheme::decrypt(&dk, &prepared_ct))
-            .collect::<Result<Vec<P>>>()
-            .unwrap();
+    let plaintexts = prepared_cts
+        .into_par_iter()
+        .map(|prepared_ct| Scheme::decrypt(&dk, &prepared_ct))
+        .collect::<Result<Vec<P>>>()
+        .unwrap();
 
-    (
-        dk,
-        d,
-        pfs,
-        plaintexts
-    )
+    (dk, d, pfs, plaintexts)
 }

--- a/crates/aptos-batch-encryption/src/traits.rs
+++ b/crates/aptos-batch-encryption/src/traits.rs
@@ -105,6 +105,17 @@ pub trait BatchThresholdEncryption {
         Vec<Self::MasterSecretKeyShare>,
     )>;
 
+    /// Gets the max batch size that the given digest key supports.
+    fn max_batch_size(
+        dk: &Self::DigestKey
+    ) -> usize;
+
+
+    /// Gets the number of rounds that the given digest key supports.
+    fn num_rounds(
+        dk: &Self::DigestKey
+    ) -> usize;
+
     /// Encrypt a plaintext with respect to any arbitrary associated data. This associated data is
     /// "bound" to the resulting CT, such that it will only verify with respect to the same
     /// associated data.

--- a/crates/aptos-batch-encryption/src/traits.rs
+++ b/crates/aptos-batch-encryption/src/traits.rs
@@ -106,15 +106,10 @@ pub trait BatchThresholdEncryption {
     )>;
 
     /// Gets the max batch size that the given digest key supports.
-    fn max_batch_size(
-        dk: &Self::DigestKey
-    ) -> usize;
-
+    fn max_batch_size(dk: &Self::DigestKey) -> usize;
 
     /// Gets the number of rounds that the given digest key supports.
-    fn num_rounds(
-        dk: &Self::DigestKey
-    ) -> usize;
+    fn num_rounds(dk: &Self::DigestKey) -> usize;
 
     /// Encrypt a plaintext with respect to any arbitrary associated data. This associated data is
     /// "bound" to the resulting CT, such that it will only verify with respect to the same


### PR DESCRIPTION
* Adds `num_rounds(dk: Scheme::DigestKey)` and `max_batch_size(dk: Scheme::DigestKey)` methods to `BatchThresholdEncryption` trait, so that users can generically query these two params
* Adds smoke test that tests all rounds of a given digest key instead of just a single round. Going to use this to test the ceremony output.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new required methods on the `BatchThresholdEncryption` trait, forcing all implementers to update; smoke tests now exercise multiple rounds and full-batch decryption, which may increase test runtime and expose latent round-dependent bugs.
> 
> **Overview**
> **Extends `BatchThresholdEncryption` with digest-key capability queries.** Adds required `max_batch_size()` and `num_rounds()` methods and implements them for `FPTX`, `FPTXSuccinct`, and `FPTXWeighted` by delegating to `DigestKey`.
> 
> **Refactors smoke tests to cover all digest rounds and batch sizes.** Replaces the single `run_smoke` helper with `run_smoke_single_round` plus a new `run_smoke_all_rounds` that iterates `0..num_rounds`, tests both single-CT and max-batch decryption, and parallelizes prepare/decrypt over ciphertexts via `rayon`; scheme smoke tests are updated to invoke the appropriate helpers (including new multi-round cases for `FPTX` and weighted PVSS).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40a4e29a3cdaf8e44df40c88c6fa150695a59d08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->