### PR TITLE
[trading-native][storage-core] Extract ShardedJmtMerkleDb substrate from state_merkle_db

### DIFF
--- a/storage/aptosdb/src/lib.rs
+++ b/storage/aptosdb/src/lib.rs
@@ -32,6 +32,7 @@ mod event_store;
 mod ledger_db;
 mod lru_node_cache;
 mod pruner;
+mod sharded_jmt_merkle_db;
 mod state_kv_db;
 mod state_merkle_db;
 mod state_store;

--- a/storage/aptosdb/src/sharded_jmt_merkle_db.rs
+++ b/storage/aptosdb/src/sharded_jmt_merkle_db.rs
@@ -1,0 +1,650 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Shared sharded JMT merkle DB substrate.
+//!
+//! Holds the 16-shard RocksDB layout + a separate metadata DB for the
+//! top-level (non-sharded) JMT nodes, plus the two cache layers
+//! (`VersionedNodeCache` per shard + per-top-level, optional `LruNodeCache`).
+//!
+//! All JMT-side operations live here:
+//! `batch_put_value_set_for_shard`, `merklize_value_set_for_shard`,
+//! `calculate_top_levels`, `commit`, `create_jmt_commit_batch_for_shard`,
+//! plus `TreeReader<StateKey>` / `TreeWriter<StateKey>` impls.
+//!
+//! Domain-specific concerns — how the shard/metadata RocksDB
+//! instances are opened (paths, CFDs, hot/cold split, truncation-on-startup),
+//! checkpoint creation, and the metrics tag used for per-tree timer
+//! labels — are left to outer wrappers that compose this substrate.
+
+use crate::{
+    lru_node_cache::LruNodeCache,
+    metrics::{NODE_CACHE_SECONDS, OTHER_TIMERS_SECONDS},
+    schema::{
+        db_metadata::{DbMetadataKey, DbMetadataSchema, DbMetadataValue},
+        jellyfish_merkle_node::JellyfishMerkleNodeSchema,
+        stale_node_index::StaleNodeIndexSchema,
+        stale_node_index_cross_epoch::StaleNodeIndexCrossEpochSchema,
+    },
+    versioned_node_cache::VersionedNodeCache,
+};
+use aptos_crypto::HashValue;
+use aptos_experimental_runtimes::thread_manager::THREAD_MANAGER;
+use aptos_jellyfish_merkle::{
+    node_type::NodeKey, JellyfishMerkleTree, TreeReader, TreeUpdateBatch, TreeWriter,
+};
+use aptos_logger::info;
+use aptos_metrics_core::TimerHelper;
+use aptos_schemadb::{
+    batch::{IntoRawBatch, RawBatch, SchemaBatch, WriteBatch},
+    DB,
+};
+#[cfg(test)]
+use aptos_scratchpad::get_state_shard_id;
+use aptos_storage_interface::{db_ensure as ensure, AptosDbError, Result};
+use aptos_types::{
+    nibble::{nibble_path::NibblePath, ROOT_NIBBLE_HEIGHT},
+    proof::{SparseMerkleProofExt, SparseMerkleRangeProof},
+    state_store::{state_key::StateKey, NUM_STATE_SHARDS},
+    transaction::Version,
+};
+use rayon::prelude::*;
+use std::{collections::HashMap, sync::Arc, time::Instant};
+
+pub(crate) type LeafNode = aptos_jellyfish_merkle::node_type::LeafNode<StateKey>;
+pub(crate) type Node = aptos_jellyfish_merkle::node_type::Node<StateKey>;
+type NodeBatch = aptos_jellyfish_merkle::NodeBatch<StateKey>;
+
+/// Sharded JMT merkle DB substrate. See module docs.
+#[derive(Debug)]
+pub struct ShardedJmtMerkleDb {
+    /// Stores metadata and top levels (non-sharded part) of tree nodes.
+    metadata_db: Arc<DB>,
+    /// Stores sharded part of tree nodes.
+    shards: [Arc<DB>; NUM_STATE_SHARDS],
+    /// shard_id -> cache. `None` key is the top-levels cache.
+    version_caches: HashMap<Option<usize>, VersionedNodeCache>,
+    /// `None` means the LRU cache is disabled.
+    lru_cache: Option<LruNodeCache>,
+    /// Metrics tag for per-tree timer labels (e.g. `"hot"`, `"cold"`, `"position"`).
+    db_tag: &'static str,
+}
+
+impl ShardedJmtMerkleDb {
+    pub(crate) fn new(
+        metadata_db: Arc<DB>,
+        shards: [Arc<DB>; NUM_STATE_SHARDS],
+        max_nodes_per_lru_cache_shard: usize,
+        db_tag: &'static str,
+    ) -> Self {
+        let mut version_caches = HashMap::with_capacity(NUM_STATE_SHARDS + 1);
+        version_caches.insert(None, VersionedNodeCache::new());
+        for i in 0..NUM_STATE_SHARDS {
+            version_caches.insert(Some(i), VersionedNodeCache::new());
+        }
+        let lru_cache =
+            std::num::NonZeroUsize::new(max_nodes_per_lru_cache_shard).map(LruNodeCache::new);
+        Self {
+            metadata_db,
+            shards,
+            version_caches,
+            lru_cache,
+            db_tag,
+        }
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn db_tag(&self) -> &'static str {
+        self.db_tag
+    }
+
+    pub(crate) fn metadata_db(&self) -> &DB {
+        &self.metadata_db
+    }
+
+    pub(crate) fn metadata_db_arc(&self) -> Arc<DB> {
+        Arc::clone(&self.metadata_db)
+    }
+
+    pub(crate) fn db_shard(&self, shard_id: usize) -> &DB {
+        &self.shards[shard_id]
+    }
+
+    pub(crate) fn db_shard_arc(&self, shard_id: usize) -> Arc<DB> {
+        Arc::clone(&self.shards[shard_id])
+    }
+
+    pub(crate) fn db(&self, shard_id: Option<usize>) -> &DB {
+        if let Some(shard_id) = shard_id {
+            self.db_shard(shard_id)
+        } else {
+            self.metadata_db()
+        }
+    }
+
+    pub(crate) fn num_shards(&self) -> usize {
+        NUM_STATE_SHARDS
+    }
+
+    pub(crate) fn cache_enabled(&self) -> bool {
+        self.lru_cache.is_some()
+    }
+
+    pub(crate) fn version_caches(&self) -> &HashMap<Option<usize>, VersionedNodeCache> {
+        &self.version_caches
+    }
+
+    pub(crate) fn lru_cache(&self) -> Option<&LruNodeCache> {
+        self.lru_cache.as_ref()
+    }
+
+    pub(crate) fn commit(
+        &self,
+        version: Version,
+        top_levels_batch: impl IntoRawBatch,
+        batches_for_shards: Vec<impl IntoRawBatch + Send>,
+    ) -> Result<()> {
+        ensure!(
+            batches_for_shards.len() == NUM_STATE_SHARDS,
+            "Shard count mismatch."
+        );
+        THREAD_MANAGER.get_io_pool().install(|| {
+            batches_for_shards
+                .into_par_iter()
+                .enumerate()
+                .for_each(|(shard_id, batch)| {
+                    self.db_shard(shard_id)
+                        .write_schemas(batch)
+                        .unwrap_or_else(|err| {
+                            panic!("Failed to commit state merkle shard {shard_id}: {err}")
+                        });
+                })
+        });
+
+        self.commit_top_levels(version, top_levels_batch)
+    }
+
+    /// Commits JMT node data without writing any commit progress metadata.
+    /// Used by `TreeWriter::write_node_batch` during fast-sync / state
+    /// snapshot restore. Sequential write so that on crash all
+    /// fully-committed shards form a prefix.
+    pub(crate) fn commit_no_progress(
+        &self,
+        top_level_batch: SchemaBatch,
+        batches_for_shards: Vec<SchemaBatch>,
+    ) -> Result<()> {
+        ensure!(
+            batches_for_shards.len() == NUM_STATE_SHARDS,
+            "Shard count mismatch."
+        );
+        let mut batches = batches_for_shards.into_iter();
+        for shard_id in 0..NUM_STATE_SHARDS {
+            let batch = batches.next().unwrap();
+            self.shards[shard_id].write_schemas(batch)?;
+        }
+        self.metadata_db.write_schemas(top_level_batch)
+    }
+
+    pub(crate) fn commit_top_levels(
+        &self,
+        version: Version,
+        batch: impl IntoRawBatch,
+    ) -> Result<()> {
+        info!(
+            version = version,
+            db_tag = self.db_tag,
+            "Committing merkle metadata DB."
+        );
+        self.metadata_db.write_schemas(batch)
+    }
+
+    pub fn get_with_proof_ext(
+        &self,
+        key: &HashValue,
+        version: Version,
+        root_depth: usize,
+    ) -> Result<(
+        Option<(HashValue, (StateKey, Version))>,
+        SparseMerkleProofExt,
+    )> {
+        JellyfishMerkleTree::new(self).get_with_proof_ext(key, version, root_depth)
+    }
+
+    pub fn get_range_proof(
+        &self,
+        rightmost_key: HashValue,
+        version: Version,
+    ) -> Result<SparseMerkleRangeProof> {
+        JellyfishMerkleTree::new(self).get_range_proof(rightmost_key, version)
+    }
+
+    pub fn get_root_hash(&self, version: Version) -> Result<HashValue> {
+        JellyfishMerkleTree::new(self).get_root_hash(version)
+    }
+
+    pub fn get_leaf_count(&self, version: Version) -> Result<usize> {
+        JellyfishMerkleTree::new(self).get_leaf_count(version)
+    }
+
+    pub fn batch_put_value_set_for_shard(
+        &self,
+        shard_id: usize,
+        value_set: Vec<(HashValue, Option<&(HashValue, StateKey)>)>,
+        node_hashes: Option<&HashMap<NibblePath, HashValue>>,
+        persisted_version: Option<Version>,
+        version: Version,
+    ) -> Result<(Node, TreeUpdateBatch<StateKey>)> {
+        JellyfishMerkleTree::new(self).batch_put_value_set_for_shard(
+            shard_id as u8,
+            value_set,
+            node_hashes,
+            persisted_version,
+            version,
+        )
+    }
+
+    pub fn get_state_snapshot_version_before(
+        &self,
+        next_version: Version,
+    ) -> Result<Option<Version>> {
+        if next_version > 0 {
+            let max_possible_version = next_version - 1;
+            let mut iter = self.metadata_db().rev_iter::<JellyfishMerkleNodeSchema>()?;
+            iter.seek_for_prev(&NodeKey::new_empty_path(max_possible_version))?;
+            if let Some((key, _node)) = iter.next().transpose()? {
+                let version = key.version();
+                if self
+                    .metadata_db()
+                    .get::<JellyfishMerkleNodeSchema>(&NodeKey::new_empty_path(version))?
+                    .is_some()
+                {
+                    return Ok(Some(version));
+                }
+                // Since we split state merkle commit into multiple batches, it's possible that
+                // the root is not committed yet. In this case we need to look at the previous
+                // root.
+                return self.get_state_snapshot_version_before(version);
+            }
+        }
+        // No version before genesis.
+        Ok(None)
+    }
+
+    pub(crate) fn create_jmt_commit_batch_for_shard(
+        &self,
+        version: Version,
+        shard_id: Option<usize>,
+        tree_update_batch: &TreeUpdateBatch<StateKey>,
+        previous_epoch_ending_version: Option<Version>,
+    ) -> Result<RawBatch> {
+        let _timer = OTHER_TIMERS_SECONDS.timer_with(&[&format!(
+            "{}__create_jmt_commit_batch_for_shard",
+            self.db_tag
+        )]);
+
+        let mut batch = self.db(shard_id).new_native_batch();
+
+        let node_batch = tree_update_batch
+            .node_batch
+            .iter()
+            .flatten()
+            .collect::<Vec<_>>();
+        node_batch.iter().try_for_each(|(node_key, node)| {
+            ensure!(node_key.get_shard_id() == shard_id, "shard_id mismatch");
+            batch.put::<JellyfishMerkleNodeSchema>(node_key, node)
+        })?;
+
+        let stale_node_index_batch = tree_update_batch
+            .stale_node_index_batch
+            .iter()
+            .flatten()
+            .collect::<Vec<_>>();
+        stale_node_index_batch.iter().try_for_each(|row| {
+            ensure!(row.node_key.get_shard_id() == shard_id, "shard_id mismatch");
+            if previous_epoch_ending_version.is_some()
+                && row.node_key.version() <= previous_epoch_ending_version.unwrap()
+            {
+                batch.put::<StaleNodeIndexCrossEpochSchema>(row, &())
+            } else {
+                // These are processed by the state merkle pruner.
+                batch.put::<StaleNodeIndexSchema>(row, &())
+            }
+        })?;
+
+        Self::put_progress(Some(version), shard_id, &mut batch)?;
+
+        batch.into_raw_batch(self.db(shard_id))
+    }
+
+    pub(crate) fn put_progress(
+        version: Option<Version>,
+        shard_id: Option<usize>,
+        batch: &mut impl WriteBatch,
+    ) -> Result<()> {
+        let key = if let Some(shard_id) = shard_id {
+            DbMetadataKey::StateMerkleShardCommitProgress(shard_id)
+        } else {
+            DbMetadataKey::StateMerkleCommitProgress
+        };
+
+        if let Some(version) = version {
+            batch.put::<DbMetadataSchema>(&key, &DbMetadataValue::Version(version))
+        } else {
+            batch.delete::<DbMetadataSchema>(&key)
+        }
+    }
+
+    /// Test-only helper accepting KV updates from all shards.
+    #[cfg(test)]
+    pub fn merklize_value_set(
+        &self,
+        value_set: Vec<(HashValue, Option<&(HashValue, StateKey)>)>,
+        version: Version,
+        base_version: Option<Version>,
+        previous_epoch_ending_version: Option<Version>,
+    ) -> Result<(RawBatch, Vec<RawBatch>, HashValue)> {
+        let mut sharded_value_set: Vec<Vec<(HashValue, Option<&(HashValue, StateKey)>)>> =
+            Vec::new();
+        sharded_value_set.resize(NUM_STATE_SHARDS, Default::default());
+        value_set.into_iter().for_each(|(k, v)| {
+            sharded_value_set[get_state_shard_id(&k) as usize].push((k, v));
+        });
+
+        let (shard_root_nodes, sharded_batches) = (0..16)
+            .map(|shard_id| {
+                self.merklize_value_set_for_shard(
+                    shard_id,
+                    sharded_value_set[shard_id].clone(),
+                    /*node_hashes=*/ None,
+                    version,
+                    base_version,
+                    base_version,
+                    previous_epoch_ending_version,
+                )
+                .unwrap()
+            })
+            .collect::<Vec<_>>()
+            .into_iter()
+            .unzip();
+
+        let (root_hash, _leaf_count, top_levels_batch) = self.calculate_top_levels(
+            shard_root_nodes,
+            version,
+            base_version,
+            previous_epoch_ending_version,
+        )?;
+
+        Ok((top_levels_batch, sharded_batches, root_hash))
+    }
+
+    /// Calculates db updates for nodes in shard `shard_id`.
+    pub fn merklize_value_set_for_shard(
+        &self,
+        shard_id: usize,
+        value_set: Vec<(HashValue, Option<&(HashValue, StateKey)>)>,
+        node_hashes: Option<&HashMap<NibblePath, HashValue>>,
+        version: Version,
+        base_version: Option<Version>,
+        shard_persisted_version: Option<Version>,
+        previous_epoch_ending_version: Option<Version>,
+    ) -> Result<(Node, RawBatch)> {
+        if let Some(shard_persisted_version) = shard_persisted_version {
+            assert!(shard_persisted_version <= base_version.expect("Must have base version."));
+        }
+
+        let (shard_root_node, tree_update_batch) = {
+            let _timer =
+                OTHER_TIMERS_SECONDS.timer_with(&[&format!("{}__jmt_update", self.db_tag)]);
+
+            self.batch_put_value_set_for_shard(
+                shard_id,
+                value_set,
+                node_hashes,
+                shard_persisted_version,
+                version,
+            )
+        }?;
+
+        if self.cache_enabled() {
+            self.version_caches
+                .get(&Some(shard_id))
+                .unwrap()
+                .add_version(
+                    version,
+                    tree_update_batch
+                        .node_batch
+                        .iter()
+                        .flatten()
+                        .cloned()
+                        .collect(),
+                );
+        }
+
+        let batch = self.create_jmt_commit_batch_for_shard(
+            version,
+            Some(shard_id),
+            &tree_update_batch,
+            previous_epoch_ending_version,
+        )?;
+
+        Ok((shard_root_node, batch))
+    }
+
+    /// Calculates db updates for non-sharded nodes at top levels.
+    pub fn calculate_top_levels(
+        &self,
+        shard_root_nodes: Vec<Node>,
+        version: Version,
+        base_version: Option<Version>,
+        previous_epoch_ending_version: Option<Version>,
+    ) -> Result<(HashValue, usize, RawBatch)> {
+        assert!(shard_root_nodes.len() == 16);
+
+        let (root_hash, leaf_count, tree_update_batch) = JellyfishMerkleTree::new(self)
+            .put_top_levels_nodes(shard_root_nodes, base_version, version)?;
+
+        if self.cache_enabled() {
+            self.version_caches.get(&None).unwrap().add_version(
+                version,
+                tree_update_batch
+                    .node_batch
+                    .iter()
+                    .flatten()
+                    .cloned()
+                    .collect(),
+            );
+        }
+
+        let batch = self.create_jmt_commit_batch_for_shard(
+            version,
+            None,
+            &tree_update_batch,
+            previous_epoch_ending_version,
+        )?;
+
+        Ok((root_hash, leaf_count, batch.into_raw_batch(self.db(None))?))
+    }
+
+    pub(crate) fn get_shard_persisted_versions(
+        &self,
+        root_persisted_version: Option<Version>,
+    ) -> Result<[Option<Version>; NUM_STATE_SHARDS]> {
+        JellyfishMerkleTree::new(self).get_shard_persisted_versions(root_persisted_version)
+    }
+
+    pub(crate) fn write_pruner_progress(
+        &self,
+        progress_key: &DbMetadataKey,
+        version: Version,
+    ) -> Result<()> {
+        self.metadata_db
+            .put::<DbMetadataSchema>(progress_key, &DbMetadataValue::Version(version))
+    }
+
+    fn db_by_key(&self, node_key: &NodeKey) -> &DB {
+        if let Some(shard_id) = node_key.get_shard_id() {
+            self.db_shard(shard_id)
+        } else {
+            self.metadata_db()
+        }
+    }
+
+    /// Finds the rightmost leaf by scanning the entire DB. Test-only.
+    #[cfg(test)]
+    pub fn get_rightmost_leaf_naive(
+        &self,
+        version: Version,
+    ) -> Result<Option<(NodeKey, LeafNode)>> {
+        let mut ret = None;
+        let shards = 0..self.num_shards();
+        let start_num_of_nibbles = 1;
+        for shard_id in shards.rev() {
+            let shard_db = self.shards[shard_id].clone();
+            let mut shard_iter = shard_db.iter::<JellyfishMerkleNodeSchema>()?;
+            shard_iter.seek(&(version, start_num_of_nibbles)).unwrap();
+
+            while let Some((node_key, node)) = shard_iter.next().transpose()? {
+                if let Node::Leaf(leaf_node) = node {
+                    if node_key.version() != version {
+                        break;
+                    }
+                    match ret {
+                        None => ret = Some((node_key, leaf_node)),
+                        Some(ref other) => {
+                            if leaf_node.account_key() > other.1.account_key() {
+                                ret = Some((node_key, leaf_node));
+                            }
+                        },
+                    }
+                }
+            }
+        }
+
+        Ok(ret)
+    }
+
+    fn get_rightmost_leaf_in_single_shard(
+        &self,
+        version: Version,
+        shard_id: usize,
+    ) -> Result<Option<(NodeKey, LeafNode)>> {
+        assert!(
+            shard_id < NUM_STATE_SHARDS,
+            "Invalid shard_id: {}",
+            shard_id
+        );
+        let shard_db = self.shards[shard_id].clone();
+        let mut ret = None;
+
+        for num_nibbles in 0..=ROOT_NIBBLE_HEIGHT {
+            let mut iter = shard_db.iter::<JellyfishMerkleNodeSchema>()?;
+            let seek_key = (version, (num_nibbles + 1) as u8);
+            iter.seek_for_prev(&seek_key)?;
+
+            if let Some((node_key, node)) = iter.next().transpose()? {
+                if node_key.version() != version {
+                    continue;
+                }
+                if let Node::Leaf(leaf_node) = node {
+                    match ret {
+                        None => ret = Some((node_key, leaf_node)),
+                        Some(ref other) => {
+                            if leaf_node.account_key() > other.1.account_key() {
+                                ret = Some((node_key, leaf_node));
+                            }
+                        },
+                    }
+                }
+            }
+        }
+        Ok(ret)
+    }
+}
+
+impl TreeReader<StateKey> for ShardedJmtMerkleDb {
+    fn get_node_option(&self, node_key: &NodeKey, tag: &str) -> Result<Option<Node>> {
+        let start_time = Instant::now();
+        if !self.cache_enabled() {
+            let node_opt = self
+                .db_by_key(node_key)
+                .get::<JellyfishMerkleNodeSchema>(node_key)?;
+            NODE_CACHE_SECONDS.observe_with(
+                &[tag, "cache_disabled", self.db_tag],
+                start_time.elapsed().as_secs_f64(),
+            );
+            return Ok(node_opt);
+        }
+        if let Some(node_cache) = self
+            .version_caches
+            .get(&node_key.get_shard_id())
+            .unwrap()
+            .get_version(node_key.version())
+        {
+            let node = node_cache.get(node_key).cloned();
+            NODE_CACHE_SECONDS.observe_with(
+                &[tag, "versioned_cache_hit", self.db_tag],
+                start_time.elapsed().as_secs_f64(),
+            );
+            return Ok(node);
+        }
+
+        if let Some(lru_cache) = &self.lru_cache {
+            if let Some(node) = lru_cache.get(node_key) {
+                NODE_CACHE_SECONDS.observe_with(
+                    &[tag, "lru_cache_hit", self.db_tag],
+                    start_time.elapsed().as_secs_f64(),
+                );
+                return Ok(Some(node));
+            }
+        }
+
+        let node_opt = self
+            .db_by_key(node_key)
+            .get::<JellyfishMerkleNodeSchema>(node_key)?;
+        if let Some(lru_cache) = &self.lru_cache {
+            if let Some(node) = &node_opt {
+                lru_cache.put(node_key.clone(), node.clone());
+            }
+        }
+        NODE_CACHE_SECONDS.observe_with(
+            &[tag, "cache_miss", self.db_tag],
+            start_time.elapsed().as_secs_f64(),
+        );
+        Ok(node_opt)
+    }
+
+    fn get_rightmost_leaf(&self, version: Version) -> Result<Option<(NodeKey, LeafNode)>> {
+        let ret = None;
+        let shards = 0..NUM_STATE_SHARDS;
+
+        // Search from right to left to find the first leaf node.
+        for shard_id in shards.rev() {
+            if let Some((node_key, leaf_node)) =
+                self.get_rightmost_leaf_in_single_shard(version, shard_id)?
+            {
+                return Ok(Some((node_key, leaf_node)));
+            }
+        }
+
+        Ok(ret)
+    }
+}
+
+impl TreeWriter<StateKey> for ShardedJmtMerkleDb {
+    fn write_node_batch(&self, node_batch: &NodeBatch) -> Result<()> {
+        let _timer = OTHER_TIMERS_SECONDS
+            .timer_with(&[&format!("{}__tree_writer_write_batch", self.db_tag)]);
+        // Get the top level batch and sharded batch from raw NodeBatch
+        let mut top_level_batch = SchemaBatch::new();
+        let mut jmt_shard_batches: Vec<SchemaBatch> = Vec::with_capacity(NUM_STATE_SHARDS);
+        jmt_shard_batches.resize_with(NUM_STATE_SHARDS, SchemaBatch::new);
+        node_batch.iter().try_for_each(|(node_key, node)| {
+            if let Some(shard_id) = node_key.get_shard_id() {
+                jmt_shard_batches[shard_id].put::<JellyfishMerkleNodeSchema>(node_key, node)
+            } else {
+                top_level_batch.put::<JellyfishMerkleNodeSchema>(node_key, node)
+            }
+        })?;
+        self.commit_no_progress(top_level_batch, jmt_shard_batches)
+    }
+}

--- a/storage/aptosdb/src/state_merkle_db.rs
+++ b/storage/aptosdb/src/state_merkle_db.rs
@@ -1,48 +1,42 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
+//! Main-state merkle DB. Thin wrapper around the shared
+//! [`crate::sharded_jmt_merkle_db::ShardedJmtMerkleDb`] substrate that
+//! adds the state-specific bits: opening shards via
+//! `StorageDirPaths::{state,hot_state}_merkle_db_*_root_path`,
+//! hot-vs-cold folder naming, the truncation-on-startup integration,
+//! and `create_checkpoint`.
+//!
+//! `Deref` to `ShardedJmtMerkleDb` so all the JMT/commit/read methods
+//! (commit, merklize_value_set_for_shard, calculate_top_levels,
+//! get_root_hash, etc.) keep working on `&StateMerkleDb` exactly as
+//! before. `TreeReader<StateKey>` / `TreeWriter<StateKey>` are
+//! delegated.
+
+#![forbid(unsafe_code)]
+
+pub(crate) use crate::sharded_jmt_merkle_db::{LeafNode, Node};
 use crate::{
     db_options::gen_state_merkle_cfds,
-    lru_node_cache::LruNodeCache,
-    metrics::{NODE_CACHE_SECONDS, OTHER_TIMERS_SECONDS},
-    schema::{
-        db_metadata::{DbMetadataKey, DbMetadataSchema, DbMetadataValue},
-        jellyfish_merkle_node::JellyfishMerkleNodeSchema,
-        stale_node_index::StaleNodeIndexSchema,
-        stale_node_index_cross_epoch::StaleNodeIndexCrossEpochSchema,
-    },
+    sharded_jmt_merkle_db::ShardedJmtMerkleDb,
     utils::truncation_helper::{get_state_merkle_commit_progress, truncate_state_merkle_db_shards},
-    versioned_node_cache::VersionedNodeCache,
 };
 use aptos_config::config::{RocksdbConfig, StorageDirPaths};
-use aptos_crypto::HashValue;
-use aptos_experimental_runtimes::thread_manager::THREAD_MANAGER;
-use aptos_jellyfish_merkle::{
-    node_type::NodeKey, JellyfishMerkleTree, TreeReader, TreeUpdateBatch, TreeWriter,
-};
+use aptos_jellyfish_merkle::{node_type::NodeKey, TreeReader, TreeWriter};
 use aptos_logger::prelude::*;
-use aptos_metrics_core::TimerHelper;
 use aptos_rocksdb_options::gen_rocksdb_options;
-use aptos_schemadb::{
-    batch::{IntoRawBatch, RawBatch, SchemaBatch, WriteBatch},
-    Cache, Env, DB,
-};
-#[cfg(test)]
-use aptos_scratchpad::get_state_shard_id;
+use aptos_schemadb::{Cache, Env, DB};
 use aptos_storage_interface::{db_ensure as ensure, AptosDbError, Result};
 use aptos_types::{
-    nibble::{nibble_path::NibblePath, ROOT_NIBBLE_HEIGHT},
-    proof::{SparseMerkleProofExt, SparseMerkleRangeProof},
     state_store::{state_key::StateKey, NUM_STATE_SHARDS},
     transaction::Version,
 };
 use rayon::prelude::*;
 use std::{
-    collections::HashMap,
-    num::NonZeroUsize,
+    ops::Deref,
     path::{Path, PathBuf},
     sync::Arc,
-    time::Instant,
 };
 
 fn db_folder_name(is_hot: bool) -> &'static str {
@@ -61,34 +55,23 @@ fn metadata_db_name(is_hot: bool) -> &'static str {
     }
 }
 
-pub(crate) type LeafNode = aptos_jellyfish_merkle::node_type::LeafNode<StateKey>;
-pub(crate) type Node = aptos_jellyfish_merkle::node_type::Node<StateKey>;
-type NodeBatch = aptos_jellyfish_merkle::NodeBatch<StateKey>;
-
 #[derive(Debug)]
 pub struct StateMerkleDb {
-    // Stores metadata and top levels (non-sharded part) of tree nodes.
-    state_merkle_metadata_db: Arc<DB>,
-    // Stores sharded part of tree nodes.
-    state_merkle_db_shards: [Arc<DB>; NUM_STATE_SHARDS],
-    // shard_id -> cache.
-    version_caches: HashMap<Option<usize>, VersionedNodeCache>,
-    // `None` means the cache is not enabled.
-    lru_cache: Option<LruNodeCache>,
+    inner: ShardedJmtMerkleDb,
     is_hot: bool,
+}
+
+impl Deref for StateMerkleDb {
+    type Target = ShardedJmtMerkleDb;
+
+    fn deref(&self) -> &ShardedJmtMerkleDb {
+        &self.inner
+    }
 }
 
 impl StateMerkleDb {
     pub(crate) fn is_hot(&self) -> bool {
         self.is_hot
-    }
-
-    fn db_tag(&self) -> &'static str {
-        if self.is_hot {
-            "hot"
-        } else {
-            "cold"
-        }
     }
 
     pub(crate) fn new(
@@ -108,81 +91,16 @@ impl StateMerkleDb {
             "Only hot state can be cleared on restart"
         );
 
-        let mut version_caches = HashMap::with_capacity(NUM_STATE_SHARDS + 1);
-        version_caches.insert(None, VersionedNodeCache::new());
-        for i in 0..NUM_STATE_SHARDS {
-            version_caches.insert(Some(i), VersionedNodeCache::new());
-        }
-        let lru_cache = NonZeroUsize::new(max_nodes_per_lru_cache_shard).map(LruNodeCache::new);
-
         Self::open(
             db_paths,
             state_merkle_db_config,
             env,
             block_cache,
             readonly,
-            version_caches,
-            lru_cache,
+            max_nodes_per_lru_cache_shard,
             is_hot,
             delete_on_restart,
         )
-    }
-
-    pub(crate) fn commit(
-        &self,
-        version: Version,
-        top_levels_batch: impl IntoRawBatch,
-        batches_for_shards: Vec<impl IntoRawBatch + Send>,
-    ) -> Result<()> {
-        ensure!(
-            batches_for_shards.len() == NUM_STATE_SHARDS,
-            "Shard count mismatch."
-        );
-        THREAD_MANAGER.get_io_pool().install(|| {
-            batches_for_shards
-                .into_par_iter()
-                .enumerate()
-                .for_each(|(shard_id, batch)| {
-                    self.db_shard(shard_id)
-                        .write_schemas(batch)
-                        .unwrap_or_else(|err| {
-                            panic!("Failed to commit state merkle shard {shard_id}: {err}")
-                        });
-                })
-        });
-
-        self.commit_top_levels(version, top_levels_batch)
-    }
-
-    /// Commits JMT node data without writing any commit progress metadata
-    /// (`StateMerkleCommitProgress` / `StateMerkleShardCommitProgress`).
-    ///
-    /// Only used by `TreeWriter::write_node_batch` during fast-sync / state snapshot restore,
-    /// where the caller (JMT restore) writes raw `NodeBatch` data that contains only JMT nodes —
-    /// no progress bookkeeping. Progress is tracked externally by the restore framework instead.
-    ///
-    /// Unlike [`Self::commit`] which writes shards in parallel, this method commits shards
-    /// sequentially from left (shard 0) to right (shard N-1). This is because JMT restore
-    /// processes keys in hash order (left to right), so each `write_node_batch` call contains
-    /// frozen nodes spanning a contiguous range of shards. Sequential left-to-right writes
-    /// ensure that on crash, all fully-committed shards form a prefix, making it
-    /// straightforward to determine a consistent resume point.
-    pub(crate) fn commit_no_progress(
-        &self,
-        top_level_batch: SchemaBatch,
-        batches_for_shards: Vec<SchemaBatch>,
-    ) -> Result<()> {
-        ensure!(
-            batches_for_shards.len() == NUM_STATE_SHARDS,
-            "Shard count mismatch."
-        );
-        let mut batches = batches_for_shards.into_iter();
-        for shard_id in 0..NUM_STATE_SHARDS {
-            let state_merkle_batch = batches.next().unwrap();
-            self.state_merkle_db_shards[shard_id].write_schemas(state_merkle_batch)?;
-        }
-
-        self.state_merkle_metadata_db.write_schemas(top_level_batch)
     }
 
     pub(crate) fn create_checkpoint(
@@ -221,358 +139,13 @@ impl StateMerkleDb {
         Ok(())
     }
 
-    pub(crate) fn metadata_db(&self) -> &DB {
-        &self.state_merkle_metadata_db
-    }
-
-    pub(crate) fn metadata_db_arc(&self) -> Arc<DB> {
-        Arc::clone(&self.state_merkle_metadata_db)
-    }
-
-    pub(crate) fn db_shard(&self, shard_id: usize) -> &DB {
-        &self.state_merkle_db_shards[shard_id]
-    }
-
-    pub(crate) fn db_shard_arc(&self, shard_id: usize) -> Arc<DB> {
-        Arc::clone(&self.state_merkle_db_shards[shard_id])
-    }
-
-    pub(crate) fn db(&self, shard_id: Option<usize>) -> &DB {
-        if let Some(shard_id) = shard_id {
-            self.db_shard(shard_id)
-        } else {
-            self.metadata_db()
-        }
-    }
-
-    pub(crate) fn commit_top_levels(
-        &self,
-        version: Version,
-        batch: impl IntoRawBatch,
-    ) -> Result<()> {
-        info!(version = version, "Committing StateMerkleDb.");
-        self.state_merkle_metadata_db.write_schemas(batch)
-    }
-
-    pub fn get_with_proof_ext(
-        &self,
-        key: &HashValue,
-        version: Version,
-        root_depth: usize,
-    ) -> Result<(
-        Option<(HashValue, (StateKey, Version))>,
-        SparseMerkleProofExt,
-    )> {
-        JellyfishMerkleTree::new(self).get_with_proof_ext(key, version, root_depth)
-    }
-
-    pub fn get_range_proof(
-        &self,
-        rightmost_key: HashValue,
-        version: Version,
-    ) -> Result<SparseMerkleRangeProof> {
-        JellyfishMerkleTree::new(self).get_range_proof(rightmost_key, version)
-    }
-
-    pub fn get_root_hash(&self, version: Version) -> Result<HashValue> {
-        JellyfishMerkleTree::new(self).get_root_hash(version)
-    }
-
-    pub fn get_leaf_count(&self, version: Version) -> Result<usize> {
-        JellyfishMerkleTree::new(self).get_leaf_count(version)
-    }
-
-    pub fn batch_put_value_set_for_shard(
-        &self,
-        shard_id: usize,
-        value_set: Vec<(HashValue, Option<&(HashValue, StateKey)>)>,
-        node_hashes: Option<&HashMap<NibblePath, HashValue>>,
-        persisted_version: Option<Version>,
-        version: Version,
-    ) -> Result<(Node, TreeUpdateBatch<StateKey>)> {
-        JellyfishMerkleTree::new(self).batch_put_value_set_for_shard(
-            shard_id as u8,
-            value_set,
-            node_hashes,
-            persisted_version,
-            version,
-        )
-    }
-
-    pub fn get_state_snapshot_version_before(
-        &self,
-        next_version: Version,
-    ) -> Result<Option<Version>> {
-        if next_version > 0 {
-            let max_possible_version = next_version - 1;
-            let mut iter = self.metadata_db().rev_iter::<JellyfishMerkleNodeSchema>()?;
-            iter.seek_for_prev(&NodeKey::new_empty_path(max_possible_version))?;
-            if let Some((key, _node)) = iter.next().transpose()? {
-                let version = key.version();
-                if self
-                    .metadata_db()
-                    .get::<JellyfishMerkleNodeSchema>(&NodeKey::new_empty_path(version))?
-                    .is_some()
-                {
-                    return Ok(Some(version));
-                }
-                // Since we split state merkle commit into multiple batches, it's possible that
-                // the root is not committed yet. In this case we need to look at the previous
-                // root.
-                return self.get_state_snapshot_version_before(version);
-            }
-        }
-        // No version before genesis.
-        Ok(None)
-    }
-
-    pub(crate) fn create_jmt_commit_batch_for_shard(
-        &self,
-        version: Version,
-        shard_id: Option<usize>,
-        tree_update_batch: &TreeUpdateBatch<StateKey>,
-        previous_epoch_ending_version: Option<Version>,
-    ) -> Result<RawBatch> {
-        let _timer = OTHER_TIMERS_SECONDS.timer_with(&[&format!(
-            "{}__create_jmt_commit_batch_for_shard",
-            self.db_tag()
-        )]);
-
-        let mut batch = self.db(shard_id).new_native_batch();
-
-        let node_batch = tree_update_batch
-            .node_batch
-            .iter()
-            .flatten()
-            .collect::<Vec<_>>();
-        node_batch.iter().try_for_each(|(node_key, node)| {
-            ensure!(node_key.get_shard_id() == shard_id, "shard_id mismatch");
-            batch.put::<JellyfishMerkleNodeSchema>(node_key, node)
-        })?;
-
-        let stale_node_index_batch = tree_update_batch
-            .stale_node_index_batch
-            .iter()
-            .flatten()
-            .collect::<Vec<_>>();
-        stale_node_index_batch.iter().try_for_each(|row| {
-            ensure!(row.node_key.get_shard_id() == shard_id, "shard_id mismatch");
-            if previous_epoch_ending_version.is_some()
-                && row.node_key.version() <= previous_epoch_ending_version.unwrap()
-            {
-                batch.put::<StaleNodeIndexCrossEpochSchema>(row, &())
-            } else {
-                // These are processed by the state merkle pruner.
-                batch.put::<StaleNodeIndexSchema>(row, &())
-            }
-        })?;
-
-        Self::put_progress(Some(version), shard_id, &mut batch)?;
-
-        batch.into_raw_batch(self.db(shard_id))
-    }
-
-    pub(crate) fn put_progress(
-        version: Option<Version>,
-        shard_id: Option<usize>,
-        batch: &mut impl WriteBatch,
-    ) -> Result<()> {
-        let key = if let Some(shard_id) = shard_id {
-            DbMetadataKey::StateMerkleShardCommitProgress(shard_id)
-        } else {
-            DbMetadataKey::StateMerkleCommitProgress
-        };
-
-        if let Some(version) = version {
-            batch.put::<DbMetadataSchema>(&key, &DbMetadataValue::Version(version))
-        } else {
-            batch.delete::<DbMetadataSchema>(&key)
-        }
-    }
-
-    // A non-sharded helper function accepting KV updates from all shards.
-    #[cfg(test)]
-    pub fn merklize_value_set(
-        &self,
-        value_set: Vec<(HashValue, Option<&(HashValue, StateKey)>)>,
-        version: Version,
-        base_version: Option<Version>,
-        previous_epoch_ending_version: Option<Version>,
-    ) -> Result<(RawBatch, Vec<RawBatch>, HashValue)> {
-        let mut sharded_value_set: Vec<Vec<(HashValue, Option<&(HashValue, StateKey)>)>> =
-            Vec::new();
-        sharded_value_set.resize(NUM_STATE_SHARDS, Default::default());
-        value_set.into_iter().for_each(|(k, v)| {
-            sharded_value_set[get_state_shard_id(&k) as usize].push((k, v));
-        });
-
-        let (shard_root_nodes, sharded_batches) = (0..16)
-            .map(|shard_id| {
-                self.merklize_value_set_for_shard(
-                    shard_id,
-                    sharded_value_set[shard_id].clone(),
-                    /*node_hashes=*/ None,
-                    version,
-                    base_version,
-                    base_version,
-                    previous_epoch_ending_version,
-                )
-                .unwrap()
-            })
-            .collect::<Vec<_>>()
-            .into_iter()
-            .unzip();
-
-        let (root_hash, _leaf_count, top_levels_batch) = self.calculate_top_levels(
-            shard_root_nodes,
-            version,
-            base_version,
-            previous_epoch_ending_version,
-        )?;
-
-        Ok((top_levels_batch, sharded_batches, root_hash))
-    }
-
-    /// Calculates db updates for nodes in shard `shard_id`.
-    ///
-    /// Assumes 16 shards in total for now.
-    pub fn merklize_value_set_for_shard(
-        &self,
-        shard_id: usize,
-        value_set: Vec<(HashValue, Option<&(HashValue, StateKey)>)>,
-        node_hashes: Option<&HashMap<NibblePath, HashValue>>,
-        version: Version,
-        base_version: Option<Version>,
-        shard_persisted_version: Option<Version>,
-        previous_epoch_ending_version: Option<Version>,
-    ) -> Result<(Node, RawBatch)> {
-        if let Some(shard_persisted_version) = shard_persisted_version {
-            assert!(shard_persisted_version <= base_version.expect("Must have base version."));
-        }
-
-        let (shard_root_node, tree_update_batch) = {
-            let _timer =
-                OTHER_TIMERS_SECONDS.timer_with(&[&format!("{}__jmt_update", self.db_tag())]);
-
-            self.batch_put_value_set_for_shard(
-                shard_id,
-                value_set,
-                node_hashes,
-                shard_persisted_version,
-                version,
-            )
-        }?;
-
-        if self.cache_enabled() {
-            self.version_caches
-                .get(&Some(shard_id))
-                .unwrap()
-                .add_version(
-                    version,
-                    tree_update_batch
-                        .node_batch
-                        .iter()
-                        .flatten()
-                        .cloned()
-                        .collect(),
-                );
-        }
-
-        let batch = self.create_jmt_commit_batch_for_shard(
-            version,
-            Some(shard_id),
-            &tree_update_batch,
-            previous_epoch_ending_version,
-        )?;
-
-        Ok((shard_root_node, batch))
-    }
-
-    /// Calculates db updates for non-sharded nodes at top levels.
-    ///
-    /// Assumes 16 shards in total for now.
-    pub fn calculate_top_levels(
-        &self,
-        shard_root_nodes: Vec<Node>,
-        version: Version,
-        base_version: Option<Version>,
-        previous_epoch_ending_version: Option<Version>,
-    ) -> Result<(HashValue, usize, RawBatch)> {
-        assert!(shard_root_nodes.len() == 16);
-
-        let (root_hash, leaf_count, tree_update_batch) = JellyfishMerkleTree::new(self)
-            .put_top_levels_nodes(shard_root_nodes, base_version, version)?;
-
-        if self.cache_enabled() {
-            self.version_caches.get(&None).unwrap().add_version(
-                version,
-                tree_update_batch
-                    .node_batch
-                    .iter()
-                    .flatten()
-                    .cloned()
-                    .collect(),
-            );
-        }
-
-        let batch = self.create_jmt_commit_batch_for_shard(
-            version,
-            None,
-            &tree_update_batch,
-            previous_epoch_ending_version,
-        )?;
-
-        Ok((root_hash, leaf_count, batch.into_raw_batch(self.db(None))?))
-    }
-
-    pub(crate) fn get_shard_persisted_versions(
-        &self,
-        root_persisted_version: Option<Version>,
-    ) -> Result<[Option<Version>; NUM_STATE_SHARDS]> {
-        JellyfishMerkleTree::new(self).get_shard_persisted_versions(root_persisted_version)
-    }
-
-    pub(crate) fn cache_enabled(&self) -> bool {
-        self.lru_cache.is_some()
-    }
-
-    pub(crate) fn version_caches(&self) -> &HashMap<Option<usize>, VersionedNodeCache> {
-        &self.version_caches
-    }
-
-    pub(crate) fn lru_cache(&self) -> Option<&LruNodeCache> {
-        self.lru_cache.as_ref()
-    }
-
-    pub(crate) fn write_pruner_progress(
-        &self,
-        progress_key: &DbMetadataKey,
-        version: Version,
-    ) -> Result<()> {
-        self.state_merkle_metadata_db
-            .put::<DbMetadataSchema>(progress_key, &DbMetadataValue::Version(version))
-    }
-
-    pub(crate) fn num_shards(&self) -> usize {
-        NUM_STATE_SHARDS
-    }
-
-    fn db_by_key(&self, node_key: &NodeKey) -> &DB {
-        if let Some(shard_id) = node_key.get_shard_id() {
-            self.db_shard(shard_id)
-        } else {
-            self.metadata_db()
-        }
-    }
-
     fn open(
         db_paths: &StorageDirPaths,
         state_merkle_db_config: RocksdbConfig,
         env: Option<&Env>,
         block_cache: Option<&Cache>,
         readonly: bool,
-        version_caches: HashMap<Option<usize>, VersionedNodeCache>,
-        lru_cache: Option<LruNodeCache>,
+        max_nodes_per_lru_cache_shard: usize,
         is_hot: bool,
         delete_on_restart: bool,
     ) -> Result<Self> {
@@ -600,7 +173,7 @@ impl StateMerkleDb {
             "Opened state merkle metadata db!"
         );
 
-        let state_merkle_db_shards = (0..NUM_STATE_SHARDS)
+        let state_merkle_db_shards: [Arc<DB>; NUM_STATE_SHARDS] = (0..NUM_STATE_SHARDS)
             .into_par_iter()
             .map(|shard_id| {
                 let shard_root_path = if is_hot {
@@ -627,13 +200,15 @@ impl StateMerkleDb {
             .try_into()
             .unwrap();
 
-        let state_merkle_db = Self {
+        let db_tag: &'static str = if is_hot { "hot" } else { "cold" };
+        let inner = ShardedJmtMerkleDb::new(
             state_merkle_metadata_db,
             state_merkle_db_shards,
-            version_caches,
-            lru_cache,
-            is_hot,
-        };
+            max_nodes_per_lru_cache_shard,
+            db_tag,
+        );
+
+        let state_merkle_db = Self { inner, is_hot };
 
         if !readonly {
             if let Some(overall_state_merkle_commit_progress) =
@@ -721,186 +296,23 @@ impl StateMerkleDb {
             .join(db_folder_name(is_hot))
             .join("metadata")
     }
-
-    /// Finds the rightmost leaf by scanning the entire DB.
-    #[cfg(test)]
-    pub fn get_rightmost_leaf_naive(
-        &self,
-        version: Version,
-    ) -> Result<Option<(NodeKey, LeafNode)>> {
-        let mut ret = None;
-
-        // traverse all shards in a naive way
-        let shards = 0..self.num_shards();
-        let start_num_of_nibbles = 1;
-        for shard_id in shards.rev() {
-            let shard_db = self.state_merkle_db_shards[shard_id].clone();
-            let mut shard_iter = shard_db.iter::<JellyfishMerkleNodeSchema>()?;
-            // DB sharded only contain nodes with num_of_nibbles >= 1
-            shard_iter.seek(&(version, start_num_of_nibbles)).unwrap();
-
-            while let Some((node_key, node)) = shard_iter.next().transpose()? {
-                if let Node::Leaf(leaf_node) = node {
-                    if node_key.version() != version {
-                        break;
-                    }
-                    match ret {
-                        None => ret = Some((node_key, leaf_node)),
-                        Some(ref other) => {
-                            if leaf_node.account_key() > other.1.account_key() {
-                                ret = Some((node_key, leaf_node));
-                            }
-                        },
-                    }
-                }
-            }
-        }
-
-        Ok(ret)
-    }
-
-    fn get_rightmost_leaf_in_single_shard(
-        &self,
-        version: Version,
-        shard_id: usize,
-    ) -> Result<Option<(NodeKey, LeafNode)>> {
-        assert!(
-            shard_id < NUM_STATE_SHARDS,
-            "Invalid shard_id: {}",
-            shard_id
-        );
-        let shard_db = self.state_merkle_db_shards[shard_id].clone();
-        // The encoding of key and value in DB looks like:
-        //
-        // | <-------------- key --------------> | <- value -> |
-        // | version | num_nibbles | nibble_path |    node     |
-        //
-        // Here version is fixed. For each num_nibbles, there could be a range of nibble paths
-        // of the same length. If one of them is the rightmost leaf R, it must be at the end of this
-        // range. Otherwise let's assume the R is in the middle of the range, so we
-        // call the node at the end of this range X:
-        //   1. If X is leaf, then X.account_key() > R.account_key(), because the nibble path is a
-        //      prefix of the account key. So R is not the rightmost leaf.
-        //   2. If X is internal node, then X must be on the right side of R, so all its children's
-        //      account keys are larger than R.account_key(). So R is not the rightmost leaf.
-        //
-        // Given that num_nibbles ranges from 0 to ROOT_NIBBLE_HEIGHT, there are only
-        // ROOT_NIBBLE_HEIGHT+1 ranges, so we can just find the node at the end of each range and
-        // then pick the one with the largest account key.
-        let mut ret = None;
-
-        for num_nibbles in 0..=ROOT_NIBBLE_HEIGHT {
-            let mut iter = shard_db.iter::<JellyfishMerkleNodeSchema>()?;
-            // nibble_path is always non-empty except for the root, so if we use an empty nibble
-            // path as the seek key, the iterator will end up pointing to the end of the previous
-            // range.
-            let seek_key = (version, (num_nibbles + 1) as u8);
-            iter.seek_for_prev(&seek_key)?;
-
-            if let Some((node_key, node)) = iter.next().transpose()? {
-                if node_key.version() != version {
-                    continue;
-                }
-                if let Node::Leaf(leaf_node) = node {
-                    match ret {
-                        None => ret = Some((node_key, leaf_node)),
-                        Some(ref other) => {
-                            if leaf_node.account_key() > other.1.account_key() {
-                                ret = Some((node_key, leaf_node));
-                            }
-                        },
-                    }
-                }
-            }
-        }
-        Ok(ret)
-    }
 }
 
 impl TreeReader<StateKey> for StateMerkleDb {
     fn get_node_option(&self, node_key: &NodeKey, tag: &str) -> Result<Option<Node>> {
-        let start_time = Instant::now();
-        if !self.cache_enabled() {
-            let node_opt = self
-                .db_by_key(node_key)
-                .get::<JellyfishMerkleNodeSchema>(node_key)?;
-            NODE_CACHE_SECONDS.observe_with(
-                &[tag, "cache_disabled", self.db_tag()],
-                start_time.elapsed().as_secs_f64(),
-            );
-            return Ok(node_opt);
-        }
-        if let Some(node_cache) = self
-            .version_caches
-            .get(&node_key.get_shard_id())
-            .unwrap()
-            .get_version(node_key.version())
-        {
-            let node = node_cache.get(node_key).cloned();
-            NODE_CACHE_SECONDS.observe_with(
-                &[tag, "versioned_cache_hit", self.db_tag()],
-                start_time.elapsed().as_secs_f64(),
-            );
-            return Ok(node);
-        }
-
-        if let Some(lru_cache) = &self.lru_cache {
-            if let Some(node) = lru_cache.get(node_key) {
-                NODE_CACHE_SECONDS.observe_with(
-                    &[tag, "lru_cache_hit", self.db_tag()],
-                    start_time.elapsed().as_secs_f64(),
-                );
-                return Ok(Some(node));
-            }
-        }
-
-        let node_opt = self
-            .db_by_key(node_key)
-            .get::<JellyfishMerkleNodeSchema>(node_key)?;
-        if let Some(lru_cache) = &self.lru_cache {
-            if let Some(node) = &node_opt {
-                lru_cache.put(node_key.clone(), node.clone());
-            }
-        }
-        NODE_CACHE_SECONDS.observe_with(
-            &[tag, "cache_miss", self.db_tag()],
-            start_time.elapsed().as_secs_f64(),
-        );
-        Ok(node_opt)
+        self.inner.get_node_option(node_key, tag)
     }
 
     fn get_rightmost_leaf(&self, version: Version) -> Result<Option<(NodeKey, LeafNode)>> {
-        let ret = None;
-        let shards = 0..NUM_STATE_SHARDS;
-
-        // Search from right to left to find the first leaf node.
-        for shard_id in shards.rev() {
-            if let Some((node_key, leaf_node)) =
-                self.get_rightmost_leaf_in_single_shard(version, shard_id)?
-            {
-                return Ok(Some((node_key, leaf_node)));
-            }
-        }
-
-        Ok(ret)
+        self.inner.get_rightmost_leaf(version)
     }
 }
 
 impl TreeWriter<StateKey> for StateMerkleDb {
-    fn write_node_batch(&self, node_batch: &NodeBatch) -> Result<()> {
-        let _timer = OTHER_TIMERS_SECONDS
-            .timer_with(&[&format!("{}__tree_writer_write_batch", self.db_tag())]);
-        // Get the top level batch and sharded batch from raw NodeBatch
-        let mut top_level_batch = SchemaBatch::new();
-        let mut jmt_shard_batches: Vec<SchemaBatch> = Vec::with_capacity(NUM_STATE_SHARDS);
-        jmt_shard_batches.resize_with(NUM_STATE_SHARDS, SchemaBatch::new);
-        node_batch.iter().try_for_each(|(node_key, node)| {
-            if let Some(shard_id) = node_key.get_shard_id() {
-                jmt_shard_batches[shard_id].put::<JellyfishMerkleNodeSchema>(node_key, node)
-            } else {
-                top_level_batch.put::<JellyfishMerkleNodeSchema>(node_key, node)
-            }
-        })?;
-        self.commit_no_progress(top_level_batch, jmt_shard_batches)
+    fn write_node_batch(
+        &self,
+        node_batch: &aptos_jellyfish_merkle::NodeBatch<StateKey>,
+    ) -> Result<()> {
+        self.inner.write_node_batch(node_batch)
     }
 }

--- a/storage/aptosdb/src/utils/truncation_helper.rs
+++ b/storage/aptosdb/src/utils/truncation_helper.rs
@@ -24,6 +24,7 @@ use crate::{
         version_data::VersionDataSchema,
         write_set::WriteSetSchema,
     },
+    sharded_jmt_merkle_db::ShardedJmtMerkleDb,
     state_kv_db::StateKvDb,
     state_merkle_db::StateMerkleDb,
     state_store::MAX_COMMIT_PROGRESS_DIFFERENCE,
@@ -608,7 +609,7 @@ fn delete_nodes_and_stale_indices_at_or_after_version(
         batch.delete::<JellyfishMerkleNodeSchema>(&key)?;
     }
 
-    StateMerkleDb::put_progress(version.checked_sub(1), shard_id, batch)
+    ShardedJmtMerkleDb::put_progress(version.checked_sub(1), shard_id, batch)
 }
 
 struct Progress {


### PR DESCRIPTION
Pull the 16-shard + metadata DB + version/LRU cache + JMT/commit/read infrastructure out of StateMerkleDb into a new ShardedJmtMerkleDb substrate. StateMerkleDb keeps its is_hot flag and hot/cold path resolution, opens its DBs the same way as before, and Deref's to ShardedJmtMerkleDb so all the JMT/commit/read methods keep working on &StateMerkleDb. TreeReader and TreeWriter are delegated.

Pure refactor on the state side. No observable behavior change in state's open / commit / read paths. Sets up a single sharded merkle DB substrate that the position-side wrapper can share in the next commit.

## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [x] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [x] Validator Node
- [x] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Primarily a refactor but it moves core state-merkle commit/read/caching logic into a new shared type; any subtle divergence in batching, caching, or progress metadata handling could affect state sync or pruning.
> 
> **Overview**
> **Extracts a new shared substrate** `ShardedJmtMerkleDb` that owns the 16 shard DBs + metadata DB, version/LRU caches, and all JMT operations (merklize, commit batching, proofs, root/leaf queries, and `TreeReader`/`TreeWriter` impls).
> 
> **Refactors `StateMerkleDb` into a wrapper** that only handles hot/cold path resolution, shard/metadata DB opening, truncation-on-startup, and checkpoint creation, while `Deref`/delegation preserves the existing call surface for commit/read/write paths.
> 
> Updates truncation logic to use `ShardedJmtMerkleDb::put_progress` and wires the new module into `lib.rs`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41cafe9743aa6db7fb762d06ea7e970edd3ee983. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->