### PR TITLE
Fix Homebrew formula bump action in CLI release workflow

### DIFF
--- a/.github/workflows/cli-release.yaml
+++ b/.github/workflows/cli-release.yaml
@@ -189,9 +189,10 @@ jobs:
     steps:
       # mislav/bump-homebrew-formula-action@v3 broke after GitHub changed
       # authenticated tarball redirects from HTTP 302 to 303 (upstream
-      # issue #340, no patch released). dawidd6/action-homebrew-bump-formula
-      # wraps `brew bump-formula-pr`, which handles redirects correctly.
-      - uses: dawidd6/action-homebrew-bump-formula@v7
+      # mislav/bump-homebrew-formula-action#340, no patch released).
+      # dawidd6/action-homebrew-bump-formula wraps `brew bump-formula-pr`,
+      # which handles redirects correctly.
+      - uses: dawidd6/action-homebrew-bump-formula@1446dca236b0440c6f02723a3f14f13be2c04ab0 # pin@v7
         with:
           token: ${{ secrets.APTOS_BOT_GH_PAT_APTOS_CORE_HOMEBREW_BUMPER }}
           formula: aptos

--- a/.github/workflows/cli-release.yaml
+++ b/.github/workflows/cli-release.yaml
@@ -183,19 +183,18 @@ jobs:
     name: "Make PR to bump version in Homebrew"
     needs:
       - release-binaries
-    runs-on: 2cpu-gh-ubuntu24-x64
+    # GitHub-hosted ubuntu-24.04 ships Linuxbrew preinstalled, which the
+    # action below requires. The previous self-hosted runner did not.
+    runs-on: ubuntu-24.04
     steps:
-      - uses: mislav/bump-homebrew-formula-action@v3
+      # mislav/bump-homebrew-formula-action@v3 broke after GitHub changed
+      # authenticated tarball redirects from HTTP 302 to 303 (upstream
+      # issue #340, no patch released). dawidd6/action-homebrew-bump-formula
+      # wraps `brew bump-formula-pr`, which handles redirects correctly.
+      - uses: dawidd6/action-homebrew-bump-formula@v7
         with:
-          formula-name: aptos
-          tag-name: "${{ format('aptos-cli-v{0}', inputs.release_version) }}"
-          base-branch: main
-          create-pullrequest: true
-          commit-message: |
-            {{formulaName}} {{version}}
-
-            Created by https://github.com/mislav/bump-homebrew-formula-action
-
+          token: ${{ secrets.APTOS_BOT_GH_PAT_APTOS_CORE_HOMEBREW_BUMPER }}
+          formula: aptos
+          tag: "${{ format('aptos-cli-v{0}', inputs.release_version) }}"
+          message: |
             From CLI release run ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        env:
-          COMMITTER_TOKEN: ${{ secrets.APTOS_BOT_GH_PAT_APTOS_CORE_HOMEBREW_BUMPER }}


### PR DESCRIPTION
## Description

Updates the CLI release workflow to fix the Homebrew formula bumping step by switching from the unmaintained `mislav/bump-homebrew-formula-action@v3` to `dawidd6/action-homebrew-bump-formula@v7`.

**Why this change is needed:**
- `mislav/bump-homebrew-formula-action@v3` broke after GitHub changed authenticated tarball redirects from HTTP 302 to 303 (upstream issue #340, no patch released)
- `dawidd6/action-homebrew-bump-formula` wraps `brew bump-formula-pr`, which handles redirects correctly

**Additional improvements:**
- Changed runner from self-hosted `2cpu-gh-ubuntu24-x64` to GitHub-hosted `ubuntu-24.04`, which ships Linuxbrew preinstalled (required by the new action)
- Updated action inputs to match the new action's API:
  - `formula-name` → `formula`
  - `tag-name` → `tag`
  - `commit-message` → `message`
  - `COMMITTER_TOKEN` env var → `token` input parameter

## How Has This Been Tested?

This is a workflow configuration change. The fix will be validated when the next CLI release is triggered and the Homebrew formula bump step executes successfully.

## Key Areas to Review

- Verify that the new action `dawidd6/action-homebrew-bump-formula@v7` is the correct replacement and properly maintained
- Confirm that the GitHub-hosted `ubuntu-24.04` runner has all necessary dependencies (Linuxbrew) for the action to work
- Ensure the `APTOS_BOT_GH_PAT_APTOS_CORE_HOMEBREW_BUMPER` token has appropriate permissions for the new action

## Type of Change

- [x] Bug fix
- [x] Dependency update

## Which Components or Systems Does This Change Impact?

- [x] Aptos CLI/SDK
- [x] Developer Infrastructure

## Checklist

- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers

https://claude.ai/code/session_01Xpzk6vPA6RMeYeq3UZz31h