### PR TITLE
[Storage] Lower max total WAL size

### DIFF
--- a/config/src/config/storage_config.rs
+++ b/config/src/config/storage_config.rs
@@ -167,9 +167,9 @@ impl Default for RocksdbConfig {
         Self {
             // Allow db to close old sst files, saving memory.
             max_open_files: 5000,
-            // For now we set the max total WAL size to be 1G. This config can be useful when column
+            // Max size WAL can accumulate per DB before a flush is forced. Useful when column
             // families are updated at non-uniform frequencies.
-            max_total_wal_size: 1u64 << 30,
+            max_total_wal_size: 512 << 20,
             // This includes jobs for flush and compaction.
             max_background_jobs: 4,
             // Not used. Only kept for backward compatibility.
@@ -220,10 +220,14 @@ impl Default for RocksdbConfigs {
     fn default() -> Self {
         Self {
             ledger_db_config: RocksdbConfig::default(),
-            state_merkle_db_config: RocksdbConfig::default(),
+            state_merkle_db_config: RocksdbConfig {
+                max_total_wal_size: 256 << 20,
+                ..Default::default()
+            },
             state_kv_db_config: RocksdbConfig {
                 bloom_filter_bits: Some(10.0),
                 bloom_before_level: Some(2),
+                max_total_wal_size: 256 << 20,
                 ..Default::default()
             },
             index_db_config: RocksdbConfig {


### PR DESCRIPTION

Large accumulated WAL can lead to slow recovery and long startup time (as seen
on devnet on some nodes). The 1GB configuration was likely set a long time ago
before all the sharding changes. It should be safe to lower this by 2x or 4x.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default RocksDB WAL size limits, which can impact write/flush behavior and runtime performance despite being a config-only change.
> 
> **Overview**
> Lowers the default RocksDB `max_total_wal_size` from **1GB to 512MB** to reduce WAL accumulation and improve recovery/startup times.
> 
> Adds more conservative WAL limits for specific DBs by setting `state_merkle_db_config` and `state_kv_db_config` defaults to **256MB**, instead of inheriting the global default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1631fe7b16b6f9ae7cc5be84dc8f87b056cedcd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->