### PR TITLE
[execution] Enable WriteSet V1 construction

### DIFF
--- a/config/src/config/storage_config.rs
+++ b/config/src/config/storage_config.rs
@@ -269,7 +269,7 @@ impl Default for HotStateConfig {
             refresh_interval_versions: 100_000,
             delete_on_restart: true,
             compute_root_hash: true,
-            use_write_set_v1: true,
+            use_write_set_v1: false,
             persist_hotness_in_epilogue: false,
         }
     }
@@ -687,14 +687,6 @@ impl ConfigOptimizer for StorageConfig {
             }
             if chain_id.is_testnet() && config_yaml["assert_rlimit_nofile"].is_null() {
                 config.assert_rlimit_nofile = true;
-                modified_config = true;
-            }
-            // TODO(HotState): WriteSet V1 is disabled on mainnet and testnet unless explicitly
-            // enabled.
-            if (chain_id.is_mainnet() || chain_id.is_testnet())
-                && config_yaml["hot_state_config"]["use_write_set_v1"].as_bool() != Some(true)
-            {
-                config.hot_state_config.use_write_set_v1 = false;
                 modified_config = true;
             }
         }

--- a/execution/executor/src/workflow/do_get_execution_output.rs
+++ b/execution/executor/src/workflow/do_get_execution_output.rs
@@ -167,6 +167,9 @@ impl DoGetExecutionOutput {
                 );
             }
         }
+        if parent_state.latest().hot_state_config().use_write_set_v1 {
+            Self::convert_write_sets_to_v1(&mut transaction_outputs);
+        }
 
         Parser::parse(
             state_view.next_version(),
@@ -191,11 +194,14 @@ impl DoGetExecutionOutput {
         append_state_checkpoint_to_block: Option<HashValue>,
     ) -> Result<ExecutionOutput> {
         let state_view_arc = Arc::new(state_view);
-        let transaction_outputs = Self::execute_block_sharded::<V>(
+        let mut transaction_outputs = Self::execute_block_sharded::<V>(
             transactions.clone(),
             state_view_arc.clone(),
             onchain_config,
         )?;
+        if parent_state.latest().hot_state_config().use_write_set_v1 {
+            Self::convert_write_sets_to_v1(&mut transaction_outputs);
+        }
 
         // TODO(Manu): Handle state checkpoint here.
 
@@ -217,6 +223,12 @@ impl DoGetExecutionOutput {
             false, // prime_state_cache
             append_state_checkpoint_to_block.is_some(),
         )
+    }
+
+    fn convert_write_sets_to_v1(transaction_outputs: &mut [TransactionOutput]) {
+        transaction_outputs
+            .iter_mut()
+            .for_each(TransactionOutput::convert_write_set_to_v1);
     }
 
     pub fn by_transaction_output(

--- a/storage/aptosdb/src/schema/write_set/test.rs
+++ b/storage/aptosdb/src/schema/write_set/test.rs
@@ -39,41 +39,26 @@ fn test_v0_roundtrip() {
     assert_eq!(decoded.hotness_keys().count(), 0);
 }
 
-/// V1 WriteSets (crafted from a mirror since the production code has no public
-/// `WriteSet::V1` constructor yet) round-trip through the schema codec.
+/// V1 WriteSets constructed by production code round-trip through the schema codec.
 #[test]
 fn test_v1_roundtrip() {
-    use aptos_types::write_set::{Extension, WriteSetMut};
-
-    // Mirrors the on-wire shape of `WriteSetV1`.
-    #[derive(serde::Serialize)]
-    struct WriteSetV1Mirror<'a> {
-        value_writes: &'a WriteSetMut,
-        hotness: &'a BTreeSet<StateKey>,
-        extensions: &'a [Extension],
-    }
-
-    let value_writes = WriteSetMut::new(vec![(
+    let mut ws = WriteSet::new(vec![(
         StateKey::raw(b"key1"),
         WriteOp::legacy_creation(b"val1".to_vec().into()),
-    )]);
+    )])
+    .unwrap();
     let hotness: BTreeSet<_> = [StateKey::raw(b"hot1")].into_iter().collect();
+    ws.add_hotness(hotness.clone());
+    let ws = ws.into_v1();
 
-    let mut bytes = vec![1u8]; // BCS variant tag for V1.
-    bytes.extend(
-        bcs::to_bytes(&WriteSetV1Mirror {
-            value_writes: &value_writes,
-            hotness: &hotness,
-            extensions: &[],
-        })
-        .unwrap(),
-    );
-
+    let bytes = ws.encode_value().unwrap();
     let decoded = WriteSet::decode_value(&bytes).unwrap();
-    let reencoded = decoded.encode_value().unwrap();
-    assert_eq!(reencoded, bytes);
-    let redecoded = WriteSet::decode_value(&reencoded).unwrap();
-    assert_eq!(decoded, redecoded);
+    assert!(matches!(decoded, WriteSet::V1(_)));
+    assert_eq!(decoded, ws);
+    assert_eq!(
+        decoded.hotness_keys().cloned().collect::<BTreeSet<_>>(),
+        hotness
+    );
 }
 
 /// Legacy V1 bytes (variant tag 1 with `value ++ hotness`, no trailing extensions) must

--- a/storage/storage-interface/src/state_store/state.rs
+++ b/storage/storage-interface/src/state_store/state.rs
@@ -139,6 +139,10 @@ impl State {
         self.usage
     }
 
+    pub fn hot_state_config(&self) -> HotStateConfig {
+        self.hot_state_config
+    }
+
     pub fn shards(&self) -> &[MapLayer<HashValue, StateSlot>; NUM_STATE_SHARDS] {
         &self.shards
     }

--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -2088,6 +2088,10 @@ impl TransactionOutput {
         &self.write_set
     }
 
+    pub fn convert_write_set_to_v1(&mut self) {
+        self.write_set = std::mem::take(&mut self.write_set).into_v1();
+    }
+
     // This is a special function to update the total supply in the write set. 'TransactionOutput'
     // already has materialized write set, but in case of sharding support for total_supply, we
     // want to update the total supply in the write set by aggregating the total supply deltas from

--- a/types/src/write_set.rs
+++ b/types/src/write_set.rs
@@ -637,6 +637,17 @@ impl WriteSet {
         }
     }
 
+    pub fn into_v1(self) -> Self {
+        match self {
+            Self::V0(ws) => Self::V1(WriteSetV1 {
+                value_writes: ws.value_writes,
+                hotness: ws.hotness,
+                extensions: ws.extensions,
+            }),
+            Self::V1(ws) => Self::V1(ws),
+        }
+    }
+
     pub fn new(write_ops: impl IntoIterator<Item = (StateKey, WriteOp)>) -> Result<Self> {
         WriteSetMut::new(write_ops).freeze()
     }


### PR DESCRIPTION

Enable hot state end-to-end on devnet by constructing WriteSet V1 when
HotStateConfig::use_write_set_v1 is set.

This keeps the change small by converting execution-produced outputs at the
executor boundary, after block epilogue hotness is attached and before
TransactionInfo hashes are computed. Devnet data is wiped between deployments,
so this path can prioritize getting hotness serialized and deserialized without
solving full backward compatibility.

This is intended as a pragmatic bridge rather than the final form. A later
cleanup can move write-set version selection closer to VM output construction
along with the existing HotState TODO.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Execution outputs can now be rewritten into `WriteSet` V1 before hashing/commit, which affects transaction output serialization and hashes when enabled. Default remains off, but enabling it may impact compatibility with existing devnet/test tooling and stored data.
> 
> **Overview**
> When `HotStateConfig::use_write_set_v1` is enabled, the executor now converts all `TransactionOutput` write sets to **V1** after attaching block-epilogue hotness and before `ExecutionOutput` parsing/hashing.
> 
> This introduces `WriteSet::into_v1()` and `TransactionOutput::convert_write_set_to_v1()` helpers, exposes `State::hot_state_config()` for the executor gate, and updates AptosDB write-set schema tests to construct and round-trip real production V1 write sets (including hotness) rather than using a mirrored encoding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c6fdd07bea5fb2a967716fc74801301aa8874d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->