### PR TITLE
[release] Enable versioned transaction validation

### DIFF
--- a/aptos-move/aptos-release-builder/data/versioned-transaction-validation.yaml
+++ b/aptos-move/aptos-release-builder/data/versioned-transaction-validation.yaml
@@ -1,0 +1,12 @@
+remote_endpoint: ~
+name: "v1.45-versioned-transaction-validation"
+proposals:
+  - name: versioned_transaction_validation
+    metadata:
+      title: "Proposal to enable versioned transaction validation APIs"
+      description: "Enables new prologue/epilogue functions for better maintainability and future extensions"
+    execution_mode: MultiStep
+    update_sequence:
+      - FeatureFlag:
+          enabled:
+            - versioned_transaction_validation


### PR DESCRIPTION
## Summary
- Adds release-builder proposal yaml to enable the `versioned_transaction_validation` feature flag on v1.45.
- Enables new prologue/epilogue functions for better maintainability and future extensions.

## Test plan
- [ ] Generate the proposal via aptos-release-builder and verify it parses.
- [ ] Validate the rollout on testnet before mainnet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new release-builder proposal that enables the `versioned_transaction_validation` feature flag; while the change is just configuration, it can alter transaction validation behavior once executed.
> 
> **Overview**
> Adds a new `aptos-release-builder` proposal YAML (`v1.45-versioned-transaction-validation`) to **enable the `versioned_transaction_validation` feature flag** via a MultiStep update sequence, turning on the new versioned prologue/epilogue transaction validation APIs for v1.45.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67c430b3e47c618d2267404246ccb05353a40931. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->