### PR TITLE
[release] Enable transaction limits

### DIFF
--- a/aptos-move/aptos-release-builder/data/transaction-limits.yaml
+++ b/aptos-move/aptos-release-builder/data/transaction-limits.yaml
@@ -1,0 +1,12 @@
+remote_endpoint: ~
+name: "v1.45-transaction-limits"
+proposals:
+  - name: transaction_limits
+    metadata:
+      title: "Proposal to enable high transaction limits"
+      description: "AIP-146: staking-based transaction limits (https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-146-staking-based-transaction-limits.md)."
+    execution_mode: MultiStep
+    update_sequence:
+      - FeatureFlag:
+          enabled:
+            - transaction_limits


### PR DESCRIPTION
## Summary
- Adds release-builder proposal yaml to enable the `transaction_limits` feature flag on v1.45.
- AIP-146: staking-based transaction limits (https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-146-staking-based-transaction-limits.md).

## Test plan
- [ ] Generate the proposal via aptos-release-builder and verify it parses.
- [ ] Validate the rollout on testnet before mainnet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Enables a new on-chain feature flag via release governance, which can materially affect network transaction behavior. Change scope is small but the operational impact of the flag rollout is significant if misconfigured or activated unintentionally.
> 
> **Overview**
> Adds a new aptos-release-builder proposal file, `data/transaction-limits.yaml`, defining a `v1.45-transaction-limits` multistep governance update that enables the `transaction_limits` feature flag (per AIP-146).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0dd8f3c31ab710102fa35eefa1d24a104ee59dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->