### PR TITLE
[execution] Add TransactionInfo V1 with hot state checkpoint hash

### DIFF
--- a/config/src/config/storage_config.rs
+++ b/config/src/config/storage_config.rs
@@ -260,6 +260,8 @@ pub struct HotStateConfig {
     pub use_write_set_v1: bool,
     /// Whether to embed the per-block hot-state promotions into the epilogue transactions.
     pub persist_hotness_in_epilogue: bool,
+    /// Whether execution should assemble `TransactionInfoV1` which carries hot state root hash.
+    pub use_transaction_info_v1: bool,
 }
 
 impl Default for HotStateConfig {
@@ -271,6 +273,7 @@ impl Default for HotStateConfig {
             compute_root_hash: true,
             use_write_set_v1: false,
             persist_hotness_in_epilogue: false,
+            use_transaction_info_v1: false,
         }
     }
 }

--- a/execution/executor-types/src/state_checkpoint_output.rs
+++ b/execution/executor-types/src/state_checkpoint_output.rs
@@ -20,10 +20,12 @@ impl StateCheckpointOutput {
     pub fn new(
         state_summary: LedgerStateSummary,
         state_checkpoint_hashes: Vec<Option<HashValue>>,
+        hot_state_checkpoint_hashes: Option<Vec<Option<HashValue>>>,
     ) -> Self {
         Self::new_impl(Inner {
             state_summary,
             state_checkpoint_hashes,
+            hot_state_checkpoint_hashes,
         })
     }
 
@@ -31,6 +33,7 @@ impl StateCheckpointOutput {
         Self::new_impl(Inner {
             state_summary: parent_state_summary,
             state_checkpoint_hashes: vec![],
+            hot_state_checkpoint_hashes: None,
         })
     }
 
@@ -53,4 +56,7 @@ impl StateCheckpointOutput {
 pub struct Inner {
     pub state_summary: LedgerStateSummary,
     pub state_checkpoint_hashes: Vec<Option<HashValue>>,
+    // TODO(HotState): this is currently None in testnet and mainnet, since we don't run hot state
+    // root hashes in consensus or state-sync yet.
+    pub hot_state_checkpoint_hashes: Option<Vec<Option<HashValue>>>,
 }

--- a/execution/executor/src/block_executor/mod.rs
+++ b/execution/executor/src/block_executor/mod.rs
@@ -351,11 +351,17 @@ where
                 fail_point!("executor::block_state_checkpoint", |_| {
                     Err(anyhow::anyhow!("Injected error in block state checkpoint."))
                 });
+                let parent_state_summary = parent_block.output.ensure_result_state_summary()?;
+                let use_transaction_info_v1 = parent_state_summary
+                    .hot_state_config()
+                    .use_transaction_info_v1;
                 output.set_state_checkpoint_output(DoStateCheckpoint::run(
                     &output.execution_output,
-                    parent_block.output.ensure_result_state_summary()?,
+                    parent_state_summary,
                     &ProvableStateSummary::new_persisted(self.db.reader.as_ref())?,
                     None,
+                    None,
+                    use_transaction_info_v1,
                 )?);
                 output.set_ledger_update_output(DoLedgerUpdate::run(
                     &output.execution_output,

--- a/execution/executor/src/chunk_executor/mod.rs
+++ b/execution/executor/src/chunk_executor/mod.rs
@@ -343,17 +343,33 @@ impl<V: VMBlockExecutor> ChunkExecutorInner<V> {
             chunk_verifier,
         } = chunk;
 
+        let txn_infos = chunk_verifier.transaction_infos();
+        let all_v1 = matches!(txn_infos.first(), Some(TransactionInfo::V1(_)));
+        ensure!(
+            txn_infos
+                .iter()
+                .all(|t| matches!(t, TransactionInfo::V1(_)) == all_v1),
+            "Mixed TransactionInfo variants in the same chunk are not allowed.",
+        );
+        let known_state_checkpoints = Some(
+            txn_infos
+                .iter()
+                .map(|t| t.state_checkpoint_hash())
+                .collect_vec(),
+        );
+        let known_hot_state_checkpoints = all_v1.then(|| {
+            txn_infos
+                .iter()
+                .map(|t| t.hot_state_checkpoint_hash())
+                .collect_vec()
+        });
         let state_checkpoint_output = DoStateCheckpoint::run(
             &output.execution_output,
             &parent_state_summary,
             &ProvableStateSummary::new_persisted(self.db.reader.as_ref())?,
-            Some(
-                chunk_verifier
-                    .transaction_infos()
-                    .iter()
-                    .map(|t| t.state_checkpoint_hash())
-                    .collect_vec(),
-            ),
+            known_state_checkpoints,
+            known_hot_state_checkpoints,
+            all_v1,
         )?;
 
         let ledger_update_output = DoLedgerUpdate::run(

--- a/execution/executor/src/workflow/do_ledger_update.rs
+++ b/execution/executor/src/workflow/do_ledger_update.rs
@@ -27,10 +27,16 @@ impl DoLedgerUpdate {
     ) -> Result<LedgerUpdateOutput> {
         let _timer = OTHER_TIMERS.timer_with(&["do_ledger_update"]);
 
-        // Assemble `TransactionInfo`s
+        // Assemble `TransactionInfo`s. The variant (V0 vs V1) is driven by whether
+        // `hot_state_checkpoint_hashes` is present: `DoStateCheckpoint` produces `Some`
+        // iff V1 should be emitted (block path: local `use_transaction_info_v1`; chunk
+        // path: matches the incoming chunk's actual format).
         let (transaction_infos, transaction_info_hashes) = Self::assemble_transaction_infos(
             &execution_output.to_commit,
-            state_checkpoint_output.state_checkpoint_hashes.clone(),
+            &state_checkpoint_output.state_checkpoint_hashes,
+            state_checkpoint_output
+                .hot_state_checkpoint_hashes
+                .as_deref(),
         );
 
         // Calculate root hash
@@ -46,7 +52,8 @@ impl DoLedgerUpdate {
 
     fn assemble_transaction_infos(
         to_commit: &TransactionsWithOutput,
-        state_checkpoint_hashes: Vec<Option<HashValue>>,
+        state_checkpoint_hashes: &[Option<HashValue>],
+        hot_state_checkpoint_hashes: Option<&[Option<HashValue>]>,
     ) -> (Vec<TransactionInfo>, Vec<HashValue>) {
         let _timer = OTHER_TIMERS.timer_with(&["assemble_transaction_infos"]);
 
@@ -74,18 +81,32 @@ impl DoLedgerUpdate {
                 let event_root_hash =
                     InMemoryEventAccumulator::from_leaves(&event_hashes).root_hash();
                 let write_set_hash = CryptoHash::hash(txn_output.write_set());
-                let txn_info = TransactionInfo::new(
-                    txn.committed_hash(),
-                    write_set_hash,
-                    event_root_hash,
-                    state_checkpoint_hash,
-                    txn_output.gas_used(),
-                    txn_output
-                        .status()
-                        .as_kept_status()
-                        .expect("Already sorted."),
-                    auxiliary_info_hash,
-                );
+                let status = txn_output
+                    .status()
+                    .as_kept_status()
+                    .expect("Already sorted.");
+                let txn_info = if let Some(hot) = hot_state_checkpoint_hashes {
+                    TransactionInfo::new_v1(
+                        txn.committed_hash(),
+                        write_set_hash,
+                        event_root_hash,
+                        state_checkpoint_hash,
+                        hot[i],
+                        txn_output.gas_used(),
+                        status,
+                        auxiliary_info_hash,
+                    )
+                } else {
+                    TransactionInfo::new(
+                        txn.committed_hash(),
+                        write_set_hash,
+                        event_root_hash,
+                        state_checkpoint_hash,
+                        txn_output.gas_used(),
+                        status,
+                        auxiliary_info_hash,
+                    )
+                };
                 let txn_info_hash = txn_info.hash();
                 (txn_info, txn_info_hash)
             })

--- a/execution/executor/src/workflow/do_state_checkpoint.rs
+++ b/execution/executor/src/workflow/do_state_checkpoint.rs
@@ -20,6 +20,8 @@ impl DoStateCheckpoint {
         parent_state_summary: &LedgerStateSummary,
         persisted_state_summary: &ProvableStateSummary,
         known_state_checkpoints: Option<Vec<Option<HashValue>>>,
+        known_hot_state_checkpoints: Option<Vec<Option<HashValue>>>,
+        use_transaction_info_v1: bool,
     ) -> Result<StateCheckpointOutput> {
         let _timer = OTHER_TIMERS.timer_with(&["do_state_checkpoint"]);
 
@@ -29,24 +31,39 @@ impl DoStateCheckpoint {
             execution_output.to_commit.state_update_refs(),
         )?;
 
+        let last_checkpoint = state_summary.last_checkpoint();
+
         let state_checkpoint_hashes = Self::get_state_checkpoint_hashes(
             execution_output,
             known_state_checkpoints,
-            &state_summary,
+            last_checkpoint.root_hash(),
+            "state",
         )?;
+        let hot_state_checkpoint_hashes = use_transaction_info_v1
+            .then(|| {
+                Self::get_state_checkpoint_hashes(
+                    execution_output,
+                    known_hot_state_checkpoints,
+                    last_checkpoint.hot_root_hash(),
+                    "hot_state",
+                )
+            })
+            .transpose()?;
 
         Ok(StateCheckpointOutput::new(
             state_summary,
             state_checkpoint_hashes,
+            hot_state_checkpoint_hashes,
         ))
     }
 
     fn get_state_checkpoint_hashes(
         execution_output: &ExecutionOutput,
         known_state_checkpoints: Option<Vec<Option<HashValue>>>,
-        state_summary: &LedgerStateSummary,
+        computed_last_checkpoint_hash: HashValue,
+        label: &str,
     ) -> Result<Vec<Option<HashValue>>> {
-        let _timer = OTHER_TIMERS.timer_with(&["get_state_checkpoint_hashes"]);
+        let _timer = OTHER_TIMERS.timer_with(&[&format!("get_{label}_checkpoint_hashes")]);
 
         let num_txns = execution_output.to_commit.len();
         let last_checkpoint_index = execution_output
@@ -57,19 +74,18 @@ impl DoStateCheckpoint {
         if let Some(known) = known_state_checkpoints {
             ensure!(
                 known.len() == num_txns,
-                "Bad number of known hashes. {} vs {}",
+                "Bad number of known {label} hashes. {} vs {}",
                 known.len(),
-                num_txns
+                num_txns,
             );
             if let Some(idx) = last_checkpoint_index {
                 ensure!(
-                    known[idx] == Some(state_summary.last_checkpoint().root_hash()),
-                    "Root hash mismatch with known hashes passed in. {:?} vs {:?}",
+                    known[idx] == Some(computed_last_checkpoint_hash),
+                    "{label} root hash mismatch with known hashes passed in. {:?} vs {:?}",
                     known[idx],
-                    Some(&state_summary.last_checkpoint().root_hash()),
+                    Some(computed_last_checkpoint_hash),
                 );
             }
-
             Ok(known)
         } else {
             if !execution_output.is_block {
@@ -78,11 +94,9 @@ impl DoStateCheckpoint {
             }
 
             let mut out = vec![None; num_txns];
-
             if let Some(index) = last_checkpoint_index {
-                out[index] = Some(state_summary.last_checkpoint().root_hash());
+                out[index] = Some(computed_last_checkpoint_hash);
             }
-
             Ok(out)
         }
     }

--- a/execution/executor/src/workflow/mod.rs
+++ b/execution/executor/src/workflow/mod.rs
@@ -24,11 +24,17 @@ impl ApplyExecutionOutput {
         base_view: LedgerSummary,
         reader: &(dyn DbReader + Sync),
     ) -> Result<PartialStateComputeResult> {
+        let use_transaction_info_v1 = base_view
+            .state_summary
+            .hot_state_config()
+            .use_transaction_info_v1;
         let state_checkpoint_output = DoStateCheckpoint::run(
             &execution_output,
             &base_view.state_summary,
             &ProvableStateSummary::new_persisted(reader)?,
             None,
+            None,
+            use_transaction_info_v1,
         )?;
         let ledger_update_output = DoLedgerUpdate::run(
             &execution_output,

--- a/storage/aptosdb/src/state_store/hot_state.rs
+++ b/storage/aptosdb/src/state_store/hot_state.rs
@@ -721,6 +721,7 @@ mod tests {
         compute_root_hash: true,
         use_write_set_v1: true,
         persist_hotness_in_epilogue: false,
+        use_transaction_info_v1: false,
     };
 
     fn make_hot_slot(key: &StateKey, version: Version, value: &[u8]) -> StateSlot {

--- a/storage/aptosdb/src/state_store/tests/restart.rs
+++ b/storage/aptosdb/src/state_store/tests/restart.rs
@@ -36,6 +36,7 @@ fn open_db<P: AsRef<Path>>(
         compute_root_hash: true,
         use_write_set_v1: true,
         persist_hotness_in_epilogue: false,
+        use_transaction_info_v1: false,
     };
     AptosDB::open(
         StorageDirPaths::from_path(path),

--- a/storage/aptosdb/src/state_store/tests/speculative_state_workflow.rs
+++ b/storage/aptosdb/src/state_store/tests/speculative_state_workflow.rs
@@ -64,6 +64,7 @@ const TEST_CONFIG: HotStateConfig = HotStateConfig {
     compute_root_hash: true,
     use_write_set_v1: true,
     persist_hotness_in_epilogue: false,
+    use_transaction_info_v1: false,
 };
 
 #[derive(Clone, Debug)]

--- a/storage/storage-interface/src/state_store/state_summary.rs
+++ b/storage/storage-interface/src/state_store/state_summary.rs
@@ -69,6 +69,10 @@ impl StateSummary {
         self.global_state_summary.root_hash()
     }
 
+    pub fn hot_state_config(&self) -> HotStateConfig {
+        self.hot_state_config
+    }
+
     pub fn next_version(&self) -> Version {
         self.next_version
     }

--- a/testsuite/generate-format/src/api.rs
+++ b/testsuite/generate-format/src/api.rs
@@ -126,6 +126,7 @@ pub fn get_registry() -> Result<Registry> {
     tracer.trace_type::<transaction::UserTxnLimitsRequest>(&samples)?;
     tracer.trace_type::<transaction::WriteSetPayload>(&samples)?;
     tracer.trace_type::<transaction::BlockEpiloguePayload>(&samples)?;
+    tracer.trace_type::<transaction::TransactionInfo>(&samples)?;
     tracer.trace_type::<StateKey>(&samples)?;
     tracer.trace_type::<transaction::ExecutionStatus>(&samples)?;
     tracer.trace_type::<TransactionAuthenticator>(&samples)?;

--- a/testsuite/generate-format/tests/staged/api.yaml
+++ b/testsuite/generate-format/tests/staged/api.yaml
@@ -1027,6 +1027,10 @@ TransactionInfo:
       V0:
         NEWTYPE:
           TYPENAME: TransactionInfoV0
+    1:
+      V1:
+        NEWTYPE:
+          TYPENAME: TransactionInfoV1
 TransactionInfoV0:
   STRUCT:
     - gas_used: U64
@@ -1042,6 +1046,50 @@ TransactionInfoV0:
         OPTION:
           TYPENAME: HashValue
     - auxiliary_info_hash:
+        OPTION:
+          TYPENAME: HashValue
+TransactionInfoV1:
+  STRUCT:
+    - gas_used: U64
+    - status:
+        TYPENAME: ExecutionStatus
+    - transaction_hash:
+        TYPENAME: HashValue
+    - event_root_hash:
+        TYPENAME: HashValue
+    - state_change_hash:
+        TYPENAME: HashValue
+    - state_checkpoint_hash:
+        OPTION:
+          TYPENAME: HashValue
+    - hot_state_checkpoint_hash:
+        OPTION:
+          TYPENAME: HashValue
+    - auxiliary_info_hash:
+        OPTION:
+          TYPENAME: HashValue
+    - placeholder0:
+        OPTION:
+          TYPENAME: HashValue
+    - placeholder1:
+        OPTION:
+          TYPENAME: HashValue
+    - placeholder2:
+        OPTION:
+          TYPENAME: HashValue
+    - placeholder3:
+        OPTION:
+          TYPENAME: HashValue
+    - placeholder4:
+        OPTION:
+          TYPENAME: HashValue
+    - placeholder5:
+        OPTION:
+          TYPENAME: HashValue
+    - placeholder6:
+        OPTION:
+          TYPENAME: HashValue
+    - placeholder7:
         OPTION:
           TYPENAME: HashValue
 TransactionOnChainData:

--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -2226,6 +2226,7 @@ impl TransactionOutput {
 #[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
 pub enum TransactionInfo {
     V0(TransactionInfoV0),
+    V1(TransactionInfoV1),
 }
 
 impl TransactionInfo {
@@ -2243,6 +2244,28 @@ impl TransactionInfo {
             state_change_hash,
             event_root_hash,
             state_checkpoint_hash,
+            gas_used,
+            status,
+            auxiliary_info_hash,
+        ))
+    }
+
+    pub fn new_v1(
+        transaction_hash: HashValue,
+        state_change_hash: HashValue,
+        event_root_hash: HashValue,
+        state_checkpoint_hash: Option<HashValue>,
+        hot_state_checkpoint_hash: Option<HashValue>,
+        gas_used: u64,
+        status: ExecutionStatus,
+        auxiliary_info_hash: Option<HashValue>,
+    ) -> Self {
+        Self::V1(TransactionInfoV1::new(
+            transaction_hash,
+            state_change_hash,
+            event_root_hash,
+            state_checkpoint_hash,
+            hot_state_checkpoint_hash,
             gas_used,
             status,
             auxiliary_info_hash,
@@ -2278,19 +2301,74 @@ impl TransactionInfo {
             Some(HashValue::default()),
         )
     }
-}
 
-impl Deref for TransactionInfo {
-    type Target = TransactionInfoV0;
-
-    fn deref(&self) -> &Self::Target {
+    pub fn transaction_hash(&self) -> HashValue {
         match self {
-            Self::V0(txn_info) => txn_info,
+            Self::V0(v) => v.transaction_hash,
+            Self::V1(v) => v.transaction_hash,
+        }
+    }
+
+    pub fn state_change_hash(&self) -> HashValue {
+        match self {
+            Self::V0(v) => v.state_change_hash,
+            Self::V1(v) => v.state_change_hash,
+        }
+    }
+
+    pub fn event_root_hash(&self) -> HashValue {
+        match self {
+            Self::V0(v) => v.event_root_hash,
+            Self::V1(v) => v.event_root_hash,
+        }
+    }
+
+    pub fn state_checkpoint_hash(&self) -> Option<HashValue> {
+        match self {
+            Self::V0(v) => v.state_checkpoint_hash,
+            Self::V1(v) => v.state_checkpoint_hash,
+        }
+    }
+
+    pub fn has_state_checkpoint_hash(&self) -> bool {
+        self.state_checkpoint_hash().is_some()
+    }
+
+    pub fn ensure_state_checkpoint_hash(&self) -> Result<HashValue> {
+        self.state_checkpoint_hash()
+            .ok_or_else(|| format_err!("State checkpoint hash not present in TransactionInfo"))
+    }
+
+    pub fn hot_state_checkpoint_hash(&self) -> Option<HashValue> {
+        match self {
+            Self::V0(_) => None,
+            Self::V1(v) => v.hot_state_checkpoint_hash,
+        }
+    }
+
+    pub fn auxiliary_info_hash(&self) -> Option<HashValue> {
+        match self {
+            Self::V0(v) => v.auxiliary_info_hash,
+            Self::V1(v) => v.auxiliary_info_hash,
+        }
+    }
+
+    pub fn gas_used(&self) -> u64 {
+        match self {
+            Self::V0(v) => v.gas_used,
+            Self::V1(v) => v.gas_used,
+        }
+    }
+
+    pub fn status(&self) -> &ExecutionStatus {
+        match self {
+            Self::V0(v) => &v.status,
+            Self::V1(v) => &v.status,
         }
     }
 }
 
-#[derive(Clone, CryptoHasher, BCSCryptoHash, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
 pub struct TransactionInfoV0 {
     /// The amount of gas used.
@@ -2340,42 +2418,60 @@ impl TransactionInfoV0 {
             auxiliary_info_hash,
         }
     }
+}
 
-    pub fn transaction_hash(&self) -> HashValue {
-        self.transaction_hash
-    }
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
+pub struct TransactionInfoV1 {
+    gas_used: u64,
+    status: ExecutionStatus,
+    transaction_hash: HashValue,
+    event_root_hash: HashValue,
+    state_change_hash: HashValue,
+    state_checkpoint_hash: Option<HashValue>,
+    hot_state_checkpoint_hash: Option<HashValue>,
+    auxiliary_info_hash: Option<HashValue>,
 
-    pub fn state_change_hash(&self) -> HashValue {
-        self.state_change_hash
-    }
+    // Reserved for future changes.
+    placeholder0: Option<HashValue>,
+    placeholder1: Option<HashValue>,
+    placeholder2: Option<HashValue>,
+    placeholder3: Option<HashValue>,
+    placeholder4: Option<HashValue>,
+    placeholder5: Option<HashValue>,
+    placeholder6: Option<HashValue>,
+    placeholder7: Option<HashValue>,
+}
 
-    pub fn has_state_checkpoint_hash(&self) -> bool {
-        self.state_checkpoint_hash().is_some()
-    }
-
-    pub fn state_checkpoint_hash(&self) -> Option<HashValue> {
-        self.state_checkpoint_hash
-    }
-
-    pub fn auxiliary_info_hash(&self) -> Option<HashValue> {
-        self.auxiliary_info_hash
-    }
-
-    pub fn ensure_state_checkpoint_hash(&self) -> Result<HashValue> {
-        self.state_checkpoint_hash
-            .ok_or_else(|| format_err!("State checkpoint hash not present in TransactionInfo"))
-    }
-
-    pub fn event_root_hash(&self) -> HashValue {
-        self.event_root_hash
-    }
-
-    pub fn gas_used(&self) -> u64 {
-        self.gas_used
-    }
-
-    pub fn status(&self) -> &ExecutionStatus {
-        &self.status
+impl TransactionInfoV1 {
+    pub fn new(
+        transaction_hash: HashValue,
+        state_change_hash: HashValue,
+        event_root_hash: HashValue,
+        state_checkpoint_hash: Option<HashValue>,
+        hot_state_checkpoint_hash: Option<HashValue>,
+        gas_used: u64,
+        status: ExecutionStatus,
+        auxiliary_info_hash: Option<HashValue>,
+    ) -> Self {
+        Self {
+            gas_used,
+            status,
+            transaction_hash,
+            event_root_hash,
+            state_change_hash,
+            state_checkpoint_hash,
+            hot_state_checkpoint_hash,
+            auxiliary_info_hash,
+            placeholder0: None,
+            placeholder1: None,
+            placeholder2: None,
+            placeholder3: None,
+            placeholder4: None,
+            placeholder5: None,
+            placeholder6: None,
+            placeholder7: None,
+        }
     }
 }
 
@@ -2383,8 +2479,22 @@ impl Display for TransactionInfo {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(
             f,
-            "TransactionInfo: [txn_hash: {}, state_change_hash: {}, event_root_hash: {}, state_checkpoint_hash: {:?}, gas_used: {}, recorded_status: {:?}]",
-            self.transaction_hash(), self.state_change_hash(), self.event_root_hash(), self.state_checkpoint_hash(), self.gas_used(), self.status(),
+            "TransactionInfo: [\
+                txn_hash: {}, \
+                state_change_hash: {}, \
+                event_root_hash: {}, \
+                state_checkpoint_hash: {:?}, \
+                hot_state_checkpoint_hash: {:?}, \
+                gas_used: {}, \
+                recorded_status: {:?}\
+            ]",
+            self.transaction_hash(),
+            self.state_change_hash(),
+            self.event_root_hash(),
+            self.state_checkpoint_hash(),
+            self.hot_state_checkpoint_hash(),
+            self.gas_used(),
+            self.status(),
         )
     }
 }


### PR DESCRIPTION

Introduce `TransactionInfoV1` carrying a new `hot_state_checkpoint_hash`
alongside the existing (cold) `state_checkpoint_hash`, so the hot-state
root can be committed into the per-block transaction accumulator.

Gating is via a new `HotStateConfig::use_transaction_info_v1` bool,
default `false`, following the same devnet-bootstrap pattern as
`use_write_set_v1` and `persist_hotness_in_epilogue`. The flag will be
promoted to an on-chain feature flag before any wider rollout.

Also added a few placeholders for future changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches transaction accumulator contents and state checkpoint/ledger update assembly, so a bug could break state sync/proof verification or cause consensus/state-sync incompatibilities when the flag is enabled.
> 
> **Overview**
> Introduces **`TransactionInfo::V1`** (plus `TransactionInfoV1`) to carry an additional `hot_state_checkpoint_hash` (and reserved placeholders), and updates BCS format generation to include the new enum variant.
> 
> Threads an opt-in `HotStateConfig::use_transaction_info_v1` flag through executor workflows so `DoStateCheckpoint` can optionally compute/accept hot-state checkpoint hashes and `DoLedgerUpdate` assembles either V0 or V1 `TransactionInfo` accordingly; chunk state-sync additionally rejects mixed V0/V1 chunks and passes through known checkpoint hashes for verification.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2592353a839222414b54e712ec13e58c30af3c4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->