### PR TITLE
[dkg] Shrink vectors after construction

### DIFF
--- a/crates/aptos-batch-encryption/src/shared/digest_key_file.rs
+++ b/crates/aptos-batch-encryption/src/shared/digest_key_file.rs
@@ -256,13 +256,15 @@ pub fn read_digest_key_v1_range(
 }
 
 pub fn read_round(file: &File, header: &HeaderV1) -> Result<Round> {
-    let tau_powers_g1: Vec<G1Affine> = (0..header.num_powers_per_round())
+    let mut tau_powers_g1: Vec<G1Affine> = (0..header.num_powers_per_round())
         .map(|_| G1Affine::deserialize_with_mode(file, Compress::No, Validate::No))
         .collect::<std::result::Result<Vec<G1Affine>, SerializationError>>()?;
+    tau_powers_g1.shrink_to_fit();
 
-    let prepared_input_y: Vec<G1Projective> = (0..header.prepared_input_size())
+    let mut prepared_input_y: Vec<G1Projective> = (0..header.prepared_input_size())
         .map(|_| G1Projective::deserialize_with_mode(file, Compress::No, Validate::No))
         .collect::<std::result::Result<Vec<G1Projective>, SerializationError>>()?;
+    prepared_input_y.shrink_to_fit();
 
     Ok(Round {
         tau_powers_g1,


### PR DESCRIPTION

Saves about 1.3GB memory for a testnet node.

We can save more if we don't load everything into memroy all the time.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Memory-only tweak in digest key file loading; no change to cryptography, APIs, or serialization format.
> 
> **Overview**
> After deserializing each digest-key round in `read_round`, the PR calls **`shrink_to_fit()`** on the **`tau_powers_g1`** and **`prepared_input_y`** vectors so their backing capacity matches the element count instead of whatever **`collect`** may have reserved.
> 
> That trims heap use when loading large on-disk digest keys (the author cites ~**1.3GB** saved on a testnet node). Behavior and on-disk format are unchanged; only in-memory **`Vec`** capacity is reduced.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c79b0d9f67404f20bd96c76e93faf10e38de2a8d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->