### PR TITLE
[storage] Cap total write buffer size

### DIFF
--- a/config/src/config/storage_config.rs
+++ b/config/src/config/storage_config.rs
@@ -205,11 +205,15 @@ pub struct RocksdbConfigs {
     pub low_priority_background_threads: i32,
     /// The size of the single block cache shared by all the DB instances in `AptosDB`.
     pub shared_block_cache_size: usize,
+    /// Total memtable memory budget (bytes) shared by all the DB instances in `AptosDB`.
+    pub shared_write_buffer_manager_size: usize,
 }
 
 impl RocksdbConfigs {
     /// Default block cache size is 24GB.
     pub const DEFAULT_BLOCK_CACHE_SIZE: usize = 24 * (1 << 30);
+    /// Default shared write buffer manager budget is 2GB across all CFs/DBs.
+    pub const DEFAULT_WRITE_BUFFER_MANAGER_SIZE: usize = 2 * (1 << 30);
 }
 
 fn default_to_true() -> bool {
@@ -238,6 +242,7 @@ impl Default for RocksdbConfigs {
             high_priority_background_threads: 4,
             low_priority_background_threads: 4,
             shared_block_cache_size: Self::DEFAULT_BLOCK_CACHE_SIZE,
+            shared_write_buffer_manager_size: Self::DEFAULT_WRITE_BUFFER_MANAGER_SIZE,
         }
     }
 }

--- a/storage/aptosdb/src/db/aptosdb_internal.rs
+++ b/storage/aptosdb/src/db/aptosdb_internal.rs
@@ -26,7 +26,7 @@ use aptos_logger::prelude::*;
 use aptos_metrics_core::{IntGaugeVecHelper, TimerHelper};
 #[cfg(any(test, feature = "db-debugger"))]
 use aptos_schemadb::batch::SchemaBatch;
-use aptos_schemadb::{Cache, Env};
+use aptos_schemadb::{Cache, Env, WriteBufferManager};
 #[cfg(test)]
 use aptos_storage_interface::Order;
 use aptos_storage_interface::{
@@ -133,6 +133,13 @@ impl AptosDB {
             rocksdb_configs.shared_block_cache_size,
             /* estimated_entry_charge = */ 0,
         );
+        let write_buffer_manager =
+            (rocksdb_configs.shared_write_buffer_manager_size > 0).then(|| {
+                WriteBufferManager::new_write_buffer_manager(
+                    rocksdb_configs.shared_write_buffer_manager_size,
+                    /* allow_stall = */ false,
+                )
+            });
 
         let (ledger_db, hot_state_merkle_db, state_merkle_db, hot_state_kv_db, state_kv_db) =
             Self::open_dbs(
@@ -140,6 +147,7 @@ impl AptosDB {
                 rocksdb_configs,
                 Some(&env),
                 Some(&block_cache),
+                write_buffer_manager.as_ref(),
                 readonly,
                 max_num_nodes_per_lru_cache_shard,
                 hot_state_config,
@@ -243,6 +251,7 @@ impl AptosDB {
                 RocksdbConfigs::default(),
                 None,  // env
                 None,  // block_cache
+                None,  // write_buffer_manager
                 false, // readonly
                 0,     // max_num_nodes_per_lru_cache_shard
                 HotStateConfig {

--- a/storage/aptosdb/src/db/aptosdb_test.rs
+++ b/storage/aptosdb/src/db/aptosdb_test.rs
@@ -437,6 +437,7 @@ proptest! {
                 RocksdbConfigs::default(),
                 None,
                 None,
+                None,
                 /*readonly=*/ false,
                 /*max_num_nodes_per_lru_cache_shard=*/ 0,
                 HotStateConfig {

--- a/storage/aptosdb/src/db/mod.rs
+++ b/storage/aptosdb/src/db/mod.rs
@@ -10,7 +10,7 @@ use crate::{
 use aptos_config::config::{HotStateConfig, PrunerConfig, RocksdbConfigs, StorageDirPaths};
 use aptos_db_indexer::db_indexer::InternalIndexerDB;
 use aptos_logger::prelude::*;
-use aptos_schemadb::{batch::SchemaBatch, Cache, Env};
+use aptos_schemadb::{batch::SchemaBatch, Cache, Env, WriteBufferManager};
 use aptos_storage_interface::{db_ensure as ensure, AptosDbError, Result};
 use aptos_types::{ledger_info::LedgerInfoWithSignatures, transaction::Version};
 use std::{path::Path, sync::Arc, time::Instant};
@@ -103,6 +103,7 @@ impl AptosDB {
         rocksdb_configs: RocksdbConfigs,
         env: Option<&Env>,
         block_cache: Option<&Cache>,
+        write_buffer_manager: Option<&WriteBufferManager>,
         readonly: bool,
         max_num_nodes_per_lru_cache_shard: usize,
         hot_state_config: HotStateConfig,
@@ -118,6 +119,7 @@ impl AptosDB {
             rocksdb_configs.ledger_db_config,
             env,
             block_cache,
+            write_buffer_manager,
             readonly,
         )?;
         let hot_state_kv_db = if !readonly {
@@ -126,6 +128,7 @@ impl AptosDB {
                 rocksdb_configs.state_kv_db_config,
                 env,
                 block_cache,
+                write_buffer_manager,
                 readonly,
                 /* is_hot = */ true,
                 hot_state_config.delete_on_restart,
@@ -138,6 +141,7 @@ impl AptosDB {
             rocksdb_configs.state_kv_db_config,
             env,
             block_cache,
+            write_buffer_manager,
             readonly,
             /* is_hot = */ false,
             /* delete_on_restart = */ false,
@@ -148,6 +152,7 @@ impl AptosDB {
                 rocksdb_configs.state_merkle_db_config,
                 env,
                 block_cache,
+                write_buffer_manager,
                 readonly,
                 max_num_nodes_per_lru_cache_shard,
                 /* is_hot = */ true,
@@ -161,6 +166,7 @@ impl AptosDB {
             rocksdb_configs.state_merkle_db_config,
             env,
             block_cache,
+            write_buffer_manager,
             readonly,
             max_num_nodes_per_lru_cache_shard,
             /* is_hot = */ false,

--- a/storage/aptosdb/src/db_debugger/common/mod.rs
+++ b/storage/aptosdb/src/db_debugger/common/mod.rs
@@ -21,11 +21,13 @@ impl DbDir {
     pub fn open_state_merkle_db(&self) -> Result<StateMerkleDb> {
         let env = None;
         let block_cache = None;
+        let write_buffer_manager = None;
         StateMerkleDb::new(
             &StorageDirPaths::from_path(&self.db_dir),
             RocksdbConfig::default(),
             env,
             block_cache,
+            write_buffer_manager,
             /* read_only = */ false,
             /* max_nodes_per_lru_cache_shard = */ 0,
             /* is_hot = */ false,
@@ -36,11 +38,13 @@ impl DbDir {
     pub fn open_state_kv_db(&self) -> Result<StateKvDb> {
         let env = None;
         let block_cache = None;
+        let write_buffer_manager = None;
         StateKvDb::new(
             &StorageDirPaths::from_path(&self.db_dir),
             RocksdbConfig::default(),
             env,
             block_cache,
+            write_buffer_manager,
             /* read_only = */ true,
             /* is_hot = */ false,
             /* delete_on_restart = */ false,
@@ -50,11 +54,13 @@ impl DbDir {
     pub fn open_ledger_db(&self) -> Result<LedgerDb> {
         let env = None;
         let block_cache = None;
+        let write_buffer_manager = None;
         LedgerDb::new(
             self.db_dir.as_path(),
             RocksdbConfig::default(),
             env,
             block_cache,
+            write_buffer_manager,
             /*readonly=*/ true,
         )
     }

--- a/storage/aptosdb/src/db_debugger/examine/print_db_versions.rs
+++ b/storage/aptosdb/src/db_debugger/examine/print_db_versions.rs
@@ -36,6 +36,7 @@ impl Cmd {
         let rocksdb_config = RocksdbConfigs::default();
         let env = None;
         let block_cache = None;
+        let write_buffer_manager = None;
         // TODO(HotState): handle hot state merkle db and hot state kv db.
         let (ledger_db, _hot_state_merkle_db, state_merkle_db, _hot_state_kv_db, state_kv_db) =
             AptosDB::open_dbs(
@@ -43,6 +44,7 @@ impl Cmd {
                 rocksdb_config,
                 env,
                 block_cache,
+                write_buffer_manager,
                 /*readonly=*/ true,
                 /*max_num_nodes_per_lru_cache_shard=*/ 0,
                 HotStateConfig {

--- a/storage/aptosdb/src/db_debugger/examine/print_raw_data_by_version.rs
+++ b/storage/aptosdb/src/db_debugger/examine/print_raw_data_by_version.rs
@@ -22,12 +22,14 @@ impl Cmd {
         let rocksdb_config = RocksdbConfigs::default();
         let env = None;
         let block_cache = None;
+        let write_buffer_manager = None;
 
         let (ledger_db, _, _, _, _) = AptosDB::open_dbs(
             &StorageDirPaths::from_path(&self.db_dir),
             rocksdb_config,
             env,
             block_cache,
+            write_buffer_manager,
             /*readonly=*/ true,
             /*max_num_nodes_per_lru_cache_shard=*/ 0,
             HotStateConfig {

--- a/storage/aptosdb/src/db_debugger/truncate/mod.rs
+++ b/storage/aptosdb/src/db_debugger/truncate/mod.rs
@@ -64,6 +64,7 @@ impl Cmd {
                     RocksdbConfigs::default(),
                     None,
                     None,
+                    None,
                     /*readonly=*/ false,
                     /*max_num_nodes_per_lru_cache_shard=*/ 0,
                     HotStateConfig {

--- a/storage/aptosdb/src/db_debugger/validation.rs
+++ b/storage/aptosdb/src/db_debugger/validation.rs
@@ -123,6 +123,7 @@ pub fn verify_state_kvs(
         RocksdbConfig::default(),
         None,
         None,
+        None,
         /* readonly = */ false,
         /* is_hot = */ false,
         /* delete_on_restart = */ false,

--- a/storage/aptosdb/src/ledger_db/mod.rs
+++ b/storage/aptosdb/src/ledger_db/mod.rs
@@ -22,7 +22,9 @@ use aptos_config::config::RocksdbConfig;
 use aptos_experimental_runtimes::thread_manager::THREAD_MANAGER;
 use aptos_logger::prelude::info;
 use aptos_rocksdb_options::gen_rocksdb_options;
-use aptos_schemadb::{batch::SchemaBatch, Cache, ColumnFamilyDescriptor, Env, DB};
+use aptos_schemadb::{
+    batch::SchemaBatch, Cache, ColumnFamilyDescriptor, Env, WriteBufferManager, DB,
+};
 use aptos_storage_interface::Result;
 use aptos_types::transaction::Version;
 use std::{
@@ -114,6 +116,7 @@ impl LedgerDb {
         ledger_db_config: RocksdbConfig,
         env: Option<&Env>,
         block_cache: Option<&Cache>,
+        write_buffer_manager: Option<&WriteBufferManager>,
         readonly: bool,
     ) -> Result<Self> {
         let ledger_metadata_db_path = Self::metadata_db_path(db_root_path.as_ref());
@@ -123,6 +126,7 @@ impl LedgerDb {
             &ledger_db_config,
             env,
             block_cache,
+            write_buffer_manager,
             readonly,
         )?);
 
@@ -149,6 +153,7 @@ impl LedgerDb {
                         &ledger_db_config,
                         env,
                         block_cache,
+                        write_buffer_manager,
                         readonly,
                     )
                     .unwrap(),
@@ -166,6 +171,7 @@ impl LedgerDb {
                         &ledger_db_config,
                         env,
                         block_cache,
+                        write_buffer_manager,
                         readonly,
                     )
                     .unwrap(),
@@ -179,6 +185,7 @@ impl LedgerDb {
                         &ledger_db_config,
                         env,
                         block_cache,
+                        write_buffer_manager,
                         readonly,
                     )
                     .unwrap(),
@@ -192,6 +199,7 @@ impl LedgerDb {
                         &ledger_db_config,
                         env,
                         block_cache,
+                        write_buffer_manager,
                         readonly,
                     )
                     .unwrap(),
@@ -205,6 +213,7 @@ impl LedgerDb {
                         &ledger_db_config,
                         env,
                         block_cache,
+                        write_buffer_manager,
                         readonly,
                     )
                     .unwrap(),
@@ -218,6 +227,7 @@ impl LedgerDb {
                         &ledger_db_config,
                         env,
                         block_cache,
+                        write_buffer_manager,
                         readonly,
                     )
                     .unwrap(),
@@ -231,6 +241,7 @@ impl LedgerDb {
                         &ledger_db_config,
                         env,
                         block_cache,
+                        write_buffer_manager,
                         readonly,
                     )
                     .unwrap(),
@@ -259,6 +270,7 @@ impl LedgerDb {
         let ledger_db = Self::new(
             db_root_path,
             RocksdbConfig::default(),
+            None,
             None,
             None,
             /*readonly=*/ false,
@@ -394,18 +406,19 @@ impl LedgerDb {
         db_config: &RocksdbConfig,
         env: Option<&Env>,
         block_cache: Option<&Cache>,
+        write_buffer_manager: Option<&WriteBufferManager>,
         readonly: bool,
     ) -> Result<DB> {
         let db = if readonly {
             DB::open_cf_readonly(
-                gen_rocksdb_options(db_config, env, true),
+                gen_rocksdb_options(db_config, env, write_buffer_manager, true),
                 path.clone(),
                 name,
                 Self::gen_cfds_by_name(db_config, block_cache, name),
             )?
         } else {
             DB::open_cf(
-                gen_rocksdb_options(db_config, env, false),
+                gen_rocksdb_options(db_config, env, write_buffer_manager, false),
                 path.clone(),
                 name,
                 Self::gen_cfds_by_name(db_config, block_cache, name),

--- a/storage/aptosdb/src/state_kv_db.rs
+++ b/storage/aptosdb/src/state_kv_db.rs
@@ -24,7 +24,7 @@ use aptos_metrics_core::TimerHelper;
 use aptos_rocksdb_options::gen_rocksdb_options;
 use aptos_schemadb::{
     batch::{SchemaBatch, WriteBatch},
-    Cache, Env, ReadOptions, DB,
+    Cache, Env, ReadOptions, WriteBufferManager, DB,
 };
 use aptos_storage_interface::Result;
 use aptos_types::{
@@ -85,6 +85,7 @@ impl StateKvDb {
         state_kv_db_config: RocksdbConfig,
         env: Option<&Env>,
         block_cache: Option<&Cache>,
+        write_buffer_manager: Option<&WriteBufferManager>,
         readonly: bool,
         is_hot: bool,
         delete_on_restart: bool,
@@ -94,6 +95,7 @@ impl StateKvDb {
             state_kv_db_config,
             env,
             block_cache,
+            write_buffer_manager,
             readonly,
             is_hot,
             delete_on_restart,
@@ -105,6 +107,7 @@ impl StateKvDb {
         state_kv_db_config: RocksdbConfig,
         env: Option<&Env>,
         block_cache: Option<&Cache>,
+        write_buffer_manager: Option<&WriteBufferManager>,
         readonly: bool,
         is_hot: bool,
         delete_on_restart: bool,
@@ -127,6 +130,7 @@ impl StateKvDb {
             &state_kv_db_config,
             env,
             block_cache,
+            write_buffer_manager,
             readonly,
             is_hot,
             delete_on_restart,
@@ -152,6 +156,7 @@ impl StateKvDb {
                     &state_kv_db_config,
                     env,
                     block_cache,
+                    write_buffer_manager,
                     readonly,
                     is_hot,
                     delete_on_restart,
@@ -247,6 +252,7 @@ impl StateKvDb {
             RocksdbConfig::default(),
             None,
             None,
+            None,
             /* readonly = */ false,
             is_hot,
             /* delete_on_restart = */ false,
@@ -313,6 +319,7 @@ impl StateKvDb {
         state_kv_db_config: &RocksdbConfig,
         env: Option<&Env>,
         block_cache: Option<&Cache>,
+        write_buffer_manager: Option<&WriteBufferManager>,
         readonly: bool,
         is_hot: bool,
         delete_on_restart: bool,
@@ -328,6 +335,7 @@ impl StateKvDb {
             state_kv_db_config,
             env,
             block_cache,
+            write_buffer_manager,
             readonly,
             is_hot,
             delete_on_restart,
@@ -340,6 +348,7 @@ impl StateKvDb {
         state_kv_db_config: &RocksdbConfig,
         env: Option<&Env>,
         block_cache: Option<&Cache>,
+        write_buffer_manager: Option<&WriteBufferManager>,
         readonly: bool,
         is_hot: bool,
         delete_on_restart: bool,
@@ -350,7 +359,8 @@ impl StateKvDb {
             std::fs::remove_dir_all(&path).unwrap_or(());
         }
 
-        let rocksdb_opts = gen_rocksdb_options(state_kv_db_config, env, readonly);
+        let rocksdb_opts =
+            gen_rocksdb_options(state_kv_db_config, env, write_buffer_manager, readonly);
         let cfds = if is_hot {
             gen_hot_state_kv_shard_cfds(state_kv_db_config, block_cache)
         } else {

--- a/storage/aptosdb/src/state_merkle_db.rs
+++ b/storage/aptosdb/src/state_merkle_db.rs
@@ -26,7 +26,7 @@ use aptos_config::config::{RocksdbConfig, StorageDirPaths};
 use aptos_jellyfish_merkle::{node_type::NodeKey, TreeReader, TreeWriter};
 use aptos_logger::prelude::*;
 use aptos_rocksdb_options::gen_rocksdb_options;
-use aptos_schemadb::{Cache, Env, DB};
+use aptos_schemadb::{Cache, Env, WriteBufferManager, DB};
 use aptos_storage_interface::{db_ensure as ensure, AptosDbError, Result};
 use aptos_types::{
     state_store::{state_key::StateKey, NUM_STATE_SHARDS},
@@ -79,6 +79,7 @@ impl StateMerkleDb {
         state_merkle_db_config: RocksdbConfig,
         env: Option<&Env>,
         block_cache: Option<&Cache>,
+        write_buffer_manager: Option<&WriteBufferManager>,
         readonly: bool,
         // TODO(grao): Currently when this value is set to 0 we disable both caches. This is
         // hacky, need to revisit.
@@ -96,6 +97,7 @@ impl StateMerkleDb {
             state_merkle_db_config,
             env,
             block_cache,
+            write_buffer_manager,
             readonly,
             max_nodes_per_lru_cache_shard,
             is_hot,
@@ -114,6 +116,7 @@ impl StateMerkleDb {
             RocksdbConfig::default(),
             /*env=*/ None,
             /*block_cache=*/ None,
+            /*write_buffer_manager=*/ None,
             /*readonly=*/ false,
             /*max_nodes_per_lru_cache_shard=*/ 0,
             is_hot,
@@ -144,6 +147,7 @@ impl StateMerkleDb {
         state_merkle_db_config: RocksdbConfig,
         env: Option<&Env>,
         block_cache: Option<&Cache>,
+        write_buffer_manager: Option<&WriteBufferManager>,
         readonly: bool,
         max_nodes_per_lru_cache_shard: usize,
         is_hot: bool,
@@ -164,6 +168,7 @@ impl StateMerkleDb {
             &state_merkle_db_config,
             env,
             block_cache,
+            write_buffer_manager,
             readonly,
             delete_on_restart,
         )?);
@@ -187,6 +192,7 @@ impl StateMerkleDb {
                     &state_merkle_db_config,
                     env,
                     block_cache,
+                    write_buffer_manager,
                     readonly,
                     is_hot,
                     delete_on_restart,
@@ -230,6 +236,7 @@ impl StateMerkleDb {
         state_merkle_db_config: &RocksdbConfig,
         env: Option<&Env>,
         block_cache: Option<&Cache>,
+        write_buffer_manager: Option<&WriteBufferManager>,
         readonly: bool,
         is_hot: bool,
         delete_on_restart: bool,
@@ -245,6 +252,7 @@ impl StateMerkleDb {
             state_merkle_db_config,
             env,
             block_cache,
+            write_buffer_manager,
             readonly,
             delete_on_restart,
         )
@@ -256,6 +264,7 @@ impl StateMerkleDb {
         state_merkle_db_config: &RocksdbConfig,
         env: Option<&Env>,
         block_cache: Option<&Cache>,
+        write_buffer_manager: Option<&WriteBufferManager>,
         readonly: bool,
         delete_on_restart: bool,
     ) -> Result<DB> {
@@ -267,14 +276,14 @@ impl StateMerkleDb {
 
         Ok(if readonly {
             DB::open_cf_readonly(
-                gen_rocksdb_options(state_merkle_db_config, env, true),
+                gen_rocksdb_options(state_merkle_db_config, env, write_buffer_manager, true),
                 path,
                 name,
                 gen_state_merkle_cfds(state_merkle_db_config, block_cache),
             )?
         } else {
             DB::open_cf(
-                gen_rocksdb_options(state_merkle_db_config, env, false),
+                gen_rocksdb_options(state_merkle_db_config, env, write_buffer_manager, false),
                 path,
                 name,
                 gen_state_merkle_cfds(state_merkle_db_config, block_cache),

--- a/storage/aptosdb/src/state_store/tests/hot_state_kv.rs
+++ b/storage/aptosdb/src/state_store/tests/hot_state_kv.rs
@@ -35,6 +35,7 @@ fn create_hot_state_kv_db(path: &TempPath) -> StateKvDb {
         RocksdbConfig::default(),
         /* env = */ None,
         /* block_cache = */ None,
+        /* write_buffer_manager = */ None,
         /* readonly = */ false,
         /* is_hot = */ true,
         /* delete_on_restart = */ false,

--- a/storage/indexer/src/db_ops.rs
+++ b/storage/indexer/src/db_ops.rs
@@ -17,19 +17,20 @@ pub fn open_db<P: AsRef<Path>>(
     readonly: bool,
 ) -> Result<DB> {
     let env = None;
+    let write_buffer_manager = None;
     if readonly {
         Ok(DB::open_readonly(
             db_path,
             TABLE_INFO_DB_NAME,
             column_families(),
-            gen_rocksdb_options(rocksdb_config, env, readonly),
+            gen_rocksdb_options(rocksdb_config, env, write_buffer_manager, readonly),
         )?)
     } else {
         Ok(DB::open(
             db_path,
             TABLE_INFO_DB_NAME,
             column_families(),
-            gen_rocksdb_options(rocksdb_config, env, readonly),
+            gen_rocksdb_options(rocksdb_config, env, write_buffer_manager, readonly),
         )?)
     }
 }
@@ -39,11 +40,12 @@ pub fn open_internal_indexer_db<P: AsRef<Path>>(
     rocksdb_config: &RocksdbConfig,
 ) -> Result<DB> {
     let env = None;
+    let write_buffer_manager = None;
     Ok(DB::open(
         db_path,
         INTERNAL_INDEXER_DB_NAME,
         internal_indexer_column_families(),
-        gen_rocksdb_options(rocksdb_config, env, false),
+        gen_rocksdb_options(rocksdb_config, env, write_buffer_manager, false),
     )?)
 }
 

--- a/storage/rocksdb-options/src/lib.rs
+++ b/storage/rocksdb-options/src/lib.rs
@@ -2,7 +2,7 @@
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use aptos_config::config::{RocksDBStatsLevel, RocksdbConfig};
-use rocksdb::{statistics::StatsLevel, Env, Options};
+use rocksdb::{statistics::StatsLevel, Env, Options, WriteBufferManager};
 
 // TODO: Clean this up. It is currently separated into its own crate
 // to avoid circular dependencies, because it depends on aptos-config (which
@@ -19,10 +19,18 @@ fn convert_stats_level(level: RocksDBStatsLevel) -> StatsLevel {
     }
 }
 
-pub fn gen_rocksdb_options(config: &RocksdbConfig, env: Option<&Env>, readonly: bool) -> Options {
+pub fn gen_rocksdb_options(
+    config: &RocksdbConfig,
+    env: Option<&Env>,
+    write_buffer_manager: Option<&WriteBufferManager>,
+    readonly: bool,
+) -> Options {
     let mut db_opts = Options::default();
     if let Some(env) = env {
         db_opts.set_env(env);
+    }
+    if let Some(wbm) = write_buffer_manager {
+        db_opts.set_write_buffer_manager(wbm);
     }
     db_opts.set_max_open_files(config.max_open_files);
     db_opts.set_max_total_wal_size(config.max_total_wal_size);

--- a/storage/schemadb/src/lib.rs
+++ b/storage/schemadb/src/lib.rs
@@ -36,7 +36,8 @@ use iterator::{ScanDirection, SchemaIterator};
 /// Type alias to `rocksdb::ReadOptions`. See [`rocksdb doc`](https://github.com/pingcap/rust-rocksdb/blob/master/src/rocksdb_options.rs)
 pub use rocksdb::{
     statistics::Ticker, BlockBasedIndexType, BlockBasedOptions, Cache, ColumnFamilyDescriptor,
-    DBCompressionType, Env, Options, ReadOptions, SliceTransform, DEFAULT_COLUMN_FAMILY_NAME,
+    DBCompressionType, Env, Options, ReadOptions, SliceTransform, WriteBufferManager,
+    DEFAULT_COLUMN_FAMILY_NAME,
 };
 use rocksdb::{ErrorKind, WriteOptions};
 use std::{collections::HashSet, fmt, iter::Iterator, path::Path};


### PR DESCRIPTION

As we introduce more DB instances and column families, the memory cost of write
buffers has grown to several GBs, since each CF holds its own memtable which can
often be 10s of MBs.

This commit caps the total size to 2GB.
