### PR TITLE
[move-prover][trivial] Fix duplicated deref in enum

### DIFF
--- a/third_party/move/move-prover/boogie-backend/src/bytecode_translator.rs
+++ b/third_party/move/move-prover/boogie-backend/src/bytecode_translator.rs
@@ -6190,7 +6190,12 @@ impl FunctionTranslator<'_> {
                     GetVariantField(mid, sid, variants, inst, field_offset) => {
                         let inst = &self.inst_slice(inst);
                         let src = srcs[0];
-                        let mut src_str = str_local(src);
+                        let src_str = str_local(src);
+                        let value_str = if self.get_local_type(src).is_reference() {
+                            format!("$Dereference({})", src_str)
+                        } else {
+                            src_str
+                        };
                         let dest_str = str_local(dests[0]);
                         let struct_env = env.get_module(*mid).into_struct(*sid);
                         self.check_intrinsic_select(attr_id, &struct_env);
@@ -6198,9 +6203,6 @@ impl FunctionTranslator<'_> {
                         // Need to go through all variants to find the correct field
                         for variant in variants {
                             emitln!(writer, "{} if (", else_symbol);
-                            if self.get_local_type(src).is_reference() {
-                                src_str = format!("$Dereference({})", src_str);
-                            };
                             let struct_variant_name =
                                 boogie_struct_variant_name(&struct_env, inst, *variant);
                             let field_env = struct_env.get_field_by_offset_optional_variant(
@@ -6208,8 +6210,8 @@ impl FunctionTranslator<'_> {
                                 *field_offset,
                             );
                             let field_sel = boogie_field_sel(&field_env);
-                            emit!(writer, "{} is {}) {{", src_str, struct_variant_name);
-                            emitln!(writer, "{} := {}->{};", dest_str, src_str, field_sel);
+                            emit!(writer, "{} is {}) {{", value_str, struct_variant_name);
+                            emitln!(writer, "{} := {}->{};", dest_str, value_str, field_sel);
                             emitln!(writer, "}");
                             if else_symbol.is_empty() {
                                 else_symbol = " else ";

--- a/third_party/move/move-prover/tests/sources/functional/enum_19872.move
+++ b/third_party/move/move-prover/tests/sources/functional/enum_19872.move
@@ -1,0 +1,31 @@
+// Regression test for https://github.com/aptos-labs/aptos-core/issues/19872
+//
+// Reading a common field via projection on `&mut Enum` (where the enum has
+// 2+ variants sharing that field name) used to cause the Move-to-Boogie
+// translator to emit an extra `$Dereference` call for each subsequent
+// variant arm in the synthesized match, breaking Boogie type-checking.
+
+module 0x42::enum_match_repro {
+    enum Foo has key {
+        V1 { val: u64 },
+        V2 { val: u64 },
+        V3 { val: u64 },
+    }
+
+    public fun read_val(self: &mut Foo): u64 {
+        self.val
+    }
+
+    spec read_val {
+        aborts_if false;
+    }
+
+    public fun write_val(self: &mut Foo, v: u64) {
+        self.val = v;
+    }
+
+    spec write_val {
+        aborts_if false;
+        ensures self.val == v;
+    }
+}


### PR DESCRIPTION
## Description

When a function reads a common field via projection on `&mut Enum` (where the enum has 2+ variants sharing that field name), the Move-to-Boogie translator emitted a spurious extra `$Dereference` call for each subsequent variant arm in the synthesized match. Boogie then rejected the program with type-checking errors:

```
if ($Dereference($t0) is Foo_V1) { ... }                                  // 1 deref — correct
else if ($Dereference($Dereference($t0)) is Foo_V2) { ... }               // 2 derefs — WRONG
else if ($Dereference($Dereference($Dereference($t0))) is Foo_V3) { ... } // 3 derefs — WRONG
```

**Root cause:** in `GetVariantField` (`bytecode_translator.rs`), `src_str` was mutably reassigned inside the per-variant loop:

```rust
if self.get_local_type(src).is_reference() {
    src_str = format!("$Dereference({})", src_str);  // accumulates each iteration
};
```

On iteration 2 `src_str` was already `$Dereference($t0)`, so wrapping again produced `$Dereference($Dereference($t0))`, and so on.

**Fix:** compute the dereferenced expression once before the loop, mirroring the already-correct `BorrowVariantField` pattern a few lines above.

## How Has This Been Tested?

- Added regression test `third_party/move/move-prover/tests/sources/functional/enum_19872.move` exercising both field read (`self.val`) and field write (`self.val = v`) through `&mut Foo` on a 3-variant enum with a common field. Before the fix this test produces 6 Boogie type-check errors matching the issue; after the fix it verifies cleanly.
- Full `cargo test -p move-prover --test testsuite` passes (233 tests, including all 10 enum-related tests).

## Key Areas to Review

- `third_party/move/move-prover/boogie-backend/src/bytecode_translator.rs` — the `GetVariantField` arm. Confirm the new shape matches the existing `BorrowVariantField` handling immediately above (single dereference computed before the loop, reused per variant arm).

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [x] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [x] Other (specify): Move Prover

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized translator fix aligned with existing `BorrowVariantField` behavior; regression test added.
> 
> **Overview**
> Fixes the Move Prover’s Boogie backend when **common enum fields** are read through a reference on enums with multiple variants sharing the same field name.
> 
> `GetVariantField` used to wrap `src_str` in `$Dereference` **inside** the per-variant loop, so each `else if` arm accumulated another deref and Boogie type-checking failed. The translator now builds a single `value_str` (with at most one `$Dereference`) **before** the loop, matching `BorrowVariantField`.
> 
> A regression test covers read/write of a shared field on a 3-variant enum via `&mut`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47de92d575cbc03d51db7a65e5c06f70a6bb1a28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->