### PR TITLE
[move-prover] fix div/mod for signed integers in Move prover

### DIFF
--- a/third_party/move/move-prover/boogie-backend/src/boogie_helpers.rs
+++ b/third_party/move/move-prover/boogie-backend/src/boogie_helpers.rs
@@ -461,6 +461,29 @@ pub fn boogie_num_type_string_capital(kind: &str, num: &str, bv_flag: bool) -> S
     [pre, num].join("")
 }
 
+/// Boogie procedure-name suffix for an integer-typed dest of an arithmetic op,
+/// e.g. `U64`, `I128`, `Bv32`. Used by the `Add`/`Sub`/`Mul`/`Div`/`Mod` arms of
+/// the bytecode translator to dispatch to the right per-type Boogie procedure.
+/// Panics if `ty` is not a primitive integer.
+pub fn boogie_int_suffix(ty: &Type, bv_flag: bool) -> String {
+    use PrimitiveType::*;
+    match ty {
+        Type::Primitive(U8) => boogie_num_type_string_capital("U", "8", bv_flag),
+        Type::Primitive(U16) => boogie_num_type_string_capital("U", "16", bv_flag),
+        Type::Primitive(U32) => boogie_num_type_string_capital("U", "32", bv_flag),
+        Type::Primitive(U64) => boogie_num_type_string_capital("U", "64", bv_flag),
+        Type::Primitive(U128) => boogie_num_type_string_capital("U", "128", bv_flag),
+        Type::Primitive(U256) => boogie_num_type_string_capital("U", "256", bv_flag),
+        Type::Primitive(I8) => boogie_num_type_string_capital("I", "8", bv_flag),
+        Type::Primitive(I16) => boogie_num_type_string_capital("I", "16", bv_flag),
+        Type::Primitive(I32) => boogie_num_type_string_capital("I", "32", bv_flag),
+        Type::Primitive(I64) => boogie_num_type_string_capital("I", "64", bv_flag),
+        Type::Primitive(I128) => boogie_num_type_string_capital("I", "128", bv_flag),
+        Type::Primitive(I256) => boogie_num_type_string_capital("I", "256", bv_flag),
+        _ => unreachable!("non-integer dest for arithmetic op"),
+    }
+}
+
 /// Return the boogie base type for a number type.
 /// If `bv_flag` is true, returns "Bv8", "Bv16", etc. for bitvector types.
 /// Otherwise returns "8", "16", etc. for integer types.

--- a/third_party/move/move-prover/boogie-backend/src/bytecode_translator.rs
+++ b/third_party/move/move-prover/boogie-backend/src/bytecode_translator.rs
@@ -6770,29 +6770,55 @@ impl FunctionTranslator<'_> {
                             .get_temp_index_oper(mid, fid, dest, baseline_flag)
                             .unwrap();
                         let bv_flag = self.bv_flag(num_oper);
-                        let div_type = if bv_flag {
-                            match &self.get_local_type(dest) {
-                                Type::Primitive(PrimitiveType::U8) => "Bv8".to_string(),
-                                Type::Primitive(PrimitiveType::U16) => "Bv16".to_string(),
-                                Type::Primitive(PrimitiveType::U32) => "Bv32".to_string(),
-                                Type::Primitive(PrimitiveType::U64) => "Bv64".to_string(),
-                                Type::Primitive(PrimitiveType::U128) => "Bv128".to_string(),
-                                Type::Primitive(PrimitiveType::U256) => "Bv256".to_string(),
-                                Type::Primitive(_)
-                                | Type::Tuple(_)
-                                | Type::Vector(_)
-                                | Type::Struct(_, _, _)
-                                | Type::TypeParameter(_)
-                                | Type::Reference(_, _)
-                                | Type::Fun(..)
-                                | Type::TypeDomain(_)
-                                | Type::ResourceDomain(_, _, _)
-                                | Type::StateDomain
-                                | Type::Error
-                                | Type::Var(_) => unreachable!(),
-                            }
-                        } else {
-                            "".to_string()
+                        let div_type = match &self.get_local_type(dest) {
+                            Type::Primitive(PrimitiveType::U8) => {
+                                boogie_num_type_string_capital("U", "8", bv_flag)
+                            },
+                            Type::Primitive(PrimitiveType::U16) => {
+                                boogie_num_type_string_capital("U", "16", bv_flag)
+                            },
+                            Type::Primitive(PrimitiveType::U32) => {
+                                boogie_num_type_string_capital("U", "32", bv_flag)
+                            },
+                            Type::Primitive(PrimitiveType::U64) => {
+                                boogie_num_type_string_capital("U", "64", bv_flag)
+                            },
+                            Type::Primitive(PrimitiveType::U128) => {
+                                boogie_num_type_string_capital("U", "128", bv_flag)
+                            },
+                            Type::Primitive(PrimitiveType::U256) => {
+                                boogie_num_type_string_capital("U", "256", bv_flag)
+                            },
+                            Type::Primitive(PrimitiveType::I8) => {
+                                boogie_num_type_string_capital("I", "8", bv_flag)
+                            },
+                            Type::Primitive(PrimitiveType::I16) => {
+                                boogie_num_type_string_capital("I", "16", bv_flag)
+                            },
+                            Type::Primitive(PrimitiveType::I32) => {
+                                boogie_num_type_string_capital("I", "32", bv_flag)
+                            },
+                            Type::Primitive(PrimitiveType::I64) => {
+                                boogie_num_type_string_capital("I", "64", bv_flag)
+                            },
+                            Type::Primitive(PrimitiveType::I128) => {
+                                boogie_num_type_string_capital("I", "128", bv_flag)
+                            },
+                            Type::Primitive(PrimitiveType::I256) => {
+                                boogie_num_type_string_capital("I", "256", bv_flag)
+                            },
+                            Type::Primitive(_)
+                            | Type::Tuple(_)
+                            | Type::Vector(_)
+                            | Type::Struct(_, _, _)
+                            | Type::TypeParameter(_)
+                            | Type::Reference(_, _)
+                            | Type::Fun(..)
+                            | Type::TypeDomain(_)
+                            | Type::ResourceDomain(_, _, _)
+                            | Type::StateDomain
+                            | Type::Error
+                            | Type::Var(_) => unreachable!(),
                         };
                         emitln!(
                             writer,
@@ -6811,29 +6837,55 @@ impl FunctionTranslator<'_> {
                             .get_temp_index_oper(mid, fid, dest, baseline_flag)
                             .unwrap();
                         let bv_flag = self.bv_flag(num_oper);
-                        let mod_type = if bv_flag {
-                            match &self.get_local_type(dest) {
-                                Type::Primitive(PrimitiveType::U8) => "Bv8".to_string(),
-                                Type::Primitive(PrimitiveType::U16) => "Bv16".to_string(),
-                                Type::Primitive(PrimitiveType::U32) => "Bv32".to_string(),
-                                Type::Primitive(PrimitiveType::U64) => "Bv64".to_string(),
-                                Type::Primitive(PrimitiveType::U128) => "Bv128".to_string(),
-                                Type::Primitive(PrimitiveType::U256) => "Bv256".to_string(),
-                                Type::Primitive(_)
-                                | Type::Tuple(_)
-                                | Type::Vector(_)
-                                | Type::Struct(_, _, _)
-                                | Type::TypeParameter(_)
-                                | Type::Reference(_, _)
-                                | Type::Fun(..)
-                                | Type::TypeDomain(_)
-                                | Type::ResourceDomain(_, _, _)
-                                | Type::StateDomain
-                                | Type::Error
-                                | Type::Var(_) => unreachable!(),
-                            }
-                        } else {
-                            "".to_string()
+                        let mod_type = match &self.get_local_type(dest) {
+                            Type::Primitive(PrimitiveType::U8) => {
+                                boogie_num_type_string_capital("U", "8", bv_flag)
+                            },
+                            Type::Primitive(PrimitiveType::U16) => {
+                                boogie_num_type_string_capital("U", "16", bv_flag)
+                            },
+                            Type::Primitive(PrimitiveType::U32) => {
+                                boogie_num_type_string_capital("U", "32", bv_flag)
+                            },
+                            Type::Primitive(PrimitiveType::U64) => {
+                                boogie_num_type_string_capital("U", "64", bv_flag)
+                            },
+                            Type::Primitive(PrimitiveType::U128) => {
+                                boogie_num_type_string_capital("U", "128", bv_flag)
+                            },
+                            Type::Primitive(PrimitiveType::U256) => {
+                                boogie_num_type_string_capital("U", "256", bv_flag)
+                            },
+                            Type::Primitive(PrimitiveType::I8) => {
+                                boogie_num_type_string_capital("I", "8", bv_flag)
+                            },
+                            Type::Primitive(PrimitiveType::I16) => {
+                                boogie_num_type_string_capital("I", "16", bv_flag)
+                            },
+                            Type::Primitive(PrimitiveType::I32) => {
+                                boogie_num_type_string_capital("I", "32", bv_flag)
+                            },
+                            Type::Primitive(PrimitiveType::I64) => {
+                                boogie_num_type_string_capital("I", "64", bv_flag)
+                            },
+                            Type::Primitive(PrimitiveType::I128) => {
+                                boogie_num_type_string_capital("I", "128", bv_flag)
+                            },
+                            Type::Primitive(PrimitiveType::I256) => {
+                                boogie_num_type_string_capital("I", "256", bv_flag)
+                            },
+                            Type::Primitive(_)
+                            | Type::Tuple(_)
+                            | Type::Vector(_)
+                            | Type::Struct(_, _, _)
+                            | Type::TypeParameter(_)
+                            | Type::Reference(_, _)
+                            | Type::Fun(..)
+                            | Type::TypeDomain(_)
+                            | Type::ResourceDomain(_, _, _)
+                            | Type::StateDomain
+                            | Type::Error
+                            | Type::Var(_) => unreachable!(),
                         };
                         emitln!(
                             writer,

--- a/third_party/move/move-prover/boogie-backend/src/bytecode_translator.rs
+++ b/third_party/move/move-prover/boogie-backend/src/bytecode_translator.rs
@@ -13,9 +13,9 @@ use crate::{
         boogie_closure_pack_name, boogie_constant_blob, boogie_debug_track_abort,
         boogie_debug_track_local, boogie_debug_track_return, boogie_equality_for_type,
         boogie_field_sel, boogie_field_update, boogie_fun_apply_name, boogie_fun_param_name,
-        boogie_function_name, boogie_make_vec_from_strings, boogie_modifies_memory_name,
-        boogie_native_spec_fun_name, boogie_num_literal, boogie_num_type_base,
-        boogie_num_type_string_capital, boogie_reflection_type_info, boogie_reflection_type_name,
+        boogie_function_name, boogie_int_suffix, boogie_make_vec_from_strings,
+        boogie_modifies_memory_name, boogie_native_spec_fun_name, boogie_num_literal,
+        boogie_num_type_base, boogie_reflection_type_info, boogie_reflection_type_name,
         boogie_resource_memory_name, boogie_spec_fun_name, boogie_struct_field_name,
         boogie_struct_field_result_fun_name, boogie_struct_field_spec_fun_name, boogie_struct_name,
         boogie_struct_variant_name, boogie_temp, boogie_temp_from_suffix, boogie_type,
@@ -6547,77 +6547,11 @@ impl FunctionTranslator<'_> {
                             .unwrap();
                         let bv_flag = self.bv_flag(num_oper);
 
+                        let suffix = boogie_int_suffix(&self.get_local_type(dest), bv_flag);
+                        // Quirk: U8 omits the _unchecked suffix even when set.
                         let add_type = match &self.get_local_type(dest) {
-                            Type::Primitive(PrimitiveType::U8) => {
-                                boogie_num_type_string_capital("U", "8", bv_flag)
-                            },
-                            Type::Primitive(PrimitiveType::U16) => format!(
-                                "{}{}",
-                                boogie_num_type_string_capital("U", "16", bv_flag),
-                                unchecked
-                            ),
-                            Type::Primitive(PrimitiveType::U32) => format!(
-                                "{}{}",
-                                boogie_num_type_string_capital("U", "32", bv_flag),
-                                unchecked
-                            ),
-                            Type::Primitive(PrimitiveType::U64) => format!(
-                                "{}{}",
-                                boogie_num_type_string_capital("U", "64", bv_flag),
-                                unchecked
-                            ),
-                            Type::Primitive(PrimitiveType::U128) => format!(
-                                "{}{}",
-                                boogie_num_type_string_capital("U", "128", bv_flag),
-                                unchecked
-                            ),
-                            Type::Primitive(PrimitiveType::U256) => format!(
-                                "{}{}",
-                                boogie_num_type_string_capital("U", "256", bv_flag),
-                                unchecked
-                            ),
-                            Type::Primitive(PrimitiveType::I8) => format!(
-                                "{}{}",
-                                boogie_num_type_string_capital("I", "8", bv_flag),
-                                unchecked
-                            ),
-                            Type::Primitive(PrimitiveType::I16) => format!(
-                                "{}{}",
-                                boogie_num_type_string_capital("I", "16", bv_flag),
-                                unchecked
-                            ),
-                            Type::Primitive(PrimitiveType::I32) => format!(
-                                "{}{}",
-                                boogie_num_type_string_capital("I", "32", bv_flag),
-                                unchecked
-                            ),
-                            Type::Primitive(PrimitiveType::I64) => format!(
-                                "{}{}",
-                                boogie_num_type_string_capital("I", "64", bv_flag),
-                                unchecked
-                            ),
-                            Type::Primitive(PrimitiveType::I128) => format!(
-                                "{}{}",
-                                boogie_num_type_string_capital("I", "128", bv_flag),
-                                unchecked
-                            ),
-                            Type::Primitive(PrimitiveType::I256) => format!(
-                                "{}{}",
-                                boogie_num_type_string_capital("I", "256", bv_flag),
-                                unchecked
-                            ),
-                            Type::Primitive(_)
-                            | Type::Tuple(_)
-                            | Type::Vector(_)
-                            | Type::Struct(_, _, _)
-                            | Type::TypeParameter(_)
-                            | Type::Reference(_, _)
-                            | Type::Fun(..)
-                            | Type::TypeDomain(_)
-                            | Type::ResourceDomain(_, _, _)
-                            | Type::StateDomain
-                            | Type::Error
-                            | Type::Var(_) => unreachable!(),
+                            Type::Primitive(PrimitiveType::U8) => suffix,
+                            _ => format!("{}{}", suffix, unchecked),
                         };
                         emitln!(
                             writer,
@@ -6636,56 +6570,7 @@ impl FunctionTranslator<'_> {
                             .get_temp_index_oper(mid, fid, dest, baseline_flag)
                             .unwrap();
                         let bv_flag = self.bv_flag(num_oper);
-                        let sub_type = match &self.get_local_type(dest) {
-                            Type::Primitive(PrimitiveType::U8) => {
-                                boogie_num_type_string_capital("U", "8", bv_flag)
-                            },
-                            Type::Primitive(PrimitiveType::U16) => {
-                                boogie_num_type_string_capital("U", "16", bv_flag)
-                            },
-                            Type::Primitive(PrimitiveType::U32) => {
-                                boogie_num_type_string_capital("U", "32", bv_flag)
-                            },
-                            Type::Primitive(PrimitiveType::U64) => {
-                                boogie_num_type_string_capital("U", "64", bv_flag)
-                            },
-                            Type::Primitive(PrimitiveType::U128) => {
-                                boogie_num_type_string_capital("U", "128", bv_flag)
-                            },
-                            Type::Primitive(PrimitiveType::U256) => {
-                                boogie_num_type_string_capital("U", "256", bv_flag)
-                            },
-                            Type::Primitive(PrimitiveType::I8) => {
-                                boogie_num_type_string_capital("I", "8", bv_flag)
-                            },
-                            Type::Primitive(PrimitiveType::I16) => {
-                                boogie_num_type_string_capital("I", "16", bv_flag)
-                            },
-                            Type::Primitive(PrimitiveType::I32) => {
-                                boogie_num_type_string_capital("I", "32", bv_flag)
-                            },
-                            Type::Primitive(PrimitiveType::I64) => {
-                                boogie_num_type_string_capital("I", "64", bv_flag)
-                            },
-                            Type::Primitive(PrimitiveType::I128) => {
-                                boogie_num_type_string_capital("I", "128", bv_flag)
-                            },
-                            Type::Primitive(PrimitiveType::I256) => {
-                                boogie_num_type_string_capital("I", "256", bv_flag)
-                            },
-                            Type::Primitive(_)
-                            | Type::Tuple(_)
-                            | Type::Vector(_)
-                            | Type::Struct(_, _, _)
-                            | Type::TypeParameter(_)
-                            | Type::Reference(_, _)
-                            | Type::Fun(..)
-                            | Type::TypeDomain(_)
-                            | Type::ResourceDomain(_, _, _)
-                            | Type::StateDomain
-                            | Type::Error
-                            | Type::Var(_) => unreachable!(),
-                        };
+                        let sub_type = boogie_int_suffix(&self.get_local_type(dest), bv_flag);
                         emitln!(
                             writer,
                             "call {} := $Sub{}({}, {});",
@@ -6703,56 +6588,7 @@ impl FunctionTranslator<'_> {
                             .get_temp_index_oper(mid, fid, dest, baseline_flag)
                             .unwrap();
                         let bv_flag = self.bv_flag(num_oper);
-                        let mul_type = match &self.get_local_type(dest) {
-                            Type::Primitive(PrimitiveType::U8) => {
-                                boogie_num_type_string_capital("U", "8", bv_flag)
-                            },
-                            Type::Primitive(PrimitiveType::U16) => {
-                                boogie_num_type_string_capital("U", "16", bv_flag)
-                            },
-                            Type::Primitive(PrimitiveType::U32) => {
-                                boogie_num_type_string_capital("U", "32", bv_flag)
-                            },
-                            Type::Primitive(PrimitiveType::U64) => {
-                                boogie_num_type_string_capital("U", "64", bv_flag)
-                            },
-                            Type::Primitive(PrimitiveType::U128) => {
-                                boogie_num_type_string_capital("U", "128", bv_flag)
-                            },
-                            Type::Primitive(PrimitiveType::U256) => {
-                                boogie_num_type_string_capital("U", "256", bv_flag)
-                            },
-                            Type::Primitive(PrimitiveType::I8) => {
-                                boogie_num_type_string_capital("I", "8", bv_flag)
-                            },
-                            Type::Primitive(PrimitiveType::I16) => {
-                                boogie_num_type_string_capital("I", "16", bv_flag)
-                            },
-                            Type::Primitive(PrimitiveType::I32) => {
-                                boogie_num_type_string_capital("I", "32", bv_flag)
-                            },
-                            Type::Primitive(PrimitiveType::I64) => {
-                                boogie_num_type_string_capital("I", "64", bv_flag)
-                            },
-                            Type::Primitive(PrimitiveType::I128) => {
-                                boogie_num_type_string_capital("I", "128", bv_flag)
-                            },
-                            Type::Primitive(PrimitiveType::I256) => {
-                                boogie_num_type_string_capital("I", "256", bv_flag)
-                            },
-                            Type::Primitive(_)
-                            | Type::Tuple(_)
-                            | Type::Vector(_)
-                            | Type::Struct(_, _, _)
-                            | Type::TypeParameter(_)
-                            | Type::Reference(_, _)
-                            | Type::Fun(..)
-                            | Type::TypeDomain(_)
-                            | Type::ResourceDomain(_, _, _)
-                            | Type::StateDomain
-                            | Type::Error
-                            | Type::Var(_) => unreachable!(),
-                        };
+                        let mul_type = boogie_int_suffix(&self.get_local_type(dest), bv_flag);
                         emitln!(
                             writer,
                             "call {} := $Mul{}({}, {});",
@@ -6770,56 +6606,7 @@ impl FunctionTranslator<'_> {
                             .get_temp_index_oper(mid, fid, dest, baseline_flag)
                             .unwrap();
                         let bv_flag = self.bv_flag(num_oper);
-                        let div_type = match &self.get_local_type(dest) {
-                            Type::Primitive(PrimitiveType::U8) => {
-                                boogie_num_type_string_capital("U", "8", bv_flag)
-                            },
-                            Type::Primitive(PrimitiveType::U16) => {
-                                boogie_num_type_string_capital("U", "16", bv_flag)
-                            },
-                            Type::Primitive(PrimitiveType::U32) => {
-                                boogie_num_type_string_capital("U", "32", bv_flag)
-                            },
-                            Type::Primitive(PrimitiveType::U64) => {
-                                boogie_num_type_string_capital("U", "64", bv_flag)
-                            },
-                            Type::Primitive(PrimitiveType::U128) => {
-                                boogie_num_type_string_capital("U", "128", bv_flag)
-                            },
-                            Type::Primitive(PrimitiveType::U256) => {
-                                boogie_num_type_string_capital("U", "256", bv_flag)
-                            },
-                            Type::Primitive(PrimitiveType::I8) => {
-                                boogie_num_type_string_capital("I", "8", bv_flag)
-                            },
-                            Type::Primitive(PrimitiveType::I16) => {
-                                boogie_num_type_string_capital("I", "16", bv_flag)
-                            },
-                            Type::Primitive(PrimitiveType::I32) => {
-                                boogie_num_type_string_capital("I", "32", bv_flag)
-                            },
-                            Type::Primitive(PrimitiveType::I64) => {
-                                boogie_num_type_string_capital("I", "64", bv_flag)
-                            },
-                            Type::Primitive(PrimitiveType::I128) => {
-                                boogie_num_type_string_capital("I", "128", bv_flag)
-                            },
-                            Type::Primitive(PrimitiveType::I256) => {
-                                boogie_num_type_string_capital("I", "256", bv_flag)
-                            },
-                            Type::Primitive(_)
-                            | Type::Tuple(_)
-                            | Type::Vector(_)
-                            | Type::Struct(_, _, _)
-                            | Type::TypeParameter(_)
-                            | Type::Reference(_, _)
-                            | Type::Fun(..)
-                            | Type::TypeDomain(_)
-                            | Type::ResourceDomain(_, _, _)
-                            | Type::StateDomain
-                            | Type::Error
-                            | Type::Var(_) => unreachable!(),
-                        };
+                        let div_type = boogie_int_suffix(&self.get_local_type(dest), bv_flag);
                         emitln!(
                             writer,
                             "call {} := $Div{}({}, {});",
@@ -6837,56 +6624,7 @@ impl FunctionTranslator<'_> {
                             .get_temp_index_oper(mid, fid, dest, baseline_flag)
                             .unwrap();
                         let bv_flag = self.bv_flag(num_oper);
-                        let mod_type = match &self.get_local_type(dest) {
-                            Type::Primitive(PrimitiveType::U8) => {
-                                boogie_num_type_string_capital("U", "8", bv_flag)
-                            },
-                            Type::Primitive(PrimitiveType::U16) => {
-                                boogie_num_type_string_capital("U", "16", bv_flag)
-                            },
-                            Type::Primitive(PrimitiveType::U32) => {
-                                boogie_num_type_string_capital("U", "32", bv_flag)
-                            },
-                            Type::Primitive(PrimitiveType::U64) => {
-                                boogie_num_type_string_capital("U", "64", bv_flag)
-                            },
-                            Type::Primitive(PrimitiveType::U128) => {
-                                boogie_num_type_string_capital("U", "128", bv_flag)
-                            },
-                            Type::Primitive(PrimitiveType::U256) => {
-                                boogie_num_type_string_capital("U", "256", bv_flag)
-                            },
-                            Type::Primitive(PrimitiveType::I8) => {
-                                boogie_num_type_string_capital("I", "8", bv_flag)
-                            },
-                            Type::Primitive(PrimitiveType::I16) => {
-                                boogie_num_type_string_capital("I", "16", bv_flag)
-                            },
-                            Type::Primitive(PrimitiveType::I32) => {
-                                boogie_num_type_string_capital("I", "32", bv_flag)
-                            },
-                            Type::Primitive(PrimitiveType::I64) => {
-                                boogie_num_type_string_capital("I", "64", bv_flag)
-                            },
-                            Type::Primitive(PrimitiveType::I128) => {
-                                boogie_num_type_string_capital("I", "128", bv_flag)
-                            },
-                            Type::Primitive(PrimitiveType::I256) => {
-                                boogie_num_type_string_capital("I", "256", bv_flag)
-                            },
-                            Type::Primitive(_)
-                            | Type::Tuple(_)
-                            | Type::Vector(_)
-                            | Type::Struct(_, _, _)
-                            | Type::TypeParameter(_)
-                            | Type::Reference(_, _)
-                            | Type::Fun(..)
-                            | Type::TypeDomain(_)
-                            | Type::ResourceDomain(_, _, _)
-                            | Type::StateDomain
-                            | Type::Error
-                            | Type::Var(_) => unreachable!(),
-                        };
+                        let mod_type = boogie_int_suffix(&self.get_local_type(dest), bv_flag);
                         emitln!(
                             writer,
                             "call {} := $Mod{}({}, {});",

--- a/third_party/move/move-prover/boogie-backend/src/prelude/prelude.bpl
+++ b/third_party/move/move-prover/boogie-backend/src/prelude/prelude.bpl
@@ -28,7 +28,13 @@ options provided to the prover.
 // Integer Types
 
 // Constants, Instructions, and Procedures needed by both unsigned and signed integers, but defined separately.
-{% macro integer_type(name, typename, min, max) %}
+//
+// Division and modulus use Move runtime semantics (truncate toward zero,
+// remainder takes sign of the dividend), not Boogie's built-in Euclidean
+// `div`/`mod`. For unsigned types the two coincide and the emitted body is
+// a single `div`/`mod` op; for signed types we branch on the sign of the
+// dividend so the SMT formula stays linear (no `*` in conditions).
+{% macro integer_type(name, typename, min, max, signed) %}
 const $MIN_{{name}}: int;
 const $MAX_{{name}}: int;
 axiom $MIN_{{name}} == {{min}};
@@ -82,42 +88,81 @@ procedure {:inline 1} $Mul{{name}}(src1: int, src2: int) returns (dst: int)
     }
     dst := src1 * src2;
 }
+
+procedure {:inline 1} $Div{{name}}(src1: int, src2: int) returns (dst: int)
+{
+{%- if signed %}
+    if (src2 == 0 || (src1 == $MIN_{{name}} && src2 == -1)) {
+        call $ExecFailureAbort();
+        return;
+    }
+    // Truncate toward zero. Boogie's `div` is Euclidean and agrees with
+    // truncation when the dividend is non-negative; for negative dividend
+    // we negate, divide, negate.
+    if (src1 >= 0) {
+        dst := src1 div src2;
+    } else {
+        dst := -((-src1) div src2);
+    }
+{%- else %}
+    if (src2 == 0) {
+        call $ExecFailureAbort();
+        return;
+    }
+    dst := src1 div src2;
+{%- endif %}
+}
+
+procedure {:inline 1} $Mod{{name}}(src1: int, src2: int) returns (dst: int)
+{
+{%- if signed %}
+    if (src2 == 0) {
+        call $ExecFailureAbort();
+        return;
+    }
+    // Truncate-toward-zero remainder: same sign as the dividend.
+    if (src1 >= 0) {
+        dst := src1 mod src2;
+    } else {
+        dst := -((-src1) mod src2);
+    }
+{%- else %}
+    if (src2 == 0) {
+        call $ExecFailureAbort();
+        return;
+    }
+    dst := src1 mod src2;
+{%- endif %}
+}
 {% endmacro %}
 
-{{ self::integer_type(name="U8", typename="u8", min=0, max=255) }}
-{{ self::integer_type(name="U16", typename="u16", min=0, max=65535) }}
-{{ self::integer_type(name="U32", typename="u32", min=0, max=4294967295) }}
-{{ self::integer_type(name="U64", typename="u64", min=0, max="18446744073709551615") }}
-{{ self::integer_type(name="U128", typename="u128", min=0, max="340282366920938463463374607431768211455") }}
-{{ self::integer_type(name="U256", typename="u256", min=0, max="115792089237316195423570985008687907853269984665640564039457584007913129639935") }}
-{{ self::integer_type(name="I8", typename="i8", min=-128, max=127) }}
-{{ self::integer_type(name="I16", typename="i16", min=-32768, max=32767) }}
-{{ self::integer_type(name="I32", typename="i32", min=-2147483648, max=2147483647) }}
-{{ self::integer_type(name="I64", typename="i64", min="-9223372036854775808", max="9223372036854775807") }}
-{{ self::integer_type(name="I128", typename="i128", min="-170141183460469231731687303715884105728", max="170141183460469231731687303715884105727") }}
-{{ self::integer_type(name="I256", typename="i256", min="-57896044618658097711785492504343953926634992332820282019728792003956564819968", max="57896044618658097711785492504343953926634992332820282019728792003956564819967") }}
+{{ self::integer_type(name="U8", typename="u8", min=0, max=255, signed=false) }}
+{{ self::integer_type(name="U16", typename="u16", min=0, max=65535, signed=false) }}
+{{ self::integer_type(name="U32", typename="u32", min=0, max=4294967295, signed=false) }}
+{{ self::integer_type(name="U64", typename="u64", min=0, max="18446744073709551615", signed=false) }}
+{{ self::integer_type(name="U128", typename="u128", min=0, max="340282366920938463463374607431768211455", signed=false) }}
+{{ self::integer_type(name="U256", typename="u256", min=0, max="115792089237316195423570985008687907853269984665640564039457584007913129639935", signed=false) }}
+{{ self::integer_type(name="I8", typename="i8", min=-128, max=127, signed=true) }}
+{{ self::integer_type(name="I16", typename="i16", min=-32768, max=32767, signed=true) }}
+{{ self::integer_type(name="I32", typename="i32", min=-2147483648, max=2147483647, signed=true) }}
+{{ self::integer_type(name="I64", typename="i64", min="-9223372036854775808", max="9223372036854775807", signed=true) }}
+{{ self::integer_type(name="I128", typename="i128", min="-170141183460469231731687303715884105728", max="170141183460469231731687303715884105727", signed=true) }}
+{{ self::integer_type(name="I256", typename="i256", min="-57896044618658097711785492504343953926634992332820282019728792003956564819968", max="57896044618658097711785492504343953926634992332820282019728792003956564819967", signed=true) }}
 
 // Instructions and Procedures shared by unsigned and signed integers
 
 // uninterpreted function to return an undefined value.
 function $undefined_int(): int;
 
-procedure {:inline 1} $Div(src1: int, src2: int) returns (dst: int)
-{
-    if (src2 == 0) {
-        call $ExecFailureAbort();
-        return;
-    }
-    dst := src1 div src2;
+// Spec-level signed division / modulus, truncated toward zero (Move runtime
+// semantics). The spec translator emits these for `/` and `%` on signed
+// operand types; for unsigned operands Boogie's built-in `div`/`mod` is
+// emitted directly (the two coincide when both operands are non-negative).
+function {:inline} $signed_div(a: int, b: int): int {
+    if a >= 0 then a div b else -((-a) div b)
 }
-
-procedure {:inline 1} $Mod(src1: int, src2: int) returns (dst: int)
-{
-    if (src2 == 0) {
-        call $ExecFailureAbort();
-        return;
-    }
-    dst := src1 mod src2;
+function {:inline} $signed_mod(a: int, b: int): int {
+    if a >= 0 then a mod b else -((-a) mod b)
 }
 
 // Unimplemented binary arithmetic operations; return the dst

--- a/third_party/move/move-prover/boogie-backend/src/prelude/prelude.bpl
+++ b/third_party/move/move-prover/boogie-backend/src/prelude/prelude.bpl
@@ -27,13 +27,21 @@ options provided to the prover.
 // ============================================================================================
 // Integer Types
 
+// Signed division / modulus with Move runtime semantics: truncate toward
+// zero (the remainder takes the sign of the dividend), not Boogie's
+// built-in Euclidean `div`/`mod`. Defined once here and reused by both the
+// signed procedure bodies below and by the spec translator. The branch on
+// dividend sign keeps the SMT formula linear (no `*` in conditions); for
+// unsigned operands Boogie's `div`/`mod` is emitted directly because the
+// two semantics coincide when both operands are non-negative.
+function {:inline} $signed_div(a: int, b: int): int {
+    if a >= 0 then a div b else -((-a) div b)
+}
+function {:inline} $signed_mod(a: int, b: int): int {
+    if a >= 0 then a mod b else -((-a) mod b)
+}
+
 // Constants, Instructions, and Procedures needed by both unsigned and signed integers, but defined separately.
-//
-// Division and modulus use Move runtime semantics (truncate toward zero,
-// remainder takes sign of the dividend), not Boogie's built-in Euclidean
-// `div`/`mod`. For unsigned types the two coincide and the emitted body is
-// a single `div`/`mod` op; for signed types we branch on the sign of the
-// dividend so the SMT formula stays linear (no `*` in conditions).
 {% macro integer_type(name, typename, min, max, signed) %}
 const $MIN_{{name}}: int;
 const $MAX_{{name}}: int;
@@ -92,18 +100,13 @@ procedure {:inline 1} $Mul{{name}}(src1: int, src2: int) returns (dst: int)
 procedure {:inline 1} $Div{{name}}(src1: int, src2: int) returns (dst: int)
 {
 {%- if signed %}
+    // Signed: abort on div-by-zero *and* MIN/-1 (the latter overflows the
+    // signed range; Rust runtime returns None from `ix::checked_div`).
     if (src2 == 0 || (src1 == $MIN_{{name}} && src2 == -1)) {
         call $ExecFailureAbort();
         return;
     }
-    // Truncate toward zero. Boogie's `div` is Euclidean and agrees with
-    // truncation when the dividend is non-negative; for negative dividend
-    // we negate, divide, negate.
-    if (src1 >= 0) {
-        dst := src1 div src2;
-    } else {
-        dst := -((-src1) div src2);
-    }
+    dst := $signed_div(src1, src2);
 {%- else %}
     if (src2 == 0) {
         call $ExecFailureAbort();
@@ -116,16 +119,14 @@ procedure {:inline 1} $Div{{name}}(src1: int, src2: int) returns (dst: int)
 procedure {:inline 1} $Mod{{name}}(src1: int, src2: int) returns (dst: int)
 {
 {%- if signed %}
-    if (src2 == 0) {
+    // Signed: abort on mod-by-zero *and* MIN/-1. Rust's `ix::checked_rem`
+    // returns None for `MIN % -1`; the truncated formula would otherwise
+    // silently yield 0 since Boogie ints are unbounded.
+    if (src2 == 0 || (src1 == $MIN_{{name}} && src2 == -1)) {
         call $ExecFailureAbort();
         return;
     }
-    // Truncate-toward-zero remainder: same sign as the dividend.
-    if (src1 >= 0) {
-        dst := src1 mod src2;
-    } else {
-        dst := -((-src1) mod src2);
-    }
+    dst := $signed_mod(src1, src2);
 {%- else %}
     if (src2 == 0) {
         call $ExecFailureAbort();
@@ -153,17 +154,6 @@ procedure {:inline 1} $Mod{{name}}(src1: int, src2: int) returns (dst: int)
 
 // uninterpreted function to return an undefined value.
 function $undefined_int(): int;
-
-// Spec-level signed division / modulus, truncated toward zero (Move runtime
-// semantics). The spec translator emits these for `/` and `%` on signed
-// operand types; for unsigned operands Boogie's built-in `div`/`mod` is
-// emitted directly (the two coincide when both operands are non-negative).
-function {:inline} $signed_div(a: int, b: int): int {
-    if a >= 0 then a div b else -((-a) div b)
-}
-function {:inline} $signed_mod(a: int, b: int): int {
-    if a >= 0 then a mod b else -((-a) mod b)
-}
 
 // Unimplemented binary arithmetic operations; return the dst
 procedure {:inline 1} $ArithBinaryUnimplemented(src1: int, src2: int) returns (dst: int);

--- a/third_party/move/move-prover/boogie-backend/src/spec_translator.rs
+++ b/third_party/move/move-prover/boogie-backend/src/spec_translator.rs
@@ -1395,11 +1395,11 @@ impl SpecTranslator<'_> {
             Operation::Copy | Operation::Move => self.translate_exp(&args[0]),
 
             // Binary operators
-            Operation::Add => self.translate_op("+", "Add", args),
-            Operation::Sub => self.translate_op("-", "Sub", args),
-            Operation::Mul => self.translate_op("*", "Mul", args),
-            Operation::Mod => self.translate_div_or_mod("mod", "Mod", "$signed_mod", args),
-            Operation::Div => self.translate_div_or_mod("div", "Div", "$signed_div", args),
+            Operation::Add => self.translate_op("+", "Add", None, args),
+            Operation::Sub => self.translate_op("-", "Sub", None, args),
+            Operation::Mul => self.translate_op("*", "Mul", None, args),
+            Operation::Mod => self.translate_op("mod", "Mod", Some("$signed_mod"), args),
+            Operation::Div => self.translate_op("div", "Div", Some("$signed_div"), args),
             Operation::BitOr => self.translate_bit_op("$Or", args),
             Operation::BitAnd => self.translate_bit_op("$And", args),
             Operation::Xor => self.translate_bit_op("$Xor", args),
@@ -1409,10 +1409,10 @@ impl SpecTranslator<'_> {
             Operation::Iff => self.translate_logical_op("<==>", args),
             Operation::And => self.translate_logical_op("&&", args),
             Operation::Or => self.translate_logical_op("||", args),
-            Operation::Lt => self.translate_op("<", "Lt", args),
-            Operation::Le => self.translate_op("<=", "Le", args),
-            Operation::Gt => self.translate_op(">", "Gt", args),
-            Operation::Ge => self.translate_op(">=", "Ge", args),
+            Operation::Lt => self.translate_op("<", "Lt", None, args),
+            Operation::Le => self.translate_op("<=", "Le", None, args),
+            Operation::Gt => self.translate_op(">", "Gt", None, args),
+            Operation::Ge => self.translate_op(">=", "Ge", None, args),
             Operation::Identical => self.translate_identical(args),
             Operation::Eq => self.translate_eq_neq("$IsEqual", args),
             Operation::Neq => self.translate_eq_neq("!$IsEqual", args),
@@ -3335,16 +3335,17 @@ impl SpecTranslator<'_> {
         }
     }
 
-    /// Translates `div` / `mod`. Mirrors `translate_op` for the unsigned and
-    /// bitwise cases, but for signed operand types emits a call to the
-    /// truncate-toward-zero helper (`$signed_div` / `$signed_mod`) so the spec
-    /// matches Move runtime semantics rather than Boogie's Euclidean
-    /// `div` / `mod`.
-    fn translate_div_or_mod(
+    /// Translates a binary arithmetic / relational op. `boogie_op` is the
+    /// infix operator for the unsigned (Euclidean / boolean) case; `bv_op` is
+    /// the bitwise function-name prefix (e.g. `Div`, `Lt`). `signed_helper`
+    /// is `Some("$signed_div" | "$signed_mod")` for `/` and `%`, which need
+    /// truncate-toward-zero semantics on signed operands; all other ops pass
+    /// `None` because they coincide under Move's and Boogie's encodings.
+    fn translate_op(
         &self,
         boogie_op: &str,
         bv_op: &str,
-        signed_helper: &str,
+        signed_helper: Option<&str>,
         args: &[Exp],
     ) {
         let global_state = &self
@@ -3362,38 +3363,13 @@ impl SpecTranslator<'_> {
             emit!(self.writer, "${}'{}'(", bv_op, oper_base);
             self.translate_seq(args.iter(), ", ", |e| self.translate_exp(e));
             emit!(self.writer, ")");
-        } else if self
-            .env
-            .get_node_type(args[0].node_id())
-            .skip_reference()
-            .is_signed_int()
-        {
-            emit!(self.writer, "{}(", signed_helper);
-            self.translate_seq(args.iter(), ", ", |e| self.translate_exp(e));
-            emit!(self.writer, ")");
-        } else {
-            emit!(self.writer, "(");
-            self.translate_exp(&args[0]);
-            emit!(self.writer, " {} ", boogie_op);
-            self.translate_exp(&args[1]);
-            emit!(self.writer, ")");
-        }
-    }
-
-    fn translate_op(&self, boogie_op: &str, bv_op: &str, args: &[Exp]) {
-        let global_state = &self
-            .env
-            .get_extension::<GlobalNumberOperationState>()
-            .expect("global number operation state");
-        let num_oper = global_state.get_node_num_oper(args[0].node_id());
-        if num_oper == Bitwise {
-            let oper_base = boogie_num_type_base(
-                self.env,
-                Some(self.env.get_node_loc(args[0].node_id())),
-                &self.env.get_node_type(args[0].node_id()),
-                true,
-            );
-            emit!(self.writer, "${}'{}'(", bv_op, oper_base);
+        } else if let Some(helper) = signed_helper.filter(|_| {
+            self.env
+                .get_node_type(args[0].node_id())
+                .skip_reference()
+                .is_signed_int()
+        }) {
+            emit!(self.writer, "{}(", helper);
             self.translate_seq(args.iter(), ", ", |e| self.translate_exp(e));
             emit!(self.writer, ")");
         } else {

--- a/third_party/move/move-prover/boogie-backend/src/spec_translator.rs
+++ b/third_party/move/move-prover/boogie-backend/src/spec_translator.rs
@@ -1398,8 +1398,8 @@ impl SpecTranslator<'_> {
             Operation::Add => self.translate_op("+", "Add", args),
             Operation::Sub => self.translate_op("-", "Sub", args),
             Operation::Mul => self.translate_op("*", "Mul", args),
-            Operation::Mod => self.translate_op("mod", "Mod", args),
-            Operation::Div => self.translate_op("div", "Div", args),
+            Operation::Mod => self.translate_div_or_mod("mod", "Mod", "$signed_mod", args),
+            Operation::Div => self.translate_div_or_mod("div", "Div", "$signed_div", args),
             Operation::BitOr => self.translate_bit_op("$Or", args),
             Operation::BitAnd => self.translate_bit_op("$And", args),
             Operation::Xor => self.translate_bit_op("$Xor", args),
@@ -3332,6 +3332,51 @@ impl SpecTranslator<'_> {
                 emit!(self.writer, "$t{} == $t{}", idx1, idx2);
             },
             _ => self.translate_rel_op("==", args),
+        }
+    }
+
+    /// Translates `div` / `mod`. Mirrors `translate_op` for the unsigned and
+    /// bitwise cases, but for signed operand types emits a call to the
+    /// truncate-toward-zero helper (`$signed_div` / `$signed_mod`) so the spec
+    /// matches Move runtime semantics rather than Boogie's Euclidean
+    /// `div` / `mod`.
+    fn translate_div_or_mod(
+        &self,
+        boogie_op: &str,
+        bv_op: &str,
+        signed_helper: &str,
+        args: &[Exp],
+    ) {
+        let global_state = &self
+            .env
+            .get_extension::<GlobalNumberOperationState>()
+            .expect("global number operation state");
+        let num_oper = global_state.get_node_num_oper(args[0].node_id());
+        if num_oper == Bitwise {
+            let oper_base = boogie_num_type_base(
+                self.env,
+                Some(self.env.get_node_loc(args[0].node_id())),
+                &self.env.get_node_type(args[0].node_id()),
+                true,
+            );
+            emit!(self.writer, "${}'{}'(", bv_op, oper_base);
+            self.translate_seq(args.iter(), ", ", |e| self.translate_exp(e));
+            emit!(self.writer, ")");
+        } else if self
+            .env
+            .get_node_type(args[0].node_id())
+            .skip_reference()
+            .is_signed_int()
+        {
+            emit!(self.writer, "{}(", signed_helper);
+            self.translate_seq(args.iter(), ", ", |e| self.translate_exp(e));
+            emit!(self.writer, ")");
+        } else {
+            emit!(self.writer, "(");
+            self.translate_exp(&args[0]);
+            emit!(self.writer, " {} ", boogie_op);
+            self.translate_exp(&args[1]);
+            emit!(self.writer, ")");
         }
     }
 

--- a/third_party/move/move-prover/tests/sources/functional/signed_div_mod_19877.move
+++ b/third_party/move/move-prover/tests/sources/functional/signed_div_mod_19877.move
@@ -1,0 +1,94 @@
+// Regression test for https://github.com/aptos-labs/aptos-core/issues/19877
+//
+// The Move runtime truncates signed integer division toward zero
+// (Rust / C semantics). The Move Prover used to model `$Div` and `$Mod`
+// with Boogie's built-in `div` / `mod`, which are Euclidean (floor toward
+// `-inf`, non-negative remainder). The two semantics diverge whenever
+// the dividend is negative with a non-zero remainder.
+//
+// This test pins down truncate-toward-zero semantics for both `/` and `%`
+// across all sign combinations and the `MIN_I / -1` overflow case.
+
+module 0x42::signed_div_mod {
+
+    // --- Division ----------------------------------------------------------
+
+    public fun div_i64(x: i64, y: i64): i64 {
+        x / y
+    }
+
+    spec div_i64 {
+        aborts_if y == 0;
+        aborts_if x == MIN_I64 && y == -1;
+        // Truncate toward zero: same sign as mathematical quotient,
+        // magnitude = floor(|x| / |y|).
+        ensures x == -1 && y == 2 ==> result == 0;
+        ensures x == -7 && y == 3 ==> result == -2;
+        ensures x == -7 && y == -3 ==> result == 2;
+        ensures x == 7 && y == -3 ==> result == -2;
+        ensures x == 7 && y == 3 ==> result == 2;
+        ensures x == -10 && y == 3 ==> result == -3;
+    }
+
+    // Cast pattern from the issue: (signed as i128) / (unsigned as i128).
+    public fun cast_div(x: i64, y: u64): i64 {
+        ((x as i128) / (y as i128)) as i64
+    }
+
+    spec cast_div {
+        aborts_if y == 0;
+        ensures x == -1 && y == 2 ==> result == 0;
+    }
+
+    // --- Modulus -----------------------------------------------------------
+
+    // Under truncate-toward-zero, `x % y` has the same sign as `x`,
+    // and `|x % y| < |y|`. (Boogie's Euclidean `mod` keeps the remainder
+    // non-negative, which diverges whenever the dividend is negative.)
+    public fun mod_i64(x: i64, y: i64): i64 {
+        x % y
+    }
+
+    spec mod_i64 {
+        aborts_if y == 0;
+        ensures x == 7 && y == 3 ==> result == 1;
+        ensures x == -7 && y == 3 ==> result == -1;
+        ensures x == 7 && y == -3 ==> result == 1;
+        ensures x == -7 && y == -3 ==> result == -1;
+    }
+
+    // --- Overflow ----------------------------------------------------------
+
+    // MIN_I64 / -1 is mathematically MAX_I64 + 1, which doesn't fit in i64.
+    // The runtime aborts; the prover must too.
+    public fun div_min_by_neg_one_aborts(): i64 {
+        MIN_I64 / -1
+    }
+
+    spec div_min_by_neg_one_aborts {
+        aborts_if true;
+    }
+
+    // --- Unsigned (regression: must not change behavior) -------------------
+
+    public fun div_u64(x: u64, y: u64): u64 {
+        x / y
+    }
+
+    spec div_u64 {
+        aborts_if y == 0;
+        ensures result == x / y;
+        ensures x == 7 && y == 3 ==> result == 2;
+        ensures x == 7 && y == 2 ==> result == 3;
+    }
+
+    public fun mod_u64(x: u64, y: u64): u64 {
+        x % y
+    }
+
+    spec mod_u64 {
+        aborts_if y == 0;
+        ensures result == x % y;
+        ensures x == 7 && y == 3 ==> result == 1;
+    }
+}

--- a/third_party/move/move-prover/tests/sources/functional/signed_div_mod_19877.move
+++ b/third_party/move/move-prover/tests/sources/functional/signed_div_mod_19877.move
@@ -51,6 +51,9 @@ module 0x42::signed_div_mod {
 
     spec mod_i64 {
         aborts_if y == 0;
+        // MIN % -1 overflows in Rust (`checked_rem` returns None); the prover
+        // must abort here too.
+        aborts_if x == MIN_I64 && y == -1;
         ensures x == 7 && y == 3 ==> result == 1;
         ensures x == -7 && y == 3 ==> result == -1;
         ensures x == 7 && y == -3 ==> result == 1;
@@ -67,6 +70,20 @@ module 0x42::signed_div_mod {
 
     spec div_min_by_neg_one_aborts {
         aborts_if true;
+    }
+
+    // Variable-operand check that `%` aborts on `MIN / -1` at runtime. (A
+    // constant-operand version like `MIN_I64 % -1` would be folded to `0` by
+    // the Move compiler before reaching the prover, so it can't exercise
+    // `$ModI64`'s guard — `spec mod_i64` above carries the actual check via
+    // its `aborts_if x == MIN_I64 && y == -1` clause.)
+    public fun mod_aborts_on_min_neg_one(x: i64, y: i64): i64 {
+        x % y
+    }
+
+    spec mod_aborts_on_min_neg_one {
+        aborts_if y == 0;
+        aborts_if x == MIN_I64 && y == -1;
     }
 
     // --- Unsigned (regression: must not change behavior) -------------------

--- a/third_party/move/move-prover/tests/sources/functional/signed_int/artithmetic.exp
+++ b/third_party/move/move-prover/tests/sources/functional/signed_int/artithmetic.exp
@@ -1,221 +1,221 @@
 Move prover returns: exiting with verification errors
 error: abort not covered by any of the `aborts_if` clauses
-    ┌─ tests/sources/functional/signed_int/artithmetic.move:128:5
+    ┌─ tests/sources/functional/signed_int/artithmetic.move:129:5
     │
-126 │           x / y
+127 │           x / y
     │           ----- abort happened here with execution failure
-127 │       }
-128 │ ╭     spec div_by_zero_i64_incorrect {
-129 │ │         aborts_if false;
-130 │ │     }
+128 │       }
+129 │ ╭     spec div_by_zero_i64_incorrect {
+130 │ │         aborts_if false;
+131 │ │     }
     │ ╰─────^
     │
-    =     at tests/sources/functional/signed_int/artithmetic.move:125: div_by_zero_i64_incorrect
-    =         x = <redacted>
-    =         y = <redacted>
     =     at tests/sources/functional/signed_int/artithmetic.move:126: div_by_zero_i64_incorrect
+    =         x = <redacted>
+    =         y = <redacted>
+    =     at tests/sources/functional/signed_int/artithmetic.move:127: div_by_zero_i64_incorrect
     =         ABORTED
 
 error: abort not covered by any of the `aborts_if` clauses
-    ┌─ tests/sources/functional/signed_int/artithmetic.move:148:5
+    ┌─ tests/sources/functional/signed_int/artithmetic.move:150:5
     │
-146 │           x + y
+148 │           x + y
     │           ----- abort happened here with execution failure
-147 │       }
-148 │ ╭     spec overflow_i8_add_incorrect {
-149 │ │         aborts_if false;
-150 │ │     }
+149 │       }
+150 │ ╭     spec overflow_i8_add_incorrect {
+151 │ │         aborts_if false;
+152 │ │     }
     │ ╰─────^
     │
-    =     at tests/sources/functional/signed_int/artithmetic.move:145: overflow_i8_add_incorrect
+    =     at tests/sources/functional/signed_int/artithmetic.move:147: overflow_i8_add_incorrect
     =         x = <redacted>
     =         y = <redacted>
-    =     at tests/sources/functional/signed_int/artithmetic.move:146: overflow_i8_add_incorrect
+    =     at tests/sources/functional/signed_int/artithmetic.move:148: overflow_i8_add_incorrect
     =         ABORTED
 
 error: abort not covered by any of the `aborts_if` clauses
-    ┌─ tests/sources/functional/signed_int/artithmetic.move:164:5
+    ┌─ tests/sources/functional/signed_int/artithmetic.move:166:5
     │
-162 │           x + y
+164 │           x + y
     │           ----- abort happened here with execution failure
-163 │       }
-164 │ ╭     spec overflow_i16_add_incorrect {
-165 │ │         aborts_if false;
-166 │ │     }
+165 │       }
+166 │ ╭     spec overflow_i16_add_incorrect {
+167 │ │         aborts_if false;
+168 │ │     }
     │ ╰─────^
     │
-    =     at tests/sources/functional/signed_int/artithmetic.move:161: overflow_i16_add_incorrect
+    =     at tests/sources/functional/signed_int/artithmetic.move:163: overflow_i16_add_incorrect
     =         x = <redacted>
     =         y = <redacted>
-    =     at tests/sources/functional/signed_int/artithmetic.move:162: overflow_i16_add_incorrect
+    =     at tests/sources/functional/signed_int/artithmetic.move:164: overflow_i16_add_incorrect
     =         ABORTED
 
 error: abort not covered by any of the `aborts_if` clauses
-    ┌─ tests/sources/functional/signed_int/artithmetic.move:180:5
+    ┌─ tests/sources/functional/signed_int/artithmetic.move:182:5
     │
-178 │           x + y
+180 │           x + y
     │           ----- abort happened here with execution failure
-179 │       }
-180 │ ╭     spec overflow_i32_add_incorrect {
-181 │ │         aborts_if false;
-182 │ │     }
+181 │       }
+182 │ ╭     spec overflow_i32_add_incorrect {
+183 │ │         aborts_if false;
+184 │ │     }
     │ ╰─────^
     │
-    =     at tests/sources/functional/signed_int/artithmetic.move:177: overflow_i32_add_incorrect
+    =     at tests/sources/functional/signed_int/artithmetic.move:179: overflow_i32_add_incorrect
     =         x = <redacted>
     =         y = <redacted>
-    =     at tests/sources/functional/signed_int/artithmetic.move:178: overflow_i32_add_incorrect
+    =     at tests/sources/functional/signed_int/artithmetic.move:180: overflow_i32_add_incorrect
     =         ABORTED
 
 error: abort not covered by any of the `aborts_if` clauses
-    ┌─ tests/sources/functional/signed_int/artithmetic.move:196:5
+    ┌─ tests/sources/functional/signed_int/artithmetic.move:198:5
     │
-194 │           x + y
+196 │           x + y
     │           ----- abort happened here with execution failure
-195 │       }
-196 │ ╭     spec overflow_i64_add_incorrect {
-197 │ │         aborts_if false;
-198 │ │     }
+197 │       }
+198 │ ╭     spec overflow_i64_add_incorrect {
+199 │ │         aborts_if false;
+200 │ │     }
     │ ╰─────^
     │
-    =     at tests/sources/functional/signed_int/artithmetic.move:193: overflow_i64_add_incorrect
+    =     at tests/sources/functional/signed_int/artithmetic.move:195: overflow_i64_add_incorrect
     =         x = <redacted>
     =         y = <redacted>
-    =     at tests/sources/functional/signed_int/artithmetic.move:194: overflow_i64_add_incorrect
+    =     at tests/sources/functional/signed_int/artithmetic.move:196: overflow_i64_add_incorrect
     =         ABORTED
 
 error: abort not covered by any of the `aborts_if` clauses
-    ┌─ tests/sources/functional/signed_int/artithmetic.move:212:5
+    ┌─ tests/sources/functional/signed_int/artithmetic.move:214:5
     │
-210 │           x + y
+212 │           x + y
     │           ----- abort happened here with execution failure
-211 │       }
-212 │ ╭     spec overflow_i128_add_incorrect {
-213 │ │         aborts_if false;
-214 │ │     }
+213 │       }
+214 │ ╭     spec overflow_i128_add_incorrect {
+215 │ │         aborts_if false;
+216 │ │     }
     │ ╰─────^
     │
-    =     at tests/sources/functional/signed_int/artithmetic.move:209: overflow_i128_add_incorrect
+    =     at tests/sources/functional/signed_int/artithmetic.move:211: overflow_i128_add_incorrect
     =         x = <redacted>
     =         y = <redacted>
-    =     at tests/sources/functional/signed_int/artithmetic.move:210: overflow_i128_add_incorrect
+    =     at tests/sources/functional/signed_int/artithmetic.move:212: overflow_i128_add_incorrect
     =         ABORTED
 
 error: abort not covered by any of the `aborts_if` clauses
-    ┌─ tests/sources/functional/signed_int/artithmetic.move:228:5
+    ┌─ tests/sources/functional/signed_int/artithmetic.move:230:5
     │
-226 │           x + y
+228 │           x + y
     │           ----- abort happened here with execution failure
-227 │       }
-228 │ ╭     spec overflow_i256_add_incorrect {
-229 │ │         aborts_if false;
-230 │ │     }
+229 │       }
+230 │ ╭     spec overflow_i256_add_incorrect {
+231 │ │         aborts_if false;
+232 │ │     }
     │ ╰─────^
     │
-    =     at tests/sources/functional/signed_int/artithmetic.move:225: overflow_i256_add_incorrect
+    =     at tests/sources/functional/signed_int/artithmetic.move:227: overflow_i256_add_incorrect
     =         x = <redacted>
     =         y = <redacted>
-    =     at tests/sources/functional/signed_int/artithmetic.move:226: overflow_i256_add_incorrect
+    =     at tests/sources/functional/signed_int/artithmetic.move:228: overflow_i256_add_incorrect
     =         ABORTED
 
 error: abort not covered by any of the `aborts_if` clauses
-    ┌─ tests/sources/functional/signed_int/artithmetic.move:249:5
+    ┌─ tests/sources/functional/signed_int/artithmetic.move:251:5
     │
-247 │           x * y
+249 │           x * y
     │           ----- abort happened here with execution failure
-248 │       }
-249 │ ╭     spec overflow_i8_mul_incorrect {
-250 │ │         aborts_if false;
-251 │ │     }
+250 │       }
+251 │ ╭     spec overflow_i8_mul_incorrect {
+252 │ │         aborts_if false;
+253 │ │     }
     │ ╰─────^
     │
-    =     at tests/sources/functional/signed_int/artithmetic.move:246: overflow_i8_mul_incorrect
+    =     at tests/sources/functional/signed_int/artithmetic.move:248: overflow_i8_mul_incorrect
     =         x = <redacted>
     =         y = <redacted>
-    =     at tests/sources/functional/signed_int/artithmetic.move:247: overflow_i8_mul_incorrect
+    =     at tests/sources/functional/signed_int/artithmetic.move:249: overflow_i8_mul_incorrect
     =         ABORTED
 
 error: abort not covered by any of the `aborts_if` clauses
-    ┌─ tests/sources/functional/signed_int/artithmetic.move:265:5
+    ┌─ tests/sources/functional/signed_int/artithmetic.move:267:5
     │
-263 │           x * y
+265 │           x * y
     │           ----- abort happened here with execution failure
-264 │       }
-265 │ ╭     spec overflow_i16_mul_incorrect {
-266 │ │         aborts_if false;
-267 │ │     }
+266 │       }
+267 │ ╭     spec overflow_i16_mul_incorrect {
+268 │ │         aborts_if false;
+269 │ │     }
     │ ╰─────^
     │
-    =     at tests/sources/functional/signed_int/artithmetic.move:262: overflow_i16_mul_incorrect
+    =     at tests/sources/functional/signed_int/artithmetic.move:264: overflow_i16_mul_incorrect
     =         x = <redacted>
     =         y = <redacted>
-    =     at tests/sources/functional/signed_int/artithmetic.move:263: overflow_i16_mul_incorrect
+    =     at tests/sources/functional/signed_int/artithmetic.move:265: overflow_i16_mul_incorrect
     =         ABORTED
 
 error: abort not covered by any of the `aborts_if` clauses
-    ┌─ tests/sources/functional/signed_int/artithmetic.move:281:5
+    ┌─ tests/sources/functional/signed_int/artithmetic.move:283:5
     │
-279 │           x * y
+281 │           x * y
     │           ----- abort happened here with execution failure
-280 │       }
-281 │ ╭     spec overflow_i32_mul_incorrect {
-282 │ │         aborts_if false;
-283 │ │     }
+282 │       }
+283 │ ╭     spec overflow_i32_mul_incorrect {
+284 │ │         aborts_if false;
+285 │ │     }
     │ ╰─────^
     │
-    =     at tests/sources/functional/signed_int/artithmetic.move:278: overflow_i32_mul_incorrect
+    =     at tests/sources/functional/signed_int/artithmetic.move:280: overflow_i32_mul_incorrect
     =         x = <redacted>
     =         y = <redacted>
-    =     at tests/sources/functional/signed_int/artithmetic.move:279: overflow_i32_mul_incorrect
+    =     at tests/sources/functional/signed_int/artithmetic.move:281: overflow_i32_mul_incorrect
     =         ABORTED
 
 error: abort not covered by any of the `aborts_if` clauses
-    ┌─ tests/sources/functional/signed_int/artithmetic.move:297:5
+    ┌─ tests/sources/functional/signed_int/artithmetic.move:299:5
     │
-295 │           x * y
+297 │           x * y
     │           ----- abort happened here with execution failure
-296 │       }
-297 │ ╭     spec overflow_i64_mul_incorrect {
-298 │ │         aborts_if false;
-299 │ │     }
+298 │       }
+299 │ ╭     spec overflow_i64_mul_incorrect {
+300 │ │         aborts_if false;
+301 │ │     }
     │ ╰─────^
     │
-    =     at tests/sources/functional/signed_int/artithmetic.move:294: overflow_i64_mul_incorrect
+    =     at tests/sources/functional/signed_int/artithmetic.move:296: overflow_i64_mul_incorrect
     =         x = <redacted>
     =         y = <redacted>
-    =     at tests/sources/functional/signed_int/artithmetic.move:295: overflow_i64_mul_incorrect
+    =     at tests/sources/functional/signed_int/artithmetic.move:297: overflow_i64_mul_incorrect
     =         ABORTED
 
 error: abort not covered by any of the `aborts_if` clauses
-    ┌─ tests/sources/functional/signed_int/artithmetic.move:312:5
+    ┌─ tests/sources/functional/signed_int/artithmetic.move:314:5
     │
-310 │           x * y
+312 │           x * y
     │           ----- abort happened here with execution failure
-311 │       }
-312 │ ╭     spec overflow_i128_mul_incorrect {
-313 │ │         aborts_if false;
-314 │ │     }
+313 │       }
+314 │ ╭     spec overflow_i128_mul_incorrect {
+315 │ │         aborts_if false;
+316 │ │     }
     │ ╰─────^
     │
-    =     at tests/sources/functional/signed_int/artithmetic.move:309: overflow_i128_mul_incorrect
+    =     at tests/sources/functional/signed_int/artithmetic.move:311: overflow_i128_mul_incorrect
     =         x = <redacted>
     =         y = <redacted>
-    =     at tests/sources/functional/signed_int/artithmetic.move:310: overflow_i128_mul_incorrect
+    =     at tests/sources/functional/signed_int/artithmetic.move:312: overflow_i128_mul_incorrect
     =         ABORTED
 
 error: abort not covered by any of the `aborts_if` clauses
-    ┌─ tests/sources/functional/signed_int/artithmetic.move:327:5
+    ┌─ tests/sources/functional/signed_int/artithmetic.move:329:5
     │
-325 │           x * y
+327 │           x * y
     │           ----- abort happened here with execution failure
-326 │       }
-327 │ ╭     spec overflow_i256_mul_incorrect {
-328 │ │         aborts_if false;
-329 │ │     }
+328 │       }
+329 │ ╭     spec overflow_i256_mul_incorrect {
+330 │ │         aborts_if false;
+331 │ │     }
     │ ╰─────^
     │
-    =     at tests/sources/functional/signed_int/artithmetic.move:324: overflow_i256_mul_incorrect
+    =     at tests/sources/functional/signed_int/artithmetic.move:326: overflow_i256_mul_incorrect
     =         x = <redacted>
     =         y = <redacted>
-    =     at tests/sources/functional/signed_int/artithmetic.move:325: overflow_i256_mul_incorrect
+    =     at tests/sources/functional/signed_int/artithmetic.move:327: overflow_i256_mul_incorrect
     =         ABORTED

--- a/third_party/move/move-prover/tests/sources/functional/signed_int/artithmetic.move
+++ b/third_party/move/move-prover/tests/sources/functional/signed_int/artithmetic.move
@@ -28,6 +28,7 @@ module 0x42::TestSintArithmetic {
     }
     spec div {
         aborts_if y == 0;
+        aborts_if x == MIN_I64 && y == -1;
         ensures result_1 == x / y;
         ensures result_2 == x % y;
     }
@@ -134,6 +135,7 @@ module 0x42::TestSintArithmetic {
     }
     spec div_by_zero_i64 {
         aborts_if y == 0;
+        aborts_if x == MIN_I64 && y == -1;
     }
 
 


### PR DESCRIPTION
## Description

Fixes #19877.

The Move runtime truncates signed integer division toward zero (Rust / C semantics). The prover previously modeled `$Div` and `$Mod` with Boogie's built-in `div` / `mod`, which are Euclidean — they diverge from truncation whenever the dividend is negative with a non-zero remainder. As a result every spec involving signed division was rejected by the prover for inputs the runtime would handle correctly, e.g. `(-1) / 2` is `0` at runtime but the prover modeled it as `-1`. Three related soundness gaps came along for the ride:

- The shared `$Div` had no `MIN_Ix / -1` overflow check, so the prover did not consider that abort case for any signed type.
- The matching `$Mod` had no `MIN_Ix / -1` check either. Rust's `ix::checked_rem` returns `None` for `MIN % -1`, but the prover would silently produce a value because Boogie ints are unbounded and `-((-MIN) mod -1)` yields `0`.
- The spec-language `/` and `%` were lowered to Boogie's `div` / `mod` too — so even after fixing the body, spec assertions like `result == x / y` would still be Euclidean and disagree with the now-truncating body.

## Approach

Two reviewer constraints shaped the implementation:
1. **No multiplication / division in branch conditions** — SMT solvers handle non-linear integer arithmetic poorly. The conditional must stay linear (constant comparison only).
2. **Don't pessimize the unsigned hot path** — most arithmetic in the framework is unsigned and should stay a single SMT op.

Both are satisfied by splitting `$Div` / `$Mod` into **per-type procedures** emitted from the existing `integer_type` macro:

- **Unsigned `$Div{N}` / `$Mod{N}`**: zero-check + `dst := src1 div src2;` — identical SMT formula to before.
- **Signed `$Div{N}` / `$Mod{N}`**: zero-check + `MIN_{N}/-1` overflow check + `dst := $signed_div(src1, src2);` (or `$signed_mod`). The truncation formula lives in a single inline Boogie function and is reused by both the procedure bodies *and* the spec translator, so there's exactly one definition.

The truncation formula itself is the linear-condition form:
```boogie
function {:inline} $signed_div(a: int, b: int): int {
    if a >= 0 then a div b else -((-a) div b)
}
```

The translator's `Div` / `Mod` arms are updated to dispatch per-type (mirroring how `$Add{N}`, `$Sub{N}`, `$Mul{N}` already work), and the shared `$Div` / `$Mod` are removed.

For the **spec side**, `translate_op` gained a `signed_helper: Option<&str>` parameter. Add/Sub/Mul/Lt/Le/Gt/Ge pass `None`; Div/Mod pass `Some("$signed_div")` / `Some("$signed_mod")`. Signed operands hit the helper branch; unsigned and bitwise paths emit unchanged.

## Consolidation: `boogie_int_suffix`

The arithmetic arms in the translator (`Add`, `Sub`, `Mul`, `Div`, `Mod`) each had a copy of the same 12-arm 48-line `match` deciding the per-type Boogie procedure suffix. They are now one-liner calls to a new `boogie_int_suffix(ty, bv_flag)` helper in `boogie_helpers.rs`. The Add arm's existing `_unchecked` quirk (U8 omits it) is preserved with a tiny inline check.

Despite adding signed div/mod support, the **net PR diff is a deletion of ~32 lines**, with `bytecode_translator.rs` shrinking by ~212 lines.

## How Has This Been Tested?

- **New regression**: `third_party/move/move-prover/tests/sources/functional/signed_div_mod_19877.move` exercises both `/` and `%` across all four sign combinations (`-1/2`, `-7/3`, `-7/-3`, `7/-3`, …), the `MIN_I64/-1` div abort, the `(x as i128) / (y as i128)` cast pattern from the issue, the variable-operand `MIN/-1` mod abort, and the unsigned no-change cases. Fails before the fix with the exact counterexamples described in #19877; passes after.
- **Existing signed-int test updated**: `signed_int/artithmetic.move` had two specs (`div`, `div_by_zero_i64`) that were passing under the old broken semantics — they didn't list `MIN_I64/-1` as an abort. The fix exposes those gaps, and the missing `aborts_if x == MIN_I64 && y == -1` clauses are added. The `.exp` diff is pure line-number drift (+2) from those two new lines.
- **Full prover suite**: `cargo test -p move-prover --test testsuite` — 233/233 pass.
- **Framework prover suites** (signal for unsigned hot-path perf): `move_stdlib_prover_tests`, `move_aptos_stdlib_prover_tests`, `move_framework_prover_tests` all pass; `move_framework_prover_tests` completes in ~154s (vs ~166s pre-refactor — slight improvement). Strong evidence the unsigned encoding hasn't been pessimized.

## Key Areas to Review

- `prelude.bpl` — the `integer_type` macro gained a `signed` parameter and now emits per-type `$Div{N}` / `$Mod{N}` whose signed bodies are a zero-and-overflow guard followed by `dst := $signed_{div|mod}(src1, src2);`. Worth confirming:
  - The signed body's abort guard is symmetric for div and mod (both cover `src2 == 0` and `MIN/-1`).
  - The unsigned body emits the *same* SMT op as before (single `div` / `mod`, no extra branches).
  - `$signed_div` / `$signed_mod` are defined once at the top of the prelude and reused by procedure bodies and the spec translator.
- `bytecode_translator.rs` — `Add`, `Sub`, `Mul`, `Div`, `Mod` arms all dispatch through the same `boogie_int_suffix` helper. The Add arm's `_unchecked` quirk for U8 is preserved.
- `boogie_helpers.rs` — new `boogie_int_suffix`. Centralized per-type Boogie suffix mapping for arithmetic ops.
- `spec_translator.rs` — `translate_op` now takes `signed_helper: Option<&str>`; signed `/` / `%` route through `$signed_div` / `$signed_mod`. Other ops pass `None` because they coincide under truncating and Euclidean semantics.

## Out of Scope / Follow-ups

- **Signed bitvector div / mod.** Lines 260–261 of the prelude still use `bvudiv` / `bvurem`. The translator's BV dispatch hits `unreachable!` for signed types and `bv_all_types` in `lib.rs` explicitly excludes signed ints — so this code is currently unreachable for signed types and the existing `bvudiv` / `bvurem` is correct for the only types that actually flow through it. A future patch enabling signed-BV support would need to split this template by signedness (`bvsdiv` / `bvsrem`) and add a `MIN/-1` check.
- **Move v2 compiler constant-fold inconsistency.** While writing the regression test I noticed that `MIN_I64 % -1` is constant-folded to `0` by the Move compiler, while `MIN_I64 / -1` is **not** folded (it's emitted as a runtime op that this PR makes abort). This is a separate compiler-side bug — the fold should either preserve the runtime abort or not happen — and is why the variable-operand `mod_aborts_on_min_neg_one(x, y)` shape is used in the new regression test. Worth a follow-up issue.
- **Formal `--benchmark` numbers.** The framework suite times look unchanged (slight improvement) but a side-by-side benchmark run was not done.

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [x] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [x] Other (specify): Move Prover

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes formal semantics for signed division/modulus and abort conditions across bytecode and spec lowering; unsigned paths are intended to stay equivalent but verification behavior shifts for signed specs.
> 
> **Overview**
> Aligns the Move Prover with **truncate-toward-zero** signed `/` and `%` (Move/Rust), instead of Boogie’s Euclidean `div`/`mod`, and fixes missing **`MIN / -1`** abort modeling for signed division and modulus.
> 
> **Boogie prelude:** Adds inline `$signed_div` / `$signed_mod`, extends the `integer_type` macro with a `signed` flag, and emits per-width `$Div{N}` / `$Mod{N}` (signed bodies use the helpers plus overflow guards; unsigned bodies stay a single `div`/`mod` after a zero check). **Bytecode translation:** `Div`/`Mod` (and other arithmetic arms) dispatch via new `boogie_int_suffix`, removing large duplicated type `match` blocks. **Spec translation:** Signed `/` and `%` in specs call the same helpers; other ops are unchanged.
> 
> Adds regression coverage for issue #19877 and tightens existing signed-int specs with `aborts_if x == MIN_I64 && y == -1`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c535cd40f31f059c4548395328bda29d147a2591. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->