### PR TITLE
[Forge] Small fixes to forge stable.

### DIFF
--- a/.github/workflows/forge-stable.yaml
+++ b/.github/workflows/forge-stable.yaml
@@ -134,11 +134,11 @@ jobs:
               { TEST_NAME: 'realistic-env-graceful-overload', FORGE_RUNNER_DURATION_SECS: 1200, FORGE_TEST_SUITE: 'realistic_env_graceful_overload' },
               { TEST_NAME: 'consensus-stress-test', FORGE_RUNNER_DURATION_SECS: 2400, FORGE_TEST_SUITE: 'consensus_stress_test' },
               { TEST_NAME: 'changing-working-quorum-test', FORGE_RUNNER_DURATION_SECS: 1200, FORGE_TEST_SUITE: 'changing_working_quorum_test', FORGE_ENABLE_FAILPOINTS: true },
-              { TEST_NAME: 'realistic-env-max-load-long', FORGE_RUNNER_DURATION_SECS: 7200, FORGE_TEST_SUITE: 'realistic_env_max_load_large' },
+              { TEST_NAME: 'realistic-env-max-load-long', FORGE_RUNNER_DURATION_SECS: 3600, FORGE_TEST_SUITE: 'realistic_env_max_load_large' },
               { TEST_NAME: 'realistic-env-max-load-encrypted', FORGE_RUNNER_DURATION_SECS: 480, FORGE_TEST_SUITE: 'realistic_env_max_load_encrypted' },
               // Pin to the aptos-core SHA that the etna-rust image is built from, so the forge
               // test runner matches the etna binary under test.
-              { TEST_NAME: 'etna', FORGE_RUNNER_DURATION_SECS: 7200, FORGE_TEST_SUITE: 'land_blocking', FORGE_IMAGE_NAME: 'etna-rust', GIT_SHA: 'c66dbf952b692bc017b459e3e6e44cc2a43d6958' }
+              { TEST_NAME: 'etna', FORGE_RUNNER_DURATION_SECS: 3600, FORGE_TEST_SUITE: 'land_blocking', FORGE_IMAGE_NAME: 'etna-rust', GIT_SHA: 'c66dbf952b692bc017b459e3e6e44cc2a43d6958' }
             ];
 
             const matrix = testName != "all" ? tests.filter(test => test.TEST_NAME === testName) : tests;

--- a/testsuite/forge-cli/src/suites/realistic_environment.rs
+++ b/testsuite/forge-cli/src/suites/realistic_environment.rs
@@ -138,8 +138,7 @@ pub(crate) fn realistic_env_workload_sweep_test() -> ForgeConfig {
             TransactionWorkload::new(TransactionTypeArg::NoOp, 20000).with_num_modules(100),
             TransactionWorkload::new(TransactionTypeArg::ModifyGlobalResource, 6000)
                 .with_transactions_per_account(1),
-            TransactionWorkload::new(TransactionTypeArg::TokenV2AmbassadorMint, 20000)
-                .with_unique_senders(),
+            TransactionWorkload::new(TransactionTypeArg::TokenV2AmbassadorMint, 20000),
             // TODO(ibalajiarun): this is disabled due to Forge Stable failure on PosToProposal latency.
             TransactionWorkload::new(TransactionTypeArg::PublishPackage, 200)
                 .with_transactions_per_account(1),
@@ -148,10 +147,10 @@ pub(crate) fn realistic_env_workload_sweep_test() -> ForgeConfig {
         criteria: [
             (7000, 100, 0.3 + 0.5, 0.5, 0.5),
             (8500, 100, 0.3 + 0.5, 0.5, 0.4),
-            (2000, 300, 0.3 + 1.0, 0.6, 1.0),
-            (3200, 500, 0.3 + 1.0, 0.7, 0.8),
+            (2000, 300, 0.3 + 2.0, 0.6, 1.0),
+            (3200, 500, 0.3 + 2.0, 0.7, 0.8),
             // TODO - pos-to-proposal is set to high, until it is calibrated/understood.
-            (28, 5, 0.3 + 5.0, 0.7, 1.0),
+            (28, 5, 0.3 + 15.0, 0.7, 1.0),
         ]
         .into_iter()
         .map(
@@ -365,9 +364,8 @@ pub(crate) fn realistic_env_graceful_overload(duration: Duration) -> ForgeConfig
                     // Check that we don't use more than 28 CPU cores for 20% of the time.
                     MetricsThreshold::new(28.0, 20),
                     // TODO(ibalajiarun): Investigate the high utilization and adjust accordingly.
-                    // Memory starts around 8GB, and grows around 8GB/hr in this test.
                     // Check that we don't use more than final expected memory for more than 20% of the time.
-                    MetricsThreshold::new_gb(16.0 + 8.0 * (duration.as_secs_f64() / 3600.0), 20),
+                    MetricsThreshold::new_gb(26.0 + 8.0 * (duration.as_secs_f64() / 3600.0), 20),
                 ))
                 .add_latency_threshold(10.0, LatencyType::P50)
                 .add_latency_threshold(30.0, LatencyType::P90)
@@ -407,9 +405,8 @@ pub(crate) fn realistic_env_max_load_test(
         .add_system_metrics_threshold(SystemMetricsThreshold::new(
             // Check that we don't use more than 18 CPU cores for 15% of the time.
             MetricsThreshold::new(25.0, 15),
-            // Memory starts around 8GB, and grows around 1.4GB/hr in this test.
             // Check that we don't use more than final expected memory for more than 20% of the time.
-            MetricsThreshold::new_gb(16.0 + 8.0 * (duration_secs as f64 / 3600.0), 20),
+            MetricsThreshold::new_gb(26.0 + 8.0 * (duration_secs as f64 / 3600.0), 20),
         ))
         .add_no_restarts()
         .add_wait_for_catchup_s(
@@ -565,8 +562,8 @@ pub(crate) fn realistic_env_max_load_encrypted_test(duration: Duration) -> Forge
             helm_values["chain"]["initial_features_override"] =
                 serde_yaml::to_value(features).expect("must serialize");
         }))
-        .with_digest_key_blob_url("https://github.com/aptos-labs/aptos-networks/raw/6f69f6b2cd942bcae17efaada3d0f996a4741e85/devnet/digest_key.bin")
-        .with_public_parameters_blob_url("https://github.com/aptos-labs/aptos-networks/raw/6f69f6b2cd942bcae17efaada3d0f996a4741e85/devnet/pp.bin")
+        .with_digest_key_blob_url("https://github.com/aptos-labs/aptos-networks/raw/8cfc400bc1e42a232b5b36cde779a5b71d4d275b/devnet/digest_key.bin")
+        .with_public_parameters_blob_url("https://github.com/aptos-labs/aptos-networks/raw/8cfc400bc1e42a232b5b36cde779a5b71d4d275b/devnet/pp.bin")
         .with_validator_override_node_config_fn(Arc::new(|config, _| {
             config.api.allow_encrypted_txns_submission = true;
             config.consensus.quorum_store.enable_batch_v2_tx = true;
@@ -619,7 +616,10 @@ pub(crate) fn realistic_env_max_load_encrypted_mix_test(duration: Duration) -> F
                 .mode(EmitJobMode::MaxLoad { mempool_backlog })
                 .init_gas_price_multiplier(20)
                 .transaction_mix(vec![
-                    (TransactionTypeArg::EncryptedCoinTransfer.materialize_default(), 1),
+                    (
+                        TransactionTypeArg::EncryptedCoinTransfer.materialize_default(),
+                        1,
+                    ),
                     (TransactionTypeArg::CoinTransfer.materialize_default(), 9),
                 ]),
             inner_success_criteria: SuccessCriteria::new(300),
@@ -643,8 +643,8 @@ pub(crate) fn realistic_env_max_load_encrypted_mix_test(duration: Duration) -> F
             helm_values["chain"]["initial_features_override"] =
                 serde_yaml::to_value(features).expect("must serialize");
         }))
-        .with_digest_key_blob_url("https://github.com/aptos-labs/aptos-networks/raw/6f69f6b2cd942bcae17efaada3d0f996a4741e85/devnet/digest_key.bin")
-        .with_public_parameters_blob_url("https://github.com/aptos-labs/aptos-networks/raw/6f69f6b2cd942bcae17efaada3d0f996a4741e85/devnet/pp.bin")
+        .with_digest_key_blob_url("https://github.com/aptos-labs/aptos-networks/raw/8cfc400bc1e42a232b5b36cde779a5b71d4d275b/devnet/digest_key.bin")
+        .with_public_parameters_blob_url("https://github.com/aptos-labs/aptos-networks/raw/8cfc400bc1e42a232b5b36cde779a5b71d4d275b/devnet/pp.bin")
         .with_validator_override_node_config_fn(Arc::new(|config, _| {
             config.api.allow_encrypted_txns_submission = true;
             config.consensus.quorum_store.enable_batch_v2_tx = true;


### PR DESCRIPTION
## Description
Small fixes to forge stable. The latest run is almost green: https://github.com/aptos-labs/aptos-core/actions/runs/26534264646

> [!NOTE]
> **Low Risk**
> Changes only CI durations and Forge test success criteria/config URLs; no production validator or consensus logic.
> 
> **Overview**
> Forge Stable CI and suite definitions are tuned to reduce flake and runtime without changing which tests run.
> 
> **CI:** `realistic-env-max-load-long` and `etna` runner durations drop from **7200s to 3600s** in `forge-stable.yaml`.
> 
> **Workload sweep:** `TokenV2AmbassadorMint` no longer uses `with_unique_senders()`. Latency breakdown limits are **relaxed** for several workloads (e.g. mempool-to-block-creation from +1.0 to +2.0, pos-to-proposal from +5.0 to +15.0).
> 
> **Resource gates:** Graceful overload and max-load tests raise the **memory threshold baseline** from **16 GB to 26 GB** (still with the +8 GB/hr growth term).
> 
> **Encrypted Forge:** Digest key and public-parameters blob URLs point to a **newer `aptos-networks` commit** (`8cfc400…`); encrypted mix workload has a small formatting-only change to the transaction mix tuple.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16ddb4391233175d302dcd70cd196d84d9e8b856. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->