### PR TITLE
[compiler] Fix const folding bug for modulo operation on signed integers

### DIFF
--- a/third_party/move/move-binary-format/src/file_format.rs
+++ b/third_party/move/move-binary-format/src/file_format.rs
@@ -2213,12 +2213,14 @@ pub enum Bytecode {
     #[description = r#"
         Perform a modulo operation on the two integer values at the top of the stack and push the result on the stack.
 
-        This operation aborts the transaction in case the right hand side is zero.
+        This operation aborts the transaction in case the right hand side is zero or overflow happens.
+        Overflow can only happen for signed integer types, when the left hand side is the minimum
+        value of the type and the right hand side is -1.
     "#]
     #[semantics = r#"
         stack >> rhs
         stack >> lhs
-        if rhs == 0
+        if rhs == 0 || (lhs == i<N>::MIN && rhs == -1)
             arithmetic error
         else
             stack << (lhs % rhs)

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/signed-int/rem_min_edge_cases.baseline.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/signed-int/rem_min_edge_cases.baseline.exp
@@ -1,0 +1,262 @@
+processed 21 tasks
+task 0 lines 1-27:  publish [module 0xff::rem_min {]
+task 1 lines 29-47:  publish [module 0xff::const_rem_neg1 {]
+Error: compilation errors:
+ error: Invalid expression in `const`. Operator `%` result value out of range for `i8`
+   ┌─ TEMPFILE1:31:26
+   │
+31 │     const C_I8:   i8   = -128i8 % -1i8;
+   │                          ^^^^^^^^^^^^^
+
+error: Invalid expression in `const`. Operator `%` result value out of range for `i16`
+   ┌─ TEMPFILE1:32:26
+   │
+32 │     const C_I16:  i16  = -32768i16 % -1i16;
+   │                          ^^^^^^^^^^^^^^^^^
+
+error: Invalid expression in `const`. Operator `%` result value out of range for `i32`
+   ┌─ TEMPFILE1:33:26
+   │
+33 │     const C_I32:  i32  = -2147483648i32 % -1i32;
+   │                          ^^^^^^^^^^^^^^^^^^^^^^
+
+error: Invalid expression in `const`. Operator `%` result value out of range for `i64`
+   ┌─ TEMPFILE1:34:26
+   │
+34 │     const C_I64:  i64  = -9223372036854775808i64 % -1i64;
+   │                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Invalid expression in `const`. Operator `%` result value out of range for `i128`
+   ┌─ TEMPFILE1:36:9
+   │
+36 │         -170141183460469231731687303715884105728i128 % -1i128;
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Invalid expression in `const`. Operator `%` result value out of range for `i256`
+   ┌─ TEMPFILE1:38:9
+   │  
+38 │ ╭         -57896044618658097711785492504343953926634992332820282019728792003956564819968i256
+39 │ │             % -1i256;
+   │ ╰────────────────────^
+
+
+task 2 lines 49-67:  publish [module 0xff::const_rem_0 {]
+Error: compilation errors:
+ error: Invalid expression in `const`. Operator `%` result value out of range for `i8`
+   ┌─ TEMPFILE2:51:26
+   │
+51 │     const C_I8:   i8   = -128i8 % 0i8;
+   │                          ^^^^^^^^^^^^
+
+error: Invalid expression in `const`. Operator `%` result value out of range for `i16`
+   ┌─ TEMPFILE2:52:26
+   │
+52 │     const C_I16:  i16  = -32768i16 % 0i16;
+   │                          ^^^^^^^^^^^^^^^^
+
+error: Invalid expression in `const`. Operator `%` result value out of range for `i32`
+   ┌─ TEMPFILE2:53:26
+   │
+53 │     const C_I32:  i32  = -2147483648i32 % 0i32;
+   │                          ^^^^^^^^^^^^^^^^^^^^^
+
+error: Invalid expression in `const`. Operator `%` result value out of range for `i64`
+   ┌─ TEMPFILE2:54:26
+   │
+54 │     const C_I64:  i64  = -9223372036854775808i64 % 0i64;
+   │                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Invalid expression in `const`. Operator `%` result value out of range for `i128`
+   ┌─ TEMPFILE2:56:9
+   │
+56 │         -170141183460469231731687303715884105728i128 % 0i128;
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Invalid expression in `const`. Operator `%` result value out of range for `i256`
+   ┌─ TEMPFILE2:58:9
+   │  
+58 │ ╭         -57896044618658097711785492504343953926634992332820282019728792003956564819968i256
+59 │ │             % 0i256;
+   │ ╰───────────────────^
+
+
+task 3 lines 69-74:  run --verbose [script {]
+Error: Script execution failed with VMError: {
+    message: Integer remainder by zero,
+    major_status: ARITHMETIC_ERROR,
+    sub_status: None,
+    location: script,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 2)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}
+task 4 lines 76-81:  run --verbose [script {]
+Error: Script execution failed with VMError: {
+    message: Integer remainder by zero,
+    major_status: ARITHMETIC_ERROR,
+    sub_status: None,
+    location: script,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 2)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}
+task 5 lines 83-88:  run --verbose [script {]
+Error: Script execution failed with VMError: {
+    message: Integer remainder by zero,
+    major_status: ARITHMETIC_ERROR,
+    sub_status: None,
+    location: script,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 2)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}
+task 6 lines 90-95:  run --verbose [script {]
+Error: Script execution failed with VMError: {
+    message: Integer remainder by zero,
+    major_status: ARITHMETIC_ERROR,
+    sub_status: None,
+    location: script,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 2)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}
+task 7 lines 97-105:  run --verbose [script {]
+Error: Script execution failed with VMError: {
+    message: Integer remainder by zero,
+    major_status: ARITHMETIC_ERROR,
+    sub_status: None,
+    location: script,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 2)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}
+task 8 lines 107-116:  run --verbose [script {]
+Error: Script execution failed with VMError: {
+    message: Integer remainder by zero,
+    major_status: ARITHMETIC_ERROR,
+    sub_status: None,
+    location: script,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 2)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}
+task 9 lines 119-124:  run --verbose [script {]
+Error: Script execution failed with VMError: {
+    message: Integer remainder by zero,
+    major_status: ARITHMETIC_ERROR,
+    sub_status: None,
+    location: script,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 2)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}
+task 10 lines 126-131:  run --verbose [script {]
+Error: Script execution failed with VMError: {
+    message: Integer remainder by zero,
+    major_status: ARITHMETIC_ERROR,
+    sub_status: None,
+    location: script,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 2)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}
+task 11 lines 133-138:  run --verbose [script {]
+Error: Script execution failed with VMError: {
+    message: Integer remainder by zero,
+    major_status: ARITHMETIC_ERROR,
+    sub_status: None,
+    location: script,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 2)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}
+task 12 lines 140-145:  run --verbose [script {]
+Error: Script execution failed with VMError: {
+    message: Integer remainder by zero,
+    major_status: ARITHMETIC_ERROR,
+    sub_status: None,
+    location: script,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 2)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}
+task 13 lines 147-152:  run --verbose [script {]
+Error: Script execution failed with VMError: {
+    message: Integer remainder by zero,
+    major_status: ARITHMETIC_ERROR,
+    sub_status: None,
+    location: script,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 2)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}
+task 14 lines 154-160:  run --verbose [script {]
+Error: Script execution failed with VMError: {
+    message: Integer remainder by zero,
+    major_status: ARITHMETIC_ERROR,
+    sub_status: None,
+    location: script,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 2)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}
+task 15 lines 163-163:  run 0xff::rem_min::min_i8_rem_0 --verbose
+Error: Function execution failed with VMError: {
+    message: Integer remainder by zero,
+    major_status: ARITHMETIC_ERROR,
+    sub_status: None,
+    location: 0xff::rem_min,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(16), 2)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}
+task 16 lines 165-165:  run 0xff::rem_min::min_i16_rem_0 --verbose
+Error: Function execution failed with VMError: {
+    message: Integer remainder by zero,
+    major_status: ARITHMETIC_ERROR,
+    sub_status: None,
+    location: 0xff::rem_min,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(4), 2)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}
+task 17 lines 167-167:  run 0xff::rem_min::min_i32_rem_0 --verbose
+Error: Function execution failed with VMError: {
+    message: Integer remainder by zero,
+    major_status: ARITHMETIC_ERROR,
+    sub_status: None,
+    location: 0xff::rem_min,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(10), 2)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}
+task 18 lines 169-169:  run 0xff::rem_min::min_i64_rem_0 --verbose
+Error: Function execution failed with VMError: {
+    message: Integer remainder by zero,
+    major_status: ARITHMETIC_ERROR,
+    sub_status: None,
+    location: 0xff::rem_min,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(13), 2)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}
+task 19 lines 171-171:  run 0xff::rem_min::min_i128_rem_0 --verbose
+Error: Function execution failed with VMError: {
+    message: Integer remainder by zero,
+    major_status: ARITHMETIC_ERROR,
+    sub_status: None,
+    location: 0xff::rem_min,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(1), 2)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}
+task 20 lines 173-173:  run 0xff::rem_min::min_i256_rem_0 --verbose
+Error: Function execution failed with VMError: {
+    message: Integer remainder by zero,
+    major_status: ARITHMETIC_ERROR,
+    sub_status: None,
+    location: 0xff::rem_min,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(7), 2)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/signed-int/rem_min_edge_cases.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/signed-int/rem_min_edge_cases.move
@@ -1,0 +1,173 @@
+//# publish
+module 0xff::rem_min {
+    public fun min_i8(): i8 { -128i8 }
+    public fun min_i16(): i16 { -32768i16 }
+    public fun min_i32(): i32 { -2147483648i32 }
+    public fun min_i64(): i64 { -9223372036854775808i64 }
+    public fun min_i128(): i128 {
+        -170141183460469231731687303715884105728i128
+    }
+    public fun min_i256(): i256 {
+        -57896044618658097711785492504343953926634992332820282019728792003956564819968i256
+    }
+
+    public fun min_i8_rem_neg1(): i8     { min_i8()   % -1i8   }
+    public fun min_i16_rem_neg1(): i16   { min_i16()  % -1i16  }
+    public fun min_i32_rem_neg1(): i32   { min_i32()  % -1i32  }
+    public fun min_i64_rem_neg1(): i64   { min_i64()  % -1i64  }
+    public fun min_i128_rem_neg1(): i128 { min_i128() % -1i128 }
+    public fun min_i256_rem_neg1(): i256 { min_i256() % -1i256 }
+
+    public fun min_i8_rem_0(): i8     { min_i8()   % 0i8   }
+    public fun min_i16_rem_0(): i16   { min_i16()  % 0i16  }
+    public fun min_i32_rem_0(): i32   { min_i32()  % 0i32  }
+    public fun min_i64_rem_0(): i64   { min_i64()  % 0i64  }
+    public fun min_i128_rem_0(): i128 { min_i128() % 0i128 }
+    public fun min_i256_rem_0(): i256 { min_i256() % 0i256 }
+}
+
+//# publish
+module 0xff::const_rem_neg1 {
+    const C_I8:   i8   = -128i8 % -1i8;
+    const C_I16:  i16  = -32768i16 % -1i16;
+    const C_I32:  i32  = -2147483648i32 % -1i32;
+    const C_I64:  i64  = -9223372036854775808i64 % -1i64;
+    const C_I128: i128 =
+        -170141183460469231731687303715884105728i128 % -1i128;
+    const C_I256: i256 =
+        -57896044618658097711785492504343953926634992332820282019728792003956564819968i256
+            % -1i256;
+
+    public fun get_i8():   i8   { C_I8   }
+    public fun get_i16():  i16  { C_I16  }
+    public fun get_i32():  i32  { C_I32  }
+    public fun get_i64():  i64  { C_I64  }
+    public fun get_i128(): i128 { C_I128 }
+    public fun get_i256(): i256 { C_I256 }
+}
+
+//# publish
+module 0xff::const_rem_0 {
+    const C_I8:   i8   = -128i8 % 0i8;
+    const C_I16:  i16  = -32768i16 % 0i16;
+    const C_I32:  i32  = -2147483648i32 % 0i32;
+    const C_I64:  i64  = -9223372036854775808i64 % 0i64;
+    const C_I128: i128 =
+        -170141183460469231731687303715884105728i128 % 0i128;
+    const C_I256: i256 =
+        -57896044618658097711785492504343953926634992332820282019728792003956564819968i256
+            % 0i256;
+
+    public fun get_i8():   i8   { C_I8   }
+    public fun get_i16():  i16  { C_I16  }
+    public fun get_i32():  i32  { C_I32  }
+    public fun get_i64():  i64  { C_I64  }
+    public fun get_i128(): i128 { C_I128 }
+    public fun get_i256(): i256 { C_I256 }
+}
+
+//# run --verbose
+script {
+    fun main() {
+        assert!(-128i8 % -1i8 == 0i8, 100);
+    }
+}
+
+//# run --verbose
+script {
+    fun main() {
+        assert!(-32768i16 % -1i16 == 0i16, 200);
+    }
+}
+
+//# run --verbose
+script {
+    fun main() {
+        assert!(-2147483648i32 % -1i32 == 0i32, 300);
+    }
+}
+
+//# run --verbose
+script {
+    fun main() {
+        assert!(-9223372036854775808i64 % -1i64 == 0i64, 400);
+    }
+}
+
+//# run --verbose
+script {
+    fun main() {
+        assert!(
+            -170141183460469231731687303715884105728i128 % -1i128 == 0i128,
+            500,
+        );
+    }
+}
+
+//# run --verbose
+script {
+    fun main() {
+        assert!(
+            -57896044618658097711785492504343953926634992332820282019728792003956564819968i256
+                % -1i256 == 0i256,
+            600,
+        );
+    }
+}
+
+
+//# run --verbose
+script {
+    fun main() {
+        -128i8 % 0i8;
+    }
+}
+
+//# run --verbose
+script {
+    fun main() {
+        -32768i16 % 0i16;
+    }
+}
+
+//# run --verbose
+script {
+    fun main() {
+        -2147483648i32 % 0i32;
+    }
+}
+
+//# run --verbose
+script {
+    fun main() {
+        -9223372036854775808i64 % 0i64;
+    }
+}
+
+//# run --verbose
+script {
+    fun main() {
+        -170141183460469231731687303715884105728i128 % 0i128;
+    }
+}
+
+//# run --verbose
+script {
+    fun main() {
+        -57896044618658097711785492504343953926634992332820282019728792003956564819968i256
+            % 0i256;
+    }
+}
+
+
+//# run 0xff::rem_min::min_i8_rem_0 --verbose
+
+//# run 0xff::rem_min::min_i16_rem_0 --verbose
+
+//# run 0xff::rem_min::min_i32_rem_0 --verbose
+
+//# run 0xff::rem_min::min_i64_rem_0 --verbose
+
+//# run 0xff::rem_min::min_i128_rem_0 --verbose
+
+//# run 0xff::rem_min::min_i256_rem_0 --verbose

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/signed-int/rem_min_edge_cases.no-optimize.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/signed-int/rem_min_edge_cases.no-optimize.exp
@@ -1,0 +1,262 @@
+processed 21 tasks
+task 0 lines 1-27:  publish [module 0xff::rem_min {]
+task 1 lines 29-47:  publish [module 0xff::const_rem_neg1 {]
+Error: compilation errors:
+ error: Invalid expression in `const`. Operator `%` result value out of range for `i8`
+   ┌─ TEMPFILE1:31:26
+   │
+31 │     const C_I8:   i8   = -128i8 % -1i8;
+   │                          ^^^^^^^^^^^^^
+
+error: Invalid expression in `const`. Operator `%` result value out of range for `i16`
+   ┌─ TEMPFILE1:32:26
+   │
+32 │     const C_I16:  i16  = -32768i16 % -1i16;
+   │                          ^^^^^^^^^^^^^^^^^
+
+error: Invalid expression in `const`. Operator `%` result value out of range for `i32`
+   ┌─ TEMPFILE1:33:26
+   │
+33 │     const C_I32:  i32  = -2147483648i32 % -1i32;
+   │                          ^^^^^^^^^^^^^^^^^^^^^^
+
+error: Invalid expression in `const`. Operator `%` result value out of range for `i64`
+   ┌─ TEMPFILE1:34:26
+   │
+34 │     const C_I64:  i64  = -9223372036854775808i64 % -1i64;
+   │                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Invalid expression in `const`. Operator `%` result value out of range for `i128`
+   ┌─ TEMPFILE1:36:9
+   │
+36 │         -170141183460469231731687303715884105728i128 % -1i128;
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Invalid expression in `const`. Operator `%` result value out of range for `i256`
+   ┌─ TEMPFILE1:38:9
+   │  
+38 │ ╭         -57896044618658097711785492504343953926634992332820282019728792003956564819968i256
+39 │ │             % -1i256;
+   │ ╰────────────────────^
+
+
+task 2 lines 49-67:  publish [module 0xff::const_rem_0 {]
+Error: compilation errors:
+ error: Invalid expression in `const`. Operator `%` result value out of range for `i8`
+   ┌─ TEMPFILE2:51:26
+   │
+51 │     const C_I8:   i8   = -128i8 % 0i8;
+   │                          ^^^^^^^^^^^^
+
+error: Invalid expression in `const`. Operator `%` result value out of range for `i16`
+   ┌─ TEMPFILE2:52:26
+   │
+52 │     const C_I16:  i16  = -32768i16 % 0i16;
+   │                          ^^^^^^^^^^^^^^^^
+
+error: Invalid expression in `const`. Operator `%` result value out of range for `i32`
+   ┌─ TEMPFILE2:53:26
+   │
+53 │     const C_I32:  i32  = -2147483648i32 % 0i32;
+   │                          ^^^^^^^^^^^^^^^^^^^^^
+
+error: Invalid expression in `const`. Operator `%` result value out of range for `i64`
+   ┌─ TEMPFILE2:54:26
+   │
+54 │     const C_I64:  i64  = -9223372036854775808i64 % 0i64;
+   │                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Invalid expression in `const`. Operator `%` result value out of range for `i128`
+   ┌─ TEMPFILE2:56:9
+   │
+56 │         -170141183460469231731687303715884105728i128 % 0i128;
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Invalid expression in `const`. Operator `%` result value out of range for `i256`
+   ┌─ TEMPFILE2:58:9
+   │  
+58 │ ╭         -57896044618658097711785492504343953926634992332820282019728792003956564819968i256
+59 │ │             % 0i256;
+   │ ╰───────────────────^
+
+
+task 3 lines 69-74:  run --verbose [script {]
+Error: Script execution failed with VMError: {
+    message: Integer remainder by zero,
+    major_status: ARITHMETIC_ERROR,
+    sub_status: None,
+    location: script,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 2)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}
+task 4 lines 76-81:  run --verbose [script {]
+Error: Script execution failed with VMError: {
+    message: Integer remainder by zero,
+    major_status: ARITHMETIC_ERROR,
+    sub_status: None,
+    location: script,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 2)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}
+task 5 lines 83-88:  run --verbose [script {]
+Error: Script execution failed with VMError: {
+    message: Integer remainder by zero,
+    major_status: ARITHMETIC_ERROR,
+    sub_status: None,
+    location: script,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 2)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}
+task 6 lines 90-95:  run --verbose [script {]
+Error: Script execution failed with VMError: {
+    message: Integer remainder by zero,
+    major_status: ARITHMETIC_ERROR,
+    sub_status: None,
+    location: script,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 2)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}
+task 7 lines 97-105:  run --verbose [script {]
+Error: Script execution failed with VMError: {
+    message: Integer remainder by zero,
+    major_status: ARITHMETIC_ERROR,
+    sub_status: None,
+    location: script,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 2)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}
+task 8 lines 107-116:  run --verbose [script {]
+Error: Script execution failed with VMError: {
+    message: Integer remainder by zero,
+    major_status: ARITHMETIC_ERROR,
+    sub_status: None,
+    location: script,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 2)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}
+task 9 lines 119-124:  run --verbose [script {]
+Error: Script execution failed with VMError: {
+    message: Integer remainder by zero,
+    major_status: ARITHMETIC_ERROR,
+    sub_status: None,
+    location: script,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 2)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}
+task 10 lines 126-131:  run --verbose [script {]
+Error: Script execution failed with VMError: {
+    message: Integer remainder by zero,
+    major_status: ARITHMETIC_ERROR,
+    sub_status: None,
+    location: script,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 2)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}
+task 11 lines 133-138:  run --verbose [script {]
+Error: Script execution failed with VMError: {
+    message: Integer remainder by zero,
+    major_status: ARITHMETIC_ERROR,
+    sub_status: None,
+    location: script,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 2)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}
+task 12 lines 140-145:  run --verbose [script {]
+Error: Script execution failed with VMError: {
+    message: Integer remainder by zero,
+    major_status: ARITHMETIC_ERROR,
+    sub_status: None,
+    location: script,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 2)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}
+task 13 lines 147-152:  run --verbose [script {]
+Error: Script execution failed with VMError: {
+    message: Integer remainder by zero,
+    major_status: ARITHMETIC_ERROR,
+    sub_status: None,
+    location: script,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 2)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}
+task 14 lines 154-160:  run --verbose [script {]
+Error: Script execution failed with VMError: {
+    message: Integer remainder by zero,
+    major_status: ARITHMETIC_ERROR,
+    sub_status: None,
+    location: script,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 2)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}
+task 15 lines 163-163:  run 0xff::rem_min::min_i8_rem_0 --verbose
+Error: Function execution failed with VMError: {
+    message: Integer remainder by zero,
+    major_status: ARITHMETIC_ERROR,
+    sub_status: None,
+    location: 0xff::rem_min,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(16), 2)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}
+task 16 lines 165-165:  run 0xff::rem_min::min_i16_rem_0 --verbose
+Error: Function execution failed with VMError: {
+    message: Integer remainder by zero,
+    major_status: ARITHMETIC_ERROR,
+    sub_status: None,
+    location: 0xff::rem_min,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(4), 2)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}
+task 17 lines 167-167:  run 0xff::rem_min::min_i32_rem_0 --verbose
+Error: Function execution failed with VMError: {
+    message: Integer remainder by zero,
+    major_status: ARITHMETIC_ERROR,
+    sub_status: None,
+    location: 0xff::rem_min,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(10), 2)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}
+task 18 lines 169-169:  run 0xff::rem_min::min_i64_rem_0 --verbose
+Error: Function execution failed with VMError: {
+    message: Integer remainder by zero,
+    major_status: ARITHMETIC_ERROR,
+    sub_status: None,
+    location: 0xff::rem_min,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(13), 2)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}
+task 19 lines 171-171:  run 0xff::rem_min::min_i128_rem_0 --verbose
+Error: Function execution failed with VMError: {
+    message: Integer remainder by zero,
+    major_status: ARITHMETIC_ERROR,
+    sub_status: None,
+    location: 0xff::rem_min,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(1), 2)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}
+task 20 lines 173-173:  run 0xff::rem_min::min_i256_rem_0 --verbose
+Error: Function execution failed with VMError: {
+    message: Integer remainder by zero,
+    major_status: ARITHMETIC_ERROR,
+    sub_status: None,
+    location: 0xff::rem_min,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(7), 2)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/signed-int/rem_min_edge_cases.opt-extra.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/signed-int/rem_min_edge_cases.opt-extra.exp
@@ -1,0 +1,262 @@
+processed 21 tasks
+task 0 lines 1-27:  publish [module 0xff::rem_min {]
+task 1 lines 29-47:  publish [module 0xff::const_rem_neg1 {]
+Error: compilation errors:
+ error: Invalid expression in `const`. Operator `%` result value out of range for `i8`
+   ┌─ TEMPFILE1:31:26
+   │
+31 │     const C_I8:   i8   = -128i8 % -1i8;
+   │                          ^^^^^^^^^^^^^
+
+error: Invalid expression in `const`. Operator `%` result value out of range for `i16`
+   ┌─ TEMPFILE1:32:26
+   │
+32 │     const C_I16:  i16  = -32768i16 % -1i16;
+   │                          ^^^^^^^^^^^^^^^^^
+
+error: Invalid expression in `const`. Operator `%` result value out of range for `i32`
+   ┌─ TEMPFILE1:33:26
+   │
+33 │     const C_I32:  i32  = -2147483648i32 % -1i32;
+   │                          ^^^^^^^^^^^^^^^^^^^^^^
+
+error: Invalid expression in `const`. Operator `%` result value out of range for `i64`
+   ┌─ TEMPFILE1:34:26
+   │
+34 │     const C_I64:  i64  = -9223372036854775808i64 % -1i64;
+   │                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Invalid expression in `const`. Operator `%` result value out of range for `i128`
+   ┌─ TEMPFILE1:36:9
+   │
+36 │         -170141183460469231731687303715884105728i128 % -1i128;
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Invalid expression in `const`. Operator `%` result value out of range for `i256`
+   ┌─ TEMPFILE1:38:9
+   │  
+38 │ ╭         -57896044618658097711785492504343953926634992332820282019728792003956564819968i256
+39 │ │             % -1i256;
+   │ ╰────────────────────^
+
+
+task 2 lines 49-67:  publish [module 0xff::const_rem_0 {]
+Error: compilation errors:
+ error: Invalid expression in `const`. Operator `%` result value out of range for `i8`
+   ┌─ TEMPFILE2:51:26
+   │
+51 │     const C_I8:   i8   = -128i8 % 0i8;
+   │                          ^^^^^^^^^^^^
+
+error: Invalid expression in `const`. Operator `%` result value out of range for `i16`
+   ┌─ TEMPFILE2:52:26
+   │
+52 │     const C_I16:  i16  = -32768i16 % 0i16;
+   │                          ^^^^^^^^^^^^^^^^
+
+error: Invalid expression in `const`. Operator `%` result value out of range for `i32`
+   ┌─ TEMPFILE2:53:26
+   │
+53 │     const C_I32:  i32  = -2147483648i32 % 0i32;
+   │                          ^^^^^^^^^^^^^^^^^^^^^
+
+error: Invalid expression in `const`. Operator `%` result value out of range for `i64`
+   ┌─ TEMPFILE2:54:26
+   │
+54 │     const C_I64:  i64  = -9223372036854775808i64 % 0i64;
+   │                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Invalid expression in `const`. Operator `%` result value out of range for `i128`
+   ┌─ TEMPFILE2:56:9
+   │
+56 │         -170141183460469231731687303715884105728i128 % 0i128;
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Invalid expression in `const`. Operator `%` result value out of range for `i256`
+   ┌─ TEMPFILE2:58:9
+   │  
+58 │ ╭         -57896044618658097711785492504343953926634992332820282019728792003956564819968i256
+59 │ │             % 0i256;
+   │ ╰───────────────────^
+
+
+task 3 lines 69-74:  run --verbose [script {]
+Error: Script execution failed with VMError: {
+    message: Integer remainder by zero,
+    major_status: ARITHMETIC_ERROR,
+    sub_status: None,
+    location: script,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 2)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}
+task 4 lines 76-81:  run --verbose [script {]
+Error: Script execution failed with VMError: {
+    message: Integer remainder by zero,
+    major_status: ARITHMETIC_ERROR,
+    sub_status: None,
+    location: script,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 2)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}
+task 5 lines 83-88:  run --verbose [script {]
+Error: Script execution failed with VMError: {
+    message: Integer remainder by zero,
+    major_status: ARITHMETIC_ERROR,
+    sub_status: None,
+    location: script,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 2)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}
+task 6 lines 90-95:  run --verbose [script {]
+Error: Script execution failed with VMError: {
+    message: Integer remainder by zero,
+    major_status: ARITHMETIC_ERROR,
+    sub_status: None,
+    location: script,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 2)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}
+task 7 lines 97-105:  run --verbose [script {]
+Error: Script execution failed with VMError: {
+    message: Integer remainder by zero,
+    major_status: ARITHMETIC_ERROR,
+    sub_status: None,
+    location: script,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 2)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}
+task 8 lines 107-116:  run --verbose [script {]
+Error: Script execution failed with VMError: {
+    message: Integer remainder by zero,
+    major_status: ARITHMETIC_ERROR,
+    sub_status: None,
+    location: script,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 2)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}
+task 9 lines 119-124:  run --verbose [script {]
+Error: Script execution failed with VMError: {
+    message: Integer remainder by zero,
+    major_status: ARITHMETIC_ERROR,
+    sub_status: None,
+    location: script,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 2)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}
+task 10 lines 126-131:  run --verbose [script {]
+Error: Script execution failed with VMError: {
+    message: Integer remainder by zero,
+    major_status: ARITHMETIC_ERROR,
+    sub_status: None,
+    location: script,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 2)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}
+task 11 lines 133-138:  run --verbose [script {]
+Error: Script execution failed with VMError: {
+    message: Integer remainder by zero,
+    major_status: ARITHMETIC_ERROR,
+    sub_status: None,
+    location: script,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 2)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}
+task 12 lines 140-145:  run --verbose [script {]
+Error: Script execution failed with VMError: {
+    message: Integer remainder by zero,
+    major_status: ARITHMETIC_ERROR,
+    sub_status: None,
+    location: script,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 2)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}
+task 13 lines 147-152:  run --verbose [script {]
+Error: Script execution failed with VMError: {
+    message: Integer remainder by zero,
+    major_status: ARITHMETIC_ERROR,
+    sub_status: None,
+    location: script,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 2)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}
+task 14 lines 154-160:  run --verbose [script {]
+Error: Script execution failed with VMError: {
+    message: Integer remainder by zero,
+    major_status: ARITHMETIC_ERROR,
+    sub_status: None,
+    location: script,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 2)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}
+task 15 lines 163-163:  run 0xff::rem_min::min_i8_rem_0 --verbose
+Error: Function execution failed with VMError: {
+    message: Integer remainder by zero,
+    major_status: ARITHMETIC_ERROR,
+    sub_status: None,
+    location: 0xff::rem_min,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(16), 2)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}
+task 16 lines 165-165:  run 0xff::rem_min::min_i16_rem_0 --verbose
+Error: Function execution failed with VMError: {
+    message: Integer remainder by zero,
+    major_status: ARITHMETIC_ERROR,
+    sub_status: None,
+    location: 0xff::rem_min,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(4), 2)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}
+task 17 lines 167-167:  run 0xff::rem_min::min_i32_rem_0 --verbose
+Error: Function execution failed with VMError: {
+    message: Integer remainder by zero,
+    major_status: ARITHMETIC_ERROR,
+    sub_status: None,
+    location: 0xff::rem_min,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(10), 2)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}
+task 18 lines 169-169:  run 0xff::rem_min::min_i64_rem_0 --verbose
+Error: Function execution failed with VMError: {
+    message: Integer remainder by zero,
+    major_status: ARITHMETIC_ERROR,
+    sub_status: None,
+    location: 0xff::rem_min,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(13), 2)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}
+task 19 lines 171-171:  run 0xff::rem_min::min_i128_rem_0 --verbose
+Error: Function execution failed with VMError: {
+    message: Integer remainder by zero,
+    major_status: ARITHMETIC_ERROR,
+    sub_status: None,
+    location: 0xff::rem_min,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(1), 2)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}
+task 20 lines 173-173:  run 0xff::rem_min::min_i256_rem_0 --verbose
+Error: Function execution failed with VMError: {
+    message: Integer remainder by zero,
+    major_status: ARITHMETIC_ERROR,
+    sub_status: None,
+    location: 0xff::rem_min,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(7), 2)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/signed-int/rem_min_edge_cases.optimize.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/signed-int/rem_min_edge_cases.optimize.exp
@@ -1,0 +1,262 @@
+processed 21 tasks
+task 0 lines 1-27:  publish [module 0xff::rem_min {]
+task 1 lines 29-47:  publish [module 0xff::const_rem_neg1 {]
+Error: compilation errors:
+ error: Invalid expression in `const`. Operator `%` result value out of range for `i8`
+   ┌─ TEMPFILE1:31:26
+   │
+31 │     const C_I8:   i8   = -128i8 % -1i8;
+   │                          ^^^^^^^^^^^^^
+
+error: Invalid expression in `const`. Operator `%` result value out of range for `i16`
+   ┌─ TEMPFILE1:32:26
+   │
+32 │     const C_I16:  i16  = -32768i16 % -1i16;
+   │                          ^^^^^^^^^^^^^^^^^
+
+error: Invalid expression in `const`. Operator `%` result value out of range for `i32`
+   ┌─ TEMPFILE1:33:26
+   │
+33 │     const C_I32:  i32  = -2147483648i32 % -1i32;
+   │                          ^^^^^^^^^^^^^^^^^^^^^^
+
+error: Invalid expression in `const`. Operator `%` result value out of range for `i64`
+   ┌─ TEMPFILE1:34:26
+   │
+34 │     const C_I64:  i64  = -9223372036854775808i64 % -1i64;
+   │                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Invalid expression in `const`. Operator `%` result value out of range for `i128`
+   ┌─ TEMPFILE1:36:9
+   │
+36 │         -170141183460469231731687303715884105728i128 % -1i128;
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Invalid expression in `const`. Operator `%` result value out of range for `i256`
+   ┌─ TEMPFILE1:38:9
+   │  
+38 │ ╭         -57896044618658097711785492504343953926634992332820282019728792003956564819968i256
+39 │ │             % -1i256;
+   │ ╰────────────────────^
+
+
+task 2 lines 49-67:  publish [module 0xff::const_rem_0 {]
+Error: compilation errors:
+ error: Invalid expression in `const`. Operator `%` result value out of range for `i8`
+   ┌─ TEMPFILE2:51:26
+   │
+51 │     const C_I8:   i8   = -128i8 % 0i8;
+   │                          ^^^^^^^^^^^^
+
+error: Invalid expression in `const`. Operator `%` result value out of range for `i16`
+   ┌─ TEMPFILE2:52:26
+   │
+52 │     const C_I16:  i16  = -32768i16 % 0i16;
+   │                          ^^^^^^^^^^^^^^^^
+
+error: Invalid expression in `const`. Operator `%` result value out of range for `i32`
+   ┌─ TEMPFILE2:53:26
+   │
+53 │     const C_I32:  i32  = -2147483648i32 % 0i32;
+   │                          ^^^^^^^^^^^^^^^^^^^^^
+
+error: Invalid expression in `const`. Operator `%` result value out of range for `i64`
+   ┌─ TEMPFILE2:54:26
+   │
+54 │     const C_I64:  i64  = -9223372036854775808i64 % 0i64;
+   │                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Invalid expression in `const`. Operator `%` result value out of range for `i128`
+   ┌─ TEMPFILE2:56:9
+   │
+56 │         -170141183460469231731687303715884105728i128 % 0i128;
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Invalid expression in `const`. Operator `%` result value out of range for `i256`
+   ┌─ TEMPFILE2:58:9
+   │  
+58 │ ╭         -57896044618658097711785492504343953926634992332820282019728792003956564819968i256
+59 │ │             % 0i256;
+   │ ╰───────────────────^
+
+
+task 3 lines 69-74:  run --verbose [script {]
+Error: Script execution failed with VMError: {
+    message: Integer remainder by zero,
+    major_status: ARITHMETIC_ERROR,
+    sub_status: None,
+    location: script,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 2)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}
+task 4 lines 76-81:  run --verbose [script {]
+Error: Script execution failed with VMError: {
+    message: Integer remainder by zero,
+    major_status: ARITHMETIC_ERROR,
+    sub_status: None,
+    location: script,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 2)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}
+task 5 lines 83-88:  run --verbose [script {]
+Error: Script execution failed with VMError: {
+    message: Integer remainder by zero,
+    major_status: ARITHMETIC_ERROR,
+    sub_status: None,
+    location: script,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 2)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}
+task 6 lines 90-95:  run --verbose [script {]
+Error: Script execution failed with VMError: {
+    message: Integer remainder by zero,
+    major_status: ARITHMETIC_ERROR,
+    sub_status: None,
+    location: script,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 2)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}
+task 7 lines 97-105:  run --verbose [script {]
+Error: Script execution failed with VMError: {
+    message: Integer remainder by zero,
+    major_status: ARITHMETIC_ERROR,
+    sub_status: None,
+    location: script,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 2)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}
+task 8 lines 107-116:  run --verbose [script {]
+Error: Script execution failed with VMError: {
+    message: Integer remainder by zero,
+    major_status: ARITHMETIC_ERROR,
+    sub_status: None,
+    location: script,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 2)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}
+task 9 lines 119-124:  run --verbose [script {]
+Error: Script execution failed with VMError: {
+    message: Integer remainder by zero,
+    major_status: ARITHMETIC_ERROR,
+    sub_status: None,
+    location: script,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 2)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}
+task 10 lines 126-131:  run --verbose [script {]
+Error: Script execution failed with VMError: {
+    message: Integer remainder by zero,
+    major_status: ARITHMETIC_ERROR,
+    sub_status: None,
+    location: script,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 2)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}
+task 11 lines 133-138:  run --verbose [script {]
+Error: Script execution failed with VMError: {
+    message: Integer remainder by zero,
+    major_status: ARITHMETIC_ERROR,
+    sub_status: None,
+    location: script,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 2)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}
+task 12 lines 140-145:  run --verbose [script {]
+Error: Script execution failed with VMError: {
+    message: Integer remainder by zero,
+    major_status: ARITHMETIC_ERROR,
+    sub_status: None,
+    location: script,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 2)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}
+task 13 lines 147-152:  run --verbose [script {]
+Error: Script execution failed with VMError: {
+    message: Integer remainder by zero,
+    major_status: ARITHMETIC_ERROR,
+    sub_status: None,
+    location: script,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 2)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}
+task 14 lines 154-160:  run --verbose [script {]
+Error: Script execution failed with VMError: {
+    message: Integer remainder by zero,
+    major_status: ARITHMETIC_ERROR,
+    sub_status: None,
+    location: script,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 2)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}
+task 15 lines 163-163:  run 0xff::rem_min::min_i8_rem_0 --verbose
+Error: Function execution failed with VMError: {
+    message: Integer remainder by zero,
+    major_status: ARITHMETIC_ERROR,
+    sub_status: None,
+    location: 0xff::rem_min,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(16), 2)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}
+task 16 lines 165-165:  run 0xff::rem_min::min_i16_rem_0 --verbose
+Error: Function execution failed with VMError: {
+    message: Integer remainder by zero,
+    major_status: ARITHMETIC_ERROR,
+    sub_status: None,
+    location: 0xff::rem_min,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(4), 2)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}
+task 17 lines 167-167:  run 0xff::rem_min::min_i32_rem_0 --verbose
+Error: Function execution failed with VMError: {
+    message: Integer remainder by zero,
+    major_status: ARITHMETIC_ERROR,
+    sub_status: None,
+    location: 0xff::rem_min,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(10), 2)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}
+task 18 lines 169-169:  run 0xff::rem_min::min_i64_rem_0 --verbose
+Error: Function execution failed with VMError: {
+    message: Integer remainder by zero,
+    major_status: ARITHMETIC_ERROR,
+    sub_status: None,
+    location: 0xff::rem_min,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(13), 2)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}
+task 19 lines 171-171:  run 0xff::rem_min::min_i128_rem_0 --verbose
+Error: Function execution failed with VMError: {
+    message: Integer remainder by zero,
+    major_status: ARITHMETIC_ERROR,
+    sub_status: None,
+    location: 0xff::rem_min,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(1), 2)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}
+task 20 lines 173-173:  run 0xff::rem_min::min_i256_rem_0 --verbose
+Error: Function execution failed with VMError: {
+    message: Integer remainder by zero,
+    major_status: ARITHMETIC_ERROR,
+    sub_status: None,
+    location: 0xff::rem_min,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(7), 2)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/signed-int/round-trip/rem_min_edge_cases.decompiled
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/signed-int/round-trip/rem_min_edge_cases.decompiled
@@ -1,0 +1,168 @@
+//**** Cross-compiled for `move` syntax from `tests/signed-int/rem_min_edge_cases.move`
+
+//# publish
+module 0xff::rem_min {
+    public fun min_i128(): i128 {
+        MIN_I128
+    }
+    public fun min_i128_rem_0(): i128 {
+        min_i128() % 0i128
+    }
+    public fun min_i128_rem_neg1(): i128 {
+        min_i128() % -1i128
+    }
+    public fun min_i16(): i16 {
+        MIN_I16
+    }
+    public fun min_i16_rem_0(): i16 {
+        min_i16() % 0i16
+    }
+    public fun min_i16_rem_neg1(): i16 {
+        min_i16() % -1i16
+    }
+    public fun min_i256(): i256 {
+        MIN_I256
+    }
+    public fun min_i256_rem_0(): i256 {
+        min_i256() % 0i256
+    }
+    public fun min_i256_rem_neg1(): i256 {
+        min_i256() % -1i256
+    }
+    public fun min_i32(): i32 {
+        MIN_I32
+    }
+    public fun min_i32_rem_0(): i32 {
+        min_i32() % 0i32
+    }
+    public fun min_i32_rem_neg1(): i32 {
+        min_i32() % -1i32
+    }
+    public fun min_i64(): i64 {
+        MIN_I64
+    }
+    public fun min_i64_rem_0(): i64 {
+        min_i64() % 0i64
+    }
+    public fun min_i64_rem_neg1(): i64 {
+        min_i64() % -1i64
+    }
+    public fun min_i8(): i8 {
+        MIN_I8
+    }
+    public fun min_i8_rem_0(): i8 {
+        min_i8() % 0i8
+    }
+    public fun min_i8_rem_neg1(): i8 {
+        min_i8() % -1i8
+    }
+}
+
+
+//# run --verbose
+script {
+    fun main() {
+        assert!(MIN_I8 % -1i8 == 0i8, 100);
+    }
+}
+
+
+//# run --verbose
+script {
+    fun main() {
+        assert!(MIN_I16 % -1i16 == 0i16, 200);
+    }
+}
+
+
+//# run --verbose
+script {
+    fun main() {
+        assert!(MIN_I32 % -1i32 == 0i32, 300);
+    }
+}
+
+
+//# run --verbose
+script {
+    fun main() {
+        assert!(MIN_I64 % -1i64 == 0i64, 400);
+    }
+}
+
+
+//# run --verbose
+script {
+    fun main() {
+        assert!(MIN_I128 % -1i128 == 0i128, 500);
+    }
+}
+
+
+//# run --verbose
+script {
+    fun main() {
+        assert!(MIN_I256 % -1i256 == 0i256, 600);
+    }
+}
+
+
+//# run --verbose
+script {
+    fun main() {
+        let _v0 = MIN_I8 % 0i8;
+    }
+}
+
+
+//# run --verbose
+script {
+    fun main() {
+        let _v0 = MIN_I16 % 0i16;
+    }
+}
+
+
+//# run --verbose
+script {
+    fun main() {
+        let _v0 = MIN_I32 % 0i32;
+    }
+}
+
+
+//# run --verbose
+script {
+    fun main() {
+        let _v0 = MIN_I64 % 0i64;
+    }
+}
+
+
+//# run --verbose
+script {
+    fun main() {
+        let _v0 = MIN_I128 % 0i128;
+    }
+}
+
+
+//# run --verbose
+script {
+    fun main() {
+        let _v0 = MIN_I256 % 0i256;
+    }
+}
+
+
+//# run 0xff::rem_min::min_i8_rem_0 --verbose
+
+//# run 0xff::rem_min::min_i16_rem_0 --verbose
+
+//# run 0xff::rem_min::min_i32_rem_0 --verbose
+
+//# run 0xff::rem_min::min_i64_rem_0 --verbose
+
+//# run 0xff::rem_min::min_i128_rem_0 --verbose
+
+//# run 0xff::rem_min::min_i256_rem_0 --verbose

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/signed-int/round-trip/rem_min_edge_cases.decompiled.baseline.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/signed-int/round-trip/rem_min_edge_cases.decompiled.baseline.exp
@@ -1,0 +1,182 @@
+processed 19 tasks
+task 0 lines 3-59:  publish [module 0xff::rem_min {]
+task 1 lines 62-67:  run --verbose [script {]
+Error: Script execution failed with VMError: {
+    message: Integer remainder by zero,
+    major_status: ARITHMETIC_ERROR,
+    sub_status: None,
+    location: script,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 2)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}
+task 2 lines 70-75:  run --verbose [script {]
+Error: Script execution failed with VMError: {
+    message: Integer remainder by zero,
+    major_status: ARITHMETIC_ERROR,
+    sub_status: None,
+    location: script,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 2)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}
+task 3 lines 78-83:  run --verbose [script {]
+Error: Script execution failed with VMError: {
+    message: Integer remainder by zero,
+    major_status: ARITHMETIC_ERROR,
+    sub_status: None,
+    location: script,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 2)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}
+task 4 lines 86-91:  run --verbose [script {]
+Error: Script execution failed with VMError: {
+    message: Integer remainder by zero,
+    major_status: ARITHMETIC_ERROR,
+    sub_status: None,
+    location: script,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 2)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}
+task 5 lines 94-99:  run --verbose [script {]
+Error: Script execution failed with VMError: {
+    message: Integer remainder by zero,
+    major_status: ARITHMETIC_ERROR,
+    sub_status: None,
+    location: script,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 2)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}
+task 6 lines 102-107:  run --verbose [script {]
+Error: Script execution failed with VMError: {
+    message: Integer remainder by zero,
+    major_status: ARITHMETIC_ERROR,
+    sub_status: None,
+    location: script,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 2)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}
+task 7 lines 110-115:  run --verbose [script {]
+Error: Script execution failed with VMError: {
+    message: Integer remainder by zero,
+    major_status: ARITHMETIC_ERROR,
+    sub_status: None,
+    location: script,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 2)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}
+task 8 lines 118-123:  run --verbose [script {]
+Error: Script execution failed with VMError: {
+    message: Integer remainder by zero,
+    major_status: ARITHMETIC_ERROR,
+    sub_status: None,
+    location: script,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 2)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}
+task 9 lines 126-131:  run --verbose [script {]
+Error: Script execution failed with VMError: {
+    message: Integer remainder by zero,
+    major_status: ARITHMETIC_ERROR,
+    sub_status: None,
+    location: script,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 2)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}
+task 10 lines 134-139:  run --verbose [script {]
+Error: Script execution failed with VMError: {
+    message: Integer remainder by zero,
+    major_status: ARITHMETIC_ERROR,
+    sub_status: None,
+    location: script,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 2)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}
+task 11 lines 142-147:  run --verbose [script {]
+Error: Script execution failed with VMError: {
+    message: Integer remainder by zero,
+    major_status: ARITHMETIC_ERROR,
+    sub_status: None,
+    location: script,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 2)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}
+task 12 lines 150-155:  run --verbose [script {]
+Error: Script execution failed with VMError: {
+    message: Integer remainder by zero,
+    major_status: ARITHMETIC_ERROR,
+    sub_status: None,
+    location: script,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 2)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}
+task 13 lines 158-158:  run 0xff::rem_min::min_i8_rem_0 --verbose
+Error: Function execution failed with VMError: {
+    message: Integer remainder by zero,
+    major_status: ARITHMETIC_ERROR,
+    sub_status: None,
+    location: 0xff::rem_min,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(16), 2)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}
+task 14 lines 160-160:  run 0xff::rem_min::min_i16_rem_0 --verbose
+Error: Function execution failed with VMError: {
+    message: Integer remainder by zero,
+    major_status: ARITHMETIC_ERROR,
+    sub_status: None,
+    location: 0xff::rem_min,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(4), 2)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}
+task 15 lines 162-162:  run 0xff::rem_min::min_i32_rem_0 --verbose
+Error: Function execution failed with VMError: {
+    message: Integer remainder by zero,
+    major_status: ARITHMETIC_ERROR,
+    sub_status: None,
+    location: 0xff::rem_min,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(10), 2)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}
+task 16 lines 164-164:  run 0xff::rem_min::min_i64_rem_0 --verbose
+Error: Function execution failed with VMError: {
+    message: Integer remainder by zero,
+    major_status: ARITHMETIC_ERROR,
+    sub_status: None,
+    location: 0xff::rem_min,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(13), 2)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}
+task 17 lines 166-166:  run 0xff::rem_min::min_i128_rem_0 --verbose
+Error: Function execution failed with VMError: {
+    message: Integer remainder by zero,
+    major_status: ARITHMETIC_ERROR,
+    sub_status: None,
+    location: 0xff::rem_min,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(1), 2)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}
+task 18 lines 168-168:  run 0xff::rem_min::min_i256_rem_0 --verbose
+Error: Function execution failed with VMError: {
+    message: Integer remainder by zero,
+    major_status: ARITHMETIC_ERROR,
+    sub_status: None,
+    location: 0xff::rem_min,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(7), 2)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}

--- a/third_party/move/move-model/src/constant_folder.rs
+++ b/third_party/move/move-model/src/constant_folder.rs
@@ -299,7 +299,25 @@ impl<'env> ConstantFolder<'env> {
                     O::Div => {
                         self.binop_num(name(), BigInt::checked_div, id, result_pty, val0, val1)
                     },
-                    O::Mod => self.binop_num(name(), Self::checked_rem, id, result_pty, val0, val1),
+                    O::Mod => {
+                        // Move semantics for signed MIN % -1 is abort. Reject
+                        // in const evaluation and refuse to fold elsewhere so
+                        // the runtime executes the abort.
+                        if result_pty.is_signed()
+                            && val1 == &BigInt::from(-1)
+                            && result_pty.get_min_value().as_ref() == Some(val0)
+                        {
+                            self.constant_folding_error(id, |aself: &mut Self| {
+                                format!(
+                                    "Operator `{}` result value out of range for `{}`",
+                                    name(),
+                                    aself.display_type(&Type::Primitive(*result_pty)),
+                                )
+                            })
+                        } else {
+                            self.binop_num(name(), Self::checked_rem, id, result_pty, val0, val1)
+                        }
+                    },
                     O::Shl => {
                         // result_pty should be same size as arg0
                         let arg0_size = Self::ptype_num_bits_bigint(result_pty);

--- a/third_party/move/move-prover/bytecode-pipeline/src/spec_inference.rs
+++ b/third_party/move/move-prover/bytecode-pipeline/src/spec_inference.rs
@@ -4892,9 +4892,20 @@ impl<'env> SpecInferenceAnalyzer<'env> {
                 }
             },
             Operation::Mod => {
-                // Modulo aborts on: b == 0
+                // Modulo aborts on: b == 0, or for signed: a == MIN && b == -1
                 let zero = self.mk_num_const(BigInt::zero());
-                Some(self.mk_eq(b, zero))
+                let mod_zero = self.mk_eq(b.clone(), zero);
+
+                if ty.is_signed_int() {
+                    let min = self.mk_num_min(prim_ty)?;
+                    let neg_one = self.mk_num_const(BigInt::from(-1));
+                    let a_eq_min = self.mk_eq(a, min);
+                    let b_eq_neg1 = self.mk_eq(b, neg_one);
+                    let min_mod_neg1 = self.mk_and(a_eq_min, b_eq_neg1);
+                    Some(self.mk_or(mod_zero, min_mod_neg1))
+                } else {
+                    Some(mod_zero)
+                }
             },
             _ => None,
         }


### PR DESCRIPTION
## Description

In this PR, we align compile-time and runtime semantics for the modulo operator's signed-integer overflow corner case. The constant folder in the compiler was updated so that `MIN % -1` on a signed integer type is a semantic overflow, not foldable to `0` (which was the previous diverging behavior). 

Bug originally reported by @GotenJBZ 

## How Has This Been Tested?

Added a new transactional test that shows non-diverging behavior under various optimization conditions.

## Type of Change
- [x] Bug fix

## Which Components or Systems Does This Change Impact?
- [x] Move Compiler


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes compile-time evaluation and prover abort conditions for `%` on signed integers; behavior is more correct but any code relying on the old folded `0` at compile time will fail to compile.
> 
> **Overview**
> Aligns **signed integer modulo** with runtime semantics for the `MIN % -1` corner case (and documents the same rule in the bytecode spec). Previously, compile-time constant folding could treat `MIN % -1` as foldable to `0`, diverging from VM behavior where that case is an arithmetic error.
> 
> **`constant_folder`** now rejects folding when the left operand is the type minimum and the right is `-1`, surfacing the same “result out of range” error as other invalid `const` `%` expressions. **`spec_inference`** treats signed `%` abort conditions like division: zero divisor plus `MIN % -1`. **`file_format`** `Mod` opcode description/semantics now state abort on divisor zero or signed overflow (`lhs == MIN && rhs == -1`).
> 
> Adds transactional tests (`rem_min_edge_cases`) across optimization modes and round-trip decompile expectations to lock in const-compile failures and runtime `ARITHMETIC_ERROR` for `% 0` and related cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f176a1724227946ca783db9fda6c362849b932b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->