### PR TITLE
[forge] use land_blocking suite for etna stable test

### DIFF
--- a/.github/workflows/forge-stable.yaml
+++ b/.github/workflows/forge-stable.yaml
@@ -138,7 +138,7 @@ jobs:
               { TEST_NAME: 'realistic-env-max-load-encrypted', FORGE_RUNNER_DURATION_SECS: 480, FORGE_TEST_SUITE: 'realistic_env_max_load_encrypted' },
               // Pin to the aptos-core SHA that the etna-rust image is built from, so the forge
               // test runner matches the etna binary under test.
-              { TEST_NAME: 'etna', FORGE_RUNNER_DURATION_SECS: 7200, FORGE_TEST_SUITE: 'etna', FORGE_IMAGE_NAME: 'etna-rust', GIT_SHA: 'c66dbf952b692bc017b459e3e6e44cc2a43d6958' }
+              { TEST_NAME: 'etna', FORGE_RUNNER_DURATION_SECS: 7200, FORGE_TEST_SUITE: 'land_blocking', FORGE_IMAGE_NAME: 'etna-rust', GIT_SHA: 'c66dbf952b692bc017b459e3e6e44cc2a43d6958' }
             ];
 
             const matrix = testName != "all" ? tests.filter(test => test.TEST_NAME === testName) : tests;


### PR DESCRIPTION
## Summary

- The `forge-etna / forge` job in `forge-stable.yaml` was failing immediately with `Unknown suite: 'etna'` (e.g. [run 26421447677](https://github.com/aptos-labs/aptos-core/actions/runs/26421447677/job/77807731601)).
- The `etna-rust` binary built from the pinned SHA does not register an `etna` suite. Its known suites are `land_blocking` and parametric `realistic_{N}tps` / `isolated_{N}tps` patterns (see `aptos-labs/etna` `rust/etna-forge/src/main.rs`).
- Switch `FORGE_TEST_SUITE` to `land_blocking`, which is the etna runner's default full workload sweep (Realistic + RealisticBackstopIsolated perp-dex across 250 / 500 / 1000 / 1500 TPS, 5 validators / 1 VFN each).

## Test plan

- [ ] Trigger the `forge-stable` workflow (or just the `etna` matrix entry via `adhoc-forge`) and confirm the runner now accepts the suite and proceeds past CLI parsing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)