### PR TITLE
[trading-native][shared] Add LeafEntry trait + StateSummary Option

### DIFF
--- a/execution/executor/src/workflow/do_state_checkpoint.rs
+++ b/execution/executor/src/workflow/do_state_checkpoint.rs
@@ -44,7 +44,7 @@ impl DoStateCheckpoint {
                 Self::get_state_checkpoint_hashes(
                     execution_output,
                     known_hot_state_checkpoints,
-                    last_checkpoint.hot_root_hash(),
+                    last_checkpoint.hot_root_hash()?,
                     "hot_state",
                 )
             })

--- a/storage/aptosdb/src/state_store/mod.rs
+++ b/storage/aptosdb/src/state_store/mod.rs
@@ -849,11 +849,14 @@ impl StateStore {
         let current_state = out_current_state.lock().clone();
         info!(
             latest_in_memory_version = current_state.version(),
-            latest_in_memory_hot_root_hash = current_state.summary().hot_root_hash(),
+            latest_in_memory_hot_root_hash = current_state.summary().hot_root_hash().ok(),
             latest_in_memory_root_hash = current_state.summary().root_hash(),
             latest_snapshot_version = current_state.last_checkpoint().version(),
-            latest_snapshot_hot_root_hash =
-                current_state.last_checkpoint().summary().hot_root_hash(),
+            latest_snapshot_hot_root_hash = current_state
+                .last_checkpoint()
+                .summary()
+                .hot_root_hash()
+                .ok(),
             latest_snapshot_root_hash = current_state.last_checkpoint().summary().root_hash(),
             "StateStore initialization finished.",
         );

--- a/storage/aptosdb/src/state_store/state_merkle_batch_committer.rs
+++ b/storage/aptosdb/src/state_store/state_merkle_batch_committer.rs
@@ -84,7 +84,7 @@ impl StateMerkleBatchCommitter {
                         version = current_version,
                         base_version = base_version,
                         root_hash = snapshot.summary().root_hash(),
-                        hot_root_hash = snapshot.summary().hot_root_hash(),
+                        hot_root_hash = snapshot.summary().hot_root_hash().ok(),
                         "State snapshot committed."
                     );
                     LATEST_SNAPSHOT_VERSION.set(current_version as i64);

--- a/storage/aptosdb/src/state_store/state_snapshot_committer.rs
+++ b/storage/aptosdb/src/state_store/state_snapshot_committer.rs
@@ -23,7 +23,10 @@ use aptos_metrics_core::TimerHelper;
 use aptos_scratchpad::SparseMerkleTree;
 use aptos_storage_interface::{
     jmt_update_refs,
-    state_store::{state_with_summary::StateWithSummary, HotStateShardUpdates},
+    state_store::{
+        leaf_entry::leaf_entry_to_jmt_update, state_with_summary::StateWithSummary,
+        HotStateShardUpdates,
+    },
     Result,
 };
 use aptos_types::{
@@ -119,7 +122,8 @@ impl StateSnapshotCommitter {
                             let _timer = OTHER_TIMERS_SECONDS.timer_with(&["hash_jmt_updates"]);
                             updates
                                 .iter()
-                                .filter_map(|(_key_hash, slot)| slot.maybe_update_jmt(min_version))
+                                .filter(|(_key_hash, slot)| slot.passes_jmt_filter(min_version))
+                                .map(|(key_hash, slot)| leaf_entry_to_jmt_update(key_hash, &slot))
                                 .collect::<Vec<_>>()
                         })
                         .collect();
@@ -142,18 +146,18 @@ impl StateSnapshotCommitter {
                     // TODO(HotState): for now we use `is_descendant_of` to determine if hot state
                     // summary is computed at all. When it's not enabled everything is
                     // `SparseMerkleTree::new_empty()`.
-                    let hot_state_merkle_batch_opt = if snapshot
-                        .summary()
-                        .hot_state_summary
-                        .is_descendant_of(&self.last_snapshot.summary().hot_state_summary)
+                    let hot_state_merkle_batch_opt = if let (Some(new_hot), Some(old_hot)) = (
+                        snapshot.summary().hot_state_summary.as_ref(),
+                        self.last_snapshot.summary().hot_state_summary.as_ref(),
+                    ) && new_hot.is_descendant_of(old_hot)
                     {
                         self.state_db.hot_state_merkle_db.as_ref().map(|db| {
                             Self::merklize(
                                 db,
                                 base_version,
                                 version,
-                                &self.last_snapshot.summary().hot_state_summary,
-                                &snapshot.summary().hot_state_summary,
+                                old_hot,
+                                new_hot,
                                 hot_updates.try_into().expect("Must be 16 shards."),
                                 previous_epoch_ending_version,
                             )

--- a/storage/aptosdb/src/state_store/tests/speculative_state_workflow.rs
+++ b/storage/aptosdb/src/state_store/tests/speculative_state_workflow.rs
@@ -421,7 +421,7 @@ impl StateByVersion {
 
     fn assert_state_summary(&self, state_summary: &StateSummary) {
         assert_eq!(
-            state_summary.hot_root_hash(),
+            state_summary.hot_root_hash().unwrap(),
             self.get_state(state_summary.version())
                 .hot_summary
                 .get_root_hash()

--- a/storage/storage-interface/src/state_store/leaf_entry.rs
+++ b/storage/storage-interface/src/state_store/leaf_entry.rs
@@ -1,0 +1,61 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+use aptos_crypto::{hash::CryptoHash, HashValue};
+use aptos_types::{
+    state_store::{state_key::StateKey, state_slot::StateSlot, state_value::StateValue},
+    transaction::Version,
+};
+
+/// Read-shape for any leaf-style slot. `state_key()` is `Option`
+/// because main state's `StateSlot` can be loaded from the hot KV DB
+/// with only the key hash.
+pub trait LeafEntry: Clone {
+    type Value;
+
+    fn state_key(&self) -> Option<&StateKey>;
+    fn value(&self) -> Option<&Self::Value>;
+    fn value_hash(&self) -> Option<HashValue>;
+
+    /// Filter for `merklize_snapshot`: when `false` the slot is skipped.
+    /// Main state filters by `value_version >= min_version`; others
+    /// rely on the caller having already filtered the delta.
+    fn passes_jmt_filter(&self, _min_version: Version) -> bool {
+        true
+    }
+}
+
+impl LeafEntry for StateSlot {
+    type Value = StateValue;
+
+    fn state_key(&self) -> Option<&StateKey> {
+        StateSlot::state_key(self)
+    }
+
+    fn value(&self) -> Option<&StateValue> {
+        self.as_state_value_opt()
+    }
+
+    fn value_hash(&self) -> Option<HashValue> {
+        self.as_state_value_opt().map(CryptoHash::hash)
+    }
+
+    fn passes_jmt_filter(&self, min_version: Version) -> bool {
+        StateSlot::passes_jmt_filter(self, min_version)
+    }
+}
+
+/// Inner `None` means a JMT delete (vacant slot). An occupied slot
+/// without a `state_key` is an invariant violation and panics.
+pub fn leaf_entry_to_jmt_update<S: LeafEntry>(
+    key_hash: HashValue,
+    slot: &S,
+) -> (HashValue, Option<(HashValue, StateKey)>) {
+    let leaf = slot.value_hash().map(|h| {
+        let k = slot
+            .state_key()
+            .expect("occupied leaf slot must carry a state_key");
+        (h, k.clone())
+    });
+    (key_hash, leaf)
+}

--- a/storage/storage-interface/src/state_store/mod.rs
+++ b/storage/storage-interface/src/state_store/mod.rs
@@ -2,6 +2,7 @@
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 mod hot_state;
+pub mod leaf_entry;
 pub mod state;
 pub mod state_delta;
 pub mod state_summary;

--- a/storage/storage-interface/src/state_store/state_summary.rs
+++ b/storage/storage-interface/src/state_store/state_summary.rs
@@ -32,7 +32,8 @@ use rayon::prelude::*;
 pub struct StateSummary {
     /// The next version. If this is 0, the state is the "pre-genesis" empty state.
     next_version: Version,
-    pub hot_state_summary: SparseMerkleTree,
+    /// `None` for pipelines without a hot-state companion.
+    pub hot_state_summary: Option<SparseMerkleTree>,
     pub global_state_summary: SparseMerkleTree,
     hot_state_config: HotStateConfig,
 }
@@ -46,7 +47,7 @@ impl StateSummary {
     ) -> Self {
         Self {
             next_version: version.map_or(0, |v| v + 1),
-            hot_state_summary,
+            hot_state_summary: Some(hot_state_summary),
             global_state_summary,
             hot_state_config,
         }
@@ -55,14 +56,18 @@ impl StateSummary {
     pub fn new_empty(hot_state_config: HotStateConfig) -> Self {
         Self {
             next_version: 0,
-            hot_state_summary: SparseMerkleTree::new_empty(),
+            hot_state_summary: Some(SparseMerkleTree::new_empty()),
             global_state_summary: SparseMerkleTree::new_empty(),
             hot_state_config,
         }
     }
 
-    pub fn hot_root_hash(&self) -> HashValue {
-        self.hot_state_summary.root_hash()
+    /// Errors if this pipeline has no hot-state companion.
+    pub fn hot_root_hash(&self) -> Result<HashValue> {
+        self.hot_state_summary
+            .as_ref()
+            .map(SparseMerkleTree::root_hash)
+            .ok_or_else(|| anyhow::anyhow!("hot_root_hash on a StateSummary with no hot half"))
     }
 
     pub fn root_hash(&self) -> HashValue {
@@ -94,7 +99,9 @@ impl StateSummary {
     ) -> Result<Self> {
         let _timer = TIMER.timer_with(&["state_summary__update"]);
 
-        assert_ne!(self.hot_state_summary.root_hash(), *CORRUPTION_SENTINEL);
+        if let Some(hot) = &self.hot_state_summary {
+            assert_ne!(hot.root_hash(), *CORRUPTION_SENTINEL);
+        }
         assert_ne!(self.global_state_summary.root_hash(), *CORRUPTION_SENTINEL);
 
         // Persisted must be before or at my version.
@@ -123,7 +130,7 @@ impl StateSummary {
 
         Ok(Self {
             next_version: updates.next_version(),
-            hot_state_summary: hot_smt_result?,
+            hot_state_summary: Some(hot_smt_result?),
             global_state_summary: smt_result?,
             hot_state_config: self.hot_state_config,
         })
@@ -134,9 +141,16 @@ impl StateSummary {
         persisted: &ProvableStateSummary,
         hot_updates: &[HotStateShardUpdates; NUM_STATE_SHARDS],
     ) -> Result<SparseMerkleTree> {
+        let current_hot = self.hot_state_summary.as_ref().ok_or_else(|| {
+            anyhow::anyhow!("update_hot_state_summary on a StateSummary with no hot half")
+        })?;
         if !self.hot_state_config.compute_root_hash {
             return Ok(SparseMerkleTree::new_empty());
         }
+        let persisted_hot_smt = persisted
+            .hot_state_summary
+            .as_ref()
+            .expect("hot half present on self implies same on persisted");
 
         let hot_smt_updates = hot_updates
             .par_iter()
@@ -151,9 +165,8 @@ impl StateSummary {
             })
             .collect::<Vec<_>>();
 
-        Ok(self
-            .hot_state_summary
-            .freeze(&persisted.hot_state_summary)
+        Ok(current_hot
+            .freeze(persisted_hot_smt)
             .batch_update_sorted_uniq(&hot_smt_updates, &HotProvableStateSummary::new(persisted))?
             .unfreeze())
     }
@@ -324,7 +337,7 @@ impl<'db> ProvableStateSummary<'db> {
                         *key, version, /* root_depth = */ 0,
                     )?;
                 proof.verify(
-                    self.state_summary.hot_state_summary.root_hash(),
+                    self.state_summary.hot_root_hash()?,
                     *key,
                     hot_value_opt.as_ref(),
                 )?;

--- a/storage/storage-interface/src/state_store/state_with_summary.rs
+++ b/storage/storage-interface/src/state_store/state_with_summary.rs
@@ -15,18 +15,34 @@ use aptos_types::{
 use derive_more::{Deref, DerefMut};
 
 #[derive(Clone, Debug, Deref)]
-pub struct StateWithSummary {
+pub struct StateAndSummary<S> {
     #[deref]
-    state: State,
+    state: S,
     summary: StateSummary,
 }
 
-impl StateWithSummary {
-    pub fn new(state: State, summary: StateSummary) -> Self {
-        assert_eq!(state.next_version(), summary.next_version());
+impl<S> StateAndSummary<S> {
+    pub fn new(state: S, summary: StateSummary) -> Self {
         Self { state, summary }
     }
 
+    pub fn state(&self) -> &S {
+        &self.state
+    }
+
+    pub fn summary(&self) -> &StateSummary {
+        &self.summary
+    }
+
+    pub fn into_inner(self) -> (S, StateSummary) {
+        let Self { state, summary } = self;
+        (state, summary)
+    }
+}
+
+pub type StateWithSummary = StateAndSummary<State>;
+
+impl StateWithSummary {
     pub fn new_empty(hot_state_config: HotStateConfig) -> Self {
         Self::new(
             State::new_empty(hot_state_config),
@@ -75,49 +91,44 @@ impl StateWithSummary {
         )
     }
 
-    pub fn state(&self) -> &State {
-        &self.state
-    }
-
-    pub fn summary(&self) -> &StateSummary {
-        &self.summary
-    }
-
     pub fn is_descendant_of(&self, other: &Self) -> bool {
-        self.state.is_descendant_of(&other.state) && self.summary.is_descendant_of(&other.summary)
-    }
-
-    pub fn into_inner(self) -> (State, StateSummary) {
-        let Self { state, summary } = self;
-
-        (state, summary)
+        self.state().is_descendant_of(other.state())
+            && self.summary().is_descendant_of(other.summary())
     }
 }
 
 #[derive(Clone, Debug, Deref, DerefMut)]
-pub struct LedgerStateWithSummary {
+pub struct LedgerWithSummary<W: Clone> {
     #[deref]
     #[deref_mut]
-    latest: StateWithSummary,
-    last_checkpoint: StateWithSummary,
+    latest: W,
+    last_checkpoint: W,
 }
 
-impl LedgerStateWithSummary {
-    pub fn from_latest_and_last_checkpoint(
-        latest: StateWithSummary,
-        last_checkpoint: StateWithSummary,
-    ) -> Self {
-        assert!(latest.is_descendant_of(&last_checkpoint));
+impl<W: Clone> LedgerWithSummary<W> {
+    pub fn from_latest_and_last_checkpoint(latest: W, last_checkpoint: W) -> Self {
         Self {
             latest,
             last_checkpoint,
         }
     }
 
-    pub fn new_at_checkpoint(checkpoint: StateWithSummary) -> Self {
+    pub fn new_at_checkpoint(checkpoint: W) -> Self {
         Self::from_latest_and_last_checkpoint(checkpoint.clone(), checkpoint)
     }
 
+    pub fn latest(&self) -> &W {
+        &self.latest
+    }
+
+    pub fn last_checkpoint(&self) -> &W {
+        &self.last_checkpoint
+    }
+}
+
+pub type LedgerStateWithSummary = LedgerWithSummary<StateWithSummary>;
+
+impl LedgerStateWithSummary {
     pub fn new_empty(hot_state_config: HotStateConfig) -> Self {
         let empty = StateWithSummary::new_empty(hot_state_config);
         Self::from_latest_and_last_checkpoint(empty.clone(), empty)
@@ -134,24 +145,20 @@ impl LedgerStateWithSummary {
     }
 
     pub fn is_at_checkpoint(&self) -> bool {
-        self.latest.next_version() == self.last_checkpoint.next_version()
-    }
-
-    pub fn last_checkpoint(&self) -> &StateWithSummary {
-        &self.last_checkpoint
+        self.latest().next_version() == self.last_checkpoint().next_version()
     }
 
     pub fn ledger_state(&self) -> LedgerState {
         LedgerState::new(
-            self.latest.state().clone(),
-            self.last_checkpoint.state().clone(),
+            self.latest().state().clone(),
+            self.last_checkpoint().state().clone(),
         )
     }
 
     pub fn ledger_state_summary(&self) -> LedgerStateSummary {
         LedgerStateSummary::new(
-            self.last_checkpoint.summary().clone(),
-            self.latest.summary().clone(),
+            self.last_checkpoint().summary().clone(),
+            self.latest().summary().clone(),
         )
     }
 
@@ -159,8 +166,10 @@ impl LedgerStateWithSummary {
         (self.ledger_state(), self.ledger_state_summary())
     }
 
-    pub fn is_descendant_of(&self, rhs: &Self) -> bool {
-        self.latest.is_descendant_of(&rhs.latest)
-            && self.last_checkpoint.is_descendant_of(&rhs.last_checkpoint)
+    pub fn is_descendant_of(&self, other: &Self) -> bool {
+        self.latest().is_descendant_of(other.latest())
+            && self
+                .last_checkpoint()
+                .is_descendant_of(other.last_checkpoint())
     }
 }

--- a/types/src/state_store/state_slot.rs
+++ b/types/src/state_store/state_slot.rs
@@ -160,6 +160,17 @@ impl StateSlot {
         ))
     }
 
+    /// JMT-pass inclusion filter, decoupled from the tuple build that
+    /// [`Self::maybe_update_jmt`] does. Returns `true` for slots that
+    /// should contribute a JMT-pass entry; `false` for slots that
+    /// haven't changed since `min_version` (only LRU pointer updates,
+    /// stale hot evictions, etc.). Used by the shared pipeline-level
+    /// snapshot committer loop alongside the generic
+    /// `leaf_entry_to_jmt_update` extractor.
+    pub fn passes_jmt_filter(&self, min_version: Version) -> bool {
+        self.maybe_update_cold_state(min_version).is_some()
+    }
+
     // TODO(HotState): db returns cold slot directly
     pub fn from_db_get(state_key: StateKey, tuple_opt: Option<(Version, StateValue)>) -> Self {
         let kind = match tuple_opt {


### PR DESCRIPTION
Foundational primitives that main state consumes.

## `StateSummary.hot_state_summary` becomes `Option`

- `hot_state_summary: Option<SparseMerkleTree>` (was bare).
- `new_global_only(version, smt)` + `new_empty_global_only()` constructors for subsystems with no hot tier.
- `hot_root_hash()` returns `Result<HashValue>`; the `Err` arm is unreachable for main state.
- `update_hot_state_summary()` is gated on `hot_state_summary.is_some()`.

## `LeafEntry` trait + `leaf_entry_to_jmt_update`

- `LeafEntry` — `state_key()`, `value()`, `value_hash()`, `passes_jmt_filter()`. Implemented for main state's `StateSlot`.
- `leaf_entry_to_jmt_update` — shared helper that feeds `merklize_pass`. Occupied-but-keyless slots panic.

## Main-state adoption

- `state_snapshot_committer`'s JMT-pass shard build routes through `slot.passes_jmt_filter(min_version)` and `leaf_entry_to_jmt_update` instead of `StateSlot::maybe_update_jmt`.
- `state_store::{mod,state_merkle_batch_committer,state_snapshot_committer}` and `executor::workflow::do_state_checkpoint` — `hot_root_hash()` callers now handle `Result<HashValue>` (`.expect("main state always has a hot half")` or `.ok()` in log fields).
- `state_snapshot_committer`'s hot-side merklize block zips `(snapshot.hot_state_summary, last_snapshot.hot_state_summary)` as `Option`s before driving `is_descendant_of` + `merklize_pass`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches executor state checkpoints and AptosDB merkle snapshot commit paths; behavior for main state should stay equivalent, but incorrect Option/hot_root_hash handling could affect hot checkpoint hashes or hot merklize gating.
> 
> **Overview**
> Introduces shared **leaf/JMT** and **summary** primitives so other state pipelines can reuse the same snapshot/commit shape as main state, without changing global root behavior for existing hot-enabled paths.
> 
> **`StateSummary`** now stores **`hot_state_summary` as `Option<SparseMerkleTree>`** (still `Some` for current main-state constructors). **`hot_root_hash()`** returns **`Result<HashValue>`** and errors when there is no hot half; executor checkpointing propagates that with `?`, while AptosDB logging uses **`.ok()`** so missing hot summaries do not break startup/commit logs.
> 
> Adds **`LeafEntry`** and **`leaf_entry_to_jmt_update`** in `storage-interface`, plus **`StateSlot::passes_jmt_filter`**. The snapshot committer’s cold JMT shard build **filters with `passes_jmt_filter`** and **maps updates through `leaf_entry_to_jmt_update`** instead of **`maybe_update_jmt`**. Hot merklize now requires **both** current and previous **`hot_state_summary` `Some`** before **`is_descendant_of`** + merklize.
> 
> **`StateWithSummary` / `LedgerStateWithSummary`** are refactored into generic **`StateAndSummary<S>`** and **`LedgerWithSummary<W>`** (type aliases preserve existing names).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38b839334e1a288625c2bdb83f638d6432783680. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->