### PR TITLE
[gas] Bump gas feature version to V47

### DIFF
--- a/aptos-move/aptos-gas-schedule/src/ver.rs
+++ b/aptos-move/aptos-gas-schedule/src/ver.rs
@@ -8,6 +8,8 @@
 ///   - Changing how gas is calculated in any way
 ///
 /// Change log:
+/// - V47:
+///   - TBA
 /// - V46:
 ///    - Correct value for gas param `algebra.ark_bn254_fr_one`.
 ///    - Fix BN254 `Fr::one()` native to charge `algebra.ark_bn254_fr_one`.
@@ -80,7 +82,7 @@
 ///       global operations.
 /// - V1
 ///   - TBA
-pub const LATEST_GAS_FEATURE_VERSION: u64 = gas_feature_versions::RELEASE_V1_46;
+pub const LATEST_GAS_FEATURE_VERSION: u64 = gas_feature_versions::RELEASE_V1_47;
 
 pub mod gas_feature_versions {
     pub const RELEASE_V1_8: u64 = 11;
@@ -121,4 +123,5 @@ pub mod gas_feature_versions {
     pub const RELEASE_V1_44: u64 = 48;
     pub const RELEASE_V1_45: u64 = 49;
     pub const RELEASE_V1_46: u64 = 50;
+    pub const RELEASE_V1_47: u64 = 51;
 }


### PR DESCRIPTION
## Summary
- Bumps `LATEST_GAS_FEATURE_VERSION` to `RELEASE_V1_47` (51)
- Adds `RELEASE_V1_47` constant and a placeholder V47 changelog entry

## Test plan
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)