### PR TITLE
[Release] release.yaml for v1.45.0 mainnet framework

### DIFF
--- a/aptos-move/aptos-release-builder/data/release.yaml
+++ b/aptos-move/aptos-release-builder/data/release.yaml
@@ -1,13 +1,13 @@
 ---
-remote_endpoint: https://fullnode.testnet.aptoslabs.com
+remote_endpoint: https://fullnode.mainnet.aptoslabs.com
 # replace with below for actual release, compat test needs concrete URL above:
 # remote_endpoint: ~
-name: "v1.45.0-rc"
+name: "v1.45.0"
 proposals:
   - name: proposal_1_upgrade_framework
     metadata:
-      title: "Multi-step proposal to upgrade testnet framework, version v1.45.0-rc"
-      description: "This includes changes in https://github.com/aptos-labs/aptos-core/releases/tag/aptos-framework-v1.45.0-rc"
+      title: "Multi-step proposal to upgrade mainnet framework, version v1.45.0"
+      description: "This includes changes in https://github.com/aptos-labs/aptos-core/releases/tag/aptos-framework-v1.45.0"
     execution_mode: MultiStep
     update_sequence:
       - Gas:


### PR DESCRIPTION
## Summary
- Retarget `release.yaml` from the v1.45.0-rc testnet release to the v1.45.0 mainnet release
- Flip `remote_endpoint`, proposal `name`, `title`, and description URL to mainnet / `aptos-framework-v1.45.0`
- Gas schedule (v1.44.0 → v1.45.1) and `bytecode_version: 9` carry over unchanged from the rc — no framework changes since `aptos-framework-v1.45.0-rc`

Follows the same shape as the prior v1.44.2 mainnet release (#19757).

## Test plan
- [ ] Compatibility test against mainnet via `aptos-release-builder`
- [ ] Verify `aptos-framework-v1.45.0` release tag is cut before the proposal is submitted (description URL depends on it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Config-only but governs a mainnet multi-step framework upgrade proposal; wrong endpoint or tag would mis-target production governance.
> 
> **Overview**
> Retargets the embedded **`release.yaml`** used by **`aptos-release-builder`** from the **v1.45.0-rc testnet** cut to the **v1.45.0 mainnet** framework upgrade.
> 
> **`remote_endpoint`** switches from the testnet fullnode to **mainnet**. Proposal **`name`**, **`title`**, and **`description`** drop the `-rc` suffix and point at the **`aptos-framework-v1.45.0`** release tag instead of testnet/rc wording.
> 
> The **multi-step proposal** itself is unchanged: same **gas** bump (**v1.44.0 → v1.45.1** URLs) and **framework** step with **`bytecode_version: 9`** and **`git_hash: ~`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c35d55feda2a840a9a198dcc8dcd18fa002017e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->