### PR TITLE
[ide-debugger] Minimal version of aptos-core changes to support debugger

### DIFF
--- a/aptos-move/cli/src/source_locator.rs
+++ b/aptos-move/cli/src/source_locator.rs
@@ -105,6 +105,9 @@ impl AptosSourceLocator {
             line_starts,
         });
 
+        // As we're using the `module_id.name()` here, it's prone to the name collisions.
+        // We're leaving it as-is now, as it only used if named addresses are different from the local ones.
+        // In this case we can't rely on address, so we match against the name-only in best-effort way.
         self.name_to_module_id
             .insert(module_id.name().to_string(), module_id.clone());
         self.source_data

--- a/aptos-move/cli/src/source_locator.rs
+++ b/aptos-move/cli/src/source_locator.rs
@@ -56,6 +56,9 @@ pub struct AptosSourceLocator {
     source_data: AHashMap<ModuleId, ModuleSourceData>,
     struct_field_names: AHashMap<ModuleId, AHashMap<String, Vec<String>>>,
     enum_variants: AHashMap<ModuleId, AHashMap<String, Vec<(String, Vec<String>)>>>,
+    /// Module name → full ModuleId, for fallback when the on-chain address
+    /// differs from the local dev address.
+    name_to_module_id: AHashMap<String, ModuleId>,
 }
 
 impl Default for AptosSourceLocator {
@@ -70,6 +73,7 @@ impl AptosSourceLocator {
             source_data: AHashMap::new(),
             struct_field_names: AHashMap::new(),
             enum_variants: AHashMap::new(),
+            name_to_module_id: AHashMap::new(),
         }
     }
 
@@ -101,6 +105,8 @@ impl AptosSourceLocator {
             line_starts,
         });
 
+        self.name_to_module_id
+            .insert(module_id.name().to_string(), module_id.clone());
         self.source_data
             .insert(module_id.clone(), ModuleSourceData { source_map, files });
 
@@ -108,6 +114,14 @@ impl AptosSourceLocator {
         self.add_struct_field_names_from_module(module);
 
         Ok(())
+    }
+
+    /// Facilitates IDE debugger, not used in aptos-core otherwise.
+    pub fn known_source_files(&self) -> Vec<&str> {
+        self.source_data
+            .values()
+            .flat_map(|d| d.files.values().map(|f| f.filename.as_str()))
+            .collect()
     }
 
     /// Extract struct and enum type information from a compiled module and store
@@ -152,6 +166,13 @@ impl AptosSourceLocator {
             }
         }
     }
+
+    fn resolve_module_id<'a>(&'a self, module_id: &'a ModuleId) -> Option<&'a ModuleId> {
+        if self.source_data.contains_key(module_id) {
+            return Some(module_id);
+        }
+        self.name_to_module_id.get(module_id.name().as_str())
+    }
 }
 
 // ── SourceLocator implementation ──────────────────────────────────────────────
@@ -165,8 +186,11 @@ impl SourceLocator for AptosSourceLocator {
     ) -> Option<String> {
         let debug = is_debug_enabled();
 
-        let data = match self.source_data.get(module_id) {
-            Some(d) => d,
+        let data = match self
+            .resolve_module_id(module_id)
+            .and_then(|module_id| self.source_data.get(module_id))
+        {
+            Some(id) => id,
             None => {
                 if debug {
                     eprintln!("[source_locator] no source data for module {}", module_id);
@@ -216,7 +240,9 @@ impl SourceLocator for AptosSourceLocator {
         module_id: &ModuleId,
         func_def_idx: FunctionDefinitionIndex,
     ) -> Option<(usize, Vec<String>)> {
-        let data = self.source_data.get(module_id)?;
+        let data = self
+            .resolve_module_id(module_id)
+            .and_then(|module_id| self.source_data.get(module_id))?;
         let func_map = data.source_map.get_function_source_map(func_def_idx).ok()?;
         let param_count = func_map.parameters.len();
         let names = func_map
@@ -233,8 +259,9 @@ impl SourceLocator for AptosSourceLocator {
         module_id: &ModuleId,
         struct_name: &str,
     ) -> Option<Vec<String>> {
+        let resolved_id = self.resolve_module_id(module_id)?;
         self.struct_field_names
-            .get(module_id)?
+            .get(resolved_id)?
             .get(struct_name)
             .cloned()
     }
@@ -244,7 +271,8 @@ impl SourceLocator for AptosSourceLocator {
         module_id: &ModuleId,
         enum_name: &str,
     ) -> Option<Vec<(String, Vec<String>)>> {
-        self.enum_variants.get(module_id)?.get(enum_name).cloned()
+        let resolved_id = self.resolve_module_id(module_id)?;
+        self.enum_variants.get(resolved_id)?.get(enum_name).cloned()
     }
 }
 

--- a/third_party/move/move-vm/runtime/src/debug.rs
+++ b/third_party/move/move-vm/runtime/src/debug.rs
@@ -3,9 +3,8 @@
 // Parts of the file are Copyright (c) Aptos Foundation
 // All Aptos Foundation code and content is licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-use crate::{
-    interpreter::InterpreterDebugInterface, source_locator, LoadedFunction, RuntimeEnvironment,
-};
+pub use crate::interpreter::InterpreterDebugInterface;
+use crate::{source_locator, LoadedFunction, RuntimeEnvironment};
 use move_vm_types::{instr::Instruction, values::Locals};
 use std::{
     collections::{BTreeSet, VecDeque},
@@ -130,9 +129,27 @@ impl FromStr for DebugCommand {
     }
 }
 
+pub trait ThreadStateHandle: Send + Sync {
+    fn install_on_thread(&self);
+}
+
+pub trait DebugContext: Send {
+    fn debug_loop(
+        &mut self,
+        function: &LoadedFunction,
+        locals: &Locals,
+        pc: u16,
+        instr: &Instruction,
+        runtime_environment: &RuntimeEnvironment,
+        interpreter: &dyn InterpreterDebugInterface,
+    );
+
+    fn capture_thread_state(&self) -> Box<dyn ThreadStateHandle>;
+}
+
 #[derive(Debug)]
 #[allow(unused)]
-pub(crate) struct DebugContext {
+pub(crate) struct MoveStepDebugContext {
     breakpoints: BTreeSet<String>,
     input_checker: InputChecker,
 }
@@ -151,7 +168,7 @@ enum InputChecker {
     Continue,
 }
 
-impl DebugContext {
+impl MoveStepDebugContext {
     #[allow(unused)]
     pub(crate) fn new() -> Self {
         Self {
@@ -159,9 +176,11 @@ impl DebugContext {
             input_checker: InputChecker::StepRemaining(1),
         }
     }
+}
 
+impl DebugContext for MoveStepDebugContext {
     #[allow(unused)]
-    pub(crate) fn debug_loop(
+    fn debug_loop(
         &mut self,
         function: &LoadedFunction,
         locals: &Locals,
@@ -346,5 +365,15 @@ impl DebugContext {
                 }
             }
         }
+    }
+
+    fn capture_thread_state(&self) -> Box<dyn ThreadStateHandle> {
+        struct NoopThreadState;
+
+        impl ThreadStateHandle for NoopThreadState {
+            fn install_on_thread(&self) {}
+        }
+
+        Box::new(NoopThreadState)
     }
 }

--- a/third_party/move/move-vm/runtime/src/interpreter.rs
+++ b/third_party/move/move-vm/runtime/src/interpreter.rs
@@ -124,13 +124,19 @@ macro_rules! set_err_info {
 /// It mimics execution on a single thread, with an call stack and an operand stack.
 pub(crate) struct Interpreter;
 
-pub(crate) trait InterpreterDebugInterface {
+pub trait InterpreterDebugInterface {
     fn get_stack_frames(&self, count: usize) -> ExecutionState;
+    fn get_stack_depth(&self) -> usize;
     fn debug_print_stack_trace(
         &self,
         buf: &mut String,
         runtime_environment: &RuntimeEnvironment,
     ) -> PartialVMResult<()>;
+    fn get_frame_locals(&self, depth: usize) -> Option<(&LoadedFunction, &Locals)>;
+    fn load_struct_type(
+        &self,
+        idx: &move_vm_types::loaded_data::struct_name_indexing::StructNameIndex,
+    ) -> Option<std::sync::Arc<move_vm_types::loaded_data::runtime_types::StructType>>;
 }
 
 /// `InterpreterImpl` instances can execute Move functions.
@@ -1646,7 +1652,6 @@ where
         err
     }
 
-    #[allow(dead_code)]
     fn debug_print_frame<B: Write>(
         &self,
         buf: &mut B,
@@ -1747,7 +1752,7 @@ where
         internal_state.push_str(
             format!(
                 "*frame #{}: {} [pc = {}]:\n",
-                self.call_stack.0.len(),
+                self.get_stack_depth(),
                 current_frame.function.name_as_pretty_string(),
                 current_frame.pc,
             )
@@ -1808,7 +1813,6 @@ impl<LoaderImpl> InterpreterDebugInterface for InterpreterImpl<'_, LoaderImpl>
 where
     LoaderImpl: Loader,
 {
-    #[allow(dead_code)]
     #[cold]
     fn debug_print_stack_trace(
         &self,
@@ -1850,6 +1854,31 @@ where
             })
             .collect();
         ExecutionState::new(stack_trace)
+    }
+
+    fn get_stack_depth(&self) -> usize {
+        self.call_stack.0.len()
+    }
+
+    fn get_frame_locals(&self, depth: usize) -> Option<(&LoadedFunction, &Locals)> {
+        let len = self.call_stack.0.len();
+        if depth >= len {
+            return None;
+        }
+        let frame = &self.call_stack.0[len - 1 - depth];
+        Some((&frame.function, &frame.locals))
+    }
+
+    fn load_struct_type(
+        &self,
+        idx: &move_vm_types::loaded_data::struct_name_indexing::StructNameIndex,
+    ) -> Option<std::sync::Arc<move_vm_types::loaded_data::runtime_types::StructType>> {
+        use crate::module_traversal::{TraversalContext, TraversalStorage};
+        let storage = TraversalStorage::new();
+        let mut ctx = TraversalContext::new(&storage);
+        self.loader
+            .load_struct_definition(&mut move_vm_types::gas::UnmeteredGasMeter, &mut ctx, idx)
+            .ok()
     }
 }
 
@@ -2067,7 +2096,7 @@ impl Frame {
             };
             if is_tracing_for!(TraceCategory::VMError) {
                 let mut str = String::new();
-                let abort_idx = interpreter.call_stack.0.len();
+                let abort_idx = interpreter.get_stack_depth();
                 if let Err(print_err) = interpreter
                     .debug_print_stack_trace(&mut str, interpreter.loader.runtime_environment())
                 {

--- a/third_party/move/move-vm/runtime/src/lib.rs
+++ b/third_party/move/move-vm/runtime/src/lib.rs
@@ -22,7 +22,7 @@ pub mod tracing;
 pub mod config;
 pub mod module_traversal;
 
-mod debug;
+pub mod debug;
 pub mod source_locator;
 
 mod frame;

--- a/third_party/move/move-vm/runtime/src/loader/function.rs
+++ b/third_party/move/move-vm/runtime/src/loader/function.rs
@@ -641,7 +641,7 @@ impl LoadedFunction {
         self.function.code.len()
     }
 
-    pub(crate) fn name_as_pretty_string(&self) -> String {
+    pub fn name_as_pretty_string(&self) -> String {
         match &self.owner {
             LoadedFunctionOwner::Script(_) => "script::main".into(),
             LoadedFunctionOwner::Module(m) => format!(

--- a/third_party/move/move-vm/runtime/src/source_locator.rs
+++ b/third_party/move/move-vm/runtime/src/source_locator.rs
@@ -71,6 +71,11 @@ pub fn set_source_locator(loc: Arc<dyn SourceLocator>) {
     LOCATOR.with(|l| *l.borrow_mut() = Some(loc));
 }
 
+/// Return a clone of the current thread's source locator, if any.
+pub fn get_source_locator() -> Option<Arc<dyn SourceLocator>> {
+    LOCATOR.with(|l| l.borrow().clone())
+}
+
 /// Remove the source locator for the current thread.
 pub fn clear_source_locator() {
     LOCATOR.with(|l| *l.borrow_mut() = None);
@@ -131,7 +136,7 @@ pub fn get_enum_variant_info(
 /// blank lines; this function only writes the Parameters / Locals sections.
 ///
 /// `compact` – when `true`, `Invalid` slots (already moved out) are omitted.
-pub(crate) fn print_locals_enriched<B: fmt::Write>(
+pub(crate) fn print_locals_enаriched<B: fmt::Write>(
     buf: &mut B,
     function: &crate::LoadedFunction,
     locals: &Locals,

--- a/third_party/move/move-vm/runtime/src/source_locator.rs
+++ b/third_party/move/move-vm/runtime/src/source_locator.rs
@@ -136,7 +136,7 @@ pub fn get_enum_variant_info(
 /// blank lines; this function only writes the Parameters / Locals sections.
 ///
 /// `compact` – when `true`, `Invalid` slots (already moved out) are omitted.
-pub(crate) fn print_locals_enаriched<B: fmt::Write>(
+pub(crate) fn print_locals_enriched<B: fmt::Write>(
     buf: &mut B,
     function: &crate::LoadedFunction,
     locals: &Locals,

--- a/third_party/move/move-vm/runtime/src/tracing.rs
+++ b/third_party/move/move-vm/runtime/src/tracing.rs
@@ -4,12 +4,15 @@
 // All Aptos Foundation code and content is licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
-    debug::DebugContext, interpreter::InterpreterDebugInterface, loader::LoadedFunction,
+    debug::{DebugContext, MoveStepDebugContext},
+    interpreter::InterpreterDebugInterface,
+    loader::LoadedFunction,
     RuntimeEnvironment,
 };
 use arc_swap::ArcSwap;
 use move_vm_types::{instr::Instruction, values::Locals};
 use std::{
+    cell::{Cell, RefCell},
     env,
     fs::{File, OpenOptions},
     io::{BufWriter, Write},
@@ -28,9 +31,16 @@ pub(crate) const MOVE_VM_STEP_COMMANDS_ENV_VAR_NAME: &str = "MOVE_VM_STEP_COMMAN
 
 static FILE_PATH: OnceLock<ArcSwap<String>> = OnceLock::new();
 static TRACING_ENABLED: OnceLock<AtomicBool> = OnceLock::new();
-static DEBUGGING_ENABLED: OnceLock<AtomicBool> = OnceLock::new();
 static LOGGING_FILE_WRITER: OnceLock<Mutex<BufWriter<File>>> = OnceLock::new();
-static DEBUG_CONTEXT: OnceLock<Mutex<DebugContext>> = OnceLock::new();
+
+thread_local! {
+    static DEBUGGING_ENABLED: Cell<bool> = Cell::new(
+        env::var(MOVE_VM_STEPPING_ENV_VAR_NAME).is_ok()
+            || env::var(MOVE_VM_STEP_COMMANDS_ENV_VAR_NAME).is_ok(),
+    );
+    static DEBUG_CONTEXT: RefCell<Box<dyn DebugContext>> =
+        RefCell::new(Box::new(MoveStepDebugContext::new()));
+}
 
 /// Turn tracing on or off, saving info to the path.
 pub fn enable_tracing(path_opt: Option<&str>) {
@@ -59,13 +69,12 @@ pub(crate) fn is_tracing_enabled() -> &'static AtomicBool {
 }
 
 #[inline]
-pub(crate) fn is_debugging_enabled() -> &'static AtomicBool {
-    DEBUGGING_ENABLED.get_or_init(|| {
-        AtomicBool::new(
-            env::var(MOVE_VM_STEPPING_ENV_VAR_NAME).is_ok()
-                || env::var(MOVE_VM_STEP_COMMANDS_ENV_VAR_NAME).is_ok(),
-        )
-    })
+pub(crate) fn is_debugging_enabled() -> bool {
+    DEBUGGING_ENABLED.with(|c| c.get())
+}
+
+pub fn set_debugging_enabled(enable: bool) {
+    DEBUGGING_ENABLED.with(|c| c.set(enable));
 }
 
 pub fn flush_tracing_buffer() {
@@ -100,8 +109,12 @@ fn create_buffered_output(path: &Path) -> BufWriter<File> {
     BufWriter::with_capacity(4096 * 1024 /* 4096KB */, file)
 }
 
-pub(crate) fn get_debug_context() -> &'static Mutex<DebugContext> {
-    DEBUG_CONTEXT.get_or_init(|| Mutex::new(DebugContext::new()))
+pub fn set_debug_context(ctx: Box<dyn DebugContext>) {
+    DEBUG_CONTEXT.with(|cell| *cell.borrow_mut() = ctx);
+}
+
+pub fn capture_debug_thread_state() -> Box<dyn crate::debug::ThreadStateHandle> {
+    DEBUG_CONTEXT.with(|cell| cell.borrow().capture_thread_state())
 }
 
 pub(crate) fn debug_trace(
@@ -122,14 +135,16 @@ pub(crate) fn debug_trace(
             ))
             .unwrap();
     }
-    if is_debugging_enabled().load(Ordering::Relaxed) {
-        get_debug_context().lock().unwrap().debug_loop(
-            function,
-            locals,
-            pc,
-            instr,
-            runtime_environment,
-            interpreter,
-        );
+    if is_debugging_enabled() {
+        DEBUG_CONTEXT.with(|cell| {
+            cell.borrow_mut().debug_loop(
+                function,
+                locals,
+                pc,
+                instr,
+                runtime_environment,
+                interpreter,
+            );
+        });
     }
 }

--- a/third_party/move/move-vm/types/src/values/function_values_impl.rs
+++ b/third_party/move/move-vm/types/src/values/function_values_impl.rs
@@ -235,7 +235,7 @@ where
 /// Value:closure(AbstractFunction, [Value]) requires an AbstractFunction, which is agnostic from runtime implementation.
 /// This mock is used to test the function values system.
 #[cfg(any(test, feature = "fuzzing", feature = "testing"))]
-pub(crate) mod mock {
+pub mod mock {
     use super::*;
     use better_any::{Tid, TidAble, TidExt};
     use move_binary_format::errors::PartialVMResult;
@@ -250,13 +250,13 @@ pub(crate) mod mock {
 
     // Since Abstract functions are `Tid`, we cannot auto-mock them, so need to mock manually.
     #[derive(Clone, Tid)]
-    pub(crate) struct MockAbstractFunction {
-        pub(crate) data: SerializedFunctionData,
+    pub struct MockAbstractFunction {
+        pub data: SerializedFunctionData,
     }
 
     impl MockAbstractFunction {
         #[allow(dead_code)]
-        pub(crate) fn new(
+        pub fn new(
             fun_name: &str,
             ty_args: Vec<TypeTag>,
             mask: ClosureMask,

--- a/third_party/move/move-vm/types/src/values/values_impl.rs
+++ b/third_party/move/move-vm/types/src/values/values_impl.rs
@@ -135,7 +135,7 @@ pub enum Value {
 /// sites unchanged. To move the inner Rc out (e.g., for `take_unique_ownership`), call
 /// [`NestedValues::into_rc`]. To clone (share), use `.clone()`.
 #[derive(Debug)]
-pub(crate) struct NestedValues(Rc<RefCell<Vec<Value>>>);
+pub struct NestedValues(Rc<RefCell<Vec<Value>>>);
 
 impl NestedValues {
     #[inline]
@@ -292,7 +292,7 @@ impl Drop for NestedValues {
 /// Except when not owned by the VM stack, a container always lives inside an Rc<RefCell<>>,
 /// making it possible to be shared by references.
 #[derive(Debug)]
-pub(crate) enum Container {
+pub enum Container {
     Locals(NestedValues),
     Vec(NestedValues),
     Struct(NestedValues),
@@ -316,7 +316,7 @@ pub(crate) enum Container {
 /// or in global storage. In the latter case, it also keeps a status flag indicating whether
 /// the container has been possibly modified.
 #[derive(Debug)]
-pub(crate) enum ContainerRef {
+pub enum ContainerRef {
     Local(Container),
     Global {
         status: Rc<RefCell<GlobalDataStatus>>,
@@ -328,7 +328,7 @@ pub(crate) enum ContainerRef {
 /// Clean - the data was only read.
 /// Dirty - the data was possibly modified.
 #[derive(Debug, Clone, Copy)]
-pub(crate) enum GlobalDataStatus {
+pub enum GlobalDataStatus {
     Clean,
     Dirty,
 }
@@ -339,9 +339,9 @@ pub(crate) enum GlobalDataStatus {
 /// addresses, delayed values, or closures). Container values (structs/vectors/locals) use
 /// [`ContainerRef`] instead.
 #[derive(Debug)]
-pub(crate) struct IndexedRef {
-    idx: u32,
-    container_ref: ContainerRef,
+pub struct IndexedRef {
+    pub idx: u32,
+    pub container_ref: ContainerRef,
     /// Only set for enums.
     tag: Option<u16>,
 }
@@ -625,7 +625,7 @@ fn take_unique_ownership<T: Debug>(r: Rc<RefCell<T>>) -> PartialVMResult<T> {
 }
 
 impl ContainerRef {
-    fn container(&self) -> &Container {
+    pub fn container(&self) -> &Container {
         match self {
             Self::Local(container) | Self::Global { container, .. } => container,
         }
@@ -2645,6 +2645,10 @@ impl Locals {
             Some(_) => Ok(false),
             None => Err(Self::local_index_out_of_bounds(idx, locals.len())),
         }
+    }
+
+    pub fn borrow_values(&self) -> std::cell::Ref<'_, Vec<Value>> {
+        self.0.borrow()
     }
 
     #[cold]

--- a/third_party/move/tools/move-unit-test/src/test_runner.rs
+++ b/third_party/move/tools/move-unit-test/src/test_runner.rs
@@ -205,8 +205,12 @@ impl TestRunner {
         writer: &Mutex<W>,
         options: &Mutex<F>,
     ) -> Result<TestResults> {
+        let thread_state = move_vm_runtime::tracing::capture_debug_thread_state();
         rayon::ThreadPoolBuilder::new()
             .num_threads(self.num_threads)
+            .start_handler(move |_| {
+                thread_state.install_on_thread()
+            })
             .build()
             .unwrap()
             .install(|| {


### PR DESCRIPTION
Debugger itself lives in my repo for now, but the plan is to move it into the monorepo eventually. 
https://github.com/aptos-labs/aptos-debugger

**Note:**
Global mutex -> thread-local change for context is for debugger tests to work, otherwise they step onto each other. 



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches VM runtime debugging and tracing paths (thread-local vs global context) and widens public APIs, but production execution is unchanged when stepping is off; parallel test behavior depends on correct thread-state installation.
> 
> **Overview**
> Adds **minimal aptos-core / Move VM plumbing** for an external IDE debugger: public debug APIs, per-thread stepping state, and better source mapping when deployed module addresses differ from local builds.
> 
> **Source locator:** `AptosSourceLocator` now keeps a module-name → `ModuleId` map and resolves lookups through `resolve_module_id` so bytecode PCs can map to `.move` files when on-chain addresses do not match local named addresses. Adds `known_source_files()` for the IDE.
> 
> **VM debugging surface:** `debug` is public; stepping uses a `DebugContext` trait (default `MoveStepDebugContext`) plus `ThreadStateHandle` for copying debug state onto worker threads. Global `Mutex<DebugContext>` and atomic stepping flags become **thread-local** with `set_debug_context`, `set_debugging_enabled`, and `capture_debug_thread_state`. `get_source_locator()` exposes the per-thread locator.
> 
> **Interpreter introspection:** `InterpreterDebugInterface` is public and extended with `get_stack_depth`, `get_frame_locals`, and `load_struct_type`; several value/container types and `Locals::borrow_values` are public for rich variable display.
> 
> **Tests:** `move-unit-test` rayon pool installs captured thread state so parallel debugger tests do not share stepping context.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 258dffe0b29bc3c909a997bc31203a2355feec47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->