### PR TITLE
[mono-move] Typed errors for loader

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12814,6 +12814,7 @@ dependencies = [
  "move-core-types",
  "shared-dsa",
  "specializer",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -12855,6 +12856,7 @@ dependencies = [
  "mono-move-alloc",
  "mono-move-core",
  "mono-move-gas",
+ "mono-move-loader",
  "move-core-types",
  "proptest",
  "rand 0.7.3",

--- a/third_party/move/mono-move/core/src/error.rs
+++ b/third_party/move/mono-move/core/src/error.rs
@@ -35,6 +35,9 @@ pub enum ExecutionErrorKind {
     /// Program attempted an operation that failed at runtime (vector
     /// OOB, arithmetic overflow, missing resource, etc.).
     InvalidOperation,
+    /// A referenced module, function, or struct could not be resolved
+    /// or had an incompatible signature.
+    LinkingError,
     /// A condition that should never occur — a VM bug. Production
     /// deployments should alert on these; users should not see them
     /// surface as transaction failures with diagnostic detail. Can
@@ -52,6 +55,7 @@ impl fmt::Display for ExecutionErrorKind {
             ExecutionErrorKind::OutOfGas => write!(f, "OutOfGas"),
             ExecutionErrorKind::RuntimeLimitExceeded => write!(f, "RuntimeLimitExceeded"),
             ExecutionErrorKind::InvalidOperation => write!(f, "InvalidOperation"),
+            ExecutionErrorKind::LinkingError => write!(f, "LinkingError"),
             ExecutionErrorKind::InvariantViolation => write!(f, "InvariantViolation"),
             ExecutionErrorKind::Placeholder => write!(f, "Placeholder"),
         }

--- a/third_party/move/mono-move/core/src/lib.rs
+++ b/third_party/move/mono-move/core/src/lib.rs
@@ -3,7 +3,6 @@
 
 pub mod align;
 mod error;
-mod execution_context;
 mod function;
 mod instruction;
 pub mod interner;
@@ -15,7 +14,6 @@ pub use align::{
     align_max, align_up, align_up_u32, checked_align_max, checked_align_up, MAX_ALIGN,
 };
 pub use error::{ExecutionError, ExecutionErrorKind, ExecutionResult, IntoExecutionError};
-pub use execution_context::{ExecutionContext, LocalExecutionContext};
 pub use function::{
     Code, FrameLayoutInfo, Function, FunctionPtr, SafePointEntry, SortedSafePointEntries,
 };

--- a/third_party/move/mono-move/global-context/src/context/loaded_module.rs
+++ b/third_party/move/mono-move/global-context/src/context/loaded_module.rs
@@ -5,7 +5,6 @@
 //! with the lowered monomorphic functions and generic function instantiations.
 
 use crate::context::ExecutionGuard;
-use anyhow::{anyhow, bail};
 use mono_move_alloc::{LeakedBoxPtr, VersionedLeakedBoxPtr};
 use mono_move_core::{
     interner::{InternedIdentifier, InternedModuleId},
@@ -97,11 +96,11 @@ impl ModuleMandatoryDependencies {
     }
 
     /// Returns the cell for lazy mandatory dependencies.
-    pub fn as_lazy(&self) -> anyhow::Result<&OnceLock<Arc<[LoadedModuleSlot]>>> {
-        let Self::Lazy(cell) = self else {
-            bail!("Mandatory dependencies must always be lazy");
-        };
-        Ok(cell)
+    pub fn as_lazy(&self) -> Option<&OnceLock<Arc<[LoadedModuleSlot]>>> {
+        match self {
+            Self::Lazy(cell) => Some(cell),
+            Self::Package(_) => None,
+        }
     }
 
     /// Returns empty mandatory dependencies for lazy module loads. This does
@@ -219,37 +218,21 @@ impl LoadedModule {
         self.cost
     }
 
-    /// Returns the monomorphized function pointer for the given name. If the
-    /// function has not been monomorphized, returns [`None`].
-    pub fn get_function_ptr(
-        &self,
-        name: InternedIdentifier,
-    ) -> anyhow::Result<Option<FunctionPtr>> {
-        Ok(self.get_function_slot(name)?.get().map(|f| f.function))
-    }
-
     /// Returns the function slot for the given name where monomorphized code
-    /// may or may not be installed.
-    pub fn get_function_slot(
-        &self,
-        name: InternedIdentifier,
-    ) -> anyhow::Result<&OnceLock<FunctionSlot>> {
-        self.functions
-            .get(&name)
-            .ok_or_else(|| anyhow!("Linker error: function not found"))
+    /// may or may not be installed, or `None` if the function is not found.
+    pub fn get_function_slot(&self, name: InternedIdentifier) -> Option<&OnceLock<FunctionSlot>> {
+        self.functions.get(&name)
     }
 
     /// Returns the polymorphic IR for the function with the given name.
-    pub fn get_function_ir(&self, name: InternedIdentifier) -> anyhow::Result<&FunctionIR> {
-        let idx = *self
-            .function_indices
-            .get(&name)
-            .ok_or_else(|| anyhow!("Linker error: function not found"))?;
-        self.ir
-            .functions
-            .get(idx)
-            .and_then(|slot| slot.as_ref())
-            .ok_or_else(|| anyhow!("Linker error: function IR missing"))
+    ///
+    /// The two-level [`Option`] distinguishes three cases:
+    /// - [`None`]: the function is not defined in this module.
+    /// - [`Some(None)`]: the function is a native (no IR).
+    /// - [`Some(Some(ir))`]: the IR is available.
+    pub fn get_function_ir(&self, name: InternedIdentifier) -> Option<Option<&FunctionIR>> {
+        let idx = *self.function_indices.get(&name)?;
+        Some(self.ir.functions.get(idx).and_then(|slot| slot.as_ref()))
     }
 
     /// Returns the function and its mandatory dependencies for the given

--- a/third_party/move/mono-move/loader/Cargo.toml
+++ b/third_party/move/mono-move/loader/Cargo.toml
@@ -21,6 +21,7 @@ move-binary-format = { workspace = true }
 move-core-types = { workspace = true }
 shared-dsa = { workspace = true }
 specializer = { workspace = true }
+thiserror = { workspace = true }
 
 [dev-dependencies]
 mono-move-testsuite = { workspace = true }

--- a/third_party/move/mono-move/loader/src/error.rs
+++ b/third_party/move/mono-move/loader/src/error.rs
@@ -1,0 +1,162 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Loader subsystem error types.
+
+use mono_move_core::{ExecutionErrorKind, IntoExecutionError};
+use mono_move_gas::GasExhaustedError;
+use move_core_types::account_address::AccountAddress;
+use thiserror::Error;
+
+pub type LoaderResult<T> = Result<T, LoaderError>;
+
+#[derive(Debug, Error)]
+pub enum LoaderError {
+    #[error(transparent)]
+    GasExhausted(#[from] GasExhaustedError),
+
+    #[error("Module {address}::{name} not found")]
+    ModuleNotFound {
+        address: AccountAddress,
+        name: String,
+    },
+
+    #[error("Function {address}::{module}::{name} not found")]
+    FunctionNotFound {
+        address: AccountAddress,
+        module: String,
+        name: String,
+    },
+
+    /// TODO: temporary until natives are supported.
+    #[error("Function IR missing")]
+    FunctionIrMissing,
+
+    /// TODO: temporary until nominal types are supported.
+    #[error("Failed to lower function: {reason}")]
+    LoweringSkipped { reason: &'static str },
+
+    /// TODO: replace once the deserializer has its own error type.
+    #[error(transparent)]
+    Deserialization(anyhow::Error),
+
+    /// TODO: replace once the verifier has its own error type.
+    #[error(transparent)]
+    Verification(anyhow::Error),
+
+    /// Catch-all for `ModuleProvider` failures.
+    /// TODO: figure out the right error type(s) here.
+    #[error(transparent)]
+    ModuleProvider(anyhow::Error),
+
+    /// TODO: replace once the global context has its own error type.
+    #[error(transparent)]
+    GlobalContext(anyhow::Error),
+
+    /// TODO: replace once the specializer has its own error type.
+    #[error(transparent)]
+    Specializer(anyhow::Error),
+
+    #[error(transparent)]
+    InvariantViolation(#[from] LoaderInvariantViolation),
+}
+
+impl IntoExecutionError for LoaderError {
+    fn kind(&self) -> ExecutionErrorKind {
+        use LoaderError::*;
+        match self {
+            GasExhausted(_) => ExecutionErrorKind::OutOfGas,
+
+            ModuleNotFound { .. } | FunctionNotFound { .. } | FunctionIrMissing => {
+                ExecutionErrorKind::LinkingError
+            },
+
+            // TODO: delegate to the inner errors once they have their own types.
+            Deserialization(_)
+            | Verification(_)
+            | ModuleProvider(_)
+            | GlobalContext(_)
+            | Specializer(_)
+            | LoweringSkipped { .. } => ExecutionErrorKind::Placeholder,
+
+            InvariantViolation(_) => ExecutionErrorKind::InvariantViolation,
+        }
+    }
+}
+
+/// Read-set state-machine and cache-consistency assertions raised by the
+/// loader. Surfaced rather than panicked so callers can produce a clean
+/// per-transaction outcome and alert operationally on
+/// [`ExecutionErrorKind::InvariantViolation`].
+#[derive(Debug, Error)]
+pub enum LoaderInvariantViolation {
+    // ---- read_set transitions ----
+    #[error("There should be no entry when marked as pending")]
+    EntryAlreadyExists,
+
+    #[error("Module must be recorded as pending")]
+    ModuleExpectedPending,
+
+    #[error("Module is already loaded")]
+    ModuleAlreadyLoaded,
+
+    #[error("Module must be loaded")]
+    ModuleExpectedLoaded,
+
+    #[error("Module must be at least loaded")]
+    ModuleExpectedAtLeastLoaded,
+
+    #[error("Module is already metered")]
+    ModuleAlreadyMetered,
+
+    #[error("Module must be metered")]
+    ModuleExpectedMetered,
+
+    #[error("Module is already ready for lowering")]
+    ModuleAlreadyReady,
+
+    // ---- loader cross-checks against the read-set ----
+    #[error("All modules in the read-set must be metered")]
+    ReadSetEntryNotMetered,
+
+    #[error("All modules in the read-set must be loaded")]
+    ReadSetEntryNotLoaded,
+
+    #[error("Target module is not loaded")]
+    TargetModuleNotLoaded,
+
+    #[error("Target module is not metered and ready")]
+    TargetModuleNotReady,
+
+    #[error("All modules must be present in the read-set")]
+    UnexpectedReadSetMiss,
+
+    // ---- function slot ----
+    #[error("Function slot has just been set")]
+    FunctionSlotEmptyAfterSet,
+
+    // ---- mandatory dependencies ----
+    #[error("Mandatory dependencies must be set")]
+    MandatoryDepsNotSet,
+
+    #[error("Mandatory dependencies must always be lazy")]
+    MandatoryDepsNotLazy,
+}
+
+/// Returns from the enclosing function with a [`LoaderError::InvariantViolation`]
+/// wrapping the named [`LoaderInvariantViolation`] variant. Works for both
+/// unit and struct variants:
+///
+/// ```ignore
+/// invariant_violation!(PendingEntryAlreadyExists);
+/// ```
+#[macro_export]
+macro_rules! invariant_violation {
+    ($($body:tt)+) => {
+        return ::core::result::Result::Err(
+            $crate::error::LoaderError::InvariantViolation(
+                $crate::error::LoaderInvariantViolation::$($body)+,
+            ),
+        )
+    };
+}

--- a/third_party/move/mono-move/loader/src/lib.rs
+++ b/third_party/move/mono-move/loader/src/lib.rs
@@ -21,12 +21,12 @@
 //!   package atomically. Lowering is lazy: any function that needs information
 //!   outside the package is lowered during the first call.
 
+mod error;
 mod loader;
 mod module_provider;
 mod read_set;
-mod transaction_context;
 
+pub use error::{LoaderError, LoaderResult};
 pub use loader::{Loader, LoadingPolicy, LoweringPolicy};
 pub use module_provider::ModuleProvider;
 pub use read_set::{ModuleRead, ModuleReadSet, ModuleState};
-pub use transaction_context::TransactionContext;

--- a/third_party/move/mono-move/loader/src/loader.rs
+++ b/third_party/move/mono-move/loader/src/loader.rs
@@ -18,13 +18,14 @@
 //! then inserted into cache.
 
 use crate::{
+    error::{LoaderError, LoaderResult},
+    invariant_violation,
     module_provider::ModuleProvider,
     read_set::{ModuleRead, ModuleReadSet, ModuleState},
 };
-use anyhow::{anyhow, bail};
 use mono_move_core::{
     interner::{InternedIdentifier, InternedModuleId},
-    types::{InternedType, InternedTypeList, EMPTY_TYPE_LIST},
+    types::{view_name, InternedType, InternedTypeList, EMPTY_TYPE_LIST},
     DescriptorId, FieldTypes, FrameOffset, Function, FunctionPtr, Interner, ModuleId,
 };
 use mono_move_gas::GasMeter;
@@ -129,7 +130,7 @@ impl<'guard, 'ctx> Loader<'guard, 'ctx> {
         read_set: &mut ModuleReadSet<'guard>,
         gas_meter: &mut impl GasMeter,
         id: ArenaRef<'guard, ModuleId>,
-    ) -> anyhow::Result<&'guard LoadedModule> {
+    ) -> LoaderResult<&'guard LoadedModule> {
         match &self.policy {
             LoadingPolicy::Lazy(lowering) => {
                 use LoweringPolicy::*;
@@ -149,7 +150,7 @@ impl<'guard, 'ctx> Loader<'guard, 'ctx> {
         module_id: InternedModuleId,
         func_name: InternedIdentifier,
         ty_args: InternedTypeList,
-    ) -> anyhow::Result<FunctionPtr> {
+    ) -> LoaderResult<FunctionPtr> {
         let id = self.guard.arena_ref_for_module_id(module_id);
 
         let module = match read_set.get(id) {
@@ -160,16 +161,22 @@ impl<'guard, 'ctx> Loader<'guard, 'ctx> {
                     module
                 },
                 ModuleState::Unmetered => {
-                    bail!("All modules in the read-set must be metered");
+                    invariant_violation!(ReadSetEntryNotMetered);
                 },
             },
-            Some(ModuleRead::Pending) => bail!("All modules in the read-set must be loaded"),
+            Some(ModuleRead::Pending) => invariant_violation!(ReadSetEntryNotLoaded),
             None => self.load_module(read_set, gas_meter, id)?,
         };
 
         // Non-generic call.
         if ty_args.is_empty() {
-            let slot = module.get_function_slot(func_name)?;
+            let slot = module.get_function_slot(func_name).ok_or_else(|| {
+                LoaderError::FunctionNotFound {
+                    address: *id.address(),
+                    module: id.name().to_string(),
+                    name: view_name(func_name).to_string(),
+                }
+            })?;
             if let Some(loaded) = slot.get() {
                 self.charge_non_read_set_slots(
                     read_set,
@@ -190,10 +197,10 @@ impl<'guard, 'ctx> Loader<'guard, 'ctx> {
                 // because it lost the race: safe to free.
                 unsafe { loser.function.free_unchecked() };
             }
-            return slot
-                .get()
-                .ok_or_else(|| anyhow!("Function slot has just been set"))
-                .map(|f| f.function);
+            let Some(f) = slot.get() else {
+                invariant_violation!(FunctionSlotEmptyAfterSet);
+            };
+            return Ok(f.function);
         }
 
         // Otherwise this function is generic. Need to lookup in a separate
@@ -226,15 +233,27 @@ impl<'guard, 'ctx> Loader<'guard, 'ctx> {
         module: &LoadedModule,
         func_name: InternedIdentifier,
         ty_args: InternedTypeList,
-    ) -> anyhow::Result<(Function, Arc<[LoadedModuleSlot]>)> {
-        let func_ir = module.get_function_ir(func_name)?;
+    ) -> LoaderResult<(Function, Arc<[LoadedModuleSlot]>)> {
+        let func_ir = match module.get_function_ir(func_name) {
+            Some(Some(ir)) => ir,
+            Some(None) => return Err(LoaderError::FunctionIrMissing),
+            None => {
+                let id = self.guard.arena_ref_for_module_id(module.id());
+                return Err(LoaderError::FunctionNotFound {
+                    address: *id.address(),
+                    module: id.name().to_string(),
+                    name: view_name(func_name).to_string(),
+                });
+            },
+        };
         let mut loading_ctx = LoweringContext::new(self, read_set);
         let vec_descriptors = try_discover_types_for_lowering_in_function(
             &mut loading_ctx,
             module.ir(),
             func_ir,
             ty_args,
-        )?;
+        )
+        .map_err(LoaderError::Specializer)?;
 
         let parent_ms_ids = module
             .mandatory_dependencies()
@@ -248,11 +267,13 @@ impl<'guard, 'ctx> Loader<'guard, 'ctx> {
         let function_ms = Arc::<[LoadedModuleSlot]>::from(loading_ctx.discovered);
 
         self.record_loaded_and_charge_slots(read_set, gas_meter, &function_ms, |_, _| {
-            bail!("All modules are in the read-set");
+            invariant_violation!(UnexpectedReadSetMiss);
         })?;
 
         let function =
-            match try_lower_function(module.ir(), func_ir, ty_args, self.guard, vec_descriptors)? {
+            match try_lower_function(module.ir(), func_ir, ty_args, self.guard, vec_descriptors)
+                .map_err(LoaderError::Specializer)?
+            {
                 LoweringOutcome::Built(f) => f,
                 // TODO: drop this arm — together with the `LoweringOutcome`
                 // enum and the corresponding `BuildContextOutcome::Skipped`
@@ -260,7 +281,9 @@ impl<'guard, 'ctx> Loader<'guard, 'ctx> {
                 // handles nominal types and partial concretization. At that
                 // point `try_lower_function` is total and can go back to
                 // returning `Result<Function>` directly.
-                LoweringOutcome::Skipped(reason) => bail!("Failed to lower function: {}", reason),
+                LoweringOutcome::Skipped(reason) => {
+                    return Err(LoaderError::LoweringSkipped { reason })
+                },
             };
         Ok((function, function_ms))
     }
@@ -278,7 +301,7 @@ impl<'guard, 'ctx> Loader<'guard, 'ctx> {
         read_set: &mut ModuleReadSet<'guard>,
         gas_meter: &mut impl GasMeter,
         id: ArenaRef<'guard, ModuleId>,
-    ) -> anyhow::Result<&'guard LoadedModule> {
+    ) -> LoaderResult<&'guard LoadedModule> {
         read_set.record_pending_loading(id)?;
         let module = match self.guard.get_module(id) {
             Some(module) => module,
@@ -300,7 +323,7 @@ impl<'guard, 'ctx> Loader<'guard, 'ctx> {
         read_set: &mut ModuleReadSet<'guard>,
         gas_meter: &mut impl GasMeter,
         id: ArenaRef<'guard, ModuleId>,
-    ) -> anyhow::Result<&'guard LoadedModule> {
+    ) -> LoaderResult<&'guard LoadedModule> {
         let package = match self.guard.get_module(id) {
             Some(module) => module.mandatory_dependencies().clone(),
             None => self.build_mandatory_dependencies_for_id(id)?,
@@ -345,11 +368,11 @@ impl<'guard, 'ctx> Loader<'guard, 'ctx> {
 
         if let Some(ModuleRead::Loaded { module, state }) = read_set.get(id) {
             if !matches!(state, ModuleState::ReadyForLowering) {
-                bail!("Target module is not metered and ready");
+                invariant_violation!(TargetModuleNotReady);
             }
             Ok(module)
         } else {
-            bail!("Target module is not loaded")
+            invariant_violation!(TargetModuleNotLoaded)
         }
     }
 
@@ -358,13 +381,14 @@ impl<'guard, 'ctx> Loader<'guard, 'ctx> {
     fn build_mandatory_dependencies_for_id(
         &self,
         id: ArenaRef<'guard, ModuleId>,
-    ) -> anyhow::Result<ModuleMandatoryDependencies> {
+    ) -> LoaderResult<ModuleMandatoryDependencies> {
         match &self.policy {
             LoadingPolicy::Lazy(_) => Ok(ModuleMandatoryDependencies::lazy_unset()),
             LoadingPolicy::Package => {
                 let module_names = self
                     .module_provider
-                    .get_same_package_modules(id.address(), id.name())?;
+                    .get_same_package_modules(id.address(), id.name())
+                    .map_err(LoaderError::ModuleProvider)?;
                 let package_slots = module_names
                     .into_iter()
                     .map(|module_name| {
@@ -387,7 +411,7 @@ impl<'guard, 'ctx> Loader<'guard, 'ctx> {
         read_set: &mut ModuleReadSet<'guard>,
         gas_meter: &mut impl GasMeter,
         id: ArenaRef<'guard, ModuleId>,
-    ) -> anyhow::Result<&'guard LoadedModule> {
+    ) -> LoaderResult<&'guard LoadedModule> {
         let module = match self.guard.get_module(id) {
             None => {
                 read_set.record_pending_loading(id)?;
@@ -397,7 +421,10 @@ impl<'guard, 'ctx> Loader<'guard, 'ctx> {
                 module
             },
             Some(module) => {
-                if module.mandatory_dependencies().as_lazy()?.get().is_some() {
+                let Some(deps) = module.mandatory_dependencies().as_lazy() else {
+                    invariant_violation!(MandatoryDepsNotLazy);
+                };
+                if deps.get().is_some() {
                     // Mandatory set is already cached - only need to charge gas.
                     self.charge_mandatory_set_for_eager_lowering(read_set, gas_meter, id, module)?;
                     return Ok(module);
@@ -425,14 +452,17 @@ impl<'guard, 'ctx> Loader<'guard, 'ctx> {
         gas_meter: &mut impl GasMeter,
         id: ArenaRef<'guard, ModuleId>,
         module: &'guard LoadedModule,
-    ) -> anyhow::Result<()> {
+    ) -> LoaderResult<()> {
         match &self.policy {
             LoadingPolicy::Lazy(LoweringPolicy::Lazy) => {
                 // Nothing extra to charge, safe to mark ready for lowering.
                 read_set.mark_ready_for_lowering(id)?;
             },
             LoadingPolicy::Lazy(LoweringPolicy::Eager) => {
-                if module.mandatory_dependencies().as_lazy()?.get().is_some() {
+                let Some(deps) = module.mandatory_dependencies().as_lazy() else {
+                    invariant_violation!(MandatoryDepsNotLazy);
+                };
+                if deps.get().is_some() {
                     self.charge_mandatory_set_for_eager_lowering(read_set, gas_meter, id, module)?;
                 } else {
                     self.compute_mandatory_set_for_eager_lowering(read_set, gas_meter, id, module)?;
@@ -456,12 +486,13 @@ impl<'guard, 'ctx> Loader<'guard, 'ctx> {
         gas_meter: &mut impl GasMeter,
         id: ArenaRef<'guard, ModuleId>,
         module: &'guard LoadedModule,
-    ) -> anyhow::Result<()> {
-        let slots = module
-            .mandatory_dependencies()
-            .as_lazy()?
-            .get()
-            .ok_or_else(|| anyhow!("Mandatory dependencies must be set"))?;
+    ) -> LoaderResult<()> {
+        let Some(deps) = module.mandatory_dependencies().as_lazy() else {
+            invariant_violation!(MandatoryDepsNotLazy);
+        };
+        let Some(slots) = deps.get() else {
+            invariant_violation!(MandatoryDepsNotSet);
+        };
         self.charge_non_read_set_slots(read_set, gas_meter, slots)?;
         read_set.mark_ready_for_lowering(id)?;
         Ok(())
@@ -482,7 +513,7 @@ impl<'guard, 'ctx> Loader<'guard, 'ctx> {
         gas_meter: &mut impl GasMeter,
         id: ArenaRef<'guard, ModuleId>,
         module: &'guard LoadedModule,
-    ) -> anyhow::Result<()> {
+    ) -> LoaderResult<()> {
         let mut walker = LoweringContext::new(self, read_set);
         let self_slot = self.guard.get_or_create_module_slot(id);
         walker.discovered_seen.insert(module.id());
@@ -491,25 +522,24 @@ impl<'guard, 'ctx> Loader<'guard, 'ctx> {
         // Per-function lowering re-walks types and rebuilds its own
         // descriptor map; only the side-effecting publish-to-guard
         // matters here.
-        let _ = try_discover_types_for_lowering_in_module(&mut walker, module.ir())?;
+        let _ = try_discover_types_for_lowering_in_module(&mut walker, module.ir())
+            .map_err(LoaderError::Specializer)?;
 
         // Set the mandatory set for the module. Because of concurrency, it is
         // possible that other thread sets it at before, so we need to reload
         // it.
-        let _ = module
-            .mandatory_dependencies()
-            .as_lazy()?
-            .set(walker.discovered.into());
-        let ms = module
-            .mandatory_dependencies()
-            .as_lazy()?
-            .get()
-            .ok_or_else(|| anyhow!("Mandatory dependencies must be set"))?;
+        let Some(deps) = module.mandatory_dependencies().as_lazy() else {
+            invariant_violation!(MandatoryDepsNotLazy);
+        };
+        let _ = deps.set(walker.discovered.into());
+        let Some(ms) = deps.get() else {
+            invariant_violation!(MandatoryDepsNotSet);
+        };
 
         // For all modules in mandatory set, charge gas. This charging also
         // includes self. Once done, we need to mark it as ready for lowering.
         self.record_loaded_and_charge_slots(read_set, gas_meter, ms, |_, _| {
-            bail!("All modules must be present in the read-set")
+            invariant_violation!(UnexpectedReadSetMiss)
         })?;
         read_set.mark_ready_for_lowering(id)?;
         Ok(())
@@ -520,20 +550,30 @@ impl<'guard, 'ctx> Loader<'guard, 'ctx> {
     fn get_verified_module_from_storage(
         &self,
         id: ArenaRef<'guard, ModuleId>,
-    ) -> anyhow::Result<(ModuleIR, u64)> {
+    ) -> LoaderResult<(ModuleIR, u64)> {
         let bytes = self
             .module_provider
-            .get_module_bytes(id.address(), id.name())?
-            .ok_or_else(|| anyhow!("Linker error"))?;
+            .get_module_bytes(id.address(), id.name())
+            .map_err(LoaderError::ModuleProvider)?
+            .ok_or_else(|| LoaderError::ModuleNotFound {
+                address: *id.address(),
+                name: id.name().to_string(),
+            })?;
         // TODO: placeholder cost model — byte length of the module. Replace
         // with a proper cost function (bucketed by size, verifier cost, etc.).
         let cost = bytes.len() as u64;
-        let compiled_module = self.module_provider.deserialize_module(&bytes)?;
-        self.module_provider.verify_module(&compiled_module)?;
+        let compiled_module = self
+            .module_provider
+            .deserialize_module(&bytes)
+            .map_err(LoaderError::Deserialization)?;
+        self.module_provider
+            .verify_module(&compiled_module)
+            .map_err(LoaderError::Verification)?;
         // TODO:
         //   This can run verification twice because destack runs it and we verified before.
         //   Destack should take a hook so we can add more things to verify.
-        let module_ir = specializer::destack(compiled_module, self.guard)?;
+        let module_ir =
+            specializer::destack(compiled_module, self.guard).map_err(LoaderError::Specializer)?;
         Ok((module_ir, cost))
     }
 
@@ -550,10 +590,11 @@ impl<'guard, 'ctx> Loader<'guard, 'ctx> {
         &self,
         id: ArenaRef<'guard, ModuleId>,
         deps: ModuleMandatoryDependencies,
-    ) -> anyhow::Result<&'guard LoadedModule> {
+    ) -> LoaderResult<&'guard LoadedModule> {
         let (module_ir, cost) = self.get_verified_module_from_storage(id)?;
         self.guard
             .insert_module(LoadedModule::new(module_ir, cost, deps))
+            .map_err(LoaderError::GlobalContext)
     }
 
     /// Records all modules in the slots in the read-set and charges its cost
@@ -564,9 +605,9 @@ impl<'guard, 'ctx> Loader<'guard, 'ctx> {
         gas_meter: &mut impl GasMeter,
         slots: &[LoadedModuleSlot],
         mut on_read_set_miss: F,
-    ) -> anyhow::Result<()>
+    ) -> LoaderResult<()>
     where
-        F: FnMut(&mut ModuleReadSet<'guard>, &ModuleSlot) -> anyhow::Result<&'guard LoadedModule>,
+        F: FnMut(&mut ModuleReadSet<'guard>, &ModuleSlot) -> LoaderResult<&'guard LoadedModule>,
     {
         let mut loading_cost = 0u64;
         for slot in slots.iter().map(|s| self.module_slot(s)) {
@@ -579,7 +620,7 @@ impl<'guard, 'ctx> Loader<'guard, 'ctx> {
                         read_set.mark_metered(id)?;
                     },
                 },
-                Some(ModuleRead::Pending) => bail!("All modules have to be loaded"),
+                Some(ModuleRead::Pending) => invariant_violation!(ReadSetEntryNotLoaded),
                 None => {
                     let module = on_read_set_miss(read_set, slot)?;
                     loading_cost = loading_cost.saturating_add(module.cost());
@@ -597,7 +638,7 @@ impl<'guard, 'ctx> Loader<'guard, 'ctx> {
         read_set: &mut ModuleReadSet<'guard>,
         gas_meter: &mut impl GasMeter,
         slots: &[LoadedModuleSlot],
-    ) -> anyhow::Result<()> {
+    ) -> LoaderResult<()> {
         self.record_loaded_and_charge_slots(read_set, gas_meter, slots, |read_set, slot| {
             let id = self.guard.arena_ref_for_module_id(slot.id());
             read_set.record_pending_loading(id)?;
@@ -652,7 +693,12 @@ impl SpecializerContext for LoweringContext<'_, '_, '_> {
         // Every module needs to be in the read-set.
         let module = match self.read_set.get(id) {
             Some(ModuleRead::Loaded { module, .. }) => module,
-            Some(ModuleRead::Pending) => bail!("All modules have to be loaded or not present"),
+            Some(ModuleRead::Pending) => {
+                // TODO: should be `invariant_violation!(ReadSetEntryNotLoaded)`.
+                // The specializer needs a typed error first, without creating
+                // a circular dependency with `LoaderError`.
+                anyhow::bail!("All modules have to be loaded or not present")
+            },
             None => {
                 self.read_set.record_pending_loading(id)?;
                 let module = match self.loader.guard.get_module(id) {

--- a/third_party/move/mono-move/loader/src/read_set.rs
+++ b/third_party/move/mono-move/loader/src/read_set.rs
@@ -4,7 +4,7 @@
 //! Per-transaction set of modules recorded by the loader, pinning one
 //! version per module for the duration of the transaction.
 
-use anyhow::{bail, Result};
+use crate::{error::LoaderResult, invariant_violation};
 use mono_move_core::ModuleId;
 use mono_move_global_context::{ArenaRef, LoadedModule};
 use shared_dsa::UnorderedMap;
@@ -84,9 +84,9 @@ impl<'guard> ModuleReadSet<'guard> {
 
     /// Records a module that is about to be loaded. Used so a load that fails
     /// due to deserialization / verification still leaves the read in the set.
-    pub fn record_pending_loading(&mut self, id: ArenaRef<'guard, ModuleId>) -> Result<()> {
+    pub fn record_pending_loading(&mut self, id: ArenaRef<'guard, ModuleId>) -> LoaderResult<()> {
         if self.inner.insert(id, ModuleRead::Pending).is_some() {
-            bail!("Invariant violated: there should be no entry when marked as pending")
+            invariant_violation!(EntryAlreadyExists);
         }
         Ok(())
     }
@@ -96,7 +96,7 @@ impl<'guard> ModuleReadSet<'guard> {
         &mut self,
         id: ArenaRef<'guard, ModuleId>,
         module: &'guard LoadedModule,
-    ) -> Result<()> {
+    ) -> LoaderResult<()> {
         let read = ModuleRead::Loaded {
             module,
             state: ModuleState::Unmetered,
@@ -104,7 +104,7 @@ impl<'guard> ModuleReadSet<'guard> {
         let prev = self.inner.insert(id, read);
         match prev {
             Some(ModuleRead::Pending) => Ok(()),
-            Some(ModuleRead::Loaded { .. }) | None => bail!("Module must be recorded as pending"),
+            Some(ModuleRead::Loaded { .. }) | None => invariant_violation!(ModuleExpectedPending),
         }
     }
 
@@ -113,7 +113,7 @@ impl<'guard> ModuleReadSet<'guard> {
         &mut self,
         id: ArenaRef<'guard, ModuleId>,
         module: &'guard LoadedModule,
-    ) -> Result<()> {
+    ) -> LoaderResult<()> {
         let read = ModuleRead::Loaded {
             module,
             state: ModuleState::Metered,
@@ -121,7 +121,7 @@ impl<'guard> ModuleReadSet<'guard> {
         let prev = self.inner.insert(id, read);
         match prev {
             Some(ModuleRead::Pending) => Ok(()),
-            Some(ModuleRead::Loaded { .. }) | None => bail!("Module must be recorded as pending"),
+            Some(ModuleRead::Loaded { .. }) | None => invariant_violation!(ModuleExpectedPending),
         }
     }
 
@@ -131,7 +131,7 @@ impl<'guard> ModuleReadSet<'guard> {
         &mut self,
         id: ArenaRef<'guard, ModuleId>,
         module: &'guard LoadedModule,
-    ) -> Result<()> {
+    ) -> LoaderResult<()> {
         match self.inner.get(&id) {
             Some(ModuleRead::Pending) => {
                 self.inner.insert(id, ModuleRead::Loaded {
@@ -140,13 +140,13 @@ impl<'guard> ModuleReadSet<'guard> {
                 });
                 Ok(())
             },
-            None => bail!("Module must be recorded as pending"),
-            Some(ModuleRead::Loaded { .. }) => bail!("Module is already loaded"),
+            None => invariant_violation!(ModuleExpectedPending),
+            Some(ModuleRead::Loaded { .. }) => invariant_violation!(ModuleAlreadyLoaded),
         }
     }
 
     /// Transitions an existing loaded module from unmetered to metered state.
-    pub fn mark_metered(&mut self, id: ArenaRef<'guard, ModuleId>) -> Result<()> {
+    pub fn mark_metered(&mut self, id: ArenaRef<'guard, ModuleId>) -> LoaderResult<()> {
         match self.inner.get_mut(&id) {
             Some(ModuleRead::Loaded { state, .. }) => match state {
                 ModuleState::Unmetered => {
@@ -154,26 +154,26 @@ impl<'guard> ModuleReadSet<'guard> {
                     Ok(())
                 },
                 ModuleState::Metered | ModuleState::ReadyForLowering => {
-                    bail!("Module is already metered")
+                    invariant_violation!(ModuleAlreadyMetered);
                 },
             },
-            Some(ModuleRead::Pending) | None => bail!("Module must be loaded"),
+            Some(ModuleRead::Pending) | None => invariant_violation!(ModuleExpectedLoaded),
         }
     }
 
     /// Records that existing loaded module has satisfied the lowering
     /// requirements (i.e., its mandatory dependency set has been computed).
-    pub fn mark_ready_for_lowering(&mut self, id: ArenaRef<'guard, ModuleId>) -> Result<()> {
+    pub fn mark_ready_for_lowering(&mut self, id: ArenaRef<'guard, ModuleId>) -> LoaderResult<()> {
         match self.inner.get_mut(&id) {
             Some(ModuleRead::Loaded { state, .. }) => match state {
-                ModuleState::Unmetered => bail!("Module must be metered"),
-                ModuleState::ReadyForLowering => bail!("Module is already ready for lowering"),
+                ModuleState::Unmetered => invariant_violation!(ModuleExpectedMetered),
+                ModuleState::ReadyForLowering => invariant_violation!(ModuleAlreadyReady),
                 ModuleState::Metered => {
                     *state = ModuleState::ReadyForLowering;
                     Ok(())
                 },
             },
-            Some(ModuleRead::Pending) | None => bail!("Module must be at least loaded"),
+            Some(ModuleRead::Pending) | None => invariant_violation!(ModuleExpectedAtLeastLoaded),
         }
     }
 

--- a/third_party/move/mono-move/programs/tests/bst.rs
+++ b/third_party/move/mono-move/programs/tests/bst.rs
@@ -120,12 +120,14 @@ fn native_insert_remove_sequence() {
 
 #[cfg(feature = "micro-op")]
 mod micro_op {
-    use mono_move_core::{ExecutionContext, Function};
+    use mono_move_core::Function;
     use mono_move_programs::bst::{
         generate_ops, micro_op_bst, native_run_ops_with_results, FN_GET, FN_INSERT, FN_NEW,
         FN_REMOVE,
     };
-    use mono_move_runtime::{DescriptorProvider, InterpreterContext, LocalRuntimeContext};
+    use mono_move_runtime::{
+        DescriptorProvider, ExecutionContext, InterpreterContext, LocalRuntimeContext,
+    };
 
     fn bst_new<T: ExecutionContext + DescriptorProvider>(
         ctx: &mut InterpreterContext<'_, T>,

--- a/third_party/move/mono-move/runtime/Cargo.toml
+++ b/third_party/move/mono-move/runtime/Cargo.toml
@@ -17,6 +17,7 @@ anyhow = { workspace = true }
 mono-move-alloc = { workspace = true }
 mono-move-core = { workspace = true }
 mono-move-gas = { workspace = true }
+mono-move-loader = { workspace = true }
 move-core-types = { workspace = true }
 rand = { workspace = true }
 thiserror = { workspace = true }

--- a/third_party/move/mono-move/runtime/src/error.rs
+++ b/third_party/move/mono-move/runtime/src/error.rs
@@ -5,6 +5,7 @@
 
 use mono_move_core::{ExecutionErrorKind, IntTy, IntoExecutionError};
 use mono_move_gas::GasExhaustedError;
+use mono_move_loader::LoaderError;
 use std::fmt;
 use thiserror::Error;
 
@@ -15,9 +16,8 @@ pub enum RuntimeError {
     #[error(transparent)]
     GasExhausted(#[from] GasExhaustedError),
 
-    // TODO: replace with a typed loader error once the loader has one.
     #[error(transparent)]
-    Loader(anyhow::Error),
+    Loader(#[from] LoaderError),
 
     #[error("{op}.{ty}: overflow")]
     ArithmeticOverflow { op: ArithOp, ty: IntTy },
@@ -80,8 +80,7 @@ impl IntoExecutionError for RuntimeError {
         match self {
             GasExhausted(_) => ExecutionErrorKind::OutOfGas,
 
-            // TODO: delegate to the loader's typed error once it has one.
-            Loader(_) => ExecutionErrorKind::Placeholder,
+            Loader(e) => e.kind(),
 
             ArithmeticOverflow { .. }
             | ArithmeticUnderflow { .. }

--- a/third_party/move/mono-move/runtime/src/execution_context.rs
+++ b/third_party/move/mono-move/runtime/src/execution_context.rs
@@ -4,12 +4,13 @@
 //! Defines the [`ExecutionContext`] trait the interpreter calls into,
 //! and a minimal [`LocalExecutionContext`] impl for tests and benchmarks.
 
-use crate::{
+use mono_move_core::{
     interner::{InternedIdentifier, InternedModuleId},
     types::InternedTypeList,
     FunctionPtr,
 };
 use mono_move_gas::{GasMeter, NoOpGasMeter, SimpleGasMeter};
+use mono_move_loader::LoaderResult;
 
 /// Runtime context consulted by the interpreter during execution: gas
 /// charging and cross-module function resolution.
@@ -25,7 +26,7 @@ pub trait ExecutionContext {
         module_id: InternedModuleId,
         name: InternedIdentifier,
         ty_args: InternedTypeList,
-    ) -> anyhow::Result<FunctionPtr>;
+    ) -> LoaderResult<FunctionPtr>;
 }
 
 /// A [`ExecutionContext`] that supports only local execution within a
@@ -72,7 +73,7 @@ impl<G: GasMeter> ExecutionContext for LocalExecutionContext<G> {
         _module_id: InternedModuleId,
         _name: InternedIdentifier,
         _ty_args: InternedTypeList,
-    ) -> anyhow::Result<FunctionPtr> {
-        anyhow::bail!("LocalExecutionContext: load_function not supported")
+    ) -> LoaderResult<FunctionPtr> {
+        panic!("LocalExecutionContext: load_function not supported")
     }
 }

--- a/third_party/move/mono-move/runtime/src/interpreter.rs
+++ b/third_party/move/mono-move/runtime/src/interpreter.rs
@@ -21,14 +21,15 @@ use crate::{
         META_SAVED_FP_OFFSET, META_SAVED_FUNC_PTR_OFFSET, META_SAVED_PC_OFFSET, VEC_DATA_OFFSET,
         VEC_LENGTH_OFFSET,
     },
+    ExecutionContext,
 };
 use mono_move_core::{
-    CallClosureOp, ClosureFuncRef, DescriptorId, DescriptorProvider, ExecutionContext, FrameOffset,
-    Function, IntBinaryOp, IntNegateOp, IntOperand, IntShiftOp, IntTy, MicroOp, PackClosureOp,
-    ShiftOperand, CAPTURED_DATA_TAG_MATERIALIZED, CAPTURED_DATA_TAG_OFFSET,
-    CAPTURED_DATA_VALUES_OFFSET, CLOSURE_CAPTURED_DATA_PTR_OFFSET, CLOSURE_DESCRIPTOR_ID,
-    CLOSURE_FUNC_REF_OFFSET, CLOSURE_MASK_OFFSET, FRAME_METADATA_SIZE, FUNC_REF_PAYLOAD_OFFSET,
-    FUNC_REF_TAG_OFFSET, FUNC_REF_TAG_RESOLVED, MAX_ALIGN, OBJECT_HEADER_SIZE,
+    CallClosureOp, ClosureFuncRef, DescriptorId, DescriptorProvider, FrameOffset, Function,
+    IntBinaryOp, IntNegateOp, IntOperand, IntShiftOp, IntTy, MicroOp, PackClosureOp, ShiftOperand,
+    CAPTURED_DATA_TAG_MATERIALIZED, CAPTURED_DATA_TAG_OFFSET, CAPTURED_DATA_VALUES_OFFSET,
+    CLOSURE_CAPTURED_DATA_PTR_OFFSET, CLOSURE_DESCRIPTOR_ID, CLOSURE_FUNC_REF_OFFSET,
+    CLOSURE_MASK_OFFSET, FRAME_METADATA_SIZE, FUNC_REF_PAYLOAD_OFFSET, FUNC_REF_TAG_OFFSET,
+    FUNC_REF_TAG_RESOLVED, MAX_ALIGN, OBJECT_HEADER_SIZE,
 };
 use mono_move_gas::GasMeter;
 use move_core_types::int256::{I256, U256};

--- a/third_party/move/mono-move/runtime/src/lib.rs
+++ b/third_party/move/mono-move/runtime/src/lib.rs
@@ -4,14 +4,17 @@
 //! MonoVM runtime implementation.
 
 mod error;
+mod execution_context;
 pub(crate) mod heap;
 mod interpreter;
 mod local_runtime_context;
 pub(crate) mod memory;
+mod transaction_context;
 mod types;
 mod verifier;
 
 pub use error::{RuntimeError, RuntimeStatus};
+pub use execution_context::{ExecutionContext, LocalExecutionContext};
 pub use heap::pinned_roots::{PinGuard, PinnedRoots};
 pub use interpreter::InterpreterContext;
 pub use local_runtime_context::LocalRuntimeContext;
@@ -22,5 +25,6 @@ pub use mono_move_core::{
     DescriptorProvider, ObjectDescriptor, ObjectDescriptorTable, CLOSURE_DESCRIPTOR_ID,
     TRIVIAL_DESCRIPTOR_ID,
 };
+pub use transaction_context::TransactionContext;
 pub use types::{StepResult, VEC_DATA_OFFSET, VEC_LENGTH_OFFSET};
 pub use verifier::{verify_function, verify_program, VerificationError};

--- a/third_party/move/mono-move/runtime/src/local_runtime_context.rs
+++ b/third_party/move/mono-move/runtime/src/local_runtime_context.rs
@@ -4,13 +4,14 @@
 //! Minimal [`ExecutionContext`] + [`DescriptorProvider`] impl for tests
 //! and benchmarks that don't go through the full loader stack.
 
+use crate::{ExecutionContext, LocalExecutionContext};
 use mono_move_core::{
     interner::{InternedIdentifier, InternedModuleId},
     types::InternedTypeList,
-    DescriptorId, DescriptorProvider, ExecutionContext, FunctionPtr, LocalExecutionContext,
-    ObjectDescriptor, ObjectDescriptorTable,
+    DescriptorId, DescriptorProvider, FunctionPtr, ObjectDescriptor, ObjectDescriptorTable,
 };
 use mono_move_gas::{GasMeter, NoOpGasMeter, SimpleGasMeter};
+use mono_move_loader::LoaderResult;
 
 /// Combines a [`LocalExecutionContext`] with an owned
 /// [`ObjectDescriptorTable`]. Used by tests and benches that need vector/object
@@ -81,7 +82,7 @@ impl<G: GasMeter> ExecutionContext for LocalRuntimeContext<G> {
         module_id: InternedModuleId,
         name: InternedIdentifier,
         ty_args: InternedTypeList,
-    ) -> anyhow::Result<FunctionPtr> {
+    ) -> LoaderResult<FunctionPtr> {
         self.inner.load_function(module_id, name, ty_args)
     }
 }

--- a/third_party/move/mono-move/runtime/src/transaction_context.rs
+++ b/third_party/move/mono-move/runtime/src/transaction_context.rs
@@ -3,14 +3,17 @@
 
 //! Transaction context that wires the [`Loader`] into the interpreter's
 //! cross-module dispatch path.
+//
+// TODO: move out of the runtime once a layer above it exists.
 
-use crate::{read_set::ModuleReadSet, Loader};
+use crate::ExecutionContext;
 use mono_move_core::{
     interner::{InternedIdentifier, InternedModuleId},
     types::InternedTypeList,
-    DescriptorId, DescriptorProvider, ExecutionContext, FunctionPtr, ObjectDescriptor,
+    DescriptorId, DescriptorProvider, FunctionPtr, ObjectDescriptor,
 };
 use mono_move_gas::GasMeter;
+use mono_move_loader::{Loader, LoaderResult, ModuleReadSet};
 
 /// Per-transaction execution context. Maintains per-transaction state
 /// (gas meter, read-set of loaded modules) and serves the interpreter's
@@ -48,7 +51,7 @@ impl<'guard, 'ctx, G: GasMeter> ExecutionContext for TransactionContext<'guard, 
         module_id: InternedModuleId,
         name: InternedIdentifier,
         ty_args: InternedTypeList,
-    ) -> anyhow::Result<FunctionPtr> {
+    ) -> LoaderResult<FunctionPtr> {
         self.loader.load_function(
             &mut self.read_set,
             &mut self.gas_meter,

--- a/third_party/move/mono-move/testsuite/src/runner.rs
+++ b/third_party/move/mono-move/testsuite/src/runner.rs
@@ -12,11 +12,11 @@ use crate::{
     print_sections,
 };
 use anyhow::{anyhow, bail};
-use mono_move_core::{types::EMPTY_TYPE_LIST, ExecutionContext};
+use mono_move_core::types::EMPTY_TYPE_LIST;
 use mono_move_gas::SimpleGasMeter;
 use mono_move_global_context::{ExecutionGuard, GlobalContext};
-use mono_move_loader::{Loader, LoadingPolicy, LoweringPolicy, TransactionContext};
-use mono_move_runtime::{InterpreterContext, RuntimeStatus};
+use mono_move_loader::{Loader, LoadingPolicy, LoweringPolicy};
+use mono_move_runtime::{ExecutionContext, InterpreterContext, RuntimeStatus, TransactionContext};
 use move_core_types::{
     account_address::AccountAddress,
     identifier::IdentStr,

--- a/third_party/move/mono-move/testsuite/tests/cross_module_lazy_load.rs
+++ b/third_party/move/mono-move/testsuite/tests/cross_module_lazy_load.rs
@@ -9,11 +9,11 @@
 //! `CallIndirect` at runtime lazily loads it through the transaction
 //! context.
 
-use mono_move_core::{types::EMPTY_TYPE_LIST, ExecutionContext};
+use mono_move_core::types::EMPTY_TYPE_LIST;
 use mono_move_gas::SimpleGasMeter;
 use mono_move_global_context::GlobalContext;
-use mono_move_loader::{Loader, LoadingPolicy, LoweringPolicy, TransactionContext};
-use mono_move_runtime::InterpreterContext;
+use mono_move_loader::{Loader, LoadingPolicy, LoweringPolicy};
+use mono_move_runtime::{ExecutionContext, InterpreterContext, TransactionContext};
 use mono_move_testsuite::InMemoryModuleProvider;
 use move_core_types::{account_address::AccountAddress, ident_str};
 

--- a/third_party/move/mono-move/testsuite/tests/gas_test.rs
+++ b/third_party/move/mono-move/testsuite/tests/gas_test.rs
@@ -3,11 +3,13 @@
 
 //! Integration tests for gas metering through the full pipeline.
 
-use mono_move_core::{types::EMPTY_TYPE_LIST, ExecutionContext};
+use mono_move_core::types::EMPTY_TYPE_LIST;
 use mono_move_gas::SimpleGasMeter;
 use mono_move_global_context::GlobalContext;
-use mono_move_loader::{Loader, LoadingPolicy, LoweringPolicy, ModuleReadSet, TransactionContext};
-use mono_move_runtime::{InterpreterContext, LocalRuntimeContext, RuntimeError};
+use mono_move_loader::{Loader, LoadingPolicy, LoweringPolicy, ModuleReadSet};
+use mono_move_runtime::{
+    ExecutionContext, InterpreterContext, LocalRuntimeContext, RuntimeError, TransactionContext,
+};
 use mono_move_testsuite::InMemoryModuleProvider;
 use move_core_types::{account_address::AccountAddress, ident_str};
 


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

Introduces `LoaderError` and `LoaderInvariantViolation` in `mono-move-loader`. Variants cover the loader's error surface (`ModuleNotFound`, `FunctionNotFound`, gas exhaustion, read-set state-machine invariants, cache invariants) plus pass-through variants for upstream subsystems that still use `anyhow` (deserializer, verifier, specializer, `ModuleProvider`, global context). All `bail!`/`anyhow!` sites inside the loader now use either typed variants or the `invariant_violation!` macro.

**Other changes**:

- **`ExecutionContext` trait moves to `mono-move-runtime`.** Trait method `load_function` returns `LoaderResult<FunctionPtr>` directly. The `TransactionContext` struct also moves to runtime, alongside its `ExecutionContext` impl. New dep: `mono-move-runtime → mono-move-loader`.
- **`mono-move-global-context` cleanups:** `as_lazy()` returns `Option`, `get_function_slot` returns `Option`, `get_function_ir` returns `Option<Option<&FunctionIR>>`. The loader synthesizes typed errors at the call sites. The unused `get_function_ptr` wrapper was removed.

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how module/function resolution and read-set invariant failures surface through the VM execution path, affecting transaction failure categorization; behavior is largely a refactor but touches cross-module dispatch and linking outcomes.
> 
> **Overview**
> Introduces **`LoaderError`** / **`LoaderInvariantViolation`** in `mono-move-loader`, replacing `anyhow`/`bail!` across module load, read-set transitions, and function resolution. Missing modules/functions map to **`ExecutionErrorKind::LinkingError`** (new public category); read-set and cache bugs use **`invariant_violation!`** instead of panics or opaque errors.
> 
> **`LoadedModule`** lookups now return **`Option`** / nested **`Option`**; the loader builds **`ModuleNotFound`**, **`FunctionNotFound`**, etc. at call sites. **`ExecutionContext`** and **`TransactionContext`** move to **`mono-move-runtime`**; **`load_function`** returns **`LoaderResult`**, and **`RuntimeError::Loader`** forwards **`IntoExecutionError`** so interpreter failures surface loader categories correctly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26fc1254406b12bc5e8a97bc9307e5ad700a6715. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->