### PR TITLE
[cherry-pick] [vm] Make `MoveTypeLayout` trait impls DAG-safe

### DIFF
--- a/aptos-move/aptos-aggregator/src/types.rs
+++ b/aptos-move/aptos-aggregator/src/types.rs
@@ -161,13 +161,9 @@ impl DelayedFieldValue {
             (Derived(bytes), layout) if is_derived_string_struct_layout(layout) => {
                 bytes_and_width_to_derived_string_struct(bytes, width as usize)?
             },
-            (value, layout) => {
-                return Err(
-                    PartialVMError::new(StatusCode::VM_EXTENSION_ERROR).with_message(format!(
-                        "Failed to convert {:?} into Move value with {} layout",
-                        value, layout
-                    )),
-                )
+            (value, _layout) => {
+                return Err(PartialVMError::new(StatusCode::VM_EXTENSION_ERROR)
+                    .with_message(format!("Failed to convert {:?} into Move value", value)))
             },
         })
     }
@@ -213,8 +209,8 @@ impl TryFromMoveValue for DelayedFieldValue {
             _ => {
                 return Err(
                     PartialVMError::new(StatusCode::VM_EXTENSION_ERROR).with_message(format!(
-                        "Failed to convert Move value {:?} with {} layout into AggregatorValue",
-                        value, layout
+                        "Failed to convert Move value {} into AggregatorValue",
+                        value
                     )),
                 )
             },

--- a/aptos-move/e2e-move-tests/src/tests/function_value_layout_dag.rs
+++ b/aptos-move/e2e-move-tests/src/tests/function_value_layout_dag.rs
@@ -1,0 +1,97 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Regression test for captured-closure-layout DAG blow-up during BCS serialization.
+//!
+//! Publishes a doubling-struct chain whose layout is a DAG and packs a persistent
+//! closure that captures it. Checks that small N is accepted and large N is rejected.
+
+use crate::{assert_success, tests::common, MoveHarness};
+use aptos_framework::BuildOptions;
+use aptos_package_builder::PackageBuilder;
+use aptos_types::{
+    account_address::AccountAddress,
+    transaction::{ExecutionStatus, TransactionStatus},
+};
+use move_core_types::vm_status::StatusCode;
+
+fn gen_source(addr: &str, n: usize) -> String {
+    assert!(n >= 1);
+    let mut s = String::new();
+    s.push_str(&format!("module {}::test {{\n", addr));
+    s.push_str("    struct S0 has copy, drop, store { v: u8 }\n");
+    for i in 0..n {
+        s.push_str(&format!(
+            "    struct S{} has copy, drop, store {{ l: S{}, r: S{} }}\n",
+            i + 1,
+            i,
+            i
+        ));
+    }
+    s.push_str("    struct Work has copy, drop, store, key { bar: || }\n");
+    s.push_str(&format!(
+        "    #[persistent] fun consumer(_o: vector<S{}>) {{}}\n",
+        n
+    ));
+    s.push_str(&format!(
+        "    entry fun store_closure(s: &signer) {{\n        \
+                 let o: vector<S{}> = vector[];\n        \
+                 move_to(s, Work {{ bar: || consumer(o) }})\n    \
+             }}\n",
+        n
+    ));
+    s.push_str("}\n");
+    s
+}
+
+fn run_for(n: usize) -> TransactionStatus {
+    let addr = "0xcafe";
+    let src = gen_source(addr, n);
+
+    let mut builder = PackageBuilder::new("Test");
+    builder.add_source("test.move", &src);
+    builder.add_local_dep(
+        "MoveStdlib",
+        &common::framework_dir_path("move-stdlib").to_string_lossy(),
+    );
+    let path = builder.write_to_temp().unwrap();
+
+    let mut h = MoveHarness::new();
+    let acc = h.new_account_at(AccountAddress::from_hex_literal(addr).unwrap());
+    assert_success!(h.publish_package_with_options(
+        &acc,
+        path.path(),
+        BuildOptions::move_2().set_latest_language(),
+    ));
+
+    let txn = h.create_entry_function(
+        &acc,
+        str::parse(&format!("{}::test::store_closure", addr)).unwrap(),
+        vec![],
+        vec![],
+    );
+    h.run(txn)
+}
+
+/// Expanded layout has 3*2^10 - 1 = 3071 nodes, under the 4096 cap.
+#[test]
+fn captured_layout_dag_under_cap_succeeds() {
+    let status = run_for(10);
+    assert_success!(status);
+}
+
+/// Expanded layout has 3*2^11 - 1 = 6143 nodes, over the 4096 cap.
+#[test]
+fn captured_layout_dag_over_cap_rejected() {
+    let status = run_for(11);
+    assert!(
+        matches!(
+            status,
+            TransactionStatus::Keep(ExecutionStatus::MiscellaneousError(Some(
+                StatusCode::VALUE_SERIALIZATION_ERROR
+            )))
+        ),
+        "unexpected status: {:?}",
+        status
+    );
+}

--- a/aptos-move/e2e-move-tests/src/tests/mod.rs
+++ b/aptos-move/e2e-move-tests/src/tests/mod.rs
@@ -28,6 +28,7 @@ mod fee_payer;
 mod friends;
 mod function_caches;
 mod function_value_depth;
+mod function_value_layout_dag;
 mod function_values;
 mod fungible_asset;
 mod fv_as_table_keys;

--- a/third_party/move/move-core/types/src/function.rs
+++ b/third_party/move/move-core/types/src/function.rs
@@ -233,7 +233,7 @@ mod closure_mask_tests {
 //===========================================================================================
 
 /// Function type layout, with arguments and result types.
-#[derive(Debug, Clone, Hash, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[cfg_attr(
     any(test, feature = "fuzzing"),
     derive(arbitrary::Arbitrary, dearbitrary::Dearbitrary)

--- a/third_party/move/move-core/types/src/value.rs
+++ b/third_party/move/move-core/types/src/value.rs
@@ -24,6 +24,7 @@ use serde::{
     Deserialize, Serialize,
 };
 use std::{
+    collections::{HashMap, HashSet},
     convert::TryInto,
     fmt::{self, Debug},
     sync::Arc,
@@ -133,7 +134,7 @@ pub enum MoveValue {
 }
 
 /// A layout associated with a named field
-#[derive(Debug, Clone, Hash, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(
     any(test, feature = "fuzzing"),
     derive(arbitrary::Arbitrary, dearbitrary::Dearbitrary)
@@ -149,7 +150,7 @@ impl MoveFieldLayout {
     }
 }
 
-#[derive(Debug, Clone, Hash, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(
     any(test, feature = "fuzzing"),
     derive(arbitrary::Arbitrary, dearbitrary::Dearbitrary)
@@ -159,7 +160,7 @@ pub struct MoveVariantLayout {
     pub fields: Vec<MoveFieldLayout>,
 }
 
-#[derive(Debug, Clone, Hash, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(
     any(test, feature = "fuzzing"),
     derive(arbitrary::Arbitrary, dearbitrary::Dearbitrary)
@@ -186,7 +187,7 @@ pub enum MoveStructLayout {
 }
 
 /// Used to distinguish between aggregators ans snapshots.
-#[derive(Debug, Clone, Hash, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[cfg_attr(
     any(test, feature = "fuzzing"),
     derive(arbitrary::Arbitrary, dearbitrary::Dearbitrary)
@@ -222,7 +223,7 @@ impl IdentifierMappingKind {
     }
 }
 
-#[derive(Debug, Clone, Hash, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(
     any(test, feature = "fuzzing"),
     derive(arbitrary::Arbitrary, dearbitrary::Dearbitrary)
@@ -280,11 +281,266 @@ pub enum MoveTypeLayout {
     I256,
 }
 
+/// Limit on the number of nodes a [`MoveTypeLayout`] may unfold to when serialized.
+pub const MAX_LAYOUT_NODES: u64 = 4096;
+
+/// Returns an error if `layout` unfolds to more than [`MAX_LAYOUT_NODES`] nodes.
+/// Use this before serializing a layout sourced from untrusted input to prevent
+/// pathological DAGs from expanding into multi-megabyte BCS output.
+pub fn check_layout_within_bounds<E: serde::ser::Error>(layout: &MoveTypeLayout) -> Result<(), E> {
+    let count = layout.unfolded_node_count();
+    if count > MAX_LAYOUT_NODES {
+        return Err(E::custom(format!(
+            "layout unfolds to {} nodes, exceeding the maximum of {}",
+            count, MAX_LAYOUT_NODES
+        )));
+    }
+    Ok(())
+}
+
 impl MoveTypeLayout {
     /// Creates a `MoveTypeLayout::Struct` wrapping the given layout in an `Arc`.
     pub fn new_struct(layout: MoveStructLayout) -> Self {
         Self::Struct(Arc::new(layout))
     }
+
+    /// Counts every node in the layout; shared `Arc<MoveStructLayout>`
+    /// occurrences are not deduped, each contributing its full subtree.
+    pub fn unfolded_node_count(&self) -> u64 {
+        layout_unfolded_node_count(self, &mut LayoutCountCache::new())
+    }
+}
+
+type LayoutCountCache = HashMap<*const MoveStructLayout, u64>;
+
+fn layout_unfolded_node_count(layout: &MoveTypeLayout, cache: &mut LayoutCountCache) -> u64 {
+    use MoveTypeLayout::*;
+    match layout {
+        Bool | U8 | U16 | U32 | U64 | U128 | U256 | I8 | I16 | I32 | I64 | I128 | I256
+        | Address | Signer | Function => 1,
+        Vector(inner) | Native(_, inner) => {
+            1u64.saturating_add(layout_unfolded_node_count(inner, cache))
+        },
+        Struct(inner) => {
+            let ptr = Arc::as_ptr(inner);
+            match cache.get(&ptr) {
+                Some(cached) => *cached,
+                None => {
+                    let count =
+                        1u64.saturating_add(struct_layout_unfolded_node_count(inner, cache));
+                    cache.insert(ptr, count);
+                    count
+                },
+            }
+        },
+    }
+}
+
+fn struct_layout_unfolded_node_count(
+    layout: &MoveStructLayout,
+    cache: &mut LayoutCountCache,
+) -> u64 {
+    use MoveStructLayout::*;
+    match layout {
+        Runtime(fields) => fields.iter().fold(0u64, |acc, l| {
+            acc.saturating_add(layout_unfolded_node_count(l, cache))
+        }),
+        RuntimeVariants(variants) => variants.iter().flat_map(|v| v.iter()).fold(0u64, |acc, l| {
+            acc.saturating_add(layout_unfolded_node_count(l, cache))
+        }),
+        WithFields(fields) | WithTypes { fields, .. } => fields.iter().fold(0u64, |acc, f| {
+            acc.saturating_add(layout_unfolded_node_count(&f.layout, cache))
+        }),
+        WithVariants { variants, .. } => variants
+            .iter()
+            .flat_map(|v| v.fields.iter())
+            .fold(0u64, |acc, f| {
+                acc.saturating_add(layout_unfolded_node_count(&f.layout, cache))
+            }),
+    }
+}
+
+// Equality on the layout DAG with pointer-identity memoization on
+// `Arc<MoveStructLayout>`. A derived `PartialEq` would compare the inner
+// `MoveStructLayout` once per occurrence of a shared `Arc`, expanding the DAG
+// into a tree; the impl below short-circuits on `Arc::ptr_eq` and caches
+// structurally equal pairs so the work is `O(number of unique node pairs)`.
+type LayoutEqCache = HashSet<(*const MoveStructLayout, *const MoveStructLayout)>;
+
+impl PartialEq for MoveTypeLayout {
+    fn eq(&self, other: &Self) -> bool {
+        layout_eq(self, other, &mut LayoutEqCache::new())
+    }
+}
+
+impl Eq for MoveTypeLayout {}
+
+impl PartialEq for MoveStructLayout {
+    fn eq(&self, other: &Self) -> bool {
+        struct_layout_eq(self, other, &mut LayoutEqCache::new())
+    }
+}
+
+impl Eq for MoveStructLayout {}
+
+impl PartialEq for MoveFieldLayout {
+    fn eq(&self, other: &Self) -> bool {
+        field_layout_eq(self, other, &mut LayoutEqCache::new())
+    }
+}
+
+impl Eq for MoveFieldLayout {}
+
+impl PartialEq for MoveVariantLayout {
+    fn eq(&self, other: &Self) -> bool {
+        variant_layout_eq(self, other, &mut LayoutEqCache::new())
+    }
+}
+
+impl Eq for MoveVariantLayout {}
+
+fn layout_eq(a: &MoveTypeLayout, b: &MoveTypeLayout, cache: &mut LayoutEqCache) -> bool {
+    use MoveTypeLayout::*;
+    match (a, b) {
+        (Bool, Bool)
+        | (Address, Address)
+        | (Signer, Signer)
+        | (Function, Function)
+        | (U8, U8)
+        | (U16, U16)
+        | (U32, U32)
+        | (U64, U64)
+        | (U128, U128)
+        | (U256, U256)
+        | (I8, I8)
+        | (I16, I16)
+        | (I32, I32)
+        | (I64, I64)
+        | (I128, I128)
+        | (I256, I256) => true,
+        (Vector(x), Vector(y)) => layout_eq(x, y, cache),
+        (Native(ka, x), Native(kb, y)) => ka == kb && layout_eq(x, y, cache),
+        (Struct(x), Struct(y)) => arc_struct_layout_eq(x, y, cache),
+        // Listed exhaustively so adding a new variant forces an update here.
+        (Bool, _)
+        | (Address, _)
+        | (Signer, _)
+        | (Function, _)
+        | (U8, _)
+        | (U16, _)
+        | (U32, _)
+        | (U64, _)
+        | (U128, _)
+        | (U256, _)
+        | (I8, _)
+        | (I16, _)
+        | (I32, _)
+        | (I64, _)
+        | (I128, _)
+        | (I256, _)
+        | (Vector(_), _)
+        | (Native(_, _), _)
+        | (Struct(_), _) => false,
+    }
+}
+
+fn arc_struct_layout_eq(
+    a: &Arc<MoveStructLayout>,
+    b: &Arc<MoveStructLayout>,
+    cache: &mut LayoutEqCache,
+) -> bool {
+    if Arc::ptr_eq(a, b) {
+        return true;
+    }
+    let key = {
+        let pa = Arc::as_ptr(a);
+        let pb = Arc::as_ptr(b);
+        if pa <= pb {
+            (pa, pb)
+        } else {
+            (pb, pa)
+        }
+    };
+    if cache.contains(&key) {
+        return true;
+    }
+    let result = struct_layout_eq(a, b, cache);
+    if result {
+        cache.insert(key);
+    }
+    result
+}
+
+fn struct_layout_eq(a: &MoveStructLayout, b: &MoveStructLayout, cache: &mut LayoutEqCache) -> bool {
+    use MoveStructLayout::*;
+    match (a, b) {
+        (Runtime(xs), Runtime(ys)) => {
+            xs.len() == ys.len() && xs.iter().zip(ys).all(|(x, y)| layout_eq(x, y, cache))
+        },
+        (RuntimeVariants(xs), RuntimeVariants(ys)) => {
+            xs.len() == ys.len()
+                && xs.iter().zip(ys).all(|(vx, vy)| {
+                    vx.len() == vy.len() && vx.iter().zip(vy).all(|(x, y)| layout_eq(x, y, cache))
+                })
+        },
+        (WithFields(xs), WithFields(ys)) => {
+            xs.len() == ys.len() && xs.iter().zip(ys).all(|(x, y)| field_layout_eq(x, y, cache))
+        },
+        (
+            WithTypes {
+                type_: ta,
+                fields: fa,
+            },
+            WithTypes {
+                type_: tb,
+                fields: fb,
+            },
+        ) => {
+            ta == tb
+                && fa.len() == fb.len()
+                && fa.iter().zip(fb).all(|(x, y)| field_layout_eq(x, y, cache))
+        },
+        (
+            WithVariants {
+                type_: ta,
+                variants: va,
+            },
+            WithVariants {
+                type_: tb,
+                variants: vb,
+            },
+        ) => {
+            ta == tb
+                && va.len() == vb.len()
+                && va
+                    .iter()
+                    .zip(vb)
+                    .all(|(x, y)| variant_layout_eq(x, y, cache))
+        },
+        // Listed exhaustively so adding a new variant forces an update here.
+        (Runtime(_), _)
+        | (RuntimeVariants(_), _)
+        | (WithFields(_), _)
+        | (WithTypes { .. }, _)
+        | (WithVariants { .. }, _) => false,
+    }
+}
+
+fn field_layout_eq(a: &MoveFieldLayout, b: &MoveFieldLayout, cache: &mut LayoutEqCache) -> bool {
+    a.name == b.name && layout_eq(&a.layout, &b.layout, cache)
+}
+
+fn variant_layout_eq(
+    a: &MoveVariantLayout,
+    b: &MoveVariantLayout,
+    cache: &mut LayoutEqCache,
+) -> bool {
+    a.name == b.name
+        && a.fields.len() == b.fields.len()
+        && a.fields
+            .iter()
+            .zip(&b.fields)
+            .all(|(x, y)| field_layout_eq(x, y, cache))
 }
 
 impl MoveValue {
@@ -909,84 +1165,6 @@ impl serde::Serialize for MoveStruct {
     }
 }
 
-impl fmt::Display for MoveFieldLayout {
-    fn fmt(&self, f: &mut fmt::Formatter) -> std::fmt::Result {
-        write!(f, "{}: {}", self.name, self.layout)
-    }
-}
-
-impl fmt::Display for MoveTypeLayout {
-    fn fmt(&self, f: &mut fmt::Formatter) -> std::fmt::Result {
-        use MoveTypeLayout::*;
-        match self {
-            Bool => write!(f, "bool"),
-            U8 => write!(f, "u8"),
-            U16 => write!(f, "u16"),
-            U32 => write!(f, "u32"),
-            U64 => write!(f, "u64"),
-            U128 => write!(f, "u128"),
-            U256 => write!(f, "u256"),
-            I8 => write!(f, "i8"),
-            I16 => write!(f, "i16"),
-            I32 => write!(f, "i32"),
-            I64 => write!(f, "i64"),
-            I128 => write!(f, "i128"),
-            I256 => write!(f, "i256"),
-            Address => write!(f, "address"),
-            Vector(typ) => write!(f, "vector<{}>", typ),
-            Struct(s) => fmt::Display::fmt(s.as_ref(), f),
-            Function => write!(f, "function"),
-            Signer => write!(f, "signer"),
-            // TODO[agg_v2](cleanup): consider printing the tag as well.
-            Native(_, typ) => write!(f, "native<{}>", typ),
-        }
-    }
-}
-
-impl fmt::Display for MoveStructLayout {
-    fn fmt(&self, f: &mut fmt::Formatter) -> std::fmt::Result {
-        write!(f, "{{ ")?;
-        match self {
-            Self::Runtime(layouts) => {
-                for (i, l) in layouts.iter().enumerate() {
-                    write!(f, "{}: {}, ", i, l)?
-                }
-            },
-            Self::RuntimeVariants(variants) => {
-                for (i, v) in variants.iter().enumerate() {
-                    write!(f, "#{}{{", i)?;
-                    for (i, l) in v.iter().enumerate() {
-                        write!(f, "{}: {}, ", i, l)?
-                    }
-                    write!(f, "}}")?;
-                }
-            },
-            Self::WithFields(layouts) => {
-                for layout in layouts {
-                    write!(f, "{}, ", layout)?
-                }
-            },
-            Self::WithTypes { type_, fields } => {
-                write!(f, "Type: {}", type_.to_canonical_string())?;
-                write!(f, "Fields:")?;
-                for field in fields {
-                    write!(f, "{}, ", field)?
-                }
-            },
-            Self::WithVariants { variants, .. } => {
-                for v in variants {
-                    write!(f, "{}{{", v.name)?;
-                    for layout in &v.fields {
-                        write!(f, "{}", layout)?;
-                    }
-                    write!(f, "}}")?;
-                }
-            },
-        }
-        write!(f, "}}")
-    }
-}
-
 impl TryInto<TypeTag> for &MoveTypeLayout {
     type Error = anyhow::Error;
 
@@ -1033,6 +1211,51 @@ impl TryInto<StructTag> for &MoveStructLayout {
                 "Invalid MoveTypeLayout -> StructTag conversion--needed MoveLayoutType::WithTypes or WithVariants"
             ),
             WithTypes { type_, .. } | WithVariants { type_, .. } => Ok(type_.clone()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod unfolded_node_count_tests {
+    use super::*;
+
+    /// Primitives are leaves and always count as 1.
+    #[test]
+    fn primitives_count_as_one() {
+        assert_eq!(MoveTypeLayout::U8.unfolded_node_count(), 1);
+        assert_eq!(MoveTypeLayout::Address.unfolded_node_count(), 1);
+        assert_eq!(MoveTypeLayout::Function.unfolded_node_count(), 1);
+    }
+
+    /// Containers add one node for themselves and recurse into the element.
+    #[test]
+    fn containers_add_one_per_level() {
+        let layout = MoveTypeLayout::Vector(Box::new(MoveTypeLayout::Vector(Box::new(
+            MoveTypeLayout::U8,
+        ))));
+        assert_eq!(layout.unfolded_node_count(), 3);
+    }
+
+    /// Builds layouts for
+    /// ```text
+    /// struct S_0 { v: u8 }
+    /// struct S_i { l: S_{i - 1}, r: S_{i - 1} }  // for i > 0
+    /// ```
+    /// The expanded node count is `c(N) = 3 * 2^N - 1`. Verifies that the count
+    /// reflects the fully-expanded tree, not the deduplicated in-memory DAG.
+    #[test]
+    fn doubling_dag_counts_tree_expansion() {
+        fn build(n: usize) -> MoveTypeLayout {
+            let mut current = Arc::new(MoveStructLayout::Runtime(vec![MoveTypeLayout::U8]));
+            for _ in 0..n {
+                let child = MoveTypeLayout::Struct(current);
+                current = Arc::new(MoveStructLayout::Runtime(vec![child; 2]));
+            }
+            MoveTypeLayout::Struct(current)
+        }
+        for n in 0..10 {
+            let layout = build(n);
+            assert_eq!(layout.unfolded_node_count(), 3u64 * (1u64 << n) - 1);
         }
     }
 }

--- a/third_party/move/move-vm/types/src/delayed_values/delayed_field_id.rs
+++ b/third_party/move/move-vm/types/src/delayed_values/delayed_field_id.rs
@@ -150,8 +150,8 @@ impl TryIntoMoveValue for DelayedFieldID {
             },
             _ => {
                 return Err(code_invariant_error(format!(
-                    "Failed to convert {:?} into a Move value with {} layout",
-                    self, layout
+                    "Failed to convert {:?} into a Move value",
+                    self
                 )))
             },
         })
@@ -191,7 +191,7 @@ impl TryFromMoveValue for DelayedFieldID {
             // We use value to ID conversion in serialization.
             _ => {
                 return Err(code_invariant_error(format!(
-                    "Failed to convert a Move value with {layout} layout into an identifier, tagged with {hint:?}, with value {value:?}",
+                    "Failed to convert a Move value into an identifier, tagged with {hint:?}, with value {value:?}",
                 )))
             },
         };

--- a/third_party/move/move-vm/types/src/values/function_values_impl.rs
+++ b/third_party/move/move-vm/types/src/values/function_values_impl.rs
@@ -10,7 +10,7 @@ use move_core_types::{
     function::{ClosureMask, FUNCTION_DATA_SERIALIZATION_FORMAT_V1},
     identifier::Identifier,
     language_storage::{ModuleId, TypeTag},
-    value::MoveTypeLayout,
+    value::{check_layout_within_bounds, MoveTypeLayout},
     vm_status::StatusCode,
 };
 use serde::{
@@ -142,6 +142,8 @@ impl serde::Serialize for SerializationReadyValue<'_, '_, '_, (), Closure> {
         seq.serialize_element(&data.ty_args)?;
         seq.serialize_element(&data.mask)?;
         for (layout, value) in data.captured_layouts.into_iter().zip(captured.iter()) {
+            // Reject captured layouts whose DAG would unfold past the node-count cap.
+            check_layout_within_bounds::<S::Error>(&layout)?;
             seq.serialize_element(&layout)?;
             seq.serialize_element(&SerializationReadyValue {
                 ctx: self.ctx,

--- a/third_party/move/move-vm/types/src/values/values_impl.rs
+++ b/third_party/move/move-vm/types/src/values/values_impl.rs
@@ -5412,8 +5412,8 @@ impl serde::Serialize for SerializationReadyValue<'_, '_, '_, MoveTypeLayout, Va
                                 .map_err(|e| S::Error::custom(format!("{}", e)))?,
                             None => id.try_into_move_value(layout).map_err(|_| {
                                 S::Error::custom(format!(
-                                    "Custom serialization failed for {:?} with layout {}",
-                                    kind, layout
+                                    "Custom serialization failed for {:?}",
+                                    kind
                                 ))
                             })?,
                         };
@@ -5433,8 +5433,8 @@ impl serde::Serialize for SerializationReadyValue<'_, '_, '_, MoveTypeLayout, Va
                         // If no delayed field extension, it is not known how the delayed value
                         // should be serialized. So, just return an error.
                         Err(invariant_violation::<S>(format!(
-                            "no custom serializer for delayed value ({:?}) with layout {}",
-                            kind, layout
+                            "no custom serializer for delayed value ({:?})",
+                            kind
                         )))
                     },
                 }
@@ -5637,9 +5637,9 @@ impl<'d> serde::de::DeserializeSeed<'d> for DeserializationSeed<'_, &MoveTypeLay
                                     DelayedFieldID::try_from_move_value(layout, value, &())
                                         .map_err(|_| {
                                             D::Error::custom(format!(
-                                        "Custom deserialization failed for {:?} with layout {}",
-                                        kind, layout
-                                    ))
+                                                "Custom deserialization failed for {:?}",
+                                                kind
+                                            ))
                                         })?;
                                 id
                             },
@@ -5653,8 +5653,8 @@ impl<'d> serde::de::DeserializeSeed<'d> for DeserializationSeed<'_, &MoveTypeLay
                         Err(D::Error::custom(
                             PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
                                 .with_message(format!(
-                                    "no custom deserializer for native value ({:?}) with layout {}",
-                                    kind, layout
+                                    "no custom deserializer for native value ({:?})",
+                                    kind
                                 )),
                         ))
                     },
@@ -6475,11 +6475,8 @@ impl Value {
         use crate::values::function_values_impl::mock::MockAbstractFunction;
         use MoveTypeLayout as L;
 
-        if let L::Native(kind, layout) = layout {
-            panic!(
-                "impossible to get native layout ({:?}) with {}",
-                kind, layout
-            )
+        if let L::Native(kind, _) = layout {
+            panic!("impossible to get native layout ({:?})", kind)
         }
 
         match (layout, &self) {


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

Cherry-pick of aptos-labs/aptos-core-private@89e74df

**Motivation**

`MoveTypeLayout::Struct` holds an `Arc<MoveStructLayout>`, making layouts DAGs. Some trait impls, however, traverse the layout naively without accounting for shared nodes, implicitly expanding it into a tree. A crafted struct chain of the form `struct S(i + 1) { l: S(i), r: S(i) }` causes this tree to grow exponentially.

**Changes**

Makes the affected trait impls DAG-safe:

- **`Serialize`** — routed through a new `BoundedLayout` wrapper that rejects layouts whose unfolded node count exceeds `MAX_LAYOUT_NODES = 4096`.
- **`PartialEq`** — rewritten with an `Arc::ptr_eq` short-circuit and pointer-identity memoization.
- **`Display`** — removed.
- **`TryInto<TypeTag>`** — audited and kept as-is; safe because it does not recurse over struct fields.

The serialization cap is enforced on the closure-captured layout serialization path, where a malicious package could otherwise publish a sufficiently deep struct chain and trigger OOM.

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

- New regression test `function_value_layout_dag`:
  - N=10 (3071 unfolded nodes, under cap) accepted
  - N=11 (6143 unfolded nodes, over cap) rejected
- Existing `e2e-move-tests` suite passes

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [x] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> VM serialization and equality on untrusted layout DAGs are security-sensitive; incorrect bounds or eq logic could allow OOM/DoS or break layout comparisons.
> 
> **Overview**
> **`MoveTypeLayout`** can form a DAG via shared **`Arc<MoveStructLayout>`** nodes; naive **`PartialEq`** / serialization could expand that DAG exponentially and enable DoS (e.g. malicious closure capture layouts).
> 
> This PR makes layout handling **DAG-aware**: custom **`PartialEq`** with **`Arc::ptr_eq`** and memoization, **`unfolded_node_count`** plus **`MAX_LAYOUT_NODES` (4096)** and **`check_layout_within_bounds`** applied when serializing **closure captured layouts** in the VM. **`Display`** for layout types is removed; **`Hash`** is dropped from several layout derives. Error strings in aggregator/delayed-field paths are shortened.
> 
> A new **`function_value_layout_dag`** e2e test checks depth **N=10** succeeds and **N=11** fails with **`VALUE_SERIALIZATION_ERROR`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 942c5f4ab8878cfa23a28345d7dd3d30119b60ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->