### PR TITLE
[trading-native][shared] Lift async-commit pipeline into crate::common

### DIFF
--- a/storage/aptosdb/src/common.rs
+++ b/storage/aptosdb/src/common.rs
@@ -1,9 +1,451 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
+use crate::schema::{
+    jellyfish_merkle_node::JellyfishMerkleNodeSchema, stale_node_index::StaleNodeIndexSchema,
+    stale_node_index_cross_epoch::StaleNodeIndexCrossEpochSchema,
+};
+use aptos_infallible::Mutex;
+use aptos_jellyfish_merkle::TreeUpdateBatch;
+use aptos_schemadb::batch::WriteBatch;
+use aptos_storage_interface::{
+    state_store::state_with_summary::{LedgerStateWithSummary, StateWithSummary},
+    Result,
+};
+use aptos_types::{state_store::state_key::StateKey, transaction::Version};
+use std::{
+    sync::{
+        mpsc::{self, Receiver, Sender, SyncSender},
+        Arc,
+    },
+    thread::JoinHandle,
+};
+
 pub const LEDGER_DB_NAME: &str = "ledger_db";
 pub const STATE_MERKLE_DB_NAME: &str = "state_merkle_db";
 
 // TODO: Either implement an iteration API to allow a very old client to loop through a long history
 // or guarantee that there is always a recent enough waypoint and client knows to boot from there.
 pub(crate) const MAX_NUM_EPOCH_ENDING_LEDGER_INFO: usize = 100;
+
+/// `Sync(Sender<()>)` is a drain barrier — the receiver signals back
+/// when it has processed all preceding `Data` messages.
+pub(crate) enum CommitMessage<T> {
+    Data(T),
+    Sync(Sender<()>),
+    Exit,
+}
+
+pub(crate) struct AsyncCommitThread<T: Send + 'static> {
+    sender: SyncSender<CommitMessage<T>>,
+    join_handle: Option<JoinHandle<()>>,
+}
+
+impl<T: Send + 'static> AsyncCommitThread<T> {
+    pub(crate) fn spawn<F>(name: &'static str, capacity: usize, run: F) -> Self
+    where
+        F: FnOnce(Receiver<CommitMessage<T>>) + Send + 'static,
+    {
+        let (sender, receiver) = mpsc::sync_channel(capacity);
+        let join_handle = std::thread::Builder::new()
+            .name(name.to_string())
+            .spawn(move || run(receiver))
+            .unwrap_or_else(|e| panic!("Failed to spawn {name} thread: {e}"));
+        Self {
+            sender,
+            join_handle: Some(join_handle),
+        }
+    }
+
+    pub(crate) fn sender(&self) -> &SyncSender<CommitMessage<T>> {
+        &self.sender
+    }
+
+    pub(crate) fn drain_barrier(&self) {
+        let (sync_sender, sync_receiver) = mpsc::channel();
+        self.sender
+            .send(CommitMessage::Sync(sync_sender))
+            .expect("commit thread dropped");
+        sync_receiver.recv().expect("sync barrier dropped");
+    }
+
+    /// `false` once `quit()` has joined the thread; sends are unsafe.
+    pub(crate) fn is_alive(&self) -> bool {
+        self.join_handle.is_some()
+    }
+}
+
+impl<T: Send + 'static> Drop for AsyncCommitThread<T> {
+    fn drop(&mut self) {
+        if let Some(handle) = self.join_handle.take() {
+            let _ = self.sender.send(CommitMessage::Exit);
+            let _ = handle.join();
+        }
+    }
+}
+
+pub(crate) struct SnapshotCommitter<S, I, O>
+where
+    S: CheckpointSnapshot,
+    I: Send + 'static,
+    O: Send + 'static,
+{
+    pub(crate) last_snapshot: S,
+    pub(crate) receiver: Receiver<CommitMessage<I>>,
+    pub(crate) batch_thread: AsyncCommitThread<O>,
+}
+
+impl<S, I, O> SnapshotCommitter<S, I, O>
+where
+    S: CheckpointSnapshot,
+    I: Send + 'static,
+    O: Send + 'static,
+{
+    pub(crate) fn new(
+        last_snapshot: S,
+        receiver: Receiver<CommitMessage<I>>,
+        batch_thread: AsyncCommitThread<O>,
+    ) -> Self {
+        Self {
+            last_snapshot,
+            receiver,
+            batch_thread,
+        }
+    }
+
+    pub(crate) fn run<F>(self, mut merklize: F)
+    where
+        F: FnMut(&mut S, I) -> O,
+    {
+        let Self {
+            mut last_snapshot,
+            receiver,
+            batch_thread,
+        } = self;
+        let batch_sender = batch_thread.sender().clone();
+        run_snapshot_committer_loop(receiver, batch_sender, |input| {
+            merklize(&mut last_snapshot, input)
+        });
+        // `batch_thread` drops here → Exit + join cascades downstream.
+    }
+}
+
+pub(crate) fn spawn_commit_pipeline<S, I, O, RunBatch, Merklize>(
+    snapshot_thread_name: &'static str,
+    snapshot_channel_capacity: usize,
+    batch_thread_name: &'static str,
+    batch_channel_capacity: usize,
+    initial_last_snapshot: S,
+    run_batch_committer: RunBatch,
+    mut merklize: Merklize,
+) -> AsyncCommitThread<I>
+where
+    S: CheckpointSnapshot + Send + 'static,
+    I: Send + 'static,
+    O: Send + 'static,
+    RunBatch: FnOnce(Receiver<CommitMessage<O>>) + Send + 'static,
+    Merklize: FnMut(&mut S, I) -> O + Send + 'static,
+{
+    AsyncCommitThread::spawn(
+        snapshot_thread_name,
+        snapshot_channel_capacity,
+        move |receiver| {
+            let batch_thread = AsyncCommitThread::spawn(
+                batch_thread_name,
+                batch_channel_capacity,
+                run_batch_committer,
+            );
+            let committer: SnapshotCommitter<S, I, O> =
+                SnapshotCommitter::new(initial_last_snapshot, receiver, batch_thread);
+            committer.run(move |last, input| merklize(last, input));
+        },
+    )
+}
+
+pub(crate) fn run_snapshot_committer_loop<I, O>(
+    receiver: Receiver<CommitMessage<I>>,
+    batch_sender: SyncSender<CommitMessage<O>>,
+    mut merklize: impl FnMut(I) -> O,
+) {
+    while let Ok(msg) = receiver.recv() {
+        match msg {
+            CommitMessage::Data(input) => {
+                let output = merklize(input);
+                batch_sender
+                    .send(CommitMessage::Data(output))
+                    .expect("downstream batch committer dropped");
+            },
+            CommitMessage::Sync(finish_sender) => {
+                batch_sender
+                    .send(CommitMessage::Sync(finish_sender))
+                    .expect("downstream batch committer dropped");
+            },
+            CommitMessage::Exit => break,
+        }
+    }
+}
+
+pub(crate) fn run_batch_committer_loop<T>(
+    receiver: Receiver<CommitMessage<T>>,
+    mut handle: impl FnMut(T),
+) {
+    while let Ok(msg) = receiver.recv() {
+        match msg {
+            CommitMessage::Data(payload) => handle(payload),
+            CommitMessage::Sync(finish_sender) => {
+                finish_sender.send(()).expect("sync barrier dropped")
+            },
+            CommitMessage::Exit => break,
+        }
+    }
+}
+
+pub(crate) struct MerkleBatch {
+    pub top_levels_batch: aptos_schemadb::batch::RawBatch,
+    pub batches_for_shards: Vec<aptos_schemadb::batch::RawBatch>,
+}
+
+/// Routes each `stale_node_index_batch` entry into the cross-epoch
+/// schema when its node version is `<= previous_epoch_ending_version`,
+/// otherwise the regular stale-index schema.
+pub(crate) fn populate_jmt_writes<W: WriteBatch>(
+    batch: &mut W,
+    tree_update_batch: &TreeUpdateBatch<StateKey>,
+    previous_epoch_ending_version: Option<Version>,
+) -> Result<()> {
+    for (node_key, node) in tree_update_batch.node_batch.iter().flatten() {
+        batch.put::<JellyfishMerkleNodeSchema>(node_key, node)?;
+    }
+    for row in tree_update_batch.stale_node_index_batch.iter().flatten() {
+        if previous_epoch_ending_version.is_some_and(|prev| row.node_key.version() <= prev) {
+            batch.put::<StaleNodeIndexCrossEpochSchema>(row, &())?;
+        } else {
+            batch.put::<StaleNodeIndexSchema>(row, &())?;
+        }
+    }
+    Ok(())
+}
+
+pub trait CheckpointSnapshot: Clone {
+    fn next_version(&self) -> Version;
+}
+
+pub trait LedgerStateView {
+    type Snapshot: CheckpointSnapshot;
+    fn next_version(&self) -> Version;
+    fn last_checkpoint_snapshot(&self) -> Self::Snapshot;
+    fn is_descendant_of(&self, other: &Self) -> bool;
+}
+
+pub(crate) struct BufferedStateCore<L, S, P>
+where
+    L: LedgerStateView<Snapshot = S>,
+    S: CheckpointSnapshot,
+    P: Send + 'static,
+{
+    pub(crate) current_state: Arc<Mutex<L>>,
+    pub(crate) last_snapshot: S,
+    pub(crate) commit_thread: AsyncCommitThread<P>,
+    pub(crate) estimated_items: usize,
+    pub(crate) target_items: usize,
+    pub(crate) target_snapshot_interval: u64,
+}
+
+impl<L, S, P> BufferedStateCore<L, S, P>
+where
+    L: LedgerStateView<Snapshot = S>,
+    S: CheckpointSnapshot,
+    P: Send + 'static,
+{
+    pub(crate) fn new(
+        current_state: Arc<Mutex<L>>,
+        last_snapshot: S,
+        commit_thread: AsyncCommitThread<P>,
+        target_items: usize,
+        target_snapshot_interval: u64,
+    ) -> Self {
+        Self {
+            current_state,
+            last_snapshot,
+            commit_thread,
+            estimated_items: 0,
+            target_items,
+            target_snapshot_interval,
+        }
+    }
+
+    pub(crate) fn add_estimated_items(&mut self, n: usize) {
+        self.estimated_items += n;
+    }
+
+    pub(crate) fn buffered_versions(&self) -> u64 {
+        let latest_next = self.current_state.lock().next_version();
+        latest_next.saturating_sub(self.last_snapshot.next_version())
+    }
+
+    pub(crate) fn should_commit(&self, checkpoint: &S, sync_commit: bool) -> bool {
+        checkpoint.next_version() != self.last_snapshot.next_version()
+            && (sync_commit
+                || self.estimated_items >= self.target_items
+                || self.buffered_versions() >= self.target_snapshot_interval)
+    }
+
+    pub(crate) fn enqueue(&mut self, checkpoint: S, payload: P) {
+        self.commit_thread
+            .sender()
+            .send(CommitMessage::Data(payload))
+            .expect("commit thread dropped");
+        self.estimated_items = 0;
+        self.last_snapshot = checkpoint;
+    }
+
+    pub(crate) fn drain_if_sync(&self, sync_commit: bool) {
+        if sync_commit {
+            self.commit_thread.drain_barrier();
+        }
+    }
+
+    pub(crate) fn force_last_snapshot(&mut self, snapshot: S) {
+        self.last_snapshot = snapshot;
+    }
+
+    /// Drain + shut down the commit pipeline against the current
+    /// `current_state` family. Must run *before* any caller repoints
+    /// `current_state` at a new MapLayer family — otherwise the
+    /// committer thread's drop-time `sync_commit` would compute deltas
+    /// across families and panic on `is_descendant_of`.
+    pub(crate) fn quit(&mut self) {
+        if !self.commit_thread.is_alive() {
+            return;
+        }
+        self.commit_thread.drain_barrier();
+        if let Some(handle) = self.commit_thread.join_handle.take() {
+            let _ = self.commit_thread.sender.send(CommitMessage::Exit);
+            let _ = handle.join();
+        }
+    }
+}
+
+impl CheckpointSnapshot for StateWithSummary {
+    fn next_version(&self) -> Version {
+        (**self).next_version()
+    }
+}
+
+impl LedgerStateView for LedgerStateWithSummary {
+    type Snapshot = StateWithSummary;
+
+    fn next_version(&self) -> Version {
+        (***self).next_version()
+    }
+
+    fn last_checkpoint_snapshot(&self) -> Self::Snapshot {
+        self.last_checkpoint().clone()
+    }
+
+    fn is_descendant_of(&self, other: &Self) -> bool {
+        LedgerStateWithSummary::is_descendant_of(self, other)
+    }
+}
+
+pub trait BufferedStateExtras<P, S>: Send + 'static {
+    type ChunkInput;
+    fn absorb_chunk(&mut self, input: Self::ChunkInput, checkpoint_advanced: bool);
+    fn build_payload(&mut self, snapshot: S) -> P;
+}
+
+pub struct BufferedState<L, S, P, X>
+where
+    L: LedgerStateView<Snapshot = S> + Clone,
+    S: CheckpointSnapshot,
+    P: Send + 'static,
+    X: BufferedStateExtras<P, S>,
+{
+    pub(crate) core: BufferedStateCore<L, S, P>,
+    pub(crate) extras: X,
+}
+
+impl<L, S, P, X> BufferedState<L, S, P, X>
+where
+    L: LedgerStateView<Snapshot = S> + Clone,
+    S: CheckpointSnapshot,
+    P: Send + 'static,
+    X: BufferedStateExtras<P, S>,
+{
+    pub(crate) fn new(core: BufferedStateCore<L, S, P>, extras: X) -> Self {
+        Self { core, extras }
+    }
+
+    pub(crate) fn update(
+        &mut self,
+        new_state: L,
+        chunk_input: X::ChunkInput,
+        estimated_new_items: usize,
+        sync_commit: bool,
+    ) -> aptos_storage_interface::Result<()> {
+        let old_next_version = {
+            let current_state = self.core.current_state.lock();
+            assert!(
+                new_state.is_descendant_of(&current_state),
+                "BufferedState::update: new_state must descend from current_state"
+            );
+            current_state.next_version()
+        };
+        self.core.add_estimated_items(estimated_new_items);
+
+        let new_last_checkpoint = new_state.last_checkpoint_snapshot();
+        let new_checkpoint_next = new_last_checkpoint.next_version();
+        let checkpoint_advanced = old_next_version < new_checkpoint_next;
+        let checkpoint_to_commit_opt = checkpoint_advanced.then(|| new_last_checkpoint.clone());
+
+        *self.core.current_state.lock() = new_state;
+
+        self.extras.absorb_chunk(chunk_input, checkpoint_advanced);
+        self.maybe_commit(checkpoint_to_commit_opt, sync_commit);
+
+        Ok(())
+    }
+
+    pub(crate) fn sync_commit(&mut self) {
+        let checkpoint = self.core.current_state.lock().last_checkpoint_snapshot();
+        self.maybe_commit(Some(checkpoint), /* sync_commit = */ true);
+    }
+
+    pub(crate) fn force_last_snapshot(&mut self, snapshot: S) {
+        self.core.force_last_snapshot(snapshot);
+    }
+
+    fn maybe_commit(&mut self, checkpoint: Option<S>, sync_commit: bool) {
+        if let Some(cp) = checkpoint {
+            if self.core.should_commit(&cp, sync_commit) {
+                let payload = self.extras.build_payload(cp.clone());
+                self.core.enqueue(cp, payload);
+            }
+        }
+        self.core.drain_if_sync(sync_commit);
+    }
+
+    /// Drain + shut down the commit pipeline. After this the
+    /// `BufferedState` is dead; only safe next op is `Drop` (which
+    /// short-circuits because the pipeline is already joined).
+    pub(crate) fn quit(&mut self) {
+        self.sync_commit();
+        self.core.quit();
+    }
+}
+
+impl<L, S, P, X> Drop for BufferedState<L, S, P, X>
+where
+    L: LedgerStateView<Snapshot = S> + Clone,
+    S: CheckpointSnapshot,
+    P: Send + 'static,
+    X: BufferedStateExtras<P, S>,
+{
+    fn drop(&mut self) {
+        // Skip if `quit()` already shut the pipeline down — sending
+        // on the closed channel would panic.
+        if self.core.commit_thread.is_alive() {
+            self.sync_commit();
+        }
+    }
+}

--- a/storage/aptosdb/src/sharded_jmt_merkle_db.rs
+++ b/storage/aptosdb/src/sharded_jmt_merkle_db.rs
@@ -18,13 +18,12 @@
 //! labels — are left to outer wrappers that compose this substrate.
 
 use crate::{
+    common::populate_jmt_writes,
     lru_node_cache::LruNodeCache,
     metrics::{NODE_CACHE_SECONDS, OTHER_TIMERS_SECONDS},
     schema::{
         db_metadata::{DbMetadataKey, DbMetadataSchema, DbMetadataValue},
         jellyfish_merkle_node::JellyfishMerkleNodeSchema,
-        stale_node_index::StaleNodeIndexSchema,
-        stale_node_index_cross_epoch::StaleNodeIndexCrossEpochSchema,
     },
     versioned_node_cache::VersionedNodeCache,
 };
@@ -130,14 +129,6 @@ impl ShardedJmtMerkleDb {
         self.lru_cache.is_some()
     }
 
-    pub(crate) fn version_caches(&self) -> &HashMap<Option<usize>, VersionedNodeCache> {
-        &self.version_caches
-    }
-
-    pub(crate) fn lru_cache(&self) -> Option<&LruNodeCache> {
-        self.lru_cache.as_ref()
-    }
-
     pub(crate) fn commit(
         &self,
         version: Version,
@@ -161,7 +152,15 @@ impl ShardedJmtMerkleDb {
                 })
         });
 
-        self.commit_top_levels(version, top_levels_batch)
+        self.commit_top_levels(version, top_levels_batch)?;
+
+        if let Some(lru_cache) = self.lru_cache.as_ref() {
+            self.version_caches
+                .iter()
+                .for_each(|(_, cache)| cache.maybe_evict_version(lru_cache));
+        }
+
+        Ok(())
     }
 
     /// Commits JMT node data without writing any commit progress metadata.
@@ -282,35 +281,15 @@ impl ShardedJmtMerkleDb {
             self.db_tag
         )]);
 
-        let mut batch = self.db(shard_id).new_native_batch();
-
-        let node_batch = tree_update_batch
-            .node_batch
-            .iter()
-            .flatten()
-            .collect::<Vec<_>>();
-        node_batch.iter().try_for_each(|(node_key, node)| {
+        for (node_key, _) in tree_update_batch.node_batch.iter().flatten() {
             ensure!(node_key.get_shard_id() == shard_id, "shard_id mismatch");
-            batch.put::<JellyfishMerkleNodeSchema>(node_key, node)
-        })?;
-
-        let stale_node_index_batch = tree_update_batch
-            .stale_node_index_batch
-            .iter()
-            .flatten()
-            .collect::<Vec<_>>();
-        stale_node_index_batch.iter().try_for_each(|row| {
+        }
+        for row in tree_update_batch.stale_node_index_batch.iter().flatten() {
             ensure!(row.node_key.get_shard_id() == shard_id, "shard_id mismatch");
-            if previous_epoch_ending_version.is_some()
-                && row.node_key.version() <= previous_epoch_ending_version.unwrap()
-            {
-                batch.put::<StaleNodeIndexCrossEpochSchema>(row, &())
-            } else {
-                // These are processed by the state merkle pruner.
-                batch.put::<StaleNodeIndexSchema>(row, &())
-            }
-        })?;
+        }
 
+        let mut batch = self.db(shard_id).new_native_batch();
+        populate_jmt_writes(&mut batch, tree_update_batch, previous_epoch_ending_version)?;
         Self::put_progress(Some(version), shard_id, &mut batch)?;
 
         batch.into_raw_batch(self.db(shard_id))
@@ -470,6 +449,62 @@ impl ShardedJmtMerkleDb {
         root_persisted_version: Option<Version>,
     ) -> Result<[Option<Version>; NUM_STATE_SHARDS]> {
         JellyfishMerkleTree::new(self).get_shard_persisted_versions(root_persisted_version)
+    }
+
+    /// Asserts JMT root == SMT root to catch scratchpad/JMT drift.
+    pub fn merklize_snapshot(
+        &self,
+        base_version: Option<Version>,
+        version: Version,
+        last_smt: &aptos_scratchpad::SparseMerkleTree,
+        smt: &aptos_scratchpad::SparseMerkleTree,
+        all_updates: [Vec<(HashValue, Option<(HashValue, StateKey)>)>; NUM_STATE_SHARDS],
+        previous_epoch_ending_version: Option<Version>,
+    ) -> Result<(HashValue, usize, RawBatch, Vec<RawBatch>)> {
+        let shard_persisted_versions = self.get_shard_persisted_versions(base_version)?;
+
+        let (shard_root_nodes, batches_for_shards): (Vec<_>, Vec<_>) =
+            THREAD_MANAGER.get_non_exe_cpu_pool().install(|| {
+                let _timer = OTHER_TIMERS_SECONDS.timer_with(&["calculate_batches_for_shards"]);
+                all_updates
+                    .into_par_iter()
+                    .enumerate()
+                    .map(|(shard_id, updates)| {
+                        let node_hashes = smt.new_node_hashes_since(last_smt, shard_id as u8);
+                        let updates_refs: Vec<_> =
+                            updates.iter().map(|(h, v)| (*h, v.as_ref())).collect();
+                        self.merklize_value_set_for_shard(
+                            shard_id,
+                            updates_refs,
+                            Some(&node_hashes),
+                            version,
+                            base_version,
+                            shard_persisted_versions[shard_id],
+                            previous_epoch_ending_version,
+                        )
+                    })
+                    .collect::<Result<Vec<_>>>()
+                    .expect("Error calculating shard JMT batches.")
+                    .into_iter()
+                    .unzip()
+            });
+
+        let _timer = OTHER_TIMERS_SECONDS.timer_with(&["calculate_top_levels_batch"]);
+        let (root_hash, leaf_count, top_levels_batch) = self.calculate_top_levels(
+            shard_root_nodes,
+            version,
+            base_version,
+            previous_epoch_ending_version,
+        )?;
+        assert_eq!(
+            root_hash,
+            smt.root_hash(),
+            "JMT vs SMT root hash mismatch — scratchpad/JMT drift detected: jmt={}, smt={}",
+            root_hash,
+            smt.root_hash()
+        );
+
+        Ok((root_hash, leaf_count, top_levels_batch, batches_for_shards))
     }
 
     pub(crate) fn write_pruner_progress(

--- a/storage/aptosdb/src/state_store/buffered_state.rs
+++ b/storage/aptosdb/src/state_store/buffered_state.rs
@@ -1,68 +1,99 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-//! This file defines state store buffered state that has been committed.
-
 use crate::{
+    common::{spawn_commit_pipeline, BufferedStateCore, BufferedStateExtras},
     metrics::{LATEST_CHECKPOINT_VERSION, OTHER_TIMERS_SECONDS},
     state_store::{
         persisted_state::PersistedState,
-        state_snapshot_committer::{SnapshotToCommit, StateSnapshotCommitter},
+        state_merkle_batch_committer::StateMerkleBatchCommitter,
+        state_snapshot_committer::{
+            merklize_main_state, SnapshotToCommit, STATE_BATCH_CHANNEL_SIZE,
+        },
         StateDb,
     },
 };
 use aptos_infallible::Mutex;
 use aptos_metrics_core::TimerHelper;
-use aptos_storage_interface::{
-    state_store::{
-        empty_hot_state_updates,
-        state_with_summary::{LedgerStateWithSummary, StateWithSummary},
-        HotStateShardUpdates, HotStateUpdates,
-    },
-    Result,
+use aptos_storage_interface::state_store::{
+    empty_hot_state_updates,
+    state_with_summary::{LedgerStateWithSummary, StateWithSummary},
+    HotStateShardUpdates, HotStateUpdates,
 };
-use aptos_types::{state_store::NUM_STATE_SHARDS, transaction::Version};
+use aptos_types::state_store::NUM_STATE_SHARDS;
 use itertools::Itertools;
-use std::{
-    sync::{
-        mpsc,
-        mpsc::{Sender, SyncSender},
-        Arc, MutexGuard,
-    },
-    thread::JoinHandle,
-};
+use std::sync::Arc;
 
 pub(crate) const ASYNC_COMMIT_CHANNEL_BUFFER_SIZE: u64 = 1;
 pub(crate) const TARGET_SNAPSHOT_INTERVAL_IN_VERSION: u64 = 100_000;
 
-/// BufferedState manages a range of recent state checkpoints and asynchronously commits
-/// the updates in batches.
-#[derive(Debug)]
-pub struct BufferedState {
-    /// the current state and the last checkpoint. shared with outside world.
-    current_state: Arc<Mutex<LedgerStateWithSummary>>,
-    /// The most recent checkpoint sent for persistence, not guaranteed to have committed already.
-    last_snapshot: StateWithSummary,
-    /// channel to send a checkpoint for persistence asynchronously
-    state_commit_sender: SyncSender<CommitMessage<SnapshotToCommit>>,
-    /// Estimated number of items in the buffer.
-    estimated_items: usize,
-    /// The target number of items in the buffer between commits.
-    target_items: usize,
-    /// Hot state updates covering `[last_snapshot, current_state.last_checkpoint()]`.
-    /// Drained into the committer on every snapshot flush.
-    pending_hot_state_updates: [HotStateShardUpdates; NUM_STATE_SHARDS],
-    /// Hot state updates covering `(current_state.last_checkpoint(), current_state.latest()]`.
-    /// Folded into `pending_hot_state_updates` once a later chunk advances the checkpoint past
-    /// them.
-    post_checkpoint_hot_state_updates: [HotStateShardUpdates; NUM_STATE_SHARDS],
-    join_handle: Option<JoinHandle<()>>,
+pub type BufferedState = crate::common::BufferedState<
+    LedgerStateWithSummary,
+    StateWithSummary,
+    SnapshotToCommit,
+    HotStateAccumulator,
+>;
+
+/// `pending` covers `(last_snapshot, current.last_checkpoint()]` and
+/// drains into the snapshot payload on every flush. `post_checkpoint`
+/// covers `(last_checkpoint, latest()]` and folds into `pending` once
+/// a later chunk advances the checkpoint past it.
+pub struct HotStateAccumulator {
+    pending: [HotStateShardUpdates; NUM_STATE_SHARDS],
+    post_checkpoint: [HotStateShardUpdates; NUM_STATE_SHARDS],
 }
 
-pub(crate) enum CommitMessage<T> {
-    Data(T),
-    Sync(Sender<()>),
-    Exit,
+impl HotStateAccumulator {
+    pub fn new() -> Self {
+        Self {
+            pending: empty_hot_state_updates(),
+            post_checkpoint: empty_hot_state_updates(),
+        }
+    }
+
+    fn merge_hot_state_updates(
+        target: &mut [HotStateShardUpdates; NUM_STATE_SHARDS],
+        incoming: [HotStateShardUpdates; NUM_STATE_SHARDS],
+    ) {
+        for (t, i) in target.iter_mut().zip_eq(incoming.into_iter()) {
+            t.merge(i);
+        }
+    }
+}
+
+impl Default for HotStateAccumulator {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl BufferedStateExtras<SnapshotToCommit, StateWithSummary> for HotStateAccumulator {
+    type ChunkInput = HotStateUpdates;
+
+    fn absorb_chunk(&mut self, input: HotStateUpdates, checkpoint_advanced: bool) {
+        // Order: (1) fold prior post_checkpoint into pending if the
+        // checkpoint advanced past it, (2) merge this chunk's
+        // pre-checkpoint share into pending, (3) merge this chunk's
+        // post-checkpoint share into post_checkpoint.
+        if checkpoint_advanced {
+            let prev_post = std::mem::replace(&mut self.post_checkpoint, empty_hot_state_updates());
+            Self::merge_hot_state_updates(&mut self.pending, prev_post);
+        }
+        if let Some(shards) = input.for_last_checkpoint {
+            Self::merge_hot_state_updates(&mut self.pending, shards);
+        }
+        if let Some(shards) = input.for_latest {
+            Self::merge_hot_state_updates(&mut self.post_checkpoint, shards);
+        }
+    }
+
+    fn build_payload(&mut self, snapshot: StateWithSummary) -> SnapshotToCommit {
+        let hot_state_updates = std::mem::replace(&mut self.pending, empty_hot_state_updates());
+        SnapshotToCommit {
+            snapshot,
+            hot_state_updates,
+        }
+    }
 }
 
 impl BufferedState {
@@ -73,186 +104,57 @@ impl BufferedState {
         out_current_state: Arc<Mutex<LedgerStateWithSummary>>,
         out_persisted_state: PersistedState,
     ) -> Self {
-        let (state_commit_sender, state_commit_receiver) =
-            mpsc::sync_channel(ASYNC_COMMIT_CHANNEL_BUFFER_SIZE as usize);
         let arc_state_db = Arc::clone(state_db);
         *out_current_state.lock() =
             LedgerStateWithSummary::new_at_checkpoint(last_snapshot.clone());
         out_persisted_state.hack_reset(last_snapshot.clone());
 
+        let merklize_state_db = Arc::clone(&arc_state_db);
         let persisted_state_clone = out_persisted_state.clone();
-        let last_snapshot_clone = last_snapshot.clone();
-        // Create a new thread with receiver subscribing to state commit changes
-        let join_handle = std::thread::Builder::new()
-            .name("state-committer".to_string())
-            .spawn(move || {
-                let committer = StateSnapshotCommitter::new(
-                    arc_state_db,
-                    state_commit_receiver,
-                    last_snapshot_clone,
-                    persisted_state_clone,
-                );
-                committer.run();
-            })
-            .expect("Failed to spawn state committer thread.");
-        Self::report_last_checkpoint_version(last_snapshot.version());
-        Self {
-            current_state: out_current_state.clone(),
-            last_snapshot,
-            state_commit_sender,
-            estimated_items: 0,
-            target_items,
-            pending_hot_state_updates: empty_hot_state_updates(),
-            post_checkpoint_hot_state_updates: empty_hot_state_updates(),
-            // The join handle of the async state commit thread for graceful drop.
-            join_handle: Some(join_handle),
-        }
-    }
-
-    /// Merges `incoming` into `target` per-shard.
-    fn merge_hot_state_updates(
-        target: &mut [HotStateShardUpdates; NUM_STATE_SHARDS],
-        incoming: [HotStateShardUpdates; NUM_STATE_SHARDS],
-    ) {
-        for (t, i) in target.iter_mut().zip_eq(incoming.into_iter()) {
-            t.merge(i);
-        }
-    }
-
-    /// This method checks whether a commit is needed based on the target_items value and the number of items in state_until_checkpoint.
-    /// If a commit is needed, it sends a CommitMessage::Data message to the StateSnapshotCommitter thread to commit the data.
-    /// If sync_commit is true, it also sends a CommitMessage::Sync message to ensure that the commit is completed before returning.
-    fn maybe_commit(&mut self, checkpoint: Option<StateWithSummary>, sync_commit: bool) {
-        if let Some(checkpoint) = checkpoint {
-            if !checkpoint.is_the_same(&self.last_snapshot)
-                && (sync_commit
-                    || self.estimated_items >= self.target_items
-                    || self.buffered_versions() >= TARGET_SNAPSHOT_INTERVAL_IN_VERSION)
-            {
-                self.enqueue_commit(checkpoint);
-            }
-        }
-
-        if sync_commit {
-            self.drain_commits();
-        }
-    }
-
-    fn current_state_locked(&self) -> MutexGuard<'_, LedgerStateWithSummary> {
-        self.current_state.lock()
-    }
-
-    fn buffered_versions(&self) -> u64 {
-        self.current_state_locked().next_version() - self.last_snapshot.next_version()
-    }
-
-    fn enqueue_commit(&mut self, checkpoint: StateWithSummary) {
-        let _timer = OTHER_TIMERS_SECONDS.timer_with(&["buffered_state___enqueue_commit"]);
-
-        let hot_state_updates = std::mem::replace(
-            &mut self.pending_hot_state_updates,
-            empty_hot_state_updates(),
+        let commit_thread = spawn_commit_pipeline(
+            "state-committer",
+            ASYNC_COMMIT_CHANNEL_BUFFER_SIZE as usize,
+            "state_batch_committer",
+            STATE_BATCH_CHANNEL_SIZE,
+            last_snapshot.clone(),
+            move |batch_receiver| {
+                StateMerkleBatchCommitter::new(arc_state_db, batch_receiver, persisted_state_clone)
+                    .run();
+            },
+            move |last_snapshot, input| {
+                merklize_main_state(&merklize_state_db, last_snapshot, input)
+            },
         );
-        self.state_commit_sender
-            .send(CommitMessage::Data(SnapshotToCommit {
-                snapshot: checkpoint.clone(),
-                hot_state_updates,
-            }))
-            .unwrap();
-        // n.b. if the latest state is not a (the latest) checkpoint, the items between them are
-        // not counted towards the next commit. If this becomes a concern we can count the items
-        // instead of putting it 0 here.
-        self.estimated_items = 0;
-        self.last_snapshot = checkpoint;
+        BufferedState::new(
+            BufferedStateCore::new(
+                out_current_state,
+                last_snapshot,
+                commit_thread,
+                target_items,
+                TARGET_SNAPSHOT_INTERVAL_IN_VERSION,
+            ),
+            HotStateAccumulator::new(),
+        )
     }
 
-    fn drain_commits(&mut self) {
-        let _timer = OTHER_TIMERS_SECONDS.timer_with(&["buffered_state___drain_commits"]);
-
-        let (commit_sync_sender, commit_sync_receiver) = mpsc::channel();
-        self.state_commit_sender
-            .send(CommitMessage::Sync(commit_sync_sender))
-            .unwrap();
-        commit_sync_receiver.recv().unwrap();
-    }
-
-    pub(crate) fn sync_commit(&mut self) {
-        let checkpoint = self.current_state_locked().last_checkpoint().clone();
-        self.maybe_commit(Some(checkpoint), true /* sync_commit */);
-    }
-
-    fn report_last_checkpoint_version(version: Option<Version>) {
-        LATEST_CHECKPOINT_VERSION.set(version.map_or(-1, |v| v as i64));
-    }
-
-    /// This method updates the buffered state with new data.
-    pub fn update(
+    /// Calls `update` and reports `LATEST_CHECKPOINT_VERSION` so the metric
+    /// stays in lockstep with the snapshot's checkpoint version.
+    pub(crate) fn update_and_report(
         &mut self,
         new_state: LedgerStateWithSummary,
         hot_state_updates: HotStateUpdates,
         estimated_new_items: usize,
         sync_commit: bool,
-    ) -> Result<()> {
+    ) -> aptos_storage_interface::Result<()> {
         let _timer = OTHER_TIMERS_SECONDS.timer_with(&["buffered_state___update"]);
-
-        let old_state = self.current_state_locked().clone();
-        assert!(new_state.is_descendant_of(&old_state));
-
-        self.estimated_items += estimated_new_items;
         let version = new_state.last_checkpoint().version();
-
-        let last_checkpoint = new_state.last_checkpoint().clone();
-        // Commit state only if there is a new checkpoint, eases testing and make estimated
-        // buffer size a tad more realistic.
-        let checkpoint_to_commit_opt =
-            (old_state.next_version() < last_checkpoint.next_version()).then_some(last_checkpoint);
-        *self.current_state_locked() = new_state;
-
-        // When a new checkpoint advances past earlier chunks' post-checkpoint updates,
-        // those updates are now pre-(new-)checkpoint and become eligible for the next
-        // snapshot flush. Fold them into `pending_hot_state_updates` first.
-        if checkpoint_to_commit_opt.is_some() {
-            let prev_post_checkpoint = std::mem::replace(
-                &mut self.post_checkpoint_hot_state_updates,
-                empty_hot_state_updates(),
-            );
-            Self::merge_hot_state_updates(
-                &mut self.pending_hot_state_updates,
-                prev_post_checkpoint,
-            );
-        }
-        // Merge this chunk's pre-checkpoint portion before potentially flushing.
-        if let Some(shards) = hot_state_updates.for_last_checkpoint {
-            Self::merge_hot_state_updates(&mut self.pending_hot_state_updates, shards);
-        }
-        self.maybe_commit(checkpoint_to_commit_opt, sync_commit);
-        // The post-checkpoint portion of this chunk goes into `post_checkpoint` so it is
-        // NOT flushed at the current checkpoint — its versions are past the snapshot.
-        if let Some(shards) = hot_state_updates.for_latest {
-            Self::merge_hot_state_updates(&mut self.post_checkpoint_hot_state_updates, shards);
-        }
-        Self::report_last_checkpoint_version(version);
+        self.update(
+            new_state,
+            hot_state_updates,
+            estimated_new_items,
+            sync_commit,
+        )?;
+        LATEST_CHECKPOINT_VERSION.set(version.map_or(-1, |v| v as i64));
         Ok(())
-    }
-
-    pub(crate) fn quit(&mut self) {
-        if let Some(handle) = self.join_handle.take() {
-            self.sync_commit();
-            self.state_commit_sender.send(CommitMessage::Exit).unwrap();
-            handle
-                .join()
-                .expect("snapshot commit thread should join peacefully.");
-        }
-    }
-
-    /// used by restore tooling
-    pub(crate) fn force_last_snapshot(&mut self, snapshot: StateWithSummary) {
-        self.last_snapshot = snapshot
-    }
-}
-
-impl Drop for BufferedState {
-    fn drop(&mut self) {
-        self.quit()
     }
 }

--- a/storage/aptosdb/src/state_store/mod.rs
+++ b/storage/aptosdb/src/state_store/mod.rs
@@ -849,14 +849,17 @@ impl StateStore {
         let current_state = out_current_state.lock().clone();
         info!(
             latest_in_memory_version = current_state.version(),
-            latest_in_memory_hot_root_hash = current_state.summary().hot_root_hash().ok(),
+            latest_in_memory_hot_root_hash = current_state
+                .summary()
+                .hot_root_hash()
+                .expect("main state always has a hot half"),
             latest_in_memory_root_hash = current_state.summary().root_hash(),
             latest_snapshot_version = current_state.last_checkpoint().version(),
             latest_snapshot_hot_root_hash = current_state
                 .last_checkpoint()
                 .summary()
                 .hot_root_hash()
-                .ok(),
+                .expect("main state always has a hot half"),
             latest_snapshot_root_hash = current_state.last_checkpoint().summary().root_hash(),
             "StateStore initialization finished.",
         );
@@ -935,7 +938,7 @@ impl StateStore {
         }
 
         // synchronously commit the snapshot at the last checkpoint here if not committed to disk yet.
-        buffered_state.update(
+        buffered_state.update_and_report(
             updated,
             hot_state_updates,
             0,    /* estimated_items, doesn't matter since we sync-commit */
@@ -1008,6 +1011,12 @@ impl StateStore {
     }
 
     pub fn reset(&self) {
+        // Drain + shut down the old pipeline against the *current*
+        // chain family before `create_buffered_state_from_latest_snapshot`
+        // repoints `current_state` at a new MapLayer family. Doing
+        // the shutdown lazily via `Drop` would let the old thread's
+        // drop-time `sync_commit` read the new family and panic on
+        // `is_descendant_of`.
         self.buffered_state.lock().quit();
         // TODO(HotState): restore does not reconstruct the hot state yet, so we pass empty
         // metadata here. This is safe because callers (restore / state-sync) open the DB with

--- a/storage/aptosdb/src/state_store/state_merkle_batch_committer.rs
+++ b/storage/aptosdb/src/state_store/state_merkle_batch_committer.rs
@@ -4,30 +4,23 @@
 //! This file defines the state merkle snapshot committer running in background thread.
 
 use crate::{
+    common::{run_batch_committer_loop, CommitMessage, MerkleBatch},
     metrics::{LATEST_SNAPSHOT_VERSION, OTHER_TIMERS_SECONDS},
     pruner::PrunerManager,
     schema::jellyfish_merkle_node::JellyfishMerkleNodeSchema,
-    state_merkle_db::StateMerkleDb,
-    state_store::{buffered_state::CommitMessage, persisted_state::PersistedState, StateDb},
+    state_store::{persisted_state::PersistedState, StateDb},
 };
 use anyhow::{anyhow, ensure, Result};
 use aptos_jellyfish_merkle::node_type::NodeKey;
 use aptos_logger::{info, trace};
 use aptos_metrics_core::TimerHelper;
-use aptos_schemadb::batch::RawBatch;
 use aptos_storage_interface::state_store::{state::State, state_with_summary::StateWithSummary};
-use aptos_types::transaction::Version;
 use std::sync::{mpsc::Receiver, Arc};
 
 pub(crate) struct StateMerkleCommit {
     pub snapshot: StateWithSummary,
-    pub hot_batch: Option<StateMerkleBatch>,
-    pub cold_batch: StateMerkleBatch,
-}
-
-pub(crate) struct StateMerkleBatch {
-    pub top_levels_batch: RawBatch,
-    pub batches_for_shards: Vec<RawBatch>,
+    pub hot_batch: Option<MerkleBatch>,
+    pub cold_batch: MerkleBatch,
 }
 
 pub(crate) struct StateMerkleBatchCommitter {
@@ -50,126 +43,115 @@ impl StateMerkleBatchCommitter {
     }
 
     pub fn run(self) {
-        while let Ok(msg) = self.state_merkle_batch_receiver.recv() {
+        let Self {
+            state_db,
+            state_merkle_batch_receiver,
+            persisted_state,
+        } = self;
+        run_batch_committer_loop(state_merkle_batch_receiver, |commit| {
             let _timer = OTHER_TIMERS_SECONDS.timer_with(&["batch_committer_work"]);
-            match msg {
-                CommitMessage::Data(StateMerkleCommit {
-                    snapshot,
-                    hot_batch,
-                    cold_batch,
-                }) => {
-                    let base_version = self.persisted_state.get_state_summary().version();
-                    let current_version = snapshot
-                        .version()
-                        .expect("Current version should not be None");
+            let StateMerkleCommit {
+                snapshot,
+                hot_batch,
+                cold_batch,
+            } = commit;
+            let base_version = persisted_state.get_state_summary().version();
+            let current_version = snapshot
+                .version()
+                .expect("Current version should not be None");
 
-                    // commit jellyfish merkle nodes
-                    let _timer =
-                        OTHER_TIMERS_SECONDS.timer_with(&["commit_jellyfish_merkle_nodes"]);
-                    if let Some(hot_state_merkle_batch) = hot_batch {
-                        self.commit(
-                            self.state_db
-                                .hot_state_merkle_db
-                                .as_ref()
-                                .expect("Hot state merkle db must exist."),
-                            current_version,
-                            hot_state_merkle_batch,
-                        )
-                        .expect("Hot state merkle nodes commit failed.");
-                    }
-                    self.commit(&self.state_db.state_merkle_db, current_version, cold_batch)
-                        .expect("State merkle nodes commit failed.");
-
-                    info!(
-                        version = current_version,
-                        base_version = base_version,
-                        root_hash = snapshot.summary().root_hash(),
-                        hot_root_hash = snapshot.summary().hot_root_hash().ok(),
-                        "State snapshot committed."
-                    );
-                    LATEST_SNAPSHOT_VERSION.set(current_version as i64);
-                    if let Some(pruner) = &self.state_db.state_pruner.hot_state_merkle_pruner {
-                        pruner.maybe_set_pruner_target_db_version(current_version);
-                    }
-                    if let Some(pruner) = &self.state_db.state_pruner.hot_epoch_snapshot_pruner {
-                        pruner.maybe_set_pruner_target_db_version(current_version);
-                    }
-                    self.state_db
-                        .state_pruner
-                        .state_merkle_pruner
-                        .maybe_set_pruner_target_db_version(current_version);
-                    self.state_db
-                        .state_pruner
-                        .epoch_snapshot_pruner
-                        .maybe_set_pruner_target_db_version(current_version);
-
-                    self.check_usage_consistency(&snapshot).unwrap();
-
-                    snapshot
-                        .summary()
-                        .global_state_summary
-                        .log_generation("buffered_state_commit");
-                    self.persisted_state.set(snapshot);
-                },
-                CommitMessage::Sync(finish_sender) => finish_sender.send(()).unwrap(),
-                CommitMessage::Exit => {
-                    break;
-                },
+            // commit jellyfish merkle nodes
+            let _timer = OTHER_TIMERS_SECONDS.timer_with(&["commit_jellyfish_merkle_nodes"]);
+            // `ShardedJmtMerkleDb::commit` handles version-cache eviction
+            // internally — see `sharded_jmt_merkle_db.rs`.
+            if let Some(hot) = hot_batch {
+                state_db
+                    .hot_state_merkle_db
+                    .as_ref()
+                    .expect("Hot state merkle db must exist.")
+                    .commit(
+                        current_version,
+                        hot.top_levels_batch,
+                        hot.batches_for_shards,
+                    )
+                    .expect("Hot state merkle nodes commit failed.");
             }
-        }
+            state_db
+                .state_merkle_db
+                .commit(
+                    current_version,
+                    cold_batch.top_levels_batch,
+                    cold_batch.batches_for_shards,
+                )
+                .expect("State merkle nodes commit failed.");
+
+            info!(
+                version = current_version,
+                base_version = base_version,
+                root_hash = snapshot.summary().root_hash(),
+                hot_root_hash = snapshot
+                    .summary()
+                    .hot_root_hash()
+                    .expect("main state always has a hot half"),
+                "State snapshot committed."
+            );
+            LATEST_SNAPSHOT_VERSION.set(current_version as i64);
+            if let Some(pruner) = &state_db.state_pruner.hot_state_merkle_pruner {
+                pruner.maybe_set_pruner_target_db_version(current_version);
+            }
+            if let Some(pruner) = &state_db.state_pruner.hot_epoch_snapshot_pruner {
+                pruner.maybe_set_pruner_target_db_version(current_version);
+            }
+            state_db
+                .state_pruner
+                .state_merkle_pruner
+                .maybe_set_pruner_target_db_version(current_version);
+            state_db
+                .state_pruner
+                .epoch_snapshot_pruner
+                .maybe_set_pruner_target_db_version(current_version);
+
+            check_usage_consistency(&state_db, &snapshot).unwrap();
+
+            snapshot
+                .summary()
+                .global_state_summary
+                .log_generation("buffered_state_commit");
+            persisted_state.set(snapshot);
+        });
         trace!("State merkle batch committing thread exit.")
     }
+}
 
-    fn commit(
-        &self,
-        db: &StateMerkleDb,
-        current_version: Version,
-        state_merkle_batch: StateMerkleBatch,
-    ) -> Result<()> {
-        let StateMerkleBatch {
-            top_levels_batch,
-            batches_for_shards,
-        } = state_merkle_batch;
-        db.commit(current_version, top_levels_batch, batches_for_shards)?;
-        if let Some(lru_cache) = db.lru_cache() {
-            db.version_caches()
-                .iter()
-                .for_each(|(_, cache)| cache.maybe_evict_version(lru_cache));
-        }
-        Ok(())
-    }
+fn check_usage_consistency(state_db: &StateDb, state: &State) -> Result<()> {
+    let version = state
+        .version()
+        .ok_or_else(|| anyhow!("Committing without version."))?;
 
-    fn check_usage_consistency(&self, state: &State) -> Result<()> {
-        let version = state
-            .version()
-            .ok_or_else(|| anyhow!("Committing without version."))?;
+    let usage_from_ledger_db = state_db.ledger_db.metadata_db().get_usage(version)?;
+    let leaf_count_from_jmt = state_db
+        .state_merkle_db
+        .metadata_db()
+        .get::<JellyfishMerkleNodeSchema>(&NodeKey::new_empty_path(version))?
+        .ok_or_else(|| anyhow!("Root node missing at version {}", version))?
+        .leaf_count();
 
-        let usage_from_ledger_db = self.state_db.ledger_db.metadata_db().get_usage(version)?;
-        let leaf_count_from_jmt = self
-            .state_db
-            .state_merkle_db
-            .metadata_db()
-            .get::<JellyfishMerkleNodeSchema>(&NodeKey::new_empty_path(version))?
-            .ok_or_else(|| anyhow!("Root node missing at version {}", version))?
-            .leaf_count();
+    ensure!(
+        usage_from_ledger_db.items() == leaf_count_from_jmt,
+        "State item count inconsistent, {} from ledger db and {} from state tree.",
+        usage_from_ledger_db.items(),
+        leaf_count_from_jmt,
+    );
 
+    let usage_from_in_mem_state = state.usage();
+    if !usage_from_in_mem_state.is_untracked() {
         ensure!(
-            usage_from_ledger_db.items() == leaf_count_from_jmt,
-            "State item count inconsistent, {} from ledger db and {} from state tree.",
-            usage_from_ledger_db.items(),
-            leaf_count_from_jmt,
+            usage_from_in_mem_state == usage_from_ledger_db,
+            "State storage usage info inconsistent. from smt: {:?}, from ledger_db: {:?}",
+            usage_from_in_mem_state,
+            usage_from_ledger_db,
         );
-
-        let usage_from_in_mem_state = state.usage();
-        if !usage_from_in_mem_state.is_untracked() {
-            ensure!(
-                usage_from_in_mem_state == usage_from_ledger_db,
-                "State storage usage info inconsistent. from smt: {:?}, from ledger_db: {:?}",
-                usage_from_in_mem_state,
-                usage_from_ledger_db,
-            );
-        }
-
-        Ok(())
     }
+
+    Ok(())
 }

--- a/storage/aptosdb/src/state_store/state_snapshot_committer.rs
+++ b/storage/aptosdb/src/state_store/state_snapshot_committer.rs
@@ -1,286 +1,144 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-//! This file defines the state snapshot committer running in background thread within StateStore.
-
 use crate::{
+    common::MerkleBatch,
     metrics::OTHER_TIMERS_SECONDS,
-    state_merkle_db::StateMerkleDb,
-    state_store::{
-        buffered_state::CommitMessage,
-        persisted_state::PersistedState,
-        state_merkle_batch_committer::{
-            StateMerkleBatch, StateMerkleBatchCommitter, StateMerkleCommit,
-        },
-        StateDb,
-    },
+    state_store::{state_merkle_batch_committer::StateMerkleCommit, StateDb},
     versioned_node_cache::VersionedNodeCache,
 };
-use aptos_crypto::{hash::CryptoHash, HashValue};
-use aptos_experimental_runtimes::thread_manager::THREAD_MANAGER;
-use aptos_logger::info;
+use aptos_crypto::hash::CryptoHash;
 use aptos_metrics_core::TimerHelper;
-use aptos_scratchpad::SparseMerkleTree;
-use aptos_storage_interface::{
-    jmt_update_refs,
-    state_store::{
-        leaf_entry::leaf_entry_to_jmt_update, state_with_summary::StateWithSummary,
-        HotStateShardUpdates,
-    },
-    Result,
+use aptos_storage_interface::state_store::{
+    leaf_entry::leaf_entry_to_jmt_update, state_with_summary::StateWithSummary,
+    HotStateShardUpdates,
 };
-use aptos_types::{
-    state_store::{state_key::StateKey, NUM_STATE_SHARDS},
-    transaction::Version,
-};
-use rayon::prelude::*;
+use aptos_types::state_store::NUM_STATE_SHARDS;
 use static_assertions::const_assert;
-use std::{
-    sync::{
-        mpsc::{self, Receiver, SyncSender},
-        Arc,
-    },
-    thread::JoinHandle,
-};
 
-/// Payload sent to the state snapshot committer thread.
 pub(crate) struct SnapshotToCommit {
     pub snapshot: StateWithSummary,
     pub hot_state_updates: [HotStateShardUpdates; NUM_STATE_SHARDS],
 }
 
-pub(crate) struct StateSnapshotCommitter {
-    state_db: Arc<StateDb>,
-    /// Last snapshot merklized and sent for persistence, not guaranteed to have committed already.
-    last_snapshot: StateWithSummary,
-    state_snapshot_commit_receiver: Receiver<CommitMessage<SnapshotToCommit>>,
-    state_merkle_batch_commit_sender: SyncSender<CommitMessage<StateMerkleCommit>>,
-    join_handle: Option<JoinHandle<()>>,
-}
+/// Rendezvous channel — must stay below the JMT node cache depth.
+pub(crate) const STATE_BATCH_CHANNEL_SIZE: usize = 0;
+const_assert!(STATE_BATCH_CHANNEL_SIZE < VersionedNodeCache::NUM_VERSIONS_TO_CACHE);
 
-impl StateSnapshotCommitter {
-    const CHANNEL_SIZE: usize = 0;
+/// Advances `*last_snapshot` on success.
+pub(crate) fn merklize_main_state(
+    state_db: &StateDb,
+    last_snapshot: &mut StateWithSummary,
+    SnapshotToCommit {
+        snapshot,
+        hot_state_updates,
+    }: SnapshotToCommit,
+) -> StateMerkleCommit {
+    let version = snapshot.version().expect("Cannot be empty");
+    let base_version = last_snapshot.version();
+    let previous_epoch_ending_version = state_db
+        .ledger_db
+        .metadata_db()
+        .get_previous_epoch_ending(version)
+        .unwrap()
+        .map(|(v, _e)| v);
+    let min_version = last_snapshot.next_version();
 
-    pub fn new(
-        state_db: Arc<StateDb>,
-        state_snapshot_commit_receiver: Receiver<CommitMessage<SnapshotToCommit>>,
-        last_snapshot: StateWithSummary,
-        persisted_state: PersistedState,
-    ) -> Self {
-        // Note: This is to ensure we cache nodes in memory from previous batches before they get committed to DB.
-        const_assert!(
-            StateSnapshotCommitter::CHANNEL_SIZE < VersionedNodeCache::NUM_VERSIONS_TO_CACHE
-        );
-        // Rendezvous channel
-        let (state_merkle_batch_commit_sender, state_merkle_batch_commit_receiver) =
-            mpsc::sync_channel(Self::CHANNEL_SIZE);
-        let arc_state_db = Arc::clone(&state_db);
-        let join_handle = std::thread::Builder::new()
-            .name("state_batch_committer".to_string())
-            .spawn(move || {
-                let committer = StateMerkleBatchCommitter::new(
-                    arc_state_db,
-                    state_merkle_batch_commit_receiver,
-                    persisted_state.clone(),
-                );
-                committer.run();
-            })
-            .expect("Failed to spawn state merkle batch committer thread.");
-        Self {
-            state_db,
-            last_snapshot,
-            state_snapshot_commit_receiver,
-            state_merkle_batch_commit_sender,
-            join_handle: Some(join_handle),
-        }
-    }
+    // Element format: (key_hash, Option<(value_hash, key)>). Routes
+    // through the shared `LeafEntry`-based extractor — same shape
+    // position-shaped pipelines use. Main state's per-slot filter
+    // (`passes_jmt_filter`, which checks `value_version`/
+    // `hot_since_version >= min_version`) skips entries that haven't
+    // changed since the last snapshot; position-shaped pipelines'
+    // default `passes_jmt_filter` returns `true`.
+    let all_updates: Vec<_> = snapshot
+        .make_delta(last_snapshot)
+        .shards
+        .iter()
+        .map(|updates| {
+            let _timer = OTHER_TIMERS_SECONDS.timer_with(&["hash_jmt_updates"]);
+            updates
+                .iter()
+                .filter(|(_key_hash, slot)| slot.passes_jmt_filter(min_version))
+                .map(|(key_hash, slot)| leaf_entry_to_jmt_update(key_hash, &slot))
+                .collect::<Vec<_>>()
+        })
+        .collect();
 
-    pub fn run(mut self) {
-        while let Ok(msg) = self.state_snapshot_commit_receiver.recv() {
-            match msg {
-                CommitMessage::Data(SnapshotToCommit {
-                    snapshot,
-                    hot_state_updates,
-                }) => {
-                    let version = snapshot.version().expect("Cannot be empty");
-                    let base_version = self.last_snapshot.version();
-                    let previous_epoch_ending_version = self
-                        .state_db
-                        .ledger_db
-                        .metadata_db()
-                        .get_previous_epoch_ending(version)
-                        .unwrap()
-                        .map(|(v, _e)| v);
-                    let min_version = self.last_snapshot.next_version();
+    let hot_updates: Vec<_> = hot_state_updates
+        .into_iter()
+        .map(|shard| {
+            let _timer = OTHER_TIMERS_SECONDS.timer_with(&["hash_hot_jmt_updates"]);
+            shard
+                .insertions
+                .into_iter()
+                .map(|(key_hash, op)| (key_hash, Some((op.value.hash(), op.state_key))))
+                .chain(shard.evictions.into_keys().map(|key_hash| (key_hash, None)))
+                .collect()
+        })
+        .collect();
 
-                    // Element format: (key_hash, Option<(value_hash, key)>)
-                    let all_updates: Vec<_> = snapshot
-                        .make_delta(&self.last_snapshot)
-                        .shards
-                        .iter()
-                        .map(|updates| {
-                            let _timer = OTHER_TIMERS_SECONDS.timer_with(&["hash_jmt_updates"]);
-                            updates
-                                .iter()
-                                .filter(|(_key_hash, slot)| slot.passes_jmt_filter(min_version))
-                                .map(|(key_hash, slot)| leaf_entry_to_jmt_update(key_hash, &slot))
-                                .collect::<Vec<_>>()
-                        })
-                        .collect();
-
-                    let hot_updates: Vec<_> = hot_state_updates
-                        .into_iter()
-                        .map(|shard| {
-                            let _timer = OTHER_TIMERS_SECONDS.timer_with(&["hash_hot_jmt_updates"]);
-                            shard
-                                .insertions
-                                .into_iter()
-                                .map(|(key_hash, op)| {
-                                    (key_hash, Some((op.value.hash(), op.state_key)))
-                                })
-                                .chain(shard.evictions.into_keys().map(|key_hash| (key_hash, None)))
-                                .collect()
-                        })
-                        .collect();
-
-                    // TODO(HotState): for now we use `is_descendant_of` to determine if hot state
-                    // summary is computed at all. When it's not enabled everything is
-                    // `SparseMerkleTree::new_empty()`.
-                    let hot_state_merkle_batch_opt = if let (Some(new_hot), Some(old_hot)) = (
-                        snapshot.summary().hot_state_summary.as_ref(),
-                        self.last_snapshot.summary().hot_state_summary.as_ref(),
-                    ) && new_hot.is_descendant_of(old_hot)
-                    {
-                        self.state_db.hot_state_merkle_db.as_ref().map(|db| {
-                            Self::merklize(
-                                db,
-                                base_version,
-                                version,
-                                old_hot,
-                                new_hot,
-                                hot_updates.try_into().expect("Must be 16 shards."),
-                                previous_epoch_ending_version,
-                            )
-                            .expect("Failed to compute JMT commit batch for hot state.")
-                            .0
-                        })
-                    } else {
-                        // TODO(HotState): this means that the relevant code path isn't enabled yet.
-                        None
-                    };
-                    let (state_merkle_batch, leaf_count) = Self::merklize(
-                        &self.state_db.state_merkle_db,
+    // TODO(HotState): for now we use `is_descendant_of` to determine if hot state
+    // summary is computed at all. When it's not enabled everything is
+    // `SparseMerkleTree::new_empty()`.
+    let hot_pair = snapshot
+        .summary()
+        .hot_state_summary
+        .as_ref()
+        .zip(last_snapshot.summary().hot_state_summary.as_ref());
+    let hot_state_merkle_batch_opt = match hot_pair {
+        Some((snap_hot, last_hot)) if snap_hot.is_descendant_of(last_hot) => {
+            state_db.hot_state_merkle_db.as_ref().map(|db| {
+                let (_root, _leaf_count, top_levels_batch, batches_for_shards) = db
+                    .merklize_snapshot(
                         base_version,
                         version,
-                        &self.last_snapshot.summary().global_state_summary,
-                        &snapshot.summary().global_state_summary,
-                        all_updates.try_into().expect("Must be 16 shards."),
+                        last_hot,
+                        snap_hot,
+                        hot_updates.try_into().expect("Must be 16 shards."),
                         previous_epoch_ending_version,
                     )
-                    .expect("Failed to compute JMT commit batch.");
-                    let usage = snapshot.state().usage();
-                    if !usage.is_untracked() {
-                        assert_eq!(
-                            leaf_count,
-                            usage.items(),
-                            "Num of state items mismatch: jmt: {}, state: {}",
-                            leaf_count,
-                            usage.items(),
-                        );
-                    }
-
-                    self.last_snapshot = snapshot.clone();
-
-                    self.state_merkle_batch_commit_sender
-                        .send(CommitMessage::Data(StateMerkleCommit {
-                            snapshot,
-                            hot_batch: hot_state_merkle_batch_opt,
-                            cold_batch: state_merkle_batch,
-                        }))
-                        .unwrap();
-                },
-                CommitMessage::Sync(finish_sender) => {
-                    self.state_merkle_batch_commit_sender
-                        .send(CommitMessage::Sync(finish_sender))
-                        .unwrap();
-                },
-                CommitMessage::Exit => {
-                    self.state_merkle_batch_commit_sender
-                        .send(CommitMessage::Exit)
-                        .unwrap();
-                    break;
-                },
-            }
-        }
-        info!("State snapshot committing thread exit.");
-    }
-
-    fn merklize(
-        db: &StateMerkleDb,
-        base_version: Option<Version>,
-        version: Version,
-        last_smt: &SparseMerkleTree,
-        smt: &SparseMerkleTree,
-        all_updates: [Vec<(HashValue, Option<(HashValue, StateKey)>)>; NUM_STATE_SHARDS],
-        previous_epoch_ending_version: Option<Version>,
-    ) -> Result<(StateMerkleBatch, usize)> {
-        let shard_persisted_versions = db.get_shard_persisted_versions(base_version)?;
-
-        let (shard_root_nodes, batches_for_shards) =
-            THREAD_MANAGER.get_non_exe_cpu_pool().install(|| {
-                let _timer = OTHER_TIMERS_SECONDS.timer_with(&["calculate_batches_for_shards"]);
-                all_updates
-                    .par_iter()
-                    .enumerate()
-                    .map(|(shard_id, updates)| {
-                        let node_hashes = smt.new_node_hashes_since(last_smt, shard_id as u8);
-                        db.merklize_value_set_for_shard(
-                            shard_id,
-                            jmt_update_refs(updates),
-                            Some(&node_hashes),
-                            version,
-                            base_version,
-                            shard_persisted_versions[shard_id],
-                            previous_epoch_ending_version,
-                        )
-                    })
-                    .collect::<Result<Vec<_>>>()
-                    .expect("Error calculating StateMerkleBatch for shards.")
-                    .into_iter()
-                    .unzip()
-            });
-
-        let _timer = OTHER_TIMERS_SECONDS.timer_with(&["calculate_top_levels_batch"]);
-        let (root_hash, leaf_count, top_levels_batch) = db.calculate_top_levels(
-            shard_root_nodes,
-            version,
+                    .expect("Failed to compute JMT commit batch for hot state.");
+                MerkleBatch {
+                    top_levels_batch,
+                    batches_for_shards,
+                }
+            })
+        },
+        // TODO(HotState): this means that the relevant code path isn't enabled yet.
+        _ => None,
+    };
+    let (_root, leaf_count, top_levels_batch, batches_for_shards) = state_db
+        .state_merkle_db
+        .merklize_snapshot(
             base_version,
+            version,
+            &last_snapshot.summary().global_state_summary,
+            &snapshot.summary().global_state_summary,
+            all_updates.try_into().expect("Must be 16 shards."),
             previous_epoch_ending_version,
-        )?;
+        )
+        .expect("Failed to compute JMT commit batch.");
+    let state_merkle_batch = MerkleBatch {
+        top_levels_batch,
+        batches_for_shards,
+    };
+    let usage = snapshot.state().usage();
+    if !usage.is_untracked() {
         assert_eq!(
-            root_hash,
-            smt.root_hash(),
-            "root hash mismatch: jmt: {}, smt: {}",
-            root_hash,
-            smt.root_hash()
-        );
-
-        Ok((
-            StateMerkleBatch {
-                top_levels_batch,
-                batches_for_shards,
-            },
             leaf_count,
-        ))
+            usage.items(),
+            "Num of state items mismatch: jmt: {}, state: {}",
+            leaf_count,
+            usage.items(),
+        );
     }
-}
 
-impl Drop for StateSnapshotCommitter {
-    fn drop(&mut self) {
-        self.join_handle
-            .take()
-            .expect("state merkle batch commit thread must exist.")
-            .join()
-            .expect("state merkle batch thread should join peacefully.");
+    *last_snapshot = snapshot.clone();
+
+    StateMerkleCommit {
+        snapshot,
+        hot_batch: hot_state_merkle_batch_opt,
+        cold_batch: state_merkle_batch,
     }
 }


### PR DESCRIPTION
Lifts the two-stage async commit pipeline scaffolding out of `state_store::buffered_state` / `state_snapshot_committer` / `state_merkle_batch_committer` into `crate::common` so multiple JMT-sharded subsystems can share the exact same shells. Main state is migrated to the new primitives in this PR; behavior is unchanged.

New in `crate::common`:

- `CommitMessage<T>` — `Data(T) | Sync(Sender<()>) | Exit`. Promoted from `state_store::buffered_state`.
- `AsyncCommitThread<T>` — channel + named-thread spawn + sync barrier + Exit-on-drop. Replaces the hand-rolled channel/join bookkeeping previously duplicated in each pipeline stage.
- `SnapshotCommitter<S, I, O>` — generic first-stage committer shell. Holds `last_snapshot`, the incoming `Receiver`, and the downstream `AsyncCommitThread`. `run(merklize)` drives the Data/Sync/Exit loop; the merklize closure carries pipeline-specific DB handles.
- `BufferedStateCore<L, S, P>` — generic buffered-state core. Wraps `Arc<Mutex<L>>` + `last_snapshot` + commit thread, exposes `should_commit` / `enqueue` / `drain_if_sync` / `quit`.
- Traits `CheckpointSnapshot` + `LedgerStateView` so the core is generic over the latest-state-view type. `LedgerStateView` carries `is_descendant_of` so `BufferedState::update` can re-assert `new_state.is_descendant_of(&old_state)` (which the old `state_store::buffered_state::update` enforced).
- Free helpers `run_snapshot_committer_loop`, `run_batch_committer_loop`, `populate_jmt_writes` for callers that want the channel-forwarding loop or the `TreeUpdateBatch → SchemaBatch` translation without the struct shell.

Main-state migration:
- `state_store::BufferedState` composes `BufferedStateCore`.
- `state_store::StateSnapshotCommitter` struct is gone — replaced by an inline construction of `SnapshotCommitter<StateWithSummary, SnapshotToCommit, StateMerkleCommit>` in `BufferedState::new_at_snapshot`. Merklize logic kept as a free `merklize_main_state` fn.
- `state_store::StateMerkleBatchCommitter::run` is reduced to driving `run_batch_committer_loop`; the method bodies become free `commit_state_merkle_batch` + `check_usage_consistency` fns.
- `state_store::StateStore::reset` calls `buffered_state.lock().quit()` *before* constructing the replacement, draining the old pipeline against the old chain family. Doing the shutdown lazily via `Drop` would let the old thread's drop-time `sync_commit` read the new family and panic on `is_descendant_of`.
- `sharded_jmt_merkle_db::create_jmt_commit_batch_for_shard` is routed through the new `populate_jmt_writes` helper.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors background threads, channels, and shutdown ordering on the state Merkle commit path; incorrect lifecycle handling could cause panics or inconsistent commits on reset.
> 
> **Overview**
> Introduces **`crate::common`** as the shared shell for AptosDB’s two-stage async commit path: `CommitMessage`, `AsyncCommitThread` (spawn, sync drain, exit-on-drop), `spawn_commit_pipeline` / `SnapshotCommitter`, generic **`BufferedState`** + **`BufferedStateCore`**, and helpers like **`populate_jmt_writes`** and **`merklize_snapshot`**.
> 
> **Main state** is rewired to compose those primitives instead of hand-rolled channels/threads: `BufferedState` is now a thin wrapper with **`HotStateAccumulator`**, snapshot merklization lives in **`merklize_main_state`**, and the batch stage drives **`run_batch_committer_loop`**. **`StateStore::reset`** explicitly **`quit()`**s the old pipeline before repointing in-memory state so drop-time sync cannot cross MapLayer families and trip **`is_descendant_of`**.
> 
> **`ShardedJmtMerkleDb`** centralizes JMT write batching via **`populate_jmt_writes`**, adds **`merklize_snapshot`** (parallel shards + JMT/SMT root assert), and moves LRU eviction into **`commit`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8297de889d899594feb9e4f0a511e93c6bae1af7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->