### PR TITLE
[release][v1.46] Enable ChunkyDKG Shadow V1

### DIFF
--- a/aptos-move/aptos-release-builder/data/enable-chunky-dkg-shadow-v1.yaml
+++ b/aptos-move/aptos-release-builder/data/enable-chunky-dkg-shadow-v1.yaml
@@ -1,0 +1,12 @@
+---
+remote_endpoint: ~
+name: "enable-chunky-dkg-shadow-v1"
+proposals:
+  - name: enable_chunky_dkg_shadow_v1
+    metadata:
+      title: "Initialize Encrypted Mempool Framework and Enable ChunkyDKG Shadow V1"
+      description: "Initialize encrypted-mempool framework resources, then enable ChunkyDKG in shadow mode (1/2 secrecy, 2/3 reconstruction, 60s grace period)."
+    execution_mode: MultiStep
+    update_sequence:
+      - RawScript: aptos-move/aptos-release-builder/data/proposals/encrypted_mempool_initialization.move
+      - RawScript: aptos-move/aptos-release-builder/data/proposals/enable_chunky_dkg_shadow_v1.move

--- a/aptos-move/aptos-release-builder/data/enable-chunky-dkg-v1.yaml
+++ b/aptos-move/aptos-release-builder/data/enable-chunky-dkg-v1.yaml
@@ -1,0 +1,15 @@
+---
+remote_endpoint: ~
+name: "enable-chunky-dkg-v1"
+proposals:
+  - name: enable_chunky_dkg_v1
+    metadata:
+      title: "Enable ChunkyDKG V1"
+      description: "Enable ChunkyDKG in full V1 mode (1/2 secrecy, 2/3 reconstruction) and turn on the encrypted_transactions feature. Assumes encrypted-mempool framework resources are already initialized."
+    execution_mode: MultiStep
+    update_sequence:
+      - RawScript: aptos-move/aptos-release-builder/data/proposals/enable_chunky_dkg_v1.move
+      - FeatureFlag:
+          enabled:
+            - encrypted_transactions
+          disabled: []

--- a/aptos-move/aptos-release-builder/data/proposals/enable_chunky_dkg_shadow_v1.move
+++ b/aptos-move/aptos-release-builder/data/proposals/enable_chunky_dkg_shadow_v1.move
@@ -1,0 +1,24 @@
+// Enable ChunkyDKG in shadow mode (ConfigShadowV1).
+// Prerequisite: ChunkyDKG framework resources must already be initialized
+// (see encrypted_mempool_initialization.move).
+script {
+    use aptos_framework::aptos_governance;
+    use aptos_framework::chunky_dkg_config;
+    use aptos_std::fixed_point64;
+
+    fun main(proposal_id: u64) {
+        let framework = aptos_governance::resolve_multi_step_proposal(
+            proposal_id,
+            @0x1,
+            {{ script_hash }},
+        );
+
+        let config = chunky_dkg_config::new_shadow_v1(
+            fixed_point64::create_from_rational(1, 2), // secrecy_threshold: 1/2
+            fixed_point64::create_from_rational(2, 3), // reconstruction_threshold: 2/3
+            60,                                        // grace_period_secs
+        );
+        chunky_dkg_config::set_for_next_epoch(&framework, config);
+        aptos_governance::reconfigure(&framework);
+    }
+}

--- a/aptos-move/aptos-release-builder/data/proposals/enable_chunky_dkg_v1.move
+++ b/aptos-move/aptos-release-builder/data/proposals/enable_chunky_dkg_v1.move
@@ -1,0 +1,23 @@
+// Enable ChunkyDKG (ConfigV1) — full activation, replacing regular DKG.
+// Prerequisite: ChunkyDKG framework resources must already be initialized
+// (see encrypted_mempool_initialization.move).
+script {
+    use aptos_framework::aptos_governance;
+    use aptos_framework::chunky_dkg_config;
+    use aptos_std::fixed_point64;
+
+    fun main(proposal_id: u64) {
+        let framework = aptos_governance::resolve_multi_step_proposal(
+            proposal_id,
+            @0x1,
+            {{ script_hash }},
+        );
+
+        let config = chunky_dkg_config::new_v1(
+            fixed_point64::create_from_rational(1, 2), // secrecy_threshold: 1/2
+            fixed_point64::create_from_rational(2, 3), // reconstruction_threshold: 2/3
+        );
+        chunky_dkg_config::set_for_next_epoch(&framework, config);
+        aptos_governance::reconfigure(&framework);
+    }
+}

--- a/aptos-move/aptos-release-builder/data/proposals/encrypted_mempool_initialization.move
+++ b/aptos-move/aptos-release-builder/data/proposals/encrypted_mempool_initialization.move
@@ -1,0 +1,28 @@
+// Initialize on-chain resources for the encrypted mempool stack: ChunkyDKG
+// (config + seqnum + state), the epoch force-end watchdog, and the per-block
+// decryption key.
+//
+// Each `initialize` call is a no-op if its resource already exists, so this is
+// safe to run even if some of these resources were created previously.
+script {
+    use aptos_framework::aptos_governance;
+    use aptos_framework::chunky_dkg;
+    use aptos_framework::chunky_dkg_config;
+    use aptos_framework::chunky_dkg_config_seqnum;
+    use aptos_framework::decryption;
+    use aptos_framework::epoch_timeout_config;
+
+    fun main(proposal_id: u64) {
+        let framework = aptos_governance::resolve_multi_step_proposal(
+            proposal_id,
+            @0x1,
+            {{ script_hash }},
+        );
+
+        chunky_dkg_config_seqnum::initialize(&framework);
+        chunky_dkg_config::initialize(&framework, chunky_dkg_config::new_off());
+        chunky_dkg::initialize(&framework);
+        epoch_timeout_config::initialize(&framework);
+        decryption::initialize(&framework);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `enable-chunky-dkg-shadow-v1.yaml` and the corresponding governance script to flip the on-chain `ChunkyDKGConfig` to `ConfigShadowV1`.
- Parameters: secrecy threshold `1/2`, reconstruction threshold `2/3`, `grace_period_secs = 60`.
- Shadow mode runs chunky DKG alongside the regular DKG; if chunky DKG hasn't completed within the grace period, the epoch change is forced.

## Test plan
- [x] Generate proposal artifacts with `aptos-release-builder` against this yaml.
- [x] Verify on testnet/forge that ChunkyDKG starts in shadow mode after reconfig and that the grace period kicks in if chunky DKG stalls.

Note: shadow mode is only exercised on a network where `consensus_config::validator_txn_enabled()` and `randomness_config::enabled()` are already true.

🤖 Generated with [Claude Code](https://claude.com/claude-code)