### PR TITLE
Change benchmark BlockMetadata

### DIFF
--- a/execution/executor-benchmark/src/native/native_transaction.rs
+++ b/execution/executor-benchmark/src/native/native_transaction.rs
@@ -122,6 +122,7 @@ impl NativeTransaction {
             },
             aptos_types::transaction::Transaction::BlockEpilogue(_) => Self::BlockEpilogue,
             aptos_types::transaction::Transaction::BlockMetadata(_) => Self::BlockMetadata,
+            aptos_types::transaction::Transaction::BlockMetadataExt(_) => Self::BlockMetadata,
             _ => unimplemented!("non-user transaction {:?}", txn),
         }
     }

--- a/execution/executor-benchmark/src/transaction_generator.rs
+++ b/execution/executor-benchmark/src/transaction_generator.rs
@@ -19,8 +19,10 @@ use aptos_types::{
     account_address::AccountAddress,
     account_config::{aptos_test_root_address, AccountResource, BlockResource, CORE_CODE_ADDRESS},
     block_metadata::BlockMetadata,
+    block_metadata_ext::BlockMetadataExt,
     chain_id::ChainId,
     on_chain_config::ConfigurationResource,
+    randomness::{RandMetadata, Randomness},
     state_store::MoveResourceExt,
     timestamp::TimestampResource,
     transaction::{
@@ -31,7 +33,7 @@ use chrono::Local;
 use indicatif::{ProgressBar, ProgressStyle};
 use itertools::Itertools;
 use move_core_types::{ident_str, language_storage::ModuleId};
-use rand::{rngs::StdRng, seq::SliceRandom, thread_rng, Rng, SeedableRng};
+use rand::{rngs::StdRng, seq::SliceRandom, thread_rng, Rng, RngCore, SeedableRng};
 use rayon::{
     iter::{IntoParallelRefIterator, IntoParallelRefMutIterator, ParallelIterator},
     ThreadPool, ThreadPoolBuilder,
@@ -168,7 +170,7 @@ impl BenchmarkTimestamp {
         self.base_usecs / 1_000_000 + 60
     }
 
-    /// Creates a `BlockMetadata` transaction for the next block, using a
+    /// Creates a `BlockMetadataExt` transaction for the next block, using a
     /// strictly increasing timestamp derived from this `BenchmarkTimestamp`.
     pub fn next_block_metadata_txn(&self, db: &DbReaderWriter) -> Transaction {
         let (round, timestamp_usecs) = self.next_round_and_timestamp();
@@ -180,7 +182,17 @@ impl BenchmarkTimestamp {
             timestamp_usecs
         );
 
-        Transaction::BlockMetadata(BlockMetadata::new(
+        let mut seed = vec![0u8; 32];
+        thread_rng().fill_bytes(&mut seed);
+        let randomness = Randomness::new(
+            RandMetadata {
+                epoch: self.epoch(),
+                round,
+            },
+            seed,
+        );
+
+        Transaction::BlockMetadataExt(BlockMetadataExt::new_v1(
             HashValue::random(),
             self.epoch(),
             round,
@@ -188,6 +200,7 @@ impl BenchmarkTimestamp {
             vec![],
             vec![],
             timestamp_usecs,
+            Some(randomness),
         ))
     }
 
@@ -197,6 +210,13 @@ impl BenchmarkTimestamp {
     /// computes a timestamp that triggers reconfiguration
     /// (`last_reconfig_time + epoch_interval + 1`), and returns the
     /// block (a `Vec<Transaction>` with one `BlockMetadata` entry).
+    ///
+    /// Uses `BlockMetadata` (not `BlockMetadataExt`) so that `block_prologue`
+    /// calls `reconfiguration::reconfigure()` directly and the epoch advances
+    /// immediately.  `BlockMetadataExt` would initiate a DKG session via
+    /// `reconfiguration_with_dkg::try_start()`, which can never complete in the
+    /// benchmark environment (no real DKG infrastructure), causing the epoch
+    /// change to stall.
     ///
     /// After committing this block, callers should use
     /// `BenchmarkTimestamp::from_db()` to get a fresh timestamp state


### PR DESCRIPTION
use blockMetadataExt instead to have rand metadata in benchmark framework

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to the executor-benchmark harness and native transaction classification; epoch reconfiguration behavior is explicitly preserved via plain BlockMetadata.
> 
> **Overview**
> Benchmark block prologues now use **`BlockMetadataExt`** (v1) with synthetic **`Randomness`** (`RandMetadata` for the current epoch/round plus a 32-byte random seed) instead of plain **`BlockMetadata`**, so normal benchmark blocks carry rand metadata closer to production.
> 
> **`epoch_change_block`** still emits **`BlockMetadata`** only: **`BlockMetadataExt`** would start DKG via `reconfiguration_with_dkg::try_start()`, which cannot finish in the benchmark harness and would stall epoch changes.
> 
> The native executor benchmark path maps **`Transaction::BlockMetadataExt`** to the same **`NativeTransaction::BlockMetadata`** handling as classic block metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c705584710a5aaf91c7e1d0983718532529c08d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->