### PR TITLE
[trading-native][storage-core] Commit applier + JMT pipeline + AptosDB wiring

### DIFF
--- a/storage/aptosdb/Cargo.toml
+++ b/storage/aptosdb/Cargo.toml
@@ -20,6 +20,7 @@ aptos-crypto = { workspace = true }
 aptos-db-indexer = { workspace = true }
 aptos-db-indexer-schemas = { workspace = true, features = ["fuzzing"] }
 aptos-executor-types = { workspace = true }
+aptos-experimental-layered-map = { workspace = true }
 aptos-experimental-runtimes = { workspace = true }
 aptos-infallible = { workspace = true }
 aptos-jellyfish-merkle = { workspace = true }

--- a/storage/aptosdb/src/common.rs
+++ b/storage/aptosdb/src/common.rs
@@ -449,3 +449,27 @@ where
         }
     }
 }
+
+/// `current_state` is shared with outside readers; `buffered_state` is
+/// the commit-path mutex.
+pub struct PipelineStateStore<L, BS> {
+    current_state: Arc<Mutex<L>>,
+    buffered_state: Mutex<BS>,
+}
+
+impl<L, BS> PipelineStateStore<L, BS> {
+    pub fn from_parts(current_state: Arc<Mutex<L>>, buffered_state: BS) -> Self {
+        Self {
+            current_state,
+            buffered_state: Mutex::new(buffered_state),
+        }
+    }
+
+    pub fn current_state(&self) -> Arc<Mutex<L>> {
+        Arc::clone(&self.current_state)
+    }
+
+    pub(crate) fn buffered_state_locked(&self) -> aptos_infallible::MutexGuard<'_, BS> {
+        self.buffered_state.lock()
+    }
+}

--- a/storage/aptosdb/src/db/aptosdb_internal.rs
+++ b/storage/aptosdb/src/db/aptosdb_internal.rs
@@ -11,6 +11,7 @@ use crate::{
     state_kv_db::StateKvDb,
     state_merkle_db::StateMerkleDb,
     state_store::{StatePruner, StateStore},
+    trading_native::ENABLE_TRADING_NATIVE,
     transaction_store::TransactionStore,
 };
 #[cfg(any(test, feature = "db-debugger"))]
@@ -84,6 +85,9 @@ impl AptosDB {
             hot_state_config,
         ));
 
+        // The native-position DB isn't open here; it attaches later
+        // via `AptosDB::init_native_position`, which re-binds the
+        // pruner via `LedgerPrunerManager::attach_native_pruners`.
         let ledger_pruner = LedgerPrunerManager::new(
             Arc::clone(&ledger_db),
             pruner_config.ledger_pruner_config,
@@ -106,6 +110,7 @@ impl AptosDB {
             pre_commit_lock: std::sync::Mutex::new(()),
             commit_lock: std::sync::Mutex::new(()),
             update_subscriber: None,
+            position: None,
         }
     }
 
@@ -155,7 +160,7 @@ impl AptosDB {
             db.write_pruner_progress(synced_version)?;
         }
 
-        let myself = Self::new_with_dbs(
+        let mut myself = Self::new_with_dbs(
             ledger_db,
             hot_state_merkle_db,
             state_merkle_db,
@@ -168,6 +173,17 @@ impl AptosDB {
             internal_indexer_db,
             hot_state_config,
         );
+
+        if ENABLE_TRADING_NATIVE {
+            myself.init_native_position(
+                db_paths,
+                rocksdb_configs.state_kv_db_config,
+                rocksdb_configs.state_merkle_db_config,
+                &env,
+                &block_cache,
+                readonly,
+            )?;
+        }
 
         if !readonly {
             if let Some(version) = myself.get_synced_version()? {

--- a/storage/aptosdb/src/db/aptosdb_native_position.rs
+++ b/storage/aptosdb/src/db/aptosdb_native_position.rs
@@ -1,0 +1,250 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+use crate::{
+    db::AptosDB,
+    native_state_committer::NativeStateCommitter,
+    position_buffered_state::{
+        new_empty_position_state, position_state_at_version, PositionLedgerStateWithSummary,
+        PositionProofReader, PositionSlot,
+    },
+    position_db::{PositionDb, NUM_NATIVE_VALUE_SHARDS},
+    position_merkle_db::PositionMerkleDb,
+    position_state_store::PositionStateStore,
+    utils::truncation_helper::{
+        get_position_commit_progress, get_position_merkle_commit_progress,
+        truncate_position_db_shards, truncate_position_merkle_db,
+    },
+};
+use aptos_config::config::{RocksdbConfig, StorageDirPaths};
+use aptos_crypto::{hash::CryptoHash, HashValue};
+use aptos_logger::info;
+use aptos_schemadb::{Cache, Env};
+use aptos_storage_interface::{AptosDbError, Result};
+use aptos_types::{state_store::state_value::StateValue, transaction::Version};
+use std::{collections::HashMap, sync::Arc};
+
+pub struct PositionBundle {
+    pub kv_db: Arc<PositionDb>,
+    pub merkle_db: Arc<PositionMerkleDb>,
+    /// `None` in readonly mode.
+    pub(crate) state_store: Option<Arc<PositionStateStore>>,
+    /// JMT version the in-memory MapLayer chain is rooted at — the
+    /// version `PositionProofReader` queries. Stays at init time
+    /// because the chain doesn't rebase as new snapshots are taken
+    /// (the chain just grows). When chain-rebasing lands, update
+    /// this alongside the rebase.
+    pub(crate) snapshot_version: Option<Version>,
+}
+
+impl AptosDB {
+    pub fn position(&self) -> Option<&Arc<PositionBundle>> {
+        self.position.as_ref()
+    }
+
+    pub fn native_state_committer(&self) -> Option<NativeStateCommitter> {
+        let bundle = self.position.as_ref()?;
+        Some(NativeStateCommitter::new(bundle.kv_db.clone()))
+    }
+
+    /// Called automatically from `open_internal` when
+    /// `ENABLE_TRADING_NATIVE` is `true`. Shares `env` and
+    /// `block_cache` with the main AptosDB so RocksDB background
+    /// threads and the block cache stay singleton.
+    pub fn init_native_position(
+        &mut self,
+        db_paths: &StorageDirPaths,
+        kv_config: RocksdbConfig,
+        merkle_config: RocksdbConfig,
+        env: &Env,
+        block_cache: &Cache,
+        readonly: bool,
+    ) -> Result<()> {
+        if self.position.is_some() {
+            return Err(AptosDbError::Other(
+                "init_native_position called twice; native-position subsystem is already \
+                 attached to this AptosDB"
+                    .to_string(),
+            ));
+        }
+
+        let position_db =
+            PositionDb::new(db_paths, kv_config, Some(env), Some(block_cache), readonly)?;
+        let merkle_db = PositionMerkleDb::new(
+            db_paths,
+            merkle_config,
+            Some(env),
+            Some(block_cache),
+            readonly,
+            /* max_nodes_per_lru_cache_shard */ 0,
+        )?;
+
+        // Mirror `StateStore::sync_commit_progress`: align both
+        // position DBs with the ledger's `OverallCommitProgress`
+        // (truncating ahead-of-chain rows from a crash) and find the
+        // latest JMT snapshot at or before that point.
+        let merkle_progress = if readonly {
+            None
+        } else {
+            self.sync_position_commit_progress(&position_db, &merkle_db)?
+        };
+
+        let kv_db = Arc::new(position_db);
+        let merkle_db = Arc::new(merkle_db);
+
+        let state_store = if readonly {
+            None
+        } else {
+            let last_snapshot = match merkle_progress {
+                Some(version) => {
+                    let root_hash = merkle_db.get_root_hash(version)?;
+                    position_state_at_version(version, root_hash)
+                },
+                None => new_empty_position_state(),
+            };
+            Some(Arc::new(PositionStateStore::new_at_snapshot(
+                Arc::clone(&merkle_db),
+                Arc::clone(&self.ledger_db),
+                last_snapshot,
+            )))
+        };
+
+        // Replay write sets between the JMT snapshot and the chain
+        // tip so the in-memory pipeline + the JMT catch up to
+        // `OverallCommitProgress`.
+        if let Some(store) = state_store.as_ref()
+            && let Some(v_overall) = self.ledger_db.metadata_db().get_synced_version()?
+        {
+            let snapshot_next_version = merkle_progress.map_or(0, |v| v + 1);
+            if snapshot_next_version <= v_overall {
+                self.replay_position_after_snapshot(
+                    store,
+                    &merkle_db,
+                    snapshot_next_version,
+                    v_overall + 1,
+                )?;
+            }
+        }
+
+        self.position = Some(Arc::new(PositionBundle {
+            kv_db,
+            merkle_db,
+            state_store,
+            snapshot_version: merkle_progress,
+        }));
+
+        info!(
+            num_shards = NUM_NATIVE_VALUE_SHARDS,
+            readonly = readonly,
+            "Native-position subsystem initialized."
+        );
+
+        Ok(())
+    }
+
+    /// Align position DB progress with the chain. Truncates `kv_db`
+    /// down to `OverallCommitProgress` if it ran ahead (crash between
+    /// the position commit and the ledger's commit-progress write),
+    /// and returns the merkle DB's latest snapshot version after
+    /// truncating it to its own progress. The merkle DB should never
+    /// exceed `OverallCommitProgress` in normal operation.
+    fn sync_position_commit_progress(
+        &self,
+        position_db: &PositionDb,
+        merkle_db: &PositionMerkleDb,
+    ) -> Result<Option<Version>> {
+        let v_overall = self.ledger_db.metadata_db().get_synced_version()?;
+
+        if let Some(v_kv) = get_position_commit_progress(position_db)? {
+            let target = v_overall.map_or(0, |v| std::cmp::min(v_kv, v));
+            if v_kv != target {
+                info!(
+                    v_kv = v_kv,
+                    v_overall = ?v_overall,
+                    target = target,
+                    "Truncating position_db down to chain's OverallCommitProgress."
+                );
+            }
+            truncate_position_db_shards(position_db, target)?;
+        }
+
+        let progress = get_position_merkle_commit_progress(merkle_db)?;
+        if let Some(v_merkle) = progress {
+            if let Some(v) = v_overall {
+                assert!(
+                    v_merkle <= v,
+                    "position_merkle_db at version {v_merkle} is ahead of chain {v}"
+                );
+            }
+            truncate_position_merkle_db(merkle_db, v_merkle)?;
+        }
+        Ok(progress)
+    }
+
+    /// Replay `WriteSet`s in `[snapshot_next_version, num_transactions)`
+    /// — the gap between the persisted JMT snapshot and the chain
+    /// tip. Coalesces latest-wins-per-key, extends in one shot, and
+    /// sync-commits the resulting snapshot before returning.
+    fn replay_position_after_snapshot(
+        &self,
+        store: &PositionStateStore,
+        merkle_db: &Arc<PositionMerkleDb>,
+        snapshot_next_version: Version,
+        num_transactions: u64,
+    ) -> Result<()> {
+        info!(
+            snapshot_next_version = snapshot_next_version,
+            num_transactions = num_transactions,
+            "Replaying position write sets to catch up the in-memory pipeline."
+        );
+
+        let write_sets = self
+            .ledger_db
+            .write_set_db()
+            .get_write_sets(snapshot_next_version, num_transactions)?;
+
+        let mut pending_leaf_updates: HashMap<HashValue, PositionSlot> = HashMap::new();
+        for write_set in &write_sets {
+            for (key, op) in write_set.native_position_iter() {
+                let maybe_value = op.as_write_op().as_state_value_opt().cloned();
+                let value_hash = maybe_value.as_ref().map(StateValue::hash);
+                pending_leaf_updates.insert(key.hash(), PositionSlot {
+                    state_key: key.clone(),
+                    value_hash,
+                    value: None,
+                });
+            }
+        }
+
+        if pending_leaf_updates.is_empty() {
+            return Ok(());
+        }
+
+        let state_lock = store.current_state();
+        let pipeline_latest = state_lock.lock().latest().clone();
+        let snapshot_version = pipeline_latest.version();
+
+        let target_version = num_transactions - 1;
+        let updates: Vec<_> = pending_leaf_updates.into_iter().collect();
+        let proof_reader = PositionProofReader {
+            merkle_db: Arc::clone(merkle_db),
+            version: snapshot_version,
+        };
+        let new_latest = pipeline_latest.extend(target_version, updates, &proof_reader)?;
+
+        // Treat the target as a checkpoint so the buffered_state
+        // sync-commits the JMT snapshot before we return.
+        let new_state = PositionLedgerStateWithSummary::from_latest_and_last_checkpoint(
+            new_latest.clone(),
+            new_latest,
+        );
+        let mut bufstate = store.buffered_state_locked();
+        bufstate.update(
+            new_state,
+            (),
+            write_sets.len(),
+            /* sync_commit = */ true,
+        )?;
+        Ok(())
+    }
+}

--- a/storage/aptosdb/src/db/aptosdb_writer.rs
+++ b/storage/aptosdb/src/db/aptosdb_writer.rs
@@ -13,6 +13,11 @@ use crate::{
     metrics::{
         COMMITTED_TXNS, LATEST_TXN_VERSION, LEDGER_VERSION, NEXT_BLOCK_EPOCH, OTHER_TIMERS_SECONDS,
     },
+    native_state_committer::{new_sharded_kv_batches, InChunkPriorVersions, NativeStateCommitter},
+    position_buffered_state::{
+        PositionLedgerStateWithSummary, PositionProofReader, PositionSlot, PositionStateWithSummary,
+    },
+    position_state_store::PositionStateStore,
     pruner::PrunerManager,
     schema::{
         db_metadata::{DbMetadataKey, DbMetadataSchema, DbMetadataValue},
@@ -40,7 +45,14 @@ use aptos_types::{
     write_set::WriteSet,
 };
 use rayon::prelude::*;
-use std::{iter::Iterator, time::Instant};
+use std::{collections::HashMap, iter::Iterator, sync::Arc, time::Instant};
+
+struct ChainPipeline<'a> {
+    store: &'a Arc<PositionStateStore>,
+    latest: PositionStateWithSummary,
+    last_checkpoint: PositionStateWithSummary,
+    snapshot_version: Option<Version>,
+}
 
 impl DbWriter for AptosDB {
     fn pre_commit_ledger(&self, chunk: ChunkToCommit, sync_commit: bool) -> Result<()> {
@@ -310,9 +322,127 @@ impl AptosDB {
                     .commit_transaction_accumulator(chunk.first_version, chunk.transaction_infos)
                     .unwrap()
             });
+            if self.position.is_some() {
+                s.spawn(|_| self.commit_native_position(chunk).unwrap());
+            }
         });
 
         Ok(new_root_hash)
+    }
+
+    fn commit_native_position(&self, chunk: &ChunkToCommit) -> Result<()> {
+        let _timer = OTHER_TIMERS_SECONDS.timer_with(&["commit_native_position"]);
+        let Some(bundle) = self.position.as_ref() else {
+            return Ok(());
+        };
+        if chunk.transaction_outputs.is_empty() {
+            return Ok(());
+        }
+        let committer = NativeStateCommitter::new(bundle.kv_db.clone());
+
+        let chunk_first = chunk.first_version;
+        let chunk_last_inclusive = chunk_first + chunk.transaction_outputs.len() as Version - 1;
+        let chunk_checkpoint_version = chunk.state.last_checkpoint().version();
+        let checkpoint_within_chunk =
+            chunk_checkpoint_version.filter(|v| (chunk_first..=chunk_last_inclusive).contains(v));
+
+        let mut chain = bundle.state_store.as_ref().map(|store| {
+            let state = store.current_state();
+            let current = state.lock();
+            ChainPipeline {
+                store,
+                latest: current.latest().clone(),
+                last_checkpoint: current.last_checkpoint().clone(),
+                // The persisted JMT root the in-memory MapLayer
+                // chain is rooted at — what proof_reader queries.
+                snapshot_version: bundle.snapshot_version,
+            }
+        });
+
+        // Accumulate the whole chunk into per-shard batches; commit
+        // once at the end.
+        let mut sharded_kv_batches = new_sharded_kv_batches();
+        let mut in_chunk_prior = InChunkPriorVersions::new();
+
+        // SMT leaf updates queued for the next extend call. Within a
+        // segment (chunk_first..=checkpoint, then checkpoint+1..=chunk_last)
+        // each key collapses to its latest write; `committer.apply`
+        // still records every per-version write into the kv batches
+        // and stale-index.
+        let mut pending_leaf_updates: HashMap<HashValue, PositionSlot> = HashMap::new();
+
+        for (i, output) in chunk.transaction_outputs.iter().enumerate() {
+            let version = chunk_first + i as Version;
+            let position_writes: Vec<_> = output
+                .write_set()
+                .native_position_iter()
+                .map(|(k, op)| (k.clone(), op.as_write_op().clone()))
+                .collect();
+            if !position_writes.is_empty() {
+                let merkle_updates = committer
+                    .apply(
+                        version,
+                        position_writes,
+                        &mut sharded_kv_batches,
+                        &mut in_chunk_prior,
+                    )
+                    .map_err(|e| AptosDbError::Other(format!("native commit: {e}")))?
+                    .position;
+                for u in merkle_updates {
+                    pending_leaf_updates.insert(u.state_key_hash, PositionSlot {
+                        state_key: u.state_key,
+                        value_hash: u.value_hash,
+                        value: None,
+                    });
+                }
+            }
+
+            if Some(version) == checkpoint_within_chunk
+                && let Some(pipeline) = chain.as_mut()
+                && !pending_leaf_updates.is_empty()
+            {
+                let updates: Vec<_> = std::mem::take(&mut pending_leaf_updates)
+                    .into_iter()
+                    .collect();
+                let proof_reader = PositionProofReader {
+                    merkle_db: bundle.merkle_db.clone(),
+                    version: pipeline.snapshot_version,
+                };
+                let new_latest = pipeline.latest.extend(version, updates, &proof_reader)?;
+                pipeline.last_checkpoint = new_latest.clone();
+                pipeline.latest = new_latest;
+            }
+        }
+
+        if !pending_leaf_updates.is_empty()
+            && let Some(pipeline) = chain.as_mut()
+        {
+            let updates: Vec<_> = pending_leaf_updates.into_iter().collect();
+            let proof_reader = PositionProofReader {
+                merkle_db: bundle.merkle_db.clone(),
+                version: pipeline.snapshot_version,
+            };
+            pipeline.latest =
+                pipeline
+                    .latest
+                    .extend(chunk_last_inclusive, updates, &proof_reader)?;
+        }
+
+        bundle
+            .kv_db
+            .commit(chunk_last_inclusive, None, sharded_kv_batches)
+            .map_err(|e| AptosDbError::Other(format!("position_db commit failed: {e}")))?;
+
+        if let Some(pipeline) = chain {
+            let new_state = PositionLedgerStateWithSummary::from_latest_and_last_checkpoint(
+                pipeline.latest,
+                pipeline.last_checkpoint,
+            );
+            let estimated_items = chunk.transaction_outputs.len();
+            let mut bufstate = pipeline.store.buffered_state_locked();
+            bufstate.update(new_state, (), estimated_items, /* sync_commit */ false)?;
+        }
+        Ok(())
     }
 
     fn commit_state_kv_and_ledger_metadata(&self, chunk: &ChunkToCommit) -> Result<()> {

--- a/storage/aptosdb/src/db/mod.rs
+++ b/storage/aptosdb/src/db/mod.rs
@@ -2,10 +2,11 @@
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
-    backup::backup_handler::BackupHandler, event_store::EventStore, ledger_db::LedgerDb,
-    pruner::LedgerPrunerManager, rocksdb_property_reporter::RocksdbPropertyReporter,
-    state_kv_db::StateKvDb, state_merkle_db::StateMerkleDb, state_store::StateStore,
-    transaction_store::TransactionStore,
+    backup::backup_handler::BackupHandler, db::aptosdb_native_position::PositionBundle,
+    event_store::EventStore, ledger_db::LedgerDb, position_db::PositionDb,
+    position_merkle_db::PositionMerkleDb, pruner::LedgerPrunerManager,
+    rocksdb_property_reporter::RocksdbPropertyReporter, state_kv_db::StateKvDb,
+    state_merkle_db::StateMerkleDb, state_store::StateStore, transaction_store::TransactionStore,
 };
 use aptos_config::config::{HotStateConfig, PrunerConfig, RocksdbConfigs, StorageDirPaths};
 use aptos_db_indexer::db_indexer::InternalIndexerDB;
@@ -37,6 +38,7 @@ pub struct AptosDB {
     /// This is just to detect concurrent calls to `commit_ledger()`
     commit_lock: std::sync::Mutex<()>,
     update_subscriber: Option<Sender<(Instant, Version)>>,
+    pub(crate) position: Option<Arc<PositionBundle>>,
 }
 
 // DbReader implementations and private functions used by them.
@@ -45,6 +47,9 @@ mod aptosdb_reader;
 mod aptosdb_writer;
 // Other private methods.
 mod aptosdb_internal;
+// Native-position subsystem: `PositionBundle` + `impl AptosDB` for
+// `position()` / `native_state_committer()` / `init_native_position()`.
+mod aptosdb_native_position;
 // Testonly methods.
 #[cfg(any(test, feature = "fuzzing", feature = "consensus-only-perf-test"))]
 mod aptosdb_testonly;
@@ -212,6 +217,13 @@ impl AptosDB {
             cp_path.as_ref(),
             /* is_hot = */ false,
         )?;
+        // Native-position DBs. The static `create_checkpoint` opens
+        // the source DB from `db_path` (creating it if absent), then
+        // checkpoints into `cp_path`. Deployments that never activated
+        // native-position still produce empty position checkpoints —
+        // matches state's always-create behavior.
+        PositionDb::create_checkpoint(db_path.as_ref(), cp_path.as_ref())?;
+        PositionMerkleDb::create_checkpoint(db_path.as_ref(), cp_path.as_ref())?;
 
         info!(
             db_path = db_path.as_ref(),

--- a/storage/aptosdb/src/lib.rs
+++ b/storage/aptosdb/src/lib.rs
@@ -31,11 +31,23 @@ mod db_options;
 mod event_store;
 mod ledger_db;
 mod lru_node_cache;
+pub mod native_state_committer;
+pub mod position_buffered_state;
 pub mod position_db;
+pub(crate) mod position_merkle_batch_committer;
 pub mod position_merkle_db;
+pub mod position_metrics;
+pub(crate) mod position_snapshot_committer;
+pub mod position_state_store;
 mod pruner;
 mod sharded_jmt_merkle_db;
 mod sharded_kv_db;
+mod trading_native;
+
+#[cfg(test)]
+mod native_storage_tests;
+
+pub use native_state_committer::{MerkleLeafUpdate, NativeMerkleLeafUpdates, NativeStateCommitter};
 mod state_kv_db;
 mod state_merkle_db;
 mod state_store;

--- a/storage/aptosdb/src/native_state_committer.rs
+++ b/storage/aptosdb/src/native_state_committer.rs
@@ -1,0 +1,141 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+#![forbid(unsafe_code)]
+
+use crate::{
+    position_db::{PositionDb, NUM_NATIVE_VALUE_SHARDS},
+    position_metrics::POSITION_WRITES,
+    schema::{
+        position_value::PositionValueSchema,
+        stale_position_value_index::{StalePositionValueIndex, StalePositionValueIndexSchema},
+    },
+    sharded_kv_db::ShardedKvDb,
+};
+use aptos_crypto::{hash::CryptoHash, HashValue};
+use aptos_schemadb::batch::SchemaBatch;
+use aptos_storage_interface::{AptosDbError, Result};
+use aptos_types::{
+    state_store::{
+        state_key::{
+            inner::{StateKeyInner, TradingNativeKey},
+            StateKey,
+        },
+        state_value::StateValue,
+    },
+    transaction::Version,
+    write_set::WriteOp,
+};
+use std::{collections::HashMap, sync::Arc};
+
+#[derive(Clone, Debug)]
+pub struct MerkleLeafUpdate {
+    pub state_key_hash: HashValue,
+    pub state_key: StateKey,
+    pub value_hash: Option<HashValue>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct NativeMerkleLeafUpdates {
+    pub position: Vec<MerkleLeafUpdate>,
+}
+
+/// Per-chunk batches accumulated by `NativeStateCommitter::apply`.
+/// Allocate once per chunk, drive `apply` per transaction, then
+/// `PositionDb::commit` once at chunk end.
+pub type PositionShardedKvBatches = [Option<SchemaBatch>; NUM_NATIVE_VALUE_SHARDS];
+
+/// Per-chunk map of latest version seen for each key hash; used to
+/// emit stale-index entries without re-reading the DB.
+pub type InChunkPriorVersions = HashMap<HashValue, Version>;
+
+pub fn new_sharded_kv_batches() -> PositionShardedKvBatches {
+    std::array::from_fn(|_| None)
+}
+
+pub struct NativeStateCommitter {
+    position_db: Arc<PositionDb>,
+}
+
+impl NativeStateCommitter {
+    pub fn new(position_db: Arc<PositionDb>) -> Self {
+        Self { position_db }
+    }
+
+    /// Accumulate one transaction's Position writes into the
+    /// per-chunk batches. The caller commits once per chunk via
+    /// `PositionDb::commit`.
+    pub fn apply<P>(
+        &self,
+        version: Version,
+        position_writes: P,
+        sharded_kv_batches: &mut PositionShardedKvBatches,
+        in_chunk_prior: &mut InChunkPriorVersions,
+    ) -> Result<NativeMerkleLeafUpdates>
+    where
+        P: IntoIterator<Item = (StateKey, WriteOp)>,
+    {
+        let mut position_merkle: Vec<MerkleLeafUpdate> = Vec::new();
+        for (state_key, op) in position_writes {
+            match state_key.inner() {
+                StateKeyInner::TradingNative(TradingNativeKey::Position { .. }) => (),
+                other => {
+                    return Err(AptosDbError::Other(format!(
+                        "position_write_set contained non-Position StateKey: {other:?}"
+                    )));
+                },
+            };
+            let maybe_value = op.as_state_value_opt().cloned();
+            let kind_label = if maybe_value.is_some() {
+                "upsert"
+            } else {
+                "delete"
+            };
+            POSITION_WRITES.with_label_values(&[kind_label]).inc();
+            let state_key_hash = state_key.hash();
+            let shard = ShardedKvDb::shard_of_state_key(&state_key);
+            let pos_batch = sharded_kv_batches[shard].get_or_insert_with(SchemaBatch::new);
+
+            // In-chunk map first (same-chunk earlier writes), then DB.
+            let prior_v = match in_chunk_prior.get(&state_key_hash) {
+                Some(&v) => Some(v),
+                None => self
+                    .position_db
+                    .find_prior_version(state_key_hash, version)
+                    .map_err(|e| AptosDbError::Other(format!("find_prior_version: {e}")))?,
+            };
+            // Always emit a stale-index row — first writes use
+            // `NO_PREV_VERSION` and the pruner skips them via
+            // `is_first_write()`. Lets truncation iterate this CF
+            // alone to reach every kv row.
+            pos_batch
+                .put::<StalePositionValueIndexSchema>(
+                    &StalePositionValueIndex {
+                        stale_since_version: version,
+                        version: prior_v.unwrap_or(StalePositionValueIndex::NO_PREV_VERSION),
+                        state_key_hash,
+                    },
+                    &(),
+                )
+                .map_err(|e| AptosDbError::Other(format!("stale_position_value_index put: {e}")))?;
+            pos_batch
+                .put::<PositionValueSchema>(&(state_key_hash, version), &maybe_value)
+                .map_err(|e| {
+                    AptosDbError::Other(format!("position_value batch put failed: {e}"))
+                })?;
+
+            in_chunk_prior.insert(state_key_hash, version);
+
+            let value_hash = maybe_value.as_ref().map(StateValue::hash);
+            position_merkle.push(MerkleLeafUpdate {
+                state_key_hash,
+                state_key: state_key.clone(),
+                value_hash,
+            });
+        }
+
+        Ok(NativeMerkleLeafUpdates {
+            position: position_merkle,
+        })
+    }
+}

--- a/storage/aptosdb/src/native_storage_tests.rs
+++ b/storage/aptosdb/src/native_storage_tests.rs
@@ -1,0 +1,270 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Storage-core unit tests for the native-position commit applier
+//! and durable layer: `find_prior_version`, stale-index emission,
+//! and truncation progress.
+
+use crate::{
+    native_state_committer::{new_sharded_kv_batches, InChunkPriorVersions, NativeStateCommitter},
+    position_db::PositionDb,
+    schema::stale_position_value_index::{StalePositionValueIndex, StalePositionValueIndexSchema},
+    utils::truncation_helper::{get_position_commit_progress, truncate_position_db_shards},
+};
+use aptos_crypto::hash::CryptoHash;
+use aptos_temppath::TempPath;
+use aptos_types::{state_store::state_key::StateKey, transaction::Version, write_set::WriteOp};
+use move_core_types::account_address::AccountAddress;
+use std::sync::Arc;
+
+fn open_position_db() -> (TempPath, Arc<PositionDb>) {
+    let tmpdir = TempPath::new();
+    std::fs::create_dir_all(tmpdir.path()).unwrap();
+    let db_paths = aptos_config::config::StorageDirPaths::from_path(tmpdir.path());
+    let db = Arc::new(
+        PositionDb::new(
+            &db_paths,
+            aptos_config::config::RocksdbConfig::default(),
+            None,
+            None,
+            /* readonly = */ false,
+        )
+        .expect("PositionDb::new"),
+    );
+    (tmpdir, db)
+}
+
+fn exchange(byte: u8) -> AccountAddress {
+    let mut a = [0u8; AccountAddress::LENGTH];
+    a[AccountAddress::LENGTH - 1] = byte;
+    AccountAddress::new(a)
+}
+
+fn user(byte: u8) -> AccountAddress {
+    exchange(byte)
+}
+
+fn market(byte: u8) -> AccountAddress {
+    exchange(byte)
+}
+
+fn position_key(byte: u8) -> StateKey {
+    StateKey::position(exchange(1), user(byte), market(1))
+}
+
+fn upsert(bytes: &[u8]) -> WriteOp {
+    WriteOp::legacy_modification(bytes.to_vec().into())
+}
+
+fn delete() -> WriteOp {
+    WriteOp::legacy_deletion()
+}
+
+/// Commit one position write at `version` using the committer's
+/// per-chunk-batched path. Returns the merkle leaf updates.
+fn commit_one(
+    db: &Arc<PositionDb>,
+    version: Version,
+    key: StateKey,
+    op: WriteOp,
+) -> Vec<crate::native_state_committer::MerkleLeafUpdate> {
+    let committer = NativeStateCommitter::new(Arc::clone(db));
+    let mut sharded_kv_batches = new_sharded_kv_batches();
+    let mut in_chunk_prior = InChunkPriorVersions::new();
+    let updates = committer
+        .apply(
+            version,
+            std::iter::once((key, op)),
+            &mut sharded_kv_batches,
+            &mut in_chunk_prior,
+        )
+        .expect("apply")
+        .position;
+    db.commit(version, None, sharded_kv_batches)
+        .expect("position_db commit");
+    updates
+}
+
+#[test]
+fn find_prior_version_returns_none_for_unwritten_key() {
+    let (_tmp, db) = open_position_db();
+    let hash = position_key(1).hash();
+    assert_eq!(db.find_prior_version(hash, 10).unwrap(), None);
+}
+
+#[test]
+fn find_prior_version_returns_latest_below_target() {
+    let (_tmp, db) = open_position_db();
+    let key = position_key(1);
+    let hash = key.hash();
+
+    commit_one(&db, 0, key.clone(), upsert(b"v0"));
+    commit_one(&db, 5, key.clone(), upsert(b"v5"));
+    commit_one(&db, 10, key.clone(), upsert(b"v10"));
+
+    assert_eq!(db.find_prior_version(hash, 11).unwrap(), Some(10));
+    assert_eq!(db.find_prior_version(hash, 10).unwrap(), Some(5));
+    assert_eq!(db.find_prior_version(hash, 8).unwrap(), Some(5));
+    assert_eq!(db.find_prior_version(hash, 5).unwrap(), Some(0));
+    assert_eq!(db.find_prior_version(hash, 1).unwrap(), Some(0));
+    assert_eq!(db.find_prior_version(hash, 0).unwrap(), None);
+}
+
+#[test]
+fn apply_emits_no_prev_version_sentinel_for_first_write() {
+    let (_tmp, db) = open_position_db();
+    let key = position_key(1);
+    let hash = key.hash();
+
+    commit_one(&db, 7, key.clone(), upsert(b"v7"));
+
+    let shard = crate::sharded_kv_db::ShardedKvDb::shard_of_hash(hash);
+    let mut iter = db
+        .shard(shard)
+        .iter::<StalePositionValueIndexSchema>()
+        .unwrap();
+    iter.seek_to_first();
+    let mut entries: Vec<StalePositionValueIndex> = Vec::new();
+    for row in iter {
+        let (idx, _) = row.unwrap();
+        if idx.state_key_hash == hash {
+            entries.push(idx);
+        }
+    }
+    assert_eq!(entries.len(), 1, "first write emits one stale-index row");
+    assert!(
+        entries[0].is_first_write(),
+        "first write uses NO_PREV_VERSION sentinel"
+    );
+    assert_eq!(entries[0].stale_since_version, 7);
+}
+
+#[test]
+fn apply_emits_prior_version_on_overwrite() {
+    let (_tmp, db) = open_position_db();
+    let key = position_key(1);
+    let hash = key.hash();
+
+    commit_one(&db, 0, key.clone(), upsert(b"v0"));
+    commit_one(&db, 5, key.clone(), upsert(b"v5"));
+
+    let shard = crate::sharded_kv_db::ShardedKvDb::shard_of_hash(hash);
+    let mut iter = db
+        .shard(shard)
+        .iter::<StalePositionValueIndexSchema>()
+        .unwrap();
+    iter.seek_to_first();
+    let mut entries: Vec<StalePositionValueIndex> = Vec::new();
+    for row in iter {
+        let (idx, _) = row.unwrap();
+        if idx.state_key_hash == hash {
+            entries.push(idx);
+        }
+    }
+    assert_eq!(entries.len(), 2);
+
+    // v0 row is the first write (NO_PREV_VERSION sentinel).
+    let v0 = entries
+        .iter()
+        .find(|i| i.stale_since_version == 0)
+        .expect("v0 stale-index");
+    assert!(v0.is_first_write());
+
+    // v5 row supersedes v0.
+    let v5 = entries
+        .iter()
+        .find(|i| i.stale_since_version == 5)
+        .expect("v5 stale-index");
+    assert!(!v5.is_first_write());
+    assert_eq!(v5.version, 0);
+}
+
+#[test]
+fn apply_tombstone_carries_no_value_hash() {
+    let (_tmp, db) = open_position_db();
+    let key = position_key(1);
+
+    let upserts = commit_one(&db, 0, key.clone(), upsert(b"v0"));
+    assert!(upserts[0].value_hash.is_some());
+
+    let deletes = commit_one(&db, 1, key.clone(), delete());
+    assert_eq!(deletes[0].value_hash, None);
+}
+
+#[test]
+fn truncate_advances_overall_position_commit_progress() {
+    let (_tmp, db) = open_position_db();
+    let key = position_key(1);
+    let hash = key.hash();
+
+    commit_one(&db, 3, key.clone(), upsert(b"v3"));
+    commit_one(&db, 7, key.clone(), upsert(b"v7"));
+    assert_eq!(get_position_commit_progress(&db).unwrap(), Some(7));
+
+    truncate_position_db_shards(&db, 3).unwrap();
+    assert_eq!(
+        get_position_commit_progress(&db).unwrap(),
+        Some(3),
+        "overall progress marker must reflect the truncated version"
+    );
+
+    // The v7 stale-index row is gone; v3 remains.
+    let shard = crate::sharded_kv_db::ShardedKvDb::shard_of_hash(hash);
+    let mut iter = db
+        .shard(shard)
+        .iter::<StalePositionValueIndexSchema>()
+        .unwrap();
+    iter.seek_to_first();
+    let stale_since_versions: Vec<Version> = iter
+        .filter_map(|r| r.ok())
+        .map(|(idx, _)| idx)
+        .filter(|i| i.state_key_hash == hash)
+        .map(|i| i.stale_since_version)
+        .collect();
+    assert_eq!(stale_since_versions, vec![3]);
+}
+
+#[test]
+fn in_chunk_writes_chain_stale_index_versions() {
+    let (_tmp, db) = open_position_db();
+    let key = position_key(1);
+    let hash = key.hash();
+    let committer = NativeStateCommitter::new(Arc::clone(&db));
+    let mut sharded_kv_batches = new_sharded_kv_batches();
+    let mut in_chunk_prior = InChunkPriorVersions::new();
+
+    // Three writes to the same key inside a single chunk.
+    for (i, payload) in [b"a".as_slice(), b"b".as_slice(), b"c".as_slice()]
+        .iter()
+        .enumerate()
+    {
+        committer
+            .apply(
+                i as Version,
+                std::iter::once((key.clone(), upsert(payload))),
+                &mut sharded_kv_batches,
+                &mut in_chunk_prior,
+            )
+            .expect("apply");
+    }
+    db.commit(2, None, sharded_kv_batches)
+        .expect("position_db commit");
+
+    let shard = crate::sharded_kv_db::ShardedKvDb::shard_of_hash(hash);
+    let mut iter = db
+        .shard(shard)
+        .iter::<StalePositionValueIndexSchema>()
+        .unwrap();
+    iter.seek_to_first();
+    let mut entries: Vec<StalePositionValueIndex> = iter
+        .filter_map(|r| r.ok())
+        .map(|(idx, _)| idx)
+        .filter(|i| i.state_key_hash == hash)
+        .collect();
+    entries.sort_by_key(|i| i.stale_since_version);
+
+    assert_eq!(entries.len(), 3);
+    assert!(entries[0].is_first_write(), "v0 is first write");
+    assert_eq!(entries[1].version, 0, "v1's stale-index points at v0");
+    assert_eq!(entries[2].version, 1, "v2's stale-index points at v1");
+}

--- a/storage/aptosdb/src/position_buffered_state.rs
+++ b/storage/aptosdb/src/position_buffered_state.rs
@@ -1,0 +1,166 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+#![forbid(unsafe_code)]
+
+use crate::{
+    common::{
+        spawn_commit_pipeline, BufferedStateCore, BufferedStateExtras, CheckpointSnapshot,
+        LedgerStateView,
+    },
+    ledger_db::LedgerDb,
+    position_merkle_batch_committer::PositionMerkleBatchCommitter,
+    position_merkle_db::PositionMerkleDb,
+    position_snapshot_committer::{
+        merklize_position, PositionSnapshotToCommit, POSITION_BATCH_CHANNEL_SIZE,
+    },
+    state_store::buffered_state::{
+        ASYNC_COMMIT_CHANNEL_BUFFER_SIZE, TARGET_SNAPSHOT_INTERVAL_IN_VERSION,
+    },
+};
+use aptos_crypto::HashValue;
+use aptos_infallible::Mutex;
+use aptos_jellyfish_merkle::JellyfishMerkleTree;
+use aptos_scratchpad::{ProofRead, SparseMerkleTree};
+use aptos_storage_interface::state_store::{
+    sharded_jmt_state::{LeafSlot, ShardedJmtState},
+    state_summary::StateSummary,
+    state_with_summary::{LedgerWithSummary, StateAndSummary},
+};
+use aptos_types::{proof::SparseMerkleProofExt, transaction::Version};
+use std::sync::Arc;
+
+pub type PositionSlot = LeafSlot<()>;
+
+pub type PositionStateSummary = StateSummary;
+
+pub type PositionStateWithSummary = StateAndSummary<ShardedJmtState<PositionSlot>>;
+
+pub fn new_empty_position_state() -> PositionStateWithSummary {
+    PositionStateWithSummary::new_empty("position")
+}
+
+/// Restart-from-disk constructor: seeds the in-memory pipeline with
+/// the JMT root persisted at `version`.
+pub fn position_state_at_version(
+    version: Version,
+    root_hash: HashValue,
+) -> PositionStateWithSummary {
+    PositionStateWithSummary::new(
+        ShardedJmtState::new_at_version(Some(version), "position"),
+        StateSummary::new_global_only(version, SparseMerkleTree::new(root_hash)),
+    )
+}
+
+pub type PositionLedgerStateWithSummary = LedgerWithSummary<PositionStateWithSummary>;
+
+impl CheckpointSnapshot for PositionStateWithSummary {
+    fn next_version(&self) -> Version {
+        self.next_version()
+    }
+}
+
+impl LedgerStateView for PositionLedgerStateWithSummary {
+    type Snapshot = PositionStateWithSummary;
+
+    fn next_version(&self) -> Version {
+        self.latest().next_version()
+    }
+
+    fn last_checkpoint_snapshot(&self) -> Self::Snapshot {
+        self.last_checkpoint().clone()
+    }
+
+    fn is_descendant_of(&self, other: &Self) -> bool {
+        self.latest().is_descendant_of(other.latest())
+            && self
+                .last_checkpoint()
+                .is_descendant_of(other.last_checkpoint())
+    }
+}
+
+pub struct PositionProofReader {
+    pub merkle_db: Arc<PositionMerkleDb>,
+    /// `None` before any snapshot has been persisted; in that case
+    /// the SMT extend path never reaches the proof reader.
+    pub version: Option<Version>,
+}
+
+impl ProofRead for PositionProofReader {
+    fn get_proof(&self, key: &HashValue, root_depth: usize) -> Option<SparseMerkleProofExt> {
+        let version = self.version?;
+        let tree = JellyfishMerkleTree::new(self.merkle_db.as_ref());
+        let (_value, proof) = tree
+            .get_with_proof_ext(key, version, root_depth)
+            .expect("Failed to get position state proof by version.");
+        Some(proof)
+    }
+}
+
+pub(crate) const POSITION_TARGET_ITEMS: usize = 200_000;
+
+pub(crate) type PositionBufferedState = crate::common::BufferedState<
+    PositionLedgerStateWithSummary,
+    PositionStateWithSummary,
+    PositionSnapshotToCommit,
+    PositionExtras,
+>;
+
+pub struct PositionExtras;
+
+impl BufferedStateExtras<PositionSnapshotToCommit, PositionStateWithSummary> for PositionExtras {
+    type ChunkInput = ();
+
+    fn absorb_chunk(&mut self, (): (), _checkpoint_advanced: bool) {}
+
+    fn build_payload(&mut self, snapshot: PositionStateWithSummary) -> PositionSnapshotToCommit {
+        PositionSnapshotToCommit { snapshot }
+    }
+}
+
+impl PositionBufferedState {
+    pub fn new_at_snapshot(
+        merkle_db: Arc<PositionMerkleDb>,
+        ledger_db: Arc<LedgerDb>,
+        last_snapshot: PositionStateWithSummary,
+        target_items: usize,
+        out_current_state: Arc<Mutex<PositionLedgerStateWithSummary>>,
+    ) -> Self {
+        *out_current_state.lock() =
+            PositionLedgerStateWithSummary::new_at_checkpoint(last_snapshot.clone());
+
+        let snapshot_merkle_db = Arc::clone(&merkle_db);
+        let snapshot_ledger_db = Arc::clone(&ledger_db);
+        let batch_merkle_db = Arc::clone(&merkle_db);
+        let commit_thread = spawn_commit_pipeline(
+            "position_snapshot_committer",
+            ASYNC_COMMIT_CHANNEL_BUFFER_SIZE as usize,
+            "position_merkle_batch_committer",
+            POSITION_BATCH_CHANNEL_SIZE,
+            last_snapshot.clone(),
+            move |batch_receiver| {
+                PositionMerkleBatchCommitter::new(batch_merkle_db, batch_receiver).run();
+            },
+            move |last_snapshot, input| {
+                merklize_position(
+                    &snapshot_merkle_db,
+                    &snapshot_ledger_db,
+                    last_snapshot,
+                    input,
+                )
+                .expect("Failed to compute position JMT commit batch.")
+            },
+        );
+
+        PositionBufferedState::new(
+            BufferedStateCore::new(
+                out_current_state,
+                last_snapshot,
+                commit_thread,
+                target_items,
+                TARGET_SNAPSHOT_INTERVAL_IN_VERSION,
+            ),
+            PositionExtras,
+        )
+    }
+}

--- a/storage/aptosdb/src/position_db.rs
+++ b/storage/aptosdb/src/position_db.rs
@@ -3,13 +3,22 @@
 
 #![forbid(unsafe_code)]
 
-use crate::{db_options::gen_position_cfds, sharded_kv_db::ShardedKvDb};
+use crate::{
+    db_options::gen_position_cfds,
+    schema::{
+        db_metadata::{DbMetadataKey, DbMetadataSchema, DbMetadataValue},
+        position_value::PositionValueSchema,
+    },
+    sharded_kv_db::ShardedKvDb,
+};
 use aptos_config::config::{RocksdbConfig, StorageDirPaths};
+use aptos_crypto::HashValue;
+use aptos_experimental_runtimes::thread_manager::THREAD_MANAGER;
 use aptos_logger::info;
 use aptos_rocksdb_options::gen_rocksdb_options;
-use aptos_schemadb::{Cache, Env, DB};
+use aptos_schemadb::{batch::SchemaBatch, Cache, Env, DB};
 use aptos_storage_interface::{AptosDbError, Result};
-use aptos_types::state_store::NUM_STATE_SHARDS;
+use aptos_types::{state_store::NUM_STATE_SHARDS, transaction::Version};
 use rayon::prelude::*;
 use std::{
     ops::Deref,
@@ -181,5 +190,69 @@ impl PositionDb {
         &self,
     ) -> [aptos_schemadb::batch::NativeBatch<'_>; NUM_NATIVE_VALUE_SHARDS] {
         std::array::from_fn(|shard_id| self.shard(shard_id).new_native_batch())
+    }
+
+    pub fn commit(
+        &self,
+        version: Version,
+        metadata_batch: Option<SchemaBatch>,
+        per_shard_batches: [Option<SchemaBatch>; NUM_NATIVE_VALUE_SHARDS],
+    ) -> Result<()> {
+        THREAD_MANAGER.get_io_pool().scope(|s| {
+            for (shard_id, batch_opt) in per_shard_batches.into_iter().enumerate() {
+                s.spawn(move |_| {
+                    self.commit_single_shard(version, shard_id, batch_opt)
+                        .unwrap_or_else(|err| {
+                            panic!("Failed to commit position shard {shard_id}: {err}.")
+                        });
+                });
+            }
+        });
+        if let Some(batch) = metadata_batch {
+            self.metadata_db().write_schemas(batch)?;
+        }
+        self.write_progress(version)
+    }
+
+    pub fn commit_single_shard(
+        &self,
+        version: Version,
+        shard_id: usize,
+        batch_opt: Option<SchemaBatch>,
+    ) -> Result<()> {
+        let mut batch = batch_opt.unwrap_or_default();
+        batch.put::<DbMetadataSchema>(
+            &DbMetadataKey::PositionShardCommitProgress(shard_id),
+            &DbMetadataValue::Version(version),
+        )?;
+        self.shard(shard_id).write_schemas(batch)
+    }
+
+    pub fn write_progress(&self, version: Version) -> Result<()> {
+        self.metadata_db().put::<DbMetadataSchema>(
+            &DbMetadataKey::PositionCommitProgress,
+            &DbMetadataValue::Version(version),
+        )
+    }
+
+    pub fn find_prior_version(
+        &self,
+        state_key_hash: HashValue,
+        at_version: Version,
+    ) -> Result<Option<Version>> {
+        if at_version == 0 {
+            return Ok(None);
+        }
+        let shard = ShardedKvDb::shard_of_hash(state_key_hash);
+        let mut iter = self.shard(shard).iter::<PositionValueSchema>()?;
+        // PositionValueSchema bit-inverts the version (newest-first); a
+        // forward seek lands on the largest version <= at_version-1.
+        iter.seek(&(state_key_hash, at_version - 1))?;
+        if let Some(Ok(((row_hash, row_version), _value))) = iter.next()
+            && row_hash == state_key_hash
+        {
+            return Ok(Some(row_version));
+        }
+        Ok(None)
     }
 }

--- a/storage/aptosdb/src/position_merkle_batch_committer.rs
+++ b/storage/aptosdb/src/position_merkle_batch_committer.rs
@@ -1,0 +1,62 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+#![forbid(unsafe_code)]
+
+use crate::{
+    common::{run_batch_committer_loop, CommitMessage, MerkleBatch},
+    metrics::OTHER_TIMERS_SECONDS,
+    position_merkle_db::PositionMerkleDb,
+};
+use aptos_crypto::HashValue;
+use aptos_logger::{info, trace};
+use aptos_metrics_core::TimerHelper;
+use aptos_types::transaction::Version;
+use std::sync::{mpsc::Receiver, Arc};
+
+pub(crate) struct PositionMerkleCommit {
+    pub version: Version,
+    pub root_hash: HashValue,
+    pub batch: MerkleBatch,
+}
+
+pub(crate) struct PositionMerkleBatchCommitter {
+    merkle_db: Arc<PositionMerkleDb>,
+    receiver: Receiver<CommitMessage<PositionMerkleCommit>>,
+}
+
+impl PositionMerkleBatchCommitter {
+    pub fn new(
+        merkle_db: Arc<PositionMerkleDb>,
+        receiver: Receiver<CommitMessage<PositionMerkleCommit>>,
+    ) -> Self {
+        Self {
+            merkle_db,
+            receiver,
+        }
+    }
+
+    pub fn run(self) {
+        let Self {
+            merkle_db,
+            receiver,
+        } = self;
+        run_batch_committer_loop(receiver, |commit| {
+            let _timer = OTHER_TIMERS_SECONDS.timer_with(&["position_batch_committer_work"]);
+            let PositionMerkleCommit {
+                version,
+                root_hash,
+                batch,
+            } = commit;
+            merkle_db
+                .commit(version, batch.top_levels_batch, batch.batches_for_shards)
+                .expect("Position merkle commit failed.");
+            info!(
+                version = version,
+                root_hash = %root_hash,
+                "Position merkle snapshot committed."
+            );
+        });
+        trace!("Position merkle batch committing thread exit.");
+    }
+}

--- a/storage/aptosdb/src/position_metrics.rs
+++ b/storage/aptosdb/src/position_metrics.rs
@@ -1,0 +1,14 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+use aptos_metrics_core::{register_int_counter_vec, IntCounterVec};
+use once_cell::sync::Lazy;
+
+pub static POSITION_WRITES: Lazy<IntCounterVec> = Lazy::new(|| {
+    register_int_counter_vec!(
+        "aptos_position_writes_total",
+        "Position writes applied by NativeStateCommitter",
+        &["kind"]
+    )
+    .unwrap()
+});

--- a/storage/aptosdb/src/position_snapshot_committer.rs
+++ b/storage/aptosdb/src/position_snapshot_committer.rs
@@ -1,0 +1,68 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+#![forbid(unsafe_code)]
+
+use crate::{
+    ledger_db::LedgerDb, position_buffered_state::PositionStateWithSummary,
+    position_merkle_batch_committer::PositionMerkleCommit, position_merkle_db::PositionMerkleDb,
+};
+use aptos_storage_interface::{
+    state_store::{leaf_entry::leaf_entry_to_jmt_update, sharded_jmt_state::pre_shard_jmt_updates},
+    AptosDbError, Result,
+};
+
+/// Rendezvous channel.
+pub(crate) const POSITION_BATCH_CHANNEL_SIZE: usize = 0;
+
+pub(crate) struct PositionSnapshotToCommit {
+    pub snapshot: PositionStateWithSummary,
+}
+
+/// Advances `*last_snapshot` on success.
+pub(crate) fn merklize_position(
+    merkle_db: &PositionMerkleDb,
+    ledger_db: &LedgerDb,
+    last_snapshot: &mut PositionStateWithSummary,
+    snapshot: PositionSnapshotToCommit,
+) -> Result<PositionMerkleCommit> {
+    let new_state = snapshot.snapshot;
+    let version = new_state
+        .version()
+        .expect("snapshot enqueued for merklize must have a concrete version");
+    let previous_epoch_ending_version = ledger_db
+        .metadata_db()
+        .get_previous_epoch_ending(version)?
+        .map(|(v, _e)| v);
+    let base_version = last_snapshot.version();
+
+    let updates = new_state.make_delta(last_snapshot);
+
+    let all_updates = pre_shard_jmt_updates(
+        updates
+            .iter()
+            .map(|(key_hash, slot)| leaf_entry_to_jmt_update(*key_hash, slot)),
+    );
+
+    let (root_hash, _leaf_count, top_levels_batch, batches_for_shards) = merkle_db
+        .merklize_snapshot(
+            base_version,
+            version,
+            &last_snapshot.summary().global_state_summary,
+            &new_state.summary().global_state_summary,
+            all_updates,
+            previous_epoch_ending_version,
+        )
+        .map_err(|e| AptosDbError::Other(format!("position JMT merklize_snapshot failed: {e}")))?;
+
+    *last_snapshot = new_state;
+
+    Ok(PositionMerkleCommit {
+        version,
+        root_hash,
+        batch: crate::common::MerkleBatch {
+            top_levels_batch,
+            batches_for_shards,
+        },
+    })
+}

--- a/storage/aptosdb/src/position_state_store.rs
+++ b/storage/aptosdb/src/position_state_store.rs
@@ -1,0 +1,39 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+#![forbid(unsafe_code)]
+
+use crate::{
+    common::PipelineStateStore,
+    ledger_db::LedgerDb,
+    position_buffered_state::{
+        PositionBufferedState, PositionLedgerStateWithSummary, PositionStateWithSummary,
+        POSITION_TARGET_ITEMS,
+    },
+    position_merkle_db::PositionMerkleDb,
+};
+use aptos_infallible::Mutex;
+use std::sync::Arc;
+
+pub(crate) type PositionStateStore =
+    PipelineStateStore<PositionLedgerStateWithSummary, PositionBufferedState>;
+
+impl PositionStateStore {
+    pub fn new_at_snapshot(
+        merkle_db: Arc<PositionMerkleDb>,
+        ledger_db: Arc<LedgerDb>,
+        last_snapshot: PositionStateWithSummary,
+    ) -> Self {
+        let current_state = Arc::new(Mutex::new(
+            PositionLedgerStateWithSummary::new_at_checkpoint(last_snapshot.clone()),
+        ));
+        let buffered_state = PositionBufferedState::new_at_snapshot(
+            merkle_db,
+            ledger_db,
+            last_snapshot,
+            POSITION_TARGET_ITEMS,
+            Arc::clone(&current_state),
+        );
+        Self::from_parts(current_state, buffered_state)
+    }
+}

--- a/storage/aptosdb/src/schema/db_metadata/mod.rs
+++ b/storage/aptosdb/src/schema/db_metadata/mod.rs
@@ -72,6 +72,8 @@ pub enum DbMetadataKey {
     StaleNodeCleanupDone,
     StaleNodeCleanupRegularProgress,
     StaleNodeCleanupEpochProgress,
+    PositionCommitProgress,
+    PositionShardCommitProgress(ShardId),
 }
 
 define_schema!(

--- a/storage/aptosdb/src/trading_native.rs
+++ b/storage/aptosdb/src/trading_native.rs
@@ -1,0 +1,10 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Crate-wide flag for the native-trading subsystem (positions today;
+//! orders and collateral land later). Gates whether
+//! `AptosDB::open_internal` attaches the position DBs, runs the
+//! native commit applier, and exposes the in-memory mirror.
+
+/// Flip to `true` once order/collateral land.
+pub(crate) const ENABLE_TRADING_NATIVE: bool = false;

--- a/storage/aptosdb/src/utils/truncation_helper.rs
+++ b/storage/aptosdb/src/utils/truncation_helper.rs
@@ -6,14 +6,18 @@ use crate::{
         ledger_metadata_db::LedgerMetadataDb, transaction_db::TransactionDb, LedgerDb,
         LedgerDbSchemaBatches,
     },
+    position_db::{PositionDb, NUM_NATIVE_VALUE_SHARDS},
+    position_merkle_db::{PositionMerkleDb, NUM_POSITION_MERKLE_SHARDS},
     schema::{
         db_metadata::{DbMetadataKey, DbMetadataSchema, DbMetadataValue},
         epoch_by_version::EpochByVersionSchema,
         hot_state_value_by_key_hash::HotStateValueByKeyHashSchema,
         jellyfish_merkle_node::JellyfishMerkleNodeSchema,
         ledger_info::LedgerInfoSchema,
+        position_value::PositionValueSchema,
         stale_node_index::StaleNodeIndexSchema,
         stale_node_index_cross_epoch::StaleNodeIndexCrossEpochSchema,
+        stale_position_value_index::StalePositionValueIndexSchema,
         stale_state_value_index_by_key_hash::StaleStateValueIndexByKeyHashSchema,
         state_value_by_key_hash::StateValueByKeyHashSchema,
         transaction::TransactionSchema,
@@ -65,6 +69,121 @@ pub(crate) fn get_state_merkle_commit_progress(
         state_merkle_db.metadata_db(),
         &DbMetadataKey::StateMerkleCommitProgress,
     )
+}
+
+pub(crate) fn get_position_commit_progress(position_db: &PositionDb) -> Result<Option<Version>> {
+    get_progress(
+        position_db.metadata_db(),
+        &DbMetadataKey::PositionCommitProgress,
+    )
+}
+
+pub(crate) fn get_position_merkle_commit_progress(
+    position_merkle_db: &PositionMerkleDb,
+) -> Result<Option<Version>> {
+    // `StateMerkleCommitProgress` is the generic JMT commit-progress
+    // key written by `ShardedJmtMerkleDb::put_progress`.
+    get_progress(
+        position_merkle_db.metadata_db(),
+        &DbMetadataKey::StateMerkleCommitProgress,
+    )
+}
+
+/// Walk position merkle snapshots back to `target_version`, peeling
+/// one snapshot at a time. Each iteration deletes the top-level
+/// nodes and stale indices at-or-after the current snapshot, commits
+/// the top-levels batch at the previous snapshot version, then
+/// truncates the per-shard DBs down to that previous version.
+pub(crate) fn truncate_position_merkle_db(
+    position_merkle_db: &PositionMerkleDb,
+    target_version: Version,
+) -> Result<()> {
+    loop {
+        let current_version =
+            find_closest_node_version_at_or_before(position_merkle_db.metadata_db(), Version::MAX)?
+                .expect("position_merkle_db must have at least one snapshot before truncation");
+        assert!(current_version >= target_version);
+        if current_version == target_version {
+            break;
+        }
+
+        let version_before = find_closest_node_version_at_or_before(
+            position_merkle_db.metadata_db(),
+            current_version - 1,
+        )?
+        .expect("position_merkle_db must have a snapshot before the current one");
+
+        let mut top_levels_batch = SchemaBatch::new();
+        delete_nodes_and_stale_indices_at_or_after_version(
+            position_merkle_db.metadata_db(),
+            current_version,
+            /* shard_id = */ None,
+            &mut top_levels_batch,
+        )?;
+        position_merkle_db.commit_top_levels(version_before, top_levels_batch)?;
+        truncate_position_merkle_db_shards(position_merkle_db, version_before)?;
+    }
+    Ok(())
+}
+
+fn truncate_position_merkle_db_shards(
+    position_merkle_db: &PositionMerkleDb,
+    target_version: Version,
+) -> Result<()> {
+    (0..NUM_POSITION_MERKLE_SHARDS)
+        .into_par_iter()
+        .try_for_each(|shard_id| {
+            let mut batch = SchemaBatch::new();
+            delete_nodes_and_stale_indices_at_or_after_version(
+                position_merkle_db.db_shard(shard_id),
+                target_version + 1,
+                Some(shard_id),
+                &mut batch,
+            )?;
+            position_merkle_db.db_shard(shard_id).write_schemas(batch)
+        })
+}
+
+pub(crate) fn truncate_position_db_shards(
+    position_db: &PositionDb,
+    target_version: Version,
+) -> Result<()> {
+    (0..NUM_NATIVE_VALUE_SHARDS)
+        .into_par_iter()
+        .try_for_each(|shard_id| {
+            truncate_position_db_single_shard(position_db, shard_id, target_version)
+        })?;
+    // Overall progress marker is the source of truth for restart;
+    // per-shard commits above only update the per-shard markers.
+    position_db.write_progress(target_version)
+}
+
+fn truncate_position_db_single_shard(
+    position_db: &PositionDb,
+    shard_id: usize,
+    target_version: Version,
+) -> Result<()> {
+    let mut batch = SchemaBatch::new();
+    delete_position_value_and_index(position_db.shard(shard_id), target_version + 1, &mut batch)?;
+    position_db.commit_single_shard(target_version, shard_id, Some(batch))
+}
+
+fn delete_position_value_and_index(
+    db_shard: &DB,
+    start_version: Version,
+    batch: &mut SchemaBatch,
+) -> Result<()> {
+    // The stale-index is keyed by `stale_since_version` BE; forward
+    // seek lands on the first row to delete. Every kv write has a
+    // paired stale-index row (first writes use `NO_PREV_VERSION`).
+    let mut iter = db_shard.iter::<StalePositionValueIndexSchema>()?;
+    iter.seek(&start_version)?;
+    for row in iter {
+        let (index, _) = row?;
+        batch.delete::<StalePositionValueIndexSchema>(&index)?;
+        batch.delete::<PositionValueSchema>(&(index.state_key_hash, index.stale_since_version))?;
+    }
+    Ok(())
 }
 
 pub(crate) fn truncate_ledger_db(ledger_db: Arc<LedgerDb>, target_version: Version) -> Result<()> {

--- a/storage/storage-interface/src/state_store/mod.rs
+++ b/storage/storage-interface/src/state_store/mod.rs
@@ -3,6 +3,7 @@
 
 mod hot_state;
 pub mod leaf_entry;
+pub mod sharded_jmt_state;
 pub mod state;
 pub mod state_delta;
 pub mod state_summary;

--- a/storage/storage-interface/src/state_store/sharded_jmt_state.rs
+++ b/storage/storage-interface/src/state_store/sharded_jmt_state.rs
@@ -1,0 +1,186 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+use crate::{
+    state_store::{
+        leaf_entry::LeafEntry, state_summary::StateSummary, state_with_summary::StateAndSummary,
+    },
+    AptosDbError, Result,
+};
+use aptos_crypto::HashValue;
+use aptos_experimental_layered_map::MapLayer;
+use aptos_scratchpad::ProofRead;
+use aptos_types::{
+    state_store::{state_key::StateKey, NUM_STATE_SHARDS},
+    transaction::Version,
+};
+use arr_macro::arr;
+use std::sync::Arc;
+
+#[derive(Clone, Debug)]
+pub struct LeafSlot<V: Clone + Send + Sync + 'static = ()> {
+    pub state_key: StateKey,
+    pub value_hash: Option<HashValue>,
+    pub value: Option<V>,
+}
+
+impl<V: Clone + Send + Sync + 'static> LeafEntry for LeafSlot<V> {
+    type Value = V;
+
+    fn state_key(&self) -> Option<&StateKey> {
+        Some(&self.state_key)
+    }
+
+    fn value(&self) -> Option<&V> {
+        self.value.as_ref()
+    }
+
+    fn value_hash(&self) -> Option<HashValue> {
+        self.value_hash
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct ShardedJmtState<Slot: Clone + Send + Sync + 'static> {
+    next_version: Version,
+    shards: Arc<[MapLayer<HashValue, Slot>; NUM_STATE_SHARDS]>,
+}
+
+impl<Slot: Clone + Send + Sync + 'static> ShardedJmtState<Slot> {
+    pub fn new_empty(family: &'static str) -> Self {
+        Self {
+            next_version: 0,
+            shards: Arc::new(arr![MapLayer::new_family(family); 16]),
+        }
+    }
+
+    pub fn new_at_version(version: Option<Version>, family: &'static str) -> Self {
+        Self {
+            next_version: version.map_or(0, |v| v + 1),
+            shards: Arc::new(arr![MapLayer::new_family(family); 16]),
+        }
+    }
+
+    pub fn next_version(&self) -> Version {
+        self.next_version
+    }
+
+    pub fn version(&self) -> Option<Version> {
+        self.next_version.checked_sub(1)
+    }
+
+    pub fn shards(&self) -> &[MapLayer<HashValue, Slot>; NUM_STATE_SHARDS] {
+        &self.shards
+    }
+
+    pub fn is_descendant_of(&self, rhs: &Self) -> bool {
+        self.shards[0].is_descendant_of(&rhs.shards[0])
+    }
+
+    pub fn extend(&self, new_version: Version, updates: Vec<(HashValue, Slot)>) -> Self {
+        let mut per_shard: [Vec<(HashValue, Slot)>; NUM_STATE_SHARDS] = arr![Vec::new(); 16];
+        for (key_hash, slot) in updates {
+            per_shard[usize::from(key_hash.nibble(0))].push((key_hash, slot));
+        }
+        let new_shards: Vec<MapLayer<HashValue, Slot>> = self
+            .shards
+            .iter()
+            .enumerate()
+            .map(|(shard_id, base_layer)| {
+                let view = base_layer.view_layers_after(base_layer);
+                view.new_layer(&per_shard[shard_id])
+            })
+            .collect();
+        let new_shards: [MapLayer<HashValue, Slot>; NUM_STATE_SHARDS] = new_shards
+            .try_into()
+            .unwrap_or_else(|_| panic!("Known to be 16 shards"));
+        Self {
+            next_version: new_version + 1,
+            shards: Arc::new(new_shards),
+        }
+    }
+
+    pub fn make_delta(&self, base: &Self) -> Vec<(HashValue, Slot)> {
+        assert!(
+            self.is_descendant_of(base),
+            "make_delta requires self to descend from base in the same MapLayer family"
+        );
+        let mut out = Vec::new();
+        for shard_id in 0..NUM_STATE_SHARDS {
+            let view = self.shards[shard_id].view_layers_after(&base.shards[shard_id]);
+            for (key_hash, slot) in view.iter() {
+                out.push((key_hash, slot));
+            }
+        }
+        out
+    }
+}
+
+impl<Slot: Clone + Send + Sync + LeafEntry + 'static> StateAndSummary<ShardedJmtState<Slot>> {
+    pub fn new_empty(family: &'static str) -> Self {
+        Self::new(
+            ShardedJmtState::new_empty(family),
+            StateSummary::new_empty_global_only(),
+        )
+    }
+
+    pub fn is_descendant_of(&self, other: &Self) -> bool {
+        self.state().is_descendant_of(other.state())
+            && self.summary().is_descendant_of(other.summary())
+    }
+
+    pub fn version(&self) -> Option<Version> {
+        self.summary().version()
+    }
+
+    pub fn next_version(&self) -> Version {
+        self.summary().next_version()
+    }
+
+    pub fn root_hash(&self) -> HashValue {
+        self.summary().root_hash()
+    }
+
+    pub fn extend(
+        &self,
+        new_version: Version,
+        updates: Vec<(HashValue, Slot)>,
+        proof_reader: &impl ProofRead,
+    ) -> Result<Self> {
+        let smt_updates: Vec<(HashValue, Option<HashValue>)> =
+            updates.iter().map(|(k, s)| (*k, s.value_hash())).collect();
+        let new_global = if smt_updates.is_empty() {
+            self.summary().global_state_summary.clone()
+        } else {
+            self.summary()
+                .global_state_summary
+                .freeze(&self.summary().global_state_summary)
+                .batch_update(smt_updates.iter(), proof_reader)
+                .map_err(|e| {
+                    AptosDbError::Other(format!("scratchpad SMT batch_update failed: {e:?}"))
+                })?
+                .unfreeze()
+        };
+        let new_summary = StateSummary::new_global_only(new_version, new_global);
+        let new_state = self.state().extend(new_version, updates);
+        Ok(Self::new(new_state, new_summary))
+    }
+
+    pub fn make_delta(&self, base: &Self) -> Vec<(HashValue, Slot)> {
+        self.state().make_delta(base.state())
+    }
+}
+
+pub fn pre_shard_jmt_updates<I>(
+    flat: I,
+) -> [Vec<(HashValue, Option<(HashValue, StateKey)>)>; NUM_STATE_SHARDS]
+where
+    I: IntoIterator<Item = (HashValue, Option<(HashValue, StateKey)>)>,
+{
+    let mut shards: [Vec<(HashValue, Option<(HashValue, StateKey)>)>; NUM_STATE_SHARDS] =
+        std::array::from_fn(|_| Vec::new());
+    for (key_hash, leaf) in flat {
+        shards[usize::from(key_hash.nibble(0))].push((key_hash, leaf));
+    }
+    shards
+}

--- a/storage/storage-interface/src/state_store/state_summary.rs
+++ b/storage/storage-interface/src/state_store/state_summary.rs
@@ -13,7 +13,7 @@ use crate::{
 use anyhow::{bail, Result};
 use aptos_config::config::HotStateConfig;
 use aptos_crypto::{
-    hash::{CryptoHash, CORRUPTION_SENTINEL},
+    hash::{CryptoHash, CORRUPTION_SENTINEL, SPARSE_MERKLE_PLACEHOLDER_HASH},
     HashValue,
 };
 use aptos_logger::warn;
@@ -59,6 +59,24 @@ impl StateSummary {
             hot_state_summary: Some(SparseMerkleTree::new_empty()),
             global_state_summary: SparseMerkleTree::new_empty(),
             hot_state_config,
+        }
+    }
+
+    pub fn new_global_only(version: Version, global_state_summary: SparseMerkleTree) -> Self {
+        Self {
+            next_version: version + 1,
+            hot_state_summary: None,
+            global_state_summary,
+            hot_state_config: HotStateConfig::default(),
+        }
+    }
+
+    pub fn new_empty_global_only() -> Self {
+        Self {
+            next_version: 0,
+            hot_state_summary: None,
+            global_state_summary: SparseMerkleTree::new(*SPARSE_MERKLE_PLACEHOLDER_HASH),
+            hot_state_config: HotStateConfig::default(),
         }
     }
 


### PR DESCRIPTION
Adds the durable-commit applier, the two-stage JMT commit pipeline, and the AptosDB integration for native positions. Builds on the durable storage tier in PR #19883 and the shared primitives in PRs #19894 + #19908.

The in-memory scanner mirror (the `NativeStateStore` DashMap and its readers) is layered on top in a later commit; the durable + JMT side here stands on its own.

## Commit applier

- `NativeStateCommitter::apply`: per-shard `SchemaBatch` fan-out against `position_db` for every Position write, returning `NativeMerkleLeafUpdates` (`MerkleLeafUpdate` per write) for the JMT pipeline. Stale-index entries for prior versions are written into the same batch so the pruner can drop them later.

## Commit pipeline

- `PositionBufferedState` — alias of the shared `BufferedState<L, S, P, X>` generic with position's pipeline parameters and a no-op `PositionExtras`. Constructed via `spawn_commit_pipeline`.
- `PositionSnapshotCommitter` driver (`merklize_position`): pulls `PositionSnapshotToCommit` payloads, runs the snapshot through `ShardedJmtMerkleDb::merklize_snapshot`, forwards the resulting `PositionMerkleCommit` downstream.
- `PositionMerkleBatchCommitter`: pulls `PositionMerkleCommit`s and persists per-shard JMT batches + top-levels batch to `position_merkle_db`.

## State-shape primitives

Adds `storage/storage-interface/src/state_store/sharded_jmt_state.rs` with the JMT-sharded pipeline primitives that aren't main-state shared: `LeafSlot<V>` + `impl LeafEntry for LeafSlot<V>`, `ShardedJmtState<Slot>` (16 `MapLayer` chains + `extend` / `make_delta` / `is_descendant_of`), the inherent impl on `StateAndSummary<ShardedJmtState<Slot: LeafEntry>>` (`new_empty`, `extend`, `make_delta`, etc.), and `pre_shard_jmt_updates`.

Also adds two `StateSummary` constructors that only JMT-sharded pipelines without a hot companion need: `new_global_only(version, smt)` and `new_empty_global_only()`.

In the `aptos-db` crate:
- `PositionSlot` — type alias of `LeafSlot<()>` (value not carried in-slot; lives in `position_db` durably).
- `PositionStateStore` — owner / coordinator, type alias of the shared `PipelineStateStore<L, BS>` (also added in this commit, in `crate::common`). Wraps the shared `current_state` mutex (readable by outside consumers) and the `PositionBufferedState` mutex (commit-path serialization).
- `PositionDb` gains the `commit` / `commit_single_shard` / `write_progress` / `find_prior_version` methods that the committer uses.

## AptosDB wiring

- `AptosDB` gains optional handles for `PositionDb` + `PositionMerkleDb` + `PositionStateStore`. Accessed via `native_position_handles` / `native_state_committer`.
- `init_native_position`: opens 16 sharded position DBs + unsharded merkle DB with production CF tuning. Spawns the async commit pipeline seeded with the empty-tree placeholder root. Idempotent (rejects second call). Logs the open.
- `commit_native_position` (in `aptosdb_writer.rs`): rayon-spawned alongside main-state commit; drains `output.write_set().native_position_iter()` (the WriteSet sibling bucket from [types]) through `NativeStateCommitter`, feeding the resulting `MerkleLeafUpdate`s into the position JMT pipeline.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Introduces a new ledger commit sub-path and dual-DB crash/truncation/replay logic for trading positions; mitigated while `ENABLE_TRADING_NATIVE` remains false.
> 
> **Overview**
> Adds **native trading position** persistence and commit integration in `aptos-db`, wired like main state but on a separate `position_db` / `position_merkle_db` pair and `WriteSet::native_position_iter()`.
> 
> **Durable KV path:** `NativeStateCommitter::apply` batches per-shard `PositionValue` writes and stale-index rows (with in-chunk prior-version chaining), then `PositionDb::commit` once per ledger chunk. `PositionDb` gains `find_prior_version`, progress metadata, and truncation helpers aligned with chain `OverallCommitProgress`.
> 
> **In-memory + JMT path:** New `ShardedJmtState` / `LeafSlot` types and `StateSummary::new_global_only` support a position-specific `BufferedState` pipeline (`merklize_position` → async `PositionMerkleBatchCommitter`). `PipelineStateStore` coordinates shared `current_state` vs commit-path `buffered_state`.
> 
> **AptosDB:** Optional `PositionBundle` on open when `ENABLE_TRADING_NATIVE` is true (currently **`false`**). `init_native_position` opens DBs, truncates ahead-of-chain data on restart, replays gap write sets, and seeds the pipeline. `commit_native_position` runs in parallel during pre-commit: applies native writes, extends SMT at checkpoints, commits KV, updates buffered state. Checkpoints now include position DBs.
> 
> Unit tests cover stale-index semantics, tombstones, truncation, and in-chunk overwrite chaining.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f3172caa3e4ae903b964a44a918976cc221a9ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->