### PR TITLE
[Gas Schedule] Bump gas version to v48.

### DIFF
--- a/aptos-move/aptos-gas-schedule/src/ver.rs
+++ b/aptos-move/aptos-gas-schedule/src/ver.rs
@@ -8,6 +8,8 @@
 ///   - Changing how gas is calculated in any way
 ///
 /// Change log:
+/// - V48:
+///   - TBA
 /// - V47:
 ///   - TBA
 /// - V46:
@@ -82,7 +84,7 @@
 ///       global operations.
 /// - V1
 ///   - TBA
-pub const LATEST_GAS_FEATURE_VERSION: u64 = gas_feature_versions::RELEASE_V1_47;
+pub const LATEST_GAS_FEATURE_VERSION: u64 = gas_feature_versions::RELEASE_V1_48;
 
 pub mod gas_feature_versions {
     pub const RELEASE_V1_8: u64 = 11;
@@ -124,4 +126,5 @@ pub mod gas_feature_versions {
     pub const RELEASE_V1_45: u64 = 49;
     pub const RELEASE_V1_46: u64 = 50;
     pub const RELEASE_V1_47: u64 = 51;
+    pub const RELEASE_V1_48: u64 = 52;
 }


### PR DESCRIPTION
## Description
This PR bumps the gas version on `main` by 1.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version metadata only in ver.rs; no gas calculation or parameter changes in this PR.
> 
> **Overview**
> Advances the Aptos gas feature version from **v47** to **v48** in `ver.rs`, following the usual post-release bump pattern.
> 
> `LATEST_GAS_FEATURE_VERSION` now points at `RELEASE_V1_48` (numeric id **52**), the changelog adds a **V48** section marked **TBA**, and `gas_feature_versions` defines the new `RELEASE_V1_48` constant. No gas formulas or parameters are changed in this diff—only the version bookkeeping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit acff51c3e0f7d5b5bde5cbc046edc4866fcbd80c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->