### PR TITLE
[move-prover] Support fun spec block for inline functions

### DIFF
--- a/third_party/move/move-compiler-v2/src/env_pipeline/function_checker.rs
+++ b/third_party/move/move-compiler-v2/src/env_pipeline/function_checker.rs
@@ -110,15 +110,23 @@ pub fn check_access_after_inlining(env: &GlobalEnv) {
                 let callee = env.get_function(callee_id);
 
                 if callee.is_inline() {
-                    for site in &sites {
-                        env.diag(
-                            Severity::Bug,
-                            &env.get_node_loc(*site),
-                            &format!(
-                                "call to inline function `{}` should have been expanded",
-                                callee.get_name_str(),
-                            ),
-                        );
+                    // Opaque inline functions that carry a function-level spec are
+                    // intentionally left as calls so the prover can substitute the
+                    // spec at the call site. A finalizing inliner pass run before
+                    // file format generation expands these, so the runtime binary
+                    // is unaffected.
+                    let kept_for_spec = callee.is_opaque() && callee.has_fun_spec();
+                    if !kept_for_spec {
+                        for site in &sites {
+                            env.diag(
+                                Severity::Bug,
+                                &env.get_node_loc(*site),
+                                &format!(
+                                    "call to inline function `{}` should have been expanded",
+                                    callee.get_name_str(),
+                                ),
+                            );
+                        }
                     }
                 }
 

--- a/third_party/move/move-compiler-v2/src/env_pipeline/inliner.rs
+++ b/third_party/move/move-compiler-v2/src/env_pipeline/inliner.rs
@@ -85,6 +85,22 @@ pub fn run_inlining(
     keep_inline_functions: bool,
     lift_inline_funs: bool,
 ) {
+    run_inlining_with_options(env, scope, keep_inline_functions, lift_inline_funs, false)
+}
+
+/// Like `run_inlining`, but allows forcing expansion of opaque inline functions that
+/// carry a function-level spec. In spec-rewrite (prover) mode, such calls are
+/// normally preserved so the prover can substitute the spec at the call site. The
+/// compile path calls this with `force_expand_opaque_spec_inlines = true` as a
+/// finalizing pass just before file format generation, so the file format does not
+/// contain calls to inline functions.
+pub fn run_inlining_with_options(
+    env: &mut GlobalEnv,
+    scope: RewritingScope,
+    keep_inline_functions: bool,
+    lift_inline_funs: bool,
+    force_expand_opaque_spec_inlines: bool,
+) {
     // Get function roots for running inlining.
     // Also generate errors for any invalid target inline functions.
     let mut targets = RewriteTargets::create(env, scope);
@@ -126,7 +142,12 @@ pub fn run_inlining(
         {
             // We inline functions bottom-up, so that any inline function which itself has calls to
             // inline functions has already had its stuff inlined.
-            let mut inliner = Inliner::new(env, targets, lift_inline_funs);
+            let mut inliner = Inliner::new(
+                env,
+                targets,
+                lift_inline_funs,
+                force_expand_opaque_spec_inlines,
+            );
             for target in targets_needing_inlining.into_iter() {
                 inliner.do_inlining_in(target);
             }
@@ -144,12 +165,22 @@ pub fn run_inlining(
     // scenarios since env dumping crashes if the functions are removed but still referenced
     // from somewhere.
     if !keep_inline_functions {
+        let spec_rewrite = env
+            .get_extension::<Options>()
+            .map(|o| o.experiment_on(Experiment::SPEC_REWRITE))
+            .unwrap_or(false);
         // First construct a list of functions to remove.
         let mut inline_funs = BTreeSet::new();
         for module in env.get_modules() {
             for func in module.get_functions() {
                 let id = func.get_qualified_id();
                 if func.is_inline() && func.get_def().is_some() {
+                    // In spec-rewrite (prover) mode, keep inline functions that carry
+                    // a function-level spec: the prover verifies the body against the
+                    // spec like a normal function.
+                    if spec_rewrite && func.has_fun_spec() {
+                        continue;
+                    }
                     // Only delete functions with a body.
                     inline_funs.insert(id);
                 }
@@ -414,6 +445,11 @@ struct Inliner<'env> {
     inline_targets: RewriteTargets,
     /// Flag to lift lambda expression arguments to inline functions
     lift_inline_funs: bool,
+    /// Whether to preserve call ops to opaque inline functions that carry a
+    /// function-level spec instead of expanding them. Set when running in
+    /// spec-rewrite (prover) mode AND the caller has not asked to force
+    /// expansion (the compile path does, just before file format gen).
+    preserve_opaque_spec_inline_calls: bool,
 }
 
 impl<'env> Inliner<'env> {
@@ -421,11 +457,18 @@ impl<'env> Inliner<'env> {
         env: &'env mut GlobalEnv,
         inline_targets: RewriteTargets,
         lift_inline_funs: bool,
+        force_expand_opaque_spec_inlines: bool,
     ) -> Self {
+        let spec_rewrite = env
+            .get_extension::<Options>()
+            .map(|o| o.experiment_on(Experiment::SPEC_REWRITE))
+            .unwrap_or(false);
+        let preserve_opaque_spec_inline_calls = spec_rewrite && !force_expand_opaque_spec_inlines;
         Self {
             env,
             inline_targets,
             lift_inline_funs,
+            preserve_opaque_spec_inline_calls,
         }
     }
 
@@ -527,6 +570,17 @@ impl ExpRewriterFunctions for OuterInlinerRewriter<'_, '_> {
             let qfid = module_id.qualified(*fun_id);
             let func_env = self.inliner.env.get_function(qfid);
             if func_env.is_inline() {
+                // Opaque inline functions that carry a function-level spec keep
+                // their call op intact so the prover substitutes the spec at the
+                // call site, just like a normal opaque function. The compile path
+                // runs a finalizing inliner pass (force_expand=true) before file
+                // format generation, which clears this flag and expands them.
+                if self.inliner.preserve_opaque_spec_inline_calls
+                    && func_env.is_opaque()
+                    && func_env.has_fun_spec()
+                {
+                    return None;
+                }
                 // inline the function call
                 let type_args = self.inliner.env.get_node_instantiation(call_id);
                 let parameters = func_env.get_parameters();

--- a/third_party/move/move-compiler-v2/src/env_pipeline/spec_rewriter.rs
+++ b/third_party/move/move-compiler-v2/src/env_pipeline/spec_rewriter.rs
@@ -92,10 +92,15 @@ pub fn run_spec_rewriter(env: &mut GlobalEnv) {
         };
         for callee in callees {
             called_funs.insert(callee);
-            let mut transitive = env
-                .get_function(callee)
-                .get_transitive_closure_of_called_functions();
-            called_funs.append(&mut transitive);
+            // Callees referenced from specs can outlive their definitions in the env
+            // — for example, an inline function called from a spec is removed from
+            // the env by the inliner when `KEEP_INLINE_FUNS` is off. Skip such
+            // callees instead of panicking; without a body in the env there is no
+            // transitive closure to add.
+            if let Some(callee_env) = env.find_function(callee) {
+                let mut transitive = callee_env.get_transitive_closure_of_called_functions();
+                called_funs.append(&mut transitive);
+            }
         }
     }
 

--- a/third_party/move/move-compiler-v2/src/lib.rs
+++ b/third_party/move/move-compiler-v2/src/lib.rs
@@ -3,7 +3,7 @@
 // Parts of the file are Copyright (c) Aptos Foundation
 // All Aptos Foundation code and content is licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-mod bytecode_generator;
+pub mod bytecode_generator;
 pub mod diagnostics;
 pub mod env_pipeline;
 mod experiments;
@@ -60,8 +60,9 @@ use move_binary_format::errors::VMError;
 use move_bytecode_source_map::source_map::SourceMap;
 use move_core_types::vm_status::StatusType;
 use move_model::{
+    ast::{Exp, ExpData, Operation},
     metadata::LanguageVersion,
-    model::{GlobalEnv, Loc, MoveIrLoc},
+    model::{FunId, GlobalEnv, Loc, MoveIrLoc, QualifiedId},
     PackageInfo,
 };
 use move_stackless_bytecode::function_target_pipeline::{
@@ -69,7 +70,10 @@ use move_stackless_bytecode::function_target_pipeline::{
 };
 use move_symbol_pool::Symbol;
 pub use options::Options;
-use std::{collections::BTreeSet, path::Path};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    path::Path,
+};
 
 const DEBUG: bool = false;
 const COMPILER_BUG_REPORT_MSG: &str =
@@ -230,6 +234,31 @@ pub fn run_move_compiler_to_model(mut options: Options) -> anyhow::Result<Global
         return Ok(env);
     }
 
+    // Opaque inline functions with a function-level spec have their call ops kept
+    // in caller bodies by the inliner so the prover can substitute the spec at
+    // the call site. File format generation cannot represent these calls (the
+    // referenced function is never emitted to the binary), so we snapshot the
+    // affected caller defs, run a finalizing inliner pass that expands them, do
+    // file format generation, and restore the snapshots so the prover sees the
+    // call-preserving version of each affected caller.
+    let preserved_defs = snapshot_opaque_inline_spec_callers(&env);
+    if !preserved_defs.is_empty() {
+        let lift_inline_funs = options.experiment_on(Experiment::LIFT_INLINE_FUNS);
+        let keep_inline_funs = options.experiment_on(Experiment::KEEP_INLINE_FUNS);
+        let rewriting_scope = RewritingScope::Everything;
+        inliner::run_inlining_with_options(
+            &mut env,
+            rewriting_scope,
+            keep_inline_funs,
+            lift_inline_funs,
+            true,
+        );
+        if env.has_errors() {
+            env.treat_everything_as_target(false);
+            return Ok(env);
+        }
+    }
+
     // Regenerate stackless bytecode after AST optimizations.
     let mut targets = run_stackless_bytecode_gen(&env);
     if env.has_errors() {
@@ -259,9 +288,58 @@ pub fn run_move_compiler_to_model(mut options: Options) -> anyhow::Result<Global
     let annotated_units = annotate_units(modules_and_scripts);
     run_bytecode_verifier(&annotated_units, &mut env);
 
+    // Restore the call-preserving caller defs that we set aside before file format
+    // generation, so downstream consumers (notably the prover) see the calls to
+    // opaque inline spec callees and can substitute the spec at each call site.
+    for (qfid, def) in preserved_defs {
+        env.set_function_def(qfid, def);
+    }
+
     env.set_compiler_v2(true);
     env.treat_everything_as_target(false);
     Ok(env)
+}
+
+/// Returns true if `def` contains a call to an opaque inline function that
+/// carries a function-level spec. The inliner preserves these calls in
+/// spec-rewrite (prover) mode so the prover can substitute the spec at the
+/// call site, just like for a normal opaque function.
+pub fn def_has_opaque_inline_spec_call(env: &GlobalEnv, def: &Exp) -> bool {
+    def.as_ref().any(&mut |e| {
+        if let ExpData::Call(_, Operation::MoveFunction(mid, fid), _) = e {
+            let callee = env.get_function(mid.qualified(*fid));
+            callee.is_inline() && callee.is_opaque() && callee.has_fun_spec()
+        } else {
+            false
+        }
+    })
+}
+
+/// Find caller functions whose AST contains a call to an opaque inline function
+/// that carries a function-level spec. The inliner preserves these calls in
+/// spec-rewrite (prover) mode, so we snapshot the affected caller defs here in
+/// order to restore them after file format generation has expanded the calls.
+///
+/// Inline functions without a function-level spec are skipped: the finalizing
+/// inliner pass drops them from the env, so there is nothing to restore. Inline
+/// functions WITH a function-level spec are included — they survive pruning and
+/// the prover verifies their bodies against the spec, so their preserved calls
+/// to other opaque-inline-with-spec funs must be restored too.
+fn snapshot_opaque_inline_spec_callers(env: &GlobalEnv) -> BTreeMap<QualifiedId<FunId>, Exp> {
+    let mut snapshot = BTreeMap::new();
+    for module in env.get_modules() {
+        for fun in module.get_functions() {
+            if fun.is_inline() && !fun.has_fun_spec() {
+                continue;
+            }
+            if let Some(def) = fun.get_def() {
+                if def_has_opaque_inline_spec_call(env, def) {
+                    snapshot.insert(fun.get_qualified_id(), def.clone());
+                }
+            }
+        }
+    }
+    snapshot
 }
 
 /// Run the type checker and return the global env (with errors if encountered). The result

--- a/third_party/move/move-compiler-v2/tests/checking/specs/inline_fun_spec_err.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/specs/inline_fun_spec_err.exp
@@ -1,7 +1,7 @@
 
 Diagnostics:
-error: functional spec blocks for inline functions are not supported yet
-  ┌─ tests/checking/specs/inline_fun_spec_err.move:5:10
+error: function-level spec blocks are not supported on inline functions with function-typed parameters
+  ┌─ tests/checking/specs/inline_fun_spec_err.move:5:29
   │
-5 │     spec f {
-  │          ^
+5 │     public inline fun apply(f: |u64| u64, x: u64): u64 {
+  │                             ^

--- a/third_party/move/move-compiler-v2/tests/checking/specs/inline_fun_spec_err.move
+++ b/third_party/move/move-compiler-v2/tests/checking/specs/inline_fun_spec_err.move
@@ -1,9 +1,11 @@
+// Function-level specs on inline functions are not supported when the
+// function has a parameter of function type, because the lambda is inlined
+// at the call site rather than passed as a value the spec can refer to.
 module 0x42::M {
-    public inline fun f(): u64 {
-        42
+    public inline fun apply(f: |u64| u64, x: u64): u64 {
+        f(x)
     }
-    spec f {
-        aborts_if false;
-        ensures result == 42;
+    spec apply {
+        ensures result == f(x);
     }
 }

--- a/third_party/move/move-model/bytecode/src/borrow_analysis.rs
+++ b/third_party/move/move-model/bytecode/src/borrow_analysis.rs
@@ -497,7 +497,7 @@ impl FunctionTargetProcessor for BorrowAnalysisProcessor {
         writeln!(f, "\n\n==== borrow analysis summaries ====\n")?;
         for ref module in env.get_modules() {
             for ref fun in module.get_functions() {
-                if fun.is_inline() {
+                if fun.is_inline() && !fun.has_fun_spec() {
                     continue;
                 }
                 for (_, ref target) in targets.get_targets(fun) {

--- a/third_party/move/move-model/bytecode/src/function_target_pipeline.rs
+++ b/third_party/move/move-model/bytecode/src/function_target_pipeline.rs
@@ -184,7 +184,9 @@ impl FunctionTargetsHolder {
 
     /// Adds a new function target. The target will be initialized from the Move byte code.
     pub fn add_target(&mut self, func_env: &FunctionEnv<'_>) {
-        // Skip inlined functions, they do not have associated bytecode.
+        // Skip inlined functions, they do not have associated bytecode. Inline functions
+        // with a function-level spec are added by the prover's higher-level setup using
+        // the AST-based bytecode generator (see `create_and_process_bytecode`).
         if func_env.is_inline() {
             return;
         }
@@ -241,8 +243,8 @@ impl FunctionTargetsHolder {
         func_env: &'env FunctionEnv<'env>,
     ) -> Vec<(FunctionVariant, FunctionTarget<'env>)> {
         assert!(
-            !func_env.is_inline(),
-            "attempt to get bytecode function target for inline function"
+            !func_env.is_inline() || func_env.has_fun_spec(),
+            "attempt to get bytecode function target for inline function without a function-level spec"
         );
         self.targets
             .get(&func_env.get_qualified_id())
@@ -482,7 +484,7 @@ impl FunctionTargetPipeline {
                             // check for fixedpoint in summaries
                             for fid in scc {
                                 let func_env = env.get_function(*fid);
-                                if func_env.is_inline() {
+                                if func_env.is_inline() && !func_env.has_fun_spec() {
                                     continue;
                                 }
                                 for (_, target) in targets.get_targets(&func_env) {

--- a/third_party/move/move-model/bytecode/src/lib.rs
+++ b/third_party/move/move-model/bytecode/src/lib.rs
@@ -62,7 +62,7 @@ pub fn print_targets_with_annotations_for_test(
             continue;
         }
         for func_env in module_env.get_functions() {
-            if func_env.is_inline() || func_env.is_lemma() {
+            if (func_env.is_inline() && !func_env.has_fun_spec()) || func_env.is_lemma() {
                 continue;
             }
             for (variant, target) in targets.get_targets(&func_env) {

--- a/third_party/move/move-model/bytecode/src/usage_analysis.rs
+++ b/third_party/move/move-model/bytecode/src/usage_analysis.rs
@@ -337,7 +337,7 @@ impl FunctionTargetProcessor for UsageProcessor {
                 continue;
             }
             for fun in module.get_functions() {
-                if fun.is_inline() {
+                if fun.is_inline() && !fun.has_fun_spec() {
                     continue;
                 }
                 for (_, ref target) in targets.get_targets(&fun) {

--- a/third_party/move/move-model/src/builder/module_builder.rs
+++ b/third_party/move/move-model/src/builder/module_builder.rs
@@ -1258,12 +1258,22 @@ impl ModuleBuilder<'_, '_> {
                                 self.validate_target_signature(&fun_decl, &loc, signature);
                             }
 
-                            // TODO: to be revisited once we have high-order function
+                            // Inline functions may carry function-level specs, but in this
+                            // first iteration we disallow function-typed parameters: a lambda
+                            // argument gets inlined at the call site rather than passed as a
+                            // first-class function value, so referring to it from a spec is
+                            // not yet supported.
                             if fun_decl.kind == FunctionKind::Inline {
-                                self.parent.error(
-                                    &loc,
-                                    "functional spec blocks for inline functions are not supported yet",
-                                );
+                                if let Some(bad) = fun_decl
+                                    .params
+                                    .iter()
+                                    .find(|Parameter(_, ty, _)| matches!(ty, Type::Fun(..)))
+                                {
+                                    self.parent.error(
+                                        &bad.2,
+                                        "function-level spec blocks are not supported on inline functions with function-typed parameters",
+                                    );
+                                }
                             }
                         },
                         SpecBlockContext::Struct(..) | SpecBlockContext::Module => (),

--- a/third_party/move/move-model/src/model.rs
+++ b/third_party/move/move-model/src/model.rs
@@ -2240,6 +2240,18 @@ impl GlobalEnv {
             .map(|module| module.into_function(fun.id))
     }
 
+    /// Looks up the `FunctionEnv` for `fun`, returning `None` if either the module or
+    /// the function within it has been removed from the env. Unlike `get_function_opt`,
+    /// this does NOT panic when the module exists but the function entry has been
+    /// removed (e.g., inline functions pruned by `inliner::run_inlining`).
+    pub fn find_function(&self, fun: QualifiedId<FunId>) -> Option<FunctionEnv<'_>> {
+        let module = self.get_module_opt(fun.module_id)?;
+        if !module.data.function_data.contains_key(&fun.id) {
+            return None;
+        }
+        Some(module.into_function(fun.id))
+    }
+
     /// Sets the AST based definition of the function.
     pub fn set_function_def(&mut self, fun: QualifiedId<FunId>, def: Exp) {
         let data = self
@@ -5468,10 +5480,17 @@ impl<'env> FunctionEnv<'env> {
 
     /// Returns true if this function has no verified bytecode, meaning it should
     /// be skipped by prover pipeline processors that analyze or instrument code.
-    /// This includes non-compiled functions (native, inline, lemma) and intrinsic
-    /// functions (which have opaque semantics defined by the prover).
+    /// This includes natives, lemmas, intrinsics (opaque semantics defined by the
+    /// prover), and inline functions WITHOUT a function-level spec. Inline
+    /// functions WITH a function-level spec do have verified bytecode — the
+    /// prover generates it from the AST via `add_prover_target` — so they must
+    /// be visible to compositional analyses (e.g. borrow summaries) like a
+    /// normal compiled function.
     pub fn no_verified_bytecode(&self) -> bool {
-        !self.is_compiled() || self.is_intrinsic()
+        self.is_native()
+            || self.is_lemma()
+            || self.is_intrinsic()
+            || (self.is_inline() && !self.has_fun_spec())
     }
 
     /// Returns kind of this function.
@@ -5888,7 +5907,14 @@ impl<'env> FunctionEnv<'env> {
                 reachable_funcs.push_back(self.clone());
                 while let Some(fnc) = reachable_funcs.pop_front() {
                     for callee in fnc.get_used_functions().expect("call info available") {
-                        let f = env.get_function(*callee);
+                        // Same robustness as in
+                        // `get_transitive_closure_of_called_functions`: stale
+                        // `used_funs` entries may point at functions that have been
+                        // removed from the env.
+                        let Some(f) = env.find_function(*callee) else {
+                            set.insert(*callee);
+                            continue;
+                        };
                         if set.insert(f.get_qualified_id()) {
                             reachable_funcs.push_back(f);
                         }
@@ -6021,7 +6047,14 @@ impl<'env> FunctionEnv<'env> {
                 reachable_funcs.push_back(self.clone());
                 while let Some(fnc) = reachable_funcs.pop_front() {
                     for callee in fnc.get_called_functions().expect("call info available") {
-                        let f = env.get_function(*callee);
+                        // The cached `called_funs` set on a function may reference
+                        // functions that have since been removed from the env (e.g.,
+                        // inline functions pruned by the inliner). Treat such callees
+                        // as having no further callees rather than panicking.
+                        let Some(f) = env.find_function(*callee) else {
+                            set.insert(*callee);
+                            continue;
+                        };
                         if set.insert(f.get_qualified_id()) {
                             reachable_funcs.push_back(f);
                         }

--- a/third_party/move/move-model/src/model.rs
+++ b/third_party/move/move-model/src/model.rs
@@ -1861,20 +1861,26 @@ impl GlobalEnv {
             }
         }
 
-        // Assign synthetic def_idx to lemma functions for Boogie debug tracking.
-        // Lemma functions are not compiled, so they lack a FunctionDefinitionIndex.
-        // We give them synthetic indices starting after the last compiled function,
-        // so `boogie_debug_track` can emit $track_local calls and the model extractor
-        // can resolve them back via `try_get_function_id`.
+        // Assign synthetic def_idx to lemma functions and to inline functions that
+        // carry a function-level spec, both of which need Boogie debug tracking but
+        // are absent from the compiled module's function defs. We give them synthetic
+        // indices starting after the last compiled function so `boogie_debug_track`
+        // can emit `$track_local`/`$track_abort` calls and the model extractor can
+        // resolve them back via `try_get_function_id`.
         let next_idx = module.function_defs.len() as u16;
         let mod_data = &mut self.module_data[module_id.0 as usize];
-        let lemma_funs: Vec<_> = mod_data
+        let synthetic_funs: Vec<_> = mod_data
             .function_data
             .iter()
-            .filter(|(_, data)| data.kind == FunctionKind::Lemma)
+            .filter(|(_, data)| {
+                data.kind == FunctionKind::Lemma
+                    || (data.kind == FunctionKind::Inline
+                        && (!data.spec.borrow().conditions.is_empty()
+                            || data.spec.borrow().frame_spec.is_some()))
+            })
             .map(|(fun_id, _)| *fun_id)
             .collect();
-        for (i, fun_id) in lemma_funs.iter().enumerate() {
+        for (i, fun_id) in synthetic_funs.iter().enumerate() {
             let def_idx = FunctionDefinitionIndex(next_idx + i as u16);
             if let Some(fun_data) = mod_data.function_data.get_mut(fun_id) {
                 fun_data.def_idx = Some(def_idx);
@@ -5240,11 +5246,13 @@ impl<'env> FunctionEnv<'env> {
 
     /// Returns `true` for functions that have no independently-processed bytecode target in the
     /// prover pipeline and should be skipped when iterating over functions for analysis:
-    /// - inline functions: their bodies are inlined at every call site
+    /// - inline functions: their bodies are inlined at every call site, EXCEPT when the
+    ///   inline function carries a function-level spec, in which case the prover verifies
+    ///   the body against the spec like any other function
     /// - struct API wrappers: their call sites are replaced by native operations
     ///   (Pack, BorrowField, etc.) in stackless_bytecode_generator before any processor runs
     pub fn is_not_prover_target(&self) -> bool {
-        self.is_inline() || self.is_struct_api()
+        (self.is_inline() && !self.has_fun_spec()) || self.is_struct_api()
     }
 
     /// If this is a struct API wrapper, returns `(ModuleId, StructId)` of the struct it
@@ -5441,6 +5449,16 @@ impl<'env> FunctionEnv<'env> {
     /// Return true if the function is an inline function
     pub fn is_inline(&self) -> bool {
         self.data.kind == FunctionKind::Inline
+    }
+
+    /// Return true if the function has a user-written function-level spec, i.e. a
+    /// `spec foo { ... }` block contributing at least one condition or frame condition.
+    /// Used to decide whether an inline function should participate in prover
+    /// verification (its body checked against the spec) and, when combined with
+    /// `is_opaque()`, whether to preserve calls to it at call sites rather than inlining.
+    pub fn has_fun_spec(&self) -> bool {
+        let spec = self.get_spec();
+        !spec.conditions.is_empty() || spec.frame_spec.is_some()
     }
 
     /// Return true if this is a lemma function (synthesized from a lemma declaration).

--- a/third_party/move/move-model/tests/sources/inline_fun_spec_err.exp
+++ b/third_party/move/move-model/tests/sources/inline_fun_spec_err.exp
@@ -1,5 +1,5 @@
-error: functional spec blocks for inline functions are not supported yet
-  ┌─ tests/sources/inline_fun_spec_err.move:5:10
+error: function-level spec blocks are not supported on inline functions with function-typed parameters
+  ┌─ tests/sources/inline_fun_spec_err.move:5:29
   │
-5 │     spec f {
-  │          ^
+5 │     public inline fun apply(f: |u64| u64, x: u64): u64 {
+  │                             ^

--- a/third_party/move/move-model/tests/sources/inline_fun_spec_err.move
+++ b/third_party/move/move-model/tests/sources/inline_fun_spec_err.move
@@ -1,9 +1,11 @@
+// Function-level specs on inline functions are not supported when the
+// function has a parameter of function type, because the lambda is inlined
+// at the call site rather than passed as a value the spec can refer to.
 module 0x42::M {
-    public inline fun f(): u64 {
-        42
+    public inline fun apply(f: |u64| u64, x: u64): u64 {
+        f(x)
     }
-    spec f {
-        aborts_if false;
-        ensures result == 42;
+    spec apply {
+        ensures result == f(x);
     }
 }

--- a/third_party/move/move-model/tests/sources/inline_fun_spec_function_ok.exp
+++ b/third_party/move/move-model/tests/sources/inline_fun_spec_function_ok.exp
@@ -1,0 +1,1 @@
+All good, no errors!

--- a/third_party/move/move-model/tests/sources/inline_fun_spec_function_ok.move
+++ b/third_party/move/move-model/tests/sources/inline_fun_spec_function_ok.move
@@ -1,0 +1,20 @@
+// Function-level spec blocks are accepted on inline functions whose
+// parameters do not have function type.
+module 0x42::M {
+    public inline fun add_one(x: u64): u64 {
+        x + 1
+    }
+    spec add_one {
+        aborts_if x == 0xFFFFFFFFFFFFFFFF;
+        ensures result == x + 1;
+    }
+
+    public inline fun double(x: u64): u64 {
+        x * 2
+    }
+    spec double {
+        pragma opaque;
+        aborts_if x > 0xFFFFFFFFFFFFFFFF / 2;
+        ensures result == x * 2;
+    }
+}

--- a/third_party/move/move-prover/bytecode-pipeline/src/verification_analysis.rs
+++ b/third_party/move/move-prover/bytecode-pipeline/src/verification_analysis.rs
@@ -390,7 +390,7 @@ impl VerificationAnalysisProcessor {
         if fun_env.is_test_only()
             || fun_env.is_intrinsic()
             || fun_env.is_native()
-            || fun_env.is_inline()
+            || (fun_env.is_inline() && !fun_env.has_fun_spec())
             || fun_env.is_struct_api()
         {
             // do not verify any of these function types

--- a/third_party/move/move-prover/src/inference.rs
+++ b/third_party/move/move-prover/src/inference.rs
@@ -41,8 +41,7 @@ use move_model::{
 };
 use move_prover_bytecode_pipeline::pipeline_factory;
 use move_stackless_bytecode::{
-    function_target_pipeline::{FunctionTargetsHolder, FunctionVariant},
-    print_targets_with_annotations_for_test,
+    function_target_pipeline::FunctionTargetsHolder, print_targets_with_annotations_for_test,
 };
 use std::{
     fs,
@@ -142,33 +141,7 @@ fn run_spec_inference_inner<W: WriteColor>(
             if func_env.is_test_only() {
                 continue;
             }
-            if func_env.is_inline() && func_env.has_fun_spec() {
-                let data = move_compiler_v2::bytecode_generator::generate_bytecode(
-                    env,
-                    func_env.get_qualified_id(),
-                );
-                targets.insert_target_data(
-                    &func_env.get_qualified_id(),
-                    FunctionVariant::Baseline,
-                    data,
-                );
-                continue;
-            }
-            if let Some(def) = func_env.get_def() {
-                if move_compiler_v2::def_has_opaque_inline_spec_call(env, def) {
-                    let data = move_compiler_v2::bytecode_generator::generate_bytecode(
-                        env,
-                        func_env.get_qualified_id(),
-                    );
-                    targets.insert_target_data(
-                        &func_env.get_qualified_id(),
-                        FunctionVariant::Baseline,
-                        data,
-                    );
-                    continue;
-                }
-            }
-            targets.add_target(&func_env)
+            crate::add_prover_target(&mut targets, env, &func_env);
         }
     }
 

--- a/third_party/move/move-prover/src/inference.rs
+++ b/third_party/move/move-prover/src/inference.rs
@@ -41,7 +41,8 @@ use move_model::{
 };
 use move_prover_bytecode_pipeline::pipeline_factory;
 use move_stackless_bytecode::{
-    function_target_pipeline::FunctionTargetsHolder, print_targets_with_annotations_for_test,
+    function_target_pipeline::{FunctionTargetsHolder, FunctionVariant},
+    print_targets_with_annotations_for_test,
 };
 use std::{
     fs,
@@ -138,9 +139,36 @@ fn run_spec_inference_inner<W: WriteColor>(
             info!("preparing module {}", module_env.get_full_name_str());
         }
         for func_env in module_env.get_functions() {
-            if !func_env.is_test_only() {
-                targets.add_target(&func_env)
+            if func_env.is_test_only() {
+                continue;
             }
+            if func_env.is_inline() && func_env.has_fun_spec() {
+                let data = move_compiler_v2::bytecode_generator::generate_bytecode(
+                    env,
+                    func_env.get_qualified_id(),
+                );
+                targets.insert_target_data(
+                    &func_env.get_qualified_id(),
+                    FunctionVariant::Baseline,
+                    data,
+                );
+                continue;
+            }
+            if let Some(def) = func_env.get_def() {
+                if move_compiler_v2::def_has_opaque_inline_spec_call(env, def) {
+                    let data = move_compiler_v2::bytecode_generator::generate_bytecode(
+                        env,
+                        func_env.get_qualified_id(),
+                    );
+                    targets.insert_target_data(
+                        &func_env.get_qualified_id(),
+                        FunctionVariant::Baseline,
+                        data,
+                    );
+                    continue;
+                }
+            }
+            targets.add_target(&func_env)
         }
     }
 

--- a/third_party/move/move-prover/src/lib.rs
+++ b/third_party/move/move-prover/src/lib.rs
@@ -22,7 +22,7 @@ use move_prover_boogie_backend::{
 use move_prover_bytecode_pipeline::{
     number_operation::GlobalNumberOperationState, pipeline_factory,
 };
-use move_stackless_bytecode::function_target_pipeline::FunctionTargetsHolder;
+use move_stackless_bytecode::function_target_pipeline::{FunctionTargetsHolder, FunctionVariant};
 use std::{
     fs,
     path::Path,
@@ -285,6 +285,43 @@ pub fn create_and_process_bytecode(options: &Options, env: &GlobalEnv) -> Functi
                 // Struct API wrappers have no user-written specs; skip them to avoid
                 // spurious invariant failures from DataInvariantInstrumentationProcessor.
                 continue;
+            }
+            if func_env.is_inline() && func_env.has_fun_spec() {
+                // Inline functions with a function-level spec are verified against
+                // their spec like any other function. They have no compiled module
+                // entry (inline funs are never emitted to the file format), so the
+                // legacy `add_target` path can't produce bytecode for them. Use the
+                // AST-based bytecode generator from compiler-v2 instead and insert
+                // the resulting baseline data directly.
+                let data = move_compiler_v2::bytecode_generator::generate_bytecode(
+                    env,
+                    func_env.get_qualified_id(),
+                );
+                targets.insert_target_data(
+                    &func_env.get_qualified_id(),
+                    FunctionVariant::Baseline,
+                    data,
+                );
+                continue;
+            }
+            // Callers that contain a preserved call to an opaque inline function
+            // with a function-level spec must be generated from their AST: the
+            // file format bytecode attached to the env was produced from the
+            // fully-inlined version and has lost the call op, but the AST has
+            // been restored to the call-preserving form for our benefit.
+            if let Some(def) = func_env.get_def() {
+                if move_compiler_v2::def_has_opaque_inline_spec_call(env, def) {
+                    let data = move_compiler_v2::bytecode_generator::generate_bytecode(
+                        env,
+                        func_env.get_qualified_id(),
+                    );
+                    targets.insert_target_data(
+                        &func_env.get_qualified_id(),
+                        FunctionVariant::Baseline,
+                        data,
+                    );
+                    continue;
+                }
             }
             targets.add_target(&func_env)
         }

--- a/third_party/move/move-prover/src/lib.rs
+++ b/third_party/move/move-prover/src/lib.rs
@@ -14,7 +14,9 @@ use log::{debug, info, warn};
 use log::{log_enabled, Level};
 use move_compiler_v2::Experiment;
 use move_model::{
-    code_writer::CodeWriter, metadata::LATEST_STABLE_COMPILER_VERSION_VALUE, model::GlobalEnv,
+    code_writer::CodeWriter,
+    metadata::LATEST_STABLE_COMPILER_VERSION_VALUE,
+    model::{FunctionEnv, GlobalEnv},
 };
 use move_prover_boogie_backend::{
     add_prelude, boogie_wrapper::BoogieWrapper, bytecode_translator::BoogieTranslator,
@@ -260,6 +262,44 @@ pub fn verify_boogie(
     Ok(())
 }
 
+/// Adds a single function to the prover's targets, choosing between the AST-based
+/// bytecode generator and the legacy compiled-module-based one. The AST-based path
+/// is used in two cases that the legacy generator cannot handle correctly:
+///
+/// 1. Inline functions with a function-level spec. These have no entry in the
+///    compiled module (inline funs are never emitted to the file format), so the
+///    legacy generator (which reads from the compiled module) has no bytecode to
+///    work with.
+/// 2. Non-inline callers that retain a preserved call to an opaque inline function
+///    with a function-level spec. The compiled module attached to the env was
+///    produced from the fully-inlined version of the AST, so the legacy generator
+///    would lose the call op. The AST has since been restored to the
+///    call-preserving form, so we go through the AST-based generator to make the
+///    call visible to spec instrumentation.
+pub(crate) fn add_prover_target(
+    targets: &mut FunctionTargetsHolder,
+    env: &GlobalEnv,
+    func_env: &FunctionEnv<'_>,
+) {
+    let use_ast_generator = (func_env.is_inline() && func_env.has_fun_spec())
+        || func_env
+            .get_def()
+            .is_some_and(|def| move_compiler_v2::def_has_opaque_inline_spec_call(env, def));
+    if use_ast_generator {
+        let data = move_compiler_v2::bytecode_generator::generate_bytecode(
+            env,
+            func_env.get_qualified_id(),
+        );
+        targets.insert_target_data(
+            &func_env.get_qualified_id(),
+            FunctionVariant::Baseline,
+            data,
+        );
+    } else {
+        targets.add_target(func_env);
+    }
+}
+
 /// Create bytecode and process it.
 pub fn create_and_process_bytecode(options: &Options, env: &GlobalEnv) -> FunctionTargetsHolder {
     let mut targets = FunctionTargetsHolder::default();
@@ -286,44 +326,7 @@ pub fn create_and_process_bytecode(options: &Options, env: &GlobalEnv) -> Functi
                 // spurious invariant failures from DataInvariantInstrumentationProcessor.
                 continue;
             }
-            if func_env.is_inline() && func_env.has_fun_spec() {
-                // Inline functions with a function-level spec are verified against
-                // their spec like any other function. They have no compiled module
-                // entry (inline funs are never emitted to the file format), so the
-                // legacy `add_target` path can't produce bytecode for them. Use the
-                // AST-based bytecode generator from compiler-v2 instead and insert
-                // the resulting baseline data directly.
-                let data = move_compiler_v2::bytecode_generator::generate_bytecode(
-                    env,
-                    func_env.get_qualified_id(),
-                );
-                targets.insert_target_data(
-                    &func_env.get_qualified_id(),
-                    FunctionVariant::Baseline,
-                    data,
-                );
-                continue;
-            }
-            // Callers that contain a preserved call to an opaque inline function
-            // with a function-level spec must be generated from their AST: the
-            // file format bytecode attached to the env was produced from the
-            // fully-inlined version and has lost the call op, but the AST has
-            // been restored to the call-preserving form for our benefit.
-            if let Some(def) = func_env.get_def() {
-                if move_compiler_v2::def_has_opaque_inline_spec_call(env, def) {
-                    let data = move_compiler_v2::bytecode_generator::generate_bytecode(
-                        env,
-                        func_env.get_qualified_id(),
-                    );
-                    targets.insert_target_data(
-                        &func_env.get_qualified_id(),
-                        FunctionVariant::Baseline,
-                        data,
-                    );
-                    continue;
-                }
-            }
-            targets.add_target(&func_env)
+            add_prover_target(&mut targets, env, &func_env);
         }
     }
 

--- a/third_party/move/move-prover/tests/sources/functional/inline_fun_spec.move
+++ b/third_party/move/move-prover/tests/sources/functional/inline_fun_spec.move
@@ -1,0 +1,54 @@
+// Function-level specs on inline functions.
+//
+// Two flavors are exercised:
+//   1. Non-opaque inline functions: body is inlined at call sites as today.
+//      The body is also verified against the spec independently.
+//   2. Opaque inline functions: at call sites the prover substitutes the spec
+//      instead of the inlined body, just like a normal opaque function.
+//      The body is still verified against the spec independently.
+module 0x42::TestInlineFunSpec {
+
+    spec module {
+        pragma verify = true;
+    }
+
+    // -- (1) non-opaque inline ------------------------------------------------
+
+    public inline fun add_one(x: u64): u64 {
+        x + 1
+    }
+    spec add_one {
+        aborts_if x == 0xFFFFFFFFFFFFFFFF;
+        ensures result == x + 1;
+    }
+
+    public fun caller_inline(): u64 {
+        add_one(41)
+    }
+    spec caller_inline {
+        ensures result == 42;
+    }
+
+    // -- (2) opaque inline ----------------------------------------------------
+
+    // Body returns `x + 1`. The spec is the canonical contract used at call
+    // sites; the body is verified against this spec.
+    public inline fun add_one_opaque(x: u64): u64 {
+        x + 1
+    }
+    spec add_one_opaque {
+        pragma opaque = true;
+        aborts_if x == 0xFFFFFFFFFFFFFFFF;
+        ensures result == x + 1;
+    }
+
+    // The caller's post-condition is discharged by the callee's spec, not by
+    // looking at the inlined body — `pragma opaque` hides the body at the
+    // call site.
+    public fun caller_opaque(): u64 {
+        add_one_opaque(41)
+    }
+    spec caller_opaque {
+        ensures result == 42;
+    }
+}

--- a/third_party/move/move-prover/tests/sources/functional/inline_fun_spec_err.exp
+++ b/third_party/move/move-prover/tests/sources/functional/inline_fun_spec_err.exp
@@ -1,0 +1,15 @@
+Move prover returns: exiting with verification errors
+error: post-condition does not hold
+   ┌─ tests/sources/functional/inline_fun_spec_err.move:15:9
+   │
+15 │         ensures result == x + 2;
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   =     at tests/sources/functional/inline_fun_spec_err.move:10: add_one_wrong_spec
+   =         x = <redacted>
+   =     at tests/sources/functional/inline_fun_spec_err.move:11: add_one_wrong_spec
+   =         <redacted> = <redacted>
+   =         return = <redacted>
+   =         result = <redacted>
+   =     at tests/sources/functional/inline_fun_spec_err.move:14: add_one_wrong_spec (spec)
+   =     at tests/sources/functional/inline_fun_spec_err.move:15: add_one_wrong_spec (spec)

--- a/third_party/move/move-prover/tests/sources/functional/inline_fun_spec_err.move
+++ b/third_party/move/move-prover/tests/sources/functional/inline_fun_spec_err.move
@@ -1,0 +1,17 @@
+// The body of an inline function with a function-level spec is verified
+// against the spec. Here the body returns `x + 1` but the spec claims the
+// result is `x + 2`, so verification of the inline function's spec must fail.
+module 0x42::TestInlineFunSpecErr {
+
+    spec module {
+        pragma verify = true;
+    }
+
+    public inline fun add_one_wrong_spec(x: u64): u64 {
+        x + 1
+    }
+    spec add_one_wrong_spec {
+        aborts_if x == 0xFFFFFFFFFFFFFFFF;
+        ensures result == x + 2;
+    }
+}

--- a/third_party/move/move-prover/tests/sources/functional/inline_fun_spec_nested.move
+++ b/third_party/move/move-prover/tests/sources/functional/inline_fun_spec_nested.move
@@ -1,0 +1,46 @@
+// Regression: a non-opaque inline function with a function-level spec that
+// itself calls an opaque inline function with a function-level spec.
+//
+// `outer_inline` (non-opaque) calls `inner_opaque` (opaque). When the prover
+// verifies `outer_inline`'s body against its spec, the call to `inner_opaque`
+// must be treated opaquely — the prover uses inner_opaque's spec at the call
+// site, not the body. inner_opaque's spec lies (says `result == x + 2`) so the
+// only way `outer_inline`'s spec `result == x + 2` can verify is if the
+// substitution happens at the call site.
+//
+// `top` is a non-inline caller of `inner_opaque` whose only purpose is to
+// trigger the finalizing inliner pass — without it, the snapshot is empty and
+// the pass is skipped, hiding the regression.
+module 0x42::TestInlineFunSpecNested {
+
+    spec module {
+        pragma verify = true;
+    }
+
+    public inline fun inner_opaque(x: u64): u64 {
+        x + 1
+    }
+    spec inner_opaque {
+        pragma opaque = true;
+        pragma verify = false;
+        aborts_if x == 0xFFFFFFFFFFFFFFFF || x == 0xFFFFFFFFFFFFFFFE;
+        ensures result == x + 2;
+    }
+
+    public inline fun outer_inline(x: u64): u64 {
+        inner_opaque(x)
+    }
+    spec outer_inline {
+        aborts_if x == 0xFFFFFFFFFFFFFFFF || x == 0xFFFFFFFFFFFFFFFE;
+        ensures result == x + 2;
+    }
+
+    // Forces the finalizing inliner pass to run by ensuring at least one
+    // non-inline caller has a preserved opaque-inline-spec call.
+    public fun top(): u64 {
+        inner_opaque(41)
+    }
+    spec top {
+        ensures result == 43;
+    }
+}

--- a/third_party/move/move-prover/tests/sources/functional/inline_fun_spec_opaque_substitution.exp
+++ b/third_party/move/move-prover/tests/sources/functional/inline_fun_spec_opaque_substitution.exp
@@ -1,0 +1,29 @@
+Move prover returns: exiting with verification errors
+error: function does not abort under this condition
+   ┌─ tests/sources/functional/inline_fun_spec_opaque_substitution.move:23:9
+   │
+23 │         aborts_if x == 0xFFFFFFFFFFFFFFFF || x == 0xFFFFFFFFFFFFFFFE;
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   =     at tests/sources/functional/inline_fun_spec_opaque_substitution.move:18: add_one_opaque
+   =         x = <redacted>
+   =     at tests/sources/functional/inline_fun_spec_opaque_substitution.move:19: add_one_opaque
+   =         <redacted> = <redacted>
+   =         return = <redacted>
+   =         result = <redacted>
+   =     at tests/sources/functional/inline_fun_spec_opaque_substitution.move:23: add_one_opaque (spec)
+
+error: post-condition does not hold
+   ┌─ tests/sources/functional/inline_fun_spec_opaque_substitution.move:24:9
+   │
+24 │         ensures result == x + 2;
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   =     at tests/sources/functional/inline_fun_spec_opaque_substitution.move:18: add_one_opaque
+   =         x = <redacted>
+   =     at tests/sources/functional/inline_fun_spec_opaque_substitution.move:19: add_one_opaque
+   =         <redacted> = <redacted>
+   =         return = <redacted>
+   =         result = <redacted>
+   =     at tests/sources/functional/inline_fun_spec_opaque_substitution.move:23: add_one_opaque (spec)
+   =     at tests/sources/functional/inline_fun_spec_opaque_substitution.move:24: add_one_opaque (spec)

--- a/third_party/move/move-prover/tests/sources/functional/inline_fun_spec_opaque_substitution.move
+++ b/third_party/move/move-prover/tests/sources/functional/inline_fun_spec_opaque_substitution.move
@@ -1,0 +1,33 @@
+// Demonstrates that `pragma opaque` on an inline function causes the prover to
+// substitute the SPEC at call sites instead of the inlined body.
+//
+// The body of `add_one_opaque` returns `x + 1`. The post-condition lies and
+// says the result is `x + 2`. The caller's post-condition uses `2 + 41 = 43`.
+//
+// If the prover were inlining the body at the call site, `caller` would
+// compute `41 + 1 = 42` and the post `result == 43` would fail. The fact that
+// `caller` verifies proves the prover used the (lying) spec at the call site,
+// not the body. Independently, the body of `add_one_opaque` is checked
+// against its spec, and that check is expected to fail.
+module 0x42::TestInlineFunSpecOpaque {
+
+    spec module {
+        pragma verify = true;
+    }
+
+    public inline fun add_one_opaque(x: u64): u64 {
+        x + 1
+    }
+    spec add_one_opaque {
+        pragma opaque = true;
+        aborts_if x == 0xFFFFFFFFFFFFFFFF || x == 0xFFFFFFFFFFFFFFFE;
+        ensures result == x + 2;
+    }
+
+    public fun caller(): u64 {
+        add_one_opaque(41)
+    }
+    spec caller {
+        ensures result == 43;
+    }
+}


### PR DESCRIPTION
## Description

Function-level spec blocks (`spec foo { requires ...; ensures ...; ... }`) are now allowed on inline functions, with semantics that mirror normal functions:

- **Body verification.** The body of an inline function with a function-level spec is verified against the spec, just like a normal function.
- **Opaque substitution at call sites.** When the spec carries `pragma opaque = true`, the prover substitutes the spec at each call site instead of inlining the body — exactly as it does for normal opaque functions. The body is still independently verified against the spec.
- **Compile path unchanged.** The runtime / file-format-bound compile pipeline still inlines the body at every call site. The new behavior is prover-only; nothing in emitted bytecode changes.

In this first iteration we **do not** support function-level specs on inline functions that take a parameter of function type: a lambda argument is inlined at the call site rather than passed as a value, so a spec cannot meaningfully refer to it. The checker rejects this combination with a targeted error.

This PR also closes #17524 by adding defensive code when retrieving the function.

### High-level mechanism

The blocker for opaque-at-call-site was that file format generation cannot represent a CALL to an inline function (inline funs are never emitted to the binary). We resolve this by snapshotting and restoring around file format generation:

1. **Inliner (first pass, prover mode).** In spec-rewrite mode, `OuterInlinerRewriter::rewrite_call` returns `None` for opaque-inline-with-spec callees so the `Call` op survives in caller bodies. Inline funs with a function-level spec are also kept alive after the post-inlining pruning step.
2. **Finalizing inliner pass.** `run_inlining_with_options(..., force_expand_opaque_spec_inlines=true)` is invoked from `run_move_compiler_to_model` after the env optimization pipeline but before file format generation. It expands the preserved `Call` ops. `snapshot_opaque_inline_spec_callers` saves the call-preserving caller `Exp`s first.
3. **File format gen + bytecode verifier** run cleanly on the fully-inlined AST.
4. **Restore.** `set_function_def` puts the call-preserving `Exp`s back on the env.
5. **Prover bytecode regeneration.** The prover's `create_and_process_bytecode` (and the inference path) detect callers with restored `Call` ops via the public helper `def_has_opaque_inline_spec_call`, and generate their stackless bytecode from the AST using `move_compiler_v2::bytecode_generator::generate_bytecode` instead of the legacy `add_target` (which would read the fully-inlined version from the file format). Inline-with-spec funs themselves go through the same AST-based generator.
6. **Debug tracking.** `attach_compiled_module` now also assigns synthetic `def_idx`s to inline-with-spec funs (same trick used for lemma funs), so `boogie_debug_track_*` works for them.

### What's deferred

- Inline functions with function-typed parameters cannot yet carry a function-level spec. This is the only intentionally-rejected case.

## How Has This Been Tested?

Three new prover tests cover the end-to-end behavior:

- `move-prover/tests/sources/functional/inline_fun_spec.move` — both opaque and non-opaque inline funs with function-level specs verify cleanly, and their callers verify too.
- `move-prover/tests/sources/functional/inline_fun_spec_err.move` — a non-opaque inline fun whose body returns `x + 1` but whose spec lies and says `result == x + 2`. Demonstrates that the body is being checked against the spec (post-condition does not hold).
- `move-prover/tests/sources/functional/inline_fun_spec_opaque_substitution.move` — the body of an opaque inline fun returns `x + 1`, but its spec lies and says `result == x + 2`. The caller's post relies on the lying value (`result == 43` from input `41`). The caller verifies (proving the spec was substituted at the call site, not the body), while the body's own verification of the spec correctly fails.

Existing model and checker tests cover the parser/checker side:

- `move-model/tests/sources/inline_fun_spec_err.move` (and the matching `move-compiler-v2` checker test) — exercises the new rejection of function-level specs on inline funs with function-typed parameters.

All test suites green: `move-model` (32), `move-compiler-v2` (2240), `move-prover` (237).

## Key Areas to Review

- **Snapshot / restore around file format gen** in `third_party/move/move-compiler-v2/src/lib.rs` (`run_move_compiler_to_model` and `snapshot_opaque_inline_spec_callers`). The window between snapshot and restore briefly leaves the env in a fully-inlined state; nothing else reads the env during this window, but please confirm.
- **Inliner gate** in `third_party/move/move-compiler-v2/src/env_pipeline/inliner.rs` — the `preserve_opaque_spec_inline_calls` flag and the new `run_inlining_with_options`. Pruning intentionally keeps inline-with-spec funs alive in spec-rewrite mode regardless of `force_expand`, so the prover can verify them.
- **Prover bytecode regeneration** in `third_party/move/move-prover/src/lib.rs` and `inference.rs`. The choice between legacy `add_target` (file-format-driven) and `bytecode_generator::generate_bytecode` (AST-driven) for affected callers is what makes the restored Call op visible to spec instrumentation.
- **Synthetic def_idx** in `third_party/move/move-model/src/model.rs` (`attach_compiled_module`) — now extended from lemma funs to also cover inline-with-spec funs.
- **Checker rejection** in `third_party/move/move-model/src/builder/module_builder.rs` — only rejects when an inline fun with a function-level spec has a `Type::Fun(..)` parameter.

## Type of Change

- [x] New feature

## Which Components or Systems Does This Change Impact?

- [x] Move Compiler
- [x] Other (specify): Move Prover

## Checklist

- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I tested both happy and unhappy path of the functionality

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes span compiler inlining, env snapshot/restore around file format generation, and prover bytecode selection—easy to get subtle mismatches between compiled vs prover AST, though runtime bytecode behavior is intended unchanged.
> 
> **Overview**
> **Function-level `spec` blocks on inline functions** are now supported when parameters are not function-typed. Bodies are verified against the spec; **`pragma opaque`** causes the prover to use the spec at call sites instead of the inlined body. Inline functions with a **`Type::Fun` parameter** still cannot have a function-level spec (targeted checker error).
> 
> The compile path still fully inlines for the binary. In **spec-rewrite / prover mode**, the inliner **keeps** calls to **opaque inline + spec** callees and **retains** inline functions that have a spec. Before file format generation, **`run_move_compiler_to_model`** snapshots affected caller ASTs, runs a **finalizing** `run_inlining_with_options(..., force_expand_opaque_spec_inlines = true)`, generates bytecode, then **restores** snapshots so the prover still sees preserved calls.
> 
> Downstream wiring includes **`has_fun_spec`**, **`find_function`** (avoid panics on pruned inline callees), **synthetic `def_idx`** for inline-with-spec (like lemmas), bytecode holders treating them as real targets, and **`add_prover_target`** / **`bytecode_generator::generate_bytecode`** for inline-with-spec and callers containing those calls. **`pub mod bytecode_generator`** exposes the AST generator to the prover.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a66ab8a8dcb2d6d0d8188f559f545421f48de18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->