### PR TITLE
[compiler] Use receiver style calls for macro-generated code

### DIFF
--- a/third_party/move/move-model/src/builder/macros.rs
+++ b/third_party/move/move-model/src/builder/macros.rs
@@ -128,7 +128,7 @@ impl ExpTranslator<'_, '_, '_> {
     /// if (cond) {
     ///     ()
     /// } else {
-    ///     abort string::into_bytes(string_utils::format<N>(&fmt, arg1, ..., argN))
+    ///     abort string_utils::format<N>(&fmt, arg1, ..., argN).into_bytes()
     /// }
     /// ```
     fn expand_assert(&self, loc: Loc, args: &Spanned<Vec<Exp>>) -> Exp_ {
@@ -207,7 +207,7 @@ impl ExpTranslator<'_, '_, '_> {
     /// if ($left == $right) {
     ///     ()
     /// } else {
-    ///     abort string::into_bytes(string_utils::format2(<assertion_failed_message>, $left, $right))
+    ///     abort string_utils::format2(<assertion_failed_message>, $left, $right).into_bytes()
     /// }
     /// ```
     ///
@@ -221,7 +221,7 @@ impl ExpTranslator<'_, '_, '_> {
     /// if ($left == $right) {
     ///     ()
     /// } else {
-    ///     abort string::into_bytes(string_utils::format3(<assertion_failed_message>, string::utf8(message), $left, $right))
+    ///     abort string_utils::format3(<assertion_failed_message>, string::utf8(message), $left, $right).into_bytes()
     /// }
     /// ```
     ///
@@ -235,7 +235,7 @@ impl ExpTranslator<'_, '_, '_> {
     /// if ($left == $right) {
     ///     ()
     /// } else {
-    ///     abort string::into_bytes(string_utils::format3(<assertion_failed_message>, string_utils::format<N>(&fmt, arg1, ..., argN), $left, $right))
+    ///     abort string_utils::format3(<assertion_failed_message>, string_utils::format<N>(&fmt, arg1, ..., argN), $left, $right).into_bytes()
     /// }
     /// ```
     fn expand_assert_eq(&self, loc: Loc, args: &Spanned<Vec<Exp>>) -> Exp_ {
@@ -353,9 +353,17 @@ impl ExpTranslator<'_, '_, '_> {
         )
     }
 
-    /// Calls `std::string::into_bytes(s)`.
+    /// Calls `s.into_bytes()` in receiver style.
     fn call_into_bytes(&self, loc: Loc, s: Exp) -> Exp {
-        self.call_stdlib_function(loc, STRING_MODULE, INTO_BYTES_FUNCTION_NAME, vec![s])
+        if !self.check_stdlib_module(loc, STRING_MODULE) {
+            return sp(loc, Exp_::UnresolvedError);
+        }
+        let function_name = sp(loc, INTO_BYTES_FUNCTION_NAME.into());
+        let module_access = sp(loc, ModuleAccess_::Name(function_name));
+        sp(
+            loc,
+            Exp_::Call(module_access, CallKind::Receiver, None, sp(loc, vec![s])),
+        )
     }
 
     /// Calls `std::string::utf8(bytes)`.

--- a/third_party/move/move-stdlib/sources/string.move
+++ b/third_party/move/move-stdlib/sources/string.move
@@ -35,8 +35,8 @@ module std::string {
     }
 
     /// Returns the underlying byte vector.
-    public fun into_bytes(s: String): vector<u8> {
-        let String { bytes } = s;
+    public fun into_bytes(self: String): vector<u8> {
+        let String { bytes } = self;
         bytes
     }
 


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

The `use_receiver_style` lint was flagging the `std::string::into_bytes(...)` call generated by `assert!`/`assert_eq!`/`assert_ne!` expansion. Switch the expansion to receiver style.

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

Existing tests pass.

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving AST shape and stdlib signature alignment for lint compliance; no auth, VM, or runtime logic changes.
> 
> **Overview**
> Macro expansion for **`assert!`**, **`assert_eq!`**, and **`assert_ne!`** now turns formatted abort payloads into bytes via **receiver-style** `string_utils::format…().into_bytes()` instead of **`std::string::into_bytes(…)`**, so generated code satisfies the **`use_receiver_style`** lint.
> 
> The expander’s **`call_into_bytes`** builds a **`CallKind::Receiver`** call to **`into_bytes`** (with the same stdlib module check as before). **`std::string::into_bytes`** is updated to take **`self: String`** to match that calling convention.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8774779efd1e359583d640f1cbbf18cab7b7b5e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->