### PR TITLE
[txn-tracing] Label pre-execution-filtered txns as Filtered, not Keep

### DIFF
--- a/crates/aptos-transaction-tracing/src/store.rs
+++ b/crates/aptos-transaction-tracing/src/store.rs
@@ -333,11 +333,21 @@ impl TransactionTraceStore {
         }
     }
 
-    /// Record execution results (Keep/Retry/Discard) for traced txns in a block.
-    /// Called from block_executor::execute_and_update_state after execution.
+    /// Record execution results (Keep/Retry/Discard/Filtered) for traced txns
+    /// in a block. Called from block_executor::execute_and_update_state after
+    /// execution.
+    ///
+    /// `keep_hashes`, `retry_hashes`, `discard_hashes` come from
+    /// `execution_output.to_commit/to_retry/to_discard`. A traced txn proposed
+    /// in this block but absent from all three sets was pre-filtered before
+    /// BlockSTM (most commonly: the prepare-block deduper saw the hash was
+    /// already committed in an earlier block) and is recorded as `Filtered`.
+    /// Without this fall-through case, deduped txns would be silently
+    /// mislabeled as `Keep`.
     pub fn record_execution_result(
         &self,
         block_id: &HashValue,
+        keep_hashes: &[HashValue],
         retry_hashes: &[HashValue],
         discard_hashes: &[HashValue],
     ) {
@@ -345,35 +355,30 @@ impl TransactionTraceStore {
             use crate::types::{ExecutionStatus, StageMetadata};
             let now = now_usecs();
 
+            let keep_set: std::collections::HashSet<HashValue> =
+                keep_hashes.iter().copied().collect();
             let retry_set: std::collections::HashSet<HashValue> =
                 retry_hashes.iter().copied().collect();
             let discard_set: std::collections::HashSet<HashValue> =
                 discard_hashes.iter().copied().collect();
 
             for hash in &traced_hashes {
-                if retry_set.contains(hash) {
-                    self.record_stage_with_metadata_at(
-                        hash,
-                        TransactionStage::Executed,
-                        StageMetadata::Execution(ExecutionStatus::Retry),
-                        now,
-                    );
+                let status = if keep_set.contains(hash) {
+                    ExecutionStatus::Keep
+                } else if retry_set.contains(hash) {
                     self.mark_retry(hash);
+                    ExecutionStatus::Retry
                 } else if discard_set.contains(hash) {
-                    self.record_stage_with_metadata_at(
-                        hash,
-                        TransactionStage::Executed,
-                        StageMetadata::Execution(ExecutionStatus::Discard),
-                        now,
-                    );
+                    ExecutionStatus::Discard
                 } else {
-                    self.record_stage_with_metadata_at(
-                        hash,
-                        TransactionStage::Executed,
-                        StageMetadata::Execution(ExecutionStatus::Keep),
-                        now,
-                    );
-                }
+                    ExecutionStatus::Filtered
+                };
+                self.record_stage_with_metadata_at(
+                    hash,
+                    TransactionStage::Executed,
+                    StageMetadata::Execution(status),
+                    now,
+                );
             }
         }
     }
@@ -781,6 +786,7 @@ fn log_trace(trace: &TransactionTrace) {
         match last_exec {
             Some(ExecutionStatus::Discard) => "discarded",
             Some(ExecutionStatus::Retry) => "retry_incomplete",
+            Some(ExecutionStatus::Filtered) => "filtered",
             _ => "unknown",
         }
     };
@@ -1177,6 +1183,57 @@ mod tests {
         assert_eq!(scalars.mempool_commit_ms, Some(3)); // (4500-1000)/1000 = 3
         assert_eq!(scalars.qs_batch_created_ms, None);
         assert_eq!(scalars.executed_status.as_deref(), Some("Keep"));
+    }
+
+    #[test]
+    fn test_record_execution_result_dispatches_all_four_statuses() {
+        use crate::types::{ExecutionStatus, StageMetadata};
+        let store = TransactionTraceStore::new();
+        let sender = AccountAddress::random();
+        let mut allowlist = std::collections::HashSet::new();
+        allowlist.insert(sender);
+        store.update_filter(TransactionFilter::new(true, allowlist, 1.0, 1.0));
+
+        let keep_hash = HashValue::random();
+        let retry_hash = HashValue::random();
+        let discard_hash = HashValue::random();
+        // Filtered = present in the block's traced set but in none of the
+        // three execution-output sets. Mirrors the duplicate-inclusion case
+        // where the prepare-block deduper drops the txn before BlockSTM
+        // because the same hash already committed in an earlier block.
+        let filtered_hash = HashValue::random();
+        for h in [keep_hash, retry_hash, discard_hash, filtered_hash] {
+            store.maybe_start_trace(h, sender, 0);
+        }
+        let block_id = HashValue::random();
+        store.register_block(block_id, vec![
+            keep_hash,
+            retry_hash,
+            discard_hash,
+            filtered_hash,
+        ]);
+
+        store.record_execution_result(&block_id, &[keep_hash], &[retry_hash], &[discard_hash]);
+
+        let last_exec_status = |h: &HashValue| -> Option<ExecutionStatus> {
+            let trace = store.get_trace(h).unwrap();
+            trace.stages.iter().rev().find_map(|s| match &s.metadata {
+                Some(StageMetadata::Execution(st)) => Some(*st),
+                _ => None,
+            })
+        };
+        assert_eq!(last_exec_status(&keep_hash), Some(ExecutionStatus::Keep));
+        assert_eq!(last_exec_status(&retry_hash), Some(ExecutionStatus::Retry));
+        assert_eq!(
+            last_exec_status(&discard_hash),
+            Some(ExecutionStatus::Discard)
+        );
+        assert_eq!(
+            last_exec_status(&filtered_hash),
+            Some(ExecutionStatus::Filtered),
+            "txn present in block but absent from keep/retry/discard sets must \
+             be tagged Filtered, not silently Keep"
+        );
     }
 
     #[test]

--- a/crates/aptos-transaction-tracing/src/types.rs
+++ b/crates/aptos-transaction-tracing/src/types.rs
@@ -41,11 +41,17 @@ pub enum BatchInclusionType {
 }
 
 /// Execution outcome for a transaction.
+///
+/// `Filtered` covers txns that were dropped before reaching BlockSTM (e.g.
+/// the prepare-block deduper removed a hash already committed in an earlier
+/// block, signature verification failed, etc.). Such a txn appears in the
+/// proposed block but in none of `to_commit` / `to_retry` / `to_discard`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, strum_macros::AsRefStr)]
 pub enum ExecutionStatus {
     Keep,
     Retry,
     Discard,
+    Filtered,
 }
 
 /// A single batch creation event (one per pull round that produced batches)

--- a/execution/executor/src/block_executor/mod.rs
+++ b/execution/executor/src/block_executor/mod.rs
@@ -269,10 +269,21 @@ where
                 )?
             };
 
-        // Record Executed(Keep/Retry/Discard) for traced txns in this block.
+        // Record Executed(Keep/Retry/Discard/Filtered) for traced txns in this
+        // block. Pass all three output sets so the tracer can distinguish
+        // pre-execution-filtered txns (deduped by hash before BlockSTM, e.g.
+        // because the same hash already committed in an earlier block) from
+        // VM-discarded ones. Without `keep_hashes`, the tracer would fall
+        // through to `Keep` for filtered txns and mislabel them.
         {
             let store = aptos_transaction_tracing::store::TransactionTraceStore::global();
             if store.is_enabled() {
+                let keep_hashes: Vec<HashValue> = execution_output
+                    .to_commit
+                    .transactions
+                    .iter()
+                    .map(|t| t.committed_hash())
+                    .collect();
                 let retry_hashes: Vec<HashValue> = execution_output
                     .to_retry
                     .transactions
@@ -285,7 +296,12 @@ where
                     .iter()
                     .map(|t| t.committed_hash())
                     .collect();
-                store.record_execution_result(&block_id, &retry_hashes, &discard_hashes);
+                store.record_execution_result(
+                    &block_id,
+                    &keep_hashes,
+                    &retry_hashes,
+                    &discard_hashes,
+                );
             }
         }
 


### PR DESCRIPTION
## Summary

The tracer's `record_execution_result` (in `aptos-transaction-tracing`) takes `retry_hashes` and `discard_hashes` from `execution_output` and assumes any traced txn proposed in the block but absent from both is implicitly `Keep`. That ignores a fourth case: **txns that were dropped before reaching BlockSTM** — most commonly when the prepare-block deduper sees the hash was already committed in an earlier block. Those txns are in none of `to_commit` / `to_retry` / `to_discard`, so the existing fall-through silently mislabels them as `Keep`.

This shows up in production as duplicate-inclusion traces where the same hash appears to be `Executed(Keep)` twice — once in the real commit block, then again in a later block that actually had the duplicate deduped before VM execution.

## Fix

- Add `ExecutionStatus::Filtered` variant.
- Pass `keep_hashes` from `execution_output.to_commit` explicitly.
- Dispatch on all four sets in `record_execution_result`; a traced hash in the block's traced set but in none of (keep/retry/discard) is recorded as `Filtered`.
- Outcome map adds `Some(Filtered) => "filtered"` for symmetry.

## Real example this resolves

```
TxnTrace hash=0xca7b2c4d... attempts=1 outcome=committed
  ...
  Committed=1194ms                   ← real commit (block r=74629)
  QsBatchPull=1216ms                 ← QS re-pulls during the 1s mempool-commit-notification gap
  ...
  BlockReceived(r=74634)=1921ms
  Executed(Keep)=2153ms              ← BUG: deduper actually filtered, never executed
  Committed=2190ms
  MempoolCommit=2192ms
```

After this PR the second pass renders `Executed(Filtered)`, and Humio queries on duplicate inclusion can distinguish the real commit from the deduper drop. The underlying mempool-commit-notification race (1000ms gap) is the next thing to look at; that's a separate change.

## Test plan
- [x] `cargo test -p aptos-transaction-tracing --lib` — 14/14 passing, including new `test_record_execution_result_dispatches_all_four_statuses`
- [x] `cargo check -p aptos-executor` — call-site updated and compiles
- [x] `./scripts/rust_lint.sh --check -p aptos-transaction-tracing -p aptos-executor` — clean
- [ ] Verify on mainnet-euwe4-0 after deploy: known duplicate-inclusion traces now show `Executed(Filtered)` on the second pass instead of `Executed(Keep)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only changes on the executor hot path (extra hash collection and set lookup); no consensus or execution semantics.
> 
> **Overview**
> Transaction tracing no longer treats every proposed-but-unlisted txn as **`Executed(Keep)`**. It adds **`ExecutionStatus::Filtered`** for hashes in the block trace that appear in none of **`to_commit`**, **`to_retry`**, or **`to_discard`** (e.g. prepare-block dedup before BlockSTM).
> 
> **`record_execution_result`** now takes **`keep_hashes`** and classifies each traced hash explicitly; the executor passes commit hashes from **`execution_output`**. Incomplete traces can surface outcome **`filtered`** in logs instead of **`unknown`**.
> 
> A unit test covers all four execution statuses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed5f98012234ddcebb1a3134c2a19d6528a43130. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->