### PR TITLE
[Consensus Observer] Bound number of batch proofs per payload

### DIFF
--- a/config/src/config/consensus_config.rs
+++ b/config/src/config/consensus_config.rs
@@ -17,7 +17,7 @@ use serde_yaml::Value;
 use std::path::PathBuf;
 
 // NOTE: when changing, make sure to update QuorumStoreBackPressureConfig::backlog_txn_limit_count as well.
-const MAX_SENDING_BLOCK_TXNS_AFTER_FILTERING: u64 = 1800;
+pub const MAX_SENDING_BLOCK_TXNS_AFTER_FILTERING: u64 = 1800;
 const MAX_SENDING_OPT_BLOCK_TXNS_AFTER_FILTERING: u64 = 1300;
 const MAX_SENDING_BLOCK_TXNS: u64 = 5000;
 pub(crate) static MAX_RECEIVING_BLOCK_TXNS: Lazy<u64> =

--- a/config/src/config/consensus_observer_config.rs
+++ b/config/src/config/consensus_observer_config.rs
@@ -3,6 +3,7 @@
 
 use crate::config::{
     config_optimizer::ConfigOptimizer, node_config_loader::NodeType, Error, NodeConfig,
+    MAX_SENDING_BLOCK_TXNS_AFTER_FILTERING,
 };
 use aptos_types::chain_id::ChainId;
 use serde::{Deserialize, Serialize};
@@ -59,6 +60,9 @@ pub struct ConsensusObserverConfig {
     /// Duration (in milliseconds) of acceptable sync lag before entering fallback mode
     pub observer_fallback_sync_lag_threshold_ms: u64,
 
+    /// Maximum number of proof-of-store batches allowed in a single block payload message
+    pub max_num_payload_proofs: u64,
+
     /// Whether to send V2 ordered block messages (with secret_shared_key).
     /// Set to true only after all nodes in the fleet have been upgraded to
     /// understand V2 messages.
@@ -85,6 +89,7 @@ impl Default for ConsensusObserverConfig {
             observer_fallback_startup_period_ms: 60_000, // 60 seconds
             observer_fallback_progress_threshold_ms: 10_000, // 10 seconds
             observer_fallback_sync_lag_threshold_ms: 15_000, // 15 seconds
+            max_num_payload_proofs: MAX_SENDING_BLOCK_TXNS_AFTER_FILTERING,
             enable_v2_message_sending: true,
         }
     }

--- a/consensus/consensus-types/src/common.rs
+++ b/consensus/consensus-types/src/common.rs
@@ -192,6 +192,10 @@ pub fn verify_batch_info_limits<T: TBatchInfo>(
     max_batch_bytes: u64,
 ) -> anyhow::Result<()> {
     ensure!(
+        batch.num_txns() >= 1,
+        "Batch must contain at least one transaction, got 0",
+    );
+    ensure!(
         batch.num_txns() <= max_batch_txns,
         "Batch txn count {} exceeds limit {}",
         batch.num_txns(),
@@ -716,6 +720,13 @@ mod tests {
         let author = PeerId::random();
         let batch = make_batch_info(author, 50, 500_000);
         assert!(verify_batch_info_limits(&batch, MAX_BATCH_TXNS, MAX_BATCH_BYTES).is_ok());
+    }
+
+    #[test]
+    fn test_verify_batch_info_limits_rejects_empty_batch() {
+        let author = PeerId::random();
+        let batch = make_batch_info(author, 0, 0);
+        assert!(verify_batch_info_limits(&batch, MAX_BATCH_TXNS, MAX_BATCH_BYTES).is_err());
     }
 
     #[test]

--- a/consensus/src/consensus_observer/network/observer_message.rs
+++ b/consensus/src/consensus_observer/network/observer_message.rs
@@ -1065,7 +1065,7 @@ impl BlockPayload {
     }
 
     /// Verifies the block payload digests and returns an error if the data is invalid
-    pub fn verify_payload_digests(&self) -> Result<(), Error> {
+    pub fn verify_payload_digests(&self, max_num_payload_proofs: u64) -> Result<(), Error> {
         // Get the block info and transactions
         let block_info = self.block.clone();
         let transactions = self.transaction_payload.transactions();
@@ -1100,6 +1100,24 @@ impl BlockPayload {
         let num_transactions = transactions.len();
         let num_payload_proofs = proof_batch_infos.len();
         let num_opt_and_inline_batches = inline_batch_infos.len();
+
+        // Verify the number of payload proofs does not exceed the maximum
+        if num_payload_proofs as u64 > max_num_payload_proofs {
+            return Err(Error::InvalidMessageError(format!(
+                "Number of payload proofs ({}) exceeds the maximum allowed ({})",
+                num_payload_proofs, max_num_payload_proofs
+            )));
+        }
+
+        // Verify that all proof batches and inline batches contain at least one transaction
+        for batch_info in proof_batch_infos.iter().chain(inline_batch_infos.iter()) {
+            if batch_info.num_txns() == 0 {
+                return Err(Error::InvalidMessageError(format!(
+                    "Payload batch contains zero transactions: {:?}",
+                    batch_info
+                )));
+            }
+        }
 
         // Gather the transactions for each payload batch
         let mut batches_and_transactions: Vec<(BatchInfo, Vec<SignedTransaction>)> = vec![];
@@ -1671,6 +1689,7 @@ mod test {
             .collect();
 
         // Create multiple batch proofs with random digests
+        let max_num_payload_proofs = 10_000;
         let num_batches = num_signed_transactions - 1;
         let mut proofs = vec![];
         for _ in 0..num_batches {
@@ -1692,7 +1711,9 @@ mod test {
             create_block_payload(None, &signed_transactions, &proofs, &inline_batches);
 
         // Verify the block hybrid payload digests and ensure it fails (the batch digests don't match)
-        let error = block_payload.verify_payload_digests().unwrap_err();
+        let error = block_payload
+            .verify_payload_digests(max_num_payload_proofs)
+            .unwrap_err();
         assert_matches!(error, Error::InvalidMessageError(_));
 
         // Create a block optqs payload (with the transactions, proofs and inline batches)
@@ -1704,7 +1725,9 @@ mod test {
         );
 
         // Verify the block optqs payload digests and ensure it fails (the batch digests don't match)
-        let error = block_payload.verify_payload_digests().unwrap_err();
+        let error = block_payload
+            .verify_payload_digests(max_num_payload_proofs)
+            .unwrap_err();
         assert_matches!(error, Error::InvalidMessageError(_));
 
         // Create multiple batch proofs with the correct digests
@@ -1721,7 +1744,9 @@ mod test {
             create_block_payload(None, &signed_transactions, &proofs, &inline_batches);
 
         // Verify the block payload digests and ensure it fails (the inline batch digests don't match)
-        let error = block_payload.verify_payload_digests().unwrap_err();
+        let error = block_payload
+            .verify_payload_digests(max_num_payload_proofs)
+            .unwrap_err();
         assert_matches!(error, Error::InvalidMessageError(_));
 
         // Create a block optqs payload (with the transactions, correct proofs and optqs and inline batches)
@@ -1733,7 +1758,9 @@ mod test {
         );
 
         // Verify the block optqs payload digests and ensure it fails (the inline batch digests don't match)
-        let error = block_payload.verify_payload_digests().unwrap_err();
+        let error = block_payload
+            .verify_payload_digests(max_num_payload_proofs)
+            .unwrap_err();
         assert_matches!(error, Error::InvalidMessageError(_));
 
         // Create a single inline batch with the correct digest
@@ -1757,7 +1784,9 @@ mod test {
             create_block_payload(None, &signed_transactions, &proofs, &inline_batches);
 
         // Verify the block payload digests and ensure it passes
-        block_payload.verify_payload_digests().unwrap();
+        block_payload
+            .verify_payload_digests(max_num_payload_proofs)
+            .unwrap();
 
         // Create a block payload (with the transactions, correct proofs and correct inline batches)
         let block_payload = create_block_optqs_payload(
@@ -1768,7 +1797,9 @@ mod test {
         );
 
         // Verify the block payload digests and ensure it passes
-        block_payload.verify_payload_digests().unwrap();
+        block_payload
+            .verify_payload_digests(max_num_payload_proofs)
+            .unwrap();
 
         // Create a block payload (with too many transactions)
         signed_transactions.append(&mut create_signed_transactions(1));
@@ -1776,7 +1807,9 @@ mod test {
             create_block_payload(None, &signed_transactions, &proofs, &inline_batches);
 
         // Verify the block payload digests and ensure it fails (there are too many transactions)
-        let error = block_payload.verify_payload_digests().unwrap_err();
+        let error = block_payload
+            .verify_payload_digests(max_num_payload_proofs)
+            .unwrap_err();
         assert_matches!(error, Error::InvalidMessageError(_));
 
         // Create a block optqs payload (with too many transactions)
@@ -1793,7 +1826,9 @@ mod test {
         );
 
         // Verify the block payload digests and ensure it fails (there are too many transactions)
-        let error = block_payload.verify_payload_digests().unwrap_err();
+        let error = block_payload
+            .verify_payload_digests(max_num_payload_proofs)
+            .unwrap_err();
         assert_matches!(error, Error::InvalidMessageError(_));
 
         // Create a block payload (with too few transactions)
@@ -1804,7 +1839,9 @@ mod test {
             create_block_payload(None, &signed_transactions, &proofs, &inline_batches);
 
         // Verify the block payload digests and ensure it fails (there are too few transactions)
-        let error = block_payload.verify_payload_digests().unwrap_err();
+        let error = block_payload
+            .verify_payload_digests(max_num_payload_proofs)
+            .unwrap_err();
         assert_matches!(error, Error::InvalidMessageError(_));
 
         // Create a block optqs payload (with too few transactions)
@@ -1821,7 +1858,9 @@ mod test {
         );
 
         // Verify the block payload digests and ensure it fails (there are too few transactions)
-        let error = block_payload.verify_payload_digests().unwrap_err();
+        let error = block_payload
+            .verify_payload_digests(max_num_payload_proofs)
+            .unwrap_err();
         assert_matches!(error, Error::InvalidMessageError(_));
     }
 
@@ -1844,6 +1883,7 @@ mod test {
         let signed_transactions = create_signed_transactions(num_signed_transactions);
 
         // Create multiple batch proofs (where some batches are expired)
+        let max_num_payload_proofs = 10_000;
         let (proofs, non_expired_transactions) =
             create_mixed_expiration_proofs(block_timestamp, &signed_transactions);
 
@@ -1856,7 +1896,7 @@ mod test {
         );
 
         // Verify the block payload digests and ensure it passes
-        assert_ok!(block_payload.verify_payload_digests());
+        assert_ok!(block_payload.verify_payload_digests(max_num_payload_proofs));
 
         // Create multiple inline transactions
         let num_inline_transactions = 25;
@@ -1879,7 +1919,9 @@ mod test {
         );
 
         // Verify the block payload digests and ensure it fails (expired inline batches are still checked)
-        let error = block_payload.verify_payload_digests().unwrap_err();
+        let error = block_payload
+            .verify_payload_digests(max_num_payload_proofs)
+            .unwrap_err();
         assert_matches!(error, Error::InvalidMessageError(_));
 
         // Create a block payload (with all inline transactions, no proofs and inline batches)
@@ -1891,7 +1933,7 @@ mod test {
         );
 
         // Verify the block payload digests and ensure it now passes
-        assert_ok!(block_payload.verify_payload_digests());
+        assert_ok!(block_payload.verify_payload_digests(max_num_payload_proofs));
 
         // Gather all transactions (from both QS and inline batches)
         let all_transactions: Vec<_> = non_expired_transactions
@@ -1909,7 +1951,52 @@ mod test {
         );
 
         // Verify the block payload digests and ensure it passes
-        assert_ok!(block_payload.verify_payload_digests());
+        assert_ok!(block_payload.verify_payload_digests(max_num_payload_proofs));
+    }
+
+    #[test]
+    fn test_verify_payload_digests_proof_count_limit() {
+        // Create transactions and proofs
+        let num_signed_transactions = 5;
+        let signed_transactions = create_signed_transactions(num_signed_transactions);
+
+        let mut proofs = vec![];
+        for transaction in &signed_transactions {
+            let batch_payload = BatchPayload::new(PeerId::ZERO, vec![transaction.clone()]);
+            let batch_info = create_batch_info_with_digest(batch_payload.hash(), 1, 1000);
+            let proof = ProofOfStore::new(batch_info, AggregateSignature::empty());
+            proofs.push(proof);
+        }
+
+        let block_payload = create_block_payload(None, &signed_transactions, &proofs, &[]);
+
+        // Ensure verification passes when the limit is at least the number of proofs
+        assert_ok!(block_payload.verify_payload_digests(num_signed_transactions as u64));
+
+        // Ensure verification fails when the limit is below the number of proofs
+        let error = block_payload
+            .verify_payload_digests(num_signed_transactions as u64 - 1)
+            .unwrap_err();
+        assert_matches!(error, Error::InvalidMessageError(_));
+    }
+
+    #[test]
+    fn test_verify_payload_digests_empty_batch_rejected() {
+        // Create a single transaction and a proof whose BatchInfo claims 0 txns
+        let signed_transactions = create_signed_transactions(1);
+        let batch_payload = BatchPayload::new(PeerId::ZERO, signed_transactions.clone());
+        let zero_txn_batch_info = create_batch_info_with_digest(batch_payload.hash(), 0, 1000);
+        let proof = ProofOfStore::new(zero_txn_batch_info, AggregateSignature::empty());
+
+        // Create a block payload with the transaction and the proof
+        let max_num_payload_proofs = 10;
+        let block_payload = create_block_payload(None, &signed_transactions, &[proof], &[]);
+
+        // Ensure verification fails because the proof batch declares zero transactions
+        let error = block_payload
+            .verify_payload_digests(max_num_payload_proofs)
+            .unwrap_err();
+        assert_matches!(error, Error::InvalidMessageError(_));
     }
 
     #[test]

--- a/consensus/src/consensus_observer/observer/consensus_observer.rs
+++ b/consensus/src/consensus_observer/observer/consensus_observer.rs
@@ -68,6 +68,9 @@ const LOG_MESSAGES_AT_INFO_LEVEL: bool = false;
 
 /// The consensus observer receives consensus updates and propagates them to the execution pipeline
 pub struct ConsensusObserver {
+    // The consensus observer config
+    consensus_observer_config: ConsensusObserverConfig,
+
     // The execution client to the buffer manager
     execution_client: Arc<dyn TExecutionClient>,
 
@@ -143,6 +146,7 @@ impl ConsensusObserver {
 
         // Create the consensus observer
         Self {
+            consensus_observer_config,
             execution_client,
             observer_block_data,
             observer_epoch_state,
@@ -394,7 +398,9 @@ impl ConsensusObserver {
         update_metrics_for_block_payload_message(peer_network_id, &block_payload);
 
         // Verify the block payload digests
-        if let Err(error) = block_payload.verify_payload_digests() {
+        if let Err(error) = block_payload
+            .verify_payload_digests(self.consensus_observer_config.max_num_payload_proofs)
+        {
             // Log the error and update the invalid message counter
             error!(
                 LogSchema::new(LogEntry::ConsensusObserver).message(&format!(

--- a/consensus/src/quorum_store/tests/types_test.rs
+++ b/consensus/src/quorum_store/tests/types_test.rs
@@ -40,3 +40,10 @@ fn test_batch() {
 
     assert_eq!(batch.into_transactions(), signed_txns);
 }
+
+#[test]
+fn test_batch_verify_rejects_empty() {
+    let source = AccountAddress::random();
+    let batch = Batch::new(BatchId::new_for_test(1), vec![], 0, 1, source, 0);
+    assert_err!(batch.verify());
+}

--- a/consensus/src/quorum_store/types.rs
+++ b/consensus/src/quorum_store/types.rs
@@ -297,6 +297,10 @@ impl<T: TBatchInfo> Batch<T> {
             "Payload hash doesn't match the digest"
         );
         ensure!(
+            self.payload.num_txns() >= 1,
+            "Batch must contain at least one transaction, got 0",
+        );
+        ensure!(
             self.payload.num_txns() as u64 == self.num_txns(),
             "Payload num txns doesn't match batch info"
         );


### PR DESCRIPTION
## Description
This PR bounds the number of batch proofs per payload.

## Testing Plan
New and existing test infrastructure.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes consensus-observer acceptance of block payloads and shared batch validation; misconfiguration could drop valid payloads, but defaults align with existing block txn limits.
> 
> **Overview**
> Adds a configurable cap on how many **proof-of-store** batches may appear in a single consensus-observer **block payload**, and tightens batch sanity checks so empty batches are rejected end-to-end.
> 
> **Consensus observer** gains `max_num_payload_proofs` in `ConsensusObserverConfig` (default **1800**, tied to the existing `MAX_SENDING_BLOCK_TXNS_AFTER_FILTERING` constant, which is now **public** for reuse). `BlockPayload::verify_payload_digests` takes this limit and fails oversized proof lists before digest reconstruction; it also rejects any proof or inline/opt batch whose `BatchInfo` declares **zero** transactions. The observer passes the configured limit when handling incoming block payloads.
> 
> **Quorum store / payload verification** now require at least one transaction per batch in `verify_batch_info_limits` and in `Batch::verify`, with matching unit tests.
> 
> Existing digest-verification tests were updated for the new parameter; new tests cover the proof-count limit and zero-txn batch rejection on the observer path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7baabed9765acb3db4d83b17ace59ab836be095d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->