### PR TITLE
[mono-move] Implement integer cast micro-op

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12857,6 +12857,8 @@ dependencies = [
  "mono-move-gas",
  "mono-move-loader",
  "move-core-types",
+ "num-bigint 0.3.3",
+ "paste",
  "proptest",
  "rand 0.7.3",
  "thiserror 1.0.69",

--- a/third_party/move/mono-move/core/src/instruction/gas.rs
+++ b/third_party/move/mono-move/core/src/instruction/gas.rs
@@ -70,6 +70,7 @@ impl HasCfgInfo for MicroOp {
             | MicroOp::IntShl(_)
             | MicroOp::IntShr(_)
             | MicroOp::IntNegate(_)
+            | MicroOp::IntCast(_)
             | MicroOp::Return
             | MicroOp::Abort { .. }
             | MicroOp::AbortMsg { .. }
@@ -193,6 +194,7 @@ impl RemapTargets for MicroOp {
             | MicroOp::IntShl(_)
             | MicroOp::IntShr(_)
             | MicroOp::IntNegate(_)
+            | MicroOp::IntCast(_)
             | MicroOp::Return
             | MicroOp::Abort { .. }
             | MicroOp::AbortMsg { .. }
@@ -283,7 +285,8 @@ impl GasSchedule<MicroOp> for MicroOpGasSchedule {
             | MicroOp::IntBitXor(_)
             | MicroOp::IntShl(_)
             | MicroOp::IntShr(_)
-            | MicroOp::IntNegate(_) => 5,
+            | MicroOp::IntNegate(_)
+            | MicroOp::IntCast(_) => 5,
 
             // --- Control flow ---
             MicroOp::CallIndirect { .. } | MicroOp::CallDirect { .. } => 10,

--- a/third_party/move/mono-move/core/src/instruction/mod.rs
+++ b/third_party/move/mono-move/core/src/instruction/mod.rs
@@ -126,7 +126,9 @@ use std::fmt;
 mod gas;
 mod unspecialized;
 pub use gas::MicroOpGasSchedule;
-pub use unspecialized::{IntBinaryOp, IntNegateOp, IntOperand, IntShiftOp, IntTy, ShiftOperand};
+pub use unspecialized::{
+    IntBinaryOp, IntCastOp, IntNegateOp, IntOperand, IntShiftOp, IntTy, ShiftOperand,
+};
 
 /// A typed wrapper around a `u32` frame-pointer-relative byte offset.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -484,6 +486,7 @@ pub enum MicroOp {
     IntShl(IntShiftOp),
     IntShr(IntShiftOp),
     IntNegate(IntNegateOp),
+    IntCast(IntCastOp),
 
     //======================================================================
     // Control flow
@@ -1085,6 +1088,11 @@ impl fmt::Display for MicroOp {
             MicroOp::IntNegate(op) => {
                 write!(f, "IntNegate.{} [{}] <- -[{}]", op.ty, op.dst.0, op.src.0)
             },
+            MicroOp::IntCast(op) => write!(
+                f,
+                "IntCast.{}->{} [{}] <- [{}]",
+                op.from, op.to, op.dst.0, op.src.0
+            ),
             MicroOp::CallIndirect {
                 module_id,
                 func_name,
@@ -1596,6 +1604,7 @@ impl MicroOp {
             | MicroOp::IntShl(_)
             | MicroOp::IntShr(_)
             | MicroOp::IntNegate(_)
+            | MicroOp::IntCast(_)
             | MicroOp::Exists { .. }
             | MicroOp::BorrowGlobal { .. }
             | MicroOp::MoveTo { .. } => false,

--- a/third_party/move/mono-move/core/src/instruction/unspecialized.rs
+++ b/third_party/move/mono-move/core/src/instruction/unspecialized.rs
@@ -324,3 +324,16 @@ pub struct IntNegateOp {
     pub dst: FrameOffset,
     pub src: FrameOffset,
 }
+
+/// Universal cast operation, supporting all integer pairs — including
+/// self-casts.
+///
+/// Abort semantics follow one universal rule: the cast succeeds iff the
+/// source value fits in the target type's range, and aborts otherwise.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct IntCastOp {
+    pub from: IntTy,
+    pub to: IntTy,
+    pub dst: FrameOffset,
+    pub src: FrameOffset,
+}

--- a/third_party/move/mono-move/core/src/lib.rs
+++ b/third_party/move/mono-move/core/src/lib.rs
@@ -19,9 +19,9 @@ pub use function::{
     Code, FrameLayoutInfo, Function, FunctionPtr, SafePointEntry, SortedSafePointEntries,
 };
 pub use instruction::{
-    CallClosureOp, ClosureFuncRef, CodeOffset, DescriptorId, FrameOffset, IntBinaryOp, IntNegateOp,
-    IntOperand, IntShiftOp, IntTy, MicroOp, MicroOpGasSchedule, PackClosureOp, ShiftOperand,
-    SizedSlot, CAPTURED_DATA_TAG_MATERIALIZED, CAPTURED_DATA_TAG_OFFSET,
+    CallClosureOp, ClosureFuncRef, CodeOffset, DescriptorId, FrameOffset, IntBinaryOp, IntCastOp,
+    IntNegateOp, IntOperand, IntShiftOp, IntTy, MicroOp, MicroOpGasSchedule, PackClosureOp,
+    ShiftOperand, SizedSlot, CAPTURED_DATA_TAG_MATERIALIZED, CAPTURED_DATA_TAG_OFFSET,
     CAPTURED_DATA_VALUES_OFFSET, CLOSURE_CAPTURED_DATA_PTR_OFFSET, CLOSURE_DATA_SIZE,
     CLOSURE_FUNC_REF_OFFSET, CLOSURE_FUNC_REF_SIZE, CLOSURE_MASK_OFFSET, ENUM_DATA_OFFSET,
     ENUM_TAG_OFFSET, FRAME_METADATA_SIZE, FUNC_REF_PAYLOAD_OFFSET, FUNC_REF_TAG_OFFSET,

--- a/third_party/move/mono-move/runtime/Cargo.toml
+++ b/third_party/move/mono-move/runtime/Cargo.toml
@@ -23,4 +23,6 @@ rand = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
+num-bigint = { workspace = true }
+paste = { workspace = true }
 proptest = { workspace = true }

--- a/third_party/move/mono-move/runtime/src/error.rs
+++ b/third_party/move/mono-move/runtime/src/error.rs
@@ -46,6 +46,9 @@ pub enum RuntimeError {
     #[error("Negate.{ty}: Negate of MIN overflows")]
     NegateMinOverflow { ty: IntTy },
 
+    #[error("Cast.{from}->{to}: value out of range for {to}")]
+    CastOutOfRange { from: IntTy, to: IntTy },
+
     #[error("VecPopBack on empty vector")]
     PopFromEmptyVector,
 
@@ -102,6 +105,7 @@ impl IntoExecutionError for RuntimeError {
             | ArithmeticUnderOverflow { .. }
             | DivisionByZeroOrOverflow { .. }
             | NegateMinOverflow { .. }
+            | CastOutOfRange { .. }
             | PopFromEmptyVector
             | VectorIndexOutOfBounds { .. }
             | InvalidAbortMessage

--- a/third_party/move/mono-move/runtime/src/interpreter.rs
+++ b/third_party/move/mono-move/runtime/src/interpreter.rs
@@ -26,8 +26,8 @@ use crate::{
 };
 use mono_move_core::{
     storage::resource_provider::StorageKey, CallClosureOp, ClosureFuncRef, DescriptorId,
-    DescriptorProvider, FrameOffset, Function, IntBinaryOp, IntNegateOp, IntOperand, IntShiftOp,
-    IntTy, MicroOp, PackClosureOp, ShiftOperand, CAPTURED_DATA_TAG_MATERIALIZED,
+    DescriptorProvider, FrameOffset, Function, IntBinaryOp, IntCastOp, IntNegateOp, IntOperand,
+    IntShiftOp, IntTy, MicroOp, PackClosureOp, ShiftOperand, CAPTURED_DATA_TAG_MATERIALIZED,
     CAPTURED_DATA_TAG_OFFSET, CAPTURED_DATA_VALUES_OFFSET, CLOSURE_CAPTURED_DATA_PTR_OFFSET,
     CLOSURE_DESCRIPTOR_ID, CLOSURE_FUNC_REF_OFFSET, CLOSURE_MASK_OFFSET, FRAME_METADATA_SIZE,
     FUNC_REF_PAYLOAD_OFFSET, FUNC_REF_TAG_OFFSET, FUNC_REF_TAG_RESOLVED, MAX_ALIGN,
@@ -669,6 +669,56 @@ unsafe fn exec_int_negate(fp: *mut u8, op: &IntNegateOp) -> RuntimeResult<()> {
                 });
             },
         }
+        Ok(())
+    }
+}
+
+// Helper macro to dispatch based on an [`IntTy`] tag.
+macro_rules! dispatch_int_ty {
+    ($ty:expr, $action:ident) => {
+        match $ty {
+            IntTy::U8 => $action!(u8),
+            IntTy::U16 => $action!(u16),
+            IntTy::U32 => $action!(u32),
+            IntTy::U64 => $action!(u64),
+            IntTy::U128 => $action!(u128),
+            IntTy::U256 => $action!(U256),
+            IntTy::I8 => $action!(i8),
+            IntTy::I16 => $action!(i16),
+            IntTy::I32 => $action!(i32),
+            IntTy::I64 => $action!(i64),
+            IntTy::I128 => $action!(i128),
+            IntTy::I256 => $action!(I256),
+        }
+    };
+}
+
+/// Executes an `IntCast` operation. Handles all possible pairs of integer types.
+///
+/// # Safety
+///
+/// Same as [`exec_int_add`].
+#[inline(never)]
+unsafe fn exec_int_cast(fp: *mut u8, op: &IntCastOp) -> RuntimeResult<()> {
+    unsafe {
+        macro_rules! cast_from {
+            ($src_ty:ty) => {{
+                let src_val: $src_ty = read_int::<$src_ty>(fp, op.src);
+                macro_rules! cast_to {
+                    ($dst_ty: ty) => {{
+                        let result: $dst_ty = <$dst_ty>::try_from(src_val).map_err(|_| {
+                            RuntimeError::CastOutOfRange {
+                                from: op.from,
+                                to: op.to,
+                            }
+                        })?;
+                        write_int::<$dst_ty>(fp, op.dst, result);
+                    }};
+                }
+                dispatch_int_ty!(op.to, cast_to);
+            }};
+        }
+        dispatch_int_ty!(op.from, cast_from);
         Ok(())
     }
 }
@@ -1334,6 +1384,7 @@ impl<T: ExecutionContext + DescriptorProvider> InterpreterContext<'_, T> {
                 MicroOp::IntShl(ref op) => exec_int_shl(fp, op)?,
                 MicroOp::IntShr(ref op) => exec_int_shr(fp, op)?,
                 MicroOp::IntNegate(ref op) => exec_int_negate(fp, op)?,
+                MicroOp::IntCast(ref op) => exec_int_cast(fp, op)?,
 
                 MicroOp::Exists { addr, ty, dst } => {
                     let address = read_address(fp, addr);

--- a/third_party/move/mono-move/runtime/src/verifier.rs
+++ b/third_party/move/mono-move/runtime/src/verifier.rs
@@ -372,6 +372,13 @@ impl<P: DescriptorProvider + ?Sized> FunctionVerifier<'_, P> {
                 self.check_frame_access(Some(pc), op.dst, size);
             },
 
+            MicroOp::IntCast(op) => {
+                // Note: the Move bytecode permits casting from one integer type to self, effectively a no-op.
+                // Therefore we must NOT ban it here.
+                self.check_frame_access(Some(pc), op.src, op.from.byte_width() as u32);
+                self.check_frame_access(Some(pc), op.dst, op.to.byte_width() as u32);
+            },
+
             MicroOp::Move { dst, src, size } => {
                 self.check_nonzero_size(pc, size);
                 self.check_frame_access(Some(pc), src, size);

--- a/third_party/move/mono-move/runtime/tests/int_ops.rs
+++ b/third_party/move/mono-move/runtime/tests/int_ops.rs
@@ -1,7 +1,8 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-//! Property tests for integer arithmetic / bitwise / shift micro-ops.
+//! Property tests for the integer micro-ops: arithmetic, bitwise, shift,
+//! negate, and cast.
 //!
 //! For every supported (type, kind) combination, the property is the same
 //! shape:
@@ -26,15 +27,23 @@
 //!
 //! Each property fires the proptest default (256 cases). Edge values
 //! (MAX, MIN, 0) get hit through proptest's shrinker + random sampling.
+//!
+//! The cast micro-op ([`MicroOp::IntCast`]) is also tested here, in the
+//! cast section at the end, reusing the same single-op harness.
+//!
+//! TODO: Revisit endianness. Interpreter uses native order for built-in types.
+//! I256/U256 currently do not have other endianness exposed.
 
 use mono_move_alloc::GlobalArenaPtr;
 use mono_move_core::{
-    Code, FrameLayoutInfo, FrameOffset as FO, Function, IntBinaryOp, IntNegateOp, IntOperand,
-    IntShiftOp, IntTy, MicroOp, ShiftOperand, SortedSafePointEntries, FRAME_METADATA_SIZE,
+    Code, FrameLayoutInfo, FrameOffset as FO, Function, IntBinaryOp, IntCastOp, IntNegateOp,
+    IntOperand, IntShiftOp, IntTy, MicroOp, ShiftOperand, SortedSafePointEntries,
+    FRAME_METADATA_SIZE,
 };
 use mono_move_runtime::{InterpreterContext, LocalRuntimeContext};
 use move_core_types::int256::{I256, U256};
-use proptest::prelude::*;
+use num_bigint::{BigInt, Sign};
+use proptest::{prelude::*, strategy::BoxedStrategy};
 
 // ---------------------------------------------------------------------------
 // Test-local op-kind enums
@@ -1127,3 +1136,156 @@ prop_negate!(i32_negate, i32, i32::checked_neg);
 prop_negate!(i64_negate, i64, i64::checked_neg);
 prop_negate!(i128_negate, i128, i128::checked_neg);
 prop_negate!(i256_negate, I256, I256::checked_neg);
+
+// ---------------------------------------------------------------------------
+// IntCast — all 12×12 (from, to) pairs
+// ---------------------------------------------------------------------------
+
+/// Helper trait to define various properties/operations for all integer types.
+/// BigInt is used as a convenience as it can represent integers of any size and be
+/// used for range checks.
+trait CastType: Copy + std::fmt::Debug {
+    const TAG: IntTy;
+    const WIDTH: usize;
+    fn to_slot_bytes(self) -> Vec<u8>;
+    fn to_bigint(self) -> BigInt;
+    fn range_bigint() -> (BigInt, BigInt);
+    fn decode(bytes: &[u8]) -> String;
+    fn strategy() -> BoxedStrategy<Self>;
+}
+
+macro_rules! impl_cast_type_native {
+    ($ty:ty, $tag:expr) => {
+        impl CastType for $ty {
+            const TAG: IntTy = $tag;
+            const WIDTH: usize = std::mem::size_of::<$ty>();
+
+            fn to_slot_bytes(self) -> Vec<u8> {
+                self.to_ne_bytes().to_vec()
+            }
+
+            fn to_bigint(self) -> BigInt {
+                BigInt::from(self)
+            }
+
+            fn range_bigint() -> (BigInt, BigInt) {
+                (BigInt::from(<$ty>::MIN), BigInt::from(<$ty>::MAX))
+            }
+
+            fn decode(bytes: &[u8]) -> String {
+                <$ty>::from_ne_bytes(bytes.try_into().unwrap()).to_string()
+            }
+
+            fn strategy() -> BoxedStrategy<Self> {
+                any::<$ty>().boxed()
+            }
+        }
+    };
+}
+
+impl_cast_type_native!(u8, IntTy::U8);
+impl_cast_type_native!(u16, IntTy::U16);
+impl_cast_type_native!(u32, IntTy::U32);
+impl_cast_type_native!(u64, IntTy::U64);
+impl_cast_type_native!(u128, IntTy::U128);
+impl_cast_type_native!(i8, IntTy::I8);
+impl_cast_type_native!(i16, IntTy::I16);
+impl_cast_type_native!(i32, IntTy::I32);
+impl_cast_type_native!(i64, IntTy::I64);
+impl_cast_type_native!(i128, IntTy::I128);
+
+macro_rules! impl_cast_type_wide {
+    ($ty:ty, $tag:expr, $bytes_to_big:expr) => {
+        impl CastType for $ty {
+            const TAG: IntTy = $tag;
+            const WIDTH: usize = 32;
+
+            fn to_slot_bytes(self) -> Vec<u8> {
+                self.to_le_bytes().to_vec()
+            }
+
+            fn to_bigint(self) -> BigInt {
+                $bytes_to_big(&self.to_le_bytes())
+            }
+
+            fn range_bigint() -> (BigInt, BigInt) {
+                (
+                    $bytes_to_big(&<$ty>::MIN.to_le_bytes()),
+                    $bytes_to_big(&<$ty>::MAX.to_le_bytes()),
+                )
+            }
+
+            fn decode(bytes: &[u8]) -> String {
+                <$ty>::from_le_bytes(bytes.try_into().unwrap()).to_string()
+            }
+
+            fn strategy() -> BoxedStrategy<Self> {
+                any::<[u8; 32]>().prop_map(<$ty>::from_le_bytes).boxed()
+            }
+        }
+    };
+}
+
+impl_cast_type_wide!(U256, IntTy::U256, |b: &[u8]| BigInt::from_bytes_le(
+    Sign::Plus,
+    b
+));
+impl_cast_type_wide!(I256, IntTy::I256, |b: &[u8]| {
+    BigInt::from_signed_bytes_le(b)
+});
+
+/// Run the cast micro-op (from `S` to `D`) using the VM runtime.
+fn cast_runtime<S: CastType, D: CastType>(v: S) -> Option<String> {
+    let op = MicroOp::IntCast(IntCastOp {
+        from: S::TAG,
+        to: D::TAG,
+        dst: FO(SLOT_DST),
+        src: FO(SLOT_LHS),
+    });
+    run_wide(op, &v.to_slot_bytes(), &[], D::WIDTH)
+        .ok()
+        .map(|bytes| D::decode(&bytes))
+}
+
+/// Reference impl of a cast (from `S` to `D`).
+fn cast_reference_impl<S: CastType, D: CastType>(v: S) -> Option<String> {
+    let value = v.to_bigint();
+    let (lo, hi) = D::range_bigint();
+    (value >= lo && value <= hi).then(|| value.to_string())
+}
+
+/// Defines one proptest for the (src, dst) cast pair.
+macro_rules! cast_case {
+    ($src:ident, $dst:ident) => {
+        paste::paste! {
+            proptest! {
+                #[test]
+                fn [<cast_from_ $src:lower _to_ $dst:lower>](
+                    v in <$src as CastType>::strategy()
+                ) {
+                    prop_assert_eq!(
+                        cast_runtime::<$src, $dst>(v),
+                        cast_reference_impl::<$src, $dst>(v)
+                    );
+                }
+            }
+        }
+    };
+}
+
+/// Generate a [`cast_case!`] for the full cross product of a type list --
+/// every type cast into every type, including itself.
+macro_rules! cast_matrix {
+    ($($ty:ident),+ $(,)?) => {
+        cast_matrix!(@outer [$($ty),+] [$($ty),+]);
+    };
+    (@outer [$($src:ident),+] $dsts:tt) => {
+        $( cast_matrix!(@inner $src $dsts); )+
+    };
+    (@inner $src:ident [$($dst:ident),+]) => {
+        $( cast_case!($src, $dst); )+
+    };
+}
+
+// Generates all 144 (12 × 12) cast combinations, one test per pair.
+cast_matrix!(u8, u16, u32, u64, u128, U256, i8, i16, i32, i64, i128, I256);

--- a/third_party/move/mono-move/specializer/src/lower/translate.rs
+++ b/third_party/move/mono-move/specializer/src/lower/translate.rs
@@ -15,8 +15,8 @@ use crate::stackless_exec_ir::{
 use anyhow::{bail, Context, Result};
 use mono_move_core::{
     types::{strip_ref, view_type, InternedType, Type},
-    CodeOffset, FrameLayoutInfo, FrameOffset, IntBinaryOp, IntNegateOp, IntOperand, IntShiftOp,
-    IntTy, MicroOp, SafePointEntry, ShiftOperand,
+    CodeOffset, FrameLayoutInfo, FrameOffset, IntBinaryOp, IntCastOp, IntNegateOp, IntOperand,
+    IntShiftOp, IntTy, MicroOp, SafePointEntry, ShiftOperand,
 };
 use move_binary_format::file_format::FieldHandleIndex;
 use move_core_types::account_address::AccountAddress;
@@ -198,6 +198,21 @@ impl<'a> LoweringState<'a> {
     /// when an interned pointer is needed instead.
     fn slot_type(&self, slot: Slot) -> Result<&'static Type> {
         Ok(view_type(self.slot_interned_type(slot)?))
+    }
+
+    /// Emit an `IntCast` to `to` from `src` into `dst`. The source type comes
+    /// from `src`'s slot type and the `to` type is supplied by the caller.
+    fn lower_cast(&mut self, dst: Slot, src: Slot, to: IntTy) -> Result<()> {
+        let from = IntTy::from_type(self.slot_type(src)?)
+            .ok_or_else(|| anyhow::anyhow!("cast source must be an integer type"))?;
+        let src_info = self.slot(src)?;
+        let dst_info = self.def_slot(dst)?;
+        self.emit(MicroOp::IntCast(IntCastOp {
+            from,
+            to,
+            dst: dst_info.offset,
+            src: src_info.offset,
+        }))
     }
 
     /// Size in bytes of `ref_slot`'s pointee.
@@ -625,6 +640,12 @@ impl<'a> LoweringState<'a> {
             },
 
             // --- Unary ops ---
+            Instr::UnaryOp(dst, op, src) if op.cast_target_ty().is_some() => {
+                let to = op
+                    .cast_target_ty()
+                    .expect("guard above ensures this is a cast");
+                self.lower_cast(*dst, *src, to)?;
+            },
             Instr::UnaryOp(dst, UnaryOp::Negate, src) => {
                 let src_ty = self.slot_type(*src)?;
                 let signed_ty = IntTy::from_type(src_ty)

--- a/third_party/move/mono-move/specializer/src/stackless_exec_ir/mod.rs
+++ b/third_party/move/mono-move/specializer/src/stackless_exec_ir/mod.rs
@@ -11,7 +11,7 @@ pub(crate) mod instr_utils;
 
 use mono_move_core::{
     types::{InternedType, InternedTypeList},
-    PreparedModule,
+    IntTy, PreparedModule,
 };
 use move_binary_format::file_format::{
     ConstantPoolIndex, FieldHandleIndex, FieldInstantiationIndex, FunctionHandleIndex,
@@ -80,6 +80,28 @@ pub enum UnaryOp {
     Not,
     Negate,
     FreezeRef,
+}
+
+impl UnaryOp {
+    /// Returns the target [`IntTy`] if the operation is a cast operation,
+    /// otherwise `None`.
+    pub fn cast_target_ty(self) -> Option<IntTy> {
+        Some(match self {
+            UnaryOp::CastU8 => IntTy::U8,
+            UnaryOp::CastU16 => IntTy::U16,
+            UnaryOp::CastU32 => IntTy::U32,
+            UnaryOp::CastU64 => IntTy::U64,
+            UnaryOp::CastU128 => IntTy::U128,
+            UnaryOp::CastU256 => IntTy::U256,
+            UnaryOp::CastI8 => IntTy::I8,
+            UnaryOp::CastI16 => IntTy::I16,
+            UnaryOp::CastI32 => IntTy::I32,
+            UnaryOp::CastI64 => IntTy::I64,
+            UnaryOp::CastI128 => IntTy::I128,
+            UnaryOp::CastI256 => IntTy::I256,
+            UnaryOp::Not | UnaryOp::Negate | UnaryOp::FreezeRef => return None,
+        })
+    }
 }
 
 /// Comparison operations that produce a boolean result.

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/casts/int_cast.move
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/casts/int_cast.move
@@ -1,0 +1,108 @@
+// RUN: publish
+module 0x1::test {
+    // Widening, same sign — always succeeds.
+    fun u64_to_u128(x: u64): u128 { x as u128 }
+    fun i64_to_i256(x: i64): i256 { x as i256 }
+
+    // Narrowing, same sign — aborts when the value doesn't fit.
+    fun u128_to_u64(x: u128): u64 { x as u64 }
+    fun u256_to_u128(x: u256): u128 { x as u128 }
+    fun i128_to_i64(x: i128): i64 { x as i64 }
+
+    // Unsigned -> signed.
+    fun u64_to_i64(x: u64): i64 { x as i64 }      // same width: top half overflows
+    fun u64_to_i128(x: u64): i128 { x as i128 }   // widening: always fits
+    fun u256_to_i256(x: u256): i256 { x as i256 } // same width: top half overflows
+    fun u256_to_i64(x: u256): i64 { x as i64 }    // narrowing
+
+    // Signed -> unsigned — aborts on negative inputs.
+    fun i64_to_u64(x: i64): u64 { x as u64 }
+    fun i64_to_u128(x: i64): u128 { x as u128 }   // widening: negative still aborts
+    fun i256_to_u256(x: i256): u256 { x as u256 }
+}
+
+// In-range casts — both VMs return the same value.
+
+// RUN: execute 0x1::test::u64_to_u128 --args 12345
+// CHECK: results: 12345
+
+// RUN: execute 0x1::test::i64_to_i256 --args -42
+// CHECK: results: -42
+
+// RUN: execute 0x1::test::u128_to_u64 --args 255
+// CHECK: results: 255
+
+// u128::MAX-shaped value that still fits u64 (== u64::MAX).
+// RUN: execute 0x1::test::u128_to_u64 --args 18446744073709551615
+// CHECK: results: 18446744073709551615
+
+// RUN: execute 0x1::test::u256_to_u128 --args 1000000000000000000000
+// CHECK: results: 1000000000000000000000
+
+// RUN: execute 0x1::test::i128_to_i64 --args -1000
+// CHECK: results: -1000
+
+// u64 value below i64::MAX casts cleanly.
+// RUN: execute 0x1::test::u64_to_i64 --args 5
+// CHECK: results: 5
+
+// u64::MAX widens into i128 without loss.
+// RUN: execute 0x1::test::u64_to_i128 --args 18446744073709551615
+// CHECK: results: 18446744073709551615
+
+// RUN: execute 0x1::test::u256_to_i256 --args 100
+// CHECK: results: 100
+
+// Below i64::MAX (9223372036854775807).
+// RUN: execute 0x1::test::u256_to_i64 --args 9000000000000000000
+// CHECK: results: 9000000000000000000
+
+// RUN: execute 0x1::test::i64_to_u64 --args 7
+// CHECK: results: 7
+
+// RUN: execute 0x1::test::i64_to_u128 --args 7
+// CHECK: results: 7
+
+// RUN: execute 0x1::test::i256_to_u256 --args 123456789
+// CHECK: results: 123456789
+
+// Out-of-range casts — both VMs abort.
+
+// 2^64 doesn't fit u64.
+// RUN: execute 0x1::test::u128_to_u64 --args 18446744073709551616
+// CHECK-V1-SUBSTR: ARITHMETIC_ERROR
+// CHECK-V2-SUBSTR: value out of range
+
+// u256 value above u128::MAX.
+// RUN: execute 0x1::test::u256_to_u128 --args 340282366920938463463374607431768211456
+// CHECK-V1-SUBSTR: ARITHMETIC_ERROR
+// CHECK-V2-SUBSTR: value out of range
+
+// i64::MAX + 1 doesn't fit i64.
+// RUN: execute 0x1::test::i128_to_i64 --args 9223372036854775808
+// CHECK-V1-SUBSTR: ARITHMETIC_ERROR
+// CHECK-V2-SUBSTR: value out of range
+
+// u64::MAX > i64::MAX.
+// RUN: execute 0x1::test::u64_to_i64 --args 18446744073709551615
+// CHECK-V1-SUBSTR: ARITHMETIC_ERROR
+// CHECK-V2-SUBSTR: value out of range
+
+// u256::MAX > i256::MAX (top half of the unsigned range).
+// RUN: execute 0x1::test::u256_to_i256 --args 115792089237316195423570985008687907853269984665640564039457584007913129639935
+// CHECK-V1-SUBSTR: ARITHMETIC_ERROR
+// CHECK-V2-SUBSTR: value out of range
+
+// Negative -> unsigned aborts.
+// RUN: execute 0x1::test::i64_to_u64 --args -1
+// CHECK-V1-SUBSTR: ARITHMETIC_ERROR
+// CHECK-V2-SUBSTR: value out of range
+
+// Negative -> wider unsigned still aborts.
+// RUN: execute 0x1::test::i64_to_u128 --args -5
+// CHECK-V1-SUBSTR: ARITHMETIC_ERROR
+// CHECK-V2-SUBSTR: value out of range
+
+// RUN: execute 0x1::test::i256_to_u256 --args -1
+// CHECK-V1-SUBSTR: ARITHMETIC_ERROR
+// CHECK-V2-SUBSTR: value out of range

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/casts/self_cast.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/casts/self_cast.exp
@@ -1,0 +1,11 @@
+=== micro-ops ===
+// module 0x66::test
+
+fun self_cast() {
+  frame_data_size: 16
+  code:
+    0: Charge #9
+    1: IntCast.u64->u64 [8] <- [0]
+    2: Move8 [0] <- [8]
+    3: Return
+}

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/casts/self_cast.masm
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/casts/self_cast.masm
@@ -1,0 +1,20 @@
+// Tests same-type casts (`x as u64` where `x: u64`), which are valid Move
+// bytecode and execute as identity. Written as MASM tests so we don't depend
+// on the compiler not optimizing them out.
+
+// RUN: publish --print(micro-ops)
+module 0x66::test
+
+fun self_cast(a: u64): u64
+    copy_loc a
+    cast_u64
+    ret
+
+// RUN: execute 0x66::test::self_cast --args 42
+// CHECK: results: 42
+
+// RUN: execute 0x66::test::self_cast --args 0
+// CHECK: results: 0
+
+// RUN: execute 0x66::test::self_cast --args 18446744073709551615
+// CHECK: results: 18446744073709551615


### PR DESCRIPTION
## Summary

Implements the family of integer cast micro-ops for the mono-move VM as a single universal `IntCast` micro-op that covers all 12×12 `(from, to)` integer type pairs.

The cast is **value-preserving**: it reproduces the source's mathematical integer value in the target type and aborts iff that value falls outside the target's `[MIN, MAX]` range. This matches the existing Move VM's `Value::cast_*` semantics exactly (widening, narrowing, and signed↔unsigned).

Self-casts (`from == to`) are accepted and run as identity — the bytecode verifier admits them (the operand only has to be an integer) and the production VM executes them, so mono-move must not reject them.

## Changes

- **core**: `IntCastOp` operand + `MicroOp::IntCast`, with `Display`, gas cost, `is_allocating`, and re-exports.
- **runtime**: `exec_int_cast` doing a uniform per-pair `<dst>::try_from(src)` dispatch (native↔native via std, native↔256-bit via the `int256` crate, identity via the blanket impl); a new `CastOutOfRange` error; verifier frame-access checks.
- **specializer**: lowers `UnaryOp::Cast*` to `IntCast`, with the target type resolved by a new `UnaryOp::extract_to_int_ty` helper.

## Testing

- **Property tests** (`runtime/tests/arithmetic_ops.rs`): all 144 `(from, to)` pairs, each checked against an independent `num-bigint` range-check oracle — one generated test per pair.
- **Differential tests**: `int_cast.move` covers every cast category (widen / narrow / signed↔unsigned, both success and out-of-range) for the wide integer types end-to-end against the legacy VM; `self_cast.masm` pins the self-cast identity behavior.

Note: the narrow widths (`u8`..`u32`, `i8`..`i32`) can't yet flow through the `.move` pipeline (the 8-byte slot-align rule), so they're covered by the property tests rather than the differential `.move` tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Cast semantics must match the legacy Move VM across all 12×12 type pairs; incorrect range checks would change abort behavior for production bytecode.
> 
> **Overview**
> Adds a single **`IntCast`** micro-op for all integer cast pairs (including identity self-casts), wired through core IR, gas, display, and exports.
> 
> The **runtime** implements `exec_int_cast` via nested `IntTy` dispatch and `try_from`, maps failures to **`CastOutOfRange`**, and extends the verifier for source/dest frame access. The **specializer** lowers `UnaryOp::Cast*` through `UnaryOp::cast_target_ty` and `lower_cast`.
> 
> **Testing**: 144 proptest pairs in `int_ops.rs` (BigInt oracle), differential `int_cast.move` vs legacy VM, and MASM `self_cast` for same-type casts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3594183690228e18d9fa23c9e91db6749b813840. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->