### PR TITLE
[docker] Verify release tag matches Cargo version

### DIFF
--- a/docker/image-helpers.js
+++ b/docker/image-helpers.js
@@ -103,10 +103,13 @@ export const Environment = {
 
 
 export function getEnvironment() {
-  if (process.env.CI === "true") {
-    return Environment.CI;
-  } else if (import.meta.jest !== undefined) {
+  // jest also runs with CI=true on GitHub Actions, so resolve to TEST first; otherwise
+  // reportError would call core.setFailed and fail the job on tests that intentionally
+  // trigger errors (e.g. the version-mismatch assertion test).
+  if (import.meta.jest !== undefined) {
     return Environment.TEST;
+  } else if (process.env.CI === "true") {
+    return Environment.CI;
   } else {
     return Environment.LOCAL;
   }

--- a/docker/release-images.mjs
+++ b/docker/release-images.mjs
@@ -33,9 +33,11 @@
 
 import {
   assertExecutingInRepoRoot,
+  assertTagMatchesSourceVersion,
   CargoBuildFeatures,
   CargoBuildProfiles,
   installCrane,
+  isReleaseImage,
   lazyImports,
   parseArgsFromFlagOrEnv,
   pnpmInstall,
@@ -82,6 +84,14 @@ async function main() {
   const parsedArgs = parseArgsFromFlagOrEnv(REQUIRED_ARGS, OPTIONAL_ARGS, BOOLEAN_ARGS);
 
   await assertExecutingInRepoRoot();
+
+  // For release tags (aptos-node-vX.Y.Z), fail fast if the tag version doesn't match
+  // aptos-node/Cargo.toml. Non-release prefixes (devnet, nightly, adhoc, ...) are not
+  // version tags, so isReleaseImage() skips them.
+  if (isReleaseImage(parsedArgs.IMAGE_TAG_PREFIX)) {
+    assertTagMatchesSourceVersion(parsedArgs.IMAGE_TAG_PREFIX);
+  }
+
   const crane = await installCrane();
   const craneVersion = await $`${crane} version`;
   console.log(`INFO: crane version: ${craneVersion}`);


### PR DESCRIPTION

`release-images.mjs` no longer verifies that a release tag matches the
source version. `assertTagMatchesSourceVersion` (in
`docker/image-helpers.js`, with unit tests and an `IMAGE_TAGGING.md`
description saying it runs before copying) used to be called from the
release path, but the call was dropped when wait-images was split out
of release-images (#16234). So a release tag pushed without first
bumping `aptos-node/Cargo.toml` would still copy images under a version
that isn't present in the source.

Restore the assertion in the release path, gated by `isReleaseImage` so
only `aptos-node-vX.Y.Z` prefixes are checked and branch / non-release
prefixes (devnet, nightly, adhoc, ...) are skipped. It runs before any
crane work, so a mismatch fails fast.

Also reorder `getEnvironment` to detect the jest environment before CI.
jest runs with `CI=true` on GitHub Actions, so `getEnvironment` resolved
to CI under jest and the version-mismatch test tripped `reportError`'s
CI branch (`core.setFailed`), failing the run even though the test
itself passes. This ordering is long-standing and stayed harmless until
the early-May tooling bumps (notably `@actions/core` 1.x -> 3.x,
#19637), whose `setFailed` sets `process.exitCode` and so reddens the
jest run. The identical code ran `test-copy-images` green through late
April; that job only runs on `release-images.mjs` / `__tests__`
changes, so this PR is just the first run after the bump.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-guard and test-environment ordering only; no runtime node or auth behavior changes beyond failing fast on mismatched release tags.
> 
> **Overview**
> Restores **release tag vs. source version** checks in the docker image release path and fixes **jest/CI environment detection** so unit tests stay green on GitHub Actions.
> 
> `release-images.mjs` again calls `assertTagMatchesSourceVersion` for `aptos-node-vX.Y.Z` prefixes (via `isReleaseImage`) **before** any crane copy work, so a tag that doesn’t match `aptos-node/Cargo.toml` fails fast instead of publishing mislabeled images. Non-release prefixes (`devnet`, `nightly`, `adhoc`, …) are unchanged and skip the check.
> 
> `getEnvironment()` in `image-helpers.js` now treats **jest as `TEST` before `CI=true`**, so tests that intentionally hit `reportError` (e.g. version-mismatch) no longer go through the CI path and `core.setFailed`, which was reddening the job after the `@actions/core` bump even when assertions passed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a84e41241f557a7ff304d49bfa33f1a87a22520. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->