### PR TITLE
[consensus] Don't default Features on read failure

### DIFF
--- a/consensus/src/consensus_observer/observer/epoch_state.rs
+++ b/consensus/src/consensus_observer/observer/epoch_state.rs
@@ -253,17 +253,10 @@ async fn extract_on_chain_configs(
         onchain_chunky_dkg_config.ok(),
     );
 
-    // Extract the Features (or use the default if it's missing)
-    let onchain_features: anyhow::Result<Features> = on_chain_configs.get();
-    if let Err(error) = &onchain_features {
-        error!(
-            LogSchema::new(LogEntry::ConsensusObserver).message(&format!(
-                "Failed to read on-chain features! Error: {:?}",
-                error
-            ))
-        );
-    }
-    let features = onchain_features.unwrap_or_default();
+    // Extract the Features
+    let features: Features = on_chain_configs
+        .get()
+        .expect("Failed to get the features from the on-chain configs!");
 
     // Return the extracted epoch state and on-chain configs
     (

--- a/consensus/src/epoch_manager.rs
+++ b/consensus/src/epoch_manager.rs
@@ -1244,11 +1244,7 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
         self.epoch_state = Some(epoch_state.clone());
 
         let onchain_consensus_config: anyhow::Result<OnChainConsensusConfig> = payload.get();
-        let onchain_features: anyhow::Result<Features> = payload.get();
-        if let Err(error) = &onchain_features {
-            warn!("Failed to read on-chain features {}", error);
-        }
-        let features = onchain_features.unwrap_or_default();
+        let features: Features = payload.get().expect("failed to get Features from payload");
         self.encrypted_enabled = features.is_encrypted_transactions_enabled();
         let onchain_execution_config: anyhow::Result<OnChainExecutionConfig> = payload.get();
         let onchain_randomness_config_seq_num: anyhow::Result<RandomnessConfigSeqNum> =


### PR DESCRIPTION

At every epoch boundary the validator (`epoch_manager`) and the consensus
observer read the on-chain `Features` resource via `OnChainConfigPayload::get`,
which performs a live DB read followed by BCS decoding. Both previously fell
back to `Features::default()` on any error.

That fallback is unsafe here: `features` feeds `BlockExecutorConfigFromOnchain`
(write-set format, `TransactionInfo` version, hot-state root) and
`encrypted_enabled`, so a node that silently substitutes defaults can execute
the epoch with different semantics than the rest of the network and diverge — a
transient or local DB fault is enough to trigger it.

Unlike the randomness / JWK / chunky-DKG configs, which can legitimately be
absent on older chains and so default deliberately, `Features` is written at
genesis and is always present at any post-genesis epoch boundary. An error
therefore always signals a bug, corruption, or local storage fault, where
failing fast (and recovering on restart) is safer than silently diverging. This
matches how `ValidatorSet` is already handled in both paths.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes epoch-boundary failure mode from warn+log+defaults to panic, which is safer for correctness but will crash the process on any Features read/decode fault until restart/recovery.
> 
> **Overview**
> At epoch boundaries, **validator** (`epoch_manager`) and **consensus observer** paths no longer substitute `Features::default()` when `OnChainConfigPayload::get()` fails for `Features`. Both now **panic** via `.expect(...)`, aligned with how `ValidatorSet` is already loaded.
> 
> That removes a silent divergence risk: `Features` drives execution semantics (e.g. write-set format, `TransactionInfo` version, hot-state root) and `encrypted_enabled`, so a transient DB/decode error could previously leave a node executing a different epoch than peers. Other on-chain configs that may be absent on older chains still use deliberate defaults; `Features` is treated as always present post-genesis, so failure means fail-fast rather than continue with wrong flags.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d31429d350a2b050b56f36c44a58eac65067a15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->