### PR TITLE
Rust 1.94

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.93.1"
+channel = "1.94.1"
 
 # Note: we don't specify cargofmt in our toolchain because we rely on
 # the nightly version of cargofmt and verify formatting in CI/CD.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single toolchain version bump with no application code changes; main risk is CI/local build compatibility with Rust 1.94.1.
> 
> **Overview**
> Bumps the pinned Rust toolchain in `rust-toolchain.toml` from **1.93.1** to **1.94.1**. Local builds and CI that use `rust-toolchain-file` (or equivalent) will pick up the new compiler; listed components (`cargo`, `clippy`, `rustc`, etc.) are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 381c800c97bd933210ce889a49f8075abbafddc1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->