### PR TITLE
[storage] Produce hot state snapshot chunks

### DIFF
--- a/storage/aptosdb/src/db/aptosdb_internal.rs
+++ b/storage/aptosdb/src/db/aptosdb_internal.rs
@@ -337,6 +337,40 @@ impl AptosDB {
         }
     }
 
+    pub(super) fn error_if_hot_state_merkle_pruned(
+        &self,
+        data_type: &str,
+        version: Version,
+    ) -> Result<()> {
+        let state_pruner = &self.state_store.state_db.state_pruner;
+        // When hot state is disabled the pruners are absent and nothing is pruned here; the read
+        // path returns a clear `HotStateError` instead.
+        let (Some(merkle_pruner), Some(epoch_snapshot_pruner)) = (
+            state_pruner.hot_state_merkle_pruner.as_ref(),
+            state_pruner.hot_epoch_snapshot_pruner.as_ref(),
+        ) else {
+            return Ok(());
+        };
+
+        let min_readable_version = merkle_pruner.get_min_readable_version();
+        if version >= min_readable_version {
+            return Ok(());
+        }
+
+        let min_readable_epoch_snapshot_version = epoch_snapshot_pruner.get_min_readable_version();
+        if version >= min_readable_epoch_snapshot_version {
+            self.ledger_db.metadata_db().ensure_epoch_ending(version)
+        } else {
+            bail!(
+                "{} at version {} is pruned. snapshots are available at >= {}, epoch snapshots are available at >= {}",
+                data_type,
+                version,
+                min_readable_version,
+                min_readable_epoch_snapshot_version,
+            )
+        }
+    }
+
     pub(super) fn error_if_state_kv_pruned(&self, data_type: &str, version: Version) -> Result<()> {
         let min_readable_version = self
             .state_store

--- a/storage/aptosdb/src/db/aptosdb_reader.rs
+++ b/storage/aptosdb/src/db/aptosdb_reader.rs
@@ -35,7 +35,7 @@ use aptos_types::{
         hot_state::HotStateValue,
         state_key::StateKey,
         state_storage_usage::StateStorageUsage,
-        state_value::{StateValue, StateValueChunkWithProof},
+        state_value::{HotStateValueChunkWithProof, StateValue, StateValueChunkWithProof},
     },
     transaction::{
         IndexedTransactionSummary, PersistedAuxiliaryInfo, Transaction, TransactionAuxiliaryData,
@@ -783,6 +783,19 @@ impl DbReader for AptosDB {
             self.error_if_state_merkle_pruned("State merkle", version)?;
             self.state_store
                 .get_value_chunk_with_proof(version, first_index, chunk_size)
+        })
+    }
+
+    fn get_hot_state_value_chunk_with_proof(
+        &self,
+        version: Version,
+        first_index: usize,
+        chunk_size: usize,
+    ) -> Result<HotStateValueChunkWithProof> {
+        gauged_api("get_hot_state_value_chunk_with_proof", || {
+            self.error_if_hot_state_merkle_pruned("Hot state merkle", version)?;
+            self.state_store
+                .get_hot_value_chunk_with_proof(version, first_index, chunk_size)
         })
     }
 

--- a/storage/aptosdb/src/db/fake_aptosdb.rs
+++ b/storage/aptosdb/src/db/fake_aptosdb.rs
@@ -44,7 +44,7 @@ use aptos_types::{
         combine_sharded_state_updates,
         state_key::{prefix::StateKeyPrefix, StateKey},
         state_storage_usage::StateStorageUsage,
-        state_value::{StateValue, StateValueChunkWithProof},
+        state_value::{HotStateValueChunkWithProof, StateValue, StateValueChunkWithProof},
         table,
     },
     transaction::{
@@ -885,6 +885,16 @@ impl DbReader for FakeAptosDB {
     ) -> Result<StateValueChunkWithProof> {
         self.inner
             .get_state_value_chunk_with_proof(version, start_idx, chunk_size)
+    }
+
+    fn get_hot_state_value_chunk_with_proof(
+        &self,
+        version: Version,
+        start_idx: usize,
+        chunk_size: usize,
+    ) -> Result<HotStateValueChunkWithProof> {
+        self.inner
+            .get_hot_state_value_chunk_with_proof(version, start_idx, chunk_size)
     }
 
     fn is_state_merkle_pruner_enabled(&self) -> Result<bool> {

--- a/storage/aptosdb/src/state_store/mod.rs
+++ b/storage/aptosdb/src/state_store/mod.rs
@@ -71,7 +71,10 @@ use aptos_types::{
         state_key::StateKey,
         state_slot::{StateSlot, StateSlotKind},
         state_storage_usage::StateStorageUsage,
-        state_value::{StaleStateValueByKeyHashIndex, StateValue, StateValueChunkWithProof},
+        state_value::{
+            HotStateValueChunkWithProof, StaleStateValueByKeyHashIndex, StateValue,
+            StateValueChunkWithProof,
+        },
         NUM_STATE_SHARDS,
     },
     transaction::Version,
@@ -1482,6 +1485,81 @@ impl StateStore {
         let root_hash = self.get_root_hash(version)?;
 
         Ok(StateValueChunkWithProof {
+            first_index: first_index as u64,
+            last_index,
+            first_key,
+            last_key,
+            raw_values: state_key_values,
+            proof,
+            root_hash,
+        })
+    }
+
+    /// Hot state counterpart of [`Self::get_value_chunk_with_proof`]. Reads from the hot state
+    /// Merkle tree and KV; the proof and root hash are over the hot state tree.
+    pub fn get_hot_value_chunk_with_proof(
+        self: &Arc<Self>,
+        version: Version,
+        first_index: usize,
+        chunk_size: usize,
+    ) -> Result<HotStateValueChunkWithProof> {
+        let state_key_values: Vec<(StateKey, HotStateValue)> = self
+            .get_hot_value_chunk_iter(version, first_index, chunk_size)?
+            .collect::<Result<Vec<_>>>()?;
+        self.get_hot_value_chunk_proof(version, first_index, state_key_values)
+    }
+
+    pub fn get_hot_value_chunk_iter(
+        self: &Arc<Self>,
+        version: Version,
+        first_index: usize,
+        chunk_size: usize,
+    ) -> Result<impl Iterator<Item = Result<(StateKey, HotStateValue)>> + Send + Sync + use<>> {
+        let store = Arc::clone(self);
+        let hot_state_merkle_db = self
+            .hot_state_merkle_db
+            .as_ref()
+            .ok_or(AptosDbError::HotStateError)?;
+        let value_chunk_iter = JellyfishMerkleIterator::new_by_index(
+            Arc::clone(hot_state_merkle_db),
+            version,
+            first_index,
+        )?
+        .take(chunk_size)
+        .map(move |res| {
+            res.and_then(|(key_hash, (key, version))| {
+                Ok((
+                    key.clone(),
+                    store.expect_hot_state_value_by_version(key_hash, version)?,
+                ))
+            })
+        });
+
+        Ok(value_chunk_iter)
+    }
+
+    pub fn get_hot_value_chunk_proof(
+        self: &Arc<Self>,
+        version: Version,
+        first_index: usize,
+        state_key_values: Vec<(StateKey, HotStateValue)>,
+    ) -> Result<HotStateValueChunkWithProof> {
+        ensure!(
+            !state_key_values.is_empty(),
+            "Hot state chunk starting at {}",
+            first_index,
+        );
+        let last_index = (state_key_values.len() - 1 + first_index) as u64;
+        let first_key = state_key_values.first().expect("checked to exist").0.hash();
+        let last_key = state_key_values.last().expect("checked to exist").0.hash();
+        let hot_state_merkle_db = self
+            .hot_state_merkle_db
+            .as_ref()
+            .ok_or(AptosDbError::HotStateError)?;
+        let proof = hot_state_merkle_db.get_range_proof(last_key, version)?;
+        let root_hash = hot_state_merkle_db.get_root_hash(version)?;
+
+        Ok(HotStateValueChunkWithProof {
             first_index: first_index as u64,
             last_index,
             first_key,

--- a/storage/storage-interface/src/lib.rs
+++ b/storage/storage-interface/src/lib.rs
@@ -20,7 +20,7 @@ use aptos_types::{
         hot_state::HotStateValue,
         state_key::StateKey,
         state_storage_usage::StateStorageUsage,
-        state_value::{StateValue, StateValueChunkWithProof},
+        state_value::{HotStateValueChunkWithProof, StateValue, StateValueChunkWithProof},
     },
     transaction::{
         IndexedTransactionSummary, PersistedAuxiliaryInfo, Transaction, TransactionAuxiliaryData,
@@ -439,6 +439,16 @@ pub trait DbReader: Send + Sync {
             start_idx: usize,
             chunk_size: usize,
         ) -> Result<StateValueChunkWithProof>;
+
+        /// Get a chunk of hot state values, addressed by the index. The returned proof and root
+        /// hash are over the hot state Merkle tree (i.e. the `hot_state_checkpoint_hash` committed
+        /// in `TransactionInfoV1`), not the main state tree.
+        fn get_hot_state_value_chunk_with_proof(
+            &self,
+            version: Version,
+            start_idx: usize,
+            chunk_size: usize,
+        ) -> Result<HotStateValueChunkWithProof>;
 
         /// Returns an iterator of state key value pairs starting from the index.
         fn get_state_value_chunk_iter(

--- a/types/src/state_store/hot_state.rs
+++ b/types/src/state_store/hot_state.rs
@@ -46,6 +46,7 @@ pub trait THotStateSlot {
 
 /// `HotStateValue` is what gets hashed into the hot state Merkle tree.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, BCSCryptoHash, CryptoHasher)]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(proptest_derive::Arbitrary))]
 pub struct HotStateValue {
     /// `Some` means occupied and `None` means vacant.
     value: Option<StateValue>,

--- a/types/src/state_store/state_value.rs
+++ b/types/src/state_store/state_value.rs
@@ -2,8 +2,10 @@
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
-    on_chain_config::CurrentTimeMicroseconds, proof::SparseMerkleRangeProof,
-    state_store::state_key::StateKey, transaction::Version,
+    on_chain_config::CurrentTimeMicroseconds,
+    proof::SparseMerkleRangeProof,
+    state_store::{hot_state::HotStateValue, state_key::StateKey},
+    transaction::Version,
 };
 use aptos_crypto::{hash::SPARSE_MERKLE_PLACEHOLDER_HASH, HashValue};
 use aptos_crypto_derive::{BCSCryptoHash, CryptoHasher};
@@ -355,6 +357,38 @@ pub struct StateValueChunkWithProof {
 impl StateValueChunkWithProof {
     /// Returns true iff this chunk is the last chunk (i.e., there are no
     /// more state values to write to storage after this chunk).
+    pub fn is_last_chunk(&self) -> bool {
+        let right_siblings = self.proof.right_siblings();
+        right_siblings
+            .iter()
+            .all(|sibling| *sibling == *SPARSE_MERKLE_PLACEHOLDER_HASH)
+    }
+}
+
+/// A single chunk of all hot state values at a specific version. This is the hot
+/// state counterpart of [`StateValueChunkWithProof`], used to transfer a hot
+/// state snapshot during fast sync.
+///
+/// The hot state Merkle tree hashes a `HotStateValue` (the value together with
+/// its `hot_since_version`) at each leaf rather than a bare `StateValue`, so each
+/// entry carries the full `HotStateValue`. `proof` and `root_hash` are over the
+/// hot state sparse merkle tree (i.e. the `hot_state_checkpoint_hash` committed
+/// in `TransactionInfoV1`), not the main state tree.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(proptest_derive::Arbitrary))]
+pub struct HotStateValueChunkWithProof {
+    pub first_index: u64,     // The first hashed state index in chunk
+    pub last_index: u64,      // The last hashed state index in chunk
+    pub first_key: HashValue, // The first hashed state key in chunk
+    pub last_key: HashValue,  // The last hashed state key in chunk
+    pub raw_values: Vec<(StateKey, HotStateValue)>, // The state key and its hot state value.
+    pub proof: SparseMerkleRangeProof, // The proof to ensure the chunk is in the hot states
+    pub root_hash: HashValue, // The root hash of the hot state sparse merkle tree for this chunk
+}
+
+impl HotStateValueChunkWithProof {
+    /// Returns true iff this chunk is the last chunk (i.e., there are no
+    /// more hot state values to write to storage after this chunk).
     pub fn is_last_chunk(&self) -> bool {
         let right_siblings = self.proof.right_siblings();
         right_siblings


### PR DESCRIPTION

Fast sync (`DownloadLatestStates`) rebuilds only the cold state. The hot
state is a separate Merkle tree whose root is committed in
`TransactionInfoV1`, and it cannot be derived from the cold snapshot, so
supporting hot state under fast sync requires transferring and verifying a
hot state snapshot of its own.

This adds the storage-layer read primitive for that transfer:

- `HotStateValueChunkWithProof`, the hot-state counterpart of
  `StateValueChunkWithProof`. Each entry carries a full `HotStateValue`
  (the value together with its `hot_since_version`) since that is what the
  hot state tree hashes at each leaf; the proof and root hash are over the
  hot tree.

- `DbReader::get_hot_state_value_chunk_with_proof`, which produces such a
  chunk by mirroring the cold `get_value_chunk_with_proof`: it iterates the
  hot state Merkle DB and reconstructs each value through
  `expect_hot_state_value_by_version`, taking the range proof and root from
  the hot tree.

The AptosDB implementation reuses the `gauged_api` metrics wrapper and
guards against pruned versions; mocks and delegating readers inherit the
method via `delegate_read!`.

Serving/streaming and the restore path are left for follow-ups.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
