### PR TITLE
[api] Track Rosetta secondary store balances

### DIFF
--- a/crates/aptos-rosetta/src/account.rs
+++ b/crates/aptos-rosetta/src/account.rs
@@ -20,7 +20,10 @@ use aptos_rest_client::{
     error::{AptosErrorResponse, RestError},
     Client,
 };
-use aptos_types::{account_address::AccountAddress, account_config::AccountResource};
+use aptos_types::{
+    account_address::AccountAddress,
+    account_config::{fungible_store::FungibleStoreResource, AccountResource},
+};
 use move_core_types::{
     ident_str,
     identifier::IdentStr,
@@ -126,18 +129,18 @@ async fn get_balances(
     if account.is_base_account() {
         balances =
             get_base_balances(&rest_client, owner_address, version, currencies_to_lookup).await?;
-    } else if pool_address.is_some() {
+    } else if let Some(currency) = account.secondary_store_currency() {
+        if currencies_to_lookup.contains(currency) {
+            balances =
+                get_secondary_store_balance(&rest_client, owner_address, version, currency).await?;
+        }
+    } else if let Some(pool_address) = pool_address {
         // Lookup the delegation pool, if it's provided in the account information
         // Filter appropriately, must have native coin
         if currencies_to_lookup.contains(&native_coin()) {
-            (balances, lockup_expiration) = get_delegation_info(
-                &rest_client,
-                &account,
-                owner_address,
-                pool_address.unwrap(),
-                version,
-            )
-            .await?;
+            (balances, lockup_expiration) =
+                get_delegation_info(&rest_client, &account, owner_address, pool_address, version)
+                    .await?;
         }
     } else {
         // Retrieve staking information (if it applies)
@@ -157,6 +160,88 @@ async fn get_balances(
         balances,
         lockup_expiration,
     ))
+}
+
+async fn get_secondary_store_balance(
+    rest_client: &Client,
+    store_address: AccountAddress,
+    version: u64,
+    currency: &Currency,
+) -> ApiResult<Vec<Amount>> {
+    match rest_client
+        .get_account_resource_at_version_bcs(
+            store_address,
+            "0x1::fungible_asset::FungibleStore",
+            version,
+        )
+        .await
+    {
+        Ok(response) => {
+            let store: FungibleStoreResource = response.into_inner();
+            Ok(vec![secondary_store_amount(&store, currency)?])
+        },
+        Err(RestError::Api(AptosErrorResponse {
+            error:
+                AptosError {
+                    error_code: AptosErrorCode::AccountNotFound,
+                    ..
+                },
+            ..
+        }))
+        | Err(RestError::Api(AptosErrorResponse {
+            error:
+                AptosError {
+                    error_code: AptosErrorCode::ResourceNotFound,
+                    ..
+                },
+            ..
+        })) => Ok(vec![Amount {
+            value: 0.to_string(),
+            currency: currency.clone(),
+        }]),
+        Err(err) => Err(ApiError::InternalError(Some(format!(
+            "Failed to retrieve secondary store balance: {}",
+            err
+        )))),
+    }
+}
+
+fn secondary_store_amount(store: &FungibleStoreResource, currency: &Currency) -> ApiResult<Amount> {
+    let expected_metadata = currency_fa_metadata_address(currency)?.ok_or_else(|| {
+        ApiError::InvalidInput(Some(format!(
+            "Currency {} does not identify a fungible asset metadata address",
+            currency.symbol
+        )))
+    })?;
+
+    if store.metadata() != expected_metadata {
+        return Err(ApiError::InvalidInput(Some(format!(
+            "Secondary store metadata {} does not match requested currency metadata {}",
+            store.metadata(),
+            expected_metadata
+        ))));
+    }
+
+    Ok(Amount {
+        value: store.balance().to_string(),
+        currency: currency.clone(),
+    })
+}
+
+fn currency_fa_metadata_address(currency: &Currency) -> ApiResult<Option<AccountAddress>> {
+    if let Some(metadata) = currency.metadata.as_ref() {
+        if let Some(fa_address) = metadata.fa_address.as_ref() {
+            return AccountAddress::from_str(fa_address)
+                .map(Some)
+                .map_err(|err| ApiError::InvalidInput(Some(err.to_string())));
+        }
+    }
+
+    if currency == &native_coin() {
+        Ok(Some(AccountAddress::TEN))
+    } else {
+        Ok(None)
+    }
 }
 
 async fn get_sequence_number(
@@ -402,4 +487,57 @@ pub async fn view<T: DeserializeOwned>(
         )
         .await?
         .into_inner())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::CurrencyMetadata;
+
+    #[test]
+    fn test_secondary_store_amount_for_native_coin() {
+        let store = FungibleStoreResource::new(AccountAddress::TEN, 50_000_000, false);
+        let amount = secondary_store_amount(&store, &native_coin()).unwrap();
+
+        assert_eq!(amount.value, "50000000");
+        assert_eq!(amount.currency, native_coin());
+    }
+
+    #[test]
+    fn test_secondary_store_amount_preserves_fa_currency() {
+        let metadata_address =
+            AccountAddress::from_str("0x12341234123412341234123412341234").unwrap();
+        let currency = Currency {
+            symbol: "FUN".to_string(),
+            decimals: 2,
+            metadata: Some(CurrencyMetadata {
+                move_type: None,
+                fa_address: Some(metadata_address.to_string()),
+            }),
+        };
+        let store = FungibleStoreResource::new(metadata_address, 123, false);
+        let amount = secondary_store_amount(&store, &currency).unwrap();
+
+        assert_eq!(amount.value, "123");
+        assert_eq!(amount.currency, currency);
+    }
+
+    #[test]
+    fn test_secondary_store_amount_rejects_mismatched_currency() {
+        let store_metadata =
+            AccountAddress::from_str("0x12341234123412341234123412341234").unwrap();
+        let requested_metadata =
+            AccountAddress::from_str("0x56785678567856785678567856785678").unwrap();
+        let currency = Currency {
+            symbol: "FUN".to_string(),
+            decimals: 2,
+            metadata: Some(CurrencyMetadata {
+                move_type: None,
+                fa_address: Some(requested_metadata.to_string()),
+            }),
+        };
+        let store = FungibleStoreResource::new(store_metadata, 123, false);
+
+        assert!(secondary_store_amount(&store, &currency).is_err());
+    }
 }

--- a/crates/aptos-rosetta/src/test/mod.rs
+++ b/crates/aptos-rosetta/src/test/mod.rs
@@ -4,8 +4,9 @@
 use crate::{
     common::native_coin,
     types::{
-        Currency, CurrencyMetadata, OperationType, Transaction, FUNGIBLE_ASSET_MODULE,
-        FUNGIBLE_STORE_RESOURCE, OBJECT_CORE_RESOURCE, OBJECT_MODULE, OBJECT_RESOURCE_GROUP,
+        AccountIdentifier, Currency, CurrencyMetadata, OperationType, Transaction,
+        FUNGIBLE_ASSET_MODULE, FUNGIBLE_STORE_RESOURCE, OBJECT_CORE_RESOURCE, OBJECT_MODULE,
+        OBJECT_RESOURCE_GROUP,
     },
     RosettaContext,
 };
@@ -15,6 +16,7 @@ use aptos_crypto::{
 };
 use aptos_rest_client::aptos_api_types::{ResourceGroup, TransactionOnChainData};
 use aptos_types::{
+    account_address::create_derived_object_address,
     account_config::{
         fungible_store::FungibleStoreResource, DepositFAEvent, ObjectCoreResource, WithdrawFAEvent,
     },
@@ -50,6 +52,10 @@ async fn test_rosetta_context() -> RosettaContext {
     currencies.insert(OTHER_CURRENCY.clone());
 
     RosettaContext::new(None, ChainId::test(), None, currencies).await
+}
+
+fn primary_store_address(owner: AccountAddress, metadata: AccountAddress) -> AccountAddress {
+    create_derived_object_address(owner, metadata)
 }
 
 fn test_transaction(
@@ -251,7 +257,7 @@ async fn test_fa_mint() {
     let version = 0;
     let amount = 100;
     let sender = AccountAddress::random();
-    let store_address = AccountAddress::random();
+    let store_address = primary_store_address(sender, APT_ADDRESS);
     let (mint_changes, mint_events) = mint_fa_output(sender, APT_ADDRESS, store_address, 0, amount);
     let input = test_transaction(sender, version, mint_changes, mint_events);
 
@@ -300,8 +306,8 @@ async fn test_fa_transfer() {
     let amount = 100;
     let sender = AccountAddress::random();
     let receiver = AccountAddress::random();
-    let store_address = AccountAddress::random();
-    let receiver_store_address = AccountAddress::random();
+    let store_address = primary_store_address(sender, APT_ADDRESS);
+    let receiver_store_address = primary_store_address(receiver, APT_ADDRESS);
     let (changes, events) = transfer_fa_output(
         sender,
         APT_ADDRESS,
@@ -371,6 +377,155 @@ async fn test_fa_transfer() {
 }
 
 #[tokio::test]
+async fn test_mainnet_apt_fa_transfer_tracks_primary_stores() {
+    let context = test_rosetta_context().await;
+
+    // Mainnet transaction 4141282946:
+    // https://explorer.aptoslabs.com/txn/4141282946/userTxnOverview?network=mainnet
+    let version = 4_141_282_946;
+    let amount = 100_000;
+    let sender = AccountAddress::from_str(
+        "0x5b470b5a9536d94da23746acf069d1d41e45e2b01605ab4aa1b3892f6cac5f5f",
+    )
+    .unwrap();
+    let receiver = AccountAddress::from_str(
+        "0xc67545d6f3d36ed01efc9b28cbfd0c1ae326d5d262dd077a29539bcee0edce9e",
+    )
+    .unwrap();
+    let store_address = AccountAddress::from_str(
+        "0x9016ac2c7b1016f621e463edf37bf4993a45f810df80bbec1cd1b25453cd0d5e",
+    )
+    .unwrap();
+    let receiver_store_address = AccountAddress::from_str(
+        "0xeba1a450b0a5e7cbda0e2ed079bbbe9bd17aeda5910d832a3b22888e38633d76",
+    )
+    .unwrap();
+
+    assert_eq!(store_address, primary_store_address(sender, APT_ADDRESS));
+    assert_eq!(
+        receiver_store_address,
+        primary_store_address(receiver, APT_ADDRESS)
+    );
+
+    let (changes, events) = transfer_fa_output(
+        sender,
+        APT_ADDRESS,
+        store_address,
+        60_420_417,
+        receiver,
+        receiver_store_address,
+        10_362_875_460,
+        amount,
+    );
+    let input = test_transaction(sender, version, changes, events);
+
+    let result = Transaction::from_transaction(&context, input).await;
+    let expected_txn = result.expect("Must succeed");
+    assert_eq!(3, expected_txn.operations.len(), "Ops: {:#?}", expected_txn);
+
+    let withdraw_op = expected_txn.operations.first().unwrap();
+    assert_eq!(
+        withdraw_op.operation_type,
+        OperationType::Withdraw.to_string()
+    );
+    assert_eq!(
+        withdraw_op
+            .account
+            .as_ref()
+            .unwrap()
+            .account_address()
+            .unwrap(),
+        sender
+    );
+    assert_eq!(
+        withdraw_op.amount.as_ref().unwrap().value,
+        format!("-{}", amount)
+    );
+    assert_eq!(withdraw_op.amount.as_ref().unwrap().currency, native_coin());
+
+    let deposit_op = expected_txn.operations.get(1).unwrap();
+    assert_eq!(
+        deposit_op.operation_type,
+        OperationType::Deposit.to_string()
+    );
+    assert_eq!(
+        deposit_op
+            .account
+            .as_ref()
+            .unwrap()
+            .account_address()
+            .unwrap(),
+        receiver
+    );
+    assert_eq!(
+        deposit_op.amount.as_ref().unwrap().value,
+        format!("{}", amount)
+    );
+    assert_eq!(deposit_op.amount.as_ref().unwrap().currency, native_coin());
+}
+
+#[tokio::test]
+async fn test_mainnet_reclaim_non_primary_store_tracks_secondary_store() {
+    let context = test_rosetta_context().await;
+
+    // Mainnet transaction 5519638905:
+    // https://explorer.aptoslabs.com/txn/5519638905/userTxnOverview?network=mainnet
+    let version = 5_519_638_905;
+    let amount = 50_000_000;
+    let sender = AccountAddress::from_str(
+        "0xf10387b231218d7ad53fb44ff6cd9eda5e50b3e3ed6aaf4d13b9f9e54d1f4cae",
+    )
+    .unwrap();
+    let non_primary_store_address = AccountAddress::from_str(
+        "0x76dbc266c7c11ba64308fcfa6b2507c77b3e2bfa48edcf6235e9f15eeeb5839d",
+    )
+    .unwrap();
+    let expected_primary_store_address = AccountAddress::from_str(
+        "0xd0f5f74b99a9fe669a3cbd88215c6ee175113e12a33158b8ad21ce39af5ad6fe",
+    )
+    .unwrap();
+
+    assert_ne!(
+        non_primary_store_address,
+        primary_store_address(sender, APT_ADDRESS)
+    );
+    assert_eq!(
+        expected_primary_store_address,
+        primary_store_address(sender, APT_ADDRESS)
+    );
+
+    let (changes, events) =
+        mint_fa_output(sender, APT_ADDRESS, non_primary_store_address, 0, amount);
+    let input = test_transaction(sender, version, changes, events);
+
+    let result = Transaction::from_transaction(&context, input).await;
+    let expected_txn = result.expect("Must succeed");
+    assert_eq!(2, expected_txn.operations.len(), "Ops: {:#?}", expected_txn);
+
+    let deposit_op = expected_txn.operations.first().unwrap();
+    assert_eq!(
+        deposit_op.operation_type,
+        OperationType::Deposit.to_string()
+    );
+    assert_eq!(
+        deposit_op.account.as_ref().unwrap(),
+        &AccountIdentifier::secondary_store_account(&non_primary_store_address, &native_coin())
+    );
+    assert_eq!(
+        deposit_op.amount.as_ref().unwrap().value,
+        format!("{}", amount)
+    );
+    assert_eq!(deposit_op.amount.as_ref().unwrap().currency, native_coin());
+
+    let fee_op = expected_txn.operations.get(1).unwrap();
+    assert_eq!(fee_op.operation_type, OperationType::Fee.to_string());
+    assert_eq!(
+        fee_op.account.as_ref().unwrap().account_address().unwrap(),
+        sender
+    );
+}
+
+#[tokio::test]
 async fn test_fa_transfer_other_currency() {
     let context = test_rosetta_context().await;
 
@@ -378,11 +533,12 @@ async fn test_fa_transfer_other_currency() {
     let amount = 100;
     let sender = AccountAddress::random();
     let receiver = AccountAddress::random();
-    let store_address = AccountAddress::random();
-    let receiver_store_address = AccountAddress::random();
+    let fa_metadata_address = AccountAddress::from_str(OTHER_CURRENCY_ADDRESS).unwrap();
+    let store_address = primary_store_address(sender, fa_metadata_address);
+    let receiver_store_address = primary_store_address(receiver, fa_metadata_address);
     let (changes, events) = transfer_fa_output(
         sender,
-        AccountAddress::from_str(OTHER_CURRENCY_ADDRESS).unwrap(),
+        fa_metadata_address,
         store_address,
         amount * 2,
         receiver,
@@ -514,8 +670,8 @@ async fn test_fee_payer_transfer_attributes_fee_to_fee_payer() {
     let sender = AccountAddress::random();
     let fee_payer = AccountAddress::random();
     let receiver = AccountAddress::random();
-    let store_address = AccountAddress::random();
-    let receiver_store_address = AccountAddress::random();
+    let store_address = primary_store_address(sender, APT_ADDRESS);
+    let receiver_store_address = primary_store_address(receiver, APT_ADDRESS);
     let (changes, events) = transfer_fa_output(
         sender,
         APT_ADDRESS,
@@ -584,7 +740,7 @@ async fn test_fee_payer_mint_attributes_fee_to_fee_payer() {
     let amount = 100;
     let sender = AccountAddress::random();
     let fee_payer = AccountAddress::random();
-    let store_address = AccountAddress::random();
+    let store_address = primary_store_address(sender, APT_ADDRESS);
     let (mint_changes, mint_events) = mint_fa_output(sender, APT_ADDRESS, store_address, 0, amount);
     let input = test_fee_payer_transaction(sender, fee_payer, version, mint_changes, mint_events);
 
@@ -625,7 +781,7 @@ async fn test_fee_payer_storage_refund_attributes_to_fee_payer() {
     let storage_refund = 500u64;
     let sender = AccountAddress::random();
     let fee_payer = AccountAddress::random();
-    let store_address = AccountAddress::random();
+    let store_address = primary_store_address(sender, APT_ADDRESS);
 
     let (mint_changes, mut mint_events) =
         mint_fa_output(sender, APT_ADDRESS, store_address, 0, amount);
@@ -702,7 +858,7 @@ async fn test_no_fee_payer_storage_refund_attributes_to_sender() {
     let amount = 100;
     let storage_refund = 500u64;
     let sender = AccountAddress::random();
-    let store_address = AccountAddress::random();
+    let store_address = primary_store_address(sender, APT_ADDRESS);
 
     let (mint_changes, mut mint_events) =
         mint_fa_output(sender, APT_ADDRESS, store_address, 0, amount);
@@ -775,7 +931,7 @@ async fn test_storage_refund_exceeds_gas_fee() {
     let amount = 100;
     let sender = AccountAddress::random();
     let fee_payer = AccountAddress::random();
-    let store_address = AccountAddress::random();
+    let store_address = primary_store_address(sender, APT_ADDRESS);
 
     // gas_used=178 and gas_unit_price=101 from test helpers, so gas fee = 17,978 octas.
     // Set storage refund to 25,000 so it exceeds the gas fee (net = +7,022 for fee payer).

--- a/crates/aptos-rosetta/src/types/identifiers.rs
+++ b/crates/aptos-rosetta/src/types/identifiers.rs
@@ -8,6 +8,7 @@
 use crate::{
     common::{to_hex_lower, BlockHash, BLOCKCHAIN},
     error::{ApiError, ApiResult},
+    types::Currency,
 };
 use aptos_types::{
     account_address::AccountAddress, chain_id::ChainId, transaction::TransactionInfo,
@@ -40,7 +41,9 @@ impl AccountIdentifier {
     pub fn pool_address(&self) -> ApiResult<Option<AccountAddress>> {
         if let Some(sub_account) = &self.sub_account {
             if let Some(metadata) = &sub_account.metadata {
-                return str_to_account_address(metadata.pool_address.as_str()).map(Some);
+                if let Some(pool_address) = metadata.pool_address.as_deref() {
+                    return str_to_account_address(pool_address).map(Some);
+                }
             }
         }
 
@@ -106,9 +109,29 @@ impl AccountIdentifier {
         }
     }
 
+    pub fn secondary_store_account(store_address: &AccountAddress, currency: &Currency) -> Self {
+        AccountIdentifier {
+            address: to_hex_lower(store_address),
+            sub_account: Some(SubAccountIdentifier::new_secondary_store(currency)),
+        }
+    }
+
     /// Returns true if the account doesn't have a sub account
     pub fn is_base_account(&self) -> bool {
         self.sub_account.is_none()
+    }
+
+    pub fn secondary_store_currency(&self) -> Option<&Currency> {
+        self.sub_account.as_ref().and_then(|sub_account| {
+            if sub_account.is_secondary_store() {
+                sub_account
+                    .metadata
+                    .as_ref()
+                    .and_then(|metadata| metadata.currency.as_ref())
+            } else {
+                None
+            }
+        })
     }
 
     pub fn is_total_stake(&self) -> bool {
@@ -241,6 +264,7 @@ const PENDING_INACTIVE_STAKE: &str = "pending_inactive_stake";
 const INACTIVE_STAKE: &str = "inactive_stake";
 const COMMISSION: &str = "commission";
 const REWARDS: &str = "rewards";
+const SECONDARY_STORE: &str = "secondary_store";
 const ACCOUNT_SEPARATOR: char = '-';
 
 impl SubAccountIdentifier {
@@ -336,6 +360,16 @@ impl SubAccountIdentifier {
         }
     }
 
+    pub fn new_secondary_store(currency: &Currency) -> SubAccountIdentifier {
+        SubAccountIdentifier {
+            address: SECONDARY_STORE.to_string(),
+            metadata: Some(SubAccountIdentifierMetadata {
+                pool_address: None,
+                currency: Some(currency.clone()),
+            }),
+        }
+    }
+
     pub fn is_total_stake(&self) -> bool {
         self.address.as_str() == STAKE
     }
@@ -376,6 +410,12 @@ impl SubAccountIdentifier {
         self.address.as_str() == PENDING_INACTIVE_STAKE && self.metadata.is_some()
     }
 
+    pub fn is_secondary_store(&self) -> bool {
+        self.address.as_str() == SECONDARY_STORE
+            && self.metadata.is_some()
+            && self.metadata.as_ref().unwrap().currency.is_some()
+    }
+
     pub fn operator_address(&self) -> ApiResult<AccountAddress> {
         let mut parts = self.address.split(ACCOUNT_SEPARATOR);
 
@@ -397,13 +437,18 @@ impl SubAccountIdentifier {
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct SubAccountIdentifierMetadata {
     /// Hex encoded Pool beginning with 0x
-    pub pool_address: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pool_address: Option<String>,
+    /// Store currency
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub currency: Option<Currency>,
 }
 
 impl SubAccountIdentifierMetadata {
     pub fn new_pool_address(pool_address: AccountAddress) -> Self {
         SubAccountIdentifierMetadata {
-            pool_address: to_hex_lower(&pool_address),
+            pool_address: Some(to_hex_lower(&pool_address)),
+            currency: None,
         }
     }
 }

--- a/crates/aptos-rosetta/src/types/objects.rs
+++ b/crates/aptos-rosetta/src/types/objects.rs
@@ -28,7 +28,7 @@ use aptos_logger::warn;
 use aptos_rest_client::aptos_api_types::{ResourceGroup, TransactionOnChainData, U64};
 use aptos_types::{
     access_path::Path,
-    account_address::AccountAddress,
+    account_address::{create_derived_object_address, AccountAddress},
     account_config::{
         fungible_store::FungibleStoreResource, AccountResource, CoinStoreResourceUntyped,
         CoinWithdraw, DepositFAEvent, ObjectCoreResource, WithdrawEvent,
@@ -2189,12 +2189,19 @@ fn parse_fungible_store_changes(
 
     let owner = maybe_owner.copied().unwrap();
 
+    // We double check if the address is a primary store
+    let account = if is_primary_store(&address, &owner, currency) {
+        AccountIdentifier::base_account(owner)
+    } else {
+        AccountIdentifier::secondary_store_account(&address, currency)
+    };
+
     let withdraw_amounts = get_amount_from_fa_event(events, &WITHDRAW_TYPE_TAG, address);
     for amount in withdraw_amounts {
         operations.push(Operation::withdraw(
             operation_index,
             Some(OperationStatusType::Success),
-            AccountIdentifier::base_account(owner),
+            account.clone(),
             currency.clone(),
             amount,
         ));
@@ -2206,7 +2213,7 @@ fn parse_fungible_store_changes(
         operations.push(Operation::deposit(
             operation_index,
             Some(OperationStatusType::Success),
-            AccountIdentifier::base_account(owner),
+            account.clone(),
             currency.clone(),
             amount,
         ));
@@ -2214,6 +2221,26 @@ fn parse_fungible_store_changes(
     }
 
     Ok(operations)
+}
+
+fn is_primary_store(
+    store_address: &AccountAddress,
+    owner: &AccountAddress,
+    currency: &Currency,
+) -> bool {
+    let metadata_address = match currency.metadata.as_ref().and_then(|metadata| {
+        metadata
+            .fa_address
+            .as_ref()
+            .map(|fa_address| AccountAddress::from_str(fa_address))
+    }) {
+        Some(Ok(metadata_address)) => metadata_address,
+        Some(Err(_)) => return false,
+        None if currency == &native_coin() => AccountAddress::TEN,
+        None => return false,
+    };
+
+    create_derived_object_address(*owner, metadata_address) == *store_address
 }
 
 /// Pulls the balance change from a withdraw or deposit event


### PR DESCRIPTION
## Description
Add secondary fungible-store account identifiers so Rosetta can attribute non-primary store changes and query their balances directly.

## How Has This Been Tested?
Unit testing accordingly

## Key Areas to Review
Ensure that this keeps primary addresses correct and separates out secondary stores with a sub account

## Type of Change
- [x] New feature
- [ ] Bug fix
- [x] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [x] Other (Rosetta)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
