### PR TITLE
[vm] Fail-closed when squashing a write with a later in-place delayed-field change

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8762,6 +8762,8 @@ name = "e2e-move-tests"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "aptos-aggregator",
+ "aptos-block-executor",
  "aptos-cached-packages",
  "aptos-crypto",
  "aptos-framework",
@@ -8770,6 +8772,7 @@ dependencies = [
  "aptos-gas-schedule",
  "aptos-language-e2e-tests",
  "aptos-move-e2e-test-harness",
+ "aptos-mvhashmap",
  "aptos-package-builder",
  "aptos-rest-client",
  "aptos-sdk",
@@ -8787,6 +8790,8 @@ dependencies = [
  "move-coverage",
  "move-model",
  "move-package",
+ "move-vm-runtime",
+ "move-vm-types",
  "once_cell",
  "proptest",
  "rstest",
@@ -8795,6 +8800,7 @@ dependencies = [
  "test-case",
  "thousands",
  "tokio",
+ "triomphe",
 ]
 
 [[package]]

--- a/aptos-move/aptos-vm-types/src/change_set.rs
+++ b/aptos-move/aptos-vm-types/src/change_set.rs
@@ -554,6 +554,11 @@ impl VMChangeSet {
     pub(crate) fn squash_additional_resource_writes(
         write_set: &mut BTreeMap<StateKey, AbstractResourceWriteOp>,
         additional_write_set: BTreeMap<StateKey, AbstractResourceWriteOp>,
+        // Gated by gas feature version (see ChangeSetConfigs::strict_delayed_field_squash). When
+        // true, a full write (resource group or standalone delayed-field resource) followed by an
+        // in-place delayed-field change on the same key is rejected outright instead of being
+        // allowed when sizes match.
+        strict_delayed_field_squash: bool,
     ) -> Result<(), PanicError> {
         use AbstractResourceWriteOp::*;
         for (key, additional_entry) in additional_write_set.into_iter() {
@@ -644,7 +649,23 @@ impl VMChangeSet {
                                 ..
                             }),
                         ) => {
-                            // Read cannot change the size (i.e. delayed fields don't modify size)
+                            if strict_delayed_field_squash {
+                                // SAFETY (gas_feature_version >= RELEASE_V1_46): fail closed, the
+                                // standalone-resource analogue of the resource-group arm below. A
+                                // full resource write squashed with a later in-place delayed-field
+                                // exchange on the same key is rejected; a matching materialized
+                                // size does not prove the later exchange reconciles with what the
+                                // earlier session wrote.
+                                return Err(code_invariant_error(format!(
+                                    "Refusing to squash a resource write with a later in-place \
+                                     delayed-field change on the same key (fail-closed for safety): \
+                                     {:?} into {:?}.",
+                                    key, additional_entry
+                                )));
+                            }
+                            // Legacy behavior (gas_feature_version < RELEASE_V1_46): a read cannot
+                            // change the size (i.e. delayed fields don't modify size), so allow the
+                            // merge only when the materialized sizes match.
                             if materialized_size != &Some(*additional_materialized_size) {
                                 return Err(code_invariant_error(format!(
                                     "Trying to squash writes where read has different size: {:?}: {:?}",
@@ -667,7 +688,30 @@ impl VMChangeSet {
                                 },
                             ),
                         ) => {
-                            // Read cannot change the size (i.e. delayed fields don't modify size)
+                            if strict_delayed_field_squash {
+                                // SAFETY (gas_feature_version >= RELEASE_V1_46): fail closed. We
+                                // deliberately do NOT allow squashing a full resource-group write
+                                // (an earlier session that wrote the group, e.g. structurally
+                                // changed its membership) with a later in-place delayed-field
+                                // exchange on the same group (e.g. the gas epilogue touching an
+                                // aggregator in that group). A matching materialized size does not
+                                // prove the later session's delayed-field exchange reconciles with
+                                // the group the earlier session wrote, so rather than risk a silent
+                                // mis-merge of a resource group (which holds asset balances), we
+                                // abort the transaction. This is asset-safe: no change set is
+                                // applied. Legitimate flows touch the group purely in place
+                                // (ResourceGroupInPlaceDelayedFieldChange on both sides), handled by
+                                // the arm below.
+                                return Err(code_invariant_error(format!(
+                                    "Refusing to squash a resource-group write with a later \
+                                     in-place delayed-field change on the same group (fail-closed \
+                                     for safety): {:?} into {:?}.",
+                                    key, additional_entry
+                                )));
+                            }
+                            // Legacy behavior (gas_feature_version < RELEASE_V1_46): a read cannot
+                            // change the size (i.e. delayed fields don't modify size), so allow the
+                            // merge only when the materialized sizes match.
                             if materialized_size.map(|v| v.get())
                                 != Some(*additional_materialized_size)
                             {
@@ -739,6 +783,8 @@ impl VMChangeSet {
     pub fn squash_additional_change_set(
         &mut self,
         additional_change_set: Self,
+        // Gated by gas feature version (see ChangeSetConfigs::strict_delayed_field_squash).
+        strict_delayed_field_squash: bool,
     ) -> PartialVMResult<()> {
         let Self {
             resource_write_set: additional_resource_write_set,
@@ -757,6 +803,7 @@ impl VMChangeSet {
         Self::squash_additional_resource_writes(
             &mut self.resource_write_set,
             additional_resource_write_set,
+            strict_delayed_field_squash,
         )?;
         Self::squash_additional_delayed_field_changes(
             &mut self.delayed_field_change_set,

--- a/aptos-move/aptos-vm-types/src/storage/change_set_configs.rs
+++ b/aptos-move/aptos-vm-types/src/storage/change_set_configs.rs
@@ -65,6 +65,19 @@ impl ChangeSetConfigs {
         self.gas_feature_version < 3
     }
 
+    /// From `RELEASE_V1_46`, squashing a full write (an earlier session that wrote a value or a
+    /// resource group) with a later *in-place delayed-field change* on the *same* key (e.g. the gas
+    /// epilogue exchanging an aggregator in that value/group) is rejected outright (fail-closed).
+    /// This covers both the resource-group arm (`WriteResourceGroup ⊕
+    /// ResourceGroupInPlaceDelayedFieldChange`) and the standalone-resource arm
+    /// (`WriteWithDelayedFields ⊕ InPlaceDelayedFieldChange`). Before that version, the merge was
+    /// permitted whenever the materialized sizes happened to match -- a matching size does not
+    /// prove the later session's delayed-field exchange reconciles with what the earlier session
+    /// wrote, so we no longer rely on it. See `VMChangeSet::squash_additional_resource_writes`.
+    pub fn strict_delayed_field_squash(&self) -> bool {
+        self.gas_feature_version >= aptos_gas_schedule::gas_feature_versions::RELEASE_V1_46
+    }
+
     fn for_feature_version_3() -> Self {
         const MB: u64 = 1 << 20;
 

--- a/aptos-move/aptos-vm-types/src/tests/test_change_set.rs
+++ b/aptos-move/aptos-vm-types/src/tests/test_change_set.rs
@@ -163,7 +163,7 @@ fn build_change_sets_for_test() -> (VMChangeSet, VMChangeSet) {
 #[test]
 fn test_successful_squash() {
     let (mut change_set, additional_change_set) = build_change_sets_for_test();
-    assert_ok!(change_set.squash_additional_change_set(additional_change_set,));
+    assert_ok!(change_set.squash_additional_change_set(additional_change_set, true));
 
     let descriptor = "r";
     assert_eq!(
@@ -211,7 +211,7 @@ macro_rules! assert_invariant_violation {
         let cs2 = VMChangeSetBuilder::new()
             .with_resource_write_set($w2.clone())
             .build();
-        let res = cs1.squash_additional_change_set(cs2);
+        let res = cs1.squash_additional_change_set(cs2, true);
         check(res);
         let mut cs1 = VMChangeSetBuilder::new()
             .with_aggregator_v1_write_set($w3.clone())
@@ -219,7 +219,7 @@ macro_rules! assert_invariant_violation {
         let cs2 = VMChangeSetBuilder::new()
             .with_aggregator_v1_write_set($w4.clone())
             .build();
-        let res = cs1.squash_additional_change_set(cs2);
+        let res = cs1.squash_additional_change_set(cs2, true);
         check(res);
     };
 }
@@ -276,7 +276,7 @@ fn test_unsuccessful_squash_delete_delta() {
     let additional_change_set = VMChangeSetBuilder::new()
         .with_aggregator_v1_delta_set(aggregator_delta_set_2)
         .build();
-    let res = change_set.squash_additional_change_set(additional_change_set);
+    let res = change_set.squash_additional_change_set(additional_change_set, true);
     let err = assert_err!(res);
     assert_eq!(
         err.major_status(),
@@ -296,7 +296,7 @@ fn test_unsuccessful_squash_delta_create() {
     let additional_change_set = VMChangeSetBuilder::new()
         .with_aggregator_v1_write_set(aggregator_write_set_2)
         .build();
-    let res = change_set.squash_additional_change_set(additional_change_set);
+    let res = change_set.squash_additional_change_set(additional_change_set, true);
     let err = assert_err!(res);
     assert_eq!(
         err.major_status(),
@@ -406,7 +406,7 @@ fn test_aggregator_v2_snapshots_and_derived() {
         .with_delayed_field_change_set(agg_changes_2)
         .build();
 
-    assert_ok!(change_set_1.squash_additional_change_set(change_set_2,));
+    assert_ok!(change_set_1.squash_additional_change_set(change_set_2, true));
 
     let output_map = change_set_1.delayed_field_change_set();
     assert_eq!(output_map.len(), 3);
@@ -503,7 +503,7 @@ fn test_resource_groups_squashing() {
 
     {
         let mut change_set = create_tag_0.clone();
-        assert_ok!(change_set.squash_additional_change_set(modify_tag_0.clone(),));
+        assert_ok!(change_set.squash_additional_change_set(modify_tag_0.clone(), true));
         assert_eq!(change_set.resource_write_set().len(), 1);
         // create(x)+modify(y) becomes create(y)
         assert_some_eq!(
@@ -519,7 +519,7 @@ fn test_resource_groups_squashing() {
 
     {
         let mut change_set = create_tag_0.clone();
-        assert_ok!(change_set.squash_additional_change_set(create_tag_1.clone(),));
+        assert_ok!(change_set.squash_additional_change_set(create_tag_1.clone(), true));
         assert_eq!(change_set.resource_write_set().len(), 1);
         assert_some_eq!(
             change_set.resource_write_set().get(&as_state_key!("1")),
@@ -531,7 +531,7 @@ fn test_resource_groups_squashing() {
             ))
         );
 
-        assert_ok!(change_set.squash_additional_change_set(modify_tag_1.clone(),));
+        assert_ok!(change_set.squash_additional_change_set(modify_tag_1.clone(), true));
         assert_eq!(change_set.resource_write_set().len(), 1);
         // create(x)+modify(y) becomes create(y)
         assert_some_eq!(
@@ -547,7 +547,7 @@ fn test_resource_groups_squashing() {
 
     {
         let mut change_set = create_tag_0.clone();
-        assert_ok!(change_set.squash_additional_change_set(modify_tag_1.clone(),));
+        assert_ok!(change_set.squash_additional_change_set(modify_tag_1.clone(), true));
         assert_eq!(change_set.resource_write_set().len(), 1);
         assert_some_eq!(
             change_set.resource_write_set().get(&as_state_key!("1")),
@@ -561,16 +561,40 @@ fn test_resource_groups_squashing() {
     }
 
     {
-        // read cannot modify size
-        let mut change_set = create_tag_0.clone();
-        assert_err!(change_set.squash_additional_change_set(
-            ExpandedVMChangeSetBuilder::new()
-                .with_group_reads_needing_delayed_field_exchange(vec![(
-                    as_state_key!("1"),
-                    (modification_metadata.metadata().clone(), 400)
-                )])
-                .build(),
-        ));
+        // A group write squashed with an in-place delayed-field change of a *different* size is
+        // rejected under both gas feature versions (a read cannot modify size).
+        let mismatched_inplace = ExpandedVMChangeSetBuilder::new()
+            .with_group_reads_needing_delayed_field_exchange(vec![(
+                as_state_key!("1"),
+                (modification_metadata.metadata().clone(), 400),
+            )])
+            .build();
+        let mut legacy = create_tag_0.clone();
+        assert_err!(legacy.squash_additional_change_set(mismatched_inplace.clone(), false));
+        let mut strict = create_tag_0.clone();
+        assert_err!(strict.squash_additional_change_set(mismatched_inplace, true));
+    }
+
+    {
+        // WriteResourceGroup ⊕ in-place delayed-field change of *matching* size: permitted under
+        // the legacy rules (the group write is kept), but fail-closed from RELEASE_V1_46. This is
+        // the gas-version-gated behavior change.
+        let matching_inplace = ExpandedVMChangeSetBuilder::new()
+            .with_group_reads_needing_delayed_field_exchange(vec![(
+                as_state_key!("1"),
+                (
+                    modification_metadata.metadata().clone(),
+                    single_tag_group_size.get(),
+                ),
+            )])
+            .build();
+
+        let mut legacy = create_tag_0.clone();
+        assert_ok!(legacy.squash_additional_change_set(matching_inplace.clone(), false));
+        assert_eq!(legacy.resource_write_set().len(), 1);
+
+        let mut strict = create_tag_0.clone();
+        assert_err!(strict.squash_additional_change_set(matching_inplace, true));
     }
 }
 
@@ -612,6 +636,40 @@ fn test_write_and_read_discrepancy_caught() {
             (metadata_op.metadata().clone(), group_size.get())
         )])
         .try_build());
+}
+
+/// Standalone-resource analogue of the resource-group gate: a `WriteWithDelayedFields` squashed
+/// with a later `InPlaceDelayedFieldChange` on the same key is rejected outright under the strict
+/// (gas_feature_version >= RELEASE_V1_46) squash, regardless of whether the materialized sizes
+/// match. (The group analogue is exercised in `test_resource_groups_squashing`.)
+#[test]
+fn test_squash_standalone_write_then_inplace_delayed_field_gated() {
+    let layout = TriompheArc::new(MoveTypeLayout::U64);
+    let write = ExpandedVMChangeSetBuilder::new()
+        .with_resource_write_set(vec![(
+            as_state_key!("1"),
+            (
+                WriteOp::creation(as_bytes!(1).into(), raw_metadata(100)),
+                Some(layout.clone()),
+            ),
+        )])
+        .build();
+    let inplace = ExpandedVMChangeSetBuilder::new()
+        .with_reads_needing_delayed_field_exchange(vec![(
+            as_state_key!("1"),
+            (raw_metadata(100), 8, layout),
+        )])
+        .build();
+
+    // Strict (>= RELEASE_V1_46): rejected outright, fail-closed.
+    let mut strict = write.clone();
+    let err = assert_err!(strict.squash_additional_change_set(inplace.clone(), true));
+    assert!(
+        format!("{:?}", err)
+            .contains("Refusing to squash a resource write with a later in-place delayed-field"),
+        "unexpected error: {:?}",
+        err
+    );
 }
 
 // TODO[agg_v2](cleanup) combine utilities with above utilities, and see if tests need cleanup.
@@ -748,7 +806,8 @@ mod tests {
 
         assert_ok!(VMChangeSet::squash_additional_resource_writes(
             &mut base_update,
-            additional_update
+            additional_update,
+            true,
         ));
 
         assert_eq!(base_update.len(), 2);
@@ -791,7 +850,8 @@ mod tests {
 
         assert_ok!(VMChangeSet::squash_additional_resource_writes(
             &mut base_update,
-            additional_update
+            additional_update,
+            true,
         ));
 
         assert_eq!(base_update.len(), 1);
@@ -829,7 +889,8 @@ mod tests {
 
         assert_err!(VMChangeSet::squash_additional_resource_writes(
             &mut base_update,
-            additional_update
+            additional_update,
+            true,
         ));
     }
 
@@ -860,7 +921,8 @@ mod tests {
 
         assert_ok!(VMChangeSet::squash_additional_resource_writes(
             &mut base_update,
-            additional_update
+            additional_update,
+            true,
         ));
         assert!(base_update.is_empty(), "Must become a no-op");
     }
@@ -948,7 +1010,8 @@ mod tests {
 
         assert_ok!(VMChangeSet::squash_additional_resource_writes(
             &mut base_update,
-            additional_update
+            additional_update,
+            true,
         ));
         assert_eq!(base_update.len(), 2);
         let inner_ops_1 = &extract_group_op(base_update.get(&key_1).unwrap()).inner_ops;
@@ -987,7 +1050,8 @@ mod tests {
         )]);
         assert_err!(VMChangeSet::squash_additional_resource_writes(
             &mut base_update,
-            additional_update
+            additional_update,
+            true,
         ));
     }
 }

--- a/aptos-move/aptos-vm/src/move_vm_ext/session/respawned_session.rs
+++ b/aptos-move/aptos-vm/src/move_vm_ext/session/respawned_session.rs
@@ -98,7 +98,10 @@ impl<'r> RespawnedSession<'r> {
         }
         let mut change_set = self.into_heads().executor_view.change_set;
         change_set
-            .squash_additional_change_set(additional_change_set)
+            .squash_additional_change_set(
+                additional_change_set,
+                change_set_configs.strict_delayed_field_squash(),
+            )
             .map_err(|_err| {
                 VMStatus::error(
                     StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR,

--- a/aptos-move/aptos-vm/src/move_vm_ext/session/view_with_change_set.rs
+++ b/aptos-move/aptos-vm/src/move_vm_ext/session/view_with_change_set.rs
@@ -41,6 +41,16 @@ pub struct ExecutorViewWithChangeSet<'r> {
     pub(crate) change_set: VMChangeSet,
 }
 
+/// Test-only constructor so cross-session squash PoCs can layer a prior session's change set
+/// over an executor view (mirrors how the respawned epilogue session is built).
+pub fn new_for_executor_view_with_change_set_for_test<'r>(
+    base_executor_view: &'r dyn ExecutorView,
+    base_resource_group_view: &'r dyn ResourceGroupView,
+    change_set: VMChangeSet,
+) -> ExecutorViewWithChangeSet<'r> {
+    ExecutorViewWithChangeSet::new(base_executor_view, base_resource_group_view, change_set)
+}
+
 impl<'r> ExecutorViewWithChangeSet<'r> {
     pub(crate) fn new(
         base_executor_view: &'r dyn ExecutorView,

--- a/aptos-move/block-executor/src/code_cache_global_manager.rs
+++ b/aptos-move/block-executor/src/code_cache_global_manager.rs
@@ -315,6 +315,17 @@ impl AptosModuleCacheManagerGuard<'_> {
         }
     }
 
+    /// Testing-only `None` guard whose environment has the delayed-field optimization enabled.
+    /// Exposed (behind the `testing` feature) so cross-session delayed-field PoCs in other crates
+    /// can drive the block executor.
+    #[cfg(any(test, feature = "testing"))]
+    pub fn none_with_delayed_fields_for_testing(state_view: &impl StateView) -> Self {
+        AptosModuleCacheManagerGuard::None {
+            environment: AptosEnvironment::new_with_delayed_field_optimization_enabled(state_view),
+            module_cache: GlobalModuleCache::empty(),
+        }
+    }
+
     /// Takes a shallow snapshot of the current global module cache (hot cache).
     /// Only available under fuzzing. The snapshot shares underlying Arc module code.
     #[cfg(fuzzing)]

--- a/aptos-move/block-executor/src/executor.rs
+++ b/aptos-move/block-executor/src/executor.rs
@@ -1939,6 +1939,26 @@ where
         ))
     }
 
+    /// Testing-only public wrapper (behind the `testing` feature) so PoCs in other crates can
+    /// drive parallel block execution with a custom `ExecutorTask`. Mirrors the internal
+    /// `execute_transactions_parallel` signature, including its `Result<_, ()>`.
+    #[cfg(any(test, feature = "testing"))]
+    #[allow(clippy::result_unit_err)]
+    pub fn execute_transactions_parallel_for_testing(
+        &self,
+        signature_verified_block: &TP,
+        base_view: &S,
+        transaction_slice_metadata: &TransactionSliceMetadata,
+        module_cache_manager_guard: &mut AptosModuleCacheManagerGuard,
+    ) -> Result<BlockOutput<T, E::Output>, ()> {
+        self.execute_transactions_parallel(
+            signature_verified_block,
+            base_view,
+            transaction_slice_metadata,
+            module_cache_manager_guard,
+        )
+    }
+
     pub(crate) fn execute_transactions_parallel(
         &self,
         signature_verified_block: &TP,

--- a/aptos-move/e2e-move-tests/Cargo.toml
+++ b/aptos-move/e2e-move-tests/Cargo.toml
@@ -45,12 +45,18 @@ sha3 = { workspace = true }
 test-case = { workspace = true }
 
 [dev-dependencies]
+aptos-aggregator = { workspace = true }
+aptos-block-executor = { workspace = true, features = ["testing"] }
+aptos-mvhashmap = { workspace = true }
 aptos-vm-types = { workspace = true }
 claims = { workspace = true }
 memory-stats = { workspace = true }
+move-vm-runtime = { workspace = true }
+move-vm-types = { workspace = true }
 test-case = { workspace = true }
 thousands = { workspace = true }
 tokio = { workspace = true }
+triomphe = { workspace = true }
 
 [lib]
 doctest = false

--- a/aptos-move/e2e-move-tests/src/tests/mod.rs
+++ b/aptos-move/e2e-move-tests/src/tests/mod.rs
@@ -69,6 +69,7 @@ mod remote_state;
 mod resource_groups;
 mod rotate_auth_key;
 mod scripts;
+mod sessions_with_delayed_fields;
 mod simple_defi;
 mod smart_data_structures;
 mod stake;

--- a/aptos-move/e2e-move-tests/src/tests/session.data/pack/Move.toml
+++ b/aptos-move/e2e-move-tests/src/tests/session.data/pack/Move.toml
@@ -1,0 +1,6 @@
+[package]
+name = "session"
+version = "0.0.0"
+
+[dependencies]
+AptosFramework = { local = "../../../../../framework/aptos-framework" }

--- a/aptos-move/e2e-move-tests/src/tests/session.data/pack/sources/session.move
+++ b/aptos-move/e2e-move-tests/src/tests/session.data/pack/sources/session.move
@@ -1,0 +1,175 @@
+module 0x1::session {
+    use std::signer;
+    use std::vector;
+    use aptos_framework::aggregator_v2::{Aggregator, Self};
+
+    fun init_module(account: &signer) {
+        let test_1 = Test1 {
+            data: vector::empty<u64>(),
+            aggregator: aggregator_v2::create_unbounded_aggregator<u64>(),
+        };
+        move_to(account, test_1);
+
+        let test_2 = Test2 {
+            aggregator: aggregator_v2::create_unbounded_aggregator<u64>(),
+        };
+        move_to(account, test_2);
+
+        let b1 = BGroup1 {
+            data: vector::singleton(123),
+            aggregator: aggregator_v2::create_unbounded_aggregator<u64>(),
+        };
+        move_to(account, b1);
+    }
+
+    // Testcases:
+
+    struct Test1 has key, drop {
+        data: vector<u64>,
+        aggregator: Aggregator<u64>,
+    }
+
+    struct Test2 has key, drop {
+        aggregator: Aggregator<u64>,
+    }
+
+    struct Tmp has key, drop {
+        data: u128,
+        aggregator: Aggregator<u64>,
+    }
+
+    #[resource_group(scope = global)]
+    struct Group1 {}
+
+    #[resource_group_member(group = 0x1::session::Group1)]
+    struct AGroup1 has key, drop {}
+
+    #[resource_group_member(group = 0x1::session::Group1)]
+    struct BGroup1 has key, drop {
+        data: vector<u128>,
+        aggregator: Aggregator<u64>,
+    }
+
+    #[resource_group(scope = global)]
+    struct Group2 {}
+
+    #[resource_group_member(group = 0x1::session::Group2)]
+    struct AGroup2 has key, drop {
+        data: vector<u128>,
+        aggregator: Aggregator<u64>,
+    }
+
+    #[resource_group_member(group = 0x1::session::Group2)]
+    struct BGroup2 has key, drop {
+        data: vector<u128>,
+    }
+
+    public entry fun test_1_change_resource_size(account: &signer) acquires Test1 {
+        let addr = signer::address_of(account);
+        let resource = borrow_global_mut<Test1>(addr);
+        vector::push_back(&mut resource.data, 1);
+        vector::push_back(&mut resource.data, 2);
+    }
+
+    public entry fun test_1_increment_aggregator(account: &signer) acquires Test1 {
+        let addr = signer::address_of(account);
+        let resource = borrow_global_mut<Test1>(addr);
+        aggregator_v2::add(&mut resource.aggregator, 1);
+    }
+
+    public entry fun test_2_move_aggregator(account: &signer) acquires Test2 {
+        let addr = signer::address_of(account);
+        let Test2 { aggregator } = move_from<Test2>(addr);
+        let tmp = Tmp {
+            data: 12345,
+            aggregator,
+        };
+        move_to(account, tmp);
+    }
+
+    public entry fun test_2_increment_aggregator(account: &signer) acquires Tmp {
+        let addr = signer::address_of(account);
+        let resource = borrow_global_mut<Tmp>(addr);
+        aggregator_v2::add(&mut resource.aggregator, 1);
+    }
+
+    public entry fun test_3_increment_fst_aggregator(account: &signer) acquires Test1 {
+        let addr = signer::address_of(account);
+        let resource = borrow_global_mut<Test1>(addr);
+        aggregator_v2::add(&mut resource.aggregator, 100);
+    }
+
+    public entry fun test_3_increment_snd_aggregator(account: &signer) acquires Test2 {
+        let addr = signer::address_of(account);
+        let resource = borrow_global_mut<Test2>(addr);
+        aggregator_v2::add(&mut resource.aggregator, 200);
+    }
+
+    public entry fun test_4_write_fst_resource(account: &signer) acquires Test1 {
+        let addr = signer::address_of(account);
+        let resource = borrow_global_mut<Test1>(addr);
+        vector::push_back(&mut resource.data, 1);
+        vector::push_back(&mut resource.data, 2);
+        vector::push_back(&mut resource.data, 3);
+    }
+
+    public entry fun test_4_write_snd_resource(account: &signer) acquires Test2 {
+        let addr = signer::address_of(account);
+        let resource = borrow_global_mut<Test2>(addr);
+        *resource = Test2 {
+            aggregator: aggregator_v2::create_unbounded_aggregator<u64>(),
+        };
+    }
+
+    public entry fun test_5_change_resource_group_size(account: &signer){
+        move_to(account, AGroup1 {})
+    }
+
+    public entry fun test_5_increment_aggregator(account: &signer) acquires BGroup1 {
+        let addr = signer::address_of(account);
+        let resource = borrow_global_mut<BGroup1>(addr);
+        aggregator_v2::add(&mut resource.aggregator, 1);
+    }
+
+    public entry fun test_6_move_aggregator_between_groups(account: &signer) acquires BGroup1 {
+        let addr = signer::address_of(account);
+        let BGroup1 { data: _, aggregator } = move_from<BGroup1>(addr);
+        let a2 = AGroup2 {
+            data: vector::singleton(1),
+            aggregator,
+        };
+        move_to(account, a2);
+    }
+
+    public entry fun test_6_increment_aggregator(account: &signer) acquires AGroup2 {
+        let addr = signer::address_of(account);
+        let resource = borrow_global_mut<AGroup2>(addr);
+        aggregator_v2::add(&mut resource.aggregator, 1);
+    }
+
+    public entry fun test_7_move_aggregator_from_group_to_resource(account: &signer) acquires BGroup1 {
+        let addr = signer::address_of(account);
+        let BGroup1 { data: _, aggregator } = move_from<BGroup1>(addr);
+        let tmp = Tmp {
+            data: 0,
+            aggregator,
+        };
+        move_to(account, tmp);
+    }
+
+    public entry fun test_7_increment_aggregator(account: &signer) acquires Tmp {
+        let addr = signer::address_of(account);
+        let resource = borrow_global_mut<Tmp>(addr);
+        aggregator_v2::add(&mut resource.aggregator, 1);
+    }
+
+    /// Full WRITE of a group member's non-delayed field (BGroup1.data) WITHOUT touching the
+    /// aggregator. Produces a `WriteResourceGroup` on Group1 with the aggregator left as a
+    /// placeholder, so it can be paired to construct `WriteResourceGroup`-vs-* arms while the
+    /// aggregator value flows through the delayed-field change set.
+    public entry fun test_8_write_group_member_data(account: &signer) acquires BGroup1 {
+        let addr = signer::address_of(account);
+        let resource = borrow_global_mut<BGroup1>(addr);
+        vector::push_back(&mut resource.data, 999);
+    }
+}

--- a/aptos-move/e2e-move-tests/src/tests/sessions_with_delayed_fields.rs
+++ b/aptos-move/e2e-move-tests/src/tests/sessions_with_delayed_fields.rs
@@ -1,0 +1,602 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Cross-session delayed-field squash regression matrix (harness originally from
+//! aptos-core-private #292). Each scenario runs two VM sessions over a test-only `0x1::session`
+//! package — session_1 transforms a delayed-field container, session_2 touches the aggregator —
+//! then squashes their change sets, exactly mirroring the prologue/user/epilogue interaction but
+//! with full control over both sessions. Asserted under the STRICT resource-group squash
+//! (`gas_feature_version >= RELEASE_V1_46`): benign delta+delta flows and disjoint controls
+//! succeed with correct materialized values, while cross-session structural cases fail closed with
+//! the exact expected error (see `session.move` for the scenarios).
+
+use crate::{assert_success, tests::common, MoveHarness};
+use aptos_aggregator::{
+    delayed_change::DelayedChange, delta_change_set::DeltaOp, resolver::TDelayedFieldView,
+    types::DelayedFieldValue,
+};
+use aptos_block_executor::{
+    code_cache_global_manager::AptosModuleCacheManagerGuard,
+    executor::BlockExecutor,
+    task::{
+        AfterMaterializationOutput, BeforeMaterializationOutput, ExecutionStatus, ExecutorTask,
+        TransactionOutput,
+    },
+    txn_commit_hook::NoOpTransactionCommitHook,
+    txn_provider::default::DefaultTxnProvider,
+    types::InputOutputKey,
+};
+use aptos_gas_schedule::LATEST_GAS_FEATURE_VERSION;
+use aptos_mvhashmap::types::TxnIndex;
+use aptos_types::{
+    block_executor::{
+        config::BlockExecutorConfig, transaction_slice_metadata::TransactionSliceMetadata,
+    },
+    contract_event::ContractEvent,
+    error::PanicError,
+    fee_statement::FeeStatement,
+    state_store::{state_key::StateKey, state_value::StateValueMetadata, TStateView},
+    transaction::{AuxiliaryInfo, BlockExecutableTransaction},
+    write_set::WriteOp,
+};
+use aptos_vm::{
+    move_vm_ext::{
+        session::view_with_change_set::new_for_executor_view_with_change_set_for_test,
+        AptosMoveResolver, SessionId,
+    },
+    AptosVM,
+};
+use aptos_vm_environment::environment::AptosEnvironment;
+use aptos_vm_types::{
+    change_set::VMChangeSet,
+    module_and_script_storage::code_storage::AptosCodeStorage,
+    module_write_set::ModuleWrite,
+    resolver::{
+        BlockSynchronizationKillSwitch, ExecutorView, ResourceGroupSize, ResourceGroupView,
+    },
+    storage::change_set_configs::ChangeSetConfigs,
+};
+use claims::assert_ok;
+use move_core_types::{
+    account_address::AccountAddress,
+    identifier::Identifier,
+    language_storage::{ModuleId, StructTag},
+    value::{MoveTypeLayout, MoveValue},
+    vm_status::{StatusCode, VMStatus},
+};
+use move_vm_runtime::{
+    execution_tracing::Trace,
+    module_traversal::{TraversalContext, TraversalStorage},
+    ModuleStorage,
+};
+use move_vm_types::{delayed_values::delayed_field_id::DelayedFieldID, gas::UnmeteredGasMeter};
+use once_cell::sync::OnceCell;
+use std::{
+    collections::{BTreeMap, HashMap, HashSet},
+    str::FromStr,
+    sync::{Mutex, OnceLock},
+};
+
+/// What we expect a scenario to do once squashed.
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum Expected {
+    /// Squash must fail-closed AND the error must contain every one of these substrings. This pins
+    /// the *exact* failure (status code + the discriminating message), not merely that it failed.
+    Fail(&'static [&'static str]),
+    /// Squash succeeds and the aggregators materialize to exactly these (sorted) values.
+    Values(Vec<u128>),
+}
+
+/// Observed outcome recorded by `execute_transaction` (runs on Block-STM worker threads),
+/// read back and asserted by `testcase`. `Failed` carries the full `{:?}` of the squash error
+/// (which includes the major status code and message) so the exact error can be asserted.
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum Outcome {
+    Ok(Vec<u128>),
+    Failed(String),
+}
+
+fn outcome_cell() -> &'static Mutex<Option<Outcome>> {
+    static CELL: OnceLock<Mutex<Option<Outcome>>> = OnceLock::new();
+    CELL.get_or_init(|| Mutex::new(None))
+}
+use triomphe::Arc as TriompheArc;
+
+struct TestTask {
+    vm: AptosVM,
+}
+
+impl TestTask {
+    fn run(
+        &self,
+        resolver: &impl AptosMoveResolver,
+        module_storage: &impl ModuleStorage,
+        workload: &SessionWorkload,
+    ) -> VMChangeSet {
+        let mut session = self.vm.new_session(resolver, SessionId::Void, None);
+        let traversal_storage = TraversalStorage::new();
+        let mut traversal_ctx = TraversalContext::new(&traversal_storage);
+        let args = vec![MoveValue::Signer(AccountAddress::ONE)
+            .simple_serialize()
+            .unwrap()];
+        let result = session.execute_function_bypass_visibility(
+            &workload.module,
+            workload.function.as_ident_str(),
+            vec![],
+            args,
+            &mut UnmeteredGasMeter,
+            &mut traversal_ctx,
+            module_storage,
+        );
+        assert_ok!(result);
+        let result = session.finish(
+            &ChangeSetConfigs::unlimited_at_gas_feature_version(LATEST_GAS_FEATURE_VERSION),
+            module_storage,
+        );
+        assert_ok!(result)
+    }
+}
+
+#[derive(Clone)]
+struct SessionWorkload {
+    module: ModuleId,
+    function: Identifier,
+}
+
+#[derive(Clone)]
+struct TestTransaction {
+    session_1: SessionWorkload,
+    session_2: SessionWorkload,
+}
+
+impl BlockExecutableTransaction for TestTransaction {
+    type Event = ContractEvent;
+    type Key = StateKey;
+    type Tag = StructTag;
+    type Value = WriteOp;
+
+    fn user_txn_bytes_len(&self) -> usize {
+        0
+    }
+}
+
+#[derive(Debug)]
+struct TestOutput {
+    committed: OnceCell<aptos_types::transaction::TransactionOutput>,
+}
+
+impl TransactionOutput for TestOutput {
+    type AfterMaterializationGuard<'a> = &'a Self;
+    type BeforeMaterializationGuard<'a> = &'a Self;
+    type Txn = TestTransaction;
+
+    fn committed_output(&self) -> &OnceCell<aptos_types::transaction::TransactionOutput> {
+        &self.committed
+    }
+
+    fn skip_output() -> Self {
+        Self {
+            committed: OnceCell::new(),
+        }
+    }
+
+    fn discard_output(_discard_code: StatusCode) -> Self {
+        Self {
+            committed: OnceCell::new(),
+        }
+    }
+
+    fn before_materialization(&self) -> Result<Self::BeforeMaterializationGuard<'_>, PanicError> {
+        Ok(self)
+    }
+
+    fn after_materialization(&self) -> Result<Self::AfterMaterializationGuard<'_>, PanicError> {
+        Ok(self)
+    }
+
+    fn is_materialized_and_success(&self) -> bool {
+        true
+    }
+
+    fn check_materialization(&self) -> Result<bool, PanicError> {
+        Ok(true)
+    }
+
+    fn incorporate_materialized_txn_output(
+        &mut self,
+        _aggregator_v1_writes: Vec<(StateKey, WriteOp)>,
+        _patched_resource_write_set: Vec<(StateKey, WriteOp)>,
+        _patched_events: Vec<ContractEvent>,
+    ) -> Result<Trace, PanicError> {
+        Ok(Trace::empty())
+    }
+
+    fn set_txn_output_for_non_dynamic_change_set(&mut self) {}
+
+    fn legacy_sequential_materialize_agg_v1(
+        &mut self,
+        _view: &impl aptos_aggregator::resolver::TAggregatorV1View<Identifier = StateKey>,
+    ) {
+    }
+}
+
+impl BeforeMaterializationOutput<TestTransaction> for &TestOutput {
+    fn resource_write_set(
+        &self,
+    ) -> HashMap<StateKey, (TriompheArc<WriteOp>, Option<TriompheArc<MoveTypeLayout>>)> {
+        HashMap::new()
+    }
+
+    fn module_write_set(&self) -> &BTreeMap<StateKey, ModuleWrite<WriteOp>> {
+        static EMPTY: OnceCell<BTreeMap<StateKey, ModuleWrite<WriteOp>>> = OnceCell::new();
+        EMPTY.get_or_init(BTreeMap::new)
+    }
+
+    fn aggregator_v1_write_set(&self) -> BTreeMap<StateKey, WriteOp> {
+        BTreeMap::new()
+    }
+
+    fn aggregator_v1_delta_set(&self) -> BTreeMap<StateKey, DeltaOp> {
+        BTreeMap::new()
+    }
+
+    fn delayed_field_change_set(&self) -> BTreeMap<DelayedFieldID, DelayedChange<DelayedFieldID>> {
+        BTreeMap::new()
+    }
+
+    fn reads_needing_delayed_field_exchange(
+        &self,
+    ) -> Vec<(StateKey, StateValueMetadata, TriompheArc<MoveTypeLayout>)> {
+        vec![]
+    }
+
+    fn group_reads_needing_delayed_field_exchange(&self) -> Vec<(StateKey, StateValueMetadata)> {
+        vec![]
+    }
+
+    fn get_events(&self) -> Vec<(ContractEvent, Option<MoveTypeLayout>)> {
+        vec![]
+    }
+
+    fn resource_group_write_set(
+        &self,
+    ) -> HashMap<
+        StateKey,
+        (
+            WriteOp,
+            ResourceGroupSize,
+            BTreeMap<StructTag, (WriteOp, Option<TriompheArc<MoveTypeLayout>>)>,
+        ),
+    > {
+        HashMap::new()
+    }
+
+    fn for_each_resource_key_no_aggregator_v1(
+        &self,
+        _callback: &mut dyn FnMut(&StateKey) -> Result<(), PanicError>,
+    ) -> Result<(), PanicError> {
+        Ok(())
+    }
+
+    fn for_each_resource_group_key_and_tags(
+        &self,
+        _callback: &mut dyn FnMut(&StateKey, HashSet<&StructTag>) -> Result<(), PanicError>,
+    ) -> Result<(), PanicError> {
+        Ok(())
+    }
+
+    fn fee_statement(&self) -> FeeStatement {
+        FeeStatement::zero()
+    }
+
+    fn has_new_epoch_event(&self) -> bool {
+        false
+    }
+
+    fn output_approx_size(&self) -> u64 {
+        0
+    }
+
+    fn get_write_summary(&self) -> HashSet<InputOutputKey<StateKey, StructTag>> {
+        HashSet::new()
+    }
+}
+
+impl AfterMaterializationOutput<TestTransaction> for &TestOutput {
+    fn fee_statement(&self) -> FeeStatement {
+        FeeStatement::zero()
+    }
+
+    fn has_new_epoch_event(&self) -> bool {
+        false
+    }
+}
+
+impl ExecutorTask for TestTask {
+    type AuxiliaryInfo = AuxiliaryInfo;
+    type Error = VMStatus;
+    type Output = TestOutput;
+    type Txn = TestTransaction;
+
+    fn init(
+        environment: &AptosEnvironment,
+        _state_view: &impl TStateView<Key = StateKey>,
+        async_runtime_checks_enabled: bool,
+    ) -> Self {
+        assert!(environment.vm_config().delayed_field_optimization_enabled);
+        let vm = AptosVM::new_for_block_executor(environment, async_runtime_checks_enabled);
+        Self { vm }
+    }
+
+    fn execute_transaction(
+        &self,
+        view: &(impl ExecutorView
+              + ResourceGroupView
+              + AptosCodeStorage
+              + BlockSynchronizationKillSwitch),
+        txn: &Self::Txn,
+        _auxiliary_info: &Self::AuxiliaryInfo,
+        _txn_idx: TxnIndex,
+    ) -> ExecutionStatus<Self::Output, Self::Error> {
+        let resolver = self.vm.as_move_resolver_with_group_view(view);
+        let mut change_set_1 = self.run(&resolver, view, &txn.session_1);
+        println!("  [session_1] change set: {:?}", change_set_1);
+
+        let new_view =
+            new_for_executor_view_with_change_set_for_test(view, view, change_set_1.clone());
+        let new_resolver = self.vm.as_move_resolver_with_group_view(&new_view);
+        let change_set_2 = self.run(&new_resolver, view, &txn.session_2);
+        println!("  [session_2] change set: {:?}", change_set_2);
+
+        // Use the strict (gas_feature_version >= RELEASE_V1_46) resource-group squash, matching
+        // production behavior at the latest gas feature version.
+        let outcome = match change_set_1.squash_additional_change_set(change_set_2, true) {
+            Ok(()) => {
+                // Resolve every aggregator in the SQUASHED change set to its final, materialized
+                // value (base value + recorded change), via a layered view over the base. This
+                // proves the squash result is semantically correct, not merely non-aborting.
+                let final_view = new_for_executor_view_with_change_set_for_test(
+                    view,
+                    view,
+                    change_set_1.clone(),
+                );
+                let mut vals: Vec<u128> = vec![];
+                for id in change_set_1.delayed_field_change_set().keys() {
+                    match final_view.get_delayed_field_value(id) {
+                        Ok(DelayedFieldValue::Aggregator(v)) => vals.push(v),
+                        other => panic!("unexpected delayed field value for {id:?}: {other:?}"),
+                    }
+                }
+                vals.sort();
+                println!("  SQUASH OK; resolved aggregator values = {vals:?}");
+                Outcome::Ok(vals)
+            },
+            Err(e) => {
+                // NOTE: this is the RAW squash error (a `code_invariant_error`, status
+                // DELAYED_FIELD_OR_BLOCKSTM_CODE_INVARIANT_ERROR) because the harness calls
+                // `squash_additional_change_set` directly. In the real VM, the epilogue's
+                // `RespawnedSession::finish_with_squashed_change_set` catches any squash error and
+                // remaps it to `UNKNOWN_INVARIANT_VIOLATION_ERROR`, so the on-chain transaction is a
+                // terminal `Keep(MiscellaneousError)` (gas charged) -- not a Block-STM fatal.
+                let detail = format!("{:?}", e);
+                println!("  SQUASH FAILED: {detail}");
+                Outcome::Failed(detail)
+            },
+        };
+        *outcome_cell().lock().unwrap() = Some(outcome);
+
+        ExecutionStatus::Success(TestOutput {
+            committed: OnceCell::new(),
+        })
+    }
+
+    fn is_transaction_dynamic_change_set_capable(_txn: &Self::Txn) -> bool {
+        unreachable!("Never used for tests")
+    }
+}
+
+fn testcase(label: &str, txn: TestTransaction, expected: Expected) {
+    println!("######## SCENARIO: {label} ########");
+    *outcome_cell().lock().unwrap() = None;
+    let mut h = MoveHarness::new();
+    let path = common::test_dir_path("session.data/pack");
+    let account = h.new_account_at(AccountAddress::ONE);
+    assert_success!(h.publish_package(&account, &path));
+
+    let state_view = h.executor.get_state_view();
+    let txn_provider =
+        DefaultTxnProvider::<TestTransaction, AuxiliaryInfo>::new_without_info(vec![txn]);
+    let mut guard = AptosModuleCacheManagerGuard::none_with_delayed_fields_for_testing(state_view);
+    let executor = BlockExecutor::<
+        TestTransaction,
+        TestTask,
+        _,
+        NoOpTransactionCommitHook<TestOutput>,
+        DefaultTxnProvider<TestTransaction, AuxiliaryInfo>,
+        AuxiliaryInfo,
+    >::new(BlockExecutorConfig::new_maybe_block_limit(2, None), None);
+    let _ = executor.execute_transactions_parallel_for_testing(
+        &txn_provider,
+        state_view,
+        &TransactionSliceMetadata::unknown(),
+        &mut guard,
+    );
+
+    let observed = outcome_cell()
+        .lock()
+        .unwrap()
+        .clone()
+        .expect("execute_transaction must have recorded an outcome");
+    match (&expected, &observed) {
+        (Expected::Fail(needles), Outcome::Failed(detail)) => {
+            for needle in *needles {
+                assert!(
+                    detail.contains(needle),
+                    "[{label}] error did not contain expected substring.\n  expected substring: {needle}\n  actual error: {detail}"
+                );
+            }
+            println!("  => MATCH: fail-closed with the exact expected error");
+        },
+        (Expected::Values(exp), Outcome::Ok(got)) => {
+            assert_eq!(
+                got, exp,
+                "[{label}] aggregator values wrong: got {got:?}, expected {exp:?}"
+            );
+            println!("  => MATCH: squash OK and values correct {got:?}");
+        },
+        (exp, got) => panic!("[{label}] outcome mismatch: expected {exp:?}, observed {got:?}"),
+    }
+}
+
+fn test_txn(session_1_function: &str, session_2_function: &str) -> TestTransaction {
+    let module = ModuleId::from_str("0x1::session").unwrap();
+    TestTransaction {
+        session_1: SessionWorkload {
+            module: module.clone(),
+            function: Identifier::new(session_1_function).unwrap(),
+        },
+        session_2: SessionWorkload {
+            module,
+            function: Identifier::new(session_2_function).unwrap(),
+        },
+    }
+}
+
+#[test]
+fn test_session_with_delayed_fields() {
+    // Block-STM + Move VM recursion needs a large stack; run off the default test thread.
+    std::thread::Builder::new()
+        .stack_size(128 * 1024 * 1024)
+        .spawn(run_all_scenarios)
+        .unwrap()
+        .join()
+        .unwrap();
+}
+
+fn run_all_scenarios() {
+    // (label, session_1, session_2, expected), asserted under the STRICT resource-group squash
+    // (gas_feature_version >= RELEASE_V1_46). Cross-session structural cases fail closed with the
+    // exact error; benign delta+delta flows and disjoint controls succeed with correct values.
+    let scenarios = [
+        // NORMAL concurrent-FA flow: same aggregator delta'd in BOTH sessions, NO structural
+        // change (user-session transfer delta + epilogue gas delta). Must stay allowed + correct.
+        (
+            "N1 normal GROUP delta+delta (FA flow)",
+            "test_5_increment_aggregator",
+            "test_5_increment_aggregator",
+            Expected::Values(vec![2]),
+        ),
+        (
+            "N2 normal standalone delta+delta",
+            "test_1_increment_aggregator",
+            "test_1_increment_aggregator",
+            Expected::Values(vec![2]),
+        ),
+        (
+            "1 standalone resource resize + agg",
+            "test_1_change_resource_size",
+            "test_1_increment_aggregator",
+            Expected::Fail(&[
+                "DELAYED_FIELD_OR_BLOCKSTM_CODE_INVARIANT_ERROR",
+                "Refusing to squash a resource write with a later in-place delayed-field change on the same key (fail-closed for safety)",
+                "Resource(0x1::session::Test1)",
+                "into InPlaceDelayedFieldChange",
+            ]),
+        ),
+        (
+            "2 move agg between resources",
+            "test_2_move_aggregator",
+            "test_2_increment_aggregator",
+            Expected::Fail(&[
+                "DELAYED_FIELD_OR_BLOCKSTM_CODE_INVARIANT_ERROR",
+                "Trying to squash incompatible writes",
+                "Resource(0x1::session::Test2)",
+                "into InPlaceDelayedFieldChange",
+            ]),
+        ),
+        (
+            "3 two aggregators",
+            "test_3_increment_fst_aggregator",
+            "test_3_increment_snd_aggregator",
+            Expected::Values(vec![100, 200]),
+        ),
+        (
+            "4 write/overwrite resources",
+            "test_4_write_fst_resource",
+            "test_4_write_snd_resource",
+            Expected::Values(vec![0]),
+        ),
+        (
+            "5 GROUP grow (sibling) + agg",
+            "test_5_change_resource_group_size",
+            "test_5_increment_aggregator",
+            Expected::Fail(&[
+                "DELAYED_FIELD_OR_BLOCKSTM_CODE_INVARIANT_ERROR",
+                "Refusing to squash a resource-group write with a later in-place delayed-field change on the same group (fail-closed for safety)",
+                "ResourceGroup(0x1::session::Group1)",
+                "materialized_size: 84",
+            ]),
+        ),
+        (
+            "6 move agg between groups",
+            "test_6_move_aggregator_between_groups",
+            "test_6_increment_aggregator",
+            Expected::Fail(&[
+                "DELAYED_FIELD_OR_BLOCKSTM_CODE_INVARIANT_ERROR",
+                "Refusing to squash a resource-group write with a later in-place delayed-field change on the same group (fail-closed for safety)",
+                "ResourceGroup(0x1::session::Group1)",
+                "materialized_size: 84",
+            ]),
+        ),
+        (
+            "7 move agg group->resource",
+            "test_7_move_aggregator_from_group_to_resource",
+            "test_7_increment_aggregator",
+            Expected::Fail(&[
+                "DELAYED_FIELD_OR_BLOCKSTM_CODE_INVARIANT_ERROR",
+                "Refusing to squash a resource-group write with a later in-place delayed-field change on the same group (fail-closed for safety)",
+                "ResourceGroup(0x1::session::Group1)",
+                "materialized_size: 84",
+            ]),
+        ),
+        // ---- Additional delayed-field arm coverage (understand each squash arm's behavior) ----
+        // GROUP, reverse of #5: session_1 deltas the group aggregator (RG-InPlace), session_2 does
+        // a full group write (WriteResourceGroup). This is the OVERWRITE arm
+        // `RG-InPlace ⊕ WriteResourceGroup` — must succeed AND the later session must read the
+        // earlier delta (resolved value proves it).
+        (
+            "8 group RG-InPlace then WriteResourceGroup (overwrite)",
+            "test_5_increment_aggregator",
+            "test_5_change_resource_group_size",
+            Expected::Values(vec![1]),
+        ),
+        // GROUP: two full group writes `WriteResourceGroup ⊕ WriteResourceGroup` (merge), neither
+        // touches the aggregator.
+        (
+            "9 group WriteResourceGroup then WriteResourceGroup (merge)",
+            "test_5_change_resource_group_size",
+            "test_8_write_group_member_data",
+            Expected::Values(vec![]),
+        ),
+        // STANDALONE, reverse of #1: session_1 deltas the resource aggregator (InPlace), session_2
+        // rewrites the resource (WriteWithDelayedFields). OVERWRITE arm
+        // `InPlaceDelayedFieldChange ⊕ WriteWithDelayedFields` — must succeed and carry the delta.
+        (
+            "10 standalone InPlace then WriteWithDelayedFields (overwrite)",
+            "test_1_increment_aggregator",
+            "test_1_change_resource_size",
+            Expected::Values(vec![1]),
+        ),
+        // STANDALONE: two full resource writes `WriteWithDelayedFields ⊕ WriteWithDelayedFields`
+        // (merge), neither touches the aggregator.
+        (
+            "11 standalone WriteWithDelayedFields x2 (merge)",
+            "test_1_change_resource_size",
+            "test_4_write_fst_resource",
+            Expected::Values(vec![]),
+        ),
+    ];
+    for (label, s1, s2, expected) in scenarios {
+        testcase(label, test_txn(s1, s2), expected);
+    }
+}

--- a/aptos-move/vm-genesis/src/lib.rs
+++ b/aptos-move/vm-genesis/src/lib.rs
@@ -231,7 +231,8 @@ pub fn encode_aptos_mainnet_genesis_transaction(
         HashValue::new(new_id),
         framework,
     );
-    assert_ok!(change_set.squash_additional_change_set(additional_change_set));
+    // Genesis runs at the latest gas feature version, so use the strict resource-group squash.
+    assert_ok!(change_set.squash_additional_change_set(additional_change_set, true));
 
     let change_set = assert_ok!(change_set.try_combine_into_storage_change_set(module_write_set));
     verify_genesis_module_write_set(change_set.write_set());
@@ -404,7 +405,8 @@ pub fn encode_genesis_change_set(
         HashValue::new(new_id),
         framework,
     );
-    assert_ok!(change_set.squash_additional_change_set(additional_change_set));
+    // Genesis runs at the latest gas feature version, so use the strict resource-group squash.
+    assert_ok!(change_set.squash_additional_change_set(additional_change_set, true));
 
     let change_set = assert_ok!(change_set.try_combine_into_storage_change_set(module_write_set));
     verify_genesis_module_write_set(change_set.write_set());


### PR DESCRIPTION
## What

Harden the cross-session `VMChangeSet` squash. When an earlier session wrote a **full value** (a standalone resource or a resource group) and a later session (e.g. the gas epilogue exchanging an aggregator in it) produces an **in-place delayed-field change** on the same key, we previously allowed the merge whenever the materialized sizes happened to match. A matching size does **not** prove the later session's delayed-field exchange reconciles with what the earlier session wrote, so this could in principle silently mis-merge a value that holds asset balances.

This PR rejects **both** such arms outright — **fail-closed** (the transaction aborts, no change set is applied):

- `WriteResourceGroup ⊕ ResourceGroupInPlaceDelayedFieldChange`
- `WriteWithDelayedFields ⊕ InPlaceDelayedFieldChange`

## Gating (consensus-safety)

Consensus-observable (it alters which transactions succeed), so gated on **`gas_feature_version >= RELEASE_V1_46`** via `ChangeSetConfigs::strict_delayed_field_squash()`:

- Below the version it is a **byte-for-byte no-op** — historical blocks on every chain replay with the prior behavior (no state-sync/replay divergence).
- A fresh gas-version threshold is in the future for every existing chain (including testnet/devnet where `CONCURRENT_FUNGIBLE_BALANCE` is default-on), so activation is a clean epoch boundary everywhere.

**Why gas version rather than a feature flag:** monotonic VM execution-semantics change (a safety rule that should never be toggled off), and resource-group *size* semantics are already gas-version-gated (`GroupSizeKind::from_gas_feature_version`).

**Why gate at all (vs. relying on unreachability):** the group arm is reachable because the gas epilogue touches APT `ConcurrentSupply` (a delayed field in `0xa`'s `ObjectGroup`) regardless of `CONCURRENT_FUNGIBLE_BALANCE`, so the change is gated rather than resting on a fragile reachability argument.

> Reviewer note: `RELEASE_V1_46` (50) is below the code's current `LATEST_GAS_FEATURE_VERSION` (`RELEASE_V1_47` = 51). This is intended to land as mainnet's next on-chain bump; if mainnet's on-chain gas version is already >= 50, bump the gate to the next version before merge.

## Tests

- **`aptos-vm-types`**: matching-size `WriteResourceGroup`/`WriteWithDelayedFields` + an in-place delayed-field change is **allowed** under the legacy version and **rejected** under strict (`test_resource_groups_squashing`, `test_squash_standalone_write_then_inplace_delayed_field_gated`).
- **`e2e-move-tests`** (`sessions_with_delayed_fields`): a cross-session matrix over a test-only `0x1::session` package (mirrors prologue/user/epilogue) covering **every** delayed-field squash arm — it **resolves the materialized aggregator value** to prove the overwrite/merge arms preserve the delta (e.g. `RG-InPlace ⊕ WriteResourceGroup` resolves to the correct value, not lost), and asserts the **exact error** for the fail-closed arms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Consensus-visible execution semantics change (which transactions succeed) for resource/group squash involving delayed fields and balances; gated on gas feature version but still alters VM safety behavior at activation.
> 
> **Overview**
> **Fail-closed cross-session squash** when an earlier session produced a **full write** (`WriteWithDelayedFields` or `WriteResourceGroup`) and a later session (e.g. gas epilogue) adds an **in-place delayed-field change** on the **same** key. Matching materialized size no longer authorizes that merge, because it does not prove the delayed-field exchange matches what the earlier session wrote.
> 
> The behavior is gated by **`gas_feature_version >= RELEASE_V1_46`** via `ChangeSetConfigs::strict_delayed_field_squash()` and threaded through `squash_additional_change_set` / `squash_additional_resource_writes`. Below that version, squash stays a **byte-for-byte no-op** for replay. Production paths (`RespawnedSession`, genesis) pass the flag from configs.
> 
> **Tests** cover legacy vs strict in `aptos-vm-types`, plus a new **`e2e-move-tests`** matrix (`sessions_with_delayed_fields`) that runs two VM sessions and asserts exact fail-closed errors or resolved aggregator values. Small **`testing`** hooks expose block-executor and delayed-field module-cache setup for those PoCs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a173acaca9875520bc7ee8e120f56912036bbf2b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->