### PR TITLE
[docker] bump Rust image to 1.94.1

### DIFF
--- a/docker/builder/docker-bake-rust-all.hcl
+++ b/docker/builder/docker-bake-rust-all.hcl
@@ -82,8 +82,8 @@ target "builder-base" {
   target     = "builder-base"
   context    = "."
   contexts = {
-    # Run `docker buildx imagetools inspect rust:1.93.1-trixie` to find the latest multi-platform hash
-    rust = "docker-image://rust:1.93.1-trixie@sha256:ecbe59a8408895edd02d9ef422504b8501dd9fa1526de27a45b73406d734d659"
+    # Run `docker buildx imagetools inspect rust:1.94.1-trixie` to find the latest multi-platform hash
+    rust = "docker-image://rust:1.94.1-trixie@sha256:652612f07bfbbdfa3af34761c1e435094c00dde4a98036132fca28c7bb2b165c"
   }
   args = {
     PROFILE            = "${PROFILE}"

--- a/scripts/update_docker_images.py
+++ b/scripts/update_docker_images.py
@@ -10,7 +10,7 @@ OS = "linux"
 
 IMAGES = {
     "debian": "debian:trixie",
-    "rust": "rust:1.93.1-trixie",
+    "rust": "rust:1.94.1-trixie",
 }
 
 


### PR DESCRIPTION

Update the Docker builder image and the update script from rust:1.93.1-trixie
to rust:1.94.1-trixie, matching the toolchain version in rust-toolchain.toml.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Infrastructure-only version pin updates for the builder image; no application logic changes.
> 
> **Overview**
> Bumps the **Docker build base image** for Rust from `1.93.1-trixie` to **`1.94.1-trixie`**, including the pinned digest in `docker/builder/docker-bake-rust-all.hcl` and the image tag used by `scripts/update_docker_images.py`, so container builds use the same toolchain as `rust-toolchain.toml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f36595076a629d294148b26cd439f8620e12a3f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->