### PR TITLE
[types] Include fee_payer_signer in MAX_NUM_OF_SIGS cap

### DIFF
--- a/types/src/transaction/authenticator.rs
+++ b/types/src/transaction/authenticator.rs
@@ -158,12 +158,15 @@ impl TransactionAuthenticator {
 
     /// Return Ok if all AccountAuthenticator's public keys match their signatures, Err otherwise
     pub fn verify(&self, raw_txn: &RawTransaction) -> Result<()> {
-        let num_sigs: usize = self.sender().number_of_signatures()
-            + self
-                .secondary_signers()
-                .iter()
-                .map(|auth| auth.number_of_signatures())
-                .sum::<usize>();
+        // The cap must include every account authenticator that participates in the
+        // transaction. Using `all_signers()` keeps this count consistent with
+        // `to_single_key_authenticators()` and ensures the fee payer signer (when
+        // present in the FeePayer variant) is not omitted from the global cap.
+        let num_sigs: usize = self
+            .all_signers()
+            .iter()
+            .map(|auth| auth.number_of_signatures())
+            .sum();
         if num_sigs > MAX_NUM_OF_SIGS {
             return Err(Error::new(AuthenticationError::MaxSignaturesExceeded));
         }
@@ -2376,6 +2379,94 @@ mod tests {
         let signed_txn = maul_raw_groth16_txn(pk, sig, raw_txn);
 
         assert!(signed_txn.verify_signature().is_err());
+    }
+
+    /// Regression test for a bug where the global `MAX_NUM_OF_SIGS` cap enforced by
+    /// `TransactionAuthenticator::verify()` for the `FeePayer` variant did not include
+    /// the signatures contributed by the `fee_payer_signer`. With the bug, a transaction
+    /// could carry `MAX_NUM_OF_SIGS` signatures in the sender plus additional signatures
+    /// in the fee payer authenticator and still pass `verify()` — even though
+    /// `all_signers()` / `to_single_key_authenticators()` materialized every one of those
+    /// signatures.
+    #[test]
+    fn fee_payer_total_signatures_count_against_max_sigs_cap() {
+        fn build_multi_key_authenticator(num_sigs: usize) -> AccountAuthenticator {
+            assert!(num_sigs > 0 && num_sigs <= MAX_NUM_OF_SIGS);
+            let mut keys = Vec::with_capacity(num_sigs);
+            for _ in 0..num_sigs {
+                let private_key = Ed25519PrivateKey::generate(&mut rand::thread_rng());
+                keys.push(AnyPublicKey::ed25519(private_key.public_key()));
+            }
+            let multi_key = MultiKey::new(keys, num_sigs as u8).unwrap();
+            let signatures: Vec<(u8, AnySignature)> = (0..num_sigs as u8)
+                .map(|i| (i, AnySignature::ed25519(Ed25519Signature::dummy_signature())))
+                .collect();
+            let mk_auth = MultiKeyAuthenticator::new(multi_key, signatures).unwrap();
+            assert_eq!(mk_auth.signatures().len(), num_sigs);
+            AccountAuthenticator::multi_key(mk_auth)
+        }
+
+        let raw_txn = {
+            let sender_key = Ed25519PrivateKey::generate_for_testing();
+            let sender_addr =
+                AuthenticationKey::ed25519(&sender_key.public_key()).account_address();
+            crate::test_helpers::transaction_test_helpers::get_test_signed_transaction(
+                sender_addr,
+                0,
+                &sender_key,
+                sender_key.public_key(),
+                None,
+                0,
+                0,
+                None,
+            )
+            .into_raw_transaction()
+        };
+
+        // 32 (sender) + 1 (fee payer) = 33 total. Without counting the fee payer signer
+        // against the cap this would erroneously pass; with the fix it must fail with
+        // `MaxSignaturesExceeded`.
+        let over_cap = TransactionAuthenticator::fee_payer(
+            build_multi_key_authenticator(MAX_NUM_OF_SIGS),
+            vec![],
+            vec![],
+            AccountAddress::random(),
+            build_multi_key_authenticator(1),
+        );
+        let err = over_cap
+            .verify(&raw_txn)
+            .expect_err("fee payer signatures must count against MAX_NUM_OF_SIGS");
+        assert_eq!(
+            err.downcast::<AuthenticationError>().unwrap(),
+            AuthenticationError::MaxSignaturesExceeded,
+        );
+        // Sanity check: `all_signers()` does see every signature.
+        let total_sigs: usize = over_cap
+            .all_signers()
+            .iter()
+            .map(|a| a.number_of_signatures())
+            .sum();
+        assert_eq!(total_sigs, MAX_NUM_OF_SIGS + 1);
+
+        // Boundary: sender + secondary + fee payer signers that together sum to exactly
+        // `MAX_NUM_OF_SIGS` must pass the cap check (signature verification itself is
+        // expected to fail later because the dummy signatures are not valid, but the
+        // cap-check error must not be the one raised).
+        let at_cap = TransactionAuthenticator::fee_payer(
+            build_multi_key_authenticator(MAX_NUM_OF_SIGS / 2),
+            vec![],
+            vec![],
+            AccountAddress::random(),
+            build_multi_key_authenticator(MAX_NUM_OF_SIGS / 2),
+        );
+        match at_cap.verify(&raw_txn) {
+            Ok(()) => {},
+            Err(e) => assert!(
+                e.downcast_ref::<AuthenticationError>()
+                    != Some(&AuthenticationError::MaxSignaturesExceeded),
+                "exactly MAX_NUM_OF_SIGS signatures must not trip the cap, got: {e:?}",
+            ),
+        }
     }
 
     #[test]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

`TransactionAuthenticator::verify()` enforces a global cap of `MAX_NUM_OF_SIGS = 32` signatures per transaction across every participating account authenticator. For the `FeePayer` variant the cap was computed as:

```rust
sender.number_of_signatures()
    + secondary_signers.iter().map(|a| a.number_of_signatures()).sum::<usize>()
```

This omitted `fee_payer_signer.number_of_signatures()`, even though `all_signers()` (and therefore `to_single_key_authenticators()`) *does* include the fee payer signer. The result is a mismatch between:

- the number of signatures the cap counts,
- the number of real signatures present in the transaction, and
- the number of single-key authenticators materialized downstream.

Concretely, a `FeePayer` transaction whose sender is a 32-of-32 `MultiKey` and whose fee payer is a 32-of-32 `MultiKey` carries 64 real signatures but the cap check sees only 32, so the transaction passes `TransactionAuthenticator::verify()`, `SignedTransaction::verify_signature()`, and `SignedTransaction::check_signature()` — bypassing the resource bound that the cap is intended to enforce.

This change replaces the manual `sender + secondary_signers` sum with `all_signers()`, which already returns every account authenticator participating in the transaction (sender + secondary signers + fee payer signer if present). After the fix:

- the cap is computed from exactly the same set of authenticators that are later verified and materialized into single-key authenticators;
- the FeePayer variant can no longer be used to smuggle additional signatures past the global cap;
- behavior of every other `TransactionAuthenticator` variant is unchanged (none of them have a fee payer signer, so `all_signers()` yields the same count as the previous expression).

## How Has This Been Tested?

- `cargo test -p aptos-types --lib transaction::authenticator::tests` — all 17 tests pass, including the existing fee-payer / multikey / encrypted-payload coverage and the new regression test.
- New regression test `fee_payer_total_signatures_count_against_max_sigs_cap`:
  - constructs a `FeePayer` with a 32-sig `MultiKey` sender + 1-sig `MultiKey` fee payer (33 total) and asserts `verify()` returns `AuthenticationError::MaxSignaturesExceeded`;
  - cross-checks that `all_signers()` actually sees all 33 signatures;
  - verifies that a boundary case summing to exactly `MAX_NUM_OF_SIGS` across sender + fee payer does **not** trip the cap (it may fail later for unrelated signature-verification reasons because the test uses dummy signatures, but the cap-check error must not be raised).
- Confirmed negative control: with the fix temporarily reverted, the new regression test fails because the cap check is bypassed and execution falls through to signature verification, which then fails for a different reason.

## Key Areas to Review

- `TransactionAuthenticator::verify()` in `types/src/transaction/authenticator.rs` — the only behavioral change. `all_signers()` allocates a `Vec<AccountAuthenticator>` per call, which adds one short-lived allocation on this path; this matches the style already used by `to_single_key_authenticators()` and is dominated by the signature verification work that immediately follows.
- The fix relies on `all_signers()` being the canonical "every participating authenticator" enumeration. Any new `TransactionAuthenticator` variant added in the future must continue to be covered by `all_signers()` so it is also covered by the global cap; the existing exhaustive `match` in `all_signers()` enforces this at compile time.
- The change does not touch the legacy MultiEd25519 cap (`MultiEd25519Signature` has its own structural limits), nor the per-`MultiKey` 32-key cap added in #17006.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [x] Tests

## Which Components or Systems Does This Change Impact?
- [x] Validator Node
- [x] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [x] Other (specify): transaction authentication / mempool admission

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fa392402-e039-4225-9ee2-315295bb9c7b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fa392402-e039-4225-9ee2-315295bb9c7b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

