### PR TITLE
[storage] Add regression test for hash-only HotVacant eviction

### DIFF
--- a/storage/aptosdb/src/db/aptosdb_test.rs
+++ b/storage/aptosdb/src/db/aptosdb_test.rs
@@ -356,6 +356,7 @@ proptest! {
         2,   /* max_user_txns_per_block */
         80,  /* min_blocks */
         120, /* max_blocks */
+        false, /* make_hot_in_epilogue */
     )) {
         aptos_logger::Logger::new().init();
         let tmp_dir = TempPath::new();

--- a/storage/aptosdb/src/db/test_helper.rs
+++ b/storage/aptosdb/src/db/test_helper.rs
@@ -141,6 +141,7 @@ prop_compose! {
         max_user_txns_per_block: usize,
         min_blocks: usize,
         max_blocks: usize,
+        make_hot_in_epilogue: bool,
     )(
         mut universe in any_with::<AccountInfoUniverse>(num_accounts).no_shrink(),
         block_gens in vec(any_with::<BlockGen>(max_user_txns_per_block), min_blocks..=max_blocks),
@@ -152,7 +153,8 @@ prop_compose! {
         let mut result = Vec::new();
 
         for block_gen in block_gens {
-            let (mut txns_to_commit, mut ledger_info) = block_gen.materialize(&mut universe);
+            let (mut txns_to_commit, mut ledger_info) =
+                block_gen.materialize(&mut universe, make_hot_in_epilogue);
             smt = update_in_memory_state(&smt, &root_smt, &txns_to_commit);
             let state_checkpoint_root_hash = smt.root_hash();
 
@@ -209,7 +211,7 @@ pub fn arb_blocks_to_commit_with_block_nums(
     arb_blocks_to_commit_with_params(
         5, /* num_accounts */
         2, /* max_user_txns_per_block */
-        min_blocks, max_blocks,
+        min_blocks, max_blocks, false, /* make_hot_in_epilogue */
     )
 }
 
@@ -218,12 +220,14 @@ pub fn arb_blocks_to_commit_with_params(
     max_user_txns_per_block: usize,
     min_blocks: usize,
     max_blocks: usize,
+    make_hot_in_epilogue: bool,
 ) -> impl Strategy<Value = Vec<(Vec<TransactionToCommit>, LedgerInfoWithSignatures)>> {
     arb_blocks_to_commit_impl(
         num_accounts,
         max_user_txns_per_block,
         min_blocks,
         max_blocks,
+        make_hot_in_epilogue,
     )
 }
 

--- a/storage/aptosdb/src/state_store/tests/restart.rs
+++ b/storage/aptosdb/src/state_store/tests/restart.rs
@@ -116,32 +116,35 @@ fn test_restart_impl(
 }
 
 proptest! {
-    #![proptest_config(ProptestConfig::with_cases(20))]
+    #![proptest_config(ProptestConfig::with_cases(30))]
 
     #[test]
     fn test_restart(
         (input, split_at, max_items_per_shard, buffered_state_target_items)
-            in arb_blocks_to_commit_with_params(
-                10, /* num_accounts */
-                2,  /* max_user_txns_per_block */
-                3,  /* min_blocks */
-                8,  /* max_blocks */
-            ).prop_flat_map(|blocks| {
-                let len = blocks.len();
-                (
-                    Just(blocks),
-                    proptest::collection::vec(any::<bool>(), len),
-                    1usize..len,
-                    1usize..10,
-                    1usize..1000,
-                )
-            }).prop_map(|(blocks, sync_flags, split_at, max_items_per_shard, buffered_state_target_items)| {
-                let input = blocks
-                    .into_iter()
-                    .zip(sync_flags)
-                    .map(|((txns, li), sync)| (txns, li, sync))
-                    .collect::<Vec<_>>();
-                (input, split_at, max_items_per_shard, buffered_state_target_items)
+            in any::<bool>().prop_flat_map(|make_hot_in_epilogue| {
+                arb_blocks_to_commit_with_params(
+                    10, /* num_accounts */
+                    2,  /* max_user_txns_per_block */
+                    3,  /* min_blocks */
+                    8,  /* max_blocks */
+                    make_hot_in_epilogue,
+                ).prop_flat_map(|blocks| {
+                    let len = blocks.len();
+                    (
+                        Just(blocks),
+                        proptest::collection::vec(any::<bool>(), len),
+                        1usize..len,
+                        1usize..10,
+                        1usize..1000,
+                    )
+                }).prop_map(|(blocks, sync_flags, split_at, max_items_per_shard, buffered_state_target_items)| {
+                    let input = blocks
+                        .into_iter()
+                        .zip(sync_flags)
+                        .map(|((txns, li), sync)| (txns, li, sync))
+                        .collect::<Vec<_>>();
+                    (input, split_at, max_items_per_shard, buffered_state_target_items)
+                })
             }),
     ) {
         test_restart_impl(

--- a/types/src/proptest_types.rs
+++ b/types/src/proptest_types.rs
@@ -22,12 +22,12 @@ use crate::{
     proof::TransactionInfoListWithProof,
     state_store::state_key::StateKey,
     transaction::{
-        ChangeSet, EntryFunction, ExecutionStatus, IndexedTransactionSummary, Module, Multisig,
-        MultisigTransactionPayload, RawTransaction, ReplayProtector, Script,
-        SignatureCheckedTransaction, SignedTransaction, Transaction, TransactionArgument,
-        TransactionAuxiliaryData, TransactionExecutable, TransactionExtraConfig, TransactionInfo,
-        TransactionListWithProof, TransactionPayload, TransactionPayloadInner, TransactionStatus,
-        TransactionToCommit, Version, WriteSetPayload,
+        BlockEndInfo, ChangeSet, EntryFunction, ExecutionStatus, FeeDistribution,
+        IndexedTransactionSummary, Module, Multisig, MultisigTransactionPayload, RawTransaction,
+        ReplayProtector, Script, SignatureCheckedTransaction, SignedTransaction, Transaction,
+        TransactionArgument, TransactionAuxiliaryData, TransactionExecutable,
+        TransactionExtraConfig, TransactionInfo, TransactionListWithProof, TransactionPayload,
+        TransactionPayloadInner, TransactionStatus, TransactionToCommit, Version, WriteSetPayload,
     },
     validator_info::ValidatorInfo,
     validator_signer::ValidatorSigner,
@@ -1265,6 +1265,7 @@ impl BlockGen {
     pub fn materialize(
         self,
         universe: &mut AccountInfoUniverse,
+        make_hot_in_epilogue: bool,
     ) -> (Vec<TransactionToCommit>, LedgerInfo) {
         let num_txns = self.txn_gens.len() + 1;
 
@@ -1278,14 +1279,47 @@ impl BlockGen {
             txns_to_commit.push(txn_gen.materialize(universe));
         }
 
+        let (block_ending_txn, write_set) = if make_hot_in_epilogue {
+            // Promote a resource of an account that was never created, so it stays absent and
+            // lands as a `HotVacant` entry. Derive the address from the block version so it differs
+            // per block and cannot collide with the key-hash addresses in the universe.
+            let mut address = [0u8; AccountAddress::LENGTH];
+            address[..std::mem::size_of::<u64>()]
+                .copy_from_slice(&ledger_info.version().to_be_bytes());
+            let to_make_hot = BTreeSet::from([StateKey::resource_typed::<AccountResource>(
+                &AccountAddress::new(address),
+            )
+            .unwrap()]);
+
+            // The promotion has to ride in the write set too, as V1 so the `hotness` bucket survives
+            // serialization across a restart; that's what persists the `HotVacant`.
+            let mut write_set = WriteSet::default();
+            write_set.add_hotness(to_make_hot.clone());
+
+            (
+                Transaction::block_epilogue_v2(
+                    HashValue::random(),
+                    BlockEndInfo::new_empty(),
+                    FeeDistribution::new(BTreeMap::new()),
+                    to_make_hot,
+                ),
+                write_set.into_v1(),
+            )
+        } else {
+            (
+                Transaction::StateCheckpoint(HashValue::random()),
+                WriteSet::default(),
+            )
+        };
+
         txns_to_commit.push(TransactionToCommit::new(
-            Transaction::StateCheckpoint(HashValue::random()),
+            block_ending_txn,
             TransactionInfo::new_placeholder(
                 0,
                 Some(HashValue::random()),
                 ExecutionStatus::Success,
             ),
-            WriteSet::default(),
+            write_set,
             if ledger_info.ends_epoch() {
                 vec![ContractEvent::new_v2(
                     NEW_EPOCH_EVENT_V2_MOVE_TYPE_TAG.clone(),


### PR DESCRIPTION

A `HotVacant` hot-state entry persisted to the hot KV DB reloads after a
restart carrying only its key hash, without the full `StateKey`. Aging out of
the hot LRU untouched, it reaches the snapshot committer's cold JMT pass as a
hash-only `ColdVacant`.

This is currently masked by `3eef0346` (the `LeafEntry` refactor, #19894): the
committer routes slots through `passes_jmt_filter` + `leaf_entry_to_jmt_update`,
which turns a vacant slot into a delete keyed by hash alone and never reads its
`StateKey`. The earlier `maybe_update_jmt` called `expect_state_key()` before
splitting on occupancy, so it panicked on the `state-committer` thread for any
slot lacking a `StateKey`. The eviction now stays a hash-only delete; this test
guards that, and would fire again if a key-dependent vacant path returned.

The restart proptest never reached this: the block generator only emitted value
writes, so no `HotVacant` arose — it needs a `MakeHot` read of an absent key (or
a deletion).

Add a `make_hot_in_epilogue` flag to the block generator. When set, the
block-ending transaction is a `BlockEpilogue::V2` whose `to_make_hot` promotes a
resource of an account that was never created (absent, so it lands as a
`HotVacant`); the epilogue write set carries the same `hotness`, kept as V1 so
it survives the restart replay. This mirrors production, where promotions ride
in the block epilogue. `test_restart` toggles the flag; other generator callers
keep their previous behavior.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only and proptest generator changes; no production storage or consensus logic is modified.
> 
> **Overview**
> Extends AptosDB **proptest block generation** so restart tests can exercise **hash-only `HotVacant`** keys that survive hot KV persistence, LRU aging, and cold JMT eviction.
> 
> A new **`make_hot_in_epilogue`** flag flows through `arb_blocks_to_commit_*` into `BlockGen::materialize`. When enabled, the block-ending txn is **`BlockEpilogue::V2`** with `to_make_hot` on an **never-created** `AccountResource` (address derived from block version), plus a **V1 write set** carrying the same hotness so promotions replay correctly after restart—mirroring production. When disabled, behavior stays **`StateCheckpoint`** + empty write set.
> 
> **`test_restart`** now draws that flag with `any::<bool>()` (30 cases, up from 20). Truncation and other generator callers pass **`false`** so they are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7bb31fd24ade28ba12526f50df5596213871a8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->