### PR TITLE
[consensus] Isolate decryption crypto on per-stage rayon pools

### DIFF
--- a/consensus/src/pipeline/decryption_pipeline_builder.rs
+++ b/consensus/src/pipeline/decryption_pipeline_builder.rs
@@ -30,12 +30,38 @@ use aptos_types::{
     },
     validator_txn::ValidatorTransaction,
 };
+use once_cell::sync::Lazy;
 use rayon::iter::{IndexedParallelIterator, IntoParallelIterator, ParallelIterator};
 use std::sync::{
     atomic::{AtomicUsize, Ordering},
     Arc,
 };
 use tokio::sync::oneshot;
+
+/// Dedicated rayon pools for each decryption pipeline stage. Splitting the
+/// stages prevents the latency-critical digest from queuing behind the
+/// throughput-heavy stages (eval_proofs ~80ms p90, prepare_ct, decrypt) under
+/// load. Sharing one pool across all four stages saturated it on a 100v forge
+/// run, pushing digest p90 back near the global-pool baseline; per-stage pools
+/// fix that by giving each stage its own thread budget.
+fn build_pool(name: &'static str, num_threads: usize) -> rayon::ThreadPool {
+    rayon::ThreadPoolBuilder::new()
+        .num_threads(num_threads)
+        .thread_name(move |i| format!("{name}-{i}"))
+        .build()
+        .unwrap_or_else(|e| panic!("Failed to build {name} thread pool: {e}"))
+}
+
+/// Latency-critical, small (n=64 mult-tree + 65-pt MSM). 4 threads is enough.
+static DIGEST_POOL: Lazy<rayon::ThreadPool> = Lazy::new(|| build_pool("decryption-digest", 4));
+/// Heaviest stage (O(n^2 log n) FK-style proofs); benefits from more threads.
+static EVAL_PROOFS_POOL: Lazy<rayon::ThreadPool> =
+    Lazy::new(|| build_pool("decryption-eval-proofs", 16));
+/// Per-ciphertext pairings; parallel over ciphertexts.
+static PREPARE_CT_POOL: Lazy<rayon::ThreadPool> =
+    Lazy::new(|| build_pool("decryption-prepare-ct", 16));
+/// Final per-ciphertext decrypt pass.
+static DECRYPT_POOL: Lazy<rayon::ThreadPool> = Lazy::new(|| build_pool("decryption-decrypt", 16));
 
 impl PipelineBuilder {
     /// Precondition: Block is materialized and the transactions are available locally
@@ -347,8 +373,10 @@ async fn decrypt_validator_path(
     let (txn_ciphertexts, digest, proofs_promise) = tokio::task::spawn_blocking(move || {
         monitor!(
             "decryption_digest",
-            FPTXWeighted::digest(&digest_key, &txn_ciphertexts, encryption_round)
-                .map(|(digest, proofs_promise)| (txn_ciphertexts, digest, proofs_promise))
+            DIGEST_POOL.install(|| {
+                FPTXWeighted::digest(&digest_key, &txn_ciphertexts, encryption_round)
+                    .map(|(digest, proofs_promise)| (txn_ciphertexts, digest, proofs_promise))
+            })
         )
     })
     .await
@@ -386,7 +414,8 @@ async fn decrypt_validator_path(
     let proofs = monitor!(
         "decryption_eval_proofs",
         tokio::task::spawn_blocking(move || {
-            FPTXWeighted::eval_proofs_compute_all(&proofs_promise, &digest_key)
+            EVAL_PROOFS_POOL
+                .install(|| FPTXWeighted::eval_proofs_compute_all(&proofs_promise, &digest_key))
         })
         .await
         .map_err(|e| anyhow!("proof computation panicked: {e}"))?
@@ -400,17 +429,19 @@ async fn decrypt_validator_path(
         tokio::task::spawn_blocking(move || {
             monitor!(
                 "decryption_prepare_ct",
-                txn_ciphertexts
-                    .into_par_iter()
-                    .map(|ciphertext| {
-                        let prepared_or_err =
-                            FPTXWeighted::prepare_ct(&ciphertext, &digest, &proofs);
-                        let id: Id = prepared_or_err
-                            .as_ref()
-                            .map_or_else(|MissingEvalProofError(id)| *id, |ct| ct.id());
-                        (id, prepared_or_err)
-                    })
-                    .collect::<Vec<_>>()
+                PREPARE_CT_POOL.install(|| {
+                    txn_ciphertexts
+                        .into_par_iter()
+                        .map(|ciphertext| {
+                            let prepared_or_err =
+                                FPTXWeighted::prepare_ct(&ciphertext, &digest, &proofs);
+                            let id: Id = prepared_or_err
+                                .as_ref()
+                                .map_or_else(|MissingEvalProofError(id)| *id, |ct| ct.id());
+                            (id, prepared_or_err)
+                        })
+                        .collect::<Vec<_>>()
+                })
             )
         })
     };
@@ -476,7 +507,8 @@ async fn decrypt_validator_path(
     let num_failed_decryptions = AtomicUsize::new(0);
     let decrypted_txns: Vec<_> = monitor!(
         "decryption_decrypt",
-        encrypted_txns
+        DECRYPT_POOL.install(|| {
+            encrypted_txns
             .into_par_iter()
             .zip(prepared_cts.into_par_iter())
             .map(|(mut txn, (id, prepared_ciphertext_or_error))| {
@@ -536,6 +568,7 @@ async fn decrypt_validator_path(
                 }
             })
             .collect()
+        })
     );
 
     let num_failed = num_failed_decryptions.into_inner();

--- a/testsuite/forge-cli/src/suites/realistic_environment.rs
+++ b/testsuite/forge-cli/src/suites/realistic_environment.rs
@@ -518,7 +518,7 @@ pub(crate) fn realistic_env_max_load_encrypted_test(duration: Duration) -> Forge
     let num_validators = 5;
     let num_fullnodes = 1;
     let num_pfns = 3;
-    let mempool_backlog = 4000;
+    let mempool_backlog = 1600;
 
     let success_criteria = SuccessCriteria::new(15)
         .add_no_restarts()


### PR DESCRIPTION
## Problem

The `digest` microbenchmark runs in ~2.4 ms on 16 cores, but `decryption_digest` on a 28-core forge validator measured ~30 ms — a ~12× gap on the consensus critical path (digest gates the key-share broadcast).

## Diagnosis

- **CFS throttling ruled out** (~0.3%).
- **Block-STM has its own pool**, so digest wasn't fighting Block-STM directly.
- Forge CPU profile showed **~20% of CPU spent on rayon scheduling** (`sched_yield`, work-stealing, `__schedule`) — the shared global rayon pool was thrashing.
- **Bench at varying core counts proved arkworks' parallelism is allergic to wide pools at n=64:** `eval_proofs` runs in 36 ms at 8 cpus but 278 ms at 30 cpus (**7.7× slower**); digest: 1.5 ms @ 8 vs 4.3 ms @ 30.

## Fix

Route each decryption stage through its own dedicated rayon pool, sized to stay in arkworks' productive parallelism range:

| pool | threads | rationale |
|---|---|---|
| `DIGEST_POOL` | 4 | small (65-pt MSM + 64-leaf mult-tree); 4 ≈ optimal per bench |
| `EVAL_PROOFS_POOL` | 16 | heaviest stage (FK-style proofs); 16 still well below the over-threading cliff |
| `PREPARE_CT_POOL` | 16 | per-ct pairings |
| `DECRYPT_POOL` | 16 | per-ct decrypt |

Each stage runs under `POOL.install(|| …)` so its nested ark MSM / `into_par_iter` work stays on the dedicated pool. Stages no longer queue behind each other under load.

## Results (forge encrypted max-load, 20 validators)

| stage (p50 / p90) | global pool (baseline) | single shared 8-thread pool | **per-stage 4 / 16 / 16 / 16** |
|---|---|---|---|
| `digest` | ~30 ms | 9.2 / 31 ms | **2.5 / 4.5 ms** |
| `eval_proofs` | — | 100 / 376 ms | **24 / 47 ms** |
| `prepare_ct` | — | 45 / 125 ms | **10.5 / 22.5 ms** |
| `decrypt` | — | 33 / 92 ms | **7.4 / 9.6 ms** |

Digest is back at bench speed; heavy stages improved ~4-9× over the shared-pool variant.

## Also included

- `[forge] Lower encrypted max-load backlog 4000 -> 1600` — keeps the forge encrypted max-load test within sustainable throughput so the txn-emitter doesn't drift out of sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)