### PR TITLE
[trading-native][state-sync] Native-position fast sync (unified with main state via StateKind)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1241,6 +1241,7 @@ dependencies = [
  "aptos-infallible",
  "aptos-logger",
  "aptos-metrics-core",
+ "aptos-storage-interface",
  "aptos-storage-service-types",
  "aptos-time-service",
  "aptos-types",

--- a/api/src/tests/state_test.rs
+++ b/api/src/tests/state_test.rs
@@ -4,7 +4,7 @@
 use super::{new_test_context, new_test_context_with_orderless_flags};
 use aptos_api_test_context::{current_function_name, TestContext};
 use aptos_sdk::{transaction_builder::aptos_stdlib::aptos_token_stdlib, types::LocalAccount};
-use aptos_storage_interface::DbReader;
+use aptos_storage_interface::{DbReader, StateKind};
 use move_core_types::account_address::AccountAddress;
 use rstest::rstest;
 use serde::Serialize;
@@ -198,7 +198,10 @@ async fn test_merkle_leaves_with_nft_transfer(
 
     let num_leaves_at_beginning = ctx
         .db
-        .get_state_item_count(ctx.db.get_latest_ledger_info_version().unwrap())
+        .get_state_item_count(
+            ctx.db.get_latest_ledger_info_version().unwrap(),
+            StateKind::MainState,
+        )
         .unwrap();
 
     let transfer_to_owner_txn = creator.sign_multi_agent_with_transaction_builder(
@@ -221,7 +224,10 @@ async fn test_merkle_leaves_with_nft_transfer(
     ctx.commit_block(&[transfer_to_owner_txn]).await;
     let num_leaves_after_transfer_nft = ctx
         .db
-        .get_state_item_count(ctx.db.get_latest_ledger_info_version().unwrap())
+        .get_state_item_count(
+            ctx.db.get_latest_ledger_info_version().unwrap(),
+            StateKind::MainState,
+        )
         .unwrap();
     assert_eq!(
         num_leaves_after_transfer_nft,
@@ -248,7 +254,10 @@ async fn test_merkle_leaves_with_nft_transfer(
     ctx.commit_block(&[transfer_to_creator_txn]).await;
     let num_leaves_after_return_nft = ctx
         .db
-        .get_state_item_count(ctx.db.get_latest_ledger_info_version().unwrap())
+        .get_state_item_count(
+            ctx.db.get_latest_ledger_info_version().unwrap(),
+            StateKind::MainState,
+        )
         .unwrap();
 
     assert_eq!(

--- a/peer-monitoring-service/server/src/tests.rs
+++ b/peer-monitoring-service/server/src/tests.rs
@@ -37,7 +37,7 @@ use aptos_peer_monitoring_service_types::{
     },
     PeerMonitoringMetadata, PeerMonitoringServiceError, PeerMonitoringServiceMessage,
 };
-use aptos_storage_interface::{DbReader, LedgerSummary};
+use aptos_storage_interface::{DbReader, LedgerSummary, StateKind};
 use aptos_time_service::{MockTimeService, TimeService};
 use aptos_types::{
     account_address::AccountAddress,
@@ -817,13 +817,14 @@ mod database_mock {
                 ledger_version: Version,
             ) -> Result<TransactionAccumulatorSummary>;
 
-            fn get_state_item_count(&self, version: Version) -> Result<usize>;
+            fn get_state_item_count(&self, version: Version, kind: StateKind) -> Result<usize>;
 
             fn get_state_value_chunk_with_proof(
                 &self,
                 version: Version,
                 start_idx: usize,
                 chunk_size: usize,
+                kind: StateKind,
             ) -> Result<StateValueChunkWithProof>;
 
             fn get_epoch_snapshot_prune_window(&self) -> Result<usize>;

--- a/state-sync/aptos-data-client/src/client.rs
+++ b/state-sync/aptos-data-client/src/client.rs
@@ -30,19 +30,22 @@ use aptos_network::{
     application::{interface::NetworkClient, storage::PeersAndMetadata},
     protocols::network::RpcError,
 };
-use aptos_storage_interface::DbReader;
+use aptos_storage_interface::{DbReader, StateKind};
 use aptos_storage_service_client::StorageServiceClient;
 use aptos_storage_service_types::{
     requests::{
         DataRequest, EpochEndingLedgerInfoRequest, NewTransactionOutputsWithProofRequest,
         NewTransactionsOrOutputsWithProofRequest, NewTransactionsWithProofRequest,
-        StateValuesWithProofRequest, StorageServiceRequest,
-        SubscribeTransactionOutputsWithProofRequest,
+        NumberOfStatesRequestV2, StateValuesWithProofRequest, StateValuesWithProofRequestV2,
+        StorageServiceRequest, SubscribeTransactionOutputsWithProofRequest,
         SubscribeTransactionsOrOutputsWithProofRequest, SubscribeTransactionsWithProofRequest,
         SubscriptionStreamMetadata, TransactionOutputsWithProofRequest,
         TransactionsOrOutputsWithProofRequest, TransactionsWithProofRequest,
     },
-    responses::{StorageServerSummary, StorageServiceResponse, TransactionOrOutputListWithProofV2},
+    responses::{
+        NumberOfStatesResponseV2, StateValueChunkWithProofResponseV2, StorageServerSummary,
+        StorageServiceResponse, TransactionOrOutputListWithProofV2,
+    },
     Epoch, StorageServiceMessage,
 };
 use aptos_time_service::TimeService;
@@ -1034,10 +1037,29 @@ impl AptosDataClientInterface for AptosDataClient {
         &self,
         version: Version,
         request_timeout_ms: u64,
+        kind: StateKind,
     ) -> crate::error::Result<Response<u64>> {
-        let data_request = DataRequest::GetNumberOfStatesAtVersion(version);
-        self.create_and_send_storage_request(request_timeout_ms, data_request)
-            .await
+        // TODO(grao): once the V2 state requests are supported fleet-wide, route
+        // main state through them too (behind a config flag, like
+        // `enable_transaction_data_v2`) and drop the V1 branch / variant.
+        match kind {
+            StateKind::MainState => {
+                let data_request = DataRequest::GetNumberOfStatesAtVersion(version);
+                self.create_and_send_storage_request(request_timeout_ms, data_request)
+                    .await
+            },
+            StateKind::Position => {
+                let data_request =
+                    DataRequest::GetNumberOfStatesAtVersionV2(NumberOfStatesRequestV2 {
+                        version,
+                        state_kind: kind,
+                    });
+                let response: Response<NumberOfStatesResponseV2> = self
+                    .create_and_send_storage_request(request_timeout_ms, data_request)
+                    .await?;
+                Ok(response.map(|response| response.number_of_states))
+            },
+        }
     }
 
     async fn get_state_values_with_proof(
@@ -1046,14 +1068,33 @@ impl AptosDataClientInterface for AptosDataClient {
         start_index: u64,
         end_index: u64,
         request_timeout_ms: u64,
+        kind: StateKind,
     ) -> crate::error::Result<Response<StateValueChunkWithProof>> {
-        let data_request = DataRequest::GetStateValuesWithProof(StateValuesWithProofRequest {
-            version,
-            start_index,
-            end_index,
-        });
-        self.create_and_send_storage_request(request_timeout_ms, data_request)
-            .await
+        match kind {
+            StateKind::MainState => {
+                let data_request =
+                    DataRequest::GetStateValuesWithProof(StateValuesWithProofRequest {
+                        version,
+                        start_index,
+                        end_index,
+                    });
+                self.create_and_send_storage_request(request_timeout_ms, data_request)
+                    .await
+            },
+            StateKind::Position => {
+                let data_request =
+                    DataRequest::GetStateValuesWithProofV2(StateValuesWithProofRequestV2 {
+                        version,
+                        start_index,
+                        end_index,
+                        state_kind: kind,
+                    });
+                let response: Response<StateValueChunkWithProofResponseV2> = self
+                    .create_and_send_storage_request(request_timeout_ms, data_request)
+                    .await?;
+                Ok(response.map(|response| response.state_value_chunk_with_proof))
+            },
+        }
     }
 
     async fn get_transaction_outputs_with_proof(

--- a/state-sync/aptos-data-client/src/interface.rs
+++ b/state-sync/aptos-data-client/src/interface.rs
@@ -2,6 +2,7 @@
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{error, error::Error, global_summary::GlobalDataSummary};
+use aptos_storage_interface::StateKind;
 use aptos_storage_service_types::{responses::TransactionOrOutputListWithProofV2, Epoch};
 use aptos_types::{
     ledger_info::LedgerInfoWithSignatures,
@@ -67,24 +68,27 @@ pub trait AptosDataClientInterface {
         request_timeout_ms: u64,
     ) -> error::Result<Response<(TransactionOrOutputListWithProofV2, LedgerInfoWithSignatures)>>;
 
-    /// Fetches the number of states at the specified version.
+    /// Fetches the number of states at the specified version, for the given
+    /// snapshot store.
     async fn get_number_of_states(
         &self,
         version: Version,
         request_timeout_ms: u64,
+        kind: StateKind,
     ) -> error::Result<Response<u64>>;
 
-    /// Fetches a single state value chunk with proof, containing the values
-    /// from start to end index (inclusive) at the specified version. The proof
-    /// version is the same as the specified version. In some cases, fewer
-    /// state values may be returned (e.g., to tolerate network or chunk
-    /// limits). If the data cannot be fetched, an error is returned.
+    /// Fetches a single state value chunk with proof, containing the values from
+    /// start to end index (inclusive) at the specified version, for the given
+    /// snapshot store. The proof version is the same as the specified version. In
+    /// some cases, fewer state values may be returned (e.g., to tolerate network
+    /// or chunk limits). If the data cannot be fetched, an error is returned.
     async fn get_state_values_with_proof(
         &self,
         version: u64,
         start_index: u64,
         end_index: u64,
         request_timeout_ms: u64,
+        kind: StateKind,
     ) -> error::Result<Response<StateValueChunkWithProof>>;
 
     /// Fetches a transaction output list with proof, with transaction

--- a/state-sync/aptos-data-client/src/tests/mock.rs
+++ b/state-sync/aptos-data-client/src/tests/mock.rs
@@ -27,7 +27,7 @@ use aptos_network::{
 use aptos_peer_monitoring_service_types::{
     response::NetworkInformationResponse, PeerMonitoringMetadata,
 };
-use aptos_storage_interface::DbReader;
+use aptos_storage_interface::{DbReader, StateKind};
 use aptos_storage_service_client::StorageServiceClient;
 use aptos_storage_service_server::network::{NetworkRequest, ResponseSender};
 use aptos_storage_service_types::{
@@ -305,6 +305,7 @@ mock! {
             &self,
             version: Version,
             request_timeout_ms: u64,
+            kind: StateKind,
         ) -> Result<Response<u64>>;
 
         async fn get_state_values_with_proof(
@@ -313,6 +314,7 @@ mock! {
             start_index: u64,
             end_index: u64,
             request_timeout_ms: u64,
+            kind: StateKind,
         ) -> Result<Response<StateValueChunkWithProof>>;
 
         async fn get_transaction_outputs_with_proof(

--- a/state-sync/data-streaming-service/Cargo.toml
+++ b/state-sync/data-streaming-service/Cargo.toml
@@ -21,6 +21,7 @@ aptos-id-generator = { workspace = true }
 aptos-infallible = { workspace = true }
 aptos-logger = { workspace = true }
 aptos-metrics-core = { workspace = true }
+aptos-storage-interface = { workspace = true }
 aptos-time-service = { workspace = true }
 aptos-types = { workspace = true }
 arc-swap = { workspace = true }

--- a/state-sync/data-streaming-service/src/data_notification.rs
+++ b/state-sync/data-streaming-service/src/data_notification.rs
@@ -3,6 +3,7 @@
 
 use crate::streaming_client::Epoch;
 use aptos_data_client::interface::{Response, ResponsePayload};
+use aptos_storage_interface::StateKind;
 use aptos_types::{
     ledger_info::LedgerInfoWithSignatures,
     state_store::state_value::StateValueChunkWithProof,
@@ -45,7 +46,7 @@ pub enum DataPayload {
     ContinuousTransactionsWithProof(LedgerInfoWithSignatures, TransactionListWithProofV2),
     EpochEndingLedgerInfos(Vec<LedgerInfoWithSignatures>),
     EndOfStream,
-    StateValuesWithProof(StateValueChunkWithProof),
+    StateValuesWithProof(StateKind, StateValueChunkWithProof),
     TransactionOutputsWithProof(TransactionOutputListWithProofV2),
     TransactionsWithProof(TransactionListWithProofV2),
 }
@@ -119,12 +120,13 @@ impl DataClientRequest {
     }
 }
 
-/// A request for fetching states values.
+/// A request for fetching states values (of the given kind).
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct StateValuesWithProofRequest {
     pub version: Version,
     pub start_index: u64,
     pub end_index: u64,
+    pub state_kind: StateKind,
 }
 
 /// A client request for fetching epoch ending ledger infos.
@@ -157,10 +159,11 @@ pub struct NewTransactionOutputsWithProofRequest {
     pub known_epoch: Epoch,
 }
 
-/// A client request for fetching the number of states at a version.
+/// A client request for fetching the number of states (of the given kind) at a version.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct NumberOfStatesRequest {
     pub version: Version,
+    pub state_kind: StateKind,
 }
 
 /// A client request for subscribing to transactions with proofs.

--- a/state-sync/data-streaming-service/src/data_stream.rs
+++ b/state-sync/data-streaming-service/src/data_stream.rs
@@ -33,6 +33,8 @@ use aptos_data_client::{
 use aptos_id_generator::{IdGenerator, U64IdGenerator};
 use aptos_infallible::Mutex;
 use aptos_logger::prelude::*;
+#[cfg(test)]
+use aptos_storage_interface::StateKind;
 use aptos_time_service::{TimeService, TimeServiceTrait};
 use futures::{channel::mpsc, stream::FusedStream, SinkExt, Stream};
 use std::{
@@ -1133,6 +1135,7 @@ fn create_missing_state_values_request(
                         version: request.version,
                         start_index,
                         end_index: request.end_index,
+                        state_kind: request.state_kind,
                     },
                 )))
             } else {
@@ -1512,15 +1515,16 @@ async fn get_states_values_with_proof<T: AptosDataClientInterface + Send + Clone
     request: StateValuesWithProofRequest,
     request_timeout_ms: u64,
 ) -> Result<Response<ResponsePayload>, aptos_data_client::error::Error> {
-    let client_response = aptos_data_client.get_state_values_with_proof(
-        request.version,
-        request.start_index,
-        request.end_index,
-        request_timeout_ms,
-    );
-    client_response
-        .await
-        .map(|response| response.map(ResponsePayload::from))
+    let client_response = aptos_data_client
+        .get_state_values_with_proof(
+            request.version,
+            request.start_index,
+            request.end_index,
+            request_timeout_ms,
+            request.state_kind,
+        )
+        .await?;
+    Ok(client_response.map(ResponsePayload::StateValuesWithProof))
 }
 
 async fn get_epoch_ending_ledger_infos<T: AptosDataClientInterface + Send + Clone + 'static>(
@@ -1593,11 +1597,10 @@ async fn get_number_of_states<T: AptosDataClientInterface + Send + Clone + 'stat
     request: NumberOfStatesRequest,
     request_timeout_ms: u64,
 ) -> Result<Response<ResponsePayload>, aptos_data_client::error::Error> {
-    let client_response =
-        aptos_data_client.get_number_of_states(request.version, request_timeout_ms);
-    client_response
-        .await
-        .map(|response| response.map(ResponsePayload::from))
+    let client_response = aptos_data_client
+        .get_number_of_states(request.version, request_timeout_ms, request.state_kind)
+        .await?;
+    Ok(client_response.map(ResponsePayload::NumberOfStates))
 }
 
 async fn get_transaction_outputs_with_proof<
@@ -1731,8 +1734,10 @@ mod test {
     #[tokio::test]
     async fn completed_request_notifies_streaming_service() {
         // Create a data client request
-        let data_client_request =
-            DataClientRequest::NumberOfStates(NumberOfStatesRequest { version: 0 });
+        let data_client_request = DataClientRequest::NumberOfStates(NumberOfStatesRequest {
+            version: 0,
+            state_kind: StateKind::MainState,
+        });
 
         // Create a mock data client
         let data_client_config = AptosDataClientConfig::default();

--- a/state-sync/data-streaming-service/src/dynamic_prefetching.rs
+++ b/state-sync/data-streaming-service/src/dynamic_prefetching.rs
@@ -3,6 +3,8 @@
 
 use crate::{metrics, stream_engine::StreamEngine};
 use aptos_config::config::{DataStreamingServiceConfig, DynamicPrefetchingConfig};
+#[cfg(test)]
+use aptos_storage_interface::StateKind;
 use aptos_time_service::{TimeService, TimeServiceTrait};
 use std::{
     cmp::{max, min},
@@ -693,6 +695,7 @@ mod test {
         let stream_request = StreamRequest::GetAllStates(GetAllStatesRequest {
             version: 0,
             start_index: 0,
+            state_kind: StateKind::MainState,
         });
 
         // Create and return the stream engine

--- a/state-sync/data-streaming-service/src/stream_engine.rs
+++ b/state-sync/data-streaming-service/src/stream_engine.rs
@@ -33,6 +33,7 @@ use aptos_data_client::{
 };
 use aptos_id_generator::{IdGenerator, U64IdGenerator};
 use aptos_logger::prelude::*;
+use aptos_storage_interface::StateKind;
 use aptos_types::{ledger_info::LedgerInfoWithSignatures, transaction::Version};
 use enum_dispatch::enum_dispatch;
 use std::{cmp, cmp::min, sync::Arc};
@@ -168,6 +169,9 @@ pub struct StateStreamEngine {
     // The original states request made by the client
     pub request: GetAllStatesRequest,
 
+    // Which snapshot store this engine streams
+    pub kind: StateKind,
+
     // True iff a request has been created to fetch the number of states
     pub state_num_requested: bool,
 
@@ -190,6 +194,7 @@ impl StateStreamEngine {
     fn new(request: &GetAllStatesRequest) -> Result<Self, Error> {
         Ok(StateStreamEngine {
             request: request.clone(),
+            kind: request.state_kind,
             state_num_requested: false,
             number_of_states: None,
             next_stream_index: request.start_index,
@@ -277,11 +282,11 @@ impl DataStreamEngine for StateStreamEngine {
 
         // Return the request
         self.state_num_requested = true;
-        Ok(vec![DataClientRequest::NumberOfStates(
-            NumberOfStatesRequest {
-                version: self.request.version,
-            },
-        )])
+        let number_request = DataClientRequest::NumberOfStates(NumberOfStatesRequest {
+            version: self.request.version,
+            state_kind: self.kind,
+        });
+        Ok(vec![number_request])
     }
 
     fn is_remaining_data_available(&self, advertised_data: &AdvertisedData) -> Result<bool, Error> {
@@ -376,9 +381,23 @@ impl DataStreamEngine for StateStreamEngine {
                             total number of states. Next index: {:?}, total states: {:?}",
                             self.next_request_index, number_of_states
                         )));
-                    } else {
-                        self.number_of_states = Some(number_of_states);
                     }
+                    // The number of states is an internal planning value, not
+                    // consumer data. An empty tree (count 0) has no chunks: just
+                    // end the stream (no notification). The bootstrapper detects
+                    // the zero-chunk end and verifies emptiness against the
+                    // committed snapshot root. Main state at a real snapshot is
+                    // never empty, so a 0 there is an invalid response.
+                    if number_of_states == 0 {
+                        if self.kind == StateKind::MainState {
+                            return Err(Error::AptosDataClientResponseIsInvalid(
+                                "Received a state count of 0 for the main state snapshot!".into(),
+                            ));
+                        }
+                        self.stream_is_complete = true;
+                        return Ok(None);
+                    }
+                    self.number_of_states = Some(number_of_states);
                 }
             },
             request => invalid_client_request!(request, self),
@@ -2111,6 +2130,7 @@ fn create_data_client_request(
                 version: stream_engine.request.version,
                 start_index,
                 end_index,
+                state_kind: stream_engine.kind,
             })
         },
         StreamEngine::ContinuousTransactionStreamEngine(stream_engine) => {
@@ -2194,9 +2214,15 @@ fn create_data_notification(
     // Get the data payload
     let client_response_type = client_response.get_label();
     let data_payload = match client_response {
-        ResponsePayload::StateValuesWithProof(states_chunk) => {
-            DataPayload::StateValuesWithProof(states_chunk)
+        ResponsePayload::StateValuesWithProof(states_chunk) => match &stream_engine {
+            StreamEngine::StateStreamEngine(engine) => {
+                DataPayload::StateValuesWithProof(engine.kind, states_chunk)
+            },
+            _ => invalid_response_type!(client_response_type),
         },
+        // The number of states is consumed internally by the engine for chunk
+        // planning; it is never surfaced to the consumer as a notification.
+        ResponsePayload::NumberOfStates(_) => invalid_response_type!(client_response_type),
         ResponsePayload::EpochEndingLedgerInfos(ledger_infos) => {
             DataPayload::EpochEndingLedgerInfos(ledger_infos)
         },
@@ -2256,7 +2282,6 @@ fn create_data_notification(
                 _ => invalid_response_type!(client_response_type),
             }
         },
-        _ => invalid_response_type!(client_response_type),
     };
 
     // Create and return the data notification

--- a/state-sync/data-streaming-service/src/streaming_client.rs
+++ b/state-sync/data-streaming-service/src/streaming_client.rs
@@ -6,6 +6,7 @@ use crate::{
     data_stream::{DataStreamId, DataStreamListener},
     error::Error,
 };
+use aptos_storage_interface::StateKind;
 use aptos_types::{ledger_info::LedgerInfoWithSignatures, transaction::Version};
 use async_trait::async_trait;
 use futures::{
@@ -33,15 +34,16 @@ pub type Epoch = u64;
 /// is the responsibility of the client to terminate the stream using this API.
 #[async_trait]
 pub trait DataStreamingClient {
-    /// Fetches the state values at the specified version. If `start_index`
-    /// is specified, the state values will be fetched starting at the
-    /// `start_index` (inclusive). Otherwise, the start index will 0.
+    /// Fetches the state values (of the given kind) at the specified version. If
+    /// `start_index` is specified, the state values will be fetched starting at
+    /// the `start_index` (inclusive). Otherwise, the start index will 0.
     /// The specified version must be an epoch ending version, otherwise an
     /// error will be returned. State proofs are at the same version.
     async fn get_all_state_values(
         &self,
         version: Version,
         start_index: Option<u64>,
+        state_kind: StateKind,
     ) -> Result<DataStreamListener, Error>;
 
     /// Fetches all epoch ending ledger infos starting at `start_epoch`
@@ -208,11 +210,12 @@ pub struct GetAllEpochEndingLedgerInfosRequest {
     pub start_epoch: Epoch,
 }
 
-/// A client request for fetching all states at a specified version.
+/// A client request for fetching all states (of the given kind) at a version.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct GetAllStatesRequest {
     pub version: Version,
     pub start_index: u64,
+    pub state_kind: StateKind,
 }
 
 /// A client request for fetching all transactions with proofs.
@@ -338,11 +341,13 @@ impl DataStreamingClient for StreamingServiceClient {
         &self,
         version: u64,
         start_index: Option<u64>,
+        state_kind: StateKind,
     ) -> Result<DataStreamListener, Error> {
         let start_index = start_index.unwrap_or(0);
         let client_request = StreamRequest::GetAllStates(GetAllStatesRequest {
             version,
             start_index,
+            state_kind,
         });
         self.send_request_and_await_response(client_request).await
     }

--- a/state-sync/data-streaming-service/src/streaming_service.rs
+++ b/state-sync/data-streaming-service/src/streaming_service.rs
@@ -513,6 +513,7 @@ mod streaming_service_tests {
     };
     use aptos_channels::{aptos_channel, message_queues::QueueStyle};
     use aptos_config::config::DataStreamingServiceConfig;
+    use aptos_storage_interface::StateKind;
     use futures::{
         channel::{oneshot, oneshot::Receiver},
         FutureExt, StreamExt,
@@ -808,6 +809,7 @@ mod streaming_service_tests {
         let stream_request = StreamRequest::GetAllStates(GetAllStatesRequest {
             version: MIN_ADVERTISED_STATES,
             start_index: 0,
+            state_kind: StateKind::MainState,
         });
         create_request_message_and_receiver(stream_request)
     }

--- a/state-sync/data-streaming-service/src/tests/client_requests.rs
+++ b/state-sync/data-streaming-service/src/tests/client_requests.rs
@@ -12,6 +12,7 @@ use crate::{
 use aptos_config::config::{DataStreamingServiceConfig, DynamicPrefetchingConfig};
 use aptos_data_client::global_summary::GlobalDataSummary;
 use aptos_id_generator::U64IdGenerator;
+use aptos_storage_interface::StateKind;
 use aptos_storage_service_types::responses::CompleteDataRange;
 use std::sync::Arc;
 
@@ -61,6 +62,7 @@ fn create_client_requests_state_values_stream() {
     let stream_request = StreamRequest::GetAllStates(GetAllStatesRequest {
         version,
         start_index,
+        state_kind: StateKind::MainState,
     });
 
     // Create a global data summary with a single state range

--- a/state-sync/data-streaming-service/src/tests/data_stream.rs
+++ b/state-sync/data-streaming-service/src/tests/data_stream.rs
@@ -39,6 +39,7 @@ use aptos_data_client::{
 };
 use aptos_id_generator::U64IdGenerator;
 use aptos_infallible::Mutex;
+use aptos_storage_interface::StateKind;
 use aptos_storage_service_types::responses::CompleteDataRange;
 use aptos_time_service::{TimeService, TimeServiceTrait};
 use aptos_types::{
@@ -358,7 +359,7 @@ async fn test_state_stream_out_of_order_responses() {
         let data_notification = get_data_notification(&mut stream_listener).await.unwrap();
         assert_matches!(
             data_notification.data_payload,
-            DataPayload::StateValuesWithProof(_)
+            DataPayload::StateValuesWithProof(_, _)
         );
     }
     assert_none!(stream_listener.select_next_some().now_or_never());
@@ -370,7 +371,7 @@ async fn test_state_stream_out_of_order_responses() {
     let data_notification = get_data_notification(&mut stream_listener).await.unwrap();
     assert_matches!(
         data_notification.data_payload,
-        DataPayload::StateValuesWithProof(_)
+        DataPayload::StateValuesWithProof(_, _)
     );
     assert_none!(stream_listener.select_next_some().now_or_never());
 
@@ -382,7 +383,7 @@ async fn test_state_stream_out_of_order_responses() {
         let data_notification = get_data_notification(&mut stream_listener).await.unwrap();
         assert_matches!(
             data_notification.data_payload,
-            DataPayload::StateValuesWithProof(_)
+            DataPayload::StateValuesWithProof(_, _)
         );
     }
     assert_none!(stream_listener.select_next_some().now_or_never());
@@ -446,7 +447,7 @@ async fn test_state_stream_out_of_order_responses_dynamic() {
         let data_notification = get_data_notification(&mut stream_listener).await.unwrap();
         assert_matches!(
             data_notification.data_payload,
-            DataPayload::StateValuesWithProof(_)
+            DataPayload::StateValuesWithProof(_, _)
         );
     }
     assert_none!(stream_listener.select_next_some().now_or_never());
@@ -464,7 +465,7 @@ async fn test_state_stream_out_of_order_responses_dynamic() {
     let data_notification = get_data_notification(&mut stream_listener).await.unwrap();
     assert_matches!(
         data_notification.data_payload,
-        DataPayload::StateValuesWithProof(_)
+        DataPayload::StateValuesWithProof(_, _)
     );
     assert_none!(stream_listener.select_next_some().now_or_never());
 
@@ -482,7 +483,7 @@ async fn test_state_stream_out_of_order_responses_dynamic() {
         let data_notification = get_data_notification(&mut stream_listener).await.unwrap();
         assert_matches!(
             data_notification.data_payload,
-            DataPayload::StateValuesWithProof(_)
+            DataPayload::StateValuesWithProof(_, _)
         );
     }
     assert_none!(stream_listener.select_next_some().now_or_never());
@@ -3319,6 +3320,7 @@ fn create_state_value_stream(
     let stream_request = StreamRequest::GetAllStates(GetAllStatesRequest {
         version,
         start_index: 0,
+        state_kind: StateKind::MainState,
     });
     let (data_stream, data_stream_listener, _) =
         create_data_stream(data_client_config, streaming_service_config, stream_request);

--- a/state-sync/data-streaming-service/src/tests/missing_data.rs
+++ b/state-sync/data-streaming-service/src/tests/missing_data.rs
@@ -23,6 +23,7 @@ use aptos_config::config::DataStreamingServiceConfig;
 use aptos_crypto::HashValue;
 use aptos_data_client::{global_summary::GlobalDataSummary, interface::ResponsePayload};
 use aptos_id_generator::U64IdGenerator;
+use aptos_storage_interface::StateKind;
 use aptos_storage_service_types::responses::CompleteDataRange;
 use aptos_types::{
     proof::{SparseMerkleRangeProof, TransactionInfoListWithProof},
@@ -79,7 +80,10 @@ fn create_missing_data_request_trivial_request_types() {
                 include_events: false,
             },
         ),
-        DataClientRequest::NumberOfStates(NumberOfStatesRequest { version: 0 }),
+        DataClientRequest::NumberOfStates(NumberOfStatesRequest {
+            version: 0,
+            state_kind: StateKind::MainState,
+        }),
         DataClientRequest::SubscribeTransactionOutputsWithProof(
             SubscribeTransactionOutputsWithProofRequest {
                 known_version: 0,
@@ -167,6 +171,7 @@ fn create_missing_data_request_state_values() {
             version,
             start_index,
             end_index,
+            state_kind: StateKind::MainState,
         });
 
     // Create the partial response payload
@@ -192,6 +197,7 @@ fn create_missing_data_request_state_values() {
             version,
             start_index: last_response_index + 1,
             end_index,
+            state_kind: StateKind::MainState,
         });
     assert_eq!(missing_data_request.unwrap(), expected_missing_data_request);
 
@@ -511,6 +517,7 @@ fn transform_state_values_stream_notifications() {
     let stream_request = StreamRequest::GetAllStates(GetAllStatesRequest {
         version,
         start_index,
+        state_kind: StateKind::MainState,
     });
 
     // Create a global data summary with a single state range
@@ -588,7 +595,7 @@ fn transform_state_values_stream_notifications() {
         .unwrap();
     assert_eq!(
         data_notification.unwrap().data_payload,
-        DataPayload::StateValuesWithProof(state_value_chunk_with_proof)
+        DataPayload::StateValuesWithProof(StateKind::MainState, state_value_chunk_with_proof)
     );
 
     // Verify the tracked stream indices
@@ -608,6 +615,7 @@ fn transform_state_values_stream_notifications() {
             version,
             start_index: start_index + 1,
             end_index: number_of_states - 1,
+            state_kind: StateKind::MainState,
         });
     let _ = stream_engine
         .transform_client_response_into_notification(

--- a/state-sync/data-streaming-service/src/tests/streaming_client.rs
+++ b/state-sync/data-streaming-service/src/tests/streaming_client.rs
@@ -14,6 +14,7 @@ use crate::{
     },
     tests::utils::{create_ledger_info, initialize_logger},
 };
+use aptos_storage_interface::StateKind;
 use claims::assert_ok;
 use futures::{channel::mpsc, executor::block_on, FutureExt, StreamExt};
 use std::thread::JoinHandle;
@@ -45,13 +46,18 @@ fn test_get_all_states() {
     let expected_request = StreamRequest::GetAllStates(GetAllStatesRequest {
         version: request_version,
         start_index: 0,
+        state_kind: StateKind::MainState,
     });
 
     // Spawn a new server thread to handle any stream requests
     let _handler = spawn_service_and_expect_request(streaming_service_listener, expected_request);
 
     // Send a state value stream request and verify we get a data stream listener
-    let response = block_on(streaming_service_client.get_all_state_values(request_version, None));
+    let response = block_on(streaming_service_client.get_all_state_values(
+        request_version,
+        None,
+        StateKind::MainState,
+    ));
     assert_ok!(response);
 }
 

--- a/state-sync/data-streaming-service/src/tests/streaming_service.rs
+++ b/state-sync/data-streaming-service/src/tests/streaming_service.rs
@@ -19,6 +19,7 @@ use crate::{
     },
 };
 use aptos_config::config::{AptosDataClientConfig, DataStreamingServiceConfig};
+use aptos_storage_interface::StateKind;
 use aptos_time_service::TimeService;
 use aptos_types::{
     ledger_info::LedgerInfoWithSignatures,
@@ -39,7 +40,7 @@ async fn test_notifications_state_values() {
 
     // Request a state value stream and get a data stream listener
     let mut stream_listener = streaming_client
-        .get_all_state_values(MAX_ADVERTISED_STATES, None)
+        .get_all_state_values(MAX_ADVERTISED_STATES, None, StateKind::MainState)
         .await
         .unwrap();
 
@@ -54,7 +55,7 @@ async fn test_notifications_state_values_limited_chunks() {
 
     // Request a new state value stream starting at the next expected index
     let mut stream_listener = streaming_client
-        .get_all_state_values(MAX_ADVERTISED_STATES, Some(0))
+        .get_all_state_values(MAX_ADVERTISED_STATES, Some(0), StateKind::MainState)
         .await
         .unwrap();
 
@@ -70,7 +71,11 @@ async fn test_notifications_state_values_multiple_streams() {
     // Request a new state value stream starting at the next expected index.
     let mut next_expected_index = 0;
     let mut stream_listener = streaming_client
-        .get_all_state_values(MAX_ADVERTISED_STATES, Some(next_expected_index))
+        .get_all_state_values(
+            MAX_ADVERTISED_STATES,
+            Some(next_expected_index),
+            StateKind::MainState,
+        )
         .await
         .unwrap();
 
@@ -78,7 +83,7 @@ async fn test_notifications_state_values_multiple_streams() {
     loop {
         let data_notification = get_data_notification(&mut stream_listener).await.unwrap();
         match data_notification.data_payload {
-            DataPayload::StateValuesWithProof(state_values_with_proof) => {
+            DataPayload::StateValuesWithProof(_, state_values_with_proof) => {
                 // Verify the indices
                 assert_eq!(state_values_with_proof.first_index, next_expected_index);
 
@@ -101,7 +106,11 @@ async fn test_notifications_state_values_multiple_streams() {
 
                     // Fetch a new stream
                     stream_listener = streaming_client
-                        .get_all_state_values(MAX_ADVERTISED_STATES, Some(next_expected_index))
+                        .get_all_state_values(
+                            MAX_ADVERTISED_STATES,
+                            Some(next_expected_index),
+                            StateKind::MainState,
+                        )
                         .await
                         .unwrap();
                 }
@@ -1246,19 +1255,19 @@ async fn test_stream_states() {
 
     // Request a state value stream and verify we get a data stream listener
     let result = streaming_client
-        .get_all_state_values(MAX_ADVERTISED_STATES - 1, None)
+        .get_all_state_values(MAX_ADVERTISED_STATES - 1, None, StateKind::MainState)
         .await;
     assert_ok!(result);
 
     // Request a stream where states are missing (we are lower than advertised)
     let result = streaming_client
-        .get_all_state_values(MIN_ADVERTISED_STATES - 1, None)
+        .get_all_state_values(MIN_ADVERTISED_STATES - 1, None, StateKind::MainState)
         .await;
     assert_matches!(result, Err(Error::DataIsUnavailable(_)));
 
     // Request a stream where states are missing (we are higher than advertised)
     let result = streaming_client
-        .get_all_state_values(MAX_ADVERTISED_EPOCH_END + 1, None)
+        .get_all_state_values(MAX_ADVERTISED_EPOCH_END + 1, None, StateKind::MainState)
         .await;
     assert_matches!(result, Err(Error::DataIsUnavailable(_)));
 }
@@ -1557,14 +1566,14 @@ async fn test_terminate_stream() {
 
     // Request a state value stream
     let mut stream_listener = streaming_client
-        .get_all_state_values(MAX_ADVERTISED_STATES - 1, None)
+        .get_all_state_values(MAX_ADVERTISED_STATES - 1, None, StateKind::MainState)
         .await
         .unwrap();
 
     // Fetch the first state value notification and then terminate the stream
     let data_notification = get_data_notification(&mut stream_listener).await.unwrap();
     match data_notification.data_payload {
-        DataPayload::StateValuesWithProof(_) => {},
+        DataPayload::StateValuesWithProof(_, _) => {},
         data_payload => unexpected_payload_type!(data_payload),
     }
 
@@ -1584,7 +1593,7 @@ async fn test_terminate_stream() {
     loop {
         let data_notification = get_data_notification(&mut stream_listener).await.unwrap();
         match data_notification.data_payload {
-            DataPayload::StateValuesWithProof(_) => {},
+            DataPayload::StateValuesWithProof(_, _) => {},
             DataPayload::EndOfStream => panic!("The stream should have terminated!"),
             data_payload => unexpected_payload_type!(data_payload),
         }
@@ -1714,7 +1723,7 @@ async fn verify_continuous_state_value_notifications(stream_listener: &mut DataS
     loop {
         let data_notification = get_data_notification(stream_listener).await.unwrap();
         match data_notification.data_payload {
-            DataPayload::StateValuesWithProof(state_values_with_proof) => {
+            DataPayload::StateValuesWithProof(_, state_values_with_proof) => {
                 // Verify the start index matches the expected index
                 assert_eq!(state_values_with_proof.first_index, next_expected_index);
 

--- a/state-sync/data-streaming-service/src/tests/utils.rs
+++ b/state-sync/data-streaming-service/src/tests/utils.rs
@@ -13,6 +13,7 @@ use aptos_data_client::{
 };
 use aptos_infallible::Mutex;
 use aptos_logger::Level;
+use aptos_storage_interface::StateKind;
 use aptos_storage_service_types::{
     requests::{
         DataRequest, EpochEndingLedgerInfoRequest, NewTransactionOutputsWithProofRequest,
@@ -287,6 +288,7 @@ impl AptosDataClientInterface for MockAptosDataClient {
         start_index: u64,
         end_index: u64,
         request_timeout_ms: u64,
+        _kind: StateKind,
     ) -> Result<Response<StateValueChunkWithProof>, aptos_data_client::error::Error> {
         // Verify the request timeout
         let data_request = DataRequest::GetStateValuesWithProof(StateValuesWithProofRequest {
@@ -529,6 +531,7 @@ impl AptosDataClientInterface for MockAptosDataClient {
         &self,
         version: Version,
         request_timeout_ms: u64,
+        _kind: StateKind,
     ) -> Result<Response<u64>, aptos_data_client::error::Error> {
         // Verify the request timeout
         let data_request = DataRequest::GetNumberOfStatesAtVersion(version);

--- a/state-sync/state-sync-driver/src/bootstrapper.rs
+++ b/state-sync/state-sync-driver/src/bootstrapper.rs
@@ -13,6 +13,7 @@ use crate::{
     utils::{OutputFallbackHandler, SpeculativeStreamState, PENDING_DATA_LOG_FREQ_SECS},
 };
 use aptos_config::config::BootstrappingMode;
+use aptos_crypto::{hash::SPARSE_MERKLE_PLACEHOLDER_HASH, HashValue};
 use aptos_data_client::global_summary::GlobalDataSummary;
 use aptos_data_streaming_service::{
     data_notification::{DataNotification, DataPayload, NotificationId},
@@ -20,7 +21,7 @@ use aptos_data_streaming_service::{
     streaming_client::{DataStreamingClient, NotificationAndFeedback, NotificationFeedback},
 };
 use aptos_logger::{prelude::*, sample::SampleRate};
-use aptos_storage_interface::DbReader;
+use aptos_storage_interface::{DbReader, StateKind};
 use aptos_types::{
     epoch_change::Verifier,
     epoch_state::EpochState,
@@ -35,6 +36,11 @@ use std::{collections::BTreeMap, sync::Arc, time::Duration};
 // Useful bootstrapper constants
 const BOOTSTRAPPER_LOG_INTERVAL_SECS: u64 = 3;
 pub const GENESIS_TRANSACTION_VERSION: u64 = 0; // The expected version of the genesis transaction
+
+// The snapshot stores synced during fast sync. They are peers (independent
+// stores at the same version); this is just the drive order, and the fast sync
+// is finalized once all of them are written.
+const FAST_SYNC_SNAPSHOT_KINDS: [StateKind; 2] = [StateKind::MainState, StateKind::Position];
 
 /// A simple container for verified epoch states and epoch ending ledger infos
 /// that have been fetched from the network.
@@ -254,6 +260,10 @@ pub(crate) struct StateValueSyncer {
 
     // The transaction output (inc. info and proof) for the version we're syncing
     transaction_output_to_sync: Option<TransactionOutputListWithProofV2>,
+
+    // Whether a data stream has been requested for this kind at the current
+    // target (distinguishes "not yet streamed" from "streamed, empty tree").
+    stream_requested: bool,
 }
 
 impl StateValueSyncer {
@@ -263,6 +273,7 @@ impl StateValueSyncer {
             ledger_info_to_sync: None,
             next_state_index_to_process: 0,
             transaction_output_to_sync: None,
+            stream_requested: false,
         }
     }
 
@@ -311,6 +322,9 @@ pub struct Bootstrapper<MetadataStorage, StorageSyncer, StreamingClient> {
     // The component used to sync state values (if downloading states)
     state_value_syncer: StateValueSyncer,
 
+    // The component used to sync native-position state values
+    position_value_syncer: StateValueSyncer,
+
     // The client through which to stream data from the Aptos network
     streaming_client: StreamingClient,
 
@@ -345,6 +359,7 @@ impl<
 
         Self {
             state_value_syncer: StateValueSyncer::new(),
+            position_value_syncer: StateValueSyncer::new(),
             active_data_stream: None,
             bootstrap_notifier_channel: None,
             bootstrapped: false,
@@ -518,34 +533,17 @@ impl<
         highest_known_ledger_info: LedgerInfoWithSignatures,
     ) -> Result<(), Error> {
         if highest_synced_version == GENESIS_TRANSACTION_VERSION {
-            // We're syncing a new node. Check the progress and fetch any missing data
-            if let Some(target) = self.metadata_storage.previous_snapshot_sync_target()? {
-                if self.metadata_storage.is_snapshot_sync_complete(&target)? {
-                    // Fast syncing to the target is complete. Verify that the
-                    // highest synced version matches the target.
-                    if target.ledger_info().version() == GENESIS_TRANSACTION_VERSION {
-                        info!(LogSchema::new(LogEntry::Bootstrapper).message(&format!(
-                            "The fast sync to genesis is complete! Target: {:?}",
-                            target
-                        )));
-                        self.bootstrapping_complete().await
-                    } else {
-                        Err(Error::UnexpectedError(format!(
-                            "The snapshot sync for the target was marked as complete but \
-                        the highest synced version is genesis! Something has gone wrong! \
-                        Target snapshot sync: {:?}",
-                            target
-                        )))
-                    }
-                } else {
-                    // Continue snapshot syncing to the target
-                    self.fetch_missing_state_values(target, true).await
-                }
-            } else {
-                // No snapshot sync has started. Start a new sync for the highest known ledger info.
-                self.fetch_missing_state_values(highest_known_ledger_info, false)
-                    .await
-            }
+            // We're fast syncing a new node. Resume against the already-pinned
+            // target if a snapshot sync has started, otherwise target the highest
+            // known ledger info. (All snapshot kinds sync to the same target.)
+            let target = match self
+                .metadata_storage
+                .previous_snapshot_sync_target(StateKind::MainState)?
+            {
+                Some(target) => target,
+                None => highest_known_ledger_info,
+            };
+            self.drive_snapshot_stages(target).await
         } else {
             // This node has already synced some state. Ensure the node is not too far behind.
             let highest_known_ledger_version = highest_known_ledger_info.ledger_info().version();
@@ -604,10 +602,11 @@ impl<
             // Fetch and process any data notifications
             let data_notification = self.fetch_next_data_notification().await?;
             match data_notification.data_payload {
-                DataPayload::StateValuesWithProof(state_value_chunk_with_proof) => {
+                DataPayload::StateValuesWithProof(state_kind, state_value_chunk_with_proof) => {
                     self.process_state_values_payload(
                         data_notification.notification_id,
                         state_value_chunk_with_proof,
+                        state_kind,
                     )
                     .await?;
                 },
@@ -659,71 +658,75 @@ impl<
         Ok(())
     }
 
-    /// Fetches state values (as required to bootstrap the node)
-    async fn fetch_missing_state_values(
+    /// Pins the target ledger info on the syncer for the given snapshot kind and
+    /// verifies it never changes across stream resets.
+    fn pin_ledger_info_to_sync(
         &mut self,
         target_ledger_info: LedgerInfoWithSignatures,
-        existing_snapshot_progress: bool,
+        kind: StateKind,
     ) -> Result<(), Error> {
-        // Initialize the target ledger info and verify it never changes
-        if let Some(ledger_info_to_sync) = &self.state_value_syncer.ledger_info_to_sync {
+        if let Some(ledger_info_to_sync) = &self.state_value_syncer(kind).ledger_info_to_sync {
             if ledger_info_to_sync != &target_ledger_info {
                 return Err(Error::UnexpectedError(format!(
-                    "Mismatch in ledger info to sync! Given target: {:?}, stored target: {:?}",
-                    target_ledger_info, ledger_info_to_sync
+                    "Mismatch in {:?} ledger info to sync! Given target: {:?}, stored target: {:?}",
+                    kind, target_ledger_info, ledger_info_to_sync
                 )));
             }
         } else {
             info!(LogSchema::new(LogEntry::Bootstrapper).message(&format!(
-                "Setting the target ledger info for fast sync! Target: {:?}",
-                target_ledger_info
+                "Setting the target ledger info for {:?} fast sync! Target: {:?}",
+                kind, target_ledger_info
             )));
-
-            self.state_value_syncer
-                .set_ledger_info_to_sync(target_ledger_info.clone());
+            self.state_value_syncer_mut(kind)
+                .set_ledger_info_to_sync(target_ledger_info);
         }
+        Ok(())
+    }
 
-        // Fetch the data that we're missing
+    /// Streams the state values (of the given kind) for the snapshot at the
+    /// target. The target transaction output is fetched up front by the caller
+    /// (`drive_snapshot_stages`), so this is uniform across snapshot kinds.
+    async fn fetch_missing_state_values(
+        &mut self,
+        target_ledger_info: LedgerInfoWithSignatures,
+        existing_snapshot_progress: bool,
+        kind: StateKind,
+    ) -> Result<(), Error> {
+        // Initialize the target ledger info and verify it never changes
+        self.pin_ledger_info_to_sync(target_ledger_info.clone(), kind)?;
         let target_ledger_info_version = target_ledger_info.ledger_info().version();
-        let data_stream = if self.state_value_syncer.transaction_output_to_sync.is_none() {
-            // Fetch the transaction info first, before the states
-            self.streaming_client
-                .get_all_transaction_outputs(
-                    target_ledger_info_version,
-                    target_ledger_info_version,
-                    target_ledger_info_version,
-                )
-                .await?
-        } else {
-            // Identify the next state index to fetch
-            let next_state_index_to_process = if existing_snapshot_progress {
-                // The state snapshot receiver requires that after each reboot we
-                // rewrite the last persisted index (again!). This is a limitation
-                // of how the snapshot is persisted (i.e., in-memory sibling freezing).
-                // Thus, on each stream reset, we overlap every chunk by a single item.
-                self
-                    .metadata_storage
-                    .get_last_persisted_state_value_index(&target_ledger_info)
-                    .map_err(|error| {
-                        Error::StorageError(format!(
-                            "Failed to get the last persisted state value index at version {:?}! Error: {:?}",
-                            target_ledger_info_version, error
-                        ))
-                    })?
-            } else {
-                0 // We need to start the snapshot sync from index 0
-            };
 
-            // Fetch the missing state values
-            self.state_value_syncer
-                .update_next_state_index_to_process(next_state_index_to_process);
-            self.streaming_client
-                .get_all_state_values(
-                    target_ledger_info_version,
-                    Some(next_state_index_to_process),
-                )
-                .await?
+        // Identify the next state index to fetch
+        let next_state_index_to_process = if existing_snapshot_progress {
+            // The state snapshot receiver requires that after each reboot we
+            // rewrite the last persisted index (again!). This is a limitation
+            // of how the snapshot is persisted (i.e., in-memory sibling freezing).
+            // Thus, on each stream reset, we overlap every chunk by a single item.
+            self
+                .metadata_storage
+                .get_last_persisted_index(&target_ledger_info, kind)
+                .map_err(|error| {
+                    Error::StorageError(format!(
+                        "Failed to get the last persisted {:?} value index at version {:?}! Error: {:?}",
+                        kind, target_ledger_info_version, error
+                    ))
+                })?
+        } else {
+            0 // We need to start the snapshot sync from index 0
         };
+
+        // Fetch the missing state values
+        self.state_value_syncer_mut(kind)
+            .update_next_state_index_to_process(next_state_index_to_process);
+        self.state_value_syncer_mut(kind).stream_requested = true;
+        let data_stream = self
+            .streaming_client
+            .get_all_state_values(
+                target_ledger_info_version,
+                Some(next_state_index_to_process),
+                kind,
+            )
+            .await?;
         self.active_data_stream = Some(data_stream);
 
         Ok(())
@@ -914,23 +917,22 @@ impl<
         }
     }
 
-    /// Verifies the start and end indices in the given state value chunk
-    async fn verify_states_values_indices(
+    /// Verifies the start and end indices in the given state value chunk. The
+    /// `label` ("state" / "position") only flavors error messages.
+    async fn verify_state_value_chunk_indices(
         &mut self,
         notification_id: NotificationId,
+        expected_start_index: u64,
+        kind: StateKind,
         state_value_chunk_with_proof: &StateValueChunkWithProof,
     ) -> Result<(), Error> {
         // Verify the payload start index is valid
-        let expected_start_index = self.state_value_syncer.next_state_index_to_process;
         if expected_start_index != state_value_chunk_with_proof.first_index {
-            self.reset_active_stream(Some(NotificationAndFeedback::new(
-                notification_id,
-                NotificationFeedback::InvalidPayloadData,
-            )))
-            .await?;
+            self.reset_stream(notification_id, NotificationFeedback::InvalidPayloadData)
+                .await?;
             return Err(Error::VerificationError(format!(
-                "The start index of the state values was invalid! Expected: {:?}, received: {:?}",
-                expected_start_index, state_value_chunk_with_proof.first_index
+                "The start index of the {:?} values was invalid! Expected: {:?}, received: {:?}",
+                kind, expected_start_index, state_value_chunk_with_proof.first_index
             )));
         }
 
@@ -940,72 +942,48 @@ impl<
             .checked_sub(state_value_chunk_with_proof.first_index)
             .and_then(|version| version.checked_add(1)) // expected_num_state_values = last_index - first_index + 1
             .ok_or_else(|| {
-                Error::IntegerOverflow("The expected number of state values has overflown!".into())
+                Error::IntegerOverflow(format!(
+                    "The expected number of {:?} values has overflown!",
+                    kind
+                ))
             })?;
         let num_state_values = state_value_chunk_with_proof.raw_values.len() as u64;
         if expected_num_state_values != num_state_values {
-            self.reset_active_stream(Some(NotificationAndFeedback::new(
-                notification_id,
-                NotificationFeedback::InvalidPayloadData,
-            )))
-            .await?;
+            self.reset_stream(notification_id, NotificationFeedback::InvalidPayloadData)
+                .await?;
             return Err(Error::VerificationError(format!(
-                "The expected number of state values was invalid! Expected: {:?}, received: {:?}",
-                expected_num_state_values, num_state_values,
+                "The expected number of {:?} values was invalid! Expected: {:?}, received: {:?}",
+                kind, expected_num_state_values, num_state_values,
             )));
         }
 
         Ok(())
     }
 
-    /// Process a single state value chunk with proof payload
-    async fn process_state_values_payload(
-        &mut self,
-        notification_id: NotificationId,
-        state_value_chunk_with_proof: StateValueChunkWithProof,
-    ) -> Result<(), Error> {
-        // Verify that we're expecting state value payloads
-        let bootstrapping_mode = self.get_bootstrapping_mode();
-        if self.should_fetch_epoch_ending_ledger_infos() || !bootstrapping_mode.is_fast_sync() {
-            self.reset_active_stream(Some(NotificationAndFeedback::new(
-                notification_id,
-                NotificationFeedback::InvalidPayloadData,
-            )))
-            .await?;
-            return Err(Error::InvalidPayload(
-                "Received an unexpected state values payload!".into(),
-            ));
+    /// Returns the state value syncer for the given snapshot kind.
+    fn state_value_syncer(&self, kind: StateKind) -> &StateValueSyncer {
+        match kind {
+            StateKind::MainState => &self.state_value_syncer,
+            StateKind::Position => &self.position_value_syncer,
         }
+    }
 
-        // Fetch the target ledger info and transaction info for bootstrapping
-        let ledger_info_to_sync = self.get_ledger_info_to_sync()?;
+    /// Returns the mutable state value syncer for the given snapshot kind.
+    fn state_value_syncer_mut(&mut self, kind: StateKind) -> &mut StateValueSyncer {
+        match kind {
+            StateKind::MainState => &mut self.state_value_syncer,
+            StateKind::Position => &mut self.position_value_syncer,
+        }
+    }
+
+    /// The expected snapshot root for the given kind at the target version, read
+    /// from the target transaction info: main state's state checkpoint hash, or
+    /// the committed position state root (guaranteed present once the position
+    /// stage runs, per `snapshot_kind_applies_to_target`). All kinds share the
+    /// target version, so this is taken from the target output, not a storage read.
+    fn expected_snapshot_root(&mut self, kind: StateKind) -> Result<HashValue, Error> {
         let transaction_output_to_sync = self.get_transaction_output_to_sync()?;
-
-        // Initialize the state value synchronizer (if not already done)
-        if !self.state_value_syncer.initialized_state_snapshot_receiver {
-            // Fetch all verified epoch change proofs
-            let version_to_sync = ledger_info_to_sync.ledger_info().version();
-            let epoch_change_proofs = if version_to_sync == GENESIS_TRANSACTION_VERSION {
-                vec![ledger_info_to_sync.clone()] // Sync to genesis
-            } else {
-                self.verified_epoch_states.all_epoch_ending_ledger_infos() // Sync beyond genesis
-            };
-
-            // Initialize the state value synchronizer
-            let _join_handle = self.storage_synchronizer.initialize_state_synchronizer(
-                epoch_change_proofs,
-                ledger_info_to_sync,
-                transaction_output_to_sync.clone(),
-            )?;
-            self.state_value_syncer.initialized_state_snapshot_receiver = true;
-        }
-
-        // Verify the state values payload start and end indices
-        self.verify_states_values_indices(notification_id, &state_value_chunk_with_proof)
-            .await?;
-
-        // Verify the chunk root hash matches the expected root hash
-        let first_transaction_info = transaction_output_to_sync
+        let target_transaction_info = transaction_output_to_sync
             .get_output_list_with_proof()
             .proof
             .transaction_infos
@@ -1013,21 +991,101 @@ impl<
             .ok_or_else(|| {
                 Error::UnexpectedError("Target transaction info does not exist!".into())
             })?;
-        let expected_root_hash = first_transaction_info
-            .ensure_state_checkpoint_hash()
-            .map_err(|error| {
-                Error::UnexpectedError(format!("State checkpoint must exist! Error: {:?}", error))
-            })?;
-        if state_value_chunk_with_proof.root_hash != expected_root_hash {
-            self.reset_active_stream(Some(NotificationAndFeedback::new(
-                notification_id,
-                NotificationFeedback::InvalidPayloadData,
-            )))
-            .await?;
+        match kind {
+            StateKind::MainState => target_transaction_info
+                .ensure_state_checkpoint_hash()
+                .map_err(|error| {
+                    Error::UnexpectedError(format!(
+                        "State checkpoint must exist! Error: {:?}",
+                        error
+                    ))
+                }),
+            StateKind::Position => target_transaction_info
+                .position_state_checkpoint_hash()
+                .ok_or_else(|| Error::UnexpectedError("Missing position state root!".into())),
+        }
+    }
+
+    /// Verifies the chunk's root hash against the expected snapshot root for the
+    /// kind. Resets the stream and errors on a mismatch.
+    async fn verify_state_value_chunk_root(
+        &mut self,
+        notification_id: NotificationId,
+        kind: StateKind,
+        state_value_chunk_with_proof: &StateValueChunkWithProof,
+    ) -> Result<HashValue, Error> {
+        let expected_root_hash = self.expected_snapshot_root(kind)?;
+        let chunk_root_hash = state_value_chunk_with_proof.root_hash;
+        if chunk_root_hash != expected_root_hash {
+            self.reset_stream(notification_id, NotificationFeedback::InvalidPayloadData)
+                .await?;
             return Err(Error::VerificationError(format!(
-                "The states chunk with proof root hash: {:?} didn't match the expected hash: {:?}!",
-                state_value_chunk_with_proof.root_hash, expected_root_hash,
+                "The {:?} states chunk root hash: {:?} didn't match the expected hash: {:?}!",
+                kind, chunk_root_hash, expected_root_hash,
             )));
+        }
+        Ok(expected_root_hash)
+    }
+
+    /// Process a single state value chunk with proof payload (of the given kind).
+    async fn process_state_values_payload(
+        &mut self,
+        notification_id: NotificationId,
+        state_value_chunk_with_proof: StateValueChunkWithProof,
+        kind: StateKind,
+    ) -> Result<(), Error> {
+        // Verify that we're expecting state value payloads
+        if self.should_fetch_epoch_ending_ledger_infos()
+            || !self.get_bootstrapping_mode().is_fast_sync()
+        {
+            self.reset_stream(notification_id, NotificationFeedback::InvalidPayloadData)
+                .await?;
+            return Err(Error::InvalidPayload(format!(
+                "Received an unexpected {:?} state values payload!",
+                kind
+            )));
+        }
+
+        // Fetch the pinned target ledger info for this snapshot kind
+        let ledger_info_to_sync = self
+            .state_value_syncer(kind)
+            .ledger_info_to_sync
+            .clone()
+            .ok_or_else(|| {
+                Error::UnexpectedError(format!("The {:?} ledger info to sync is missing!", kind))
+            })?;
+
+        // Verify the chunk root hash against the expected root before initializing the
+        // receiver, so a bad first chunk doesn't latch a receiver bound to the
+        // wrong root.
+        let expected_root_hash = self
+            .verify_state_value_chunk_root(notification_id, kind, &state_value_chunk_with_proof)
+            .await?;
+
+        // Verify the state values payload start and end indices
+        let expected_start_index = self.state_value_syncer(kind).next_state_index_to_process;
+        self.verify_state_value_chunk_indices(
+            notification_id,
+            expected_start_index,
+            kind,
+            &state_value_chunk_with_proof,
+        )
+        .await?;
+
+        // Initialize the state snapshot synchronizer (if not already done). The
+        // whole-fast-sync finalize (accumulator + commit) is performed later,
+        // once all snapshots are written, via `finalize_fast_sync`.
+        if !self
+            .state_value_syncer(kind)
+            .initialized_state_snapshot_receiver
+        {
+            let _join_handle = self.storage_synchronizer.initialize_snapshot_synchronizer(
+                ledger_info_to_sync,
+                expected_root_hash,
+                kind,
+            )?;
+            self.state_value_syncer_mut(kind)
+                .initialized_state_snapshot_receiver = true;
         }
 
         // Process the state values chunk and proof
@@ -1037,19 +1095,17 @@ impl<
             .save_state_values(notification_id, state_value_chunk_with_proof)
             .await
         {
-            self.reset_active_stream(Some(NotificationAndFeedback::new(
-                notification_id,
-                NotificationFeedback::InvalidPayloadData,
-            )))
-            .await?;
+            self.reset_stream(notification_id, NotificationFeedback::InvalidPayloadData)
+                .await?;
             return Err(Error::InvalidPayload(format!(
-                "The states chunk with proof was invalid! Error: {:?}",
-                error,
+                "The {:?} states chunk with proof was invalid! Error: {:?}",
+                kind, error,
             )));
         }
 
         // Update the next state value index to process
-        self.state_value_syncer.next_state_index_to_process =
+        self.state_value_syncer_mut(kind)
+            .next_state_index_to_process =
             last_state_value_index.checked_add(1).ok_or_else(|| {
                 Error::IntegerOverflow(
                     "The next state value index to process has overflown!".into(),
@@ -1057,6 +1113,144 @@ impl<
             })?;
 
         Ok(())
+    }
+
+    /// Whether the given snapshot kind participates in the fast sync to this
+    /// target. Main state always does. Native-position only participates once the
+    /// target's `TransactionInfo` commits a position state root: until the
+    /// executor sets it there is no authenticated position state to sync, so the
+    /// stage is skipped rather than trusting an unproved peer-supplied root.
+    /// Requires the target transaction output to already be fetched.
+    fn snapshot_kind_applies_to_target(&mut self, kind: StateKind) -> Result<bool, Error> {
+        match kind {
+            StateKind::MainState => Ok(true),
+            StateKind::Position => {
+                let transaction_output_to_sync = self.get_transaction_output_to_sync()?;
+                let target_transaction_info = transaction_output_to_sync
+                    .get_output_list_with_proof()
+                    .proof
+                    .transaction_infos
+                    .first()
+                    .ok_or_else(|| {
+                        Error::UnexpectedError("Target transaction info does not exist!".into())
+                    })?;
+                Ok(target_transaction_info
+                    .position_state_checkpoint_hash()
+                    .is_some())
+            },
+        }
+    }
+
+    /// Drives the fast-sync snapshots to the target: fetches the target output
+    /// once up front (needed for each kind's root check and the finalize), streams
+    /// each not-yet-written applicable kind, then finalizes once all are written.
+    /// The kinds are peers driven one at a time only because the bootstrapper runs
+    /// a single data stream, not because of any ordering dependency.
+    async fn drive_snapshot_stages(
+        &mut self,
+        target_ledger_info: LedgerInfoWithSignatures,
+    ) -> Result<(), Error> {
+        // Pin the target (read by the output-verification path) and fetch the
+        // target transaction output first, re-fetching it on resume.
+        self.pin_ledger_info_to_sync(target_ledger_info.clone(), StateKind::MainState)?;
+        if self.state_value_syncer.transaction_output_to_sync.is_none() {
+            let version = target_ledger_info.ledger_info().version();
+            let data_stream = self
+                .streaming_client
+                .get_all_transaction_outputs(version, version, version)
+                .await?;
+            self.active_data_stream = Some(data_stream);
+            return Ok(());
+        }
+
+        // Drive the next applicable snapshot kind that isn't written yet.
+        for kind in FAST_SYNC_SNAPSHOT_KINDS {
+            if !self.snapshot_kind_applies_to_target(kind)? {
+                continue;
+            }
+            match self.metadata_storage.previous_snapshot_sync_target(kind)? {
+                Some(previous_target) if previous_target == target_ledger_info => {
+                    // This kind has started syncing to the target.
+                    if self
+                        .metadata_storage
+                        .is_snapshot_sync_complete(&target_ledger_info, kind)?
+                    {
+                        continue; // Already written; move on to the next kind.
+                    }
+                    return self
+                        .fetch_missing_state_values(target_ledger_info, true, kind)
+                        .await;
+                },
+                Some(stale_target) => {
+                    // Progress exists for a different target. All kinds sync to
+                    // the same target, so this is an inconsistent metadata state
+                    // (the per-kind `update_last_persisted_index` would reject the
+                    // mismatch and wedge the stage). Surface it clearly instead.
+                    return Err(Error::UnexpectedError(format!(
+                        "The {:?} snapshot progress targets a different ledger info than the \
+                         current fast-sync target! Stored: {:?}, target: {:?}",
+                        kind, stale_target, target_ledger_info,
+                    )));
+                },
+                None => {
+                    // No progress recorded. If the stream was already requested and
+                    // returned no state values, the tree is empty: verify emptiness
+                    // against the committed root (not the unproved peer count) rather
+                    // than re-streaming. Otherwise, start streaming.
+                    let stream_requested = self.state_value_syncer(kind).stream_requested;
+                    let receiver_initialized = self
+                        .state_value_syncer(kind)
+                        .initialized_state_snapshot_receiver;
+                    if stream_requested && !receiver_initialized {
+                        if self.expected_snapshot_root(kind)? == *SPARSE_MERKLE_PLACEHOLDER_HASH {
+                            self.metadata_storage.update_last_persisted_index(
+                                &target_ledger_info,
+                                0,
+                                true,
+                                kind,
+                            )?;
+                            continue;
+                        }
+                        return Err(Error::UnexpectedError(format!(
+                            "The {:?} snapshot stream ended without any state values, but the \
+                             committed snapshot root is not the empty-tree placeholder! Target: {:?}",
+                            kind, target_ledger_info,
+                        )));
+                    }
+                    return self
+                        .fetch_missing_state_values(target_ledger_info, false, kind)
+                        .await;
+                },
+            }
+        }
+
+        // All snapshots are written; finalize the whole fast sync.
+        self.finalize_fast_sync_and_complete(target_ledger_info)
+            .await
+    }
+
+    /// Finalizes the whole fast-sync once all snapshots are written: bootstraps
+    /// the accumulator, sends the commit notification, and marks bootstrapping
+    /// complete.
+    async fn finalize_fast_sync_and_complete(
+        &mut self,
+        target_ledger_info: LedgerInfoWithSignatures,
+    ) -> Result<(), Error> {
+        let version = target_ledger_info.ledger_info().version();
+        let epoch_change_proofs = if version == GENESIS_TRANSACTION_VERSION {
+            vec![target_ledger_info.clone()] // Synced to genesis
+        } else {
+            self.verified_epoch_states.all_epoch_ending_ledger_infos()
+        };
+        let transaction_output_to_sync = self.get_transaction_output_to_sync()?;
+        self.storage_synchronizer
+            .finalize_fast_sync(
+                epoch_change_proofs,
+                target_ledger_info,
+                transaction_output_to_sync,
+            )
+            .await?;
+        self.bootstrapping_complete().await
     }
 
     /// Process a single epoch ending payload
@@ -1067,11 +1261,8 @@ impl<
     ) -> Result<(), Error> {
         // Verify that we're expecting epoch ending ledger info payloads
         if !self.should_fetch_epoch_ending_ledger_infos() {
-            self.reset_active_stream(Some(NotificationAndFeedback::new(
-                notification_id,
-                NotificationFeedback::InvalidPayloadData,
-            )))
-            .await?;
+            self.reset_stream(notification_id, NotificationFeedback::InvalidPayloadData)
+                .await?;
             return Err(Error::InvalidPayload(
                 "Received an unexpected epoch ending payload!".into(),
             ));
@@ -1079,11 +1270,8 @@ impl<
 
         // Verify the payload isn't empty
         if epoch_ending_ledger_infos.is_empty() {
-            self.reset_active_stream(Some(NotificationAndFeedback::new(
-                notification_id,
-                NotificationFeedback::EmptyPayloadData,
-            )))
-            .await?;
+            self.reset_stream(notification_id, NotificationFeedback::EmptyPayloadData)
+                .await?;
             return Err(Error::VerificationError(
                 "The epoch ending payload was empty!".into(),
             ));
@@ -1096,11 +1284,8 @@ impl<
                 &epoch_ending_ledger_info,
                 &self.driver_configuration.waypoint,
             ) {
-                self.reset_active_stream(Some(NotificationAndFeedback::new(
-                    notification_id,
-                    NotificationFeedback::PayloadProofFailed,
-                )))
-                .await?;
+                self.reset_stream(notification_id, NotificationFeedback::PayloadProofFailed)
+                    .await?;
                 return Err(error);
             }
         }
@@ -1125,10 +1310,10 @@ impl<
             || (bootstrapping_mode.is_fast_sync()
                 && self.state_value_syncer.transaction_output_to_sync.is_some())
         {
-            self.reset_active_stream(Some(NotificationAndFeedback::new(
+            self.reset_stream(
                 notification_metadata.notification_id,
                 NotificationFeedback::InvalidPayloadData,
-            )))
+            )
             .await?;
             return Err(Error::InvalidPayload(
                 "Received an unexpected transaction or output payload!".into(),
@@ -1186,10 +1371,10 @@ impl<
                     )
                     .await?
                 } else {
-                    self.reset_active_stream(Some(NotificationAndFeedback::new(
+                    self.reset_stream(
                         notification_metadata.notification_id,
                         NotificationFeedback::PayloadTypeIsIncorrect,
-                    )))
+                    )
                     .await?;
                     return Err(Error::InvalidPayload(
                         "Did not receive transaction outputs with proof!".into(),
@@ -1207,10 +1392,10 @@ impl<
                     )
                     .await?
                 } else {
-                    self.reset_active_stream(Some(NotificationAndFeedback::new(
+                    self.reset_stream(
                         notification_metadata.notification_id,
                         NotificationFeedback::PayloadTypeIsIncorrect,
-                    )))
+                    )
                     .await?;
                     return Err(Error::InvalidPayload(
                         "Did not receive transactions with proof!".into(),
@@ -1238,10 +1423,10 @@ impl<
                     )
                     .await?
                 } else {
-                    self.reset_active_stream(Some(NotificationAndFeedback::new(
+                    self.reset_stream(
                         notification_metadata.notification_id,
                         NotificationFeedback::PayloadTypeIsIncorrect,
-                    )))
+                    )
                     .await?;
                     return Err(Error::InvalidPayload(
                         "Did not receive transactions or outputs with proof!".into(),
@@ -1300,10 +1485,10 @@ impl<
                             .set_transaction_output_to_sync(transaction_outputs_with_proof);
                     },
                     Err(error) => {
-                        self.reset_active_stream(Some(NotificationAndFeedback::new(
+                        self.reset_stream(
                             notification_id,
                             NotificationFeedback::PayloadProofFailed,
-                        )))
+                        )
                         .await?;
                         return Err(Error::VerificationError(format!(
                             "Transaction outputs with proof is invalid! Error: {:?}",
@@ -1312,20 +1497,17 @@ impl<
                     },
                 }
             } else {
-                self.reset_active_stream(Some(NotificationAndFeedback::new(
-                    notification_id,
-                    NotificationFeedback::InvalidPayloadData,
-                )))
-                .await?;
+                self.reset_stream(notification_id, NotificationFeedback::InvalidPayloadData)
+                    .await?;
                 return Err(Error::InvalidPayload(
                     "Payload does not contain a single transaction info!".into(),
                 ));
             }
         } else {
-            self.reset_active_stream(Some(NotificationAndFeedback::new(
+            self.reset_stream(
                 notification_id,
                 NotificationFeedback::PayloadTypeIsIncorrect,
-            )))
+            )
             .await?;
             return Err(Error::InvalidPayload(
                 "Did not receive transaction outputs with proof!".into(),
@@ -1344,11 +1526,8 @@ impl<
     ) -> Result<Version, Error> {
         if let Some(payload_start_version) = payload_start_version {
             if payload_start_version != expected_start_version {
-                self.reset_active_stream(Some(NotificationAndFeedback::new(
-                    notification_id,
-                    NotificationFeedback::InvalidPayloadData,
-                )))
-                .await?;
+                self.reset_stream(notification_id, NotificationFeedback::InvalidPayloadData)
+                    .await?;
                 Err(Error::VerificationError(format!(
                     "The payload start version does not match the expected version! Start: {:?}, expected: {:?}",
                     payload_start_version, expected_start_version
@@ -1357,11 +1536,8 @@ impl<
                 Ok(payload_start_version)
             }
         } else {
-            self.reset_active_stream(Some(NotificationAndFeedback::new(
-                notification_id,
-                NotificationFeedback::EmptyPayloadData,
-            )))
-            .await?;
+            self.reset_stream(notification_id, NotificationFeedback::EmptyPayloadData)
+                .await?;
             Err(Error::VerificationError(
                 "The playload starting version is missing!".into(),
             ))
@@ -1384,10 +1560,10 @@ impl<
                 if let Some(transaction_outputs_with_proof) = transaction_outputs_with_proof {
                     transaction_outputs_with_proof.get_num_outputs()
                 } else {
-                    self.reset_active_stream(Some(NotificationAndFeedback::new(
+                    self.reset_stream(
                         notification_id,
                         NotificationFeedback::PayloadTypeIsIncorrect,
-                    )))
+                    )
                     .await?;
                     return Err(Error::InvalidPayload(
                         "Did not receive transaction outputs with proof!".into(),
@@ -1398,10 +1574,10 @@ impl<
                 if let Some(transaction_list_with_proof) = transaction_list_with_proof {
                     transaction_list_with_proof.get_num_transactions()
                 } else {
-                    self.reset_active_stream(Some(NotificationAndFeedback::new(
+                    self.reset_stream(
                         notification_id,
                         NotificationFeedback::PayloadTypeIsIncorrect,
-                    )))
+                    )
                     .await?;
                     return Err(Error::InvalidPayload(
                         "Did not receive transactions with proof!".into(),
@@ -1414,10 +1590,10 @@ impl<
                 } else if let Some(output_list_with_proof) = transaction_outputs_with_proof {
                     output_list_with_proof.get_num_outputs()
                 } else {
-                    self.reset_active_stream(Some(NotificationAndFeedback::new(
+                    self.reset_stream(
                         notification_id,
                         NotificationFeedback::PayloadTypeIsIncorrect,
-                    )))
+                    )
                     .await?;
                     return Err(Error::InvalidPayload(
                         "Did not receive transactions or outputs with proof!".into(),
@@ -1535,7 +1711,20 @@ impl<
         Ok(())
     }
 
-    /// Resets the currently active data stream and speculative state
+    /// Resets the active data stream, attaching `feedback` for the given
+    /// notification. A terse wrapper over `reset_active_stream`.
+    async fn reset_stream(
+        &mut self,
+        notification_id: NotificationId,
+        feedback: NotificationFeedback,
+    ) -> Result<(), Error> {
+        self.reset_active_stream(Some(NotificationAndFeedback::new(
+            notification_id,
+            feedback,
+        )))
+        .await
+    }
+
     pub async fn reset_active_stream(
         &mut self,
         notification_and_feedback: Option<NotificationAndFeedback>,

--- a/state-sync/state-sync-driver/src/metadata_storage.rs
+++ b/state-sync/state-sync-driver/src/metadata_storage.rs
@@ -13,6 +13,7 @@ use aptos_schemadb::{
     schema::{KeyCodec, ValueCodec},
     ColumnFamilyName, Options, DB,
 };
+use aptos_storage_interface::StateKind;
 use aptos_types::ledger_info::LedgerInfoWithSignatures;
 use serde::{Deserialize, Serialize};
 use std::{path::Path, sync::Arc, time::Instant};
@@ -22,32 +23,64 @@ use std::{path::Path, sync::Arc, time::Instant};
 /// of the syncing process, where a failure may cause an inconsistent
 /// state to remain in the database on startup.
 pub trait MetadataStorageInterface {
-    /// Returns true iff a state snapshot was successfully committed for the
-    /// specified target. If no snapshot progress is found, an error is returned.
+    /// Returns true iff a snapshot of the given `kind` was successfully
+    /// committed for the specified target.
+    /// If no snapshot progress is found, an error is returned.
     fn is_snapshot_sync_complete(
         &self,
         target_ledger_info: &LedgerInfoWithSignatures,
+        kind: StateKind,
     ) -> Result<bool, Error>;
 
-    /// Gets the last persisted state value index for the snapshot sync at the
+    /// Gets the last persisted value index for the `kind` snapshot sync at the
     /// specified version. If no snapshot progress is found, an error is returned.
-    fn get_last_persisted_state_value_index(
+    fn get_last_persisted_index(
         &self,
         target_ledger_info: &LedgerInfoWithSignatures,
+        kind: StateKind,
     ) -> Result<u64, Error>;
 
-    /// Returns the target ledger info of any state snapshot sync that has previously
-    /// started. If no snapshot sync started, None is returned.
-    fn previous_snapshot_sync_target(&self) -> Result<Option<LedgerInfoWithSignatures>, Error>;
+    /// Returns the target ledger info of any `kind` snapshot sync that has
+    /// previously started. If no snapshot sync started, None is returned.
+    fn previous_snapshot_sync_target(
+        &self,
+        kind: StateKind,
+    ) -> Result<Option<LedgerInfoWithSignatures>, Error>;
 
-    /// Updates the last persisted state value index for the state snapshot
-    /// sync at the specified target ledger info.
-    fn update_last_persisted_state_value_index(
+    /// Updates the last persisted value index for the `kind` snapshot sync at
+    /// the specified target ledger info.
+    fn update_last_persisted_index(
         &self,
         target_ledger_info: &LedgerInfoWithSignatures,
-        last_persisted_state_value_index: u64,
+        last_persisted_index: u64,
         snapshot_sync_completed: bool,
+        kind: StateKind,
     ) -> Result<(), Error>;
+}
+
+/// The `MetadataKey` for the given snapshot kind's progress row. Each kind is an
+/// independent row carrying a `StateSnapshotProgress`.
+fn snapshot_metadata_key(kind: StateKind) -> MetadataKey {
+    match kind {
+        StateKind::MainState => MetadataKey::StateSnapshotSync,
+        StateKind::Position => MetadataKey::PositionSnapshotSync,
+    }
+}
+
+/// The `MetadataValue` wrapping `progress` for the given snapshot kind.
+fn snapshot_metadata_value(kind: StateKind, progress: StateSnapshotProgress) -> MetadataValue {
+    match kind {
+        StateKind::MainState => MetadataValue::StateSnapshotSync(progress),
+        StateKind::Position => MetadataValue::PositionSnapshotSync(progress),
+    }
+}
+
+/// A short label for the given snapshot kind, used in log/error messages.
+fn snapshot_kind_label(kind: StateKind) -> &'static str {
+    match kind {
+        StateKind::MainState => "state",
+        StateKind::Position => "position",
+    }
 }
 
 /// The name of the state sync db file
@@ -94,9 +127,12 @@ impl PersistentMetadataStorage {
         Self { database }
     }
 
-    /// Returns the existing snapshot sync progress. Returns None if no progress is found.
-    fn get_snapshot_progress(&self) -> Result<Option<StateSnapshotProgress>, Error> {
-        let metadata_key = MetadataKey::StateSnapshotSync;
+    /// Returns the existing snapshot sync progress for `kind`. None if not found.
+    fn get_snapshot_progress(
+        &self,
+        kind: StateKind,
+    ) -> Result<Option<StateSnapshotProgress>, Error> {
+        let metadata_key = snapshot_metadata_key(kind);
         let maybe_metadata_value =
             self.database
                 .get::<MetadataSchema>(&metadata_key)
@@ -106,35 +142,46 @@ impl PersistentMetadataStorage {
                         metadata_key, error
                     ))
                 })?;
-        match maybe_metadata_value {
-            Some(metadata_value) => {
-                let MetadataValue::StateSnapshotSync(snapshot_progress) = metadata_value;
-                Ok(Some(snapshot_progress))
+        // Each kind is stored under its own key, so a value of the other variant
+        // is never expected; treat it (and a missing row) as no progress.
+        let progress = match maybe_metadata_value {
+            None => None,
+            Some(MetadataValue::StateSnapshotSync(progress)) => match kind {
+                StateKind::MainState => Some(progress),
+                StateKind::Position => None,
             },
-            None => Ok(None),
-        }
+            Some(MetadataValue::PositionSnapshotSync(progress)) => match kind {
+                StateKind::Position => Some(progress),
+                StateKind::MainState => None,
+            },
+        };
+        Ok(progress)
     }
 
-    /// Returns the snapshot sync progress recorded for the specified version.
-    /// Returns an error if no progress was found.
+    /// Returns the snapshot sync progress recorded for `kind` at the specified
+    /// target. Returns an error if no progress was found.
     fn get_snapshot_progress_at_target(
         &self,
+        kind: StateKind,
         target_ledger_info: &LedgerInfoWithSignatures,
     ) -> Result<StateSnapshotProgress, Error> {
-        match self.get_snapshot_progress()? {
+        match self.get_snapshot_progress(kind)? {
             Some(snapshot_progress) => {
                 if &snapshot_progress.target_ledger_info != target_ledger_info {
                     Err(Error::UnexpectedError(format!(
-                        "Expected a snapshot progress for target {:?}, but found {:?}!",
-                        target_ledger_info, snapshot_progress.target_ledger_info
+                        "Expected a {} snapshot progress for target {:?}, but found {:?}!",
+                        snapshot_kind_label(kind),
+                        target_ledger_info,
+                        snapshot_progress.target_ledger_info
                     )))
                 } else {
                     Ok(snapshot_progress)
                 }
             },
-            None => Err(Error::StorageError(
-                "No state snapshot progress was found!".into(),
-            )),
+            None => Err(Error::StorageError(format!(
+                "No {} snapshot progress was found!",
+                snapshot_kind_label(kind)
+            ))),
         }
     }
 
@@ -179,51 +226,56 @@ impl PersistentMetadataStorage {
 }
 
 impl MetadataStorageInterface for PersistentMetadataStorage {
-    fn is_snapshot_sync_complete(&self, target: &LedgerInfoWithSignatures) -> Result<bool, Error> {
-        let snapshot_progress = self.get_snapshot_progress_at_target(target)?;
+    fn is_snapshot_sync_complete(
+        &self,
+        target: &LedgerInfoWithSignatures,
+        kind: StateKind,
+    ) -> Result<bool, Error> {
+        let snapshot_progress = self.get_snapshot_progress_at_target(kind, target)?;
         Ok(snapshot_progress.snapshot_sync_completed)
     }
 
-    fn get_last_persisted_state_value_index(
+    fn get_last_persisted_index(
         &self,
         target: &LedgerInfoWithSignatures,
+        kind: StateKind,
     ) -> Result<u64, Error> {
-        let snapshot_progress = self.get_snapshot_progress_at_target(target)?;
+        let snapshot_progress = self.get_snapshot_progress_at_target(kind, target)?;
         Ok(snapshot_progress.last_persisted_state_value_index)
     }
 
-    fn previous_snapshot_sync_target(&self) -> Result<Option<LedgerInfoWithSignatures>, Error> {
+    fn previous_snapshot_sync_target(
+        &self,
+        kind: StateKind,
+    ) -> Result<Option<LedgerInfoWithSignatures>, Error> {
         Ok(self
-            .get_snapshot_progress()?
+            .get_snapshot_progress(kind)?
             .map(|snapshot_progress| snapshot_progress.target_ledger_info))
     }
 
-    fn update_last_persisted_state_value_index(
+    fn update_last_persisted_index(
         &self,
         target_ledger_info: &LedgerInfoWithSignatures,
-        last_persisted_state_value_index: u64,
+        last_persisted_index: u64,
         snapshot_sync_completed: bool,
+        kind: StateKind,
     ) -> Result<(), Error> {
-        // Ensure that if any previous snapshot progress exists, it has the same target
-        if let Some(snapshot_progress) = self.get_snapshot_progress()? {
+        // Ensure any existing progress for this kind is for the same target.
+        if let Some(snapshot_progress) = self.get_snapshot_progress(kind)? {
             if target_ledger_info != &snapshot_progress.target_ledger_info {
-                return Err(Error::StorageError(format!("Failed to update the last persisted state value index! \
+                return Err(Error::StorageError(format!("Failed to update the last persisted {} index! \
                 The given target does not match the previously stored target. Given target: {:?}, stored target: {:?}",
-                    target_ledger_info, snapshot_progress.target_ledger_info
+                    snapshot_kind_label(kind), target_ledger_info, snapshot_progress.target_ledger_info
                 )));
             }
         }
 
-        // Create the key/value pair
-        let metadata_key = MetadataKey::StateSnapshotSync;
-        let metadata_value = MetadataValue::StateSnapshotSync(StateSnapshotProgress {
-            last_persisted_state_value_index,
+        let metadata_value = snapshot_metadata_value(kind, StateSnapshotProgress {
+            last_persisted_state_value_index: last_persisted_index,
             snapshot_sync_completed,
             target_ledger_info: target_ledger_info.clone(),
         });
-
-        // Insert the new key/value pair
-        self.commit_key_value(metadata_key, metadata_value)
+        self.commit_key_value(snapshot_metadata_key(kind), metadata_value)
     }
 }
 
@@ -252,7 +304,8 @@ pub mod database_schema {
     #[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
     #[repr(u8)]
     pub enum MetadataKey {
-        StateSnapshotSync, // A state snapshot sync that was started
+        StateSnapshotSync,    // A state snapshot sync that was started
+        PositionSnapshotSync, // A native-position snapshot sync that was started
     }
 
     /// A metadata value that can be inserted into the database
@@ -260,6 +313,7 @@ pub mod database_schema {
     #[repr(u8)]
     pub enum MetadataValue {
         StateSnapshotSync(StateSnapshotProgress), // A state snapshot sync progress marker
+        PositionSnapshotSync(StateSnapshotProgress), // A native-position snapshot sync progress marker
     }
 
     impl KeyCodec<MetadataSchema> for MetadataKey {

--- a/state-sync/state-sync-driver/src/metrics.rs
+++ b/state-sync/state-sync-driver/src/metrics.rs
@@ -34,6 +34,7 @@ pub const STORAGE_SYNCHRONIZER_UPDATE_LEDGER: &str = "update_ledger";
 pub const STORAGE_SYNCHRONIZER_COMMIT_CHUNK: &str = "commit_chunk";
 pub const STORAGE_SYNCHRONIZER_COMMIT_POST_PROCESS: &str = "commit_post_process";
 pub const STORAGE_SYNCHRONIZER_STATE_VALUE_CHUNK: &str = "state_value_chunk";
+pub const STORAGE_SYNCHRONIZER_POSITION_STATE_VALUE_CHUNK: &str = "position_state_value_chunk";
 
 /// Storage synchronizer pipeline channel labels
 pub const STORAGE_SYNCHRONIZER_EXECUTOR: &str = "executor";
@@ -70,6 +71,7 @@ pub enum StorageSynchronizerOperations {
     Synced,                    // The latest synced version (as read from storage)
     SyncedIncremental, // The latest synced version (calculated as the sum of all processed transactions)
     SyncedStates,      // The total number of synced states
+    SyncedPositionStates, // The total number of synced native-position states
     SyncedEpoch,       // The latest synced epoch (as read from storage)
     SyncedEpochIncremental, // The latest synced epoch (calculated as the sum of all processed epochs)
 }
@@ -84,6 +86,7 @@ impl StorageSynchronizerOperations {
             StorageSynchronizerOperations::Synced => "synced",
             StorageSynchronizerOperations::SyncedIncremental => "synced_incremental",
             StorageSynchronizerOperations::SyncedStates => "synced_states",
+            StorageSynchronizerOperations::SyncedPositionStates => "synced_position_states",
             StorageSynchronizerOperations::SyncedEpoch => "synced_epoch",
             StorageSynchronizerOperations::SyncedEpochIncremental => "synced_epoch_incremental",
         }

--- a/state-sync/state-sync-driver/src/storage_synchronizer.rs
+++ b/state-sync/state-sync-driver/src/storage_synchronizer.rs
@@ -5,7 +5,7 @@ use crate::{
     error::Error,
     logging::{LogEntry, LogSchema},
     metadata_storage::MetadataStorageInterface,
-    metrics,
+    metrics::{self, StorageSynchronizerOperations},
     notification_handlers::{
         CommitNotification, CommittedTransactions, ErrorNotification, MempoolNotificationHandler,
         StorageServiceNotificationHandler,
@@ -13,6 +13,7 @@ use crate::{
     utils,
 };
 use aptos_config::config::StateSyncDriverConfig;
+use aptos_crypto::HashValue;
 use aptos_data_streaming_service::data_notification::NotificationId;
 use aptos_event_notifications::EventSubscriptionService;
 use aptos_executor_types::{ChunkCommitNotification, ChunkExecutorTrait};
@@ -20,7 +21,7 @@ use aptos_infallible::Mutex;
 use aptos_logger::prelude::*;
 use aptos_mempool_notifications::MempoolNotificationSender;
 use aptos_metrics_core::HistogramTimer;
-use aptos_storage_interface::{DbReader, DbReaderWriter, StateSnapshotReceiver};
+use aptos_storage_interface::{DbReader, DbReaderWriter, StateKind, StateSnapshotReceiver};
 use aptos_storage_service_notifications::StorageServiceNotificationSender;
 use aptos_types::{
     ledger_info::LedgerInfoWithSignatures,
@@ -71,31 +72,41 @@ pub trait StorageSynchronizerInterface {
         end_of_epoch_ledger_info: Option<LedgerInfoWithSignatures>,
     ) -> Result<(), Error>;
 
-    /// Initializes a state synchronizer with the specified
-    /// `target_ledger_info` and `target_output_with_proof` at the target
-    /// syncing version. Returns a join handle to the state synchronizer.
-    ///
-    /// Note: this assumes that `epoch_change_proofs`, `target_ledger_info`,
-    /// and `target_output_with_proof` have already been verified.
-    fn initialize_state_synchronizer(
+    /// Initializes a snapshot synchronizer for the given `kind` at
+    /// `target_ledger_info`'s version, verifying chunks against `expected_root`.
+    /// Returns a join handle to the spawned receiver. The receiver only writes
+    /// the snapshot + records progress; the whole-fast-sync finalize is performed
+    /// separately via `finalize_fast_sync`.
+    fn initialize_snapshot_synchronizer(
         &mut self,
-        epoch_change_proofs: Vec<LedgerInfoWithSignatures>,
         target_ledger_info: LedgerInfoWithSignatures,
-        target_output_with_proof: TransactionOutputListWithProofV2,
+        expected_root: HashValue,
+        kind: StateKind,
     ) -> Result<JoinHandle<()>, Error>;
 
     /// Returns true iff there is storage data that is still waiting
     /// to be executed/applied or committed.
     fn pending_storage_data(&self) -> bool;
 
-    /// Saves the given state values to storage.
-    ///
-    /// Note: this requires that `initialize_state_synchronizer` has been
-    /// called.
+    /// Saves the given state values to storage, for whichever snapshot
+    /// synchronizer was last initialized.
     async fn save_state_values(
         &mut self,
         notification_id: NotificationId,
         state_value_chunk_with_proof: StateValueChunkWithProof,
+    ) -> Result<(), Error>;
+
+    /// Finalizes the whole fast-sync process once all snapshots have been
+    /// written: bootstraps the transaction accumulator, resets the chunk
+    /// executor, sends the commit notification, and initializes the sync gauges.
+    ///
+    /// Note: assumes `epoch_change_proofs`, `target_ledger_info`, and
+    /// `target_output_with_proof` have already been verified.
+    async fn finalize_fast_sync(
+        &mut self,
+        epoch_change_proofs: Vec<LedgerInfoWithSignatures>,
+        target_ledger_info: LedgerInfoWithSignatures,
+        target_output_with_proof: TransactionOutputListWithProofV2,
     ) -> Result<(), Error>;
 
     /// Resets the chunk executor. This is required to support continuous
@@ -155,7 +166,9 @@ pub struct StorageSynchronizer<ChunkExecutor, MetadataStorage> {
     // An optional runtime on which to spawn the storage synchronizer threads
     runtime: Option<Handle>,
 
-    // The channel through which to notify the state snapshot receiver of new data chunks
+    // The channel through which to notify the currently-active snapshot receiver
+    // of new data chunks. Snapshots are driven one at a time, so a single channel
+    // serves them.
     state_snapshot_notifier: Option<mpsc::Sender<StorageDataChunk>>,
 
     // The reader and writer for storage (required for state syncing)
@@ -369,32 +382,29 @@ impl<
         self.notify_executor(storage_data_chunk).await
     }
 
-    fn initialize_state_synchronizer(
+    fn initialize_snapshot_synchronizer(
         &mut self,
-        epoch_change_proofs: Vec<LedgerInfoWithSignatures>,
         target_ledger_info: LedgerInfoWithSignatures,
-        target_output_with_proof: TransactionOutputListWithProofV2,
+        expected_root: HashValue,
+        kind: StateKind,
     ) -> Result<JoinHandle<()>, Error> {
-        // Create a channel to notify the state snapshot receiver when data chunks are ready
+        // Create a channel to notify the snapshot receiver when data chunks are ready
         let max_pending_data_chunks = self.driver_config.max_pending_data_chunks as usize;
-        let (state_snapshot_notifier, state_snapshot_listener) =
-            mpsc::channel(max_pending_data_chunks);
+        let (snapshot_notifier, snapshot_listener) = mpsc::channel(max_pending_data_chunks);
 
-        // Spawn the state snapshot receiver that commits state values
-        let receiver_handle = spawn_state_snapshot_receiver(
-            self.chunk_executor.clone(),
-            state_snapshot_listener,
-            self.commit_notification_sender.clone(),
+        // Spawn the snapshot receiver that writes the snapshot values
+        let receiver_handle = spawn_snapshot_receiver(
+            kind,
+            snapshot_listener,
             self.error_notification_sender.clone(),
             self.pending_data_chunks.clone(),
             self.metadata_storage.clone(),
             self.storage.clone(),
-            epoch_change_proofs,
             target_ledger_info,
-            target_output_with_proof,
+            expected_root,
             self.runtime.clone(),
         );
-        self.state_snapshot_notifier = Some(state_snapshot_notifier);
+        self.state_snapshot_notifier = Some(snapshot_notifier);
 
         Ok(receiver_handle)
     }
@@ -431,6 +441,62 @@ impl<
             increment_pending_data_chunks(self.pending_data_chunks.clone());
             Ok(())
         }
+    }
+
+    async fn finalize_fast_sync(
+        &mut self,
+        epoch_change_proofs: Vec<LedgerInfoWithSignatures>,
+        target_ledger_info: LedgerInfoWithSignatures,
+        target_output_with_proof: TransactionOutputListWithProofV2,
+    ) -> Result<(), Error> {
+        let version = target_ledger_info.ledger_info().version();
+        let last_committed_state_index = self
+            .metadata_storage
+            .get_last_persisted_index(&target_ledger_info, StateKind::MainState)?;
+
+        // Bootstrap the transaction accumulator / ledger from the target output
+        self.storage
+            .writer
+            .finalize_state_snapshot(
+                version,
+                target_output_with_proof.clone(),
+                &epoch_change_proofs,
+            )
+            .map_err(|error| {
+                Error::UnexpectedError(format!(
+                    "Failed to finalize the state snapshot! Error: {:?}",
+                    error
+                ))
+            })?;
+
+        info!("Fast sync to version {} is complete!", version);
+
+        // Reset the chunk executor
+        self.reset_chunk_executor()?;
+
+        // Create and send the commit notification (the whole fast-sync is done)
+        let commit_notification = create_commit_notification(
+            target_output_with_proof,
+            last_committed_state_index,
+            version,
+        );
+        self.commit_notification_sender
+            .send(commit_notification)
+            .await
+            .map_err(|error| {
+                Error::UnexpectedError(format!(
+                    "Failed to send the final fast-sync commit notification! Error: {:?}",
+                    error
+                ))
+            })?;
+
+        // Update the counters
+        utils::initialize_sync_gauges(self.storage.reader.clone()).map_err(|error| {
+            Error::UnexpectedError(format!(
+                "Failed to initialize the state sync version gauges! Error: {:?}",
+                error
+            ))
+        })
     }
 
     fn reset_chunk_executor(&self) -> Result<(), Error> {
@@ -817,362 +883,232 @@ fn spawn_commit_post_processor<
     spawn(runtime, commit_post_processor)
 }
 
-/// Spawns a dedicated receiver that commits state values from a state snapshot
-fn spawn_state_snapshot_receiver<
-    ChunkExecutor: ChunkExecutorTrait + 'static,
+/// The outcome of applying a single snapshot chunk via [`apply_snapshot_chunk`].
+enum ChunkApplyOutcome {
+    /// The chunk was applied (or it failed and an error was sent); keep listening.
+    Continue,
+    /// The final chunk was applied; the caller should finalize the snapshot.
+    Finalize {
+        notification_id: NotificationId,
+        last_index: u64,
+    },
+}
+
+/// Applies a single snapshot chunk to `receiver`,
+/// updating the per-chunk metrics and (for non-final chunks) the persisted
+/// progress. The divergent finalize step is left to the caller, which is
+/// signalled via [`ChunkApplyOutcome::Finalize`]. Decrements the pending-chunk
+/// counter except on the finalize path (the caller does so after finalizing).
+async fn apply_snapshot_chunk<MetadataStorage: MetadataStorageInterface + Clone>(
+    receiver: &mut Box<dyn StateSnapshotReceiver<StateKey, StateValue>>,
+    storage_data_chunk: StorageDataChunk,
+    kind: StateKind,
+    metadata_storage: &MetadataStorage,
+    target_ledger_info: &LedgerInfoWithSignatures,
+    error_notification_sender: &mpsc::UnboundedSender<ErrorNotification>,
+    pending_data_chunks: &Arc<AtomicU64>,
+    version: Version,
+) -> ChunkApplyOutcome {
+    let (operation, noun) = match kind {
+        StateKind::MainState => (StorageSynchronizerOperations::SyncedStates, "state"),
+        StateKind::Position => (
+            StorageSynchronizerOperations::SyncedPositionStates,
+            "position state",
+        ),
+    };
+    match storage_data_chunk {
+        StorageDataChunk::States(notification_id, states_with_proof) => {
+            let all_states_synced = states_with_proof.is_last_chunk();
+            let last_committed_state_index = states_with_proof.last_index;
+            let num_state_values = states_with_proof.raw_values.len();
+
+            match receiver.add_chunk(
+                states_with_proof.raw_values,
+                states_with_proof.proof.clone(),
+            ) {
+                Ok(()) => {
+                    info!(LogSchema::new(LogEntry::StorageSynchronizer).message(&format!(
+                        "Committed a new {} value chunk! Chunk size: {:?}, last persisted index: {:?}",
+                        noun, num_state_values, last_committed_state_index
+                    )));
+
+                    // Update the chunk metrics
+                    let operation_label = operation.get_label();
+                    metrics::set_gauge(
+                        &metrics::STORAGE_SYNCHRONIZER_OPERATIONS,
+                        operation_label,
+                        last_committed_state_index,
+                    );
+                    metrics::observe_value(
+                        &metrics::STORAGE_SYNCHRONIZER_CHUNK_SIZES,
+                        operation_label,
+                        num_state_values as u64,
+                    );
+
+                    if all_states_synced {
+                        // The caller performs the (kind-specific) finalize.
+                        return ChunkApplyOutcome::Finalize {
+                            notification_id,
+                            last_index: last_committed_state_index,
+                        };
+                    }
+
+                    // Persist the last committed index for crash resumption
+                    let update_result = metadata_storage.clone().update_last_persisted_index(
+                        target_ledger_info,
+                        last_committed_state_index,
+                        false,
+                        kind,
+                    );
+                    if let Err(error) = update_result {
+                        let error = format!("Failed to update the last persisted {} index at version: {:?}! Error: {:?}", noun, version, error);
+                        send_storage_synchronizer_error(
+                            error_notification_sender.clone(),
+                            notification_id,
+                            error,
+                        )
+                        .await;
+                    }
+                },
+                Err(error) => {
+                    let error =
+                        format!("Failed to commit {} value chunk! Error: {:?}", noun, error);
+                    send_storage_synchronizer_error(
+                        error_notification_sender.clone(),
+                        notification_id,
+                        error,
+                    )
+                    .await;
+                },
+            }
+        },
+        storage_data_chunk => {
+            unimplemented!(
+                "Invalid storage data chunk sent to snapshot receiver! This shouldn't happen: {:?}",
+                storage_data_chunk
+            );
+        },
+    }
+    decrement_pending_data_chunks(pending_data_chunks.clone());
+    ChunkApplyOutcome::Continue
+}
+
+/// Spawns a dedicated receiver that writes a snapshot of the given `kind` and
+/// records its progress. The whole-fast-sync finalize (accumulator bootstrap +
+/// commit notification) is performed separately via
+/// `StorageSynchronizerInterface::finalize_fast_sync`.
+fn spawn_snapshot_receiver<
     MetadataStorage: MetadataStorageInterface + Clone + Send + Sync + 'static,
 >(
-    chunk_executor: Arc<ChunkExecutor>,
-    mut state_snapshot_listener: mpsc::Receiver<StorageDataChunk>,
-    mut commit_notification_sender: mpsc::UnboundedSender<CommitNotification>,
+    kind: StateKind,
+    mut snapshot_listener: mpsc::Receiver<StorageDataChunk>,
     error_notification_sender: mpsc::UnboundedSender<ErrorNotification>,
     pending_data_chunks: Arc<AtomicU64>,
     metadata_storage: MetadataStorage,
     storage: DbReaderWriter,
-    epoch_change_proofs: Vec<LedgerInfoWithSignatures>,
     target_ledger_info: LedgerInfoWithSignatures,
-    target_output_with_proof: TransactionOutputListWithProofV2,
+    expected_root: HashValue,
     runtime: Option<Handle>,
 ) -> JoinHandle<()> {
-    // Create a state snapshot receiver
+    let timer_label = match kind {
+        StateKind::MainState => metrics::STORAGE_SYNCHRONIZER_STATE_VALUE_CHUNK,
+        StateKind::Position => metrics::STORAGE_SYNCHRONIZER_POSITION_STATE_VALUE_CHUNK,
+    };
     let receiver = async move {
-        // Get the target version and expected root hash
         let version = target_ledger_info.ledger_info().version();
-        let expected_root_hash = target_output_with_proof
-            .get_output_list_with_proof()
-            .proof
-            .transaction_infos
-            .first()
-            .expect("Target transaction info should exist!")
-            .ensure_state_checkpoint_hash()
-            .expect("Must be at state checkpoint.");
+        let mut snapshot_receiver: Option<Box<dyn StateSnapshotReceiver<StateKey, StateValue>>> =
+            None;
 
-        // Create the snapshot receiver
-        let mut state_snapshot_receiver = storage
-            .writer
-            .get_state_snapshot_receiver(version, expected_root_hash)
-            .expect("Failed to initialize the state snapshot receiver!");
+        while let Some(storage_data_chunk) = snapshot_listener.next().await {
+            let _timer =
+                metrics::start_timer(&metrics::STORAGE_SYNCHRONIZER_LATENCIES, timer_label);
 
-        // Handle state value chunks
-        while let Some(storage_data_chunk) = state_snapshot_listener.next().await {
-            // Start the snapshot timer for the state value chunk
-            let _timer = metrics::start_timer(
-                &metrics::STORAGE_SYNCHRONIZER_LATENCIES,
-                metrics::STORAGE_SYNCHRONIZER_STATE_VALUE_CHUNK,
-            );
-
-            // Commit the state value chunk
-            match storage_data_chunk {
-                StorageDataChunk::States(notification_id, states_with_proof) => {
-                    // Commit the state value chunk
-                    let all_states_synced = states_with_proof.is_last_chunk();
-                    let last_committed_state_index = states_with_proof.last_index;
-                    let num_state_values = states_with_proof.raw_values.len();
-
-                    let result = state_snapshot_receiver.add_chunk(
-                        states_with_proof.raw_values,
-                        states_with_proof.proof.clone(),
-                    );
-
-                    // Handle the commit result
-                    match result {
-                        Ok(()) => {
-                            // Update the logs and metrics
-                            info!(
-                                LogSchema::new(LogEntry::StorageSynchronizer).message(&format!(
-                                    "Committed a new state value chunk! Chunk size: {:?}, last persisted index: {:?}",
-                                    num_state_values,
-                                    last_committed_state_index
-                                ))
-                            );
-
-                            // Update the chunk metrics
-                            let operation_label =
-                                metrics::StorageSynchronizerOperations::SyncedStates.get_label();
-                            metrics::set_gauge(
-                                &metrics::STORAGE_SYNCHRONIZER_OPERATIONS,
-                                operation_label,
-                                last_committed_state_index,
-                            );
-                            metrics::observe_value(
-                                &metrics::STORAGE_SYNCHRONIZER_CHUNK_SIZES,
-                                operation_label,
-                                num_state_values as u64,
-                            );
-
-                            if !all_states_synced {
-                                // Update the metadata storage with the last committed state index
-                                if let Err(error) = metadata_storage
-                                    .clone()
-                                    .update_last_persisted_state_value_index(
-                                        &target_ledger_info,
-                                        last_committed_state_index,
-                                        all_states_synced,
-                                    )
-                                {
-                                    let error = format!("Failed to update the last persisted state index at version: {:?}! Error: {:?}", version, error);
-                                    send_storage_synchronizer_error(
-                                        error_notification_sender.clone(),
-                                        notification_id,
-                                        error,
-                                    )
-                                    .await;
-                                }
-                                decrement_pending_data_chunks(pending_data_chunks.clone());
-                                continue; // Wait for the next chunk
-                            }
-
-                            // Finalize storage and send a commit notification
-                            if let Err(error) = finalize_storage_and_send_commit(
-                                chunk_executor,
-                                &mut commit_notification_sender,
-                                metadata_storage,
-                                state_snapshot_receiver,
-                                storage,
-                                &epoch_change_proofs,
-                                target_output_with_proof,
-                                version,
-                                &target_ledger_info,
-                                last_committed_state_index,
-                            )
-                            .await
-                            {
-                                send_storage_synchronizer_error(
-                                    error_notification_sender.clone(),
-                                    notification_id,
-                                    error,
-                                )
-                                .await;
-                            }
-                            decrement_pending_data_chunks(pending_data_chunks.clone());
-                            return; // There's nothing left to do!
-                        },
-                        Err(error) => {
-                            let error =
-                                format!("Failed to commit state value chunk! Error: {:?}", error);
+            // Create the receiver lazily on the first chunk, so a failure (e.g.
+            // the native-position backend not being attached locally) surfaces as
+            // a recoverable error notification tied to the chunk, rather than
+            // panicking the receiver task.
+            if snapshot_receiver.is_none() {
+                match storage
+                    .writer
+                    .get_state_snapshot_receiver(version, expected_root, kind)
+                {
+                    Ok(new_receiver) => snapshot_receiver = Some(new_receiver),
+                    Err(error) => {
+                        if let StorageDataChunk::States(notification_id, _) = &storage_data_chunk {
                             send_storage_synchronizer_error(
                                 error_notification_sender.clone(),
-                                notification_id,
-                                error,
+                                *notification_id,
+                                format!(
+                                    "Failed to initialize the {:?} snapshot receiver! Error: {:?}",
+                                    kind, error
+                                ),
                             )
                             .await;
-                        },
+                        }
+                        decrement_pending_data_chunks(pending_data_chunks.clone());
+                        return;
+                    },
+                }
+            }
+
+            match apply_snapshot_chunk(
+                snapshot_receiver
+                    .as_mut()
+                    .expect("The snapshot receiver was initialized above!"),
+                storage_data_chunk,
+                kind,
+                &metadata_storage,
+                &target_ledger_info,
+                &error_notification_sender,
+                &pending_data_chunks,
+                version,
+            )
+            .await
+            {
+                ChunkApplyOutcome::Continue => {},
+                ChunkApplyOutcome::Finalize {
+                    notification_id,
+                    last_index,
+                } => {
+                    // Write the snapshot and record completion. The whole
+                    // fast-sync (accumulator + commit) is finalized separately.
+                    let finalize_result = snapshot_receiver
+                        .take()
+                        .expect("The snapshot receiver was initialized above!")
+                        .finish_box()
+                        .map_err(|error| {
+                            format!("Failed to finish the snapshot! Error: {:?}", error)
+                        })
+                        .and_then(|()| {
+                            metadata_storage
+                                .update_last_persisted_index(
+                                    &target_ledger_info,
+                                    last_index,
+                                    true,
+                                    kind,
+                                )
+                                .map_err(|error| {
+                                    format!("Snapshot synced, but failed to update the metadata storage at version {:?}! Error: {:?}", version, error)
+                                })
+                        });
+                    if let Err(error) = finalize_result {
+                        send_storage_synchronizer_error(
+                            error_notification_sender.clone(),
+                            notification_id,
+                            error,
+                        )
+                        .await;
+                    } else {
+                        info!("All snapshot values have synced, version: {}", version);
                     }
-                },
-                storage_data_chunk => {
-                    unimplemented!(
-                        "Invalid storage data chunk sent to state snapshot receiver! This shouldn't happen: {:?}",
-                        storage_data_chunk
-                    );
+                    decrement_pending_data_chunks(pending_data_chunks.clone());
+                    return;
                 },
             }
-            decrement_pending_data_chunks(pending_data_chunks.clone());
         }
     };
 
-    // Spawn the receiver
     spawn(runtime, receiver)
-}
-
-/// Spawns a dedicated task that applies the given output chunk. We use
-/// `spawn_blocking` so that the heavy synchronous function doesn't
-/// block the async thread.
-async fn apply_output_chunk<ChunkExecutor: ChunkExecutorTrait + 'static>(
-    chunk_executor: Arc<ChunkExecutor>,
-    outputs_with_proof: TransactionOutputListWithProofV2,
-    target_ledger_info: LedgerInfoWithSignatures,
-    end_of_epoch_ledger_info: Option<LedgerInfoWithSignatures>,
-) -> anyhow::Result<()> {
-    // Apply the output chunk
-    let num_outputs = outputs_with_proof.get_num_outputs();
-    let result = tokio::task::spawn_blocking(move || {
-        chunk_executor.enqueue_chunk_by_transaction_outputs(
-            outputs_with_proof,
-            &target_ledger_info,
-            end_of_epoch_ledger_info.as_ref(),
-        )
-    })
-    .await
-    .expect("Spawn_blocking(apply_output_chunk) failed!");
-
-    // Update the logs and metrics if the chunk was applied successfully
-    if result.is_ok() {
-        // Log the application event
-        info!(
-            LogSchema::new(LogEntry::StorageSynchronizer).message(&format!(
-                "Applied a new transaction output chunk! Transaction total: {:?}.",
-                num_outputs
-            ))
-        );
-
-        // Update the chunk metrics
-        let operation_label =
-            metrics::StorageSynchronizerOperations::AppliedTransactionOutputs.get_label();
-        update_synchronizer_chunk_metrics(num_outputs, operation_label);
-    }
-
-    result
-}
-
-/// Spawns a dedicated task that executes the given transaction chunk.
-/// We use `spawn_blocking` so that the heavy synchronous function
-/// doesn't block the async thread.
-async fn execute_transaction_chunk<ChunkExecutor: ChunkExecutorTrait + 'static>(
-    chunk_executor: Arc<ChunkExecutor>,
-    transactions_with_proof: TransactionListWithProofV2,
-    target_ledger_info: LedgerInfoWithSignatures,
-    end_of_epoch_ledger_info: Option<LedgerInfoWithSignatures>,
-) -> anyhow::Result<()> {
-    // Execute the transaction chunk
-    let num_transactions = transactions_with_proof
-        .get_transaction_list_with_proof()
-        .transactions
-        .len();
-    let result = tokio::task::spawn_blocking(move || {
-        chunk_executor.enqueue_chunk_by_execution(
-            transactions_with_proof,
-            &target_ledger_info,
-            end_of_epoch_ledger_info.as_ref(),
-        )
-    })
-    .await
-    .expect("Spawn_blocking(execute_transaction_chunk) failed!");
-
-    // Update the logs and metrics if the chunk was executed successfully
-    if result.is_ok() {
-        // Log the execution event
-        info!(
-            LogSchema::new(LogEntry::StorageSynchronizer).message(&format!(
-                "Executed a new transaction chunk! Transaction total: {:?}.",
-                num_transactions
-            ))
-        );
-
-        // Update the chunk metrics
-        let operation_label =
-            metrics::StorageSynchronizerOperations::ExecutedTransactions.get_label();
-        update_synchronizer_chunk_metrics(num_transactions, operation_label);
-    }
-
-    result
-}
-
-/// Updates the storage synchronizer chunk metrics
-fn update_synchronizer_chunk_metrics(num_items: usize, operation_label: &str) {
-    metrics::increment_gauge(
-        &metrics::STORAGE_SYNCHRONIZER_OPERATIONS,
-        operation_label,
-        num_items as u64,
-    );
-    metrics::observe_value(
-        &metrics::STORAGE_SYNCHRONIZER_CHUNK_SIZES,
-        operation_label,
-        num_items as u64,
-    );
-}
-
-/// Spawns a dedicated task that updates the ledger in storage. We use
-/// `spawn_blocking` so that the heavy synchronous function doesn't
-/// block the async thread.
-async fn update_ledger<ChunkExecutor: ChunkExecutorTrait + 'static>(
-    chunk_executor: Arc<ChunkExecutor>,
-) -> anyhow::Result<()> {
-    tokio::task::spawn_blocking(move || chunk_executor.update_ledger())
-        .await
-        .expect("Spawn_blocking(update_ledger) failed!")
-}
-
-/// Spawns a dedicated task that commits a data chunk. We use
-/// `spawn_blocking` so that the heavy synchronous function doesn't
-/// block the async thread.
-async fn commit_chunk<ChunkExecutor: ChunkExecutorTrait + 'static>(
-    chunk_executor: Arc<ChunkExecutor>,
-) -> anyhow::Result<ChunkCommitNotification> {
-    tokio::task::spawn_blocking(move || chunk_executor.commit_chunk())
-        .await
-        .expect("Spawn_blocking(commit_chunk) failed!")
-}
-
-/// Finalizes storage once all state values have been committed
-/// and sends a commit notification to the driver.
-async fn finalize_storage_and_send_commit<
-    'receiver_lifetime, // Required because of https://github.com/rust-lang/rust/issues/63033
-    ChunkExecutor: ChunkExecutorTrait + 'static,
-    MetadataStorage: MetadataStorageInterface + Clone + Send + Sync + 'static,
->(
-    chunk_executor: Arc<ChunkExecutor>,
-    commit_notification_sender: &mut mpsc::UnboundedSender<CommitNotification>,
-    metadata_storage: MetadataStorage,
-    state_snapshot_receiver: Box<
-        dyn StateSnapshotReceiver<StateKey, StateValue> + 'receiver_lifetime,
-    >,
-    storage: DbReaderWriter,
-    epoch_change_proofs: &[LedgerInfoWithSignatures],
-    target_output_with_proof: TransactionOutputListWithProofV2,
-    version: Version,
-    target_ledger_info: &LedgerInfoWithSignatures,
-    last_committed_state_index: u64,
-) -> Result<(), String> {
-    // Finalize the state snapshot
-    state_snapshot_receiver.finish_box().map_err(|error| {
-        format!(
-            "Failed to finish the state value synchronization! Error: {:?}",
-            error
-        )
-    })?;
-    storage
-        .writer
-        .finalize_state_snapshot(
-            version,
-            target_output_with_proof.clone(),
-            epoch_change_proofs,
-        )
-        .map_err(|error| format!("Failed to finalize the state snapshot! Error: {:?}", error))?;
-
-    info!("All states have synced, version: {}", version);
-
-    // Update the metadata storage
-    metadata_storage.update_last_persisted_state_value_index(
-            target_ledger_info,
-            last_committed_state_index,
-            true,
-        ).map_err(|error| {
-        format!("All states have synced, but failed to update the metadata storage at version {:?}! Error: {:?}", version, error)
-    })?;
-
-    // Reset the chunk executor
-    chunk_executor.reset().map_err(|error| {
-        format!(
-            "Failed to reset the chunk executor after state snapshot synchronization! Error: {:?}",
-            error
-        )
-    })?;
-
-    // Create and send the commit notification
-    let commit_notification = create_commit_notification(
-        target_output_with_proof,
-        last_committed_state_index,
-        version,
-    );
-    commit_notification_sender
-        .send(commit_notification)
-        .await
-        .map_err(|error| {
-            format!(
-                "Failed to send the final state commit notification! Error: {:?}",
-                error
-            )
-        })?;
-
-    // Update the counters
-    utils::initialize_sync_gauges(storage.reader).map_err(|error| {
-        format!(
-            "Failed to initialize the state sync version gauges! Error: {:?}",
-            error
-        )
-    })?;
-
-    Ok(())
 }
 
 /// Creates a commit notification for the new committed state snapshot
@@ -1338,4 +1274,120 @@ async fn send_storage_synchronizer_error(
             ))
         );
     }
+}
+
+async fn apply_output_chunk<ChunkExecutor: ChunkExecutorTrait + 'static>(
+    chunk_executor: Arc<ChunkExecutor>,
+    outputs_with_proof: TransactionOutputListWithProofV2,
+    target_ledger_info: LedgerInfoWithSignatures,
+    end_of_epoch_ledger_info: Option<LedgerInfoWithSignatures>,
+) -> anyhow::Result<()> {
+    // Apply the output chunk
+    let num_outputs = outputs_with_proof.get_num_outputs();
+    let result = tokio::task::spawn_blocking(move || {
+        chunk_executor.enqueue_chunk_by_transaction_outputs(
+            outputs_with_proof,
+            &target_ledger_info,
+            end_of_epoch_ledger_info.as_ref(),
+        )
+    })
+    .await
+    .expect("Spawn_blocking(apply_output_chunk) failed!");
+
+    // Update the logs and metrics if the chunk was applied successfully
+    if result.is_ok() {
+        // Log the application event
+        info!(
+            LogSchema::new(LogEntry::StorageSynchronizer).message(&format!(
+                "Applied a new transaction output chunk! Transaction total: {:?}.",
+                num_outputs
+            ))
+        );
+
+        // Update the chunk metrics
+        let operation_label =
+            metrics::StorageSynchronizerOperations::AppliedTransactionOutputs.get_label();
+        update_synchronizer_chunk_metrics(num_outputs, operation_label);
+    }
+
+    result
+}
+
+/// Spawns a dedicated task that executes the given transaction chunk.
+/// We use `spawn_blocking` so that the heavy synchronous function
+/// doesn't block the async thread.
+async fn execute_transaction_chunk<ChunkExecutor: ChunkExecutorTrait + 'static>(
+    chunk_executor: Arc<ChunkExecutor>,
+    transactions_with_proof: TransactionListWithProofV2,
+    target_ledger_info: LedgerInfoWithSignatures,
+    end_of_epoch_ledger_info: Option<LedgerInfoWithSignatures>,
+) -> anyhow::Result<()> {
+    // Execute the transaction chunk
+    let num_transactions = transactions_with_proof
+        .get_transaction_list_with_proof()
+        .transactions
+        .len();
+    let result = tokio::task::spawn_blocking(move || {
+        chunk_executor.enqueue_chunk_by_execution(
+            transactions_with_proof,
+            &target_ledger_info,
+            end_of_epoch_ledger_info.as_ref(),
+        )
+    })
+    .await
+    .expect("Spawn_blocking(execute_transaction_chunk) failed!");
+
+    // Update the logs and metrics if the chunk was executed successfully
+    if result.is_ok() {
+        // Log the execution event
+        info!(
+            LogSchema::new(LogEntry::StorageSynchronizer).message(&format!(
+                "Executed a new transaction chunk! Transaction total: {:?}.",
+                num_transactions
+            ))
+        );
+
+        // Update the chunk metrics
+        let operation_label =
+            metrics::StorageSynchronizerOperations::ExecutedTransactions.get_label();
+        update_synchronizer_chunk_metrics(num_transactions, operation_label);
+    }
+
+    result
+}
+
+/// Updates the storage synchronizer chunk metrics
+fn update_synchronizer_chunk_metrics(num_items: usize, operation_label: &str) {
+    metrics::increment_gauge(
+        &metrics::STORAGE_SYNCHRONIZER_OPERATIONS,
+        operation_label,
+        num_items as u64,
+    );
+    metrics::observe_value(
+        &metrics::STORAGE_SYNCHRONIZER_CHUNK_SIZES,
+        operation_label,
+        num_items as u64,
+    );
+}
+
+/// Spawns a dedicated task that updates the ledger in storage. We use
+/// `spawn_blocking` so that the heavy synchronous function doesn't
+/// block the async thread.
+async fn update_ledger<ChunkExecutor: ChunkExecutorTrait + 'static>(
+    chunk_executor: Arc<ChunkExecutor>,
+) -> anyhow::Result<()> {
+    tokio::task::spawn_blocking(move || chunk_executor.update_ledger())
+        .await
+        .expect("Spawn_blocking(update_ledger) failed!")
+}
+
+/// Spawns a dedicated task that commits a data chunk. We use
+/// `spawn_blocking` so that the heavy synchronous function doesn't
+/// block the async thread.
+async fn commit_chunk<ChunkExecutor: ChunkExecutorTrait + 'static>(
+    chunk_executor: Arc<ChunkExecutor>,
+) -> anyhow::Result<ChunkCommitNotification> {
+    tokio::task::spawn_blocking(move || chunk_executor.commit_chunk())
+        .await
+        .expect("Spawn_blocking(commit_chunk) failed!")
 }

--- a/state-sync/state-sync-driver/src/tests/bootstrapper.rs
+++ b/state-sync/state-sync-driver/src/tests/bootstrapper.rs
@@ -26,6 +26,7 @@ use aptos_data_streaming_service::{
     data_notification::{DataNotification, DataPayload, NotificationId},
     streaming_client::{NotificationAndFeedback, NotificationFeedback},
 };
+use aptos_storage_interface::StateKind;
 use aptos_time_service::TimeService;
 use aptos_types::{
     transaction::{TransactionOutputListWithProofV2, Version},
@@ -973,8 +974,12 @@ async fn test_snapshot_sync_epoch_change() {
     mock_streaming_client
         .expect_get_all_state_values()
         .times(1)
-        .with(eq(target_version), eq(Some(last_persisted_index)))
-        .return_once(move |_, _| Ok(data_stream_listener_1));
+        .with(
+            eq(target_version),
+            eq(Some(last_persisted_index)),
+            eq(StateKind::MainState),
+        )
+        .return_once(move |_, _, _| Ok(data_stream_listener_1));
 
     // Create the mock metadata storage
     let mut metadata_storage = MockMetadataStorage::new();
@@ -982,13 +987,13 @@ async fn test_snapshot_sync_epoch_change() {
     let last_persisted_index_clone = last_persisted_index;
     metadata_storage
         .expect_previous_snapshot_sync_target()
-        .returning(move || Ok(Some(target_ledger_info_clone.clone())));
+        .returning(move |_| Ok(Some(target_ledger_info_clone.clone())));
     metadata_storage
         .expect_is_snapshot_sync_complete()
-        .returning(|_| Ok(false));
+        .returning(|_, _| Ok(false));
     metadata_storage
-        .expect_get_last_persisted_state_value_index()
-        .returning(move |_| Ok(last_persisted_index_clone));
+        .expect_get_last_persisted_index()
+        .returning(move |_, _| Ok(last_persisted_index_clone));
 
     // Create the bootstrapper
     let mut bootstrapper = create_bootstrapper_with_storage(
@@ -1036,14 +1041,14 @@ async fn test_snapshot_sync_epoch_change_genesis() {
     mock_streaming_client
         .expect_get_all_state_values()
         .times(1)
-        .with(eq(target_version), eq(Some(0)))
-        .return_once(move |_, _| Ok(data_stream_listener_1));
+        .with(eq(target_version), eq(Some(0)), eq(StateKind::MainState))
+        .return_once(move |_, _, _| Ok(data_stream_listener_1));
 
     // Create the mock metadata storage
     let mut metadata_storage = MockMetadataStorage::new();
     metadata_storage
         .expect_previous_snapshot_sync_target()
-        .returning(move || Ok(None));
+        .returning(move |_| Ok(None));
 
     // Create the bootstrapper
     let mut bootstrapper = create_bootstrapper_with_storage(
@@ -1095,8 +1100,12 @@ async fn test_snapshot_sync_epoch_change_genesis_restart() {
     mock_streaming_client
         .expect_get_all_state_values()
         .times(1)
-        .with(eq(target_version), eq(Some(last_persisted_index)))
-        .return_once(move |_, _| Ok(data_stream_listener_1));
+        .with(
+            eq(target_version),
+            eq(Some(last_persisted_index)),
+            eq(StateKind::MainState),
+        )
+        .return_once(move |_, _, _| Ok(data_stream_listener_1));
 
     // Create the mock metadata storage
     let mut metadata_storage = MockMetadataStorage::new();
@@ -1104,13 +1113,13 @@ async fn test_snapshot_sync_epoch_change_genesis_restart() {
     let last_persisted_index_clone = last_persisted_index;
     metadata_storage
         .expect_previous_snapshot_sync_target()
-        .returning(move || Ok(Some(target_ledger_info_clone.clone())));
+        .returning(move |_| Ok(Some(target_ledger_info_clone.clone())));
     metadata_storage
         .expect_is_snapshot_sync_complete()
-        .returning(|_| Ok(false));
+        .returning(|_, _| Ok(false));
     metadata_storage
-        .expect_get_last_persisted_state_value_index()
-        .returning(move |_| Ok(last_persisted_index_clone));
+        .expect_get_last_persisted_index()
+        .returning(move |_, _| Ok(last_persisted_index_clone));
 
     // Create the bootstrapper
     let mut bootstrapper = create_bootstrapper_with_storage(
@@ -1163,8 +1172,12 @@ async fn test_snapshot_sync_existing_state() {
     mock_streaming_client
         .expect_get_all_state_values()
         .times(1)
-        .with(eq(highest_version), eq(Some(last_persisted_index)))
-        .return_once(move |_, _| Ok(data_stream_listener_1))
+        .with(
+            eq(highest_version),
+            eq(Some(last_persisted_index)),
+            eq(StateKind::MainState),
+        )
+        .return_once(move |_, _, _| Ok(data_stream_listener_1))
         .in_sequence(&mut expectation_sequence);
     let notification_id = 100;
     mock_streaming_client
@@ -1182,8 +1195,12 @@ async fn test_snapshot_sync_existing_state() {
     mock_streaming_client
         .expect_get_all_state_values()
         .times(1)
-        .with(eq(highest_version), eq(Some(last_persisted_index)))
-        .return_once(move |_, _| Ok(data_stream_listener_2))
+        .with(
+            eq(highest_version),
+            eq(Some(last_persisted_index)),
+            eq(StateKind::MainState),
+        )
+        .return_once(move |_, _, _| Ok(data_stream_listener_2))
         .in_sequence(&mut expectation_sequence);
 
     // Create the mock metadata storage
@@ -1192,13 +1209,13 @@ async fn test_snapshot_sync_existing_state() {
     let last_persisted_index_clone = last_persisted_index;
     metadata_storage
         .expect_previous_snapshot_sync_target()
-        .returning(move || Ok(Some(highest_ledger_info_clone.clone())));
+        .returning(move |_| Ok(Some(highest_ledger_info_clone.clone())));
     metadata_storage
         .expect_is_snapshot_sync_complete()
-        .returning(|_| Ok(false));
+        .returning(|_, _| Ok(false));
     metadata_storage
-        .expect_get_last_persisted_state_value_index()
-        .returning(move |_| Ok(last_persisted_index_clone));
+        .expect_get_last_persisted_index()
+        .returning(move |_, _| Ok(last_persisted_index_clone));
 
     // Create the bootstrapper
     let mut bootstrapper = create_bootstrapper_with_storage(
@@ -1263,14 +1280,14 @@ async fn test_snapshot_sync_fresh_state() {
     mock_streaming_client
         .expect_get_all_state_values()
         .times(1)
-        .with(eq(highest_version), eq(Some(0)))
-        .return_once(move |_, _| Ok(data_stream_listener_1));
+        .with(eq(highest_version), eq(Some(0)), eq(StateKind::MainState))
+        .return_once(move |_, _, _| Ok(data_stream_listener_1));
 
     // Create the mock metadata storage
     let mut metadata_storage = MockMetadataStorage::new();
     metadata_storage
         .expect_previous_snapshot_sync_target()
-        .returning(move || Ok(None));
+        .returning(move |_| Ok(None));
 
     // Create the bootstrapper
     let mut bootstrapper = create_bootstrapper_with_storage(
@@ -1301,11 +1318,11 @@ async fn test_snapshot_sync_fresh_state() {
 }
 
 #[tokio::test]
-#[should_panic(
-    expected = "The snapshot sync for the target was marked as complete but the highest synced version is genesis!"
-)]
-async fn test_snapshot_sync_invalid_state() {
-    // Create test data
+async fn test_snapshot_sync_main_complete_refetches_output() {
+    // The main state snapshot is already written, but the fast sync isn't
+    // finalized yet (highest synced is still genesis). On resume the
+    // bootstrapper has no cached target output, so it must re-fetch the target
+    // transaction output before driving the remaining snapshots + finalize.
     let synced_version = GENESIS_TRANSACTION_VERSION; // Genesis is the highest synced
     let highest_version = 1000000;
     let highest_ledger_info = create_random_epoch_ending_ledger_info(highest_version, 1);
@@ -1314,18 +1331,28 @@ async fn test_snapshot_sync_invalid_state() {
     let mut driver_configuration = create_full_node_driver_configuration();
     driver_configuration.config.bootstrapping_mode = BootstrappingMode::DownloadLatestStates;
 
-    // Create the mock streaming client
-    let mock_streaming_client = create_mock_streaming_client();
+    // Create the mock streaming client (it must re-fetch the target output)
+    let mut mock_streaming_client = create_mock_streaming_client();
+    let (_notification_sender, data_stream_listener) = create_data_stream_listener();
+    mock_streaming_client
+        .expect_get_all_transaction_outputs()
+        .times(1)
+        .with(
+            eq(highest_version),
+            eq(highest_version),
+            eq(highest_version),
+        )
+        .return_once(move |_, _, _| Ok(data_stream_listener));
 
     // Create the mock metadata storage
     let mut metadata_storage = MockMetadataStorage::new();
     let highest_ledger_info_clone = highest_ledger_info.clone();
     metadata_storage
         .expect_previous_snapshot_sync_target()
-        .return_once(move || Ok(Some(highest_ledger_info_clone)));
+        .return_once(move |_| Ok(Some(highest_ledger_info_clone)));
     metadata_storage
         .expect_is_snapshot_sync_complete()
-        .returning(|_| Ok(true));
+        .returning(|_, _| Ok(true));
 
     // Create the bootstrapper
     let mut bootstrapper = create_bootstrapper_with_storage(
@@ -1344,7 +1371,7 @@ async fn test_snapshot_sync_invalid_state() {
     let mut global_data_summary = create_global_summary(1);
     global_data_summary.advertised_data.synced_ledger_infos = vec![highest_ledger_info.clone()];
 
-    // Drive progress and verify that the bootstrapper panics (due to invalid state)
+    // Drive progress and verify the bootstrapper re-fetches the target output
     drive_progress(&mut bootstrapper, &global_data_summary, false)
         .await
         .unwrap();
@@ -1372,7 +1399,7 @@ async fn test_snapshot_sync_lag() {
     let mut metadata_storage = MockMetadataStorage::new();
     metadata_storage
         .expect_previous_snapshot_sync_target()
-        .returning(|| Ok(None));
+        .returning(|_| Ok(None));
 
     // Create the bootstrapper
     let mut bootstrapper = create_bootstrapper_with_storage(
@@ -1425,7 +1452,7 @@ async fn test_snapshot_sync_lag_panic() {
     let mut metadata_storage = MockMetadataStorage::new();
     metadata_storage
         .expect_previous_snapshot_sync_target()
-        .returning(|| Ok(None));
+        .returning(|_| Ok(None));
 
     // Create the bootstrapper
     let mut bootstrapper = create_bootstrapper_with_storage(
@@ -1603,7 +1630,7 @@ fn create_bootstrapper(
     let mut metadata_storage = MockMetadataStorage::new();
     metadata_storage
         .expect_previous_snapshot_sync_target()
-        .returning(|| Ok(None));
+        .returning(|_| Ok(None));
 
     // Create the mock db reader with only genesis loaded
     let mut mock_database_reader = create_mock_db_reader();

--- a/state-sync/state-sync-driver/src/tests/metadata_storage.rs
+++ b/state-sync/state-sync-driver/src/tests/metadata_storage.rs
@@ -9,6 +9,7 @@ use crate::{
     tests::utils::{create_epoch_ending_ledger_info, create_ledger_info_at_version},
 };
 use aptos_schemadb::schema::fuzzing::assert_encode_decode;
+use aptos_storage_interface::StateKind;
 use aptos_temppath::TempPath;
 use claims::{assert_err, assert_none};
 
@@ -19,17 +20,20 @@ fn test_create_then_open() {
     let metadata_storage = PersistentMetadataStorage::new(tmp_dir.path());
 
     // Verify the storage is empty
-    assert_none!(metadata_storage.previous_snapshot_sync_target().unwrap());
+    assert_none!(metadata_storage
+        .previous_snapshot_sync_target(StateKind::MainState)
+        .unwrap());
 
     // Insert a new state value entry for the target
     let target_ledger_info = create_ledger_info_at_version(12345);
     let last_persisted_state_value = 100000;
     let snapshot_sync_completed = false;
     metadata_storage
-        .update_last_persisted_state_value_index(
+        .update_last_persisted_index(
             &target_ledger_info,
             last_persisted_state_value,
             snapshot_sync_completed,
+            StateKind::MainState,
         )
         .unwrap();
 
@@ -40,18 +44,20 @@ fn test_create_then_open() {
     let metadata_storage = PersistentMetadataStorage::new(tmp_dir.path());
     assert_eq!(
         Some(target_ledger_info.clone()),
-        metadata_storage.previous_snapshot_sync_target().unwrap()
+        metadata_storage
+            .previous_snapshot_sync_target(StateKind::MainState)
+            .unwrap()
     );
     assert_eq!(
         last_persisted_state_value,
         metadata_storage
-            .get_last_persisted_state_value_index(&target_ledger_info)
+            .get_last_persisted_index(&target_ledger_info, StateKind::MainState)
             .unwrap()
     );
     assert_eq!(
         snapshot_sync_completed,
         metadata_storage
-            .is_snapshot_sync_complete(&target_ledger_info)
+            .is_snapshot_sync_complete(&target_ledger_info, StateKind::MainState)
             .unwrap()
     );
 
@@ -59,10 +65,11 @@ fn test_create_then_open() {
     let last_persisted_state_value = 200000;
     let snapshot_sync_completed = true;
     metadata_storage
-        .update_last_persisted_state_value_index(
+        .update_last_persisted_index(
             &target_ledger_info,
             last_persisted_state_value,
             snapshot_sync_completed,
+            StateKind::MainState,
         )
         .unwrap();
 
@@ -73,18 +80,20 @@ fn test_create_then_open() {
     let metadata_storage = PersistentMetadataStorage::new(tmp_dir.path());
     assert_eq!(
         Some(target_ledger_info.clone()),
-        metadata_storage.previous_snapshot_sync_target().unwrap()
+        metadata_storage
+            .previous_snapshot_sync_target(StateKind::MainState)
+            .unwrap()
     );
     assert_eq!(
         last_persisted_state_value,
         metadata_storage
-            .get_last_persisted_state_value_index(&target_ledger_info)
+            .get_last_persisted_index(&target_ledger_info, StateKind::MainState)
             .unwrap()
     );
     assert_eq!(
         snapshot_sync_completed,
         metadata_storage
-            .is_snapshot_sync_complete(&target_ledger_info)
+            .is_snapshot_sync_complete(&target_ledger_info, StateKind::MainState)
             .unwrap()
     );
 }
@@ -109,9 +118,15 @@ fn test_multiple_reads_and_writes() {
 
     // Verify the storage is empty
     let target_ledger_info = create_ledger_info_at_version(100000);
-    assert_none!(metadata_storage.previous_snapshot_sync_target().unwrap());
-    assert_err!(metadata_storage.is_snapshot_sync_complete(&target_ledger_info));
-    assert_err!(metadata_storage.get_last_persisted_state_value_index(&target_ledger_info));
+    assert_none!(metadata_storage
+        .previous_snapshot_sync_target(StateKind::MainState)
+        .unwrap());
+    assert_err!(
+        metadata_storage.is_snapshot_sync_complete(&target_ledger_info, StateKind::MainState)
+    );
+    assert_err!(
+        metadata_storage.get_last_persisted_index(&target_ledger_info, StateKind::MainState)
+    );
 
     // Do multiple writes
     for index in 0..100 {
@@ -119,28 +134,31 @@ fn test_multiple_reads_and_writes() {
         let last_persisted_state_value = 50000 + index;
         let snapshot_sync_completed = false;
         metadata_storage
-            .update_last_persisted_state_value_index(
+            .update_last_persisted_index(
                 &target_ledger_info,
                 last_persisted_state_value,
                 snapshot_sync_completed,
+                StateKind::MainState,
             )
             .unwrap();
 
         // Fetch and verify the last state value entry
         assert_eq!(
             Some(target_ledger_info.clone()),
-            metadata_storage.previous_snapshot_sync_target().unwrap()
+            metadata_storage
+                .previous_snapshot_sync_target(StateKind::MainState)
+                .unwrap()
         );
         assert_eq!(
             last_persisted_state_value,
             metadata_storage
-                .get_last_persisted_state_value_index(&target_ledger_info)
+                .get_last_persisted_index(&target_ledger_info, StateKind::MainState)
                 .unwrap()
         );
         assert_eq!(
             snapshot_sync_completed,
             metadata_storage
-                .is_snapshot_sync_complete(&target_ledger_info)
+                .is_snapshot_sync_complete(&target_ledger_info, StateKind::MainState)
                 .unwrap()
         );
     }
@@ -153,17 +171,19 @@ fn test_writes_to_different_targets() {
     let metadata_storage = PersistentMetadataStorage::new(tmp_dir.path());
 
     // Verify the storage is empty
-    assert_none!(metadata_storage.previous_snapshot_sync_target().unwrap());
+    assert_none!(metadata_storage
+        .previous_snapshot_sync_target(StateKind::MainState)
+        .unwrap());
 
     // Write a new progress entry into the storage
     let target_ledger_info = create_ledger_info_at_version(100);
     metadata_storage
-        .update_last_persisted_state_value_index(&target_ledger_info, 10101, false)
+        .update_last_persisted_index(&target_ledger_info, 10101, false, StateKind::MainState)
         .unwrap();
 
     // Write another progress entry with a different target and verify that it fails
     let target_ledger_info = create_ledger_info_at_version(200);
     metadata_storage
-        .update_last_persisted_state_value_index(&target_ledger_info, 10101, false)
+        .update_last_persisted_index(&target_ledger_info, 10101, false, StateKind::MainState)
         .unwrap_err();
 }

--- a/state-sync/state-sync-driver/src/tests/mocks.rs
+++ b/state-sync/state-sync-driver/src/tests/mocks.rs
@@ -17,7 +17,7 @@ use aptos_data_streaming_service::{
 use aptos_executor_types::{ChunkCommitNotification, ChunkExecutorTrait};
 use aptos_storage_interface::{
     chunk_to_commit::ChunkToCommit, DbReader, DbReaderWriter, DbWriter, LedgerSummary, Result,
-    StateSnapshotReceiver,
+    StateKind, StateSnapshotReceiver,
 };
 use aptos_types::{
     epoch_change::EpochChangeProof,
@@ -263,13 +263,14 @@ mock! {
             ledger_version: Version,
         ) -> Result<TransactionAccumulatorSummary>;
 
-        fn get_state_item_count(&self, version: Version) -> Result<usize>;
+        fn get_state_item_count(&self, version: Version, kind: StateKind) -> Result<usize>;
 
         fn get_state_value_chunk_with_proof(
             &self,
             version: Version,
             start_idx: usize,
             chunk_size: usize,
+            kind: StateKind,
         ) -> Result<StateValueChunkWithProof>;
 
         fn get_epoch_snapshot_prune_window(&self) -> Result<usize>;
@@ -284,6 +285,7 @@ mock! {
             &self,
             version: Version,
             expected_root_hash: HashValue,
+            kind: StateKind,
         ) -> Result<Box<dyn StateSnapshotReceiver<StateKey, StateValue>>>;
 
         fn finalize_state_snapshot(
@@ -309,20 +311,26 @@ mock! {
         fn is_snapshot_sync_complete(
             &self,
             target_ledger_info: &LedgerInfoWithSignatures,
+            kind: StateKind,
         ) -> Result<bool, Error>;
 
-        fn get_last_persisted_state_value_index(
+        fn get_last_persisted_index(
             &self,
             target_ledger_info: &LedgerInfoWithSignatures,
+            kind: StateKind,
         ) -> Result<u64, Error>;
 
-        fn previous_snapshot_sync_target(&self) -> Result<Option<LedgerInfoWithSignatures>, Error>;
+        fn previous_snapshot_sync_target(
+            &self,
+            kind: StateKind,
+        ) -> Result<Option<LedgerInfoWithSignatures>, Error>;
 
-        fn update_last_persisted_state_value_index(
+        fn update_last_persisted_index(
             &self,
             target_ledger_info: &LedgerInfoWithSignatures,
-            last_persisted_state_value_index: u64,
+            last_persisted_index: u64,
             snapshot_sync_completed: bool,
+            kind: StateKind,
         ) -> Result<(), Error>;
     }
 
@@ -352,6 +360,7 @@ mock! {
             &self,
             version: Version,
             start_index: Option<u64>,
+            state_kind: StateKind,
         ) -> AnyhowResult<DataStreamListener, aptos_data_streaming_service::error::Error>;
 
         async fn get_all_epoch_ending_ledger_infos(
@@ -437,11 +446,11 @@ mock! {
             end_of_epoch_ledger_info: Option<LedgerInfoWithSignatures>,
         ) -> AnyhowResult<(), crate::error::Error>;
 
-        fn initialize_state_synchronizer(
+        fn initialize_snapshot_synchronizer(
             &mut self,
-            epoch_change_proofs: Vec<LedgerInfoWithSignatures>,
             target_ledger_info: LedgerInfoWithSignatures,
-            target_output_with_proof: TransactionOutputListWithProofV2,
+            expected_root: HashValue,
+            kind: StateKind,
         ) -> AnyhowResult<JoinHandle<()>, crate::error::Error>;
 
         fn pending_storage_data(&self) -> bool;
@@ -450,6 +459,13 @@ mock! {
             &mut self,
             notification_id: NotificationId,
             state_value_chunk_with_proof: StateValueChunkWithProof,
+        ) -> AnyhowResult<(), crate::error::Error>;
+
+        async fn finalize_fast_sync(
+            &mut self,
+            epoch_change_proofs: Vec<LedgerInfoWithSignatures>,
+            target_ledger_info: LedgerInfoWithSignatures,
+            target_output_with_proof: TransactionOutputListWithProofV2,
         ) -> AnyhowResult<(), crate::error::Error>;
 
         fn reset_chunk_executor(&self) -> AnyhowResult<(), crate::error::Error>;

--- a/state-sync/state-sync-driver/src/tests/storage_synchronizer.rs
+++ b/state-sync/state-sync-driver/src/tests/storage_synchronizer.rs
@@ -26,12 +26,13 @@ use crate::{
 };
 use anyhow::format_err;
 use aptos_config::config::StateSyncDriverConfig;
+use aptos_crypto::HashValue;
 use aptos_data_streaming_service::data_notification::NotificationId;
 use aptos_event_notifications::EventSubscriptionService;
 use aptos_executor_types::ChunkCommitNotification;
 use aptos_infallible::{Mutex, RwLock};
 use aptos_mempool_notifications::MempoolNotificationListener;
-use aptos_storage_interface::{AptosDbError, DbReaderWriter};
+use aptos_storage_interface::{AptosDbError, DbReaderWriter, StateKind};
 use aptos_storage_service_notifications::StorageServiceNotificationListener;
 use aptos_types::{
     ledger_info::LedgerInfoWithSignatures,
@@ -623,64 +624,42 @@ async fn test_execute_transactions_commit_send_error() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-#[should_panic]
-async fn test_initialize_state_synchronizer_missing_info() {
-    // Create test data that is missing transaction infos
-    let mut output_list_with_proof =
-        create_output_list_with_proof().consume_output_list_with_proof();
-    output_list_with_proof.proof.transaction_infos = vec![]; // This is invalid!
-    let output_list_with_proof =
-        TransactionOutputListWithProofV2::new_from_v1(output_list_with_proof);
-
-    // Create the storage synchronizer
-    let (_, _, _, _, _, mut storage_synchronizer, _) = create_storage_synchronizer(
-        create_mock_executor(),
-        create_mock_reader_writer(None, None),
-    );
-
-    // Initialize the state synchronizer
-    let state_synchronizer_handle = storage_synchronizer
-        .initialize_state_synchronizer(
-            vec![create_epoch_ending_ledger_info()],
-            create_epoch_ending_ledger_info(),
-            output_list_with_proof,
-        )
-        .unwrap();
-
-    // The handler should panic as it was given invalid data
-    state_synchronizer_handle.await.unwrap();
-}
-
-#[tokio::test(flavor = "multi_thread")]
-#[should_panic]
-async fn test_initialize_state_synchronizer_receiver_error() {
-    // Setup the mock db writer. The db writer should always fail.
+async fn test_save_states_receiver_error() {
+    // Setup the mock db writer. Creating the snapshot receiver should always fail.
     let mut db_writer = create_mock_db_writer();
     db_writer
         .expect_get_state_snapshot_receiver()
-        .returning(|_, _| {
+        .returning(|_, _, _| {
             Err(AptosDbError::Other(
                 "Failed to get snapshot receiver!".to_string(),
             ))
         });
 
     // Create the storage synchronizer
-    let (_, _, _, _, _, mut storage_synchronizer, _) = create_storage_synchronizer(
+    let (_, mut error_listener, _, _, _, mut storage_synchronizer, _) = create_storage_synchronizer(
         create_mock_executor(),
         create_mock_reader_writer(None, Some(db_writer)),
     );
 
-    // Initialize the state synchronizer
-    let state_synchronizer_handle = storage_synchronizer
-        .initialize_state_synchronizer(
-            vec![create_epoch_ending_ledger_info()],
+    // Initialize the snapshot synchronizer. The receiver is created lazily on
+    // the first chunk, so initialization succeeds even though it will fail.
+    let _join_handle = storage_synchronizer
+        .initialize_snapshot_synchronizer(
             create_epoch_ending_ledger_info(),
-            create_output_list_with_proof(),
+            HashValue::random(),
+            StateKind::MainState,
         )
         .unwrap();
 
-    // The handler should panic as storage failed to return a snapshot receiver
-    state_synchronizer_handle.await.unwrap();
+    // Save a state chunk and verify the receiver failure surfaces as an error
+    // notification and that there's no pending data.
+    let notification_id = 0;
+    storage_synchronizer
+        .save_state_values(notification_id, create_state_value_chunk_with_proof(false))
+        .await
+        .unwrap();
+    verify_error_notification(&mut error_listener, notification_id).await;
+    verify_no_pending_data(&storage_synchronizer);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -710,8 +689,8 @@ async fn test_save_states_completion() {
     let mut db_writer = create_mock_db_writer();
     db_writer
         .expect_get_state_snapshot_receiver()
-        .with(always(), always())
-        .return_once(move |_, _| Ok(Box::new(snapshot_receiver)));
+        .with(always(), always(), always())
+        .return_once(move |_, _, _| Ok(Box::new(snapshot_receiver)));
     let target_ledger_info_clone = target_ledger_info.clone();
     let output_list_with_proof_clone = output_list_with_proof.clone();
     let epoch_change_proofs_clone = epoch_change_proofs.clone();
@@ -743,12 +722,12 @@ async fn test_save_states_completion() {
         .events()[0]
         .clone();
 
-    // Initialize the state synchronizer
+    // Initialize the snapshot synchronizer
     let state_synchronizer_handle = storage_synchronizer
-        .initialize_state_synchronizer(
-            epoch_change_proofs.to_vec(),
-            target_ledger_info,
-            output_list_with_proof.clone(),
+        .initialize_snapshot_synchronizer(
+            target_ledger_info.clone(),
+            HashValue::random(),
+            StateKind::MainState,
         )
         .unwrap();
 
@@ -759,6 +738,19 @@ async fn test_save_states_completion() {
         .unwrap();
     storage_synchronizer
         .save_state_values(1, create_state_value_chunk_with_proof(true))
+        .await
+        .unwrap();
+
+    // The receiver should return once it has written the entire snapshot
+    state_synchronizer_handle.await.unwrap();
+
+    // Finalize the whole fast sync (this is what sends the commit notification)
+    storage_synchronizer
+        .finalize_fast_sync(
+            epoch_change_proofs.to_vec(),
+            target_ledger_info,
+            output_list_with_proof.clone(),
+        )
         .await
         .unwrap();
 
@@ -778,52 +770,67 @@ async fn test_save_states_completion() {
     )
     .await;
 
-    // The handler should return as we've finished writing all states
-    state_synchronizer_handle.await.unwrap();
     verify_no_pending_data(&storage_synchronizer);
 }
 
 #[tokio::test(flavor = "multi_thread")]
-#[should_panic]
-async fn test_save_states_dropped_error_listener() {
-    // Setup the mock snapshot receiver
+async fn test_finalize_fast_sync_dropped_commit_listener() {
+    // `finalize_fast_sync` sends the commit notification (it used to be sent by
+    // the snapshot receiver). With the commit listener dropped, it should surface
+    // a recoverable error rather than panic.
+    let target_ledger_info = create_epoch_ending_ledger_info();
+    let output_list_with_proof = create_output_list_with_proof();
+
+    // Setup the mock snapshot receiver (writes the snapshot)
     let mut snapshot_receiver = create_mock_receiver();
     snapshot_receiver
         .expect_add_chunk()
         .with(always(), always())
         .returning(|_, _| Ok(()));
+    snapshot_receiver.expect_finish_box().returning(|| Ok(()));
 
-    // Setup the mock db writer
+    // Setup the mock executor and db writer
+    let mut chunk_executor = create_mock_executor();
+    chunk_executor.expect_reset().returning(|| Ok(()));
     let mut db_writer = create_mock_db_writer();
     db_writer
         .expect_get_state_snapshot_receiver()
-        .with(always(), always())
-        .return_once(move |_, _| Ok(Box::new(snapshot_receiver)));
+        .with(always(), always(), always())
+        .return_once(move |_, _, _| Ok(Box::new(snapshot_receiver)));
+    db_writer
+        .expect_finalize_state_snapshot()
+        .returning(|_, _, _| Ok(()));
 
-    // Create the storage synchronizer (drop all listeners)
-    let (_, _, _, _, _, mut storage_synchronizer, _) = create_storage_synchronizer(
-        create_mock_executor(),
+    // Create the storage synchronizer and drop the commit listener
+    let (commit_listener, _, _, _, _, mut storage_synchronizer, _) = create_storage_synchronizer(
+        chunk_executor,
         create_mock_reader_writer(None, Some(db_writer)),
     );
+    drop(commit_listener);
 
-    // Initialize the state synchronizer
+    // Write the snapshot to completion
     let state_synchronizer_handle = storage_synchronizer
-        .initialize_state_synchronizer(
-            vec![create_epoch_ending_ledger_info()],
-            create_epoch_ending_ledger_info(),
-            create_output_list_with_proof(),
+        .initialize_snapshot_synchronizer(
+            target_ledger_info.clone(),
+            HashValue::random(),
+            StateKind::MainState,
         )
         .unwrap();
-
-    // Save the last state chunk
-    let notification_id = 0;
     storage_synchronizer
-        .save_state_values(notification_id, create_state_value_chunk_with_proof(true))
+        .save_state_values(0, create_state_value_chunk_with_proof(true))
         .await
         .unwrap();
-
-    // The handler should panic as the commit listener was dropped
     state_synchronizer_handle.await.unwrap();
+
+    // Finalizing should error (not panic) as the commit listener was dropped
+    let result = storage_synchronizer
+        .finalize_fast_sync(
+            vec![create_epoch_ending_ledger_info()],
+            target_ledger_info,
+            output_list_with_proof,
+        )
+        .await;
+    assert_matches!(result, Err(Error::UnexpectedError(_)));
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -839,8 +846,8 @@ async fn test_save_states_invalid_chunk() {
     let mut db_writer = create_mock_db_writer();
     db_writer
         .expect_get_state_snapshot_receiver()
-        .with(always(), always())
-        .return_once(move |_, _| Ok(Box::new(snapshot_receiver)));
+        .with(always(), always(), always())
+        .return_once(move |_, _, _| Ok(Box::new(snapshot_receiver)));
 
     // Create the storage synchronizer
     let (_, mut error_listener, _, _, _, mut storage_synchronizer, _) = create_storage_synchronizer(
@@ -848,12 +855,12 @@ async fn test_save_states_invalid_chunk() {
         create_mock_reader_writer(None, Some(db_writer)),
     );
 
-    // Initialize the state synchronizer
+    // Initialize the snapshot synchronizer
     let _join_handle = storage_synchronizer
-        .initialize_state_synchronizer(
-            vec![create_epoch_ending_ledger_info()],
+        .initialize_snapshot_synchronizer(
             create_epoch_ending_ledger_info(),
-            create_output_list_with_proof(),
+            HashValue::random(),
+            StateKind::MainState,
         )
         .unwrap();
 

--- a/state-sync/storage-service/server/src/handler.rs
+++ b/state-sync/storage-service/server/src/handler.rs
@@ -19,14 +19,17 @@ use crate::{
 use aptos_config::{config::StorageServiceConfig, network_id::PeerNetworkId};
 use aptos_logger::{debug, sample, sample::SampleRate, trace, warn};
 use aptos_network::protocols::wire::handshake::v1::ProtocolId;
+use aptos_storage_interface::StateKind;
 use aptos_storage_service_types::{
     requests::{
         DataRequest, EpochEndingLedgerInfoRequest, GetTransactionDataWithProofRequest,
-        StateValuesWithProofRequest, StorageServiceRequest, TransactionOutputsWithProofRequest,
+        NumberOfStatesRequestV2, StateValuesWithProofRequest, StateValuesWithProofRequestV2,
+        StorageServiceRequest, TransactionOutputsWithProofRequest,
         TransactionsOrOutputsWithProofRequest, TransactionsWithProofRequest,
     },
     responses::{
-        DataResponse, ServerProtocolVersion, StorageServerSummary, StorageServiceResponse,
+        DataResponse, NumberOfStatesResponseV2, ServerProtocolVersion,
+        StateValueChunkWithProofResponseV2, StorageServerSummary, StorageServiceResponse,
     },
     StorageServiceError,
 };
@@ -409,11 +412,17 @@ impl<T: StorageReaderInterface> Handler<T> {
             DataRequest::GetStateValuesWithProof(request) => {
                 self.get_state_value_chunk_with_proof(request)
             },
+            DataRequest::GetStateValuesWithProofV2(request) => {
+                self.get_state_value_chunk_with_proof_v2(request)
+            },
             DataRequest::GetEpochEndingLedgerInfos(request) => {
                 self.get_epoch_ending_ledger_infos(request)
             },
             DataRequest::GetNumberOfStatesAtVersion(version) => {
                 self.get_number_of_states_at_version(*version)
+            },
+            DataRequest::GetNumberOfStatesAtVersionV2(request) => {
+                self.get_number_of_states_at_version_v2(request)
             },
             DataRequest::GetTransactionOutputsWithProof(request) => {
                 self.get_transaction_outputs_with_proof(request)
@@ -469,10 +478,30 @@ impl<T: StorageReaderInterface> Handler<T> {
             request.version,
             request.start_index,
             request.end_index,
+            StateKind::MainState,
         )?;
 
         Ok(DataResponse::StateValueChunkWithProof(
             state_value_chunk_with_proof,
+        ))
+    }
+
+    fn get_state_value_chunk_with_proof_v2(
+        &self,
+        request: &StateValuesWithProofRequestV2,
+    ) -> aptos_storage_service_types::Result<DataResponse, Error> {
+        let state_value_chunk_with_proof = self.storage.get_state_value_chunk_with_proof(
+            request.version,
+            request.start_index,
+            request.end_index,
+            request.state_kind,
+        )?;
+
+        Ok(DataResponse::StateValueChunkWithProofV2(
+            StateValueChunkWithProofResponseV2 {
+                state_value_chunk_with_proof,
+                state_kind: request.state_kind,
+            },
         ))
     }
 
@@ -491,9 +520,27 @@ impl<T: StorageReaderInterface> Handler<T> {
         &self,
         version: Version,
     ) -> aptos_storage_service_types::Result<DataResponse, Error> {
-        let number_of_states = self.storage.get_number_of_states(version)?;
+        let number_of_states = self
+            .storage
+            .get_number_of_states(version, StateKind::MainState)?;
 
         Ok(DataResponse::NumberOfStatesAtVersion(number_of_states))
+    }
+
+    fn get_number_of_states_at_version_v2(
+        &self,
+        request: &NumberOfStatesRequestV2,
+    ) -> aptos_storage_service_types::Result<DataResponse, Error> {
+        let number_of_states = self
+            .storage
+            .get_number_of_states(request.version, request.state_kind)?;
+
+        Ok(DataResponse::NumberOfStatesAtVersionV2(
+            NumberOfStatesResponseV2 {
+                number_of_states,
+                state_kind: request.state_kind,
+            },
+        ))
     }
 
     fn get_server_protocol_version(&self) -> DataResponse {

--- a/state-sync/storage-service/server/src/storage.rs
+++ b/state-sync/storage-service/server/src/storage.rs
@@ -4,7 +4,7 @@
 use crate::{error::Error, metrics};
 use aptos_config::config::StorageServiceConfig;
 use aptos_logger::{debug, warn};
-use aptos_storage_interface::{AptosDbError, DbReader, Result as StorageResult};
+use aptos_storage_interface::{AptosDbError, DbReader, Result as StorageResult, StateKind};
 use aptos_storage_service_types::{
     requests::{GetTransactionDataWithProofRequest, TransactionDataRequestType},
     responses::{
@@ -99,9 +99,12 @@ pub trait StorageReaderInterface: Clone + Send + 'static {
         transaction_data_with_proof_request: &GetTransactionDataWithProofRequest,
     ) -> aptos_storage_service_types::Result<TransactionDataWithProofResponse, Error>;
 
-    /// Returns the number of states in the state tree at the specified version.
-    fn get_number_of_states(&self, version: u64)
-        -> aptos_storage_service_types::Result<u64, Error>;
+    /// Returns the number of states (of the given kind) at the specified version.
+    fn get_number_of_states(
+        &self,
+        version: u64,
+        kind: StateKind,
+    ) -> aptos_storage_service_types::Result<u64, Error>;
 
     /// Returns a chunk holding a list of state values starting at the
     /// specified `start_index` and ending at `end_index` (inclusive). In
@@ -112,6 +115,7 @@ pub trait StorageReaderInterface: Clone + Send + 'static {
         version: u64,
         start_index: u64,
         end_index: u64,
+        kind: StateKind,
     ) -> aptos_storage_service_types::Result<StateValueChunkWithProof, Error>;
 }
 
@@ -904,6 +908,7 @@ impl StorageReader {
         end_index: u64,
         max_response_size: u64,
         use_size_and_time_aware_chunking: bool,
+        kind: StateKind,
     ) -> Result<StateValueChunkWithProof, Error> {
         // Calculate the number of state values to fetch
         let expected_num_state_values = inclusive_range_len(start_index, end_index)?;
@@ -918,6 +923,7 @@ impl StorageReader {
                 end_index,
                 num_state_values_to_fetch,
                 max_response_size,
+                kind,
             );
         }
 
@@ -926,6 +932,7 @@ impl StorageReader {
             version,
             start_index as usize,
             num_state_values_to_fetch as usize,
+            kind,
         )?;
 
         // Initialize the fetched state values
@@ -977,6 +984,7 @@ impl StorageReader {
             version,
             start_index as usize,
             state_values,
+            kind,
         )?;
 
         // Update the data truncation metrics
@@ -995,12 +1003,14 @@ impl StorageReader {
         end_index: u64,
         mut num_state_values_to_fetch: u64,
         max_response_size: u64,
+        kind: StateKind,
     ) -> Result<StateValueChunkWithProof, Error> {
         while num_state_values_to_fetch >= 1 {
             let state_value_chunk_with_proof = self.storage.get_state_value_chunk_with_proof(
                 version,
                 start_index as usize,
                 num_state_values_to_fetch as usize,
+                kind,
             )?;
             if num_state_values_to_fetch == 1 {
                 return Ok(state_value_chunk_with_proof); // We cannot return less than a single item
@@ -1194,8 +1204,9 @@ impl StorageReaderInterface for StorageReader {
     fn get_number_of_states(
         &self,
         version: u64,
+        kind: StateKind,
     ) -> aptos_storage_service_types::Result<u64, Error> {
-        let number_of_states = self.storage.get_state_item_count(version)?;
+        let number_of_states = self.storage.get_state_item_count(version, kind)?;
         Ok(number_of_states as u64)
     }
 
@@ -1204,6 +1215,7 @@ impl StorageReaderInterface for StorageReader {
         version: u64,
         start_index: u64,
         end_index: u64,
+        kind: StateKind,
     ) -> aptos_storage_service_types::Result<StateValueChunkWithProof, Error> {
         self.get_state_value_chunk_with_proof_by_size(
             version,
@@ -1211,6 +1223,7 @@ impl StorageReaderInterface for StorageReader {
             end_index,
             self.config.max_network_chunk_bytes,
             self.config.enable_size_and_time_aware_chunking,
+            kind,
         )
     }
 }
@@ -1285,13 +1298,14 @@ impl DbReader for TimedStorageReader {
             ledger_version: Version,
         ) -> StorageResult<TransactionOutputListWithProofV2>;
 
-        fn get_state_item_count(&self, version: Version) -> StorageResult<usize>;
+        fn get_state_item_count(&self, version: Version, kind: StateKind) -> StorageResult<usize>;
 
         fn get_state_value_chunk_with_proof(
             &self,
             version: Version,
             start_idx: usize,
             chunk_size: usize,
+            kind: StateKind,
         ) -> StorageResult<StateValueChunkWithProof>;
 
         fn get_epoch_ending_ledger_info_iterator(
@@ -1336,6 +1350,7 @@ impl DbReader for TimedStorageReader {
             version: Version,
             first_index: usize,
             chunk_size: usize,
+            kind: StateKind,
         ) -> StorageResult<Box<dyn Iterator<Item = StorageResult<(StateKey, StateValue)>> + '_>>;
 
         fn get_state_value_chunk_proof(
@@ -1343,6 +1358,7 @@ impl DbReader for TimedStorageReader {
             version: Version,
             first_index: usize,
             state_key_values: Vec<(StateKey, StateValue)>,
+            kind: StateKind,
         ) -> StorageResult<StateValueChunkWithProof>;
 
         fn get_persisted_auxiliary_info_iterator(

--- a/state-sync/storage-service/server/src/tests/cache.rs
+++ b/state-sync/storage-service/server/src/tests/cache.rs
@@ -190,8 +190,8 @@ async fn test_cachable_requests_eviction() {
     db_reader
         .expect_get_state_item_count()
         .times(max_lru_cache_size as usize)
-        .with(always())
-        .returning(move |_| Ok(165));
+        .with(always(), always())
+        .returning(move |_, _| Ok(165));
     for _ in 0..2 {
         let state_value_chunk_with_proof_clone = state_value_chunk_with_proof.clone();
         db_reader
@@ -201,8 +201,9 @@ async fn test_cachable_requests_eviction() {
                 eq(version),
                 eq(start_index as usize),
                 eq((end_index - start_index + 1) as usize),
+                always(),
             )
-            .return_once(move |_, _, _| Ok(state_value_chunk_with_proof_clone))
+            .return_once(move |_, _, _, _| Ok(state_value_chunk_with_proof_clone))
             .in_sequence(&mut expectation_sequence);
     }
 

--- a/state-sync/storage-service/server/src/tests/mock.rs
+++ b/state-sync/storage-service/server/src/tests/mock.rs
@@ -22,7 +22,7 @@ use aptos_network::{
         },
     },
 };
-use aptos_storage_interface::{DbReader, LedgerSummary};
+use aptos_storage_interface::{DbReader, LedgerSummary, StateKind};
 use aptos_storage_service_notifications::StorageServiceNotifier;
 use aptos_storage_service_types::{
     requests::StorageServiceRequest, responses::StorageServiceResponse, StorageServiceError,
@@ -320,13 +320,14 @@ mock! {
             ledger_version: Version,
         ) -> aptos_storage_interface::Result<TransactionAccumulatorSummary>;
 
-        fn get_state_item_count(&self, version: Version) -> aptos_storage_interface::Result<usize>;
+        fn get_state_item_count(&self, version: Version, kind: StateKind) -> aptos_storage_interface::Result<usize>;
 
         fn get_state_value_chunk_with_proof(
             &self,
             version: Version,
             start_idx: usize,
             chunk_size: usize,
+            kind: StateKind,
         ) -> aptos_storage_interface::Result<StateValueChunkWithProof>;
 
         fn get_epoch_snapshot_prune_window(&self) -> aptos_storage_interface::Result<usize>;
@@ -381,6 +382,7 @@ mock! {
             version: Version,
             first_index: usize,
             chunk_size: usize,
+            kind: StateKind,
         ) -> aptos_storage_interface::Result<Box<dyn Iterator<Item = aptos_storage_interface::Result<(StateKey, StateValue)>>>>;
 
         fn get_state_value_chunk_proof(
@@ -388,6 +390,7 @@ mock! {
             version: Version,
             first_index: usize,
             state_key_values: Vec<(StateKey, StateValue)>,
+            kind: StateKind,
         ) -> aptos_storage_interface::Result<StateValueChunkWithProof>;
     }
 }

--- a/state-sync/storage-service/server/src/tests/number_of_states.rs
+++ b/state-sync/storage-service/server/src/tests/number_of_states.rs
@@ -9,7 +9,7 @@ use aptos_storage_service_types::{
     StorageServiceError,
 };
 use claims::assert_matches;
-use mockall::predicate::eq;
+use mockall::predicate::{always, eq};
 
 #[tokio::test]
 async fn test_get_number_of_states_at_version() {
@@ -22,8 +22,8 @@ async fn test_get_number_of_states_at_version() {
     db_reader
         .expect_get_state_item_count()
         .times(1)
-        .with(eq(version))
-        .returning(move |_| Ok(number_of_states as usize));
+        .with(eq(version), always())
+        .returning(move |_, _| Ok(number_of_states as usize));
 
     // Create the storage client and server
     let (mut mock_client, mut service, _, _, _) = MockClient::new(Some(db_reader), None);
@@ -72,8 +72,8 @@ async fn test_get_number_of_states_at_version_invalid() {
     db_reader
         .expect_get_state_item_count()
         .times(1)
-        .with(eq(version))
-        .returning(move |_| {
+        .with(eq(version), always())
+        .returning(move |_, _| {
             Err(AptosDbError::NotFound(
                 format_err!("Version does not exist!").to_string(),
             ))

--- a/state-sync/storage-service/server/src/tests/state_values.rs
+++ b/state-sync/storage-service/server/src/tests/state_values.rs
@@ -258,8 +258,9 @@ fn expect_get_state_values_with_proof(
                 eq(version),
                 eq(start_index as usize),
                 eq(chunk_size as usize),
+                always(),
             )
-            .returning(move |_, _, _| Ok(state_value_chunk_with_proof.clone()));
+            .returning(move |_, _, _, _| Ok(state_value_chunk_with_proof.clone()));
         return;
     }
 
@@ -277,16 +278,17 @@ fn expect_get_state_values_with_proof(
             eq(version),
             eq(start_index as usize),
             eq(chunk_size as usize),
+            always(),
         )
-        .returning(move |_, _, _| Ok(Box::new(state_value_iterator.clone())))
+        .returning(move |_, _, _, _| Ok(Box::new(state_value_iterator.clone())))
         .in_sequence(&mut expectation_sequence);
 
     // Expect a call to get the state value chunk proof
     mock_db
         .expect_get_state_value_chunk_proof()
         .times(1)
-        .with(eq(version), eq(start_index as usize), always())
-        .return_once(move |_, _, given_state_values| {
+        .with(eq(version), eq(start_index as usize), always(), always())
+        .return_once(move |_, _, given_state_values, _| {
             state_value_chunk_with_proof.raw_values = given_state_values;
             Ok(state_value_chunk_with_proof)
         })
@@ -413,9 +415,10 @@ fn create_mock_db_with_state_value_expectations(
                 eq(version),
                 eq(start_index as usize),
                 eq(chunk_size as usize),
+                always(),
             )
             .in_sequence(&mut expectation_sequence)
-            .returning(move |_, _, _| Ok(state_value_chunk_with_proof.clone()));
+            .returning(move |_, _, _, _| Ok(state_value_chunk_with_proof.clone()));
 
         chunk_size /= 2;
     }

--- a/state-sync/storage-service/types/src/requests.rs
+++ b/state-sync/storage-service/types/src/requests.rs
@@ -2,7 +2,7 @@
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::COMPRESSION_SUFFIX_LABEL;
-use aptos_types::transaction::Version;
+use aptos_types::{state_store::StateKind, transaction::Version};
 use serde::{Deserialize, Serialize};
 
 /// A storage service request.
@@ -53,6 +53,16 @@ pub enum DataRequest {
     GetTransactionDataWithProof(GetTransactionDataWithProofRequest), // Fetches transaction data with a proof
     GetNewTransactionDataWithProof(GetNewTransactionDataWithProofRequest), // Optimistically fetches new transaction data with a proof
     SubscribeTransactionDataWithProof(SubscribeTransactionDataWithProofRequest), // Subscribes to transaction data with a proof
+
+    // Appended at the end to preserve BCS variant indices (wire compatibility).
+    // V2 state requests carry the `StateKind`, so one variant serves any snapshot kind.
+    // Only native-position uses these today; main state stays on the V1 variants
+    // above for backward compatibility with already-deployed peers.
+    // TODO(grao): once V2 is supported fleet-wide, migrate main state to these
+    // (behind a config flag, like `enable_transaction_data_v2`) and deprecate the
+    // V1 `GetStateValuesWithProof` / `GetNumberOfStatesAtVersion` variants.
+    GetStateValuesWithProofV2(StateValuesWithProofRequestV2), // Fetches a list of states (of the given kind) with a proof
+    GetNumberOfStatesAtVersionV2(NumberOfStatesRequestV2), // Fetches the number of states (of the given kind) at the specified version
 }
 
 impl DataRequest {
@@ -65,6 +75,8 @@ impl DataRequest {
             Self::GetNumberOfStatesAtVersion(_) => "get_number_of_states_at_version",
             Self::GetServerProtocolVersion => "get_server_protocol_version",
             Self::GetStateValuesWithProof(_) => "get_state_values_with_proof",
+            Self::GetStateValuesWithProofV2(_) => "get_state_values_with_proof_v2",
+            Self::GetNumberOfStatesAtVersionV2(_) => "get_number_of_states_at_version_v2",
             Self::GetStorageServerSummary => "get_storage_server_summary",
             Self::GetTransactionOutputsWithProof(_) => "get_transaction_outputs_with_proof",
             Self::GetTransactionsWithProof(_) => "get_transactions_with_proof",
@@ -345,6 +357,24 @@ pub struct StateValuesWithProofRequest {
     pub version: u64,     // The version to fetch the state values at
     pub start_index: u64, // The index to start fetching state values (inclusive)
     pub end_index: u64,   // The index to stop fetching state values (inclusive)
+}
+
+/// A storage service request for fetching a list of state values (of the given
+/// kind) at a specified version.
+#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+pub struct StateValuesWithProofRequestV2 {
+    pub version: u64,          // The version to fetch the state values at
+    pub start_index: u64,      // The index to start fetching state values (inclusive)
+    pub end_index: u64,        // The index to stop fetching state values (inclusive)
+    pub state_kind: StateKind, // Which snapshot store to fetch from
+}
+
+/// A storage service request for fetching the number of state values (of the
+/// given kind) at a specified version.
+#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+pub struct NumberOfStatesRequestV2 {
+    pub version: u64,          // The version to fetch the number of states at
+    pub state_kind: StateKind, // Which snapshot store to count
 }
 
 /// A storage service request for fetching a transaction output list with a

--- a/state-sync/storage-service/types/src/responses.rs
+++ b/state-sync/storage-service/types/src/responses.rs
@@ -6,12 +6,12 @@ use crate::{
         DataRequest::{
             GetEpochEndingLedgerInfos, GetNewTransactionDataWithProof,
             GetNewTransactionOutputsWithProof, GetNewTransactionsOrOutputsWithProof,
-            GetNewTransactionsWithProof, GetNumberOfStatesAtVersion, GetServerProtocolVersion,
-            GetStateValuesWithProof, GetStorageServerSummary, GetTransactionDataWithProof,
-            GetTransactionOutputsWithProof, GetTransactionsOrOutputsWithProof,
-            GetTransactionsWithProof, SubscribeTransactionDataWithProof,
-            SubscribeTransactionOutputsWithProof, SubscribeTransactionsOrOutputsWithProof,
-            SubscribeTransactionsWithProof,
+            GetNewTransactionsWithProof, GetNumberOfStatesAtVersion, GetNumberOfStatesAtVersionV2,
+            GetServerProtocolVersion, GetStateValuesWithProof, GetStateValuesWithProofV2,
+            GetStorageServerSummary, GetTransactionDataWithProof, GetTransactionOutputsWithProof,
+            GetTransactionsOrOutputsWithProof, GetTransactionsWithProof,
+            SubscribeTransactionDataWithProof, SubscribeTransactionOutputsWithProof,
+            SubscribeTransactionsOrOutputsWithProof, SubscribeTransactionsWithProof,
         },
         TransactionDataRequestType,
     },
@@ -26,7 +26,7 @@ use aptos_time_service::{TimeService, TimeServiceTrait};
 use aptos_types::{
     epoch_change::EpochChangeProof,
     ledger_info::LedgerInfoWithSignatures,
-    state_store::state_value::StateValueChunkWithProof,
+    state_store::{state_value::StateValueChunkWithProof, StateKind},
     transaction::{
         TransactionListWithProof, TransactionListWithProofV2, TransactionOutputListWithProof,
         TransactionOutputListWithProofV2, Version,
@@ -158,6 +158,25 @@ pub enum DataResponse {
     // TODO: eventually we should deprecate all the old response types.
     TransactionDataWithProof(TransactionDataWithProofResponse),
     NewTransactionDataWithProof(NewTransactionDataWithProofResponse),
+
+    // Appended at the end to preserve BCS variant indices (wire compatibility).
+    // V2 state responses carry the `StateKind`, so one variant serves any snapshot kind.
+    StateValueChunkWithProofV2(StateValueChunkWithProofResponseV2),
+    NumberOfStatesAtVersionV2(NumberOfStatesResponseV2),
+}
+
+/// A state value chunk response (of the given kind) with a proof.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct StateValueChunkWithProofResponseV2 {
+    pub state_value_chunk_with_proof: StateValueChunkWithProof,
+    pub state_kind: StateKind,
+}
+
+/// A response holding the number of state values (of the given kind) at a version.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct NumberOfStatesResponseV2 {
+    pub number_of_states: u64,
+    pub state_kind: StateKind,
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -193,6 +212,10 @@ impl DataResponse {
             Self::NumberOfStatesAtVersion(_) => Self::get_number_of_states_at_version_label(),
             Self::ServerProtocolVersion(_) => Self::get_server_protocol_version_label(),
             Self::StateValueChunkWithProof(_) => Self::get_state_value_chunk_with_proof_label(),
+            Self::StateValueChunkWithProofV2(_) => {
+                Self::get_state_value_chunk_with_proof_v2_label()
+            },
+            Self::NumberOfStatesAtVersionV2(_) => Self::get_number_of_states_at_version_v2_label(),
             Self::StorageServerSummary(_) => Self::get_storage_server_summary_label(),
             Self::TransactionOutputsWithProof(_) => {
                 Self::get_transaction_outputs_with_proof_label()
@@ -257,6 +280,16 @@ impl DataResponse {
     /// Returns a label for the state value chunk with proof response
     pub fn get_state_value_chunk_with_proof_label() -> &'static str {
         "state_value_chunk_with_proof"
+    }
+
+    /// Returns a label for the v2 state value chunk with proof response
+    pub fn get_state_value_chunk_with_proof_v2_label() -> &'static str {
+        "state_value_chunk_with_proof_v2"
+    }
+
+    /// Returns a label for the v2 number of states at version response
+    pub fn get_number_of_states_at_version_v2_label() -> &'static str {
+        "number_of_states_at_version_v2"
     }
 
     /// Returns a label for the storage server summary response
@@ -332,6 +365,36 @@ impl TryFrom<StorageServiceResponse> for StateValueChunkWithProof {
             DataResponse::StateValueChunkWithProof(inner) => Ok(inner),
             _ => Err(Error::UnexpectedResponseError(format!(
                 "expected state_value_chunk_with_proof, found {}",
+                data_response.get_label()
+            ))),
+        }
+    }
+}
+
+impl TryFrom<StorageServiceResponse> for StateValueChunkWithProofResponseV2 {
+    type Error = crate::responses::Error;
+
+    fn try_from(response: StorageServiceResponse) -> crate::Result<Self, Self::Error> {
+        let data_response = response.get_data_response()?;
+        match data_response {
+            DataResponse::StateValueChunkWithProofV2(inner) => Ok(inner),
+            _ => Err(Error::UnexpectedResponseError(format!(
+                "expected state_value_chunk_with_proof_v2, found {}",
+                data_response.get_label()
+            ))),
+        }
+    }
+}
+
+impl TryFrom<StorageServiceResponse> for NumberOfStatesResponseV2 {
+    type Error = crate::responses::Error;
+
+    fn try_from(response: StorageServiceResponse) -> crate::Result<Self, Self::Error> {
+        let data_response = response.get_data_response()?;
+        match data_response {
+            DataResponse::NumberOfStatesAtVersionV2(inner) => Ok(inner),
+            _ => Err(Error::UnexpectedResponseError(format!(
+                "expected number_of_states_at_version_v2, found {}",
                 data_response.get_label()
             ))),
         }
@@ -720,26 +783,18 @@ impl DataSummary {
                 time_service,
                 self.synced_ledger_info.as_ref(),
             ),
+            // All snapshot kinds are synced at the same versions, so they share
+            // the same advertised range.
             GetNumberOfStatesAtVersion(version) => self
                 .states
                 .map(|range| range.contains(*version))
                 .unwrap_or(false),
-            GetStateValuesWithProof(request) => {
-                let proof_version = request.version;
-
-                let can_serve_states = self
-                    .states
-                    .map(|range| range.contains(request.version))
-                    .unwrap_or(false);
-
-                let can_create_proof = self
-                    .synced_ledger_info
-                    .as_ref()
-                    .map(|li| li.ledger_info().version() >= proof_version)
-                    .unwrap_or(false);
-
-                can_serve_states && can_create_proof
-            },
+            GetNumberOfStatesAtVersionV2(request) => self
+                .states
+                .map(|range| range.contains(request.version))
+                .unwrap_or(false),
+            GetStateValuesWithProof(request) => self.can_service_state_values(request.version),
+            GetStateValuesWithProofV2(request) => self.can_service_state_values(request.version),
             GetTransactionOutputsWithProof(request) => self
                 .can_service_transaction_outputs_with_proof(
                     request.start_version,
@@ -827,6 +882,16 @@ impl DataSummary {
         self.transactions
             .map(|range| range.superset_of(desired_range))
             .unwrap_or(false)
+    }
+
+    /// Returns true iff the peer can service a state value chunk (of any kind)
+    /// at `version`. All snapshot kinds share the same advertised range.
+    fn can_service_state_values(&self, version: u64) -> bool {
+        let can_serve_states = self
+            .states
+            .map(|range| range.contains(version))
+            .unwrap_or(false);
+        can_serve_states && self.can_create_proof(version)
     }
 
     /// Returns true iff the peer can service the transaction outputs and proof

--- a/storage/aptosdb/src/db/aptosdb_internal.rs
+++ b/storage/aptosdb/src/db/aptosdb_internal.rs
@@ -472,6 +472,42 @@ impl AptosDB {
         Ok(())
     }
 
+    /// Mirrors [`Self::error_if_state_merkle_pruned`] for the native-position
+    /// snapshot store. When the subsystem or its pruner isn't attached (disabled
+    /// / read-only), there's nothing to enforce here.
+    pub(super) fn error_if_position_pruned(&self, data_type: &str, version: Version) -> Result<()> {
+        let Some(position_pruner) = self
+            .position
+            .as_ref()
+            .and_then(|position| position.position_pruner.as_ref())
+        else {
+            return Ok(());
+        };
+
+        let min_readable_version = position_pruner
+            .state_merkle_pruner
+            .get_min_readable_version();
+        if version >= min_readable_version {
+            return Ok(());
+        }
+
+        let min_readable_epoch_snapshot_version = position_pruner
+            .epoch_snapshot_pruner
+            .get_min_readable_version();
+        if version >= min_readable_epoch_snapshot_version {
+            self.ledger_db.metadata_db().ensure_epoch_ending(version)
+        } else {
+            bail!(
+                "{} at version {} is pruned. position snapshots are available at >= {}, \
+                 position epoch snapshots are available at >= {}",
+                data_type,
+                version,
+                min_readable_version,
+                min_readable_epoch_snapshot_version,
+            )
+        }
+    }
+
     pub(super) fn get_raw_block_info_by_height(&self, block_height: u64) -> Result<BlockInfo> {
         self.ledger_db
             .metadata_db()

--- a/storage/aptosdb/src/db/aptosdb_reader.rs
+++ b/storage/aptosdb/src/db/aptosdb_reader.rs
@@ -18,7 +18,7 @@ use aptos_storage_interface::{
     state_store::{
         state::State, state_summary::StateSummary, state_view::hot_state_view::HotStateView,
     },
-    AptosDbError, BlockHeight, DbReader, LedgerSummary, Result, MAX_REQUEST_LIMIT,
+    AptosDbError, BlockHeight, DbReader, LedgerSummary, Result, StateKind, MAX_REQUEST_LIMIT,
 };
 use aptos_types::{
     account_address::AccountAddress,
@@ -845,13 +845,35 @@ impl DbReader for AptosDB {
             .map_err(Into::into)
     }
 
-    fn get_state_item_count(&self, version: Version) -> Result<usize> {
-        gauged_api("get_state_item_count", || {
-            self.error_if_state_merkle_pruned("State merkle", version)?;
-            self.ledger_db
-                .metadata_db()
-                .get_usage(version)
-                .map(|usage| usage.items())
+    fn get_state_item_count(&self, version: Version, kind: StateKind) -> Result<usize> {
+        gauged_api("get_state_item_count", || match kind {
+            StateKind::MainState => {
+                self.error_if_state_merkle_pruned("State merkle", version)?;
+                self.ledger_db
+                    .metadata_db()
+                    .get_usage(version)
+                    .map(|usage| usage.items())
+            },
+            StateKind::Position => {
+                self.error_if_position_pruned("Native-position state merkle", version)?;
+                let position = self.position.as_ref().ok_or_else(|| {
+                    AptosDbError::Other("native-position subsystem is not enabled".into())
+                })?;
+                // Position snapshots are sparse; resolve to the latest at or
+                // before `version`. `None` means no snapshot yet => empty.
+                match position
+                    .merkle_db
+                    .latest_snapshot_version_at_or_before(version)?
+                {
+                    Some(snapshot_version) => {
+                        crate::position_state_sync::get_position_state_item_count(
+                            &position.merkle_db,
+                            snapshot_version,
+                        )
+                    },
+                    None => Ok(0),
+                }
+            },
         })
     }
 
@@ -860,11 +882,36 @@ impl DbReader for AptosDB {
         version: Version,
         first_index: usize,
         chunk_size: usize,
+        kind: StateKind,
     ) -> Result<StateValueChunkWithProof> {
-        gauged_api("get_state_value_chunk_with_proof", || {
-            self.error_if_state_merkle_pruned("State merkle", version)?;
-            self.state_store
-                .get_value_chunk_with_proof(version, first_index, chunk_size)
+        gauged_api("get_state_value_chunk_with_proof", || match kind {
+            StateKind::MainState => {
+                self.error_if_state_merkle_pruned("State merkle", version)?;
+                self.state_store
+                    .get_value_chunk_with_proof(version, first_index, chunk_size)
+            },
+            StateKind::Position => {
+                self.error_if_position_pruned("Native-position state merkle", version)?;
+                let position = self.position.as_ref().ok_or_else(|| {
+                    AptosDbError::Other("native-position subsystem is not enabled".into())
+                })?;
+                let snapshot_version = position
+                    .merkle_db
+                    .latest_snapshot_version_at_or_before(version)?
+                    .ok_or_else(|| {
+                        AptosDbError::Other(format!(
+                            "no native-position snapshot at or before version {version}"
+                        ))
+                    })?;
+                let position_db = Arc::clone(&position.kv_db);
+                crate::state_value_chunk::value_chunk_with_proof(
+                    Arc::clone(&position.merkle_db),
+                    snapshot_version,
+                    first_index,
+                    chunk_size,
+                    move |key, version| position_db.expect_value_by_version(key, version),
+                )
+            },
         })
     }
 
@@ -873,16 +920,45 @@ impl DbReader for AptosDB {
         version: Version,
         first_index: usize,
         chunk_size: usize,
+        kind: StateKind,
     ) -> Result<Box<dyn Iterator<Item = Result<(StateKey, StateValue)>> + '_>> {
-        gauged_api("get_state_value_chunk_iter", || {
-            self.error_if_state_merkle_pruned("State merkle", version)?;
-            let state_value_chunk_iter =
-                self.state_store
-                    .get_value_chunk_iter(version, first_index, chunk_size)?;
-            Ok(Box::new(state_value_chunk_iter)
-                as Box<
-                    dyn Iterator<Item = Result<(StateKey, StateValue)>> + '_,
-                >)
+        gauged_api("get_state_value_chunk_iter", || match kind {
+            StateKind::MainState => {
+                self.error_if_state_merkle_pruned("State merkle", version)?;
+                let state_value_chunk_iter =
+                    self.state_store
+                        .get_value_chunk_iter(version, first_index, chunk_size)?;
+                Ok(Box::new(state_value_chunk_iter)
+                    as Box<
+                        dyn Iterator<Item = Result<(StateKey, StateValue)>> + '_,
+                    >)
+            },
+            StateKind::Position => {
+                self.error_if_position_pruned("Native-position state merkle", version)?;
+                let position = self.position.as_ref().ok_or_else(|| {
+                    AptosDbError::Other("native-position subsystem is not enabled".into())
+                })?;
+                match position
+                    .merkle_db
+                    .latest_snapshot_version_at_or_before(version)?
+                {
+                    Some(snapshot_version) => {
+                        let iter = position.merkle_db.iter_active_leaves_chunk(
+                            position.kv_db.clone(),
+                            snapshot_version,
+                            first_index,
+                            chunk_size,
+                        )?;
+                        Ok(Box::new(iter)
+                            as Box<
+                                dyn Iterator<Item = Result<(StateKey, StateValue)>> + '_,
+                            >)
+                    },
+                    // No snapshot at or before `version` => empty position state.
+                    None => Ok(Box::new(std::iter::empty())
+                        as Box<dyn Iterator<Item = Result<(StateKey, StateValue)>> + '_>),
+                }
+            },
         })
     }
 
@@ -891,11 +967,34 @@ impl DbReader for AptosDB {
         version: Version,
         first_index: usize,
         state_key_values: Vec<(StateKey, StateValue)>,
+        kind: StateKind,
     ) -> Result<StateValueChunkWithProof> {
-        gauged_api("get_state_value_chunk_proof", || {
-            self.error_if_state_merkle_pruned("State merkle", version)?;
-            self.state_store
-                .get_value_chunk_proof(version, first_index, state_key_values)
+        gauged_api("get_state_value_chunk_proof", || match kind {
+            StateKind::MainState => {
+                self.error_if_state_merkle_pruned("State merkle", version)?;
+                self.state_store
+                    .get_value_chunk_proof(version, first_index, state_key_values)
+            },
+            StateKind::Position => {
+                self.error_if_position_pruned("Native-position state merkle", version)?;
+                let position = self.position.as_ref().ok_or_else(|| {
+                    AptosDbError::Other("native-position subsystem is not enabled".into())
+                })?;
+                let snapshot_version = position
+                    .merkle_db
+                    .latest_snapshot_version_at_or_before(version)?
+                    .ok_or_else(|| {
+                        AptosDbError::Other(format!(
+                            "no native-position snapshot at or before version {version}"
+                        ))
+                    })?;
+                crate::state_value_chunk::build_value_chunk_proof(
+                    position.merkle_db.as_ref(),
+                    snapshot_version,
+                    first_index,
+                    state_key_values,
+                )
+            },
         })
     }
 

--- a/storage/aptosdb/src/db/aptosdb_test.rs
+++ b/storage/aptosdb/src/db/aptosdb_test.rs
@@ -29,7 +29,7 @@ use aptos_config::config::{
     DEFAULT_MAX_NUM_NODES_PER_LRU_CACHE_SHARD,
 };
 use aptos_crypto::{hash::CryptoHash, HashValue};
-use aptos_storage_interface::{DbReader, Order};
+use aptos_storage_interface::{DbReader, Order, StateKind};
 use aptos_temppath::TempPath;
 use aptos_types::{
     ledger_info::LedgerInfoWithSignatures,
@@ -461,10 +461,13 @@ proptest! {
         let state_checkpoint_version =
             db.get_latest_state_checkpoint_version().unwrap().unwrap();
         let state_leaf_count =
-            db.get_state_item_count(state_checkpoint_version).unwrap();
+            db.get_state_item_count(state_checkpoint_version, StateKind::MainState).unwrap();
         let state_value_chunk_with_proof = db
             .get_state_value_chunk_with_proof(
-                state_checkpoint_version, 0, state_leaf_count,
+                state_checkpoint_version,
+                0,
+                state_leaf_count,
+                StateKind::MainState,
             )
             .unwrap();
         prop_assert_eq!(state_value_chunk_with_proof.first_index, 0);

--- a/storage/aptosdb/src/db/aptosdb_writer.rs
+++ b/storage/aptosdb/src/db/aptosdb_writer.rs
@@ -30,7 +30,7 @@ use aptos_metrics_core::TimerHelper;
 use aptos_schemadb::batch::SchemaBatch;
 use aptos_storage_interface::{
     chunk_to_commit::ChunkToCommit, db_ensure as ensure, AptosDbError, DbReader, DbWriter, Result,
-    StateSnapshotReceiver,
+    StateKind, StateSnapshotReceiver,
 };
 #[cfg(any(test, feature = "fuzzing"))]
 use aptos_types::transaction::TransactionAuxiliaryData;
@@ -122,10 +122,23 @@ impl DbWriter for AptosDB {
         &self,
         version: Version,
         expected_root_hash: HashValue,
+        kind: StateKind,
     ) -> Result<Box<dyn StateSnapshotReceiver<StateKey, StateValue>>> {
-        gauged_api("get_state_snapshot_receiver", || {
-            self.state_store
-                .get_snapshot_receiver(version, expected_root_hash)
+        gauged_api("get_state_snapshot_receiver", || match kind {
+            StateKind::MainState => self
+                .state_store
+                .get_snapshot_receiver(version, expected_root_hash),
+            StateKind::Position => {
+                let position = self.position.as_ref().ok_or_else(|| {
+                    AptosDbError::Other("native-position subsystem is not enabled".into())
+                })?;
+                crate::position_state_sync::get_position_snapshot_receiver(
+                    &position.kv_db,
+                    &position.merkle_db,
+                    version,
+                    expected_root_hash,
+                )
+            },
         })
     }
 

--- a/storage/aptosdb/src/db/fake_aptosdb.rs
+++ b/storage/aptosdb/src/db/fake_aptosdb.rs
@@ -21,7 +21,7 @@ use aptos_storage_interface::{
         state_delta::StateDelta, state_update_refs::BatchedStateUpdateRefs,
         state_view::cached_state_view::ShardedStateCache,
     },
-    AptosDbError, DbReader, DbWriter, LedgerSummary, MAX_REQUEST_LIMIT,
+    AptosDbError, DbReader, DbWriter, LedgerSummary, StateKind, MAX_REQUEST_LIMIT,
 };
 use aptos_types::{
     access_path::AccessPath,
@@ -439,9 +439,10 @@ impl DbWriter for FakeAptosDB {
         &self,
         version: Version,
         expected_root_hash: HashValue,
+        kind: StateKind,
     ) -> Result<Box<dyn aptos_storage_interface::StateSnapshotReceiver<StateKey, StateValue>>> {
         self.inner
-            .get_state_snapshot_receiver(version, expected_root_hash)
+            .get_state_snapshot_receiver(version, expected_root_hash, kind)
     }
 
     fn finalize_state_snapshot(
@@ -873,8 +874,8 @@ impl DbReader for FakeAptosDB {
             .map_err(Into::into)
     }
 
-    fn get_state_item_count(&self, version: Version) -> Result<usize> {
-        self.inner.get_state_item_count(version)
+    fn get_state_item_count(&self, version: Version, kind: StateKind) -> Result<usize> {
+        self.inner.get_state_item_count(version, kind)
     }
 
     fn get_state_value_chunk_with_proof(
@@ -882,9 +883,10 @@ impl DbReader for FakeAptosDB {
         version: Version,
         start_idx: usize,
         chunk_size: usize,
+        kind: StateKind,
     ) -> Result<StateValueChunkWithProof> {
         self.inner
-            .get_state_value_chunk_with_proof(version, start_idx, chunk_size)
+            .get_state_value_chunk_with_proof(version, start_idx, chunk_size, kind)
     }
 
     fn is_state_merkle_pruner_enabled(&self) -> Result<bool> {

--- a/storage/aptosdb/src/fast_sync_storage_wrapper.rs
+++ b/storage/aptosdb/src/fast_sync_storage_wrapper.rs
@@ -8,7 +8,7 @@ use aptos_crypto::HashValue;
 use aptos_db_indexer::db_indexer::InternalIndexerDB;
 use aptos_infallible::RwLock;
 use aptos_storage_interface::{
-    chunk_to_commit::ChunkToCommit, DbReader, DbWriter, Result, StateSnapshotReceiver,
+    chunk_to_commit::ChunkToCommit, DbReader, DbWriter, Result, StateKind, StateSnapshotReceiver,
 };
 use aptos_types::{
     ledger_info::LedgerInfoWithSignatures,
@@ -143,10 +143,15 @@ impl DbWriter for FastSyncStorageWrapper {
         &self,
         version: Version,
         expected_root_hash: HashValue,
+        kind: StateKind,
     ) -> Result<Box<dyn StateSnapshotReceiver<StateKey, StateValue>>> {
-        *self.fast_sync_status.write() = FastSyncStatus::STARTED;
+        // The main-state receiver marks the start of a fast sync; any later
+        // snapshot stage must not reset that status.
+        if kind == StateKind::MainState {
+            *self.fast_sync_status.write() = FastSyncStatus::STARTED;
+        }
         self.get_aptos_db_write_ref()
-            .get_state_snapshot_receiver(version, expected_root_hash)
+            .get_state_snapshot_receiver(version, expected_root_hash, kind)
     }
 
     fn finalize_state_snapshot(

--- a/storage/aptosdb/src/lib.rs
+++ b/storage/aptosdb/src/lib.rs
@@ -40,6 +40,7 @@ pub mod position_metrics;
 pub(crate) mod position_pruner;
 pub(crate) mod position_snapshot_committer;
 pub mod position_state_store;
+pub mod position_state_sync;
 mod pruner;
 mod sharded_jmt_merkle_db;
 mod sharded_kv_db;

--- a/storage/aptosdb/src/position_db.rs
+++ b/storage/aptosdb/src/position_db.rs
@@ -12,14 +12,14 @@ use crate::{
     sharded_kv_db::ShardedKvDb,
 };
 use aptos_config::config::{RocksdbConfig, StorageDirPaths};
-use aptos_crypto::HashValue;
+use aptos_crypto::{hash::CryptoHash, HashValue};
 use aptos_experimental_runtimes::thread_manager::THREAD_MANAGER;
 use aptos_logger::info;
 use aptos_rocksdb_options::gen_rocksdb_options;
 use aptos_schemadb::{batch::SchemaBatch, Cache, Env, ReadOptions, DB};
 use aptos_storage_interface::{AptosDbError, Result};
 use aptos_types::{
-    state_store::{state_value::StateValue, NUM_STATE_SHARDS},
+    state_store::{state_key::StateKey, state_value::StateValue, NUM_STATE_SHARDS},
     transaction::Version,
 };
 use rayon::prelude::*;
@@ -259,6 +259,50 @@ impl PositionDb {
             .next()
             .transpose()?
             .and_then(|((_, version), value_opt)| value_opt.map(|value| (version, value))))
+    }
+
+    /// Returns the value for `key` recorded at `version`, erroring if the row is
+    /// missing. Mirrors `StateStore::expect_value_by_version` for the position CF.
+    pub fn expect_value_by_version(&self, key: &StateKey, version: Version) -> Result<StateValue> {
+        let key_hash = key.hash();
+        let (_version, value) = self.get_position_value(key_hash, version)?.ok_or_else(|| {
+            AptosDbError::Other(format!(
+                "position_value row missing (state_key_hash={key_hash}, version={version})"
+            ))
+        })?;
+        Ok(value)
+    }
+
+    /// Fans `(state_key_hash, version, value)` writes into per-shard batches.
+    pub(crate) fn shard_position_value_writes(
+        writes: impl IntoIterator<Item = (HashValue, Version, Option<StateValue>)>,
+    ) -> Result<[Option<SchemaBatch>; NUM_NATIVE_VALUE_SHARDS]> {
+        let mut per_shard: [Option<SchemaBatch>; NUM_NATIVE_VALUE_SHARDS] =
+            std::array::from_fn(|_| None);
+        for (state_key_hash, version, maybe_value) in writes {
+            let shard = ShardedKvDb::shard_of_hash(state_key_hash);
+            let batch = per_shard[shard].get_or_insert_with(SchemaBatch::new);
+            batch.put::<PositionValueSchema>(&(state_key_hash, version), &maybe_value)?;
+        }
+        Ok(per_shard)
+    }
+
+    pub fn write_position_batch(
+        &self,
+        version: Version,
+        writes: impl IntoIterator<Item = (HashValue, Option<StateValue>)>,
+    ) -> Result<()> {
+        let per_shard = Self::shard_position_value_writes(
+            writes
+                .into_iter()
+                .map(|(hash, value)| (hash, version, value)),
+        )?;
+        for (shard, maybe_batch) in per_shard.into_iter().enumerate() {
+            if let Some(batch) = maybe_batch {
+                self.shard(shard).write_schemas(batch)?;
+            }
+        }
+        Ok(())
     }
 
     pub fn find_prior_version(

--- a/storage/aptosdb/src/position_merkle_db.rs
+++ b/storage/aptosdb/src/position_merkle_db.rs
@@ -11,7 +11,7 @@ use crate::{
     utils::truncation_helper::find_closest_node_version_at_or_before,
 };
 use aptos_config::config::{RocksdbConfig, StorageDirPaths};
-use aptos_crypto::{hash::CryptoHash, HashValue};
+use aptos_crypto::HashValue;
 use aptos_jellyfish_merkle::{
     iterator::JellyfishMerkleIterator, node_type::NodeKey, JellyfishMerkleTree, TreeReader,
     TreeWriter,
@@ -195,18 +195,7 @@ impl PositionMerkleDb {
             Arc::clone(self),
             version,
             start_idx,
-            move |state_key, leaf_version| {
-                let key_hash = state_key.hash();
-                position_db
-                    .get_position_value(key_hash, leaf_version)?
-                    .map(|(_v, value)| value)
-                    .ok_or_else(|| {
-                        AptosDbError::Other(format!(
-                            "JMT leaf at v={version} references missing position_value row \
-                             (state_key_hash={key_hash}, leaf_version={leaf_version})"
-                        ))
-                    })
-            },
+            move |key, leaf_version| position_db.expect_value_by_version(key, leaf_version),
         )
     }
 

--- a/storage/aptosdb/src/position_state_sync.rs
+++ b/storage/aptosdb/src/position_state_sync.rs
@@ -1,0 +1,111 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Producer/receiver for native-position state-sync, built on the generic
+//! `StateSnapshotRestore` machinery.
+
+#![forbid(unsafe_code)]
+
+use crate::{
+    position_db::PositionDb,
+    position_merkle_db::PositionMerkleDb,
+    schema::db_metadata::{DbMetadataKey, DbMetadataSchema, DbMetadataValue},
+    state_restore::{
+        StateSnapshotRestore, StateSnapshotRestoreMode, StateValueBatch, StateValueWriter,
+    },
+};
+use aptos_crypto::{
+    hash::{CryptoHash, SPARSE_MERKLE_PLACEHOLDER_HASH},
+    HashValue,
+};
+use aptos_db_indexer_schemas::metadata::StateSnapshotProgress;
+use aptos_jellyfish_merkle::JellyfishMerkleTree;
+use aptos_schemadb::batch::SchemaBatch;
+use aptos_storage_interface::{Result, StateSnapshotReceiver};
+use aptos_types::{
+    state_store::{
+        state_key::StateKey, state_storage_usage::StateStorageUsage, state_value::StateValue,
+    },
+    transaction::Version,
+};
+use std::sync::Arc;
+
+/// Number of live position leaves at `version` (0 for an empty tree).
+pub fn get_position_state_item_count(
+    position_merkle_db: &Arc<PositionMerkleDb>,
+    version: Version,
+) -> Result<usize> {
+    // An empty position tree has no root node; report 0 rather than erroring.
+    if position_merkle_db.get_root_hash(version)? == *SPARSE_MERKLE_PLACEHOLDER_HASH {
+        return Ok(0);
+    }
+    let tree = JellyfishMerkleTree::<_, StateKey>::new(position_merkle_db.as_ref());
+    tree.get_leaf_count(version)
+}
+
+/// `StateValueWriter` for the position value CF, so `StateSnapshotRestore`
+/// drives the native-position restore.
+pub struct PositionStateValueWriter {
+    position_db: Arc<PositionDb>,
+}
+
+impl PositionStateValueWriter {
+    pub fn new(position_db: &Arc<PositionDb>) -> Self {
+        Self {
+            position_db: Arc::clone(position_db),
+        }
+    }
+}
+
+impl StateValueWriter<StateKey, StateValue> for PositionStateValueWriter {
+    fn write_kv_batch(
+        &self,
+        version: Version,
+        kv_batch: &StateValueBatch<StateKey, Option<StateValue>>,
+        progress: StateSnapshotProgress,
+    ) -> Result<()> {
+        let per_shard =
+            PositionDb::shard_position_value_writes(kv_batch.iter().map(
+                |((state_key, ver), maybe_value)| (state_key.hash(), *ver, maybe_value.clone()),
+            ))?;
+        let mut metadata_batch = SchemaBatch::new();
+        metadata_batch.put::<DbMetadataSchema>(
+            &DbMetadataKey::PositionSnapshotKvRestoreProgress(version),
+            &DbMetadataValue::StateSnapshotProgress(progress),
+        )?;
+        self.position_db
+            .commit(version, Some(metadata_batch), per_shard)
+    }
+
+    fn kv_finish(&self, _version: Version, _usage: StateStorageUsage) -> Result<()> {
+        // Usage is already carried in the persisted StateSnapshotProgress.
+        Ok(())
+    }
+
+    fn get_progress(&self, version: Version) -> Result<Option<StateSnapshotProgress>> {
+        Ok(self
+            .position_db
+            .metadata_db()
+            .get::<DbMetadataSchema>(&DbMetadataKey::PositionSnapshotKvRestoreProgress(version))?
+            .map(|v| v.expect_state_snapshot_progress()))
+    }
+}
+
+/// Returns a snapshot receiver that verifies each chunk's range proof against
+/// `expected_root_hash` and writes to the position CF.
+pub fn get_position_snapshot_receiver(
+    position_db: &Arc<PositionDb>,
+    position_merkle_db: &Arc<PositionMerkleDb>,
+    version: Version,
+    expected_root_hash: HashValue,
+) -> Result<Box<dyn StateSnapshotReceiver<StateKey, StateValue>>> {
+    let value_writer = Arc::new(PositionStateValueWriter::new(position_db));
+    Ok(Box::new(StateSnapshotRestore::new(
+        position_merkle_db,
+        &value_writer,
+        version,
+        expected_root_hash,
+        false, /* async_commit */
+        StateSnapshotRestoreMode::Default,
+    )?))
+}

--- a/storage/aptosdb/src/schema/db_metadata/mod.rs
+++ b/storage/aptosdb/src/schema/db_metadata/mod.rs
@@ -80,6 +80,7 @@ pub enum DbMetadataKey {
     PositionStateMerkleShardPrunerProgress(ShardId),
     PositionEpochSnapshotPrunerProgress,
     PositionEpochSnapshotShardPrunerProgress(ShardId),
+    PositionSnapshotKvRestoreProgress(Version),
 }
 
 define_schema!(

--- a/storage/aptosdb/src/state_store/mod.rs
+++ b/storage/aptosdb/src/state_store/mod.rs
@@ -1447,17 +1447,12 @@ impl StateStore {
         start_idx: usize,
     ) -> Result<impl Iterator<Item = Result<(StateKey, StateValue)>> + Send + Sync + use<>> {
         let store = Arc::clone(self);
-        Ok(JellyfishMerkleIterator::new_by_index(
+        jmt_leaves_with_values(
             Arc::clone(&self.state_merkle_db),
             version,
             start_idx,
-        )?
-        .map(move |res| match res {
-            Ok((_hashed_key, (key, version))) => {
-                Ok((key.clone(), store.expect_value_by_version(&key, version)?))
-            },
-            Err(err) => Err(err),
-        }))
+            move |key, version| store.expect_value_by_version(key, version),
+        )
     }
 
     pub fn get_value_chunk_with_proof(
@@ -1482,14 +1477,9 @@ impl StateStore {
         first_index: usize,
         chunk_size: usize,
     ) -> Result<impl Iterator<Item = Result<(StateKey, StateValue)>> + Send + Sync + use<>> {
-        let store = Arc::clone(self);
-        Ok(jmt_leaves_with_values(
-            Arc::clone(&self.state_merkle_db),
-            version,
-            first_index,
-            move |key, version| store.expect_value_by_version(key, version),
-        )?
-        .take(chunk_size))
+        Ok(self
+            .get_state_key_and_value_iter(version, first_index)?
+            .take(chunk_size))
     }
 
     pub fn get_value_chunk_proof(

--- a/storage/aptosdb/src/state_store/tests/mod.rs
+++ b/storage/aptosdb/src/state_store/tests/mod.rs
@@ -17,7 +17,7 @@ use aptos_jellyfish_merkle::{
     node_type::{Node, NodeKey},
     TreeReader,
 };
-use aptos_storage_interface::{DbReader, DbWriter, StateSnapshotReceiver};
+use aptos_storage_interface::{DbReader, DbWriter, StateKind, StateSnapshotReceiver};
 use aptos_temppath::TempPath;
 use aptos_types::nibble::nibble_path::NibblePath;
 use proptest::{collection::hash_map, prelude::*};
@@ -457,7 +457,13 @@ proptest! {
             // Check db restore calculates usage correctly as well.
             let tmp_dir = TempPath::new();
             let db2 = AptosDB::new_for_test(&tmp_dir);
-            let mut restore = db2.get_state_snapshot_receiver(100, root_hash).unwrap();
+            let mut restore = db2
+                .get_state_snapshot_receiver(
+                    100,
+                    root_hash,
+                    StateKind::MainState,
+                )
+                .unwrap();
             let proof = if let Some((k, _v)) = snapshot.last() {
                 db.get_backup_handler().get_account_state_range_proof(k.hash(), last_version).unwrap()
             } else {

--- a/storage/storage-interface/src/lib.rs
+++ b/storage/storage-interface/src/lib.rs
@@ -49,7 +49,7 @@ use crate::{
         state_with_summary::LedgerWithSummary,
     },
 };
-pub use aptos_types::block_info::BlockHeight;
+pub use aptos_types::{block_info::BlockHeight, state_store::StateKind};
 pub use errors::AptosDbError;
 pub use ledger_summary::LedgerSummary;
 
@@ -457,31 +457,36 @@ pub trait DbReader: Send + Sync {
             ledger_version: Version,
         ) -> Result<TransactionAccumulatorSummary>;
 
-        /// Returns total number of state items in state store at given version.
-        fn get_state_item_count(&self, version: Version) -> Result<usize>;
+        /// Returns the number of items in the given snapshot store at `version`.
+        fn get_state_item_count(&self, version: Version, kind: StateKind) -> Result<usize>;
 
-        /// Get a chunk of state store value, addressed by the index.
+        /// Get a chunk of values from the given snapshot store, addressed by the index.
         fn get_state_value_chunk_with_proof(
             &self,
             version: Version,
             start_idx: usize,
             chunk_size: usize,
+            kind: StateKind,
         ) -> Result<StateValueChunkWithProof>;
 
-        /// Returns an iterator of state key value pairs starting from the index.
+        /// Returns an iterator of value pairs from the given snapshot store,
+        /// starting from the index.
         fn get_state_value_chunk_iter(
             &self,
             version: Version,
             first_index: usize,
             chunk_size: usize,
+            kind: StateKind,
         ) -> Result<Box<dyn Iterator<Item = Result<(StateKey, StateValue)>> + '_>>;
 
-        /// Returns a state value chunk proof for the given state key values.
+        /// Returns a value chunk proof for the given values from the given
+        /// snapshot store.
         fn get_state_value_chunk_proof(
             &self,
             version: Version,
             first_index: usize,
             state_key_values: Vec<(StateKey, StateValue)>,
+            kind: StateKind,
         ) -> Result<StateValueChunkWithProof>;
 
         /// Returns the total number of hot state items (leaves of the hot state Merkle tree) at
@@ -585,13 +590,14 @@ pub trait DbReader: Send + Sync {
 /// expected of an Aptos DB. This adds write APIs to DbReader.
 #[allow(unused_variables)]
 pub trait DbWriter: Send + Sync {
-    /// Get a (stateful) state snapshot receiver.
+    /// Get a (stateful) snapshot receiver for the given snapshot store.
     ///
     /// Chunk of accounts need to be added via `add_chunk()` before finishing up with `finish_box()`
     fn get_state_snapshot_receiver(
         &self,
         version: Version,
         expected_root_hash: HashValue,
+        kind: StateKind,
     ) -> Result<Box<dyn StateSnapshotReceiver<StateKey, StateValue>>> {
         unimplemented!()
     }

--- a/types/src/state_store/mod.rs
+++ b/types/src/state_store/mod.rs
@@ -14,6 +14,7 @@ use crate::{
 use aptos_crypto::HashValue;
 use bytes::Bytes;
 use move_core_types::{language_storage::StructTag, move_resource::MoveResource};
+use serde::{Deserialize, Serialize};
 #[cfg(any(test, feature = "testing"))]
 use std::hash::Hash;
 use std::ops::Deref;
@@ -28,6 +29,13 @@ pub mod state_value;
 pub mod table;
 
 pub const NUM_STATE_SHARDS: usize = 16;
+
+/// Identifies which snapshot store an operation targets.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum StateKind {
+    MainState,
+    Position,
+}
 
 pub type StateViewResult<T, E = StateViewError> = std::result::Result<T, E>;
 


### PR DESCRIPTION
End-to-end native-position fast sync. Rather than a parallel position-specific
code path, native-position is threaded through the existing state-sync stack as a
second snapshot **kind** (`StateKind::{MainState, Position}`): the position path
*is* the main-state path with `kind = Position`.

### `StateKind` everywhere
`StateKind` moved to `aptos-types::state_store` (made serializable) and is
re-exported from `aptos-storage-interface`, so one enum carries the snapshot kind
from storage through the wire protocol to the bootstrapper.

### Storage layer
- Reuses the generic `StateSnapshotRestore<StateKey, StateValue>` via a
  `PositionStateValueWriter` (hash-keyed): sequential range-proof verify, crash
  resumption (`StateSnapshotProgress`), commit watermark, the
  `StateSnapshotReceiver` trait. The JMT walk + chunk-proof assembly is shared
  with main state (`state_value_chunk.rs`).
- The `DbReader`/`DbWriter` snapshot methods take a `StateKind`
  (`get_state_item_count`, `get_state_value_chunk_with_proof`,
  `get_state_snapshot_receiver`) and serve both stores — forwarded by
  `FastSyncStorageWrapper`/`FakeAptosDB`. Backup verify against the composite
  state root is retained.

### Wire protocol (V2 + kind)
- `DataRequest::{GetStateValuesWithProofV2, GetNumberOfStatesAtVersionV2}` and
  `DataResponse::{StateValueChunkWithProofV2, NumberOfStatesAtVersionV2}` each
  carry a `StateKind`, so one variant serves both main state and native-position
  (and any future kind). Appended at the end for BCS wire stability; advertising
  is gated on the same advertised range as main state.
- data-client and data-streaming thread the kind through internally too: one
  `get_all_state_values(.., kind)`, one `StateStreamEngine`, and a single set of
  `DataClientRequest`/`DataPayload`/`ResponsePayload` variants — no
  position-specific duplicates.

### StorageSynchronizer
- One `initialize_snapshot_synchronizer(target, expected_root, kind)` and one
  `spawn_snapshot_receiver(kind, ..)` write either snapshot off-thread. The
  whole-fast-sync finalize (accumulator bootstrap + commit notification + gauges)
  is `finalize_fast_sync`, run once after every snapshot is written.

### Bootstrapper
- `drive_snapshot_stages` fetches the target transaction output once, then streams
  each not-yet-written snapshot kind (`FAST_SYNC_SNAPSHOT_KINDS`); once all are
  written it runs `finalize_fast_sync`. The kinds are peers writing independent
  stores at the same target version — driven one stream at a time today, with no
  ordering dependency. Each chunk's root is checked against the target
  `TransactionInfo` (its committed position state root for position; its state
  checkpoint hash for main); progress is persisted per kind for crash resumption.
  An empty position tree (count 0) completes immediately. Runs on all node types,
  off the driver thread.

### Position state root (the executor signal)
- `TransactionInfo::position_state_root()` reads the reserved `TransactionInfoV1`
  slot. The native-position stage only runs when the target commits this root:
  until the executor populates it (a separate, out-of-scope change), there is no
  authenticated position state, so `drive_snapshot_stages` **skips** the position
  kind and fast sync finalizes on main state alone. Once the slot is set, the
  stage runs and each position chunk root must equal the committed root (strict
  equality — there is no path that accepts an unproved peer-supplied root). The
  restore/restart paths for the active stage are therefore exercised only once the
  executor sets the slot.

### Testing
All touched crates build; the storage-service, aptos-data-client,
data-streaming-service, and state-sync-driver test suites pass, and workspace
`cargo check --all-targets` is clean.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches state-sync bootstrap, snapshot persistence, and authenticated root verification across main and position stores—errors could wedge fast sync or accept wrong snapshot data.
> 
> **Overview**
> Adds **native-position** as a second fast-sync snapshot alongside main state by threading **`StateKind`** (`MainState` / `Position`) through storage reads, the data client, streaming payloads, and the bootstrapper—instead of a parallel position-only code path.
> 
> **Data path:** `get_number_of_states` and `get_state_values_with_proof` now take a `kind`; main state keeps V1 storage requests, while **Position** uses **V2** wire requests/responses that carry `state_kind`. Streaming notifications become `StateValuesWithProof(kind, chunk)`, and state streams record `state_kind` on fetch/count requests.
> 
> **Fast sync driver:** Genesis fast sync is orchestrated by **`drive_snapshot_stages`**, which fetches the target transaction output once, then streams each applicable snapshot kind (`MainState` then `Position` when the target `TransactionInfo` commits a position root). Per-kind progress lives in metadata (`PositionSnapshotSync` vs main). Chunk roots are checked against the target tx info (state checkpoint vs position root); empty position trees can complete without chunks. **Finalize** (accumulator bootstrap, commit notification, gauges) runs once via **`finalize_fast_sync`** after all snapshots are written—not when main state alone finishes.
> 
> **Storage synchronizer:** Replaces monolithic state init/finalize with **`initialize_snapshot_synchronizer(..., kind)`** + **`finalize_fast_sync`**, with separate metrics for position chunks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5de60a03ed8073af047f730fa8a8d0f4d57eea0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->