### PR TITLE
[types] Enable HOTNESS_IN_EPILOGUE by default at genesis

### DIFF
--- a/execution/executor/src/db_bootstrapper/mod.rs
+++ b/execution/executor/src/db_bootstrapper/mod.rs
@@ -23,7 +23,7 @@ use aptos_types::{
     },
     block_info::{BlockInfo, GENESIS_EPOCH, GENESIS_ROUND, GENESIS_TIMESTAMP_USECS},
     ledger_info::{LedgerInfo, LedgerInfoWithSignatures},
-    on_chain_config::ConfigurationResource,
+    on_chain_config::{ConfigurationResource, Features, OnChainConfig},
     state_store::{state_key::StateKey, StateViewId, TStateView},
     timestamp::TimestampResource,
     transaction::{AuxiliaryInfo, AuxiliaryInfoTrait, Transaction},
@@ -126,6 +126,7 @@ pub fn calculate_genesis<V: VMBlockExecutor>(
         Arc::clone(&db.reader),
         ledger_summary.state.latest().clone(),
     )?;
+    let onchain_config = genesis_onchain_config(&base_state_view);
 
     let epoch = if genesis_version == 0 {
         GENESIS_EPOCH
@@ -141,7 +142,7 @@ pub fn calculate_genesis<V: VMBlockExecutor>(
         vec![AuxiliaryInfo::new_empty()],
         &ledger_summary.state,
         base_state_view,
-        BlockExecutorConfigFromOnchain::new_no_block_limit(),
+        onchain_config,
         TransactionSliceMetadata::unknown(),
     )?;
     ensure!(
@@ -202,6 +203,22 @@ pub fn calculate_genesis<V: VMBlockExecutor>(
         &committer.output.ledger_info_opt, committer.waypoint,
     );
     Ok(committer)
+}
+
+fn genesis_onchain_config(state_view: &CachedStateView) -> BlockExecutorConfigFromOnchain {
+    let base = BlockExecutorConfigFromOnchain::new_no_block_limit();
+    // Bootstrapping from an empty DB is the common case, so the parent state usually has no
+    // `Features` resource. Hard-fork genesis is the case where parent-state features exist.
+    match Features::fetch_config(state_view) {
+        Some(features) => base.with_features(&features),
+        None => {
+            info!(
+                next_version = state_view.next_version(),
+                "No `Features` resource in parent state; genesis executes with no on-chain features applied."
+            );
+            base
+        },
+    }
 }
 
 fn get_state_timestamp(state_view: &CachedStateView) -> Result<u64> {

--- a/execution/executor/tests/db_bootstrapper_test.rs
+++ b/execution/executor/tests/db_bootstrapper_test.rs
@@ -4,7 +4,7 @@
 #![forbid(unsafe_code)]
 
 use aptos_cached_packages::aptos_stdlib;
-use aptos_crypto::{ed25519::Ed25519PrivateKey, HashValue, PrivateKey, Uniform};
+use aptos_crypto::{ed25519::Ed25519PrivateKey, hash::CryptoHash, HashValue, PrivateKey, Uniform};
 use aptos_db::AptosDB;
 use aptos_executor::{
     block_executor::BlockExecutor,
@@ -25,14 +25,14 @@ use aptos_types::{
         NewBlockEvent, ObjectGroupResource, NEW_EPOCH_EVENT_V2_MOVE_TYPE_TAG,
     },
     contract_event::ContractEvent,
-    on_chain_config::{ConfigurationResource, OnChainConfig, ValidatorSet},
+    on_chain_config::{ConfigurationResource, FeatureFlag, Features, OnChainConfig, ValidatorSet},
     state_store::{state_key::StateKey, MoveResourceExt},
     test_helpers::transaction_test_helpers::{block, TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG},
     transaction::{authenticator::AuthenticationKey, ChangeSet, Transaction, WriteSetPayload},
     trusted_state::TrustedState,
     validator_signer::ValidatorSigner,
     waypoint::Waypoint,
-    write_set::{WriteOp, WriteSetMut},
+    write_set::{WriteOp, WriteSet, WriteSetMut},
 };
 use aptos_vm::aptos_vm::AptosVMBlockExecutor;
 use move_core_types::{language_storage::TypeTag, move_resource::MoveStructType};
@@ -186,6 +186,34 @@ fn get_configuration(db: &DbReaderWriter) -> ConfigurationResource {
     ConfigurationResource::fetch_config(&db_state_view).unwrap()
 }
 
+fn get_features(db: &DbReaderWriter) -> Features {
+    let db_state_view = db.reader.latest_state_checkpoint_view().unwrap();
+    Features::fetch_config(&db_state_view).unwrap()
+}
+
+fn assert_committed_write_set_version(db: &DbReaderWriter, version: u64, expected_v1: bool) {
+    let ledger_version = db.reader.expect_synced_version();
+    let outputs = db
+        .reader
+        .get_transaction_outputs(version, 1, ledger_version)
+        .unwrap();
+    let output_list = outputs.get_output_list_with_proof();
+
+    assert_eq!(output_list.first_transaction_output_version, Some(version));
+    assert_eq!(output_list.transactions_and_outputs.len(), 1);
+    assert_eq!(output_list.proof.transaction_infos.len(), 1);
+
+    let write_set = output_list.transactions_and_outputs[0].1.write_set();
+    let txn_info = &output_list.proof.transaction_infos[0];
+    assert_eq!(CryptoHash::hash(write_set), txn_info.state_change_hash());
+
+    match (expected_v1, write_set) {
+        (false, WriteSet::V0(_)) | (true, WriteSet::V1(_)) => {},
+        (false, WriteSet::V1(_)) => panic!("expected WriteSetV0 at version {}", version),
+        (true, WriteSet::V0(_)) => panic!("expected WriteSetV1 at version {}", version),
+    }
+}
+
 #[test]
 #[cfg_attr(feature = "consensus-only-perf-test", ignore)]
 fn test_new_genesis() {
@@ -196,6 +224,8 @@ fn test_new_genesis() {
     let tmp_dir = TempPath::new();
     let db = DbReaderWriter::new(AptosDB::new_for_test(&tmp_dir));
     let waypoint = bootstrap_genesis::<AptosVMBlockExecutor>(&db, &genesis_txn).unwrap();
+    assert_committed_write_set_version(&db, 0, false);
+    assert!(get_features(&db).is_enabled(FeatureFlag::HOTNESS_IN_EPILOGUE));
     let signer = ValidatorSigner::new(
         genesis.1[0].data.owner_address,
         Arc::new(genesis.1[0].consensus_key.clone()),
@@ -284,6 +314,7 @@ fn test_new_genesis() {
             .is_some()
     );
     assert_eq!(waypoint.version(), 6);
+    assert_committed_write_set_version(&db, waypoint.version(), true);
 
     // Client bootable from waypoint.
     let trusted_state = TrustedState::from_epoch_waypoint(waypoint);

--- a/types/src/on_chain_config/aptos_features.rs
+++ b/types/src/on_chain_config/aptos_features.rs
@@ -304,6 +304,7 @@ impl FeatureFlag {
             Self::VERSIONED_TRANSACTION_VALIDATION,
             Self::STORAGE_SLOT_NATIVES,
             Self::ALLOW_FRIEND_ENTRY_VISIBILITY_DOWNGRADE,
+            Self::HOTNESS_IN_EPILOGUE,
         ]
     }
 }


### PR DESCRIPTION

The `indexer-grpc-v2-devnet` fullnode hit a `hot_state root hash
mismatch`.

## Root cause

The fullnode state-syncs by applying transaction outputs (write sets).
With `HOTNESS_IN_EPILOGUE` off, those write sets carried no hot-state
promotions, so the fullnode built hot state that diverged from
upstream, producing silent mismatches until `TRANSACTION_INFO_V1` was
turned on.

Enabling `HOTNESS_IN_EPILOGUE` from genesis makes every transaction
output carry hot-state promotions starting at block 1, so fullnodes
that sync by applying outputs stay consistent with upstream. Since
`default_features()` feeds all new genesis, this also turns the flag
on for local/test/forge networks, not just devnet.

## Why earlier local testing missed it

The divergence only shows up through the output-application state-sync
path. Earlier local runs spawned all validators and VFNs at the same
time, so the VFNs stayed caught up and never bulk-applied outputs over
the window where the missing promotions mattered. I tried to
deliberately delayed the start of VFNs and only spawn them 5 minutes
after validators started, then the issue surfaced.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default on-chain features and genesis/hard-fork execution config, affecting VM output format and hot-state consistency for nodes that state-sync from outputs.
> 
> **Overview**
> Turns on **`HOTNESS_IN_EPILOGUE`** in `FeatureFlag::default_features()` so fresh genesis chains (local, test, forge, devnet) execute with hot-state promotions in transaction outputs from block 1.
> 
> Genesis execution no longer always uses a bare `BlockExecutorConfigFromOnchain::new_no_block_limit()`. **`genesis_onchain_config`** loads parent-state **`Features`** when present (hard-fork / re-genesis) and passes them into the block executor; empty parent state keeps the previous no-features path with a log line.
> 
> **`db_bootstrapper_test`** now asserts genesis commits **`HOTNESS_IN_EPILOGUE`**, **`WriteSet` V0** on first genesis and **V1** after re-bootstrap at the new waypoint—matching output-sync behavior when the flag is on.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 998e3836710f432f1f5e9b66ad18a7ec92980e35. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->