### PR TITLE
[mono-move] Add signer support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12886,6 +12886,9 @@ name = "mono-move-testsuite"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "aptos-gas-schedule",
+ "aptos-types",
+ "aptos-vm",
  "bytes",
  "codespan-reporting",
  "datatest-stable",

--- a/third_party/move/mono-move/core/src/instruction/mod.rs
+++ b/third_party/move/mono-move/core/src/instruction/mod.rs
@@ -977,12 +977,10 @@ pub enum MicroOp {
     },
 
     /// Move the owned value in the source slot `src` into global storage as a
-    /// resource of type `ty` at the address in `addr`. `src` holds an 8-byte
-    /// owned heap pointer. Aborts if the resource already exists.
+    /// resource of type `ty`, published under the address of the signer referenced
+    /// by the `signer_ref`.
     MoveTo {
-        // TODO(correctness):
-        //   Move requires this to be a signer, using address for simplicity for now.
-        addr: FrameOffset,
+        signer_ref: FrameOffset,
         ty: InternedType,
         src: FrameOffset,
     },
@@ -1528,10 +1526,14 @@ impl fmt::Display for MicroOp {
                 display_type(f, *ty)?;
                 write!(f, "> [{}] <- addr=[{}], ty=", dst.0, addr.0)
             },
-            MicroOp::MoveTo { addr, ty, src } => {
+            MicroOp::MoveTo {
+                signer_ref,
+                ty,
+                src,
+            } => {
                 write!(f, "MoveTo<")?;
                 display_type(f, *ty)?;
-                write!(f, "> addr=[{}], src=[{}]", addr.0, src.0)
+                write!(f, "> signer=[{}], src=[{}]", signer_ref.0, src.0)
             },
         }
     }

--- a/third_party/move/mono-move/natives/src/lib.rs
+++ b/third_party/move/mono-move/natives/src/lib.rs
@@ -8,12 +8,22 @@
 
 // Re-exported so the `natives!` macro can name it via `$crate::NativeFunction`
 // without callers having to add `mono-move-core` to their imports.
+use mono_move_core::native::NativeContextFamily;
 pub use mono_move_core::native::NativeFunction;
 use move_core_types::{account_address::AccountAddress, identifier::Identifier};
 
+pub mod signer;
 pub mod test_natives;
 
+pub use signer::make_all_signer_natives;
 pub use test_natives::{make_all_test_natives, native_u64_add, native_u64_identity};
+
+/// All natives shipped with the production MonoMove VM. Additional native
+/// modules are concatenated here as they are implemented.
+pub fn make_all_production_natives<F: NativeContextFamily>(
+) -> Vec<(AccountAddress, Identifier, Identifier, NativeFunction<F>)> {
+    make_all_signer_natives::<F>()
+}
 
 /// Parses a fully-qualified function name (e.g. "0x1::natives::u64_add")
 /// into its component parts. Panics on malformed input.

--- a/third_party/move/mono-move/natives/src/signer.rs
+++ b/third_party/move/mono-move/natives/src/signer.rs
@@ -1,0 +1,55 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Natives for the `signer` type.
+//!
+//! MonoMove currently represents a `signer` as a bare 32-byte account address — the
+//! same layout as `address`. Permissioned signers are not supported, for now.
+
+use crate::{natives, NativeFunction};
+use mono_move_core::native::{NativeContext, NativeContextFamily, NativeStatus, VMInternalError};
+use move_core_types::{account_address::AccountAddress, identifier::Identifier};
+
+/// `0x1::create_signer::create_signer(addr: address): signer`
+///
+/// No-op. A `signer` has the same 32-byte layout as its `address`, so no conversion
+/// needs to be done.
+pub fn native_create_signer<C: NativeContext>(
+    _ctx: &mut C,
+) -> Result<NativeStatus, VMInternalError> {
+    Ok(NativeStatus::Success)
+}
+
+/// `0x1::signer::borrow_address(self: &signer): &address`
+///
+/// No-op. A `signer` has the same 32-byte layout as its `address`, so no change to
+/// the reference as well.
+pub fn native_borrow_address<C: NativeContext>(
+    _ctx: &mut C,
+) -> Result<NativeStatus, VMInternalError> {
+    Ok(NativeStatus::Success)
+}
+
+/// `0x1::permissioned_signer::is_permissioned_signer_impl(s: &signer): bool`
+///
+/// Always returns `false` as we do not support permissioned signers for now.
+pub fn native_is_permissioned_signer<C: NativeContext>(
+    ctx: &mut C,
+) -> Result<NativeStatus, VMInternalError> {
+    // SAFETY: `bool` matches the Move-level `bool` return at slot 0.
+    unsafe { ctx.set_return(0, false) }?;
+    Ok(NativeStatus::Success)
+}
+
+/// Builds a list of all signer-related natives.
+pub fn make_all_signer_natives<F: NativeContextFamily>(
+) -> Vec<(AccountAddress, Identifier, Identifier, NativeFunction<F>)> {
+    natives![
+        ("0x1::signer::borrow_address", native_borrow_address),
+        ("0x1::create_signer::create_signer", native_create_signer),
+        (
+            "0x1::permissioned_signer::is_permissioned_signer_impl",
+            native_is_permissioned_signer
+        ),
+    ]
+}

--- a/third_party/move/mono-move/runtime/src/interpreter.rs
+++ b/third_party/move/mono-move/runtime/src/interpreter.rs
@@ -17,8 +17,8 @@ use crate::{
     },
     invariant_violation,
     memory::{
-        read_bool, read_fat_ptr, read_obj_size, read_ptr, read_u64, read_u8, vec_elem_ptr,
-        write_bool, write_fat_ptr, write_ptr, write_u64, write_u8, MemoryRegion,
+        read_account_address, read_bool, read_fat_ptr, read_obj_size, read_ptr, read_u64, read_u8,
+        vec_elem_ptr, write_bool, write_fat_ptr, write_ptr, write_u64, write_u8, MemoryRegion,
     },
     types::{
         StepResult, ABORT_MESSAGE_SIZE_LIMIT, DEFAULT_HEAP_SIZE, DEFAULT_STACK_SIZE,
@@ -38,10 +38,7 @@ use mono_move_core::{
     FUNC_REF_TAG_OFFSET, FUNC_REF_TAG_RESOLVED, MAX_ALIGN, OBJECT_HEADER_SIZE,
 };
 use mono_move_gas::GasMeter;
-use move_core_types::{
-    account_address::AccountAddress,
-    int256::{I256, U256},
-};
+use move_core_types::int256::{I256, U256};
 use rand::{rngs::StdRng, Rng, SeedableRng};
 use std::ptr::{null, NonNull};
 
@@ -395,18 +392,6 @@ unsafe fn write_int<T: Copy>(base: *mut u8, byte_offset: impl Into<usize>, val: 
             ptr.write_unaligned(val)
         }
     }
-}
-
-/// Read a 32-byte [`AccountAddress`] from a frame slot.
-///
-/// # Safety
-///
-/// `[fp + offset, fp + offset + 32]` must lie within the current
-/// frame's accessible region.
-#[inline(always)]
-unsafe fn read_address(fp: *const u8, offset: FrameOffset) -> AccountAddress {
-    let ptr = unsafe { fp.add(offset.into()) as *const AccountAddress };
-    unsafe { ptr.read() }
 }
 
 /// [`U256`]'s `Shl`/`Shr` trait impls require `Self` as the rhs.
@@ -1452,7 +1437,7 @@ impl<T: ExecutionContext + DescriptorProvider> InterpreterContext<'_, T> {
                 MicroOp::IntCast(ref op) => exec_int_cast(fp, op)?,
 
                 MicroOp::Exists { addr, ty, dst } => {
-                    let address = read_address(fp, addr);
+                    let address = read_account_address(fp, addr);
                     let exists = self.read_write_set.exists(
                         self.exec_ctx.resource_provider(),
                         StorageKey::Resource(address, ty),
@@ -1461,7 +1446,7 @@ impl<T: ExecutionContext + DescriptorProvider> InterpreterContext<'_, T> {
                 },
 
                 MicroOp::BorrowGlobal { addr, ty, dst } => {
-                    let address = read_address(fp, addr);
+                    let address = read_account_address(fp, addr);
                     let ptr = self.read_write_set.borrow_global(
                         self.exec_ctx.resource_provider(),
                         StorageKey::Resource(address, ty),
@@ -1472,7 +1457,7 @@ impl<T: ExecutionContext + DescriptorProvider> InterpreterContext<'_, T> {
                 },
 
                 MicroOp::BorrowGlobalMut { addr, ty, dst } => {
-                    let address = read_address(fp, addr);
+                    let address = read_account_address(fp, addr);
                     let key = StorageKey::Resource(address, ty);
                     let ptr = match self
                         .read_write_set
@@ -1491,7 +1476,7 @@ impl<T: ExecutionContext + DescriptorProvider> InterpreterContext<'_, T> {
                 },
 
                 MicroOp::MoveFrom { addr, ty, dst } => {
-                    let address = read_address(fp, addr);
+                    let address = read_account_address(fp, addr);
                     let key = StorageKey::Resource(address, ty);
                     let entry_ptr = self
                         .read_write_set
@@ -1507,8 +1492,14 @@ impl<T: ExecutionContext + DescriptorProvider> InterpreterContext<'_, T> {
                     write_ptr(fp, dst, ptr.as_ptr());
                 },
 
-                MicroOp::MoveTo { addr, ty, src } => {
-                    let address = read_address(fp, addr);
+                MicroOp::MoveTo {
+                    signer_ref,
+                    ty,
+                    src,
+                } => {
+                    // Dereference the `&signer` to obtain the 32-byte publishing address
+                    let (base, offset) = read_fat_ptr(fp, signer_ref);
+                    let address = read_account_address(base, offset as usize);
                     let Some(ptr) = NonNull::new(read_ptr(fp, src)) else {
                         invariant_violation!(MoveToNullSource);
                     };

--- a/third_party/move/mono-move/runtime/src/memory.rs
+++ b/third_party/move/mono-move/runtime/src/memory.rs
@@ -5,6 +5,7 @@
 
 use crate::VEC_DATA_OFFSET;
 use mono_move_core::{DescriptorId, MAX_ALIGN};
+use move_core_types::account_address::AccountAddress;
 use std::alloc::{self, Layout};
 
 // ---------------------------------------------------------------------------
@@ -187,6 +188,31 @@ pub unsafe fn read_u32(base: *const u8, byte_offset: impl Into<usize>) -> u32 {
 pub unsafe fn write_u32(base: *mut u8, byte_offset: impl Into<usize>, val: u32) {
     // SAFETY: caller must uphold the documented pointer requirements.
     unsafe { (base.add(byte_offset.into()) as *mut u32).write(val) }
+}
+
+/// Read a 32-byte [`AccountAddress`] starting at `byte_offset`. Reads aligned
+/// when its alignment is within [`MAX_ALIGN`], otherwise unaligned.
+///
+/// This check shall have no impact on performance as it is easily optimized
+/// away by the compiler.
+///
+/// # Safety
+/// `base.add(byte_offset)` must be valid and point to an initialized
+/// [`AccountAddress`].
+#[inline(always)]
+pub unsafe fn read_account_address(
+    base: *const u8,
+    byte_offset: impl Into<usize>,
+) -> AccountAddress {
+    let ptr = unsafe { base.add(byte_offset.into()) as *const AccountAddress };
+    // SAFETY: caller must uphold the documented pointer requirements.
+    unsafe {
+        if std::mem::align_of::<AccountAddress>() <= MAX_ALIGN {
+            ptr.read()
+        } else {
+            ptr.read_unaligned()
+        }
+    }
 }
 
 /// Pointer to the `idx`-th element inside a vector's data region.

--- a/third_party/move/mono-move/runtime/src/verifier.rs
+++ b/third_party/move/mono-move/runtime/src/verifier.rs
@@ -699,10 +699,14 @@ impl<P: DescriptorProvider + ?Sized> FunctionVerifier<'_, P> {
                 self.check_frame_access(Some(pc), addr, 32);
                 self.check_frame_access(Some(pc), dst, 16);
             },
-            MicroOp::MoveTo { addr, ty: _, src } => {
-                // TODO(correctness):
-                //   Move use signer reference, so we need 16 bytes if we no longer use address.
-                self.check_frame_access(Some(pc), addr, 32);
+            MicroOp::MoveTo {
+                signer_ref,
+                ty: _,
+                src,
+            } => {
+                // `signer_ref` is a 16-byte `&signer` fat pointer; `src` is an
+                // 8-byte owned heap pointer to the resource value.
+                self.check_frame_access(Some(pc), signer_ref, 16);
                 self.check_frame_access_8(pc, src);
             },
         }

--- a/third_party/move/mono-move/runtime/tests/global_storage_checkpoint.rs
+++ b/third_party/move/mono-move/runtime/tests/global_storage_checkpoint.rs
@@ -59,6 +59,7 @@ fn local_ctx_with<'r>(
 const DST: FO = FO(0);
 const ADDR: FO = FO(8);
 const TMP: FO = FO(40);
+const SIGNER_REF: FO = FO(56);
 
 fn make_program(code: Vec<MicroOp>, frame_layout: FrameLayoutInfo) -> Function {
     Function {
@@ -66,8 +67,8 @@ fn make_program(code: Vec<MicroOp>, frame_layout: FrameLayoutInfo) -> Function {
         code: Code::from_vec(code),
         param_slots: vec![],
         param_region_size: 0,
-        param_and_local_sizes_sum: 56,
-        extended_frame_size: 80,
+        param_and_local_sizes_sum: 72,
+        extended_frame_size: 96,
         zero_frame: true,
         frame_layout,
         safe_point_layouts: SortedSafePointEntries::empty(),
@@ -216,8 +217,12 @@ fn rollback_of_move_from_then_move_to_restores_to_deleted() {
                 dst: TMP,
                 descriptor_id: desc_id,
             },
+            MicroOp::SlotBorrow {
+                dst: SIGNER_REF,
+                local: ADDR,
+            },
             MicroOp::MoveTo {
-                addr: ADDR,
+                signer_ref: SIGNER_REF,
                 ty: resource_ty(),
                 src: TMP,
             },

--- a/third_party/move/mono-move/runtime/tests/global_storage_mut.rs
+++ b/third_party/move/mono-move/runtime/tests/global_storage_mut.rs
@@ -80,6 +80,7 @@ fn make_program_with_tmp(code: Vec<MicroOp>, frame_layout: FrameLayoutInfo) -> F
 const DST: FO = FO(0);
 const ADDR: FO = FO(8);
 const TMP: FO = FO(40);
+const SIGNER_REF: FO = FO(48);
 
 // ---------------------------------------------------------------------------
 // BorrowGlobalMut
@@ -179,8 +180,12 @@ fn move_to_publishes_resource_and_exists_is_true() {
                 dst: TMP,
                 descriptor_id: desc_id,
             },
+            MicroOp::SlotBorrow {
+                dst: SIGNER_REF,
+                local: ADDR,
+            },
             MicroOp::MoveTo {
-                addr: ADDR,
+                signer_ref: SIGNER_REF,
                 ty: resource_ty(),
                 src: TMP,
             },
@@ -193,8 +198,8 @@ fn move_to_publishes_resource_and_exists_is_true() {
         ]),
         param_slots: vec![],
         param_region_size: 0,
-        param_and_local_sizes_sum: 48,
-        extended_frame_size: 72,
+        param_and_local_sizes_sum: 64,
+        extended_frame_size: 88,
         zero_frame: true,
         frame_layout: FrameLayoutInfo::new(vec![TMP]),
         safe_point_layouts: SortedSafePointEntries::empty(),
@@ -221,8 +226,12 @@ fn move_to_aborts_when_already_present() {
                 dst: TMP,
                 descriptor_id: desc_id,
             },
+            MicroOp::SlotBorrow {
+                dst: SIGNER_REF,
+                local: ADDR,
+            },
             MicroOp::MoveTo {
-                addr: ADDR,
+                signer_ref: SIGNER_REF,
                 ty: resource_ty(),
                 src: TMP,
             },
@@ -230,8 +239,8 @@ fn move_to_aborts_when_already_present() {
         ]),
         param_slots: vec![],
         param_region_size: 0,
-        param_and_local_sizes_sum: 48,
-        extended_frame_size: 72,
+        param_and_local_sizes_sum: 64,
+        extended_frame_size: 88,
         zero_frame: true,
         frame_layout: FrameLayoutInfo::new(vec![TMP]),
         safe_point_layouts: SortedSafePointEntries::empty(),

--- a/third_party/move/mono-move/testsuite/Cargo.toml
+++ b/third_party/move/mono-move/testsuite/Cargo.toml
@@ -14,6 +14,9 @@ rust-version = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }
+aptos-gas-schedule = { workspace = true }
+aptos-types = { workspace = true }
+aptos-vm = { workspace = true }
 bytes = { workspace = true }
 codespan-reporting = { workspace = true }
 legacy-move-compiler = { workspace = true }

--- a/third_party/move/mono-move/testsuite/src/compile.rs
+++ b/third_party/move/mono-move/testsuite/src/compile.rs
@@ -43,15 +43,30 @@ pub fn compile(source: &str, kind: SourceKind) -> Result<Vec<CompiledModule>> {
 ///
 /// The full Move stdlib is injected as dependencies.
 pub fn compile_move_path(path: &Path) -> Result<Vec<CompiledModule>> {
-    let options = Options {
+    run_compiler(Options {
         sources: vec![path.to_string_lossy().into_owned()],
         dependencies: move_stdlib::move_stdlib_files(),
         named_address_mapping: move_stdlib::move_stdlib_named_addresses_strings(),
         known_attributes: KnownAttribute::get_all_attribute_names().clone(),
         language_version: Some(LanguageVersion::latest_stable()),
         ..Options::default()
-    };
+    })
+}
 
+/// Compile the Move stdlib into its modules, so they can be published into a
+/// test's storage.
+pub fn compile_move_stdlib() -> Result<Vec<CompiledModule>> {
+    run_compiler(Options {
+        sources: move_stdlib::move_stdlib_files(),
+        named_address_mapping: move_stdlib::move_stdlib_named_addresses_strings(),
+        known_attributes: KnownAttribute::get_all_attribute_names().clone(),
+        language_version: Some(LanguageVersion::latest_stable()),
+        ..Options::default()
+    })
+}
+
+/// Run the v2 compiler and collect the produced modules (scripts dropped).
+fn run_compiler(options: Options) -> Result<Vec<CompiledModule>> {
     let mut errors = Buffer::no_color();
     let result = {
         let mut emitter = options.error_emitter(&mut errors);

--- a/third_party/move/mono-move/testsuite/src/runner.rs
+++ b/third_party/move/mono-move/testsuite/src/runner.rs
@@ -5,13 +5,16 @@
 //! normalized output for comparison.
 
 use crate::{
-    compile::{compile, SourceKind},
+    compile::{compile, compile_move_stdlib, SourceKind},
     matcher::check_output,
     module_provider::InMemoryModuleProvider,
     parser::{PrintSection, Step},
     print_sections,
 };
 use anyhow::{anyhow, bail};
+use aptos_gas_schedule::{MiscGasParameters, NativeGasParameters, LATEST_GAS_FEATURE_VERSION};
+use aptos_types::on_chain_config::{Features, TimedFeaturesBuilder};
+use aptos_vm::natives::aptos_natives;
 use mono_move_core::{
     native::{NativeName, ProductionContextFamily, ProductionNativeRegistry},
     types::EMPTY_TYPE_LIST,
@@ -20,8 +23,9 @@ use mono_move_core::{
 use mono_move_gas::SimpleGasMeter;
 use mono_move_global_context::{ExecutionGuard, GlobalContext};
 use mono_move_loader::{Loader, LoadingPolicy, LoweringPolicy};
-use mono_move_natives::make_all_test_natives;
+use mono_move_natives::{make_all_production_natives, make_all_test_natives};
 use mono_move_runtime::{ExecutionContext, InterpreterContext, RuntimeStatus, TransactionContext};
+use move_binary_format::CompiledModule;
 use move_core_types::{
     account_address::AccountAddress,
     identifier::IdentStr,
@@ -35,12 +39,13 @@ use move_vm_runtime::{
     module_traversal::{TraversalContext, TraversalStorage},
     move_vm::MoveVM,
     native_extensions::NativeContextExtensions,
+    native_functions::NativeFunctionTable,
     AsUnsyncModuleStorage, InstantiatedFunctionLoader, LazyLoader, LegacyLoaderConfig,
     RuntimeEnvironment,
 };
 use move_vm_test_utils::InMemoryStorage;
 use move_vm_types::{gas::UnmeteredGasMeter, loaded_data::runtime_types::Type};
-use std::path::Path;
+use std::{path::Path, sync::OnceLock};
 
 /// Execution output from a VM as a normalized display string.
 struct Output {
@@ -55,10 +60,21 @@ pub fn run_test(steps: Vec<Step>, kind: SourceKind, test_path: &Path) -> anyhow:
     let ctx = GlobalContext::with_num_execution_workers(1);
     let guard = ctx.try_execution_context(0).unwrap();
 
-    let runtime_env = RuntimeEnvironment::new(crate::v1_test_natives::make_all_v1_test_natives());
+    let runtime_env = RuntimeEnvironment::new(v1_native_table());
     let mut storage = InMemoryStorage::new_with_runtime_environment(runtime_env);
     let mut module_provider = InMemoryModuleProvider::new();
     let mut snapshot = String::new();
+
+    // Publish the Move stdlib into both VMs so tests can call real stdlib
+    // natives.
+    for module in stdlib_modules() {
+        let mut blob = vec![];
+        module
+            .serialize(&mut blob)
+            .expect("stdlib module serializes");
+        storage.add_module_bytes(module.self_addr(), module.self_name(), blob.into());
+        module_provider.add_module(module);
+    }
 
     for step in steps {
         match step {
@@ -120,6 +136,26 @@ pub fn run_test(steps: Vec<Step>, kind: SourceKind, test_path: &Path) -> anyhow:
     }
 
     Ok(())
+}
+
+/// Native table for the legacy VM. This includes both the real Aptos production
+/// natives and some toy ones for tests.
+fn v1_native_table() -> NativeFunctionTable {
+    let mut table = aptos_natives(
+        LATEST_GAS_FEATURE_VERSION,
+        NativeGasParameters::zeros(),
+        MiscGasParameters::zeros(),
+        TimedFeaturesBuilder::enable_all().build(),
+        Features::default(),
+    );
+    table.extend(crate::v1_test_natives::make_all_v1_test_natives());
+    table
+}
+
+/// The compiled Move stdlib, compiled once and shared across tests.
+fn stdlib_modules() -> &'static [CompiledModule] {
+    static STDLIB: OnceLock<Vec<CompiledModule>> = OnceLock::new();
+    STDLIB.get_or_init(|| compile_move_stdlib().expect("Move stdlib compiles"))
 }
 
 /// Output of V1 execution, plus the parameter and return types so V2 can
@@ -240,6 +276,9 @@ fn execute_function_v2(
         .register_all(
             make_all_test_natives::<ProductionContextFamily<SimpleGasMeter>>()
                 .into_iter()
+                .chain(make_all_production_natives::<
+                    ProductionContextFamily<SimpleGasMeter>,
+                >())
                 .map(|(addr, module, function, func)| {
                     let name = NativeName {
                         module: guard.module_id_of(&addr, &module),
@@ -248,7 +287,7 @@ fn execute_function_v2(
                     (name, func)
                 }),
         )
-        .expect("test natives have unique qualified names");
+        .expect("natives have unique qualified names");
     let loader = Loader::new_with_policy(
         guard,
         module_provider,

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/natives/signer.move
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/natives/signer.move
@@ -1,0 +1,38 @@
+// Differential test for the signer natives.
+
+// `create_signer` is declared here for two reasons:
+// 1. To avoid pulling in the Aptos Framework, which is a bit more heavy weight for now
+// 2. The version defined in the Aptos Framework is public(friend) so we can't use it anyway
+
+// RUN: publish
+module 0x1::create_signer {
+    public native fun create_signer(addr: address): signer;
+}
+module 0x1::permissioned_signer {
+    public native fun is_permissioned_signer_impl(s: &signer): bool;
+}
+module 0x1::main {
+    public fun roundtrip(addr: address): address {
+        let s = 0x1::create_signer::create_signer(addr);
+        *std::signer::borrow_address(&s)
+    }
+
+    // A signer made by `create_signer` is a master (non-permissioned) signer,
+    // so this is always false.
+    public fun is_permissioned(addr: address): bool {
+        let s = 0x1::create_signer::create_signer(addr);
+        0x1::permissioned_signer::is_permissioned_signer_impl(&s)
+    }
+}
+
+// RUN: execute 0x1::main::roundtrip --args 0xcafe
+// CHECK: results: 0xcafe
+
+// RUN: execute 0x1::main::roundtrip --args 0x0
+// CHECK: results: 0x0
+
+// RUN: execute 0x1::main::roundtrip --args 0x123456789abcdef
+// CHECK: results: 0x123456789abcdef
+
+// RUN: execute 0x1::main::is_permissioned --args 0xcafe
+// CHECK: results: false


### PR DESCRIPTION
## Summary

Adds the `signer`-type natives to the MonoMove VM, changes `MoveTo` to consume a `&signer`, and wires the differential test harness's legacy VM to the real Aptos native implementations.

Permissioned signers are intentionally not supported

## Testing

- Differential test round-trips an address through `create_signer` + `std::signer::borrow_address` on both VMs.

## Known limitation

`is_permissioned_signer_impl` returns `bool`, whose 1-byte return slot is not yet supported at a call site by the lowering (call slots must be 8-byte aligned). Will add the test once bool support lands

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> MoveTo semantics and global resource publishing now depend on signer references; incorrect lowering or native ABI could break resource moves, though scope is bounded to signer/stdlib test wiring.
> 
> **Overview**
> Adds **signer** support to MonoMove: production natives for `create_signer`, `borrow_address`, and `is_permissioned_signer_impl` (signer modeled as a 32-byte address; permissioned signers always report false). **`MoveTo`** now takes a **`&signer`** fat pointer instead of a raw address slot; the interpreter dereferences it to get the publish address, and the verifier/runtime tests were updated accordingly.
> 
> Shared **`read_account_address`** replaces ad-hoc address reads for global-storage ops. The differential testsuite **publishes the Move stdlib** into both VMs, registers **production natives** on the MonoMove side, and uses **real Aptos natives** on the legacy VM, plus a new **`signer.move`** differential test for address round-trip.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53c831b29de842fee9c7299f9ecdbd02d14c8c64. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->