### PR TITLE
[mono-move] Layouts and value traversals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6670,6 +6670,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "boxcar"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36f64beae40a84da1b4b26ff2761a5b895c12adc41dc25aaee1c4f2bbfe97a6e"
+
+[[package]]
 name = "brotli"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12779,6 +12785,7 @@ name = "mono-move-core"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "bitflags 2.11.0",
  "bytes",
  "mono-move-alloc",
  "mono-move-gas",
@@ -12802,6 +12809,7 @@ dependencies = [
  "ahash 0.8.12",
  "anyhow",
  "arc-swap",
+ "boxcar",
  "dashmap 7.0.0-rc2",
  "fxhash",
  "mono-move-alloc",
@@ -12852,6 +12860,7 @@ name = "mono-move-runtime"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "bcs 0.1.4",
  "mono-move-alloc",
  "mono-move-core",
  "mono-move-gas",
@@ -12861,6 +12870,7 @@ dependencies = [
  "paste",
  "proptest",
  "rand 0.7.3",
+ "serde",
  "thiserror 1.0.69",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -542,7 +542,9 @@ bcs = { git = "https://github.com/aptos-labs/bcs.git", rev = "d31fab9d81748e2594
 better_any = "0.1.1"
 bigdecimal = { version = "0.4.0", features = ["serde"] }
 version-compare = "0.1.1"
+bitflags = "2.11.0"
 bitvec = "1.0.1"
+boxcar = "0.2.13"
 blake2 = "0.10.4"
 blake3 = { version = "1.5.4", features = ["mmap", "rayon"] }
 blake2-rfc = "0.2.18"

--- a/third_party/move/mono-move/core/Cargo.toml
+++ b/third_party/move/mono-move/core/Cargo.toml
@@ -13,6 +13,7 @@ rust-version = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }
+bitflags = { workspace = true }
 bytes = { workspace = true }
 mono-move-alloc = { workspace = true }
 mono-move-gas = { workspace = true }

--- a/third_party/move/mono-move/core/src/lib.rs
+++ b/third_party/move/mono-move/core/src/lib.rs
@@ -10,6 +10,7 @@ pub mod native;
 mod object_descriptor;
 mod prepared_module;
 pub mod storage;
+pub mod type_layout;
 pub mod types;
 
 pub use align::{
@@ -41,5 +42,9 @@ pub use prepared_module::{
 pub use storage::{
     ModuleProvider, NoResourceProvider, ResourceProvider, ResourceProviderError, StorageRead,
     NO_RESOURCE_PROVIDER,
+};
+pub use type_layout::{
+    reserved_layout_id, reserved_layouts, FieldTypeLayout, LayoutFlags, LayoutId, LayoutKind,
+    LayoutProvider, TypeLayout, TypeLayoutTable,
 };
 pub use types::{convert_mut_to_immut_ref, strip_ref};

--- a/third_party/move/mono-move/core/src/lib.rs
+++ b/third_party/move/mono-move/core/src/lib.rs
@@ -10,8 +10,8 @@ pub mod native;
 mod object_descriptor;
 mod prepared_module;
 pub mod storage;
-pub mod type_layout;
 pub mod types;
+pub mod value_layout;
 
 pub use align::{
     align_max, align_up, align_up_u32, checked_align_max, checked_align_up, MAX_ALIGN,
@@ -43,8 +43,8 @@ pub use storage::{
     ModuleProvider, NoResourceProvider, ResourceProvider, ResourceProviderError, StorageRead,
     NO_RESOURCE_PROVIDER,
 };
-pub use type_layout::{
-    reserved_layout_id, reserved_layouts, FieldTypeLayout, LayoutFlags, LayoutId, LayoutKind,
-    LayoutProvider, TypeLayout, TypeLayoutTable,
-};
 pub use types::{convert_mut_to_immut_ref, strip_ref};
+pub use value_layout::{
+    reserved_layout_id, reserved_layouts, FieldValueLayout, LayoutFlags, LayoutId, LayoutKind,
+    LayoutProvider, ValueLayout, ValueLayoutTable,
+};

--- a/third_party/move/mono-move/core/src/type_layout.rs
+++ b/third_party/move/mono-move/core/src/type_layout.rs
@@ -1,0 +1,533 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Type layouts: a flat, ID-indexed description of a value's shape used to
+//! drive layout-sensitive value walks (BCS size queries, BCS serialization,
+//! BCS deserialization into the flat in-memory representation, as well as
+//! comparison and equality).
+//!
+//! A [`TypeLayout`] is resolved once per concrete type at lowering time and
+//! then walked by chasing [`LayoutId`]s, so there is no need for the walk to
+//! re-interpret the [`Type`] DAG. Layouts are built in the same pass that
+//! publishes GC [`ObjectDescriptor`](crate::ObjectDescriptor)s. The two tables
+//! stay separate: descriptors are shallow, must-be-present-now, and live for
+//! the value's lifetime (GC reads them out of object headers), while layouts
+//! are deep and built on demand. They meet at one point: a [`LayoutKind::Vector`]
+//! carries the [`DescriptorId`] so that deserialization can add it to the value
+//! header.
+//! TODO: We will need descriptor IDs for non-inline structs and enums later.
+
+use crate::{
+    types::{view_type, InternedType, InternedTypeList, Type},
+    DescriptorId,
+};
+use bitflags::bitflags;
+use std::collections::HashMap;
+
+/// Typed index into the program's [`TypeLayout`] table.
+#[repr(transparent)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub struct LayoutId(u32);
+
+impl LayoutId {
+    /// Builds a layout ID from a table index.
+    ///
+    /// # Invariant
+    ///
+    /// - Index must always fit into `u32`.
+    #[inline(always)]
+    pub const fn from_usize(idx: usize) -> Self {
+        debug_assert!(idx <= u32::MAX as usize);
+        Self(idx as u32)
+    }
+
+    /// Returns the underlying index as `usize`.
+    #[inline(always)]
+    pub const fn as_usize(self) -> usize {
+        self.0 as usize
+    }
+}
+
+bitflags! {
+    /// Layout flags encoding information about value layouts.
+    #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+    pub struct LayoutFlags: u8 {
+        /// This value has no heap pointers and no padding. That is, it can be
+        /// serialized in one `memcpy` and compared for equality with `memcmp`.
+        const NO_POINTERS_NO_PADDING = 0b0000_0001;
+    }
+}
+
+/// Layout description of a value.
+pub struct TypeLayout {
+    /// In-memory size in bytes.
+    pub size: u32,
+    /// In-memory alignment.
+    pub align: u32,
+    /// Fixed BCS size in bytes, or [`None`] when data-dependent (e.g., for
+    /// vectors, enums, function values and anything that transitively owns
+    /// them).
+    pub const_bcs_size: Option<u32>,
+    /// Flags with extra information about this layout / type.
+    pub flags: LayoutFlags,
+    /// Describes layout's shape.
+    pub kind: LayoutKind,
+}
+
+/// Layout information for a struct field.
+pub struct FieldTypeLayout {
+    pub offset: u32,
+    pub id: LayoutId,
+}
+
+/// Shape-specific layout data.
+pub enum LayoutKind {
+    /// An unsigned integer (`u8`, ...,`u256`) or boolean.
+    UnsignedInt,
+    /// A signed integer (`i8`, ..., `i256`).
+    SignedInt,
+    /// An `address` or `signer` (32 bytes).
+    Address,
+    /// An inline struct: fields laid out flat in the parent's payload.
+    /// TODO: for non-inline structs, we need a descriptor ID.
+    Struct {
+        /// Byte offsets and IDs of each field within the struct payload.
+        fields: Box<[FieldTypeLayout]>,
+    },
+    /// A vector: an 8-byte heap-pointer slot. `elem_id` is the element layout
+    /// (for the per-element walk); `descriptor_id` is the GC descriptor of the
+    /// heap box (for stamping the header on deserialization).
+    Vector {
+        elem_id: LayoutId,
+        descriptor_id: DescriptorId,
+    },
+    /// An enum whose variants are resolved lazily on every walk (upgradable).
+    /// TODO: not yet implemented; the walks error on this kind.
+    /// TODO: add closed enum (for framework, frozen ones)
+    OpenEnum {
+        ty: InternedType,
+        ty_args: InternedTypeList,
+    },
+    /// A reference (16-byte fat pointer). All references share this layout.
+    Ref,
+    /// A function/closure value (8-byte heap-pointer slot). All function
+    /// values share this layout.
+    Function,
+}
+
+impl TypeLayout {
+    /// Builds a layout from its parts. The flag computation lives in the
+    /// builder (it needs child layouts), so this is a plain constructor.
+    pub fn new(
+        size: u32,
+        align: u32,
+        const_bcs_size: Option<u32>,
+        flags: LayoutFlags,
+        kind: LayoutKind,
+    ) -> Self {
+        Self {
+            size,
+            align,
+            const_bcs_size,
+            flags,
+            kind,
+        }
+    }
+
+    /// Returns true if a value of this layout has no padding and no pointers.
+    pub fn has_no_pointers_no_padding(&self) -> bool {
+        self.flags.contains(LayoutFlags::NO_POINTERS_NO_PADDING)
+    }
+
+    /// The fixed BCS size of this type, or [`None`] when data-dependent.
+    pub fn const_serialized_size(&self) -> Option<u32> {
+        self.const_bcs_size
+    }
+
+    /// Layout of `bool` (ordered as a 1-byte unsigned integer).
+    pub fn bool() -> Self {
+        Self::unsigned_int(1, 1)
+    }
+
+    /// Layout of `u8`.
+    pub fn u8() -> Self {
+        Self::unsigned_int(1, 1)
+    }
+
+    /// Layout of `u16`.
+    pub fn u16() -> Self {
+        Self::unsigned_int(2, 2)
+    }
+
+    /// Layout of `u32`.
+    pub fn u32() -> Self {
+        Self::unsigned_int(4, 4)
+    }
+
+    /// Layout of `u64`.
+    pub fn u64() -> Self {
+        Self::unsigned_int(8, 8)
+    }
+
+    /// Layout of `u128`.
+    pub fn u128() -> Self {
+        Self::unsigned_int(16, 8)
+    }
+
+    /// Layout of `u256`.
+    pub fn u256() -> Self {
+        Self::unsigned_int(32, 8)
+    }
+
+    /// Layout of `i8`.
+    pub fn i8() -> Self {
+        Self::signed_int(1, 1)
+    }
+
+    /// Layout of `i16`.
+    pub fn i16() -> Self {
+        Self::signed_int(2, 2)
+    }
+
+    /// Layout of `i32`.
+    pub fn i32() -> Self {
+        Self::signed_int(4, 4)
+    }
+
+    /// Layout of `i64`.
+    pub fn i64() -> Self {
+        Self::signed_int(8, 8)
+    }
+
+    /// Layout of `i128`.
+    pub fn i128() -> Self {
+        Self::signed_int(16, 8)
+    }
+
+    /// Layout of `i256`.
+    pub fn i256() -> Self {
+        Self::signed_int(32, 8)
+    }
+
+    /// Layout of `address` or a signer.
+    pub fn address() -> Self {
+        Self {
+            size: 32,
+            align: 8,
+            const_bcs_size: Some(32),
+            flags: LayoutFlags::NO_POINTERS_NO_PADDING,
+            kind: LayoutKind::Address,
+        }
+    }
+
+    /// Layout shared by all reference types (16-byte fat pointer).
+    pub fn reference() -> Self {
+        Self {
+            size: 16,
+            align: 8,
+            const_bcs_size: None,
+            flags: LayoutFlags::empty(),
+            kind: LayoutKind::Ref,
+        }
+    }
+
+    /// Layout shared by all function values (heap-pointer slot).
+    pub fn function() -> Self {
+        Self {
+            size: 8,
+            align: 8,
+            const_bcs_size: None,
+            flags: LayoutFlags::empty(),
+            kind: LayoutKind::Function,
+        }
+    }
+
+    /// Layout for vectors (heap pointer slot).
+    pub fn vector(elem_id: LayoutId, descriptor_id: DescriptorId) -> Self {
+        Self {
+            size: 8,
+            align: 8,
+            const_bcs_size: None,
+            // Vectors are heap pointers, so their data can be bulk copied or
+            // compared only if its element has no pointers or no padding, but
+            // otherwise vectors do not qualify.
+            flags: LayoutFlags::empty(),
+            kind: LayoutKind::Vector {
+                elem_id,
+                descriptor_id,
+            },
+        }
+    }
+
+    /// Layout for a struct.
+    pub fn struct_layout(
+        size: u32,
+        align: u32,
+        const_bcs_size: Option<u32>,
+        flags: LayoutFlags,
+        fields: Box<[FieldTypeLayout]>,
+    ) -> TypeLayout {
+        Self {
+            size,
+            align,
+            const_bcs_size,
+            flags,
+            kind: LayoutKind::Struct { fields },
+        }
+    }
+
+    /// Layout for an open enum.
+    pub fn open_enum(ty: InternedType, ty_args: InternedTypeList) -> TypeLayout {
+        Self {
+            size: 8,
+            align: 8,
+            const_bcs_size: None,
+            flags: LayoutFlags::empty(),
+            kind: LayoutKind::OpenEnum { ty, ty_args },
+        }
+    }
+
+    fn unsigned_int(size: u32, align: u32) -> Self {
+        Self {
+            size,
+            align,
+            const_bcs_size: Some(size),
+            flags: LayoutFlags::NO_POINTERS_NO_PADDING,
+            kind: LayoutKind::UnsignedInt,
+        }
+    }
+
+    fn signed_int(size: u32, align: u32) -> Self {
+        Self {
+            size,
+            align,
+            const_bcs_size: Some(size),
+            flags: LayoutFlags::NO_POINTERS_NO_PADDING,
+            kind: LayoutKind::SignedInt,
+        }
+    }
+}
+
+/// Reserved layout ID for [`Type::Bool`].
+pub const BOOL_LAYOUT_ID: LayoutId = LayoutId(0);
+
+/// Reserved layout ID for [`Type::U8`].
+pub const U8_LAYOUT_ID: LayoutId = LayoutId(1);
+
+/// Reserved layout ID for [`Type::U16`].
+pub const U16_LAYOUT_ID: LayoutId = LayoutId(2);
+
+/// Reserved layout ID for [`Type::U32`].
+pub const U32_LAYOUT_ID: LayoutId = LayoutId(3);
+
+/// Reserved layout ID for [`Type::U64`].
+pub const U64_LAYOUT_ID: LayoutId = LayoutId(4);
+
+/// Reserved layout ID for [`Type::U128`].
+pub const U128_LAYOUT_ID: LayoutId = LayoutId(5);
+
+/// Reserved layout ID for [`Type::U256`].
+pub const U256_LAYOUT_ID: LayoutId = LayoutId(6);
+
+/// Reserved layout ID for [`Type::I8`].
+pub const I8_LAYOUT_ID: LayoutId = LayoutId(7);
+/// Reserved layout ID for [`Type::I16`].
+pub const I16_LAYOUT_ID: LayoutId = LayoutId(8);
+/// Reserved layout ID for [`Type::I32`].
+pub const I32_LAYOUT_ID: LayoutId = LayoutId(9);
+/// Reserved layout ID for [`Type::I64`].
+pub const I64_LAYOUT_ID: LayoutId = LayoutId(10);
+
+/// Reserved layout ID for [`Type::I128`].
+pub const I128_LAYOUT_ID: LayoutId = LayoutId(11);
+
+/// Reserved layout ID for [`Type::I256`].
+pub const I256_LAYOUT_ID: LayoutId = LayoutId(12);
+
+/// Reserved layout ID for [`Type::Address`]. Note that  [`Type::Signer`]
+/// has the same layout.
+pub const ADDRESS_LAYOUT_ID: LayoutId = LayoutId(13);
+
+/// Reserved layout ID shared by all reference types.
+pub const REF_LAYOUT_ID: LayoutId = LayoutId(14);
+
+/// Reserved layout ID shared by all function values.
+pub const FUNCTION_LAYOUT_ID: LayoutId = LayoutId(15);
+
+/// Returns the reserved [`LayoutId`] for a type whose layout is arg-independent
+/// (primitives, references, functions), or [`None`] for types that must be
+/// built and looked up in the table (vectors, nominals) or are unsized (type
+/// parameters).
+pub fn reserved_layout_id(ty: &Type) -> Option<LayoutId> {
+    Some(match ty {
+        Type::Bool => BOOL_LAYOUT_ID,
+        Type::U8 => U8_LAYOUT_ID,
+        Type::U16 => U16_LAYOUT_ID,
+        Type::U32 => U32_LAYOUT_ID,
+        Type::U64 => U64_LAYOUT_ID,
+        Type::U128 => U128_LAYOUT_ID,
+        Type::U256 => U256_LAYOUT_ID,
+        Type::I8 => I8_LAYOUT_ID,
+        Type::I16 => I16_LAYOUT_ID,
+        Type::I32 => I32_LAYOUT_ID,
+        Type::I64 => I64_LAYOUT_ID,
+        Type::I128 => I128_LAYOUT_ID,
+        Type::I256 => I256_LAYOUT_ID,
+        // Signer shares the address layout.
+        Type::Address | Type::Signer => ADDRESS_LAYOUT_ID,
+        Type::ImmutRef { .. } | Type::MutRef { .. } => REF_LAYOUT_ID,
+        Type::Function { .. } => FUNCTION_LAYOUT_ID,
+        Type::Vector { .. } | Type::Nominal { .. } | Type::TypeParam { .. } => return None,
+    })
+}
+
+/// Returns the initial layout table: the reserved entries in ID order.
+pub fn reserved_layouts() -> Vec<TypeLayout> {
+    // Order MUST match the `*_LAYOUT_ID` constants above.
+    vec![
+        TypeLayout::bool(),
+        TypeLayout::u8(),
+        TypeLayout::u16(),
+        TypeLayout::u32(),
+        TypeLayout::u64(),
+        TypeLayout::u128(),
+        TypeLayout::u256(),
+        TypeLayout::i8(),
+        TypeLayout::i16(),
+        TypeLayout::i32(),
+        TypeLayout::i64(),
+        TypeLayout::i128(),
+        TypeLayout::i256(),
+        TypeLayout::address(),
+        TypeLayout::reference(),
+        TypeLayout::function(),
+    ]
+}
+
+/// Per-ID and per-type lookup of [`TypeLayout`]s.
+pub trait LayoutProvider {
+    /// Returns the layout for `id`, or [`None`] if `id` is unknown.
+    fn layout(&self, id: LayoutId) -> Option<&TypeLayout>;
+
+    /// Returns the layout id for `ty`, or [`None`] if no layout has been
+    /// published for it yet (e.g. its module is not loaded).
+    fn layout_id(&self, ty: InternedType) -> Option<LayoutId>;
+
+    fn layout_by_ty(&self, ty: InternedType) -> Option<&TypeLayout> {
+        let id = self.layout_id(ty)?;
+        self.layout(id)
+    }
+}
+
+// TODO: Test-only, remove when local execution context is refactored and removed.
+pub struct TypeLayoutTable {
+    table: Vec<TypeLayout>,
+    by_ty: HashMap<InternedType, LayoutId>,
+}
+
+impl TypeLayoutTable {
+    pub fn new() -> Self {
+        Self {
+            table: reserved_layouts(),
+            by_ty: HashMap::new(),
+        }
+    }
+
+    pub fn push(&mut self, ty: InternedType, layout: TypeLayout) -> LayoutId {
+        let id = LayoutId::from_usize(self.table.len());
+        self.table.push(layout);
+        self.by_ty.insert(ty, id);
+        id
+    }
+}
+
+impl Default for TypeLayoutTable {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl LayoutProvider for TypeLayoutTable {
+    fn layout(&self, id: LayoutId) -> Option<&TypeLayout> {
+        self.table.get(id.as_usize())
+    }
+
+    fn layout_id(&self, ty: InternedType) -> Option<LayoutId> {
+        if let Some(id) = reserved_layout_id(view_type(ty)) {
+            return Some(id);
+        }
+        self.by_ty.get(&ty).copied()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reserved_layouts_match_ids() {
+        let layouts = reserved_layouts();
+        assert_eq!(layouts.len(), 16);
+
+        let cases = [
+            (BOOL_LAYOUT_ID, 1),
+            (U8_LAYOUT_ID, 1),
+            (U16_LAYOUT_ID, 2),
+            (U32_LAYOUT_ID, 4),
+            (U64_LAYOUT_ID, 8),
+            (U128_LAYOUT_ID, 16),
+            (U256_LAYOUT_ID, 32),
+            (I8_LAYOUT_ID, 1),
+            (I256_LAYOUT_ID, 32),
+            (ADDRESS_LAYOUT_ID, 32),
+        ];
+        for (id, width) in cases {
+            let l = &layouts[id.as_usize()];
+            assert_eq!(l.size, width);
+            assert_eq!(l.const_bcs_size, Some(width));
+            assert!(l.has_no_pointers_no_padding());
+        }
+
+        assert!(matches!(
+            layouts[U64_LAYOUT_ID.as_usize()].kind,
+            LayoutKind::UnsignedInt
+        ));
+        assert!(matches!(
+            layouts[I8_LAYOUT_ID.as_usize()].kind,
+            LayoutKind::SignedInt
+        ));
+        assert!(matches!(
+            layouts[ADDRESS_LAYOUT_ID.as_usize()].kind,
+            LayoutKind::Address
+        ));
+
+        let r = &layouts[REF_LAYOUT_ID.as_usize()];
+        assert_eq!(r.size, 16);
+        assert_eq!(r.const_bcs_size, None);
+        assert!(matches!(r.kind, LayoutKind::Ref));
+
+        let f = &layouts[FUNCTION_LAYOUT_ID.as_usize()];
+        assert_eq!(f.size, 8);
+        assert!(matches!(f.kind, LayoutKind::Function));
+    }
+
+    #[test]
+    fn reserved_layout_id_maps_primitives_and_pointers() {
+        assert_eq!(reserved_layout_id(&Type::U64), Some(U64_LAYOUT_ID));
+        assert_eq!(reserved_layout_id(&Type::Address), Some(ADDRESS_LAYOUT_ID));
+        assert_eq!(reserved_layout_id(&Type::Signer), Some(ADDRESS_LAYOUT_ID));
+        assert_eq!(
+            reserved_layout_id(&Type::ImmutRef {
+                inner: crate::types::U64_TY
+            }),
+            Some(REF_LAYOUT_ID)
+        );
+        assert_eq!(
+            reserved_layout_id(&Type::Vector {
+                elem: crate::types::U64_TY
+            }),
+            None
+        );
+        assert_eq!(reserved_layout_id(&Type::TypeParam { idx: 0 }), None);
+    }
+}

--- a/third_party/move/mono-move/core/src/value_layout.rs
+++ b/third_party/move/mono-move/core/src/value_layout.rs
@@ -2,11 +2,11 @@
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 //! Type layouts: a flat, ID-indexed description of a value's shape used to
-//! drive layout-sensitive value walks (BCS size queries, BCS serialization,
-//! BCS deserialization into the flat in-memory representation, as well as
-//! comparison and equality).
+//! drive layout-sensitive value walks (e.g., BCS size queries, BCS
+//! serialization, BCS deserialization into the flat in-memory representation,
+//! comparison, and equality).
 //!
-//! A [`TypeLayout`] is resolved once per concrete type at lowering time and
+//! A [`ValueLayout`] is resolved once per concrete type at lowering time and
 //! then walked by chasing [`LayoutId`]s, so there is no need for the walk to
 //! re-interpret the [`Type`] DAG. Layouts are built in the same pass that
 //! publishes GC [`ObjectDescriptor`](crate::ObjectDescriptor)s. The two tables
@@ -19,12 +19,12 @@
 
 use crate::{
     types::{view_type, InternedType, InternedTypeList, Type},
-    DescriptorId,
+    DescriptorId, MAX_ALIGN,
 };
 use bitflags::bitflags;
 use std::collections::HashMap;
 
-/// Typed index into the program's [`TypeLayout`] table.
+/// Typed index into the program's [`ValueLayout`] table.
 #[repr(transparent)]
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct LayoutId(u32);
@@ -59,7 +59,7 @@ bitflags! {
 }
 
 /// Layout description of a value.
-pub struct TypeLayout {
+pub struct ValueLayout {
     /// In-memory size in bytes.
     pub size: u32,
     /// In-memory alignment.
@@ -67,7 +67,7 @@ pub struct TypeLayout {
     /// Fixed BCS size in bytes, or [`None`] when data-dependent (e.g., for
     /// vectors, enums, function values and anything that transitively owns
     /// them).
-    pub const_bcs_size: Option<u32>,
+    pub fixed_bcs_size: Option<u32>,
     /// Flags with extra information about this layout / type.
     pub flags: LayoutFlags,
     /// Describes layout's shape.
@@ -75,14 +75,16 @@ pub struct TypeLayout {
 }
 
 /// Layout information for a struct field.
-pub struct FieldTypeLayout {
+pub struct FieldValueLayout {
     pub offset: u32,
     pub id: LayoutId,
 }
 
 /// Shape-specific layout data.
 pub enum LayoutKind {
-    /// An unsigned integer (`u8`, ...,`u256`) or boolean.
+    /// A boolean: a 1-byte value holding `0` or `1`.
+    Bool,
+    /// An unsigned integer (`u8`, ..., `u256`).
     UnsignedInt,
     /// A signed integer (`i8`, ..., `i256`).
     SignedInt,
@@ -92,7 +94,7 @@ pub enum LayoutKind {
     /// TODO: for non-inline structs, we need a descriptor ID.
     Struct {
         /// Byte offsets and IDs of each field within the struct payload.
-        fields: Box<[FieldTypeLayout]>,
+        fields: Box<[FieldValueLayout]>,
     },
     /// A vector: an 8-byte heap-pointer slot. `elem_id` is the element layout
     /// (for the per-element walk); `descriptor_id` is the GC descriptor of the
@@ -115,20 +117,24 @@ pub enum LayoutKind {
     Function,
 }
 
-impl TypeLayout {
+impl ValueLayout {
     /// Builds a layout from its parts. The flag computation lives in the
     /// builder (it needs child layouts), so this is a plain constructor.
     pub fn new(
         size: u32,
         align: u32,
-        const_bcs_size: Option<u32>,
+        fixed_bcs_size: Option<u32>,
         flags: LayoutFlags,
         kind: LayoutKind,
     ) -> Self {
+        debug_assert!(
+            align <= MAX_ALIGN as u32,
+            "value alignment must not exceed MAX_ALIGN"
+        );
         Self {
             size,
             align,
-            const_bcs_size,
+            fixed_bcs_size,
             flags,
             kind,
         }
@@ -139,14 +145,21 @@ impl TypeLayout {
         self.flags.contains(LayoutFlags::NO_POINTERS_NO_PADDING)
     }
 
-    /// The fixed BCS size of this type, or [`None`] when data-dependent.
-    pub fn const_serialized_size(&self) -> Option<u32> {
-        self.const_bcs_size
+    /// The fixed BCS size of a value of this type, or [`None`] when
+    /// data-dependent.
+    pub fn fixed_serialized_size(&self) -> Option<u32> {
+        self.fixed_bcs_size
     }
 
-    /// Layout of `bool` (ordered as a 1-byte unsigned integer).
+    /// Layout of `bool`: a 1-byte `0`/`1` value.
     pub fn bool() -> Self {
-        Self::unsigned_int(1, 1)
+        Self {
+            size: 1,
+            align: 1,
+            fixed_bcs_size: Some(1),
+            flags: LayoutFlags::NO_POINTERS_NO_PADDING,
+            kind: LayoutKind::Bool,
+        }
     }
 
     /// Layout of `u8`.
@@ -171,12 +184,12 @@ impl TypeLayout {
 
     /// Layout of `u128`.
     pub fn u128() -> Self {
-        Self::unsigned_int(16, 8)
+        Self::unsigned_int(16, MAX_ALIGN as u32)
     }
 
     /// Layout of `u256`.
     pub fn u256() -> Self {
-        Self::unsigned_int(32, 8)
+        Self::unsigned_int(32, MAX_ALIGN as u32)
     }
 
     /// Layout of `i8`.
@@ -201,20 +214,20 @@ impl TypeLayout {
 
     /// Layout of `i128`.
     pub fn i128() -> Self {
-        Self::signed_int(16, 8)
+        Self::signed_int(16, MAX_ALIGN as u32)
     }
 
     /// Layout of `i256`.
     pub fn i256() -> Self {
-        Self::signed_int(32, 8)
+        Self::signed_int(32, MAX_ALIGN as u32)
     }
 
     /// Layout of `address` or a signer.
     pub fn address() -> Self {
         Self {
             size: 32,
-            align: 8,
-            const_bcs_size: Some(32),
+            align: MAX_ALIGN as u32,
+            fixed_bcs_size: Some(32),
             flags: LayoutFlags::NO_POINTERS_NO_PADDING,
             kind: LayoutKind::Address,
         }
@@ -224,8 +237,8 @@ impl TypeLayout {
     pub fn reference() -> Self {
         Self {
             size: 16,
-            align: 8,
-            const_bcs_size: None,
+            align: MAX_ALIGN as u32,
+            fixed_bcs_size: None,
             flags: LayoutFlags::empty(),
             kind: LayoutKind::Ref,
         }
@@ -235,8 +248,8 @@ impl TypeLayout {
     pub fn function() -> Self {
         Self {
             size: 8,
-            align: 8,
-            const_bcs_size: None,
+            align: MAX_ALIGN as u32,
+            fixed_bcs_size: None,
             flags: LayoutFlags::empty(),
             kind: LayoutKind::Function,
         }
@@ -246,8 +259,8 @@ impl TypeLayout {
     pub fn vector(elem_id: LayoutId, descriptor_id: DescriptorId) -> Self {
         Self {
             size: 8,
-            align: 8,
-            const_bcs_size: None,
+            align: MAX_ALIGN as u32,
+            fixed_bcs_size: None,
             // Vectors are heap pointers, so their data can be bulk copied or
             // compared only if its element has no pointers or no padding, but
             // otherwise vectors do not qualify.
@@ -263,25 +276,29 @@ impl TypeLayout {
     pub fn struct_layout(
         size: u32,
         align: u32,
-        const_bcs_size: Option<u32>,
+        fixed_bcs_size: Option<u32>,
         flags: LayoutFlags,
-        fields: Box<[FieldTypeLayout]>,
-    ) -> TypeLayout {
+        fields: Box<[FieldValueLayout]>,
+    ) -> ValueLayout {
+        debug_assert!(
+            align <= MAX_ALIGN as u32,
+            "value alignment must not exceed MAX_ALIGN"
+        );
         Self {
             size,
             align,
-            const_bcs_size,
+            fixed_bcs_size,
             flags,
             kind: LayoutKind::Struct { fields },
         }
     }
 
     /// Layout for an open enum.
-    pub fn open_enum(ty: InternedType, ty_args: InternedTypeList) -> TypeLayout {
+    pub fn open_enum(ty: InternedType, ty_args: InternedTypeList) -> ValueLayout {
         Self {
             size: 8,
-            align: 8,
-            const_bcs_size: None,
+            align: MAX_ALIGN as u32,
+            fixed_bcs_size: None,
             flags: LayoutFlags::empty(),
             kind: LayoutKind::OpenEnum { ty, ty_args },
         }
@@ -291,7 +308,7 @@ impl TypeLayout {
         Self {
             size,
             align,
-            const_bcs_size: Some(size),
+            fixed_bcs_size: Some(size),
             flags: LayoutFlags::NO_POINTERS_NO_PADDING,
             kind: LayoutKind::UnsignedInt,
         }
@@ -301,12 +318,24 @@ impl TypeLayout {
         Self {
             size,
             align,
-            const_bcs_size: Some(size),
+            fixed_bcs_size: Some(size),
             flags: LayoutFlags::NO_POINTERS_NO_PADDING,
             kind: LayoutKind::SignedInt,
         }
     }
 }
+
+// Reserved layout IDs for types whose layout does not depend on type
+// arguments (primitives, references, functions). They occupy the first slots
+// of every layout table, in exactly this order.
+//
+// # Invariants
+//
+// - The numeric IDs below must match the order of [`reserved_layouts`], which
+//   seeds the table. Keep the two in sync.
+// - Never reorder or renumber an existing entry, and never insert in the
+//   middle: a layout table built at an earlier version would then resolve old
+//   IDs to the wrong layout. Only append new reserved IDs at the end.
 
 /// Reserved layout ID for [`Type::Bool`].
 pub const BOOL_LAYOUT_ID: LayoutId = LayoutId(0);
@@ -331,10 +360,13 @@ pub const U256_LAYOUT_ID: LayoutId = LayoutId(6);
 
 /// Reserved layout ID for [`Type::I8`].
 pub const I8_LAYOUT_ID: LayoutId = LayoutId(7);
+
 /// Reserved layout ID for [`Type::I16`].
 pub const I16_LAYOUT_ID: LayoutId = LayoutId(8);
+
 /// Reserved layout ID for [`Type::I32`].
 pub const I32_LAYOUT_ID: LayoutId = LayoutId(9);
+
 /// Reserved layout ID for [`Type::I64`].
 pub const I64_LAYOUT_ID: LayoutId = LayoutId(10);
 
@@ -382,50 +414,50 @@ pub fn reserved_layout_id(ty: &Type) -> Option<LayoutId> {
 }
 
 /// Returns the initial layout table: the reserved entries in ID order.
-pub fn reserved_layouts() -> Vec<TypeLayout> {
+pub fn reserved_layouts() -> Vec<ValueLayout> {
     // Order MUST match the `*_LAYOUT_ID` constants above.
     vec![
-        TypeLayout::bool(),
-        TypeLayout::u8(),
-        TypeLayout::u16(),
-        TypeLayout::u32(),
-        TypeLayout::u64(),
-        TypeLayout::u128(),
-        TypeLayout::u256(),
-        TypeLayout::i8(),
-        TypeLayout::i16(),
-        TypeLayout::i32(),
-        TypeLayout::i64(),
-        TypeLayout::i128(),
-        TypeLayout::i256(),
-        TypeLayout::address(),
-        TypeLayout::reference(),
-        TypeLayout::function(),
+        ValueLayout::bool(),
+        ValueLayout::u8(),
+        ValueLayout::u16(),
+        ValueLayout::u32(),
+        ValueLayout::u64(),
+        ValueLayout::u128(),
+        ValueLayout::u256(),
+        ValueLayout::i8(),
+        ValueLayout::i16(),
+        ValueLayout::i32(),
+        ValueLayout::i64(),
+        ValueLayout::i128(),
+        ValueLayout::i256(),
+        ValueLayout::address(),
+        ValueLayout::reference(),
+        ValueLayout::function(),
     ]
 }
 
-/// Per-ID and per-type lookup of [`TypeLayout`]s.
+/// Per-ID and per-type lookup of [`ValueLayout`]s.
 pub trait LayoutProvider {
     /// Returns the layout for `id`, or [`None`] if `id` is unknown.
-    fn layout(&self, id: LayoutId) -> Option<&TypeLayout>;
+    fn layout(&self, id: LayoutId) -> Option<&ValueLayout>;
 
     /// Returns the layout id for `ty`, or [`None`] if no layout has been
     /// published for it yet (e.g. its module is not loaded).
     fn layout_id(&self, ty: InternedType) -> Option<LayoutId>;
 
-    fn layout_by_ty(&self, ty: InternedType) -> Option<&TypeLayout> {
+    fn layout_by_ty(&self, ty: InternedType) -> Option<&ValueLayout> {
         let id = self.layout_id(ty)?;
         self.layout(id)
     }
 }
 
 // TODO: Test-only, remove when local execution context is refactored and removed.
-pub struct TypeLayoutTable {
-    table: Vec<TypeLayout>,
+pub struct ValueLayoutTable {
+    table: Vec<ValueLayout>,
     by_ty: HashMap<InternedType, LayoutId>,
 }
 
-impl TypeLayoutTable {
+impl ValueLayoutTable {
     pub fn new() -> Self {
         Self {
             table: reserved_layouts(),
@@ -433,7 +465,7 @@ impl TypeLayoutTable {
         }
     }
 
-    pub fn push(&mut self, ty: InternedType, layout: TypeLayout) -> LayoutId {
+    pub fn push(&mut self, ty: InternedType, layout: ValueLayout) -> LayoutId {
         let id = LayoutId::from_usize(self.table.len());
         self.table.push(layout);
         self.by_ty.insert(ty, id);
@@ -441,14 +473,14 @@ impl TypeLayoutTable {
     }
 }
 
-impl Default for TypeLayoutTable {
+impl Default for ValueLayoutTable {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl LayoutProvider for TypeLayoutTable {
-    fn layout(&self, id: LayoutId) -> Option<&TypeLayout> {
+impl LayoutProvider for ValueLayoutTable {
+    fn layout(&self, id: LayoutId) -> Option<&ValueLayout> {
         self.table.get(id.as_usize())
     }
 
@@ -484,7 +516,7 @@ mod tests {
         for (id, width) in cases {
             let l = &layouts[id.as_usize()];
             assert_eq!(l.size, width);
-            assert_eq!(l.const_bcs_size, Some(width));
+            assert_eq!(l.fixed_bcs_size, Some(width));
             assert!(l.has_no_pointers_no_padding());
         }
 
@@ -503,7 +535,7 @@ mod tests {
 
         let r = &layouts[REF_LAYOUT_ID.as_usize()];
         assert_eq!(r.size, 16);
-        assert_eq!(r.const_bcs_size, None);
+        assert_eq!(r.fixed_bcs_size, None);
         assert!(matches!(r.kind, LayoutKind::Ref));
 
         let f = &layouts[FUNCTION_LAYOUT_ID.as_usize()];

--- a/third_party/move/mono-move/global-context/Cargo.toml
+++ b/third_party/move/mono-move/global-context/Cargo.toml
@@ -15,6 +15,7 @@ rust-version = { workspace = true }
 ahash = { workspace = true }
 anyhow = { workspace = true }
 arc-swap = { workspace = true }
+boxcar = { workspace = true }
 dashmap = { workspace = true }
 fxhash = { workspace = true }
 mono-move-alloc = { workspace = true }

--- a/third_party/move/mono-move/global-context/src/context.rs
+++ b/third_party/move/mono-move/global-context/src/context.rs
@@ -56,8 +56,7 @@ use mono_move_alloc::{GlobalArenaPool, GlobalArenaPtr, GlobalArenaShard};
 use mono_move_core::{
     reserved_layout_id, reserved_layouts, types::NominalLayout, DescriptorId, DescriptorProvider,
     FrameOffset, FunctionRef, Interner, LayoutId, LayoutProvider, ModuleId, ObjectDescriptor,
-    TypeLayout, TRIVIAL_DESCRIPTOR_ID,
-
+    ValueLayout, TRIVIAL_DESCRIPTOR_ID,
 };
 use move_binary_format::{file_format::SignatureToken, CompiledModule};
 use parking_lot::{RwLock, RwLockReadGuard, RwLockWriteGuard};
@@ -225,20 +224,29 @@ fn initial_descriptors() -> Vec<Arc<ObjectDescriptor>> {
 struct Layouts {
     /// Type to layout ID mapping. Types are concrete.
     by_ty: DashMap<InternedType, LayoutId, ahash::RandomState>,
-    /// All existing layouts in ID order.
-    table: boxcar::Vec<TypeLayout>,
+    /// All existing layouts in ID order. `boxcar::Vec` is an append-only
+    /// concurrent vector: entries are pushed through a shared `&` reference and
+    /// are never moved, so [`LayoutId`] indices stay stable and concurrent
+    /// reads need no lock.
+    table: boxcar::Vec<ValueLayout>,
 }
 
 impl Default for Layouts {
     fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Layouts {
+    /// Creates a fresh table seeded with the reserved layouts and an empty
+    /// type-to-ID map.
+    fn new() -> Self {
         Self {
             by_ty: DashMap::default(),
             table: initial_layouts(),
         }
     }
-}
 
-impl Layouts {
     /// Resets layout table and type to layout ID mappings. Reserved layouts
     /// are added back to the layout table.
     fn reset(&mut self) {
@@ -248,7 +256,7 @@ impl Layouts {
     }
 }
 
-fn initial_layouts() -> boxcar::Vec<TypeLayout> {
+fn initial_layouts() -> boxcar::Vec<ValueLayout> {
     let mut table = boxcar::Vec::new();
     table.extend(reserved_layouts());
     table
@@ -731,7 +739,7 @@ impl<'ctx> ExecutionGuard<'ctx> {
 
     /// Publishes the layout for the given type and returns its assigned
     /// [`LayoutId`].
-    pub fn publish_layout(&self, ty: InternedType, layout: TypeLayout) -> LayoutId {
+    pub fn publish_layout(&self, ty: InternedType, layout: ValueLayout) -> LayoutId {
         if let Some(id) = self.ctx.layouts.by_ty.get(&ty) {
             return *id;
         }
@@ -780,7 +788,7 @@ impl<'ctx> DescriptorProvider for ExecutionGuard<'ctx> {
 }
 
 impl<'ctx> LayoutProvider for ExecutionGuard<'ctx> {
-    fn layout(&self, id: LayoutId) -> Option<&TypeLayout> {
+    fn layout(&self, id: LayoutId) -> Option<&ValueLayout> {
         self.ctx.layouts.table.get(id.as_usize())
     }
 

--- a/third_party/move/mono-move/global-context/src/context.rs
+++ b/third_party/move/mono-move/global-context/src/context.rs
@@ -54,8 +54,10 @@ use arc_swap::ArcSwap;
 use dashmap::DashMap;
 use mono_move_alloc::{GlobalArenaPool, GlobalArenaPtr, GlobalArenaShard};
 use mono_move_core::{
-    types::NominalLayout, DescriptorId, DescriptorProvider, FrameOffset, FunctionRef, Interner,
-    ModuleId, ObjectDescriptor, TRIVIAL_DESCRIPTOR_ID,
+    reserved_layout_id, reserved_layouts, types::NominalLayout, DescriptorId, DescriptorProvider,
+    FrameOffset, FunctionRef, Interner, LayoutId, LayoutProvider, ModuleId, ObjectDescriptor,
+    TypeLayout, TRIVIAL_DESCRIPTOR_ID,
+
 };
 use move_binary_format::{file_format::SignatureToken, CompiledModule};
 use parking_lot::{RwLock, RwLockReadGuard, RwLockWriteGuard};
@@ -111,6 +113,7 @@ pub struct GlobalContext {
     /// Lock to switch between execution and maintenance modes:
     ///   - Read lock: execution phase.
     ///   - Write lock: maintenance phase.
+    // TODO: Consider removing since maintenance context requires &mut GlobalContext.
     phase: RwLock<()>,
 }
 
@@ -134,6 +137,9 @@ struct Context {
     module_cache: ModuleCache,
     /// Published object descriptors.
     descriptors: Descriptors,
+    /// Published type layouts (the type-driven walk shape, separate from the
+    /// GC object descriptors above).
+    layouts: Layouts,
 }
 
 /// Storage for the published object-descriptor set.
@@ -207,6 +213,47 @@ fn initial_descriptors() -> Vec<Arc<ObjectDescriptor>> {
     ]
 }
 
+/// Table of type layouts.
+///
+/// # Invariants
+///
+/// - Layouts can be obtained by indexing the table with [`LayoutId`] index.
+///   By construction, these indices always have to be in bounds.
+/// - First few slots are reserved for primitives, references, etc. These IDs
+///   do not have the mapping from type to ID. For all other types, the mapping
+///   from type to ID exists where ID can be used to index type's layout.
+struct Layouts {
+    /// Type to layout ID mapping. Types are concrete.
+    by_ty: DashMap<InternedType, LayoutId, ahash::RandomState>,
+    /// All existing layouts in ID order.
+    table: boxcar::Vec<TypeLayout>,
+}
+
+impl Default for Layouts {
+    fn default() -> Self {
+        Self {
+            by_ty: DashMap::default(),
+            table: initial_layouts(),
+        }
+    }
+}
+
+impl Layouts {
+    /// Resets layout table and type to layout ID mappings. Reserved layouts
+    /// are added back to the layout table.
+    fn reset(&mut self) {
+        let Self { by_ty, table } = self;
+        by_ty.clear();
+        *table = initial_layouts();
+    }
+}
+
+fn initial_layouts() -> boxcar::Vec<TypeLayout> {
+    let mut table = boxcar::Vec::new();
+    table.extend(reserved_layouts());
+    table
+}
+
 /// RAII guard for the maintenance phase providing exclusive write access.
 ///
 /// Only one maintenance context can exist at a time, ensuring exclusive
@@ -214,8 +261,8 @@ fn initial_descriptors() -> Vec<Arc<ObjectDescriptor>> {
 /// is held for the lifetime of this guard and automatically released when
 /// dropped.
 pub struct MaintenanceGuard<'ctx> {
-    /// Reference to the caches stored in context.
-    ctx: &'ctx Context,
+    /// Exclusive reference to the caches stored in context.
+    ctx: &'ctx mut Context,
     /// Pool of all arenas managing global allocations.
     global_arena: &'ctx GlobalArenaPool,
     /// Configuration controlling maintenance behavior.
@@ -299,6 +346,7 @@ impl GlobalContext {
                 function_refs: DashMap::default(),
                 module_cache: ModuleCache::new(),
                 descriptors: Descriptors::default(),
+                layouts: Layouts::default(),
             },
             global_arena: GlobalArenaPool::with_num_arenas(num_workers),
             maintenance_config,
@@ -314,11 +362,11 @@ impl GlobalContext {
     /// Returns [`None`] if [`ExecutionGuard`] is currently held or there is
     /// an ongoing maintenance.
     #[must_use]
-    pub fn try_maintenance_context(&self) -> Option<MaintenanceGuard<'_>> {
+    pub fn try_maintenance_context(&mut self) -> Option<MaintenanceGuard<'_>> {
         let _guard = self.phase.try_write()?;
 
         Some(MaintenanceGuard {
-            ctx: &self.ctx,
+            ctx: &mut self.ctx,
             global_arena: &self.global_arena,
             maintenance_config: &self.maintenance_config,
             _guard,
@@ -672,6 +720,29 @@ impl<'ctx> ExecutionGuard<'ctx> {
             })
     }
 
+    /// Returns the layout ID for the given type, or [`None`] if no layout has
+    /// been published yet.
+    pub fn layout_id_for(&self, ty: InternedType) -> Option<LayoutId> {
+        if let Some(id) = reserved_layout_id(view_type(ty)) {
+            return Some(id);
+        }
+        self.ctx.layouts.by_ty.get(&ty).map(|r| *r)
+    }
+
+    /// Publishes the layout for the given type and returns its assigned
+    /// [`LayoutId`].
+    pub fn publish_layout(&self, ty: InternedType, layout: TypeLayout) -> LayoutId {
+        if let Some(id) = self.ctx.layouts.by_ty.get(&ty) {
+            return *id;
+        }
+
+        // TODO(perf): consider if we should append to the table without holding the shard lock.
+        *self.ctx.layouts.by_ty.entry(ty).or_insert_with(|| {
+            let idx = self.ctx.layouts.table.push(layout);
+            LayoutId::from_usize(idx)
+        })
+    }
+
     /// Looks up a type previously interned from a signature token of `module`.
     /// Returns `None` if the token has not yet been interned in this module's
     /// context.
@@ -705,6 +776,16 @@ impl<'ctx> DescriptorProvider for ExecutionGuard<'ctx> {
         // that resolved here stays alive for the returned reference's
         // lifetime, which is tied to `&self`.
         Some(unsafe { &*ptr })
+    }
+}
+
+impl<'ctx> LayoutProvider for ExecutionGuard<'ctx> {
+    fn layout(&self, id: LayoutId) -> Option<&TypeLayout> {
+        self.ctx.layouts.table.get(id.as_usize())
+    }
+
+    fn layout_id(&self, ty: InternedType) -> Option<LayoutId> {
+        self.layout_id_for(ty)
     }
 }
 
@@ -941,6 +1022,7 @@ impl<'ctx> MaintenanceGuard<'ctx> {
             function_refs,
             module_cache,
             descriptors,
+            layouts,
         } = self.ctx;
 
         identifiers.clear();
@@ -949,6 +1031,7 @@ impl<'ctx> MaintenanceGuard<'ctx> {
         type_lists.clear();
         function_refs.clear();
         descriptors.reset();
+        layouts.reset();
 
         // SAFETY: We are in maintenance phase, and therefore there are no
         // execution guards alive. Hence, there are no pointers to modules

--- a/third_party/move/mono-move/global-context/tests/context_tests.rs
+++ b/third_party/move/mono-move/global-context/tests/context_tests.rs
@@ -14,7 +14,7 @@ use std::{
 
 #[test]
 fn test_contexts() {
-    let ctx = GlobalContext::with_num_execution_workers(4);
+    let mut ctx = GlobalContext::with_num_execution_workers(4);
 
     {
         let _guard = ctx.try_execution_context(0).unwrap();
@@ -61,96 +61,9 @@ fn test_concurrent_execution_contexts() {
 }
 
 #[test]
-fn test_maintenance_blocks_maintenance() {
-    let num_threads = 2;
-
-    let ctx = Arc::new(GlobalContext::with_num_execution_workers(num_threads));
-    let barrier = Arc::new(Barrier::new(num_threads));
-
-    let handle = thread::spawn({
-        let ctx: Arc<GlobalContext> = Arc::clone(&ctx);
-        let barrier = Arc::clone(&barrier);
-        move || {
-            let _guard = ctx.try_maintenance_context().unwrap();
-
-            // Signal that we have the lock. Sleep for long enough to ensure
-            // the main thread has enough time to try to acquire the guard.
-            barrier.wait();
-            thread::sleep(Duration::from_millis(2000));
-        }
-    });
-
-    // Wait for thread 1 to be in maintenance mode.
-    barrier.wait();
-    thread::sleep(Duration::from_millis(10));
-    assert!(ctx.try_maintenance_context().is_none());
-
-    handle.join().unwrap();
-}
-
-#[test]
-fn test_maintenance_blocks_execution() {
-    let num_threads = 2;
-
-    let ctx = Arc::new(GlobalContext::with_num_execution_workers(num_threads));
-    let barrier = Arc::new(Barrier::new(num_threads));
-
-    let handle = thread::spawn({
-        let ctx: Arc<GlobalContext> = Arc::clone(&ctx);
-        let barrier = Arc::clone(&barrier);
-        move || {
-            let _guard = ctx.try_maintenance_context().unwrap();
-
-            // Signal that we have the lock. Sleep for long enough to ensure
-            // the main thread has enough time to try to acquire the guard.
-            barrier.wait();
-            thread::sleep(Duration::from_millis(2000));
-        }
-    });
-
-    // Wait for thread 1 to be in maintenance mode.
-    barrier.wait();
-    thread::sleep(Duration::from_millis(10));
-    assert!(ctx.try_execution_context(0).is_none());
-
-    handle.join().unwrap();
-}
-
-#[test]
-fn test_execution_blocks_maintenance() {
-    let num_threads = 4;
-
-    let ctx = Arc::new(GlobalContext::with_num_execution_workers(num_threads));
-    let barrier = Arc::new(Barrier::new(num_threads + 1));
-
-    // Spawn multiple threads holding execution guards.
-    let handles: Vec<_> = (0..num_threads)
-        .map(|worker_id| {
-            let ctx: Arc<GlobalContext> = Arc::clone(&ctx);
-            let barrier = Arc::clone(&barrier);
-            thread::spawn(move || {
-                let _guard = ctx.try_execution_context(worker_id).unwrap();
-
-                // Signal that we have the lock.
-                barrier.wait();
-                thread::sleep(Duration::from_millis(2000));
-            })
-        })
-        .collect();
-
-    barrier.wait();
-    thread::sleep(Duration::from_millis(10));
-    assert!(ctx.try_maintenance_context().is_none());
-
-    for handle in handles {
-        handle.join().unwrap();
-    }
-}
-
-#[test]
 fn test_block_execution_simulation() {
     let num_threads = 4;
-    let ctx = Arc::new(GlobalContext::with_num_execution_workers(num_threads));
+    let mut ctx = Arc::new(GlobalContext::with_num_execution_workers(num_threads));
 
     for _ in 0..5 {
         // Execution phase: concurrent execution.
@@ -169,6 +82,7 @@ fn test_block_execution_simulation() {
         }
 
         // Maintenance phase: single thread with exclusive access.
+        let ctx = Arc::get_mut(&mut ctx).unwrap();
         let _guard = ctx.try_maintenance_context().unwrap();
         thread::sleep(Duration::from_millis(100));
     }
@@ -176,7 +90,7 @@ fn test_block_execution_simulation() {
 
 #[test]
 fn test_global_arena_reset() {
-    let ctx = GlobalContext::with_num_execution_workers(1);
+    let mut ctx = GlobalContext::with_num_execution_workers(1);
 
     {
         let guard = ctx.try_execution_context(0).unwrap();

--- a/third_party/move/mono-move/loader/src/loader.rs
+++ b/third_party/move/mono-move/loader/src/loader.rs
@@ -26,8 +26,8 @@ use mono_move_core::{
     interner::{InternedIdentifier, InternedModuleId},
     native::NativeResolver,
     types::{view_name, InternedType, InternedTypeList, EMPTY_TYPE_LIST},
-    DescriptorId, FieldTypes, FrameOffset, Function, FunctionPtr, Interner, ModuleId,
-    ModuleProvider,
+    DescriptorId, FieldTypes, FrameOffset, Function, FunctionPtr, Interner, LayoutId,
+    LayoutProvider, ModuleId, ModuleProvider, TypeLayout,
 };
 use mono_move_gas::GasMeter;
 use mono_move_global_context::{
@@ -791,5 +791,17 @@ impl SpecializerContext for LoweringContext<'_, '_, '_> {
             .loader
             .guard
             .publish_captured_data_descriptor(values_size, pointer_offsets))
+    }
+
+    fn layout_id_for(&self, ty: InternedType) -> Option<LayoutId> {
+        self.loader.guard.layout_id_for(ty)
+    }
+
+    fn layout(&self, id: LayoutId) -> Option<&TypeLayout> {
+        self.loader.guard.layout(id)
+    }
+
+    fn publish_layout(&self, ty: InternedType, layout: TypeLayout) -> LayoutId {
+        self.loader.guard.publish_layout(ty, layout)
     }
 }

--- a/third_party/move/mono-move/loader/src/loader.rs
+++ b/third_party/move/mono-move/loader/src/loader.rs
@@ -27,7 +27,7 @@ use mono_move_core::{
     native::NativeResolver,
     types::{view_name, InternedType, InternedTypeList, EMPTY_TYPE_LIST},
     DescriptorId, FieldTypes, FrameOffset, Function, FunctionPtr, Interner, LayoutId,
-    LayoutProvider, ModuleId, ModuleProvider, TypeLayout,
+    LayoutProvider, ModuleId, ModuleProvider, ValueLayout,
 };
 use mono_move_gas::GasMeter;
 use mono_move_global_context::{
@@ -797,11 +797,11 @@ impl SpecializerContext for LoweringContext<'_, '_, '_> {
         self.loader.guard.layout_id_for(ty)
     }
 
-    fn layout(&self, id: LayoutId) -> Option<&TypeLayout> {
+    fn layout(&self, id: LayoutId) -> Option<&ValueLayout> {
         self.loader.guard.layout(id)
     }
 
-    fn publish_layout(&self, ty: InternedType, layout: TypeLayout) -> LayoutId {
+    fn publish_layout(&self, ty: InternedType, layout: ValueLayout) -> LayoutId {
         self.loader.guard.publish_layout(ty, layout)
     }
 }

--- a/third_party/move/mono-move/runtime/Cargo.toml
+++ b/third_party/move/mono-move/runtime/Cargo.toml
@@ -14,6 +14,7 @@ rust-version = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }
+bcs = { workspace = true }
 mono-move-alloc = { workspace = true }
 mono-move-core = { workspace = true }
 mono-move-gas = { workspace = true }
@@ -26,3 +27,4 @@ thiserror = { workspace = true }
 num-bigint = { workspace = true }
 paste = { workspace = true }
 proptest = { workspace = true }
+serde = { workspace = true }

--- a/third_party/move/mono-move/runtime/src/error.rs
+++ b/third_party/move/mono-move/runtime/src/error.rs
@@ -93,6 +93,18 @@ pub enum RuntimeError {
 
     #[error(transparent)]
     VMInternal(#[from] VMInternalError),
+
+    #[error("BCS deserialize: unexpected end of input")]
+    BcsEof,
+
+    #[error("BCS deserialize: malformed ULEB128 length")]
+    BcsInvalidUleb,
+
+    #[error("BCS deserialize: sequence length {len} exceeds maximum")]
+    BcsSequenceTooLong { len: u64 },
+
+    #[error("BCS deserialize: {remaining} trailing byte(s) after value")]
+    BcsRemainingInput { remaining: usize },
 }
 
 impl IntoExecutionError for RuntimeError {
@@ -122,6 +134,10 @@ impl IntoExecutionError for RuntimeError {
             | AllocationTooLarge { .. }
             | VecAllocSizeOverflow
             | AbortMessageTooLong { .. } => ExecutionErrorKind::RuntimeLimitExceeded,
+
+            BcsEof | BcsInvalidUleb | BcsSequenceTooLong { .. } | BcsRemainingInput { .. } => {
+                ExecutionErrorKind::InvalidOperation
+            },
 
             InvariantViolation(_) => ExecutionErrorKind::InvariantViolation,
             ResourceProvider(e) => e.kind(),
@@ -235,6 +251,12 @@ pub enum RuntimeInvariantViolation {
 
     #[error("descriptor {descriptor_id} not found in descriptor table")]
     DescriptorNotFound { descriptor_id: u32 },
+
+    #[error("type has no published layout")]
+    TypeLayoutNotFound,
+
+    #[error("unreachable: {0}")]
+    Unreachable(String),
 
     #[error("GC scan: invalid object size {size} (expected non-zero, MAX_ALIGN-byte aligned)")]
     GcInvalidObjectSize { size: usize },

--- a/third_party/move/mono-move/runtime/src/error.rs
+++ b/third_party/move/mono-move/runtime/src/error.rs
@@ -95,16 +95,16 @@ pub enum RuntimeError {
     VMInternal(#[from] VMInternalError),
 
     #[error("BCS deserialize: unexpected end of input")]
-    BcsEof,
+    BCSEof,
 
     #[error("BCS deserialize: malformed ULEB128 length")]
-    BcsInvalidUleb,
+    BCSInvalidUleb,
 
     #[error("BCS deserialize: sequence length {len} exceeds maximum")]
-    BcsSequenceTooLong { len: u64 },
+    BCSSequenceTooLong { len: u64 },
 
     #[error("BCS deserialize: {remaining} trailing byte(s) after value")]
-    BcsRemainingInput { remaining: usize },
+    BCSRemainingInput { remaining: usize },
 }
 
 impl IntoExecutionError for RuntimeError {
@@ -135,7 +135,7 @@ impl IntoExecutionError for RuntimeError {
             | VecAllocSizeOverflow
             | AbortMessageTooLong { .. } => ExecutionErrorKind::RuntimeLimitExceeded,
 
-            BcsEof | BcsInvalidUleb | BcsSequenceTooLong { .. } | BcsRemainingInput { .. } => {
+            BCSEof | BCSInvalidUleb | BCSSequenceTooLong { .. } | BCSRemainingInput { .. } => {
                 ExecutionErrorKind::InvalidOperation
             },
 
@@ -253,7 +253,7 @@ pub enum RuntimeInvariantViolation {
     DescriptorNotFound { descriptor_id: u32 },
 
     #[error("type has no published layout")]
-    TypeLayoutNotFound,
+    ValueLayoutNotFound,
 
     #[error("unreachable: {0}")]
     Unreachable(String),

--- a/third_party/move/mono-move/runtime/src/heap/deep_copy.rs
+++ b/third_party/move/mono-move/runtime/src/heap/deep_copy.rs
@@ -9,8 +9,8 @@
 use crate::{
     error::{RuntimeError, RuntimeInvariantViolation},
     heap::{heap_alloc, AllocationError, AllocationResult, Heap},
-    memory::{read_descriptor, read_obj_size, read_ptr, read_u64, write_ptr},
-    types::{VEC_DATA_OFFSET, VEC_LENGTH_OFFSET},
+    memory::{read_descriptor, read_obj_size, read_ptr, read_u64, read_vec_len, write_ptr},
+    types::VEC_DATA_OFFSET,
 };
 use mono_move_core::{
     DescriptorId, DescriptorProvider, ObjectDescriptorInner, CAPTURED_DATA_VALUES_OFFSET,
@@ -41,7 +41,8 @@ impl Heap {
         debug_assert!(src_size >= OBJECT_HEADER_SIZE);
 
         let new_raw = heap_alloc(self, src_size, src_desc_id)?;
-        // SAFETY: `heap_alloc` returns non-null on success.
+        // SAFETY: `heap_alloc` returns non-null on success and this is an
+        // object pointer that cannot be null.
         let new = unsafe { NonNull::new_unchecked(new_raw) };
 
         // SAFETY: regions don't overlap (different allocations).
@@ -117,7 +118,7 @@ impl Heap {
             } => {
                 // SAFETY: length lives at `VEC_LENGTH_OFFSET` of every
                 // vector payload.
-                let length = unsafe { read_u64(new.as_ptr(), VEC_LENGTH_OFFSET) } as usize;
+                let length = unsafe { read_vec_len(new.as_ptr()) as usize };
                 // Length comes from the GC-maintained object header, not from
                 // attacker-controlled bytes, so a debug assertion suffices
                 // (unlike the enum tag, which is validated unconditionally).

--- a/third_party/move/mono-move/runtime/src/heap/mod.rs
+++ b/third_party/move/mono-move/runtime/src/heap/mod.rs
@@ -230,7 +230,7 @@ pub(crate) enum AllocationError {
     RuntimeError(RuntimeError),
 }
 
-type AllocationResult<T> = Result<T, AllocationError>;
+pub(crate) type AllocationResult<T> = Result<T, AllocationError>;
 
 impl From<RuntimeError> for AllocationError {
     fn from(err: RuntimeError) -> Self {
@@ -325,7 +325,7 @@ impl<'a> RootScanner<'a> {
 ///
 /// Returns [`AllocationError::OutOfHeapMemory`] when the heap is full
 /// so the caller can trigger GC and retry.
-fn heap_alloc(
+pub(crate) fn heap_alloc(
     heap: &mut Heap,
     total_size: usize,
     descriptor_id: DescriptorId,

--- a/third_party/move/mono-move/runtime/src/interpreter.rs
+++ b/third_party/move/mono-move/runtime/src/interpreter.rs
@@ -18,8 +18,8 @@ use crate::{
     invariant_violation,
     memory::{
         read_account_address, read_bool, read_descriptor, read_fat_ptr, read_obj_size, read_ptr,
-        read_u32, read_u64, read_u8, vec_elem_ptr, write_bool, write_fat_ptr, write_ptr, write_u32,
-        write_u64, write_u8, MemoryRegion,
+        read_u32, read_u64, read_u8, read_vec_len, vec_elem_ptr, write_bool, write_fat_ptr,
+        write_ptr, write_u32, write_u64, write_u8, MemoryRegion,
     },
     types::{
         StepResult, ABORT_MESSAGE_SIZE_LIMIT, DEFAULT_HEAP_SIZE, DEFAULT_STACK_SIZE,
@@ -35,8 +35,8 @@ use mono_move_core::{
     storage::resource_provider::StorageKey,
     CallClosureOp, ClosureFuncRef, CmpKind, DescriptorId, DescriptorProvider, FrameOffset,
     Function, FunctionRef, IntBinaryOp, IntCastOp, IntNegateOp, IntOperand, IntShiftOp, IntTy,
-    MicroOp, PackClosureOp, ShiftOperand, CAPTURED_DATA_TAG_MATERIALIZED, CAPTURED_DATA_TAG_OFFSET,
-    CAPTURED_DATA_VALUES_OFFSET, CAPTURED_DATA_VALUES_SIZE_OFFSET,
+    LayoutProvider, MicroOp, PackClosureOp, ShiftOperand, CAPTURED_DATA_TAG_MATERIALIZED,
+    CAPTURED_DATA_TAG_OFFSET, CAPTURED_DATA_VALUES_OFFSET, CAPTURED_DATA_VALUES_SIZE_OFFSET,
     CLOSURE_CAPTURED_DATA_PTR_OFFSET, CLOSURE_DESCRIPTOR_ID, CLOSURE_FUNC_REF_OFFSET,
     CLOSURE_MASK_OFFSET, FRAME_METADATA_SIZE, FUNC_REF_PAYLOAD_OFFSET, FUNC_REF_TAG_OFFSET,
     FUNC_REF_TAG_RESOLVED, FUNC_REF_TAG_UNRESOLVED, MAX_ALIGN, OBJECT_HEADER_SIZE,
@@ -45,13 +45,12 @@ use mono_move_gas::GasMeter;
 use move_core_types::int256::{I256, U256};
 use rand::{rngs::StdRng, Rng, SeedableRng};
 use std::ptr::{null, NonNull};
-
 // ---------------------------------------------------------------------------
 // Runtime state
 // ---------------------------------------------------------------------------
 
 /// Interpreter context with a unified call stack and a GC-managed heap.
-pub struct InterpreterContext<'a, T: ExecutionContext + DescriptorProvider> {
+pub struct InterpreterContext<'a, T: ExecutionContext + DescriptorProvider + LayoutProvider> {
     /// Per-transaction context (function resolution, gas counters,
     /// descriptor table, etc.).
     pub(crate) exec_ctx: &'a mut T,
@@ -77,7 +76,7 @@ pub struct InterpreterContext<'a, T: ExecutionContext + DescriptorProvider> {
     rng: StdRng,
 }
 
-impl<'a, T: ExecutionContext + DescriptorProvider> InterpreterContext<'a, T> {
+impl<'a, T: ExecutionContext + DescriptorProvider + LayoutProvider> InterpreterContext<'a, T> {
     pub fn new(exec_ctx: &'a mut T, entry: &Function) -> Self {
         Self::with_heap_size(exec_ctx, entry, DEFAULT_HEAP_SIZE)
     }
@@ -750,7 +749,7 @@ unsafe fn int_cmp_bool(fp: *mut u8, lhs: FrameOffset, op: CmpKind, rhs: &IntOper
 // Interpreter loop
 // ---------------------------------------------------------------------------
 
-impl<T: ExecutionContext + DescriptorProvider> InterpreterContext<'_, T> {
+impl<T: ExecutionContext + DescriptorProvider + LayoutProvider> InterpreterContext<'_, T> {
     #[inline(always)]
     pub fn step(&mut self) -> RuntimeResult<StepResult> {
         // SAFETY: Current function is always a valid, non-null pointer because
@@ -947,19 +946,19 @@ impl<T: ExecutionContext + DescriptorProvider> InterpreterContext<'_, T> {
                 MicroOp::AbortMsg { code, message } => {
                     let code = read_u64(fp, code);
                     let vec_ptr = read_ptr(fp, message);
-                    let message = if vec_ptr.is_null() {
+                    let len = read_vec_len(vec_ptr) as usize;
+                    let message = if len == 0 {
                         String::new()
                     } else {
                         // TODO: charge gas for abort message bytes.
-                        let len = read_u64(vec_ptr, VEC_LENGTH_OFFSET) as usize;
                         if len > ABORT_MESSAGE_SIZE_LIMIT {
                             return Err(RuntimeError::AbortMessageTooLong {
                                 len,
                                 max: ABORT_MESSAGE_SIZE_LIMIT,
                             });
                         }
-                        // SAFETY: `vec_ptr` is non-null (checked above) and
-                        // points at a heap vector with `len` initialized
+                        // SAFETY: `vec_ptr` is non-null for non-zero lengths
+                        // and points at a heap vector with `len` initialized
                         // bytes at `VEC_DATA_OFFSET`.
                         let data = vec_ptr.add(VEC_DATA_OFFSET);
                         String::from_utf8(std::slice::from_raw_parts(data, len).to_vec())
@@ -1140,11 +1139,7 @@ impl<T: ExecutionContext + DescriptorProvider> InterpreterContext<'_, T> {
                 MicroOp::VecLen { dst, vec_ref } => {
                     let (ref_base, ref_off) = read_fat_ptr(fp, vec_ref);
                     let vec_ptr = read_ptr(ref_base, ref_off as usize);
-                    let len = if vec_ptr.is_null() {
-                        0
-                    } else {
-                        read_u64(vec_ptr, VEC_LENGTH_OFFSET)
-                    };
+                    let len = read_vec_len(vec_ptr);
                     write_u64(fp, dst, len);
                 },
 
@@ -1164,7 +1159,7 @@ impl<T: ExecutionContext + DescriptorProvider> InterpreterContext<'_, T> {
                         write_ptr(ref_base, ref_off as usize, vec_ptr);
                     }
 
-                    let len = read_u64(vec_ptr, VEC_LENGTH_OFFSET);
+                    let len = read_vec_len(vec_ptr);
                     let total = read_obj_size(vec_ptr) as usize;
                     let cap_in_elems = ((total - OBJECT_HEADER_SIZE - VEC_DATA_OFFSET)
                         / elem_size as usize) as u64;
@@ -1188,10 +1183,7 @@ impl<T: ExecutionContext + DescriptorProvider> InterpreterContext<'_, T> {
                 } => {
                     let (ref_base, ref_off) = read_fat_ptr(fp, vec_ref);
                     let vec_ptr = read_ptr(ref_base, ref_off as usize);
-                    if vec_ptr.is_null() {
-                        return Err(RuntimeError::PopFromEmptyVector);
-                    }
-                    let len = read_u64(vec_ptr, VEC_LENGTH_OFFSET);
+                    let len = read_vec_len(vec_ptr);
                     if len == 0 {
                         return Err(RuntimeError::PopFromEmptyVector);
                     }
@@ -1213,14 +1205,7 @@ impl<T: ExecutionContext + DescriptorProvider> InterpreterContext<'_, T> {
                     let (ref_base, ref_off) = read_fat_ptr(fp, vec_ref);
                     let vec_ptr = read_ptr(ref_base, ref_off as usize);
                     let idx = read_u64(fp, idx);
-                    if vec_ptr.is_null() {
-                        return Err(RuntimeError::VectorIndexOutOfBounds {
-                            op: VecOp::LoadElem,
-                            idx,
-                            len: 0,
-                        });
-                    }
-                    let len = read_u64(vec_ptr, VEC_LENGTH_OFFSET);
+                    let len = read_vec_len(vec_ptr);
                     if idx >= len {
                         return Err(RuntimeError::VectorIndexOutOfBounds {
                             op: VecOp::LoadElem,
@@ -1244,14 +1229,7 @@ impl<T: ExecutionContext + DescriptorProvider> InterpreterContext<'_, T> {
                     let (ref_base, ref_off) = read_fat_ptr(fp, vec_ref);
                     let vec_ptr = read_ptr(ref_base, ref_off as usize);
                     let idx = read_u64(fp, idx);
-                    if vec_ptr.is_null() {
-                        return Err(RuntimeError::VectorIndexOutOfBounds {
-                            op: VecOp::StoreElem,
-                            idx,
-                            len: 0,
-                        });
-                    }
-                    let len = read_u64(vec_ptr, VEC_LENGTH_OFFSET);
+                    let len = read_vec_len(vec_ptr);
                     if idx >= len {
                         return Err(RuntimeError::VectorIndexOutOfBounds {
                             op: VecOp::StoreElem,
@@ -1276,14 +1254,7 @@ impl<T: ExecutionContext + DescriptorProvider> InterpreterContext<'_, T> {
                     let (ref_base, ref_off) = read_fat_ptr(fp, vec_ref);
                     let vec_ptr = read_ptr(ref_base, ref_off as usize);
                     let idx = read_u64(fp, idx);
-                    if vec_ptr.is_null() {
-                        return Err(RuntimeError::VectorIndexOutOfBounds {
-                            op: VecOp::Borrow,
-                            idx,
-                            len: 0,
-                        });
-                    }
-                    let len = read_u64(vec_ptr, VEC_LENGTH_OFFSET);
+                    let len = read_vec_len(vec_ptr);
                     if idx >= len {
                         return Err(RuntimeError::VectorIndexOutOfBounds {
                             op: VecOp::Borrow,

--- a/third_party/move/mono-move/runtime/src/lib.rs
+++ b/third_party/move/mono-move/runtime/src/lib.rs
@@ -12,6 +12,7 @@ mod local_runtime_context;
 pub(crate) mod memory;
 mod transaction_context;
 mod types;
+mod value_utils;
 mod verifier;
 
 pub use error::{RuntimeError, RuntimeStatus};
@@ -24,8 +25,8 @@ pub use memory::{
     write_u64, MemoryRegion,
 };
 pub use mono_move_core::{
-    DescriptorProvider, ObjectDescriptor, ObjectDescriptorTable, CLOSURE_DESCRIPTOR_ID,
-    TRIVIAL_DESCRIPTOR_ID,
+    DescriptorProvider, LayoutProvider, ObjectDescriptor, ObjectDescriptorTable,
+    CLOSURE_DESCRIPTOR_ID, TRIVIAL_DESCRIPTOR_ID,
 };
 pub use transaction_context::TransactionContext;
 pub use types::{StepResult, VEC_DATA_OFFSET, VEC_LENGTH_OFFSET};

--- a/third_party/move/mono-move/runtime/src/local_runtime_context.rs
+++ b/third_party/move/mono-move/runtime/src/local_runtime_context.rs
@@ -10,7 +10,7 @@ use mono_move_core::{
     native::ProductionNativeRegistry,
     types::{InternedType, InternedTypeList},
     DescriptorId, DescriptorProvider, FunctionPtr, LayoutId, LayoutProvider, ObjectDescriptor,
-    ObjectDescriptorTable, ResourceProvider, TypeLayout, TypeLayoutTable,
+    ObjectDescriptorTable, ResourceProvider, ValueLayout, ValueLayoutTable,
 };
 use mono_move_gas::{GasMeter, NoOpGasMeter, SimpleGasMeter};
 use mono_move_loader::LoaderResult;
@@ -27,7 +27,7 @@ use mono_move_loader::LoaderResult;
 pub struct LocalRuntimeContext<'r, G: GasMeter = NoOpGasMeter> {
     inner: LocalExecutionContext<'r, G>,
     descriptors: ObjectDescriptorTable,
-    layouts: TypeLayoutTable,
+    layouts: ValueLayoutTable,
 }
 
 impl LocalRuntimeContext<'static, NoOpGasMeter> {
@@ -37,7 +37,7 @@ impl LocalRuntimeContext<'static, NoOpGasMeter> {
         Self {
             inner: LocalExecutionContext::unmetered(),
             descriptors: ObjectDescriptorTable::new(),
-            layouts: TypeLayoutTable::new(),
+            layouts: ValueLayoutTable::new(),
         }
     }
 
@@ -46,7 +46,7 @@ impl LocalRuntimeContext<'static, NoOpGasMeter> {
         Self {
             inner: LocalExecutionContext::unmetered(),
             descriptors,
-            layouts: TypeLayoutTable::new(),
+            layouts: ValueLayoutTable::new(),
         }
     }
 }
@@ -63,7 +63,7 @@ impl<'r, G: GasMeter> LocalRuntimeContext<'r, G> {
         Self {
             inner: LocalExecutionContext::new(gas_meter, resource_provider),
             descriptors,
-            layouts: TypeLayoutTable::new(),
+            layouts: ValueLayoutTable::new(),
         }
     }
 }
@@ -75,7 +75,7 @@ impl LocalRuntimeContext<'static, SimpleGasMeter> {
         Self {
             inner: LocalExecutionContext::with_max_budget(),
             descriptors,
-            layouts: TypeLayoutTable::new(),
+            layouts: ValueLayoutTable::new(),
         }
     }
 
@@ -91,7 +91,7 @@ impl LocalRuntimeContext<'static, SimpleGasMeter> {
         Self {
             inner: LocalExecutionContext::with_budget(amount),
             descriptors: ObjectDescriptorTable::new(),
-            layouts: TypeLayoutTable::new(),
+            layouts: ValueLayoutTable::new(),
         }
     }
 }
@@ -141,7 +141,7 @@ impl<'r, G: GasMeter> DescriptorProvider for LocalRuntimeContext<'r, G> {
 }
 
 impl<'r, G: GasMeter> LayoutProvider for LocalRuntimeContext<'r, G> {
-    fn layout(&self, id: LayoutId) -> Option<&TypeLayout> {
+    fn layout(&self, id: LayoutId) -> Option<&ValueLayout> {
         self.layouts.layout(id)
     }
 

--- a/third_party/move/mono-move/runtime/src/local_runtime_context.rs
+++ b/third_party/move/mono-move/runtime/src/local_runtime_context.rs
@@ -8,9 +8,9 @@ use crate::{ExecutionContext, LocalExecutionContext};
 use mono_move_core::{
     interner::{InternedIdentifier, InternedModuleId},
     native::ProductionNativeRegistry,
-    types::InternedTypeList,
-    DescriptorId, DescriptorProvider, FunctionPtr, ObjectDescriptor, ObjectDescriptorTable,
-    ResourceProvider,
+    types::{InternedType, InternedTypeList},
+    DescriptorId, DescriptorProvider, FunctionPtr, LayoutId, LayoutProvider, ObjectDescriptor,
+    ObjectDescriptorTable, ResourceProvider, TypeLayout, TypeLayoutTable,
 };
 use mono_move_gas::{GasMeter, NoOpGasMeter, SimpleGasMeter};
 use mono_move_loader::LoaderResult;
@@ -27,6 +27,7 @@ use mono_move_loader::LoaderResult;
 pub struct LocalRuntimeContext<'r, G: GasMeter = NoOpGasMeter> {
     inner: LocalExecutionContext<'r, G>,
     descriptors: ObjectDescriptorTable,
+    layouts: TypeLayoutTable,
 }
 
 impl LocalRuntimeContext<'static, NoOpGasMeter> {
@@ -36,6 +37,7 @@ impl LocalRuntimeContext<'static, NoOpGasMeter> {
         Self {
             inner: LocalExecutionContext::unmetered(),
             descriptors: ObjectDescriptorTable::new(),
+            layouts: TypeLayoutTable::new(),
         }
     }
 
@@ -44,6 +46,7 @@ impl LocalRuntimeContext<'static, NoOpGasMeter> {
         Self {
             inner: LocalExecutionContext::unmetered(),
             descriptors,
+            layouts: TypeLayoutTable::new(),
         }
     }
 }
@@ -60,6 +63,7 @@ impl<'r, G: GasMeter> LocalRuntimeContext<'r, G> {
         Self {
             inner: LocalExecutionContext::new(gas_meter, resource_provider),
             descriptors,
+            layouts: TypeLayoutTable::new(),
         }
     }
 }
@@ -71,6 +75,7 @@ impl LocalRuntimeContext<'static, SimpleGasMeter> {
         Self {
             inner: LocalExecutionContext::with_max_budget(),
             descriptors,
+            layouts: TypeLayoutTable::new(),
         }
     }
 
@@ -86,6 +91,7 @@ impl LocalRuntimeContext<'static, SimpleGasMeter> {
         Self {
             inner: LocalExecutionContext::with_budget(amount),
             descriptors: ObjectDescriptorTable::new(),
+            layouts: TypeLayoutTable::new(),
         }
     }
 }
@@ -131,5 +137,15 @@ impl<'r, G: GasMeter> ExecutionContext for LocalRuntimeContext<'r, G> {
 impl<'r, G: GasMeter> DescriptorProvider for LocalRuntimeContext<'r, G> {
     fn descriptor(&self, id: DescriptorId) -> Option<&ObjectDescriptor> {
         self.descriptors.descriptor(id)
+    }
+}
+
+impl<'r, G: GasMeter> LayoutProvider for LocalRuntimeContext<'r, G> {
+    fn layout(&self, id: LayoutId) -> Option<&TypeLayout> {
+        self.layouts.layout(id)
+    }
+
+    fn layout_id(&self, ty: InternedType) -> Option<LayoutId> {
+        self.layouts.layout_id(ty)
     }
 }

--- a/third_party/move/mono-move/runtime/src/memory.rs
+++ b/third_party/move/mono-move/runtime/src/memory.rs
@@ -3,7 +3,7 @@
 
 //! Low-level memory utilities: aligned buffer and raw pointer helpers.
 
-use crate::VEC_DATA_OFFSET;
+use crate::{VEC_DATA_OFFSET, VEC_LENGTH_OFFSET};
 use mono_move_core::{DescriptorId, MAX_ALIGN};
 use move_core_types::account_address::AccountAddress;
 use std::alloc::{self, Layout};
@@ -58,6 +58,20 @@ impl Drop for MemoryRegion {
 // ---------------------------------------------------------------------------
 // Raw pointer helpers
 // ---------------------------------------------------------------------------
+
+/// Reads a vector's length, treating the null pointer as the empty vector.
+///
+/// # Safety
+///
+/// `ptr` is null or points to a vector allocation.
+pub unsafe fn read_vec_len(ptr: *mut u8) -> u64 {
+    if ptr.is_null() {
+        0
+    } else {
+        // SAFETY: caller guarantees this is a vector.
+        unsafe { read_u64(ptr, VEC_LENGTH_OFFSET) }
+    }
+}
 
 /// # Safety
 /// `base.add(byte_offset)` must be valid and point to an initialized `u8`.

--- a/third_party/move/mono-move/runtime/src/transaction_context.rs
+++ b/third_party/move/mono-move/runtime/src/transaction_context.rs
@@ -12,7 +12,7 @@ use mono_move_core::{
     native::ProductionNativeRegistry,
     types::{InternedType, InternedTypeList},
     DescriptorId, DescriptorProvider, FunctionPtr, LayoutId, LayoutProvider, ObjectDescriptor,
-    ResourceProvider, TypeLayout,
+    ResourceProvider, ValueLayout,
 };
 use mono_move_gas::GasMeter;
 use mono_move_loader::{Loader, LoaderResult, ModuleReadSet};
@@ -103,7 +103,7 @@ impl<'guard, 'ctx, G: GasMeter> DescriptorProvider for TransactionContext<'guard
 }
 
 impl<'guard, 'ctx, G: GasMeter> LayoutProvider for TransactionContext<'guard, 'ctx, G> {
-    fn layout(&self, id: LayoutId) -> Option<&TypeLayout> {
+    fn layout(&self, id: LayoutId) -> Option<&ValueLayout> {
         self.loader.guard().layout(id)
     }
 

--- a/third_party/move/mono-move/runtime/src/transaction_context.rs
+++ b/third_party/move/mono-move/runtime/src/transaction_context.rs
@@ -10,8 +10,9 @@ use crate::ExecutionContext;
 use mono_move_core::{
     interner::{InternedIdentifier, InternedModuleId},
     native::ProductionNativeRegistry,
-    types::InternedTypeList,
-    DescriptorId, DescriptorProvider, FunctionPtr, ObjectDescriptor, ResourceProvider,
+    types::{InternedType, InternedTypeList},
+    DescriptorId, DescriptorProvider, FunctionPtr, LayoutId, LayoutProvider, ObjectDescriptor,
+    ResourceProvider, TypeLayout,
 };
 use mono_move_gas::GasMeter;
 use mono_move_loader::{Loader, LoaderResult, ModuleReadSet};
@@ -98,5 +99,15 @@ impl<'guard, 'ctx, G: GasMeter> ExecutionContext for TransactionContext<'guard, 
 impl<'guard, 'ctx, G: GasMeter> DescriptorProvider for TransactionContext<'guard, 'ctx, G> {
     fn descriptor(&self, id: DescriptorId) -> Option<&ObjectDescriptor> {
         self.loader.guard().descriptor(id)
+    }
+}
+
+impl<'guard, 'ctx, G: GasMeter> LayoutProvider for TransactionContext<'guard, 'ctx, G> {
+    fn layout(&self, id: LayoutId) -> Option<&TypeLayout> {
+        self.loader.guard().layout(id)
+    }
+
+    fn layout_id(&self, ty: InternedType) -> Option<LayoutId> {
+        self.loader.guard().layout_id(ty)
     }
 }

--- a/third_party/move/mono-move/runtime/src/value_utils.rs
+++ b/third_party/move/mono-move/runtime/src/value_utils.rs
@@ -1,23 +1,26 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-//! Operations over value trees driven by value layouts.
-//!
-//!   - [`const_serialized_size`]: calculates BCS serialized size, if it is
-//!     fixed.
-//!   - [`serialized_size`]: returns BCS serialized size of an in-memory value.
-//!   - [`serialize`]: returns BCS-serialized bytes of an in-memory value.
-//!   - [`equals`]: structural equality of two values.
-//!   - [`compare`]: structural comparison of two values.
-//!   - [`deserialize`]: deserializes BCS bytes into in-memory representation,
-//!     allocating data on the heap if needed (e.g., for vectors). Fails if
-//!     there is not enough heap space.
+//! Operations over value trees driven by value layouts: BCS-serializing an
+//! in-memory value and reporting its serialized size (fixed when the type
+//! allows, otherwise computed by walking the value), deserializing BCS bytes
+//! back into the flat in-memory representation (allocating heap storage for
+//! vectors, and failing rather than running GC when heap space runs out), and
+//! comparing two values for structural equality and ordering.
 //!
 //! TODO(correctness):
 //!   Current implementation works only for little-endian architectures,
 //!   we should revisit it to have big-endian working as well. In particular,
 //!   serialization fast-path via memcpy or integer comparison are broken for
 //!   big endian hosts.
+//!
+//! TODO:
+//!   Unify these value walks (serialize, deserialize, equals, compare) under a
+//!   shared visitor/fold abstraction instead of four parallel recursive
+//!   implementations.
+//!
+//! TODO(test):
+//!   Add differential tests for these walks against the existing Move VM.
 
 use crate::{
     error::{RuntimeError, RuntimeInvariantViolation, RuntimeResult},
@@ -26,20 +29,20 @@ use crate::{
     types::{VEC_DATA_OFFSET, VEC_LENGTH_OFFSET},
 };
 use mono_move_core::{
-    types::InternedType, LayoutId, LayoutKind, LayoutProvider, TypeLayout, OBJECT_HEADER_SIZE,
+    types::InternedType, LayoutId, LayoutKind, LayoutProvider, ValueLayout, OBJECT_HEADER_SIZE,
 };
 use move_core_types::int256::{I256, U256};
 use std::cmp::Ordering;
 
-/// Returns the BCS size of the type if it has one, and it is a constant.
-/// Returns [`None`] otherwise (e.g., for enums, function values, etc.).
+/// Returns the fixed BCS size of a value of the given type, or [`None`] when it
+/// is data-dependent (e.g., for vectors, enums, function values, etc.).
 #[allow(dead_code)]
-pub fn const_serialized_size<T: LayoutProvider + ?Sized>(
+pub fn fixed_serialized_size<T: LayoutProvider + ?Sized>(
     layouts: &T,
     ty: InternedType,
-) -> RuntimeResult<Option<u32>> {
+) -> RuntimeResult<Option<usize>> {
     let layout = layouts.layout_by_ty(ty).ok_or_else(layout_not_found)?;
-    Ok(layout.const_serialized_size())
+    Ok(layout.fixed_serialized_size().map(|n| n as usize))
 }
 
 /// Returns the BCS serialized size the value stored at `base` of the given type.
@@ -75,7 +78,7 @@ pub unsafe fn serialize<T: LayoutProvider + ?Sized>(
     let layout = layouts.layout_by_ty(ty).ok_or_else(layout_not_found)?;
 
     let mut out = vec![];
-    if let Some(serialized_size) = layout.const_serialized_size() {
+    if let Some(serialized_size) = layout.fixed_serialized_size() {
         out.reserve(serialized_size as usize);
     }
 
@@ -93,9 +96,11 @@ pub unsafe fn serialize<T: LayoutProvider + ?Sized>(
 unsafe fn serialize_impl<T: LayoutProvider + ?Sized>(
     layouts: &T,
     base: *const u8,
-    layout: &TypeLayout,
+    layout: &ValueLayout,
     out: &mut Vec<u8>,
 ) -> RuntimeResult<()> {
+    // TODO: This walk recurses on struct fields and vector elements; convert it
+    // to a non-recursive form to bound stack depth on deeply nested values.
     if layout.has_no_pointers_no_padding() {
         // SAFETY: for values with no padding and pointers, value's in-memory
         // bytes are its BCS encoding.
@@ -107,7 +112,10 @@ unsafe fn serialize_impl<T: LayoutProvider + ?Sized>(
     }
 
     match &layout.kind {
-        LayoutKind::UnsignedInt | LayoutKind::SignedInt | LayoutKind::Address => Err(unreachable(
+        LayoutKind::Bool
+        | LayoutKind::UnsignedInt
+        | LayoutKind::SignedInt
+        | LayoutKind::Address => Err(unreachable(
             "Primitive types have no padding / pointers and must be already handled",
         )),
         LayoutKind::Struct { fields } => {
@@ -129,7 +137,7 @@ unsafe fn serialize_impl<T: LayoutProvider + ?Sized>(
             let vec_ptr = unsafe { read_ptr(base, 0usize) };
             let len = unsafe { read_vec_len(vec_ptr) };
             if len > bcs::MAX_SEQUENCE_LENGTH as u64 {
-                return Err(RuntimeError::BcsSequenceTooLong { len });
+                return Err(RuntimeError::BCSSequenceTooLong { len });
             }
             write_uleb128_len(out, len);
             if len == 0 {
@@ -172,17 +180,17 @@ unsafe fn serialize_impl<T: LayoutProvider + ?Sized>(
     }
 }
 
-/// Structural equality of two values of the given type.
+/// Structural equality of two non-reference values of the given type.
 ///
 /// # Safety
 ///
 /// Input pointers `a` and `b` must point to fully initialized values of the
 /// given type.
 ///
-/// # Invariant
+/// # Precondition
 ///
-/// The reference values, the caller must read the reference to obtain the
-/// `base` pointer to the actual data.
+/// For reference values, the caller must first read the reference to obtain
+/// the `base` pointer to the actual data; these walks operate on the pointee.
 #[allow(dead_code)]
 pub unsafe fn equals<T: LayoutProvider + ?Sized>(
     layouts: &T,
@@ -202,16 +210,18 @@ pub unsafe fn equals<T: LayoutProvider + ?Sized>(
 /// Input pointers `a` and `b` must point to fully initialized values with the
 /// given layout.
 ///
-/// # Invariant
+/// # Precondition
 ///
-/// The reference values, the caller must read the reference to obtain the
-/// `base` pointer to the actual data.
+/// For reference values, the caller must first read the reference to obtain
+/// the `base` pointer to the actual data; these walks operate on the pointee.
 unsafe fn equals_impl<T: LayoutProvider + ?Sized>(
     layouts: &T,
     a: *const u8,
     b: *const u8,
     id: LayoutId,
 ) -> RuntimeResult<bool> {
+    // TODO: This walk recurses on struct fields and vector elements; convert it
+    // to a non-recursive form to bound stack depth on deeply nested values.
     let layout = layouts.layout(id).ok_or_else(layout_not_found)?;
 
     if layout.has_no_pointers_no_padding() {
@@ -221,7 +231,10 @@ unsafe fn equals_impl<T: LayoutProvider + ?Sized>(
     }
 
     match &layout.kind {
-        LayoutKind::UnsignedInt | LayoutKind::SignedInt | LayoutKind::Address => Err(unreachable(
+        LayoutKind::Bool
+        | LayoutKind::UnsignedInt
+        | LayoutKind::SignedInt
+        | LayoutKind::Address => Err(unreachable(
             "Primitive layouts must be handled by fast-path",
         )),
         LayoutKind::Struct { fields } => {
@@ -307,10 +320,10 @@ unsafe fn equals_impl<T: LayoutProvider + ?Sized>(
 /// Input pointers `a` and `b` must point to fully initialized values with the
 /// given layout.
 ///
-/// # Invariant
+/// # Precondition
 ///
-/// The reference values, the caller must read the reference to obtain the
-/// `base` pointer to the actual data.
+/// For reference values, the caller must first read the reference to obtain
+/// the `base` pointer to the actual data; these walks operate on the pointee.
 #[allow(dead_code)]
 pub unsafe fn compare<T: LayoutProvider + ?Sized>(
     layouts: &T,
@@ -323,29 +336,38 @@ pub unsafe fn compare<T: LayoutProvider + ?Sized>(
     unsafe { compare_impl(layouts, a, b, id) }
 }
 
-/// Implementation of structural comparison of two values of the given layout.
+/// Implementation of structural comparison of two non-reference values of the
+/// given layout.
 ///
 /// # Safety
 ///
 /// Input pointers `a` and `b` must point to fully initialized values with the
 /// given layout.
 ///
-/// # Invariant
+/// # Precondition
 ///
-/// The reference values, the caller must read the reference to obtain the
-/// `base` pointer to the actual data.
+/// For reference values, the caller must first read the reference to obtain
+/// the `base` pointer to the actual data; these walks operate on the pointee.
 unsafe fn compare_impl<T: LayoutProvider + ?Sized>(
     layouts: &T,
     a: *const u8,
     b: *const u8,
     id: LayoutId,
 ) -> RuntimeResult<Ordering> {
+    // TODO: This walk recurses on struct fields and vector elements; convert it
+    // to a non-recursive form to bound stack depth on deeply nested values.
     let layout = layouts.layout(id).ok_or_else(layout_not_found)?;
     match &layout.kind {
-        LayoutKind::UnsignedInt => {
+        // A `bool` is a 1-byte `0`/`1` value, so it compares like a `u8`.
+        LayoutKind::Bool | LayoutKind::UnsignedInt => {
             // Read the little-endian bytes into the native integer of the
             // matching width and compare numerically. `from_le_bytes` keeps
             // this correct on any host endianness.
+            //
+            // TODO: These are unaligned, little-endian numeric reads, distinct
+            // from the aligned native-endian helpers in `memory.rs`. Endianness
+            // makes unifying the two non-trivial; revisit whether a shared set
+            // of typed read helpers can serve both.
             //
             // SAFETY: both pointers point to a valid `layout.size`-byte region.
             Ok(unsafe {
@@ -444,8 +466,14 @@ unsafe fn compare_impl<T: LayoutProvider + ?Sized>(
 /// # Allocating semantics
 ///
 /// May allocate data on the heap, e.g. for vectors. **Never runs GC** and
-/// instead fails if there is not enough heap space. It is responsibility of
-/// the caller to run GC and retry.
+/// instead fails gracefully with an [`AllocationError`] if there is not enough
+/// heap space; it is the caller's responsibility to run GC and retry. Heap
+/// exhaustion is a normal error, never undefined behavior.
+///
+/// # Precondition
+///
+/// The given type must not be a reference: references are never serialized or
+/// deserialized.
 ///
 /// # Safety
 ///
@@ -465,7 +493,7 @@ pub unsafe fn deserialize<T: LayoutProvider + ?Sized>(
     // SAFETY: caller must enforce the safety precondition.
     unsafe { deserialize_impl(layouts, heap, layout, bytes, &mut cursor, dst)? };
     if cursor != bytes.len() {
-        return Err(RuntimeError::BcsRemainingInput {
+        return Err(RuntimeError::BCSRemainingInput {
             remaining: bytes.len().saturating_sub(cursor),
         }
         .into());
@@ -479,11 +507,14 @@ pub unsafe fn deserialize<T: LayoutProvider + ?Sized>(
 unsafe fn deserialize_impl<T: LayoutProvider + ?Sized>(
     layouts: &T,
     heap: &mut Heap,
-    layout: &TypeLayout,
+    layout: &ValueLayout,
     bytes: &[u8],
     cursor: &mut usize,
     dst: *mut u8,
 ) -> AllocationResult<()> {
+    // TODO: This walk recurses on struct fields and vector elements; convert it
+    // to a non-recursive form to bound stack depth on deeply nested values.
+    //
     // If no padding or no pointers, value's BCS bytes are exactly its
     // in-memory image.
     // TODO(correctness): breaks on big-endian hosts. This writes the
@@ -499,7 +530,10 @@ unsafe fn deserialize_impl<T: LayoutProvider + ?Sized>(
     }
 
     match &layout.kind {
-        LayoutKind::UnsignedInt | LayoutKind::SignedInt | LayoutKind::Address => {
+        LayoutKind::Bool
+        | LayoutKind::UnsignedInt
+        | LayoutKind::SignedInt
+        | LayoutKind::Address => {
             Err(unreachable("Primitive layouts must be handled by fast-path").into())
         },
         LayoutKind::Struct { fields } => {
@@ -527,7 +561,7 @@ unsafe fn deserialize_impl<T: LayoutProvider + ?Sized>(
         } => {
             let len = read_uleb128_len(bytes, cursor)?;
             if len > bcs::MAX_SEQUENCE_LENGTH as u64 {
-                return Err(RuntimeError::BcsSequenceTooLong { len }.into());
+                return Err(RuntimeError::BCSSequenceTooLong { len }.into());
             }
             if len == 0 {
                 // The empty vector is the null pointer.
@@ -633,14 +667,17 @@ unsafe fn bytes_cmp(a: *const u8, b: *const u8, n: usize) -> Ordering {
 /// Borrows the next `n` bytes, advancing the cursor. Returns an error if
 /// there is not enough bytes to read or the size of the slice overflows.
 fn read_slice<'b>(bytes: &'b [u8], cursor: &mut usize, n: usize) -> RuntimeResult<&'b [u8]> {
-    let end = cursor.checked_add(n).ok_or_else(|| RuntimeError::BcsEof)?;
+    let end = cursor.checked_add(n).ok_or_else(|| RuntimeError::BCSEof)?;
     if end > bytes.len() {
-        return Err(RuntimeError::BcsEof);
+        return Err(RuntimeError::BCSEof);
     }
     let slice = &bytes[*cursor..end];
     *cursor = end;
     Ok(slice)
 }
+
+// TODO: See if we can reuse move-binary-format's uleb128 APIs instead of
+// reimplementing the encode/decode here.
 
 /// Writes ULEB128-encoded length data.
 fn write_uleb128_len(out: &mut Vec<u8>, mut v: u64) {
@@ -665,7 +702,7 @@ fn read_uleb128_len(bytes: &[u8], cursor: &mut usize) -> RuntimeResult<u64> {
     let mut result = 0u64;
     let mut shift = 0u32;
     loop {
-        let byte = *bytes.get(*cursor).ok_or_else(|| RuntimeError::BcsEof)?;
+        let byte = *bytes.get(*cursor).ok_or_else(|| RuntimeError::BCSEof)?;
         *cursor += 1;
 
         let cur = (byte & 0x7F) as u64;
@@ -673,13 +710,13 @@ fn read_uleb128_len(bytes: &[u8], cursor: &mut usize) -> RuntimeResult<u64> {
         // shift count is out of range, or the high bits would be truncated (e.g.
         // a terminal `0x02` on the 10th byte where `shift == 63`).
         if shift >= 64 || (cur << shift) >> shift != cur {
-            return Err(RuntimeError::BcsInvalidUleb);
+            return Err(RuntimeError::BCSInvalidUleb);
         }
         result |= cur << shift;
         if byte & 0x80 == 0 {
             // Reject a non-minimal encoding (a trailing zero continuation).
             if byte == 0 && shift != 0 {
-                return Err(RuntimeError::BcsInvalidUleb);
+                return Err(RuntimeError::BCSInvalidUleb);
             }
             return Ok(result);
         }
@@ -689,7 +726,7 @@ fn read_uleb128_len(bytes: &[u8], cursor: &mut usize) -> RuntimeResult<u64> {
 
 /// Invariant violation error when layout is not available during value walk.
 fn layout_not_found() -> RuntimeError {
-    RuntimeError::InvariantViolation(RuntimeInvariantViolation::TypeLayoutNotFound)
+    RuntimeError::InvariantViolation(RuntimeInvariantViolation::ValueLayoutNotFound)
 }
 
 /// An invariant violation for an unreachable state.
@@ -702,9 +739,9 @@ mod tests {
     use super::*;
     use crate::heap::AllocationError;
     use mono_move_core::{
-        type_layout::{U16_LAYOUT_ID, U64_LAYOUT_ID, U8_LAYOUT_ID},
         types::U64_TY,
-        DescriptorId, FieldTypeLayout, LayoutFlags, LayoutId, TypeLayoutTable,
+        value_layout::{U16_LAYOUT_ID, U64_LAYOUT_ID, U8_LAYOUT_ID},
+        DescriptorId, FieldValueLayout, LayoutFlags, LayoutId, ValueLayoutTable,
     };
     use serde::Serialize;
     use std::mem::{offset_of, size_of};
@@ -713,14 +750,14 @@ mod tests {
         x as *const T as *const u8
     }
 
-    fn vector_layout(elem_id: LayoutId) -> TypeLayout {
-        TypeLayout::vector(elem_id, DescriptorId(2))
+    fn vector_layout(elem_id: LayoutId) -> ValueLayout {
+        ValueLayout::vector(elem_id, DescriptorId(2))
     }
 
     #[test]
     fn deserialize_empty_vector_is_null() {
         let mut heap = Heap::new(4096);
-        let table = TypeLayoutTable::new();
+        let table = ValueLayoutTable::new();
         let layout = vector_layout(U8_LAYOUT_ID);
         let bytes = [0u8]; // ULEB len 0.
         let mut slot = 0u64;
@@ -742,7 +779,7 @@ mod tests {
 
     #[test]
     fn deserialize_out_of_heap_memory_errors() {
-        let mut table = TypeLayoutTable::new();
+        let mut table = ValueLayoutTable::new();
         let vid = table.push(U64_TY, vector_layout(U64_LAYOUT_ID));
         let layout = table.layout(vid).unwrap();
         // The vector for 1000 u64s far exceeds this heap, so allocation fails.
@@ -800,7 +837,7 @@ mod tests {
         let mut cursor = 0;
         assert!(matches!(
             read_uleb128_len(&bytes, &mut cursor),
-            Err(RuntimeError::BcsInvalidUleb)
+            Err(RuntimeError::BCSInvalidUleb)
         ));
     }
 
@@ -813,7 +850,7 @@ mod tests {
         let mut cursor = 0;
         assert!(matches!(
             read_uleb128_len(&bytes, &mut cursor),
-            Err(RuntimeError::BcsInvalidUleb)
+            Err(RuntimeError::BCSInvalidUleb)
         ));
     }
 
@@ -824,7 +861,7 @@ mod tests {
         let mut cursor = 0;
         assert!(matches!(
             read_uleb128_len(&bytes, &mut cursor),
-            Err(RuntimeError::BcsInvalidUleb)
+            Err(RuntimeError::BCSInvalidUleb)
         ));
     }
 
@@ -835,14 +872,14 @@ mod tests {
         let mut cursor = 0;
         assert!(matches!(
             read_uleb128_len(&bytes, &mut cursor),
-            Err(RuntimeError::BcsEof)
+            Err(RuntimeError::BCSEof)
         ));
     }
 
     #[test]
     fn deserialize_rejects_trailing_bytes() {
-        let mut table = TypeLayoutTable::new();
-        table.push(U64_TY, TypeLayout::u64());
+        let mut table = ValueLayoutTable::new();
+        table.push(U64_TY, ValueLayout::u64());
         let mut heap = Heap::new(4096);
 
         let mut bytes = bcs::to_bytes(&7u64).unwrap();
@@ -860,7 +897,7 @@ mod tests {
         assert!(matches!(
             result,
             Err(AllocationError::RuntimeError(
-                RuntimeError::BcsRemainingInput { remaining: 1 }
+                RuntimeError::BCSRemainingInput { remaining: 1 }
             ))
         ));
     }
@@ -868,14 +905,14 @@ mod tests {
     /// Builds a struct layout from field offsets/ids and the in-memory size,
     /// deriving the const BCS size and no-padding flag as the specializer does.
     fn build_struct_layout(
-        table: &TypeLayoutTable,
+        table: &ValueLayoutTable,
         size: u32,
         fields: Vec<(u32, LayoutId)>,
-    ) -> TypeLayout {
+    ) -> ValueLayout {
         let mut const_total = 0u64;
         let mut data_dependent = false;
         for &(_, id) in &fields {
-            match table.layout(id).unwrap().const_serialized_size() {
+            match table.layout(id).unwrap().fixed_serialized_size() {
                 Some(n) => const_total += n as u64,
                 None => data_dependent = true,
             }
@@ -887,10 +924,10 @@ mod tests {
         }
         let field_layouts = fields
             .into_iter()
-            .map(|(offset, id)| FieldTypeLayout { offset, id })
+            .map(|(offset, id)| FieldValueLayout { offset, id })
             .collect::<Vec<_>>()
             .into_boxed_slice();
-        TypeLayout::struct_layout(size, 8, const_bcs, flags, field_layouts)
+        ValueLayout::struct_layout(size, 8, const_bcs, flags, field_layouts)
     }
 
     /// Checks the walks for a fixed-size struct against the Rust oracle:
@@ -902,7 +939,7 @@ mod tests {
     /// Every value must match the layout at `id`, and `size` must be that
     /// layout's in-memory size.
     unsafe fn check_struct<S: Serialize + Ord>(
-        table: &TypeLayoutTable,
+        table: &ValueLayoutTable,
         id: LayoutId,
         values: &[S],
         size: usize,
@@ -912,7 +949,7 @@ mod tests {
 
         // Const size is the packed BCS size; blittable iff that equals the
         // in-memory size.
-        assert_eq!(layout.const_serialized_size(), Some(bcs_len as u32));
+        assert_eq!(layout.fixed_serialized_size(), Some(bcs_len as u32));
         assert_eq!(layout.has_no_pointers_no_padding(), bcs_len == size);
 
         for x in values {
@@ -969,13 +1006,13 @@ mod tests {
             b: u64,
         }
 
-        let mut table = TypeLayoutTable::new();
+        let mut table = ValueLayoutTable::new();
         let layout = build_struct_layout(&table, size_of::<S>() as u32, vec![
             (offset_of!(S, a) as u32, U8_LAYOUT_ID),
             (offset_of!(S, b) as u32, U64_LAYOUT_ID),
         ]);
         // In-memory 16, BCS 9 (7 bytes padding), so not blittable.
-        assert_eq!(layout.const_serialized_size(), Some(9));
+        assert_eq!(layout.fixed_serialized_size(), Some(9));
         assert!(!layout.has_no_pointers_no_padding());
 
         let id = table.push(U64_TY, layout);
@@ -1001,13 +1038,13 @@ mod tests {
             b: u64,
         }
 
-        let mut table = TypeLayoutTable::new();
+        let mut table = ValueLayoutTable::new();
         let layout = build_struct_layout(&table, size_of::<S>() as u32, vec![
             (offset_of!(S, a) as u32, U64_LAYOUT_ID),
             (offset_of!(S, b) as u32, U64_LAYOUT_ID),
         ]);
         // No padding: BCS 16 equals in-memory 16, so blittable.
-        assert_eq!(layout.const_serialized_size(), Some(16));
+        assert_eq!(layout.fixed_serialized_size(), Some(16));
         assert!(layout.has_no_pointers_no_padding());
 
         let id = table.push(U64_TY, layout);
@@ -1035,13 +1072,13 @@ mod tests {
             c: u64,
         }
 
-        let mut table = TypeLayoutTable::new();
+        let mut table = ValueLayoutTable::new();
         let layout = build_struct_layout(&table, size_of::<S>() as u32, vec![
             (offset_of!(S, a) as u32, U16_LAYOUT_ID),
             (offset_of!(S, b) as u32, U8_LAYOUT_ID),
             (offset_of!(S, c) as u32, U64_LAYOUT_ID),
         ]);
-        assert_eq!(layout.const_serialized_size(), Some(11));
+        assert_eq!(layout.fixed_serialized_size(), Some(11));
         assert!(!layout.has_no_pointers_no_padding());
 
         let id = table.push(U64_TY, layout);
@@ -1075,7 +1112,7 @@ mod tests {
             y: u8,
         }
 
-        let mut table = TypeLayoutTable::new();
+        let mut table = ValueLayoutTable::new();
         let inner = build_struct_layout(&table, size_of::<Inner>() as u32, vec![
             (offset_of!(Inner, a) as u32, U64_LAYOUT_ID),
             (offset_of!(Inner, b) as u32, U64_LAYOUT_ID),
@@ -1088,7 +1125,7 @@ mod tests {
         ]);
         // Outer is BCS 17, size 24 (trailing pad): a blittable child (Inner)
         // does not make the parent blittable.
-        assert_eq!(outer.const_serialized_size(), Some(17));
+        assert_eq!(outer.fixed_serialized_size(), Some(17));
         assert!(!outer.has_no_pointers_no_padding());
 
         let id = table.push(U64_TY, outer);
@@ -1126,7 +1163,7 @@ mod tests {
     ///
     /// `id` and `size` must be the layout and in-memory size matching `S`.
     unsafe fn check_roundtrip<S: Serialize + Ord>(
-        table: &TypeLayoutTable,
+        table: &ValueLayoutTable,
         id: LayoutId,
         size: usize,
         values: &[S],
@@ -1174,9 +1211,9 @@ mod tests {
 
     #[test]
     fn test_vector_u64() {
-        let mut table = TypeLayoutTable::new();
+        let mut table = ValueLayoutTable::new();
         let vid = table.push(U64_TY, vector_layout(U64_LAYOUT_ID));
-        assert_eq!(table.layout(vid).unwrap().const_serialized_size(), None);
+        assert_eq!(table.layout(vid).unwrap().fixed_serialized_size(), None);
         let values: [Vec<u64>; 7] = [
             vec![],
             vec![1],
@@ -1191,7 +1228,7 @@ mod tests {
 
     #[test]
     fn test_vector_u8() {
-        let mut table = TypeLayoutTable::new();
+        let mut table = ValueLayoutTable::new();
         let vid = table.push(U64_TY, vector_layout(U8_LAYOUT_ID));
         let values = vec![
             vec![],
@@ -1206,7 +1243,7 @@ mod tests {
 
     #[test]
     fn test_vector_nested() {
-        let mut table = TypeLayoutTable::new();
+        let mut table = ValueLayoutTable::new();
         // `vector<vector<u64>>`: the element is a vector pointer (not
         // blittable), so the walks recurse per element.
         let inner_id = table.push(U64_TY, vector_layout(U64_LAYOUT_ID));
@@ -1233,7 +1270,7 @@ mod tests {
             v: u64,
         }
 
-        let mut table = TypeLayoutTable::new();
+        let mut table = ValueLayoutTable::new();
         let kv_layout = build_struct_layout(&table, size_of::<Kv>() as u32, vec![
             (offset_of!(Kv, k) as u32, U8_LAYOUT_ID),
             (offset_of!(Kv, v) as u32, U64_LAYOUT_ID),
@@ -1262,12 +1299,12 @@ mod tests {
             items: Vec<u64>,
         }
 
-        let mut table = TypeLayoutTable::new();
+        let mut table = ValueLayoutTable::new();
         let vec_id = table.push(U64_TY, vector_layout(U64_LAYOUT_ID));
         let bag_layout = build_struct_layout(&table, 16, vec![(0, U64_LAYOUT_ID), (8, vec_id)]);
         let id = table.push(U64_TY, bag_layout);
         // The vector field makes the struct data-dependent and not blittable.
-        assert_eq!(table.layout(id).unwrap().const_serialized_size(), None);
+        assert_eq!(table.layout(id).unwrap().fixed_serialized_size(), None);
         assert!(!table.layout(id).unwrap().has_no_pointers_no_padding());
 
         let values: [Bag; 5] = [
@@ -1304,7 +1341,7 @@ mod prop_tests {
             ADDRESS_TY, BOOL_TY, I128_TY, I16_TY, I256_TY, I32_TY, I64_TY, I8_TY, U128_TY, U16_TY,
             U256_TY, U32_TY, U64_TY, U8_TY,
         },
-        TypeLayoutTable,
+        ValueLayoutTable,
     };
     use move_core_types::{
         account_address::AccountAddress,
@@ -1317,7 +1354,7 @@ mod prop_tests {
             proptest! {
                 #[test]
                 fn $name(x in $strat, y in $strat) {
-                    let table = TypeLayoutTable::new();
+                    let table = ValueLayoutTable::new();
                     let mut heap = Heap::new(128);
                     let size = std::mem::size_of::<$t>();
                     let bytes = bcs::to_bytes(&x).unwrap();
@@ -1325,8 +1362,8 @@ mod prop_tests {
 
                     // Constant serialized size is the fixed width.
                     prop_assert_eq!(
-                        const_serialized_size(&table, $ty).unwrap(),
-                        Some(size as u32)
+                        fixed_serialized_size(&table, $ty).unwrap(),
+                        Some(size)
                     );
 
                     let px = &x as *const $t as *const u8;

--- a/third_party/move/mono-move/runtime/src/value_utils.rs
+++ b/third_party/move/mono-move/runtime/src/value_utils.rs
@@ -1,0 +1,1409 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Operations over value trees driven by value layouts.
+//!
+//!   - [`const_serialized_size`]: calculates BCS serialized size, if it is
+//!     fixed.
+//!   - [`serialized_size`]: returns BCS serialized size of an in-memory value.
+//!   - [`serialize`]: returns BCS-serialized bytes of an in-memory value.
+//!   - [`equals`]: structural equality of two values.
+//!   - [`compare`]: structural comparison of two values.
+//!   - [`deserialize`]: deserializes BCS bytes into in-memory representation,
+//!     allocating data on the heap if needed (e.g., for vectors). Fails if
+//!     there is not enough heap space.
+//!
+//! TODO(correctness):
+//!   Current implementation works only for little-endian architectures,
+//!   we should revisit it to have big-endian working as well. In particular,
+//!   serialization fast-path via memcpy or integer comparison are broken for
+//!   big endian hosts.
+
+use crate::{
+    error::{RuntimeError, RuntimeInvariantViolation, RuntimeResult},
+    heap::{heap_alloc, AllocationResult, Heap},
+    memory::{read_ptr, read_vec_len, write_ptr, write_u64},
+    types::{VEC_DATA_OFFSET, VEC_LENGTH_OFFSET},
+};
+use mono_move_core::{
+    types::InternedType, LayoutId, LayoutKind, LayoutProvider, TypeLayout, OBJECT_HEADER_SIZE,
+};
+use move_core_types::int256::{I256, U256};
+use std::cmp::Ordering;
+
+/// Returns the BCS size of the type if it has one, and it is a constant.
+/// Returns [`None`] otherwise (e.g., for enums, function values, etc.).
+#[allow(dead_code)]
+pub fn const_serialized_size<T: LayoutProvider + ?Sized>(
+    layouts: &T,
+    ty: InternedType,
+) -> RuntimeResult<Option<u32>> {
+    let layout = layouts.layout_by_ty(ty).ok_or_else(layout_not_found)?;
+    Ok(layout.const_serialized_size())
+}
+
+/// Returns the BCS serialized size the value stored at `base` of the given type.
+///
+/// # Safety
+///
+/// `base` must point to a fully initialized value of the given type, and must
+/// remain valid (with all reachable heap objects live) throughout the call.
+#[allow(dead_code)]
+pub unsafe fn serialized_size<T: LayoutProvider + ?Sized>(
+    layouts: &T,
+    base: *const u8,
+    ty: InternedType,
+) -> RuntimeResult<usize> {
+    // TODO: Implement a more efficient serialized size implementation:
+    //   - Use constant serialized size as fast path
+    //   - Avoid allocations into buffer when serializing.
+    unsafe { serialize(layouts, base, ty).map(|bytes| bytes.len()) }
+}
+
+/// BCS-serializes the value stored at `base` of the given type.
+///
+/// # Safety
+///
+/// `base` must point to a fully initialized value of the given type, and must
+/// remain valid (with all reachable heap objects live) throughout the call.
+#[allow(dead_code)]
+pub unsafe fn serialize<T: LayoutProvider + ?Sized>(
+    layouts: &T,
+    base: *const u8,
+    ty: InternedType,
+) -> RuntimeResult<Vec<u8>> {
+    let layout = layouts.layout_by_ty(ty).ok_or_else(layout_not_found)?;
+
+    let mut out = vec![];
+    if let Some(serialized_size) = layout.const_serialized_size() {
+        out.reserve(serialized_size as usize);
+    }
+
+    // SAFETY: precondition enforced by the caller guarantees safety.
+    unsafe { serialize_impl(layouts, base, layout, &mut out)? };
+    Ok(out)
+}
+
+/// Implementation of BCS serialization of a value with the given layout.
+///
+/// # Safety
+///
+/// `base` must point to a fully initialized value of the given type, and must
+/// remain valid (with all reachable heap objects live) throughout the call.
+unsafe fn serialize_impl<T: LayoutProvider + ?Sized>(
+    layouts: &T,
+    base: *const u8,
+    layout: &TypeLayout,
+    out: &mut Vec<u8>,
+) -> RuntimeResult<()> {
+    if layout.has_no_pointers_no_padding() {
+        // SAFETY: for values with no padding and pointers, value's in-memory
+        // bytes are its BCS encoding.
+        // TODO(correctness): breaks on big-endian hosts. The in-memory
+        // representation is native-endian, so this raw copy only equals the
+        // little-endian BCS encoding on little-endian hosts.
+        unsafe { out.extend_from_slice(std::slice::from_raw_parts(base, layout.size as usize)) };
+        return Ok(());
+    }
+
+    match &layout.kind {
+        LayoutKind::UnsignedInt | LayoutKind::SignedInt | LayoutKind::Address => Err(unreachable(
+            "Primitive types have no padding / pointers and must be already handled",
+        )),
+        LayoutKind::Struct { fields } => {
+            for field in fields.iter() {
+                let field_layout = layouts.layout(field.id).ok_or_else(layout_not_found)?;
+                // SAFETY: the field lies within `base`'s region at `offset`
+                // which holds for well-typed values, as guaranteed by the
+                // safety precondition of this function.
+                unsafe {
+                    serialize_impl(layouts, base.add(field.offset as usize), field_layout, out)?
+                };
+            }
+            Ok(())
+        },
+        LayoutKind::Vector { elem_id, .. } => {
+            // SAFETY: vector value holds an 8-byte heap pointer pointing to
+            // its data for any well-typed value. The length is stored in the
+            // data pointed to.
+            let vec_ptr = unsafe { read_ptr(base, 0usize) };
+            let len = unsafe { read_vec_len(vec_ptr) };
+            if len > bcs::MAX_SEQUENCE_LENGTH as u64 {
+                return Err(RuntimeError::BcsSequenceTooLong { len });
+            }
+            write_uleb128_len(out, len);
+            if len == 0 {
+                return Ok(());
+            }
+
+            let elem_layout = layouts.layout(*elem_id).ok_or_else(layout_not_found)?;
+            let elem_size = elem_layout.size as usize;
+            if elem_layout.has_no_pointers_no_padding() {
+                // TODO(correctness): breaks on big-endian hosts, for the same
+                // reason as the scalar fast path: native-endian in-memory bytes
+                // equal the little-endian BCS bytes only on little-endian hosts.
+                // SAFETY: vector data is a single allocation, pointer is not
+                // null and is within bounds.
+                let vec_data = unsafe {
+                    std::slice::from_raw_parts(
+                        vec_ptr.add(VEC_DATA_OFFSET),
+                        len as usize * elem_size,
+                    )
+                };
+                out.extend_from_slice(vec_data);
+            } else {
+                for i in 0..len as usize {
+                    // SAFETY: ith element lies within the vector data region,
+                    // so the pointer is non-null and new pointer points within
+                    // the data region.
+                    let elem_ptr = unsafe { vec_ptr.add(VEC_DATA_OFFSET + i * elem_size) };
+                    // SAFETY: element pointer is a valid value of the given
+                    // element layout, as guaranteed by the valid `base` value
+                    // pointer passed into this function.
+                    unsafe { serialize_impl(layouts, elem_ptr, elem_layout, out)? };
+                }
+            }
+            Ok(())
+        },
+        LayoutKind::OpenEnum { .. } | LayoutKind::Function => {
+            todo!("enums and function values is not yet supported");
+        },
+        LayoutKind::Ref => Err(unreachable("References cannot be serialized")),
+    }
+}
+
+/// Structural equality of two values of the given type.
+///
+/// # Safety
+///
+/// Input pointers `a` and `b` must point to fully initialized values of the
+/// given type.
+///
+/// # Invariant
+///
+/// The reference values, the caller must read the reference to obtain the
+/// `base` pointer to the actual data.
+#[allow(dead_code)]
+pub unsafe fn equals<T: LayoutProvider + ?Sized>(
+    layouts: &T,
+    a: *const u8,
+    b: *const u8,
+    ty: InternedType,
+) -> RuntimeResult<bool> {
+    let id = layouts.layout_id(ty).ok_or_else(layout_not_found)?;
+    // SAFETY: caller must enforce the safety precondition.
+    unsafe { equals_impl(layouts, a, b, id) }
+}
+
+/// Implementation of structural equality of two values of the given layout.
+///
+/// # Safety
+///
+/// Input pointers `a` and `b` must point to fully initialized values with the
+/// given layout.
+///
+/// # Invariant
+///
+/// The reference values, the caller must read the reference to obtain the
+/// `base` pointer to the actual data.
+unsafe fn equals_impl<T: LayoutProvider + ?Sized>(
+    layouts: &T,
+    a: *const u8,
+    b: *const u8,
+    id: LayoutId,
+) -> RuntimeResult<bool> {
+    let layout = layouts.layout(id).ok_or_else(layout_not_found)?;
+
+    if layout.has_no_pointers_no_padding() {
+        // SAFETY: both pointers must have layout's size and have no pointers,
+        // no padding.
+        return Ok(unsafe { bytes_cmp(a, b, layout.size as usize).is_eq() });
+    }
+
+    match &layout.kind {
+        LayoutKind::UnsignedInt | LayoutKind::SignedInt | LayoutKind::Address => Err(unreachable(
+            "Primitive layouts must be handled by fast-path",
+        )),
+        LayoutKind::Struct { fields } => {
+            for field in fields.iter() {
+                // SAFETY: value is a valid struct, so all fields lie at `offset`
+                // and are within bounds.
+                let eq = unsafe {
+                    equals_impl(
+                        layouts,
+                        a.add(field.offset as usize),
+                        b.add(field.offset as usize),
+                        field.id,
+                    )?
+                };
+                if !eq {
+                    return Ok(false);
+                }
+            }
+            Ok(true)
+        },
+        LayoutKind::Vector { elem_id, .. } => {
+            // SAFETY: vector values hold 8-byte heap pointers pointing to
+            // their data for any well-typed value. The length is stored in
+            // the data pointed to.
+            let vec_a = unsafe { read_ptr(a, 0usize) };
+            let len_a = unsafe { read_vec_len(vec_a) };
+            let vec_b = unsafe { read_ptr(b, 0usize) };
+            let len_b = unsafe { read_vec_len(vec_b) };
+
+            if len_a != len_b {
+                return Ok(false);
+            }
+            if len_a == 0 {
+                return Ok(true);
+            }
+
+            let elem_layout = layouts.layout(*elem_id).ok_or_else(layout_not_found)?;
+            let elem_size = elem_layout.size as usize;
+            if elem_layout.has_no_pointers_no_padding() {
+                // SAFETY: both vectors have same size specified by the layout.
+                let data_a = unsafe { vec_a.add(VEC_DATA_OFFSET) };
+                let data_b = unsafe { vec_b.add(VEC_DATA_OFFSET) };
+                return Ok(unsafe {
+                    bytes_cmp(data_a, data_b, len_a as usize * elem_size).is_eq()
+                });
+            }
+
+            for i in 0..len_a as usize {
+                // SAFETY: ith element lies within the vector data region,
+                // so the pointer is non-null and new pointer points within
+                // the data region. Lengths of `a` and `b` are the same.
+                let elem_a = unsafe { vec_a.add(VEC_DATA_OFFSET + i * elem_size) };
+                let elem_b = unsafe { vec_b.add(VEC_DATA_OFFSET + i * elem_size) };
+
+                // SAFETY: element pointers point to valid vector element
+                // values.
+                let eq = unsafe { equals_impl(layouts, elem_a, elem_b, *elem_id)? };
+                if !eq {
+                    return Ok(false);
+                }
+            }
+            Ok(true)
+        },
+        LayoutKind::OpenEnum { .. } | LayoutKind::Function => {
+            todo!("enums or function values are not yet supported");
+        },
+        LayoutKind::Ref => Err(unreachable("Equality runs on pointee types only")),
+    }
+}
+
+/// Comparison of two values of the given type.
+///
+/// # Semantics
+///
+/// 1. Integers compare numerically.
+/// 2. Addresses or signers (also represented as an address) compare
+///    lexicographically over their bytes.
+/// 3. Vectors compare lexicographically (over smaller prefix)
+/// 4. Structs compare field-by-field.
+///
+/// # Safety
+///
+/// Input pointers `a` and `b` must point to fully initialized values with the
+/// given layout.
+///
+/// # Invariant
+///
+/// The reference values, the caller must read the reference to obtain the
+/// `base` pointer to the actual data.
+#[allow(dead_code)]
+pub unsafe fn compare<T: LayoutProvider + ?Sized>(
+    layouts: &T,
+    a: *const u8,
+    b: *const u8,
+    ty: InternedType,
+) -> RuntimeResult<Ordering> {
+    let id = layouts.layout_id(ty).ok_or_else(layout_not_found)?;
+    // SAFETY: caller must enforce the safety precondition.
+    unsafe { compare_impl(layouts, a, b, id) }
+}
+
+/// Implementation of structural comparison of two values of the given layout.
+///
+/// # Safety
+///
+/// Input pointers `a` and `b` must point to fully initialized values with the
+/// given layout.
+///
+/// # Invariant
+///
+/// The reference values, the caller must read the reference to obtain the
+/// `base` pointer to the actual data.
+unsafe fn compare_impl<T: LayoutProvider + ?Sized>(
+    layouts: &T,
+    a: *const u8,
+    b: *const u8,
+    id: LayoutId,
+) -> RuntimeResult<Ordering> {
+    let layout = layouts.layout(id).ok_or_else(layout_not_found)?;
+    match &layout.kind {
+        LayoutKind::UnsignedInt => {
+            // Read the little-endian bytes into the native integer of the
+            // matching width and compare numerically. `from_le_bytes` keeps
+            // this correct on any host endianness.
+            //
+            // SAFETY: both pointers point to a valid `layout.size`-byte region.
+            Ok(unsafe {
+                match layout.size {
+                    1 => (*a).cmp(&*b),
+                    2 => u16::from_le_bytes(read_array(a)).cmp(&u16::from_le_bytes(read_array(b))),
+                    4 => u32::from_le_bytes(read_array(a)).cmp(&u32::from_le_bytes(read_array(b))),
+                    8 => u64::from_le_bytes(read_array(a)).cmp(&u64::from_le_bytes(read_array(b))),
+                    16 => {
+                        u128::from_le_bytes(read_array(a)).cmp(&u128::from_le_bytes(read_array(b)))
+                    },
+                    32 => {
+                        U256::from_le_bytes(read_array(a)).cmp(&U256::from_le_bytes(read_array(b)))
+                    },
+                    _ => return Err(unreachable("Unexpected unsigned integer width")),
+                }
+            })
+        },
+        LayoutKind::SignedInt => {
+            // SAFETY: both pointers point to a valid `layout.size`-byte region.
+            Ok(unsafe {
+                match layout.size {
+                    1 => (*(a as *const i8)).cmp(&*(b as *const i8)),
+                    2 => i16::from_le_bytes(read_array(a)).cmp(&i16::from_le_bytes(read_array(b))),
+                    4 => i32::from_le_bytes(read_array(a)).cmp(&i32::from_le_bytes(read_array(b))),
+                    8 => i64::from_le_bytes(read_array(a)).cmp(&i64::from_le_bytes(read_array(b))),
+                    16 => {
+                        i128::from_le_bytes(read_array(a)).cmp(&i128::from_le_bytes(read_array(b)))
+                    },
+                    32 => {
+                        I256::from_le_bytes(read_array(a)).cmp(&I256::from_le_bytes(read_array(b)))
+                    },
+                    _ => return Err(unreachable("Unexpected signed integer width")),
+                }
+            })
+        },
+        LayoutKind::Address => {
+            // SAFETY: values are valid byte arrays of the size specified by
+            // the layout, as guaranteed by the precondition of this function.
+            Ok(unsafe { bytes_cmp(a, b, layout.size as usize) })
+        },
+        LayoutKind::Struct { fields } => {
+            for field in fields.iter() {
+                // SAFETY: value is a valid struct, so all fields lie at `offset`
+                // and are within bounds.
+                let ord = unsafe {
+                    compare_impl(
+                        layouts,
+                        a.add(field.offset as usize),
+                        b.add(field.offset as usize),
+                        field.id,
+                    )?
+                };
+                if ord.is_ne() {
+                    return Ok(ord);
+                }
+            }
+            Ok(Ordering::Equal)
+        },
+        LayoutKind::Vector { elem_id, .. } => {
+            // SAFETY: vector values hold 8-byte heap pointers pointing to
+            // their data for any well-typed value. The length is stored in
+            // the data pointed to.
+            let vec_a = unsafe { read_ptr(a, 0usize) };
+            let len_a = unsafe { read_vec_len(vec_a) };
+            let vec_b = unsafe { read_ptr(b, 0usize) };
+            let len_b = unsafe { read_vec_len(vec_b) };
+
+            let elem = layouts.layout(*elem_id).ok_or_else(layout_not_found)?;
+            let elem_size = elem.size as usize;
+            for i in 0..len_a.min(len_b) as usize {
+                // SAFETY: ith element lies within the vector data region,
+                // so the pointer is non-null and new pointer points within
+                // the data region.
+                let elem_a = unsafe { vec_a.add(VEC_DATA_OFFSET + i * elem_size) };
+                let elem_b = unsafe { vec_b.add(VEC_DATA_OFFSET + i * elem_size) };
+
+                // SAFETY: element pointers point to valid values.
+                let ord = unsafe { compare_impl(layouts, elem_a, elem_b, *elem_id)? };
+                if ord.is_ne() {
+                    return Ok(ord);
+                }
+            }
+            Ok(len_a.cmp(&len_b))
+        },
+        LayoutKind::OpenEnum { .. } | LayoutKind::Function => {
+            todo!("enums and function values are not yet supported");
+        },
+        LayoutKind::Ref => Err(unreachable("Comparison runs on pointee types only")),
+    }
+}
+
+/// Deserializes BCS bytes of a value of the given type into the flat in-memory
+/// representation at `dst`.
+///
+/// # Allocating semantics
+///
+/// May allocate data on the heap, e.g. for vectors. **Never runs GC** and
+/// instead fails if there is not enough heap space. It is responsibility of
+/// the caller to run GC and retry.
+///
+/// # Safety
+///
+/// `dst` pointer must be writable for the in-memory size of the given type and
+/// outlive the call.
+#[allow(dead_code)]
+pub unsafe fn deserialize<T: LayoutProvider + ?Sized>(
+    layouts: &T,
+    heap: &mut Heap,
+    ty: InternedType,
+    bytes: &[u8],
+    dst: *mut u8,
+) -> AllocationResult<()> {
+    let layout = layouts.layout_by_ty(ty).ok_or_else(layout_not_found)?;
+
+    let mut cursor = 0usize;
+    // SAFETY: caller must enforce the safety precondition.
+    unsafe { deserialize_impl(layouts, heap, layout, bytes, &mut cursor, dst)? };
+    if cursor != bytes.len() {
+        return Err(RuntimeError::BcsRemainingInput {
+            remaining: bytes.len().saturating_sub(cursor),
+        }
+        .into());
+    }
+    Ok(())
+}
+
+/// # Safety
+///
+/// `dst` must be writable for `layout.size` bytes.
+unsafe fn deserialize_impl<T: LayoutProvider + ?Sized>(
+    layouts: &T,
+    heap: &mut Heap,
+    layout: &TypeLayout,
+    bytes: &[u8],
+    cursor: &mut usize,
+    dst: *mut u8,
+) -> AllocationResult<()> {
+    // If no padding or no pointers, value's BCS bytes are exactly its
+    // in-memory image.
+    // TODO(correctness): breaks on big-endian hosts. This writes the
+    // little-endian BCS bytes verbatim, but the in-memory representation is
+    // native-endian, so the two only match on little-endian hosts.
+    if layout.has_no_pointers_no_padding() {
+        let n = layout.size as usize;
+        let src = read_slice(bytes, cursor, n)?;
+        // SAFETY: caller ensures `n` bytes can be written to `dst` and it is
+        // not aliasing `src`.
+        unsafe { std::ptr::copy_nonoverlapping(src.as_ptr(), dst, n) };
+        return Ok(());
+    }
+
+    match &layout.kind {
+        LayoutKind::UnsignedInt | LayoutKind::SignedInt | LayoutKind::Address => {
+            Err(unreachable("Primitive layouts must be handled by fast-path").into())
+        },
+        LayoutKind::Struct { fields } => {
+            for field in fields.iter() {
+                let field_layout = layouts.layout(field.id).ok_or_else(layout_not_found)?;
+                // SAFETY: value is a valid struct, so all fields lie at `offset`
+                // and are within bounds. `dst` is correctly sized so there is
+                // enough space to write all fields.
+                unsafe {
+                    deserialize_impl(
+                        layouts,
+                        heap,
+                        field_layout,
+                        bytes,
+                        cursor,
+                        dst.add(field.offset as usize),
+                    )?
+                };
+            }
+            Ok(())
+        },
+        LayoutKind::Vector {
+            elem_id,
+            descriptor_id,
+        } => {
+            let len = read_uleb128_len(bytes, cursor)?;
+            if len > bcs::MAX_SEQUENCE_LENGTH as u64 {
+                return Err(RuntimeError::BcsSequenceTooLong { len }.into());
+            }
+            if len == 0 {
+                // The empty vector is the null pointer.
+                // SAFETY: `dst` has size to write the null pointer as
+                // guaranteed by the caller.
+                unsafe { write_ptr(dst, 0usize, std::ptr::null()) };
+                return Ok(());
+            }
+
+            let elem_layout = layouts.layout(*elem_id).ok_or_else(layout_not_found)?;
+            let elem_size = elem_layout.size as usize;
+
+            let data_size = (len as usize)
+                .checked_mul(elem_size)
+                .ok_or(RuntimeError::VecAllocSizeOverflow)?;
+            let total_size = data_size
+                .checked_add(OBJECT_HEADER_SIZE + VEC_DATA_OFFSET)
+                .ok_or(RuntimeError::VecAllocSizeOverflow)?;
+
+            // An OOM here propagates as `AllocationError::OutOfHeapMemory`.
+            let vec_ptr = heap_alloc(heap, total_size, *descriptor_id)?;
+
+            // SAFETY: the allocated data must store length at this offset
+            // as guaranteed by the allocator.
+            unsafe { write_u64(vec_ptr, VEC_LENGTH_OFFSET, len) };
+
+            if elem_layout.has_no_pointers_no_padding() {
+                // If elements have no padding and no pointers, element bytes
+                // equal their BCS bytes.
+                // TODO(correctness): breaks on big-endian hosts, for the same
+                // reason as the scalar fast path above: native-endian in-memory
+                // bytes equal the little-endian BCS bytes only on little-endian
+                // hosts.
+                let src = read_slice(bytes, cursor, data_size)?;
+
+                // SAFETY: the vector data region has space to write
+                // `data_size` bytes and source has same size.
+                unsafe {
+                    std::ptr::copy_nonoverlapping(
+                        src.as_ptr(),
+                        vec_ptr.add(VEC_DATA_OFFSET),
+                        data_size,
+                    )
+                };
+            } else {
+                for i in 0..len as usize {
+                    // SAFETY: ith element lies within the vector data region,
+                    // so the pointer is non-null and new pointer points within
+                    // the data region.
+                    let elem_ptr = unsafe { vec_ptr.add(VEC_DATA_OFFSET + i * elem_size) };
+                    // SAFETY: element pointer is a valid value of the given
+                    // element layout, as guaranteed by the precondition of the
+                    // function.
+                    unsafe {
+                        deserialize_impl(layouts, heap, elem_layout, bytes, cursor, elem_ptr)?
+                    };
+                }
+            }
+
+            // SAFETY: `dst` has size to write the vector pointer as
+            // guaranteed by the caller.
+            unsafe { write_ptr(dst, 0usize, vec_ptr) };
+            Ok(())
+        },
+        LayoutKind::OpenEnum { .. } | LayoutKind::Function => {
+            todo!("enums and function values are not yet supported");
+        },
+        LayoutKind::Ref => Err(unreachable("References cannot be deserialized").into()),
+    }
+}
+
+/// Reads `N` bytes from the pointer into an array.
+///
+/// # Safety
+///
+/// Pointer must point to at least `N` readable, initialized bytes.
+#[inline(always)]
+unsafe fn read_array<const N: usize>(p: *const u8) -> [u8; N] {
+    // SAFETY: `[u8; N]` has alignment 1, so this unaligned read is valid given
+    // the caller's guarantee of `N` readable bytes at `p`.
+    unsafe { (p as *const [u8; N]).read_unaligned() }
+}
+
+/// Byte comparison of two `n`-byte regions.
+///
+/// # Safety
+///
+/// Behavior is undefined if any of the following conditions are violated:
+///
+/// 1. Pointers are non-null.
+/// 2. Pointers point to a single allocation of `n` bytes, allocated.
+unsafe fn bytes_cmp(a: *const u8, b: *const u8, n: usize) -> Ordering {
+    // SAFETY: Caller guarantees non-null pointers of the specified length into
+    // a single allocation. The total size never overflows and the data is not
+    // being mutated.
+    unsafe {
+        let a = std::slice::from_raw_parts(a, n);
+        let b = std::slice::from_raw_parts(b, n);
+        a.cmp(b)
+    }
+}
+
+/// Borrows the next `n` bytes, advancing the cursor. Returns an error if
+/// there is not enough bytes to read or the size of the slice overflows.
+fn read_slice<'b>(bytes: &'b [u8], cursor: &mut usize, n: usize) -> RuntimeResult<&'b [u8]> {
+    let end = cursor.checked_add(n).ok_or_else(|| RuntimeError::BcsEof)?;
+    if end > bytes.len() {
+        return Err(RuntimeError::BcsEof);
+    }
+    let slice = &bytes[*cursor..end];
+    *cursor = end;
+    Ok(slice)
+}
+
+/// Writes ULEB128-encoded length data.
+fn write_uleb128_len(out: &mut Vec<u8>, mut v: u64) {
+    loop {
+        let mut byte = (v & 0x7F) as u8;
+        v >>= 7;
+        if v != 0 {
+            byte |= 0x80;
+        }
+        out.push(byte);
+        if v == 0 {
+            break;
+        }
+    }
+}
+
+/// Reads ULEB128-encoded length data, advancing the cursor. Returns an error
+/// if:
+/// - data is not a valid ULEB128,
+/// - end of input is unexpectedly reached.
+fn read_uleb128_len(bytes: &[u8], cursor: &mut usize) -> RuntimeResult<u64> {
+    let mut result = 0u64;
+    let mut shift = 0u32;
+    loop {
+        let byte = *bytes.get(*cursor).ok_or_else(|| RuntimeError::BcsEof)?;
+        *cursor += 1;
+
+        let cur = (byte & 0x7F) as u64;
+        // Reject any byte whose payload bits do not survive the shift: either the
+        // shift count is out of range, or the high bits would be truncated (e.g.
+        // a terminal `0x02` on the 10th byte where `shift == 63`).
+        if shift >= 64 || (cur << shift) >> shift != cur {
+            return Err(RuntimeError::BcsInvalidUleb);
+        }
+        result |= cur << shift;
+        if byte & 0x80 == 0 {
+            // Reject a non-minimal encoding (a trailing zero continuation).
+            if byte == 0 && shift != 0 {
+                return Err(RuntimeError::BcsInvalidUleb);
+            }
+            return Ok(result);
+        }
+        shift += 7;
+    }
+}
+
+/// Invariant violation error when layout is not available during value walk.
+fn layout_not_found() -> RuntimeError {
+    RuntimeError::InvariantViolation(RuntimeInvariantViolation::TypeLayoutNotFound)
+}
+
+/// An invariant violation for an unreachable state.
+fn unreachable(message: &str) -> RuntimeError {
+    RuntimeError::InvariantViolation(RuntimeInvariantViolation::Unreachable(message.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::heap::AllocationError;
+    use mono_move_core::{
+        type_layout::{U16_LAYOUT_ID, U64_LAYOUT_ID, U8_LAYOUT_ID},
+        types::U64_TY,
+        DescriptorId, FieldTypeLayout, LayoutFlags, LayoutId, TypeLayoutTable,
+    };
+    use serde::Serialize;
+    use std::mem::{offset_of, size_of};
+
+    fn ptr<T>(x: &T) -> *const u8 {
+        x as *const T as *const u8
+    }
+
+    fn vector_layout(elem_id: LayoutId) -> TypeLayout {
+        TypeLayout::vector(elem_id, DescriptorId(2))
+    }
+
+    #[test]
+    fn deserialize_empty_vector_is_null() {
+        let mut heap = Heap::new(4096);
+        let table = TypeLayoutTable::new();
+        let layout = vector_layout(U8_LAYOUT_ID);
+        let bytes = [0u8]; // ULEB len 0.
+        let mut slot = 0u64;
+        let mut cursor = 0;
+        unsafe {
+            deserialize_impl(
+                &table,
+                &mut heap,
+                &layout,
+                &bytes,
+                &mut cursor,
+                &mut slot as *mut u64 as *mut u8,
+            )
+            .unwrap()
+        };
+        assert_eq!(cursor, 1);
+        assert_eq!(slot, 0, "empty vector is the null pointer");
+    }
+
+    #[test]
+    fn deserialize_out_of_heap_memory_errors() {
+        let mut table = TypeLayoutTable::new();
+        let vid = table.push(U64_TY, vector_layout(U64_LAYOUT_ID));
+        let layout = table.layout(vid).unwrap();
+        // The vector for 1000 u64s far exceeds this heap, so allocation fails.
+        let bytes = bcs::to_bytes(&vec![0u64; 1000]).unwrap();
+        let mut heap = Heap::new(128);
+        let mut slot = 0u64;
+        let mut cursor = 0;
+        let result = unsafe {
+            deserialize_impl(
+                &table,
+                &mut heap,
+                layout,
+                &bytes,
+                &mut cursor,
+                &mut slot as *mut u64 as *mut u8,
+            )
+        };
+        assert!(matches!(
+            result,
+            Err(AllocationError::OutOfHeapMemory { .. })
+        ));
+    }
+
+    #[test]
+    fn read_uleb128_len_valid() {
+        // The max payload on the 10th byte is bit 63, so `0x01` there encodes
+        // `2^63` and nine `0x7F` payload bytes plus `0x01` encode `u64::MAX`.
+        let cases: &[(&[u8], u64)] = &[
+            (&[0x00], 0),
+            (&[0x01], 1),
+            (&[0x7F], 127),
+            (&[0x80, 0x01], 128),
+            (&[0xFF, 0x01], 255),
+            (
+                &[0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x01],
+                u64::MAX,
+            ),
+            (
+                &[0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x01],
+                1u64 << 63,
+            ),
+        ];
+        for (bytes, expected) in cases {
+            let mut cursor = 0;
+            assert_eq!(read_uleb128_len(bytes, &mut cursor).unwrap(), *expected);
+            assert_eq!(cursor, bytes.len());
+        }
+    }
+
+    #[test]
+    fn read_uleb128_len_rejects_overflow_on_last_byte() {
+        // The 10th byte sits at `shift == 63`; a payload above bit 0 (here
+        // `0x02`) would be truncated, so it must be rejected, not accepted as 0.
+        let bytes = [0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x02];
+        let mut cursor = 0;
+        assert!(matches!(
+            read_uleb128_len(&bytes, &mut cursor),
+            Err(RuntimeError::BcsInvalidUleb)
+        ));
+    }
+
+    #[test]
+    fn read_uleb128_len_rejects_too_many_bytes() {
+        // An 11th byte pushes `shift` to 70, past the u64 width.
+        let bytes = [
+            0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x01,
+        ];
+        let mut cursor = 0;
+        assert!(matches!(
+            read_uleb128_len(&bytes, &mut cursor),
+            Err(RuntimeError::BcsInvalidUleb)
+        ));
+    }
+
+    #[test]
+    fn read_uleb128_len_rejects_non_minimal() {
+        // A trailing zero continuation byte is a non-canonical encoding of 0.
+        let bytes = [0x80, 0x00];
+        let mut cursor = 0;
+        assert!(matches!(
+            read_uleb128_len(&bytes, &mut cursor),
+            Err(RuntimeError::BcsInvalidUleb)
+        ));
+    }
+
+    #[test]
+    fn read_uleb128_len_eof() {
+        // The continuation bit is set but no further byte follows.
+        let bytes = [0x80, 0x80];
+        let mut cursor = 0;
+        assert!(matches!(
+            read_uleb128_len(&bytes, &mut cursor),
+            Err(RuntimeError::BcsEof)
+        ));
+    }
+
+    #[test]
+    fn deserialize_rejects_trailing_bytes() {
+        let mut table = TypeLayoutTable::new();
+        table.push(U64_TY, TypeLayout::u64());
+        let mut heap = Heap::new(4096);
+
+        let mut bytes = bcs::to_bytes(&7u64).unwrap();
+        bytes.push(0xAB); // Trailing byte after a complete value.
+        let mut slot = 0u64;
+        let result = unsafe {
+            deserialize(
+                &table,
+                &mut heap,
+                U64_TY,
+                &bytes,
+                &mut slot as *mut u64 as *mut u8,
+            )
+        };
+        assert!(matches!(
+            result,
+            Err(AllocationError::RuntimeError(
+                RuntimeError::BcsRemainingInput { remaining: 1 }
+            ))
+        ));
+    }
+
+    /// Builds a struct layout from field offsets/ids and the in-memory size,
+    /// deriving the const BCS size and no-padding flag as the specializer does.
+    fn build_struct_layout(
+        table: &TypeLayoutTable,
+        size: u32,
+        fields: Vec<(u32, LayoutId)>,
+    ) -> TypeLayout {
+        let mut const_total = 0u64;
+        let mut data_dependent = false;
+        for &(_, id) in &fields {
+            match table.layout(id).unwrap().const_serialized_size() {
+                Some(n) => const_total += n as u64,
+                None => data_dependent = true,
+            }
+        }
+        let const_bcs = (!data_dependent).then_some(const_total as u32);
+        let mut flags = LayoutFlags::empty();
+        if const_bcs == Some(size) {
+            flags |= LayoutFlags::NO_POINTERS_NO_PADDING;
+        }
+        let field_layouts = fields
+            .into_iter()
+            .map(|(offset, id)| FieldTypeLayout { offset, id })
+            .collect::<Vec<_>>()
+            .into_boxed_slice();
+        TypeLayout::struct_layout(size, 8, const_bcs, flags, field_layouts)
+    }
+
+    /// Checks the walks for a fixed-size struct against the Rust oracle:
+    /// `bcs::to_bytes` for serialization and size, and derived `Ord`/`Eq` for
+    /// pairwise comparison and equality.
+    ///
+    /// # Safety
+    ///
+    /// Every value must match the layout at `id`, and `size` must be that
+    /// layout's in-memory size.
+    unsafe fn check_struct<S: Serialize + Ord>(
+        table: &TypeLayoutTable,
+        id: LayoutId,
+        values: &[S],
+        size: usize,
+    ) {
+        let layout = table.layout(id).unwrap();
+        let bcs_len = bcs::to_bytes(&values[0]).unwrap().len();
+
+        // Const size is the packed BCS size; blittable iff that equals the
+        // in-memory size.
+        assert_eq!(layout.const_serialized_size(), Some(bcs_len as u32));
+        assert_eq!(layout.has_no_pointers_no_padding(), bcs_len == size);
+
+        for x in values {
+            let x_bcs = bcs::to_bytes(x).unwrap();
+            // A fixed-size struct encodes to the same length for every value.
+            assert_eq!(x_bcs.len(), bcs_len);
+
+            // Serialize matches bcs; a wrongly-blittable padded struct would
+            // memcpy its padding and diverge here.
+            let mut out = vec![];
+            unsafe { serialize_impl(table, ptr(x), layout, &mut out).unwrap() };
+            assert_eq!(out, x_bcs);
+
+            // Round-trip through the packed bytes, not `dst` directly: the
+            // field walk leaves padding bytes in `dst` untouched.
+            let mut heap = Heap::new(128);
+            let mut dst = vec![0u8; size];
+            let mut cursor = 0;
+            unsafe {
+                deserialize_impl(
+                    table,
+                    &mut heap,
+                    layout,
+                    &x_bcs,
+                    &mut cursor,
+                    dst.as_mut_ptr(),
+                )
+                .unwrap()
+            };
+            assert_eq!(cursor, x_bcs.len());
+            let mut reser = vec![];
+            unsafe { serialize_impl(table, dst.as_ptr(), layout, &mut reser).unwrap() };
+            assert_eq!(reser, x_bcs);
+        }
+
+        // Pairwise ordering and equality match Rust's derived Ord/Eq (repr(C)
+        // declaration order is offset order, which both sides walk).
+        for x in values {
+            for y in values {
+                unsafe {
+                    assert_eq!(compare_impl(table, ptr(x), ptr(y), id).unwrap(), x.cmp(y));
+                    assert_eq!(equals_impl(table, ptr(x), ptr(y), id).unwrap(), x == y);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_struct_padded() {
+        #[repr(C)]
+        #[derive(Serialize, PartialEq, Eq, PartialOrd, Ord)]
+        struct S {
+            a: u8,
+            b: u64,
+        }
+
+        let mut table = TypeLayoutTable::new();
+        let layout = build_struct_layout(&table, size_of::<S>() as u32, vec![
+            (offset_of!(S, a) as u32, U8_LAYOUT_ID),
+            (offset_of!(S, b) as u32, U64_LAYOUT_ID),
+        ]);
+        // In-memory 16, BCS 9 (7 bytes padding), so not blittable.
+        assert_eq!(layout.const_serialized_size(), Some(9));
+        assert!(!layout.has_no_pointers_no_padding());
+
+        let id = table.push(U64_TY, layout);
+        let values = [
+            S { a: 0, b: 0 },
+            S { a: 0, b: 1 },
+            S { a: 1, b: 0 },
+            S { a: 1, b: 0 },
+            S {
+                a: u8::MAX,
+                b: u64::MAX,
+            },
+        ];
+        unsafe { check_struct(&table, id, &values, size_of::<S>()) };
+    }
+
+    #[test]
+    fn test_struct_blittable() {
+        #[repr(C)]
+        #[derive(Serialize, PartialEq, Eq, PartialOrd, Ord)]
+        struct S {
+            a: u64,
+            b: u64,
+        }
+
+        let mut table = TypeLayoutTable::new();
+        let layout = build_struct_layout(&table, size_of::<S>() as u32, vec![
+            (offset_of!(S, a) as u32, U64_LAYOUT_ID),
+            (offset_of!(S, b) as u32, U64_LAYOUT_ID),
+        ]);
+        // No padding: BCS 16 equals in-memory 16, so blittable.
+        assert_eq!(layout.const_serialized_size(), Some(16));
+        assert!(layout.has_no_pointers_no_padding());
+
+        let id = table.push(U64_TY, layout);
+        let values = [
+            S { a: 0, b: 0 },
+            S { a: 0, b: 1 },
+            S { a: 1, b: 0 },
+            S { a: 1, b: 0 },
+            S {
+                a: u64::MAX,
+                b: u64::MAX,
+            },
+        ];
+        unsafe { check_struct(&table, id, &values, size_of::<S>()) };
+    }
+
+    #[test]
+    fn test_struct_three_fields() {
+        // `{u16, u8, u64}`: a@0, b@2, c@8 (two padding gaps), size 16, BCS 11.
+        #[repr(C)]
+        #[derive(Serialize, PartialEq, Eq, PartialOrd, Ord)]
+        struct S {
+            a: u16,
+            b: u8,
+            c: u64,
+        }
+
+        let mut table = TypeLayoutTable::new();
+        let layout = build_struct_layout(&table, size_of::<S>() as u32, vec![
+            (offset_of!(S, a) as u32, U16_LAYOUT_ID),
+            (offset_of!(S, b) as u32, U8_LAYOUT_ID),
+            (offset_of!(S, c) as u32, U64_LAYOUT_ID),
+        ]);
+        assert_eq!(layout.const_serialized_size(), Some(11));
+        assert!(!layout.has_no_pointers_no_padding());
+
+        let id = table.push(U64_TY, layout);
+        let values = [
+            S { a: 0, b: 0, c: 0 },
+            S { a: 0, b: 0, c: 1 },
+            S { a: 0, b: 1, c: 0 },
+            S { a: 1, b: 0, c: 0 },
+            S { a: 0, b: 1, c: 0 },
+            S {
+                a: u16::MAX,
+                b: u8::MAX,
+                c: u64::MAX,
+            },
+        ];
+        unsafe { check_struct(&table, id, &values, size_of::<S>()) };
+    }
+
+    #[test]
+    fn test_struct_nested() {
+        #[repr(C)]
+        #[derive(Serialize, PartialEq, Eq, PartialOrd, Ord)]
+        struct Inner {
+            a: u64,
+            b: u64,
+        }
+        #[repr(C)]
+        #[derive(Serialize, PartialEq, Eq, PartialOrd, Ord)]
+        struct Outer {
+            x: Inner,
+            y: u8,
+        }
+
+        let mut table = TypeLayoutTable::new();
+        let inner = build_struct_layout(&table, size_of::<Inner>() as u32, vec![
+            (offset_of!(Inner, a) as u32, U64_LAYOUT_ID),
+            (offset_of!(Inner, b) as u32, U64_LAYOUT_ID),
+        ]);
+        let inner_id = table.push(U64_TY, inner);
+
+        let outer = build_struct_layout(&table, size_of::<Outer>() as u32, vec![
+            (offset_of!(Outer, x) as u32, inner_id),
+            (offset_of!(Outer, y) as u32, U8_LAYOUT_ID),
+        ]);
+        // Outer is BCS 17, size 24 (trailing pad): a blittable child (Inner)
+        // does not make the parent blittable.
+        assert_eq!(outer.const_serialized_size(), Some(17));
+        assert!(!outer.has_no_pointers_no_padding());
+
+        let id = table.push(U64_TY, outer);
+        let values = [
+            Outer {
+                x: Inner { a: 0, b: 0 },
+                y: 0,
+            },
+            Outer {
+                x: Inner { a: 0, b: 0 },
+                y: 1,
+            },
+            Outer {
+                x: Inner { a: 0, b: 1 },
+                y: 0,
+            },
+            Outer {
+                x: Inner { a: 1, b: 0 },
+                y: 0,
+            },
+            Outer {
+                x: Inner { a: 0, b: 0 },
+                y: 1,
+            },
+        ];
+        unsafe { check_struct(&table, id, &values, size_of::<Outer>()) };
+    }
+
+    /// Like [`check_struct`], but builds the value by deserializing its bcs
+    /// rather than pointing at the Rust value, so it also covers types that own
+    /// heap boxes (vectors, and structs containing them) whose in-memory layout
+    /// differs from Rust's.
+    ///
+    /// # Safety
+    ///
+    /// `id` and `size` must be the layout and in-memory size matching `S`.
+    unsafe fn check_roundtrip<S: Serialize + Ord>(
+        table: &TypeLayoutTable,
+        id: LayoutId,
+        size: usize,
+        values: &[S],
+    ) {
+        let layout = table.layout(id).unwrap();
+        let mut heap = Heap::new(8192);
+        // Each buffer holds the deserialized value; its boxes live in `heap`.
+        let mut bufs: Vec<Vec<u8>> = Vec::with_capacity(values.len());
+        for v in values {
+            let bytes = bcs::to_bytes(v).unwrap();
+            let mut dst = vec![0u8; size];
+            let mut cursor = 0;
+            unsafe {
+                deserialize_impl(
+                    table,
+                    &mut heap,
+                    layout,
+                    &bytes,
+                    &mut cursor,
+                    dst.as_mut_ptr(),
+                )
+                .unwrap()
+            };
+            assert_eq!(cursor, bytes.len());
+
+            // Re-serializing the deserialized value reproduces its bcs.
+            let mut out = vec![];
+            unsafe { serialize_impl(table, dst.as_ptr(), layout, &mut out).unwrap() };
+            assert_eq!(out, bytes);
+
+            bufs.push(dst);
+        }
+
+        // Compare and equals match the value's `Ord`/`Eq` across every pair.
+        for (i, vi) in values.iter().enumerate() {
+            for (j, vj) in values.iter().enumerate() {
+                let (pi, pj) = (bufs[i].as_ptr(), bufs[j].as_ptr());
+                unsafe {
+                    assert_eq!(compare_impl(table, pi, pj, id).unwrap(), vi.cmp(vj));
+                    assert_eq!(equals_impl(table, pi, pj, id).unwrap(), vi == vj);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_vector_u64() {
+        let mut table = TypeLayoutTable::new();
+        let vid = table.push(U64_TY, vector_layout(U64_LAYOUT_ID));
+        assert_eq!(table.layout(vid).unwrap().const_serialized_size(), None);
+        let values: [Vec<u64>; 7] = [
+            vec![],
+            vec![1],
+            vec![1, 2],
+            vec![1, 2, 3],
+            vec![1, 3],
+            vec![2],
+            vec![1, 2],
+        ];
+        unsafe { check_roundtrip(&table, vid, 8, &values) };
+    }
+
+    #[test]
+    fn test_vector_u8() {
+        let mut table = TypeLayoutTable::new();
+        let vid = table.push(U64_TY, vector_layout(U8_LAYOUT_ID));
+        let values = vec![
+            vec![],
+            vec![0u8],
+            vec![0u8, 0],
+            vec![255u8],
+            vec![1u8, 2, 3],
+            vec![7u8; 200], // > 127 forces a multi-byte ULEB length.
+        ];
+        unsafe { check_roundtrip(&table, vid, 8, &values) };
+    }
+
+    #[test]
+    fn test_vector_nested() {
+        let mut table = TypeLayoutTable::new();
+        // `vector<vector<u64>>`: the element is a vector pointer (not
+        // blittable), so the walks recurse per element.
+        let inner_id = table.push(U64_TY, vector_layout(U64_LAYOUT_ID));
+        let vid = table.push(U64_TY, vector_layout(inner_id));
+        let values: [Vec<Vec<u64>>; 6] = [
+            vec![],
+            vec![vec![]],
+            vec![vec![1]],
+            vec![vec![1], vec![2]],
+            vec![vec![1, 2]],
+            vec![vec![1], vec![2]],
+        ];
+        unsafe { check_roundtrip(&table, vid, 8, &values) };
+    }
+
+    #[test]
+    fn test_vector_of_struct() {
+        // Element is a padded (non-blittable) struct, so the vector recurses
+        // per element into the struct field walk.
+        #[repr(C)]
+        #[derive(Serialize, PartialEq, Eq, PartialOrd, Ord)]
+        struct Kv {
+            k: u8,
+            v: u64,
+        }
+
+        let mut table = TypeLayoutTable::new();
+        let kv_layout = build_struct_layout(&table, size_of::<Kv>() as u32, vec![
+            (offset_of!(Kv, k) as u32, U8_LAYOUT_ID),
+            (offset_of!(Kv, v) as u32, U64_LAYOUT_ID),
+        ]);
+        let kv_id = table.push(U64_TY, kv_layout);
+        let vid = table.push(U64_TY, vector_layout(kv_id));
+
+        let values: [Vec<Kv>; 5] = [
+            vec![],
+            vec![Kv { k: 1, v: 2 }],
+            vec![Kv { k: 1, v: 2 }, Kv { k: 3, v: 4 }],
+            vec![Kv { k: 1, v: 9 }],
+            vec![Kv { k: 1, v: 2 }],
+        ];
+        unsafe { check_roundtrip(&table, vid, 8, &values) };
+    }
+
+    #[test]
+    fn test_struct_of_vector() {
+        // `{u64, vector<u64>}`: in-memory size 16 (u64 + box pointer), narrower
+        // than the Rust oracle's `Vec` field, so build the layout explicitly
+        // and use `Bag` only as the oracle (never point at it).
+        #[derive(Serialize, PartialEq, Eq, PartialOrd, Ord)]
+        struct Bag {
+            id: u64,
+            items: Vec<u64>,
+        }
+
+        let mut table = TypeLayoutTable::new();
+        let vec_id = table.push(U64_TY, vector_layout(U64_LAYOUT_ID));
+        let bag_layout = build_struct_layout(&table, 16, vec![(0, U64_LAYOUT_ID), (8, vec_id)]);
+        let id = table.push(U64_TY, bag_layout);
+        // The vector field makes the struct data-dependent and not blittable.
+        assert_eq!(table.layout(id).unwrap().const_serialized_size(), None);
+        assert!(!table.layout(id).unwrap().has_no_pointers_no_padding());
+
+        let values: [Bag; 5] = [
+            Bag {
+                id: 1,
+                items: vec![],
+            },
+            Bag {
+                id: 1,
+                items: vec![7],
+            },
+            Bag {
+                id: 2,
+                items: vec![],
+            },
+            Bag {
+                id: 1,
+                items: vec![7, 8],
+            },
+            Bag {
+                id: 1,
+                items: vec![7],
+            },
+        ];
+        unsafe { check_roundtrip(&table, id, 16, &values) };
+    }
+}
+
+#[cfg(test)]
+mod prop_tests {
+    use super::*;
+    use mono_move_core::{
+        types::{
+            ADDRESS_TY, BOOL_TY, I128_TY, I16_TY, I256_TY, I32_TY, I64_TY, I8_TY, U128_TY, U16_TY,
+            U256_TY, U32_TY, U64_TY, U8_TY,
+        },
+        TypeLayoutTable,
+    };
+    use move_core_types::{
+        account_address::AccountAddress,
+        int256::{I256, U256},
+    };
+    use proptest::prelude::*;
+
+    macro_rules! prop_primitive {
+        ($name:ident, $t:ty, $ty:expr, $strat:expr) => {
+            proptest! {
+                #[test]
+                fn $name(x in $strat, y in $strat) {
+                    let table = TypeLayoutTable::new();
+                    let mut heap = Heap::new(128);
+                    let size = std::mem::size_of::<$t>();
+                    let bytes = bcs::to_bytes(&x).unwrap();
+                    prop_assert_eq!(bytes.len(), size);
+
+                    // Constant serialized size is the fixed width.
+                    prop_assert_eq!(
+                        const_serialized_size(&table, $ty).unwrap(),
+                        Some(size as u32)
+                    );
+
+                    let px = &x as *const $t as *const u8;
+                    let py = &y as *const $t as *const u8;
+
+                    // Serialize matches the BCS encoding.
+                    let out = unsafe { serialize(&table, px, $ty).unwrap() };
+                    prop_assert_eq!(&out, &bytes);
+                    prop_assert_eq!(
+                        unsafe { serialized_size(&table, px, $ty).unwrap() },
+                        bytes.len()
+                    );
+
+                    // Deserialize reproduces the value's in-memory bytes.
+                    let mut dst = vec![0u8; size];
+                    unsafe {
+                        deserialize(&table, &mut heap, $ty, &bytes, dst.as_mut_ptr()).unwrap()
+                    };
+                    let x_bytes = unsafe { std::slice::from_raw_parts(px, size) };
+                    prop_assert_eq!(dst.as_slice(), x_bytes);
+
+                    // Compare and equals match Rust's ordering and equality.
+                    prop_assert_eq!(unsafe { compare(&table, px, py, $ty).unwrap() }, x.cmp(&y));
+                    prop_assert_eq!(unsafe { equals(&table, px, py, $ty).unwrap() }, x == y);
+                    let eq_self = unsafe { equals(&table, px, px, $ty).unwrap() };
+                    prop_assert!(eq_self);
+                }
+            }
+        };
+    }
+
+    macro_rules! unsigned_strategy {
+        ($t:ty) => {
+            prop_oneof![Just(0 as $t), Just(<$t>::MAX), any::<$t>()]
+        };
+    }
+
+    macro_rules! signed_strategy {
+        ($t:ty) => {
+            prop_oneof![
+                Just(0 as $t),
+                Just(-1 as $t),
+                Just(<$t>::MIN),
+                Just(<$t>::MAX),
+                any::<$t>()
+            ]
+        };
+    }
+
+    prop_primitive!(prop_bool, bool, BOOL_TY, prop_oneof![
+        Just(false),
+        Just(true)
+    ]);
+    prop_primitive!(prop_u8, u8, U8_TY, unsigned_strategy!(u8));
+    prop_primitive!(prop_u16, u16, U16_TY, unsigned_strategy!(u16));
+    prop_primitive!(prop_u32, u32, U32_TY, unsigned_strategy!(u32));
+    prop_primitive!(prop_u64, u64, U64_TY, unsigned_strategy!(u64));
+    prop_primitive!(prop_u128, u128, U128_TY, unsigned_strategy!(u128));
+    prop_primitive!(prop_i8, i8, I8_TY, signed_strategy!(i8));
+    prop_primitive!(prop_i16, i16, I16_TY, signed_strategy!(i16));
+    prop_primitive!(prop_i32, i32, I32_TY, signed_strategy!(i32));
+    prop_primitive!(prop_i64, i64, I64_TY, signed_strategy!(i64));
+    prop_primitive!(prop_i128, i128, I128_TY, signed_strategy!(i128));
+    prop_primitive!(prop_u256, U256, U256_TY, prop_oneof![
+        Just(U256::MIN),
+        Just(U256::MAX),
+        any::<[u8; 32]>().prop_map(U256::from_le_bytes)
+    ]);
+    prop_primitive!(prop_i256, I256, I256_TY, prop_oneof![
+        Just(I256::MIN),
+        Just(I256::MAX),
+        Just(I256::from_le_bytes([0xFF; 32])),
+        any::<[u8; 32]>().prop_map(I256::from_le_bytes)
+    ]);
+    prop_primitive!(prop_address, AccountAddress, ADDRESS_TY, prop_oneof![
+        Just(AccountAddress::new([0; 32])),
+        Just(AccountAddress::new([0xFF; 32])),
+        any::<[u8; 32]>().prop_map(AccountAddress::new)
+    ]);
+}

--- a/third_party/move/mono-move/specializer/src/lower/context.rs
+++ b/third_party/move/mono-move/specializer/src/lower/context.rs
@@ -19,14 +19,14 @@ use mono_move_core::{
     interner::{InternedFunctionRef, InternedIdentifier, InternedModuleId},
     native::{NativeIdx, NativeName, NativeResolver},
     next_captured_value_offset,
-    type_layout::REF_LAYOUT_ID,
     types::{
         view_type, view_type_list, Alignment, FieldLayout, InternedType, InternedTypeList, Size,
         Type, EMPTY_TYPE_LIST,
     },
-    Code, CodeOffset, DescriptorId, FieldTypeLayout, FieldTypes, FrameLayoutInfo, FrameOffset,
+    value_layout::REF_LAYOUT_ID,
+    Code, CodeOffset, DescriptorId, FieldTypes, FieldValueLayout, FrameLayoutInfo, FrameOffset,
     Function, Interner, LayoutFlags, LayoutId, MicroOpGasSchedule, PreparedModule, SafePointEntry,
-    SizedSlot, SortedSafePointEntries, TypeLayout, FRAME_METADATA_SIZE, MAX_ALIGN,
+    SizedSlot, SortedSafePointEntries, ValueLayout, FRAME_METADATA_SIZE, MAX_ALIGN,
 };
 use mono_move_gas::GasInstrumentor;
 use move_binary_format::{access::ModuleAccess, file_format::FunctionHandleIndex};
@@ -571,10 +571,10 @@ pub trait SpecializerContext {
     fn layout_id_for(&self, ty: InternedType) -> Option<LayoutId>;
 
     /// Returns the published layout for `id`, or `None` if unknown.
-    fn layout(&self, id: LayoutId) -> Option<&TypeLayout>;
+    fn layout(&self, id: LayoutId) -> Option<&ValueLayout>;
 
     /// Publishes `layout` for `ty` and returns its assigned id. Idempotent.
-    fn publish_layout(&self, ty: InternedType, layout: TypeLayout) -> LayoutId;
+    fn publish_layout(&self, ty: InternedType, layout: ValueLayout) -> LayoutId;
 }
 
 /// Interned type list of a closure target's captured parameters (the mask-set
@@ -850,7 +850,7 @@ fn discover_captured_data_descriptor(
 
 /// Recursive post-order DFS that visits every nominal reachable from the given
 /// type and, as a side effect, publishes its GC vector descriptors,
-/// `NominalLayout`s, and `TypeLayout`s. Returns the type's [`LayoutId`] when one
+/// `NominalLayout`s, and `ValueLayout`s. Returns the type's [`LayoutId`] when one
 /// could be built, or `None` when it is deferred.
 ///
 /// Additionally, for each `Type::Vector` reached, recurses into the element
@@ -925,7 +925,7 @@ fn discover_type_metadata(
             // uses), so `descriptor_id` is always valid on the layout.
             match (elem_id, descriptor_id) {
                 (Some(elem_id), Some(descriptor_id)) => {
-                    let layout = TypeLayout::vector(elem_id, descriptor_id);
+                    let layout = ValueLayout::vector(elem_id, descriptor_id);
                     Ok(Some(ctx.publish_layout(ty, layout)))
                 },
                 _ => Ok(None),
@@ -973,7 +973,7 @@ fn discover_type_metadata(
                     let mut nominal_fields = Vec::with_capacity(fields.len());
 
                     let mut layout_fields = Vec::with_capacity(fields.len());
-                    let mut const_bcs_total: u64 = 0;
+                    let mut fixed_bcs_total: u64 = 0;
                     let mut data_dependent = false;
 
                     for (&ft, &fid) in fields.iter().zip(&field_ids) {
@@ -994,10 +994,10 @@ fn discover_type_metadata(
                         offset = align_up_u32(offset, al);
                         max_align = max_align.max(al);
                         nominal_fields.push(FieldLayout::new(offset, ft));
-                        layout_fields.push(FieldTypeLayout { offset, id });
-                        match child.const_bcs_size {
+                        layout_fields.push(FieldValueLayout { offset, id });
+                        match child.fixed_bcs_size {
                             Some(bcs_sz) => {
-                                const_bcs_total = const_bcs_total.saturating_add(bcs_sz as u64)
+                                fixed_bcs_total = fixed_bcs_total.saturating_add(bcs_sz as u64)
                             },
                             None => data_dependent = true,
                         }
@@ -1006,35 +1006,35 @@ fn discover_type_metadata(
                     let total = align_up_u32(offset, max_align);
                     ctx.set_nominal_layout(ty, total, max_align, Some(&nominal_fields))?;
 
-                    let const_bcs_size = if data_dependent || const_bcs_total > u32::MAX as u64 {
+                    let fixed_bcs_size = if data_dependent || fixed_bcs_total > u32::MAX as u64 {
                         None
                     } else {
-                        Some(const_bcs_total as u32)
+                        Some(fixed_bcs_total as u32)
                     };
                     // The struct has no pointers and no padding exactly when
                     // its packed BCS size equals its in-memory size: a pointer
                     // field makes the BCS size data-dependent (`None`), and any
                     // alignment padding makes it strictly smaller than `total`.
                     let mut flags = LayoutFlags::empty();
-                    if const_bcs_size == Some(total) {
+                    if fixed_bcs_size == Some(total) {
                         flags |= LayoutFlags::NO_POINTERS_NO_PADDING;
                     }
-                    let type_layout = TypeLayout::struct_layout(
+                    let value_layout = ValueLayout::struct_layout(
                         total,
                         max_align,
-                        const_bcs_size,
+                        fixed_bcs_size,
                         flags,
                         layout_fields.into_boxed_slice(),
                     );
-                    Ok(Some(ctx.publish_layout(ty, type_layout)))
+                    Ok(Some(ctx.publish_layout(ty, value_layout)))
                 },
                 Some(FieldTypes::Enum(_)) => {
                     // Enum size is fixed (heap pointer) regardless of variant
                     // fields. We do not walk variants here because their types
                     // are only needed for pack/unpack/test.
                     ctx.set_nominal_layout(ty, 8, 8, None)?;
-                    let type_layout = TypeLayout::open_enum(ty, *nominal_ty_args);
-                    Ok(Some(ctx.publish_layout(ty, type_layout)))
+                    let value_layout = ValueLayout::open_enum(ty, *nominal_ty_args);
+                    Ok(Some(ctx.publish_layout(ty, value_layout)))
                 },
             }
         },

--- a/third_party/move/mono-move/specializer/src/lower/context.rs
+++ b/third_party/move/mono-move/specializer/src/lower/context.rs
@@ -13,19 +13,20 @@ use crate::{
     },
     stackless_exec_ir::{instr_utils::nominal_type_in_instr, FunctionIR, Instr, ModuleIR},
 };
-use anyhow::Result;
+use anyhow::{bail, Result};
 use mono_move_core::{
     align_up_u32,
     interner::{InternedFunctionRef, InternedIdentifier, InternedModuleId},
     native::{NativeIdx, NativeName, NativeResolver},
     next_captured_value_offset,
+    type_layout::REF_LAYOUT_ID,
     types::{
         view_type, view_type_list, Alignment, FieldLayout, InternedType, InternedTypeList, Size,
         Type, EMPTY_TYPE_LIST,
     },
-    Code, CodeOffset, DescriptorId, FieldTypes, FrameLayoutInfo, FrameOffset, Function, Interner,
-    MicroOpGasSchedule, PreparedModule, SafePointEntry, SizedSlot, SortedSafePointEntries,
-    FRAME_METADATA_SIZE, MAX_ALIGN,
+    Code, CodeOffset, DescriptorId, FieldTypeLayout, FieldTypes, FrameLayoutInfo, FrameOffset,
+    Function, Interner, LayoutFlags, LayoutId, MicroOpGasSchedule, PreparedModule, SafePointEntry,
+    SizedSlot, SortedSafePointEntries, TypeLayout, FRAME_METADATA_SIZE, MAX_ALIGN,
 };
 use mono_move_gas::GasInstrumentor;
 use move_binary_format::{access::ModuleAccess, file_format::FunctionHandleIndex};
@@ -564,6 +565,16 @@ pub trait SpecializerContext {
         values_size: u32,
         pointer_offsets: &[FrameOffset],
     ) -> Result<DescriptorId>;
+
+    /// Returns the layout id for `ty`, or `None` if no layout has been
+    /// published yet. Primitives/references/functions resolve to a reserved id.
+    fn layout_id_for(&self, ty: InternedType) -> Option<LayoutId>;
+
+    /// Returns the published layout for `id`, or `None` if unknown.
+    fn layout(&self, id: LayoutId) -> Option<&TypeLayout>;
+
+    /// Publishes `layout` for `ty` and returns its assigned id. Idempotent.
+    fn publish_layout(&self, ty: InternedType, layout: TypeLayout) -> LayoutId;
 }
 
 /// Interned type list of a closure target's captured parameters (the mask-set
@@ -838,10 +849,9 @@ fn discover_captured_data_descriptor(
 }
 
 /// Recursive post-order DFS that visits every nominal reachable from the given
-/// type. Best-effort: for each visited nominal, computes its layout size,
-/// alignment, field offsets when all its fields are sized. Skips nominals for
-/// which field information is not available (same treatment as generic type
-/// parameters).
+/// type and, as a side effect, publishes its GC vector descriptors,
+/// `NominalLayout`s, and `TypeLayout`s. Returns the type's [`LayoutId`] when one
+/// could be built, or `None` when it is deferred.
 ///
 /// Additionally, for each `Type::Vector` reached, recurses into the element
 /// type, then publishes a vector descriptor and records the assigned
@@ -856,10 +866,10 @@ fn discover_type_metadata(
     ty_args: InternedTypeList,
     visited: &mut UnorderedSet<InternedType>,
     vec_descriptors: &mut UnorderedMap<InternedType, DescriptorId>,
-) -> Result<()> {
+) -> Result<Option<LayoutId>> {
     let ty = ctx.subst_type(ty, ty_args)?;
     if !visited.insert(ty) {
-        return Ok(());
+        return Ok(ctx.layout_id_for(ty));
     }
 
     match view_type(ty) {
@@ -880,25 +890,45 @@ fn discover_type_metadata(
         | Type::Signer
         | Type::TypeParam { .. }
         | Type::Function { .. } => {
-            // Sizes for primitives and function types are known; type
-            // parameters have unknown size — nothing to discover.
+            // Primitives have known layouts; function value layout depends
+            // on actual data, and type parameters have no layout. Nothing to
+            // discover.
+            Ok(ctx.layout_id_for(ty))
         },
         Type::ImmutRef { inner } | Type::MutRef { inner } => {
-            // Refs are fixed-size, but the referent's types still need
-            // discovery. `ty` was already substituted above, so any
-            // type params in `inner` are concrete — pass `EMPTY_TYPE_LIST`.
+            // Refs are fixed-size and have known layout, but the referent's
+            // types still need discovery. `ty` was already substituted above,
+            // so any  type params in `inner` are concrete, not type arguments
+            // to pass here.
             discover_type_metadata(ctx, *inner, EMPTY_TYPE_LIST, visited, vec_descriptors)?;
+            Ok(Some(REF_LAYOUT_ID))
         },
         Type::Vector { elem } => {
-            discover_type_metadata(ctx, *elem, EMPTY_TYPE_LIST, visited, vec_descriptors)?;
-            if let Some(id) = ctx.vec_descriptor_for(*elem) {
-                vec_descriptors.insert(ty, id);
+            let elem_id =
+                discover_type_metadata(ctx, *elem, EMPTY_TYPE_LIST, visited, vec_descriptors)?;
+            // Get or publish the GC descriptor for the element.
+            let descriptor_id = if let Some(id) = ctx.vec_descriptor_for(*elem) {
+                Some(id)
             } else if let Some((elem_size, _)) = type_size_and_align(*elem)
                 && let Ok(ptr_offsets) = type_pointer_offsets(*elem)
             {
                 let ptr_offsets = ptr_offsets.into_iter().map(FrameOffset).collect::<Vec<_>>();
-                let id = ctx.publish_vec_descriptor(*elem, elem_size, &ptr_offsets)?;
+                Some(ctx.publish_vec_descriptor(*elem, elem_size, &ptr_offsets)?)
+            } else {
+                None
+            };
+            if let Some(id) = descriptor_id {
                 vec_descriptors.insert(ty, id);
+            }
+            // Publish the vector layout only when both the element layout and
+            // the descriptor are available (the same condition the descriptor
+            // uses), so `descriptor_id` is always valid on the layout.
+            match (elem_id, descriptor_id) {
+                (Some(elem_id), Some(descriptor_id)) => {
+                    let layout = TypeLayout::vector(elem_id, descriptor_id);
+                    Ok(Some(ctx.publish_layout(ty, layout)))
+                },
+                _ => Ok(None),
             }
         },
         Type::Nominal {
@@ -911,7 +941,8 @@ fn discover_type_metadata(
                 None => {
                     // The context does not have field information for this
                     // nominal (e.g., the module has not been loaded). Treat
-                    // like a generic type parameter: skip.
+                    // like a generic type parameter: defer.
+                    Ok(None)
                 },
                 Some(FieldTypes::Struct(fields)) => {
                     let fields = fields
@@ -919,49 +950,93 @@ fn discover_type_metadata(
                         .map(|f| ctx.subst_type(*f, *nominal_ty_args))
                         .collect::<Result<Vec<_>>>()?;
 
-                    // We have to recurse unconditionally because if size is
-                    // set, it does not mean that all modules used have been
-                    // resolved. Other thread can set struct's size so this
-                    // traversal is needed. Recursing on the substituted
-                    // fields also surfaces transitively-referenced nominals
-                    // (e.g., `Coin<USDC>` field - `USDC` as a root).
+                    // Recurse on every field unconditionally (a deferred or
+                    // unsized field must not stop discovery of later fields'
+                    // descriptors), collecting each field's layout id.
+                    let mut field_ids = Vec::with_capacity(fields.len());
                     for &ft in &fields {
-                        // At this point we have already substituted fields, so
-                        // all types inside must be instantiated. Even if we
-                        // encounter some nominal, its type arguments would be
-                        // substituted as well.
-                        discover_type_metadata(ctx, ft, EMPTY_TYPE_LIST, visited, vec_descriptors)?;
+                        field_ids.push(discover_type_metadata(
+                            ctx,
+                            ft,
+                            EMPTY_TYPE_LIST,
+                            visited,
+                            vec_descriptors,
+                        )?);
                     }
 
                     // Best-effort layout computation. If any field is still
-                    // not sized, so is the nominal type.
+                    // not sized (or has no published layout), so is the
+                    // nominal type: defer.
                     let mut offset = 0u32;
                     let mut max_align = 1u32;
-                    let mut layout = Vec::with_capacity(fields.len());
-                    let mut all_sized = true;
-                    for &ft in &fields {
+                    // TODO: remove legacy size/layout.
+                    let mut nominal_fields = Vec::with_capacity(fields.len());
+
+                    let mut layout_fields = Vec::with_capacity(fields.len());
+                    let mut const_bcs_total: u64 = 0;
+                    let mut data_dependent = false;
+
+                    for (&ft, &fid) in fields.iter().zip(&field_ids) {
                         let Some((sz, al)) = view_type(ft).size_and_align() else {
-                            all_sized = false;
-                            break;
+                            return Ok(None);
+                        };
+                        // A field can be sized yet still lack a published layout:
+                        // `vector<T>` always reports an 8-byte pointer, but its
+                        // layout is deferred until the element layout and vector
+                        // descriptor exist. Defer the nominal too, rather than
+                        // treating this as an invariant violation.
+                        let Some(id) = fid else {
+                            return Ok(None);
+                        };
+                        let Some(child) = ctx.layout(id) else {
+                            bail!("published layout id does not resolve to a layout");
                         };
                         offset = align_up_u32(offset, al);
                         max_align = max_align.max(al);
-                        layout.push(FieldLayout::new(offset, ft));
+                        nominal_fields.push(FieldLayout::new(offset, ft));
+                        layout_fields.push(FieldTypeLayout { offset, id });
+                        match child.const_bcs_size {
+                            Some(bcs_sz) => {
+                                const_bcs_total = const_bcs_total.saturating_add(bcs_sz as u64)
+                            },
+                            None => data_dependent = true,
+                        }
                         offset += sz;
                     }
-                    if all_sized {
-                        let total = align_up_u32(offset, max_align);
-                        ctx.set_nominal_layout(ty, total, max_align, Some(&layout))?;
+                    let total = align_up_u32(offset, max_align);
+                    ctx.set_nominal_layout(ty, total, max_align, Some(&nominal_fields))?;
+
+                    let const_bcs_size = if data_dependent || const_bcs_total > u32::MAX as u64 {
+                        None
+                    } else {
+                        Some(const_bcs_total as u32)
+                    };
+                    // The struct has no pointers and no padding exactly when
+                    // its packed BCS size equals its in-memory size: a pointer
+                    // field makes the BCS size data-dependent (`None`), and any
+                    // alignment padding makes it strictly smaller than `total`.
+                    let mut flags = LayoutFlags::empty();
+                    if const_bcs_size == Some(total) {
+                        flags |= LayoutFlags::NO_POINTERS_NO_PADDING;
                     }
+                    let type_layout = TypeLayout::struct_layout(
+                        total,
+                        max_align,
+                        const_bcs_size,
+                        flags,
+                        layout_fields.into_boxed_slice(),
+                    );
+                    Ok(Some(ctx.publish_layout(ty, type_layout)))
                 },
                 Some(FieldTypes::Enum(_)) => {
                     // Enum size is fixed (heap pointer) regardless of variant
                     // fields. We do not walk variants here because their types
                     // are only needed for pack/unpack/test.
                     ctx.set_nominal_layout(ty, 8, 8, None)?;
+                    let type_layout = TypeLayout::open_enum(ty, *nominal_ty_args);
+                    Ok(Some(ctx.publish_layout(ty, type_layout)))
                 },
             }
         },
     }
-    Ok(())
 }

--- a/third_party/move/mono-move/testsuite/src/print_sections.rs
+++ b/third_party/move/mono-move/testsuite/src/print_sections.rs
@@ -20,7 +20,7 @@ use mono_move_core::{
     interner::{InternedIdentifier, InternedModuleId},
     native::NoNatives,
     types::{FieldLayout, InternedType, InternedTypeList, EMPTY_TYPE_LIST},
-    DescriptorId, FieldTypes, FrameOffset, Interner, LayoutId, LayoutProvider, TypeLayout,
+    DescriptorId, FieldTypes, FrameOffset, Interner, LayoutId, LayoutProvider, ValueLayout,
 };
 use mono_move_global_context::ExecutionGuard;
 use move_binary_format::{access::ModuleAccess, CompiledModule};
@@ -256,11 +256,11 @@ impl SpecializerContext for SnapshotLoaderContext<'_, '_, '_> {
         self.guard.layout_id_for(ty)
     }
 
-    fn layout(&self, id: LayoutId) -> Option<&TypeLayout> {
+    fn layout(&self, id: LayoutId) -> Option<&ValueLayout> {
         self.guard.layout(id)
     }
 
-    fn publish_layout(&self, ty: InternedType, layout: TypeLayout) -> LayoutId {
+    fn publish_layout(&self, ty: InternedType, layout: ValueLayout) -> LayoutId {
         self.guard.publish_layout(ty, layout)
     }
 }

--- a/third_party/move/mono-move/testsuite/src/print_sections.rs
+++ b/third_party/move/mono-move/testsuite/src/print_sections.rs
@@ -20,7 +20,7 @@ use mono_move_core::{
     interner::{InternedIdentifier, InternedModuleId},
     native::NoNatives,
     types::{FieldLayout, InternedType, InternedTypeList, EMPTY_TYPE_LIST},
-    DescriptorId, FieldTypes, FrameOffset, Interner,
+    DescriptorId, FieldTypes, FrameOffset, Interner, LayoutId, LayoutProvider, TypeLayout,
 };
 use mono_move_global_context::ExecutionGuard;
 use move_binary_format::{access::ModuleAccess, CompiledModule};
@@ -250,5 +250,17 @@ impl SpecializerContext for SnapshotLoaderContext<'_, '_, '_> {
         Ok(self
             .guard
             .publish_captured_data_descriptor(values_size, pointer_offsets))
+    }
+
+    fn layout_id_for(&self, ty: InternedType) -> Option<LayoutId> {
+        self.guard.layout_id_for(ty)
+    }
+
+    fn layout(&self, id: LayoutId) -> Option<&TypeLayout> {
+        self.guard.layout(id)
+    }
+
+    fn publish_layout(&self, ty: InternedType, layout: TypeLayout) -> LayoutId {
+        self.guard.publish_layout(ty, layout)
     }
 }


### PR DESCRIPTION
## Description

This adds a flat, ID-indexed `TypeLayout` table and the type-driven value walks that run off it. A layout describes the shape of a concrete type once, and the walks chase `LayoutId`s instead of re-interpreting the `Type` DAG on every access.

Layouts are built in the same specializer pass that already publishes GC object descriptors (`discover_type_metadata`). The two tables stay separate on purpose:

- Object descriptors are shallow, must be present at the moment a value exists, and live for the value's lifetime. The GC reads them out of object headers.
- Type layouts are deep and describe the full nested shape. They drive serialization, comparison, and so on.

They meet at exactly one point: a `Vector` layout carries the `DescriptorId` of its heap box, so deserialization can stamp the header on a freshly allocated box.

The walks added in `runtime/src/value_utils.rs`:

- `const_serialized_size` — fixed BCS size, or `None` when data-dependent.
- `serialize` / `serialized_size` — BCS-encode an in-memory value.
- `deserialize` — the write side; allocates heap boxes for vectors.
- `equals` — structural equality.
- `compare` — 3-way ordering (integers numerically, `address`/`signer` and vectors lexicographically, structs field-by-field).

### Design notes

The blittable fast path is the main performance lever. A layout flagged `NO_POINTERS_NO_PADDING` has no heap pointers and no padding, so serialize and deserialize are a single `memcpy` and equality is a single `memcmp`. For a struct, that flag reduces to one check: `const_bcs_size == in_memory_size`. A pointer field forces `const_bcs_size` to `None`, and any alignment padding makes the packed BCS size strictly smaller than the in-memory size, so the equality catches both conditions on its own.

The serialize and deserialize `memcpy` paths are sound only on little-endian hosts, because they treat the native-endian in-memory bytes as the little-endian BCS encoding. Those four spots carry `TODO(correctness)` markers. The `memcmp` equality path is endian-neutral (bitwise equality holds regardless of byte order).

Integers cannot use `memcmp` for ordering, so `UnsignedInt`/`SignedInt`/`Address` are separate layout kinds with their own compare. `compare` loads the little-endian bytes into the native integer of the matching width (`u8`..`u128`/`U256`, signed analogues, via `from_le_bytes`) and compares numerically. This is one wide register compare per scalar, and it is endian-portable: `from_le_bytes` yields the correct logical value on any host. `address` and `signer` are 32-byte lexicographic, which is `memcmp`.

The layout table is a `boxcar::Vec` (append-only, stable addresses, lock-free reads) with a `DashMap` from type to ID. Reserved IDs 0..15 are pre-seeded for primitives, references, and function values, so those never hit the map. Publishing races are possible under concurrent execution and are resolved the same way as the existing descriptor table: the loser's pushed slot is harmless waste, bounded by unique types times workers.

`deserialize` allocates heap boxes directly and does not run GC mid-walk, the same invariant `deep_copy` relies on. It returns an `AllocationResult`, so on out-of-memory the caller runs GC and retries rather than us trying to keep partial values rooted across a collection.

`try_maintenance_context` now takes `&mut self` and the maintenance guard holds `&mut Context`. The layout table is reset under that exclusive reference, so it needs no per-access locking. This let three runtime-locking race tests go away — the exclusivity is now enforced at compile time.

### Not supported yet

- Enums (`OpenEnum`) and function values: the layout kinds exist but the walks `todo!()`. References serialize to an error and are unreachable in the other walks.
- `deserialize` assumes trusted input (resources, global storage). It does not yet validate `bool` bytes, enum tags, or full input consumption (trailing bytes are not rejected), so it is not safe for adversarial `bcs::from_bytes` input. That checked path is future work.
- Big-endian hosts. The blittable serialize/deserialize `memcpy` fast paths assume the in-memory representation equals the BCS byte order (marked with `TODO(correctness)`); `compare` and `equals` are already endian-neutral.
- The walks are not wired into the interpreter yet (`#[allow(dead_code)]`); this PR is the layout machinery and the walks, tested directly.

## How Has This Been Tested?

Unit tests in `core/src/type_layout.rs` (reserved IDs match their constants, primitive const sizes) and in `runtime/src/value_utils.rs` (round-trips for primitives, blittable and padded structs, `vector<u8>`, nested vectors, empty-vector-is-null, plus equality and ordering). Property tests cross-check `serialize`/`deserialize`/`compare`/`equals` against `bcs` and Rust's derived `Ord`/`Eq` for every integer width, `bool`, and `address`. Existing BST cross-check and snapshot tests still pass.

## Key Areas to Review

- `specializer/src/lower/context.rs` — the struct arm of `discover_type_metadata`. Layout building piggybacks on the existing offset/size fold in a single pass: one recursion collects field layout IDs, then one fold computes offsets, the const BCS size, and the blittable flag together. Worth checking the defer logic — a field that is sized but whose layout is not yet published only happens for a vector whose element type is not yet built, and that path returns `Ok(None)` to retry on a later pass.
- `runtime/src/value_utils.rs` — all walks are `unsafe` and do raw pointer arithmetic against the value representation. The vector arms depend on the "null pointer means empty vector" invariant. The integer `compare` arms read fixed-width arrays straight from the pointer (`read_array`) and compare via `from_le_bytes`.
- `global-context/src/context.rs` — the `&mut` maintenance change and the layout table reset.
- The blittable predicate (`const_bcs_size == size`) — the argument for why it is sufficient on its own is in the design notes above.

## Type of Change
- [x] New feature

## Which Components or Systems Does This Change Impact?
- [x] Move/Aptos Virtual Machine

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches VM value representation and unsafe layout walks that will underpin serialization and comparison; maintenance API change to `&mut` affects global context lifecycle, though interpreter integration is still deferred.
> 
> **Overview**
> Introduces **flat, ID-indexed `ValueLayout` tables** and layout-driven value walks for mono-move, separate from but built alongside existing GC object descriptors.
> 
> **Core & global context:** New `value_layout` types (`LayoutId`, `ValueLayout`, `LayoutKind`, `LayoutProvider`, reserved primitive IDs 0–15). `GlobalContext` stores published layouts in an append-only `boxcar::Vec` plus a type→ID `DashMap`, with `publish_layout` / lookup on `ExecutionGuard`. Maintenance now takes `&mut GlobalContext` and holds `&mut Context` so layout tables reset under exclusive access (replacing several runtime lock race tests).
> 
> **Specializer:** `discover_type_metadata` now also publishes `ValueLayout`s (vectors link element layout + vector `DescriptorId`; structs compute field offsets, fixed BCS size, and `NO_POINTERS_NO_PADDING` when packed BCS size equals in-memory size).
> 
> **Runtime:** New `value_utils` implements BCS **serialize** / **deserialize**, **equals**, and **compare** by walking layouts (blittable `memcpy`/`memcmp` fast paths; deserialize allocates vector boxes via `heap_alloc` without mid-walk GC). `LayoutProvider` is threaded through loader, transaction/local contexts, and the interpreter type bound. Adds `read_vec_len` (null pointer = empty vector), BCS-specific runtime errors, and exports `heap_alloc` for deserialization.
> 
> Walks are **not yet hooked into interpreter micro-ops** (`#[allow(dead_code)]`); enums/functions/refs in walks remain `todo!()` or errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6012c75025465401cc9f332e5de8eb40665de24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->