### PR TITLE
[types] Return Result from OnChainConfig::fetch_config

### DIFF
--- a/api/src/context.rs
+++ b/api/src/context.rs
@@ -168,7 +168,7 @@ impl Context {
 
     pub fn feature_enabled(&self, feature: FeatureFlag) -> Result<bool> {
         let state_view = self.latest_state_view()?;
-        let features = Features::fetch_config(&state_view)
+        let features = Features::fetch_config(&state_view)?
             .ok_or_else(|| anyhow::anyhow!("Failed to fetch features from state view"))?;
         Ok(features.is_enabled(feature))
     }
@@ -1455,8 +1455,10 @@ impl Context {
                 })?;
 
             let gas_schedule_params = {
-                let may_be_params =
-                    GasScheduleV2::fetch_config(&state_view).and_then(|gas_schedule| {
+                let may_be_params = GasScheduleV2::fetch_config(&state_view)
+                    .ok()
+                    .flatten()
+                    .and_then(|gas_schedule| {
                         let feature_version = gas_schedule.feature_version;
                         let gas_schedule = gas_schedule.into_btree_map();
                         AptosGasParameters::from_on_chain_gas_schedule(
@@ -1468,6 +1470,8 @@ impl Context {
                 match may_be_params {
                     Some(gas_schedule) => Ok(gas_schedule),
                     None => GasSchedule::fetch_config(&state_view)
+                        .ok()
+                        .flatten()
                         .and_then(|gas_schedule| {
                             let gas_schedule = gas_schedule.into_btree_map();
                             AptosGasParameters::from_on_chain_gas_schedule(&gas_schedule, 0).ok()
@@ -1525,6 +1529,8 @@ impl Context {
                 })?;
 
             let execution_onchain_config = OnChainExecutionConfig::fetch_config(&state_view)
+                .ok()
+                .flatten()
                 .unwrap_or_else(OnChainExecutionConfig::default_if_missing);
 
             // Update the cache

--- a/aptos-move/aptos-e2e-comparison-testing/src/execution.rs
+++ b/aptos-move/aptos-e2e-comparison-testing/src/execution.rs
@@ -409,7 +409,7 @@ impl Execution {
         }
 
         // Update features if needed to the correct binary format used by V2 compiler.
-        let mut features = Features::fetch_config(&state).unwrap_or_default();
+        let mut features = Features::fetch_config(&state).unwrap().unwrap_or_default();
         self.enable_features(&mut features, &self.enable_features);
         self.disable_features(&mut features, &self.disable_features);
 

--- a/aptos-move/aptos-release-builder/src/simulate.rs
+++ b/aptos-move/aptos-release-builder/src/simulate.rs
@@ -328,7 +328,7 @@ fn force_end_epoch(state_view: &impl SimulationStateStore) -> Result<()> {
     let module_storage = state_view.as_aptos_code_storage(&env);
 
     let gas_schedule =
-        GasScheduleV2::fetch_config(&state_view).context("failed to fetch gas schedule v2")?;
+        GasScheduleV2::fetch_config(&state_view)?.context("failed to fetch gas schedule v2")?;
     let gas_feature_version = gas_schedule.feature_version;
 
     let change_set_configs =
@@ -432,10 +432,10 @@ pub async fn simulate_multistep_proposal(
 
         // Fetch the on-chain configs that are needed for the simulation.
         let chain_id =
-            ChainIdResource::fetch_config(&state_view).context("failed to fetch chain id")?;
+            ChainIdResource::fetch_config(&state_view)?.context("failed to fetch chain id")?;
 
         let gas_schedule =
-            GasScheduleV2::fetch_config(&state_view).context("failed to fetch gas schedule v2")?;
+            GasScheduleV2::fetch_config(&state_view)?.context("failed to fetch gas schedule v2")?;
         let gas_feature_version = gas_schedule.feature_version;
         let gas_params = AptosGasParameters::from_on_chain_gas_schedule(
             &gas_schedule.into_btree_map(),

--- a/aptos-move/aptos-resource-viewer/src/module_view.rs
+++ b/aptos-move/aptos-resource-viewer/src/module_view.rs
@@ -40,7 +40,10 @@ pub struct ModuleView<'a, S> {
 
 impl<'a, S: StateView> ModuleView<'a, S> {
     pub fn new(state_view: &'a S) -> Self {
-        let features = Features::fetch_config(state_view).unwrap_or_default();
+        let features = Features::fetch_config(state_view)
+            .ok()
+            .flatten()
+            .unwrap_or_default();
         let deserializer_config = aptos_prod_deserializer_config(&features);
 
         Self {

--- a/aptos-move/aptos-transaction-benchmarks/src/transaction_bench_state.rs
+++ b/aptos-move/aptos-transaction-benchmarks/src/transaction_bench_state.rs
@@ -116,6 +116,7 @@ where
         };
 
         let validator_set = ValidatorSet::fetch_config(&InMemoryStateStore::from_head_genesis())
+            .unwrap()
             .expect("Unable to retrieve the validator set from storage");
 
         Self {

--- a/aptos-move/aptos-transaction-simulation/src/state_store.rs
+++ b/aptos-move/aptos-transaction-simulation/src/state_store.rs
@@ -132,7 +132,7 @@ pub trait SimulationStateStore: TStateView<Key = StateKey> {
         Self: Sized,
         C: OnChainConfig,
     {
-        C::fetch_config(self).ok_or_else(|| {
+        C::fetch_config(self)?.ok_or_else(|| {
             anyhow!(
                 "failed to fetch on-chain config: {:?}",
                 std::any::type_name::<C>()

--- a/aptos-move/aptos-vm-environment/src/environment.rs
+++ b/aptos-move/aptos-vm-environment/src/environment.rs
@@ -323,7 +323,7 @@ fn fetch_config_and_update_hash<T: OnChainConfig>(
     sha3_256: &mut Sha3_256,
     state_view: &impl StateView,
 ) -> Option<T> {
-    let (config, bytes) = T::fetch_config_and_bytes(state_view)?;
+    let (config, bytes) = T::fetch_config_and_bytes(state_view).ok().flatten()?;
     sha3_256.update(&bytes);
     Some(config)
 }

--- a/aptos-move/aptos-vm-environment/src/gas.rs
+++ b/aptos-move/aptos-vm-environment/src/gas.rs
@@ -14,6 +14,8 @@ use sha3::{digest::Update, Sha3_256};
 /// returns 0 gas feature version.
 pub fn get_gas_feature_version(state_view: &impl StateView) -> u64 {
     GasScheduleV2::fetch_config(state_view)
+        .ok()
+        .flatten()
         .map(|gas_schedule| gas_schedule.feature_version)
         .unwrap_or(0)
 }
@@ -24,7 +26,10 @@ fn get_gas_config_from_storage(
     sha3_256: &mut Sha3_256,
     state_view: &impl StateView,
 ) -> (Result<AptosGasParameters, String>, u64) {
-    match GasScheduleV2::fetch_config_and_bytes(state_view) {
+    match GasScheduleV2::fetch_config_and_bytes(state_view)
+        .ok()
+        .flatten()
+    {
         Some((gas_schedule, bytes)) => {
             sha3_256.update(&bytes);
             let feature_version = gas_schedule.feature_version;
@@ -34,7 +39,10 @@ fn get_gas_config_from_storage(
                 feature_version,
             )
         },
-        None => match GasSchedule::fetch_config_and_bytes(state_view) {
+        None => match GasSchedule::fetch_config_and_bytes(state_view)
+            .ok()
+            .flatten()
+        {
             Some((gas_schedule, bytes)) => {
                 sha3_256.update(&bytes);
                 let map = gas_schedule.into_btree_map();

--- a/aptos-move/aptos-vm-environment/src/prod_configs.rs
+++ b/aptos-move/aptos-vm-environment/src/prod_configs.rs
@@ -320,9 +320,13 @@ impl RandomnessConfig {
     /// Returns randomness config based on the current state.
     pub fn fetch(state_view: &impl StateView) -> Self {
         let randomness_api_v0_required_deposit = RequiredGasDeposit::fetch_config(state_view)
+            .ok()
+            .flatten()
             .unwrap_or_else(RequiredGasDeposit::default_if_missing)
             .gas_amount;
         let allow_rand_contract_custom_max_gas = AllowCustomMaxGasFlag::fetch_config(state_view)
+            .ok()
+            .flatten()
             .unwrap_or_else(AllowCustomMaxGasFlag::default_if_missing)
             .value;
         Self {

--- a/aptos-move/aptos-vm-types/src/storage/io_pricing.rs
+++ b/aptos-move/aptos-vm-types/src/storage/io_pricing.rs
@@ -249,7 +249,10 @@ impl IoPricing {
 
         match feature_version {
             0 => V1(IoPricingV1::new(gas_params)),
-            1..=9 => match StorageGasSchedule::fetch_config(config_storage) {
+            1..=9 => match StorageGasSchedule::fetch_config(config_storage)
+                .ok()
+                .flatten()
+            {
                 None => V1(IoPricingV1::new(gas_params)),
                 Some(schedule) => V2(IoPricingV2::new_with_storage_curves(
                     feature_version,

--- a/aptos-move/aptos-vm-types/src/storage/mod.rs
+++ b/aptos-move/aptos-vm-types/src/storage/mod.rs
@@ -79,7 +79,7 @@ impl StorageGasParameters {
 struct DummyConfigStorage;
 
 impl ConfigStorage for DummyConfigStorage {
-    fn fetch_config_bytes(&self, _state_key: &StateKey) -> Option<Bytes> {
+    fn fetch_config_bytes(&self, _state_key: &StateKey) -> anyhow::Result<Option<Bytes>> {
         unreachable!("Not supposed to be called from latest() / tests.")
     }
 }

--- a/aptos-move/aptos-vm/src/data_cache.rs
+++ b/aptos-move/aptos-vm/src/data_cache.rs
@@ -251,10 +251,8 @@ impl<E: ExecutorView> TDelayedFieldView for StorageAdapter<'_, E> {
 }
 
 impl<E: ExecutorView> ConfigStorage for StorageAdapter<'_, E> {
-    fn fetch_config_bytes(&self, state_key: &StateKey) -> Option<Bytes> {
-        self.executor_view
-            .get_resource_bytes(state_key, None)
-            .ok()?
+    fn fetch_config_bytes(&self, state_key: &StateKey) -> anyhow::Result<Option<Bytes>> {
+        Ok(self.executor_view.get_resource_bytes(state_key, None)?)
     }
 }
 
@@ -265,7 +263,10 @@ pub trait AsMoveResolver<S> {
 
 impl<S: StateView> AsMoveResolver<S> for S {
     fn as_move_resolver(&self) -> StorageAdapter<'_, S> {
-        let features = Features::fetch_config(self).unwrap_or_default();
+        let features = Features::fetch_config(self)
+            .ok()
+            .flatten()
+            .unwrap_or_default();
         let gas_feature_version = get_gas_feature_version(self);
         let resource_group_adapter = ResourceGroupAdapter::new(
             None,

--- a/aptos-move/aptos-vm/src/keyless_validation.rs
+++ b/aptos-move/aptos-vm/src/keyless_validation.rs
@@ -83,13 +83,18 @@ fn get_resource_on_chain_at_addr<T: MoveStructType + for<'a> Deserialize<'a>>(
 fn get_current_time_onchain(
     resolver: &impl AptosMoveResolver,
 ) -> anyhow::Result<CurrentTimeMicroseconds, VMStatus> {
-    CurrentTimeMicroseconds::fetch_config(resolver).ok_or_else(|| {
-        value_deserialization_error!("could not fetch CurrentTimeMicroseconds on-chain config")
-    })
+    CurrentTimeMicroseconds::fetch_config(resolver)
+        .ok()
+        .flatten()
+        .ok_or_else(|| {
+            value_deserialization_error!("could not fetch CurrentTimeMicroseconds on-chain config")
+        })
 }
 
 fn get_jwks_onchain(resolver: &impl AptosMoveResolver) -> anyhow::Result<PatchedJWKs, VMStatus> {
     PatchedJWKs::fetch_config(resolver)
+        .ok()
+        .flatten()
         .ok_or_else(|| value_deserialization_error!("could not deserialize PatchedJWKs"))
 }
 

--- a/aptos-move/aptos-vm/src/move_vm_ext/write_op_converter.rs
+++ b/aptos-move/aptos-vm/src/move_vm_ext/write_op_converter.rs
@@ -63,7 +63,8 @@ impl<'r> WriteOpConverter<'r> {
     ) -> Self {
         let mut new_slot_metadata: Option<StateValueMetadata> = None;
         if is_storage_slot_metadata_enabled {
-            if let Some(current_time) = CurrentTimeMicroseconds::fetch_config(remote) {
+            if let Some(current_time) = CurrentTimeMicroseconds::fetch_config(remote).ok().flatten()
+            {
                 // The deposit on the metadata is a placeholder (0), it will be updated later when
                 // storage fee is charged.
                 new_slot_metadata = Some(StateValueMetadata::placeholder(&current_time));

--- a/aptos-move/aptos-vm/src/transaction_metadata.rs
+++ b/aptos-move/aptos-vm/src/transaction_metadata.rs
@@ -68,6 +68,8 @@ impl TransactionMetadata {
             if let Ok(TransactionExecutableRef::Script(s)) = txn.payload().executable_ref() {
                 let script_hash = HashValue::sha3_256_of(s.code()).to_vec();
                 let is_approved_gov_script = ApprovedExecutionHashes::fetch_config(resolver)
+                    .ok()
+                    .flatten()
                     .is_some_and(|approved| {
                         approved
                             .entries

--- a/aptos-move/aptos-vm/src/validator_txns/chunky_dkg.rs
+++ b/aptos-move/aptos-vm/src/validator_txns/chunky_dkg.rs
@@ -106,19 +106,25 @@ impl AptosVM {
             signature,
         } = certified_transcript;
 
-        let config_resource = ConfigurationResource::fetch_config(resolver).ok_or(
-            ExecutionFailure::Expected(ExpectedFailure::MissingResourceConfiguration),
-        )?;
+        let config_resource = ConfigurationResource::fetch_config(resolver)
+            .ok()
+            .flatten()
+            .ok_or(ExecutionFailure::Expected(
+                ExpectedFailure::MissingResourceConfiguration,
+            ))?;
         if metadata.epoch != config_resource.epoch() {
             return Err(ExecutionFailure::Expected(ExpectedFailure::EpochNotCurrent));
         }
 
-        let validator_set = ValidatorSet::fetch_config(resolver).ok_or(
+        let validator_set = ValidatorSet::fetch_config(resolver).ok().flatten().ok_or(
             ExecutionFailure::Expected(ExpectedFailure::MissingResourceValidatorSet),
         )?;
-        let chunky_dkg_state = ChunkyDKGState::fetch_config(resolver).ok_or(
-            ExecutionFailure::Expected(ExpectedFailure::MissingResourceChunkyDKGState),
-        )?;
+        let chunky_dkg_state = ChunkyDKGState::fetch_config(resolver)
+            .ok()
+            .flatten()
+            .ok_or(ExecutionFailure::Expected(
+                ExpectedFailure::MissingResourceChunkyDKGState,
+            ))?;
 
         let _in_progress_session_state =
             chunky_dkg_state

--- a/aptos-move/aptos-vm/src/validator_txns/dkg.rs
+++ b/aptos-move/aptos-vm/src/validator_txns/dkg.rs
@@ -88,9 +88,13 @@ impl AptosVM {
         session_id: SessionId,
         dkg_node: DKGTranscript,
     ) -> Result<(VMStatus, VMOutput), ExecutionFailure> {
-        let dkg_state =
-            OnChainConfig::fetch_config(resolver).ok_or(Expected(MissingResourceDKGState))?;
+        let dkg_state = OnChainConfig::fetch_config(resolver)
+            .ok()
+            .flatten()
+            .ok_or(Expected(MissingResourceDKGState))?;
         let config_resource = ConfigurationResource::fetch_config(resolver)
+            .ok()
+            .flatten()
             .ok_or(Expected(MissingResourceConfiguration))?;
         let DKGState { in_progress, .. } = dkg_state;
         let in_progress_session_state =

--- a/aptos-move/aptos-vm/src/validator_txns/jwk.rs
+++ b/aptos-move/aptos-vm/src/validator_txns/jwk.rs
@@ -106,10 +106,14 @@ impl AptosVM {
         update: jwks::QuorumCertifiedUpdate,
     ) -> Result<(VMStatus, VMOutput), ExecutionFailure> {
         // Load resources.
-        let validator_set =
-            ValidatorSet::fetch_config(resolver).ok_or(Expected(MissingResourceValidatorSet))?;
-        let observed_jwks =
-            ObservedJWKs::fetch_config(resolver).ok_or(Expected(MissingResourceObservedJWKs))?;
+        let validator_set = ValidatorSet::fetch_config(resolver)
+            .ok()
+            .flatten()
+            .ok_or(Expected(MissingResourceValidatorSet))?;
+        let observed_jwks = ObservedJWKs::fetch_config(resolver)
+            .ok()
+            .flatten()
+            .ok_or(Expected(MissingResourceObservedJWKs))?;
 
         let mut jwks_by_issuer: HashMap<Issuer, ProviderJWKs> =
             observed_jwks.into_providers_jwks().into();

--- a/aptos-move/e2e-tests/src/executor.rs
+++ b/aptos-move/e2e-tests/src/executor.rs
@@ -512,8 +512,9 @@ impl<O: OutputLogger> FakeExecutorImpl<O> {
         //  - the e2e test outputs a golden file, and
         //  - the environment variable is properly set
         if let Some(env_trace_dir) = env::var_os(ENV_TRACE_DIR) {
-            let aptos_version =
-                AptosVersion::fetch_config(&self.state_store).map_or(0, |v| v.major);
+            let aptos_version = AptosVersion::fetch_config(&self.state_store)
+                .unwrap()
+                .map_or(0, |v| v.major);
 
             let trace_dir = Path::new(&env_trace_dir).join(file_name);
             if trace_dir.exists() {
@@ -602,7 +603,9 @@ impl<O: OutputLogger> FakeExecutorImpl<O> {
         balance: u64,
         seq_num: u64,
     ) -> AccountData {
-        let features = Features::fetch_config(&self.state_store).unwrap_or_default();
+        let features = Features::fetch_config(&self.state_store)
+            .unwrap()
+            .unwrap_or_default();
         let use_fa_balance = features.is_enabled(FeatureFlag::NEW_ACCOUNTS_DEFAULT_TO_FA_APT_STORE);
         let use_concurrent_balance =
             features.is_enabled(FeatureFlag::DEFAULT_TO_CONCURRENT_FUNGIBLE_BALANCE);
@@ -1226,6 +1229,7 @@ impl<O: OutputLogger> FakeExecutorImpl<O> {
         txn_block: Vec<Transaction>,
     ) -> Result<Vec<TransactionOutput>, VMStatus> {
         let validator_set = ValidatorSet::fetch_config(&self.state_store)
+            .unwrap()
             .expect("Unable to retrieve the validator set from storage");
         let proposer = *validator_set.payload().next().unwrap().account_address();
         // when updating time, proposer cannot be ZERO.
@@ -1240,6 +1244,7 @@ impl<O: OutputLogger> FakeExecutorImpl<O> {
         mut txn_block: Vec<Transaction>,
     ) -> Result<Vec<TransactionOutput>, VMStatus> {
         let validator_set = ValidatorSet::fetch_config(&self.state_store)
+            .unwrap()
             .expect("Unable to retrieve the validator set from storage");
         let new_block_metadata = BlockMetadata::new(
             HashValue::zero(),
@@ -1298,6 +1303,7 @@ impl<O: OutputLogger> FakeExecutorImpl<O> {
         self.block_time = time_microseconds;
 
         let validator_set = ValidatorSet::fetch_config(&self.state_store)
+            .unwrap()
             .expect("Unable to retrieve the validator set from storage");
         let proposer = *validator_set.payload().next().unwrap().account_address();
         // when updating time, proposer cannot be ZERO.

--- a/aptos-move/e2e-testsuite/src/tests/on_chain_configs.rs
+++ b/aptos-move/e2e-testsuite/src/tests/on_chain_configs.rs
@@ -16,7 +16,10 @@ fn initial_aptos_version() {
     let resolver = executor.get_state_view().as_move_resolver();
     let version = aptos_types::on_chain_config::APTOS_MAX_KNOWN_VERSION;
 
-    assert_eq!(AptosVersion::fetch_config(&resolver).unwrap(), version);
+    assert_eq!(
+        AptosVersion::fetch_config(&resolver).unwrap().unwrap(),
+        version
+    );
     let account = executor.new_account_at(CORE_CODE_ADDRESS);
     let txn_0 = account
         .transaction()
@@ -35,7 +38,7 @@ fn initial_aptos_version() {
 
     let resolver = executor.get_state_view().as_move_resolver();
     assert_eq!(
-        AptosVersion::fetch_config(&resolver).unwrap(),
+        AptosVersion::fetch_config(&resolver).unwrap().unwrap(),
         AptosVersion {
             major: version.major + 1
         }
@@ -47,7 +50,10 @@ fn drop_txn_after_reconfiguration() {
     let mut executor = FakeExecutor::from_head_genesis();
     let resolver = executor.get_state_view().as_move_resolver();
     let version = aptos_types::on_chain_config::APTOS_MAX_KNOWN_VERSION;
-    assert_eq!(AptosVersion::fetch_config(&resolver).unwrap(), version);
+    assert_eq!(
+        AptosVersion::fetch_config(&resolver).unwrap().unwrap(),
+        version
+    );
 
     let txn = executor
         .new_account_at(CORE_CODE_ADDRESS)

--- a/aptos-node/src/utils.rs
+++ b/aptos-node/src/utils.rs
@@ -46,7 +46,7 @@ pub fn fetch_chain_id(db: &DbReaderWriter) -> anyhow::Result<ChainId> {
         .reader
         .latest_state_checkpoint_view()
         .map_err(|err| anyhow!("[aptos-node] failed to create db state view {}", err))?;
-    Ok(ChainIdResource::fetch_config(&db_state_view)
+    Ok(ChainIdResource::fetch_config(&db_state_view)?
         .expect("[aptos-node] missing chain ID resource")
         .chain_id())
 }

--- a/execution/executor/src/chunk_executor/mod.rs
+++ b/execution/executor/src/chunk_executor/mod.rs
@@ -77,10 +77,10 @@ pub mod transaction_chunk;
 /// When the `Features` resource is absent in the parent state — pre-genesis
 /// replay, or test setups whose genesis doesn't write it — fall back to
 /// `new_no_block_limit()`'s defaults, matching `db_bootstrapper`.
-fn chunk_onchain_config(state_view: &CachedStateView) -> BlockExecutorConfigFromOnchain {
+fn chunk_onchain_config(state_view: &CachedStateView) -> Result<BlockExecutorConfigFromOnchain> {
     // State sync executor shouldn't have block gas limit.
     let base = BlockExecutorConfigFromOnchain::new_no_block_limit();
-    match Features::fetch_config(state_view) {
+    Ok(match Features::fetch_config(state_view)? {
         Some(features) => base.with_features(&features),
         None => {
             info!(
@@ -89,7 +89,7 @@ fn chunk_onchain_config(state_view: &CachedStateView) -> BlockExecutorConfigFrom
             );
             base
         },
-    }
+    })
 }
 
 pub struct ChunkExecutor<V> {
@@ -649,7 +649,7 @@ impl<V: VMBlockExecutor> ChunkExecutorInner<V> {
             .take((end_version - begin_version) as usize)
             .map(|persisted_aux_info| AuxiliaryInfo::new(*persisted_aux_info, None))
             .collect::<Vec<_>>();
-        let onchain_config = chunk_onchain_config(&state_view);
+        let onchain_config = chunk_onchain_config(&state_view)?;
         let execution_output = DoGetExecutionOutput::by_transaction_execution::<V>(
             &V::new(),
             txns.into(),

--- a/execution/executor/src/chunk_executor/transaction_chunk.rs
+++ b/execution/executor/src/chunk_executor/transaction_chunk.rs
@@ -96,7 +96,7 @@ impl TransactionChunk for ChunkToExecute {
         };
 
         let _timer = VM_EXECUTE_CHUNK.start_timer();
-        let onchain_config = chunk_onchain_config(&state_view);
+        let onchain_config = chunk_onchain_config(&state_view)?;
         DoGetExecutionOutput::by_transaction_execution::<V>(
             &V::new(),
             sig_verified_txns.into(),
@@ -140,7 +140,7 @@ impl TransactionChunk for ChunkToApply {
             first_version: _,
         } = self;
 
-        let onchain_config = chunk_onchain_config(&state_view);
+        let onchain_config = chunk_onchain_config(&state_view)?;
         DoGetExecutionOutput::by_transaction_output(
             transactions,
             transaction_outputs,

--- a/execution/executor/src/db_bootstrapper/mod.rs
+++ b/execution/executor/src/db_bootstrapper/mod.rs
@@ -126,7 +126,7 @@ pub fn calculate_genesis<V: VMBlockExecutor>(
         Arc::clone(&db.reader),
         ledger_summary.state.latest().clone(),
     )?;
-    let onchain_config = genesis_onchain_config(&base_state_view);
+    let onchain_config = genesis_onchain_config(&base_state_view)?;
 
     let epoch = if genesis_version == 0 {
         GENESIS_EPOCH
@@ -205,11 +205,11 @@ pub fn calculate_genesis<V: VMBlockExecutor>(
     Ok(committer)
 }
 
-fn genesis_onchain_config(state_view: &CachedStateView) -> BlockExecutorConfigFromOnchain {
+fn genesis_onchain_config(state_view: &CachedStateView) -> Result<BlockExecutorConfigFromOnchain> {
     let base = BlockExecutorConfigFromOnchain::new_no_block_limit();
     // Bootstrapping from an empty DB is the common case, so the parent state usually has no
     // `Features` resource. Hard-fork genesis is the case where parent-state features exist.
-    match Features::fetch_config(state_view) {
+    Ok(match Features::fetch_config(state_view)? {
         Some(features) => base.with_features(&features),
         None => {
             info!(
@@ -218,7 +218,7 @@ fn genesis_onchain_config(state_view: &CachedStateView) -> BlockExecutorConfigFr
             );
             base
         },
-    }
+    })
 }
 
 fn get_state_timestamp(state_view: &CachedStateView) -> Result<u64> {

--- a/execution/executor/src/workflow/do_get_execution_output.rs
+++ b/execution/executor/src/workflow/do_get_execution_output.rs
@@ -543,9 +543,9 @@ impl Parser {
             write_set: last_write_set,
         };
 
-        let validator_set = ValidatorSet::fetch_config(&write_set_view)
+        let validator_set = ValidatorSet::fetch_config(&write_set_view)?
             .ok_or_else(|| anyhow!("ValidatorSet not touched on epoch change"))?;
-        let configuration = ConfigurationResource::fetch_config(&write_set_view)
+        let configuration = ConfigurationResource::fetch_config(&write_set_view)?
             .ok_or_else(|| anyhow!("Configuration resource not touched on epoch change"))?;
 
         Ok(EpochState::new(

--- a/execution/executor/tests/db_bootstrapper_test.rs
+++ b/execution/executor/tests/db_bootstrapper_test.rs
@@ -183,12 +183,14 @@ fn get_balance(account: &AccountAddress, db: &DbReaderWriter) -> u64 {
 
 fn get_configuration(db: &DbReaderWriter) -> ConfigurationResource {
     let db_state_view = db.reader.latest_state_checkpoint_view().unwrap();
-    ConfigurationResource::fetch_config(&db_state_view).unwrap()
+    ConfigurationResource::fetch_config(&db_state_view)
+        .unwrap()
+        .unwrap()
 }
 
 fn get_features(db: &DbReaderWriter) -> Features {
     let db_state_view = db.reader.latest_state_checkpoint_view().unwrap();
-    Features::fetch_config(&db_state_view).unwrap()
+    Features::fetch_config(&db_state_view).unwrap().unwrap()
 }
 
 fn assert_committed_write_set_version(db: &DbReaderWriter, version: u64, expected_v1: bool) {

--- a/execution/executor/tests/storage_integration_test.rs
+++ b/execution/executor/tests/storage_integration_test.rs
@@ -94,6 +94,7 @@ fn test_reconfiguration() {
     assert_eq!(
         ValidatorSet::fetch_config(&db_state_view)
             .unwrap()
+            .unwrap()
             .payload()
             .next()
             .unwrap()
@@ -176,7 +177,10 @@ fn test_reconfiguration() {
         .unwrap();
 
     assert_eq!(
-        AptosVersion::fetch_config(&db_state_view).unwrap().major,
+        AptosVersion::fetch_config(&db_state_view)
+            .unwrap()
+            .unwrap()
+            .major,
         42
     );
 }

--- a/state-sync/inter-component/event-notifications/src/lib.rs
+++ b/state-sync/inter-component/event-notifications/src/lib.rs
@@ -294,6 +294,8 @@ impl EventSubscriptionService {
                 ))
             })?;
         let epoch = ConfigurationResource::fetch_config(&db_state_view)
+            .ok()
+            .flatten()
             .ok_or_else(|| {
                 Error::UnexpectedErrorEncountered("Configuration resource does not exist!".into())
             })?

--- a/types/src/on_chain_config/mod.rs
+++ b/types/src/on_chain_config/mod.rs
@@ -141,7 +141,7 @@ impl<P: OnChainConfigProvider> OnChainConfigPayload<P> {
 
 /// Trait to be implemented by a storage type from which to read on-chain configs
 pub trait ConfigStorage {
-    fn fetch_config_bytes(&self, state_key: &StateKey) -> Option<Bytes>;
+    fn fetch_config_bytes(&self, state_key: &StateKey) -> Result<Option<Bytes>>;
 }
 
 /// Trait to be implemented by a Rust struct representation of an on-chain config
@@ -177,23 +177,25 @@ pub trait OnChainConfig: Send + Sync + DeserializeOwned {
     }
 
     /// TODO: This does not work if `T`'s reflection on the Move side is using resource groups.
-    fn fetch_config<T>(storage: &T) -> Option<Self>
+    fn fetch_config<T>(storage: &T) -> Result<Option<Self>>
     where
         T: ConfigStorage + ?Sized,
     {
-        Some(Self::fetch_config_and_bytes(storage)?.0)
+        Ok(Self::fetch_config_and_bytes(storage)?.map(|(config, _bytes)| config))
     }
 
     /// Same as [Self::fetch_config], but also returns the underlying bytes that were used to
     /// deserialize into config.
-    fn fetch_config_and_bytes<T>(storage: &T) -> Option<(Self, Bytes)>
+    fn fetch_config_and_bytes<T>(storage: &T) -> Result<Option<(Self, Bytes)>>
     where
         T: ConfigStorage + ?Sized,
     {
-        let state_key = StateKey::on_chain_config::<Self>().ok()?;
-        let bytes = storage.fetch_config_bytes(&state_key)?;
-        let config = Self::deserialize_into_config(&bytes).ok()?;
-        Some((config, bytes))
+        let state_key = StateKey::on_chain_config::<Self>()?;
+        let Some(bytes) = storage.fetch_config_bytes(&state_key)? else {
+            return Ok(None);
+        };
+        let config = Self::deserialize_into_config(&bytes)?;
+        Ok(Some((config, bytes)))
     }
 
     fn address() -> &'static AccountAddress {
@@ -206,10 +208,8 @@ pub trait OnChainConfig: Send + Sync + DeserializeOwned {
 }
 
 impl<S: StateView> ConfigStorage for S {
-    fn fetch_config_bytes(&self, state_key: &StateKey) -> Option<Bytes> {
-        self.get_state_value(state_key)
-            .ok()?
-            .map(|s| s.bytes().clone())
+    fn fetch_config_bytes(&self, state_key: &StateKey) -> Result<Option<Bytes>> {
+        Ok(self.get_state_value(state_key)?.map(|s| s.bytes().clone()))
     }
 }
 


### PR DESCRIPTION

`fetch_config`, `fetch_config_and_bytes`, and `ConfigStorage::fetch_config_bytes`
used to return `Option`, which silently hid storage and deserialization errors
behind a `None`.

They now return `Result<Option<_>>` so those errors can surface. Call sites
mostly keep the original behavior for now: non-`Result` callers use
`.ok().flatten()`, `anyhow::Result` callers propagate with `?`, and
tests/benchmarks just unwrap.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches VM, API gas/feature caches, executor bootstrap/chunk paths, and validator txn handling; many production paths still use `.ok().flatten()`, so errors may remain hidden until callers adopt explicit propagation.
> 
> **Overview**
> On-chain config reads no longer collapse storage and deserialization failures into a bare `None`. **`OnChainConfig::fetch_config`**, **`fetch_config_and_bytes`**, and **`ConfigStorage::fetch_config_bytes`** now return **`Result<Option<_>>`**: missing resources stay **`Ok(None)`**, while I/O and BCS errors can propagate.
> 
> Call sites across the **API**, **VM**, **executor** (chunk/bootstrap/epoch helpers), **state sync**, **simulation**, and **tests** were updated mechanically—**`?`** where the caller is already `anyhow::Result`, **`.ok().flatten()`** where prior behavior treated any failure like “not found”, and extra **`.unwrap()`** in tests/benchmarks. **`chunk_onchain_config`** / **`genesis_onchain_config`** now return **`Result`** so feature lookup errors surface during chunk execution and bootstrap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d65176a764a0e261cb0934492663d03a83ed617. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->