### PR TITLE
[storage] Native-position value + merkle pruners (reuse main-state machinery)

### DIFF
--- a/storage/aptosdb/src/db/aptosdb_internal.rs
+++ b/storage/aptosdb/src/db/aptosdb_internal.rs
@@ -20,7 +20,8 @@ use crate::{
     utils::truncation_helper::get_current_version_in_state_merkle_db,
 };
 use aptos_config::config::{
-    HotStateConfig, PrunerConfig, RocksdbConfigs, StorageDirPaths, NO_OP_STORAGE_PRUNER_CONFIG,
+    HotStateConfig, PrunerConfig, RocksdbConfigs, StateMerklePrunerConfig, StorageDirPaths,
+    NO_OP_STORAGE_PRUNER_CONFIG,
 };
 use aptos_db_indexer::db_indexer::InternalIndexerDB;
 use aptos_logger::prelude::*;
@@ -160,6 +161,13 @@ impl AptosDB {
             db.write_pruner_progress(synced_version)?;
         }
 
+        // Capture before `pruner_config` is moved; the position pruners
+        // reuse the same windows as main state's value/merkle pruners.
+        let position_value_pruner_config = pruner_config.ledger_pruner_config;
+        let position_state_merkle_pruner_config = pruner_config.state_merkle_pruner_config;
+        let position_epoch_snapshot_pruner_config: StateMerklePrunerConfig =
+            pruner_config.epoch_snapshot_pruner_config.into();
+
         let mut myself = Self::new_with_dbs(
             ledger_db,
             hot_state_merkle_db,
@@ -179,6 +187,9 @@ impl AptosDB {
                 db_paths,
                 rocksdb_configs.state_kv_db_config,
                 rocksdb_configs.state_merkle_db_config,
+                position_value_pruner_config,
+                position_state_merkle_pruner_config,
+                position_epoch_snapshot_pruner_config,
                 &env,
                 &block_cache,
                 readonly,
@@ -215,6 +226,28 @@ impl AptosDB {
                 }
                 if let Some(pruner) = &myself.state_store.state_pruner.hot_epoch_snapshot_pruner {
                     pruner.maybe_set_pruner_target_db_version(version);
+                }
+            }
+
+            // Activate the native-position pruners; otherwise their
+            // workers idle at persisted progress until the next position
+            // commit, even when committed versions are already ahead.
+            let synced_version = myself.get_synced_version()?;
+            if let Some(bundle) = myself.position.as_ref()
+                && let Some(position_pruner) = bundle.position_pruner.as_ref()
+            {
+                if let Some(version) = synced_version {
+                    position_pruner
+                        .value_pruner
+                        .maybe_set_pruner_target_db_version(version);
+                }
+                if let Some(version) = bundle.snapshot_version {
+                    position_pruner
+                        .state_merkle_pruner
+                        .maybe_set_pruner_target_db_version(version);
+                    position_pruner
+                        .epoch_snapshot_pruner
+                        .maybe_set_pruner_target_db_version(version);
                 }
             }
         }

--- a/storage/aptosdb/src/db/aptosdb_native_position.rs
+++ b/storage/aptosdb/src/db/aptosdb_native_position.rs
@@ -10,13 +10,16 @@ use crate::{
     },
     position_db::{PositionDb, NUM_NATIVE_VALUE_SHARDS},
     position_merkle_db::PositionMerkleDb,
+    position_pruner::PositionPruner,
     position_state_store::PositionStateStore,
     utils::truncation_helper::{
         get_position_commit_progress, get_position_merkle_commit_progress,
         truncate_position_db_shards, truncate_position_merkle_db,
     },
 };
-use aptos_config::config::{RocksdbConfig, StorageDirPaths};
+use aptos_config::config::{
+    LedgerPrunerConfig, RocksdbConfig, StateMerklePrunerConfig, StorageDirPaths,
+};
 use aptos_crypto::{hash::CryptoHash, HashValue};
 use aptos_logger::info;
 use aptos_schemadb::{Cache, Env};
@@ -27,6 +30,12 @@ use std::{collections::HashMap, sync::Arc};
 pub struct PositionBundle {
     pub kv_db: Arc<PositionDb>,
     pub merkle_db: Arc<PositionMerkleDb>,
+    /// Pruner managers (value + merkle), the analog of main state's
+    /// `StatePruner`. `None` in readonly mode. Held as `Arc` so the
+    /// position merkle batch committer shares it; the value pruner is
+    /// driven from `commit_native_position`, the merkle pruners from the
+    /// committer, and all are re-activated on restart from `open_internal`.
+    pub(crate) position_pruner: Option<Arc<PositionPruner>>,
     /// `None` in readonly mode.
     pub(crate) state_store: Option<Arc<PositionStateStore>>,
     /// JMT version the in-memory MapLayer chain is rooted at — the
@@ -56,6 +65,9 @@ impl AptosDB {
         db_paths: &StorageDirPaths,
         kv_config: RocksdbConfig,
         merkle_config: RocksdbConfig,
+        value_pruner_config: LedgerPrunerConfig,
+        state_merkle_pruner_config: StateMerklePrunerConfig,
+        epoch_snapshot_pruner_config: StateMerklePrunerConfig,
         env: &Env,
         block_cache: &Cache,
         readonly: bool,
@@ -92,6 +104,20 @@ impl AptosDB {
         let kv_db = Arc::new(position_db);
         let merkle_db = Arc::new(merkle_db);
 
+        // Pruner managers (value + merkle), grouped like main state's
+        // `StatePruner`. Shared with the merkle batch committer via `Arc`.
+        let position_pruner = if readonly {
+            None
+        } else {
+            Some(Arc::new(PositionPruner::new(
+                Arc::clone(&kv_db),
+                Arc::clone(&merkle_db),
+                value_pruner_config,
+                state_merkle_pruner_config,
+                epoch_snapshot_pruner_config,
+            )))
+        };
+
         let state_store = if readonly {
             None
         } else {
@@ -106,6 +132,11 @@ impl AptosDB {
                 Arc::clone(&merkle_db),
                 Arc::clone(&self.ledger_db),
                 last_snapshot,
+                Arc::clone(
+                    position_pruner
+                        .as_ref()
+                        .expect("position_pruner present in non-readonly mode"),
+                ),
             )))
         };
 
@@ -129,6 +160,7 @@ impl AptosDB {
         self.position = Some(Arc::new(PositionBundle {
             kv_db,
             merkle_db,
+            position_pruner,
             state_store,
             snapshot_version: merkle_progress,
         }));

--- a/storage/aptosdb/src/db/aptosdb_test.rs
+++ b/storage/aptosdb/src/db/aptosdb_test.rs
@@ -10,7 +10,7 @@ use crate::{
         },
         AptosDB,
     },
-    pruner::{LedgerPrunerManager, PrunerManager, StateMerklePrunerManager},
+    pruner::{LedgerPrunerManager, PrunerManager, StateMerkle, StateMerklePrunerManager},
     schema::{
         epoch_by_version::EpochByVersionSchema, jellyfish_merkle_node::JellyfishMerkleNodeSchema,
         ledger_info::LedgerInfoSchema, stale_node_index::StaleNodeIndexSchema,
@@ -106,7 +106,7 @@ fn test_pruner_config() {
     let tmp_dir = TempPath::new();
     let aptos_db = AptosDB::new_for_test(&tmp_dir);
     for enable in [false, true] {
-        let state_merkle_pruner = StateMerklePrunerManager::<StaleNodeIndexSchema>::new(
+        let state_merkle_pruner = StateMerklePrunerManager::<StateMerkle>::new(
             Arc::clone(&aptos_db.state_merkle_db()),
             StateMerklePrunerConfig {
                 enable,

--- a/storage/aptosdb/src/db/aptosdb_writer.rs
+++ b/storage/aptosdb/src/db/aptosdb_writer.rs
@@ -770,6 +770,18 @@ impl AptosDB {
             if let Some(pruner) = &self.state_store.state_pruner.hot_state_kv_pruner {
                 pruner.maybe_set_pruner_target_db_version(version);
             }
+            // Activate the native-position value pruner here too, after
+            // the commit is durable — same point as `state_kv_pruner`.
+            // (The merkle pruners are driven when snapshots persist.)
+            if let Some(position_pruner) = self
+                .position
+                .as_ref()
+                .and_then(|bundle| bundle.position_pruner.as_ref())
+            {
+                position_pruner
+                    .value_pruner
+                    .maybe_set_pruner_target_db_version(version);
+            }
         }
 
         // Once everything is successfully persisted, update the latest in-memory ledger info.

--- a/storage/aptosdb/src/lib.rs
+++ b/storage/aptosdb/src/lib.rs
@@ -37,6 +37,7 @@ pub mod position_db;
 pub(crate) mod position_merkle_batch_committer;
 pub mod position_merkle_db;
 pub mod position_metrics;
+pub(crate) mod position_pruner;
 pub(crate) mod position_snapshot_committer;
 pub mod position_state_store;
 mod pruner;

--- a/storage/aptosdb/src/position_buffered_state.rs
+++ b/storage/aptosdb/src/position_buffered_state.rs
@@ -11,6 +11,7 @@ use crate::{
     ledger_db::LedgerDb,
     position_merkle_batch_committer::PositionMerkleBatchCommitter,
     position_merkle_db::PositionMerkleDb,
+    position_pruner::PositionPruner,
     position_snapshot_committer::{
         merklize_position, PositionSnapshotToCommit, POSITION_BATCH_CHANNEL_SIZE,
     },
@@ -125,6 +126,7 @@ impl PositionBufferedState {
         last_snapshot: PositionStateWithSummary,
         target_items: usize,
         out_current_state: Arc<Mutex<PositionLedgerStateWithSummary>>,
+        position_pruner: Arc<PositionPruner>,
     ) -> Self {
         *out_current_state.lock() =
             PositionLedgerStateWithSummary::new_at_checkpoint(last_snapshot.clone());
@@ -139,7 +141,8 @@ impl PositionBufferedState {
             POSITION_BATCH_CHANNEL_SIZE,
             last_snapshot.clone(),
             move |batch_receiver| {
-                PositionMerkleBatchCommitter::new(batch_merkle_db, batch_receiver).run();
+                PositionMerkleBatchCommitter::new(batch_merkle_db, batch_receiver, position_pruner)
+                    .run();
             },
             move |last_snapshot, input| {
                 merklize_position(

--- a/storage/aptosdb/src/position_merkle_batch_committer.rs
+++ b/storage/aptosdb/src/position_merkle_batch_committer.rs
@@ -7,6 +7,8 @@ use crate::{
     common::{run_batch_committer_loop, CommitMessage, MerkleBatch},
     metrics::OTHER_TIMERS_SECONDS,
     position_merkle_db::PositionMerkleDb,
+    position_pruner::PositionPruner,
+    pruner::PrunerManager,
 };
 use aptos_crypto::HashValue;
 use aptos_logger::{info, trace};
@@ -23,16 +25,19 @@ pub(crate) struct PositionMerkleCommit {
 pub(crate) struct PositionMerkleBatchCommitter {
     merkle_db: Arc<PositionMerkleDb>,
     receiver: Receiver<CommitMessage<PositionMerkleCommit>>,
+    position_pruner: Arc<PositionPruner>,
 }
 
 impl PositionMerkleBatchCommitter {
     pub fn new(
         merkle_db: Arc<PositionMerkleDb>,
         receiver: Receiver<CommitMessage<PositionMerkleCommit>>,
+        position_pruner: Arc<PositionPruner>,
     ) -> Self {
         Self {
             merkle_db,
             receiver,
+            position_pruner,
         }
     }
 
@@ -40,6 +45,7 @@ impl PositionMerkleBatchCommitter {
         let Self {
             merkle_db,
             receiver,
+            position_pruner,
         } = self;
         run_batch_committer_loop(receiver, |commit| {
             let _timer = OTHER_TIMERS_SECONDS.timer_with(&["position_batch_committer_work"]);
@@ -56,6 +62,14 @@ impl PositionMerkleBatchCommitter {
                 root_hash = %root_hash,
                 "Position merkle snapshot committed."
             );
+            // Activate the position merkle pruners now that a snapshot
+            // has persisted.
+            position_pruner
+                .state_merkle_pruner
+                .maybe_set_pruner_target_db_version(version);
+            position_pruner
+                .epoch_snapshot_pruner
+                .maybe_set_pruner_target_db_version(version);
         });
         trace!("Position merkle batch committing thread exit.");
     }

--- a/storage/aptosdb/src/position_pruner.rs
+++ b/storage/aptosdb/src/position_pruner.rs
@@ -1,0 +1,138 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Groups the native-position pruner managers, the analog of main
+//! state's `StatePruner`: the value pruner plus the regular and
+//! epoch-snapshot merkle pruners. The value pruner's target is driven
+//! from `commit_native_position`; the merkle pruners' from the position
+//! merkle batch committer.
+
+#![forbid(unsafe_code)]
+
+use crate::{
+    position_db::PositionDb,
+    position_merkle_db::PositionMerkleDb,
+    pruner::{
+        PositionEpochSnapshotPrunerManager, PositionStateMerklePrunerManager,
+        PositionValuePrunerManager,
+    },
+};
+use aptos_config::config::{LedgerPrunerConfig, StateMerklePrunerConfig};
+use std::sync::Arc;
+
+pub(crate) struct PositionPruner {
+    pub(crate) value_pruner: PositionValuePrunerManager,
+    pub(crate) state_merkle_pruner: PositionStateMerklePrunerManager,
+    pub(crate) epoch_snapshot_pruner: PositionEpochSnapshotPrunerManager,
+}
+
+impl PositionPruner {
+    pub(crate) fn new(
+        kv_db: Arc<PositionDb>,
+        merkle_db: Arc<PositionMerkleDb>,
+        value_pruner_config: LedgerPrunerConfig,
+        state_merkle_pruner_config: StateMerklePrunerConfig,
+        epoch_snapshot_pruner_config: StateMerklePrunerConfig,
+    ) -> Self {
+        Self {
+            value_pruner: PositionValuePrunerManager::new(kv_db, value_pruner_config),
+            state_merkle_pruner: PositionStateMerklePrunerManager::new(
+                Arc::clone(&merkle_db),
+                state_merkle_pruner_config,
+            ),
+            epoch_snapshot_pruner: PositionEpochSnapshotPrunerManager::new(
+                merkle_db,
+                epoch_snapshot_pruner_config,
+            ),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{pruner::PrunerManager, schema::stale_node_index::StaleNodeIndexSchema};
+    use aptos_config::config::{RocksdbConfig, StorageDirPaths};
+    use aptos_crypto::{hash::CryptoHash, HashValue};
+    use aptos_schemadb::DB;
+    use aptos_temppath::TempPath;
+    use aptos_types::{state_store::state_key::StateKey, transaction::Version};
+
+    fn open_dbs() -> (TempPath, Arc<PositionDb>, Arc<PositionMerkleDb>) {
+        let tmpdir = TempPath::new();
+        std::fs::create_dir_all(tmpdir.path()).unwrap();
+        let db_paths = StorageDirPaths::from_path(tmpdir.path());
+        let kv_db = Arc::new(
+            PositionDb::new(&db_paths, RocksdbConfig::default(), None, None, false)
+                .expect("PositionDb::new"),
+        );
+        let merkle_db = Arc::new(
+            PositionMerkleDb::new(&db_paths, RocksdbConfig::default(), None, None, false, 0)
+                .expect("PositionMerkleDb::new"),
+        );
+        (tmpdir, kv_db, merkle_db)
+    }
+
+    /// Commit a single-key merkle snapshot, overwriting the prior value
+    /// so the superseded nodes go stale.
+    fn commit_key(merkle_db: &PositionMerkleDb, version: Version, base: Option<Version>) {
+        let key = StateKey::raw(b"position-pruner-test");
+        let entry = (HashValue::random(), key.clone());
+        let (top_levels_batch, batches_for_shards, _root) = merkle_db
+            .merklize_value_set(vec![(key.hash(), Some(&entry))], version, base, None)
+            .expect("merklize");
+        merkle_db
+            .commit(version, top_levels_batch, batches_for_shards)
+            .expect("commit");
+    }
+
+    fn stale_rows_up_to(merkle_db: &PositionMerkleDb, target: Version) -> usize {
+        let count_in = |db: &DB| {
+            let mut iter = db.iter::<StaleNodeIndexSchema>().unwrap();
+            iter.seek_to_first();
+            iter.filter_map(|r| r.ok())
+                .filter(|(idx, _)| idx.stale_since_version <= target)
+                .count()
+        };
+        let mut total = count_in(merkle_db.metadata_db());
+        for shard_id in 0..merkle_db.num_shards() {
+            total += count_in(merkle_db.db_shard(shard_id));
+        }
+        total
+    }
+
+    #[test]
+    fn merkle_pruner_in_group_prunes_stale_nodes() {
+        let (_tmp, kv_db, merkle_db) = open_dbs();
+        commit_key(&merkle_db, 0, None);
+        commit_key(&merkle_db, 1, Some(0));
+        assert!(
+            stale_rows_up_to(&merkle_db, 1) > 0,
+            "overwrite leaves stale nodes"
+        );
+
+        let pruner = PositionPruner::new(
+            kv_db,
+            Arc::clone(&merkle_db),
+            LedgerPrunerConfig {
+                enable: true,
+                prune_window: 0,
+                batch_size: 1,
+                user_pruning_window_offset: 0,
+            },
+            StateMerklePrunerConfig {
+                enable: true,
+                prune_window: 0,
+                batch_size: 1000,
+            },
+            StateMerklePrunerConfig {
+                enable: true,
+                prune_window: 0,
+                batch_size: 1000,
+            },
+        );
+        pruner.state_merkle_pruner.wake_and_wait_pruner(1).unwrap();
+
+        assert_eq!(stale_rows_up_to(&merkle_db, 1), 0, "stale nodes pruned");
+    }
+}

--- a/storage/aptosdb/src/position_state_store.rs
+++ b/storage/aptosdb/src/position_state_store.rs
@@ -11,6 +11,7 @@ use crate::{
         POSITION_TARGET_ITEMS,
     },
     position_merkle_db::PositionMerkleDb,
+    position_pruner::PositionPruner,
 };
 use aptos_infallible::Mutex;
 use std::sync::Arc;
@@ -23,6 +24,7 @@ impl PositionStateStore {
         merkle_db: Arc<PositionMerkleDb>,
         ledger_db: Arc<LedgerDb>,
         last_snapshot: PositionStateWithSummary,
+        position_pruner: Arc<PositionPruner>,
     ) -> Self {
         let current_state = Arc::new(Mutex::new(
             PositionLedgerStateWithSummary::new_at_checkpoint(last_snapshot.clone()),
@@ -33,6 +35,7 @@ impl PositionStateStore {
             last_snapshot,
             POSITION_TARGET_ITEMS,
             Arc::clone(&current_state),
+            position_pruner,
         );
         Self::from_parts(current_state, buffered_state)
     }

--- a/storage/aptosdb/src/pruner/mod.rs
+++ b/storage/aptosdb/src/pruner/mod.rs
@@ -5,14 +5,22 @@ mod db_pruner;
 mod db_sub_pruner;
 mod ledger_pruner;
 mod pruner_manager;
-mod pruner_utils;
+pub(crate) mod pruner_utils;
 mod pruner_worker;
 mod state_kv_pruner;
 mod state_merkle_pruner;
 
 pub(crate) use ledger_pruner::ledger_pruner_manager::LedgerPrunerManager;
 pub(crate) use pruner_manager::PrunerManager;
-pub(crate) use state_kv_pruner::state_kv_pruner_manager::StateKvPrunerManager;
+pub(crate) use state_kv_pruner::{
+    generics::{ColdStateKv, HotStateKv, PositionValuePrunerManager},
+    state_kv_pruner_manager::StateKvPrunerManager,
+};
 pub(crate) use state_merkle_pruner::{
-    leaked_stale_node_cleaner, state_merkle_pruner_manager::StateMerklePrunerManager,
+    generics::{
+        EpochSnapshot, PositionEpochSnapshotPrunerManager, PositionStateMerklePrunerManager,
+        StateMerkle,
+    },
+    leaked_stale_node_cleaner,
+    state_merkle_pruner_manager::StateMerklePrunerManager,
 };

--- a/storage/aptosdb/src/pruner/pruner_utils.rs
+++ b/storage/aptosdb/src/pruner/pruner_utils.rs
@@ -5,40 +5,33 @@
 
 use crate::{
     ledger_db::LedgerDb,
-    pruner::state_merkle_pruner::generics::StaleNodeIndexSchemaTrait,
+    pruner::{
+        state_kv_pruner::generics::StateValuePrunerSchema,
+        state_merkle_pruner::generics::MerklePrunerSchema,
+    },
     schema::db_metadata::{DbMetadataKey, DbMetadataSchema, DbMetadataValue},
-    state_kv_db::StateKvDb,
-    state_merkle_db::StateMerkleDb,
+    sharded_jmt_merkle_db::ShardedJmtMerkleDb,
+    sharded_kv_db::ShardedKvDb,
     utils::get_progress,
 };
 use anyhow::Result;
-use aptos_jellyfish_merkle::StaleNodeIndex;
-use aptos_schemadb::{schema::KeyCodec, DB};
+use aptos_schemadb::DB;
 use aptos_types::transaction::Version;
 
 pub(crate) fn get_ledger_pruner_progress(ledger_db: &LedgerDb) -> Result<Version> {
     Ok(ledger_db.metadata_db().get_pruner_progress().unwrap_or(0))
 }
 
-pub(crate) fn get_state_kv_pruner_progress(state_kv_db: &StateKvDb) -> Result<Version> {
-    Ok(get_progress(
-        state_kv_db.metadata_db(),
-        &DbMetadataKey::StateKvPrunerProgress,
-    )?
-    .unwrap_or(0))
+pub(crate) fn get_state_kv_pruner_progress<S: StateValuePrunerSchema>(
+    state_kv_db: &ShardedKvDb,
+) -> Result<Version> {
+    Ok(get_progress(state_kv_db.metadata_db(), &S::pruner_progress_key())?.unwrap_or(0))
 }
 
-pub(crate) fn get_state_merkle_pruner_progress<S: StaleNodeIndexSchemaTrait>(
-    state_merkle_db: &StateMerkleDb,
-) -> Result<Version>
-where
-    StaleNodeIndex: KeyCodec<S>,
-{
-    Ok(get_progress(
-        state_merkle_db.metadata_db(),
-        &S::progress_metadata_key(None),
-    )?
-    .unwrap_or(0))
+pub(crate) fn get_state_merkle_pruner_progress<M: MerklePrunerSchema>(
+    state_merkle_db: &ShardedJmtMerkleDb,
+) -> Result<Version> {
+    Ok(get_progress(state_merkle_db.metadata_db(), &M::pruner_progress_key())?.unwrap_or(0))
 }
 
 pub(crate) fn get_or_initialize_subpruner_progress(

--- a/storage/aptosdb/src/pruner/state_kv_pruner/generics.rs
+++ b/storage/aptosdb/src/pruner/state_kv_pruner/generics.rs
@@ -1,0 +1,108 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Abstracts the (value CF, stale-index CF, progress keys, name) a
+//! state-value pruner operates on. The stale-index entry type
+//! (`StaleStateValueByKeyHashIndex`) and value key type
+//! (`(HashValue, Version)`) are shared by every implementor; only the
+//! column families and progress keys differ.
+
+use crate::{
+    position_db::PositionDb,
+    pruner::state_kv_pruner::state_kv_pruner_manager::StateKvPrunerManager,
+    schema::{
+        db_metadata::DbMetadataKey, hot_state_value_by_key_hash::HotStateValueByKeyHashSchema,
+        position_value::PositionValueSchema,
+        stale_position_value_index::StalePositionValueIndexSchema,
+        stale_state_value_index_by_key_hash::StaleStateValueIndexByKeyHashSchema,
+        state_value_by_key_hash::StateValueByKeyHashSchema,
+    },
+};
+use aptos_crypto::HashValue;
+use aptos_schemadb::schema::Schema;
+use aptos_types::{state_store::state_value::StaleStateValueByKeyHashIndex, transaction::Version};
+
+pub(crate) trait StateValuePrunerSchema: 'static + Send + Sync {
+    /// Stale-index CF, keyed by [`StaleStateValueByKeyHashIndex`].
+    type StaleIndexSchema: Schema<Key = StaleStateValueByKeyHashIndex, Value = ()>;
+    /// Value CF, keyed by `(state_key_hash, version)`. The pruner only
+    /// ever deletes by key, so the value type is unconstrained.
+    type ValueSchema: Schema<Key = (HashValue, Version)>;
+
+    fn name() -> &'static str;
+    fn worker_name() -> &'static str;
+    fn shard_progress_key(shard_id: usize) -> DbMetadataKey;
+    fn pruner_progress_key() -> DbMetadataKey;
+}
+
+/// Main-state cold value pruner.
+pub(crate) enum ColdStateKv {}
+impl StateValuePrunerSchema for ColdStateKv {
+    type StaleIndexSchema = StaleStateValueIndexByKeyHashSchema;
+    type ValueSchema = StateValueByKeyHashSchema;
+
+    fn name() -> &'static str {
+        "state_kv_pruner"
+    }
+
+    fn worker_name() -> &'static str {
+        "state_kv"
+    }
+
+    fn shard_progress_key(shard_id: usize) -> DbMetadataKey {
+        DbMetadataKey::StateKvShardPrunerProgress(shard_id)
+    }
+
+    fn pruner_progress_key() -> DbMetadataKey {
+        DbMetadataKey::StateKvPrunerProgress
+    }
+}
+
+/// Main-state hot value pruner.
+pub(crate) enum HotStateKv {}
+impl StateValuePrunerSchema for HotStateKv {
+    type StaleIndexSchema = StaleStateValueIndexByKeyHashSchema;
+    type ValueSchema = HotStateValueByKeyHashSchema;
+
+    fn name() -> &'static str {
+        "hot_state_kv_pruner"
+    }
+
+    fn worker_name() -> &'static str {
+        "hot_state_kv"
+    }
+
+    fn shard_progress_key(shard_id: usize) -> DbMetadataKey {
+        DbMetadataKey::StateKvShardPrunerProgress(shard_id)
+    }
+
+    fn pruner_progress_key() -> DbMetadataKey {
+        DbMetadataKey::StateKvPrunerProgress
+    }
+}
+
+/// Native-position value pruner.
+pub(crate) enum PositionValue {}
+impl StateValuePrunerSchema for PositionValue {
+    type StaleIndexSchema = StalePositionValueIndexSchema;
+    type ValueSchema = PositionValueSchema;
+
+    fn name() -> &'static str {
+        "position_value_pruner"
+    }
+
+    fn worker_name() -> &'static str {
+        "position_value"
+    }
+
+    fn shard_progress_key(shard_id: usize) -> DbMetadataKey {
+        DbMetadataKey::PositionValueShardPrunerProgress(shard_id)
+    }
+
+    fn pruner_progress_key() -> DbMetadataKey {
+        DbMetadataKey::PositionValuePrunerProgress
+    }
+}
+
+/// The native-position value pruner manager.
+pub(crate) type PositionValuePrunerManager = StateKvPrunerManager<PositionValue, PositionDb>;

--- a/storage/aptosdb/src/pruner/state_kv_pruner/mod.rs
+++ b/storage/aptosdb/src/pruner/state_kv_pruner/mod.rs
@@ -1,6 +1,9 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
+pub(in crate::pruner) mod generics;
+#[cfg(test)]
+mod position_value_test;
 mod state_kv_metadata_pruner;
 pub(crate) mod state_kv_pruner_manager;
 mod state_kv_shard_pruner;
@@ -10,42 +13,52 @@ use crate::{
     pruner::{
         db_pruner::DBPruner,
         state_kv_pruner::{
-            state_kv_metadata_pruner::StateKvMetadataPruner,
+            generics::StateValuePrunerSchema, state_kv_metadata_pruner::StateKvMetadataPruner,
             state_kv_shard_pruner::StateKvShardPruner,
         },
     },
-    state_kv_db::StateKvDb,
+    sharded_kv_db::ShardedKvDb,
 };
 use anyhow::anyhow;
 use aptos_experimental_runtimes::thread_manager::THREAD_MANAGER;
 use aptos_logger::info;
 use aptos_metrics_core::TimerHelper;
+use aptos_schemadb::schema::SeekKeyCodec;
 use aptos_storage_interface::Result;
-use aptos_types::transaction::{AtomicVersion, Version};
+use aptos_types::{
+    state_store::NUM_STATE_SHARDS,
+    transaction::{AtomicVersion, Version},
+};
 use rayon::prelude::*;
 use std::{
     cmp::min,
+    marker::PhantomData,
+    ops::Deref,
     sync::{atomic::Ordering, Arc},
 };
 
-/// Responsible for pruning state kv db.
-pub(crate) struct StateKvPruner {
+/// Responsible for pruning state value data (main-state cold/hot or position).
+pub(crate) struct StateKvPruner<S> {
     /// Keeps track of the target version that the pruner needs to achieve.
     target_version: AtomicVersion,
     progress: AtomicVersion,
-    name: &'static str,
 
-    metadata_pruner: StateKvMetadataPruner,
-    shard_pruners: Vec<StateKvShardPruner>,
+    metadata_pruner: StateKvMetadataPruner<S>,
+    shard_pruners: Vec<StateKvShardPruner<S>>,
+
+    _phantom: PhantomData<S>,
 }
 
-impl DBPruner for StateKvPruner {
+impl<S: StateValuePrunerSchema> DBPruner for StateKvPruner<S>
+where
+    Version: SeekKeyCodec<S::StaleIndexSchema>,
+{
     fn name(&self) -> &'static str {
-        self.name
+        S::name()
     }
 
     fn prune(&self, max_versions: usize) -> Result<Version> {
-        let _timer = OTHER_TIMERS_SECONDS.timer_with(&[&format!("{}__prune", self.name)]);
+        let _timer = OTHER_TIMERS_SECONDS.timer_with(&[&format!("{}__prune", S::name())]);
 
         let mut progress = self.progress();
         let target_version = self.target_version();
@@ -57,7 +70,7 @@ impl DBPruner for StateKvPruner {
             info!(
                 progress = progress,
                 target_version = current_batch_target_version,
-                name = self.name,
+                name = S::name(),
                 "Pruning state kv data."
             );
             self.metadata_pruner.prune(current_batch_target_version)?;
@@ -68,7 +81,8 @@ impl DBPruner for StateKvPruner {
                         .prune(progress, current_batch_target_version)
                         .map_err(|err| {
                             anyhow!(
-                                "Failed to prune state kv shard {}: {err}",
+                                "Failed to prune {} shard {}: {err}",
+                                S::name(),
                                 shard_pruner.shard_id(),
                             )
                         })
@@ -79,7 +93,7 @@ impl DBPruner for StateKvPruner {
             self.record_progress(progress);
             info!(
                 progress = progress,
-                name = self.name,
+                name = S::name(),
                 "Pruning state kv data is done."
             );
         }
@@ -94,7 +108,7 @@ impl DBPruner for StateKvPruner {
     fn set_target_version(&self, target_version: Version) {
         self.target_version.store(target_version, Ordering::SeqCst);
         PRUNER_VERSIONS
-            .with_label_values(&[self.name, "target"])
+            .with_label_values(&[S::name(), "target"])
             .set(target_version as i64);
     }
 
@@ -105,51 +119,49 @@ impl DBPruner for StateKvPruner {
     fn record_progress(&self, progress: Version) {
         self.progress.store(progress, Ordering::SeqCst);
         PRUNER_VERSIONS
-            .with_label_values(&[self.name, "progress"])
+            .with_label_values(&[S::name(), "progress"])
             .set(progress as i64);
     }
 }
 
-impl StateKvPruner {
-    pub fn new(state_kv_db: Arc<StateKvDb>) -> Result<Self> {
-        let name = if state_kv_db.is_hot() {
-            "hot_state_kv_pruner"
-        } else {
-            "state_kv_pruner"
-        };
-        info!(name = name, "Initializing...");
+impl<S: StateValuePrunerSchema> StateKvPruner<S>
+where
+    Version: SeekKeyCodec<S::StaleIndexSchema>,
+{
+    pub(in crate::pruner) fn new<D: Deref<Target = ShardedKvDb>>(
+        state_kv_db: Arc<D>,
+    ) -> Result<Self> {
+        info!(name = S::name(), "Initializing...");
 
-        let metadata_pruner = StateKvMetadataPruner::new(Arc::clone(&state_kv_db));
+        let metadata_pruner = StateKvMetadataPruner::new(Arc::clone(state_kv_db.metadata_db()));
 
         let metadata_progress = metadata_pruner.progress()?;
 
         info!(
             metadata_progress = metadata_progress,
-            name = name,
+            name = S::name(),
             "Created state kv metadata pruner, start catching up all shards."
         );
 
-        let num_shards = state_kv_db.num_shards();
-        let mut shard_pruners = Vec::with_capacity(num_shards);
-        for shard_id in 0..num_shards {
+        let mut shard_pruners = Vec::with_capacity(NUM_STATE_SHARDS);
+        for shard_id in 0..NUM_STATE_SHARDS {
             shard_pruners.push(StateKvShardPruner::new(
                 shard_id,
-                state_kv_db.db_shard_arc(shard_id),
+                Arc::clone(state_kv_db.shard(shard_id)),
                 metadata_progress,
-                state_kv_db.is_hot(),
             )?);
         }
 
         let pruner = StateKvPruner {
             target_version: AtomicVersion::new(metadata_progress),
             progress: AtomicVersion::new(metadata_progress),
-            name,
             metadata_pruner,
             shard_pruners,
+            _phantom: PhantomData,
         };
 
         info!(
-            name = pruner.name(),
+            name = S::name(),
             progress = metadata_progress,
             "Initialized."
         );

--- a/storage/aptosdb/src/pruner/state_kv_pruner/position_value_test.rs
+++ b/storage/aptosdb/src/pruner/state_kv_pruner/position_value_test.rs
@@ -1,0 +1,185 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Tests for the `PositionValue` instantiation of the KV pruner.
+
+use super::{
+    generics::{PositionValue, PositionValuePrunerManager},
+    StateKvPruner,
+};
+use crate::{
+    native_state_committer::{new_sharded_kv_batches, InChunkPriorVersions, NativeStateCommitter},
+    position_db::PositionDb,
+    pruner::{db_pruner::DBPruner, pruner_manager::PrunerManager},
+    schema::{
+        position_value::PositionValueSchema,
+        stale_position_value_index::StalePositionValueIndexSchema,
+    },
+    sharded_kv_db::ShardedKvDb,
+};
+use aptos_config::config::{LedgerPrunerConfig, RocksdbConfig, StorageDirPaths};
+use aptos_crypto::{hash::CryptoHash, HashValue};
+use aptos_temppath::TempPath;
+use aptos_types::{state_store::state_key::StateKey, transaction::Version, write_set::WriteOp};
+use move_core_types::account_address::AccountAddress;
+use std::{collections::BTreeSet, sync::Arc};
+
+fn open_position_db() -> (TempPath, Arc<PositionDb>) {
+    let tmpdir = TempPath::new();
+    std::fs::create_dir_all(tmpdir.path()).unwrap();
+    let db_paths = StorageDirPaths::from_path(tmpdir.path());
+    let db = Arc::new(
+        PositionDb::new(&db_paths, RocksdbConfig::default(), None, None, false)
+            .expect("PositionDb::new"),
+    );
+    (tmpdir, db)
+}
+
+fn addr(byte: u8) -> AccountAddress {
+    let mut a = [0u8; AccountAddress::LENGTH];
+    a[AccountAddress::LENGTH - 1] = byte;
+    AccountAddress::new(a)
+}
+
+fn position_key(user_byte: u8) -> StateKey {
+    StateKey::position(addr(1), addr(user_byte), addr(1))
+}
+
+fn upsert(bytes: &[u8]) -> WriteOp {
+    WriteOp::legacy_modification(bytes.to_vec().into())
+}
+
+fn commit_at(db: &Arc<PositionDb>, version: Version, writes: Vec<(StateKey, WriteOp)>) {
+    let committer = NativeStateCommitter::new(Arc::clone(db));
+    let mut batches = new_sharded_kv_batches();
+    let mut in_chunk_prior = InChunkPriorVersions::new();
+    committer
+        .apply(version, writes, &mut batches, &mut in_chunk_prior)
+        .expect("apply");
+    db.commit(version, None, batches).expect("commit");
+}
+
+fn value_exists(db: &PositionDb, hash: HashValue, version: Version) -> bool {
+    let shard = ShardedKvDb::shard_of_hash(hash);
+    db.shard(shard)
+        .get::<PositionValueSchema>(&(hash, version))
+        .unwrap()
+        .is_some()
+}
+
+fn stale_versions(db: &PositionDb, hash: HashValue) -> Vec<Version> {
+    let shard = ShardedKvDb::shard_of_hash(hash);
+    let mut iter = db
+        .shard(shard)
+        .iter::<StalePositionValueIndexSchema>()
+        .unwrap();
+    iter.seek_to_first();
+    let mut v: Vec<Version> = iter
+        .filter_map(|r| r.ok())
+        .map(|(idx, _)| idx)
+        .filter(|i| i.state_key_hash == hash)
+        .map(|i| i.stale_since_version)
+        .collect();
+    v.sort_unstable();
+    v
+}
+
+#[test]
+fn position_pruner_removes_superseded_values_keeps_live() {
+    let (_tmp, db) = open_position_db();
+    let key = position_key(1);
+    let hash = key.hash();
+
+    commit_at(&db, 0, vec![(key.clone(), upsert(b"v0"))]);
+    commit_at(&db, 5, vec![(key.clone(), upsert(b"v5"))]);
+    commit_at(&db, 10, vec![(key.clone(), upsert(b"v10"))]);
+
+    let pruner = StateKvPruner::<PositionValue>::new(Arc::clone(&db)).unwrap();
+    pruner.set_target_version(7);
+    pruner.prune(100).unwrap();
+
+    assert_eq!(pruner.progress(), 7);
+    assert!(!value_exists(&db, hash, 0), "v0 value pruned");
+    assert!(value_exists(&db, hash, 5), "v5 value retained");
+    assert!(value_exists(&db, hash, 10), "v10 value retained");
+    assert_eq!(
+        stale_versions(&db, hash),
+        vec![10],
+        "only past-target row left"
+    );
+}
+
+#[test]
+fn position_pruner_first_write_removes_index_but_not_value() {
+    let (_tmp, db) = open_position_db();
+    let key = position_key(1);
+    let hash = key.hash();
+
+    commit_at(&db, 3, vec![(key.clone(), upsert(b"v3"))]);
+
+    let pruner = StateKvPruner::<PositionValue>::new(Arc::clone(&db)).unwrap();
+    pruner.set_target_version(100);
+    pruner.prune(100).unwrap();
+
+    assert!(
+        stale_versions(&db, hash).is_empty(),
+        "sentinel index row drained"
+    );
+    assert!(value_exists(&db, hash, 3), "first-write value must survive");
+}
+
+#[test]
+fn position_pruner_fans_out_across_shards() {
+    let (_tmp, db) = open_position_db();
+    let keys: Vec<StateKey> = (1..=40u8).map(position_key).collect();
+    let hashes: Vec<HashValue> = keys.iter().map(CryptoHash::hash).collect();
+
+    let shards: BTreeSet<usize> = hashes
+        .iter()
+        .map(|h| ShardedKvDb::shard_of_hash(*h))
+        .collect();
+    assert!(shards.len() > 1, "test keys must span multiple shards");
+
+    commit_at(
+        &db,
+        0,
+        keys.iter().cloned().map(|k| (k, upsert(b"a"))).collect(),
+    );
+    commit_at(
+        &db,
+        1,
+        keys.iter().cloned().map(|k| (k, upsert(b"b"))).collect(),
+    );
+
+    let pruner = StateKvPruner::<PositionValue>::new(Arc::clone(&db)).unwrap();
+    pruner.set_target_version(1);
+    pruner.prune(100).unwrap();
+
+    for hash in &hashes {
+        assert!(!value_exists(&db, *hash, 0), "v0 pruned in every shard");
+        assert!(value_exists(&db, *hash, 1), "live v1 retained");
+        assert!(stale_versions(&db, *hash).is_empty(), "stale index drained");
+    }
+}
+
+/// The manager drives pruning through its background worker.
+#[test]
+fn position_manager_drives_pruning() {
+    let (_tmp, db) = open_position_db();
+    let key = position_key(1);
+    let hash = key.hash();
+    commit_at(&db, 0, vec![(key.clone(), upsert(b"v0"))]);
+    commit_at(&db, 5, vec![(key.clone(), upsert(b"v5"))]);
+
+    let manager = PositionValuePrunerManager::new(Arc::clone(&db), LedgerPrunerConfig {
+        enable: true,
+        prune_window: 0,
+        batch_size: 1,
+        user_pruning_window_offset: 0,
+    });
+    manager.wake_and_wait_pruner(5).unwrap();
+
+    assert!(!value_exists(&db, hash, 0), "v0 collected by the worker");
+    assert!(value_exists(&db, hash, 5), "v5 retained");
+    assert_eq!(manager.get_min_readable_version(), 5);
+}

--- a/storage/aptosdb/src/pruner/state_kv_pruner/state_kv_metadata_pruner.rs
+++ b/storage/aptosdb/src/pruner/state_kv_pruner/state_kv_metadata_pruner.rs
@@ -2,42 +2,42 @@
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
-    schema::db_metadata::{DbMetadataKey, DbMetadataSchema, DbMetadataValue},
-    state_kv_db::StateKvDb,
+    pruner::state_kv_pruner::generics::StateValuePrunerSchema,
+    schema::db_metadata::{DbMetadataSchema, DbMetadataValue},
     utils::get_progress,
 };
-use aptos_schemadb::batch::SchemaBatch;
+use aptos_schemadb::{batch::SchemaBatch, DB};
 use aptos_storage_interface::Result;
 use aptos_types::transaction::Version;
-use std::sync::Arc;
+use std::{marker::PhantomData, sync::Arc};
 
-pub(in crate::pruner) struct StateKvMetadataPruner {
-    state_kv_db: Arc<StateKvDb>,
+pub(in crate::pruner) struct StateKvMetadataPruner<S> {
+    metadata_db: Arc<DB>,
+    _phantom: PhantomData<S>,
 }
 
-impl StateKvMetadataPruner {
-    pub(in crate::pruner) fn new(state_kv_db: Arc<StateKvDb>) -> Self {
-        Self { state_kv_db }
+impl<S: StateValuePrunerSchema> StateKvMetadataPruner<S> {
+    pub(in crate::pruner) fn new(metadata_db: Arc<DB>) -> Self {
+        Self {
+            metadata_db,
+            _phantom: PhantomData,
+        }
     }
 
-    /// Records pruning progress. The actual deletion of stale state values
-    /// is handled by `StateKvShardPruner` per shard.
+    /// Records pruning progress. The actual deletion of stale values is
+    /// handled by `StateKvShardPruner` per shard.
     pub(in crate::pruner) fn prune(&self, target_version: Version) -> Result<()> {
         let mut batch = SchemaBatch::new();
 
         batch.put::<DbMetadataSchema>(
-            &DbMetadataKey::StateKvPrunerProgress,
+            &S::pruner_progress_key(),
             &DbMetadataValue::Version(target_version),
         )?;
 
-        self.state_kv_db.metadata_db().write_schemas(batch)
+        self.metadata_db.write_schemas(batch)
     }
 
     pub(in crate::pruner) fn progress(&self) -> Result<Version> {
-        Ok(get_progress(
-            self.state_kv_db.metadata_db(),
-            &DbMetadataKey::StateKvPrunerProgress,
-        )?
-        .unwrap_or(0))
+        Ok(get_progress(&self.metadata_db, &S::pruner_progress_key())?.unwrap_or(0))
     }
 }

--- a/storage/aptosdb/src/pruner/state_kv_pruner/state_kv_pruner_manager.rs
+++ b/storage/aptosdb/src/pruner/state_kv_pruner/state_kv_pruner_manager.rs
@@ -4,21 +4,28 @@
 use crate::{
     metrics::{PRUNER_BATCH_SIZE, PRUNER_VERSIONS, PRUNER_WINDOW},
     pruner::{
-        pruner_manager::PrunerManager, pruner_utils, pruner_worker::PrunerWorker,
-        state_kv_pruner::StateKvPruner,
+        pruner_manager::PrunerManager,
+        pruner_utils,
+        pruner_worker::PrunerWorker,
+        state_kv_pruner::{generics::StateValuePrunerSchema, StateKvPruner},
     },
+    schema::db_metadata::{DbMetadataSchema, DbMetadataValue},
+    sharded_kv_db::ShardedKvDb,
     state_kv_db::StateKvDb,
 };
 use aptos_config::config::LedgerPrunerConfig;
+use aptos_schemadb::schema::SeekKeyCodec;
 use aptos_storage_interface::Result;
 use aptos_types::transaction::{AtomicVersion, Version};
-use std::sync::{atomic::Ordering, Arc};
+use std::{
+    marker::PhantomData,
+    ops::Deref,
+    sync::{atomic::Ordering, Arc},
+};
 
 /// The `PrunerManager` for `StateKvPruner`.
-pub(crate) struct StateKvPrunerManager {
-    state_kv_db: Arc<StateKvDb>,
-    /// Pruner name for metrics and logging.
-    name: &'static str,
+pub(crate) struct StateKvPrunerManager<S, D = StateKvDb> {
+    state_kv_db: Arc<D>,
     /// DB version window, which dictates how many version of state values to keep.
     prune_window: Version,
     /// It is None iff the pruner is not enabled.
@@ -27,10 +34,17 @@ pub(crate) struct StateKvPrunerManager {
     pruning_batch_size: usize,
     /// The minimal readable version for the ledger data.
     min_readable_version: AtomicVersion,
+
+    _phantom: PhantomData<S>,
 }
 
-impl PrunerManager for StateKvPrunerManager {
-    type Pruner = StateKvPruner;
+impl<S, D> PrunerManager for StateKvPrunerManager<S, D>
+where
+    S: StateValuePrunerSchema,
+    D: Deref<Target = ShardedKvDb> + Send + Sync + 'static,
+    Version: SeekKeyCodec<S::StaleIndexSchema>,
+{
+    type Pruner = StateKvPruner<S>;
 
     fn is_pruner_enabled(&self) -> bool {
         self.pruner_worker.is_some()
@@ -61,10 +75,13 @@ impl PrunerManager for StateKvPrunerManager {
             .store(min_readable_version, Ordering::SeqCst);
 
         PRUNER_VERSIONS
-            .with_label_values(&[self.name, "min_readable"])
+            .with_label_values(&[S::name(), "min_readable"])
             .set(min_readable_version as i64);
 
-        self.state_kv_db.write_pruner_progress(min_readable_version)
+        self.state_kv_db.metadata_db().put::<DbMetadataSchema>(
+            &S::pruner_progress_key(),
+            &DbMetadataValue::Version(min_readable_version),
+        )
     }
 
     #[cfg(test)]
@@ -83,14 +100,13 @@ impl PrunerManager for StateKvPrunerManager {
     }
 }
 
-impl StateKvPrunerManager {
-    pub fn new(state_kv_db: Arc<StateKvDb>, state_kv_pruner_config: LedgerPrunerConfig) -> Self {
-        let name = if state_kv_db.is_hot() {
-            "hot_state_kv_pruner"
-        } else {
-            "state_kv_pruner"
-        };
-
+impl<S, D> StateKvPrunerManager<S, D>
+where
+    S: StateValuePrunerSchema,
+    D: Deref<Target = ShardedKvDb> + Send + Sync + 'static,
+    Version: SeekKeyCodec<S::StaleIndexSchema>,
+{
+    pub(crate) fn new(state_kv_db: Arc<D>, state_kv_pruner_config: LedgerPrunerConfig) -> Self {
         let pruner_worker = if state_kv_pruner_config.enable {
             Some(Self::init_pruner(
                 Arc::clone(&state_kv_db),
@@ -101,40 +117,39 @@ impl StateKvPrunerManager {
         };
 
         let min_readable_version =
-            pruner_utils::get_state_kv_pruner_progress(&state_kv_db).expect("Must succeed.");
+            pruner_utils::get_state_kv_pruner_progress::<S>(&state_kv_db).expect("Must succeed.");
 
         PRUNER_VERSIONS
-            .with_label_values(&[name, "min_readable"])
+            .with_label_values(&[S::name(), "min_readable"])
             .set(min_readable_version as i64);
 
         Self {
             state_kv_db,
-            name,
             prune_window: state_kv_pruner_config.prune_window,
             pruner_worker,
             pruning_batch_size: state_kv_pruner_config.batch_size,
             min_readable_version: AtomicVersion::new(min_readable_version),
+            _phantom: PhantomData,
         }
     }
 
     fn init_pruner(
-        state_kv_db: Arc<StateKvDb>,
+        state_kv_db: Arc<D>,
         state_kv_pruner_config: LedgerPrunerConfig,
     ) -> PrunerWorker {
-        let is_hot = state_kv_db.is_hot();
-        let pruner =
-            Arc::new(StateKvPruner::new(state_kv_db).expect("Failed to create state kv pruner."));
+        let pruner = Arc::new(
+            StateKvPruner::<S>::new(state_kv_db).expect("Failed to create state kv pruner."),
+        );
 
         PRUNER_WINDOW
-            .with_label_values(&[pruner.name])
+            .with_label_values(&[S::name()])
             .set(state_kv_pruner_config.prune_window as i64);
 
         PRUNER_BATCH_SIZE
-            .with_label_values(&[pruner.name])
+            .with_label_values(&[S::name()])
             .set(state_kv_pruner_config.batch_size as i64);
 
-        let worker_name = if is_hot { "hot_state_kv" } else { "state_kv" };
-        PrunerWorker::new(pruner, state_kv_pruner_config.batch_size, worker_name)
+        PrunerWorker::new(pruner, state_kv_pruner_config.batch_size, S::worker_name())
     }
 
     fn set_pruner_target_db_version(&self, latest_version: Version) {
@@ -144,7 +159,7 @@ impl StateKvPrunerManager {
             .store(min_readable_version, Ordering::SeqCst);
 
         PRUNER_VERSIONS
-            .with_label_values(&[self.name, "min_readable"])
+            .with_label_values(&[S::name(), "min_readable"])
             .set(min_readable_version as i64);
 
         self.pruner_worker

--- a/storage/aptosdb/src/pruner/state_kv_pruner/state_kv_shard_pruner.rs
+++ b/storage/aptosdb/src/pruner/state_kv_pruner/state_kv_shard_pruner.rs
@@ -2,50 +2,50 @@
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
-    pruner::pruner_utils::get_or_initialize_subpruner_progress,
-    schema::{
-        db_metadata::{DbMetadataKey, DbMetadataSchema, DbMetadataValue},
-        hot_state_value_by_key_hash::HotStateValueByKeyHashSchema,
-        stale_state_value_index_by_key_hash::StaleStateValueIndexByKeyHashSchema,
-        state_value_by_key_hash::StateValueByKeyHashSchema,
+    pruner::{
+        pruner_utils::get_or_initialize_subpruner_progress,
+        state_kv_pruner::generics::StateValuePrunerSchema,
     },
+    schema::db_metadata::{DbMetadataSchema, DbMetadataValue},
 };
 use aptos_logger::info;
-use aptos_schemadb::{batch::SchemaBatch, ReadOptions, DB};
+use aptos_schemadb::{batch::SchemaBatch, schema::SeekKeyCodec, ReadOptions, DB};
 use aptos_storage_interface::Result;
 use aptos_types::transaction::Version;
-use std::sync::Arc;
+use std::{marker::PhantomData, sync::Arc};
 
-// Per-shard pruner for state KV data
-pub(in crate::pruner) struct StateKvShardPruner {
+// Per-shard pruner for state value data (main-state cold/hot or position).
+pub(in crate::pruner) struct StateKvShardPruner<S> {
     shard_id: usize,
     db_shard: Arc<DB>,
-    is_hot: bool,
+    _phantom: PhantomData<S>,
 }
 
-impl StateKvShardPruner {
+impl<S: StateValuePrunerSchema> StateKvShardPruner<S>
+where
+    Version: SeekKeyCodec<S::StaleIndexSchema>,
+{
     pub(in crate::pruner) fn new(
         shard_id: usize,
         db_shard: Arc<DB>,
         metadata_progress: Version,
-        is_hot: bool,
     ) -> Result<Self> {
         let progress = get_or_initialize_subpruner_progress(
             &db_shard,
-            &DbMetadataKey::StateKvShardPrunerProgress(shard_id),
+            &S::shard_progress_key(shard_id),
             metadata_progress,
         )?;
         let myself = Self {
             shard_id,
             db_shard,
-            is_hot,
+            _phantom: PhantomData,
         };
 
         info!(
             progress = progress,
             metadata_progress = metadata_progress,
-            is_hot = is_hot,
-            "Catching up state kv shard {shard_id}."
+            "Catching up {} shard {shard_id}.",
+            S::name(),
         );
         myself.prune(progress, metadata_progress)?;
 
@@ -63,25 +63,21 @@ impl StateKvShardPruner {
         read_opts.fill_cache(false);
         let mut iter = self
             .db_shard
-            .iter_with_opts::<StaleStateValueIndexByKeyHashSchema>(read_opts)?;
+            .iter_with_opts::<S::StaleIndexSchema>(read_opts)?;
+        // Seek to the first stale-index row at or after `current_progress`.
         iter.seek(&current_progress)?;
         for item in iter {
             let (index, _) = item?;
             if index.stale_since_version > target_version {
                 break;
             }
-            batch.delete::<StaleStateValueIndexByKeyHashSchema>(&index)?;
+            batch.delete::<S::StaleIndexSchema>(&index)?;
             if !index.is_first_write() {
-                let db_key = (index.state_key_hash, index.version);
-                if self.is_hot {
-                    batch.delete::<HotStateValueByKeyHashSchema>(&db_key)?;
-                } else {
-                    batch.delete::<StateValueByKeyHashSchema>(&db_key)?;
-                }
+                batch.delete::<S::ValueSchema>(&(index.state_key_hash, index.version))?;
             }
         }
         batch.put::<DbMetadataSchema>(
-            &DbMetadataKey::StateKvShardPrunerProgress(self.shard_id),
+            &S::shard_progress_key(self.shard_id),
             &DbMetadataValue::Version(target_version),
         )?;
 

--- a/storage/aptosdb/src/pruner/state_merkle_pruner/generics.rs
+++ b/storage/aptosdb/src/pruner/state_merkle_pruner/generics.rs
@@ -1,45 +1,122 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-use crate::schema::{
-    db_metadata::DbMetadataKey, stale_node_index::StaleNodeIndexSchema,
-    stale_node_index_cross_epoch::StaleNodeIndexCrossEpochSchema,
+//! Abstracts the stale-node-index CF, progress keys, and pruner name a
+//! merkle pruner operates on. The stale-node-index entry type
+//! (`StaleNodeIndex`) is shared by every implementor; only the column
+//! family, progress keys, and name differ.
+
+use crate::{
+    position_merkle_db::PositionMerkleDb,
+    pruner::state_merkle_pruner::state_merkle_pruner_manager::StateMerklePrunerManager,
+    schema::{
+        db_metadata::DbMetadataKey, stale_node_index::StaleNodeIndexSchema,
+        stale_node_index_cross_epoch::StaleNodeIndexCrossEpochSchema,
+    },
 };
 use aptos_jellyfish_merkle::StaleNodeIndex;
-use aptos_schemadb::schema::{KeyCodec, Schema};
+use aptos_schemadb::schema::Schema;
 
-pub trait StaleNodeIndexSchemaTrait: Schema<Key = StaleNodeIndex>
-where
-    StaleNodeIndex: KeyCodec<Self>,
-{
-    fn progress_metadata_key(shard_id: Option<usize>) -> DbMetadataKey;
+pub(crate) trait MerklePrunerSchema: 'static + Send + Sync {
+    /// Stale-node-index CF, keyed by [`StaleNodeIndex`].
+    type StaleIndexSchema: Schema<Key = StaleNodeIndex, Value = ()>;
+
     fn name() -> &'static str;
+    fn worker_name() -> &'static str;
+    fn shard_progress_key(shard_id: usize) -> DbMetadataKey;
+    fn pruner_progress_key() -> DbMetadataKey;
 }
 
-impl StaleNodeIndexSchemaTrait for StaleNodeIndexSchema {
-    fn progress_metadata_key(shard_id: Option<usize>) -> DbMetadataKey {
-        if let Some(shard_id) = shard_id {
-            DbMetadataKey::StateMerkleShardPrunerProgress(shard_id)
-        } else {
-            DbMetadataKey::StateMerklePrunerProgress
-        }
-    }
+/// Main-state regular merkle pruner (cold and hot share this identity,
+/// distinguished by their DB).
+pub(crate) enum StateMerkle {}
+impl MerklePrunerSchema for StateMerkle {
+    type StaleIndexSchema = StaleNodeIndexSchema;
 
     fn name() -> &'static str {
         "state_merkle_pruner"
     }
+
+    fn worker_name() -> &'static str {
+        "state_merkle"
+    }
+
+    fn shard_progress_key(shard_id: usize) -> DbMetadataKey {
+        DbMetadataKey::StateMerkleShardPrunerProgress(shard_id)
+    }
+
+    fn pruner_progress_key() -> DbMetadataKey {
+        DbMetadataKey::StateMerklePrunerProgress
+    }
 }
 
-impl StaleNodeIndexSchemaTrait for StaleNodeIndexCrossEpochSchema {
-    fn progress_metadata_key(shard_id: Option<usize>) -> DbMetadataKey {
-        if let Some(shard_id) = shard_id {
-            DbMetadataKey::EpochEndingStateMerkleShardPrunerProgress(shard_id)
-        } else {
-            DbMetadataKey::EpochEndingStateMerklePrunerProgress
-        }
-    }
+/// Main-state epoch-snapshot merkle pruner.
+pub(crate) enum EpochSnapshot {}
+impl MerklePrunerSchema for EpochSnapshot {
+    type StaleIndexSchema = StaleNodeIndexCrossEpochSchema;
 
     fn name() -> &'static str {
         "epoch_snapshot_pruner"
     }
+
+    fn worker_name() -> &'static str {
+        "state_merkle"
+    }
+
+    fn shard_progress_key(shard_id: usize) -> DbMetadataKey {
+        DbMetadataKey::EpochEndingStateMerkleShardPrunerProgress(shard_id)
+    }
+
+    fn pruner_progress_key() -> DbMetadataKey {
+        DbMetadataKey::EpochEndingStateMerklePrunerProgress
+    }
 }
+
+/// Native-position regular merkle pruner.
+pub(crate) enum PositionStateMerkle {}
+impl MerklePrunerSchema for PositionStateMerkle {
+    type StaleIndexSchema = StaleNodeIndexSchema;
+
+    fn name() -> &'static str {
+        "position_state_merkle_pruner"
+    }
+
+    fn worker_name() -> &'static str {
+        "position_state_merkle"
+    }
+
+    fn shard_progress_key(shard_id: usize) -> DbMetadataKey {
+        DbMetadataKey::PositionStateMerkleShardPrunerProgress(shard_id)
+    }
+
+    fn pruner_progress_key() -> DbMetadataKey {
+        DbMetadataKey::PositionStateMerklePrunerProgress
+    }
+}
+
+/// Native-position epoch-snapshot merkle pruner.
+pub(crate) enum PositionEpochSnapshot {}
+impl MerklePrunerSchema for PositionEpochSnapshot {
+    type StaleIndexSchema = StaleNodeIndexCrossEpochSchema;
+
+    fn name() -> &'static str {
+        "position_epoch_snapshot_pruner"
+    }
+
+    fn worker_name() -> &'static str {
+        "position_epoch_snapshot"
+    }
+
+    fn shard_progress_key(shard_id: usize) -> DbMetadataKey {
+        DbMetadataKey::PositionEpochSnapshotShardPrunerProgress(shard_id)
+    }
+
+    fn pruner_progress_key() -> DbMetadataKey {
+        DbMetadataKey::PositionEpochSnapshotPrunerProgress
+    }
+}
+
+pub(crate) type PositionStateMerklePrunerManager =
+    StateMerklePrunerManager<PositionStateMerkle, PositionMerkleDb>;
+pub(crate) type PositionEpochSnapshotPrunerManager =
+    StateMerklePrunerManager<PositionEpochSnapshot, PositionMerkleDb>;

--- a/storage/aptosdb/src/pruner/state_merkle_pruner/mod.rs
+++ b/storage/aptosdb/src/pruner/state_merkle_pruner/mod.rs
@@ -11,15 +11,8 @@ mod test;
 
 use crate::{
     metrics::{OTHER_TIMERS_SECONDS, PRUNER_VERSIONS},
-    pruner::{
-        db_pruner::DBPruner,
-        state_merkle_pruner::{
-            generics::StaleNodeIndexSchemaTrait,
-            state_merkle_metadata_pruner::StateMerkleMetadataPruner,
-            state_merkle_shard_pruner::StateMerkleShardPruner,
-        },
-    },
-    state_merkle_db::StateMerkleDb,
+    pruner::{db_pruner::DBPruner, state_merkle_pruner::generics::MerklePrunerSchema},
+    sharded_jmt_merkle_db::ShardedJmtMerkleDb,
 };
 use anyhow::anyhow;
 use aptos_experimental_runtimes::thread_manager::THREAD_MANAGER;
@@ -30,35 +23,38 @@ use aptos_schemadb::{schema::KeyCodec, ReadOptions, DB};
 use aptos_storage_interface::Result;
 use aptos_types::transaction::{AtomicVersion, Version};
 use rayon::prelude::*;
+// Re-exported for the native-position merkle pruner.
+pub(in crate::pruner) use state_merkle_metadata_pruner::StateMerkleMetadataPruner;
+pub(in crate::pruner) use state_merkle_shard_pruner::StateMerkleShardPruner;
 use std::{
     marker::PhantomData,
+    ops::Deref,
     sync::{atomic::Ordering, Arc},
 };
 
 /// Responsible for pruning the state tree.
-pub struct StateMerklePruner<S> {
+pub struct StateMerklePruner<M> {
     /// Keeps track of the target version that the pruner needs to achieve.
     target_version: AtomicVersion,
     /// Overall progress, updated when the whole version is done.
     progress: AtomicVersion,
 
-    metadata_pruner: StateMerkleMetadataPruner<S>,
+    metadata_pruner: StateMerkleMetadataPruner<M>,
     // Non-empty iff sharding is enabled.
-    shard_pruners: Vec<StateMerkleShardPruner<S>>,
+    shard_pruners: Vec<StateMerkleShardPruner<M>>,
 
-    _phantom: PhantomData<S>,
+    _phantom: PhantomData<M>,
 }
 
-impl<S: StaleNodeIndexSchemaTrait> DBPruner for StateMerklePruner<S>
+impl<M: MerklePrunerSchema> DBPruner for StateMerklePruner<M>
 where
-    StaleNodeIndex: KeyCodec<S>,
+    StaleNodeIndex: KeyCodec<M::StaleIndexSchema>,
 {
     fn name(&self) -> &'static str {
-        S::name()
+        M::name()
     }
 
     fn prune(&self, batch_size: usize) -> Result<Version> {
-        // TODO(grao): Consider separate pruner metrics, and have a label for pruner name.
         let _timer = OTHER_TIMERS_SECONDS.timer_with(&["state_merkle_pruner__prune"]);
         let mut progress = self.progress();
         let target_version = self.target_version();
@@ -68,7 +64,7 @@ where
         }
 
         info!(
-            name = S::name(),
+            name = M::name(),
             current_progress = progress,
             target_version = target_version,
             "Start pruning..."
@@ -81,7 +77,7 @@ where
             {
                 self.prune_shards(progress, target_version_for_this_round, batch_size)?;
                 progress = target_version_for_this_round;
-                info!(name = S::name(), progress = progress);
+                info!(name = M::name(), progress = progress);
                 self.record_progress(target_version_for_this_round);
             } else {
                 self.prune_shards(progress, target_version, batch_size)?;
@@ -90,7 +86,7 @@ where
             }
         }
 
-        info!(name = S::name(), progress = target_version, "Done pruning.");
+        info!(name = M::name(), progress = target_version, "Done pruning.");
 
         Ok(target_version)
     }
@@ -102,7 +98,7 @@ where
     fn set_target_version(&self, target_version: Version) {
         self.target_version.store(target_version, Ordering::SeqCst);
         PRUNER_VERSIONS
-            .with_label_values(&[S::name(), "target"])
+            .with_label_values(&[M::name(), "target"])
             .set(target_version as i64);
     }
 
@@ -113,17 +109,17 @@ where
     fn record_progress(&self, progress: Version) {
         self.progress.store(progress, Ordering::SeqCst);
         PRUNER_VERSIONS
-            .with_label_values(&[S::name(), "progress"])
+            .with_label_values(&[M::name(), "progress"])
             .set(progress as i64);
     }
 }
 
-impl<S: StaleNodeIndexSchemaTrait> StateMerklePruner<S>
+impl<M: MerklePrunerSchema> StateMerklePruner<M>
 where
-    StaleNodeIndex: KeyCodec<S>,
+    StaleNodeIndex: KeyCodec<M::StaleIndexSchema>,
 {
-    pub fn new(state_merkle_db: Arc<StateMerkleDb>) -> Result<Self> {
-        info!(name = S::name(), "Initializing...");
+    pub fn new<D: Deref<Target = ShardedJmtMerkleDb>>(state_merkle_db: Arc<D>) -> Result<Self> {
+        info!(name = M::name(), "Initializing...");
 
         let metadata_pruner = StateMerkleMetadataPruner::new(state_merkle_db.metadata_db_arc());
         let metadata_progress = metadata_pruner.progress()?;
@@ -131,7 +127,7 @@ where
         info!(
             metadata_progress = metadata_progress,
             "Created {} metadata pruner, start catching up all shards.",
-            S::name(),
+            M::name(),
         );
 
         let num_shards = state_merkle_db.num_shards();
@@ -149,11 +145,11 @@ where
             progress: AtomicVersion::new(metadata_progress),
             metadata_pruner,
             shard_pruners,
-            _phantom: std::marker::PhantomData,
+            _phantom: PhantomData,
         };
 
         info!(
-            name = pruner.name(),
+            name = M::name(),
             progress = metadata_progress,
             "Initialized."
         );
@@ -175,7 +171,8 @@ where
                         .prune(current_progress, target_version, batch_size)
                         .map_err(|err| {
                             anyhow!(
-                                "Failed to prune state merkle shard {}: {err}",
+                                "Failed to prune {} shard {}: {err}",
+                                M::name(),
                                 shard_pruner.shard_id(),
                             )
                         })
@@ -193,7 +190,7 @@ where
         let mut indices = Vec::new();
         let mut read_opts = ReadOptions::default();
         read_opts.fill_cache(false);
-        let mut iter = state_merkle_db_shard.iter_with_opts::<S>(read_opts)?;
+        let mut iter = state_merkle_db_shard.iter_with_opts::<M::StaleIndexSchema>(read_opts)?;
         iter.seek(&StaleNodeIndex {
             stale_since_version: start_version,
             node_key: NodeKey::new_empty_path(0),

--- a/storage/aptosdb/src/pruner/state_merkle_pruner/state_merkle_metadata_pruner.rs
+++ b/storage/aptosdb/src/pruner/state_merkle_pruner/state_merkle_metadata_pruner.rs
@@ -2,7 +2,7 @@
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
-    pruner::state_merkle_pruner::{generics::StaleNodeIndexSchemaTrait, StateMerklePruner},
+    pruner::state_merkle_pruner::{generics::MerklePrunerSchema, StateMerklePruner},
     schema::{
         db_metadata::{DbMetadataSchema, DbMetadataValue},
         jellyfish_merkle_node::JellyfishMerkleNodeSchema,
@@ -19,15 +19,15 @@ use std::{
     sync::{atomic::Ordering, Arc},
 };
 
-pub(in crate::pruner) struct StateMerkleMetadataPruner<S> {
+pub(in crate::pruner) struct StateMerkleMetadataPruner<M> {
     metadata_db: Arc<DB>,
     next_version: AtomicVersion,
-    _phantom: PhantomData<S>,
+    _phantom: PhantomData<M>,
 }
 
-impl<S: StaleNodeIndexSchemaTrait> StateMerkleMetadataPruner<S>
+impl<M: MerklePrunerSchema> StateMerkleMetadataPruner<M>
 where
-    StaleNodeIndex: KeyCodec<S>,
+    StaleNodeIndex: KeyCodec<M::StaleIndexSchema>,
 {
     pub(in crate::pruner) fn new(metadata_db: Arc<DB>) -> Self {
         Self {
@@ -50,7 +50,7 @@ where
         }
 
         // When next_version is not initialized, this call is used to initialize it.
-        let (indices, next_version) = StateMerklePruner::get_stale_node_indices(
+        let (indices, next_version) = StateMerklePruner::<M>::get_stale_node_indices(
             &self.metadata_db,
             current_progress,
             target_version_for_this_round,
@@ -60,11 +60,11 @@ where
         let mut batch = SchemaBatch::new();
         indices.into_iter().try_for_each(|index| {
             batch.delete::<JellyfishMerkleNodeSchema>(&index.node_key)?;
-            batch.delete::<S>(&index)
+            batch.delete::<M::StaleIndexSchema>(&index)
         })?;
 
         batch.put::<DbMetadataSchema>(
-            &S::progress_metadata_key(None),
+            &M::pruner_progress_key(),
             &DbMetadataValue::Version(target_version_for_this_round),
         )?;
 
@@ -79,6 +79,6 @@ where
     }
 
     pub(in crate::pruner) fn progress(&self) -> Result<Version> {
-        Ok(get_progress(&self.metadata_db, &S::progress_metadata_key(None))?.unwrap_or(0))
+        Ok(get_progress(&self.metadata_db, &M::pruner_progress_key())?.unwrap_or(0))
     }
 }

--- a/storage/aptosdb/src/pruner/state_merkle_pruner/state_merkle_pruner_manager.rs
+++ b/storage/aptosdb/src/pruner/state_merkle_pruner/state_merkle_pruner_manager.rs
@@ -10,8 +10,9 @@ use crate::{
         pruner_manager::PrunerManager,
         pruner_utils,
         pruner_worker::PrunerWorker,
-        state_merkle_pruner::{generics::StaleNodeIndexSchemaTrait, StateMerklePruner},
+        state_merkle_pruner::{generics::MerklePrunerSchema, StateMerklePruner},
     },
+    sharded_jmt_merkle_db::ShardedJmtMerkleDb,
     state_merkle_db::StateMerkleDb,
 };
 use aptos_config::config::StateMerklePrunerConfig;
@@ -21,6 +22,7 @@ use aptos_storage_interface::Result;
 use aptos_types::transaction::{AtomicVersion, Version};
 use std::{
     marker::PhantomData,
+    ops::Deref,
     sync::{atomic::Ordering, Arc},
 };
 
@@ -30,11 +32,8 @@ use std::{
 /// If the state pruner is enabled, it creates a worker thread on construction and joins it on
 /// destruction. When destructed, it quits the worker thread eagerly without waiting for all
 /// pending work to be done.
-pub struct StateMerklePrunerManager<S: StaleNodeIndexSchemaTrait>
-where
-    StaleNodeIndex: KeyCodec<S>,
-{
-    state_merkle_db: Arc<StateMerkleDb>,
+pub struct StateMerklePrunerManager<M, D = StateMerkleDb> {
+    state_merkle_db: Arc<D>,
     /// DB version window, which dictates how many versions of state merkle data to keep.
     prune_window: Version,
     /// It is None iff the pruner is not enabled.
@@ -42,14 +41,16 @@ where
     /// The minimal readable version for the state merkle data.
     min_readable_version: AtomicVersion,
 
-    _phantom: PhantomData<S>,
+    _phantom: PhantomData<M>,
 }
 
-impl<S: StaleNodeIndexSchemaTrait> PrunerManager for StateMerklePrunerManager<S>
+impl<M, D> PrunerManager for StateMerklePrunerManager<M, D>
 where
-    StaleNodeIndex: KeyCodec<S>,
+    M: MerklePrunerSchema,
+    D: Deref<Target = ShardedJmtMerkleDb> + Send + Sync + 'static,
+    StaleNodeIndex: KeyCodec<M::StaleIndexSchema>,
 {
-    type Pruner = StateMerklePruner<S>;
+    type Pruner = StateMerklePruner<M>;
 
     fn is_pruner_enabled(&self) -> bool {
         self.pruner_worker.is_some()
@@ -76,11 +77,11 @@ where
             .store(min_readable_version, Ordering::SeqCst);
 
         PRUNER_VERSIONS
-            .with_label_values(&[S::name(), "min_readable"])
+            .with_label_values(&[M::name(), "min_readable"])
             .set(min_readable_version as i64);
 
         self.state_merkle_db
-            .write_pruner_progress(&S::progress_metadata_key(None), min_readable_version)
+            .write_pruner_progress(&M::pruner_progress_key(), min_readable_version)
     }
 
     #[cfg(test)]
@@ -99,13 +100,15 @@ where
     }
 }
 
-impl<S: StaleNodeIndexSchemaTrait> StateMerklePrunerManager<S>
+impl<M, D> StateMerklePrunerManager<M, D>
 where
-    StaleNodeIndex: KeyCodec<S>,
+    M: MerklePrunerSchema,
+    D: Deref<Target = ShardedJmtMerkleDb> + Send + Sync + 'static,
+    StaleNodeIndex: KeyCodec<M::StaleIndexSchema>,
 {
     /// Creates a worker thread that waits on a channel for pruning commands.
     pub fn new(
-        state_merkle_db: Arc<StateMerkleDb>,
+        state_merkle_db: Arc<D>,
         state_merkle_pruner_config: StateMerklePrunerConfig,
     ) -> Self {
         let pruner_worker = if state_merkle_pruner_config.enable {
@@ -117,11 +120,12 @@ where
             None
         };
 
-        let min_readable_version = pruner_utils::get_state_merkle_pruner_progress(&state_merkle_db)
-            .expect("Must succeed.");
+        let min_readable_version =
+            pruner_utils::get_state_merkle_pruner_progress::<M>(&state_merkle_db)
+                .expect("Must succeed.");
 
         PRUNER_VERSIONS
-            .with_label_values(&[S::name(), "min_readable"])
+            .with_label_values(&[M::name(), "min_readable"])
             .set(min_readable_version as i64);
 
         Self {
@@ -134,26 +138,26 @@ where
     }
 
     fn init_pruner(
-        state_merkle_db: Arc<StateMerkleDb>,
+        state_merkle_db: Arc<D>,
         state_merkle_pruner_config: StateMerklePrunerConfig,
     ) -> PrunerWorker {
         let pruner = Arc::new(
-            StateMerklePruner::<S>::new(Arc::clone(&state_merkle_db))
+            StateMerklePruner::<M>::new(Arc::clone(&state_merkle_db))
                 .expect("Failed to create state merkle pruner."),
         );
 
         PRUNER_WINDOW
-            .with_label_values(&[S::name()])
+            .with_label_values(&[M::name()])
             .set(state_merkle_pruner_config.prune_window as i64);
 
         PRUNER_BATCH_SIZE
-            .with_label_values(&[S::name()])
+            .with_label_values(&[M::name()])
             .set(state_merkle_pruner_config.batch_size as i64);
 
         PrunerWorker::new(
             pruner,
             state_merkle_pruner_config.batch_size,
-            "state_merkle",
+            M::worker_name(),
         )
     }
 
@@ -165,7 +169,7 @@ where
             .store(min_readable_version, Ordering::SeqCst);
 
         PRUNER_VERSIONS
-            .with_label_values(&[S::name(), "min_readable"])
+            .with_label_values(&[M::name(), "min_readable"])
             .set(min_readable_version as i64);
 
         self.pruner_worker

--- a/storage/aptosdb/src/pruner/state_merkle_pruner/state_merkle_shard_pruner.rs
+++ b/storage/aptosdb/src/pruner/state_merkle_pruner/state_merkle_shard_pruner.rs
@@ -4,7 +4,7 @@
 use crate::{
     pruner::{
         pruner_utils::get_or_initialize_subpruner_progress,
-        state_merkle_pruner::{generics::StaleNodeIndexSchemaTrait, StateMerklePruner},
+        state_merkle_pruner::{generics::MerklePrunerSchema, StateMerklePruner},
     },
     schema::{
         db_metadata::{DbMetadataSchema, DbMetadataValue},
@@ -18,15 +18,15 @@ use aptos_schemadb::{batch::SchemaBatch, schema::KeyCodec, DB};
 use aptos_types::transaction::Version;
 use std::{marker::PhantomData, sync::Arc};
 
-pub(in crate::pruner) struct StateMerkleShardPruner<S> {
+pub(in crate::pruner) struct StateMerkleShardPruner<M> {
     shard_id: usize,
     db_shard: Arc<DB>,
-    _phantom: PhantomData<S>,
+    _phantom: PhantomData<M>,
 }
 
-impl<S: StaleNodeIndexSchemaTrait> StateMerkleShardPruner<S>
+impl<M: MerklePrunerSchema> StateMerkleShardPruner<M>
 where
-    StaleNodeIndex: KeyCodec<S>,
+    StaleNodeIndex: KeyCodec<M::StaleIndexSchema>,
 {
     pub(in crate::pruner) fn new(
         shard_id: usize,
@@ -35,7 +35,7 @@ where
     ) -> Result<Self> {
         let progress = get_or_initialize_subpruner_progress(
             &db_shard,
-            &S::progress_metadata_key(Some(shard_id)),
+            &M::shard_progress_key(shard_id),
             metadata_progress,
         )?;
         let myself = Self {
@@ -48,7 +48,7 @@ where
             progress = progress,
             metadata_progress = metadata_progress,
             "Catching up {} shard {shard_id}.",
-            S::name(),
+            M::name(),
         );
         myself.prune(progress, metadata_progress, usize::MAX)?;
 
@@ -63,7 +63,7 @@ where
     ) -> Result<()> {
         loop {
             let mut batch = SchemaBatch::new();
-            let (indices, next_version) = StateMerklePruner::get_stale_node_indices(
+            let (indices, next_version) = StateMerklePruner::<M>::get_stale_node_indices(
                 &self.db_shard,
                 current_progress,
                 target_version,
@@ -72,7 +72,7 @@ where
 
             indices.into_iter().try_for_each(|index| {
                 batch.delete::<JellyfishMerkleNodeSchema>(&index.node_key)?;
-                batch.delete::<S>(&index)
+                batch.delete::<M::StaleIndexSchema>(&index)
             })?;
 
             let mut done = true;
@@ -84,7 +84,7 @@ where
 
             if done {
                 batch.put::<DbMetadataSchema>(
-                    &S::progress_metadata_key(Some(self.shard_id)),
+                    &M::shard_progress_key(self.shard_id),
                     &DbMetadataValue::Version(target_version),
                 )?;
             }

--- a/storage/aptosdb/src/pruner/state_merkle_pruner/test.rs
+++ b/storage/aptosdb/src/pruner/state_merkle_pruner/test.rs
@@ -6,7 +6,9 @@ use crate::{
         test_helper::{arb_state_kv_sets_with_genesis, update_store},
         AptosDB,
     },
-    pruner::{PrunerManager, StateKvPrunerManager, StateMerklePrunerManager},
+    pruner::{
+        ColdStateKv, PrunerManager, StateKvPrunerManager, StateMerkle, StateMerklePrunerManager,
+    },
     schema::{
         stale_node_index::StaleNodeIndexSchema,
         stale_state_value_index_by_key_hash::StaleStateValueIndexByKeyHashSchema,
@@ -53,12 +55,15 @@ fn verify_state_in_store(
 fn create_state_merkle_pruner_manager(
     state_merkle_db: &Arc<StateMerkleDb>,
     prune_batch_size: usize,
-) -> StateMerklePrunerManager<StaleNodeIndexSchema> {
-    StateMerklePrunerManager::new(Arc::clone(state_merkle_db), StateMerklePrunerConfig {
-        enable: true,
-        prune_window: 0,
-        batch_size: prune_batch_size,
-    })
+) -> StateMerklePrunerManager<StateMerkle> {
+    StateMerklePrunerManager::<StateMerkle>::new(
+        Arc::clone(state_merkle_db),
+        StateMerklePrunerConfig {
+            enable: true,
+            prune_window: 0,
+            batch_size: prune_batch_size,
+        },
+    )
 }
 
 #[test]
@@ -316,12 +321,13 @@ fn verify_state_value_pruner(inputs: Vec<Vec<(StateKey, Option<StateValue>)>>) {
 
     let mut version = 0;
     let mut current_state_values = HashMap::new();
-    let pruner = StateKvPrunerManager::new(Arc::clone(&db.state_kv_db), LedgerPrunerConfig {
-        enable: true,
-        prune_window: 0,
-        batch_size: 1,
-        user_pruning_window_offset: 0,
-    });
+    let pruner =
+        StateKvPrunerManager::<ColdStateKv>::new(Arc::clone(&db.state_kv_db), LedgerPrunerConfig {
+            enable: true,
+            prune_window: 0,
+            batch_size: 1,
+            user_pruning_window_offset: 0,
+        });
     for batch in inputs {
         update_store(store, batch.clone().into_iter(), version);
         for (k, v) in batch.iter() {

--- a/storage/aptosdb/src/schema/db_metadata/mod.rs
+++ b/storage/aptosdb/src/schema/db_metadata/mod.rs
@@ -74,6 +74,12 @@ pub enum DbMetadataKey {
     StaleNodeCleanupEpochProgress,
     PositionCommitProgress,
     PositionShardCommitProgress(ShardId),
+    PositionValuePrunerProgress,
+    PositionValueShardPrunerProgress(ShardId),
+    PositionStateMerklePrunerProgress,
+    PositionStateMerkleShardPrunerProgress(ShardId),
+    PositionEpochSnapshotPrunerProgress,
+    PositionEpochSnapshotShardPrunerProgress(ShardId),
 }
 
 define_schema!(

--- a/storage/aptosdb/src/state_kv_db.rs
+++ b/storage/aptosdb/src/state_kv_db.rs
@@ -293,10 +293,6 @@ impl StateKvDb {
         self.inner.shard(shard_id)
     }
 
-    pub(crate) fn db_shard_arc(&self, shard_id: usize) -> Arc<DB> {
-        Arc::clone(self.inner.shard(shard_id))
-    }
-
     pub(crate) fn num_shards(&self) -> usize {
         NUM_STATE_SHARDS
     }

--- a/storage/aptosdb/src/state_store/mod.rs
+++ b/storage/aptosdb/src/state_store/mod.rs
@@ -6,12 +6,13 @@
 use crate::{
     ledger_db::{ledger_metadata_db::LedgerMetadataDb, LedgerDb},
     metrics::{OTHER_TIMERS_SECONDS, STATE_ITEMS, TOTAL_STATE_BYTES},
-    pruner::{leaked_stale_node_cleaner, StateKvPrunerManager, StateMerklePrunerManager},
+    pruner::{
+        leaked_stale_node_cleaner, ColdStateKv, EpochSnapshot, HotStateKv, StateKvPrunerManager,
+        StateMerkle, StateMerklePrunerManager,
+    },
     schema::{
         db_metadata::{DbMetadataKey, DbMetadataSchema, DbMetadataValue},
         hot_state_value_by_key_hash::{HotStateEntry, HotStateValueByKeyHashSchema},
-        stale_node_index::StaleNodeIndexSchema,
-        stale_node_index_cross_epoch::StaleNodeIndexCrossEpochSchema,
         stale_state_value_index_by_key_hash::StaleStateValueIndexByKeyHashSchema,
         state_value_by_key_hash::StateValueByKeyHashSchema,
         version_data::VersionDataSchema,
@@ -103,12 +104,12 @@ const MAX_WRITE_SETS_AFTER_SNAPSHOT: LeafCount = buffered_state::TARGET_SNAPSHOT
 pub const MAX_COMMIT_PROGRESS_DIFFERENCE: u64 = 1_000_000;
 
 pub(crate) struct StatePruner {
-    pub hot_state_merkle_pruner: Option<StateMerklePrunerManager<StaleNodeIndexSchema>>,
-    pub hot_epoch_snapshot_pruner: Option<StateMerklePrunerManager<StaleNodeIndexCrossEpochSchema>>,
-    pub hot_state_kv_pruner: Option<StateKvPrunerManager>,
-    pub state_merkle_pruner: StateMerklePrunerManager<StaleNodeIndexSchema>,
-    pub epoch_snapshot_pruner: StateMerklePrunerManager<StaleNodeIndexCrossEpochSchema>,
-    pub state_kv_pruner: StateKvPrunerManager,
+    pub hot_state_merkle_pruner: Option<StateMerklePrunerManager<StateMerkle>>,
+    pub hot_epoch_snapshot_pruner: Option<StateMerklePrunerManager<EpochSnapshot>>,
+    pub hot_state_kv_pruner: Option<StateKvPrunerManager<HotStateKv>>,
+    pub state_merkle_pruner: StateMerklePrunerManager<StateMerkle>,
+    pub epoch_snapshot_pruner: StateMerklePrunerManager<EpochSnapshot>,
+    pub state_kv_pruner: StateKvPrunerManager<ColdStateKv>,
 }
 
 impl StatePruner {
@@ -120,22 +121,29 @@ impl StatePruner {
         config: PrunerConfig,
     ) -> Self {
         let hot_state_merkle_pruner = hot_state_merkle_db.as_ref().map(|db| {
-            StateMerklePrunerManager::new(Arc::clone(db), config.state_merkle_pruner_config)
+            StateMerklePrunerManager::<StateMerkle>::new(
+                Arc::clone(db),
+                config.state_merkle_pruner_config,
+            )
         });
         let hot_epoch_snapshot_pruner = hot_state_merkle_db.map(|db| {
-            StateMerklePrunerManager::new(db, config.epoch_snapshot_pruner_config.into())
+            StateMerklePrunerManager::<EpochSnapshot>::new(
+                db,
+                config.epoch_snapshot_pruner_config.into(),
+            )
         });
-        let hot_state_kv_pruner =
-            hot_state_kv_db.map(|db| StateKvPrunerManager::new(db, config.ledger_pruner_config));
-        let state_merkle_pruner = StateMerklePrunerManager::new(
+        let hot_state_kv_pruner = hot_state_kv_db
+            .map(|db| StateKvPrunerManager::<HotStateKv>::new(db, config.ledger_pruner_config));
+        let state_merkle_pruner = StateMerklePrunerManager::<StateMerkle>::new(
             Arc::clone(&state_merkle_db),
             config.state_merkle_pruner_config,
         );
-        let epoch_snapshot_pruner = StateMerklePrunerManager::new(
+        let epoch_snapshot_pruner = StateMerklePrunerManager::<EpochSnapshot>::new(
             Arc::clone(&state_merkle_db),
             config.epoch_snapshot_pruner_config.into(),
         );
-        let state_kv_pruner = StateKvPrunerManager::new(state_kv_db, config.ledger_pruner_config);
+        let state_kv_pruner =
+            StateKvPrunerManager::<ColdStateKv>::new(state_kv_db, config.ledger_pruner_config);
 
         leaked_stale_node_cleaner::maybe_start_cleaner(
             state_merkle_db,


### PR DESCRIPTION
## Summary

Adds pruning for the native-position subsystem's two durable stores by **reusing main state's pruner machinery directly** — the position DBs share the same substrates and schemas, so the existing pruners are generalized over the DB (and, for KV, the schema set) rather than duplicated. Both pruners are gated behind `ENABLE_TRADING_NATIVE`.

### Value-CF pruner
`StateKvPruner` / `StateKvPrunerManager` are generalized over a `StateValuePrunerSchema` trait (abstracting the value CF, stale-index CF, progress keys, name) and over the DB type (`Deref<Target = ShardedKvDb>`, default `StateKvDb`). Main state's runtime `is_hot` bool becomes a compile-time marker, giving three instantiations: `ColdStateKv`, `HotStateKv`, and `PositionValue`. The position value pruner is just `StateKvPrunerManager<PositionValue, PositionDb>`, driven from `commit_native_position` after the value commit. This is sound because the stale-index entry type (`StaleStateValueByKeyHashIndex`) and value key type (`(HashValue, Version)`) are shared across all three.

### Merkle/JMT pruner
Mirrors main state's `state_merkle_pruner` + `epoch_snapshot_pruner` pair — two `StateMerklePrunerManager`s over the position merkle DB (regular + cross-epoch stale-node indices), each on its own window. The position merkle DB shares the JMT schemas with main state, so `StateMerklePruner` / `StateMerklePrunerManager` are generalized over the DB type (`Deref<Target = ShardedJmtMerkleDb>`, default `StateMerkleDb`). Targets advance from the position merkle batch committer as snapshots persist, mirroring `state_merkle_batch_committer`.

All main-state generalizations are behavior-preserving (default type params leave existing call sites unchanged; same CFs, progress keys, and names).

## Testing

`cargo test -p aptos-db --lib` — covers the `PositionValue` KV instantiation (superseded-value GC with horizon boundary, first-write sentinels, cross-shard fan-out, worker-driven manager) and stale JMT-node collection over the position merkle DB. Main-state pruner tests (cold KV + merkle) are unchanged and pass, confirming the generalizations are transparent.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core pruning paths and deletes stale KV/JMT data; mistakes could prune readable position or main-state data, though changes are mostly generic wrappers with new call sites and tests.
> 
> **Overview**
> Adds **native-position pruning** by introducing `PositionPruner` (value + regular merkle + epoch-snapshot merkle managers) and wiring it through `PositionBundle`, `init_native_position`, the position buffered-state pipeline, and `PositionMerkleBatchCommitter`.
> 
> **Generalizes** existing KV and merkle pruner code instead of forking it: `StateValuePrunerSchema` / `MerklePrunerSchema` traits parameterize column families and progress keys; `StateKvPruner` and `StateMerklePruner` work over any `ShardedKvDb` / `ShardedJmtMerkleDb` via `Deref`. Main state keeps the same behavior via `ColdStateKv`, `HotStateKv`, `StateMerkle`, and `EpochSnapshot` markers.
> 
> **Activation**: position value pruner targets advance in `post_commit` (with main `state_kv_pruner`); merkle pruners advance when position JMT snapshots persist; on DB open, all three are caught up from synced / snapshot versions so workers do not stall after restart. New `DbMetadataKey` entries track position pruner progress.
> 
> Tests cover `PositionValue` pruning and position merkle stale-node collection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64d502a1a726ecdeb4f602f19cee46d1a555cd3e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->