### PR TITLE
[Consensus Observer] Small fixes and improvements.

### DIFF
--- a/consensus/src/consensus_observer/observer/block_data.rs
+++ b/consensus/src/consensus_observer/observer/block_data.rs
@@ -181,45 +181,50 @@ impl ObserverBlockData {
 
     /// Handles commited blocks up to the given ledger info
     fn handle_committed_blocks(&mut self, ledger_info: LedgerInfoWithSignatures) {
-        // Remove the committed blocks from the payload and ordered block stores
-        self.block_payload_store.remove_blocks_for_epoch_round(
-            ledger_info.commit_info().epoch(),
-            ledger_info.commit_info().round(),
-        );
-        self.ordered_block_store
-            .remove_blocks_for_commit(&ledger_info);
+        // Get the root commit info, epoch and round
+        let root_commit_info = self.root.commit_info();
+        let root_epoch = root_commit_info.epoch();
+        let root_round = root_commit_info.round();
+
+        // Get the ledger commit info, epoch and round
+        let ledger_commit_info = ledger_info.commit_info();
+        let ledger_epoch = ledger_commit_info.epoch();
+        let ledger_round = ledger_commit_info.round();
 
         // Verify the ledger info is for the same epoch
-        let root_commit_info = self.root.commit_info();
-        if ledger_info.commit_info().epoch() != root_commit_info.epoch() {
+        if ledger_epoch != root_epoch {
             warn!(
                 LogSchema::new(LogEntry::ConsensusObserver).message(&format!(
                     "Received commit callback for a different epoch! Ledger info: {:?}, Root: {:?}",
-                    ledger_info.commit_info(),
-                    root_commit_info
+                    ledger_commit_info, root_commit_info
                 ))
             );
             return;
         }
 
+        // Remove the committed blocks from the payload and ordered block stores
+        self.block_payload_store
+            .remove_blocks_for_epoch_round(ledger_epoch, ledger_round);
+        self.ordered_block_store
+            .remove_blocks_for_commit(&ledger_info);
+
         // Update the root ledger info. Note: we only want to do this if
         // the new ledger info round is greater than the current root
         // round. Otherwise, this can race with the state sync process.
-        if ledger_info.commit_info().round() > root_commit_info.round() {
-            let new_commit_info = ledger_info.commit_info();
+        if ledger_round > root_round {
             debug!(
                 LogSchema::new(LogEntry::ConsensusObserver).message(&format!(
                     "Updating the root ledger info! Old root: (epoch: {:?}, round: {:?}). New root: (epoch: {:?}, round: {:?})",
-                    root_commit_info.epoch(),
-                    root_commit_info.round(),
-                    new_commit_info.epoch(),
-                    new_commit_info.round(),
+                    root_epoch,
+                    root_round,
+                    ledger_epoch,
+                    ledger_round,
                 ))
             );
             metrics::set_gauge_with_label(
                 &metrics::OBSERVER_ROOT_LEDGER_INFO_ROUND,
                 metrics::COMMITTED_BLOCKS_LABEL,
-                new_commit_info.round(),
+                ledger_round,
             );
             self.root = ledger_info;
         }
@@ -629,6 +634,54 @@ mod test {
         assert_eq!(observer_block_data.get_all_ordered_blocks().len(), 1);
         assert_eq!(observer_block_data.get_block_payloads().lock().len(), 1);
         assert_eq!(observer_block_data.root(), committed_ledger_info);
+    }
+
+    #[test]
+    fn test_handle_committed_blocks_preserves_blocks() {
+        // Create a root ledger info
+        let epoch = 10;
+        let round = 5;
+        let root = create_ledger_info(epoch, round);
+
+        // Create the observer block data
+        let mut observer_block_data =
+            ObserverBlockData::new_with_root(ConsensusObserverConfig::default(), root.clone());
+
+        // Add ordered blocks and their payloads
+        let num_ordered_blocks = 5;
+        let ordered_blocks = create_and_add_ordered_blocks(
+            &mut observer_block_data,
+            num_ordered_blocks,
+            epoch,
+            round,
+        );
+        for ordered_block in &ordered_blocks {
+            create_and_add_payloads_for_ordered_block(&mut observer_block_data, ordered_block);
+        }
+
+        // Verify the blocks and payloads are present
+        assert_eq!(
+            observer_block_data.get_all_ordered_blocks().len(),
+            num_ordered_blocks
+        );
+        assert_eq!(
+            observer_block_data.get_block_payloads().lock().len(),
+            num_ordered_blocks
+        );
+
+        // Fire a commit callback for a different epoch (simulating a stale/orphaned callback)
+        observer_block_data.handle_committed_blocks(create_ledger_info(epoch + 1, round + 3));
+
+        // Verify the blocks and payloads are not deleted and the root is unchanged
+        assert_eq!(
+            observer_block_data.get_all_ordered_blocks().len(),
+            num_ordered_blocks
+        );
+        assert_eq!(
+            observer_block_data.get_block_payloads().lock().len(),
+            num_ordered_blocks
+        );
+        assert_eq!(observer_block_data.root(), root);
     }
 
     #[test]

--- a/consensus/src/consensus_observer/observer/payload_store.rs
+++ b/consensus/src/consensus_observer/observer/payload_store.rs
@@ -165,14 +165,12 @@ impl BlockPayloadStore {
             let block_epoch = ordered_block.epoch();
             let block_round = ordered_block.round();
 
-            // Fetch the block payload
+            // Verify the block payload
             match self.block_payloads.lock().entry((block_epoch, block_round)) {
+                // Get the block payload
                 Entry::Occupied(entry) => {
-                    // Get the block transaction payload
-                    let transaction_payload = match entry.get() {
-                        BlockPayloadStatus::AvailableAndVerified(block_payload) => {
-                            block_payload.transaction_payload()
-                        },
+                    let block_payload = match entry.get() {
+                        BlockPayloadStatus::AvailableAndVerified(block_payload) => block_payload,
                         BlockPayloadStatus::AvailableAndUnverified(_) => {
                             // The payload should have already been verified
                             return Err(Error::InvalidMessageError(format!(
@@ -182,6 +180,21 @@ impl BlockPayloadStore {
                             )));
                         },
                     };
+
+                    // Verify the pre-execution fields in the block payload's block info
+                    if !block_payload
+                        .block()
+                        .match_ordered_only(&ordered_block.block_info())
+                    {
+                        return Err(Error::InvalidMessageError(format!(
+                            "Payload verification failed! Block info mismatch for epoch: {:?} and round: {:?}. \
+                            Expected block info: {:?}, but found: {:?}",
+                            block_epoch,
+                            block_round,
+                            ordered_block.block_info(),
+                            block_payload.block()
+                        )));
+                    }
 
                     // Get the ordered block payload
                     let ordered_block_payload = match ordered_block.block().payload() {
@@ -196,7 +209,9 @@ impl BlockPayloadStore {
                     };
 
                     // Verify the transaction payload against the ordered block payload
-                    transaction_payload.verify_against_ordered_payload(ordered_block_payload)?;
+                    block_payload
+                        .transaction_payload()
+                        .verify_against_ordered_payload(ordered_block_payload)?;
                 },
                 Entry::Vacant(_) => {
                     // The payload is missing (this should never happen)
@@ -976,6 +991,65 @@ mod test {
         block_payload_store.clear_all_payloads();
 
         // Verify the ordered block and ensure it fails (since the payloads are missing)
+        let error = block_payload_store
+            .verify_payloads_against_ordered_block(&ordered_block)
+            .unwrap_err();
+        assert_matches!(error, Error::InvalidMessageError(_));
+    }
+
+    #[test]
+    fn test_verify_payloads_against_ordered_block_tampered_block_info() {
+        // Create a new block payload store
+        let consensus_observer_config = ConsensusObserverConfig::default();
+        let mut block_payload_store = BlockPayloadStore::new(consensus_observer_config);
+
+        // Add some verified blocks for the current epoch
+        let current_epoch = 0;
+        let num_verified_blocks = 5;
+        let verified_blocks = create_and_add_blocks_to_store(
+            &mut block_payload_store,
+            num_verified_blocks,
+            current_epoch,
+            true,
+        );
+
+        // Create an ordered block using the verified blocks
+        let ordered_block = OrderedBlock::new(
+            verified_blocks.clone(),
+            create_empty_ledger_info(current_epoch),
+        );
+
+        // Verify the ordered block passes before tampering
+        block_payload_store
+            .verify_payloads_against_ordered_block(&ordered_block)
+            .unwrap();
+
+        // Tamper with the block info of the first block payload by changing timestamp_usecs while
+        // keeping the block ID correct. This simulates the actual attack: a malicious publisher
+        // sets a far-future timestamp to force QS batch expiration while keeping the block ID
+        // intact. match_ordered_only() catches this because it compares timestamp_usecs directly.
+        let tampered_block = &verified_blocks[0];
+        let tampered_block_info = BlockInfo::new(
+            tampered_block.epoch(),
+            tampered_block.round(),
+            tampered_block.id(), // Correct block ID (attacker copies the real one)
+            HashValue::random(),
+            0,
+            u64::MAX, // Tampered timestamp to force batch expiration
+            None,
+        );
+        let block_payloads = block_payload_store.get_block_payloads();
+        let mut block_payloads = block_payloads.lock();
+        let entry = block_payloads
+            .get_mut(&(tampered_block.epoch(), tampered_block.round()))
+            .unwrap();
+        *entry = BlockPayloadStatus::AvailableAndVerified(BlockPayload::new(
+            tampered_block_info,
+            BlockTransactionPayload::empty(),
+        ));
+        drop(block_payloads);
+
+        // Verify the ordered block fails due to the tampered block info
         let error = block_payload_store
             .verify_payloads_against_ordered_block(&ordered_block)
             .unwrap_err();


### PR DESCRIPTION
## Description
This PR makes several small modifications to consensus observer:
1. Verify the block info in block payload messages before processing.
2. Verify the commit callback before clearing blocks.

## Testing Plan
New and existing test infrastructure.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes consensus observer commit and payload validation paths; incorrect logic could retain stale blocks or reject valid traffic, but scope is localized and covered by new tests.
> 
> **Overview**
> Hardens **consensus observer** handling of commits and block payloads so stale or malicious inputs cannot wipe in-memory state or slip through with mismatched metadata.
> 
> **Commit callbacks** now check that the ledger info’s **epoch matches the root** before removing anything from the payload or ordered-block stores or advancing the root. Store cleanup runs only after that check (previously removal could happen before the epoch guard). A new test confirms a wrong-epoch callback leaves ordered blocks, payloads, and the root unchanged.
> 
> **Payload verification** adds a **`match_ordered_only`** check between each stored block payload’s block info and the corresponding ordered block’s block info (e.g. catching a correct block ID paired with a tampered timestamp), then continues with transaction-payload verification as before. A regression test covers the tampered-timestamp scenario.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02901c453cbdc5e7d6f7e4f21e6862a0895b7556. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->