### PR TITLE
[cli] Apply node API key in move package commands

### DIFF
--- a/aptos-move/cli/src/commands.rs
+++ b/aptos-move/cli/src/commands.rs
@@ -1334,13 +1334,13 @@ impl CliCommand<TransactionSummary> for UpgradeObjectPackage {
     async fn execute(self) -> CliTypedResult<TransactionSummary> {
         let built_package =
             build_package_options(&self.move_options, &self.included_artifacts_args, &self.env)?;
-        let url = self
+        let client = self
             .txn_options
             .rest_options
-            .url(&self.txn_options.profile_options)?;
+            .client(&self.txn_options.profile_options)?;
 
         // Get the `PackageRegistry` at the given object address.
-        let registry = CachedPackageRegistry::create(url, self.object_address, false).await?;
+        let registry = CachedPackageRegistry::create(client, self.object_address, false).await?;
         let package = registry
             .get_package(built_package.name())
             .await
@@ -1608,13 +1608,13 @@ impl CliCommand<TransactionSummary> for UpgradeCodeObject {
         // Get the `PackageRegistry` at the given code object address.
         let upgrade_policy = match &self.txn_options.session {
             None => {
-                let url = self
+                let client = self
                     .txn_options
                     .rest_options
-                    .url(&self.txn_options.profile_options)?;
+                    .client(&self.txn_options.profile_options)?;
 
                 let registry =
-                    CachedPackageRegistry::create(url, self.object_address, false).await?;
+                    CachedPackageRegistry::create(client, self.object_address, false).await?;
                 let package_info = registry
                     .get_package(package.name())
                     .await
@@ -2034,8 +2034,8 @@ impl CliCommand<&'static str> for DownloadPackage {
     }
 
     async fn execute(self) -> CliTypedResult<&'static str> {
-        let url = self.rest_options.url(&self.profile_options)?;
-        let registry = CachedPackageRegistry::create(url, self.account, self.bytecode).await?;
+        let client = self.rest_options.client(&self.profile_options)?;
+        let registry = CachedPackageRegistry::create(client, self.account, self.bytecode).await?;
         let output_dir = dir_default_to_current(self.output_dir)?;
 
         let package = registry
@@ -2118,8 +2118,8 @@ impl CliCommand<&'static str> for VerifyPackage {
         let compiled_metadata = pack.extract_metadata()?;
 
         // Now pull the compiled package
-        let url = self.rest_options.url(&self.profile_options)?;
-        let registry = CachedPackageRegistry::create(url, self.account, false).await?;
+        let client = self.rest_options.client(&self.profile_options)?;
+        let registry = CachedPackageRegistry::create(client, self.account, false).await?;
         let package = registry
             .get_package(pack.name())
             .await
@@ -2194,8 +2194,8 @@ impl CliCommand<&'static str> for ListPackage {
     }
 
     async fn execute(self) -> CliTypedResult<&'static str> {
-        let url = self.rest_options.url(&self.profile_options)?;
-        let registry = CachedPackageRegistry::create(url, self.account, false).await?;
+        let client = self.rest_options.client(&self.profile_options)?;
+        let registry = CachedPackageRegistry::create(client, self.account, false).await?;
         match self.query {
             MoveListQuery::Packages => {
                 for name in registry.package_names() {

--- a/aptos-move/cli/src/package_hooks.rs
+++ b/aptos-move/cli/src/package_hooks.rs
@@ -4,6 +4,7 @@
 use crate::stored_package::CachedPackageRegistry;
 use aptos_cli_common::load_account_arg;
 use aptos_framework::UPGRADE_POLICY_CUSTOM_FIELD;
+use aptos_rest_client::Client;
 use futures::executor::block_on;
 use move_package::{
     compilation::package_layout::CompiledPackageLayout, package_hooks::PackageHooks,
@@ -43,7 +44,7 @@ async fn maybe_download_package(info: &CustomDepInfo) -> anyhow::Result<()> {
         .exists()
     {
         let registry = CachedPackageRegistry::create(
-            Url::parse(info.node_url.as_str())?,
+            Client::new(Url::parse(info.node_url.as_str())?),
             load_account_arg(info.package_address.as_str())?,
             false,
         )

--- a/aptos-move/cli/src/stored_package.rs
+++ b/aptos-move/cli/src/stored_package.rs
@@ -9,7 +9,6 @@ use aptos_framework::{
 use aptos_rest_client::Client;
 use aptos_types::account_address::AccountAddress;
 use move_package::compilation::package_layout::CompiledPackageLayout;
-use reqwest::Url;
 use std::{collections::BTreeMap, fmt, fs, path::Path};
 
 // TODO: this is a first naive implementation of the package registry. Before mainnet
@@ -41,11 +40,10 @@ impl fmt::Display for CachedPackageMetadata<'_> {
 impl CachedPackageRegistry {
     /// Creates a new registry.
     pub async fn create(
-        url: Url,
+        client: Client,
         addr: AccountAddress,
         with_bytecode: bool,
     ) -> anyhow::Result<Self> {
-        let client = Client::new(url);
         // Need to use a different type to deserialize JSON
         let inner = client
             .get_account_resource_bcs::<PackageRegistry>(addr, "0x1::code::PackageRegistry")


### PR DESCRIPTION
## Description

`aptos move download/verify-package/list/upgrade-object-package/upgrade-object`
ignored the node API key. They obtained only the URL from `RestOptions`
(`rest_options.url(...)`) and handed it to `CachedPackageRegistry::create`,
which did `Client::new(url)` - a client with no `Authorization` header. The
`--node-api-key` flag and `NODE_API_KEY` env var were accepted (flattened
`RestOptions`) but discarded, so calls were unauthenticated and hit the
anonymous per-IP rate limit.

`RestOptions::client()` is the only path that applies the key. This PR
threads the already-configured client into `CachedPackageRegistry::create`
instead of a bare URL, fixing all five commands (and the `-b` bytecode
fetch, which reuses the same client).

## Scope

In scope (share the `CachedPackageRegistry::create` root cause): `download`,
`verify-package`, `list`, `upgrade-object-package`, `upgrade-object`.

Out of scope (follow-ups): `aptos init` and the `package_hooks`
custom-dependency resolver have no `RestOptions` and cannot take the flag
today.

## How Has This Been Tested?

- `cargo test -p aptos-move-cli` - 45 passed, 0 failed
- `cargo check --tests` on all reverse deps (`aptos`, `aptos-release-builder`,
  `aptos-move-flow`, `aptos-move-debugger`, `aptos-indexer-transaction-generator`,
  `smoke-test`) - all build

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow wiring change to use the existing RestOptions client builder; no auth or transaction logic changes beyond attaching the API key header for registry/module reads.
> 
> **Overview**
> Several **aptos move** commands that read on-chain package registries now build the REST client via **`RestOptions::client()`** instead of passing only a URL into **`CachedPackageRegistry::create`**, which previously called **`Client::new(url)`** and dropped **`--node-api-key`** / **`NODE_API_KEY`**.
> 
> **`CachedPackageRegistry::create`** now takes an **`aptos_rest_client::Client`** directly (no internal client construction). Call sites updated include **download**, **verify-package**, **list**, **upgrade-object-package**, and **upgrade-object** (including registry lookups before upgrade). **`package_hooks`** custom-dependency downloads use **`Client::new(Url::…)`** with the new signature; that path still cannot apply profile API keys (noted as follow-up in the PR).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4d08751a69d10a27bb41d9fc31af870c8507627. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->