### PR TITLE
[api] Prevent unbounded type layout expansion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8778,6 +8778,7 @@ dependencies = [
  "aptos-move-e2e-test-harness",
  "aptos-mvhashmap",
  "aptos-package-builder",
+ "aptos-resource-viewer",
  "aptos-rest-client",
  "aptos-sdk",
  "aptos-transaction-simulation",
@@ -8790,6 +8791,7 @@ dependencies = [
  "hex",
  "memory-stats",
  "move-binary-format",
+ "move-bytecode-utils",
  "move-core-types",
  "move-coverage",
  "move-model",
@@ -13490,6 +13492,7 @@ name = "move-resource-viewer"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "fxhash",
  "hex",
  "move-binary-format",
  "move-bytecode-utils",

--- a/aptos-move/e2e-move-tests/Cargo.toml
+++ b/aptos-move/e2e-move-tests/Cargo.toml
@@ -48,9 +48,11 @@ test-case = { workspace = true }
 aptos-aggregator = { workspace = true }
 aptos-block-executor = { workspace = true, features = ["testing"] }
 aptos-mvhashmap = { workspace = true }
+aptos-resource-viewer = { workspace = true }
 aptos-vm-types = { workspace = true }
 claims = { workspace = true }
 memory-stats = { workspace = true }
+move-bytecode-utils = { workspace = true }
 move-vm-runtime = { workspace = true }
 move-vm-types = { workspace = true }
 test-case = { workspace = true }

--- a/aptos-move/e2e-move-tests/src/tests/mod.rs
+++ b/aptos-move/e2e-move-tests/src/tests/mod.rs
@@ -65,6 +65,7 @@ mod public_const_upgrade;
 mod public_struct_args;
 mod public_structs_enums_upgrade;
 mod randomness_test_and_abort;
+mod read_side_layout_dag;
 mod remote_state;
 mod resource_groups;
 mod rotate_auth_key;

--- a/aptos-move/e2e-move-tests/src/tests/read_side_layout_dag.rs
+++ b/aptos-move/e2e-move-tests/src/tests/read_side_layout_dag.rs
@@ -1,0 +1,126 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Read-side `MoveTypeLayout` construction from small, verifier-legal types whose layout has
+//! exponentially many nodes when shared instantiations are expanded instead of reused. Reached
+//! through the two off-chain builders the REST API uses.
+
+use crate::{assert_success, MoveHarness};
+use aptos_package_builder::PackageBuilder;
+use aptos_resource_viewer::{AnnotatedMoveValue, AptosValueAnnotator};
+use aptos_types::account_address::AccountAddress;
+use claims::{assert_err, assert_ok};
+use move_core_types::{
+    identifier::Identifier,
+    language_storage::{StructTag, TypeTag},
+};
+
+const DEPTH: usize = 8;
+const FAN_OUT: usize = 16;
+
+/// A module with a generic `struct Wide<T>` of `FAN_OUT` fields, each of type `T`.
+fn wide_module_source(addr: &str) -> String {
+    let mut s = format!("module {}::wide {{\n", addr);
+    s.push_str("    struct Wide<T> has copy, drop, store {\n");
+    for i in 0..FAN_OUT {
+        s.push_str(&format!("        f{}: T,\n", i));
+    }
+    s.push_str("    }\n}\n");
+    s
+}
+
+/// `vector<Wide<Wide<...<u8>>>>` with `DEPTH` levels of `Wide`.
+fn nested_wide_vector(addr: AccountAddress) -> TypeTag {
+    let mut inner = TypeTag::U8;
+    for _ in 0..DEPTH {
+        inner = TypeTag::Struct(Box::new(StructTag {
+            address: addr,
+            module: Identifier::new("wide").unwrap(),
+            name: Identifier::new("Wide").unwrap(),
+            type_args: vec![inner],
+        }));
+    }
+    TypeTag::Vector(Box::new(inner))
+}
+
+/// `view_value` shares repeated struct instantiations instead of expanding them into a tree.
+#[test]
+fn view_value_bounds_layout_dag() {
+    let addr = "0xcafe";
+    let account_address = AccountAddress::from_hex_literal(addr).unwrap();
+
+    let mut builder = PackageBuilder::new("Wide");
+    builder.add_source("wide.move", &wide_module_source(addr));
+    let path = builder.write_to_temp().unwrap();
+
+    let mut h = MoveHarness::new();
+    let acc = h.new_account_at(account_address);
+    assert_success!(h.publish_package(&acc, path.path()));
+
+    let type_tag = nested_wide_vector(account_address);
+    let empty_vector = bcs::to_bytes(&Vec::<u8>::new()).unwrap();
+
+    let annotator = AptosValueAnnotator::new(h.executor.state_store());
+    let value = assert_ok!(annotator.view_value(&type_tag, &empty_vector));
+
+    match value {
+        AnnotatedMoveValue::Vector(_, elems) => assert!(elems.is_empty()),
+        other => panic!("expected an empty vector, got {:?}", other),
+    }
+}
+
+/// A concrete-width chain `L0 { v: u8 }`, `L(i+1) { f0..f15: Li }`. With no type parameters to
+/// share, `TypeLayoutBuilder` rebuilds each field, so `Li`'s layout has `16^i` nodes.
+fn concrete_chain_source(addr: &str, depth: usize) -> String {
+    let mut s = format!("module {}::nest {{\n", addr);
+    s.push_str("    struct L0 has copy, drop, store { v: u8 }\n");
+    for i in 0..depth {
+        s.push_str(&format!("    struct L{} has copy, drop, store {{\n", i + 1));
+        for f in 0..FAN_OUT {
+            s.push_str(&format!("        f{}: L{},\n", f, i));
+        }
+        s.push_str("    }\n");
+    }
+    s.push_str("}\n");
+    s
+}
+
+fn l_struct_tag(addr: AccountAddress, level: usize) -> TypeTag {
+    TypeTag::Struct(Box::new(StructTag {
+        address: addr,
+        module: Identifier::new("nest").unwrap(),
+        name: Identifier::new(format!("L{}", level)).unwrap(),
+        type_args: vec![],
+    }))
+}
+
+/// `view_fully_decorated_ty_layout` caps the layout's node count.
+#[test]
+fn view_fully_decorated_ty_layout_bounds_layout_dag() {
+    let addr = "0xcafe";
+    let account_address = AccountAddress::from_hex_literal(addr).unwrap();
+
+    let mut builder = PackageBuilder::new("Nest");
+    builder.add_source("nest.move", &concrete_chain_source(addr, 4));
+    let path = builder.write_to_temp().unwrap();
+
+    let mut h = MoveHarness::new();
+    let acc = h.new_account_at(account_address);
+    assert_success!(h.publish_package(&acc, path.path()));
+
+    let annotator = AptosValueAnnotator::new(h.executor.state_store());
+
+    // L1's layout is 16 nodes, well under the cap.
+    assert_ok!(annotator.view_fully_decorated_ty_layout(&l_struct_tag(account_address, 1)));
+    // L4's is 16^4, over the cap.
+    assert_err!(annotator.view_fully_decorated_ty_layout(&l_struct_tag(account_address, 4)));
+}
+
+/// The layout node cap must match the VM's runtime `layout_max_size`.
+#[test]
+fn layout_node_cap_matches_vm_limit() {
+    assert_eq!(
+        move_bytecode_utils::layout::MAX_TYPE_LAYOUT_NODES,
+        move_vm_runtime::config::VMConfig::default().layout_max_size,
+    );
+}

--- a/third_party/move/tools/move-bytecode-utils/src/layout.rs
+++ b/third_party/move/tools/move-bytecode-utils/src/layout.rs
@@ -29,6 +29,33 @@ enum LayoutType {
     Runtime,
 }
 
+/// Upper bound on the number of nodes in a layout built from a type. A small, verifier-legal type
+/// can still describe a very large layout, so the builder caps the node count.
+///
+/// Mirrors the VM's runtime `layout_max_size` and should be kept in sync with it.
+/// This crate can't import that value, so a test in `e2e-move-tests` checks they match.
+pub const MAX_TYPE_LAYOUT_NODES: u64 = 512;
+
+/// Running budget of layout nodes built so far in one traversal, enforcing [`MAX_TYPE_LAYOUT_NODES`].
+#[derive(Default)]
+struct LayoutBudget {
+    nodes: u64,
+}
+
+impl LayoutBudget {
+    /// Accounts for one layout node, failing once the cap is exceeded.
+    fn charge(&mut self) -> anyhow::Result<()> {
+        if self.nodes > MAX_TYPE_LAYOUT_NODES {
+            bail!(
+                "type layout exceeds the maximum of {} nodes",
+                MAX_TYPE_LAYOUT_NODES
+            );
+        }
+        self.nodes += 1;
+        Ok(())
+    }
+}
+
 impl TypeLayoutBuilder {
     /// Construct a WithTypes `TypeLayout` with fields from `t`.
     /// Panics if `resolver` cannot resolve a module whose types are referenced directly or
@@ -37,7 +64,12 @@ impl TypeLayoutBuilder {
         t: &TypeTag,
         compiled_module_view: &impl CompiledModuleView,
     ) -> anyhow::Result<MoveTypeLayout> {
-        Self::build(t, compiled_module_view, LayoutType::WithTypes)
+        Self::build(
+            t,
+            compiled_module_view,
+            LayoutType::WithTypes,
+            &mut LayoutBudget::default(),
+        )
     }
 
     /// Construct a WithFields `TypeLayout` with fields from `t`.
@@ -47,7 +79,12 @@ impl TypeLayoutBuilder {
         t: &TypeTag,
         compiled_module_view: &impl CompiledModuleView,
     ) -> anyhow::Result<MoveTypeLayout> {
-        Self::build(t, compiled_module_view, LayoutType::WithFields)
+        Self::build(
+            t,
+            compiled_module_view,
+            LayoutType::WithFields,
+            &mut LayoutBudget::default(),
+        )
     }
 
     /// Construct a runtime `TypeLayout` from `t`.
@@ -57,15 +94,22 @@ impl TypeLayoutBuilder {
         t: &TypeTag,
         compiled_module_view: &impl CompiledModuleView,
     ) -> anyhow::Result<MoveTypeLayout> {
-        Self::build(t, compiled_module_view, LayoutType::Runtime)
+        Self::build(
+            t,
+            compiled_module_view,
+            LayoutType::Runtime,
+            &mut LayoutBudget::default(),
+        )
     }
 
     fn build(
         t: &TypeTag,
         compiled_module_view: &impl CompiledModuleView,
         layout_type: LayoutType,
+        budget: &mut LayoutBudget,
     ) -> anyhow::Result<MoveTypeLayout> {
         use TypeTag::*;
+        budget.charge()?;
         Ok(match t {
             Bool => MoveTypeLayout::Bool,
             U8 => MoveTypeLayout::U8,
@@ -86,11 +130,13 @@ impl TypeLayoutBuilder {
                 elem_t,
                 compiled_module_view,
                 layout_type,
+                budget,
             )?)),
             Struct(s) => MoveTypeLayout::new_struct(StructLayoutBuilder::build(
                 s,
                 compiled_module_view,
                 layout_type,
+                budget,
             )?),
             Function(_) => MoveTypeLayout::Function,
         })
@@ -102,8 +148,10 @@ impl TypeLayoutBuilder {
         type_arguments: &[MoveTypeLayout],
         compiled_module_view: &impl CompiledModuleView,
         layout_type: LayoutType,
+        budget: &mut LayoutBudget,
     ) -> anyhow::Result<MoveTypeLayout> {
         use SignatureToken::*;
+        budget.charge()?;
         Ok(match s {
             Function(..) => bail!("function types NYI for MoveTypeLayout"),
             Vector(t) => MoveTypeLayout::Vector(Box::new(Self::build_from_signature_token(
@@ -112,6 +160,7 @@ impl TypeLayoutBuilder {
                 type_arguments,
                 compiled_module_view,
                 layout_type,
+                budget,
             )?)),
             Struct(shi) => MoveTypeLayout::new_struct(StructLayoutBuilder::build_from_handle_idx(
                 m,
@@ -119,6 +168,7 @@ impl TypeLayoutBuilder {
                 vec![],
                 compiled_module_view,
                 layout_type,
+                budget,
             )?),
             StructInstantiation(shi, type_actuals) => {
                 let actual_layouts = type_actuals
@@ -130,6 +180,7 @@ impl TypeLayoutBuilder {
                             type_arguments,
                             compiled_module_view,
                             layout_type,
+                            budget,
                         )
                     })
                     .collect::<anyhow::Result<Vec<_>>>()?;
@@ -139,6 +190,7 @@ impl TypeLayoutBuilder {
                     actual_layouts,
                     compiled_module_view,
                     layout_type,
+                    budget,
                 )?)
             },
             TypeParameter(i) => type_arguments[*i as usize].clone(),
@@ -167,14 +219,24 @@ impl StructLayoutBuilder {
         s: &StructTag,
         compiled_module_view: &impl CompiledModuleView,
     ) -> anyhow::Result<MoveStructLayout> {
-        Self::build(s, compiled_module_view, LayoutType::Runtime)
+        Self::build(
+            s,
+            compiled_module_view,
+            LayoutType::Runtime,
+            &mut LayoutBudget::default(),
+        )
     }
 
     pub fn build_with_fields(
         s: &StructTag,
         compiled_module_view: &impl CompiledModuleView,
     ) -> anyhow::Result<MoveStructLayout> {
-        Self::build(s, compiled_module_view, LayoutType::WithFields)
+        Self::build(
+            s,
+            compiled_module_view,
+            LayoutType::WithFields,
+            &mut LayoutBudget::default(),
+        )
     }
 
     /// Construct an expanded `TypeLayout` from `s`.
@@ -184,11 +246,12 @@ impl StructLayoutBuilder {
         s: &StructTag,
         compiled_module_view: &impl CompiledModuleView,
         layout_type: LayoutType,
+        budget: &mut LayoutBudget,
     ) -> anyhow::Result<MoveStructLayout> {
         let type_arguments = s
             .type_args
             .iter()
-            .map(|t| TypeLayoutBuilder::build(t, compiled_module_view, layout_type))
+            .map(|t| TypeLayoutBuilder::build(t, compiled_module_view, layout_type, budget))
             .collect::<anyhow::Result<Vec<MoveTypeLayout>>>()?;
         Self::build_from_name(
             &s.module_id(),
@@ -196,6 +259,7 @@ impl StructLayoutBuilder {
             type_arguments,
             compiled_module_view,
             layout_type,
+            budget,
         )
     }
 
@@ -205,6 +269,7 @@ impl StructLayoutBuilder {
         type_arguments: Vec<MoveTypeLayout>,
         compiled_module_view: &impl CompiledModuleView,
         layout_type: LayoutType,
+        budget: &mut LayoutBudget,
     ) -> anyhow::Result<MoveStructLayout> {
         let s_handle = m.struct_handle_at(s.struct_handle);
         if s_handle.type_parameters.len() != type_arguments.len() {
@@ -224,6 +289,7 @@ impl StructLayoutBuilder {
                             &type_arguments,
                             compiled_module_view,
                             layout_type,
+                            budget,
                         )
                     })
                     .collect::<anyhow::Result<Vec<MoveTypeLayout>>>()?;
@@ -296,6 +362,7 @@ impl StructLayoutBuilder {
                             &type_arguments,
                             compiled_module_view,
                             layout_type,
+                            budget,
                         )?;
                         let vector_layout = MoveTypeLayout::Vector(Box::new(layout));
                         let identifier = Identifier::new(LEGACY_OPTION_VEC)?;
@@ -319,6 +386,7 @@ impl StructLayoutBuilder {
                                         &type_arguments,
                                         compiled_module_view,
                                         layout_type,
+                                        budget,
                                     )
                                 })
                                 .collect::<anyhow::Result<Vec<MoveTypeLayout>>>()?;
@@ -357,6 +425,7 @@ impl StructLayoutBuilder {
         type_arguments: Vec<MoveTypeLayout>,
         module_viewer: &impl CompiledModuleView,
         layout_type: LayoutType,
+        budget: &mut LayoutBudget,
     ) -> anyhow::Result<MoveStructLayout> {
         let module = match module_viewer.view_compiled_module(declaring_module) {
             Err(_) | Ok(None) => bail!("Could not find module"),
@@ -378,6 +447,7 @@ impl StructLayoutBuilder {
             type_arguments,
             module_viewer,
             layout_type,
+            budget,
         )
     }
 
@@ -387,10 +457,18 @@ impl StructLayoutBuilder {
         type_arguments: Vec<MoveTypeLayout>,
         compiled_module_view: &impl CompiledModuleView,
         layout_type: LayoutType,
+        budget: &mut LayoutBudget,
     ) -> anyhow::Result<MoveStructLayout> {
         if let Some(def) = m.find_struct_def(s) {
             // declared internally
-            Self::build_from_definition(m, def, type_arguments, compiled_module_view, layout_type)
+            Self::build_from_definition(
+                m,
+                def,
+                type_arguments,
+                compiled_module_view,
+                layout_type,
+                budget,
+            )
         } else {
             let handle = m.struct_handle_at(s);
             let name = m.identifier_at(handle.name);
@@ -402,6 +480,7 @@ impl StructLayoutBuilder {
                 type_arguments,
                 compiled_module_view,
                 layout_type,
+                budget,
             )
         }
     }

--- a/third_party/move/tools/move-resource-viewer/Cargo.toml
+++ b/third_party/move/tools/move-resource-viewer/Cargo.toml
@@ -16,4 +16,5 @@ move-core-types = { workspace = true }
 serde = { workspace = true, features = ["derive", "rc"] }
 
 anyhow = { workspace = true }
+fxhash = { workspace = true }
 hex = { workspace = true }

--- a/third_party/move/tools/move-resource-viewer/src/fat_type.rs
+++ b/third_party/move/tools/move-resource-viewer/src/fat_type.rs
@@ -5,6 +5,7 @@
 //! Loaded representation for runtime types.
 
 use crate::limit::Limiter;
+use fxhash::FxHashMap;
 use move_binary_format::errors::{PartialVMError, PartialVMResult};
 use move_core_types::{
     ability::AbilitySet,
@@ -18,7 +19,7 @@ use move_core_types::{
     vm_status::StatusCode,
 };
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use std::{cmp::Ordering, convert::TryInto, ops::Deref, rc::Rc};
+use std::{cmp::Ordering, convert::TryInto, ops::Deref, rc::Rc, sync::Arc};
 
 #[derive(Debug, Clone, Copy, PartialOrd, Ord, PartialEq, Eq)]
 pub(crate) struct WrappedAbilitySet(pub AbilitySet);
@@ -565,27 +566,42 @@ impl FatType {
     }
 }
 
+/// Caches each struct instantiation's `Arc<MoveStructLayout>`, keyed by `Rc<FatStructType>` pointer
+/// identity. The annotator shares one `Rc` per instantiation, so reusing the cached `Arc` keeps the
+/// conversion proportional to the source DAG instead of expanding it into a tree.
+type LayoutMemo = FxHashMap<*const FatStructType, Arc<MoveStructLayout>>;
+
 impl TryInto<MoveStructLayout> for &FatStructType {
     type Error = PartialVMError;
 
     fn try_into(self) -> Result<MoveStructLayout, Self::Error> {
+        self.to_struct_layout(&mut LayoutMemo::default())
+    }
+}
+
+impl FatStructType {
+    /// Lowers this struct into a [`MoveStructLayout`], reusing already-built instantiations via `memo`
+    /// so the result stays proportional to the source DAG.
+    pub(crate) fn to_struct_layout(
+        &self,
+        memo: &mut LayoutMemo,
+    ) -> PartialVMResult<MoveStructLayout> {
         Ok(match &self.layout {
-            FatStructLayout::Singleton(fields) => MoveStructLayout::new(into_types(fields.iter())?),
+            FatStructLayout::Singleton(fields) => MoveStructLayout::new(into_types(fields, memo)?),
             FatStructLayout::Variants(variants) => MoveStructLayout::new_variants(
                 variants
                     .iter()
-                    .map(|fields| into_types(fields.iter()))
+                    .map(|fields| into_types(fields, memo))
                     .collect::<PartialVMResult<_>>()?,
             ),
         })
     }
 }
 
-fn into_types<'a>(
-    types: impl Iterator<Item = &'a FatType>,
-) -> PartialVMResult<Vec<MoveTypeLayout>> {
+fn into_types(types: &[FatType], memo: &mut LayoutMemo) -> PartialVMResult<Vec<MoveTypeLayout>> {
     types
-        .map(|ty| ty.try_into())
+        .iter()
+        .map(|ty| ty.to_type_layout(memo))
         .collect::<PartialVMResult<Vec<_>>>()
 }
 
@@ -593,11 +609,14 @@ impl TryInto<MoveTypeLayout> for &FatType {
     type Error = PartialVMError;
 
     fn try_into(self) -> Result<MoveTypeLayout, Self::Error> {
-        let slice_into = |tys: &[FatType]| {
-            tys.iter()
-                .map(|ty| ty.try_into())
-                .collect::<PartialVMResult<Vec<MoveTypeLayout>>>()
-        };
+        self.to_type_layout(&mut LayoutMemo::default())
+    }
+}
+
+impl FatType {
+    /// Lowers this type into a [`MoveTypeLayout`], reusing already-built instantiations via `memo`
+    /// so the result stays proportional to the source DAG.
+    pub(crate) fn to_type_layout(&self, memo: &mut LayoutMemo) -> PartialVMResult<MoveTypeLayout> {
         Ok(match self {
             FatType::Address => MoveTypeLayout::Address,
             FatType::U8 => MoveTypeLayout::U8,
@@ -613,16 +632,27 @@ impl TryInto<MoveTypeLayout> for &FatType {
             FatType::I128 => MoveTypeLayout::I128,
             FatType::I256 => MoveTypeLayout::I256,
             FatType::Bool => MoveTypeLayout::Bool,
-            FatType::Vector(v) => MoveTypeLayout::Vector(Box::new(v.as_ref().try_into()?)),
-            FatType::Struct(s) => MoveTypeLayout::new_struct(s.as_ref().try_into()?),
+            FatType::Vector(v) => MoveTypeLayout::Vector(Box::new(v.to_type_layout(memo)?)),
+            FatType::Struct(s) => {
+                let key = Rc::as_ptr(&s.rc);
+                let layout = match memo.get(&key) {
+                    Some(layout) => layout.clone(),
+                    None => {
+                        let layout = Arc::new(s.to_struct_layout(memo)?);
+                        memo.insert(key, layout.clone());
+                        layout
+                    },
+                };
+                MoveTypeLayout::Struct(layout)
+            },
             FatType::Function(_) => MoveTypeLayout::Function,
             FatType::Runtime(tys) => {
-                MoveTypeLayout::new_struct(MoveStructLayout::Runtime(slice_into(tys)?))
+                MoveTypeLayout::new_struct(MoveStructLayout::Runtime(into_types(tys, memo)?))
             },
             FatType::RuntimeVariants(vars) => {
                 MoveTypeLayout::new_struct(MoveStructLayout::RuntimeVariants(
                     vars.iter()
-                        .map(|tys| slice_into(tys))
+                        .map(|tys| into_types(tys, memo))
                         .collect::<Result<Vec<_>, _>>()?,
                 ))
             },


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

See https://github.com/aptos-labs/aptos-core-private/pull/432 for detailed description.

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes layout-building behavior for API/read paths; legitimate very large decorated layouts may now error, but the cap matches VM limits and reduces DoS risk on full nodes.
> 
> **Overview**
> Off-chain **Move type layout** construction (used by REST value annotation) is hardened against **exponential blow-up** from small, verifier-legal types whose layouts are huge when shared generic instantiations are expanded as trees.
> 
> **`move-bytecode-utils`** threads a **`LayoutBudget`** through `TypeLayoutBuilder` / `StructLayoutBuilder` and enforces **`MAX_TYPE_LAYOUT_NODES` (512)**, aligned with the VM’s **`layout_max_size`** (checked in a new e2e test).
> 
> **`move-resource-viewer`** memoizes **`FatType` → `MoveTypeLayout`** by **`Rc<FatStructType>`** pointer so **`view_value`** reuses repeated struct instantiations instead of duplicating layout nodes.
> 
> New **`read_side_layout_dag`** e2e tests cover deep generic **`Wide<T>`** vectors (annotator path) and wide concrete struct chains (decorated layout path, expect failure over the cap).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3870a82935d465f14c5b0591a2b8ee742deda2b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->