### PR TITLE
[consensus] Disable enable_batch_v2_tx on v1.46

### DIFF
--- a/config/src/config/quorum_store_config.rs
+++ b/config/src/config/quorum_store_config.rs
@@ -160,7 +160,7 @@ impl Default for QuorumStoreConfig {
             enable_opt_quorum_store: true,
             opt_qs_minimum_batch_age_usecs: Duration::from_millis(50).as_micros() as u64,
             enable_payload_v2: false,
-            enable_batch_v2_tx: true,
+            enable_batch_v2_tx: false,
             enable_batch_v2_rx: true,
             enable_opt_qs_v2_payload_tx: true,
             enable_opt_qs_v2_payload_rx: true,


### PR DESCRIPTION
## Summary
- Flip the default of `enable_batch_v2_tx` to `false` in `QuorumStoreConfig` for the v1.46 release so nodes do not send Batch V2 transactions.
- `enable_batch_v2_rx` and `enable_opt_qs_v2_payload_tx` are intentionally left as `true`.

## Test plan
- [x] CI green