### PR TITLE
[mono-move] Table keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12861,6 +12861,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
+ "hashbrown 0.14.3",
  "mono-move-alloc",
  "mono-move-core",
  "mono-move-gas",

--- a/third_party/move/mono-move/core/src/storage/resource_provider.rs
+++ b/third_party/move/mono-move/core/src/storage/resource_provider.rs
@@ -14,9 +14,20 @@ use thiserror::Error;
 //   Replace with Block-STM transaction index and incarnation pair.
 pub type Version = u64;
 
-/// Key to (in-memory) global storage.
-#[derive(Copy, Clone, Eq, PartialEq, Hash)]
-pub enum StorageKey {
+/// Key into the in-memory global storage of a single transaction.
+///
+/// Resources and table items live in the same per-transaction read-write set,
+/// so they share one key enum and one map. Both are entries anchored at an
+/// address: a resource at the address it is published under, a table item at
+/// its table handle. Keeping them in one map lets every global-storage access
+/// (resource ops and, later, native table ops) go through the same lookup,
+/// read-set recording, undo journal, and checkpoint machinery.
+///
+/// The key is "in-memory" because it embeds interned, arena-backed data that
+/// must not outlive the current execution. It is not a stable, serializable
+/// storage key.
+#[derive(Clone, Eq, PartialEq, Hash)]
+pub enum InMemoryStorageKey {
     /// Every resource can be identified in storage by the address where it is
     /// published and its struct/enum type.
     ///
@@ -25,7 +36,10 @@ pub enum StorageKey {
     /// (for the duration of execution, bounded by the execution guard). Keys
     /// must not be stored past arena reset, nor compared across two different
     /// arenas: equality and hashing rely on the interned pointer identity.
-    Resource(AccountAddress, InternedType),
+    Resource {
+        address: AccountAddress,
+        ty: InternedType,
+    },
     /// A table item, identified by its table handle and the serialized bytes of
     /// its key.
     TableItem {
@@ -35,19 +49,30 @@ pub enum StorageKey {
     },
 }
 
-impl StorageKey {
+impl InMemoryStorageKey {
+    /// Builds a resource key from its publishing address and interned type.
+    pub fn resource(address: AccountAddress, ty: InternedType) -> Self {
+        InMemoryStorageKey::Resource { address, ty }
+    }
+
     /// Builds a table item key from its handle and the serialized key bytes.
     pub fn table_item(handle: AccountAddress, key: Box<[u8]>) -> Self {
-        StorageKey::TableItem { handle, key }
+        InMemoryStorageKey::TableItem { handle, key }
     }
 
     /// Returns the address a key is anchored at: the publishing address for a
     /// resource, or the table handle for a table item.
     pub fn address(&self) -> AccountAddress {
         match self {
-            StorageKey::Resource(addr, _) => *addr,
-            StorageKey::TableItem { handle, .. } => *handle,
+            InMemoryStorageKey::Resource { address, .. } => *address,
+            InMemoryStorageKey::TableItem { handle, .. } => *handle,
         }
+    }
+}
+
+impl From<&InMemoryStorageKey> for InMemoryStorageKey {
+    fn from(key: &InMemoryStorageKey) -> Self {
+        key.clone()
     }
 }
 
@@ -98,14 +123,17 @@ pub trait ResourceProvider {
     /// Returns [`StorageRead::DoesNotExist`] if the resource does not exist.
     /// Returns a [`ResourceProviderError`] if the backend cannot satisfy the
     /// read.
-    fn get_resource(&self, key: &StorageKey) -> Result<StorageRead, ResourceProviderError>;
+    fn get_resource(&self, key: &InMemoryStorageKey) -> Result<StorageRead, ResourceProviderError>;
 }
 
 /// Empty storage with no resources.
 pub struct NoResourceProvider;
 
 impl ResourceProvider for NoResourceProvider {
-    fn get_resource(&self, _key: &StorageKey) -> Result<StorageRead, ResourceProviderError> {
+    fn get_resource(
+        &self,
+        _key: &InMemoryStorageKey,
+    ) -> Result<StorageRead, ResourceProviderError> {
         Ok(StorageRead::DoesNotExist)
     }
 }

--- a/third_party/move/mono-move/core/src/storage/resource_provider.rs
+++ b/third_party/move/mono-move/core/src/storage/resource_provider.rs
@@ -15,24 +15,38 @@ use thiserror::Error;
 pub type Version = u64;
 
 /// Key to (in-memory) global storage.
-///
-/// A key embeds an [`InternedType`], which is a pointer into the global type
-/// arena. The key is therefore only valid while that arena is alive (for the
-/// duration of execution, bounded by the execution guard). Keys must not be
-/// stored past arena reset, nor compared across two different arenas: equality
-/// and hashing rely on the interned pointer identity.
 #[derive(Copy, Clone, Eq, PartialEq, Hash)]
 pub enum StorageKey {
     /// Every resource can be identified in storage by the address where it is
     /// published and its struct/enum type.
+    ///
+    /// A key embeds an [`InternedType`], which is a pointer into the global
+    /// type arena. The key is therefore only valid while that arena is alive
+    /// (for the duration of execution, bounded by the execution guard). Keys
+    /// must not be stored past arena reset, nor compared across two different
+    /// arenas: equality and hashing rely on the interned pointer identity.
     Resource(AccountAddress, InternedType),
-    // TODO: Can add tables and other extensions here.
+    /// A table item, identified by its table handle and the serialized bytes of
+    /// its key.
+    TableItem {
+        handle: AccountAddress,
+        // TODO(perf): consider interning these keys later.
+        key: Box<[u8]>,
+    },
 }
 
 impl StorageKey {
+    /// Builds a table item key from its handle and the serialized key bytes.
+    pub fn table_item(handle: AccountAddress, key: Box<[u8]>) -> Self {
+        StorageKey::TableItem { handle, key }
+    }
+
+    /// Returns the address a key is anchored at: the publishing address for a
+    /// resource, or the table handle for a table item.
     pub fn address(&self) -> AccountAddress {
         match self {
             StorageKey::Resource(addr, _) => *addr,
+            StorageKey::TableItem { handle, .. } => *handle,
         }
     }
 }
@@ -84,14 +98,14 @@ pub trait ResourceProvider {
     /// Returns [`StorageRead::DoesNotExist`] if the resource does not exist.
     /// Returns a [`ResourceProviderError`] if the backend cannot satisfy the
     /// read.
-    fn get_resource(&self, key: StorageKey) -> Result<StorageRead, ResourceProviderError>;
+    fn get_resource(&self, key: &StorageKey) -> Result<StorageRead, ResourceProviderError>;
 }
 
 /// Empty storage with no resources.
 pub struct NoResourceProvider;
 
 impl ResourceProvider for NoResourceProvider {
-    fn get_resource(&self, _key: StorageKey) -> Result<StorageRead, ResourceProviderError> {
+    fn get_resource(&self, _key: &StorageKey) -> Result<StorageRead, ResourceProviderError> {
         Ok(StorageRead::DoesNotExist)
     }
 }

--- a/third_party/move/mono-move/runtime/Cargo.toml
+++ b/third_party/move/mono-move/runtime/Cargo.toml
@@ -15,6 +15,7 @@ rust-version = { workspace = true }
 [dependencies]
 anyhow = { workspace = true }
 bcs = { workspace = true }
+hashbrown = { workspace = true }
 mono-move-alloc = { workspace = true }
 mono-move-core = { workspace = true }
 mono-move-gas = { workspace = true }

--- a/third_party/move/mono-move/runtime/src/global_storage.rs
+++ b/third_party/move/mono-move/runtime/src/global_storage.rs
@@ -57,11 +57,9 @@ use crate::{
     heap::RootScanner,
     invariant_violation,
 };
+use hashbrown::{hash_map::RawEntryMut, HashMap};
 use mono_move_core::{storage::resource_provider::StorageKey, ResourceProvider, StorageRead};
-use std::{
-    collections::{hash_map, HashMap},
-    ptr::NonNull,
-};
+use std::ptr::NonNull;
 
 /// Counter incremented by every checkpoint. Used to tell whether a pending
 /// write was made in the current checkpoint (and so is directly writable) or
@@ -207,7 +205,7 @@ impl ResourceReadWriteSet {
     pub(crate) fn exists(
         &mut self,
         provider: &dyn ResourceProvider,
-        key: StorageKey,
+        key: &StorageKey,
     ) -> RuntimeResult<bool> {
         Ok(get_or_create_resource_entry(&mut self.entries, provider, key)?.exists())
     }
@@ -217,7 +215,7 @@ impl ResourceReadWriteSet {
     pub(crate) fn borrow_global(
         &mut self,
         provider: &dyn ResourceProvider,
-        key: StorageKey,
+        key: &StorageKey,
     ) -> RuntimeResult<NonNull<u8>> {
         get_or_create_resource_entry(&mut self.entries, provider, key)?
             .as_ptr()
@@ -237,7 +235,7 @@ impl ResourceReadWriteSet {
     pub(crate) fn try_borrow_global_mut(
         &mut self,
         provider: &dyn ResourceProvider,
-        key: StorageKey,
+        key: &StorageKey,
     ) -> RuntimeResult<EntryPtr> {
         get_or_create_resource_entry(&mut self.entries, provider, key)?
             .as_ptr_mut(self.current_epoch)
@@ -257,10 +255,10 @@ impl ResourceReadWriteSet {
     ///
     /// [`Self::try_borrow_global_mut`] ensures that entry exists in the map.
     /// If this condition is violated, panics.
-    pub(crate) fn commit_borrow_global_mut(&mut self, key: StorageKey, ptr: NonNull<u8>) {
+    pub(crate) fn commit_borrow_global_mut(&mut self, key: &StorageKey, ptr: NonNull<u8>) {
         let entry = self
             .entries
-            .get_mut(&key)
+            .get_mut(key)
             .expect("Entry must exist after mutable borrow attempt");
         let old_write = std::mem::replace(&mut entry.write, StorageWrite::LocalHeap {
             ptr,
@@ -279,7 +277,7 @@ impl ResourceReadWriteSet {
     pub(crate) fn move_to(
         &mut self,
         provider: &dyn ResourceProvider,
-        key: StorageKey,
+        key: &StorageKey,
         ptr: NonNull<u8>,
     ) -> RuntimeResult<()> {
         let entry = get_or_create_resource_entry(&mut self.entries, provider, key)?;
@@ -306,7 +304,7 @@ impl ResourceReadWriteSet {
     pub(crate) fn try_move_from(
         &mut self,
         provider: &dyn ResourceProvider,
-        key: StorageKey,
+        key: &StorageKey,
     ) -> RuntimeResult<EntryPtr> {
         let entry = get_or_create_resource_entry(&mut self.entries, provider, key)?;
         let ptr = entry.as_ptr_mut(self.current_epoch).ok_or_else(|| {
@@ -336,10 +334,10 @@ impl ResourceReadWriteSet {
     ///
     /// [`Self::try_move_from`] ensures that entry exists in the map.
     /// If this condition is violated, panics.
-    pub(crate) fn commit_move_from(&mut self, key: StorageKey) {
+    pub(crate) fn commit_move_from(&mut self, key: &StorageKey) {
         let entry = self
             .entries
-            .get_mut(&key)
+            .get_mut(key)
             .expect("Entry must exist after move_from attempt");
         let old_write = std::mem::replace(&mut entry.write, StorageWrite::Deleted {
             epoch: self.current_epoch,
@@ -435,9 +433,12 @@ impl ResourceReadWriteSet {
     /// the old one) if:
     ///   - previous write does not exist, or
     ///   - previous write was made in a different (older) epoch.
-    fn record_write_to_journal(&mut self, key: StorageKey, write: StorageWrite) {
+    fn record_write_to_journal(&mut self, key: &StorageKey, write: StorageWrite) {
         if !write.is_at_epoch(self.current_epoch) {
-            self.journal.push(JournalEntry { key, write });
+            self.journal.push(JournalEntry {
+                key: key.clone(),
+                write,
+            });
         }
     }
 }
@@ -447,13 +448,18 @@ impl ResourceReadWriteSet {
 fn get_or_create_resource_entry<'a>(
     entries: &'a mut HashMap<StorageKey, Entry>,
     provider: &dyn ResourceProvider,
-    key: StorageKey,
+    key: &StorageKey,
 ) -> RuntimeResult<&'a mut Entry> {
-    match entries.entry(key) {
-        hash_map::Entry::Occupied(entry) => Ok(entry.into_mut()),
-        hash_map::Entry::Vacant(entry) => Ok(entry.insert(Entry {
-            read: provider.get_resource(key)?,
-            write: StorageWrite::NotModified,
-        })),
+    match entries.raw_entry_mut().from_key(key) {
+        RawEntryMut::Occupied(entry) => Ok(entry.into_mut()),
+        RawEntryMut::Vacant(entry) => {
+            let read = provider.get_resource(key)?;
+            Ok(entry
+                .insert(key.clone(), Entry {
+                    read,
+                    write: StorageWrite::NotModified,
+                })
+                .1)
+        },
     }
 }

--- a/third_party/move/mono-move/runtime/src/global_storage.rs
+++ b/third_party/move/mono-move/runtime/src/global_storage.rs
@@ -4,7 +4,7 @@
 //! Per-transaction global-storage state.
 //!
 //! Tracks every resource a transaction touches in a [`ResourceReadWriteSet`]:
-//! a map from [`StorageKey`] to an [`Entry`], plus an undo journal and a
+//! a map from [`InMemoryStorageKey`] to an [`Entry`], plus an undo journal and a
 //! checkpoint stack for rollback.
 //!
 //! # The read-write set
@@ -57,8 +57,10 @@ use crate::{
     heap::RootScanner,
     invariant_violation,
 };
-use hashbrown::{hash_map::RawEntryMut, HashMap};
-use mono_move_core::{storage::resource_provider::StorageKey, ResourceProvider, StorageRead};
+use hashbrown::{hash_map::EntryRef, HashMap};
+use mono_move_core::{
+    storage::resource_provider::InMemoryStorageKey, ResourceProvider, StorageRead,
+};
 use std::ptr::NonNull;
 
 /// Counter incremented by every checkpoint. Used to tell whether a pending
@@ -169,7 +171,7 @@ impl Entry {
 
 /// An entry in the undo journal that records old state of the resource.
 struct JournalEntry {
-    key: StorageKey,
+    key: InMemoryStorageKey,
     write: StorageWrite,
 }
 
@@ -186,7 +188,19 @@ struct Checkpoint {
 #[derive(Default)]
 pub struct ResourceReadWriteSet {
     /// Reads and writes to the global storage.
-    entries: HashMap<StorageKey, Entry>,
+    ///
+    /// This is a hash map, so iteration order is non-deterministic. Every place
+    /// that iterates `entries` must not depend on that order:
+    ///   - read-set validation (Block-STM) only checks each entry, so order
+    ///     does not matter;
+    ///   - aggregation (such as gas) must use a commutative combine so the
+    ///     result is order-independent;
+    ///   - producing the final write set must sort the entries into a
+    ///     deterministic order before emitting them.
+    // TODO(correctness):
+    //   Make sure we have a deterministic iteration API and write-set
+    //   generation.
+    entries: HashMap<InMemoryStorageKey, Entry>,
     /// Undo log of writes originating from older epochs. Used for rolling back
     /// to older checkpoints.
     journal: Vec<JournalEntry>,
@@ -205,7 +219,7 @@ impl ResourceReadWriteSet {
     pub(crate) fn exists(
         &mut self,
         provider: &dyn ResourceProvider,
-        key: &StorageKey,
+        key: &InMemoryStorageKey,
     ) -> RuntimeResult<bool> {
         Ok(get_or_create_resource_entry(&mut self.entries, provider, key)?.exists())
     }
@@ -215,7 +229,7 @@ impl ResourceReadWriteSet {
     pub(crate) fn borrow_global(
         &mut self,
         provider: &dyn ResourceProvider,
-        key: &StorageKey,
+        key: &InMemoryStorageKey,
     ) -> RuntimeResult<NonNull<u8>> {
         get_or_create_resource_entry(&mut self.entries, provider, key)?
             .as_ptr()
@@ -235,7 +249,7 @@ impl ResourceReadWriteSet {
     pub(crate) fn try_borrow_global_mut(
         &mut self,
         provider: &dyn ResourceProvider,
-        key: &StorageKey,
+        key: &InMemoryStorageKey,
     ) -> RuntimeResult<EntryPtr> {
         get_or_create_resource_entry(&mut self.entries, provider, key)?
             .as_ptr_mut(self.current_epoch)
@@ -255,7 +269,7 @@ impl ResourceReadWriteSet {
     ///
     /// [`Self::try_borrow_global_mut`] ensures that entry exists in the map.
     /// If this condition is violated, panics.
-    pub(crate) fn commit_borrow_global_mut(&mut self, key: &StorageKey, ptr: NonNull<u8>) {
+    pub(crate) fn commit_borrow_global_mut(&mut self, key: &InMemoryStorageKey, ptr: NonNull<u8>) {
         let entry = self
             .entries
             .get_mut(key)
@@ -277,7 +291,7 @@ impl ResourceReadWriteSet {
     pub(crate) fn move_to(
         &mut self,
         provider: &dyn ResourceProvider,
-        key: &StorageKey,
+        key: &InMemoryStorageKey,
         ptr: NonNull<u8>,
     ) -> RuntimeResult<()> {
         let entry = get_or_create_resource_entry(&mut self.entries, provider, key)?;
@@ -304,7 +318,7 @@ impl ResourceReadWriteSet {
     pub(crate) fn try_move_from(
         &mut self,
         provider: &dyn ResourceProvider,
-        key: &StorageKey,
+        key: &InMemoryStorageKey,
     ) -> RuntimeResult<EntryPtr> {
         let entry = get_or_create_resource_entry(&mut self.entries, provider, key)?;
         let ptr = entry.as_ptr_mut(self.current_epoch).ok_or_else(|| {
@@ -334,7 +348,7 @@ impl ResourceReadWriteSet {
     ///
     /// [`Self::try_move_from`] ensures that entry exists in the map.
     /// If this condition is violated, panics.
-    pub(crate) fn commit_move_from(&mut self, key: &StorageKey) {
+    pub(crate) fn commit_move_from(&mut self, key: &InMemoryStorageKey) {
         let entry = self
             .entries
             .get_mut(key)
@@ -433,7 +447,7 @@ impl ResourceReadWriteSet {
     /// the old one) if:
     ///   - previous write does not exist, or
     ///   - previous write was made in a different (older) epoch.
-    fn record_write_to_journal(&mut self, key: &StorageKey, write: StorageWrite) {
+    fn record_write_to_journal(&mut self, key: &InMemoryStorageKey, write: StorageWrite) {
         if !write.is_at_epoch(self.current_epoch) {
             self.journal.push(JournalEntry {
                 key: key.clone(),
@@ -446,20 +460,18 @@ impl ResourceReadWriteSet {
 /// Looks up the resource entry, materializing it as a read and recording in
 /// the read-set.
 fn get_or_create_resource_entry<'a>(
-    entries: &'a mut HashMap<StorageKey, Entry>,
+    entries: &'a mut HashMap<InMemoryStorageKey, Entry>,
     provider: &dyn ResourceProvider,
-    key: &StorageKey,
+    key: &InMemoryStorageKey,
 ) -> RuntimeResult<&'a mut Entry> {
-    match entries.raw_entry_mut().from_key(key) {
-        RawEntryMut::Occupied(entry) => Ok(entry.into_mut()),
-        RawEntryMut::Vacant(entry) => {
+    match entries.entry_ref(key) {
+        EntryRef::Occupied(entry) => Ok(entry.into_mut()),
+        EntryRef::Vacant(entry) => {
             let read = provider.get_resource(key)?;
-            Ok(entry
-                .insert(key.clone(), Entry {
-                    read,
-                    write: StorageWrite::NotModified,
-                })
-                .1)
+            Ok(entry.insert(Entry {
+                read,
+                write: StorageWrite::NotModified,
+            }))
         },
     }
 }

--- a/third_party/move/mono-move/runtime/src/interpreter.rs
+++ b/third_party/move/mono-move/runtime/src/interpreter.rs
@@ -1426,7 +1426,7 @@ impl<T: ExecutionContext + DescriptorProvider + LayoutProvider> InterpreterConte
                     let address = read_account_address(fp, addr);
                     let exists = self.read_write_set.exists(
                         self.exec_ctx.resource_provider(),
-                        StorageKey::Resource(address, ty),
+                        &StorageKey::Resource(address, ty),
                     )?;
                     write_bool(fp, dst, exists);
                 },
@@ -1435,7 +1435,7 @@ impl<T: ExecutionContext + DescriptorProvider + LayoutProvider> InterpreterConte
                     let address = read_account_address(fp, addr);
                     let ptr = self.read_write_set.borrow_global(
                         self.exec_ctx.resource_provider(),
-                        StorageKey::Resource(address, ty),
+                        &StorageKey::Resource(address, ty),
                     )?;
                     // A reference is a 16-byte fat pointer; the borrow points
                     // at the start of the resource, so the offset half is 0.
@@ -1447,12 +1447,12 @@ impl<T: ExecutionContext + DescriptorProvider + LayoutProvider> InterpreterConte
                     let key = StorageKey::Resource(address, ty);
                     let ptr = match self
                         .read_write_set
-                        .try_borrow_global_mut(self.exec_ctx.resource_provider(), key)?
+                        .try_borrow_global_mut(self.exec_ctx.resource_provider(), &key)?
                     {
                         EntryPtr::Writable(ptr) => ptr,
                         EntryPtr::NonWritable(ptr) => {
                             let ptr = self.deep_copy(ptr)?;
-                            self.read_write_set.commit_borrow_global_mut(key, ptr);
+                            self.read_write_set.commit_borrow_global_mut(&key, ptr);
                             ptr
                         },
                     };
@@ -1466,12 +1466,12 @@ impl<T: ExecutionContext + DescriptorProvider + LayoutProvider> InterpreterConte
                     let key = StorageKey::Resource(address, ty);
                     let entry_ptr = self
                         .read_write_set
-                        .try_move_from(self.exec_ctx.resource_provider(), key)?;
+                        .try_move_from(self.exec_ctx.resource_provider(), &key)?;
                     let ptr = match entry_ptr {
                         EntryPtr::Writable(ptr) => ptr,
                         EntryPtr::NonWritable(ptr) => {
                             let ptr = self.deep_copy(ptr)?;
-                            self.read_write_set.commit_move_from(key);
+                            self.read_write_set.commit_move_from(&key);
                             ptr
                         },
                     };
@@ -1492,7 +1492,7 @@ impl<T: ExecutionContext + DescriptorProvider + LayoutProvider> InterpreterConte
 
                     self.read_write_set.move_to(
                         self.exec_ctx.resource_provider(),
-                        StorageKey::Resource(address, ty),
+                        &StorageKey::Resource(address, ty),
                         ptr,
                     )?;
                 },

--- a/third_party/move/mono-move/runtime/src/interpreter.rs
+++ b/third_party/move/mono-move/runtime/src/interpreter.rs
@@ -33,7 +33,7 @@ use mono_move_core::{
     captured_values_size,
     native::{NativeABI, NativeIdx, NativeStatus, ProductionNativeContext},
     next_captured_value_offset,
-    storage::resource_provider::StorageKey,
+    storage::resource_provider::InMemoryStorageKey,
     CallClosureOp, ClosureFuncRef, CmpKind, ConstantPoolIndex, DescriptorId, DescriptorProvider,
     FrameOffset, Function, FunctionRef, IntBinaryOp, IntCastOp, IntNegateOp, IntOperand,
     IntShiftOp, IntTy, LayoutProvider, MicroOp, PackClosureOp, ShiftOperand,
@@ -1426,7 +1426,7 @@ impl<T: ExecutionContext + DescriptorProvider + LayoutProvider> InterpreterConte
                     let address = read_account_address(fp, addr);
                     let exists = self.read_write_set.exists(
                         self.exec_ctx.resource_provider(),
-                        &StorageKey::Resource(address, ty),
+                        &InMemoryStorageKey::resource(address, ty),
                     )?;
                     write_bool(fp, dst, exists);
                 },
@@ -1435,7 +1435,7 @@ impl<T: ExecutionContext + DescriptorProvider + LayoutProvider> InterpreterConte
                     let address = read_account_address(fp, addr);
                     let ptr = self.read_write_set.borrow_global(
                         self.exec_ctx.resource_provider(),
-                        &StorageKey::Resource(address, ty),
+                        &InMemoryStorageKey::resource(address, ty),
                     )?;
                     // A reference is a 16-byte fat pointer; the borrow points
                     // at the start of the resource, so the offset half is 0.
@@ -1444,7 +1444,7 @@ impl<T: ExecutionContext + DescriptorProvider + LayoutProvider> InterpreterConte
 
                 MicroOp::BorrowGlobalMut { addr, ty, dst } => {
                     let address = read_account_address(fp, addr);
-                    let key = StorageKey::Resource(address, ty);
+                    let key = InMemoryStorageKey::resource(address, ty);
                     let ptr = match self
                         .read_write_set
                         .try_borrow_global_mut(self.exec_ctx.resource_provider(), &key)?
@@ -1463,7 +1463,7 @@ impl<T: ExecutionContext + DescriptorProvider + LayoutProvider> InterpreterConte
 
                 MicroOp::MoveFrom { addr, ty, dst } => {
                     let address = read_account_address(fp, addr);
-                    let key = StorageKey::Resource(address, ty);
+                    let key = InMemoryStorageKey::resource(address, ty);
                     let entry_ptr = self
                         .read_write_set
                         .try_move_from(self.exec_ctx.resource_provider(), &key)?;
@@ -1492,7 +1492,7 @@ impl<T: ExecutionContext + DescriptorProvider + LayoutProvider> InterpreterConte
 
                     self.read_write_set.move_to(
                         self.exec_ctx.resource_provider(),
-                        &StorageKey::Resource(address, ty),
+                        &InMemoryStorageKey::resource(address, ty),
                         ptr,
                     )?;
                 },

--- a/third_party/move/mono-move/runtime/tests/common/mod.rs
+++ b/third_party/move/mono-move/runtime/tests/common/mod.rs
@@ -106,8 +106,8 @@ impl InMemoryResources {
 }
 
 impl ResourceProvider for InMemoryResources {
-    fn get_resource(&self, key: StorageKey) -> Result<StorageRead, ResourceProviderError> {
-        Ok(match self.entries.borrow().get(&key) {
+    fn get_resource(&self, key: &StorageKey) -> Result<StorageRead, ResourceProviderError> {
+        Ok(match self.entries.borrow().get(key) {
             Some(&ptr) => {
                 // SAFETY: pointer came from `install_anchor`, which
                 // returned the data-region start of a live anchored

--- a/third_party/move/mono-move/runtime/tests/common/mod.rs
+++ b/third_party/move/mono-move/runtime/tests/common/mod.rs
@@ -11,7 +11,7 @@
 
 use mono_move_core::{
     align::{checked_align_max, MAX_ALIGN},
-    storage::resource_provider::StorageKey,
+    storage::resource_provider::InMemoryStorageKey,
     types::InternedType,
     DescriptorId, ResourceProvider, ResourceProviderError, StorageRead, OBJECT_HEADER_SIZE,
 };
@@ -45,7 +45,7 @@ pub struct InMemoryResources {
     /// Map keys to the data-region pointer of an allocation in
     /// `anchors`. The allocation outlives `self`; the pointer is
     /// safe to hand to `get_resource`.
-    entries: RefCell<HashMap<StorageKey, *const u8>>,
+    entries: RefCell<HashMap<InMemoryStorageKey, *const u8>>,
     anchors: RefCell<Vec<Box<[u64]>>>,
 }
 
@@ -101,12 +101,12 @@ impl InMemoryResources {
     pub fn entries_install(&self, addr: AccountAddress, ty: InternedType, ptr: *const u8) {
         self.entries
             .borrow_mut()
-            .insert(StorageKey::Resource(addr, ty), ptr);
+            .insert(InMemoryStorageKey::resource(addr, ty), ptr);
     }
 }
 
 impl ResourceProvider for InMemoryResources {
-    fn get_resource(&self, key: &StorageKey) -> Result<StorageRead, ResourceProviderError> {
+    fn get_resource(&self, key: &InMemoryStorageKey) -> Result<StorageRead, ResourceProviderError> {
         Ok(match self.entries.borrow().get(key) {
             Some(&ptr) => {
                 // SAFETY: pointer came from `install_anchor`, which


### PR DESCRIPTION
Adds a `StorageKey::TableItem { handle, key }` variant so table items can live as first-class entries in the per-transaction resource read-write set, inheriting copy-on-write, epoch rollback, and GC relocation from the existing resource path. The key's identity is `(handle, serialized key bytes)` with no value type — matching the production `StateKey` — and `StorageKey` becomes `Clone`; the rws and interpreter now take `&StorageKey`, and the working map uses hashbrown's `raw_entry_mut` so the key is cloned only on first-touch insert and journal push, with no read-path regression. This is foundation only: the five rws operations are already key-agnostic, so a follow-up wires the Move `table` natives — serializing keys via the value-layout codec and threading the value type to the provider (e.g. `get_table_item(handle, &key_bytes, value_ty)`) to deserialize values on a cache miss — plus write-set extraction. Table create/destroy stays native-layer, since a table has no standalone storage entry, only its items do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core transaction global-storage keying and copy-on-write/journal behavior; incorrect hashing or cloning could affect rollback correctness, though resource paths are largely mechanical refactors.
> 
> **Overview**
> Renames per-transaction storage keys to **`InMemoryStorageKey`** and extends them with a **`TableItem { handle, key }`** variant so table entries can share the same read-write set, journal, and checkpoint path as resources. Resource keys move to named fields plus **`resource()` / `table_item()`** constructors; keys are **`Clone`** so the undo journal can own a copy on rollback.
> 
> **`ResourceProvider::get_resource`** and all **`ResourceReadWriteSet`** global ops now take **`&InMemoryStorageKey`**. The working map switches to **hashbrown** and **`entry_ref`** so lookups hash by reference and only clone the key on first insert or journal push. The interpreter and test **`InMemoryResources`** provider are updated accordingly; **Move table natives are not wired in this PR**—only the key type and plumbing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26df74180ef6039bb1a7f68522e77ffdb7bd9258. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->