### PR TITLE
[mono-move] Equality support

### DIFF
--- a/third_party/move/mono-move/core/src/instruction/gas.rs
+++ b/third_party/move/mono-move/core/src/instruction/gas.rs
@@ -39,6 +39,8 @@ impl HasCfgInfo for MicroOp {
             | MicroOp::JumpGreaterEqualU64 { target, .. }
             | MicroOp::JumpNotEqualU64 { target, .. } => Some(target.0 as usize),
             MicroOp::JumpIntCmp(op) => Some(op.target.0 as usize),
+            MicroOp::JumpValueCmp(op) => Some(op.target.0 as usize),
+            MicroOp::JumpValueRefCmp(op) => Some(op.target.0 as usize),
             MicroOp::StoreImm1 { .. }
             | MicroOp::StoreImm2 { .. }
             | MicroOp::StoreImm4 { .. }
@@ -115,6 +117,8 @@ impl HasCfgInfo for MicroOp {
             | MicroOp::MoveFrom { .. }
             | MicroOp::MoveTo { .. }
             | MicroOp::IntCmp(_)
+            | MicroOp::ValueCmp(_)
+            | MicroOp::ValueRefCmp(_)
             | MicroOp::BoolNot { .. }
             | MicroOp::BoolAnd { .. }
             | MicroOp::BoolOr { .. } => None,
@@ -146,6 +150,14 @@ impl RemapTargets for MicroOp {
             MicroOp::JumpIntCmp(mut op) => {
                 op.target = co(op.target);
                 MicroOp::JumpIntCmp(op)
+            },
+            MicroOp::JumpValueCmp(mut op) => {
+                op.target = co(op.target);
+                MicroOp::JumpValueCmp(op)
+            },
+            MicroOp::JumpValueRefCmp(mut op) => {
+                op.target = co(op.target);
+                MicroOp::JumpValueRefCmp(op)
             },
             MicroOp::JumpGreaterEqualU64Imm { target, src, imm } => {
                 MicroOp::JumpGreaterEqualU64Imm {
@@ -260,6 +272,8 @@ impl RemapTargets for MicroOp {
             | MicroOp::MoveFrom { .. }
             | MicroOp::MoveTo { .. }
             | MicroOp::IntCmp(_)
+            | MicroOp::ValueCmp(_)
+            | MicroOp::ValueRefCmp(_)
             | MicroOp::BoolNot { .. }
             | MicroOp::BoolAnd { .. }
             | MicroOp::BoolOr { .. }) => op,
@@ -328,6 +342,7 @@ impl GasSchedule<MicroOp> for MicroOpGasSchedule {
 
             // --- Comparison & boolean logic ---
             MicroOp::IntCmp(_) => 3,
+            MicroOp::ValueCmp(_) | MicroOp::ValueRefCmp(_) => 6,
             MicroOp::BoolNot { .. } | MicroOp::BoolAnd { .. } | MicroOp::BoolOr { .. } => 2,
 
             // --- Control flow ---
@@ -348,6 +363,7 @@ impl GasSchedule<MicroOp> for MicroOpGasSchedule {
             | MicroOp::JumpLessU64 { .. }
             | MicroOp::JumpGreaterEqualU64 { .. }
             | MicroOp::JumpNotEqualU64 { .. } => 3,
+            MicroOp::JumpValueCmp(_) | MicroOp::JumpValueRefCmp(_) => 6,
 
             // --- Vector operations ---
             MicroOp::VecNew { .. } => 10,

--- a/third_party/move/mono-move/core/src/instruction/mod.rs
+++ b/third_party/move/mono-move/core/src/instruction/mod.rs
@@ -130,7 +130,7 @@ mod unspecialized;
 pub use gas::MicroOpGasSchedule;
 pub use unspecialized::{
     CmpKind, IntBinaryOp, IntCastOp, IntCmpOp, IntNegateOp, IntOperand, IntShiftOp, IntTy,
-    JumpIntCmpOp, ShiftOperand,
+    JumpIntCmpOp, JumpValueCmpOp, JumpValueRefCmpOp, ShiftOperand, ValueCmpOp, ValueRefCmpOp,
 };
 
 /// A typed wrapper around a `u32` frame-pointer-relative byte offset.
@@ -532,6 +532,15 @@ pub enum MicroOp {
     /// `dst = (lhs <op> rhs)`, writing a 1-byte boolean. See [`IntCmpOp`].
     IntCmp(IntCmpOp),
 
+    /// `dst = (lhs == rhs)` (or `!=`), a structural equality over inline
+    /// values. `lhs`/`rhs` hold the values directly. See [`ValueCmpOp`].
+    ValueCmp(ValueCmpOp),
+
+    /// `dst = (lhs == rhs)` (or `!=`), a structural equality where `lhs`/`rhs`
+    /// hold references (16-byte fat pointers) read through to the operand
+    /// values. See [`ValueRefCmpOp`].
+    ValueRefCmp(ValueRefCmpOp),
+
     /// `dst = !src`, both `dst` and `src` are 1-byte booleans.
     BoolNot {
         dst: FrameOffset,
@@ -633,6 +642,15 @@ pub enum MicroOp {
     /// Unspecialized fused compare-and-branch: jump to `target` if
     /// `op(lhs, rhs)` holds, dispatching on the operand type.
     JumpIntCmp(JumpIntCmpOp),
+
+    /// Fused structural-equality compare-and-branch: jump to `target` if
+    /// `lhs == rhs` (or `!=`) over inline values. See [`JumpValueCmpOp`].
+    JumpValueCmp(JumpValueCmpOp),
+
+    /// Fused structural-equality compare-and-branch where `lhs`/`rhs` hold
+    /// references (16-byte fat pointers) read through to the operand values.
+    /// See [`JumpValueRefCmpOp`].
+    JumpValueRefCmp(JumpValueRefCmpOp),
 
     /// Jump to `target` if the u64 at `src` is **>=** `imm`.
     JumpGreaterEqualU64Imm {
@@ -1207,6 +1225,24 @@ impl fmt::Display for MicroOp {
                 "IntCmp [{}] <- [{}] {} {}",
                 op.dst.0, op.lhs.0, op.op, op.rhs
             ),
+            MicroOp::ValueCmp(op) => {
+                let rel = if op.negate { "!=" } else { "==" };
+                write!(
+                    f,
+                    "ValueCmp [{}] <- [{}] {} [{}] : ",
+                    op.dst.0, op.lhs.0, rel, op.rhs.0
+                )?;
+                display_type(f, op.ty)
+            },
+            MicroOp::ValueRefCmp(op) => {
+                let rel = if op.negate { "!=" } else { "==" };
+                write!(
+                    f,
+                    "ValueRefCmp [{}] <- *[{}] {} *[{}] : ",
+                    op.dst.0, op.lhs.0, rel, op.rhs.0
+                )?;
+                display_type(f, op.ty)
+            },
             MicroOp::BoolNot { dst, src } => {
                 write!(f, "BoolNot [{}] <- ![{}]", dst.0, src.0)
             },
@@ -1294,6 +1330,24 @@ impl fmt::Display for MicroOp {
                 "JumpIntCmp @{} [{}] {} {}",
                 op.target.0, op.lhs.0, op.op, op.rhs
             ),
+            MicroOp::JumpValueCmp(op) => {
+                let rel = if op.negate { "!=" } else { "==" };
+                write!(
+                    f,
+                    "JumpValueCmp @{} [{}] {} [{}] : ",
+                    op.target.0, op.lhs.0, rel, op.rhs.0
+                )?;
+                display_type(f, op.ty)
+            },
+            MicroOp::JumpValueRefCmp(op) => {
+                let rel = if op.negate { "!=" } else { "==" };
+                write!(
+                    f,
+                    "JumpValueRefCmp @{} *[{}] {} *[{}] : ",
+                    op.target.0, op.lhs.0, rel, op.rhs.0
+                )?;
+                display_type(f, op.ty)
+            },
             MicroOp::JumpGreaterEqualU64Imm { target, src, imm } => {
                 write!(
                     f,
@@ -1768,6 +1822,8 @@ impl MicroOp {
             | MicroOp::JumpNotZeroByte { .. }
             | MicroOp::JumpZeroByte { .. }
             | MicroOp::JumpIntCmp(_)
+            | MicroOp::JumpValueCmp(_)
+            | MicroOp::JumpValueRefCmp(_)
             | MicroOp::JumpGreaterEqualU64Imm { .. }
             | MicroOp::JumpLessU64Imm { .. }
             | MicroOp::JumpGreaterU64Imm { .. }
@@ -1814,6 +1870,8 @@ impl MicroOp {
             | MicroOp::BorrowGlobal { .. }
             | MicroOp::MoveTo { .. }
             | MicroOp::IntCmp(_)
+            | MicroOp::ValueCmp(_)
+            | MicroOp::ValueRefCmp(_)
             | MicroOp::BoolNot { .. }
             | MicroOp::BoolAnd { .. }
             | MicroOp::BoolOr { .. } => false,

--- a/third_party/move/mono-move/core/src/instruction/mod.rs
+++ b/third_party/move/mono-move/core/src/instruction/mod.rs
@@ -532,8 +532,10 @@ pub enum MicroOp {
     /// `dst = (lhs <op> rhs)`, writing a 1-byte boolean. See [`IntCmpOp`].
     IntCmp(IntCmpOp),
 
-    /// `dst = (lhs == rhs)` (or `!=`), a structural equality over inline
-    /// values. `lhs`/`rhs` hold the values directly. See [`ValueCmpOp`].
+    /// `dst = (lhs == rhs)` (or `!=`), a structural equality over aggregate
+    /// values (vectors, structs). `lhs`/`rhs` are the operand slots; a vector
+    /// slot holds a pointer to its heap data, which the comparison reads
+    /// through. See [`ValueCmpOp`].
     ValueCmp(ValueCmpOp),
 
     /// `dst = (lhs == rhs)` (or `!=`), a structural equality where `lhs`/`rhs`

--- a/third_party/move/mono-move/core/src/instruction/unspecialized.rs
+++ b/third_party/move/mono-move/core/src/instruction/unspecialized.rs
@@ -392,10 +392,11 @@ pub struct JumpIntCmpOp {
     pub rhs: IntOperand,
 }
 
-/// `dst = (lhs == rhs)` (or `!=` when `negate`) for a structural equality of
-/// two values held **inline** at `lhs`/`rhs`, producing a 1-byte boolean. Used
-/// for aggregate types (vectors, structs) — everything that is not a flat
-/// scalar handled by [`IntCmpOp`].
+/// `dst = (lhs == rhs)` (or `!=` when `negate`), a structural equality over
+/// the aggregate values at `lhs`/`rhs`, producing a 1-byte boolean. Used for
+/// aggregate types (vectors, structs) — everything that is not a flat scalar
+/// handled by [`IntCmpOp`]. A vector slot holds a pointer to its heap data,
+/// which the comparison reads through.
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub struct ValueCmpOp {
     pub negate: bool,

--- a/third_party/move/mono-move/core/src/instruction/unspecialized.rs
+++ b/third_party/move/mono-move/core/src/instruction/unspecialized.rs
@@ -13,7 +13,7 @@
 //! the operand type at runtime.
 
 use super::{CodeOffset, FrameOffset};
-use crate::types::Type;
+use crate::types::{InternedType, Type};
 use move_core_types::int256::{I256, U256};
 use std::fmt;
 
@@ -390,4 +390,52 @@ pub struct JumpIntCmpOp {
     pub op: CmpKind,
     pub lhs: FrameOffset,
     pub rhs: IntOperand,
+}
+
+/// `dst = (lhs == rhs)` (or `!=` when `negate`) for a structural equality of
+/// two values held **inline** at `lhs`/`rhs`, producing a 1-byte boolean. Used
+/// for aggregate types (vectors, structs) — everything that is not a flat
+/// scalar handled by [`IntCmpOp`].
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct ValueCmpOp {
+    pub negate: bool,
+    pub dst: FrameOffset,
+    pub lhs: FrameOffset,
+    pub rhs: FrameOffset,
+    pub ty: InternedType,
+}
+
+/// Like [`ValueCmpOp`], but the operands are **references**: `lhs`/`rhs` hold
+/// 16-byte fat pointers, read through to obtain the operand pointers of the
+/// referent value of type `ty`.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct ValueRefCmpOp {
+    pub negate: bool,
+    pub dst: FrameOffset,
+    pub lhs: FrameOffset,
+    pub rhs: FrameOffset,
+    pub ty: InternedType,
+}
+
+/// Fused compare-and-branch counterpart of [`ValueCmpOp`]: jump to `target`
+/// if the equality result holds (negated when `negate`). Operands are inline
+/// values; see [`ValueCmpOp`] for the field meanings.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct JumpValueCmpOp {
+    pub target: CodeOffset,
+    pub negate: bool,
+    pub lhs: FrameOffset,
+    pub rhs: FrameOffset,
+    pub ty: InternedType,
+}
+
+/// Fused compare-and-branch counterpart of [`ValueRefCmpOp`]: operands are
+/// 16-byte fat pointers read through to the referent values.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct JumpValueRefCmpOp {
+    pub target: CodeOffset,
+    pub negate: bool,
+    pub lhs: FrameOffset,
+    pub rhs: FrameOffset,
+    pub ty: InternedType,
 }

--- a/third_party/move/mono-move/core/src/lib.rs
+++ b/third_party/move/mono-move/core/src/lib.rs
@@ -23,13 +23,13 @@ pub use function::{
 pub use instruction::{
     captured_values_size, next_captured_value_offset, CallClosureOp, ClosureFuncRef, CmpKind,
     CodeOffset, DescriptorId, FrameOffset, IntBinaryOp, IntCastOp, IntCmpOp, IntNegateOp,
-    IntOperand, IntShiftOp, IntTy, JumpIntCmpOp, MicroOp, MicroOpGasSchedule, PackClosureOp,
-    ShiftOperand, SizedSlot, CAPTURED_DATA_TAG_MATERIALIZED, CAPTURED_DATA_TAG_OFFSET,
-    CAPTURED_DATA_VALUES_OFFSET, CAPTURED_DATA_VALUES_SIZE_OFFSET,
-    CLOSURE_CAPTURED_DATA_PTR_OFFSET, CLOSURE_DATA_SIZE, CLOSURE_FUNC_REF_OFFSET,
-    CLOSURE_FUNC_REF_SIZE, CLOSURE_MASK_OFFSET, ENUM_DATA_OFFSET, ENUM_TAG_OFFSET,
-    FRAME_METADATA_SIZE, FUNC_REF_PAYLOAD_OFFSET, FUNC_REF_TAG_OFFSET, FUNC_REF_TAG_RESOLVED,
-    FUNC_REF_TAG_UNRESOLVED, OBJECT_HEADER_SIZE,
+    IntOperand, IntShiftOp, IntTy, JumpIntCmpOp, JumpValueCmpOp, JumpValueRefCmpOp, MicroOp,
+    MicroOpGasSchedule, PackClosureOp, ShiftOperand, SizedSlot, ValueCmpOp, ValueRefCmpOp,
+    CAPTURED_DATA_TAG_MATERIALIZED, CAPTURED_DATA_TAG_OFFSET, CAPTURED_DATA_VALUES_OFFSET,
+    CAPTURED_DATA_VALUES_SIZE_OFFSET, CLOSURE_CAPTURED_DATA_PTR_OFFSET, CLOSURE_DATA_SIZE,
+    CLOSURE_FUNC_REF_OFFSET, CLOSURE_FUNC_REF_SIZE, CLOSURE_MASK_OFFSET, ENUM_DATA_OFFSET,
+    ENUM_TAG_OFFSET, FRAME_METADATA_SIZE, FUNC_REF_PAYLOAD_OFFSET, FUNC_REF_TAG_OFFSET,
+    FUNC_REF_TAG_RESOLVED, FUNC_REF_TAG_UNRESOLVED, OBJECT_HEADER_SIZE,
 };
 pub use interner::{view_function_ref, FunctionRef, InternedFunctionRef, Interner, ModuleId};
 pub use move_binary_format::file_format::ConstantPoolIndex;

--- a/third_party/move/mono-move/runtime/src/interpreter.rs
+++ b/third_party/move/mono-move/runtime/src/interpreter.rs
@@ -26,8 +26,7 @@ use crate::{
         META_SAVED_FP_OFFSET, META_SAVED_FUNC_PTR_OFFSET, META_SAVED_PC_OFFSET, VEC_DATA_OFFSET,
         VEC_LENGTH_OFFSET,
     },
-    value_utils::deserialize,
-    ExecutionContext,
+    value_utils, ExecutionContext,
 };
 use mono_move_core::{
     captured_values_size,
@@ -852,6 +851,38 @@ impl<T: ExecutionContext + DescriptorProvider + LayoutProvider> InterpreterConte
                     return Ok(StepResult::Continue);
                 },
 
+                MicroOp::JumpValueCmp(ref op) => {
+                    // Operands are values held inline at their slots.
+                    let a = fp.add(op.lhs.into());
+                    let b = fp.add(op.rhs.into());
+                    let eq = value_utils::equals(self.exec_ctx, a, b, op.ty)?;
+                    self.pc = if eq ^ op.negate {
+                        op.target.into()
+                    } else {
+                        self.pc + 1
+                    };
+                    return Ok(StepResult::Continue);
+                },
+
+                MicroOp::JumpValueRefCmp(ref op) => {
+                    // Operands are references; read through the fat pointers to
+                    // obtain the operand data pointers.
+                    let (lb, lo) = read_fat_ptr(fp, op.lhs);
+                    let (rb, ro) = read_fat_ptr(fp, op.rhs);
+                    let eq = value_utils::equals(
+                        self.exec_ctx,
+                        lb.add(lo as usize),
+                        rb.add(ro as usize),
+                        op.ty,
+                    )?;
+                    self.pc = if eq ^ op.negate {
+                        op.target.into()
+                    } else {
+                        self.pc + 1
+                    };
+                    return Ok(StepResult::Continue);
+                },
+
                 MicroOp::JumpGreaterEqualU64Imm { target, src, imm } => {
                     self.pc = if read_u64(fp, src) >= imm {
                         target.into()
@@ -1500,6 +1531,26 @@ impl<T: ExecutionContext + DescriptorProvider + LayoutProvider> InterpreterConte
                     let result = int_cmp_bool(fp, op.lhs, op.op, &op.rhs);
                     write_u8(fp, op.dst, result as u8);
                 },
+                MicroOp::ValueCmp(ref op) => {
+                    // Operands are values held inline at their slots.
+                    let a = fp.add(op.lhs.into());
+                    let b = fp.add(op.rhs.into());
+                    let eq = value_utils::equals(&*self.exec_ctx, a, b, op.ty)?;
+                    write_bool(fp, op.dst, eq ^ op.negate);
+                },
+                MicroOp::ValueRefCmp(ref op) => {
+                    // Operands are references; read through the fat pointers to
+                    // obtain the operand data pointers.
+                    let (lb, lo) = read_fat_ptr(fp, op.lhs);
+                    let (rb, ro) = read_fat_ptr(fp, op.rhs);
+                    let eq = value_utils::equals(
+                        &*self.exec_ctx,
+                        lb.add(lo as usize),
+                        rb.add(ro as usize),
+                        op.ty,
+                    )?;
+                    write_bool(fp, op.dst, eq ^ op.negate);
+                },
                 MicroOp::BoolNot { dst, src } => write_bool(fp, dst, !read_bool(fp, src)),
                 MicroOp::BoolAnd { dst, lhs, rhs } => {
                     let left = read_bool(fp, lhs);
@@ -1533,7 +1584,8 @@ impl<T: ExecutionContext + DescriptorProvider + LayoutProvider> InterpreterConte
         // and is writable (no aliasing to the heap).
         unsafe {
             let dst = self.frame_ptr.add(usize::from(dst));
-            if let Err(err) = deserialize(self.exec_ctx, &mut self.heap, ty, bytes, dst) {
+            if let Err(err) = value_utils::deserialize(self.exec_ctx, &mut self.heap, ty, bytes, dst)
+            {
                 match err {
                     AllocationError::RuntimeError(err) => return Err(err),
                     AllocationError::OutOfHeapMemory { .. } => {
@@ -1542,7 +1594,7 @@ impl<T: ExecutionContext + DescriptorProvider + LayoutProvider> InterpreterConte
                         // path runs. Needs a `ForceGC` native to drive it
                         // deterministically in the differential suite.
                         gc_collect!(self)?;
-                        deserialize(self.exec_ctx, &mut self.heap, ty, bytes, dst)
+                        value_utils::deserialize(self.exec_ctx, &mut self.heap, ty, bytes, dst)
                             .map_err(AllocationError::into_runtime_error)?;
                     },
                 }

--- a/third_party/move/mono-move/runtime/src/interpreter.rs
+++ b/third_party/move/mono-move/runtime/src/interpreter.rs
@@ -852,7 +852,8 @@ impl<T: ExecutionContext + DescriptorProvider + LayoutProvider> InterpreterConte
                 },
 
                 MicroOp::JumpValueCmp(ref op) => {
-                    // Operands are values held inline at their slots.
+                    // Operands are the aggregate values at their slots; a
+                    // vector slot holds a pointer read through to its heap data.
                     let a = fp.add(op.lhs.into());
                     let b = fp.add(op.rhs.into());
                     let eq = value_utils::equals(self.exec_ctx, a, b, op.ty)?;
@@ -1532,7 +1533,8 @@ impl<T: ExecutionContext + DescriptorProvider + LayoutProvider> InterpreterConte
                     write_u8(fp, op.dst, result as u8);
                 },
                 MicroOp::ValueCmp(ref op) => {
-                    // Operands are values held inline at their slots.
+                    // Operands are the aggregate values at their slots; a
+                    // vector slot holds a pointer read through to its heap data.
                     let a = fp.add(op.lhs.into());
                     let b = fp.add(op.rhs.into());
                     let eq = value_utils::equals(&*self.exec_ctx, a, b, op.ty)?;
@@ -1584,7 +1586,8 @@ impl<T: ExecutionContext + DescriptorProvider + LayoutProvider> InterpreterConte
         // and is writable (no aliasing to the heap).
         unsafe {
             let dst = self.frame_ptr.add(usize::from(dst));
-            if let Err(err) = value_utils::deserialize(self.exec_ctx, &mut self.heap, ty, bytes, dst)
+            if let Err(err) =
+                value_utils::deserialize(self.exec_ctx, &mut self.heap, ty, bytes, dst)
             {
                 match err {
                     AllocationError::RuntimeError(err) => return Err(err),

--- a/third_party/move/mono-move/runtime/src/verifier.rs
+++ b/third_party/move/mono-move/runtime/src/verifier.rs
@@ -11,9 +11,12 @@
 //! publish time.
 
 use mono_move_core::{
-    captured_values_size, native::NativeABI, CallClosureOp, ClosureFuncRef, CodeOffset,
-    DescriptorId, DescriptorProvider, FrameOffset, Function, IntBinaryOp, MicroOp,
-    ObjectDescriptorInner, PackClosureOp, ShiftOperand, CLOSURE_DESCRIPTOR_ID, FRAME_METADATA_SIZE,
+    captured_values_size,
+    native::NativeABI,
+    types::{view_type, InternedType},
+    CallClosureOp, ClosureFuncRef, CodeOffset, DescriptorId, DescriptorProvider, FrameOffset,
+    Function, IntBinaryOp, MicroOp, ObjectDescriptorInner, PackClosureOp, ShiftOperand,
+    CLOSURE_DESCRIPTOR_ID, FRAME_METADATA_SIZE,
 };
 use std::fmt;
 
@@ -403,7 +406,9 @@ impl<P: DescriptorProvider + ?Sized> FunctionVerifier<'_, P> {
             },
 
             MicroOp::ValueCmp(ref op) => {
-                // TODO: We should check frame access based on the size from the type?
+                let size = self.type_size(pc, op.ty);
+                self.check_frame_access(Some(pc), op.lhs, size);
+                self.check_frame_access(Some(pc), op.rhs, size);
                 self.check_frame_access_1(pc, op.dst);
             },
             MicroOp::ValueRefCmp(ref op) => {
@@ -455,7 +460,9 @@ impl<P: DescriptorProvider + ?Sized> FunctionVerifier<'_, P> {
             },
 
             MicroOp::JumpValueCmp(ref op) => {
-                // TODO: We should check frame access based on the size from the type?
+                let size = self.type_size(pc, op.ty);
+                self.check_frame_access(Some(pc), op.lhs, size);
+                self.check_frame_access(Some(pc), op.rhs, size);
                 self.check_jump(pc, op.target);
             },
             MicroOp::JumpValueRefCmp(ref op) => {
@@ -984,6 +991,25 @@ impl<P: DescriptorProvider + ?Sized> FunctionVerifier<'_, P> {
                     offset, end, meta_start, meta_end
                 ),
             );
+        }
+    }
+
+    /// In-memory byte width of a value-comparison operand. The compared value
+    /// occupies this many bytes at its slot; for vectors the slot holds an
+    /// 8-byte pointer that the comparison reads through. Records an error and
+    /// returns `0` when the type's layout is unavailable, so the caller's
+    /// bounds check still fails the function (via the recorded error) rather
+    /// than passing on an unknown size.
+    fn type_size(&mut self, pc: usize, ty: InternedType) -> u32 {
+        match view_type(ty).size_and_align() {
+            Some((size, _align)) => size,
+            None => {
+                self.err(
+                    Some(pc),
+                    "value comparison operand type has no known layout",
+                );
+                0
+            },
         }
     }
 

--- a/third_party/move/mono-move/runtime/src/verifier.rs
+++ b/third_party/move/mono-move/runtime/src/verifier.rs
@@ -402,6 +402,16 @@ impl<P: DescriptorProvider + ?Sized> FunctionVerifier<'_, P> {
                 self.check_frame_access_1(pc, op.dst);
             },
 
+            MicroOp::ValueCmp(ref op) => {
+                // TODO: We should check frame access based on the size from the type?
+                self.check_frame_access_1(pc, op.dst);
+            },
+            MicroOp::ValueRefCmp(ref op) => {
+                self.check_frame_access(Some(pc), op.lhs, 16);
+                self.check_frame_access(Some(pc), op.rhs, 16);
+                self.check_frame_access_1(pc, op.dst);
+            },
+
             // Boolean logic: all operands are 1-byte `0`/`1` values.
             MicroOp::BoolNot { dst, src } => {
                 self.check_frame_access_1(pc, src);
@@ -441,6 +451,16 @@ impl<P: DescriptorProvider + ?Sized> FunctionVerifier<'_, P> {
                 if let Some(rhs_off) = op.rhs.slot_offset() {
                     self.check_frame_access(Some(pc), rhs_off, size);
                 }
+                self.check_jump(pc, op.target);
+            },
+
+            MicroOp::JumpValueCmp(ref op) => {
+                // TODO: We should check frame access based on the size from the type?
+                self.check_jump(pc, op.target);
+            },
+            MicroOp::JumpValueRefCmp(ref op) => {
+                self.check_frame_access(Some(pc), op.lhs, 16);
+                self.check_frame_access(Some(pc), op.rhs, 16);
                 self.check_jump(pc, op.target);
             },
 

--- a/third_party/move/mono-move/specializer/src/lower/translate.rs
+++ b/third_party/move/mono-move/specializer/src/lower/translate.rs
@@ -17,8 +17,9 @@ use mono_move_core::{
     native::{FrameSlot, NativeABI},
     types::{strip_ref, view_type, InternedType, Type},
     CallClosureOp, ClosureFuncRef, CmpKind, CodeOffset, FrameLayoutInfo, FrameOffset, IntBinaryOp,
-    IntCastOp, IntCmpOp, IntNegateOp, IntOperand, IntShiftOp, IntTy, JumpIntCmpOp, MicroOp,
-    PackClosureOp, SafePointEntry, ShiftOperand, SizedSlot, FRAME_METADATA_SIZE,
+    IntCastOp, IntCmpOp, IntNegateOp, IntOperand, IntShiftOp, IntTy, JumpIntCmpOp, JumpValueCmpOp,
+    JumpValueRefCmpOp, MicroOp, PackClosureOp, SafePointEntry, ShiftOperand, SizedSlot, ValueCmpOp,
+    ValueRefCmpOp, FRAME_METADATA_SIZE,
 };
 use move_binary_format::file_format::{ConstantPoolIndex, FieldHandleIndex};
 
@@ -521,7 +522,8 @@ impl<'a> LoweringState<'a> {
                 let lhs_info = self.slot(*lhs)?;
                 let rhs_info = self.slot(*rhs)?;
                 let dst_info = self.def_slot(*dst)?;
-                let lhs_ty = self.slot_type(*lhs)?;
+                let lhs_interned = self.slot_interned_type(*lhs)?;
+                let lhs_ty = view_type(lhs_interned);
                 let dst = dst_info.offset;
                 let lhs = lhs_info.offset;
                 let rhs = rhs_info.offset;
@@ -617,9 +619,29 @@ impl<'a> LoweringState<'a> {
                             })?;
                         },
                         // Comparison produces a 1-byte boolean.
-                        BinaryOp::Cmp(cmp) => {
-                            let rhs = cmp_operand_from_slot(lhs_ty, rhs)?;
-                            self.emit_int_cmp(*cmp, dst, lhs, rhs)?;
+                        BinaryOp::Cmp(cmp) => match eq_kind(lhs_ty)? {
+                            EqKind::Int => {
+                                let rhs = cmp_operand_from_slot(lhs_ty, rhs)?;
+                                self.emit_int_cmp(*cmp, dst, lhs, rhs)?;
+                            },
+                            EqKind::Value => {
+                                self.emit(MicroOp::ValueCmp(ValueCmpOp {
+                                    negate: eq_negate(*cmp)?,
+                                    dst,
+                                    lhs,
+                                    rhs,
+                                    ty: lhs_interned,
+                                }))?;
+                            },
+                            EqKind::Ref => {
+                                self.emit(MicroOp::ValueRefCmp(ValueRefCmpOp {
+                                    negate: eq_negate(*cmp)?,
+                                    dst,
+                                    lhs,
+                                    rhs,
+                                    ty: strip_ref(lhs_interned)?,
+                                }))?;
+                            },
                         },
                         // Logical and/or on 1-byte booleans.
                         BinaryOp::And => self.emit(MicroOp::BoolAnd { dst, lhs, rhs })?,
@@ -891,8 +913,10 @@ impl<'a> LoweringState<'a> {
 
             // --- Fused compare+branch ---
             Instr::BrCmp(Label(l), op, lhs, rhs) => {
-                let lhs_ty = self.slot_type(*lhs)?;
-                let lhs_off = self.slot(*lhs)?.offset;
+                let lhs_interned = self.slot_interned_type(*lhs)?;
+                let lhs_ty = view_type(lhs_interned);
+                let lhs_info = self.slot(*lhs)?;
+                let lhs_off = lhs_info.offset;
                 let rhs_off = self.slot(*rhs)?.offset;
                 let target = CodeOffset(encode_label(*l));
                 let idx = self.out_buf.len();
@@ -928,9 +952,29 @@ impl<'a> LoweringState<'a> {
                         lhs: lhs_off,
                         rhs: rhs_off,
                     })?,
-                    _ => {
-                        let rhs_op = cmp_operand_from_slot(lhs_ty, rhs_off)?;
-                        self.emit_jump_int_cmp(target, *op, lhs_off, rhs_op)?;
+                    _ => match eq_kind(lhs_ty)? {
+                        EqKind::Int => {
+                            let rhs_op = cmp_operand_from_slot(lhs_ty, rhs_off)?;
+                            self.emit_jump_int_cmp(target, *op, lhs_off, rhs_op)?;
+                        },
+                        EqKind::Value => {
+                            self.emit(MicroOp::JumpValueCmp(JumpValueCmpOp {
+                                target,
+                                negate: eq_negate(*op)?,
+                                lhs: lhs_off,
+                                rhs: rhs_off,
+                                ty: lhs_interned,
+                            }))?;
+                        },
+                        EqKind::Ref => {
+                            self.emit(MicroOp::JumpValueRefCmp(JumpValueRefCmpOp {
+                                target,
+                                negate: eq_negate(*op)?,
+                                lhs: lhs_off,
+                                rhs: rhs_off,
+                                ty: strip_ref(lhs_interned)?,
+                            }))?;
+                        },
                     },
                 }
             },
@@ -1499,6 +1543,8 @@ impl<'a> LoweringState<'a> {
                 | MicroOp::JumpGreaterEqualU64 { target, .. }
                 | MicroOp::JumpNotEqualU64 { target, .. } => target.0,
                 MicroOp::JumpIntCmp(op) => op.target.0,
+                MicroOp::JumpValueCmp(op) => op.target.0,
+                MicroOp::JumpValueRefCmp(op) => op.target.0,
                 other => bail!("unexpected non-branch op at fixup index {}: {}", idx, other),
             };
             let label = decode_label(encoded);
@@ -1516,6 +1562,8 @@ impl<'a> LoweringState<'a> {
                 | MicroOp::JumpGreaterEqualU64 { target, .. }
                 | MicroOp::JumpNotEqualU64 { target, .. } => target.0 = resolved,
                 MicroOp::JumpIntCmp(op) => op.target.0 = resolved,
+                MicroOp::JumpValueCmp(op) => op.target.0 = resolved,
+                MicroOp::JumpValueRefCmp(op) => op.target.0 = resolved,
                 other => bail!("unexpected non-branch op at fixup index {}: {}", idx, other),
             }
         }
@@ -1588,6 +1636,54 @@ fn cmp_kind(op: CmpOp) -> CmpKind {
         CmpOp::Ge => CmpKind::Ge,
         CmpOp::Eq => CmpKind::Eq,
         CmpOp::Neq => CmpKind::Neq,
+    }
+}
+
+enum EqKind {
+    /// Integer comparison.
+    Int,
+    /// Non-integer structural comparison.
+    Value,
+    /// Reference: compared structurally through the pointer.
+    Ref,
+}
+
+/// Classify how an equality operand of the given type is lowered.
+fn eq_kind(ty: &Type) -> Result<EqKind> {
+    Ok(match ty {
+        Type::Bool
+        | Type::Address
+        // Signers are just addresses.
+        | Type::Signer
+        | Type::U8
+        | Type::U16
+        | Type::U32
+        | Type::U64
+        | Type::U128
+        | Type::U256
+        | Type::I8
+        | Type::I16
+        | Type::I32
+        | Type::I64
+        | Type::I128
+        | Type::I256 => EqKind::Int,
+        Type::Vector { .. } | Type::Nominal { .. } => EqKind::Value,
+        Type::ImmutRef { .. } | Type::MutRef { .. } => EqKind::Ref,
+        Type::Function { .. } | Type::TypeParam { .. } => {
+            bail!("equality is not supported for this operand type")
+        },
+    })
+}
+
+/// Map an equality [`CmpOp`] to the `negate` flag of the structural-equality
+/// ops (`false` for `Eq`, `true` for `Neq`).
+fn eq_negate(op: CmpOp) -> Result<bool> {
+    match op {
+        CmpOp::Eq => Ok(false),
+        CmpOp::Neq => Ok(true),
+        CmpOp::Lt | CmpOp::Le | CmpOp::Gt | CmpOp::Ge => {
+            bail!("ordering comparison on a non-scalar operand is ill-typed")
+        },
     }
 }
 

--- a/third_party/move/mono-move/specializer/src/lower/translate.rs
+++ b/third_party/move/mono-move/specializer/src/lower/translate.rs
@@ -624,7 +624,7 @@ impl<'a> LoweringState<'a> {
                                 let rhs = cmp_operand_from_slot(lhs_ty, rhs)?;
                                 self.emit_int_cmp(*cmp, dst, lhs, rhs)?;
                             },
-                            EqKind::Value => {
+                            EqKind::NonIntValue => {
                                 self.emit(MicroOp::ValueCmp(ValueCmpOp {
                                     negate: eq_negate(*cmp)?,
                                     dst,
@@ -957,7 +957,7 @@ impl<'a> LoweringState<'a> {
                             let rhs_op = cmp_operand_from_slot(lhs_ty, rhs_off)?;
                             self.emit_jump_int_cmp(target, *op, lhs_off, rhs_op)?;
                         },
-                        EqKind::Value => {
+                        EqKind::NonIntValue => {
                             self.emit(MicroOp::JumpValueCmp(JumpValueCmpOp {
                                 target,
                                 negate: eq_negate(*op)?,
@@ -1643,7 +1643,7 @@ enum EqKind {
     /// Integer comparison.
     Int,
     /// Non-integer structural comparison.
-    Value,
+    NonIntValue,
     /// Reference: compared structurally through the pointer.
     Ref,
 }
@@ -1667,7 +1667,7 @@ fn eq_kind(ty: &Type) -> Result<EqKind> {
         | Type::I64
         | Type::I128
         | Type::I256 => EqKind::Int,
-        Type::Vector { .. } | Type::Nominal { .. } => EqKind::Value,
+        Type::Vector { .. } | Type::Nominal { .. } => EqKind::NonIntValue,
         Type::ImmutRef { .. } | Type::MutRef { .. } => EqKind::Ref,
         Type::Function { .. } | Type::TypeParam { .. } => {
             bail!("equality is not supported for this operand type")
@@ -1688,14 +1688,15 @@ fn eq_negate(op: CmpOp) -> Result<bool> {
 }
 
 /// Build an [`IntOperand`] for a comparison operand. Integer types delegate to
-/// [`int_operand_from_slot`]. `bool` (1 byte) and `address` (32 bytes) are
-/// flat values with only `==`/`!=` (no ordering), and comparing their bit
-/// patterns is exactly value equality, so they reuse the integer compare ops
-/// at the matching width.
+/// [`int_operand_from_slot`]. `bool` (1 byte), `address` and `signer` (both 32
+/// bytes) are flat values with only `==`/`!=` (no ordering), and comparing
+/// their bit patterns is exactly value equality, so they reuse the integer
+/// compare ops at the matching width.
 fn cmp_operand_from_slot(ty: &Type, off: FrameOffset) -> Result<IntOperand> {
     match ty {
         Type::Bool => Ok(IntOperand::SlotU8(off)),
-        Type::Address => Ok(IntOperand::SlotU256(off)),
+        // A signer holds an address, so it compares as a 32-byte value.
+        Type::Address | Type::Signer => Ok(IntOperand::SlotU256(off)),
         Type::U8
         | Type::U16
         | Type::U32
@@ -1708,8 +1709,7 @@ fn cmp_operand_from_slot(ty: &Type, off: FrameOffset) -> Result<IntOperand> {
         | Type::I64
         | Type::I128
         | Type::I256 => int_operand_from_slot(ty, off),
-        Type::Signer
-        | Type::ImmutRef { .. }
+        Type::ImmutRef { .. }
         | Type::MutRef { .. }
         | Type::Vector { .. }
         | Type::Nominal { .. }

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/natives/signer.move
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/natives/signer.move
@@ -23,6 +23,24 @@ module 0x1::main {
         let s = 0x1::create_signer::create_signer(addr);
         0x1::permissioned_signer::is_permissioned_signer_impl(&s)
     }
+
+    public fun eq(a: address, b: address): bool {
+        let s = 0x1::create_signer::create_signer(a);
+        let t = 0x1::create_signer::create_signer(b);
+        s == t
+    }
+
+    public fun neq(a: address, b: address): bool {
+        let s = 0x1::create_signer::create_signer(a);
+        let t = 0x1::create_signer::create_signer(b);
+        s != t
+    }
+
+    public fun sel(a: address, b: address): u64 {
+        let s = 0x1::create_signer::create_signer(a);
+        let t = 0x1::create_signer::create_signer(b);
+        if (&s == &t) { 10 } else { 20 }
+    }
 }
 
 // RUN: execute 0x1::main::roundtrip --args 0xcafe
@@ -36,3 +54,21 @@ module 0x1::main {
 
 // RUN: execute 0x1::main::is_permissioned --args 0xcafe
 // CHECK: results: false
+
+// RUN: execute 0x1::main::eq --args 0xcafe, 0xcafe
+// CHECK: results: true
+
+// RUN: execute 0x1::main::eq --args 0xcafe, 0x1
+// CHECK: results: false
+
+// RUN: execute 0x1::main::neq --args 0xcafe, 0x1
+// CHECK: results: true
+
+// RUN: execute 0x1::main::neq --args 0x7, 0x7
+// CHECK: results: false
+
+// RUN: execute 0x1::main::sel --args 0x9, 0x9
+// CHECK: results: 10
+
+// RUN: execute 0x1::main::sel --args 0x9, 0xa
+// CHECK: results: 20

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/natives/signer.move
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/natives/signer.move
@@ -1,8 +1,7 @@
 // Differential test for the signer natives.
 
-// `create_signer` is declared here for two reasons:
-// 1. To avoid pulling in the Aptos Framework, which is a bit more heavy weight for now
-// 2. The version defined in the Aptos Framework is public(friend) so we can't use it anyway
+// `create_signer` is declared here to avoid pulling in the Aptos Framework,
+// which is a bit more heavy weight for now.
 
 // RUN: publish
 module 0x1::create_signer {

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/refs/ref_eq.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/refs/ref_eq.exp
@@ -1,0 +1,137 @@
+=== bytecode ===
+// Bytecode version v10
+module 0x1::test
+struct Point has copy + drop
+  x: u64
+  y: u64
+
+// Function definition at index 0
+fun cmp_ref(l0: u64, l1: u64, l2: u64, l3: u64): u64
+    local l4: Point
+    local l5: Point
+    move_loc l0
+    move_loc l1
+    pack Point
+    st_loc l4
+    move_loc l2
+    // @5
+    move_loc l3
+    pack Point
+    st_loc l5
+    borrow_loc l4
+    borrow_loc l5
+    // @10
+    eq
+    br_false l0
+    ld_u64 10
+    ret
+l0: ld_u64 42
+    // @15
+    ret
+
+// Function definition at index 1
+fun eq_ref(l0: u64, l1: u64, l2: u64, l3: u64): bool
+    local l4: Point
+    local l5: Point
+    move_loc l0
+    move_loc l1
+    pack Point
+    st_loc l4
+    move_loc l2
+    // @5
+    move_loc l3
+    pack Point
+    st_loc l5
+    borrow_loc l4
+    borrow_loc l5
+    // @10
+    eq
+    ret
+
+=== stackless ===
+// module 0x1::test
+
+fun cmp_ref(r0, r1, r2, r3): u64 {
+  slots: params(4), locals(2), temps(3)
+    r0: u64
+    r1: u64
+    r2: u64
+    r3: u64
+    r4: 0x1::test::Point
+    r5: 0x1::test::Point
+    r6: &0x1::test::Point
+    r7: &0x1::test::Point
+    r8: u64
+  code:
+  L2:
+    0: r4 := pack 0x1::test::Point, [r0, r1]
+    1: r5 := pack 0x1::test::Point, [r2, r3]
+    2: r6 := imm_borrow_loc r4
+    3: r7 := imm_borrow_loc r5
+    4: br_neq L0, r6, r7
+  L1:
+    5: r8 := ld_u64 10
+    6: ret [r8]
+  L0:
+    7: r8 := ld_u64 42
+    8: ret [r8]
+}
+
+fun eq_ref(r0, r1, r2, r3): bool {
+  slots: params(4), locals(2), temps(3)
+    r0: u64
+    r1: u64
+    r2: u64
+    r3: u64
+    r4: 0x1::test::Point
+    r5: 0x1::test::Point
+    r6: &0x1::test::Point
+    r7: &0x1::test::Point
+    r8: bool
+  code:
+  L0:
+    0: r4 := pack 0x1::test::Point, [r0, r1]
+    1: r5 := pack 0x1::test::Point, [r2, r3]
+    2: r6 := imm_borrow_loc r4
+    3: r7 := imm_borrow_loc r5
+    4: r8 := eq r6, r7
+    5: ret [r8]
+}
+=== micro-ops ===
+// module 0x1::test
+
+fun cmp_ref() {
+  frame_data_size: 104
+  code:
+    0: Charge #18
+    1: Move8 [40] <- [8]
+    2: Move8 [32] <- [0]
+    3: Move8 [56] <- [24]
+    4: Move8 [48] <- [16]
+    5: SlotBorrow [64] <- &[32]
+    6: SlotBorrow [80] <- &[48]
+    7: JumpValueRefCmp @12 *[64] != *[80] : 0x1::test::Point
+    8: Charge #6
+    9: StoreImm8 [96] <- #10
+    10: Move8 [0] <- [96]
+    11: Return
+    12: Charge #6
+    13: StoreImm8 [96] <- #42
+    14: Move8 [0] <- [96]
+    15: Return
+}
+
+fun eq_ref() {
+  frame_data_size: 104
+  code:
+    0: Charge #25
+    1: Move8 [40] <- [8]
+    2: Move8 [32] <- [0]
+    3: Move8 [56] <- [24]
+    4: Move8 [48] <- [16]
+    5: SlotBorrow [64] <- &[32]
+    6: SlotBorrow [80] <- &[48]
+    7: ValueRefCmp [96] <- *[64] == *[80] : 0x1::test::Point
+    8: Move(1) [0] <- [96]
+    9: Return
+}

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/refs/ref_eq.move
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/refs/ref_eq.move
@@ -1,0 +1,31 @@
+// RUN: publish --print(bytecode,stackless,micro-ops)
+module 0x1::test {
+    struct Point has copy, drop {
+        x: u64,
+        y: u64,
+    }
+
+    fun eq_ref(ax: u64, ay: u64, bx: u64, by: u64): bool {
+        let a = Point { x: ax, y: ay };
+        let b = Point { x: bx, y: by };
+        &a == &b
+    }
+
+    fun cmp_ref(ax: u64, ay: u64, bx: u64, by: u64): u64 {
+        let a = Point { x: ax, y: ay };
+        let b = Point { x: bx, y: by };
+        if (&a == &b) { 10 } else { 42 }
+    }
+}
+
+// RUN: execute 0x1::test::eq_ref --args 3, 4, 3, 4
+// CHECK: results: true
+
+// RUN: execute 0x1::test::eq_ref --args 3, 4, 3, 9
+// CHECK: results: false
+
+// RUN: execute 0x1::test::cmp_ref --args 7, 8, 7, 8
+// CHECK: results: 10
+
+// RUN: execute 0x1::test::cmp_ref --args 7, 8, 9, 8
+// CHECK: results: 42

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/structs/struct_eq.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/structs/struct_eq.exp
@@ -1,0 +1,153 @@
+=== bytecode ===
+// Bytecode version v10
+module 0x1::test
+struct Point has copy + drop
+  x: u64
+  y: u64
+
+// Function definition at index 0
+fun cmp(l0: u64, l1: u64, l2: u64, l3: u64): u64
+    move_loc l0
+    move_loc l1
+    pack Point
+    move_loc l2
+    move_loc l3
+    // @5
+    pack Point
+    eq
+    br_false l0
+    ld_u64 10
+    ret
+    // @10
+l0: ld_u64 42
+    ret
+
+// Function definition at index 1
+fun eq(l0: u64, l1: u64, l2: u64, l3: u64): bool
+    move_loc l0
+    move_loc l1
+    pack Point
+    move_loc l2
+    move_loc l3
+    // @5
+    pack Point
+    eq
+    ret
+
+// Function definition at index 2
+fun neq(l0: u64, l1: u64, l2: u64, l3: u64): bool
+    move_loc l0
+    move_loc l1
+    pack Point
+    move_loc l2
+    move_loc l3
+    // @5
+    pack Point
+    neq
+    ret
+
+=== stackless ===
+// module 0x1::test
+
+fun cmp(r0, r1, r2, r3): u64 {
+  slots: params(4), locals(0), temps(3)
+    r0: u64
+    r1: u64
+    r2: u64
+    r3: u64
+    r4: 0x1::test::Point
+    r5: 0x1::test::Point
+    r6: u64
+  code:
+  L2:
+    0: r4 := pack 0x1::test::Point, [r0, r1]
+    1: r5 := pack 0x1::test::Point, [r2, r3]
+    2: br_neq L0, r4, r5
+  L1:
+    3: r6 := ld_u64 10
+    4: ret [r6]
+  L0:
+    5: r6 := ld_u64 42
+    6: ret [r6]
+}
+
+fun eq(r0, r1, r2, r3): bool {
+  slots: params(4), locals(0), temps(3)
+    r0: u64
+    r1: u64
+    r2: u64
+    r3: u64
+    r4: 0x1::test::Point
+    r5: 0x1::test::Point
+    r6: bool
+  code:
+  L0:
+    0: r4 := pack 0x1::test::Point, [r0, r1]
+    1: r5 := pack 0x1::test::Point, [r2, r3]
+    2: r6 := eq r4, r5
+    3: ret [r6]
+}
+
+fun neq(r0, r1, r2, r3): bool {
+  slots: params(4), locals(0), temps(3)
+    r0: u64
+    r1: u64
+    r2: u64
+    r3: u64
+    r4: 0x1::test::Point
+    r5: 0x1::test::Point
+    r6: bool
+  code:
+  L0:
+    0: r4 := pack 0x1::test::Point, [r0, r1]
+    1: r5 := pack 0x1::test::Point, [r2, r3]
+    2: r6 := neq r4, r5
+    3: ret [r6]
+}
+=== micro-ops ===
+// module 0x1::test
+
+fun cmp() {
+  frame_data_size: 72
+  code:
+    0: Charge #14
+    1: Move8 [40] <- [8]
+    2: Move8 [32] <- [0]
+    3: Move8 [56] <- [24]
+    4: Move8 [48] <- [16]
+    5: JumpValueCmp @10 [32] != [48] : 0x1::test::Point
+    6: Charge #6
+    7: StoreImm8 [64] <- #10
+    8: Move8 [0] <- [64]
+    9: Return
+    10: Charge #6
+    11: StoreImm8 [64] <- #42
+    12: Move8 [0] <- [64]
+    13: Return
+}
+
+fun eq() {
+  frame_data_size: 72
+  code:
+    0: Charge #21
+    1: Move8 [40] <- [8]
+    2: Move8 [32] <- [0]
+    3: Move8 [56] <- [24]
+    4: Move8 [48] <- [16]
+    5: ValueCmp [64] <- [32] == [48] : 0x1::test::Point
+    6: Move(1) [0] <- [64]
+    7: Return
+}
+
+fun neq() {
+  frame_data_size: 72
+  code:
+    0: Charge #21
+    1: Move8 [40] <- [8]
+    2: Move8 [32] <- [0]
+    3: Move8 [56] <- [24]
+    4: Move8 [48] <- [16]
+    5: ValueCmp [64] <- [32] != [48] : 0x1::test::Point
+    6: Move(1) [0] <- [64]
+    7: Return
+}

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/structs/struct_eq.move
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/structs/struct_eq.move
@@ -1,0 +1,40 @@
+// RUN: publish --print(bytecode,stackless,micro-ops)
+module 0x1::test {
+    struct Point has copy, drop {
+        x: u64,
+        y: u64,
+    }
+
+    fun eq(ax: u64, ay: u64, bx: u64, by: u64): bool {
+        Point { x: ax, y: ay } == Point { x: bx, y: by }
+    }
+
+    fun neq(ax: u64, ay: u64, bx: u64, by: u64): bool {
+        Point { x: ax, y: ay } != Point { x: bx, y: by }
+    }
+
+    fun cmp(ax: u64, ay: u64, bx: u64, by: u64): u64 {
+        if (Point { x: ax, y: ay } == Point { x: bx, y: by }) { 10 } else { 42 }
+    }
+}
+
+// RUN: execute 0x1::test::eq --args 3, 4, 3, 4
+// CHECK: results: true
+
+// RUN: execute 0x1::test::eq --args 9, 4, 3, 4
+// CHECK: results: false
+
+// RUN: execute 0x1::test::eq --args 3, 9, 3, 4
+// CHECK: results: false
+
+// RUN: execute 0x1::test::neq --args 3, 4, 3, 4
+// CHECK: results: false
+
+// RUN: execute 0x1::test::neq --args 3, 4, 3, 9
+// CHECK: results: true
+
+// RUN: execute 0x1::test::cmp --args 7, 8, 7, 8
+// CHECK: results: 10
+
+// RUN: execute 0x1::test::cmp --args 7, 8, 7, 9
+// CHECK: results: 42

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/structs/struct_nested_eq.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/structs/struct_nested_eq.exp
@@ -1,0 +1,437 @@
+=== bytecode ===
+// Bytecode version v10
+module 0x1::test
+struct Bag has copy + drop
+  id: u64
+  items: vector<u64>
+
+struct Point has copy + drop
+  x: u64
+  y: u64
+
+// Function definition at index 0
+fun bag_eq(l0: u64, l1: u64, l2: u64, l3: u64, l4: u64, l5: u64): bool
+    move_loc l0
+    move_loc l1
+    move_loc l2
+    call mk_bag
+    move_loc l3
+    // @5
+    move_loc l4
+    move_loc l5
+    call mk_bag
+    eq
+    ret
+
+// Function definition at index 1
+fun bag_eq_len(l0: u64, l1: u64, l2: u64, l3: u64, l4: u64): bool
+    move_loc l0
+    move_loc l1
+    call mk_bag1
+    move_loc l2
+    move_loc l3
+    // @5
+    move_loc l4
+    call mk_bag
+    eq
+    ret
+
+// Function definition at index 2
+fun bag_neq(l0: u64, l1: u64, l2: u64, l3: u64, l4: u64, l5: u64): bool
+    move_loc l0
+    move_loc l1
+    move_loc l2
+    call mk_bag
+    move_loc l3
+    // @5
+    move_loc l4
+    move_loc l5
+    call mk_bag
+    neq
+    ret
+
+// Function definition at index 3
+fun mk_bag(l0: u64, l1: u64, l2: u64): Bag
+    local l3: vector<u64>
+    vec_pack <u64>, 0
+    st_loc l3
+    mut_borrow_loc l3
+    move_loc l1
+    vec_push_back <u64>
+    // @5
+    mut_borrow_loc l3
+    move_loc l2
+    vec_push_back <u64>
+    move_loc l0
+    move_loc l3
+    // @10
+    pack Bag
+    ret
+
+// Function definition at index 4
+fun mk_bag1(l0: u64, l1: u64): Bag
+    local l2: vector<u64>
+    vec_pack <u64>, 0
+    st_loc l2
+    mut_borrow_loc l2
+    move_loc l1
+    vec_push_back <u64>
+    // @5
+    move_loc l0
+    move_loc l2
+    pack Bag
+    ret
+
+// Function definition at index 5
+fun mk_points(l0: u64, l1: u64, l2: u64, l3: u64): vector<Point>
+    local l4: vector<Point>
+    vec_pack <Point>, 0
+    st_loc l4
+    mut_borrow_loc l4
+    move_loc l0
+    move_loc l1
+    // @5
+    pack Point
+    vec_push_back <Point>
+    mut_borrow_loc l4
+    move_loc l2
+    move_loc l3
+    // @10
+    pack Point
+    vec_push_back <Point>
+    move_loc l4
+    ret
+
+// Function definition at index 6
+fun pts_eq(l0: u64, l1: u64, l2: u64, l3: u64, l4: u64, l5: u64, l6: u64, l7: u64): bool
+    move_loc l0
+    move_loc l1
+    move_loc l2
+    move_loc l3
+    call mk_points
+    // @5
+    move_loc l4
+    move_loc l5
+    move_loc l6
+    move_loc l7
+    call mk_points
+    // @10
+    eq
+    ret
+
+// Function definition at index 7
+fun pts_neq(l0: u64, l1: u64, l2: u64, l3: u64, l4: u64, l5: u64, l6: u64, l7: u64): bool
+    move_loc l0
+    move_loc l1
+    move_loc l2
+    move_loc l3
+    call mk_points
+    // @5
+    move_loc l4
+    move_loc l5
+    move_loc l6
+    move_loc l7
+    call mk_points
+    // @10
+    neq
+    ret
+
+=== stackless ===
+// module 0x1::test
+
+fun bag_eq(r0, r1, r2, r3, r4, r5): bool {
+  slots: params(6), locals(0), temps(2), xfer(3)
+    r0: u64
+    r1: u64
+    r2: u64
+    r3: u64
+    r4: u64
+    r5: u64
+    r6: 0x1::test::Bag
+    r7: bool
+  code:
+  L0:
+    0: [r6] := call mk_bag, [r0, r1, r2]
+    1: [x0] := call mk_bag, [r3, r4, r5]
+    2: r7 := eq r6, x0
+    3: ret [r7]
+}
+
+fun bag_eq_len(r0, r1, r2, r3, r4): bool {
+  slots: params(5), locals(0), temps(2), xfer(3)
+    r0: u64
+    r1: u64
+    r2: u64
+    r3: u64
+    r4: u64
+    r5: 0x1::test::Bag
+    r6: bool
+  code:
+  L0:
+    0: [r5] := call mk_bag1, [r0, r1]
+    1: [x0] := call mk_bag, [r2, r3, r4]
+    2: r6 := eq r5, x0
+    3: ret [r6]
+}
+
+fun bag_neq(r0, r1, r2, r3, r4, r5): bool {
+  slots: params(6), locals(0), temps(2), xfer(3)
+    r0: u64
+    r1: u64
+    r2: u64
+    r3: u64
+    r4: u64
+    r5: u64
+    r6: 0x1::test::Bag
+    r7: bool
+  code:
+  L0:
+    0: [r6] := call mk_bag, [r0, r1, r2]
+    1: [x0] := call mk_bag, [r3, r4, r5]
+    2: r7 := neq r6, x0
+    3: ret [r7]
+}
+
+fun mk_bag(r0, r1, r2): Bag {
+  slots: params(3), locals(1), temps(2)
+    r0: u64
+    r1: u64
+    r2: u64
+    r3: vector<u64>
+    r4: &mut vector<u64>
+    r5: 0x1::test::Bag
+  code:
+  L0:
+    0: r3 := vec_pack u64, 0, []
+    1: r4 := mut_borrow_loc r3
+    2: vec_push_back u64, r4, r1
+    3: r4 := mut_borrow_loc r3
+    4: vec_push_back u64, r4, r2
+    5: r5 := pack 0x1::test::Bag, [r0, r3]
+    6: ret [r5]
+}
+
+fun mk_bag1(r0, r1): Bag {
+  slots: params(2), locals(1), temps(2)
+    r0: u64
+    r1: u64
+    r2: vector<u64>
+    r3: &mut vector<u64>
+    r4: 0x1::test::Bag
+  code:
+  L0:
+    0: r2 := vec_pack u64, 0, []
+    1: r3 := mut_borrow_loc r2
+    2: vec_push_back u64, r3, r1
+    3: r4 := pack 0x1::test::Bag, [r0, r2]
+    4: ret [r4]
+}
+
+fun mk_points(r0, r1, r2, r3): vector<Point> {
+  slots: params(4), locals(1), temps(2)
+    r0: u64
+    r1: u64
+    r2: u64
+    r3: u64
+    r4: vector<0x1::test::Point>
+    r5: &mut vector<0x1::test::Point>
+    r6: 0x1::test::Point
+  code:
+  L0:
+    0: r4 := vec_pack 0x1::test::Point, 0, []
+    1: r5 := mut_borrow_loc r4
+    2: r6 := pack 0x1::test::Point, [r0, r1]
+    3: vec_push_back 0x1::test::Point, r5, r6
+    4: r5 := mut_borrow_loc r4
+    5: r6 := pack 0x1::test::Point, [r2, r3]
+    6: vec_push_back 0x1::test::Point, r5, r6
+    7: ret [r4]
+}
+
+fun pts_eq(r0, r1, r2, r3, r4, r5, r6, r7): bool {
+  slots: params(8), locals(0), temps(2), xfer(4)
+    r0: u64
+    r1: u64
+    r2: u64
+    r3: u64
+    r4: u64
+    r5: u64
+    r6: u64
+    r7: u64
+    r8: vector<0x1::test::Point>
+    r9: bool
+  code:
+  L0:
+    0: [r8] := call mk_points, [r0, r1, r2, r3]
+    1: [x0] := call mk_points, [r4, r5, r6, r7]
+    2: r9 := eq r8, x0
+    3: ret [r9]
+}
+
+fun pts_neq(r0, r1, r2, r3, r4, r5, r6, r7): bool {
+  slots: params(8), locals(0), temps(2), xfer(4)
+    r0: u64
+    r1: u64
+    r2: u64
+    r3: u64
+    r4: u64
+    r5: u64
+    r6: u64
+    r7: u64
+    r8: vector<0x1::test::Point>
+    r9: bool
+  code:
+  L0:
+    0: [r8] := call mk_points, [r0, r1, r2, r3]
+    1: [x0] := call mk_points, [r4, r5, r6, r7]
+    2: r9 := neq r8, x0
+    3: ret [r9]
+}
+=== micro-ops ===
+// module 0x1::test
+
+fun bag_eq() {
+  frame_data_size: 72
+  code:
+    0: Charge #95
+    1: Move8 [112] <- [16]
+    2: Move8 [104] <- [8]
+    3: Move8 [96] <- [0]
+    4: CallIndirect 0x1::test::mk_bag
+    5: Move(16) [48] <- [96]
+    6: Move8 [112] <- [40]
+    7: Move8 [104] <- [32]
+    8: Move8 [96] <- [24]
+    9: CallIndirect 0x1::test::mk_bag
+    10: ValueCmp [64] <- [48] == [96] : 0x1::test::Bag
+    11: Move(1) [0] <- [64]
+    12: Return
+}
+
+fun bag_eq_len() {
+  frame_data_size: 64
+  code:
+    0: Charge #93
+    1: Move8 [96] <- [8]
+    2: Move8 [88] <- [0]
+    3: CallIndirect 0x1::test::mk_bag1
+    4: Move(16) [40] <- [88]
+    5: Move8 [104] <- [32]
+    6: Move8 [96] <- [24]
+    7: Move8 [88] <- [16]
+    8: CallIndirect 0x1::test::mk_bag
+    9: ValueCmp [56] <- [40] == [88] : 0x1::test::Bag
+    10: Move(1) [0] <- [56]
+    11: Return
+}
+
+fun bag_neq() {
+  frame_data_size: 72
+  code:
+    0: Charge #95
+    1: Move8 [112] <- [16]
+    2: Move8 [104] <- [8]
+    3: Move8 [96] <- [0]
+    4: CallIndirect 0x1::test::mk_bag
+    5: Move(16) [48] <- [96]
+    6: Move8 [112] <- [40]
+    7: Move8 [104] <- [32]
+    8: Move8 [96] <- [24]
+    9: CallIndirect 0x1::test::mk_bag
+    10: ValueCmp [64] <- [48] != [96] : 0x1::test::Bag
+    11: Move(1) [0] <- [64]
+    12: Return
+}
+
+fun mk_bag() {
+  frame_data_size: 64
+  code:
+    0: Charge #126
+    1: VecNew [24]
+    2: SlotBorrow [32] <- &[24]
+    3: VecPushBack [32].push([8], size=8, desc=2)
+    4: SlotBorrow [32] <- &[24]
+    5: VecPushBack [32].push([16], size=8, desc=2)
+    6: Move8 [56] <- [24]
+    7: Move8 [48] <- [0]
+    8: Move(16) [0] <- [48]
+    9: Return
+  safe_point_layouts:
+    3: []
+    5: []
+}
+
+fun mk_bag1() {
+  frame_data_size: 56
+  code:
+    0: Charge #96
+    1: VecNew [16]
+    2: SlotBorrow [24] <- &[16]
+    3: VecPushBack [24].push([8], size=8, desc=2)
+    4: Move8 [48] <- [16]
+    5: Move8 [40] <- [0]
+    6: Move(16) [0] <- [40]
+    7: Return
+  safe_point_layouts:
+    3: []
+}
+
+fun mk_points() {
+  frame_data_size: 72
+  code:
+    0: Charge #130
+    1: VecNew [32]
+    2: SlotBorrow [40] <- &[32]
+    3: Move8 [64] <- [8]
+    4: Move8 [56] <- [0]
+    5: VecPushBack [40].push([56], size=16, desc=3)
+    6: SlotBorrow [40] <- &[32]
+    7: Move8 [64] <- [24]
+    8: Move8 [56] <- [16]
+    9: VecPushBack [40].push([56], size=16, desc=3)
+    10: Move8 [0] <- [32]
+    11: Return
+  safe_point_layouts:
+    5: []
+    9: []
+}
+
+fun pts_eq() {
+  frame_data_size: 80
+  code:
+    0: Charge #51
+    1: Move8 [128] <- [24]
+    2: Move8 [120] <- [16]
+    3: Move8 [112] <- [8]
+    4: Move8 [104] <- [0]
+    5: CallIndirect 0x1::test::mk_points
+    6: Move8 [64] <- [104]
+    7: Move8 [128] <- [56]
+    8: Move8 [120] <- [48]
+    9: Move8 [112] <- [40]
+    10: Move8 [104] <- [32]
+    11: CallIndirect 0x1::test::mk_points
+    12: ValueCmp [72] <- [64] == [104] : vector<0x1::test::Point>
+    13: Move(1) [0] <- [72]
+    14: Return
+}
+
+fun pts_neq() {
+  frame_data_size: 80
+  code:
+    0: Charge #51
+    1: Move8 [128] <- [24]
+    2: Move8 [120] <- [16]
+    3: Move8 [112] <- [8]
+    4: Move8 [104] <- [0]
+    5: CallIndirect 0x1::test::mk_points
+    6: Move8 [64] <- [104]
+    7: Move8 [128] <- [56]
+    8: Move8 [120] <- [48]
+    9: Move8 [112] <- [40]
+    10: Move8 [104] <- [32]
+    11: CallIndirect 0x1::test::mk_points
+    12: ValueCmp [72] <- [64] != [104] : vector<0x1::test::Point>
+    13: Move(1) [0] <- [72]
+    14: Return
+}

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/structs/struct_nested_eq.move
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/structs/struct_nested_eq.move
@@ -1,0 +1,96 @@
+// RUN: publish --print(bytecode,stackless,micro-ops)
+module 0x1::test {
+    use std::vector;
+
+    struct Point has copy, drop {
+        x: u64,
+        y: u64,
+    }
+
+    struct Bag has copy, drop {
+        id: u64,
+        items: vector<u64>,
+    }
+
+    fun mk_bag(id: u64, a: u64, b: u64): Bag {
+        let items = vector::empty<u64>();
+        vector::push_back(&mut items, a);
+        vector::push_back(&mut items, b);
+        Bag { id, items }
+    }
+
+    fun bag_eq(id1: u64, a1: u64, b1: u64, id2: u64, a2: u64, b2: u64): bool {
+        mk_bag(id1, a1, b1) == mk_bag(id2, a2, b2)
+    }
+
+    fun bag_neq(id1: u64, a1: u64, b1: u64, id2: u64, a2: u64, b2: u64): bool {
+        mk_bag(id1, a1, b1) != mk_bag(id2, a2, b2)
+    }
+
+    fun mk_bag1(id: u64, a: u64): Bag {
+        let items = vector::empty<u64>();
+        vector::push_back(&mut items, a);
+        Bag { id, items }
+    }
+
+    fun bag_eq_len(id1: u64, a1: u64, id2: u64, a2: u64, b2: u64): bool {
+        mk_bag1(id1, a1) == mk_bag(id2, a2, b2)
+    }
+
+    fun mk_points(x1: u64, y1: u64, x2: u64, y2: u64): vector<Point> {
+        let v = vector::empty<Point>();
+        vector::push_back(&mut v, Point { x: x1, y: y1 });
+        vector::push_back(&mut v, Point { x: x2, y: y2 });
+        v
+    }
+
+    fun pts_eq(
+        x1: u64, y1: u64, x2: u64, y2: u64,
+        x3: u64, y3: u64, x4: u64, y4: u64,
+    ): bool {
+        mk_points(x1, y1, x2, y2) == mk_points(x3, y3, x4, y4)
+    }
+
+    fun pts_neq(
+        x1: u64, y1: u64, x2: u64, y2: u64,
+        x3: u64, y3: u64, x4: u64, y4: u64,
+    ): bool {
+        mk_points(x1, y1, x2, y2) != mk_points(x3, y3, x4, y4)
+    }
+}
+
+// RUN: execute 0x1::test::bag_eq --args 1, 10, 20, 1, 10, 20
+// CHECK: results: true
+
+// RUN: execute 0x1::test::bag_eq --args 1, 10, 20, 2, 10, 20
+// CHECK: results: false
+
+// RUN: execute 0x1::test::bag_eq --args 1, 10, 20, 1, 10, 99
+// CHECK: results: false
+
+// RUN: execute 0x1::test::bag_neq --args 1, 10, 20, 1, 10, 20
+// CHECK: results: false
+
+// RUN: execute 0x1::test::bag_neq --args 1, 10, 20, 1, 99, 20
+// CHECK: results: true
+
+// RUN: execute 0x1::test::bag_neq --args 1, 10, 20, 7, 10, 20
+// CHECK: results: true
+
+// RUN: execute 0x1::test::bag_eq_len --args 1, 10, 1, 10, 20
+// CHECK: results: false
+
+// RUN: execute 0x1::test::pts_eq --args 1, 2, 3, 4, 1, 2, 3, 4
+// CHECK: results: true
+
+// RUN: execute 0x1::test::pts_eq --args 9, 2, 3, 4, 1, 2, 3, 4
+// CHECK: results: false
+
+// RUN: execute 0x1::test::pts_eq --args 1, 2, 3, 4, 1, 2, 3, 9
+// CHECK: results: false
+
+// RUN: execute 0x1::test::pts_neq --args 1, 2, 3, 4, 1, 2, 3, 4
+// CHECK: results: false
+
+// RUN: execute 0x1::test::pts_neq --args 1, 2, 3, 4, 1, 2, 3, 5
+// CHECK: results: true

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/vectors/vec_eq.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/vectors/vec_eq.exp
@@ -62,6 +62,44 @@ fun eq_len(l0: u64, l1: u64, l2: u64): bool
     // @10
     ret
 
+// Function definition at index 4
+fun eq_ref(l0: u64, l1: u64, l2: u64, l3: u64): bool
+    local l4: vector<u64>
+    local l5: vector<u64>
+    move_loc l0
+    move_loc l1
+    call build
+    st_loc l4
+    move_loc l2
+    // @5
+    move_loc l3
+    call build
+    st_loc l5
+    borrow_loc l4
+    borrow_loc l5
+    // @10
+    eq
+    ret
+
+// Function definition at index 5
+fun neq_ref(l0: u64, l1: u64, l2: u64, l3: u64): bool
+    local l4: vector<u64>
+    local l5: vector<u64>
+    move_loc l0
+    move_loc l1
+    call build
+    st_loc l4
+    move_loc l2
+    // @5
+    move_loc l3
+    call build
+    st_loc l5
+    borrow_loc l4
+    borrow_loc l5
+    // @10
+    neq
+    ret
+
 === stackless ===
 // module 0x1::test
 
@@ -135,6 +173,48 @@ fun eq_len(r0, r1, r2): bool {
     4: r5 := eq x0, r3
     5: ret [r5]
 }
+
+fun eq_ref(r0, r1, r2, r3): bool {
+  slots: params(4), locals(2), temps(3), xfer(2)
+    r0: u64
+    r1: u64
+    r2: u64
+    r3: u64
+    r4: vector<u64>
+    r5: vector<u64>
+    r6: &vector<u64>
+    r7: &vector<u64>
+    r8: bool
+  code:
+  L0:
+    0: [r4] := call build, [r0, r1]
+    1: [r5] := call build, [r2, r3]
+    2: r6 := imm_borrow_loc r4
+    3: r7 := imm_borrow_loc r5
+    4: r8 := eq r6, r7
+    5: ret [r8]
+}
+
+fun neq_ref(r0, r1, r2, r3): bool {
+  slots: params(4), locals(2), temps(3), xfer(2)
+    r0: u64
+    r1: u64
+    r2: u64
+    r3: u64
+    r4: vector<u64>
+    r5: vector<u64>
+    r6: &vector<u64>
+    r7: &vector<u64>
+    r8: bool
+  code:
+  L0:
+    0: [r4] := call build, [r0, r1]
+    1: [r5] := call build, [r2, r3]
+    2: r6 := imm_borrow_loc r4
+    3: r7 := imm_borrow_loc r5
+    4: r8 := neq r6, r7
+    5: ret [r8]
+}
 === micro-ops ===
 // module 0x1::test
 
@@ -207,4 +287,42 @@ fun eq_len() {
     9: Return
   safe_point_layouts:
     3: []
+}
+
+fun eq_ref() {
+  frame_data_size: 88
+  code:
+    0: Charge #49
+    1: Move8 [120] <- [8]
+    2: Move8 [112] <- [0]
+    3: CallIndirect 0x1::test::build
+    4: Move8 [32] <- [112]
+    5: Move8 [120] <- [24]
+    6: Move8 [112] <- [16]
+    7: CallIndirect 0x1::test::build
+    8: Move8 [40] <- [112]
+    9: SlotBorrow [48] <- &[32]
+    10: SlotBorrow [64] <- &[40]
+    11: ValueRefCmp [80] <- *[48] == *[64] : vector<u64>
+    12: Move(1) [0] <- [80]
+    13: Return
+}
+
+fun neq_ref() {
+  frame_data_size: 88
+  code:
+    0: Charge #49
+    1: Move8 [120] <- [8]
+    2: Move8 [112] <- [0]
+    3: CallIndirect 0x1::test::build
+    4: Move8 [32] <- [112]
+    5: Move8 [120] <- [24]
+    6: Move8 [112] <- [16]
+    7: CallIndirect 0x1::test::build
+    8: Move8 [40] <- [112]
+    9: SlotBorrow [48] <- &[32]
+    10: SlotBorrow [64] <- &[40]
+    11: ValueRefCmp [80] <- *[48] != *[64] : vector<u64>
+    12: Move(1) [0] <- [80]
+    13: Return
 }

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/vectors/vec_eq.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/vectors/vec_eq.exp
@@ -1,0 +1,210 @@
+=== bytecode ===
+// Bytecode version v10
+module 0x1::test
+// Function definition at index 0
+fun build(l0: u64, l1: u64): vector<u64>
+    local l2: vector<u64>
+    vec_pack <u64>, 0
+    st_loc l2
+    mut_borrow_loc l2
+    move_loc l0
+    vec_push_back <u64>
+    // @5
+    mut_borrow_loc l2
+    move_loc l1
+    vec_push_back <u64>
+    move_loc l2
+    ret
+
+// Function definition at index 1
+fun cmp(l0: u64, l1: u64, l2: u64, l3: u64): u64
+    move_loc l0
+    move_loc l1
+    call build
+    move_loc l2
+    move_loc l3
+    // @5
+    call build
+    eq
+    br_false l0
+    ld_u64 10
+    ret
+    // @10
+l0: ld_u64 42
+    ret
+
+// Function definition at index 2
+fun eq(l0: u64, l1: u64, l2: u64, l3: u64): bool
+    move_loc l0
+    move_loc l1
+    call build
+    move_loc l2
+    move_loc l3
+    // @5
+    call build
+    eq
+    ret
+
+// Function definition at index 3
+fun eq_len(l0: u64, l1: u64, l2: u64): bool
+    local l3: vector<u64>
+    vec_pack <u64>, 0
+    st_loc l3
+    mut_borrow_loc l3
+    move_loc l0
+    vec_push_back <u64>
+    // @5
+    move_loc l1
+    move_loc l2
+    call build
+    move_loc l3
+    eq
+    // @10
+    ret
+
+=== stackless ===
+// module 0x1::test
+
+fun build(r0, r1): vector<u64> {
+  slots: params(2), locals(1), temps(1)
+    r0: u64
+    r1: u64
+    r2: vector<u64>
+    r3: &mut vector<u64>
+  code:
+  L0:
+    0: r2 := vec_pack u64, 0, []
+    1: r3 := mut_borrow_loc r2
+    2: vec_push_back u64, r3, r0
+    3: r3 := mut_borrow_loc r2
+    4: vec_push_back u64, r3, r1
+    5: ret [r2]
+}
+
+fun cmp(r0, r1, r2, r3): u64 {
+  slots: params(4), locals(0), temps(2), xfer(2)
+    r0: u64
+    r1: u64
+    r2: u64
+    r3: u64
+    r4: vector<u64>
+    r5: u64
+  code:
+  L2:
+    0: [r4] := call build, [r0, r1]
+    1: [x0] := call build, [r2, r3]
+    2: br_neq L0, r4, x0
+  L1:
+    3: r5 := ld_u64 10
+    4: ret [r5]
+  L0:
+    5: r5 := ld_u64 42
+    6: ret [r5]
+}
+
+fun eq(r0, r1, r2, r3): bool {
+  slots: params(4), locals(0), temps(2), xfer(2)
+    r0: u64
+    r1: u64
+    r2: u64
+    r3: u64
+    r4: vector<u64>
+    r5: bool
+  code:
+  L0:
+    0: [r4] := call build, [r0, r1]
+    1: [x0] := call build, [r2, r3]
+    2: r5 := eq r4, x0
+    3: ret [r5]
+}
+
+fun eq_len(r0, r1, r2): bool {
+  slots: params(3), locals(1), temps(2), xfer(2)
+    r0: u64
+    r1: u64
+    r2: u64
+    r3: vector<u64>
+    r4: &mut vector<u64>
+    r5: bool
+  code:
+  L0:
+    0: r3 := vec_pack u64, 0, []
+    1: r4 := mut_borrow_loc r3
+    2: vec_push_back u64, r4, r0
+    3: [x0] := call build, [r1, r2]
+    4: r5 := eq x0, r3
+    5: ret [r5]
+}
+=== micro-ops ===
+// module 0x1::test
+
+fun build() {
+  frame_data_size: 40
+  code:
+    0: Charge #74
+    1: VecNew [16]
+    2: SlotBorrow [24] <- &[16]
+    3: VecPushBack [24].push([0], size=8, desc=2)
+    4: SlotBorrow [24] <- &[16]
+    5: VecPushBack [24].push([8], size=8, desc=2)
+    6: Move8 [0] <- [16]
+    7: Return
+  safe_point_layouts:
+    3: []
+    5: []
+}
+
+fun cmp() {
+  frame_data_size: 48
+  code:
+    0: Charge #36
+    1: Move8 [80] <- [8]
+    2: Move8 [72] <- [0]
+    3: CallIndirect 0x1::test::build
+    4: Move8 [32] <- [72]
+    5: Move8 [80] <- [24]
+    6: Move8 [72] <- [16]
+    7: CallIndirect 0x1::test::build
+    8: JumpValueCmp @13 [32] != [72] : vector<u64>
+    9: Charge #6
+    10: StoreImm8 [40] <- #10
+    11: Move8 [0] <- [40]
+    12: Return
+    13: Charge #6
+    14: StoreImm8 [40] <- #42
+    15: Move8 [0] <- [40]
+    16: Return
+}
+
+fun eq() {
+  frame_data_size: 48
+  code:
+    0: Charge #43
+    1: Move8 [80] <- [8]
+    2: Move8 [72] <- [0]
+    3: CallIndirect 0x1::test::build
+    4: Move8 [32] <- [72]
+    5: Move8 [80] <- [24]
+    6: Move8 [72] <- [16]
+    7: CallIndirect 0x1::test::build
+    8: ValueCmp [40] <- [32] == [72] : vector<u64>
+    9: Move(1) [0] <- [40]
+    10: Return
+}
+
+fun eq_len() {
+  frame_data_size: 56
+  code:
+    0: Charge #67
+    1: VecNew [24]
+    2: SlotBorrow [32] <- &[24]
+    3: VecPushBack [32].push([0], size=8, desc=2)
+    4: Move8 [88] <- [16]
+    5: Move8 [80] <- [8]
+    6: CallIndirect 0x1::test::build
+    7: ValueCmp [48] <- [80] == [24] : vector<u64>
+    8: Move(1) [0] <- [48]
+    9: Return
+  safe_point_layouts:
+    3: []
+}

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/vectors/vec_eq.move
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/vectors/vec_eq.move
@@ -22,6 +22,19 @@ module 0x1::test {
     fun cmp(a0: u64, a1: u64, b0: u64, b1: u64): u64 {
         if (build(a0, a1) == build(b0, b1)) { 10 } else { 42 }
     }
+
+    // Equality through references to vectors (exercises `ValueRefCmp`).
+    fun eq_ref(a0: u64, a1: u64, b0: u64, b1: u64): bool {
+        let a = build(a0, a1);
+        let b = build(b0, b1);
+        &a == &b
+    }
+
+    fun neq_ref(a0: u64, a1: u64, b0: u64, b1: u64): bool {
+        let a = build(a0, a1);
+        let b = build(b0, b1);
+        &a != &b
+    }
 }
 
 // RUN: execute 0x1::test::eq --args 1, 2, 1, 2
@@ -38,3 +51,15 @@ module 0x1::test {
 
 // RUN: execute 0x1::test::cmp --args 5, 6, 5, 7
 // CHECK: results: 42
+
+// RUN: execute 0x1::test::eq_ref --args 1, 2, 1, 2
+// CHECK: results: true
+
+// RUN: execute 0x1::test::eq_ref --args 1, 2, 1, 9
+// CHECK: results: false
+
+// RUN: execute 0x1::test::neq_ref --args 1, 2, 1, 9
+// CHECK: results: true
+
+// RUN: execute 0x1::test::neq_ref --args 3, 4, 3, 4
+// CHECK: results: false

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/vectors/vec_eq.move
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/vectors/vec_eq.move
@@ -1,0 +1,40 @@
+// RUN: publish --print(bytecode,stackless,micro-ops)
+module 0x1::test {
+    use std::vector;
+
+    fun build(a: u64, b: u64): vector<u64> {
+        let v = vector::empty<u64>();
+        vector::push_back(&mut v, a);
+        vector::push_back(&mut v, b);
+        v
+    }
+
+    fun eq(a0: u64, a1: u64, b0: u64, b1: u64): bool {
+        build(a0, a1) == build(b0, b1)
+    }
+
+    fun eq_len(a0: u64, b0: u64, b1: u64): bool {
+        let a = vector::empty<u64>();
+        vector::push_back(&mut a, a0);
+        build(b0, b1) == a
+    }
+
+    fun cmp(a0: u64, a1: u64, b0: u64, b1: u64): u64 {
+        if (build(a0, a1) == build(b0, b1)) { 10 } else { 42 }
+    }
+}
+
+// RUN: execute 0x1::test::eq --args 1, 2, 1, 2
+// CHECK: results: true
+
+// RUN: execute 0x1::test::eq --args 1, 2, 1, 9
+// CHECK: results: false
+
+// RUN: execute 0x1::test::eq_len --args 1, 1, 2
+// CHECK: results: false
+
+// RUN: execute 0x1::test::cmp --args 5, 6, 5, 6
+// CHECK: results: 10
+
+// RUN: execute 0x1::test::cmp --args 5, 6, 5, 7
+// CHECK: results: 42


### PR DESCRIPTION
Adds structural equality (`==`/`!=`) for non-scalar values to the mono-move interpreter. Four micro-ops carry it: `ValueCmp`/`ValueRefCmp` produce a boolean, and `JumpValueCmp`/`JumpValueRefCmp` are their fused compare-and-branch forms; the `Ref` variants dereference their operands first. All four delegate to `value_utils::equals`, which walks the value's layout. The specializer classifies each `Eq`/`Neq` operand: flat scalars (integers, `bool`, `address`) keep using the existing `IntCmp`/`JumpIntCmp` path, aggregates compare by value, and references compare through the pointer. Ordering (`<`, `<=`, `>`, `>=`) stays integer-only, matching the bytecode verifier.

Tested with differential cases that run each function on both the legacy MoveVM and mono-move and compare the results: struct, vector, reference, and signer equality; nested shapes (a struct with a vector field, and a vector of structs); differing vector lengths; and both `==`/`!=` and the fused `if` form.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches interpreter comparison semantics and lowering for a core bytecode feature; risk is mitigated by verifier checks and differential tests against MoveVM, but nested structural walks could have edge-case bugs.
> 
> **Overview**
> Adds **structural `==` / `!=`** for aggregates in mono-move via four new micro-ops: `ValueCmp` / `ValueRefCmp` (boolean result) and fused `JumpValueCmp` / `JumpValueRefCmp`. The interpreter runs them through `value_utils::equals`; reference ops dereference 16-byte fat pointers first.
> 
> The **specializer** routes equality by operand kind: scalars (ints, `bool`, `address`, `signer`) still use `IntCmp` / `JumpIntCmp`; structs and vectors use `ValueCmp` / `JumpValueCmp`; references use the `ValueRef*` ops with the referent type. Ordering comparisons on non-scalars are rejected at lower time. **Signer** scalar equality is fixed to compare as 32-byte values like addresses.
> 
> **Gas**, CFG remapping, display, and the static **verifier** (frame bounds via `type_size`) are wired for the new ops. Differential tests cover struct/vector/ref/signer equality, nested shapes, and fused branches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87a361fe413b776567947fef0cd6c8b66b214d88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->