### PR TITLE
[api] Annotate closure captured arguments

### DIFF
--- a/api/src/tests/function_value_test.rs
+++ b/api/src/tests/function_value_test.rs
@@ -133,7 +133,7 @@ async fn test_function_values_with_captured_struct() {
         response["data"],
         json!({
             "f": {
-                "__captured__": [ {"_0": "1"} ],
+                "__captured__": [ {"value": "1", "extra": "2"} ],
                 "__fun_name__": &expected_name,
                 "__mask__": "1",
             }

--- a/api/src/tests/move/pack_function_values_with_struct/sources/test.move
+++ b/api/src/tests/move/pack_function_values_with_struct/sources/test.move
@@ -5,7 +5,10 @@ module account::test {
         f: ||R has copy+drop+store,
     }
 
-    struct R(u64) has copy, drop, key, store;
+    struct R has copy, drop, key, store {
+        value: u64,
+        extra: u64,
+    }
 
     public fun id(x: R): R {
         x
@@ -14,7 +17,7 @@ module account::test {
     struct R2<T: copy + drop +store>(T) has copy, drop, key, store;
 
     fun init_module(account: &signer) {
-        let v = R(1);
+        let v = R { value: 1, extra: 2 };
         let v2 = R2(option::none<u64>());
         let v3 = R2(option::some<u32>(1));
         let f: ||R has copy+drop+store = || id(v);

--- a/api/types/src/move_types.rs
+++ b/api/types/src/move_types.rs
@@ -3,9 +3,7 @@
 
 use crate::{Address, Bytecode, IdentifierWrapper, VerifyInput, VerifyInputWithRecursion};
 use anyhow::{bail, format_err};
-use aptos_resource_viewer::{
-    AnnotatedMoveClosure, AnnotatedMoveStruct, AnnotatedMoveValue, RawMoveStruct,
-};
+use aptos_resource_viewer::{AnnotatedMoveClosure, AnnotatedMoveStruct, AnnotatedMoveValue};
 use aptos_types::{account_config::CORE_CODE_ADDRESS, event::EventKey, transaction::Module};
 use move_binary_format::{
     access::ModuleAccess,
@@ -278,27 +276,6 @@ impl TryFrom<AnnotatedMoveStruct> for MoveStructValue {
     }
 }
 
-impl TryFrom<RawMoveStruct> for MoveStructValue {
-    type Error = anyhow::Error;
-
-    fn try_from(s: RawMoveStruct) -> anyhow::Result<Self> {
-        let mut map = BTreeMap::new();
-        if let Some(tag) = s.variant_info {
-            map.insert(
-                IdentifierWrapper::from_str("__variant_tag__")?,
-                MoveValue::U16(tag).json()?,
-            );
-        }
-        for (pos, val) in s.field_values.into_iter().enumerate() {
-            map.insert(
-                IdentifierWrapper::from_str(format!("_{}", pos).as_str())?,
-                MoveValue::try_from(val)?.json()?,
-            );
-        }
-        Ok(Self(map))
-    }
-}
-
 impl TryFrom<AnnotatedMoveClosure> for MoveStructValue {
     type Error = anyhow::Error;
 
@@ -441,7 +418,6 @@ impl TryFrom<AnnotatedMoveValue> for MoveValue {
                     MoveValue::Struct(v.try_into()?)
                 }
             },
-            AnnotatedMoveValue::RawStruct(v) => MoveValue::Struct(v.try_into()?),
             AnnotatedMoveValue::Closure(c) => MoveValue::Struct(c.try_into()?),
         })
     }

--- a/aptos-move/aptos-resource-viewer/src/lib.rs
+++ b/aptos-move/aptos-resource-viewer/src/lib.rs
@@ -19,7 +19,7 @@ use move_core_types::{
 };
 use move_resource_viewer::MoveValueAnnotator;
 pub use move_resource_viewer::{
-    AnnotatedMoveClosure, AnnotatedMoveStruct, AnnotatedMoveValue, MoveTableInfo, RawMoveStruct,
+    AnnotatedMoveClosure, AnnotatedMoveStruct, AnnotatedMoveValue, MoveTableInfo,
 };
 use std::sync::Arc;
 

--- a/aptos-move/e2e-move-tests/src/tests/function_values_annotated_captured_args.rs
+++ b/aptos-move/e2e-move-tests/src/tests/function_values_annotated_captured_args.rs
@@ -1,0 +1,253 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! On-demand annotation of a storable closure's captured arguments by the resource
+//! viewer. The captured values are stored with raw (nameless) layouts, but the viewer
+//! resolves their real types on-demand from the function signature, so the annotation
+//! carries proper struct and field names. These tests cover named structs, multiple
+//! captures, generic instantiation, captures from another module, and a non-captured
+//! reference parameter.
+
+use crate::{assert_success, MoveHarness};
+use aptos_package_builder::PackageBuilder;
+use aptos_resource_viewer::{AnnotatedMoveValue, AptosValueAnnotator};
+use aptos_types::account_address::AccountAddress;
+use claims::assert_ok;
+use move_core_types::{
+    ability::AbilitySet,
+    function::{ClosureMask, MoveClosure},
+    identifier::Identifier,
+    language_storage::{FunctionParamOrReturnTag, FunctionTag, ModuleId, TypeTag},
+    value::{MoveStruct, MoveStructLayout, MoveTypeLayout, MoveValue},
+};
+
+const OTHER_SOURCE: &str = r#"
+module 0xcafe::other {
+    struct Foreign has copy, drop, store { z: u64 }
+}
+"#;
+
+const M_SOURCE: &str = r#"
+module 0xcafe::m {
+    use 0xcafe::other::Foreign;
+
+    struct S has copy, drop, store { x: u64, y: bool }
+    struct Wrapper<T: copy + drop + store> has copy, drop, store { val: T }
+
+    public fun cap_named(s: S, k: u64): u64 { s.x + k }
+    public fun cap_two(a: S, b: u64): u64 { a.x + b }
+    public fun cap_generic<T: copy + drop + store>(_w: Wrapper<T>, k: u64): u64 { k }
+    public fun cap_foreign(_f: Foreign, k: u64): u64 { k }
+    public fun cap_with_ref(s: S, _r: &u64): u64 { s.x }
+}
+"#;
+
+fn publish() -> (MoveHarness, AccountAddress) {
+    let account_address = AccountAddress::from_hex_literal("0xcafe").unwrap();
+    let mut builder = PackageBuilder::new("M");
+    builder.add_source("other.move", OTHER_SOURCE);
+    builder.add_source("m.move", M_SOURCE);
+    let path = builder.write_to_temp().unwrap();
+
+    let mut h = MoveHarness::new();
+    let acc = h.new_account_at(account_address);
+    assert_success!(h.publish_package(&acc, path.path()));
+    (h, account_address)
+}
+
+/// A function type tag standing for the residual closure type. Its exact shape does
+/// not affect captured-argument annotation, which resolves layouts from the function.
+fn fun_tag() -> TypeTag {
+    TypeTag::Function(Box::new(FunctionTag {
+        args: vec![FunctionParamOrReturnTag::Value(TypeTag::U64)],
+        results: vec![FunctionParamOrReturnTag::Value(TypeTag::U64)],
+        abilities: AbilitySet::PUBLIC_FUNCTIONS,
+    }))
+}
+
+/// A runtime struct layout + value built from per-field `(layout, value)` pairs. This
+/// is the nameless form a closure stores its captured struct as.
+fn runtime_struct(fields: Vec<(MoveTypeLayout, MoveValue)>) -> (MoveTypeLayout, MoveValue) {
+    let (layouts, values): (Vec<_>, Vec<_>) = fields.into_iter().unzip();
+    (
+        MoveTypeLayout::new_struct(MoveStructLayout::Runtime(layouts)),
+        MoveValue::Struct(MoveStruct::Runtime(values)),
+    )
+}
+
+/// Serializes a closure over `addr::module::fun<ty_args>` capturing `captured` (each a
+/// `(layout, value)` pair, as stored on chain).
+fn serialize_closure(
+    addr: AccountAddress,
+    module: &str,
+    fun: &str,
+    ty_args: Vec<TypeTag>,
+    mask: ClosureMask,
+    captured: Vec<(MoveTypeLayout, MoveValue)>,
+) -> Vec<u8> {
+    MoveValue::Closure(Box::new(MoveClosure {
+        module_id: ModuleId::new(addr, Identifier::new(module).unwrap()),
+        fun_id: Identifier::new(fun).unwrap(),
+        ty_args,
+        mask,
+        captured,
+    }))
+    .simple_serialize()
+    .unwrap()
+}
+
+/// Annotates a closure blob and returns its captured values.
+fn annotate_captured(h: &MoveHarness, blob: &[u8]) -> Vec<AnnotatedMoveValue> {
+    let annotator = AptosValueAnnotator::new(h.executor.state_store());
+    match assert_ok!(annotator.view_value(&fun_tag(), blob)) {
+        AnnotatedMoveValue::Closure(c) => c.captured,
+        other => panic!("expected a closure, got {:?}", other),
+    }
+}
+
+fn annotate_single_captured(h: &MoveHarness, blob: &[u8]) -> AnnotatedMoveValue {
+    let captured = annotate_captured(h, blob);
+    assert_eq!(captured.len(), 1, "expected exactly one captured value");
+    captured.into_iter().next().unwrap()
+}
+
+/// Returns `(struct_name, [(field_name, debug_value)])` for a captured struct.
+fn struct_fields(value: &AnnotatedMoveValue) -> (String, Vec<(String, String)>) {
+    match value {
+        AnnotatedMoveValue::Struct(s) => (
+            s.ty_tag.name.as_str().to_string(),
+            s.value
+                .iter()
+                .map(|(f, v)| (f.as_str().to_string(), format!("{:?}", v)))
+                .collect(),
+        ),
+        other => panic!("expected a struct, got {:?}", other),
+    }
+}
+
+/// The captured struct `S { x: 42, y: true }` annotates with its real field names.
+#[test]
+fn named_struct_captured_arg() {
+    let (h, addr) = publish();
+
+    let captured = runtime_struct(vec![
+        (MoveTypeLayout::U64, MoveValue::U64(42)),
+        (MoveTypeLayout::Bool, MoveValue::Bool(true)),
+    ]);
+    let blob = serialize_closure(addr, "m", "cap_named", vec![], ClosureMask::new(0b1), vec![
+        captured,
+    ]);
+
+    let (name, fields) = struct_fields(&annotate_single_captured(&h, &blob));
+    assert_eq!(name, "S");
+    assert_eq!(fields, vec![
+        ("x".to_string(), "U64(42)".to_string()),
+        ("y".to_string(), "Bool(true)".to_string()),
+    ]);
+}
+
+/// Two captured arguments of different types (`S { x: 42, y: true }` and `7u64`) are
+/// annotated, named, and in order.
+#[test]
+fn multiple_captured_args() {
+    let (h, addr) = publish();
+
+    let s = runtime_struct(vec![
+        (MoveTypeLayout::U64, MoveValue::U64(42)),
+        (MoveTypeLayout::Bool, MoveValue::Bool(true)),
+    ]);
+    let blob = serialize_closure(addr, "m", "cap_two", vec![], ClosureMask::new(0b11), vec![
+        s,
+        (MoveTypeLayout::U64, MoveValue::U64(7)),
+    ]);
+
+    let captured = annotate_captured(&h, &blob);
+    assert_eq!(captured.len(), 2);
+    let (name, fields) = struct_fields(&captured[0]);
+    assert_eq!(name, "S");
+    assert_eq!(fields, vec![
+        ("x".to_string(), "U64(42)".to_string()),
+        ("y".to_string(), "Bool(true)".to_string()),
+    ]);
+    assert!(matches!(&captured[1], AnnotatedMoveValue::U64(v) if *v == 7));
+}
+
+/// A generic function's captured argument is resolved with the closure's type
+/// arguments substituted in: `Wrapper<u64> { val: 7 }`.
+#[test]
+fn generic_capture_substitutes_type_arguments() {
+    let (h, addr) = publish();
+
+    let captured = runtime_struct(vec![(MoveTypeLayout::U64, MoveValue::U64(7))]);
+    let blob = serialize_closure(
+        addr,
+        "m",
+        "cap_generic",
+        vec![TypeTag::U64],
+        ClosureMask::new(0b1),
+        vec![captured],
+    );
+
+    match annotate_single_captured(&h, &blob) {
+        AnnotatedMoveValue::Struct(s) => {
+            assert_eq!(s.ty_tag.name.as_str(), "Wrapper");
+            assert_eq!(s.ty_tag.type_args, vec![TypeTag::U64]);
+            let (field, field_value) = &s.value[0];
+            assert_eq!(field.as_str(), "val");
+            assert!(matches!(field_value, AnnotatedMoveValue::U64(v) if *v == 7));
+        },
+        other => panic!("expected named struct, got {:?}", other),
+    }
+}
+
+/// Only the captured parameter is resolved. A non-captured reference parameter
+/// (`_r: &u64`) must be skipped, not resolved (references cannot be annotated).
+#[test]
+fn capture_skips_non_captured_reference_param() {
+    let (h, addr) = publish();
+
+    let captured = runtime_struct(vec![
+        (MoveTypeLayout::U64, MoveValue::U64(5)),
+        (MoveTypeLayout::Bool, MoveValue::Bool(false)),
+    ]);
+    let blob = serialize_closure(
+        addr,
+        "m",
+        "cap_with_ref",
+        vec![],
+        ClosureMask::new(0b1),
+        vec![captured],
+    );
+
+    let (name, fields) = struct_fields(&annotate_single_captured(&h, &blob));
+    assert_eq!(name, "S");
+    assert_eq!(fields[0].0, "x");
+}
+
+/// A captured struct defined in a different module than the function is resolved
+/// across the module boundary: `other::Foreign { z: 9 }`.
+#[test]
+fn captured_struct_from_other_module() {
+    let (h, addr) = publish();
+
+    let captured = runtime_struct(vec![(MoveTypeLayout::U64, MoveValue::U64(9))]);
+    let blob = serialize_closure(
+        addr,
+        "m",
+        "cap_foreign",
+        vec![],
+        ClosureMask::new(0b1),
+        vec![captured],
+    );
+
+    match annotate_single_captured(&h, &blob) {
+        AnnotatedMoveValue::Struct(s) => {
+            assert_eq!(s.ty_tag.module.as_str(), "other");
+            assert_eq!(s.ty_tag.name.as_str(), "Foreign");
+            let (field, field_value) = &s.value[0];
+            assert_eq!(field.as_str(), "z");
+            assert!(matches!(field_value, AnnotatedMoveValue::U64(v) if *v == 9));
+        },
+        other => panic!("expected named struct, got {:?}", other),
+    }
+}

--- a/aptos-move/e2e-move-tests/src/tests/mod.rs
+++ b/aptos-move/e2e-move-tests/src/tests/mod.rs
@@ -30,6 +30,7 @@ mod function_caches;
 mod function_value_depth;
 mod function_value_layout_dag;
 mod function_values;
+mod function_values_annotated_captured_args;
 mod fungible_asset;
 mod fv_as_table_keys;
 mod gas;

--- a/third_party/move/tools/move-resource-viewer/src/fat_type.rs
+++ b/third_party/move/tools/move-resource-viewer/src/fat_type.rs
@@ -68,11 +68,6 @@ pub(crate) enum FatType {
     U256,
     // NOTE: Added in bytecode version v8, do not reorder!
     Function(Box<FatFunctionType>),
-    // `Runtime` and `RuntimeVariants` are used for typing
-    // captured structures in closures, for which we only know
-    // the raw layout (no struct name, no field names).
-    Runtime(Vec<FatType>),
-    RuntimeVariants(Vec<Vec<FatType>>),
     // NOTE: Added in bytecode version v9, do not reorder!
     I8,
     I16,
@@ -317,17 +312,7 @@ impl FatType {
             MutableReference(ty) => MutableReference(Box::new(ty.clone_with_limit(limit)?)),
             Struct(struct_ty) => Struct(struct_ty.clone()),
             Function(fun_ty) => Function(Box::new(fun_ty.clone_with_limit(limit)?)),
-            Runtime(tys) => Runtime(Self::clone_with_limit_slice(tys, limit)?),
-            RuntimeVariants(vars) => RuntimeVariants(
-                vars.iter()
-                    .map(|tys| Self::clone_with_limit_slice(tys, limit))
-                    .collect::<PartialVMResult<Vec<_>>>()?,
-            ),
         })
-    }
-
-    fn clone_with_limit_slice(tys: &[Self], limit: &mut Limiter) -> PartialVMResult<Vec<Self>> {
-        tys.iter().map(|ty| ty.clone_with_limit(limit)).collect()
     }
 
     pub fn subst(
@@ -389,20 +374,6 @@ impl FatType {
             },
 
             Function(fun_ty) => Function(Box::new(fun_ty.subst(ty_args, subst_struct, limit)?)),
-            Runtime(tys) => Runtime(
-                tys.iter()
-                    .map(|ty| ty.subst(ty_args, subst_struct, limit))
-                    .collect::<PartialVMResult<Vec<_>>>()?,
-            ),
-            RuntimeVariants(vars) => RuntimeVariants(
-                vars.iter()
-                    .map(|tys| {
-                        tys.iter()
-                            .map(|ty| ty.subst(ty_args, subst_struct, limit))
-                            .collect::<PartialVMResult<Vec<_>>>()
-                    })
-                    .collect::<PartialVMResult<Vec<Vec<_>>>>()?,
-            ),
         };
 
         Ok(res)
@@ -431,7 +402,7 @@ impl FatType {
             Struct(struct_ty) => TypeTag::Struct(Box::new(struct_ty.struct_tag(limit)?)),
             Function(fun_ty) => TypeTag::Function(Box::new(fun_ty.fun_tag(limit)?)),
 
-            Reference(_) | MutableReference(_) | TyParam(_) | RuntimeVariants(_) | Runtime(..) => {
+            Reference(_) | MutableReference(_) | TyParam(_) => {
                 return Err(
                     PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
                         .with_message(format!("cannot derive type tag for {:?}", self)),
@@ -442,83 +413,12 @@ impl FatType {
         Ok(res)
     }
 
-    pub(crate) fn from_runtime_layout(
-        layout: &MoveTypeLayout,
-        limit: &mut Limiter,
-    ) -> PartialVMResult<FatType> {
-        use MoveTypeLayout::*;
-        Ok(match layout {
-            Bool => FatType::Bool,
-            U8 => FatType::U8,
-            U16 => FatType::U16,
-            U32 => FatType::U32,
-            U64 => FatType::U64,
-            U128 => FatType::U128,
-            U256 => FatType::U256,
-            I8 => FatType::I8,
-            I16 => FatType::I16,
-            I32 => FatType::I32,
-            I64 => FatType::I64,
-            I128 => FatType::I128,
-            I256 => FatType::I256,
-            Address => FatType::Address,
-            Signer => FatType::Signer,
-            Vector(ty) => FatType::Vector(Box::new(Self::from_runtime_layout(ty, limit)?)),
-            Struct(struct_layout) => match struct_layout.as_ref() {
-                MoveStructLayout::Runtime(tys) => {
-                    FatType::Runtime(Self::from_layout_slice(tys, limit)?)
-                },
-                MoveStructLayout::RuntimeVariants(vars) => FatType::RuntimeVariants(
-                    vars.iter()
-                        .map(|tys| Self::from_layout_slice(tys, limit))
-                        .collect::<PartialVMResult<Vec<Vec<_>>>>()?,
-                ),
-                _ => {
-                    return Err(PartialVMError::new_invariant_violation(format!(
-                        "cannot derive fat type for {:?}",
-                        layout
-                    )))
-                },
-            },
-            Function => {
-                // We cannot derive the actual type from layout, however, a dummy
-                // function type will do since annotation of closures is not depending
-                // actually on their type, but only their (hidden) captured arguments.
-                // Currently, `from_runtime_layout` is only used to annotate captured arguments
-                // of closures.
-                FatType::Function(Box::new(FatFunctionType {
-                    args: vec![],
-                    results: vec![],
-                    abilities: AbilitySet::EMPTY,
-                }))
-            },
-            Native(..) => {
-                return Err(PartialVMError::new_invariant_violation(format!(
-                    "cannot derive fat type for {:?}",
-                    layout
-                )))
-            },
-        })
-    }
-
-    fn from_layout_slice(
-        layouts: &[MoveTypeLayout],
-        limit: &mut Limiter,
-    ) -> PartialVMResult<Vec<FatType>> {
-        layouts
-            .iter()
-            .map(|l| Self::from_runtime_layout(l, limit))
-            .collect()
-    }
-
     pub(crate) fn contains_tables(&self) -> bool {
         match self {
             FatType::Struct(st) => st.contains_tables,
             FatType::MutableReference(ty) | FatType::Reference(ty) | FatType::Vector(ty) => {
                 ty.contains_tables()
             },
-            FatType::Runtime(tys) => tys.iter().any(|ty| ty.contains_tables()),
-            FatType::RuntimeVariants(vars) => vars.iter().flatten().any(|ty| ty.contains_tables()),
             FatType::Bool
             | FatType::U8
             | FatType::U64
@@ -620,16 +520,6 @@ impl FatType {
                 MoveTypeLayout::Struct(layout)
             },
             FatType::Function(_) => MoveTypeLayout::Function,
-            FatType::Runtime(tys) => {
-                MoveTypeLayout::new_struct(MoveStructLayout::Runtime(into_types(tys, memo)?))
-            },
-            FatType::RuntimeVariants(vars) => {
-                MoveTypeLayout::new_struct(MoveStructLayout::RuntimeVariants(
-                    vars.iter()
-                        .map(|tys| into_types(tys, memo))
-                        .collect::<Result<Vec<_>, _>>()?,
-                ))
-            },
             FatType::Signer => MoveTypeLayout::Signer,
             FatType::Reference(_) | FatType::MutableReference(_) | FatType::TyParam(_) => {
                 return Err(PartialVMError::new(StatusCode::ABORT_TYPE_MISMATCH_ERROR))

--- a/third_party/move/tools/move-resource-viewer/src/lib.rs
+++ b/third_party/move/tools/move-resource-viewer/src/lib.rs
@@ -53,16 +53,7 @@ pub struct AnnotatedMoveStruct {
     pub value: Vec<(Identifier, AnnotatedMoveValue)>,
 }
 
-/// Used to represent raw struct data, without struct name and field names. This stems
-/// from closure capture values for which only the serialization layout is known.
-#[derive(Clone, Debug)]
-pub struct RawMoveStruct {
-    pub variant_info: Option<u16>,
-    pub field_values: Vec<AnnotatedMoveValue>,
-}
-
-/// Used to represent an annotated closure. The `captured` values will have only
-/// `RawMoveStruct` information and are not fully decorated.
+/// Used to represent an annotated closure.
 #[derive(Clone, Debug)]
 pub struct AnnotatedMoveClosure {
     pub module_id: ModuleId,
@@ -92,7 +83,6 @@ pub enum AnnotatedMoveValue {
     U256(int256::U256),
     // NOTE: Added in v8
     Closure(AnnotatedMoveClosure),
-    RawStruct(RawMoveStruct),
     // NOTE: Added in bytecode version v9, do not reorder!
     I8(i8),
     I16(i16),
@@ -205,10 +195,7 @@ impl<V: CompiledModuleView> MoveValueAnnotator<V> {
         let types: Vec<&FatType> = param_tys
             .iter()
             .filter(|t| match t {
-                FatType::Signer
-                | FatType::Function(_)
-                | FatType::Runtime(_)
-                | FatType::RuntimeVariants(_) => false,
+                FatType::Signer | FatType::Function(_) => false,
                 FatType::Reference(inner) => !matches!(&**inner, FatType::Signer),
                 FatType::Bool
                 | FatType::U8
@@ -815,38 +802,6 @@ impl<V: CompiledModuleView> MoveValueAnnotator<V> {
         }
     }
 
-    fn annotate_raw_struct(
-        &self,
-        move_struct: &MoveStruct,
-        ty: &FatType,
-        limit: &mut Limiter,
-    ) -> anyhow::Result<RawMoveStruct> {
-        let annotate_values = |values: &[MoveValue], tys: &[FatType], limit: &mut Limiter| {
-            values
-                .iter()
-                .zip(tys)
-                .map(|(v, ty)| self.annotate_value(v, ty, limit))
-                .collect::<anyhow::Result<Vec<_>>>()
-        };
-        match (move_struct, ty) {
-            (MoveStruct::Runtime(values), FatType::Runtime(tys)) if values.len() == tys.len() => {
-                Ok(RawMoveStruct {
-                    variant_info: None,
-                    field_values: annotate_values(values, tys, limit)?,
-                })
-            },
-            (MoveStruct::RuntimeVariant(tag, values), FatType::RuntimeVariants(vars))
-                if (*tag as usize) < vars.len() && values.len() == vars[*tag as usize].len() =>
-            {
-                Ok(RawMoveStruct {
-                    variant_info: Some(*tag),
-                    field_values: annotate_values(values, &vars[*tag as usize], limit)?,
-                })
-            },
-            _ => bail!("type and value mismatch: inconsistent raw struct information"),
-        }
-    }
-
     fn annotate_closure(
         &self,
         move_closure: &MoveClosure,
@@ -860,13 +815,22 @@ impl<V: CompiledModuleView> MoveValueAnnotator<V> {
             mask,
             captured,
         } = move_closure;
+
+        // Resolve the captured argument types on-demand from the function signature.
+        // This gives fully named annotations (real struct and field names) instead of
+        // the raw, nameless layouts stored with the closure, at the cost of requiring
+        // the defining module to be loadable at the read version.
+        let captured_tys = self.resolve_captured_types(module_id, fun_id, ty_args, *mask, limit)?;
+        anyhow::ensure!(
+            captured.len() == captured_tys.len(),
+            "captured value/type count mismatch: {} values, {} types",
+            captured.len(),
+            captured_tys.len(),
+        );
         let captured = captured
             .iter()
-            .map(|(layout, value)| {
-                let fat_type = FatType::from_runtime_layout(layout, limit)
-                    .map_err(|e| anyhow!("failed to annotate captured value: {}", e))?;
-                self.annotate_value(value, &fat_type, limit)
-            })
+            .zip(&captured_tys)
+            .map(|((_layout, value), ty)| self.annotate_value(value, ty, limit))
             .collect::<anyhow::Result<Vec<_>>>()?;
         Ok(AnnotatedMoveClosure {
             module_id: module_id.clone(),
@@ -875,6 +839,90 @@ impl<V: CompiledModuleView> MoveValueAnnotator<V> {
             mask: *mask,
             captured,
         })
+    }
+
+    /// Resolves the types of a closure's captured arguments from the function
+    /// signature: the captured parameters are selected by the closure mask, then the
+    /// closure's type arguments are substituted in. The resulting types are fully
+    /// named (carry struct and field names), unlike the closure's stored layouts.
+    fn resolve_captured_types(
+        &self,
+        module_id: &ModuleId,
+        fun_id: &IdentStr,
+        ty_args: &[TypeTag],
+        mask: ClosureMask,
+        limit: &mut Limiter,
+    ) -> anyhow::Result<Vec<FatType>> {
+        if mask.captured_count() == 0 {
+            return Ok(vec![]);
+        }
+        let captured_tys = self.resolve_captured_parameter_types(module_id, fun_id, mask, limit)?;
+
+        let ty_args = ty_args
+            .iter()
+            .map(|ty| self.resolve_type_impl(ty, limit))
+            .collect::<anyhow::Result<Vec<_>>>()?;
+        captured_tys
+            .into_iter()
+            .map(|ty| {
+                if ty_args.is_empty() {
+                    Ok(ty)
+                } else {
+                    ty.subst(&ty_args, &self.struct_substitutor(), limit)
+                        .map_err(anyhow::Error::from)
+                }
+            })
+            .collect::<anyhow::Result<Vec<_>>>()
+    }
+
+    /// Resolves only the captured parameter types of a function, selected by the
+    /// closure mask. Only the captured parameters are resolved: non-captured ones may
+    /// be references (which cannot be captured), and resolving those would fail.
+    fn resolve_captured_parameter_types(
+        &self,
+        module_id: &ModuleId,
+        fun_id: &IdentStr,
+        mask: ClosureMask,
+        limit: &mut Limiter,
+    ) -> anyhow::Result<Vec<FatType>> {
+        let module = self.view_existing_module(module_id)?;
+        let module = module.borrow();
+
+        // Pseudo-cost for loading + scanning this module's function table. Bounds the
+        // amplification where a vector of small closures forces repeated module loads
+        // and O(functions) scans; the captured data itself is already size-bounded.
+        limit.charge(10 * module.function_defs.len())?;
+
+        for def in module.function_defs.iter() {
+            let fhandle = module.function_handle_at(def.function);
+            let fhandle_view = FunctionHandleView::new(module, fhandle);
+            if fhandle_view.name() == fun_id {
+                let captured_tokens = mask.extract(&fhandle_view.parameters().0, true);
+                // A well-formed closure only sets mask bits for real parameters.
+                // `extract` ignores bits past the parameter list, so without this
+                // check a mask claiming more captured args than the function has
+                // would (in the V2 format) silently decode fewer captured values
+                // than the mask implies.
+                anyhow::ensure!(
+                    captured_tokens.len() == mask.captured_count() as usize,
+                    "closure mask captures {} arguments but `{}` has only {} capturable parameters",
+                    mask.captured_count(),
+                    fun_id,
+                    captured_tokens.len(),
+                );
+                return captured_tokens
+                    .into_iter()
+                    .map(|tok| {
+                        self.resolve_signature(BinaryIndexedView::Module(module), tok, limit)
+                    })
+                    .collect();
+            }
+        }
+        Err(anyhow!(
+            "Function {:?} not found in {:?}",
+            fun_id,
+            module_id
+        ))
     }
 
     fn annotate_value(
@@ -916,9 +964,6 @@ impl<V: CompiledModuleView> MoveValueAnnotator<V> {
             },
             (MoveValue::Struct(s), FatType::Struct(ty)) => {
                 AnnotatedMoveValue::Struct(self.annotate_struct(s, ty.as_ref(), limit)?)
-            },
-            (MoveValue::Struct(s), FatType::Runtime(_) | FatType::RuntimeVariants(_)) => {
-                AnnotatedMoveValue::RawStruct(self.annotate_raw_struct(s, ty, limit)?)
             },
             (MoveValue::Closure(c), FatType::Function(ty)) => {
                 AnnotatedMoveValue::Closure(self.annotate_closure(c, ty, limit)?)
@@ -1007,21 +1052,6 @@ impl<V: CompiledModuleView> MoveValueAnnotator<V> {
                     Ok(())
                 }
             },
-            (FatType::Runtime(tys), MoveValue::Struct(MoveStruct::Runtime(vals))) => {
-                for (ty, val) in tys.iter().zip(vals) {
-                    self.collect_table_info_from_value(ty, val, limit, infos)?
-                }
-                Ok(())
-            },
-            (
-                FatType::RuntimeVariants(vars),
-                MoveValue::Struct(MoveStruct::RuntimeVariant(tag, vals)),
-            ) if (tag as usize) < vars.len() => {
-                for (ty, val) in vars[tag as usize].iter().zip(vals) {
-                    self.collect_table_info_from_value(ty, val, limit, infos)?
-                }
-                Ok(())
-            },
 
             // Every other combo cannot harbor tables.
             (FatType::Bool, _)
@@ -1038,8 +1068,6 @@ impl<V: CompiledModuleView> MoveValueAnnotator<V> {
             | (FatType::Reference(_), _)
             | (FatType::MutableReference(_), _)
             | (FatType::TyParam(_), _)
-            | (FatType::Runtime(_), _)
-            | (FatType::RuntimeVariants(_), _)
             | (FatType::Function(_), _)
             | (FatType::I8, _)
             | (FatType::I16, _)
@@ -1111,7 +1139,6 @@ fn pretty_print_value(
         },
         AnnotatedMoveValue::Bytes(v) => write!(f, "{}", hex::encode(v)),
         AnnotatedMoveValue::Struct(s) => pretty_print_struct(f, s, indent),
-        AnnotatedMoveValue::RawStruct(s) => pretty_print_raw_struct(f, s, indent),
         AnnotatedMoveValue::Closure(c) => pretty_print_closure(f, c, indent),
     }
 }
@@ -1134,27 +1161,6 @@ fn pretty_print_struct(
         writeln!(f)?;
     }
     write_indent(f, indent)?;
-    write!(f, "}}")
-}
-
-fn pretty_print_raw_struct(
-    f: &mut Formatter,
-    value: &RawMoveStruct,
-    indent: u64,
-) -> std::fmt::Result {
-    let RawMoveStruct {
-        variant_info,
-        field_values: value,
-    } = value;
-    if let Some(var) = variant_info {
-        write!(f, "#{}", var)?
-    }
-    writeln!(f, "{{")?;
-    for elem in value {
-        write_indent(f, indent + 4)?;
-        pretty_print_value(f, elem, indent + 4)?;
-        writeln!(f)?
-    }
     write!(f, "}}")
 }
 
@@ -1232,22 +1238,6 @@ impl serde::Serialize for AnnotatedMoveStruct {
         }
         for (f, v) in &self.value {
             s.serialize_entry(f, v)?
-        }
-        s.end()
-    }
-}
-
-impl serde::Serialize for RawMoveStruct {
-    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut s;
-        if let Some(tag) = &self.variant_info {
-            s = serializer.serialize_map(Some(self.field_values.len() + 1))?;
-            s.serialize_entry("$variant_tag", tag)?;
-        } else {
-            s = serializer.serialize_map(Some(self.field_values.len()))?;
-        }
-        for (i, v) in self.field_values.iter().enumerate() {
-            s.serialize_entry(&i, v)?
         }
         s.end()
     }
@@ -1360,7 +1350,6 @@ impl serde::Serialize for AnnotatedMoveValue {
                 }
             },
             Struct(s) => s.serialize(serializer),
-            RawStruct(s) => s.serialize(serializer),
             Closure(c) => c.serialize(serializer),
         }
     }

--- a/third_party/move/tools/move-resource-viewer/src/lib.rs
+++ b/third_party/move/tools/move-resource-viewer/src/lib.rs
@@ -40,6 +40,7 @@ use std::{
     collections::BTreeMap,
     convert::{TryFrom, TryInto},
     fmt::{Display, Formatter},
+    rc::Rc,
 };
 
 mod fat_type;
@@ -113,7 +114,15 @@ pub struct MoveValueAnnotator<V> {
     fat_struct_inst_cache: RefCell<BTreeMap<(StructName, Vec<FatType>), FatStructRef>>,
     /// A cache for whether type tags represent types with tables
     contains_tables_cache: RefCell<BTreeMap<TypeTag, bool>>,
+    /// Caches resolved captured types per closure signature, so many closures
+    /// with the same signature resolve only once. Like the caches above, this
+    /// affects the `Limiter`, which is fine on a read path.
+    captured_tys_cache: RefCell<BTreeMap<ClosureCapturedTysCacheKey, Rc<Vec<FatType>>>>,
 }
+
+/// Cache key for resolved captured types: the closure's defining module,
+/// function, type arguments, and capture mask.
+type ClosureCapturedTysCacheKey = (ModuleId, Identifier, Vec<TypeTag>, ClosureMask);
 
 impl<V: CompiledModuleView> MoveValueAnnotator<V> {
     pub fn new(module_viewer: V) -> Self {
@@ -122,6 +131,7 @@ impl<V: CompiledModuleView> MoveValueAnnotator<V> {
             fat_struct_def_cache: RefCell::default(),
             fat_struct_inst_cache: RefCell::default(),
             contains_tables_cache: RefCell::default(),
+            captured_tys_cache: RefCell::default(),
         }
     }
 
@@ -734,6 +744,13 @@ impl<V: CompiledModuleView> MoveValueAnnotator<V> {
         }
 
         let annotate_values = |values: &[MoveValue], tys: &[FatType], limit: &mut Limiter| {
+            anyhow::ensure!(
+                values.len() == tys.len() && tys.len() == field_names.len(),
+                "struct field count mismatch: {} values, {} types, {} names",
+                values.len(),
+                tys.len(),
+                field_names.len(),
+            );
             values
                 .iter()
                 .zip(tys)
@@ -821,6 +838,7 @@ impl<V: CompiledModuleView> MoveValueAnnotator<V> {
         // the raw, nameless layouts stored with the closure, at the cost of requiring
         // the defining module to be loadable at the read version.
         let captured_tys = self.resolve_captured_types(module_id, fun_id, ty_args, *mask, limit)?;
+        let captured_tys = captured_tys.as_deref().map_or(&[][..], Vec::as_slice);
         anyhow::ensure!(
             captured.len() == captured_tys.len(),
             "captured value/type count mismatch: {} values, {} types",
@@ -829,7 +847,7 @@ impl<V: CompiledModuleView> MoveValueAnnotator<V> {
         );
         let captured = captured
             .iter()
-            .zip(&captured_tys)
+            .zip(captured_tys)
             .map(|((_layout, value), ty)| self.annotate_value(value, ty, limit))
             .collect::<anyhow::Result<Vec<_>>>()?;
         Ok(AnnotatedMoveClosure {
@@ -852,17 +870,22 @@ impl<V: CompiledModuleView> MoveValueAnnotator<V> {
         ty_args: &[TypeTag],
         mask: ClosureMask,
         limit: &mut Limiter,
-    ) -> anyhow::Result<Vec<FatType>> {
+    ) -> anyhow::Result<Option<Rc<Vec<FatType>>>> {
         if mask.captured_count() == 0 {
-            return Ok(vec![]);
+            return Ok(None);
         }
+        let key = (module_id.clone(), fun_id.to_owned(), ty_args.to_vec(), mask);
+        if let Some(tys) = self.captured_tys_cache.borrow().get(&key) {
+            return Ok(Some(tys.clone()));
+        }
+
         let captured_tys = self.resolve_captured_parameter_types(module_id, fun_id, mask, limit)?;
 
         let ty_args = ty_args
             .iter()
             .map(|ty| self.resolve_type_impl(ty, limit))
             .collect::<anyhow::Result<Vec<_>>>()?;
-        captured_tys
+        let resolved = captured_tys
             .into_iter()
             .map(|ty| {
                 if ty_args.is_empty() {
@@ -872,7 +895,13 @@ impl<V: CompiledModuleView> MoveValueAnnotator<V> {
                         .map_err(anyhow::Error::from)
                 }
             })
-            .collect::<anyhow::Result<Vec<_>>>()
+            .collect::<anyhow::Result<Vec<_>>>()?;
+
+        let resolved = Rc::new(resolved);
+        self.captured_tys_cache
+            .borrow_mut()
+            .insert(key, resolved.clone());
+        Ok(Some(resolved))
     }
 
     /// Resolves only the captured parameter types of a function, selected by the


### PR DESCRIPTION
## Description

The resource viewer annotated a closure's captured values from the raw, nameless layouts stored with the closure, so a captured struct came out with positional field names (`_0`, `_1`). This change resolves the captured argument types **on-demand from the function signature** instead, so the annotation carries the real struct and field names.

- For each captured argument, the viewer looks up the function's parameter at the captured position (selected by the closure mask), substitutes the closure's type arguments, and annotates the stored value with that named type — ignoring the stored nameless layout.
- The resolution is metered through the existing annotation limiter and bounded, so a resource holding a vector of closures cannot turn one read into unbounded module loading + function-table scanning.
- The now-unreachable raw-struct annotation path (`RawMoveStruct` / `from_runtime_layout`) is removed.

Trade-off: annotating a closure now requires the defining module to be loadable at the read version (the old raw path needed none). This is acceptable for the read/display path.

A layout-free **V2** closure format (captured values as an opaque blob, inline layouts dropped) is **deferred** — it will be added separately, per discussion with the team.

## How Has This Been Tested?

- `aptos-api` `test_function_values*`: a stored closure capturing a named-field struct now annotates as `{"value": "1", "extra": "2"}` through the full API (VM stores the closure → resource viewer → JSON).
- New e2e suite `function_values_annotated_captured_args`: named struct, multiple captures, generic instantiation, cross-module struct, and a non-captured reference parameter.
- `move-core-types` / `move-vm-types` closure (de)serialization round-trips unchanged.

## Key Areas to Review

- `move-resource-viewer` `annotate_closure` + `resolve_captured_types` / `resolve_captured_parameter_types`: on-demand resolution, the zero-capture short-circuit, the limiter charge, and the mask-vs-arity check.
- Removal of the raw-struct path (`RawMoveStruct`, `from_runtime_layout`, `FatType::Runtime`/`RuntimeVariants`).

## Type of Change
- [x] New feature

## Which Components or Systems Does This Change Impact?
- [x] Full Node (API, Indexer, etc.)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes full-node read/display behavior and API JSON shape for closure captures, and adds on-demand module loading during annotation (mitigated by limiter bounds).
> 
> **Overview**
> Closure **captured arguments** in resource/API JSON are now annotated using **types from the defining function’s signature** (closure mask + type-arg substitution), not the **nameless runtime layouts** stored on chain—so captures show **real struct and field names** (e.g. `value` / `extra` instead of `_0`).
> 
> The resource viewer adds **`resolve_captured_types`** with a **signature cache** and **limiter charge** on module/function lookup; it **drops** the old **`RawMoveStruct`** / **`FatType::Runtime`** path and related API conversion. **Annotating a closure now requires the defining module** at the read version.
> 
> New **e2e** and **API** tests cover named captures, generics, cross-module structs, and skipping non-captured reference params.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3f139026f1f0bd50b927cf0b8e06a96640d6bd6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->