### PR TITLE
[mono-move] LdConst vector support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18444,7 +18444,6 @@ name = "specializer"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "bcs 0.1.4",
  "mono-move-core",
  "mono-move-gas",
  "move-binary-format",

--- a/third_party/move/mono-move/core/src/function.rs
+++ b/third_party/move/mono-move/core/src/function.rs
@@ -1,7 +1,10 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-use crate::instruction::{CodeOffset, FrameOffset, MicroOp, SizedSlot, FRAME_METADATA_SIZE};
+use crate::{
+    instruction::{CodeOffset, FrameOffset, MicroOp, SizedSlot, FRAME_METADATA_SIZE},
+    interner::InternedModuleId,
+};
 use mono_move_alloc::{GlobalArenaPtr, LeakedBoxPtr};
 use std::{fmt, ptr::NonNull};
 
@@ -133,6 +136,7 @@ impl SortedSafePointEntries {
 /// functions (no callee region).
 pub struct Function {
     pub name: GlobalArenaPtr<str>,
+    pub module_id: InternedModuleId,
     pub code: Code,
     /// Per-parameter (aligned) frame slot, in declaration order.
     pub param_slots: Vec<SizedSlot>,

--- a/third_party/move/mono-move/core/src/instruction/gas.rs
+++ b/third_party/move/mono-move/core/src/instruction/gas.rs
@@ -89,6 +89,7 @@ impl HasCfgInfo for MicroOp {
             | MicroOp::VecPopBack { .. }
             | MicroOp::VecLoadElem { .. }
             | MicroOp::VecStoreElem { .. }
+            | MicroOp::StoreImmVec { .. }
             | MicroOp::SlotBorrow { .. }
             | MicroOp::VecBorrow { .. }
             | MicroOp::HeapBorrow { .. }
@@ -233,6 +234,7 @@ impl RemapTargets for MicroOp {
             | MicroOp::VecPopBack { .. }
             | MicroOp::VecLoadElem { .. }
             | MicroOp::VecStoreElem { .. }
+            | MicroOp::StoreImmVec { .. }
             | MicroOp::SlotBorrow { .. }
             | MicroOp::VecBorrow { .. }
             | MicroOp::HeapBorrow { .. }
@@ -281,6 +283,8 @@ impl GasSchedule<MicroOp> for MicroOpGasSchedule {
             MicroOp::StoreImm1 { .. } => 2,
             MicroOp::StoreImm2 { .. } => 2,
             MicroOp::StoreImm4 { .. } => 2,
+            // TODO(gas): make size proportional to BCS size?
+            MicroOp::StoreImmVec { .. } => 10,
             MicroOp::StoreImm8 { .. } => 2,
             MicroOp::StoreImm16 { .. } => 3,
             MicroOp::StoreImm32 { .. } => 4,

--- a/third_party/move/mono-move/core/src/instruction/mod.rs
+++ b/third_party/move/mono-move/core/src/instruction/mod.rs
@@ -120,6 +120,7 @@ use crate::{
     types::{display_type, display_type_list, view_name, InternedType, InternedTypeList},
     FunctionPtr,
 };
+use move_binary_format::file_format::ConstantPoolIndex;
 use move_core_types::int256::U256;
 use std::fmt;
 
@@ -770,6 +771,14 @@ pub enum MicroOp {
         elem_size: u32,
     },
 
+    /// Creates a vector from the constant pool, allocating it on the heap and
+    /// writing the data pointer into `dst`. The empty-vector constant creates
+    /// a null pointer. MAY TRIGGER GC.
+    StoreImmVec {
+        dst: FrameOffset,
+        idx: ConstantPoolIndex,
+    },
+
     //======================================================================
     // Reference (fat pointer) operations
     //======================================================================
@@ -1358,6 +1367,9 @@ impl fmt::Display for MicroOp {
                     vec_ref.0, idx.0, src.0, elem_size
                 )
             },
+            MicroOp::StoreImmVec { dst, idx } => {
+                write!(f, "StoreImmVec [{}] <- const[{}]", dst.0, idx.0)
+            },
             MicroOp::SlotBorrow { dst, local } => {
                 write!(f, "SlotBorrow [{}] <- &[{}]", dst.0, local.0)
             },
@@ -1714,6 +1726,7 @@ impl MicroOp {
             // Allocating: may trigger GC.
             MicroOp::HeapNew { .. }
             | MicroOp::VecPushBack { .. }
+            | MicroOp::StoreImmVec { .. }
             | MicroOp::PackClosure(_)
             | MicroOp::BorrowGlobalMut { .. }
             | MicroOp::MoveFrom { .. }

--- a/third_party/move/mono-move/core/src/lib.rs
+++ b/third_party/move/mono-move/core/src/lib.rs
@@ -32,6 +32,7 @@ pub use instruction::{
     FUNC_REF_TAG_UNRESOLVED, OBJECT_HEADER_SIZE,
 };
 pub use interner::{view_function_ref, FunctionRef, InternedFunctionRef, Interner, ModuleId};
+pub use move_binary_format::file_format::ConstantPoolIndex;
 pub use object_descriptor::{
     DescriptorProvider, ObjectDescriptor, ObjectDescriptorInner, ObjectDescriptorTable,
     CLOSURE_DESCRIPTOR_ID, RESERVED_DESCRIPTOR_COUNT, TRIVIAL_DESCRIPTOR_ID,

--- a/third_party/move/mono-move/loader/src/read_set.rs
+++ b/third_party/move/mono-move/loader/src/read_set.rs
@@ -82,6 +82,17 @@ impl<'guard> ModuleReadSet<'guard> {
         self.inner.get(&id).copied()
     }
 
+    /// Returns the loaded module for `id`. Callers that resolve a module they
+    /// are already executing from rely on it being present and loaded, so a
+    /// missing or still-pending entry is an invariant violation.
+    pub fn get_loaded(&self, id: ArenaRef<'guard, ModuleId>) -> LoaderResult<&'guard LoadedModule> {
+        match self.get(id) {
+            Some(ModuleRead::Loaded { module, .. }) => Ok(module),
+            Some(ModuleRead::Pending) => invariant_violation!(ReadSetEntryNotLoaded),
+            None => invariant_violation!(UnexpectedReadSetMiss),
+        }
+    }
+
     /// Records a module that is about to be loaded. Used so a load that fails
     /// due to deserialization / verification still leaves the read in the set.
     pub fn record_pending_loading(&mut self, id: ArenaRef<'guard, ModuleId>) -> LoaderResult<()> {

--- a/third_party/move/mono-move/runtime/src/error.rs
+++ b/third_party/move/mono-move/runtime/src/error.rs
@@ -255,6 +255,9 @@ pub enum RuntimeInvariantViolation {
     #[error("type has no published layout")]
     ValueLayoutNotFound,
 
+    #[error("constant at pool index {idx} could not be resolved from the module read set")]
+    ConstantNotFound { idx: u16 },
+
     #[error("unreachable: {0}")]
     Unreachable(String),
 

--- a/third_party/move/mono-move/runtime/src/error.rs
+++ b/third_party/move/mono-move/runtime/src/error.rs
@@ -255,9 +255,6 @@ pub enum RuntimeInvariantViolation {
     #[error("type has no published layout")]
     ValueLayoutNotFound,
 
-    #[error("constant at pool index {idx} could not be resolved from the module read set")]
-    ConstantNotFound { idx: u16 },
-
     #[error("unreachable: {0}")]
     Unreachable(String),
 

--- a/third_party/move/mono-move/runtime/src/execution_context.rs
+++ b/third_party/move/mono-move/runtime/src/execution_context.rs
@@ -4,6 +4,7 @@
 //! Defines the [`ExecutionContext`] trait the interpreter calls into,
 //! and a minimal [`LocalExecutionContext`] impl for tests and benchmarks.
 
+use crate::error::RuntimeResult;
 use mono_move_core::{
     interner::{InternedIdentifier, InternedModuleId},
     native::{NativeRegistry, ProductionNativeRegistry},
@@ -46,14 +47,14 @@ pub trait ExecutionContext {
     ) -> LoaderResult<FunctionPtr>;
 
     /// Resolve a constant from `module_id`'s constant pool, returning its
-    /// interned type and BCS bytes. The module is expected to be in the
-    /// read set already (the calling function was loaded from it). Returns
-    /// [`None`] if the module cannot be found.
+    /// interned type and BCS bytes. The calling function was loaded from
+    /// `module_id`, so the module is always present and loaded in the read
+    /// set; a missing or not-yet-loaded entry is an invariant violation.
     fn load_constant(
         &self,
         module_id: InternedModuleId,
         idx: ConstantPoolIndex,
-    ) -> Option<(InternedType, &[u8])>;
+    ) -> RuntimeResult<(InternedType, &[u8])>;
 
     /// Access the resource provider to fetch resource from storage on read-set
     /// cache miss.
@@ -146,8 +147,8 @@ impl<'r, G: GasMeter> ExecutionContext for LocalExecutionContext<'r, G> {
         &self,
         _module_id: InternedModuleId,
         _idx: ConstantPoolIndex,
-    ) -> Option<(InternedType, &[u8])> {
-        None
+    ) -> RuntimeResult<(InternedType, &[u8])> {
+        panic!("LocalExecutionContext: load_constant not supported")
     }
 
     fn resource_provider(&self) -> &dyn ResourceProvider {

--- a/third_party/move/mono-move/runtime/src/execution_context.rs
+++ b/third_party/move/mono-move/runtime/src/execution_context.rs
@@ -8,8 +8,8 @@ use mono_move_core::{
     interner::{InternedIdentifier, InternedModuleId},
     native::{NativeRegistry, ProductionNativeRegistry},
     storage::{ResourceProvider, NO_RESOURCE_PROVIDER},
-    types::InternedTypeList,
-    FunctionPtr,
+    types::{InternedType, InternedTypeList},
+    ConstantPoolIndex, FunctionPtr,
 };
 use mono_move_gas::{GasMeter, NoOpGasMeter, SimpleGasMeter};
 use mono_move_loader::LoaderResult;
@@ -44,6 +44,16 @@ pub trait ExecutionContext {
         name: InternedIdentifier,
         ty_args: InternedTypeList,
     ) -> LoaderResult<FunctionPtr>;
+
+    /// Resolve a constant from `module_id`'s constant pool, returning its
+    /// interned type and BCS bytes. The module is expected to be in the
+    /// read set already (the calling function was loaded from it). Returns
+    /// [`None`] if the module cannot be found.
+    fn load_constant(
+        &self,
+        module_id: InternedModuleId,
+        idx: ConstantPoolIndex,
+    ) -> Option<(InternedType, &[u8])>;
 
     /// Access the resource provider to fetch resource from storage on read-set
     /// cache miss.
@@ -130,6 +140,14 @@ impl<'r, G: GasMeter> ExecutionContext for LocalExecutionContext<'r, G> {
         _ty_args: InternedTypeList,
     ) -> LoaderResult<FunctionPtr> {
         panic!("LocalExecutionContext: load_function not supported")
+    }
+
+    fn load_constant(
+        &self,
+        _module_id: InternedModuleId,
+        _idx: ConstantPoolIndex,
+    ) -> Option<(InternedType, &[u8])> {
+        None
     }
 
     fn resource_provider(&self) -> &dyn ResourceProvider {

--- a/third_party/move/mono-move/runtime/src/interpreter.rs
+++ b/third_party/move/mono-move/runtime/src/interpreter.rs
@@ -26,6 +26,7 @@ use crate::{
         META_SAVED_FP_OFFSET, META_SAVED_FUNC_PTR_OFFSET, META_SAVED_PC_OFFSET, VEC_DATA_OFFSET,
         VEC_LENGTH_OFFSET,
     },
+    value_utils::deserialize,
     ExecutionContext,
 };
 use mono_move_core::{
@@ -33,9 +34,9 @@ use mono_move_core::{
     native::{NativeABI, NativeIdx, NativeStatus, ProductionNativeContext},
     next_captured_value_offset,
     storage::resource_provider::StorageKey,
-    CallClosureOp, ClosureFuncRef, CmpKind, DescriptorId, DescriptorProvider, FrameOffset,
-    Function, FunctionRef, IntBinaryOp, IntCastOp, IntNegateOp, IntOperand, IntShiftOp, IntTy,
-    LayoutProvider, MicroOp, PackClosureOp, ShiftOperand, CAPTURED_DATA_TAG_MATERIALIZED,
+    CallClosureOp, ClosureFuncRef, CmpKind, ConstantPoolIndex, DescriptorId, DescriptorProvider,
+    FrameOffset, Function, FunctionRef, IntBinaryOp, IntCastOp, IntNegateOp, IntOperand, IntShiftOp,
+    IntTy, LayoutProvider, MicroOp, PackClosureOp, ShiftOperand, CAPTURED_DATA_TAG_MATERIALIZED,
     CAPTURED_DATA_TAG_OFFSET, CAPTURED_DATA_VALUES_OFFSET, CAPTURED_DATA_VALUES_SIZE_OFFSET,
     CLOSURE_CAPTURED_DATA_PTR_OFFSET, CLOSURE_DESCRIPTOR_ID, CLOSURE_FUNC_REF_OFFSET,
     CLOSURE_MASK_OFFSET, FRAME_METADATA_SIZE, FUNC_REF_PAYLOAD_OFFSET, FUNC_REF_TAG_OFFSET,
@@ -977,6 +978,9 @@ impl<T: ExecutionContext + DescriptorProvider + LayoutProvider> InterpreterConte
                 MicroOp::StoreImm8 { dst, ref imm } => write_int::<[u8; 8]>(fp, dst, *imm),
                 MicroOp::StoreImm16 { dst, ref imm } => write_int::<[u8; 16]>(fp, dst, **imm),
                 MicroOp::StoreImm32 { dst, ref imm } => write_int::<[u8; 32]>(fp, dst, **imm),
+                MicroOp::StoreImmVec { dst, idx } => {
+                    self.exec_store_imm_vec(dst, idx)?;
+                },
 
                 // Add
                 MicroOp::AddU64 { dst, lhs, rhs } => {
@@ -1511,6 +1515,37 @@ impl<T: ExecutionContext + DescriptorProvider + LayoutProvider> InterpreterConte
 
         self.pc += 1;
         Ok(StepResult::Continue)
+    }
+
+    /// Allocates vector from constant pool and writes data pointer into `dst`.
+    fn exec_store_imm_vec(
+        &mut self,
+        dst: FrameOffset,
+        idx: ConstantPoolIndex,
+    ) -> RuntimeResult<()> {
+        // SAFETY: `current_func` points to the live, currently-executing
+        // function.
+        let module_id = unsafe { self.current_func.as_ref() }.module_id;
+        let Some((ty, bytes)) = self.exec_ctx.load_constant(module_id, idx) else {
+            invariant_violation!(ConstantNotFound { idx: idx.0 });
+        };
+
+        // SAFETY: `dst` is a verified 8-byte frame slot for a vector pointer
+        // and is writable (no aliasing to the heap).
+        unsafe {
+            let dst = self.frame_ptr.add(usize::from(dst));
+            if let Err(err) = deserialize(self.exec_ctx, &mut self.heap, ty, bytes, dst) {
+                match err {
+                    AllocationError::RuntimeError(err) => return Err(err),
+                    AllocationError::OutOfHeapMemory { .. } => {
+                        gc_collect!(self)?;
+                        deserialize(self.exec_ctx, &mut self.heap, ty, bytes, dst)
+                            .map_err(AllocationError::into_runtime_error)?;
+                    },
+                }
+            }
+            Ok(())
+        }
     }
 
     /// Deep-copy the value tree rooted at the specified source into the

--- a/third_party/move/mono-move/runtime/src/interpreter.rs
+++ b/third_party/move/mono-move/runtime/src/interpreter.rs
@@ -35,12 +35,13 @@ use mono_move_core::{
     next_captured_value_offset,
     storage::resource_provider::StorageKey,
     CallClosureOp, ClosureFuncRef, CmpKind, ConstantPoolIndex, DescriptorId, DescriptorProvider,
-    FrameOffset, Function, FunctionRef, IntBinaryOp, IntCastOp, IntNegateOp, IntOperand, IntShiftOp,
-    IntTy, LayoutProvider, MicroOp, PackClosureOp, ShiftOperand, CAPTURED_DATA_TAG_MATERIALIZED,
-    CAPTURED_DATA_TAG_OFFSET, CAPTURED_DATA_VALUES_OFFSET, CAPTURED_DATA_VALUES_SIZE_OFFSET,
-    CLOSURE_CAPTURED_DATA_PTR_OFFSET, CLOSURE_DESCRIPTOR_ID, CLOSURE_FUNC_REF_OFFSET,
-    CLOSURE_MASK_OFFSET, FRAME_METADATA_SIZE, FUNC_REF_PAYLOAD_OFFSET, FUNC_REF_TAG_OFFSET,
-    FUNC_REF_TAG_RESOLVED, FUNC_REF_TAG_UNRESOLVED, MAX_ALIGN, OBJECT_HEADER_SIZE,
+    FrameOffset, Function, FunctionRef, IntBinaryOp, IntCastOp, IntNegateOp, IntOperand,
+    IntShiftOp, IntTy, LayoutProvider, MicroOp, PackClosureOp, ShiftOperand,
+    CAPTURED_DATA_TAG_MATERIALIZED, CAPTURED_DATA_TAG_OFFSET, CAPTURED_DATA_VALUES_OFFSET,
+    CAPTURED_DATA_VALUES_SIZE_OFFSET, CLOSURE_CAPTURED_DATA_PTR_OFFSET, CLOSURE_DESCRIPTOR_ID,
+    CLOSURE_FUNC_REF_OFFSET, CLOSURE_MASK_OFFSET, FRAME_METADATA_SIZE, FUNC_REF_PAYLOAD_OFFSET,
+    FUNC_REF_TAG_OFFSET, FUNC_REF_TAG_RESOLVED, FUNC_REF_TAG_UNRESOLVED, MAX_ALIGN,
+    OBJECT_HEADER_SIZE,
 };
 use mono_move_gas::GasMeter;
 use move_core_types::int256::{I256, U256};
@@ -1526,9 +1527,7 @@ impl<T: ExecutionContext + DescriptorProvider + LayoutProvider> InterpreterConte
         // SAFETY: `current_func` points to the live, currently-executing
         // function.
         let module_id = unsafe { self.current_func.as_ref() }.module_id;
-        let Some((ty, bytes)) = self.exec_ctx.load_constant(module_id, idx) else {
-            invariant_violation!(ConstantNotFound { idx: idx.0 });
-        };
+        let (ty, bytes) = self.exec_ctx.load_constant(module_id, idx)?;
 
         // SAFETY: `dst` is a verified 8-byte frame slot for a vector pointer
         // and is writable (no aliasing to the heap).
@@ -1538,6 +1537,10 @@ impl<T: ExecutionContext + DescriptorProvider + LayoutProvider> InterpreterConte
                 match err {
                     AllocationError::RuntimeError(err) => return Err(err),
                     AllocationError::OutOfHeapMemory { .. } => {
+                        // TODO: add an ld_const test that fills the heap so
+                        // the first deserialize fails and this GC-then-retry
+                        // path runs. Needs a `ForceGC` native to drive it
+                        // deterministically in the differential suite.
                         gc_collect!(self)?;
                         deserialize(self.exec_ctx, &mut self.heap, ty, bytes, dst)
                             .map_err(AllocationError::into_runtime_error)?;

--- a/third_party/move/mono-move/runtime/src/local_runtime_context.rs
+++ b/third_party/move/mono-move/runtime/src/local_runtime_context.rs
@@ -9,8 +9,8 @@ use mono_move_core::{
     interner::{InternedIdentifier, InternedModuleId},
     native::ProductionNativeRegistry,
     types::{InternedType, InternedTypeList},
-    DescriptorId, DescriptorProvider, FunctionPtr, LayoutId, LayoutProvider, ObjectDescriptor,
-    ObjectDescriptorTable, ResourceProvider, ValueLayout, ValueLayoutTable,
+    ConstantPoolIndex, DescriptorId, DescriptorProvider, FunctionPtr, LayoutId, LayoutProvider,
+    ObjectDescriptor, ObjectDescriptorTable, ResourceProvider, ValueLayout, ValueLayoutTable,
 };
 use mono_move_gas::{GasMeter, NoOpGasMeter, SimpleGasMeter};
 use mono_move_loader::LoaderResult;
@@ -127,6 +127,14 @@ impl<'r, G: GasMeter> ExecutionContext for LocalRuntimeContext<'r, G> {
         ty_args: InternedTypeList,
     ) -> LoaderResult<FunctionPtr> {
         self.inner.load_function(module_id, name, ty_args)
+    }
+
+    fn load_constant(
+        &self,
+        module_id: InternedModuleId,
+        idx: ConstantPoolIndex,
+    ) -> Option<(InternedType, &[u8])> {
+        self.inner.load_constant(module_id, idx)
     }
 
     fn resource_provider(&self) -> &dyn ResourceProvider {

--- a/third_party/move/mono-move/runtime/src/local_runtime_context.rs
+++ b/third_party/move/mono-move/runtime/src/local_runtime_context.rs
@@ -4,7 +4,7 @@
 //! Minimal [`ExecutionContext`] + [`DescriptorProvider`] impl for tests
 //! and benchmarks that don't go through the full loader stack.
 
-use crate::{ExecutionContext, LocalExecutionContext};
+use crate::{error::RuntimeResult, ExecutionContext, LocalExecutionContext};
 use mono_move_core::{
     interner::{InternedIdentifier, InternedModuleId},
     native::ProductionNativeRegistry,
@@ -133,7 +133,7 @@ impl<'r, G: GasMeter> ExecutionContext for LocalRuntimeContext<'r, G> {
         &self,
         module_id: InternedModuleId,
         idx: ConstantPoolIndex,
-    ) -> Option<(InternedType, &[u8])> {
+    ) -> RuntimeResult<(InternedType, &[u8])> {
         self.inner.load_constant(module_id, idx)
     }
 

--- a/third_party/move/mono-move/runtime/src/transaction_context.rs
+++ b/third_party/move/mono-move/runtime/src/transaction_context.rs
@@ -6,7 +6,7 @@
 //
 // TODO: move out of the runtime once a layer above it exists.
 
-use crate::ExecutionContext;
+use crate::{error::RuntimeResult, ExecutionContext};
 use mono_move_core::{
     interner::{InternedIdentifier, InternedModuleId},
     native::ProductionNativeRegistry,
@@ -15,7 +15,7 @@ use mono_move_core::{
     ObjectDescriptor, ResourceProvider, ValueLayout,
 };
 use mono_move_gas::GasMeter;
-use mono_move_loader::{Loader, LoaderResult, ModuleRead, ModuleReadSet};
+use mono_move_loader::{Loader, LoaderResult, ModuleReadSet};
 
 /// Per-transaction execution context. Maintains per-transaction state
 /// (gas meter, read-set of loaded modules) and serves the interpreter's
@@ -95,18 +95,13 @@ impl<'guard, 'ctx, G: GasMeter> ExecutionContext for TransactionContext<'guard, 
         &self,
         module_id: InternedModuleId,
         idx: ConstantPoolIndex,
-    ) -> Option<(InternedType, &[u8])> {
+    ) -> RuntimeResult<(InternedType, &[u8])> {
         let arena_ref = self.loader.guard().arena_ref_for_module_id(module_id);
-        match self.read_set.get(arena_ref)? {
-            ModuleRead::Loaded { module, .. } => {
-                let module = &module.ir().module;
-                Some((
-                    module.interned_constant_type_at(idx),
-                    module.constant_data_at(idx),
-                ))
-            },
-            ModuleRead::Pending => None,
-        }
+        let module = &self.read_set.get_loaded(arena_ref)?.ir().module;
+        Ok((
+            module.interned_constant_type_at(idx),
+            module.constant_data_at(idx),
+        ))
     }
 
     fn resource_provider(&self) -> &dyn ResourceProvider {

--- a/third_party/move/mono-move/runtime/src/transaction_context.rs
+++ b/third_party/move/mono-move/runtime/src/transaction_context.rs
@@ -11,11 +11,11 @@ use mono_move_core::{
     interner::{InternedIdentifier, InternedModuleId},
     native::ProductionNativeRegistry,
     types::{InternedType, InternedTypeList},
-    DescriptorId, DescriptorProvider, FunctionPtr, LayoutId, LayoutProvider, ObjectDescriptor,
-    ResourceProvider, ValueLayout,
+    ConstantPoolIndex, DescriptorId, DescriptorProvider, FunctionPtr, LayoutId, LayoutProvider,
+    ObjectDescriptor, ResourceProvider, ValueLayout,
 };
 use mono_move_gas::GasMeter;
-use mono_move_loader::{Loader, LoaderResult, ModuleReadSet};
+use mono_move_loader::{Loader, LoaderResult, ModuleRead, ModuleReadSet};
 
 /// Per-transaction execution context. Maintains per-transaction state
 /// (gas meter, read-set of loaded modules) and serves the interpreter's
@@ -89,6 +89,24 @@ impl<'guard, 'ctx, G: GasMeter> ExecutionContext for TransactionContext<'guard, 
             name,
             ty_args,
         )
+    }
+
+    fn load_constant(
+        &self,
+        module_id: InternedModuleId,
+        idx: ConstantPoolIndex,
+    ) -> Option<(InternedType, &[u8])> {
+        let arena_ref = self.loader.guard().arena_ref_for_module_id(module_id);
+        match self.read_set.get(arena_ref)? {
+            ModuleRead::Loaded { module, .. } => {
+                let module = &module.ir().module;
+                Some((
+                    module.interned_constant_type_at(idx),
+                    module.constant_data_at(idx),
+                ))
+            },
+            ModuleRead::Pending => None,
+        }
     }
 
     fn resource_provider(&self) -> &dyn ResourceProvider {

--- a/third_party/move/mono-move/runtime/src/value_utils.rs
+++ b/third_party/move/mono-move/runtime/src/value_utils.rs
@@ -479,7 +479,6 @@ unsafe fn compare_impl<T: LayoutProvider + ?Sized>(
 ///
 /// `dst` pointer must be writable for the in-memory size of the given type and
 /// outlive the call.
-#[allow(dead_code)]
 pub unsafe fn deserialize<T: LayoutProvider + ?Sized>(
     layouts: &T,
     heap: &mut Heap,

--- a/third_party/move/mono-move/runtime/src/verifier.rs
+++ b/third_party/move/mono-move/runtime/src/verifier.rs
@@ -510,6 +510,11 @@ impl<P: DescriptorProvider + ?Sized> FunctionVerifier<'_, P> {
                 self.check_frame_access_8(pc, dst);
             },
 
+            // ----- StoreImmVec: writes an 8-byte heap pointer to `dst` -----
+            MicroOp::StoreImmVec { dst, .. } => {
+                self.check_frame_access_8(pc, dst);
+            },
+
             MicroOp::VecLen { dst, vec_ref } => {
                 self.check_frame_access(Some(pc), vec_ref, 16);
                 self.check_frame_access_8(pc, dst);

--- a/third_party/move/mono-move/runtime/tests/common/mod.rs
+++ b/third_party/move/mono-move/runtime/tests/common/mod.rs
@@ -19,6 +19,19 @@ use mono_move_runtime::write_object_header;
 use move_core_types::account_address::AccountAddress;
 use std::{cell::RefCell, collections::HashMap, ptr::NonNull};
 
+/// Builds an interned module id for hand-built test functions.
+#[macro_export]
+macro_rules! program_module_id {
+    ($name:literal) => {{
+        static MODULE_ID: ::mono_move_core::interner::ModuleId =
+            ::mono_move_core::interner::ModuleId::new(
+                ::move_core_types::account_address::AccountAddress::ONE,
+                ::mono_move_alloc::GlobalArenaPtr::from_static($name),
+            );
+        ::mono_move_alloc::GlobalArenaPtr::from_static(&MODULE_ID)
+    }};
+}
+
 /// In-memory [`ResourceProvider`] for tests. Owns the resource
 /// bytes in `Box<[u64]>` buffers (giving `MAX_ALIGN` alignment and
 /// stable addresses); `install_global` writes a leading object

--- a/third_party/move/mono-move/runtime/tests/enum_test.rs
+++ b/third_party/move/mono-move/runtime/tests/enum_test.rs
@@ -3,6 +3,8 @@
 
 //! Tests for Move enum support (heap-allocated tagged unions).
 
+mod common;
+
 use mono_move_alloc::GlobalArenaPtr;
 use mono_move_core::{
     Code, CodeOffset as CO, FrameLayoutInfo, FrameOffset as FO, Function, MicroOp,
@@ -46,6 +48,7 @@ fn enum_basic() {
     ];
     let functions = [Function {
         name: GlobalArenaPtr::from_static("test"),
+        module_id: crate::program_module_id!("test"),
         code: Code::from_vec(code),
         param_slots: vec![],
         param_region_size: 0,
@@ -100,6 +103,7 @@ fn enum_survives_gc() {
     ];
     let functions = [Function {
         name: GlobalArenaPtr::from_static("test"),
+        module_id: crate::program_module_id!("test"),
         code: Code::from_vec(code),
         param_slots: vec![],
         param_region_size: 0,
@@ -162,6 +166,7 @@ fn enum_gc_traces_refs() {
     ];
     let functions = [Function {
         name: GlobalArenaPtr::from_static("test"),
+        module_id: crate::program_module_id!("test"),
         code: Code::from_vec(code),
         param_slots: vec![],
         param_region_size: 0,
@@ -227,6 +232,7 @@ fn enum_pattern_match() {
     ];
     let functions = [Function {
         name: GlobalArenaPtr::from_static("test"),
+        module_id: crate::program_module_id!("test"),
         code: Code::from_vec(code),
         param_slots: vec![],
         param_region_size: 0,
@@ -276,6 +282,7 @@ fn enum_variant_switch() {
     ];
     let functions = [Function {
         name: GlobalArenaPtr::from_static("test"),
+        module_id: crate::program_module_id!("test"),
         code: Code::from_vec(code),
         param_slots: vec![],
         param_region_size: 0,
@@ -327,6 +334,7 @@ fn enum_borrow_field() {
     ];
     let functions = [Function {
         name: GlobalArenaPtr::from_static("test"),
+        module_id: crate::program_module_id!("test"),
         code: Code::from_vec(code),
         param_slots: vec![],
         param_region_size: 0,
@@ -384,6 +392,7 @@ fn enum_gc_variant_switching() {
     ];
     let functions = [Function {
         name: GlobalArenaPtr::from_static("test"),
+        module_id: crate::program_module_id!("test"),
         code: Code::from_vec(code),
         param_slots: vec![],
         param_region_size: 0,
@@ -443,6 +452,7 @@ fn enum_in_struct() {
     ];
     let functions = [Function {
         name: GlobalArenaPtr::from_static("test"),
+        module_id: crate::program_module_id!("test"),
         code: Code::from_vec(code),
         param_slots: vec![],
         param_region_size: 0,
@@ -513,6 +523,7 @@ fn enum_in_vector() {
     ];
     let functions = [Function {
         name: GlobalArenaPtr::from_static("test"),
+        module_id: crate::program_module_id!("test"),
         code: Code::from_vec(code),
         param_slots: vec![],
         param_region_size: 0,

--- a/third_party/move/mono-move/runtime/tests/gc_stress.rs
+++ b/third_party/move/mono-move/runtime/tests/gc_stress.rs
@@ -21,6 +21,8 @@
 //! At the end, walks the VM's outer vector via heap pointers and compares
 //! element-by-element against a pure-Rust simulation using the same seed.
 
+mod common;
+
 use mono_move_alloc::GlobalArenaPtr;
 use mono_move_core::{
     Code, CodeOffset as CO, FrameLayoutInfo, FrameOffset as FO, Function, FunctionPtr, MicroOp,
@@ -126,6 +128,7 @@ fn make_gc_stress_program(
     ];
     let callee_ptr = FunctionPtr::new(Box::new(Function {
         name: GlobalArenaPtr::from_static("test"),
+        module_id: crate::program_module_id!("test"),
         code: Code::from_vec(make_entry_code),
         param_slots: vec![],
         param_region_size: 8,
@@ -233,6 +236,7 @@ fn make_gc_stress_program(
     ];
     let main_ptr = FunctionPtr::new(Box::new(Function {
         name: GlobalArenaPtr::from_static("test"),
+        module_id: crate::program_module_id!("test"),
         code: Code::from_vec(code),
         param_slots: vec![],
         param_region_size: 0,

--- a/third_party/move/mono-move/runtime/tests/global_storage_checkpoint.rs
+++ b/third_party/move/mono-move/runtime/tests/global_storage_checkpoint.rs
@@ -64,6 +64,7 @@ const SIGNER_REF: FO = FO(56);
 fn make_program(code: Vec<MicroOp>, frame_layout: FrameLayoutInfo) -> Function {
     Function {
         name: GlobalArenaPtr::from_static("test"),
+        module_id: crate::program_module_id!("test"),
         code: Code::from_vec(code),
         param_slots: vec![],
         param_region_size: 0,

--- a/third_party/move/mono-move/runtime/tests/global_storage_mut.rs
+++ b/third_party/move/mono-move/runtime/tests/global_storage_mut.rs
@@ -66,6 +66,7 @@ fn local_ctx_with<'r>(
 fn make_program_with_tmp(code: Vec<MicroOp>, frame_layout: FrameLayoutInfo) -> Function {
     Function {
         name: GlobalArenaPtr::from_static("test"),
+        module_id: crate::program_module_id!("test"),
         code: Code::from_vec(code),
         param_slots: vec![],
         param_region_size: 0,
@@ -130,6 +131,7 @@ fn borrow_global_mut_same_epoch_no_extra_copy() {
     let result_b: FO = FO(56);
     let func = Function {
         name: GlobalArenaPtr::from_static("test"),
+        module_id: crate::program_module_id!("test"),
         code: Code::from_vec(vec![
             MicroOp::BorrowGlobalMut {
                 addr: ADDR,
@@ -175,6 +177,7 @@ fn move_to_publishes_resource_and_exists_is_true() {
 
     let func = Function {
         name: GlobalArenaPtr::from_static("test"),
+        module_id: crate::program_module_id!("test"),
         code: Code::from_vec(vec![
             MicroOp::HeapNew {
                 dst: TMP,
@@ -221,6 +224,7 @@ fn move_to_aborts_when_already_present() {
 
     let func = Function {
         name: GlobalArenaPtr::from_static("test"),
+        module_id: crate::program_module_id!("test"),
         code: Code::from_vec(vec![
             MicroOp::HeapNew {
                 dst: TMP,
@@ -301,6 +305,7 @@ fn gc_traces_and_relocates_local_heap_writes() {
 
     let func = Function {
         name: GlobalArenaPtr::from_static("test"),
+        module_id: crate::program_module_id!("test"),
         code: Code::from_vec(vec![
             MicroOp::BorrowGlobalMut {
                 addr: ADDR,
@@ -361,6 +366,7 @@ fn distinct_keys_track_independently() {
     let dst_b: FO = FO(56);
     let func = Function {
         name: GlobalArenaPtr::from_static("test"),
+        module_id: crate::program_module_id!("test"),
         code: Code::from_vec(vec![
             MicroOp::BorrowGlobalMut {
                 addr: ADDR,

--- a/third_party/move/mono-move/runtime/tests/global_storage_nested.rs
+++ b/third_party/move/mono-move/runtime/tests/global_storage_nested.rs
@@ -65,6 +65,7 @@ fn make_borrow_mut_program(desc_id: DescriptorId) -> Function {
     let _ = desc_id; // descriptor_id is no longer carried on the MicroOp.
     Function {
         name: GlobalArenaPtr::from_static("test"),
+        module_id: crate::program_module_id!("test"),
         code: Code::from_vec(vec![
             MicroOp::BorrowGlobalMut {
                 addr: ADDR,
@@ -253,6 +254,7 @@ fn deep_copy_survives_gc_mid_walk() {
 
     let func = Function {
         name: GlobalArenaPtr::from_static("test_gc_mid_copy"),
+        module_id: crate::program_module_id!("test"),
         code: Code::from_vec(vec![
             // Three garbage allocations into the same unrooted slot.
             // Each HeapNew is 16B (header + 8B payload). With heap=32,
@@ -338,6 +340,7 @@ fn move_from_deep_copies_external_resource_survives_gc_mid_walk() {
 
     let func = Function {
         name: GlobalArenaPtr::from_static("test_move_from_gc_mid_copy"),
+        module_id: crate::program_module_id!("test"),
         code: Code::from_vec(vec![
             // Three garbage allocations into the same unrooted slot —
             // same pressure pattern as the BorrowGlobalMut variant.

--- a/third_party/move/mono-move/runtime/tests/global_storage_read.rs
+++ b/third_party/move/mono-move/runtime/tests/global_storage_read.rs
@@ -62,6 +62,7 @@ fn local_ctx_with<'r>(
 fn make_program(code: Vec<MicroOp>) -> Function {
     Function {
         name: GlobalArenaPtr::from_static("test"),
+        module_id: crate::program_module_id!("test"),
         code: Code::from_vec(code),
         param_slots: vec![],
         param_region_size: 0,
@@ -133,6 +134,7 @@ fn exists_returns_false_after_move_from() {
     let tmp: FO = FO(40);
     let func = Function {
         name: GlobalArenaPtr::from_static("test"),
+        module_id: crate::program_module_id!("test"),
         code: Code::from_vec(vec![
             MicroOp::MoveFrom {
                 addr: ADDR,
@@ -288,6 +290,7 @@ fn move_from_marks_deleted_and_second_borrow_aborts() {
     let tmp: FO = FO(40);
     let func = Function {
         name: GlobalArenaPtr::from_static("test"),
+        module_id: crate::program_module_id!("test"),
         code: Code::from_vec(vec![
             MicroOp::MoveFrom {
                 addr: ADDR,

--- a/third_party/move/mono-move/runtime/tests/int_ops.rs
+++ b/third_party/move/mono-move/runtime/tests/int_ops.rs
@@ -34,6 +34,8 @@
 //! TODO: Revisit endianness. Interpreter uses native order for built-in types.
 //! I256/U256 currently do not have other endianness exposed.
 
+mod common;
+
 use mono_move_alloc::GlobalArenaPtr;
 use mono_move_core::{
     Code, FrameLayoutInfo, FrameOffset as FO, Function, IntBinaryOp, IntCastOp, IntNegateOp,
@@ -190,6 +192,7 @@ const FRAME_SIZE: u32 = 96;
 fn make_func(op: MicroOp) -> Function {
     Function {
         name: GlobalArenaPtr::from_static("op"),
+        module_id: crate::program_module_id!("test"),
         code: Code::from_vec(vec![op, MicroOp::Return]),
         param_slots: vec![],
         param_region_size: 0,

--- a/third_party/move/mono-move/runtime/tests/ref_test.rs
+++ b/third_party/move/mono-move/runtime/tests/ref_test.rs
@@ -4,6 +4,8 @@
 //! Tests for fat-pointer references (VecBorrow, SlotBorrow, ReadRef, WriteRef,
 //! HeapBorrow).
 
+mod common;
+
 use mono_move_alloc::GlobalArenaPtr;
 use mono_move_core::{
     Code, FrameLayoutInfo, FrameOffset as FO, Function, FunctionPtr, MicroOp,
@@ -49,6 +51,7 @@ fn ref_basic() {
     ];
     let functions = [Function {
         name: GlobalArenaPtr::from_static("test"),
+        module_id: crate::program_module_id!("test"),
         code: Code::from_vec(code),
         param_slots: vec![],
         param_region_size: 0,
@@ -108,6 +111,7 @@ fn ref_survives_gc() {
     ];
     let functions = [Function {
         name: GlobalArenaPtr::from_static("test"),
+        module_id: crate::program_module_id!("test"),
         code: Code::from_vec(code),
         param_slots: vec![],
         param_region_size: 0,
@@ -156,6 +160,7 @@ fn ref_cross_frame() {
     ];
     let callee_ptr = FunctionPtr::new(Box::new(Function {
         name: GlobalArenaPtr::from_static("test"),
+        module_id: crate::program_module_id!("test"),
         code: Code::from_vec(callee_code),
         param_slots: vec![],
         param_region_size: 16,
@@ -194,6 +199,7 @@ fn ref_cross_frame() {
     ];
     let main_func = Function {
         name: GlobalArenaPtr::from_static("test"),
+        module_id: crate::program_module_id!("test"),
         code: Code::from_vec(main_code),
         param_slots: vec![],
         param_region_size: 0,
@@ -274,6 +280,7 @@ fn ref_multiple_borrows() {
     ];
     let functions = [Function {
         name: GlobalArenaPtr::from_static("test"),
+        module_id: crate::program_module_id!("test"),
         code: Code::from_vec(code),
         param_slots: vec![],
         param_region_size: 0,
@@ -339,6 +346,7 @@ fn ref_borrow_local() {
     ];
     let functions = [Function {
         name: GlobalArenaPtr::from_static("test"),
+        module_id: crate::program_module_id!("test"),
         code: Code::from_vec(code),
         param_slots: vec![],
         param_region_size: 0,
@@ -418,6 +426,7 @@ fn ref_nested_vectors() {
     ];
     let functions = [Function {
         name: GlobalArenaPtr::from_static("test"),
+        module_id: crate::program_module_id!("test"),
         code: Code::from_vec(code),
         param_slots: vec![],
         param_region_size: 0,
@@ -504,6 +513,7 @@ fn ref_survives_double_gc() {
     ];
     let functions = [Function {
         name: GlobalArenaPtr::from_static("test"),
+        module_id: crate::program_module_id!("test"),
         code: Code::from_vec(code),
         param_slots: vec![],
         param_region_size: 0,
@@ -560,6 +570,7 @@ fn ref_struct_field_borrow() {
     ];
     let functions = [Function {
         name: GlobalArenaPtr::from_static("test"),
+        module_id: crate::program_module_id!("test"),
         code: Code::from_vec(code),
         param_slots: vec![],
         param_region_size: 0,
@@ -611,6 +622,7 @@ fn ref_struct_field_survives_gc() {
     ];
     let functions = [Function {
         name: GlobalArenaPtr::from_static("test"),
+        module_id: crate::program_module_id!("test"),
         code: Code::from_vec(code),
         param_slots: vec![],
         param_region_size: 0,
@@ -655,6 +667,7 @@ fn ref_self_copy() {
     ];
     let function = Function {
         name: GlobalArenaPtr::from_static("test"),
+        module_id: crate::program_module_id!("test"),
         code: Code::from_vec(code),
         param_slots: vec![],
         param_region_size: 0,

--- a/third_party/move/mono-move/runtime/tests/struct_test.rs
+++ b/third_party/move/mono-move/runtime/tests/struct_test.rs
@@ -3,6 +3,8 @@
 
 //! Tests for Move struct support (both inline and heap-allocated).
 
+mod common;
+
 use mono_move_alloc::GlobalArenaPtr;
 use mono_move_core::{
     Code, FrameLayoutInfo, FrameOffset as FO, Function, MicroOp, SortedSafePointEntries,
@@ -33,6 +35,7 @@ fn struct_inline() {
     ];
     let functions = [Function {
         name: GlobalArenaPtr::from_static("test"),
+        module_id: crate::program_module_id!("test"),
         code: Code::from_vec(code),
         param_slots: vec![],
         param_region_size: 0,
@@ -76,6 +79,7 @@ fn struct_inline_borrow() {
     ];
     let functions = [Function {
         name: GlobalArenaPtr::from_static("test"),
+        module_id: crate::program_module_id!("test"),
         code: Code::from_vec(code),
         param_slots: vec![],
         param_region_size: 0,
@@ -122,6 +126,7 @@ fn struct_heap_basic() {
     ];
     let functions = [Function {
         name: GlobalArenaPtr::from_static("test"),
+        module_id: crate::program_module_id!("test"),
         code: Code::from_vec(code),
         param_slots: vec![],
         param_region_size: 0,
@@ -168,6 +173,7 @@ fn struct_heap_survives_gc() {
     ];
     let functions = [Function {
         name: GlobalArenaPtr::from_static("test"),
+        module_id: crate::program_module_id!("test"),
         code: Code::from_vec(code),
         param_slots: vec![],
         param_region_size: 0,
@@ -231,6 +237,7 @@ fn struct_with_vector_field() {
     ];
     let functions = [Function {
         name: GlobalArenaPtr::from_static("test"),
+        module_id: crate::program_module_id!("test"),
         code: Code::from_vec(code),
         param_slots: vec![],
         param_region_size: 0,
@@ -292,6 +299,7 @@ fn struct_borrow_field() {
     ];
     let functions = [Function {
         name: GlobalArenaPtr::from_static("test"),
+        module_id: crate::program_module_id!("test"),
         code: Code::from_vec(code),
         param_slots: vec![],
         param_region_size: 0,
@@ -344,6 +352,7 @@ fn struct_borrow_survives_gc() {
     ];
     let functions = [Function {
         name: GlobalArenaPtr::from_static("test"),
+        module_id: crate::program_module_id!("test"),
         code: Code::from_vec(code),
         param_slots: vec![],
         param_region_size: 0,

--- a/third_party/move/mono-move/runtime/tests/vec_sum.rs
+++ b/third_party/move/mono-move/runtime/tests/vec_sum.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
+mod common;
+
 use mono_move_alloc::GlobalArenaPtr;
 use mono_move_core::{
     Code, CodeOffset as CO, FrameLayoutInfo, FrameOffset as FO, Function, MicroOp,
@@ -51,6 +53,7 @@ fn make_vec_sum_program(n: u64) -> (Vec<Function>, ObjectDescriptorTable) {
     ];
     let func = Function {
         name: GlobalArenaPtr::from_static("test"),
+        module_id: crate::program_module_id!("test"),
         code: Code::from_vec(code),
         param_slots: vec![],
         param_region_size: 0,

--- a/third_party/move/mono-move/runtime/tests/verifier_test.rs
+++ b/third_party/move/mono-move/runtime/tests/verifier_test.rs
@@ -3,6 +3,8 @@
 
 //! Tests for the static verifier (`verify_function`, `verify_descriptors`).
 
+mod common;
+
 use mono_move_alloc::GlobalArenaPtr;
 use mono_move_core::{
     Code, CodeOffset as CO, DescriptorId, FrameLayoutInfo, FrameOffset as FO, Function, MicroOp,
@@ -20,6 +22,7 @@ fn trivial_descriptors() -> ObjectDescriptorTable {
 fn minimal_func() -> Function {
     Function {
         name: GlobalArenaPtr::from_static("test"),
+        module_id: crate::program_module_id!("test"),
         code: Code::from_vec(vec![MicroOp::Return]),
         param_slots: vec![],
         param_region_size: 0,
@@ -56,6 +59,7 @@ fn valid_with_arithmetic_and_jumps() {
     ];
     let func = Function {
         name: GlobalArenaPtr::from_static("test"),
+        module_id: crate::program_module_id!("test"),
         code: Code::from_vec(code),
         param_slots: vec![],
         param_region_size: 0,
@@ -83,6 +87,7 @@ fn valid_with_vec_and_pointer_slots() {
     ];
     let func = Function {
         name: GlobalArenaPtr::from_static("test"),
+        module_id: crate::program_module_id!("test"),
         code: Code::from_vec(code),
         param_slots: vec![],
         param_region_size: 0,
@@ -105,6 +110,7 @@ fn frame_bounds_store_u64() {
     use MicroOp::*;
     let func = Function {
         name: GlobalArenaPtr::from_static("test"),
+        module_id: crate::program_module_id!("test"),
         code: Code::from_vec(vec![
             StoreImm8 {
                 dst: FO(8),
@@ -134,6 +140,7 @@ fn frame_bounds_mov() {
     use MicroOp::*;
     let func = Function {
         name: GlobalArenaPtr::from_static("test"),
+        module_id: crate::program_module_id!("test"),
         code: Code::from_vec(vec![
             Move {
                 dst: FO(8),
@@ -162,6 +169,7 @@ fn frame_bounds_fat_ptr_write() {
     use MicroOp::*;
     let func = Function {
         name: GlobalArenaPtr::from_static("test"),
+        module_id: crate::program_module_id!("test"),
         code: Code::from_vec(vec![
             StoreImm8 {
                 dst: FO(0),
@@ -193,6 +201,7 @@ fn frame_bounds_extended_frame_too_small() {
     use MicroOp::*;
     let func = Function {
         name: GlobalArenaPtr::from_static("test"),
+        module_id: crate::program_module_id!("test"),
         code: Code::from_vec(vec![Return]),
         param_slots: vec![],
         param_and_local_sizes_sum: 8,
@@ -217,6 +226,7 @@ fn frame_bounds_extended_frame_too_small() {
 fn pointer_slots_offset_out_of_bounds() {
     let func = Function {
         name: GlobalArenaPtr::from_static("test"),
+        module_id: crate::program_module_id!("test"),
         code: Code::from_vec(vec![MicroOp::Return]),
         param_slots: vec![],
         param_region_size: 0,
@@ -237,6 +247,7 @@ fn pointer_slots_offset_out_of_bounds() {
 fn pointer_slots_overlaps_metadata() {
     let func = Function {
         name: GlobalArenaPtr::from_static("test"),
+        module_id: crate::program_module_id!("test"),
         code: Code::from_vec(vec![MicroOp::Return]),
         param_slots: vec![],
         param_region_size: 0,
@@ -258,6 +269,7 @@ fn param_and_local_sizes_sum_misaligned() {
     // SAFETY: Arena is alive for the duration of the test.
     let func = Function {
         name: GlobalArenaPtr::from_static("test"),
+        module_id: crate::program_module_id!("test"),
         code: Code::from_vec(vec![MicroOp::Return]),
         param_slots: vec![],
         param_region_size: 0,
@@ -276,6 +288,7 @@ fn param_and_local_sizes_sum_misaligned() {
 fn args_size_exceeds_data_size() {
     let func = Function {
         name: GlobalArenaPtr::from_static("test"),
+        module_id: crate::program_module_id!("test"),
         code: Code::from_vec(vec![MicroOp::Return]),
         param_slots: vec![],
         param_and_local_sizes_sum: 8,
@@ -301,6 +314,7 @@ fn invalid_jump_target() {
     use MicroOp::*;
     let func = Function {
         name: GlobalArenaPtr::from_static("test"),
+        module_id: crate::program_module_id!("test"),
         code: Code::from_vec(vec![
             Jump { target: CO(5) }, // only 2 instructions -> 5 >= 2
             Return,
@@ -323,6 +337,7 @@ fn invalid_conditional_jump_target() {
     use MicroOp::*;
     let func = Function {
         name: GlobalArenaPtr::from_static("test"),
+        module_id: crate::program_module_id!("test"),
         code: Code::from_vec(vec![
             StoreImm8 {
                 dst: FO(0),
@@ -357,6 +372,7 @@ fn invalid_descriptor_id() {
 
     let func = Function {
         name: GlobalArenaPtr::from_static("test"),
+        module_id: crate::program_module_id!("test"),
         code: Code::from_vec(vec![
             VecNew { dst: FO(0) },
             SlotBorrow {
@@ -397,6 +413,7 @@ fn zero_size_mov() {
     use MicroOp::*;
     let func = Function {
         name: GlobalArenaPtr::from_static("test"),
+        module_id: crate::program_module_id!("test"),
         code: Code::from_vec(vec![
             Move {
                 dst: FO(0),
@@ -424,6 +441,7 @@ fn zero_elem_size_vec_push() {
 
     let func = Function {
         name: GlobalArenaPtr::from_static("test"),
+        module_id: crate::program_module_id!("test"),
         code: Code::from_vec(vec![
             VecNew { dst: FO(0) },
             SlotBorrow {
@@ -463,6 +481,7 @@ fn zero_elem_size_vec_push() {
 fn empty_code() {
     let func = Function {
         name: GlobalArenaPtr::from_static("test"),
+        module_id: crate::program_module_id!("test"),
         code: Code::from_vec(vec![]),
         param_slots: vec![],
         param_region_size: 0,
@@ -481,6 +500,7 @@ fn empty_code() {
 fn zero_frame_size() {
     let func = Function {
         name: GlobalArenaPtr::from_static("test"),
+        module_id: crate::program_module_id!("test"),
         code: Code::from_vec(vec![MicroOp::Return]),
         param_slots: vec![],
         param_region_size: 0,
@@ -506,6 +526,7 @@ fn zero_frame_size() {
 fn func_with_single_op(op: MicroOp) -> Function {
     Function {
         name: GlobalArenaPtr::from_static("test"),
+        module_id: crate::program_module_id!("test"),
         code: Code::from_vec(vec![op, MicroOp::Return]),
         param_slots: vec![],
         param_region_size: 0,
@@ -612,6 +633,7 @@ fn multiple_errors_collected() {
     use MicroOp::*;
     let func = Function {
         name: GlobalArenaPtr::from_static("test"),
+        module_id: crate::program_module_id!("test"),
         code: Code::from_vec(vec![
             StoreImm8 {
                 dst: FO(100),
@@ -649,6 +671,7 @@ fn vec_pushback_must_target_vector_descriptor() {
     use MicroOp::*;
     let func = Function {
         name: GlobalArenaPtr::from_static("test"),
+        module_id: crate::program_module_id!("test"),
         code: Code::from_vec(vec![
             VecNew { dst: FO(0) },
             SlotBorrow {
@@ -687,6 +710,7 @@ fn heap_new_rejects_vector_descriptor() {
     // trivial_descriptors() has Vector at index 2.
     let func = Function {
         name: GlobalArenaPtr::from_static("test"),
+        module_id: crate::program_module_id!("test"),
         code: Code::from_vec(vec![
             HeapNew {
                 dst: FO(0),

--- a/third_party/move/mono-move/specializer/Cargo.toml
+++ b/third_party/move/mono-move/specializer/Cargo.toml
@@ -6,7 +6,6 @@ publish = false
 
 [dependencies]
 anyhow = { workspace = true }
-bcs = { workspace = true }
 mono-move-core = { workspace = true }
 mono-move-gas = { workspace = true }
 move-binary-format = { workspace = true }

--- a/third_party/move/mono-move/specializer/src/lower/context.rs
+++ b/third_party/move/mono-move/specializer/src/lower/context.rs
@@ -803,9 +803,10 @@ fn try_discover_types_for_lowering_in_function_impl(
             descriptors.closure_captured.push(layout);
         }
 
-        // A constant references its own type, which `nominal_type_in_instr`
-        // does not surface. Discover it so the runtime layout (and any nested
-        // vector descriptors) that `StoreImmVec` resolves are published.
+        // The walks above don't reach a constant's own type. A vector
+        // constant needs its (possibly nested) vector descriptors published
+        // so `StoreImmVec` can resolve them at runtime, so discover the
+        // constant's type here.
         if let Instr::LdConst(_, idx) = instr {
             let ty = module_ir.module.interned_constant_type_at(*idx);
             discover_type_metadata(ctx, ty, ty_args, visited, &mut descriptors.vec)?;

--- a/third_party/move/mono-move/specializer/src/lower/context.rs
+++ b/third_party/move/mono-move/specializer/src/lower/context.rs
@@ -676,6 +676,7 @@ pub fn try_lower_function(
 
     Ok(LoweringOutcome::Built(Function {
         name,
+        module_id: module_ir.module.id(),
         code: Code::from_vec(code),
         param_slots,
         param_region_size: derived.param_region_size as usize,
@@ -800,6 +801,14 @@ fn try_discover_types_for_lowering_in_function_impl(
             let layout =
                 discover_captured_data_descriptor(ctx, interner, module_ir, *fhi, *mask, ty_args)?;
             descriptors.closure_captured.push(layout);
+        }
+
+        // A constant references its own type, which `nominal_type_in_instr`
+        // does not surface. Discover it so the runtime layout (and any nested
+        // vector descriptors) that `StoreImmVec` resolves are published.
+        if let Instr::LdConst(_, idx) = instr {
+            let ty = module_ir.module.interned_constant_type_at(*idx);
+            discover_type_metadata(ctx, ty, ty_args, visited, &mut descriptors.vec)?;
         }
     }
 

--- a/third_party/move/mono-move/specializer/src/lower/translate.rs
+++ b/third_party/move/mono-move/specializer/src/lower/translate.rs
@@ -12,7 +12,7 @@ use crate::stackless_exec_ir::{
     instr_utils::{clobbers_xfer, for_each_value_use},
     BinaryOp, CmpOp, FunctionIR, ImmValue, Instr, Label, Slot, UnaryOp,
 };
-use anyhow::{bail, Context, Result};
+use anyhow::{anyhow, bail, Context, Result};
 use mono_move_core::{
     native::{FrameSlot, NativeABI},
     types::{strip_ref, view_type, InternedType, Type},
@@ -20,8 +20,22 @@ use mono_move_core::{
     IntCastOp, IntCmpOp, IntNegateOp, IntOperand, IntShiftOp, IntTy, JumpIntCmpOp, MicroOp,
     PackClosureOp, SafePointEntry, ShiftOperand, SizedSlot, FRAME_METADATA_SIZE,
 };
-use move_binary_format::file_format::FieldHandleIndex;
-use move_core_types::account_address::AccountAddress;
+use move_binary_format::file_format::{ConstantPoolIndex, FieldHandleIndex};
+
+/// Validates that a primitive constant's BCS bytes are exactly `N` wide and
+/// returns them as a fixed array. Fixed-width integers and `address` encode
+/// with no length prefix, so these bytes are already the in-memory
+/// representation the matching `StoreImm` expects.
+fn const_imm<const N: usize>(idx: ConstantPoolIndex, bytes: &[u8]) -> Result<[u8; N]> {
+    bytes.try_into().map_err(|_| {
+        anyhow!(
+            "LdConst at constant pool index {}: expected {}-byte constant data, got {}",
+            idx.0,
+            N,
+            bytes.len()
+        )
+    })
+}
 
 /// Lower a slot-allocated function to its micro-op form.
 ///
@@ -423,27 +437,70 @@ impl<'a> LoweringState<'a> {
             },
             Instr::LdConst(dst, idx) => {
                 let ty = view_type(self.ctx.module.interned_constant_type_at(*idx));
+                let bcs_bytes = self.ctx.module.constant_data_at(*idx);
+                let dst_info = self.def_slot(*dst)?;
+                // Constants store their value BCS-encoded. Fixed-width
+                // integers encode as their raw little-endian bytes and
+                // `address` as its 32 raw bytes, both with no length prefix,
+                // so the constant data drops straight into the matching
+                // `StoreImm`. Vectors are heap-allocated at runtime from the
+                // constant pool, so they keep their own micro-op.
+                //
+                // TODO(endianness): revisit this when we fix the endianness
+                // story for the VM.
                 match ty {
-                    Type::Address => {
-                        let bytes = self.ctx.module.constant_data_at(*idx);
-                        let addr = bcs::from_bytes::<AccountAddress>(bytes)
-                            .context("LdConst<address>: malformed constant data")?;
-                        let dst_info = self.def_slot(*dst)?;
+                    Type::Bool | Type::U8 | Type::I8 => {
+                        self.emit(MicroOp::StoreImm1 {
+                            dst: dst_info.offset,
+                            imm: const_imm::<1>(*idx, bcs_bytes)?[0],
+                        })?;
+                    },
+                    Type::U16 | Type::I16 => {
+                        self.emit(MicroOp::StoreImm2 {
+                            dst: dst_info.offset,
+                            imm: const_imm::<2>(*idx, bcs_bytes)?,
+                        })?;
+                    },
+                    Type::U32 | Type::I32 => {
+                        self.emit(MicroOp::StoreImm4 {
+                            dst: dst_info.offset,
+                            imm: const_imm::<4>(*idx, bcs_bytes)?,
+                        })?;
+                    },
+                    Type::U64 | Type::I64 => {
+                        self.emit(MicroOp::StoreImm8 {
+                            dst: dst_info.offset,
+                            imm: const_imm::<8>(*idx, bcs_bytes)?,
+                        })?;
+                    },
+                    Type::U128 | Type::I128 => {
+                        self.emit(MicroOp::StoreImm16 {
+                            dst: dst_info.offset,
+                            imm: Box::new(const_imm::<16>(*idx, bcs_bytes)?),
+                        })?;
+                    },
+                    Type::U256 | Type::I256 | Type::Address => {
                         self.emit(MicroOp::StoreImm32 {
                             dst: dst_info.offset,
-                            imm: Box::new(addr.into_bytes()),
+                            imm: Box::new(const_imm::<32>(*idx, bcs_bytes)?),
                         })?;
                     },
                     Type::Vector { .. } => {
-                        let dst_info = self.def_slot(*dst)?;
                         self.emit(MicroOp::StoreImmVec {
                             dst: dst_info.offset,
                             idx: *idx,
                         })?;
                     },
-                    _ => bail!(
-                        "LdConst at constant pool index {} not yet lowered \
-                         (only address and vector constants are supported)",
+                    // The bytecode verifier rejects constants of these types,
+                    // so reaching them here is an invariant violation.
+                    Type::Signer
+                    | Type::ImmutRef { .. }
+                    | Type::MutRef { .. }
+                    | Type::Nominal { .. }
+                    | Type::Function { .. }
+                    | Type::TypeParam { .. } => bail!(
+                        "LdConst at constant pool index {}: constant type is not \
+                         permitted by the bytecode verifier",
                         idx.0,
                     ),
                 }

--- a/third_party/move/mono-move/specializer/src/lower/translate.rs
+++ b/third_party/move/mono-move/specializer/src/lower/translate.rs
@@ -423,9 +423,9 @@ impl<'a> LoweringState<'a> {
             },
             Instr::LdConst(dst, idx) => {
                 let ty = view_type(self.ctx.module.interned_constant_type_at(*idx));
-                let bytes = self.ctx.module.constant_data_at(*idx);
                 match ty {
                     Type::Address => {
+                        let bytes = self.ctx.module.constant_data_at(*idx);
                         let addr = bcs::from_bytes::<AccountAddress>(bytes)
                             .context("LdConst<address>: malformed constant data")?;
                         let dst_info = self.def_slot(*dst)?;
@@ -434,9 +434,16 @@ impl<'a> LoweringState<'a> {
                             imm: Box::new(addr.into_bytes()),
                         })?;
                     },
+                    Type::Vector { .. } => {
+                        let dst_info = self.def_slot(*dst)?;
+                        self.emit(MicroOp::StoreImmVec {
+                            dst: dst_info.offset,
+                            idx: *idx,
+                        })?;
+                    },
                     _ => bail!(
                         "LdConst at constant pool index {} not yet lowered \
-                         (only address constants are supported)",
+                         (only address and vector constants are supported)",
                         idx.0,
                     ),
                 }

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/constants/ld_const_nested_vec.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/constants/ld_const_nested_vec.exp
@@ -1,0 +1,153 @@
+=== stackless ===
+// module 0x1::test
+
+fun is_empty(): bool {
+  slots: params(0), locals(1), temps(3)
+    r0: vector<vector<u8>>
+    r1: &vector<vector<u8>>
+    r2: u64
+    r3: bool
+  code:
+  L0:
+    0: r0 := vec_pack vector<u8>, 0, []
+    1: r1 := imm_borrow_loc r0
+    2: r2 := vec_len vector<u8>, r1
+    3: r3 := eq r2, #0
+    4: ret [r3]
+}
+
+fun elem(r0, r1): u8 {
+  slots: params(2), locals(1), temps(4)
+    r0: u64
+    r1: u64
+    r2: vector<vector<u8>>
+    r3: &vector<vector<u8>>
+    r4: &vector<u8>
+    r5: &u8
+    r6: u8
+  code:
+  L0:
+    0: r2 := ld_const #0
+    1: r3 := imm_borrow_loc r2
+    2: r4 := vec_imm_borrow vector<u8>, r3, r0
+    3: r5 := vec_imm_borrow u8, r4, r1
+    4: r6 := read_ref r5
+    5: ret [r6]
+}
+
+fun inner_0_len(): u64 {
+  slots: params(0), locals(1), temps(3)
+    r0: vector<vector<u8>>
+    r1: &vector<vector<u8>>
+    r2: u64
+    r3: &vector<u8>
+  code:
+  L0:
+    0: r0 := ld_const #0
+    1: r1 := imm_borrow_loc r0
+    2: r2 := ld_u64 0
+    3: r3 := vec_imm_borrow vector<u8>, r1, r2
+    4: r2 := vec_len u8, r3
+    5: ret [r2]
+}
+
+fun inner_1_len(): u64 {
+  slots: params(0), locals(1), temps(3)
+    r0: vector<vector<u8>>
+    r1: &vector<vector<u8>>
+    r2: u64
+    r3: &vector<u8>
+  code:
+  L0:
+    0: r0 := ld_const #0
+    1: r1 := imm_borrow_loc r0
+    2: r2 := ld_u64 1
+    3: r3 := vec_imm_borrow vector<u8>, r1, r2
+    4: r2 := vec_len u8, r3
+    5: ret [r2]
+}
+
+fun outer_len(): u64 {
+  slots: params(0), locals(1), temps(2)
+    r0: vector<vector<u8>>
+    r1: &vector<vector<u8>>
+    r2: u64
+  code:
+  L0:
+    0: r0 := ld_const #0
+    1: r1 := imm_borrow_loc r0
+    2: r2 := vec_len vector<u8>, r1
+    3: ret [r2]
+}
+=== micro-ops ===
+// module 0x1::test
+
+fun is_empty() {
+  frame_data_size: 40
+  code:
+    0: Charge #24
+    1: VecNew [0]
+    2: SlotBorrow [8] <- &[0]
+    3: VecLen [24] <- vec_len([8])
+    4: IntCmp [32] <- [24] == u64 #0
+    5: Move(1) [0] <- [32]
+    6: Return
+}
+
+fun elem() {
+  frame_data_size: 80
+  code:
+    0: Charge #30
+    1: StoreImmVec [16] <- const[0]
+    2: SlotBorrow [24] <- &[16]
+    3: VecBorrow [40] <- &[24][[0]] (elem_size=8)
+    4: VecBorrow [56] <- &[40][[8]] (elem_size=1)
+    5: ReadRef [72] <- *[56] (size=1)
+    6: Move(1) [0] <- [72]
+    7: Return
+  safe_point_layouts:
+    1: []
+}
+
+fun inner_0_len() {
+  frame_data_size: 48
+  code:
+    0: Charge #23
+    1: StoreImmVec [0] <- const[0]
+    2: SlotBorrow [8] <- &[0]
+    3: StoreImm8 [24] <- #0
+    4: VecBorrow [32] <- &[8][[24]] (elem_size=8)
+    5: VecLen [24] <- vec_len([32])
+    6: Move8 [0] <- [24]
+    7: Return
+  safe_point_layouts:
+    1: []
+}
+
+fun inner_1_len() {
+  frame_data_size: 48
+  code:
+    0: Charge #23
+    1: StoreImmVec [0] <- const[0]
+    2: SlotBorrow [8] <- &[0]
+    3: StoreImm8 [24] <- #1
+    4: VecBorrow [32] <- &[8][[24]] (elem_size=8)
+    5: VecLen [24] <- vec_len([32])
+    6: Move8 [0] <- [24]
+    7: Return
+  safe_point_layouts:
+    1: []
+}
+
+fun outer_len() {
+  frame_data_size: 32
+  code:
+    0: Charge #18
+    1: StoreImmVec [0] <- const[0]
+    2: SlotBorrow [8] <- &[0]
+    3: VecLen [24] <- vec_len([8])
+    4: Move8 [0] <- [24]
+    5: Return
+  safe_point_layouts:
+    1: []
+}

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/constants/ld_const_nested_vec.move
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/constants/ld_const_nested_vec.move
@@ -1,0 +1,43 @@
+// RUN: publish --print(stackless,micro-ops)
+module 0x1::test {
+    const NESTED_EMPTY: vector<vector<u8>> = vector[];
+    const NESTED: vector<vector<u8>> = vector[vector[10], vector[20, 30, 40]];
+
+    fun is_empty(): bool {
+        std::vector::length(&NESTED_EMPTY) == 0
+    }
+
+    fun outer_len(): u64 {
+        std::vector::length(&NESTED)
+    }
+
+    fun inner_0_len(): u64 {
+        std::vector::length(std::vector::borrow(&NESTED, 0))
+    }
+
+    fun inner_1_len(): u64 {
+        std::vector::length(std::vector::borrow(&NESTED, 1))
+    }
+
+    fun elem(a: u64, b: u64): u8 {
+        *std::vector::borrow(std::vector::borrow(&NESTED, a), b)
+    }
+}
+
+// RUN: execute 0x1::test::is_empty
+// CHECK: results: true
+
+// RUN: execute 0x1::test::outer_len
+// CHECK: results: 2
+
+// RUN: execute 0x1::test::inner_0_len
+// CHECK: results: 1
+
+// RUN: execute 0x1::test::inner_1_len
+// CHECK: results: 3
+
+// RUN: execute 0x1::test::elem --args 0, 0
+// CHECK: results: 10
+
+// RUN: execute 0x1::test::elem --args 1, 1
+// CHECK: results: 30

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/constants/ld_const_scalars.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/constants/ld_const_scalars.exp
@@ -1,0 +1,259 @@
+=== stackless ===
+// module 0x66::test
+
+fun c_bool_true(): bool {
+  slots: params(0), locals(0), temps(1)
+    r0: bool
+  code:
+  L0:
+    0: r0 := ld_const #0
+    1: ret [r0]
+}
+
+fun c_bool_false(): bool {
+  slots: params(0), locals(0), temps(1)
+    r0: bool
+  code:
+  L0:
+    0: r0 := ld_const #1
+    1: ret [r0]
+}
+
+fun c_u8(): u8 {
+  slots: params(0), locals(0), temps(1)
+    r0: u8
+  code:
+  L0:
+    0: r0 := ld_const #2
+    1: ret [r0]
+}
+
+fun c_u16(): u16 {
+  slots: params(0), locals(0), temps(1)
+    r0: u16
+  code:
+  L0:
+    0: r0 := ld_const #3
+    1: ret [r0]
+}
+
+fun c_u32(): u32 {
+  slots: params(0), locals(0), temps(1)
+    r0: u32
+  code:
+  L0:
+    0: r0 := ld_const #4
+    1: ret [r0]
+}
+
+fun c_u64(): u64 {
+  slots: params(0), locals(0), temps(1)
+    r0: u64
+  code:
+  L0:
+    0: r0 := ld_const #5
+    1: ret [r0]
+}
+
+fun c_u128(): u128 {
+  slots: params(0), locals(0), temps(1)
+    r0: u128
+  code:
+  L0:
+    0: r0 := ld_const #6
+    1: ret [r0]
+}
+
+fun c_u256(): u256 {
+  slots: params(0), locals(0), temps(1)
+    r0: u256
+  code:
+  L0:
+    0: r0 := ld_const #7
+    1: ret [r0]
+}
+
+fun c_i8(): i8 {
+  slots: params(0), locals(0), temps(1)
+    r0: i8
+  code:
+  L0:
+    0: r0 := ld_const #8
+    1: ret [r0]
+}
+
+fun c_i16(): i16 {
+  slots: params(0), locals(0), temps(1)
+    r0: i16
+  code:
+  L0:
+    0: r0 := ld_const #9
+    1: ret [r0]
+}
+
+fun c_i32(): i32 {
+  slots: params(0), locals(0), temps(1)
+    r0: i32
+  code:
+  L0:
+    0: r0 := ld_const #10
+    1: ret [r0]
+}
+
+fun c_i64(): i64 {
+  slots: params(0), locals(0), temps(1)
+    r0: i64
+  code:
+  L0:
+    0: r0 := ld_const #11
+    1: ret [r0]
+}
+
+fun c_i128(): i128 {
+  slots: params(0), locals(0), temps(1)
+    r0: i128
+  code:
+  L0:
+    0: r0 := ld_const #12
+    1: ret [r0]
+}
+
+fun c_i256(): i256 {
+  slots: params(0), locals(0), temps(1)
+    r0: i256
+  code:
+  L0:
+    0: r0 := ld_const #13
+    1: ret [r0]
+}
+
+fun c_address(): address {
+  slots: params(0), locals(0), temps(1)
+    r0: address
+  code:
+  L0:
+    0: r0 := ld_const #14
+    1: ret [r0]
+}
+=== micro-ops ===
+// module 0x66::test
+
+fun c_bool_true() {
+  frame_data_size: 8
+  code:
+    0: Charge #4
+    1: StoreImm1 [0] <- #1
+    2: Return
+}
+
+fun c_bool_false() {
+  frame_data_size: 8
+  code:
+    0: Charge #4
+    1: StoreImm1 [0] <- #0
+    2: Return
+}
+
+fun c_u8() {
+  frame_data_size: 8
+  code:
+    0: Charge #4
+    1: StoreImm1 [0] <- #255
+    2: Return
+}
+
+fun c_u16() {
+  frame_data_size: 8
+  code:
+    0: Charge #4
+    1: StoreImm2 [0] <- #65535
+    2: Return
+}
+
+fun c_u32() {
+  frame_data_size: 8
+  code:
+    0: Charge #4
+    1: StoreImm4 [0] <- #4294967295
+    2: Return
+}
+
+fun c_u64() {
+  frame_data_size: 8
+  code:
+    0: Charge #4
+    1: StoreImm8 [0] <- #18446744073709551615
+    2: Return
+}
+
+fun c_u128() {
+  frame_data_size: 16
+  code:
+    0: Charge #5
+    1: StoreImm16 [0] <- #340282366920938463463374607431768211455
+    2: Return
+}
+
+fun c_u256() {
+  frame_data_size: 32
+  code:
+    0: Charge #6
+    1: StoreImm32 [0] <- #115792089237316195423570985008687907853269984665640564039457584007913129639935
+    2: Return
+}
+
+fun c_i8() {
+  frame_data_size: 8
+  code:
+    0: Charge #4
+    1: StoreImm1 [0] <- #128
+    2: Return
+}
+
+fun c_i16() {
+  frame_data_size: 8
+  code:
+    0: Charge #4
+    1: StoreImm2 [0] <- #32768
+    2: Return
+}
+
+fun c_i32() {
+  frame_data_size: 8
+  code:
+    0: Charge #4
+    1: StoreImm4 [0] <- #2147483648
+    2: Return
+}
+
+fun c_i64() {
+  frame_data_size: 8
+  code:
+    0: Charge #4
+    1: StoreImm8 [0] <- #9223372036854775808
+    2: Return
+}
+
+fun c_i128() {
+  frame_data_size: 16
+  code:
+    0: Charge #5
+    1: StoreImm16 [0] <- #170141183460469231731687303715884105728
+    2: Return
+}
+
+fun c_i256() {
+  frame_data_size: 32
+  code:
+    0: Charge #6
+    1: StoreImm32 [0] <- #57896044618658097711785492504343953926634992332820282019728792003956564819968
+    2: Return
+}
+
+fun c_address() {
+  frame_data_size: 32
+  code:
+    0: Charge #6
+    1: StoreImm32 [0] <- #115244366647234896281400162783457603113363464657609122162439886085512417509376
+    2: Return
+}

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/constants/ld_const_scalars.masm
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/constants/ld_const_scalars.masm
@@ -1,0 +1,107 @@
+// RUN: publish --print(stackless,micro-ops)
+module 0x66::test
+
+fun c_bool_true(): bool
+    ld_const<bool> 1
+    ret
+
+fun c_bool_false(): bool
+    ld_const<bool> 0
+    ret
+
+fun c_u8(): u8
+    ld_const<u8> 255
+    ret
+
+fun c_u16(): u16
+    ld_const<u16> 65535
+    ret
+
+fun c_u32(): u32
+    ld_const<u32> 4294967295
+    ret
+
+fun c_u64(): u64
+    ld_const<u64> 18446744073709551615
+    ret
+
+fun c_u128(): u128
+    ld_const<u128> 340282366920938463463374607431768211455
+    ret
+
+fun c_u256(): u256
+    ld_const<u256> 115792089237316195423570985008687907853269984665640564039457584007913129639935
+    ret
+
+fun c_i8(): i8
+    ld_const<i8> -128
+    ret
+
+fun c_i16(): i16
+    ld_const<i16> -32768
+    ret
+
+fun c_i32(): i32
+    ld_const<i32> -2147483648
+    ret
+
+fun c_i64(): i64
+    ld_const<i64> -9223372036854775808
+    ret
+
+fun c_i128(): i128
+    ld_const<i128> -170141183460469231731687303715884105728
+    ret
+
+fun c_i256(): i256
+    ld_const<i256> -57896044618658097711785492504343953926634992332820282019728792003956564819968
+    ret
+
+fun c_address(): address
+    ld_const<address> 0xCAFE
+    ret
+
+// RUN: execute 0x66::test::c_bool_true
+// CHECK: results: true
+
+// RUN: execute 0x66::test::c_bool_false
+// CHECK: results: false
+
+// RUN: execute 0x66::test::c_u8
+// CHECK: results: 255
+
+// RUN: execute 0x66::test::c_u16
+// CHECK: results: 65535
+
+// RUN: execute 0x66::test::c_u32
+// CHECK: results: 4294967295
+
+// RUN: execute 0x66::test::c_u64
+// CHECK: results: 18446744073709551615
+
+// RUN: execute 0x66::test::c_u128
+// CHECK: results: 340282366920938463463374607431768211455
+
+// RUN: execute 0x66::test::c_u256
+// CHECK: results: 115792089237316195423570985008687907853269984665640564039457584007913129639935
+
+// RUN: execute 0x66::test::c_i8
+// CHECK: results: -128
+
+// RUN: execute 0x66::test::c_i16
+// CHECK: results: -32768
+
+// RUN: execute 0x66::test::c_i32
+// CHECK: results: -2147483648
+
+// RUN: execute 0x66::test::c_i64
+// CHECK: results: -9223372036854775808
+
+// RUN: execute 0x66::test::c_i128
+// CHECK: results: -170141183460469231731687303715884105728
+
+// RUN: execute 0x66::test::c_i256
+// CHECK: results: -57896044618658097711785492504343953926634992332820282019728792003956564819968
+
+// RUN: execute 0x66::test::c_address
+// CHECK: results: 0xcafe

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/constants/ld_const_vec_address.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/constants/ld_const_vec_address.exp
@@ -1,0 +1,60 @@
+=== stackless ===
+// module 0x1::test
+
+fun len(): u64 {
+  slots: params(0), locals(1), temps(2)
+    r0: vector<address>
+    r1: &vector<address>
+    r2: u64
+  code:
+  L0:
+    0: r0 := ld_const #0
+    1: r1 := imm_borrow_loc r0
+    2: r2 := vec_len address, r1
+    3: ret [r2]
+}
+
+fun addr(r0): address {
+  slots: params(1), locals(1), temps(3)
+    r0: u64
+    r1: vector<address>
+    r2: &vector<address>
+    r3: &address
+    r4: address
+  code:
+  L0:
+    0: r1 := ld_const #0
+    1: r2 := imm_borrow_loc r1
+    2: r3 := vec_imm_borrow address, r2, r0
+    3: r4 := read_ref r3
+    4: ret [r4]
+}
+=== micro-ops ===
+// module 0x1::test
+
+fun len() {
+  frame_data_size: 32
+  code:
+    0: Charge #18
+    1: StoreImmVec [0] <- const[0]
+    2: SlotBorrow [8] <- &[0]
+    3: VecLen [24] <- vec_len([8])
+    4: Move8 [0] <- [24]
+    5: Return
+  safe_point_layouts:
+    1: []
+}
+
+fun addr() {
+  frame_data_size: 80
+  code:
+    0: Charge #213
+    1: StoreImmVec [8] <- const[0]
+    2: SlotBorrow [16] <- &[8]
+    3: VecBorrow [32] <- &[16][[0]] (elem_size=32)
+    4: ReadRef [48] <- *[32] (size=32)
+    5: Move(32) [0] <- [48]
+    6: Return
+  safe_point_layouts:
+    1: []
+}

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/constants/ld_const_vec_address.move
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/constants/ld_const_vec_address.move
@@ -1,0 +1,24 @@
+// RUN: publish --print(stackless,micro-ops)
+module 0x1::test {
+    const ADDRS: vector<address> = vector[@0x1, @0xCAFE, @0x0];
+
+    fun len(): u64 {
+        std::vector::length(&ADDRS)
+    }
+
+    fun addr(n: u64): address {
+        *std::vector::borrow(&ADDRS, n)
+    }
+}
+
+// RUN: execute 0x1::test::len
+// CHECK: results: 3
+
+// RUN: execute 0x1::test::addr --args 0
+// CHECK: results: 0x1
+
+// RUN: execute 0x1::test::addr --args 1
+// CHECK: results: 0xcafe
+
+// RUN: execute 0x1::test::addr --args 2
+// CHECK: results: 0x0

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/constants/ld_const_vec_bool.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/constants/ld_const_vec_bool.exp
@@ -1,0 +1,34 @@
+=== stackless ===
+// module 0x1::test
+
+fun flag(r0): bool {
+  slots: params(1), locals(1), temps(3)
+    r0: u64
+    r1: vector<bool>
+    r2: &vector<bool>
+    r3: &bool
+    r4: bool
+  code:
+  L0:
+    0: r1 := ld_const #0
+    1: r2 := imm_borrow_loc r1
+    2: r3 := vec_imm_borrow bool, r2, r0
+    3: r4 := read_ref r3
+    4: ret [r4]
+}
+=== micro-ops ===
+// module 0x1::test
+
+fun flag() {
+  frame_data_size: 56
+  code:
+    0: Charge #27
+    1: StoreImmVec [8] <- const[0]
+    2: SlotBorrow [16] <- &[8]
+    3: VecBorrow [32] <- &[16][[0]] (elem_size=1)
+    4: ReadRef [48] <- *[32] (size=1)
+    5: Move(1) [0] <- [48]
+    6: Return
+  safe_point_layouts:
+    1: []
+}

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/constants/ld_const_vec_bool.move
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/constants/ld_const_vec_bool.move
@@ -1,0 +1,14 @@
+// RUN: publish --print(stackless,micro-ops)
+module 0x1::test {
+    const FLAGS: vector<bool> = vector[true, false];
+
+    fun flag(n: u64): bool {
+        *std::vector::borrow(&FLAGS, n)
+    }
+}
+
+// RUN: execute 0x1::test::flag --args 0
+// CHECK: results: true
+
+// RUN: execute 0x1::test::flag --args 1
+// CHECK: results: false

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/constants/ld_const_vec_u64.exp
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/constants/ld_const_vec_u64.exp
@@ -1,0 +1,135 @@
+=== stackless ===
+// module 0x1::test
+
+fun nums_first(): u64 {
+  slots: params(0), locals(1), temps(3)
+    r0: vector<u64>
+    r1: &vector<u64>
+    r2: u64
+    r3: &u64
+  code:
+  L0:
+    0: r0 := ld_const #0
+    1: r1 := imm_borrow_loc r0
+    2: r2 := ld_u64 0
+    3: r3 := vec_imm_borrow u64, r1, r2
+    4: r2 := read_ref r3
+    5: ret [r2]
+}
+
+fun nums_last(): u64 {
+  slots: params(0), locals(1), temps(3)
+    r0: vector<u64>
+    r1: &vector<u64>
+    r2: u64
+    r3: &u64
+  code:
+  L0:
+    0: r0 := ld_const #0
+    1: r1 := imm_borrow_loc r0
+    2: r2 := ld_u64 2
+    3: r3 := vec_imm_borrow u64, r1, r2
+    4: r2 := read_ref r3
+    5: ret [r2]
+}
+
+fun nums_len(): u64 {
+  slots: params(0), locals(1), temps(2)
+    r0: vector<u64>
+    r1: &vector<u64>
+    r2: u64
+  code:
+  L0:
+    0: r0 := ld_const #0
+    1: r1 := imm_borrow_loc r0
+    2: r2 := vec_len u64, r1
+    3: ret [r2]
+}
+
+fun nums_modification(): u64 {
+  slots: params(0), locals(2), temps(4)
+    r0: vector<u64>
+    r1: &mut u64
+    r2: &mut vector<u64>
+    r3: u64
+    r4: &vector<u64>
+    r5: &u64
+  code:
+  L0:
+    0: r0 := ld_const #0
+    1: r2 := mut_borrow_loc r0
+    2: r3 := ld_u64 0
+    3: r1 := vec_mut_borrow u64, r2, r3
+    4: r3 := ld_u64 400
+    5: write_ref r1, r3
+    6: r4 := imm_borrow_loc r0
+    7: r3 := ld_u64 0
+    8: r5 := vec_imm_borrow u64, r4, r3
+    9: r3 := read_ref r5
+    10: ret [r3]
+}
+=== micro-ops ===
+// module 0x1::test
+
+fun nums_first() {
+  frame_data_size: 48
+  code:
+    0: Charge #47
+    1: StoreImmVec [0] <- const[0]
+    2: SlotBorrow [8] <- &[0]
+    3: StoreImm8 [24] <- #0
+    4: VecBorrow [32] <- &[8][[24]] (elem_size=8)
+    5: ReadRef [24] <- *[32] (size=8)
+    6: Move8 [0] <- [24]
+    7: Return
+  safe_point_layouts:
+    1: []
+}
+
+fun nums_last() {
+  frame_data_size: 48
+  code:
+    0: Charge #47
+    1: StoreImmVec [0] <- const[0]
+    2: SlotBorrow [8] <- &[0]
+    3: StoreImm8 [24] <- #2
+    4: VecBorrow [32] <- &[8][[24]] (elem_size=8)
+    5: ReadRef [24] <- *[32] (size=8)
+    6: Move8 [0] <- [24]
+    7: Return
+  safe_point_layouts:
+    1: []
+}
+
+fun nums_len() {
+  frame_data_size: 32
+  code:
+    0: Charge #18
+    1: StoreImmVec [0] <- const[0]
+    2: SlotBorrow [8] <- &[0]
+    3: VecLen [24] <- vec_len([8])
+    4: Move8 [0] <- [24]
+    5: Return
+  safe_point_layouts:
+    1: []
+}
+
+fun nums_modification() {
+  frame_data_size: 80
+  code:
+    0: Charge #82
+    1: StoreImmVec [0] <- const[0]
+    2: SlotBorrow [24] <- &[0]
+    3: StoreImm8 [40] <- #0
+    4: VecBorrow [8] <- &[24][[40]] (elem_size=8)
+    5: StoreImm8 [40] <- #400
+    6: WriteRef *[8] <- [40] (size=8)
+    7: SlotBorrow [48] <- &[0]
+    8: StoreImm8 [40] <- #0
+    9: VecBorrow [64] <- &[48][[40]] (elem_size=8)
+    10: ReadRef [40] <- *[64] (size=8)
+    11: Move8 [0] <- [40]
+    12: Return
+  safe_point_layouts:
+    1: []
+}

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/constants/ld_const_vec_u64.move
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/constants/ld_const_vec_u64.move
@@ -1,0 +1,35 @@
+// RUN: publish --print(stackless,micro-ops)
+module 0x1::test {
+    const NUMS: vector<u64> = vector[100, 200, 300];
+
+    fun nums_len(): u64 {
+        std::vector::length(&NUMS)
+    }
+
+    fun nums_first(): u64 {
+        *std::vector::borrow(&NUMS, 0)
+    }
+
+    fun nums_last(): u64 {
+        *std::vector::borrow(&NUMS, 2)
+    }
+
+    fun nums_modification(): u64 {
+        let nums = NUMS;
+        let v = std::vector::borrow_mut(&mut nums, 0);
+        *v = 400;
+        *std::vector::borrow(&nums, 0)
+    }
+}
+
+// RUN: execute 0x1::test::nums_len
+// CHECK: results: 3
+
+// RUN: execute 0x1::test::nums_first
+// CHECK: results: 100
+
+// RUN: execute 0x1::test::nums_last
+// CHECK: results: 300
+
+// RUN: execute 0x1::test::nums_modification
+// CHECK: results: 400


### PR DESCRIPTION
## Description

Adds support for `vector` constants in `LdConst` for the new Move VM (mono-move). Previously only `address` constants were lowered; any vector constant hit a `bail!`.

A vector constant is materialized on every `LdConst` as a fresh, fully-owned heap value (Move semantics emit a separate `LdConst` per use, so the loaded value can be mutated independently). This reuses the existing `value_utils::deserialize`, which already picks a single bulk `memcpy` for pointer-free element types and recurses for nested vectors.

Changes:
- New runtime micro-op `StoreImmVec { dst, idx }` (core). It carries only the constant pool index; the type and BCS bytes are resolved at runtime.
- `Function.module_id` so the executing function can resolve its own constants against the module read set.
- `ExecutionContext::load_constant(module_id, idx)` — resolves `(InternedType, &[u8])` from the read set on `TransactionContext`; `None` on the module-less local contexts.
- Interpreter handler calls `deserialize` with a GC-collect-and-retry on out-of-heap (the deserializer never runs GC itself).
- Lowering emits `StoreImmVec` for `Type::Vector` constants; discovery publishes each constant's layout and nested vector descriptors.

For P0 the constant is copied on every load. A read-only-sharing / copy-on-write optimization is deferred. `StoreImmVec` gas is a fixed placeholder (TODO: make size-proportional).

## How Has This Been Tested?

New differential tests under `testsuite/.../differential/constants/` run each case on both the legacy Move VM and mono-move and assert the results match:
- `ld_const_vec_u64.move`, `ld_const_vec_bool.move`, `ld_const_vec_address.move` — different element widths.
- `ld_const_nested_vec.move` — `vector<vector<u8>>` / `vector<vector<u64>>`, exercising the recursive deserialize path.

Each baseline `.exp` shows `StoreImmVec` in the lowered micro-ops, confirming the new op is exercised. Full `mono-move-testsuite` and `mono-move-runtime` suites pass with no regressions.

## Key Areas to Review

- The GC-retry contract in the interpreter handler: `deserialize` is all-or-nothing and writes `dst` only on success, so a failed first attempt leaves no partial state and `dst` is not yet a live pointer when the retry GC runs.
- Constant-type discovery in the specializer — required so `layout_by_ty` (and nested vector descriptors) resolve at runtime.

## Type of Change
- [x] New feature
- [x] Tests

## Which Components or Systems Does This Change Impact?
- [x] Move/Aptos Virtual Machine

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I tested both happy and unhappy path of the functionality

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches VM interpreter heap allocation, GC retry paths, and constant deserialization at runtime; scope is contained to mono-move with broad test coverage but each `LdConst` of a vector allocates on the heap.
> 
> **Overview**
> Adds full **`LdConst`** support in mono-move: scalar constants map to existing **`StoreImm*`** ops from raw BCS bytes (replacing address-only **`bcs`** decoding), and **vector** constants use a new allocating micro-op **`StoreImmVec`** that materializes a fresh heap vector per load via **`deserialize`**, with GC-and-retry on OOM.
> 
> **`Function`** now carries **`module_id`** so the interpreter can resolve constants through **`ExecutionContext::load_constant`**, implemented on **`TransactionContext`** via **`ModuleReadSet::get_loaded`** and the prepared module’s constant pool. The specializer discovers descriptor metadata for **`LdConst`** vector types during lowering; **`bcs`** is dropped from the specializer crate.
> 
> Differential testsuite cases cover scalar, vector, nested vector, and address-element constants; hand-built runtime tests set **`module_id`** via a **`program_module_id!`** macro.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1842fd00a6bb6c9cd0954ca182043dc29424c38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->