### PR TITLE
[consensus] bind round-0 parent QC to local genesis at proposal validation

### DIFF
--- a/consensus/src/round_manager.rs
+++ b/consensus/src/round_manager.rs
@@ -1242,6 +1242,31 @@ impl RoundManager {
             proposal,
         );
 
+        // A round-0 parent QC is the epoch's genesis certificate. `QuorumCert::verify`
+        // accepts it without signatures (it is implicitly agreed upon), so it only checks
+        // self-consistency and does not bind the certified BlockInfo to any real state.
+        // Bind it here to the genesis QC we derived locally from the previous epoch's final
+        // LedgerInfo (identical on every honest node), so a malicious proposer cannot smuggle
+        // an attacker-chosen genesis BlockInfo (fake executed_state_id / version) into the
+        // SafetyRules voting path.
+        let parent_qc = proposal.quorum_cert();
+        if parent_qc.certified_block().round() == 0 {
+            let local_genesis = self
+                .block_store
+                .get_quorum_cert_for_block(parent_qc.certified_block().id());
+            // Comparing the certified BlockInfo is sufficient: it carries executed_state_id and
+            // version (the fields the attacker forges, and the only part of the round-0 QC that
+            // flows into the signed vote LedgerInfo). The QC itself is signatureless by
+            // construction (QuorumCert::verify requires zero voters for round 0), so nothing else
+            // in the QC is security-relevant here.
+            ensure!(
+                local_genesis.map(|qc| qc.certified_block().clone())
+                    == Some(parent_qc.certified_block().clone()),
+                "[RoundManager] Proposal {} carries a round-0 QC whose certified block does not match the local genesis",
+                proposal.id(),
+            );
+        }
+
         // If the proposal contains any inline transactions that need to be denied
         // (e.g., due to filtering) drop the message and do not vote for the block.
         if let Err(error) = self

--- a/consensus/src/round_manager_tests/consensus_test.rs
+++ b/consensus/src/round_manager_tests/consensus_test.rs
@@ -25,16 +25,23 @@ use aptos_consensus_types::{
     common::{Author, Payload, Round},
     opt_proposal_msg::OptProposalMsg,
     proposal_msg::ProposalMsg,
+    quorum_cert::QuorumCert,
     sync_info::SyncInfo,
     timeout_2chain::{TwoChainTimeout, TwoChainTimeoutWithPartialSignatures},
+    vote_data::VoteData,
 };
-use aptos_crypto::HashValue;
+use aptos_crypto::{hash::CryptoHash, HashValue};
 use aptos_infallible::Mutex;
 use aptos_logger::prelude::info;
 use aptos_network::{protocols::network::Event, ProtocolId};
 use aptos_safety_rules::{PersistentSafetyStorage, SafetyRulesManager};
 use aptos_secure_storage::Storage;
-use aptos_types::validator_verifier::generate_validator_verifier;
+use aptos_types::{
+    aggregate_signature::AggregateSignature,
+    block_info::BlockInfo,
+    ledger_info::{LedgerInfo, LedgerInfoWithSignatures},
+    validator_verifier::generate_validator_verifier,
+};
 use futures::{channel::oneshot, StreamExt};
 use std::{sync::Arc, time::Duration};
 use tokio::{runtime::Runtime, time::timeout};
@@ -290,6 +297,85 @@ fn vote_on_successful_proposal() {
         assert_eq!(consensus_state.last_voted_round(), 1);
         assert_eq!(consensus_state.preferred_round(), 0);
         assert!(consensus_state.in_validator_set());
+    });
+}
+
+#[test]
+/// A round-0 (genesis) QC is accepted by `QuorumCert::verify` without signatures, so a
+/// malicious proposer could embed a round-0 QC that reuses the real genesis block id but carries
+/// an attacker-chosen executed_state_id / version. `process_proposal` binds the round-0 parent
+/// QC's certified BlockInfo to the locally-trusted genesis and must reject the forged one.
+///
+/// The no-false-rejection direction (a proposal carrying the genuine genesis QC is accepted) is
+/// covered by `vote_on_successful_proposal`, which also exercises this binding.
+fn reject_proposal_with_forged_genesis_qc() {
+    let runtime = consensus_runtime();
+    let mut playground = NetworkPlayground::new(runtime.handle().clone());
+    let mut nodes = NodeSetup::create_nodes(
+        &mut playground,
+        runtime.handle().clone(),
+        1,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        false,
+    );
+    let node = &mut nodes[0];
+
+    let genesis_qc = certificate_for_genesis();
+    let genuine_genesis = genesis_qc.certified_block();
+    // Forge a round-0 BlockInfo: same genesis block id (so the proposal links to the local root)
+    // but with attacker-controlled execution state.
+    let forged_genesis = BlockInfo::new(
+        genuine_genesis.epoch(),
+        genuine_genesis.round(),
+        genuine_genesis.id(),
+        HashValue::random(),
+        genuine_genesis.version() + 1,
+        genuine_genesis.timestamp_usecs(),
+        genuine_genesis.next_epoch_state().cloned(),
+    );
+    assert_ne!(&forged_genesis, genuine_genesis);
+    // The forged QC is internally self-consistent (parent == certified == commit_info, no voters),
+    // so it passes the round-0 shortcut in `QuorumCert::verify`.
+    let forged_vote_data = VoteData::new(forged_genesis.clone(), forged_genesis.clone());
+    let forged_qc = QuorumCert::new(
+        forged_vote_data.clone(),
+        LedgerInfoWithSignatures::new(
+            LedgerInfo::new(forged_genesis, forged_vote_data.hash()),
+            AggregateSignature::empty(),
+        ),
+    );
+    forged_qc
+        .verify(&generate_validator_verifier(&[node.signer.clone()]))
+        .unwrap();
+
+    timed_block_on(&runtime, async {
+        // Start round 1 and clear the message queue.
+        node.next_proposal().await;
+
+        let forged_proposal = Block::new_proposal(
+            Payload::empty(false),
+            1,
+            1,
+            forged_qc,
+            &node.signer,
+            Vec::new(),
+        )
+        .unwrap();
+        let err = node
+            .round_manager
+            .process_proposal(forged_proposal)
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("does not match the local genesis"),
+            "unexpected rejection reason: {}",
+            err
+        );
     });
 }
 

--- a/consensus/src/round_manager_tests/consensus_test.rs
+++ b/consensus/src/round_manager_tests/consensus_test.rs
@@ -350,7 +350,9 @@ fn reject_proposal_with_forged_genesis_qc() {
         ),
     );
     forged_qc
-        .verify(&generate_validator_verifier(&[node.signer.clone()]))
+        .verify(&generate_validator_verifier(std::slice::from_ref(
+            &node.signer,
+        )))
         .unwrap();
 
     timed_block_on(&runtime, async {


### PR DESCRIPTION
## Summary

A round-0 (genesis) QC is accepted by `QuorumCert::verify` **without signatures** — it is implicitly agreed upon, so `verify` only checks internal self-consistency (`parent == certified == commit_info`, zero voters) and never binds the certified `BlockInfo` to any real state.

A malicious proposer selected for round 1 of an epoch can exploit this: embed a round-0 QC that reuses the **real genesis block id** but carries an **attacker-chosen `executed_state_id` / `version`**. The proposal passes existing validation (proposer signature, parent-id linkage, round-0 `QuorumCert::verify`), and the forged `BlockInfo` rides into the SafetyRules voting path.

## Fix

In `RoundManager::process_proposal`, bind any round-0 parent QC's certified `BlockInfo` to the locally-trusted genesis (`get_quorum_cert_for_block(genesis_id)`):

- Comparing the **`BlockInfo`** (not the whole QC) is sufficient — it carries `executed_state_id` and `version`, which are the forged fields and the only part of a round-0 QC that flows into the signed vote `LedgerInfo`. The QC is signatureless by construction for round 0 (`QuorumCert::verify` requires zero voters), so nothing else in it is security-relevant here.
- The genesis QC is derived deterministically from the previous epoch's final `LedgerInfo`, identical on every honest node, so this never false-rejects honest round-1 proposals.

This is a **local-only acceptance check with no change to signed content**, hence backwards compatible (safe to roll out without a feature gate).

It complements the existing `block0 > 0` signing guard (#19891): acceptance-side rejection in addition to signing-side refusal.

## Test

`reject_proposal_with_forged_genesis_qc`: builds a round-0 QC reusing the real genesis id with a mutated `executed_state_id` / `version`, asserts it still passes `QuorumCert::verify` (the gap), then asserts `process_proposal` rejects it. The no-false-rejection direction is covered by the existing `vote_on_successful_proposal` (which now also exercises this binding).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Consensus security fix in proposal acceptance and SafetyRules voting path; incorrect genesis binding could reject honest proposals or leave the forgery window open.
> 
> **Overview**
> Closes a consensus acceptance gap where **round-0 (genesis) parent QCs** pass `QuorumCert::verify` without binding `executed_state_id` / `version`, so a malicious round-1 proposer could smuggle forged genesis `BlockInfo` toward SafetyRules voting.
> 
> **`RoundManager::process_proposal`** now requires that when the proposal’s parent QC certifies round 0, its certified `BlockInfo` exactly matches the genesis QC looked up locally via `get_quorum_cert_for_block` (same block id). Mismatches are rejected before voting; honest genesis QCs are unchanged.
> 
> Adds **`reject_proposal_with_forged_genesis_qc`**: a self-consistent forged round-0 QC still verifies, but `process_proposal` fails with the new genesis-binding error. Genuine genesis acceptance remains covered by **`vote_on_successful_proposal`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 996a211f8d32b29b54c5058cf6eb1c7bdba635a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->