### PR TITLE
[consensus] Log block_num_txns on proposal receive

### DIFF
--- a/consensus/src/round_manager.rs
+++ b/consensus/src/round_manager.rs
@@ -776,6 +776,11 @@ impl RoundManager {
             block_round = proposal_msg.proposal().round(),
             block_hash = proposal_msg.proposal().id(),
             block_parent_hash = proposal_msg.proposal().quorum_cert().certified_block().id(),
+            block_num_txns = proposal_msg
+                .proposal()
+                .payload()
+                .map(|p| p.len())
+                .unwrap_or(0),
         );
 
         let in_correct_round = self
@@ -908,6 +913,7 @@ impl RoundManager {
             block_round = proposal.round(),
             block_hash = proposal.id(),
             block_parent_hash = proposal.quorum_cert().certified_block().id(),
+            block_num_txns = proposal.payload().map(|p| p.len()).unwrap_or(0),
         );
         self.process_proposal(proposal).await
     }


### PR DESCRIPTION
## Summary
Adds `block_num_txns` to `ReceiveProposal` and `ProcessOptProposal` info logs so Humio can identify proposers shipping empty/small proposals — proposer and payload size end up on the same log line.

## Test plan
- [ ] `cargo check -p aptos-consensus` passes
- [ ] `./scripts/rust_lint.sh --check` passes
- [ ] After deploy, verify Humio shows `data.block_num_txns` on `data.event = "ReceiveProposal"` and `data.event = "ProcessOptProposal"` events

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging-only change with no consensus behavior, safety rules, or network protocol impact.
> 
> **Overview**
> Adds **`block_num_txns`** to consensus **`ReceiveProposal`** and **`ProcessOptProposal`** `info!` logs in `round_manager.rs`, computed as proposal payload length (`payload().map(|p| p.len()).unwrap_or(0)`).
> 
> This puts proposer identity and transaction count on the same Humio line for spotting empty or very small proposals, for both standard and optimistic proposal paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 643a7972c9a3372f23023394fe72030c91cbec64. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->