### PR TITLE
[trading-native][in-memory-store] Execution-stage per-account position index

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1306,6 +1306,7 @@ dependencies = [
  "serde",
  "static_assertions",
  "status-line",
+ "thiserror 1.0.69",
  "tokio",
 ]
 

--- a/execution/executor-types/src/state_checkpoint_output.rs
+++ b/execution/executor-types/src/state_checkpoint_output.rs
@@ -8,7 +8,7 @@ use aptos_crypto::HashValue;
 use aptos_drop_helper::DropHelper;
 use aptos_storage_interface::state_store::{
     sharded_jmt_state::PositionStateWithSummary, state_summary::LedgerStateSummary,
-    state_with_summary::LedgerWithSummary,
+    state_with_summary::LedgerWithSummary, user_positions::UserPositions,
 };
 use derive_more::Deref;
 use std::sync::Arc;
@@ -26,6 +26,7 @@ impl StateCheckpointOutput {
         hot_state_checkpoint_hashes: Option<Vec<Option<HashValue>>>,
         position_state_summary: Option<LedgerWithSummary<PositionStateWithSummary>>,
         position_state_checkpoint_hashes: Option<Vec<Option<HashValue>>>,
+        user_positions: Option<LedgerWithSummary<UserPositions>>,
     ) -> Self {
         Self::new_impl(Inner {
             state_summary,
@@ -33,12 +34,14 @@ impl StateCheckpointOutput {
             hot_state_checkpoint_hashes,
             position_state_summary,
             position_state_checkpoint_hashes,
+            user_positions,
         })
     }
 
     pub fn new_empty(
         parent_state_summary: LedgerStateSummary,
         position_state_summary: Option<LedgerWithSummary<PositionStateWithSummary>>,
+        user_positions: Option<LedgerWithSummary<UserPositions>>,
     ) -> Self {
         Self::new_impl(Inner {
             state_summary: parent_state_summary,
@@ -46,12 +49,14 @@ impl StateCheckpointOutput {
             hot_state_checkpoint_hashes: None,
             position_state_summary,
             position_state_checkpoint_hashes: None,
+            user_positions,
         })
     }
 
     pub fn new_dummy() -> Self {
         Self::new_empty(
             LedgerStateSummary::new_empty(HotStateConfig::default()),
+            None,
             None,
         )
     }
@@ -63,12 +68,13 @@ impl StateCheckpointOutput {
     }
 
     pub fn reconfig_suffix(&self) -> Self {
-        // An empty reconfig-suffix block produces no position writes, so the
-        // position state is unchanged — propagate it for the next block's
-        // freeze base.
+        // An empty reconfig-suffix block produces no position writes, so
+        // both `position_state_summary` and `user_positions` are unchanged
+        // — propagate them for the next block's freeze base / read floor.
         Self::new_empty(
             self.state_summary.clone(),
             self.position_state_summary.clone(),
+            self.user_positions.clone(),
         )
     }
 }
@@ -87,4 +93,9 @@ pub struct Inner {
     /// Per-transaction position state root: `Some` at the checkpoint index,
     /// `None` elsewhere. `None` (the whole option) unless the feature is on.
     pub position_state_checkpoint_hashes: Option<Vec<Option<HashValue>>>,
+    /// Per-account position index after this chunk, computed at execution
+    /// time alongside `position_state_summary`. Commit publishes it onto
+    /// `bundle.user_positions` for validator-side scanner reads. `None`
+    /// when native position is disabled.
+    pub user_positions: Option<LedgerWithSummary<UserPositions>>,
 }

--- a/execution/executor-types/src/state_compute_result.rs
+++ b/execution/executor-types/src/state_compute_result.rs
@@ -168,6 +168,7 @@ impl StateComputeResult {
             state_reads: &self.execution_output.state_reads,
             hot_state_updates: &self.execution_output.hot_state_updates,
             position_state_summary: self.state_checkpoint_output.position_state_summary.as_ref(),
+            user_positions: self.state_checkpoint_output.user_positions.as_ref(),
             is_reconfig: self.execution_output.next_epoch_state.is_some(),
         }
     }

--- a/execution/executor/src/block_executor/mod.rs
+++ b/execution/executor/src/block_executor/mod.rs
@@ -360,6 +360,8 @@ where
                     .transpose()?;
                 let parent_position_summary =
                     parent_block.output.ensure_result_position_state_summary()?;
+                let parent_user_positions =
+                    parent_block.output.ensure_result_user_positions()?;
                 output.set_state_checkpoint_output(DoStateCheckpoint::run(
                     &output.execution_output,
                     parent_state_summary,
@@ -369,6 +371,7 @@ where
                     parent_position_summary,
                     position_persisted.as_ref(),
                     None,
+                    parent_user_positions,
                 )?);
                 output.set_ledger_update_output(DoLedgerUpdate::run(
                     &output.execution_output,

--- a/execution/executor/src/chunk_executor/chunk_commit_queue.rs
+++ b/execution/executor/src/chunk_executor/chunk_commit_queue.rs
@@ -16,6 +16,7 @@ use aptos_storage_interface::{
     state_store::{
         sharded_jmt_state::PositionStateWithSummary, state::LedgerState,
         state_summary::LedgerStateSummary, state_with_summary::LedgerWithSummary,
+        user_positions::UserPositions,
     },
     DbReader, LedgerSummary,
 };
@@ -46,6 +47,12 @@ pub struct ChunkCommitQueue {
     /// Native-position summary chained across chunks (the parent the next
     /// chunk rebases from). `None` when native position is disabled.
     latest_position_state_summary: Option<LedgerWithSummary<PositionStateWithSummary>>,
+    /// Per-account `UserPositions` index chained across chunks (the
+    /// parent the next chunk extends from). Mirrors
+    /// `latest_position_state_summary`. `None` when native position
+    /// is disabled.
+    latest_user_positions:
+        Option<LedgerWithSummary<UserPositions>>,
     latest_txn_accumulator: Arc<InMemoryTransactionAccumulator>,
     to_commit: VecDeque<Option<ExecutedChunk>>,
     to_update_ledger: VecDeque<Option<ChunkToUpdateLedger>>,
@@ -58,12 +65,14 @@ impl ChunkCommitQueue {
             state_summary,
             transaction_accumulator,
             position_state_summary,
+            user_positions,
         } = db.get_pre_committed_ledger_summary()?;
 
         Ok(Self {
             latest_state: state,
             latest_state_summary: state_summary,
             latest_position_state_summary: position_state_summary,
+            latest_user_positions: user_positions,
             latest_txn_accumulator: transaction_accumulator,
             to_commit: VecDeque::new(),
             to_update_ledger: VecDeque::new(),
@@ -95,6 +104,7 @@ impl ChunkCommitQueue {
     ) -> Result<(
         LedgerStateSummary,
         Option<LedgerWithSummary<PositionStateWithSummary>>,
+        Option<LedgerWithSummary<UserPositions>>,
         Arc<InMemoryTransactionAccumulator>,
         ChunkToUpdateLedger,
     )> {
@@ -108,6 +118,7 @@ impl ChunkCommitQueue {
         Ok((
             self.latest_state_summary.clone(),
             self.latest_position_state_summary.clone(),
+            self.latest_user_positions.clone(),
             self.latest_txn_accumulator.clone(),
             chunk,
         ))
@@ -133,6 +144,11 @@ impl ChunkCommitQueue {
             .output
             .ensure_state_checkpoint_output()?
             .position_state_summary
+            .clone();
+        self.latest_user_positions = chunk
+            .output
+            .ensure_state_checkpoint_output()?
+            .user_positions
             .clone();
         self.latest_txn_accumulator = chunk
             .output

--- a/execution/executor/src/chunk_executor/mod.rs
+++ b/execution/executor/src/chunk_executor/mod.rs
@@ -363,8 +363,13 @@ impl<V: VMBlockExecutor> ChunkExecutorInner<V> {
     pub fn update_ledger(&self) -> Result<()> {
         let _timer = CHUNK_OTHER_TIMERS.timer_with(&["chunk_update_ledger_total"]);
 
-        let (parent_state_summary, parent_position_state_summary, parent_accumulator, chunk) =
-            self.commit_queue.lock().next_chunk_to_update_ledger()?;
+        let (
+            parent_state_summary,
+            parent_position_state_summary,
+            parent_user_positions,
+            parent_accumulator,
+            chunk,
+        ) = self.commit_queue.lock().next_chunk_to_update_ledger()?;
         let ChunkToUpdateLedger {
             output,
             chunk_verifier,
@@ -407,6 +412,7 @@ impl<V: VMBlockExecutor> ChunkExecutorInner<V> {
             parent_position_state_summary.as_ref(),
             position_persisted.as_ref(),
             known_position_state_checkpoints,
+            parent_user_positions.as_ref(),
         )?;
 
         let ledger_update_output = DoLedgerUpdate::run(

--- a/execution/executor/src/types/partial_state_compute_result.rs
+++ b/execution/executor/src/types/partial_state_compute_result.rs
@@ -12,6 +12,7 @@ use aptos_storage_interface::{
     state_store::{
         sharded_jmt_state::PositionStateWithSummary, state::LedgerState,
         state_summary::LedgerStateSummary, state_with_summary::LedgerWithSummary,
+        user_positions::UserPositions,
     },
     LedgerSummary,
 };
@@ -48,6 +49,7 @@ impl PartialStateComputeResult {
             .set(StateCheckpointOutput::new_empty(
                 ledger_summary.state_summary,
                 ledger_summary.position_state_summary,
+                ledger_summary.user_positions,
             ))
             .expect("First set.");
 
@@ -82,6 +84,13 @@ impl PartialStateComputeResult {
     ) -> Result<Option<&LedgerWithSummary<PositionStateWithSummary>>> {
         self.ensure_state_checkpoint_output()
             .map(|out| out.position_state_summary.as_ref())
+    }
+
+    pub fn ensure_result_user_positions(
+        &self,
+    ) -> Result<Option<&LedgerWithSummary<UserPositions>>> {
+        self.ensure_state_checkpoint_output()
+            .map(|out| out.user_positions.as_ref())
     }
 
     pub fn set_state_checkpoint_output(&self, state_checkpoint_output: StateCheckpointOutput) {

--- a/execution/executor/src/workflow/do_state_checkpoint.rs
+++ b/execution/executor/src/workflow/do_state_checkpoint.rs
@@ -12,8 +12,13 @@ use aptos_storage_interface::state_store::{
     sharded_jmt_state::{PositionSlot, PositionStateWithSummary},
     state_summary::{LedgerStateSummary, ProvablePositionStateSummary, ProvableStateSummary},
     state_with_summary::LedgerWithSummary,
+    user_positions::{materialize_user_position_updates, PositionWrite, UserPositionKey, UserPositions},
 };
-use aptos_types::state_store::state_value::StateValue;
+use aptos_types::state_store::{
+    native_position::NativePosition,
+    state_key::inner::{StateKeyInner, TradingNativeKey},
+    state_value::StateValue,
+};
 use std::collections::HashMap;
 
 pub struct DoStateCheckpoint;
@@ -28,6 +33,7 @@ impl DoStateCheckpoint {
         parent_position_state_summary: Option<&LedgerWithSummary<PositionStateWithSummary>>,
         persisted_position_state_summary: Option<&ProvablePositionStateSummary>,
         known_position_state_checkpoints: Option<Vec<Option<HashValue>>>,
+        parent_user_positions: Option<&LedgerWithSummary<UserPositions>>,
     ) -> Result<StateCheckpointOutput> {
         let _timer = OTHER_TIMERS.timer_with(&["do_state_checkpoint"]);
 
@@ -72,13 +78,144 @@ impl DoStateCheckpoint {
                 (None, None)
             };
 
+        // Compute the per-account `UserPositions` index alongside the JMT
+        // summary. Required for validator-side reads to see prior-block
+        // writes — the bundle's reader handle is published from this on
+        // commit. `parent_user_positions` is None only at genesis or on
+        // restart before the executor seeds from durable storage; both
+        // produce an empty starting chain.
+        let user_positions = Self::compute_user_positions_checkpoint(
+            execution_output,
+            parent_user_positions,
+        )?;
+
         Ok(StateCheckpointOutput::new(
             state_summary,
             state_checkpoint_hashes,
             hot_state_checkpoint_hashes,
             position_state_summary,
             position_state_checkpoint_hashes,
+            user_positions,
         ))
+    }
+
+    /// Per-block extension of the `UserPositions` layered index.
+    /// Decodes each tx's Position writes, materializes per-account
+    /// deltas against `parent`, and pushes one layer at the block's
+    /// last version. Returns the latest+last_checkpoint pair so the
+    /// next block's executor can chain off it.
+    ///
+    /// **Not gated on `compute_trading_native_state_roots`** unlike
+    /// `compute_position_checkpoint` — the consensus-state-root flag
+    /// only affects the JMT-side computation. The user-positions
+    /// index advances whenever the executor has a parent threaded
+    /// from the bundle (i.e., `ENABLE_TRADING_NATIVE` is on at the
+    /// Rust level). When that's not the case, `parent` is `None`,
+    /// writes are empty, and this returns `None`.
+    ///
+    /// Returns `None` when there's no parent AND no writes. Errors
+    /// if writes are non-empty but parent is `None` — that means the
+    /// executor was reached without going through the bundle, which
+    /// indicates a wiring bug.
+    fn compute_user_positions_checkpoint(
+        execution_output: &ExecutionOutput,
+        parent: Option<&LedgerWithSummary<UserPositions>>,
+    ) -> Result<Option<LedgerWithSummary<UserPositions>>> {
+        let _timer = OTHER_TIMERS.timer_with(&["compute_user_positions_checkpoint"]);
+
+        let num_txns = execution_output.to_commit.len();
+        let first_version = execution_output.first_version;
+
+        // Collect the chunk's typed PositionWrites in arrival order
+        // (latest-wins per (account, market) handled inside
+        // materialize_user_position_updates).
+        let mut writes: Vec<PositionWrite> = Vec::new();
+        for output in &execution_output.to_commit.transaction_outputs {
+            for (key, op) in output.write_set().native_position_iter() {
+                let (exchange, account, market) = match key.inner() {
+                    StateKeyInner::TradingNative(TradingNativeKey::Position {
+                        exchange,
+                        account,
+                        market,
+                    }) => (*exchange, *account, *market),
+                    other => {
+                        anyhow::bail!(
+                            "non-Position native StateKey in chunk write set: {other:?}"
+                        );
+                    },
+                };
+                let value = op
+                    .as_write_op()
+                    .as_state_value_opt()
+                    .map(|sv| NativePosition::deserialize(sv.bytes()))
+                    .transpose()
+                    .map_err(|e| {
+                        anyhow::anyhow!(
+                            "native position value failed to decode at execution: {e}"
+                        )
+                    })?;
+                writes.push(PositionWrite {
+                    position_key: UserPositionKey { exchange, account },
+                    market,
+                    value,
+                });
+            }
+        }
+
+        // Refuse to fabricate a UserPositions family when there's no
+        // parent: `MapLayer::new_family` would produce a fresh family
+        // with a random ID, unrelated to the bundle's chain. Publishing
+        // that to `bundle.user_positions` later would orphan the
+        // cold-loaded data. Under correct wiring the executor always
+        // gets a parent (LedgerSummary populates from the bundle), so
+        // None here means the feature is off OR there's a wiring bug.
+        let Some(parent) = parent else {
+            if !writes.is_empty() {
+                anyhow::bail!(
+                    "compute_user_positions_checkpoint: parent is None but chunk has \
+                     {} position writes; executor wiring should always provide a parent \
+                     when ENABLE_TRADING_NATIVE is on",
+                    writes.len(),
+                );
+            }
+            return Ok(None);
+        };
+
+        let parent_latest = parent.latest().clone();
+        let parent_last_checkpoint = parent.last_checkpoint().clone();
+
+        if num_txns == 0 {
+            return Ok(Some(LedgerWithSummary::from_latest_and_last_checkpoint(
+                parent_latest,
+                parent_last_checkpoint,
+            )));
+        }
+
+        let last_version = first_version + num_txns as u64 - 1;
+        let updates = if writes.is_empty() {
+            Vec::new()
+        } else {
+            materialize_user_position_updates(&parent_latest, writes)
+        };
+        let new_latest = parent_latest.extend(last_version, updates);
+        // last_checkpoint advances with latest only when the chunk
+        // crossed a state-checkpoint boundary; otherwise it stays at
+        // the parent's last_checkpoint.
+        let new_last_checkpoint = if execution_output
+            .to_commit
+            .state_update_refs()
+            .last_inner_checkpoint_index()
+            .is_some()
+        {
+            new_latest.clone()
+        } else {
+            parent_last_checkpoint
+        };
+
+        Ok(Some(LedgerWithSummary::from_latest_and_last_checkpoint(
+            new_latest,
+            new_last_checkpoint,
+        )))
     }
 
     /// Computes the position summary (latest + last_checkpoint) and per-txn

--- a/execution/executor/src/workflow/mod.rs
+++ b/execution/executor/src/workflow/mod.rs
@@ -38,6 +38,7 @@ impl ApplyExecutionOutput {
             base_view.position_state_summary.as_ref(),
             position_persisted.as_ref(),
             None,
+            base_view.user_positions.as_ref(),
         )?;
         let ledger_update_output = DoLedgerUpdate::run(
             &execution_output,

--- a/storage/aptosdb/Cargo.toml
+++ b/storage/aptosdb/Cargo.toml
@@ -72,6 +72,7 @@ rayon = { workspace = true }
 serde = { workspace = true }
 static_assertions = { workspace = true }
 status-line = { workspace = true }
+thiserror = { workspace = true }
 tokio = { workspace = true }
 
 [dev-dependencies]

--- a/storage/aptosdb/src/db/aptosdb_native_position.rs
+++ b/storage/aptosdb/src/db/aptosdb_native_position.rs
@@ -3,10 +3,16 @@
 
 use crate::{
     db::AptosDB,
-    native_state_committer::NativeStateCommitter,
+    native_state_committer::{PositionWrite, NativeStateCommitter},
+    native_state_reader::{install_global_reader, InMemoryNativeStateReader},
+    native_state_store::{
+        decode_rows_to_user_position_states, materialize_user_position_updates, UserPositionKey,
+        UserPositions,
+    },
     position_buffered_state::{
         new_empty_position_state, position_state_at_version, PositionLedgerStateWithSummary,
         PositionPersistedState, PositionProofReader, PositionSlot,
+        MAX_POSITION_WRITE_SETS_AFTER_SNAPSHOT,
     },
     position_db::{PositionDb, NUM_NATIVE_VALUE_SHARDS},
     position_merkle_db::PositionMerkleDb,
@@ -21,10 +27,14 @@ use aptos_config::config::{
     LedgerPrunerConfig, RocksdbConfig, StateMerklePrunerConfig, StorageDirPaths,
 };
 use aptos_crypto::{hash::CryptoHash, HashValue};
+use aptos_infallible::Mutex;
 use aptos_logger::info;
 use aptos_schemadb::{Cache, Env};
-use aptos_storage_interface::{AptosDbError, Result};
-use aptos_types::{state_store::state_value::StateValue, transaction::Version};
+use aptos_storage_interface::{db_ensure as ensure, AptosDbError, Result};
+use aptos_types::{
+    state_store::{native_position::NativePosition, state_value::StateValue},
+    transaction::Version,
+};
 use std::{collections::HashMap, sync::Arc};
 
 pub struct PositionBundle {
@@ -36,6 +46,13 @@ pub struct PositionBundle {
     /// driven from `commit_native_position`, the merkle pruners from the
     /// committer, and all are re-activated on restart from `open_internal`.
     pub(crate) position_pruner: Option<Arc<PositionPruner>>,
+    /// Per-account committed-state cache for validator-side scanners.
+    /// Sits at the bundle level — separate from the JMT pipeline state
+    /// — and is extended only after `position_db.commit(...)` succeeds.
+    /// In readonly mode it stays at cold-load. External callers reach
+    /// this via [`NativeStateReader`] (see `native_state_reader()`),
+    /// not through the bundle directly.
+    pub(crate) user_positions: Arc<Mutex<UserPositions>>,
     /// `None` in readonly mode.
     pub(crate) state_store: Option<Arc<PositionStateStore>>,
     /// Latest persisted in-memory snapshot — the base the in-memory
@@ -54,6 +71,11 @@ impl AptosDB {
     pub fn native_state_committer(&self) -> Option<NativeStateCommitter> {
         let bundle = self.position.as_ref()?;
         Some(NativeStateCommitter::new(bundle.kv_db.clone()))
+    }
+
+    pub fn native_state_reader(&self) -> Option<InMemoryNativeStateReader> {
+        let bundle = self.position.as_ref()?;
+        Some(InMemoryNativeStateReader::new(Arc::clone(&bundle.user_positions)))
     }
 
     /// Called automatically from `open_internal` when
@@ -91,7 +113,7 @@ impl AptosDB {
             /* max_nodes_per_lru_cache_shard */ 0,
         )?;
 
-        // Mirror `StateStore::sync_commit_progress`: align both
+        // Match `StateStore::sync_commit_progress`: align both
         // position DBs with the ledger's `OverallCommitProgress`
         // (truncating ahead-of-chain rows from a crash) and find the
         // latest JMT snapshot at or before that point.
@@ -103,6 +125,36 @@ impl AptosDB {
 
         let kv_db = Arc::new(position_db);
         let merkle_db = Arc::new(merkle_db);
+
+        // Cold-load: stream the durable JMT snapshot into a decoded
+        // `(UserPositionKey, UserPositionState)` seed and hydrate the `UserPositions`
+        // base layer. Memory is bounded by the live position set, not
+        // by the on-disk snapshot. The gap
+        // `[snapshot_version + 1, chain_tip]` from a crash between
+        // JMT-snapshot and chain commit is closed by
+        // `replay_position_after_snapshot`.
+        let user_positions = match merkle_progress {
+            Some(snapshot_version) => {
+                let iter = merkle_db.iter_active_leaves_with_values(
+                    Arc::clone(&kv_db),
+                    snapshot_version,
+                    0,
+                )?;
+                let seed = decode_rows_to_user_position_states(iter)?;
+                info!(
+                    snapshot_version = snapshot_version,
+                    n_accounts = seed.len(),
+                    "Native-position cold-load complete."
+                );
+                UserPositions::new_at_version(Some(snapshot_version), "position")
+                    .with_seeded_base(seed)
+            },
+            None => UserPositions::new_empty("position"),
+        };
+        let user_positions = Arc::new(Mutex::new(user_positions));
+        install_global_reader(Arc::new(InMemoryNativeStateReader::new(Arc::clone(
+            &user_positions,
+        ))));
 
         // Pruner managers (value + merkle), grouped like main state's
         // `StatePruner`. Shared with the merkle batch committer via `Arc`.
@@ -142,6 +194,7 @@ impl AptosDB {
                         .expect("position_pruner present in non-readonly mode"),
                 ),
                 persisted.clone(),
+                Arc::clone(&user_positions),
             ));
             (Some(store), Some(persisted))
         };
@@ -159,6 +212,7 @@ impl AptosDB {
                     &merkle_db,
                     snapshot_next_version,
                     v_overall + 1,
+                    &user_positions,
                 )?;
             }
         }
@@ -167,6 +221,7 @@ impl AptosDB {
             kv_db,
             merkle_db,
             position_pruner,
+            user_positions,
             state_store,
             persisted,
         }));
@@ -232,19 +287,39 @@ impl AptosDB {
 
     /// Replay `WriteSet`s in `[snapshot_next_version, num_transactions)`
     /// — the gap between the persisted JMT snapshot and the chain
-    /// tip. Coalesces latest-wins-per-key, extends in one shot, and
-    /// sync-commits the resulting snapshot before returning.
+    /// tip. Coalesces latest-wins-per-key, extends the JMT pipeline
+    /// state in one shot, and folds the per-account updates into the
+    /// `UserPositions` before returning.
     fn replay_position_after_snapshot(
         &self,
         store: &PositionStateStore,
         merkle_db: &Arc<PositionMerkleDb>,
         snapshot_next_version: Version,
         num_transactions: u64,
+        user_positions: &Arc<Mutex<UserPositions>>,
     ) -> Result<()> {
         info!(
             snapshot_next_version = snapshot_next_version,
             num_transactions = num_transactions,
             "Replaying position write sets to catch up the in-memory pipeline."
+        );
+
+        // Mirrors main state's `MAX_WRITE_SETS_AFTER_SNAPSHOT` guard:
+        // the replay path materializes every write set in the gap
+        // into one `Vec`, so unbounded gaps are an OOM risk. A node
+        // enabling trading-native before its first position snapshot
+        // (merkle_progress == None ⇒ snapshot_next_version == 0)
+        // against a long-running chain would otherwise pull the
+        // entire history.
+        let gap = num_transactions.saturating_sub(snapshot_next_version);
+        ensure!(
+            gap <= MAX_POSITION_WRITE_SETS_AFTER_SNAPSHOT,
+            "Too many versions to replay after position snapshot. snapshot_next_version: {}, \
+             num_transactions: {}, gap: {}, max: {}",
+            snapshot_next_version,
+            num_transactions,
+            gap,
+            MAX_POSITION_WRITE_SETS_AFTER_SNAPSHOT,
         );
 
         let write_sets = self
@@ -253,14 +328,42 @@ impl AptosDB {
             .get_write_sets(snapshot_next_version, num_transactions)?;
 
         let mut pending_leaf_updates: HashMap<HashValue, PositionSlot> = HashMap::new();
+        let mut pending_position_writes: Vec<PositionWrite> = Vec::new();
         for write_set in &write_sets {
             for (key, op) in write_set.native_position_iter() {
                 let maybe_value = op.as_write_op().as_state_value_opt().cloned();
                 let value_hash = maybe_value.as_ref().map(StateValue::hash);
+                let (exchange, account, market) = match key.inner() {
+                    aptos_types::state_store::state_key::inner::StateKeyInner::TradingNative(
+                        aptos_types::state_store::state_key::inner::TradingNativeKey::Position {
+                            exchange,
+                            account,
+                            market,
+                        },
+                    ) => (*exchange, *account, *market),
+                    other => {
+                        return Err(AptosDbError::Other(format!(
+                            "non-Position native key in replay write set: {other:?}"
+                        )));
+                    },
+                };
+                let typed = match maybe_value.as_ref() {
+                    Some(sv) => Some(NativePosition::deserialize(sv.bytes()).map_err(|e| {
+                        AptosDbError::Other(format!(
+                            "position value decode failed during replay: {e}"
+                        ))
+                    })?),
+                    None => None,
+                };
                 pending_leaf_updates.insert(key.hash(), PositionSlot {
                     state_key: key.clone(),
                     value_hash,
                     value: None,
+                });
+                pending_position_writes.push(PositionWrite {
+                    position_key: UserPositionKey { exchange, account },
+                    market,
+                    value: typed,
                 });
             }
         }
@@ -284,6 +387,14 @@ impl AptosDB {
         let base_summary = pipeline_latest.summary().clone();
         let new_latest =
             pipeline_latest.extend(target_version, updates, &base_summary, &proof_reader)?;
+
+        // Fold the replayed account-level updates into `UserPositions`;
+        // this matches the durable JMT state we just extended to.
+        {
+            let mut user_pos = user_positions.lock();
+            let updates = materialize_user_position_updates(&user_pos, pending_position_writes);
+            *user_pos = user_pos.extend(target_version, updates);
+        }
 
         // Treat the target as a checkpoint so the buffered_state
         // sync-commits the JMT snapshot before we return.

--- a/storage/aptosdb/src/db/aptosdb_reader.rs
+++ b/storage/aptosdb/src/db/aptosdb_reader.rs
@@ -17,6 +17,7 @@ use aptos_storage_interface::{
     db_ensure as ensure,
     state_store::{
         state::State, state_summary::StateSummary, state_view::hot_state_view::HotStateView,
+        state_with_summary::LedgerWithSummary, user_positions::UserPositions,
     },
     AptosDbError, BlockHeight, DbReader, LedgerSummary, Result, MAX_REQUEST_LIMIT,
 };
@@ -93,6 +94,28 @@ impl DbReader for AptosDB {
                 .as_ref()
                 .and_then(|bundle| bundle.state_store.as_ref())
                 .map(|store| store.current_state().lock().clone())
+                .ok_or_else(|| {
+                    AptosDbError::Other(
+                        "COMPUTE_TRADING_NATIVE_STATE_ROOTS is enabled but native-position \
+                         storage is not initialized (ENABLE_TRADING_NATIVE is off)"
+                            .to_string(),
+                    )
+                })
+        })
+    }
+
+    fn get_pre_committed_user_positions(&self) -> Result<LedgerWithSummary<UserPositions>> {
+        gauged_api("get_pre_committed_user_positions", || {
+            // Bundle holds the current `UserPositions` top, advanced by
+            // `commit_native_position`. Wrap into a LedgerWithSummary
+            // where latest == last_checkpoint == current top, so the
+            // executor can chain blocks off it after restart.
+            self.position
+                .as_ref()
+                .map(|bundle| {
+                    let top = bundle.user_positions.lock().clone();
+                    LedgerWithSummary::from_latest_and_last_checkpoint(top.clone(), top)
+                })
                 .ok_or_else(|| {
                     AptosDbError::Other(
                         "COMPUTE_TRADING_NATIVE_STATE_ROOTS is enabled but native-position \
@@ -706,11 +729,19 @@ impl DbReader for AptosDB {
                 .as_ref()
                 .and_then(|bundle| bundle.state_store.as_ref())
                 .map(|store| store.current_state().lock().clone());
+            // Mirror `position_state_summary` — bundle's user_positions
+            // wrapped as a single-tip `LedgerWithSummary` so the
+            // executor's first block after restart chains from it.
+            let user_positions = self.position.as_ref().map(|bundle| {
+                let top = bundle.user_positions.lock().clone();
+                LedgerWithSummary::from_latest_and_last_checkpoint(top.clone(), top)
+            });
             Ok(LedgerSummary {
                 state,
                 state_summary,
                 transaction_accumulator,
                 position_state_summary,
+                user_positions,
             })
         })
     }

--- a/storage/aptosdb/src/db/aptosdb_testonly.rs
+++ b/storage/aptosdb/src/db/aptosdb_testonly.rs
@@ -158,6 +158,7 @@ impl AptosDB {
             state_reads: &reads,
             hot_state_updates: &hot_state_updates,
             position_state_summary: None,
+            user_positions: None,
             is_reconfig: transactions_to_keep.is_reconfig(),
         };
 

--- a/storage/aptosdb/src/db/aptosdb_writer.rs
+++ b/storage/aptosdb/src/db/aptosdb_writer.rs
@@ -13,7 +13,10 @@ use crate::{
     metrics::{
         COMMITTED_TXNS, LATEST_TXN_VERSION, LEDGER_VERSION, NEXT_BLOCK_EPOCH, OTHER_TIMERS_SECONDS,
     },
-    native_state_committer::{new_sharded_kv_batches, InChunkPriorVersions, NativeStateCommitter},
+    native_state_committer::{
+        new_sharded_kv_batches, InChunkPriorVersions, PositionWrite, NativeStateCommitter,
+    },
+    native_state_store::materialize_user_position_updates,
     position_buffered_state::{
         PositionLedgerStateWithSummary, PositionProofReader, PositionSlot, PositionStateWithSummary,
     },
@@ -343,6 +346,11 @@ impl AptosDB {
         // Persist the position KV values + stale index.
         let mut sharded_kv_batches = new_sharded_kv_batches();
         let mut in_chunk_prior = InChunkPriorVersions::new();
+        // Decoded `PositionWrite`s for the whole chunk, in arrival
+        // order. Folded into `bundle.user_positions` once at chunk
+        // end, after the durable `position_db.commit(...)` succeeds.
+        let mut chunk_position_writes: Vec<PositionWrite> = Vec::new();
+
         for (i, output) in chunk.transaction_outputs.iter().enumerate() {
             let version = chunk_first + i as Version;
             let position_writes: Vec<_> = output
@@ -351,7 +359,7 @@ impl AptosDB {
                 .map(|(k, op)| (k.clone(), op.as_write_op().clone()))
                 .collect();
             if !position_writes.is_empty() {
-                committer
+                let writes = committer
                     .apply(
                         version,
                         position_writes,
@@ -359,12 +367,46 @@ impl AptosDB {
                         &mut in_chunk_prior,
                     )
                     .map_err(|e| AptosDbError::Other(format!("native commit: {e}")))?;
+                chunk_position_writes.extend(writes);
             }
         }
         bundle
             .kv_db
             .commit(chunk_last_inclusive, None, sharded_kv_batches)
             .map_err(|e| AptosDbError::Other(format!("position_db commit failed: {e}")))?;
+
+        // Advance `bundle.user_positions` for validator-side scanner
+        // reads. Two code paths, each preserving the bundle's
+        // `MapLayer` family (so cold-loaded data stays reachable):
+        //
+        // - `chunk.user_positions = Some(executed)`: the executor
+        //   extended its parent (sourced from `bundle.user_positions`
+        //   via `get_pre_committed_user_positions`) and threaded the
+        //   result through. Publishing `latest()` keeps the bundle
+        //   in the same family the executor extended. This is the
+        //   Phase-1 path: block N+1's execution already saw block N's
+        //   writes via the parent chain.
+        //
+        // - `None`: feature is off OR the executor was bypassed
+        //   (state-sync replay before chunk_executor wiring lands).
+        //   Materialize locally against the bundle's current top, so
+        //   the bundle stays current as a scanner-read structure.
+        //
+        // The two paths are mutually consistent: both extend the same
+        // logical family rooted at the cold-loaded base.
+        match chunk.user_positions {
+            Some(executed) => {
+                *bundle.user_positions.lock() = executed.latest().clone();
+            },
+            None => {
+                if !chunk_position_writes.is_empty() {
+                    let mut user_positions = bundle.user_positions.lock();
+                    let updates =
+                        materialize_user_position_updates(&user_positions, chunk_position_writes);
+                    *user_positions = user_positions.extend(chunk_last_inclusive, updates);
+                }
+            },
+        }
 
         // Advance the position pipeline (merklize + persist + advance the base).
         // Flag on: the summary comes from execution on the chunk; off: compute

--- a/storage/aptosdb/src/db/mod.rs
+++ b/storage/aptosdb/src/db/mod.rs
@@ -44,7 +44,7 @@ pub struct AptosDB {
 // DbReader implementations and private functions used by them.
 mod aptosdb_reader;
 // DbWriter implementations and private functions used by them.
-mod aptosdb_writer;
+pub(crate) mod aptosdb_writer;
 // Other private methods.
 mod aptosdb_internal;
 // Native-position subsystem: `PositionBundle` + `impl AptosDB` for

--- a/storage/aptosdb/src/lib.rs
+++ b/storage/aptosdb/src/lib.rs
@@ -32,6 +32,8 @@ mod event_store;
 mod ledger_db;
 mod lru_node_cache;
 pub mod native_state_committer;
+pub mod native_state_reader;
+pub mod native_state_store;
 pub mod position_buffered_state;
 pub mod position_db;
 pub(crate) mod position_merkle_batch_committer;
@@ -48,7 +50,11 @@ mod trading_native;
 #[cfg(test)]
 mod native_storage_tests;
 
-pub use native_state_committer::{MerkleLeafUpdate, NativeMerkleLeafUpdates, NativeStateCommitter};
+pub use native_state_committer::{NativeStateCommitter, PositionWrite};
+pub use native_state_reader::{InMemoryNativeStateReader, NativeStateReader};
+pub use native_state_store::{
+    decode_rows_to_user_position_states, UserPositionKey, UserPositionState, UserPositions,
+};
 mod state_kv_db;
 mod state_merkle_db;
 mod state_store;

--- a/storage/aptosdb/src/native_state_committer.rs
+++ b/storage/aptosdb/src/native_state_committer.rs
@@ -3,7 +3,10 @@
 
 #![forbid(unsafe_code)]
 
+pub use crate::native_state_store::PositionWrite;
+
 use crate::{
+    native_state_store::UserPositionKey,
     position_db::{PositionDb, NUM_NATIVE_VALUE_SHARDS},
     position_metrics::POSITION_WRITES,
     schema::{
@@ -17,28 +20,16 @@ use aptos_schemadb::batch::SchemaBatch;
 use aptos_storage_interface::{AptosDbError, Result};
 use aptos_types::{
     state_store::{
+        native_position::NativePosition,
         state_key::{
             inner::{StateKeyInner, TradingNativeKey},
             StateKey,
         },
-        state_value::StateValue,
     },
     transaction::Version,
     write_set::WriteOp,
 };
 use std::{collections::HashMap, sync::Arc};
-
-#[derive(Clone, Debug)]
-pub struct MerkleLeafUpdate {
-    pub state_key_hash: HashValue,
-    pub state_key: StateKey,
-    pub value_hash: Option<HashValue>,
-}
-
-#[derive(Clone, Debug, Default)]
-pub struct NativeMerkleLeafUpdates {
-    pub position: Vec<MerkleLeafUpdate>,
-}
 
 /// Per-chunk batches accumulated by `NativeStateCommitter::apply`.
 /// Allocate once per chunk, drive `apply` per transaction, then
@@ -62,23 +53,27 @@ impl NativeStateCommitter {
         Self { position_db }
     }
 
-    /// Accumulate one transaction's Position writes into the
-    /// per-chunk batches. The caller commits once per chunk via
-    /// `PositionDb::commit`.
+    /// Accumulate one transaction's Position writes into the per-chunk
+    /// kv batches and emit the decoded `PositionWrite`s for the caller
+    /// to fold into the layered per-account `UserPositions`.
     pub fn apply<P>(
         &self,
         version: Version,
         position_writes: P,
         sharded_kv_batches: &mut PositionShardedKvBatches,
         in_chunk_prior: &mut InChunkPriorVersions,
-    ) -> Result<NativeMerkleLeafUpdates>
+    ) -> Result<Vec<PositionWrite>>
     where
         P: IntoIterator<Item = (StateKey, WriteOp)>,
     {
-        let mut position_merkle: Vec<MerkleLeafUpdate> = Vec::new();
+        let mut user_position_writes: Vec<PositionWrite> = Vec::new();
         for (state_key, op) in position_writes {
-            match state_key.inner() {
-                StateKeyInner::TradingNative(TradingNativeKey::Position { .. }) => (),
+            let (exchange, account, market) = match state_key.inner() {
+                StateKeyInner::TradingNative(TradingNativeKey::Position {
+                    exchange,
+                    account,
+                    market,
+                }) => (*exchange, *account, *market),
                 other => {
                     return Err(AptosDbError::Other(format!(
                         "position_write_set contained non-Position StateKey: {other:?}"
@@ -126,16 +121,24 @@ impl NativeStateCommitter {
 
             in_chunk_prior.insert(state_key_hash, version);
 
-            let value_hash = maybe_value.as_ref().map(StateValue::hash);
-            position_merkle.push(MerkleLeafUpdate {
-                state_key_hash,
-                state_key: state_key.clone(),
-                value_hash,
+            // Decode once: the caller folds this into the layered
+            // `UserPositions` and validator-side readers consume
+            // decoded values.
+            let typed = match maybe_value.as_ref() {
+                Some(sv) => Some(NativePosition::deserialize(sv.bytes()).map_err(|e| {
+                    AptosDbError::Other(format!(
+                        "position value at version {version} failed to decode: {e}"
+                    ))
+                })?),
+                None => None,
+            };
+            user_position_writes.push(PositionWrite {
+                position_key: UserPositionKey { exchange, account },
+                market,
+                value: typed,
             });
         }
 
-        Ok(NativeMerkleLeafUpdates {
-            position: position_merkle,
-        })
+        Ok(user_position_writes)
     }
 }

--- a/storage/aptosdb/src/native_state_reader.rs
+++ b/storage/aptosdb/src/native_state_reader.rs
@@ -115,7 +115,7 @@ impl NativeStateView {
         let key = UserPositionKey { exchange, account };
         self.user_positions
             .get(&key)
-            .map(|us| us.positions.into_iter().collect())
+            .map(|us| us.positions.iter().map(|(k, v)| (*k, v.clone())).collect())
             .unwrap_or_default()
     }
 }

--- a/storage/aptosdb/src/native_state_reader.rs
+++ b/storage/aptosdb/src/native_state_reader.rs
@@ -1,0 +1,121 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Validator-side reader API for native-position data.
+//!
+//! At block boundaries off-Move consumers query the layered
+//! per-account [`UserPositions`] held at the `PositionBundle` level
+//! via [`NativeStateReader`] to inspect committed Position state
+//! without going through the VM session cache.
+
+#![forbid(unsafe_code)]
+
+use crate::native_state_store::{UserPositionKey, UserPositions};
+use aptos_infallible::Mutex;
+use aptos_types::state_store::native_position::NativePosition;
+use move_core_types::account_address::AccountAddress;
+use std::sync::Arc;
+
+static LATEST_READER: std::sync::Mutex<Option<Arc<InMemoryNativeStateReader>>> =
+    std::sync::Mutex::new(None);
+
+pub fn install_global_reader(reader: Arc<InMemoryNativeStateReader>) {
+    if let Ok(mut guard) = LATEST_READER.lock() {
+        *guard = Some(reader);
+    }
+}
+
+pub fn global_reader() -> Option<Arc<InMemoryNativeStateReader>> {
+    LATEST_READER.lock().ok().and_then(|g| g.clone())
+}
+
+pub trait NativeStateReader: Send + Sync {
+    fn iter_position_accounts_for_exchange(&self, exchange: AccountAddress) -> Vec<AccountAddress>;
+
+    fn get_account_positions(
+        &self,
+        exchange: AccountAddress,
+        account: AccountAddress,
+    ) -> Vec<(AccountAddress, NativePosition)>;
+
+    fn count_positions_for_exchange(&self, exchange: AccountAddress) -> usize;
+}
+
+pub struct InMemoryNativeStateReader {
+    user_positions: Arc<Mutex<UserPositions>>,
+}
+
+impl InMemoryNativeStateReader {
+    pub fn new(user_positions: Arc<Mutex<UserPositions>>) -> Self {
+        Self { user_positions }
+    }
+
+    pub fn snapshot(&self) -> NativeStateView {
+        NativeStateView {
+            user_positions: self.user_positions.lock().clone(),
+        }
+    }
+}
+
+impl NativeStateReader for InMemoryNativeStateReader {
+    fn iter_position_accounts_for_exchange(&self, exchange: AccountAddress) -> Vec<AccountAddress> {
+        self.snapshot().iter_position_accounts_for_exchange(exchange)
+    }
+
+    fn count_positions_for_exchange(&self, exchange: AccountAddress) -> usize {
+        self.snapshot().count_positions_for_exchange(exchange)
+    }
+
+    fn get_account_positions(
+        &self,
+        exchange: AccountAddress,
+        account: AccountAddress,
+    ) -> Vec<(AccountAddress, NativePosition)> {
+        self.snapshot().get_account_positions(exchange, account)
+    }
+}
+
+pub struct NativeStateView {
+    user_positions: UserPositions,
+}
+
+impl NativeStateView {
+    pub fn iter_position_accounts_for_exchange(
+        &self,
+        exchange: AccountAddress,
+    ) -> Vec<AccountAddress> {
+        let view = self
+            .user_positions
+            .top()
+            .view_layers_after(self.user_positions.family_root());
+        view.iter()
+            .filter_map(|(position_key, state)| {
+                (position_key.exchange == exchange && !state.is_empty())
+                    .then_some(position_key.account)
+            })
+            .collect()
+    }
+
+    pub fn count_positions_for_exchange(&self, exchange: AccountAddress) -> usize {
+        let view = self
+            .user_positions
+            .top()
+            .view_layers_after(self.user_positions.family_root());
+        view.iter()
+            .filter(|(position_key, _)| position_key.exchange == exchange)
+            .map(|(_, state)| state.positions.len())
+            .sum()
+    }
+
+    pub fn get_account_positions(
+        &self,
+        exchange: AccountAddress,
+        account: AccountAddress,
+    ) -> Vec<(AccountAddress, NativePosition)> {
+        let key = UserPositionKey { exchange, account };
+        self.user_positions
+            .get(&key)
+            .map(|us| us.positions.into_iter().collect())
+            .unwrap_or_default()
+    }
+}

--- a/storage/aptosdb/src/native_state_store.rs
+++ b/storage/aptosdb/src/native_state_store.rs
@@ -1,0 +1,13 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Crate-level re-export of the per-account position index types
+//! (now defined in `aptos-storage-interface` so the executor can name
+//! them in its function signatures).
+
+#![forbid(unsafe_code)]
+
+pub use aptos_storage_interface::state_store::user_positions::{
+    decode_rows_to_user_position_states, materialize_user_position_updates, PositionWrite,
+    UserPositionKey, UserPositionState, UserPositions,
+};

--- a/storage/aptosdb/src/native_storage_tests.rs
+++ b/storage/aptosdb/src/native_storage_tests.rs
@@ -13,7 +13,11 @@ use crate::{
 };
 use aptos_crypto::hash::CryptoHash;
 use aptos_temppath::TempPath;
-use aptos_types::{state_store::state_key::StateKey, transaction::Version, write_set::WriteOp};
+use aptos_types::{
+    state_store::{native_position::NativePosition, state_key::StateKey},
+    transaction::Version,
+    write_set::WriteOp,
+};
 use move_core_types::account_address::AccountAddress;
 use std::sync::Arc;
 
@@ -40,7 +44,7 @@ fn exchange(byte: u8) -> AccountAddress {
     AccountAddress::new(a)
 }
 
-fn user(byte: u8) -> AccountAddress {
+fn account(byte: u8) -> AccountAddress {
     exchange(byte)
 }
 
@@ -49,11 +53,30 @@ fn market(byte: u8) -> AccountAddress {
 }
 
 fn position_key(byte: u8) -> StateKey {
-    StateKey::position(exchange(1), user(byte), market(1))
+    StateKey::position(exchange(1), account(byte), market(1))
 }
 
-fn upsert(bytes: &[u8]) -> WriteOp {
-    WriteOp::legacy_modification(bytes.to_vec().into())
+/// Build a valid BCS-encoded `NativePosition` whose `size` carries
+/// `tag` — lets tests distinguish writes without needing the bytes
+/// to look like a particular string.
+fn position_bytes(tag: u64) -> Vec<u8> {
+    NativePosition::PerpV1 {
+        size: tag,
+        is_long: true,
+        entry_px_times_size_sum: 0,
+        avg_acquire_entry_px: 0,
+        user_leverage: 1,
+        is_isolated: false,
+        funding_index_at_last_update: 0,
+        unrealized_funding_amount_before_last_update: 0,
+        timestamp: 0,
+    }
+    .serialize()
+    .expect("NativePosition serialize")
+}
+
+fn upsert(tag: u64) -> WriteOp {
+    WriteOp::legacy_modification(position_bytes(tag).into())
 }
 
 fn delete() -> WriteOp {
@@ -61,28 +84,28 @@ fn delete() -> WriteOp {
 }
 
 /// Commit one position write at `version` using the committer's
-/// per-chunk-batched path. Returns the merkle leaf updates.
+/// per-chunk-batched path. Returns the decoded `PositionWrite`s the
+/// committer emitted for this chunk.
 fn commit_one(
     db: &Arc<PositionDb>,
     version: Version,
     key: StateKey,
     op: WriteOp,
-) -> Vec<crate::native_state_committer::MerkleLeafUpdate> {
+) -> Vec<crate::native_state_committer::PositionWrite> {
     let committer = NativeStateCommitter::new(Arc::clone(db));
     let mut sharded_kv_batches = new_sharded_kv_batches();
     let mut in_chunk_prior = InChunkPriorVersions::new();
-    let updates = committer
+    let writes = committer
         .apply(
             version,
             std::iter::once((key, op)),
             &mut sharded_kv_batches,
             &mut in_chunk_prior,
         )
-        .expect("apply")
-        .position;
+        .expect("apply");
     db.commit(version, None, sharded_kv_batches)
         .expect("position_db commit");
-    updates
+    writes
 }
 
 #[test]
@@ -98,9 +121,9 @@ fn find_prior_version_returns_latest_below_target() {
     let key = position_key(1);
     let hash = key.hash();
 
-    commit_one(&db, 0, key.clone(), upsert(b"v0"));
-    commit_one(&db, 5, key.clone(), upsert(b"v5"));
-    commit_one(&db, 10, key.clone(), upsert(b"v10"));
+    commit_one(&db, 0, key.clone(), upsert(0));
+    commit_one(&db, 5, key.clone(), upsert(5));
+    commit_one(&db, 10, key.clone(), upsert(10));
 
     assert_eq!(db.find_prior_version(hash, 11).unwrap(), Some(10));
     assert_eq!(db.find_prior_version(hash, 10).unwrap(), Some(5));
@@ -116,7 +139,7 @@ fn apply_emits_no_prev_version_sentinel_for_first_write() {
     let key = position_key(1);
     let hash = key.hash();
 
-    commit_one(&db, 7, key.clone(), upsert(b"v7"));
+    commit_one(&db, 7, key.clone(), upsert(7));
 
     let shard = crate::sharded_kv_db::ShardedKvDb::shard_of_hash(hash);
     let mut iter = db
@@ -145,8 +168,8 @@ fn apply_emits_prior_version_on_overwrite() {
     let key = position_key(1);
     let hash = key.hash();
 
-    commit_one(&db, 0, key.clone(), upsert(b"v0"));
-    commit_one(&db, 5, key.clone(), upsert(b"v5"));
+    commit_one(&db, 0, key.clone(), upsert(0));
+    commit_one(&db, 5, key.clone(), upsert(5));
 
     let shard = crate::sharded_kv_db::ShardedKvDb::shard_of_hash(hash);
     let mut iter = db
@@ -180,15 +203,72 @@ fn apply_emits_prior_version_on_overwrite() {
 }
 
 #[test]
-fn apply_tombstone_carries_no_value_hash() {
+fn apply_emits_typed_position_for_upsert_none_for_delete() {
     let (_tmp, db) = open_position_db();
     let key = position_key(1);
 
-    let upserts = commit_one(&db, 0, key.clone(), upsert(b"v0"));
-    assert!(upserts[0].value_hash.is_some());
+    let upserts = commit_one(&db, 0, key.clone(), upsert(7));
+    assert_eq!(upserts.len(), 1);
+    let pos = upserts[0]
+        .value
+        .as_ref()
+        .expect("upsert PositionWrite carries decoded value");
+    assert_eq!(pos.size(), 7, "decoded NativePosition's tag survives apply");
 
     let deletes = commit_one(&db, 1, key.clone(), delete());
-    assert_eq!(deletes[0].value_hash, None);
+    assert_eq!(deletes.len(), 1);
+    assert!(
+        deletes[0].value.is_none(),
+        "delete PositionWrite has no decoded value"
+    );
+}
+
+/// Verifies that a single `apply` call over a batch of position
+/// writes emits one `PositionWrite` per input in arrival order, each
+/// with the correct `position_key`, `market`, and decoded value.
+#[test]
+fn apply_emits_one_position_write_per_input() {
+    let (_tmp, db) = open_position_db();
+    let committer = NativeStateCommitter::new(Arc::clone(&db));
+    let mut sharded_kv_batches = new_sharded_kv_batches();
+    let mut in_chunk_prior = InChunkPriorVersions::new();
+
+    let exch = exchange(1);
+    let acct_a = account(2);
+    let acct_b = account(3);
+    let market_x = market(7);
+    let market_y = market(8);
+
+    let inputs = vec![
+        (
+            StateKey::position(exch, acct_a, market_x),
+            upsert(100),
+        ),
+        (
+            StateKey::position(exch, acct_b, market_y),
+            upsert(200),
+        ),
+        (StateKey::position(exch, acct_a, market_y), delete()),
+    ];
+
+    let writes = committer
+        .apply(0, inputs, &mut sharded_kv_batches, &mut in_chunk_prior)
+        .expect("apply");
+
+    assert_eq!(writes.len(), 3, "one PositionWrite per input");
+
+    assert_eq!(writes[0].position_key.exchange, exch);
+    assert_eq!(writes[0].position_key.account, acct_a);
+    assert_eq!(writes[0].market, market_x);
+    assert_eq!(writes[0].value.as_ref().unwrap().size(), 100);
+
+    assert_eq!(writes[1].position_key.account, acct_b);
+    assert_eq!(writes[1].market, market_y);
+    assert_eq!(writes[1].value.as_ref().unwrap().size(), 200);
+
+    assert_eq!(writes[2].position_key.account, acct_a);
+    assert_eq!(writes[2].market, market_y);
+    assert!(writes[2].value.is_none(), "delete carries no value");
 }
 
 #[test]
@@ -197,8 +277,8 @@ fn truncate_advances_overall_position_commit_progress() {
     let key = position_key(1);
     let hash = key.hash();
 
-    commit_one(&db, 3, key.clone(), upsert(b"v3"));
-    commit_one(&db, 7, key.clone(), upsert(b"v7"));
+    commit_one(&db, 3, key.clone(), upsert(3));
+    commit_one(&db, 7, key.clone(), upsert(7));
     assert_eq!(get_position_commit_progress(&db).unwrap(), Some(7));
 
     truncate_position_db_shards(&db, 3).unwrap();
@@ -234,14 +314,11 @@ fn in_chunk_writes_chain_stale_index_versions() {
     let mut in_chunk_prior = InChunkPriorVersions::new();
 
     // Three writes to the same key inside a single chunk.
-    for (i, payload) in [b"a".as_slice(), b"b".as_slice(), b"c".as_slice()]
-        .iter()
-        .enumerate()
-    {
+    for (i, tag) in [11u64, 12, 13].iter().enumerate() {
         committer
             .apply(
                 i as Version,
-                std::iter::once((key.clone(), upsert(payload))),
+                std::iter::once((key.clone(), upsert(*tag))),
                 &mut sharded_kv_batches,
                 &mut in_chunk_prior,
             )
@@ -267,4 +344,230 @@ fn in_chunk_writes_chain_stale_index_versions() {
     assert!(entries[0].is_first_write(), "v0 is first write");
     assert_eq!(entries[1].version, 0, "v1's stale-index points at v0");
     assert_eq!(entries[2].version, 1, "v2's stale-index points at v1");
+}
+
+mod integration {
+    use super::{account, exchange, market};
+    use crate::{
+        native_state_committer::PositionWrite,
+        native_state_store::materialize_user_position_updates,
+        native_state_reader::{InMemoryNativeStateReader, NativeStateReader},
+        native_state_store::{UserPositionKey, UserPositions},
+    };
+    use aptos_infallible::Mutex;
+    use aptos_types::{state_store::native_position::NativePosition, transaction::Version};
+    use std::sync::Arc;
+
+    fn position(size: u64) -> NativePosition {
+        NativePosition::PerpV1 {
+            size,
+            is_long: true,
+            entry_px_times_size_sum: 0,
+            avg_acquire_entry_px: 0,
+            user_leverage: 1,
+            is_isolated: false,
+            funding_index_at_last_update: 0,
+            unrealized_funding_amount_before_last_update: 0,
+            timestamp: 0,
+        }
+    }
+
+    /// Simulates the writer's post-commit fold of one chunk: turns
+    /// per-tx `PositionWrite`s into per-account `UserPositionState`
+    /// deltas via `materialize_user_position_updates`, then extends
+    /// the layered `UserPositions` once.
+    fn fold_chunk(
+        handle: &Arc<Mutex<UserPositions>>,
+        version: Version,
+        writes: Vec<PositionWrite>,
+    ) {
+        let mut up = handle.lock();
+        let updates = materialize_user_position_updates(&up, writes);
+        *up = up.extend(version, updates);
+    }
+
+    /// Writer-shaped chunk fold against the same `Arc<Mutex<UserPositions>>`
+    /// the reader holds. Verifies inserts, latest-wins overwrites,
+    /// deletes, and cross-exchange isolation across multiple chunks.
+    #[test]
+    fn reader_sees_writes_folded_through_user_positions() {
+        let handle = Arc::new(Mutex::new(UserPositions::new_empty("test")));
+        let reader = InMemoryNativeStateReader::new(Arc::clone(&handle));
+
+        let exch_a = exchange(1);
+        let exch_b = exchange(2);
+        let acct_x = account(10);
+        let acct_y = account(11);
+        let mkt_p = market(100);
+        let mkt_q = market(101);
+
+        // Chunk 0: account X on exchange A opens two markets.
+        fold_chunk(&handle, 0, vec![
+            PositionWrite {
+                position_key: UserPositionKey {
+                    exchange: exch_a,
+                    account: acct_x,
+                },
+                market: mkt_p,
+                value: Some(position(100)),
+            },
+            PositionWrite {
+                position_key: UserPositionKey {
+                    exchange: exch_a,
+                    account: acct_x,
+                },
+                market: mkt_q,
+                value: Some(position(200)),
+            },
+        ]);
+
+        let xa = reader.get_account_positions(exch_a, acct_x);
+        let xa_sizes: Vec<u64> = xa.iter().map(|(_, p)| p.size()).collect();
+        assert_eq!(xa.len(), 2);
+        assert!(xa_sizes.contains(&100));
+        assert!(xa_sizes.contains(&200));
+
+        assert_eq!(
+            reader.iter_position_accounts_for_exchange(exch_a),
+            vec![acct_x]
+        );
+        assert_eq!(reader.count_positions_for_exchange(exch_a), 2);
+
+        // Exchange B is empty at this point.
+        assert!(reader.iter_position_accounts_for_exchange(exch_b).is_empty());
+        assert_eq!(reader.count_positions_for_exchange(exch_b), 0);
+
+        // Chunk 1: overwrite mkt_p on X, delete mkt_q on X, open one
+        // position for account Y on a different exchange.
+        fold_chunk(&handle, 1, vec![
+            PositionWrite {
+                position_key: UserPositionKey {
+                    exchange: exch_a,
+                    account: acct_x,
+                },
+                market: mkt_p,
+                value: Some(position(300)),
+            },
+            PositionWrite {
+                position_key: UserPositionKey {
+                    exchange: exch_a,
+                    account: acct_x,
+                },
+                market: mkt_q,
+                value: None,
+            },
+            PositionWrite {
+                position_key: UserPositionKey {
+                    exchange: exch_b,
+                    account: acct_y,
+                },
+                market: mkt_p,
+                value: Some(position(50)),
+            },
+        ]);
+
+        // Account X: latest-wins on mkt_p, mkt_q gone.
+        let xa = reader.get_account_positions(exch_a, acct_x);
+        assert_eq!(xa.len(), 1);
+        assert_eq!(xa[0].0, mkt_p);
+        assert_eq!(xa[0].1.size(), 300);
+        assert_eq!(reader.count_positions_for_exchange(exch_a), 1);
+
+        // Account Y now visible on exchange B.
+        assert_eq!(
+            reader.iter_position_accounts_for_exchange(exch_b),
+            vec![acct_y]
+        );
+        let yb = reader.get_account_positions(exch_b, acct_y);
+        assert_eq!(yb.len(), 1);
+        assert_eq!(yb[0].1.size(), 50);
+
+        // Chunk 2: delete account X's last position. The layer
+        // stores an empty `UserPositionState`, which
+        // `iter_position_accounts_for_exchange` filters out.
+        fold_chunk(&handle, 2, vec![PositionWrite {
+            position_key: UserPositionKey {
+                exchange: exch_a,
+                account: acct_x,
+            },
+            market: mkt_p,
+            value: None,
+        }]);
+        assert!(reader.iter_position_accounts_for_exchange(exch_a).is_empty());
+        assert!(reader.get_account_positions(exch_a, acct_x).is_empty());
+        assert_eq!(reader.count_positions_for_exchange(exch_a), 0);
+    }
+
+    /// `InMemoryNativeStateReader::snapshot` returns a coherent view
+    /// across many queries — writes that land after the snapshot
+    /// is taken must not leak in.
+    #[test]
+    fn snapshot_view_is_coherent_across_writes() {
+        let handle = Arc::new(Mutex::new(UserPositions::new_empty("test")));
+        let reader = InMemoryNativeStateReader::new(Arc::clone(&handle));
+
+        let exch_a = exchange(1);
+        let exch_b = exchange(2);
+        let acct_x = account(10);
+        let acct_y = account(11);
+        let mkt_p = market(100);
+
+        // Chunk 0: account X on A, account Y on B.
+        fold_chunk(&handle, 0, vec![
+            PositionWrite {
+                position_key: UserPositionKey {
+                    exchange: exch_a,
+                    account: acct_x,
+                },
+                market: mkt_p,
+                value: Some(position(7)),
+            },
+            PositionWrite {
+                position_key: UserPositionKey {
+                    exchange: exch_b,
+                    account: acct_y,
+                },
+                market: mkt_p,
+                value: Some(position(9)),
+            },
+        ]);
+
+        // Take a snapshot, then mutate via another chunk. Snapshot
+        // must keep showing the version-0 state for ALL queries.
+        let snap = reader.snapshot();
+
+        fold_chunk(&handle, 1, vec![
+            // After-snapshot delete on X and append on B's Y.
+            PositionWrite {
+                position_key: UserPositionKey {
+                    exchange: exch_a,
+                    account: acct_x,
+                },
+                market: mkt_p,
+                value: None,
+            },
+            PositionWrite {
+                position_key: UserPositionKey {
+                    exchange: exch_b,
+                    account: acct_y,
+                },
+                market: market(101),
+                value: Some(position(11)),
+            },
+        ]);
+
+        // Snapshot still reflects v0.
+        assert_eq!(snap.iter_position_accounts_for_exchange(exch_a), vec![
+            acct_x
+        ]);
+        assert_eq!(snap.count_positions_for_exchange(exch_a), 1);
+        let xa = snap.get_account_positions(exch_a, acct_x);
+        assert_eq!(xa.len(), 1);
+        assert_eq!(xa[0].1.size(), 7);
+        assert_eq!(snap.count_positions_for_exchange(exch_b), 1);
+
+        // Live reader now reflects v1.
+        assert!(reader.iter_position_accounts_for_exchange(exch_a).is_empty());
+        assert_eq!(reader.count_positions_for_exchange(exch_b), 2);
+    }
 }

--- a/storage/aptosdb/src/position_buffered_state.rs
+++ b/storage/aptosdb/src/position_buffered_state.rs
@@ -109,6 +109,13 @@ impl PositionPersistedState {
 
 pub(crate) const POSITION_TARGET_ITEMS: usize = 200_000;
 
+/// Mirrors `state_store::MAX_WRITE_SETS_AFTER_SNAPSHOT`. Cap on the
+/// startup replay window so a node enabling trading-native from
+/// before its first position snapshot doesn't load arbitrarily many
+/// historical write sets into one `Vec`.
+pub(crate) const MAX_POSITION_WRITE_SETS_AFTER_SNAPSHOT: u64 =
+    TARGET_SNAPSHOT_INTERVAL_IN_VERSION * (ASYNC_COMMIT_CHANNEL_BUFFER_SIZE + 2 + 1) * 2;
+
 pub(crate) type PositionBufferedState = crate::common::BufferedState<
     PositionLedgerStateWithSummary,
     PositionStateWithSummary,
@@ -137,6 +144,9 @@ impl PositionBufferedState {
         out_current_state: Arc<Mutex<PositionLedgerStateWithSummary>>,
         position_pruner: Arc<PositionPruner>,
         persisted: PositionPersistedState,
+        user_positions: Arc<
+            Mutex<aptos_storage_interface::state_store::user_positions::UserPositions>,
+        >,
     ) -> Self {
         *out_current_state.lock() =
             PositionLedgerStateWithSummary::new_at_checkpoint(last_snapshot.clone());
@@ -156,6 +166,7 @@ impl PositionBufferedState {
                     batch_receiver,
                     position_pruner,
                     persisted,
+                    user_positions,
                 )
                 .run();
             },

--- a/storage/aptosdb/src/position_merkle_batch_committer.rs
+++ b/storage/aptosdb/src/position_merkle_batch_committer.rs
@@ -12,8 +12,10 @@ use crate::{
     pruner::PrunerManager,
 };
 use aptos_crypto::HashValue;
+use aptos_infallible::Mutex;
 use aptos_logger::{info, trace};
 use aptos_metrics_core::TimerHelper;
+use aptos_storage_interface::state_store::user_positions::UserPositions;
 use aptos_types::transaction::Version;
 use std::sync::{mpsc::Receiver, Arc};
 
@@ -32,6 +34,10 @@ pub(crate) struct PositionMerkleBatchCommitter {
     receiver: Receiver<CommitMessage<PositionMerkleCommit>>,
     position_pruner: Arc<PositionPruner>,
     persisted: PositionPersistedState,
+    /// Bundle handle for the scanner-side `UserPositions` index.
+    /// After a snapshot lands the chain is collapsed in place so the
+    /// in-memory depth doesn't grow without bound.
+    user_positions: Arc<Mutex<UserPositions>>,
 }
 
 impl PositionMerkleBatchCommitter {
@@ -40,12 +46,14 @@ impl PositionMerkleBatchCommitter {
         receiver: Receiver<CommitMessage<PositionMerkleCommit>>,
         position_pruner: Arc<PositionPruner>,
         persisted: PositionPersistedState,
+        user_positions: Arc<Mutex<UserPositions>>,
     ) -> Self {
         Self {
             merkle_db,
             receiver,
             position_pruner,
             persisted,
+            user_positions,
         }
     }
 
@@ -55,6 +63,7 @@ impl PositionMerkleBatchCommitter {
             receiver,
             position_pruner,
             persisted,
+            user_positions,
         } = self;
         run_batch_committer_loop(receiver, |commit| {
             let _timer = OTHER_TIMERS_SECONDS.timer_with(&["position_batch_committer_work"]);
@@ -84,6 +93,13 @@ impl PositionMerkleBatchCommitter {
             // `version` are on disk, so cold-key proofs against this base
             // are serviceable.
             persisted.set(snapshot);
+            // Collapse the scanner-side `UserPositions` chain into a
+            // fresh family holding the current full state. Bounds
+            // in-memory chain depth by snapshot cadence — outstanding
+            // speculative branches keep the old family alive until
+            // they drop, then it's collected.
+            let mut up = user_positions.lock();
+            *up = up.rebase();
         });
         trace!("Position merkle batch committing thread exit.");
     }

--- a/storage/aptosdb/src/position_metrics.rs
+++ b/storage/aptosdb/src/position_metrics.rs
@@ -1,7 +1,9 @@
 // Copyright (c) Aptos Foundation
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
-use aptos_metrics_core::{register_int_counter_vec, IntCounterVec};
+use aptos_metrics_core::{
+    exponential_buckets, register_histogram, register_int_counter_vec, Histogram, IntCounterVec,
+};
 use once_cell::sync::Lazy;
 
 pub static POSITION_WRITES: Lazy<IntCounterVec> = Lazy::new(|| {
@@ -9,6 +11,15 @@ pub static POSITION_WRITES: Lazy<IntCounterVec> = Lazy::new(|| {
         "aptos_position_writes_total",
         "Position writes applied by NativeStateCommitter",
         &["kind"]
+    )
+    .unwrap()
+});
+
+pub static POSITION_COLD_LOAD_SECONDS: Lazy<Histogram> = Lazy::new(|| {
+    register_histogram!(
+        "aptos_position_cold_load_seconds",
+        "Wall-clock duration of the position_db startup scan",
+        exponential_buckets(0.1, 2.0, 12).unwrap()
     )
     .unwrap()
 });

--- a/storage/aptosdb/src/position_state_store.rs
+++ b/storage/aptosdb/src/position_state_store.rs
@@ -14,6 +14,7 @@ use crate::{
     position_pruner::PositionPruner,
 };
 use aptos_infallible::Mutex;
+use aptos_storage_interface::state_store::user_positions::UserPositions;
 use std::sync::Arc;
 
 pub(crate) type PositionStateStore =
@@ -26,6 +27,7 @@ impl PositionStateStore {
         last_snapshot: PositionStateWithSummary,
         position_pruner: Arc<PositionPruner>,
         persisted: PositionPersistedState,
+        user_positions: Arc<Mutex<UserPositions>>,
     ) -> Self {
         let current_state = Arc::new(Mutex::new(
             PositionLedgerStateWithSummary::new_at_checkpoint(last_snapshot.clone()),
@@ -38,6 +40,7 @@ impl PositionStateStore {
             Arc::clone(&current_state),
             position_pruner,
             persisted,
+            user_positions,
         );
         Self::from_parts(current_state, buffered_state)
     }

--- a/storage/aptosdb/src/pruner/state_kv_pruner/position_value_test.rs
+++ b/storage/aptosdb/src/pruner/state_kv_pruner/position_value_test.rs
@@ -20,7 +20,11 @@ use crate::{
 use aptos_config::config::{LedgerPrunerConfig, RocksdbConfig, StorageDirPaths};
 use aptos_crypto::{hash::CryptoHash, HashValue};
 use aptos_temppath::TempPath;
-use aptos_types::{state_store::state_key::StateKey, transaction::Version, write_set::WriteOp};
+use aptos_types::{
+    state_store::{native_position::NativePosition, state_key::StateKey},
+    transaction::Version,
+    write_set::WriteOp,
+};
 use move_core_types::account_address::AccountAddress;
 use std::{collections::BTreeSet, sync::Arc};
 
@@ -45,8 +49,25 @@ fn position_key(user_byte: u8) -> StateKey {
     StateKey::position(addr(1), addr(user_byte), addr(1))
 }
 
-fn upsert(bytes: &[u8]) -> WriteOp {
-    WriteOp::legacy_modification(bytes.to_vec().into())
+/// BCS-encoded `NativePosition` carrying `tag` in the `size` field.
+fn position_bytes(tag: u64) -> Vec<u8> {
+    NativePosition::PerpV1 {
+        size: tag,
+        is_long: true,
+        entry_px_times_size_sum: 0,
+        avg_acquire_entry_px: 0,
+        user_leverage: 1,
+        is_isolated: false,
+        funding_index_at_last_update: 0,
+        unrealized_funding_amount_before_last_update: 0,
+        timestamp: 0,
+    }
+    .serialize()
+    .expect("NativePosition serialize")
+}
+
+fn upsert(tag: u64) -> WriteOp {
+    WriteOp::legacy_modification(position_bytes(tag).into())
 }
 
 fn commit_at(db: &Arc<PositionDb>, version: Version, writes: Vec<(StateKey, WriteOp)>) {
@@ -90,9 +111,9 @@ fn position_pruner_removes_superseded_values_keeps_live() {
     let key = position_key(1);
     let hash = key.hash();
 
-    commit_at(&db, 0, vec![(key.clone(), upsert(b"v0"))]);
-    commit_at(&db, 5, vec![(key.clone(), upsert(b"v5"))]);
-    commit_at(&db, 10, vec![(key.clone(), upsert(b"v10"))]);
+    commit_at(&db, 0, vec![(key.clone(), upsert(100))]);
+    commit_at(&db, 5, vec![(key.clone(), upsert(105))]);
+    commit_at(&db, 10, vec![(key.clone(), upsert(110))]);
 
     let pruner = StateKvPruner::<PositionValue>::new(Arc::clone(&db)).unwrap();
     pruner.set_target_version(7);
@@ -115,7 +136,7 @@ fn position_pruner_first_write_removes_index_but_not_value() {
     let key = position_key(1);
     let hash = key.hash();
 
-    commit_at(&db, 3, vec![(key.clone(), upsert(b"v3"))]);
+    commit_at(&db, 3, vec![(key.clone(), upsert(103))]);
 
     let pruner = StateKvPruner::<PositionValue>::new(Arc::clone(&db)).unwrap();
     pruner.set_target_version(100);
@@ -143,12 +164,12 @@ fn position_pruner_fans_out_across_shards() {
     commit_at(
         &db,
         0,
-        keys.iter().cloned().map(|k| (k, upsert(b"a"))).collect(),
+        keys.iter().cloned().map(|k| (k, upsert(1001))).collect(),
     );
     commit_at(
         &db,
         1,
-        keys.iter().cloned().map(|k| (k, upsert(b"b"))).collect(),
+        keys.iter().cloned().map(|k| (k, upsert(1002))).collect(),
     );
 
     let pruner = StateKvPruner::<PositionValue>::new(Arc::clone(&db)).unwrap();
@@ -168,8 +189,8 @@ fn position_manager_drives_pruning() {
     let (_tmp, db) = open_position_db();
     let key = position_key(1);
     let hash = key.hash();
-    commit_at(&db, 0, vec![(key.clone(), upsert(b"v0"))]);
-    commit_at(&db, 5, vec![(key.clone(), upsert(b"v5"))]);
+    commit_at(&db, 0, vec![(key.clone(), upsert(100))]);
+    commit_at(&db, 5, vec![(key.clone(), upsert(105))]);
 
     let manager = PositionValuePrunerManager::new(Arc::clone(&db), LedgerPrunerConfig {
         enable: true,

--- a/storage/aptosdb/src/schema/position_value/mod.rs
+++ b/storage/aptosdb/src/schema/position_value/mod.rs
@@ -3,8 +3,8 @@
 
 //! Physical storage schema for the native-position `position_value` CF.
 //!
-//! Hash-keyed, mirroring `state_value_by_key_hash` from the main-state
-//! tier. The row key is the 32-byte `StateKey::hash()` (the same hash
+//! Hash-keyed, same shape as `state_value_by_key_hash` in the
+//! main-state tier. The row key is the 32-byte `StateKey::hash()` (the same hash
 //! the JMT uses as `account_key`) plus the bit-inverted version for
 //! newest-first ordering.
 //!

--- a/storage/aptosdb/src/schema/stale_position_value_index/mod.rs
+++ b/storage/aptosdb/src/schema/stale_position_value_index/mod.rs
@@ -2,9 +2,9 @@
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 //! Physical storage schema for the native-position
-//! `stale_position_value_index` CF. Hash-keyed, mirroring
-//! `stale_state_value_index_by_key_hash` from the main-state tier —
-//! same `(stale_since_version, version, state_key_hash)` shape, so
+//! `stale_position_value_index` CF. Hash-keyed, same shape as
+//! `stale_state_value_index_by_key_hash` in the main-state tier —
+//! same `(stale_since_version, version, state_key_hash)` layout, so
 //! the position pruner reuses
 //! [`aptos_types::state_store::state_value::StaleStateValueByKeyHashIndex`]
 //! directly under the local alias [`StalePositionValueIndex`]. Only

--- a/storage/aptosdb/src/trading_native.rs
+++ b/storage/aptosdb/src/trading_native.rs
@@ -4,7 +4,7 @@
 //! Crate-wide flag for the native-trading subsystem (positions today;
 //! orders and collateral land later). Gates whether
 //! `AptosDB::open_internal` attaches the position DBs, runs the
-//! native commit applier, and exposes the in-memory mirror.
+//! native commit applier, and exposes the in-memory `UserPositions`.
 
 /// Flip to `true` once order/collateral land.
 pub(crate) const ENABLE_TRADING_NATIVE: bool = false;

--- a/storage/storage-interface/src/chunk_to_commit.rs
+++ b/storage/storage-interface/src/chunk_to_commit.rs
@@ -8,6 +8,7 @@ use crate::state_store::{
     state_update_refs::StateUpdateRefs,
     state_view::cached_state_view::ShardedStateCache,
     state_with_summary::{LedgerStateWithSummary, LedgerWithSummary, StateWithSummary},
+    user_positions::UserPositions,
     HotStateUpdates,
 };
 use aptos_types::transaction::{
@@ -30,6 +31,12 @@ pub struct ChunkToCommit<'a> {
     /// be persisted/merklized at commit without recomputation. `None` when
     /// native position is disabled.
     pub position_state_summary: Option<&'a LedgerWithSummary<PositionStateWithSummary>>,
+    /// Per-account `UserPositions` index computed at execution time
+    /// (alongside `position_state_summary`). Commit publishes this
+    /// onto the bundle's user-positions handle so the validator-side
+    /// scanner sees the latest committed view. `None` when native
+    /// position is disabled.
+    pub user_positions: Option<&'a LedgerWithSummary<UserPositions>>,
     pub is_reconfig: bool,
 }
 

--- a/storage/storage-interface/src/ledger_summary.rs
+++ b/storage/storage-interface/src/ledger_summary.rs
@@ -4,6 +4,7 @@
 use crate::state_store::{
     sharded_jmt_state::PositionStateWithSummary, state::LedgerState,
     state_summary::LedgerStateSummary, state_with_summary::LedgerWithSummary,
+    user_positions::UserPositions,
 };
 use aptos_config::config::HotStateConfig;
 use aptos_types::{
@@ -19,6 +20,8 @@ pub struct LedgerSummary {
     pub transaction_accumulator: Arc<InMemoryTransactionAccumulator>,
     /// Pre-committed native-position summary; `None` when position is disabled.
     pub position_state_summary: Option<LedgerWithSummary<PositionStateWithSummary>>,
+    /// Pre-committed per-account position index; `None` when position is disabled.
+    pub user_positions: Option<LedgerWithSummary<UserPositions>>,
 }
 
 impl LedgerSummary {
@@ -34,6 +37,7 @@ impl LedgerSummary {
             state_summary,
             transaction_accumulator,
             position_state_summary: None,
+            user_positions: None,
         }
     }
 

--- a/storage/storage-interface/src/lib.rs
+++ b/storage/storage-interface/src/lib.rs
@@ -46,7 +46,7 @@ use crate::{
     chunk_to_commit::ChunkToCommit,
     state_store::{
         sharded_jmt_state::PositionStateWithSummary, state::State, state_summary::StateSummary,
-        state_with_summary::LedgerWithSummary,
+        state_with_summary::LedgerWithSummary, user_positions::UserPositions,
     },
 };
 pub use aptos_types::block_info::BlockHeight;
@@ -397,6 +397,14 @@ pub trait DbReader: Send + Sync {
         fn get_pre_committed_position_state_summary(
             &self,
         ) -> Result<LedgerWithSummary<PositionStateWithSummary>>;
+
+        /// Pre-committed per-account position index. Returned as a
+        /// `LedgerWithSummary` so the executor can chain blocks off
+        /// it. Errors when the feature is on but native-position
+        /// storage is absent.
+        fn get_pre_committed_user_positions(
+            &self,
+        ) -> Result<LedgerWithSummary<UserPositions>>;
 
         /// Native-position analog of `get_state_proof_by_version_ext`: a
         /// cold-key proof from the persisted position JMT at `version`.

--- a/storage/storage-interface/src/state_store/mod.rs
+++ b/storage/storage-interface/src/state_store/mod.rs
@@ -10,6 +10,7 @@ pub mod state_summary;
 pub mod state_update_refs;
 pub mod state_view;
 pub mod state_with_summary;
+pub mod user_positions;
 pub mod versioned_state_value;
 
 use anyhow::{bail, Result};

--- a/storage/storage-interface/src/state_store/user_positions.rs
+++ b/storage/storage-interface/src/state_store/user_positions.rs
@@ -3,19 +3,24 @@
 
 //! Per-account layered position index.
 //!
-//! `UserPositions` is the in-memory speculative view that mirrors
-//! `ShardedJmtState<PositionSlot>`'s pipelined shape but is keyed by
+//! `UserPositions` is the in-memory speculative view keyed by
 //! `(exchange, account)` and carries the *decoded* `UserPositionState`
 //! per layer.
+//!
+//! **Values are stored as `Arc<UserPositionState>` in the layered
+//! map.** Layer construction and rebase only refcount-bump untouched
+//! accounts; deep-cloning the inner `BTreeMap` happens once per
+//! actually-written account on the write path.
 //!
 //! **Chain growth bounded by periodic rebase.** `family_root` is
 //! pinned so reads can view-from-root regardless of chain depth (the
 //! scanner's hot path stays decode-free with no durable fallback).
 //! Unbounded growth is avoided via [`UserPositions::rebase`] —
 //! triggered by the merkle batch committer when a snapshot lands.
-//! Rebase walks the current top, collects the full live state, and
-//! seeds a fresh family with one layer holding it; the old family
-//! drops as soon as outstanding speculative references release.
+//! Rebase walks the current top, collects the full live state (one
+//! `Arc` clone per account, no value copy), and seeds a fresh family
+//! with one layer holding it; the old family drops as soon as
+//! outstanding speculative references release.
 
 #![forbid(unsafe_code)]
 
@@ -62,18 +67,20 @@ impl UserPositionState {
 
 /// Multi-version layered per-account position index. Each chunk
 /// pushes one new layer; speculative branches Arc-drop the layer
-/// without disturbing ancestors.
+/// without disturbing ancestors. Layer values are
+/// `Arc<UserPositionState>` so untouched accounts cost a refcount
+/// bump per layer build, not a deep copy.
 ///
 /// `family_root` keeps the family-root layer alive so `get` /
 /// full-walk views can `view_layers_after(family_root)` and see the
-/// whole chain — without that anchor, the parent `Weak` references
-/// could be dropped and `LayeredMap::get` would lose visibility into
-/// older layers. See module-level TODO for the chain-pruning rework.
+/// whole chain — without that pinned reference the parent `Weak`
+/// links could be dropped and `LayeredMap::get` would lose visibility
+/// into older layers.
 #[derive(Clone, Debug)]
 pub struct UserPositions {
     next_version: Version,
-    family_root: Arc<MapLayer<UserPositionKey, UserPositionState>>,
-    top: MapLayer<UserPositionKey, UserPositionState>,
+    family_root: Arc<MapLayer<UserPositionKey, Arc<UserPositionState>>>,
+    top: MapLayer<UserPositionKey, Arc<UserPositionState>>,
 }
 
 impl UserPositions {
@@ -103,11 +110,11 @@ impl UserPositions {
         self.next_version.checked_sub(1)
     }
 
-    pub fn family_root(&self) -> &MapLayer<UserPositionKey, UserPositionState> {
+    pub fn family_root(&self) -> &MapLayer<UserPositionKey, Arc<UserPositionState>> {
         &self.family_root
     }
 
-    pub fn top(&self) -> &MapLayer<UserPositionKey, UserPositionState> {
+    pub fn top(&self) -> &MapLayer<UserPositionKey, Arc<UserPositionState>> {
         &self.top
     }
 
@@ -116,15 +123,20 @@ impl UserPositions {
     }
 
     /// Layered read: returns the top-most `UserPositionState` for
-    /// `key` reachable from the family root.
-    pub fn get(&self, key: &UserPositionKey) -> Option<UserPositionState> {
+    /// `key` reachable from the family root. The returned `Arc` is
+    /// shared with the layer that owns the value — callers wanting
+    /// to mutate must `Arc::make_mut` (or build a fresh state).
+    pub fn get(&self, key: &UserPositionKey) -> Option<Arc<UserPositionState>> {
         self.top.view_layers_after(&self.family_root).get(key)
     }
 
     /// Seed a single base layer above the family root with `seed`.
     /// Used by cold-load to hydrate at startup. `next_version` is
     /// unchanged (set by the caller via `new_at_version`).
-    pub fn with_seeded_base(self, seed: Vec<(UserPositionKey, UserPositionState)>) -> Self {
+    pub fn with_seeded_base(
+        self,
+        seed: Vec<(UserPositionKey, Arc<UserPositionState>)>,
+    ) -> Self {
         let top = self
             .top
             .view_layers_after(&self.family_root)
@@ -143,24 +155,29 @@ impl UserPositions {
     /// references (e.g. per-block `UserPositions` in
     /// `PartialStateComputeResult`) release.
     ///
+    /// Untouched accounts cost only an `Arc::clone` here — the inner
+    /// `BTreeMap<MarketAddress, NativePosition>` is not duplicated.
+    /// Touched accounts already paid their inner-map cost on the
+    /// write path; this walk shares those same `Arc`s.
+    ///
     /// Called by the merkle batch committer when a snapshot lands —
     /// keeps in-memory chain depth bounded by snapshot cadence while
     /// preserving the "in-memory holds all data" invariant the
     /// scanner reads rely on (no durable fallback needed).
     pub fn rebase(&self) -> Self {
-        let entries: Vec<(UserPositionKey, UserPositionState)> =
+        let entries: Vec<(UserPositionKey, Arc<UserPositionState>)> =
             self.top.view_layers_after(&self.family_root).iter().collect();
         Self::new_at_version(self.version(), "position").with_seeded_base(entries)
     }
 
-    /// Push a new layer atop `self`. The new layer's `base_layer`
-    /// field is anchored at `family_root` so reader paths viewing
-    /// from `family_root` see the whole chain across any number of
+    /// Push a new layer atop `self`. The new layer's base is
+    /// anchored at `family_root` so reader paths viewing from
+    /// `family_root` see the whole chain across any number of
     /// extends.
     pub fn extend(
         &self,
         new_version: Version,
-        updates: Vec<(UserPositionKey, UserPositionState)>,
+        updates: Vec<(UserPositionKey, Arc<UserPositionState>)>,
     ) -> Self {
         let top = self
             .top
@@ -174,14 +191,14 @@ impl UserPositions {
     }
 }
 
-/// Streams JMT rows into the `(UserPositionKey, UserPositionState)`
+/// Streams JMT rows into the `(UserPositionKey, Arc<UserPositionState>)`
 /// seed used to initialize the base layer of a [`UserPositions`] at
 /// startup. Memory is bounded by the live position set — one
 /// decoded row at a time, no double-buffering of the durable
 /// snapshot.
 pub fn decode_rows_to_user_position_states<I>(
     rows: I,
-) -> crate::Result<Vec<(UserPositionKey, UserPositionState)>>
+) -> crate::Result<Vec<(UserPositionKey, Arc<UserPositionState>)>>
 where
     I: IntoIterator<Item = crate::Result<(StateKey, StateValue)>>,
 {
@@ -211,7 +228,7 @@ where
             .positions
             .insert(market, position);
     }
-    Ok(by_account.into_iter().collect())
+    Ok(by_account.into_iter().map(|(k, v)| (k, Arc::new(v))).collect())
 }
 
 /// Decoded per-tx Position write captured by the commit applier.
@@ -226,18 +243,28 @@ pub struct PositionWrite {
 }
 
 /// Collapse a chunk's `PositionWrite` stream into one
-/// `UserPositionState` per touched `UserPositionKey`, reading the
-/// base from `current` (the previous committed layer). Writes apply
-/// in arrival order, latest-wins per `(account, market)`.
+/// `Arc<UserPositionState>` per touched `UserPositionKey`, reading
+/// the base from `current` (the previous committed layer). Writes
+/// apply in arrival order, latest-wins per `(account, market)`.
+///
+/// We deep-clone the inner `BTreeMap` once per touched account (when
+/// the prior state is shared with the layered map). Untouched
+/// accounts pay nothing — they stay in their existing layer as
+/// shared `Arc`s.
 pub fn materialize_user_position_updates(
     current: &UserPositions,
     writes: Vec<PositionWrite>,
-) -> Vec<(UserPositionKey, UserPositionState)> {
+) -> Vec<(UserPositionKey, Arc<UserPositionState>)> {
     use std::collections::hash_map::Entry;
     let mut by_account: HashMap<UserPositionKey, UserPositionState> = HashMap::new();
     for w in writes {
         let entry = match by_account.entry(w.position_key) {
-            Entry::Vacant(v) => v.insert(current.get(&w.position_key).unwrap_or_default()),
+            Entry::Vacant(v) => v.insert(
+                current
+                    .get(&w.position_key)
+                    .map(|arc| (*arc).clone())
+                    .unwrap_or_default(),
+            ),
             Entry::Occupied(o) => o.into_mut(),
         };
         match w.value {
@@ -249,7 +276,10 @@ pub fn materialize_user_position_updates(
             },
         }
     }
-    by_account.into_iter().collect()
+    by_account
+        .into_iter()
+        .map(|(k, v)| (k, Arc::new(v)))
+        .collect()
 }
 
 #[cfg(test)]
@@ -276,10 +306,10 @@ mod tests {
         }
     }
 
-    fn user_state(market: AccountAddress, size: u64) -> UserPositionState {
+    fn user_state(market: AccountAddress, size: u64) -> Arc<UserPositionState> {
         let mut positions = BTreeMap::new();
         positions.insert(market, position(size));
-        UserPositionState { positions }
+        Arc::new(UserPositionState { positions })
     }
 
     #[test]
@@ -399,5 +429,35 @@ mod tests {
         assert_eq!(*k, key);
         assert_eq!(state.positions[&market_x].size(), 150);
         assert_eq!(state.positions[&market_y].size(), 50);
+    }
+
+    #[test]
+    fn rebase_shares_value_arcs_for_untouched_accounts() {
+        let key_touched = UserPositionKey {
+            exchange: addr(1),
+            account: addr(2),
+        };
+        let key_quiet = UserPositionKey {
+            exchange: addr(1),
+            account: addr(3),
+        };
+        let market = addr(9);
+
+        let v0 = UserPositions::new_empty("test").extend(
+            0,
+            vec![
+                (key_touched, user_state(market, 100)),
+                (key_quiet, user_state(market, 200)),
+            ],
+        );
+        let v1 = v0.extend(1, vec![(key_touched, user_state(market, 300))]);
+
+        let before = v1.get(&key_quiet).expect("quiet must be present");
+        let rebased = v1.rebase();
+        let after = rebased.get(&key_quiet).expect("quiet must survive rebase");
+
+        // Untouched account's Arc is the *same* allocation as before
+        // the rebase — rebase did not deep-clone its inner BTreeMap.
+        assert!(Arc::ptr_eq(&before, &after));
     }
 }

--- a/storage/storage-interface/src/state_store/user_positions.rs
+++ b/storage/storage-interface/src/state_store/user_positions.rs
@@ -1,0 +1,403 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Per-account layered position index.
+//!
+//! `UserPositions` is the in-memory speculative view that mirrors
+//! `ShardedJmtState<PositionSlot>`'s pipelined shape but is keyed by
+//! `(exchange, account)` and carries the *decoded* `UserPositionState`
+//! per layer.
+//!
+//! **Chain growth bounded by periodic rebase.** `family_root` is
+//! pinned so reads can view-from-root regardless of chain depth (the
+//! scanner's hot path stays decode-free with no durable fallback).
+//! Unbounded growth is avoided via [`UserPositions::rebase`] —
+//! triggered by the merkle batch committer when a snapshot lands.
+//! Rebase walks the current top, collects the full live state, and
+//! seeds a fresh family with one layer holding it; the old family
+//! drops as soon as outstanding speculative references release.
+
+#![forbid(unsafe_code)]
+
+use aptos_experimental_layered_map::MapLayer;
+use aptos_types::{
+    account_address::AccountAddress,
+    state_store::{
+        native_position::NativePosition,
+        state_key::{
+            inner::{StateKeyInner, TradingNativeKey},
+            StateKey,
+        },
+        state_value::StateValue,
+    },
+    transaction::Version,
+};
+use std::{
+    collections::{BTreeMap, HashMap},
+    sync::Arc,
+};
+
+#[derive(Clone, Copy, Eq, Hash, Ord, PartialEq, PartialOrd, Debug)]
+pub struct UserPositionKey {
+    pub exchange: AccountAddress,
+    pub account: AccountAddress,
+}
+
+/// `BTreeMap` so iteration is sorted for cross-validator determinism.
+///
+/// Values are stored decoded (`NativePosition`), not as `StateValue`
+/// bytes. Validator-side scanners walk the layered view frequently
+/// for risk / ADL — we pay one BCS decode at commit / cold-load time
+/// and zero decodes per read.
+#[derive(Default, Debug, Clone)]
+pub struct UserPositionState {
+    pub positions: BTreeMap<AccountAddress, NativePosition>,
+}
+
+impl UserPositionState {
+    pub fn is_empty(&self) -> bool {
+        self.positions.is_empty()
+    }
+}
+
+/// Multi-version layered per-account position index. Each chunk
+/// pushes one new layer; speculative branches Arc-drop the layer
+/// without disturbing ancestors.
+///
+/// `family_root` keeps the family-root layer alive so `get` /
+/// full-walk views can `view_layers_after(family_root)` and see the
+/// whole chain — without that anchor, the parent `Weak` references
+/// could be dropped and `LayeredMap::get` would lose visibility into
+/// older layers. See module-level TODO for the chain-pruning rework.
+#[derive(Clone, Debug)]
+pub struct UserPositions {
+    next_version: Version,
+    family_root: Arc<MapLayer<UserPositionKey, UserPositionState>>,
+    top: MapLayer<UserPositionKey, UserPositionState>,
+}
+
+impl UserPositions {
+    pub fn new_empty(family: &'static str) -> Self {
+        let root = MapLayer::new_family(family);
+        Self {
+            next_version: 0,
+            family_root: Arc::new(root.clone()),
+            top: root,
+        }
+    }
+
+    pub fn new_at_version(version: Option<Version>, family: &'static str) -> Self {
+        let root = MapLayer::new_family(family);
+        Self {
+            next_version: version.map_or(0, |v| v + 1),
+            family_root: Arc::new(root.clone()),
+            top: root,
+        }
+    }
+
+    pub fn next_version(&self) -> Version {
+        self.next_version
+    }
+
+    pub fn version(&self) -> Option<Version> {
+        self.next_version.checked_sub(1)
+    }
+
+    pub fn family_root(&self) -> &MapLayer<UserPositionKey, UserPositionState> {
+        &self.family_root
+    }
+
+    pub fn top(&self) -> &MapLayer<UserPositionKey, UserPositionState> {
+        &self.top
+    }
+
+    pub fn is_descendant_of(&self, rhs: &Self) -> bool {
+        self.top.is_descendant_of(&rhs.top)
+    }
+
+    /// Layered read: returns the top-most `UserPositionState` for
+    /// `key` reachable from the family root.
+    pub fn get(&self, key: &UserPositionKey) -> Option<UserPositionState> {
+        self.top.view_layers_after(&self.family_root).get(key)
+    }
+
+    /// Seed a single base layer above the family root with `seed`.
+    /// Used by cold-load to hydrate at startup. `next_version` is
+    /// unchanged (set by the caller via `new_at_version`).
+    pub fn with_seeded_base(self, seed: Vec<(UserPositionKey, UserPositionState)>) -> Self {
+        let top = self
+            .top
+            .view_layers_after(&self.family_root)
+            .new_layer(&seed);
+        Self {
+            next_version: self.next_version,
+            family_root: self.family_root,
+            top,
+        }
+    }
+
+    /// Collapse the chain into a fresh `MapLayer` family holding
+    /// the current full state in a single layer. `next_version` is
+    /// preserved. The old family becomes unreachable from the
+    /// returned value; it drops as soon as outstanding speculative
+    /// references (e.g. per-block `UserPositions` in
+    /// `PartialStateComputeResult`) release.
+    ///
+    /// Called by the merkle batch committer when a snapshot lands —
+    /// keeps in-memory chain depth bounded by snapshot cadence while
+    /// preserving the "in-memory holds all data" invariant the
+    /// scanner reads rely on (no durable fallback needed).
+    pub fn rebase(&self) -> Self {
+        let entries: Vec<(UserPositionKey, UserPositionState)> =
+            self.top.view_layers_after(&self.family_root).iter().collect();
+        Self::new_at_version(self.version(), "position").with_seeded_base(entries)
+    }
+
+    /// Push a new layer atop `self`. The new layer's `base_layer`
+    /// field is anchored at `family_root` so reader paths viewing
+    /// from `family_root` see the whole chain across any number of
+    /// extends.
+    pub fn extend(
+        &self,
+        new_version: Version,
+        updates: Vec<(UserPositionKey, UserPositionState)>,
+    ) -> Self {
+        let top = self
+            .top
+            .view_layers_after(&self.family_root)
+            .new_layer(&updates);
+        Self {
+            next_version: new_version + 1,
+            family_root: Arc::clone(&self.family_root),
+            top,
+        }
+    }
+}
+
+/// Streams JMT rows into the `(UserPositionKey, UserPositionState)`
+/// seed used to initialize the base layer of a [`UserPositions`] at
+/// startup. Memory is bounded by the live position set — one
+/// decoded row at a time, no double-buffering of the durable
+/// snapshot.
+pub fn decode_rows_to_user_position_states<I>(
+    rows: I,
+) -> crate::Result<Vec<(UserPositionKey, UserPositionState)>>
+where
+    I: IntoIterator<Item = crate::Result<(StateKey, StateValue)>>,
+{
+    let mut by_account: HashMap<UserPositionKey, UserPositionState> = HashMap::new();
+    for row in rows {
+        let (state_key, state_value) = row?;
+        let (exchange, account, market) = match state_key.inner() {
+            StateKeyInner::TradingNative(TradingNativeKey::Position {
+                exchange,
+                account,
+                market,
+            }) => (*exchange, *account, *market),
+            other => {
+                return Err(crate::AptosDbError::Other(format!(
+                    "non-Position native StateKey in position snapshot: {other:?}"
+                )));
+            },
+        };
+        let position = NativePosition::deserialize(state_value.bytes()).map_err(|e| {
+            crate::AptosDbError::Other(format!(
+                "native position value at startup failed to decode: {e}"
+            ))
+        })?;
+        by_account
+            .entry(UserPositionKey { exchange, account })
+            .or_default()
+            .positions
+            .insert(market, position);
+    }
+    Ok(by_account.into_iter().collect())
+}
+
+/// Decoded per-tx Position write captured by the commit applier.
+/// The caller groups by `position_key`, reads the previous
+/// `UserPositionState` from the layered view, applies the writes,
+/// and pushes the resulting per-account updates as the next layer.
+#[derive(Clone, Debug)]
+pub struct PositionWrite {
+    pub position_key: UserPositionKey,
+    pub market: AccountAddress,
+    pub value: Option<NativePosition>,
+}
+
+/// Collapse a chunk's `PositionWrite` stream into one
+/// `UserPositionState` per touched `UserPositionKey`, reading the
+/// base from `current` (the previous committed layer). Writes apply
+/// in arrival order, latest-wins per `(account, market)`.
+pub fn materialize_user_position_updates(
+    current: &UserPositions,
+    writes: Vec<PositionWrite>,
+) -> Vec<(UserPositionKey, UserPositionState)> {
+    use std::collections::hash_map::Entry;
+    let mut by_account: HashMap<UserPositionKey, UserPositionState> = HashMap::new();
+    for w in writes {
+        let entry = match by_account.entry(w.position_key) {
+            Entry::Vacant(v) => v.insert(current.get(&w.position_key).unwrap_or_default()),
+            Entry::Occupied(o) => o.into_mut(),
+        };
+        match w.value {
+            Some(pos) => {
+                entry.positions.insert(w.market, pos);
+            },
+            None => {
+                entry.positions.remove(&w.market);
+            },
+        }
+    }
+    by_account.into_iter().collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn addr(byte: u8) -> AccountAddress {
+        let mut a = [0u8; AccountAddress::LENGTH];
+        a[AccountAddress::LENGTH - 1] = byte;
+        AccountAddress::new(a)
+    }
+
+    fn position(size: u64) -> NativePosition {
+        NativePosition::PerpV1 {
+            size,
+            is_long: true,
+            entry_px_times_size_sum: 0,
+            avg_acquire_entry_px: 0,
+            user_leverage: 1,
+            is_isolated: false,
+            funding_index_at_last_update: 0,
+            unrealized_funding_amount_before_last_update: 0,
+            timestamp: 0,
+        }
+    }
+
+    fn user_state(market: AccountAddress, size: u64) -> UserPositionState {
+        let mut positions = BTreeMap::new();
+        positions.insert(market, position(size));
+        UserPositionState { positions }
+    }
+
+    #[test]
+    fn reads_through_family_root_after_multiple_extends() {
+        let key_a = UserPositionKey {
+            exchange: addr(1),
+            account: addr(2),
+        };
+        let key_b = UserPositionKey {
+            exchange: addr(1),
+            account: addr(3),
+        };
+        let market = addr(9);
+
+        let v0 = UserPositions::new_empty("test").extend(0, vec![(key_a, user_state(market, 100))]);
+        let v1 = v0.extend(1, vec![(key_b, user_state(market, 200))]);
+        let v2 = v1.extend(2, vec![(key_a, user_state(market, 300))]);
+
+        assert_eq!(
+            v2.get(&key_a).map(|s| s.positions[&market].size()),
+            Some(300)
+        );
+        assert_eq!(
+            v2.get(&key_b).map(|s| s.positions[&market].size()),
+            Some(200)
+        );
+    }
+
+    #[test]
+    fn cold_load_seed_then_extend() {
+        let key_a = UserPositionKey {
+            exchange: addr(1),
+            account: addr(2),
+        };
+        let key_b = UserPositionKey {
+            exchange: addr(1),
+            account: addr(3),
+        };
+        let market = addr(9);
+
+        let seeded = UserPositions::new_at_version(Some(10), "test")
+            .with_seeded_base(vec![(key_a, user_state(market, 50))]);
+        let v11 = seeded.extend(11, vec![(key_b, user_state(market, 60))]);
+
+        assert_eq!(
+            v11.get(&key_a).map(|s| s.positions[&market].size()),
+            Some(50)
+        );
+        assert_eq!(
+            v11.get(&key_b).map(|s| s.positions[&market].size()),
+            Some(60)
+        );
+    }
+
+    #[test]
+    fn rebase_collapses_chain_preserving_content() {
+        let key_a = UserPositionKey {
+            exchange: addr(1),
+            account: addr(2),
+        };
+        let key_b = UserPositionKey {
+            exchange: addr(1),
+            account: addr(3),
+        };
+        let market = addr(9);
+
+        // Build a chain of three layers.
+        let v0 = UserPositions::new_empty("test").extend(0, vec![(key_a, user_state(market, 100))]);
+        let v1 = v0.extend(1, vec![(key_b, user_state(market, 200))]);
+        let v2 = v1.extend(2, vec![(key_a, user_state(market, 300))]);
+
+        let rebased = v2.rebase();
+
+        // Same per-key content visible from the rebased view.
+        assert_eq!(
+            rebased.get(&key_a).map(|s| s.positions[&market].size()),
+            Some(300)
+        );
+        assert_eq!(
+            rebased.get(&key_b).map(|s| s.positions[&market].size()),
+            Some(200)
+        );
+
+        // Fresh family — not a descendant of v2.
+        assert!(!rebased.is_descendant_of(&v2));
+        // next_version preserved.
+        assert_eq!(rebased.next_version(), v2.next_version());
+    }
+
+    #[test]
+    fn materialize_collapses_chunk_writes_per_account() {
+        let key = UserPositionKey {
+            exchange: addr(1),
+            account: addr(2),
+        };
+        let market_x = addr(7);
+        let market_y = addr(8);
+
+        let current = UserPositions::new_empty("test")
+            .extend(0, vec![(key, user_state(market_x, 100))]);
+
+        let writes = vec![
+            PositionWrite {
+                position_key: key,
+                market: market_y,
+                value: Some(position(50)),
+            },
+            PositionWrite {
+                position_key: key,
+                market: market_x,
+                value: Some(position(150)),
+            },
+        ];
+        let updates = materialize_user_position_updates(&current, writes);
+        assert_eq!(updates.len(), 1);
+        let (k, state) = &updates[0];
+        assert_eq!(*k, key);
+        assert_eq!(state.positions[&market_x].size(), 150);
+        assert_eq!(state.positions[&market_y].size(), 50);
+    }
+}


### PR DESCRIPTION
## Summary

Per-account position index updated at **execution time** (not commit time) so block N+1's executor sees block N's committed position writes via the threaded parent — mirrors how `position_state_summary` was moved to execution in PR #20016.

### Changes

- **`storage-interface::state_store::user_positions`** — new module: `UserPositions` (layered `MapLayer<UserPositionKey, UserPositionState>`), `PositionWrite`, `materialize_user_position_updates`, `decode_rows_to_user_position_states`. Types live in storage-interface so executor crates can name them.

- **`StateCheckpointOutput.user_positions: Option<LedgerWithSummary<UserPositions>>`** — per-block extended view computed by `DoStateCheckpoint::compute_user_positions_checkpoint`. Decodes the block's `PositionWrite`s, materializes against `parent.latest()`, pushes one layer.

- **`block_executor` threads `parent_user_positions`** from `parent_block.output.ensure_result_user_positions()` into `DoStateCheckpoint::run`. Mirrors `position_state_summary` plumbing.

- **`chunk_executor` carries `latest_user_positions`** across chunks in `ChunkCommitQueue` for the state-sync path.

- **`DbReader::get_pre_committed_user_positions` + `LedgerSummary.user_positions`** — returns the bundle's tip wrapped as `LedgerWithSummary` so the executor's restart path (workflow base-view) chains from the cold-loaded state.

- **`commit_native_position`** prefers `chunk.user_positions` (publishes `latest()` to `bundle.user_positions`); falls back to commit-stage materialization when the feature flag is off. Both paths preserve the bundle's MapLayer family.

- **`NativeStateReader` + `NativeStateView`** — scanner-side reader, snapshot-once batch queries.

### Safety

- **Family fabrication guarded**: `compute_user_positions_checkpoint` errors instead of fabricating a fresh MapLayer family when `parent` is `None` but writes are non-empty (would silently replace the bundle's chain on publish, orphaning cold-loaded data). Returns `None` only when both parent and writes are empty.

- **Same materialize fn used in three places** (commit fallback, replay-after-snapshot, executor's compute), so chunk-write semantics (latest-wins per `(account, market)`) are uniform.

### Known limitation

- **`UserPositions::family_root` is pinned** so reads can view-from-root regardless of chain depth. Chain depth grows monotonically until process restart. Main state's pattern (drop pin, let merkle-batch-committer's persisted handle act as floor) is the right fix but requires the scanner reader to support `(floor, top]` view + durable JMT fallback. Documented at the top of `user_positions.rs`.

- **Phase 2** (BlockSTM intra-block: tx_{i+1} sees tx_i's writes within a block) is out of scope. See `project_native_position_blockstm_gap`.

## Dependencies

Built on top of **#20016** (`[trading-native] Native-position consensus state root`) which established the execution-stage compute pattern for `position_state_summary`. This PR adds the same shape for `user_positions`.

## Test plan

- [ ] `cargo build -p aptos-db` clean (verified)
- [ ] `cargo test -p aptos-db --lib -- native_storage_tests pruner::state_kv_pruner::position_value_test` — 14 pass (verified)
- [ ] `cargo check --workspace` clean (verified)
- [ ] Unit tests in `user_positions` module: layered reads, cold-load+extend, chunk-write materialization.

The new `compute_user_positions_checkpoint` doesn't have a direct unit test (matches the precedent for `compute_position_checkpoint` which is also exercised only via executor integration tests). Its underlying primitives (`materialize_user_position_updates`, `UserPositions::extend`) are unit-tested in `storage-interface`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)