### PR TITLE
[mono-move] Aggregator natives

### DIFF
--- a/third_party/move/mono-move/core/src/native/registry.rs
+++ b/third_party/move/mono-move/core/src/native/registry.rs
@@ -23,10 +23,9 @@ pub struct NativeIdx(pub u32);
 ///
 /// A native is either a template that serves every instantiation, or a body
 /// specialized to one concrete instantiation. The two variants let
-/// type-agnostic natives (e.g. `signer::borrow_address`) register once while
-/// type-sensitive natives (e.g. `aggregator_v2::try_add`) register a separate
-/// body per concrete type. Resolution tries the monomorphic key first and falls
-/// back to the polymorphic one (see [`NativeRegistry::resolve`]).
+/// type-agnostic natives register once while type-sensitive natives register a
+/// separate body per concrete type. Resolution tries the monomorphic key first
+/// and falls back to the polymorphic one (see [`NativeRegistry::resolve`]).
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub enum NativeName {
     /// One implementation for all instantiations.

--- a/third_party/move/mono-move/core/src/native/registry.rs
+++ b/third_party/move/mono-move/core/src/native/registry.rs
@@ -9,6 +9,7 @@ use super::context::NativeContext;
 use crate::{
     interner::{InternedIdentifier, InternedModuleId},
     native::{NativeStatus, VMInternalError},
+    types::InternedTypeList,
 };
 use shared_dsa::UnorderedMap;
 use thiserror::Error;
@@ -18,11 +19,28 @@ use thiserror::Error;
 #[repr(transparent)]
 pub struct NativeIdx(pub u32);
 
-/// Fully-qualified native function name — used as keys in [`NativeRegistry`].
-#[derive(Clone, PartialEq, Eq, Hash)]
-pub struct NativeName {
-    pub module: InternedModuleId,
-    pub function: InternedIdentifier,
+/// Key under which a native is registered in a [`NativeRegistry`].
+///
+/// A native is either a template that serves every instantiation, or a body
+/// specialized to one concrete instantiation. The two variants let
+/// type-agnostic natives (e.g. `signer::borrow_address`) register once while
+/// type-sensitive natives (e.g. `aggregator_v2::try_add`) register a separate
+/// body per concrete type. Resolution tries the monomorphic key first and falls
+/// back to the polymorphic one (see [`NativeRegistry::resolve`]).
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+pub enum NativeName {
+    /// One implementation for all instantiations.
+    Polymorphic {
+        module: InternedModuleId,
+        function: InternedIdentifier,
+    },
+    /// Implementation specialized to one concrete instantiation, matched only
+    /// when the call's type arguments equal `ty_args`.
+    Monomorphic {
+        module: InternedModuleId,
+        function: InternedIdentifier,
+        ty_args: InternedTypeList,
+    },
 }
 
 /// Describes a family of [`NativeContext`] types indexed by a lifetime.
@@ -48,9 +66,15 @@ pub type NativeFunction<F> = Box<
         + Sync,
 >;
 
-/// Resolves a fully-qualified native name to its [`NativeIdx`].
+/// Resolves a native call to its [`NativeIdx`] from the callee's qualified name
+/// and the call's concrete type arguments.
 pub trait NativeResolver {
-    fn resolve(&self, name: &NativeName) -> Option<NativeIdx>;
+    fn resolve(
+        &self,
+        module: InternedModuleId,
+        function: InternedIdentifier,
+        ty_args: InternedTypeList,
+    ) -> Option<NativeIdx>;
 }
 
 /// A [`NativeResolver`] that resolves nothing -- useful for tests and simulations that
@@ -58,7 +82,12 @@ pub trait NativeResolver {
 pub struct NoNatives;
 
 impl NativeResolver for NoNatives {
-    fn resolve(&self, _name: &NativeName) -> Option<NativeIdx> {
+    fn resolve(
+        &self,
+        _module: InternedModuleId,
+        _function: InternedIdentifier,
+        _ty_args: InternedTypeList,
+    ) -> Option<NativeIdx> {
         None
     }
 }
@@ -139,7 +168,19 @@ impl<F: NativeContextFamily> Default for NativeRegistry<F> {
 }
 
 impl<F: NativeContextFamily> NativeResolver for NativeRegistry<F> {
-    fn resolve(&self, name: &NativeName) -> Option<NativeIdx> {
-        self.lookup_by_name(name)
+    /// Resolves the monomorphic registration for `ty_args` if one exists,
+    /// otherwise falls back to a polymorphic (template) registration.
+    fn resolve(
+        &self,
+        module: InternedModuleId,
+        function: InternedIdentifier,
+        ty_args: InternedTypeList,
+    ) -> Option<NativeIdx> {
+        self.lookup_by_name(&NativeName::Monomorphic {
+            module,
+            function,
+            ty_args,
+        })
+        .or_else(|| self.lookup_by_name(&NativeName::Polymorphic { module, function }))
     }
 }

--- a/third_party/move/mono-move/natives/src/aggregator_v2.rs
+++ b/third_party/move/mono-move/natives/src/aggregator_v2.rs
@@ -1,0 +1,443 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Natives for `0x1::aggregator_v2`. Support `u64` and `u128` integer types.
+//!
+//! MonoMove currently does not support parallelisation via delayed fields and
+//! all aggregator operations are sequential.
+//!
+//! TODO(perf): delayed fields integration needed.
+//! TODO(gas): missing gas charging for natives.
+//! TODO: support DerivedStringSnapshot.
+
+use crate::{monomorphic_natives, NativeEntry};
+use mono_move_core::{
+    native::{
+        NativeContext, NativeContextFamily, NativeStatus, Opaque, Ref, RootPool, VMInternalError,
+        VMValue,
+    },
+    types::{U128_TY, U64_TY},
+};
+use std::{fmt::Display, marker::PhantomData};
+
+/// A reference to an aggregator or a snapshot. Wraps a Move reference (a 16-byte
+/// fat pointer), rooted for the lifetime of the native call so it survives GC.
+struct AggregatorOrSnapshotRef<'a, T> {
+    inner: Ref<'a, Opaque>,
+    _t: PhantomData<T>,
+}
+
+impl<'a, T> VMValue<'a> for AggregatorOrSnapshotRef<'a, T> {
+    // A reference is a 16-byte fat pointer.
+    const FRAME_SLOT_SIZE: usize = 16;
+
+    unsafe fn read_from_frame(pool: &'a RootPool, frame_ptr: *const u8, offset: usize) -> Self {
+        Self {
+            inner: unsafe { Ref::read_from_frame(pool, frame_ptr, offset) },
+            _t: PhantomData,
+        }
+    }
+
+    unsafe fn write_to_frame(self, frame_ptr: *mut u8, offset: usize) {
+        unsafe { self.inner.write_to_frame(frame_ptr, offset) }
+    }
+}
+
+impl<T: UnsignedInt> AggregatorOrSnapshotRef<'_, T> {
+    fn read_value(&self) -> T {
+        // SAFETY: `value` is the 0th field for **both** Aggregator and
+        // AggregatorSnapshot, so we read directly from the referent without
+        // extra offsets. The referent stays rooted for the call.
+        unsafe { T::read(self.inner.ptr()) }
+    }
+
+    fn write_value(&self, value: T) {
+        // SAFETY: `value` is the 0th field for **both** Aggregator and
+        // AggregatorSnapshot, so we write directly to the referent without
+        // extra offsets. The referent stays rooted for the call.
+        unsafe { value.write(self.inner.ptr()) }
+    }
+
+    fn read_max_value(&self) -> T {
+        // SAFETY: `max_value` is the 1st Aggregator field, so we have to add
+        // the byte size of the `value` element.
+        unsafe { T::read(self.inner.ptr().add(T::SIZE)) }
+    }
+}
+
+/// Mirrors `0x1::aggregator_v2::Aggregator<T>` in Move.
+struct Aggregator<T> {
+    value: T,
+    max_value: T,
+}
+
+impl<'a, T: VMValue<'a>> VMValue<'a> for Aggregator<T> {
+    const FRAME_SLOT_SIZE: usize = 2 * <T as VMValue<'a>>::FRAME_SLOT_SIZE;
+
+    unsafe fn read_from_frame(pool: &'a RootPool, frame_ptr: *const u8, offset: usize) -> Self {
+        let value = unsafe { T::read_from_frame(pool, frame_ptr, offset) };
+        let max_value = unsafe {
+            T::read_from_frame(
+                pool,
+                frame_ptr,
+                offset + <T as VMValue<'a>>::FRAME_SLOT_SIZE,
+            )
+        };
+        Self { value, max_value }
+    }
+
+    unsafe fn write_to_frame(self, frame_ptr: *mut u8, offset: usize) {
+        unsafe {
+            self.value.write_to_frame(frame_ptr, offset);
+            self.max_value
+                .write_to_frame(frame_ptr, offset + <T as VMValue<'a>>::FRAME_SLOT_SIZE);
+        }
+    }
+}
+
+/// Mirrors `0x1::aggregator_v2::AggregatorSnapshot<T>` in Move.
+struct AggregatorSnapshot<T> {
+    value: T,
+}
+
+impl<'a, T: VMValue<'a>> VMValue<'a> for AggregatorSnapshot<T> {
+    const FRAME_SLOT_SIZE: usize = <T as VMValue<'a>>::FRAME_SLOT_SIZE;
+
+    unsafe fn read_from_frame(pool: &'a RootPool, frame_ptr: *const u8, offset: usize) -> Self {
+        // SAFETY: `value` is the 0th (and only) snapshot field.
+        let value = unsafe { T::read_from_frame(pool, frame_ptr, offset) };
+        Self { value }
+    }
+
+    unsafe fn write_to_frame(self, frame_ptr: *mut u8, offset: usize) {
+        // SAFETY: `value` is the 0th (and only) snapshot field.
+        unsafe { self.value.write_to_frame(frame_ptr, offset) };
+    }
+}
+
+/// The integer element types an aggregator holds.
+trait UnsignedInt: Copy + Ord + Display + for<'a> VMValue<'a> {
+    const ZERO: Self;
+    const MAX: Self;
+    /// Byte size of the value in a frame slot.
+    const SIZE: usize;
+    fn checked_add(self, other: Self) -> Option<Self>;
+    fn checked_sub(self, other: Self) -> Option<Self>;
+
+    /// Reads the value from a raw referent pointer.
+    ///
+    /// # Safety
+    ///
+    /// `ptr` must point to [`Self::SIZE`] valid, initialized bytes.
+    unsafe fn read(ptr: *const u8) -> Self;
+
+    /// Writes the value to a raw referent pointer.
+    ///
+    /// # Safety
+    ///
+    /// `ptr` must point to [`Self::SIZE`] writable bytes.
+    unsafe fn write(self, ptr: *mut u8);
+}
+
+impl UnsignedInt for u64 {
+    const MAX: Self = u64::MAX;
+    const SIZE: usize = 8;
+    const ZERO: Self = 0;
+
+    fn checked_add(self, other: Self) -> Option<Self> {
+        u64::checked_add(self, other)
+    }
+
+    fn checked_sub(self, other: Self) -> Option<Self> {
+        u64::checked_sub(self, other)
+    }
+
+    unsafe fn read(ptr: *const u8) -> Self {
+        unsafe { core::ptr::read_unaligned(ptr as *const u64) }
+    }
+
+    unsafe fn write(self, ptr: *mut u8) {
+        unsafe { core::ptr::write_unaligned(ptr as *mut u64, self) }
+    }
+}
+
+impl UnsignedInt for u128 {
+    const MAX: Self = u128::MAX;
+    const SIZE: usize = 16;
+    const ZERO: Self = 0;
+
+    fn checked_add(self, other: Self) -> Option<Self> {
+        u128::checked_add(self, other)
+    }
+
+    fn checked_sub(self, other: Self) -> Option<Self> {
+        u128::checked_sub(self, other)
+    }
+
+    unsafe fn read(ptr: *const u8) -> Self {
+        unsafe { core::ptr::read_unaligned(ptr as *const u128) }
+    }
+
+    unsafe fn write(self, ptr: *mut u8) {
+        unsafe { core::ptr::write_unaligned(ptr as *mut u128, self) }
+    }
+}
+
+/// `0x1::agregator_v2::create_aggregator<T>(max_value: T): Aggregator<T>`
+///
+/// Creates an aggregator with the given `max_value` and zero `value`.
+fn native_create_aggregator<C: NativeContext, T: UnsignedInt>(
+    ctx: &C,
+) -> Result<NativeStatus, VMInternalError> {
+    // SAFETY: arg 0 is `max_value` of type `T`.
+    let max_value = unsafe { ctx.arg::<T>(0) }?;
+    // SAFETY: return 0 is an aggregator with layout matching VM value layout.
+    unsafe {
+        ctx.set_return(0, Aggregator::<T> {
+            value: T::ZERO,
+            max_value,
+        })
+    }?;
+    Ok(NativeStatus::Success)
+}
+
+/// `0x1::agregator_v2::create_unbounded_aggregator<T>(): Aggregator<T>`
+///
+/// Creates an aggregator with bound inferred from the passed integer type
+/// (its maximum) and zero `value`.
+fn native_create_unbounded_aggregator<C: NativeContext, T: UnsignedInt>(
+    ctx: &C,
+) -> Result<NativeStatus, VMInternalError> {
+    // SAFETY: return 0 is an aggregator with layout matching VM value layout.
+    unsafe {
+        ctx.set_return(0, Aggregator::<T> {
+            value: T::ZERO,
+            max_value: T::MAX,
+        })
+    }?;
+    Ok(NativeStatus::Success)
+}
+
+/// `0x1::agregator_v2::try_add<T>(self: &mut Aggregator<T>, value: T): bool`
+///
+/// Adds `value` to aggregators's `value` and returns true if the result is
+/// at most aggregator's `max_value`. Otherwise, no-op and returns false.
+fn native_try_add<C: NativeContext, T: UnsignedInt>(
+    ctx: &C,
+) -> Result<NativeStatus, VMInternalError> {
+    // SAFETY: arg 0 is aggregator reference (fat pointer); arg 1 is `T`.
+    let aggregator = unsafe { ctx.arg::<AggregatorOrSnapshotRef<T>>(0) }?;
+    let value = unsafe { ctx.arg::<T>(1) }?;
+
+    let success = match aggregator.read_value().checked_add(value) {
+        Some(result) if result <= aggregator.read_max_value() => {
+            aggregator.write_value(result);
+            true
+        },
+        // Overflow otherwise.
+        _ => false,
+    };
+
+    // SAFETY: return 0 is `bool`.
+    unsafe { ctx.set_return(0, success) }?;
+    Ok(NativeStatus::Success)
+}
+
+/// `0x1::agregator_v2::try_sub<T>(self: &mut Aggregator<T>, value: T): bool`
+///
+/// Subtracts `value` from aggregators's `value` and returns true if the result
+/// is non-negative. Otherwise, no-op and returns false indicating underflow.
+fn native_try_sub<C: NativeContext, T: UnsignedInt>(
+    ctx: &C,
+) -> Result<NativeStatus, VMInternalError> {
+    // SAFETY: arg 0 is aggregator reference (fat pointer); arg 1 is `T`.
+    let aggregator = unsafe { ctx.arg::<AggregatorOrSnapshotRef<T>>(0) }?;
+    let rhs = unsafe { ctx.arg::<T>(1) }?;
+
+    let success = match aggregator.read_value().checked_sub(rhs) {
+        Some(result) => {
+            aggregator.write_value(result);
+            true
+        },
+        None => false,
+    };
+
+    // SAFETY: return 0 is `bool`.
+    unsafe { ctx.set_return(0, success) }?;
+    Ok(NativeStatus::Success)
+}
+
+/// `0x1::agregator_v2::is_at_least_impl<T>(self: &Aggregator<T>, min_amount: T): bool`
+///
+/// Returns true when the `value` of aggregator is at least this specified
+/// minimum amount.
+fn native_is_at_least_impl<C: NativeContext, T: UnsignedInt>(
+    ctx: &C,
+) -> Result<NativeStatus, VMInternalError> {
+    // SAFETY: arg 0 is aggregator reference (fat pointer), and arg 1 is the
+    // amount to compare against.
+    let aggregator = unsafe { ctx.arg::<AggregatorOrSnapshotRef<T>>(0) }?;
+    let min_amount = unsafe { ctx.arg::<T>(1) }?;
+
+    let result = aggregator.read_value() >= min_amount;
+
+    // SAFETY: return 0 is `bool`.
+    unsafe { ctx.set_return(0, result) }?;
+    Ok(NativeStatus::Success)
+}
+
+/// `0x1::agregator_v2::read<T>(self: &Aggregator<T>): T`
+///
+/// Returns `value` of the aggregator.
+fn native_read<C: NativeContext, T: UnsignedInt>(ctx: &C) -> Result<NativeStatus, VMInternalError> {
+    // SAFETY: arg 0 is aggregator reference (fat pointer).
+    let aggregator = unsafe { ctx.arg::<AggregatorOrSnapshotRef<T>>(0) }?;
+
+    let value = aggregator.read_value();
+    let max_value = aggregator.read_max_value();
+    if value > max_value {
+        return Err(VMInternalError::InvariantViolation(format!(
+            "Aggregator read returned value greater than max: {value} > {max_value}"
+        )));
+    }
+
+    // SAFETY: return 0 is the read value.
+    unsafe { ctx.set_return(0, value) }?;
+    Ok(NativeStatus::Success)
+}
+
+/// `0x1::agregator_v2::snapshot<T>(self: &Aggregator<T>): AggregatorSnapshot<T>`
+///
+/// Captures the aggregator's current `value` into a snapshot.
+fn native_snapshot<C: NativeContext, T: UnsignedInt>(
+    ctx: &C,
+) -> Result<NativeStatus, VMInternalError> {
+    // SAFETY: arg 0 is aggregator reference (fat pointer).
+    let aggregator = unsafe { ctx.arg::<AggregatorOrSnapshotRef<T>>(0) }?;
+    let value = aggregator.read_value();
+
+    // SAFETY: return 0 is a snapshot with layout matching VM value layout.
+    unsafe { ctx.set_return(0, AggregatorSnapshot::<T> { value }) }?;
+    Ok(NativeStatus::Success)
+}
+
+/// `0x1::agregator_v2::create_snapshot<T>(value: T): AggregatorSnapshot<T>`
+///
+/// Wraps `value` into a snapshot.
+fn native_create_snapshot<C: NativeContext, T: UnsignedInt>(
+    ctx: &C,
+) -> Result<NativeStatus, VMInternalError> {
+    // SAFETY: arg 0 is `value` of type `T`.
+    let value = unsafe { ctx.arg::<T>(0) }?;
+
+    // SAFETY: return 0 is a snapshot with layout matching VM value layout.
+    unsafe { ctx.set_return(0, AggregatorSnapshot::<T> { value }) }?;
+    Ok(NativeStatus::Success)
+}
+
+/// `0x1::agregator_v2::read_snapshot<T>(self: &AggregatorSnapshot<T>): T`
+///
+/// Returns the value held by the snapshot.
+fn native_read_snapshot<C: NativeContext, T: UnsignedInt>(
+    ctx: &C,
+) -> Result<NativeStatus, VMInternalError> {
+    // SAFETY: arg 0 is a snapshot reference (fat pointer).
+    let snapshot = unsafe { ctx.arg::<AggregatorOrSnapshotRef<T>>(0) }?;
+    let value = snapshot.read_value();
+
+    // SAFETY: return 0 is the snapshot value.
+    unsafe { ctx.set_return(0, value) }?;
+    Ok(NativeStatus::Success)
+}
+
+// Only u64 and u128 types are supported.
+pub fn make_all_aggregator_v2_natives<F: NativeContextFamily>() -> Vec<NativeEntry<F>> {
+    monomorphic_natives![
+        (
+            "0x1::aggregator_v2::create_aggregator",
+            &[U64_TY],
+            native_create_aggregator::<_, u64>
+        ),
+        (
+            "0x1::aggregator_v2::create_aggregator",
+            &[U128_TY],
+            native_create_aggregator::<_, u128>
+        ),
+        (
+            "0x1::aggregator_v2::create_unbounded_aggregator",
+            &[U64_TY],
+            native_create_unbounded_aggregator::<_, u64>
+        ),
+        (
+            "0x1::aggregator_v2::create_unbounded_aggregator",
+            &[U128_TY],
+            native_create_unbounded_aggregator::<_, u128>
+        ),
+        (
+            "0x1::aggregator_v2::try_add",
+            &[U64_TY],
+            native_try_add::<_, u64>
+        ),
+        (
+            "0x1::aggregator_v2::try_add",
+            &[U128_TY],
+            native_try_add::<_, u128>
+        ),
+        (
+            "0x1::aggregator_v2::try_sub",
+            &[U64_TY],
+            native_try_sub::<_, u64>
+        ),
+        (
+            "0x1::aggregator_v2::try_sub",
+            &[U128_TY],
+            native_try_sub::<_, u128>
+        ),
+        (
+            "0x1::aggregator_v2::is_at_least_impl",
+            &[U64_TY],
+            native_is_at_least_impl::<_, u64>
+        ),
+        (
+            "0x1::aggregator_v2::is_at_least_impl",
+            &[U128_TY],
+            native_is_at_least_impl::<_, u128>
+        ),
+        ("0x1::aggregator_v2::read", &[U64_TY], native_read::<_, u64>),
+        (
+            "0x1::aggregator_v2::read",
+            &[U128_TY],
+            native_read::<_, u128>
+        ),
+        (
+            "0x1::aggregator_v2::snapshot",
+            &[U64_TY],
+            native_snapshot::<_, u64>
+        ),
+        (
+            "0x1::aggregator_v2::snapshot",
+            &[U128_TY],
+            native_snapshot::<_, u128>
+        ),
+        (
+            "0x1::aggregator_v2::create_snapshot",
+            &[U64_TY],
+            native_create_snapshot::<_, u64>
+        ),
+        (
+            "0x1::aggregator_v2::create_snapshot",
+            &[U128_TY],
+            native_create_snapshot::<_, u128>
+        ),
+        (
+            "0x1::aggregator_v2::read_snapshot",
+            &[U64_TY],
+            native_read_snapshot::<_, u64>
+        ),
+        (
+            "0x1::aggregator_v2::read_snapshot",
+            &[U128_TY],
+            native_read_snapshot::<_, u128>
+        ),
+    ]
+}

--- a/third_party/move/mono-move/natives/src/function_info.rs
+++ b/third_party/move/mono-move/natives/src/function_info.rs
@@ -3,11 +3,11 @@
 
 //! Natives for the `function_info` module.
 
-use crate::{natives, NativeFunction};
+use crate::{monomorphic_natives, NativeEntry};
 use mono_move_core::native::{
     NativeContext, NativeContextFamily, NativeStatus, Ref, VMInternalError, Vector,
 };
-use move_core_types::{account_address::AccountAddress, identifier::Identifier};
+use move_core_types::identifier::Identifier;
 
 /// `0x1::function_info::is_identifier(s: &vector<u8>): bool`
 ///
@@ -30,7 +30,6 @@ pub fn native_is_identifier<C: NativeContext>(ctx: &C) -> Result<NativeStatus, V
 }
 
 /// Natives for the `function_info` module.
-pub fn make_all_function_info_natives<F: NativeContextFamily>(
-) -> Vec<(AccountAddress, Identifier, Identifier, NativeFunction<F>)> {
-    natives![("0x1::function_info::is_identifier", native_is_identifier)]
+pub fn make_all_function_info_natives<F: NativeContextFamily>() -> Vec<NativeEntry<F>> {
+    monomorphic_natives![("0x1::function_info::is_identifier", native_is_identifier)]
 }

--- a/third_party/move/mono-move/natives/src/lib.rs
+++ b/third_party/move/mono-move/natives/src/lib.rs
@@ -31,6 +31,11 @@ pub use type_info::make_all_type_info_natives;
 /// specialized to one concrete instantiation registers as
 /// [`Dispatch::Monomorphic`] carrying that instantiation's type arguments. The
 /// consumer interns these into a `NativeName` registry key.
+//
+// TODO: this duplicates `NativeName`'s shape. We keep it separate because
+// `NativeName` holds arena-interned ids that require an `ExecutionGuard`, which
+// is unavailable when these tables are built statically. Revisit if interning
+// becomes available earlier.
 pub enum Dispatch {
     Polymorphic,
     Monomorphic(&'static [InternedType]),

--- a/third_party/move/mono-move/natives/src/lib.rs
+++ b/third_party/move/mono-move/natives/src/lib.rs
@@ -8,30 +8,52 @@
 
 // Re-exported so the `natives!` macro can name it via `$crate::NativeFunction`
 // without callers having to add `mono-move-core` to their imports.
-use mono_move_core::native::NativeContextFamily;
 pub use mono_move_core::native::NativeFunction;
+use mono_move_core::{native::NativeContextFamily, types::InternedType};
 use move_core_types::{account_address::AccountAddress, identifier::Identifier};
 
+pub mod aggregator_v2;
 pub mod function_info;
 pub mod mem;
 pub mod signer;
 pub mod test_natives;
 pub mod type_info;
 
+pub use aggregator_v2::make_all_aggregator_v2_natives;
 pub use function_info::make_all_function_info_natives;
 pub use mem::make_all_mem_natives;
 pub use signer::make_all_signer_natives;
 pub use test_natives::{make_all_test_natives, native_u64_add, native_u64_identity};
 pub use type_info::make_all_type_info_natives;
 
+/// How a native is dispatched against a call's type arguments. A native that
+/// works for any instantiation registers as [`Dispatch::Polymorphic`]; a native
+/// specialized to one concrete instantiation registers as
+/// [`Dispatch::Monomorphic`] carrying that instantiation's type arguments. The
+/// consumer interns these into a `NativeName` registry key.
+pub enum Dispatch {
+    Polymorphic,
+    Monomorphic(&'static [InternedType]),
+}
+
+/// One native registration: its qualified name parts, its dispatch kind, and
+/// the boxed implementation.
+pub type NativeEntry<F> = (
+    AccountAddress,
+    Identifier,
+    Identifier,
+    Dispatch,
+    NativeFunction<F>,
+);
+
 /// All natives shipped with the production MonoMove VM. Additional native
 /// modules are concatenated here as they are implemented.
-pub fn make_all_production_natives<F: NativeContextFamily>(
-) -> Vec<(AccountAddress, Identifier, Identifier, NativeFunction<F>)> {
+pub fn make_all_production_natives<F: NativeContextFamily>() -> Vec<NativeEntry<F>> {
     let mut natives = make_all_signer_natives::<F>();
     natives.extend(make_all_mem_natives::<F>());
     natives.extend(make_all_type_info_natives::<F>());
     natives.extend(make_all_function_info_natives::<F>());
+    natives.extend(make_all_aggregator_v2_natives::<F>());
     natives
 }
 
@@ -65,26 +87,59 @@ pub(crate) fn parse_qualified_native_name(qname: &str) -> (AccountAddress, Ident
     (addr, module, function)
 }
 
-/// Builds a list of natives from human-readable qualified names and Rust functions.
+/// Builds one [`NativeEntry`]: parses the qualified name, boxes the function,
+/// and pairs it with the given [`Dispatch`]. Shared by the list macros below.
+macro_rules! native_entry {
+    ($qname:expr, $dispatch:expr, $func:expr) => {{
+        let (addr, module, function) = $crate::parse_qualified_native_name($qname);
+        let func: $crate::NativeFunction<_> = ::std::boxed::Box::new(|ctx| $func(ctx));
+        (addr, module, function, $dispatch, func)
+    }};
+}
+pub(crate) use native_entry;
+
+/// Builds a list of monomorphic natives: each body is registered for one
+/// concrete instantiation, and the specializer resolves it from the call's type
+/// arguments. Each entry is either `(name, fn)` — empty type arguments (a
+/// non-generic native) — or `(name, &[ty, ...], fn)` to specialize on the given
+/// static type arguments. The caller supplies the concrete types (e.g. the
+/// turbofished function and `&[U64_TY]`).
 ///
 /// Example:
 /// ```ignore
-/// let natives = natives![
-///     ("0x1::test_natives::u64_add", native_u64_add),
-///     ("0x1::test_natives::u64_identity", native_u64_identity),
+/// let natives = monomorphic_natives![
+///     ("0x1::aggregator_v2::try_add", &[U64_TY], native_try_add::<_, u64>),
+///     ("0x1::aggregator_v2::try_add", &[U128_TY], native_try_add::<_, u128>),
 /// ];
 /// ```
-macro_rules! natives {
-    [ $( ( $qname:expr , $func:expr ) ),* $(,)? ] => {
-        ::std::vec![
-            $({
-                let (addr, module, function) =
-                    $crate::parse_qualified_native_name($qname);
-                let func: $crate::NativeFunction<_> =
-                    ::std::boxed::Box::new(|ctx| $func(ctx));
-                (addr, module, function, func)
-            }),*
-        ]
+macro_rules! monomorphic_natives {
+    [ $( $entry:tt ),* $(,)? ] => {
+        ::std::vec![ $( $crate::monomorphic_natives!(@entry $entry) ),* ]
+    };
+    (@entry ( $qname:expr , $ty_args:expr , $func:expr )) => {
+        $crate::native_entry!($qname, $crate::Dispatch::Monomorphic($ty_args), $func)
+    };
+    (@entry ( $qname:expr , $func:expr )) => {
+        $crate::native_entry!($qname, $crate::Dispatch::Monomorphic(&[]), $func)
     };
 }
-pub(crate) use natives;
+pub(crate) use monomorphic_natives;
+
+/// Builds a list of polymorphic natives: each body works for any instantiation
+/// and the specializer resolves it from the call's module and function name
+/// alone. Each entry is `(name, fn)`.
+///
+/// Example:
+/// ```ignore
+/// let natives = polymorphic_natives![
+///     ("0x1::mem::swap", native_swap),
+/// ];
+/// ```
+macro_rules! polymorphic_natives {
+    [ $( ( $qname:expr , $func:expr ) ),* $(,)? ] => {
+        ::std::vec![ $(
+            $crate::native_entry!($qname, $crate::Dispatch::Polymorphic, $func)
+        ),* ]
+    };
+}
+pub(crate) use polymorphic_natives;

--- a/third_party/move/mono-move/natives/src/mem.rs
+++ b/third_party/move/mono-move/natives/src/mem.rs
@@ -3,12 +3,11 @@
 
 //! Native for the `mem` module.
 
-use crate::{natives, NativeFunction};
+use crate::{polymorphic_natives, NativeEntry};
 use mono_move_core::{
     native::{NativeContext, NativeContextFamily, NativeStatus, Opaque, Ref, VMInternalError},
     types::view_type,
 };
-use move_core_types::{account_address::AccountAddress, identifier::Identifier};
 
 /// `0x1::mem::swap<T>(left: &mut T, right: &mut T)`
 ///
@@ -36,7 +35,6 @@ pub fn native_swap<C: NativeContext>(ctx: &C) -> Result<NativeStatus, VMInternal
 }
 
 /// Natives for the `mem` module.
-pub fn make_all_mem_natives<F: NativeContextFamily>(
-) -> Vec<(AccountAddress, Identifier, Identifier, NativeFunction<F>)> {
-    natives![("0x1::mem::swap", native_swap)]
+pub fn make_all_mem_natives<F: NativeContextFamily>() -> Vec<NativeEntry<F>> {
+    polymorphic_natives![("0x1::mem::swap", native_swap)]
 }

--- a/third_party/move/mono-move/natives/src/signer.rs
+++ b/third_party/move/mono-move/natives/src/signer.rs
@@ -6,9 +6,8 @@
 //! MonoMove currently represents a `signer` as a bare 32-byte account address — the
 //! same layout as `address`. Permissioned signers are not supported, for now.
 
-use crate::{natives, NativeFunction};
+use crate::{monomorphic_natives, NativeEntry};
 use mono_move_core::native::{NativeContext, NativeContextFamily, NativeStatus, VMInternalError};
-use move_core_types::{account_address::AccountAddress, identifier::Identifier};
 
 /// `0x1::create_signer::create_signer(addr: address): signer`
 ///
@@ -38,9 +37,8 @@ pub fn native_is_permissioned_signer<C: NativeContext>(
 }
 
 /// Builds a list of all signer-related natives.
-pub fn make_all_signer_natives<F: NativeContextFamily>(
-) -> Vec<(AccountAddress, Identifier, Identifier, NativeFunction<F>)> {
-    natives![
+pub fn make_all_signer_natives<F: NativeContextFamily>() -> Vec<NativeEntry<F>> {
+    monomorphic_natives![
         ("0x1::signer::borrow_address", native_borrow_address),
         ("0x1::create_signer::create_signer", native_create_signer),
         (

--- a/third_party/move/mono-move/natives/src/test_natives.rs
+++ b/third_party/move/mono-move/natives/src/test_natives.rs
@@ -4,9 +4,8 @@
 //! Synthetic natives used by the differential harness. Expected to go
 //! away once real natives are wired up.
 
-use crate::{natives, NativeFunction};
+use crate::{monomorphic_natives, NativeEntry};
 use mono_move_core::native::{NativeContext, NativeContextFamily, NativeStatus, VMInternalError};
-use move_core_types::{account_address::AccountAddress, identifier::Identifier};
 
 pub fn native_u64_add<C: NativeContext>(ctx: &C) -> Result<NativeStatus, VMInternalError> {
     // SAFETY: u64 matches the Move-level `u64` type of args 0/1 and return 0.
@@ -32,9 +31,8 @@ pub fn native_u64_identity<C: NativeContext>(ctx: &C) -> Result<NativeStatus, VM
     Ok(NativeStatus::Success)
 }
 
-pub fn make_all_test_natives<F: NativeContextFamily>(
-) -> Vec<(AccountAddress, Identifier, Identifier, NativeFunction<F>)> {
-    natives![
+pub fn make_all_test_natives<F: NativeContextFamily>() -> Vec<NativeEntry<F>> {
+    monomorphic_natives![
         ("0x1::test_natives::u64_add", native_u64_add),
         ("0x1::test_natives::u64_identity", native_u64_identity),
     ]

--- a/third_party/move/mono-move/natives/src/type_info.rs
+++ b/third_party/move/mono-move/natives/src/type_info.rs
@@ -3,7 +3,7 @@
 
 //! Natives for the `type_info` module.
 
-use crate::{natives, NativeFunction};
+use crate::{polymorphic_natives, NativeEntry};
 use mono_move_core::{
     native::{
         NativeContext, NativeContextFamily, NativeStatus, RootPool, VMInternalError, VMValue,
@@ -11,7 +11,7 @@ use mono_move_core::{
     },
     types::{type_to_string, view_name, view_type, view_type_list, Type},
 };
-use move_core_types::{account_address::AccountAddress, identifier::Identifier};
+use move_core_types::account_address::AccountAddress;
 
 /// `0x1::type_info::type_name<T>(): String`
 ///
@@ -138,9 +138,8 @@ pub fn native_type_of<C: NativeContext>(ctx: &C) -> Result<NativeStatus, VMInter
 }
 
 /// Natives for the `type_info` module.
-pub fn make_all_type_info_natives<F: NativeContextFamily>(
-) -> Vec<(AccountAddress, Identifier, Identifier, NativeFunction<F>)> {
-    natives![
+pub fn make_all_type_info_natives<F: NativeContextFamily>() -> Vec<NativeEntry<F>> {
+    polymorphic_natives![
         ("0x1::type_info::type_name", native_type_name),
         ("0x1::type_info::type_of", native_type_of),
     ]

--- a/third_party/move/mono-move/specializer/src/lower/context.rs
+++ b/third_party/move/mono-move/specializer/src/lower/context.rs
@@ -20,7 +20,7 @@ use anyhow::{bail, Result};
 use mono_move_core::{
     align_up_u32,
     interner::{InternedFunctionRef, InternedIdentifier, InternedModuleId},
-    native::{NativeIdx, NativeName, NativeResolver},
+    native::{NativeIdx, NativeResolver},
     next_captured_value_offset,
     types::{
         strip_ref, view_type, view_type_list, Alignment, FieldLayout, InternedType,
@@ -388,10 +388,7 @@ pub fn try_build_context<'a>(
                 // TODO: support native closure targets. `CallClosure` resolves
                 // via `load_function`, which has no IR for natives, so skip them.
                 if natives
-                    .resolve(&NativeName {
-                        module: callee_module_id,
-                        function: callee_func_name,
-                    })
+                    .resolve(callee_module_id, callee_func_name, EMPTY_TYPE_LIST)
                     .is_some()
                 {
                     return Ok(BuildContextOutcome::Skipped(
@@ -454,10 +451,7 @@ pub fn try_build_context<'a>(
         // Consider cross-checking against the callee module's `is_native` flag
         // against the callee module's `is_native` flag so a registered impl cannot
         // shadow a Move-body function with the same qualified name.
-        let native_idx = natives.resolve(&NativeName {
-            module: callee_module_id,
-            function: callee_func_name,
-        });
+        let native_idx = natives.resolve(callee_module_id, callee_func_name, call_ty_args);
         call_sites.push(CallSiteInfo {
             callee_module_id,
             callee_func_name,

--- a/third_party/move/mono-move/testsuite/src/engine.rs
+++ b/third_party/move/mono-move/testsuite/src/engine.rs
@@ -13,7 +13,7 @@ use mono_move_core::{
 };
 use mono_move_global_context::{ExecutionGuard, GlobalContext};
 use mono_move_loader::{Loader, LoadingPolicy, LoweringPolicy};
-use mono_move_natives::{make_all_production_natives, make_all_test_natives};
+use mono_move_natives::{make_all_production_natives, make_all_test_natives, Dispatch};
 use mono_move_runtime::{
     ExecutionContext, InterpreterContext, ProductionContextFamily, ProductionNativeRegistry,
     RuntimeStatus, TransactionContext,
@@ -128,10 +128,16 @@ pub fn with_mono_function<'guard, 'ctx, R>(
             make_all_test_natives::<ProductionContextFamily>()
                 .into_iter()
                 .chain(make_all_production_natives::<ProductionContextFamily>())
-                .map(|(addr, module, function, func)| {
-                    let name = NativeName {
-                        module: guard.module_id_of(&addr, &module),
-                        function: guard.identifier_of(&function),
+                .map(|(addr, module, function, dispatch, func)| {
+                    let module = guard.module_id_of(&addr, &module);
+                    let function = guard.identifier_of(&function);
+                    let name = match dispatch {
+                        Dispatch::Polymorphic => NativeName::Polymorphic { module, function },
+                        Dispatch::Monomorphic(ty_args) => NativeName::Monomorphic {
+                            module,
+                            function,
+                            ty_args: guard.type_list_of(ty_args),
+                        },
                     };
                     (name, func)
                 }),

--- a/third_party/move/mono-move/testsuite/src/runner.rs
+++ b/third_party/move/mono-move/testsuite/src/runner.rs
@@ -9,7 +9,7 @@ use crate::{
     engine::RunResult,
     matcher::check_output,
     module_provider::InMemoryModuleProvider,
-    parser::{PrintSection, Step},
+    parser::{Check, PrintSection, Step},
     print_sections,
 };
 use anyhow::{anyhow, bail};
@@ -106,25 +106,45 @@ pub fn run_test(steps: Vec<Step>, kind: SourceKind, test_path: &Path) -> anyhow:
                 heap_size,
                 checks,
             } => {
-                let v1_output =
-                    execute_function_v1(&storage, &address, &module_name, &function_name, &args);
-                let (v2_output, v2_gc_count) = execute_function_v2(
-                    &guard,
-                    &module_provider,
-                    &address,
-                    &module_name,
-                    &function_name,
-                    &args,
-                    &v1_output.param_kinds,
-                    &v1_output.return_kinds,
-                    heap_size,
-                );
-                check_output(
-                    &checks,
-                    &v1_output.output.display,
-                    &v2_output.display,
-                    v2_gc_count,
-                )?;
+                // Run only the VM(s) a step actually checks (via `CHECK-V1` /
+                // `CHECK-V2`). This lets a step assert just one side — needed for
+                // natives one VM cannot run (e.g. `aggregator_v2`, which the
+                // legacy harness installs no extension for and would panic on).
+                // `CHECK-GC-COUNT` inspects the V2 collector, so it also needs V2.
+                let needs_v1 = checks.iter().any(|c| matches!(c, Check::V1(..)));
+                let needs_v2 = checks
+                    .iter()
+                    .any(|c| matches!(c, Check::V2(..) | Check::GcCount(..)));
+
+                let v1 = needs_v1.then(|| {
+                    execute_function_v1(&storage, &address, &module_name, &function_name, &args)
+                });
+
+                let (v2_display, v2_gc_count) = if needs_v2 {
+                    // V2 needs the arg/return kinds. Reuse V1's if it ran,
+                    // otherwise load the function (without running it) to size them.
+                    let (param_kinds, return_kinds) = match &v1 {
+                        Some(v1) => (v1.param_kinds.clone(), v1.return_kinds.clone()),
+                        None => load_signature_v1(&storage, &address, &module_name, &function_name),
+                    };
+                    let (v2_output, v2_gc_count) = execute_function_v2(
+                        &guard,
+                        &module_provider,
+                        &address,
+                        &module_name,
+                        &function_name,
+                        &args,
+                        &param_kinds,
+                        &return_kinds,
+                        heap_size,
+                    );
+                    (v2_output.display, v2_gc_count)
+                } else {
+                    (String::new(), 0)
+                };
+
+                let v1_display = v1.map(|v| v.output.display).unwrap_or_default();
+                check_output(&checks, &v1_display, &v2_display, v2_gc_count)?;
             },
         }
     }
@@ -165,6 +185,60 @@ struct V1Output {
     return_kinds: Vec<PrimitiveKind>,
 }
 
+/// Maps a function's parameter and return types to [`PrimitiveKind`]s. Panics on
+/// any non-primitive type — the harness only supports primitive args/returns.
+fn primitive_kinds(
+    param_tys: &[Type],
+    return_tys: &[Type],
+    env: &RuntimeEnvironment,
+) -> (Vec<PrimitiveKind>, Vec<PrimitiveKind>) {
+    let param_kinds = param_tys
+        .iter()
+        .map(|ty| {
+            PrimitiveKind::from_type(ty).expect("Only primitive argument types are supported")
+        })
+        .collect::<Vec<_>>();
+    let return_kinds = return_tys
+        .iter()
+        .map(|ty| PrimitiveKind::from_return_type(ty, env))
+        .collect::<Vec<_>>();
+    (param_kinds, return_kinds)
+}
+
+/// Loads a function via the legacy VM and returns its parameter and return
+/// kinds, without executing it. Used to size the V2 arg/return regions when the
+/// legacy VM is skipped for a step (no `CHECK-V1`/shared checks).
+fn load_signature_v1(
+    storage: &InMemoryStorage,
+    address: &AccountAddress,
+    module_name: &IdentStr,
+    function_name: &IdentStr,
+) -> (Vec<PrimitiveKind>, Vec<PrimitiveKind>) {
+    let mut gas_meter = UnmeteredGasMeter;
+    let traversal_storage = TraversalStorage::new();
+    let mut traversal_context = TraversalContext::new(&traversal_storage);
+    let module_storage = storage.as_unsync_module_storage();
+    let loader = LazyLoader::new(&module_storage);
+
+    let function = match loader.load_instantiated_function(
+        &LegacyLoaderConfig::unmetered(),
+        &mut gas_meter,
+        &mut traversal_context,
+        &ModuleId::new(*address, module_name.to_owned()),
+        function_name,
+        &[],
+    ) {
+        Ok(function) => function,
+        Err(err) => panic!("Failed to load function: {}", err),
+    };
+
+    primitive_kinds(
+        function.param_tys(),
+        function.return_tys(),
+        module_storage.runtime_environment(),
+    )
+}
+
 /// Execute a function via legacy MoveVM and returns normalized output.
 fn execute_function_v1(
     storage: &InMemoryStorage,
@@ -200,19 +274,11 @@ fn execute_function_v1(
     if function.param_tys().len() != args.len() {
         panic!("Function requires a different number of arguments");
     }
-    let param_kinds = function
-        .param_tys()
-        .iter()
-        .map(|ty| {
-            PrimitiveKind::from_type(ty).expect("Only primitive argument types are supported")
-        })
-        .collect::<Vec<_>>();
-    let runtime_env = module_storage.runtime_environment();
-    let return_kinds = function
-        .return_tys()
-        .iter()
-        .map(|ty| PrimitiveKind::from_return_type(ty, runtime_env))
-        .collect::<Vec<_>>();
+    let (param_kinds, return_kinds) = primitive_kinds(
+        function.param_tys(),
+        function.return_tys(),
+        module_storage.runtime_environment(),
+    );
     let serialized_args = param_kinds
         .iter()
         .zip(args.iter())

--- a/third_party/move/mono-move/testsuite/src/runner.rs
+++ b/third_party/move/mono-move/testsuite/src/runner.rs
@@ -127,6 +127,11 @@ pub fn run_test(steps: Vec<Step>, kind: SourceKind, test_path: &Path) -> anyhow:
                         Some(v1) => (v1.param_kinds.clone(), v1.return_kinds.clone()),
                         None => load_signature_v1(&storage, &address, &module_name, &function_name),
                     };
+                    assert_eq!(
+                        param_kinds.len(),
+                        args.len(),
+                        "function requires a different number of arguments"
+                    );
                     let (v2_output, v2_gc_count) = execute_function_v2(
                         &guard,
                         &module_provider,

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/natives/aggregator_v2.move
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/natives/aggregator_v2.move
@@ -1,0 +1,135 @@
+// V2-only test for the aggregator_v2 natives (u64 and u128).
+//
+// `aggregator_v2` is declared locally (with the same struct fields and native
+// signatures as the framework) to avoid pulling in the Aptos Framework, and
+// because the legacy harness installs no `NativeAggregatorContext` to run these
+// natives. Entry wrappers take/return primitives only and instantiate the
+// generic natives at a concrete integer type.
+
+// RUN: publish
+module 0x1::aggregator_v2 {
+    struct Aggregator<IntElement> has store, drop {
+        value: IntElement,
+        max_value: IntElement,
+    }
+
+    struct AggregatorSnapshot<IntElement> has store, drop {
+        value: IntElement,
+    }
+
+    public native fun create_aggregator<IntElement>(max_value: IntElement): Aggregator<IntElement>;
+    public native fun create_unbounded_aggregator<IntElement>(): Aggregator<IntElement>;
+    public native fun try_add<IntElement>(self: &mut Aggregator<IntElement>, value: IntElement): bool;
+    public native fun try_sub<IntElement>(self: &mut Aggregator<IntElement>, value: IntElement): bool;
+    native fun is_at_least_impl<IntElement>(self: &Aggregator<IntElement>, min_amount: IntElement): bool;
+    public native fun read<IntElement>(self: &Aggregator<IntElement>): IntElement;
+    public native fun snapshot<IntElement>(self: &Aggregator<IntElement>): AggregatorSnapshot<IntElement>;
+    public native fun create_snapshot<IntElement>(value: IntElement): AggregatorSnapshot<IntElement>;
+    public native fun read_snapshot<IntElement>(self: &AggregatorSnapshot<IntElement>): IntElement;
+
+    public fun is_at_least<IntElement>(self: &Aggregator<IntElement>, min_amount: IntElement): bool {
+        is_at_least_impl(self, min_amount)
+    }
+}
+
+module 0x1::main {
+    use 0x1::aggregator_v2;
+
+    public fun add_read_u64(a: u64, b: u64): u64 {
+        let agg = aggregator_v2::create_unbounded_aggregator<u64>();
+        aggregator_v2::try_add(&mut agg, a);
+        aggregator_v2::try_add(&mut agg, b);
+        aggregator_v2::read(&agg)
+    }
+
+    // Returns whether the subtraction succeeded (false when b > a).
+    public fun sub_ok_u64(a: u64, b: u64): bool {
+        let agg = aggregator_v2::create_unbounded_aggregator<u64>();
+        aggregator_v2::try_add(&mut agg, a);
+        aggregator_v2::try_sub(&mut agg, b)
+    }
+
+    public fun at_least_u64(a: u64, m: u64): bool {
+        let agg = aggregator_v2::create_unbounded_aggregator<u64>();
+        aggregator_v2::try_add(&mut agg, a);
+        aggregator_v2::is_at_least(&agg, m)
+    }
+
+    public fun add_read_u128(a: u128, b: u128): u128 {
+        let agg = aggregator_v2::create_unbounded_aggregator<u128>();
+        aggregator_v2::try_add(&mut agg, a);
+        aggregator_v2::try_add(&mut agg, b);
+        aggregator_v2::read(&agg)
+    }
+
+    // Adds `a` then `b` to an aggregator bounded by `max`; returns whether the
+    // second add stayed within `max`.
+    public fun bounded_add_u64(max: u64, a: u64, b: u64): bool {
+        let agg = aggregator_v2::create_aggregator<u64>(max);
+        aggregator_v2::try_add(&mut agg, a);
+        aggregator_v2::try_add(&mut agg, b)
+    }
+
+    public fun create_add_read_u128(max: u128, a: u128): u128 {
+        let agg = aggregator_v2::create_aggregator<u128>(max);
+        aggregator_v2::try_add(&mut agg, a);
+        aggregator_v2::read(&agg)
+    }
+
+    // Snapshot an aggregator's current value, then read it back.
+    public fun snapshot_read_u64(a: u64): u64 {
+        let agg = aggregator_v2::create_unbounded_aggregator<u64>();
+        aggregator_v2::try_add(&mut agg, a);
+        let snap = aggregator_v2::snapshot(&agg);
+        aggregator_v2::read_snapshot(&snap)
+    }
+
+    // Create a snapshot directly from a value and read it back.
+    public fun create_read_snapshot_u64(v: u64): u64 {
+        let snap = aggregator_v2::create_snapshot<u64>(v);
+        aggregator_v2::read_snapshot(&snap)
+    }
+
+    public fun create_read_snapshot_u128(v: u128): u128 {
+        let snap = aggregator_v2::create_snapshot<u128>(v);
+        aggregator_v2::read_snapshot(&snap)
+    }
+}
+
+// RUN: execute 0x1::main::add_read_u64 --args 10, 32
+// CHECK-V2: results: 42
+
+// RUN: execute 0x1::main::sub_ok_u64 --args 5, 3
+// CHECK-V2: results: true
+
+// RUN: execute 0x1::main::sub_ok_u64 --args 3, 5
+// CHECK-V2: results: false
+
+// RUN: execute 0x1::main::at_least_u64 --args 7, 7
+// CHECK-V2: results: true
+
+// RUN: execute 0x1::main::at_least_u64 --args 7, 8
+// CHECK-V2: results: false
+
+// RUN: execute 0x1::main::add_read_u128 --args 10, 32
+// CHECK-V2: results: 42
+
+// 7 + 3 = 10 <= max (10), so the second add fits.
+// RUN: execute 0x1::main::bounded_add_u64 --args 10, 7, 3
+// CHECK-V2: results: true
+
+// 7 + 5 = 12 > max (10), so the second add is rejected.
+// RUN: execute 0x1::main::bounded_add_u64 --args 10, 7, 5
+// CHECK-V2: results: false
+
+// RUN: execute 0x1::main::create_add_read_u128 --args 100, 42
+// CHECK-V2: results: 42
+
+// RUN: execute 0x1::main::snapshot_read_u64 --args 42
+// CHECK-V2: results: 42
+
+// RUN: execute 0x1::main::create_read_snapshot_u64 --args 7
+// CHECK-V2: results: 7
+
+// RUN: execute 0x1::main::create_read_snapshot_u128 --args 99
+// CHECK-V2: results: 99


### PR DESCRIPTION
Implements the sequential `0x1::aggregator_v2` natives in the MonoMove VM — `create_aggregator`, `create_unbounded_aggregator`, `try_add`, `try_sub`, `is_at_least_impl`, `read`, `create_snapshot`, `snapshot`, `read_snapshot` — for both `u64` and `u128` aggregators/snpashots, operating directly on the Move `Aggregator`/`AggregatorSnapshot` structs (the no-resolver path).

Each native is a single body generic over the integer type, registered once per concrete instantiation. To make that work, `NativeName` becomes a `Polymorphic`/`Monomorphic` enum and the specializer resolves the right implementation from the call's type arguments. The `Aggregator` struct crosses the native ABI through two small `VMValue` mirror types, so no new `NativeContext` methods were needed. The differential test harness now runs only the VM(s) a step checks, which lets the new test assert the V2 result (the legacy VM has no aggregator extension wired up in this harness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core native lookup/dispatch and adds stateful aggregator logic with unsafe frame/memory access; mitigated by focused tests but affects VM specialization and execution paths.
> 
> **Overview**
> Adds **MonoMove `0x1::aggregator_v2` natives** for sequential `u64`/`u128` aggregators and snapshots (create, bounded/unbounded create, try_add/sub, read, snapshot APIs), registered via new **monomorphic** dispatch and wired into production natives.
> 
> **Native resolution** is extended so registry keys are **`Polymorphic` vs `Monomorphic` (with `ty_args`)**, `NativeResolver::resolve` takes the call’s type arguments, and lookup prefers a monomorphic match then falls back to a polymorphic template. Natives are declared through **`Dispatch` + `NativeEntry`**, with **`monomorphic_natives!` / `polymorphic_natives!`** replacing the old flat registration macros; the specializer and test engine pass **`ty_args`** when resolving natives.
> 
> The **differential testsuite** runs only the VM(s) referenced by each step’s checks (so **V2-only `CHECK-V2`** steps work without legacy aggregator support), and adds an **`aggregator_v2.move`** coverage file for those natives.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b59fa8706b7081a86377024171f6f940baf0bd65. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->