### PR TITLE
[storage] Parallelize within-shard hot state load

### DIFF
--- a/storage/aptosdb/src/state_kv_db.rs
+++ b/storage/aptosdb/src/state_kv_db.rs
@@ -46,6 +46,22 @@ use std::{
     time::Instant,
 };
 
+/// Distinct values of a nibble. Byte 0 of a key hash is the shard in its high nibble plus a low
+/// nibble, so each shard owns `NIBBLE_VALUES` consecutive byte-0 values.
+const NIBBLE_VALUES: usize = 16;
+/// Number of concurrent key-hash sub-ranges scanned per shard when loading hot state on restart.
+const NUM_HOT_LOAD_SUBSCANS: usize = 16;
+const _: () = assert!(
+    NUM_STATE_SHARDS == NIBBLE_VALUES,
+    "hot-state sub-range math treats the shard as the high nibble of byte 0",
+);
+const _: () = assert!(
+    NUM_HOT_LOAD_SUBSCANS >= 1
+        && NUM_HOT_LOAD_SUBSCANS <= NIBBLE_VALUES
+        && NIBBLE_VALUES.is_multiple_of(NUM_HOT_LOAD_SUBSCANS),
+    "NUM_HOT_LOAD_SUBSCANS must evenly divide a nibble's values (one of 1, 2, 4, 8, 16)",
+);
+
 fn db_folder_name(is_hot: bool) -> &'static str {
     if is_hot {
         "hot_state_kv_db"
@@ -440,10 +456,37 @@ impl StateKvDb {
 
         let start = Instant::now();
 
-        let shards: [_; NUM_STATE_SHARDS] = (0..NUM_STATE_SHARDS)
+        // Scan each shard's key-hash space in NUM_HOT_LOAD_SUBSCANS contiguous ranges concurrently.
+        // The scan is I/O-latency-bound on a cold restart (one random seek per live key), so we run
+        // it on dedicated threads rather than the rayon pool (sized to the core count) to let the
+        // blocking scans oversubscribe and raise the read queue depth.
+        let mut per_shard_entries: [_; NUM_STATE_SHARDS] = std::array::from_fn(|_| Vec::new());
+        std::thread::scope(|scope| {
+            let mut handles = vec![];
+            for shard_id in 0..NUM_STATE_SHARDS {
+                for sub in 0..NUM_HOT_LOAD_SUBSCANS {
+                    let handle = scope.spawn(move || {
+                        self.scan_shard_range(shard_id, sub, snapshot_version)
+                            .unwrap_or_else(|e| {
+                                panic!(
+                                    "Failed to scan hot state shard {shard_id} sub-range {sub} \
+                                     at snapshot version {snapshot_version}: {e:?}"
+                                )
+                            })
+                    });
+                    handles.push((shard_id, handle));
+                }
+            }
+            for (shard_id, handle) in handles {
+                let entries = handle.join().expect("Hot state load thread panicked");
+                per_shard_entries[shard_id].extend(entries);
+            }
+        });
+
+        let shards: [_; NUM_STATE_SHARDS] = per_shard_entries
             .into_par_iter()
-            .map(|shard_id| self.load_shard(shard_id, snapshot_version))
-            .collect::<Result<Vec<_>>>()?
+            .map(Self::assemble_lru_chain)
+            .collect::<Vec<_>>()
             .try_into()
             .expect("Collected exactly NUM_STATE_SHARDS results");
 
@@ -460,14 +503,27 @@ impl StateKvDb {
         Ok(shards)
     }
 
-    fn load_shard(
-        &self,
-        shard_id: usize,
-        snapshot_version: Version,
-    ) -> Result<LoadedHotStateShard> {
-        let entries = self.scan_shard_entries(shard_id, snapshot_version)?;
-        let loaded = Self::assemble_lru_chain(entries);
-        Ok(loaded)
+    /// Key-hash bounds `[lo, hi)` of sub-range `sub` within `shard_id`. Byte 0 of a key hash holds
+    /// the shard in its high nibble; its 16 low-nibble values are split into NUM_HOT_LOAD_SUBSCANS
+    /// equal groups, one per sub-range. `hi == None` (no upper bound) occurs only for the last
+    /// sub-range of the last shard, whose upper edge 0x100 overflows byte 0.
+    fn shard_subscan_bounds(shard_id: usize, sub: usize) -> (HashValue, Option<HashValue>) {
+        let hash_with_byte0 = |byte0: usize| {
+            let mut bytes = [0u8; HashValue::LENGTH];
+            bytes[0] = byte0 as u8;
+            HashValue::new(bytes)
+        };
+
+        // `shard_id` is byte 0's high nibble, hence the `* NIBBLE_VALUES`; each sub-range spans
+        // `span` low-nibble values, so the next starts `span` further.
+        let span = NIBBLE_VALUES / NUM_HOT_LOAD_SUBSCANS;
+        let lo_byte0 = shard_id * NIBBLE_VALUES + sub * span;
+        let hi_byte0 = lo_byte0 + span;
+
+        let lo = hash_with_byte0(lo_byte0);
+        // `hi_byte0 == NUM_STATE_SHARDS * NIBBLE_VALUES` (0x100) overflows byte 0 — no upper bound.
+        let hi = (hi_byte0 < NUM_STATE_SHARDS * NIBBLE_VALUES).then(|| hash_with_byte0(hi_byte0));
+        (lo, hi)
     }
 
     fn next_key_hash(key_hash: HashValue) -> Option<HashValue> {
@@ -483,14 +539,17 @@ impl StateKvDb {
         None
     }
 
-    /// Scans a single shard DB and returns the most recent hot entry per key_hash as of
-    /// `snapshot_version`. Entries newer than the snapshot are skipped. Evicted keys are excluded.
-    /// The returned entries have uninitialized LRU pointers.
-    fn scan_shard_entries(
+    /// Scans one key-hash sub-range of a shard DB and returns the most recent hot entry per
+    /// key_hash as of `snapshot_version`. Entries newer than the snapshot are skipped. Evicted keys
+    /// are excluded. The returned entries have uninitialized LRU pointers.
+    fn scan_shard_range(
         &self,
         shard_id: usize,
+        sub: usize,
         snapshot_version: Version,
     ) -> Result<Vec<(HashValue, Version, StateSlotKind)>> {
+        let (lo, hi) = Self::shard_subscan_bounds(shard_id, sub);
+
         // Below we seek across key_hash boundaries to skip stale versions of a key. The CF has a
         // prefix bloom filter on key_hash (production config), so without total-order seek the
         // bloom excludes the SST for the absent next prefix and the scan stops after one key.
@@ -499,11 +558,16 @@ impl StateKvDb {
         let mut iter = self
             .db_shard(shard_id)
             .iter_with_opts::<HotStateValueByKeyHashSchema>(read_opts)?;
-        iter.seek_to_first();
+        iter.seek(&(lo, Version::MAX))?;
 
         let mut entries = Vec::new();
 
         while let Some(((key_hash, hot_since_version), entry_opt)) = iter.next().transpose()? {
+            // Stop once the scan crosses into the next sub-range.
+            if hi.is_some_and(|hi| key_hash >= hi) {
+                break;
+            }
+
             // Skip entries newer than the snapshot version — they will be replayed.
             if hot_since_version > snapshot_version {
                 continue;

--- a/storage/aptosdb/src/state_kv_db.rs
+++ b/storage/aptosdb/src/state_kv_db.rs
@@ -470,9 +470,19 @@ impl StateKvDb {
         Ok(loaded)
     }
 
-    // TODO(HotState): The current implementation does a full scan per shard. This can be
-    // further sped up (e.g. parallel within-shard scan, prefix-seek per key group, or maintaining
-    // a separate index), but is left for later since correctness matters more at this stage.
+    fn next_key_hash(key_hash: HashValue) -> Option<HashValue> {
+        let mut bytes = *key_hash.as_ref();
+        for byte in bytes.iter_mut().rev() {
+            if *byte == u8::MAX {
+                *byte = 0;
+            } else {
+                *byte += 1;
+                return Some(HashValue::new(bytes));
+            }
+        }
+        None
+    }
+
     /// Scans a single shard DB and returns the most recent hot entry per key_hash as of
     /// `snapshot_version`. Entries newer than the snapshot are skipped. Evicted keys are excluded.
     /// The returned entries have uninitialized LRU pointers.
@@ -481,54 +491,51 @@ impl StateKvDb {
         shard_id: usize,
         snapshot_version: Version,
     ) -> Result<Vec<(HashValue, Version, StateSlotKind)>> {
+        // Below we seek across key_hash boundaries to skip stale versions of a key. The CF has a
+        // prefix bloom filter on key_hash (production config), so without total-order seek the
+        // bloom excludes the SST for the absent next prefix and the scan stops after one key.
+        let mut read_opts = ReadOptions::default();
+        read_opts.set_total_order_seek(true);
         let mut iter = self
             .db_shard(shard_id)
-            .iter::<HotStateValueByKeyHashSchema>()?;
+            .iter_with_opts::<HotStateValueByKeyHashSchema>(read_opts)?;
         iter.seek_to_first();
 
         let mut entries = Vec::new();
-        let mut current_key_hash: Option<HashValue> = None;
-        let mut found_for_current = false;
 
-        for item in iter {
-            let ((key_hash, hot_since_version), entry_opt) = item?;
-
-            // New key group?
-            if current_key_hash != Some(key_hash) {
-                current_key_hash = Some(key_hash);
-                found_for_current = false;
-            }
-
-            if found_for_current {
-                continue;
-            }
-
+        while let Some(((key_hash, hot_since_version), entry_opt)) = iter.next().transpose()? {
             // Skip entries newer than the snapshot version — they will be replayed.
             if hot_since_version > snapshot_version {
                 continue;
             }
 
             // This is the most recent entry for this key_hash at the snapshot version.
-            found_for_current = true;
-
-            let kind = match entry_opt {
-                None => continue, // Evicted — not hot.
+            if let Some(kind) = match entry_opt {
+                None => None, // Evicted — not hot.
                 Some(HotStateEntry::Occupied {
                     value,
                     value_version,
-                }) => StateSlotKind::HotOccupied {
+                }) => Some(StateSlotKind::HotOccupied {
                     value_version,
                     value,
                     hot_since_version,
                     lru_info: LRUEntry::uninitialized(),
-                },
-                Some(HotStateEntry::Vacant) => StateSlotKind::HotVacant {
+                }),
+                Some(HotStateEntry::Vacant) => Some(StateSlotKind::HotVacant {
                     hot_since_version,
                     lru_info: LRUEntry::uninitialized(),
-                },
-            };
+                }),
+            } {
+                entries.push((key_hash, hot_since_version, kind));
+            }
 
-            entries.push((key_hash, hot_since_version, kind));
+            // Older versions for this key_hash sort immediately after this row.
+            // Jump to the next key group.
+            if let Some(next_key_hash) = Self::next_key_hash(key_hash) {
+                iter.seek(&(next_key_hash, Version::MAX))?;
+            } else {
+                break;
+            }
         }
 
         Ok(entries)

--- a/storage/aptosdb/src/state_store/tests/hot_state_kv.rs
+++ b/storage/aptosdb/src/state_store/tests/hot_state_kv.rs
@@ -7,6 +7,7 @@ use crate::{
     schema::{
         hot_state_value_by_key_hash::{HotStateEntry, HotStateValueByKeyHashSchema},
         stale_state_value_index_by_key_hash::StaleStateValueIndexByKeyHashSchema,
+        HOT_STATE_VALUE_BY_KEY_HASH_CF_NAME,
     },
     state_kv_db::{LoadedHotStateShard, StateKvDb},
     state_store::StateStore,
@@ -32,9 +33,13 @@ use proptest::{collection::vec, prelude::*};
 use std::collections::HashMap;
 
 fn create_hot_state_kv_db(path: &TempPath) -> StateKvDb {
+    create_hot_state_kv_db_with_config(path, RocksdbConfig::default())
+}
+
+fn create_hot_state_kv_db_with_config(path: &TempPath, rocksdb_config: RocksdbConfig) -> StateKvDb {
     StateKvDb::new(
         &StorageDirPaths::from_path(path.path()),
-        RocksdbConfig::default(),
+        rocksdb_config,
         /* env = */ None,
         /* block_cache = */ None,
         /* readonly = */ false,
@@ -42,6 +47,17 @@ fn create_hot_state_kv_db(path: &TempPath) -> StateKvDb {
         /* delete_on_restart = */ false,
     )
     .unwrap()
+}
+
+/// Flush the hot state value CF in every shard so the data lives in SSTs rather than the
+/// memtable. The prefix bloom filter (only built under production config) lives on SSTs, so
+/// only after flushing does the cross-key-hash seek in `load_hot_state_kvs` contend with it.
+fn flush_hot_state_value_cf(db: &StateKvDb) {
+    for shard_id in 0..NUM_STATE_SHARDS {
+        db.db_shard(shard_id)
+            .flush_cf(HOT_STATE_VALUE_BY_KEY_HASH_CF_NAME)
+            .unwrap();
+    }
 }
 
 fn make_state_key(seed: u8) -> StateKey {
@@ -59,10 +75,19 @@ fn put_hot_state_entry(
     version: Version,
     entry: Option<HotStateEntry>,
 ) {
-    let shard_id = key.get_shard_id();
+    put_hot_state_entry_by_hash(db, CryptoHash::hash(key), version, entry);
+}
+
+fn put_hot_state_entry_by_hash(
+    db: &StateKvDb,
+    key_hash: HashValue,
+    version: Version,
+    entry: Option<HotStateEntry>,
+) {
+    let shard_id = usize::from(key_hash.nibble(0));
     let mut batch = db.db_shard(shard_id).new_native_batch();
     batch
-        .put::<HotStateValueByKeyHashSchema>(&(CryptoHash::hash(key), version), &entry)
+        .put::<HotStateValueByKeyHashSchema>(&(key_hash, version), &entry)
         .unwrap();
     db.db_shard(shard_id).write_schemas(batch).unwrap();
 }
@@ -442,6 +467,99 @@ fn test_load_skips_future_entry_and_falls_back_to_older_version() {
     let shards = db.load_hot_state_kvs(15).unwrap();
     let shard = &shards[key.get_shard_id()];
     assert_hot_occupied(shard, key_hash, 10, 5, make_state_value(91));
+    shard.validate_lru_chain();
+}
+
+#[test]
+fn test_load_handles_max_key_hash() {
+    let tmp = TempPath::new();
+    let db = create_hot_state_kv_db(&tmp);
+
+    let key_hash = HashValue::new([0xFF; HashValue::LENGTH]);
+    let shard_id = usize::from(key_hash.nibble(0));
+    put_hot_state_entry_by_hash(
+        &db,
+        key_hash,
+        10,
+        Some(HotStateEntry::Occupied {
+            value: make_state_value(10),
+            value_version: 5,
+        }),
+    );
+    put_hot_state_entry_by_hash(
+        &db,
+        key_hash,
+        20,
+        Some(HotStateEntry::Occupied {
+            value: make_state_value(20),
+            value_version: 15,
+        }),
+    );
+
+    let shards = db.load_hot_state_kvs(15).unwrap();
+    let shard = &shards[shard_id];
+    assert_hot_occupied(shard, key_hash, 10, 5, make_state_value(10));
+    shard.validate_lru_chain();
+}
+
+/// Regression test for the prefix-bloom interaction in the per-shard hot-state scan.
+///
+/// The `hot_state_value_by_key_hash` CF carries a prefix bloom filter on the 32-byte key hash
+/// (enabled explicitly below via `bloom_filter_bits`, as production does). `scan_shard_entries`
+/// jumps to the next key group by seeking to `(key_hash + 1, Version::MAX)` — a prefix that need
+/// not exist. Without `total_order_seek`, the bloom excludes every SST for that absent prefix and
+/// the scan stops after the first key per shard.
+///
+/// The bloom lives only on SSTs, hence the flush below; the default unit-test config (no bloom,
+/// data in the memtable) cannot reproduce this.
+#[test]
+fn test_load_with_prefix_bloom_loads_all_keys_in_shard() {
+    let tmp = TempPath::new();
+    let rocksdb_config = RocksdbConfig {
+        bloom_filter_bits: Some(10.0),
+        ..RocksdbConfig::default()
+    };
+    let db = create_hot_state_kv_db_with_config(&tmp, rocksdb_config);
+
+    // Several distinct key hashes that all map to the same shard (shard 0: high nibble of
+    // byte 0 is 0 for any first byte in 0x00..=0x0f), so the scan must cross key-hash groups.
+    let key_hashes: Vec<HashValue> = (0u8..8)
+        .map(|i| {
+            let mut bytes = [0u8; HashValue::LENGTH];
+            bytes[0] = i;
+            HashValue::new(bytes)
+        })
+        .collect();
+    let shard_id = usize::from(key_hashes[0].nibble(0));
+    assert!(key_hashes
+        .iter()
+        .all(|kh| usize::from(kh.nibble(0)) == shard_id));
+
+    for key_hash in &key_hashes {
+        put_hot_state_entry_by_hash(
+            &db,
+            *key_hash,
+            10,
+            Some(HotStateEntry::Occupied {
+                value: make_state_value(1),
+                value_version: 5,
+            }),
+        );
+    }
+    flush_hot_state_value_cf(&db);
+
+    let shards = db.load_hot_state_kvs(100).unwrap();
+    let shard = &shards[shard_id];
+    assert_eq!(
+        shard.num_items,
+        key_hashes.len(),
+        "expected all {} keys in shard {shard_id} to load, got {}",
+        key_hashes.len(),
+        shard.num_items,
+    );
+    for key_hash in &key_hashes {
+        assert!(shard.map.contains_key(key_hash), "missing key {key_hash:?}");
+    }
     shard.validate_lru_chain();
 }
 

--- a/storage/aptosdb/src/state_store/tests/hot_state_kv.rs
+++ b/storage/aptosdb/src/state_store/tests/hot_state_kv.rs
@@ -28,6 +28,8 @@ use aptos_types::{
     },
     transaction::Version,
 };
+use proptest::{collection::vec, prelude::*};
+use std::collections::HashMap;
 
 fn create_hot_state_kv_db(path: &TempPath) -> StateKvDb {
     StateKvDb::new(
@@ -47,7 +49,8 @@ fn make_state_key(seed: u8) -> StateKey {
 }
 
 fn make_state_value(seed: u8) -> StateValue {
-    StateValue::new_legacy(vec![seed, seed].into())
+    // Vary length with the seed so total_value_bytes isn't summed over fixed-width values.
+    StateValue::new_legacy(vec![seed; (seed % 16) as usize + 1].into())
 }
 
 fn put_hot_state_entry(
@@ -187,6 +190,29 @@ fn collect_lru_order(shard: &LoadedHotStateShard) -> Vec<(HashValue, Version)> {
     result
 }
 
+fn assert_hot_occupied(
+    shard: &LoadedHotStateShard,
+    key_hash: HashValue,
+    expected_hot_since_version: Version,
+    expected_value_version: Version,
+    expected_value: StateValue,
+) {
+    let slot = shard.map.get(&key_hash).unwrap();
+    match slot.kind() {
+        StateSlotKind::HotOccupied {
+            value_version,
+            value,
+            hot_since_version,
+            ..
+        } => {
+            assert_eq!(*hot_since_version, expected_hot_since_version);
+            assert_eq!(*value_version, expected_value_version);
+            assert_eq!(*value, expected_value);
+        },
+        other => panic!("Expected HotOccupied, got {other:?}"),
+    }
+}
+
 #[test]
 fn test_load_empty_db() {
     let tmp = TempPath::new();
@@ -228,19 +254,8 @@ fn test_load_single_entry() {
     assert!(slot.is_hot());
     assert!(slot.prev().is_none()); // Only entry: head.
     assert!(slot.next().is_none()); // Only entry: tail.
-    match slot.kind() {
-        StateSlotKind::HotOccupied {
-            value_version,
-            value,
-            hot_since_version,
-            ..
-        } => {
-            assert_eq!(*value_version, 5);
-            assert_eq!(*value, make_state_value(1));
-            assert_eq!(*hot_since_version, 10);
-        },
-        other => panic!("Expected HotOccupied, got {other:?}"),
-    }
+
+    assert_hot_occupied(shard, key_hash, 10, 5, make_state_value(1));
     shard.validate_lru_chain();
 }
 
@@ -276,6 +291,45 @@ fn test_load_occupied_and_vacant() {
     let slot_vac = shard_vac.map.get(&CryptoHash::hash(&key_vac)).unwrap();
     assert!(matches!(slot_vac.kind(), StateSlotKind::HotVacant { .. }));
     shard_vac.validate_lru_chain();
+}
+
+#[test]
+fn test_load_total_value_bytes() {
+    let tmp = TempPath::new();
+    let db = create_hot_state_kv_db(&tmp);
+
+    let key_occ1 = make_state_key(21);
+    let value1 = make_state_value(21);
+    put_hot_state_entry(
+        &db,
+        &key_occ1,
+        100,
+        Some(HotStateEntry::Occupied {
+            value: value1.clone(),
+            value_version: 50,
+        }),
+    );
+
+    let key_occ2 = make_state_key(30);
+    let value2 = make_state_value(30);
+    put_hot_state_entry(
+        &db,
+        &key_occ2,
+        110,
+        Some(HotStateEntry::Occupied {
+            value: value2.clone(),
+            value_version: 60,
+        }),
+    );
+
+    let key_vac = make_state_key(22);
+    put_hot_state_entry(&db, &key_vac, 200, Some(HotStateEntry::Vacant));
+
+    // Distinct sizes so the assertion checks a real per-value sum, not count * constant.
+    assert_ne!(value1.size(), value2.size());
+    let shards = db.load_hot_state_kvs(300).unwrap();
+    let total_value_bytes: usize = shards.iter().map(|shard| shard.total_value_bytes).sum();
+    assert_eq!(total_value_bytes, value1.size() + value2.size());
 }
 
 #[test]
@@ -355,21 +409,84 @@ fn test_load_multiple_versions_same_key() {
     // Load at V20 — should pick V20 (the most recent entry).
     let shards = db.load_hot_state_kvs(20).unwrap();
     let shard = &shards[key.get_shard_id()];
-    let slot = shard.map.get(&CryptoHash::hash(&key)).unwrap();
-    match slot.kind() {
-        StateSlotKind::HotOccupied {
-            value_version,
-            hot_since_version,
-            value,
-            ..
-        } => {
-            assert_eq!(*hot_since_version, 20);
-            assert_eq!(*value_version, 15);
-            assert_eq!(*value, make_state_value(72));
-        },
-        other => panic!("Expected HotOccupied, got {other:?}"),
-    }
+    assert_hot_occupied(shard, CryptoHash::hash(&key), 20, 15, make_state_value(72));
     shard.validate_lru_chain();
+}
+
+#[test]
+fn test_load_skips_future_entry_and_falls_back_to_older_version() {
+    let tmp = TempPath::new();
+    let db = create_hot_state_kv_db(&tmp);
+
+    let key = make_state_key(9);
+    let key_hash = CryptoHash::hash(&key);
+    put_hot_state_entry(
+        &db,
+        &key,
+        10,
+        Some(HotStateEntry::Occupied {
+            value: make_state_value(91),
+            value_version: 5,
+        }),
+    );
+    put_hot_state_entry(
+        &db,
+        &key,
+        20,
+        Some(HotStateEntry::Occupied {
+            value: make_state_value(92),
+            value_version: 15,
+        }),
+    );
+
+    let shards = db.load_hot_state_kvs(15).unwrap();
+    let shard = &shards[key.get_shard_id()];
+    assert_hot_occupied(shard, key_hash, 10, 5, make_state_value(91));
+    shard.validate_lru_chain();
+}
+
+#[test]
+fn test_load_snapshot_boundaries_across_eviction_and_reinsert() {
+    let tmp = TempPath::new();
+    let db = create_hot_state_kv_db(&tmp);
+
+    let key = make_state_key(11);
+    let key_hash = CryptoHash::hash(&key);
+    let shard_id = key.get_shard_id();
+    put_hot_state_entry(
+        &db,
+        &key,
+        10,
+        Some(HotStateEntry::Occupied {
+            value: make_state_value(111),
+            value_version: 5,
+        }),
+    );
+    put_hot_state_entry(&db, &key, 20, None);
+    put_hot_state_entry(
+        &db,
+        &key,
+        30,
+        Some(HotStateEntry::Occupied {
+            value: make_state_value(112),
+            value_version: 25,
+        }),
+    );
+
+    let shards_at_15 = db.load_hot_state_kvs(15).unwrap();
+    let shard_at_15 = &shards_at_15[shard_id];
+    assert_hot_occupied(shard_at_15, key_hash, 10, 5, make_state_value(111));
+    shard_at_15.validate_lru_chain();
+
+    let shards_at_25 = db.load_hot_state_kvs(25).unwrap();
+    let shard_at_25 = &shards_at_25[shard_id];
+    assert!(!shard_at_25.map.contains_key(&key_hash));
+    shard_at_25.validate_lru_chain();
+
+    let shards_at_30 = db.load_hot_state_kvs(30).unwrap();
+    let shard_at_30 = &shards_at_30[shard_id];
+    assert_hot_occupied(shard_at_30, key_hash, 30, 25, make_state_value(112));
+    shard_at_30.validate_lru_chain();
 }
 
 #[test]
@@ -404,18 +521,7 @@ fn test_load_evict_then_reinsert() {
     // Load at V30 — should pick the re-insertion (most recent entry).
     let shards = db.load_hot_state_kvs(30).unwrap();
     let shard = &shards[key.get_shard_id()];
-    let slot = shard.map.get(&CryptoHash::hash(&key)).unwrap();
-    match slot.kind() {
-        StateSlotKind::HotOccupied {
-            hot_since_version,
-            value,
-            ..
-        } => {
-            assert_eq!(*hot_since_version, 30);
-            assert_eq!(*value, make_state_value(82));
-        },
-        other => panic!("Expected HotOccupied, got {other:?}"),
-    }
+    assert_hot_occupied(shard, CryptoHash::hash(&key), 30, 25, make_state_value(82));
     shard.validate_lru_chain();
 }
 
@@ -466,6 +572,54 @@ fn test_load_lru_chain_ordering() {
             }
         }
     }
+}
+
+#[test]
+fn test_load_lru_chain_same_version_orders_by_key_hash() {
+    let tmp = TempPath::new();
+    let db = create_hot_state_kv_db(&tmp);
+
+    let mut keys_by_shard: Vec<Vec<StateKey>> = (0..NUM_STATE_SHARDS).map(|_| Vec::new()).collect();
+    for seed in 0..=255u8 {
+        let key = make_state_key(seed);
+        keys_by_shard[key.get_shard_id()].push(key);
+    }
+
+    let (shard_id, mut keys) = keys_by_shard
+        .into_iter()
+        .enumerate()
+        .find(|(_, keys)| keys.len() >= 3)
+        .expect("at least one shard should have three keys");
+    keys.truncate(3);
+
+    for key in &keys {
+        put_hot_state_entry(
+            &db,
+            key,
+            100,
+            Some(HotStateEntry::Occupied {
+                value: make_state_value(100),
+                value_version: 50,
+            }),
+        );
+    }
+
+    let shards = db.load_hot_state_kvs(100).unwrap();
+    let shard = &shards[shard_id];
+    shard.validate_lru_chain();
+
+    let actual: Vec<_> = collect_lru_order(shard)
+        .into_iter()
+        .map(|(key_hash, hot_since_version)| {
+            assert_eq!(hot_since_version, 100);
+            key_hash
+        })
+        .collect();
+    let mut expected: Vec<_> = keys.iter().map(CryptoHash::hash).collect();
+    expected.sort();
+    expected.reverse();
+
+    assert_eq!(actual, expected);
 }
 
 #[test]
@@ -545,20 +699,7 @@ fn test_load_write_then_load_roundtrip() {
 
     // Verify key1.
     let shard1 = &loaded_shards[key1.get_shard_id()];
-    let slot1 = shard1.map.get(&CryptoHash::hash(&key1)).unwrap();
-    match slot1.kind() {
-        StateSlotKind::HotOccupied {
-            value_version,
-            value,
-            hot_since_version,
-            ..
-        } => {
-            assert_eq!(*value_version, 50);
-            assert_eq!(*value, val1);
-            assert_eq!(*hot_since_version, 100);
-        },
-        other => panic!("Expected HotOccupied for key1, got {other:?}"),
-    }
+    assert_hot_occupied(shard1, CryptoHash::hash(&key1), 100, 50, val1);
     shard1.validate_lru_chain();
 
     // Verify key2.
@@ -573,6 +714,178 @@ fn test_load_write_then_load_roundtrip() {
         other => panic!("Expected HotVacant for key2, got {other:?}"),
     }
     shard2.validate_lru_chain();
+}
+
+// ---------------------------------------------------------------------------
+// Randomized end-to-end check against an oracle
+// ---------------------------------------------------------------------------
+
+fn make_state_key_u32(id: u32) -> StateKey {
+    StateKey::raw(&id.to_be_bytes())
+}
+
+/// Writes many hot state entries with one native batch per shard, rather than one
+/// commit per entry, so a few-hundred-key proptest case stays cheap.
+fn put_hot_state_entries_bulk(
+    db: &StateKvDb,
+    writes: Vec<(StateKey, Version, Option<HotStateEntry>)>,
+) {
+    let mut batches = db.new_sharded_native_batches();
+    for (key, version, entry) in writes {
+        batches[key.get_shard_id()]
+            .put::<HotStateValueByKeyHashSchema>(&(key.hash(), version), &entry)
+            .unwrap();
+    }
+    for (shard_id, batch) in batches.into_iter().enumerate() {
+        db.db_shard(shard_id).write_schemas(batch).unwrap();
+    }
+}
+
+/// One generated write, resolved against the `hot_since_version` it gets assigned.
+#[derive(Clone, Debug)]
+enum GenEntry {
+    Occupied {
+        value_seed: u8,
+        value_version_delta: Version,
+    },
+    Vacant,
+    Evicted,
+}
+
+impl GenEntry {
+    fn to_entry(&self, hot_since_version: Version) -> Option<HotStateEntry> {
+        match self {
+            GenEntry::Occupied {
+                value_seed,
+                value_version_delta,
+            } => Some(HotStateEntry::Occupied {
+                value: make_state_value(*value_seed),
+                value_version: hot_since_version.saturating_sub(*value_version_delta),
+            }),
+            GenEntry::Vacant => Some(HotStateEntry::Vacant),
+            GenEntry::Evicted => None,
+        }
+    }
+}
+
+fn arb_gen_entry() -> impl Strategy<Value = GenEntry> {
+    prop_oneof![
+        3 => (any::<u8>(), 0u64..8).prop_map(|(value_seed, value_version_delta)| {
+            GenEntry::Occupied {
+                value_seed,
+                value_version_delta,
+            }
+        }),
+        1 => Just(GenEntry::Vacant),
+        1 => Just(GenEntry::Evicted),
+    ]
+}
+
+/// A few hundred writes over up to 400 keys, paired with a snapshot version in
+/// `[0, num_writes]` so loading exercises both included and skipped (future) entries.
+fn arb_load_input() -> impl Strategy<Value = (Vec<(u32, GenEntry)>, Version)> {
+    vec((0u32..400, arb_gen_entry()), 300..800).prop_flat_map(|ops| {
+        let num_writes = ops.len() as Version;
+        (Just(ops), 0..=num_writes)
+    })
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(20))]
+
+    /// Build a hot state KV DB from many versioned writes, then check that
+    /// `load_hot_state_kvs` at a random snapshot reproduces, for every key, its most
+    /// recent entry at or before that snapshot (absent if that entry is an eviction) —
+    /// with a well-formed LRU chain and matching `total_value_bytes`.
+    #[test]
+    fn test_load_hot_state_kvs_matches_oracle(
+        (ops, snapshot_version) in arb_load_input(),
+    ) {
+        let tmp = TempPath::new();
+        let db = create_hot_state_kv_db(&tmp);
+
+        // Each op gets a unique, strictly increasing hot_since_version (its index).
+        let mut writes = vec![];
+        // Oracle: per key, the latest (key, hot_since, entry) written at or before the snapshot.
+        let mut oracle = HashMap::new();
+        for (idx, (key_id, gen_entry)) in ops.into_iter().enumerate() {
+            let version = idx as Version;
+            let key = make_state_key_u32(key_id);
+            let entry = gen_entry.to_entry(version);
+            if version <= snapshot_version {
+                oracle.insert(key.hash(), (key.clone(), version, entry.clone()));
+            }
+            writes.push((key, version, entry));
+        }
+        put_hot_state_entries_bulk(&db, writes);
+
+        let shards = db.load_hot_state_kvs(snapshot_version).unwrap();
+
+        // Verify each expected slot and collect the expected LRU members per shard.
+        let mut expected_chain = vec![Vec::new(); NUM_STATE_SHARDS];
+        let mut expected_total_value_bytes = 0usize;
+        for (key, hot_since, entry) in oracle.values() {
+            let shard_id = key.get_shard_id();
+            let key_hash = key.hash();
+            let expected_entry = match entry {
+                None => {
+                    // Evicted: must be absent after load.
+                    prop_assert!(
+                        !shards[shard_id].map.contains_key(&key_hash),
+                        "evicted key {key_hash} (shard {shard_id}) should be absent"
+                    );
+                    continue;
+                },
+                Some(e) => e,
+            };
+            expected_chain[shard_id].push((key_hash, *hot_since));
+
+            let slot = shards[shard_id].map.get(&key_hash);
+            prop_assert!(
+                slot.is_some(),
+                "key {key_hash} (shard {shard_id}) missing from loaded shard"
+            );
+            let slot = slot.unwrap();
+            prop_assert_eq!(slot.expect_hot_since_version(), *hot_since);
+            match (slot.kind(), expected_entry) {
+                (
+                    StateSlotKind::HotOccupied {
+                        value,
+                        value_version,
+                        ..
+                    },
+                    HotStateEntry::Occupied {
+                        value: exp_value,
+                        value_version: exp_vv,
+                    },
+                ) => {
+                    prop_assert_eq!(value, exp_value);
+                    prop_assert_eq!(value_version, exp_vv);
+                    expected_total_value_bytes += exp_value.size();
+                },
+                (StateSlotKind::HotVacant { .. }, HotStateEntry::Vacant) => {},
+                (actual, _) => prop_assert!(
+                    false,
+                    "kind mismatch for {key_hash}: {actual:?} vs {expected_entry:?}"
+                ),
+            }
+        }
+
+        // Every shard's chain is well-formed and ordered by (hot_since_version, key_hash)
+        // descending head→tail, with num_items matching the oracle.
+        for (shard_id, shard) in shards.iter().enumerate() {
+            shard.validate_lru_chain();
+            prop_assert_eq!(shard.num_items, expected_chain[shard_id].len());
+
+            let mut expected = expected_chain[shard_id].clone();
+            expected.sort_by_key(|(key_hash, version)| (*version, *key_hash));
+            expected.reverse();
+            prop_assert_eq!(collect_lru_order(shard), expected);
+        }
+
+        let actual_total_value_bytes: usize = shards.iter().map(|s| s.total_value_bytes).sum();
+        prop_assert_eq!(actual_total_value_bytes, expected_total_value_bytes);
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/storage/aptosdb/src/state_store/tests/hot_state_kv.rs
+++ b/storage/aptosdb/src/state_store/tests/hot_state_kv.rs
@@ -505,10 +505,10 @@ fn test_load_handles_max_key_hash() {
 /// Regression test for the prefix-bloom interaction in the per-shard hot-state scan.
 ///
 /// The `hot_state_value_by_key_hash` CF carries a prefix bloom filter on the 32-byte key hash
-/// (enabled explicitly below via `bloom_filter_bits`, as production does). `scan_shard_entries`
-/// jumps to the next key group by seeking to `(key_hash + 1, Version::MAX)` — a prefix that need
-/// not exist. Without `total_order_seek`, the bloom excludes every SST for that absent prefix and
-/// the scan stops after the first key per shard.
+/// (enabled explicitly below via `bloom_filter_bits`, as production does). `scan_shard_range`
+/// seeks to the next key group via `(key_hash + 1, Version::MAX)` — a prefix that need not exist.
+/// Without `total_order_seek`, the bloom excludes every SST for that absent prefix and the scan
+/// stops early, dropping the rest of the sub-range's keys.
 ///
 /// The bloom lives only on SSTs, hence the flush below; the default unit-test config (no bloom,
 /// data in the memtable) cannot reproduce this.
@@ -521,13 +521,20 @@ fn test_load_with_prefix_bloom_loads_all_keys_in_shard() {
     };
     let db = create_hot_state_kv_db_with_config(&tmp, rocksdb_config);
 
-    // Several distinct key hashes that all map to the same shard (shard 0: high nibble of
-    // byte 0 is 0 for any first byte in 0x00..=0x0f), so the scan must cross key-hash groups.
-    let key_hashes: Vec<HashValue> = (0u8..8)
-        .map(|i| {
-            let mut bytes = [0u8; HashValue::LENGTH];
-            bytes[0] = i;
-            HashValue::new(bytes)
+    // All keys are in shard 0 (byte 0 in 0x00..=0x0f → high nibble 0). byte 0 spreads them across
+    // every within-shard sub-range; byte 1 puts several keys in each, forcing the scan to seek
+    // across absent next-key prefixes *within* a sub-range — the step the prefix bloom blocks
+    // without total-order seek. byte 1 starts at 1 so no key equals a sub-range's lower bound
+    // (byte 0 = b, rest 0), as in production where that bound is almost never a real key, so even
+    // the first seek of each sub-range targets an absent prefix.
+    let key_hashes: Vec<HashValue> = (0u8..16)
+        .flat_map(|b0| {
+            (1u8..=3).map(move |b1| {
+                let mut bytes = [0u8; HashValue::LENGTH];
+                bytes[0] = b0;
+                bytes[1] = b1;
+                HashValue::new(bytes)
+            })
         })
         .collect();
     let shard_id = usize::from(key_hashes[0].nibble(0));


### PR DESCRIPTION

After the prefix-seek change, the restart scan does roughly one random
SST seek per live key (up to `max_items_per_shard` per shard). On a cold
restart this is I/O-latency-bound, so the previous one-job-per-shard
layout caps the read queue depth at the shard count and leaves the
device's I/O parallelism idle.

Split each shard's key-hash space into `NUM_HOT_LOAD_SUBSCANS` contiguous
sub-ranges scanned concurrently. A shard is the high nibble of byte 0, so
splitting on the low nibble keeps the (uniformly distributed) hashes
balanced across ranges. The scans run on dedicated threads rather than
the rayon pool — rayon is sized to the core count, while these blocking
reads want to oversubscribe to push queue depth higher. The CPU-bound LRU
assembly (sort + `DashMap` build) stays on rayon.

Widen the bloom-enabled regression test to span the shard's whole low-nibble
space so it crosses every sub-range boundary with the prefix bloom in play.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes node-restart hot state reconstruction and RocksDB scan/seek behavior; incorrect loading would corrupt in-memory hot state, though behavior is heavily regression-tested including prefix-bloom and randomized oracles.
> 
> **Overview**
> **Speeds up cold-restart hot state recovery** by scanning each shard’s key-hash space in **16 concurrent sub-ranges** (`NUM_HOT_LOAD_SUBSCANS`) on **dedicated threads** instead of one rayon job per shard, so blocking RocksDB reads can oversubscribe I/O. Per-shard results are merged, then **LRU assembly** still runs on rayon.
> 
> The per-shard scan is refactored to **`scan_shard_range`**: bounded `[lo, hi)` via byte-0 nibble math, **`total_order_seek`** plus seek-to-next-key-hash (fixes **prefix bloom** stopping early), and snapshot/eviction semantics unchanged.
> 
> Tests add a **proptest oracle**, **`total_value_bytes`**, snapshot/eviction edge cases, a **widened prefix-bloom regression** (flush + bloom config), and shared helpers (`assert_hot_occupied`, bulk writes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit afcbe5e3f994f2c186d9af8daf0ea136e4b6d11d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->