### PR TITLE
[API] Small tweaks and new test cases.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -469,6 +469,7 @@ dependencies = [
  "bcs 0.1.4",
  "bytes",
  "fail",
+ "flate2",
  "futures",
  "hex",
  "itertools 0.13.0",
@@ -9957,6 +9958,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures_codec"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad004dd81205978a2bba6c566ed70535ccf88c0be34649e628186474603f43ca"
+dependencies = [
+ "bytes",
+ "futures-sink",
+ "futures-util",
+ "memchr",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "fuzzer"
 version = "0.1.0"
 dependencies = [
@@ -15363,6 +15377,7 @@ dependencies = [
  "serde_urlencoded",
  "serde_yaml 0.9.30",
  "smallvec",
+ "sse-codec",
  "sync_wrapper 1.0.1",
  "tempfile",
  "thiserror 1.0.69",
@@ -18509,6 +18524,17 @@ checksum = "8baeff88f34ed0691978ec34440140e1572b68c7dd4a495fd14a3dc1944daa80"
 dependencies = [
  "base64ct",
  "der 0.8.0",
+]
+
+[[package]]
+name = "sse-codec"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a395a858c7ff5c4b42aeab0501e07c978ac5e1ae5059f301884dab3fa405f47"
+dependencies = [
+ "futures-io",
+ "futures_codec",
+ "memchr",
 ]
 
 [[package]]

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -59,9 +59,11 @@ aptos-gas-schedule = { workspace = true, features = ["testing"] }
 aptos-move-stdlib = { workspace = true }
 aptos-proptest-helpers = { workspace = true }
 aptos-transaction-filters = { workspace = true, features = ["fuzzing"] }
+flate2 = { workspace = true }
 move-package = { workspace = true }
 passkey-types = { workspace = true }
 percent-encoding = { workspace = true }
+poem = { workspace = true, features = ["test"] }
 proptest = { workspace = true }
 rand = { workspace = true }
 regex = { workspace = true }

--- a/api/goldens/aptos_api__tests__transactions_test__test_create_signing_message_rejects_no_content_length_request.json
+++ b/api/goldens/aptos_api__tests__transactions_test__test_create_signing_message_rejects_no_content_length_request.json
@@ -1,5 +1,0 @@
-{
-  "message": "missing `Content-Length` header",
-  "error_code": "web_framework_error",
-  "vm_error_code": null
-}

--- a/api/src/check_size.rs
+++ b/api/src/check_size.rs
@@ -2,14 +2,17 @@
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use poem::{
-    error::SizedLimitError,
+    error::{ReadBodyError, SizedLimitError},
     http::Method,
-    web::headers::{self, HeaderMapExt},
-    Endpoint, Middleware, Request, Result,
+    web::{headers, headers::HeaderMapExt},
+    Body, Endpoint, Middleware, Request, Result,
 };
 
-/// This middleware confirms that the Content-Length header is set and the
-/// value is within the acceptable range. It only applies to POST requests.
+/// This middleware confirms that:
+/// 1. If the Content-Length header is set, then it is within the acceptable range.
+/// 2. The actual size of the request body is within the acceptable range.
+///
+/// Note: this is only applicable to POST requests.
 pub struct PostSizeLimit {
     max_size: u64,
 }
@@ -40,20 +43,183 @@ pub struct PostSizeLimitEndpoint<E> {
 impl<E: Endpoint> Endpoint for PostSizeLimitEndpoint<E> {
     type Output = E::Output;
 
-    async fn call(&self, req: Request) -> Result<Self::Output> {
+    async fn call(&self, mut req: Request) -> Result<Self::Output> {
+        // If the request method is not POST, skip the checks
         if req.method() != Method::POST {
             return self.inner.call(req).await;
         }
 
-        let content_length = req
-            .headers()
-            .typed_get::<headers::ContentLength>()
-            .ok_or(SizedLimitError::MissingContentLength)?;
-
-        if content_length.0 > self.max_size {
-            return Err(SizedLimitError::PayloadTooLarge.into());
+        // If Content-Length is present and exceeds the limit, reject the request
+        if let Some(content_length) = req.headers().typed_get::<headers::ContentLength>() {
+            if content_length.0 > self.max_size {
+                return Err(SizedLimitError::PayloadTooLarge.into());
+            }
         }
 
-        self.inner.call(req).await
+        // Verify the request body size is within the limit
+        match req
+            .take_body()
+            .into_bytes_limit(self.max_size as usize)
+            .await
+        {
+            Ok(bytes) => {
+                req.set_body(Body::from_bytes(bytes));
+                self.inner.call(req).await
+            },
+            Err(ReadBodyError::PayloadTooLarge) => Err(SizedLimitError::PayloadTooLarge.into()),
+            Err(e) => Err(e.into()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::headers_sanity_check::HeadersSanityCheck;
+    use flate2::{write::GzEncoder, Compression as GzCompression};
+    use poem::{handler, http::StatusCode, middleware::Compression, test::TestClient, EndpointExt};
+    use std::io::Write;
+
+    // Small size limit (for testing)
+    const TEST_SIZE_LIMIT: u64 = 1024; // 1 KB
+
+    #[tokio::test]
+    async fn test_post_within_limit_passes() {
+        let cli = TestClient::new(ok_handler.with(PostSizeLimit::new(TEST_SIZE_LIMIT)));
+        let resp = cli.post("/").body(vec![0u8; 50]).send().await;
+        resp.assert_status_is_ok();
+    }
+
+    #[tokio::test]
+    async fn test_post_at_exact_limit_passes() {
+        let cli = TestClient::new(ok_handler.with(PostSizeLimit::new(TEST_SIZE_LIMIT)));
+        let resp = cli
+            .post("/")
+            .body(vec![0u8; TEST_SIZE_LIMIT as usize])
+            .send()
+            .await;
+        resp.assert_status_is_ok();
+    }
+
+    #[tokio::test]
+    async fn test_post_over_limit_rejected() {
+        let cli = TestClient::new(ok_handler.with(PostSizeLimit::new(TEST_SIZE_LIMIT)));
+        let resp = cli
+            .post("/")
+            .body(vec![0u8; TEST_SIZE_LIMIT as usize + 1])
+            .send()
+            .await;
+        resp.assert_status(StatusCode::PAYLOAD_TOO_LARGE);
+    }
+
+    #[tokio::test]
+    async fn test_post_content_length_within_limit_passes() {
+        let cli = TestClient::new(ok_handler.with(PostSizeLimit::new(TEST_SIZE_LIMIT)));
+        let resp = cli
+            .post("/")
+            .header("content-length", "50")
+            .body(vec![0u8; 50])
+            .send()
+            .await;
+        resp.assert_status_is_ok();
+    }
+
+    #[tokio::test]
+    async fn test_post_content_length_over_limit_rejected() {
+        let cli = TestClient::new(ok_handler.with(PostSizeLimit::new(TEST_SIZE_LIMIT)));
+        let resp = cli
+            .post("/")
+            .header("content-length", (TEST_SIZE_LIMIT + 1).to_string())
+            .body(vec![0u8; TEST_SIZE_LIMIT as usize + 1])
+            .send()
+            .await;
+        resp.assert_status(StatusCode::PAYLOAD_TOO_LARGE);
+    }
+
+    #[tokio::test]
+    async fn test_get_over_limit_not_checked() {
+        let cli = TestClient::new(ok_handler.with(PostSizeLimit::new(TEST_SIZE_LIMIT)));
+        let resp = cli
+            .get("/")
+            .body(vec![0u8; TEST_SIZE_LIMIT as usize * 10])
+            .send()
+            .await;
+        resp.assert_status_is_ok();
+    }
+
+    #[tokio::test]
+    async fn test_uncompressed_post_over_limit_rejected() {
+        let cli = TestClient::new(full_stack());
+        let resp = cli
+            .post("/")
+            .body(vec![0u8; TEST_SIZE_LIMIT as usize + 1])
+            .send()
+            .await;
+        resp.assert_status(StatusCode::PAYLOAD_TOO_LARGE);
+    }
+
+    #[tokio::test]
+    async fn test_gzip_body_within_decompressed_limit_passes() {
+        let cli = TestClient::new(full_stack());
+        let compressed = gzip(&vec![b'A'; (TEST_SIZE_LIMIT / 2) as usize]);
+        let resp = cli
+            .post("/")
+            .header("content-encoding", "gzip")
+            .body(compressed)
+            .send()
+            .await;
+        resp.assert_status_is_ok();
+    }
+
+    #[tokio::test]
+    async fn test_gzip_decompressed_over_limit_rejected() {
+        let cli = TestClient::new(full_stack());
+        let compressed = gzip(&vec![b'A'; TEST_SIZE_LIMIT as usize * 100]);
+
+        // Verify that the compressed body is actually smaller than the limit
+        assert!(compressed.len() < TEST_SIZE_LIMIT as usize,);
+
+        // Now send the request with the compressed body and expect it to be rejected due to decompressed size
+        let resp = cli
+            .post("/")
+            .header("content-encoding", "gzip")
+            .body(compressed)
+            .send()
+            .await;
+        resp.assert_status(StatusCode::PAYLOAD_TOO_LARGE);
+    }
+
+    #[tokio::test]
+    async fn test_content_length_over_limit_fast_rejected_by_headers_check() {
+        let cli = TestClient::new(full_stack());
+        let resp = cli
+            .post("/")
+            .header("content-length", (TEST_SIZE_LIMIT + 1).to_string())
+            .body(vec![0u8; TEST_SIZE_LIMIT as usize + 1])
+            .send()
+            .await;
+        resp.assert_status(StatusCode::PAYLOAD_TOO_LARGE);
+    }
+
+    /// A simple handler that returns "ok" for testing purposes
+    #[handler]
+    fn ok_handler() -> &'static str {
+        "ok"
+    }
+
+    /// Helper function to create a full middleware stack for testing.
+    /// Note: Poem uses LIFO chaining: .with(A).with(B).with(C) executes as C → B → A → handler.
+    fn full_stack() -> impl Endpoint<Output = poem::Response> {
+        ok_handler
+            .with(PostSizeLimit::new(TEST_SIZE_LIMIT))
+            .with(Compression::new())
+            .with(HeadersSanityCheck::new(TEST_SIZE_LIMIT))
+    }
+
+    /// Helper function to gzip-compress data for testing
+    fn gzip(data: &[u8]) -> Vec<u8> {
+        let mut enc = GzEncoder::new(Vec::new(), GzCompression::best());
+        enc.write_all(data).unwrap();
+        enc.finish().unwrap()
     }
 }

--- a/api/src/headers_sanity_check.rs
+++ b/api/src/headers_sanity_check.rs
@@ -1,0 +1,151 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+use poem::{
+    error::{BadRequest, SizedLimitError},
+    http::Method,
+    web::headers::{self, HeaderMapExt},
+    Endpoint, Middleware, Request, Result,
+};
+
+/// This middleware confirms that:
+/// 1. If the Content-Length header is set, then it is within the acceptable range.
+/// 2. Transfer-Encoding header is not set (as it is not supported).
+///
+/// Note: this is only applicable to POST requests.
+pub struct HeadersSanityCheck {
+    max_size: u64,
+}
+
+impl HeadersSanityCheck {
+    pub fn new(max_size: u64) -> Self {
+        Self { max_size }
+    }
+}
+
+impl<E: Endpoint> Middleware<E> for HeadersSanityCheck {
+    type Output = HeadersSanityCheckEndpoint<E>;
+
+    fn transform(&self, ep: E) -> Self::Output {
+        HeadersSanityCheckEndpoint {
+            inner: ep,
+            max_size: self.max_size,
+        }
+    }
+}
+
+pub struct HeadersSanityCheckEndpoint<E> {
+    inner: E,
+    max_size: u64,
+}
+
+impl<E: Endpoint> Endpoint for HeadersSanityCheckEndpoint<E> {
+    type Output = E::Output;
+
+    async fn call(&self, req: Request) -> Result<Self::Output> {
+        // If the request method is not POST, skip the checks
+        if req.method() != Method::POST {
+            return self.inner.call(req).await;
+        }
+
+        // If Content-Length is present and exceeds the limit, reject the request
+        if let Some(content_length) = req.headers().typed_get::<headers::ContentLength>() {
+            if content_length.0 > self.max_size {
+                return Err(SizedLimitError::PayloadTooLarge.into());
+            }
+        }
+
+        // Verify that Transfer-Encoding header is not set (as it is not supported)
+        if req
+            .headers()
+            .typed_get::<headers::TransferEncoding>()
+            .is_some()
+        {
+            return Err(BadRequest(std::io::Error::other(
+                "Transfer-Encoding is not supported",
+            )));
+        }
+
+        self.inner.call(req).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use poem::{handler, http::StatusCode, test::TestClient, EndpointExt};
+
+    // Small size limit (for testing)
+    const TEST_SIZE_LIMIT: u64 = 1024; // 1 KB
+
+    #[tokio::test]
+    async fn test_post_content_length_within_limit_passes() {
+        let cli = TestClient::new(ok_handler.with(HeadersSanityCheck::new(TEST_SIZE_LIMIT)));
+        let resp = cli
+            .post("/")
+            .header("content-length", "50")
+            .body(vec![0u8; 50])
+            .send()
+            .await;
+        resp.assert_status_is_ok();
+    }
+
+    #[tokio::test]
+    async fn test_post_content_length_over_limit_rejected() {
+        let cli = TestClient::new(ok_handler.with(HeadersSanityCheck::new(TEST_SIZE_LIMIT)));
+        let resp = cli
+            .post("/")
+            .header("content-length", (TEST_SIZE_LIMIT + 1).to_string())
+            .body(vec![0u8; TEST_SIZE_LIMIT as usize + 1])
+            .send()
+            .await;
+        resp.assert_status(StatusCode::PAYLOAD_TOO_LARGE);
+    }
+
+    #[tokio::test]
+    async fn test_post_missing_content_length_passes() {
+        let cli = TestClient::new(ok_handler.with(HeadersSanityCheck::new(TEST_SIZE_LIMIT)));
+        let resp = cli.post("/").body(vec![0u8; 50]).send().await;
+        resp.assert_status_is_ok();
+    }
+
+    #[tokio::test]
+    async fn test_post_transfer_encoding_rejected() {
+        let cli = TestClient::new(ok_handler.with(HeadersSanityCheck::new(TEST_SIZE_LIMIT)));
+        let resp = cli
+            .post("/")
+            .header("transfer-encoding", "chunked")
+            .send()
+            .await;
+        resp.assert_status(StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn test_get_transfer_encoding_not_checked() {
+        // HeadersSanityCheck only applies to POST
+        let cli = TestClient::new(ok_handler.with(HeadersSanityCheck::new(TEST_SIZE_LIMIT)));
+        let resp = cli
+            .get("/")
+            .header("transfer-encoding", "chunked")
+            .send()
+            .await;
+        resp.assert_status_is_ok();
+    }
+
+    #[tokio::test]
+    async fn test_get_content_length_over_limit_not_checked() {
+        let cli = TestClient::new(ok_handler.with(HeadersSanityCheck::new(TEST_SIZE_LIMIT)));
+        let resp = cli
+            .get("/")
+            .header("content-length", (TEST_SIZE_LIMIT + 1).to_string())
+            .send()
+            .await;
+        resp.assert_status_is_ok();
+    }
+
+    /// A simple handler that returns "ok" for testing purposes
+    #[handler]
+    fn ok_handler() -> &'static str {
+        "ok"
+    }
+}

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -13,6 +13,7 @@ pub mod context;
 mod error_converter;
 mod events;
 mod failpoint;
+mod headers_sanity_check;
 mod index;
 mod log;
 pub mod metrics;

--- a/api/src/runtime.rs
+++ b/api/src/runtime.rs
@@ -9,6 +9,7 @@ use crate::{
     context::Context,
     error_converter::{convert_error, panic_handler},
     events::EventsApi,
+    headers_sanity_check::HeadersSanityCheck,
     index::IndexApi,
     log::middleware_log,
     set_failpoints,
@@ -250,9 +251,12 @@ pub fn attach_poem_to_runtime(
                         poem::get(set_failpoints::set_failpoint_poem).data(context.clone()),
                     ),
             )
+            // NOTE: The order of the middleware handlers are important here.
+            // Poem uses LIFO chaining: .with(A).with(B).with(C) executes as C → B → A → handler.
             .with(cors)
-            .with_if(config.api.compression_enabled, Compression::new())
             .with(PostSizeLimit::new(size_limit))
+            .with_if(config.api.compression_enabled, Compression::new())
+            .with(HeadersSanityCheck::new(size_limit))
             .with(CatchPanic::new().with_handler(panic_handler))
             // NOTE: Make sure to keep this after all the `with` middleware.
             .catch_all_error(convert_error)

--- a/api/src/tests/transactions_test.rs
+++ b/api/src/tests/transactions_test.rs
@@ -2289,32 +2289,6 @@ async fn test_create_signing_message_rejects_invalid_json(
     context.check_golden_output(resp);
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-#[rstest(
-    use_txn_payload_v2_format,
-    use_orderless_transactions,
-    case(false, false),
-    case(true, false),
-    case(true, true)
-)]
-async fn test_create_signing_message_rejects_no_content_length_request(
-    use_txn_payload_v2_format: bool,
-    use_orderless_transactions: bool,
-) {
-    let mut context = new_test_context_with_orderless_flags(
-        current_function_name!(),
-        use_txn_payload_v2_format,
-        use_orderless_transactions,
-    );
-    let req = warp::test::request()
-        .header("content-type", "application/json")
-        .method("POST")
-        .path(&build_path("/encode_submission"));
-
-    let resp = context.expect_status_code(411).execute(req).await;
-    context.check_golden_output(resp);
-}
-
 // Note: in tests, the min gas unit price is 0
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[rstest(


### PR DESCRIPTION
## Description
This PR adds several small hardening improvements to the API, with simple tests. We also bump the API limits to add extra breathing room.

## Testing Plan
New and existing test infrastructure.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes behavior for all POST traffic (chunked encoding now 400, missing Content-Length allowed), and middleware order affects gzip bomb handling—review for client compatibility.
> 
> **Overview**
> Hardens Aptos REST API **POST** request handling by splitting header checks from body size enforcement and fixing middleware order relative to **gzip** decompression.
> 
> **`PostSizeLimit`** no longer requires `Content-Length`; it only rejects an oversized header when present, then buffers the body with `into_bytes_limit` so limits apply to **actual** (including decompressed) payload size. **`HeadersSanityCheck`** is new: same optional `Content-Length` cap, rejects **`Transfer-Encoding`** (e.g. chunked), and allows POSTs without `Content-Length`. In **`runtime`**, middleware is reordered (Poem LIFO): `HeadersSanityCheck` → `Compression` → `PostSizeLimit`, so gzip is expanded before size checks. The integration test and golden that expected **411** for missing `Content-Length` on encode_submission are removed; **`check_size`** / **`headers_sanity_check`** gain Poem `TestClient` tests (plain, gzip within/over limit).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 941ae4869e856b1d74503408ba8b6b20b34a9143. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->