### PR TITLE
[storage] Share state-value chunk helpers across main state + native-position

### DIFF
--- a/storage/aptosdb/src/lib.rs
+++ b/storage/aptosdb/src/lib.rs
@@ -52,5 +52,6 @@ pub use native_state_committer::{MerkleLeafUpdate, NativeMerkleLeafUpdates, Nati
 mod state_kv_db;
 mod state_merkle_db;
 mod state_store;
+mod state_value_chunk;
 mod transaction_store;
 mod versioned_node_cache;

--- a/storage/aptosdb/src/position_db.rs
+++ b/storage/aptosdb/src/position_db.rs
@@ -16,9 +16,12 @@ use aptos_crypto::HashValue;
 use aptos_experimental_runtimes::thread_manager::THREAD_MANAGER;
 use aptos_logger::info;
 use aptos_rocksdb_options::gen_rocksdb_options;
-use aptos_schemadb::{batch::SchemaBatch, Cache, Env, DB};
+use aptos_schemadb::{batch::SchemaBatch, Cache, Env, ReadOptions, DB};
 use aptos_storage_interface::{AptosDbError, Result};
-use aptos_types::{state_store::NUM_STATE_SHARDS, transaction::Version};
+use aptos_types::{
+    state_store::{state_value::StateValue, NUM_STATE_SHARDS},
+    transaction::Version,
+};
 use rayon::prelude::*;
 use std::{
     ops::Deref,
@@ -233,6 +236,29 @@ impl PositionDb {
             &DbMetadataKey::PositionCommitProgress,
             &DbMetadataValue::Version(version),
         )
+    }
+
+    /// Point lookup for the position-value row referenced by a JMT
+    /// leaf. Returns `Some((version, value))` for the latest version
+    /// at or before `version` for `state_key_hash`, or `None` if no
+    /// such row exists. `prefix_same_as_start` constrains the seek so
+    /// a different `state_key_hash` doesn't bleed in.
+    pub fn get_position_value(
+        &self,
+        state_key_hash: HashValue,
+        version: Version,
+    ) -> Result<Option<(Version, StateValue)>> {
+        let mut read_opts = ReadOptions::default();
+        read_opts.set_prefix_same_as_start(true);
+        let shard = ShardedKvDb::shard_of_hash(state_key_hash);
+        let mut iter = self
+            .shard(shard)
+            .iter_with_opts::<PositionValueSchema>(read_opts)?;
+        iter.seek(&(state_key_hash, version))?;
+        Ok(iter
+            .next()
+            .transpose()?
+            .and_then(|((_, version), value_opt)| value_opt.map(|value| (version, value))))
     }
 
     pub fn find_prior_version(

--- a/storage/aptosdb/src/position_merkle_db.rs
+++ b/storage/aptosdb/src/position_merkle_db.rs
@@ -5,16 +5,23 @@
 
 use crate::{
     db_options::gen_position_merkle_cfds,
+    position_db::PositionDb,
     sharded_jmt_merkle_db::{LeafNode, Node as ShardedNode, ShardedJmtMerkleDb},
+    state_value_chunk::jmt_leaves_with_values,
+    utils::truncation_helper::find_closest_node_version_at_or_before,
 };
 use aptos_config::config::{RocksdbConfig, StorageDirPaths};
-use aptos_jellyfish_merkle::{node_type::NodeKey, TreeReader, TreeWriter};
+use aptos_crypto::{hash::CryptoHash, HashValue};
+use aptos_jellyfish_merkle::{
+    iterator::JellyfishMerkleIterator, node_type::NodeKey, JellyfishMerkleTree, TreeReader,
+    TreeWriter,
+};
 use aptos_logger::info;
 use aptos_rocksdb_options::gen_rocksdb_options;
 use aptos_schemadb::{Cache, Env, DB};
 use aptos_storage_interface::{AptosDbError, Result};
 use aptos_types::{
-    state_store::{state_key::StateKey, NUM_STATE_SHARDS},
+    state_store::{state_key::StateKey, state_value::StateValue, NUM_STATE_SHARDS},
     transaction::Version,
 };
 use rayon::prelude::*;
@@ -120,6 +127,104 @@ impl PositionMerkleDb {
                 .create_checkpoint(Self::db_shard_path(cp_root_path.as_ref(), shard_id))?;
         }
         Ok(())
+    }
+
+    /// Returns the position JMT root at exactly `version`.
+    ///
+    /// **Precondition:** `version` must be a position-JMT snapshot version
+    /// (one at which `commit_native_position` actually wrote nodes).
+    /// Position snapshots are sparse — many ledger versions have no JMT
+    /// nodes — so callers holding an arbitrary ledger version must first
+    /// resolve it via [`Self::latest_snapshot_version_at_or_before`].
+    /// Returns an error if no snapshot exists at `version`.
+    pub fn get_root_hash(&self, version: Version) -> Result<HashValue> {
+        let tree = JellyfishMerkleTree::<_, StateKey>::new(&self.inner);
+        tree.get_root_hash_option(version)
+            .map_err(|e| AptosDbError::Other(format!("position_merkle_db get_root_hash: {e}")))?
+            .ok_or_else(|| {
+                AptosDbError::Other(format!(
+                    "position_merkle_db: no JMT snapshot at version {version}; \
+                     callers must pass a snapshot version (see \
+                     latest_snapshot_version_at_or_before)"
+                ))
+            })
+    }
+
+    /// Resolves an arbitrary ledger `version` to the latest position-JMT
+    /// snapshot version at or before it. Returns `None` if no snapshot
+    /// exists at or before `version` (e.g. the position store is fresh
+    /// and `version` precedes its first write).
+    pub fn latest_snapshot_version_at_or_before(
+        &self,
+        version: Version,
+    ) -> Result<Option<Version>> {
+        find_closest_node_version_at_or_before(self.metadata_db(), version)
+    }
+
+    /// Walks the position JMT at exactly `version`, yielding
+    /// `(StateKey, HashValue)` for every live leaf.
+    ///
+    /// **Precondition:** same as [`Self::get_root_hash`] — `version`
+    /// must be a snapshot version.
+    pub fn iter_active_leaves(
+        self: &Arc<Self>,
+        version: Version,
+    ) -> Result<impl Iterator<Item = Result<(StateKey, HashValue)>>> {
+        let iter = JellyfishMerkleIterator::<Self, StateKey>::new(
+            Arc::clone(self),
+            version,
+            HashValue::zero(),
+        )?;
+        Ok(iter.map(|res| res.map(|(key_hash, (state_key, _leaf_version))| (state_key, key_hash))))
+    }
+
+    /// JMT-walk + KV-CF value join: yields `(StateKey, StateValue)` for
+    /// every live position leaf at `version`, starting at JMT index
+    /// `start_idx`. Thin wrapper around [`jmt_leaves_with_values`] with
+    /// the position-specific value lookup baked in.
+    ///
+    /// **Precondition:** same as [`Self::get_root_hash`] — `version`
+    /// must be a snapshot version.
+    pub fn iter_active_leaves_with_values(
+        self: &Arc<Self>,
+        position_db: Arc<PositionDb>,
+        version: Version,
+        start_idx: usize,
+    ) -> Result<impl Iterator<Item = Result<(StateKey, StateValue)>> + Send + Sync + use<>> {
+        jmt_leaves_with_values(
+            Arc::clone(self),
+            version,
+            start_idx,
+            move |state_key, leaf_version| {
+                let key_hash = state_key.hash();
+                position_db
+                    .get_position_value(key_hash, leaf_version)?
+                    .map(|(_v, value)| value)
+                    .ok_or_else(|| {
+                        AptosDbError::Other(format!(
+                            "JMT leaf at v={version} references missing position_value row \
+                             (state_key_hash={key_hash}, leaf_version={leaf_version})"
+                        ))
+                    })
+            },
+        )
+    }
+
+    /// Bounded variant of [`Self::iter_active_leaves_with_values`] —
+    /// takes at most `chunk_size` leaves starting at `first_index`.
+    ///
+    /// **Precondition:** same as [`Self::get_root_hash`] — `version`
+    /// must be a snapshot version.
+    pub fn iter_active_leaves_chunk(
+        self: &Arc<Self>,
+        position_db: Arc<PositionDb>,
+        version: Version,
+        first_index: usize,
+        chunk_size: usize,
+    ) -> Result<impl Iterator<Item = Result<(StateKey, StateValue)>> + Send + Sync + use<>> {
+        Ok(self
+            .iter_active_leaves_with_values(position_db, version, first_index)?
+            .take(chunk_size))
     }
 
     #[cfg(any(test, feature = "fuzzing"))]

--- a/storage/aptosdb/src/state_store/mod.rs
+++ b/storage/aptosdb/src/state_store/mod.rs
@@ -21,6 +21,7 @@ use crate::{
     state_merkle_db::StateMerkleDb,
     state_restore::{StateSnapshotRestore, StateSnapshotRestoreMode, StateValueWriter},
     state_store::{buffered_state::BufferedState, persisted_state::PersistedState},
+    state_value_chunk::{build_value_chunk_proof, jmt_leaves_with_values, value_chunk_with_proof},
     utils::{
         truncation_helper::{
             find_tree_root_at_or_before, get_max_version_in_state_merkle_db, truncate_ledger_db,
@@ -1411,6 +1412,8 @@ impl StateStore {
         Ok(())
     }
 
+    #[cfg(any(test, feature = "fuzzing"))]
+    #[allow(dead_code)]
     pub fn get_root_hash(&self, version: Version) -> Result<HashValue> {
         self.state_merkle_db.get_root_hash(version)
     }
@@ -1444,10 +1447,14 @@ impl StateStore {
         first_index: usize,
         chunk_size: usize,
     ) -> Result<StateValueChunkWithProof> {
-        let state_key_values: Vec<(StateKey, StateValue)> = self
-            .get_value_chunk_iter(version, first_index, chunk_size)?
-            .collect::<Result<Vec<_>>>()?;
-        self.get_value_chunk_proof(version, first_index, state_key_values)
+        let store = Arc::clone(self);
+        value_chunk_with_proof(
+            Arc::clone(&self.state_merkle_db),
+            version,
+            first_index,
+            chunk_size,
+            move |key, version| store.expect_value_by_version(key, version),
+        )
     }
 
     pub fn get_value_chunk_iter(
@@ -1457,19 +1464,13 @@ impl StateStore {
         chunk_size: usize,
     ) -> Result<impl Iterator<Item = Result<(StateKey, StateValue)>> + Send + Sync + use<>> {
         let store = Arc::clone(self);
-        let value_chunk_iter = JellyfishMerkleIterator::new_by_index(
+        Ok(jmt_leaves_with_values(
             Arc::clone(&self.state_merkle_db),
             version,
             first_index,
+            move |key, version| store.expect_value_by_version(key, version),
         )?
-        .take(chunk_size)
-        .map(move |res| {
-            res.and_then(|(_, (key, version))| {
-                Ok((key.clone(), store.expect_value_by_version(&key, version)?))
-            })
-        });
-
-        Ok(value_chunk_iter)
+        .take(chunk_size))
     }
 
     pub fn get_value_chunk_proof(
@@ -1478,26 +1479,12 @@ impl StateStore {
         first_index: usize,
         state_key_values: Vec<(StateKey, StateValue)>,
     ) -> Result<StateValueChunkWithProof> {
-        ensure!(
-            !state_key_values.is_empty(),
-            "State chunk starting at {}",
+        build_value_chunk_proof(
+            self.state_merkle_db.as_ref(),
+            version,
             first_index,
-        );
-        let last_index = (state_key_values.len() - 1 + first_index) as u64;
-        let first_key = state_key_values.first().expect("checked to exist").0.hash();
-        let last_key = state_key_values.last().expect("checked to exist").0.hash();
-        let proof = self.get_value_range_proof(last_key, version)?;
-        let root_hash = self.get_root_hash(version)?;
-
-        Ok(StateValueChunkWithProof {
-            first_index: first_index as u64,
-            last_index,
-            first_key,
-            last_key,
-            raw_values: state_key_values,
-            proof,
-            root_hash,
-        })
+            state_key_values,
+        )
     }
 
     // state sync doesn't query for the progress, but keeps its record by itself.

--- a/storage/aptosdb/src/state_value_chunk.rs
+++ b/storage/aptosdb/src/state_value_chunk.rs
@@ -1,0 +1,97 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Shared state-value snapshot chunk helpers, generic over the backing
+//! Jellyfish Merkle store. The JMT walk and range-proof assembly are identical
+//! across snapshot kinds; only the value lookup differs.
+
+#![forbid(unsafe_code)]
+
+use aptos_crypto::hash::CryptoHash;
+use aptos_jellyfish_merkle::{iterator::JellyfishMerkleIterator, JellyfishMerkleTree, TreeReader};
+use aptos_storage_interface::{AptosDbError, Result};
+use aptos_types::{
+    state_store::{
+        state_key::StateKey,
+        state_value::{StateValue, StateValueChunkWithProof},
+    },
+    transaction::Version,
+};
+use std::sync::Arc;
+
+/// Walks the JMT at `version` from `start_idx` and yields `(StateKey, StateValue)`
+/// for each live leaf, resolving the value via `value_for(key, leaf_version)`.
+pub(crate) fn jmt_leaves_with_values<R, F>(
+    merkle_db: Arc<R>,
+    version: Version,
+    start_idx: usize,
+    value_for: F,
+) -> Result<impl Iterator<Item = Result<(StateKey, StateValue)>> + Send + Sync + use<R, F>>
+where
+    R: TreeReader<StateKey> + Send + Sync + 'static,
+    F: Fn(&StateKey, Version) -> Result<StateValue> + Send + Sync + 'static,
+{
+    Ok(
+        JellyfishMerkleIterator::new_by_index(merkle_db, version, start_idx)?.map(move |res| {
+            res.and_then(|(_hashed_key, (key, leaf_version))| {
+                let value = value_for(&key, leaf_version)?;
+                Ok((key, value))
+            })
+        }),
+    )
+}
+
+/// Reads up to `chunk_size` live leaves from `first_index` (resolving values via
+/// `value_for`) and stamps them with a range proof against the store's root at
+/// `version`. The caller re-requests any remainder.
+pub(crate) fn value_chunk_with_proof<R, F>(
+    merkle_db: Arc<R>,
+    version: Version,
+    first_index: usize,
+    chunk_size: usize,
+    value_for: F,
+) -> Result<StateValueChunkWithProof>
+where
+    R: TreeReader<StateKey> + Send + Sync + 'static,
+    F: Fn(&StateKey, Version) -> Result<StateValue> + Send + Sync + 'static,
+{
+    let raw_values =
+        jmt_leaves_with_values(Arc::clone(&merkle_db), version, first_index, value_for)?
+            .take(chunk_size)
+            .collect::<Result<Vec<_>>>()?;
+    build_value_chunk_proof(merkle_db.as_ref(), version, first_index, raw_values)
+}
+
+/// Assembles a [`StateValueChunkWithProof`] for `raw_values`: a range proof for
+/// the rightmost key against the store's root at `version`. The caller is
+/// responsible for any byte/time bounding of `raw_values`.
+pub(crate) fn build_value_chunk_proof<R>(
+    merkle_db: &R,
+    version: Version,
+    first_index: usize,
+    raw_values: Vec<(StateKey, StateValue)>,
+) -> Result<StateValueChunkWithProof>
+where
+    R: TreeReader<StateKey> + Sync,
+{
+    if raw_values.is_empty() {
+        return Err(AptosDbError::Other(format!(
+            "State value chunk starting at {first_index} is empty"
+        )));
+    }
+    let last_index = (first_index + raw_values.len() - 1) as u64;
+    let first_key = raw_values.first().expect("checked non-empty").0.hash();
+    let last_key = raw_values.last().expect("checked non-empty").0.hash();
+    let tree = JellyfishMerkleTree::<R, StateKey>::new(merkle_db);
+    let proof = tree.get_range_proof(last_key, version)?;
+    let root_hash = tree.get_root_hash(version)?;
+    Ok(StateValueChunkWithProof {
+        first_index: first_index as u64,
+        last_index,
+        first_key,
+        last_key,
+        raw_values,
+        proof,
+        root_hash,
+    })
+}


### PR DESCRIPTION
## Summary

Extracts the JMT-walk + range-proof machinery used by snapshot chunk serving into a single generic module, and routes both the main-state and the native-position consumers through it. Also adds the position-side iteration helpers.

### New shared module `storage/aptosdb/src/state_value_chunk.rs`

Generic over the backing JMT store (`R: TreeReader<StateKey>`), parameterized on a caller-supplied `value_for(key, leaf_version)` closure so the per-kind value lookup is the only thing that differs across snapshot kinds:

- `jmt_leaves_with_values(merkle_db, version, start_idx, value_for)` — walks the JMT at `version` from `start_idx` and yields `(StateKey, StateValue)` for each live leaf.
- `value_chunk_with_proof(merkle_db, version, first_index, chunk_size, value_for)` — reads up to `chunk_size` live leaves and stamps them with a range proof against the store's root.
- `build_value_chunk_proof(merkle_db, version, first_index, raw_values)` — proof-only step for pre-assembled values (used by the byte/time-bounded chunking path).

### Main-state migration (`storage/aptosdb/src/state_store/mod.rs`)

All three chunk methods delegate to the shared module:

- `get_value_chunk_with_proof` → `value_chunk_with_proof`
- `get_value_chunk_iter` → `jmt_leaves_with_values`
- `get_value_chunk_proof` → `build_value_chunk_proof`

The previously inline JMT walk + proof assembly are gone. `StateStore::get_root_hash` is now `#[cfg(any(test, feature = "fuzzing"))]`-gated since its only remaining callers are in the test module.

### Position layer

`storage/aptosdb/src/position_merkle_db.rs`:
- `get_root_hash(version)` — returns the position JMT root at exactly `version`; errors if no snapshot exists there. Position snapshots are sparse (only versions with native-position writes have JMT nodes), so callers holding an arbitrary ledger version must first resolve it via `latest_snapshot_version_at_or_before`.
- `latest_snapshot_version_at_or_before(version)` — resolves an arbitrary ledger version to the latest position-JMT snapshot version at or before it, or `None` if no snapshot exists.
- `iter_active_leaves(version)` — keys-only JMT walk, yields `(StateKey, HashValue)`. Same snapshot-version precondition.
- `iter_active_leaves_with_values(position_db, version, start_idx)` — thin wrapper around `jmt_leaves_with_values` with the position-specific value lookup baked in. Same snapshot-version precondition.
- `iter_active_leaves_chunk(position_db, version, first_index, chunk_size)` — bounded variant. Same snapshot-version precondition.

`storage/aptosdb/src/position_db.rs`:
- `get_position_value(state_key_hash, version)` — point lookup used by the JMT iterator. `prefix_same_as_start` constrains the seek so a different key hash doesn't bleed in.

## Test plan

- [x] `cargo build -p aptos-db --quiet` clean, no warnings
- [x] `cargo test -p aptos-db --lib --no-run` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches state sync/backup chunk proof assembly and adds new position storage read paths; behavior should be equivalent for main state but errors on empty chunks change shape slightly.
> 
> **Overview**
> Introduces **`state_value_chunk`** as shared JMT walk + range-proof logic for snapshot chunks, parameterized by a `value_for` closure so only value lookup differs between snapshot kinds.
> 
> **Main state** `get_value_chunk_*` methods now delegate to that module instead of inlined iterator/proof code; empty-chunk errors use `AptosDbError::Other` via `build_value_chunk_proof`. `StateStore::get_root_hash` is limited to test/fuzzing builds.
> 
> **Native position** gains read paths aligned with main-state chunking: `PositionDb::get_position_value` (prefix-safe KV seek), plus `PositionMerkleDb` APIs for root hash, sparse snapshot version resolution (`latest_snapshot_version_at_or_before`), and leaf iteration with values/chunks wired through `jmt_leaves_with_values`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96ee0fb2cb663400107c0e5d1cd97ecb05ab9d74. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->