### PR TITLE
[consensus] Delay empty pending-ordering proposals

### DIFF
--- a/config/src/config/quorum_store_config.rs
+++ b/config/src/config/quorum_store_config.rs
@@ -158,7 +158,7 @@ impl Default for QuorumStoreConfig {
             batch_buckets: DEFAULT_BUCKETS.to_vec(),
             allow_batches_without_pos_in_proposal: true,
             enable_opt_quorum_store: true,
-            opt_qs_minimum_batch_age_usecs: Duration::from_millis(50).as_micros() as u64,
+            opt_qs_minimum_batch_age_usecs: Duration::from_millis(10).as_micros() as u64,
             enable_payload_v2: false,
             enable_batch_v2_tx: false,
             enable_batch_v2_rx: true,

--- a/consensus/src/payload_client/user/quorum_store_client.rs
+++ b/consensus/src/payload_client/user/quorum_store_client.rs
@@ -20,6 +20,7 @@ use std::time::{Duration, Instant};
 use tokio::time::{sleep, timeout};
 
 const NO_TXN_DELAY: u64 = 30;
+const PENDING_ORDERING_EMPTY_RETRIES: u64 = 1;
 
 /// Client that pulls blocks from Quorum Store
 #[derive(Clone)]
@@ -124,7 +125,10 @@ impl UserPayloadClient for QuorumStoreClient {
                     params.block_timestamp,
                 )
                 .await?;
-            if payload.is_empty() && !return_empty && !done {
+            if payload.is_empty()
+                && !done
+                && (!return_empty || empty_retries < PENDING_ORDERING_EMPTY_RETRIES)
+            {
                 empty_retries += 1;
                 sleep(Duration::from_millis(NO_TXN_DELAY)).await;
                 continue;

--- a/consensus/src/payload_client/user/quorum_store_client.rs
+++ b/consensus/src/payload_client/user/quorum_store_client.rs
@@ -20,6 +20,7 @@ use std::time::{Duration, Instant};
 use tokio::time::{sleep, timeout};
 
 const NO_TXN_DELAY: u64 = 30;
+const PENDING_ORDERING_NO_TXN_DELAY: u64 = 10;
 const PENDING_ORDERING_EMPTY_RETRIES: u64 = 1;
 
 /// Client that pulls blocks from Quorum Store
@@ -130,7 +131,12 @@ impl UserPayloadClient for QuorumStoreClient {
                 && (!return_empty || empty_retries < PENDING_ORDERING_EMPTY_RETRIES)
             {
                 empty_retries += 1;
-                sleep(Duration::from_millis(NO_TXN_DELAY)).await;
+                let no_txn_delay = if return_empty {
+                    PENDING_ORDERING_NO_TXN_DELAY
+                } else {
+                    NO_TXN_DELAY
+                };
+                sleep(Duration::from_millis(no_txn_delay)).await;
                 continue;
             }
             break payload;

--- a/consensus/src/quorum_store/batch_proof_queue.rs
+++ b/consensus/src/quorum_store/batch_proof_queue.rs
@@ -136,6 +136,16 @@ impl<'a> PullSession<'a> {
     }
 }
 
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct ProofQueueSnapshot {
+    pub(crate) total_proofs: u64,
+    pub(crate) local_proofs: u64,
+    pub(crate) remote_proofs: u64,
+    pub(crate) total_txns: u64,
+    pub(crate) local_txns: u64,
+    pub(crate) remote_txns: u64,
+}
+
 fn batch_kind_metric_label(kind: Option<BatchKind>) -> &'static str {
     match kind {
         Some(BatchKind::Normal) => "normal",
@@ -246,6 +256,21 @@ impl BatchProofQueue {
 
     pub(crate) fn num_batches_without_proof(&self) -> u64 {
         self.num_batches_without_proof_count
+    }
+
+    pub(crate) fn proof_queue_snapshot(&self) -> ProofQueueSnapshot {
+        ProofQueueSnapshot {
+            total_proofs: self.remaining_proofs,
+            local_proofs: self.remaining_local_proofs,
+            remote_proofs: self
+                .remaining_proofs
+                .saturating_sub(self.remaining_local_proofs),
+            total_txns: self.remaining_txns_with_duplicates,
+            local_txns: self.remaining_local_txns,
+            remote_txns: self
+                .remaining_txns_with_duplicates
+                .saturating_sub(self.remaining_local_txns),
+        }
     }
 
     #[cfg(test)]

--- a/consensus/src/quorum_store/batch_proof_queue.rs
+++ b/consensus/src/quorum_store/batch_proof_queue.rs
@@ -66,6 +66,12 @@ pub(crate) struct PullSession<'a> {
     pub(crate) excluded_batch_keys: HashSet<BatchKey>,
     pub(crate) filtered_txns: HashSet<&'a TxnSummaryWithExpiration>,
     pub(crate) cur_txns_per_kind: HashMap<BatchKind, u64>,
+    pub(crate) too_young_local_batches: u64,
+    pub(crate) too_young_remote_batches: u64,
+    pub(crate) too_young_local_txns: u64,
+    pub(crate) too_young_remote_txns: u64,
+    pub(crate) too_young_local_ages_ms: Vec<u64>,
+    pub(crate) too_young_remote_ages_ms: Vec<u64>,
 }
 
 impl<'a> PullSession<'a> {
@@ -89,6 +95,12 @@ impl<'a> PullSession<'a> {
             excluded_batch_keys,
             filtered_txns,
             cur_txns_per_kind: HashMap::new(),
+            too_young_local_batches: 0,
+            too_young_remote_batches: 0,
+            too_young_local_txns: 0,
+            too_young_remote_txns: 0,
+            too_young_local_ages_ms: vec![],
+            too_young_remote_ages_ms: vec![],
         }
     }
 
@@ -134,6 +146,18 @@ impl<'a> PullSession<'a> {
     ) -> PerBatchKindTxnLimits {
         per_kind_txn_limits.remaining(&self.cur_txns_per_kind)
     }
+
+    fn record_too_young(&mut self, author: Author, num_txns: u64, age_ms: u64, my_peer_id: PeerId) {
+        if author == my_peer_id {
+            self.too_young_local_batches += 1;
+            self.too_young_local_txns += num_txns;
+            self.too_young_local_ages_ms.push(age_ms);
+        } else {
+            self.too_young_remote_batches += 1;
+            self.too_young_remote_txns += num_txns;
+            self.too_young_remote_ages_ms.push(age_ms);
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -141,6 +165,16 @@ pub(crate) struct ProofQueueSnapshot {
     pub(crate) total_proofs: u64,
     pub(crate) local_proofs: u64,
     pub(crate) remote_proofs: u64,
+    pub(crate) total_txns: u64,
+    pub(crate) local_txns: u64,
+    pub(crate) remote_txns: u64,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct BatchQueueSnapshot {
+    pub(crate) total_batches: u64,
+    pub(crate) local_batches: u64,
+    pub(crate) remote_batches: u64,
     pub(crate) total_txns: u64,
     pub(crate) local_txns: u64,
     pub(crate) remote_txns: u64,
@@ -271,6 +305,33 @@ impl BatchProofQueue {
                 .remaining_txns_with_duplicates
                 .saturating_sub(self.remaining_local_txns),
         }
+    }
+
+    pub(crate) fn non_proof_batch_queue_snapshot(&self) -> BatchQueueSnapshot {
+        let mut snapshot = BatchQueueSnapshot {
+            total_batches: 0,
+            local_batches: 0,
+            remote_batches: 0,
+            total_txns: 0,
+            local_txns: 0,
+            remote_txns: 0,
+        };
+
+        for (author, batches) in &self.author_to_non_proof_batches {
+            let num_batches = batches.len() as u64;
+            let num_txns = batches.values().map(|batch| batch.num_txns()).sum::<u64>();
+            snapshot.total_batches += num_batches;
+            snapshot.total_txns += num_txns;
+            if *author == self.my_peer_id {
+                snapshot.local_batches += num_batches;
+                snapshot.local_txns += num_txns;
+            } else {
+                snapshot.remote_batches += num_batches;
+                snapshot.remote_txns += num_txns;
+            }
+        }
+
+        snapshot
     }
 
     #[cfg(test)]
@@ -834,8 +895,9 @@ impl BatchProofQueue {
         // session's filtered_txns for subsequent pulls.
         let mut pending_filtered_txns: HashSet<&TxnSummaryWithExpiration> = HashSet::new();
 
-        let max_batch_creation_ts_usecs = min_batch_age_usecs
-            .map(|min_age| aptos_infallible::duration_since_epoch().as_micros() as u64 - min_age);
+        let now_usecs = aptos_infallible::duration_since_epoch().as_micros() as u64;
+        let max_batch_creation_ts_usecs =
+            min_batch_age_usecs.map(|min_age| now_usecs.saturating_sub(min_age));
 
         // Select the appropriate author map based on proof status
         let author_map = if batches_without_proofs {
@@ -854,18 +916,6 @@ impl BatchProofQueue {
         {
             let batch_iter = batches.iter().rev().filter_map(|(sort_key, _info)| {
                 if let Some(item) = items.get(&sort_key.batch_key) {
-                    let batch_create_ts_usecs =
-                        item.info.expiration().saturating_sub(batch_expiry_gap);
-
-                    if max_batch_creation_ts_usecs
-                        .is_some_and(|max_create_ts| batch_create_ts_usecs > max_create_ts)
-                    {
-                        counters::BATCH_SKIPPED_TOO_YOUNG
-                            .with_label_values(&[item.info.author().short_str().as_str()])
-                            .inc();
-                        return None;
-                    }
-
                     return Some((&item.info, item));
                 }
                 None
@@ -879,6 +929,25 @@ impl BatchProofQueue {
         while !iters.is_empty() && !full {
             match iters[idx].next() {
                 Some((batch, item)) => {
+                    let batch_create_ts_usecs =
+                        item.info.expiration().saturating_sub(batch_expiry_gap);
+
+                    if max_batch_creation_ts_usecs
+                        .is_some_and(|max_create_ts| batch_create_ts_usecs > max_create_ts)
+                    {
+                        counters::BATCH_SKIPPED_TOO_YOUNG
+                            .with_label_values(&[item.info.author().short_str().as_str()])
+                            .inc();
+                        session.record_too_young(
+                            item.info.author(),
+                            item.info.num_txns(),
+                            now_usecs.saturating_sub(batch_create_ts_usecs) / 1_000,
+                            self.my_peer_id,
+                        );
+                        idx = (idx + 1) % iters.len();
+                        continue;
+                    }
+
                     if session
                         .excluded_batch_keys
                         .contains(&BatchKey::from_info(batch))

--- a/consensus/src/quorum_store/counters.rs
+++ b/consensus/src/quorum_store/counters.rs
@@ -615,6 +615,26 @@ pub static NUM_TXNS_IN_PROOF_QUEUE_AFTER_PULL: Lazy<Histogram> = Lazy::new(|| {
     ).unwrap()
 });
 
+pub static PROPOSAL_PROOF_QUEUE_PROOFS: Lazy<HistogramVec> = Lazy::new(|| {
+    register_histogram_vec!(
+        "quorum_store_proposal_proof_queue_proofs",
+        "Proof queue proof count before block proposal generation, split by proposal result and proof scope.",
+        &["proposal_result", "scope"],
+        PROOF_COUNT_BUCKETS.clone(),
+    )
+    .unwrap()
+});
+
+pub static PROPOSAL_PROOF_QUEUE_TXNS: Lazy<HistogramVec> = Lazy::new(|| {
+    register_histogram_vec!(
+        "quorum_store_proposal_proof_queue_txns",
+        "Proof queue txn count before block proposal generation, split by proposal result and proof scope.",
+        &["proposal_result", "scope"],
+        TRANSACTION_COUNT_BUCKETS.clone(),
+    )
+    .unwrap()
+});
+
 /// Histogram for the number of total txns left after adding or cleaning batches.
 pub static NUM_TOTAL_TXNS_LEFT_ON_UPDATE: Lazy<Histogram> = Lazy::new(|| {
     register_avg_counter(

--- a/consensus/src/quorum_store/counters.rs
+++ b/consensus/src/quorum_store/counters.rs
@@ -635,6 +635,56 @@ pub static PROPOSAL_PROOF_QUEUE_TXNS: Lazy<HistogramVec> = Lazy::new(|| {
     .unwrap()
 });
 
+pub static PROPOSAL_NON_PROOF_QUEUE_BATCHES: Lazy<HistogramVec> = Lazy::new(|| {
+    register_histogram_vec!(
+        "quorum_store_proposal_non_proof_queue_batches",
+        "Non-proof batch queue count before block proposal generation, split by proposal result and batch scope.",
+        &["proposal_result", "scope"],
+        PROOF_COUNT_BUCKETS.clone(),
+    )
+    .unwrap()
+});
+
+pub static PROPOSAL_NON_PROOF_QUEUE_TXNS: Lazy<HistogramVec> = Lazy::new(|| {
+    register_histogram_vec!(
+        "quorum_store_proposal_non_proof_queue_txns",
+        "Non-proof batch queue txn count before block proposal generation, split by proposal result and batch scope.",
+        &["proposal_result", "scope"],
+        TRANSACTION_COUNT_BUCKETS.clone(),
+    )
+    .unwrap()
+});
+
+pub static PROPOSAL_TOO_YOUNG_BATCHES: Lazy<HistogramVec> = Lazy::new(|| {
+    register_histogram_vec!(
+        "quorum_store_proposal_too_young_batches",
+        "OptQS batches skipped as too young during block proposal generation, split by proposal result and batch scope.",
+        &["proposal_result", "scope"],
+        PROOF_COUNT_BUCKETS.clone(),
+    )
+    .unwrap()
+});
+
+pub static PROPOSAL_TOO_YOUNG_TXNS: Lazy<HistogramVec> = Lazy::new(|| {
+    register_histogram_vec!(
+        "quorum_store_proposal_too_young_txns",
+        "OptQS batch transactions skipped as too young during block proposal generation, split by proposal result and batch scope.",
+        &["proposal_result", "scope"],
+        TRANSACTION_COUNT_BUCKETS.clone(),
+    )
+    .unwrap()
+});
+
+pub static PROPOSAL_TOO_YOUNG_BATCH_AGE_MS: Lazy<HistogramVec> = Lazy::new(|| {
+    register_histogram_vec!(
+        "quorum_store_proposal_too_young_batch_age_ms",
+        "Age in milliseconds of OptQS batches skipped as too young during block proposal generation.",
+        &["proposal_result", "scope"],
+        QUORUM_STORE_LATENCY_BUCKETS_IN_MS.to_vec(),
+    )
+    .unwrap()
+});
+
 /// Histogram for the number of total txns left after adding or cleaning batches.
 pub static NUM_TOTAL_TXNS_LEFT_ON_UPDATE: Lazy<Histogram> = Lazy::new(|| {
     register_avg_counter(

--- a/consensus/src/quorum_store/proof_manager.rs
+++ b/consensus/src/quorum_store/proof_manager.rs
@@ -6,7 +6,7 @@ use crate::{
     monitor,
     quorum_store::{
         batch_generator::BackPressure,
-        batch_proof_queue::BatchProofQueue,
+        batch_proof_queue::{BatchProofQueue, ProofQueueSnapshot},
         counters,
         tracing::{observe_batch, BatchStage},
     },
@@ -133,6 +133,7 @@ impl ProofManager {
 
     pub(crate) fn handle_proposal_request(&mut self, msg: GetPayloadCommand) {
         let GetPayloadCommand::GetPayloadRequest(request) = msg;
+        let proof_queue_snapshot = self.batch_proof_queue.proof_queue_snapshot();
 
         let excluded_batches: HashSet<_> = match request.filter {
             PayloadFilter::Empty => HashSet::new(),
@@ -228,6 +229,28 @@ impl ProofManager {
         counters::NUM_INLINE_BATCHES.observe(inline_block.len() as f64);
         counters::NUM_INLINE_TXNS.observe(inline_block_size.count() as f64);
 
+        let proposal_result =
+            if proof_block.is_empty() && opt_batches.is_empty() && inline_block.is_empty() {
+                "empty"
+            } else {
+                "non_empty"
+            };
+        Self::observe_proposal_proof_queue_snapshot(proposal_result, proof_queue_snapshot);
+        if proposal_result == "empty" {
+            sample!(
+                SampleRate::Duration(Duration::from_secs(1)),
+                info!(
+                    "QS: empty proposal payload; proof_queue_total_proofs={}, proof_queue_local_proofs={}, proof_queue_remote_proofs={}, proof_queue_total_txns={}, proof_queue_local_txns={}, proof_queue_remote_txns={}",
+                    proof_queue_snapshot.total_proofs,
+                    proof_queue_snapshot.local_proofs,
+                    proof_queue_snapshot.remote_proofs,
+                    proof_queue_snapshot.total_txns,
+                    proof_queue_snapshot.local_txns,
+                    proof_queue_snapshot.remote_txns,
+                );
+            );
+        }
+
         let enable_optqs_v2 = request
             .maybe_optqs_payload_pull_params
             .as_ref()
@@ -282,6 +305,24 @@ impl ProofManager {
         match request.callback.send(Ok(res)) {
             Ok(_) => (),
             Err(err) => debug!("BlockResponse receiver not available! error {:?}", err),
+        }
+    }
+
+    fn observe_proposal_proof_queue_snapshot(
+        proposal_result: &'static str,
+        snapshot: ProofQueueSnapshot,
+    ) {
+        for (scope, proofs, txns) in [
+            ("total", snapshot.total_proofs, snapshot.total_txns),
+            ("local", snapshot.local_proofs, snapshot.local_txns),
+            ("remote", snapshot.remote_proofs, snapshot.remote_txns),
+        ] {
+            counters::PROPOSAL_PROOF_QUEUE_PROOFS
+                .with_label_values(&[proposal_result, scope])
+                .observe(proofs as f64);
+            counters::PROPOSAL_PROOF_QUEUE_TXNS
+                .with_label_values(&[proposal_result, scope])
+                .observe(txns as f64);
         }
     }
 

--- a/consensus/src/quorum_store/proof_manager.rs
+++ b/consensus/src/quorum_store/proof_manager.rs
@@ -6,7 +6,7 @@ use crate::{
     monitor,
     quorum_store::{
         batch_generator::BackPressure,
-        batch_proof_queue::{BatchProofQueue, ProofQueueSnapshot},
+        batch_proof_queue::{BatchProofQueue, BatchQueueSnapshot, ProofQueueSnapshot, PullSession},
         counters,
         tracing::{observe_batch, BatchStage},
     },
@@ -134,6 +134,8 @@ impl ProofManager {
     pub(crate) fn handle_proposal_request(&mut self, msg: GetPayloadCommand) {
         let GetPayloadCommand::GetPayloadRequest(request) = msg;
         let proof_queue_snapshot = self.batch_proof_queue.proof_queue_snapshot();
+        let non_proof_batch_queue_snapshot =
+            self.batch_proof_queue.non_proof_batch_queue_snapshot();
 
         let excluded_batches: HashSet<_> = match request.filter {
             PayloadFilter::Empty => HashSet::new(),
@@ -236,6 +238,11 @@ impl ProofManager {
                 "non_empty"
             };
         Self::observe_proposal_proof_queue_snapshot(proposal_result, proof_queue_snapshot);
+        Self::observe_proposal_non_proof_batch_queue_snapshot(
+            proposal_result,
+            non_proof_batch_queue_snapshot,
+        );
+        Self::observe_proposal_too_young_snapshot(proposal_result, &session);
         if proposal_result == "empty" {
             sample!(
                 SampleRate::Duration(Duration::from_secs(1)),
@@ -323,6 +330,72 @@ impl ProofManager {
             counters::PROPOSAL_PROOF_QUEUE_TXNS
                 .with_label_values(&[proposal_result, scope])
                 .observe(txns as f64);
+        }
+    }
+
+    fn observe_proposal_non_proof_batch_queue_snapshot(
+        proposal_result: &'static str,
+        snapshot: BatchQueueSnapshot,
+    ) {
+        for (scope, batches, txns) in [
+            ("total", snapshot.total_batches, snapshot.total_txns),
+            ("local", snapshot.local_batches, snapshot.local_txns),
+            ("remote", snapshot.remote_batches, snapshot.remote_txns),
+        ] {
+            counters::PROPOSAL_NON_PROOF_QUEUE_BATCHES
+                .with_label_values(&[proposal_result, scope])
+                .observe(batches as f64);
+            counters::PROPOSAL_NON_PROOF_QUEUE_TXNS
+                .with_label_values(&[proposal_result, scope])
+                .observe(txns as f64);
+        }
+    }
+
+    fn observe_proposal_too_young_snapshot(
+        proposal_result: &'static str,
+        session: &PullSession<'_>,
+    ) {
+        let total_batches = session.too_young_local_batches + session.too_young_remote_batches;
+        let total_txns = session.too_young_local_txns + session.too_young_remote_txns;
+        for (scope, batches, txns) in [
+            ("total", total_batches, total_txns),
+            (
+                "local",
+                session.too_young_local_batches,
+                session.too_young_local_txns,
+            ),
+            (
+                "remote",
+                session.too_young_remote_batches,
+                session.too_young_remote_txns,
+            ),
+        ] {
+            counters::PROPOSAL_TOO_YOUNG_BATCHES
+                .with_label_values(&[proposal_result, scope])
+                .observe(batches as f64);
+            counters::PROPOSAL_TOO_YOUNG_TXNS
+                .with_label_values(&[proposal_result, scope])
+                .observe(txns as f64);
+        }
+
+        for age_ms in session
+            .too_young_local_ages_ms
+            .iter()
+            .chain(session.too_young_remote_ages_ms.iter())
+        {
+            counters::PROPOSAL_TOO_YOUNG_BATCH_AGE_MS
+                .with_label_values(&[proposal_result, "total"])
+                .observe(*age_ms as f64);
+        }
+        for age_ms in &session.too_young_local_ages_ms {
+            counters::PROPOSAL_TOO_YOUNG_BATCH_AGE_MS
+                .with_label_values(&[proposal_result, "local"])
+                .observe(*age_ms as f64);
+        }
+        for age_ms in &session.too_young_remote_ages_ms {
+            counters::PROPOSAL_TOO_YOUNG_BATCH_AGE_MS
+                .with_label_values(&[proposal_result, "remote"])
+                .observe(*age_ms as f64);
         }
     }
 


### PR DESCRIPTION
## Summary
- Add one short retry before accepting an empty quorum-store payload when `pending_ordering` would otherwise allow an immediate empty carrier proposal.
- Keep the delay bounded by the existing `NO_TXN_DELAY` and `max_poll_time`, so non-empty payloads still return immediately.

## Test plan
- `cargo +nightly fmt --check -p aptos-consensus`
- `cargo check -p aptos-consensus`


Made with [Cursor](https://cursor.com)