### PR TITLE
[mono-move] Native extensions + txn-context/object/state-storage/event natives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12801,6 +12801,7 @@ dependencies = [
  "anyhow",
  "bitflags 2.11.0",
  "bytes",
+ "fxhash",
  "mono-move-alloc",
  "move-binary-format",
  "move-core-types",
@@ -12848,6 +12849,7 @@ version = "0.1.0"
 dependencies = [
  "mono-move-core",
  "move-core-types",
+ "sha3 0.9.1",
 ]
 
 [[package]]
@@ -12885,9 +12887,11 @@ name = "mono-move-testsuite"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "aptos-framework-natives",
  "aptos-gas-schedule",
  "aptos-types",
  "aptos-vm",
+ "aptos-vm-types",
  "bcs 0.1.4",
  "bytes",
  "codespan-reporting",

--- a/third_party/move/mono-move/core/Cargo.toml
+++ b/third_party/move/mono-move/core/Cargo.toml
@@ -15,6 +15,7 @@ rust-version = { workspace = true }
 anyhow = { workspace = true }
 bitflags = { workspace = true }
 bytes = { workspace = true }
+fxhash = { workspace = true }
 mono-move-alloc = { workspace = true }
 move-binary-format = { workspace = true }
 move-core-types = { workspace = true }

--- a/third_party/move/mono-move/core/src/native/context.rs
+++ b/third_party/move/mono-move/core/src/native/context.rs
@@ -4,10 +4,12 @@
 //! Native function interface — the API surface natives are written against.
 
 use super::{
+    extension::NativeExtension,
     result::VMInternalError,
     value::{VMValue, Vector},
 };
-use crate::types::InternedType;
+use crate::{interner::InternedModuleId, types::InternedType};
+use core::cell::RefMut;
 
 /// Trait that native functions are written generic over.
 ///
@@ -68,8 +70,25 @@ pub trait NativeContext {
     /// The `i`-th type argument.
     fn ty_arg(&self, i: usize) -> Result<InternedType, VMInternalError>;
 
+    /// Returns a copy of the `i`-th argument's raw in-frame bytes -- a low-level
+    /// API for natives that need to operate on generic opaque values.
+    fn arg_raw(&self, i: usize) -> Result<Vec<u8>, VMInternalError>;
+
+    /// Returns the heap-pointer offsets within the `i`-th argument,
+    /// relative to the value's start.
+    fn arg_ptr_offsets(&self, i: usize) -> Result<Vec<u32>, VMInternalError>;
+
+    /// Returns the module of the caller of the function that invoked this native,
+    /// or `None` if the frame is the entry point (which has no caller).
+    fn caller_module(&self) -> Option<InternedModuleId>;
+
     /// Allocates a `vector<u8>` on the VM heap initialized with `bytes` and
     /// returns a handle to it. The vector stays live for the rest of the
     /// native call.
     fn new_byte_vector<'a>(&'a self, bytes: &[u8]) -> Result<Vector<'a, u8>, VMInternalError>;
+
+    /// Obtains a mutable reference to the extension of type `T`.
+    ///
+    /// Errors if `T` is not installed, or if it is already borrowed.
+    fn get_extension<T: NativeExtension>(&self) -> Result<RefMut<'_, T>, VMInternalError>;
 }

--- a/third_party/move/mono-move/core/src/native/extension.rs
+++ b/third_party/move/mono-move/core/src/native/extension.rs
@@ -1,0 +1,279 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+use super::result::VMInternalError;
+use fxhash::FxHashMap;
+use std::{
+    any::{Any, TypeId},
+    cell::{RefCell, RefMut},
+};
+
+/// An extensible state defined by a native function. Persisted throughout
+/// a transaction.
+pub trait NativeExtension: Any {
+    /// Relocates the extension's GC roots in place.
+    ///
+    /// Must call `relocate` on every heap pointer the extension holds and write
+    /// back the new address whenever one is returned. Missing a pointer leaves a
+    /// dangling root after collection. Extensions that hold no heap pointers
+    /// implement this as a no-op.
+    ///
+    /// # Safety
+    ///
+    /// `relocate` must not re-enter the heap or GC (e.g. by allocating), and
+    /// must return a valid relocated address for each live pointer (or `None`).
+    unsafe fn relocate_roots(&mut self, relocate: &mut dyn FnMut(*mut u8) -> Option<*mut u8>);
+
+    /// Called when a checkpoint is taken (the start of a new sub-session). An
+    /// extension with rollback-able state snapshots it here; one that the legacy
+    /// VM reset on session start resets the same state. Extensions with no such
+    /// state implement this as a no-op.
+    fn on_checkpoint(&mut self);
+
+    /// Rolls back the effects of the `n` most recent checkpoints. Extensions
+    /// with no rollback-able state implement this as a no-op returning `Ok`.
+    fn on_rollback(&mut self, n: usize) -> Result<(), VMInternalError>;
+}
+
+/// Type-keyed collection of [`NativeExtension`]s available to native
+/// functions during a transaction.
+///
+/// Specifically, disjoint borrows of extensions are allowed, as long as
+/// there is at most one borrow of the same extension at a time.
+/// This is currently ensured by storing each extension in its own [`RefCell`];
+/// the extra indirection is unlikely to matter performance-wise.
+#[derive(Default)]
+pub struct NativeExtensions {
+    map: FxHashMap<TypeId, RefCell<Box<dyn NativeExtension>>>,
+}
+
+impl NativeExtensions {
+    pub fn new() -> Self {
+        Self {
+            map: FxHashMap::default(),
+        }
+    }
+
+    /// Adds the extension to the collection.
+    ///
+    /// Panics if an extension of the same type is already present.
+    pub fn add<T: NativeExtension>(&mut self, ext: T) {
+        let prev = self
+            .map
+            .insert(TypeId::of::<T>(), RefCell::new(Box::new(ext)));
+        assert!(
+            prev.is_none(),
+            "duplicate native extension of type {}",
+            std::any::type_name::<T>(),
+        );
+    }
+
+    /// Gets a mutable access to the extension of type `T`.
+    ///
+    /// Errors if `T` is not installed, or if it is already borrowed.
+    pub fn get_mut<T: NativeExtension>(&self) -> Result<RefMut<'_, T>, VMInternalError> {
+        let cell = self.map.get(&TypeId::of::<T>()).ok_or_else(|| {
+            VMInternalError::InvariantViolation(format!(
+                "native extension {} not installed for this transaction",
+                std::any::type_name::<T>(),
+            ))
+        })?;
+        let guard = cell.try_borrow_mut().map_err(|_| {
+            VMInternalError::InvariantViolation(format!(
+                "native extension {} is already borrowed",
+                std::any::type_name::<T>(),
+            ))
+        })?;
+        Ok(RefMut::map(guard, |ext| {
+            // Upcast `dyn NativeExtension` to `dyn Any`, then downcast to `T`.
+            let ext: &mut dyn Any = &mut **ext;
+            ext.downcast_mut::<T>()
+                .expect("TypeId key matches the stored extension type")
+        }))
+    }
+
+    /// Relocate every extension's GC roots during collection.
+    ///
+    /// # Safety
+    ///
+    /// Same contract as [`NativeExtension::relocate_roots`]: `relocate` must not
+    /// re-enter the heap/GC and must return valid relocated addresses.
+    ///
+    /// TODO: this currently has one major issue -- if this is called while a native extension is
+    /// borrowed, it will error. Figure out how we can guarantee exclusive access to the pointers
+    /// safely during GC.
+    pub unsafe fn relocate_all_roots(
+        &self,
+        relocate: &mut dyn FnMut(*mut u8) -> Option<*mut u8>,
+    ) -> Result<(), VMInternalError> {
+        for ext in self.map.values() {
+            let mut ext = ext.try_borrow_mut().map_err(|_| {
+                VMInternalError::InvariantViolation(
+                    "a native extension is borrowed during GC (held across an allocation?)".into(),
+                )
+            })?;
+            // SAFETY: forwarded from this function's contract.
+            unsafe { ext.relocate_roots(&mut *relocate) };
+        }
+        Ok(())
+    }
+
+    /// Signals a checkpoint to every extension.
+    pub fn checkpoint(&self) -> Result<(), VMInternalError> {
+        for ext in self.map.values() {
+            ext.try_borrow_mut()
+                .map_err(|_| {
+                    VMInternalError::InvariantViolation(
+                        "cannot checkpoint: a native extension is unexpectedly still borrowed"
+                            .into(),
+                    )
+                })?
+                .on_checkpoint();
+        }
+        Ok(())
+    }
+
+    /// Rolls back the `n` most recent checkpoints across every extension.
+    /// `n == 0` is a no-op, so each `on_rollback` only ever sees `n >= 1`.
+    pub fn rollback(&self, n: usize) -> Result<(), VMInternalError> {
+        if n == 0 {
+            return Ok(());
+        }
+        for ext in self.map.values() {
+            ext.try_borrow_mut()
+                .map_err(|_| {
+                    VMInternalError::InvariantViolation(
+                        "cannot roll back: a native extension is unexpectedly still borrowed"
+                            .into(),
+                    )
+                })?
+                .on_rollback(n)?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct Counter(u64);
+    impl NativeExtension for Counter {
+        unsafe fn relocate_roots(&mut self, _relocate: &mut dyn FnMut(*mut u8) -> Option<*mut u8>) {
+        }
+
+        fn on_checkpoint(&mut self) {}
+
+        fn on_rollback(&mut self, _n: usize) -> Result<(), VMInternalError> {
+            Ok(())
+        }
+    }
+
+    struct Flag(bool);
+    impl NativeExtension for Flag {
+        unsafe fn relocate_roots(&mut self, _relocate: &mut dyn FnMut(*mut u8) -> Option<*mut u8>) {
+        }
+
+        fn on_checkpoint(&mut self) {}
+
+        fn on_rollback(&mut self, _n: usize) -> Result<(), VMInternalError> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn add_and_get_mut_by_type() {
+        let mut exts = NativeExtensions::new();
+        exts.add(Counter(0));
+        exts.add(Flag(false));
+
+        exts.get_mut::<Counter>().unwrap().0 += 5;
+        exts.get_mut::<Flag>().unwrap().0 = true;
+
+        assert_eq!(exts.get_mut::<Counter>().unwrap().0, 5);
+        assert!(exts.get_mut::<Flag>().unwrap().0);
+    }
+
+    #[test]
+    fn get_mut_missing_errors() {
+        let exts = NativeExtensions::new();
+        assert!(exts.get_mut::<Counter>().is_err());
+    }
+
+    #[test]
+    fn distinct_extensions_borrow_simultaneously() {
+        let mut exts = NativeExtensions::new();
+        exts.add(Counter(0));
+        exts.add(Flag(false));
+
+        // Holding two distinct extensions at once is allowed.
+        let mut counter = exts.get_mut::<Counter>().unwrap();
+        let mut flag = exts.get_mut::<Flag>().unwrap();
+        counter.0 += 1;
+        flag.0 = true;
+        assert_eq!(counter.0, 1);
+        assert!(flag.0);
+    }
+
+    #[test]
+    fn same_extension_double_borrow_errors() {
+        let mut exts = NativeExtensions::new();
+        exts.add(Counter(0));
+        let _first = exts.get_mut::<Counter>().unwrap();
+        // Second borrow while the first is live errors rather than panicking.
+        assert!(exts.get_mut::<Counter>().is_err());
+    }
+
+    #[test]
+    #[should_panic(expected = "duplicate native extension")]
+    fn duplicate_add_panics() {
+        let mut exts = NativeExtensions::new();
+        exts.add(Counter(1));
+        exts.add(Counter(2));
+    }
+
+    /// Extension whose value is checkpointed on each new sub-session and
+    /// restored on rollback.
+    #[derive(Default)]
+    struct Checkpointed {
+        value: u64,
+        snapshots: Vec<u64>,
+    }
+    impl NativeExtension for Checkpointed {
+        unsafe fn relocate_roots(&mut self, _relocate: &mut dyn FnMut(*mut u8) -> Option<*mut u8>) {
+        }
+
+        fn on_checkpoint(&mut self) {
+            self.snapshots.push(self.value);
+        }
+
+        fn on_rollback(&mut self, n: usize) -> Result<(), VMInternalError> {
+            let keep = self.snapshots.len().checked_sub(n).ok_or_else(|| {
+                VMInternalError::InvariantViolation("rollback past the first checkpoint".into())
+            })?;
+            self.value = self.snapshots[keep];
+            self.snapshots.truncate(keep);
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn checkpoint_and_rollback_hooks() {
+        let mut exts = NativeExtensions::new();
+        exts.add(Checkpointed::default());
+
+        exts.checkpoint().unwrap(); // snapshot value = 0
+        exts.get_mut::<Checkpointed>().unwrap().value = 10;
+        exts.checkpoint().unwrap(); // snapshot value = 10
+        exts.get_mut::<Checkpointed>().unwrap().value = 20;
+
+        exts.rollback(1).unwrap();
+        assert_eq!(exts.get_mut::<Checkpointed>().unwrap().value, 10);
+
+        exts.rollback(1).unwrap();
+        assert_eq!(exts.get_mut::<Checkpointed>().unwrap().value, 0);
+
+        // Nothing left to roll back.
+        assert!(exts.rollback(1).is_err());
+    }
+}

--- a/third_party/move/mono-move/core/src/native/mod.rs
+++ b/third_party/move/mono-move/core/src/native/mod.rs
@@ -4,6 +4,7 @@
 //! Native function interface for MonoMove.
 pub mod abi;
 pub mod context;
+pub mod extension;
 pub mod registry;
 pub mod result;
 pub mod value;
@@ -12,6 +13,7 @@ pub mod value;
 pub use crate::root_pool::{ObjectHandle, ReferenceHandle, RootPool};
 pub use abi::{FrameSlot, NativeABI, NativeABIError};
 pub use context::NativeContext;
+pub use extension::{NativeExtension, NativeExtensions};
 pub use registry::{
     NativeContextFamily, NativeFunction, NativeIdx, NativeName, NativeRegistry,
     NativeRegistryError, NativeResolver, NoNatives,

--- a/third_party/move/mono-move/natives/Cargo.toml
+++ b/third_party/move/mono-move/natives/Cargo.toml
@@ -14,3 +14,4 @@ rust-version = { workspace = true }
 [dependencies]
 mono-move-core = { workspace = true }
 move-core-types = { workspace = true }
+sha3 = { workspace = true }

--- a/third_party/move/mono-move/natives/src/address_derivation.rs
+++ b/third_party/move/mono-move/natives/src/address_derivation.rs
@@ -1,0 +1,77 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Address derivations replicated from
+//! `aptos_types::transaction::authenticator::AuthenticationKey`.
+//
+// TODO: unify with aptos-core's `AuthenticationKey` so we don't end up having two
+// duplicate implementation of the same scheme and derivation algorithm.
+
+use move_core_types::account_address::AccountAddress;
+use sha3::{Digest, Sha3_256};
+
+/// `Scheme::DeriveAuid` discriminant.
+const DERIVE_AUID_SCHEME: u8 = 251;
+/// `Scheme::DeriveObjectAddressFromObject` discriminant.
+const DERIVE_OBJECT_FROM_OBJECT_SCHEME: u8 = 252;
+
+/// `sha3_256(preimage || scheme)` as an address, mirroring
+/// `AuthenticationKey::from_preimage`.
+fn address_from_preimage(mut preimage: Vec<u8>, scheme: u8) -> AccountAddress {
+    preimage.push(scheme);
+    let digest = Sha3_256::digest(&preimage);
+    AccountAddress::new(digest.into())
+}
+
+/// AUID address: `sha3_256(txn_hash || auid_counter_le || DeriveAuid)`.
+pub(crate) fn auid_address(txn_hash: &[u8], auid_counter: u64) -> AccountAddress {
+    let mut preimage = Vec::with_capacity(txn_hash.len() + 8);
+    preimage.extend_from_slice(txn_hash);
+    preimage.extend_from_slice(&auid_counter.to_le_bytes());
+    address_from_preimage(preimage, DERIVE_AUID_SCHEME)
+}
+
+/// Object-from-object address:
+/// `sha3_256(source || derive_from || DeriveObjectAddressFromObject)`.
+pub(crate) fn object_address_from_object(
+    source: &AccountAddress,
+    derive_from: &AccountAddress,
+) -> AccountAddress {
+    let mut preimage = source.to_vec();
+    preimage.extend_from_slice(derive_from.as_ref());
+    address_from_preimage(preimage, DERIVE_OBJECT_FROM_OBJECT_SCHEME)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Pin the on-chain-frozen scheme discriminants.
+    #[test]
+    fn scheme_bytes_are_frozen() {
+        assert_eq!(DERIVE_AUID_SCHEME, 251);
+        assert_eq!(DERIVE_OBJECT_FROM_OBJECT_SCHEME, 252);
+    }
+
+    // Known-answer tests, also cross-checked end-to-end against the legacy VM's
+    // `AuthenticationKey` in the differential suite.
+    #[test]
+    fn auid_known_answer() {
+        let addr = auid_address(&[0u8; 32], 1);
+        assert_eq!(
+            addr.to_hex_literal(),
+            "0x777e34c52ecee7cd877e439f7cbf8f5a2394c369855c7bb8a140fced68b3aed6"
+        );
+    }
+
+    #[test]
+    fn object_from_object_known_answer() {
+        let source = AccountAddress::from_hex_literal("0xa").unwrap();
+        let derive_from = AccountAddress::from_hex_literal("0xb").unwrap();
+        let addr = object_address_from_object(&source, &derive_from);
+        assert_eq!(
+            addr.to_hex_literal(),
+            "0xc168433b37d568f2c5cb143f04e177e102d9e40247cefdcb41b8dcc56caa44b0"
+        );
+    }
+}

--- a/third_party/move/mono-move/natives/src/event.rs
+++ b/third_party/move/mono-move/natives/src/event.rs
@@ -1,0 +1,173 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Natives for the `event` module, plus the backing event store.
+
+use crate::{polymorphic_natives, NativeEntry};
+use mono_move_core::{
+    native::{
+        NativeContext, NativeContextFamily, NativeExtension, NativeStatus, VMInternalError, Vector,
+    },
+    types::{view_type, InternedType, Type},
+};
+
+/// Number of bytes a heap pointer occupies in the flat value representation.
+const POINTER_SIZE: usize = 8;
+
+/// Axuiliary info/tag to distinguish the two event formats.
+pub enum EventKind {
+    /// Module event (`ContractEvent::V2`)
+    V2,
+    /// Handle event (`ContractEvent::V1`)
+    V1 { guid: Vec<u8>, sequence_number: u64 },
+}
+
+/// Represents a recorded event. Supports both V1 and V2.
+pub struct EventEntry {
+    pub msg_ty: InternedType,
+    pub msg_data: Vec<u8>,
+    pub ptr_offsets: Vec<u32>,
+    pub kind: EventKind,
+}
+
+/// Per-transaction store of emitted events, in emission order.
+///
+/// TODO: This is currently implemented as a Rust struct, but should eventually be moved to
+/// the VM's own heap.
+#[derive(Default)]
+pub struct EventStore {
+    entries: Vec<EventEntry>,
+    checkpoints: Vec<usize>,
+}
+
+impl EventStore {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Records an event.
+    fn emit(
+        &mut self,
+        msg_ty: InternedType,
+        msg_data: Vec<u8>,
+        ptr_offsets: Vec<u32>,
+        kind: EventKind,
+    ) {
+        self.entries.push(EventEntry {
+            msg_ty,
+            msg_data,
+            ptr_offsets,
+            kind,
+        });
+    }
+
+    /// The recorded events, in emission order.
+    pub fn entries(&self) -> &[EventEntry] {
+        &self.entries
+    }
+}
+
+impl NativeExtension for EventStore {
+    unsafe fn relocate_roots(&mut self, relocate: &mut dyn FnMut(*mut u8) -> Option<*mut u8>) {
+        for entry in &mut self.entries {
+            for &off in &entry.ptr_offsets {
+                let off = off as usize;
+                let bytes: [u8; POINTER_SIZE] = entry.msg_data[off..off + POINTER_SIZE]
+                    .try_into()
+                    .expect("offsets keep each pointer slot in bounds");
+                let ptr = usize::from_ne_bytes(bytes) as *mut u8;
+                if let Some(new) = relocate(ptr) {
+                    entry.msg_data[off..off + POINTER_SIZE]
+                        .copy_from_slice(&(new as usize).to_ne_bytes());
+                }
+            }
+        }
+    }
+
+    fn on_checkpoint(&mut self) {
+        self.checkpoints.push(self.entries.len());
+    }
+
+    fn on_rollback(&mut self, n: usize) -> Result<(), VMInternalError> {
+        if n > self.checkpoints.len() {
+            return Err(VMInternalError::InvariantViolation(format!(
+                "event rollback({n}): only {} checkpoint(s)",
+                self.checkpoints.len(),
+            )));
+        }
+        let snapshot = self.checkpoints[self.checkpoints.len() - n];
+        self.checkpoints.truncate(self.checkpoints.len() - n);
+        self.entries.truncate(snapshot);
+        Ok(())
+    }
+}
+
+/// `0x1::event::write_module_event_to_store<T>(msg: T)`
+//
+// TODO: charge gas.
+pub fn native_write_module_event_to_store<C: NativeContext>(
+    ctx: &C,
+) -> Result<NativeStatus, VMInternalError> {
+    let msg_ty = ctx.ty_arg(0)?;
+
+    // The event type must be nominal, and the module emitting it must be the
+    // one that defines it. Enums are admitted here; an unsupported enum layout
+    // is rejected later, when its pointer offsets are computed.
+    let Type::Nominal { module_id, .. } = view_type(msg_ty) else {
+        return Err(VMInternalError::InvariantViolation(
+            "write_module_event_to_store: event type must be a struct or enum".into(),
+        ));
+    };
+    let caller = ctx.caller_module().ok_or_else(|| {
+        VMInternalError::InvariantViolation(
+            "write_module_event_to_store: scripts cannot emit module events".into(),
+        )
+    })?;
+    if caller != *module_id {
+        return Err(VMInternalError::InvariantViolation(
+            "write_module_event_to_store: caller module does not define the event type".into(),
+        ));
+    }
+
+    let msg_data = ctx.arg_raw(0)?;
+    let ptr_offsets = ctx.arg_ptr_offsets(0)?;
+    ctx.get_extension::<EventStore>()?
+        .emit(msg_ty, msg_data, ptr_offsets, EventKind::V2);
+    Ok(NativeStatus::Success)
+}
+
+/// `0x1::event::write_to_event_store<T>(guid: vector<u8>, count: u64, msg: T)`
+//
+// TODO: charge gas.
+pub fn native_write_to_event_store<C: NativeContext>(
+    ctx: &C,
+) -> Result<NativeStatus, VMInternalError> {
+    // SAFETY: arg 0 is `guid: vector<u8>`.
+    let guid_vec = unsafe { ctx.arg::<Vector<u8>>(0)? };
+    let guid = unsafe { guid_vec.as_bytes() }.to_vec();
+    // SAFETY: arg 1 is `count: u64`.
+    let sequence_number = unsafe { ctx.arg::<u64>(1)? };
+    let msg_data = ctx.arg_raw(2)?;
+    let ptr_offsets = ctx.arg_ptr_offsets(2)?;
+    let msg_ty = ctx.ty_arg(0)?;
+    ctx.get_extension::<EventStore>()?
+        .emit(msg_ty, msg_data, ptr_offsets, EventKind::V1 {
+            guid,
+            sequence_number,
+        });
+    Ok(NativeStatus::Success)
+}
+
+/// Natives for the `event` module.
+pub fn make_all_event_natives<F: NativeContextFamily>() -> Vec<NativeEntry<F>> {
+    polymorphic_natives![
+        (
+            "0x1::event::write_module_event_to_store",
+            native_write_module_event_to_store
+        ),
+        (
+            "0x1::event::write_to_event_store",
+            native_write_to_event_store
+        ),
+    ]
+}

--- a/third_party/move/mono-move/natives/src/lib.rs
+++ b/third_party/move/mono-move/natives/src/lib.rs
@@ -12,18 +12,27 @@ pub use mono_move_core::native::NativeFunction;
 use mono_move_core::{native::NativeContextFamily, types::InternedType};
 use move_core_types::{account_address::AccountAddress, identifier::Identifier};
 
+mod address_derivation;
 pub mod aggregator_v2;
+pub mod event;
 pub mod function_info;
 pub mod mem;
+pub mod object;
 pub mod signer;
+pub mod state_storage;
 pub mod test_natives;
+pub mod transaction_context;
 pub mod type_info;
 
 pub use aggregator_v2::make_all_aggregator_v2_natives;
+pub use event::{make_all_event_natives, EventEntry, EventKind, EventStore};
 pub use function_info::make_all_function_info_natives;
 pub use mem::make_all_mem_natives;
+pub use object::{make_all_object_natives, ObjectContextExtension};
 pub use signer::make_all_signer_natives;
+pub use state_storage::{make_all_state_storage_natives, StorageUsageAtEpochBoundary};
 pub use test_natives::{make_all_test_natives, native_u64_add, native_u64_identity};
+pub use transaction_context::{make_all_transaction_context_natives, TransactionContextExtension};
 pub use type_info::make_all_type_info_natives;
 
 /// How a native is dispatched against a call's type arguments. A native that
@@ -59,6 +68,10 @@ pub fn make_all_production_natives<F: NativeContextFamily>() -> Vec<NativeEntry<
     natives.extend(make_all_type_info_natives::<F>());
     natives.extend(make_all_function_info_natives::<F>());
     natives.extend(make_all_aggregator_v2_natives::<F>());
+    natives.extend(make_all_transaction_context_natives::<F>());
+    natives.extend(make_all_object_natives::<F>());
+    natives.extend(make_all_state_storage_natives::<F>());
+    natives.extend(make_all_event_natives::<F>());
     natives
 }
 

--- a/third_party/move/mono-move/natives/src/object.rs
+++ b/third_party/move/mono-move/natives/src/object.rs
@@ -1,0 +1,65 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Natives for the `object` module, plus the extension backing them.
+
+use crate::{address_derivation::object_address_from_object, monomorphic_natives, NativeEntry};
+use mono_move_core::native::{
+    NativeContext, NativeContextFamily, NativeExtension, NativeStatus, VMInternalError,
+};
+use move_core_types::account_address::AccountAddress;
+use std::collections::HashMap;
+
+/// Per-transaction memo cache for derived object addresses. Pure compute
+/// optimization — the derivation is deterministic, so caching only saves work.
+#[derive(Default)]
+pub struct ObjectContextExtension {
+    /// The keys are user-controlled addresses, so the DoS-resistant std
+    /// hash table is used.
+    derived: HashMap<(AccountAddress, AccountAddress), AccountAddress>,
+}
+
+impl ObjectContextExtension {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl NativeExtension for ObjectContextExtension {
+    unsafe fn relocate_roots(&mut self, _relocate: &mut dyn FnMut(*mut u8) -> Option<*mut u8>) {}
+
+    fn on_checkpoint(&mut self) {}
+
+    fn on_rollback(&mut self, _n: usize) -> Result<(), VMInternalError> {
+        Ok(())
+    }
+}
+
+/// `0x1::object::create_user_derived_object_address_impl(source: address, derive_from: address): address`
+//
+// TODO: charge gas (constant cost) once the gas API lands.
+pub fn native_create_user_derived_object_address_impl<C: NativeContext>(
+    ctx: &C,
+) -> Result<NativeStatus, VMInternalError> {
+    // SAFETY: args 0 and 1 are both `address` per the Move declaration.
+    let source: AccountAddress = unsafe { ctx.arg(0)? };
+    let derive_from: AccountAddress = unsafe { ctx.arg(1)? };
+
+    let mut ext = ctx.get_extension::<ObjectContextExtension>()?;
+    let address = *ext
+        .derived
+        .entry((source, derive_from))
+        .or_insert_with(|| object_address_from_object(&source, &derive_from));
+
+    // SAFETY: return 0 is `address`.
+    unsafe { ctx.set_return(0, address)? };
+    Ok(NativeStatus::Success)
+}
+
+/// Natives for the `object` module.
+pub fn make_all_object_natives<F: NativeContextFamily>() -> Vec<NativeEntry<F>> {
+    monomorphic_natives![(
+        "0x1::object::create_user_derived_object_address_impl",
+        native_create_user_derived_object_address_impl
+    ),]
+}

--- a/third_party/move/mono-move/natives/src/state_storage.rs
+++ b/third_party/move/mono-move/natives/src/state_storage.rs
@@ -1,0 +1,89 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Natives for the `state_storage` module, plus the extension backing them.
+
+use crate::{monomorphic_natives, NativeEntry};
+use mono_move_core::native::{
+    NativeContext, NativeContextFamily, NativeExtension, NativeStatus, RootPool, VMInternalError,
+    VMValue,
+};
+
+/// State-storage usage captured at the epoch boundary, served read-only to the
+/// `state_storage` native.
+///
+/// This is different from the legacy VM, which reads this from a borrowed
+/// host view, but the effects shall be the same.
+pub struct StorageUsageAtEpochBoundary {
+    items: u64,
+    bytes: u64,
+}
+
+impl StorageUsageAtEpochBoundary {
+    pub fn new(items: u64, bytes: u64) -> Self {
+        Self { items, bytes }
+    }
+}
+
+impl NativeExtension for StorageUsageAtEpochBoundary {
+    unsafe fn relocate_roots(&mut self, _relocate: &mut dyn FnMut(*mut u8) -> Option<*mut u8>) {}
+
+    fn on_checkpoint(&mut self) {}
+
+    fn on_rollback(&mut self, _n: usize) -> Result<(), VMInternalError> {
+        Ok(())
+    }
+}
+
+const USAGE_BYTES_OFFSET: usize = 8;
+
+/// Rust mirror of `0x1::state_storage::Usage`.
+struct Usage {
+    items: u64,
+    bytes: u64,
+}
+
+impl<'a> VMValue<'a> for Usage {
+    const FRAME_SLOT_SIZE: usize = USAGE_BYTES_OFFSET + 8;
+
+    unsafe fn read_from_frame(pool: &'a RootPool, frame_ptr: *const u8, offset: usize) -> Self {
+        unsafe {
+            Usage {
+                items: u64::read_from_frame(pool, frame_ptr, offset),
+                bytes: u64::read_from_frame(pool, frame_ptr, offset + USAGE_BYTES_OFFSET),
+            }
+        }
+    }
+
+    unsafe fn write_to_frame(self, frame_ptr: *mut u8, offset: usize) {
+        unsafe {
+            self.items.write_to_frame(frame_ptr, offset);
+            self.bytes
+                .write_to_frame(frame_ptr, offset + USAGE_BYTES_OFFSET);
+        }
+    }
+}
+
+/// `0x1::state_storage::get_state_storage_usage_only_at_epoch_beginning(): Usage`
+//
+// TODO: charge gas (constant cost) once the gas API lands.
+pub fn native_get_state_storage_usage_only_at_epoch_beginning<C: NativeContext>(
+    ctx: &C,
+) -> Result<NativeStatus, VMInternalError> {
+    let ext = ctx.get_extension::<StorageUsageAtEpochBoundary>()?;
+    let usage = Usage {
+        items: ext.items,
+        bytes: ext.bytes,
+    };
+    // SAFETY: return 0 is `Usage { items: u64, bytes: u64 }`.
+    unsafe { ctx.set_return(0, usage)? };
+    Ok(NativeStatus::Success)
+}
+
+/// Natives for the `state_storage` module.
+pub fn make_all_state_storage_natives<F: NativeContextFamily>() -> Vec<NativeEntry<F>> {
+    monomorphic_natives![(
+        "0x1::state_storage::get_state_storage_usage_only_at_epoch_beginning",
+        native_get_state_storage_usage_only_at_epoch_beginning
+    ),]
+}

--- a/third_party/move/mono-move/natives/src/transaction_context.rs
+++ b/third_party/move/mono-move/natives/src/transaction_context.rs
@@ -1,0 +1,136 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Natives for the `transaction_context` module, plus the extension backing them.
+
+use crate::{address_derivation::auid_address, monomorphic_natives, NativeEntry};
+use mono_move_core::native::{
+    NativeContext, NativeContextFamily, NativeExtension, NativeStatus, VMInternalError,
+};
+
+/// Per-transaction context backing the `transaction_context` natives.
+//
+// TODO: source `transaction_index` / `reserved_byte` from aptos-core's
+// `UserTransactionContext` rather than carrying them as plain fields, and model
+// the "transaction index not available" case.
+pub struct TransactionContextExtension {
+    txn_hash: Vec<u8>,
+    /// AUIDs issued so far in this transaction.
+    auid_counter: u64,
+    /// Per-session counter feeding the low bits of the monotonic counter.
+    local_counter: u16,
+    /// Identifies the session within the transaction.
+    session_counter: u8,
+    /// Index of the transaction within its block/chunk.
+    transaction_index: u32,
+    /// Top byte of the monotonic counter (0 for block execution, 1 for
+    /// validation/simulation).
+    reserved_byte: u8,
+}
+
+impl TransactionContextExtension {
+    pub fn new(
+        txn_hash: Vec<u8>,
+        session_counter: u8,
+        transaction_index: u32,
+        reserved_byte: u8,
+    ) -> Self {
+        Self {
+            txn_hash,
+            auid_counter: 0,
+            local_counter: 0,
+            session_counter,
+            transaction_index,
+            reserved_byte,
+        }
+    }
+}
+
+impl NativeExtension for TransactionContextExtension {
+    unsafe fn relocate_roots(&mut self, _relocate: &mut dyn FnMut(*mut u8) -> Option<*mut u8>) {}
+
+    // TODO: In the legacy VM, the AUID and the monotonic counter reset at every session start.
+    // However because each legacy VM session gets a fresh `session_hash` / `session_counter`,
+    // the derived IDs and counters are still guaranteed to be unique across the whole transaction.
+    // In some sense, this is a mechanism to accommodate the legacy VM's insufficient session model.
+    //
+    // Mono Move's session natively supports checkpoints and rollbacks, so there is no need to
+    // create multiple sessions. AUID and the monotonic counter are naturally unique as long as we
+    // do not reset them.
+    //
+    // This is likely fine for their intended use cases, but it does break binary compatibility with
+    // the legacy implementation. We'll need to revisit this and see if it ends up being a real
+    // problem. Perhaps a compatibility mode is needed if we want to replay existing transactions
+    // using the new VM?
+    fn on_checkpoint(&mut self) {}
+
+    fn on_rollback(&mut self, _n: usize) -> Result<(), VMInternalError> {
+        Ok(())
+    }
+}
+
+/// `error::invalid_state(EMONOTONICALLY_INCREASING_COUNTER_OVERFLOW)` in
+/// `0x1::transaction_context` (category 3, reason 2).
+const COUNTER_OVERFLOW_ABORT_CODE: u64 = (3 << 16) | 2;
+
+/// `0x1::transaction_context::generate_unique_address(): address`
+///
+/// Returns a freshly derived address, which is guaranteed to be unique within
+/// the transaction.
+//
+// TODO: charge gas.
+pub fn native_generate_unique_address<C: NativeContext>(
+    ctx: &C,
+) -> Result<NativeStatus, VMInternalError> {
+    let mut ext = ctx.get_extension::<TransactionContextExtension>()?;
+    ext.auid_counter += 1;
+    let address = auid_address(&ext.txn_hash, ext.auid_counter);
+    // SAFETY: return 0 is `address`.
+    unsafe { ctx.set_return(0, address)? };
+    Ok(NativeStatus::Success)
+}
+
+/// `0x1::transaction_context::monotonically_increasing_counter_internal(timestamp_us: u64): u128`
+///
+/// Packs `reserved_byte || timestamp_us || transaction_index || session_counter
+/// || local_counter` into a value that strictly increases within a session.
+//
+// TODO: charge gas.
+pub fn native_monotonically_increasing_counter_internal<C: NativeContext>(
+    ctx: &C,
+) -> Result<NativeStatus, VMInternalError> {
+    // SAFETY: arg 0 is `timestamp_us: u64`.
+    let timestamp_us = unsafe { ctx.arg::<u64>(0)? };
+
+    let mut ext = ctx.get_extension::<TransactionContextExtension>()?;
+    if ext.local_counter == u16::MAX {
+        return Ok(NativeStatus::Abort {
+            code: COUNTER_OVERFLOW_ABORT_CODE,
+            message: Some("monotonically increasing counter overflow".into()),
+        });
+    }
+    ext.local_counter += 1;
+
+    let counter = ((ext.reserved_byte as u128) << 120)
+        | ((timestamp_us as u128) << 56)
+        | ((ext.transaction_index as u128) << 24)
+        | ((ext.session_counter as u128) << 16)
+        | (ext.local_counter as u128);
+    // SAFETY: return 0 is `u128`.
+    unsafe { ctx.set_return(0, counter)? };
+    Ok(NativeStatus::Success)
+}
+
+/// Natives for the `transaction_context` module.
+pub fn make_all_transaction_context_natives<F: NativeContextFamily>() -> Vec<NativeEntry<F>> {
+    monomorphic_natives![
+        (
+            "0x1::transaction_context::generate_unique_address",
+            native_generate_unique_address
+        ),
+        (
+            "0x1::transaction_context::monotonically_increasing_counter_internal",
+            native_monotonically_increasing_counter_internal
+        ),
+    ]
+}

--- a/third_party/move/mono-move/runtime/src/error.rs
+++ b/third_party/move/mono-move/runtime/src/error.rs
@@ -318,6 +318,9 @@ pub enum RuntimeInvariantViolation {
 
     #[error("CallNative: native_idx {idx} out of bounds in registry of size {registry_size}")]
     NativeIdxOutOfBounds { idx: u32, registry_size: usize },
+
+    #[error("a native extension was borrowed when the GC tried to scan its roots")]
+    ExtensionBorrowedDuringGC,
 }
 
 /// Successful terminal outcomes from `Interpreter::run`. Runtime

--- a/third_party/move/mono-move/runtime/src/execution_context.rs
+++ b/third_party/move/mono-move/runtime/src/execution_context.rs
@@ -7,7 +7,7 @@
 use crate::{error::RuntimeResult, native_context::ProductionNativeRegistry};
 use mono_move_core::{
     interner::{InternedIdentifier, InternedModuleId},
-    native::NativeRegistry,
+    native::{NativeExtensions, NativeRegistry},
     storage::{ResourceProvider, NO_RESOURCE_PROVIDER},
     types::{InternedType, InternedTypeList},
     ConstantPoolIndex, DescriptorProvider, FunctionPtr, GasMeter, NO_DESCRIPTOR_PROVIDER,
@@ -23,16 +23,18 @@ pub trait ExecutionContext {
     /// Read-only access to the native function registry.
     fn natives(&self) -> &ProductionNativeRegistry;
 
-    /// Disjoint borrow of the native registry, the descriptor provider, and
-    /// the gas meter — all of which a native call site needs at once: the
-    /// registry to resolve the function, the provider for any GC the native
-    /// triggers, and the gas meter for charging.
-    fn natives_descriptors_and_gas_meter(
+    /// The per-transaction native extensions.
+    fn extensions(&self) -> &NativeExtensions;
+
+    /// Disjoint borrows all the sub-components needed for a native call.
+    /// Needed for avoiding borrow conflicts downstream.
+    fn native_call_borrows(
         &mut self,
     ) -> (
         &ProductionNativeRegistry,
         &dyn DescriptorProvider,
         &mut GasMeter,
+        &NativeExtensions,
     );
 
     /// Resolve a runtime function call.
@@ -71,6 +73,7 @@ pub struct LocalExecutionContext<'r> {
     gas_meter: GasMeter,
     natives: ProductionNativeRegistry,
     resource_provider: &'r dyn ResourceProvider,
+    extensions: NativeExtensions,
 }
 
 impl LocalExecutionContext<'static> {
@@ -84,6 +87,7 @@ impl LocalExecutionContext<'static> {
         Self {
             gas_meter: GasMeter::new(amount),
             natives: NativeRegistry::new(),
+            extensions: NativeExtensions::new(),
             resource_provider: &NO_RESOURCE_PROVIDER,
         }
     }
@@ -95,6 +99,7 @@ impl<'r> LocalExecutionContext<'r> {
         Self {
             gas_meter,
             natives: NativeRegistry::new(),
+            extensions: NativeExtensions::new(),
             resource_provider,
         }
     }
@@ -103,6 +108,13 @@ impl<'r> LocalExecutionContext<'r> {
     /// previously-installed registry.
     pub fn with_natives(mut self, natives: ProductionNativeRegistry) -> Self {
         self.natives = natives;
+        self
+    }
+
+    /// Install the per-transaction native extensions. Replaces any previously
+    /// installed set.
+    pub fn with_extensions(mut self, extensions: NativeExtensions) -> Self {
+        self.extensions = extensions;
         self
     }
 }
@@ -116,14 +128,24 @@ impl ExecutionContext for LocalExecutionContext<'_> {
         &self.natives
     }
 
-    fn natives_descriptors_and_gas_meter(
+    fn extensions(&self) -> &NativeExtensions {
+        &self.extensions
+    }
+
+    fn native_call_borrows(
         &mut self,
     ) -> (
         &ProductionNativeRegistry,
         &dyn DescriptorProvider,
         &mut GasMeter,
+        &NativeExtensions,
     ) {
-        (&self.natives, &NO_DESCRIPTOR_PROVIDER, &mut self.gas_meter)
+        (
+            &self.natives,
+            &NO_DESCRIPTOR_PROVIDER,
+            &mut self.gas_meter,
+            &self.extensions,
+        )
     }
 
     fn load_function(

--- a/third_party/move/mono-move/runtime/src/heap/mod.rs
+++ b/third_party/move/mono-move/runtime/src/heap/mod.rs
@@ -25,10 +25,11 @@ use crate::{
     },
 };
 use mono_move_core::{
-    align_max, checked_align_max, native::NativeABI, DescriptorId, DescriptorProvider, FrameOffset,
-    Function, ObjectDescriptorInner, RootPool, CAPTURED_DATA_VALUES_OFFSET,
-    CLOSURE_CAPTURED_DATA_PTR_OFFSET, CLOSURE_DATA_SIZE, ENUM_DATA_OFFSET, ENUM_TAG_OFFSET,
-    FRAME_METADATA_SIZE, OBJECT_HEADER_SIZE,
+    align_max, checked_align_max,
+    native::{NativeABI, NativeExtensions},
+    DescriptorId, DescriptorProvider, FrameOffset, Function, ObjectDescriptorInner, RootPool,
+    CAPTURED_DATA_VALUES_OFFSET, CLOSURE_CAPTURED_DATA_PTR_OFFSET, CLOSURE_DATA_SIZE,
+    ENUM_DATA_OFFSET, ENUM_TAG_OFFSET, FRAME_METADATA_SIZE, OBJECT_HEADER_SIZE,
 };
 use std::ptr::NonNull;
 
@@ -70,6 +71,7 @@ pub(crate) mod macros {
                 $ctx.exec_ctx,
                 &mut $ctx.read_write_set,
                 &$ctx.root_pool,
+                $ctx.exec_ctx.extensions(),
                 $fp,
                 $crate::heap::TopFrame::Function {
                     func: $ctx.current_func,
@@ -96,6 +98,7 @@ pub(crate) mod macros {
                 $ctx.exec_ctx,
                 &mut $ctx.read_write_set,
                 &$ctx.root_pool,
+                $ctx.exec_ctx.extensions(),
                 $fp,
                 $crate::heap::TopFrame::Function {
                     func: $ctx.current_func,
@@ -118,6 +121,7 @@ pub(crate) mod macros {
                 $ctx.exec_ctx,
                 &mut $ctx.read_write_set,
                 &$ctx.root_pool,
+                $ctx.exec_ctx.extensions(),
                 $fp,
                 $crate::heap::TopFrame::Function {
                     func: $ctx.current_func,
@@ -145,6 +149,7 @@ pub(crate) mod macros {
                 $ctx.exec_ctx,
                 &mut $ctx.read_write_set,
                 &$ctx.root_pool,
+                $ctx.exec_ctx.extensions(),
                 $crate::heap::TopFrame::Function {
                     func: $ctx.current_func,
                     pc: $ctx.pc,
@@ -166,6 +171,7 @@ pub(crate) mod macros {
                 $ctx.exec_ctx,
                 &mut $ctx.read_write_set,
                 &$ctx.root_pool,
+                $ctx.exec_ctx.extensions(),
                 $ctx.frame_ptr,
                 $crate::heap::TopFrame::Function {
                     func: $ctx.current_func,
@@ -267,6 +273,7 @@ pub(crate) fn alloc_or_gc<P: DescriptorProvider + ?Sized>(
     provider: &P,
     rws: &mut ResourceReadWriteSet,
     extra_roots: &RootPool,
+    extensions: &NativeExtensions,
     fp: *mut u8,
     top_frame: TopFrame<'_>,
     try_alloc: impl Fn(&mut Heap) -> AllocationResult<*mut u8>,
@@ -274,7 +281,7 @@ pub(crate) fn alloc_or_gc<P: DescriptorProvider + ?Sized>(
     match try_alloc(heap) {
         Ok(ptr) => Ok(ptr),
         Err(AllocationError::OutOfHeapMemory { .. }) => {
-            gc_collect(heap, provider, rws, extra_roots, fp, top_frame)?;
+            gc_collect(heap, provider, rws, extra_roots, extensions, fp, top_frame)?;
             try_alloc(heap).map_err(AllocationError::into_runtime_error)
         },
         Err(e) => Err(e.into_runtime_error()),
@@ -383,14 +390,22 @@ fn alloc_sized<P: DescriptorProvider + ?Sized>(
     provider: &P,
     rws: &mut ResourceReadWriteSet,
     extra_roots: &RootPool,
+    extensions: &NativeExtensions,
     fp: *mut u8,
     top_frame: TopFrame<'_>,
     total_size: usize,
     descriptor_id: DescriptorId,
 ) -> RuntimeResult<*mut u8> {
-    alloc_or_gc(heap, provider, rws, extra_roots, fp, top_frame, |h| {
-        heap_alloc(h, total_size, descriptor_id)
-    })
+    alloc_or_gc(
+        heap,
+        provider,
+        rws,
+        extra_roots,
+        extensions,
+        fp,
+        top_frame,
+        |h| heap_alloc(h, total_size, descriptor_id),
+    )
 }
 
 /// Allocate a new vector object on the heap.
@@ -404,6 +419,7 @@ pub(crate) fn alloc_vec<P: DescriptorProvider + ?Sized>(
     provider: &P,
     rws: &mut ResourceReadWriteSet,
     extra_roots: &RootPool,
+    extensions: &NativeExtensions,
     fp: *mut u8,
     top_frame: TopFrame<'_>,
     descriptor_id: DescriptorId,
@@ -420,6 +436,7 @@ pub(crate) fn alloc_vec<P: DescriptorProvider + ?Sized>(
         provider,
         rws,
         extra_roots,
+        extensions,
         fp,
         top_frame,
         total_size,
@@ -434,6 +451,7 @@ pub(crate) fn alloc_obj<P: DescriptorProvider + ?Sized>(
     provider: &P,
     rws: &mut ResourceReadWriteSet,
     extra_roots: &RootPool,
+    extensions: &NativeExtensions,
     fp: *mut u8,
     top_frame: TopFrame<'_>,
     descriptor_id: DescriptorId,
@@ -464,6 +482,7 @@ pub(crate) fn alloc_obj<P: DescriptorProvider + ?Sized>(
         provider,
         rws,
         extra_roots,
+        extensions,
         fp,
         top_frame,
         total_size,
@@ -480,6 +499,7 @@ pub(crate) fn alloc_captured_data<P: DescriptorProvider + ?Sized>(
     provider: &P,
     rws: &mut ResourceReadWriteSet,
     extra_roots: &RootPool,
+    extensions: &NativeExtensions,
     fp: *mut u8,
     top_frame: TopFrame<'_>,
     values_size: u32,
@@ -491,6 +511,7 @@ pub(crate) fn alloc_captured_data<P: DescriptorProvider + ?Sized>(
         provider,
         rws,
         extra_roots,
+        extensions,
         fp,
         top_frame,
         total_size,
@@ -516,6 +537,7 @@ pub(crate) fn grow_vec_ref<P: DescriptorProvider + ?Sized>(
     provider: &P,
     rws: &mut ResourceReadWriteSet,
     extra_roots: &RootPool,
+    extensions: &NativeExtensions,
     top_frame: TopFrame<'_>,
     fp: *mut u8,
     vec_ref_offset: usize,
@@ -548,6 +570,7 @@ pub(crate) fn grow_vec_ref<P: DescriptorProvider + ?Sized>(
             provider,
             rws,
             extra_roots,
+            extensions,
             fp,
             top_frame,
             descriptor_id,
@@ -616,6 +639,7 @@ pub(crate) fn gc_collect<P: DescriptorProvider + ?Sized>(
     provider: &P,
     rws: &mut ResourceReadWriteSet,
     extra_roots: &RootPool,
+    extensions: &NativeExtensions,
     frame_ptr: *mut u8,
     top_frame: TopFrame<'_>,
 ) -> Result<(), RuntimeInvariantViolation> {
@@ -693,6 +717,17 @@ pub(crate) fn gc_collect<P: DescriptorProvider + ?Sized>(
     // point into the local heap and must be relocated alongside the call
     // stack and pinned roots.
     rws.scan(&mut scanner);
+
+    // Phase 1d: native extension roots.
+    //
+    // TODO(correctness, security): a native holding an extension borrow across an
+    // allocation makes this a hard error; revisit how to guarantee exclusive
+    // access here (e.g. relocating only the disjoint root set).
+    unsafe {
+        extensions
+            .relocate_all_roots(&mut |base| scanner.relocate(base))
+            .map_err(|_| RuntimeInvariantViolation::ExtensionBorrowedDuringGC)?;
+    }
 
     // Phase 2: Cheney-style breadth-first scan of copied objects.
     // `scan_ptr` is a raw cursor — header start of the next object to

--- a/third_party/move/mono-move/runtime/src/interpreter.rs
+++ b/third_party/move/mono-move/runtime/src/interpreter.rs
@@ -30,7 +30,7 @@ use crate::{
 };
 use mono_move_core::{
     captured_values_size,
-    native::{NativeABI, NativeIdx, NativeStatus, RootPool},
+    native::{NativeABI, NativeExtensions, NativeIdx, NativeStatus, RootPool},
     next_captured_value_offset,
     storage::resource_provider::InMemoryStorageKey,
     types::{view_type_list, InternedTypeList},
@@ -126,14 +126,41 @@ impl<'a, T: ExecutionContext + DescriptorProvider + LayoutProvider> InterpreterC
         self.heap.gc_count
     }
 
-    /// TODO: move to execution context
-    pub fn checkpoint(&mut self) {
-        self.read_write_set.checkpoint();
+    /// The VM heap. Exposed so callers can read heap-resident values.
+    pub fn heap(&self) -> &Heap {
+        &self.heap
     }
 
-    /// TODO: move to execution context
+    pub fn extensions(&self) -> &NativeExtensions {
+        self.exec_ctx.extensions()
+    }
+
+    /// Takes a checkpoint (opening a new sub-session): checkpoints the
+    /// read-write set and signals every native extension. The two advance in
+    /// lockstep, so a single [`Self::rollback`] depth undoes a checkpoint's
+    /// effects across both.
+    //
+    // TODO: move to execution context
+    pub fn checkpoint(&mut self) -> RuntimeResult<()> {
+        self.read_write_set.checkpoint();
+        self.exec_ctx
+            .extensions()
+            .checkpoint()
+            .map_err(RuntimeError::VMInternal)
+    }
+
+    /// Rolls back the `n` most recent checkpoints across the read-write set and
+    /// every native extension. `n == 0` is a no-op; `n` beyond the current
+    /// depth is an invariant violation. The read-write set rolls back first, so
+    /// an underflow is caught before any extension is touched.
+    //
+    // TODO: move to execution context
     pub fn rollback(&mut self, n: usize) -> RuntimeResult<()> {
-        self.read_write_set.rollback(n)
+        self.read_write_set.rollback(n)?;
+        self.exec_ctx
+            .extensions()
+            .rollback(n)
+            .map_err(RuntimeError::VMInternal)
     }
 
     /// TODO: move to execution context
@@ -2219,7 +2246,7 @@ impl<T: ExecutionContext + DescriptorProvider + LayoutProvider> InterpreterConte
         let saved_fp = self.frame_ptr;
         self.frame_ptr = new_fp;
         let result = {
-            let (registry, provider, gas_meter) = self.exec_ctx.natives_descriptors_and_gas_meter();
+            let (registry, provider, gas_meter, extensions) = self.exec_ctx.native_call_borrows();
             let func = registry.lookup_by_idx(native_idx).ok_or_else(|| {
                 RuntimeError::InvariantViolation(RuntimeInvariantViolation::NativeIdxOutOfBounds {
                     idx: native_idx.0,
@@ -2240,6 +2267,7 @@ impl<T: ExecutionContext + DescriptorProvider + LayoutProvider> InterpreterConte
                 provider,
                 &mut self.heap,
                 &mut self.read_write_set,
+                extensions,
             );
             func(&ctx)
         };

--- a/third_party/move/mono-move/runtime/src/lib.rs
+++ b/third_party/move/mono-move/runtime/src/lib.rs
@@ -34,4 +34,5 @@ pub use native_context::{
 };
 pub use transaction_context::TransactionContext;
 pub use types::{StepResult, VEC_DATA_OFFSET, VEC_LENGTH_OFFSET};
+pub use value_utils::serialize;
 pub use verifier::{verify_function, verify_program, VerificationError};

--- a/third_party/move/mono-move/runtime/src/local_runtime_context.rs
+++ b/third_party/move/mono-move/runtime/src/local_runtime_context.rs
@@ -10,6 +10,7 @@ use crate::{
 };
 use mono_move_core::{
     interner::{InternedIdentifier, InternedModuleId},
+    native::NativeExtensions,
     types::{InternedType, InternedTypeList},
     ConstantPoolIndex, DescriptorId, DescriptorProvider, FunctionPtr, GasMeter, LayoutId,
     LayoutProvider, ObjectDescriptor, ObjectDescriptorTable, ResourceProvider, ValueLayout,
@@ -84,6 +85,12 @@ impl LocalRuntimeContext<'_> {
         self.inner = self.inner.with_natives(natives);
         self
     }
+
+    /// Install the per-transaction native extensions on the inner context.
+    pub fn with_extensions(mut self, extensions: NativeExtensions) -> Self {
+        self.inner = self.inner.with_extensions(extensions);
+        self
+    }
 }
 
 impl ExecutionContext for LocalRuntimeContext<'_> {
@@ -95,15 +102,20 @@ impl ExecutionContext for LocalRuntimeContext<'_> {
         self.inner.natives()
     }
 
-    fn natives_descriptors_and_gas_meter(
+    fn extensions(&self) -> &NativeExtensions {
+        self.inner.extensions()
+    }
+
+    fn native_call_borrows(
         &mut self,
     ) -> (
         &ProductionNativeRegistry,
         &dyn DescriptorProvider,
         &mut GasMeter,
+        &NativeExtensions,
     ) {
-        let (natives, _, gas_meter) = self.inner.natives_descriptors_and_gas_meter();
-        (natives, &self.descriptors, gas_meter)
+        let (natives, _, gas_meter, extensions) = self.inner.native_call_borrows();
+        (natives, &self.descriptors, gas_meter, extensions)
     }
 
     fn load_function(

--- a/third_party/move/mono-move/runtime/src/native_context.rs
+++ b/third_party/move/mono-move/runtime/src/native_context.rs
@@ -10,18 +10,19 @@ use crate::{
     error::RuntimeError,
     global_storage::ResourceReadWriteSet,
     heap::{alloc_vec, is_heap_ptr, Heap, TopFrame},
-    memory::write_u64,
-    types::{VEC_DATA_OFFSET, VEC_LENGTH_OFFSET},
+    memory::{read_ptr, write_u64},
+    types::{META_SAVED_FP_OFFSET, META_SAVED_FUNC_PTR_OFFSET, VEC_DATA_OFFSET, VEC_LENGTH_OFFSET},
 };
 use mono_move_core::{
+    interner::InternedModuleId,
     native::{
-        NativeABI, NativeContext, NativeContextFamily, NativeFunction, NativeRegistry, RootPool,
-        VMInternalError, VMValue, Vector,
+        NativeABI, NativeContext, NativeContextFamily, NativeExtension, NativeExtensions,
+        NativeFunction, NativeRegistry, RootPool, VMInternalError, VMValue, Vector,
     },
     types::InternedType,
-    DescriptorProvider, GasMeter, TRIVIAL_DESCRIPTOR_ID,
+    DescriptorProvider, Function, GasMeter, FRAME_METADATA_SIZE, TRIVIAL_DESCRIPTOR_ID,
 };
-use std::cell::{Cell, UnsafeCell};
+use std::cell::{Cell, RefMut, UnsafeCell};
 
 /// Concrete [`NativeContext`] used by the production runtime.
 ///
@@ -61,6 +62,10 @@ pub struct ProductionNativeContext<'a> {
     heap: UnsafeCell<&'a mut Heap>,
     /// The transaction's read write set -- provides global storage access.
     rws: UnsafeCell<&'a mut ResourceReadWriteSet>,
+    /// Per-transaction native extensions, shared across native calls. Accessed
+    /// sharedly — each extension's own [`RefCell`](std::cell::RefCell) provides
+    /// the interior mutability.
+    extensions: &'a NativeExtensions,
     /// GC roots backing the references and heap objects the native holds.
     pool: RootPool,
     /// Set after the first [`Self::set_return`]; blocks further `arg` /
@@ -79,6 +84,7 @@ impl<'a> ProductionNativeContext<'a> {
         desc_provider: &'a dyn DescriptorProvider,
         heap: &'a mut Heap,
         rws: &'a mut ResourceReadWriteSet,
+        extensions: &'a NativeExtensions,
     ) -> Self {
         Self {
             abi,
@@ -88,6 +94,7 @@ impl<'a> ProductionNativeContext<'a> {
             gas: UnsafeCell::new(gas_meter),
             heap: UnsafeCell::new(heap),
             rws: UnsafeCell::new(rws),
+            extensions,
             pool: RootPool::new(),
             returns_started: Cell::new(false),
         }
@@ -125,7 +132,7 @@ impl NativeContext for ProductionNativeContext<'_> {
         // inside the native's slot region; the interpreter sets `frame_ptr` to the
         // base of that region. Referenced/allocated memory is rooted in `pool`.
         //
-        // `T` is responsible for the correctness of its own `write_to_frame` impl.
+        // `T` is responsible for the correctness of its own `read_from_frame` impl.
         Ok(unsafe { T::read_from_frame(&self.pool, self.frame_ptr, slot.offset as usize) })
     }
 
@@ -174,6 +181,65 @@ impl NativeContext for ProductionNativeContext<'_> {
         })
     }
 
+    fn arg_raw(&self, i: usize) -> Result<Vec<u8>, VMInternalError> {
+        if self.returns_started.get() {
+            return Err(VMInternalError::InvariantViolation(format!(
+                "arg_raw({i}) called after a return value was written",
+            )));
+        }
+        let slot = self.abi.args().get(i).copied().ok_or_else(|| {
+            VMInternalError::InvariantViolation(format!(
+                "arg index {} out of bounds (num_args={})",
+                i,
+                self.abi.args().len(),
+            ))
+        })?;
+        // SAFETY: the ABI keeps `[offset, offset + size)` within the frame, and
+        // the caller wrote the argument's bytes there before the native ran.
+        let bytes = unsafe {
+            std::slice::from_raw_parts(self.frame_ptr.add(slot.offset as usize), slot.size as usize)
+        };
+        Ok(bytes.to_vec())
+    }
+
+    fn arg_ptr_offsets(&self, i: usize) -> Result<Vec<u32>, VMInternalError> {
+        let slot = self.abi.args().get(i).copied().ok_or_else(|| {
+            VMInternalError::InvariantViolation(format!(
+                "arg index {} out of bounds (num_args={})",
+                i,
+                self.abi.args().len(),
+            ))
+        })?;
+        // The ABI's heap-pointer offsets are frame-relative and span all args;
+        // keep the ones inside this arg's slot and rebase them to the arg start.
+        Ok(self
+            .abi
+            .heap_ptr_offsets()
+            .iter()
+            .map(|o| o.0)
+            .filter(|&o| slot.offset <= o && o < slot.offset + slot.size)
+            .map(|o| o - slot.offset)
+            .collect())
+    }
+
+    fn caller_module(&self) -> Option<InternedModuleId> {
+        // Walk two frames up: the native's metadata records its immediate
+        // caller's frame pointer, and that caller's metadata records *its*
+        // caller. A null saved-function pointer marks the entry frame, which
+        // has no caller.
+        unsafe {
+            let caller_fp = read_ptr(
+                self.frame_ptr.sub(FRAME_METADATA_SIZE),
+                META_SAVED_FP_OFFSET,
+            );
+            let caller_caller = read_ptr(
+                caller_fp.sub(FRAME_METADATA_SIZE),
+                META_SAVED_FUNC_PTR_OFFSET,
+            ) as *const Function;
+            caller_caller.as_ref().map(|f| f.module_id)
+        }
+    }
+
     fn new_byte_vector<'a>(&'a self, bytes: &[u8]) -> Result<Vector<'a, u8>, VMInternalError> {
         if self.returns_started.get() {
             return Err(VMInternalError::InvariantViolation(
@@ -199,6 +265,7 @@ impl NativeContext for ProductionNativeContext<'_> {
             self.desc_provider,
             rws,
             &self.pool,
+            self.extensions,
             self.frame_ptr,
             TopFrame::Native(self.abi),
             TRIVIAL_DESCRIPTOR_ID,
@@ -227,6 +294,10 @@ impl NativeContext for ProductionNativeContext<'_> {
         // Root it so it survives later allocations and is GC-relocated.
         // SAFETY: `ptr` is the data pointer of the freshly allocated vector.
         Ok(Vector::from_handle(unsafe { self.pool.root_object(ptr) }))
+    }
+
+    fn get_extension<T: NativeExtension>(&self) -> Result<RefMut<'_, T>, VMInternalError> {
+        self.extensions.get_mut::<T>()
     }
 }
 

--- a/third_party/move/mono-move/runtime/src/transaction_context.rs
+++ b/third_party/move/mono-move/runtime/src/transaction_context.rs
@@ -9,6 +9,7 @@
 use crate::{error::RuntimeResult, native_context::ProductionNativeRegistry, ExecutionContext};
 use mono_move_core::{
     interner::{InternedIdentifier, InternedModuleId},
+    native::NativeExtensions,
     types::{InternedType, InternedTypeList},
     ConstantPoolIndex, DescriptorId, DescriptorProvider, FunctionPtr, GasMeter, LayoutId,
     LayoutProvider, ObjectDescriptor, ResourceProvider, ValueLayout,
@@ -33,6 +34,8 @@ pub struct TransactionContext<'guard, 'ctx> {
     // TODO: Enforce that `natives` here and the `NativeResolver` passed
     // to `loader` are the same instance.
     natives: &'guard ProductionNativeRegistry,
+    /// Per-transaction native extensions, shared across native calls.
+    extensions: NativeExtensions,
 }
 
 impl<'guard, 'ctx> TransactionContext<'guard, 'ctx> {
@@ -48,7 +51,15 @@ impl<'guard, 'ctx> TransactionContext<'guard, 'ctx> {
             gas_meter,
             resource_provider,
             natives,
+            extensions: NativeExtensions::new(),
         }
+    }
+
+    /// Install the per-transaction native extensions. Replaces any previously
+    /// installed set.
+    pub fn with_extensions(mut self, extensions: NativeExtensions) -> Self {
+        self.extensions = extensions;
+        self
     }
 
     /// Returns the transaction's read-set.
@@ -66,14 +77,24 @@ impl ExecutionContext for TransactionContext<'_, '_> {
         self.natives
     }
 
-    fn natives_descriptors_and_gas_meter(
+    fn extensions(&self) -> &NativeExtensions {
+        &self.extensions
+    }
+
+    fn native_call_borrows(
         &mut self,
     ) -> (
         &ProductionNativeRegistry,
         &dyn DescriptorProvider,
         &mut GasMeter,
+        &NativeExtensions,
     ) {
-        (self.natives, self.loader.guard(), &mut self.gas_meter)
+        (
+            self.natives,
+            self.loader.guard(),
+            &mut self.gas_meter,
+            &self.extensions,
+        )
     }
 
     /// Looks up cross-module targets in the read-set, falling back to

--- a/third_party/move/mono-move/runtime/tests/extension_checkpoints.rs
+++ b/third_party/move/mono-move/runtime/tests/extension_checkpoints.rs
@@ -1,0 +1,89 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! The interpreter's `checkpoint()` / `rollback()` drive the native extensions'
+//! checkpoint hooks in lockstep with the read-write set.
+
+mod common;
+
+use mono_move_alloc::GlobalArenaPtr;
+use mono_move_core::{
+    native::{NativeExtension, NativeExtensions, VMInternalError},
+    Code, FrameLayoutInfo, Function, MicroOp, SortedSafePointEntries,
+};
+use mono_move_runtime::{InterpreterContext, LocalRuntimeContext, ObjectDescriptorTable};
+
+/// Test extension that records the checkpoint hooks the interpreter fires, so
+/// the test can confirm extensions move in lockstep with the read-write set.
+#[derive(Default)]
+struct CheckpointProbe {
+    depth: usize,
+    checkpoints: usize,
+    rolled_back: usize,
+}
+
+impl NativeExtension for CheckpointProbe {
+    unsafe fn relocate_roots(&mut self, _relocate: &mut dyn FnMut(*mut u8) -> Option<*mut u8>) {}
+
+    fn on_checkpoint(&mut self) {
+        self.depth += 1;
+        self.checkpoints += 1;
+    }
+
+    fn on_rollback(&mut self, n: usize) -> Result<(), VMInternalError> {
+        self.depth -= n;
+        self.rolled_back += n;
+        Ok(())
+    }
+}
+
+fn trivial_program() -> Function {
+    Function {
+        name: GlobalArenaPtr::from_static("test"),
+        module_id: crate::program_module_id!("test"),
+        code: Code::from_vec(vec![MicroOp::Return]),
+        entry_gas: 0,
+        param_slots: vec![],
+        param_region_size: 0,
+        param_and_local_sizes_sum: 40,
+        extended_frame_size: 64,
+        zero_frame: true,
+        frame_layout: FrameLayoutInfo::new(vec![]),
+        safe_point_layouts: SortedSafePointEntries::empty(),
+    }
+}
+
+#[test]
+fn checkpoint_rollback_drives_extensions_in_lockstep() {
+    let descriptors = ObjectDescriptorTable::new();
+    let func = trivial_program();
+    let mut extensions = NativeExtensions::new();
+    extensions.add(CheckpointProbe::default());
+    let mut exec_ctx =
+        LocalRuntimeContext::with_max_budget(descriptors).with_extensions(extensions);
+    let mut ctx = InterpreterContext::new(&mut exec_ctx, &func);
+
+    ctx.checkpoint().unwrap();
+    ctx.checkpoint().unwrap();
+    assert_eq!(ctx.checkpoint_depth(), 2);
+    {
+        let probe = ctx.extensions().get_mut::<CheckpointProbe>().unwrap();
+        assert_eq!(probe.depth, 2, "extension advanced with the read-write set");
+        assert_eq!(probe.checkpoints, 2);
+    }
+
+    // A partial rollback undoes the extension's checkpoints too.
+    ctx.rollback(1).unwrap();
+    assert_eq!(ctx.checkpoint_depth(), 1);
+    {
+        let probe = ctx.extensions().get_mut::<CheckpointProbe>().unwrap();
+        assert_eq!(probe.depth, 1);
+        assert_eq!(probe.rolled_back, 1);
+    }
+
+    // n == 0 leaves the extensions untouched.
+    ctx.rollback(0).unwrap();
+    let probe = ctx.extensions().get_mut::<CheckpointProbe>().unwrap();
+    assert_eq!(probe.depth, 1);
+    assert_eq!(probe.rolled_back, 1);
+}

--- a/third_party/move/mono-move/testsuite/Cargo.toml
+++ b/third_party/move/mono-move/testsuite/Cargo.toml
@@ -14,9 +14,11 @@ rust-version = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }
+aptos-framework-natives = { workspace = true }
 aptos-gas-schedule = { workspace = true }
 aptos-types = { workspace = true }
 aptos-vm = { workspace = true }
+aptos-vm-types = { workspace = true }
 bcs = { workspace = true }
 bytes = { workspace = true }
 codespan-reporting = { workspace = true }

--- a/third_party/move/mono-move/testsuite/src/engine.rs
+++ b/third_party/move/mono-move/testsuite/src/engine.rs
@@ -9,7 +9,9 @@ use crate::{
 };
 use anyhow::{anyhow, bail, Result};
 use mono_move_core::{
-    native::NativeName, types::EMPTY_TYPE_LIST, Function, GasMeter, Interner, NO_RESOURCE_PROVIDER,
+    native::{NativeExtensions, NativeName},
+    types::EMPTY_TYPE_LIST,
+    Function, GasMeter, Interner, NO_RESOURCE_PROVIDER,
 };
 use mono_move_global_context::{ExecutionGuard, GlobalContext};
 use mono_move_loader::{Loader, LoadingPolicy, LoweringPolicy};
@@ -112,14 +114,15 @@ impl<'guard, 'ctx> MonoRunner<'_, 'guard, 'ctx> {
 }
 
 /// Build the loader/native/transaction stack over an existing guard and module
-/// provider, load `address::module_name::function_name`, and hand a
-/// [`MonoRunner`] to `body`.
+/// provider, install `extensions`, load `address::module_name::function_name`,
+/// and hand a [`MonoRunner`] to `body`.
 pub fn with_mono_function<'guard, 'ctx, R>(
     guard: &'guard ExecutionGuard<'ctx>,
     module_provider: &'guard InMemoryModuleProvider,
     address: AccountAddress,
     module_name: &IdentStr,
     function_name: &IdentStr,
+    extensions: NativeExtensions,
     body: impl FnOnce(&mut MonoRunner<'_, '_, 'ctx>) -> R,
 ) -> Result<R> {
     let mut natives = ProductionNativeRegistry::new();
@@ -155,7 +158,8 @@ pub fn with_mono_function<'guard, 'ctx, R>(
         GasMeter::new(GAS_BUDGET),
         &NO_RESOURCE_PROVIDER,
         &natives,
-    );
+    )
+    .with_extensions(extensions);
 
     let id = guard
         .intern_address_name(&address, module_name)
@@ -205,6 +209,7 @@ pub fn with_loaded_mono_function<R>(
         address,
         module_name,
         function_name,
+        NativeExtensions::new(),
         body,
     )
 }

--- a/third_party/move/mono-move/testsuite/src/runner.rs
+++ b/third_party/move/mono-move/testsuite/src/runner.rs
@@ -13,10 +13,30 @@ use crate::{
     print_sections,
 };
 use anyhow::{anyhow, bail};
+use aptos_framework_natives::{
+    event::NativeEventContext, object::NativeObjectContext,
+    state_storage::NativeStateStorageContext, transaction_context::NativeTransactionContext,
+};
 use aptos_gas_schedule::{MiscGasParameters, NativeGasParameters, LATEST_GAS_FEATURE_VERSION};
-use aptos_types::on_chain_config::{Features, TimedFeaturesBuilder};
+use aptos_types::{
+    contract_event::ContractEvent,
+    event::EventKey,
+    on_chain_config::{Features, TimedFeaturesBuilder},
+    state_store::{
+        errors::StateViewError, state_key::StateKey, state_storage_usage::StateStorageUsage,
+        StateViewId,
+    },
+    transaction::user_transaction_context::{TransactionIndexKind, UserTransactionContext},
+};
 use aptos_vm::natives::aptos_natives;
+use aptos_vm_types::resolver::StateStorageView;
+use mono_move_core::{native::NativeExtensions, types::type_to_string};
 use mono_move_global_context::{ExecutionGuard, GlobalContext};
+use mono_move_natives::{
+    EventKind, EventStore, ObjectContextExtension, StorageUsageAtEpochBoundary,
+    TransactionContextExtension,
+};
+use mono_move_runtime::serialize;
 use move_binary_format::CompiledModule;
 use move_core_types::{
     account_address::AccountAddress,
@@ -42,6 +62,144 @@ use std::{path::Path, sync::OnceLock};
 /// Execution output from a VM as a normalized display string.
 struct Output {
     display: String,
+}
+
+// Fixed inputs seeded into both VMs' native extensions, so extension-backed
+// natives (AUID generation, state-storage usage, ...) produce matching output
+// across the two engines.
+const TEST_TXN_HASH: [u8; 32] = [7u8; 32];
+const TEST_STATE_ITEMS: u64 = 100;
+const TEST_STATE_BYTES: u64 = 2000;
+// Inputs to the monotonically-increasing counter. The reserved byte is 0,
+// matching `TransactionIndexKind::BlockExecution`.
+const TEST_SESSION_COUNTER: u8 = 2;
+const TEST_TXN_INDEX: u32 = 5;
+const TEST_RESERVED_BYTE: u8 = 0;
+
+/// A [`StateStorageView`] over empty storage that serves a fixed usage, for
+/// exercising the legacy `state_storage` native in the differential tests.
+//
+// TODO: replace with a real state view if tests need natives that read actual
+// stored state.
+struct MockEmptyStateStorage {
+    usage: StateStorageUsage,
+}
+
+impl StateStorageView for MockEmptyStateStorage {
+    type Key = StateKey;
+
+    fn id(&self) -> StateViewId {
+        StateViewId::Miscellaneous
+    }
+
+    fn read_state_value(&self, _state_key: &StateKey) -> Result<(), StateViewError> {
+        Ok(())
+    }
+
+    fn get_usage(&self) -> Result<StateStorageUsage, StateViewError> {
+        Ok(self.usage)
+    }
+}
+
+/// Normalized rendering of one emitted event, used to diff the two VMs' events.
+/// `creator`/`seq` are `Some` only for handle (V1) events.
+fn render_event(
+    creator: Option<AccountAddress>,
+    seq: Option<u64>,
+    type_str: &str,
+    blob: &[u8],
+) -> String {
+    match (creator, seq) {
+        (Some(creator), Some(seq)) => format!(
+            "handle creator={} seq={} {} {}",
+            creator.to_hex_literal(),
+            seq,
+            type_str,
+            render_bytes(blob),
+        ),
+        _ => format!("module {} {}", type_str, render_bytes(blob)),
+    }
+}
+
+/// Combines return values and rendered events into the normalized output string
+/// that `CHECK` directives match against: a `results:` segment when the call
+/// returns values and an `events:` segment when it emits events, joined by
+/// ` | `. A void, event-free call renders as `results:`.
+fn render_execution_output(vals: &[String], events: &[String]) -> String {
+    let mut segments = Vec::new();
+    if !vals.is_empty() {
+        segments.push(format!("results: {}", vals.join(", ")));
+    }
+    if !events.is_empty() {
+        segments.push(format!("events: {}", events.join("; ")));
+    }
+    if segments.is_empty() {
+        return "results:".to_string();
+    }
+    segments.join(" | ")
+}
+
+/// Renders the events emitted into the legacy VM's [`NativeEventContext`], in
+/// emission order, for cross-VM comparison.
+fn finalize_events_v1(extensions: &NativeContextExtensions) -> Vec<String> {
+    extensions
+        .get::<NativeEventContext>()
+        .events_iter()
+        .map(|event| {
+            let type_str = event.type_tag().to_canonical_string();
+            match event {
+                ContractEvent::V1(e) => render_event(
+                    Some(e.key().get_creator_address()),
+                    Some(e.sequence_number()),
+                    &type_str,
+                    e.event_data(),
+                ),
+                ContractEvent::V2(_) => render_event(None, None, &type_str, event.event_data()),
+            }
+        })
+        .collect()
+}
+
+/// Serializes and renders the events recorded in mono-move's [`EventStore`], in
+/// emission order, for cross-VM comparison. `layouts` (the guard's published
+/// layouts) resolves the event types.
+///
+/// # Safety
+///
+/// The VM heap must be live: each entry's `msg_data` embeds heap pointers that
+/// [`serialize`] dereferences.
+unsafe fn finalize_events_v2(
+    extensions: &NativeExtensions,
+    layouts: &ExecutionGuard<'_>,
+) -> Vec<String> {
+    let store = extensions
+        .get_mut::<EventStore>()
+        .expect("event store installed");
+    store
+        .entries()
+        .iter()
+        .map(|entry| {
+            let type_str = type_to_string(entry.msg_ty);
+            // SAFETY: forwarded from this function's contract — the heap is live.
+            let blob = unsafe { serialize(layouts, entry.msg_data.as_ptr(), entry.msg_ty) }
+                .expect("event value serializes");
+            match &entry.kind {
+                EventKind::V2 => render_event(None, None, &type_str, &blob),
+                EventKind::V1 {
+                    guid,
+                    sequence_number,
+                } => {
+                    let key: EventKey = bcs::from_bytes(guid).expect("guid decodes to EventKey");
+                    render_event(
+                        Some(key.get_creator_address()),
+                        Some(*sequence_number),
+                        &type_str,
+                        &blob,
+                    )
+                },
+            }
+        })
+        .collect()
 }
 
 /// Run all steps in a differential test, checking both VMs produce matching
@@ -290,6 +448,37 @@ fn execute_function_v1(
         .map(|(kind, arg)| kind.to_move_value(arg).simple_serialize().unwrap())
         .collect::<Vec<_>>();
 
+    // Seed the native extensions with the same fixed inputs as the mono-move
+    // side, so extension-backed natives produce matching output.
+    let state_storage_view = MockEmptyStateStorage {
+        usage: StateStorageUsage::new(TEST_STATE_ITEMS as usize, TEST_STATE_BYTES as usize),
+    };
+    let mut extensions = NativeContextExtensions::default();
+    let user_transaction_context = UserTransactionContext::new(
+        AccountAddress::ZERO,
+        vec![],
+        AccountAddress::ZERO,
+        0,
+        0,
+        0,
+        None,
+        None,
+        TransactionIndexKind::BlockExecution {
+            transaction_index: TEST_TXN_INDEX,
+        },
+        false,
+    );
+    extensions.add(NativeTransactionContext::new(
+        TEST_TXN_HASH.to_vec(),
+        vec![],
+        0,
+        Some(user_transaction_context),
+        TEST_SESSION_COUNTER,
+    ));
+    extensions.add(NativeObjectContext::default());
+    extensions.add(NativeStateStorageContext::new(&state_storage_view));
+    extensions.add(NativeEventContext::default());
+
     let mut data_cache = TransactionDataCache::empty();
     let output = match MoveVM::execute_loaded_function(
         function,
@@ -297,7 +486,7 @@ fn execute_function_v1(
         &mut MoveVmDataCacheAdapter::new(&mut data_cache, storage, &loader),
         &mut gas_meter,
         &mut traversal_context,
-        &mut NativeContextExtensions::default(),
+        &mut extensions,
         &loader,
     ) {
         Ok(result) => {
@@ -315,8 +504,9 @@ fn execute_function_v1(
                     _ => kind.format_bytes(bytes),
                 })
                 .collect::<Vec<_>>();
+            let events = finalize_events_v1(&extensions);
             Output {
-                display: format!("results: {}", vals.join(", ")),
+                display: render_execution_output(&vals, &events),
             }
         },
         Err(err) if err.major_status() == StatusCode::ABORTED => {
@@ -351,6 +541,21 @@ fn execute_function_v2(
     return_kinds: &[PrimitiveKind],
     heap_size: Option<usize>,
 ) -> (Output, usize) {
+    // Seed extensions with the same fixed inputs as the legacy side.
+    let mut extensions = NativeExtensions::new();
+    extensions.add(TransactionContextExtension::new(
+        TEST_TXN_HASH.to_vec(),
+        TEST_SESSION_COUNTER,
+        TEST_TXN_INDEX,
+        TEST_RESERVED_BYTE,
+    ));
+    extensions.add(ObjectContextExtension::new());
+    extensions.add(StorageUsageAtEpochBoundary::new(
+        TEST_STATE_ITEMS,
+        TEST_STATE_BYTES,
+    ));
+    extensions.add(EventStore::new());
+
     // Run through the shared pipeline engine. Argument placement and result
     // reading mirror mono-move's frame slot layout.
     let mut gc_count = 0;
@@ -360,6 +565,7 @@ fn execute_function_v2(
         *address,
         module_name,
         function_name,
+        extensions,
         |runner| {
             runner.set_heap_size(heap_size);
             let result = runner.run(
@@ -394,7 +600,10 @@ fn execute_function_v2(
                         }
                         ret_off += kind.size();
                     }
-                    vals
+                    // SAFETY: the heap (and every pointer the events embed) is
+                    // live while the interpreter is.
+                    let events = unsafe { finalize_events_v2(interpreter.extensions(), guard) };
+                    (vals, events)
                 },
             );
             gc_count = runner.gc_count();
@@ -409,7 +618,7 @@ fn execute_function_v2(
             Some(m) => format!("aborted: code {} ({})", code, m),
             None => format!("aborted: code {}", code),
         },
-        Ok(RunResult::Success(vals)) => format!("results: {}", vals.join(", ")),
+        Ok(RunResult::Success((vals, events))) => render_execution_output(&vals, &events),
     };
     (Output { display }, gc_count)
 }

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/natives/events.move
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/natives/events.move
@@ -1,0 +1,62 @@
+// Differential test for the event natives `write_module_event_to_store` (V2,
+// module events) and `write_to_event_store` (V1, handle events).
+
+// RUN: publish
+module 0x1::event {
+    use std::vector;
+
+    struct MyEvent has drop, store {
+        a: u64,
+        data: vector<u8>,
+    }
+
+    native fun write_module_event_to_store<T: drop + store>(msg: T);
+    native fun write_to_event_store<T: drop + store>(guid: vector<u8>, count: u64, msg: T);
+
+    fun bytes_1_2_3(): vector<u8> {
+        let v = vector::empty<u8>();
+        vector::push_back(&mut v, 1u8);
+        vector::push_back(&mut v, 2u8);
+        vector::push_back(&mut v, 3u8);
+        v
+    }
+
+    // The legacy `write_module_event_to_store` checks that its *caller* is a
+    // function in the event's module, so the native is called from a nested
+    // function.
+    //
+    // The entry function itself is not sufficient -- it does not have a Move
+    // *caller*.
+    fun do_emit() {
+        write_module_event_to_store(MyEvent { a: 7, data: bytes_1_2_3() });
+    }
+
+    // Module (V2) event.
+    public fun emit_module() {
+        do_emit();
+    }
+
+    // Mock `guid` -- the BCS encoding of an `EventKey { creation_number: 1,
+    // account_address: 0x0 }`
+    fun handle_guid(): vector<u8> {
+        let guid = vector::empty<u8>();
+        vector::push_back(&mut guid, 1u8);
+        let i = 0;
+        while (i < 39) {
+            vector::push_back(&mut guid, 0u8);
+            i = i + 1;
+        };
+        guid
+    }
+
+    // Handle (V1) event.
+    public fun emit_handle() {
+        write_to_event_store(handle_guid(), 5u64, MyEvent { a: 9, data: bytes_1_2_3() });
+    }
+}
+
+// RUN: execute 0x1::event::emit_module
+// CHECK: events: module 0x1::event::MyEvent 0x070000000000000003010203
+
+// RUN: execute 0x1::event::emit_handle
+// CHECK: events: handle creator=0x0 seq=5 0x1::event::MyEvent 0x090000000000000003010203

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/natives/object.move
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/natives/object.move
@@ -1,0 +1,26 @@
+// Differential test for `object::create_user_derived_object_address_impl`.
+
+// RUN: publish
+module 0x1::object {
+    public native fun create_user_derived_object_address_impl(
+        source: address,
+        derive_from: address,
+    ): address;
+
+    public fun derive(): address {
+        create_user_derived_object_address_impl(@0xa, @0xb)
+    }
+
+    // The memo cache must not change the result: the second (cached) call
+    // returns the same address as the first.
+    public fun derive_twice_same(): bool {
+        create_user_derived_object_address_impl(@0xa, @0xb)
+            == create_user_derived_object_address_impl(@0xa, @0xb)
+    }
+}
+
+// RUN: execute 0x1::object::derive
+// CHECK: results: 0xc168433b37d568f2c5cb143f04e177e102d9e40247cefdcb41b8dcc56caa44b0
+
+// RUN: execute 0x1::object::derive_twice_same
+// CHECK: results: true

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/natives/state_storage.move
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/natives/state_storage.move
@@ -1,0 +1,28 @@
+// Differential test for `state_storage::get_state_storage_usage_only_at_epoch_beginning`.
+//
+// Both VMs are seeded with the same fixed usage (items=100, bytes=2000) via
+// their state-storage native extension.
+
+// RUN: publish
+module 0x1::state_storage {
+    struct Usage has copy, drop, store {
+        items: u64,
+        bytes: u64,
+    }
+
+    public native fun get_state_storage_usage_only_at_epoch_beginning(): Usage;
+
+    public fun items(): u64 {
+        get_state_storage_usage_only_at_epoch_beginning().items
+    }
+
+    public fun bytes(): u64 {
+        get_state_storage_usage_only_at_epoch_beginning().bytes
+    }
+}
+
+// RUN: execute 0x1::state_storage::items
+// CHECK: results: 100
+
+// RUN: execute 0x1::state_storage::bytes
+// CHECK: results: 2000

--- a/third_party/move/mono-move/testsuite/tests/test_cases/differential/natives/transaction_context.move
+++ b/third_party/move/mono-move/testsuite/tests/test_cases/differential/natives/transaction_context.move
@@ -1,0 +1,45 @@
+// Differential test for `transaction_context::generate_unique_address` and
+// `monotonically_increasing_counter_internal`.
+//
+// Both VMs seed the transaction-context extension with the same fixed inputs
+// (transaction hash, session counter, transaction index), so the derived
+// addresses and counters match.
+
+// RUN: publish
+module 0x1::transaction_context {
+    public native fun generate_unique_address(): address;
+    native fun monotonically_increasing_counter_internal(timestamp_us: u64): u128;
+
+    public fun gen(): address {
+        generate_unique_address()
+    }
+
+    // Successive calls within a transaction must differ (the AUID counter
+    // increments each call).
+    public fun two_differ(): bool {
+        generate_unique_address() != generate_unique_address()
+    }
+
+    // With timestamp 0 the counter is `transaction_index << 24 | session_counter
+    // << 16 | local_counter`, and the first call sets local_counter to 1.
+    public fun counter(): u128 {
+        monotonically_increasing_counter_internal(0)
+    }
+
+    // The per-session local counter increments each call.
+    public fun counters_increase(): bool {
+        monotonically_increasing_counter_internal(0) < monotonically_increasing_counter_internal(0)
+    }
+}
+
+// RUN: execute 0x1::transaction_context::gen
+// CHECK: results: 0xfed7af230c8570d8202056f471c0a73b3dabb935969297cd6294fa507aa196a8
+
+// RUN: execute 0x1::transaction_context::two_differ
+// CHECK: results: true
+
+// RUN: execute 0x1::transaction_context::counter
+// CHECK: results: 84017153
+
+// RUN: execute 0x1::transaction_context::counters_increase
+// CHECK: results: true


### PR DESCRIPTION
Builds on #19996 (landed). Adds the native-extension mechanism for mono-move and the first extension-backed natives.

## What's here

- **`NativeExtensions`** — a per-transaction, `TypeId`-keyed store of native state. Extensions are GC-traced (`relocate_roots`, now required) and take part in **sub-sessions**: the interpreter's `checkpoint()` / `rollback(n)` drive the read-write set and every extension in lockstep (`on_checkpoint` / `on_rollback`).
- **Natives**:
  - `transaction_context` — `generate_unique_address`, `monotonically_increasing_counter_internal`
  - `object` — `create_user_derived_object_address_impl`
  - `state_storage` — `get_state_storage_usage_only_at_epoch_beginning`
  - `event` — `write_module_event_to_store` / `write_to_event_store` (backed by an `EventStore`, serialized at txn end via `value_utils::serialize`)
- **`NativeContext` additions** (no `VMValue` changes — that trait is left exactly as on `main`): `arg_raw` (untyped arg bytes for opaque/generic values), `arg_ptr_offsets` (heap-pointer offsets read from the native ABI), and `caller_module` (for the event admission check).

Verified by the differential testsuite against the legacy MoveVM (123 cases) plus unit tests for the extension / sub-session machinery (including an interpreter checkpoint/rollback lockstep test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches GC root scanning and transaction semantics (events, AUID/counter behavior vs legacy sessions); incorrect extension relocation or checkpoint rollback could corrupt execution or diverge from on-chain behavior.
> 
> **Overview**
> Introduces **per-transaction native extensions** for MonoMove: a `TypeId`-keyed `NativeExtensions` store with GC root relocation, checkpoint/rollback hooks, and wiring through `ExecutionContext`, native dispatch, and Cheney GC.
> 
> **`NativeContext`** gains `arg_raw`, `arg_ptr_offsets`, `caller_module`, and `get_extension` so natives can handle opaque values, trace heap pointers, and read transaction state.
> 
> **New framework natives** (registered in production): `transaction_context` (AUID addresses, monotonic counter), `object` (derived object addresses + memo cache), `state_storage` (epoch-boundary usage), and `event` (V1/V2 event store with rollback). Address derivation uses local `sha3_256` mirroring `AuthenticationKey` schemes.
> 
> **Interpreter** `checkpoint()` / `rollback()` now drive extensions in lockstep with the read-write set. **Differential testsuite** seeds matching extension state on both VMs and compares **events** alongside return values; new `.move` cases cover each native module.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17cddb6845129f1890b7900c5050d4db9bb0e966. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->