### PR TITLE
[docker] Build forge with release profile for perf images

### DIFF
--- a/docker/builder/build-forge-cli.sh
+++ b/docker/builder/build-forge-cli.sh
@@ -5,18 +5,21 @@ set -ex
 
 PROFILE=${PROFILE:-release}
 
-echo "Building forge"
-echo "PROFILE: $PROFILE"
-echo "CARGO_TARGET_DIR: $CARGO_TARGET_DIR"
-
-PERF_FLAGS=()
+BUILD_PROFILE=$PROFILE
 if [[ "$PROFILE" == "performance" ]]; then
-  PERF_FLAGS=(--config .cargo/performance.toml)
+  # No need to build with `--profile performance` since the most demanding
+  # thing forge does is generate load.
+  BUILD_PROFILE=release
 fi
 
-cargo build --locked --profile=$PROFILE "${PERF_FLAGS[@]}" \
+echo "Building forge"
+echo "PROFILE: $PROFILE"
+echo "BUILD_PROFILE: $BUILD_PROFILE"
+echo "CARGO_TARGET_DIR: $CARGO_TARGET_DIR"
+
+cargo build --locked --profile=$BUILD_PROFILE \
     -p aptos-forge-cli \
     "$@"
 
 mkdir dist
-cp $CARGO_TARGET_DIR/$PROFILE/forge dist/forge
+cp $CARGO_TARGET_DIR/$BUILD_PROFILE/forge dist/forge


### PR DESCRIPTION

Forge is an internal load generator and test harness. The `performance`
profile adds thin LTO and `codegen-units=1`, which cost substantial
build time for only marginal runtime gains over `release` (both use
`opt-level=3`). Map `performance` -> `release` for the forge build and
skip cross-language LTO.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docker-only forge build script change; no auth, data, or node runtime behavior affected.
> 
> **Overview**
> When Docker builds forge with **`PROFILE=performance`**, **`build-forge-cli.sh`** now compiles and copies from the **`release`** profile instead of **`performance`**.
> 
> It drops the **`--config .cargo/performance.toml`** path (thin LTO / **`codegen-units=1`**) and uses a **`BUILD_PROFILE`** variable so **`cargo build`** and the **`dist/forge`** copy stay aligned. The intent is faster forge image builds with little runtime downside for a load/test harness.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7184d57ad1f3552a27dde3a3c6a8de468413006. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->