### PR TITLE
[storage] Make hot state DBs non-optional

### DIFF
--- a/storage/aptosdb/src/db/aptosdb_internal.rs
+++ b/storage/aptosdb/src/db/aptosdb_internal.rs
@@ -48,9 +48,9 @@ use std::{
 impl AptosDB {
     fn new_with_dbs(
         ledger_db: LedgerDb,
-        hot_state_merkle_db: Option<StateMerkleDb>,
+        hot_state_merkle_db: StateMerkleDb,
         state_merkle_db: StateMerkleDb,
-        hot_state_kv_db: Option<StateKvDb>,
+        hot_state_kv_db: StateKvDb,
         state_kv_db: StateKvDb,
         pruner_config: PrunerConfig,
         buffered_state_target_items: usize,
@@ -60,14 +60,14 @@ impl AptosDB {
         hot_state_config: HotStateConfig,
     ) -> Self {
         let ledger_db = Arc::new(ledger_db);
-        let hot_state_merkle_db = hot_state_merkle_db.map(Arc::new);
+        let hot_state_merkle_db = Arc::new(hot_state_merkle_db);
         let state_merkle_db = Arc::new(state_merkle_db);
-        let hot_state_kv_db = hot_state_kv_db.map(Arc::new);
+        let hot_state_kv_db = Arc::new(hot_state_kv_db);
         let state_kv_db = Arc::new(state_kv_db);
         let state_pruner = StatePruner::new(
-            hot_state_merkle_db.clone(),
+            Arc::clone(&hot_state_merkle_db),
             Arc::clone(&state_merkle_db),
-            hot_state_kv_db.clone(),
+            Arc::clone(&hot_state_kv_db),
             Arc::clone(&state_kv_db),
             pruner_config,
         );
@@ -75,7 +75,7 @@ impl AptosDB {
             Arc::clone(&ledger_db),
             hot_state_merkle_db,
             Arc::clone(&state_merkle_db),
-            hot_state_kv_db.clone(),
+            Arc::clone(&hot_state_kv_db),
             Arc::clone(&state_kv_db),
             state_pruner,
             buffered_state_target_items,
@@ -155,10 +155,9 @@ impl AptosDB {
         // initializing the pruner, so the pruner doesn't catch up from 0 over an empty DB.
         if !readonly
             && hot_state_config.delete_on_restart
-            && let Some(db) = hot_state_kv_db.as_ref()
             && let Some(synced_version) = ledger_db.metadata_db().get_synced_version()?
         {
-            db.write_pruner_progress(synced_version)?;
+            hot_state_kv_db.write_pruner_progress(synced_version)?;
         }
 
         // Capture before `pruner_config` is moved; the position pruners
@@ -206,9 +205,11 @@ impl AptosDB {
                     .state_pruner
                     .state_kv_pruner
                     .maybe_set_pruner_target_db_version(version);
-                if let Some(pruner) = &myself.state_store.state_pruner.hot_state_kv_pruner {
-                    pruner.maybe_set_pruner_target_db_version(version);
-                }
+                myself
+                    .state_store
+                    .state_pruner
+                    .hot_state_kv_pruner
+                    .maybe_set_pruner_target_db_version(version);
             }
             if let Some(version) = myself.get_latest_state_checkpoint_version()? {
                 myself
@@ -221,12 +222,16 @@ impl AptosDB {
                     .state_pruner
                     .epoch_snapshot_pruner
                     .maybe_set_pruner_target_db_version(version);
-                if let Some(pruner) = &myself.state_store.state_pruner.hot_state_merkle_pruner {
-                    pruner.maybe_set_pruner_target_db_version(version);
-                }
-                if let Some(pruner) = &myself.state_store.state_pruner.hot_epoch_snapshot_pruner {
-                    pruner.maybe_set_pruner_target_db_version(version);
-                }
+                myself
+                    .state_store
+                    .state_pruner
+                    .hot_state_merkle_pruner
+                    .maybe_set_pruner_target_db_version(version);
+                myself
+                    .state_store
+                    .state_pruner
+                    .hot_epoch_snapshot_pruner
+                    .maybe_set_pruner_target_db_version(version);
             }
 
             // Activate the native-position pruners; otherwise their
@@ -270,7 +275,10 @@ impl AptosDB {
             buffered_state_target_items,
             max_num_nodes_per_lru_cache_shard,
             None,
-            HotStateConfig::default(),
+            HotStateConfig {
+                delete_on_restart: !readonly,
+                ..HotStateConfig::default()
+            },
         )
         .expect("Unable to open AptosDB")
     }
@@ -301,9 +309,9 @@ impl AptosDB {
             )?;
 
         let ledger_db = Arc::new(ledger_db);
-        let hot_state_merkle_db = hot_state_merkle_db.map(Arc::new);
+        let hot_state_merkle_db = Arc::new(hot_state_merkle_db);
         let state_merkle_db = Arc::new(state_merkle_db);
-        let hot_state_kv_db = hot_state_kv_db.map(Arc::new);
+        let hot_state_kv_db = Arc::new(hot_state_kv_db);
         let state_kv_db = Arc::new(state_kv_db);
 
         let mut batch = SchemaBatch::new();
@@ -317,8 +325,8 @@ impl AptosDB {
             Arc::clone(&ledger_db),
             Arc::clone(&state_kv_db),
             Arc::clone(&state_merkle_db),
-            hot_state_kv_db.clone(),
-            hot_state_merkle_db.clone(),
+            Arc::clone(&hot_state_kv_db),
+            Arc::clone(&hot_state_merkle_db),
             /*crash_if_difference_is_too_large=*/ false,
             delete_hot_state_on_restart,
         );

--- a/storage/aptosdb/src/db/aptosdb_writer.rs
+++ b/storage/aptosdb/src/db/aptosdb_writer.rs
@@ -459,11 +459,7 @@ impl AptosDB {
             &mut sharded_state_kv_batches,
         )?;
 
-        let hot_state_kv_db = self
-            .hot_state_kv_db
-            .as_ref()
-            .expect("hot_state_kv_db must exist on the write path");
-        let mut sharded_hot_state_kv_batches = hot_state_kv_db.new_sharded_native_batches();
+        let mut sharded_hot_state_kv_batches = self.hot_state_kv_db.new_sharded_native_batches();
         StateStore::put_hot_state_updates(
             chunk.hot_state_updates,
             &mut sharded_hot_state_kv_batches,
@@ -507,7 +503,7 @@ impl AptosDB {
                     .unwrap();
             });
             s.spawn(|_| {
-                hot_state_kv_db
+                self.hot_state_kv_db
                     .commit(
                         chunk.expect_last_version(),
                         None,
@@ -767,9 +763,10 @@ impl AptosDB {
                 .state_pruner
                 .state_kv_pruner
                 .maybe_set_pruner_target_db_version(version);
-            if let Some(pruner) = &self.state_store.state_pruner.hot_state_kv_pruner {
-                pruner.maybe_set_pruner_target_db_version(version);
-            }
+            self.state_store
+                .state_pruner
+                .hot_state_kv_pruner
+                .maybe_set_pruner_target_db_version(version);
             // Activate the native-position value pruner here too, after
             // the commit is durable — same point as `state_kv_pruner`.
             // (The merkle pruners are driven when snapshots persist.)

--- a/storage/aptosdb/src/db/mod.rs
+++ b/storage/aptosdb/src/db/mod.rs
@@ -26,7 +26,7 @@ pub mod test_helper;
 /// access to the core Aptos data structures.
 pub struct AptosDB {
     pub(crate) ledger_db: Arc<LedgerDb>,
-    pub(crate) hot_state_kv_db: Option<Arc<StateKvDb>>,
+    pub(crate) hot_state_kv_db: Arc<StateKvDb>,
     pub(crate) state_kv_db: Arc<StateKvDb>,
     pub(crate) event_store: Arc<EventStore>,
     pub(crate) state_store: Arc<StateStore>,
@@ -111,13 +111,7 @@ impl AptosDB {
         readonly: bool,
         max_num_nodes_per_lru_cache_shard: usize,
         hot_state_config: HotStateConfig,
-    ) -> Result<(
-        LedgerDb,
-        Option<StateMerkleDb>,
-        StateMerkleDb,
-        Option<StateKvDb>,
-        StateKvDb,
-    )> {
+    ) -> Result<(LedgerDb, StateMerkleDb, StateMerkleDb, StateKvDb, StateKvDb)> {
         let ledger_db = LedgerDb::new(
             db_paths.ledger_db_root_path(),
             rocksdb_configs.ledger_db_config,
@@ -125,19 +119,15 @@ impl AptosDB {
             block_cache,
             readonly,
         )?;
-        let hot_state_kv_db = if !readonly {
-            Some(StateKvDb::new(
-                db_paths,
-                rocksdb_configs.state_kv_db_config,
-                env,
-                block_cache,
-                readonly,
-                /* is_hot = */ true,
-                hot_state_config.delete_on_restart,
-            )?)
-        } else {
-            None
-        };
+        let hot_state_kv_db = StateKvDb::new(
+            db_paths,
+            rocksdb_configs.state_kv_db_config,
+            env,
+            block_cache,
+            readonly,
+            /* is_hot = */ true,
+            hot_state_config.delete_on_restart,
+        )?;
         let state_kv_db = StateKvDb::new(
             db_paths,
             rocksdb_configs.state_kv_db_config,
@@ -147,20 +137,16 @@ impl AptosDB {
             /* is_hot = */ false,
             /* delete_on_restart = */ false,
         )?;
-        let hot_state_merkle_db = if !readonly {
-            Some(StateMerkleDb::new(
-                db_paths,
-                rocksdb_configs.state_merkle_db_config,
-                env,
-                block_cache,
-                readonly,
-                max_num_nodes_per_lru_cache_shard,
-                /* is_hot = */ true,
-                hot_state_config.delete_on_restart,
-            )?)
-        } else {
-            None
-        };
+        let hot_state_merkle_db = StateMerkleDb::new(
+            db_paths,
+            rocksdb_configs.state_merkle_db_config,
+            env,
+            block_cache,
+            readonly,
+            max_num_nodes_per_lru_cache_shard,
+            /* is_hot = */ true,
+            hot_state_config.delete_on_restart,
+        )?;
         let state_merkle_db = StateMerkleDb::new(
             db_paths,
             rocksdb_configs.state_merkle_db_config,

--- a/storage/aptosdb/src/sharded_jmt_merkle_db.rs
+++ b/storage/aptosdb/src/sharded_jmt_merkle_db.rs
@@ -221,6 +221,11 @@ impl ShardedJmtMerkleDb {
         JellyfishMerkleTree::new(self).get_root_hash(version)
     }
 
+    /// Like [`Self::get_root_hash`], but returns `None` when there is no root node at `version`.
+    pub fn get_root_hash_option(&self, version: Version) -> Result<Option<HashValue>> {
+        JellyfishMerkleTree::new(self).get_root_hash_option(version)
+    }
+
     pub fn get_leaf_count(&self, version: Version) -> Result<usize> {
         JellyfishMerkleTree::new(self).get_leaf_count(version)
     }

--- a/storage/aptosdb/src/state_store/mod.rs
+++ b/storage/aptosdb/src/state_store/mod.rs
@@ -104,9 +104,9 @@ const MAX_WRITE_SETS_AFTER_SNAPSHOT: LeafCount = buffered_state::TARGET_SNAPSHOT
 pub const MAX_COMMIT_PROGRESS_DIFFERENCE: u64 = 1_000_000;
 
 pub(crate) struct StatePruner {
-    pub hot_state_merkle_pruner: Option<StateMerklePrunerManager<StateMerkle>>,
-    pub hot_epoch_snapshot_pruner: Option<StateMerklePrunerManager<EpochSnapshot>>,
-    pub hot_state_kv_pruner: Option<StateKvPrunerManager<HotStateKv>>,
+    pub hot_state_merkle_pruner: StateMerklePrunerManager<StateMerkle>,
+    pub hot_epoch_snapshot_pruner: StateMerklePrunerManager<EpochSnapshot>,
+    pub hot_state_kv_pruner: StateKvPrunerManager<HotStateKv>,
     pub state_merkle_pruner: StateMerklePrunerManager<StateMerkle>,
     pub epoch_snapshot_pruner: StateMerklePrunerManager<EpochSnapshot>,
     pub state_kv_pruner: StateKvPrunerManager<ColdStateKv>,
@@ -114,26 +114,22 @@ pub(crate) struct StatePruner {
 
 impl StatePruner {
     pub fn new(
-        hot_state_merkle_db: Option<Arc<StateMerkleDb>>,
+        hot_state_merkle_db: Arc<StateMerkleDb>,
         state_merkle_db: Arc<StateMerkleDb>,
-        hot_state_kv_db: Option<Arc<StateKvDb>>,
+        hot_state_kv_db: Arc<StateKvDb>,
         state_kv_db: Arc<StateKvDb>,
         config: PrunerConfig,
     ) -> Self {
-        let hot_state_merkle_pruner = hot_state_merkle_db.as_ref().map(|db| {
-            StateMerklePrunerManager::<StateMerkle>::new(
-                Arc::clone(db),
-                config.state_merkle_pruner_config,
-            )
-        });
-        let hot_epoch_snapshot_pruner = hot_state_merkle_db.map(|db| {
-            StateMerklePrunerManager::<EpochSnapshot>::new(
-                db,
-                config.epoch_snapshot_pruner_config.into(),
-            )
-        });
-        let hot_state_kv_pruner = hot_state_kv_db
-            .map(|db| StateKvPrunerManager::<HotStateKv>::new(db, config.ledger_pruner_config));
+        let hot_state_merkle_pruner = StateMerklePrunerManager::<StateMerkle>::new(
+            Arc::clone(&hot_state_merkle_db),
+            config.state_merkle_pruner_config,
+        );
+        let hot_epoch_snapshot_pruner = StateMerklePrunerManager::<EpochSnapshot>::new(
+            hot_state_merkle_db,
+            config.epoch_snapshot_pruner_config.into(),
+        );
+        let hot_state_kv_pruner =
+            StateKvPrunerManager::<HotStateKv>::new(hot_state_kv_db, config.ledger_pruner_config);
         let state_merkle_pruner = StateMerklePrunerManager::<StateMerkle>::new(
             Arc::clone(&state_merkle_db),
             config.state_merkle_pruner_config,
@@ -163,9 +159,9 @@ impl StatePruner {
 
 pub(crate) struct StateDb {
     pub ledger_db: Arc<LedgerDb>,
-    pub hot_state_merkle_db: Option<Arc<StateMerkleDb>>,
+    pub hot_state_merkle_db: Arc<StateMerkleDb>,
     pub state_merkle_db: Arc<StateMerkleDb>,
-    pub hot_state_kv_db: Option<Arc<StateKvDb>>,
+    pub hot_state_kv_db: Arc<StateKvDb>,
     pub state_kv_db: Arc<StateKvDb>,
     pub state_pruner: StatePruner,
     pub skip_usage: bool,
@@ -244,9 +240,7 @@ impl DbReader for StateDb {
         use_hot_state: bool,
     ) -> Result<SparseMerkleProofExt> {
         let db = if use_hot_state {
-            self.hot_state_merkle_db
-                .as_ref()
-                .ok_or(AptosDbError::HotStateError)?
+            &self.hot_state_merkle_db
         } else {
             &self.state_merkle_db
         };
@@ -280,11 +274,9 @@ impl DbReader for StateDb {
         version: Version,
         root_depth: usize,
     ) -> Result<(Option<HotStateValue>, SparseMerkleProofExt)> {
-        let merkle_db = self
+        let (leaf_data, proof) = self
             .hot_state_merkle_db
-            .as_ref()
-            .ok_or(AptosDbError::HotStateError)?;
-        let (leaf_data, proof) = merkle_db.get_with_proof_ext(&key_hash, version, root_depth)?;
+            .get_with_proof_ext(&key_hash, version, root_depth)?;
         let value = match leaf_data {
             Some((_val_hash, (_key, ver))) => {
                 Some(self.expect_hot_state_value_by_version(key_hash, ver)?)
@@ -405,12 +397,11 @@ impl StateDb {
         key_hash: HashValue,
         version: Version,
     ) -> Result<Option<HotStateValue>> {
-        let db = self
-            .hot_state_kv_db
-            .as_ref()
-            .ok_or(AptosDbError::HotStateError)?;
         Ok(
-            match db.get_hot_state_entry_by_version(key_hash, version)? {
+            match self
+                .hot_state_kv_db
+                .get_hot_state_entry_by_version(key_hash, version)?
+            {
                 // No row at or before `version` — key was never hot.
                 None => None,
                 // Eviction tombstone — no hot entry at `version`.
@@ -447,9 +438,9 @@ impl StateDb {
 impl StateStore {
     pub(crate) fn new(
         ledger_db: Arc<LedgerDb>,
-        hot_state_merkle_db: Option<Arc<StateMerkleDb>>,
+        hot_state_merkle_db: Arc<StateMerkleDb>,
         state_merkle_db: Arc<StateMerkleDb>,
-        hot_state_kv_db: Option<Arc<StateKvDb>>,
+        hot_state_kv_db: Arc<StateKvDb>,
         state_kv_db: Arc<StateKvDb>,
         state_pruner: StatePruner,
         buffered_state_target_items: usize,
@@ -464,8 +455,8 @@ impl StateStore {
                 Arc::clone(&ledger_db),
                 Arc::clone(&state_kv_db),
                 Arc::clone(&state_merkle_db),
-                hot_state_kv_db.clone(),
-                hot_state_merkle_db.clone(),
+                Arc::clone(&hot_state_kv_db),
+                Arc::clone(&hot_state_merkle_db),
                 /*crash_if_difference_is_too_large=*/ true,
                 hot_state_config.delete_on_restart,
             );
@@ -530,8 +521,8 @@ impl StateStore {
         ledger_db: Arc<LedgerDb>,
         state_kv_db: Arc<StateKvDb>,
         state_merkle_db: Arc<StateMerkleDb>,
-        hot_state_kv_db: Option<Arc<StateKvDb>>,
-        hot_state_merkle_db: Option<Arc<StateMerkleDb>>,
+        hot_state_kv_db: Arc<StateKvDb>,
+        hot_state_merkle_db: Arc<StateMerkleDb>,
         crash_if_difference_is_too_large: bool,
         delete_hot_state_on_restart: bool,
     ) {
@@ -577,9 +568,9 @@ impl StateStore {
         // When `delete_on_restart` in config is flipped from true to false, the node will have been
         // running for a while, so its hot_state_kv_db is extremely unlikely to not have a progress
         // marker and `sync_state_kv_commit_progress` should work.
-        if !delete_hot_state_on_restart && let Some(db) = &hot_state_kv_db {
+        if !delete_hot_state_on_restart {
             Self::sync_state_kv_commit_progress(
-                db,
+                &hot_state_kv_db,
                 overall_commit_progress,
                 crash_if_difference_is_too_large,
             );
@@ -592,17 +583,16 @@ impl StateStore {
             overall_commit_progress,
             crash_if_difference_is_too_large,
         );
-        let hot_merkle_target =
-            if !delete_hot_state_on_restart && let Some(db) = &hot_state_merkle_db {
-                Some(Self::find_state_merkle_truncation_target(
-                    ledger_metadata_db,
-                    db,
-                    overall_commit_progress,
-                    crash_if_difference_is_too_large,
-                ))
-            } else {
-                None
-            };
+        let hot_merkle_target = if !delete_hot_state_on_restart {
+            Some(Self::find_state_merkle_truncation_target(
+                ledger_metadata_db,
+                &hot_state_merkle_db,
+                overall_commit_progress,
+                crash_if_difference_is_too_large,
+            ))
+        } else {
+            None
+        };
 
         // Truncate both merkle DBs to the min of their targets so they end up at the
         // same snapshot version. After a partial-commit crash one DB may be one snapshot
@@ -617,8 +607,8 @@ impl StateStore {
             "State merkle truncation targets.",
         );
         Self::truncate_state_merkle_if_needed(&state_merkle_db, merkle_target);
-        if !delete_hot_state_on_restart && let Some(db) = &hot_state_merkle_db {
-            Self::truncate_state_merkle_if_needed(db, merkle_target);
+        if !delete_hot_state_on_restart {
+            Self::truncate_state_merkle_if_needed(&hot_state_merkle_db, merkle_target);
         }
     }
 
@@ -703,15 +693,15 @@ impl StateStore {
     #[cfg(any(test, feature = "db-debugger"))]
     pub fn catch_up_state_merkle_db(
         ledger_db: Arc<LedgerDb>,
-        hot_state_merkle_db: Option<Arc<StateMerkleDb>>,
+        hot_state_merkle_db: Arc<StateMerkleDb>,
         state_merkle_db: Arc<StateMerkleDb>,
-        hot_state_kv_db: Option<Arc<StateKvDb>>,
+        hot_state_kv_db: Arc<StateKvDb>,
         state_kv_db: Arc<StateKvDb>,
     ) -> Result<Option<Version>> {
         let state_pruner = StatePruner::new(
-            hot_state_merkle_db.clone(),
+            Arc::clone(&hot_state_merkle_db),
             Arc::clone(&state_merkle_db),
-            hot_state_kv_db.clone(),
+            Arc::clone(&hot_state_kv_db),
             Arc::clone(&state_kv_db),
             aptos_config::config::NO_OP_STORAGE_PRUNER_CONFIG,
         );
@@ -783,10 +773,14 @@ impl StateStore {
         };
         let hot_state_root_hash = if !hot_state_config.delete_on_restart
             && let Some(version) = latest_snapshot_version
-            && let Some(db) = &state_db.hot_state_merkle_db
         {
-            db.get_root_hash(version)
+            // No hot state root at `version` yet (e.g. before the hot state has ever been
+            // committed) — fall back to the placeholder.
+            state_db
+                .hot_state_merkle_db
+                .get_root_hash_option(version)
                 .expect("Failed to query hot state root hash on initialization.")
+                .unwrap_or(*SPARSE_MERKLE_PLACEHOLDER_HASH)
         } else {
             *SPARSE_MERKLE_PLACEHOLDER_HASH
         };
@@ -825,13 +819,13 @@ impl StateStore {
             );
         }
 
-        if hot_state_root_hash == *SPARSE_MERKLE_PLACEHOLDER_HASH
-            && snapshot_next_version > 0
-            && let Some(db) = &state_db.hot_state_merkle_db
-        {
+        if hot_state_root_hash == *SPARSE_MERKLE_PLACEHOLDER_HASH && snapshot_next_version > 0 {
             // TODO(HotState): this is needed while starting with an empty hot state during
             // development.
-            Self::write_hot_state_null_node(db, snapshot_next_version - 1)?;
+            Self::write_hot_state_null_node(
+                &state_db.hot_state_merkle_db,
+                snapshot_next_version - 1,
+            )?;
         }
 
         if snapshot_next_version < num_transactions {
@@ -939,7 +933,8 @@ impl StateStore {
 
         // `delete_on_restart` wiped the hot state KV for this range; re-write it so it
         // matches the JMT we're about to commit.
-        if delete_hot_state_on_restart && let Some(db) = state_db.hot_state_kv_db.as_ref() {
+        if delete_hot_state_on_restart {
+            let db = &state_db.hot_state_kv_db;
             let mut sharded_batches = db.new_sharded_native_batches();
             Self::put_hot_state_updates(&hot_state_updates, &mut sharded_batches)?;
             db.commit(num_transactions - 1, None, sharded_batches)?;
@@ -977,10 +972,6 @@ impl StateStore {
         if hot_state_config.delete_on_restart {
             return empty();
         }
-        let hot_kv_db = match &state_db.hot_state_kv_db {
-            Some(db) => db,
-            None => return empty(),
-        };
         let snapshot_version = match state_db
             .state_merkle_db
             .get_state_snapshot_version_before(Version::MAX)
@@ -990,7 +981,8 @@ impl StateStore {
             None => return empty(),
         };
 
-        let loaded = hot_kv_db
+        let loaded = state_db
+            .hot_state_kv_db
             .load_hot_state_kvs(snapshot_version)
             .expect("Failed to load hot state KVs from DB.");
         let metadata = std::array::from_fn(|i| {

--- a/storage/aptosdb/src/state_store/state_merkle_batch_committer.rs
+++ b/storage/aptosdb/src/state_store/state_merkle_batch_committer.rs
@@ -67,8 +67,6 @@ impl StateMerkleBatchCommitter {
             if let Some(hot) = hot_batch {
                 state_db
                     .hot_state_merkle_db
-                    .as_ref()
-                    .expect("Hot state merkle db must exist.")
                     .commit(
                         current_version,
                         hot.top_levels_batch,
@@ -96,12 +94,14 @@ impl StateMerkleBatchCommitter {
                 "State snapshot committed."
             );
             LATEST_SNAPSHOT_VERSION.set(current_version as i64);
-            if let Some(pruner) = &state_db.state_pruner.hot_state_merkle_pruner {
-                pruner.maybe_set_pruner_target_db_version(current_version);
-            }
-            if let Some(pruner) = &state_db.state_pruner.hot_epoch_snapshot_pruner {
-                pruner.maybe_set_pruner_target_db_version(current_version);
-            }
+            state_db
+                .state_pruner
+                .hot_state_merkle_pruner
+                .maybe_set_pruner_target_db_version(current_version);
+            state_db
+                .state_pruner
+                .hot_epoch_snapshot_pruner
+                .maybe_set_pruner_target_db_version(current_version);
             state_db
                 .state_pruner
                 .state_merkle_pruner

--- a/storage/aptosdb/src/state_store/state_snapshot_committer.rs
+++ b/storage/aptosdb/src/state_store/state_snapshot_committer.rs
@@ -88,21 +88,20 @@ pub(crate) fn merklize_main_state(
         .zip(last_snapshot.summary().hot_state_summary.as_ref());
     let hot_state_merkle_batch_opt = match hot_pair {
         Some((snap_hot, last_hot)) if snap_hot.is_descendant_of(last_hot) => {
-            state_db.hot_state_merkle_db.as_ref().map(|db| {
-                let (_root, _leaf_count, top_levels_batch, batches_for_shards) = db
-                    .merklize_snapshot(
-                        base_version,
-                        version,
-                        last_hot,
-                        snap_hot,
-                        hot_updates.try_into().expect("Must be 16 shards."),
-                        previous_epoch_ending_version,
-                    )
-                    .expect("Failed to compute JMT commit batch for hot state.");
-                MerkleBatch {
-                    top_levels_batch,
-                    batches_for_shards,
-                }
+            let (_root, _leaf_count, top_levels_batch, batches_for_shards) = state_db
+                .hot_state_merkle_db
+                .merklize_snapshot(
+                    base_version,
+                    version,
+                    last_hot,
+                    snap_hot,
+                    hot_updates.try_into().expect("Must be 16 shards."),
+                    previous_epoch_ending_version,
+                )
+                .expect("Failed to compute JMT commit batch for hot state.");
+            Some(MerkleBatch {
+                top_levels_batch,
+                batches_for_shards,
             })
         },
         // TODO(HotState): this means that the relevant code path isn't enabled yet.

--- a/storage/aptosdb/src/state_store/tests/hot_state_kv.rs
+++ b/storage/aptosdb/src/state_store/tests/hot_state_kv.rs
@@ -782,7 +782,7 @@ fn test_load_cross_shard() {
 fn test_load_write_then_load_roundtrip() {
     let tmp = TempPath::new();
     let aptos_db = AptosDB::new_for_test(&tmp);
-    let hot_state_kv_db = aptos_db.hot_state_kv_db.as_ref().unwrap();
+    let hot_state_kv_db = &aptos_db.hot_state_kv_db;
 
     let key1 = make_state_key(10);
     let val1 = make_state_value(10);
@@ -1062,7 +1062,7 @@ fn test_stale_index_direct_write_read() {
 fn test_put_hot_state_updates_values_and_stale_indices() {
     let tmp = TempPath::new();
     let aptos_db = AptosDB::new_for_test(&tmp);
-    let hot_state_kv_db = aptos_db.hot_state_kv_db.as_ref().unwrap();
+    let hot_state_kv_db = &aptos_db.hot_state_kv_db;
 
     let key1 = make_state_key(10);
     let val1 = make_state_value(10);
@@ -1208,7 +1208,7 @@ fn test_hot_state_kv_pruner_deletes_old_entries() {
         HotStateConfig::default(),
     )
     .unwrap();
-    let hot_state_kv_db = aptos_db.hot_state_kv_db.as_ref().unwrap();
+    let hot_state_kv_db = &aptos_db.hot_state_kv_db;
 
     let key1 = make_state_key(42);
     let val_old = make_state_value(1);
@@ -1255,12 +1255,7 @@ fn test_hot_state_kv_pruner_deletes_old_entries() {
     assert!(get_hot_state_entry(hot_state_kv_db, &key1, 200).is_some());
 
     // Trigger pruning
-    let pruner = aptos_db
-        .state_store
-        .state_pruner
-        .hot_state_kv_pruner
-        .as_ref()
-        .expect("hot state kv pruner should exist");
+    let pruner = &aptos_db.state_store.state_pruner.hot_state_kv_pruner;
     pruner
         .wake_and_wait_pruner(200)
         .expect("pruner should complete");

--- a/storage/storage-interface/src/errors.rs
+++ b/storage/storage-interface/src/errors.rs
@@ -32,8 +32,6 @@ pub enum AptosDbError {
     RecvError(String),
     #[error("AptosDB ParseInt Error: {0}")]
     ParseIntError(String),
-    #[error("Hot state not configured properly")]
-    HotStateError,
 }
 
 impl From<anyhow::Error> for AptosDbError {


### PR DESCRIPTION

It used to be `Optional` because the production database didn't have
these DBs and we didn't want replay-verify jobs to try to open them
and fail. This is not a concern any more, so we can remove these
`Option`s and make the code cleaner.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/aptos-labs/aptos-core/pull/20030).
* #20031
* __->__ #20030