### PR TITLE
[mono-move][trivial] Refactor: unify CmpKind and CmpOp

### DIFF
--- a/third_party/move/mono-move/core/src/instruction/unspecialized.rs
+++ b/third_party/move/mono-move/core/src/instruction/unspecialized.rs
@@ -357,6 +357,20 @@ pub enum CmpKind {
     Neq,
 }
 
+impl CmpKind {
+    /// Return the logically negated comparison.
+    pub fn negate(self) -> Self {
+        match self {
+            CmpKind::Lt => CmpKind::Ge,
+            CmpKind::Ge => CmpKind::Lt,
+            CmpKind::Gt => CmpKind::Le,
+            CmpKind::Le => CmpKind::Gt,
+            CmpKind::Eq => CmpKind::Neq,
+            CmpKind::Neq => CmpKind::Eq,
+        }
+    }
+}
+
 impl fmt::Display for CmpKind {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(match self {
@@ -445,4 +459,23 @@ pub struct JumpValueRefCmpOp {
     pub ty: InternedType,
     pub gas_taken: u64,
     pub gas_fallthrough: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cmp_kind_double_negate_is_identity() {
+        for kind in [
+            CmpKind::Lt,
+            CmpKind::Le,
+            CmpKind::Gt,
+            CmpKind::Ge,
+            CmpKind::Eq,
+            CmpKind::Neq,
+        ] {
+            assert_eq!(kind.negate().negate(), kind);
+        }
+    }
 }

--- a/third_party/move/mono-move/specializer/src/destack/ssa_conversion.rs
+++ b/third_party/move/mono-move/specializer/src/destack/ssa_conversion.rs
@@ -8,7 +8,7 @@
 //! are mutable across blocks and keep their original slot indices.
 
 use super::ssa_function::SSAFunction;
-use crate::stackless_exec_ir::{BasicBlock, BinaryOp, CmpOp, Instr, Label, Slot, UnaryOp};
+use crate::stackless_exec_ir::{BasicBlock, BinaryOp, CmpKind, Instr, Label, Slot, UnaryOp};
 use anyhow::{anyhow, bail, ensure, Context, Result};
 use mono_move_core::{
     convert_mut_to_immut_ref, strip_ref,
@@ -410,12 +410,12 @@ impl<'a, I: Interner> SsaConverter<'a, I> {
             B::Shl => self.convert_binop(BinaryOp::Shl, false)?,
             B::Shr => self.convert_binop(BinaryOp::Shr, false)?,
             // --- Comparisons / logical (result type = bool) ---
-            B::Lt => self.convert_binop(BinaryOp::Cmp(CmpOp::Lt), true)?,
-            B::Gt => self.convert_binop(BinaryOp::Cmp(CmpOp::Gt), true)?,
-            B::Le => self.convert_binop(BinaryOp::Cmp(CmpOp::Le), true)?,
-            B::Ge => self.convert_binop(BinaryOp::Cmp(CmpOp::Ge), true)?,
-            B::Eq => self.convert_binop(BinaryOp::Cmp(CmpOp::Eq), true)?,
-            B::Neq => self.convert_binop(BinaryOp::Cmp(CmpOp::Neq), true)?,
+            B::Lt => self.convert_binop(BinaryOp::Cmp(CmpKind::Lt), true)?,
+            B::Gt => self.convert_binop(BinaryOp::Cmp(CmpKind::Gt), true)?,
+            B::Le => self.convert_binop(BinaryOp::Cmp(CmpKind::Le), true)?,
+            B::Ge => self.convert_binop(BinaryOp::Cmp(CmpKind::Ge), true)?,
+            B::Eq => self.convert_binop(BinaryOp::Cmp(CmpKind::Eq), true)?,
+            B::Neq => self.convert_binop(BinaryOp::Cmp(CmpKind::Neq), true)?,
             B::Or => self.convert_binop(BinaryOp::Or, true)?,
             B::And => self.convert_binop(BinaryOp::And, true)?,
 

--- a/third_party/move/mono-move/specializer/src/lower/translate.rs
+++ b/third_party/move/mono-move/specializer/src/lower/translate.rs
@@ -12,7 +12,7 @@ use crate::{
     gas,
     stackless_exec_ir::{
         instr_utils::{clobbers_xfer, for_each_value_use, is_fallthrough_terminator},
-        BinaryOp, CmpOp, FunctionIR, ImmValue, Instr, Label, Slot, UnaryOp,
+        BinaryOp, FunctionIR, ImmValue, Instr, Label, Slot, UnaryOp,
     },
 };
 use anyhow::{anyhow, bail, Context, Result};
@@ -367,13 +367,13 @@ impl<'a> LoweringState<'a> {
     /// Emit a standalone comparison writing a 1-byte boolean to `dst`.
     fn emit_int_cmp(
         &mut self,
-        cmp: CmpOp,
+        cmp: CmpKind,
         dst: FrameOffset,
         lhs: FrameOffset,
         rhs: IntOperand,
     ) -> Result<()> {
         self.emit(MicroOp::IntCmp(IntCmpOp {
-            op: cmp_kind(cmp),
+            op: cmp,
             dst,
             lhs,
             rhs,
@@ -385,13 +385,13 @@ impl<'a> LoweringState<'a> {
     fn emit_jump_int_cmp(
         &mut self,
         target: CodeOffset,
-        cmp: CmpOp,
+        cmp: CmpKind,
         lhs: FrameOffset,
         rhs: IntOperand,
     ) -> Result<()> {
         self.emit(MicroOp::JumpIntCmp(JumpIntCmpOp {
             target,
-            op: cmp_kind(cmp),
+            op: cmp,
             lhs,
             rhs,
             gas_taken: 0,
@@ -996,14 +996,14 @@ impl<'a> LoweringState<'a> {
                 // specialized jumps. Everything else goes through the general
                 // `JumpIntCmp`, which dispatches on the operand type.
                 match (lhs_ty.is_u64(), op) {
-                    (true, CmpOp::Lt) => self.emit(MicroOp::JumpLessU64 {
+                    (true, CmpKind::Lt) => self.emit(MicroOp::JumpLessU64 {
                         target,
                         lhs: lhs_off,
                         rhs: rhs_off,
                         gas_taken: 0,
                         gas_fallthrough: 0,
                     })?,
-                    (true, CmpOp::Ge) => self.emit(MicroOp::JumpGreaterEqualU64 {
+                    (true, CmpKind::Ge) => self.emit(MicroOp::JumpGreaterEqualU64 {
                         target,
                         lhs: lhs_off,
                         rhs: rhs_off,
@@ -1011,7 +1011,7 @@ impl<'a> LoweringState<'a> {
                         gas_fallthrough: 0,
                     })?,
                     // x > y ↔ y < x
-                    (true, CmpOp::Gt) => self.emit(MicroOp::JumpLessU64 {
+                    (true, CmpKind::Gt) => self.emit(MicroOp::JumpLessU64 {
                         target,
                         lhs: rhs_off,
                         rhs: lhs_off,
@@ -1019,14 +1019,14 @@ impl<'a> LoweringState<'a> {
                         gas_fallthrough: 0,
                     })?,
                     // x <= y ↔ y >= x
-                    (true, CmpOp::Le) => self.emit(MicroOp::JumpGreaterEqualU64 {
+                    (true, CmpKind::Le) => self.emit(MicroOp::JumpGreaterEqualU64 {
                         target,
                         lhs: rhs_off,
                         rhs: lhs_off,
                         gas_taken: 0,
                         gas_fallthrough: 0,
                     })?,
-                    (true, CmpOp::Neq) => self.emit(MicroOp::JumpNotEqualU64 {
+                    (true, CmpKind::Neq) => self.emit(MicroOp::JumpNotEqualU64 {
                         target,
                         lhs: lhs_off,
                         rhs: rhs_off,
@@ -1074,35 +1074,35 @@ impl<'a> LoweringState<'a> {
                     // the general `JumpIntCmp`.
                     let v = imm_to_u64(imm)?;
                     match op {
-                        CmpOp::Ge => self.emit(MicroOp::JumpGreaterEqualU64Imm {
+                        CmpKind::Ge => self.emit(MicroOp::JumpGreaterEqualU64Imm {
                             target,
                             src: src_off,
                             imm: v,
                             gas_taken: 0,
                             gas_fallthrough: 0,
                         })?,
-                        CmpOp::Lt => self.emit(MicroOp::JumpLessU64Imm {
+                        CmpKind::Lt => self.emit(MicroOp::JumpLessU64Imm {
                             target,
                             src: src_off,
                             imm: v,
                             gas_taken: 0,
                             gas_fallthrough: 0,
                         })?,
-                        CmpOp::Gt => self.emit(MicroOp::JumpGreaterU64Imm {
+                        CmpKind::Gt => self.emit(MicroOp::JumpGreaterU64Imm {
                             target,
                             src: src_off,
                             imm: v,
                             gas_taken: 0,
                             gas_fallthrough: 0,
                         })?,
-                        CmpOp::Le => self.emit(MicroOp::JumpLessEqualU64Imm {
+                        CmpKind::Le => self.emit(MicroOp::JumpLessEqualU64Imm {
                             target,
                             src: src_off,
                             imm: v,
                             gas_taken: 0,
                             gas_fallthrough: 0,
                         })?,
-                        CmpOp::Eq | CmpOp::Neq => {
+                        CmpKind::Eq | CmpKind::Neq => {
                             self.emit_jump_int_cmp(target, *op, src_off, IntOperand::ImmU64(v))?
                         },
                     }
@@ -1817,21 +1817,6 @@ fn int_operand_from_slot(ty: &Type, off: FrameOffset) -> Result<IntOperand> {
     Ok(IntOperand::slot(int_ty, off))
 }
 
-/// Map an IR [`CmpOp`] to the micro-op [`CmpKind`].
-///
-/// TODO: `CmpOp` and `CmpKind` have identical variants; consider unifying on a
-/// single shared type in core to drop this mapping.
-fn cmp_kind(op: CmpOp) -> CmpKind {
-    match op {
-        CmpOp::Lt => CmpKind::Lt,
-        CmpOp::Le => CmpKind::Le,
-        CmpOp::Gt => CmpKind::Gt,
-        CmpOp::Ge => CmpKind::Ge,
-        CmpOp::Eq => CmpKind::Eq,
-        CmpOp::Neq => CmpKind::Neq,
-    }
-}
-
 enum EqKind {
     /// Integer comparison.
     Int,
@@ -1868,13 +1853,13 @@ fn eq_kind(ty: &Type) -> Result<EqKind> {
     })
 }
 
-/// Map an equality [`CmpOp`] to the `negate` flag of the structural-equality
+/// Map an equality [`CmpKind`] to the `negate` flag of the structural-equality
 /// ops (`false` for `Eq`, `true` for `Neq`).
-fn eq_negate(op: CmpOp) -> Result<bool> {
+fn eq_negate(op: CmpKind) -> Result<bool> {
     match op {
-        CmpOp::Eq => Ok(false),
-        CmpOp::Neq => Ok(true),
-        CmpOp::Lt | CmpOp::Le | CmpOp::Gt | CmpOp::Ge => {
+        CmpKind::Eq => Ok(false),
+        CmpKind::Neq => Ok(true),
+        CmpKind::Lt | CmpKind::Le | CmpKind::Gt | CmpKind::Ge => {
             bail!("ordering comparison on a non-scalar operand is ill-typed")
         },
     }

--- a/third_party/move/mono-move/specializer/src/stackless_exec_ir/display.rs
+++ b/third_party/move/mono-move/specializer/src/stackless_exec_ir/display.rs
@@ -4,7 +4,7 @@
 //! Display for the stackless IR. Types render from their interned form;
 //! entity handles (functions, fields, variants) resolve via `CompiledModule`.
 
-use super::{BinaryOp, CmpOp, FunctionIR, ImmValue, Instr, ModuleIR, Slot, UnaryOp};
+use super::{BinaryOp, CmpKind, FunctionIR, ImmValue, Instr, ModuleIR, Slot, UnaryOp};
 use mono_move_core::types::{display_type, display_type_list};
 use move_binary_format::{
     access::ModuleAccess,
@@ -777,14 +777,14 @@ fn binary_op_name(op: &BinaryOp) -> &'static str {
     }
 }
 
-fn cmp_op_name(op: &CmpOp) -> &'static str {
+fn cmp_op_name(op: &CmpKind) -> &'static str {
     match op {
-        CmpOp::Lt => "lt",
-        CmpOp::Gt => "gt",
-        CmpOp::Le => "le",
-        CmpOp::Ge => "ge",
-        CmpOp::Eq => "eq",
-        CmpOp::Neq => "neq",
+        CmpKind::Lt => "lt",
+        CmpKind::Gt => "gt",
+        CmpKind::Le => "le",
+        CmpKind::Ge => "ge",
+        CmpKind::Eq => "eq",
+        CmpKind::Neq => "neq",
     }
 }
 

--- a/third_party/move/mono-move/specializer/src/stackless_exec_ir/instr_utils.rs
+++ b/third_party/move/mono-move/specializer/src/stackless_exec_ir/instr_utils.rs
@@ -431,7 +431,7 @@ pub(crate) fn extract_imm_value(instr: &Instr) -> Option<(Slot, ImmValue)> {
 /// without changing the result).
 #[inline]
 pub(crate) fn is_commutative(op: &BinaryOp) -> bool {
-    use crate::stackless_exec_ir::CmpOp;
+    use crate::stackless_exec_ir::CmpKind;
     matches!(
         op,
         BinaryOp::Add
@@ -439,8 +439,8 @@ pub(crate) fn is_commutative(op: &BinaryOp) -> bool {
             | BinaryOp::BitOr
             | BinaryOp::BitAnd
             | BinaryOp::BitXor
-            | BinaryOp::Cmp(CmpOp::Eq)
-            | BinaryOp::Cmp(CmpOp::Neq)
+            | BinaryOp::Cmp(CmpKind::Eq)
+            | BinaryOp::Cmp(CmpKind::Neq)
             | BinaryOp::Or
             | BinaryOp::And
     )

--- a/third_party/move/mono-move/specializer/src/stackless_exec_ir/mod.rs
+++ b/third_party/move/mono-move/specializer/src/stackless_exec_ir/mod.rs
@@ -9,6 +9,7 @@
 mod display;
 pub(crate) mod instr_utils;
 
+pub use mono_move_core::CmpKind;
 use mono_move_core::{
     types::{InternedType, InternedTypeList},
     IntTy, PreparedModule,
@@ -105,31 +106,6 @@ impl UnaryOp {
     }
 }
 
-/// Comparison operations that produce a boolean result.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum CmpOp {
-    Lt,
-    Gt,
-    Le,
-    Ge,
-    Eq,
-    Neq,
-}
-
-impl CmpOp {
-    /// Return the logically negated comparison.
-    pub fn negate(self) -> Self {
-        match self {
-            CmpOp::Lt => CmpOp::Ge,
-            CmpOp::Ge => CmpOp::Lt,
-            CmpOp::Gt => CmpOp::Le,
-            CmpOp::Le => CmpOp::Gt,
-            CmpOp::Eq => CmpOp::Neq,
-            CmpOp::Neq => CmpOp::Eq,
-        }
-    }
-}
-
 /// Binary operations.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum BinaryOp {
@@ -143,7 +119,7 @@ pub enum BinaryOp {
     BitXor,
     Shl,
     Shr,
-    Cmp(CmpOp),
+    Cmp(CmpKind),
     Or,
     And,
 }
@@ -309,9 +285,9 @@ pub enum Instr {
     BrTrue(Label, Slot),
     BrFalse(Label, Slot),
     /// `BrCmp(target, op, lhs, rhs)` — branch to `target` if `op(lhs, rhs)` is true.
-    BrCmp(Label, CmpOp, Slot, Slot),
+    BrCmp(Label, CmpKind, Slot, Slot),
     /// `BrCmpImm(target, op, src, imm)` — branch to `target` if `op(src, imm)` is true.
-    BrCmpImm(Label, CmpOp, Slot, ImmValue),
+    BrCmpImm(Label, CmpKind, Slot, ImmValue),
     Ret(Vec<Slot>),
     Abort(Slot),
     AbortMsg(Slot, Slot),


### PR DESCRIPTION
## Description

Following up on a previous PR comment, @vgao suggested unifying these two enums that were independently developed but serve very similar purposes, keeping them separate and converting between them is not good.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical type unification with identical enum variants; behavior should be unchanged aside from moving `negate` to core.
> 
> **Overview**
> **Unifies comparison kinds** by removing the duplicate stackless IR `CmpOp` enum and using `mono_move_core::CmpKind` everywhere (IR `BinaryOp::Cmp`, `BrCmp` / `BrCmpImm`, SSA conversion, lowering, display, and instr utils).
> 
> `CmpKind::negate` now lives in core (with a unit test that double-negation is identity). Lowering no longer needs the `cmp_kind` `CmpOp` → `CmpKind` mapper—compare micro-ops take `CmpKind` directly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d165d0d543a0d2753dc56fe83f7bc084c1504a8d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->