### PR TITLE
[replay-verify] Tune testnet: 32 MiB stack, 60m per-pod timeout, cap retries at 3

### DIFF
--- a/testsuite/replay-verify/main.py
+++ b/testsuite/replay-verify/main.py
@@ -138,9 +138,9 @@ class LocalPhase(Enum):
 
     Scheduler treatment of terminal states:
       SUCCEEDED — task marked succeeded, slot freed
-      FAILED    — if evicted → reschedule task (up to MAX_RETRIES),
+      FAILED    — if evicted → reschedule task (up to max_retries),
                   else → treat as permanent failure
-      LOST      — reschedule task (up to MAX_RETRIES), else → permanent failure
+      LOST      — reschedule task (up to max_retries), else → permanent failure
     """
     UNKNOWN = "Unknown"
     PENDING = "Pending"
@@ -201,8 +201,13 @@ class ReplayConfig:
             self.workers_per_pvc = 10
             self.min_range_size = 10_000
             self.range_size = 5_000_000
-            # Testnet has the 6.7B-6.8B heavy zone; some 1M chunks take ~33m.
-            self.running_timeout = 40 * 60
+            # Testnet has the 6.7B-6.8B heavy zone; a few outlier 1M chunks
+            # consistently run past 40m, so give the Running phase 60m here.
+            self.running_timeout = 60 * 60
+            # Those outliers tend to blow the budget on every attempt, so cap
+            # reschedules below mainnet to avoid burning the CI budget retrying
+            # the same doomed range.
+            self.max_retries = 3
         else:
             self.concurrent_replayer = 35
             self.pvc_number = 10
@@ -210,6 +215,7 @@ class ReplayConfig:
             self.min_range_size = 10_000
             self.range_size = 2_000_000
             self.running_timeout = 30 * 60
+            self.max_retries = MAX_RETRIES
         # Timeout chain for the Running phase — each layer is a backstop:
         #   scheduler (running_timeout) -> binary (+10m) -> K8s TTL (+10m).
         self.binary_timeout = self.running_timeout + 10 * 60
@@ -907,9 +913,9 @@ class ReplayScheduler:
                                 f"phase={worker.get_phase()}, "
                                 f"container={worker.get_container_status_summary()}, "
                                 f"age={int(timeout_age)}s > {timeout_threshold}s, "
-                                f"attempt {retries}/{MAX_RETRIES}"
+                                f"attempt {retries}/{self.config.max_retries}"
                             )
-                            if retries < MAX_RETRIES:
+                            if retries < self.config.max_retries:
                                 self.kill_pod_and_reschedule_task(worker, i)
                             else:
                                 logger.error(
@@ -989,11 +995,11 @@ class ReplayScheduler:
         if worker_pod.is_failed():
             reason = worker_pod.get_failure_reason()
             retries = self.task_stats[worker_pod.name].retry_count + 1
-            if worker_pod.should_reschedule() and retries < MAX_RETRIES:
+            if worker_pod.should_reschedule() and retries < self.config.max_retries:
                 logger.info(
                     f"Worker {worker_idx} completed: {worker_pod.name}, "
                     f"status=Failed({reason}), duration={duration}s, "
-                    f"rescheduling (attempt {retries}/{MAX_RETRIES})"
+                    f"rescheduling (attempt {retries}/{self.config.max_retries})"
                 )
                 # Don't set end_time — task will be re-dispatched
                 self.kill_pod_and_reschedule_task(worker_pod, worker_idx)

--- a/testsuite/replay-verify/replay-verify-worker-template.yaml
+++ b/testsuite/replay-verify/replay-verify-worker-template.yaml
@@ -23,6 +23,11 @@ spec:
           value: "info"
         - name: RUST_BACKTRACE
           value: "full"
+        # Replay executes Move on rayon/std worker threads that don't set an
+        # explicit stack size, so they inherit RUST_MIN_STACK. Bump above the
+        # 2 MiB default to avoid stack overflows replaying deeply nested values.
+        - name: RUST_MIN_STACK
+          value: "33554432" # 32 MiB
       resources:
         requests:
           memory: "100Gi"


### PR DESCRIPTION
Operational tuning for the testnet replay-verify job, which has been failing (stack overflows) and timing out on a few outlier chunks. All changes are config/scheduler-level — no node-binary behavior change.

## 1. `RUST_MIN_STACK` = 32 MiB in worker pods

Testnet replay-verify was failing with **stack overflows**. The workers run `aptos-debugger aptos-db replay-on-archive`, which executes Move on a rayon pool (`storage/db-tool/src/replay_on_archive.rs`); with `REPLAY_CONCURRENCY_LEVEL = 1` the VM runs directly on those rayon threads. Neither that pool nor the Block-STM `par_exec` pool sets an explicit `stack_size`, so they inherit the std default of **2 MiB** unless `RUST_MIN_STACK` is set — and it wasn't set anywhere in the replay path.

Set `RUST_MIN_STACK=33554432` (32 MiB, matching coverage CI) in the worker pod template. Config-only, no binary rebuild. The Move value-nesting depth is bounded at `DEFAULT_MAX_VM_VALUE_NESTED_DEPTH = 128`, so 32 MiB clears the deep-value recursion with large margin.

## 2. Testnet per-pod Running timeout 40m → 60m

A few outlier 1M-txn chunks in testnet's 6.7B–6.8B heavy zone consistently exceed the 40m per-pod Running-phase limit. Bump `running_timeout` to 60m for testnet; the binary self-timeout (+10m) and K8s pod TTL (+10m) cascade from it automatically. Mainnet unchanged.

## 3. Network-keyed `max_retries`, testnet capped at 3

Those outliers tend to blow the budget on *every* attempt, so retrying 5× just burns the 7h CI budget on a doomed range. Added a network-keyed `max_retries` to `ReplayConfig` (testnet = 3, mainnet keeps the prior default of 5). Only the **task-reschedule** paths use it; the k8s API-resilience retries (pod-create loop + tenacity decorators) stay on the module-level `MAX_RETRIES`.

## Notes

- Production `aptos-node` does not set `RUST_MIN_STACK` (runs execution on the 2 MiB default), so this makes replay *more* generous than production — intentional, since replay does extra per-chunk work (re-deriving/comparing writesets, events, txn-infos) and may run a newer build than originally executed the txns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
